### PR TITLE
fix(quanticstransform): correct public docs crate path

### DIFF
--- a/crates/tensor4all-quanticstransform/README.md
+++ b/crates/tensor4all-quanticstransform/README.md
@@ -21,7 +21,7 @@ All transformations return `LinearOperator` from `tensor4all-treetn` for consist
 ## Usage
 
 ```rust
-use tensor4all_quantics_transform::{
+use tensor4all_quanticstransform::{
     flip_operator, shift_operator, phase_rotation_operator,
     cumsum_operator, quantics_fourier_operator,
     BoundaryCondition, FourierOptions,
@@ -47,7 +47,7 @@ let options = FourierOptions::forward();
 let ft_op = quantics_fourier_operator(r, options)?;
 
 // Affine transform: y = A*x + b with A = [[1, 1], [1, -1]], b = [0, 0]
-use tensor4all_quantics_transform::{affine_operator, AffineParams};
+use tensor4all_quanticstransform::{affine_operator, AffineParams};
 use num_rational::Rational64;
 
 let a = vec![

--- a/crates/tensor4all-quanticstransform/src/affine.rs
+++ b/crates/tensor4all-quanticstransform/src/affine.rs
@@ -171,8 +171,8 @@ fn remap_affine_site_indices(
 /// LinearOperator representing the affine transformation
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::{affine_operator, AffineParams, BoundaryCondition};
+/// ```no_run
+/// use tensor4all_quanticstransform::{affine_operator, AffineParams, BoundaryCondition};
 /// use num_rational::Rational64;
 ///
 /// // Transform g(x, y) -> g(x + y, x - y) (rotation by 45°, scaled)
@@ -367,8 +367,10 @@ fn affine_transform_mpo(
 /// Vector of R tensors with unfused physical indices.
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::{affine_transform_tensors_unfused, AffineParams, BoundaryCondition};
+/// ```no_run
+/// use tensor4all_quanticstransform::{
+///     affine_transform_tensors_unfused, AffineParams, BoundaryCondition,
+/// };
 ///
 /// let params = AffineParams::from_integers(vec![1, 1, 0, 1], vec![0, 0], 2, 2).unwrap();
 /// let bc = vec![BoundaryCondition::Periodic; 2];

--- a/crates/tensor4all-quanticstransform/src/binaryop.rs
+++ b/crates/tensor4all-quanticstransform/src/binaryop.rs
@@ -76,8 +76,8 @@ impl BinaryCoeffs {
 /// LinearOperator representing the binary transformation
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::{binaryop_operator, BinaryCoeffs, BoundaryCondition};
+/// ```no_run
+/// use tensor4all_quanticstransform::{binaryop_operator, BinaryCoeffs, BoundaryCondition};
 ///
 /// // Transform g(x, y) -> g(x+y, x-y)
 /// let coeffs1 = BinaryCoeffs::sum();       // x + y

--- a/crates/tensor4all-quanticstransform/src/cumsum.rs
+++ b/crates/tensor4all-quanticstransform/src/cumsum.rs
@@ -33,8 +33,8 @@ pub enum TriangleType {
 /// LinearOperator representing the cumulative sum
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::cumsum_operator;
+/// ```no_run
+/// use tensor4all_quanticstransform::cumsum_operator;
 ///
 /// let op = cumsum_operator(8).unwrap();
 /// ```

--- a/crates/tensor4all-quanticstransform/src/flip.rs
+++ b/crates/tensor4all-quanticstransform/src/flip.rs
@@ -24,8 +24,8 @@ use crate::common::{
 /// LinearOperator representing the flip transformation
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::{flip_operator, BoundaryCondition};
+/// ```no_run
+/// use tensor4all_quanticstransform::{flip_operator, BoundaryCondition};
 ///
 /// let op = flip_operator(8, BoundaryCondition::Periodic).unwrap();
 /// ```

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -22,8 +22,8 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use tensor4all_quantics_transform::{flip_operator, BoundaryCondition};
+//! ```no_run
+//! use tensor4all_quanticstransform::{flip_operator, BoundaryCondition};
 //!
 //! // Create a flip operator for 8-bit quantics representation
 //! let op = flip_operator(8, BoundaryCondition::Periodic).unwrap();

--- a/crates/tensor4all-quanticstransform/src/phase_rotation.rs
+++ b/crates/tensor4all-quanticstransform/src/phase_rotation.rs
@@ -31,8 +31,8 @@ use crate::common::{
 /// LinearOperator representing the phase rotation
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::phase_rotation_operator;
+/// ```no_run
+/// use tensor4all_quanticstransform::phase_rotation_operator;
 /// use std::f64::consts::PI;
 ///
 /// // Apply phase rotation by π/4

--- a/crates/tensor4all-quanticstransform/src/shift.rs
+++ b/crates/tensor4all-quanticstransform/src/shift.rs
@@ -25,8 +25,8 @@ use crate::common::{
 /// LinearOperator representing the shift transformation
 ///
 /// # Example
-/// ```ignore
-/// use tensor4all_quantics_transform::{shift_operator, BoundaryCondition};
+/// ```no_run
+/// use tensor4all_quanticstransform::{shift_operator, BoundaryCondition};
 ///
 /// // Shift by 10 positions with periodic boundary
 /// let op = shift_operator(8, 10, BoundaryCondition::Periodic).unwrap();


### PR DESCRIPTION
## Summary

- fix the published tensor4all-quanticstransform README imports to use the real crate path
- update rustdoc examples to use tensor4all_quanticstransform and switch them from ignore to no_run so default doctests compile-check them

Fixes #286.

## Verification

- cargo fmt --all
- cargo test --release -p tensor4all-quanticstransform --doc
- cargo nextest run --release -p tensor4all-quanticstransform
- downstream README-style compile via temporary crate against tensor4all-quanticstransform
