### PR TITLE
refactor(test): simplify tensor comparisons using isapprox/maxabs

### DIFF
--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -5,7 +5,7 @@ use tensor4all_core::index::Index;
 use tensor4all_core::{
     factorize, Canonical, DynIndex, FactorizeAlg, FactorizeError, FactorizeOptions,
 };
-use tensor4all_core::{storage::DenseStorageF64, Storage, TensorDynLen};
+use tensor4all_core::{storage::DenseStorageF64, Storage, TensorDynLen, TensorLike};
 
 // ============================================================================
 // Test Data Helpers
@@ -270,26 +270,9 @@ fn test_diag_dense_contraction_svd_internals() {
 // ============================================================================
 
 fn assert_tensors_approx_equal(a: &TensorDynLen, b: &TensorDynLen, tol: f64) {
-    assert_eq!(a.dims(), b.dims(), "Tensor dimensions don't match");
-
-    match (a.storage().as_ref(), b.storage().as_ref()) {
-        (Storage::DenseF64(a_data), Storage::DenseF64(b_data)) => {
-            let a_slice = a_data.as_slice();
-            let b_slice = b_data.as_slice();
-            assert_eq!(a_slice.len(), b_slice.len(), "Storage lengths don't match");
-
-            for (i, (&av, &bv)) in a_slice.iter().zip(b_slice.iter()).enumerate() {
-                let diff = (av - bv).abs();
-                assert!(
-                    diff < tol,
-                    "Element {} differs: {} vs {} (diff={})",
-                    i,
-                    av,
-                    bv,
-                    diff
-                );
-            }
-        }
-        _ => panic!("Unsupported storage types for comparison"),
-    }
+    assert!(
+        a.isapprox(b, tol, 0.0),
+        "Tensors differ: maxabs diff = {}",
+        (a - b).maxabs()
+    );
 }

--- a/crates/tensor4all-core/tests/linalg_qr.rs
+++ b/crates/tensor4all-core/tests/linalg_qr.rs
@@ -2,7 +2,7 @@ use num_complex::Complex64;
 use std::sync::Arc;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::{qr, qr_c64};
-use tensor4all_core::{Storage, TensorDynLen};
+use tensor4all_core::{Storage, TensorDynLen, TensorLike};
 
 #[test]
 fn test_qr_identity() {
@@ -123,23 +123,12 @@ fn test_qr_reconstruction() {
     // Check dimensions match
     assert_eq!(reconstructed.dims(), vec![3, 4]);
 
-    // Extract reconstructed data
-    let reconstructed_data_vec = match reconstructed.storage().as_ref() {
-        Storage::DenseF64(dense) => dense.as_slice().to_vec(),
-        _ => panic!("Reconstructed should be dense"),
-    };
-
-    // Check reconstruction accuracy (within tolerance)
-    for (idx, (orig, recon)) in data.iter().zip(reconstructed_data_vec.iter()).enumerate() {
-        assert!(
-            (orig - recon).abs() < 1e-8,
-            "Element {}: original={}, reconstructed={}, diff={}",
-            idx,
-            orig,
-            recon,
-            (orig - recon).abs()
-        );
-    }
+    // Check reconstruction accuracy
+    assert!(
+        tensor.isapprox(&reconstructed, 1e-8, 0.0),
+        "QR reconstruction failed: maxabs diff = {}",
+        (&tensor - &reconstructed).maxabs()
+    );
 }
 
 #[test]

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -2,7 +2,7 @@ use num_complex::Complex64;
 use std::sync::Arc;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::{default_svd_rtol, set_default_svd_rtol, svd, svd_c64, svd_with, SvdOptions};
-use tensor4all_core::{Storage, TensorDynLen};
+use tensor4all_core::{Storage, TensorDynLen, TensorLike};
 
 #[test]
 fn test_svd_identity() {
@@ -158,23 +158,12 @@ fn test_svd_reconstruction() {
     // Check dimensions match
     assert_eq!(reconstructed.dims(), vec![3, 4]);
 
-    // Extract reconstructed data
-    let reconstructed_data_vec = match reconstructed.storage().as_ref() {
-        Storage::DenseF64(dense) => dense.as_slice().to_vec(),
-        _ => panic!("Reconstructed should be dense"),
-    };
-
-    // Check reconstruction accuracy (within tolerance)
-    for (i, (orig, recon)) in data.iter().zip(reconstructed_data_vec.iter()).enumerate() {
-        assert!(
-            (orig - recon).abs() < 1e-8,
-            "Element {}: original={}, reconstructed={}, diff={}",
-            i,
-            orig,
-            recon,
-            (orig - recon).abs()
-        );
-    }
+    // Check reconstruction accuracy
+    assert!(
+        tensor.isapprox(&reconstructed, 1e-8, 0.0),
+        "SVD reconstruction failed: maxabs diff = {}",
+        (&tensor - &reconstructed).maxabs()
+    );
 }
 
 #[test]

--- a/docs/plans/2026-02-15-simplify-test-assertions-design.md
+++ b/docs/plans/2026-02-15-simplify-test-assertions-design.md
@@ -1,0 +1,37 @@
+# Simplify Test Assertions Using isapprox/maxabs (Issue #244)
+
+## Scope
+
+Replace element-wise comparison loops on TensorDynLen with `isapprox`/`maxabs`. Scalar comparisons are out of scope.
+
+## Target pattern
+
+Before:
+```rust
+let data_a = a.to_vec_f64().unwrap();
+let data_b = b.to_vec_f64().unwrap();
+for (i, (&x, &y)) in data_a.iter().zip(data_b.iter()).enumerate() {
+    assert!((x - y).abs() < 1e-10, "...", i, x, y);
+}
+```
+
+After:
+```rust
+assert!(a.isapprox(&b, 1e-10, 0.0));
+```
+
+## Files to update
+
+1. `crates/tensor4all-itensorlike/src/contract.rs` — `assert_matches_naive` helper
+2. `crates/tensor4all-treetn/src/treetn/addition.rs` — `test_add_verifies_with_contraction`
+3. `crates/tensor4all-treetn/tests/ops.rs` — tensor comparison loops
+4. `crates/tensor4all-core/tests/linalg_factorize.rs` — `assert_tensors_approx_equal` helper
+5. `crates/tensor4all-core/tests/linalg_svd.rs` — reconstruction loops
+6. `crates/tensor4all-core/tests/linalg_qr.rs` — reconstruction loops
+7. `crates/tensor4all-core/tests/tensor_basic.rs` — `.iter().zip()` comparisons
+
+## Rules
+
+- Preserve existing tolerance values (don't change `1e-10` to `1e-8` etc.)
+- Only replace tensor-to-tensor comparisons, not scalar result checks
+- Use `isapprox(other, atol, 0.0)` for absolute tolerance patterns


### PR DESCRIPTION
## Summary
- Replace element-wise comparison loops with `TensorLike::isapprox` across 6 test files
- Net: -40 lines (90 added, 130 removed)

## Files changed
- `itensorlike/contract.rs` — `assert_matches_naive` simplified from 15 lines to 5
- `treetn/addition.rs` — element-wise loop replaced with `isapprox` + `axpby`
- `treetn/tests/ops.rs` — `test_to_dense_single_node`, `test_add_two_nodes`
- `core/tests/linalg_factorize.rs` — `assert_tensors_approx_equal` simplified from 12 lines to 4
- `core/tests/linalg_svd.rs` — SVD reconstruction comparison
- `core/tests/linalg_qr.rs` — QR reconstruction comparison

Closes #244

## Test plan
- [x] All workspace tests pass
- [x] No tolerance values changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)