### PR TITLE
Make blocked-mdarray generic over scalar type (f64/Complex64)

### DIFF
--- a/crates/blocked-mdarray/Cargo.toml
+++ b/crates/blocked-mdarray/Cargo.toml
@@ -15,6 +15,7 @@ thiserror.workspace = true
 mdarray.workspace = true
 mdarray-linalg.workspace = true
 mdarray-linalg-faer.workspace = true
+faer-traits.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/crates/blocked-mdarray/src/block_data.rs
+++ b/crates/blocked-mdarray/src/block_data.rs
@@ -3,29 +3,33 @@
 //! This module provides type aliases and helper functions for block data,
 //! built on top of mdarray's Tensor and Slice types.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
-use mdarray::{DTensor, DSlice, Dense, Strided};
+use mdarray::{DSlice, DTensor, Dense, Strided};
+
+use crate::scalar::Scalar;
 
 /// Owned 2D block data.
 ///
 /// Uses mdarray's DTensor for efficient storage and operations.
 /// Data is stored in row-major (C) order.
-pub type BlockTensor2 = DTensor<f64, 2>;
+pub type BlockTensor2<T> = DTensor<T, 2>;
 
 /// View over 2D block data (dense layout).
-pub type BlockSlice2<'a> = &'a DSlice<f64, 2, Dense>;
+pub type BlockSlice2<'a, T> = &'a DSlice<T, 2, Dense>;
 
 /// View over 2D block data (strided layout, for permuted views).
-pub type BlockSliceStrided2<'a> = &'a DSlice<f64, 2, Strided>;
+pub type BlockSliceStrided2<'a, T> = &'a DSlice<T, 2, Strided>;
 
 /// Owned block data wrapped with Arc for sharing.
 #[derive(Debug, Clone)]
-pub struct BlockData {
-    tensor: Arc<BlockTensor2>,
+pub struct BlockData<T: Scalar> {
+    tensor: Arc<BlockTensor2<T>>,
+    _marker: PhantomData<T>,
 }
 
-impl BlockData {
+impl<T: Scalar> BlockData<T> {
     /// Create a new block from data and shape.
     ///
     /// # Arguments
@@ -34,7 +38,7 @@ impl BlockData {
     ///
     /// # Panics
     /// Panics if data length doesn't match shape.
-    pub fn new(data: Vec<f64>, shape: [usize; 2]) -> Self {
+    pub fn new(data: Vec<T>, shape: [usize; 2]) -> Self {
         let expected_len = shape[0] * shape[1];
         assert_eq!(
             data.len(),
@@ -46,25 +50,27 @@ impl BlockData {
         );
 
         // Create tensor using from_fn to ensure row-major order
-        let tensor: BlockTensor2 = DTensor::<f64, 2>::from_fn(shape, |idx| {
+        let tensor: BlockTensor2<T> = DTensor::<T, 2>::from_fn(shape, |idx| {
             let linear = idx[0] * shape[1] + idx[1];
             data[linear]
         });
 
         Self {
             tensor: Arc::new(tensor),
+            _marker: PhantomData,
         }
     }
 
-    /// Create a scalar block (1×1).
-    pub fn scalar(value: f64) -> Self {
+    /// Create a scalar block (1x1).
+    pub fn scalar(value: T) -> Self {
         Self::new(vec![value], [1, 1])
     }
 
     /// Create a block from an existing DTensor.
-    pub fn from_tensor(tensor: BlockTensor2) -> Self {
+    pub fn from_tensor(tensor: BlockTensor2<T>) -> Self {
         Self {
             tensor: Arc::new(tensor),
+            _marker: PhantomData,
         }
     }
 
@@ -95,17 +101,17 @@ impl BlockData {
     }
 
     /// Get a view (slice) of this block.
-    pub fn as_slice(&self) -> &DSlice<f64, 2, Dense> {
+    pub fn as_slice(&self) -> &DSlice<T, 2, Dense> {
         self.tensor.as_ref()
     }
 
     /// Get the underlying tensor reference.
-    pub fn as_tensor(&self) -> &BlockTensor2 {
+    pub fn as_tensor(&self) -> &BlockTensor2<T> {
         &self.tensor
     }
 
     /// Get element at [i, j].
-    pub fn get(&self, idx: [usize; 2]) -> f64 {
+    pub fn get(&self, idx: [usize; 2]) -> T {
         self.tensor[idx]
     }
 
@@ -113,14 +119,15 @@ impl BlockData {
     ///
     /// Returns an owned BlockData with transposed data.
     /// For zero-copy transpose, use `as_slice().t()` directly.
-    pub fn transpose(&self) -> BlockData {
+    pub fn transpose(&self) -> BlockData<T> {
         let [m, n] = self.shape();
-        let transposed: BlockTensor2 = DTensor::<f64, 2>::from_fn([n, m], |idx| self.tensor[[idx[1], idx[0]]]);
+        let transposed: BlockTensor2<T> =
+            DTensor::<T, 2>::from_fn([n, m], |idx| self.tensor[[idx[1], idx[0]]]);
         Self::from_tensor(transposed)
     }
 
     /// Convert to Vec in row-major order.
-    pub fn to_vec(&self) -> Vec<f64> {
+    pub fn to_vec(&self) -> Vec<T> {
         let [m, n] = self.shape();
         let mut result = Vec::with_capacity(m * n);
         for i in 0..m {
@@ -135,19 +142,18 @@ impl BlockData {
     ///
     /// # Panics
     /// Panics if shapes don't match.
-    pub fn add(&self, other: &BlockData) -> BlockData {
+    pub fn add(&self, other: &BlockData<T>) -> BlockData<T> {
         assert_eq!(self.shape(), other.shape(), "Shape mismatch in add");
         let [m, n] = self.shape();
-        let result: BlockTensor2 = DTensor::<f64, 2>::from_fn([m, n], |idx| {
-            self.tensor[idx] + other.tensor[idx]
-        });
+        let result: BlockTensor2<T> =
+            DTensor::<T, 2>::from_fn([m, n], |idx| self.tensor[idx] + other.tensor[idx]);
         Self::from_tensor(result)
     }
 }
 
 // For convenient creation from Vec with shape
-impl From<(Vec<f64>, [usize; 2])> for BlockData {
-    fn from((data, shape): (Vec<f64>, [usize; 2])) -> Self {
+impl<T: Scalar> From<(Vec<T>, [usize; 2])> for BlockData<T> {
+    fn from((data, shape): (Vec<T>, [usize; 2])) -> Self {
         Self::new(data, shape)
     }
 }
@@ -155,11 +161,14 @@ impl From<(Vec<f64>, [usize; 2])> for BlockData {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use num_complex::Complex64;
 
-    #[test]
-    fn test_block_data_new() {
-        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let block = BlockData::new(data, [2, 3]);
+    fn test_block_data_new_generic<T: Scalar>() {
+        let data: Vec<T> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+            .into_iter()
+            .map(T::from_f64)
+            .collect();
+        let block = BlockData::<T>::new(data, [2, 3]);
 
         assert_eq!(block.shape(), [2, 3]);
         assert_eq!(block.nrows(), 2);
@@ -168,67 +177,169 @@ mod tests {
     }
 
     #[test]
-    fn test_block_data_scalar() {
-        let block = BlockData::scalar(42.0);
+    fn test_block_data_new_f64() {
+        test_block_data_new_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_data_new_c64() {
+        test_block_data_new_generic::<Complex64>();
+    }
+
+    fn test_block_data_scalar_generic<T: Scalar>() {
+        let block = BlockData::<T>::scalar(T::from_f64(42.0));
 
         assert_eq!(block.shape(), [1, 1]);
         assert_eq!(block.len(), 1);
-        assert_eq!(block.get([0, 0]), 42.0);
+        assert_eq!(block.get([0, 0]), T::from_f64(42.0));
     }
 
     #[test]
-    fn test_block_data_get() {
+    fn test_block_data_scalar_f64() {
+        test_block_data_scalar_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_data_scalar_c64() {
+        test_block_data_scalar_generic::<Complex64>();
+    }
+
+    fn test_block_data_get_generic<T: Scalar>() {
         // Row-major: [[1, 2, 3], [4, 5, 6]]
-        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let block = BlockData::new(data, [2, 3]);
+        let data: Vec<T> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+            .into_iter()
+            .map(T::from_f64)
+            .collect();
+        let block = BlockData::<T>::new(data, [2, 3]);
 
-        assert_eq!(block.get([0, 0]), 1.0);
-        assert_eq!(block.get([0, 2]), 3.0);
-        assert_eq!(block.get([1, 0]), 4.0);
-        assert_eq!(block.get([1, 2]), 6.0);
+        assert_eq!(block.get([0, 0]), T::from_f64(1.0));
+        assert_eq!(block.get([0, 2]), T::from_f64(3.0));
+        assert_eq!(block.get([1, 0]), T::from_f64(4.0));
+        assert_eq!(block.get([1, 2]), T::from_f64(6.0));
     }
 
     #[test]
-    fn test_block_data_transpose() {
+    fn test_block_data_get_f64() {
+        test_block_data_get_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_data_get_c64() {
+        test_block_data_get_generic::<Complex64>();
+    }
+
+    fn test_block_data_transpose_generic<T: Scalar>() {
         // [[1, 2, 3], [4, 5, 6]] -> [[1, 4], [2, 5], [3, 6]]
-        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let block = BlockData::new(data, [2, 3]);
+        let data: Vec<T> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+            .into_iter()
+            .map(T::from_f64)
+            .collect();
+        let block = BlockData::<T>::new(data, [2, 3]);
         let transposed = block.transpose();
 
         assert_eq!(transposed.shape(), [3, 2]);
-        assert_eq!(transposed.get([0, 0]), 1.0);
-        assert_eq!(transposed.get([0, 1]), 4.0);
-        assert_eq!(transposed.get([1, 0]), 2.0);
-        assert_eq!(transposed.get([2, 1]), 6.0);
+        assert_eq!(transposed.get([0, 0]), T::from_f64(1.0));
+        assert_eq!(transposed.get([0, 1]), T::from_f64(4.0));
+        assert_eq!(transposed.get([1, 0]), T::from_f64(2.0));
+        assert_eq!(transposed.get([2, 1]), T::from_f64(6.0));
     }
 
     #[test]
-    fn test_block_data_add() {
-        let a = BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]);
-        let b = BlockData::new(vec![10.0, 20.0, 30.0, 40.0], [2, 2]);
+    fn test_block_data_transpose_f64() {
+        test_block_data_transpose_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_data_transpose_c64() {
+        test_block_data_transpose_generic::<Complex64>();
+    }
+
+    fn test_block_data_add_generic<T: Scalar>() {
+        let a = BlockData::<T>::new(
+            vec![1.0, 2.0, 3.0, 4.0]
+                .into_iter()
+                .map(T::from_f64)
+                .collect(),
+            [2, 2],
+        );
+        let b = BlockData::<T>::new(
+            vec![10.0, 20.0, 30.0, 40.0]
+                .into_iter()
+                .map(T::from_f64)
+                .collect(),
+            [2, 2],
+        );
         let c = a.add(&b);
 
-        assert_eq!(c.get([0, 0]), 11.0);
-        assert_eq!(c.get([0, 1]), 22.0);
-        assert_eq!(c.get([1, 0]), 33.0);
-        assert_eq!(c.get([1, 1]), 44.0);
+        assert_eq!(c.get([0, 0]), T::from_f64(11.0));
+        assert_eq!(c.get([0, 1]), T::from_f64(22.0));
+        assert_eq!(c.get([1, 0]), T::from_f64(33.0));
+        assert_eq!(c.get([1, 1]), T::from_f64(44.0));
     }
 
     #[test]
-    fn test_block_data_to_vec() {
-        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let block = BlockData::new(data.clone(), [2, 3]);
+    fn test_block_data_add_f64() {
+        test_block_data_add_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_data_add_c64() {
+        test_block_data_add_generic::<Complex64>();
+    }
+
+    fn test_block_data_to_vec_generic<T: Scalar>() {
+        let data: Vec<T> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+            .into_iter()
+            .map(T::from_f64)
+            .collect();
+        let block = BlockData::<T>::new(data.clone(), [2, 3]);
 
         assert_eq!(block.to_vec(), data);
     }
 
     #[test]
-    fn test_as_slice() {
-        let block = BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]);
+    fn test_block_data_to_vec_f64() {
+        test_block_data_to_vec_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_data_to_vec_c64() {
+        test_block_data_to_vec_generic::<Complex64>();
+    }
+
+    fn test_as_slice_generic<T: Scalar>() {
+        let block = BlockData::<T>::new(
+            vec![1.0, 2.0, 3.0, 4.0]
+                .into_iter()
+                .map(T::from_f64)
+                .collect(),
+            [2, 2],
+        );
         let slice = block.as_slice();
 
         // Access via mdarray slice
-        assert_eq!(slice[[0, 0]], 1.0);
-        assert_eq!(slice[[1, 1]], 4.0);
+        assert_eq!(slice[[0, 0]], T::from_f64(1.0));
+        assert_eq!(slice[[1, 1]], T::from_f64(4.0));
+    }
+
+    #[test]
+    fn test_as_slice_f64() {
+        test_as_slice_generic::<f64>();
+    }
+
+    #[test]
+    fn test_as_slice_c64() {
+        test_as_slice_generic::<Complex64>();
+    }
+
+    #[test]
+    fn test_complex_specific() {
+        // Test complex-specific behavior
+        let z1 = Complex64::new(1.0, 2.0);
+        let z2 = Complex64::new(3.0, 4.0);
+        let block = BlockData::<Complex64>::new(vec![z1, z2], [1, 2]);
+
+        assert_eq!(block.get([0, 0]), z1);
+        assert_eq!(block.get([0, 1]), z2);
     }
 }

--- a/crates/blocked-mdarray/src/lib.rs
+++ b/crates/blocked-mdarray/src/lib.rs
@@ -11,11 +11,13 @@
 //! - Transposition returns views (no data copy)
 //! - Data is only copied when materialized via `to_owned()`
 //! - Blocks are stored in a sparse HashMap
+//! - Generic over scalar type `T` (f64, Complex64, etc.)
 //!
 //! # Core Types
 //!
+//! - [`Scalar`]: Trait for scalar types (f64, Complex64)
 //! - [`BlockPartition`]: Defines how an axis is divided into blocks
-//! - [`BlockData`]: Owned 2D block data (wraps mdarray's `DTensor<f64, 2>`)
+//! - [`BlockData`]: Owned 2D block data (wraps mdarray's `DTensor<T, 2>`)
 //! - [`BlockedArray`]: Owned blocked array
 //! - [`BlockedView`]: Borrowed view (supports lazy transposition)
 //!
@@ -24,12 +26,12 @@
 //! ```
 //! use blocked_mdarray::{BlockPartition, BlockedArray, BlockData, blocked_matmul};
 //!
-//! // Create a 4x4 matrix split into 2x2 blocks
+//! // Create a 4x4 matrix split into 2x2 blocks (f64)
 //! let parts = vec![
 //!     BlockPartition::uniform(2, 2),
 //!     BlockPartition::uniform(2, 2),
 //! ];
-//! let mut matrix = BlockedArray::new(parts);
+//! let mut matrix = BlockedArray::<f64>::new(parts);
 //!
 //! // Set only diagonal blocks (block-diagonal matrix)
 //! matrix.set_block(vec![0, 0], BlockData::new(vec![1.0, 0.0, 0.0, 1.0], [2, 2]));
@@ -39,15 +41,43 @@
 //! let result = blocked_matmul(&matrix, &matrix).unwrap();
 //! assert_eq!(result.num_nonzero_blocks(), 2);
 //! ```
+//!
+//! # Complex64 Example
+//!
+//! ```
+//! use blocked_mdarray::{BlockPartition, BlockedArray, BlockData, blocked_matmul};
+//! use num_complex::Complex64;
+//!
+//! // Create a complex blocked array
+//! let parts = vec![
+//!     BlockPartition::trivial(2),
+//!     BlockPartition::trivial(2),
+//! ];
+//! let mut matrix = BlockedArray::<Complex64>::new(parts);
+//!
+//! // Set with complex values
+//! matrix.set_block(
+//!     vec![0, 0],
+//!     BlockData::new(
+//!         vec![
+//!             Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0),
+//!             Complex64::new(0.0, -1.0), Complex64::new(1.0, 0.0),
+//!         ],
+//!         [2, 2],
+//!     ),
+//! );
+//! ```
 
 mod block_data;
 mod blocked_array;
 mod error;
 mod matmul;
 mod partition;
+mod scalar;
 
 pub use block_data::{BlockData, BlockSlice2, BlockSliceStrided2, BlockTensor2};
 pub use blocked_array::{BlockedArray, BlockedArrayLike, BlockedView};
 pub use error::{BlockedArrayError, Result};
 pub use matmul::blocked_matmul;
 pub use partition::{block_linear_index, block_multi_index, BlockIndex, BlockPartition};
+pub use scalar::Scalar;

--- a/crates/blocked-mdarray/src/matmul.rs
+++ b/crates/blocked-mdarray/src/matmul.rs
@@ -9,13 +9,17 @@ use mdarray_linalg_faer::Faer;
 use crate::block_data::{BlockData, BlockTensor2};
 use crate::blocked_array::{BlockedArray, BlockedArrayLike};
 use crate::error::{BlockedArrayError, Result};
+use crate::scalar::Scalar;
 
 /// Build index of non-zero blocks grouped by a specific axis.
 ///
 /// For a 2D blocked array, returns a map from axis index to list of other-axis indices.
 /// - `group_by_axis=0`: groups by row, returns `row -> [cols with non-zero blocks]`
 /// - `group_by_axis=1`: groups by col, returns `col -> [rows with non-zero blocks]`
-fn build_nonzero_index<A: BlockedArrayLike>(arr: &A, group_by_axis: usize) -> HashMap<usize, Vec<usize>> {
+fn build_nonzero_index<T: Scalar, A: BlockedArrayLike<T>>(
+    arr: &A,
+    group_by_axis: usize,
+) -> HashMap<usize, Vec<usize>> {
     let mut index: HashMap<usize, Vec<usize>> = HashMap::new();
 
     for (block_idx, _) in arr.iter_nonzero_blocks() {
@@ -48,10 +52,11 @@ fn build_nonzero_index<A: BlockedArrayLike>(arr: &A, group_by_axis: usize) -> Ha
 /// # Errors
 /// - Returns `BlockedArrayError::NotMatrix` if inputs are not 2D.
 /// - Returns `BlockedArrayError::IncompatiblePartitions` if inner partitions don't match.
-pub fn blocked_matmul<A, B>(a: &A, b: &B) -> Result<BlockedArray>
+pub fn blocked_matmul<T, A, B>(a: &A, b: &B) -> Result<BlockedArray<T>>
 where
-    A: BlockedArrayLike,
-    B: BlockedArrayLike,
+    T: Scalar,
+    A: BlockedArrayLike<T>,
+    B: BlockedArrayLike<T>,
 {
     // Check: must be 2D
     if a.rank() != 2 {
@@ -108,10 +113,10 @@ where
 /// Multiply two blocks (2D matrices).
 ///
 /// Handles three cases for efficiency:
-/// - Case 1: scalar × scalar (both 1×1)
-/// - Case 2: scalar × dense or dense × scalar → scaling operation
-/// - Case 3: dense × dense → delegates to mdarray-linalg (Faer backend)
-fn block_matmul(a: &BlockData, b: &BlockData) -> Result<BlockData> {
+/// - Case 1: scalar x scalar (both 1x1)
+/// - Case 2: scalar x dense or dense x scalar -> scaling operation
+/// - Case 3: dense x dense -> delegates to mdarray-linalg (Faer backend)
+fn block_matmul<T: Scalar>(a: &BlockData<T>, b: &BlockData<T>) -> Result<BlockData<T>> {
     let [m, k1] = a.shape();
     let [k2, n] = b.shape();
 
@@ -124,27 +129,29 @@ fn block_matmul(a: &BlockData, b: &BlockData) -> Result<BlockData> {
 
     let k = k1;
 
-    // Case 1: scalar × scalar (both 1×1)
+    // Case 1: scalar x scalar (both 1x1)
     if m == 1 && k == 1 && n == 1 {
         let result = a.get([0, 0]) * b.get([0, 0]);
         return Ok(BlockData::scalar(result));
     }
 
-    // Case 2: scalar × dense (a is 1×1)
+    // Case 2: scalar x dense (a is 1x1)
     if m == 1 && k == 1 {
         let scalar = a.get([0, 0]);
-        let result: BlockTensor2 = DTensor::<f64, 2>::from_fn([1, n], |idx| scalar * b.get([0, idx[1]]));
+        let result: BlockTensor2<T> =
+            DTensor::<T, 2>::from_fn([1, n], |idx| scalar * b.get([0, idx[1]]));
         return Ok(BlockData::from_tensor(result));
     }
 
-    // Case 2: dense × scalar (b is 1×1)
+    // Case 2: dense x scalar (b is 1x1)
     if k == 1 && n == 1 {
         let scalar = b.get([0, 0]);
-        let result: BlockTensor2 = DTensor::<f64, 2>::from_fn([m, 1], |idx| a.get([idx[0], 0]) * scalar);
+        let result: BlockTensor2<T> =
+            DTensor::<T, 2>::from_fn([m, 1], |idx| a.get([idx[0], 0]) * scalar);
         return Ok(BlockData::from_tensor(result));
     }
 
-    // Case 3: dense × dense - delegate to mdarray-linalg
+    // Case 3: dense x dense - delegate to mdarray-linalg
     // Use mdarray slices directly with Faer backend
     let a_slice = a.as_slice();
     let b_slice = b.as_slice();
@@ -159,9 +166,9 @@ mod tests {
     use super::*;
     use crate::blocked_array::BlockedArray;
     use crate::partition::BlockPartition;
+    use num_complex::Complex64;
 
-    #[test]
-    fn test_blocked_matmul_identity() {
+    fn test_blocked_matmul_identity_generic<T: Scalar>() {
         // Identity matrix @ vector
         // [1 0] @ [a] = [a]
         // [0 1]   [b]   [b]
@@ -170,29 +177,38 @@ mod tests {
             BlockPartition::uniform(1, 2),
             BlockPartition::uniform(1, 2),
         ];
-        let mut a = BlockedArray::new(a_parts);
-        a.set_block(vec![0, 0], BlockData::scalar(1.0));
-        a.set_block(vec![1, 1], BlockData::scalar(1.0));
+        let mut a = BlockedArray::<T>::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::scalar(T::from_f64(1.0)));
+        a.set_block(vec![1, 1], BlockData::scalar(T::from_f64(1.0)));
 
         let b_parts = vec![
             BlockPartition::uniform(1, 2),
             BlockPartition::trivial(1),
         ];
-        let mut b = BlockedArray::new(b_parts);
-        b.set_block(vec![0, 0], BlockData::scalar(3.0));
-        b.set_block(vec![1, 0], BlockData::scalar(5.0));
+        let mut b = BlockedArray::<T>::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::scalar(T::from_f64(3.0)));
+        b.set_block(vec![1, 0], BlockData::scalar(T::from_f64(5.0)));
 
         let c = blocked_matmul(&a, &b).unwrap();
 
         assert_eq!(c.shape(), vec![2, 1]);
         let c00 = c.get_block(&vec![0, 0]).unwrap();
         let c10 = c.get_block(&vec![1, 0]).unwrap();
-        assert_eq!(c00.get([0, 0]), 3.0);
-        assert_eq!(c10.get([0, 0]), 5.0);
+        assert_eq!(c00.get([0, 0]), T::from_f64(3.0));
+        assert_eq!(c10.get([0, 0]), T::from_f64(5.0));
     }
 
     #[test]
-    fn test_blocked_matmul_simple() {
+    fn test_blocked_matmul_identity_f64() {
+        test_blocked_matmul_identity_generic::<f64>();
+    }
+
+    #[test]
+    fn test_blocked_matmul_identity_c64() {
+        test_blocked_matmul_identity_generic::<Complex64>();
+    }
+
+    fn test_blocked_matmul_simple_generic<T: Scalar>() {
         // [1 2] @ [5 6] = [1*5+2*7  1*6+2*8] = [19 22]
         // [3 4]   [7 8]   [3*5+4*7  3*6+4*8]   [43 50]
 
@@ -201,29 +217,50 @@ mod tests {
             BlockPartition::trivial(2),
         ];
 
-        let mut a = BlockedArray::new(parts.clone());
+        let mut a = BlockedArray::<T>::new(parts.clone());
         a.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]),
+            BlockData::new(
+                vec![1.0, 2.0, 3.0, 4.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         );
 
-        let mut b = BlockedArray::new(parts.clone());
+        let mut b = BlockedArray::<T>::new(parts.clone());
         b.set_block(
             vec![0, 0],
-            BlockData::new(vec![5.0, 6.0, 7.0, 8.0], [2, 2]),
+            BlockData::new(
+                vec![5.0, 6.0, 7.0, 8.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         );
 
         let c = blocked_matmul(&a, &b).unwrap();
 
         let c_block = c.get_block(&vec![0, 0]).unwrap();
-        assert_eq!(c_block.get([0, 0]), 19.0);
-        assert_eq!(c_block.get([0, 1]), 22.0);
-        assert_eq!(c_block.get([1, 0]), 43.0);
-        assert_eq!(c_block.get([1, 1]), 50.0);
+        assert_eq!(c_block.get([0, 0]), T::from_f64(19.0));
+        assert_eq!(c_block.get([0, 1]), T::from_f64(22.0));
+        assert_eq!(c_block.get([1, 0]), T::from_f64(43.0));
+        assert_eq!(c_block.get([1, 1]), T::from_f64(50.0));
     }
 
     #[test]
-    fn test_blocked_matmul_sparse() {
+    fn test_blocked_matmul_simple_f64() {
+        test_blocked_matmul_simple_generic::<f64>();
+    }
+
+    #[test]
+    fn test_blocked_matmul_simple_c64() {
+        test_blocked_matmul_simple_generic::<Complex64>();
+    }
+
+    fn test_blocked_matmul_sparse_generic<T: Scalar>() {
         // Block-diagonal matrix @ Block-diagonal matrix
         // [A 0] @ [C 0] = [AC  0]
         // [0 B]   [0 D]   [ 0 BD]
@@ -233,24 +270,48 @@ mod tests {
             BlockPartition::uniform(2, 2),
         ];
 
-        let mut a = BlockedArray::new(parts.clone());
+        let mut a = BlockedArray::<T>::new(parts.clone());
         a.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 2.0, 3.0, 4.0], [2, 2]),
+            BlockData::new(
+                vec![1.0, 2.0, 3.0, 4.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         ); // A
         a.set_block(
             vec![1, 1],
-            BlockData::new(vec![5.0, 6.0, 7.0, 8.0], [2, 2]),
+            BlockData::new(
+                vec![5.0, 6.0, 7.0, 8.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         ); // B
 
-        let mut b = BlockedArray::new(parts.clone());
+        let mut b = BlockedArray::<T>::new(parts.clone());
         b.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 0.0, 0.0, 1.0], [2, 2]),
+            BlockData::new(
+                vec![1.0, 0.0, 0.0, 1.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         ); // C = I
         b.set_block(
             vec![1, 1],
-            BlockData::new(vec![2.0, 0.0, 0.0, 2.0], [2, 2]),
+            BlockData::new(
+                vec![2.0, 0.0, 0.0, 2.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         ); // D = 2I
 
         let c = blocked_matmul(&a, &b).unwrap();
@@ -260,13 +321,13 @@ mod tests {
 
         // AC = A * I = A
         let c00 = c.get_block(&vec![0, 0]).unwrap();
-        assert_eq!(c00.get([0, 0]), 1.0);
-        assert_eq!(c00.get([1, 1]), 4.0);
+        assert_eq!(c00.get([0, 0]), T::from_f64(1.0));
+        assert_eq!(c00.get([1, 1]), T::from_f64(4.0));
 
         // BD = B * 2I = 2B
         let c11 = c.get_block(&vec![1, 1]).unwrap();
-        assert_eq!(c11.get([0, 0]), 10.0);
-        assert_eq!(c11.get([1, 1]), 16.0);
+        assert_eq!(c11.get([0, 0]), T::from_f64(10.0));
+        assert_eq!(c11.get([1, 1]), T::from_f64(16.0));
 
         // Zero blocks
         assert!(c.get_block(&vec![0, 1]).is_none());
@@ -274,7 +335,16 @@ mod tests {
     }
 
     #[test]
-    fn test_blocked_matmul_transposed() {
+    fn test_blocked_matmul_sparse_f64() {
+        test_blocked_matmul_sparse_generic::<f64>();
+    }
+
+    #[test]
+    fn test_blocked_matmul_sparse_c64() {
+        test_blocked_matmul_sparse_generic::<Complex64>();
+    }
+
+    fn test_blocked_matmul_transposed_generic<T: Scalar>() {
         // Test with transposed input
         // A^T @ B where A is stored and we use transpose view
 
@@ -283,23 +353,35 @@ mod tests {
             BlockPartition::trivial(2),
         ];
 
-        let mut a = BlockedArray::new(parts.clone());
+        let mut a = BlockedArray::<T>::new(parts.clone());
         // A = [1 3]
         //     [2 4]
         // Stored as row-major: [1, 3, 2, 4]
         a.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 3.0, 2.0, 4.0], [2, 2]),
+            BlockData::new(
+                vec![1.0, 3.0, 2.0, 4.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         );
 
         // A^T = [1 2]
         //       [3 4]
         let a_t = a.transpose();
 
-        let mut b = BlockedArray::new(parts.clone());
+        let mut b = BlockedArray::<T>::new(parts.clone());
         b.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 0.0, 0.0, 1.0], [2, 2]),
+            BlockData::new(
+                vec![1.0, 0.0, 0.0, 1.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 2],
+            ),
         ); // Identity
 
         let c = blocked_matmul(&a_t, &b).unwrap();
@@ -307,10 +389,20 @@ mod tests {
         let c_block = c.get_block(&vec![0, 0]).unwrap();
         // A^T @ I = A^T = [1 2]
         //                 [3 4]
-        assert_eq!(c_block.get([0, 0]), 1.0);
-        assert_eq!(c_block.get([0, 1]), 2.0);
-        assert_eq!(c_block.get([1, 0]), 3.0);
-        assert_eq!(c_block.get([1, 1]), 4.0);
+        assert_eq!(c_block.get([0, 0]), T::from_f64(1.0));
+        assert_eq!(c_block.get([0, 1]), T::from_f64(2.0));
+        assert_eq!(c_block.get([1, 0]), T::from_f64(3.0));
+        assert_eq!(c_block.get([1, 1]), T::from_f64(4.0));
+    }
+
+    #[test]
+    fn test_blocked_matmul_transposed_f64() {
+        test_blocked_matmul_transposed_generic::<f64>();
+    }
+
+    #[test]
+    fn test_blocked_matmul_transposed_c64() {
+        test_blocked_matmul_transposed_generic::<Complex64>();
     }
 
     #[test]
@@ -319,13 +411,13 @@ mod tests {
             BlockPartition::uniform(2, 2),
             BlockPartition::uniform(3, 2), // Inner dim: 6
         ];
-        let a = BlockedArray::new(a_parts);
+        let a = BlockedArray::<f64>::new(a_parts);
 
         let b_parts = vec![
             BlockPartition::uniform(4, 2), // Inner dim: 8 (mismatch!)
             BlockPartition::uniform(2, 2),
         ];
-        let b = BlockedArray::new(b_parts);
+        let b = BlockedArray::<f64>::new(b_parts);
 
         let result = blocked_matmul(&a, &b);
         assert!(matches!(
@@ -334,58 +426,84 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_block_matmul_scalar_times_scalar() {
-        // Case 1: 1×1 × 1×1 = 1×1
+    fn test_block_matmul_scalar_times_scalar_generic<T: Scalar>() {
+        // Case 1: 1x1 x 1x1 = 1x1
         // [3] @ [4] = [12]
         let a_parts = vec![
             BlockPartition::trivial(1),
             BlockPartition::trivial(1),
         ];
-        let mut a = BlockedArray::new(a_parts);
-        a.set_block(vec![0, 0], BlockData::scalar(3.0));
+        let mut a = BlockedArray::<T>::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::scalar(T::from_f64(3.0)));
 
         let b_parts = vec![
             BlockPartition::trivial(1),
             BlockPartition::trivial(1),
         ];
-        let mut b = BlockedArray::new(b_parts);
-        b.set_block(vec![0, 0], BlockData::scalar(4.0));
+        let mut b = BlockedArray::<T>::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::scalar(T::from_f64(4.0)));
 
         let c = blocked_matmul(&a, &b).unwrap();
         let c_block = c.get_block(&vec![0, 0]).unwrap();
-        assert_eq!(c_block.get([0, 0]), 12.0);
+        assert_eq!(c_block.get([0, 0]), T::from_f64(12.0));
     }
 
     #[test]
-    fn test_block_matmul_scalar_times_dense() {
-        // Case 2a: 1×1 × 1×3 = 1×3
+    fn test_block_matmul_scalar_times_scalar_f64() {
+        test_block_matmul_scalar_times_scalar_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_matmul_scalar_times_scalar_c64() {
+        test_block_matmul_scalar_times_scalar_generic::<Complex64>();
+    }
+
+    fn test_block_matmul_scalar_times_dense_generic<T: Scalar>() {
+        // Case 2a: 1x1 x 1x3 = 1x3
         // [2] @ [1 2 3] = [2 4 6]
         let a_parts = vec![
             BlockPartition::trivial(1),
             BlockPartition::trivial(1),
         ];
-        let mut a = BlockedArray::new(a_parts);
-        a.set_block(vec![0, 0], BlockData::scalar(2.0));
+        let mut a = BlockedArray::<T>::new(a_parts);
+        a.set_block(vec![0, 0], BlockData::scalar(T::from_f64(2.0)));
 
         let b_parts = vec![
             BlockPartition::trivial(1),
             BlockPartition::trivial(3),
         ];
-        let mut b = BlockedArray::new(b_parts);
-        b.set_block(vec![0, 0], BlockData::new(vec![1.0, 2.0, 3.0], [1, 3]));
+        let mut b = BlockedArray::<T>::new(b_parts);
+        b.set_block(
+            vec![0, 0],
+            BlockData::new(
+                vec![1.0, 2.0, 3.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [1, 3],
+            ),
+        );
 
         let c = blocked_matmul(&a, &b).unwrap();
         let c_block = c.get_block(&vec![0, 0]).unwrap();
         assert_eq!(c_block.shape(), [1, 3]);
-        assert_eq!(c_block.get([0, 0]), 2.0);
-        assert_eq!(c_block.get([0, 1]), 4.0);
-        assert_eq!(c_block.get([0, 2]), 6.0);
+        assert_eq!(c_block.get([0, 0]), T::from_f64(2.0));
+        assert_eq!(c_block.get([0, 1]), T::from_f64(4.0));
+        assert_eq!(c_block.get([0, 2]), T::from_f64(6.0));
     }
 
     #[test]
-    fn test_block_matmul_dense_times_scalar() {
-        // Case 2b: 3×1 × 1×1 = 3×1
+    fn test_block_matmul_scalar_times_dense_f64() {
+        test_block_matmul_scalar_times_dense_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_matmul_scalar_times_dense_c64() {
+        test_block_matmul_scalar_times_dense_generic::<Complex64>();
+    }
+
+    fn test_block_matmul_dense_times_scalar_generic<T: Scalar>() {
+        // Case 2b: 3x1 x 1x1 = 3x1
         // [1]     [2]
         // [2] @ [2] = [4]
         // [3]     [6]
@@ -393,27 +511,45 @@ mod tests {
             BlockPartition::trivial(3),
             BlockPartition::trivial(1),
         ];
-        let mut a = BlockedArray::new(a_parts);
-        a.set_block(vec![0, 0], BlockData::new(vec![1.0, 2.0, 3.0], [3, 1]));
+        let mut a = BlockedArray::<T>::new(a_parts);
+        a.set_block(
+            vec![0, 0],
+            BlockData::new(
+                vec![1.0, 2.0, 3.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [3, 1],
+            ),
+        );
 
         let b_parts = vec![
             BlockPartition::trivial(1),
             BlockPartition::trivial(1),
         ];
-        let mut b = BlockedArray::new(b_parts);
-        b.set_block(vec![0, 0], BlockData::scalar(2.0));
+        let mut b = BlockedArray::<T>::new(b_parts);
+        b.set_block(vec![0, 0], BlockData::scalar(T::from_f64(2.0)));
 
         let c = blocked_matmul(&a, &b).unwrap();
         let c_block = c.get_block(&vec![0, 0]).unwrap();
         assert_eq!(c_block.shape(), [3, 1]);
-        assert_eq!(c_block.get([0, 0]), 2.0);
-        assert_eq!(c_block.get([1, 0]), 4.0);
-        assert_eq!(c_block.get([2, 0]), 6.0);
+        assert_eq!(c_block.get([0, 0]), T::from_f64(2.0));
+        assert_eq!(c_block.get([1, 0]), T::from_f64(4.0));
+        assert_eq!(c_block.get([2, 0]), T::from_f64(6.0));
     }
 
     #[test]
-    fn test_block_matmul_dense_times_dense_with_faer() {
-        // Case 3: 3×2 × 2×4 = 3×4 (uses mdarray-linalg/Faer)
+    fn test_block_matmul_dense_times_scalar_f64() {
+        test_block_matmul_dense_times_scalar_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_matmul_dense_times_scalar_c64() {
+        test_block_matmul_dense_times_scalar_generic::<Complex64>();
+    }
+
+    fn test_block_matmul_dense_times_dense_with_faer_generic<T: Scalar>() {
+        // Case 3: 3x2 x 2x4 = 3x4 (uses mdarray-linalg/Faer)
         // [1 2]   [1 2 3 4]   [1+10 2+12 3+14 4+16]   [11 14 17 20]
         // [3 4] @ [5 6 7 8] = [3+20 6+24 9+28 12+32] = [23 30 37 44]
         // [5 6]               [5+30 10+36 15+42 20+48] [35 46 57 68]
@@ -421,20 +557,32 @@ mod tests {
             BlockPartition::trivial(3),
             BlockPartition::trivial(2),
         ];
-        let mut a = BlockedArray::new(a_parts);
+        let mut a = BlockedArray::<T>::new(a_parts);
         a.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [3, 2]),
+            BlockData::new(
+                vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [3, 2],
+            ),
         );
 
         let b_parts = vec![
             BlockPartition::trivial(2),
             BlockPartition::trivial(4),
         ];
-        let mut b = BlockedArray::new(b_parts);
+        let mut b = BlockedArray::<T>::new(b_parts);
         b.set_block(
             vec![0, 0],
-            BlockData::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], [2, 4]),
+            BlockData::new(
+                vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+                    .into_iter()
+                    .map(T::from_f64)
+                    .collect(),
+                [2, 4],
+            ),
         );
 
         let c = blocked_matmul(&a, &b).unwrap();
@@ -442,21 +590,62 @@ mod tests {
         assert_eq!(c_block.shape(), [3, 4]);
 
         // First row: [1,2] @ [[1,2,3,4],[5,6,7,8]] = [11, 14, 17, 20]
-        assert_eq!(c_block.get([0, 0]), 11.0);
-        assert_eq!(c_block.get([0, 1]), 14.0);
-        assert_eq!(c_block.get([0, 2]), 17.0);
-        assert_eq!(c_block.get([0, 3]), 20.0);
+        assert_eq!(c_block.get([0, 0]), T::from_f64(11.0));
+        assert_eq!(c_block.get([0, 1]), T::from_f64(14.0));
+        assert_eq!(c_block.get([0, 2]), T::from_f64(17.0));
+        assert_eq!(c_block.get([0, 3]), T::from_f64(20.0));
 
         // Second row: [3,4] @ [[1,2,3,4],[5,6,7,8]] = [23, 30, 37, 44]
-        assert_eq!(c_block.get([1, 0]), 23.0);
-        assert_eq!(c_block.get([1, 1]), 30.0);
-        assert_eq!(c_block.get([1, 2]), 37.0);
-        assert_eq!(c_block.get([1, 3]), 44.0);
+        assert_eq!(c_block.get([1, 0]), T::from_f64(23.0));
+        assert_eq!(c_block.get([1, 1]), T::from_f64(30.0));
+        assert_eq!(c_block.get([1, 2]), T::from_f64(37.0));
+        assert_eq!(c_block.get([1, 3]), T::from_f64(44.0));
 
         // Third row: [5,6] @ [[1,2,3,4],[5,6,7,8]] = [35, 46, 57, 68]
-        assert_eq!(c_block.get([2, 0]), 35.0);
-        assert_eq!(c_block.get([2, 1]), 46.0);
-        assert_eq!(c_block.get([2, 2]), 57.0);
-        assert_eq!(c_block.get([2, 3]), 68.0);
+        assert_eq!(c_block.get([2, 0]), T::from_f64(35.0));
+        assert_eq!(c_block.get([2, 1]), T::from_f64(46.0));
+        assert_eq!(c_block.get([2, 2]), T::from_f64(57.0));
+        assert_eq!(c_block.get([2, 3]), T::from_f64(68.0));
+    }
+
+    #[test]
+    fn test_block_matmul_dense_times_dense_with_faer_f64() {
+        test_block_matmul_dense_times_dense_with_faer_generic::<f64>();
+    }
+
+    #[test]
+    fn test_block_matmul_dense_times_dense_with_faer_c64() {
+        test_block_matmul_dense_times_dense_with_faer_generic::<Complex64>();
+    }
+
+    #[test]
+    fn test_complex_matmul_with_imaginary() {
+        // Test complex multiplication with non-zero imaginary parts
+        // [1+i] @ [2-i] = (1+i)(2-i) = 2 - i + 2i + 1 = 3 + i
+        let a_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(1),
+        ];
+        let mut a = BlockedArray::<Complex64>::new(a_parts);
+        a.set_block(
+            vec![0, 0],
+            BlockData::scalar(Complex64::new(1.0, 1.0)),
+        );
+
+        let b_parts = vec![
+            BlockPartition::trivial(1),
+            BlockPartition::trivial(1),
+        ];
+        let mut b = BlockedArray::<Complex64>::new(b_parts);
+        b.set_block(
+            vec![0, 0],
+            BlockData::scalar(Complex64::new(2.0, -1.0)),
+        );
+
+        let c = blocked_matmul(&a, &b).unwrap();
+        let c_block = c.get_block(&vec![0, 0]).unwrap();
+        let result = c_block.get([0, 0]);
+        assert!((result.re - 3.0).abs() < 1e-10);
+        assert!((result.im - 1.0).abs() < 1e-10);
     }
 }

--- a/crates/blocked-mdarray/src/scalar.rs
+++ b/crates/blocked-mdarray/src/scalar.rs
@@ -1,0 +1,94 @@
+//! Scalar trait for generic block operations.
+//!
+//! This module defines the `Scalar` trait that abstracts over f64 and Complex64
+//! for blocked array operations.
+
+use std::fmt::Debug;
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use faer_traits::ComplexField;
+use num_complex::{Complex64, ComplexFloat};
+use num_traits::{MulAdd, One, Zero};
+
+/// Trait for scalar types used in blocked array operations.
+///
+/// This trait provides the minimal interface needed for block operations including
+/// matrix multiplication via the Faer backend.
+pub trait Scalar:
+    Clone
+    + Copy
+    + Debug
+    + Default
+    + PartialEq
+    + Zero
+    + One
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Neg<Output = Self>
+    + ComplexFloat
+    + ComplexField
+    + MulAdd<Output = Self>
+    + Send
+    + Sync
+    + 'static
+{
+    /// Create a scalar from f64.
+    fn from_f64(val: f64) -> Self;
+
+    /// Get the real part as f64.
+    fn real_f64(&self) -> f64;
+
+    /// Check if this type is complex.
+    fn is_complex_type() -> bool;
+}
+
+impl Scalar for f64 {
+    fn from_f64(val: f64) -> Self {
+        val
+    }
+
+    fn real_f64(&self) -> f64 {
+        *self
+    }
+
+    fn is_complex_type() -> bool {
+        false
+    }
+}
+
+impl Scalar for Complex64 {
+    fn from_f64(val: f64) -> Self {
+        Complex64::new(val, 0.0)
+    }
+
+    fn real_f64(&self) -> f64 {
+        self.re
+    }
+
+    fn is_complex_type() -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scalar_f64() {
+        let x: f64 = Scalar::from_f64(3.0);
+        assert_eq!(x, 3.0);
+        assert_eq!(x.real_f64(), 3.0);
+        assert!(!f64::is_complex_type());
+    }
+
+    #[test]
+    fn test_scalar_complex64() {
+        let z: Complex64 = Scalar::from_f64(3.0);
+        assert_eq!(z, Complex64::new(3.0, 0.0));
+        assert_eq!(z.real_f64(), 3.0);
+        assert!(Complex64::is_complex_type());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Scalar` trait for generic scalar operations (f64, Complex64)
- Make `BlockData<T>`, `BlockedArray<T>`, `BlockedView<T>` generic over scalar type
- Make `blocked_matmul` generic to support both real and complex matrix multiplication
- Add comprehensive tests for both f64 and Complex64 types

## Motivation
This change enables using blocked-mdarray for DiagTensor * DenseTensor contraction in tensor4all-core, supporting both real and complex tensors via the sparse * dense pattern.

## Test plan
- [x] All existing tests pass with f64
- [x] New generic tests pass with Complex64
- [x] Doc tests updated and pass
- [x] Complex-specific test for imaginary multiplication

🤖 Generated with [Claude Code](https://claude.ai/code)