### PR TITLE
Refactor TensorDynLen storage API and add contraction helpers

### DIFF
--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -139,7 +139,7 @@ pub extern "C" fn t4a_tensor_get_storage_kind(
 
     let result = catch_unwind(|| {
         let tensor = unsafe { &*ptr };
-        let kind = t4a_storage_kind::from_storage(tensor.inner().storage.as_ref());
+        let kind = t4a_storage_kind::from_storage(tensor.inner().storage().as_ref());
         unsafe { *out_kind = kind };
         T4A_SUCCESS
     });
@@ -178,7 +178,7 @@ pub extern "C" fn t4a_tensor_get_data_f64(
     let result = catch_unwind(|| {
         let tensor = unsafe { &*ptr };
 
-        let data = match tensor.inner().storage.as_ref() {
+        let data = match tensor.inner().storage().as_ref() {
             Storage::DenseF64(ds) => ds.as_slice(),
             _ => return T4A_INVALID_ARGUMENT,
         };
@@ -235,7 +235,7 @@ pub extern "C" fn t4a_tensor_get_data_c64(
     let result = catch_unwind(|| {
         let tensor = unsafe { &*ptr };
 
-        let data = match tensor.inner().storage.as_ref() {
+        let data = match tensor.inner().storage().as_ref() {
             Storage::DenseC64(ds) => ds.as_slice(),
             _ => return T4A_INVALID_ARGUMENT,
         };

--- a/crates/tensor4all-core/src/defaults/direct_sum.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum.rs
@@ -48,7 +48,7 @@ pub fn direct_sum(
     pairs: &[(DynIndex, DynIndex)],
 ) -> Result<(TensorDynLen, Vec<DynIndex>)> {
     // Dispatch based on storage type
-    match (a.storage.as_ref(), b.storage.as_ref()) {
+    match (a.storage().as_ref(), b.storage().as_ref()) {
         (Storage::DenseF64(_), Storage::DenseF64(_)) => direct_sum_f64(a, b, pairs),
         (Storage::DenseC64(_), Storage::DenseC64(_)) => direct_sum_c64(a, b, pairs),
         _ => Err(anyhow::anyhow!(
@@ -241,11 +241,11 @@ fn direct_sum_f64(
 ) -> Result<(TensorDynLen, Vec<DynIndex>)> {
     let setup = setup_direct_sum(a, b, pairs)?;
 
-    let a_data = match a.storage.as_ref() {
+    let a_data = match a.storage().as_ref() {
         Storage::DenseF64(s) => s.as_slice(),
         _ => return Err(anyhow::anyhow!("Expected DenseF64 storage")),
     };
-    let b_data = match b.storage.as_ref() {
+    let b_data = match b.storage().as_ref() {
         Storage::DenseF64(s) => s.as_slice(),
         _ => return Err(anyhow::anyhow!("Expected DenseF64 storage")),
     };
@@ -302,11 +302,11 @@ fn direct_sum_c64(
 ) -> Result<(TensorDynLen, Vec<DynIndex>)> {
     let setup = setup_direct_sum(a, b, pairs)?;
 
-    let a_data = match a.storage.as_ref() {
+    let a_data = match a.storage().as_ref() {
         Storage::DenseC64(s) => s.as_slice(),
         _ => return Err(anyhow::anyhow!("Expected DenseC64 storage")),
     };
-    let b_data = match b.storage.as_ref() {
+    let b_data = match b.storage().as_ref() {
         Storage::DenseC64(s) => s.as_slice(),
         _ => return Err(anyhow::anyhow!("Expected DenseC64 storage")),
     };
@@ -409,7 +409,7 @@ mod tests {
         assert_eq!(new_indices[0].dim(), 7);
 
         // Check data
-        let data = match result.storage.as_ref() {
+        let data = match result.storage().as_ref() {
             Storage::DenseF64(s) => s.as_slice(),
             _ => panic!("Expected DenseF64"),
         };

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -63,7 +63,7 @@ pub fn factorize(
     options: &FactorizeOptions,
 ) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
     // Dispatch based on storage type
-    match t.storage.as_ref() {
+    match t.storage().as_ref() {
         Storage::DenseF64(_) => factorize_impl::<f64>(t, left_inds, options),
         Storage::DenseC64(_) => factorize_impl::<Complex64>(t, left_inds, options),
         Storage::DiagF64(_) | Storage::DiagC64(_) => Err(FactorizeError::UnsupportedStorage(
@@ -331,7 +331,7 @@ where
 
 /// Extract singular values from a diagonal tensor.
 fn extract_singular_values(s: &TensorDynLen) -> Vec<f64> {
-    match s.storage.as_ref() {
+    match s.storage().as_ref() {
         Storage::DiagF64(diag) => diag.as_slice().to_vec(),
         Storage::DiagC64(diag) => {
             // Singular values should be real

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -18,6 +18,7 @@
 //! a good balance of flexibility and performance.
 
 pub mod index;
+pub mod tensor_data;
 pub mod tensordynlen;
 
 // Contraction
@@ -32,6 +33,7 @@ pub mod svd;
 pub use index::{
     DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet,
 };
+pub use tensor_data::{TensorComponent, TensorData};
 pub use tensordynlen::{
     compute_permutation_from_indices, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor,
     unfold_split, TensorAccess, TensorDynLen,

--- a/crates/tensor4all-core/src/defaults/tensor_data.rs
+++ b/crates/tensor4all-core/src/defaults/tensor_data.rs
@@ -1,0 +1,470 @@
+//! TensorData: Lazy tensor representation as outer product of storages.
+//!
+//! This module provides a lazy tensor representation that tracks outer products
+//! and permutations without actually performing them until necessary.
+//!
+//! # Architecture
+//!
+//! ```text
+//! TensorDynLen (high-level API with Index info)
+//!     ↓
+//! TensorData (outer product structure, lazy permutation)
+//!     ↓
+//! Storage (raw data, passed to backend)
+//! ```
+
+use std::sync::Arc;
+
+use crate::defaults::DynId;
+use crate::storage::Storage;
+
+/// A component of a TensorData, representing a single Storage with its index mapping.
+#[derive(Debug, Clone)]
+pub struct TensorComponent {
+    /// The underlying storage.
+    pub storage: Arc<Storage>,
+    /// Index IDs for each dimension of this storage (in storage memory order).
+    pub index_ids: Vec<DynId>,
+    /// Dimension sizes (same order as index_ids).
+    pub dims: Vec<usize>,
+}
+
+impl TensorComponent {
+    /// Create a new TensorComponent.
+    pub fn new(storage: Arc<Storage>, index_ids: Vec<DynId>, dims: Vec<usize>) -> Self {
+        debug_assert_eq!(
+            index_ids.len(),
+            dims.len(),
+            "index_ids and dims must have the same length"
+        );
+        Self {
+            storage,
+            index_ids,
+            dims,
+        }
+    }
+
+    /// Get the number of dimensions.
+    pub fn ndim(&self) -> usize {
+        self.index_ids.len()
+    }
+
+    /// Get the total number of elements.
+    pub fn numel(&self) -> usize {
+        self.dims.iter().product()
+    }
+}
+
+/// Lazy tensor representation as an outer product of component storages.
+///
+/// TensorData tracks:
+/// - Multiple component storages (from outer products)
+/// - The external index order (which may differ from storage order due to permutations)
+///
+/// Operations like `outer_product` and `permute` are lazy - they only update
+/// the structure without moving data. Actual computation happens during
+/// `materialize` or `contraction`.
+#[derive(Debug, Clone)]
+pub struct TensorData {
+    /// Component storages forming the outer product.
+    pub components: Vec<TensorComponent>,
+    /// External index IDs in current user-facing order.
+    /// This is the order that will be used when materializing.
+    pub external_index_ids: Vec<DynId>,
+    /// Dimension for each external index (same order as external_index_ids).
+    pub external_dims: Vec<usize>,
+}
+
+impl TensorData {
+    /// Create a new TensorData from a single storage.
+    pub fn new(storage: Arc<Storage>, index_ids: Vec<DynId>, dims: Vec<usize>) -> Self {
+        let component = TensorComponent::new(storage, index_ids.clone(), dims.clone());
+        Self {
+            components: vec![component],
+            external_index_ids: index_ids,
+            external_dims: dims,
+        }
+    }
+
+    /// Create TensorData from components with explicit external order.
+    pub fn from_components(
+        components: Vec<TensorComponent>,
+        external_index_ids: Vec<DynId>,
+        external_dims: Vec<usize>,
+    ) -> Self {
+        Self {
+            components,
+            external_index_ids,
+            external_dims,
+        }
+    }
+
+    /// Check if this is a simple tensor (single component, no permutation needed).
+    pub fn is_simple(&self) -> bool {
+        self.components.len() == 1 && self.components[0].index_ids == self.external_index_ids
+    }
+
+    /// Get the underlying storage if this is a simple tensor.
+    pub fn storage(&self) -> Option<&Arc<Storage>> {
+        if self.is_simple() {
+            Some(&self.components[0].storage)
+        } else {
+            None
+        }
+    }
+
+    /// Get the number of external dimensions.
+    pub fn ndim(&self) -> usize {
+        self.external_index_ids.len()
+    }
+
+    /// Get the total number of elements.
+    pub fn numel(&self) -> usize {
+        self.external_dims.iter().product()
+    }
+
+    /// Get the external dimensions.
+    pub fn dims(&self) -> &[usize] {
+        &self.external_dims
+    }
+
+    /// Get the external index IDs.
+    pub fn index_ids(&self) -> &[DynId] {
+        &self.external_index_ids
+    }
+
+    /// Compute outer product of two TensorData (lazy).
+    ///
+    /// This just concatenates the components and index lists without
+    /// actually computing the outer product data.
+    pub fn outer_product(a: &Self, b: &Self) -> Self {
+        let mut components = a.components.clone();
+        components.extend(b.components.iter().cloned());
+
+        let mut external_index_ids = a.external_index_ids.clone();
+        external_index_ids.extend(b.external_index_ids.iter().cloned());
+
+        let mut external_dims = a.external_dims.clone();
+        external_dims.extend(b.external_dims.iter().cloned());
+
+        Self {
+            components,
+            external_index_ids,
+            external_dims,
+        }
+    }
+
+    /// Permute the external index order (lazy).
+    ///
+    /// This only updates the external_index_ids order without touching
+    /// the underlying storage data.
+    ///
+    /// # Arguments
+    /// * `new_order` - The new index order as a list of DynIds.
+    ///                 Must be a permutation of external_index_ids.
+    pub fn permute(&self, new_order: &[DynId]) -> Self {
+        assert_eq!(
+            new_order.len(),
+            self.external_index_ids.len(),
+            "new_order must have the same length as external_index_ids"
+        );
+
+        // Build the permutation and new dims
+        let mut new_dims = Vec::with_capacity(new_order.len());
+        for new_id in new_order {
+            let pos = self
+                .external_index_ids
+                .iter()
+                .position(|id| id == new_id)
+                .expect("new_order must be a permutation of external_index_ids");
+            new_dims.push(self.external_dims[pos]);
+        }
+
+        Self {
+            components: self.components.clone(),
+            external_index_ids: new_order.to_vec(),
+            external_dims: new_dims,
+        }
+    }
+
+    /// Permute using a permutation array.
+    ///
+    /// # Arguments
+    /// * `perm` - Permutation array where `perm[i]` is the old position of
+    ///            the index that should be at new position `i`.
+    pub fn permute_by_perm(&self, perm: &[usize]) -> Self {
+        assert_eq!(
+            perm.len(),
+            self.external_index_ids.len(),
+            "perm must have the same length as external_index_ids"
+        );
+
+        let new_order: Vec<DynId> = perm
+            .iter()
+            .map(|&old_pos| self.external_index_ids[old_pos].clone())
+            .collect();
+
+        let new_dims: Vec<usize> = perm
+            .iter()
+            .map(|&old_pos| self.external_dims[old_pos])
+            .collect();
+
+        Self {
+            components: self.components.clone(),
+            external_index_ids: new_order,
+            external_dims: new_dims,
+        }
+    }
+
+    /// Materialize the tensor into a single Storage with the external index order.
+    ///
+    /// This contracts all components and permutes the result to match
+    /// the external_index_ids order.
+    ///
+    /// # Returns
+    /// A tuple of (Storage, dims) where dims matches external_dims.
+    pub fn materialize(&self) -> anyhow::Result<(Arc<Storage>, Vec<usize>)> {
+        use crate::defaults::{contract_multi, DynIndex, Index, TensorDynLen};
+        use crate::tensor_like::TensorLike;
+
+        if self.components.is_empty() {
+            return Err(anyhow::anyhow!("Cannot materialize empty TensorData"));
+        }
+
+        // Convert components to TensorDynLen for contraction
+        let tensors: Vec<TensorDynLen> = self
+            .components
+            .iter()
+            .map(|comp| {
+                let indices: Vec<DynIndex> = comp
+                    .index_ids
+                    .iter()
+                    .zip(comp.dims.iter())
+                    .map(|(id, &dim)| Index::new(id.clone(), dim))
+                    .collect();
+                TensorDynLen::new(indices, comp.dims.clone(), comp.storage.clone())
+            })
+            .collect();
+
+        // Contract all components (outer product if no common indices)
+        let contracted = contract_multi(&tensors)?;
+
+        // Check if we need to permute to match external order
+        let contracted_ids: Vec<DynId> = contracted
+            .indices
+            .iter()
+            .map(|idx| idx.id.clone())
+            .collect();
+
+        if contracted_ids == self.external_index_ids {
+            // Already in the right order
+            Ok((contracted.storage().clone(), contracted.dims))
+        } else {
+            // Need to permute
+            let target_indices: Vec<DynIndex> = self
+                .external_index_ids
+                .iter()
+                .zip(self.external_dims.iter())
+                .map(|(id, &dim)| Index::new(id.clone(), dim))
+                .collect();
+
+            let permuted = contracted.permuteinds(&target_indices)?;
+            Ok((permuted.storage().clone(), permuted.dims))
+        }
+    }
+
+    /// Get all components (for passing to contraction).
+    pub fn into_components(self) -> Vec<TensorComponent> {
+        self.components
+    }
+
+    /// Get a reference to all components.
+    pub fn components(&self) -> &[TensorComponent] {
+        &self.components
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{DenseStorageF64, Storage};
+
+    fn make_test_storage(data: Vec<f64>) -> Arc<Storage> {
+        Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data)))
+    }
+
+    fn new_id() -> DynId {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        DynId(COUNTER.fetch_add(1, Ordering::Relaxed) as u128)
+    }
+
+    #[test]
+    fn test_tensor_data_simple() {
+        let storage = make_test_storage(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let data = TensorData::new(storage, vec![id_i.clone(), id_j.clone()], vec![2, 3]);
+
+        assert!(data.is_simple());
+        assert_eq!(data.ndim(), 2);
+        assert_eq!(data.numel(), 6);
+        assert_eq!(data.dims(), &[2, 3]);
+    }
+
+    #[test]
+    fn test_outer_product() {
+        let storage_a = make_test_storage(vec![1.0, 2.0]);
+        let storage_b = make_test_storage(vec![3.0, 4.0, 5.0]);
+
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let a = TensorData::new(storage_a, vec![id_i.clone()], vec![2]);
+        let b = TensorData::new(storage_b, vec![id_j.clone()], vec![3]);
+
+        let c = TensorData::outer_product(&a, &b);
+
+        assert!(!c.is_simple());
+        assert_eq!(c.components.len(), 2);
+        assert_eq!(c.ndim(), 2);
+        assert_eq!(c.numel(), 6);
+        assert_eq!(c.external_index_ids, vec![id_i, id_j]);
+        assert_eq!(c.external_dims, vec![2, 3]);
+    }
+
+    #[test]
+    fn test_permute() {
+        let storage = make_test_storage(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let data = TensorData::new(storage, vec![id_i.clone(), id_j.clone()], vec![2, 3]);
+
+        // Permute to [j, i]
+        let permuted = data.permute(&[id_j.clone(), id_i.clone()]);
+
+        // After permute, external order differs from storage order, so not simple
+        assert!(!permuted.is_simple());
+        assert_eq!(permuted.external_index_ids, vec![id_j, id_i]);
+        assert_eq!(permuted.external_dims, vec![3, 2]);
+
+        // Internal storage order unchanged
+        assert_eq!(permuted.components[0].index_ids, data.components[0].index_ids);
+    }
+
+    #[test]
+    fn test_permute_outer_product() {
+        let storage_a = make_test_storage(vec![1.0, 2.0]);
+        let storage_b = make_test_storage(vec![3.0, 4.0, 5.0]);
+
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let a = TensorData::new(storage_a, vec![id_i.clone()], vec![2]);
+        let b = TensorData::new(storage_b, vec![id_j.clone()], vec![3]);
+
+        let c = TensorData::outer_product(&a, &b);
+
+        // Permute to [j, i]
+        let permuted = c.permute(&[id_j.clone(), id_i.clone()]);
+
+        assert_eq!(permuted.external_index_ids, vec![id_j, id_i]);
+        assert_eq!(permuted.external_dims, vec![3, 2]);
+
+        // Components unchanged
+        assert_eq!(permuted.components.len(), 2);
+        assert_eq!(permuted.components[0].index_ids, vec![id_i]);
+        assert_eq!(permuted.components[1].index_ids, vec![id_j]);
+    }
+
+    #[test]
+    fn test_materialize_simple() {
+        let storage = make_test_storage(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let data = TensorData::new(storage.clone(), vec![id_i.clone(), id_j.clone()], vec![2, 3]);
+
+        let (materialized, dims) = data.materialize().unwrap();
+        assert_eq!(dims, vec![2, 3]);
+
+        // For a simple tensor, materialized storage should match original
+        match (materialized.as_ref(), storage.as_ref()) {
+            (Storage::DenseF64(m), Storage::DenseF64(orig)) => {
+                assert_eq!(m.as_slice(), orig.as_slice());
+            }
+            _ => panic!("Expected DenseF64 storage"),
+        }
+    }
+
+    #[test]
+    fn test_materialize_outer_product() {
+        // a = [1, 2], b = [3, 4, 5]
+        // outer product a ⊗ b should be:
+        // [[1*3, 1*4, 1*5], [2*3, 2*4, 2*5]] = [[3, 4, 5], [6, 8, 10]]
+        // In row-major: [3, 4, 5, 6, 8, 10]
+        let storage_a = make_test_storage(vec![1.0, 2.0]);
+        let storage_b = make_test_storage(vec![3.0, 4.0, 5.0]);
+
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let a = TensorData::new(storage_a, vec![id_i.clone()], vec![2]);
+        let b = TensorData::new(storage_b, vec![id_j.clone()], vec![3]);
+
+        let c = TensorData::outer_product(&a, &b);
+
+        let (materialized, dims) = c.materialize().unwrap();
+        assert_eq!(dims, vec![2, 3]);
+
+        match materialized.as_ref() {
+            Storage::DenseF64(m) => {
+                let data = m.as_slice();
+                assert_eq!(data.len(), 6);
+                // Expected: [3, 4, 5, 6, 8, 10]
+                let expected = vec![3.0, 4.0, 5.0, 6.0, 8.0, 10.0];
+                for (a, b) in data.iter().zip(expected.iter()) {
+                    assert!((a - b).abs() < 1e-10);
+                }
+            }
+            _ => panic!("Expected DenseF64 storage"),
+        }
+    }
+
+    #[test]
+    fn test_materialize_with_permute() {
+        // a = [1, 2], b = [3, 4, 5]
+        // outer product a ⊗ b with indices [i, j] gives [[3, 4, 5], [6, 8, 10]]
+        // After permute to [j, i], should be transposed:
+        // [[3, 6], [4, 8], [5, 10]] in row-major: [3, 6, 4, 8, 5, 10]
+        let storage_a = make_test_storage(vec![1.0, 2.0]);
+        let storage_b = make_test_storage(vec![3.0, 4.0, 5.0]);
+
+        let id_i = new_id();
+        let id_j = new_id();
+
+        let a = TensorData::new(storage_a, vec![id_i.clone()], vec![2]);
+        let b = TensorData::new(storage_b, vec![id_j.clone()], vec![3]);
+
+        let c = TensorData::outer_product(&a, &b);
+        let permuted = c.permute(&[id_j.clone(), id_i.clone()]);
+
+        let (materialized, dims) = permuted.materialize().unwrap();
+        assert_eq!(dims, vec![3, 2]);
+
+        match materialized.as_ref() {
+            Storage::DenseF64(m) => {
+                let data = m.as_slice();
+                assert_eq!(data.len(), 6);
+                // Expected after transpose: [3, 6, 4, 8, 5, 10]
+                let expected = vec![3.0, 6.0, 4.0, 8.0, 5.0, 10.0];
+                for (a, b) in data.iter().zip(expected.iter()) {
+                    assert!((a - b).abs() < 1e-10);
+                }
+            }
+            _ => panic!("Expected DenseF64 storage"),
+        }
+    }
+}

--- a/crates/tensor4all-core/src/index_ops.rs
+++ b/crates/tensor4all-core/src/index_ops.rs
@@ -475,3 +475,307 @@ pub fn common_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
         .cloned()
         .collect()
 }
+
+/// Find common indices between two slices and return their positions.
+///
+/// Returns a vector of `(pos_a, pos_b)` tuples where each tuple indicates
+/// that `indices_a[pos_a]` and `indices_b[pos_b]` have the same ID.
+///
+/// # Example
+/// ```
+/// use tensor4all_core::index::DefaultIndex as Index;
+/// use tensor4all_core::index_ops::common_ind_positions;
+///
+/// let i = Index::new_dyn(2);
+/// let j = Index::new_dyn(3);
+/// let k = Index::new_dyn(4);
+///
+/// let indices_a = vec![i.clone(), j.clone()];
+/// let indices_b = vec![j.clone(), k.clone()];
+///
+/// let positions = common_ind_positions(&indices_a, &indices_b);
+/// assert_eq!(positions, vec![(1, 0)]); // j is at position 1 in a, position 0 in b
+/// ```
+pub fn common_ind_positions<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<(usize, usize)> {
+    let mut positions = Vec::new();
+    for (pos_a, idx_a) in indices_a.iter().enumerate() {
+        for (pos_b, idx_b) in indices_b.iter().enumerate() {
+            if idx_a.id() == idx_b.id() {
+                positions.push((pos_a, pos_b));
+                break; // Each index in a can match at most one in b
+            }
+        }
+    }
+    positions
+}
+
+/// Result of preparing a tensor contraction.
+///
+/// Contains all the information needed to perform the contraction:
+/// - Which axes to contract from each tensor
+/// - The resulting indices and dimensions after contraction
+#[derive(Debug, Clone)]
+pub struct ContractionSpec<I: IndexLike> {
+    /// Axes to contract from the first tensor (positions in indices_a)
+    pub axes_a: Vec<usize>,
+    /// Axes to contract from the second tensor (positions in indices_b)
+    pub axes_b: Vec<usize>,
+    /// Indices of the result tensor (non-contracted indices from both tensors)
+    pub result_indices: Vec<I>,
+    /// Dimensions of the result tensor
+    pub result_dims: Vec<usize>,
+}
+
+/// Error type for contraction preparation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContractionError {
+    /// No common indices found for contraction
+    NoCommonIndices,
+    /// Dimension mismatch for a common index
+    DimensionMismatch {
+        pos_a: usize,
+        pos_b: usize,
+        dim_a: usize,
+        dim_b: usize,
+    },
+    /// Duplicate axis specified in contraction
+    DuplicateAxis { tensor: &'static str, pos: usize },
+    /// Index not found in tensor
+    IndexNotFound { tensor: &'static str },
+    /// Batch contraction not yet implemented
+    BatchContractionNotImplemented,
+}
+
+impl std::fmt::Display for ContractionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ContractionError::NoCommonIndices => {
+                write!(f, "No common indices found for contraction")
+            }
+            ContractionError::DimensionMismatch {
+                pos_a,
+                pos_b,
+                dim_a,
+                dim_b,
+            } => {
+                write!(
+                    f,
+                    "Dimension mismatch: tensor_a[{}]={} != tensor_b[{}]={}",
+                    pos_a, dim_a, pos_b, dim_b
+                )
+            }
+            ContractionError::DuplicateAxis { tensor, pos } => {
+                write!(f, "Duplicate axis {} in {} tensor", pos, tensor)
+            }
+            ContractionError::IndexNotFound { tensor } => {
+                write!(f, "Index not found in {} tensor", tensor)
+            }
+            ContractionError::BatchContractionNotImplemented => {
+                write!(f, "Batch contraction not yet implemented")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ContractionError {}
+
+/// Prepare contraction data for two tensors that share common indices.
+///
+/// This function finds common indices and computes the axes to contract
+/// and the resulting indices/dimensions.
+///
+/// # Example
+/// ```
+/// use tensor4all_core::index::DefaultIndex as Index;
+/// use tensor4all_core::index_ops::prepare_contraction;
+///
+/// let i = Index::new_dyn(2);
+/// let j = Index::new_dyn(3);
+/// let k = Index::new_dyn(4);
+///
+/// let indices_a = vec![i.clone(), j.clone()];
+/// let dims_a = vec![2, 3];
+/// let indices_b = vec![j.clone(), k.clone()];
+/// let dims_b = vec![3, 4];
+///
+/// let spec = prepare_contraction(&indices_a, &dims_a, &indices_b, &dims_b).unwrap();
+/// assert_eq!(spec.axes_a, vec![1]);  // j is at position 1 in a
+/// assert_eq!(spec.axes_b, vec![0]);  // j is at position 0 in b
+/// assert_eq!(spec.result_dims, vec![2, 4]);  // [i, k]
+/// ```
+pub fn prepare_contraction<I: IndexLike>(
+    indices_a: &[I],
+    dims_a: &[usize],
+    indices_b: &[I],
+    dims_b: &[usize],
+) -> Result<ContractionSpec<I>, ContractionError> {
+    // Find common indices and their positions
+    let positions = common_ind_positions(indices_a, indices_b);
+    if positions.is_empty() {
+        return Err(ContractionError::NoCommonIndices);
+    }
+
+    let (axes_a, axes_b): (Vec<_>, Vec<_>) = positions.iter().copied().unzip();
+
+    // Verify dimensions match
+    for &(pos_a, pos_b) in &positions {
+        if dims_a[pos_a] != dims_b[pos_b] {
+            return Err(ContractionError::DimensionMismatch {
+                pos_a,
+                pos_b,
+                dim_a: dims_a[pos_a],
+                dim_b: dims_b[pos_b],
+            });
+        }
+    }
+
+    // Build result indices and dimensions (non-contracted indices)
+    let mut result_indices = Vec::new();
+    let mut result_dims = Vec::new();
+
+    for (i, idx) in indices_a.iter().enumerate() {
+        if !axes_a.contains(&i) {
+            result_indices.push(idx.clone());
+            result_dims.push(dims_a[i]);
+        }
+    }
+
+    for (i, idx) in indices_b.iter().enumerate() {
+        if !axes_b.contains(&i) {
+            result_indices.push(idx.clone());
+            result_dims.push(dims_b[i]);
+        }
+    }
+
+    Ok(ContractionSpec {
+        axes_a,
+        axes_b,
+        result_indices,
+        result_dims,
+    })
+}
+
+/// Prepare contraction data for explicit index pairs (like tensordot).
+///
+/// Unlike `prepare_contraction`, this function takes explicit pairs of indices
+/// to contract, allowing contraction of indices with different IDs.
+///
+/// # Example
+/// ```
+/// use tensor4all_core::index::DefaultIndex as Index;
+/// use tensor4all_core::index_ops::prepare_contraction_pairs;
+///
+/// let i = Index::new_dyn(2);
+/// let j = Index::new_dyn(3);
+/// let k = Index::new_dyn(3);  // Same dim as j but different ID
+/// let l = Index::new_dyn(4);
+///
+/// let indices_a = vec![i.clone(), j.clone()];
+/// let dims_a = vec![2, 3];
+/// let indices_b = vec![k.clone(), l.clone()];
+/// let dims_b = vec![3, 4];
+///
+/// // Contract j with k
+/// let spec = prepare_contraction_pairs(
+///     &indices_a, &dims_a,
+///     &indices_b, &dims_b,
+///     &[(j.clone(), k.clone())]
+/// ).unwrap();
+/// assert_eq!(spec.axes_a, vec![1]);
+/// assert_eq!(spec.axes_b, vec![0]);
+/// assert_eq!(spec.result_dims, vec![2, 4]);
+/// ```
+pub fn prepare_contraction_pairs<I: IndexLike>(
+    indices_a: &[I],
+    dims_a: &[usize],
+    indices_b: &[I],
+    dims_b: &[usize],
+    pairs: &[(I, I)],
+) -> Result<ContractionSpec<I>, ContractionError> {
+    use std::collections::HashSet;
+
+    if pairs.is_empty() {
+        return Err(ContractionError::NoCommonIndices);
+    }
+
+    // Check for batch contraction (common indices not in pairs)
+    let contracted_a_ids: HashSet<_> = pairs.iter().map(|(idx, _)| idx.id()).collect();
+    let contracted_b_ids: HashSet<_> = pairs.iter().map(|(_, idx)| idx.id()).collect();
+
+    let common_positions = common_ind_positions(indices_a, indices_b);
+    for (pos_a, pos_b) in &common_positions {
+        let id_a = indices_a[*pos_a].id();
+        let id_b = indices_b[*pos_b].id();
+        if !contracted_a_ids.contains(id_a) || !contracted_b_ids.contains(id_b) {
+            return Err(ContractionError::BatchContractionNotImplemented);
+        }
+    }
+
+    // Find positions and validate
+    let mut axes_a = Vec::new();
+    let mut axes_b = Vec::new();
+
+    for (idx_a, idx_b) in pairs {
+        let pos_a = indices_a
+            .iter()
+            .position(|idx| idx.id() == idx_a.id())
+            .ok_or(ContractionError::IndexNotFound { tensor: "self" })?;
+
+        let pos_b = indices_b
+            .iter()
+            .position(|idx| idx.id() == idx_b.id())
+            .ok_or(ContractionError::IndexNotFound { tensor: "other" })?;
+
+        // Verify dimensions match
+        if dims_a[pos_a] != dims_b[pos_b] {
+            return Err(ContractionError::DimensionMismatch {
+                pos_a,
+                pos_b,
+                dim_a: dims_a[pos_a],
+                dim_b: dims_b[pos_b],
+            });
+        }
+
+        // Check for duplicate axes
+        if axes_a.contains(&pos_a) {
+            return Err(ContractionError::DuplicateAxis {
+                tensor: "self",
+                pos: pos_a,
+            });
+        }
+        if axes_b.contains(&pos_b) {
+            return Err(ContractionError::DuplicateAxis {
+                tensor: "other",
+                pos: pos_b,
+            });
+        }
+
+        axes_a.push(pos_a);
+        axes_b.push(pos_b);
+    }
+
+    // Build result indices and dimensions
+    let mut result_indices = Vec::new();
+    let mut result_dims = Vec::new();
+
+    for (i, idx) in indices_a.iter().enumerate() {
+        if !axes_a.contains(&i) {
+            result_indices.push(idx.clone());
+            result_dims.push(dims_a[i]);
+        }
+    }
+
+    for (i, idx) in indices_b.iter().enumerate() {
+        if !axes_b.contains(&i) {
+            result_indices.push(idx.clone());
+            result_dims.push(dims_b[i]);
+        }
+    }
+
+    Ok(ContractionSpec {
+        axes_a,
+        axes_b,
+        result_indices,
+        result_dims,
+    })
+}

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -16,8 +16,10 @@ pub use index_like::{ConjState, IndexLike};
 // Index operations (uses defaults::*)
 pub mod index_ops;
 pub use index_ops::{
-    check_unique_indices, common_inds, hascommoninds, hasind, hasinds, noncommon_inds, replaceinds,
-    replaceinds_in_place, union_inds, unique_inds, ReplaceIndsError,
+    check_unique_indices, common_ind_positions, common_inds, hascommoninds, hasind, hasinds,
+    noncommon_inds, prepare_contraction, prepare_contraction_pairs, replaceinds,
+    replaceinds_in_place, union_inds, unique_inds, ContractionError, ContractionSpec,
+    ReplaceIndsError,
 };
 pub use smallstring::{SmallChar, SmallString, SmallStringError};
 pub use tagset::{Tag, TagSetError, TagSetLike};
@@ -42,6 +44,7 @@ pub use defaults::tensordynlen::{
     compute_permutation_from_indices, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor,
     unfold_split, TensorAccess, TensorDynLen,
 };
+pub use defaults::tensor_data::{TensorComponent, TensorData};
 pub use tensor_like::{
     Canonical, DirectSumResult, FactorizeAlg, FactorizeError, FactorizeOptions, FactorizeResult, TensorLike,
 };

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -17,11 +17,7 @@ fn create_test_matrix() -> TensorDynLen {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data)));
 
-    TensorDynLen {
-        indices: vec![i, j],
-        dims: vec![2, 3],
-        storage,
-    }
+    TensorDynLen::new(vec![i, j], vec![2, 3], storage)
 }
 
 /// Helper to create a rank-3 tensor for testing.
@@ -33,11 +29,7 @@ fn create_rank3_tensor() -> TensorDynLen {
     let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
     let storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data)));
 
-    TensorDynLen {
-        indices: vec![i, j, k],
-        dims: vec![2, 3, 2],
-        storage,
-    }
+    TensorDynLen::new(vec![i, j, k], vec![2, 3, 2], storage)
 }
 
 // ============================================================================
@@ -240,16 +232,12 @@ fn test_diag_dense_contraction_svd_internals() {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data)));
 
-    let tensor: TensorDynLen = TensorDynLen {
-        indices: vec![i.clone(), j.clone()],
-        dims: vec![2, 3],
-        storage,
-    };
+    let tensor: TensorDynLen = TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 3], storage);
 
     let (u, s, v) = svd::<f64>(&tensor, &[i.clone()]).expect("SVD should succeed");
 
     // Verify S is diagonal storage
-    assert!(matches!(s.storage.as_ref(), Storage::DiagF64(_)));
+    assert!(matches!(s.storage().as_ref(), Storage::DiagF64(_)));
 
     // Verify S and V share a common index
     let common_found = s
@@ -273,7 +261,7 @@ fn test_diag_dense_contraction_svd_internals() {
 fn assert_tensors_approx_equal(a: &TensorDynLen, b: &TensorDynLen, tol: f64) {
     assert_eq!(a.dims, b.dims, "Tensor dimensions don't match");
 
-    match (a.storage.as_ref(), b.storage.as_ref()) {
+    match (a.storage().as_ref(), b.storage().as_ref()) {
         (Storage::DenseF64(a_data), Storage::DenseF64(b_data)) => {
             let a_slice = a_data.as_slice();
             let b_slice = b_data.as_slice();

--- a/crates/tensor4all-core/tests/linalg_qr.rs
+++ b/crates/tensor4all-core/tests/linalg_qr.rs
@@ -90,11 +90,11 @@ fn test_qr_reconstruction() {
 
     // Reconstruct: A = Q * R
     // Extract Q and R data
-    let q_data = match q.storage.as_ref() {
+    let q_data = match q.storage().as_ref() {
         Storage::DenseF64(dense) => dense.as_slice(),
         _ => panic!("Q should be dense"),
     };
-    let r_data = match r.storage.as_ref() {
+    let r_data = match r.storage().as_ref() {
         Storage::DenseF64(dense) => dense.as_slice(),
         _ => panic!("R should be dense"),
     };
@@ -128,7 +128,7 @@ fn test_qr_reconstruction() {
     assert_eq!(reconstructed.dims, vec![3, 4]);
 
     // Extract reconstructed data
-    let reconstructed_data_vec = match reconstructed.storage.as_ref() {
+    let reconstructed_data_vec = match reconstructed.storage().as_ref() {
         Storage::DenseF64(dense) => dense.as_slice().to_vec(),
         _ => panic!("Reconstructed should be dense"),
     };
@@ -252,11 +252,11 @@ fn test_qr_complex_reconstruction() {
 
     let (q, r) = qr_c64(&tensor, &[i_idx.clone()]).expect("Complex QR should succeed");
 
-    let q_data = match q.storage.as_ref() {
+    let q_data = match q.storage().as_ref() {
         Storage::DenseC64(dense) => dense.as_slice(),
         _ => panic!("Q should be dense complex"),
     };
-    let r_data = match r.storage.as_ref() {
+    let r_data = match r.storage().as_ref() {
         Storage::DenseC64(dense) => dense.as_slice(),
         _ => panic!("R should be dense complex"),
     };

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -35,7 +35,7 @@ fn test_svd_identity() {
 
     // For identity matrix, singular values should be [1, 1] (in some order)
     // Extract singular values from diagonal storage
-    match s.storage.as_ref() {
+    match s.storage().as_ref() {
         Storage::DiagF64(diag) => {
             let s_vals = diag.as_slice();
             assert_eq!(s_vals.len(), 2);
@@ -121,15 +121,15 @@ fn test_svd_reconstruction() {
 
     // For now, let's use a simpler approach: manually reconstruct
     // Extract U, S, V data
-    let u_data = match u.storage.as_ref() {
+    let u_data = match u.storage().as_ref() {
         Storage::DenseF64(dense) => dense.as_slice(),
         _ => panic!("U should be dense"),
     };
-    let s_data = match s.storage.as_ref() {
+    let s_data = match s.storage().as_ref() {
         Storage::DiagF64(diag) => diag.as_slice(),
         _ => panic!("S should be diagonal"),
     };
-    let v_data = match v.storage.as_ref() {
+    let v_data = match v.storage().as_ref() {
         Storage::DenseF64(dense) => dense.as_slice(),
         _ => panic!("V should be dense"),
     };
@@ -163,7 +163,7 @@ fn test_svd_reconstruction() {
     assert_eq!(reconstructed.dims, vec![3, 4]);
 
     // Extract reconstructed data
-    let reconstructed_data_vec = match reconstructed.storage.as_ref() {
+    let reconstructed_data_vec = match reconstructed.storage().as_ref() {
         Storage::DenseF64(dense) => dense.as_slice().to_vec(),
         _ => panic!("Reconstructed should be dense"),
     };
@@ -295,15 +295,15 @@ fn test_svd_complex_reconstruction() {
 
     let (u, s, v) = svd_c64(&tensor, &[i_idx.clone()]).expect("Complex SVD should succeed");
 
-    let u_data = match u.storage.as_ref() {
+    let u_data = match u.storage().as_ref() {
         Storage::DenseC64(dense) => dense.as_slice(),
         _ => panic!("U should be dense complex"),
     };
-    let s_data = match s.storage.as_ref() {
+    let s_data = match s.storage().as_ref() {
         Storage::DiagF64(diag) => diag.as_slice(),
         _ => panic!("S should be diagonal real (f64)"),
     };
-    let v_data = match v.storage.as_ref() {
+    let v_data = match v.storage().as_ref() {
         Storage::DenseC64(dense) => dense.as_slice(),
         _ => panic!("V should be dense complex"),
     };
@@ -377,7 +377,7 @@ fn test_svd_truncation() {
     assert_eq!(v.dims, vec![2, 1], "V should be truncated to rank 1");
 
     // Check singular value
-    match s.storage.as_ref() {
+    match s.storage().as_ref() {
         Storage::DiagF64(diag) => {
             let s_vals = diag.as_slice();
             assert_eq!(s_vals.len(), 1);

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -127,49 +127,26 @@ fn test_tensor_dyn_len_mismatch() {
 }
 
 #[test]
-fn test_tensor_cow() {
+fn test_tensor_shared_storage() {
     let indices = vec![Index::new_dyn(2)];
     let dims = vec![2];
     let storage = Arc::new(Storage::new_dense_f64(2));
 
-    let mut tensor1 =
-        TensorDynLen::new(indices.clone(), dims.clone(), Arc::clone(&storage));
+    let tensor1 = TensorDynLen::new(indices.clone(), dims.clone(), Arc::clone(&storage));
     let tensor2 = TensorDynLen::new(indices, dims, storage);
 
-    // Initially, both tensors share the same storage
-    assert!(Arc::ptr_eq(&tensor1.storage, &tensor2.storage));
+    // Both tensors share the same storage
+    assert!(Arc::ptr_eq(tensor1.storage(), tensor2.storage()));
 
-    // Mutate tensor1's storage (should clone due to COW)
-    {
-        let mut_storage = tensor1.storage_mut();
-        match mut_storage {
-            Storage::DenseF64(v) => {
-                v.push(42.0);
-            }
-            Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => {
-                panic!("expected DenseF64")
-            }
-        }
-    }
+    // Operations that don't modify storage should still share it
+    let cloned = tensor1.clone();
+    assert!(Arc::ptr_eq(tensor1.storage(), cloned.storage()));
 
-    // After mutation, they should have different storage
-    assert!(!Arc::ptr_eq(&tensor1.storage, &tensor2.storage));
-
-    // tensor2's storage should be unchanged
-    match tensor2.storage.as_ref() {
+    // Check that both tensors have the expected empty storage
+    match tensor1.storage().as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.len(), 0);
-        }
-        Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => {
-            panic!("expected DenseF64")
-        }
-    }
-
-    // tensor1's storage should have the new data
-    match tensor1.storage.as_ref() {
-        Storage::DenseF64(v) => {
-            assert_eq!(v.len(), 1);
-            assert_eq!(v.get(0), 42.0);
+            assert_eq!(v.capacity(), 2);
         }
         Storage::DenseC64(_) | Storage::DiagF64(_) | Storage::DiagC64(_) => {
             panic!("expected DenseF64")
@@ -271,7 +248,7 @@ fn test_replaceind_basic() {
     // Check that dimensions are unchanged
     assert_eq!(replaced.dims, vec![2, 3]);
     // Check that storage is shared (no data copy)
-    assert!(Arc::ptr_eq(&tensor.storage, &replaced.storage));
+    assert!(Arc::ptr_eq(tensor.storage(), replaced.storage()));
 }
 
 #[test]
@@ -449,7 +426,7 @@ fn test_tensor_conj_f64() {
     // Dims should be the same
     assert_eq!(conj_tensor.dims, vec![2]);
     // Data should be the same (real conj is identity)
-    match conj_tensor.storage.as_ref() {
+    match conj_tensor.storage().as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.as_slice(), &data);
         }
@@ -483,7 +460,7 @@ fn test_tensor_conj_c64() {
     // Dims should be preserved
     assert_eq!(conj_tensor.dims, vec![2, 3]);
     // Data should be conjugated
-    match conj_tensor.storage.as_ref() {
+    match conj_tensor.storage().as_ref() {
         Storage::DenseC64(v) => {
             let expected = vec![
                 Complex64::new(1.0, -1.0),
@@ -496,5 +473,117 @@ fn test_tensor_conj_c64() {
             assert_eq!(v.as_slice(), &expected);
         }
         _ => panic!("Expected DenseC64"),
+    }
+}
+
+// ============================================================================
+// TensorData integration tests
+// ============================================================================
+
+#[test]
+fn test_tensor_has_tensor_data() {
+    use tensor4all_core::storage::DenseStorageF64;
+
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data)));
+    let tensor: TensorDynLen =
+        TensorDynLen::new(vec![i.clone(), j.clone()], vec![2, 3], storage);
+
+    // TensorDynLen now contains TensorData internally
+    let tensor_data = tensor.tensor_data();
+
+    // Check properties
+    assert!(tensor_data.is_simple());
+    assert_eq!(tensor_data.ndim(), 2);
+    assert_eq!(tensor_data.dims(), &[2, 3]);
+    assert_eq!(tensor_data.index_ids()[0], i.id);
+    assert_eq!(tensor_data.index_ids()[1], j.id);
+
+    // Tensor should also be simple
+    assert!(tensor.is_simple());
+}
+
+#[test]
+fn test_tensor_data_lazy_outer_product() {
+    use tensor4all_core::storage::DenseStorageF64;
+    use tensor4all_core::TensorData;
+
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+
+    let data_a = vec![1.0, 2.0];
+    let storage_a = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data_a)));
+    let td_a = TensorData::new(storage_a, vec![i.id.clone()], vec![2]);
+
+    let data_b = vec![3.0, 4.0, 5.0];
+    let storage_b = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data_b)));
+    let td_b = TensorData::new(storage_b, vec![j.id.clone()], vec![3]);
+
+    // Lazy outer product using TensorData directly
+    let lazy_result = TensorData::outer_product(&td_a, &td_b);
+
+    // Should have 2 components (not materialized yet)
+    assert!(!lazy_result.is_simple());
+    assert_eq!(lazy_result.components().len(), 2);
+    assert_eq!(lazy_result.ndim(), 2);
+    assert_eq!(lazy_result.dims(), &[2, 3]);
+
+    // Materialize and verify
+    let (storage, dims) = lazy_result.materialize().unwrap();
+    assert_eq!(dims, vec![2, 3]);
+
+    match storage.as_ref() {
+        Storage::DenseF64(v) => {
+            // Expected: [[1*3, 1*4, 1*5], [2*3, 2*4, 2*5]] = [3, 4, 5, 6, 8, 10]
+            let expected = vec![3.0, 4.0, 5.0, 6.0, 8.0, 10.0];
+            assert_eq!(v.as_slice().len(), expected.len());
+            for (a, b) in v.as_slice().iter().zip(expected.iter()) {
+                assert!((a - b).abs() < 1e-10);
+            }
+        }
+        _ => panic!("Expected DenseF64"),
+    }
+}
+
+#[test]
+fn test_tensor_data_lazy_outer_product_with_permute() {
+    use tensor4all_core::storage::DenseStorageF64;
+    use tensor4all_core::TensorData;
+
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+
+    let data_a = vec![1.0, 2.0];
+    let storage_a = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data_a)));
+    let td_a = TensorData::new(storage_a, vec![i.id.clone()], vec![2]);
+
+    let data_b = vec![3.0, 4.0, 5.0];
+    let storage_b = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data_b)));
+    let td_b = TensorData::new(storage_b, vec![j.id.clone()], vec![3]);
+
+    // Lazy outer product then permute using TensorData directly
+    let lazy_result = TensorData::outer_product(&td_a, &td_b);
+    let permuted = lazy_result.permute(&[j.id.clone(), i.id.clone()]);
+
+    // Check permuted dimensions
+    assert_eq!(permuted.dims(), &[3, 2]);
+
+    // Materialize and verify - should be transposed
+    let (storage, dims) = permuted.materialize().unwrap();
+    assert_eq!(dims, vec![3, 2]);
+
+    match storage.as_ref() {
+        Storage::DenseF64(v) => {
+            // Original was [[3, 4, 5], [6, 8, 10]] in row-major: [3, 4, 5, 6, 8, 10]
+            // Transposed should be [[3, 6], [4, 8], [5, 10]] in row-major: [3, 6, 4, 8, 5, 10]
+            let expected = vec![3.0, 6.0, 4.0, 8.0, 5.0, 10.0];
+            assert_eq!(v.as_slice().len(), expected.len());
+            for (a, b) in v.as_slice().iter().zip(expected.iter()) {
+                assert!((a - b).abs() < 1e-10);
+            }
+        }
+        _ => panic!("Expected DenseF64"),
     }
 }

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -47,7 +47,7 @@ fn test_contract_dyn_len_matrix_multiplication() {
     assert_eq!(result.indices[1].id, k.id);
 
     // Check that all elements are 3.0
-    if let Storage::DenseF64(ref vec) = *result.storage {
+    if let Storage::DenseF64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 8); // 2 * 4 = 8
         for &val in vec.iter() {
             assert_eq!(val, 3.0);
@@ -86,7 +86,7 @@ fn test_mul_operator_contraction() {
     assert_eq!(result.indices[1].id, k.id);
 
     // Check that all elements are 3.0
-    if let Storage::DenseF64(ref vec) = *result.storage {
+    if let Storage::DenseF64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 8); // 2 * 4 = 8
         for &val in vec.iter() {
             assert_eq!(val, 3.0);
@@ -120,7 +120,7 @@ fn test_mul_operator_owned() {
 }
 
 #[test]
-#[should_panic(expected = "No common indices found")]
+#[should_panic(expected = "NoCommonIndices")]
 fn test_contract_no_common_indices() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
@@ -169,7 +169,7 @@ fn test_contract_three_indices() {
     assert_eq!(result.indices[1].id, l.id);
 
     // Check that all elements are 12.0
-    if let Storage::DenseF64(ref vec) = *result.storage {
+    if let Storage::DenseF64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 10); // 2 * 5 = 10
         for &val in vec.as_slice().iter() {
             assert_eq!(val, 12.0);
@@ -214,7 +214,7 @@ fn test_contract_mixed_f64_c64() {
     assert_eq!(result.indices[1].id, k.id);
 
     // Check result storage type and values
-    if let Storage::DenseC64(ref vec) = *result.storage {
+    if let Storage::DenseC64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 4);
         // All elements should be the same: sum of first column and sum of second column
         // First row: [6+8i, 10+12i]
@@ -265,7 +265,7 @@ fn test_contract_mixed_c64_f64() {
     assert_eq!(result.dims, vec![2, 2]);
 
     // Check result storage type
-    if let Storage::DenseC64(ref vec) = *result.storage {
+    if let Storage::DenseC64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 4);
         // Check actual computed values
         assert!((vec.get(0) - Complex64::new(4.0, 6.0)).norm() < 1e-10);
@@ -307,7 +307,7 @@ fn test_tensordot_different_ids() {
     assert_eq!(result.indices[1].id, l.id);
 
     // Check that all elements are 3.0
-    if let Storage::DenseF64(ref vec) = *result.storage {
+    if let Storage::DenseF64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 8);
         for &val in vec.iter() {
             assert_eq!(val, 3.0);
@@ -338,7 +338,11 @@ fn test_tensordot_dimension_mismatch() {
     assert!(result.is_err());
     if let Err(e) = result {
         let err_msg = format!("{}", e);
-        assert!(err_msg.contains("dimension") || err_msg.contains("mismatch"));
+        assert!(
+            err_msg.contains("Dimension") || err_msg.contains("mismatch"),
+            "Expected dimension mismatch error, got: {}",
+            err_msg
+        );
     }
 }
 
@@ -365,7 +369,11 @@ fn test_tensordot_index_not_found() {
     assert!(result.is_err());
     if let Err(e) = result {
         let err_msg = format!("{}", e);
-        assert!(err_msg.contains("not found") || err_msg.contains("index"));
+        assert!(
+            err_msg.contains("not found") || err_msg.contains("Index"),
+            "Expected index not found error, got: {}",
+            err_msg
+        );
     }
 }
 
@@ -423,6 +431,9 @@ fn test_tensordot_empty_pairs() {
             err_msg.contains("No pairs")
                 || err_msg.contains("empty")
                 || err_msg.contains("specified")
+                || err_msg.contains("NoCommon"),
+            "Expected empty pairs error, got: {}",
+            err_msg
         );
     }
 }

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -51,7 +51,7 @@ fn test_diag_tensor_permute() {
     assert_eq!(permuted.dims, vec![3, 3, 3]);
 
     // Verify diagonal data is unchanged
-    if let Storage::DiagF64(ref diag) = *permuted.storage {
+    if let Storage::DiagF64(ref diag) = **permuted.storage() {
         assert_eq!(diag.as_slice(), &diag_data);
     } else {
         panic!("Expected DiagF64 storage");
@@ -74,7 +74,7 @@ fn test_diag_tensor_contract_diag_diag_all_contracted() {
 
     // Result should be scalar: 1*3 + 2*4 = 11
     assert_eq!(result.dims.len(), 0);
-    if let Storage::DenseF64(ref vec) = *result.storage {
+    if let Storage::DenseF64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 1);
         assert_eq!(vec.as_slice()[0], 11.0);
     } else {
@@ -101,7 +101,7 @@ fn test_diag_tensor_contract_diag_diag_partial() {
     assert!(is_diag_tensor(&result));
 
     // Result diagonal should be element-wise product: [1*4, 2*5, 3*6] = [4, 10, 18]
-    if let Storage::DiagF64(ref diag) = *result.storage {
+    if let Storage::DiagF64(ref diag) = **result.storage() {
         assert_eq!(diag.as_slice(), &vec![4.0, 10.0, 18.0]);
     } else {
         panic!("Expected DiagF64 storage");
@@ -130,7 +130,7 @@ fn test_diag_tensor_contract_diag_dense() {
 
     assert_eq!(result.dims, vec![2, 2]);
     // Result should be DenseTensor (Diag×Dense converts Diag to Dense first)
-    if let Storage::DenseF64(ref vec) = *result.storage {
+    if let Storage::DenseF64(ref vec) = **result.storage() {
         assert_eq!(vec.len(), 4);
         // A is diagonal [1, 2], B is all ones, so result[i, k] = A[i, i] * B[i, k] = diag[i] * 1
         // For i=0: result[0, k] = 1 * 1 = 1 for all k
@@ -161,7 +161,7 @@ fn test_diag_tensor_convert_to_dense() {
     let diag_data = vec![1.0, 2.0, 3.0];
 
     let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data);
-    let dense_storage = tensor.storage.to_dense_storage(&tensor.dims);
+    let dense_storage = tensor.storage().to_dense_storage(&tensor.dims);
 
     if let Storage::DenseF64(ref vec) = dense_storage {
         assert_eq!(vec.len(), 9); // 3x3 = 9
@@ -234,7 +234,7 @@ fn test_diag_tensor_contract_rank3() {
     assert!(is_diag_tensor(&result));
 
     // Result diagonal should be element-wise product: [1*3, 2*4] = [3, 8]
-    if let Storage::DiagF64(ref diag) = *result.storage {
+    if let Storage::DiagF64(ref diag) = **result.storage() {
         assert_eq!(diag.as_slice(), &vec![3.0, 8.0]);
     } else {
         panic!("Expected DiagF64 storage");

--- a/crates/tensor4all-core/tests/tensor_permute.rs
+++ b/crates/tensor4all-core/tests/tensor_permute.rs
@@ -88,7 +88,7 @@ fn test_permute_dyn_f64_2d() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
 
-    match &*permuted.storage {
+    match permuted.storage().as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
         }
@@ -128,7 +128,7 @@ fn test_permute_dyn_c64_2d() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
 
-    match &*permuted.storage {
+    match permuted.storage().as_ref() {
         Storage::DenseC64(v) => {
             assert_eq!(v.get(0), Complex64::new(1.0, 0.0));
             assert_eq!(v.get(1), Complex64::new(4.0, 0.0));
@@ -174,7 +174,7 @@ fn test_permute_dyn_f64_3d() {
     // Verify data was permuted correctly
     // Original: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
     // After permute [2, 0, 1]: should reorganize the data
-    match &*permuted.storage {
+    match permuted.storage().as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.len(), 24);
             // Check first few values to verify permutation
@@ -210,7 +210,7 @@ fn test_permute_identity() {
     assert_eq!(permuted.indices[0].id, i.id);
     assert_eq!(permuted.indices[1].id, j.id);
 
-    match &*permuted.storage {
+    match permuted.storage().as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.as_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         }
@@ -243,7 +243,7 @@ fn test_permute_indices_dyn_f64_2d() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
 
-    match &*permuted.storage {
+    match permuted.storage().as_ref() {
         Storage::DenseF64(v) => {
             assert_eq!(v.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
         }
@@ -283,7 +283,7 @@ fn test_permute_indices_c64() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
 
-    match &*permuted.storage {
+    match permuted.storage().as_ref() {
         Storage::DenseC64(v) => {
             assert_eq!(v.get(0), Complex64::new(1.0, 0.0));
             assert_eq!(v.get(1), Complex64::new(4.0, 0.0));

--- a/crates/tensor4all-treetn/src/dyn_treetn.rs
+++ b/crates/tensor4all-treetn/src/dyn_treetn.rs
@@ -1,0 +1,650 @@
+//! Dynamic Tree Tensor Network with heterogeneous node types.
+//!
+//! This module provides `DynTreeTN`, a tree tensor network that can hold
+//! heterogeneous `TensorLike` objects as node payloads. Unlike `TreeTN` which
+//! stores homogeneous `TensorDynLen` tensors, `DynTreeTN` allows mixing different
+//! tensor representations (dense tensors, other TTNs, custom types, etc.).
+//!
+//! # Type Parameters
+//!
+//! The associated types are fixed to canonical values for simplicity:
+//! - `Id = DynId` (runtime identity)
+//! - `Symm = NoSymmSpace` (no symmetry)
+//! - `Tags = TagSet` (Arc-wrapped tag set)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use tensor4all_treetn::DynTreeTN;
+//! use tensor4all_core::{TensorDynLen, TensorLike};
+//!
+//! let mut tn = DynTreeTN::<String>::new();
+//!
+//! // Add a dense tensor
+//! let tensor = TensorDynLen::from_indices(...);
+//! tn.add_node("A".to_string(), tensor)?;
+//!
+//! // Add another TreeTN as a node (heterogeneous!)
+//! let sub_network = TreeTN::new(tensors, node_names)?;
+//! tn.add_node("B".to_string(), sub_network)?;
+//! ```
+
+use petgraph::stable_graph::{EdgeIndex, NodeIndex};
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::fmt::Debug;
+
+use std::collections::HashMap;
+use tensor4all_core::index::{DynId, Index, NoSymmSpace, TagSet};
+use tensor4all_core::{TensorDynLen, TensorLike};
+
+use crate::named_graph::NamedGraph;
+use crate::site_index_network::SiteIndexNetwork;
+
+use anyhow::{Context, Result};
+
+/// Type alias for the canonical Index type used in DynTreeTN.
+pub type DynIndex = Index<DynId, NoSymmSpace, TagSet>;
+
+/// Type alias for boxed TensorLike trait objects with canonical type parameters.
+///
+/// This is the node payload type for `DynTreeTN`.
+pub type BoxedTensorLike = Box<dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = TagSet>>;
+
+/// Dynamic Tree Tensor Network that can hold heterogeneous TensorLike objects.
+///
+/// Unlike `TreeTN<Id, Symm, V>` which stores homogeneous `TensorDynLen<Id, Symm>` tensors,
+/// `DynTreeTN<V>` can store any object implementing `TensorLike` as node payloads.
+/// This enables mixing different tensor representations within the same network.
+///
+/// # Type Parameters
+///
+/// - `V`: Node name type (default: `NodeIndex` for backward compatibility)
+///
+/// # Fixed Associated Types
+///
+/// The `TensorLike` associated types are fixed to canonical values:
+/// - `Id = DynId` (runtime identity)
+/// - `Symm = NoSymmSpace` (no symmetry)
+/// - `Tags = TagSet` (Arc-wrapped tag set)
+///
+/// This ensures all nodes in the network have compatible index types.
+///
+/// # Heterogeneous Nodes
+///
+/// Each node can hold a different concrete type implementing `TensorLike`:
+/// - `TensorDynLen<DynId, NoSymmSpace>` - dense tensors
+/// - `TreeTN<DynId, NoSymmSpace, _>` - sub-networks
+/// - Custom types implementing `TensorLike`
+///
+/// # Example
+///
+/// ```ignore
+/// let mut tn = DynTreeTN::<String>::new();
+///
+/// // Mix different tensor types
+/// tn.add_node("dense".to_string(), some_tensor)?;
+/// tn.add_node("network".to_string(), some_treetn)?;
+/// ```
+pub struct DynTreeTN<V = NodeIndex>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Named graph: maps node names to boxed TensorLike trait objects.
+    /// Edges store bond indices directly (Index<DynId, NoSymmSpace>).
+    graph: NamedGraph<V, BoxedTensorLike, Index<DynId, NoSymmSpace>>,
+    /// Orthogonalization region (node names).
+    canonical_center: HashSet<V>,
+    /// Site index network: manages topology and site space (physical indices).
+    site_index_network: SiteIndexNetwork<V, DynId, NoSymmSpace, TagSet>,
+    /// Orthogonalization direction for each edge (node name that ortho points towards).
+    ortho_towards: HashMap<EdgeIndex, V>,
+}
+
+impl<V> DynTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Create a new empty DynTreeTN.
+    pub fn new() -> Self {
+        Self {
+            graph: NamedGraph::new(),
+            canonical_center: HashSet::new(),
+            site_index_network: SiteIndexNetwork::new(),
+            ortho_towards: HashMap::new(),
+        }
+    }
+
+    /// Add a TensorLike object as a node in the network.
+    ///
+    /// The object is boxed and stored as a trait object. Its external indices
+    /// become the site/physical indices for this node.
+    ///
+    /// # Arguments
+    /// * `node_name` - Name for the node
+    /// * `tensor_like` - Any object implementing `TensorLike` with the canonical type parameters
+    ///
+    /// # Returns
+    /// The `NodeIndex` of the newly added node, or an error if the node name already exists.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let mut tn = DynTreeTN::<String>::new();
+    /// let tensor = TensorDynLen::from_indices(indices, storage);
+    /// tn.add_node("A".to_string(), tensor)?;
+    /// ```
+    pub fn add_node<T>(&mut self, node_name: V, tensor_like: T) -> Result<NodeIndex>
+    where
+        T: TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = TagSet> + 'static,
+    {
+        // Get external indices before boxing
+        let external_indices: HashSet<DynIndex> = tensor_like.external_indices().into_iter().collect();
+
+        // Box the tensor_like object
+        let boxed: BoxedTensorLike = Box::new(tensor_like);
+
+        // Add to graph
+        let node_idx = self.graph.add_node(node_name.clone(), boxed)
+            .map_err(|e: String| anyhow::anyhow!(e))
+            .context("Failed to add node to graph")?;
+
+        // Add to site_index_network
+        self.site_index_network.add_node(node_name, external_indices)
+            .map_err(|e| anyhow::anyhow!("Failed to add node to site_index_network: {}", e))?;
+
+        Ok(node_idx)
+    }
+
+    /// Add a pre-boxed TensorLike object as a node.
+    ///
+    /// This is useful when you already have a `BoxedTensorLike` or when working
+    /// with trait objects directly.
+    ///
+    /// # Arguments
+    /// * `node_name` - Name for the node
+    /// * `boxed` - Boxed TensorLike trait object
+    ///
+    /// # Returns
+    /// The `NodeIndex` of the newly added node.
+    pub fn add_boxed_node(&mut self, node_name: V, boxed: BoxedTensorLike) -> Result<NodeIndex> {
+        // Get external indices from the boxed object
+        let external_indices: HashSet<DynIndex> = boxed.external_indices().into_iter().collect();
+
+        // Add to graph
+        let node_idx = self.graph.add_node(node_name.clone(), boxed)
+            .map_err(|e: String| anyhow::anyhow!(e))
+            .context("Failed to add node to graph")?;
+
+        // Add to site_index_network
+        self.site_index_network.add_node(node_name, external_indices)
+            .map_err(|e| anyhow::anyhow!("Failed to add node to site_index_network: {}", e))?;
+
+        Ok(node_idx)
+    }
+
+    /// Get a reference to a node's TensorLike object by NodeIndex.
+    pub fn node(&self, node: NodeIndex) -> Option<&dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = TagSet>> {
+        self.graph.graph().node_weight(node).map(|b| b.as_ref())
+    }
+
+    /// Get a reference to a node's TensorLike object by node name.
+    pub fn node_by_name(&self, name: &V) -> Option<&dyn TensorLike<Id = DynId, Symm = NoSymmSpace, Tags = TagSet>> {
+        self.graph.node_index(name)
+            .and_then(|idx| self.node(idx))
+    }
+
+    /// Connect two nodes with a bond.
+    ///
+    /// The indices must exist in the respective nodes' external indices and have matching dimensions.
+    ///
+    /// # Arguments
+    /// * `node_a` - First node
+    /// * `index_a` - Index from node_a to use for the bond
+    /// * `node_b` - Second node
+    /// * `index_b` - Index from node_b to use for the bond
+    ///
+    /// # Returns
+    /// The `EdgeIndex` of the created connection.
+    pub fn connect(
+        &mut self,
+        node_a: NodeIndex,
+        index_a: &DynIndex,
+        node_b: NodeIndex,
+        index_b: &DynIndex,
+    ) -> Result<EdgeIndex> {
+        // Validate that nodes exist
+        if !self.graph.contains_node(node_a) || !self.graph.contains_node(node_b) {
+            return Err(anyhow::anyhow!("One or both nodes do not exist"))
+                .context("Failed to connect nodes");
+        }
+
+        // Validate that indices exist in respective nodes' external indices
+        let node_a_obj = self.graph.graph().node_weight(node_a)
+            .ok_or_else(|| anyhow::anyhow!("Node A not found"))?;
+        let node_b_obj = self.graph.graph().node_weight(node_b)
+            .ok_or_else(|| anyhow::anyhow!("Node B not found"))?;
+
+        let ext_a = node_a_obj.external_indices();
+        let ext_b = node_b_obj.external_indices();
+
+        let has_index_a = ext_a.iter().any(|idx| index_a.id == idx.id);
+        let has_index_b = ext_b.iter().any(|idx| index_b.id == idx.id);
+
+        if !has_index_a {
+            return Err(anyhow::anyhow!("Index not found in node A's external indices"))
+                .context("Failed to connect: index_a must be an external index of node A");
+        }
+        if !has_index_b {
+            return Err(anyhow::anyhow!("Index not found in node B's external indices"))
+                .context("Failed to connect: index_b must be an external index of node B");
+        }
+
+        // Get node names for site_index_network (before mutable borrow)
+        let node_name_a = self.graph.node_name(node_a)
+            .ok_or_else(|| anyhow::anyhow!("Node name for node_a not found"))?
+            .clone();
+        let node_name_b = self.graph.node_name(node_b)
+            .ok_or_else(|| anyhow::anyhow!("Node name for node_b not found"))?
+            .clone();
+
+        // In Einsum mode, both indices share the same ID, so store just one bond index
+        // Validate that index_a and index_b have matching IDs and dimensions
+        if index_a.id != index_b.id {
+            return Err(anyhow::anyhow!(
+                "In Einsum mode, indices must have the same ID: {:?} != {:?}",
+                index_a.id, index_b.id
+            )).context("Failed to connect: index mismatch");
+        }
+        if index_a.size() != index_b.size() {
+            return Err(anyhow::anyhow!(
+                "Dimension mismatch: {} != {}",
+                index_a.size(), index_b.size()
+            )).context("Failed to connect: dimension mismatch");
+        }
+
+        // Store the bond index directly on the edge (converts to Index<DynId, NoSymmSpace> by dropping tags)
+        let bond_index = Index::new(index_a.id, index_a.symm.clone());
+
+        // Add edge to graph
+        let edge_idx = self.graph.graph_mut().add_edge(node_a, node_b, bond_index);
+
+        // Add edge to site_index_network
+        self.site_index_network.add_edge(&node_name_a, &node_name_b)
+            .map_err(|e| anyhow::anyhow!("Failed to add edge to site_index_network: {}", e))?;
+
+        // Update physical indices: remove connection indices from site space
+        if let Some(site_space_a) = self.site_index_network.site_space_mut(&node_name_a) {
+            site_space_a.remove(index_a);
+        }
+        if let Some(site_space_b) = self.site_index_network.site_space_mut(&node_name_b) {
+            site_space_b.remove(index_b);
+        }
+
+        Ok(edge_idx)
+    }
+
+    /// Get a reference to a bond index by EdgeIndex.
+    pub fn bond_index(&self, edge: EdgeIndex) -> Option<&Index<DynId, NoSymmSpace>> {
+        self.graph.graph().edge_weight(edge)
+    }
+
+    /// Get a mutable reference to a bond index by EdgeIndex.
+    pub fn bond_index_mut(&mut self, edge: EdgeIndex) -> Option<&mut Index<DynId, NoSymmSpace>> {
+        self.graph.graph_mut().edge_weight_mut(edge)
+    }
+
+    /// Get the number of nodes in the network.
+    pub fn node_count(&self) -> usize {
+        self.graph.graph().node_count()
+    }
+
+    /// Get the number of edges in the network.
+    pub fn edge_count(&self) -> usize {
+        self.graph.graph().edge_count()
+    }
+
+    /// Get all node names in the network.
+    pub fn node_names(&self) -> Vec<V> {
+        self.graph.graph().node_indices()
+            .filter_map(|idx| self.graph.node_name(idx).cloned())
+            .collect()
+    }
+
+    /// Get all node indices in the network.
+    pub fn node_indices(&self) -> Vec<NodeIndex> {
+        self.graph.graph().node_indices().collect()
+    }
+
+    /// Get the NodeIndex for a node name.
+    pub fn node_index(&self, name: &V) -> Option<NodeIndex> {
+        self.graph.node_index(name)
+    }
+
+    /// Get the node name for a NodeIndex.
+    pub fn node_name(&self, node: NodeIndex) -> Option<&V> {
+        self.graph.node_name(node)
+    }
+
+    /// Get a reference to the site index network.
+    pub fn site_index_network(&self) -> &SiteIndexNetwork<V, DynId, NoSymmSpace, TagSet> {
+        &self.site_index_network
+    }
+
+    /// Get a reference to the orthogonalization region.
+    pub fn canonical_center(&self) -> &HashSet<V> {
+        &self.canonical_center
+    }
+
+    /// Contract the entire network to a single tensor.
+    ///
+    /// Each node's `to_tensor()` is called to convert it to a `TensorDynLen`,
+    /// then all tensors are contracted along their connected indices.
+    ///
+    /// # Returns
+    /// A `TensorDynLen` representing the contracted network.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The network is empty
+    /// - Any node's `to_tensor()` fails
+    /// - The graph is not a tree (has cycles or is disconnected)
+    pub fn contract_to_tensor(&self) -> Result<TensorDynLen<DynId, NoSymmSpace>> {
+        let node_count = self.node_count();
+
+        if node_count == 0 {
+            return Err(anyhow::anyhow!("Cannot contract empty network"));
+        }
+
+        if node_count == 1 {
+            // Single node: just convert to tensor
+            let node = self.graph.graph().node_indices().next().unwrap();
+            let obj = self.graph.graph().node_weight(node).unwrap();
+            return obj.to_tensor();
+        }
+
+        // For multi-node networks, we contract pairwise
+        // First, collect all tensors
+        let mut tensors: Vec<TensorDynLen<DynId, NoSymmSpace>> = Vec::new();
+        for node in self.graph.graph().node_indices() {
+            let obj = self.graph.graph().node_weight(node).unwrap();
+            let tensor = obj.to_tensor()
+                .with_context(|| format!("Failed to convert node {:?} to tensor", self.graph.node_name(node)))?;
+            tensors.push(tensor);
+        }
+
+        // Contract all tensors together using common indices
+        let mut result = tensors.remove(0);
+        for tensor in tensors {
+            result = result.contract_einsum(&tensor);
+        }
+
+        Ok(result)
+    }
+}
+
+impl<V> Default for DynTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V> Clone for DynTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    fn clone(&self) -> Self {
+        // Clone each boxed tensor using dyn-clone
+        let mut new_graph = NamedGraph::new();
+
+        for node in self.graph.graph().node_indices() {
+            if let (Some(name), Some(boxed)) = (
+                self.graph.node_name(node),
+                self.graph.graph().node_weight(node),
+            ) {
+                let cloned_box: BoxedTensorLike = dyn_clone::clone_box(&**boxed);
+                let _ = new_graph.add_node(name.clone(), cloned_box);
+            }
+        }
+
+        // Clone edges
+        for edge in self.graph.graph().edge_indices() {
+            if let Some((src, tgt)) = self.graph.graph().edge_endpoints(edge) {
+                if let Some(conn) = self.graph.graph().edge_weight(edge) {
+                    new_graph.graph_mut().add_edge(src, tgt, conn.clone());
+                }
+            }
+        }
+
+        Self {
+            graph: new_graph,
+            canonical_center: self.canonical_center.clone(),
+            site_index_network: self.site_index_network.clone(),
+            ortho_towards: self.ortho_towards.clone(),
+        }
+    }
+}
+
+impl<V> Debug for DynTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DynTreeTN")
+            .field("node_count", &self.node_count())
+            .field("edge_count", &self.edge_count())
+            .field("canonical_center", &self.canonical_center)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::storage::DenseStorageF64;
+    use tensor4all_core::Storage;
+    use std::sync::Arc;
+
+    fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen<DynId, NoSymmSpace> {
+        let total_size: usize = indices.iter().map(|idx| idx.size()).product();
+        let data: Vec<f64> = (0..total_size).map(|i| i as f64).collect();
+        let storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(data)));
+        let dims: Vec<usize> = indices.iter().map(|idx| idx.size()).collect();
+        // Convert DynIndex to Index<DynId, NoSymmSpace>
+        let indices_no_tags: Vec<Index<DynId, NoSymmSpace>> = indices
+            .iter()
+            .map(|idx| Index::new(idx.id, idx.symm.clone()))
+            .collect();
+        TensorDynLen::new(indices_no_tags, dims, storage)
+    }
+
+    #[test]
+    fn test_dyn_treetn_new() {
+        let tn = DynTreeTN::<String>::new();
+        assert_eq!(tn.node_count(), 0);
+        assert_eq!(tn.edge_count(), 0);
+    }
+
+    #[test]
+    fn test_dyn_treetn_add_node() {
+        let mut tn = DynTreeTN::<String>::new();
+
+        let i: DynIndex = Index::new_dyn(2);
+        let j: DynIndex = Index::new_dyn(3);
+        let tensor = make_tensor(vec![i.clone(), j.clone()]);
+
+        let node_idx = tn.add_node("A".to_string(), tensor).unwrap();
+
+        assert_eq!(tn.node_count(), 1);
+        assert!(tn.node(node_idx).is_some());
+        assert!(tn.node_by_name(&"A".to_string()).is_some());
+    }
+
+    #[test]
+    fn test_dyn_treetn_heterogeneous_nodes() {
+        let mut tn = DynTreeTN::<String>::new();
+
+        // Add a TensorDynLen
+        let i: DynIndex = Index::new_dyn(2);
+        let tensor = make_tensor(vec![i.clone()]);
+        tn.add_node("tensor".to_string(), tensor).unwrap();
+
+        // Add another TensorDynLen with different dimensions
+        let j: DynIndex = Index::new_dyn(3);
+        let tensor2 = make_tensor(vec![j.clone()]);
+        tn.add_node("tensor2".to_string(), tensor2).unwrap();
+
+        assert_eq!(tn.node_count(), 2);
+
+        // Verify we can access both nodes
+        let node1 = tn.node_by_name(&"tensor".to_string()).unwrap();
+        let node2 = tn.node_by_name(&"tensor2".to_string()).unwrap();
+
+        assert_eq!(node1.num_external_indices(), 1);
+        assert_eq!(node2.num_external_indices(), 1);
+    }
+
+    #[test]
+    fn test_dyn_treetn_connect() {
+        let mut tn = DynTreeTN::<String>::new();
+
+        let i: DynIndex = Index::new_dyn(2);
+        let bond: DynIndex = Index::new_dyn(4);
+        let j: DynIndex = Index::new_dyn(3);
+
+        let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
+        let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
+
+        let node_a = tn.add_node("A".to_string(), tensor_a).unwrap();
+        let node_b = tn.add_node("B".to_string(), tensor_b).unwrap();
+
+        // Connect using the shared bond index
+        let edge = tn.connect(node_a, &bond, node_b, &bond).unwrap();
+
+        assert_eq!(tn.edge_count(), 1);
+        assert!(tn.bond_index(edge).is_some());
+    }
+
+    #[test]
+    fn test_dyn_treetn_contract_single_node() {
+        let mut tn = DynTreeTN::<String>::new();
+
+        let i: DynIndex = Index::new_dyn(2);
+        let j: DynIndex = Index::new_dyn(3);
+        let tensor = make_tensor(vec![i.clone(), j.clone()]);
+
+        tn.add_node("A".to_string(), tensor).unwrap();
+
+        let result = tn.contract_to_tensor().unwrap();
+        assert_eq!(result.indices.len(), 2);
+    }
+
+    #[test]
+    fn test_dyn_treetn_contract_two_nodes() {
+        let mut tn = DynTreeTN::<String>::new();
+
+        let i: DynIndex = Index::new_dyn(2);
+        let bond: DynIndex = Index::new_dyn(4);
+        let j: DynIndex = Index::new_dyn(3);
+
+        let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
+        let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
+
+        let node_a = tn.add_node("A".to_string(), tensor_a).unwrap();
+        let node_b = tn.add_node("B".to_string(), tensor_b).unwrap();
+
+        tn.connect(node_a, &bond, node_b, &bond).unwrap();
+
+        let result = tn.contract_to_tensor().unwrap();
+        // Result should have indices i and j (bond contracted)
+        assert_eq!(result.indices.len(), 2);
+    }
+
+    #[test]
+    fn test_dyn_treetn_clone() {
+        let mut tn = DynTreeTN::<String>::new();
+
+        let i: DynIndex = Index::new_dyn(2);
+        let tensor = make_tensor(vec![i.clone()]);
+        tn.add_node("A".to_string(), tensor).unwrap();
+
+        let cloned = tn.clone();
+        assert_eq!(cloned.node_count(), 1);
+        assert!(cloned.node_by_name(&"A".to_string()).is_some());
+    }
+
+    #[test]
+    fn test_dyn_treetn_mix_tensor_and_treetn() {
+        use crate::TreeTN;
+
+        let mut dyn_tn = DynTreeTN::<String>::new();
+
+        // Create a TensorDynLen node
+        let i: DynIndex = Index::new_dyn(2);
+        let tensor = make_tensor(vec![i.clone()]);
+        dyn_tn.add_node("dense_tensor".to_string(), tensor).unwrap();
+
+        // Create a TreeTN (sub-network) with its own structure
+        let j: DynIndex = Index::new_dyn(3);
+        let sub_tensor = make_tensor(vec![j.clone()]);
+        let sub_tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors(
+            vec![sub_tensor],
+            vec!["sub_node".to_string()],
+        ).unwrap();
+
+        // Add the TreeTN as a node in DynTreeTN - heterogeneous!
+        dyn_tn.add_node("sub_network".to_string(), sub_tn).unwrap();
+
+        assert_eq!(dyn_tn.node_count(), 2);
+
+        // Verify we can access both nodes through the TensorLike interface
+        let dense_node = dyn_tn.node_by_name(&"dense_tensor".to_string()).unwrap();
+        let network_node = dyn_tn.node_by_name(&"sub_network".to_string()).unwrap();
+
+        assert_eq!(dense_node.num_external_indices(), 1);
+        assert_eq!(network_node.num_external_indices(), 1);
+
+        // Both nodes can be converted to tensors through the TensorLike interface
+        let dense_tensor = dense_node.to_tensor().unwrap();
+        let network_tensor = network_node.to_tensor().unwrap();
+
+        assert_eq!(dense_tensor.indices.len(), 1);
+        assert_eq!(network_tensor.indices.len(), 1);
+    }
+
+    #[test]
+    fn test_dyn_treetn_nested_networks() {
+        use crate::TreeTN;
+
+        // Create a TreeTN with two connected nodes
+        let i: DynIndex = Index::new_dyn(2);
+        let bond: DynIndex = Index::new_dyn(4);
+        let j: DynIndex = Index::new_dyn(3);
+
+        let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
+        let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
+
+        let inner_tn = TreeTN::<DynId, NoSymmSpace, String>::from_tensors(
+            vec![tensor_a, tensor_b],
+            vec!["A".to_string(), "B".to_string()],
+        ).unwrap();
+
+        // The inner TreeTN has external indices i and j (bond is internal)
+        assert_eq!(inner_tn.num_external_indices(), 2);
+
+        // Add to DynTreeTN
+        let mut dyn_tn = DynTreeTN::<String>::new();
+        dyn_tn.add_node("inner_network".to_string(), inner_tn).unwrap();
+
+        // The DynTreeTN node should have the same external indices
+        let node = dyn_tn.node_by_name(&"inner_network".to_string()).unwrap();
+        assert_eq!(node.num_external_indices(), 2);
+
+        // Contract the DynTreeTN - this will call to_tensor() on the inner TreeTN
+        let result = dyn_tn.contract_to_tensor().unwrap();
+        assert_eq!(result.indices.len(), 2);
+    }
+}

--- a/crates/tensor4all-treetn/src/operator/compose.rs
+++ b/crates/tensor4all-treetn/src/operator/compose.rs
@@ -316,7 +316,6 @@ mod tests {
     use crate::random::{random_treetn_f64, LinkSpace};
     use tensor4all_core::index::{DynId, Index, TagSet};
     use tensor4all_core::storage::Storage;
-    use tensor4all_core::TensorAccess;
     use tensor4all_core::TensorDynLen;
 
     type DynIndex = Index<DynId, TagSet>;
@@ -873,7 +872,7 @@ mod tests {
         assert_eq!(n1_tensor.dims, vec![3, 3]);
 
         // Check it's diagonal (only diagonal elements are 1.0)
-        let data = match n1_tensor.storage() {
+        let data = match n1_tensor.storage().as_ref() {
             Storage::DenseF64(d) => d.as_slice(),
             _ => panic!("Expected DenseF64"),
         };

--- a/crates/tensor4all-treetn/src/operator/identity.rs
+++ b/crates/tensor4all-treetn/src/operator/identity.rs
@@ -133,21 +133,20 @@ pub fn build_identity_operator_tensor_c64(
 mod tests {
     use super::*;
     use tensor4all_core::index::Index;
-    use tensor4all_core::TensorAccess;
 
     fn make_index(dim: usize) -> DynIndex {
         Index::new_dyn(dim)
     }
 
     fn get_f64_data(tensor: &TensorDynLen) -> &[f64] {
-        match tensor.storage() {
+        match tensor.storage().as_ref() {
             Storage::DenseF64(d) => d.as_slice(),
             _ => panic!("Expected DenseF64 storage"),
         }
     }
 
     fn get_c64_data(tensor: &TensorDynLen) -> &[Complex64] {
-        match tensor.storage() {
+        match tensor.storage().as_ref() {
             Storage::DenseC64(d) => d.as_slice(),
             _ => panic!("Expected DenseC64 storage"),
         }

--- a/crates/tensor4all-treetn/src/treetn/linsolve/local_linop.rs
+++ b/crates/tensor4all-treetn/src/treetn/linsolve/local_linop.rs
@@ -112,7 +112,7 @@ where
             AnyScalar::C64(z) => z.re == 0.0 && z.im == 0.0,
         };
         if a0_is_zero {
-            return Ok(hx.scale(self.a1.clone()));
+            return hx.scale(self.a1.clone());
         }
 
         // Align hx indices to match x's index order for axpby

--- a/crates/tensor4all-treetn/tests/linsolve.rs
+++ b/crates/tensor4all-treetn/tests/linsolve.rs
@@ -490,7 +490,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
 
     // Debug: print initial state
     let contracted_init = x.contract_to_tensor().unwrap();
-    let sol_init: Vec<f64> = f64::extract_dense_view(contracted_init.storage.as_ref())
+    let sol_init: Vec<f64> = f64::extract_dense_view(contracted_init.storage().as_ref())
         .expect("Failed to extract initial")
         .to_vec();
     eprintln!("Initial state: {:?}", sol_init);
@@ -499,7 +499,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
     for node_name in x.node_names() {
         let node_idx = x.node_index(&node_name).unwrap();
         let tensor = x.tensor(node_idx).unwrap();
-        let data: Vec<f64> = f64::extract_dense_view(tensor.storage.as_ref())
+        let data: Vec<f64> = f64::extract_dense_view(tensor.storage().as_ref())
             .expect("Failed to extract tensor")
             .to_vec();
         let dims: Vec<usize> = tensor.external_indices().iter().map(|i| i.dim()).collect();
@@ -514,7 +514,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
 
         // Print state before step
         let contracted_before = x.contract_to_tensor().unwrap();
-        let sol_before: Vec<f64> = f64::extract_dense_view(contracted_before.storage.as_ref())
+        let sol_before: Vec<f64> = f64::extract_dense_view(contracted_before.storage().as_ref())
             .expect("Failed to extract")
             .to_vec();
         eprintln!("    State before step: {:?}", sol_before);
@@ -523,7 +523,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
         for node_name in x.node_names() {
             let node_idx = x.node_index(&node_name).unwrap();
             let tensor = x.tensor(node_idx).unwrap();
-            let data: Vec<f64> = f64::extract_dense_view(tensor.storage.as_ref())
+            let data: Vec<f64> = f64::extract_dense_view(tensor.storage().as_ref())
                 .expect("Failed to extract tensor")
                 .to_vec();
             eprintln!("      Tensor {:?}: {:?}", node_name, data);
@@ -538,7 +538,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
         for node_name in subtree.node_names() {
             let node_idx = subtree.node_index(&node_name).unwrap();
             let tensor = subtree.tensor(node_idx).unwrap();
-            let data: Vec<f64> = f64::extract_dense_view(tensor.storage.as_ref())
+            let data: Vec<f64> = f64::extract_dense_view(tensor.storage().as_ref())
                 .expect("Failed to extract tensor")
                 .to_vec();
             eprintln!("      Subtree {:?}: {:?}", node_name, data);
@@ -551,7 +551,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
         for node_name in updated_subtree.node_names() {
             let node_idx = updated_subtree.node_index(&node_name).unwrap();
             let tensor = updated_subtree.tensor(node_idx).unwrap();
-            let data: Vec<f64> = f64::extract_dense_view(tensor.storage.as_ref())
+            let data: Vec<f64> = f64::extract_dense_view(tensor.storage().as_ref())
                 .expect("Failed to extract tensor")
                 .to_vec();
             eprintln!("      Updated {:?}: {:?}", node_name, data);
@@ -562,7 +562,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
 
         // Print state after step
         let contracted_after = x.contract_to_tensor().unwrap();
-        let sol_after: Vec<f64> = f64::extract_dense_view(contracted_after.storage.as_ref())
+        let sol_after: Vec<f64> = f64::extract_dense_view(contracted_after.storage().as_ref())
             .expect("Failed to extract")
             .to_vec();
         eprintln!("    State after step: {:?}", sol_after);
@@ -571,7 +571,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
         for node_name in x.node_names() {
             let node_idx = x.node_index(&node_name).unwrap();
             let tensor = x.tensor(node_idx).unwrap();
-            let data: Vec<f64> = f64::extract_dense_view(tensor.storage.as_ref())
+            let data: Vec<f64> = f64::extract_dense_view(tensor.storage().as_ref())
                 .expect("Failed to extract tensor")
                 .to_vec();
             eprintln!("      Tensor {:?}: {:?}", node_name, data);
@@ -583,7 +583,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
     for sweep in 1..10 {
         apply_local_update_sweep(&mut x, &plan, &mut updater).unwrap();
         let contracted_debug = x.contract_to_tensor().unwrap();
-        let sol_debug: Vec<f64> = f64::extract_dense_view(contracted_debug.storage.as_ref())
+        let sol_debug: Vec<f64> = f64::extract_dense_view(contracted_debug.storage().as_ref())
             .expect("Failed to extract solution")
             .to_vec();
         eprintln!("Sweep {}: raw solution = {:?}", sweep, sol_debug);
@@ -593,7 +593,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
     let contracted = x.contract_to_tensor().unwrap();
 
     // Extract solution values
-    let solution_values: Vec<f64> = f64::extract_dense_view(contracted.storage.as_ref())
+    let solution_values: Vec<f64> = f64::extract_dense_view(contracted.storage().as_ref())
         .expect("Failed to extract solution")
         .to_vec();
 
@@ -1146,7 +1146,7 @@ fn test_linear_operator_apply_local() {
     // Check values - the diagonal operator at site0 has value 2.0
     // D|0⟩ = 2.0 * |0⟩ = [2.0, 0.0]
     use tensor4all_core::storage::StorageScalar;
-    let values: Vec<f64> = f64::extract_dense_view(result_tensor.storage.as_ref())
+    let values: Vec<f64> = f64::extract_dense_view(result_tensor.storage().as_ref())
         .expect("Failed to extract values")
         .to_vec();
 
@@ -1241,7 +1241,7 @@ fn test_linear_operator_apply_local_two_sites() {
 
     // Check values
     use tensor4all_core::storage::StorageScalar;
-    let values: Vec<f64> = f64::extract_dense_view(result_tensor.storage.as_ref())
+    let values: Vec<f64> = f64::extract_dense_view(result_tensor.storage().as_ref())
         .expect("Failed to extract values")
         .to_vec();
 
@@ -1405,7 +1405,7 @@ fn test_linsolve_with_index_mappings_diagonal() {
     // Expected solution: D*x = b => x = b/6 = [1, 0, 0, 0]
     // Contract solution to get full tensor using contract_to_tensor
     let contracted = x.contract_to_tensor().unwrap();
-    let values: Vec<f64> = f64::extract_dense_view(contracted.storage.as_ref())
+    let values: Vec<f64> = f64::extract_dense_view(contracted.storage().as_ref())
         .expect("Failed to extract values")
         .to_vec();
 
@@ -1977,7 +1977,7 @@ fn test_linsolve_pauli_x() {
     let contracted = x.contract_to_tensor().unwrap();
 
     // Extract solution values
-    let solution_values: Vec<f64> = f64::extract_dense_view(contracted.storage.as_ref())
+    let solution_values: Vec<f64> = f64::extract_dense_view(contracted.storage().as_ref())
         .expect("Failed to extract solution")
         .to_vec();
 
@@ -2148,7 +2148,7 @@ fn test_linsolve_general_matrix() {
     let contracted = x.contract_to_tensor().unwrap();
 
     // Extract solution values
-    let solution_values: Vec<f64> = f64::extract_dense_view(contracted.storage.as_ref())
+    let solution_values: Vec<f64> = f64::extract_dense_view(contracted.storage().as_ref())
         .expect("Failed to extract solution")
         .to_vec();
 

--- a/docs/api/tensor4all_callback_test.md
+++ b/docs/api/tensor4all_callback_test.md
@@ -1,0 +1,28 @@
+# tensor4all-callback-test
+
+## src/lib.rs
+
+### `pub fn t4a_callback_test_simple(callback: EvalCallback, user_data: * mut c_void, result: * mut f64) -> i32`
+
+Simple test: call the callback once with fixed indices [1, 2, 3]
+
+### `pub fn t4a_callback_test_multiple(callback: EvalCallback, user_data: * mut c_void, n_calls: usize, result: * mut f64) -> i32`
+
+Test: call the callback multiple times and sum the results Calls the callback with indices [i, i+1, i+2] for i in 0..n_calls
+
+### `pub fn t4a_callback_test_with_indices(callback: EvalCallback, user_data: * mut c_void, indices: * const i64, n_indices: usize, result: * mut f64) -> i32`
+
+Test: call the callback with variable-length indices
+
+### ` fn sum_callback(indices: * const i64, n_indices: usize, result: * mut f64, _user_data: * mut c_void) -> i32`
+
+### ` fn multiply_callback(indices: * const i64, n_indices: usize, result: * mut f64, user_data: * mut c_void) -> i32`
+
+### ` fn test_simple_callback()`
+
+### ` fn test_callback_with_user_data()`
+
+### ` fn test_multiple_callbacks()`
+
+### ` fn test_with_custom_indices()`
+

--- a/docs/api/tensor4all_simplett.md
+++ b/docs/api/tensor4all_simplett.md
@@ -1,0 +1,1150 @@
+# tensor4all-simplett
+
+## src/arithmetic.rs
+
+### `pub fn add(&self, other: & Self) -> Result < Self >` (impl TensorTrain < T >)
+
+Add two tensor trains element-wise The result has bond dimension equal to the sum of the input bond dimensions. Use `compress` to reduce the bond dimension afterward.
+
+### `pub fn sub(&self, other: & Self) -> Result < Self >` (impl TensorTrain < T >)
+
+Subtract another tensor train from this one
+
+### `pub fn negate(&self) -> Self` (impl TensorTrain < T >)
+
+Negate the tensor train (multiply by -1)
+
+### ` fn add(self, other: Self) -> Self :: Output` (impl TensorTrain < T >)
+
+### ` fn add(self, other: Self) -> Self :: Output` (impl & TensorTrain < T >)
+
+### ` fn sub(self, other: Self) -> Self :: Output` (impl TensorTrain < T >)
+
+### ` fn sub(self, other: Self) -> Self :: Output` (impl & TensorTrain < T >)
+
+### ` fn neg(self) -> Self :: Output` (impl TensorTrain < T >)
+
+### ` fn neg(self) -> Self :: Output` (impl & TensorTrain < T >)
+
+### ` fn mul(self, scalar: T) -> Self :: Output` (impl TensorTrain < T >)
+
+### ` fn mul(self, scalar: T) -> Self :: Output` (impl & TensorTrain < T >)
+
+### ` fn test_add_constant_tensors()`
+
+### ` fn test_sub_constant_tensors()`
+
+### ` fn test_negate()`
+
+### ` fn test_add_operator()`
+
+### ` fn test_add_preserves_evaluation()`
+
+## src/cache.rs
+
+### `pub fn new(tt: & TT) -> Self` (impl TTCache < T >)
+
+Create a new TTCache from a tensor train
+
+### `pub fn with_site_dims(tt: & TT, site_dims: Vec < Vec < usize > >) -> Result < Self >` (impl TTCache < T >)
+
+Create a new TTCache with custom site dimensions This allows treating a single tensor site as multiple logical indices.
+
+### `pub fn len(&self) -> usize` (impl TTCache < T >)
+
+Number of sites
+
+### `pub fn is_empty(&self) -> bool` (impl TTCache < T >)
+
+Check if empty
+
+### `pub fn site_dims(&self) -> & [Vec < usize >]` (impl TTCache < T >)
+
+Get site dimensions
+
+### `pub fn link_dims(&self) -> Vec < usize >` (impl TTCache < T >)
+
+Get link dimensions
+
+### `pub fn link_dim(&self, i: usize) -> usize` (impl TTCache < T >)
+
+Get link dimension at position i (between site i and i+1)
+
+### `pub fn clear_cache(&mut self)` (impl TTCache < T >)
+
+Clear all cached values
+
+### ` fn multi_to_flat(&self, site: usize, indices: & [LocalIndex]) -> LocalIndex` (impl TTCache < T >)
+
+Convert multi-index to flat index for a site
+
+### `pub fn evaluate_left(&mut self, indices: & [LocalIndex]) -> Vec < T >` (impl TTCache < T >)
+
+Evaluate from the left up to (but not including) site `end` Returns a vector of size `link_dim(end-1)` (or 1 if end == 0)
+
+### `pub fn evaluate_right(&mut self, indices: & [LocalIndex]) -> Vec < T >` (impl TTCache < T >)
+
+Evaluate from the right starting at site `start` `indices` contains indices for sites `start` to `n-1` Returns a vector of size `link_dim(start-1)` (or 1 if start == n)
+
+### `pub fn evaluate(&mut self, indices: & [LocalIndex]) -> Result < T >` (impl TTCache < T >)
+
+Evaluate the tensor train at a given index set using cache
+
+### `pub fn batch_evaluate(&mut self, left_indices: & [MultiIndex], right_indices: & [MultiIndex], n_center: usize) -> Result < (Vec < T > , Vec < usize >) >` (impl TTCache < T >)
+
+Batch evaluate the tensor train Evaluates for all combinations of left_indices and right_indices, with `n_center` free indices in the middle.
+
+### ` fn test_ttcache_evaluate()`
+
+### ` fn test_ttcache_caching()`
+
+### ` fn test_ttcache_batch_evaluate()`
+
+### ` fn test_ttcache_clear()`
+
+## src/canonical.rs
+
+### ` fn qr_decomp(matrix: & Matrix < T >) -> (Matrix < T > , Matrix < T >)`
+
+Compute QR decomposition using rank-revealing LU with left-orthogonal output
+
+### ` fn lq_decomp(matrix: & Matrix < T >) -> (Matrix < T > , Matrix < T >)`
+
+Compute LQ decomposition (transpose, QR, transpose)
+
+### ` fn tensor3_to_left_matrix(tensor: & Tensor3 < T >) -> Matrix < T >`
+
+Convert Tensor3 to Matrix with left dimensions flattened
+
+### ` fn tensor3_to_right_matrix(tensor: & Tensor3 < T >) -> Matrix < T >`
+
+Convert Tensor3 to Matrix with right dimensions flattened
+
+### `pub fn new(tensors: Vec < Tensor3 < T > >, center: usize) -> Result < Self >` (impl SiteTensorTrain < T >)
+
+Create a new SiteTensorTrain from tensors with specified center
+
+### `pub fn from_tensor_train(tt: & TensorTrain < T >, center: usize) -> Result < Self >` (impl SiteTensorTrain < T >)
+
+Create from TensorTrain with specified center
+
+### `pub fn center(&self) -> usize` (impl SiteTensorTrain < T >)
+
+Get the center index
+
+### `pub fn partition(&self) -> & Range < usize >` (impl SiteTensorTrain < T >)
+
+Get the partition range
+
+### `pub fn site_tensors_mut(&mut self) -> & mut [Tensor3 < T >]` (impl SiteTensorTrain < T >)
+
+Get mutable access to site tensors
+
+### ` fn canonicalize(&mut self)` (impl SiteTensorTrain < T >)
+
+Canonicalize the tensor train around the center
+
+### ` fn make_left_orthogonal(&mut self, i: usize)` (impl SiteTensorTrain < T >)
+
+Make tensor at site i left-orthogonal, pushing R to site i+1
+
+### ` fn make_right_orthogonal(&mut self, i: usize)` (impl SiteTensorTrain < T >)
+
+Make tensor at site i right-orthogonal, pushing L to site i-1
+
+### `pub fn move_center_right(&mut self) -> Result < () >` (impl SiteTensorTrain < T >)
+
+Move the center one position to the right
+
+### `pub fn move_center_left(&mut self) -> Result < () >` (impl SiteTensorTrain < T >)
+
+Move the center one position to the left
+
+### `pub fn set_center(&mut self, new_center: usize) -> Result < () >` (impl SiteTensorTrain < T >)
+
+Move the center to a specific position
+
+### `pub fn to_tensor_train(&self) -> TensorTrain < T >` (impl SiteTensorTrain < T >)
+
+Convert to a regular TensorTrain
+
+### `pub fn set_site_tensor(&mut self, i: usize, tensor: Tensor3 < T >)` (impl SiteTensorTrain < T >)
+
+Set the tensor at a specific site Note: This may invalidate the canonical form. Use with caution.
+
+### `pub fn set_two_site_tensors(&mut self, i: usize, tensor1: Tensor3 < T >, tensor2: Tensor3 < T >) -> Result < () >` (impl SiteTensorTrain < T >)
+
+Set two adjacent site tensors (useful for TEBD-like algorithms)
+
+### ` fn len(&self) -> usize` (impl SiteTensorTrain < T >)
+
+### ` fn site_tensor(&self, i: usize) -> & Tensor3 < T >` (impl SiteTensorTrain < T >)
+
+### ` fn site_tensors(&self) -> & [Tensor3 < T >]` (impl SiteTensorTrain < T >)
+
+### `pub fn center_canonicalize(tensors: & mut [Tensor3 < T >], center: usize)`
+
+Center canonicalize a vector of tensors in place
+
+### ` fn test_site_tensor_train_creation()`
+
+### ` fn test_site_tensor_train_preserves_values()`
+
+### ` fn test_move_center()`
+
+### ` fn test_set_center()`
+
+### ` fn test_to_tensor_train()`
+
+### ` fn test_center_canonicalize_function()`
+
+### ` fn test_evaluate_matches_original()`
+
+## src/compression.rs
+
+### ` fn default() -> Self` (impl CompressionOptions)
+
+### ` fn tensor3_to_left_matrix(tensor: & Tensor3 < T >) -> Matrix < T >`
+
+Convert Tensor3 to Matrix for factorization (left matrix view)
+
+### ` fn tensor3_to_right_matrix(tensor: & Tensor3 < T >) -> Matrix < T >`
+
+Convert Tensor3 to Matrix for factorization (right matrix view)
+
+### ` fn factorize(matrix: & Matrix < T >, method: CompressionMethod, tolerance: f64, max_bond_dim: usize, left_orthogonal: bool) -> (Matrix < T > , Matrix < T > , usize)`
+
+Factorize a matrix into left and right factors
+
+### `pub fn compress(&mut self, options: & CompressionOptions) -> Result < () >` (impl TensorTrain < T >)
+
+Compress the tensor train in-place using the specified method This performs a two-sweep compression: 1. Left-to-right sweep with left-orthogonal factorization (no truncation)
+
+### `pub fn compressed(&self, options: & CompressionOptions) -> Result < Self >` (impl TensorTrain < T >)
+
+Create a compressed copy of the tensor train
+
+### ` fn test_compress_constant()`
+
+### ` fn test_compress_preserves_values()`
+
+### ` fn test_compress_with_max_bond_dim()`
+
+## src/contraction.rs
+
+### ` fn default() -> Self` (impl ContractionOptions)
+
+### `pub fn dot(&self, other: & Self) -> Result < T >` (impl TensorTrain < T >)
+
+Compute the inner product (dot product) of two tensor trains Returns: sum over all indices i of self[i] * other[i]
+
+### `pub fn dot(a: & TensorTrain < T >, b: & TensorTrain < T >) -> Result < T >`
+
+Convenience function to compute dot product
+
+### ` fn test_dot_constant()`
+
+### ` fn test_dot_different_tensors()`
+
+## src/mpo/contract_fit.rs
+
+### ` fn default() -> Self` (impl FitOptions)
+
+### `pub fn contract_fit(mpo_a: & MPO < T >, mpo_b: & MPO < T >, options: & FitOptions, initial: Option < MPO < T > >) -> Result < MPO < T > >`
+
+Perform variational fitting contraction of two MPOs This computes C = A * B using a variational (DMRG-like) algorithm that alternates between sweeping left-to-right and right-to-left,
+
+### ` fn identity(dim_result: usize, dim_a: usize, dim_b: usize) -> Self` (impl Environment < T >)
+
+### ` fn get(&self, r: usize, a: usize, b: usize) -> T` (impl Environment < T >)
+
+### ` fn set(&mut self, r: usize, a: usize, b: usize, val: T)` (impl Environment < T >)
+
+### ` fn build_left_environment(tensor_a: & Tensor4 < T >, tensor_b: & Tensor4 < T >, tensor_result: & Tensor4 < T >, prev_env: & Environment < T >) -> Result < Environment < T > >`
+
+Build left environment by extending from previous environment
+
+### ` fn build_right_environment(tensor_a: & Tensor4 < T >, tensor_b: & Tensor4 < T >, tensor_result: & Tensor4 < T >, next_env: & Environment < T >) -> Result < Environment < T > >`
+
+Build right environment by extending from next environment
+
+### ` fn update_two_site_core(_mpo_a: & MPO < T >, _mpo_b: & MPO < T >, _result: & mut SiteMPO < T >, _site: usize, _left_envs: & [Option < Environment < T > >], _right_envs: & [Option < Environment < T > >], _options: & FitOptions) -> Result < bool >`
+
+Update the two-site core tensor at positions site and site+1
+
+### ` fn test_contract_fit_identity()`
+
+### ` fn test_contract_fit_constant()`
+
+## src/mpo/contract_naive.rs
+
+### ` fn matrix2_zeros(rows: usize, cols: usize) -> Matrix2 < T >`
+
+Helper function to create a zero-filled 2D tensor
+
+### `pub fn contract_naive(mpo_a: & MPO < T >, mpo_b: & MPO < T >, options: Option < ContractionOptions >) -> Result < MPO < T > >`
+
+Perform naive contraction of two MPOs This computes C = A * B where the contraction is over the shared physical index (s2 of A contracts with s1 of B).
+
+### ` fn compress_mpo(mpo: & mut MPO < T >, options: & ContractionOptions) -> Result < () >`
+
+Compress an MPO using the specified options
+
+### ` fn test_contract_naive_identity()`
+
+### ` fn test_contract_naive_constant()`
+
+### ` fn test_contract_naive_dimension_mismatch()`
+
+### ` fn test_contract_naive_with_compression()`
+
+## src/mpo/contract_zipup.rs
+
+### ` fn matrix2_zeros(rows: usize, cols: usize) -> Matrix2 < T >`
+
+Helper function to create a zero-filled 2D tensor
+
+### `pub fn contract_zipup(mpo_a: & MPO < T >, mpo_b: & MPO < T >, options: & ContractionOptions) -> Result < MPO < T > >`
+
+Perform zip-up contraction of two MPOs This computes C = A * B where the contraction is over the shared physical index (s2 of A contracts with s1 of B), with on-the-fly
+
+### ` fn test_contract_zipup_identity()`
+
+### ` fn test_contract_zipup_constant()`
+
+### ` fn test_contract_zipup_compresses()`
+
+## src/mpo/contraction.rs
+
+### ` fn matrix2_zeros(rows: usize, cols: usize) -> Matrix2 < T >`
+
+Helper function to create a zero-filled 2D tensor
+
+### ` fn default() -> Self` (impl ContractionOptions)
+
+### `pub fn new(mpo_a: MPO < T >, mpo_b: MPO < T >) -> Result < Self >` (impl Contraction < T >)
+
+Create a new Contraction from two MPOs
+
+### `pub fn with_transform(mpo_a: MPO < T >, mpo_b: MPO < T >, f: F) -> Result < Self >` (impl Contraction < T >)
+
+Create a new Contraction with a transformation function
+
+### `pub fn len(&self) -> usize` (impl Contraction < T >)
+
+Get the number of sites
+
+### `pub fn is_empty(&self) -> bool` (impl Contraction < T >)
+
+Check if empty
+
+### `pub fn result_site_dims(&self) -> Vec < (usize , usize) >` (impl Contraction < T >)
+
+Get site dimensions for the contracted result Returns (s1_result, s2_result) at each site where: - s1_result = s1_a (first physical index of A)
+
+### `pub fn clear_cache(&mut self)` (impl Contraction < T >)
+
+Clear all cached environments
+
+### `pub fn evaluate(&mut self, indices: & [(usize , usize)]) -> Result < T >` (impl Contraction < T >)
+
+Evaluate the contraction at a specific set of indices indices should be [(i1, j1), (i2, j2), ...] where: - i_k is the index for s1 of MPO A at site k
+
+### `pub fn evaluate_left(&mut self, n: usize, indices: & [(usize , usize)]) -> Result < Matrix2 < T > >` (impl Contraction < T >)
+
+Evaluate the left environment up to site n (exclusive) Returns L[n] = product of sites 0..n
+
+### `pub fn evaluate_right(&mut self, n: usize, indices: & [(usize , usize)]) -> Result < Matrix2 < T > >` (impl Contraction < T >)
+
+Evaluate the right environment from site n (exclusive) to the end Returns R[n] = product of sites n..L
+
+### ` fn test_contraction_new()`
+
+### ` fn test_contraction_evaluate()`
+
+### ` fn test_contraction_with_transform()`
+
+## src/mpo/dispatch.rs
+
+### `pub fn contract(mpo_a: & MPO < T >, mpo_b: & MPO < T >, algorithm: ContractionAlgorithm, options: & ContractionOptions) -> Result < MPO < T > >`
+
+Unified contraction function with algorithm dispatch Contracts two MPOs using the specified algorithm.
+
+### ` fn test_contract_dispatch_naive()`
+
+### ` fn test_contract_dispatch_zipup()`
+
+### ` fn test_contract_dispatch_fit()`
+
+### ` fn test_contract_algorithms_consistent()`
+
+## src/mpo/environment.rs
+
+### ` fn matrix2_zeros(rows: usize, cols: usize) -> Matrix2 < T >`
+
+Helper function to create a zero-filled 2D tensor
+
+### `pub fn contract_tensors(_a: & [T], _a_shape: & [usize], _b: & [T], _b_shape: & [usize], _idx_a: & [usize], _idx_b: & [usize]) -> Result < (Vec < T > , Vec < usize >) >`
+
+Contract two general tensors over specified indices This is the Rust equivalent of `_contract` from Julia.
+
+### `pub fn contract_site_tensors(a: & Tensor4 < T >, b: & Tensor4 < T >) -> Result < Tensor4 < T > >`
+
+Contract two 4D site tensors over their shared physical index Given two 4D tensors: - A: (left_a, s1_a, s2_a, right_a) where s2_a is the shared index
+
+### `pub fn left_environment(mpo_a: & MPO < T >, mpo_b: & MPO < T >, site: usize, cache: & mut Vec < Option < Matrix2 < T > > >) -> Result < Matrix2 < T > >`
+
+Compute the left environment at site i for MPO contraction The left environment L[i] represents the contraction of all sites 0..i for the product of two MPOs A and B.
+
+### `pub fn right_environment(mpo_a: & MPO < T >, mpo_b: & MPO < T >, site: usize, cache: & mut Vec < Option < Matrix2 < T > > >) -> Result < Matrix2 < T > >`
+
+Compute the right environment at site i for MPO contraction The right environment R[i] represents the contraction of all sites i+1..L for the product of two MPOs A and B.
+
+### ` fn test_contract_site_tensors()`
+
+### ` fn test_left_environment()`
+
+### ` fn test_right_environment()`
+
+## src/mpo/factorize.rs
+
+### ` fn default() -> Self` (impl FactorizeMethod)
+
+### ` fn default() -> Self` (impl FactorizeOptions)
+
+### `pub fn factorize(matrix: & Matrix2 < T >, options: & FactorizeOptions) -> Result < FactorizeResult < T > >`
+
+Factorize a matrix into left and right factors Returns (L, R, rank, discarded) where: - L: left factor matrix (rows x rank)
+
+### ` fn matrix2_zeros(rows: usize, cols: usize) -> Matrix2 < T >`
+
+Helper function to create a zero-filled 2D tensor
+
+### ` fn factorize_svd(matrix: & Matrix2 < T >, options: & FactorizeOptions) -> Result < FactorizeResult < T > >`
+
+Factorize using SVD
+
+### ` fn factorize_rsvd(_matrix: & Matrix2 < T >, _options: & FactorizeOptions) -> Result < FactorizeResult < T > >`
+
+Factorize using randomized SVD
+
+### `pub fn factorize_lu(matrix: & Matrix2 < T >, options: & FactorizeOptions) -> Result < FactorizeResult < T > >`
+
+Factorize using LU decomposition This function requires the matrixci::Scalar trait. Use this directly when you need LU-based factorization.
+
+### `pub fn factorize_ci(matrix: & Matrix2 < T >, options: & FactorizeOptions) -> Result < FactorizeResult < T > >`
+
+Factorize using Cross Interpolation This function requires the matrixci::Scalar trait. Use this directly when you need CI-based factorization.
+
+### ` fn test_factorize_svd()`
+
+### ` fn test_factorize_lu()`
+
+### ` fn test_factorize_with_truncation()`
+
+### ` fn test_factorize_svd_complex64()`
+
+## src/mpo/inverse_mpo.rs
+
+### `pub fn from_mpo(_mpo: MPO < T >) -> Result < Self >` (impl InverseMPO < T >)
+
+Create an InverseMPO from an MPO
+
+### `pub(crate) fn from_parts_unchecked(tensors: Vec < Tensor4 < T > >, inv_lambdas: Vec < Vec < f64 > >) -> Self` (impl InverseMPO < T >)
+
+Create an InverseMPO from parts without validation
+
+### `pub fn len(&self) -> usize` (impl InverseMPO < T >)
+
+Get the number of sites
+
+### `pub fn is_empty(&self) -> bool` (impl InverseMPO < T >)
+
+Check if empty
+
+### `pub fn site_tensor(&self, i: usize) -> & Tensor4 < T >` (impl InverseMPO < T >)
+
+Get the tensor at position i
+
+### `pub fn site_tensor_mut(&mut self, i: usize) -> & mut Tensor4 < T >` (impl InverseMPO < T >)
+
+Get mutable reference to the tensor at position i
+
+### `pub fn site_tensors(&self) -> & [Tensor4 < T >]` (impl InverseMPO < T >)
+
+Get all tensors
+
+### `pub fn inv_lambda(&self, i: usize) -> & [f64]` (impl InverseMPO < T >)
+
+Get the inverse Lambda vector at bond i (between sites i and i+1)
+
+### `pub fn inv_lambdas(&self) -> & [Vec < f64 >]` (impl InverseMPO < T >)
+
+Get all inverse Lambda vectors
+
+### `pub fn link_dims(&self) -> Vec < usize >` (impl InverseMPO < T >)
+
+Bond dimensions
+
+### `pub fn site_dims(&self) -> Vec < (usize , usize) >` (impl InverseMPO < T >)
+
+Site dimensions
+
+### `pub fn rank(&self) -> usize` (impl InverseMPO < T >)
+
+Maximum bond dimension
+
+### `pub fn into_mpo(self) -> Result < MPO < T > >` (impl InverseMPO < T >)
+
+Convert to basic MPO
+
+### ` fn test_inverse_mpo_placeholder()`
+
+## src/mpo/mpo.rs
+
+### `pub fn new(tensors: Vec < Tensor4 < T > >) -> Result < Self >` (impl MPO < T >)
+
+Create a new MPO from a list of 4D tensors Each tensor should have shape (left_bond, site_dim_1, site_dim_2, right_bond) where the right_bond of tensor i equals the left_bond of tensor i+1.
+
+### `pub(crate) fn from_tensors_unchecked(tensors: Vec < Tensor4 < T > >) -> Self` (impl MPO < T >)
+
+Create an MPO from tensors without dimension validation (for internal use when dimensions are known to be correct)
+
+### `pub fn zeros(site_dims: & [(usize , usize)]) -> Self` (impl MPO < T >)
+
+Create an MPO representing the zero operator
+
+### `pub fn constant(site_dims: & [(usize , usize)], value: T) -> Self` (impl MPO < T >)
+
+Create an MPO representing a constant operator Each element O[i1, j1, i2, j2, ..., iL, jL] = value
+
+### `pub fn identity(site_dims: & [usize]) -> Result < Self >` (impl MPO < T >)
+
+Create an identity MPO (only when site_dim_1 == site_dim_2 at each site) The identity operator: O[i1, j1, ...] = delta(i1, j1) * delta(i2, j2) * ...
+
+### `pub fn len(&self) -> usize` (impl MPO < T >)
+
+Number of sites (tensors) in the MPO
+
+### `pub fn is_empty(&self) -> bool` (impl MPO < T >)
+
+Check if the MPO is empty
+
+### `pub fn site_tensor(&self, i: usize) -> & Tensor4 < T >` (impl MPO < T >)
+
+Get the site tensor at position i
+
+### `pub fn site_tensor_mut(&mut self, i: usize) -> & mut Tensor4 < T >` (impl MPO < T >)
+
+Get mutable reference to the site tensor at position i
+
+### `pub fn site_tensors(&self) -> & [Tensor4 < T >]` (impl MPO < T >)
+
+Get all site tensors
+
+### `pub fn site_tensors_mut(&mut self) -> & mut [Tensor4 < T >]` (impl MPO < T >)
+
+Get mutable access to the site tensors
+
+### `pub fn link_dims(&self) -> Vec < usize >` (impl MPO < T >)
+
+Bond dimensions along the links between tensors Returns a vector of length L-1 where L is the number of sites
+
+### `pub fn link_dim(&self, i: usize) -> usize` (impl MPO < T >)
+
+Bond dimension at the link between tensor i and i+1
+
+### `pub fn site_dims(&self) -> Vec < (usize , usize) >` (impl MPO < T >)
+
+Site dimensions (physical dimensions) for each tensor Returns a vector of (site_dim_1, site_dim_2) tuples
+
+### `pub fn site_dim(&self, i: usize) -> (usize , usize)` (impl MPO < T >)
+
+Site dimensions at position i
+
+### `pub fn rank(&self) -> usize` (impl MPO < T >)
+
+Maximum bond dimension (rank) of the MPO
+
+### `pub fn evaluate(&self, indices: & [LocalIndex]) -> Result < T >` (impl MPO < T >)
+
+Evaluate the MPO at a given index set indices should have length 2*L where L is the number of sites alternating between site_dim_1 and site_dim_2 indices:
+
+### `pub fn sum(&self) -> T` (impl MPO < T >)
+
+Sum over all indices of the MPO
+
+### `pub fn scale(&mut self, factor: T)` (impl MPO < T >)
+
+Multiply the MPO by a scalar
+
+### `pub fn scaled(&self, factor: T) -> Self` (impl MPO < T >)
+
+Create a scaled copy of the MPO
+
+### `pub fn fulltensor(&self) -> (Vec < T > , Vec < usize >)` (impl MPO < T >)
+
+Convert the MPO to a full tensor Returns a flat vector containing all tensor elements in row-major order, along with the shape (alternating site_dim_1, site_dim_2 dimensions).
+
+### ` fn test_mpo_zeros()`
+
+### ` fn test_mpo_constant()`
+
+### ` fn test_mpo_identity()`
+
+### ` fn test_mpo_evaluate()`
+
+### ` fn test_mpo_scale()`
+
+### ` fn test_mpo_link_dims()`
+
+### ` fn test_mpo_fulltensor()`
+
+## src/mpo/site_mpo.rs
+
+### `pub fn from_mpo(mpo: MPO < T >, center: usize) -> Result < Self >` (impl SiteMPO < T >)
+
+Create a SiteMPO from an MPO, placing the center at the given position
+
+### `pub(crate) fn from_tensors_unchecked(tensors: Vec < Tensor4 < T > >, center: usize) -> Self` (impl SiteMPO < T >)
+
+Create a SiteMPO from tensors without validation
+
+### `pub fn center(&self) -> usize` (impl SiteMPO < T >)
+
+Get the current orthogonality center position
+
+### `pub fn len(&self) -> usize` (impl SiteMPO < T >)
+
+Get the number of sites
+
+### `pub fn is_empty(&self) -> bool` (impl SiteMPO < T >)
+
+Check if empty
+
+### `pub fn site_tensor(&self, i: usize) -> & Tensor4 < T >` (impl SiteMPO < T >)
+
+Get the site tensor at position i
+
+### `pub fn site_tensor_mut(&mut self, i: usize) -> & mut Tensor4 < T >` (impl SiteMPO < T >)
+
+Get mutable reference to the site tensor at position i
+
+### `pub fn site_tensors(&self) -> & [Tensor4 < T >]` (impl SiteMPO < T >)
+
+Get all site tensors
+
+### `pub fn site_tensors_mut(&mut self) -> & mut [Tensor4 < T >]` (impl SiteMPO < T >)
+
+Get mutable access to site tensors
+
+### `pub fn link_dims(&self) -> Vec < usize >` (impl SiteMPO < T >)
+
+Bond dimensions
+
+### `pub fn site_dims(&self) -> Vec < (usize , usize) >` (impl SiteMPO < T >)
+
+Site dimensions
+
+### `pub fn rank(&self) -> usize` (impl SiteMPO < T >)
+
+Maximum bond dimension
+
+### `pub fn move_center_left(&mut self) -> Result < () >` (impl SiteMPO < T >)
+
+Move the orthogonality center one position to the left
+
+### `pub fn move_center_right(&mut self) -> Result < () >` (impl SiteMPO < T >)
+
+Move the orthogonality center one position to the right
+
+### `pub fn set_center(&mut self, target: usize) -> Result < () >` (impl SiteMPO < T >)
+
+Move the orthogonality center to the specified position
+
+### `pub fn into_mpo(self) -> MPO < T >` (impl SiteMPO < T >)
+
+Convert to basic MPO
+
+### ` fn test_site_mpo_creation()`
+
+### ` fn test_site_mpo_move_center()`
+
+### ` fn test_site_mpo_invalid_center()`
+
+## src/mpo/types.rs
+
+### `pub fn left_dim(&self) -> usize` (trait Tensor4Ops)
+
+Get the left (bond) dimension
+
+### `pub fn site_dim_1(&self) -> usize` (trait Tensor4Ops)
+
+Get the first site (physical) dimension
+
+### `pub fn site_dim_2(&self) -> usize` (trait Tensor4Ops)
+
+Get the second site (physical) dimension
+
+### `pub fn right_dim(&self) -> usize` (trait Tensor4Ops)
+
+Get the right (bond) dimension
+
+### `pub fn get4(&self, l: usize, s1: usize, s2: usize, r: usize) -> & T` (trait Tensor4Ops)
+
+Get element at (left, site1, site2, right)
+
+### `pub fn get4_mut(&mut self, l: usize, s1: usize, s2: usize, r: usize) -> & mut T` (trait Tensor4Ops)
+
+Get mutable element at (left, site1, site2, right)
+
+### `pub fn set4(&mut self, l: usize, s1: usize, s2: usize, r: usize, value: T)` (trait Tensor4Ops)
+
+Set element at (left, site1, site2, right)
+
+### `pub fn slice_site(&self, s1: usize, s2: usize) -> Vec < T >` (trait Tensor4Ops)
+
+Get a slice for fixed site indices: returns (left_dim, right_dim) matrix as flat Vec
+
+### `pub fn as_left_matrix(&self) -> (Vec < T > , usize , usize)` (trait Tensor4Ops)
+
+Reshape this tensor to a matrix (left_dim * site_dim_1 * site_dim_2, right_dim)
+
+### `pub fn as_right_matrix(&self) -> (Vec < T > , usize , usize)` (trait Tensor4Ops)
+
+Reshape this tensor to a matrix (left_dim, site_dim_1 * site_dim_2 * right_dim)
+
+### `pub fn as_center_matrix(&self) -> (Vec < T > , usize , usize)` (trait Tensor4Ops)
+
+Reshape this tensor to a matrix (left_dim * site_dim_1, site_dim_2 * right_dim)
+
+### ` fn left_dim(&self) -> usize` (impl Tensor4 < T >)
+
+### ` fn site_dim_1(&self) -> usize` (impl Tensor4 < T >)
+
+### ` fn site_dim_2(&self) -> usize` (impl Tensor4 < T >)
+
+### ` fn right_dim(&self) -> usize` (impl Tensor4 < T >)
+
+### ` fn get4(&self, l: usize, s1: usize, s2: usize, r: usize) -> & T` (impl Tensor4 < T >)
+
+### ` fn get4_mut(&mut self, l: usize, s1: usize, s2: usize, r: usize) -> & mut T` (impl Tensor4 < T >)
+
+### ` fn set4(&mut self, l: usize, s1: usize, s2: usize, r: usize, value: T)` (impl Tensor4 < T >)
+
+### ` fn slice_site(&self, s1: usize, s2: usize) -> Vec < T >` (impl Tensor4 < T >)
+
+### ` fn as_left_matrix(&self) -> (Vec < T > , usize , usize)` (impl Tensor4 < T >)
+
+### ` fn as_right_matrix(&self) -> (Vec < T > , usize , usize)` (impl Tensor4 < T >)
+
+### ` fn as_center_matrix(&self) -> (Vec < T > , usize , usize)` (impl Tensor4 < T >)
+
+### `pub fn tensor4_zeros(left_dim: usize, site_dim_1: usize, site_dim_2: usize, right_dim: usize) -> Tensor4 < T >`
+
+Create a zero-filled Tensor4
+
+### `pub fn tensor4_from_data(data: Vec < T >, left_dim: usize, site_dim_1: usize, site_dim_2: usize, right_dim: usize) -> Tensor4 < T >`
+
+Create a Tensor4 from flat data (row-major order)
+
+### ` fn test_tensor4_zeros()`
+
+### ` fn test_tensor4_get_set()`
+
+### ` fn test_tensor4_from_data()`
+
+### ` fn test_slice_site()`
+
+### ` fn test_as_left_matrix()`
+
+### ` fn test_as_right_matrix()`
+
+### ` fn test_as_center_matrix()`
+
+## src/mpo/vidal_mpo.rs
+
+### `pub fn from_mpo(_mpo: MPO < T >) -> Result < Self >` (impl VidalMPO < T >)
+
+Create a VidalMPO from an MPO
+
+### `pub(crate) fn from_parts_unchecked(gammas: Vec < Tensor4 < T > >, lambdas: Vec < Vec < f64 > >) -> Self` (impl VidalMPO < T >)
+
+Create a VidalMPO from tensors and lambdas without validation
+
+### `pub fn len(&self) -> usize` (impl VidalMPO < T >)
+
+Get the number of sites
+
+### `pub fn is_empty(&self) -> bool` (impl VidalMPO < T >)
+
+Check if empty
+
+### `pub fn gamma(&self, i: usize) -> & Tensor4 < T >` (impl VidalMPO < T >)
+
+Get the Gamma tensor at position i
+
+### `pub fn gamma_mut(&mut self, i: usize) -> & mut Tensor4 < T >` (impl VidalMPO < T >)
+
+Get mutable reference to the Gamma tensor at position i
+
+### `pub fn gammas(&self) -> & [Tensor4 < T >]` (impl VidalMPO < T >)
+
+Get all Gamma tensors
+
+### `pub fn lambda(&self, i: usize) -> & [f64]` (impl VidalMPO < T >)
+
+Get the Lambda vector at bond i (between sites i and i+1)
+
+### `pub fn lambdas(&self) -> & [Vec < f64 >]` (impl VidalMPO < T >)
+
+Get all Lambda vectors
+
+### `pub fn link_dims(&self) -> Vec < usize >` (impl VidalMPO < T >)
+
+Bond dimensions
+
+### `pub fn site_dims(&self) -> Vec < (usize , usize) >` (impl VidalMPO < T >)
+
+Site dimensions
+
+### `pub fn rank(&self) -> usize` (impl VidalMPO < T >)
+
+Maximum bond dimension
+
+### `pub fn into_mpo(self) -> Result < MPO < T > >` (impl VidalMPO < T >)
+
+Convert to basic MPO
+
+### ` fn test_vidal_mpo_placeholder()`
+
+## src/tensortrain.rs
+
+### `pub fn new(tensors: Vec < Tensor3 < T > >) -> Result < Self >` (impl TensorTrain < T >)
+
+Create a new tensor train from a list of 3D tensors Each tensor should have shape (left_bond, site_dim, right_bond) where the right_bond of tensor i equals the left_bond of tensor i+1.
+
+### `pub(crate) fn from_tensors_unchecked(tensors: Vec < Tensor3 < T > >) -> Self` (impl TensorTrain < T >)
+
+Create a tensor train from tensors without dimension validation (for internal use when dimensions are known to be correct)
+
+### `pub fn zeros(site_dims: & [usize]) -> Self` (impl TensorTrain < T >)
+
+Create a tensor train representing the zero function
+
+### `pub fn constant(site_dims: & [usize], value: T) -> Self` (impl TensorTrain < T >)
+
+Create a tensor train representing a constant function
+
+### `pub fn site_tensors_mut(&mut self) -> & mut [Tensor3 < T >]` (impl TensorTrain < T >)
+
+Get mutable access to the site tensors
+
+### `pub fn scale(&mut self, factor: T)` (impl TensorTrain < T >)
+
+Multiply the tensor train by a scalar
+
+### `pub fn scaled(&self, factor: T) -> Self` (impl TensorTrain < T >)
+
+Create a scaled copy of the tensor train
+
+### `pub fn reverse(&self) -> Self` (impl TensorTrain < T >)
+
+Reverse the tensor train (swap left and right)
+
+### `pub fn fulltensor(&self) -> (Vec < T > , Vec < usize >)` (impl TensorTrain < T >)
+
+Convert the tensor train to a full tensor Returns a flat vector containing all tensor elements in row-major order, along with the shape (site dimensions).
+
+### ` fn len(&self) -> usize` (impl TensorTrain < T >)
+
+### ` fn site_tensor(&self, i: usize) -> & Tensor3 < T >` (impl TensorTrain < T >)
+
+### ` fn site_tensors(&self) -> & [Tensor3 < T >]` (impl TensorTrain < T >)
+
+### ` fn test_tensortrain_zeros()`
+
+### ` fn test_tensortrain_constant()`
+
+### ` fn test_tensortrain_evaluate()`
+
+### ` fn test_tensortrain_scale()`
+
+### ` fn test_tensortrain_reverse()`
+
+### ` fn test_fulltensor()`
+
+### ` fn test_fulltensor_matches_evaluate()`
+
+### ` fn test_log_norm_matches_norm()`
+
+### ` fn test_log_norm_with_varied_values()`
+
+### ` fn test_log_norm_zero_tensor()`
+
+## src/traits.rs
+
+### `pub fn conj(self) -> Self` (trait TTScalar)
+
+Conjugate
+
+### `pub fn abs_sq(self) -> f64` (trait TTScalar)
+
+Absolute value squared
+
+### `pub fn from_f64(val: f64) -> Self` (trait TTScalar)
+
+Create from f64
+
+### ` fn conj(self) -> Self` (impl f64)
+
+### ` fn abs_sq(self) -> f64` (impl f64)
+
+### ` fn from_f64(val: f64) -> Self` (impl f64)
+
+### ` fn conj(self) -> Self` (impl f32)
+
+### ` fn abs_sq(self) -> f64` (impl f32)
+
+### ` fn from_f64(val: f64) -> Self` (impl f32)
+
+### ` fn conj(self) -> Self` (impl num_complex :: Complex64)
+
+### ` fn abs_sq(self) -> f64` (impl num_complex :: Complex64)
+
+### ` fn from_f64(val: f64) -> Self` (impl num_complex :: Complex64)
+
+### ` fn conj(self) -> Self` (impl num_complex :: Complex32)
+
+### ` fn abs_sq(self) -> f64` (impl num_complex :: Complex32)
+
+### ` fn from_f64(val: f64) -> Self` (impl num_complex :: Complex32)
+
+### `pub fn len(&self) -> usize` (trait AbstractTensorTrain)
+
+Number of sites (tensors) in the tensor train
+
+### `pub fn is_empty(&self) -> bool` (trait AbstractTensorTrain default)
+
+Check if the tensor train is empty
+
+### `pub fn site_tensor(&self, i: usize) -> & Tensor3 < T >` (trait AbstractTensorTrain)
+
+Get the site tensor at position i
+
+### `pub fn site_tensors(&self) -> & [Tensor3 < T >]` (trait AbstractTensorTrain)
+
+Get all site tensors
+
+### `pub fn link_dims(&self) -> Vec < usize >` (trait AbstractTensorTrain default)
+
+Bond dimensions along the links between tensors Returns a vector of length L-1 where L is the number of sites
+
+### `pub fn link_dim(&self, i: usize) -> usize` (trait AbstractTensorTrain default)
+
+Bond dimension at the link between tensor i and i+1
+
+### `pub fn site_dims(&self) -> Vec < usize >` (trait AbstractTensorTrain default)
+
+Site dimensions (physical dimensions) for each tensor
+
+### `pub fn site_dim(&self, i: usize) -> usize` (trait AbstractTensorTrain default)
+
+Site dimension at position i
+
+### `pub fn rank(&self) -> usize` (trait AbstractTensorTrain default)
+
+Maximum bond dimension (rank) of the tensor train
+
+### `pub fn evaluate(&self, indices: & [LocalIndex]) -> Result < T >` (trait AbstractTensorTrain default)
+
+Evaluate the tensor train at a given index set
+
+### `pub fn sum(&self) -> T` (trait AbstractTensorTrain default)
+
+Sum over all indices of the tensor train
+
+### `pub fn norm2(&self) -> f64` (trait AbstractTensorTrain default)
+
+Compute the squared Frobenius norm of the tensor train
+
+### `pub fn norm(&self) -> f64` (trait AbstractTensorTrain default)
+
+Compute the Frobenius norm of the tensor train
+
+### `pub fn log_norm(&self) -> f64` (trait AbstractTensorTrain default)
+
+Compute the logarithm of the Frobenius norm of the tensor train This is more numerically stable than `norm().ln()` for tensor trains with very large or very small norms, as it avoids overflow/underflow
+
+## src/types.rs
+
+### `pub fn left_dim(&self) -> usize` (trait Tensor3Ops)
+
+Get the left (bond) dimension
+
+### `pub fn site_dim(&self) -> usize` (trait Tensor3Ops)
+
+Get the site (physical) dimension
+
+### `pub fn right_dim(&self) -> usize` (trait Tensor3Ops)
+
+Get the right (bond) dimension
+
+### `pub fn get3(&self, l: usize, s: usize, r: usize) -> & T` (trait Tensor3Ops)
+
+Get element at (left, site, right)
+
+### `pub fn get3_mut(&mut self, l: usize, s: usize, r: usize) -> & mut T` (trait Tensor3Ops)
+
+Get mutable element at (left, site, right)
+
+### `pub fn set3(&mut self, l: usize, s: usize, r: usize, value: T)` (trait Tensor3Ops)
+
+Set element at (left, site, right)
+
+### `pub fn slice_site(&self, s: usize) -> Vec < T >` (trait Tensor3Ops)
+
+Get a slice for fixed site index: returns (left_dim, right_dim) matrix as flat Vec
+
+### `pub fn as_left_matrix(&self) -> (Vec < T > , usize , usize)` (trait Tensor3Ops)
+
+Reshape this tensor to a matrix (left_dim * site_dim, right_dim)
+
+### `pub fn as_right_matrix(&self) -> (Vec < T > , usize , usize)` (trait Tensor3Ops)
+
+Reshape this tensor to a matrix (left_dim, site_dim * right_dim)
+
+### ` fn left_dim(&self) -> usize` (impl Tensor3 < T >)
+
+### ` fn site_dim(&self) -> usize` (impl Tensor3 < T >)
+
+### ` fn right_dim(&self) -> usize` (impl Tensor3 < T >)
+
+### ` fn get3(&self, l: usize, s: usize, r: usize) -> & T` (impl Tensor3 < T >)
+
+### ` fn get3_mut(&mut self, l: usize, s: usize, r: usize) -> & mut T` (impl Tensor3 < T >)
+
+### ` fn set3(&mut self, l: usize, s: usize, r: usize, value: T)` (impl Tensor3 < T >)
+
+### ` fn slice_site(&self, s: usize) -> Vec < T >` (impl Tensor3 < T >)
+
+### ` fn as_left_matrix(&self) -> (Vec < T > , usize , usize)` (impl Tensor3 < T >)
+
+### ` fn as_right_matrix(&self) -> (Vec < T > , usize , usize)` (impl Tensor3 < T >)
+
+### `pub fn tensor3_zeros(left_dim: usize, site_dim: usize, right_dim: usize) -> Tensor3 < T >`
+
+Create a zero-filled Tensor3
+
+### `pub fn tensor3_from_data(data: Vec < T >, left_dim: usize, site_dim: usize, right_dim: usize) -> Tensor3 < T >`
+
+Create a Tensor3 from flat data (row-major order)
+
+## src/vidal.rs
+
+### ` fn qr_decomp(matrix: & Matrix < T >) -> (Matrix < T > , Matrix < T >)`
+
+Compute QR decomposition
+
+### ` fn lq_decomp(matrix: & Matrix < T >) -> (Matrix < T > , Matrix < T >)`
+
+Compute LQ decomposition
+
+### ` fn tensor3_to_left_matrix(tensor: & Tensor3 < T >) -> Matrix < T >`
+
+Convert Tensor3 to Matrix with left dimensions flattened
+
+### ` fn tensor3_to_right_matrix(tensor: & Tensor3 < T >) -> Matrix < T >`
+
+Convert Tensor3 to Matrix with right dimensions flattened
+
+### `pub fn from_tensor_train(tt: & TensorTrain < T >) -> Result < Self >` (impl VidalTensorTrain < T >)
+
+Create a VidalTensorTrain from a regular TensorTrain
+
+### `pub fn from_tensor_train_with_partition(tt: & TensorTrain < T >, partition: Range < usize >) -> Result < Self >` (impl VidalTensorTrain < T >)
+
+Create a VidalTensorTrain with a specific partition
+
+### `pub fn new(tensors: Vec < Tensor3 < T > >, singular_values: Vec < DiagMatrix >) -> Result < Self >` (impl VidalTensorTrain < T >)
+
+Create a VidalTensorTrain with given tensors and singular values
+
+### `pub fn singular_values(&self, i: usize) -> & DiagMatrix` (impl VidalTensorTrain < T >)
+
+Get the singular values between sites i and i+1
+
+### `pub fn all_singular_values(&self) -> & [DiagMatrix]` (impl VidalTensorTrain < T >)
+
+Get all singular value matrices
+
+### `pub fn partition(&self) -> & Range < usize >` (impl VidalTensorTrain < T >)
+
+Get the partition range
+
+### `pub fn site_tensors_mut(&mut self) -> & mut [Tensor3 < T >]` (impl VidalTensorTrain < T >)
+
+Get mutable access to site tensors
+
+### `pub fn singular_values_mut(&mut self, i: usize) -> & mut DiagMatrix` (impl VidalTensorTrain < T >)
+
+Get mutable access to singular values
+
+### `pub fn to_tensor_train(&self) -> TensorTrain < T >` (impl VidalTensorTrain < T >)
+
+Convert to a regular TensorTrain
+
+### ` fn len(&self) -> usize` (impl VidalTensorTrain < T >)
+
+### ` fn site_tensor(&self, i: usize) -> & Tensor3 < T >` (impl VidalTensorTrain < T >)
+
+### ` fn site_tensors(&self) -> & [Tensor3 < T >]` (impl VidalTensorTrain < T >)
+
+### `pub fn from_vidal(vidal: & VidalTensorTrain < T >) -> Result < Self >` (impl InverseTensorTrain < T >)
+
+Create an InverseTensorTrain from a VidalTensorTrain
+
+### `pub fn from_tensor_train(tt: & TensorTrain < T >) -> Result < Self >` (impl InverseTensorTrain < T >)
+
+Create an InverseTensorTrain from a regular TensorTrain
+
+### `pub fn inverse_singular_values(&self, i: usize) -> & DiagMatrix` (impl InverseTensorTrain < T >)
+
+Get the inverse singular values between sites i and i+1
+
+### `pub fn all_inverse_singular_values(&self) -> & [DiagMatrix]` (impl InverseTensorTrain < T >)
+
+Get all inverse singular value matrices
+
+### `pub fn partition(&self) -> & Range < usize >` (impl InverseTensorTrain < T >)
+
+Get the partition range
+
+### `pub fn site_tensors_mut(&mut self) -> & mut [Tensor3 < T >]` (impl InverseTensorTrain < T >)
+
+Get mutable access to site tensors
+
+### `pub fn set_two_site_tensors(&mut self, i: usize, tensor1: Tensor3 < T >, inv_sv: DiagMatrix, tensor2: Tensor3 < T >) -> Result < () >` (impl InverseTensorTrain < T >)
+
+Set two adjacent site tensors along with their inverse singular values
+
+### `pub fn to_tensor_train(&self) -> TensorTrain < T >` (impl InverseTensorTrain < T >)
+
+Convert to a regular TensorTrain
+
+### ` fn len(&self) -> usize` (impl InverseTensorTrain < T >)
+
+### ` fn site_tensor(&self, i: usize) -> & Tensor3 < T >` (impl InverseTensorTrain < T >)
+
+### ` fn site_tensors(&self) -> & [Tensor3 < T >]` (impl InverseTensorTrain < T >)
+
+### ` fn test_vidal_creation()`
+
+### ` fn test_vidal_to_tensor_train_preserves_sum()`
+
+### ` fn test_inverse_creation()`
+
+### ` fn test_inverse_to_tensor_train_preserves_sum()`
+
+### ` fn test_vidal_singular_values_positive()`
+

--- a/docs/api/tensor4all_tensorbackend.md
+++ b/docs/api/tensor4all_tensorbackend.md
@@ -1,0 +1,362 @@
+# tensor4all-tensorbackend
+
+## src/any_scalar.rs
+
+### ` fn sum_from_storage(storage: & Storage) -> Self` (impl AnyScalar)
+
+### `pub fn new_real(x: f64) -> Self` (impl AnyScalar)
+
+Create a real scalar value.
+
+### `pub fn new_complex(re: f64, im: f64) -> Self` (impl AnyScalar)
+
+Create a complex scalar value from real and imaginary parts.
+
+### `pub fn is_complex(&self) -> bool` (impl AnyScalar)
+
+Check if this scalar is complex.
+
+### `pub fn real(&self) -> f64` (impl AnyScalar)
+
+Get the real part of the scalar.
+
+### `pub fn abs(&self) -> f64` (impl AnyScalar)
+
+Get the absolute value (magnitude).
+
+### `pub fn sqrt(&self) -> Self` (impl AnyScalar)
+
+Compute square root. For negative real numbers, returns a complex number with the principal value.
+
+### `pub fn powf(&self, exp: f64) -> Self` (impl AnyScalar)
+
+Raise to a floating-point power. For negative real numbers, returns a complex number with the principal value.
+
+### `pub fn powi(&self, exp: i32) -> Self` (impl AnyScalar)
+
+Raise to an integer power.
+
+### ` fn add(self, rhs: Self) -> Self :: Output` (impl AnyScalar)
+
+### ` fn sub(self, rhs: Self) -> Self :: Output` (impl AnyScalar)
+
+### ` fn mul(self, rhs: Self) -> Self :: Output` (impl AnyScalar)
+
+### ` fn div(self, rhs: Self) -> Self :: Output` (impl AnyScalar)
+
+### ` fn neg(self) -> Self :: Output` (impl AnyScalar)
+
+### ` fn from(x: f64) -> Self` (impl AnyScalar)
+
+### ` fn from(z: Complex64) -> Self` (impl AnyScalar)
+
+### ` fn try_from(value: AnyScalar) -> Result < Self , Self :: Error >` (impl f64)
+
+### ` fn from(value: AnyScalar) -> Self` (impl Complex64)
+
+### ` fn default() -> Self` (impl AnyScalar)
+
+### ` fn zero() -> Self` (impl AnyScalar)
+
+### ` fn is_zero(&self) -> bool` (impl AnyScalar)
+
+### ` fn one() -> Self` (impl AnyScalar)
+
+### ` fn partial_cmp(&self, other: & Self) -> Option < std :: cmp :: Ordering >` (impl AnyScalar)
+
+### ` fn fmt(&self, f: & mut fmt :: Formatter < '_ >) -> fmt :: Result` (impl AnyScalar)
+
+## src/backend.rs
+
+### ` fn tensor_to_dtensor(tensor: & mdarray :: Tensor < T , (usize , usize) >) -> DTensor < T , 2 >`
+
+Convert mdarray Tensor<T, (usize, usize)> to DTensor<T, 2>
+
+### `pub fn svd_backend(a: & mut DSlice < T , 2 >) -> Result < SvdResult < T > >`
+
+Compute SVD decomposition using FAER backend.
+
+### `pub fn qr_backend(a: & mut DSlice < T , 2 >) -> (DTensor < T , 2 > , DTensor < T , 2 >)`
+
+Compute QR decomposition using FAER backend.
+
+### `pub fn svd_impl(a: & mut DSlice < Self , 2 >) -> Result < SvdResult < Self > >` (trait SvdBackendImpl)
+
+### `pub fn qr_impl(a: & mut DSlice < Self , 2 >) -> (DTensor < Self , 2 > , DTensor < Self , 2 >)` (trait QrBackendImpl)
+
+### `pub fn svd_backend(a: & mut DSlice < T , 2 >) -> Result < SvdResult < T > >`
+
+Compute SVD decomposition using LAPACK backend.
+
+### `pub fn qr_backend(a: & mut DSlice < T , 2 >) -> (DTensor < T , 2 > , DTensor < T , 2 >)`
+
+Compute QR decomposition using LAPACK backend.
+
+## src/storage.rs
+
+### `pub fn with_capacity(capacity: usize) -> Self` (impl DenseStorageF64)
+
+### `pub fn from_vec(vec: Vec < f64 >) -> Self` (impl DenseStorageF64)
+
+### `pub fn random(rng: & mut R, size: usize) -> Self` (impl DenseStorageF64)
+
+Create storage with random values from standard normal distribution.
+
+### `pub fn as_slice(&self) -> & [f64]` (impl DenseStorageF64)
+
+### `pub fn as_mut_slice(&mut self) -> & mut [f64]` (impl DenseStorageF64)
+
+### `pub fn into_vec(self) -> Vec < f64 >` (impl DenseStorageF64)
+
+### `pub fn len(&self) -> usize` (impl DenseStorageF64)
+
+### `pub fn capacity(&self) -> usize` (impl DenseStorageF64)
+
+### `pub fn push(&mut self, val: f64)` (impl DenseStorageF64)
+
+### `pub fn extend_from_slice(&mut self, other: & [f64])` (impl DenseStorageF64)
+
+### `pub fn extend(&mut self, iter: I)` (impl DenseStorageF64)
+
+### `pub fn get(&self, i: usize) -> f64` (impl DenseStorageF64)
+
+### `pub fn set(&mut self, i: usize, val: f64)` (impl DenseStorageF64)
+
+### `pub fn iter(&self) -> std :: slice :: Iter < '_ , f64 >` (impl DenseStorageF64)
+
+### `pub fn permute(&self, dims: & [usize], perm: & [usize]) -> Self` (impl DenseStorageF64)
+
+Permute the dense storage data according to the given permutation.
+
+### `pub fn contract(&self, dims: & [usize], axes: & [usize], other: & Self, other_dims: & [usize], other_axes: & [usize]) -> Self` (impl DenseStorageF64)
+
+Contract this dense storage with another dense storage. This method handles non-contiguous contracted axes by permuting the tensors to make the contracted axes contiguous before calling mdarray-linalg's contract.
+
+### ` fn contract_via_gemm(a: & [f64], dims_a: & [usize], axes_a: & [usize], b: & [f64], dims_b: & [usize], axes_b: & [usize]) -> Vec < f64 >`
+
+Contract two tensors via GEMM (matrix multiplication). This function assumes that contracted axes are already contiguous: - For `a`: contracted axes are at the END (axes_a are the last naxes positions)
+
+### ` fn contract_via_gemm_c64(a: & [Complex64], dims_a: & [usize], axes_a: & [usize], b: & [Complex64], dims_b: & [usize], axes_b: & [usize]) -> Vec < Complex64 >`
+
+Contract two Complex64 tensors via GEMM (matrix multiplication). Same as contract_via_gemm but for complex numbers.
+
+### ` fn compute_contraction_permutation(dims: & [usize], axes: & [usize], axes_at_front: bool) -> (Vec < usize > , Vec < usize > , Vec < usize >)`
+
+Compute permutation to make contracted axes contiguous. If `axes_at_front` is true, contracted axes are moved to the front (maintaining original order). If false, contracted axes are moved to the end (maintaining original order).
+
+### `pub fn with_capacity(capacity: usize) -> Self` (impl DenseStorageC64)
+
+### `pub fn from_vec(vec: Vec < Complex64 >) -> Self` (impl DenseStorageC64)
+
+### `pub fn random(rng: & mut R, size: usize) -> Self` (impl DenseStorageC64)
+
+Create storage with random complex values (re, im both from standard normal).
+
+### `pub fn as_slice(&self) -> & [Complex64]` (impl DenseStorageC64)
+
+### `pub fn as_mut_slice(&mut self) -> & mut [Complex64]` (impl DenseStorageC64)
+
+### `pub fn into_vec(self) -> Vec < Complex64 >` (impl DenseStorageC64)
+
+### `pub fn len(&self) -> usize` (impl DenseStorageC64)
+
+### `pub fn capacity(&self) -> usize` (impl DenseStorageC64)
+
+### `pub fn push(&mut self, val: Complex64)` (impl DenseStorageC64)
+
+### `pub fn extend_from_slice(&mut self, other: & [Complex64])` (impl DenseStorageC64)
+
+### `pub fn extend(&mut self, iter: I)` (impl DenseStorageC64)
+
+### `pub fn get(&self, i: usize) -> Complex64` (impl DenseStorageC64)
+
+### `pub fn set(&mut self, i: usize, val: Complex64)` (impl DenseStorageC64)
+
+### `pub fn permute(&self, dims: & [usize], perm: & [usize]) -> Self` (impl DenseStorageC64)
+
+Permute the dense storage data according to the given permutation.
+
+### `pub fn contract(&self, dims: & [usize], axes: & [usize], other: & Self, other_dims: & [usize], other_axes: & [usize]) -> Self` (impl DenseStorageC64)
+
+Contract this dense storage with another dense storage. This method handles non-contiguous contracted axes by permuting the tensors to make the contracted axes contiguous before calling mdarray-linalg's contract.
+
+### `pub fn from_vec(vec: Vec < f64 >) -> Self` (impl DiagStorageF64)
+
+### `pub fn as_slice(&self) -> & [f64]` (impl DiagStorageF64)
+
+### `pub fn as_mut_slice(&mut self) -> & mut [f64]` (impl DiagStorageF64)
+
+### `pub fn into_vec(self) -> Vec < f64 >` (impl DiagStorageF64)
+
+### `pub fn len(&self) -> usize` (impl DiagStorageF64)
+
+### `pub fn get(&self, i: usize) -> f64` (impl DiagStorageF64)
+
+### `pub fn set(&mut self, i: usize, val: f64)` (impl DiagStorageF64)
+
+### `pub fn to_dense_vec(&self, dims: & [usize]) -> Vec < f64 >` (impl DiagStorageF64)
+
+Convert diagonal storage to a dense vector representation. Creates a dense vector with diagonal elements set and off-diagonal elements as zero.
+
+### `pub fn contract_diag_diag(&self, dims: & [usize], other: & Self, other_dims: & [usize], result_dims: & [usize]) -> Storage` (impl DiagStorageF64)
+
+Contract this diagonal storage with another diagonal storage. Returns either a scalar (DenseStorageF64 with one element) or a diagonal storage.
+
+### `pub fn from_vec(vec: Vec < Complex64 >) -> Self` (impl DiagStorageC64)
+
+### `pub fn as_slice(&self) -> & [Complex64]` (impl DiagStorageC64)
+
+### `pub fn as_mut_slice(&mut self) -> & mut [Complex64]` (impl DiagStorageC64)
+
+### `pub fn into_vec(self) -> Vec < Complex64 >` (impl DiagStorageC64)
+
+### `pub fn len(&self) -> usize` (impl DiagStorageC64)
+
+### `pub fn get(&self, i: usize) -> Complex64` (impl DiagStorageC64)
+
+### `pub fn set(&mut self, i: usize, val: Complex64)` (impl DiagStorageC64)
+
+### `pub fn to_dense_vec(&self, dims: & [usize]) -> Vec < Complex64 >` (impl DiagStorageC64)
+
+Convert diagonal storage to a dense vector representation. Creates a dense vector with diagonal elements set and off-diagonal elements as zero.
+
+### `pub fn contract_diag_diag(&self, dims: & [usize], other: & Self, other_dims: & [usize], result_dims: & [usize]) -> Storage` (impl DiagStorageC64)
+
+Contract this diagonal storage with another diagonal storage. Returns either a scalar (DenseStorageC64 with one element) or a diagonal storage.
+
+### `pub fn new_dense(capacity: usize) -> Storage` (trait DenseStorageFactory)
+
+### ` fn new_dense(capacity: usize) -> Storage` (impl f64)
+
+### ` fn new_dense(capacity: usize) -> Storage` (impl Complex64)
+
+### `pub fn sum_from_storage(storage: & Storage) -> Self` (trait SumFromStorage)
+
+### ` fn sum_from_storage(storage: & Storage) -> Self` (impl f64)
+
+### ` fn sum_from_storage(storage: & Storage) -> Self` (impl Complex64)
+
+### `pub fn new_dense_f64(capacity: usize) -> Self` (impl Storage)
+
+Create a new DenseF64 storage with the given capacity.
+
+### `pub fn new_dense_c64(capacity: usize) -> Self` (impl Storage)
+
+Create a new DenseC64 storage with the given capacity.
+
+### `pub fn new_diag_f64(diag_data: Vec < f64 >) -> Self` (impl Storage)
+
+Create a new DiagF64 storage with the given diagonal data.
+
+### `pub fn new_diag_c64(diag_data: Vec < Complex64 >) -> Self` (impl Storage)
+
+Create a new DiagC64 storage with the given diagonal data.
+
+### `pub fn is_diag(&self) -> bool` (impl Storage)
+
+Check if this storage is a Diag storage type.
+
+### `pub fn len(&self) -> usize` (impl Storage)
+
+Get the length of the storage (number of elements).
+
+### `pub fn sum_f64(&self) -> f64` (impl Storage)
+
+Sum all elements as f64.
+
+### `pub fn sum_c64(&self) -> Complex64` (impl Storage)
+
+Sum all elements as Complex64.
+
+### `pub fn to_dense_storage(&self, dims: & [usize]) -> Storage` (impl Storage)
+
+Convert this storage to dense storage. For Diag storage, creates a Dense storage with diagonal elements set and off-diagonal elements as zero.
+
+### `pub fn permute_storage(&self, dims: & [usize], perm: & [usize]) -> Storage` (impl Storage)
+
+Permute the storage data according to the given permutation.
+
+### `pub fn extract_real_part(&self) -> Storage` (impl Storage)
+
+Extract real part from Complex64 storage as f64 storage. For f64 storage, returns a copy.
+
+### `pub fn extract_imag_part(&self, dims: & [usize]) -> Storage` (impl Storage)
+
+Extract imaginary part from Complex64 storage as f64 storage. For f64 storage, returns zero storage (will be resized appropriately).
+
+### `pub fn to_complex_storage(&self) -> Storage` (impl Storage)
+
+Convert f64 storage to Complex64 storage (real part only, imaginary part is zero). For Complex64 storage, returns a copy.
+
+### `pub fn conj(&self) -> Self` (impl Storage)
+
+Complex conjugate of all elements. For real (f64) storage, returns a copy (conjugate of real is identity). For complex (Complex64) storage, conjugates each element.
+
+### `pub fn combine_to_complex(real_storage: & Storage, imag_storage: & Storage) -> Storage` (impl Storage)
+
+Combine two f64 storages into Complex64 storage. real_storage becomes the real part, imag_storage becomes the imaginary part. Formula: real + i * imag
+
+### `pub fn try_add(&self, other: & Storage) -> Result < Storage , String >` (impl Storage)
+
+Add two storages element-wise, returning `Result` on error instead of panicking. Both storages must have the same type and length.
+
+### `pub fn try_sub(&self, other: & Storage) -> Result < Storage , String >` (impl Storage)
+
+Try to subtract two storages element-wise. Returns an error if the storages have different types or lengths.
+
+### `pub fn scale(&self, scalar: & crate :: AnyScalar) -> Storage` (impl Storage)
+
+Scale storage by a scalar value. If the scalar is complex but the storage is real, the storage is promoted to complex.
+
+### `pub fn axpby(&self, a: & crate :: AnyScalar, other: & Storage, b: & crate :: AnyScalar) -> Result < Storage , String >` (impl Storage)
+
+Compute linear combination: `a * self + b * other`. Returns an error if the storages have different types or lengths. If any scalar is complex, the result is promoted to complex.
+
+### `pub fn make_mut_storage(arc: & mut Arc < Storage >) -> & mut Storage`
+
+Helper to get a mutable reference to storage, cloning if needed (COW).
+
+### `pub fn mindim(dims: & [usize]) -> usize`
+
+Get the minimum dimension from a slice of dimensions. This is used for DiagTensor where all indices must have the same dimension.
+
+### `pub fn contract_storage(storage_a: & Storage, dims_a: & [usize], axes_a: & [usize], storage_b: & Storage, dims_b: & [usize], axes_b: & [usize], result_dims: & [usize]) -> Storage`
+
+Contract two storage tensors along specified axes. This is an internal helper function that contracts two `Storage` tensors. For Dense tensors, uses mdarray-linalg's contract method.
+
+### `pub fn extract_dense_view(storage: & 'a Storage) -> Result < & 'a [Self] , String >` (trait StorageScalar)
+
+Extract a borrowed view of dense storage data (no copy). Returns an error if the storage is not the matching dense type.
+
+### `pub fn extract_dense_cow(storage: & 'a Storage) -> Result < Cow < 'a , [Self] > , String >` (trait StorageScalar default)
+
+Extract dense storage data as `Cow` (borrowed if possible, owned if needed). For dense storage, returns `Cow::Borrowed` (no copy). For other storage types, may need to convert to dense first (copy).
+
+### `pub fn extract_dense(storage: & Storage) -> Result < Vec < Self > , String >` (trait StorageScalar default)
+
+Extract dense storage data as owned `Vec` (always copies). This is a convenience method that calls `extract_dense_cow` and converts to owned.
+
+### `pub fn dense_storage(data: Vec < Self >) -> Arc < Storage >` (trait StorageScalar)
+
+Create `Storage` from owned dense data.
+
+### `pub fn storage_to_dtensor(storage: & Storage, shape: [usize ; 2]) -> Result < DTensor < T , 2 > , String >`
+
+Convert dense storage to a DTensor with rank 2. This function extracts data from dense storage and reshapes it into a `DTensor<T, 2>` with the specified shape `[m, n]`. The data length must match `m * n`.
+
+### ` fn extract_dense_view(storage: & 'a Storage) -> Result < & 'a [Self] , String >` (impl f64)
+
+### ` fn dense_storage(data: Vec < Self >) -> Arc < Storage >` (impl f64)
+
+### ` fn extract_dense_view(storage: & 'a Storage) -> Result < & 'a [Self] , String >` (impl Complex64)
+
+### ` fn dense_storage(data: Vec < Self >) -> Arc < Storage >` (impl Complex64)
+
+### ` fn add(self, rhs: & Storage) -> Self :: Output` (impl & Storage)
+
+### ` fn mul(self, scalar: f64) -> Self :: Output` (impl & Storage)
+
+### ` fn mul(self, scalar: Complex64) -> Self :: Output` (impl & Storage)
+
+### ` fn mul(self, scalar: AnyScalar) -> Self :: Output` (impl & Storage)
+


### PR DESCRIPTION
## Summary
- Refactor storage access methods: `storage()`, `try_storage()`, `materialize_storage()`
- Add `TensorData` for lazy tensor representation (outer products, permutations)
- Extract contraction preparation logic to `index_ops.rs` (`ContractionSpec`, `prepare_contraction`)
- Add `diagonal()` and `scalar_one()` to `TensorLike` trait; `delta()` now uses `diagonal()` outer products
- Fix `add`/`axpby`/`scale` to work with lazy tensors; `scale()` now returns `Result<Self>`

## Test plan
- [x] All existing tests pass (`cargo test`)
- [x] New unit tests for `TensorData` (materialize, outer product, permute)
- [x] Contraction helper tests in `index_ops.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)