### PR TITLE
test: add tests to improve code coverage for high-level APIs

### DIFF
--- a/crates/tensor4all-capi/src/tensortrain.rs
+++ b/crates/tensor4all-capi/src/tensortrain.rs
@@ -856,4 +856,47 @@ mod tests {
         crate::t4a_index_release(s0);
         crate::t4a_index_release(s0_clone);
     }
+
+    #[test]
+    fn test_tt_inner() {
+        use crate::{t4a_index_clone, t4a_index_new, t4a_tensor_new_dense_f64};
+
+        // Build two 1-site tensor trains with the same site index
+        let s0 = t4a_index_new(2);
+        let s0_clone = t4a_index_clone(s0);
+
+        // Create vector [1, 0] normalized
+        let data_a: Vec<f64> = vec![1.0, 0.0];
+        // Create vector [0, 1]
+        let data_b: Vec<f64> = vec![0.0, 1.0];
+
+        let inds_a: [*const t4a_index; 1] = [s0];
+        let dims_a: [libc::size_t; 1] = [2];
+        let t0 = t4a_tensor_new_dense_f64(1, inds_a.as_ptr(), dims_a.as_ptr(), data_a.as_ptr(), 2);
+
+        let inds_b: [*const t4a_index; 1] = [s0_clone];
+        let dims_b: [libc::size_t; 1] = [2];
+        let t1 = t4a_tensor_new_dense_f64(1, inds_b.as_ptr(), dims_b.as_ptr(), data_b.as_ptr(), 2);
+
+        let tensors0: [*const t4a_tensor; 1] = [t0];
+        let tensors1: [*const t4a_tensor; 1] = [t1];
+        let tt0 = t4a_tt_new(tensors0.as_ptr(), 1);
+        let tt1 = t4a_tt_new(tensors1.as_ptr(), 1);
+
+        // Compute inner product - should be 0 for orthogonal vectors
+        let mut re: f64 = 0.0;
+        let mut im: f64 = 0.0;
+        let status = t4a_tt_inner(tt0, tt1, &mut re, &mut im);
+        assert_eq!(status, T4A_SUCCESS);
+        assert!((re - 0.0).abs() < 1e-10);
+        assert!((im - 0.0).abs() < 1e-10);
+
+        // Cleanup
+        t4a_tensortrain_release(tt0);
+        t4a_tensortrain_release(tt1);
+        crate::t4a_tensor_release(t0);
+        crate::t4a_tensor_release(t1);
+        crate::t4a_index_release(s0);
+        crate::t4a_index_release(s0_clone);
+    }
 }

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -354,3 +354,30 @@ impl From<t4a_contract_method> for tensor4all_itensorlike::ContractMethod {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_complex::Complex64;
+    use tensor4all_core::storage::{DiagStorageC64, DiagStorageF64};
+
+    #[test]
+    fn test_storage_kind_from_storage_diag() {
+        // Test DiagF64
+        let diag_f64 = Storage::DiagF64(DiagStorageF64::from_vec(vec![1.0, 2.0]));
+        assert_eq!(
+            t4a_storage_kind::from_storage(&diag_f64),
+            t4a_storage_kind::DiagF64
+        );
+
+        // Test DiagC64
+        let diag_c64 = Storage::DiagC64(DiagStorageC64::from_vec(vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+        ]));
+        assert_eq!(
+            t4a_storage_kind::from_storage(&diag_c64),
+            t4a_storage_kind::DiagC64
+        );
+    }
+}

--- a/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
@@ -1,0 +1,47 @@
+//! Tests for TensorTrain inner product operations
+
+use tensor4all_core::index::DefaultIndex as Index;
+use tensor4all_core::TensorDynLen;
+use tensor4all_itensorlike::TensorTrain;
+
+/// Test inner product of empty tensor trains
+#[test]
+fn test_inner_empty_tensor_trains() {
+    let tt1 = TensorTrain::new(vec![]).unwrap();
+    let tt2 = TensorTrain::new(vec![]).unwrap();
+
+    let result = tt1.inner(&tt2);
+    assert_eq!(result.real(), 0.0);
+}
+
+/// Test inner product of single-site tensor trains
+#[test]
+fn test_inner_single_site() {
+    let site = Index::new_dyn(2);
+    let link_left = Index::new_dyn(1);
+    let link_right = Index::new_dyn(1);
+
+    // Create [1, 0] as tensor with shape [1, 2, 1]
+    let t1 = TensorDynLen::from_dense_f64(
+        vec![link_left.clone(), site.clone(), link_right.clone()],
+        vec![1.0, 0.0],
+    );
+
+    // Create [0, 1] as tensor with shape [1, 2, 1]
+    let t2 = TensorDynLen::from_dense_f64(
+        vec![link_left.clone(), site.clone(), link_right.clone()],
+        vec![0.0, 1.0],
+    );
+
+    let tt1 = TensorTrain::new(vec![t1.clone()]).unwrap();
+    let tt2 = TensorTrain::new(vec![t2.clone()]).unwrap();
+
+    // Orthogonal vectors: inner product should be 0
+    let result = tt1.inner(&tt2);
+    assert!((result.real() - 0.0).abs() < 1e-10);
+
+    // Same vector: inner product should be 1
+    let tt3 = TensorTrain::new(vec![t1.clone()]).unwrap();
+    let result2 = tt1.inner(&tt3);
+    assert!((result2.real() - 1.0).abs() < 1e-10);
+}

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -2697,4 +2697,55 @@ mod tests {
             _ => panic!("Expected DiagF64"),
         }
     }
+
+    // ===== Type inspection tests =====
+
+    #[test]
+    fn test_is_f64() {
+        let dense_f64 = Storage::DenseF64(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
+        let dense_c64 = Storage::DenseC64(DenseStorage::from_vec_with_shape(
+            vec![Complex64::new(1.0, 0.0)],
+            &[1],
+        ));
+        let diag_f64 = Storage::DiagF64(DiagStorage::from_vec(vec![1.0]));
+        let diag_c64 = Storage::DiagC64(DiagStorage::from_vec(vec![Complex64::new(1.0, 0.0)]));
+
+        assert!(dense_f64.is_f64());
+        assert!(!dense_c64.is_f64());
+        assert!(diag_f64.is_f64());
+        assert!(!diag_c64.is_f64());
+    }
+
+    #[test]
+    fn test_is_c64() {
+        let dense_f64 = Storage::DenseF64(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
+        let dense_c64 = Storage::DenseC64(DenseStorage::from_vec_with_shape(
+            vec![Complex64::new(1.0, 0.0)],
+            &[1],
+        ));
+        let diag_f64 = Storage::DiagF64(DiagStorage::from_vec(vec![1.0]));
+        let diag_c64 = Storage::DiagC64(DiagStorage::from_vec(vec![Complex64::new(1.0, 0.0)]));
+
+        assert!(!dense_f64.is_c64());
+        assert!(dense_c64.is_c64());
+        assert!(!diag_f64.is_c64());
+        assert!(diag_c64.is_c64());
+    }
+
+    #[test]
+    fn test_is_complex() {
+        let dense_f64 = Storage::DenseF64(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
+        let dense_c64 = Storage::DenseC64(DenseStorage::from_vec_with_shape(
+            vec![Complex64::new(1.0, 0.0)],
+            &[1],
+        ));
+        let diag_f64 = Storage::DiagF64(DiagStorage::from_vec(vec![1.0]));
+        let diag_c64 = Storage::DiagC64(DiagStorage::from_vec(vec![Complex64::new(1.0, 0.0)]));
+
+        // is_complex is an alias for is_c64
+        assert!(!dense_f64.is_complex());
+        assert!(dense_c64.is_complex());
+        assert!(!diag_f64.is_complex());
+        assert!(diag_c64.is_complex());
+    }
 }

--- a/crates/tensor4all-treetn/src/operator/identity.rs
+++ b/crates/tensor4all-treetn/src/operator/identity.rs
@@ -231,4 +231,30 @@ mod tests {
         assert_eq!(data[2], Complex64::new(0.0, 0.0));
         assert_eq!(data[3], Complex64::new(1.0, 0.0));
     }
+
+    #[test]
+    fn test_identity_c64_multi_site() {
+        // Test with multiple sites to cover the main loop in build_identity_operator_tensor_c64
+        let s1_in = make_index(2);
+        let s1_out = make_index(2);
+        let s2_in = make_index(2);
+        let s2_out = make_index(2);
+
+        let tensor =
+            build_identity_operator_tensor_c64(&[s1_in, s2_in], &[s1_out, s2_out]).unwrap();
+
+        // Shape should be [2, 2, 2, 2] = 16 elements
+        assert_eq!(tensor.dims, vec![2, 2, 2, 2]);
+        let data = get_c64_data(&tensor);
+        assert_eq!(data.len(), 16);
+
+        // Diagonal elements should be 1, others 0
+        // In identity operator, data[i, i, j, j] = 1 for all i, j
+        // Linear index: (i1, o1, i2, o2) -> i1*8 + o1*4 + i2*2 + o2
+        // (0,0,0,0)=0, (0,0,1,1)=3, (1,1,0,0)=12, (1,1,1,1)=15
+        assert_eq!(data[0], Complex64::new(1.0, 0.0));
+        assert_eq!(data[3], Complex64::new(1.0, 0.0));
+        assert_eq!(data[12], Complex64::new(1.0, 0.0));
+        assert_eq!(data[15], Complex64::new(1.0, 0.0));
+    }
 }


### PR DESCRIPTION
## Summary
- Add tests for TensorDynLen high-level APIs (from_dense_*, scalar_*, zeros_*, as_slice_*, to_vec_*, is_f64, is_complex)
- Add tests for Storage type inspection methods (is_f64, is_c64, is_complex)
- Add test for t4a_tt_inner C API function
- Add test for DiagF64/DiagC64 storage kind detection
- Add test for multi-site identity operator C64
- Add test for TensorTrain inner product with empty trains

This PR adds test coverage for the new high-level APIs introduced in PR #144, which were flagged by codecov/patch.

## Test plan
- [x] Run `cargo test --workspace` - all tests pass
- [x] Run `cargo clippy --workspace` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)