### PR TITLE
fix(qr): use row-norm relative comparison for QR rank truncation

### DIFF
--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -206,7 +206,8 @@ fn compute_retained_rank_qr_from_storage(
 /// The input tensor can have any rank >= 2, and indices are split into left and right groups.
 /// The tensor is unfolded into a matrix by grouping left indices as rows and right indices as columns.
 ///
-/// Truncation is performed based on R's diagonal elements: columns with |R[i, i]| < rtol are truncated.
+/// Truncation is performed based on R's row norms: rows whose norm is below
+/// `rtol * max_row_norm` are discarded.
 ///
 /// For the mathematical convention:
 /// \[ A = Q * R \]
@@ -257,7 +258,8 @@ where
 /// The input tensor can have any rank >= 2, and indices are split into left and right groups.
 /// The tensor is unfolded into a matrix by grouping left indices as rows and right indices as columns.
 ///
-/// Truncation is performed based on R's diagonal elements: columns with |R[i, i]| < rtol are truncated.
+/// Truncation is performed based on R's row norms: rows whose norm is below
+/// `rtol * max_row_norm` are discarded.
 ///
 /// For the mathematical convention:
 /// \[ A = Q * R \]

--- a/crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs
@@ -137,7 +137,7 @@ fn test_truncate_drops_significant_singular_values() {
     let rel_err = diff.norm() / f_dense_before.norm();
     eprintln!("rel_err = {:.6e}", rel_err);
 
-    // truncate with rtol=0.0 also gives wrong results!
+    // truncate with rtol=0.0 should also preserve the function
     let mut f_trunc0 = f.clone();
     f_trunc0
         .truncate(&TruncateOptions::svd().with_rtol(0.0))
@@ -148,13 +148,13 @@ fn test_truncate_drops_significant_singular_values() {
         .unwrap();
     let rel_err_0 = diff_0.norm() / f_dense_before.norm();
     eprintln!(
-        "truncate(rtol=0.0): bonds={:?} rel_err={:.6e} (also wrong!)",
+        "truncate(rtol=0.0): bonds={:?} rel_err={:.6e}",
         bond_dims(&f_trunc0),
         rel_err_0
     );
     assert!(
         rel_err_0 < 1e-12,
-        "truncate(rtol=0.0) also changed the function! rel_err={:.6e}",
+        "truncate(rtol=0.0) changed the function! rel_err={:.6e}",
         rel_err_0,
     );
 


### PR DESCRIPTION
## Summary

- Fix `compute_retained_rank_qr_from_storage` to use row-norm relative comparison (matching the non-native path), instead of absolute diagonal comparison with early break
- This fixes `orthogonalize`/`canonicalize`/`truncate` silently dropping significant components from TTs with zero-coefficient bonds (e.g., from `axpby` with a zero term)
- Fix zipup test to compare dense representations, avoiding catastrophic cancellation in TT-arithmetic norm computation

## Root Cause

The native QR path had two bugs:
1. Compared `|R[i,i]| < rtol` (absolute) instead of row-norm relative comparison
2. Broke at the first small diagonal — incorrect for non-pivoted QR where diagonals like `[nonzero, 0, nonzero]` are possible

## Test plan

- [x] All 3 tests in `bug_zipup_inflated_bonds.rs` pass (previously all 3 failed)
- [x] All existing tests in `tensor4all-core`, `tensor4all-treetn`, `tensor4all-itensorlike` pass
- [x] `cargo fmt --all` and `cargo clippy` clean

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)