### PR TITLE
feat(tensor4all-core): add AllowedPairs option to tensor contraction

### DIFF
--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -22,6 +22,7 @@ dyn-clone.workspace = true
 rand.workspace = true
 rand_distr.workspace = true
 omeco.workspace = true
+petgraph.workspace = true
 
 [dev-dependencies]
 rand_chacha.workspace = true

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -4,47 +4,285 @@
 //! by using omeco's GreedyMethod to find the optimal contraction order.
 //!
 //! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
+//!
+//! # Main Functions
+//!
+//! - [`contract_multi`]: Contracts tensors, handling disconnected components via outer product
+//! - [`contract_connected`]: Contracts tensors that must form a connected graph
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use anyhow::Result;
 use omeco::{optimize_code, EinCode, GreedyMethod, NestedEinsum};
+use petgraph::prelude::*;
+use petgraph::algo::connected_components;
 
 use crate::index_like::IndexLike;
-use crate::defaults::TensorDynLen;
+use crate::defaults::{DynId, DynIndex, Index, TensorDynLen};
+use crate::tensor_like::AllowedPairs;
 
-/// Contract multiple tensors into a single tensor.
+/// Contract multiple tensors into a single tensor, handling disconnected components.
 ///
-/// Uses omeco's GreedyMethod to find the optimal contraction order for N>=3 tensors.
+/// This function automatically handles disconnected tensor graphs by:
+/// 1. Finding connected components based on contractable indices
+/// 2. Contracting each connected component separately
+/// 3. Combining results using outer product
 ///
 /// # Arguments
 /// * `tensors` - Slice of tensors to contract
+/// * `allowed` - Specifies which tensor pairs can have their indices contracted
 ///
 /// # Returns
-/// The result of contracting all tensors over common indices
-/// (indices appearing in exactly two tensors are contracted).
+/// The result of contracting all tensors over allowed contractable indices.
+/// If tensors form disconnected components, they are combined via outer product.
 ///
 /// # Behavior by N
 /// - N=0: Error
 /// - N=1: Clone of input
-/// - N=2: Direct tensordot
-/// - N>=3: Optimal order via omeco's GreedyMethod
+/// - N>=2: Contract connected components, combine with outer product
+///
+/// # Errors
+/// - `AllowedPairs::Specified` contains a pair with no contractable indices
 ///
 /// # Example
 /// ```ignore
-/// use tensor4all_core::contract_multi;
+/// use tensor4all_core::{contract_multi, AllowedPairs};
 ///
-/// let tensors = vec![tensor_a, tensor_b, tensor_c];
-/// let result = contract_multi(&tensors)?;
+/// // Connected tensors: contracts via omeco
+/// let result = contract_multi(&[a, b, c], AllowedPairs::All)?;
+///
+/// // Disconnected tensors: contracts each component, outer product to combine
+/// let result = contract_multi(&[a, b], AllowedPairs::All)?;  // a, b have no common indices
 /// ```
-pub fn contract_multi(tensors: &[TensorDynLen]) -> Result<TensorDynLen> {
+pub fn contract_multi(tensors: &[TensorDynLen], allowed: AllowedPairs<'_>) -> Result<TensorDynLen> {
     match tensors.len() {
         0 => Err(anyhow::anyhow!("No tensors to contract")),
         1 => Ok(tensors[0].clone()),
-        2 => contract_pair(&tensors[0], &tensors[1]),
-        _ => contract_multi_optimized(tensors),
+        _ => {
+            // Validate AllowedPairs::Specified pairs have contractable indices
+            if let AllowedPairs::Specified(pairs) = allowed {
+                for &(i, j) in pairs {
+                    if !has_contractable_indices(&tensors[i], &tensors[j]) {
+                        return Err(anyhow::anyhow!(
+                            "Specified pair ({}, {}) has no contractable indices",
+                            i, j
+                        ));
+                    }
+                }
+            }
+
+            // Find connected components
+            let components = find_tensor_connected_components(tensors, allowed);
+
+            if components.len() == 1 {
+                // All tensors connected - use optimized contraction
+                contract_connected(tensors, allowed)
+            } else {
+                // Multiple components - contract each and combine with outer product
+                let mut results: Vec<TensorDynLen> = Vec::new();
+                for component in &components {
+                    let component_tensors: Vec<TensorDynLen> =
+                        component.iter().map(|&i| tensors[i].clone()).collect();
+
+                    // Remap AllowedPairs for the component
+                    let remapped_allowed = remap_allowed_pairs(allowed, component);
+                    let contracted = contract_connected(&component_tensors, remapped_allowed.as_ref())?;
+                    results.push(contracted);
+                }
+
+                // Combine with outer product
+                let mut result = results.pop().unwrap();
+                for other in results.into_iter().rev() {
+                    result = result.outer_product(&other)?;
+                }
+                Ok(result)
+            }
+        }
     }
 }
+
+/// Contract multiple tensors that form a connected graph.
+///
+/// Uses omeco's GreedyMethod to find the optimal contraction order.
+///
+/// # Arguments
+/// * `tensors` - Slice of tensors to contract (must form a connected graph)
+/// * `allowed` - Specifies which tensor pairs can have their indices contracted
+///
+/// # Returns
+/// The result of contracting all tensors over allowed contractable indices.
+///
+/// # Connectivity Requirement
+/// All tensors must form a connected graph through contractable indices.
+/// Two tensors are connected if they share a contractable index (same ID, dual direction).
+/// If the tensors form disconnected components, this function returns an error.
+///
+/// Use [`contract_multi`] if you want automatic handling of disconnected components.
+///
+/// # Behavior by N
+/// - N=0: Error
+/// - N=1: Clone of input
+/// - N>=2: Optimal order via omeco's GreedyMethod
+///
+/// # Example
+/// ```ignore
+/// use tensor4all_core::{contract_connected, AllowedPairs};
+///
+/// let tensors = vec![tensor_a, tensor_b, tensor_c];  // Must be connected
+/// let result = contract_connected(&tensors, AllowedPairs::All)?;
+/// ```
+pub fn contract_connected(tensors: &[TensorDynLen], allowed: AllowedPairs<'_>) -> Result<TensorDynLen> {
+    match tensors.len() {
+        0 => Err(anyhow::anyhow!("No tensors to contract")),
+        1 => Ok(tensors[0].clone()),
+        _ => contract_connected_optimized(tensors, allowed),
+    }
+}
+
+// ============================================================================
+// Helper functions for connected component detection
+// ============================================================================
+
+/// Check if two tensors have any contractable indices.
+fn has_contractable_indices(a: &TensorDynLen, b: &TensorDynLen) -> bool {
+    a.indices
+        .iter()
+        .any(|idx_a| b.indices.iter().any(|idx_b| idx_a.is_contractable(idx_b)))
+}
+
+/// Find connected components of tensors based on contractable indices.
+///
+/// Uses petgraph for O(V+E) connected component detection.
+///
+/// # Arguments
+/// * `tensors` - Slice of tensors
+/// * `allowed` - Which tensor pairs can have their indices contracted
+///
+/// # Returns
+/// A vector of components, where each component is a vector of tensor indices.
+/// Components are sorted by their smallest tensor index for determinism.
+fn find_tensor_connected_components(
+    tensors: &[TensorDynLen],
+    allowed: AllowedPairs<'_>,
+) -> Vec<Vec<usize>> {
+    let n = tensors.len();
+    if n == 0 {
+        return vec![];
+    }
+    if n == 1 {
+        return vec![vec![0]];
+    }
+
+    // Build undirected graph
+    let mut graph = UnGraph::<(), ()>::new_undirected();
+    let nodes: Vec<_> = (0..n).map(|_| graph.add_node(())).collect();
+
+    // Add edges based on connectivity
+    match allowed {
+        AllowedPairs::All => {
+            // Two tensors connected if they have any contractable indices
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    if has_contractable_indices(&tensors[i], &tensors[j]) {
+                        graph.add_edge(nodes[i], nodes[j], ());
+                    }
+                }
+            }
+        }
+        AllowedPairs::Specified(pairs) => {
+            // Only specified pairs with contractable indices are connected
+            for &(i, j) in pairs {
+                if has_contractable_indices(&tensors[i], &tensors[j]) {
+                    graph.add_edge(nodes[i], nodes[j], ());
+                }
+            }
+        }
+    }
+
+    // Find connected components using petgraph
+    let num_components = connected_components(&graph);
+
+    if num_components == 1 {
+        // All connected - return single component with all indices
+        return vec![(0..n).collect()];
+    }
+
+    // Multiple components - group by component ID
+    // petgraph's connected_components returns the number, we need to compute assignments
+    use petgraph::visit::Dfs;
+    let mut visited = vec![false; n];
+    let mut components = Vec::new();
+
+    for start in 0..n {
+        if !visited[start] {
+            let mut component = Vec::new();
+            let mut dfs = Dfs::new(&graph, nodes[start]);
+            while let Some(node) = dfs.next(&graph) {
+                let idx = node.index();
+                if !visited[idx] {
+                    visited[idx] = true;
+                    component.push(idx);
+                }
+            }
+            component.sort(); // Deterministic order within component
+            components.push(component);
+        }
+    }
+
+    // Sort components by smallest index for determinism
+    components.sort_by_key(|c| c[0]);
+    components
+}
+
+/// Remap AllowedPairs for a subset of tensors.
+///
+/// Given original tensor indices in `component`, returns AllowedPairs
+/// with indices remapped to the component's local indices.
+fn remap_allowed_pairs(allowed: AllowedPairs<'_>, component: &[usize]) -> RemappedAllowedPairs {
+    match allowed {
+        AllowedPairs::All => RemappedAllowedPairs::All,
+        AllowedPairs::Specified(pairs) => {
+            // Build map from original index to local index
+            let orig_to_local: HashMap<usize, usize> = component
+                .iter()
+                .enumerate()
+                .map(|(local, &orig)| (orig, local))
+                .collect();
+
+            // Filter and remap pairs
+            let remapped: Vec<(usize, usize)> = pairs
+                .iter()
+                .filter_map(|&(i, j)| {
+                    match (orig_to_local.get(&i), orig_to_local.get(&j)) {
+                        (Some(&li), Some(&lj)) => Some((li, lj)),
+                        _ => None, // Pair not in this component
+                    }
+                })
+                .collect();
+
+            RemappedAllowedPairs::Specified(remapped)
+        }
+    }
+}
+
+/// Owned version of AllowedPairs for remapped components.
+enum RemappedAllowedPairs {
+    All,
+    Specified(Vec<(usize, usize)>),
+}
+
+impl RemappedAllowedPairs {
+    fn as_ref(&self) -> AllowedPairs<'_> {
+        match self {
+            RemappedAllowedPairs::All => AllowedPairs::All,
+            RemappedAllowedPairs::Specified(pairs) => AllowedPairs::Specified(pairs),
+        }
+    }
+}
+
+// ============================================================================
+// Core contraction implementation
+// ============================================================================
 
 /// Contract two tensors over their common indices.
 /// If there are no common indices, performs outer product.
@@ -69,34 +307,34 @@ fn contract_pair(a: &TensorDynLen, b: &TensorDynLen) -> Result<TensorDynLen> {
 }
 
 /// Contract multiple tensors using omeco's GreedyMethod for optimal ordering.
-fn contract_multi_optimized(tensors: &[TensorDynLen]) -> Result<TensorDynLen> {
-    use crate::defaults::DynId;
-
-    // Build mapping from DynId -> usize for omeco
-    let mut id_to_idx: HashMap<DynId, usize> = HashMap::new();
-    let mut next_idx = 0usize;
-
-    for tensor in tensors {
-        for idx in &tensor.indices {
-            id_to_idx
-                .entry(idx.id().clone())
-                .or_insert_with(|| {
-                    let i = next_idx;
-                    next_idx += 1;
-                    i
-                });
+///
+/// Uses internal IDs to control which indices are contracted based on `allowed`.
+fn contract_connected_optimized(
+    tensors: &[TensorDynLen],
+    allowed: AllowedPairs<'_>,
+) -> Result<TensorDynLen> {
+    // 1. Validate for Specified pairs
+    if let AllowedPairs::Specified(pairs) = allowed {
+        // 1a. Check that all specified pairs have contractable indices
+        for &(i, j) in pairs {
+            if !has_contractable_indices(&tensors[i], &tensors[j]) {
+                return Err(anyhow::anyhow!(
+                    "Specified pair ({}, {}) has no contractable indices",
+                    i,
+                    j
+                ));
+            }
         }
+        // 1b. Check that the graph formed by pairs is connected
+        validate_connected_graph(tensors.len(), pairs)?;
     }
 
-    // Build EinCode with usize labels
-    let ixs: Vec<Vec<usize>> = tensors
-        .iter()
-        .map(|t| t.indices.iter().map(|idx| id_to_idx[idx.id()]).collect())
-        .collect();
+    // 2. Build internal IDs
+    //    - Allowed pairs' contractable indices get shared internal IDs
+    //    - All other indices get unique internal IDs
+    let (ixs, internal_id_to_original) = build_internal_ids(tensors, allowed);
 
-    // Determine output indices (appear exactly once across all tensors)
-    // Keep them sorted by their first occurrence in the input tensors
-    // (which is their assigned usize value in id_to_idx)
+    // 3. Output = count == 1 internal IDs (external indices)
     let mut idx_count: HashMap<usize, usize> = HashMap::new();
     for ix in &ixs {
         for &i in ix {
@@ -108,25 +346,236 @@ fn contract_multi_optimized(tensors: &[TensorDynLen]) -> Result<TensorDynLen> {
         .filter(|(_, &count)| count == 1)
         .map(|(&idx, _)| idx)
         .collect();
-    // Sort to maintain deterministic ordering based on first occurrence
-    output.sort();
+    output.sort(); // deterministic order
 
-    // Build size dictionary
+    // 4. Build sizes from tensors
     let mut sizes: HashMap<usize, usize> = HashMap::new();
-    for tensor in tensors {
-        for (idx, &dim) in tensor.indices.iter().zip(tensor.dims.iter()) {
-            let i = id_to_idx[idx.id()];
-            sizes.entry(i).or_insert(dim);
+    for (tensor_idx, tensor) in tensors.iter().enumerate() {
+        for (pos, &dim) in tensor.dims.iter().enumerate() {
+            let internal_id = ixs[tensor_idx][pos];
+            sizes.entry(internal_id).or_insert(dim);
         }
     }
 
-    // Optimize contraction order using GreedyMethod
-    let code = EinCode::new(ixs, output);
+    // 5. Optimize contraction order using GreedyMethod
+    let code = EinCode::new(ixs.clone(), output.clone());
     let tree = optimize_code(&code, &sizes, &GreedyMethod::default())
         .ok_or_else(|| anyhow::anyhow!("Failed to optimize contraction order"))?;
 
-    // Execute the contraction tree
-    execute_contraction_tree(tensors, &tree)
+    // 5a. Check if omeco returned an incomplete tree (doesn't include all tensors)
+    // This happens when tensors form disconnected components in the contraction graph.
+    if tree.leaf_count() != tensors.len() {
+        return Err(anyhow::anyhow!(
+            "Contraction graph is disconnected: only {} of {} tensors are connected. \
+             All tensors must form a connected graph through contractable indices.",
+            tree.leaf_count(),
+            tensors.len()
+        ));
+    }
+
+    // 6. Create temporary tensors with internal ID-based indices
+    //    This ensures contract_pair uses internal IDs for contraction determination
+    let temp_tensors: Vec<TensorDynLen> = tensors
+        .iter()
+        .enumerate()
+        .map(|(tensor_idx, tensor)| {
+            let temp_indices: Vec<DynIndex> = ixs[tensor_idx]
+                .iter()
+                .zip(tensor.dims.iter())
+                .map(|(&internal_id, &dim)| {
+                    // Create index with internal_id as the DynId
+                    Index::new(DynId(internal_id as u128), dim)
+                })
+                .collect();
+            TensorDynLen::new(temp_indices, tensor.dims.clone(), tensor.storage().clone())
+        })
+        .collect();
+
+    // 7. Execute the contraction tree using temporary tensors
+    let result = execute_contraction_tree(&temp_tensors, &tree)?;
+
+    // 8. Restore original indices from internal IDs
+    //    Use result's actual index order (not sorted output) to match storage layout
+    let restored_indices: Vec<DynIndex> = result
+        .indices
+        .iter()
+        .map(|temp_idx| {
+            // temp_idx has DynId(internal_id as u128)
+            let internal_id = temp_idx.id().0 as usize;
+            let (tensor_idx, pos) = internal_id_to_original[&internal_id];
+            tensors[tensor_idx].indices[pos].clone()
+        })
+        .collect();
+
+    Ok(TensorDynLen::new(
+        restored_indices,
+        result.dims.clone(),
+        result.storage().clone(),
+    ))
+}
+
+/// Build internal IDs for contraction.
+///
+/// Internal IDs are integers that represent indices during contraction:
+/// - Contractable pairs in allowed tensor pairs share the same internal ID
+/// - All other indices get unique internal IDs
+///
+/// These internal IDs are used for:
+/// 1. Determining which indices to contract (count >= 2)
+/// 2. Optimizing contraction order (omeco uses these)
+/// 3. Mapping back to original indices after contraction
+///
+/// Returns: (ixs, internal_id_to_original)
+/// - ixs: Vec<Vec<usize>> - internal IDs for each tensor's indices
+/// - internal_id_to_original: Maps internal_id -> (tensor_idx, index_position)
+fn build_internal_ids(
+    tensors: &[TensorDynLen],
+    allowed: AllowedPairs<'_>,
+) -> (Vec<Vec<usize>>, HashMap<usize, (usize, usize)>) {
+    let mut next_id = 0usize;
+    // (tensor_idx, index_position) -> internal_id
+    let mut assigned: HashMap<(usize, usize), usize> = HashMap::new();
+    // internal_id -> (tensor_idx, index_position) for restoring
+    let mut internal_id_to_original: HashMap<usize, (usize, usize)> = HashMap::new();
+
+    // Helper: assign shared internal ID for contractable indices between tensor pair
+    // Handles hyperedges (same index appearing in 3+ tensors) by propagating IDs
+    let mut assign_contractable = |ti: usize, tj: usize| {
+        for (pi, idx_i) in tensors[ti].indices.iter().enumerate() {
+            for (pj, idx_j) in tensors[tj].indices.iter().enumerate() {
+                if idx_i.is_contractable(idx_j) {
+                    let key_i = (ti, pi);
+                    let key_j = (tj, pj);
+                    match (assigned.get(&key_i).copied(), assigned.get(&key_j).copied()) {
+                        (None, None) => {
+                            // Neither assigned: create new shared ID
+                            assigned.insert(key_i, next_id);
+                            assigned.insert(key_j, next_id);
+                            internal_id_to_original.insert(next_id, key_i);
+                            next_id += 1;
+                        }
+                        (Some(id), None) => {
+                            // key_i assigned, key_j not: share key_i's ID
+                            assigned.insert(key_j, id);
+                        }
+                        (None, Some(id)) => {
+                            // key_j assigned, key_i not: share key_j's ID
+                            assigned.insert(key_i, id);
+                        }
+                        (Some(id_i), Some(id_j)) => {
+                            // Both assigned - they should have the same ID
+                            // (same original index ID means all occurrences should share internal ID)
+                            debug_assert_eq!(
+                                id_i, id_j,
+                                "Conflicting internal IDs for contractable indices"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    match allowed {
+        AllowedPairs::All => {
+            // All tensor pairs are allowed to contract
+            for ti in 0..tensors.len() {
+                for tj in (ti + 1)..tensors.len() {
+                    assign_contractable(ti, tj);
+                }
+            }
+        }
+        AllowedPairs::Specified(pairs) => {
+            // Only specified pairs are allowed to contract
+            for &(ti, tj) in pairs {
+                assign_contractable(ti, tj);
+            }
+        }
+    }
+
+    // Assign unique IDs for all unassigned indices (external indices)
+    for (tensor_idx, tensor) in tensors.iter().enumerate() {
+        for pos in 0..tensor.indices.len() {
+            let key = (tensor_idx, pos);
+            if let std::collections::hash_map::Entry::Vacant(e) = assigned.entry(key) {
+                e.insert(next_id);
+                internal_id_to_original.insert(next_id, key);
+                next_id += 1;
+            }
+        }
+    }
+
+    // Build ixs: internal IDs for each tensor
+    let ixs: Vec<Vec<usize>> = tensors
+        .iter()
+        .enumerate()
+        .map(|(tensor_idx, tensor)| {
+            (0..tensor.indices.len())
+                .map(|pos| assigned[&(tensor_idx, pos)])
+                .collect()
+        })
+        .collect();
+
+    (ixs, internal_id_to_original)
+}
+
+/// Validate that the specified tensor pairs form a connected graph.
+///
+/// Returns an error if the graph is disconnected.
+fn validate_connected_graph(num_tensors: usize, pairs: &[(usize, usize)]) -> Result<()> {
+    if num_tensors == 0 {
+        return Ok(());
+    }
+    if num_tensors == 1 {
+        return Ok(());
+    }
+    if pairs.is_empty() {
+        return Err(anyhow::anyhow!(
+            "AllowedPairs::Specified with empty pairs results in disconnected graph"
+        ));
+    }
+
+    // Build adjacency list
+    let mut adj: Vec<HashSet<usize>> = vec![HashSet::new(); num_tensors];
+    for &(a, b) in pairs {
+        if a >= num_tensors || b >= num_tensors {
+            return Err(anyhow::anyhow!(
+                "Invalid tensor index in AllowedPairs: ({}, {}) but only {} tensors",
+                a,
+                b,
+                num_tensors
+            ));
+        }
+        adj[a].insert(b);
+        adj[b].insert(a);
+    }
+
+    // BFS to check connectivity
+    let mut visited = vec![false; num_tensors];
+    let mut queue = VecDeque::new();
+    queue.push_back(0);
+    visited[0] = true;
+    let mut count = 1;
+
+    while let Some(node) = queue.pop_front() {
+        for &neighbor in &adj[node] {
+            if !visited[neighbor] {
+                visited[neighbor] = true;
+                count += 1;
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    if count != num_tensors {
+        return Err(anyhow::anyhow!(
+            "AllowedPairs::Specified forms a disconnected graph: only {} of {} tensors are connected",
+            count,
+            num_tensors
+        ));
+    }
+
+    Ok(())
 }
 
 /// Execute a contraction tree by recursively contracting tensors.
@@ -179,7 +628,7 @@ mod tests {
     #[test]
     fn test_contract_multi_empty() {
         let tensors: Vec<TensorDynLen> = vec![];
-        let result = contract_multi(&tensors);
+        let result = contract_multi(&tensors, AllowedPairs::All);
         assert!(result.is_err());
     }
 
@@ -187,7 +636,7 @@ mod tests {
     fn test_contract_multi_single() {
         let tensor = make_test_tensor(&[2, 3], &[1, 2]);
         let tensors = vec![tensor.clone()];
-        let result = contract_multi(&tensors).unwrap();
+        let result = contract_multi(&tensors, AllowedPairs::All).unwrap();
         assert_eq!(result.dims, tensor.dims);
     }
 
@@ -197,7 +646,7 @@ mod tests {
         let a = make_test_tensor(&[2, 3], &[1, 2]); // i=1, j=2
         let b = make_test_tensor(&[3, 4], &[2, 3]); // j=2, k=3
         let tensors = vec![a, b];
-        let result = contract_multi(&tensors).unwrap();
+        let result = contract_multi(&tensors, AllowedPairs::All).unwrap();
         assert_eq!(result.dims, vec![2, 4]); // i, k
     }
 
@@ -208,7 +657,7 @@ mod tests {
         let b = make_test_tensor(&[3, 4], &[2, 3]); // j=2, k=3
         let c = make_test_tensor(&[4, 5], &[3, 4]); // k=3, l=4
         let tensors = vec![a, b, c];
-        let result = contract_multi(&tensors).unwrap();
+        let result = contract_multi(&tensors, AllowedPairs::All).unwrap();
         // Output has dimensions for i and l (order may vary due to tree structure)
         let mut sorted_dims = result.dims.clone();
         sorted_dims.sort();
@@ -223,7 +672,7 @@ mod tests {
         let c = make_test_tensor(&[4, 5], &[3, 4]);
         let d = make_test_tensor(&[5, 6], &[4, 5]);
         let tensors = vec![a, b, c, d];
-        let result = contract_multi(&tensors).unwrap();
+        let result = contract_multi(&tensors, AllowedPairs::All).unwrap();
         // Output has dimensions for i and m (order may vary due to tree structure)
         let mut sorted_dims = result.dims.clone();
         sorted_dims.sort();
@@ -231,16 +680,126 @@ mod tests {
     }
 
     #[test]
-    fn test_contract_multi_no_contraction() {
-        // A[i,j] * B[k,l] -> C[i,j,k,l] (no common indices)
+    fn test_contract_multi_outer_product() {
+        // A[i,j] * B[k,l] (no common indices) -> outer product C[i,j,k,l]
         let a = make_test_tensor(&[2, 3], &[1, 2]);
         let b = make_test_tensor(&[4, 5], &[3, 4]);
         let tensors = vec![a, b];
-        let result = contract_multi(&tensors).unwrap();
+        let result = contract_multi(&tensors, AllowedPairs::All).unwrap();
         // Total elements should be 2*3*4*5 = 120
         let total_elements: usize = result.dims.iter().product();
         assert_eq!(total_elements, 2 * 3 * 4 * 5);
         assert_eq!(result.dims.len(), 4);
+    }
+
+    #[test]
+    fn test_contract_multi_vector_outer_product() {
+        // A[i] * B[j] (no common indices) -> outer product C[i,j]
+        let a = make_test_tensor(&[2], &[1]); // i=1
+        let b = make_test_tensor(&[3], &[2]); // j=2
+        let tensors = vec![a, b];
+        let result = contract_multi(&tensors, AllowedPairs::All).unwrap();
+        // Total elements should be 2*3 = 6
+        let total_elements: usize = result.dims.iter().product();
+        assert_eq!(total_elements, 2 * 3);
+        assert_eq!(result.dims.len(), 2);
+    }
+
+    #[test]
+    fn test_contract_connected_disconnected_error() {
+        // contract_connected should error on disconnected graphs
+        let a = make_test_tensor(&[2, 3], &[1, 2]);
+        let b = make_test_tensor(&[4, 5], &[3, 4]);
+        let tensors = vec![a, b];
+        let result = contract_connected(&tensors, AllowedPairs::All);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("disconnected"));
+    }
+
+    #[test]
+    fn test_contract_connected_specified_no_contractable_error() {
+        // contract_connected with Specified pair that has no contractable indices
+        // Should give clear error message (not just "disconnected")
+        let a = make_test_tensor(&[2, 3], &[1, 2]); // i=1, j=2
+        let b = make_test_tensor(&[4, 5], &[3, 4]); // k=3, l=4 (no common with a)
+        let tensors = vec![a, b];
+        let result = contract_connected(&tensors, AllowedPairs::Specified(&[(0, 1)]));
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("no contractable indices"));
+    }
+
+    // ========================================================================
+    // Tests for AllowedPairs::Specified
+    // ========================================================================
+
+    #[test]
+    fn test_contract_specified_pairs() {
+        // A[i,j], B[j,k], C[i,l] - tensors 0, 1, 2
+        // Specified(&[(0, 1), (0, 2)]) - A-B and A-C contractions
+        // j is contracted (A-B), i is contracted (A-C)
+        // Result should be [k, l]
+        let a = make_test_tensor(&[2, 3], &[1, 2]); // i=1, j=2
+        let b = make_test_tensor(&[3, 4], &[2, 3]); // j=2, k=3
+        let c = make_test_tensor(&[2, 5], &[1, 4]); // i=1, l=4
+        let tensors = vec![a, b, c];
+        let result =
+            contract_multi(&tensors, AllowedPairs::Specified(&[(0, 1), (0, 2)])).unwrap();
+        let mut sorted_dims = result.dims.clone();
+        sorted_dims.sort();
+        assert_eq!(sorted_dims, vec![4, 5]); // k=4, l=5
+    }
+
+    #[test]
+    fn test_contract_specified_no_contractable_indices_error() {
+        // A[i,j], B[j,k], C[m,l] - tensors 0, 1, 2
+        // Specified(&[(0, 1), (1, 2)]) - A-B and B-C pairs allowed
+        // j is contracted (A-B), but B-C has no common indices
+        // Should error because pair (1, 2) has no contractable indices
+        let a = make_test_tensor(&[2, 3], &[1, 2]); // i=1, j=2
+        let b = make_test_tensor(&[3, 4], &[2, 3]); // j=2, k=3
+        let c = make_test_tensor(&[6, 5], &[5, 4]); // m=5, l=4 (no common with B)
+        let tensors = vec![a, b, c];
+        let result = contract_multi(&tensors, AllowedPairs::Specified(&[(0, 1), (1, 2)]));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("no contractable indices"));
+    }
+
+    #[test]
+    fn test_contract_specified_disconnected_outer_product() {
+        // Specified(&[(0,1), (2,3)]) with 4 tensors
+        // {A,B} and {C,D} each have contractable indices, but are disconnected
+        // Should succeed via outer product of the two contracted components
+        let a = make_test_tensor(&[2, 3], &[1, 2]); // i=1, j=2
+        let b = make_test_tensor(&[3, 4], &[2, 3]); // j=2, k=3
+        let c = make_test_tensor(&[4, 5], &[4, 5]); // m=4, n=5
+        let d = make_test_tensor(&[5, 6], &[5, 6]); // n=5, p=6
+        let tensors = vec![a, b, c, d];
+        let result = contract_multi(&tensors, AllowedPairs::Specified(&[(0, 1), (2, 3)])).unwrap();
+        // A-B contracts j: result has i, k (dims 2, 4)
+        // C-D contracts n: result has m, p (dims 4, 6)
+        // Outer product: result has 4 indices
+        assert_eq!(result.dims.len(), 4);
+        let mut sorted_dims = result.dims.clone();
+        sorted_dims.sort();
+        assert_eq!(sorted_dims, vec![2, 4, 4, 6]);
+    }
+
+    #[test]
+    fn test_validate_connected_graph() {
+        // Connected
+        assert!(validate_connected_graph(3, &[(0, 1), (1, 2)]).is_ok());
+        assert!(validate_connected_graph(3, &[(0, 1), (0, 2)]).is_ok());
+        assert!(validate_connected_graph(4, &[(0, 1), (1, 2), (2, 3)]).is_ok());
+
+        // Disconnected
+        assert!(validate_connected_graph(4, &[(0, 1), (2, 3)]).is_err());
+        assert!(validate_connected_graph(3, &[(0, 1)]).is_err()); // tensor 2 not connected
+
+        // Edge cases
+        assert!(validate_connected_graph(0, &[]).is_ok());
+        assert!(validate_connected_graph(1, &[]).is_ok());
+        assert!(validate_connected_graph(2, &[]).is_err()); // 2 tensors, no edges
     }
 
     /// Test omeco's handling of hyperedges.

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -38,7 +38,7 @@ pub use tensordynlen::{
     compute_permutation_from_indices, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor,
     unfold_split, TensorAccess, TensorDynLen,
 };
-pub use contract::contract_multi;
+pub use contract::{contract_connected, contract_multi};
 
 // Re-export linear algebra functions and types
 pub use direct_sum::direct_sum;

--- a/crates/tensor4all-core/src/defaults/tensor_data.rs
+++ b/crates/tensor4all-core/src/defaults/tensor_data.rs
@@ -225,7 +225,7 @@ impl TensorData {
     /// A tuple of (Storage, dims) where dims matches external_dims.
     pub fn materialize(&self) -> anyhow::Result<(Arc<Storage>, Vec<usize>)> {
         use crate::defaults::{contract_multi, DynIndex, Index, TensorDynLen};
-        use crate::tensor_like::TensorLike;
+        use crate::tensor_like::{AllowedPairs, TensorLike};
 
         if self.components.is_empty() {
             return Err(anyhow::anyhow!("Cannot materialize empty TensorData"));
@@ -246,8 +246,8 @@ impl TensorData {
             })
             .collect();
 
-        // Contract all components (outer product if no common indices)
-        let contracted = contract_multi(&tensors)?;
+        // Contract all components (handles disconnected components via outer product)
+        let contracted = contract_multi(&tensors, AllowedPairs::All)?;
 
         // Check if we need to permute to match external order
         let contracted_ids: Vec<DynId> = contracted

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -851,7 +851,7 @@ impl TensorDynLen {
     pub fn inner_product(&self, other: &Self) -> Result<AnyScalar> {
         // Contract self.conj() with other over all indices
         let conj_self = self.conj();
-        let result = super::contract::contract_multi(&[conj_self, other.clone()])?;
+        let result = super::contract::contract_multi(&[conj_self, other.clone()], crate::AllowedPairs::All)?;
         // Result should be a scalar (no indices)
         Ok(result.sum())
     }
@@ -1415,9 +1415,14 @@ impl TensorLike for TensorDynLen {
         Ok(TensorDynLen::permute_indices(self, new_order))
     }
 
-    fn contract(tensors: &[Self]) -> Result<Self> {
-        // Delegate to contract_multi which uses omeco for optimization
-        super::contract::contract_multi(tensors)
+    fn contract(tensors: &[Self], allowed: crate::AllowedPairs<'_>) -> Result<Self> {
+        // Delegate to contract_multi which handles disconnected components
+        super::contract::contract_multi(tensors, allowed)
+    }
+
+    fn contract_connected(tensors: &[Self], allowed: crate::AllowedPairs<'_>) -> Result<Self> {
+        // Delegate to contract_connected which requires connected graph
+        super::contract::contract_connected(tensors, allowed)
     }
 
     fn axpby(&self, a: crate::AnyScalar, other: &Self, b: crate::AnyScalar) -> Result<Self> {

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -49,12 +49,13 @@ pub use defaults::tensordynlen::{
 };
 pub use defaults::tensor_data::{TensorComponent, TensorData};
 pub use tensor_like::{
-    Canonical, DirectSumResult, FactorizeAlg, FactorizeError, FactorizeOptions, FactorizeResult, TensorLike,
+    AllowedPairs, Canonical, DirectSumResult, FactorizeAlg, FactorizeError, FactorizeOptions,
+    FactorizeResult, TensorLike,
 };
 
 // Contraction - backwards compatibility
 pub use defaults::contract;
-pub use defaults::contract::contract_multi;
+pub use defaults::contract::{contract_connected, contract_multi};
 
 // Linear algebra backend - re-exported from tensor4all-tensorbackend
 pub use tensor4all_tensorbackend::backend;

--- a/crates/tensor4all-core/tests/tensor_tensor_like.rs
+++ b/crates/tensor4all-core/tests/tensor_tensor_like.rs
@@ -2,7 +2,7 @@
 
 use tensor4all_core::index::{DynId, Index};
 use tensor4all_core::DynIndex;
-use tensor4all_core::{StorageScalar, TensorDynLen, TensorIndex, TensorLike};
+use tensor4all_core::{AllowedPairs, StorageScalar, TensorDynLen, TensorIndex, TensorLike};
 
 /// Helper to create a simple tensor with given dimensions
 fn make_tensor(dims: &[usize]) -> TensorDynLen {
@@ -53,11 +53,140 @@ fn test_tensor_like_contract_basic() {
     let b = TensorDynLen::from_indices(vec![j_copy.clone(), k.clone()], f64::dense_storage(b_data));
 
     // Use TensorLike::contract - auto-detects contractable pairs via is_contractable
-    let c = <TensorDynLen as TensorLike>::contract(&[a, b])
+    let c = <TensorDynLen as TensorLike>::contract(&[a, b], AllowedPairs::All)
         .expect("contract should succeed");
 
     // Result should be 2x4
     assert_eq!(c.dims, vec![2, 4]);
+}
+
+#[test]
+fn test_contract_allowed_pairs_specified() {
+    // Create three tensors: A(i,j), B(j,k), C(k,l)
+    // With AllowedPairs::Specified(&[(0, 1), (1, 2)]) - A-B and B-C pairs allowed
+    // j is shared between A and B, k is shared between B and C
+    // All tensors form a connected chain: A-j-B-k-C
+    let i = Index::<DynId>::new_dyn(2);
+    let j = Index::<DynId>::new_dyn(3);
+    let k = Index::<DynId>::new_dyn(4);
+    let l = Index::<DynId>::new_dyn(5);
+
+    // Tensor A: 2x3 matrix (i, j)
+    let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
+    let a = TensorDynLen::from_indices(vec![i.clone(), j.clone()], f64::dense_storage(a_data));
+
+    // Tensor B: 3x4 matrix (j, k) - j has same id as A's j
+    let j_copy = Index::new(j.id.clone(), j.dim);
+    let b_data: Vec<f64> = (0..12).map(|x| x as f64).collect();
+    let b = TensorDynLen::from_indices(vec![j_copy.clone(), k.clone()], f64::dense_storage(b_data));
+
+    // Tensor C: 4x5 matrix (k, l) - k has same id as B's k
+    let k_copy = Index::new(k.id.clone(), k.dim);
+    let c_data: Vec<f64> = (0..20).map(|x| x as f64).collect();
+    let c = TensorDynLen::from_indices(vec![k_copy.clone(), l.clone()], f64::dense_storage(c_data));
+
+    // Contract with specified pairs
+    // j is contracted between A and B (in pair (0,1))
+    // k is contracted between B and C (in pair (1,2))
+    let result = <TensorDynLen as TensorLike>::contract(
+        &[a, b, c],
+        AllowedPairs::Specified(&[(0, 1), (1, 2)]),
+    )
+    .expect("contract should succeed");
+
+    // Result should have: i (from A, dim=2), l (from C, dim=5)
+    // j and k are contracted
+    assert_eq!(result.dims.len(), 2);
+    let mut sorted_dims = result.dims.clone();
+    sorted_dims.sort();
+    assert_eq!(sorted_dims, vec![2, 5]);
+}
+
+#[test]
+fn test_contract_specified_empty_with_common_indices_errors() {
+    // AllowedPairs::Specified(&[]) with tensors that share index IDs should error
+    // because outer_product requires tensors to have no common indices
+    let i = Index::<DynId>::new_dyn(2);
+    let j = Index::<DynId>::new_dyn(3);
+
+    // Tensor A: 2x3 matrix
+    let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
+    let a = TensorDynLen::from_indices(vec![i.clone(), j.clone()], f64::dense_storage(a_data));
+
+    // Tensor B: 2x3 matrix (use copies of i and j with same ids)
+    let i_copy = Index::new(i.id.clone(), i.dim);
+    let j_copy = Index::new(j.id.clone(), j.dim);
+    let b_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
+    let b = TensorDynLen::from_indices(vec![i_copy.clone(), j_copy.clone()], f64::dense_storage(b_data));
+
+    // With empty allowed pairs and tensors that share index IDs,
+    // outer_product will fail because tensors have common indices
+    let result = <TensorDynLen as TensorLike>::contract(
+        &[a.clone(), b.clone()],
+        AllowedPairs::Specified(&[]),
+    );
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(err_msg.contains("common indices"));
+}
+
+#[test]
+fn test_contract_specified_empty_outer_product() {
+    // AllowedPairs::Specified(&[]) with tensors that have different index IDs
+    // should succeed via outer product
+    let i = Index::<DynId>::new_dyn(2);
+    let j = Index::<DynId>::new_dyn(3);
+    let k = Index::<DynId>::new_dyn(4);
+    let l = Index::<DynId>::new_dyn(5);
+
+    // Tensor A: 2x3 matrix with indices (i, j)
+    let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
+    let a = TensorDynLen::from_indices(vec![i.clone(), j.clone()], f64::dense_storage(a_data));
+
+    // Tensor B: 4x5 matrix with indices (k, l) - different from a
+    let b_data: Vec<f64> = (0..20).map(|x| x as f64).collect();
+    let b = TensorDynLen::from_indices(vec![k.clone(), l.clone()], f64::dense_storage(b_data));
+
+    // With empty allowed pairs and different index IDs, outer product succeeds
+    let result = <TensorDynLen as TensorLike>::contract(
+        &[a.clone(), b.clone()],
+        AllowedPairs::Specified(&[]),
+    ).unwrap();
+
+    // Result should have 4 indices (i, j, k, l)
+    assert_eq!(result.dims.len(), 4);
+    let mut sorted_dims = result.dims.clone();
+    sorted_dims.sort();
+    assert_eq!(sorted_dims, vec![2, 3, 4, 5]);
+}
+
+#[test]
+fn test_contract_specified_disconnected_outer_product() {
+    // AllowedPairs::Specified(&[(0,1), (2,3)]) with 4 tensors
+    // This creates a disconnected graph: {A,B} and {C,D}
+    // Each component contracts within itself, then outer product combines them
+    let i = Index::<DynId>::new_dyn(2);
+    let j = Index::<DynId>::new_dyn(3);
+
+    let a = TensorDynLen::from_indices(vec![i.clone()], f64::dense_storage(vec![1.0, 2.0]));
+    let i_copy = Index::new(i.id.clone(), i.dim);
+    let b = TensorDynLen::from_indices(vec![i_copy.clone()], f64::dense_storage(vec![3.0, 4.0]));
+    let c = TensorDynLen::from_indices(vec![j.clone()], f64::dense_storage(vec![5.0, 6.0, 7.0]));
+    let j_copy = Index::new(j.id.clone(), j.dim);
+    let d = TensorDynLen::from_indices(vec![j_copy.clone()], f64::dense_storage(vec![8.0, 9.0, 10.0]));
+
+    // Disconnected pairs: (0,1) and (2,3)
+    // A and B contract i, C and D contract j, then outer product combines results
+    let result = <TensorDynLen as TensorLike>::contract(
+        &[a, b, c, d],
+        AllowedPairs::Specified(&[(0, 1), (2, 3)]),
+    ).unwrap();
+
+    // A(i) * B(i) contracts to scalar (dim 0)
+    // C(j) * D(j) contracts to scalar (dim 0)
+    // Outer product of two scalars is a scalar
+    assert_eq!(result.dims.len(), 0);
 }
 
 // Note: trait object tests removed - TensorLike is now fully generic and does not support dyn

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 
 use anyhow::{Context, Result};
 
-use tensor4all_core::{Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike};
 use crate::algorithm::CanonicalForm;
 
 use super::TreeTN;
@@ -154,7 +154,7 @@ where
 
             // Contract and store result at `to`
             // (bond indices are auto-detected via is_contractable)
-            let contracted = T::contract(&[to_tensor, from_tensor])
+            let contracted = T::contract(&[to_tensor, from_tensor], AllowedPairs::All)
                 .context("Failed to contract along edge")?;
             tensors.insert(to, contracted);
         }
@@ -288,7 +288,7 @@ where
                 .ok_or_else(|| anyhow::anyhow!("contract_zipup: tensor not found"))?;
 
             // Contract t1 and t2 - common indices are auto-detected via is_contractable
-            let result = T::contract(&[t1.clone(), t2.clone()])?;
+            let result = T::contract(&[t1.clone(), t2.clone()], AllowedPairs::All)?;
             let mut result_tn = Self::new();
             let node_name = tn1
                 .graph
@@ -319,7 +319,7 @@ where
 
             // Contract along site indices
             // T::contract auto-contracts all is_contractable pairs
-            let contracted = T::contract(&[t1.clone(), t2.clone()])?;
+            let contracted = T::contract(&[t1.clone(), t2.clone()], AllowedPairs::All)?;
 
             result_tensors.insert(node_name, contracted);
         }
@@ -375,7 +375,7 @@ where
                     .remove(parent_name)
                     .ok_or_else(|| anyhow::anyhow!("Parent tensor {:?} not found", parent_name))?;
 
-                let contracted = T::contract(&[parent_tensor, child_tensor])?;
+                let contracted = T::contract(&[parent_tensor, child_tensor], AllowedPairs::All)?;
                 result_tensors.insert(parent_name.clone(), contracted);
                 // Don't re-insert child - it's been absorbed
                 continue;
@@ -404,7 +404,7 @@ where
             // Right factor has: new_bond (from factorize), bond1, bond2
             // Parent has: bond1, bond2 (among other indices)
             // Contract along bond1 and bond2
-            let contracted = T::contract(&[parent_tensor, factorize_result.right])?;
+            let contracted = T::contract(&[parent_tensor, factorize_result.right], AllowedPairs::All)?;
             result_tensors.insert(parent_name.clone(), contracted);
         }
 
@@ -502,7 +502,7 @@ where
 
         // 4. Contract along common indices
         // T::contract auto-contracts all is_contractable pairs
-        T::contract(&[tensor1, tensor2])
+        T::contract(&[tensor1, tensor2], AllowedPairs::All)
     }
 
     /// Validate that `canonical_center` and edge `ortho_towards` are consistent.

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -31,7 +31,7 @@ use std::hash::Hash;
 
 use anyhow::Result;
 
-use tensor4all_core::{Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike};
 
 use super::localupdate::{LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater};
 use super::TreeTN;
@@ -294,14 +294,14 @@ where
 
     // Contract A * B on site indices
     // T::contract auto-contracts all is_contractable pairs
-    let ab = T::contract(&[tensor_a.clone(), tensor_b.clone()])
+    let ab = T::contract(&[tensor_a.clone(), tensor_b.clone()], AllowedPairs::All)
         .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
     // Contract with conj(C) on remaining site indices
     let c_conj = tensor_c.conj();
 
     // Contract AB with conj(C) - T::contract auto-contracts all is_contractable pairs
-    let env = T::contract(&[ab, c_conj])
+    let env = T::contract(&[ab, c_conj], AllowedPairs::All)
         .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
     Ok(env)
@@ -352,17 +352,17 @@ where
 
     // Non-leaf: contract A × B × conj(C) × child_envs
     // T::contract auto-contracts all is_contractable pairs
-    let ab = T::contract(&[tensor_a.clone(), tensor_b.clone()])
+    let ab = T::contract(&[tensor_a.clone(), tensor_b.clone()], AllowedPairs::All)
         .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
     // Contract with conj(C)
     let c_conj = tensor_c.conj();
-    let mut result = T::contract(&[ab, c_conj])
+    let mut result = T::contract(&[ab, c_conj], AllowedPairs::All)
         .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
     // Contract with child environments
     for child_env in child_envs {
-        result = T::contract(&[result, child_env.clone()])
+        result = T::contract(&[result, child_env.clone()], AllowedPairs::All)
             .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
     }
 
@@ -500,19 +500,19 @@ where
 
         // Compute optimal 2-site tensor: env × A[u] × B[u] × A[v] × B[v] × env
         // T::contract auto-contracts all is_contractable pairs
-        let ab_u = T::contract(&[a_u.clone(), b_u.clone()])
+        let ab_u = T::contract(&[a_u.clone(), b_u.clone()], AllowedPairs::All)
             .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
-        let ab_v = T::contract(&[a_v.clone(), b_v.clone()])
+        let ab_v = T::contract(&[a_v.clone(), b_v.clone()], AllowedPairs::All)
             .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
         // Contract ab_u and ab_v on internal bonds
-        let mut ab_uv = T::contract(&[ab_u, ab_v])
+        let mut ab_uv = T::contract(&[ab_u, ab_v], AllowedPairs::All)
             .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
 
         // Contract with environment tensors
         for env in env_tensors {
-            ab_uv = T::contract(&[ab_uv, env.clone()])
+            ab_uv = T::contract(&[ab_uv, env.clone()], AllowedPairs::All)
                 .map_err(|e| anyhow::anyhow!("contract failed: {}", e))?;
         }
 

--- a/crates/tensor4all-treetn/src/treetn/linsolve/linear_operator.rs
+++ b/crates/tensor4all-treetn/src/treetn/linsolve/linear_operator.rs
@@ -25,6 +25,7 @@ use std::hash::Hash;
 
 use anyhow::Result;
 
+use tensor4all_core::AllowedPairs;
 use tensor4all_core::IndexLike;
 use tensor4all_core::TensorLike;
 
@@ -231,7 +232,7 @@ where
             };
 
             // Step 2: Contract with operator
-            let contracted = T::contract(&[transformed_state, op_tensor.clone()])?;
+            let contracted = T::contract(&[transformed_state, op_tensor.clone()], AllowedPairs::All)?;
 
             // Step 3: Replace MPO's output indices with true output indices
             let result_tensor = if let Some(mapping) = self.output_mapping.get(&node) {
@@ -287,14 +288,14 @@ where
 
             op_tensor = Some(match op_tensor {
                 None => tensor,
-                Some(t) => T::contract(&[t, tensor.clone()])?,
+                Some(t) => T::contract(&[t, tensor.clone()], AllowedPairs::All)?,
             });
         }
 
         let op_tensor = op_tensor.ok_or_else(|| anyhow::anyhow!("Empty region"))?;
 
         // Contract transformed tensor with operator
-        let contracted = T::contract(&[transformed, op_tensor])?;
+        let contracted = T::contract(&[transformed, op_tensor], AllowedPairs::All)?;
 
         // Step 3: Replace output indices back to true indices
         let mut result = contracted;

--- a/crates/tensor4all-treetn/src/treetn/linsolve/projected_operator.rs
+++ b/crates/tensor4all-treetn/src/treetn/linsolve/projected_operator.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 
 use anyhow::Result;
 
-use tensor4all_core::{IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, IndexLike, TensorLike};
 
 use super::environment::{EnvironmentCache, NetworkTopology};
 use crate::treetn::TreeTN;
@@ -178,7 +178,7 @@ where
         }
 
         // Contract all tensors
-        let contracted = T::contract(&all_tensors)?;
+        let contracted = T::contract(&all_tensors, AllowedPairs::All)?;
 
         // Step 4: Transform output - replace internal output indices with true indices
         if let Some(ref output_mapping) = self.output_mapping {
@@ -303,10 +303,10 @@ where
         };
 
         // Contract ket with op - T::contract auto-detects contractable pairs
-        let ket_op = T::contract(&[transformed_ket, tensor_op.clone()])?;
+        let ket_op = T::contract(&[transformed_ket, tensor_op.clone()], AllowedPairs::All)?;
 
         // Contract ket_op with transformed_bra_conj
-        let ket_op_bra = T::contract(&[ket_op, transformed_bra_conj])?;
+        let ket_op_bra = T::contract(&[ket_op, transformed_bra_conj], AllowedPairs::All)?;
 
         // Contract ket_op_bra with child environments using T::contract
         if child_envs.is_empty() {
@@ -314,7 +314,7 @@ where
         } else {
             let mut all_tensors: Vec<T> = vec![ket_op_bra];
             all_tensors.extend(child_envs);
-            T::contract(&all_tensors)
+            T::contract(&all_tensors, AllowedPairs::All)
         }
     }
 

--- a/crates/tensor4all-treetn/src/treetn/linsolve/projected_state.rs
+++ b/crates/tensor4all-treetn/src/treetn/linsolve/projected_state.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 
 use anyhow::Result;
 
-use tensor4all_core::{IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, IndexLike, TensorLike};
 
 use super::environment::{EnvironmentCache, NetworkTopology};
 use crate::treetn::TreeTN;
@@ -124,7 +124,7 @@ where
         }
 
         // Use T::contract for optimal contraction ordering
-        T::contract(&all_tensors)
+        T::contract(&all_tensors, AllowedPairs::All)
     }
 
     /// Ensure environments are computed for neighbors of the region.
@@ -197,7 +197,7 @@ where
         let bra_conj = tensor_bra.conj();
 
         // Contract bra and ket - T::contract auto-detects contractable pairs
-        let bra_ket = T::contract(&[bra_conj, tensor_ket.clone()])?;
+        let bra_ket = T::contract(&[bra_conj, tensor_ket.clone()], AllowedPairs::All)?;
 
         // Contract bra*ket with child environments using T::contract
         if child_envs.is_empty() {
@@ -205,7 +205,7 @@ where
         } else {
             let mut all_tensors: Vec<T> = vec![bra_ket];
             all_tensors.extend(child_envs);
-            T::contract(&all_tensors)
+            T::contract(&all_tensors, AllowedPairs::All)
         }
     }
 

--- a/crates/tensor4all-treetn/src/treetn/linsolve/updater.rs
+++ b/crates/tensor4all-treetn/src/treetn/linsolve/updater.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 
 use tensor4all_core::any_scalar::AnyScalar;
 use tensor4all_core::krylov::{gmres, GmresOptions};
-use tensor4all_core::{FactorizeAlg, IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, FactorizeAlg, IndexLike, TensorLike};
 
 use super::local_linop::LocalLinOp;
 use super::options::LinsolveOptions;
@@ -357,7 +357,7 @@ where
             .collect::<Result<_>>()?;
 
         // Use TensorLike::contract for contraction
-        T::contract(&tensors)
+        T::contract(&tensors, AllowedPairs::All)
     }
 
     /// Build TreeTopology for the subtree region from the solved tensor.

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 
 use anyhow::{Context, Result};
 
-use tensor4all_core::{IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, IndexLike, TensorLike};
 
 use super::TreeTN;
 use crate::node_name_network::NodeNameNetwork;
@@ -441,7 +441,7 @@ where
         // Contract A and B
         let tensor_a = subtree.tensor(idx_a).unwrap();
         let tensor_b = subtree.tensor(idx_b).unwrap();
-        let tensor_ab = T::contract(&[tensor_a.clone(), tensor_b.clone()])
+        let tensor_ab = T::contract(&[tensor_a.clone(), tensor_b.clone()], AllowedPairs::All)
             .context("Failed to contract A and B")?;
 
         // Determine left indices (indices that will remain on A after factorization)

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -27,7 +27,7 @@ use std::hash::Hash;
 
 use anyhow::{Context, Result};
 
-use tensor4all_core::{FactorizeOptions, IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, FactorizeOptions, IndexLike, TensorLike};
 use crate::algorithm::CanonicalForm;
 
 use crate::named_graph::NamedGraph;
@@ -553,7 +553,7 @@ where
             .ok_or_else(|| anyhow::anyhow!("Tensor not found for dst node {:?}", dst))
             .with_context(|| format!("{}: dst tensor not found", context_name))?;
 
-        let updated_dst_tensor = T::contract(&[tensor_dst.clone(), right_tensor])
+        let updated_dst_tensor = T::contract(&[tensor_dst.clone(), right_tensor], AllowedPairs::All)
             .with_context(|| {
                 format!(
                     "{}: failed to absorb right factor into dst tensor",

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 use anyhow::{Context, Result};
 use petgraph::stable_graph::NodeIndex;
 
-use tensor4all_core::{Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike};
+use tensor4all_core::{AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike};
 
 use super::TreeTN;
 use crate::options::SplitOptions;
@@ -232,7 +232,7 @@ where
 
             // Contract using TensorLike::contract
             // (bond indices are auto-detected via is_contractable)
-            let contracted = T::contract(&[to_tensor, from_tensor])
+            let contracted = T::contract(&[to_tensor, from_tensor], AllowedPairs::All)
                 .map_err(|e| anyhow::anyhow!("Failed to contract tensors: {}", e))?;
 
             tensors.insert(to, contracted);


### PR DESCRIPTION
## Summary

- Add `AllowedPairs` parameter to `contract_multi` for controlling which tensor pairs can contract
- Add `contract_connected` function that requires a connected tensor graph
- Use petgraph for O(V+E) connected component detection
- Handle disconnected graphs via outer product in `contract_multi`
- Update README.md with documentation for new contraction API

## Motivation

This enables tree tensor network (TreeTN) use cases where only edges between connected nodes should be contracted, not all tensors with matching index IDs.

## API

```rust
// Contract all pairs (default behavior)
let result = contract_multi(&tensors, AllowedPairs::All)?;

// Contract only specified pairs
let result = contract_multi(&tensors, AllowedPairs::Specified(&[(0, 1), (1, 2)]))?;

// Require connected graph (error on disconnected)
let result = contract_connected(&tensors, AllowedPairs::All)?;
```

## Test plan

- [x] `cargo test -p tensor4all-core` passes
- [x] `cargo test -p tensor4all-treetn` passes
- [x] New tests for `AllowedPairs::Specified`
- [x] New tests for disconnected graph handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)