### PR TITLE
Add tensor4all-linalg: SVD returning (U,S,V)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tensor4all-index", "crates/tensor4all-tensor"]
+members = ["crates/tensor4all-index", "crates/tensor4all-tensor", "crates/tensor4all-linalg"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/tensor4all-linalg/Cargo.toml
+++ b/crates/tensor4all-linalg/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tensor4all-linalg"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+tensor4all-tensor = { path = "../tensor4all-tensor" }
+tensor4all-index = { path = "../tensor4all-index" }
+mdarray = { git = "https://github.com/fre-hu/mdarray.git", rev = "70c43898d202682bf35e0db0c08475ec820ee7fa" }
+mdarray-linalg = { git = "https://github.com/grothesque/mdarray-linalg", branch = "main" }
+mdarray-linalg-faer = { git = "https://github.com/grothesque/mdarray-linalg", branch = "main", package = "mdarray-linalg-faer" }
+thiserror = "2.0"
+num-complex = "0.4"
+
+[dev-dependencies]
+

--- a/crates/tensor4all-linalg/src/lib.rs
+++ b/crates/tensor4all-linalg/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod svd;
+
+pub use svd::{svd, svd_c64, SvdError};
+

--- a/crates/tensor4all-linalg/src/svd.rs
+++ b/crates/tensor4all-linalg/src/svd.rs
@@ -1,0 +1,272 @@
+use std::sync::Arc;
+use tensor4all_index::index::{Index, DynId, NoSymmSpace, Symmetry};
+use tensor4all_index::tagset::DefaultTagSet;
+use tensor4all_tensor::{Storage, TensorDynLen};
+use tensor4all_tensor::storage::DenseStorageF64;
+use mdarray::{Dense, Slice, tensor};
+use mdarray_linalg::svd::{SVD, SVDDecomp, SVDError as MdarraySvdError};
+use mdarray_linalg_faer::Faer;
+use num_complex::Complex64;
+use thiserror::Error;
+
+/// Error type for SVD operations in tensor4all-linalg.
+#[derive(Debug, Error)]
+pub enum SvdError {
+    #[error("Tensor must have rank 2, got rank {0}")]
+    InvalidRank(usize),
+
+    #[error("Tensor storage must be DenseF64, got {0:?}")]
+    UnsupportedStorage(String),
+
+    #[error("mdarray-linalg SVD error: {0}")]
+    BackendError(#[from] MdarraySvdError),
+}
+
+/// Compute SVD decomposition of a rank-2 tensor, returning (U, S, V).
+///
+/// This function mimics ITensor's SVD API, returning U, S, and V (not Vt).
+/// The input tensor must be rank-2 with DenseF64 storage.
+///
+/// # Arguments
+/// * `t` - Input tensor of rank 2 with DenseF64 storage
+///
+/// # Returns
+/// A tuple `(U, S, V)` where:
+/// - `U` is an m×k tensor with indices `[left_index, bond_index]`
+/// - `S` is a k×k diagonal tensor with indices `[bond_index, bond_index]`
+/// - `V` is an n×k tensor with indices `[right_index, bond_index]`
+/// where `k = min(m, n)` is the bond dimension.
+///
+/// # Errors
+/// Returns `SvdError` if the tensor is not rank-2, storage is not DenseF64,
+/// or if the SVD computation fails.
+pub fn svd<Id, Symm>(
+    t: &TensorDynLen<Id, f64, Symm>,
+) -> Result<
+    (
+        TensorDynLen<Id, f64, Symm>,
+        TensorDynLen<Id, f64, Symm>,
+        TensorDynLen<Id, f64, Symm>,
+    ),
+    SvdError,
+>
+where
+    Id: Clone + std::hash::Hash + Eq + From<DynId>,
+    Symm: Clone + Symmetry + From<NoSymmSpace>,
+{
+    // Validate rank
+    if t.dims.len() != 2 {
+        return Err(SvdError::InvalidRank(t.dims.len()));
+    }
+
+    // Validate storage type
+    let dense_storage = match t.storage.as_ref() {
+        Storage::DenseF64(ds) => ds,
+        _ => {
+            return Err(SvdError::UnsupportedStorage(format!(
+                "{:?}",
+                t.storage
+            )));
+        }
+    };
+
+    let m = t.dims[0];
+    let n = t.dims[1];
+    let k = m.min(n);
+
+    // Get original indices
+    let left_index = t.indices[0].clone();
+    let right_index = t.indices[1].clone();
+
+    // Create mdarray tensor from dense storage data
+    // SVD destroys the input, so we need to clone the data
+    let a_data = dense_storage.as_slice().to_vec();
+    let mut a_tensor = tensor![[0.0; n]; m];
+    for i in 0..m {
+        for j in 0..n {
+            a_tensor[[i, j]] = a_data[i * n + j];
+        }
+    }
+
+    // Call SVD using faer backend
+    let bd = Faer;
+    let a_slice: &mut Slice<f64, (usize, usize), Dense> = a_tensor.as_mut();
+    let SVDDecomp { s, u, vt } = bd.svd(a_slice)?;
+
+    // Extract singular values.
+    //
+    // NOTE:
+    // `mdarray-linalg-faer` writes singular values into a diagonal view created by
+    // `into_faer_diag_mut`, which (by design) treats the **first row** as the
+    // singular-value buffer (LAPACK-style convention). Therefore, the values live at
+    // `s[0, i]`, not necessarily at `s[i, i]`.
+    let mut s_vec = Vec::with_capacity(k);
+    for i in 0..k {
+        s_vec.push(s[[0, i]]);
+    }
+
+    // Convert U from m×m to m×k (take first k columns)
+    let mut u_vec = Vec::with_capacity(m * k);
+    for i in 0..m {
+        for j in 0..k {
+            u_vec.push(u[[i, j]]);
+        }
+    }
+
+    // Convert backend `vt` (V^T) to V (n×k).
+    //
+    // `mdarray-linalg` returns `vt` as (conceptually) V^T. We want V (not Vt), so we take the
+    // first k rows of V^T (which correspond to the first k columns of V) and transpose.
+    let mut vt_vec = Vec::with_capacity(k * n);
+    for i in 0..k {
+        for j in 0..n {
+            vt_vec.push(vt[[i, j]]);
+        }
+    }
+
+    let mut v_vec = Vec::with_capacity(n * k);
+    for j in 0..n {
+        for i in 0..k {
+            v_vec.push(vt_vec[i * n + j]);
+        }
+    }
+
+    // Create bond index with "Link" tag
+    // Convert from DynId to Id type
+    let bond_dyn_id = DynId(tensor4all_index::index::generate_id());
+    let bond_id: Id = bond_dyn_id.into();
+    let bond_symm: Symm = NoSymmSpace::new(k).into();
+    let mut bond_index: Index<Id, Symm, DefaultTagSet> = Index::new(bond_id, bond_symm);
+    bond_index.tags_mut().add_tag("Link").map_err(|_| {
+        SvdError::UnsupportedStorage("Failed to add Link tag".to_string())
+    })?;
+
+    // Create U tensor: [left_index, bond_index]
+    let u_indices = vec![left_index.clone(), bond_index.clone()];
+    let u_dims = vec![m, k];
+    let u_storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(u_vec)));
+    let u = TensorDynLen::new(u_indices, u_dims, u_storage);
+
+    // Create S tensor: [bond_index, bond_index] (diagonal)
+    let s_indices = vec![bond_index.clone(), bond_index.clone()];
+    let s_storage = Arc::new(Storage::new_diag_f64(s_vec));
+    let s = TensorDynLen::new(s_indices, vec![k, k], s_storage);
+
+    // Create V tensor: [right_index, bond_index]
+    let v_indices = vec![right_index.clone(), bond_index.clone()];
+    let v_dims = vec![n, k];
+    let v_storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(v_vec)));
+    let v = TensorDynLen::new(v_indices, v_dims, v_storage);
+
+    Ok((u, s, v))
+}
+
+/// Compute SVD decomposition of a rank-2 complex tensor, returning (U, S, V).
+///
+/// For complex-valued matrices, the mathematical convention is:
+/// \[ A = U * Σ * V^H \]
+/// where \(V^H\) is the conjugate-transpose of \(V\).
+///
+/// `mdarray-linalg` returns `vt` (conceptually \(V^T\) / \(V^H\) depending on scalar type),
+/// and we return **V** (not Vt), so we build V by conjugate-transposing the leading k rows.
+pub fn svd_c64<Id, Symm>(
+    t: &TensorDynLen<Id, Complex64, Symm>,
+) -> Result<
+    (
+        TensorDynLen<Id, Complex64, Symm>,
+        TensorDynLen<Id, Complex64, Symm>,
+        TensorDynLen<Id, Complex64, Symm>,
+    ),
+    SvdError,
+>
+where
+    Id: Clone + std::hash::Hash + Eq + From<DynId>,
+    Symm: Clone + Symmetry + From<NoSymmSpace>,
+{
+    if t.dims.len() != 2 {
+        return Err(SvdError::InvalidRank(t.dims.len()));
+    }
+
+    let dense_storage = match t.storage.as_ref() {
+        Storage::DenseC64(ds) => ds,
+        _ => {
+            return Err(SvdError::UnsupportedStorage(format!(
+                "{:?}",
+                t.storage
+            )));
+        }
+    };
+
+    let m = t.dims[0];
+    let n = t.dims[1];
+    let k = m.min(n);
+
+    let left_index = t.indices[0].clone();
+    let right_index = t.indices[1].clone();
+
+    // Build mdarray tensor (SVD destroys input)
+    let a_data = dense_storage.as_slice().to_vec();
+    let mut a_tensor = tensor![[Complex64::new(0.0, 0.0); n]; m];
+    for i in 0..m {
+        for j in 0..n {
+            a_tensor[[i, j]] = a_data[i * n + j];
+        }
+    }
+
+    let bd = Faer;
+    let a_slice: &mut Slice<Complex64, (usize, usize), Dense> = a_tensor.as_mut();
+    let SVDDecomp { s, u, vt } = bd.svd(a_slice)?;
+
+    // Singular values live in the first row (see `into_faer_diag_mut`).
+    let mut s_vec = Vec::with_capacity(k);
+    for i in 0..k {
+        s_vec.push(s[[0, i]]);
+    }
+
+    // U is m×m; take first k columns -> m×k (row-major)
+    let mut u_vec = Vec::with_capacity(m * k);
+    for i in 0..m {
+        for j in 0..k {
+            u_vec.push(u[[i, j]]);
+        }
+    }
+
+    // vt is n×n; take first k rows (k×n) and conjugate-transpose to get V (n×k)
+    let mut vt_vec = Vec::with_capacity(k * n);
+    for i in 0..k {
+        for j in 0..n {
+            vt_vec.push(vt[[i, j]]);
+        }
+    }
+
+    let mut v_vec = Vec::with_capacity(n * k);
+    for j in 0..n {
+        for i in 0..k {
+            v_vec.push(vt_vec[i * n + j].conj());
+        }
+    }
+
+    // Bond index
+    let bond_dyn_id = DynId(tensor4all_index::index::generate_id());
+    let bond_id: Id = bond_dyn_id.into();
+    let bond_symm: Symm = NoSymmSpace::new(k).into();
+    let mut bond_index: Index<Id, Symm, DefaultTagSet> = Index::new(bond_id, bond_symm);
+    bond_index.tags_mut().add_tag("Link").map_err(|_| {
+        SvdError::UnsupportedStorage("Failed to add Link tag".to_string())
+    })?;
+
+    let u_indices = vec![left_index.clone(), bond_index.clone()];
+    let u_storage = Arc::new(Storage::DenseC64(tensor4all_tensor::storage::DenseStorageC64::from_vec(u_vec)));
+    let u_t = TensorDynLen::new(u_indices, vec![m, k], u_storage);
+
+    let s_indices = vec![bond_index.clone(), bond_index.clone()];
+    let s_storage = Arc::new(Storage::new_diag_c64(s_vec));
+    let s_t = TensorDynLen::new(s_indices, vec![k, k], s_storage);
+
+    let v_indices = vec![right_index.clone(), bond_index.clone()];
+    let v_storage = Arc::new(Storage::DenseC64(tensor4all_tensor::storage::DenseStorageC64::from_vec(v_vec)));
+    let v_t = TensorDynLen::new(v_indices, vec![n, k], v_storage);
+
+    Ok((u_t, s_t, v_t))
+}
+

--- a/crates/tensor4all-linalg/tests/svd.rs
+++ b/crates/tensor4all-linalg/tests/svd.rs
@@ -1,0 +1,266 @@
+use std::sync::Arc;
+use tensor4all_index::index::{DefaultIndex as Index, DynId};
+use tensor4all_tensor::{Storage, TensorDynLen};
+use tensor4all_linalg::{svd, svd_c64};
+use num_complex::Complex64;
+
+#[test]
+fn test_svd_identity() {
+    // Test SVD of a 2×2 identity matrix
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    
+    // Create identity matrix: [[1, 0], [0, 1]]
+    let mut data = vec![0.0; 4];
+    data[0] = 1.0; // [0, 0]
+    data[3] = 1.0; // [1, 1]
+    
+    let storage = Arc::new(Storage::DenseF64(tensor4all_tensor::storage::DenseStorageF64::from_vec(data)));
+    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(
+        vec![i.clone(), j.clone()],
+        vec![2, 2],
+        storage,
+    );
+    
+    let (u, s, v) = svd(&tensor).expect("SVD should succeed");
+    
+    // Check dimensions
+    assert_eq!(u.dims, vec![2, 2]);
+    assert_eq!(s.dims, vec![2, 2]);
+    assert_eq!(v.dims, vec![2, 2]);
+    
+    // Check indices
+    assert_eq!(u.indices.len(), 2);
+    assert_eq!(s.indices.len(), 2);
+    assert_eq!(v.indices.len(), 2);
+    
+    // For identity matrix, singular values should be [1, 1] (in some order)
+    // Extract singular values from diagonal storage
+    match s.storage.as_ref() {
+        Storage::DiagF64(diag) => {
+            let s_vals = diag.as_slice();
+            assert_eq!(s_vals.len(), 2);
+            // Singular values should be 1.0 (may be in any order)
+            let s0_ok = (s_vals[0] - 1.0).abs() < 1e-10;
+            let s1_ok = (s_vals[1] - 1.0).abs() < 1e-10;
+            assert!(s0_ok && s1_ok, "Singular values should be [1, 1], got [{}, {}]", s_vals[0], s_vals[1]);
+        }
+        _ => panic!("S should be diagonal storage"),
+    }
+}
+
+#[test]
+fn test_svd_simple_matrix() {
+    // Test SVD of a simple 2×3 matrix: [[1, 2, 3], [4, 5, 6]]
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    
+    let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let storage = Arc::new(Storage::DenseF64(tensor4all_tensor::storage::DenseStorageF64::from_vec(data)));
+    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(
+        vec![i.clone(), j.clone()],
+        vec![2, 3],
+        storage,
+    );
+    
+    let (u, s, v) = svd(&tensor).expect("SVD should succeed");
+    
+    // Check dimensions: m=2, n=3, k=min(2,3)=2
+    assert_eq!(u.dims, vec![2, 2]);
+    assert_eq!(s.dims, vec![2, 2]);
+    assert_eq!(v.dims, vec![3, 2]);
+    
+    // Check indices
+    assert_eq!(u.indices.len(), 2);
+    assert_eq!(s.indices.len(), 2);
+    assert_eq!(v.indices.len(), 2);
+    
+    // Check that U and V share the bond index
+    assert_eq!(u.indices[1].id, s.indices[0].id);
+    assert_eq!(s.indices[0].id, s.indices[1].id);
+    assert_eq!(s.indices[1].id, v.indices[1].id);
+    
+    // Check that bond index has "Link" tag
+    assert!(u.indices[1].tags().has_tag("Link"));
+    assert!(s.indices[0].tags().has_tag("Link"));
+    assert!(v.indices[1].tags().has_tag("Link"));
+}
+
+#[test]
+fn test_svd_reconstruction() {
+    // Test that U * S * V^T reconstructs the original matrix
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(4);
+    
+    // Create a random-ish matrix
+    let data = vec![
+        1.0, 2.0, 3.0, 4.0,
+        5.0, 6.0, 7.0, 8.0,
+        9.0, 10.0, 11.0, 12.0,
+    ];
+    let storage = Arc::new(Storage::DenseF64(tensor4all_tensor::storage::DenseStorageF64::from_vec(data.clone())));
+    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(
+        vec![i.clone(), j.clone()],
+        vec![3, 4],
+        storage,
+    );
+    
+    let (u, s, v) = svd(&tensor).expect("SVD should succeed");
+    
+    // Reconstruct: A = U * S * V^T
+    // Note: Our SVD returns V (not V^T), so we need to compute U * S * V^T
+    // First: S * V^T
+    // V is n×k, V^T is k×n
+    // We need to permute V's indices to get V^T shape, but the data needs to be transposed
+    // Actually, let's contract S with V first, then with U
+    // S is k×k (diagonal), V is n×k
+    // To compute S * V^T, we need V^T which is k×n
+    // But we have V which is n×k, so we need to transpose it
+    
+    // For now, let's use a simpler approach: manually reconstruct
+    // Extract U, S, V data
+    let u_data = match u.storage.as_ref() {
+        Storage::DenseF64(dense) => dense.as_slice(),
+        _ => panic!("U should be dense"),
+    };
+    let s_data = match s.storage.as_ref() {
+        Storage::DiagF64(diag) => diag.as_slice(),
+        _ => panic!("S should be diagonal"),
+    };
+    let v_data = match v.storage.as_ref() {
+        Storage::DenseF64(dense) => dense.as_slice(),
+        _ => panic!("V should be dense"),
+    };
+    
+    // Reconstruct: A[i,j] = sum_r U[i,r] * S[r] * V[j,r]
+    let m = u.dims[0];
+    let n = v.dims[0];
+    let k = u.dims[1];
+    let mut reconstructed_data = vec![0.0; m * n];
+    for i in 0..m {
+        for j in 0..n {
+            let mut sum = 0.0;
+            for r in 0..k {
+                sum += u_data[i * k + r] * s_data[r] * v_data[j * k + r];
+            }
+            reconstructed_data[i * n + j] = sum;
+        }
+    }
+    
+    // Create reconstructed tensor for comparison
+    let reconstructed_storage = Arc::new(Storage::DenseF64(tensor4all_tensor::storage::DenseStorageF64::from_vec(reconstructed_data)));
+    let reconstructed: TensorDynLen<DynId, f64> = TensorDynLen::new(
+        vec![i.clone(), j.clone()],
+        vec![m, n],
+        reconstructed_storage,
+    );
+    
+    // Check dimensions match
+    assert_eq!(reconstructed.dims, vec![3, 4]);
+    
+    // Extract reconstructed data
+    let reconstructed_data_vec = match reconstructed.storage.as_ref() {
+        Storage::DenseF64(dense) => dense.as_slice().to_vec(),
+        _ => panic!("Reconstructed should be dense"),
+    };
+    
+    // Check reconstruction accuracy (within tolerance)
+    for (i, (orig, recon)) in data.iter().zip(reconstructed_data_vec.iter()).enumerate() {
+        assert!(
+            (orig - recon).abs() < 1e-8,
+            "Element {}: original={}, reconstructed={}, diff={}",
+            i, orig, recon, (orig - recon).abs()
+        );
+    }
+}
+
+#[test]
+fn test_svd_invalid_rank() {
+    // Test that SVD fails for non-rank-2 tensors
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(4);
+    
+    let storage = Arc::new(Storage::new_dense_f64(24));
+    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(
+        vec![i, j, k],
+        vec![2, 3, 4],
+        storage,
+    );
+    
+    let result = svd(&tensor);
+    assert!(result.is_err());
+    match result {
+        Err(tensor4all_linalg::SvdError::InvalidRank(rank)) => {
+            assert_eq!(rank, 3);
+        }
+        _ => panic!("Expected InvalidRank error"),
+    }
+}
+
+#[test]
+fn test_svd_complex_reconstruction() {
+    // Complex diagonal-ish matrix where conjugation matters in principle:
+    // A = [[i, 0], [0, 2]]
+    let i_idx = Index::new_dyn(2);
+    let j_idx = Index::new_dyn(2);
+
+    let data = vec![
+        Complex64::new(0.0, 1.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(2.0, 0.0),
+    ];
+    let storage = Arc::new(Storage::DenseC64(tensor4all_tensor::storage::DenseStorageC64::from_vec(
+        data.clone(),
+    )));
+    let tensor: TensorDynLen<DynId, Complex64> = TensorDynLen::new(
+        vec![i_idx.clone(), j_idx.clone()],
+        vec![2, 2],
+        storage,
+    );
+
+    let (u, s, v) = svd_c64(&tensor).expect("Complex SVD should succeed");
+
+    let u_data = match u.storage.as_ref() {
+        Storage::DenseC64(dense) => dense.as_slice(),
+        _ => panic!("U should be dense complex"),
+    };
+    let s_data = match s.storage.as_ref() {
+        Storage::DiagC64(diag) => diag.as_slice(),
+        _ => panic!("S should be diagonal complex"),
+    };
+    let v_data = match v.storage.as_ref() {
+        Storage::DenseC64(dense) => dense.as_slice(),
+        _ => panic!("V should be dense complex"),
+    };
+
+    let m = u.dims[0];
+    let n = v.dims[0];
+    let k = u.dims[1];
+
+    // A[i,j] = Σ_r U[i,r] * S[r] * conj(V[j,r])
+    let mut reconstructed = vec![Complex64::new(0.0, 0.0); m * n];
+    for i in 0..m {
+        for j in 0..n {
+            let mut sum = Complex64::new(0.0, 0.0);
+            for r in 0..k {
+                sum += u_data[i * k + r] * s_data[r] * v_data[j * k + r].conj();
+            }
+            reconstructed[i * n + j] = sum;
+        }
+    }
+
+    for (idx, (orig, recon)) in data.iter().zip(reconstructed.iter()).enumerate() {
+        let diff = *orig - *recon;
+        assert!(
+            diff.norm() < 1e-8,
+            "Element {}: original={:?}, reconstructed={:?}, diff={:?}",
+            idx,
+            orig,
+            recon,
+            diff
+        );
+    }
+}
+


### PR DESCRIPTION
- Add new crate tensor4all-linalg\n- Implement SVD that returns (U, S, V) (not Vt)\n- Handle mdarray-linalg-faer singular value layout\n- Add Complex64 SVD (uses conjugation)\n- Add tests; cargo test passes