### PR TITLE
ci: replace manual cargo cache with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -25,16 +25,7 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-lint-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -51,16 +42,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run tests (non-HDF5)
         run: cargo test --release --workspace --exclude tensor4all-hdf5
@@ -77,16 +59,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-hdf5-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-hdf5-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run HDF5 tests
         run: cargo test --release -p tensor4all-hdf5
@@ -100,16 +73,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-libtorch-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-libtorch-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Cache libtorch
         id: cache-libtorch
@@ -144,19 +108,9 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-cov-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-cov-
+      - uses: Swatinem/rust-cache@v2
 
       - name: Generate coverage report (non-HDF5)
         run: cargo llvm-cov --workspace --exclude tensor4all-hdf5 --lcov --output-path lcov-main.info


### PR DESCRIPTION
## Summary
- Replace verbose `actions/cache@v4` blocks with `Swatinem/rust-cache@v2` one-liner in all 5 Rust CI jobs
- Removes 52 lines of manual cache configuration (path, key, restore-keys)
- Libtorch cache kept as `actions/cache` (not a Rust artifact)

## Test plan
- [ ] CI passes on this PR (the workflow itself is the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)