### PR TITLE
Use UInt128 with thread-local RNG for ID generation

### DIFF
--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 num-complex = "0.4"
+rand = "0.8"
 
 [dev-dependencies]
 

--- a/crates/tensor4all-core/tests/basic.rs
+++ b/crates/tensor4all-core/tests/basic.rs
@@ -2,6 +2,8 @@ use tensor4all_core::index::{DefaultIndex as Index, DynId, generate_id};
 use tensor4all_core::storage::{AnyScalar, DenseStorageFactory, Storage, make_mut_storage};
 use tensor4all_core::tensor::{TensorDynLen, TensorStaticLen};
 use std::sync::Arc;
+use std::thread;
+use std::collections::HashSet;
 use num_complex::Complex64;
 
 #[test]
@@ -10,11 +12,151 @@ fn test_id_generation() {
     let id2 = generate_id();
     let id3 = generate_id();
     
-    // IDs should be unique and monotonically increasing
-    assert!(id1 < id2);
-    assert!(id2 < id3);
+    // IDs should be unique (random generation, not sequential)
     assert_ne!(id1, id2);
     assert_ne!(id2, id3);
+    assert_ne!(id1, id3);
+    
+    // IDs should be non-zero (very high probability with u128)
+    assert_ne!(id1, 0);
+    assert_ne!(id2, 0);
+    assert_ne!(id3, 0);
+}
+
+#[test]
+fn test_thread_local_rng_different_seeds() {
+    // Test that different threads produce different ID sequences
+    // This verifies that each thread gets a different seed
+    const NUM_THREADS: usize = 4;
+    const IDS_PER_THREAD: usize = 100;
+    
+    let handles: Vec<_> = (0..NUM_THREADS)
+        .map(|_| {
+            thread::spawn(|| {
+                let mut thread_ids = Vec::new();
+                for _ in 0..IDS_PER_THREAD {
+                    thread_ids.push(generate_id());
+                }
+                thread_ids
+            })
+        })
+        .collect();
+    
+    let mut all_ids = HashSet::new();
+    let mut thread_sets = Vec::new();
+    
+    for handle in handles {
+        let thread_ids = handle.join().unwrap();
+        let thread_set: HashSet<_> = thread_ids.iter().cloned().collect();
+        thread_sets.push(thread_set.clone());
+        all_ids.extend(thread_ids);
+    }
+    
+    // All IDs should be unique across all threads
+    assert_eq!(all_ids.len(), NUM_THREADS * IDS_PER_THREAD, 
+               "All IDs should be unique across threads");
+    
+    // Check that different threads produce different sequences
+    // (with extremely high probability if seeds are different)
+    for i in 0..thread_sets.len() {
+        for j in (i+1)..thread_sets.len() {
+            let intersection: Vec<_> = thread_sets[i].intersection(&thread_sets[j]).collect();
+            assert_eq!(intersection.len(), 0,
+                       "Thread {} and {} should produce different ID sequences (different seeds)",
+                       i, j);
+        }
+    }
+}
+
+#[test]
+fn test_thread_count_changes() {
+    // Test behavior when thread count changes dynamically
+    // This simulates scenarios like thread pool resizing or new threads being spawned
+    
+    // Phase 1: Generate IDs in initial threads
+    const INITIAL_THREADS: usize = 2;
+    const IDS_PER_PHASE: usize = 50;
+    
+    let mut all_ids = HashSet::new();
+    let mut phase1_ids = HashSet::new();
+    
+    // Phase 1: Initial threads
+    let handles1: Vec<_> = (0..INITIAL_THREADS)
+        .map(|_| {
+            thread::spawn(|| {
+                let mut thread_ids = Vec::new();
+                for _ in 0..IDS_PER_PHASE {
+                    thread_ids.push(generate_id());
+                }
+                thread_ids
+            })
+        })
+        .collect();
+    
+    for handle in handles1 {
+        let thread_ids = handle.join().unwrap();
+        for id in &thread_ids {
+            all_ids.insert(*id);
+            phase1_ids.insert(*id);
+        }
+    }
+    
+    assert_eq!(phase1_ids.len(), INITIAL_THREADS * IDS_PER_PHASE);
+    
+    // Phase 2: Spawn new threads (simulating thread count increase)
+    const NEW_THREADS: usize = 3;
+    let handles2: Vec<_> = (0..NEW_THREADS)
+        .map(|_| {
+            thread::spawn(|| {
+                let mut thread_ids = Vec::new();
+                for _ in 0..IDS_PER_PHASE {
+                    thread_ids.push(generate_id());
+                }
+                thread_ids
+            })
+        })
+        .collect();
+    
+    let mut phase2_ids = HashSet::new();
+    for handle in handles2 {
+        let thread_ids = handle.join().unwrap();
+        for id in &thread_ids {
+            all_ids.insert(*id);
+            phase2_ids.insert(*id);
+        }
+    }
+    
+    assert_eq!(phase2_ids.len(), NEW_THREADS * IDS_PER_PHASE);
+    
+    // All IDs should still be unique across both phases
+    assert_eq!(all_ids.len(), (INITIAL_THREADS + NEW_THREADS) * IDS_PER_PHASE,
+               "All IDs should be unique even when thread count changes");
+    
+    // Phase 1 and Phase 2 IDs should not overlap
+    let intersection: Vec<_> = phase1_ids.intersection(&phase2_ids).collect();
+    assert_eq!(intersection.len(), 0,
+               "IDs from different thread phases should not overlap");
+    
+    // Phase 3: Reuse a thread (simulating thread pool reuse)
+    // When a thread is reused, it continues using its existing RNG
+    let handle3 = thread::spawn(|| {
+        let mut thread_ids = Vec::new();
+        for _ in 0..IDS_PER_PHASE {
+            thread_ids.push(generate_id());
+        }
+        thread_ids
+    });
+    
+    let phase3_ids: HashSet<_> = handle3.join().unwrap().into_iter().collect();
+    
+    // Phase 3 IDs should be unique (new thread = new seed)
+    assert_eq!(phase3_ids.len(), IDS_PER_PHASE);
+    
+    // Phase 3 should not overlap with previous phases
+    let intersection_13: Vec<_> = phase1_ids.intersection(&phase3_ids).collect();
+    let intersection_23: Vec<_> = phase2_ids.intersection(&phase3_ids).collect();
+    assert_eq!(intersection_13.len(), 0, "Phase 1 and Phase 3 should not overlap");
+    assert_eq!(intersection_23.len(), 0, "Phase 2 and Phase 3 should not overlap");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR changes the ID generation strategy from sequential AtomicU64 to random UInt128 using thread-local RNG, matching ITensors.jl's approach but with even better collision resistance.

## Changes

- **DynId type**: Changed from  to  for extremely low collision probability
- **ID generation**: Replaced  sequential counter with thread-local random number generator
- **Thread-local RNG**: Each thread uses independent RNG seeded from OS entropy (via )
- **Dependencies**: Added  dependency
- **Tests**: Added comprehensive tests for thread-local RNG behavior
- **Documentation**: Added collision probability analysis to design.md

## Collision Probability

- **UInt128**: For 10^5 indices, collision probability ≈ 1.5 × 10^-29 (effectively zero)
- **Comparison**: UInt128 provides ~2^64 times lower collision probability than UInt64

## Benefits

1. **Extremely low collision probability**: UInt128 provides effectively zero collision risk
2. **Thread-safe**: No global synchronization needed, each thread has its own RNG
3. **Better hash distribution**: Random IDs provide better distribution for hashing
4. **No ID reuse issues**: Random IDs avoid potential issues in long-running processes
5. **Matches ITensors.jl approach**: Similar to ITensors.jl's task-local RNG but with UInt128

## Testing

All existing tests pass. Added new tests:
- : Verifies different threads use different seeds
- : Verifies behavior when thread count changes dynamically