### PR TITLE
feat(capi): Add TensorTrain C-API and language bindings

### DIFF
--- a/bindings/julia/Tensor4allRs/Project.toml
+++ b/bindings/julia/Tensor4allRs/Project.toml
@@ -1,0 +1,13 @@
+name = "Tensor4allRs"
+uuid = "e8f4b8c5-8d92-4e42-a5c3-b7e9c4a3f2d1"
+authors = ["tensor4all collaboration"]
+version = "0.1.0"
+
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/bindings/julia/Tensor4allRs/src/Tensor4allRs.jl
+++ b/bindings/julia/Tensor4allRs/src/Tensor4allRs.jl
@@ -1,0 +1,61 @@
+module Tensor4allRs
+
+using Libdl
+
+# Library handle
+const _lib = Ref{Ptr{Cvoid}}(C_NULL)
+
+# Status codes (must match Rust constants)
+const T4A_SUCCESS = 0
+const T4A_NULL_POINTER = -1
+const T4A_INVALID_ARGUMENT = -2
+const T4A_TAG_OVERFLOW = -3
+const T4A_TAG_TOO_LONG = -4
+const T4A_BUFFER_TOO_SMALL = -5
+const T4A_INTERNAL_ERROR = -6
+
+"""
+    init_library(libpath::String)
+
+Initialize the Tensor4allRs library by loading the shared library.
+
+# Arguments
+- `libpath`: Path to the `libtensor4all_capi` shared library
+
+# Example
+```julia
+Tensor4allRs.init_library("/path/to/libtensor4all_capi.dylib")
+```
+"""
+function init_library(libpath::String)
+    if _lib[] != C_NULL
+        # Already initialized
+        return
+    end
+    _lib[] = Libdl.dlopen(libpath)
+    if _lib[] == C_NULL
+        error("Failed to load library: $libpath")
+    end
+end
+
+"""
+    get_lib()
+
+Get the library handle. Throws an error if the library has not been initialized.
+"""
+function get_lib()
+    if _lib[] == C_NULL
+        error("Library not initialized. Call Tensor4allRs.init_library(path) first.")
+    end
+    return _lib[]
+end
+
+# Include submodules
+include("tensortrain.jl")
+
+export TensorTrainF64, TensorTrainC64
+export zeros_tt, constant_tt
+export site_dims, link_dims, rank, evaluate, sum_tt, norm_tt, log_norm_tt
+export scale!, scaled, fulltensor
+
+end # module

--- a/bindings/julia/Tensor4allRs/src/tensortrain.jl
+++ b/bindings/julia/Tensor4allRs/src/tensortrain.jl
@@ -1,0 +1,642 @@
+# TensorTrain bindings for Julia
+
+# ============================================================================
+# TensorTrainF64
+# ============================================================================
+
+"""
+    TensorTrainF64
+
+A tensor train (Matrix Product State) with Float64 elements.
+
+Wraps the Rust `TensorTrain<f64>` type via the C API.
+"""
+mutable struct TensorTrainF64
+    ptr::Ptr{Cvoid}
+
+    function TensorTrainF64(ptr::Ptr{Cvoid})
+        tt = new(ptr)
+        finalizer(_release_tt_f64, tt)
+        return tt
+    end
+end
+
+function _release_tt_f64(tt::TensorTrainF64)
+    if tt.ptr != C_NULL
+        lib = get_lib()
+        ccall(Libdl.dlsym(lib, :t4a_tt_f64_release), Cvoid, (Ptr{Cvoid},), tt.ptr)
+        tt.ptr = C_NULL
+    end
+end
+
+"""
+    zeros_tt(::Type{Float64}, site_dims::Vector{Int})
+
+Create a tensor train representing the zero function.
+
+# Arguments
+- `site_dims`: Vector of site dimensions
+
+# Returns
+A new `TensorTrainF64` with all elements equal to zero.
+"""
+function zeros_tt(::Type{Float64}, site_dims::Vector{Int})
+    lib = get_lib()
+    dims = convert(Vector{Csize_t}, site_dims)
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_new_zeros),
+        Ptr{Cvoid},
+        (Ptr{Csize_t}, Csize_t),
+        dims,
+        length(dims),
+    )
+    ptr == C_NULL && error("Failed to create TensorTrainF64")
+    return TensorTrainF64(ptr)
+end
+
+"""
+    constant_tt(::Type{Float64}, site_dims::Vector{Int}, value::Float64)
+
+Create a tensor train representing a constant function.
+
+# Arguments
+- `site_dims`: Vector of site dimensions
+- `value`: The constant value
+
+# Returns
+A new `TensorTrainF64` with all elements equal to `value`.
+"""
+function constant_tt(::Type{Float64}, site_dims::Vector{Int}, value::Float64)
+    lib = get_lib()
+    dims = convert(Vector{Csize_t}, site_dims)
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_new_constant),
+        Ptr{Cvoid},
+        (Ptr{Csize_t}, Csize_t, Cdouble),
+        dims,
+        length(dims),
+        value,
+    )
+    ptr == C_NULL && error("Failed to create TensorTrainF64")
+    return TensorTrainF64(ptr)
+end
+
+"""
+    Base.length(tt::TensorTrainF64)
+
+Get the number of sites in the tensor train.
+"""
+function Base.length(tt::TensorTrainF64)
+    lib = get_lib()
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_len),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}),
+        tt.ptr,
+        out_len,
+    )
+    status == T4A_SUCCESS || error("Failed to get length: status = $status")
+    return Int(out_len[])
+end
+
+"""
+    site_dims(tt::TensorTrainF64)
+
+Get the site (physical) dimensions of the tensor train.
+"""
+function site_dims(tt::TensorTrainF64)
+    lib = get_lib()
+    n = length(tt)
+    out_dims = Vector{Csize_t}(undef, n)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_site_dims),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}, Csize_t),
+        tt.ptr,
+        out_dims,
+        n,
+    )
+    status == T4A_SUCCESS || error("Failed to get site_dims: status = $status")
+    return convert(Vector{Int}, out_dims)
+end
+
+"""
+    link_dims(tt::TensorTrainF64)
+
+Get the link (bond) dimensions of the tensor train.
+"""
+function link_dims(tt::TensorTrainF64)
+    lib = get_lib()
+    n = length(tt)
+    if n <= 1
+        return Int[]
+    end
+    out_dims = Vector{Csize_t}(undef, n - 1)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_link_dims),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}, Csize_t),
+        tt.ptr,
+        out_dims,
+        n - 1,
+    )
+    status == T4A_SUCCESS || error("Failed to get link_dims: status = $status")
+    return convert(Vector{Int}, out_dims)
+end
+
+"""
+    rank(tt::TensorTrainF64)
+
+Get the maximum bond dimension (rank) of the tensor train.
+"""
+function rank(tt::TensorTrainF64)
+    lib = get_lib()
+    out_rank = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_rank),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}),
+        tt.ptr,
+        out_rank,
+    )
+    status == T4A_SUCCESS || error("Failed to get rank: status = $status")
+    return Int(out_rank[])
+end
+
+"""
+    evaluate(tt::TensorTrainF64, indices::Vector{Int})
+
+Evaluate the tensor train at a given index set.
+
+# Arguments
+- `indices`: Vector of indices (1-based in Julia, converted to 0-based for Rust)
+
+# Returns
+The value of the tensor train at the given indices.
+"""
+function evaluate(tt::TensorTrainF64, indices::Vector{Int})
+    lib = get_lib()
+    # Convert to 0-based indices for Rust
+    idx = convert(Vector{Csize_t}, indices .- 1)
+    out_value = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_evaluate),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}, Csize_t, Ptr{Cdouble}),
+        tt.ptr,
+        idx,
+        length(idx),
+        out_value,
+    )
+    status == T4A_SUCCESS || error("Failed to evaluate: status = $status")
+    return out_value[]
+end
+
+"""
+    sum_tt(tt::TensorTrainF64)
+
+Compute the sum of all elements in the tensor train.
+"""
+function sum_tt(tt::TensorTrainF64)
+    lib = get_lib()
+    out_sum = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_sum),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}),
+        tt.ptr,
+        out_sum,
+    )
+    status == T4A_SUCCESS || error("Failed to compute sum: status = $status")
+    return out_sum[]
+end
+
+"""
+    norm_tt(tt::TensorTrainF64)
+
+Compute the Frobenius norm of the tensor train.
+"""
+function norm_tt(tt::TensorTrainF64)
+    lib = get_lib()
+    out_norm = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_norm),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}),
+        tt.ptr,
+        out_norm,
+    )
+    status == T4A_SUCCESS || error("Failed to compute norm: status = $status")
+    return out_norm[]
+end
+
+"""
+    log_norm_tt(tt::TensorTrainF64)
+
+Compute the logarithm of the Frobenius norm.
+
+This is more numerically stable than `log(norm_tt(tt))` for very large or small norms.
+"""
+function log_norm_tt(tt::TensorTrainF64)
+    lib = get_lib()
+    out_log_norm = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_log_norm),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}),
+        tt.ptr,
+        out_log_norm,
+    )
+    status == T4A_SUCCESS || error("Failed to compute log_norm: status = $status")
+    return out_log_norm[]
+end
+
+"""
+    scale!(tt::TensorTrainF64, factor::Float64)
+
+Scale the tensor train by a factor in place.
+"""
+function scale!(tt::TensorTrainF64, factor::Float64)
+    lib = get_lib()
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_scale_inplace),
+        Cint,
+        (Ptr{Cvoid}, Cdouble),
+        tt.ptr,
+        factor,
+    )
+    status == T4A_SUCCESS || error("Failed to scale: status = $status")
+    return tt
+end
+
+"""
+    scaled(tt::TensorTrainF64, factor::Float64)
+
+Create a new tensor train scaled by a factor.
+
+The original tensor train is unchanged.
+"""
+function scaled(tt::TensorTrainF64, factor::Float64)
+    lib = get_lib()
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_scaled),
+        Ptr{Cvoid},
+        (Ptr{Cvoid}, Cdouble),
+        tt.ptr,
+        factor,
+    )
+    ptr == C_NULL && error("Failed to create scaled TensorTrainF64")
+    return TensorTrainF64(ptr)
+end
+
+"""
+    fulltensor(tt::TensorTrainF64)
+
+Convert the tensor train to a full tensor (dense array).
+
+Returns the data reshaped to the site dimensions in column-major order (Julia convention).
+
+Warning: This can be very large for high-dimensional tensors!
+"""
+function fulltensor(tt::TensorTrainF64)
+    lib = get_lib()
+
+    # Query length
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_fulltensor),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}, Csize_t, Ptr{Csize_t}),
+        tt.ptr,
+        C_NULL,
+        0,
+        out_len,
+    )
+    status == T4A_SUCCESS || error("Failed to query fulltensor length: status = $status")
+
+    # Get data (row-major from Rust)
+    data = Vector{Cdouble}(undef, out_len[])
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_fulltensor),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}, Csize_t, Ptr{Csize_t}),
+        tt.ptr,
+        data,
+        out_len[],
+        out_len,
+    )
+    status == T4A_SUCCESS || error("Failed to get fulltensor: status = $status")
+
+    # Convert row-major to column-major
+    dims = site_dims(tt)
+    return _row_to_column_major(data, Tuple(dims))
+end
+
+"""
+    _row_to_column_major(data::Vector{T}, dims::Tuple) where T
+
+Convert row-major data to column-major (Julia convention).
+"""
+function _row_to_column_major(data::Vector{T}, dims::Tuple) where {T}
+    if isempty(dims)
+        return data
+    end
+    # Data is row-major, so reverse dims for reshape
+    arr = reshape(data, reverse(dims)...)
+    # Reverse back to get column-major
+    perm = reverse(1:length(dims))
+    return permutedims(arr, perm)
+end
+
+"""
+    Base.copy(tt::TensorTrainF64)
+
+Create a copy (clone) of the tensor train.
+"""
+function Base.copy(tt::TensorTrainF64)
+    lib = get_lib()
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_f64_clone),
+        Ptr{Cvoid},
+        (Ptr{Cvoid},),
+        tt.ptr,
+    )
+    ptr == C_NULL && error("Failed to clone TensorTrainF64")
+    return TensorTrainF64(ptr)
+end
+
+# ============================================================================
+# TensorTrainC64 (Complex{Float64})
+# ============================================================================
+
+"""
+    TensorTrainC64
+
+A tensor train (Matrix Product State) with Complex{Float64} elements.
+
+Wraps the Rust `TensorTrain<Complex64>` type via the C API.
+"""
+mutable struct TensorTrainC64
+    ptr::Ptr{Cvoid}
+
+    function TensorTrainC64(ptr::Ptr{Cvoid})
+        tt = new(ptr)
+        finalizer(_release_tt_c64, tt)
+        return tt
+    end
+end
+
+function _release_tt_c64(tt::TensorTrainC64)
+    if tt.ptr != C_NULL
+        lib = get_lib()
+        ccall(Libdl.dlsym(lib, :t4a_tt_c64_release), Cvoid, (Ptr{Cvoid},), tt.ptr)
+        tt.ptr = C_NULL
+    end
+end
+
+"""
+    zeros_tt(::Type{ComplexF64}, site_dims::Vector{Int})
+
+Create a complex tensor train representing the zero function.
+"""
+function zeros_tt(::Type{ComplexF64}, site_dims::Vector{Int})
+    lib = get_lib()
+    dims = convert(Vector{Csize_t}, site_dims)
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_new_zeros),
+        Ptr{Cvoid},
+        (Ptr{Csize_t}, Csize_t),
+        dims,
+        length(dims),
+    )
+    ptr == C_NULL && error("Failed to create TensorTrainC64")
+    return TensorTrainC64(ptr)
+end
+
+"""
+    constant_tt(::Type{ComplexF64}, site_dims::Vector{Int}, value::ComplexF64)
+
+Create a complex tensor train representing a constant function.
+"""
+function constant_tt(::Type{ComplexF64}, site_dims::Vector{Int}, value::ComplexF64)
+    lib = get_lib()
+    dims = convert(Vector{Csize_t}, site_dims)
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_new_constant),
+        Ptr{Cvoid},
+        (Ptr{Csize_t}, Csize_t, Cdouble, Cdouble),
+        dims,
+        length(dims),
+        real(value),
+        imag(value),
+    )
+    ptr == C_NULL && error("Failed to create TensorTrainC64")
+    return TensorTrainC64(ptr)
+end
+
+function Base.length(tt::TensorTrainC64)
+    lib = get_lib()
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_len),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}),
+        tt.ptr,
+        out_len,
+    )
+    status == T4A_SUCCESS || error("Failed to get length: status = $status")
+    return Int(out_len[])
+end
+
+function site_dims(tt::TensorTrainC64)
+    lib = get_lib()
+    n = length(tt)
+    out_dims = Vector{Csize_t}(undef, n)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_site_dims),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}, Csize_t),
+        tt.ptr,
+        out_dims,
+        n,
+    )
+    status == T4A_SUCCESS || error("Failed to get site_dims: status = $status")
+    return convert(Vector{Int}, out_dims)
+end
+
+function link_dims(tt::TensorTrainC64)
+    lib = get_lib()
+    n = length(tt)
+    if n <= 1
+        return Int[]
+    end
+    out_dims = Vector{Csize_t}(undef, n - 1)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_link_dims),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}, Csize_t),
+        tt.ptr,
+        out_dims,
+        n - 1,
+    )
+    status == T4A_SUCCESS || error("Failed to get link_dims: status = $status")
+    return convert(Vector{Int}, out_dims)
+end
+
+function rank(tt::TensorTrainC64)
+    lib = get_lib()
+    out_rank = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_rank),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}),
+        tt.ptr,
+        out_rank,
+    )
+    status == T4A_SUCCESS || error("Failed to get rank: status = $status")
+    return Int(out_rank[])
+end
+
+function evaluate(tt::TensorTrainC64, indices::Vector{Int})
+    lib = get_lib()
+    idx = convert(Vector{Csize_t}, indices .- 1)
+    out_re = Ref{Cdouble}(0.0)
+    out_im = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_evaluate),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Csize_t}, Csize_t, Ptr{Cdouble}, Ptr{Cdouble}),
+        tt.ptr,
+        idx,
+        length(idx),
+        out_re,
+        out_im,
+    )
+    status == T4A_SUCCESS || error("Failed to evaluate: status = $status")
+    return ComplexF64(out_re[], out_im[])
+end
+
+function sum_tt(tt::TensorTrainC64)
+    lib = get_lib()
+    out_re = Ref{Cdouble}(0.0)
+    out_im = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_sum),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cdouble}),
+        tt.ptr,
+        out_re,
+        out_im,
+    )
+    status == T4A_SUCCESS || error("Failed to compute sum: status = $status")
+    return ComplexF64(out_re[], out_im[])
+end
+
+function norm_tt(tt::TensorTrainC64)
+    lib = get_lib()
+    out_norm = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_norm),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}),
+        tt.ptr,
+        out_norm,
+    )
+    status == T4A_SUCCESS || error("Failed to compute norm: status = $status")
+    return out_norm[]
+end
+
+function log_norm_tt(tt::TensorTrainC64)
+    lib = get_lib()
+    out_log_norm = Ref{Cdouble}(0.0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_log_norm),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}),
+        tt.ptr,
+        out_log_norm,
+    )
+    status == T4A_SUCCESS || error("Failed to compute log_norm: status = $status")
+    return out_log_norm[]
+end
+
+function scale!(tt::TensorTrainC64, factor::Number)
+    f = ComplexF64(factor)
+    lib = get_lib()
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_scale_inplace),
+        Cint,
+        (Ptr{Cvoid}, Cdouble, Cdouble),
+        tt.ptr,
+        real(f),
+        imag(f),
+    )
+    status == T4A_SUCCESS || error("Failed to scale: status = $status")
+    return tt
+end
+
+function scaled(tt::TensorTrainC64, factor::Number)
+    f = ComplexF64(factor)
+    lib = get_lib()
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_scaled),
+        Ptr{Cvoid},
+        (Ptr{Cvoid}, Cdouble, Cdouble),
+        tt.ptr,
+        real(f),
+        imag(f),
+    )
+    ptr == C_NULL && error("Failed to create scaled TensorTrainC64")
+    return TensorTrainC64(ptr)
+end
+
+function fulltensor(tt::TensorTrainC64)
+    lib = get_lib()
+
+    # Query length
+    out_len = Ref{Csize_t}(0)
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_fulltensor),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cdouble}, Csize_t, Ptr{Csize_t}),
+        tt.ptr,
+        C_NULL,
+        C_NULL,
+        0,
+        out_len,
+    )
+    status == T4A_SUCCESS || error("Failed to query fulltensor length: status = $status")
+
+    # Get data
+    data_re = Vector{Cdouble}(undef, out_len[])
+    data_im = Vector{Cdouble}(undef, out_len[])
+    status = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_fulltensor),
+        Cint,
+        (Ptr{Cvoid}, Ptr{Cdouble}, Ptr{Cdouble}, Csize_t, Ptr{Csize_t}),
+        tt.ptr,
+        data_re,
+        data_im,
+        out_len[],
+        out_len,
+    )
+    status == T4A_SUCCESS || error("Failed to get fulltensor: status = $status")
+
+    # Combine to complex and convert layout
+    data = ComplexF64.(data_re, data_im)
+    dims = site_dims(tt)
+    return _row_to_column_major(data, Tuple(dims))
+end
+
+function Base.copy(tt::TensorTrainC64)
+    lib = get_lib()
+    ptr = ccall(
+        Libdl.dlsym(lib, :t4a_tt_c64_clone),
+        Ptr{Cvoid},
+        (Ptr{Cvoid},),
+        tt.ptr,
+    )
+    ptr == C_NULL && error("Failed to clone TensorTrainC64")
+    return TensorTrainC64(ptr)
+end

--- a/bindings/julia/Tensor4allRs/test/runtests.jl
+++ b/bindings/julia/Tensor4allRs/test/runtests.jl
@@ -1,0 +1,124 @@
+using Test
+using Tensor4allRs
+
+# Initialize library - adjust path as needed
+# For development, build with: cargo build --release -p tensor4all-capi
+const LIBPATH = if Sys.isapple()
+    joinpath(@__DIR__, "..", "..", "..", "..", "target", "release", "libtensor4all_capi.dylib")
+elseif Sys.islinux()
+    joinpath(@__DIR__, "..", "..", "..", "..", "target", "release", "libtensor4all_capi.so")
+elseif Sys.iswindows()
+    joinpath(@__DIR__, "..", "..", "..", "..", "target", "release", "tensor4all_capi.dll")
+else
+    error("Unsupported platform")
+end
+
+@testset "Tensor4allRs" begin
+    # Check if library exists
+    if !isfile(LIBPATH)
+        @warn "Library not found at $LIBPATH. Skipping tests. Build with: cargo build --release -p tensor4all-capi"
+        return
+    end
+
+    Tensor4allRs.init_library(LIBPATH)
+
+    @testset "TensorTrainF64" begin
+        @testset "zeros" begin
+            tt = zeros_tt(Float64, [2, 3, 2])
+            @test length(tt) == 3
+            @test site_dims(tt) == [2, 3, 2]
+            @test rank(tt) == 1
+        end
+
+        @testset "constant" begin
+            tt = constant_tt(Float64, [2, 2], 5.0)
+            @test length(tt) == 2
+            @test site_dims(tt) == [2, 2]
+
+            # Sum should be 5.0 * 2 * 2 = 20.0
+            @test isapprox(sum_tt(tt), 20.0; atol=1e-10)
+
+            # Evaluate at [1, 2] (1-based)
+            @test isapprox(evaluate(tt, [1, 2]), 5.0; atol=1e-10)
+        end
+
+        @testset "scale" begin
+            tt = constant_tt(Float64, [2, 2], 1.0)
+
+            # Immutable scale
+            tt2 = scaled(tt, 3.0)
+            @test isapprox(sum_tt(tt2), 12.0; atol=1e-10)
+            @test isapprox(sum_tt(tt), 4.0; atol=1e-10)  # Original unchanged
+
+            # In-place scale
+            scale!(tt, 2.0)
+            @test isapprox(sum_tt(tt), 8.0; atol=1e-10)
+        end
+
+        @testset "norm" begin
+            tt = constant_tt(Float64, [2, 3], 2.0)
+
+            norm_val = norm_tt(tt)
+            # norm = sqrt(sum of squares) = sqrt(6 * 4) = sqrt(24)
+            @test isapprox(norm_val, sqrt(24.0); atol=1e-10)
+
+            log_norm_val = log_norm_tt(tt)
+            @test isapprox(log_norm_val, log(norm_val); atol=1e-10)
+        end
+
+        @testset "fulltensor" begin
+            tt = constant_tt(Float64, [2, 3], 5.0)
+            arr = fulltensor(tt)
+
+            @test size(arr) == (2, 3)
+            @test all(isapprox.(arr, 5.0; atol=1e-10))
+        end
+
+        @testset "copy" begin
+            tt = constant_tt(Float64, [2, 2], 3.0)
+            tt2 = copy(tt)
+
+            @test isapprox(sum_tt(tt2), sum_tt(tt); atol=1e-10)
+
+            # Modify original, copy should be unchanged
+            scale!(tt, 2.0)
+            @test isapprox(sum_tt(tt), 24.0; atol=1e-10)
+            @test isapprox(sum_tt(tt2), 12.0; atol=1e-10)
+        end
+    end
+
+    @testset "TensorTrainC64" begin
+        @testset "zeros" begin
+            tt = zeros_tt(ComplexF64, [2, 3, 2])
+            @test length(tt) == 3
+            @test site_dims(tt) == [2, 3, 2]
+        end
+
+        @testset "constant" begin
+            tt = constant_tt(ComplexF64, [2, 2], 3.0 + 4.0im)
+            @test length(tt) == 2
+
+            val = evaluate(tt, [1, 2])
+            @test isapprox(real(val), 3.0; atol=1e-10)
+            @test isapprox(imag(val), 4.0; atol=1e-10)
+        end
+
+        @testset "scale" begin
+            tt = constant_tt(ComplexF64, [2, 2], 1.0 + 0.0im)
+
+            # Scale by complex number
+            tt2 = scaled(tt, 0.0 + 1.0im)
+            s = sum_tt(tt2)
+            @test isapprox(real(s), 0.0; atol=1e-10)
+            @test isapprox(imag(s), 4.0; atol=1e-10)
+        end
+
+        @testset "fulltensor" begin
+            tt = constant_tt(ComplexF64, [2, 3], 1.0 + 2.0im)
+            arr = fulltensor(tt)
+
+            @test size(arr) == (2, 3)
+            @test all(x -> isapprox(x, 1.0 + 2.0im; atol=1e-10), arr)
+        end
+    end
+end

--- a/bindings/python/tensor4all_rs/__init__.py
+++ b/bindings/python/tensor4all_rs/__init__.py
@@ -1,0 +1,682 @@
+"""
+Tensor4all-rs Python bindings
+
+Python interface to the tensor4all-rs library via its C API.
+"""
+
+import ctypes
+import os
+import platform
+from pathlib import Path
+from typing import List, Optional, Tuple, Union, TYPE_CHECKING
+
+try:
+    import numpy as np
+    HAS_NUMPY = True
+except ImportError:
+    np = None  # type: ignore
+    HAS_NUMPY = False
+
+# Status codes (must match Rust constants)
+T4A_SUCCESS = 0
+T4A_NULL_POINTER = -1
+T4A_INVALID_ARGUMENT = -2
+T4A_TAG_OVERFLOW = -3
+T4A_TAG_TOO_LONG = -4
+T4A_BUFFER_TOO_SMALL = -5
+T4A_INTERNAL_ERROR = -6
+
+# Library handle
+_lib: Optional[ctypes.CDLL] = None
+
+
+def init_library(libpath: Optional[str] = None) -> None:
+    """
+    Initialize the library by loading the shared library.
+
+    Parameters
+    ----------
+    libpath : str, optional
+        Path to the libtensor4all_capi shared library.
+        If not provided, attempts to find it in standard locations.
+
+    Raises
+    ------
+    OSError
+        If the library cannot be loaded.
+    """
+    global _lib
+    if _lib is not None:
+        return
+
+    if libpath is None:
+        # Try to find library in standard locations
+        system = platform.system()
+        if system == "Darwin":
+            libname = "libtensor4all_capi.dylib"
+        elif system == "Linux":
+            libname = "libtensor4all_capi.so"
+        elif system == "Windows":
+            libname = "tensor4all_capi.dll"
+        else:
+            raise OSError(f"Unsupported platform: {system}")
+
+        # Check common locations
+        search_paths = [
+            Path(__file__).parent / libname,
+            Path(__file__).parent.parent.parent.parent / "target" / "release" / libname,
+            Path(__file__).parent.parent.parent.parent / "target" / "debug" / libname,
+        ]
+
+        for path in search_paths:
+            if path.exists():
+                libpath = str(path)
+                break
+
+        if libpath is None:
+            raise OSError(
+                f"Could not find {libname}. "
+                "Please provide the path or build with: cargo build --release -p tensor4all-capi"
+            )
+
+    _lib = ctypes.CDLL(libpath)
+    _setup_function_signatures()
+
+
+def _get_lib() -> ctypes.CDLL:
+    """Get the library handle."""
+    if _lib is None:
+        raise RuntimeError(
+            "Library not initialized. Call tensor4all_rs.init_library() first."
+        )
+    return _lib
+
+
+def _setup_function_signatures() -> None:
+    """Set up ctypes function signatures for type safety."""
+    lib = _lib
+    if lib is None:
+        return
+
+    # TensorTrain F64 functions
+    lib.t4a_tt_f64_new_zeros.argtypes = [ctypes.POINTER(ctypes.c_size_t), ctypes.c_size_t]
+    lib.t4a_tt_f64_new_zeros.restype = ctypes.c_void_p
+
+    lib.t4a_tt_f64_new_constant.argtypes = [
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+        ctypes.c_double,
+    ]
+    lib.t4a_tt_f64_new_constant.restype = ctypes.c_void_p
+
+    lib.t4a_tt_f64_release.argtypes = [ctypes.c_void_p]
+    lib.t4a_tt_f64_release.restype = None
+
+    lib.t4a_tt_f64_clone.argtypes = [ctypes.c_void_p]
+    lib.t4a_tt_f64_clone.restype = ctypes.c_void_p
+
+    lib.t4a_tt_f64_len.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+    lib.t4a_tt_f64_len.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_site_dims.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+    ]
+    lib.t4a_tt_f64_site_dims.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_link_dims.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+    ]
+    lib.t4a_tt_f64_link_dims.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_rank.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+    lib.t4a_tt_f64_rank.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_evaluate.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+    ]
+    lib.t4a_tt_f64_evaluate.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_sum.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+    lib.t4a_tt_f64_sum.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_norm.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+    lib.t4a_tt_f64_norm.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_log_norm.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+    lib.t4a_tt_f64_log_norm.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_scaled.argtypes = [ctypes.c_void_p, ctypes.c_double]
+    lib.t4a_tt_f64_scaled.restype = ctypes.c_void_p
+
+    lib.t4a_tt_f64_scale_inplace.argtypes = [ctypes.c_void_p, ctypes.c_double]
+    lib.t4a_tt_f64_scale_inplace.restype = ctypes.c_int
+
+    lib.t4a_tt_f64_fulltensor.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    lib.t4a_tt_f64_fulltensor.restype = ctypes.c_int
+
+    # TensorTrain C64 functions
+    lib.t4a_tt_c64_new_zeros.argtypes = [ctypes.POINTER(ctypes.c_size_t), ctypes.c_size_t]
+    lib.t4a_tt_c64_new_zeros.restype = ctypes.c_void_p
+
+    lib.t4a_tt_c64_new_constant.argtypes = [
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+        ctypes.c_double,
+        ctypes.c_double,
+    ]
+    lib.t4a_tt_c64_new_constant.restype = ctypes.c_void_p
+
+    lib.t4a_tt_c64_release.argtypes = [ctypes.c_void_p]
+    lib.t4a_tt_c64_release.restype = None
+
+    lib.t4a_tt_c64_clone.argtypes = [ctypes.c_void_p]
+    lib.t4a_tt_c64_clone.restype = ctypes.c_void_p
+
+    lib.t4a_tt_c64_len.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+    lib.t4a_tt_c64_len.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_site_dims.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+    ]
+    lib.t4a_tt_c64_site_dims.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_link_dims.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+    ]
+    lib.t4a_tt_c64_link_dims.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_rank.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+    lib.t4a_tt_c64_rank.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_evaluate.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+    ]
+    lib.t4a_tt_c64_evaluate.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_sum.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+    ]
+    lib.t4a_tt_c64_sum.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_norm.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+    lib.t4a_tt_c64_norm.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_log_norm.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+    lib.t4a_tt_c64_log_norm.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_scaled.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.t4a_tt_c64_scaled.restype = ctypes.c_void_p
+
+    lib.t4a_tt_c64_scale_inplace.argtypes = [ctypes.c_void_p, ctypes.c_double, ctypes.c_double]
+    lib.t4a_tt_c64_scale_inplace.restype = ctypes.c_int
+
+    lib.t4a_tt_c64_fulltensor.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_size_t,
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    lib.t4a_tt_c64_fulltensor.restype = ctypes.c_int
+
+
+class TensorTrainF64:
+    """
+    A tensor train (Matrix Product State) with float64 elements.
+
+    Wraps the Rust `TensorTrain<f64>` type via the C API.
+    """
+
+    def __init__(self, ptr: ctypes.c_void_p):
+        """Initialize from a raw pointer (internal use)."""
+        self._ptr = ptr
+
+    def __del__(self):
+        """Release the tensor train."""
+        if hasattr(self, "_ptr") and self._ptr is not None:
+            lib = _get_lib()
+            lib.t4a_tt_f64_release(self._ptr)
+            self._ptr = None
+
+    @classmethod
+    def zeros(cls, site_dims: List[int]) -> "TensorTrainF64":
+        """
+        Create a tensor train representing the zero function.
+
+        Parameters
+        ----------
+        site_dims : List[int]
+            List of site dimensions.
+
+        Returns
+        -------
+        TensorTrainF64
+            A new tensor train with all elements equal to zero.
+        """
+        lib = _get_lib()
+        dims = (ctypes.c_size_t * len(site_dims))(*site_dims)
+        ptr = lib.t4a_tt_f64_new_zeros(dims, len(site_dims))
+        if ptr is None:
+            raise RuntimeError("Failed to create TensorTrainF64")
+        return cls(ptr)
+
+    @classmethod
+    def constant(cls, site_dims: List[int], value: float) -> "TensorTrainF64":
+        """
+        Create a tensor train representing a constant function.
+
+        Parameters
+        ----------
+        site_dims : List[int]
+            List of site dimensions.
+        value : float
+            The constant value.
+
+        Returns
+        -------
+        TensorTrainF64
+            A new tensor train with all elements equal to `value`.
+        """
+        lib = _get_lib()
+        dims = (ctypes.c_size_t * len(site_dims))(*site_dims)
+        ptr = lib.t4a_tt_f64_new_constant(dims, len(site_dims), value)
+        if ptr is None:
+            raise RuntimeError("Failed to create TensorTrainF64")
+        return cls(ptr)
+
+    def __len__(self) -> int:
+        """Get the number of sites in the tensor train."""
+        lib = _get_lib()
+        out_len = ctypes.c_size_t()
+        status = lib.t4a_tt_f64_len(self._ptr, ctypes.byref(out_len))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get length: status = {status}")
+        return out_len.value
+
+    @property
+    def site_dims(self) -> List[int]:
+        """Get the site (physical) dimensions."""
+        lib = _get_lib()
+        n = len(self)
+        out_dims = (ctypes.c_size_t * n)()
+        status = lib.t4a_tt_f64_site_dims(self._ptr, out_dims, n)
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get site_dims: status = {status}")
+        return list(out_dims)
+
+    @property
+    def link_dims(self) -> List[int]:
+        """Get the link (bond) dimensions."""
+        lib = _get_lib()
+        n = len(self)
+        if n <= 1:
+            return []
+        out_dims = (ctypes.c_size_t * (n - 1))()
+        status = lib.t4a_tt_f64_link_dims(self._ptr, out_dims, n - 1)
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get link_dims: status = {status}")
+        return list(out_dims)
+
+    @property
+    def rank(self) -> int:
+        """Get the maximum bond dimension (rank)."""
+        lib = _get_lib()
+        out_rank = ctypes.c_size_t()
+        status = lib.t4a_tt_f64_rank(self._ptr, ctypes.byref(out_rank))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get rank: status = {status}")
+        return out_rank.value
+
+    def evaluate(self, indices: List[int]) -> float:
+        """
+        Evaluate the tensor train at a given index set.
+
+        Parameters
+        ----------
+        indices : List[int]
+            List of indices (0-based).
+
+        Returns
+        -------
+        float
+            The value at the given indices.
+        """
+        lib = _get_lib()
+        idx = (ctypes.c_size_t * len(indices))(*indices)
+        out_value = ctypes.c_double()
+        status = lib.t4a_tt_f64_evaluate(
+            self._ptr, idx, len(indices), ctypes.byref(out_value)
+        )
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to evaluate: status = {status}")
+        return out_value.value
+
+    def sum(self) -> float:
+        """Compute the sum of all elements."""
+        lib = _get_lib()
+        out_sum = ctypes.c_double()
+        status = lib.t4a_tt_f64_sum(self._ptr, ctypes.byref(out_sum))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to compute sum: status = {status}")
+        return out_sum.value
+
+    def norm(self) -> float:
+        """Compute the Frobenius norm."""
+        lib = _get_lib()
+        out_norm = ctypes.c_double()
+        status = lib.t4a_tt_f64_norm(self._ptr, ctypes.byref(out_norm))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to compute norm: status = {status}")
+        return out_norm.value
+
+    def log_norm(self) -> float:
+        """
+        Compute the logarithm of the Frobenius norm.
+
+        This is more numerically stable than `log(norm())` for very large or small norms.
+        """
+        lib = _get_lib()
+        out_log_norm = ctypes.c_double()
+        status = lib.t4a_tt_f64_log_norm(self._ptr, ctypes.byref(out_log_norm))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to compute log_norm: status = {status}")
+        return out_log_norm.value
+
+    def scale(self, factor: float) -> None:
+        """Scale the tensor train in place."""
+        lib = _get_lib()
+        status = lib.t4a_tt_f64_scale_inplace(self._ptr, factor)
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to scale: status = {status}")
+
+    def scaled(self, factor: float) -> "TensorTrainF64":
+        """
+        Create a new tensor train scaled by a factor.
+
+        The original tensor train is unchanged.
+        """
+        lib = _get_lib()
+        ptr = lib.t4a_tt_f64_scaled(self._ptr, factor)
+        if ptr is None:
+            raise RuntimeError("Failed to create scaled TensorTrainF64")
+        return TensorTrainF64(ptr)
+
+    def to_numpy(self):
+        """
+        Convert the tensor train to a NumPy array.
+
+        Returns the full tensor as a dense array.
+        Warning: This can be very large for high-dimensional tensors!
+
+        Returns
+        -------
+        np.ndarray
+            The full tensor as a dense array.
+
+        Raises
+        ------
+        ImportError
+            If NumPy is not installed.
+        """
+        if not HAS_NUMPY:
+            raise ImportError("NumPy is required for to_numpy()")
+
+        lib = _get_lib()
+
+        # Query length
+        out_len = ctypes.c_size_t()
+        status = lib.t4a_tt_f64_fulltensor(self._ptr, None, 0, ctypes.byref(out_len))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to query fulltensor length: status = {status}")
+
+        # Get data (row-major from Rust)
+        data = (ctypes.c_double * out_len.value)()
+        status = lib.t4a_tt_f64_fulltensor(
+            self._ptr, data, out_len.value, ctypes.byref(out_len)
+        )
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get fulltensor: status = {status}")
+
+        # Convert to numpy array and reshape
+        arr = np.array(data, dtype=np.float64)
+        dims = self.site_dims
+        return arr.reshape(dims)
+
+    def copy(self) -> "TensorTrainF64":
+        """Create a copy (clone) of the tensor train."""
+        lib = _get_lib()
+        ptr = lib.t4a_tt_f64_clone(self._ptr)
+        if ptr is None:
+            raise RuntimeError("Failed to clone TensorTrainF64")
+        return TensorTrainF64(ptr)
+
+    def __copy__(self) -> "TensorTrainF64":
+        return self.copy()
+
+    def __deepcopy__(self, memo) -> "TensorTrainF64":
+        return self.copy()
+
+
+class TensorTrainC64:
+    """
+    A tensor train (Matrix Product State) with complex128 elements.
+
+    Wraps the Rust `TensorTrain<Complex64>` type via the C API.
+    """
+
+    def __init__(self, ptr: ctypes.c_void_p):
+        """Initialize from a raw pointer (internal use)."""
+        self._ptr = ptr
+
+    def __del__(self):
+        """Release the tensor train."""
+        if hasattr(self, "_ptr") and self._ptr is not None:
+            lib = _get_lib()
+            lib.t4a_tt_c64_release(self._ptr)
+            self._ptr = None
+
+    @classmethod
+    def zeros(cls, site_dims: List[int]) -> "TensorTrainC64":
+        """Create a tensor train representing the zero function."""
+        lib = _get_lib()
+        dims = (ctypes.c_size_t * len(site_dims))(*site_dims)
+        ptr = lib.t4a_tt_c64_new_zeros(dims, len(site_dims))
+        if ptr is None:
+            raise RuntimeError("Failed to create TensorTrainC64")
+        return cls(ptr)
+
+    @classmethod
+    def constant(cls, site_dims: List[int], value: complex) -> "TensorTrainC64":
+        """Create a tensor train representing a constant function."""
+        lib = _get_lib()
+        dims = (ctypes.c_size_t * len(site_dims))(*site_dims)
+        ptr = lib.t4a_tt_c64_new_constant(dims, len(site_dims), value.real, value.imag)
+        if ptr is None:
+            raise RuntimeError("Failed to create TensorTrainC64")
+        return cls(ptr)
+
+    def __len__(self) -> int:
+        """Get the number of sites in the tensor train."""
+        lib = _get_lib()
+        out_len = ctypes.c_size_t()
+        status = lib.t4a_tt_c64_len(self._ptr, ctypes.byref(out_len))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get length: status = {status}")
+        return out_len.value
+
+    @property
+    def site_dims(self) -> List[int]:
+        """Get the site (physical) dimensions."""
+        lib = _get_lib()
+        n = len(self)
+        out_dims = (ctypes.c_size_t * n)()
+        status = lib.t4a_tt_c64_site_dims(self._ptr, out_dims, n)
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get site_dims: status = {status}")
+        return list(out_dims)
+
+    @property
+    def link_dims(self) -> List[int]:
+        """Get the link (bond) dimensions."""
+        lib = _get_lib()
+        n = len(self)
+        if n <= 1:
+            return []
+        out_dims = (ctypes.c_size_t * (n - 1))()
+        status = lib.t4a_tt_c64_link_dims(self._ptr, out_dims, n - 1)
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get link_dims: status = {status}")
+        return list(out_dims)
+
+    @property
+    def rank(self) -> int:
+        """Get the maximum bond dimension (rank)."""
+        lib = _get_lib()
+        out_rank = ctypes.c_size_t()
+        status = lib.t4a_tt_c64_rank(self._ptr, ctypes.byref(out_rank))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get rank: status = {status}")
+        return out_rank.value
+
+    def evaluate(self, indices: List[int]) -> complex:
+        """Evaluate the tensor train at a given index set (0-based indices)."""
+        lib = _get_lib()
+        idx = (ctypes.c_size_t * len(indices))(*indices)
+        out_re = ctypes.c_double()
+        out_im = ctypes.c_double()
+        status = lib.t4a_tt_c64_evaluate(
+            self._ptr, idx, len(indices), ctypes.byref(out_re), ctypes.byref(out_im)
+        )
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to evaluate: status = {status}")
+        return complex(out_re.value, out_im.value)
+
+    def sum(self) -> complex:
+        """Compute the sum of all elements."""
+        lib = _get_lib()
+        out_re = ctypes.c_double()
+        out_im = ctypes.c_double()
+        status = lib.t4a_tt_c64_sum(
+            self._ptr, ctypes.byref(out_re), ctypes.byref(out_im)
+        )
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to compute sum: status = {status}")
+        return complex(out_re.value, out_im.value)
+
+    def norm(self) -> float:
+        """Compute the Frobenius norm."""
+        lib = _get_lib()
+        out_norm = ctypes.c_double()
+        status = lib.t4a_tt_c64_norm(self._ptr, ctypes.byref(out_norm))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to compute norm: status = {status}")
+        return out_norm.value
+
+    def log_norm(self) -> float:
+        """Compute the logarithm of the Frobenius norm."""
+        lib = _get_lib()
+        out_log_norm = ctypes.c_double()
+        status = lib.t4a_tt_c64_log_norm(self._ptr, ctypes.byref(out_log_norm))
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to compute log_norm: status = {status}")
+        return out_log_norm.value
+
+    def scale(self, factor: complex) -> None:
+        """Scale the tensor train in place."""
+        lib = _get_lib()
+        status = lib.t4a_tt_c64_scale_inplace(self._ptr, factor.real, factor.imag)
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to scale: status = {status}")
+
+    def scaled(self, factor: complex) -> "TensorTrainC64":
+        """Create a new tensor train scaled by a factor."""
+        lib = _get_lib()
+        ptr = lib.t4a_tt_c64_scaled(self._ptr, factor.real, factor.imag)
+        if ptr is None:
+            raise RuntimeError("Failed to create scaled TensorTrainC64")
+        return TensorTrainC64(ptr)
+
+    def to_numpy(self):
+        """Convert the tensor train to a NumPy array.
+
+        Raises
+        ------
+        ImportError
+            If NumPy is not installed.
+        """
+        if not HAS_NUMPY:
+            raise ImportError("NumPy is required for to_numpy()")
+
+        lib = _get_lib()
+
+        # Query length
+        out_len = ctypes.c_size_t()
+        status = lib.t4a_tt_c64_fulltensor(
+            self._ptr, None, None, 0, ctypes.byref(out_len)
+        )
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to query fulltensor length: status = {status}")
+
+        # Get data
+        data_re = (ctypes.c_double * out_len.value)()
+        data_im = (ctypes.c_double * out_len.value)()
+        status = lib.t4a_tt_c64_fulltensor(
+            self._ptr, data_re, data_im, out_len.value, ctypes.byref(out_len)
+        )
+        if status != T4A_SUCCESS:
+            raise RuntimeError(f"Failed to get fulltensor: status = {status}")
+
+        # Convert to numpy
+        arr_re = np.array(data_re, dtype=np.float64)
+        arr_im = np.array(data_im, dtype=np.float64)
+        arr = arr_re + 1j * arr_im
+        dims = self.site_dims
+        return arr.reshape(dims)
+
+    def copy(self) -> "TensorTrainC64":
+        """Create a copy (clone) of the tensor train."""
+        lib = _get_lib()
+        ptr = lib.t4a_tt_c64_clone(self._ptr)
+        if ptr is None:
+            raise RuntimeError("Failed to clone TensorTrainC64")
+        return TensorTrainC64(ptr)
+
+    def __copy__(self) -> "TensorTrainC64":
+        return self.copy()
+
+    def __deepcopy__(self, memo) -> "TensorTrainC64":
+        return self.copy()
+
+
+__all__ = [
+    "init_library",
+    "TensorTrainF64",
+    "TensorTrainC64",
+    "T4A_SUCCESS",
+    "T4A_NULL_POINTER",
+    "T4A_INVALID_ARGUMENT",
+    "T4A_BUFFER_TOO_SMALL",
+    "T4A_INTERNAL_ERROR",
+]

--- a/bindings/python/test_tensor4all_rs.py
+++ b/bindings/python/test_tensor4all_rs.py
@@ -1,0 +1,149 @@
+"""
+Tests for tensor4all_rs Python bindings.
+
+Run with: python -m pytest test_tensor4all_rs.py -v
+"""
+
+import os
+import platform
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# Add the bindings directory to the path
+sys.path.insert(0, str(Path(__file__).parent))
+
+import tensor4all_rs as t4a
+
+# Find library path
+if platform.system() == "Darwin":
+    LIBNAME = "libtensor4all_capi.dylib"
+elif platform.system() == "Linux":
+    LIBNAME = "libtensor4all_capi.so"
+elif platform.system() == "Windows":
+    LIBNAME = "tensor4all_capi.dll"
+else:
+    raise RuntimeError(f"Unsupported platform: {platform.system()}")
+
+LIBPATH = Path(__file__).parent.parent.parent / "target" / "release" / LIBNAME
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_lib():
+    """Initialize the library before running tests."""
+    if not LIBPATH.exists():
+        pytest.skip(
+            f"Library not found at {LIBPATH}. "
+            "Build with: cargo build --release -p tensor4all-capi"
+        )
+    t4a.init_library(str(LIBPATH))
+
+
+class TestTensorTrainF64:
+    """Tests for TensorTrainF64."""
+
+    def test_zeros(self):
+        """Test creating a zero tensor train."""
+        tt = t4a.TensorTrainF64.zeros([2, 3, 2])
+        assert len(tt) == 3
+        assert tt.site_dims == [2, 3, 2]
+        assert tt.rank == 1
+
+    def test_constant(self):
+        """Test creating a constant tensor train."""
+        tt = t4a.TensorTrainF64.constant([2, 2], 5.0)
+        assert len(tt) == 2
+        assert tt.site_dims == [2, 2]
+
+        # Sum should be 5.0 * 2 * 2 = 20.0
+        assert abs(tt.sum() - 20.0) < 1e-10
+
+        # Evaluate at [0, 1] (0-based)
+        assert abs(tt.evaluate([0, 1]) - 5.0) < 1e-10
+
+    def test_scale(self):
+        """Test scaling operations."""
+        tt = t4a.TensorTrainF64.constant([2, 2], 1.0)
+
+        # Immutable scale
+        tt2 = tt.scaled(3.0)
+        assert abs(tt2.sum() - 12.0) < 1e-10
+        assert abs(tt.sum() - 4.0) < 1e-10  # Original unchanged
+
+        # In-place scale
+        tt.scale(2.0)
+        assert abs(tt.sum() - 8.0) < 1e-10
+
+    def test_norm(self):
+        """Test norm computation."""
+        tt = t4a.TensorTrainF64.constant([2, 3], 2.0)
+
+        norm_val = tt.norm()
+        # norm = sqrt(sum of squares) = sqrt(6 * 4) = sqrt(24)
+        assert abs(norm_val - np.sqrt(24.0)) < 1e-10
+
+        log_norm_val = tt.log_norm()
+        assert abs(log_norm_val - np.log(norm_val)) < 1e-10
+
+    def test_to_numpy(self):
+        """Test conversion to NumPy array."""
+        tt = t4a.TensorTrainF64.constant([2, 3], 5.0)
+        arr = tt.to_numpy()
+
+        assert arr.shape == (2, 3)
+        assert np.allclose(arr, 5.0)
+
+    def test_copy(self):
+        """Test copying."""
+        tt = t4a.TensorTrainF64.constant([2, 2], 3.0)
+        tt2 = tt.copy()
+
+        assert abs(tt2.sum() - tt.sum()) < 1e-10
+
+        # Modify original, copy should be unchanged
+        tt.scale(2.0)
+        assert abs(tt.sum() - 24.0) < 1e-10
+        assert abs(tt2.sum() - 12.0) < 1e-10
+
+
+class TestTensorTrainC64:
+    """Tests for TensorTrainC64."""
+
+    def test_zeros(self):
+        """Test creating a zero complex tensor train."""
+        tt = t4a.TensorTrainC64.zeros([2, 3, 2])
+        assert len(tt) == 3
+        assert tt.site_dims == [2, 3, 2]
+
+    def test_constant(self):
+        """Test creating a constant complex tensor train."""
+        tt = t4a.TensorTrainC64.constant([2, 2], 3.0 + 4.0j)
+        assert len(tt) == 2
+
+        val = tt.evaluate([0, 1])
+        assert abs(val.real - 3.0) < 1e-10
+        assert abs(val.imag - 4.0) < 1e-10
+
+    def test_scale(self):
+        """Test scaling by complex number."""
+        tt = t4a.TensorTrainC64.constant([2, 2], 1.0 + 0.0j)
+
+        # Scale by imaginary unit
+        tt2 = tt.scaled(1.0j)
+        s = tt2.sum()
+        assert abs(s.real) < 1e-10
+        assert abs(s.imag - 4.0) < 1e-10
+
+    def test_to_numpy(self):
+        """Test conversion to NumPy array."""
+        tt = t4a.TensorTrainC64.constant([2, 3], 1.0 + 2.0j)
+        arr = tt.to_numpy()
+
+        assert arr.shape == (2, 3)
+        assert np.allclose(arr, 1.0 + 2.0j)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/crates/tensor4all-capi/Cargo.toml
+++ b/crates/tensor4all-capi/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 tensor4all-core-common = { path = "../tensor4all/core-common" }
 tensor4all-core-tensor = { path = "../tensor4all/core-tensor" }
+tensor4all-tensortrain = { path = "../tensor4all-tensortrain" }
 libc = "0.2"
 thiserror.workspace = true
 paste = "1.0"

--- a/crates/tensor4all-capi/src/lib.rs
+++ b/crates/tensor4all-capi/src/lib.rs
@@ -30,10 +30,12 @@ mod macros;
 
 mod index;
 mod tensor;
+mod tensortrain;
 mod types;
 
 pub use index::*;
 pub use tensor::*;
+pub use tensortrain::*;
 pub use types::*;
 
 /// Status code type for C API

--- a/crates/tensor4all-capi/src/tensortrain.rs
+++ b/crates/tensor4all-capi/src/tensortrain.rs
@@ -1,0 +1,1019 @@
+//! C API for TensorTrain
+//!
+//! Provides functions for creating, manipulating, and accessing tensor trains.
+//!
+//! ## Naming convention
+//! - `t4a_tt_f64_*` - Functions for TensorTrain<f64>
+//! - `t4a_tt_c64_*` - Functions for TensorTrain<Complex64>
+
+use std::panic::catch_unwind;
+use std::ptr;
+
+use num_complex::Complex64;
+use tensor4all_tensortrain::{AbstractTensorTrain, TensorTrain};
+
+use crate::types::{t4a_tt_c64, t4a_tt_f64};
+use crate::{
+    StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER,
+    T4A_SUCCESS,
+};
+
+// Generate lifecycle functions for t4a_tt_f64
+impl_opaque_type_common!(tt_f64);
+
+// Generate lifecycle functions for t4a_tt_c64
+impl_opaque_type_common!(tt_c64);
+
+// ============================================================================
+// Constructors - f64
+// ============================================================================
+
+/// Create a new tensor train representing the zero function (f64)
+///
+/// # Arguments
+/// - `site_dims`: Array of site dimensions
+/// - `num_sites`: Number of sites (length of site_dims array)
+///
+/// # Returns
+/// - Pointer to new t4a_tt_f64 on success
+/// - NULL on error
+///
+/// # Safety
+/// - `site_dims` must be a valid pointer to an array of length `num_sites`
+/// - Caller owns the returned tensor train and must call t4a_tt_f64_release
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_new_zeros(
+    site_dims: *const libc::size_t,
+    num_sites: libc::size_t,
+) -> *mut t4a_tt_f64 {
+    if site_dims.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let dims: Vec<usize> = unsafe { std::slice::from_raw_parts(site_dims, num_sites).to_vec() };
+        let tt = TensorTrain::<f64>::zeros(&dims);
+        Box::into_raw(Box::new(t4a_tt_f64::new(tt)))
+    }));
+
+    result.unwrap_or(ptr::null_mut())
+}
+
+/// Create a new tensor train representing a constant function (f64)
+///
+/// # Arguments
+/// - `site_dims`: Array of site dimensions
+/// - `num_sites`: Number of sites (length of site_dims array)
+/// - `value`: The constant value
+///
+/// # Returns
+/// - Pointer to new t4a_tt_f64 on success
+/// - NULL on error
+///
+/// # Safety
+/// - `site_dims` must be a valid pointer to an array of length `num_sites`
+/// - Caller owns the returned tensor train and must call t4a_tt_f64_release
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_new_constant(
+    site_dims: *const libc::size_t,
+    num_sites: libc::size_t,
+    value: libc::c_double,
+) -> *mut t4a_tt_f64 {
+    if site_dims.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let dims: Vec<usize> = unsafe { std::slice::from_raw_parts(site_dims, num_sites).to_vec() };
+        let tt = TensorTrain::<f64>::constant(&dims, value);
+        Box::into_raw(Box::new(t4a_tt_f64::new(tt)))
+    }));
+
+    result.unwrap_or(ptr::null_mut())
+}
+
+// ============================================================================
+// Constructors - Complex64
+// ============================================================================
+
+/// Create a new tensor train representing the zero function (Complex64)
+///
+/// # Arguments
+/// - `site_dims`: Array of site dimensions
+/// - `num_sites`: Number of sites (length of site_dims array)
+///
+/// # Returns
+/// - Pointer to new t4a_tt_c64 on success
+/// - NULL on error
+///
+/// # Safety
+/// - `site_dims` must be a valid pointer to an array of length `num_sites`
+/// - Caller owns the returned tensor train and must call t4a_tt_c64_release
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_new_zeros(
+    site_dims: *const libc::size_t,
+    num_sites: libc::size_t,
+) -> *mut t4a_tt_c64 {
+    if site_dims.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let dims: Vec<usize> = unsafe { std::slice::from_raw_parts(site_dims, num_sites).to_vec() };
+        let tt = TensorTrain::<Complex64>::zeros(&dims);
+        Box::into_raw(Box::new(t4a_tt_c64::new(tt)))
+    }));
+
+    result.unwrap_or(ptr::null_mut())
+}
+
+/// Create a new tensor train representing a constant function (Complex64)
+///
+/// # Arguments
+/// - `site_dims`: Array of site dimensions
+/// - `num_sites`: Number of sites (length of site_dims array)
+/// - `value_re`: Real part of the constant value
+/// - `value_im`: Imaginary part of the constant value
+///
+/// # Returns
+/// - Pointer to new t4a_tt_c64 on success
+/// - NULL on error
+///
+/// # Safety
+/// - `site_dims` must be a valid pointer to an array of length `num_sites`
+/// - Caller owns the returned tensor train and must call t4a_tt_c64_release
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_new_constant(
+    site_dims: *const libc::size_t,
+    num_sites: libc::size_t,
+    value_re: libc::c_double,
+    value_im: libc::c_double,
+) -> *mut t4a_tt_c64 {
+    if site_dims.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let dims: Vec<usize> = unsafe { std::slice::from_raw_parts(site_dims, num_sites).to_vec() };
+        let value = Complex64::new(value_re, value_im);
+        let tt = TensorTrain::<Complex64>::constant(&dims, value);
+        Box::into_raw(Box::new(t4a_tt_c64::new(tt)))
+    }));
+
+    result.unwrap_or(ptr::null_mut())
+}
+
+// ============================================================================
+// Accessors - f64
+// ============================================================================
+
+/// Get the number of sites in a tensor train (f64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_len` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_len(
+    ptr: *const t4a_tt_f64,
+    out_len: *mut libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_len.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_len = tt.inner().len() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Get the site dimensions of a tensor train (f64)
+///
+/// # Arguments
+/// - `ptr`: Tensor train handle
+/// - `out_dims`: Buffer to write dimensions (must have length >= num_sites)
+/// - `buf_len`: Length of the buffer
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_dims` must be a valid pointer to a buffer of at least `num_sites` elements
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_site_dims(
+    ptr: *const t4a_tt_f64,
+    out_dims: *mut libc::size_t,
+    buf_len: libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_dims.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let dims = tt.inner().site_dims();
+
+        if buf_len < dims.len() {
+            return T4A_BUFFER_TOO_SMALL;
+        }
+
+        unsafe {
+            for (i, &dim) in dims.iter().enumerate() {
+                *out_dims.add(i) = dim;
+            }
+        }
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Get the link dimensions (bond dimensions) of a tensor train (f64)
+///
+/// # Arguments
+/// - `ptr`: Tensor train handle
+/// - `out_dims`: Buffer to write dimensions (must have length >= num_sites - 1)
+/// - `buf_len`: Length of the buffer
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_dims` must be a valid pointer to a buffer of at least `num_sites - 1` elements
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_link_dims(
+    ptr: *const t4a_tt_f64,
+    out_dims: *mut libc::size_t,
+    buf_len: libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_dims.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let dims = tt.inner().link_dims();
+
+        if buf_len < dims.len() {
+            return T4A_BUFFER_TOO_SMALL;
+        }
+
+        unsafe {
+            for (i, &dim) in dims.iter().enumerate() {
+                *out_dims.add(i) = dim;
+            }
+        }
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Get the maximum bond dimension (rank) of a tensor train (f64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_rank` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_rank(
+    ptr: *const t4a_tt_f64,
+    out_rank: *mut libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_rank.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_rank = tt.inner().rank() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Evaluate a tensor train at a given index set (f64)
+///
+/// # Arguments
+/// - `ptr`: Tensor train handle
+/// - `indices`: Array of indices (length = num_sites)
+/// - `num_indices`: Number of indices (must equal num_sites)
+/// - `out_value`: Output: evaluated value
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `indices` must be a valid pointer to an array of length `num_indices`
+/// - `out_value` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_evaluate(
+    ptr: *const t4a_tt_f64,
+    indices: *const libc::size_t,
+    num_indices: libc::size_t,
+    out_value: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || indices.is_null() || out_value.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let idx: Vec<usize> = unsafe { std::slice::from_raw_parts(indices, num_indices).to_vec() };
+
+        match tt.inner().evaluate(&idx) {
+            Ok(value) => {
+                unsafe { *out_value = value };
+                T4A_SUCCESS
+            }
+            Err(_) => T4A_INVALID_ARGUMENT,
+        }
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Compute the sum of all elements in a tensor train (f64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_sum` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_sum(
+    ptr: *const t4a_tt_f64,
+    out_sum: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || out_sum.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_sum = tt.inner().sum() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Compute the Frobenius norm of a tensor train (f64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_norm` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_norm(
+    ptr: *const t4a_tt_f64,
+    out_norm: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || out_norm.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_norm = tt.inner().norm() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Compute the logarithm of the Frobenius norm of a tensor train (f64)
+///
+/// This is more numerically stable than computing norm and then taking log.
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_log_norm` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_log_norm(
+    ptr: *const t4a_tt_f64,
+    out_log_norm: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || out_log_norm.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_log_norm = tt.inner().log_norm() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+// ============================================================================
+// Modifiers - f64
+// ============================================================================
+
+/// Scale a tensor train by a factor, returning a new object (f64)
+///
+/// The original tensor train is unchanged.
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - Caller owns the returned tensor train and must call t4a_tt_f64_release
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_scaled(
+    ptr: *const t4a_tt_f64,
+    factor: libc::c_double,
+) -> *mut t4a_tt_f64 {
+    if ptr.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let scaled = tt.inner().scaled(factor);
+        Box::into_raw(Box::new(t4a_tt_f64::new(scaled)))
+    }));
+
+    result.unwrap_or(ptr::null_mut())
+}
+
+/// Scale a tensor train by a factor in place (f64)
+///
+/// Modifies the tensor train in place.
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_scale_inplace(
+    ptr: *mut t4a_tt_f64,
+    factor: libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &mut *ptr };
+        tt.inner_mut().scale(factor);
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Convert a tensor train to a full tensor (f64)
+///
+/// Returns the full tensor data in row-major order along with the shape.
+/// Warning: This can be very large for high-dimensional tensors!
+///
+/// # Arguments
+/// - `ptr`: Tensor train handle
+/// - `out_data`: Buffer to write data (if NULL, only out_len is written)
+/// - `data_buf_len`: Length of the data buffer
+/// - `out_len`: Output: required data buffer length
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_f64
+/// - `out_data` can be NULL (to query required length)
+/// - `out_len` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_f64_fulltensor(
+    ptr: *const t4a_tt_f64,
+    out_data: *mut libc::c_double,
+    data_buf_len: libc::size_t,
+    out_len: *mut libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_len.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let (data, _shape) = tt.inner().fulltensor();
+
+        unsafe { *out_len = data.len() };
+
+        if out_data.is_null() {
+            return T4A_SUCCESS;
+        }
+
+        if data_buf_len < data.len() {
+            return T4A_BUFFER_TOO_SMALL;
+        }
+
+        unsafe {
+            ptr::copy_nonoverlapping(data.as_ptr(), out_data, data.len());
+        }
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+// ============================================================================
+// Accessors - Complex64
+// ============================================================================
+
+/// Get the number of sites in a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_len` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_len(
+    ptr: *const t4a_tt_c64,
+    out_len: *mut libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_len.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_len = tt.inner().len() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Get the site dimensions of a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_dims` must be a valid pointer to a buffer of at least `num_sites` elements
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_site_dims(
+    ptr: *const t4a_tt_c64,
+    out_dims: *mut libc::size_t,
+    buf_len: libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_dims.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let dims = tt.inner().site_dims();
+
+        if buf_len < dims.len() {
+            return T4A_BUFFER_TOO_SMALL;
+        }
+
+        unsafe {
+            for (i, &dim) in dims.iter().enumerate() {
+                *out_dims.add(i) = dim;
+            }
+        }
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Get the link dimensions (bond dimensions) of a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_dims` must be a valid pointer to a buffer of at least `num_sites - 1` elements
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_link_dims(
+    ptr: *const t4a_tt_c64,
+    out_dims: *mut libc::size_t,
+    buf_len: libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_dims.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let dims = tt.inner().link_dims();
+
+        if buf_len < dims.len() {
+            return T4A_BUFFER_TOO_SMALL;
+        }
+
+        unsafe {
+            for (i, &dim) in dims.iter().enumerate() {
+                *out_dims.add(i) = dim;
+            }
+        }
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Get the maximum bond dimension (rank) of a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_rank` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_rank(
+    ptr: *const t4a_tt_c64,
+    out_rank: *mut libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_rank.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_rank = tt.inner().rank() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Evaluate a tensor train at a given index set (Complex64)
+///
+/// # Arguments
+/// - `ptr`: Tensor train handle
+/// - `indices`: Array of indices (length = num_sites)
+/// - `num_indices`: Number of indices (must equal num_sites)
+/// - `out_re`: Output: real part of evaluated value
+/// - `out_im`: Output: imaginary part of evaluated value
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `indices` must be a valid pointer to an array of length `num_indices`
+/// - `out_re` and `out_im` must be valid pointers
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_evaluate(
+    ptr: *const t4a_tt_c64,
+    indices: *const libc::size_t,
+    num_indices: libc::size_t,
+    out_re: *mut libc::c_double,
+    out_im: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || indices.is_null() || out_re.is_null() || out_im.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let idx: Vec<usize> = unsafe { std::slice::from_raw_parts(indices, num_indices).to_vec() };
+
+        match tt.inner().evaluate(&idx) {
+            Ok(value) => {
+                unsafe {
+                    *out_re = value.re;
+                    *out_im = value.im;
+                };
+                T4A_SUCCESS
+            }
+            Err(_) => T4A_INVALID_ARGUMENT,
+        }
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Compute the sum of all elements in a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_re` and `out_im` must be valid pointers
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_sum(
+    ptr: *const t4a_tt_c64,
+    out_re: *mut libc::c_double,
+    out_im: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || out_re.is_null() || out_im.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let sum = tt.inner().sum();
+        unsafe {
+            *out_re = sum.re;
+            *out_im = sum.im;
+        };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Compute the Frobenius norm of a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_norm` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_norm(
+    ptr: *const t4a_tt_c64,
+    out_norm: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || out_norm.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_norm = tt.inner().norm() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Compute the logarithm of the Frobenius norm of a tensor train (Complex64)
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_log_norm` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_log_norm(
+    ptr: *const t4a_tt_c64,
+    out_log_norm: *mut libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() || out_log_norm.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        unsafe { *out_log_norm = tt.inner().log_norm() };
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+// ============================================================================
+// Modifiers - Complex64
+// ============================================================================
+
+/// Scale a tensor train by a factor, returning a new object (Complex64)
+///
+/// The original tensor train is unchanged.
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - Caller owns the returned tensor train and must call t4a_tt_c64_release
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_scaled(
+    ptr: *const t4a_tt_c64,
+    factor_re: libc::c_double,
+    factor_im: libc::c_double,
+) -> *mut t4a_tt_c64 {
+    if ptr.is_null() {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let factor = Complex64::new(factor_re, factor_im);
+        let scaled = tt.inner().scaled(factor);
+        Box::into_raw(Box::new(t4a_tt_c64::new(scaled)))
+    }));
+
+    result.unwrap_or(ptr::null_mut())
+}
+
+/// Scale a tensor train by a factor in place (Complex64)
+///
+/// Modifies the tensor train in place.
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_scale_inplace(
+    ptr: *mut t4a_tt_c64,
+    factor_re: libc::c_double,
+    factor_im: libc::c_double,
+) -> StatusCode {
+    if ptr.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &mut *ptr };
+        let factor = Complex64::new(factor_re, factor_im);
+        tt.inner_mut().scale(factor);
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+/// Convert a tensor train to a full tensor (Complex64)
+///
+/// Returns the full tensor data in row-major order.
+/// Warning: This can be very large for high-dimensional tensors!
+///
+/// # Arguments
+/// - `ptr`: Tensor train handle
+/// - `out_re`: Buffer to write real parts (if NULL, only out_len is written)
+/// - `out_im`: Buffer to write imaginary parts (if NULL, only out_len is written)
+/// - `data_buf_len`: Length of the data buffers
+/// - `out_len`: Output: required data buffer length
+///
+/// # Safety
+/// - `ptr` must be a valid pointer to a t4a_tt_c64
+/// - `out_re` and `out_im` can be NULL (to query required length)
+/// - `out_len` must be a valid pointer
+#[no_mangle]
+pub extern "C" fn t4a_tt_c64_fulltensor(
+    ptr: *const t4a_tt_c64,
+    out_re: *mut libc::c_double,
+    out_im: *mut libc::c_double,
+    data_buf_len: libc::size_t,
+    out_len: *mut libc::size_t,
+) -> StatusCode {
+    if ptr.is_null() || out_len.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    let result = catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let tt = unsafe { &*ptr };
+        let (data, _shape) = tt.inner().fulltensor();
+
+        unsafe { *out_len = data.len() };
+
+        if out_re.is_null() || out_im.is_null() {
+            return T4A_SUCCESS;
+        }
+
+        if data_buf_len < data.len() {
+            return T4A_BUFFER_TOO_SMALL;
+        }
+
+        unsafe {
+            for (i, z) in data.iter().enumerate() {
+                *out_re.add(i) = z.re;
+                *out_im.add(i) = z.im;
+            }
+        }
+        T4A_SUCCESS
+    }));
+
+    result.unwrap_or(T4A_INTERNAL_ERROR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tt_f64_lifecycle() {
+        let dims = [2_usize, 3, 2];
+        let tt = t4a_tt_f64_new_zeros(dims.as_ptr(), 3);
+        assert!(!tt.is_null());
+
+        // Test is_assigned
+        assert_eq!(t4a_tt_f64_is_assigned(tt as *const _), 1);
+
+        // Test clone
+        let cloned = t4a_tt_f64_clone(tt as *const _);
+        assert!(!cloned.is_null());
+
+        // Clean up
+        t4a_tt_f64_release(cloned);
+        t4a_tt_f64_release(tt);
+    }
+
+    #[test]
+    fn test_tt_f64_constant() {
+        let dims = [2_usize, 2];
+        let tt = t4a_tt_f64_new_constant(dims.as_ptr(), 2, 5.0);
+        assert!(!tt.is_null());
+
+        // Get len
+        let mut len: usize = 0;
+        assert_eq!(t4a_tt_f64_len(tt as *const _, &mut len), T4A_SUCCESS);
+        assert_eq!(len, 2);
+
+        // Get site_dims
+        let mut out_dims = [0_usize; 2];
+        assert_eq!(
+            t4a_tt_f64_site_dims(tt as *const _, out_dims.as_mut_ptr(), 2),
+            T4A_SUCCESS
+        );
+        assert_eq!(out_dims, [2, 2]);
+
+        // Get sum (should be 5.0 * 2 * 2 = 20.0)
+        let mut sum: f64 = 0.0;
+        assert_eq!(t4a_tt_f64_sum(tt as *const _, &mut sum), T4A_SUCCESS);
+        assert!((sum - 20.0).abs() < 1e-10);
+
+        // Evaluate
+        let indices = [0_usize, 1];
+        let mut value: f64 = 0.0;
+        assert_eq!(
+            t4a_tt_f64_evaluate(tt as *const _, indices.as_ptr(), 2, &mut value),
+            T4A_SUCCESS
+        );
+        assert!((value - 5.0).abs() < 1e-10);
+
+        t4a_tt_f64_release(tt);
+    }
+
+    #[test]
+    fn test_tt_f64_scale() {
+        let dims = [2_usize, 2];
+        let tt = t4a_tt_f64_new_constant(dims.as_ptr(), 2, 1.0);
+
+        // Scale immutable
+        let scaled = t4a_tt_f64_scaled(tt as *const _, 3.0);
+        assert!(!scaled.is_null());
+
+        let mut sum: f64 = 0.0;
+        t4a_tt_f64_sum(scaled as *const _, &mut sum);
+        assert!((sum - 12.0).abs() < 1e-10);
+
+        // Original unchanged
+        t4a_tt_f64_sum(tt as *const _, &mut sum);
+        assert!((sum - 4.0).abs() < 1e-10);
+
+        // Scale in place
+        t4a_tt_f64_scale_inplace(tt, 2.0);
+        t4a_tt_f64_sum(tt as *const _, &mut sum);
+        assert!((sum - 8.0).abs() < 1e-10);
+
+        t4a_tt_f64_release(scaled);
+        t4a_tt_f64_release(tt);
+    }
+
+    #[test]
+    fn test_tt_f64_fulltensor() {
+        let dims = [2_usize, 3];
+        let tt = t4a_tt_f64_new_constant(dims.as_ptr(), 2, 5.0);
+
+        // Query length
+        let mut len: usize = 0;
+        assert_eq!(
+            t4a_tt_f64_fulltensor(tt as *const _, ptr::null_mut(), 0, &mut len),
+            T4A_SUCCESS
+        );
+        assert_eq!(len, 6);
+
+        // Get data
+        let mut data = [0.0; 6];
+        assert_eq!(
+            t4a_tt_f64_fulltensor(tt as *const _, data.as_mut_ptr(), 6, &mut len),
+            T4A_SUCCESS
+        );
+
+        // All elements should be 5.0
+        for val in &data {
+            assert!((val - 5.0).abs() < 1e-10);
+        }
+
+        t4a_tt_f64_release(tt);
+    }
+
+    #[test]
+    fn test_tt_c64_lifecycle() {
+        let dims = [2_usize, 3, 2];
+        let tt = t4a_tt_c64_new_zeros(dims.as_ptr(), 3);
+        assert!(!tt.is_null());
+
+        assert_eq!(t4a_tt_c64_is_assigned(tt as *const _), 1);
+
+        let cloned = t4a_tt_c64_clone(tt as *const _);
+        assert!(!cloned.is_null());
+
+        t4a_tt_c64_release(cloned);
+        t4a_tt_c64_release(tt);
+    }
+
+    #[test]
+    fn test_tt_c64_constant() {
+        let dims = [2_usize, 2];
+        let tt = t4a_tt_c64_new_constant(dims.as_ptr(), 2, 3.0, 4.0);
+        assert!(!tt.is_null());
+
+        // Evaluate
+        let indices = [0_usize, 1];
+        let mut re: f64 = 0.0;
+        let mut im: f64 = 0.0;
+        assert_eq!(
+            t4a_tt_c64_evaluate(tt as *const _, indices.as_ptr(), 2, &mut re, &mut im),
+            T4A_SUCCESS
+        );
+        assert!((re - 3.0).abs() < 1e-10);
+        assert!((im - 4.0).abs() < 1e-10);
+
+        t4a_tt_c64_release(tt);
+    }
+
+    #[test]
+    fn test_tt_f64_norm() {
+        let dims = [2_usize, 3];
+        let tt = t4a_tt_f64_new_constant(dims.as_ptr(), 2, 2.0);
+
+        let mut norm: f64 = 0.0;
+        assert_eq!(t4a_tt_f64_norm(tt as *const _, &mut norm), T4A_SUCCESS);
+        // norm = sqrt(sum of squares) = sqrt(6 * 4) = sqrt(24)
+        assert!((norm - 24.0_f64.sqrt()).abs() < 1e-10);
+
+        let mut log_norm: f64 = 0.0;
+        assert_eq!(
+            t4a_tt_f64_log_norm(tt as *const _, &mut log_norm),
+            T4A_SUCCESS
+        );
+        assert!((log_norm - norm.ln()).abs() < 1e-10);
+
+        t4a_tt_f64_release(tt);
+    }
+}

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -141,3 +141,103 @@ impl Drop for t4a_tensor {
 // Safety: t4a_tensor is Send + Sync because InternalTensor is Send + Sync
 unsafe impl Send for t4a_tensor {}
 unsafe impl Sync for t4a_tensor {}
+
+// ============================================================================
+// TensorTrain types
+// ============================================================================
+
+/// Opaque tensor train type for C API (f64)
+///
+/// Wraps `TensorTrain<f64>` from tensor4all-tensortrain.
+#[repr(C)]
+pub struct t4a_tt_f64 {
+    pub(crate) _private: *const c_void,
+}
+
+impl t4a_tt_f64 {
+    /// Create a new t4a_tt_f64 from a TensorTrain<f64>
+    pub(crate) fn new(tt: tensor4all_tensortrain::TensorTrain<f64>) -> Self {
+        Self {
+            _private: Box::into_raw(Box::new(tt)) as *const c_void,
+        }
+    }
+
+    /// Get a reference to the inner TensorTrain<f64>
+    pub(crate) fn inner(&self) -> &tensor4all_tensortrain::TensorTrain<f64> {
+        unsafe { &*(self._private as *const tensor4all_tensortrain::TensorTrain<f64>) }
+    }
+
+    /// Get a mutable reference to the inner TensorTrain<f64>
+    pub(crate) fn inner_mut(&mut self) -> &mut tensor4all_tensortrain::TensorTrain<f64> {
+        unsafe { &mut *(self._private as *mut tensor4all_tensortrain::TensorTrain<f64>) }
+    }
+}
+
+impl Clone for t4a_tt_f64 {
+    fn clone(&self) -> Self {
+        let inner = self.inner().clone();
+        Self::new(inner)
+    }
+}
+
+impl Drop for t4a_tt_f64 {
+    fn drop(&mut self) {
+        unsafe {
+            if !self._private.is_null() {
+                let _ = Box::from_raw(self._private as *mut tensor4all_tensortrain::TensorTrain<f64>);
+            }
+        }
+    }
+}
+
+// Safety: t4a_tt_f64 is Send + Sync because TensorTrain<f64> is Send + Sync
+unsafe impl Send for t4a_tt_f64 {}
+unsafe impl Sync for t4a_tt_f64 {}
+
+/// Opaque tensor train type for C API (Complex64)
+///
+/// Wraps `TensorTrain<Complex64>` from tensor4all-tensortrain.
+#[repr(C)]
+pub struct t4a_tt_c64 {
+    pub(crate) _private: *const c_void,
+}
+
+impl t4a_tt_c64 {
+    /// Create a new t4a_tt_c64 from a TensorTrain<Complex64>
+    pub(crate) fn new(tt: tensor4all_tensortrain::TensorTrain<num_complex::Complex64>) -> Self {
+        Self {
+            _private: Box::into_raw(Box::new(tt)) as *const c_void,
+        }
+    }
+
+    /// Get a reference to the inner TensorTrain<Complex64>
+    pub(crate) fn inner(&self) -> &tensor4all_tensortrain::TensorTrain<num_complex::Complex64> {
+        unsafe { &*(self._private as *const tensor4all_tensortrain::TensorTrain<num_complex::Complex64>) }
+    }
+
+    /// Get a mutable reference to the inner TensorTrain<Complex64>
+    pub(crate) fn inner_mut(&mut self) -> &mut tensor4all_tensortrain::TensorTrain<num_complex::Complex64> {
+        unsafe { &mut *(self._private as *mut tensor4all_tensortrain::TensorTrain<num_complex::Complex64>) }
+    }
+}
+
+impl Clone for t4a_tt_c64 {
+    fn clone(&self) -> Self {
+        let inner = self.inner().clone();
+        Self::new(inner)
+    }
+}
+
+impl Drop for t4a_tt_c64 {
+    fn drop(&mut self) {
+        unsafe {
+            if !self._private.is_null() {
+                let _ = Box::from_raw(self._private as *mut tensor4all_tensortrain::TensorTrain<num_complex::Complex64>);
+            }
+        }
+    }
+}
+
+// Safety: t4a_tt_c64 is Send + Sync because TensorTrain<Complex64> is Send + Sync
+unsafe impl Send for t4a_tt_c64 {}
+unsafe impl Sync for t4a_tt_c64 {}


### PR DESCRIPTION
## Summary

- Add C-API for `TensorTrain<f64>` and `TensorTrain<Complex64>` types to `tensor4all-capi`
- Add Julia bindings (`bindings/julia/Tensor4allRs/`)
- Add Python bindings (`bindings/python/tensor4all_rs/`)

## C-API Functions

### Opaque Types
- `t4a_tt_f64` - TensorTrain<f64>
- `t4a_tt_c64` - TensorTrain<Complex64>

### Functions (for both f64 and c64)
- **Constructors**: `new_zeros`, `new_constant`
- **Accessors**: `len`, `site_dims`, `link_dims`, `rank`, `evaluate`, `sum`, `norm`, `log_norm`
- **Modifiers**: `scale_inplace`, `scaled`, `fulltensor`
- **Lifecycle**: `release`, `clone`, `is_assigned`

## Julia Bindings

```julia
using Tensor4allRs

Tensor4allRs.init_library("/path/to/libtensor4all_capi.dylib")

tt = constant_tt(Float64, [2, 2], 5.0)
println(sum_tt(tt))  # 20.0
println(evaluate(tt, [1, 2]))  # 5.0

arr = fulltensor(tt)  # Convert to Julia array
```

## Python Bindings

```python
import tensor4all_rs as t4a

t4a.init_library("/path/to/libtensor4all_capi.dylib")

tt = t4a.TensorTrainF64.constant([2, 2], 5.0)
print(tt.sum())  # 20.0
print(tt.evaluate([0, 1]))  # 5.0

arr = tt.to_numpy()  # Convert to NumPy array
```

## Test plan

- [x] Rust unit tests pass (`cargo test -p tensor4all-capi` - 17 tests)
- [x] Julia tests pass
- [x] Python tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)