### PR TITLE
fix(quanticstransform): shift_mpo Open BC returns one instead of zero for negative full-cycle offsets (issue #269)

### DIFF
--- a/crates/tensor4all-quanticstransform/src/shift.rs
+++ b/crates/tensor4all-quanticstransform/src/shift.rs
@@ -197,11 +197,7 @@ fn shift_mpo(r: usize, offset: i64, bc: BoundaryCondition) -> Result<TensorTrain
         let bc_factor = match bc {
             BoundaryCondition::Periodic => Complex64::one(),
             BoundaryCondition::Open => {
-                if nbc > 0 {
-                    Complex64::zero() // Shifted out of bounds
-                } else {
-                    Complex64::one()
-                }
+                Complex64::zero() // Any full-cycle offset is out of bounds
             }
         };
         mpo.scale(bc_factor);
@@ -283,5 +279,45 @@ mod tests {
     fn test_shift_error_zero_sites() {
         let result = shift_operator(0, 0, BoundaryCondition::Periodic);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_shift_mpo_open_bc_negative_full_cycle_returns_zero() {
+        // offset = -16 with R=4 means nbc = -1 (one full cycle backward)
+        // Open BC should give zero MPO for any full-cycle offset
+        let mpo = shift_mpo(4, -16, BoundaryCondition::Open).unwrap();
+        // scale() applies to last tensor only, so check that contraction gives zero
+        // Evaluate the MPO on all inputs to verify it's the zero operator
+        let last = mpo.site_tensor(mpo.len() - 1);
+        for l in 0..last.left_dim() {
+            for s in 0..last.site_dim() {
+                for r in 0..last.right_dim() {
+                    assert_eq!(
+                        *last.get3(l, s, r),
+                        Complex64::zero(),
+                        "Expected zero in last tensor at ({l},{s},{r})"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_shift_mpo_open_bc_positive_full_cycle_returns_zero() {
+        // offset = 16 with R=4 means nbc = 1 (one full cycle forward)
+        // Open BC should give zero MPO for any full-cycle offset
+        let mpo = shift_mpo(4, 16, BoundaryCondition::Open).unwrap();
+        let last = mpo.site_tensor(mpo.len() - 1);
+        for l in 0..last.left_dim() {
+            for s in 0..last.site_dim() {
+                for r in 0..last.right_dim() {
+                    assert_eq!(
+                        *last.get3(l, s, r),
+                        Complex64::zero(),
+                        "Expected zero in last tensor at ({l},{s},{r})"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -1138,41 +1138,34 @@ fn test_shift_open_boundary() {
     );
 
     // Test cases: (x, offset, expected)
-    // With Open BC, the result depends on whether x + offset_mod causes carry overflow.
+    // With Open BC, the result depends on whether x + offset is in [0, N).
     //
     // Implementation detail:
     // - offset is normalized to offset_mod = offset.rem_euclid(N) in [0, N)
     // - nbc = (offset - offset_mod) / N tracks full cycles
-    // - If nbc > 0 (positive overflow beyond N), entire MPO is zeroed
-    // - If nbc < 0 (negative offset), no global zeroing, but local carry may still zero
+    // - If nbc != 0 (any full cycle), entire MPO is zeroed for Open BC
     // - Local carry overflow at MSB zeros the result via bc_val = 0
     //
     // So for Open BC:
-    // - shift(x, offset) with offset >= 0: result is zero if x + offset >= N
-    // - shift(x, offset) with offset < 0:
-    //   - offset_mod = N + offset (e.g., -1 mod 8 = 7)
-    //   - nbc = -1 (no global zeroing)
-    //   - But x + offset_mod may cause local carry overflow
-    //   - e.g., shift(7, -3): offset_mod = 5, 7 + 5 = 12 >= 8, overflow -> zero
-    //   - e.g., shift(0, -1): offset_mod = 7, 0 + 7 = 7 < 8, no overflow -> result = 7
+    // - shift(x, offset) with nbc != 0: always zero (full cycle out of bounds)
+    // - shift(x, offset) with nbc == 0: zero if x + offset >= N (carry overflow)
     //
     let test_cases: Vec<(usize, i64, Option<usize>)> = vec![
-        // No overflow cases (positive offset)
+        // No overflow cases (positive offset, nbc == 0)
         (0, 0, Some(0)), // 0 + 0 = 0, in range
         (3, 2, Some(5)), // 3 + 2 = 5, in range
         (0, 7, Some(7)), // 0 + 7 = 7, in range
         (1, 3, Some(4)), // 1 + 3 = 4, in range
-        // Overflow cases (positive offset)
+        // Overflow cases (positive offset, nbc == 0)
         (7, 1, None), // 7 + 1 = 8 >= 8, overflow
         (6, 3, None), // 6 + 3 = 9 >= 8, overflow
         (4, 5, None), // 4 + 5 = 9 >= 8, overflow
-        // Negative offset cases
-        // shift(x, -k) -> offset_mod = 8 - k, x + offset_mod >= 8 iff x >= k
-        (0, -1, Some(7)), // offset_mod = 7, 0 + 7 = 7 < 8, no overflow
-        (0, -7, Some(1)), // offset_mod = 1, 0 + 1 = 1 < 8, no overflow
-        (1, -1, None),    // offset_mod = 7, 1 + 7 = 8 >= 8, overflow
-        (2, -1, None),    // offset_mod = 7, 2 + 7 = 9 >= 8, overflow
-        (7, -7, None),    // offset_mod = 1, 7 + 1 = 8 >= 8, overflow
+        // Negative offset cases (all have nbc == -1, so entire MPO is zeroed)
+        (0, -1, None), // nbc = -1, entire MPO zeroed for Open BC
+        (0, -7, None), // nbc = -1, entire MPO zeroed for Open BC
+        (1, -1, None), // nbc = -1, entire MPO zeroed for Open BC
+        (2, -1, None), // nbc = -1, entire MPO zeroed for Open BC
+        (7, -7, None), // nbc = -1, entire MPO zeroed for Open BC
     ];
 
     for (x, offset, expected) in test_cases {


### PR DESCRIPTION
## Summary
- Fixed `shift_mpo` Open BC boundary condition factor to return `Complex64::zero()` for ALL full-cycle offsets (both positive and negative `nbc`)
- Previously, negative `nbc` with Open BC returned `Complex64::one()`, causing incorrect non-zero results
- Updated integration test expectations: negative offset cases with `nbc != 0` now correctly expect zero under Open BC

Closes #269

## Test plan
- [x] Added failing test first (TDD)
- [x] Fix applied
- [x] All crate tests pass with `cargo nextest run --release`
- [x] `cargo fmt --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)