### PR TITLE
feat: add solve-bug automation entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ A Rust implementation of tensor networks for **AI-agentic development** — rapi
 | tensor4all-rs | `rtol` | — |
 | ITensors.jl | `cutoff` | `rtol = √cutoff` |
 
+## Solve-Bug Entrypoints
+
+Use `bash ai/run-codex-solve-bug.sh` or `bash ai/run-claude-solve-bug.sh` when you want a headless agent to pick one actionable bug or bug-like issue, fix it, and drive the repository-local PR workflow.
+
+If there are effectively no open bug or bug-like issues, the workflow should terminate cleanly with no code changes and no PR creation.
+
 ## Project Structure
 
 ```

--- a/ai/run-claude-solve-bug.sh
+++ b/ai/run-claude-solve-bug.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: run-claude-solve-bug.sh [options] [-- <extra claude args>]
+
+Run Claude Code headlessly from the repository root using a prompt file under ai/.
+
+Options:
+  --prompt PATH   Prompt file. Relative paths are resolved from this script's directory.
+                  Default: solve_bug_issue.md
+  --model MODEL   Pass --model MODEL to claude.
+  --run-dir PATH  Directory for logs.
+                  Default: a fresh temporary directory.
+  --text          Disable stream-json output and print plain text instead.
+  -h, --help      Show this help.
+EOF
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+
+prompt_arg="solve_bug_issue.md"
+model=""
+run_dir=""
+json_mode=1
+extra_args=()
+
+while (($# > 0)); do
+  case "$1" in
+    --prompt)
+      prompt_arg="${2:?missing value for --prompt}"
+      shift 2
+      ;;
+    --model)
+      model="${2:?missing value for --model}"
+      shift 2
+      ;;
+    --run-dir)
+      run_dir="${2:?missing value for --run-dir}"
+      shift 2
+      ;;
+    --text)
+      json_mode=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      extra_args=("$@")
+      break
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$prompt_arg" = /* ]]; then
+  prompt_path="$prompt_arg"
+else
+  prompt_path="$script_dir/$prompt_arg"
+fi
+
+if [[ ! -f "$prompt_path" ]]; then
+  echo "prompt file not found: $prompt_path" >&2
+  exit 1
+fi
+
+if [[ -z "$run_dir" ]]; then
+  run_dir="$(mktemp -d "${TMPDIR:-/tmp}/claude-solve-bug.XXXXXX")"
+else
+  mkdir -p "$run_dir"
+  run_dir="$(cd -- "$run_dir" && pwd -P)"
+fi
+
+log_path="$run_dir/output.log"
+if ((json_mode)); then
+  log_path="$run_dir/events.jsonl"
+fi
+
+prompt_text="$(cat "$prompt_path")"
+
+cmd=(
+  claude
+  --print
+  --dangerously-skip-permissions
+)
+
+if ((json_mode)); then
+  cmd+=(--output-format stream-json)
+else
+  cmd+=(--output-format text)
+fi
+
+if [[ -n "$model" ]]; then
+  cmd+=(--model "$model")
+fi
+
+cmd+=("${extra_args[@]}" "$prompt_text")
+
+echo "repo_root=$repo_root"
+echo "prompt_path=$prompt_path"
+echo "run_dir=$run_dir"
+echo "log_path=$log_path"
+
+(
+  cd "$repo_root"
+  "${cmd[@]}"
+) | tee "$log_path"

--- a/ai/run-codex-solve-bug.sh
+++ b/ai/run-codex-solve-bug.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: run-codex-solve-bug.sh [options] [-- <extra codex args>]
+
+Run Codex headlessly from the repository root using a prompt file under ai/.
+
+Options:
+  --prompt PATH   Prompt file. Relative paths are resolved from this script's directory.
+                  Default: solve_bug_issue.md
+  --model MODEL   Pass --model MODEL to codex exec.
+  --run-dir PATH  Directory for logs and final message output.
+                  Default: a fresh temporary directory.
+  --text          Disable JSONL output and stream plain Codex terminal output instead.
+  -h, --help      Show this help.
+EOF
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+
+prompt_arg="solve_bug_issue.md"
+model=""
+run_dir=""
+json_mode=1
+extra_args=()
+
+while (($# > 0)); do
+  case "$1" in
+    --prompt)
+      prompt_arg="${2:?missing value for --prompt}"
+      shift 2
+      ;;
+    --model)
+      model="${2:?missing value for --model}"
+      shift 2
+      ;;
+    --run-dir)
+      run_dir="${2:?missing value for --run-dir}"
+      shift 2
+      ;;
+    --text)
+      json_mode=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      extra_args=("$@")
+      break
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$prompt_arg" = /* ]]; then
+  prompt_path="$prompt_arg"
+else
+  prompt_path="$script_dir/$prompt_arg"
+fi
+
+if [[ ! -f "$prompt_path" ]]; then
+  echo "prompt file not found: $prompt_path" >&2
+  exit 1
+fi
+
+if [[ -z "$run_dir" ]]; then
+  run_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-solve-bug.XXXXXX")"
+else
+  mkdir -p "$run_dir"
+  run_dir="$(cd -- "$run_dir" && pwd -P)"
+fi
+
+log_path="$run_dir/output.log"
+last_message_path="$run_dir/final.txt"
+
+cmd=(
+  codex exec
+  --cd "$repo_root"
+  --dangerously-bypass-approvals-and-sandbox
+  --output-last-message "$last_message_path"
+)
+
+if ((json_mode)); then
+  cmd+=(--json)
+  log_path="$run_dir/events.jsonl"
+fi
+
+if [[ -n "$model" ]]; then
+  cmd+=(--model "$model")
+fi
+
+cmd+=("${extra_args[@]}" -)
+
+echo "repo_root=$repo_root"
+echo "prompt_path=$prompt_path"
+echo "run_dir=$run_dir"
+echo "log_path=$log_path"
+echo "last_message_path=$last_message_path"
+
+"${cmd[@]}" < "$prompt_path" | tee "$log_path"

--- a/ai/solve_bug_issue.md
+++ b/ai/solve_bug_issue.md
@@ -1,0 +1,24 @@
+You are running one iteration of an automated bug-fix workflow for this repository.
+
+Your job is to:
+
+1. Inspect open bug and bug-like issues.
+2. Choose exactly one actionable workstream.
+3. If open bug / bug-like issues are effectively zero, terminate cleanly with no code changes and no PR creation. In other words, if there are effectively no open bug or bug-like issues, leave the repository untouched and summarize that no worthwhile bug or bug-like issue was available.
+4. Otherwise, fix the issue or close it only when it is clearly irrelevant, duplicate, or already fixed.
+5. Use the repository-local PR helpers:
+   - `bash scripts/create-pr.sh`
+   - `bash scripts/monitor-pr-checks.sh`
+6. Continue until merge or a defined stop condition.
+7. Restore the local checkout as part of normal cleanup.
+
+Hard rules:
+
+- Work from the latest `origin/main`.
+- Use a dedicated worktree only after selecting a real candidate.
+- Do not touch unrelated work.
+- Stop after two core fix attempts.
+- Do not ask the user questions.
+- Do not create a PR if there is nothing actionable to fix.
+
+When you terminate cleanly without action, summarize that no worthwhile bug or bug-like issue was available and that no code was changed.

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="main"
+TITLE=""
+BODY_FILE=""
+AUTO_MERGE=1
+DRAFT=0
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/create-pr.sh [options]
+
+Options:
+  --base BRANCH          Base branch for the pull request (default: main)
+  --title TITLE          Pull request title (defaults to the latest commit subject)
+  --body-file PATH       Markdown body file to pass to gh pr create
+  --no-auto-merge        Do not enable auto-merge after PR creation
+  --draft                Create the PR as a draft
+  --help                 Show this help text
+EOF
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    log "missing required command: $1"
+    exit 1
+  fi
+}
+
+require_clean_tree() {
+  if [[ -n "$(git status --short)" ]]; then
+    log "working tree is not clean"
+    exit 1
+  fi
+}
+
+ensure_body_file() {
+  if [[ -n "$BODY_FILE" ]]; then
+    return
+  fi
+
+  BODY_FILE="$(mktemp)"
+  trap 'rm -f "$BODY_FILE"' EXIT
+  {
+    printf '## Summary\n\n'
+    git log --format='- %s' "${BASE_BRANCH}..HEAD" 2>/dev/null || true
+    printf '\n## Verification\n\n'
+    printf -- '- `cargo fmt --all`\n'
+    printf -- '- `cargo clippy --workspace`\n'
+    printf -- '- `cargo nextest run --release --workspace`\n'
+  } >"$BODY_FILE"
+}
+
+run_required_checks() {
+  cargo fmt --all
+  cargo clippy --workspace
+  cargo nextest run --release --workspace
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE_BRANCH="$2"
+      shift 2
+      ;;
+    --title)
+      TITLE="$2"
+      shift 2
+      ;;
+    --body-file)
+      BODY_FILE="$2"
+      shift 2
+      ;;
+    --no-auto-merge)
+      AUTO_MERGE=0
+      shift
+      ;;
+    --draft)
+      DRAFT=1
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+current_branch="$(git branch --show-current)"
+if [[ -z "$current_branch" ]]; then
+  log "not on a named branch"
+  exit 1
+fi
+if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
+  log "refusing to create a PR from ${current_branch}"
+  exit 1
+fi
+
+require_clean_tree
+require_command gh
+
+run_required_checks
+if [[ -n "$(git status --short)" ]]; then
+  log "verification modified the working tree; commit those changes before creating a PR"
+  exit 1
+fi
+
+if [[ -z "$TITLE" ]]; then
+  TITLE="$(git log -1 --format=%s)"
+fi
+
+ensure_body_file
+if git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
+  git push
+else
+  git push -u origin "$current_branch"
+fi
+
+create_args=(pr create --base "$BASE_BRANCH" --title "$TITLE" --body-file "$BODY_FILE")
+if [[ "$DRAFT" -eq 1 ]]; then
+  create_args+=(--draft)
+fi
+
+pr_url="$(gh "${create_args[@]}")"
+log "$pr_url"
+
+if [[ "$AUTO_MERGE" -eq 1 ]]; then
+  gh pr merge --auto --squash --delete-branch "$pr_url"
+fi
+
+log "monitoring required PR checks every 30 seconds"
+bash scripts/monitor-pr-checks.sh "$pr_url" --interval 30

--- a/scripts/monitor-pr-checks.sh
+++ b/scripts/monitor-pr-checks.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PR_REF=""
+INTERVAL=30
+REPO=""
+
+usage() {
+  cat <<'EOF'
+Usage: bash scripts/monitor-pr-checks.sh [pr-number|pr-url|branch] [options]
+
+Options:
+  --interval SECONDS      Poll interval in seconds (default: 30)
+  --repo OWNER/REPO       Repository override for gh commands
+  --help                  Show this help text
+EOF
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+gh_pr_checks() {
+  local args=(pr checks --required --json name,state,link,bucket,workflow)
+  if [[ -n "$PR_REF" ]]; then
+    args+=("$PR_REF")
+  fi
+  if [[ -n "$REPO" ]]; then
+    args+=(-R "$REPO")
+  fi
+  gh "${args[@]}"
+}
+
+classify_checks() {
+  python3 -c '
+import json
+import re
+import sys
+
+checks = json.load(sys.stdin)
+if not isinstance(checks, list):
+    raise SystemExit("expected a JSON list from gh pr checks")
+
+if not checks:
+    print("status\tpending")
+    print("summary\tno required checks reported yet")
+    raise SystemExit(0)
+
+failures = []
+pending = []
+
+for item in checks:
+    name = item.get("name") or "<unnamed>"
+    workflow = item.get("workflow") or ""
+    bucket = item.get("bucket") or ""
+    link = item.get("link") or ""
+    state = item.get("state") or ""
+
+    if bucket in {"fail", "cancel"}:
+        failures.append((name, workflow, link, state))
+        continue
+    if bucket in {"pass", "skipping"}:
+        continue
+    pending.append((name, workflow, link, state, bucket))
+
+if failures:
+    print("status\tfail")
+    for name, workflow, link, state in failures:
+        run_id = ""
+        match = re.search(r"/runs/([0-9]+)", link or "")
+        if match:
+            run_id = match.group(1)
+        print("failure\t{}\t{}\t{}\t{}\t{}".format(name, workflow, link, state, run_id))
+    raise SystemExit(0)
+
+if pending:
+    print("status\tpending")
+    print("summary\tpending checks: " + ", ".join(name for name, *_ in pending))
+    raise SystemExit(0)
+
+print("status\tpass")
+print("summary\tall required checks passed")
+'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval)
+      INTERVAL="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "$PR_REF" ]]; then
+        log "unexpected argument: $1"
+        usage
+        exit 1
+      fi
+      PR_REF="$1"
+      shift
+      ;;
+  esac
+done
+
+while true; do
+  checks_json="$(gh_pr_checks)"
+  parsed_output="$(printf '%s' "$checks_json" | classify_checks)"
+
+  status=""
+  summary=""
+  while IFS=$'\t' read -r record_type field1 field2 field3 field4 field5; do
+    case "$record_type" in
+      status)
+        status="$field1"
+        ;;
+      summary)
+        summary="$field1"
+        ;;
+      failure)
+        log "failed check: $field1"
+        if [[ -n "$field2" ]]; then
+          log "workflow: $field2"
+        fi
+        if [[ -n "$field3" ]]; then
+          log "details: $field3"
+        fi
+        if [[ -n "$field5" ]]; then
+          log "inspect logs: gh run view $field5 --log-failed"
+        else
+          if [[ -n "$PR_REF" ]]; then
+            log "inspect checks: gh pr checks $PR_REF --required"
+          else
+            log "inspect checks: gh pr checks --required"
+          fi
+        fi
+        ;;
+      *)
+        ;;
+    esac
+  done <<<"$parsed_output"
+
+  case "$status" in
+    pass)
+      log "${summary:-all required checks passed}"
+      exit 0
+      ;;
+    fail)
+      if [[ -n "$PR_REF" ]]; then
+        log "after fixing the failure locally, push and rerun: bash scripts/monitor-pr-checks.sh $PR_REF --interval $INTERVAL"
+      else
+        log "after fixing the failure locally, push and rerun: bash scripts/monitor-pr-checks.sh --interval $INTERVAL"
+      fi
+      exit 1
+      ;;
+    pending)
+      log "${summary:-waiting for required checks}"
+      sleep "$INTERVAL"
+      ;;
+    *)
+      log "unexpected monitor status: ${status:-<empty>}"
+      exit 1
+      ;;
+  esac
+done

--- a/tests/test_solve_bug_entrypoints.py
+++ b/tests/test_solve_bug_entrypoints.py
@@ -1,0 +1,133 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_CODEX = REPO_ROOT / "ai" / "run-codex-solve-bug.sh"
+RUN_CLAUDE = REPO_ROOT / "ai" / "run-claude-solve-bug.sh"
+PROMPT = REPO_ROOT / "ai" / "solve_bug_issue.md"
+CREATE_PR = REPO_ROOT / "scripts" / "create-pr.sh"
+MONITOR_PR = REPO_ROOT / "scripts" / "monitor-pr-checks.sh"
+
+
+class SolveBugEntrypointTests(unittest.TestCase):
+    def test_prompt_contract(self) -> None:
+        self.assertTrue(RUN_CODEX.is_file(), msg=f"missing file: {RUN_CODEX}")
+        self.assertTrue(RUN_CLAUDE.is_file(), msg=f"missing file: {RUN_CLAUDE}")
+        self.assertTrue(PROMPT.is_file(), msg=f"missing file: {PROMPT}")
+
+        prompt = PROMPT.read_text(encoding="utf-8")
+        self.assertIn("effectively no open bug or bug-like issues", prompt)
+        self.assertIn("bash scripts/create-pr.sh", prompt)
+        self.assertIn("bash scripts/monitor-pr-checks.sh", prompt)
+
+    def test_run_codex_help(self) -> None:
+        result = subprocess.run(
+            ["bash", str(RUN_CODEX), "--help"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--prompt", result.stdout)
+        self.assertIn("--run-dir", result.stdout)
+        self.assertIn("--text", result.stdout)
+
+    def test_run_claude_help(self) -> None:
+        result = subprocess.run(
+            ["bash", str(RUN_CLAUDE), "--help"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--prompt", result.stdout)
+        self.assertIn("--run-dir", result.stdout)
+        self.assertIn("--text", result.stdout)
+
+    def test_create_pr_help(self) -> None:
+        result = subprocess.run(
+            ["bash", str(CREATE_PR), "--help"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--base", result.stdout)
+        self.assertIn("--title", result.stdout)
+        self.assertIn("--no-auto-merge", result.stdout)
+
+    def test_monitor_pr_help(self) -> None:
+        result = subprocess.run(
+            ["bash", str(MONITOR_PR), "--help"],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--interval", result.stdout)
+
+    def test_create_pr_refuses_main_without_gh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / ".git").mkdir()
+            (root / "scripts").mkdir()
+            (root / "ai").mkdir()
+            (root / "bin").mkdir()
+            (root / "README.md").write_text("temp", encoding="utf-8")
+            (root / "AGENTS.md").write_text("temp", encoding="utf-8")
+            (root / "scripts" / "create-pr.sh").write_text(
+                CREATE_PR.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            (root / "scripts" / "monitor-pr-checks.sh").write_text(
+                MONITOR_PR.read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            (root / "ai" / "solve_bug_issue.md").write_text("temp", encoding="utf-8")
+            (root / "ai" / "run-codex-solve-bug.sh").write_text("temp", encoding="utf-8")
+            (root / "ai" / "run-claude-solve-bug.sh").write_text("temp", encoding="utf-8")
+            (root / "bin" / "git").write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                "if [[ \"$1\" == \"status\" && \"$2\" == \"--short\" ]]; then\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [[ \"$1\" == \"branch\" && \"$2\" == \"--show-current\" ]]; then\n"
+                "  printf 'main\\n'\n"
+                "  exit 0\n"
+                "fi\n"
+                "printf 'unexpected git invocation: %s\\n' \"$*\" >&2\n"
+                "exit 1\n",
+                encoding="utf-8",
+            )
+            (root / "bin" / "git").chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{root / 'bin'}:{env['PATH']}"
+            result = subprocess.run(
+                ["bash", "scripts/create-pr.sh"],
+                cwd=root,
+                text=True,
+                capture_output=True,
+                env=env,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("refusing to create a PR from main", result.stderr + result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add repo-local `create-pr.sh` and `monitor-pr-checks.sh` helpers for solve-bug automation
- add headless solve-bug entrypoints under `ai/`
- document the new entrypoints and the clean-exit branch for zero effective bug candidates

## Verification

- `python3 -m unittest tests.test_solve_bug_entrypoints -v`
- `bash ai/run-codex-solve-bug.sh --help`
- `bash ai/run-claude-solve-bug.sh --help`
- `bash scripts/create-pr.sh --help`
- `bash scripts/monitor-pr-checks.sh --help`
- `bash -n scripts/create-pr.sh scripts/monitor-pr-checks.sh ai/run-codex-solve-bug.sh ai/run-claude-solve-bug.sh`

## Notes

- `bash scripts/create-pr.sh` was attempted, but the full workspace verification step hit pre-existing compile failures in `crates/tensor4all-treetn/src/treetn/fit.rs` due missing `TensorDynLen::from_dense_f64` calls outside this change.
