### PR TITLE
feat(capi): Add arithmetic, contraction, and compression to TensorTrain C-API

### DIFF
--- a/bindings/julia/Tensor4allRs/src/Tensor4allRs.jl
+++ b/bindings/julia/Tensor4allRs/src/Tensor4allRs.jl
@@ -53,9 +53,13 @@ end
 # Include submodules
 include("tensortrain.jl")
 
+export init_library
 export TensorTrainF64, TensorTrainC64
 export zeros_tt, constant_tt
 export site_dims, link_dims, rank, evaluate, sum_tt, norm_tt, log_norm_tt
 export scale!, scaled, fulltensor
+export add_tt, sub_tt, negate_tt, reverse_tt
+export hadamard, dot
+export compress!, compressed
 
 end # module

--- a/bindings/python/test_tensor4all_rs.py
+++ b/bindings/python/test_tensor4all_rs.py
@@ -107,6 +107,60 @@ class TestTensorTrainF64:
         assert abs(tt.sum() - 24.0) < 1e-10
         assert abs(tt2.sum() - 12.0) < 1e-10
 
+    def test_add(self):
+        """Test adding two tensor trains."""
+        tt1 = t4a.TensorTrainF64.constant([2, 3], 1.0)
+        tt2 = t4a.TensorTrainF64.constant([2, 3], 2.0)
+        result = tt1 + tt2
+        assert abs(result.sum() - 18.0) < 1e-10
+
+    def test_sub(self):
+        """Test subtracting two tensor trains."""
+        tt1 = t4a.TensorTrainF64.constant([2, 3], 5.0)
+        tt2 = t4a.TensorTrainF64.constant([2, 3], 2.0)
+        result = tt1 - tt2
+        assert abs(result.sum() - 18.0) < 1e-10
+
+    def test_negate(self):
+        """Test negating a tensor train."""
+        tt = t4a.TensorTrainF64.constant([2, 2], 3.0)
+        neg = -tt
+        assert abs(neg.sum() + tt.sum()) < 1e-10
+
+    def test_reverse(self):
+        """Test reversing a tensor train."""
+        tt = t4a.TensorTrainF64.constant([2, 3], 5.0)
+        rev = tt.reverse()
+        assert rev.site_dims == [3, 2]
+        assert abs(rev.sum() - tt.sum()) < 1e-10
+
+    def test_hadamard(self):
+        """Test Hadamard product of two tensor trains."""
+        tt1 = t4a.TensorTrainF64.constant([2, 3], 2.0)
+        tt2 = t4a.TensorTrainF64.constant([2, 3], 3.0)
+        result = tt1.hadamard(tt2)
+        assert abs(result.sum() - 36.0) < 1e-10
+
+    def test_dot(self):
+        """Test dot product of two tensor trains."""
+        tt1 = t4a.TensorTrainF64.constant([2, 3], 2.0)
+        tt2 = t4a.TensorTrainF64.constant([2, 3], 3.0)
+        d = tt1.dot(tt2)
+        assert abs(d - 36.0) < 1e-10
+
+    def test_compress(self):
+        """Test in-place compression."""
+        tt = t4a.TensorTrainF64.constant([2, 3, 2], 1.0)
+        sum_before = tt.sum()
+        tt.compress()
+        assert abs(tt.sum() - sum_before) < 1e-10
+
+    def test_compressed(self):
+        """Test creating a compressed copy."""
+        tt = t4a.TensorTrainF64.constant([2, 3, 2], 1.0)
+        comp = tt.compressed()
+        assert abs(comp.sum() - tt.sum()) < 1e-10
+
 
 class TestTensorTrainC64:
     """Tests for TensorTrainC64."""
@@ -143,6 +197,32 @@ class TestTensorTrainC64:
 
         assert arr.shape == (2, 3)
         assert np.allclose(arr, 1.0 + 2.0j)
+
+    def test_add(self):
+        """Test adding two complex tensor trains."""
+        tt1 = t4a.TensorTrainC64.constant([2, 2], 1.0 + 0.0j)
+        tt2 = t4a.TensorTrainC64.constant([2, 2], 0.0 + 1.0j)
+        result = tt1 + tt2
+        s = result.sum()
+        assert abs(s.real - 4.0) < 1e-10
+        assert abs(s.imag - 4.0) < 1e-10
+
+    def test_hadamard(self):
+        """Test Hadamard product of two complex tensor trains."""
+        tt1 = t4a.TensorTrainC64.constant([2, 2], 2.0 + 0.0j)
+        tt2 = t4a.TensorTrainC64.constant([2, 2], 0.0 + 3.0j)
+        result = tt1.hadamard(tt2)
+        s = result.sum()
+        assert abs(s.real) < 1e-10
+        assert abs(s.imag - 24.0) < 1e-10
+
+    def test_dot(self):
+        """Test dot product of two complex tensor trains."""
+        tt1 = t4a.TensorTrainC64.constant([2, 2], 2.0 + 0.0j)
+        tt2 = t4a.TensorTrainC64.constant([2, 2], 3.0 + 0.0j)
+        d = tt1.dot(tt2)
+        assert abs(d.real - 24.0) < 1e-10
+        assert abs(d.imag) < 1e-10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add arithmetic operations (add, sub, negate, reverse) to TensorTrain C-API
- Add contraction operations (hadamard, dot) to TensorTrain C-API
- Add compression functions (compress, compressed) to TensorTrain C-API
- Update Julia bindings with operator overloads and new functions
- Update Python bindings with operator overloads and new methods

## New C-API Functions

For both `t4a_tt_f64_*` and `t4a_tt_c64_*`:

| Function | Description |
|----------|-------------|
| `add` | Add two tensor trains element-wise |
| `sub` | Subtract two tensor trains |
| `negate` | Negate (multiply by -1) |
| `reverse` | Swap left and right |
| `hadamard` | Element-wise product |
| `dot` | Inner product (scalar result) |
| `compress` | In-place compression |
| `compressed` | Create compressed copy |

## Julia API Example

```julia
using Tensor4allRs
init_library("/path/to/libtensor4all_capi.dylib")

tt1 = constant_tt(Float64, [2, 3], 1.0)
tt2 = constant_tt(Float64, [2, 3], 2.0)

# Arithmetic with operators
result = tt1 + tt2
result = tt2 - tt1
result = -tt1

# Hadamard product
result = tt1 * tt2

# Dot product
d = dot(tt1, tt2)

# Compression
compress!(result)
comp = compressed(tt1)
```

## Python API Example

```python
import tensor4all_rs as t4a
t4a.init_library("/path/to/libtensor4all_capi.dylib")

tt1 = t4a.TensorTrainF64.constant([2, 3], 1.0)
tt2 = t4a.TensorTrainF64.constant([2, 3], 2.0)

# Arithmetic with operators
result = tt1 + tt2
result = tt2 - tt1
result = -tt1

# Hadamard product
result = tt1.hadamard(tt2)

# Dot product
d = tt1.dot(tt2)

# Compression
tt1.compress()
comp = tt1.compressed()
```

## Test plan

- [x] All Rust tests pass (28 tests)
- [x] Julia binding tests pass (15 tests)
- [x] Python binding tests pass (21 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)