### PR TITLE
fix(quanticstransform): zero open-boundary full-cycle shifts

### DIFF
--- a/crates/tensor4all-quanticstransform/src/shift.rs
+++ b/crates/tensor4all-quanticstransform/src/shift.rs
@@ -197,8 +197,10 @@ fn shift_mpo(r: usize, offset: i64, bc: BoundaryCondition) -> Result<TensorTrain
         let bc_factor = match bc {
             BoundaryCondition::Periodic => Complex64::one(),
             BoundaryCondition::Open => {
-                if nbc > 0 {
-                    Complex64::zero() // Shifted out of bounds
+                // `nbc` is an Euclidean quotient, so negative offsets in (-n_max, 0)
+                // still produce `nbc = -1`. Only true full-cycle offsets should zero.
+                if offset >= n_max || offset <= -n_max {
+                    Complex64::zero()
                 } else {
                     Complex64::one()
                 }

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -1288,17 +1288,16 @@ fn test_shift_open_boundary() {
     //
     // Implementation detail:
     // - offset is normalized to offset_mod = offset.rem_euclid(N) in [0, N)
-    // - nbc = (offset - offset_mod) / N tracks full cycles
-    // - If nbc > 0 (positive overflow beyond N), entire MPO is zeroed
-    // - If nbc < 0 (negative offset), no global zeroing, but local carry may still zero
-    // - Local carry overflow at MSB zeros the result via bc_val = 0
+    // - nbc = (offset - offset_mod) / N is the Euclidean quotient
+    // - For Open BC, the operator is identically zero only when |offset| >= N
+    // - Otherwise, local carry overflow at the MSB zeros out-of-range results
     //
-    // So for Open BC:
+    // So for Open BC with the cases below:
     // - shift(x, offset) with offset >= 0: result is zero if x + offset >= N
     // - shift(x, offset) with offset < 0:
     //   - offset_mod = N + offset (e.g., -1 mod 8 = 7)
-    //   - nbc = -1 (no global zeroing)
-    //   - But x + offset_mod may cause local carry overflow
+    //   - nbc = -1 even though |offset| < N, so the operator is not globally zeroed
+    //   - x + offset_mod may still cause local carry overflow
     //   - e.g., shift(7, -3): offset_mod = 5, 7 + 5 = 12 >= 8, overflow -> zero
     //   - e.g., shift(0, -1): offset_mod = 7, 0 + 7 = 7 < 8, no overflow -> result = 7
     //
@@ -1392,6 +1391,28 @@ fn test_shift_open_boundary() {
     }
 
     eprintln!("All shift Open BC tests passed!");
+}
+
+#[test]
+fn test_shift_open_boundary_negative_full_cycles_zero_operator() {
+    let r = 3;
+
+    for offset in [-8_i64, -9, -16] {
+        let op = shift_operator(r, offset, BoundaryCondition::Open)
+            .expect("Failed to create shift operator");
+        let matrix = apply_operator_to_dense_matrix(&op, r, r);
+
+        for (out_idx, row) in matrix.iter().enumerate() {
+            for (input_idx, value) in row.iter().enumerate() {
+                if value.norm() > 1e-10 {
+                    panic!(
+                        "offset {} produced nonzero entry at [{},{}] = ({:.6},{:.6})",
+                        offset, out_idx, input_idx, value.re, value.im
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Test flip operator with Open boundary condition.

--- a/docs/plans/2026-03-19-shift-open-boundary-full-cycle.md
+++ b/docs/plans/2026-03-19-shift-open-boundary-full-cycle.md
@@ -1,0 +1,78 @@
+# Shift Open Boundary Full-Cycle Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `shift_operator(..., BoundaryCondition::Open)` return the zero operator for negative full-cycle offsets, matching positive full-cycle behavior.
+
+**Architecture:** Add a regression at the public operator level, then fix the single boundary-condition branch in `shift.rs` that currently preserves negative full cycles. Verify the targeted regression plus the crate test suite so the change stays scoped to shift semantics.
+
+**Tech Stack:** Rust, cargo-nextest, tensor4all-quanticstransform integration tests
+
+---
+
+### Task 1: Add the failing regression
+
+**Files:**
+- Modify: `crates/tensor4all-quanticstransform/tests/integration_test.rs`
+- Test: `crates/tensor4all-quanticstransform/tests/integration_test.rs`
+
+**Step 1: Write the failing test**
+
+Add an integration test that builds `shift_operator(3, offset, BoundaryCondition::Open)` for `offset in [-8, -9, -16]`, contracts the operator to a dense matrix, and asserts every entry is zero.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-quanticstransform test_shift_open_boundary_negative_full_cycles_zero_operator`
+
+Expected: FAIL because the current implementation leaves negative full-cycle operators non-zero.
+
+### Task 2: Implement the minimal fix
+
+**Files:**
+- Modify: `crates/tensor4all-quanticstransform/src/shift.rs`
+
+**Step 1: Update Open boundary full-cycle handling**
+
+Change the `nbc != 0` branch so `BoundaryCondition::Open` always scales by zero, regardless of the sign of `nbc`.
+
+**Step 2: Re-run the regression**
+
+Run: `cargo nextest run --release -p tensor4all-quanticstransform test_shift_open_boundary_negative_full_cycles_zero_operator`
+
+Expected: PASS.
+
+### Task 3: Verify and finish
+
+**Files:**
+- Modify: `crates/tensor4all-quanticstransform/src/shift.rs`
+- Modify: `crates/tensor4all-quanticstransform/tests/integration_test.rs`
+
+**Step 1: Run relevant verification**
+
+Run: `cargo nextest run --release -p tensor4all-quanticstransform`
+
+Expected: PASS.
+
+**Step 2: Format**
+
+Run: `cargo fmt --all`
+
+Expected: no diff after formatting.
+
+**Step 3: Commit and open PR**
+
+Run:
+
+```bash
+git add docs/plans/2026-03-19-shift-open-boundary-full-cycle.md \
+  crates/tensor4all-quanticstransform/src/shift.rs \
+  crates/tensor4all-quanticstransform/tests/integration_test.rs
+git commit -m "fix(quanticstransform): zero open-boundary full-cycle shifts"
+bash scripts/create-pr.sh
+```
+
+**Step 4: Monitor checks and merge**
+
+Run: `bash scripts/monitor-pr-checks.sh`
+
+Expected: CI green, then merge or stop only on an external blocker.


### PR DESCRIPTION
## Summary

- fix(quanticstransform): zero open-boundary full-cycle shifts

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release --workspace`
