### PR TITLE
fix(core): correct README contraction references

### DIFF
--- a/crates/tensor4all-core/README.md
+++ b/crates/tensor4all-core/README.md
@@ -58,15 +58,15 @@ let b = TensorDynLen::random_f64(&mut rng, vec![j.clone(), k.clone()]);
 let c = TensorDynLen::random_f64(&mut rng, vec![k.clone(), l.clone()]);
 
 // Contract all tensor pairs (default behavior)
-let result = contract_multi(&[a.clone(), b.clone(), c.clone()], AllowedPairs::All)?;
+let result = contract_multi(&[&a, &b, &c], AllowedPairs::All)?;
 
 // Contract only specified pairs (useful for tree tensor networks)
 // Only A-B and B-C are connected, so j and k are contracted
 let pairs = [(0, 1), (1, 2)];  // tensor indices
-let result = contract_multi(&[a.clone(), b.clone(), c.clone()], AllowedPairs::Specified(&pairs))?;
+let result = contract_multi(&[&a, &b, &c], AllowedPairs::Specified(&pairs))?;
 
 // contract_connected requires the tensor graph to be connected (errors on disconnected)
-let result = contract_connected(&[a, b, c], AllowedPairs::All)?;
+let result = contract_connected(&[&a, &b, &c], AllowedPairs::All)?;
 
 # Ok::<(), anyhow::Error>(())
 ```

--- a/crates/tensor4all-core/tests/readme_contraction_example.rs
+++ b/crates/tensor4all-core/tests/readme_contraction_example.rs
@@ -1,0 +1,73 @@
+use std::fs;
+use std::path::Path;
+
+use rand::rng;
+use tensor4all_core::index::{DynId, Index};
+use tensor4all_core::{contract_connected, contract_multi, AllowedPairs, TensorDynLen};
+
+fn assert_readme_uses_current_contraction_example(path: &Path) {
+    let readme = fs::read_to_string(path).unwrap_or_else(|err| {
+        panic!("failed to read {}: {err}", path.display());
+    });
+
+    assert!(
+        readme.contains("contract_multi(&[&a, &b, &c], AllowedPairs::All)?"),
+        "{} should pass tensor references to contract_multi in the all-pairs example",
+        path.display()
+    );
+    assert!(
+        readme.contains("contract_multi(&[&a, &b, &c], AllowedPairs::Specified(&pairs))?"),
+        "{} should pass tensor references to contract_multi in the specified-pairs example",
+        path.display()
+    );
+    assert!(
+        readme.contains("contract_connected(&[&a, &b, &c], AllowedPairs::All)?"),
+        "{} should pass tensor references to contract_connected",
+        path.display()
+    );
+    assert!(
+        !readme.contains("contract_multi(&[a.clone(), b.clone(), c.clone()], AllowedPairs::All)?"),
+        "{} still contains the stale owned-tensor contract_multi example",
+        path.display()
+    );
+    assert!(
+        !readme.contains(
+            "contract_multi(&[a.clone(), b.clone(), c.clone()], AllowedPairs::Specified(&pairs))?"
+        ),
+        "{} still contains the stale owned-tensor specified-pairs example",
+        path.display()
+    );
+    assert!(
+        !readme.contains("contract_connected(&[a, b, c], AllowedPairs::All)?"),
+        "{} still contains the stale owned-tensor contract_connected example",
+        path.display()
+    );
+}
+
+#[test]
+fn core_readme_uses_current_contraction_api() {
+    let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    assert_readme_uses_current_contraction_example(&crate_root.join("README.md"));
+}
+
+#[test]
+fn core_readme_contraction_flow_runs_against_public_api() {
+    let i = Index::<DynId>::new_dyn_with_tag(2, "i").unwrap();
+    let j = Index::<DynId>::new_dyn_with_tag(3, "j").unwrap();
+    let k = Index::<DynId>::new_dyn_with_tag(4, "k").unwrap();
+    let l = Index::<DynId>::new_dyn_with_tag(5, "l").unwrap();
+
+    let mut rng = rng();
+    let a = TensorDynLen::random_f64(&mut rng, vec![i.clone(), j.clone()]);
+    let b = TensorDynLen::random_f64(&mut rng, vec![j.clone(), k.clone()]);
+    let c = TensorDynLen::random_f64(&mut rng, vec![k.clone(), l.clone()]);
+
+    let result_all = contract_multi(&[&a, &b, &c], AllowedPairs::All).unwrap();
+    let pairs = [(0, 1), (1, 2)];
+    let result_specified = contract_multi(&[&a, &b, &c], AllowedPairs::Specified(&pairs)).unwrap();
+    let result_connected = contract_connected(&[&a, &b, &c], AllowedPairs::All).unwrap();
+
+    assert_eq!(result_all.indices(), &[i.clone(), l.clone()]);
+    assert_eq!(result_specified.indices(), &[i.clone(), l.clone()]);
+    assert_eq!(result_connected.indices(), &[i, l]);
+}


### PR DESCRIPTION
## Summary

- fix the `tensor4all-core` README contraction snippet so it passes tensor references to `contract_multi` and `contract_connected`
- add a `tensor4all-core` regression test that checks the README text stays aligned with the public API and runs the documented contraction flow

Fixes #290

## Verification

- `cargo fmt --all`
- `cargo nextest run --release -p tensor4all-core`
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release --workspace`
