### PR TITLE
Add rtol-based truncation for SVD and QR decompositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 Cargo.lock
+*.log

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ Tensor data is shared via `Arc<Storage>` with copy-on-write (COW) semantics:
 | `NDTensors.Dense` | `Storage::DenseF64` or `Storage::DenseC64` |
 | `NDTensors.Diag` | `Storage::DiagF64` or `Storage::DiagC64` |
 
+## Truncation Tolerance Comparison
+
+tensor4all-rs and ITensors.jl use different conventions for truncation tolerance:
+
+| Library | Parameter | Semantics | Guarantee |
+|---------|-----------|----------|-----------|
+| **tensor4all-rs** | `rtol` | Relative Frobenius error tolerance | \|A - A_approx\|_F / \|A\|_F ≤ rtol |
+| **ITensors.jl** | `cutoff` | Squared relative error (discarded weight ratio) | Σ_{discarded} σ²_i / Σ_i σ²_i ≤ cutoff |
+
+**Conversion**: ITensors.jl's `cutoff` corresponds to `rtol²` in tensor4all-rs:
+- To achieve the same truncation behavior, use `rtol = sqrt(cutoff)` in tensor4all-rs
+- For example, ITensors `cutoff=1e-20` (for ~10 digit accuracy) corresponds to `rtol=1e-10` in tensor4all-rs
+
+**Default values**:
+- tensor4all-rs: `rtol = 1e-12` (near machine precision)
+- ITensors.jl: `cutoff = 1e-16` (default, corresponds to `rtol ≈ 1e-8`)
+
 ## Project Structure
 
 tensor4all-rs is organized as a Cargo workspace with two main crates:

--- a/crates/tensor4all-linalg/src/lib.rs
+++ b/crates/tensor4all-linalg/src/lib.rs
@@ -2,5 +2,9 @@ mod backend;
 pub mod qr;
 pub mod svd;
 
-pub use qr::{qr, qr_c64, QrError};
-pub use svd::{svd, svd_c64, SvdError};
+pub use qr::{
+    default_qr_rtol, qr, qr_c64, qr_with, set_default_qr_rtol, QrError, QrOptions,
+};
+pub use svd::{
+    default_svd_rtol, set_default_svd_rtol, svd, svd_c64, svd_with, SvdError, SvdOptions,
+};


### PR DESCRIPTION
This PR adds rtol-based truncation support for SVD and QR decompositions in tensor4all-linalg.

## Changes

- **SVD truncation**: Implement TSVD-style truncation with relative Frobenius error guarantee (||A - A_approx||_F / ||A||_F <= rtol)
- **QR truncation**: Add truncation based on R's diagonal elements (|R[i, i]| < rtol)
- **Global default rtol**: 
  - SVD: 1e-12 (near machine precision)
  - QR: 1e-15 (very strict)
- **Per-call override**: Add `svd_with()` and `qr_with()` APIs for per-call rtol control
- **Documentation**: Add comparison table with ITensors.jl cutoff semantics in README
- **Tests**: Comprehensive test coverage for truncation and rtol management

## API

- `svd(t, left_inds)` - Uses global default rtol
- `svd_with(t, left_inds, &SvdOptions { rtol: Some(1e-6) })` - Per-call override
- `set_default_svd_rtol(rtol)` - Set global default
- Same pattern for QR with `qr()`, `qr_with()`, `set_default_qr_rtol()`

## Compatibility

- Existing code using `svd()` and `qr()` continues to work with truncation enabled by default
- Default rtol values are conservative (1e-12 for SVD, 1e-15 for QR) to maintain high accuracy