### PR TITLE
Rename ITensorTrain to TensorTrain

### DIFF
--- a/crates/tensor4all-itensortrain/src/error.rs
+++ b/crates/tensor4all-itensortrain/src/error.rs
@@ -1,13 +1,13 @@
-//! Error types for ITensorTrain operations.
+//! Error types for TensorTrain operations.
 
 use thiserror::Error;
 
-/// Result type for ITensorTrain operations.
-pub type Result<T> = std::result::Result<T, ITensorTrainError>;
+/// Result type for TensorTrain operations.
+pub type Result<T> = std::result::Result<T, TensorTrainError>;
 
-/// Errors that can occur in ITensorTrain operations.
+/// Errors that can occur in TensorTrain operations.
 #[derive(Debug, Error)]
-pub enum ITensorTrainError {
+pub enum TensorTrainError {
     /// Tensor train is empty (has no tensors).
     #[error("Tensor train is empty")]
     Empty,

--- a/crates/tensor4all-itensortrain/src/lib.rs
+++ b/crates/tensor4all-itensortrain/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! # Features
 //!
-//! - `ITensorTrain`: Main tensor train type with orthogonality tracking
+//! - `TensorTrain`: Main tensor train type with orthogonality tracking
 //! - Canonicalization with SVD, LU, or CI algorithms
 //! - Truncation with configurable tolerance and max rank
 //! - Norm and inner product computations
@@ -13,10 +13,10 @@
 //! # Example
 //!
 //! ```ignore
-//! use tensor4all_itensortrain::{ITensorTrain, TruncateOptions};
+//! use tensor4all_itensortrain::{TensorTrain, TruncateOptions};
 //!
 //! // Create a tensor train from tensors
-//! let tt = ITensorTrain::new(tensors)?;
+//! let tt = TensorTrain::new(tensors)?;
 //!
 //! // Orthogonalize to site 2
 //! tt.orthogonalize(2)?;
@@ -39,6 +39,6 @@ pub mod error;
 pub mod options;
 pub mod tensortrain;
 
-pub use error::{ITensorTrainError, Result};
+pub use error::{TensorTrainError, Result};
 pub use options::{CanonicalMethod, TruncateAlg, TruncateOptions};
-pub use tensortrain::ITensorTrain;
+pub use tensortrain::TensorTrain;


### PR DESCRIPTION
## Summary

- Rename `ITensorTrain` struct to `TensorTrain` for clarity
- Rename `ITensorTrainError` enum to `TensorTrainError`
- Update all documentation and comments accordingly

## Test plan

- [x] `cargo check -p tensor4all-itensortrain` passes
- [x] `cargo test -p tensor4all-itensortrain` passes (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)