### PR TITLE
Add TensorLike trait to unify TensorDynLen and TreeTN

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,5 @@ faer-traits = "0.23"
 thiserror = "2.0"
 rand = "0.8"
 petgraph = "0.6"
+dyn-clone = "1.0"
 

--- a/tensor4all-treetn/Cargo.toml
+++ b/tensor4all-treetn/Cargo.toml
@@ -11,4 +11,5 @@ tensor4all = { path = "../tensor4all" }
 petgraph.workspace = true
 anyhow.workspace = true
 num-complex.workspace = true
+dyn-clone.workspace = true
 

--- a/tensor4all-treetn/src/treetn.rs
+++ b/tensor4all-treetn/src/treetn.rs
@@ -1835,6 +1835,91 @@ where
     }
 }
 
+impl<Id, Symm, V> std::fmt::Debug for TreeTN<Id, Symm, V>
+where
+    Id: Clone + std::hash::Hash + Eq + std::fmt::Debug,
+    Symm: Clone + Symmetry + std::fmt::Debug,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TreeTN")
+            .field("node_count", &self.node_count())
+            .field("edge_count", &self.edge_count())
+            .field("ortho_region", &self.ortho_region)
+            .finish_non_exhaustive()
+    }
+}
+
+// ============================================================================
+// TensorLike implementation for TreeTN
+// ============================================================================
+
+impl<Id, Symm, V> tensor4all::TensorLike for TreeTN<Id, Symm, V>
+where
+    Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync + 'static,
+    Symm: Clone + Symmetry + std::fmt::Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug + 'static,
+{
+    type Id = Id;
+    type Symm = Symm;
+    type Tags = tensor4all::DefaultTagSet;
+
+    fn external_indices(&self) -> Vec<Index<Self::Id, Self::Symm, Self::Tags>> {
+        // Collect all site indices from the site_index_network.
+        //
+        // For deterministic ordering (as required by the trait):
+        // 1. Sort nodes by name (V: Ord)
+        // 2. Within each node, sort indices by id (Id: Ord)
+        // 3. Flatten into a single Vec
+
+        // Get all node names and sort them
+        let mut node_names: Vec<_> = self.site_index_network.node_names()
+            .into_iter()
+            .cloned()
+            .collect();
+        node_names.sort();
+
+        let mut result = Vec::new();
+
+        for node_name in node_names {
+            if let Some(site_space) = self.site_index_network.site_space(&node_name) {
+                // Collect and sort indices by id
+                let mut indices: Vec<_> = site_space.iter()
+                    .map(|idx| Index::new_with_tags(
+                        idx.id.clone(),
+                        idx.symm.clone(),
+                        tensor4all::DefaultTagSet::default(),
+                    ))
+                    .collect();
+                indices.sort_by(|a, b| a.id.cmp(&b.id));
+                result.extend(indices);
+            }
+        }
+
+        result
+    }
+
+    fn num_external_indices(&self) -> usize {
+        // Sum up all site indices across all nodes
+        self.site_index_network.node_names()
+            .iter()
+            .filter_map(|name| self.site_index_network.site_space(name))
+            .map(|site_space| site_space.len())
+            .sum()
+    }
+
+    fn to_tensor(&self) -> anyhow::Result<tensor4all::TensorDynLen<Self::Id, Self::Symm>> {
+        // Use the existing contract_to_tensor method
+        self.contract_to_tensor()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    // Use the default implementation of tensordot which calls to_tensor
+}
+
 // ============================================================================
 // Helper functions for TreeTN addition (direct-sum block embedding)
 // ============================================================================

--- a/tensor4all-treetn/tests/tensor_like.rs
+++ b/tensor4all-treetn/tests/tensor_like.rs
@@ -1,0 +1,267 @@
+//! Tests for TensorLike trait implementation for TreeTN.
+
+use tensor4all_treetn::TreeTN;
+use tensor4all::index::{Index, DynId, NoSymmSpace};
+use tensor4all::{TensorDynLen, TensorLike, TensorLikeDowncast, DefaultTagSet, StorageScalar};
+
+/// Helper to create a simple tensor with given indices
+fn make_tensor(indices: Vec<Index<DynId, NoSymmSpace>>) -> TensorDynLen<DynId> {
+    let total_size: usize = indices.iter().map(|idx| idx.size()).product();
+    let data: Vec<f64> = (0..total_size).map(|i| i as f64).collect();
+    let storage = f64::dense_storage(data);
+    TensorDynLen::from_indices(indices, storage)
+}
+
+#[test]
+fn test_treetn_external_indices_single_node() {
+    // Create a TreeTN with a single node containing a 2x3 tensor
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let tensor = make_tensor(vec![i.clone(), j.clone()]);
+
+    // Use from_tensors_with_names to create the network
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor],
+        vec!["A".to_string()],
+    ).unwrap();
+
+    // External indices should be all indices (since no connections)
+    let external = tn.external_indices();
+    assert_eq!(external.len(), 2);
+
+    // Check that the indices have the correct dimensions
+    let sizes: Vec<usize> = external.iter().map(|idx| idx.size()).collect();
+    assert!(sizes.contains(&2));
+    assert!(sizes.contains(&3));
+}
+
+#[test]
+fn test_treetn_external_indices_connected_nodes() {
+    // Create a TreeTN with two connected nodes
+    // Node A: indices (i, bond_ab)
+    // Node B: indices (bond_ab, j)
+    // After connecting, external indices should be (i, j)
+
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let bond_ab = Index::new_dyn(4);
+
+    let tensor_a = make_tensor(vec![i.clone(), bond_ab.clone()]);
+    let tensor_b = make_tensor(vec![bond_ab.clone(), j.clone()]);
+
+    // from_tensors_with_names automatically connects tensors that share common indices
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor_a, tensor_b],
+        vec!["A".to_string(), "B".to_string()],
+    ).unwrap();
+
+    // External indices should be i and j (not bond_ab)
+    let external = tn.external_indices();
+    assert_eq!(external.len(), 2);
+
+    // Verify the external indices are i and j (not bond)
+    let external_ids: Vec<_> = external.iter().map(|idx| idx.id).collect();
+    assert!(external_ids.contains(&i.id));
+    assert!(external_ids.contains(&j.id));
+    assert!(!external_ids.contains(&bond_ab.id));
+}
+
+#[test]
+fn test_treetn_num_external_indices() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let bond = Index::new_dyn(4);
+
+    let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
+    let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
+
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor_a, tensor_b],
+        vec!["A".to_string(), "B".to_string()],
+    ).unwrap();
+
+    assert_eq!(tn.num_external_indices(), 2);
+}
+
+#[test]
+fn test_treetn_to_tensor() {
+    // Create a simple MPS-like network: A -- B
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let bond = Index::new_dyn(2);
+
+    // Tensor A: 2x2 with values
+    let tensor_a = TensorDynLen::from_indices(
+        vec![i.clone(), bond.clone()],
+        f64::dense_storage(vec![1.0, 0.0, 0.0, 1.0]), // identity-like
+    );
+
+    // Tensor B: 2x3 with values
+    let tensor_b = TensorDynLen::from_indices(
+        vec![bond.clone(), j.clone()],
+        f64::dense_storage(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+    );
+
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor_a, tensor_b],
+        vec!["A".to_string(), "B".to_string()],
+    ).unwrap();
+
+    // Contract to tensor
+    let result = tn.to_tensor().expect("to_tensor should succeed");
+
+    // Result should be 2x3 (dimensions of i and j)
+    assert_eq!(result.indices.len(), 2);
+    let dims: Vec<usize> = result.indices.iter().map(|idx| idx.size()).collect();
+    assert!(dims.contains(&2));
+    assert!(dims.contains(&3));
+}
+
+#[test]
+fn test_treetn_external_indices_deterministic_ordering() {
+    // Create a TreeTN with multiple nodes and verify ordering is deterministic
+    let idx_a = Index::new_dyn(2);
+    let idx_b = Index::new_dyn(3);
+    let idx_c = Index::new_dyn(4);
+
+    // Add nodes in non-alphabetical order (C, A, B)
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![
+            make_tensor(vec![idx_c.clone()]),
+            make_tensor(vec![idx_a.clone()]),
+            make_tensor(vec![idx_b.clone()]),
+        ],
+        vec!["C".to_string(), "A".to_string(), "B".to_string()],
+    ).unwrap();
+
+    // External indices should be sorted by node name first
+    let external = tn.external_indices();
+    assert_eq!(external.len(), 3);
+
+    // First call
+    let ids1: Vec<DynId> = external.iter().map(|idx| idx.id).collect();
+
+    // Second call should give same order
+    let external2 = tn.external_indices();
+    let ids2: Vec<DynId> = external2.iter().map(|idx| idx.id).collect();
+
+    assert_eq!(ids1, ids2, "external_indices should be deterministic");
+}
+
+#[test]
+fn test_treetn_tensor_like_object_safety() {
+    let i = Index::new_dyn(2);
+    let tensor = make_tensor(vec![i.clone()]);
+
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor],
+        vec!["A".to_string()],
+    ).unwrap();
+
+    // Use as trait object
+    let trait_obj: &dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet> = &tn;
+
+    assert_eq!(trait_obj.num_external_indices(), 1);
+    assert_eq!(trait_obj.external_indices().len(), 1);
+}
+
+#[test]
+fn test_treetn_clone_trait_object() {
+    let i = Index::new_dyn(2);
+    let tensor = make_tensor(vec![i.clone()]);
+
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor],
+        vec!["A".to_string()],
+    ).unwrap();
+
+    // Box as trait object
+    let boxed: Box<dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet>> =
+        Box::new(tn);
+
+    // Clone via dyn-clone
+    let cloned = dyn_clone::clone_box(&*boxed);
+
+    assert_eq!(boxed.num_external_indices(), cloned.num_external_indices());
+}
+
+#[test]
+fn test_treetn_as_any() {
+    let i = Index::new_dyn(2);
+    let tensor = make_tensor(vec![i.clone()]);
+
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor],
+        vec!["A".to_string()],
+    ).unwrap();
+
+    // Get as Any
+    let any_ref = tn.as_any();
+
+    // Should be able to downcast back to TreeTN
+    let downcast = any_ref.downcast_ref::<TreeTN<DynId, NoSymmSpace, String>>();
+    assert!(downcast.is_some());
+
+    let downcast_tn = downcast.unwrap();
+    assert_eq!(downcast_tn.node_count(), 1);
+}
+
+#[test]
+fn test_treetn_downcast_via_trait_object() {
+    let i = Index::new_dyn(2);
+    let tensor = make_tensor(vec![i.clone()]);
+
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![tensor],
+        vec!["A".to_string()],
+    ).unwrap();
+
+    // Use as trait object
+    let trait_obj: &dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet> = &tn;
+
+    // Use TensorLikeDowncast extension trait
+    assert!(trait_obj.is::<TreeTN<DynId, NoSymmSpace, String>>());
+
+    let downcast = trait_obj.downcast_ref::<TreeTN<DynId, NoSymmSpace, String>>();
+    assert!(downcast.is_some());
+    assert_eq!(downcast.unwrap().node_count(), 1);
+
+    // Should not downcast to wrong type
+    assert!(!trait_obj.is::<TensorDynLen<DynId>>());
+    assert!(trait_obj.downcast_ref::<TensorDynLen<DynId>>().is_none());
+}
+
+#[test]
+fn test_mixed_downcast() {
+    // Create a TensorDynLen and a TreeTN, put them in a Vec of trait objects,
+    // and show we can downcast each to the correct type.
+
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+
+    let tensor = make_tensor(vec![i.clone(), j.clone()]);
+    let tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors_with_names(
+        vec![make_tensor(vec![i.clone()])],
+        vec!["A".to_string()],
+    ).unwrap();
+
+    let objects: Vec<Box<dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet>>> = vec![
+        Box::new(tensor),
+        Box::new(tn),
+    ];
+
+    // First should be TensorDynLen
+    assert!(objects[0].is::<TensorDynLen<DynId>>());
+    assert!(!objects[0].is::<TreeTN<DynId, NoSymmSpace, String>>());
+
+    // Second should be TreeTN
+    assert!(!objects[1].is::<TensorDynLen<DynId>>());
+    assert!(objects[1].is::<TreeTN<DynId, NoSymmSpace, String>>());
+
+    // Downcast and verify properties
+    let tensor_ref = objects[0].downcast_ref::<TensorDynLen<DynId>>().unwrap();
+    assert_eq!(tensor_ref.num_external_indices(), 2);
+
+    let tn_ref = objects[1].downcast_ref::<TreeTN<DynId, NoSymmSpace, String>>().unwrap();
+    assert_eq!(tn_ref.node_count(), 1);
+}

--- a/tensor4all/core-tensor/Cargo.toml
+++ b/tensor4all/core-tensor/Cargo.toml
@@ -13,6 +13,7 @@ num-traits.workspace = true
 mdarray.workspace = true
 mdarray-linalg.workspace = true
 anyhow.workspace = true
+dyn-clone.workspace = true
 
 [dev-dependencies]
 

--- a/tensor4all/core-tensor/src/lib.rs
+++ b/tensor4all/core-tensor/src/lib.rs
@@ -2,9 +2,11 @@ pub mod any_scalar;
 pub mod physical_indices;
 pub mod storage;
 pub mod tensor;
+pub mod tensor_like;
 
 pub use any_scalar::AnyScalar;
 pub use physical_indices::PhysicalIndices;
 pub use storage::{DenseStorageFactory, Storage, StorageScalar, SumFromStorage, make_mut_storage, mindim, storage_to_dtensor};
 pub use tensor::{TensorDynLen, TensorType, TensorAccess, compute_permutation_from_indices, is_diag_tensor, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, unfold_split};
+pub use tensor_like::{TensorLike, TensorLikeDowncast};
 

--- a/tensor4all/core-tensor/src/tensor.rs
+++ b/tensor4all/core-tensor/src/tensor.rs
@@ -827,6 +827,19 @@ where
     }
 }
 
+impl<Id, Symm> std::fmt::Debug for TensorDynLen<Id, Symm>
+where
+    Id: std::fmt::Debug,
+    Symm: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TensorDynLen")
+            .field("indices", &self.indices)
+            .field("dims", &self.dims)
+            .field("storage", &self.storage)
+            .finish()
+    }
+}
 
 /// Create a DiagTensor with dynamic rank from diagonal data.
 ///

--- a/tensor4all/core-tensor/src/tensor_like.rs
+++ b/tensor4all/core-tensor/src/tensor_like.rs
@@ -1,0 +1,307 @@
+//! TensorLike trait for unifying tensor types.
+//!
+//! This trait provides a common interface for:
+//! - `TensorDynLen<Id, Symm>` - Dense tensors
+//! - `TreeTN<Id, Symm, V>` - Tree tensor networks
+//! - Third-party tensor-like objects
+//!
+//! The trait exposes:
+//! - **External indices**: Physical/site indices of the object
+//! - **Explicit contraction (tensordot)**: Binary contraction with specified index pairs
+
+use crate::tensor::TensorDynLen;
+use anyhow::Result;
+use dyn_clone::DynClone;
+use std::any::Any;
+use std::fmt::Debug;
+use std::hash::Hash;
+use tensor4all_core_common::index::{Index, Symmetry};
+use tensor4all_core_common::tagset::TagSetLike;
+
+/// Trait for tensor-like objects that expose external indices and support contraction.
+///
+/// This is the primary abstraction for treating both dense tensors (`TensorDynLen`)
+/// and tensor networks (`TreeTN`) through a common interface.
+///
+/// # Design Principles
+///
+/// - **Minimal interface**: Only external indices and explicit contraction
+/// - **Object-safe**: Uses `Vec` returns instead of iterators for trait object compatibility
+/// - **Clonable trait objects**: Uses `dyn-clone` for `Box<dyn TensorLike<...>>` cloneability
+/// - **Stable ordering**: `external_indices()` returns indices in deterministic order
+///
+/// # Associated Types
+///
+/// - `Id`: Index identity type (e.g., `DynId` for runtime identity)
+/// - `Symm`: Symmetry type (e.g., `NoSymmSpace` for no symmetry)
+/// - `Tags`: Tag type (e.g., `DefaultTagSet`)
+///
+/// # Example
+///
+/// ```ignore
+/// use tensor4all::TensorLike;
+///
+/// fn contract_external<T: TensorLike>(a: &T, b: &T) -> Result<TensorDynLen<T::Id, T::Symm>> {
+///     // Get common external indices and contract
+///     let pairs = find_common_indices(a.external_indices(), b.external_indices());
+///     a.tensordot(b, &pairs)
+/// }
+/// ```
+pub trait TensorLike: DynClone + Send + Sync + Debug {
+    /// Index identity type.
+    type Id: Clone + Hash + Eq + Debug + Send + Sync;
+
+    /// Symmetry type.
+    type Symm: Clone + Symmetry + Send + Sync;
+
+    /// Tag type.
+    type Tags: Clone + TagSetLike + Send + Sync;
+
+    /// Return flattened external indices for this object.
+    ///
+    /// - For `TensorDynLen`: returns the tensor's indices
+    /// - For `TreeTN`: returns union of all site/physical indices across nodes
+    ///
+    /// # Ordering
+    ///
+    /// The ordering MUST be stable (deterministic). Implementations should:
+    /// - Sort indices by their `id` field, or
+    /// - Use insertion-ordered storage
+    ///
+    /// This ensures consistent behavior for hashing, serialization, and comparison.
+    fn external_indices(&self) -> Vec<Index<Self::Id, Self::Symm, Self::Tags>>;
+
+    /// Number of external indices.
+    ///
+    /// Default implementation calls `external_indices().len()`, but implementations
+    /// SHOULD override this for efficiency when the count can be computed without
+    /// allocating the full index list.
+    fn num_external_indices(&self) -> usize {
+        self.external_indices().len()
+    }
+
+    /// Convert this object to a dense tensor.
+    ///
+    /// - For `TensorDynLen`: returns a clone of self
+    /// - For `TreeTN`: contracts all nodes to produce a single tensor
+    ///
+    /// This method is required for implementing `tensordot` via trait objects,
+    /// since we need access to the underlying tensor data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the conversion fails (e.g., empty TreeTN).
+    fn to_tensor(&self) -> Result<TensorDynLen<Self::Id, Self::Symm>>;
+
+    /// Return `self` as `Any` for optional downcasting / runtime type inspection.
+    ///
+    /// This allows callers to attempt downcasting a trait object back to its
+    /// concrete type when needed (similar to C++'s `dynamic_cast`).
+    ///
+    /// # Implementation
+    ///
+    /// Implementers should simply return `self`:
+    ///
+    /// ```ignore
+    /// fn as_any(&self) -> &dyn Any { self }
+    /// ```
+    ///
+    /// This requires the concrete type to be `'static` (the usual `Any` constraint).
+    ///
+    /// # Usage
+    ///
+    /// ```ignore
+    /// let tensor_like: &dyn TensorLike<...> = &my_tensor;
+    /// if let Some(tensor) = tensor_like.as_any().downcast_ref::<TensorDynLen<DynId>>() {
+    ///     // Use tensor directly
+    /// }
+    /// ```
+    fn as_any(&self) -> &dyn Any;
+
+    /// Explicit contraction between two tensor-like objects.
+    ///
+    /// This performs binary contraction over the specified index pairs.
+    /// Each pair `(idx_self, idx_other)` specifies:
+    /// - An index from `self` to contract
+    /// - An index from `other` to contract with
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - The other tensor-like object to contract with
+    /// * `pairs` - List of (self_index, other_index) pairs to contract
+    ///
+    /// # Returns
+    ///
+    /// A new `TensorDynLen` representing the contracted result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - `pairs` is empty
+    /// - An index in `pairs` doesn't exist in the corresponding object
+    /// - Index dimensions don't match
+    /// - There are common indices not in `pairs` (ambiguous contraction)
+    ///
+    /// # Default Implementation
+    ///
+    /// The default implementation converts both operands to `TensorDynLen` via
+    /// `to_tensor()` and then uses `TensorDynLen::tensordot`. Implementations
+    /// may override this for better performance.
+    fn tensordot(
+        &self,
+        other: &dyn TensorLike<Id = Self::Id, Symm = Self::Symm, Tags = Self::Tags>,
+        pairs: &[(
+            Index<Self::Id, Self::Symm, Self::Tags>,
+            Index<Self::Id, Self::Symm, Self::Tags>,
+        )],
+    ) -> Result<TensorDynLen<Self::Id, Self::Symm>>
+    where
+        Self::Id: Ord,
+    {
+        // Convert both operands to TensorDynLen
+        let self_tensor = self.to_tensor()?;
+        let other_tensor = other.to_tensor()?;
+
+        // Convert pairs to the format expected by TensorDynLen::tensordot
+        let converted_pairs: Vec<(Index<Self::Id, Self::Symm>, Index<Self::Id, Self::Symm>)> = pairs
+            .iter()
+            .map(|(a, b)| {
+                (
+                    Index::new(a.id.clone(), a.symm.clone()),
+                    Index::new(b.id.clone(), b.symm.clone()),
+                )
+            })
+            .collect();
+
+        // Use TensorDynLen's tensordot
+        self_tensor.tensordot(&other_tensor, &converted_pairs)
+    }
+}
+
+// Make trait objects cloneable
+dyn_clone::clone_trait_object!(<Id, Symm, Tags> TensorLike<Id=Id, Symm=Symm, Tags=Tags> where
+    Id: Clone + Hash + Eq + Debug + Send + Sync,
+    Symm: Clone + Symmetry + Send + Sync,
+    Tags: Clone + TagSetLike + Send + Sync,
+);
+
+// ============================================================================
+// Helper methods on trait objects for downcasting
+// ============================================================================
+
+/// Extension trait for downcasting `dyn TensorLike` trait objects.
+///
+/// This provides convenient methods for runtime type checking and downcasting.
+pub trait TensorLikeDowncast {
+    /// Check if the underlying type is `T`.
+    fn is<T: 'static>(&self) -> bool;
+
+    /// Attempt to downcast to a reference of type `T`.
+    fn downcast_ref<T: 'static>(&self) -> Option<&T>;
+}
+
+impl<Id, Symm, Tags> TensorLikeDowncast for dyn TensorLike<Id = Id, Symm = Symm, Tags = Tags>
+where
+    Id: Clone + Hash + Eq + Debug + Send + Sync,
+    Symm: Clone + Symmetry + Send + Sync,
+    Tags: Clone + TagSetLike + Send + Sync,
+{
+    fn is<T: 'static>(&self) -> bool {
+        self.as_any().is::<T>()
+    }
+
+    fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.as_any().downcast_ref::<T>()
+    }
+}
+
+impl<Id, Symm, Tags> TensorLikeDowncast for dyn TensorLike<Id = Id, Symm = Symm, Tags = Tags> + Send
+where
+    Id: Clone + Hash + Eq + Debug + Send + Sync,
+    Symm: Clone + Symmetry + Send + Sync,
+    Tags: Clone + TagSetLike + Send + Sync,
+{
+    fn is<T: 'static>(&self) -> bool {
+        self.as_any().is::<T>()
+    }
+
+    fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.as_any().downcast_ref::<T>()
+    }
+}
+
+impl<Id, Symm, Tags> TensorLikeDowncast for dyn TensorLike<Id = Id, Symm = Symm, Tags = Tags> + Send + Sync
+where
+    Id: Clone + Hash + Eq + Debug + Send + Sync,
+    Symm: Clone + Symmetry + Send + Sync,
+    Tags: Clone + TagSetLike + Send + Sync,
+{
+    fn is<T: 'static>(&self) -> bool {
+        self.as_any().is::<T>()
+    }
+
+    fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        self.as_any().downcast_ref::<T>()
+    }
+}
+
+// ============================================================================
+// Implementation for TensorDynLen
+// ============================================================================
+
+impl<Id, Symm> TensorLike for TensorDynLen<Id, Symm>
+where
+    Id: Clone + Hash + Eq + Debug + Send + Sync + 'static,
+    Symm: Clone + Symmetry + Debug + Send + Sync + 'static,
+{
+    type Id = Id;
+    type Symm = Symm;
+    type Tags = tensor4all_core_common::DefaultTagSet;
+
+    fn external_indices(&self) -> Vec<Index<Self::Id, Self::Symm, Self::Tags>> {
+        // For TensorDynLen, all indices are external.
+        // Convert from Index<Id, Symm> to Index<Id, Symm, DefaultTagSet> by adding default tags.
+        self.indices
+            .iter()
+            .map(|idx| Index::new_with_tags(
+                idx.id.clone(),
+                idx.symm.clone(),
+                tensor4all_core_common::DefaultTagSet::default(),
+            ))
+            .collect()
+    }
+
+    fn num_external_indices(&self) -> usize {
+        self.indices.len()
+    }
+
+    fn to_tensor(&self) -> Result<TensorDynLen<Self::Id, Self::Symm>> {
+        // TensorDynLen is already a tensor, just clone it
+        Ok(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    // Use the default implementation of tensordot which calls to_tensor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Basic compile-time check that the trait is object-safe
+    fn _assert_object_safe<Id, Symm, Tags>()
+    where
+        Id: Clone + Hash + Eq + Debug + Send + Sync + 'static,
+        Symm: Clone + Symmetry + Send + Sync + 'static,
+        Tags: Clone + TagSetLike + Send + Sync + 'static,
+    {
+        fn _takes_trait_object(
+            _obj: &dyn TensorLike<Id = (), Symm = (), Tags = ()>,
+        ) {
+            // This won't compile if TensorLike is not object-safe
+        }
+    }
+}

--- a/tensor4all/core-tensor/tests/tensor_like.rs
+++ b/tensor4all/core-tensor/tests/tensor_like.rs
@@ -1,0 +1,170 @@
+//! Tests for TensorLike trait implementation.
+
+use tensor4all_core_common::index::{Index, DynId, NoSymmSpace};
+use tensor4all_core_common::DefaultTagSet;
+use tensor4all_core_tensor::{StorageScalar, TensorDynLen, TensorLike, TensorLikeDowncast};
+
+/// Helper to create a simple tensor with given dimensions
+fn make_tensor(dims: &[usize]) -> TensorDynLen<DynId> {
+    let indices: Vec<Index<DynId, NoSymmSpace>> = dims.iter()
+        .map(|&d| Index::new_dyn(d))
+        .collect();
+    let total_size: usize = dims.iter().product();
+    let data: Vec<f64> = (0..total_size).map(|i| i as f64).collect();
+    let storage = f64::dense_storage(data);
+    TensorDynLen::from_indices(indices, storage)
+}
+
+#[test]
+fn test_tensor_like_external_indices() {
+    let tensor = make_tensor(&[2, 3, 4]);
+
+    // Use TensorLike trait
+    let external_indices = tensor.external_indices();
+    assert_eq!(external_indices.len(), 3);
+
+    // Check dimensions through the indices
+    assert_eq!(external_indices[0].size(), 2);
+    assert_eq!(external_indices[1].size(), 3);
+    assert_eq!(external_indices[2].size(), 4);
+}
+
+#[test]
+fn test_tensor_like_num_external_indices() {
+    let tensor = make_tensor(&[5, 6]);
+
+    assert_eq!(tensor.num_external_indices(), 2);
+}
+
+#[test]
+fn test_tensor_like_to_tensor() {
+    let original = make_tensor(&[2, 3]);
+
+    // to_tensor should return a clone
+    let cloned = <TensorDynLen<DynId> as TensorLike>::to_tensor(&original)
+        .expect("to_tensor should succeed");
+
+    assert_eq!(cloned.indices.len(), original.indices.len());
+    assert_eq!(cloned.dims, original.dims);
+}
+
+#[test]
+fn test_tensor_like_tensordot_basic() {
+    // Create two tensors: A(i,j) and B(j,k)
+    // Contract over j to get C(i,k)
+    let i = Index::<DynId, NoSymmSpace>::new_dyn(2);
+    let j = Index::<DynId, NoSymmSpace>::new_dyn(3);
+    let k = Index::<DynId, NoSymmSpace>::new_dyn(4);
+
+    // Tensor A: 2x3 matrix
+    let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
+    let a = TensorDynLen::from_indices(
+        vec![i.clone(), j.clone()],
+        f64::dense_storage(a_data),
+    );
+
+    // Tensor B: 3x4 matrix (use a copy of j with same id)
+    let j_copy = Index::new(j.id, j.symm.clone());
+    let b_data: Vec<f64> = (0..12).map(|x| x as f64).collect();
+    let b = TensorDynLen::from_indices(
+        vec![j_copy.clone(), k.clone()],
+        f64::dense_storage(b_data),
+    );
+
+    // Create pairs with DefaultTagSet
+    let pairs = vec![(
+        Index::<DynId, NoSymmSpace, DefaultTagSet>::new_with_tags(
+            j.id, j.symm.clone(), DefaultTagSet::default(),
+        ),
+        Index::<DynId, NoSymmSpace, DefaultTagSet>::new_with_tags(
+            j_copy.id, j_copy.symm.clone(), DefaultTagSet::default(),
+        ),
+    )];
+
+    // Use TensorLike::tensordot (via default implementation)
+    let c = <TensorDynLen<DynId> as TensorLike>::tensordot(&a, &b, &pairs)
+        .expect("tensordot should succeed");
+
+    // Result should be 2x4
+    assert_eq!(c.dims, vec![2, 4]);
+}
+
+#[test]
+fn test_tensor_like_object_safety() {
+    let tensor = make_tensor(&[2, 3]);
+
+    // Use trait object
+    let trait_obj: &dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet> = &tensor;
+
+    // Should be able to call methods on trait object
+    assert_eq!(trait_obj.num_external_indices(), 2);
+
+    let external = trait_obj.external_indices();
+    assert_eq!(external.len(), 2);
+}
+
+#[test]
+fn test_tensor_like_clone_trait_object() {
+    let tensor = make_tensor(&[2, 3]);
+
+    // Box the tensor as a trait object
+    let boxed: Box<dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet>> =
+        Box::new(tensor);
+
+    // Clone the boxed trait object (via dyn-clone)
+    let cloned = dyn_clone::clone_box(&*boxed);
+
+    // Both should have the same properties
+    assert_eq!(boxed.num_external_indices(), cloned.num_external_indices());
+}
+
+#[test]
+fn test_tensor_like_as_any() {
+    let tensor = make_tensor(&[2, 3]);
+
+    // Get as Any
+    let any_ref = tensor.as_any();
+
+    // Should be able to downcast back to TensorDynLen<DynId>
+    let downcast = any_ref.downcast_ref::<TensorDynLen<DynId>>();
+    assert!(downcast.is_some());
+
+    let downcast_tensor = downcast.unwrap();
+    assert_eq!(downcast_tensor.dims, vec![2, 3]);
+}
+
+#[test]
+fn test_tensor_like_downcast_via_trait_object() {
+    let tensor = make_tensor(&[2, 3]);
+
+    // Use as trait object
+    let trait_obj: &dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet> = &tensor;
+
+    // Use TensorLikeDowncast extension trait
+    assert!(trait_obj.is::<TensorDynLen<DynId>>());
+
+    let downcast = trait_obj.downcast_ref::<TensorDynLen<DynId>>();
+    assert!(downcast.is_some());
+    assert_eq!(downcast.unwrap().dims, vec![2, 3]);
+
+    // Should not downcast to wrong type
+    assert!(!trait_obj.is::<String>());
+    assert!(trait_obj.downcast_ref::<String>().is_none());
+}
+
+#[test]
+fn test_tensor_like_downcast_boxed() {
+    let tensor = make_tensor(&[4, 5]);
+
+    // Box as trait object
+    let boxed: Box<dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet>> =
+        Box::new(tensor);
+
+    // Downcast via as_any
+    let downcast = boxed.as_any().downcast_ref::<TensorDynLen<DynId>>();
+    assert!(downcast.is_some());
+    assert_eq!(downcast.unwrap().dims, vec![4, 5]);
+
+    // Also via extension trait
+    assert!(boxed.is::<TensorDynLen<DynId>>());
+}


### PR DESCRIPTION
## Summary

Introduces a `TensorLike` trait that provides a common interface for treating both dense tensors (`TensorDynLen`) and tree tensor networks (`TreeTN`) through a unified abstraction.

### Features

- **`external_indices()`**: Returns flattened external/physical indices with stable ordering
- **`num_external_indices()`**: Returns count of external indices (with efficient override)
- **`to_tensor()`**: Converts to dense `TensorDynLen` (clone for tensors, contract for networks)
- **`tensordot()`**: Explicit binary contraction with default implementation via `to_tensor()`
- **`as_any()`**: Runtime type inspection/downcasting support (similar to C++ `dynamic_cast`)

### Additional

- `TensorLikeDowncast` extension trait with `is<T>()` and `downcast_ref<T>()` helpers
- `dyn-clone` support for cloneable `Box<dyn TensorLike<...>>` trait objects
- Object-safe design with `Vec` returns for trait object compatibility
- Comprehensive tests for both `TensorDynLen` and `TreeTN` implementations

### API Example

```rust
// Use as trait object
let objects: Vec<Box<dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = DefaultTagSet>>> = vec![
    Box::new(tensor),
    Box::new(treetn),
];

// Downcast to concrete type
if objects[0].is::<TensorDynLen<DynId>>() {
    let t = objects[0].downcast_ref::<TensorDynLen<DynId>>().unwrap();
    // Use tensor directly
}
```

## Test plan

- [x] `cargo test -p tensor4all-core-tensor --test tensor_like` (9 tests)
- [x] `cargo test -p tensor4all-treetn --test tensor_like` (10 tests)
- [x] `cargo test` (all tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)