### PR TITLE
deps: upgrade rand 0.8->0.9, ndarray 0.16->0.17 to reduce duplicates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,14 @@ mdarray-linalg-lapack = { git = "https://github.com/grothesque/mdarray-linalg", 
 faer = "0.23"
 faer-traits = "0.23"
 thiserror = "2.0"
-rand = "0.8"
-rand_chacha = "0.3"
-rand_distr = "0.4"
+rand = "0.9"
+rand_chacha = "0.9"
+rand_distr = "0.5"
 petgraph = "0.7"
 dyn-clone = "1.0"
 kryst = { version = "2.4", default-features = false, features = ["rayon", "logging"] }
 omeco = "0.2.1"
 hdf5-metno = { version = "0.12", default-features = false }
+ndarray = "0.17"
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
 

--- a/benchmarks/rust/benchmark_contract.rs
+++ b/benchmarks/rust/benchmark_contract.rs
@@ -8,7 +8,7 @@
 //! Then contracts them using zip-up method with cutoff=0 (no truncation).
 
 use std::time::Instant;
-use rand::thread_rng;
+use rand::rng;
 
 use tensor4all_core::{DynIndex, TensorDynLen};
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, Result, TensorTrain};
@@ -32,7 +32,7 @@ fn create_random_mpo(
     output_indices: &[DynIndex],
     link_indices: &[DynIndex],
 ) -> Result<TensorTrain> {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut tensors = Vec::with_capacity(length);
 
     // Create tensors for each site

--- a/crates/tensor4all-core/README.md
+++ b/crates/tensor4all-core/README.md
@@ -14,7 +14,7 @@ Foundation library providing core data structures and algorithms for tensor oper
 
 ```rust
 use anyhow::Result;
-use rand::thread_rng;
+use rand::rng;
 use tensor4all_core::index::{DynId, Index};
 use tensor4all_core::{factorize, FactorizeOptions, TensorDynLen};
 
@@ -23,7 +23,7 @@ let i = Index::<DynId>::new_dyn_with_tag(3, "i")?;
 let j = Index::<DynId>::new_dyn_with_tag(4, "j")?;
 
 // Create a random tensor
-let mut rng = thread_rng();
+let mut rng = rng();
 let tensor = TensorDynLen::random_f64(&mut rng, vec![i.clone(), j.clone()]);
 
 // SVD factorization with truncation
@@ -42,7 +42,7 @@ The library provides flexible multi-tensor contraction with control over which t
 
 ```rust
 use anyhow::Result;
-use rand::thread_rng;
+use rand::rng;
 use tensor4all_core::index::{DynId, Index};
 use tensor4all_core::{contract_multi, contract_connected, AllowedPairs, TensorDynLen};
 
@@ -52,7 +52,7 @@ let j = Index::<DynId>::new_dyn_with_tag(3, "j")?;
 let k = Index::<DynId>::new_dyn_with_tag(4, "k")?;
 let l = Index::<DynId>::new_dyn_with_tag(5, "l")?;
 
-let mut rng = thread_rng();
+let mut rng = rng();
 let a = TensorDynLen::random_f64(&mut rng, vec![i.clone(), j.clone()]);
 let b = TensorDynLen::random_f64(&mut rng, vec![j.clone(), k.clone()]);
 let c = TensorDynLen::random_f64(&mut rng, vec![k.clone(), l.clone()]);

--- a/crates/tensor4all-core/src/defaults/index.rs
+++ b/crates/tensor4all-core/src/defaults/index.rs
@@ -327,7 +327,7 @@ thread_local! {
     ///
     /// Each thread has its own RNG, similar to ITensors.jl's task-local RNG.
     /// This provides thread-safe ID generation without global synchronization.
-    static ID_RNG: RefCell<rand::rngs::ThreadRng> = RefCell::new(rand::thread_rng());
+    static ID_RNG: RefCell<rand::rngs::ThreadRng> = RefCell::new(rand::rng());
 }
 
 /// Generate a unique random ID for dynamic indices (thread-safe).
@@ -335,7 +335,7 @@ thread_local! {
 /// Uses thread-local random number generator to generate UInt64 IDs,
 /// compatible with ITensors.jl's `IDType = UInt64`.
 pub(crate) fn generate_id() -> u64 {
-    ID_RNG.with(|rng| rng.borrow_mut().gen())
+    ID_RNG.with(|rng| rng.borrow_mut().random())
 }
 
 /// Default Index type alias (same as `Index<Id>` with default tags).

--- a/crates/tensor4all-hdf5/Cargo.toml
+++ b/crates/tensor4all-hdf5/Cargo.toml
@@ -18,7 +18,7 @@ hdf5-metno = { workspace = true, default-features = false, features = ["complex"
 hdf5-rt = { workspace = true, default-features = false, features = ["complex"], optional = true }
 num-complex = { workspace = true }
 anyhow = { workspace = true }
-ndarray = "0.16"
+ndarray = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
@@ -7,7 +7,7 @@
 //!
 //! Then contracts them using zip-up method with cutoff=0 (no truncation).
 
-use rand::thread_rng;
+use rand::rng;
 use std::time::Instant;
 
 use tensor4all_core::{DynIndex, TensorDynLen};
@@ -32,7 +32,7 @@ fn create_random_mpo(
     output_indices: &[DynIndex],
     link_indices: &[DynIndex],
 ) -> Result<TensorTrain> {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut tensors = Vec::with_capacity(length);
 
     // Create tensors for each site

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
@@ -1,6 +1,6 @@
 //! Detailed benchmark with step-by-step timing and comparison with Julia.
 
-use rand::thread_rng;
+use rand::rng;
 use std::time::Instant;
 
 use tensor4all_core::{DynIndex, TensorDynLen};
@@ -15,7 +15,7 @@ fn create_random_mpo(
     output_indices: &[DynIndex],
     link_indices: &[DynIndex],
 ) -> Result<TensorTrain> {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut tensors = Vec::with_capacity(length);
 
     for i in 0..length {

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
@@ -7,7 +7,7 @@
 //!
 //! Then contracts them using fit (variational) method with max_rank=20.
 
-use rand::thread_rng;
+use rand::rng;
 use std::time::Instant;
 
 use tensor4all_core::{DynIndex, TensorDynLen};
@@ -32,7 +32,7 @@ fn create_random_mpo(
     output_indices: &[DynIndex],
     link_indices: &[DynIndex],
 ) -> Result<TensorTrain> {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut tensors = Vec::with_capacity(length);
 
     // Create tensors for each site

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
@@ -1,6 +1,6 @@
 //! Profiled version of benchmark_contract with detailed timing.
 
-use rand::thread_rng;
+use rand::rng;
 use std::time::Instant;
 
 use tensor4all_core::{DynIndex, TensorDynLen};
@@ -15,7 +15,7 @@ fn create_random_mpo(
     output_indices: &[DynIndex],
     link_indices: &[DynIndex],
 ) -> Result<TensorTrain> {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut tensors = Vec::with_capacity(length);
 
     for i in 0..length {

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
@@ -691,9 +691,9 @@ fn create_random_operator_mpo(indices: &SharedIndices, seed: u64) -> anyhow::Res
         for j in 0..in_dim {
             for k in 0..in_dim {
                 if j == k {
-                    data.push(2.0 + rng.gen::<f64>());
+                    data.push(2.0 + rng.random::<f64>());
                 } else {
-                    data.push(0.1 * (rng.gen::<f64>() - 0.5));
+                    data.push(0.1 * (rng.random::<f64>() - 0.5));
                 }
             }
         }

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
@@ -834,10 +834,10 @@ fn create_random_mpo(indices: &SharedIndices, seed: u64) -> anyhow::Result<Tenso
             for k in 0..site_dim {
                 if j == k {
                     // Diagonal: 2.0 + random in [0, 1)
-                    data.push(2.0 + rng.gen::<f64>());
+                    data.push(2.0 + rng.random::<f64>());
                 } else {
                     // Off-diagonal: small random value
-                    data.push(0.1 * (rng.gen::<f64>() - 0.5));
+                    data.push(0.1 * (rng.random::<f64>() - 0.5));
                 }
             }
         }

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -248,9 +248,9 @@ where
     };
 
     // Add random initial pivots (0-indexed for TCI)
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..options.nrandominitpivot {
-        let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.gen_range(0..d)).collect();
+        let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.random_range(0..d)).collect();
         qinitialpivots.push(pivot);
     }
 
@@ -438,9 +438,9 @@ where
     };
 
     // Add random initial pivots (0-indexed for TCI)
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     for _ in 0..options.nrandominitpivot {
-        let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.gen_range(0..d)).collect();
+        let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.random_range(0..d)).collect();
         qinitialpivots.push(pivot);
     }
 

--- a/crates/tensor4all-simplett/benches/cache_overhead.rs
+++ b/crates/tensor4all-simplett/benches/cache_overhead.rs
@@ -21,13 +21,13 @@ fn generate_tci_like_indices(
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
 
     let left_parts: Vec<Vec<usize>> = (0..n_left)
-        .map(|_| (0..split).map(|_| rng.gen_range(0..local_dim)).collect())
+        .map(|_| (0..split).map(|_| rng.random_range(0..local_dim)).collect())
         .collect();
 
     let right_parts: Vec<Vec<usize>> = (0..n_right)
         .map(|_| {
             (0..n_sites - split)
-                .map(|_| rng.gen_range(0..local_dim))
+                .map(|_| rng.random_range(0..local_dim))
                 .collect()
         })
         .collect();
@@ -56,7 +56,7 @@ fn create_tt_with_bond_dim(n_sites: usize, local_dim: usize, bond_dim: usize) ->
         for l in 0..left_dim {
             for s in 0..local_dim {
                 for r in 0..right_dim {
-                    t.set3(l, s, r, rng.gen::<f64>());
+                    t.set3(l, s, r, rng.random::<f64>());
                 }
             }
         }

--- a/crates/tensor4all-treetn/README.md
+++ b/crates/tensor4all-treetn/README.md
@@ -16,7 +16,7 @@ Tree tensor network (TreeTN) implementation for general tensor networks beyond l
 
 ```rust
 use anyhow::Result;
-use rand::thread_rng;
+use rand::rng;
 use tensor4all_core::index::{DynId, Index};
 use tensor4all_core::TensorDynLen;
 use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
@@ -26,7 +26,7 @@ let bond = Index::<DynId>::new_dyn(10);
 let a_site = Index::<DynId>::new_dyn(2);
 let b_site = Index::<DynId>::new_dyn(2);
 
-let mut rng = thread_rng();
+let mut rng = rng();
 let a = TensorDynLen::random_f64(&mut rng, vec![a_site.clone(), bond.clone()]);
 let b = TensorDynLen::random_f64(&mut rng, vec![bond.clone(), b_site.clone()]);
 

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
@@ -34,7 +34,7 @@ fn make_node_name(i: usize) -> String {
 /// Create a DynIndex with a deterministic ID from the seeded RNG.
 fn unique_dyn_index(used: &mut HashSet<DynId>, dim: usize, rng: &mut StdRng) -> DynIndex {
     loop {
-        let id = DynId(rng.gen());
+        let id = DynId(rng.random());
         if used.insert(id) {
             return Index::new(id, dim);
         }

--- a/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
@@ -30,7 +30,7 @@ fn make_node_name(i: usize) -> String {
 /// Create a DynIndex with a deterministic ID from the seeded RNG.
 fn unique_dyn_index(used: &mut HashSet<DynId>, dim: usize, rng: &mut StdRng) -> DynIndex {
     loop {
-        let id = DynId(rng.gen());
+        let id = DynId(rng.random());
         if used.insert(id) {
             return Index::new(id, dim);
         }

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
@@ -97,7 +97,7 @@ fn create_random_mps_chain_with_sites_real_c64(
         let nelem: usize = indices.iter().map(|idx| idx.dim()).product();
         let mut data = Vec::with_capacity(nelem);
         for _ in 0..nelem {
-            let r: f64 = rng.gen();
+            let r: f64 = rng.random();
             data.push(num_complex::Complex64::new(r, 0.0));
         }
         let t = TensorDynLen::from_dense_c64(indices, data);
@@ -141,7 +141,7 @@ fn create_random_mps_chain_with_sites_imag_c64(
         let nelem: usize = indices.iter().map(|idx| idx.dim()).product();
         let mut data = Vec::with_capacity(nelem);
         for _ in 0..nelem {
-            let im: f64 = rng.gen();
+            let im: f64 = rng.random();
             data.push(num_complex::Complex64::new(0.0, im));
         }
         let t = TensorDynLen::from_dense_c64(indices, data);

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -571,7 +571,7 @@ mod tests {
         .unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo = random_treetn_f64(&mut rng, &net, link_space);
 
         let true_s0 = make_index(2);
@@ -616,7 +616,7 @@ mod tests {
         .unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo = random_treetn_f64(&mut rng, &net, link_space);
 
         let arc_op = ArcLinearOperator::new(mpo, HashMap::new(), HashMap::new());
@@ -897,7 +897,7 @@ mod tests {
         .unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo = random_treetn_f64(&mut rng, &net, link_space);
 
         let true_s0 = make_index(2);

--- a/crates/tensor4all-treetn/src/operator/compose.rs
+++ b/crates/tensor4all-treetn/src/operator/compose.rs
@@ -424,7 +424,7 @@ mod tests {
 
         // Create TreeTNs with these networks
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let op1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let op2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -454,7 +454,7 @@ mod tests {
             .unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let op1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let op2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -475,7 +475,7 @@ mod tests {
         op2_net.add_node("N2".to_string(), HashSet::new()).unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let op1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let op2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -548,7 +548,7 @@ mod tests {
 
         // Create TreeTNs for the operators
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -655,7 +655,7 @@ mod tests {
 
         // Create TreeTNs
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -729,7 +729,7 @@ mod tests {
 
         // Create TreeTNs
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -811,7 +811,7 @@ mod tests {
             .unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 
@@ -863,7 +863,7 @@ mod tests {
             .unwrap();
 
         let link_space = LinkSpace::uniform(2);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
         let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
 


### PR DESCRIPTION
## Summary

Closes #216

- Upgrade **rand** ecosystem: `rand` 0.8->0.9, `rand_chacha` 0.3->0.9, `rand_distr` 0.4->0.5
- Upgrade **ndarray** 0.16->0.17 in tensor4all-hdf5 (moved to workspace dependency)
- Migrate all rand API calls: `thread_rng()`->`rng()`, `.gen()`->`.random()`, `.gen_range()`->`.random_range()`

### Duplicates resolved (for workspace-direct usage)
- `rand` 0.8/0.9 -> unified on 0.9
- `rand_chacha` 0.3/0.9 -> unified on 0.9
- `rand_core` 0.6/0.9 -> unified on 0.9
- `rand_distr` 0.4/0.5 -> unified on 0.5
- `getrandom` 0.2/0.3 -> unified on 0.3
- `ndarray` 0.16/0.17 -> unified on 0.17

### Remaining duplicates (upstream)
- `faer` 0.22/0.23 - kryst depends on faer 0.22
- `thiserror` v1/v2 - kryst, sysctl use v1
- `approx` 0.3/0.5, `num-complex` 0.2/0.4 - sprs->alga
- `itertools` 0.10/0.14 - criterion

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets` passes (no warnings)
- [x] `cargo test --workspace` passes
- [x] `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)