### PR TITLE
docs: add comprehensive documentation to all crates

### DIFF
--- a/crates/matrixci/src/error.rs
+++ b/crates/matrixci/src/error.rs
@@ -8,9 +8,13 @@ pub enum MatrixCIError {
     /// Dimension mismatch between matrix and MatrixCI object
     #[error("Dimension mismatch: expected ({expected_rows}, {expected_cols}), got ({actual_rows}, {actual_cols})")]
     DimensionMismatch {
+        /// Expected number of rows
         expected_rows: usize,
+        /// Expected number of columns
         expected_cols: usize,
+        /// Actual number of rows
         actual_rows: usize,
+        /// Actual number of columns
         actual_cols: usize,
     },
 
@@ -19,19 +23,29 @@ pub enum MatrixCIError {
         "Index out of bounds: ({row}, {col}) is out of bounds for a ({nrows}, {ncols}) matrix"
     )]
     IndexOutOfBounds {
+        /// Row index that was out of bounds
         row: usize,
+        /// Column index that was out of bounds
         col: usize,
+        /// Number of rows in the matrix
         nrows: usize,
+        /// Number of columns in the matrix
         ncols: usize,
     },
 
     /// Duplicate pivot row
     #[error("Cannot add pivot: row {row} already has a pivot")]
-    DuplicatePivotRow { row: usize },
+    DuplicatePivotRow {
+        /// Row index that already has a pivot
+        row: usize,
+    },
 
     /// Duplicate pivot column
     #[error("Cannot add pivot: column {col} already has a pivot")]
-    DuplicatePivotCol { col: usize },
+    DuplicatePivotCol {
+        /// Column index that already has a pivot
+        col: usize,
+    },
 
     /// Matrix is already full rank
     #[error("Cannot find a new pivot: matrix is already full rank")]
@@ -39,11 +53,17 @@ pub enum MatrixCIError {
 
     /// Empty row or column set
     #[error("Cannot find a new pivot in an empty set of {dimension}")]
-    EmptyIndexSet { dimension: String },
+    EmptyIndexSet {
+        /// Description of the empty dimension ("rows" or "columns")
+        dimension: String,
+    },
 
     /// Invalid argument
     #[error("Invalid argument: {message}")]
-    InvalidArgument { message: String },
+    InvalidArgument {
+        /// Description of the invalid argument
+        message: String,
+    },
 
     /// Singular matrix encountered
     #[error("Singular matrix encountered during decomposition")]
@@ -55,7 +75,10 @@ pub enum MatrixCIError {
 
     /// NaN values encountered
     #[error("NaN values encountered in {matrix}")]
-    NaNEncountered { matrix: String },
+    NaNEncountered {
+        /// Name of the matrix where NaN was encountered
+        matrix: String,
+    },
 }
 
 /// Result type for matrix CI operations

--- a/crates/matrixci/src/lib.rs
+++ b/crates/matrixci/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Matrix Cross Interpolation library
 //!
 //! This crate provides matrix cross interpolation algorithms, including:

--- a/crates/matrixci/src/matrixaca.rs
+++ b/crates/matrixci/src/matrixaca.rs
@@ -14,7 +14,7 @@ use crate::util::{
 /// The approximation is stored as:
 /// A ≈ U * diag(alpha) * V
 ///
-/// where alpha[k] = 1/delta[k] for efficiency.
+/// where `alpha[k] = 1/delta[k]` for efficiency.
 #[derive(Debug, Clone)]
 pub struct MatrixACA<T: Scalar> {
     /// Row indices (I set)

--- a/crates/mdarray-einsum/src/error.rs
+++ b/crates/mdarray-einsum/src/error.rs
@@ -2,23 +2,41 @@
 
 use thiserror::Error;
 
+/// Error types for einsum operations.
 #[derive(Debug, Error)]
 pub enum EinsumError {
+    /// Dimension mismatch between operands for the same axis.
     #[error("Dimension mismatch: axis {axis_id:?} has size {size_a} in operand {op_a} but size {size_b} in operand {op_b}")]
     DimensionMismatch {
+        /// The axis identifier where the mismatch occurred.
         axis_id: String,
+        /// The size of the axis in the first operand.
         size_a: usize,
+        /// The size of the axis in the second operand.
         size_b: usize,
+        /// The index of the first operand.
         op_a: usize,
+        /// The index of the second operand.
         op_b: usize,
     },
 
+    /// An output axis was not found in any input operand.
     #[error("Output axis {axis_id:?} not found in any input operand")]
-    OutputAxisNotFound { axis_id: String },
+    OutputAxisNotFound {
+        /// The axis identifier that was not found.
+        axis_id: String,
+    },
 
+    /// The operand list is empty.
     #[error("Empty operand list")]
     EmptyOperands,
 
+    /// An invalid contraction path was specified.
     #[error("Invalid contraction path: index {index} out of bounds for {num_ops} operands")]
-    InvalidPath { index: usize, num_ops: usize },
+    InvalidPath {
+        /// The invalid index in the contraction path.
+        index: usize,
+        /// The number of operands available.
+        num_ops: usize,
+    },
 }

--- a/crates/mdarray-einsum/src/lib.rs
+++ b/crates/mdarray-einsum/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Einstein summation (einsum) for mdarray with ID-based axis specification.
 //!
 //! This crate provides einsum functionality similar to PyTorch's `torch.einsum`,

--- a/crates/mdarray-einsum/src/typed_tensor.rs
+++ b/crates/mdarray-einsum/src/typed_tensor.rs
@@ -13,7 +13,9 @@ type TensorRefWithIds<'a, ID, T> = (&'a [ID], &'a Slice<T, DynRank, mdarray::Den
 /// Enum wrapping either f64 or Complex64 tensor.
 #[derive(Debug, Clone)]
 pub enum TypedTensor {
+    /// A tensor containing f64 (real) values.
     F64(Tensor<f64, DynRank>),
+    /// A tensor containing Complex64 (complex) values.
     C64(Tensor<Complex64, DynRank>),
 }
 

--- a/crates/quanticsgrids/src/error.rs
+++ b/crates/quanticsgrids/src/error.rs
@@ -14,11 +14,21 @@ pub enum QuanticsGridError {
 
     /// Step must be at least 1
     #[error("Step for dimension {dim} must be at least 1, got {value}")]
-    InvalidStep { dim: usize, value: i64 },
+    InvalidStep {
+        /// Dimension index
+        dim: usize,
+        /// The invalid step value
+        value: i64,
+    },
 
     /// Resolution too large (base^R would overflow)
     #[error("Resolution {r} with base {base} is too large (base^R would overflow i64)")]
-    ResolutionTooLarge { r: usize, base: usize },
+    ResolutionTooLarge {
+        /// Resolution value
+        r: usize,
+        /// Base value
+        base: usize,
+    },
 
     /// Variable names must be unique
     #[error("Variable names must be unique, found duplicate: {0}")]
@@ -27,62 +37,120 @@ pub enum QuanticsGridError {
     /// Index table contains unknown variable
     #[error("Index table contains unknown variable '{variable}'. Valid variables: {valid:?}")]
     UnknownVariable {
+        /// The unknown variable name
         variable: String,
+        /// List of valid variable names
         valid: Vec<String>,
     },
 
     /// Index table contains invalid bit number
     #[error("Bit number {bit} for variable '{variable}' exceeds resolution {resolution}")]
     InvalidBitNumber {
+        /// Variable name
         variable: String,
+        /// The invalid bit number
         bit: usize,
+        /// Maximum allowed resolution
         resolution: usize,
     },
 
     /// Index table contains duplicate entry
     #[error("Index table contains duplicate entry for variable '{variable}' bit {bit}")]
-    DuplicateIndexEntry { variable: String, bit: usize },
+    DuplicateIndexEntry {
+        /// Variable name
+        variable: String,
+        /// Bit number
+        bit: usize,
+    },
 
     /// Index table missing entry
     #[error("Index table missing entry for variable '{variable}' bit {bit}")]
-    MissingIndexEntry { variable: String, bit: usize },
+    MissingIndexEntry {
+        /// Variable name
+        variable: String,
+        /// Bit number
+        bit: usize,
+    },
 
     /// Quantics vector has wrong length
     #[error("Quantics vector must have length {expected}, got {actual}")]
-    WrongQuanticsLength { expected: usize, actual: usize },
+    WrongQuanticsLength {
+        /// Expected length
+        expected: usize,
+        /// Actual length
+        actual: usize,
+    },
 
     /// Quantics value out of range
     #[error("Quantics value {value} for site {site} out of range [1, {max}]")]
-    QuanticsOutOfRange { site: usize, value: i64, max: i64 },
+    QuanticsOutOfRange {
+        /// Site index
+        site: usize,
+        /// The out-of-range value
+        value: i64,
+        /// Maximum allowed value
+        max: i64,
+    },
 
     /// Grid index out of bounds
     #[error("Grid index {value} for dimension {dim} out of bounds [1, {max}]")]
-    GridIndexOutOfBounds { dim: usize, value: i64, max: i64 },
+    GridIndexOutOfBounds {
+        /// Dimension index
+        dim: usize,
+        /// The out-of-bounds value
+        value: i64,
+        /// Maximum allowed value
+        max: i64,
+    },
 
     /// Coordinate out of bounds
     #[error("Coordinate {value} for dimension {dim} out of bounds [{lower}, {upper}]")]
     CoordinateOutOfBounds {
+        /// Dimension index
         dim: usize,
+        /// The out-of-bounds coordinate value
         value: f64,
+        /// Lower bound of the valid range
         lower: f64,
+        /// Upper bound of the valid range
         upper: f64,
     },
 
     /// Site index out of bounds
     #[error("Site index {site} out of bounds [0, {max})")]
-    SiteIndexOutOfBounds { site: usize, max: usize },
+    SiteIndexOutOfBounds {
+        /// The out-of-bounds site index
+        site: usize,
+        /// Maximum allowed site index (exclusive)
+        max: usize,
+    },
 
     /// Lower bound must be less than upper bound
     #[error("Lower bound {lower} must be less than upper bound {upper} for dimension {dim}")]
-    InvalidBounds { dim: usize, lower: f64, upper: f64 },
+    InvalidBounds {
+        /// Dimension index
+        dim: usize,
+        /// Lower bound value
+        lower: f64,
+        /// Upper bound value
+        upper: f64,
+    },
 
     /// Cannot include endpoint with zero resolution
     #[error("Cannot include endpoint for dimension {dim} with zero resolution")]
-    EndpointWithZeroResolution { dim: usize },
+    EndpointWithZeroResolution {
+        /// Dimension index
+        dim: usize,
+    },
 
     /// Dimension mismatch
     #[error("Dimension mismatch: expected {expected}, got {actual}")]
-    DimensionMismatch { expected: usize, actual: usize },
+    DimensionMismatch {
+        /// Expected number of dimensions
+        expected: usize,
+        /// Actual number of dimensions
+        actual: usize,
+    },
 
     /// No resolutions specified
     #[error("At least one resolution must be specified")]

--- a/crates/quanticsgrids/src/lib.rs
+++ b/crates/quanticsgrids/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Quantics grid structures for efficient conversion between quantics indices,
 //! grid indices, and original coordinates.
 //!
@@ -142,10 +143,10 @@ pub use inherent_discrete_grid::{InherentDiscreteGrid, InherentDiscreteGridBuild
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UnfoldingScheme {
     /// Each quantics index gets its own tensor core, alternating between variables.
-    /// For variables (a, b) with Rs=(2, 2), produces: [a1], [b1], [a2], [b2]
+    /// For variables (a, b) with Rs=(2, 2), produces: `[a1]`, `[b1]`, `[a2]`, `[b2]`
     Interleaved,
     /// Quantics indices at the same bit level are fused into one tensor core.
-    /// For variables (a, b) with Rs=(2, 2), produces: [b1, a1], [b2, a2]
+    /// For variables (a, b) with Rs=(2, 2), produces: `[b1, a1]`, `[b2, a2]`
     #[default]
     Fused,
 }

--- a/crates/tensor4all-capi/src/lib.rs
+++ b/crates/tensor4all-capi/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! C API for tensor4all Rust implementation
 //!
 //! This crate provides a C-compatible interface to the tensor4all library,
@@ -47,11 +48,17 @@ pub use types::*;
 /// Status code type for C API
 pub type StatusCode = libc::c_int;
 
-// Status codes
+/// Operation completed successfully.
 pub const T4A_SUCCESS: StatusCode = 0;
+/// A null pointer was passed where a valid pointer was required.
 pub const T4A_NULL_POINTER: StatusCode = -1;
+/// An invalid argument was provided.
 pub const T4A_INVALID_ARGUMENT: StatusCode = -2;
+/// Too many tags would be added to a TagSet (exceeds maximum).
 pub const T4A_TAG_OVERFLOW: StatusCode = -3;
+/// A tag string exceeds the maximum allowed length.
 pub const T4A_TAG_TOO_LONG: StatusCode = -4;
+/// The provided output buffer is too small for the result.
 pub const T4A_BUFFER_TOO_SMALL: StatusCode = -5;
+/// An internal error occurred (e.g., a panic was caught).
 pub const T4A_INTERNAL_ERROR: StatusCode = -6;

--- a/crates/tensor4all-capi/src/simplett.rs
+++ b/crates/tensor4all-capi/src/simplett.rs
@@ -12,7 +12,7 @@ use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
 // Opaque handle type
 // ============================================================================
 
-/// Opaque handle for a SimpleTT TensorTrain<f64>
+/// Opaque handle for a SimpleTT `TensorTrain<f64>`
 #[repr(C)]
 pub struct t4a_simplett_f64 {
     _private: *const c_void,

--- a/crates/tensor4all-capi/src/tensorci.rs
+++ b/crates/tensor4all-capi/src/tensorci.rs
@@ -35,7 +35,7 @@ pub type EvalCallback = extern "C" fn(
 // Opaque handle type
 // ============================================================================
 
-/// Opaque handle for TensorCI2<f64>
+/// Opaque handle for `TensorCI2<f64>`
 #[repr(C)]
 pub struct t4a_tci2_f64 {
     _private: *const c_void,

--- a/crates/tensor4all-core/src/defaults/index.rs
+++ b/crates/tensor4all-core/src/defaults/index.rs
@@ -187,8 +187,11 @@ impl TagSetLike for TagSet {
 /// ```
 #[derive(Debug, Clone)]
 pub struct Index<Id, Tags = TagSet> {
+    /// The unique identifier for this index.
     pub id: Id,
+    /// The dimension (size) of this index.
     pub dim: usize,
+    /// The tag set associated with this index.
     pub tags: Tags,
 }
 

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -9,16 +9,17 @@
 //! - [`TensorDynLen`]: Dense tensor with dynamic rank
 //!
 //! Linear algebra operations:
-//! - [`svd`]: Singular Value Decomposition
-//! - [`qr`]: QR decomposition
-//! - [`factorize`]: Unified factorization interface
-//! - [`direct_sum`]: Direct sum of tensors
+//! - [`svd::svd`]: Singular Value Decomposition
+//! - [`qr::qr`]: QR decomposition
+//! - [`factorize::factorize`]: Unified factorization interface
+//! - [`direct_sum::direct_sum`]: Direct sum of tensors
 //!
 //! These types are suitable for most tensor network applications and provide
 //! a good balance of flexibility and performance.
 
 pub mod index;
 pub mod tensor_data;
+/// Dynamic-length tensor implementation.
 pub mod tensordynlen;
 
 // Contraction

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -15,8 +15,10 @@ use thiserror::Error;
 /// Error type for QR operations in tensor4all-linalg.
 #[derive(Debug, Error)]
 pub enum QrError {
+    /// QR computation failed.
     #[error("QR computation failed: {0}")]
     ComputationError(#[from] anyhow::Error),
+    /// Invalid relative tolerance value (must be finite and non-negative).
     #[error("Invalid rtol value: {0}. rtol must be finite and non-negative.")]
     InvalidRtol(f64),
 }

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -17,8 +17,10 @@ use thiserror::Error;
 /// Error type for SVD operations in tensor4all-linalg.
 #[derive(Debug, Error)]
 pub enum SvdError {
+    /// SVD computation failed.
     #[error("SVD computation failed: {0}")]
     ComputationError(#[from] anyhow::Error),
+    /// Invalid relative tolerance value (must be finite and non-negative).
     #[error("Invalid rtol value: {0}. rtol must be finite and non-negative.")]
     InvalidRtol(f64),
 }

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -1676,7 +1676,7 @@ impl TensorDynLen {
         Complex64::extract_dense_view(self.storage()).map_err(|e| anyhow::anyhow!("{}", e))
     }
 
-    /// Convert tensor data to Vec<f64>.
+    /// Convert tensor data to `Vec<f64>`.
     ///
     /// # Returns
     /// A vector containing a copy of the tensor data.
@@ -1687,7 +1687,7 @@ impl TensorDynLen {
         f64::extract_dense(self.storage()).map_err(|e| anyhow::anyhow!("{}", e))
     }
 
-    /// Convert tensor data to Vec<Complex64>.
+    /// Convert tensor data to `Vec<Complex64>`.
     ///
     /// # Returns
     /// A vector containing a copy of the tensor data.

--- a/crates/tensor4all-core/src/index_ops.rs
+++ b/crates/tensor4all-core/src/index_ops.rs
@@ -517,33 +517,45 @@ pub fn common_ind_positions<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> V
 /// - The resulting indices and dimensions after contraction
 #[derive(Debug, Clone)]
 pub struct ContractionSpec<I: IndexLike> {
-    /// Axes to contract from the first tensor (positions in indices_a)
+    /// Axes to contract from the first tensor (positions in `indices_a`).
     pub axes_a: Vec<usize>,
-    /// Axes to contract from the second tensor (positions in indices_b)
+    /// Axes to contract from the second tensor (positions in `indices_b`).
     pub axes_b: Vec<usize>,
-    /// Indices of the result tensor (non-contracted indices from both tensors)
+    /// Indices of the result tensor (non-contracted indices from both tensors).
     pub result_indices: Vec<I>,
-    /// Dimensions of the result tensor
+    /// Dimensions of the result tensor.
     pub result_dims: Vec<usize>,
 }
 
 /// Error type for contraction preparation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContractionError {
-    /// No common indices found for contraction
+    /// No common indices found for contraction.
     NoCommonIndices,
-    /// Dimension mismatch for a common index
+    /// Dimension mismatch for a common index.
     DimensionMismatch {
+        /// Position in the first tensor.
         pos_a: usize,
+        /// Position in the second tensor.
         pos_b: usize,
+        /// Dimension in the first tensor.
         dim_a: usize,
+        /// Dimension in the second tensor.
         dim_b: usize,
     },
-    /// Duplicate axis specified in contraction
-    DuplicateAxis { tensor: &'static str, pos: usize },
-    /// Index not found in tensor
-    IndexNotFound { tensor: &'static str },
-    /// Batch contraction not yet implemented
+    /// Duplicate axis specified in contraction.
+    DuplicateAxis {
+        /// Which tensor has the duplicate ("self" or "other").
+        tensor: &'static str,
+        /// Position of the duplicate axis.
+        pos: usize,
+    },
+    /// Index not found in tensor.
+    IndexNotFound {
+        /// Which tensor the index was not found in.
+        tensor: &'static str,
+    },
+    /// Batch contraction not yet implemented.
     BatchContractionNotImplemented,
 }
 

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -1,8 +1,34 @@
+//! Core tensor operations and types for tensor4all-rs.
+//!
+//! This crate provides the foundational types and operations for tensor networks:
+//!
+//! - **Index types**: [`DynIndex`], [`Index`], [`DynId`] for tensor indices
+//! - **Tag sets**: [`TagSet`], [`TagSetLike`] for metadata tagging
+//! - **Tensors**: [`TensorDynLen`] for dynamic-rank dense tensors
+//! - **Operations**: Contraction, SVD, QR decomposition, factorization
+//!
+//! # Example
+//!
+//! ```
+//! use tensor4all_core::{Index, DynIndex, TensorDynLen};
+//!
+//! // Create indices with dynamic identity
+//! let i = Index::new_dyn(2);
+//! let j = Index::new_dyn(3);
+//!
+//! // Create a tensor
+//! let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+//! let t = TensorDynLen::from_dense_f64(vec![i.clone(), j.clone()], data);
+//! ```
+
+#![warn(missing_docs)]
 // Common (tags, utilities, scalar)
 pub mod global_default;
 pub mod index_like;
 pub mod scalar;
+/// Stack-allocated fixed-capacity string types for ITensors.jl compatibility.
 pub mod smallstring;
+/// Tag set types for tensor metadata.
 pub mod tagset;
 pub mod truncation;
 
@@ -18,7 +44,7 @@ pub use defaults::index;
 pub use defaults::{DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet};
 pub use index_like::{ConjState, IndexLike};
 
-// Index operations (uses defaults::*)
+/// Index operations (replacement, set operations, contraction preparation).
 pub mod index_ops;
 pub use index_ops::{
     check_unique_indices, common_ind_positions, common_inds, hascommoninds, hasind, hasinds,

--- a/crates/tensor4all-core/src/smallstring.rs
+++ b/crates/tensor4all-core/src/smallstring.rs
@@ -82,8 +82,18 @@ pub struct SmallString<const MAX_LEN: usize, C: SmallChar = u16> {
 /// Error type for SmallString operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SmallStringError {
-    TooLong { actual: usize, max: usize },
-    InvalidChar { char_value: char },
+    /// The string exceeds the maximum length.
+    TooLong {
+        /// The actual length of the string.
+        actual: usize,
+        /// The maximum allowed length.
+        max: usize,
+    },
+    /// A character cannot be represented in the target character type.
+    InvalidChar {
+        /// The character that could not be converted.
+        char_value: char,
+    },
 }
 
 impl<const MAX_LEN: usize, C: SmallChar> SmallString<MAX_LEN, C> {

--- a/crates/tensor4all-core/src/tagset.rs
+++ b/crates/tensor4all-core/src/tagset.rs
@@ -131,17 +131,25 @@ pub struct TagSet<const MAX_TAGS: usize, const MAX_TAG_LEN: usize, C: SmallChar 
 /// Error type for TagSet operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TagSetError {
+    /// Too many tags in the tag set (capacity exceeded).
     TooManyTags {
+        /// The actual number of tags attempted.
         actual: usize,
+        /// The maximum allowed tags.
         max: usize,
     },
+    /// A tag is too long.
     TagTooLong {
+        /// The actual length of the tag.
         actual: usize,
+        /// The maximum allowed length.
         max: usize,
     },
+    /// A tag contains invalid characters.
     InvalidTag(SmallStringError),
     /// Tag contains a comma, which is reserved as a separator in from_str.
     TagContainsComma {
+        /// The tag that contains a comma.
         tag: String,
     },
 }

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -26,31 +26,58 @@ use thiserror::Error;
 /// Error type for factorize operations.
 #[derive(Debug, Error)]
 pub enum FactorizeError {
+    /// Factorization computation failed.
     #[error("Factorization failed: {0}")]
-    ComputationError(#[from] anyhow::Error),
+    ComputationError(
+        /// The underlying error
+        #[from]
+        anyhow::Error,
+    ),
+    /// Invalid relative tolerance value (must be finite and non-negative).
     #[error("Invalid rtol value: {0}. rtol must be finite and non-negative.")]
-    InvalidRtol(f64),
+    InvalidRtol(
+        /// The invalid rtol value
+        f64,
+    ),
+    /// The storage type is not supported for this operation.
     #[error("Unsupported storage type: {0}")]
-    UnsupportedStorage(&'static str),
+    UnsupportedStorage(
+        /// Description of the unsupported storage type
+        &'static str,
+    ),
+    /// The canonical direction is not supported for this algorithm.
     #[error("Unsupported canonical direction for this algorithm: {0}")]
-    UnsupportedCanonical(&'static str),
+    UnsupportedCanonical(
+        /// Description of the unsupported canonical direction
+        &'static str,
+    ),
+    /// Error from SVD operation.
     #[error("SVD error: {0}")]
-    SvdError(#[from] crate::svd::SvdError),
+    SvdError(
+        /// The underlying SVD error
+        #[from]
+        crate::svd::SvdError,
+    ),
+    /// Error from QR operation.
     #[error("QR error: {0}")]
-    QrError(#[from] crate::qr::QrError),
+    QrError(
+        /// The underlying QR error
+        #[from]
+        crate::qr::QrError,
+    ),
 }
 
 /// Factorization algorithm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum FactorizeAlg {
-    /// Singular Value Decomposition
+    /// Singular Value Decomposition.
     #[default]
     SVD,
-    /// QR decomposition
+    /// QR decomposition.
     QR,
-    /// Rank-revealing LU decomposition
+    /// Rank-revealing LU decomposition.
     LU,
-    /// Cross Interpolation (LU-based)
+    /// Cross Interpolation (LU-based).
     CI,
 }
 
@@ -431,7 +458,7 @@ pub trait TensorLike: TensorIndex {
     /// Contract multiple tensors that must form a connected graph.
     ///
     /// This is the core contraction method that requires all tensors to be
-    /// connected through contractable indices. Use [`contract`] if you want
+    /// connected through contractable indices. Use [`Self::contract`] if you want
     /// automatic handling of disconnected components via outer product.
     ///
     /// # Arguments

--- a/crates/tensor4all-itensorlike/src/error.rs
+++ b/crates/tensor4all-itensorlike/src/error.rs
@@ -14,23 +14,39 @@ pub enum TensorTrainError {
 
     /// Site index is out of bounds.
     #[error("Site index {site} is out of bounds (tensor train has {length} sites)")]
-    SiteOutOfBounds { site: usize, length: usize },
+    SiteOutOfBounds {
+        /// The requested site index.
+        site: usize,
+        /// The total number of sites in the tensor train.
+        length: usize,
+    },
 
     /// Bond dimension mismatch between adjacent tensors.
     #[error("Bond dimension mismatch at site {site}: left tensor has right dim {left_dim}, right tensor has left dim {right_dim}")]
     BondDimensionMismatch {
+        /// The site index where the mismatch occurred.
         site: usize,
+        /// The right bond dimension of the left tensor.
         left_dim: usize,
+        /// The left bond dimension of the right tensor.
         right_dim: usize,
     },
 
     /// Tensor train does not have a well-defined orthogonality center.
     #[error("Tensor train does not have a well-defined orthogonality center (ortho_lims = {start}..{end})")]
-    NoOrthogonalityCenter { start: usize, end: usize },
+    NoOrthogonalityCenter {
+        /// The start of the orthogonality limits range.
+        start: usize,
+        /// The end of the orthogonality limits range.
+        end: usize,
+    },
 
     /// Invalid tensor structure for tensor train.
     #[error("Invalid tensor structure: {message}")]
-    InvalidStructure { message: String },
+    InvalidStructure {
+        /// A description of the structural issue.
+        message: String,
+    },
 
     /// Factorization error.
     #[error("Factorization error: {0}")]
@@ -38,5 +54,8 @@ pub enum TensorTrainError {
 
     /// General operation error.
     #[error("Operation error: {message}")]
-    OperationError { message: String },
+    OperationError {
+        /// A description of the operation error.
+        message: String,
+    },
 }

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! ITensorMPS.jl-inspired Tensor Train library with orthogonality tracking
 //!
 //! This crate provides a Rust implementation of Tensor Trains (also known as MPS)

--- a/crates/tensor4all-quanticstci/src/lib.rs
+++ b/crates/tensor4all-quanticstci/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! High-level Quantics TCI interface for function interpolation.
 //!
 //! This crate provides a user-friendly interface for interpolating functions

--- a/crates/tensor4all-quanticstransform/src/binaryop.rs
+++ b/crates/tensor4all-quanticstransform/src/binaryop.rs
@@ -17,7 +17,9 @@ use crate::common::{tensortrain_to_linear_operator, BoundaryCondition, QuanticsO
 /// The pair (a, b) = (-1, -1) is not directly supported.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BinaryCoeffs {
+    /// Coefficient for the first variable x. Must be -1, 0, or 1.
     pub a: i8,
+    /// Coefficient for the second variable y. Must be -1, 0, or 1.
     pub b: i8,
 }
 

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Quantics transformation operators for tensor train methods.
 //!
 //! This crate provides LinearOperator constructors for various transformations

--- a/crates/tensor4all-simplett/src/contraction.rs
+++ b/crates/tensor4all-simplett/src/contraction.rs
@@ -35,7 +35,7 @@ impl Default for ContractionOptions {
 impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
     /// Compute the inner product (dot product) of two tensor trains
     ///
-    /// Returns: sum over all indices i of self[i] * other[i]
+    /// Returns: sum over all indices i of self\[i\] * other\[i\]
     pub fn dot(&self, other: &Self) -> Result<T> {
         if self.len() != other.len() {
             return Err(TensorTrainError::InvalidOperation {

--- a/crates/tensor4all-simplett/src/error.rs
+++ b/crates/tensor4all-simplett/src/error.rs
@@ -10,19 +10,30 @@ pub type Result<T> = std::result::Result<T, TensorTrainError>;
 pub enum TensorTrainError {
     /// Dimension mismatch between tensors
     #[error("Dimension mismatch: tensor at site {site} has incompatible dimensions")]
-    DimensionMismatch { site: usize },
+    DimensionMismatch {
+        /// The site index where the mismatch occurred
+        site: usize,
+    },
 
     /// Invalid index provided
     #[error("Index out of bounds: index {index} at site {site} (max: {max})")]
     IndexOutOfBounds {
+        /// The site index where the error occurred
         site: usize,
+        /// The invalid index value
         index: usize,
+        /// The maximum allowed index value
         max: usize,
     },
 
     /// Length mismatch in index set
     #[error("Index set length mismatch: expected {expected}, got {got}")]
-    IndexLengthMismatch { expected: usize, got: usize },
+    IndexLengthMismatch {
+        /// The expected length
+        expected: usize,
+        /// The actual length provided
+        got: usize,
+    },
 
     /// Empty tensor train
     #[error("Tensor train is empty")]
@@ -30,5 +41,8 @@ pub enum TensorTrainError {
 
     /// Invalid operation
     #[error("Invalid operation: {message}")]
-    InvalidOperation { message: String },
+    InvalidOperation {
+        /// Description of the invalid operation
+        message: String,
+    },
 }

--- a/crates/tensor4all-simplett/src/lib.rs
+++ b/crates/tensor4all-simplett/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Tensor Train (MPS) library
 //!
 //! This crate provides tensor train (also known as Matrix Product State) algorithms,

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
@@ -17,9 +17,9 @@ use super::{matrix2_zeros, Matrix2};
 /// compression at each step.
 ///
 /// The zip-up algorithm:
-/// 1. Start from the left with a remainder tensor R = [[1]]
+/// 1. Start from the left with a remainder tensor R = \[\[1\]\]
 /// 2. At each site:
-///    a. Contract R with A[i] and B[i]
+///    a. Contract R with A\[i\] and B\[i\]
 ///    b. Reshape to matrix
 ///    c. Factorize into left and right factors
 ///    d. Store left factor as result tensor

--- a/crates/tensor4all-simplett/src/mpo/contraction.rs
+++ b/crates/tensor4all-simplett/src/mpo/contraction.rs
@@ -209,7 +209,7 @@ where
 
     /// Evaluate the left environment up to site n (exclusive)
     ///
-    /// Returns L[n] = product of sites 0..n
+    /// Returns L\[n\] = product of sites 0..n
     pub fn evaluate_left(&mut self, n: usize, indices: &[(usize, usize)]) -> Result<Matrix2<T>> {
         if n > self.len() {
             return Err(MPOError::InvalidOperation {
@@ -259,7 +259,7 @@ where
 
     /// Evaluate the right environment from site n (exclusive) to the end
     ///
-    /// Returns R[n] = product of sites n..L
+    /// Returns R\[n\] = product of sites n..L
     pub fn evaluate_right(&mut self, n: usize, indices: &[(usize, usize)]) -> Result<Matrix2<T>> {
         let len = self.len();
         if n > len {

--- a/crates/tensor4all-simplett/src/mpo/environment.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment.rs
@@ -115,10 +115,10 @@ where
 
 /// Compute the left environment at site i for MPO contraction
 ///
-/// The left environment L[i] represents the contraction of all sites 0..i
+/// The left environment L\[i\] represents the contraction of all sites 0..i
 /// for the product of two MPOs A and B.
 ///
-/// L[i] has shape (left_a_i, left_b_i) representing the accumulated
+/// L\[i\] has shape (left_a_i, left_b_i) representing the accumulated
 /// contraction from the left.
 pub fn left_environment<T: SVDScalar>(
     mpo_a: &MPO<T>,
@@ -201,10 +201,10 @@ where
 
 /// Compute the right environment at site i for MPO contraction
 ///
-/// The right environment R[i] represents the contraction of all sites i+1..L
+/// The right environment R\[i\] represents the contraction of all sites i+1..L
 /// for the product of two MPOs A and B.
 ///
-/// R[i] has shape (right_a_i, right_b_i) representing the accumulated
+/// R\[i\] has shape (right_a_i, right_b_i) representing the accumulated
 /// contraction from the right.
 pub fn right_environment<T: SVDScalar>(
     mpo_a: &MPO<T>,

--- a/crates/tensor4all-simplett/src/mpo/error.rs
+++ b/crates/tensor4all-simplett/src/mpo/error.rs
@@ -10,33 +10,50 @@ pub type Result<T> = std::result::Result<T, MPOError>;
 pub enum MPOError {
     /// Dimension mismatch between tensors
     #[error("Dimension mismatch: tensor at site {site} has incompatible dimensions")]
-    DimensionMismatch { site: usize },
+    DimensionMismatch {
+        /// The site index where the mismatch occurred
+        site: usize,
+    },
 
     /// Bond dimension mismatch between adjacent tensors
     #[error("Bond dimension mismatch at site {site}: left tensor has right_dim={left_right}, right tensor has left_dim={right_left}")]
     BondDimensionMismatch {
+        /// The site index where the mismatch occurred
         site: usize,
+        /// Right dimension of the left tensor
         left_right: usize,
+        /// Left dimension of the right tensor
         right_left: usize,
     },
 
     /// Shared dimension mismatch between two MPOs
     #[error("Shared dimension mismatch at site {site}: MPO A has site_dim_2={dim_a}, MPO B has site_dim_1={dim_b}")]
     SharedDimensionMismatch {
+        /// The site index where the mismatch occurred
         site: usize,
+        /// Second site dimension of MPO A
         dim_a: usize,
+        /// First site dimension of MPO B
         dim_b: usize,
     },
 
     /// Length mismatch between two MPOs
     #[error("MPO length mismatch: expected {expected}, got {got}")]
-    LengthMismatch { expected: usize, got: usize },
+    LengthMismatch {
+        /// The expected length
+        expected: usize,
+        /// The actual length provided
+        got: usize,
+    },
 
     /// Invalid index provided
     #[error("Index out of bounds: index {index} at site {site} (max: {max})")]
     IndexOutOfBounds {
+        /// The site index where the error occurred
         site: usize,
+        /// The invalid index value
         index: usize,
+        /// The maximum allowed index value
         max: usize,
     },
 
@@ -50,17 +67,33 @@ pub enum MPOError {
 
     /// Invalid orthogonality center
     #[error("Invalid orthogonality center: {center} is out of range [0, {max})")]
-    InvalidCenter { center: usize, max: usize },
+    InvalidCenter {
+        /// The invalid center value
+        center: usize,
+        /// The maximum allowed center value
+        max: usize,
+    },
 
     /// Factorization error
     #[error("Factorization failed: {message}")]
-    FactorizationError { message: String },
+    FactorizationError {
+        /// Description of the factorization failure
+        message: String,
+    },
 
     /// Invalid operation
     #[error("Invalid operation: {message}")]
-    InvalidOperation { message: String },
+    InvalidOperation {
+        /// Description of the invalid operation
+        message: String,
+    },
 
     /// Convergence failure
     #[error("Failed to converge after {sweeps} sweeps (final error: {error})")]
-    ConvergenceFailure { sweeps: usize, error: f64 },
+    ConvergenceFailure {
+        /// The number of sweeps performed before failure
+        sweeps: usize,
+        /// The final error value achieved
+        error: f64,
+    },
 }

--- a/crates/tensor4all-simplett/src/mpo/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mod.rs
@@ -12,9 +12,9 @@
 //!
 //! # Contraction Algorithms
 //!
-//! - [`contract_naive`]: Naive contraction (exact but memory-intensive)
-//! - [`contract_zipup`]: Zip-up contraction with on-the-fly compression
-//! - [`contract_fit`]: Variational fitting algorithm
+//! - [`fn@contract_naive`]: Naive contraction (exact but memory-intensive)
+//! - [`fn@contract_zipup`]: Zip-up contraction with on-the-fly compression
+//! - [`fn@contract_fit`]: Variational fitting algorithm
 //!
 //! # Example
 //!

--- a/crates/tensor4all-simplett/src/mpo/vidal_mpo.rs
+++ b/crates/tensor4all-simplett/src/mpo/vidal_mpo.rs
@@ -11,9 +11,9 @@ use crate::traits::TTScalar;
 /// Vidal canonical form of MPO
 ///
 /// The Vidal form represents the MPO as:
-/// O = Γ[1] · Λ[1] · Γ[2] · Λ[2] · ... · Γ[L]
+/// O = Gamma\[1\] * Lambda\[1\] * Gamma\[2\] * Lambda\[2\] * ... * Gamma\[L\]
 ///
-/// where Γ[i] are tensors and Λ[i] are diagonal matrices of singular values.
+/// where Gamma\[i\] are tensors and Lambda\[i\] are diagonal matrices of singular values.
 #[derive(Debug, Clone)]
 pub struct VidalMPO<T: TTScalar> {
     /// The Gamma tensors (4D tensors with normalized bond indices)

--- a/crates/tensor4all-simplett/src/tensortrain.rs
+++ b/crates/tensor4all-simplett/src/tensortrain.rs
@@ -9,9 +9,9 @@ use crate::types::{tensor3_zeros, Tensor3, Tensor3Ops};
 /// A tensor train represents a high-dimensional tensor as a product of
 /// lower-dimensional tensors:
 ///
-/// T[i1, i2, ..., iL] = A1[i1] * A2[i2] * ... * AL[iL]
+/// T\[i1, i2, ..., iL\] = A1\[i1\] * A2\[i2\] * ... * AL\[iL\]
 ///
-/// where each Ak[ik] is a matrix of shape (rk-1, rk).
+/// where each Ak\[ik\] is a matrix of shape (rk-1, rk).
 #[derive(Debug, Clone)]
 pub struct TensorTrain<T: TTScalar> {
     /// The tensors that make up the tensor train

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Tensor storage and linear algebra backend for tensor4all.
 //!
 //! This crate provides:
@@ -14,9 +15,13 @@
 //! - `backend-lapack`: Use LAPACK for linear algebra operations
 //! - `backend-libtorch`: Enable PyTorch/libtorch backend for tensor operations and autograd
 
+/// Dynamic scalar types supporting f64 and Complex64.
 pub mod any_scalar;
+/// Backend dispatch for SVD and QR operations.
 pub mod backend;
+/// Einstein summation operations.
 pub mod einsum;
+/// Tensor storage types (Dense and Diagonal).
 pub mod storage;
 
 // Torch backend module (feature-gated)

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -408,38 +408,46 @@ fn compute_contraction_permutation(
 pub struct DiagStorage<T>(Vec<T>);
 
 impl<T> DiagStorage<T> {
+    /// Create a new diagonal storage from a vector of diagonal elements.
     pub fn from_vec(vec: Vec<T>) -> Self {
         Self(vec)
     }
 
+    /// Get a slice of the diagonal elements.
     pub fn as_slice(&self) -> &[T] {
         &self.0
     }
 
+    /// Get a mutable slice of the diagonal elements.
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         &mut self.0
     }
 
+    /// Consume the storage and return the underlying vector.
     pub fn into_vec(self) -> Vec<T> {
         self.0
     }
 
+    /// Return the number of diagonal elements.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Return true if the storage has no elements.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
 
 impl<T: Clone> DiagStorage<T> {
+    /// Get a clone of the diagonal element at index `i`.
     pub fn get(&self, i: usize) -> T {
         self.0[i].clone()
     }
 }
 
 impl<T: Copy> DiagStorage<T> {
+    /// Set the diagonal element at index `i` to `val`.
     pub fn set(&mut self, i: usize, val: T) {
         self.0[i] = val;
     }
@@ -766,14 +774,18 @@ fn contract_dense_diag_impl<T: DenseScalar>(
 /// When `backend-libtorch` is enabled, also supports Torch storage for autograd.
 #[derive(Debug, Clone)]
 pub enum Storage {
+    /// Dense storage with f64 elements.
     DenseF64(DenseStorageF64),
+    /// Dense storage with Complex64 elements.
     DenseC64(DenseStorageC64),
+    /// Diagonal storage with f64 elements.
     DiagF64(DiagStorageF64),
+    /// Diagonal storage with Complex64 elements.
     DiagC64(DiagStorageC64),
-    /// Torch tensor storage for f64 (requires `backend-libtorch` feature)
+    /// Torch tensor storage for f64 (requires `backend-libtorch` feature).
     #[cfg(feature = "backend-libtorch")]
     TorchF64(crate::torch::TorchStorage<f64>),
-    /// Torch tensor storage for Complex64 (requires `backend-libtorch` feature)
+    /// Torch tensor storage for Complex64 (requires `backend-libtorch` feature).
     #[cfg(feature = "backend-libtorch")]
     TorchC64(crate::torch::TorchStorage<Complex64>),
 }
@@ -825,6 +837,7 @@ impl DenseStorageFactory for Complex64 {
 ///
 /// This lets callers write `let s: T = tensor.sum();` without matching on storage.
 pub trait SumFromStorage: Sized {
+    /// Compute the sum of all elements in the storage.
     fn sum_from_storage(storage: &Storage) -> Self;
 }
 

--- a/crates/tensor4all-tensorci/src/error.rs
+++ b/crates/tensor4all-tensorci/src/error.rs
@@ -10,19 +10,31 @@ pub type Result<T> = std::result::Result<T, TCIError>;
 pub enum TCIError {
     /// Dimension mismatch
     #[error("Dimension mismatch: {message}")]
-    DimensionMismatch { message: String },
+    DimensionMismatch {
+        /// Description of the dimension mismatch
+        message: String,
+    },
 
     /// Invalid index
     #[error("Index out of bounds: {message}")]
-    IndexOutOfBounds { message: String },
+    IndexOutOfBounds {
+        /// Description of the index error
+        message: String,
+    },
 
     /// Invalid pivot
     #[error("Invalid pivot: {message}")]
-    InvalidPivot { message: String },
+    InvalidPivot {
+        /// Description of the invalid pivot
+        message: String,
+    },
 
     /// Convergence failure
     #[error("Failed to converge after {iterations} iterations")]
-    ConvergenceFailure { iterations: usize },
+    ConvergenceFailure {
+        /// Number of iterations before failure
+        iterations: usize,
+    },
 
     /// Empty tensor train
     #[error("Empty tensor structure")]
@@ -30,7 +42,10 @@ pub enum TCIError {
 
     /// Invalid operation
     #[error("Invalid operation: {message}")]
-    InvalidOperation { message: String },
+    InvalidOperation {
+        /// Description of the invalid operation
+        message: String,
+    },
 
     /// Matrix CI error
     #[error("Matrix CI error: {0}")]

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Tensor Cross Interpolation (TCI) library
 //!
 //! This crate provides tensor cross interpolation algorithms for efficiently

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -1,3 +1,24 @@
+//! Tree Tensor Network (TreeTN) library for tensor4all.
+//!
+//! This crate provides data structures and algorithms for working with tree tensor networks,
+//! a generalization of matrix product states (MPS) to tree-shaped graphs. Tree tensor networks
+//! are useful for representing quantum states and operators on systems with tree-like connectivity.
+//!
+//! # Key Types
+//!
+//! - [`TreeTN`]: The main tree tensor network type, parameterized by tensor and node name types.
+//! - [`DefaultTreeTN`]: A convenient alias for `TreeTN<TensorDynLen, NodeIndex>`.
+//! - [`NamedGraph`]: A graph wrapper that maps node names to internal graph indices.
+//!
+//! # Features
+//!
+//! - **Canonicalization**: Transform networks into canonical forms (unitary, LU, CI).
+//! - **Truncation**: Compress networks using SVD-based truncation.
+//! - **Contraction**: Contract two networks using zip-up or fit algorithms.
+//! - **Linear operators**: Apply and compose linear operators on tree tensor networks.
+//! - **Linear solvers**: Solve linear systems involving tree tensor network operators.
+
+#![warn(missing_docs)]
 pub mod algorithm;
 // dyn_treetn.rs has been removed.
 // TreeTN uses the `T: TensorLike` pattern, making a separate dyn wrapper unnecessary.

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -123,7 +123,7 @@ where
     T: TensorLike,
     V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
 {
-    /// Projected operator (3-chain), wrapped in Arc<RwLock> for GMRES
+    /// Projected operator (3-chain), wrapped in `Arc<RwLock>` for GMRES.
     pub projected_operator: Arc<RwLock<ProjectedOperator<T, V>>>,
     /// Projected state for RHS (2-chain)
     pub projected_state: ProjectedState<T, V>,

--- a/crates/tensor4all-treetn/src/named_graph.rs
+++ b/crates/tensor4all-treetn/src/named_graph.rs
@@ -1,5 +1,5 @@
 //! Named graph wrapper inspired by NamedGraphs.jl
-//! (https://github.com/mtfishman/NamedGraphs.jl)
+//! (<https://github.com/mtfishman/NamedGraphs.jl>)
 //!
 //! Provides a mapping between arbitrary node name types (NodeName) and internal NodeIndex.
 //! This allows using meaningful identifiers (coordinates, strings, etc.) instead of raw indices.
@@ -252,7 +252,7 @@ where
 
     /// Perform an Euler tour traversal starting from the given root NodeIndex.
     ///
-    /// See [`euler_tour_edges`] for details.
+    /// See [`Self::euler_tour_edges`] for details.
     pub fn euler_tour_edges_by_index(&self, root: NodeIndex) -> Vec<(NodeIndex, NodeIndex)> {
         let mut visited_edges: HashSet<(NodeIndex, NodeIndex)> = HashSet::new();
         let mut tour = Vec::new();
@@ -308,7 +308,7 @@ where
 
     /// Perform an Euler tour traversal and return the vertex sequence by NodeIndex.
     ///
-    /// See [`euler_tour_vertices`] for details.
+    /// See [`Self::euler_tour_vertices`] for details.
     pub fn euler_tour_vertices_by_index(&self, root: NodeIndex) -> Vec<NodeIndex> {
         let edges = self.euler_tour_edges_by_index(root);
         if edges.is_empty() {

--- a/crates/tensor4all-treetn/src/treetn/canonicalize.rs
+++ b/crates/tensor4all-treetn/src/treetn/canonicalize.rs
@@ -79,7 +79,7 @@ where
 
     /// Canonicalize the network in-place towards the specified center using options.
     ///
-    /// This is the `&mut self` version of [`canonicalize`].
+    /// This is the `&mut self` version of [`Self::canonicalize`].
     pub fn canonicalize_mut(
         &mut self,
         canonical_center: impl IntoIterator<Item = V>,

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -529,9 +529,9 @@ where
     /// ITensors.jl's MPO zip-up algorithm.
     ///
     /// # Algorithm
-    /// 1. Process leaves: contract A[leaf] * B[leaf], factorize, store R at parent
-    /// 2. Process internal nodes: contract [R_accumulated..., A[node], B[node]], factorize, store R_new at parent
-    /// 3. Process root: contract [R_list..., A[root], B[root]], store as final result
+    /// 1. Process leaves: contract `A[leaf] * B[leaf]`, factorize, store R at parent
+    /// 2. Process internal nodes: contract `[R_accumulated..., A[node], B[node]]`, factorize, store R\_new at parent
+    /// 3. Process root: contract `[R_list..., A[root], B[root]]`, store as final result
     /// 4. Set canonical center
     ///
     /// # Arguments

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -35,8 +35,8 @@ pub struct LocalUpdateStep<V> {
     pub nodes: Vec<V>,
 
     /// The canonical center after this update step.
-    /// For nsite=1: same as nodes[0]
-    /// For nsite=2: the node in the direction of the next step
+    /// For nsite=1: same as `nodes[0]`.
+    /// For nsite=2: the node in the direction of the next step.
     pub new_center: V,
 }
 

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -75,7 +75,7 @@ where
 
     /// Truncate the network in-place towards the specified center using options.
     ///
-    /// This is the `&mut self` version of [`truncate`].
+    /// This is the `&mut self` version of [`Self::truncate`].
     pub fn truncate_mut(
         &mut self,
         canonical_center: impl IntoIterator<Item = V>,


### PR DESCRIPTION
## Summary

- Add `#![warn(missing_docs)]` to all 12 crates to enforce documentation going forward
- Document all public structs, enums, traits, functions, and their fields
- Fix rustdoc warnings: escape bracket notation in math expressions (e.g., `[i]` → `` `i` ``)
- Fix HTML tag warnings by using backticks for generic types (e.g., `<f64>` → `` `f64` ``)
- Fix broken intra-doc links
- Add crate-level documentation to `tensor4all-core` and `tensor4all-treetn`

**Before:** ~238 rustdoc warnings
**After:** 0 warnings

## Test plan

- [x] `cargo doc --workspace --no-deps` - no warnings
- [x] `cargo test --workspace` - all tests pass
- [x] `cargo fmt --all` - formatted
- [x] `cargo clippy --workspace` - no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)