### PR TITLE
fix: install libhdf5-dev in doc deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install HDF5
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -32,7 +35,7 @@ jobs:
         run: mdbook build docs/book
 
       - name: Build rustdoc
-        run: cargo doc --workspace --no-deps
+        run: cargo xtask doc
 
       - name: Combine documentation
         run: |


### PR DESCRIPTION
## Summary
- Install `libhdf5-dev` in the deploy-docs CI workflow, fixing the build failure introduced when `tensor4all-hdf5` was added (#198)
- Use `cargo xtask doc` instead of plain `cargo doc` to also generate the rustdoc index landing page

## Test plan
- [ ] Verify the deploy-docs workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)