### PR TITLE
Add quanticsgrids crate: Rust port of QuanticsGrids.jl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/tensor4all-core", "crates/tensor4all-tensor", "crates/tensor4all-linalg", "crates/tensor4all-treetn"]
+members = ["crates/tensor4all-core", "crates/tensor4all-tensor", "crates/tensor4all-linalg", "crates/tensor4all-treetn", "crates/quanticsgrids"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/quanticsgrids/Cargo.toml
+++ b/crates/quanticsgrids/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "quanticsgrids"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Quantics grid structures for efficient conversion between quantics, grid indices, and original coordinates"
+
+[dependencies]
+thiserror.workspace = true
+
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "conversions"
+harness = false

--- a/crates/quanticsgrids/benches/conversions.rs
+++ b/crates/quanticsgrids/benches/conversions.rs
@@ -1,0 +1,168 @@
+//! Benchmarks for quanticsgrids conversion functions
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use quanticsgrids::{DiscretizedGrid, InherentDiscreteGrid, UnfoldingScheme};
+
+fn bench_grididx_to_quantics(c: &mut Criterion) {
+    let mut group = c.benchmark_group("grididx_to_quantics");
+
+    for r in [4, 8, 12, 16] {
+        let grid = InherentDiscreteGrid::builder(&[r])
+            .build()
+            .unwrap();
+        let max_idx = 2i64.pow(r as u32);
+        let grididx = vec![max_idx / 2];
+
+        group.bench_with_input(BenchmarkId::new("1D_base2", r), &r, |b, _| {
+            b.iter(|| grid.grididx_to_quantics(black_box(&grididx)))
+        });
+    }
+
+    // 2D grid
+    for r in [4, 8, 12] {
+        let grid = InherentDiscreteGrid::builder(&[r, r])
+            .build()
+            .unwrap();
+        let max_idx = 2i64.pow(r as u32);
+        let grididx = vec![max_idx / 2, max_idx / 2];
+
+        group.bench_with_input(BenchmarkId::new("2D_base2", r), &r, |b, _| {
+            b.iter(|| grid.grididx_to_quantics(black_box(&grididx)))
+        });
+    }
+
+    // Base 3
+    let grid = InherentDiscreteGrid::builder(&[8])
+        .with_base(3)
+        .build()
+        .unwrap();
+    let grididx = vec![3i64.pow(4)];
+    group.bench_function("1D_base3_R8", |b| {
+        b.iter(|| grid.grididx_to_quantics(black_box(&grididx)))
+    });
+
+    group.finish();
+}
+
+fn bench_quantics_to_grididx(c: &mut Criterion) {
+    let mut group = c.benchmark_group("quantics_to_grididx");
+
+    for r in [4, 8, 12, 16] {
+        let grid = InherentDiscreteGrid::builder(&[r])
+            .build()
+            .unwrap();
+        let quantics: Vec<i64> = vec![1; r];
+
+        group.bench_with_input(BenchmarkId::new("1D_base2", r), &r, |b, _| {
+            b.iter(|| grid.quantics_to_grididx(black_box(&quantics)))
+        });
+    }
+
+    // 2D grid
+    for r in [4, 8, 12] {
+        let grid = InherentDiscreteGrid::builder(&[r, r])
+            .with_unfolding_scheme(UnfoldingScheme::Fused)
+            .build()
+            .unwrap();
+        let num_sites = grid.len();
+        let quantics: Vec<i64> = vec![1; num_sites];
+
+        group.bench_with_input(BenchmarkId::new("2D_fused_base2", r), &r, |b, _| {
+            b.iter(|| grid.quantics_to_grididx(black_box(&quantics)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_origcoord_conversions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("origcoord_conversions");
+
+    // DiscretizedGrid conversions
+    for r in [8, 12, 16] {
+        let grid = DiscretizedGrid::builder(&[r])
+            .build()
+            .unwrap();
+        let coord = vec![0.5];
+        let grididx = vec![2i64.pow(r as u32 - 1)];
+
+        group.bench_with_input(BenchmarkId::new("origcoord_to_grididx_1D", r), &r, |b, _| {
+            b.iter(|| grid.origcoord_to_grididx(black_box(&coord)))
+        });
+
+        group.bench_with_input(BenchmarkId::new("grididx_to_origcoord_1D", r), &r, |b, _| {
+            b.iter(|| grid.grididx_to_origcoord(black_box(&grididx)))
+        });
+    }
+
+    // 2D
+    let grid = DiscretizedGrid::builder(&[10, 10])
+        .build()
+        .unwrap();
+    let coord = vec![0.5, 0.5];
+    group.bench_function("origcoord_to_quantics_2D_R10", |b| {
+        b.iter(|| grid.origcoord_to_quantics(black_box(&coord)))
+    });
+
+    group.finish();
+}
+
+fn bench_roundtrip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("roundtrip");
+
+    let grid = DiscretizedGrid::builder(&[10, 10])
+        .with_variable_names(&["x", "y"])
+        .build()
+        .unwrap();
+
+    let coord = vec![0.5, 0.25];
+
+    group.bench_function("origcoord_roundtrip_2D", |b| {
+        b.iter(|| {
+            let quantics = grid.origcoord_to_quantics(black_box(&coord)).unwrap();
+            let grididx = grid.quantics_to_grididx(&quantics).unwrap();
+            grid.grididx_to_origcoord(&grididx)
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_unfolding_schemes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unfolding_schemes");
+
+    let r = 8;
+
+    // Fused scheme
+    let grid_fused = InherentDiscreteGrid::builder(&[r, r])
+        .with_unfolding_scheme(UnfoldingScheme::Fused)
+        .build()
+        .unwrap();
+    let grididx = vec![128, 128];
+
+    group.bench_function("fused_grididx_to_quantics", |b| {
+        b.iter(|| grid_fused.grididx_to_quantics(black_box(&grididx)))
+    });
+
+    // Interleaved scheme
+    let grid_interleaved = InherentDiscreteGrid::builder(&[r, r])
+        .with_unfolding_scheme(UnfoldingScheme::Interleaved)
+        .build()
+        .unwrap();
+
+    group.bench_function("interleaved_grididx_to_quantics", |b| {
+        b.iter(|| grid_interleaved.grididx_to_quantics(black_box(&grididx)))
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_grididx_to_quantics,
+    bench_quantics_to_grididx,
+    bench_origcoord_conversions,
+    bench_roundtrip,
+    bench_unfolding_schemes,
+);
+criterion_main!(benches);

--- a/crates/quanticsgrids/src/discretized_grid.rs
+++ b/crates/quanticsgrids/src/discretized_grid.rs
@@ -1,0 +1,732 @@
+//! Discretized grid implementation with continuous coordinate support
+
+use crate::error::{QuanticsGridError, Result};
+use crate::inherent_discrete_grid::InherentDiscreteGridBuilder;
+use crate::{IndexTable, InherentDiscreteGrid, UnfoldingScheme};
+
+/// A discretized grid with continuous domain and floating-point coordinates.
+///
+/// This structure wraps an [`InherentDiscreteGrid`] and adds support for
+/// continuous coordinate systems with specified lower and upper bounds.
+///
+/// # Example
+/// ```
+/// use quanticsgrids::{DiscretizedGrid, UnfoldingScheme};
+///
+/// // Create a 2D grid discretizing [0, 1) x [0, 1)
+/// let grid = DiscretizedGrid::builder(&[3, 2])
+///     .with_variable_names(&["x", "y"])
+///     .build()
+///     .unwrap();
+///
+/// // Convert between coordinate systems
+/// let quantics = grid.origcoord_to_quantics(&[0.5, 0.25]).unwrap();
+/// let coords = grid.quantics_to_origcoord(&quantics).unwrap();
+/// ```
+#[derive(Debug, Clone)]
+pub struct DiscretizedGrid {
+    /// The underlying discrete grid
+    discrete_grid: InherentDiscreteGrid,
+    /// Lower bounds for each dimension
+    lower_bound: Vec<f64>,
+    /// Upper bounds for each dimension (adjusted for endpoint inclusion)
+    upper_bound: Vec<f64>,
+}
+
+impl DiscretizedGrid {
+    /// Create a new builder for a DiscretizedGrid.
+    ///
+    /// # Example
+    /// ```
+    /// use quanticsgrids::DiscretizedGrid;
+    ///
+    /// let grid = DiscretizedGrid::builder(&[3, 2])
+    ///     .with_variable_names(&["x", "y"])
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn builder(rs: &[usize]) -> DiscretizedGridBuilder {
+        DiscretizedGridBuilder::new(rs)
+    }
+
+    /// Create a grid from an explicit index table.
+    pub fn from_index_table(
+        variable_names: &[&str],
+        index_table: IndexTable,
+    ) -> DiscretizedGridBuilder {
+        DiscretizedGridBuilder::from_index_table(variable_names, index_table)
+    }
+
+    /// Number of dimensions
+    pub fn ndims(&self) -> usize {
+        self.discrete_grid.ndims()
+    }
+
+    /// Number of tensor sites (cores)
+    pub fn len(&self) -> usize {
+        self.discrete_grid.len()
+    }
+
+    /// Returns true if the grid has no tensor sites
+    pub fn is_empty(&self) -> bool {
+        self.discrete_grid.is_empty()
+    }
+
+    /// Resolution (number of bits) per dimension
+    pub fn rs(&self) -> &[usize] {
+        self.discrete_grid.rs()
+    }
+
+    /// Variable names
+    pub fn variable_names(&self) -> &[String] {
+        self.discrete_grid.variable_names()
+    }
+
+    /// Numeric base
+    pub fn base(&self) -> usize {
+        self.discrete_grid.base()
+    }
+
+    /// Index table
+    pub fn index_table(&self) -> &IndexTable {
+        self.discrete_grid.index_table()
+    }
+
+    /// Lower bounds for each dimension
+    pub fn lower_bound(&self) -> &[f64] {
+        &self.lower_bound
+    }
+
+    /// Upper bounds for each dimension
+    pub fn upper_bound(&self) -> &[f64] {
+        &self.upper_bound
+    }
+
+    /// Local dimension of a tensor site
+    pub fn site_dim(&self, site: usize) -> Result<usize> {
+        self.discrete_grid.site_dim(site)
+    }
+
+    /// Local dimensions of all tensor sites
+    pub fn local_dimensions(&self) -> Vec<usize> {
+        self.discrete_grid.local_dimensions()
+    }
+
+    /// Grid step size in each dimension
+    pub fn grid_step(&self) -> Vec<f64> {
+        let rs = self.discrete_grid.rs();
+        let base = self.discrete_grid.base() as f64;
+        self.lower_bound
+            .iter()
+            .zip(self.upper_bound.iter())
+            .zip(rs.iter())
+            .map(|((&lo, &hi), &r)| (hi - lo) / base.powi(r as i32))
+            .collect()
+    }
+
+    /// Minimum grid coordinates (same as lower_bound)
+    pub fn grid_min(&self) -> &[f64] {
+        &self.lower_bound
+    }
+
+    /// Maximum grid coordinates (upper_bound - grid_step)
+    pub fn grid_max(&self) -> Vec<f64> {
+        let step = self.grid_step();
+        self.upper_bound
+            .iter()
+            .zip(step.iter())
+            .map(|(&hi, &s)| hi - s)
+            .collect()
+    }
+
+    /// Get original coordinates for a dimension
+    pub fn grid_origcoords(&self, dim: usize) -> Result<Vec<f64>> {
+        if dim >= self.ndims() {
+            return Err(QuanticsGridError::GridIndexOutOfBounds {
+                dim,
+                value: dim as i64,
+                max: self.ndims() as i64,
+            });
+        }
+
+        let rs = self.discrete_grid.rs();
+        let base = self.discrete_grid.base();
+        let n = base.pow(rs[dim] as u32);
+        let step = self.grid_step()[dim];
+        let start = self.lower_bound[dim];
+
+        Ok((0..n).map(|i| start + (i as f64) * step).collect())
+    }
+
+    // ========================================================================
+    // Core conversion functions
+    // ========================================================================
+
+    /// Convert quantics indices to grid indices.
+    pub fn quantics_to_grididx(&self, quantics: &[i64]) -> Result<Vec<i64>> {
+        self.discrete_grid.quantics_to_grididx(quantics)
+    }
+
+    /// Convert grid indices to quantics indices.
+    pub fn grididx_to_quantics(&self, grididx: &[i64]) -> Result<Vec<i64>> {
+        self.discrete_grid.grididx_to_quantics(grididx)
+    }
+
+    /// Convert grid indices to original coordinates.
+    pub fn grididx_to_origcoord(&self, grididx: &[i64]) -> Result<Vec<f64>> {
+        let grididx = self.expand_grididx(grididx)?;
+        self.validate_grididx(&grididx)?;
+
+        let step = self.grid_step();
+        Ok(self
+            .lower_bound
+            .iter()
+            .zip(grididx.iter())
+            .zip(step.iter())
+            .map(|((&lo, &g), &s)| lo + ((g - 1) as f64) * s)
+            .collect())
+    }
+
+    /// Convert original coordinates to grid indices.
+    pub fn origcoord_to_grididx(&self, coord: &[f64]) -> Result<Vec<i64>> {
+        let coord = self.expand_coord(coord)?;
+        self.validate_origcoord(&coord)?;
+
+        let step = self.grid_step();
+        let rs = self.discrete_grid.rs();
+        let base = self.discrete_grid.base() as i64;
+
+        let indices: Vec<i64> = self
+            .lower_bound
+            .iter()
+            .zip(coord.iter())
+            .zip(step.iter())
+            .zip(rs.iter())
+            .map(|(((&lo, &c), &s), &r)| {
+                let continuous_idx = (c - lo) / s + 1.0;
+                let discrete_idx = continuous_idx.round() as i64;
+                discrete_idx.clamp(1, base.pow(r as u32))
+            })
+            .collect();
+
+        Ok(indices)
+    }
+
+    /// Convert original coordinates to quantics indices.
+    pub fn origcoord_to_quantics(&self, coord: &[f64]) -> Result<Vec<i64>> {
+        let grididx = self.origcoord_to_grididx(coord)?;
+        self.grididx_to_quantics(&grididx)
+    }
+
+    /// Convert quantics indices to original coordinates.
+    pub fn quantics_to_origcoord(&self, quantics: &[i64]) -> Result<Vec<f64>> {
+        let grididx = self.quantics_to_grididx(quantics)?;
+        self.grididx_to_origcoord(&grididx)
+    }
+
+    // ========================================================================
+    // Private helper methods
+    // ========================================================================
+
+    fn validate_grididx(&self, grididx: &[i64]) -> Result<()> {
+        let max_grididx = self.discrete_grid.max_grididx();
+        for (dim, (&val, &max)) in grididx.iter().zip(max_grididx.iter()).enumerate() {
+            if val < 1 || val > max {
+                return Err(QuanticsGridError::GridIndexOutOfBounds {
+                    dim,
+                    value: val,
+                    max,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_origcoord(&self, coord: &[f64]) -> Result<()> {
+        for (dim, ((&c, &lo), &hi)) in coord
+            .iter()
+            .zip(self.lower_bound.iter())
+            .zip(self.upper_bound.iter())
+            .enumerate()
+        {
+            if c < lo || c > hi {
+                return Err(QuanticsGridError::CoordinateOutOfBounds {
+                    dim,
+                    value: c,
+                    lower: lo,
+                    upper: hi,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn expand_grididx(&self, grididx: &[i64]) -> Result<Vec<i64>> {
+        let ndims = self.ndims();
+        if grididx.len() == 1 && ndims > 1 {
+            Ok(vec![grididx[0]; ndims])
+        } else if grididx.len() == ndims {
+            Ok(grididx.to_vec())
+        } else {
+            Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: grididx.len(),
+            })
+        }
+    }
+
+    fn expand_coord(&self, coord: &[f64]) -> Result<Vec<f64>> {
+        let ndims = self.ndims();
+        if coord.len() == 1 && ndims > 1 {
+            Ok(vec![coord[0]; ndims])
+        } else if coord.len() == ndims {
+            Ok(coord.to_vec())
+        } else {
+            Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: coord.len(),
+            })
+        }
+    }
+}
+
+impl std::fmt::Display for DiscretizedGrid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ndims = self.ndims();
+        let rs = self.discrete_grid.rs();
+        let base = self.discrete_grid.base();
+
+        // Calculate total points
+        let total_points: u64 = rs.iter().map(|&r| (base as u64).pow(r as u32)).product();
+
+        if ndims <= 1 {
+            write!(f, "DiscretizedGrid{{{}}} with {} grid points", ndims, total_points)?;
+        } else {
+            let sizes: Vec<String> = rs.iter().map(|&r| format!("{}", (base as u64).pow(r as u32))).collect();
+            write!(f, "DiscretizedGrid{{{}}} with {} = {} grid points", ndims, sizes.join(" x "), total_points)?;
+        }
+
+        // Variable names
+        let var_names = self.discrete_grid.variable_names();
+        if var_names.iter().any(|n| !n.chars().all(|c| c.is_ascii_digit())) {
+            write!(f, "\n  Variables: ({})", var_names.join(", "))?;
+        }
+
+        // Resolutions
+        if ndims == 1 {
+            write!(f, "\n  Resolution: {} bits", rs[0])?;
+        } else {
+            let res_str: Vec<String> = var_names
+                .iter()
+                .zip(rs.iter())
+                .map(|(n, &r)| format!("{}: {}", n, r))
+                .collect();
+            write!(f, "\n  Resolutions: ({})", res_str.join(", "))?;
+        }
+
+        // Domain
+        let step = self.grid_step();
+        if ndims == 1 {
+            write!(f, "\n  Domain: [{}, {})", self.lower_bound[0], self.upper_bound[0])?;
+            write!(f, "\n  Grid spacing: {}", step[0])?;
+        } else {
+            let bounds_str: Vec<String> = self
+                .lower_bound
+                .iter()
+                .zip(self.upper_bound.iter())
+                .map(|(&lo, &hi)| format!("[{}, {})", lo, hi))
+                .collect();
+            write!(f, "\n  Domain: {}", bounds_str.join(" x "))?;
+
+            let step_str: Vec<String> = var_names
+                .iter()
+                .zip(step.iter())
+                .map(|(n, &s)| format!("d{} = {}", n, s))
+                .collect();
+            write!(f, "\n  Grid spacing: ({})", step_str.join(", "))?;
+        }
+
+        // Base (if not binary)
+        if base != 2 {
+            write!(f, "\n  Base: {}", base)?;
+        }
+
+        // Tensor structure
+        let num_sites = self.len();
+        let sitedims = self.local_dimensions();
+        write!(f, "\n  Tensor train: {} sites", num_sites)?;
+        if !sitedims.is_empty() {
+            if sitedims.iter().all(|&d| d == sitedims[0]) {
+                write!(f, " (uniform dimension {})", sitedims[0])?;
+            } else {
+                let dims_str: Vec<String> = sitedims.iter().map(|d| d.to_string()).collect();
+                write!(f, " (dimensions: {})", dims_str.join("-"))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Builder for DiscretizedGrid
+#[derive(Debug, Clone)]
+pub struct DiscretizedGridBuilder {
+    inner: InherentDiscreteGridBuilder,
+    lower_bound: Option<Vec<f64>>,
+    upper_bound: Option<Vec<f64>>,
+    include_endpoint: Option<Vec<bool>>,
+}
+
+impl DiscretizedGridBuilder {
+    /// Create a new builder with given resolutions
+    pub fn new(rs: &[usize]) -> Self {
+        Self {
+            inner: InherentDiscreteGridBuilder::new(rs),
+            lower_bound: None,
+            upper_bound: None,
+            include_endpoint: None,
+        }
+    }
+
+    /// Create a builder from an explicit index table
+    pub fn from_index_table(variable_names: &[&str], index_table: IndexTable) -> Self {
+        Self {
+            inner: InherentDiscreteGridBuilder::from_index_table(variable_names, index_table),
+            lower_bound: None,
+            upper_bound: None,
+            include_endpoint: None,
+        }
+    }
+
+    /// Set the lower bounds for each dimension
+    pub fn with_lower_bound(mut self, lower_bound: &[f64]) -> Self {
+        self.lower_bound = Some(lower_bound.to_vec());
+        self
+    }
+
+    /// Set the upper bounds for each dimension
+    pub fn with_upper_bound(mut self, upper_bound: &[f64]) -> Self {
+        self.upper_bound = Some(upper_bound.to_vec());
+        self
+    }
+
+    /// Set bounds for 1D case
+    pub fn with_bounds(mut self, lower: f64, upper: f64) -> Self {
+        self.lower_bound = Some(vec![lower]);
+        self.upper_bound = Some(vec![upper]);
+        self
+    }
+
+    /// Set whether to include the endpoint for each dimension
+    pub fn with_include_endpoint(mut self, include: &[bool]) -> Self {
+        self.include_endpoint = Some(include.to_vec());
+        self
+    }
+
+    /// Set whether to include the endpoint (single value for all dimensions)
+    pub fn include_endpoint(mut self, include: bool) -> Self {
+        // Will be expanded to match dimensions during build
+        self.include_endpoint = Some(vec![include]);
+        self
+    }
+
+    /// Set variable names
+    pub fn with_variable_names(mut self, names: &[&str]) -> Self {
+        self.inner = self.inner.with_variable_names(names);
+        self
+    }
+
+    /// Set the numeric base (default 2)
+    pub fn with_base(mut self, base: usize) -> Self {
+        self.inner = self.inner.with_base(base);
+        self
+    }
+
+    /// Set the unfolding scheme
+    pub fn with_unfolding_scheme(mut self, scheme: UnfoldingScheme) -> Self {
+        self.inner = self.inner.with_unfolding_scheme(scheme);
+        self
+    }
+
+    /// Build the DiscretizedGrid
+    pub fn build(self) -> Result<DiscretizedGrid> {
+        let discrete_grid = self.inner.build()?;
+        let ndims = discrete_grid.ndims();
+        let rs = discrete_grid.rs();
+        let base = discrete_grid.base();
+
+        // Default bounds: [0, 1) for each dimension
+        let lower_bound = self.lower_bound.unwrap_or_else(|| vec![0.0; ndims]);
+        let mut upper_bound = self.upper_bound.unwrap_or_else(|| vec![1.0; ndims]);
+
+        // Expand bounds if needed
+        let lower_bound = if lower_bound.len() == 1 && ndims > 1 {
+            vec![lower_bound[0]; ndims]
+        } else {
+            lower_bound
+        };
+
+        let upper_bound_raw = if upper_bound.len() == 1 && ndims > 1 {
+            vec![upper_bound[0]; ndims]
+        } else {
+            upper_bound.clone()
+        };
+        upper_bound = upper_bound_raw;
+
+        // Validate dimensions
+        if lower_bound.len() != ndims {
+            return Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: lower_bound.len(),
+            });
+        }
+        if upper_bound.len() != ndims {
+            return Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: upper_bound.len(),
+            });
+        }
+
+        // Validate bounds
+        for d in 0..ndims {
+            if lower_bound[d] >= upper_bound[d] {
+                return Err(QuanticsGridError::InvalidBounds {
+                    dim: d,
+                    lower: lower_bound[d],
+                    upper: upper_bound[d],
+                });
+            }
+        }
+
+        // Handle endpoint inclusion
+        let include_endpoint = match self.include_endpoint {
+            Some(v) if v.len() == 1 && ndims > 1 => vec![v[0]; ndims],
+            Some(v) if v.len() == ndims => v,
+            Some(v) if v.len() != ndims => {
+                return Err(QuanticsGridError::DimensionMismatch {
+                    expected: ndims,
+                    actual: v.len(),
+                });
+            }
+            _ => vec![false; ndims],
+        };
+
+        // Adjust upper bounds for endpoint inclusion
+        for d in 0..ndims {
+            if include_endpoint[d] {
+                if rs[d] == 0 {
+                    return Err(QuanticsGridError::EndpointWithZeroResolution { dim: d });
+                }
+                let n_points = (base as f64).powi(rs[d] as i32);
+                upper_bound[d] += (upper_bound[d] - lower_bound[d]) / (n_points - 1.0);
+            }
+        }
+
+        Ok(DiscretizedGrid {
+            discrete_grid,
+            lower_bound,
+            upper_bound,
+        })
+    }
+}
+
+/// Wrap a function to accept quantics indices
+pub fn quantics_function<F>(
+    grid: &DiscretizedGrid,
+    f: F,
+) -> impl Fn(&[i64]) -> Result<f64> + '_
+where
+    F: Fn(&[f64]) -> f64 + 'static,
+{
+    move |quantics: &[i64]| {
+        let coords = grid.quantics_to_origcoord(quantics)?;
+        Ok(f(&coords))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_1d_grid() {
+        let grid = DiscretizedGrid::builder(&[3]).build().unwrap();
+        assert_eq!(grid.ndims(), 1);
+        assert_eq!(grid.lower_bound(), &[0.0]);
+        assert_eq!(grid.upper_bound(), &[1.0]);
+        assert_eq!(grid.len(), 3);
+    }
+
+    #[test]
+    fn test_basic_2d_grid() {
+        let grid = DiscretizedGrid::builder(&[3, 2])
+            .with_variable_names(&["x", "y"])
+            .build()
+            .unwrap();
+
+        assert_eq!(grid.ndims(), 2);
+        assert_eq!(grid.variable_names(), &["x", "y"]);
+        assert_eq!(grid.lower_bound(), &[0.0, 0.0]);
+        assert_eq!(grid.upper_bound(), &[1.0, 1.0]);
+    }
+
+    #[test]
+    fn test_custom_bounds() {
+        let grid = DiscretizedGrid::builder(&[2])
+            .with_lower_bound(&[-1.0])
+            .with_upper_bound(&[1.0])
+            .build()
+            .unwrap();
+
+        assert_eq!(grid.lower_bound(), &[-1.0]);
+        assert_eq!(grid.upper_bound(), &[1.0]);
+
+        // Grid step should be (1 - (-1)) / 2^2 = 0.5
+        let step = grid.grid_step();
+        assert!((step[0] - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_origcoord_to_grididx() {
+        let grid = DiscretizedGrid::builder(&[3]).build().unwrap();
+        // Grid has 8 points: 0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875
+
+        let idx = grid.origcoord_to_grididx(&[0.0]).unwrap();
+        assert_eq!(idx, vec![1]);
+
+        let idx = grid.origcoord_to_grididx(&[0.5]).unwrap();
+        assert_eq!(idx, vec![5]);
+    }
+
+    #[test]
+    fn test_grididx_to_origcoord() {
+        let grid = DiscretizedGrid::builder(&[3]).build().unwrap();
+
+        let coord = grid.grididx_to_origcoord(&[1]).unwrap();
+        assert!((coord[0] - 0.0).abs() < 1e-10);
+
+        let coord = grid.grididx_to_origcoord(&[5]).unwrap();
+        assert!((coord[0] - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_roundtrip_all_points() {
+        let grid = DiscretizedGrid::builder(&[2, 2]).build().unwrap();
+
+        for x in 1..=4 {
+            for y in 1..=4 {
+                let grididx = vec![x, y];
+                let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+                let back = grid.quantics_to_grididx(&quantics).unwrap();
+                assert_eq!(back, grididx);
+
+                let coord = grid.grididx_to_origcoord(&grididx).unwrap();
+                let back_idx = grid.origcoord_to_grididx(&coord).unwrap();
+                assert_eq!(back_idx, grididx);
+            }
+        }
+    }
+
+    #[test]
+    fn test_include_endpoint() {
+        let grid = DiscretizedGrid::builder(&[2])
+            .include_endpoint(true)
+            .build()
+            .unwrap();
+
+        // With endpoint, upper bound is adjusted to include the last point
+        // 4 points, want last point at 1.0
+        // Adjusted upper = 1.0 + (1.0 - 0.0) / (4 - 1) = 1.0 + 1/3 = 4/3
+        let max_coord = grid.grid_max();
+        assert!((max_coord[0] - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_grid_origcoords() {
+        let grid = DiscretizedGrid::builder(&[2]).build().unwrap();
+        let coords = grid.grid_origcoords(0).unwrap();
+
+        assert_eq!(coords.len(), 4);
+        assert!((coords[0] - 0.0).abs() < 1e-10);
+        assert!((coords[1] - 0.25).abs() < 1e-10);
+        assert!((coords[2] - 0.5).abs() < 1e-10);
+        assert!((coords[3] - 0.75).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_display() {
+        let grid = DiscretizedGrid::builder(&[3, 2])
+            .with_variable_names(&["x", "y"])
+            .build()
+            .unwrap();
+
+        let display = format!("{}", grid);
+        assert!(display.contains("DiscretizedGrid"));
+        assert!(display.contains("x"));
+        assert!(display.contains("y"));
+    }
+
+    #[test]
+    fn test_error_invalid_bounds() {
+        let result = DiscretizedGrid::builder(&[2])
+            .with_lower_bound(&[1.0])
+            .with_upper_bound(&[0.0])
+            .build();
+
+        assert!(matches!(result, Err(QuanticsGridError::InvalidBounds { .. })));
+    }
+
+    #[test]
+    fn test_error_coordinate_out_of_bounds() {
+        let grid = DiscretizedGrid::builder(&[2]).build().unwrap();
+        let result = grid.origcoord_to_grididx(&[1.5]);
+        assert!(matches!(
+            result,
+            Err(QuanticsGridError::CoordinateOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_from_index_table() {
+        let index_table = vec![
+            vec![("a".to_string(), 1), ("b".to_string(), 2)],
+            vec![("a".to_string(), 2)],
+            vec![("b".to_string(), 1), ("a".to_string(), 3)],
+        ];
+
+        let grid = DiscretizedGrid::from_index_table(&["a", "b"], index_table)
+            .build()
+            .unwrap();
+
+        assert_eq!(grid.ndims(), 2);
+        assert_eq!(grid.rs(), &[3, 2]);
+
+        // Test roundtrip
+        for x in 1..=8 {
+            for y in 1..=4 {
+                let grididx = vec![x, y];
+                let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+                let back = grid.quantics_to_grididx(&quantics).unwrap();
+                assert_eq!(back, grididx);
+            }
+        }
+    }
+
+    #[test]
+    fn test_quantics_function() {
+        let grid = DiscretizedGrid::builder(&[2]).build().unwrap();
+
+        let f = |coords: &[f64]| coords[0] * 2.0;
+        let qf = quantics_function(&grid, f);
+
+        // grididx 1 -> coord 0.0 -> f = 0.0
+        let quantics = grid.grididx_to_quantics(&[1]).unwrap();
+        let result = qf(&quantics).unwrap();
+        assert!((result - 0.0).abs() < 1e-10);
+
+        // grididx 3 -> coord 0.5 -> f = 1.0
+        let quantics = grid.grididx_to_quantics(&[3]).unwrap();
+        let result = qf(&quantics).unwrap();
+        assert!((result - 1.0).abs() < 1e-10);
+    }
+}

--- a/crates/quanticsgrids/src/error.rs
+++ b/crates/quanticsgrids/src/error.rs
@@ -1,0 +1,87 @@
+//! Error types for quanticsgrids
+
+use thiserror::Error;
+
+/// Result type for quanticsgrids operations
+pub type Result<T> = std::result::Result<T, QuanticsGridError>;
+
+/// Errors that can occur during quantics grid operations
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum QuanticsGridError {
+    /// Base must be at least 2
+    #[error("Base must be at least 2, got {0}")]
+    InvalidBase(usize),
+
+    /// Step must be at least 1
+    #[error("Step for dimension {dim} must be at least 1, got {value}")]
+    InvalidStep { dim: usize, value: i64 },
+
+    /// Resolution too large (base^R would overflow)
+    #[error("Resolution {r} with base {base} is too large (base^R would overflow i64)")]
+    ResolutionTooLarge { r: usize, base: usize },
+
+    /// Variable names must be unique
+    #[error("Variable names must be unique, found duplicate: {0}")]
+    DuplicateVariableName(String),
+
+    /// Index table contains unknown variable
+    #[error("Index table contains unknown variable '{variable}'. Valid variables: {valid:?}")]
+    UnknownVariable { variable: String, valid: Vec<String> },
+
+    /// Index table contains invalid bit number
+    #[error("Bit number {bit} for variable '{variable}' exceeds resolution {resolution}")]
+    InvalidBitNumber {
+        variable: String,
+        bit: usize,
+        resolution: usize,
+    },
+
+    /// Index table contains duplicate entry
+    #[error("Index table contains duplicate entry for variable '{variable}' bit {bit}")]
+    DuplicateIndexEntry { variable: String, bit: usize },
+
+    /// Index table missing entry
+    #[error("Index table missing entry for variable '{variable}' bit {bit}")]
+    MissingIndexEntry { variable: String, bit: usize },
+
+    /// Quantics vector has wrong length
+    #[error("Quantics vector must have length {expected}, got {actual}")]
+    WrongQuanticsLength { expected: usize, actual: usize },
+
+    /// Quantics value out of range
+    #[error("Quantics value {value} for site {site} out of range [1, {max}]")]
+    QuanticsOutOfRange { site: usize, value: i64, max: i64 },
+
+    /// Grid index out of bounds
+    #[error("Grid index {value} for dimension {dim} out of bounds [1, {max}]")]
+    GridIndexOutOfBounds { dim: usize, value: i64, max: i64 },
+
+    /// Coordinate out of bounds
+    #[error("Coordinate {value} for dimension {dim} out of bounds [{lower}, {upper}]")]
+    CoordinateOutOfBounds {
+        dim: usize,
+        value: f64,
+        lower: f64,
+        upper: f64,
+    },
+
+    /// Site index out of bounds
+    #[error("Site index {site} out of bounds [0, {max})")]
+    SiteIndexOutOfBounds { site: usize, max: usize },
+
+    /// Lower bound must be less than upper bound
+    #[error("Lower bound {lower} must be less than upper bound {upper} for dimension {dim}")]
+    InvalidBounds { dim: usize, lower: f64, upper: f64 },
+
+    /// Cannot include endpoint with zero resolution
+    #[error("Cannot include endpoint for dimension {dim} with zero resolution")]
+    EndpointWithZeroResolution { dim: usize },
+
+    /// Dimension mismatch
+    #[error("Dimension mismatch: expected {expected}, got {actual}")]
+    DimensionMismatch { expected: usize, actual: usize },
+
+    /// No resolutions specified
+    #[error("At least one resolution must be specified")]
+    NoResolutions,
+}

--- a/crates/quanticsgrids/src/inherent_discrete_grid.rs
+++ b/crates/quanticsgrids/src/inherent_discrete_grid.rs
@@ -1,0 +1,916 @@
+//! Inherent discrete grid implementation
+
+use crate::error::{QuanticsGridError, Result};
+use crate::{IndexTable, LookupEntry, UnfoldingScheme};
+
+/// A discrete grid for quantics tensor train representations.
+///
+/// This structure maps between three coordinate systems:
+/// - **Quantics indices**: Integer values for each tensor core (1-indexed)
+/// - **Grid indices**: Integer positions in each dimension (1-indexed)
+/// - **Original coordinates**: Integer positions based on origin and step
+///
+/// # Example
+/// ```
+/// use quanticsgrids::{InherentDiscreteGrid, UnfoldingScheme};
+///
+/// let grid = InherentDiscreteGrid::builder(&[3, 2])
+///     .with_variable_names(&["x", "y"])
+///     .with_unfolding_scheme(UnfoldingScheme::Fused)
+///     .build()
+///     .unwrap();
+///
+/// // Convert grid indices to quantics
+/// let quantics = grid.grididx_to_quantics(&[5, 2]).unwrap();
+/// // Convert back
+/// let grididx = grid.quantics_to_grididx(&quantics).unwrap();
+/// assert_eq!(grididx, vec![5, 2]);
+/// ```
+#[derive(Debug, Clone)]
+pub struct InherentDiscreteGrid {
+    /// Number of dimensions
+    ndims: usize,
+    /// Resolution (number of bits) per dimension
+    rs: Vec<usize>,
+    /// Origin in each dimension (1-indexed by default)
+    origin: Vec<i64>,
+    /// Step size in each dimension
+    step: Vec<i64>,
+    /// Variable names for each dimension
+    variable_names: Vec<String>,
+    /// Numeric base (default 2)
+    base: usize,
+    /// Index table defining tensor structure
+    index_table: IndexTable,
+    /// Lookup table: lookup_table[dim][bit] -> (site_index, position_in_site)
+    lookup_table: Vec<Vec<LookupEntry>>,
+    /// Maximum grid index per dimension (base^R)
+    max_grididx: Vec<i64>,
+}
+
+impl InherentDiscreteGrid {
+    /// Create a new builder for an InherentDiscreteGrid.
+    ///
+    /// # Example
+    /// ```
+    /// use quanticsgrids::InherentDiscreteGrid;
+    ///
+    /// let grid = InherentDiscreteGrid::builder(&[3, 2])
+    ///     .with_variable_names(&["x", "y"])
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn builder(rs: &[usize]) -> InherentDiscreteGridBuilder {
+        InherentDiscreteGridBuilder::new(rs)
+    }
+
+    /// Create a grid from an explicit index table.
+    pub fn from_index_table(
+        variable_names: &[&str],
+        index_table: IndexTable,
+    ) -> InherentDiscreteGridBuilder {
+        InherentDiscreteGridBuilder::from_index_table(variable_names, index_table)
+    }
+
+    /// Number of dimensions
+    pub fn ndims(&self) -> usize {
+        self.ndims
+    }
+
+    /// Number of tensor sites (cores)
+    pub fn len(&self) -> usize {
+        self.index_table.len()
+    }
+
+    /// Returns true if the grid has no tensor sites
+    pub fn is_empty(&self) -> bool {
+        self.index_table.is_empty()
+    }
+
+    /// Resolution (number of bits) per dimension
+    pub fn rs(&self) -> &[usize] {
+        &self.rs
+    }
+
+    /// Origin in each dimension
+    pub fn origin(&self) -> &[i64] {
+        &self.origin
+    }
+
+    /// Step size in each dimension
+    pub fn step(&self) -> &[i64] {
+        &self.step
+    }
+
+    /// Variable names
+    pub fn variable_names(&self) -> &[String] {
+        &self.variable_names
+    }
+
+    /// Numeric base
+    pub fn base(&self) -> usize {
+        self.base
+    }
+
+    /// Index table
+    pub fn index_table(&self) -> &IndexTable {
+        &self.index_table
+    }
+
+    /// Maximum grid index per dimension
+    pub fn max_grididx(&self) -> &[i64] {
+        &self.max_grididx
+    }
+
+    /// Local dimension of a tensor site
+    pub fn site_dim(&self, site: usize) -> Result<usize> {
+        if site >= self.index_table.len() {
+            return Err(QuanticsGridError::SiteIndexOutOfBounds {
+                site,
+                max: self.index_table.len(),
+            });
+        }
+        Ok(self.base.pow(self.index_table[site].len() as u32))
+    }
+
+    /// Local dimensions of all tensor sites
+    pub fn local_dimensions(&self) -> Vec<usize> {
+        self.index_table
+            .iter()
+            .map(|site| self.base.pow(site.len() as u32))
+            .collect()
+    }
+
+    /// Minimum grid coordinate (origin)
+    pub fn grid_min(&self) -> Vec<i64> {
+        self.origin.clone()
+    }
+
+    /// Maximum grid coordinate
+    pub fn grid_max(&self) -> Vec<i64> {
+        self.origin
+            .iter()
+            .zip(self.step.iter())
+            .zip(self.max_grididx.iter())
+            .map(|((&o, &s), &m)| o + s * (m - 1))
+            .collect()
+    }
+
+    // ========================================================================
+    // Core conversion functions
+    // ========================================================================
+
+    /// Convert quantics indices to grid indices.
+    ///
+    /// # Arguments
+    /// * `quantics` - Quantics values for each tensor site (1-indexed)
+    ///
+    /// # Returns
+    /// Grid indices for each dimension (1-indexed)
+    pub fn quantics_to_grididx(&self, quantics: &[i64]) -> Result<Vec<i64>> {
+        self.validate_quantics(quantics)?;
+
+        if self.base == 2 {
+            Ok(self.quantics_to_grididx_base2(quantics))
+        } else {
+            Ok(self.quantics_to_grididx_general(quantics))
+        }
+    }
+
+    /// Convert grid indices to quantics indices.
+    ///
+    /// # Arguments
+    /// * `grididx` - Grid indices for each dimension (1-indexed)
+    ///
+    /// # Returns
+    /// Quantics values for each tensor site (1-indexed)
+    pub fn grididx_to_quantics(&self, grididx: &[i64]) -> Result<Vec<i64>> {
+        let grididx = self.expand_grididx(grididx)?;
+        self.validate_grididx(&grididx)?;
+
+        let mut result = vec![1i64; self.index_table.len()];
+        if self.base == 2 {
+            self.grididx_to_quantics_base2(&mut result, &grididx);
+        } else {
+            self.grididx_to_quantics_general(&mut result, &grididx);
+        }
+        Ok(result)
+    }
+
+    /// Convert grid indices to original coordinates.
+    ///
+    /// # Arguments
+    /// * `grididx` - Grid indices for each dimension (1-indexed)
+    ///
+    /// # Returns
+    /// Original integer coordinates
+    pub fn grididx_to_origcoord(&self, grididx: &[i64]) -> Result<Vec<i64>> {
+        let grididx = self.expand_grididx(grididx)?;
+        self.validate_grididx(&grididx)?;
+
+        Ok(self
+            .origin
+            .iter()
+            .zip(grididx.iter())
+            .zip(self.step.iter())
+            .map(|((&o, &g), &s)| o + (g - 1) * s)
+            .collect())
+    }
+
+    /// Convert original coordinates to grid indices.
+    ///
+    /// # Arguments
+    /// * `coord` - Original integer coordinates
+    ///
+    /// # Returns
+    /// Grid indices for each dimension (1-indexed)
+    pub fn origcoord_to_grididx(&self, coord: &[i64]) -> Result<Vec<i64>> {
+        let coord = self.expand_coord(coord)?;
+        self.validate_origcoord(&coord)?;
+
+        let indices: Vec<i64> = self
+            .origin
+            .iter()
+            .zip(coord.iter())
+            .zip(self.step.iter())
+            .zip(self.max_grididx.iter())
+            .map(|(((&o, &c), &s), &m)| ((c - o) / s + 1).clamp(1, m))
+            .collect();
+
+        Ok(indices)
+    }
+
+    /// Convert original coordinates to quantics indices.
+    pub fn origcoord_to_quantics(&self, coord: &[i64]) -> Result<Vec<i64>> {
+        let grididx = self.origcoord_to_grididx(coord)?;
+        self.grididx_to_quantics(&grididx)
+    }
+
+    /// Convert quantics indices to original coordinates.
+    pub fn quantics_to_origcoord(&self, quantics: &[i64]) -> Result<Vec<i64>> {
+        let grididx = self.quantics_to_grididx(quantics)?;
+        self.grididx_to_origcoord(&grididx)
+    }
+
+    // ========================================================================
+    // Private helper methods
+    // ========================================================================
+
+    fn validate_quantics(&self, quantics: &[i64]) -> Result<()> {
+        if quantics.len() != self.index_table.len() {
+            return Err(QuanticsGridError::WrongQuanticsLength {
+                expected: self.index_table.len(),
+                actual: quantics.len(),
+            });
+        }
+
+        for (site, &val) in quantics.iter().enumerate() {
+            let max = self.site_dim(site)? as i64;
+            if val < 1 || val > max {
+                return Err(QuanticsGridError::QuanticsOutOfRange {
+                    site,
+                    value: val,
+                    max,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_grididx(&self, grididx: &[i64]) -> Result<()> {
+        for (dim, (&val, &max)) in grididx.iter().zip(self.max_grididx.iter()).enumerate() {
+            if val < 1 || val > max {
+                return Err(QuanticsGridError::GridIndexOutOfBounds {
+                    dim,
+                    value: val,
+                    max,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_origcoord(&self, coord: &[i64]) -> Result<()> {
+        let min = self.grid_min();
+        let max = self.grid_max();
+        for (dim, ((&c, &lo), &hi)) in coord.iter().zip(min.iter()).zip(max.iter()).enumerate() {
+            if c < lo || c > hi {
+                return Err(QuanticsGridError::CoordinateOutOfBounds {
+                    dim,
+                    value: c as f64,
+                    lower: lo as f64,
+                    upper: hi as f64,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Expand a scalar or lower-dimensional input to full dimensions
+    fn expand_grididx(&self, grididx: &[i64]) -> Result<Vec<i64>> {
+        if grididx.len() == 1 && self.ndims > 1 {
+            Ok(vec![grididx[0]; self.ndims])
+        } else if grididx.len() == self.ndims {
+            Ok(grididx.to_vec())
+        } else {
+            Err(QuanticsGridError::DimensionMismatch {
+                expected: self.ndims,
+                actual: grididx.len(),
+            })
+        }
+    }
+
+    fn expand_coord(&self, coord: &[i64]) -> Result<Vec<i64>> {
+        if coord.len() == 1 && self.ndims > 1 {
+            Ok(vec![coord[0]; self.ndims])
+        } else if coord.len() == self.ndims {
+            Ok(coord.to_vec())
+        } else {
+            Err(QuanticsGridError::DimensionMismatch {
+                expected: self.ndims,
+                actual: coord.len(),
+            })
+        }
+    }
+
+    fn quantics_to_grididx_base2(&self, quantics: &[i64]) -> Vec<i64> {
+        (0..self.ndims)
+            .map(|d| {
+                let r_d = self.rs[d];
+                let mut grididx = 0i64;
+
+                for bitnumber in 0..r_d {
+                    let (site_idx, pos_in_site) = self.lookup_table[d][bitnumber];
+                    let bit_position = self.index_table[site_idx].len() - 1 - pos_in_site;
+                    let digit = ((quantics[site_idx] - 1) >> bit_position) & 1;
+                    grididx |= digit << (r_d - 1 - bitnumber);
+                }
+                grididx + 1
+            })
+            .collect()
+    }
+
+    fn quantics_to_grididx_general(&self, quantics: &[i64]) -> Vec<i64> {
+        let base = self.base as i64;
+
+        (0..self.ndims)
+            .map(|d| {
+                let r_d = self.rs[d];
+                let mut grididx = 1i64;
+
+                for bitnumber in 0..r_d {
+                    let (site_idx, pos_in_site) = self.lookup_table[d][bitnumber];
+                    let site_len = self.index_table[site_idx].len();
+
+                    let mut temp = quantics[site_idx] - 1;
+                    for _ in 0..(site_len - 1 - pos_in_site) {
+                        temp /= base;
+                    }
+                    let digit = temp % base;
+
+                    grididx += digit * base.pow((r_d - 1 - bitnumber) as u32);
+                }
+                grididx
+            })
+            .collect()
+    }
+
+    fn grididx_to_quantics_base2(&self, result: &mut [i64], grididx: &[i64]) {
+        for (&grid_val, (&r_d, lookup)) in grididx
+            .iter()
+            .zip(self.rs.iter().zip(self.lookup_table.iter()))
+            .take(self.ndims)
+        {
+            let zero_based_idx = grid_val - 1;
+
+            for (bitnumber, &(site_idx, pos_in_site)) in lookup.iter().enumerate().take(r_d) {
+                let site_length = self.index_table[site_idx].len();
+
+                let bit_position = r_d - 1 - bitnumber;
+                let digit = (zero_based_idx >> bit_position) & 1;
+
+                let power = site_length - 1 - pos_in_site;
+                result[site_idx] += digit << power;
+            }
+        }
+    }
+
+    fn grididx_to_quantics_general(&self, result: &mut [i64], grididx: &[i64]) {
+        let base = self.base as i64;
+
+        for (&grid_val, (&r_d, lookup)) in grididx
+            .iter()
+            .zip(self.rs.iter().zip(self.lookup_table.iter()))
+            .take(self.ndims)
+        {
+            let zero_based_idx = grid_val - 1;
+
+            for (bitnumber, &(site_idx, pos_in_site)) in lookup.iter().enumerate().take(r_d) {
+                let site_length = self.index_table[site_idx].len();
+
+                let bit_position = r_d - 1 - bitnumber;
+                let digit = (zero_based_idx / base.pow(bit_position as u32)) % base;
+
+                let power = site_length - 1 - pos_in_site;
+                result[site_idx] += digit * base.pow(power as u32);
+            }
+        }
+    }
+}
+
+/// Builder for InherentDiscreteGrid
+#[derive(Debug, Clone)]
+pub struct InherentDiscreteGridBuilder {
+    rs: Vec<usize>,
+    origin: Option<Vec<i64>>,
+    step: Option<Vec<i64>>,
+    variable_names: Option<Vec<String>>,
+    base: usize,
+    unfolding_scheme: UnfoldingScheme,
+    index_table: Option<IndexTable>,
+}
+
+impl InherentDiscreteGridBuilder {
+    /// Create a new builder with given resolutions
+    pub fn new(rs: &[usize]) -> Self {
+        Self {
+            rs: rs.to_vec(),
+            origin: None,
+            step: None,
+            variable_names: None,
+            base: 2,
+            unfolding_scheme: UnfoldingScheme::Fused,
+            index_table: None,
+        }
+    }
+
+    /// Create a builder from an explicit index table
+    pub fn from_index_table(variable_names: &[&str], index_table: IndexTable) -> Self {
+        // Compute Rs from index table
+        let rs: Vec<usize> = variable_names
+            .iter()
+            .map(|&name| {
+                index_table
+                    .iter()
+                    .flatten()
+                    .filter(|(var, _)| var == name)
+                    .count()
+            })
+            .collect();
+
+        Self {
+            rs,
+            origin: None,
+            step: None,
+            variable_names: Some(variable_names.iter().map(|s| s.to_string()).collect()),
+            base: 2,
+            unfolding_scheme: UnfoldingScheme::Fused,
+            index_table: Some(index_table),
+        }
+    }
+
+    /// Set the origin for each dimension
+    pub fn with_origin(mut self, origin: &[i64]) -> Self {
+        self.origin = Some(origin.to_vec());
+        self
+    }
+
+    /// Set the step size for each dimension
+    pub fn with_step(mut self, step: &[i64]) -> Self {
+        self.step = Some(step.to_vec());
+        self
+    }
+
+    /// Set variable names
+    pub fn with_variable_names(mut self, names: &[&str]) -> Self {
+        self.variable_names = Some(names.iter().map(|s| s.to_string()).collect());
+        self
+    }
+
+    /// Set the numeric base (default 2)
+    pub fn with_base(mut self, base: usize) -> Self {
+        self.base = base;
+        self
+    }
+
+    /// Set the unfolding scheme
+    pub fn with_unfolding_scheme(mut self, scheme: UnfoldingScheme) -> Self {
+        self.unfolding_scheme = scheme;
+        self
+    }
+
+    /// Build the InherentDiscreteGrid
+    pub fn build(self) -> Result<InherentDiscreteGrid> {
+        let ndims = self.rs.len();
+        if ndims == 0 {
+            return Err(QuanticsGridError::NoResolutions);
+        }
+
+        if self.base < 2 {
+            return Err(QuanticsGridError::InvalidBase(self.base));
+        }
+
+        // Validate resolutions
+        for (d, &r) in self.rs.iter().enumerate() {
+            if !rangecheck_r(r, self.base) {
+                return Err(QuanticsGridError::ResolutionTooLarge { r, base: self.base });
+            }
+            if let Some(ref step) = self.step {
+                if step.len() > d && step[d] < 1 {
+                    return Err(QuanticsGridError::InvalidStep {
+                        dim: d,
+                        value: step[d],
+                    });
+                }
+            }
+        }
+
+        // Default values
+        let origin = self.origin.unwrap_or_else(|| vec![1; ndims]);
+        let step = self.step.unwrap_or_else(|| vec![1; ndims]);
+        let variable_names = self.variable_names.unwrap_or_else(|| {
+            (1..=ndims).map(|i| i.to_string()).collect()
+        });
+
+        // Validate dimensions match
+        if origin.len() != ndims {
+            return Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: origin.len(),
+            });
+        }
+        if step.len() != ndims {
+            return Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: step.len(),
+            });
+        }
+        if variable_names.len() != ndims {
+            return Err(QuanticsGridError::DimensionMismatch {
+                expected: ndims,
+                actual: variable_names.len(),
+            });
+        }
+
+        // Check for duplicate variable names
+        for (i, name) in variable_names.iter().enumerate() {
+            for other in variable_names.iter().skip(i + 1) {
+                if name == other {
+                    return Err(QuanticsGridError::DuplicateVariableName(name.clone()));
+                }
+            }
+        }
+
+        // Build or use provided index table
+        let index_table = match self.index_table {
+            Some(table) => table,
+            None => build_index_table(&variable_names, &self.rs, self.unfolding_scheme),
+        };
+
+        // Build lookup table
+        let lookup_table = build_lookup_table(&self.rs, &index_table, &variable_names)?;
+
+        // Compute max grid indices
+        let max_grididx: Vec<i64> = self.rs.iter().map(|&r| (self.base as i64).pow(r as u32)).collect();
+
+        Ok(InherentDiscreteGrid {
+            ndims,
+            rs: self.rs,
+            origin,
+            step,
+            variable_names,
+            base: self.base,
+            index_table,
+            lookup_table,
+            max_grididx,
+        })
+    }
+}
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+/// Check if base^R fits in i64
+fn rangecheck_r(r: usize, base: usize) -> bool {
+    let mut result: i64 = 1;
+    for _ in 0..r {
+        if result > i64::MAX / (base as i64) {
+            return false;
+        }
+        result *= base as i64;
+    }
+    true
+}
+
+/// Build an index table from variable names and resolutions
+fn build_index_table(
+    variable_names: &[String],
+    rs: &[usize],
+    scheme: UnfoldingScheme,
+) -> IndexTable {
+    let max_r = *rs.iter().max().unwrap_or(&0);
+    let mut index_table = IndexTable::new();
+
+    for bitnumber in 0..max_r {
+        match scheme {
+            UnfoldingScheme::Interleaved => {
+                add_interleaved_indices(&mut index_table, variable_names, rs, bitnumber);
+            }
+            UnfoldingScheme::Fused => {
+                add_fused_indices(&mut index_table, variable_names, rs, bitnumber);
+            }
+        }
+    }
+
+    index_table
+}
+
+fn add_interleaved_indices(
+    index_table: &mut IndexTable,
+    variable_names: &[String],
+    rs: &[usize],
+    bitnumber: usize,
+) {
+    for (d, name) in variable_names.iter().enumerate() {
+        if bitnumber < rs[d] {
+            let qindex = (name.clone(), bitnumber + 1); // 1-indexed bit number
+            index_table.push(vec![qindex]);
+        }
+    }
+}
+
+fn add_fused_indices(
+    index_table: &mut IndexTable,
+    variable_names: &[String],
+    rs: &[usize],
+    bitnumber: usize,
+) {
+    let mut indices_bitnumber = Vec::new();
+    // Add dimensions in reverse order to match Julia convention
+    for d in (0..variable_names.len()).rev() {
+        if bitnumber < rs[d] {
+            let qindex = (variable_names[d].clone(), bitnumber + 1); // 1-indexed
+            indices_bitnumber.push(qindex);
+        }
+    }
+    if !indices_bitnumber.is_empty() {
+        index_table.push(indices_bitnumber);
+    }
+}
+
+/// Build lookup table from index table
+fn build_lookup_table(
+    rs: &[usize],
+    index_table: &IndexTable,
+    variable_names: &[String],
+) -> Result<Vec<Vec<LookupEntry>>> {
+    let mut lookup_table: Vec<Vec<LookupEntry>> = rs
+        .iter()
+        .map(|&r| vec![(0, 0); r])
+        .collect();
+
+    let mut index_visited: Vec<Vec<bool>> = rs.iter().map(|&r| vec![false; r]).collect();
+
+    for (site_idx, quantics_indices) in index_table.iter().enumerate() {
+        for (pos_in_site, (var_name, bitnumber)) in quantics_indices.iter().enumerate() {
+            let var_idx = variable_names
+                .iter()
+                .position(|n| n == var_name)
+                .ok_or_else(|| QuanticsGridError::UnknownVariable {
+                    variable: var_name.clone(),
+                    valid: variable_names.to_vec(),
+                })?;
+
+            // bitnumber is 1-indexed in QuanticsIndex
+            let bit_idx = bitnumber - 1;
+
+            if *bitnumber > rs[var_idx] {
+                return Err(QuanticsGridError::InvalidBitNumber {
+                    variable: var_name.clone(),
+                    bit: *bitnumber,
+                    resolution: rs[var_idx],
+                });
+            }
+
+            if index_visited[var_idx][bit_idx] {
+                return Err(QuanticsGridError::DuplicateIndexEntry {
+                    variable: var_name.clone(),
+                    bit: *bitnumber,
+                });
+            }
+
+            lookup_table[var_idx][bit_idx] = (site_idx, pos_in_site);
+            index_visited[var_idx][bit_idx] = true;
+        }
+    }
+
+    // Check all indices are covered
+    for (var_idx, visited) in index_visited.iter().enumerate() {
+        for (bit_idx, &v) in visited.iter().enumerate() {
+            if !v {
+                return Err(QuanticsGridError::MissingIndexEntry {
+                    variable: variable_names[var_idx].clone(),
+                    bit: bit_idx + 1, // 1-indexed
+                });
+            }
+        }
+    }
+
+    Ok(lookup_table)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_1d_grid() {
+        let grid = InherentDiscreteGrid::builder(&[3]).build().unwrap();
+        assert_eq!(grid.ndims(), 1);
+        assert_eq!(grid.len(), 3); // 3 sites for fused scheme
+        assert_eq!(grid.base(), 2);
+        assert_eq!(grid.rs(), &[3]);
+        assert_eq!(grid.max_grididx(), &[8]);
+    }
+
+    #[test]
+    fn test_basic_2d_grid() {
+        let grid = InherentDiscreteGrid::builder(&[3, 2])
+            .with_variable_names(&["x", "y"])
+            .build()
+            .unwrap();
+
+        assert_eq!(grid.ndims(), 2);
+        assert_eq!(grid.variable_names(), &["x", "y"]);
+        assert_eq!(grid.max_grididx(), &[8, 4]);
+    }
+
+    #[test]
+    fn test_grididx_to_quantics_roundtrip() {
+        let grid = InherentDiscreteGrid::builder(&[3, 2])
+            .with_variable_names(&["a", "b"])
+            .build()
+            .unwrap();
+
+        let grididx = vec![5i64, 2];
+        let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+        let back = grid.quantics_to_grididx(&quantics).unwrap();
+        assert_eq!(back, grididx);
+    }
+
+    #[test]
+    fn test_all_grididx_roundtrip() {
+        let grid = InherentDiscreteGrid::builder(&[2, 2]).build().unwrap();
+
+        for x in 1..=4 {
+            for y in 1..=4 {
+                let grididx = vec![x, y];
+                let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+                let back = grid.quantics_to_grididx(&quantics).unwrap();
+                assert_eq!(back, grididx, "Failed for grididx {:?}", grididx);
+            }
+        }
+    }
+
+    #[test]
+    fn test_interleaved_scheme() {
+        let grid = InherentDiscreteGrid::builder(&[2, 2])
+            .with_unfolding_scheme(UnfoldingScheme::Interleaved)
+            .build()
+            .unwrap();
+
+        // Interleaved: [1_1], [2_1], [1_2], [2_2]
+        assert_eq!(grid.len(), 4);
+        for x in 1..=4 {
+            for y in 1..=4 {
+                let grididx = vec![x, y];
+                let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+                let back = grid.quantics_to_grididx(&quantics).unwrap();
+                assert_eq!(back, grididx);
+            }
+        }
+    }
+
+    #[test]
+    fn test_base3_grid() {
+        let grid = InherentDiscreteGrid::builder(&[2])
+            .with_base(3)
+            .build()
+            .unwrap();
+
+        assert_eq!(grid.base(), 3);
+        assert_eq!(grid.max_grididx(), &[9]); // 3^2 = 9
+
+        for x in 1..=9 {
+            let grididx = vec![x];
+            let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+            let back = grid.quantics_to_grididx(&quantics).unwrap();
+            assert_eq!(back, grididx);
+        }
+    }
+
+    #[test]
+    fn test_origcoord_conversion() {
+        let grid = InherentDiscreteGrid::builder(&[2])
+            .with_origin(&[0])
+            .with_step(&[1])
+            .build()
+            .unwrap();
+
+        // origin=0, step=1, max_grididx=4
+        // grididx 1 -> origcoord 0
+        // grididx 4 -> origcoord 3
+        let coord = grid.grididx_to_origcoord(&[1]).unwrap();
+        assert_eq!(coord, vec![0]);
+
+        let coord = grid.grididx_to_origcoord(&[4]).unwrap();
+        assert_eq!(coord, vec![3]);
+
+        let idx = grid.origcoord_to_grididx(&[2]).unwrap();
+        assert_eq!(idx, vec![3]);
+    }
+
+    #[test]
+    fn test_error_invalid_base() {
+        let result = InherentDiscreteGrid::builder(&[3]).with_base(1).build();
+        assert!(matches!(result, Err(QuanticsGridError::InvalidBase(1))));
+    }
+
+    #[test]
+    fn test_error_duplicate_variable_names() {
+        let result = InherentDiscreteGrid::builder(&[2, 2])
+            .with_variable_names(&["x", "x"])
+            .build();
+        assert!(matches!(
+            result,
+            Err(QuanticsGridError::DuplicateVariableName(_))
+        ));
+    }
+
+    #[test]
+    fn test_error_quantics_out_of_range() {
+        let grid = InherentDiscreteGrid::builder(&[2]).build().unwrap();
+        // Rs=[2] with Fused creates 2 sites, each with dim 2
+        // So quantics should have length 2, and each value should be in [1, 2]
+        let result = grid.quantics_to_grididx(&[5, 1]); // 5 is out of range [1, 2]
+        assert!(matches!(
+            result,
+            Err(QuanticsGridError::QuanticsOutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn test_error_grididx_out_of_bounds() {
+        let grid = InherentDiscreteGrid::builder(&[2]).build().unwrap();
+        let result = grid.grididx_to_quantics(&[5]); // max is 4
+        assert!(matches!(
+            result,
+            Err(QuanticsGridError::GridIndexOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_local_dimensions() {
+        let grid = InherentDiscreteGrid::builder(&[3, 2])
+            .with_unfolding_scheme(UnfoldingScheme::Fused)
+            .build()
+            .unwrap();
+
+        let dims = grid.local_dimensions();
+        // Fused scheme with Rs=(3,2): sites have 2, 2, 1 indices each -> dims 4, 4, 2
+        // Actually: bitnumber 0: [b, a] -> dim 4
+        //           bitnumber 1: [b, a] -> dim 4
+        //           bitnumber 2: [a] -> dim 2
+        assert_eq!(dims, vec![4, 4, 2]);
+    }
+
+    #[test]
+    fn test_from_index_table() {
+        // Create a custom index table like in Julia: [[(:a, 1), (:b, 2)], [(:a, 2)], [(:b, 1), (:a, 3)]]
+        let index_table = vec![
+            vec![("a".to_string(), 1), ("b".to_string(), 2)],
+            vec![("a".to_string(), 2)],
+            vec![("b".to_string(), 1), ("a".to_string(), 3)],
+        ];
+
+        let grid = InherentDiscreteGrid::from_index_table(&["a", "b"], index_table)
+            .build()
+            .unwrap();
+
+        assert_eq!(grid.ndims(), 2);
+        assert_eq!(grid.rs(), &[3, 2]); // a has 3 bits, b has 2 bits
+        assert_eq!(grid.len(), 3);
+
+        // Test roundtrip
+        for x in 1..=8 {
+            for y in 1..=4 {
+                let grididx = vec![x, y];
+                let quantics = grid.grididx_to_quantics(&grididx).unwrap();
+                let back = grid.quantics_to_grididx(&quantics).unwrap();
+                assert_eq!(back, grididx);
+            }
+        }
+    }
+}

--- a/crates/quanticsgrids/src/lib.rs
+++ b/crates/quanticsgrids/src/lib.rs
@@ -1,0 +1,173 @@
+//! Quantics grid structures for efficient conversion between quantics indices,
+//! grid indices, and original coordinates.
+//!
+//! This crate is a Rust port of [QuanticsGrids.jl](https://github.com/tensor4all/QuanticsGrids.jl)
+//! and provides infrastructure for quantics tensor train (QTT) methods.
+//!
+//! # Overview
+//!
+//! This crate provides two main grid types:
+//! - [`InherentDiscreteGrid`]: Low-level grid working with integer coordinates
+//! - [`DiscretizedGrid`]: High-level grid with continuous domain and floating-point coordinates
+//!
+//! ## Coordinate Systems
+//!
+//! The grids support conversion between three coordinate representations:
+//!
+//! 1. **Quantics indices**: Integer values for each tensor core (1-indexed)
+//! 2. **Grid indices**: Integer positions in each dimension (1-indexed)
+//! 3. **Original coordinates**: Continuous values in the specified domain
+//!
+//! ## Unfolding Schemes
+//!
+//! Two tensor train layouts are supported via [`UnfoldingScheme`]:
+//!
+//! - **Fused** (default): Indices at the same bit level are grouped together
+//! - **Interleaved**: Indices alternate between dimensions
+//!
+//! # Quick Start
+//!
+//! ```
+//! use quanticsgrids::{DiscretizedGrid, UnfoldingScheme};
+//!
+//! // Create a 2D grid with resolution (3, 2) bits
+//! // This discretizes [0, 1) x [0, 1) into 8 x 4 = 32 grid points
+//! let grid = DiscretizedGrid::builder(&[3, 2])
+//!     .with_variable_names(&["x", "y"])
+//!     .build()
+//!     .unwrap();
+//!
+//! // Convert coordinates to quantics indices
+//! let quantics = grid.origcoord_to_quantics(&[0.5, 0.25]).unwrap();
+//!
+//! // Convert back
+//! let grididx = grid.quantics_to_grididx(&quantics).unwrap();
+//! let coords = grid.grididx_to_origcoord(&grididx).unwrap();
+//! assert!((coords[0] - 0.5).abs() < 1e-10);
+//! ```
+//!
+//! # Custom Domains
+//!
+//! ```
+//! use quanticsgrids::DiscretizedGrid;
+//!
+//! // Grid over [-1, 1) x [0, 2*pi)
+//! let grid = DiscretizedGrid::builder(&[8, 8])
+//!     .with_lower_bound(&[-1.0, 0.0])
+//!     .with_upper_bound(&[1.0, std::f64::consts::TAU])
+//!     .with_variable_names(&["x", "theta"])
+//!     .build()
+//!     .unwrap();
+//!
+//! let step = grid.grid_step();
+//! assert!((step[0] - 2.0 / 256.0).abs() < 1e-10);
+//! ```
+//!
+//! # Custom Index Tables
+//!
+//! For advanced use cases, you can specify a custom tensor train structure:
+//!
+//! ```
+//! use quanticsgrids::DiscretizedGrid;
+//!
+//! // Custom index table: [[(:a, 1), (:b, 2)], [(:a, 2)], [(:b, 1), (:a, 3)]]
+//! let index_table = vec![
+//!     vec![("a".to_string(), 1), ("b".to_string(), 2)],
+//!     vec![("a".to_string(), 2)],
+//!     vec![("b".to_string(), 1), ("a".to_string(), 3)],
+//! ];
+//!
+//! let grid = DiscretizedGrid::from_index_table(&["a", "b"], index_table)
+//!     .build()
+//!     .unwrap();
+//!
+//! assert_eq!(grid.rs(), &[3, 2]); // a has 3 bits, b has 2 bits
+//! assert_eq!(grid.len(), 3);      // 3 tensor cores
+//! ```
+//!
+//! # Using with Functions
+//!
+//! ```
+//! use quanticsgrids::{DiscretizedGrid, quantics_function};
+//!
+//! let grid = DiscretizedGrid::builder(&[8]).build().unwrap();
+//!
+//! // Wrap a function to accept quantics indices
+//! let f = |x: &[f64]| x[0] * x[0];
+//! let qf = quantics_function(&grid, f);
+//!
+//! let quantics = grid.origcoord_to_quantics(&[0.5]).unwrap();
+//! let result = qf(&quantics).unwrap();
+//! assert!((result - 0.25).abs() < 1e-10);
+//! ```
+//!
+//! # Performance
+//!
+//! All conversion functions have O(R * D) time complexity where:
+//! - R is the maximum resolution (bits) across dimensions
+//! - D is the number of dimensions
+//!
+//! Typical performance (single conversion):
+//! - 1D grids: ~30-80 ns
+//! - 2D grids: ~40-100 ns
+//! - With floating-point conversion: ~100-120 ns
+//!
+//! # Error Handling
+//!
+//! All conversion functions return [`Result`] with [`QuanticsGridError`]:
+//!
+//! ```
+//! use quanticsgrids::{DiscretizedGrid, QuanticsGridError};
+//!
+//! let grid = DiscretizedGrid::builder(&[2]).build().unwrap();
+//!
+//! // Coordinate out of bounds
+//! let result = grid.origcoord_to_grididx(&[1.5]);
+//! assert!(matches!(result, Err(QuanticsGridError::CoordinateOutOfBounds { .. })));
+//!
+//! // Grid index out of bounds
+//! let result = grid.grididx_to_quantics(&[10]);
+//! assert!(matches!(result, Err(QuanticsGridError::GridIndexOutOfBounds { .. })));
+//! ```
+
+mod error;
+mod inherent_discrete_grid;
+mod discretized_grid;
+
+pub use error::{QuanticsGridError, Result};
+pub use inherent_discrete_grid::{InherentDiscreteGrid, InherentDiscreteGridBuilder};
+pub use discretized_grid::{quantics_function, DiscretizedGrid, DiscretizedGridBuilder};
+
+/// Unfolding scheme for tensor train structure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UnfoldingScheme {
+    /// Each quantics index gets its own tensor core, alternating between variables.
+    /// For variables (a, b) with Rs=(2, 2), produces: [a1], [b1], [a2], [b2]
+    Interleaved,
+    /// Quantics indices at the same bit level are fused into one tensor core.
+    /// For variables (a, b) with Rs=(2, 2), produces: [b1, a1], [b2, a2]
+    #[default]
+    Fused,
+}
+
+/// A quantics index entry: (variable_name, bit_number)
+/// bit_number is 1-indexed (1 = most significant bit)
+pub type QuanticsIndex = (String, usize);
+
+/// Index table: structure defining tensor train layout
+/// Each inner Vec represents one tensor core, containing the quantics indices it holds
+pub type IndexTable = Vec<Vec<QuanticsIndex>>;
+
+/// Lookup entry: (site_index, position_in_site)
+/// site_index is 0-indexed, position_in_site is 0-indexed
+pub type LookupEntry = (usize, usize);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unfolding_scheme_default() {
+        assert_eq!(UnfoldingScheme::default(), UnfoldingScheme::Fused);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `quanticsgrids` crate: A Rust port of [QuanticsGrids.jl](https://github.com/tensor4all/QuanticsGrids.jl)
- Provides grid structures for efficient conversion between quantics indices, grid indices, and original coordinates
- Includes comprehensive tests (27 unit tests + 9 doc tests) and benchmarks

## Features

- **InherentDiscreteGrid**: Low-level grid with integer coordinates
- **DiscretizedGrid**: High-level grid with continuous domain support
- Two unfolding schemes: `Fused` (default) and `Interleaved`
- Support for arbitrary numeric bases (default: binary)
- Custom index tables for advanced tensor train structures
- Comprehensive error handling with `QuanticsGridError`

## API Example

```rust
use quanticsgrids::{DiscretizedGrid, UnfoldingScheme};

let grid = DiscretizedGrid::builder(&[3, 2])
    .with_variable_names(&["x", "y"])
    .build()
    .unwrap();

let quantics = grid.origcoord_to_quantics(&[0.5, 0.25]).unwrap();
let coords = grid.quantics_to_origcoord(&quantics).unwrap();
```

## Performance

Typical conversion times (benchmarked with criterion):
- 1D grids: ~30-80 ns
- 2D grids: ~40-100 ns
- With floating-point conversion: ~100-120 ns

## Test plan

- [x] All unit tests pass (`cargo test -p quanticsgrids`)
- [x] All doc tests pass
- [x] Clippy passes with no warnings
- [x] Benchmarks run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)