### PR TITLE
Add blocked-mdarray crate for block-sparse tensor operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/blocked-mdarray",
     "crates/tensor4all-core",
     "crates/tensor4all-itensorlike",
     "crates/tensor4all-treetn",

--- a/crates/blocked-mdarray/Cargo.toml
+++ b/crates/blocked-mdarray/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "blocked-mdarray"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Blocked multi-dimensional arrays with sparse-matrix-style operations"
+
+[dependencies]
+num-complex.workspace = true
+num-traits.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+mdarray.workspace = true
+mdarray-linalg.workspace = true
+mdarray-linalg-faer.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/crates/blocked-mdarray/src/block_data.rs
+++ b/crates/blocked-mdarray/src/block_data.rs
@@ -1,0 +1,234 @@
+//! Block data types using mdarray.
+//!
+//! This module provides type aliases and helper functions for block data,
+//! built on top of mdarray's Tensor and Slice types.
+
+use std::sync::Arc;
+
+use mdarray::{DTensor, DSlice, Dense, Strided};
+
+/// Owned 2D block data.
+///
+/// Uses mdarray's DTensor for efficient storage and operations.
+/// Data is stored in row-major (C) order.
+pub type BlockTensor2 = DTensor<f64, 2>;
+
+/// View over 2D block data (dense layout).
+pub type BlockSlice2<'a> = &'a DSlice<f64, 2, Dense>;
+
+/// View over 2D block data (strided layout, for permuted views).
+pub type BlockSliceStrided2<'a> = &'a DSlice<f64, 2, Strided>;
+
+/// Owned block data wrapped with Arc for sharing.
+#[derive(Debug, Clone)]
+pub struct BlockData {
+    tensor: Arc<BlockTensor2>,
+}
+
+impl BlockData {
+    /// Create a new block from data and shape.
+    ///
+    /// # Arguments
+    /// * `data` - Row-major data
+    /// * `shape` - [rows, cols]
+    ///
+    /// # Panics
+    /// Panics if data length doesn't match shape.
+    pub fn new(data: Vec<f64>, shape: [usize; 2]) -> Self {
+        let expected_len = shape[0] * shape[1];
+        assert_eq!(
+            data.len(),
+            expected_len,
+            "Data length {} does not match shape {:?} (expected {})",
+            data.len(),
+            shape,
+            expected_len
+        );
+
+        // Create tensor using from_fn to ensure row-major order
+        let tensor: BlockTensor2 = DTensor::<f64, 2>::from_fn(shape, |idx| {
+            let linear = idx[0] * shape[1] + idx[1];
+            data[linear]
+        });
+
+        Self {
+            tensor: Arc::new(tensor),
+        }
+    }
+
+    /// Create a scalar block (1×1).
+    pub fn scalar(value: f64) -> Self {
+        Self::new(vec![value], [1, 1])
+    }
+
+    /// Create a block from an existing DTensor.
+    pub fn from_tensor(tensor: BlockTensor2) -> Self {
+        Self {
+            tensor: Arc::new(tensor),
+        }
+    }
+
+    /// Get the shape of this block.
+    pub fn shape(&self) -> [usize; 2] {
+        let s = self.tensor.shape();
+        [s.0, s.1]
+    }
+
+    /// Get the number of rows.
+    pub fn nrows(&self) -> usize {
+        self.tensor.shape().0
+    }
+
+    /// Get the number of columns.
+    pub fn ncols(&self) -> usize {
+        self.tensor.shape().1
+    }
+
+    /// Get the total number of elements.
+    pub fn len(&self) -> usize {
+        self.nrows() * self.ncols()
+    }
+
+    /// Check if block is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get a view (slice) of this block.
+    pub fn as_slice(&self) -> &DSlice<f64, 2, Dense> {
+        self.tensor.as_ref()
+    }
+
+    /// Get the underlying tensor reference.
+    pub fn as_tensor(&self) -> &BlockTensor2 {
+        &self.tensor
+    }
+
+    /// Get element at [i, j].
+    pub fn get(&self, idx: [usize; 2]) -> f64 {
+        self.tensor[idx]
+    }
+
+    /// Create a transposed view (no data copy).
+    ///
+    /// Returns an owned BlockData with transposed data.
+    /// For zero-copy transpose, use `as_slice().t()` directly.
+    pub fn transpose(&self) -> BlockData {
+        let [m, n] = self.shape();
+        let transposed: BlockTensor2 = DTensor::<f64, 2>::from_fn([n, m], |idx| self.tensor[[idx[1], idx[0]]]);
+        Self::from_tensor(transposed)
+    }
+
+    /// Convert to Vec in row-major order.
+    pub fn to_vec(&self) -> Vec<f64> {
+        let [m, n] = self.shape();
+        let mut result = Vec::with_capacity(m * n);
+        for i in 0..m {
+            for j in 0..n {
+                result.push(self.tensor[[i, j]]);
+            }
+        }
+        result
+    }
+
+    /// Add another block to this one (element-wise).
+    ///
+    /// # Panics
+    /// Panics if shapes don't match.
+    pub fn add(&self, other: &BlockData) -> BlockData {
+        assert_eq!(self.shape(), other.shape(), "Shape mismatch in add");
+        let [m, n] = self.shape();
+        let result: BlockTensor2 = DTensor::<f64, 2>::from_fn([m, n], |idx| {
+            self.tensor[idx] + other.tensor[idx]
+        });
+        Self::from_tensor(result)
+    }
+}
+
+// For convenient creation from Vec with shape
+impl From<(Vec<f64>, [usize; 2])> for BlockData {
+    fn from((data, shape): (Vec<f64>, [usize; 2])) -> Self {
+        Self::new(data, shape)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_block_data_new() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let block = BlockData::new(data, [2, 3]);
+
+        assert_eq!(block.shape(), [2, 3]);
+        assert_eq!(block.nrows(), 2);
+        assert_eq!(block.ncols(), 3);
+        assert_eq!(block.len(), 6);
+    }
+
+    #[test]
+    fn test_block_data_scalar() {
+        let block = BlockData::scalar(42.0);
+
+        assert_eq!(block.shape(), [1, 1]);
+        assert_eq!(block.len(), 1);
+        assert_eq!(block.get([0, 0]), 42.0);
+    }
+
+    #[test]
+    fn test_block_data_get() {
+        // Row-major: [[1, 2, 3], [4, 5, 6]]
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let block = BlockData::new(data, [2, 3]);
+
+        assert_eq!(block.get([0, 0]), 1.0);
+        assert_eq!(block.get([0, 2]), 3.0);
+        assert_eq!(block.get([1, 0]), 4.0);
+        assert_eq!(block.get([1, 2]), 6.0);
+    }
+
+    #[test]
+    fn test_block_data_transpose() {
+        // [[1, 2, 3], [4, 5, 6]] -> [[1, 4], [2, 5], [3, 6]]
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let block = BlockData::new(data, [2, 3]);
+        let transposed = block.transpose();
+
+        assert_eq!(transposed.shape(), [3, 2]);
+        assert_eq!(transposed.get([0, 0]), 1.0);
+        assert_eq!(transposed.get([0, 1]), 4.0);
+        assert_eq!(transposed.get([1, 0]), 2.0);
+        assert_eq!(transposed.get([2, 1]), 6.0);
+    }
+
+    #[test]
+    fn test_block_data_add() {
+        let a = BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]);
+        let b = BlockData::new(vec![10.0, 20.0, 30.0, 40.0], [2, 2]);
+        let c = a.add(&b);
+
+        assert_eq!(c.get([0, 0]), 11.0);
+        assert_eq!(c.get([0, 1]), 22.0);
+        assert_eq!(c.get([1, 0]), 33.0);
+        assert_eq!(c.get([1, 1]), 44.0);
+    }
+
+    #[test]
+    fn test_block_data_to_vec() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let block = BlockData::new(data.clone(), [2, 3]);
+
+        assert_eq!(block.to_vec(), data);
+    }
+
+    #[test]
+    fn test_as_slice() {
+        let block = BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]);
+        let slice = block.as_slice();
+
+        // Access via mdarray slice
+        assert_eq!(slice[[0, 0]], 1.0);
+        assert_eq!(slice[[1, 1]], 4.0);
+    }
+}

--- a/crates/blocked-mdarray/src/blocked_array.rs
+++ b/crates/blocked-mdarray/src/blocked_array.rs
@@ -1,0 +1,463 @@
+//! Blocked array and view types.
+
+use std::collections::HashMap;
+
+use mdarray::{DSlice, Dense};
+
+use crate::block_data::BlockData;
+use crate::partition::{block_linear_index, block_multi_index, BlockIndex, BlockPartition};
+
+/// A blocked multi-dimensional array (owns data).
+///
+/// The array is partitioned along each axis, creating a grid of blocks.
+/// Only non-zero blocks are stored in memory (sparse representation).
+#[derive(Debug, Clone)]
+pub struct BlockedArray {
+    /// Block partition for each axis.
+    partitions: Vec<BlockPartition>,
+    /// Non-zero blocks stored in a HashMap.
+    /// Key: linear block index, Value: block data.
+    blocks: HashMap<usize, BlockData>,
+}
+
+impl BlockedArray {
+    /// Create an empty blocked array with given partitions.
+    pub fn new(partitions: Vec<BlockPartition>) -> Self {
+        Self {
+            partitions,
+            blocks: HashMap::new(),
+        }
+    }
+
+    /// Get the rank (number of dimensions).
+    pub fn rank(&self) -> usize {
+        self.partitions.len()
+    }
+
+    /// Get the total shape (sum of block sizes per axis).
+    pub fn shape(&self) -> Vec<usize> {
+        self.partitions.iter().map(|p| p.total_dim()).collect()
+    }
+
+    /// Get the partitions.
+    pub fn partitions(&self) -> &[BlockPartition] {
+        &self.partitions
+    }
+
+    /// Get the number of blocks per axis.
+    pub fn num_blocks(&self) -> Vec<usize> {
+        self.partitions.iter().map(|p| p.num_blocks()).collect()
+    }
+
+    /// Get the total number of blocks (including zero blocks).
+    pub fn total_blocks(&self) -> usize {
+        self.num_blocks().iter().product()
+    }
+
+    /// Get the number of non-zero (stored) blocks.
+    pub fn num_nonzero_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
+    /// Get the shape of a specific block.
+    pub fn block_shape(&self, block_idx: &BlockIndex) -> [usize; 2] {
+        assert_eq!(block_idx.len(), 2, "Only 2D blocks are supported");
+        [
+            self.partitions[0].block_size(block_idx[0]),
+            self.partitions[1].block_size(block_idx[1]),
+        ]
+    }
+
+    /// Get a block reference (returns None for zero blocks).
+    pub fn get_block(&self, block_idx: &BlockIndex) -> Option<&BlockData> {
+        let linear = block_linear_index(block_idx, &self.num_blocks());
+        self.blocks.get(&linear)
+    }
+
+    /// Get a block as mdarray slice (returns None for zero blocks).
+    pub fn get_block_slice(&self, block_idx: &BlockIndex) -> Option<&DSlice<f64, 2, Dense>> {
+        self.get_block(block_idx).map(|b| b.as_slice())
+    }
+
+    /// Set a block.
+    pub fn set_block(&mut self, block_idx: BlockIndex, data: BlockData) {
+        let expected_shape = self.block_shape(&block_idx);
+        assert_eq!(
+            data.shape(),
+            expected_shape,
+            "Block shape {:?} does not match expected {:?}",
+            data.shape(),
+            expected_shape
+        );
+
+        let linear = block_linear_index(&block_idx, &self.num_blocks());
+        self.blocks.insert(linear, data);
+    }
+
+    /// Accumulate into a block (add to existing or create new).
+    ///
+    /// Used in matrix multiplication to accumulate partial results.
+    pub fn accumulate_block(&mut self, block_idx: BlockIndex, data: BlockData) {
+        let linear = block_linear_index(&block_idx, &self.num_blocks());
+
+        if let Some(existing) = self.blocks.get(&linear) {
+            // Add to existing block
+            let sum = existing.add(&data);
+            self.blocks.insert(linear, sum);
+        } else {
+            // Insert new block
+            let expected_shape = self.block_shape(&block_idx);
+            assert_eq!(
+                data.shape(),
+                expected_shape,
+                "Block shape {:?} does not match expected {:?}",
+                data.shape(),
+                expected_shape
+            );
+            self.blocks.insert(linear, data);
+        }
+    }
+
+    /// Remove a block (make it zero).
+    pub fn remove_block(&mut self, block_idx: &BlockIndex) -> Option<BlockData> {
+        let linear = block_linear_index(block_idx, &self.num_blocks());
+        self.blocks.remove(&linear)
+    }
+
+    /// Iterate over non-zero blocks.
+    pub fn iter_blocks(&self) -> impl Iterator<Item = (BlockIndex, &BlockData)> {
+        let num_blocks = self.num_blocks();
+        self.blocks.iter().map(move |(&linear, data)| {
+            let block_idx = block_multi_index(linear, &num_blocks);
+            (block_idx, data)
+        })
+    }
+
+    /// Create a view over this array.
+    pub fn view(&self) -> BlockedView<'_> {
+        BlockedView {
+            source: self,
+            transposed: false,
+        }
+    }
+
+    /// Create a transposed view (for 2D arrays).
+    pub fn transpose(&self) -> BlockedView<'_> {
+        assert_eq!(self.rank(), 2, "Transpose requires 2D array");
+        BlockedView {
+            source: self,
+            transposed: true,
+        }
+    }
+
+    /// Compute sparsity ratio (stored elements / total elements).
+    pub fn sparsity(&self) -> f64 {
+        let stored: usize = self.blocks.values().map(|b| b.len()).sum();
+        let total: usize = self.shape().iter().product();
+        if total == 0 {
+            0.0
+        } else {
+            stored as f64 / total as f64
+        }
+    }
+}
+
+/// View over a BlockedArray (borrowed, possibly transposed).
+#[derive(Debug, Clone)]
+pub struct BlockedView<'a> {
+    /// Reference to the source array.
+    source: &'a BlockedArray,
+    /// Whether the view is transposed.
+    transposed: bool,
+}
+
+impl<'a> BlockedView<'a> {
+    /// Get the rank (number of dimensions).
+    pub fn rank(&self) -> usize {
+        self.source.rank()
+    }
+
+    /// Get the effective shape (after transposition).
+    pub fn shape(&self) -> Vec<usize> {
+        let orig_shape = self.source.shape();
+        if self.transposed {
+            vec![orig_shape[1], orig_shape[0]]
+        } else {
+            orig_shape
+        }
+    }
+
+    /// Get the effective partitions (after transposition).
+    pub fn partitions(&self) -> Vec<BlockPartition> {
+        let orig_parts = self.source.partitions();
+        if self.transposed {
+            vec![orig_parts[1].clone(), orig_parts[0].clone()]
+        } else {
+            orig_parts.to_vec()
+        }
+    }
+
+    /// Get the number of blocks per axis (after transposition).
+    pub fn num_blocks(&self) -> Vec<usize> {
+        let orig_num = self.source.num_blocks();
+        if self.transposed {
+            vec![orig_num[1], orig_num[0]]
+        } else {
+            orig_num
+        }
+    }
+
+    /// Get a block with transposition applied.
+    ///
+    /// The block index is in the transposed coordinate system.
+    /// Returns the block data (transposed if the view is transposed).
+    pub fn get_block(&self, block_idx: &BlockIndex) -> Option<BlockData> {
+        let source_idx = if self.transposed {
+            vec![block_idx[1], block_idx[0]]
+        } else {
+            block_idx.clone()
+        };
+
+        self.source.get_block(&source_idx).map(|b| {
+            if self.transposed {
+                b.transpose()
+            } else {
+                b.clone()
+            }
+        })
+    }
+
+    /// Iterate over non-zero blocks (with transposition applied).
+    pub fn iter_blocks(&self) -> impl Iterator<Item = (BlockIndex, BlockData)> + '_ {
+        self.source.iter_blocks().map(move |(orig_idx, data)| {
+            if self.transposed {
+                let transposed_idx = vec![orig_idx[1], orig_idx[0]];
+                (transposed_idx, data.transpose())
+            } else {
+                (orig_idx, data.clone())
+            }
+        })
+    }
+
+    /// Further transpose the view.
+    pub fn transpose(&self) -> BlockedView<'a> {
+        assert_eq!(self.rank(), 2, "Transpose requires 2D view");
+        BlockedView {
+            source: self.source,
+            transposed: !self.transposed,
+        }
+    }
+
+    /// Materialize to owned BlockedArray.
+    pub fn to_owned(&self) -> BlockedArray {
+        if !self.transposed {
+            return self.source.clone();
+        }
+
+        let new_partitions = self.partitions();
+        let mut result = BlockedArray::new(new_partitions);
+
+        for (idx, data) in self.iter_blocks() {
+            result.set_block(idx, data);
+        }
+
+        result
+    }
+}
+
+/// Trait for types that can act as blocked arrays (owned or view).
+pub trait BlockedArrayLike {
+    /// Get the rank.
+    fn rank(&self) -> usize;
+
+    /// Get the shape.
+    fn shape(&self) -> Vec<usize>;
+
+    /// Get the partitions.
+    fn partitions(&self) -> Vec<BlockPartition>;
+
+    /// Get the number of blocks per axis.
+    fn num_blocks(&self) -> Vec<usize>;
+
+    /// Get a block (returns owned BlockData).
+    fn get_block(&self, block_idx: &BlockIndex) -> Option<BlockData>;
+
+    /// Iterate over non-zero blocks, returning (index, data) pairs.
+    ///
+    /// Returns a Vec to maintain trait object safety.
+    fn iter_nonzero_blocks(&self) -> Vec<(BlockIndex, BlockData)>;
+}
+
+impl BlockedArrayLike for BlockedArray {
+    fn rank(&self) -> usize {
+        self.rank()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.shape()
+    }
+
+    fn partitions(&self) -> Vec<BlockPartition> {
+        self.partitions.clone()
+    }
+
+    fn num_blocks(&self) -> Vec<usize> {
+        self.num_blocks()
+    }
+
+    fn get_block(&self, block_idx: &BlockIndex) -> Option<BlockData> {
+        BlockedArray::get_block(self, block_idx).cloned()
+    }
+
+    fn iter_nonzero_blocks(&self) -> Vec<(BlockIndex, BlockData)> {
+        self.iter_blocks().map(|(idx, data)| (idx, data.clone())).collect()
+    }
+}
+
+impl<'a> BlockedArrayLike for BlockedView<'a> {
+    fn rank(&self) -> usize {
+        self.rank()
+    }
+
+    fn shape(&self) -> Vec<usize> {
+        self.shape()
+    }
+
+    fn partitions(&self) -> Vec<BlockPartition> {
+        self.partitions()
+    }
+
+    fn num_blocks(&self) -> Vec<usize> {
+        self.num_blocks()
+    }
+
+    fn get_block(&self, block_idx: &BlockIndex) -> Option<BlockData> {
+        BlockedView::get_block(self, block_idx)
+    }
+
+    fn iter_nonzero_blocks(&self) -> Vec<(BlockIndex, BlockData)> {
+        self.iter_blocks().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blocked_array_new() {
+        let partitions = vec![
+            BlockPartition::new(vec![2, 3]),
+            BlockPartition::new(vec![4, 5]),
+        ];
+        let arr = BlockedArray::new(partitions);
+
+        assert_eq!(arr.rank(), 2);
+        assert_eq!(arr.shape(), vec![5, 9]);
+        assert_eq!(arr.num_blocks(), vec![2, 2]);
+        assert_eq!(arr.total_blocks(), 4);
+        assert_eq!(arr.num_nonzero_blocks(), 0);
+    }
+
+    #[test]
+    fn test_blocked_array_set_get() {
+        let partitions = vec![
+            BlockPartition::new(vec![2, 3]),
+            BlockPartition::new(vec![4, 5]),
+        ];
+        let mut arr = BlockedArray::new(partitions);
+
+        // Set block [0, 0] (shape 2x4)
+        let data = BlockData::new(vec![1.0; 8], [2, 4]);
+        arr.set_block(vec![0, 0], data);
+
+        // Set block [1, 1] (shape 3x5)
+        let data = BlockData::new(vec![2.0; 15], [3, 5]);
+        arr.set_block(vec![1, 1], data);
+
+        assert_eq!(arr.num_nonzero_blocks(), 2);
+
+        // Get blocks
+        let block00 = arr.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(block00.shape(), [2, 4]);
+        assert_eq!(block00.get([0, 0]), 1.0);
+
+        let block11 = arr.get_block(&vec![1, 1]).unwrap();
+        assert_eq!(block11.shape(), [3, 5]);
+        assert_eq!(block11.get([0, 0]), 2.0);
+
+        // Zero block
+        assert!(arr.get_block(&vec![0, 1]).is_none());
+    }
+
+    #[test]
+    fn test_blocked_view_transpose() {
+        let partitions = vec![
+            BlockPartition::new(vec![2, 3]),
+            BlockPartition::new(vec![4, 5]),
+        ];
+        let mut arr = BlockedArray::new(partitions);
+
+        // Set block [0, 1] (shape 2x5)
+        let data = BlockData::new((0..10).map(|i| i as f64).collect(), [2, 5]);
+        arr.set_block(vec![0, 1], data);
+
+        // Create transposed view
+        let view = arr.transpose();
+        assert_eq!(view.shape(), vec![9, 5]);
+        assert_eq!(view.num_blocks(), vec![2, 2]);
+
+        // In transposed view, block [1, 0] corresponds to original [0, 1]
+        let block = view.get_block(&vec![1, 0]).unwrap();
+        assert_eq!(block.shape(), [5, 2]); // Transposed shape
+
+        // Check transposed element access
+        // Original [0, 1][0, 0] = 0.0 -> Transposed [1, 0][0, 0]
+        assert_eq!(block.get([0, 0]), 0.0);
+        // Original [0, 1][0, 1] = 1.0 -> Transposed [1, 0][1, 0]
+        assert_eq!(block.get([1, 0]), 1.0);
+    }
+
+    #[test]
+    fn test_blocked_view_to_owned() {
+        let partitions = vec![
+            BlockPartition::new(vec![2, 3]),
+            BlockPartition::new(vec![4, 5]),
+        ];
+        let mut arr = BlockedArray::new(partitions);
+
+        let data = BlockData::new((0..10).map(|i| i as f64).collect(), [2, 5]);
+        arr.set_block(vec![0, 1], data);
+
+        // Materialize transposed view
+        let transposed = arr.transpose().to_owned();
+        assert_eq!(transposed.shape(), vec![9, 5]);
+
+        // Block [1, 0] should now have transposed data
+        let block = transposed.get_block(&vec![1, 0]).unwrap();
+        assert_eq!(block.shape(), [5, 2]);
+    }
+
+    #[test]
+    fn test_accumulate_block() {
+        let partitions = vec![
+            BlockPartition::uniform(2, 2),
+            BlockPartition::uniform(2, 2),
+        ];
+        let mut arr = BlockedArray::new(partitions);
+
+        // First accumulation
+        let data1 = BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]);
+        arr.accumulate_block(vec![0, 0], data1);
+
+        // Second accumulation
+        let data2 = BlockData::new(vec![10.0, 20.0, 30.0, 40.0], [2, 2]);
+        arr.accumulate_block(vec![0, 0], data2);
+
+        let block = arr.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(block.get([0, 0]), 11.0);
+        assert_eq!(block.get([0, 1]), 22.0);
+        assert_eq!(block.get([1, 0]), 33.0);
+        assert_eq!(block.get([1, 1]), 44.0);
+    }
+}

--- a/crates/blocked-mdarray/src/error.rs
+++ b/crates/blocked-mdarray/src/error.rs
@@ -1,0 +1,36 @@
+//! Error types for blocked-mdarray operations.
+
+use thiserror::Error;
+
+/// Error type for blocked array operations.
+#[derive(Debug, Error)]
+pub enum BlockedArrayError {
+    /// Block partitions are incompatible for the operation.
+    #[error("Incompatible block partitions for operation")]
+    IncompatiblePartitions,
+
+    /// Block index is out of bounds.
+    #[error("Block index {index:?} out of bounds for shape {shape:?}")]
+    BlockIndexOutOfBounds {
+        index: Vec<usize>,
+        shape: Vec<usize>,
+    },
+
+    /// Shape mismatch in operation.
+    #[error("Shape mismatch: expected {expected:?}, got {actual:?}")]
+    ShapeMismatch {
+        expected: Vec<usize>,
+        actual: Vec<usize>,
+    },
+
+    /// Operation requires a 2D array (matrix).
+    #[error("Operation requires 2D array, got {0}D")]
+    NotMatrix(usize),
+
+    /// Invalid permutation.
+    #[error("Invalid permutation: {0}")]
+    InvalidPermutation(String),
+}
+
+/// Result type for blocked array operations.
+pub type Result<T> = std::result::Result<T, BlockedArrayError>;

--- a/crates/blocked-mdarray/src/lib.rs
+++ b/crates/blocked-mdarray/src/lib.rs
@@ -1,0 +1,53 @@
+//! Blocked multi-dimensional arrays with sparse-matrix-style operations.
+//!
+//! This crate provides efficient data structures for block-sparse tensors,
+//! where only certain blocks contain non-zero data. This is particularly
+//! useful for tensors with symmetry constraints (e.g., quantum number conservation).
+//!
+//! # Design
+//!
+//! The design follows mdarray's view-based pattern:
+//! - Built on top of mdarray's `DTensor` and `DSlice` types
+//! - Transposition returns views (no data copy)
+//! - Data is only copied when materialized via `to_owned()`
+//! - Blocks are stored in a sparse HashMap
+//!
+//! # Core Types
+//!
+//! - [`BlockPartition`]: Defines how an axis is divided into blocks
+//! - [`BlockData`]: Owned 2D block data (wraps mdarray's `DTensor<f64, 2>`)
+//! - [`BlockedArray`]: Owned blocked array
+//! - [`BlockedView`]: Borrowed view (supports lazy transposition)
+//!
+//! # Example
+//!
+//! ```
+//! use blocked_mdarray::{BlockPartition, BlockedArray, BlockData, blocked_matmul};
+//!
+//! // Create a 4x4 matrix split into 2x2 blocks
+//! let parts = vec![
+//!     BlockPartition::uniform(2, 2),
+//!     BlockPartition::uniform(2, 2),
+//! ];
+//! let mut matrix = BlockedArray::new(parts);
+//!
+//! // Set only diagonal blocks (block-diagonal matrix)
+//! matrix.set_block(vec![0, 0], BlockData::new(vec![1.0, 0.0, 0.0, 1.0], [2, 2]));
+//! matrix.set_block(vec![1, 1], BlockData::new(vec![2.0, 0.0, 0.0, 2.0], [2, 2]));
+//!
+//! // Sparse multiplication: only 2 block multiplications instead of 4
+//! let result = blocked_matmul(&matrix, &matrix).unwrap();
+//! assert_eq!(result.num_nonzero_blocks(), 2);
+//! ```
+
+mod block_data;
+mod blocked_array;
+mod error;
+mod matmul;
+mod partition;
+
+pub use block_data::{BlockData, BlockSlice2, BlockSliceStrided2, BlockTensor2};
+pub use blocked_array::{BlockedArray, BlockedArrayLike, BlockedView};
+pub use error::{BlockedArrayError, Result};
+pub use matmul::blocked_matmul;
+pub use partition::{block_linear_index, block_multi_index, BlockIndex, BlockPartition};

--- a/crates/blocked-mdarray/src/matmul.rs
+++ b/crates/blocked-mdarray/src/matmul.rs
@@ -1,0 +1,462 @@
+//! 2D matrix multiplication for blocked arrays.
+
+use std::collections::HashMap;
+
+use mdarray::DTensor;
+use mdarray_linalg::matmul::{MatMul, MatMulBuilder};
+use mdarray_linalg_faer::Faer;
+
+use crate::block_data::{BlockData, BlockTensor2};
+use crate::blocked_array::{BlockedArray, BlockedArrayLike};
+use crate::error::{BlockedArrayError, Result};
+
+/// Build index of non-zero blocks grouped by a specific axis.
+///
+/// For a 2D blocked array, returns a map from axis index to list of other-axis indices.
+/// - `group_by_axis=0`: groups by row, returns `row -> [cols with non-zero blocks]`
+/// - `group_by_axis=1`: groups by col, returns `col -> [rows with non-zero blocks]`
+fn build_nonzero_index<A: BlockedArrayLike>(arr: &A, group_by_axis: usize) -> HashMap<usize, Vec<usize>> {
+    let mut index: HashMap<usize, Vec<usize>> = HashMap::new();
+
+    for (block_idx, _) in arr.iter_nonzero_blocks() {
+        let key = block_idx[group_by_axis];
+        let value = block_idx[1 - group_by_axis];
+        index.entry(key).or_default().push(value);
+    }
+
+    index
+}
+
+/// Blocked matrix multiplication: C = A @ B.
+///
+/// Uses sparse-matrix-style algorithm (outer product formulation):
+/// only computes products of non-zero block pairs.
+///
+/// # Algorithm
+/// ```text
+/// // Build indices of non-zero blocks
+/// A_by_k[k] = [i : A[i,k] is nonzero]
+/// B_by_k[k] = [j : B[k,j] is nonzero]
+///
+/// // Only iterate over non-zero combinations
+/// for k in (keys of A_by_k ∩ keys of B_by_k):
+///     for i in A_by_k[k]:
+///         for j in B_by_k[k]:
+///             C[i,j] += A[i,k] @ B[k,j]
+/// ```
+///
+/// # Errors
+/// - Returns `BlockedArrayError::NotMatrix` if inputs are not 2D.
+/// - Returns `BlockedArrayError::IncompatiblePartitions` if inner partitions don't match.
+pub fn blocked_matmul<A, B>(a: &A, b: &B) -> Result<BlockedArray>
+where
+    A: BlockedArrayLike,
+    B: BlockedArrayLike,
+{
+    // Check: must be 2D
+    if a.rank() != 2 {
+        return Err(BlockedArrayError::NotMatrix(a.rank()));
+    }
+    if b.rank() != 2 {
+        return Err(BlockedArrayError::NotMatrix(b.rank()));
+    }
+
+    let a_parts = a.partitions();
+    let b_parts = b.partitions();
+
+    // Check compatibility: a.partitions[1] == b.partitions[0]
+    if a_parts[1] != b_parts[0] {
+        return Err(BlockedArrayError::IncompatiblePartitions);
+    }
+
+    let result_partitions = vec![a_parts[0].clone(), b_parts[1].clone()];
+    let mut result = BlockedArray::new(result_partitions);
+
+    // Build indices: group A blocks by column (k), B blocks by row (k)
+    // A_by_k[k] = list of row indices i where A[i,k] is non-zero
+    // B_by_k[k] = list of col indices j where B[k,j] is non-zero
+    let a_by_k = build_nonzero_index(a, 1); // group by column
+    let b_by_k = build_nonzero_index(b, 0); // group by row
+
+    // Outer product formulation: iterate only over k values with non-zero blocks in both A and B
+    for (k, a_rows) in &a_by_k {
+        let b_cols = match b_by_k.get(k) {
+            Some(cols) => cols,
+            None => continue, // No B blocks for this k
+        };
+
+        for &i in a_rows {
+            // A[i,k] is guaranteed to be non-zero
+            let a_block = a.get_block(&vec![i, *k]).unwrap();
+
+            for &j in b_cols {
+                // B[k,j] is guaranteed to be non-zero
+                let b_block = b.get_block(&vec![*k, j]).unwrap();
+
+                // Compute A[i,k] @ B[k,j]
+                let product = block_matmul(&a_block, &b_block)?;
+
+                // Accumulate into C[i,j]
+                result.accumulate_block(vec![i, j], product);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Multiply two blocks (2D matrices).
+///
+/// Handles three cases for efficiency:
+/// - Case 1: scalar × scalar (both 1×1)
+/// - Case 2: scalar × dense or dense × scalar → scaling operation
+/// - Case 3: dense × dense → delegates to mdarray-linalg (Faer backend)
+fn block_matmul(a: &BlockData, b: &BlockData) -> Result<BlockData> {
+    let [m, k1] = a.shape();
+    let [k2, n] = b.shape();
+
+    if k1 != k2 {
+        return Err(BlockedArrayError::ShapeMismatch {
+            expected: vec![m, k1],
+            actual: vec![k2, n],
+        });
+    }
+
+    let k = k1;
+
+    // Case 1: scalar × scalar (both 1×1)
+    if m == 1 && k == 1 && n == 1 {
+        let result = a.get([0, 0]) * b.get([0, 0]);
+        return Ok(BlockData::scalar(result));
+    }
+
+    // Case 2: scalar × dense (a is 1×1)
+    if m == 1 && k == 1 {
+        let scalar = a.get([0, 0]);
+        let result: BlockTensor2 = DTensor::<f64, 2>::from_fn([1, n], |idx| scalar * b.get([0, idx[1]]));
+        return Ok(BlockData::from_tensor(result));
+    }
+
+    // Case 2: dense × scalar (b is 1×1)
+    if k == 1 && n == 1 {
+        let scalar = b.get([0, 0]);
+        let result: BlockTensor2 = DTensor::<f64, 2>::from_fn([m, 1], |idx| a.get([idx[0], 0]) * scalar);
+        return Ok(BlockData::from_tensor(result));
+    }
+
+    // Case 3: dense × dense - delegate to mdarray-linalg
+    // Use mdarray slices directly with Faer backend
+    let a_slice = a.as_slice();
+    let b_slice = b.as_slice();
+
+    let c_tensor = Faer.matmul(a_slice, b_slice).eval();
+
+    Ok(BlockData::from_tensor(c_tensor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blocked_array::BlockedArray;
+    use crate::partition::BlockPartition;
+
+    #[test]
+    fn test_blocked_matmul_identity() {
+        // Identity matrix @ vector
+        // [1 0] @ [a] = [a]
+        // [0 1]   [b]   [b]
+
+        let a_parts = vec![
+            BlockPartition::uniform(1, 2),
+            BlockPartition::uniform(1, 2),
+        ];
+        let mut a = BlockedArray::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::scalar(1.0));
+        a.set_block(vec![1, 1], BlockData::scalar(1.0));
+
+        let b_parts = vec![
+            BlockPartition::uniform(1, 2),
+            BlockPartition::trivial(1),
+        ];
+        let mut b = BlockedArray::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::scalar(3.0));
+        b.set_block(vec![1, 0], BlockData::scalar(5.0));
+
+        let c = blocked_matmul(&a, &b).unwrap();
+
+        assert_eq!(c.shape(), vec![2, 1]);
+        let c00 = c.get_block(&vec![0, 0]).unwrap();
+        let c10 = c.get_block(&vec![1, 0]).unwrap();
+        assert_eq!(c00.get([0, 0]), 3.0);
+        assert_eq!(c10.get([0, 0]), 5.0);
+    }
+
+    #[test]
+    fn test_blocked_matmul_simple() {
+        // [1 2] @ [5 6] = [1*5+2*7  1*6+2*8] = [19 22]
+        // [3 4]   [7 8]   [3*5+4*7  3*6+4*8]   [43 50]
+
+        let parts = vec![
+            BlockPartition::trivial(2),
+            BlockPartition::trivial(2),
+        ];
+
+        let mut a = BlockedArray::new(parts.clone());
+        a.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]),
+        );
+
+        let mut b = BlockedArray::new(parts.clone());
+        b.set_block(
+            vec![0, 0],
+            BlockData::new(vec![5.0, 6.0, 7.0, 8.0], [2, 2]),
+        );
+
+        let c = blocked_matmul(&a, &b).unwrap();
+
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(c_block.get([0, 0]), 19.0);
+        assert_eq!(c_block.get([0, 1]), 22.0);
+        assert_eq!(c_block.get([1, 0]), 43.0);
+        assert_eq!(c_block.get([1, 1]), 50.0);
+    }
+
+    #[test]
+    fn test_blocked_matmul_sparse() {
+        // Block-diagonal matrix @ Block-diagonal matrix
+        // [A 0] @ [C 0] = [AC  0]
+        // [0 B]   [0 D]   [ 0 BD]
+
+        let parts = vec![
+            BlockPartition::uniform(2, 2),
+            BlockPartition::uniform(2, 2),
+        ];
+
+        let mut a = BlockedArray::new(parts.clone());
+        a.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]),
+        ); // A
+        a.set_block(
+            vec![1, 1],
+            BlockData::new(vec![5.0, 6.0, 7.0, 8.0], [2, 2]),
+        ); // B
+
+        let mut b = BlockedArray::new(parts.clone());
+        b.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 0.0, 0.0, 1.0], [2, 2]),
+        ); // C = I
+        b.set_block(
+            vec![1, 1],
+            BlockData::new(vec![2.0, 0.0, 0.0, 2.0], [2, 2]),
+        ); // D = 2I
+
+        let c = blocked_matmul(&a, &b).unwrap();
+
+        // Should have 2 non-zero blocks
+        assert_eq!(c.num_nonzero_blocks(), 2);
+
+        // AC = A * I = A
+        let c00 = c.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(c00.get([0, 0]), 1.0);
+        assert_eq!(c00.get([1, 1]), 4.0);
+
+        // BD = B * 2I = 2B
+        let c11 = c.get_block(&vec![1, 1]).unwrap();
+        assert_eq!(c11.get([0, 0]), 10.0);
+        assert_eq!(c11.get([1, 1]), 16.0);
+
+        // Zero blocks
+        assert!(c.get_block(&vec![0, 1]).is_none());
+        assert!(c.get_block(&vec![1, 0]).is_none());
+    }
+
+    #[test]
+    fn test_blocked_matmul_transposed() {
+        // Test with transposed input
+        // A^T @ B where A is stored and we use transpose view
+
+        let parts = vec![
+            BlockPartition::trivial(2),
+            BlockPartition::trivial(2),
+        ];
+
+        let mut a = BlockedArray::new(parts.clone());
+        // A = [1 3]
+        //     [2 4]
+        // Stored as row-major: [1, 3, 2, 4]
+        a.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 3.0, 2.0, 4.0], [2, 2]),
+        );
+
+        // A^T = [1 2]
+        //       [3 4]
+        let a_t = a.transpose();
+
+        let mut b = BlockedArray::new(parts.clone());
+        b.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 0.0, 0.0, 1.0], [2, 2]),
+        ); // Identity
+
+        let c = blocked_matmul(&a_t, &b).unwrap();
+
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        // A^T @ I = A^T = [1 2]
+        //                 [3 4]
+        assert_eq!(c_block.get([0, 0]), 1.0);
+        assert_eq!(c_block.get([0, 1]), 2.0);
+        assert_eq!(c_block.get([1, 0]), 3.0);
+        assert_eq!(c_block.get([1, 1]), 4.0);
+    }
+
+    #[test]
+    fn test_blocked_matmul_incompatible() {
+        let a_parts = vec![
+            BlockPartition::uniform(2, 2),
+            BlockPartition::uniform(3, 2), // Inner dim: 6
+        ];
+        let a = BlockedArray::new(a_parts);
+
+        let b_parts = vec![
+            BlockPartition::uniform(4, 2), // Inner dim: 8 (mismatch!)
+            BlockPartition::uniform(2, 2),
+        ];
+        let b = BlockedArray::new(b_parts);
+
+        let result = blocked_matmul(&a, &b);
+        assert!(matches!(
+            result,
+            Err(BlockedArrayError::IncompatiblePartitions)
+        ));
+    }
+
+    #[test]
+    fn test_block_matmul_scalar_times_scalar() {
+        // Case 1: 1×1 × 1×1 = 1×1
+        // [3] @ [4] = [12]
+        let a_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(1),
+        ];
+        let mut a = BlockedArray::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::scalar(3.0));
+
+        let b_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(1),
+        ];
+        let mut b = BlockedArray::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::scalar(4.0));
+
+        let c = blocked_matmul(&a, &b).unwrap();
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(c_block.get([0, 0]), 12.0);
+    }
+
+    #[test]
+    fn test_block_matmul_scalar_times_dense() {
+        // Case 2a: 1×1 × 1×3 = 1×3
+        // [2] @ [1 2 3] = [2 4 6]
+        let a_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(1),
+        ];
+        let mut a = BlockedArray::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::scalar(2.0));
+
+        let b_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(3),
+        ];
+        let mut b = BlockedArray::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::new(vec![1.0, 2.0, 3.0], [1, 3]));
+
+        let c = blocked_matmul(&a, &b).unwrap();
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(c_block.shape(), [1, 3]);
+        assert_eq!(c_block.get([0, 0]), 2.0);
+        assert_eq!(c_block.get([0, 1]), 4.0);
+        assert_eq!(c_block.get([0, 2]), 6.0);
+    }
+
+    #[test]
+    fn test_block_matmul_dense_times_scalar() {
+        // Case 2b: 3×1 × 1×1 = 3×1
+        // [1]     [2]
+        // [2] @ [2] = [4]
+        // [3]     [6]
+        let a_parts = vec![
+            BlockPartition::trivial(3),
+            BlockPartition::trivial(1),
+        ];
+        let mut a = BlockedArray::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::new(vec![1.0, 2.0, 3.0], [3, 1]));
+
+        let b_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(1),
+        ];
+        let mut b = BlockedArray::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::scalar(2.0));
+
+        let c = blocked_matmul(&a, &b).unwrap();
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(c_block.shape(), [3, 1]);
+        assert_eq!(c_block.get([0, 0]), 2.0);
+        assert_eq!(c_block.get([1, 0]), 4.0);
+        assert_eq!(c_block.get([2, 0]), 6.0);
+    }
+
+    #[test]
+    fn test_block_matmul_dense_times_dense_with_faer() {
+        // Case 3: 3×2 × 2×4 = 3×4 (uses mdarray-linalg/Faer)
+        // [1 2]   [1 2 3 4]   [1+10 2+12 3+14 4+16]   [11 14 17 20]
+        // [3 4] @ [5 6 7 8] = [3+20 6+24 9+28 12+32] = [23 30 37 44]
+        // [5 6]               [5+30 10+36 15+42 20+48] [35 46 57 68]
+        let a_parts = vec![
+            BlockPartition::trivial(3),
+            BlockPartition::trivial(2),
+        ];
+        let mut a = BlockedArray::new(a_parts);
+        a.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [3, 2]),
+        );
+
+        let b_parts = vec![
+            BlockPartition::trivial(2),
+            BlockPartition::trivial(4),
+        ];
+        let mut b = BlockedArray::new(b_parts);
+        b.set_block(
+            vec![0, 0],
+            BlockData::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], [2, 4]),
+        );
+
+        let c = blocked_matmul(&a, &b).unwrap();
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        assert_eq!(c_block.shape(), [3, 4]);
+
+        // First row: [1,2] @ [[1,2,3,4],[5,6,7,8]] = [11, 14, 17, 20]
+        assert_eq!(c_block.get([0, 0]), 11.0);
+        assert_eq!(c_block.get([0, 1]), 14.0);
+        assert_eq!(c_block.get([0, 2]), 17.0);
+        assert_eq!(c_block.get([0, 3]), 20.0);
+
+        // Second row: [3,4] @ [[1,2,3,4],[5,6,7,8]] = [23, 30, 37, 44]
+        assert_eq!(c_block.get([1, 0]), 23.0);
+        assert_eq!(c_block.get([1, 1]), 30.0);
+        assert_eq!(c_block.get([1, 2]), 37.0);
+        assert_eq!(c_block.get([1, 3]), 44.0);
+
+        // Third row: [5,6] @ [[1,2,3,4],[5,6,7,8]] = [35, 46, 57, 68]
+        assert_eq!(c_block.get([2, 0]), 35.0);
+        assert_eq!(c_block.get([2, 1]), 46.0);
+        assert_eq!(c_block.get([2, 2]), 57.0);
+        assert_eq!(c_block.get([2, 3]), 68.0);
+    }
+}

--- a/crates/blocked-mdarray/src/partition.rs
+++ b/crates/blocked-mdarray/src/partition.rs
@@ -1,0 +1,202 @@
+//! Block partition for array axes.
+
+use std::ops::Range;
+
+/// Partition of an axis into blocks.
+///
+/// Each axis of a blocked array has a partition that defines how
+/// the axis is divided into blocks. For example, an axis of size 10
+/// could be partitioned into blocks of sizes [3, 4, 3].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockPartition {
+    /// Size of each block.
+    block_sizes: Vec<usize>,
+    /// Cumulative offsets: [0, s0, s0+s1, ..., total_dim].
+    offsets: Vec<usize>,
+}
+
+impl BlockPartition {
+    /// Create a new partition from block sizes.
+    ///
+    /// # Example
+    /// ```
+    /// use blocked_mdarray::BlockPartition;
+    /// let p = BlockPartition::new(vec![3, 4, 3]);
+    /// assert_eq!(p.num_blocks(), 3);
+    /// assert_eq!(p.total_dim(), 10);
+    /// ```
+    pub fn new(block_sizes: Vec<usize>) -> Self {
+        let mut offsets = Vec::with_capacity(block_sizes.len() + 1);
+        offsets.push(0);
+        let mut cumsum = 0;
+        for &size in &block_sizes {
+            cumsum += size;
+            offsets.push(cumsum);
+        }
+        Self {
+            block_sizes,
+            offsets,
+        }
+    }
+
+    /// Create a uniform partition with equal block sizes.
+    ///
+    /// # Example
+    /// ```
+    /// use blocked_mdarray::BlockPartition;
+    /// let p = BlockPartition::uniform(4, 3);  // 3 blocks of size 4
+    /// assert_eq!(p.num_blocks(), 3);
+    /// assert_eq!(p.total_dim(), 12);
+    /// ```
+    pub fn uniform(block_size: usize, num_blocks: usize) -> Self {
+        Self::new(vec![block_size; num_blocks])
+    }
+
+    /// Create a trivial partition (single block containing the entire axis).
+    ///
+    /// # Example
+    /// ```
+    /// use blocked_mdarray::BlockPartition;
+    /// let p = BlockPartition::trivial(10);
+    /// assert_eq!(p.num_blocks(), 1);
+    /// assert_eq!(p.block_size(0), 10);
+    /// ```
+    pub fn trivial(total_dim: usize) -> Self {
+        Self::new(vec![total_dim])
+    }
+
+    /// Get the number of blocks.
+    #[inline]
+    pub fn num_blocks(&self) -> usize {
+        self.block_sizes.len()
+    }
+
+    /// Get the total dimension (sum of all block sizes).
+    #[inline]
+    pub fn total_dim(&self) -> usize {
+        *self.offsets.last().unwrap_or(&0)
+    }
+
+    /// Get the size of a specific block.
+    ///
+    /// # Panics
+    /// Panics if `block_idx >= num_blocks()`.
+    #[inline]
+    pub fn block_size(&self, block_idx: usize) -> usize {
+        self.block_sizes[block_idx]
+    }
+
+    /// Get the range of indices for a specific block.
+    ///
+    /// # Panics
+    /// Panics if `block_idx >= num_blocks()`.
+    #[inline]
+    pub fn block_range(&self, block_idx: usize) -> Range<usize> {
+        self.offsets[block_idx]..self.offsets[block_idx + 1]
+    }
+
+    /// Get the starting offset of a specific block.
+    #[inline]
+    pub fn block_offset(&self, block_idx: usize) -> usize {
+        self.offsets[block_idx]
+    }
+
+    /// Get a reference to the block sizes.
+    #[inline]
+    pub fn block_sizes(&self) -> &[usize] {
+        &self.block_sizes
+    }
+
+    /// Get a reference to the offsets.
+    #[inline]
+    pub fn offsets(&self) -> &[usize] {
+        &self.offsets
+    }
+}
+
+/// Multi-dimensional block index.
+pub type BlockIndex = Vec<usize>;
+
+/// Compute linear block index from multi-dimensional block index.
+///
+/// Uses row-major (C-order) indexing.
+pub fn block_linear_index(block_idx: &BlockIndex, num_blocks: &[usize]) -> usize {
+    let mut linear = 0;
+    let mut stride = 1;
+    for i in (0..block_idx.len()).rev() {
+        linear += block_idx[i] * stride;
+        stride *= num_blocks[i];
+    }
+    linear
+}
+
+/// Compute multi-dimensional block index from linear index.
+///
+/// Uses row-major (C-order) indexing.
+pub fn block_multi_index(linear_idx: usize, num_blocks: &[usize]) -> BlockIndex {
+    let mut result = vec![0; num_blocks.len()];
+    let mut remaining = linear_idx;
+    for i in (0..num_blocks.len()).rev() {
+        result[i] = remaining % num_blocks[i];
+        remaining /= num_blocks[i];
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_partition_new() {
+        let p = BlockPartition::new(vec![3, 4, 3]);
+        assert_eq!(p.num_blocks(), 3);
+        assert_eq!(p.total_dim(), 10);
+        assert_eq!(p.block_size(0), 3);
+        assert_eq!(p.block_size(1), 4);
+        assert_eq!(p.block_size(2), 3);
+    }
+
+    #[test]
+    fn test_partition_uniform() {
+        let p = BlockPartition::uniform(5, 4);
+        assert_eq!(p.num_blocks(), 4);
+        assert_eq!(p.total_dim(), 20);
+        for i in 0..4 {
+            assert_eq!(p.block_size(i), 5);
+        }
+    }
+
+    #[test]
+    fn test_partition_trivial() {
+        let p = BlockPartition::trivial(10);
+        assert_eq!(p.num_blocks(), 1);
+        assert_eq!(p.total_dim(), 10);
+        assert_eq!(p.block_size(0), 10);
+    }
+
+    #[test]
+    fn test_block_range() {
+        let p = BlockPartition::new(vec![3, 4, 3]);
+        assert_eq!(p.block_range(0), 0..3);
+        assert_eq!(p.block_range(1), 3..7);
+        assert_eq!(p.block_range(2), 7..10);
+    }
+
+    #[test]
+    fn test_linear_index() {
+        let num_blocks = vec![2, 3, 4];
+
+        // Test some known values
+        assert_eq!(block_linear_index(&vec![0, 0, 0], &num_blocks), 0);
+        assert_eq!(block_linear_index(&vec![0, 0, 1], &num_blocks), 1);
+        assert_eq!(block_linear_index(&vec![0, 1, 0], &num_blocks), 4);
+        assert_eq!(block_linear_index(&vec![1, 0, 0], &num_blocks), 12);
+
+        // Round-trip test
+        for linear in 0..24 {
+            let multi = block_multi_index(linear, &num_blocks);
+            assert_eq!(block_linear_index(&multi, &num_blocks), linear);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add new `blocked-mdarray` crate for efficient block-sparse tensor operations
- Built on top of mdarray's `DTensor` and `DSlice` types
- Implements sparse matrix multiplication using outer product formulation

## Key Components

- **BlockPartition**: Defines how an axis is divided into blocks
- **BlockData**: Owned 2D block data (wraps `DTensor<f64, 2>` with Arc)
- **BlockedArray**: Owned blocked array with sparse HashMap storage
- **BlockedView**: Borrowed view with lazy transposition
- **blocked_matmul**: Sparse block matrix multiplication

## Algorithm: Outer Product Formulation

Instead of iterating over all block combinations O(ni × nk × nj):

```
// Build indices of non-zero blocks
A_by_k[k] = [i : A[i,k] is nonzero]
B_by_k[k] = [j : B[k,j] is nonzero]

// Only iterate over non-zero combinations
for k in (keys of A_by_k ∩ keys of B_by_k):
    for i in A_by_k[k]:
        for j in B_by_k[k]:
            C[i,j] += A[i,k] @ B[k,j]
```

**Performance**:
- Index construction: O(nnz_A + nnz_B)
- Multiplication: O(Σ_k |A_by_k[k]| × |B_by_k[k]|)
- Block-diagonal matrices: O(n) vs O(n³) naive approach

## Test plan

- [x] All 26 unit tests pass
- [x] All 4 doc tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)