### PR TITLE
Replace handwritten GEMM with faer for tensor contraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ mdarray = "0.7.2"
 mdarray-linalg = { git = "https://github.com/grothesque/mdarray-linalg", rev = "febdb0756bbe" }
 mdarray-linalg-faer = { git = "https://github.com/grothesque/mdarray-linalg", rev = "febdb0756bbe", package = "mdarray-linalg-faer" }
 mdarray-linalg-lapack = { git = "https://github.com/grothesque/mdarray-linalg", rev = "febdb0756bbe", package = "mdarray-linalg-lapack" }
+faer = "0.23"
 faer-traits = "0.23"
 thiserror = "2.0"
 rand = "0.8"

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -21,6 +21,7 @@ mdarray.workspace = true
 mdarray-linalg.workspace = true
 mdarray-linalg-faer = { workspace = true, optional = true }
 mdarray-linalg-lapack = { workspace = true, optional = true }
+faer.workspace = true
 faer-traits.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true


### PR DESCRIPTION
## Summary
- Replace manual 3-loop GEMM with faer's optimized `matmul` routine in `contract_via_gemm`
- Add `faer` dependency to workspace and `tensor4all-tensorbackend`
- Update `DenseScalar` trait to include `ComplexField` and `One` bounds from faer/num_traits

Closes #112

## Details
The previous implementation used a naive O(n³) triple loop for matrix multiplication. This PR replaces it with faer's SIMD-optimized matrix multiplication by creating row-major strided `MatRef`/`MatMut` views directly over the input data without copying.

## Test plan
- [x] All existing tests pass (`cargo test -p tensor4all-tensorbackend`)
- [x] Dependent crate tests pass (`cargo test -p tensor4all-core`, `cargo test -p tensor4all-simplett`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)