### PR TITLE
Refactor Storage into typed newtypes

### DIFF
--- a/crates/tensor4all-index/tests/basic.rs
+++ b/crates/tensor4all-index/tests/basic.rs
@@ -186,6 +186,7 @@ fn test_storage_dense_f64() {
             assert_eq!(v.capacity(), 10);
         }
         Storage::DenseC64(_) => panic!("expected DenseF64"),
+        Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
     }
 }
 
@@ -200,6 +201,7 @@ fn test_storage_dense_c64() {
             assert_eq!(v.capacity(), 10);
         }
         Storage::DenseF64(_) => panic!("expected DenseC64"),
+        Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseC64"),
     }
 }
 
@@ -207,8 +209,8 @@ fn test_storage_dense_c64() {
 fn test_storage_factory_f64() {
     let storage = <f64 as DenseStorageFactory>::new_dense(7);
     match storage {
-        Storage::DenseF64(v) => assert_eq!(v.capacity(), 7),
-        Storage::DenseC64(_) => panic!("expected DenseF64"),
+            Storage::DenseF64(v) => assert_eq!(v.capacity(), 7),
+            Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
     }
 }
 
@@ -216,8 +218,8 @@ fn test_storage_factory_f64() {
 fn test_storage_factory_c64() {
     let storage = <Complex64 as DenseStorageFactory>::new_dense(9);
     match storage {
-        Storage::DenseC64(v) => assert_eq!(v.capacity(), 9),
-        Storage::DenseF64(_) => panic!("expected DenseC64"),
+            Storage::DenseC64(v) => assert_eq!(v.capacity(), 9),
+            Storage::DenseF64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseC64"),
     }
 }
 
@@ -237,7 +239,7 @@ fn test_cow_storage() {
                 v.push(1.0);
                 v.push(2.0);
             }
-            Storage::DenseC64(_) => panic!("expected DenseF64"),
+            Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
         }
     }
     
@@ -249,17 +251,17 @@ fn test_cow_storage() {
         Storage::DenseF64(v) => {
             assert_eq!(v.len(), 0);
         }
-        Storage::DenseC64(_) => panic!("expected DenseF64"),
+        Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
     }
     
     // storage1 should have the new data
     match storage1.as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.len(), 2);
-            assert_eq!(v[0], 1.0);
-            assert_eq!(v[1], 2.0);
+            assert_eq!(v.get(0), 1.0);
+            assert_eq!(v.get(1), 2.0);
         }
-        Storage::DenseC64(_) => panic!("expected DenseF64"),
+        Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
     }
 }
 
@@ -324,7 +326,7 @@ fn test_tensor_cow() {
             Storage::DenseF64(v) => {
                 v.push(42.0);
             }
-            Storage::DenseC64(_) => panic!("expected DenseF64"),
+            Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
         }
     }
     
@@ -336,16 +338,16 @@ fn test_tensor_cow() {
         Storage::DenseF64(v) => {
             assert_eq!(v.len(), 0);
         }
-        Storage::DenseC64(_) => panic!("expected DenseF64"),
+        Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
     }
     
     // tensor1's storage should have the new data
     match tensor1.storage.as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.len(), 1);
-            assert_eq!(v[0], 42.0);
+            assert_eq!(v.get(0), 42.0);
         }
-        Storage::DenseC64(_) => panic!("expected DenseF64"),
+        Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
     }
 }
 
@@ -357,8 +359,8 @@ fn test_tensor_sum_f64_no_match() {
     {
         let s = make_mut_storage(&mut storage);
         match s {
-            Storage::DenseF64(v) => v.extend([1.0, 2.0, 3.0]),
-            Storage::DenseC64(_) => panic!("expected DenseF64"),
+            Storage::DenseF64(v) => v.extend([1.0, 2.0, 3.0].iter().copied()),
+            Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseF64"),
         }
     }
 
@@ -379,7 +381,7 @@ fn test_tensor_sum_c64() {
         let s = make_mut_storage(&mut storage);
         match s {
             Storage::DenseC64(v) => v.extend([Complex64::new(1.0, 2.0), Complex64::new(3.0, -1.0)]),
-            Storage::DenseF64(_) => panic!("expected DenseC64"),
+            Storage::DenseF64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => panic!("expected DenseC64"),
         }
     }
 

--- a/crates/tensor4all-index/tests/permute.rs
+++ b/crates/tensor4all-index/tests/permute.rs
@@ -91,7 +91,7 @@ fn test_permute_dyn_f64_2d() {
     
     match &*permuted.storage {
         Storage::DenseF64(v) => {
-            assert_eq!(v, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+            assert_eq!(v.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
         }
         _ => panic!("expected DenseF64"),
     }
@@ -131,12 +131,12 @@ fn test_permute_dyn_c64_2d() {
     
     match &*permuted.storage {
         Storage::DenseC64(v) => {
-            assert_eq!(v[0], Complex64::new(1.0, 0.0));
-            assert_eq!(v[1], Complex64::new(4.0, 0.0));
-            assert_eq!(v[2], Complex64::new(2.0, 0.0));
-            assert_eq!(v[3], Complex64::new(5.0, 0.0));
-            assert_eq!(v[4], Complex64::new(3.0, 0.0));
-            assert_eq!(v[5], Complex64::new(6.0, 0.0));
+            assert_eq!(v.get(0), Complex64::new(1.0, 0.0));
+            assert_eq!(v.get(1), Complex64::new(4.0, 0.0));
+            assert_eq!(v.get(2), Complex64::new(2.0, 0.0));
+            assert_eq!(v.get(3), Complex64::new(5.0, 0.0));
+            assert_eq!(v.get(4), Complex64::new(3.0, 0.0));
+            assert_eq!(v.get(5), Complex64::new(6.0, 0.0));
         }
         _ => panic!("expected DenseC64"),
     }
@@ -180,7 +180,7 @@ fn test_permute_dyn_f64_3d() {
             assert_eq!(v.len(), 24);
             // Check first few values to verify permutation
             // This is a complex permutation, so we just verify the structure
-            assert_eq!(v[0], 1.0); // First element should be the same
+            assert_eq!(v.get(0), 1.0); // First element should be the same
         }
         _ => panic!("expected DenseF64"),
     }
@@ -213,7 +213,7 @@ fn test_permute_static_f64_2d() {
     
     match &*permuted.storage {
         Storage::DenseF64(v) => {
-            assert_eq!(v, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+            assert_eq!(v.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
         }
         _ => panic!("expected DenseF64"),
     }
@@ -246,7 +246,7 @@ fn test_permute_identity() {
     
     match &*permuted.storage {
         Storage::DenseF64(v) => {
-            assert_eq!(v, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+            assert_eq!(v.as_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         }
         _ => panic!("expected DenseF64"),
     }
@@ -279,7 +279,7 @@ fn test_permute_indices_dyn_f64_2d() {
     
     match &*permuted.storage {
         Storage::DenseF64(v) => {
-            assert_eq!(v, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+            assert_eq!(v.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
         }
         _ => panic!("expected DenseF64"),
     }
@@ -312,7 +312,7 @@ fn test_permute_indices_static_f64_2d() {
     
     match &*permuted.storage {
         Storage::DenseF64(v) => {
-            assert_eq!(v, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+            assert_eq!(v.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
         }
         _ => panic!("expected DenseF64"),
     }
@@ -352,12 +352,12 @@ fn test_permute_indices_c64() {
     
     match &*permuted.storage {
         Storage::DenseC64(v) => {
-            assert_eq!(v[0], Complex64::new(1.0, 0.0));
-            assert_eq!(v[1], Complex64::new(4.0, 0.0));
-            assert_eq!(v[2], Complex64::new(2.0, 0.0));
-            assert_eq!(v[3], Complex64::new(5.0, 0.0));
-            assert_eq!(v[4], Complex64::new(3.0, 0.0));
-            assert_eq!(v[5], Complex64::new(6.0, 0.0));
+            assert_eq!(v.get(0), Complex64::new(1.0, 0.0));
+            assert_eq!(v.get(1), Complex64::new(4.0, 0.0));
+            assert_eq!(v.get(2), Complex64::new(2.0, 0.0));
+            assert_eq!(v.get(3), Complex64::new(5.0, 0.0));
+            assert_eq!(v.get(4), Complex64::new(3.0, 0.0));
+            assert_eq!(v.get(5), Complex64::new(6.0, 0.0));
         }
         _ => panic!("expected DenseC64"),
     }

--- a/crates/tensor4all-tensor/src/lib.rs
+++ b/crates/tensor4all-tensor/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod storage;
 pub mod tensor;
 
-pub use storage::{AnyScalar, DenseStorageFactory, Storage, SumFromStorage, make_mut_storage};
-pub use tensor::{TensorDynLen, TensorStaticLen, compute_permutation_from_indices};
+pub use storage::{AnyScalar, DenseStorageFactory, Storage, SumFromStorage, make_mut_storage, mindim};
+pub use tensor::{TensorDynLen, TensorStaticLen, compute_permutation_from_indices, is_diag_tensor, is_diag_tensor_static, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, diag_tensor_static_len, diag_tensor_static_len_c64};
 

--- a/crates/tensor4all-tensor/tests/contraction.rs
+++ b/crates/tensor4all-tensor/tests/contraction.rs
@@ -1,4 +1,5 @@
 use tensor4all_tensor::{Storage, TensorDynLen, TensorStaticLen};
+use tensor4all_tensor::storage::DenseStorageF64;
 use tensor4all_index::index::{DefaultIndex as Index, DynId, common_inds};
 use std::sync::Arc;
 
@@ -27,19 +28,13 @@ fn test_contract_dyn_len_matrix_multiplication() {
     // Create tensor A[i, j] with all ones
     let indices_a = vec![i.clone(), j.clone()];
     let dims_a = vec![2, 3];
-    let mut storage_a = Storage::new_dense_f64(6);
-    if let Storage::DenseF64(ref mut vec) = storage_a {
-        vec.resize(6, 1.0);
-    }
+    let storage_a = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 6]));
     let tensor_a: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
 
     // Create tensor B[j, k] with all ones
     let indices_b = vec![j.clone(), k.clone()];
     let dims_b = vec![3, 4];
-    let mut storage_b = Storage::new_dense_f64(12);
-    if let Storage::DenseF64(ref mut vec) = storage_b {
-        vec.resize(12, 1.0);
-    }
+    let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 12]));
     let tensor_b: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j: result should be C[i, k] with all 3.0 (since each element is sum of 3 ones)
@@ -71,19 +66,13 @@ fn test_contract_static_len_matrix_multiplication() {
     // Create tensor A[i, j] with all ones
     let indices_a = [i.clone(), j.clone()];
     let dims_a = [2, 3];
-    let mut storage_a = Storage::new_dense_f64(6);
-    if let Storage::DenseF64(ref mut vec) = storage_a {
-        vec.resize(6, 1.0);
-    }
+    let storage_a = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 6]));
     let tensor_a: TensorStaticLen<2, DynId, f64> = TensorStaticLen::new(indices_a, dims_a, Arc::new(storage_a));
 
     // Create tensor B[j, k] with all ones
     let indices_b = [j.clone(), k.clone()];
     let dims_b = [3, 4];
-    let mut storage_b = Storage::new_dense_f64(12);
-    if let Storage::DenseF64(ref mut vec) = storage_b {
-        vec.resize(12, 1.0);
-    }
+    let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 12]));
     let tensor_b: TensorStaticLen<2, DynId, f64> = TensorStaticLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j: result should be C[i, k] with all 3.0
@@ -137,19 +126,13 @@ fn test_contract_three_indices() {
     // Create tensor A[i, j, k] with all ones
     let indices_a = vec![i.clone(), j.clone(), k.clone()];
     let dims_a = vec![2, 3, 4];
-    let mut storage_a = Storage::new_dense_f64(24);
-    if let Storage::DenseF64(ref mut vec) = storage_a {
-        vec.resize(24, 1.0);
-    }
+    let storage_a = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 24]));
     let tensor_a: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
 
     // Create tensor B[j, k, l] with all ones
     let indices_b = vec![j.clone(), k.clone(), l.clone()];
     let dims_b = vec![3, 4, 5];
-    let mut storage_b = Storage::new_dense_f64(60);
-    if let Storage::DenseF64(ref mut vec) = storage_b {
-        vec.resize(60, 1.0);
-    }
+    let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 60]));
     let tensor_b: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j and k: result should be C[i, l] with all 12.0 (3 * 4 = 12)
@@ -162,7 +145,7 @@ fn test_contract_three_indices() {
     // Check that all elements are 12.0
     if let Storage::DenseF64(ref vec) = *result.storage {
         assert_eq!(vec.len(), 10); // 2 * 5 = 10
-        for &val in vec.iter() {
+        for &val in vec.as_slice().iter() {
             assert_eq!(val, 12.0);
         }
     } else {


### PR DESCRIPTION
This PR refactors the Storage implementation to use typed newtypes (DenseStorageF64, DenseStorageC64, DiagStorageF64, DiagStorageC64) instead of directly wrapping Vec. This improves code organization by moving heavy operations into methods on the storage types, keeping match blocks short and clean.

## Changes

- Introduce newtype structs for each storage type
- Move permute, contract, and to_dense operations into newtype methods
- Update Storage enum to wrap newtypes
- Clean up API by removing old free helper functions
- Update all callers to use new API
- Add comprehensive DiagTensor tests
- Update README with current architecture and usage examples

## Benefits

- Better code organization: logic is grouped by storage type
- Cleaner match blocks: Storage enum is now a pure dispatcher
- Easier to extend: new storage types can add their own methods
- Improved maintainability: each storage type manages its own operations