### PR TITLE
Remove T parameter from TensorDynLen and add Storage arithmetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ let storage = Arc::new(Storage::new_dense_f64(6));  // Capacity for 2×3=6 eleme
 // Create tensor
 let indices = vec![i, j];
 let dims = vec![2, 3];
-let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(indices, dims, storage);
+let tensor: TensorDynLen<DynId> = TensorDynLen::new(indices, dims, storage);
 ```
 
 ### Diagonal Tensor Creation

--- a/crates/tensor4all-linalg/src/qr.rs
+++ b/crates/tensor4all-linalg/src/qr.rs
@@ -143,16 +143,16 @@ where
 /// - The QR computation fails
 #[allow(private_bounds)]
 pub fn qr<Id, Symm, T>(
-    t: &TensorDynLen<Id, T, Symm>,
+    t: &TensorDynLen<Id, Symm>,
     left_inds: &[Index<Id, Symm>],
-) -> Result<(TensorDynLen<Id, T, Symm>, TensorDynLen<Id, T, Symm>), QrError>
+) -> Result<(TensorDynLen<Id, Symm>, TensorDynLen<Id, Symm>), QrError>
 where
     Id: Clone + std::hash::Hash + Eq + From<DynId>,
     Symm: Clone + Symmetry + From<NoSymmSpace>,
     T: StorageScalar + ComplexFloat + ComplexField + Default + From<<T as ComplexFloat>::Real>,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
 {
-    qr_with(t, left_inds, &QrOptions::default())
+    qr_with::<Id, Symm, T>(t, left_inds, &QrOptions::default())
 }
 
 /// Compute QR decomposition of a tensor with arbitrary rank, returning (Q, R).
@@ -193,10 +193,10 @@ where
 /// - `options.rtol` is invalid (not finite or negative)
 #[allow(private_bounds)]
 pub fn qr_with<Id, Symm, T>(
-    t: &TensorDynLen<Id, T, Symm>,
+    t: &TensorDynLen<Id, Symm>,
     left_inds: &[Index<Id, Symm>],
     options: &QrOptions,
-) -> Result<(TensorDynLen<Id, T, Symm>, TensorDynLen<Id, T, Symm>), QrError>
+) -> Result<(TensorDynLen<Id, Symm>, TensorDynLen<Id, Symm>), QrError>
 where
     Id: Clone + std::hash::Hash + Eq + From<DynId>,
     Symm: Clone + Symmetry + From<NoSymmSpace>,
@@ -210,7 +210,7 @@ where
     }
 
     // Unfold tensor into matrix (returns DTensor<T, 2>)
-    let (mut a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
+    let (mut a_tensor, _, m, n, left_indices, right_indices) = unfold_split::<Id, T, Symm>(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(QrError::ComputationError)?;
     let k = m.min(n);
@@ -272,12 +272,12 @@ where
 /// The tensor is unfolded into a matrix by grouping left indices as rows and right indices as columns.
 #[inline]
 pub fn qr_c64<Id, Symm>(
-    t: &TensorDynLen<Id, Complex64, Symm>,
+    t: &TensorDynLen<Id, Symm>,
     left_inds: &[Index<Id, Symm>],
 ) -> Result<
     (
-        TensorDynLen<Id, Complex64, Symm>,
-        TensorDynLen<Id, Complex64, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
     ),
     QrError,
 >
@@ -285,5 +285,5 @@ where
     Id: Clone + std::hash::Hash + Eq + From<DynId>,
     Symm: Clone + Symmetry + From<NoSymmSpace>,
 {
-    qr(t, left_inds)
+    qr::<Id, Symm, Complex64>(t, left_inds)
 }

--- a/crates/tensor4all-linalg/src/svd.rs
+++ b/crates/tensor4all-linalg/src/svd.rs
@@ -238,13 +238,13 @@ where
 /// - The SVD computation fails
 #[allow(private_bounds)]
 pub fn svd<Id, Symm, T>(
-    t: &TensorDynLen<Id, T, Symm>,
+    t: &TensorDynLen<Id, Symm>,
     left_inds: &[Index<Id, Symm>],
 ) -> Result<
     (
-        TensorDynLen<Id, T, Symm>,
-        TensorDynLen<Id, <T as ComplexFloat>::Real, Symm>,
-        TensorDynLen<Id, T, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
     ),
     SvdError,
 >
@@ -254,7 +254,7 @@ where
     T: StorageScalar + ComplexFloat + ComplexField + Default + From<<T as ComplexFloat>::Real>,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
 {
-    svd_with(t, left_inds, &SvdOptions::default())
+    svd_with::<Id, Symm, T>(t, left_inds, &SvdOptions::default())
 }
 
 /// Compute SVD decomposition of a tensor with arbitrary rank, returning (U, S, V).
@@ -300,14 +300,14 @@ where
 /// - `options.rtol` is invalid (not finite or negative)
 #[allow(private_bounds)]
 pub fn svd_with<Id, Symm, T>(
-    t: &TensorDynLen<Id, T, Symm>,
+    t: &TensorDynLen<Id, Symm>,
     left_inds: &[Index<Id, Symm>],
     options: &SvdOptions,
 ) -> Result<
     (
-        TensorDynLen<Id, T, Symm>,
-        TensorDynLen<Id, <T as ComplexFloat>::Real, Symm>,
-        TensorDynLen<Id, T, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
     ),
     SvdError,
 >
@@ -324,7 +324,7 @@ where
     }
 
     // Unfold tensor into matrix (returns DTensor<T, 2>)
-    let (mut a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
+    let (mut a_tensor, _, m, n, left_indices, right_indices) = unfold_split::<Id, T, Symm>(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(SvdError::ComputationError)?;
     let k = m.min(n);
@@ -402,13 +402,13 @@ where
 /// Note: Singular values `S` are always real (f64), even for complex input tensors.
 #[inline]
 pub fn svd_c64<Id, Symm>(
-    t: &TensorDynLen<Id, Complex64, Symm>,
+    t: &TensorDynLen<Id, Symm>,
     left_inds: &[Index<Id, Symm>],
 ) -> Result<
     (
-        TensorDynLen<Id, Complex64, Symm>,
-        TensorDynLen<Id, f64, Symm>,
-        TensorDynLen<Id, Complex64, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
+        TensorDynLen<Id, Symm>,
     ),
     SvdError,
 >
@@ -416,5 +416,5 @@ where
     Id: Clone + std::hash::Hash + Eq + From<DynId>,
     Symm: Clone + Symmetry + From<NoSymmSpace>,
 {
-    svd(t, left_inds)
+    svd::<Id, Symm, Complex64>(t, left_inds)
 }

--- a/crates/tensor4all-linalg/tests/qr.rs
+++ b/crates/tensor4all-linalg/tests/qr.rs
@@ -18,10 +18,10 @@ fn test_qr_identity() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 2], storage);
 
-    let (q, r) = qr(&tensor, &[i.clone()]).expect("QR should succeed");
+    let (q, r) = qr::<DynId, _, f64>(&tensor, &[i.clone()]).expect("QR should succeed");
 
     // Check dimensions
     assert_eq!(q.dims, vec![2, 2]);
@@ -49,10 +49,10 @@ fn test_qr_simple_matrix() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 3], storage);
 
-    let (q, r) = qr(&tensor, &[i.clone()]).expect("QR should succeed");
+    let (q, r) = qr::<DynId, _, f64>(&tensor, &[i.clone()]).expect("QR should succeed");
 
     // Check dimensions: m=2, n=3, k=min(2,3)=2
     assert_eq!(q.dims, vec![2, 2]);
@@ -83,10 +83,10 @@ fn test_qr_reconstruction() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data.clone()),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![3, 4], storage);
 
-    let (q, r) = qr(&tensor, &[i.clone()]).expect("QR should succeed");
+    let (q, r) = qr::<DynId, _, f64>(&tensor, &[i.clone()]).expect("QR should succeed");
 
     // Reconstruct: A = Q * R
     // Extract Q and R data
@@ -118,7 +118,7 @@ fn test_qr_reconstruction() {
     let reconstructed_storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(reconstructed_data),
     ));
-    let reconstructed: TensorDynLen<DynId, f64> = TensorDynLen::new(
+    let reconstructed: TensorDynLen<DynId> = TensorDynLen::new(
         vec![i.clone(), j.clone()],
         vec![m, n],
         reconstructed_storage,
@@ -152,9 +152,9 @@ fn test_qr_invalid_rank() {
     let i = Index::new_dyn(2);
 
     let storage = Arc::new(Storage::new_dense_f64(2));
-    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(vec![i.clone()], vec![2], storage);
+    let tensor: TensorDynLen<DynId> = TensorDynLen::new(vec![i.clone()], vec![2], storage);
 
-    let result = qr(&tensor, &[i.clone()]);
+    let result = qr::<DynId, _, f64>(&tensor, &[i.clone()]);
     assert!(result.is_err());
     // Expected: unfold_split returns an error for rank < 2
     if result.is_ok() {
@@ -169,15 +169,15 @@ fn test_qr_invalid_split() {
     let j = Index::new_dyn(3);
 
     let storage = Arc::new(Storage::new_dense_f64(6));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 3], storage);
 
     // Empty left_inds should fail
-    let result = qr(&tensor, &[]);
+    let result = qr::<DynId, _, f64>(&tensor, &[]);
     assert!(result.is_err(), "Expected error for empty left_inds");
 
     // All indices in left_inds should fail
-    let result = qr(&tensor, &[i.clone(), j.clone()]);
+    let result = qr::<DynId, _, f64>(&tensor, &[i.clone(), j.clone()]);
     assert!(
         result.is_err(),
         "Expected error for all indices in left_inds"
@@ -196,7 +196,7 @@ fn test_qr_rank3() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(
+    let tensor: TensorDynLen<DynId> = TensorDynLen::new(
         vec![i.clone(), j.clone(), k.clone()],
         vec![2, 3, 4],
         storage,
@@ -204,7 +204,7 @@ fn test_qr_rank3() {
 
     // Split: left = [i], right = [j, k]
     // This unfolds to a 2×12 matrix
-    let (q, r) = qr(&tensor, &[i.clone()]).expect("QR should succeed");
+    let (q, r) = qr::<DynId, _, f64>(&tensor, &[i.clone()]).expect("QR should succeed");
 
     // Check dimensions:
     // Q should be [i, bond] = [2, min(2, 12)] = [2, 2]
@@ -247,7 +247,7 @@ fn test_qr_complex_reconstruction() {
     let storage = Arc::new(Storage::DenseC64(
         tensor4all_tensor::storage::DenseStorageC64::from_vec(data.clone()),
     ));
-    let tensor: TensorDynLen<DynId, Complex64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i_idx.clone(), j_idx.clone()], vec![2, 2], storage);
 
     let (q, r) = qr_c64(&tensor, &[i_idx.clone()]).expect("Complex QR should succeed");

--- a/crates/tensor4all-linalg/tests/svd.rs
+++ b/crates/tensor4all-linalg/tests/svd.rs
@@ -20,10 +20,10 @@ fn test_svd_identity() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 2], storage);
 
-    let (u, s, v) = svd(&tensor, &[i.clone()]).expect("SVD should succeed");
+    let (u, s, v) = svd::<DynId, _, f64>(&tensor, &[i.clone()]).expect("SVD should succeed");
 
     // Check dimensions
     assert_eq!(u.dims, vec![2, 2]);
@@ -65,10 +65,10 @@ fn test_svd_simple_matrix() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 3], storage);
 
-    let (u, s, v) = svd(&tensor, &[i.clone()]).expect("SVD should succeed");
+    let (u, s, v) = svd::<DynId, _, f64>(&tensor, &[i.clone()]).expect("SVD should succeed");
 
     // Check dimensions: m=2, n=3, k=min(2,3)=2
     assert_eq!(u.dims, vec![2, 2]);
@@ -104,10 +104,10 @@ fn test_svd_reconstruction() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data.clone()),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![3, 4], storage);
 
-    let (u, s, v) = svd(&tensor, &[i.clone()]).expect("SVD should succeed");
+    let (u, s, v) = svd::<DynId, _, f64>(&tensor, &[i.clone()]).expect("SVD should succeed");
 
     // Reconstruct: A = U * S * V^T
     // Note: Our SVD returns V (not V^T), so we need to compute U * S * V^T
@@ -153,7 +153,7 @@ fn test_svd_reconstruction() {
     let reconstructed_storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(reconstructed_data),
     ));
-    let reconstructed: TensorDynLen<DynId, f64> = TensorDynLen::new(
+    let reconstructed: TensorDynLen<DynId> = TensorDynLen::new(
         vec![i.clone(), j.clone()],
         vec![m, n],
         reconstructed_storage,
@@ -187,9 +187,9 @@ fn test_svd_invalid_rank() {
     let i = Index::new_dyn(2);
 
     let storage = Arc::new(Storage::new_dense_f64(2));
-    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(vec![i.clone()], vec![2], storage);
+    let tensor: TensorDynLen<DynId> = TensorDynLen::new(vec![i.clone()], vec![2], storage);
 
-    let result = svd(&tensor, &[i.clone()]);
+    let result = svd::<DynId, _, f64>(&tensor, &[i.clone()]);
     assert!(result.is_err());
     // Expected: unfold_split returns an error for rank < 2
     if result.is_ok() {
@@ -204,15 +204,15 @@ fn test_svd_invalid_split() {
     let j = Index::new_dyn(3);
 
     let storage = Arc::new(Storage::new_dense_f64(6));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 3], storage);
 
     // Empty left_inds should fail
-    let result = svd(&tensor, &[]);
+    let result = svd::<DynId, _, f64>(&tensor, &[]);
     assert!(result.is_err(), "Expected error for empty left_inds");
 
     // All indices in left_inds should fail
-    let result = svd(&tensor, &[i.clone(), j.clone()]);
+    let result = svd::<DynId, _, f64>(&tensor, &[i.clone(), j.clone()]);
     assert!(
         result.is_err(),
         "Expected error for all indices in left_inds"
@@ -231,7 +231,7 @@ fn test_svd_rank3() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> = TensorDynLen::new(
+    let tensor: TensorDynLen<DynId> = TensorDynLen::new(
         vec![i.clone(), j.clone(), k.clone()],
         vec![2, 3, 4],
         storage,
@@ -239,7 +239,7 @@ fn test_svd_rank3() {
 
     // Split: left = [i], right = [j, k]
     // This unfolds to a 2×12 matrix
-    let (u, s, v) = svd(&tensor, &[i.clone()]).expect("SVD should succeed");
+    let (u, s, v) = svd::<DynId, _, f64>(&tensor, &[i.clone()]).expect("SVD should succeed");
 
     // Check dimensions:
     // U should be [i, bond] = [2, min(2, 12)] = [2, 2]
@@ -288,7 +288,7 @@ fn test_svd_complex_reconstruction() {
     let storage = Arc::new(Storage::DenseC64(
         tensor4all_tensor::storage::DenseStorageC64::from_vec(data.clone()),
     ));
-    let tensor: TensorDynLen<DynId, Complex64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i_idx.clone(), j_idx.clone()], vec![2, 2], storage);
 
     let (u, s, v) = svd_c64(&tensor, &[i_idx.clone()]).expect("Complex SVD should succeed");
@@ -352,12 +352,12 @@ fn test_svd_truncation() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 2], storage);
 
     // Use a more lenient rtol to ensure truncation happens
     let options = SvdOptions::with_rtol(1e-10);
-    let (u, s, v) = svd_with(&tensor, &[i.clone()], &options).expect("SVD should succeed");
+    let (u, s, v) = svd_with::<DynId, _, f64>(&tensor, &[i.clone()], &options).expect("SVD should succeed");
 
     // With rtol=1e-10, the discarded weight ratio is (1e-14)^2 / (1^2 + (1e-14)^2) ≈ 1e-28
     // This is much less than (1e-10)^2 = 1e-20, so truncation should occur
@@ -404,7 +404,7 @@ fn test_svd_with_override() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 2], storage);
 
     // Save original default
@@ -412,12 +412,12 @@ fn test_svd_with_override() {
 
     // Test with lenient rtol (should truncate)
     let lenient_options = SvdOptions::with_rtol(1e-4);
-    let (u1, s1, _v1) = svd_with(&tensor, &[i.clone()], &lenient_options)
+    let (u1, s1, _v1) = svd_with::<DynId, _, f64>(&tensor, &[i.clone()], &lenient_options)
         .expect("SVD should succeed");
 
     // Test with strict rtol (should not truncate)
     let strict_options = SvdOptions::with_rtol(1e-12);
-    let (u2, s2, _v2) = svd_with(&tensor, &[i.clone()], &strict_options)
+    let (u2, s2, _v2) = svd_with::<DynId, _, f64>(&tensor, &[i.clone()], &strict_options)
         .expect("SVD should succeed");
 
     // With rtol=1e-4, the ratio is (1e-6)^2 / (1^2 + (1e-6)^2) ≈ 1e-12 < (1e-4)^2 = 1e-8
@@ -494,7 +494,7 @@ fn test_svd_uses_global_default() {
     let storage = Arc::new(Storage::DenseF64(
         tensor4all_tensor::storage::DenseStorageF64::from_vec(data),
     ));
-    let tensor: TensorDynLen<DynId, f64> =
+    let tensor: TensorDynLen<DynId> =
         TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 2], storage);
 
     // Save original default
@@ -504,7 +504,7 @@ fn test_svd_uses_global_default() {
     set_default_svd_rtol(1e-6).expect("Should set rtol");
 
     // svd() should use the new global default
-    let (u, s, _v) = svd(&tensor, &[i.clone()]).expect("SVD should succeed");
+    let (u, s, _v) = svd::<DynId, _, f64>(&tensor, &[i.clone()]).expect("SVD should succeed");
 
     // With rtol=1e-6, identity matrix should keep full rank (both singular values are 1.0)
     assert_eq!(u.dims[1], 2, "Identity matrix should keep full rank");

--- a/crates/tensor4all-tensor/src/any_scalar.rs
+++ b/crates/tensor4all-tensor/src/any_scalar.rs
@@ -26,6 +26,28 @@ impl SumFromStorage for AnyScalar {
 }
 
 impl AnyScalar {
+    /// Create a real scalar value.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_tensor::AnyScalar;
+    /// let s = AnyScalar::new_real(3.5);
+    /// ```
+    pub fn new_real(x: f64) -> Self {
+        x.into()
+    }
+
+    /// Create a complex scalar value from real and imaginary parts.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_tensor::AnyScalar;
+    /// let s = AnyScalar::new_complex(1.0, 2.0);  // 1 + 2i
+    /// ```
+    pub fn new_complex(re: f64, im: f64) -> Self {
+        Complex64::new(re, im).into()
+    }
+
     /// Check if this scalar is complex.
     pub fn is_complex(&self) -> bool {
         matches!(self, AnyScalar::C64(_))

--- a/crates/tensor4all-tensor/tests/any_scalar.rs
+++ b/crates/tensor4all-tensor/tests/any_scalar.rs
@@ -190,6 +190,27 @@ fn test_from_f64() {
 }
 
 #[test]
+fn test_new_real() {
+    let s = AnyScalar::new_real(3.5);
+    assert_eq!(s, AnyScalar::F64(3.5));
+    assert_eq!(s.real(), 3.5);
+}
+
+#[test]
+fn test_new_complex() {
+    let s = AnyScalar::new_complex(1.0, 2.0);
+    match s {
+        AnyScalar::C64(z) => {
+            assert_eq!(z.re, 1.0);
+            assert_eq!(z.im, 2.0);
+        }
+        _ => panic!("Expected C64"),
+    }
+    assert_eq!(s.real(), 1.0);
+    assert!(s.is_complex());
+}
+
+#[test]
 fn test_from_complex64() {
     let z = Complex64::new(1.0, 2.0);
     let s: AnyScalar = z.into();

--- a/crates/tensor4all-tensor/tests/contraction.rs
+++ b/crates/tensor4all-tensor/tests/contraction.rs
@@ -1,7 +1,8 @@
 use tensor4all_tensor::{Storage, TensorDynLen};
-use tensor4all_tensor::storage::DenseStorageF64;
+use tensor4all_tensor::storage::{DenseStorageF64, DenseStorageC64};
 use tensor4all_core::index::{DefaultIndex as Index, DynId};
 use tensor4all_core::index_ops::common_inds;
+use num_complex::Complex64;
 use std::sync::Arc;
 
 #[test]
@@ -30,13 +31,13 @@ fn test_contract_dyn_len_matrix_multiplication() {
     let indices_a = vec![i.clone(), j.clone()];
     let dims_a = vec![2, 3];
     let storage_a = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 6]));
-    let tensor_a: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
+    let tensor_a: TensorDynLen<DynId> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
 
     // Create tensor B[j, k] with all ones
     let indices_b = vec![j.clone(), k.clone()];
     let dims_b = vec![3, 4];
     let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 12]));
-    let tensor_b: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
+    let tensor_b: TensorDynLen<DynId> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j: result should be C[i, k] with all 3.0 (since each element is sum of 3 ones)
     let result = tensor_a.contract(&tensor_b);
@@ -67,12 +68,12 @@ fn test_contract_no_common_indices() {
     let indices_a = vec![i.clone(), j.clone()];
     let dims_a = vec![2, 3];
     let storage_a = Arc::new(Storage::new_dense_f64(6));
-    let tensor_a: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_a, dims_a, storage_a);
+    let tensor_a: TensorDynLen<DynId> = TensorDynLen::new(indices_a, dims_a, storage_a);
 
     let indices_b = vec![k.clone()];
     let dims_b = vec![4];
     let storage_b = Arc::new(Storage::new_dense_f64(4));
-    let tensor_b: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_b, dims_b, storage_b);
+    let tensor_b: TensorDynLen<DynId> = TensorDynLen::new(indices_b, dims_b, storage_b);
 
     // This should panic because there are no common indices
     let _result = tensor_a.contract(&tensor_b);
@@ -91,13 +92,13 @@ fn test_contract_three_indices() {
     let indices_a = vec![i.clone(), j.clone(), k.clone()];
     let dims_a = vec![2, 3, 4];
     let storage_a = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 24]));
-    let tensor_a: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
+    let tensor_a: TensorDynLen<DynId> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
 
     // Create tensor B[j, k, l] with all ones
     let indices_b = vec![j.clone(), k.clone(), l.clone()];
     let dims_b = vec![3, 4, 5];
     let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 60]));
-    let tensor_b: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
+    let tensor_b: TensorDynLen<DynId> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j and k: result should be C[i, l] with all 12.0 (3 * 4 = 12)
     let result = tensor_a.contract(&tensor_b);
@@ -114,6 +115,104 @@ fn test_contract_three_indices() {
         }
     } else {
         panic!("Expected DenseF64 storage");
+    }
+}
+
+#[test]
+fn test_contract_mixed_f64_c64() {
+    // Test contraction between f64 and Complex64 tensors
+    // A[i, j] (f64) × B[j, k] (Complex64) = C[i, k] (Complex64)
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let k = Index::new_dyn(2);
+
+    // Create tensor A[i, j] with all 1.0 (f64)
+    let indices_a = vec![i.clone(), j.clone()];
+    let dims_a = vec![2, 2];
+    let storage_a = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 4]));
+    let tensor_a: TensorDynLen<DynId> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
+
+    // Create tensor B[j, k] with complex values: [[1+2i, 3+4i], [5+6i, 7+8i]]
+    let indices_b = vec![j.clone(), k.clone()];
+    let dims_b = vec![2, 2];
+    let storage_b = Storage::DenseC64(DenseStorageC64::from_vec(vec![
+        Complex64::new(1.0, 2.0),
+        Complex64::new(3.0, 4.0),
+        Complex64::new(5.0, 6.0),
+        Complex64::new(7.0, 8.0),
+    ]));
+    let tensor_b: TensorDynLen<DynId> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
+
+    // Contract along j: result should be C[i, k] (Complex64)
+    // Expected result: [[1+2i + 5+6i, 3+4i + 7+8i], [1+2i + 5+6i, 3+4i + 7+8i]]
+    //                  = [[6+8i, 10+12i], [6+8i, 10+12i]]
+    let result = tensor_a.contract(&tensor_b);
+    assert_eq!(result.dims, vec![2, 2]);
+    assert_eq!(result.indices.len(), 2);
+    assert_eq!(result.indices[0].id, i.id);
+    assert_eq!(result.indices[1].id, k.id);
+
+    // Check result storage type and values
+    if let Storage::DenseC64(ref vec) = *result.storage {
+        assert_eq!(vec.len(), 4);
+        // All elements should be the same: sum of first column and sum of second column
+        // First row: [6+8i, 10+12i]
+        assert!((vec.get(0) - Complex64::new(6.0, 8.0)).norm() < 1e-10);
+        assert!((vec.get(1) - Complex64::new(10.0, 12.0)).norm() < 1e-10);
+        // Second row: [6+8i, 10+12i]
+        assert!((vec.get(2) - Complex64::new(6.0, 8.0)).norm() < 1e-10);
+        assert!((vec.get(3) - Complex64::new(10.0, 12.0)).norm() < 1e-10);
+    } else {
+        panic!("Expected DenseC64 storage for mixed-type contraction");
+    }
+}
+
+#[test]
+fn test_contract_mixed_c64_f64() {
+    // Test contraction between Complex64 and f64 tensors (reverse order)
+    // A[i, j] (Complex64) × B[j, k] (f64) = C[i, k] (Complex64)
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let k = Index::new_dyn(2);
+
+    // Create tensor A[i, j] with complex values
+    let indices_a = vec![i.clone(), j.clone()];
+    let dims_a = vec![2, 2];
+    let storage_a = Storage::DenseC64(DenseStorageC64::from_vec(vec![
+        Complex64::new(1.0, 2.0),
+        Complex64::new(3.0, 4.0),
+        Complex64::new(5.0, 6.0),
+        Complex64::new(7.0, 8.0),
+    ]));
+    let tensor_a: TensorDynLen<DynId> = TensorDynLen::new(indices_a, dims_a, Arc::new(storage_a));
+
+    // Create tensor B[j, k] with all 1.0 (f64)
+    let indices_b = vec![j.clone(), k.clone()];
+    let dims_b = vec![2, 2];
+    let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 4]));
+    let tensor_b: TensorDynLen<DynId> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
+
+    // Contract along j: result should be C[i, k] (Complex64)
+    // For A[i,j] * B[j,k] where A is complex and B is real:
+    // C[i,k] = sum_j A[i,j] * B[j,k]
+    // With A = [[1+2i, 3+4i], [5+6i, 7+8i]] and B = [[1, 1], [1, 1]]
+    // C[0,0] = (1+2i)*1 + (3+4i)*1 = 4+6i
+    // C[0,1] = (1+2i)*1 + (3+4i)*1 = 4+6i
+    // C[1,0] = (5+6i)*1 + (7+8i)*1 = 12+14i
+    // C[1,1] = (5+6i)*1 + (7+8i)*1 = 12+14i
+    let result = tensor_a.contract(&tensor_b);
+    assert_eq!(result.dims, vec![2, 2]);
+    
+    // Check result storage type
+    if let Storage::DenseC64(ref vec) = *result.storage {
+        assert_eq!(vec.len(), 4);
+        // Check actual computed values
+        assert!((vec.get(0) - Complex64::new(4.0, 6.0)).norm() < 1e-10);
+        assert!((vec.get(1) - Complex64::new(4.0, 6.0)).norm() < 1e-10);
+        assert!((vec.get(2) - Complex64::new(12.0, 14.0)).norm() < 1e-10);
+        assert!((vec.get(3) - Complex64::new(12.0, 14.0)).norm() < 1e-10);
+    } else {
+        panic!("Expected DenseC64 storage for mixed-type contraction");
     }
 }
 

--- a/crates/tensor4all-tensor/tests/diag.rs
+++ b/crates/tensor4all-tensor/tests/diag.rs
@@ -1,4 +1,4 @@
-use tensor4all_tensor::{Storage, TensorDynLen, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor};
+use tensor4all_tensor::{AnyScalar, Storage, TensorDynLen, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor};
 use tensor4all_core::index::{DefaultIndex as Index, DynId};
 use num_complex::Complex64;
 use std::sync::Arc;
@@ -31,8 +31,8 @@ fn test_diag_tensor_sum() {
     let diag_data = vec![1.0, 2.0, 3.0];
     
     let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data);
-    let sum: f64 = tensor.sum();
-    assert_eq!(sum, 6.0);
+    let sum: AnyScalar = tensor.sum();
+    assert_eq!(sum, AnyScalar::F64(6.0));
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn test_diag_tensor_contract_diag_dense() {
     let dims_b = vec![2, 2];
     use tensor4all_tensor::storage::DenseStorageF64;
     let storage_b = Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; 4]));
-    let tensor_b: TensorDynLen<DynId, f64> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
+    let tensor_b: TensorDynLen<DynId> = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
     
     // Contract along j: result should be DenseTensor[i, k]
     let result = tensor_a.contract(&tensor_b);
@@ -193,8 +193,8 @@ fn test_diag_tensor_rank3() {
     assert!(is_diag_tensor(&tensor));
     
     // Sum should work
-    let sum: f64 = tensor.sum();
-    assert_eq!(sum, 3.0);
+    let sum: AnyScalar = tensor.sum();
+    assert_eq!(sum, AnyScalar::F64(3.0));
 }
 
 #[test]
@@ -208,8 +208,8 @@ fn test_diag_tensor_complex() {
     assert!(is_diag_tensor(&tensor));
     
     // Sum should work
-    let sum: Complex64 = tensor.sum();
-    assert_eq!(sum, Complex64::new(3.0, 1.5));
+    let sum: AnyScalar = tensor.sum();
+    assert_eq!(sum, AnyScalar::C64(Complex64::new(3.0, 1.5)));
 }
 
 #[test]


### PR DESCRIPTION
This PR removes the type parameter T from TensorDynLen, making scalar types dynamic at runtime.

## Changes

- **TensorDynLen API**: Changed from `TensorDynLen<Id, T, Symm>` to `TensorDynLen<Id, Symm>`
- **sum() method**: Now returns `AnyScalar` instead of generic `T`
- **Storage arithmetic**: Added `Add`, `Mul<f64>`, `Mul<Complex64>`, `Mul<AnyScalar>` implementations
- **Storage helpers**: Added `extract_real_part`, `extract_imag_part`, `to_complex_storage`, `combine_to_complex`
- **Mixed-type contraction**: Implemented f64 × Complex64 contraction using real/imaginary part separation
- **unfold_split**: Updated to take `TensorDynLen<Id, Symm>` but remain generic over `T` for `DTensor<T,2>`
- **AnyScalar helpers**: Added `new_real()` and `new_complex()` convenience functions
- **Tests**: All tests updated and passing, including new mixed-type contraction tests
- **Linalg**: Updated svd/qr functions and tests to new API

## Benefits

- Scalar type is now determined at runtime via Storage enum
- Supports mixed-type operations (f64 × Complex64) efficiently
- Cleaner API with helper functions for AnyScalar creation
- All existing functionality preserved with improved flexibility