### PR TITLE
fix: make tensor4all-itensorlike README example compile

### DIFF
--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -12,20 +12,34 @@ ITensors.jl-inspired high-level API for Tensor Train (MPS) operations with ortho
 
 ## Usage
 
+This low-level constructor takes `TensorDynLen` values from `tensor4all-core`.
+
 ```rust
-use tensor4all_itensorlike::{TensorTrain, TruncateOptions, CanonicalForm};
+# fn main() -> anyhow::Result<()> {
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
 
-// Create tensor train from tensors
-let tt = TensorTrain::new(tensors)?;
+let s0 = DynIndex::new_dyn(2);
+let s1 = DynIndex::new_dyn(2);
+let s2 = DynIndex::new_dyn(2);
+let b01 = DynIndex::new_bond(2)?;
+let b12 = DynIndex::new_bond(2)?;
 
-// Orthogonalize to site 2 using QR
-tt.orthogonalize(2)?;
+let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+let t1 = TensorDynLen::from_dense(
+    vec![b01.clone(), s1.clone(), b12.clone()],
+    vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+)?;
+let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
 
-// Truncate with SVD
-tt.truncate(&TruncateOptions::svd().with_rtol(1e-10).with_max_rank(20))?;
+let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
+tt.orthogonalize(1)?;
+tt.truncate(&TruncateOptions::svd().with_rtol(1e-10).with_max_rank(2))?;
 
-// Compute norm
-let norm = tt.norm();
+assert!(tt.isortho());
+assert!(tt.norm().is_finite());
+# Ok(())
+# }
 ```
 
 ## Differences from ITensorMPS.jl

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -1,43 +1,5 @@
 #![warn(missing_docs)]
-//! ITensorMPS.jl-inspired Tensor Train library with orthogonality tracking
-//!
-//! This crate provides a Rust implementation of Tensor Trains (also known as MPS)
-//! with an API inspired by [ITensorMPS.jl](https://github.com/ITensor/ITensorMPS.jl).
-//!
-//! # Features
-//!
-//! - `TensorTrain`: Main tensor train type with orthogonality tracking
-//! - Canonicalization with multiple canonical forms:
-//!   - `Unitary`: Uses QR decomposition, each tensor is isometric
-//!   - `LU`: Uses LU decomposition, one factor has unit diagonal
-//!   - `CI`: Uses Cross Interpolation
-//! - Truncation with configurable tolerance and max rank
-//! - Norm and inner product computations
-//!
-//! # Example
-//!
-//! ```ignore
-//! use tensor4all_itensortrain::{TensorTrain, TruncateOptions};
-//!
-//! // Create a tensor train from tensors
-//! let tt = TensorTrain::new(tensors)?;
-//!
-//! // Orthogonalize to site 2
-//! tt.orthogonalize(2)?;
-//!
-//! // Truncate with SVD
-//! tt.truncate(&TruncateOptions::svd().with_rtol(1e-10))?;
-//!
-//! // Compute norm
-//! let n = tt.norm();
-//! ```
-//!
-//! # Differences from ITensorMPS.jl
-//!
-//! - Uses 0-indexed sites (Julia uses 1-indexed)
-//! - Supports multiple canonical forms: Unitary (using QR), LU, CI
-//! - Uses `conj` instead of `dag` (no index direction flipping without QN support)
-//! - Each site can have multiple site indices (not just one physical index per site)
+#![doc = include_str!("../README.md")]
 
 pub mod contract;
 pub mod error;

--- a/crates/tensor4all-itensorlike/tests/readme_usage.rs
+++ b/crates/tensor4all-itensorlike/tests/readme_usage.rs
@@ -1,0 +1,98 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn extract_first_rust_code_block(readme: &str) -> Option<&str> {
+    let start = readme.find("```rust")?;
+    let body_start = readme[start..].find('\n')? + start + 1;
+    let end = readme[body_start..].find("\n```")? + body_start;
+    Some(&readme[body_start..end])
+}
+
+fn render_doctest_snippet(snippet: &str) -> String {
+    let mut rendered = String::new();
+    for line in snippet.lines() {
+        if let Some(unhidden) = line.strip_prefix("# ") {
+            rendered.push_str(unhidden);
+        } else if line == "#" {
+            // Rustdoc treats a bare "#" as a hidden blank line.
+        } else {
+            rendered.push_str(line);
+        }
+        rendered.push('\n');
+    }
+    rendered
+}
+
+fn make_temp_project_dir() -> PathBuf {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "tensor4all-itensorlike-readme-{}-{timestamp}",
+        std::process::id()
+    ))
+}
+
+fn write_temp_project(project_dir: &Path, snippet: &str) {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let core_dir = manifest_dir.parent().unwrap().join("tensor4all-core");
+
+    fs::create_dir_all(project_dir.join("src")).unwrap();
+    fs::write(
+        project_dir.join("Cargo.toml"),
+        format!(
+            r#"[package]
+name = "tensor4all_itensorlike_readme_usage"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+tensor4all-core = {{ path = "{}" }}
+tensor4all-itensorlike = {{ path = "{}" }}
+"#,
+            core_dir.display(),
+            manifest_dir.display()
+        ),
+    )
+    .unwrap();
+    fs::write(project_dir.join("src/main.rs"), snippet).unwrap();
+}
+
+#[test]
+fn readme_usage_example_compiles() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
+    let readme = fs::read_to_string(manifest_dir.join("README.md")).unwrap();
+    let snippet =
+        extract_first_rust_code_block(&readme).expect("README should contain a Rust example");
+    let rendered_snippet = render_doctest_snippet(snippet);
+
+    let project_dir = make_temp_project_dir();
+    write_temp_project(&project_dir, &rendered_snippet);
+
+    let output = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string()))
+        .arg("check")
+        .arg("--release")
+        .arg("--offline")
+        .arg("--manifest-path")
+        .arg(project_dir.join("Cargo.toml"))
+        .arg("--target-dir")
+        .arg(workspace_root.join("target/readme-usage"))
+        .output()
+        .unwrap();
+
+    let _ = fs::remove_dir_all(&project_dir);
+
+    assert!(
+        output.status.success(),
+        "README usage example failed to compile\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- replace the broken `tensor4all-itensorlike` README snippet with a complete runnable example
- reuse the README as crate-level docs and add a regression test that compiles the README snippet as a downstream crate
- Closes #287

## Verification

- `cargo nextest run --release -p tensor4all-itensorlike --test readme_usage`
- `cargo test --doc --release -p tensor4all-itensorlike`
- `cargo nextest run --release -p tensor4all-itensorlike`
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release --workspace`
