### PR TITLE
feat: add ITensorMPS.jl-compatible API to tensor4all-itensorlike

### DIFF
--- a/crates/tensor4all-itensorlike/src/contract.rs
+++ b/crates/tensor4all-itensorlike/src/contract.rs
@@ -1,0 +1,140 @@
+//! Contraction operations for tensor trains.
+//!
+//! This module provides both a free function [`contract`] and an impl method
+//! [`TensorTrain::contract`] for contracting two tensor trains.
+
+use tensor4all_treetn::treetn::contraction::{
+    contract as treetn_contract, ContractionMethod, ContractionOptions as TreeTNContractionOptions,
+};
+use tensor4all_treetn::CanonicalForm;
+
+use crate::error::{Result, TensorTrainError};
+use crate::options::{validate_truncation_params, ContractMethod, ContractOptions};
+use crate::tensortrain::TensorTrain;
+use tensor4all_core::truncation::HasTruncationParams;
+
+/// Contract two tensor trains, returning a new tensor train.
+///
+/// This performs element-wise contraction of corresponding sites,
+/// similar to MPO-MPO contraction in ITensor.
+///
+/// # Arguments
+/// * `a` - The first tensor train
+/// * `b` - The second tensor train
+/// * `options` - Contraction options (method, max_rank, rtol, nhalfsweeps)
+///
+/// # Returns
+/// A new tensor train resulting from the contraction.
+///
+/// # Errors
+/// Returns an error if:
+/// - Either tensor train is empty
+/// - The tensor trains have different lengths
+/// - The contraction algorithm fails
+pub fn contract(
+    a: &TensorTrain,
+    b: &TensorTrain,
+    options: &ContractOptions,
+) -> Result<TensorTrain> {
+    if a.is_empty() || b.is_empty() {
+        return Err(TensorTrainError::InvalidStructure {
+            message: "Cannot contract empty tensor trains".to_string(),
+        });
+    }
+
+    if a.len() != b.len() {
+        return Err(TensorTrainError::InvalidStructure {
+            message: format!(
+                "Tensor trains must have the same length for contraction: {} vs {}",
+                a.len(),
+                b.len()
+            ),
+        });
+    }
+
+    validate_truncation_params(options.truncation_params())?;
+
+    if matches!(options.method(), ContractMethod::Fit) && !options.nhalfsweeps().is_multiple_of(2) {
+        return Err(TensorTrainError::OperationError {
+            message: format!(
+                "nhalfsweeps must be a multiple of 2 for Fit method, got {}",
+                options.nhalfsweeps()
+            ),
+        });
+    }
+
+    // Convert ContractOptions to TreeTN ContractionOptions
+    let treetn_method = match options.method() {
+        ContractMethod::Zipup => ContractionMethod::Zipup,
+        ContractMethod::Fit => ContractionMethod::Fit,
+        ContractMethod::Naive => ContractionMethod::Naive,
+    };
+
+    // Convert nhalfsweeps to nfullsweeps (nhalfsweeps / 2)
+    let nfullsweeps = options.nhalfsweeps() / 2;
+    let treetn_options = TreeTNContractionOptions::new(treetn_method).with_nfullsweeps(nfullsweeps);
+
+    let treetn_options = if let Some(max_rank) = options.max_rank() {
+        treetn_options.with_max_rank(max_rank)
+    } else {
+        treetn_options
+    };
+
+    let treetn_options = if let Some(rtol) = options.rtol() {
+        treetn_options.with_rtol(rtol)
+    } else {
+        treetn_options
+    };
+
+    // Use the last site as the canonical center (consistent with existing behavior)
+    let center = a.len() - 1;
+
+    // For zip-up method, use contract_zipup_tree_accumulated
+    let result_inner = if matches!(options.method(), ContractMethod::Zipup) {
+        a.as_treetn()
+            .contract_zipup_tree_accumulated(
+                b.as_treetn(),
+                &center,
+                CanonicalForm::Unitary,
+                options.rtol(),
+                options.max_rank(),
+            )
+            .map_err(|e| TensorTrainError::InvalidStructure {
+                message: format!("Zip-up contraction failed: {}", e),
+            })?
+    } else {
+        treetn_contract(a.as_treetn(), b.as_treetn(), &center, treetn_options).map_err(|e| {
+            TensorTrainError::InvalidStructure {
+                message: format!("TreeTN contraction failed: {}", e),
+            }
+        })?
+    };
+
+    Ok(TensorTrain::from_inner(
+        result_inner,
+        Some(CanonicalForm::Unitary),
+    ))
+}
+
+impl TensorTrain {
+    /// Contract two tensor trains, returning a new tensor train.
+    ///
+    /// This performs element-wise contraction of corresponding sites,
+    /// similar to MPO-MPO contraction in ITensor.
+    ///
+    /// # Arguments
+    /// * `other` - The other tensor train to contract with
+    /// * `options` - Contraction options (method, max_rank, rtol, nhalfsweeps)
+    ///
+    /// # Returns
+    /// A new tensor train resulting from the contraction.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Either tensor train is empty
+    /// - The tensor trains have different lengths
+    /// - The contraction algorithm fails
+    pub fn contract(&self, other: &Self, options: &ContractOptions) -> Result<Self> {
+        contract(self, other, options)
+    }
+}

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -39,10 +39,28 @@
 //! - Uses `conj` instead of `dag` (no index direction flipping without QN support)
 //! - Each site can have multiple site indices (not just one physical index per site)
 
+pub mod contract;
 pub mod error;
+pub mod linsolve;
 pub mod options;
 pub mod tensortrain;
 
+pub use contract::contract;
 pub use error::{Result, TensorTrainError};
-pub use options::{CanonicalForm, ContractMethod, ContractOptions, TruncateAlg, TruncateOptions};
+pub use linsolve::linsolve;
+pub use options::{
+    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TruncateAlg, TruncateOptions,
+};
 pub use tensortrain::TensorTrain;
+
+/// Type alias for Matrix Product State (MPS).
+///
+/// In ITensors.jl, MPS and MPO share the same underlying type.
+/// Here, both are aliases for [`TensorTrain`].
+pub type MPS = TensorTrain;
+
+/// Type alias for Matrix Product Operator (MPO).
+///
+/// In ITensors.jl, MPS and MPO share the same underlying type.
+/// Here, both are aliases for [`TensorTrain`].
+pub type MPO = TensorTrain;

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -1,0 +1,139 @@
+//! Linear equation solver for tensor trains.
+//!
+//! This module provides the [`linsolve`] function for solving linear systems
+//! of the form `(a₀ + a₁ * A) * x = b` where `A` is an MPO (TensorTrain),
+//! and `x`, `b` are MPS (TensorTrain).
+//!
+//! Internally delegates to [`tensor4all_treetn::square_linsolve`].
+
+use tensor4all_treetn::{square_linsolve, TruncationOptions};
+
+use crate::error::{Result, TensorTrainError};
+use crate::options::{validate_truncation_params, LinsolveOptions};
+use crate::tensortrain::{truncate_alg_to_form, TensorTrain};
+use tensor4all_core::truncation::HasTruncationParams;
+
+/// Solve `(a₀ + a₁ * A) * x = b` for `x`.
+///
+/// # Arguments
+/// * `operator` - The operator `A` (MPO as TensorTrain)
+/// * `rhs` - The right-hand side `b` (MPS as TensorTrain)
+/// * `init` - Initial guess for `x` (MPS as TensorTrain, consumed)
+/// * `options` - Solver options
+///
+/// # Returns
+/// The solution `x` as a TensorTrain.
+///
+/// # Errors
+/// Returns an error if:
+/// - Any tensor train is empty
+/// - `nhalfsweeps` is not a multiple of 2
+/// - The solver fails internally
+pub fn linsolve(
+    operator: &TensorTrain,
+    rhs: &TensorTrain,
+    init: TensorTrain,
+    options: &LinsolveOptions,
+) -> Result<TensorTrain> {
+    if operator.is_empty() || rhs.is_empty() || init.is_empty() {
+        return Err(TensorTrainError::InvalidStructure {
+            message: "Cannot linsolve with empty tensor trains".to_string(),
+        });
+    }
+
+    if !options.nhalfsweeps().is_multiple_of(2) {
+        return Err(TensorTrainError::OperationError {
+            message: format!(
+                "nhalfsweeps must be a multiple of 2, got {}",
+                options.nhalfsweeps()
+            ),
+        });
+    }
+
+    validate_truncation_params(options.truncation_params())?;
+
+    if !options.krylov_tol().is_finite() || options.krylov_tol() <= 0.0 {
+        return Err(TensorTrainError::OperationError {
+            message: format!(
+                "krylov_tol must be finite and > 0, got {}",
+                options.krylov_tol()
+            ),
+        });
+    }
+
+    if options.krylov_maxiter() == 0 {
+        return Err(TensorTrainError::OperationError {
+            message: "krylov_maxiter must be >= 1".to_string(),
+        });
+    }
+
+    if options.krylov_dim() == 0 {
+        return Err(TensorTrainError::OperationError {
+            message: "krylov_dim must be >= 1".to_string(),
+        });
+    }
+
+    if let Some(tol) = options.convergence_tol() {
+        if !tol.is_finite() || tol < 0.0 {
+            return Err(TensorTrainError::OperationError {
+                message: format!("convergence_tol must be finite and >= 0, got {}", tol),
+            });
+        }
+    }
+
+    // Convert LinsolveOptions → treetn::LinsolveOptions
+    let form = truncate_alg_to_form(options.alg());
+    let nfullsweeps = options.nhalfsweeps() / 2;
+
+    let treetn_options = tensor4all_treetn::LinsolveOptions::new(nfullsweeps)
+        .with_truncation(TruncationOptions::new().with_form(form))
+        .with_krylov_tol(options.krylov_tol())
+        .with_krylov_maxiter(options.krylov_maxiter())
+        .with_krylov_dim(options.krylov_dim())
+        .with_coefficients(options.coefficients().0, options.coefficients().1);
+
+    let treetn_options = if let Some(rtol) = options.rtol() {
+        treetn_options.with_rtol(rtol)
+    } else {
+        treetn_options
+    };
+
+    let treetn_options = if let Some(max_rank) = options.max_rank() {
+        treetn_options.with_max_rank(max_rank)
+    } else {
+        treetn_options
+    };
+
+    let treetn_options = if let Some(tol) = options.convergence_tol() {
+        treetn_options.with_convergence_tol(tol)
+    } else {
+        treetn_options
+    };
+
+    // Use the last site as the sweep center
+    let center = init.len() - 1;
+
+    let result = square_linsolve(
+        operator.as_treetn(),
+        rhs.as_treetn(),
+        init.treetn,
+        &center,
+        treetn_options,
+    )
+    .map_err(|e| TensorTrainError::OperationError {
+        message: format!("Linsolve failed: {}", e),
+    })?;
+
+    Ok(TensorTrain::from_inner(result.solution, Some(form)))
+}
+
+impl TensorTrain {
+    /// Solve `(a₀ + a₁ * A) * x = b` for `x`.
+    ///
+    /// `self` is the operator `A`, `rhs` is `b`, `init` is the initial guess.
+    ///
+    /// See [`linsolve`] for details.
+    pub fn linsolve(&self, rhs: &Self, init: Self, options: &LinsolveOptions) -> Result<Self> {
+        linsolve(self, rhs, init, options)
+    }
+}

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -3,11 +3,41 @@
 use std::ops::Range;
 use tensor4all_core::truncation::{HasTruncationParams, TruncationParams};
 
+use crate::error::{Result, TensorTrainError};
+
 // Re-export CanonicalForm from treetn for convenience
 pub use tensor4all_treetn::algorithm::CanonicalForm;
 
 // Re-export DecompositionAlg for convenience
 pub use tensor4all_core::truncation::DecompositionAlg;
+
+pub(crate) fn validate_truncation_params(p: &TruncationParams) -> Result<()> {
+    if let Some(cutoff) = p.cutoff {
+        if !cutoff.is_finite() || cutoff < 0.0 {
+            return Err(TensorTrainError::OperationError {
+                message: format!("cutoff must be finite and >= 0, got {}", cutoff),
+            });
+        }
+    }
+
+    if let Some(rtol) = p.rtol {
+        if !rtol.is_finite() || rtol < 0.0 {
+            return Err(TensorTrainError::OperationError {
+                message: format!("rtol must be finite and >= 0, got {}", rtol),
+            });
+        }
+    }
+
+    if let Some(max_rank) = p.max_rank {
+        if max_rank == 0 {
+            return Err(TensorTrainError::OperationError {
+                message: "max_rank/maxdim must be >= 1".to_string(),
+            });
+        }
+    }
+
+    Ok(())
+}
 
 /// Truncation algorithm.
 ///
@@ -52,15 +82,15 @@ pub type TruncateAlg = DecompositionAlg;
 #[derive(Debug, Clone)]
 pub struct TruncateOptions {
     /// Algorithm to use for truncation.
-    pub alg: TruncateAlg,
+    alg: TruncateAlg,
 
     /// Truncation parameters (rtol, max_rank).
-    pub truncation: TruncationParams,
+    truncation: TruncationParams,
 
     /// Range of sites to truncate (0-indexed, exclusive end).
     ///
     /// If `None`, all bonds are truncated.
-    pub site_range: Option<Range<usize>>,
+    site_range: Option<Range<usize>>,
 }
 
 impl Default for TruncateOptions {
@@ -109,14 +139,30 @@ impl TruncateOptions {
     }
 
     /// Set the relative tolerance for truncation.
+    ///
+    /// Clears any previously set cutoff origin.
     pub fn with_rtol(mut self, rtol: f64) -> Self {
         self.truncation.rtol = Some(rtol);
+        self.truncation.cutoff = None;
         self
     }
 
     /// Set the maximum rank (bond dimension).
     pub fn with_max_rank(mut self, max_rank: usize) -> Self {
         self.truncation.max_rank = Some(max_rank);
+        self
+    }
+
+    /// Set cutoff (ITensorMPS.jl convention). Converted to `rtol = √cutoff`.
+    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
+        self.truncation.cutoff = Some(cutoff);
+        self.truncation.rtol = Some(cutoff.sqrt());
+        self
+    }
+
+    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
+    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
+        self.truncation.max_rank = Some(maxdim);
         self
     }
 
@@ -127,6 +173,26 @@ impl TruncateOptions {
     pub fn with_site_range(mut self, range: Range<usize>) -> Self {
         self.site_range = Some(range);
         self
+    }
+
+    /// Get the truncation algorithm.
+    #[inline]
+    pub fn alg(&self) -> TruncateAlg {
+        self.alg
+    }
+
+    /// Get truncation parameters.
+    ///
+    /// This returns a copy because [`TruncationParams`] is cheap and `Copy`.
+    #[inline]
+    pub fn truncation(&self) -> TruncationParams {
+        self.truncation
+    }
+
+    /// Get the site range for truncation.
+    #[inline]
+    pub fn site_range(&self) -> Option<Range<usize>> {
+        self.site_range.clone()
     }
 
     /// Get rtol (for backwards compatibility).
@@ -171,14 +237,14 @@ pub enum ContractMethod {
 #[derive(Debug, Clone)]
 pub struct ContractOptions {
     /// Contraction method to use.
-    pub method: ContractMethod,
+    method: ContractMethod,
     /// Truncation parameters (rtol, max_rank).
-    pub truncation: TruncationParams,
+    truncation: TruncationParams,
     /// Number of half-sweeps for Fit method.
     ///
     /// A half-sweep visits edges in one direction only (forward or backward).
     /// This must be a multiple of 2 (each full sweep consists of 2 half-sweeps).
-    pub nhalfsweeps: usize,
+    nhalfsweeps: usize,
 }
 
 impl Default for ContractOptions {
@@ -236,8 +302,24 @@ impl ContractOptions {
     }
 
     /// Set relative tolerance.
+    ///
+    /// Clears any previously set cutoff origin.
     pub fn with_rtol(mut self, rtol: f64) -> Self {
         self.truncation.rtol = Some(rtol);
+        self.truncation.cutoff = None;
+        self
+    }
+
+    /// Set cutoff (ITensorMPS.jl convention). Converted to `rtol = √cutoff`.
+    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
+        self.truncation.cutoff = Some(cutoff);
+        self.truncation.rtol = Some(cutoff.sqrt());
+        self
+    }
+
+    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
+    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
+        self.truncation.max_rank = Some(maxdim);
         self
     }
 
@@ -245,15 +327,30 @@ impl ContractOptions {
     ///
     /// # Arguments
     /// * `nhalfsweeps` - Number of half-sweeps (must be a multiple of 2)
-    ///
-    /// # Panics
-    /// Panics if `nhalfsweeps` is not a multiple of 2.
     pub fn with_nhalfsweeps(mut self, nhalfsweeps: usize) -> Self {
-        if !nhalfsweeps.is_multiple_of(2) {
-            panic!("nhalfsweeps must be a multiple of 2, got {}", nhalfsweeps);
-        }
         self.nhalfsweeps = nhalfsweeps;
         self
+    }
+
+    /// Set number of full sweeps (ITensorMPS.jl convention).
+    ///
+    /// A full sweep = 2 half-sweeps (forward + backward).
+    /// Equivalent to `with_nhalfsweeps(nsweeps * 2)`.
+    pub fn with_nsweeps(mut self, nsweeps: usize) -> Self {
+        self.nhalfsweeps = nsweeps * 2;
+        self
+    }
+
+    /// Get the contraction method.
+    #[inline]
+    pub fn method(&self) -> ContractMethod {
+        self.method
+    }
+
+    /// Get number of half-sweeps.
+    #[inline]
+    pub fn nhalfsweeps(&self) -> usize {
+        self.nhalfsweeps
     }
 
     /// Get rtol (for backwards compatibility).
@@ -264,6 +361,216 @@ impl ContractOptions {
     /// Get max_rank (for backwards compatibility).
     pub fn max_rank(&self) -> Option<usize> {
         self.truncation.max_rank
+    }
+}
+
+/// Options for the linear solver.
+///
+/// Solves `(a₀ + a₁ * A) * x = b` using DMRG-like sweeps with local GMRES.
+///
+/// # Example
+///
+/// ```
+/// use tensor4all_itensorlike::LinsolveOptions;
+///
+/// let opts = LinsolveOptions::default()
+///     .with_nsweeps(10)
+///     .with_cutoff(1e-10)
+///     .with_maxdim(100)
+///     .with_krylov_tol(1e-8)
+///     .with_coefficients(1.0, -1.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct LinsolveOptions {
+    /// Number of half-sweeps (must be a multiple of 2).
+    ///
+    /// Default: 10 (= 5 full sweeps).
+    nhalfsweeps: usize,
+    /// Truncation parameters (rtol/cutoff, max_rank/maxdim).
+    truncation: TruncationParams,
+    /// Algorithm for truncation.
+    alg: TruncateAlg,
+    /// GMRES tolerance.
+    krylov_tol: f64,
+    /// Maximum GMRES iterations per local solve.
+    krylov_maxiter: usize,
+    /// Krylov subspace dimension (restart parameter).
+    krylov_dim: usize,
+    /// Coefficient a₀ in (a₀ + a₁ * A) * x = b.
+    a0: f64,
+    /// Coefficient a₁ in (a₀ + a₁ * A) * x = b.
+    a1: f64,
+    /// Convergence tolerance for early termination.
+    ///
+    /// If `Some(tol)`, stop when relative residual < tol.
+    convergence_tol: Option<f64>,
+}
+
+impl Default for LinsolveOptions {
+    fn default() -> Self {
+        Self {
+            nhalfsweeps: 10, // 5 full sweeps
+            truncation: TruncationParams::default(),
+            alg: TruncateAlg::SVD,
+            krylov_tol: 1e-10,
+            krylov_maxiter: 100,
+            krylov_dim: 30,
+            a0: 0.0,
+            a1: 1.0,
+            convergence_tol: None,
+        }
+    }
+}
+
+impl HasTruncationParams for LinsolveOptions {
+    fn truncation_params(&self) -> &TruncationParams {
+        &self.truncation
+    }
+
+    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
+        &mut self.truncation
+    }
+}
+
+impl LinsolveOptions {
+    /// Create options with specified number of full sweeps.
+    pub fn new(nsweeps: usize) -> Self {
+        Self {
+            nhalfsweeps: nsweeps * 2,
+            ..Default::default()
+        }
+    }
+
+    /// Set the relative tolerance for truncation.
+    ///
+    /// Clears any previously set cutoff origin.
+    pub fn with_rtol(mut self, rtol: f64) -> Self {
+        self.truncation.rtol = Some(rtol);
+        self.truncation.cutoff = None;
+        self
+    }
+
+    /// Set the maximum rank (bond dimension).
+    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
+        self.truncation.max_rank = Some(max_rank);
+        self
+    }
+
+    /// Set cutoff (ITensorMPS.jl convention). Converted to `rtol = √cutoff`.
+    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
+        self.truncation.cutoff = Some(cutoff);
+        self.truncation.rtol = Some(cutoff.sqrt());
+        self
+    }
+
+    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
+    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
+        self.truncation.max_rank = Some(maxdim);
+        self
+    }
+
+    /// Set the truncation algorithm.
+    pub fn with_alg(mut self, alg: TruncateAlg) -> Self {
+        self.alg = alg;
+        self
+    }
+
+    /// Set number of half-sweeps.
+    pub fn with_nhalfsweeps(mut self, nhalfsweeps: usize) -> Self {
+        self.nhalfsweeps = nhalfsweeps;
+        self
+    }
+
+    /// Set number of full sweeps (ITensorMPS.jl convention).
+    ///
+    /// A full sweep = 2 half-sweeps (forward + backward).
+    /// Equivalent to `with_nhalfsweeps(nsweeps * 2)`.
+    pub fn with_nsweeps(mut self, nsweeps: usize) -> Self {
+        self.nhalfsweeps = nsweeps * 2;
+        self
+    }
+
+    /// Set GMRES tolerance.
+    pub fn with_krylov_tol(mut self, tol: f64) -> Self {
+        self.krylov_tol = tol;
+        self
+    }
+
+    /// Set maximum GMRES iterations per local solve.
+    pub fn with_krylov_maxiter(mut self, maxiter: usize) -> Self {
+        self.krylov_maxiter = maxiter;
+        self
+    }
+
+    /// Set Krylov subspace dimension (restart parameter).
+    pub fn with_krylov_dim(mut self, dim: usize) -> Self {
+        self.krylov_dim = dim;
+        self
+    }
+
+    /// Set coefficients a₀ and a₁ in (a₀ + a₁ * A) * x = b.
+    pub fn with_coefficients(mut self, a0: f64, a1: f64) -> Self {
+        self.a0 = a0;
+        self.a1 = a1;
+        self
+    }
+
+    /// Set convergence tolerance for early termination.
+    pub fn with_convergence_tol(mut self, tol: f64) -> Self {
+        self.convergence_tol = Some(tol);
+        self
+    }
+
+    /// Get rtol (for convenience).
+    pub fn rtol(&self) -> Option<f64> {
+        self.truncation.rtol
+    }
+
+    /// Get max_rank (for convenience).
+    pub fn max_rank(&self) -> Option<usize> {
+        self.truncation.max_rank
+    }
+
+    /// Get number of half-sweeps.
+    #[inline]
+    pub fn nhalfsweeps(&self) -> usize {
+        self.nhalfsweeps
+    }
+
+    /// Get truncation algorithm.
+    #[inline]
+    pub fn alg(&self) -> TruncateAlg {
+        self.alg
+    }
+
+    /// Get GMRES tolerance.
+    #[inline]
+    pub fn krylov_tol(&self) -> f64 {
+        self.krylov_tol
+    }
+
+    /// Get maximum GMRES iterations per local solve.
+    #[inline]
+    pub fn krylov_maxiter(&self) -> usize {
+        self.krylov_maxiter
+    }
+
+    /// Get Krylov subspace dimension.
+    #[inline]
+    pub fn krylov_dim(&self) -> usize {
+        self.krylov_dim
+    }
+
+    /// Get coefficients (a0, a1).
+    #[inline]
+    pub fn coefficients(&self) -> (f64, f64) {
+        (self.a0, self.a1)
+    }
+
+    /// Get convergence tolerance.
+    #[inline]
+    pub fn convergence_tol(&self) -> Option<f64> {
+        self.convergence_tol
     }
 }
 
@@ -346,15 +653,116 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_contract_options_nhalfsweeps_must_be_multiple_of_2() {
-        // odd nhalfsweeps must panic
-        let _opts = ContractOptions::fit().with_nhalfsweeps(1);
+        // builder should not panic; validation happens at operation entry
+        let opts = ContractOptions::fit().with_nhalfsweeps(1);
+        assert_eq!(opts.nhalfsweeps(), 1);
     }
 
     #[test]
     fn test_contract_method_default() {
         let method: ContractMethod = Default::default();
         assert_eq!(method, ContractMethod::Zipup);
+    }
+
+    #[test]
+    fn test_truncate_options_cutoff() {
+        let opts = TruncateOptions::svd().with_cutoff(1e-10);
+        assert!((opts.rtol().unwrap() - 1e-5).abs() < 1e-15);
+        assert_eq!(opts.truncation.cutoff, Some(1e-10));
+    }
+
+    #[test]
+    fn test_truncate_options_maxdim() {
+        let opts = TruncateOptions::svd().with_maxdim(42);
+        assert_eq!(opts.max_rank(), Some(42));
+    }
+
+    #[test]
+    fn test_contract_options_cutoff() {
+        let opts = ContractOptions::zipup().with_cutoff(1e-8);
+        assert!((opts.rtol().unwrap() - 1e-4).abs() < 1e-15);
+        assert_eq!(opts.truncation.cutoff, Some(1e-8));
+    }
+
+    #[test]
+    fn test_contract_options_maxdim() {
+        let opts = ContractOptions::fit().with_maxdim(30);
+        assert_eq!(opts.max_rank(), Some(30));
+    }
+
+    #[test]
+    fn test_contract_options_nsweeps() {
+        let opts = ContractOptions::fit().with_nsweeps(5);
+        assert_eq!(opts.nhalfsweeps, 10);
+    }
+
+    #[test]
+    fn test_cutoff_rtol_last_wins_truncate() {
+        // cutoff then rtol: rtol wins
+        let opts = TruncateOptions::svd().with_cutoff(1e-10).with_rtol(1e-3);
+        assert_eq!(opts.rtol(), Some(1e-3));
+        assert_eq!(opts.truncation.cutoff, None);
+
+        // rtol then cutoff: cutoff wins
+        let opts = TruncateOptions::svd().with_rtol(1e-3).with_cutoff(1e-10);
+        assert!((opts.rtol().unwrap() - 1e-5).abs() < 1e-15);
+        assert_eq!(opts.truncation.cutoff, Some(1e-10));
+    }
+
+    #[test]
+    fn test_linsolve_options_default() {
+        let opts = LinsolveOptions::default();
+        assert_eq!(opts.nhalfsweeps, 10);
+        assert_eq!(opts.a0, 0.0);
+        assert_eq!(opts.a1, 1.0);
+        assert_eq!(opts.krylov_tol, 1e-10);
+        assert_eq!(opts.krylov_maxiter, 100);
+        assert_eq!(opts.krylov_dim, 30);
+        assert!(opts.convergence_tol.is_none());
+        assert_eq!(opts.rtol(), None);
+        assert_eq!(opts.max_rank(), None);
+    }
+
+    #[test]
+    fn test_linsolve_options_new() {
+        let opts = LinsolveOptions::new(5);
+        assert_eq!(opts.nhalfsweeps(), 10); // 5 full sweeps = 10 half-sweeps
+    }
+
+    #[test]
+    fn test_linsolve_options_builder() {
+        let opts = LinsolveOptions::default()
+            .with_nsweeps(10)
+            .with_cutoff(1e-10)
+            .with_maxdim(100)
+            .with_krylov_tol(1e-8)
+            .with_krylov_maxiter(200)
+            .with_krylov_dim(50)
+            .with_coefficients(1.0, -1.0)
+            .with_convergence_tol(1e-6);
+
+        assert_eq!(opts.nhalfsweeps(), 20);
+        assert!((opts.rtol().unwrap() - 1e-5).abs() < 1e-15);
+        assert_eq!(opts.truncation_params().cutoff, Some(1e-10));
+        assert_eq!(opts.max_rank(), Some(100));
+        assert_eq!(opts.krylov_tol(), 1e-8);
+        assert_eq!(opts.krylov_maxiter(), 200);
+        assert_eq!(opts.krylov_dim(), 50);
+        assert_eq!(opts.coefficients(), (1.0, -1.0));
+        assert_eq!(opts.convergence_tol(), Some(1e-6));
+    }
+
+    #[test]
+    fn test_linsolve_options_nsweeps() {
+        let opts = LinsolveOptions::default().with_nsweeps(3);
+        assert_eq!(opts.nhalfsweeps(), 6);
+    }
+
+    #[test]
+    fn test_linsolve_options_odd_nhalfsweeps_allowed_in_builder() {
+        // builder should not panic; validation happens at operation entry
+        let opts = LinsolveOptions::default().with_nhalfsweeps(3);
+        assert_eq!(opts.nhalfsweeps(), 3);
     }
 }

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -158,11 +158,13 @@ impl PartitionedTT {
                         ))
                     })?;
                     // Truncate after addition using the same truncation params as contraction
-                    let truncate_opts = TruncateOptions {
-                        alg: tensor4all_itensorlike::TruncateAlg::SVD,
-                        truncation: options.truncation,
-                        site_range: None,
-                    };
+                    let mut truncate_opts = TruncateOptions::svd();
+                    if let Some(rtol) = options.rtol() {
+                        truncate_opts = truncate_opts.with_rtol(rtol);
+                    }
+                    if let Some(max_rank) = options.max_rank() {
+                        truncate_opts = truncate_opts.with_max_rank(max_rank);
+                    }
                     summed_tt.truncate(&truncate_opts).map_err(|e| {
                         PartitionedTTError::TensorTrainError(format!(
                             "TT truncation after addition failed: {}",


### PR DESCRIPTION
## Summary
- Add `cutoff`/`maxdim`/`nsweeps` ITensorMPS.jl-compatible parameters alongside existing `rtol`/`max_rank`/`nhalfsweeps` with "last caller wins" semantics for `cutoff` vs `rtol`
- Extract `contract` and `linsolve` into separate modules with free functions + impl methods, add `LinsolveOptions` with full builder pattern
- Add `MPS`/`MPO` type aliases, make options fields private with getters, validate at operation entry points (Result-based instead of builder panics)

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test -p tensor4all-itensorlike -p tensor4all-core` passes (all 88 + 50 unit tests, integration tests, doc-tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)