### PR TITLE
Replace nested Vec with DTensor in binaryop and fourier modules

### DIFF
--- a/crates/tensor4all-quanticstransform/Cargo.toml
+++ b/crates/tensor4all-quanticstransform/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = { workspace = true }
 num-rational = "0.4"
 num-integer = "0.1"
 anyhow = { workspace = true }
+mdarray = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }


### PR DESCRIPTION
## Summary
- Replace 5-level nested Vec with `DTensor<Complex64, 5>` in `binaryop.rs::binaryop_tensor_single`
- Replace 4-level nested Vec with `DTensor<Complex64, 4>` in `fourier.rs::build_dft_core_tensor`
- Update all tensor indexing to use DTensor `[[...]]` syntax

## Test plan
- [x] All 82 lib tests pass
- [x] All 24 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)