### PR TITLE
Handle permutation and pivot errors safely

### DIFF
--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -70,7 +70,7 @@ pub mod krylov;
 pub use defaults::tensordynlen as tensor;
 
 pub use any_scalar::AnyScalar;
-pub use defaults::tensor_data::{TensorComponent, TensorData};
+pub use defaults::tensor_data::{TensorComponent, TensorData, TensorDataError};
 pub use defaults::tensordynlen::{
     compute_permutation_from_indices, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor,
     unfold_split, TensorAccess, TensorDynLen,

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -704,7 +704,9 @@ fn test_tensor_data_lazy_outer_product_with_permute() {
 
     // Lazy outer product then permute using TensorData directly
     let lazy_result = TensorData::outer_product(&td_a, &td_b);
-    let permuted = lazy_result.permute(&[j.id, i.id]);
+    let permuted = lazy_result
+        .permute(&[j.id, i.id])
+        .expect("permute should succeed");
 
     // Check permuted dimensions
     assert_eq!(permuted.dims(), &[3, 2]);

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -214,7 +214,17 @@ where
         }
 
         // Compute and cache
-        let coords = grid_clone.quantics_to_origcoord(&q_i64).unwrap();
+        let coords = match grid_clone.quantics_to_origcoord(&q_i64) {
+            Ok(coords) => coords,
+            Err(err) => {
+                debug_assert!(
+                    false,
+                    "Quantics index conversion failed for {:?}: {}",
+                    q_i64, err
+                );
+                return V::default();
+            }
+        };
         let value = f(&coords);
         #[allow(clippy::clone_on_copy)]
         cache_clone.borrow_mut().insert(q_i64, value.clone());
@@ -286,6 +296,13 @@ where
     V: Scalar + TTScalar + Default + Clone + 'static,
     F: Fn(&[f64]) -> V + 'static,
 {
+    if xvals.is_empty() {
+        return Err(anyhow!("xvals must not be empty"));
+    }
+    if xvals.iter().any(|x| x.is_empty()) {
+        return Err(anyhow!("xvals must not contain empty dimensions"));
+    }
+
     // Validate inputs
     let dimensions: Vec<f64> = xvals.iter().map(|x| (x.len() as f64).log2()).collect();
 
@@ -304,8 +321,22 @@ where
     }
 
     let rs: Vec<usize> = dimensions.iter().map(|&d| d as usize).collect();
-    let lower: Vec<f64> = xvals.iter().map(|x| *x.first().unwrap()).collect();
-    let upper: Vec<f64> = xvals.iter().map(|x| *x.last().unwrap()).collect();
+    let lower: Vec<f64> = xvals
+        .iter()
+        .map(|x| {
+            x.first()
+                .copied()
+                .ok_or_else(|| anyhow!("xvals must not be empty"))
+        })
+        .collect::<Result<Vec<f64>>>()?;
+    let upper: Vec<f64> = xvals
+        .iter()
+        .map(|x| {
+            x.last()
+                .copied()
+                .ok_or_else(|| anyhow!("xvals must not be empty"))
+        })
+        .collect::<Result<Vec<f64>>>()?;
 
     // Build grid
     let grid = DiscretizedGrid::builder(&rs)

--- a/crates/tensor4all-tensorci/src/error.rs
+++ b/crates/tensor4all-tensorci/src/error.rs
@@ -46,6 +46,12 @@ pub enum TCIError {
         /// Description of the invalid operation
         message: String,
     },
+    /// Internal index inconsistency
+    #[error("Index inconsistency: {message}")]
+    IndexInconsistency {
+        /// Description of the inconsistency
+        message: String,
+    },
 
     /// Matrix CI error
     #[error("Matrix CI error: {0}")]

--- a/crates/tensor4all-tensorci/src/tensorci1.rs
+++ b/crates/tensor4all-tensorci/src/tensorci1.rs
@@ -498,7 +498,7 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
     }
 
     /// Add a pivot row at bond p
-    fn add_pivot_row<F>(&mut self, p: usize, new_i: usize, f: &F)
+    fn add_pivot_row<F>(&mut self, p: usize, new_i: usize, f: &F) -> Result<()>
     where
         F: Fn(&MultiIndex) -> T,
     {
@@ -506,7 +506,13 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
         let _ = self.aca[p].add_pivot_row(&self.pi[p], new_i);
 
         // Add to I set at p+1
-        let new_i_multi = self.pi_i_set[p].get(new_i).unwrap().clone();
+        let new_i_multi =
+            self.pi_i_set[p]
+                .get(new_i)
+                .cloned()
+                .ok_or_else(|| TCIError::IndexInconsistency {
+                    message: format!("Missing pivot row index: bond={}, row={}", p, new_i),
+                })?;
         self.i_set[p + 1].push(new_i_multi);
 
         // Update T[p+1] - get all pivot rows from Pi
@@ -534,10 +540,11 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
         if p < self.len() - 2 {
             self.update_pi_rows(p + 1, f);
         }
+        Ok(())
     }
 
     /// Add a pivot col at bond p
-    fn add_pivot_col<F>(&mut self, p: usize, new_j: usize, f: &F)
+    fn add_pivot_col<F>(&mut self, p: usize, new_j: usize, f: &F) -> Result<()>
     where
         F: Fn(&MultiIndex) -> T,
     {
@@ -545,7 +552,11 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
         let _ = self.aca[p].add_pivot_col(&self.pi[p], new_j);
 
         // Add to J set at p
-        let new_j_multi = self.pi_j_set[p + 1].get(new_j).unwrap().clone();
+        let new_j_multi = self.pi_j_set[p + 1].get(new_j).cloned().ok_or_else(|| {
+            TCIError::IndexInconsistency {
+                message: format!("Missing pivot col index: bond={}, col={}", p, new_j),
+            }
+        })?;
         self.j_set[p].push(new_j_multi);
 
         // Update T[p] - get all pivot columns from Pi
@@ -573,6 +584,7 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
         if p > 0 {
             self.update_pi_cols(p - 1, f);
         }
+        Ok(())
     }
 
     /// Update P matrix at bond p from current I and J sets
@@ -595,12 +607,12 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
     }
 
     /// Add a pivot at bond p
-    fn add_pivot<F>(&mut self, p: usize, f: &F, tolerance: f64)
+    fn add_pivot<F>(&mut self, p: usize, f: &F, tolerance: f64) -> Result<()>
     where
         F: Fn(&MultiIndex) -> T,
     {
         if p >= self.len() - 1 {
-            return;
+            return Ok(());
         }
 
         // Check if we've reached full rank
@@ -608,7 +620,7 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
         let pi_cols = self.pi[p].ncols();
         if self.aca[p].rank() >= pi_rows.min(pi_cols) {
             self.pivot_errors[p] = 0.0;
-            return;
+            return Ok(());
         }
 
         // Find new pivot using ACA
@@ -620,17 +632,18 @@ impl<T: Scalar + TTScalar + Default> TensorCI1<T> {
                 self.pivot_errors[p] = error_val;
 
                 if error_val < tolerance {
-                    return;
+                    return Ok(());
                 }
 
                 // Add pivot column first, then row
-                self.add_pivot_col(p, new_j, f);
-                self.add_pivot_row(p, new_i, f);
+                self.add_pivot_col(p, new_j, f)?;
+                self.add_pivot_row(p, new_i, f)?;
             }
             Err(_) => {
                 self.pivot_errors[p] = 0.0;
             }
         }
+        Ok(())
     }
 
     /// Initialize from function with first pivot
@@ -891,11 +904,11 @@ where
         // Sweep
         if forward_sweep(options.sweep_strategy, iter) {
             for bond_index in 0..n - 1 {
-                tci.add_pivot(bond_index, &f, options.pivot_tolerance);
+                tci.add_pivot(bond_index, &f, options.pivot_tolerance)?;
             }
         } else {
             for bond_index in (0..n - 1).rev() {
-                tci.add_pivot(bond_index, &f, options.pivot_tolerance);
+                tci.add_pivot(bond_index, &f, options.pivot_tolerance)?;
             }
         }
 


### PR DESCRIPTION
## Summary
- make TensorData permutation APIs return Result and validate permutation inputs (length, duplicates, bounds)
- add TensorDataError and re-export it from tensor4all-core
- propagate pivot index inconsistencies in TensorCI1 using a new TCIError variant
- validate quantics input arrays for empties and avoid unwrap in grid coordinate conversion
- update affected tests to handle new Result-returning permute

## Details
- TensorData::permute / permute_by_perm now return Result and emit TensorDataError::InvalidPermutation with messages
- TensorCI1 pivot update steps (add_pivot_row/col/add_pivot) now return Result and bubble up errors to crossinterpolate1
- quanticscrossinterpolate_from_arrays checks for empty xvals or empty dimensions before computing bounds
- quanticscrossinterpolate now guards quantics_to_origcoord failure with debug_assert and Default fallback (should be unreachable)

## Testing
- cargo test -p tensor4all-tensorci
- cargo test -p tensor4all-quanticstci
- cargo test -p tensor4all-core
- cargo clippy -p tensor4all-core -p tensor4all-tensorci -p tensor4all-quanticstci --all-targets -- -D warnings
- cargo llvm-cov --workspace --lcov --output-path /tmp/lcov.info
