### PR TITLE
Update Python version from 3.9 to 3.12 in CI workflow

### DIFF
--- a/.github/workflows/CI_py.yml
+++ b/.github/workflows/CI_py.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.9'
+          - python-version: '3.12'
             os: ubuntu-latest
           - python-version: '3.12'
             os: ubuntu-latest


### PR DESCRIPTION
Update Python version in CI workflow matrix from 3.9 to 3.12 to align with other test configurations.