### PR TITLE
refactor: simplify TensorLike trait API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Rust implementation of tensor networks for **vibe coding** — rapid, AI-assis
 | `ITensor` | `QSpace` | `TensorDynLen<Id, Symm>` |
 | `Dense` | `DATA` | `Storage::DenseF64/C64` |
 | `Diag` | — | `Storage::DiagF64/C64` |
-| `A * B` | — | `a.contract_einsum(&b)` |
+| `A * B` | — | `a.contract(&b)` |
 
 ### Truncation Tolerance
 

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -129,7 +129,7 @@ where
     match options.canonical {
         Canonical::Left => {
             // L = U, R = S * V
-            let right_contracted = s.contract_einsum(&v);
+            let right_contracted = s.contract(&v);
             let right = right_contracted.replaceind(&sim_bond_index, &bond_index);
             Ok(FactorizeResult {
                 left: u,
@@ -141,7 +141,7 @@ where
         }
         Canonical::Right => {
             // L = U * S, R = V
-            let left_contracted = u.contract_einsum(&s);
+            let left_contracted = u.contract(&s);
             let left = left_contracted.replaceind(&sim_bond_index, &bond_index);
             Ok(FactorizeResult {
                 left,

--- a/crates/tensor4all-core/src/index_ops.rs
+++ b/crates/tensor4all-core/src/index_ops.rs
@@ -476,10 +476,11 @@ pub fn common_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
         .collect()
 }
 
-/// Find common indices between two slices and return their positions.
+/// Find contractable indices between two slices and return their positions.
 ///
 /// Returns a vector of `(pos_a, pos_b)` tuples where each tuple indicates
-/// that `indices_a[pos_a]` and `indices_b[pos_b]` have the same ID.
+/// that `indices_a[pos_a]` and `indices_b[pos_b]` are contractable
+/// (same ID, same dimension, and compatible ConjState).
 ///
 /// # Example
 /// ```
@@ -500,7 +501,7 @@ pub fn common_ind_positions<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> V
     let mut positions = Vec::new();
     for (pos_a, idx_a) in indices_a.iter().enumerate() {
         for (pos_b, idx_b) in indices_b.iter().enumerate() {
-            if idx_a.id() == idx_b.id() {
+            if idx_a.is_contractable(idx_b) {
                 positions.push((pos_a, pos_b));
                 break; // Each index in a can match at most one in b
             }

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -44,7 +44,7 @@ fn test_factorize_reconstruction(options: &FactorizeOptions) {
     let result = factorize(&tensor, &left_inds, options).unwrap();
 
     // Verify reconstruction: left * right ≈ original
-    let reconstructed = result.left.contract_einsum(&result.right);
+    let reconstructed = result.left.contract(&result.right);
     assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
 }
 
@@ -143,7 +143,7 @@ fn test_factorize_svd_rank3() {
     let options = FactorizeOptions::svd();
     let result = factorize(&tensor, &left_inds, &options).unwrap();
 
-    let reconstructed = result.left.contract_einsum(&result.right);
+    let reconstructed = result.left.contract(&result.right);
     assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
 }
 
@@ -247,10 +247,10 @@ fn test_diag_dense_contraction_svd_internals() {
     assert!(common_found, "S and V should share a common index");
 
     // Contractions should work
-    let sv = s.contract_einsum(&v);
+    let sv = s.contract(&v);
     assert_eq!(sv.dims.len(), 2, "S*V should be a 2D tensor");
 
-    let us = u.contract_einsum(&s);
+    let us = u.contract(&s);
     assert_eq!(us.dims.len(), 2, "U*S should be a 2D tensor");
 }
 

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -40,7 +40,7 @@ fn test_contract_dyn_len_matrix_multiplication() {
     let tensor_b: TensorDynLen = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j: result should be C[i, k] with all 3.0 (since each element is sum of 3 ones)
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
     assert_eq!(result.dims, vec![2, 4]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -137,7 +137,7 @@ fn test_contract_no_common_indices() {
     let tensor_b: TensorDynLen = TensorDynLen::new(indices_b, dims_b, storage_b);
 
     // This should panic because there are no common indices
-    let _result = tensor_a.contract_einsum(&tensor_b);
+    let _result = tensor_a.contract(&tensor_b);
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn test_contract_three_indices() {
     let tensor_b: TensorDynLen = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j and k: result should be C[i, l] with all 12.0 (3 * 4 = 12)
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
     assert_eq!(result.dims, vec![2, 5]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -207,7 +207,7 @@ fn test_contract_mixed_f64_c64() {
     // Contract along j: result should be C[i, k] (Complex64)
     // Expected result: [[1+2i + 5+6i, 3+4i + 7+8i], [1+2i + 5+6i, 3+4i + 7+8i]]
     //                  = [[6+8i, 10+12i], [6+8i, 10+12i]]
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
     assert_eq!(result.dims, vec![2, 2]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -261,7 +261,7 @@ fn test_contract_mixed_c64_f64() {
     // C[0,1] = (1+2i)*1 + (3+4i)*1 = 4+6i
     // C[1,0] = (5+6i)*1 + (7+8i)*1 = 12+14i
     // C[1,1] = (5+6i)*1 + (7+8i)*1 = 12+14i
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
     assert_eq!(result.dims, vec![2, 2]);
 
     // Check result storage type

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -70,7 +70,7 @@ fn test_diag_tensor_contract_diag_diag_all_contracted() {
     let tensor_b = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_b);
 
     // Contract all indices: result should be scalar (inner product)
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
 
     // Result should be scalar: 1*3 + 2*4 = 11
     assert_eq!(result.dims.len(), 0);
@@ -95,7 +95,7 @@ fn test_diag_tensor_contract_diag_diag_partial() {
     let tensor_b = diag_tensor_dyn_len(vec![j.clone(), k.clone()], diag_b);
 
     // Contract along j: result should be DiagTensor[i, k]
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
 
     assert_eq!(result.dims, vec![3, 3]);
     assert!(is_diag_tensor(&result));
@@ -126,7 +126,7 @@ fn test_diag_tensor_contract_diag_dense() {
     let tensor_b: TensorDynLen = TensorDynLen::new(indices_b, dims_b, Arc::new(storage_b));
 
     // Contract along j: result should be DenseTensor[i, k]
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
 
     assert_eq!(result.dims, vec![2, 2]);
     // Result should be DenseTensor (Diag×Dense converts Diag to Dense first)
@@ -228,7 +228,7 @@ fn test_diag_tensor_contract_rank3() {
     let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], diag_b);
 
     // Contract along k: result should be DiagTensor[i, j, l]
-    let result = tensor_a.contract_einsum(&tensor_b);
+    let result = tensor_a.contract(&tensor_b);
 
     assert_eq!(result.dims, vec![2, 2, 2]);
     assert!(is_diag_tensor(&result));

--- a/crates/tensor4all-core/tests/tensor_tensor_like.rs
+++ b/crates/tensor4all-core/tests/tensor_tensor_like.rs
@@ -36,7 +36,7 @@ fn test_tensor_like_num_external_indices() {
 }
 
 #[test]
-fn test_tensor_like_tensordot_basic() {
+fn test_tensor_like_contract_basic() {
     // Create two tensors: A(i,j) and B(j,k)
     // Contract over j to get C(i,k)
     let i = Index::<DynId>::new_dyn(2);
@@ -52,12 +52,9 @@ fn test_tensor_like_tensordot_basic() {
     let b_data: Vec<f64> = (0..12).map(|x| x as f64).collect();
     let b = TensorDynLen::from_indices(vec![j_copy.clone(), k.clone()], f64::dense_storage(b_data));
 
-    // Create pairs with DynIndex
-    let pairs: Vec<(DynIndex, DynIndex)> = vec![(j.clone(), j_copy.clone())];
-
-    // Use TensorLike::tensordot
-    let c = <TensorDynLen as TensorLike>::tensordot(&a, &b, &pairs)
-        .expect("tensordot should succeed");
+    // Use TensorLike::contract - auto-detects contractable pairs via is_contractable
+    let c = <TensorDynLen as TensorLike>::contract(&[a, b])
+        .expect("contract should succeed");
 
     // Result should be 2x4
     assert_eq!(c.dims, vec![2, 4]);

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -575,7 +575,7 @@ impl TensorTrain {
         let mut env = {
             let a0_conj = self.tensor(0).conj();
             let b0 = other_sim.tensor(0);
-            a0_conj.contract_einsum(b0)
+            a0_conj.contract(b0)
         };
 
         // Sweep through remaining sites
@@ -584,9 +584,9 @@ impl TensorTrain {
             let bi = other_sim.tensor(i);
 
             // Contract: env * conj(A_i) (over self's link index)
-            env = env.contract_einsum(&ai_conj);
+            env = env.contract(&ai_conj);
             // Contract: result * B_i (over other's link index and site indices)
-            env = env.contract_einsum(bi);
+            env = env.contract(bi);
         }
 
         // Result should be a scalar (0-dimensional tensor)

--- a/crates/tensor4all-treetn/src/dyn_treetn.rs
+++ b/crates/tensor4all-treetn/src/dyn_treetn.rs
@@ -376,7 +376,7 @@ where
         // Contract all tensors together using common indices
         let mut result = tensors.remove(0);
         for tensor in tensors {
-            result = result.contract_einsum(&tensor);
+            result = result.contract(&tensor);
         }
 
         Ok(result)

--- a/crates/tensor4all-treetn/src/treetn/linsolve/updater.rs
+++ b/crates/tensor4all-treetn/src/treetn/linsolve/updater.rs
@@ -356,8 +356,8 @@ where
             })
             .collect::<Result<_>>()?;
 
-        // Use TensorLike::contract_einsum for contraction
-        T::contract_einsum(&tensors)
+        // Use TensorLike::contract for contraction
+        T::contract(&tensors)
     }
 
     /// Build TreeTopology for the subtree region from the solved tensor.

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -441,8 +441,7 @@ where
         // Contract A and B
         let tensor_a = subtree.tensor(idx_a).unwrap();
         let tensor_b = subtree.tensor(idx_b).unwrap();
-        let tensor_ab = tensor_a
-            .tensordot(tensor_b, &[(bond_ab.clone(), bond_ab.clone())])
+        let tensor_ab = T::contract(&[tensor_a.clone(), tensor_b.clone()])
             .context("Failed to contract A and B")?;
 
         // Determine left indices (indices that will remain on A after factorization)

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -547,17 +547,13 @@ where
         let left_tensor = factorize_result.left;
         let right_tensor = factorize_result.right;
 
-        // Get edge index on dst side (same as src side in Einsum mode)
-        let bond_on_dst = bond_on_src.clone();
-
         // Absorb right_tensor into dst
         let tensor_dst = self
             .tensor(dst)
             .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
             .with_context(|| format!("{}: dst tensor not found", context_name))?;
 
-        let updated_dst_tensor = tensor_dst
-            .tensordot(&right_tensor, &[(bond_on_dst.clone(), bond_on_src.clone())])
+        let updated_dst_tensor = T::contract(&[tensor_dst.clone(), right_tensor])
             .with_context(|| {
                 format!(
                     "{}: failed to absorb right factor into dst tensor",

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -230,22 +230,9 @@ where
                 .remove(&to)
                 .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", to))?;
 
-            // Find the bond index for this edge
-            let edge = self
-                .graph
-                .graph()
-                .find_edge(from, to)
-                .or_else(|| self.graph.graph().find_edge(to, from))
-                .ok_or_else(|| anyhow::anyhow!("Edge not found between {:?} and {:?}", from, to))?;
-
-            let bond_idx = self
-                .bond_index(edge)
-                .ok_or_else(|| anyhow::anyhow!("Bond index not found for edge"))?
-                .clone();
-
-            // Contract using TensorLike::tensordot
-            let contracted = to_tensor
-                .tensordot(&from_tensor, &[(bond_idx.clone(), bond_idx)])
+            // Contract using TensorLike::contract
+            // (bond indices are auto-detected via is_contractable)
+            let contracted = T::contract(&[to_tensor, from_tensor])
                 .map_err(|e| anyhow::anyhow!("Failed to contract tensors: {}", e))?;
 
             tensors.insert(to, contracted);

--- a/docs/api/tensor4all_core.md
+++ b/docs/api/tensor4all_core.md
@@ -1038,7 +1038,7 @@ Permute the tensor dimensions using the given new indices order. This is the mai
 
 Permute the tensor dimensions, returning a new tensor. This method reorders the indices, dimensions, and data according to the given permutation. The permutation specifies which old axis each new
 
-### `pub fn contract_einsum(&self, other: & Self) -> Self` (impl TensorDynLen < Id , Symm >)
+### `pub fn contract(&self, other: & Self) -> Self` (impl TensorDynLen < Id , Symm >)
 
 Contract this tensor with another tensor along common indices. This method finds common indices between `self` and `other`, then contracts along those indices. The result tensor contains all non-contracted indices
 


### PR DESCRIPTION
## Summary
- Remove `tensordot` from `TensorLike` trait (keep on concrete types like `TensorDynLen`)
- Rename `contract_einsum` to `contract` in `TensorLike` trait
- Update `common_ind_positions` to use `is_contractable()` instead of id comparison
- Update all usages across treetn and core crates
- Update slides and documentation

This simplifies the generic TensorLike API to use automatic index matching via `is_contractable()`, similar to ITensor's `*` operator. The explicit `tensordot` method remains available on concrete types for advanced use cases.

Closes #123

## Test plan
- [x] All existing tests pass
- [x] cargo check passes without errors
- [x] Documentation and slides updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)