### PR TITLE
Fix run_python_tests.sh: use python3 and move build_capi.py call

### DIFF
--- a/run_python_tests.sh
+++ b/run_python_tests.sh
@@ -12,18 +12,19 @@ echo "=== Setting up Python environment ==="
 cd pytensor4all
 
 # Copy library
-python scripts/build_capi.py
 
 # Install dependencies and package
 if command -v uv &> /dev/null; then
+    uv run python scripts/build_capi.py
     echo "Using uv..."
     uv sync --all-extras
     uv pip install -e ".[dev]"
     echo "=== Running Python tests ==="
     uv run pytest -v
 else
+    python3 scripts/build_capi.py
     echo "Using pip..."
-    python -m pip install --upgrade pip
+    python3 -m pip install --upgrade pip
     pip install -e ".[dev]"
     echo "=== Running Python tests ==="
     pytest -v


### PR DESCRIPTION
## Summary
- Move `build_capi.py` execution inside uv/pip conditional blocks for proper environment handling
- Use `uv run python` when uv is available for consistent virtual environment usage
- Change `python` to `python3` in pip-based workflow for better cross-platform compatibility

## Test plan
- [x] Verify Python tests pass with uv
- [ ] Verify Python tests pass with pip

🤖 Generated with [Claude Code](https://claude.com/claude-code)