### PR TITLE
feat(treetn): add connectivity verification and dummy link support

### DIFF
--- a/crates/tensor4all-core/src/defaults/index.rs
+++ b/crates/tensor4all-core/src/defaults/index.rs
@@ -382,6 +382,21 @@ impl IndexLike for DynIndex {
             tags: self.tags.clone(),
         }
     }
+
+    fn create_dummy_link_pair() -> (Self, Self) {
+        let id = DynId(generate_id());
+        let idx1 = Index {
+            id: id.clone(),
+            dim: 1,
+            tags: TagSet::default(),
+        };
+        let idx2 = Index {
+            id,
+            dim: 1,
+            tags: TagSet::default(),
+        };
+        (idx1, idx2)
+    }
 }
 
 impl DynIndex {

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -1472,5 +1472,16 @@ impl TensorLike for TensorDynLen {
         Ok(TensorDynLen::new(vec![], vec![], storage))
     }
 
+    fn ones(indices: &[DynIndex]) -> Result<Self> {
+        use crate::storage::DenseStorageF64;
+        if indices.is_empty() {
+            return Self::scalar_one();
+        }
+        let dims: Vec<usize> = indices.iter().map(|idx| idx.size()).collect();
+        let total_size: usize = dims.iter().product();
+        let storage = Arc::new(Storage::DenseF64(DenseStorageF64::from_vec(vec![1.0; total_size])));
+        Ok(TensorDynLen::new(indices.to_vec(), dims, storage))
+    }
+
     // delta() uses the default implementation via diagonal() and outer_product()
 }

--- a/crates/tensor4all-core/src/index_like.rs
+++ b/crates/tensor4all-core/src/index_like.rs
@@ -179,4 +179,17 @@ pub trait IndexLike: Clone + Eq + Hash + Debug + Send + Sync + 'static {
     fn sim(&self) -> Self
     where
         Self: Sized;
+
+    /// Create a pair of contractable dummy indices with dimension 1.
+    ///
+    /// These are used for structural connections that don't carry quantum numbers,
+    /// such as connecting components in a tree tensor network.
+    ///
+    /// Both indices will be `Undirected` and have the same ID, making them contractable.
+    ///
+    /// # Returns
+    /// A pair `(idx1, idx2)` where `idx1.is_contractable(&idx2)` is true.
+    fn create_dummy_link_pair() -> (Self, Self)
+    where
+        Self: Sized;
 }

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -560,6 +560,19 @@ pub trait TensorLike: TensorIndex {
     ///
     /// This is used as the identity element for outer products.
     fn scalar_one() -> Result<Self>;
+
+    /// Create a tensor filled with 1.0 for the given indices.
+    ///
+    /// This is useful for adding indices to tensors via outer product
+    /// without changing tensor values (since multiplying by 1 is identity).
+    ///
+    /// # Example
+    /// To add a dummy index `l` to tensor `T`:
+    /// ```ignore
+    /// let ones = T::ones(&[l])?;
+    /// let t_with_l = t.outer_product(&ones)?;
+    /// ```
+    fn ones(indices: &[<Self as TensorIndex>::Index]) -> Result<Self>;
 }
 
 /// Result of direct sum operation.

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -154,6 +154,22 @@ where
     pub fn from_tensors(tensors: Vec<T>, node_names: Vec<V>) -> Result<Self>
     where
         <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+        V: Ord,
+    {
+        let treetn = Self::from_tensors_unchecked(tensors, node_names)?;
+
+        // Verify structural constraints after construction
+        treetn.verify_internal_consistency()
+            .context("TreeTN::from_tensors: constructed TreeTN failed internal consistency check")?;
+
+        Ok(treetn)
+    }
+
+    /// Internal version of `from_tensors` that skips verification.
+    /// Used by `verify_internal_consistency` to avoid infinite recursion.
+    fn from_tensors_unchecked(tensors: Vec<T>, node_names: Vec<V>) -> Result<Self>
+    where
+        <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
     {
         // Validate input lengths
         if tensors.len() != node_names.len() {
@@ -1179,15 +1195,21 @@ where
         true
     }
 
-    /// Verify internal data consistency by reconstructing the TreeTN from scratch.
+    /// Verify internal data consistency by checking structural invariants and reconstructing the TreeTN.
     ///
-    /// This function clones all tensors and node names, reconstructs a new TreeTN
-    /// using `from_tensors`, and verifies that the reconstruction matches the original.
+    /// This function performs two categories of checks:
     ///
-    /// # Consistency checks performed:
-    /// 1. Topology: Same nodes and edges
-    /// 2. Site space: Same physical indices for each node
-    /// 3. Tensors: Same tensor data at each node
+    /// ## Structural invariants (fail-fast checks):
+    /// 0a. **Connectivity**: All tensors must form a single connected component
+    /// 0b. **Index sharing**: Only edge-connected (adjacent) nodes may share index IDs.
+    ///     Non-adjacent nodes sharing an index ID violates tree structure assumptions.
+    ///
+    /// ## Reconstruction consistency:
+    /// After structural checks pass, clones all tensors and node names, reconstructs
+    /// a new TreeTN using `from_tensors`, and verifies:
+    /// 1. **Topology**: Same nodes and edges
+    /// 2. **Site space**: Same physical indices for each node
+    /// 3. **Tensors**: Same tensor data at each node
     ///
     /// This is useful for debugging and testing to ensure that the internal state
     /// of a TreeTN is consistent after complex operations.
@@ -1199,6 +1221,75 @@ where
         <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
         V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     {
+        // Step 0a: Verify all tensors are connected (form a single connected component)
+        // Use DFS to check connectivity since StableGraph doesn't support connected_components
+        let num_nodes = self.graph.graph().node_count();
+        if num_nodes > 1 {
+            // Start DFS from any node
+            if let Some(start_node) = self.graph.graph().node_indices().next() {
+                let mut dfs = Dfs::new(self.graph.graph(), start_node);
+                let mut visited_count = 0;
+                while dfs.next(self.graph.graph()).is_some() {
+                    visited_count += 1;
+                }
+                if visited_count != num_nodes {
+                    return Err(anyhow::anyhow!(
+                        "TreeTN is disconnected: DFS visited {} of {} nodes. All tensors must be connected.",
+                        visited_count,
+                        num_nodes
+                    ))
+                    .context("verify_internal_consistency: graph must be connected");
+                }
+            }
+        }
+
+        // Step 0b: Verify non-adjacent tensors don't share index IDs
+        // Build a map from index ID to nodes that have that index
+        let mut index_id_to_nodes: HashMap<<T::Index as IndexLike>::Id, Vec<NodeIndex>> =
+            HashMap::new();
+        for node_idx in self.graph.graph().node_indices() {
+            if let Some(tensor) = self.tensor(node_idx) {
+                for index in tensor.external_indices() {
+                    index_id_to_nodes
+                        .entry(index.id().clone())
+                        .or_default()
+                        .push(node_idx);
+                }
+            }
+        }
+
+        // Check each index ID - if shared by multiple nodes, they must be adjacent
+        for (index_id, nodes) in &index_id_to_nodes {
+            if nodes.len() > 2 {
+                // More than 2 nodes share the same index ID - always invalid for tree structure
+                return Err(anyhow::anyhow!(
+                    "Index ID {:?} is shared by {} nodes, but tree structure allows at most 2",
+                    index_id,
+                    nodes.len()
+                ))
+                .context("verify_internal_consistency: index ID shared by too many nodes");
+            }
+            if nodes.len() == 2 {
+                // Two nodes share the index - they must be adjacent (connected by an edge)
+                let node_a = nodes[0];
+                let node_b = nodes[1];
+                if self.graph.graph().find_edge(node_a, node_b).is_none()
+                    && self.graph.graph().find_edge(node_b, node_a).is_none()
+                {
+                    let name_a = self.graph.node_name(node_a);
+                    let name_b = self.graph.node_name(node_b);
+                    return Err(anyhow::anyhow!(
+                        "Non-adjacent nodes {:?} and {:?} share index ID {:?}. \
+                        Only adjacent (edge-connected) nodes may share index IDs.",
+                        name_a,
+                        name_b,
+                        index_id
+                    ))
+                    .context("verify_internal_consistency: non-adjacent nodes share index ID");
+                }
+            }
+        }
+
         // Step 1: Clone all tensors and node names
         let node_names: Vec<V> = self.node_names();
         let tensors: Vec<T> = node_names
@@ -1217,8 +1308,9 @@ where
             ));
         }
 
-        // Step 2: Reconstruct TreeTN from scratch using from_tensors
-        let reconstructed = TreeTN::<T, V>::from_tensors(tensors, node_names)
+        // Step 2: Reconstruct TreeTN from scratch using from_tensors_unchecked
+        // (use unchecked version to avoid infinite recursion)
+        let reconstructed = TreeTN::<T, V>::from_tensors_unchecked(tensors, node_names)
             .context("verify_internal_consistency: failed to reconstruct TreeTN")?;
 
         // Step 3: Verify topology matches

--- a/crates/tensor4all-treetn/tests/tensor_like.rs
+++ b/crates/tensor4all-treetn/tests/tensor_like.rs
@@ -143,17 +143,23 @@ fn test_treetn_contract_to_tensor() {
 
 #[test]
 fn test_treetn_site_indices_deterministic_ordering() {
-    // Create a TreeTN with multiple nodes and verify ordering is deterministic
-    let idx_a = DynIndex::new_dyn(2);
-    let idx_b = DynIndex::new_dyn(3);
-    let idx_c = DynIndex::new_dyn(4);
+    // Create a TreeTN with multiple connected nodes and verify ordering is deterministic
+    // Structure: C -- A -- B (linear chain)
+    let idx_a = DynIndex::new_dyn(2); // site index for A
+    let idx_b = DynIndex::new_dyn(3); // site index for B
+    let idx_c = DynIndex::new_dyn(4); // site index for C
+    let bond_ca = DynIndex::new_dyn(2); // bond between C and A
+    let bond_ab = DynIndex::new_dyn(2); // bond between A and B
 
     // Add nodes in non-alphabetical order (C, A, B)
+    // C has site index idx_c and bond to A
+    // A has site index idx_a and bonds to C and B
+    // B has site index idx_b and bond to A
     let tn = TreeTN::<TensorDynLen, String>::from_tensors(
         vec![
-            make_tensor(vec![idx_c.clone()]),
-            make_tensor(vec![idx_a.clone()]),
-            make_tensor(vec![idx_b.clone()]),
+            make_tensor(vec![idx_c.clone(), bond_ca.clone()]),
+            make_tensor(vec![bond_ca.clone(), idx_a.clone(), bond_ab.clone()]),
+            make_tensor(vec![bond_ab.clone(), idx_b.clone()]),
         ],
         vec!["C".to_string(), "A".to_string(), "B".to_string()],
     )


### PR DESCRIPTION
## Summary

- Add stricter validation to TreeTN construction:
  - All tensors must form a single connected component (DFS-based check)
  - Non-adjacent nodes cannot share index IDs (prevents accidental contractions)
- Add `IndexLike::create_dummy_link_pair()` to create contractable dim-1 index pairs
- Add `TensorLike::ones()` to create tensors filled with 1.0 for outer products
- Fix `compose_exclusive_linear_operators` to add dummy links for cross-component edges

## Test plan

- [x] All existing tests pass (`cargo test -p tensor4all-treetn`)
- [x] All core tests pass (`cargo test -p tensor4all-core`)
- [x] Updated `test_treetn_site_indices_deterministic_ordering` to use connected tensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)