### PR TITLE
Add split_to method for TreeTN structure transformation

### DIFF
--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -9,7 +9,7 @@ pub mod treetn;
 pub use dyn_treetn::{BoxedTensorLike, DynIndex, DynTreeTN};
 pub use named_graph::NamedGraph;
 pub use node_name_network::{CanonicalizeEdges, NodeNameNetwork};
-pub use options::{CanonicalizationOptions, TruncationOptions};
+pub use options::{CanonicalizationOptions, SplitOptions, TruncationOptions};
 pub use random::{random_treetn_c64, random_treetn_f64, LinkSpace};
 pub use site_index_network::SiteIndexNetwork;
 pub use treetn::{

--- a/crates/tensor4all-treetn/src/options.rs
+++ b/crates/tensor4all-treetn/src/options.rs
@@ -3,7 +3,7 @@
 //! Provides:
 //! - [`CanonicalizationOptions`]: Options for canonicalization
 //! - [`TruncationOptions`]: Options for truncation
-//! - [`CenterSpec`]: Trait for specifying canonical/truncation centers
+//! - [`SplitOptions`]: Options for split operations
 
 use tensor4all_core::CanonicalForm;
 
@@ -117,6 +117,70 @@ impl TruncationOptions {
     /// Set the canonical form / algorithm.
     pub fn with_form(mut self, form: CanonicalForm) -> Self {
         self.form = form;
+        self
+    }
+}
+
+/// Options for split operations.
+///
+/// # Builder Pattern
+///
+/// ```ignore
+/// let options = SplitOptions::default()
+///     .with_max_rank(50)
+///     .with_rtol(1e-10)
+///     .with_final_sweep(true);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct SplitOptions {
+    /// Canonical form / algorithm to use (SVD, QR, etc.)
+    pub form: CanonicalForm,
+    /// Relative tolerance for truncation (keep singular values > rtol * max_sv)
+    pub rtol: Option<f64>,
+    /// Maximum bond dimension
+    pub max_rank: Option<usize>,
+    /// Whether to perform a final sweep for global bond dimension optimization
+    pub final_sweep: bool,
+}
+
+impl Default for SplitOptions {
+    fn default() -> Self {
+        Self {
+            form: CanonicalForm::Unitary,
+            rtol: None,
+            max_rank: None,
+            final_sweep: false,
+        }
+    }
+}
+
+impl SplitOptions {
+    /// Create options with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create options with a maximum rank.
+    pub fn with_max_rank(mut self, rank: usize) -> Self {
+        self.max_rank = Some(rank);
+        self
+    }
+
+    /// Create options with a relative tolerance.
+    pub fn with_rtol(mut self, rtol: f64) -> Self {
+        self.rtol = Some(rtol);
+        self
+    }
+
+    /// Set the canonical form / algorithm.
+    pub fn with_form(mut self, form: CanonicalForm) -> Self {
+        self.form = form;
+        self
+    }
+
+    /// Enable or disable final sweep for global optimization.
+    pub fn with_final_sweep(mut self, final_sweep: bool) -> Self {
+        self.final_sweep = final_sweep;
         self
     }
 }

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides methods to transform a TreeTN's structure:
 //! - [`fuse_to`](TreeTN::fuse_to): Merge adjacent nodes to match a target structure
+//! - [`split_to`](TreeTN::split_to): Split nodes to match a target structure
 
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -9,10 +10,11 @@ use std::hash::Hash;
 use anyhow::{Context, Result};
 use petgraph::stable_graph::NodeIndex;
 
-use tensor4all_core::index::Symmetry;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::index::{DynId, NoSymmSpace, Symmetry};
+use tensor4all_core::{factorize, Canonical, FactorizeAlg, FactorizeOptions, TensorDynLen};
 
 use super::TreeTN;
+use crate::options::SplitOptions;
 use crate::site_index_network::SiteIndexNetwork;
 
 impl<Id, Symm, V> TreeTN<Id, Symm, V>
@@ -254,6 +256,234 @@ where
         tensors
             .remove(&root_idx)
             .ok_or_else(|| anyhow::anyhow!("Contraction produced no result at root"))
+    }
+
+    /// Split nodes to match the target structure.
+    ///
+    /// This operation splits nodes that contain site indices belonging to multiple
+    /// target nodes. The target structure must be a "refinement" of the current
+    /// structure: each current node's site indices should map to one or more
+    /// target nodes.
+    ///
+    /// # Algorithm (Two-Phase Approach)
+    ///
+    /// **Phase 1: Exact factorization (no truncation)**
+    /// 1. Build mapping: site index ID -> target node name
+    /// 2. For each current node, check if its site indices map to multiple target nodes
+    /// 3. If so, split the node using QR factorization
+    /// 4. Repeat until all nodes match the target structure
+    ///
+    /// **Phase 2: Truncation sweep (optional)**
+    /// If `options.final_sweep` is true, perform a truncation sweep to optimize
+    /// bond dimensions globally.
+    ///
+    /// # Arguments
+    /// * `target` - The target `SiteIndexNetwork` defining the desired structure
+    /// * `options` - Options controlling truncation and final sweep
+    ///
+    /// # Returns
+    /// A new TreeTN with the split structure, or an error if:
+    /// - The target structure is incompatible with the current structure
+    /// - Factorization fails
+    ///
+    /// # Properties
+    /// - **Bond dimension**: May increase during split, controlled by truncation
+    /// - **Exact (Phase 1)**: Without truncation, represents the same tensor
+    ///
+    /// # Example
+    /// ```text
+    /// Before: {x1_1,x2_1}---{x1_2,x2_2}---{x1_3,x2_3}  (3 nodes, fused)
+    /// After:  x1_1---x2_1---x1_2---x2_2---x1_3---x2_3  (6 nodes, interleaved)
+    /// ```
+    pub fn split_to<TargetV>(
+        &self,
+        target: &SiteIndexNetwork<TargetV, Id, Symm>,
+        options: &SplitOptions,
+    ) -> Result<TreeTN<Id, Symm, TargetV>>
+    where
+        Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + From<DynId>,
+        Symm: Clone + Symmetry + From<NoSymmSpace> + PartialEq + std::fmt::Debug,
+        TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    {
+        // Step 1: Build mapping from site index ID to target node name
+        let mut site_to_target: HashMap<Id, TargetV> = HashMap::new();
+        for target_node_name in target.node_names() {
+            if let Some(site_space) = target.site_space(target_node_name) {
+                for site_idx in site_space {
+                    site_to_target.insert(site_idx.id.clone(), target_node_name.clone());
+                }
+            }
+        }
+
+        // Step 2: For each current node, determine which target nodes it maps to
+        // and validate the mapping
+        let mut current_to_targets: HashMap<V, HashSet<TargetV>> = HashMap::new();
+        for current_node_name in self.node_names() {
+            if let Some(site_space) = self.site_space(&current_node_name) {
+                let mut targets_for_node: HashSet<TargetV> = HashSet::new();
+                for site_idx in site_space {
+                    if let Some(target_name) = site_to_target.get(&site_idx.id) {
+                        targets_for_node.insert(target_name.clone());
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "Site index {:?} in current node {:?} has no corresponding target node",
+                            site_idx.id,
+                            current_node_name
+                        ))
+                        .context("split_to: incompatible target structure");
+                    }
+                }
+                current_to_targets.insert(current_node_name.clone(), targets_for_node);
+            }
+        }
+
+        // Step 3: Phase 1 - Split all nodes that need splitting
+        // Collect all resulting tensors with their target node names
+        let mut result_tensors: Vec<(TargetV, TensorDynLen<Id, Symm>)> = Vec::new();
+
+        for current_node_name in self.node_names() {
+            let node_idx = self
+                .node_index(&current_node_name)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", current_node_name))?;
+            let tensor = self
+                .tensor(node_idx)
+                .ok_or_else(|| anyhow::anyhow!("Tensor not found for {:?}", current_node_name))?;
+
+            let targets_for_node = current_to_targets.get(&current_node_name).ok_or_else(|| {
+                anyhow::anyhow!("No target mapping for node {:?}", current_node_name)
+            })?;
+
+            if targets_for_node.len() == 1 {
+                // No split needed - just relabel
+                let target_name = targets_for_node.iter().next().unwrap().clone();
+                result_tensors.push((target_name, tensor.clone()));
+            } else {
+                // Need to split this node
+                let split_tensors = self
+                    .split_tensor_for_targets(tensor, &site_to_target)
+                    .with_context(|| {
+                        format!("split_to: failed to split node {:?}", current_node_name)
+                    })?;
+                result_tensors.extend(split_tensors);
+            }
+        }
+
+        // Step 4: Build the result TreeTN with target node names
+        // Sort by target name for deterministic ordering
+        result_tensors.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let names: Vec<TargetV> = result_tensors.iter().map(|(name, _)| name.clone()).collect();
+        let tensors: Vec<TensorDynLen<Id, Symm>> =
+            result_tensors.into_iter().map(|(_, t)| t).collect();
+
+        let result = TreeTN::<Id, Symm, TargetV>::from_tensors(tensors, names)
+            .context("split_to: failed to build result TreeTN")?;
+
+        // Step 5: Phase 2 - Optional truncation sweep
+        if options.final_sweep {
+            // Find a center node for truncation
+            let center = result.node_names().into_iter().min().ok_or_else(|| {
+                anyhow::anyhow!("split_to: no nodes in result for truncation sweep")
+            })?;
+
+            let truncation_options = crate::TruncationOptions {
+                form: options.form,
+                rtol: options.rtol,
+                max_rank: options.max_rank,
+            };
+
+            return result
+                .truncate([center], truncation_options)
+                .context("split_to: truncation sweep failed");
+        }
+
+        Ok(result)
+    }
+
+    /// Split a tensor into multiple tensors, one for each target node.
+    ///
+    /// This uses QR factorization to iteratively separate site indices
+    /// belonging to different target nodes.
+    ///
+    /// Returns a vector of (target_name, tensor) pairs.
+    fn split_tensor_for_targets<TargetV>(
+        &self,
+        tensor: &TensorDynLen<Id, Symm>,
+        site_to_target: &HashMap<Id, TargetV>,
+    ) -> Result<Vec<(TargetV, TensorDynLen<Id, Symm>)>>
+    where
+        Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + From<DynId>,
+        Symm: Clone + Symmetry + From<NoSymmSpace>,
+        TargetV: Clone + Hash + Eq + Ord + std::fmt::Debug,
+    {
+        // Group tensor's site indices by their target node
+        let mut partition: HashMap<TargetV, HashSet<Id>> = HashMap::new();
+        for idx in &tensor.indices {
+            if let Some(target_name) = site_to_target.get(&idx.id) {
+                partition
+                    .entry(target_name.clone())
+                    .or_default()
+                    .insert(idx.id.clone());
+            }
+            // Note: bond indices (not in site_to_target) are handled by factorize
+        }
+
+        // Sort target names for deterministic processing
+        let mut target_names: Vec<TargetV> = partition.keys().cloned().collect();
+        target_names.sort();
+
+        if target_names.len() <= 1 {
+            // Should not happen if called correctly, but handle gracefully
+            let target_name = target_names
+                .first()
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("No site indices found in tensor"))?;
+            return Ok(vec![(target_name, tensor.clone())]);
+        }
+
+        // Split iteratively: separate first target's indices, then next, etc.
+        let mut remaining_tensor = tensor.clone();
+        let mut result: Vec<(TargetV, TensorDynLen<Id, Symm>)> = Vec::new();
+
+        // Process all but the last target (the last one gets the remaining tensor)
+        for target_name in target_names.iter().take(target_names.len() - 1) {
+            let site_ids_for_target = partition.get(target_name).unwrap();
+
+            // Find the actual Index objects for these site IDs
+            let left_inds: Vec<_> = remaining_tensor
+                .indices
+                .iter()
+                .filter(|idx| site_ids_for_target.contains(&idx.id))
+                .cloned()
+                .collect();
+
+            if left_inds.is_empty() {
+                continue;
+            }
+
+            // Factorize: separate these site indices
+            let factorize_options = FactorizeOptions {
+                alg: FactorizeAlg::QR,
+                canonical: Canonical::Left,
+                rtol: None,
+                max_rank: None,
+            };
+
+            let factorize_result = factorize(&remaining_tensor, &left_inds, &factorize_options)
+                .map_err(|e| anyhow::anyhow!("Factorization failed: {:?}", e))?;
+
+            // Left tensor gets the separated indices
+            result.push((target_name.clone(), factorize_result.left));
+
+            // Right tensor becomes the remaining tensor for next iteration
+            remaining_tensor = factorize_result.right;
+        }
+
+        // The last target gets the remaining tensor
+        let last_target = target_names.last().unwrap().clone();
+        result.push((last_target, remaining_tensor));
+
+        Ok(result)
     }
 }
 
@@ -617,5 +847,252 @@ mod tests {
 
         let result = tn.fuse_to(&target);
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // split_to tests
+    // =========================================================================
+
+    /// Test split_to with identity transformation (same structure).
+    /// The result should equal the original tensor.
+    #[test]
+    fn test_split_to_identity() {
+        let net = create_4node_chain();
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let tn = random_treetn_f64(&mut rng, &net, LinkSpace::uniform(3));
+
+        // Identity transformation
+        let options = SplitOptions::default();
+        let split = tn.split_to(&net, &options).unwrap();
+
+        // Verify structure is preserved
+        assert_eq!(split.node_count(), tn.node_count());
+        assert_eq!(split.edge_count(), tn.edge_count());
+
+        // Verify tensor is unchanged
+        let original_tensor = tn.contract_to_tensor().unwrap();
+        let split_tensor = split.contract_to_tensor().unwrap();
+        let distance = original_tensor.distance(&split_tensor);
+        assert!(
+            distance < 1e-10,
+            "Identity split should not change tensor: distance = {}",
+            distance
+        );
+    }
+
+    /// Test split_to: split a 2-node fused chain into 4 nodes.
+    /// Before: AB -- CD (2 nodes, each with 2 site indices)
+    /// After: A -- B -- C -- D (4 nodes)
+    #[test]
+    fn test_split_to_fused_to_chain() {
+        // Create target (fine) structure: 4-node chain
+        let target = create_4node_chain();
+
+        // Get site indices from target
+        let site_a = target
+            .site_space(&"A".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_b = target
+            .site_space(&"B".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_c = target
+            .site_space(&"C".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_d = target
+            .site_space(&"D".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+
+        // Create source (coarse) structure: AB -- CD
+        let mut source = SiteIndexNetwork::<String, DynId>::new();
+        source
+            .add_node("AB".to_string(), HashSet::from([site_a.clone(), site_b.clone()]))
+            .unwrap();
+        source
+            .add_node("CD".to_string(), HashSet::from([site_c.clone(), site_d.clone()]))
+            .unwrap();
+        source
+            .add_edge(&"AB".to_string(), &"CD".to_string())
+            .unwrap();
+
+        // Create random TreeTN with source structure
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let tn = random_treetn_f64(&mut rng, &source, LinkSpace::uniform(3));
+
+        // Split to target structure
+        let options = SplitOptions::default();
+        let split = tn.split_to(&target, &options).unwrap();
+
+        // Verify structure
+        assert_eq!(split.node_count(), 4, "Should have 4 nodes after split");
+        assert_eq!(split.edge_count(), 3, "Chain should have 3 edges");
+
+        // Verify tensor is unchanged (exact factorization)
+        let original_tensor = tn.contract_to_tensor().unwrap();
+        let split_tensor = split.contract_to_tensor().unwrap();
+        let distance = original_tensor.distance(&split_tensor);
+        assert!(
+            distance < 1e-10,
+            "Split should preserve tensor: distance = {}",
+            distance
+        );
+    }
+
+    /// Test fuse_to followed by split_to (roundtrip).
+    /// A -- B -- C -- D -> AB -- CD -> A -- B -- C -- D
+    #[test]
+    fn test_fuse_then_split_roundtrip() {
+        let fine = create_4node_chain();
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let original = random_treetn_f64(&mut rng, &fine, LinkSpace::uniform(3));
+
+        // Get site indices
+        let site_a = fine
+            .site_space(&"A".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_b = fine
+            .site_space(&"B".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_c = fine
+            .site_space(&"C".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_d = fine
+            .site_space(&"D".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+
+        // Create coarse structure
+        let mut coarse = SiteIndexNetwork::<String, DynId>::new();
+        coarse
+            .add_node("AB".to_string(), HashSet::from([site_a, site_b]))
+            .unwrap();
+        coarse
+            .add_node("CD".to_string(), HashSet::from([site_c, site_d]))
+            .unwrap();
+        coarse
+            .add_edge(&"AB".to_string(), &"CD".to_string())
+            .unwrap();
+
+        // Fuse: fine -> coarse
+        let fused = original.fuse_to(&coarse).unwrap();
+        assert_eq!(fused.node_count(), 2);
+
+        // Split: coarse -> fine
+        let options = SplitOptions::default();
+        let restored = fused.split_to(&fine, &options).unwrap();
+        assert_eq!(restored.node_count(), 4);
+
+        // Verify tensor is preserved through roundtrip
+        let original_tensor = original.contract_to_tensor().unwrap();
+        let restored_tensor = restored.contract_to_tensor().unwrap();
+        let distance = original_tensor.distance(&restored_tensor);
+        assert!(
+            distance < 1e-10,
+            "Roundtrip should preserve tensor: distance = {}",
+            distance
+        );
+    }
+
+    /// Test split_to with final_sweep option.
+    #[test]
+    fn test_split_to_with_truncation() {
+        // Create target (fine) structure
+        let target = create_4node_chain();
+
+        // Get site indices from target
+        let site_a = target
+            .site_space(&"A".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_b = target
+            .site_space(&"B".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_c = target
+            .site_space(&"C".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+        let site_d = target
+            .site_space(&"D".to_string())
+            .unwrap()
+            .iter()
+            .next()
+            .unwrap()
+            .clone();
+
+        // Create source structure
+        let mut source = SiteIndexNetwork::<String, DynId>::new();
+        source
+            .add_node("AB".to_string(), HashSet::from([site_a.clone(), site_b.clone()]))
+            .unwrap();
+        source
+            .add_node("CD".to_string(), HashSet::from([site_c.clone(), site_d.clone()]))
+            .unwrap();
+        source
+            .add_edge(&"AB".to_string(), &"CD".to_string())
+            .unwrap();
+
+        // Create random TreeTN
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let tn = random_treetn_f64(&mut rng, &source, LinkSpace::uniform(5));
+
+        // Split with truncation
+        let options = SplitOptions::default()
+            .with_final_sweep(true)
+            .with_max_rank(3);
+        let split = tn.split_to(&target, &options).unwrap();
+
+        // Verify structure
+        assert_eq!(split.node_count(), 4);
+
+        // Tensor should be approximately preserved (with some truncation error)
+        let original_tensor = tn.contract_to_tensor().unwrap();
+        let split_tensor = split.contract_to_tensor().unwrap();
+        let distance = original_tensor.distance(&split_tensor);
+        // With truncation, we expect some error but it should be reasonable
+        assert!(
+            distance < 1.0,
+            "Truncated split should approximately preserve tensor: distance = {}",
+            distance
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements Issue #82: `split_to` method to split nodes to match a target SiteIndexNetwork structure.

- Add `SplitOptions` struct with `form`, `rtol`, `max_rank`, and `final_sweep` options
- Implement two-phase algorithm:
  - Phase 1: Exact QR factorization to split nodes (no truncation)
  - Phase 2: Optional truncation sweep when `final_sweep` is enabled
- Complementary to `fuse_to` for roundtrip transformations

### Example (Fused → Interleaved)
```
Before: {x1_1,x2_1}---{x1_2,x2_2}---{x1_3,x2_3}  (3 nodes)
After:  x1_1---x2_1---x1_2---x2_2---x1_3---x2_3  (6 nodes)
```

## Test plan

- [x] `test_split_to_identity`: Same structure transformation
- [x] `test_split_to_fused_to_chain`: AB--CD → A--B--C--D
- [x] `test_fuse_then_split_roundtrip`: fuse → split roundtrip
- [x] `test_split_to_with_truncation`: Split with truncation enabled

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)