### PR TITLE
Add README.md for each crate with usage examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,10 @@ Manifest.toml
 LocalPreferences.toml
 
 # Avoid accidentally committing ad-hoc analysis notes at repo root
-*.md
+/*.md
+!README.md
+!AGENTS.md
+!CLAUDE.md
 
 # Private documentation (not committed)
 privatedoc/*

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ tensor4all-rs/
 └── docs/                             # Design documents
 ```
 
+### Crate Documentation
+
+| Crate | Description |
+|-------|-------------|
+| [tensor4all-core](crates/tensor4all-core/) | Core types: Index, Tensor, Storage, SVD, QR, LU |
+| [tensor4all-treetn](crates/tensor4all-treetn/) | Tree tensor networks with arbitrary topology |
+| [tensor4all-itensorlike](crates/tensor4all-itensorlike/) | ITensors.jl-like TensorTrain API |
+| [tensor4all-simpletensortrain](crates/tensor4all-simpletensortrain/) | Simple TT/MPS with multiple canonical forms |
+| [tensor4all-tensorci](crates/tensor4all-tensorci/) | Tensor Cross Interpolation (TCI) algorithms |
+| [tensor4all-quanticstci](crates/tensor4all-quanticstci/) | High-level Quantics TCI interface |
+| [tensor4all-quantics-transform](crates/tensor4all-quantics-transform/) | Quantics transformation operators |
+| [tensor4all-capi](crates/tensor4all-capi/) | C FFI for language bindings |
+| [matrixci](crates/matrixci/) | Matrix Cross Interpolation |
+| [quanticsgrids](crates/quanticsgrids/) | Quantics grid structures |
+
 ## Usage Example (Rust)
 
 ### Tree Tensor Network

--- a/crates/matrixci/README.md
+++ b/crates/matrixci/README.md
@@ -1,0 +1,39 @@
+# matrixci
+
+Matrix Cross Interpolation (MCI) algorithms for low-rank matrix approximations. Provides multiple algorithms including standard cross interpolation, Adaptive Cross Approximation (ACA), and LU-based methods.
+
+## Features
+
+- **MatrixCI**: Standard matrix cross interpolation
+- **MatrixACA**: Adaptive Cross Approximation variant
+- **RrLU**: Rank-Revealing LU decomposition
+- **MatrixLUCI**: LU-based Cross Interpolation
+- Supports `f32`, `f64`, `Complex32`, and `Complex64`
+
+## Usage
+
+```rust
+use matrixci::{MatrixCI, crossinterpolate, AbstractMatrixCI, from_vec2d};
+
+// Create a matrix
+let m = from_vec2d(vec![
+    vec![1.0, 2.0, 3.0],
+    vec![4.0, 5.0, 6.0],
+    vec![7.0, 8.0, 9.0],
+]);
+
+// Perform cross interpolation
+let ci = crossinterpolate(&m, None);
+println!("Rank: {}", ci.rank());
+
+// Access row and column indices
+let rows = ci.row_indices();
+let cols = ci.col_indices();
+
+// Evaluate approximation at a point
+let value = ci.evaluate(1, 2);
+```
+
+## License
+
+MIT License

--- a/crates/quanticsgrids/README.md
+++ b/crates/quanticsgrids/README.md
@@ -1,0 +1,44 @@
+# quanticsgrids
+
+Grid structures for efficient conversion between quantics representation, grid indices, and original coordinates. This is a Rust port of [QuanticsGrids.jl](https://github.com/tensor4all/QuanticsGrids.jl).
+
+## Features
+
+- **InherentDiscreteGrid**: Low-level grid for integer coordinates
+- **DiscretizedGrid**: High-level grid for continuous domains
+- **UnfoldingScheme**: Fused (default) or Interleaved index ordering
+- Efficient O(R * D) coordinate conversions
+
+## Usage
+
+```rust
+use quanticsgrids::{DiscretizedGrid, UnfoldingScheme};
+
+// Create a 2D grid with 3 bits for x and 2 bits for y
+let grid = DiscretizedGrid::builder(&[3, 2])
+    .with_lower_bound(&[0.0, 0.0])
+    .with_upper_bound(&[1.0, 2.0])
+    .build()?;
+
+// Convert coordinates to quantics indices
+let quantics = grid.origcoord_to_quantics(&[0.5, 1.0])?;
+
+// Convert back to coordinates
+let coords = grid.quantics_to_origcoord(&quantics)?;
+
+// Get local dimensions for TCI
+let local_dims = grid.local_dimensions();
+```
+
+## Coordinate Conversions
+
+| From | To | Method |
+|------|-----|--------|
+| Original coordinates | Quantics indices | `origcoord_to_quantics()` |
+| Quantics indices | Original coordinates | `quantics_to_origcoord()` |
+| Grid indices | Quantics indices | `grididx_to_quantics()` |
+| Quantics indices | Grid indices | `quantics_to_grididx()` |
+
+## License
+
+MIT License

--- a/crates/tensor4all-capi/README.md
+++ b/crates/tensor4all-capi/README.md
@@ -1,0 +1,48 @@
+# tensor4all-capi
+
+C-compatible FFI interface to the tensor4all Rust library, enabling language bindings for Julia, Python, and other languages.
+
+## Features
+
+- **Index API**: Create and manipulate tensor indices with tags
+- **Tensor API**: Dense and diagonal tensors for `f64` and `Complex64`
+- **TensorTrain API**: Full MPS functionality (orthogonalize, truncate, contract)
+- **Algorithm selection**: Configurable factorization and contraction algorithms
+- **Error handling**: Status codes instead of exceptions
+- **Panic safety**: All functions protected with `catch_unwind`
+
+## API Conventions
+
+- Opaque pointers with lifecycle management (`*_new`, `*_release`, `*_clone`)
+- Status codes: `T4A_SUCCESS`, `T4A_NULL_POINTER`, `T4A_INVALID_ARGUMENT`, etc.
+- Row-major data layout for tensor data
+
+## Example (C)
+
+```c
+#include "tensor4all.h"
+
+// Create an index
+T4AIndex* idx = t4a_index_new(10);
+t4a_index_add_tag(idx, "Site");
+
+// Create a tensor
+size_t dims[] = {10, 10};
+T4ATensor* tensor = t4a_tensor_new_dense_f64(2, &idx, dims, data, 100);
+
+// Create tensor train
+T4ATensorTrain* tt = t4a_tt_new(&tensors, 3);
+
+// Orthogonalize and truncate
+t4a_tt_orthogonalize(tt, 1);
+t4a_tt_truncate(tt, 1e-10, 20);
+
+// Clean up
+t4a_tt_release(tt);
+t4a_tensor_release(tensor);
+t4a_index_release(idx);
+```
+
+## License
+
+MIT License

--- a/crates/tensor4all-core/README.md
+++ b/crates/tensor4all-core/README.md
@@ -1,0 +1,35 @@
+# tensor4all-core
+
+Foundation library providing core data structures and algorithms for tensor operations. It implements tensor types, index management, and fundamental linear algebra operations.
+
+## Features
+
+- **Index**: Flexible tensor index with identity, symmetry info, and tags
+- **Tensor**: Dynamic-rank tensor (`TensorDynLen`) with flexible index types
+- **Storage**: Dense and diagonal storage backends for `f64` and `Complex64`
+- **Factorization**: SVD, QR, LU, and CI decompositions with truncation support
+- **Contraction**: Optimal multi-tensor contraction via `contract_multi()`
+
+## Usage
+
+```rust
+use tensor4all_core::{Index, TensorDynLen, factorize, FactorizeOptions};
+
+// Create indices
+let i = Index::new_dyn(3).with_tags("i");
+let j = Index::new_dyn(4).with_tags("j");
+
+// Create a random tensor
+let tensor = TensorDynLen::random(&mut rng, &[i.clone(), j.clone()]);
+
+// SVD factorization with truncation
+let result = factorize(
+    &tensor,
+    &[i],
+    &FactorizeOptions::svd().with_rtol(1e-10)
+)?;
+```
+
+## License
+
+MIT License

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -1,0 +1,39 @@
+# tensor4all-itensorlike
+
+ITensors.jl-inspired high-level API for Tensor Train (MPS) operations with orthogonality tracking. Provides an ergonomic interface similar to the Julia ITensorMPS.jl library.
+
+## Features
+
+- **TensorTrain**: Tensor train with orthogonality center tracking
+- **Multiple canonical forms**: Unitary (QR), LU, or CI canonicalization
+- **Truncation**: Bond dimension truncation with configurable tolerance
+- **Contraction**: Contract two tensor trains (zipup, fit, or naive method)
+- **Inner products**: Efficient norm and inner product computation
+
+## Usage
+
+```rust
+use tensor4all_itensorlike::{TensorTrain, TruncateOptions, CanonicalForm};
+
+// Create tensor train from tensors
+let tt = TensorTrain::new(tensors)?;
+
+// Orthogonalize to site 2 using QR
+tt.orthogonalize(2)?;
+
+// Truncate with SVD
+tt.truncate(&TruncateOptions::svd().with_rtol(1e-10).with_max_rank(20))?;
+
+// Compute norm
+let norm = tt.norm();
+```
+
+## Differences from ITensorMPS.jl
+
+- 0-indexed sites (Julia uses 1-indexed)
+- Multiple canonical forms: Unitary (QR), LU, CI
+- Uses `conj` instead of `dag` (no QN direction flipping)
+
+## License
+
+MIT License

--- a/crates/tensor4all-quanticstci/README.md
+++ b/crates/tensor4all-quanticstci/README.md
@@ -1,0 +1,41 @@
+# tensor4all-quanticstci
+
+High-level wrapper for Quantics Tensor Train (QTT) interpolation. Provides a user-friendly interface for interpolating functions in quantics representation by combining TCI with quantics grid transformations. This is a Rust port of QuanticsTCI.jl.
+
+## Features
+
+- **QuanticsTensorCI2**: Main class for quantics TCI results
+- **Discrete grids**: Interpolate on integer grids
+- **Continuous grids**: Interpolate on floating-point domains
+- **Integration**: Compute integrals over the interpolated function
+- Builder pattern for configuration
+
+## Usage
+
+```rust
+use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+
+// Define a function on a 2D grid
+let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
+
+// Grid sizes (powers of 2)
+let sizes = vec![16, 16];
+
+// Run quantics TCI
+let (qtci, ranks, errors) = quanticscrossinterpolate_discrete(
+    &sizes,
+    f,
+    None,  // auto-select initial pivot
+    QtciOptions::default().with_tolerance(1e-10)
+)?;
+
+// Evaluate at a point
+let value = qtci.evaluate(&[5, 10])?;  // approximately 15.0
+
+// Compute sum over all grid points
+let total = qtci.sum();
+```
+
+## License
+
+MIT License

--- a/crates/tensor4all-simpletensortrain/README.md
+++ b/crates/tensor4all-simpletensortrain/README.md
@@ -1,0 +1,33 @@
+# tensor4all-simpletensortrain
+
+Simple, efficient Tensor Train (MPS) implementation focused on practical computational methods. Provides multiple canonical forms and compression algorithms.
+
+## Features
+
+- **TensorTrain**: Basic MPS with `f64` and `Complex64` support
+- **SiteTensorTrain**: Center-canonical MPS with specified orthogonality center
+- **VidalTensorTrain**: Vidal canonical form with explicit singular values
+- **TTCache**: Caching mechanism for fast repeated evaluation
+- **Compression**: LU, CI, and SVD compression methods
+
+## Usage
+
+```rust
+use tensor4all_simpletensortrain::{TensorTrain, AbstractTensorTrain};
+
+// Create a constant tensor train
+let tt = TensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
+
+// Evaluate at a specific multi-index
+let value = tt.evaluate(&[0, 1, 2])?;
+
+// Compute sum over all indices
+let total = tt.sum();
+
+// Compress with tolerance
+let compressed = tt.compressed(1e-10, Some(20))?;
+```
+
+## License
+
+MIT License

--- a/crates/tensor4all-tensorci/README.md
+++ b/crates/tensor4all-tensorci/README.md
@@ -1,0 +1,38 @@
+# tensor4all-tensorci
+
+Tensor Cross Interpolation (TCI) algorithms for efficiently approximating high-dimensional tensors as tensor trains. Provides both one-site and two-site TCI methods.
+
+## Features
+
+- **TensorCI1**: One-site TCI algorithm
+- **TensorCI2**: Two-site TCI algorithm (more accurate)
+- **CachedFunction**: Wrapper for caching function evaluations
+- **IndexSet**: Efficient management of pivot index sets
+- Supports both `f64` and `Complex64` scalar types
+
+## Usage
+
+```rust
+use tensor4all_tensorci::{crossinterpolate1, TCI1Options};
+
+// Define a function to interpolate
+let f = |idx: &[usize]| (idx[0] + idx[1] + 1) as f64;
+
+// Local dimensions for each index
+let local_dims = vec![4, 4];
+
+// Run TCI
+let (tci, ranks, errors) = crossinterpolate1(
+    f,
+    local_dims,
+    vec![1, 1],  // initial pivot
+    TCI1Options::default().with_tolerance(1e-10)
+)?;
+
+// Evaluate the approximation
+let value = tci.evaluate(&[2, 3])?;
+```
+
+## License
+
+MIT License

--- a/crates/tensor4all-treetn/README.md
+++ b/crates/tensor4all-treetn/README.md
@@ -1,0 +1,44 @@
+# tensor4all-treetn
+
+Tree tensor network (TreeTN) implementation for general tensor networks beyond linear chains. Supports arbitrary tree topologies with local update algorithms, linear solving, and generalized contractions.
+
+## Features
+
+- **TreeTN**: Generic tree tensor network with named nodes
+- **Arbitrary topology**: Build networks with any tree structure
+- **Canonicalization**: Orthogonalize towards any center node
+- **Truncation**: Bond dimension truncation with configurable tolerance
+- **Contraction**: Full contraction and variational (fit) contraction
+- **Linear solving**: Solve linear systems in tree tensor network form
+- **Local updates**: DMRG-like sweep algorithms
+
+## Usage
+
+```rust
+use tensor4all_treetn::{
+    SiteIndexNetwork, LinkSpace, random_treetn_f64,
+    CanonicalizationOptions, TruncationOptions,
+};
+use tensor4all_core::Index;
+
+// Build a tree topology: A -- B -- C
+let mut network = SiteIndexNetwork::new();
+network.add_node("A".into(), vec![Index::new_dyn(2)])?;
+network.add_node("B".into(), vec![Index::new_dyn(2)])?;
+network.add_node("C".into(), vec![Index::new_dyn(2)])?;
+network.add_edge(&"A".into(), &"B".into())?;
+network.add_edge(&"B".into(), &"C".into())?;
+
+// Create random tree tensor network
+let ttn = random_treetn_f64(&mut rng, &network, LinkSpace::uniform(10));
+
+// Canonicalize towards center node B
+let ttn = ttn.canonicalize(["B".into()], CanonicalizationOptions::default())?;
+
+// Truncate bond dimensions
+let ttn = ttn.truncate(["B".into()], TruncationOptions::default().with_max_rank(5))?;
+```
+
+## License
+
+MIT License

--- a/crates/tensor4all/README.md
+++ b/crates/tensor4all/README.md
@@ -1,0 +1,25 @@
+# tensor4all
+
+Unified re-export crate that provides access to all tensor4all functionality through a single dependency.
+
+## Features
+
+- Re-exports core types from `tensor4all-core`
+- Re-exports tensor train functionality from `tensor4all-itensorlike`
+- Re-exports tree tensor networks from `tensor4all-treetn`
+- Single dependency for full tensor4all functionality
+
+## Usage
+
+```rust
+use tensor4all::prelude::*;
+
+// All tensor4all types are available through this crate
+let i = Index::new_dyn(2);
+let j = Index::new_dyn(3);
+let tensor = TensorDynLen::random(&mut rng, &[i, j]);
+```
+
+## License
+
+MIT License


### PR DESCRIPTION
## Summary

- Add README.md to 10 crates with feature overview and sample code
- Add Crate Documentation table in root README.md with links to each crate
- Update .gitignore to allow README.md files in subdirectories

## Crates Documented

| Crate | Description |
|-------|-------------|
| tensor4all-core | Index, Tensor, Storage, SVD/QR/LU |
| tensor4all | Unified re-export package |
| tensor4all-itensorlike | ITensors.jl-like TensorTrain API |
| tensor4all-simpletensortrain | Simple TT/MPS implementation |
| tensor4all-treetn | Tree tensor networks |
| tensor4all-tensorci | Tensor Cross Interpolation |
| tensor4all-quanticstci | High-level Quantics TCI |
| tensor4all-capi | C FFI for language bindings |
| matrixci | Matrix Cross Interpolation |
| quanticsgrids | Quantics grid structures |

## Test plan

- [x] Verify README files are created in each crate directory
- [x] Verify links in root README.md work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)