### PR TITLE
Add minimal mdBook structure to fix Deploy Documentation CI

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,0 +1,8 @@
+[book]
+title = "tensor4all-rs"
+authors = ["tensor4all contributors"]
+language = "en"
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/tensor4all/tensor4all-rs"

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -1,0 +1,7 @@
+# tensor4all-rs
+
+A Rust implementation of tensor networks.
+
+For API documentation, see the [rustdoc](../rustdoc/index.html).
+
+For source code and development information, see the [GitHub repository](https://github.com/tensor4all/tensor4all-rs).

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,3 @@
+# Summary
+
+[Introduction](README.md)


### PR DESCRIPTION
## Summary
- Add `docs/book/book.toml`, `docs/book/src/SUMMARY.md`, and `docs/book/src/README.md` to provide the minimal mdBook structure required by the Deploy Documentation workflow
- The workflow was failing because `mdbook build docs/book` expected these files but they didn't exist

Closes #222

## Test plan
- [ ] Verify the Deploy Documentation workflow passes on this PR's merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)