### PR TITLE
Add TagSet and SmallString implementation

### DIFF
--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -1,8 +1,12 @@
 pub mod index;
+pub mod smallstring;
 pub mod storage;
+pub mod tagset;
 pub mod tensor;
 
-pub use index::{Index, DynId, NoSymmSpace, Symmetry, generate_id};
+pub use index::{DefaultIndex, Index, DynId, NoSymmSpace, Symmetry, generate_id};
+pub use smallstring::{SmallString, SmallStringError};
 pub use storage::{AnyScalar, DenseStorageFactory, Storage, SumFromStorage};
+pub use tagset::{DefaultTagSet, Tag, TagSet, TagSetError};
 pub use tensor::{TensorDynLen, TensorStaticLen};
 

--- a/crates/tensor4all-core/src/smallstring.rs
+++ b/crates/tensor4all-core/src/smallstring.rs
@@ -1,0 +1,115 @@
+/// A stack-allocated fixed-capacity string with explicit length.
+///
+/// This type stores characters in a fixed-size array and maintains
+/// an explicit length field, similar to ITensors.jl's `SmallString`.
+#[derive(Debug, Clone, Copy)]
+pub struct SmallString<const MAX_LEN: usize> {
+    data: [char; MAX_LEN],
+    len: usize, // Explicit length (0 ≤ len ≤ MAX_LEN)
+}
+
+/// Error type for SmallString operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SmallStringError {
+    TooLong { actual: usize, max: usize },
+}
+
+impl<const MAX_LEN: usize> SmallString<MAX_LEN> {
+    /// Create an empty SmallString.
+    pub fn new() -> Self {
+        Self {
+            data: ['\0'; MAX_LEN],
+            len: 0,
+        }
+    }
+
+    /// Create a SmallString from a string slice.
+    ///
+    /// Returns an error if the string is longer than MAX_LEN.
+    pub fn from_str(s: &str) -> Result<Self, SmallStringError> {
+        let chars: Vec<char> = s.chars().collect();
+        if chars.len() > MAX_LEN {
+            return Err(SmallStringError::TooLong {
+                actual: chars.len(),
+                max: MAX_LEN,
+            });
+        }
+
+        let mut data = ['\0'; MAX_LEN];
+        for (i, &ch) in chars.iter().enumerate() {
+            data[i] = ch;
+        }
+
+        Ok(Self {
+            data,
+            len: chars.len(),
+        })
+    }
+
+    /// Convert to a String.
+    pub fn as_str(&self) -> String {
+        self.data[..self.len].iter().collect()
+    }
+
+    /// Check if the string is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Get the length of the string.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Get the maximum capacity.
+    pub fn capacity(&self) -> usize {
+        MAX_LEN
+    }
+
+    /// Get a character at the given index.
+    pub fn get(&self, index: usize) -> Option<char> {
+        if index < self.len {
+            Some(self.data[index])
+        } else {
+            None
+        }
+    }
+
+    /// Get a reference to the internal data slice.
+    pub fn as_slice(&self) -> &[char] {
+        &self.data[..self.len]
+    }
+}
+
+impl<const MAX_LEN: usize> Default for SmallString<MAX_LEN> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const MAX_LEN: usize> PartialEq for SmallString<MAX_LEN> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && self.data[..self.len] == other.data[..other.len]
+    }
+}
+
+impl<const MAX_LEN: usize> Eq for SmallString<MAX_LEN> {}
+
+impl<const MAX_LEN: usize> PartialOrd for SmallString<MAX_LEN> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<const MAX_LEN: usize> Ord for SmallString<MAX_LEN> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.data[..self.len].cmp(&other.data[..other.len])
+    }
+}
+
+impl<const MAX_LEN: usize> std::fmt::Display for SmallString<MAX_LEN> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+

--- a/crates/tensor4all-core/src/tagset.rs
+++ b/crates/tensor4all-core/src/tagset.rs
@@ -1,0 +1,205 @@
+use crate::smallstring::{SmallString, SmallStringError};
+
+/// A set of tags with fixed capacity, stored in sorted order.
+///
+/// Tags are always maintained in sorted order, regardless of insertion order,
+/// similar to ITensors.jl's `TagSet`.
+#[derive(Debug, Clone, Copy)]
+pub struct TagSet<const MAX_TAGS: usize, const MAX_TAG_LEN: usize> {
+    tags: [SmallString<MAX_TAG_LEN>; MAX_TAGS],
+    length: usize, // Actual number of tags (0 ≤ length ≤ MAX_TAGS)
+}
+
+/// Error type for TagSet operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TagSetError {
+    TooManyTags { actual: usize, max: usize },
+    TagTooLong { actual: usize, max: usize },
+    InvalidTag(SmallStringError),
+}
+
+impl<const MAX_TAGS: usize, const MAX_TAG_LEN: usize> TagSet<MAX_TAGS, MAX_TAG_LEN> {
+    /// Create an empty TagSet.
+    pub fn new() -> Self {
+        Self {
+            tags: [SmallString::new(); MAX_TAGS],
+            length: 0,
+        }
+    }
+
+    /// Create a TagSet from a comma-separated string.
+    ///
+    /// Whitespace is ignored (similar to ITensors.jl).
+    /// Tags are automatically sorted.
+    pub fn from_str(s: &str) -> Result<Self, TagSetError> {
+        let mut tagset = Self::new();
+        
+        // Parse comma-separated tags, ignoring whitespace
+        let mut current_tag = String::new();
+        for ch in s.chars() {
+            if ch == ',' {
+                if !current_tag.is_empty() {
+                    let trimmed: String = current_tag.chars().filter(|c| !c.is_whitespace()).collect();
+                    if !trimmed.is_empty() {
+                        tagset.add_tag(&trimmed)?;
+                    }
+                    current_tag.clear();
+                }
+            } else {
+                current_tag.push(ch);
+            }
+        }
+        
+        // Handle the last tag
+        if !current_tag.is_empty() {
+            let trimmed: String = current_tag.chars().filter(|c| !c.is_whitespace()).collect();
+            if !trimmed.is_empty() {
+                tagset.add_tag(&trimmed)?;
+            }
+        }
+        
+        Ok(tagset)
+    }
+
+    /// Get the number of tags.
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    /// Get the maximum capacity.
+    pub fn capacity(&self) -> usize {
+        MAX_TAGS
+    }
+
+    /// Get a tag at the given index.
+    pub fn get(&self, index: usize) -> Option<&SmallString<MAX_TAG_LEN>> {
+        if index < self.length {
+            Some(&self.tags[index])
+        } else {
+            None
+        }
+    }
+
+    /// Iterate over tags.
+    pub fn iter(&self) -> impl Iterator<Item = &SmallString<MAX_TAG_LEN>> {
+        self.tags[..self.length].iter()
+    }
+
+    /// Check if a tag is present.
+    pub fn has_tag(&self, tag: &str) -> bool {
+        let tag_str = match SmallString::<MAX_TAG_LEN>::from_str(tag) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        self._has_tag(&tag_str)
+    }
+
+    /// Check if all tags in another TagSet are present.
+    pub fn has_tags(&self, tags: &TagSet<MAX_TAGS, MAX_TAG_LEN>) -> bool {
+        for tag in tags.iter() {
+            if !self._has_tag(tag) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Add a tag (maintains sorted order).
+    pub fn add_tag(&mut self, tag: &str) -> Result<(), TagSetError> {
+        let tag_str = SmallString::<MAX_TAG_LEN>::from_str(tag)
+            .map_err(|e| TagSetError::InvalidTag(e))?;
+        self._add_tag_ordered(tag_str)
+    }
+
+    /// Remove a tag.
+    pub fn remove_tag(&mut self, tag: &str) -> bool {
+        let tag_str = match SmallString::<MAX_TAG_LEN>::from_str(tag) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        
+        if let Some(pos) = self.tags[..self.length].iter().position(|t| *t == tag_str) {
+            // Shift remaining tags left
+            for i in pos..self.length - 1 {
+                self.tags[i] = self.tags[i + 1];
+            }
+            self.length -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get common tags between two TagSets.
+    pub fn common_tags(&self, other: &Self) -> Self {
+        let mut result = Self::new();
+        for tag in self.iter() {
+            if other._has_tag(tag) {
+                // Safe to unwrap because we know the tag fits
+                result._add_tag_ordered(*tag).ok();
+            }
+        }
+        result
+    }
+
+    /// Internal: Add a tag in sorted order (similar to ITensors.jl's `_addtag_ordered!`).
+    fn _add_tag_ordered(&mut self, tag: SmallString<MAX_TAG_LEN>) -> Result<(), TagSetError> {
+        // Check for duplicates
+        if self._has_tag(&tag) {
+            return Ok(()); // Already present, no error
+        }
+
+        // Check capacity
+        if self.length >= MAX_TAGS {
+            return Err(TagSetError::TooManyTags {
+                actual: self.length + 1,
+                max: MAX_TAGS,
+            });
+        }
+
+        // Find insertion position (binary search for sorted insertion)
+        let pos = self.tags[..self.length]
+            .binary_search(&tag)
+            .unwrap_or_else(|pos| pos);
+
+        // Shift tags right to make room
+        for i in (pos..self.length).rev() {
+            self.tags[i + 1] = self.tags[i];
+        }
+
+        // Insert the new tag
+        self.tags[pos] = tag;
+        self.length += 1;
+
+        Ok(())
+    }
+
+    /// Internal: Check if a tag is present (binary search).
+    fn _has_tag(&self, tag: &SmallString<MAX_TAG_LEN>) -> bool {
+        self.tags[..self.length].binary_search(tag).is_ok()
+    }
+}
+
+impl<const MAX_TAGS: usize, const MAX_TAG_LEN: usize> Default for TagSet<MAX_TAGS, MAX_TAG_LEN> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const MAX_TAGS: usize, const MAX_TAG_LEN: usize> PartialEq for TagSet<MAX_TAGS, MAX_TAG_LEN> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.length != other.length {
+            return false;
+        }
+        self.tags[..self.length] == other.tags[..other.length]
+    }
+}
+
+impl<const MAX_TAGS: usize, const MAX_TAG_LEN: usize> Eq for TagSet<MAX_TAGS, MAX_TAG_LEN> {}
+
+/// Default tag type (max 16 characters, matching ITensors.jl's `SmallString`).
+pub type Tag = SmallString<16>;
+
+/// Default TagSet (max 4 tags, each tag max 16 characters, matching ITensors.jl's `TagSet`).
+pub type DefaultTagSet = TagSet<4, 16>;
+

--- a/crates/tensor4all-core/tests/basic.rs
+++ b/crates/tensor4all-core/tests/basic.rs
@@ -1,4 +1,4 @@
-use tensor4all_core::index::{Index, DynId, generate_id};
+use tensor4all_core::index::{DefaultIndex as Index, DynId, generate_id};
 use tensor4all_core::storage::{AnyScalar, DenseStorageFactory, Storage, make_mut_storage};
 use tensor4all_core::tensor::{TensorDynLen, TensorStaticLen};
 use std::sync::Arc;

--- a/crates/tensor4all-core/tests/index_tags.rs
+++ b/crates/tensor4all-core/tests/index_tags.rs
@@ -1,0 +1,102 @@
+use tensor4all_core::index::DefaultIndex as Index;
+use tensor4all_core::tagset::DefaultTagSet as TagSet;
+
+#[test]
+fn test_index_with_tags() {
+    let mut idx = Index::new_dyn(8);
+    assert_eq!(idx.tags().len(), 0);
+    
+    // Add tags
+    idx.tags_mut().add_tag("site").unwrap();
+    idx.tags_mut().add_tag("up").unwrap();
+    
+    assert_eq!(idx.tags().len(), 2);
+    assert!(idx.tags().has_tag("site"));
+    assert!(idx.tags().has_tag("up"));
+}
+
+#[test]
+fn test_index_equality_by_id_only() {
+    let mut idx1 = Index::new_dyn(8);
+    idx1.tags_mut().add_tag("site").unwrap();
+    
+    let mut idx2 = Index::new_dyn(8);
+    idx2.tags_mut().add_tag("bond").unwrap();
+    
+    // Different IDs, so not equal
+    assert_ne!(idx1, idx2);
+    
+    // Same ID, should be equal even with different tags
+    let id = idx1.id;
+    let idx3 = Index {
+        id,
+        symm: idx1.symm,  // Automatically copied because Copy
+        tags: TagSet::from_str("bond").unwrap(),
+    };
+    
+    // Now they should be equal because IDs match (tags are ignored)
+    assert_eq!(idx1, idx3);
+}
+
+#[test]
+fn test_index_new_with_tags() {
+    let tags = TagSet::from_str("site,up").unwrap();
+    let idx = Index::new_dyn_with_tags(8, tags);
+    
+    assert_eq!(idx.tags().len(), 2);
+    assert!(idx.tags().has_tag("site"));
+    assert!(idx.tags().has_tag("up"));
+}
+
+#[test]
+fn test_index_hash_by_id_only() {
+    use std::collections::HashSet;
+    
+    let mut idx1 = Index::new_dyn(8);
+    idx1.tags_mut().add_tag("site").unwrap();
+    
+    let mut idx2 = Index::new_dyn(8);
+    idx2.tags_mut().add_tag("bond").unwrap();
+    
+    let mut set = HashSet::new();
+    set.insert(idx1);  // Automatically copied because Copy
+    set.insert(idx2);
+    
+    // Should have 2 entries (different IDs)
+    assert_eq!(set.len(), 2);
+    
+    // Create another index with same ID as idx1 but different tags
+    let idx3 = Index {
+        id: idx1.id,
+        symm: idx1.symm,  // Automatically copied because Copy
+        tags: TagSet::from_str("bond").unwrap(),
+    };
+    
+    // Should not add because ID matches idx1
+    set.insert(idx3);
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn test_index_tags_mutability() {
+    let mut idx = Index::new_dyn(8);
+    
+    // Initially empty
+    assert_eq!(idx.tags().len(), 0);
+    
+    // Add tags via mutable reference
+    idx.tags_mut().add_tag("site").unwrap();
+    idx.tags_mut().add_tag("up").unwrap();
+    
+    // Verify tags were added
+    assert_eq!(idx.tags().len(), 2);
+    assert!(idx.tags().has_tag("site"));
+    assert!(idx.tags().has_tag("up"));
+    
+    // Remove a tag
+    idx.tags_mut().remove_tag("site");
+    assert_eq!(idx.tags().len(), 1);
+    assert!(!idx.tags().has_tag("site"));
+    assert!(idx.tags().has_tag("up"));
+}
+

--- a/crates/tensor4all-core/tests/tagset.rs
+++ b/crates/tensor4all-core/tests/tagset.rs
@@ -1,0 +1,171 @@
+use tensor4all_core::smallstring::{SmallString, SmallStringError};
+use tensor4all_core::tagset::{DefaultTagSet, Tag, TagSet, TagSetError};
+
+#[test]
+fn test_smallstring_new() {
+    let s = SmallString::<16>::new();
+    assert_eq!(s.len(), 0);
+    assert!(s.is_empty());
+    assert_eq!(s.as_str(), "");
+}
+
+#[test]
+fn test_smallstring_from_str() {
+    let s = SmallString::<16>::from_str("hello").unwrap();
+    assert_eq!(s.len(), 5);
+    assert!(!s.is_empty());
+    assert_eq!(s.as_str(), "hello");
+}
+
+#[test]
+fn test_smallstring_too_long() {
+    let result = SmallString::<5>::from_str("hello world");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SmallStringError::TooLong { actual, max } => {
+            assert_eq!(actual, 11);
+            assert_eq!(max, 5);
+        }
+    }
+}
+
+#[test]
+fn test_smallstring_equality() {
+    let s1 = SmallString::<16>::from_str("hello").unwrap();
+    let s2 = SmallString::<16>::from_str("hello").unwrap();
+    let s3 = SmallString::<16>::from_str("world").unwrap();
+    
+    assert_eq!(s1, s2);
+    assert_ne!(s1, s3);
+}
+
+#[test]
+fn test_smallstring_ordering() {
+    let s1 = SmallString::<16>::from_str("apple").unwrap();
+    let s2 = SmallString::<16>::from_str("banana").unwrap();
+    
+    assert!(s1 < s2);
+    assert!(s2 > s1);
+}
+
+#[test]
+fn test_smallstring_unicode() {
+    let s = SmallString::<16>::from_str("αβγ").unwrap();
+    assert_eq!(s.len(), 3);
+    assert_eq!(s.as_str(), "αβγ");
+}
+
+#[test]
+fn test_tagset_new() {
+    let ts = TagSet::<4, 16>::new();
+    assert_eq!(ts.len(), 0);
+    assert_eq!(ts.capacity(), 4);
+}
+
+#[test]
+fn test_tagset_from_str() {
+    let ts = TagSet::<4, 16>::from_str("t1,t2,t3").unwrap();
+    assert_eq!(ts.len(), 3);
+    
+    // Tags should be sorted
+    assert_eq!(ts.get(0).unwrap().as_str(), "t1");
+    assert_eq!(ts.get(1).unwrap().as_str(), "t2");
+    assert_eq!(ts.get(2).unwrap().as_str(), "t3");
+}
+
+#[test]
+fn test_tagset_sorted_order() {
+    // Input order should not matter
+    let ts = TagSet::<4, 16>::from_str("t3,t2,t1").unwrap();
+    assert_eq!(ts.len(), 3);
+    
+    // Should be sorted
+    assert_eq!(ts.get(0).unwrap().as_str(), "t1");
+    assert_eq!(ts.get(1).unwrap().as_str(), "t2");
+    assert_eq!(ts.get(2).unwrap().as_str(), "t3");
+}
+
+#[test]
+fn test_tagset_whitespace_ignored() {
+    let ts = TagSet::<4, 16>::from_str(" aaa , bb bb  , ccc    ").unwrap();
+    assert_eq!(ts.len(), 3);
+    
+    // Whitespace should be removed
+    assert!(ts.has_tag("aaa"));
+    assert!(ts.has_tag("bbbb"));
+    assert!(ts.has_tag("ccc"));
+}
+
+#[test]
+fn test_tagset_has_tag() {
+    let ts = TagSet::<4, 16>::from_str("t1,t2,t3").unwrap();
+    assert!(ts.has_tag("t1"));
+    assert!(ts.has_tag("t2"));
+    assert!(ts.has_tag("t3"));
+    assert!(!ts.has_tag("t4"));
+}
+
+#[test]
+fn test_tagset_add_tag() {
+    let mut ts = TagSet::<4, 16>::new();
+    ts.add_tag("t2").unwrap();
+    ts.add_tag("t1").unwrap();
+    ts.add_tag("t3").unwrap();
+    
+    // Should be sorted
+    assert_eq!(ts.get(0).unwrap().as_str(), "t1");
+    assert_eq!(ts.get(1).unwrap().as_str(), "t2");
+    assert_eq!(ts.get(2).unwrap().as_str(), "t3");
+}
+
+#[test]
+fn test_tagset_remove_tag() {
+    let mut ts = TagSet::<4, 16>::from_str("t1,t2,t3").unwrap();
+    assert_eq!(ts.len(), 3);
+    
+    assert!(ts.remove_tag("t2"));
+    assert_eq!(ts.len(), 2);
+    assert!(!ts.has_tag("t2"));
+    assert!(ts.has_tag("t1"));
+    assert!(ts.has_tag("t3"));
+}
+
+#[test]
+fn test_tagset_common_tags() {
+    let ts1 = TagSet::<4, 16>::from_str("t1,t2,t3").unwrap();
+    let ts2 = TagSet::<4, 16>::from_str("t2,t3,t4").unwrap();
+    
+    let common = ts1.common_tags(&ts2);
+    assert_eq!(common.len(), 2);
+    assert!(common.has_tag("t2"));
+    assert!(common.has_tag("t3"));
+    assert!(!common.has_tag("t1"));
+    assert!(!common.has_tag("t4"));
+}
+
+#[test]
+fn test_tagset_too_many_tags() {
+    let mut ts = TagSet::<2, 16>::new();
+    ts.add_tag("t1").unwrap();
+    ts.add_tag("t2").unwrap();
+    
+    let result = ts.add_tag("t3");
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        TagSetError::TooManyTags { actual, max } => {
+            assert_eq!(actual, 3);
+            assert_eq!(max, 2);
+        }
+        _ => panic!("Expected TooManyTags error"),
+    }
+}
+
+#[test]
+fn test_default_types() {
+    let tag: Tag = SmallString::<16>::from_str("test").unwrap();
+    assert_eq!(tag.as_str(), "test");
+    
+    let ts: DefaultTagSet = TagSet::<4, 16>::from_str("t1,t2").unwrap();
+    assert_eq!(ts.len(), 2);
+}
+


### PR DESCRIPTION
## Summary

This PR adds TagSet and SmallString implementations to tensor4all-rs, similar to ITensors.jl.

## Changes

- **SmallString<const MAX_LEN>**: Stack-allocated fixed-capacity string with explicit length
  - Uses `[char; MAX_LEN]` for storage
  - Supports UTF-8 arbitrary characters
  - Returns `Result::Err` on overflow

- **TagSet<const MAX_TAGS, const MAX_TAG_LEN>**: Fixed-capacity tag set with sorted order
  - Tags are always maintained in sorted order (like ITensors.jl)
  - Whitespace is ignored during parsing
  - Binary search for fast tag lookup

- **Index integration**: Added TagSet support to Index
  - Equality comparison uses `id` only (tags are ignored)
  - Hash implementation uses `id` only
  - Added `Copy` trait when components are `Copy`

## Testing

- All 21 tests pass
- Comprehensive test coverage for SmallString, TagSet, and Index integration
- Unicode character support tested

## Default Types

- `Tag = SmallString<16>` (matching ITensors.jl)
- `DefaultTagSet = TagSet<4, 16>` (matching ITensors.jl)
- `DefaultIndex<Id, Symm> = Index<Id, Symm, 4, 16>`

