### PR TITLE
fix(ci): remove nightly-only rustdoc flags

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Build rustdoc
         run: cargo doc --workspace --no-deps
-        env:
-          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
 
       - name: Combine documentation
         run: |


### PR DESCRIPTION
## Summary

Fix the Deploy Documentation workflow that was failing due to nightly-only rustdoc flags.

**Error:** 
```
error: the option `Z` is only accepted on the nightly compiler
error: the option `enable-index-page` is only accepted on the nightly compiler
```

**Fix:** Remove `RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"` to use stable Rust.

## Local Testing

```bash
# mdBook build
mdbook build docs/book  # ✓

# rustdoc build
cargo doc --workspace --no-deps  # ✓
```

## Test Plan

- [x] Tested mdBook build locally
- [x] Tested rustdoc build locally
- [ ] CI workflow passes
- [ ] Documentation deploys to GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)