### PR TITLE
Add TCI crates: Rust port of T4AMatrixCI.jl, T4ATensorTrain.jl, T4ATensorCI.jl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,14 @@
 [workspace]
-members = ["crates/tensor4all-core", "crates/tensor4all-tensor", "crates/tensor4all-linalg", "crates/tensor4all-treetn", "crates/quanticsgrids"]
+members = [
+    "crates/tensor4all-core",
+    "crates/tensor4all-tensor",
+    "crates/tensor4all-linalg",
+    "crates/tensor4all-treetn",
+    "crates/quanticsgrids",
+    "crates/tensor4all-matrixci",
+    "crates/tensor4all-tensortrain",
+    "crates/tensor4all-tensorci",
+]
 resolver = "2"
 
 [workspace.package]

--- a/crates/tensor4all-matrixci/Cargo.toml
+++ b/crates/tensor4all-matrixci/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tensor4all-matrixci"
+description = "Matrix Cross Interpolation algorithms for tensor4all"
+version.workspace = true
+edition.workspace = true
+authors = ["tensor4all contributors"]
+license = "MIT"
+repository.workspace = true
+
+[dependencies]
+num-complex.workspace = true
+num-traits.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+rand.workspace = true
+
+[dev-dependencies]
+approx = "0.5"

--- a/crates/tensor4all-matrixci/src/error.rs
+++ b/crates/tensor4all-matrixci/src/error.rs
@@ -1,0 +1,60 @@
+//! Error types for tensor4all-matrixci
+
+use thiserror::Error;
+
+/// Errors that can occur during matrix cross interpolation operations
+#[derive(Debug, Error)]
+pub enum MatrixCIError {
+    /// Dimension mismatch between matrix and MatrixCI object
+    #[error("Dimension mismatch: expected ({expected_rows}, {expected_cols}), got ({actual_rows}, {actual_cols})")]
+    DimensionMismatch {
+        expected_rows: usize,
+        expected_cols: usize,
+        actual_rows: usize,
+        actual_cols: usize,
+    },
+
+    /// Index out of bounds
+    #[error("Index out of bounds: ({row}, {col}) is out of bounds for a ({nrows}, {ncols}) matrix")]
+    IndexOutOfBounds {
+        row: usize,
+        col: usize,
+        nrows: usize,
+        ncols: usize,
+    },
+
+    /// Duplicate pivot row
+    #[error("Cannot add pivot: row {row} already has a pivot")]
+    DuplicatePivotRow { row: usize },
+
+    /// Duplicate pivot column
+    #[error("Cannot add pivot: column {col} already has a pivot")]
+    DuplicatePivotCol { col: usize },
+
+    /// Matrix is already full rank
+    #[error("Cannot find a new pivot: matrix is already full rank")]
+    FullRank,
+
+    /// Empty row or column set
+    #[error("Cannot find a new pivot in an empty set of {dimension}")]
+    EmptyIndexSet { dimension: String },
+
+    /// Invalid argument
+    #[error("Invalid argument: {message}")]
+    InvalidArgument { message: String },
+
+    /// Singular matrix encountered
+    #[error("Singular matrix encountered during decomposition")]
+    SingularMatrix,
+
+    /// Rank deficient matrix
+    #[error("Rank-deficient matrix is not supported for this operation")]
+    RankDeficient,
+
+    /// NaN values encountered
+    #[error("NaN values encountered in {matrix}")]
+    NaNEncountered { matrix: String },
+}
+
+/// Result type for matrix CI operations
+pub type Result<T> = std::result::Result<T, MatrixCIError>;

--- a/crates/tensor4all-matrixci/src/lib.rs
+++ b/crates/tensor4all-matrixci/src/lib.rs
@@ -1,0 +1,43 @@
+//! Matrix Cross Interpolation library
+//!
+//! This crate provides matrix cross interpolation algorithms, including:
+//! - `MatrixCI`: Standard matrix cross interpolation
+//! - `MatrixACA`: Adaptive Cross Approximation
+//! - `RrLU`: Rank-Revealing LU decomposition
+//! - `MatrixLUCI`: LU-based Cross Interpolation
+//!
+//! # Example
+//!
+//! ```
+//! use tensor4all_matrixci::{MatrixCI, crossinterpolate, AbstractMatrixCI, from_vec2d};
+//!
+//! // Create a matrix
+//! let m = from_vec2d(vec![
+//!     vec![1.0, 2.0, 3.0],
+//!     vec![4.0, 5.0, 6.0],
+//!     vec![7.0, 8.0, 9.0],
+//! ]);
+//!
+//! // Perform cross interpolation
+//! let ci = crossinterpolate(&m, None);
+//!
+//! // Get the rank of the approximation
+//! println!("Rank: {}", ci.rank());
+//! ```
+
+pub mod error;
+pub mod matrixaca;
+pub mod matrixci;
+pub mod matrixlu;
+pub mod matrixluci;
+pub mod traits;
+pub mod util;
+
+// Re-export main types
+pub use error::{MatrixCIError, Result};
+pub use matrixaca::MatrixACA;
+pub use matrixci::{crossinterpolate, CrossInterpolateOptions, MatrixCI};
+pub use matrixlu::{rrlu, rrlu_inplace, RrLU, RrLUOptions};
+pub use matrixluci::MatrixLUCI;
+pub use traits::AbstractMatrixCI;
+pub use util::{from_vec2d, Matrix, Scalar};

--- a/crates/tensor4all-matrixci/src/matrixaca.rs
+++ b/crates/tensor4all-matrixci/src/matrixaca.rs
@@ -1,0 +1,407 @@
+//! Adaptive Cross Approximation (MatrixACA) implementation
+
+use crate::error::{MatrixCIError, Result};
+use crate::traits::AbstractMatrixCI;
+use crate::util::{
+    append_col, append_row, from_vec2d, get_col, get_row, ncols, nrows, submatrix_argmax, zeros,
+    Matrix, Scalar,
+};
+
+/// Adaptive Cross Approximation representation
+///
+/// Represents a matrix approximation using the ACA algorithm.
+/// The approximation is stored as:
+/// A ≈ U * diag(alpha) * V
+///
+/// where alpha[k] = 1/delta[k] for efficiency.
+#[derive(Debug, Clone)]
+pub struct MatrixACA<T: Scalar> {
+    /// Row indices (I set)
+    row_indices: Vec<usize>,
+    /// Column indices (J set)
+    col_indices: Vec<usize>,
+    /// U matrix: u_k(x) for all x, shape (nrows, npivots)
+    u: Matrix<T>,
+    /// V matrix: v_k(y) for all y, shape (npivots, ncols)
+    v: Matrix<T>,
+    /// Alpha values: 1/delta for each pivot
+    alpha: Vec<T>,
+}
+
+impl<T: Scalar> MatrixACA<T> {
+    /// Create an empty MatrixACA for a matrix of given size
+    pub fn new(nr: usize, nc: usize) -> Self {
+        Self {
+            row_indices: Vec::new(),
+            col_indices: Vec::new(),
+            u: zeros(nr, 0),
+            v: zeros(0, nc),
+            alpha: Vec::new(),
+        }
+    }
+
+    /// Create a MatrixACA from a matrix with an initial pivot
+    pub fn from_matrix_with_pivot(a: &Matrix<T>, first_pivot: (usize, usize)) -> Self {
+        let (i, j) = first_pivot;
+        let pivot_val = a[[i, j]];
+
+        // u = A[:, j]
+        let u_col = get_col(a, j);
+        let u = from_vec2d((0..nrows(a)).map(|r| vec![u_col[r]]).collect());
+
+        // v = A[i, :]
+        let v_row = get_row(a, i);
+        let v = from_vec2d(vec![v_row]);
+
+        let alpha = vec![T::one() / pivot_val];
+
+        Self {
+            row_indices: vec![i],
+            col_indices: vec![j],
+            u,
+            v,
+            alpha,
+        }
+    }
+
+    /// Number of pivots
+    pub fn npivots(&self) -> usize {
+        self.alpha.len()
+    }
+
+    /// Get reference to U matrix
+    pub fn u(&self) -> &Matrix<T> {
+        &self.u
+    }
+
+    /// Get reference to V matrix
+    pub fn v(&self) -> &Matrix<T> {
+        &self.v
+    }
+
+    /// Get reference to alpha values
+    pub fn alpha(&self) -> &[T] {
+        &self.alpha
+    }
+
+    /// Compute u_k(x) for all x (the k-th column of U after adding a new pivot column)
+    fn compute_uk(&self, a: &Matrix<T>) -> Vec<T> {
+        let k = self.col_indices.len();
+        let yk = self.col_indices[k - 1];
+
+        // result = A[:, yk]
+        let mut result: Vec<T> = get_col(a, yk);
+
+        // Subtract contribution from previous pivots
+        for l in 0..(k - 1) {
+            let xl = self.row_indices[l];
+            let v_l_yk = self.v[[l, yk]];
+            let u_xl_l = self.u[[xl, l]];
+            let factor = v_l_yk / u_xl_l;
+
+            for (i, res) in result.iter_mut().enumerate() {
+                *res = *res - factor * self.u[[i, l]];
+            }
+        }
+
+        result
+    }
+
+    /// Compute v_k(y) for all y (the k-th row of V after adding a new pivot row)
+    fn compute_vk(&self, a: &Matrix<T>) -> Vec<T> {
+        let k = self.row_indices.len();
+        let xk = self.row_indices[k - 1];
+
+        // result = A[xk, :]
+        let mut result: Vec<T> = get_row(a, xk);
+
+        // Subtract contribution from previous pivots
+        for l in 0..(k - 1) {
+            let xl = self.row_indices[l];
+            let u_xk_l = self.u[[xk, l]];
+            let u_xl_l = self.u[[xl, l]];
+            let factor = u_xk_l / u_xl_l;
+
+            for (j, res) in result.iter_mut().enumerate() {
+                *res = *res - factor * self.v[[l, j]];
+            }
+        }
+
+        result
+    }
+
+    /// Add a pivot column
+    pub fn add_pivot_col(&mut self, a: &Matrix<T>, col_index: usize) -> Result<()> {
+        if col_index >= self.ncols() {
+            return Err(MatrixCIError::IndexOutOfBounds {
+                row: 0,
+                col: col_index,
+                nrows: self.nrows(),
+                ncols: self.ncols(),
+            });
+        }
+
+        self.col_indices.push(col_index);
+        let uk = self.compute_uk(a);
+        self.u = append_col(&self.u, &uk);
+
+        Ok(())
+    }
+
+    /// Add a pivot row
+    pub fn add_pivot_row(&mut self, a: &Matrix<T>, row_index: usize) -> Result<()> {
+        if row_index >= self.nrows() {
+            return Err(MatrixCIError::IndexOutOfBounds {
+                row: row_index,
+                col: 0,
+                nrows: self.nrows(),
+                ncols: self.ncols(),
+            });
+        }
+
+        self.row_indices.push(row_index);
+        let vk = self.compute_vk(a);
+        self.v = append_row(&self.v, &vk);
+
+        // Update alpha
+        let xk = row_index;
+        let u_xk_last = self.u[[xk, ncols(&self.u) - 1]];
+        self.alpha.push(T::one() / u_xk_last);
+
+        Ok(())
+    }
+
+    /// Add a pivot at the given position
+    pub fn add_pivot(&mut self, a: &Matrix<T>, pivot: (usize, usize)) -> Result<()> {
+        self.add_pivot_col(a, pivot.1)?;
+        self.add_pivot_row(a, pivot.0)?;
+        Ok(())
+    }
+
+    /// Add a pivot that maximizes the error using ACA heuristic
+    pub fn add_best_pivot(&mut self, a: &Matrix<T>) -> Result<(usize, usize)> {
+        if self.is_empty() {
+            // Find global maximum
+            let rows: Vec<usize> = (0..self.nrows()).collect();
+            let cols: Vec<usize> = (0..self.ncols()).collect();
+            let (i, j, _) = submatrix_argmax(a, &rows, &cols);
+            self.add_pivot(a, (i, j))?;
+            return Ok((i, j));
+        }
+
+        // ACA heuristic: find max in last row of V, then max in corresponding column of U
+        let avail_cols = self.available_cols();
+        if avail_cols.is_empty() {
+            return Err(MatrixCIError::FullRank);
+        }
+
+        // Find column with max |v[last, j]| among available columns
+        let last_row = nrows(&self.v) - 1;
+        let mut max_val = self.v[[last_row, avail_cols[0]]].abs_sq();
+        let mut best_col = avail_cols[0];
+        for &c in &avail_cols {
+            let val = self.v[[last_row, c]].abs_sq();
+            if val > max_val {
+                max_val = val;
+                best_col = c;
+            }
+        }
+
+        self.add_pivot_col(a, best_col)?;
+
+        // Find row with max |u[i, last]| among available rows
+        let avail_rows = self.available_rows();
+        if avail_rows.is_empty() {
+            return Err(MatrixCIError::FullRank);
+        }
+
+        let last_col = ncols(&self.u) - 1;
+        let mut max_val = self.u[[avail_rows[0], last_col]].abs_sq();
+        let mut best_row = avail_rows[0];
+        for &r in &avail_rows {
+            let val = self.u[[r, last_col]].abs_sq();
+            if val > max_val {
+                max_val = val;
+                best_row = r;
+            }
+        }
+
+        self.add_pivot_row(a, best_row)?;
+
+        Ok((best_row, best_col))
+    }
+
+    /// Set columns with new pivot rows and permutation
+    pub fn set_cols(&mut self, new_pivot_rows: &Matrix<T>, permutation: &[usize]) {
+        // Permute column indices
+        self.col_indices = self
+            .col_indices
+            .iter()
+            .map(|&c| permutation[c])
+            .collect();
+
+        // Permute V matrix columns
+        let mut temp_v = zeros(nrows(&self.v), ncols(new_pivot_rows));
+        for i in 0..nrows(&self.v) {
+            for (new_j, &old_j) in permutation.iter().enumerate() {
+                if old_j < ncols(&self.v) {
+                    temp_v[[i, new_j]] = self.v[[i, old_j]];
+                }
+            }
+        }
+        self.v = temp_v;
+
+        // Insert new elements
+        let new_indices: Vec<usize> = (0..ncols(new_pivot_rows))
+            .filter(|j| !permutation.contains(j))
+            .collect();
+
+        for k in 0..nrows(new_pivot_rows) {
+            for &j in &new_indices {
+                let mut val = new_pivot_rows[[k, j]];
+                for l in 0..k {
+                    let factor = self.u[[self.row_indices[k], l]] * self.alpha[l];
+                    val = val - self.v[[l, j]] * factor;
+                }
+                self.v[[k, j]] = val;
+            }
+        }
+    }
+
+    /// Set rows with new pivot columns and permutation
+    pub fn set_rows(&mut self, new_pivot_cols: &Matrix<T>, permutation: &[usize]) {
+        // Permute row indices
+        self.row_indices = self
+            .row_indices
+            .iter()
+            .map(|&r| permutation[r])
+            .collect();
+
+        // Permute U matrix rows
+        let mut temp_u = zeros(nrows(new_pivot_cols), ncols(&self.u));
+        for (new_i, &old_i) in permutation.iter().enumerate() {
+            if old_i < nrows(&self.u) {
+                for j in 0..ncols(&self.u) {
+                    temp_u[[new_i, j]] = self.u[[old_i, j]];
+                }
+            }
+        }
+        self.u = temp_u;
+
+        // Insert new elements
+        let new_indices: Vec<usize> = (0..nrows(new_pivot_cols))
+            .filter(|i| !permutation.contains(i))
+            .collect();
+
+        for k in 0..ncols(new_pivot_cols) {
+            for &i in &new_indices {
+                let mut val = new_pivot_cols[[i, k]];
+                for l in 0..k {
+                    let factor = self.v[[l, self.col_indices[k]]] * self.alpha[l];
+                    val = val - self.u[[i, l]] * factor;
+                }
+                self.u[[i, k]] = val;
+            }
+        }
+    }
+}
+
+impl<T: Scalar> AbstractMatrixCI<T> for MatrixACA<T> {
+    fn nrows(&self) -> usize {
+        nrows(&self.u)
+    }
+
+    fn ncols(&self) -> usize {
+        ncols(&self.v)
+    }
+
+    fn rank(&self) -> usize {
+        self.row_indices.len()
+    }
+
+    fn row_indices(&self) -> &[usize] {
+        &self.row_indices
+    }
+
+    fn col_indices(&self) -> &[usize] {
+        &self.col_indices
+    }
+
+    fn evaluate(&self, i: usize, j: usize) -> T {
+        if self.is_empty() {
+            return T::zero();
+        }
+
+        let mut sum = T::zero();
+        for k in 0..self.rank() {
+            sum = sum + self.u[[i, k]] * self.alpha[k] * self.v[[k, j]];
+        }
+        sum
+    }
+
+    fn submatrix(&self, rows: &[usize], cols: &[usize]) -> Matrix<T> {
+        if self.is_empty() {
+            return zeros(rows.len(), cols.len());
+        }
+
+        let r = self.rank();
+        let mut result = zeros(rows.len(), cols.len());
+
+        for (ri, &row) in rows.iter().enumerate() {
+            for (ci, &col) in cols.iter().enumerate() {
+                let mut sum = T::zero();
+                for k in 0..r {
+                    sum = sum + self.u[[row, k]] * self.alpha[k] * self.v[[k, col]];
+                }
+                result[[ri, ci]] = sum;
+            }
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matrixaca_new() {
+        let aca = MatrixACA::<f64>::new(5, 5);
+        assert_eq!(aca.nrows(), 5);
+        assert_eq!(aca.ncols(), 5);
+        assert_eq!(aca.rank(), 0);
+        assert!(aca.is_empty());
+    }
+
+    #[test]
+    fn test_matrixaca_from_matrix() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ]);
+
+        let aca = MatrixACA::from_matrix_with_pivot(&m, (1, 1));
+        assert_eq!(aca.nrows(), 3);
+        assert_eq!(aca.ncols(), 3);
+        assert_eq!(aca.rank(), 1);
+
+        // Check that evaluation at pivot is correct
+        let val = aca.evaluate(1, 1);
+        assert!((val - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_matrixaca_add_pivot() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ]);
+
+        let mut aca = MatrixACA::from_matrix_with_pivot(&m, (0, 0));
+        assert!(aca.add_pivot(&m, (1, 1)).is_ok());
+        assert_eq!(aca.rank(), 2);
+    }
+}

--- a/crates/tensor4all-matrixci/src/matrixci.rs
+++ b/crates/tensor4all-matrixci/src/matrixci.rs
@@ -1,0 +1,399 @@
+//! Matrix Cross Interpolation (MatrixCI) implementation
+
+use crate::error::{MatrixCIError, Result};
+use crate::traits::AbstractMatrixCI;
+use crate::util::{
+    a_inv_times_b, a_times_b_inv, dot, from_vec2d, get_col, get_row, mat_mul, ncols, nrows,
+    submatrix, submatrix_argmax, zeros, append_col, append_row, Matrix, Scalar,
+};
+
+/// Matrix Cross Interpolation representation
+///
+/// Represents a cross interpolation of a matrix A as:
+/// A ≈ L * P^{-1} * R
+///
+/// where:
+/// - L = A[:, J] (pivot columns)
+/// - P = A[I, J] (pivot matrix)
+/// - R = A[I, :] (pivot rows)
+/// - I = row indices (rowindices)
+/// - J = column indices (colindices)
+#[derive(Debug, Clone)]
+pub struct MatrixCI<T: Scalar> {
+    /// Row indices (I set)
+    row_indices: Vec<usize>,
+    /// Column indices (J set)
+    col_indices: Vec<usize>,
+    /// Pivot columns: A[:, J] with shape (nrows, npivots)
+    pivot_cols: Matrix<T>,
+    /// Pivot rows: A[I, :] with shape (npivots, ncols)
+    pivot_rows: Matrix<T>,
+}
+
+impl<T: Scalar> MatrixCI<T> {
+    /// Create an empty MatrixCI for a matrix of given size
+    pub fn new(nr: usize, nc: usize) -> Self {
+        Self {
+            row_indices: Vec::new(),
+            col_indices: Vec::new(),
+            pivot_cols: zeros(nr, 0),
+            pivot_rows: zeros(0, nc),
+        }
+    }
+
+    /// Create a MatrixCI from existing parts
+    ///
+    /// # Arguments
+    /// * `row_indices` - Row indices (I set)
+    /// * `col_indices` - Column indices (J set)
+    /// * `pivot_cols` - Pivot columns A[:, J]
+    /// * `pivot_rows` - Pivot rows A[I, :]
+    pub fn from_parts(
+        row_indices: Vec<usize>,
+        col_indices: Vec<usize>,
+        pivot_cols: Matrix<T>,
+        pivot_rows: Matrix<T>,
+    ) -> Self {
+        Self {
+            row_indices,
+            col_indices,
+            pivot_cols,
+            pivot_rows,
+        }
+    }
+
+    /// Create a MatrixCI from a matrix with an initial pivot
+    pub fn from_matrix_with_pivot(a: &Matrix<T>, first_pivot: (usize, usize)) -> Self {
+        let (i, j) = first_pivot;
+        let pivot_col = get_col(a, j);
+        let pivot_row = get_row(a, i);
+
+        let nr = nrows(a);
+        let _nc = ncols(a);
+
+        let pivot_cols = from_vec2d(
+            (0..nr).map(|r| vec![pivot_col[r]]).collect()
+        );
+
+        let pivot_rows = from_vec2d(vec![pivot_row]);
+
+        Self {
+            row_indices: vec![i],
+            col_indices: vec![j],
+            pivot_cols,
+            pivot_rows,
+        }
+    }
+
+    /// Get I set (row indices)
+    pub fn iset(&self) -> &[usize] {
+        &self.row_indices
+    }
+
+    /// Get J set (column indices)
+    pub fn jset(&self) -> &[usize] {
+        &self.col_indices
+    }
+
+    /// Get the pivot matrix P = A[I, J]
+    pub fn pivot_matrix(&self) -> Matrix<T> {
+        let ranks: Vec<usize> = (0..self.rank()).collect();
+        submatrix(&self.pivot_cols, &self.row_indices, &ranks)
+    }
+
+    /// Get the left matrix L = A[:, J] * P^{-1}
+    pub fn left_matrix(&self) -> Matrix<T> {
+        if self.is_empty() {
+            return zeros(self.nrows(), 0);
+        }
+        a_times_b_inv(&self.pivot_cols, &self.pivot_matrix())
+    }
+
+    /// Get the right matrix R = P^{-1} * A[I, :]
+    pub fn right_matrix(&self) -> Matrix<T> {
+        if self.is_empty() {
+            return zeros(0, self.ncols());
+        }
+        a_inv_times_b(&self.pivot_matrix(), &self.pivot_rows)
+    }
+
+    /// Get the value of the first pivot
+    pub fn first_pivot_value(&self) -> T {
+        if self.is_empty() {
+            T::one()
+        } else {
+            self.pivot_cols[[self.row_indices[0], 0]]
+        }
+    }
+
+    /// Add a pivot row
+    pub fn add_pivot_row(&mut self, a: &Matrix<T>, row_index: usize) -> Result<()> {
+        if nrows(a) != self.nrows() || ncols(a) != self.ncols() {
+            return Err(MatrixCIError::DimensionMismatch {
+                expected_rows: self.nrows(),
+                expected_cols: self.ncols(),
+                actual_rows: nrows(a),
+                actual_cols: ncols(a),
+            });
+        }
+
+        if row_index >= self.nrows() {
+            return Err(MatrixCIError::IndexOutOfBounds {
+                row: row_index,
+                col: 0,
+                nrows: self.nrows(),
+                ncols: self.ncols(),
+            });
+        }
+
+        if self.row_indices.contains(&row_index) {
+            return Err(MatrixCIError::DuplicatePivotRow { row: row_index });
+        }
+
+        let row = get_row(a, row_index);
+        self.pivot_rows = append_row(&self.pivot_rows, &row);
+        self.row_indices.push(row_index);
+
+        Ok(())
+    }
+
+    /// Add a pivot column
+    pub fn add_pivot_col(&mut self, a: &Matrix<T>, col_index: usize) -> Result<()> {
+        if nrows(a) != self.nrows() || ncols(a) != self.ncols() {
+            return Err(MatrixCIError::DimensionMismatch {
+                expected_rows: self.nrows(),
+                expected_cols: self.ncols(),
+                actual_rows: nrows(a),
+                actual_cols: ncols(a),
+            });
+        }
+
+        if col_index >= self.ncols() {
+            return Err(MatrixCIError::IndexOutOfBounds {
+                row: 0,
+                col: col_index,
+                nrows: self.nrows(),
+                ncols: self.ncols(),
+            });
+        }
+
+        if self.col_indices.contains(&col_index) {
+            return Err(MatrixCIError::DuplicatePivotCol { col: col_index });
+        }
+
+        let col = get_col(a, col_index);
+        self.pivot_cols = append_col(&self.pivot_cols, &col);
+        self.col_indices.push(col_index);
+
+        Ok(())
+    }
+
+    /// Add a pivot at the given position
+    pub fn add_pivot(&mut self, a: &Matrix<T>, pivot: (usize, usize)) -> Result<()> {
+        let (i, j) = pivot;
+
+        if nrows(a) != self.nrows() || ncols(a) != self.ncols() {
+            return Err(MatrixCIError::DimensionMismatch {
+                expected_rows: self.nrows(),
+                expected_cols: self.ncols(),
+                actual_rows: nrows(a),
+                actual_cols: ncols(a),
+            });
+        }
+
+        if i >= self.nrows() || j >= self.ncols() {
+            return Err(MatrixCIError::IndexOutOfBounds {
+                row: i,
+                col: j,
+                nrows: self.nrows(),
+                ncols: self.ncols(),
+            });
+        }
+
+        if self.row_indices.contains(&i) {
+            return Err(MatrixCIError::DuplicatePivotRow { row: i });
+        }
+
+        if self.col_indices.contains(&j) {
+            return Err(MatrixCIError::DuplicatePivotCol { col: j });
+        }
+
+        self.add_pivot_row(a, i)?;
+        self.add_pivot_col(a, j)?;
+
+        Ok(())
+    }
+
+    /// Add a pivot that maximizes the error
+    pub fn add_best_pivot(&mut self, a: &Matrix<T>) -> Result<(usize, usize)> {
+        let ((i, j), _) = self.find_new_pivot(a)?;
+        self.add_pivot(a, (i, j))?;
+        Ok((i, j))
+    }
+}
+
+impl<T: Scalar> AbstractMatrixCI<T> for MatrixCI<T> {
+    fn nrows(&self) -> usize {
+        nrows(&self.pivot_cols)
+    }
+
+    fn ncols(&self) -> usize {
+        ncols(&self.pivot_rows)
+    }
+
+    fn rank(&self) -> usize {
+        self.row_indices.len()
+    }
+
+    fn row_indices(&self) -> &[usize] {
+        &self.row_indices
+    }
+
+    fn col_indices(&self) -> &[usize] {
+        &self.col_indices
+    }
+
+    fn evaluate(&self, i: usize, j: usize) -> T {
+        if self.is_empty() {
+            return T::zero();
+        }
+
+        let left = self.left_matrix();
+        let left_row: Vec<T> = (0..ncols(&left)).map(|k| left[[i, k]]).collect();
+        let pivot_col: Vec<T> = (0..nrows(&self.pivot_rows))
+            .map(|k| self.pivot_rows[[k, j]])
+            .collect();
+
+        dot(&left_row, &pivot_col)
+    }
+
+    fn submatrix(&self, rows: &[usize], cols: &[usize]) -> Matrix<T> {
+        if self.is_empty() {
+            return zeros(rows.len(), cols.len());
+        }
+
+        let left = self.left_matrix();
+        let ranks: Vec<usize> = (0..self.rank()).collect();
+        let left_sub = submatrix(&left, rows, &ranks);
+
+        let pivot_sub = submatrix(&self.pivot_rows, &ranks, cols);
+
+        mat_mul(&left_sub, &pivot_sub)
+    }
+}
+
+/// Options for cross interpolation
+#[derive(Debug, Clone)]
+pub struct CrossInterpolateOptions {
+    /// Tolerance for stopping criterion
+    pub tolerance: f64,
+    /// Maximum number of iterations
+    pub max_iter: usize,
+}
+
+impl Default for CrossInterpolateOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 1e-6,
+            max_iter: 200,
+        }
+    }
+}
+
+/// Perform cross interpolation of a matrix
+pub fn crossinterpolate<T: Scalar>(
+    a: &Matrix<T>,
+    options: Option<CrossInterpolateOptions>,
+) -> MatrixCI<T> {
+    let opts = options.unwrap_or_default();
+
+    // Find initial pivot (maximum absolute value)
+    let rows: Vec<usize> = (0..nrows(a)).collect();
+    let cols: Vec<usize> = (0..ncols(a)).collect();
+    let (first_i, first_j, _) = submatrix_argmax(a, &rows, &cols);
+
+    let mut ci = MatrixCI::from_matrix_with_pivot(a, (first_i, first_j));
+
+    for _ in 1..opts.max_iter {
+        match ci.find_new_pivot(a) {
+            Ok(((i, j), error)) => {
+                let error_val: f64 = error.abs_sq();
+                let tol_sq = opts.tolerance * opts.tolerance;
+                if error_val < tol_sq {
+                    break;
+                }
+                let _ = ci.add_pivot(a, (i, j));
+            }
+            Err(_) => break,
+        }
+    }
+
+    ci
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matrixci_new() {
+        let ci = MatrixCI::<f64>::new(5, 5);
+        assert_eq!(ci.nrows(), 5);
+        assert_eq!(ci.ncols(), 5);
+        assert_eq!(ci.rank(), 0);
+        assert!(ci.is_empty());
+    }
+
+    #[test]
+    fn test_matrixci_from_matrix() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ]);
+
+        let ci = MatrixCI::from_matrix_with_pivot(&m, (2, 2));
+        assert_eq!(ci.nrows(), 3);
+        assert_eq!(ci.ncols(), 3);
+        assert_eq!(ci.rank(), 1);
+        assert_eq!(ci.row_indices(), &[2]);
+        assert_eq!(ci.col_indices(), &[2]);
+    }
+
+    #[test]
+    fn test_matrixci_add_pivot() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ]);
+
+        let mut ci = MatrixCI::from_matrix_with_pivot(&m, (0, 0));
+        assert!(ci.add_pivot(&m, (1, 1)).is_ok());
+        assert_eq!(ci.rank(), 2);
+    }
+
+    #[test]
+    fn test_crossinterpolate() {
+        // Create a rank-1 matrix
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![2.0, 4.0, 6.0],
+            vec![3.0, 6.0, 9.0],
+        ]);
+
+        let ci = crossinterpolate(&m, None);
+
+        // For a rank-1 matrix, should need only 1 pivot
+        assert!(ci.rank() >= 1);
+
+        // Check approximation quality
+        let approx = ci.to_matrix();
+        for i in 0..3 {
+            for j in 0..3 {
+                let diff = (m[[i, j]] - approx[[i, j]]).abs();
+                assert!(diff < 1e-10, "Approximation error too large at ({}, {})", i, j);
+            }
+        }
+    }
+}

--- a/crates/tensor4all-matrixci/src/matrixlu.rs
+++ b/crates/tensor4all-matrixci/src/matrixlu.rs
@@ -1,0 +1,465 @@
+//! Rank-Revealing LU decomposition (rrLU) implementation
+
+use crate::error::Result;
+use crate::util::{
+    ncols, nrows, submatrix_argmax, swap_cols, swap_rows, transpose, zeros, Matrix, Scalar,
+};
+
+/// Rank-Revealing LU decomposition
+///
+/// Represents a matrix A as:
+/// P_row * A * P_col = L * U
+///
+/// where P_row and P_col are permutation matrices.
+#[derive(Debug, Clone)]
+pub struct RrLU<T: Scalar> {
+    /// Row permutation
+    row_permutation: Vec<usize>,
+    /// Column permutation
+    col_permutation: Vec<usize>,
+    /// Lower triangular matrix L
+    l: Matrix<T>,
+    /// Upper triangular matrix U
+    u: Matrix<T>,
+    /// Whether L is left-orthogonal (L has 1s on diagonal) or U is (U has 1s on diagonal)
+    left_orthogonal: bool,
+    /// Number of pivots
+    n_pivot: usize,
+    /// Last pivot error
+    error: f64,
+}
+
+impl<T: Scalar> RrLU<T> {
+    /// Create an empty rrLU for a matrix of given size
+    pub fn new(nr: usize, nc: usize, left_orthogonal: bool) -> Self {
+        Self {
+            row_permutation: (0..nr).collect(),
+            col_permutation: (0..nc).collect(),
+            l: zeros(nr, 0),
+            u: zeros(0, nc),
+            left_orthogonal,
+            n_pivot: 0,
+            error: f64::NAN,
+        }
+    }
+
+    /// Number of rows
+    pub fn nrows(&self) -> usize {
+        nrows(&self.l)
+    }
+
+    /// Number of columns
+    pub fn ncols(&self) -> usize {
+        ncols(&self.u)
+    }
+
+    /// Number of pivots
+    pub fn npivots(&self) -> usize {
+        self.n_pivot
+    }
+
+    /// Row permutation
+    pub fn row_permutation(&self) -> &[usize] {
+        &self.row_permutation
+    }
+
+    /// Column permutation
+    pub fn col_permutation(&self) -> &[usize] {
+        &self.col_permutation
+    }
+
+    /// Get row indices (selected pivots)
+    pub fn row_indices(&self) -> Vec<usize> {
+        self.row_permutation[0..self.n_pivot].to_vec()
+    }
+
+    /// Get column indices (selected pivots)
+    pub fn col_indices(&self) -> Vec<usize> {
+        self.col_permutation[0..self.n_pivot].to_vec()
+    }
+
+    /// Get left matrix (optionally permuted)
+    pub fn left(&self, permute: bool) -> Matrix<T> {
+        if permute {
+            let mut result = zeros(nrows(&self.l), ncols(&self.l));
+            for (new_i, &old_i) in self.row_permutation.iter().enumerate() {
+                for j in 0..ncols(&self.l) {
+                    result[[old_i, j]] = self.l[[new_i, j]];
+                }
+            }
+            result
+        } else {
+            self.l.clone()
+        }
+    }
+
+    /// Get right matrix (optionally permuted)
+    pub fn right(&self, permute: bool) -> Matrix<T> {
+        if permute {
+            let mut result = zeros(nrows(&self.u), ncols(&self.u));
+            for i in 0..nrows(&self.u) {
+                for (new_j, &old_j) in self.col_permutation.iter().enumerate() {
+                    result[[i, old_j]] = self.u[[i, new_j]];
+                }
+            }
+            result
+        } else {
+            self.u.clone()
+        }
+    }
+
+    /// Get diagonal elements
+    pub fn diag(&self) -> Vec<T> {
+        let n = self.n_pivot;
+        if self.left_orthogonal {
+            (0..n).map(|i| self.u[[i, i]]).collect()
+        } else {
+            (0..n).map(|i| self.l[[i, i]]).collect()
+        }
+    }
+
+    /// Get pivot errors
+    pub fn pivot_errors(&self) -> Vec<f64> {
+        let mut errors: Vec<f64> = self
+            .diag()
+            .iter()
+            .map(|d| f64::sqrt(d.abs_sq()))
+            .collect();
+        errors.push(self.error);
+        errors
+    }
+
+    /// Get last pivot error
+    pub fn last_pivot_error(&self) -> f64 {
+        self.error
+    }
+
+    /// Transpose the decomposition
+    pub fn transpose(&self) -> RrLU<T> {
+        RrLU {
+            row_permutation: self.col_permutation.clone(),
+            col_permutation: self.row_permutation.clone(),
+            l: transpose(&self.u),
+            u: transpose(&self.l),
+            left_orthogonal: !self.left_orthogonal,
+            n_pivot: self.n_pivot,
+            error: self.error,
+        }
+    }
+
+    /// Check if left-orthogonal (L has 1s on diagonal)
+    pub fn is_left_orthogonal(&self) -> bool {
+        self.left_orthogonal
+    }
+}
+
+/// Options for rank-revealing LU decomposition
+#[derive(Debug, Clone)]
+pub struct RrLUOptions {
+    /// Maximum rank
+    pub max_rank: usize,
+    /// Relative tolerance
+    pub rel_tol: f64,
+    /// Absolute tolerance
+    pub abs_tol: f64,
+    /// Left orthogonal (L has 1s on diagonal) or right orthogonal (U has 1s)
+    pub left_orthogonal: bool,
+}
+
+impl Default for RrLUOptions {
+    fn default() -> Self {
+        Self {
+            max_rank: usize::MAX,
+            rel_tol: 1e-14,
+            abs_tol: 0.0,
+            left_orthogonal: true,
+        }
+    }
+}
+
+/// Perform in-place rank-revealing LU decomposition
+pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) -> RrLU<T> {
+    let opts = options.unwrap_or_default();
+    let nr = nrows(a);
+    let nc = ncols(a);
+
+    let mut lu = RrLU::new(nr, nc, opts.left_orthogonal);
+    let max_rank = opts.max_rank.min(nr).min(nc);
+    let mut max_error = 0.0f64;
+
+    while lu.n_pivot < max_rank {
+        let k = lu.n_pivot;
+        let rows: Vec<usize> = (k..nr).collect();
+        let cols: Vec<usize> = (k..nc).collect();
+
+        if rows.is_empty() || cols.is_empty() {
+            break;
+        }
+
+        // Find pivot with maximum absolute value in submatrix
+        let (pivot_row, pivot_col, pivot_val) = submatrix_argmax(a, &rows, &cols);
+
+        let pivot_abs = f64::sqrt(pivot_val.abs_sq());
+        lu.error = pivot_abs;
+
+        // Check stopping criteria (but add at least 1 pivot)
+        if lu.n_pivot > 0 && (pivot_abs < opts.rel_tol * max_error || pivot_abs < opts.abs_tol) {
+            break;
+        }
+
+        max_error = max_error.max(pivot_abs);
+
+        // Swap rows and columns
+        if pivot_row != k {
+            *a = swap_rows(a, k, pivot_row);
+            lu.row_permutation.swap(k, pivot_row);
+        }
+        if pivot_col != k {
+            *a = swap_cols(a, k, pivot_col);
+            lu.col_permutation.swap(k, pivot_col);
+        }
+
+        let pivot = a[[k, k]];
+
+        // Eliminate
+        if opts.left_orthogonal {
+            // Scale column below pivot
+            for i in (k + 1)..nr {
+                let val = a[[i, k]] / pivot;
+                a[[i, k]] = val;
+            }
+        } else {
+            // Scale row to the right of pivot
+            for j in (k + 1)..nc {
+                let val = a[[k, j]] / pivot;
+                a[[k, j]] = val;
+            }
+        }
+
+        // Update submatrix: A[k+1:, k+1:] -= A[k+1:, k] * A[k, k+1:]
+        for i in (k + 1)..nr {
+            for j in (k + 1)..nc {
+                let x = a[[i, k]];
+                let y = a[[k, j]];
+                let old = a[[i, j]];
+                a[[i, j]] = old - x * y;
+            }
+        }
+
+        lu.n_pivot += 1;
+    }
+
+    // Extract L and U
+    let n = lu.n_pivot;
+
+    // L is lower triangular part
+    let mut l = zeros(nr, n);
+    for i in 0..nr {
+        for j in 0..n.min(i + 1) {
+            l[[i, j]] = a[[i, j]];
+        }
+    }
+
+    // U is upper triangular part
+    let mut u = zeros(n, nc);
+    for i in 0..n {
+        for j in i..nc {
+            u[[i, j]] = a[[i, j]];
+        }
+    }
+
+    // Set diagonal to 1 for the orthogonal factor
+    if opts.left_orthogonal {
+        for i in 0..n {
+            l[[i, i]] = T::one();
+        }
+    } else {
+        for i in 0..n {
+            u[[i, i]] = T::one();
+        }
+    }
+
+    // Check for NaNs
+    for i in 0..nrows(&l) {
+        for j in 0..ncols(&l) {
+            if l[[i, j]].is_nan() {
+                panic!("NaN in L matrix");
+            }
+        }
+    }
+    for i in 0..nrows(&u) {
+        for j in 0..ncols(&u) {
+            if u[[i, j]].is_nan() {
+                panic!("NaN in U matrix");
+            }
+        }
+    }
+
+    // Set error to 0 if full rank
+    if n >= nr.min(nc) {
+        lu.error = 0.0;
+    }
+
+    lu.l = l;
+    lu.u = u;
+
+    lu
+}
+
+/// Perform rank-revealing LU decomposition (non-destructive)
+pub fn rrlu<T: Scalar>(a: &Matrix<T>, options: Option<RrLUOptions>) -> RrLU<T> {
+    let mut a_copy = a.clone();
+    rrlu_inplace(&mut a_copy, options)
+}
+
+/// Convert L matrix to solve L * X = B given pivot matrix P
+pub fn cols_to_l_matrix<T: Scalar>(c: &mut Matrix<T>, p: &Matrix<T>, _left_orthogonal: bool) {
+    let n = nrows(p);
+
+    for k in 0..n {
+        let pivot = p[[k, k]];
+        // c[:, k] /= pivot
+        for i in 0..nrows(c) {
+            let val = c[[i, k]] / pivot;
+            c[[i, k]] = val;
+        }
+
+        // c[:, k+1:] -= c[:, k] * p[k, k+1:]
+        for j in (k + 1)..ncols(c) {
+            let p_kj = p[[k, j]];
+            for i in 0..nrows(c) {
+                let c_ik = c[[i, k]];
+                let old = c[[i, j]];
+                c[[i, j]] = old - c_ik * p_kj;
+            }
+        }
+    }
+}
+
+/// Convert R matrix to solve X * U = B given pivot matrix P
+pub fn rows_to_u_matrix<T: Scalar>(r: &mut Matrix<T>, p: &Matrix<T>, _left_orthogonal: bool) {
+    let n = nrows(p);
+
+    for k in 0..n {
+        let pivot = p[[k, k]];
+        // r[k, :] /= pivot
+        for j in 0..ncols(r) {
+            let val = r[[k, j]] / pivot;
+            r[[k, j]] = val;
+        }
+
+        // r[k+1:, :] -= p[k+1:, k] * r[k, :]
+        for i in (k + 1)..nrows(r) {
+            let p_ik = p[[i, k]];
+            for j in 0..ncols(r) {
+                let r_kj = r[[k, j]];
+                let old = r[[i, j]];
+                r[[i, j]] = old - p_ik * r_kj;
+            }
+        }
+    }
+}
+
+/// Solve LU * x = b
+pub fn solve_lu<T: Scalar>(l: &Matrix<T>, u: &Matrix<T>, b: &Matrix<T>) -> Result<Matrix<T>> {
+    let _n1 = nrows(l);
+    let n2 = ncols(l);
+    let n3 = ncols(u);
+    let m = ncols(b);
+
+    // Solve L * y = b (forward substitution)
+    let mut y: Matrix<T> = zeros(n2, m);
+    for i in 0..n2 {
+        for k in 0..m {
+            let mut sum = b[[i, k]];
+            for j in 0..i {
+                sum = sum - l[[i, j]] * y[[j, k]];
+            }
+            let diag = l[[i, i]];
+            y[[i, k]] = sum / diag;
+        }
+    }
+
+    // Solve U * x = y (back substitution)
+    let mut x: Matrix<T> = zeros(n3, m);
+    for i in (0..n3).rev() {
+        for k in 0..m {
+            let mut sum = y[[i, k]];
+            for j in (i + 1)..n3 {
+                sum = sum - u[[i, j]] * x[[j, k]];
+            }
+            let diag = u[[i, i]];
+            x[[i, k]] = sum / diag;
+        }
+    }
+
+    Ok(x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::{eye, from_vec2d, mat_mul};
+
+    #[test]
+    fn test_rrlu_identity() {
+        let m: Matrix<f64> = eye(3);
+        let lu = rrlu(&m, None);
+
+        assert_eq!(lu.npivots(), 3);
+        assert!(lu.error.abs() < 1e-10 || lu.error == 0.0);
+    }
+
+    #[test]
+    fn test_rrlu_rank_deficient() {
+        // Rank-1 matrix
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![2.0, 4.0, 6.0],
+            vec![3.0, 6.0, 9.0],
+        ]);
+
+        let lu = rrlu(&m, None);
+
+        // Should detect rank-1
+        assert_eq!(lu.npivots(), 1);
+    }
+
+    #[test]
+    fn test_rrlu_full_rank() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 10.0], // Not rank-deficient
+        ]);
+
+        let lu = rrlu(&m, None);
+
+        assert_eq!(lu.npivots(), 3);
+    }
+
+    #[test]
+    fn test_rrlu_reconstruct() {
+        let m = from_vec2d(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+
+        let lu = rrlu(&m, None);
+        let l = lu.left(true);
+        let u = lu.right(true);
+
+        // Reconstruct: L * U should approximate original matrix
+        let reconstructed = mat_mul(&l, &u);
+
+        for i in 0..2 {
+            for j in 0..2 {
+                let diff = (m[[i, j]] - reconstructed[[i, j]]).abs();
+                assert!(
+                    diff < 1e-10,
+                    "Reconstruction error at ({}, {}): {}",
+                    i,
+                    j,
+                    diff
+                );
+            }
+        }
+    }
+}

--- a/crates/tensor4all-matrixci/src/matrixluci.rs
+++ b/crates/tensor4all-matrixci/src/matrixluci.rs
@@ -1,0 +1,289 @@
+//! Matrix LU-based Cross Interpolation (MatrixLUCI) implementation
+
+use crate::matrixlu::{rrlu, RrLU, RrLUOptions};
+use crate::traits::AbstractMatrixCI;
+use crate::util::{mat_mul, ncols, nrows, submatrix, zeros, Matrix, Scalar};
+
+/// Matrix LU-based Cross Interpolation
+///
+/// A wrapper around RrLU that implements the AbstractMatrixCI trait.
+#[derive(Debug, Clone)]
+pub struct MatrixLUCI<T: Scalar> {
+    /// Underlying rrLU decomposition
+    lu: RrLU<T>,
+}
+
+impl<T: Scalar> MatrixLUCI<T> {
+    /// Create a MatrixLUCI from a matrix
+    pub fn from_matrix(a: &Matrix<T>, options: Option<RrLUOptions>) -> Self {
+        Self {
+            lu: rrlu(a, options),
+        }
+    }
+
+    /// Create from an existing rrLU decomposition
+    pub fn from_rrlu(lu: RrLU<T>) -> Self {
+        Self { lu }
+    }
+
+    /// Get reference to underlying rrLU
+    pub fn lu(&self) -> &RrLU<T> {
+        &self.lu
+    }
+
+    /// Get column matrix: L * U[:, :npivots]
+    pub fn col_matrix(&self) -> Matrix<T> {
+        let l = self.lu.left(true);
+        let u_sub = {
+            let u = self.lu.right(false);
+            let n = self.lu.npivots();
+            let rows: Vec<usize> = (0..n).collect();
+            let cols: Vec<usize> = (0..n).collect();
+            submatrix(&u, &rows, &cols)
+        };
+        mat_mul(&l, &u_sub)
+    }
+
+    /// Get row matrix: L[:npivots, :] * U
+    pub fn row_matrix(&self) -> Matrix<T> {
+        let l_sub = {
+            let l = self.lu.left(false);
+            let n = self.lu.npivots();
+            let rows: Vec<usize> = (0..n).collect();
+            let cols: Vec<usize> = (0..n).collect();
+            submatrix(&l, &rows, &cols)
+        };
+        let u = self.lu.right(true);
+        mat_mul(&l_sub, &u)
+    }
+
+    /// Get cols times pivot inverse
+    pub fn cols_times_pivot_inv(&self) -> Matrix<T> {
+        let n = self.lu.npivots();
+        let nr = self.nrows();
+
+        let mut actual_result = zeros(nr, n);
+
+        // Copy identity part
+        for i in 0..nr.min(n) {
+            actual_result[[i, i]] = T::one();
+        }
+
+        if n < nr {
+            let l = self.lu.left(false);
+            let l_sub = {
+                let rows: Vec<usize> = (n..nrows(&l)).collect();
+                let cols: Vec<usize> = (0..n).collect();
+                submatrix(&l, &rows, &cols)
+            };
+            let l_pivot = {
+                let rows: Vec<usize> = (0..n).collect();
+                let cols: Vec<usize> = (0..n).collect();
+                submatrix(&l, &rows, &cols)
+            };
+
+            // Solve: result[n:, :] = L[n:, :] * L[0:n, 0:n]^{-1}
+            // This is forward substitution
+            for i in 0..(nr - n) {
+                for j in 0..n {
+                    let mut val = l_sub[[i, j]];
+                    for k in 0..j {
+                        val = val - actual_result[[n + i, k]] * l_pivot[[k, j]];
+                    }
+                    let diag = l_pivot[[j, j]];
+                    actual_result[[n + i, j]] = val / diag;
+                }
+            }
+        }
+
+        // Apply row permutation
+        let perm = self.lu.row_permutation();
+        let mut permuted = zeros(nr, n);
+        for (new_i, &old_i) in perm.iter().enumerate() {
+            for j in 0..n {
+                permuted[[old_i, j]] = actual_result[[new_i, j]];
+            }
+        }
+
+        permuted
+    }
+
+    /// Get pivot inverse times rows
+    pub fn pivot_inv_times_rows(&self) -> Matrix<T> {
+        let n = self.lu.npivots();
+        let nc = self.ncols();
+
+        let mut actual_result = zeros(n, nc);
+
+        // Copy identity part
+        for i in 0..n.min(nc) {
+            actual_result[[i, i]] = T::one();
+        }
+
+        if n < nc {
+            let u = self.lu.right(false);
+            let u_sub = {
+                let rows: Vec<usize> = (0..n).collect();
+                let cols: Vec<usize> = (n..ncols(&u)).collect();
+                submatrix(&u, &rows, &cols)
+            };
+            let u_pivot = {
+                let rows: Vec<usize> = (0..n).collect();
+                let cols: Vec<usize> = (0..n).collect();
+                submatrix(&u, &rows, &cols)
+            };
+
+            // Solve: result[:, n:] = U[0:n, 0:n]^{-1} * U[:, n:]
+            // This is back substitution
+            for j in 0..(nc - n) {
+                for i in (0..n).rev() {
+                    let mut val = u_sub[[i, j]];
+                    for k in (i + 1)..n {
+                        val = val - u_pivot[[i, k]] * actual_result[[k, n + j]];
+                    }
+                    let diag = u_pivot[[i, i]];
+                    actual_result[[i, n + j]] = val / diag;
+                }
+            }
+        }
+
+        // Apply column permutation
+        let perm = self.lu.col_permutation();
+        let mut permuted = zeros(n, nc);
+        for i in 0..n {
+            for (new_j, &old_j) in perm.iter().enumerate() {
+                permuted[[i, old_j]] = actual_result[[i, new_j]];
+            }
+        }
+
+        permuted
+    }
+
+    /// Get left matrix for CI representation
+    pub fn left(&self) -> Matrix<T> {
+        if self.lu.is_left_orthogonal() {
+            self.cols_times_pivot_inv()
+        } else {
+            self.col_matrix()
+        }
+    }
+
+    /// Get right matrix for CI representation
+    pub fn right(&self) -> Matrix<T> {
+        if self.lu.is_left_orthogonal() {
+            self.row_matrix()
+        } else {
+            self.pivot_inv_times_rows()
+        }
+    }
+
+    /// Get pivot errors
+    pub fn pivot_errors(&self) -> Vec<f64> {
+        self.lu.pivot_errors()
+    }
+
+    /// Get last pivot error
+    pub fn last_pivot_error(&self) -> f64 {
+        self.lu.last_pivot_error()
+    }
+}
+
+impl<T: Scalar> AbstractMatrixCI<T> for MatrixLUCI<T> {
+    fn nrows(&self) -> usize {
+        self.lu.nrows()
+    }
+
+    fn ncols(&self) -> usize {
+        self.lu.ncols()
+    }
+
+    fn rank(&self) -> usize {
+        self.lu.npivots()
+    }
+
+    fn row_indices(&self) -> &[usize] {
+        // Return slice of row permutation
+        &self.lu.row_permutation()[0..self.rank()]
+    }
+
+    fn col_indices(&self) -> &[usize] {
+        // Return slice of column permutation
+        &self.lu.col_permutation()[0..self.rank()]
+    }
+
+    fn evaluate(&self, i: usize, j: usize) -> T {
+        let left = self.left();
+        let right = self.right();
+
+        let mut sum = T::zero();
+        for k in 0..self.rank() {
+            sum = sum + left[[i, k]] * right[[k, j]];
+        }
+        sum
+    }
+
+    fn submatrix(&self, rows: &[usize], cols: &[usize]) -> Matrix<T> {
+        let left = self.left();
+        let right = self.right();
+
+        let r = self.rank();
+        let left_sub = submatrix(&left, rows, &(0..r).collect::<Vec<_>>());
+        let right_sub = submatrix(&right, &(0..r).collect::<Vec<_>>(), cols);
+
+        mat_mul(&left_sub, &right_sub)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::from_vec2d;
+
+    #[test]
+    fn test_matrixluci_from_matrix() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 10.0],
+        ]);
+
+        let luci = MatrixLUCI::from_matrix(&m, None);
+        assert_eq!(luci.nrows(), 3);
+        assert_eq!(luci.ncols(), 3);
+        assert_eq!(luci.rank(), 3);
+    }
+
+    #[test]
+    fn test_matrixluci_reconstruct() {
+        let m = from_vec2d(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+
+        let luci = MatrixLUCI::from_matrix(&m, None);
+        let approx = luci.to_matrix();
+
+        for i in 0..2 {
+            for j in 0..2 {
+                let diff = (m[[i, j]] - approx[[i, j]]).abs();
+                assert!(
+                    diff < 1e-10,
+                    "Reconstruction error at ({}, {}): {}",
+                    i,
+                    j,
+                    diff
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_matrixluci_rank_deficient() {
+        // Rank-1 matrix
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![2.0, 4.0, 6.0],
+            vec![3.0, 6.0, 9.0],
+        ]);
+
+        let luci = MatrixLUCI::from_matrix(&m, None);
+        assert_eq!(luci.rank(), 1);
+    }
+}

--- a/crates/tensor4all-matrixci/src/traits.rs
+++ b/crates/tensor4all-matrixci/src/traits.rs
@@ -1,0 +1,153 @@
+//! Abstract traits for matrix cross interpolation
+
+use crate::error::Result;
+use crate::util::{submatrix, zeros, Matrix, Scalar};
+
+/// Abstract trait for matrix cross interpolation objects
+///
+/// This trait provides a common interface for different matrix CI implementations
+/// including MatrixCI, MatrixACA, and MatrixLUCI.
+pub trait AbstractMatrixCI<T: Scalar>: Sized {
+    /// Number of rows in the approximated matrix
+    fn nrows(&self) -> usize;
+
+    /// Number of columns in the approximated matrix
+    fn ncols(&self) -> usize;
+
+    /// Current rank of the approximation (number of pivots)
+    fn rank(&self) -> usize;
+
+    /// Row indices selected as pivots (I set)
+    fn row_indices(&self) -> &[usize];
+
+    /// Column indices selected as pivots (J set)
+    fn col_indices(&self) -> &[usize];
+
+    /// Check if the approximation is empty (no pivots)
+    fn is_empty(&self) -> bool {
+        self.rank() == 0
+    }
+
+    /// Evaluate the approximation at position (i, j)
+    fn evaluate(&self, i: usize, j: usize) -> T;
+
+    /// Get a submatrix of the approximation
+    fn submatrix(&self, rows: &[usize], cols: &[usize]) -> Matrix<T>;
+
+    /// Get a row of the approximation
+    fn row(&self, i: usize) -> Vec<T> {
+        let cols: Vec<usize> = (0..self.ncols()).collect();
+        let sub = self.submatrix(&[i], &cols);
+        (0..self.ncols()).map(|j| sub[[0, j]]).collect()
+    }
+
+    /// Get a column of the approximation
+    fn col(&self, j: usize) -> Vec<T> {
+        let rows: Vec<usize> = (0..self.nrows()).collect();
+        let sub = self.submatrix(&rows, &[j]);
+        (0..self.nrows()).map(|i| sub[[i, 0]]).collect()
+    }
+
+    /// Get the full approximated matrix
+    fn to_matrix(&self) -> Matrix<T> {
+        let rows: Vec<usize> = (0..self.nrows()).collect();
+        let cols: Vec<usize> = (0..self.ncols()).collect();
+        self.submatrix(&rows, &cols)
+    }
+
+    /// Get available row indices (rows without pivots)
+    fn available_rows(&self) -> Vec<usize> {
+        let pivot_rows: std::collections::HashSet<usize> =
+            self.row_indices().iter().copied().collect();
+        (0..self.nrows())
+            .filter(|i| !pivot_rows.contains(i))
+            .collect()
+    }
+
+    /// Get available column indices (columns without pivots)
+    fn available_cols(&self) -> Vec<usize> {
+        let pivot_cols: std::collections::HashSet<usize> =
+            self.col_indices().iter().copied().collect();
+        (0..self.ncols())
+            .filter(|j| !pivot_cols.contains(j))
+            .collect()
+    }
+
+    /// Compute local error |A - CI| for given indices
+    fn local_error(&self, a: &Matrix<T>, rows: &[usize], cols: &[usize]) -> Matrix<T>
+    where
+        T: std::ops::Sub<Output = T>,
+    {
+        let sub_a = submatrix(a, rows, cols);
+        let sub_ci = self.submatrix(rows, cols);
+
+        let mut result = zeros(rows.len(), cols.len());
+        for i in 0..rows.len() {
+            for j in 0..cols.len() {
+                let diff = sub_a[[i, j]] - sub_ci[[i, j]];
+                result[[i, j]] = diff.abs();
+            }
+        }
+        result
+    }
+
+    /// Find a new pivot that maximizes the local error
+    fn find_new_pivot(&self, a: &Matrix<T>) -> Result<((usize, usize), T)>
+    where
+        T: std::ops::Sub<Output = T>,
+    {
+        let avail_rows = self.available_rows();
+        let avail_cols = self.available_cols();
+
+        self.find_new_pivot_in(a, &avail_rows, &avail_cols)
+    }
+
+    /// Find a new pivot in the given row/column subsets
+    fn find_new_pivot_in(
+        &self,
+        a: &Matrix<T>,
+        rows: &[usize],
+        cols: &[usize],
+    ) -> Result<((usize, usize), T)>
+    where
+        T: std::ops::Sub<Output = T>,
+    {
+        use crate::error::MatrixCIError;
+
+        if self.rank() == self.nrows().min(self.ncols()) {
+            return Err(MatrixCIError::FullRank);
+        }
+
+        if rows.is_empty() {
+            return Err(MatrixCIError::EmptyIndexSet {
+                dimension: "rows".to_string(),
+            });
+        }
+
+        if cols.is_empty() {
+            return Err(MatrixCIError::EmptyIndexSet {
+                dimension: "cols".to_string(),
+            });
+        }
+
+        let errors = self.local_error(a, rows, cols);
+
+        // Find maximum error position (comparing by abs_sq which returns f64)
+        let mut max_val_sq: f64 = errors[[0, 0]].abs_sq();
+        let mut max_i = 0;
+        let mut max_j = 0;
+
+        for i in 0..rows.len() {
+            for j in 0..cols.len() {
+                let val_sq: f64 = errors[[i, j]].abs_sq();
+                if val_sq > max_val_sq {
+                    max_val_sq = val_sq;
+                    max_i = i;
+                    max_j = j;
+                }
+            }
+        }
+
+        Ok(((rows[max_i], cols[max_j]), errors[[max_i, max_j]]))
+    }
+}

--- a/crates/tensor4all-matrixci/src/util.rs
+++ b/crates/tensor4all-matrixci/src/util.rs
@@ -1,0 +1,515 @@
+//! Utility functions for matrix cross interpolation
+
+use num_traits::{Float, Zero, One};
+use rand::seq::SliceRandom;
+use rand::Rng;
+use std::collections::HashSet;
+use std::ops::{Index, IndexMut};
+
+/// Simple 2D matrix backed by Vec
+#[derive(Debug, Clone)]
+pub struct Matrix<T> {
+    data: Vec<T>,
+    nrows: usize,
+    ncols: usize,
+}
+
+impl<T: Clone> Matrix<T> {
+    /// Create a new matrix from dimensions and initial value
+    pub fn from_elem(nrows: usize, ncols: usize, elem: T) -> Self {
+        Self {
+            data: vec![elem; nrows * ncols],
+            nrows,
+            ncols,
+        }
+    }
+
+    /// Number of rows
+    pub fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    /// Number of columns
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+}
+
+impl<T: Clone + Zero> Matrix<T> {
+    /// Create a zeros matrix
+    pub fn zeros(nrows: usize, ncols: usize) -> Self {
+        Self {
+            data: vec![T::zero(); nrows * ncols],
+            nrows,
+            ncols,
+        }
+    }
+}
+
+impl<T> Index<[usize; 2]> for Matrix<T> {
+    type Output = T;
+
+    fn index(&self, idx: [usize; 2]) -> &Self::Output {
+        &self.data[idx[0] * self.ncols + idx[1]]
+    }
+}
+
+impl<T> IndexMut<[usize; 2]> for Matrix<T> {
+    fn index_mut(&mut self, idx: [usize; 2]) -> &mut Self::Output {
+        &mut self.data[idx[0] * self.ncols + idx[1]]
+    }
+}
+
+/// Create a zeros matrix with given dimensions
+pub fn zeros<T: Clone + Zero>(nrows: usize, ncols: usize) -> Matrix<T> {
+    Matrix::zeros(nrows, ncols)
+}
+
+/// Create an identity matrix
+pub fn eye<T: Clone + Zero + One>(n: usize) -> Matrix<T> {
+    let mut m = zeros(n, n);
+    for i in 0..n {
+        m[[i, i]] = T::one();
+    }
+    m
+}
+
+/// Create a matrix from a 2D vector (row-major)
+pub fn from_vec2d<T: Clone + Zero>(data: Vec<Vec<T>>) -> Matrix<T> {
+    let nrows = data.len();
+    let ncols = if nrows > 0 { data[0].len() } else { 0 };
+    let mut m = zeros(nrows, ncols);
+    for i in 0..nrows {
+        for j in 0..ncols {
+            m[[i, j]] = data[i][j].clone();
+        }
+    }
+    m
+}
+
+/// Get number of rows
+pub fn nrows<T>(m: &Matrix<T>) -> usize {
+    m.nrows
+}
+
+/// Get number of columns
+pub fn ncols<T>(m: &Matrix<T>) -> usize {
+    m.ncols
+}
+
+/// Get a row as a vector
+pub fn get_row<T: Clone>(m: &Matrix<T>, i: usize) -> Vec<T> {
+    (0..m.ncols).map(|j| m[[i, j]].clone()).collect()
+}
+
+/// Get a column as a vector
+pub fn get_col<T: Clone>(m: &Matrix<T>, j: usize) -> Vec<T> {
+    (0..m.nrows).map(|i| m[[i, j]].clone()).collect()
+}
+
+/// Get a submatrix by selecting specific rows and columns
+pub fn submatrix<T: Clone + Zero>(m: &Matrix<T>, rows: &[usize], cols: &[usize]) -> Matrix<T> {
+    let mut result = zeros(rows.len(), cols.len());
+    for (ri, &r) in rows.iter().enumerate() {
+        for (ci, &c) in cols.iter().enumerate() {
+            result[[ri, ci]] = m[[r, c]].clone();
+        }
+    }
+    result
+}
+
+/// Append a column to the right of a matrix
+pub fn append_col<T: Clone + Zero>(m: &Matrix<T>, col: &[T]) -> Matrix<T> {
+    let nr = m.nrows;
+    let nc = m.ncols;
+    assert_eq!(col.len(), nr);
+
+    let mut result = zeros(nr, nc + 1);
+    for i in 0..nr {
+        for j in 0..nc {
+            result[[i, j]] = m[[i, j]].clone();
+        }
+        result[[i, nc]] = col[i].clone();
+    }
+    result
+}
+
+/// Append a row to the bottom of a matrix
+pub fn append_row<T: Clone + Zero>(m: &Matrix<T>, row: &[T]) -> Matrix<T> {
+    let nr = m.nrows;
+    let nc = m.ncols;
+    assert_eq!(row.len(), nc);
+
+    let mut result = zeros(nr + 1, nc);
+    for i in 0..nr {
+        for j in 0..nc {
+            result[[i, j]] = m[[i, j]].clone();
+        }
+    }
+    for j in 0..nc {
+        result[[nr, j]] = row[j].clone();
+    }
+    result
+}
+
+/// Swap two rows in a matrix (in-place style, returns new matrix)
+pub fn swap_rows<T: Clone + Zero>(m: &Matrix<T>, a: usize, b: usize) -> Matrix<T> {
+    if a == b {
+        return m.clone();
+    }
+    let mut result = m.clone();
+    for j in 0..m.ncols {
+        let tmp = result[[a, j]].clone();
+        result[[a, j]] = result[[b, j]].clone();
+        result[[b, j]] = tmp;
+    }
+    result
+}
+
+/// Swap two columns in a matrix (in-place style, returns new matrix)
+pub fn swap_cols<T: Clone + Zero>(m: &Matrix<T>, a: usize, b: usize) -> Matrix<T> {
+    if a == b {
+        return m.clone();
+    }
+    let mut result = m.clone();
+    for i in 0..m.nrows {
+        let tmp = result[[i, a]].clone();
+        result[[i, a]] = result[[i, b]].clone();
+        result[[i, b]] = tmp;
+    }
+    result
+}
+
+/// Transpose the matrix
+pub fn transpose<T: Clone + Zero>(m: &Matrix<T>) -> Matrix<T> {
+    let mut result = zeros(m.ncols, m.nrows);
+    for i in 0..m.nrows {
+        for j in 0..m.ncols {
+            result[[j, i]] = m[[i, j]].clone();
+        }
+    }
+    result
+}
+
+/// Trait for scalar types used in matrix operations
+pub trait Scalar:
+    Clone
+    + Copy
+    + Zero
+    + One
+    + std::ops::Add<Output = Self>
+    + std::ops::Sub<Output = Self>
+    + std::ops::Mul<Output = Self>
+    + std::ops::Div<Output = Self>
+    + std::ops::Neg<Output = Self>
+    + Send
+    + Sync
+    + 'static
+{
+    /// Absolute value
+    fn abs(self) -> Self;
+
+    /// Square of absolute value (for complex numbers, |z|^2)
+    fn abs_sq(self) -> f64;
+
+    /// Check if value is NaN
+    fn is_nan(self) -> bool;
+
+    /// Small epsilon value for numerical comparisons
+    fn epsilon() -> f64 {
+        1e-30
+    }
+}
+
+impl Scalar for f64 {
+    fn abs(self) -> Self {
+        Float::abs(self)
+    }
+
+    fn abs_sq(self) -> f64 {
+        self * self
+    }
+
+    fn is_nan(self) -> bool {
+        Float::is_nan(self)
+    }
+}
+
+impl Scalar for f32 {
+    fn abs(self) -> Self {
+        Float::abs(self)
+    }
+
+    fn abs_sq(self) -> f64 {
+        (self * self) as f64
+    }
+
+    fn is_nan(self) -> bool {
+        Float::is_nan(self)
+    }
+}
+
+impl Scalar for num_complex::Complex64 {
+    fn abs(self) -> Self {
+        num_complex::Complex64::new(self.norm(), 0.0)
+    }
+
+    fn abs_sq(self) -> f64 {
+        self.norm_sqr()
+    }
+
+    fn is_nan(self) -> bool {
+        self.re.is_nan() || self.im.is_nan()
+    }
+}
+
+impl Scalar for num_complex::Complex32 {
+    fn abs(self) -> Self {
+        num_complex::Complex32::new(self.norm(), 0.0)
+    }
+
+    fn abs_sq(self) -> f64 {
+        self.norm_sqr() as f64
+    }
+
+    fn is_nan(self) -> bool {
+        self.re.is_nan() || self.im.is_nan()
+    }
+}
+
+/// Calculates A * B^{-1} using Gaussian elimination for numerical stability.
+pub fn a_times_b_inv<T: Scalar>(a: &Matrix<T>, b: &Matrix<T>) -> Matrix<T> {
+    let n = ncols(a);
+    assert_eq!(nrows(b), n);
+    assert_eq!(ncols(b), n);
+
+    // Solve XB = A by solving B'X' = A'
+    let bt = transpose(b);
+    let at = transpose(a);
+    let xt = solve_linear_system(&bt, &at);
+    transpose(&xt)
+}
+
+/// Calculates A^{-1} * B using Gaussian elimination for numerical stability.
+pub fn a_inv_times_b<T: Scalar>(a: &Matrix<T>, b: &Matrix<T>) -> Matrix<T> {
+    let bt = transpose(b);
+    let at = transpose(a);
+    let result = a_times_b_inv(&bt, &at);
+    transpose(&result)
+}
+
+/// Solve linear system AX = B using Gaussian elimination with partial pivoting
+#[allow(clippy::needless_range_loop)]
+fn solve_linear_system<T: Scalar>(a: &Matrix<T>, b: &Matrix<T>) -> Matrix<T> {
+    let n = nrows(a);
+    assert_eq!(ncols(a), n);
+    assert_eq!(nrows(b), n);
+    let m = ncols(b);
+
+    // Create augmented matrix [A | B]
+    let mut aug: Vec<Vec<T>> = (0..n).map(|i| {
+        let mut row = Vec::with_capacity(n + m);
+        for j in 0..n {
+            row.push(a[[i, j]]);
+        }
+        for j in 0..m {
+            row.push(b[[i, j]]);
+        }
+        row
+    }).collect();
+
+    // Forward elimination with partial pivoting
+    for k in 0..n {
+        // Find pivot
+        let mut max_idx = k;
+        let mut max_val: f64 = aug[k][k].abs_sq();
+        for i in (k + 1)..n {
+            let val: f64 = aug[i][k].abs_sq();
+            if val > max_val {
+                max_val = val;
+                max_idx = i;
+            }
+        }
+
+        // Swap rows
+        if max_idx != k {
+            aug.swap(k, max_idx);
+        }
+
+        let pivot = aug[k][k];
+        if pivot.abs_sq() < T::epsilon() {
+            continue;
+        }
+
+        // Eliminate below
+        for i in (k + 1)..n {
+            let factor = aug[i][k] / pivot;
+            for j in k..(n + m) {
+                aug[i][j] = aug[i][j] - factor * aug[k][j];
+            }
+        }
+    }
+
+    // Back substitution
+    let mut x: Vec<Vec<T>> = vec![vec![T::zero(); m]; n];
+    for i in (0..n).rev() {
+        for j in 0..m {
+            let mut sum = aug[i][n + j];
+            for k in (i + 1)..n {
+                sum = sum - aug[i][k] * x[k][j];
+            }
+            let diag = aug[i][i];
+            if diag.abs_sq() > T::epsilon() {
+                x[i][j] = sum / diag;
+            }
+        }
+    }
+
+    from_vec2d(x)
+}
+
+/// Find the position of maximum absolute value in a submatrix
+pub fn submatrix_argmax<T: Scalar>(
+    a: &Matrix<T>,
+    rows: &[usize],
+    cols: &[usize],
+) -> (usize, usize, T) {
+    assert!(!rows.is_empty(), "rows must not be empty");
+    assert!(!cols.is_empty(), "cols must not be empty");
+
+    let mut max_val: f64 = a[[rows[0], cols[0]]].abs_sq();
+    let mut max_row = rows[0];
+    let mut max_col = cols[0];
+
+    for &r in rows {
+        for &c in cols {
+            let val: f64 = a[[r, c]].abs_sq();
+            if val > max_val {
+                max_val = val;
+                max_row = r;
+                max_col = c;
+            }
+        }
+    }
+
+    (max_row, max_col, a[[max_row, max_col]])
+}
+
+/// Select a random subset of elements from a set
+pub fn random_subset<T: Clone, R: Rng>(set: &[T], n: usize, rng: &mut R) -> Vec<T> {
+    let n = n.min(set.len());
+    if n == 0 {
+        return Vec::new();
+    }
+
+    let mut indices: Vec<usize> = (0..set.len()).collect();
+    indices.shuffle(rng);
+    indices.truncate(n);
+    indices.into_iter().map(|i| set[i].clone()).collect()
+}
+
+/// Set difference: elements in `set` that are not in `exclude`
+pub fn set_diff(set: &[usize], exclude: &[usize]) -> Vec<usize> {
+    let exclude_set: HashSet<usize> = exclude.iter().copied().collect();
+    set.iter()
+        .copied()
+        .filter(|x| !exclude_set.contains(x))
+        .collect()
+}
+
+/// Dot product of two vectors
+pub fn dot<T: Scalar>(a: &[T], b: &[T]) -> T {
+    assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b.iter())
+        .fold(T::zero(), |acc, (&x, &y)| acc + x * y)
+}
+
+/// Matrix multiplication: A * B
+pub fn mat_mul<T: Scalar>(a: &Matrix<T>, b: &Matrix<T>) -> Matrix<T> {
+    let m = nrows(a);
+    let k = ncols(a);
+    let n = ncols(b);
+    assert_eq!(nrows(b), k);
+
+    let mut result = zeros(m, n);
+    for i in 0..m {
+        for j in 0..n {
+            let mut sum = T::zero();
+            for l in 0..k {
+                sum = sum + a[[i, l]] * b[[l, j]];
+            }
+            result[[i, j]] = sum;
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matrix_basic() {
+        let mut m = zeros::<f64>(3, 3);
+        m[[0, 0]] = 1.0;
+        m[[1, 1]] = 2.0;
+        m[[2, 2]] = 3.0;
+
+        assert_eq!(m[[0, 0]], 1.0);
+        assert_eq!(m[[1, 1]], 2.0);
+        assert_eq!(m[[2, 2]], 3.0);
+    }
+
+    #[test]
+    fn test_matrix_transpose() {
+        let m = from_vec2d(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+        let mt = transpose(&m);
+
+        assert_eq!(nrows(&mt), 3);
+        assert_eq!(ncols(&mt), 2);
+        assert_eq!(mt[[0, 0]], 1.0);
+        assert_eq!(mt[[0, 1]], 4.0);
+        assert_eq!(mt[[2, 0]], 3.0);
+    }
+
+    #[test]
+    fn test_submatrix_argmax() {
+        let m = from_vec2d(vec![
+            vec![1.0, 2.0, 3.0],
+            vec![4.0, 5.0, 6.0],
+            vec![7.0, 8.0, 9.0],
+        ]);
+
+        let rows: Vec<usize> = vec![0, 1, 2];
+        let cols: Vec<usize> = vec![0, 1, 2];
+        let (r, c, _) = submatrix_argmax(&m, &rows, &cols);
+        assert_eq!((r, c), (2, 2));
+    }
+
+    #[test]
+    fn test_set_diff() {
+        let set = vec![1, 2, 3, 4, 5];
+        let exclude = vec![2, 4];
+        let diff = set_diff(&set, &exclude);
+        assert_eq!(diff, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn test_mat_mul() {
+        let a = from_vec2d(vec![
+            vec![1.0, 2.0],
+            vec![3.0, 4.0],
+        ]);
+        let b = from_vec2d(vec![
+            vec![5.0, 6.0],
+            vec![7.0, 8.0],
+        ]);
+        let c = mat_mul(&a, &b);
+
+        assert_eq!(c[[0, 0]], 19.0);
+        assert_eq!(c[[0, 1]], 22.0);
+        assert_eq!(c[[1, 0]], 43.0);
+        assert_eq!(c[[1, 1]], 50.0);
+    }
+}

--- a/crates/tensor4all-tensorci/Cargo.toml
+++ b/crates/tensor4all-tensorci/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "tensor4all-tensorci"
+description = "Tensor Cross Interpolation algorithms for tensor4all"
+version.workspace = true
+edition.workspace = true
+authors = ["Marc Ritter <Ritter.Marc@physik.uni-muenchen.de>", "Hiroshi Shinaoka <h.shinaoka@gmail.com>", "tensor4all contributors"]
+license = "MIT"
+repository.workspace = true
+
+[dependencies]
+num-complex.workspace = true
+num-traits.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+rand.workspace = true
+tensor4all-matrixci = { path = "../tensor4all-matrixci" }
+tensor4all-tensortrain = { path = "../tensor4all-tensortrain" }
+
+[dev-dependencies]
+approx = "0.5"

--- a/crates/tensor4all-tensorci/src/cached_function.rs
+++ b/crates/tensor4all-tensorci/src/cached_function.rs
@@ -1,0 +1,149 @@
+//! Cached function wrapper for expensive function evaluations
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// A wrapper that caches function evaluations
+///
+/// This is useful when the function to be interpolated is expensive to evaluate.
+#[derive(Debug)]
+pub struct CachedFunction<K, V, F>
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+    F: Fn(&K) -> V,
+{
+    /// The underlying function
+    func: F,
+    /// Cache of evaluated values
+    cache: HashMap<K, V>,
+    /// Number of evaluations
+    num_evals: usize,
+    /// Number of cache hits
+    num_cache_hits: usize,
+}
+
+impl<K, V, F> CachedFunction<K, V, F>
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+    F: Fn(&K) -> V,
+{
+    /// Create a new cached function wrapper
+    pub fn new(func: F) -> Self {
+        Self {
+            func,
+            cache: HashMap::new(),
+            num_evals: 0,
+            num_cache_hits: 0,
+        }
+    }
+
+    /// Evaluate the function at a given key, using cache if available
+    pub fn eval(&mut self, key: &K) -> V {
+        if let Some(value) = self.cache.get(key) {
+            self.num_cache_hits += 1;
+            return value.clone();
+        }
+
+        self.num_evals += 1;
+        let value = (self.func)(key);
+        self.cache.insert(key.clone(), value.clone());
+        value
+    }
+
+    /// Evaluate the function at a given key, bypassing the cache
+    pub fn eval_no_cache(&self, key: &K) -> V {
+        (self.func)(key)
+    }
+
+    /// Get the number of actual function evaluations
+    pub fn num_evals(&self) -> usize {
+        self.num_evals
+    }
+
+    /// Get the number of cache hits
+    pub fn num_cache_hits(&self) -> usize {
+        self.num_cache_hits
+    }
+
+    /// Get the total number of calls (evals + cache hits)
+    pub fn total_calls(&self) -> usize {
+        self.num_evals + self.num_cache_hits
+    }
+
+    /// Get the cache hit ratio
+    pub fn cache_hit_ratio(&self) -> f64 {
+        let total = self.total_calls();
+        if total == 0 {
+            0.0
+        } else {
+            self.num_cache_hits as f64 / total as f64
+        }
+    }
+
+    /// Clear the cache
+    pub fn clear_cache(&mut self) {
+        self.cache.clear();
+    }
+
+    /// Get the number of cached entries
+    pub fn cache_size(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Check if a key is cached
+    pub fn is_cached(&self, key: &K) -> bool {
+        self.cache.contains_key(key)
+    }
+
+    /// Get a cached value without counting as a hit
+    pub fn get_cached(&self, key: &K) -> Option<&V> {
+        self.cache.get(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cached_function_basic() {
+        let mut cf = CachedFunction::new(|x: &i32| x * x);
+
+        assert_eq!(cf.eval(&5), 25);
+        assert_eq!(cf.num_evals(), 1);
+        assert_eq!(cf.num_cache_hits(), 0);
+
+        // Second call should use cache
+        assert_eq!(cf.eval(&5), 25);
+        assert_eq!(cf.num_evals(), 1);
+        assert_eq!(cf.num_cache_hits(), 1);
+
+        // Different key
+        assert_eq!(cf.eval(&3), 9);
+        assert_eq!(cf.num_evals(), 2);
+        assert_eq!(cf.num_cache_hits(), 1);
+    }
+
+    #[test]
+    fn test_cached_function_vec_key() {
+        let mut cf = CachedFunction::new(|x: &Vec<usize>| x.iter().sum::<usize>());
+
+        assert_eq!(cf.eval(&vec![1, 2, 3]), 6);
+        assert_eq!(cf.eval(&vec![1, 2, 3]), 6);
+        assert_eq!(cf.num_evals(), 1);
+        assert_eq!(cf.num_cache_hits(), 1);
+    }
+
+    #[test]
+    fn test_cached_function_clear() {
+        let mut cf = CachedFunction::new(|x: &i32| *x);
+        cf.eval(&1);
+        cf.eval(&2);
+        assert_eq!(cf.cache_size(), 2);
+
+        cf.clear_cache();
+        assert_eq!(cf.cache_size(), 0);
+    }
+}

--- a/crates/tensor4all-tensorci/src/error.rs
+++ b/crates/tensor4all-tensorci/src/error.rs
@@ -1,0 +1,42 @@
+//! Error types for tensor cross interpolation operations
+
+use thiserror::Error;
+
+/// Result type for TCI operations
+pub type Result<T> = std::result::Result<T, TCIError>;
+
+/// Errors that can occur during tensor cross interpolation operations
+#[derive(Error, Debug)]
+pub enum TCIError {
+    /// Dimension mismatch
+    #[error("Dimension mismatch: {message}")]
+    DimensionMismatch { message: String },
+
+    /// Invalid index
+    #[error("Index out of bounds: {message}")]
+    IndexOutOfBounds { message: String },
+
+    /// Invalid pivot
+    #[error("Invalid pivot: {message}")]
+    InvalidPivot { message: String },
+
+    /// Convergence failure
+    #[error("Failed to converge after {iterations} iterations")]
+    ConvergenceFailure { iterations: usize },
+
+    /// Empty tensor train
+    #[error("Empty tensor structure")]
+    Empty,
+
+    /// Invalid operation
+    #[error("Invalid operation: {message}")]
+    InvalidOperation { message: String },
+
+    /// Matrix CI error
+    #[error("Matrix CI error: {0}")]
+    MatrixCIError(#[from] tensor4all_matrixci::MatrixCIError),
+
+    /// Tensor train error
+    #[error("Tensor train error: {0}")]
+    TensorTrainError(#[from] tensor4all_tensortrain::TensorTrainError),
+}

--- a/crates/tensor4all-tensorci/src/indexset.rs
+++ b/crates/tensor4all-tensorci/src/indexset.rs
@@ -1,0 +1,164 @@
+//! Index set for managing multi-indices with bidirectional lookup
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// A bidirectional index set for efficient lookup
+///
+/// Provides O(1) lookup from integer index to value and from value to integer index.
+#[derive(Debug, Clone)]
+pub struct IndexSet<T: Clone + Eq + Hash> {
+    /// Map from value to integer index
+    to_int: HashMap<T, usize>,
+    /// Map from integer index to value
+    from_int: Vec<T>,
+}
+
+impl<T: Clone + Eq + Hash> Default for IndexSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Clone + Eq + Hash> IndexSet<T> {
+    /// Create an empty index set
+    pub fn new() -> Self {
+        Self {
+            to_int: HashMap::new(),
+            from_int: Vec::new(),
+        }
+    }
+
+    /// Create an index set from a vector
+    pub fn from_vec(values: Vec<T>) -> Self {
+        let to_int: HashMap<T, usize> = values
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (v.clone(), i))
+            .collect();
+        Self {
+            to_int,
+            from_int: values,
+        }
+    }
+
+    /// Get the value at integer index
+    pub fn get(&self, i: usize) -> Option<&T> {
+        self.from_int.get(i)
+    }
+
+    /// Get the integer position of a value
+    pub fn pos(&self, value: &T) -> Option<usize> {
+        self.to_int.get(value).copied()
+    }
+
+    /// Get positions for a slice of values
+    pub fn positions(&self, values: &[T]) -> Option<Vec<usize>> {
+        values.iter().map(|v| self.pos(v)).collect()
+    }
+
+    /// Push a new value to the set
+    pub fn push(&mut self, value: T) {
+        let idx = self.from_int.len();
+        self.from_int.push(value.clone());
+        self.to_int.insert(value, idx);
+    }
+
+    /// Check if the set contains a value
+    pub fn contains(&self, value: &T) -> bool {
+        self.to_int.contains_key(value)
+    }
+
+    /// Number of elements in the set
+    pub fn len(&self) -> usize {
+        self.from_int.len()
+    }
+
+    /// Check if the set is empty
+    pub fn is_empty(&self) -> bool {
+        self.from_int.is_empty()
+    }
+
+    /// Iterate over values
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.from_int.iter()
+    }
+
+    /// Get all values as a slice
+    pub fn values(&self) -> &[T] {
+        &self.from_int
+    }
+}
+
+impl<T: Clone + Eq + Hash> std::ops::Index<usize> for IndexSet<T> {
+    type Output = T;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.from_int[i]
+    }
+}
+
+impl<T: Clone + Eq + Hash> IntoIterator for IndexSet<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.from_int.into_iter()
+    }
+}
+
+impl<'a, T: Clone + Eq + Hash> IntoIterator for &'a IndexSet<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.from_int.iter()
+    }
+}
+
+/// MultiIndex type alias
+pub type MultiIndex = Vec<usize>;
+
+/// LocalIndex type alias
+pub type LocalIndex = usize;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_indexset_basic() {
+        let mut set: IndexSet<Vec<usize>> = IndexSet::new();
+        set.push(vec![1, 2, 3]);
+        set.push(vec![4, 5, 6]);
+
+        assert_eq!(set.len(), 2);
+        assert_eq!(set.get(0), Some(&vec![1, 2, 3]));
+        assert_eq!(set.pos(&vec![1, 2, 3]), Some(0));
+        assert_eq!(set.pos(&vec![4, 5, 6]), Some(1));
+        assert_eq!(set.pos(&vec![7, 8, 9]), None);
+    }
+
+    #[test]
+    fn test_indexset_from_vec() {
+        let set = IndexSet::from_vec(vec![vec![1], vec![2], vec![3]]);
+        assert_eq!(set.len(), 3);
+        assert_eq!(set[0], vec![1]);
+        assert_eq!(set[2], vec![3]);
+    }
+
+    #[test]
+    fn test_indexset_contains() {
+        let set = IndexSet::from_vec(vec![1, 2, 3]);
+        assert!(set.contains(&1));
+        assert!(set.contains(&3));
+        assert!(!set.contains(&4));
+    }
+
+    #[test]
+    fn test_indexset_iter() {
+        let set = IndexSet::from_vec(vec![10, 20, 30]);
+        let collected: Vec<_> = set.iter().copied().collect();
+        assert_eq!(collected, vec![10, 20, 30]);
+    }
+}

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -1,0 +1,36 @@
+//! Tensor Cross Interpolation (TCI) library
+//!
+//! This crate provides tensor cross interpolation algorithms for efficiently
+//! approximating high-dimensional tensors as tensor trains.
+//!
+//! # Main algorithms
+//!
+//! - `TensorCI1`: One-site TCI algorithm
+//! - `crossinterpolate1`: Function to perform TCI1 interpolation
+//!
+//! # Example
+//!
+//! ```
+//! use tensor4all_tensorci::{crossinterpolate1, TCI1Options};
+//!
+//! // Function to interpolate: f(i, j) = i + j + 1
+//! let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
+//! let local_dims = vec![4, 4];
+//! let first_pivot = vec![1, 1];
+//!
+//! let (tci, ranks, errors) = crossinterpolate1(f, local_dims, first_pivot, TCI1Options::default()).unwrap();
+//! println!("TCI rank: {}", tci.rank());
+//! ```
+
+pub mod cached_function;
+pub mod error;
+pub mod indexset;
+pub mod tensorci1;
+pub mod tensorci2;
+
+// Re-export main types
+pub use cached_function::CachedFunction;
+pub use error::{Result, TCIError};
+pub use indexset::{IndexSet, LocalIndex, MultiIndex};
+pub use tensorci1::{crossinterpolate1, SweepStrategy, TCI1Options, TensorCI1};
+pub use tensorci2::{crossinterpolate2, PivotSearchStrategy, TCI2Options, TensorCI2};

--- a/crates/tensor4all-tensorci/src/tensorci1.rs
+++ b/crates/tensor4all-tensorci/src/tensorci1.rs
@@ -1,0 +1,1105 @@
+//! TensorCI1 - One-site Tensor Cross Interpolation algorithm
+
+use crate::error::{Result, TCIError};
+use crate::indexset::{IndexSet, MultiIndex};
+use tensor4all_matrixci::util::{a_times_b_inv, zeros, Matrix, Scalar};
+use tensor4all_matrixci::{AbstractMatrixCI, MatrixACA};
+use tensor4all_tensortrain::{Tensor3, TensorTrain, TTScalar};
+
+/// Sweep strategy for TCI optimization
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SweepStrategy {
+    /// Sweep forward only
+    Forward,
+    /// Sweep backward only
+    Backward,
+    /// Sweep back and forth
+    #[default]
+    BackAndForth,
+}
+
+/// Returns true if this iteration should be a forward sweep
+fn forward_sweep(strategy: SweepStrategy, iter: usize) -> bool {
+    match strategy {
+        SweepStrategy::Forward => true,
+        SweepStrategy::Backward => false,
+        SweepStrategy::BackAndForth => iter % 2 == 1,
+    }
+}
+
+/// Options for TCI1 algorithm
+#[derive(Debug, Clone)]
+pub struct TCI1Options {
+    /// Tolerance for convergence
+    pub tolerance: f64,
+    /// Maximum number of iterations
+    pub max_iter: usize,
+    /// Sweep strategy
+    pub sweep_strategy: SweepStrategy,
+    /// Pivot tolerance (minimum error to add new pivot)
+    pub pivot_tolerance: f64,
+    /// Whether to normalize error by max sample value
+    pub normalize_error: bool,
+    /// Verbosity level
+    pub verbosity: usize,
+}
+
+impl Default for TCI1Options {
+    fn default() -> Self {
+        Self {
+            tolerance: 1e-8,
+            max_iter: 200,
+            sweep_strategy: SweepStrategy::BackAndForth,
+            pivot_tolerance: 1e-12,
+            normalize_error: true,
+            verbosity: 0,
+        }
+    }
+}
+
+/// TensorCI1 - One-site Tensor Cross Interpolation
+///
+/// Represents a tensor train constructed using the TCI1 algorithm.
+#[derive(Debug, Clone)]
+pub struct TensorCI1<T: Scalar + TTScalar> {
+    /// Index sets I for each site
+    i_set: Vec<IndexSet<MultiIndex>>,
+    /// Index sets J for each site
+    j_set: Vec<IndexSet<MultiIndex>>,
+    /// Local dimensions
+    local_dims: Vec<usize>,
+    /// T tensors (3-leg tensors)
+    t_tensors: Vec<Tensor3<T>>,
+    /// P matrices (pivot matrices)
+    p_matrices: Vec<Matrix<T>>,
+    /// ACA decompositions at each bond
+    aca: Vec<MatrixACA<T>>,
+    /// Pi matrices at each bond
+    pi: Vec<Matrix<T>>,
+    /// Pi I sets
+    pi_i_set: Vec<IndexSet<MultiIndex>>,
+    /// Pi J sets
+    pi_j_set: Vec<IndexSet<MultiIndex>>,
+    /// Pivot errors at each bond
+    pivot_errors: Vec<f64>,
+    /// Maximum sample value found
+    max_sample_value: f64,
+}
+
+impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
+    /// Create a new empty TensorCI1
+    pub fn new(local_dims: Vec<usize>) -> Self {
+        let n = local_dims.len();
+        Self {
+            i_set: (0..n).map(|_| IndexSet::new()).collect(),
+            j_set: (0..n).map(|_| IndexSet::new()).collect(),
+            local_dims: local_dims.clone(),
+            t_tensors: local_dims.iter().map(|&d| Tensor3::zeros(0, d, 0)).collect(),
+            p_matrices: (0..n).map(|_| zeros(0, 0)).collect(),
+            aca: (0..n).map(|_| MatrixACA::new(0, 0)).collect(),
+            pi: (0..n).map(|_| zeros(0, 0)).collect(),
+            pi_i_set: (0..n).map(|_| IndexSet::new()).collect(),
+            pi_j_set: (0..n).map(|_| IndexSet::new()).collect(),
+            pivot_errors: vec![f64::INFINITY; n.saturating_sub(1)],
+            max_sample_value: 0.0,
+        }
+    }
+
+    /// Number of sites
+    pub fn len(&self) -> usize {
+        self.t_tensors.len()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.t_tensors.is_empty()
+    }
+
+    /// Get local dimensions
+    pub fn local_dims(&self) -> &[usize] {
+        &self.local_dims
+    }
+
+    /// Get current rank (maximum bond dimension)
+    pub fn rank(&self) -> usize {
+        if self.t_tensors.len() <= 1 {
+            return if self.i_set.is_empty() || self.i_set[0].is_empty() { 0 } else { 1 };
+        }
+        self.t_tensors
+            .iter()
+            .skip(1)
+            .map(|t| t.left_dim())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Get bond dimensions
+    pub fn link_dims(&self) -> Vec<usize> {
+        if self.t_tensors.len() <= 1 {
+            return Vec::new();
+        }
+        self.t_tensors.iter().skip(1).map(|t| t.left_dim()).collect()
+    }
+
+    /// Get the maximum pivot error from the last sweep
+    pub fn last_sweep_pivot_error(&self) -> f64 {
+        self.pivot_errors.iter().cloned().fold(0.0, f64::max)
+    }
+
+    /// Get site tensor at position p (T * P^{-1})
+    pub fn site_tensor(&self, p: usize) -> Tensor3<T> {
+        if p >= self.len() {
+            return Tensor3::zeros(1, 1, 1);
+        }
+
+        let t = &self.t_tensors[p];
+        let shape = (t.left_dim(), t.site_dim(), t.right_dim());
+
+        // If empty, return identity-like tensor
+        if shape.0 == 0 || shape.2 == 0 {
+            return t.clone();
+        }
+
+        // Compute T * P^{-1}
+        let t_mat = tensor3_to_matrix(t);
+        let p_mat = &self.p_matrices[p];
+
+        if p_mat.nrows() == 0 || p_mat.ncols() == 0 {
+            return self.t_tensors[p].clone();
+        }
+
+        let result = a_times_b_inv(&t_mat, p_mat);
+        matrix_to_tensor3(&result, shape.0, shape.1, shape.2)
+    }
+
+    /// Get all site tensors
+    pub fn site_tensors(&self) -> Vec<Tensor3<T>> {
+        (0..self.len()).map(|p| self.site_tensor(p)).collect()
+    }
+
+    /// Convert to TensorTrain
+    pub fn to_tensor_train(&self) -> Result<TensorTrain<T>> {
+        let tensors = self.site_tensors();
+        TensorTrain::new(tensors).map_err(TCIError::TensorTrainError)
+    }
+
+    /// Get maximum sample value
+    pub fn max_sample_value(&self) -> f64 {
+        self.max_sample_value
+    }
+
+    /// Update maximum sample value from a slice of values
+    fn update_max_sample(&mut self, values: &[T]) {
+        for v in values {
+            let abs_val = f64::sqrt(Scalar::abs_sq(*v));
+            if abs_val > self.max_sample_value {
+                self.max_sample_value = abs_val;
+            }
+        }
+    }
+
+    /// Update maximum sample value from a matrix
+    fn update_max_sample_matrix(&mut self, mat: &Matrix<T>) {
+        for i in 0..mat.nrows() {
+            for j in 0..mat.ncols() {
+                let abs_val = f64::sqrt(Scalar::abs_sq(mat[[i, j]]));
+                if abs_val > self.max_sample_value {
+                    self.max_sample_value = abs_val;
+                }
+            }
+        }
+    }
+
+    /// Evaluate the TCI at a specific set of indices
+    #[allow(clippy::needless_range_loop)]
+    pub fn evaluate(&self, indices: &[usize]) -> Result<T> {
+        if indices.len() != self.len() {
+            return Err(TCIError::DimensionMismatch {
+                message: format!(
+                    "Index length ({}) must match number of sites ({})",
+                    indices.len(),
+                    self.len()
+                ),
+            });
+        }
+
+        if self.is_empty() {
+            return Err(TCIError::Empty);
+        }
+
+        // Check rank
+        if self.rank() == 0 {
+            return Err(TCIError::Empty);
+        }
+
+        // Evaluate by contracting site tensors
+        // For each site p, compute T[p][:, indices[p], :] * P[p]^{-1}
+        let mut result = {
+            let t = &self.t_tensors[0];
+            let idx = indices[0];
+            if idx >= t.site_dim() {
+                return Err(TCIError::IndexOutOfBounds {
+                    message: format!("Index {} out of bounds at site 0 (max {})", idx, t.site_dim()),
+                });
+            }
+            // Get slice at index
+            let mut slice = vec![T::zero(); t.right_dim()];
+            for r in 0..t.right_dim() {
+                slice[r] = *t.get(0, idx, r);
+            }
+
+            // Apply P^{-1} if needed
+            let p = &self.p_matrices[0];
+            if p.nrows() > 0 && p.ncols() > 0 {
+                let slice_mat = vec_to_row_matrix(&slice);
+                let result_mat = a_times_b_inv(&slice_mat, p);
+                row_matrix_to_vec(&result_mat)
+            } else {
+                slice
+            }
+        };
+
+        // Contract with remaining sites
+        for p in 1..self.len() {
+            let t = &self.t_tensors[p];
+            let idx = indices[p];
+            if idx >= t.site_dim() {
+                return Err(TCIError::IndexOutOfBounds {
+                    message: format!("Index {} out of bounds at site {} (max {})", idx, p, t.site_dim()),
+                });
+            }
+
+            let left_dim = t.left_dim();
+            let right_dim = t.right_dim();
+
+            // Contract: result (size left_dim) with T[:, idx, :] (left_dim x right_dim)
+            let mut next = vec![T::zero(); right_dim];
+            for r in 0..right_dim {
+                let mut sum = T::zero();
+                for l in 0..left_dim {
+                    sum = sum + result[l] * *t.get(l, idx, r);
+                }
+                next[r] = sum;
+            }
+
+            // Apply P^{-1}
+            let p_mat = &self.p_matrices[p];
+            if p_mat.nrows() > 0 && p_mat.ncols() > 0 {
+                let next_mat = vec_to_row_matrix(&next);
+                let result_mat = a_times_b_inv(&next_mat, p_mat);
+                result = row_matrix_to_vec(&result_mat);
+            } else {
+                result = next;
+            }
+        }
+
+        if result.len() != 1 {
+            return Err(TCIError::InvalidOperation {
+                message: format!("Final result should have size 1, got {}", result.len()),
+            });
+        }
+
+        Ok(result[0])
+    }
+
+    /// Get I set for a site
+    pub fn i_set(&self, p: usize) -> &IndexSet<MultiIndex> {
+        &self.i_set[p]
+    }
+
+    /// Get J set for a site
+    pub fn j_set(&self, p: usize) -> &IndexSet<MultiIndex> {
+        &self.j_set[p]
+    }
+
+    /// Build the Pi I set for site p
+    /// PiIset[p] = { [i..., up] : i in Iset[p], up in 1..localdims[p] }
+    fn get_pi_i_set(&self, p: usize) -> IndexSet<MultiIndex> {
+        let mut result = Vec::new();
+        for i_multi in self.i_set[p].iter() {
+            for up in 0..self.local_dims[p] {
+                let mut new_idx = i_multi.clone();
+                new_idx.push(up);
+                result.push(new_idx);
+            }
+        }
+        IndexSet::from_vec(result)
+    }
+
+    /// Build the Pi J set for site p
+    /// PiJset[p] = { [up+1, j...] : up+1 in 1..localdims[p], j in Jset[p] }
+    fn get_pi_j_set(&self, p: usize) -> IndexSet<MultiIndex> {
+        let mut result = Vec::new();
+        for up1 in 0..self.local_dims[p] {
+            for j_multi in self.j_set[p].iter() {
+                let mut new_idx = vec![up1];
+                new_idx.extend(j_multi.iter().cloned());
+                result.push(new_idx);
+            }
+        }
+        IndexSet::from_vec(result)
+    }
+
+    /// Build the Pi matrix at bond p
+    /// Pi[p][i, j] = f([PiIset[p][i]..., PiJset[p+1][j]...])
+    fn get_pi<F>(&mut self, p: usize, f: &F) -> Matrix<T>
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        let i_set = &self.pi_i_set[p];
+        let j_set = &self.pi_j_set[p + 1];
+
+        let mut pi = zeros(i_set.len(), j_set.len());
+        for (i, i_multi) in i_set.iter().enumerate() {
+            for (j, j_multi) in j_set.iter().enumerate() {
+                let mut full_idx = i_multi.clone();
+                full_idx.extend(j_multi.iter().cloned());
+                pi[[i, j]] = f(&full_idx);
+            }
+        }
+
+        self.update_max_sample_matrix(&pi);
+        pi
+    }
+
+    /// Update Pi rows at site p (after I set changed at p+1)
+    fn update_pi_rows<F>(&mut self, p: usize, f: &F)
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        let new_i_set = self.get_pi_i_set(p);
+        // Clone the old set to avoid borrow issues
+        let old_i_set: Vec<MultiIndex> = self.pi_i_set[p].iter().cloned().collect();
+        let old_i_set_ref = IndexSet::from_vec(old_i_set.clone());
+
+        // Find new indices
+        let new_indices: Vec<MultiIndex> = new_i_set
+            .iter()
+            .filter(|i| old_i_set_ref.pos(i).is_none())
+            .cloned()
+            .collect();
+
+        // Create new Pi matrix
+        let mut new_pi = zeros(new_i_set.len(), self.pi[p].ncols());
+
+        // Copy old rows
+        for (old_i, i_multi) in old_i_set.iter().enumerate() {
+            if let Some(new_i) = new_i_set.pos(i_multi) {
+                for j in 0..new_pi.ncols() {
+                    new_pi[[new_i, j]] = self.pi[p][[old_i, j]];
+                }
+            }
+        }
+
+        // Compute new rows
+        for i_multi in &new_indices {
+            if let Some(new_i) = new_i_set.pos(i_multi) {
+                for (j, j_multi) in self.pi_j_set[p + 1].iter().enumerate() {
+                    let mut full_idx = i_multi.clone();
+                    full_idx.extend(j_multi.iter().cloned());
+                    new_pi[[new_i, j]] = f(&full_idx);
+                }
+                // Update max sample
+                let row: Vec<T> = (0..new_pi.ncols()).map(|j| new_pi[[new_i, j]]).collect();
+                self.update_max_sample(&row);
+            }
+        }
+
+        self.pi[p] = new_pi;
+        self.pi_i_set[p] = new_i_set;
+
+        // Update ACA rows
+        let t_shape = (
+            self.t_tensors[p].left_dim(),
+            self.t_tensors[p].site_dim(),
+            self.t_tensors[p].right_dim(),
+        );
+        let t_p = tensor3_to_matrix_cols(&self.t_tensors[p], t_shape.0 * t_shape.1, t_shape.2);
+        let permutation: Vec<usize> = old_i_set
+            .iter()
+            .filter_map(|i| self.pi_i_set[p].pos(i))
+            .collect();
+        self.aca[p].set_rows(&t_p, &permutation);
+    }
+
+    /// Update Pi cols at site p (after J set changed at p)
+    fn update_pi_cols<F>(&mut self, p: usize, f: &F)
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        let new_j_set = self.get_pi_j_set(p + 1);
+        // Clone the old set to avoid borrow issues
+        let old_j_set: Vec<MultiIndex> = self.pi_j_set[p + 1].iter().cloned().collect();
+        let old_j_set_ref = IndexSet::from_vec(old_j_set.clone());
+
+        // Find new indices
+        let new_indices: Vec<MultiIndex> = new_j_set
+            .iter()
+            .filter(|j| old_j_set_ref.pos(j).is_none())
+            .cloned()
+            .collect();
+
+        // Create new Pi matrix
+        let mut new_pi = zeros(self.pi[p].nrows(), new_j_set.len());
+
+        // Copy old columns
+        for (old_j, j_multi) in old_j_set.iter().enumerate() {
+            if let Some(new_j) = new_j_set.pos(j_multi) {
+                for i in 0..new_pi.nrows() {
+                    new_pi[[i, new_j]] = self.pi[p][[i, old_j]];
+                }
+            }
+        }
+
+        // Compute new columns
+        for j_multi in &new_indices {
+            if let Some(new_j) = new_j_set.pos(j_multi) {
+                for (i, i_multi) in self.pi_i_set[p].iter().enumerate() {
+                    let mut full_idx = i_multi.clone();
+                    full_idx.extend(j_multi.iter().cloned());
+                    new_pi[[i, new_j]] = f(&full_idx);
+                }
+                // Update max sample
+                let col: Vec<T> = (0..new_pi.nrows()).map(|i| new_pi[[i, new_j]]).collect();
+                self.update_max_sample(&col);
+            }
+        }
+
+        self.pi[p] = new_pi;
+        self.pi_j_set[p + 1] = new_j_set;
+
+        // Update ACA cols
+        let t_p1 = &self.t_tensors[p + 1];
+        let t_shape = (t_p1.left_dim(), t_p1.site_dim(), t_p1.right_dim());
+        let t_mat = tensor3_to_matrix_rows(t_p1, t_shape.0, t_shape.1 * t_shape.2);
+        let permutation: Vec<usize> = old_j_set
+            .iter()
+            .filter_map(|j| self.pi_j_set[p + 1].pos(j))
+            .collect();
+        self.aca[p].set_cols(&t_mat, &permutation);
+    }
+
+    /// Add a pivot row at bond p
+    fn add_pivot_row<F>(&mut self, p: usize, new_i: usize, f: &F)
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        // Add to ACA
+        let _ = self.aca[p].add_pivot_row(&self.pi[p], new_i);
+
+        // Add to I set at p+1
+        let new_i_multi = self.pi_i_set[p].get(new_i).unwrap().clone();
+        self.i_set[p + 1].push(new_i_multi);
+
+        // Update T[p+1] - get all pivot rows from Pi
+        // Each row in the I set corresponds to a pivot row in Pi
+        let i_set_len = self.i_set[p + 1].len();
+        let local_dim = self.local_dims[p + 1];
+        let j_set_len = self.j_set[p + 1].len();
+
+        // Build pivot rows matrix: shape (i_set_len, local_dim * j_set_len)
+        let mut pivot_rows = zeros(i_set_len, local_dim * j_set_len);
+        for (row_idx, i_multi) in self.i_set[p + 1].iter().enumerate() {
+            if let Some(pi_row) = self.pi_i_set[p].pos(i_multi) {
+                for j in 0..self.pi[p].ncols() {
+                    pivot_rows[[row_idx, j]] = self.pi[p][[pi_row, j]];
+                }
+            }
+        }
+
+        self.t_tensors[p + 1] = matrix_to_tensor3(&pivot_rows, i_set_len, local_dim, j_set_len);
+
+        // Update P matrix using pivot values
+        self.update_p_matrix(p);
+
+        // Update adjacent Pi matrix if exists
+        if p < self.len() - 2 {
+            self.update_pi_rows(p + 1, f);
+        }
+    }
+
+    /// Add a pivot col at bond p
+    fn add_pivot_col<F>(&mut self, p: usize, new_j: usize, f: &F)
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        // Add to ACA
+        let _ = self.aca[p].add_pivot_col(&self.pi[p], new_j);
+
+        // Add to J set at p
+        let new_j_multi = self.pi_j_set[p + 1].get(new_j).unwrap().clone();
+        self.j_set[p].push(new_j_multi);
+
+        // Update T[p] - get all pivot columns from Pi
+        // Each column in the J set corresponds to a pivot column in Pi
+        let i_set_len = self.i_set[p].len();
+        let local_dim = self.local_dims[p];
+        let j_set_len = self.j_set[p].len();
+
+        // Build pivot cols matrix: shape (i_set_len * local_dim, j_set_len)
+        let mut pivot_cols = zeros(i_set_len * local_dim, j_set_len);
+        for (col_idx, j_multi) in self.j_set[p].iter().enumerate() {
+            if let Some(pi_col) = self.pi_j_set[p + 1].pos(j_multi) {
+                for i in 0..self.pi[p].nrows() {
+                    pivot_cols[[i, col_idx]] = self.pi[p][[i, pi_col]];
+                }
+            }
+        }
+
+        self.t_tensors[p] = matrix_to_tensor3(&pivot_cols, i_set_len, local_dim, j_set_len);
+
+        // Update P matrix using pivot values
+        self.update_p_matrix(p);
+
+        // Update adjacent Pi matrix if exists
+        if p > 0 {
+            self.update_pi_cols(p - 1, f);
+        }
+    }
+
+    /// Update P matrix at bond p from current I and J sets
+    fn update_p_matrix(&mut self, p: usize) {
+        let i_set_len = self.i_set[p + 1].len();
+        let j_set_len = self.j_set[p].len();
+
+        let mut p_mat = zeros(i_set_len, j_set_len);
+        for (i, i_multi) in self.i_set[p + 1].iter().enumerate() {
+            for (j, j_multi) in self.j_set[p].iter().enumerate() {
+                if let (Some(pi_i), Some(pi_j)) = (
+                    self.pi_i_set[p].pos(i_multi),
+                    self.pi_j_set[p + 1].pos(j_multi),
+                ) {
+                    p_mat[[i, j]] = self.pi[p][[pi_i, pi_j]];
+                }
+            }
+        }
+        self.p_matrices[p] = p_mat;
+    }
+
+    /// Add a pivot at bond p
+    fn add_pivot<F>(&mut self, p: usize, f: &F, tolerance: f64)
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        if p >= self.len() - 1 {
+            return;
+        }
+
+        // Check if we've reached full rank
+        let pi_rows = self.pi[p].nrows();
+        let pi_cols = self.pi[p].ncols();
+        if self.aca[p].rank() >= pi_rows.min(pi_cols) {
+            self.pivot_errors[p] = 0.0;
+            return;
+        }
+
+        // Find new pivot using ACA
+        let new_pivot = self.aca[p].find_new_pivot(&self.pi[p]);
+
+        match new_pivot {
+            Ok(((new_i, new_j), error)) => {
+                let error_val = f64::sqrt(Scalar::abs_sq(error));
+                self.pivot_errors[p] = error_val;
+
+                if error_val < tolerance {
+                    return;
+                }
+
+                // Add pivot column first, then row
+                self.add_pivot_col(p, new_j, f);
+                self.add_pivot_row(p, new_i, f);
+            }
+            Err(_) => {
+                self.pivot_errors[p] = 0.0;
+            }
+        }
+    }
+
+    /// Initialize from function with first pivot
+    fn initialize_from_pivot<F>(&mut self, f: &F, first_pivot: &MultiIndex) -> Result<()>
+    where
+        F: Fn(&MultiIndex) -> T,
+    {
+        let first_value = f(first_pivot);
+        if Scalar::abs_sq(first_value) < 1e-30 {
+            return Err(TCIError::InvalidPivot {
+                message: "First pivot must have non-zero function value".to_string(),
+            });
+        }
+
+        self.max_sample_value = f64::sqrt(Scalar::abs_sq(first_value));
+        let n = self.len();
+
+        // Initialize I and J sets from first pivot
+        for p in 0..n {
+            let i_indices: MultiIndex = first_pivot[0..p].to_vec();
+            let j_indices: MultiIndex = first_pivot[p + 1..].to_vec();
+            self.i_set[p] = IndexSet::from_vec(vec![i_indices]);
+            self.j_set[p] = IndexSet::from_vec(vec![j_indices]);
+        }
+
+        // Build Pi I and J sets
+        for p in 0..n {
+            self.pi_i_set[p] = self.get_pi_i_set(p);
+            self.pi_j_set[p] = self.get_pi_j_set(p);
+        }
+
+        // Build Pi matrices
+        for p in 0..n - 1 {
+            self.pi[p] = self.get_pi(p, f);
+        }
+
+        // Initialize ACA and T tensors for each bond
+        for p in 0..n - 1 {
+            // Find local pivot position in Pi
+            let local_pivot = (
+                self.pi_i_set[p].pos(&self.i_set[p + 1].get(0).cloned().unwrap_or_default()).unwrap_or(0),
+                self.pi_j_set[p + 1].pos(&self.j_set[p].get(0).cloned().unwrap_or_default()).unwrap_or(0),
+            );
+
+            // Initialize ACA from Pi with the pivot
+            self.aca[p] = MatrixACA::from_matrix_with_pivot(&self.pi[p], local_pivot);
+
+            // Update T tensors
+            if p == 0 {
+                // T[0] from pivot column of Pi[0]
+                let pivot_col: Vec<T> = (0..self.pi[p].nrows())
+                    .map(|i| self.pi[p][[i, local_pivot.1]])
+                    .collect();
+                let col_mat = vec_to_col_matrix(&pivot_col);
+                self.t_tensors[0] = matrix_to_tensor3(&col_mat, 1, self.local_dims[0], 1);
+            }
+
+            // T[p+1] from pivot row of Pi[p]
+            let pivot_row: Vec<T> = (0..self.pi[p].ncols())
+                .map(|j| self.pi[p][[local_pivot.0, j]])
+                .collect();
+            let row_mat = vec_to_row_matrix(&pivot_row);
+            self.t_tensors[p + 1] = matrix_to_tensor3(&row_mat, 1, self.local_dims[p + 1], 1);
+
+            // P[p] = Pi[p][local_pivot]
+            let mut p_mat = zeros(1, 1);
+            p_mat[[0, 0]] = self.pi[p][[local_pivot.0, local_pivot.1]];
+            self.p_matrices[p] = p_mat;
+        }
+
+        // P[n-1] = identity (1x1 of ones)
+        let mut p_last = zeros(1, 1);
+        p_last[[0, 0]] = T::one();
+        self.p_matrices[n - 1] = p_last;
+
+        Ok(())
+    }
+}
+
+// Helper functions
+
+/// Convert a vector to a row matrix
+fn vec_to_row_matrix<T: Scalar>(v: &[T]) -> Matrix<T> {
+    let mut mat = zeros(1, v.len());
+    for (j, &val) in v.iter().enumerate() {
+        mat[[0, j]] = val;
+    }
+    mat
+}
+
+/// Convert a vector to a column matrix
+fn vec_to_col_matrix<T: Scalar>(v: &[T]) -> Matrix<T> {
+    let mut mat = zeros(v.len(), 1);
+    for (i, &val) in v.iter().enumerate() {
+        mat[[i, 0]] = val;
+    }
+    mat
+}
+
+/// Convert a row matrix to a vector
+fn row_matrix_to_vec<T: Scalar>(mat: &Matrix<T>) -> Vec<T> {
+    (0..mat.ncols()).map(|j| mat[[0, j]]).collect()
+}
+
+/// Convert Tensor3 to Matrix (reshape for columns: (left*site, right))
+fn tensor3_to_matrix<T: Scalar + Default>(tensor: &Tensor3<T>) -> Matrix<T> {
+    let left_dim = tensor.left_dim();
+    let site_dim = tensor.site_dim();
+    let right_dim = tensor.right_dim();
+    let rows = left_dim * site_dim;
+    let cols = right_dim;
+
+    let mut mat = zeros(rows, cols);
+    for l in 0..left_dim {
+        for s in 0..site_dim {
+            for r in 0..right_dim {
+                mat[[l * site_dim + s, r]] = *tensor.get(l, s, r);
+            }
+        }
+    }
+    mat
+}
+
+/// Convert Tensor3 to Matrix for columns (left*site, right)
+fn tensor3_to_matrix_cols<T: Scalar + Default>(tensor: &Tensor3<T>, rows: usize, cols: usize) -> Matrix<T> {
+    let left_dim = tensor.left_dim();
+    let site_dim = tensor.site_dim();
+    let right_dim = tensor.right_dim();
+
+    let mut mat = zeros(rows, cols);
+    for l in 0..left_dim {
+        for s in 0..site_dim {
+            for r in 0..right_dim {
+                if l * site_dim + s < rows && r < cols {
+                    mat[[l * site_dim + s, r]] = *tensor.get(l, s, r);
+                }
+            }
+        }
+    }
+    mat
+}
+
+/// Convert Tensor3 to Matrix for rows (left, site*right)
+fn tensor3_to_matrix_rows<T: Scalar + Default>(tensor: &Tensor3<T>, rows: usize, cols: usize) -> Matrix<T> {
+    let left_dim = tensor.left_dim();
+    let site_dim = tensor.site_dim();
+    let right_dim = tensor.right_dim();
+
+    let mut mat = zeros(rows, cols);
+    for l in 0..left_dim {
+        for s in 0..site_dim {
+            for r in 0..right_dim {
+                if l < rows && s * right_dim + r < cols {
+                    mat[[l, s * right_dim + r]] = *tensor.get(l, s, r);
+                }
+            }
+        }
+    }
+    mat
+}
+
+/// Convert Matrix to Tensor3
+fn matrix_to_tensor3<T: Scalar + Default>(mat: &Matrix<T>, left_dim: usize, site_dim: usize, right_dim: usize) -> Tensor3<T> {
+    let mut tensor = Tensor3::zeros(left_dim, site_dim, right_dim);
+
+    // Determine the layout based on matrix dimensions
+    if mat.nrows() == left_dim * site_dim && mat.ncols() == right_dim {
+        // Column layout: (left*site, right)
+        for l in 0..left_dim {
+            for s in 0..site_dim {
+                for r in 0..right_dim {
+                    tensor.set(l, s, r, mat[[l * site_dim + s, r]]);
+                }
+            }
+        }
+    } else if mat.nrows() == left_dim && mat.ncols() == site_dim * right_dim {
+        // Row layout: (left, site*right)
+        for l in 0..left_dim {
+            for s in 0..site_dim {
+                for r in 0..right_dim {
+                    tensor.set(l, s, r, mat[[l, s * right_dim + r]]);
+                }
+            }
+        }
+    } else if mat.nrows() == 1 && mat.ncols() == site_dim {
+        // Single row with site values
+        for s in 0..site_dim {
+            tensor.set(0, s, 0, mat[[0, s]]);
+        }
+    } else if mat.nrows() == site_dim && mat.ncols() == 1 {
+        // Single column with site values
+        for s in 0..site_dim {
+            tensor.set(0, s, 0, mat[[s, 0]]);
+        }
+    }
+
+    tensor
+}
+
+/// Cross interpolate a function using TCI1 algorithm
+///
+/// # Arguments
+/// * `f` - Function to interpolate, takes a multi-index and returns a value
+/// * `local_dims` - Local dimensions for each site
+/// * `first_pivot` - Initial pivot point
+/// * `options` - Algorithm options
+///
+/// # Returns
+/// * `TensorCI1` - The constructed tensor cross interpolation
+/// * `Vec<usize>` - Ranks at each iteration
+/// * `Vec<f64>` - Errors at each iteration
+pub fn crossinterpolate1<T, F>(
+    f: F,
+    local_dims: Vec<usize>,
+    first_pivot: MultiIndex,
+    options: TCI1Options,
+) -> Result<(TensorCI1<T>, Vec<usize>, Vec<f64>)>
+where
+    T: Scalar + TTScalar + Default,
+    F: Fn(&MultiIndex) -> T,
+{
+    if local_dims.len() != first_pivot.len() {
+        return Err(TCIError::DimensionMismatch {
+            message: format!(
+                "local_dims length ({}) must match first_pivot length ({})",
+                local_dims.len(),
+                first_pivot.len()
+            ),
+        });
+    }
+
+    let mut tci = TensorCI1::new(local_dims.clone());
+    tci.initialize_from_pivot(&f, &first_pivot)?;
+
+    let n = tci.len();
+    let mut errors = Vec::new();
+    let mut ranks = Vec::new();
+
+    // Main iteration loop
+    for iter in 1..=options.max_iter {
+        // Sweep
+        if forward_sweep(options.sweep_strategy, iter) {
+            for bond_index in 0..n - 1 {
+                tci.add_pivot(bond_index, &f, options.pivot_tolerance);
+            }
+        } else {
+            for bond_index in (0..n - 1).rev() {
+                tci.add_pivot(bond_index, &f, options.pivot_tolerance);
+            }
+        }
+
+        // Record error and rank
+        let error = tci.last_sweep_pivot_error();
+        let error_normalized = if options.normalize_error && tci.max_sample_value > 0.0 {
+            error / tci.max_sample_value
+        } else {
+            error
+        };
+
+        errors.push(error_normalized);
+        ranks.push(tci.rank());
+
+        if options.verbosity > 0 && iter % 10 == 0 {
+            println!(
+                "iteration = {}, rank = {}, error = {:.2e}",
+                iter,
+                tci.rank(),
+                error_normalized
+            );
+        }
+
+        // Check convergence
+        if error_normalized < options.tolerance {
+            break;
+        }
+    }
+
+    Ok((tci, ranks, errors))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensorci1_new() {
+        let tci = TensorCI1::<f64>::new(vec![2, 3, 2]);
+        assert_eq!(tci.len(), 3);
+        assert_eq!(tci.local_dims(), &[2, 3, 2]);
+    }
+
+    #[test]
+    fn test_crossinterpolate1_constant() {
+        let f = |_: &MultiIndex| 1.0f64;
+        let local_dims = vec![2, 2];
+        let first_pivot = vec![0, 0];
+        let options = TCI1Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate1(f, local_dims, first_pivot, options).unwrap();
+        assert_eq!(tci.len(), 2);
+        assert!(tci.rank() >= 1);
+    }
+
+    #[test]
+    fn test_crossinterpolate1_simple() {
+        // f(i, j) = i + j + 1
+        let f = |idx: &MultiIndex| (idx[0] + idx[1] + 1) as f64;
+        let local_dims = vec![3, 3];
+        let first_pivot = vec![1, 1];
+        let options = TCI1Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate1(f, local_dims, first_pivot, options).unwrap();
+        assert_eq!(tci.len(), 2);
+    }
+
+    #[test]
+    fn test_crossinterpolate1_evaluate_at_pivot() {
+        // f(i, j) = (i + 1) * (j + 1)
+        let f = |idx: &MultiIndex| ((idx[0] + 1) * (idx[1] + 1)) as f64;
+        let local_dims = vec![3, 3];
+        let first_pivot = vec![1, 1];
+        let options = TCI1Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate1(f, local_dims.clone(), first_pivot.clone(), options).unwrap();
+
+        // The TCI should exactly reproduce the function at the pivot
+        let val = tci.evaluate(&first_pivot).unwrap();
+        let expected = f(&first_pivot);
+        assert!(
+            (val - expected).abs() < 1e-10,
+            "TCI evaluate at pivot: got {}, expected {}",
+            val,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_crossinterpolate1_evaluate_on_cross() {
+        // f(i, j) = (i + 1) * (j + 1)
+        let f = |idx: &MultiIndex| ((idx[0] + 1) * (idx[1] + 1)) as f64;
+        let local_dims = vec![3, 3];
+        let first_pivot = vec![1, 1];
+        let options = TCI1Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate1(f, local_dims.clone(), first_pivot.clone(), options).unwrap();
+
+        // Test evaluation at points on the cross through the pivot
+        // Points (i, 1) for all i
+        for i in 0..3 {
+            let idx = vec![i, 1];
+            let val = tci.evaluate(&idx).unwrap();
+            let expected = f(&idx);
+            assert!(
+                (val - expected).abs() < 1e-10,
+                "TCI evaluate at {:?}: got {}, expected {}",
+                idx,
+                val,
+                expected
+            );
+        }
+
+        // Points (1, j) for all j
+        for j in 0..3 {
+            let idx = vec![1, j];
+            let val = tci.evaluate(&idx).unwrap();
+            let expected = f(&idx);
+            assert!(
+                (val - expected).abs() < 1e-10,
+                "TCI evaluate at {:?}: got {}, expected {}",
+                idx,
+                val,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_crossinterpolate1_to_tensor_train() {
+        let f = |idx: &MultiIndex| ((idx[0] + 1) * (idx[1] + 1)) as f64;
+        let local_dims = vec![3, 3];
+        let first_pivot = vec![1, 1];
+        let options = TCI1Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate1(f, local_dims, first_pivot.clone(), options).unwrap();
+
+        // Convert to TensorTrain
+        let tt = tci.to_tensor_train().unwrap();
+        assert_eq!(tt.len(), 2);
+
+        // Evaluate at the pivot using the TensorTrain
+        use tensor4all_tensortrain::AbstractTensorTrain;
+        let val = tt.evaluate(&first_pivot).unwrap();
+        let expected = f(&first_pivot);
+        assert!(
+            (val - expected).abs() < 1e-10,
+            "TensorTrain evaluate at pivot: got {}, expected {}",
+            val,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_crossinterpolate1_3d() {
+        // 3D function: f(i, j, k) = i + j + k + 1
+        let f = |idx: &MultiIndex| (idx[0] + idx[1] + idx[2] + 1) as f64;
+        let local_dims = vec![2, 2, 2];
+        let first_pivot = vec![0, 0, 0];
+        let options = TCI1Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate1(f, local_dims, first_pivot.clone(), options).unwrap();
+
+        assert_eq!(tci.len(), 3);
+
+        // Test evaluation at the pivot
+        let val = tci.evaluate(&first_pivot).unwrap();
+        let expected = f(&first_pivot);
+        assert!(
+            (val - expected).abs() < 1e-10,
+            "3D TCI evaluate at pivot: got {}, expected {}",
+            val,
+            expected
+        );
+    }
+
+    #[test]
+    fn test_crossinterpolate1_rank2_function() {
+        // A rank-2 function: f(i, j) = i + j (not separable)
+        let f = |idx: &MultiIndex| (idx[0] + idx[1]) as f64;
+        let local_dims = vec![4, 4];
+        let first_pivot = vec![1, 1];
+        let mut options = TCI1Options::default();
+        options.tolerance = 1e-12;
+
+        let (tci, _ranks, errors) = crossinterpolate1(f, local_dims.clone(), first_pivot, options).unwrap();
+
+        // Should converge to rank 2
+        assert!(tci.rank() <= 3, "Expected rank <= 3, got {}", tci.rank());
+
+        // Check error is small
+        let final_error = errors.last().copied().unwrap_or(f64::INFINITY);
+        assert!(final_error < 1e-8, "Expected small error, got {}", final_error);
+
+        // Test all values
+        for i in 0..4 {
+            for j in 0..4 {
+                let idx = vec![i, j];
+                let val = tci.evaluate(&idx).unwrap();
+                let expected = f(&idx);
+                assert!(
+                    (val - expected).abs() < 1e-8,
+                    "TCI evaluate at {:?}: got {}, expected {}",
+                    idx,
+                    val,
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_crossinterpolate1_converges() {
+        // A smooth function that should converge well
+        let f = |idx: &MultiIndex| {
+            let x = idx[0] as f64 / 4.0;
+            let y = idx[1] as f64 / 4.0;
+            (x * y + 0.1).sin()
+        };
+        let local_dims = vec![5, 5];
+        let first_pivot = vec![2, 2];
+        let mut options = TCI1Options::default();
+        options.tolerance = 1e-6;
+
+        let (tci, _ranks, errors) = crossinterpolate1(f, local_dims.clone(), first_pivot, options).unwrap();
+
+        // Should achieve reasonable rank
+        assert!(tci.rank() <= 5, "Expected rank <= 5, got {}", tci.rank());
+
+        // Check errors decrease
+        if errors.len() > 1 {
+            let first_error = errors[0];
+            let last_error = errors.last().copied().unwrap();
+            assert!(
+                last_error <= first_error || last_error < 1e-6,
+                "Errors should decrease or converge: first={}, last={}",
+                first_error,
+                last_error
+            );
+        }
+    }
+}

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -1,0 +1,575 @@
+//! TensorCI2 - Two-site Tensor Cross Interpolation algorithm
+//!
+//! This implements the TCI2 algorithm which uses two-site updates for
+//! more efficient convergence. Unlike TCI1, it supports batch evaluation
+//! of function values through an explicit batch function parameter.
+
+use crate::error::{Result, TCIError};
+use crate::indexset::MultiIndex;
+use tensor4all_matrixci::util::{zeros, Scalar};
+use tensor4all_matrixci::{AbstractMatrixCI, MatrixLUCI, RrLUOptions};
+use tensor4all_tensortrain::{Tensor3, TensorTrain, TTScalar};
+
+/// Options for TCI2 algorithm
+#[derive(Debug, Clone)]
+pub struct TCI2Options {
+    /// Tolerance for convergence (relative)
+    pub tolerance: f64,
+    /// Maximum number of iterations (half-sweeps)
+    pub max_iter: usize,
+    /// Maximum bond dimension
+    pub max_bond_dim: usize,
+    /// Pivot search strategy
+    pub pivot_search: PivotSearchStrategy,
+    /// Whether to normalize error by max sample value
+    pub normalize_error: bool,
+    /// Verbosity level
+    pub verbosity: usize,
+    /// Number of global pivots to search per iteration
+    pub max_nglobal_pivot: usize,
+    /// Number of random searches for global pivots
+    pub nsearch: usize,
+}
+
+impl Default for TCI2Options {
+    fn default() -> Self {
+        Self {
+            tolerance: 1e-8,
+            max_iter: 20,
+            max_bond_dim: 50,
+            pivot_search: PivotSearchStrategy::Full,
+            normalize_error: true,
+            verbosity: 0,
+            max_nglobal_pivot: 5,
+            nsearch: 100,
+        }
+    }
+}
+
+/// Pivot search strategy for TCI2
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PivotSearchStrategy {
+    /// Full search: evaluate entire Pi matrix
+    #[default]
+    Full,
+    /// Rook search: use partial pivoting (more efficient for large matrices)
+    Rook,
+}
+
+/// TensorCI2 - Two-site Tensor Cross Interpolation
+///
+/// This structure represents a tensor train constructed using the TCI2 algorithm.
+/// TCI2 uses two-site updates which can be more efficient than TCI1 for some functions.
+#[derive(Debug, Clone)]
+pub struct TensorCI2<T: Scalar + TTScalar> {
+    /// Index sets I for each site
+    i_set: Vec<Vec<MultiIndex>>,
+    /// Index sets J for each site
+    j_set: Vec<Vec<MultiIndex>>,
+    /// Local dimensions
+    local_dims: Vec<usize>,
+    /// Site tensors (3-leg tensors)
+    site_tensors: Vec<Tensor3<T>>,
+    /// Pivot errors during back-truncation
+    pivot_errors: Vec<f64>,
+    /// Bond errors from 2-site sweep
+    bond_errors: Vec<f64>,
+    /// Maximum sample value found
+    max_sample_value: f64,
+}
+
+impl<T: Scalar + TTScalar + Default> TensorCI2<T> {
+    /// Create a new empty TensorCI2
+    pub fn new(local_dims: Vec<usize>) -> Result<Self> {
+        if local_dims.len() < 2 {
+            return Err(TCIError::DimensionMismatch {
+                message: "local_dims should have at least 2 elements".to_string(),
+            });
+        }
+
+        let n = local_dims.len();
+        Ok(Self {
+            i_set: (0..n).map(|_| Vec::new()).collect(),
+            j_set: (0..n).map(|_| Vec::new()).collect(),
+            local_dims: local_dims.clone(),
+            site_tensors: local_dims.iter().map(|&d| Tensor3::zeros(0, d, 0)).collect(),
+            pivot_errors: Vec::new(),
+            bond_errors: vec![0.0; n.saturating_sub(1)],
+            max_sample_value: 0.0,
+        })
+    }
+
+    /// Number of sites
+    pub fn len(&self) -> usize {
+        self.local_dims.len()
+    }
+
+    /// Check if empty
+    pub fn is_empty(&self) -> bool {
+        self.local_dims.is_empty()
+    }
+
+    /// Get local dimensions
+    pub fn local_dims(&self) -> &[usize] {
+        &self.local_dims
+    }
+
+    /// Get current rank (maximum bond dimension)
+    pub fn rank(&self) -> usize {
+        if self.len() <= 1 {
+            return if self.i_set.is_empty() || self.i_set[0].is_empty() { 0 } else { 1 };
+        }
+        self.i_set
+            .iter()
+            .skip(1)
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Get bond dimensions
+    pub fn link_dims(&self) -> Vec<usize> {
+        if self.len() <= 1 {
+            return Vec::new();
+        }
+        self.i_set.iter().skip(1).map(|s| s.len()).collect()
+    }
+
+    /// Get maximum sample value
+    pub fn max_sample_value(&self) -> f64 {
+        self.max_sample_value
+    }
+
+    /// Get maximum bond error
+    pub fn max_bond_error(&self) -> f64 {
+        self.bond_errors.iter().cloned().fold(0.0, f64::max)
+    }
+
+    /// Get pivot errors from back-truncation
+    pub fn pivot_errors(&self) -> &[f64] {
+        &self.pivot_errors
+    }
+
+    /// Check if site tensors are available
+    pub fn is_site_tensors_available(&self) -> bool {
+        self.site_tensors.iter().all(|t| {
+            t.left_dim() > 0 || t.right_dim() > 0
+        })
+    }
+
+    /// Get site tensor at position p
+    pub fn site_tensor(&self, p: usize) -> &Tensor3<T> {
+        &self.site_tensors[p]
+    }
+
+    /// Convert to TensorTrain
+    pub fn to_tensor_train(&self) -> Result<TensorTrain<T>> {
+        let tensors = self.site_tensors.clone();
+        TensorTrain::new(tensors).map_err(TCIError::TensorTrainError)
+    }
+
+    /// Add global pivots to the TCI
+    pub fn add_global_pivots(&mut self, pivots: &[MultiIndex]) -> Result<()> {
+        for pivot in pivots {
+            if pivot.len() != self.len() {
+                return Err(TCIError::DimensionMismatch {
+                    message: format!(
+                        "Pivot length ({}) must match number of sites ({})",
+                        pivot.len(),
+                        self.len()
+                    ),
+                });
+            }
+
+            // Add to I and J sets
+            for p in 0..self.len() {
+                let i_indices: MultiIndex = pivot[0..p].to_vec();
+                let j_indices: MultiIndex = pivot[p + 1..].to_vec();
+
+                if !self.i_set[p].contains(&i_indices) {
+                    self.i_set[p].push(i_indices);
+                }
+                if !self.j_set[p].contains(&j_indices) {
+                    self.j_set[p].push(j_indices);
+                }
+            }
+        }
+
+        // Invalidate site tensors after adding pivots
+        self.invalidate_site_tensors();
+
+        Ok(())
+    }
+
+    /// Invalidate all site tensors
+    fn invalidate_site_tensors(&mut self) {
+        for p in 0..self.len() {
+            self.site_tensors[p] = Tensor3::zeros(0, self.local_dims[p], 0);
+        }
+    }
+
+    /// Expand indices by Kronecker product with local dimension
+    fn kronecker_i(&self, p: usize) -> Vec<MultiIndex> {
+        let mut result = Vec::new();
+        for i_multi in &self.i_set[p] {
+            for local_idx in 0..self.local_dims[p] {
+                let mut new_idx = i_multi.clone();
+                new_idx.push(local_idx);
+                result.push(new_idx);
+            }
+        }
+        result
+    }
+
+    fn kronecker_j(&self, p: usize) -> Vec<MultiIndex> {
+        let mut result = Vec::new();
+        for local_idx in 0..self.local_dims[p] {
+            for j_multi in &self.j_set[p] {
+                let mut new_idx = vec![local_idx];
+                new_idx.extend(j_multi.iter().cloned());
+                result.push(new_idx);
+            }
+        }
+        result
+    }
+}
+
+/// Cross interpolate a function using TCI2 algorithm
+///
+/// # Arguments
+/// * `f` - Function to interpolate, takes a multi-index and returns a value
+/// * `batched_f` - Optional batch evaluation function for efficiency
+/// * `local_dims` - Local dimensions for each site
+/// * `initial_pivots` - Initial pivot points
+/// * `options` - Algorithm options
+///
+/// # Returns
+/// * `TensorCI2` - The constructed tensor cross interpolation
+/// * `Vec<usize>` - Ranks at each iteration
+/// * `Vec<f64>` - Errors at each iteration
+pub fn crossinterpolate2<T, F, B>(
+    f: F,
+    batched_f: Option<B>,
+    local_dims: Vec<usize>,
+    initial_pivots: Vec<MultiIndex>,
+    options: TCI2Options,
+) -> Result<(TensorCI2<T>, Vec<usize>, Vec<f64>)>
+where
+    T: Scalar + TTScalar + Default,
+    F: Fn(&MultiIndex) -> T,
+    B: Fn(&[MultiIndex]) -> Vec<T>,
+{
+    if local_dims.len() < 2 {
+        return Err(TCIError::DimensionMismatch {
+            message: "local_dims should have at least 2 elements".to_string(),
+        });
+    }
+
+    let pivots = if initial_pivots.is_empty() {
+        vec![vec![0; local_dims.len()]]
+    } else {
+        initial_pivots
+    };
+
+    let mut tci = TensorCI2::new(local_dims)?;
+    tci.add_global_pivots(&pivots)?;
+
+    // Initialize max_sample_value
+    for pivot in &pivots {
+        let value = f(pivot);
+        let abs_val = f64::sqrt(Scalar::abs_sq(value));
+        if abs_val > tci.max_sample_value {
+            tci.max_sample_value = abs_val;
+        }
+    }
+
+    if tci.max_sample_value < 1e-30 {
+        return Err(TCIError::InvalidPivot {
+            message: "Initial pivots have zero function values".to_string(),
+        });
+    }
+
+    let n = tci.len();
+    let mut errors = Vec::new();
+    let mut ranks = Vec::new();
+
+    // Main optimization loop
+    for iter in 0..options.max_iter {
+        let is_forward = iter % 2 == 0;
+
+        // Sweep through bonds
+        if is_forward {
+            for b in 0..n - 1 {
+                update_pivots(
+                    &mut tci,
+                    b,
+                    &f,
+                    &batched_f,
+                    true, // left orthogonal in forward sweep
+                    &options,
+                )?;
+            }
+        } else {
+            for b in (0..n - 1).rev() {
+                update_pivots(
+                    &mut tci,
+                    b,
+                    &f,
+                    &batched_f,
+                    false, // right orthogonal in backward sweep
+                    &options,
+                )?;
+            }
+        }
+
+        // Record error and rank
+        let error = tci.max_bond_error();
+        let error_normalized = if options.normalize_error && tci.max_sample_value > 0.0 {
+            error / tci.max_sample_value
+        } else {
+            error
+        };
+
+        errors.push(error_normalized);
+        ranks.push(tci.rank());
+
+        if options.verbosity > 0 {
+            println!(
+                "iteration = {}, rank = {}, error = {:.2e}",
+                iter + 1,
+                tci.rank(),
+                error_normalized
+            );
+        }
+
+        // Check convergence
+        if error_normalized < options.tolerance {
+            break;
+        }
+    }
+
+    Ok((tci, ranks, errors))
+}
+
+/// Update pivots at bond b using LU-based cross interpolation
+fn update_pivots<T, F, B>(
+    tci: &mut TensorCI2<T>,
+    b: usize,
+    f: &F,
+    batched_f: &Option<B>,
+    left_orthogonal: bool,
+    options: &TCI2Options,
+) -> Result<()>
+where
+    T: Scalar + TTScalar + Default,
+    F: Fn(&MultiIndex) -> T,
+    B: Fn(&[MultiIndex]) -> Vec<T>,
+{
+    // Invalidate site tensors
+    tci.invalidate_site_tensors();
+
+    // Build combined index sets
+    let i_combined = tci.kronecker_i(b);
+    let j_combined = tci.kronecker_j(b + 1);
+
+    if i_combined.is_empty() || j_combined.is_empty() {
+        return Ok(());
+    }
+
+    // Build Pi matrix
+    let mut pi = zeros(i_combined.len(), j_combined.len());
+
+    // Use batch evaluation if available, otherwise use single evaluation
+    if let Some(ref batch_fn) = batched_f {
+        // Build all index pairs
+        let mut all_indices: Vec<MultiIndex> = Vec::with_capacity(i_combined.len() * j_combined.len());
+        for i_multi in &i_combined {
+            for j_multi in &j_combined {
+                let mut full_idx = i_multi.clone();
+                full_idx.extend(j_multi.iter().cloned());
+                all_indices.push(full_idx);
+            }
+        }
+
+        // Batch evaluate
+        let values = batch_fn(&all_indices);
+
+        // Fill Pi matrix
+        let mut idx = 0;
+        for i in 0..i_combined.len() {
+            for j in 0..j_combined.len() {
+                pi[[i, j]] = values[idx];
+                let abs_val = f64::sqrt(Scalar::abs_sq(values[idx]));
+                if abs_val > tci.max_sample_value {
+                    tci.max_sample_value = abs_val;
+                }
+                idx += 1;
+            }
+        }
+    } else {
+        // Single evaluation
+        for (i, i_multi) in i_combined.iter().enumerate() {
+            for (j, j_multi) in j_combined.iter().enumerate() {
+                let mut full_idx = i_multi.clone();
+                full_idx.extend(j_multi.iter().cloned());
+                let value = f(&full_idx);
+                pi[[i, j]] = value;
+
+                let abs_val = f64::sqrt(Scalar::abs_sq(value));
+                if abs_val > tci.max_sample_value {
+                    tci.max_sample_value = abs_val;
+                }
+            }
+        }
+    }
+
+    // Apply LU-based cross interpolation
+    let lu_options = RrLUOptions {
+        max_rank: options.max_bond_dim,
+        rel_tol: options.tolerance,
+        abs_tol: 0.0,
+        left_orthogonal,
+    };
+
+    let luci = MatrixLUCI::from_matrix(&pi, Some(lu_options));
+
+    // Update I and J sets
+    let row_indices = luci.row_indices();
+    let col_indices = luci.col_indices();
+
+    tci.i_set[b + 1] = row_indices.iter().map(|&i| i_combined[i].clone()).collect();
+    tci.j_set[b] = col_indices.iter().map(|&j| j_combined[j].clone()).collect();
+
+    // Update site tensors
+    let left = luci.left();
+    let right = luci.right();
+
+    // Convert left matrix to tensor at site b
+    let left_dim = if b == 0 { 1 } else { tci.i_set[b].len() };
+    let site_dim_b = tci.local_dims[b];
+    let new_bond_dim = luci.rank().max(1);
+
+    let mut tensor_b = Tensor3::zeros(left_dim, site_dim_b, new_bond_dim);
+    for l in 0..left_dim {
+        for s in 0..site_dim_b {
+            for r in 0..new_bond_dim {
+                let row = l * site_dim_b + s;
+                if row < left.nrows() && r < left.ncols() {
+                    tensor_b.set(l, s, r, left[[row, r]]);
+                }
+            }
+        }
+    }
+    tci.site_tensors[b] = tensor_b;
+
+    // Convert right matrix to tensor at site b+1
+    let site_dim_bp1 = tci.local_dims[b + 1];
+    let right_dim = if b + 1 == tci.len() - 1 { 1 } else { tci.j_set[b + 1].len() };
+
+    let mut tensor_bp1 = Tensor3::zeros(new_bond_dim, site_dim_bp1, right_dim);
+    for l in 0..new_bond_dim {
+        for s in 0..site_dim_bp1 {
+            for r in 0..right_dim {
+                let col = s * right_dim + r;
+                if l < right.nrows() && col < right.ncols() {
+                    tensor_bp1.set(l, s, r, right[[l, col]]);
+                }
+            }
+        }
+    }
+    tci.site_tensors[b + 1] = tensor_bp1;
+
+    // Update bond error
+    let errors = luci.pivot_errors();
+    if !errors.is_empty() {
+        tci.bond_errors[b] = *errors.last().unwrap_or(&0.0);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensorci2_new() {
+        let tci = TensorCI2::<f64>::new(vec![2, 3, 2]).unwrap();
+        assert_eq!(tci.len(), 3);
+        assert_eq!(tci.local_dims(), &[2, 3, 2]);
+    }
+
+    #[test]
+    fn test_tensorci2_requires_two_sites() {
+        let result = TensorCI2::<f64>::new(vec![2]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_crossinterpolate2_constant() {
+        let f = |_: &MultiIndex| 1.0f64;
+        let local_dims = vec![2, 2];
+        let first_pivot = vec![vec![0, 0]];
+        let options = TCI2Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            f,
+            None,
+            local_dims,
+            first_pivot,
+            options,
+        ).unwrap();
+
+        assert_eq!(tci.len(), 2);
+        assert!(tci.rank() >= 1);
+    }
+
+    #[test]
+    fn test_crossinterpolate2_with_batch_function() {
+        // Use batch evaluation
+        let f = |idx: &MultiIndex| (idx[0] + idx[1] + 1) as f64;
+        let batched_f = |indices: &[MultiIndex]| -> Vec<f64> {
+            indices.iter().map(|idx| (idx[0] + idx[1] + 1) as f64).collect()
+        };
+
+        let local_dims = vec![3, 3];
+        let first_pivot = vec![vec![1, 1]];
+        let options = TCI2Options::default();
+
+        let (tci, _ranks, _errors) = crossinterpolate2(
+            f,
+            Some(batched_f),
+            local_dims,
+            first_pivot,
+            options,
+        ).unwrap();
+
+        assert_eq!(tci.len(), 2);
+    }
+
+    #[test]
+    fn test_crossinterpolate2_rank2_function() {
+        // f(i, j) = i + j
+        let f = |idx: &MultiIndex| (idx[0] + idx[1]) as f64;
+        let local_dims = vec![4, 4];
+        let first_pivot = vec![vec![1, 1]];
+        let mut options = TCI2Options::default();
+        options.tolerance = 1e-12;
+        options.max_iter = 10;
+
+        let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            f,
+            None,
+            local_dims,
+            first_pivot,
+            options,
+        ).unwrap();
+
+        // Should converge to rank 2
+        assert!(tci.rank() <= 3, "Expected rank <= 3, got {}", tci.rank());
+
+        // Check error is small
+        let final_error = errors.last().copied().unwrap_or(f64::INFINITY);
+        assert!(final_error < 0.1, "Expected small error, got {}", final_error);
+    }
+}

--- a/crates/tensor4all-tensortrain/Cargo.toml
+++ b/crates/tensor4all-tensortrain/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tensor4all-tensortrain"
+description = "Tensor Train (MPS) algorithms for tensor4all"
+version.workspace = true
+edition.workspace = true
+authors = [
+    "Simone Foderà <simone.fodera@lmu.de>",
+    "Marc Ritter <Ritter.Marc@physik.uni-muenchen.de>",
+    "Hiroshi Shinaoka <h.shinaoka@gmail.com>",
+]
+license = "MIT"
+repository.workspace = true
+
+[dependencies]
+num-complex.workspace = true
+num-traits.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+rand.workspace = true
+tensor4all-matrixci = { path = "../tensor4all-matrixci" }
+
+[dev-dependencies]
+approx = "0.5"

--- a/crates/tensor4all-tensortrain/src/arithmetic.rs
+++ b/crates/tensor4all-tensortrain/src/arithmetic.rs
@@ -1,0 +1,273 @@
+//! Arithmetic operations for tensor trains
+
+use crate::error::Result;
+use crate::tensortrain::TensorTrain;
+use crate::traits::{AbstractTensorTrain, TTScalar};
+use crate::types::Tensor3;
+
+impl<T: TTScalar> TensorTrain<T> {
+    /// Add two tensor trains element-wise
+    ///
+    /// The result has bond dimension equal to the sum of the input bond dimensions.
+    /// Use `compress` to reduce the bond dimension afterward.
+    pub fn add(&self, other: &Self) -> Result<Self> {
+        use crate::error::TensorTrainError;
+
+        if self.len() != other.len() {
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "Cannot add tensor trains of different lengths: {} vs {}",
+                    self.len(),
+                    other.len()
+                ),
+            });
+        }
+
+        if self.is_empty() {
+            return Ok(other.clone());
+        }
+
+        let n = self.len();
+        let mut tensors = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let a = self.site_tensor(i);
+            let b = other.site_tensor(i);
+
+            if a.site_dim() != b.site_dim() {
+                return Err(TensorTrainError::InvalidOperation {
+                    message: format!(
+                        "Site dimensions mismatch at site {}: {} vs {}",
+                        i,
+                        a.site_dim(),
+                        b.site_dim()
+                    ),
+                });
+            }
+
+            let site_dim = a.site_dim();
+
+            if i == 0 {
+                // First tensor: [A | B] horizontally
+                let new_right_dim = a.right_dim() + b.right_dim();
+                let mut new_tensor = Tensor3::zeros(1, site_dim, new_right_dim);
+
+                for s in 0..site_dim {
+                    for r in 0..a.right_dim() {
+                        new_tensor.set(0, s, r, *a.get(0, s, r));
+                    }
+                    for r in 0..b.right_dim() {
+                        new_tensor.set(0, s, a.right_dim() + r, *b.get(0, s, r));
+                    }
+                }
+                tensors.push(new_tensor);
+            } else if i == n - 1 {
+                // Last tensor: [A; B] vertically
+                let new_left_dim = a.left_dim() + b.left_dim();
+                let mut new_tensor = Tensor3::zeros(new_left_dim, site_dim, 1);
+
+                for l in 0..a.left_dim() {
+                    for s in 0..site_dim {
+                        new_tensor.set(l, s, 0, *a.get(l, s, 0));
+                    }
+                }
+                for l in 0..b.left_dim() {
+                    for s in 0..site_dim {
+                        new_tensor.set(a.left_dim() + l, s, 0, *b.get(l, s, 0));
+                    }
+                }
+                tensors.push(new_tensor);
+            } else {
+                // Middle tensors: block diagonal [A 0; 0 B]
+                let new_left_dim = a.left_dim() + b.left_dim();
+                let new_right_dim = a.right_dim() + b.right_dim();
+                let mut new_tensor = Tensor3::zeros(new_left_dim, site_dim, new_right_dim);
+
+                // Copy A block
+                for l in 0..a.left_dim() {
+                    for s in 0..site_dim {
+                        for r in 0..a.right_dim() {
+                            new_tensor.set(l, s, r, *a.get(l, s, r));
+                        }
+                    }
+                }
+                // Copy B block
+                for l in 0..b.left_dim() {
+                    for s in 0..site_dim {
+                        for r in 0..b.right_dim() {
+                            new_tensor.set(
+                                a.left_dim() + l,
+                                s,
+                                a.right_dim() + r,
+                                *b.get(l, s, r),
+                            );
+                        }
+                    }
+                }
+                tensors.push(new_tensor);
+            }
+        }
+
+        Ok(TensorTrain::from_tensors_unchecked(tensors))
+    }
+
+    /// Subtract another tensor train from this one
+    pub fn sub(&self, other: &Self) -> Result<Self> {
+        let neg_other = other.scaled(-T::one());
+        self.add(&neg_other)
+    }
+
+    /// Negate the tensor train (multiply by -1)
+    pub fn negate(&self) -> Self {
+        self.scaled(-T::one())
+    }
+}
+
+impl<T: TTScalar> std::ops::Add for TensorTrain<T> {
+    type Output = Result<Self>;
+
+    fn add(self, other: Self) -> Self::Output {
+        TensorTrain::add(&self, &other)
+    }
+}
+
+impl<T: TTScalar> std::ops::Add for &TensorTrain<T> {
+    type Output = Result<TensorTrain<T>>;
+
+    fn add(self, other: Self) -> Self::Output {
+        TensorTrain::add(self, other)
+    }
+}
+
+impl<T: TTScalar> std::ops::Sub for TensorTrain<T> {
+    type Output = Result<Self>;
+
+    fn sub(self, other: Self) -> Self::Output {
+        TensorTrain::sub(&self, &other)
+    }
+}
+
+impl<T: TTScalar> std::ops::Sub for &TensorTrain<T> {
+    type Output = Result<TensorTrain<T>>;
+
+    fn sub(self, other: Self) -> Self::Output {
+        TensorTrain::sub(self, other)
+    }
+}
+
+impl<T: TTScalar> std::ops::Neg for TensorTrain<T> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        self.negate()
+    }
+}
+
+impl<T: TTScalar> std::ops::Neg for &TensorTrain<T> {
+    type Output = TensorTrain<T>;
+
+    fn neg(self) -> Self::Output {
+        self.negate()
+    }
+}
+
+impl<T: TTScalar> std::ops::Mul<T> for TensorTrain<T> {
+    type Output = Self;
+
+    fn mul(self, scalar: T) -> Self::Output {
+        self.scaled(scalar)
+    }
+}
+
+impl<T: TTScalar> std::ops::Mul<T> for &TensorTrain<T> {
+    type Output = TensorTrain<T>;
+
+    fn mul(self, scalar: T) -> Self::Output {
+        self.scaled(scalar)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_constant_tensors() {
+        let tt1 = TensorTrain::<f64>::constant(&[2, 3], 1.0);
+        let tt2 = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+
+        let result = tt1.add(&tt2).unwrap();
+
+        // Sum should be (1.0 + 2.0) * 2 * 3 = 18.0
+        assert!((result.sum() - 18.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_sub_constant_tensors() {
+        let tt1 = TensorTrain::<f64>::constant(&[2, 3], 5.0);
+        let tt2 = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+
+        let result = tt1.sub(&tt2).unwrap();
+
+        // Sum should be (5.0 - 2.0) * 2 * 3 = 18.0
+        assert!((result.sum() - 18.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_negate() {
+        let tt = TensorTrain::<f64>::constant(&[2, 2], 3.0);
+        let neg_tt = tt.negate();
+
+        assert!((neg_tt.sum() + tt.sum()).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_add_operator() {
+        let tt1 = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+        let tt2 = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+
+        let result = (&tt1 + &tt2).unwrap();
+
+        // Sum should be 2.0 * 2 * 2 = 8.0
+        assert!((result.sum() - 8.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_add_preserves_evaluation() {
+        // Create two simple tensor trains
+        let mut t0_a = Tensor3::<f64>::zeros(1, 2, 1);
+        t0_a.set(0, 0, 0, 1.0);
+        t0_a.set(0, 1, 0, 2.0);
+
+        let mut t1_a = Tensor3::<f64>::zeros(1, 2, 1);
+        t1_a.set(0, 0, 0, 3.0);
+        t1_a.set(0, 1, 0, 4.0);
+
+        let tt_a = TensorTrain::new(vec![t0_a, t1_a]).unwrap();
+
+        let mut t0_b = Tensor3::<f64>::zeros(1, 2, 1);
+        t0_b.set(0, 0, 0, 0.5);
+        t0_b.set(0, 1, 0, 1.5);
+
+        let mut t1_b = Tensor3::<f64>::zeros(1, 2, 1);
+        t1_b.set(0, 0, 0, 2.5);
+        t1_b.set(0, 1, 0, 3.5);
+
+        let tt_b = TensorTrain::new(vec![t0_b, t1_b]).unwrap();
+
+        let result = tt_a.add(&tt_b).unwrap();
+
+        // Test some evaluations
+        // result([0, 0]) = a([0,0]) + b([0,0]) = 1*3 + 0.5*2.5 = 3 + 1.25 = 4.25
+        let val_00 = result.evaluate(&[0, 0]).unwrap();
+        let expected_00 =
+            tt_a.evaluate(&[0, 0]).unwrap() + tt_b.evaluate(&[0, 0]).unwrap();
+        assert!((val_00 - expected_00).abs() < 1e-10);
+
+        // result([1, 1]) = a([1,1]) + b([1,1]) = 2*4 + 1.5*3.5 = 8 + 5.25 = 13.25
+        let val_11 = result.evaluate(&[1, 1]).unwrap();
+        let expected_11 =
+            tt_a.evaluate(&[1, 1]).unwrap() + tt_b.evaluate(&[1, 1]).unwrap();
+        assert!((val_11 - expected_11).abs() < 1e-10);
+    }
+}

--- a/crates/tensor4all-tensortrain/src/compression.rs
+++ b/crates/tensor4all-tensortrain/src/compression.rs
@@ -1,0 +1,340 @@
+//! Compression algorithms for tensor trains
+
+use crate::error::Result;
+use crate::tensortrain::TensorTrain;
+use crate::traits::{AbstractTensorTrain, TTScalar};
+use crate::types::Tensor3;
+use tensor4all_matrixci::util::{mat_mul, nrows, ncols, zeros, Matrix, Scalar};
+use tensor4all_matrixci::{rrlu, AbstractMatrixCI, MatrixLUCI, RrLUOptions};
+
+/// Compression method for tensor trains
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompressionMethod {
+    /// LU decomposition (rank-revealing)
+    #[default]
+    LU,
+    /// Cross interpolation based
+    CI,
+    /// SVD decomposition (requires lapack feature)
+    SVD,
+}
+
+/// Options for compression
+#[derive(Debug, Clone)]
+pub struct CompressionOptions {
+    /// Compression method
+    pub method: CompressionMethod,
+    /// Tolerance for truncation (relative)
+    pub tolerance: f64,
+    /// Maximum bond dimension
+    pub max_bond_dim: usize,
+    /// Whether to normalize the error
+    pub normalize_error: bool,
+}
+
+impl Default for CompressionOptions {
+    fn default() -> Self {
+        Self {
+            method: CompressionMethod::LU,
+            tolerance: 1e-12,
+            max_bond_dim: usize::MAX,
+            normalize_error: true,
+        }
+    }
+}
+
+/// Convert Tensor3 to Matrix for factorization (left matrix view)
+fn tensor3_to_left_matrix<T: Scalar + Default>(tensor: &Tensor3<T>) -> Matrix<T> {
+    let left_dim = tensor.left_dim();
+    let site_dim = tensor.site_dim();
+    let right_dim = tensor.right_dim();
+    let rows = left_dim * site_dim;
+    let cols = right_dim;
+
+    let mut mat = zeros(rows, cols);
+    for l in 0..left_dim {
+        for s in 0..site_dim {
+            for r in 0..right_dim {
+                mat[[l * site_dim + s, r]] = *tensor.get(l, s, r);
+            }
+        }
+    }
+    mat
+}
+
+/// Convert Tensor3 to Matrix for factorization (right matrix view)
+fn tensor3_to_right_matrix<T: Scalar + Default>(tensor: &Tensor3<T>) -> Matrix<T> {
+    let left_dim = tensor.left_dim();
+    let site_dim = tensor.site_dim();
+    let right_dim = tensor.right_dim();
+    let rows = left_dim;
+    let cols = site_dim * right_dim;
+
+    let mut mat = zeros(rows, cols);
+    for l in 0..left_dim {
+        for s in 0..site_dim {
+            for r in 0..right_dim {
+                mat[[l, s * right_dim + r]] = *tensor.get(l, s, r);
+            }
+        }
+    }
+    mat
+}
+
+/// Factorize a matrix into left and right factors
+fn factorize<T: TTScalar + Scalar>(
+    matrix: &Matrix<T>,
+    method: CompressionMethod,
+    tolerance: f64,
+    max_bond_dim: usize,
+    left_orthogonal: bool,
+) -> (Matrix<T>, Matrix<T>, usize) {
+    let reltol = if tolerance > 0.0 { tolerance } else { 1e-14 };
+    let abstol = 0.0;
+
+    let options = RrLUOptions {
+        max_rank: max_bond_dim,
+        rel_tol: reltol,
+        abs_tol: abstol,
+        left_orthogonal,
+    };
+
+    match method {
+        CompressionMethod::LU => {
+            let lu = rrlu(matrix, Some(options));
+            let left = lu.left(true);  // permuted
+            let right = lu.right(true);  // permuted
+            let npivots = lu.npivots();
+            (left, right, npivots)
+        }
+        CompressionMethod::CI => {
+            let luci = MatrixLUCI::from_matrix(matrix, Some(options));
+            let left = luci.left();
+            let right = luci.right();
+            let npivots = luci.rank();
+            (left, right, npivots)
+        }
+        CompressionMethod::SVD => {
+            // For SVD, we'd need a linear algebra library
+            // For now, fall back to LU
+            let lu = rrlu(matrix, Some(options));
+            let left = lu.left(true);
+            let right = lu.right(true);
+            let npivots = lu.npivots();
+            (left, right, npivots)
+        }
+    }
+}
+
+impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
+    /// Compress the tensor train in-place using the specified method
+    ///
+    /// This performs a two-sweep compression:
+    /// 1. Left-to-right sweep with left-orthogonal factorization (no truncation)
+    /// 2. Right-to-left sweep with truncation
+    pub fn compress(&mut self, options: &CompressionOptions) -> Result<()> {
+        let n = self.len();
+        if n <= 1 {
+            return Ok(());
+        }
+
+        let tensors = self.site_tensors_mut();
+
+        // Left-to-right sweep: make left-orthogonal without truncation
+        for ell in 0..n - 1 {
+            let left_dim = tensors[ell].left_dim();
+            let site_dim = tensors[ell].site_dim();
+
+            // Reshape to matrix: (left_dim * site_dim, right_dim)
+            let mat = tensor3_to_left_matrix(&tensors[ell]);
+
+            // Factorize without truncation
+            let (left_factor, right_factor, new_bond_dim) = factorize(
+                &mat,
+                options.method,
+                0.0,         // No truncation in left sweep
+                usize::MAX,  // No max bond dim in left sweep
+                true,        // left orthogonal
+            );
+
+            // Update current tensor
+            let mut new_tensor = Tensor3::zeros(left_dim, site_dim, new_bond_dim);
+            for l in 0..left_dim {
+                for s in 0..site_dim {
+                    for r in 0..new_bond_dim {
+                        let row = l * site_dim + s;
+                        if row < nrows(&left_factor) && r < ncols(&left_factor) {
+                            new_tensor.set(l, s, r, left_factor[[row, r]]);
+                        }
+                    }
+                }
+            }
+            tensors[ell] = new_tensor;
+
+            // Contract right_factor with next tensor
+            let next_site_dim = tensors[ell + 1].site_dim();
+            let next_right_dim = tensors[ell + 1].right_dim();
+
+            // Build next tensor as matrix (old_left_dim, site_dim * right_dim)
+            let next_mat = tensor3_to_right_matrix(&tensors[ell + 1]);
+
+            // Multiply: right_factor * next_mat
+            let contracted = mat_mul(&right_factor, &next_mat);
+
+            // Update next tensor
+            let mut new_next_tensor = Tensor3::zeros(new_bond_dim, next_site_dim, next_right_dim);
+            for l in 0..new_bond_dim {
+                for s in 0..next_site_dim {
+                    for r in 0..next_right_dim {
+                        new_next_tensor.set(l, s, r, contracted[[l, s * next_right_dim + r]]);
+                    }
+                }
+            }
+            tensors[ell + 1] = new_next_tensor;
+        }
+
+        // Right-to-left sweep: truncate
+        for ell in (1..n).rev() {
+            let site_dim = tensors[ell].site_dim();
+            let right_dim = tensors[ell].right_dim();
+
+            // Reshape to matrix: (left_dim, site_dim * right_dim)
+            let mat = tensor3_to_right_matrix(&tensors[ell]);
+
+            // Factorize with truncation
+            let (left_factor, right_factor, new_bond_dim) = factorize(
+                &mat,
+                options.method,
+                options.tolerance,
+                options.max_bond_dim,
+                false,  // right orthogonal
+            );
+
+            // Update current tensor from right_factor
+            let mut new_tensor = Tensor3::zeros(new_bond_dim, site_dim, right_dim);
+            for l in 0..new_bond_dim {
+                for s in 0..site_dim {
+                    for r in 0..right_dim {
+                        new_tensor.set(l, s, r, right_factor[[l, s * right_dim + r]]);
+                    }
+                }
+            }
+            tensors[ell] = new_tensor;
+
+            // Contract previous tensor with left_factor
+            let prev_left_dim = tensors[ell - 1].left_dim();
+            let prev_site_dim = tensors[ell - 1].site_dim();
+
+            // Build prev tensor as matrix (left_dim * site_dim, old_right_dim)
+            let prev_mat = tensor3_to_left_matrix(&tensors[ell - 1]);
+
+            // Multiply: prev_mat * left_factor
+            let contracted = mat_mul(&prev_mat, &left_factor);
+
+            // Update prev tensor
+            let mut new_prev_tensor = Tensor3::zeros(prev_left_dim, prev_site_dim, new_bond_dim);
+            for l in 0..prev_left_dim {
+                for s in 0..prev_site_dim {
+                    for r in 0..new_bond_dim {
+                        new_prev_tensor.set(l, s, r, contracted[[l * prev_site_dim + s, r]]);
+                    }
+                }
+            }
+            tensors[ell - 1] = new_prev_tensor;
+        }
+
+        Ok(())
+    }
+
+    /// Create a compressed copy of the tensor train
+    pub fn compressed(&self, options: &CompressionOptions) -> Result<Self> {
+        let mut result = self.clone();
+        result.compress(options)?;
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compress_constant() {
+        let tt = TensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
+        let original_sum = tt.sum();
+
+        let mut tt_compressed = tt.clone();
+        tt_compressed.compress(&CompressionOptions::default()).unwrap();
+
+        let compressed_sum = tt_compressed.sum();
+        assert!((original_sum - compressed_sum).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_compress_preserves_values() {
+        // Create a simple tensor train
+        let mut t0 = Tensor3::<f64>::zeros(1, 2, 2);
+        t0.set(0, 0, 0, 1.0);
+        t0.set(0, 0, 1, 0.5);
+        t0.set(0, 1, 0, 0.0);
+        t0.set(0, 1, 1, 1.0);
+
+        let mut t1 = Tensor3::<f64>::zeros(2, 3, 2);
+        for l in 0..2 {
+            for s in 0..3 {
+                for r in 0..2 {
+                    t1.set(l, s, r, ((l + s + r) as f64) * 0.1 + 0.1);
+                }
+            }
+        }
+
+        let mut t2 = Tensor3::<f64>::zeros(2, 2, 1);
+        t2.set(0, 0, 0, 1.0);
+        t2.set(0, 1, 0, 0.5);
+        t2.set(1, 0, 0, 0.5);
+        t2.set(1, 1, 0, 1.0);
+
+        let tt = TensorTrain::new(vec![t0, t1, t2]).unwrap();
+        let original_sum = tt.sum();
+
+        let mut tt_compressed = tt.clone();
+        tt_compressed.compress(&CompressionOptions::default()).unwrap();
+
+        let compressed_sum = tt_compressed.sum();
+        assert!((original_sum - compressed_sum).abs() < 1e-8);
+    }
+
+    #[test]
+    fn test_compress_with_max_bond_dim() {
+        // Create a tensor train with higher bond dimension
+        let mut t0 = Tensor3::<f64>::zeros(1, 2, 3);
+        for s in 0..2 {
+            for r in 0..3 {
+                t0.set(0, s, r, (s + r + 1) as f64);
+            }
+        }
+
+        let mut t1 = Tensor3::<f64>::zeros(3, 2, 1);
+        for l in 0..3 {
+            for s in 0..2 {
+                t1.set(l, s, 0, (l + s + 1) as f64);
+            }
+        }
+
+        let tt = TensorTrain::new(vec![t0, t1]).unwrap();
+        let original_sum = tt.sum();
+
+        let options = CompressionOptions {
+            max_bond_dim: 2,
+            tolerance: 1e-12,
+            ..Default::default()
+        };
+
+        let mut tt_compressed = tt.clone();
+        tt_compressed.compress(&options).unwrap();
+
+        // Sum should be approximately preserved (with some truncation error)
+        let compressed_sum = tt_compressed.sum();
+        assert!((original_sum - compressed_sum).abs() < original_sum.abs() * 0.1);
+    }
+}

--- a/crates/tensor4all-tensortrain/src/contraction.rs
+++ b/crates/tensor4all-tensortrain/src/contraction.rs
@@ -1,0 +1,588 @@
+//! Contraction operations for tensor trains
+//!
+//! This module provides various ways to combine tensor trains:
+//! - `hadamard`: Element-wise (Hadamard) product
+//! - `dot`: Inner product (returns scalar)
+//! - `hadamard_zipup`: Hadamard product with on-the-fly compression
+
+use crate::compression::{CompressionMethod, CompressionOptions};
+use crate::error::{Result, TensorTrainError};
+use crate::tensortrain::TensorTrain;
+use crate::traits::{AbstractTensorTrain, TTScalar};
+use crate::types::Tensor3;
+use tensor4all_matrixci::util::{nrows, ncols, zeros, Matrix, Scalar};
+use tensor4all_matrixci::{AbstractMatrixCI, MatrixLUCI, RrLUOptions};
+
+/// Options for contraction with compression
+#[derive(Debug, Clone)]
+pub struct ContractionOptions {
+    /// Tolerance for truncation
+    pub tolerance: f64,
+    /// Maximum bond dimension
+    pub max_bond_dim: usize,
+    /// Compression method (LU or CI)
+    pub method: CompressionMethod,
+}
+
+impl Default for ContractionOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 1e-12,
+            max_bond_dim: usize::MAX,
+            method: CompressionMethod::LU,
+        }
+    }
+}
+
+impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
+    /// Compute the Hadamard (element-wise) product of two tensor trains
+    ///
+    /// For each index i = (i1, i2, ..., iL):
+    ///   result[i] = self[i] * other[i]
+    ///
+    /// The resulting bond dimension is the product of the input bond dimensions.
+    /// Use `compress` afterward to reduce the bond dimension.
+    pub fn hadamard(&self, other: &Self) -> Result<Self> {
+        if self.len() != other.len() {
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "Cannot compute Hadamard product of tensor trains with different lengths: {} vs {}",
+                    self.len(),
+                    other.len()
+                ),
+            });
+        }
+
+        if self.is_empty() {
+            return Ok(Self::from_tensors_unchecked(Vec::new()));
+        }
+
+        let n = self.len();
+        let mut tensors = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let a = self.site_tensor(i);
+            let b = other.site_tensor(i);
+
+            if a.site_dim() != b.site_dim() {
+                return Err(TensorTrainError::InvalidOperation {
+                    message: format!(
+                        "Site dimensions mismatch at site {}: {} vs {}",
+                        i,
+                        a.site_dim(),
+                        b.site_dim()
+                    ),
+                });
+            }
+
+            let site_dim = a.site_dim();
+            let new_left_dim = a.left_dim() * b.left_dim();
+            let new_right_dim = a.right_dim() * b.right_dim();
+
+            let mut new_tensor = Tensor3::zeros(new_left_dim, site_dim, new_right_dim);
+
+            // Kronecker product on bond indices
+            // new[la*lb, s, ra*rb] = a[la, s, ra] * b[lb, s, rb]
+            for la in 0..a.left_dim() {
+                for lb in 0..b.left_dim() {
+                    for s in 0..site_dim {
+                        for ra in 0..a.right_dim() {
+                            for rb in 0..b.right_dim() {
+                                let new_l = la * b.left_dim() + lb;
+                                let new_r = ra * b.right_dim() + rb;
+                                let val = *a.get(la, s, ra) * *b.get(lb, s, rb);
+                                new_tensor.set(new_l, s, new_r, val);
+                            }
+                        }
+                    }
+                }
+            }
+
+            tensors.push(new_tensor);
+        }
+
+        Ok(TensorTrain::from_tensors_unchecked(tensors))
+    }
+
+    /// Compute the inner product (dot product) of two tensor trains
+    ///
+    /// Returns: sum over all indices i of self[i] * other[i]
+    ///
+    /// This is equivalent to hadamard(self, other).sum() but more efficient.
+    pub fn dot(&self, other: &Self) -> Result<T> {
+        if self.len() != other.len() {
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "Cannot compute dot product of tensor trains with different lengths: {} vs {}",
+                    self.len(),
+                    other.len()
+                ),
+            });
+        }
+
+        if self.is_empty() {
+            return Ok(T::zero());
+        }
+
+        let n = self.len();
+
+        // Start with contraction of first site
+        // result[ra, rb] = sum_s a[0, s, ra] * b[0, s, rb]
+        let a0 = self.site_tensor(0);
+        let b0 = other.site_tensor(0);
+
+        if a0.site_dim() != b0.site_dim() {
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "Site dimensions mismatch at site 0: {} vs {}",
+                    a0.site_dim(),
+                    b0.site_dim()
+                ),
+            });
+        }
+
+        let mut result: Matrix<T> = zeros(a0.right_dim(), b0.right_dim());
+        for s in 0..a0.site_dim() {
+            for ra in 0..a0.right_dim() {
+                for rb in 0..b0.right_dim() {
+                    result[[ra, rb]] = result[[ra, rb]] + *a0.get(0, s, ra) * *b0.get(0, s, rb);
+                }
+            }
+        }
+
+        // Contract through remaining sites
+        for i in 1..n {
+            let a = self.site_tensor(i);
+            let b = other.site_tensor(i);
+
+            if a.site_dim() != b.site_dim() {
+                return Err(TensorTrainError::InvalidOperation {
+                    message: format!(
+                        "Site dimensions mismatch at site {}: {} vs {}",
+                        i,
+                        a.site_dim(),
+                        b.site_dim()
+                    ),
+                });
+            }
+
+            // new_result[ra', rb'] = sum_{la, lb, s} result[la, lb] * a[la, s, ra'] * b[lb, s, rb']
+            let mut new_result: Matrix<T> = zeros(a.right_dim(), b.right_dim());
+
+            for la in 0..a.left_dim() {
+                for lb in 0..b.left_dim() {
+                    let r_val = result[[la, lb]];
+                    for s in 0..a.site_dim() {
+                        for ra in 0..a.right_dim() {
+                            for rb in 0..b.right_dim() {
+                                new_result[[ra, rb]] = new_result[[ra, rb]]
+                                    + r_val * *a.get(la, s, ra) * *b.get(lb, s, rb);
+                            }
+                        }
+                    }
+                }
+            }
+
+            result = new_result;
+        }
+
+        // Final result should be 1x1
+        Ok(result[[0, 0]])
+    }
+
+    /// Compute Hadamard product with on-the-fly compression (zip-up algorithm)
+    ///
+    /// This is more efficient than hadamard() followed by compress() for
+    /// tensor trains with large bond dimensions, as it compresses at each step.
+    ///
+    /// Reference: https://tensornetwork.org/mps/algorithms/zip_up_mpo/
+    pub fn hadamard_zipup(&self, other: &Self, options: &ContractionOptions) -> Result<Self> {
+        if self.len() != other.len() {
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "Cannot compute Hadamard product of tensor trains with different lengths: {} vs {}",
+                    self.len(),
+                    other.len()
+                ),
+            });
+        }
+
+        if self.is_empty() {
+            return Ok(Self::from_tensors_unchecked(Vec::new()));
+        }
+
+        let n = self.len();
+
+        // R tensor carries the remainder from the previous factorization
+        // R[link_new, link_a, link_b]
+        let mut r_tensor: Tensor3<T> = Tensor3::zeros(1, 1, 1);
+        r_tensor.set(0, 0, 0, T::one());
+
+        let mut result_tensors = Vec::with_capacity(n);
+
+        for i in 0..n {
+            let a = self.site_tensor(i);
+            let b = other.site_tensor(i);
+
+            if a.site_dim() != b.site_dim() {
+                return Err(TensorTrainError::InvalidOperation {
+                    message: format!(
+                        "Site dimensions mismatch at site {}: {} vs {}",
+                        i,
+                        a.site_dim(),
+                        b.site_dim()
+                    ),
+                });
+            }
+
+            let site_dim = a.site_dim();
+
+            // Contract R with A and B:
+            // C[link_new, s, link_a', link_b'] = sum_{link_a, link_b} R[link_new, link_a, link_b]
+            //                                   * A[link_a, s, link_a'] * B[link_b, s, link_b']
+            let link_new = r_tensor.left_dim();
+            let link_a_next = a.right_dim();
+            let link_b_next = b.right_dim();
+
+            let mut c_tensor = Tensor3::<T>::zeros(
+                link_new * site_dim,
+                link_a_next,
+                link_b_next,
+            );
+
+            for ln in 0..r_tensor.left_dim() {
+                for la in 0..a.left_dim() {
+                    for lb in 0..b.left_dim() {
+                        let r_val = *r_tensor.get(ln, la, lb);
+                        for s in 0..site_dim {
+                            for ra in 0..link_a_next {
+                                for rb in 0..link_b_next {
+                                    let val = r_val * *a.get(la, s, ra) * *b.get(lb, s, rb);
+                                    let row = ln * site_dim + s;
+                                    let old_val = *c_tensor.get(row, ra, rb);
+                                    c_tensor.set(row, ra, rb, old_val + val);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if i == n - 1 {
+                // Last site: just reshape and store
+                let mut result_tensor = Tensor3::zeros(link_new, site_dim, 1);
+                for ln in 0..link_new {
+                    for s in 0..site_dim {
+                        // Sum over all link_a', link_b' (should be 1x1)
+                        result_tensor.set(ln, s, 0, *c_tensor.get(ln * site_dim + s, 0, 0));
+                    }
+                }
+                result_tensors.push(result_tensor);
+            } else {
+                // Factorize C into left and right parts
+                // C is (link_new * site_dim) x (link_a' * link_b')
+                let rows = link_new * site_dim;
+                let cols = link_a_next * link_b_next;
+
+                let mut c_mat: Matrix<T> = zeros(rows, cols);
+                for row in 0..rows {
+                    for ra in 0..link_a_next {
+                        for rb in 0..link_b_next {
+                            c_mat[[row, ra * link_b_next + rb]] = *c_tensor.get(row, ra, rb);
+                        }
+                    }
+                }
+
+                // Apply LU-based factorization
+                let lu_options = RrLUOptions {
+                    max_rank: options.max_bond_dim,
+                    rel_tol: options.tolerance,
+                    abs_tol: 0.0,
+                    left_orthogonal: true,
+                };
+
+                let luci = MatrixLUCI::from_matrix(&c_mat, Some(lu_options));
+                let left = luci.left();
+                let right = luci.right();
+                let new_bond_dim = luci.rank().max(1);
+
+                // Store left factor as site tensor: (link_new, site_dim, new_bond_dim)
+                let mut result_tensor = Tensor3::zeros(link_new, site_dim, new_bond_dim);
+                for ln in 0..link_new {
+                    for s in 0..site_dim {
+                        for r in 0..new_bond_dim {
+                            let row = ln * site_dim + s;
+                            if row < nrows(&left) && r < ncols(&left) {
+                                result_tensor.set(ln, s, r, left[[row, r]]);
+                            }
+                        }
+                    }
+                }
+                result_tensors.push(result_tensor);
+
+                // Update R tensor for next iteration: (new_bond_dim, link_a', link_b')
+                r_tensor = Tensor3::zeros(new_bond_dim, link_a_next, link_b_next);
+                for l in 0..new_bond_dim {
+                    for ra in 0..link_a_next {
+                        for rb in 0..link_b_next {
+                            let col = ra * link_b_next + rb;
+                            if l < nrows(&right) && col < ncols(&right) {
+                                r_tensor.set(l, ra, rb, right[[l, col]]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(TensorTrain::from_tensors_unchecked(result_tensors))
+    }
+
+    /// Compute Hadamard product followed by compression
+    ///
+    /// Equivalent to self.hadamard(other)?.compress(options) but may be
+    /// more efficient for large bond dimensions.
+    pub fn hadamard_compressed(
+        &self,
+        other: &Self,
+        options: &CompressionOptions,
+    ) -> Result<Self> {
+        let mut result = self.hadamard(other)?;
+        result.compress(options)?;
+        Ok(result)
+    }
+}
+
+/// Convenience function to compute Hadamard product
+pub fn hadamard<T: TTScalar + Scalar + Default>(
+    a: &TensorTrain<T>,
+    b: &TensorTrain<T>,
+) -> Result<TensorTrain<T>> {
+    a.hadamard(b)
+}
+
+/// Convenience function to compute dot product
+pub fn dot<T: TTScalar + Scalar + Default>(
+    a: &TensorTrain<T>,
+    b: &TensorTrain<T>,
+) -> Result<T> {
+    a.dot(b)
+}
+
+/// Convenience function for Hadamard with zip-up compression
+pub fn hadamard_zipup<T: TTScalar + Scalar + Default>(
+    a: &TensorTrain<T>,
+    b: &TensorTrain<T>,
+    options: &ContractionOptions,
+) -> Result<TensorTrain<T>> {
+    a.hadamard_zipup(b, options)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hadamard_constant() {
+        let tt1 = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+        let tt2 = TensorTrain::<f64>::constant(&[2, 3], 3.0);
+
+        let result = tt1.hadamard(&tt2).unwrap();
+
+        // Each element should be 2.0 * 3.0 = 6.0
+        // Sum should be 6.0 * 2 * 3 = 36.0
+        assert!((result.sum() - 36.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_hadamard_preserves_evaluation() {
+        // Create two simple tensor trains
+        let mut t0_a = Tensor3::<f64>::zeros(1, 2, 1);
+        t0_a.set(0, 0, 0, 1.0);
+        t0_a.set(0, 1, 0, 2.0);
+
+        let mut t1_a = Tensor3::<f64>::zeros(1, 2, 1);
+        t1_a.set(0, 0, 0, 3.0);
+        t1_a.set(0, 1, 0, 4.0);
+
+        let tt_a = TensorTrain::new(vec![t0_a, t1_a]).unwrap();
+
+        let mut t0_b = Tensor3::<f64>::zeros(1, 2, 1);
+        t0_b.set(0, 0, 0, 0.5);
+        t0_b.set(0, 1, 0, 1.5);
+
+        let mut t1_b = Tensor3::<f64>::zeros(1, 2, 1);
+        t1_b.set(0, 0, 0, 2.0);
+        t1_b.set(0, 1, 0, 3.0);
+
+        let tt_b = TensorTrain::new(vec![t0_b, t1_b]).unwrap();
+
+        let result = tt_a.hadamard(&tt_b).unwrap();
+
+        // Test evaluations
+        // result([0, 0]) = a([0,0]) * b([0,0]) = (1*3) * (0.5*2) = 3 * 1 = 3
+        let val_00 = result.evaluate(&[0, 0]).unwrap();
+        let expected_00 = tt_a.evaluate(&[0, 0]).unwrap() * tt_b.evaluate(&[0, 0]).unwrap();
+        assert!((val_00 - expected_00).abs() < 1e-10);
+
+        // result([1, 1]) = a([1,1]) * b([1,1]) = (2*4) * (1.5*3) = 8 * 4.5 = 36
+        let val_11 = result.evaluate(&[1, 1]).unwrap();
+        let expected_11 = tt_a.evaluate(&[1, 1]).unwrap() * tt_b.evaluate(&[1, 1]).unwrap();
+        assert!((val_11 - expected_11).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_dot_constant() {
+        let tt1 = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+        let tt2 = TensorTrain::<f64>::constant(&[2, 3], 3.0);
+
+        let result = tt1.dot(&tt2).unwrap();
+
+        // Each element product is 2.0 * 3.0 = 6.0
+        // Sum over 2*3=6 elements: 6.0 * 6 = 36.0
+        assert!((result - 36.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_dot_equals_hadamard_sum() {
+        let mut t0_a = Tensor3::<f64>::zeros(1, 3, 2);
+        for s in 0..3 {
+            for r in 0..2 {
+                t0_a.set(0, s, r, (s + r + 1) as f64);
+            }
+        }
+
+        let mut t1_a = Tensor3::<f64>::zeros(2, 2, 1);
+        for l in 0..2 {
+            for s in 0..2 {
+                t1_a.set(l, s, 0, (l + s + 1) as f64);
+            }
+        }
+
+        let tt_a = TensorTrain::new(vec![t0_a.clone(), t1_a.clone()]).unwrap();
+
+        let mut t0_b = Tensor3::<f64>::zeros(1, 3, 1);
+        for s in 0..3 {
+            t0_b.set(0, s, 0, (s + 1) as f64 * 0.5);
+        }
+
+        let mut t1_b = Tensor3::<f64>::zeros(1, 2, 1);
+        for s in 0..2 {
+            t1_b.set(0, s, 0, (s + 2) as f64 * 0.3);
+        }
+
+        let tt_b = TensorTrain::new(vec![t0_b, t1_b]).unwrap();
+
+        let hadamard_result = tt_a.hadamard(&tt_b).unwrap();
+        let hadamard_sum = hadamard_result.sum();
+
+        let dot_result = tt_a.dot(&tt_b).unwrap();
+
+        assert!(
+            (hadamard_sum - dot_result).abs() < 1e-10,
+            "hadamard.sum() = {}, dot = {}",
+            hadamard_sum,
+            dot_result
+        );
+    }
+
+    #[test]
+    fn test_hadamard_zipup_constant() {
+        let tt1 = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+        let tt2 = TensorTrain::<f64>::constant(&[2, 3], 3.0);
+
+        let options = ContractionOptions::default();
+        let result = tt1.hadamard_zipup(&tt2, &options).unwrap();
+
+        // Each element should be 2.0 * 3.0 = 6.0
+        // Sum should be 6.0 * 2 * 3 = 36.0
+        assert!((result.sum() - 36.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_hadamard_zipup_preserves_values() {
+        let mut t0_a = Tensor3::<f64>::zeros(1, 2, 2);
+        t0_a.set(0, 0, 0, 1.0);
+        t0_a.set(0, 0, 1, 0.5);
+        t0_a.set(0, 1, 0, 2.0);
+        t0_a.set(0, 1, 1, 1.0);
+
+        let mut t1_a = Tensor3::<f64>::zeros(2, 2, 1);
+        t1_a.set(0, 0, 0, 1.0);
+        t1_a.set(0, 1, 0, 2.0);
+        t1_a.set(1, 0, 0, 0.5);
+        t1_a.set(1, 1, 0, 1.5);
+
+        let tt_a = TensorTrain::new(vec![t0_a, t1_a]).unwrap();
+
+        let tt_b = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+
+        let options = ContractionOptions::default();
+        let zipup_result = tt_a.hadamard_zipup(&tt_b, &options).unwrap();
+        let naive_result = tt_a.hadamard(&tt_b).unwrap();
+
+        // Check that values match
+        for i in 0..2 {
+            for j in 0..2 {
+                let zipup_val = zipup_result.evaluate(&[i, j]).unwrap();
+                let naive_val = naive_result.evaluate(&[i, j]).unwrap();
+                assert!(
+                    (zipup_val - naive_val).abs() < 1e-10,
+                    "Mismatch at [{}, {}]: zipup={}, naive={}",
+                    i,
+                    j,
+                    zipup_val,
+                    naive_val
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_hadamard_zipup_compresses() {
+        // Create tensor trains with higher bond dimensions
+        let mut t0_a = Tensor3::<f64>::zeros(1, 2, 3);
+        for s in 0..2 {
+            for r in 0..3 {
+                t0_a.set(0, s, r, 1.0);
+            }
+        }
+
+        let mut t1_a = Tensor3::<f64>::zeros(3, 2, 1);
+        for l in 0..3 {
+            for s in 0..2 {
+                t1_a.set(l, s, 0, 1.0);
+            }
+        }
+
+        let tt_a = TensorTrain::new(vec![t0_a, t1_a]).unwrap();
+        let tt_b = tt_a.clone();
+
+        // Naive Hadamard would give bond dim 3*3=9
+        let naive_result = tt_a.hadamard(&tt_b).unwrap();
+        assert_eq!(naive_result.link_dims(), vec![9]);
+
+        // Zipup should compress
+        let options = ContractionOptions {
+            tolerance: 1e-12,
+            max_bond_dim: 5,
+            method: CompressionMethod::LU,
+        };
+        let zipup_result = tt_a.hadamard_zipup(&tt_b, &options).unwrap();
+
+        // Check bond dimension is reduced
+        assert!(
+            zipup_result.link_dims()[0] <= 5,
+            "Expected bond dim <= 5, got {}",
+            zipup_result.link_dims()[0]
+        );
+
+        // Values should still be close
+        assert!(
+            (zipup_result.sum() - naive_result.sum()).abs() < 1e-8,
+            "Sum mismatch: zipup={}, naive={}",
+            zipup_result.sum(),
+            naive_result.sum()
+        );
+    }
+}

--- a/crates/tensor4all-tensortrain/src/error.rs
+++ b/crates/tensor4all-tensortrain/src/error.rs
@@ -1,0 +1,30 @@
+//! Error types for tensor train operations
+
+use thiserror::Error;
+
+/// Result type for tensor train operations
+pub type Result<T> = std::result::Result<T, TensorTrainError>;
+
+/// Errors that can occur during tensor train operations
+#[derive(Error, Debug)]
+pub enum TensorTrainError {
+    /// Dimension mismatch between tensors
+    #[error("Dimension mismatch: tensor at site {site} has incompatible dimensions")]
+    DimensionMismatch { site: usize },
+
+    /// Invalid index provided
+    #[error("Index out of bounds: index {index} at site {site} (max: {max})")]
+    IndexOutOfBounds { site: usize, index: usize, max: usize },
+
+    /// Length mismatch in index set
+    #[error("Index set length mismatch: expected {expected}, got {got}")]
+    IndexLengthMismatch { expected: usize, got: usize },
+
+    /// Empty tensor train
+    #[error("Tensor train is empty")]
+    Empty,
+
+    /// Invalid operation
+    #[error("Invalid operation: {message}")]
+    InvalidOperation { message: String },
+}

--- a/crates/tensor4all-tensortrain/src/lib.rs
+++ b/crates/tensor4all-tensortrain/src/lib.rs
@@ -1,0 +1,40 @@
+//! Tensor Train (MPS) library
+//!
+//! This crate provides tensor train (also known as Matrix Product State) algorithms,
+//! including:
+//! - `TensorTrain`: The main tensor train structure
+//! - Compression algorithms (LU, CI, SVD)
+//! - Arithmetic operations (add, subtract, scale)
+//!
+//! # Example
+//!
+//! ```
+//! use tensor4all_tensortrain::{TensorTrain, AbstractTensorTrain};
+//!
+//! // Create a constant tensor train
+//! let tt = TensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
+//!
+//! // Evaluate at a specific index
+//! let value = tt.evaluate(&[0, 1, 1]).unwrap();
+//! println!("Value: {}", value);
+//!
+//! // Sum over all indices
+//! let sum = tt.sum();
+//! println!("Sum: {}", sum);
+//! ```
+
+pub mod arithmetic;
+pub mod compression;
+pub mod contraction;
+pub mod error;
+pub mod tensortrain;
+pub mod traits;
+pub mod types;
+
+// Re-export main types
+pub use compression::{CompressionMethod, CompressionOptions};
+pub use contraction::{dot, hadamard, hadamard_zipup, ContractionOptions};
+pub use error::{Result, TensorTrainError};
+pub use tensortrain::TensorTrain;
+pub use traits::{AbstractTensorTrain, TTScalar};
+pub use types::{LocalIndex, MultiIndex, Tensor3};

--- a/crates/tensor4all-tensortrain/src/tensortrain.rs
+++ b/crates/tensor4all-tensortrain/src/tensortrain.rs
@@ -1,0 +1,250 @@
+//! TensorTrain implementation
+
+use crate::error::{Result, TensorTrainError};
+use crate::traits::{AbstractTensorTrain, TTScalar};
+use crate::types::Tensor3;
+
+/// Tensor Train (Matrix Product State) representation
+///
+/// A tensor train represents a high-dimensional tensor as a product of
+/// lower-dimensional tensors:
+///
+/// T[i1, i2, ..., iL] = A1[i1] * A2[i2] * ... * AL[iL]
+///
+/// where each Ak[ik] is a matrix of shape (rk-1, rk).
+#[derive(Debug, Clone)]
+pub struct TensorTrain<T: TTScalar> {
+    /// The tensors that make up the tensor train
+    /// Each tensor has shape (left_bond, site_dim, right_bond)
+    tensors: Vec<Tensor3<T>>,
+}
+
+impl<T: TTScalar> TensorTrain<T> {
+    /// Create a new tensor train from a list of 3D tensors
+    ///
+    /// Each tensor should have shape (left_bond, site_dim, right_bond)
+    /// where the right_bond of tensor i equals the left_bond of tensor i+1.
+    pub fn new(tensors: Vec<Tensor3<T>>) -> Result<Self> {
+        // Validate dimensions
+        for i in 0..tensors.len().saturating_sub(1) {
+            if tensors[i].right_dim() != tensors[i + 1].left_dim() {
+                return Err(TensorTrainError::DimensionMismatch { site: i });
+            }
+        }
+
+        // First tensor should have left_dim = 1
+        if !tensors.is_empty() && tensors[0].left_dim() != 1 {
+            return Err(TensorTrainError::InvalidOperation {
+                message: "First tensor must have left dimension 1".to_string(),
+            });
+        }
+
+        // Last tensor should have right_dim = 1
+        if !tensors.is_empty() && tensors.last().unwrap().right_dim() != 1 {
+            return Err(TensorTrainError::InvalidOperation {
+                message: "Last tensor must have right dimension 1".to_string(),
+            });
+        }
+
+        Ok(Self { tensors })
+    }
+
+    /// Create a tensor train from tensors without dimension validation
+    /// (for internal use when dimensions are known to be correct)
+    pub(crate) fn from_tensors_unchecked(tensors: Vec<Tensor3<T>>) -> Self {
+        Self { tensors }
+    }
+
+    /// Create a tensor train representing the zero function
+    pub fn zeros(site_dims: &[usize]) -> Self {
+        let tensors: Vec<Tensor3<T>> = site_dims
+            .iter()
+            .map(|&d| Tensor3::zeros(1, d, 1))
+            .collect();
+        Self { tensors }
+    }
+
+    /// Create a tensor train representing a constant function
+    pub fn constant(site_dims: &[usize], value: T) -> Self {
+        if site_dims.is_empty() {
+            return Self { tensors: Vec::new() };
+        }
+
+        let n = site_dims.len();
+        let mut tensors = Vec::with_capacity(n);
+
+        // First tensor: all ones
+        let mut first = Tensor3::zeros(1, site_dims[0], 1);
+        for s in 0..site_dims[0] {
+            first.set(0, s, 0, T::one());
+        }
+        tensors.push(first);
+
+        // Middle tensors: all ones
+        for &d in &site_dims[1..n - 1] {
+            let mut tensor = Tensor3::zeros(1, d, 1);
+            for s in 0..d {
+                tensor.set(0, s, 0, T::one());
+            }
+            tensors.push(tensor);
+        }
+
+        // Last tensor: multiply by value
+        if n > 1 {
+            let mut last = Tensor3::zeros(1, site_dims[n - 1], 1);
+            for s in 0..site_dims[n - 1] {
+                last.set(0, s, 0, value);
+            }
+            tensors.push(last);
+        } else {
+            // Single site: multiply the first (and only) tensor by value
+            for s in 0..site_dims[0] {
+                let current = *tensors[0].get(0, s, 0);
+                tensors[0].set(0, s, 0, current * value);
+            }
+        }
+
+        Self { tensors }
+    }
+
+    /// Get mutable access to the site tensors
+    pub fn site_tensors_mut(&mut self) -> &mut [Tensor3<T>] {
+        &mut self.tensors
+    }
+
+    /// Multiply the tensor train by a scalar
+    pub fn scale(&mut self, factor: T) {
+        if !self.tensors.is_empty() {
+            let last = self.tensors.len() - 1;
+            let tensor = &mut self.tensors[last];
+            for l in 0..tensor.left_dim() {
+                for s in 0..tensor.site_dim() {
+                    for r in 0..tensor.right_dim() {
+                        let val = *tensor.get(l, s, r);
+                        tensor.set(l, s, r, val * factor);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Create a scaled copy of the tensor train
+    pub fn scaled(&self, factor: T) -> Self {
+        let mut result = self.clone();
+        result.scale(factor);
+        result
+    }
+
+    /// Reverse the tensor train (swap left and right)
+    pub fn reverse(&self) -> Self {
+        let mut new_tensors = Vec::with_capacity(self.tensors.len());
+        for tensor in self.tensors.iter().rev() {
+            // Swap left and right dimensions
+            let mut new_tensor =
+                Tensor3::zeros(tensor.right_dim(), tensor.site_dim(), tensor.left_dim());
+            for l in 0..tensor.left_dim() {
+                for s in 0..tensor.site_dim() {
+                    for r in 0..tensor.right_dim() {
+                        new_tensor.set(r, s, l, *tensor.get(l, s, r));
+                    }
+                }
+            }
+            new_tensors.push(new_tensor);
+        }
+        Self {
+            tensors: new_tensors,
+        }
+    }
+}
+
+impl<T: TTScalar> AbstractTensorTrain<T> for TensorTrain<T> {
+    fn len(&self) -> usize {
+        self.tensors.len()
+    }
+
+    fn site_tensor(&self, i: usize) -> &Tensor3<T> {
+        &self.tensors[i]
+    }
+
+    fn site_tensors(&self) -> &[Tensor3<T>] {
+        &self.tensors
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensortrain_zeros() {
+        let tt = TensorTrain::<f64>::zeros(&[2, 3, 2]);
+        assert_eq!(tt.len(), 3);
+        assert_eq!(tt.site_dims(), vec![2, 3, 2]);
+        assert_eq!(tt.rank(), 1);
+    }
+
+    #[test]
+    fn test_tensortrain_constant() {
+        let tt = TensorTrain::<f64>::constant(&[2, 2], 5.0);
+        assert_eq!(tt.len(), 2);
+
+        // Sum should be 5.0 * 2 * 2 = 20.0
+        let sum = tt.sum();
+        assert!((sum - 20.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_tensortrain_evaluate() {
+        // Create a simple tensor train that returns the product of indices + 1
+        let _site_dims = vec![2, 3];
+
+        // First tensor: values are 1 for index 0, 2 for index 1
+        let mut t0 = Tensor3::<f64>::zeros(1, 2, 1);
+        t0.set(0, 0, 0, 1.0);
+        t0.set(0, 1, 0, 2.0);
+
+        // Second tensor: values are 1, 2, 3 for indices 0, 1, 2
+        let mut t1 = Tensor3::<f64>::zeros(1, 3, 1);
+        t1.set(0, 0, 0, 1.0);
+        t1.set(0, 1, 0, 2.0);
+        t1.set(0, 2, 0, 3.0);
+
+        let tt = TensorTrain::new(vec![t0, t1]).unwrap();
+
+        // tt([0, 0]) = 1 * 1 = 1
+        assert!((tt.evaluate(&[0, 0]).unwrap() - 1.0).abs() < 1e-10);
+        // tt([1, 2]) = 2 * 3 = 6
+        assert!((tt.evaluate(&[1, 2]).unwrap() - 6.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_tensortrain_scale() {
+        let mut tt = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+        tt.scale(3.0);
+
+        // Sum should be 3.0 * 2 * 2 = 12.0
+        let sum = tt.sum();
+        assert!((sum - 12.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_tensortrain_reverse() {
+        let mut t0 = Tensor3::<f64>::zeros(1, 2, 1);
+        t0.set(0, 0, 0, 1.0);
+        t0.set(0, 1, 0, 2.0);
+
+        let mut t1 = Tensor3::<f64>::zeros(1, 3, 1);
+        t1.set(0, 0, 0, 1.0);
+        t1.set(0, 1, 0, 2.0);
+        t1.set(0, 2, 0, 3.0);
+
+        let tt = TensorTrain::new(vec![t0, t1]).unwrap();
+        let tt_rev = tt.reverse();
+
+        assert_eq!(tt_rev.len(), 2);
+        assert_eq!(tt_rev.site_dims(), vec![3, 2]);
+
+        // Reversed evaluation: tt_rev([2, 1]) should equal tt([1, 2])
+        assert!((tt_rev.evaluate(&[2, 1]).unwrap() - tt.evaluate(&[1, 2]).unwrap()).abs() < 1e-10);
+    }
+}

--- a/crates/tensor4all-tensortrain/src/traits.rs
+++ b/crates/tensor4all-tensortrain/src/traits.rs
@@ -1,0 +1,243 @@
+//! Abstract traits for tensor train objects
+
+use crate::error::Result;
+use crate::types::{LocalIndex, Tensor3};
+use num_traits::{One, Zero};
+
+/// Scalar trait for tensor train elements
+pub trait TTScalar:
+    Clone
+    + Copy
+    + Zero
+    + One
+    + std::ops::Add<Output = Self>
+    + std::ops::Sub<Output = Self>
+    + std::ops::Mul<Output = Self>
+    + std::ops::Div<Output = Self>
+    + std::ops::Neg<Output = Self>
+    + Default
+    + Send
+    + Sync
+    + 'static
+{
+    /// Conjugate
+    fn conj(self) -> Self;
+
+    /// Absolute value squared
+    fn abs_sq(self) -> f64;
+}
+
+impl TTScalar for f64 {
+    fn conj(self) -> Self {
+        self
+    }
+
+    fn abs_sq(self) -> f64 {
+        self * self
+    }
+}
+
+impl TTScalar for f32 {
+    fn conj(self) -> Self {
+        self
+    }
+
+    fn abs_sq(self) -> f64 {
+        (self * self) as f64
+    }
+}
+
+impl TTScalar for num_complex::Complex64 {
+    fn conj(self) -> Self {
+        num_complex::Complex64::conj(&self)
+    }
+
+    fn abs_sq(self) -> f64 {
+        self.norm_sqr()
+    }
+}
+
+impl TTScalar for num_complex::Complex32 {
+    fn conj(self) -> Self {
+        num_complex::Complex32::conj(&self)
+    }
+
+    fn abs_sq(self) -> f64 {
+        self.norm_sqr() as f64
+    }
+}
+
+/// Abstract trait for tensor train objects
+///
+/// A tensor train (also known as MPS) represents a high-dimensional tensor
+/// as a product of low-rank tensors.
+pub trait AbstractTensorTrain<T: TTScalar>: Sized {
+    /// Number of sites (tensors) in the tensor train
+    fn len(&self) -> usize;
+
+    /// Check if the tensor train is empty
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get the site tensor at position i
+    fn site_tensor(&self, i: usize) -> &Tensor3<T>;
+
+    /// Get all site tensors
+    fn site_tensors(&self) -> &[Tensor3<T>];
+
+    /// Bond dimensions along the links between tensors
+    /// Returns a vector of length L-1 where L is the number of sites
+    fn link_dims(&self) -> Vec<usize> {
+        if self.len() <= 1 {
+            return Vec::new();
+        }
+        (1..self.len())
+            .map(|i| self.site_tensor(i).left_dim())
+            .collect()
+    }
+
+    /// Bond dimension at the link between tensor i and i+1
+    fn link_dim(&self, i: usize) -> usize {
+        self.site_tensor(i + 1).left_dim()
+    }
+
+    /// Site dimensions (physical dimensions) for each tensor
+    fn site_dims(&self) -> Vec<usize> {
+        (0..self.len())
+            .map(|i| self.site_tensor(i).site_dim())
+            .collect()
+    }
+
+    /// Site dimension at position i
+    fn site_dim(&self, i: usize) -> usize {
+        self.site_tensor(i).site_dim()
+    }
+
+    /// Maximum bond dimension (rank) of the tensor train
+    fn rank(&self) -> usize {
+        let lds = self.link_dims();
+        if lds.is_empty() {
+            1
+        } else {
+            *lds.iter().max().unwrap_or(&1)
+        }
+    }
+
+    /// Evaluate the tensor train at a given index set
+    fn evaluate(&self, indices: &[LocalIndex]) -> Result<T> {
+        use crate::error::TensorTrainError;
+
+        if indices.len() != self.len() {
+            return Err(TensorTrainError::IndexLengthMismatch {
+                expected: self.len(),
+                got: indices.len(),
+            });
+        }
+
+        if self.is_empty() {
+            return Err(TensorTrainError::Empty);
+        }
+
+        // Start with the first tensor slice
+        let first = self.site_tensor(0);
+        let idx0 = indices[0];
+        if idx0 >= first.site_dim() {
+            return Err(TensorTrainError::IndexOutOfBounds {
+                site: 0,
+                index: idx0,
+                max: first.site_dim(),
+            });
+        }
+
+        // Vector of size right_dim
+        let mut current: Vec<T> = first.slice_site(idx0);
+
+        // Contract with remaining tensors
+        for (site, &idx) in indices.iter().enumerate().skip(1) {
+            let tensor = self.site_tensor(site);
+            if idx >= tensor.site_dim() {
+                return Err(TensorTrainError::IndexOutOfBounds {
+                    site,
+                    index: idx,
+                    max: tensor.site_dim(),
+                });
+            }
+
+            let slice = tensor.slice_site(idx);
+            let left_dim = tensor.left_dim();
+            let right_dim = tensor.right_dim();
+
+            // Contract: current (of size left_dim) with slice (left_dim x right_dim)
+            let mut next = vec![T::zero(); right_dim];
+            for r in 0..right_dim {
+                let mut sum = T::zero();
+                for l in 0..left_dim {
+                    sum = sum + current[l] * slice[l * right_dim + r];
+                }
+                next[r] = sum;
+            }
+            current = next;
+        }
+
+        // Should have a single element
+        if current.len() != 1 {
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "Final contraction resulted in {} elements, expected 1",
+                    current.len()
+                ),
+            });
+        }
+
+        Ok(current[0])
+    }
+
+    /// Sum over all indices of the tensor train
+    #[allow(clippy::needless_range_loop)]
+    fn sum(&self) -> T {
+        if self.is_empty() {
+            return T::zero();
+        }
+
+        // Start with sum over first tensor
+        let first = self.site_tensor(0);
+        let mut current = vec![T::zero(); first.right_dim()];
+        for s in 0..first.site_dim() {
+            for r in 0..first.right_dim() {
+                current[r] = current[r] + *first.get(0, s, r);
+            }
+        }
+
+        // Contract with sums of remaining tensors
+        for site in 1..self.len() {
+            let tensor = self.site_tensor(site);
+            let left_dim = tensor.left_dim();
+            let right_dim = tensor.right_dim();
+
+            // Sum over site index
+            let mut site_sum = vec![T::zero(); left_dim * right_dim];
+            for l in 0..left_dim {
+                for s in 0..tensor.site_dim() {
+                    for r in 0..right_dim {
+                        site_sum[l * right_dim + r] =
+                            site_sum[l * right_dim + r] + *tensor.get(l, s, r);
+                    }
+                }
+            }
+
+            // Contract with current
+            let mut next = vec![T::zero(); right_dim];
+            for r in 0..right_dim {
+                let mut sum = T::zero();
+                for l in 0..left_dim {
+                    sum = sum + current[l] * site_sum[l * right_dim + r];
+                }
+                next[r] = sum;
+            }
+            current = next;
+        }
+
+        current[0]
+    }
+}

--- a/crates/tensor4all-tensortrain/src/types.rs
+++ b/crates/tensor4all-tensortrain/src/types.rs
@@ -1,0 +1,113 @@
+//! Core types for tensor train operations
+
+/// Local index type (index within a single tensor site)
+pub type LocalIndex = usize;
+
+/// Multi-index type (indices across all sites)
+pub type MultiIndex = Vec<LocalIndex>;
+
+/// A 3D tensor represented as a flat Vec with shape information
+/// Shape is (left_dim, site_dim, right_dim)
+#[derive(Debug, Clone)]
+pub struct Tensor3<T> {
+    data: Vec<T>,
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+}
+
+impl<T: Clone + Default> Tensor3<T> {
+    /// Create a new tensor filled with default values
+    pub fn zeros(left_dim: usize, site_dim: usize, right_dim: usize) -> Self {
+        Self {
+            data: vec![T::default(); left_dim * site_dim * right_dim],
+            left_dim,
+            site_dim,
+            right_dim,
+        }
+    }
+
+    /// Create from flat data with shape
+    pub fn from_data(data: Vec<T>, left_dim: usize, site_dim: usize, right_dim: usize) -> Self {
+        assert_eq!(data.len(), left_dim * site_dim * right_dim);
+        Self {
+            data,
+            left_dim,
+            site_dim,
+            right_dim,
+        }
+    }
+
+    /// Get the left (bond) dimension
+    pub fn left_dim(&self) -> usize {
+        self.left_dim
+    }
+
+    /// Get the site (physical) dimension
+    pub fn site_dim(&self) -> usize {
+        self.site_dim
+    }
+
+    /// Get the right (bond) dimension
+    pub fn right_dim(&self) -> usize {
+        self.right_dim
+    }
+
+    /// Get element at (left, site, right)
+    pub fn get(&self, l: usize, s: usize, r: usize) -> &T {
+        let idx = (l * self.site_dim + s) * self.right_dim + r;
+        &self.data[idx]
+    }
+
+    /// Get mutable element at (left, site, right)
+    pub fn get_mut(&mut self, l: usize, s: usize, r: usize) -> &mut T {
+        let idx = (l * self.site_dim + s) * self.right_dim + r;
+        &mut self.data[idx]
+    }
+
+    /// Set element at (left, site, right)
+    pub fn set(&mut self, l: usize, s: usize, r: usize, value: T) {
+        let idx = (l * self.site_dim + s) * self.right_dim + r;
+        self.data[idx] = value;
+    }
+
+    /// Get a slice for fixed site index: returns (left_dim, right_dim) matrix
+    pub fn slice_site(&self, s: usize) -> Vec<T> {
+        let mut result = Vec::with_capacity(self.left_dim * self.right_dim);
+        for l in 0..self.left_dim {
+            for r in 0..self.right_dim {
+                result.push(self.get(l, s, r).clone());
+            }
+        }
+        result
+    }
+
+    /// Reshape this tensor to a matrix (left_dim * site_dim, right_dim)
+    pub fn as_left_matrix(&self) -> (Vec<T>, usize, usize) {
+        let rows = self.left_dim * self.site_dim;
+        let cols = self.right_dim;
+        (self.data.clone(), rows, cols)
+    }
+
+    /// Reshape this tensor to a matrix (left_dim, site_dim * right_dim)
+    pub fn as_right_matrix(&self) -> (Vec<T>, usize, usize) {
+        let rows = self.left_dim;
+        let cols = self.site_dim * self.right_dim;
+        // Data needs to be transposed for row-major
+        let mut result = Vec::with_capacity(rows * cols);
+        for l in 0..self.left_dim {
+            for s in 0..self.site_dim {
+                for r in 0..self.right_dim {
+                    result.push(self.get(l, s, r).clone());
+                }
+            }
+        }
+        (result, rows, cols)
+    }
+}
+
+impl<T: Clone + Default + num_traits::Zero> Default for Tensor3<T> {
+    fn default() -> Self {
+        Self::zeros(1, 1, 1)
+    }
+}

--- a/remaining_issues_tci.md
+++ b/remaining_issues_tci.md
@@ -1,0 +1,71 @@
+# Remaining Issues: TCI Rust Port
+
+This document tracks remaining work for the Rust port of T4AMatrixCI.jl, T4ATensorTrain.jl, and T4ATensorCI.jl.
+
+## Current Status
+
+| Crate | Tests | Status |
+|-------|-------|--------|
+| tensor4all-matrixci | 19 | Complete |
+| tensor4all-tensortrain | 20 | Core complete |
+| tensor4all-tensorci | 21 | Core complete |
+
+## tensor4all-tensortrain
+
+### Medium Priority
+
+- [ ] **TTCache** - Caching structure for repeated tensor train contractions
+  - Reference: `T4ATensorTrain.jl/src/cache.jl`
+  - Used to avoid redundant computations in TCI algorithms
+
+### Low Priority
+
+- [ ] **VidalTensorTrain** - Vidal canonical form with diagonal bond matrices (Γ-Λ form)
+  - Reference: `T4ATensorTrain.jl/src/vidal.jl`
+  - Useful for certain algorithms but not essential for basic TCI
+
+- [ ] **SiteTensorTrain** - Site-canonical (mixed-canonical) form
+  - Reference: `T4ATensorTrain.jl/src/sitetensortrain.jl`
+  - Orthogonality center at a specific site
+
+- [ ] **InverseTensorTrain** - Inverse representation for efficient division
+  - Reference: `T4ATensorTrain.jl/src/inverse.jl`
+
+- [ ] **4-leg tensor support (Tensor4)** - For MPO-MPS contraction
+  - Julia uses `TensorTrain{T,4}` for MPO operations
+  - Current Rust implementation uses 3-leg tensors (MPS only)
+  - Would enable `contract_naive` and `contract_zipup` for MPO-MPS
+
+## tensor4all-tensorci
+
+### Medium Priority
+
+- [ ] **GlobalPivotFinder** - Global pivot search strategies
+  - Reference: `T4ATensorCI.jl/src/globalpivot.jl`
+  - Random search and rook pivoting for finding good global pivots
+  - Important for robustness of TCI2
+
+- [ ] **Integration utilities** - Weighted sums and integration
+  - Reference: `T4ATensorCI.jl/src/integration.jl`
+  - `integrate(tci, weights)` for numerical integration
+  - Useful for applications in physics/chemistry
+
+### Low Priority
+
+- [ ] **More sweep strategies** - Additional pivot selection heuristics
+  - Full matrix search vs. partial (rook) search
+  - Adaptive tolerance strategies
+
+## Optional Enhancements
+
+- [ ] **Complex number testing** - Types are generic but not tested with `Complex64`
+- [ ] **SVD compression** - Currently falls back to LU; true SVD would be more accurate
+  - Requires LAPACK bindings or pure-Rust SVD implementation
+- [ ] **Benchmarks** - Performance comparison with Julia implementation
+- [ ] **Documentation** - Rustdoc examples and usage guides
+
+## Notes
+
+- The core TCI functionality (TensorCI1, TensorCI2) is complete and usable
+- TensorCI2 uses explicit `batched_f: Option<B>` parameter instead of inheritance
+- All 60 tests pass, clippy passes with no warnings


### PR DESCRIPTION
## Summary

Add three new crates porting the Julia TCI packages to Rust:

- **tensor4all-matrixci**: Matrix Cross Interpolation algorithms
  - MatrixCI, MatrixACA, RrLU, MatrixLUCI
  - 19 tests

- **tensor4all-tensortrain**: Tensor Train (MPS) representation  
  - TensorTrain, Tensor3, compression (LU/CI), arithmetic (+, -, scale)
  - Contraction: hadamard, dot, hadamard_zipup
  - 20 tests

- **tensor4all-tensorci**: Tensor Cross Interpolation algorithms
  - TensorCI1 (1-site) with full sweep logic
  - TensorCI2 (2-site) with explicit batch function parameter
  - IndexSet, CachedFunction
  - 21 tests

## Design Notes

- Uses Vec-backed Matrix instead of mdarray (avoided segfaults)
- TensorCI2 uses explicit `batched_f: Option<B>` parameter instead of inheritance
- Generic over numeric types with `Scalar` and `TTScalar` traits

## Test plan

- [x] All 60 unit tests pass (`cargo test -p tensor4all-matrixci -p tensor4all-tensortrain -p tensor4all-tensorci`)
- [x] All 3 doc tests pass
- [x] Clippy passes with no warnings

## Future work

See `remaining_issues_tci.md` for remaining items (canonical forms, global pivot finder, integration utilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)