### PR TITLE
feat(capi): capture Rust backtrace in error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ authors = ["tensor4all collaboration"]
 license = "MIT"
 repository = "https://github.com/tensor4all/tensor4all-rs"
 
+[profile.release]
+debug = true  # Include debug info in release builds (enables detailed RUST_BACKTRACE)
+
 [workspace.dependencies]
 num-complex = "0.4"
 num-traits = "0.2"


### PR DESCRIPTION
## Summary
- Capture `std::backtrace::Backtrace` in `set_last_error()` and append it to the stored error message when `RUST_BACKTRACE` is set
- Add `debug = true` to `[profile.release]` so release builds include debug info (file names and line numbers in backtraces)

## Motivation
When errors cross the FFI boundary, Julia users only saw a short error message with no indication of where in Rust the error originated. With this change, `RUST_BACKTRACE=1` produces full Rust stack traces in the error message retrieved via `t4a_last_error_message()`.

## Test plan
- [x] `cargo build --release` shows `[optimized + debuginfo]`
- [x] `RUST_BACKTRACE=1 julia test.jl` shows Rust backtrace with file/line info
- [x] Without `RUST_BACKTRACE`, error messages remain unchanged (no backtrace overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)