### PR TITLE
fix(ci): use correct rust-toolchain action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install mdBook
         run: cargo install mdbook --version 0.5.2 --locked


### PR DESCRIPTION
## Summary

Fix the Deploy Documentation workflow that was failing due to incorrect action name.

**Error:** `Unable to resolve action dtolnay/rust-action, repository not found`

**Fix:** Change `dtolnay/rust-action@stable` to `dtolnay/rust-toolchain@stable`

## Test Plan

- [ ] CI workflow passes
- [ ] Documentation deploys to GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)