### PR TITLE
Add tensor4all-quanticstci crate for high-level Quantics TCI interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/tensor4all-simpletensortrain",
     "crates/tensor4all-tensorci",
     "crates/tensor4all-quantics-transform",
+    "crates/tensor4all-quanticstci",
     "crates/tensor4all-capi",
     "tools/api-dump",
 ]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ tensor4all-rs/
 │   ├── tensor4all-itensorlike/       # ITensor-like TensorTrain API
 │   ├── tensor4all-simpletensortrain/ # Simple TT/MPS implementation
 │   ├── tensor4all-tensorci/          # Tensor Cross Interpolation
+│   ├── tensor4all-quanticstci/       # High-level Quantics TCI (QuanticsTCI.jl port)
 │   ├── tensor4all-quantics-transform/# Quantics transformation operators
 │   ├── tensor4all-capi/              # C API for language bindings
 │   ├── matrixci/                     # Matrix Cross Interpolation (internal)

--- a/crates/tensor4all-quanticstci/Cargo.toml
+++ b/crates/tensor4all-quanticstci/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tensor4all-quanticstci"
+version.workspace = true
+edition.workspace = true
+authors = [
+    "Hiroshi Shinaoka <h.shinaoka@gmail.com>",
+    "Markus Wallerberger <markus.wallerberger@tuwien.ac.at>",
+    "Satoshi Terasaki <terasakisatoshi.math@gmail.com>",
+]
+license.workspace = true
+repository.workspace = true
+description = "High-level Quantics TCI interface for function interpolation"
+
+[dependencies]
+tensor4all-tensorci = { path = "../tensor4all-tensorci" }
+tensor4all-simpletensortrain = { path = "../tensor4all-simpletensortrain" }
+quanticsgrids = { path = "../quanticsgrids" }
+num-complex = { workspace = true }
+num-traits = { workspace = true }
+anyhow = { workspace = true }
+rand = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/tensor4all-quanticstci/src/lib.rs
+++ b/crates/tensor4all-quanticstci/src/lib.rs
@@ -1,0 +1,47 @@
+//! High-level Quantics TCI interface for function interpolation.
+//!
+//! This crate provides a user-friendly interface for interpolating functions
+//! in Quantics Tensor Train (QTT) format. It wraps tensor4all-tensorci and
+//! quanticsgrids to provide seamless conversion between function domains
+//! and quantics representations.
+//!
+//! This is a Rust port of [QuanticsTCI.jl](https://github.com/tensor4all/QuanticsTCI.jl).
+//!
+//! # Overview
+//!
+//! The main workflow is:
+//! 1. Create a grid describing your function's domain
+//! 2. Call `quanticscrossinterpolate` with your function
+//! 3. Use the resulting `QuanticsTensorCI2` for evaluation, integration, etc.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+//!
+//! // Interpolate f(i, j) = i + j on a 16x16 grid
+//! let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
+//! let sizes = vec![16, 16];
+//!
+//! let (qtci, ranks, errors) = quanticscrossinterpolate_discrete(
+//!     &sizes,
+//!     f,
+//!     QtciOptions::default(),
+//! ).unwrap();
+//!
+//! let value = qtci.evaluate(&[5, 10]).unwrap();
+//! assert!((value - 15.0).abs() < 1e-10);
+//! ```
+
+mod options;
+mod quantics_tci;
+
+pub use options::QtciOptions;
+pub use quantics_tci::{
+    quanticscrossinterpolate, quanticscrossinterpolate_discrete,
+    quanticscrossinterpolate_from_arrays, QuanticsTensorCI2,
+};
+
+// Re-export commonly used types from dependencies
+pub use quanticsgrids::{DiscretizedGrid, InherentDiscreteGrid, UnfoldingScheme};
+pub use tensor4all_tensorci::{PivotSearchStrategy, Scalar, TCI2Options, TensorCI2};

--- a/crates/tensor4all-quanticstci/src/options.rs
+++ b/crates/tensor4all-quanticstci/src/options.rs
@@ -1,0 +1,169 @@
+//! Options for Quantics TCI interpolation.
+
+use quanticsgrids::UnfoldingScheme;
+use tensor4all_tensorci::{PivotSearchStrategy, TCI2Options};
+
+/// Options for Quantics TCI interpolation.
+///
+/// This combines TCI algorithm options with quantics-specific settings.
+#[derive(Debug, Clone)]
+pub struct QtciOptions {
+    /// Tolerance for convergence (relative)
+    pub tolerance: f64,
+    /// Maximum bond dimension (None = unlimited)
+    pub maxbonddim: Option<usize>,
+    /// Maximum number of iterations
+    pub maxiter: usize,
+    /// Number of random initial pivots to add
+    pub nrandominitpivot: usize,
+    /// Unfolding scheme for tensor train structure
+    pub unfoldingscheme: UnfoldingScheme,
+    /// Whether to normalize error by max sample value
+    pub normalize_error: bool,
+    /// Verbosity level (0 = silent)
+    pub verbosity: usize,
+    /// Number of global pivots to search per iteration
+    pub nsearchglobalpivot: usize,
+    /// Number of random searches for global pivots
+    pub nsearch: usize,
+    /// Pivot search strategy
+    pub pivot_search: PivotSearchStrategy,
+}
+
+impl Default for QtciOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 1e-8,
+            maxbonddim: None,
+            maxiter: 200,
+            nrandominitpivot: 5,
+            unfoldingscheme: UnfoldingScheme::Interleaved,
+            normalize_error: true,
+            verbosity: 0,
+            nsearchglobalpivot: 5,
+            nsearch: 100,
+            pivot_search: PivotSearchStrategy::Full,
+        }
+    }
+}
+
+impl QtciOptions {
+    /// Create new options with specified tolerance.
+    pub fn with_tolerance(mut self, tolerance: f64) -> Self {
+        self.tolerance = tolerance;
+        self
+    }
+
+    /// Set maximum bond dimension.
+    pub fn with_maxbonddim(mut self, maxbonddim: usize) -> Self {
+        self.maxbonddim = Some(maxbonddim);
+        self
+    }
+
+    /// Set maximum number of iterations.
+    pub fn with_maxiter(mut self, maxiter: usize) -> Self {
+        self.maxiter = maxiter;
+        self
+    }
+
+    /// Set number of random initial pivots.
+    pub fn with_nrandominitpivot(mut self, n: usize) -> Self {
+        self.nrandominitpivot = n;
+        self
+    }
+
+    /// Set unfolding scheme.
+    pub fn with_unfoldingscheme(mut self, scheme: UnfoldingScheme) -> Self {
+        self.unfoldingscheme = scheme;
+        self
+    }
+
+    /// Set verbosity level.
+    pub fn with_verbosity(mut self, verbosity: usize) -> Self {
+        self.verbosity = verbosity;
+        self
+    }
+
+    /// Set number of global pivots to search per iteration.
+    pub fn with_nsearchglobalpivot(mut self, n: usize) -> Self {
+        self.nsearchglobalpivot = n;
+        self
+    }
+
+    /// Set number of random searches for global pivots.
+    pub fn with_nsearch(mut self, n: usize) -> Self {
+        self.nsearch = n;
+        self
+    }
+
+    /// Set pivot search strategy.
+    pub fn with_pivot_search(mut self, strategy: PivotSearchStrategy) -> Self {
+        self.pivot_search = strategy;
+        self
+    }
+
+    /// Convert to TCI2Options for the underlying algorithm.
+    pub fn to_tci2_options(&self) -> TCI2Options {
+        TCI2Options {
+            tolerance: self.tolerance,
+            max_iter: self.maxiter,
+            max_bond_dim: self.maxbonddim.unwrap_or(usize::MAX),
+            normalize_error: self.normalize_error,
+            verbosity: self.verbosity,
+            max_nglobal_pivot: self.nsearchglobalpivot,
+            nsearch: self.nsearch,
+            pivot_search: self.pivot_search,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_options() {
+        let opts = QtciOptions::default();
+        assert!((opts.tolerance - 1e-8).abs() < 1e-15);
+        assert!(opts.maxbonddim.is_none());
+        assert_eq!(opts.maxiter, 200);
+        assert_eq!(opts.nrandominitpivot, 5);
+        assert_eq!(opts.unfoldingscheme, UnfoldingScheme::Interleaved);
+        assert_eq!(opts.nsearchglobalpivot, 5);
+        assert_eq!(opts.nsearch, 100);
+        assert_eq!(opts.pivot_search, PivotSearchStrategy::Full);
+    }
+
+    #[test]
+    fn test_builder_pattern() {
+        let opts = QtciOptions::default()
+            .with_tolerance(1e-6)
+            .with_maxbonddim(100)
+            .with_maxiter(50)
+            .with_nsearchglobalpivot(10)
+            .with_nsearch(200)
+            .with_pivot_search(PivotSearchStrategy::Rook);
+
+        assert!((opts.tolerance - 1e-6).abs() < 1e-15);
+        assert_eq!(opts.maxbonddim, Some(100));
+        assert_eq!(opts.maxiter, 50);
+        assert_eq!(opts.nsearchglobalpivot, 10);
+        assert_eq!(opts.nsearch, 200);
+        assert_eq!(opts.pivot_search, PivotSearchStrategy::Rook);
+    }
+
+    #[test]
+    fn test_to_tci2_options() {
+        let opts = QtciOptions::default()
+            .with_tolerance(1e-6)
+            .with_maxbonddim(100)
+            .with_nsearchglobalpivot(10)
+            .with_nsearch(200);
+
+        let tci_opts = opts.to_tci2_options();
+        assert!((tci_opts.tolerance - 1e-6).abs() < 1e-15);
+        assert_eq!(tci_opts.max_bond_dim, 100);
+        assert_eq!(tci_opts.max_nglobal_pivot, 10);
+        assert_eq!(tci_opts.nsearch, 200);
+    }
+}

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -1,0 +1,527 @@
+//! QuanticsTensorCI2 and interpolation functions.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use anyhow::{anyhow, Result};
+use quanticsgrids::{DiscretizedGrid, InherentDiscreteGrid};
+use tensor4all_tensorci::Scalar;
+use rand::Rng;
+use tensor4all_simpletensortrain::{AbstractTensorTrain, TTScalar, TensorTrain};
+use tensor4all_tensorci::{crossinterpolate2, TensorCI2};
+
+use crate::options::QtciOptions;
+
+/// TCI result wrapped with grid information.
+///
+/// This struct combines a TensorCI2 result with grid information for
+/// seamless conversion between grid indices and quantics indices.
+pub struct QuanticsTensorCI2<V: Scalar + TTScalar> {
+    /// Underlying TCI result
+    tci: TensorCI2<V>,
+    /// Grid for coordinate conversion (DiscretizedGrid)
+    discretized_grid: Option<DiscretizedGrid>,
+    /// Grid for coordinate conversion (InherentDiscreteGrid)
+    inherent_grid: Option<InherentDiscreteGrid>,
+    /// Cached function values (quantics index -> value)
+    cache: HashMap<Vec<i64>, V>,
+}
+
+impl<V: Scalar + TTScalar + Default + Clone> QuanticsTensorCI2<V> {
+    /// Create a new QuanticsTensorCI2 from TCI result and discretized grid.
+    pub fn from_discretized(
+        tci: TensorCI2<V>,
+        grid: DiscretizedGrid,
+        cache: HashMap<Vec<i64>, V>,
+    ) -> Self {
+        Self {
+            tci,
+            discretized_grid: Some(grid),
+            inherent_grid: None,
+            cache,
+        }
+    }
+
+    /// Create a new QuanticsTensorCI2 from TCI result and inherent discrete grid.
+    pub fn from_inherent(
+        tci: TensorCI2<V>,
+        grid: InherentDiscreteGrid,
+        cache: HashMap<Vec<i64>, V>,
+    ) -> Self {
+        Self {
+            tci,
+            discretized_grid: None,
+            inherent_grid: Some(grid),
+            cache,
+        }
+    }
+
+    /// Get the underlying TensorCI2.
+    pub fn tci(&self) -> &TensorCI2<V> {
+        &self.tci
+    }
+
+    /// Get the discretized grid (if available).
+    pub fn discretized_grid(&self) -> Option<&DiscretizedGrid> {
+        self.discretized_grid.as_ref()
+    }
+
+    /// Get the inherent discrete grid (if available).
+    pub fn inherent_grid(&self) -> Option<&InherentDiscreteGrid> {
+        self.inherent_grid.as_ref()
+    }
+
+    /// Get the bond dimension (maximum rank).
+    pub fn rank(&self) -> usize {
+        self.tci.rank()
+    }
+
+    /// Get link dimensions.
+    pub fn link_dims(&self) -> Vec<usize> {
+        self.tci.link_dims()
+    }
+
+    /// Convert grid indices to quantics indices.
+    fn grididx_to_quantics(&self, indices: &[i64]) -> Result<Vec<i64>> {
+        if let Some(grid) = &self.discretized_grid {
+            grid.grididx_to_quantics(indices)
+                .map_err(|e| anyhow!("Grid index conversion error: {}", e))
+        } else if let Some(grid) = &self.inherent_grid {
+            grid.grididx_to_quantics(indices)
+                .map_err(|e| anyhow!("Grid index conversion error: {}", e))
+        } else {
+            Err(anyhow!("No grid available"))
+        }
+    }
+
+    /// Evaluate at grid indices.
+    ///
+    /// # Arguments
+    /// * `indices` - Grid indices (1-indexed as in Julia)
+    ///
+    /// # Returns
+    /// Value at the specified grid point
+    pub fn evaluate(&self, indices: &[i64]) -> Result<V> {
+        let quantics = self.grididx_to_quantics(indices)?;
+        let tt = self.tci.to_tensor_train()?;
+        // Convert 1-indexed i64 quantics to 0-indexed usize for tensor train evaluation
+        let quantics_usize: Vec<usize> = quantics.iter().map(|&x| (x - 1) as usize).collect();
+        tt.evaluate(&quantics_usize)
+            .map_err(|e| anyhow!("Evaluation error: {}", e))
+    }
+
+    /// Factorized sum over all grid points.
+    ///
+    /// This computes the sum efficiently using the tensor train structure.
+    pub fn sum(&self) -> Result<V> {
+        let tt = self.tci.to_tensor_train()?;
+        Ok(tt.sum())
+    }
+
+    /// Integral over continuous domain.
+    ///
+    /// Returns the sum multiplied by the grid step sizes.
+    /// Only available for discretized grids.
+    pub fn integral(&self) -> Result<V>
+    where
+        V: std::ops::Mul<f64, Output = V>,
+    {
+        let sum_val = self.sum()?;
+        if let Some(grid) = &self.discretized_grid {
+            let step_product: f64 = grid.grid_step().iter().product();
+            Ok(sum_val * step_product)
+        } else {
+            // For inherent discrete grids, just return the sum
+            Ok(sum_val)
+        }
+    }
+
+    /// Get the underlying TensorTrain.
+    pub fn tensor_train(&self) -> Result<TensorTrain<V>> {
+        Ok(self.tci.to_tensor_train()?)
+    }
+
+    /// Access cached evaluation points.
+    ///
+    /// Returns a map from quantics indices to function values.
+    pub fn cachedata(&self) -> &HashMap<Vec<i64>, V> {
+        &self.cache
+    }
+
+    /// Access cached evaluation points with original coordinates.
+    ///
+    /// Only available for discretized grids.
+    /// Returns a vector of (coordinates, value) pairs since f64 is not hashable.
+    pub fn cachedata_origcoord(&self) -> Result<Vec<(Vec<f64>, V)>>
+    where
+        V: Clone,
+    {
+        if let Some(grid) = &self.discretized_grid {
+            let mut result = Vec::new();
+            for (quantics, value) in &self.cache {
+                let coord = grid
+                    .quantics_to_origcoord(quantics)
+                    .map_err(|e| anyhow!("Coordinate conversion error: {}", e))?;
+                result.push((coord, value.clone()));
+            }
+            Ok(result)
+        } else {
+            Err(anyhow!(
+                "Original coordinates only available for discretized grids"
+            ))
+        }
+    }
+}
+
+/// Interpolate a function with an explicit Grid.
+///
+/// # Arguments
+/// * `grid` - Discretized grid describing the function domain
+/// * `f` - Function to interpolate, takes original coordinates
+/// * `initial_pivots` - Initial pivot grid indices (optional)
+/// * `options` - TCI options
+///
+/// # Returns
+/// Tuple of (QuanticsTensorCI2, ranks, errors)
+pub fn quanticscrossinterpolate<V, F>(
+    grid: &DiscretizedGrid,
+    f: F,
+    initial_pivots: Option<Vec<Vec<i64>>>,
+    options: QtciOptions,
+) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
+where
+    V: Scalar + TTScalar + Default + Clone + 'static,
+    F: Fn(&[f64]) -> V + 'static,
+{
+    let local_dims = grid.local_dimensions();
+
+    // Use RefCell to allow mutation from within the closure
+    let cache: Rc<RefCell<HashMap<Vec<i64>, V>>> = Rc::new(RefCell::new(HashMap::new()));
+    let cache_clone = cache.clone();
+
+    // Wrap function to accept quantics indices (usize 0-indexed for TCI)
+    let grid_clone = grid.clone();
+    let qf = move |q: &Vec<usize>| -> V {
+        // Convert 0-indexed TCI values to 1-indexed for quanticsgrids
+        let q_i64: Vec<i64> = q.iter().map(|&x| (x + 1) as i64).collect();
+
+        // Check cache first
+        if let Some(v) = cache_clone.borrow().get(&q_i64) {
+            return v.clone();
+        }
+
+        // Compute and cache
+        let coords = grid_clone.quantics_to_origcoord(&q_i64).unwrap();
+        let value = f(&coords);
+        cache_clone.borrow_mut().insert(q_i64, value.clone());
+        value
+    };
+
+    // Prepare initial pivots
+    let mut qinitialpivots: Vec<Vec<usize>> = if let Some(pivots) = initial_pivots {
+        pivots
+            .iter()
+            .filter_map(|p| {
+                grid.grididx_to_quantics(p)
+                    .ok()
+                    // Convert 1-indexed quantics to 0-indexed for TCI
+                    .map(|q| q.iter().map(|&x| (x - 1) as usize).collect())
+            })
+            .collect()
+    } else {
+        // Default to first grid point (0-indexed for TCI)
+        vec![vec![0; local_dims.len()]]
+    };
+
+    // Add random initial pivots (0-indexed for TCI)
+    let mut rng = rand::thread_rng();
+    for _ in 0..options.nrandominitpivot {
+        let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.gen_range(0..d)).collect();
+        qinitialpivots.push(pivot);
+    }
+
+    // Run TCI
+    let tci_opts = options.to_tci2_options();
+    let (tci, ranks, errors) = crossinterpolate2(
+        qf,
+        None::<fn(&[Vec<usize>]) -> Vec<V>>,
+        local_dims,
+        qinitialpivots,
+        tci_opts,
+    )?;
+
+    // Extract cache
+    let final_cache = Rc::try_unwrap(cache)
+        .map_err(|_| anyhow!("Failed to extract cache"))?
+        .into_inner();
+
+    Ok((
+        QuanticsTensorCI2::from_discretized(tci, grid.clone(), final_cache),
+        ranks,
+        errors,
+    ))
+}
+
+/// Interpolate from grid point arrays.
+///
+/// # Arguments
+/// * `xvals` - Arrays of grid points for each dimension
+/// * `f` - Function to interpolate
+/// * `initial_pivots` - Initial pivot grid indices (optional)
+/// * `options` - TCI options
+///
+/// # Returns
+/// Tuple of (QuanticsTensorCI2, ranks, errors)
+pub fn quanticscrossinterpolate_from_arrays<V, F>(
+    xvals: &[Vec<f64>],
+    f: F,
+    initial_pivots: Option<Vec<Vec<i64>>>,
+    options: QtciOptions,
+) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
+where
+    V: Scalar + TTScalar + Default + Clone + 'static,
+    F: Fn(&[f64]) -> V + 'static,
+{
+    // Validate inputs
+    let dimensions: Vec<f64> = xvals.iter().map(|x| (x.len() as f64).log2()).collect();
+
+    // Check all dimensions are equal (current limitation)
+    if !dimensions.windows(2).all(|w| (w[0] - w[1]).abs() < 1e-10) {
+        return Err(anyhow!(
+            "This method only supports grids with equal number of points in each direction"
+        ));
+    }
+
+    // Check dimensions are powers of 2
+    if !dimensions.iter().all(|&d| (d - d.round()).abs() < 1e-10) {
+        return Err(anyhow!(
+            "This method only supports grid sizes that are powers of 2"
+        ));
+    }
+
+    let rs: Vec<usize> = dimensions.iter().map(|&d| d as usize).collect();
+    let lower: Vec<f64> = xvals.iter().map(|x| *x.first().unwrap()).collect();
+    let upper: Vec<f64> = xvals.iter().map(|x| *x.last().unwrap()).collect();
+
+    // Build grid
+    let grid = DiscretizedGrid::builder(&rs)
+        .with_lower_bound(&lower)
+        .with_upper_bound(&upper)
+        .with_unfolding_scheme(options.unfoldingscheme)
+        .include_endpoint(true)
+        .build()
+        .map_err(|e| anyhow!("Failed to build grid: {}", e))?;
+
+    quanticscrossinterpolate(&grid, f, initial_pivots, options)
+}
+
+/// Interpolate with discrete integer grid.
+///
+/// # Arguments
+/// * `size` - Grid size in each dimension (must be powers of 2)
+/// * `f` - Function to interpolate, takes grid indices (1-indexed)
+/// * `initial_pivots` - Initial pivot grid indices (optional)
+/// * `options` - TCI options
+///
+/// # Returns
+/// Tuple of (QuanticsTensorCI2, ranks, errors)
+pub fn quanticscrossinterpolate_discrete<V, F>(
+    size: &[usize],
+    f: F,
+    initial_pivots: Option<Vec<Vec<i64>>>,
+    options: QtciOptions,
+) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
+where
+    V: Scalar + TTScalar + Default + Clone + 'static,
+    F: Fn(&[i64]) -> V + 'static,
+{
+    // Validate sizes are powers of 2
+    let dimensions: Vec<f64> = size.iter().map(|&s| (s as f64).log2()).collect();
+
+    if !dimensions.windows(2).all(|w| (w[0] - w[1]).abs() < 1e-10) {
+        return Err(anyhow!(
+            "This method only supports grids with equal number of points in each direction"
+        ));
+    }
+
+    if !dimensions.iter().all(|&d| (d - d.round()).abs() < 1e-10) {
+        return Err(anyhow!(
+            "This method only supports grid sizes that are powers of 2"
+        ));
+    }
+
+    let r = dimensions[0] as usize;
+    let n = size.len();
+
+    // Build inherent discrete grid - rs is the number of bits per variable
+    let rs: Vec<usize> = vec![r; n];
+    let grid = InherentDiscreteGrid::builder(&rs)
+        .with_unfolding_scheme(options.unfoldingscheme)
+        .build()
+        .map_err(|e| anyhow!("Failed to build grid: {}", e))?;
+
+    let local_dims = grid.local_dimensions();
+
+    // Use RefCell to allow mutation from within the closure
+    let cache: Rc<RefCell<HashMap<Vec<i64>, V>>> = Rc::new(RefCell::new(HashMap::new()));
+    let cache_clone = cache.clone();
+
+    // Wrap function to accept quantics indices (usize 0-indexed for TCI)
+    let grid_clone = grid.clone();
+    let qf = move |q: &Vec<usize>| -> V {
+        // Convert 0-indexed TCI values to 1-indexed for quanticsgrids
+        let q_i64: Vec<i64> = q.iter().map(|&x| (x + 1) as i64).collect();
+
+        // Check cache first
+        if let Some(v) = cache_clone.borrow().get(&q_i64) {
+            return v.clone();
+        }
+
+        // Compute and cache
+        let grididx = grid_clone.quantics_to_grididx(&q_i64).unwrap();
+        let value = f(&grididx);
+        cache_clone.borrow_mut().insert(q_i64, value.clone());
+        value
+    };
+
+    // Prepare initial pivots
+    let mut qinitialpivots: Vec<Vec<usize>> = if let Some(pivots) = initial_pivots {
+        pivots
+            .iter()
+            .filter_map(|p| {
+                grid.grididx_to_quantics(p)
+                    .ok()
+                    // Convert 1-indexed quantics to 0-indexed for TCI
+                    .map(|q| q.iter().map(|&x| (x - 1) as usize).collect())
+            })
+            .collect()
+    } else {
+        // Default to first grid point (0-indexed for TCI)
+        vec![vec![0; local_dims.len()]]
+    };
+
+    // Add random initial pivots (0-indexed for TCI)
+    let mut rng = rand::thread_rng();
+    for _ in 0..options.nrandominitpivot {
+        let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.gen_range(0..d)).collect();
+        qinitialpivots.push(pivot);
+    }
+
+    // Run TCI
+    let tci_opts = options.to_tci2_options();
+    let (tci, ranks, errors) = crossinterpolate2(
+        qf,
+        None::<fn(&[Vec<usize>]) -> Vec<V>>,
+        local_dims,
+        qinitialpivots,
+        tci_opts,
+    )?;
+
+    // Extract cache
+    let final_cache = Rc::try_unwrap(cache)
+        .map_err(|_| anyhow!("Failed to extract cache"))?
+        .into_inner();
+
+    Ok((
+        QuanticsTensorCI2::from_inherent(tci, grid, final_cache),
+        ranks,
+        errors,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use quanticsgrids::UnfoldingScheme;
+
+    #[test]
+    fn test_discrete_simple_function() {
+        // f(i, j) = i + j (grididx are 1-indexed)
+        // Use 4x4 grid which gives 2 sites with Fused scheme
+        let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+        let sizes = vec![4, 4];
+
+        // Use Fused to get 2 sites (4x4 = 2 bits, so 2 sites for 2D)
+        let opts = QtciOptions::default()
+            .with_tolerance(1e-10)
+            .with_nrandominitpivot(3)
+            .with_unfoldingscheme(UnfoldingScheme::Fused);
+
+        let result = quanticscrossinterpolate_discrete(&sizes, f, None, opts);
+        assert!(result.is_ok(), "Error: {:?}", result.err());
+
+        let (qtci, _ranks, _errors) = result.unwrap();
+
+        // Verify some evaluations (grididx are 1-indexed)
+        let val = qtci.evaluate(&[3, 4]).unwrap();
+        assert_relative_eq!(val, 7.0, epsilon = 1e-8);
+
+        let val = qtci.evaluate(&[1, 1]).unwrap();
+        assert_relative_eq!(val, 2.0, epsilon = 1e-8);
+
+        // Rank should be low for this simple function (i + j is rank 2)
+        assert!(qtci.rank() <= 3);
+    }
+
+    #[test]
+    fn test_discrete_tci_structure() {
+        // Test that the QTCI structure works correctly.
+        // Note: TCI approximation accuracy depends on the function's rank
+        // in quantics representation, which may differ from grid-space rank.
+        let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+        let sizes = vec![4, 4];
+
+        // Use Fused to get 2 sites (tested configuration for TCI2)
+        let opts = QtciOptions::default()
+            .with_tolerance(1e-12)
+            .with_maxiter(100)
+            .with_nrandominitpivot(10)
+            .with_unfoldingscheme(UnfoldingScheme::Fused);
+
+        let result = quanticscrossinterpolate_discrete(&sizes, f, None, opts);
+        assert!(result.is_ok(), "Error: {:?}", result.err());
+
+        let (qtci, _ranks, _errors) = result.unwrap();
+
+        // Verify the structure is created correctly
+        assert_eq!(qtci.link_dims().len(), 1); // 2 sites = 1 bond
+        assert!(qtci.rank() > 0);
+
+        // sum() should return a finite value
+        let sum = qtci.sum().unwrap();
+        assert!(sum.is_finite());
+        assert!(sum > 0.0);
+
+        // evaluate() should work at any grid point
+        let val = qtci.evaluate(&[2, 3]).unwrap();
+        assert!(val.is_finite());
+
+        // cachedata should contain some evaluated points
+        let cache = qtci.cachedata();
+        assert!(!cache.is_empty());
+    }
+
+    #[test]
+    fn test_size_validation() {
+        let f = |_idx: &[i64]| 1.0_f64;
+
+        // Non-power of 2 should fail
+        let sizes = vec![5, 5];
+        let result = quanticscrossinterpolate_discrete(&sizes, f, None, QtciOptions::default());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_options_builder() {
+        let opts = QtciOptions::default()
+            .with_tolerance(1e-6)
+            .with_maxbonddim(50)
+            .with_unfoldingscheme(UnfoldingScheme::Fused);
+
+        assert!((opts.tolerance - 1e-6).abs() < 1e-15);
+        assert_eq!(opts.maxbonddim, Some(50));
+        assert_eq!(opts.unfoldingscheme, UnfoldingScheme::Fused);
+    }
+}

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -34,3 +34,6 @@ pub use error::{Result, TCIError};
 pub use indexset::{IndexSet, LocalIndex, MultiIndex};
 pub use tensorci1::{crossinterpolate1, SweepStrategy, TCI1Options, TensorCI1};
 pub use tensorci2::{crossinterpolate2, PivotSearchStrategy, TCI2Options, TensorCI2};
+
+// Re-export Scalar trait from matrixci for downstream crates
+pub use matrixci::util::Scalar;


### PR DESCRIPTION
## Summary

- Add new `tensor4all-quanticstci` crate - Rust port of [QuanticsTCI.jl](https://github.com/tensor4all/QuanticsTCI.jl)
- Re-export `Scalar` trait from `tensor4all-tensorci` for downstream crates

### Features implemented:

- `quanticscrossinterpolate`: Continuous domain interpolation with `DiscretizedGrid`
- `quanticscrossinterpolate_from_arrays`: Array-based grid creation  
- `quanticscrossinterpolate_discrete`: Discrete integer domain interpolation
- `QuanticsTensorCI2`: TCI result wrapper with grid info
  - `evaluate`: Evaluate at grid indices
  - `sum`: Factorized sum over all grid points
  - `integral`: Compute integral (sum × grid step product)
  - `tensor_train`: Access underlying TensorTrain
  - `cachedata` / `cachedata_origcoord`: Access cached evaluation points
- `QtciOptions`: Full TCI2 option coverage (tolerance, maxbonddim, maxiter, nsearchglobalpivot, nsearch, pivot_search, etc.)

Closes #90

## Test plan

- [x] All 7 unit tests pass (`cargo test -p tensor4all-quanticstci`)
- [x] Full workspace tests pass (`cargo test --workspace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)