### PR TITLE
Add unfused API for affine transformation and fix R=1 case

### DIFF
--- a/crates/tensor4all-quanticstransform/Cargo.toml
+++ b/crates/tensor4all-quanticstransform/Cargo.toml
@@ -25,6 +25,7 @@ num-rational = "0.4"
 num-integer = "0.1"
 anyhow = { workspace = true }
 mdarray = { workspace = true }
+sprs = "0.11"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -37,7 +37,10 @@ mod fourier;
 mod phase_rotation;
 mod shift;
 
-pub use affine::{affine_operator, AffineParams};
+pub use affine::{
+    affine_operator, affine_transform_matrix, affine_transform_tensors_unfused, AffineParams,
+    UnfusedTensorInfo,
+};
 pub use binaryop::{binaryop_operator, binaryop_single_operator, BinaryCoeffs};
 pub use common::{BoundaryCondition, CarryDirection};
 pub use cumsum::cumsum_operator;

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -1453,7 +1453,7 @@ fn test_affine_identity() {
         .expect("Failed to create affine params");
     let bc = vec![BoundaryCondition::Periodic];
 
-    let op = affine_operator(r, &params, &bc).expect("Failed to create affine operator");
+    let _op = affine_operator(r, &params, &bc).expect("Failed to create affine operator");
 
     for x in 0..n {
         // Create input state |x⟩


### PR DESCRIPTION
## Summary
- Add `affine_transform_tensors_unfused()` function returning raw tensors with fused site indices that can be reshaped to M+N separate indices
- Add `UnfusedTensorInfo` helper struct with decode/encode methods for converting between fused and unfused index representations
- Fix R=1 special case where is_lsb && is_msb are both true by adding combined handling with proper boundary condition application
- Remove unused variables and debug output

## Variable Ordering
The unfused API uses the same index encoding as Quantics.jl:
- `site_idx = y_bits | (x_bits << M)`
- Variable order: `(y[0], y[1], ..., y[M-1], x[0], x[1], ..., x[N-1])`

## Test plan
- [x] All 76 unit tests pass
- [x] All 24 integration tests pass
- [x] Workspace tests pass
- [x] New unfused API tests verify equivalence with fused representation

🤖 Generated with [Claude Code](https://claude.com/claude-code)