### PR TITLE
fix(quanticstci): align README example with i64 callback

### DIFF
--- a/crates/tensor4all-quanticstci/README.md
+++ b/crates/tensor4all-quanticstci/README.md
@@ -16,7 +16,8 @@ High-level wrapper for Quantics Tensor Train (QTT) interpolation. Provides a use
 use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
 
 // Define a function on a 2D grid
-let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
+// Discrete indices are 1-indexed and passed as `&[i64]`.
+let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
 
 // Grid sizes (powers of 2)
 let sizes = vec![16, 16];

--- a/crates/tensor4all-quanticstci/src/lib.rs
+++ b/crates/tensor4all-quanticstci/src/lib.rs
@@ -17,16 +17,18 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```rust
 //! use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
 //!
 //! // Interpolate f(i, j) = i + j on a 16x16 grid
-//! let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
+//! // Discrete indices are 1-indexed and passed as `&[i64]`.
+//! let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
 //! let sizes = vec![16, 16];
 //!
-//! let (qtci, ranks, errors) = quanticscrossinterpolate_discrete(
+//! let (qtci, _ranks, _errors) = quanticscrossinterpolate_discrete(
 //!     &sizes,
 //!     f,
+//!     None,
 //!     QtciOptions::default(),
 //! ).unwrap();
 //!

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -354,7 +354,7 @@ where
 ///
 /// # Arguments
 /// * `size` - Grid size in each dimension (must be powers of 2)
-/// * `f` - Function to interpolate, takes grid indices (1-indexed)
+/// * `f` - Function to interpolate, taking 1-indexed grid indices as `&[i64]`
 /// * `initial_pivots` - Initial pivot grid indices (optional)
 /// * `options` - TCI options
 ///

--- a/crates/tensor4all-quanticstci/tests/readme_example.rs
+++ b/crates/tensor4all-quanticstci/tests/readme_example.rs
@@ -1,0 +1,22 @@
+use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+
+#[test]
+fn readme_example_uses_public_callback_signature() {
+    let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    let sizes = vec![16, 16];
+
+    let (qtci, ranks, errors) = quanticscrossinterpolate_discrete(
+        &sizes,
+        f,
+        None,
+        QtciOptions::default().with_tolerance(1e-10),
+    )
+    .expect("README example should compile and run");
+
+    let value = qtci
+        .evaluate(&[5, 10])
+        .expect("README example should evaluate");
+    assert!((value - 15.0).abs() < 1e-10);
+    assert_eq!(ranks, vec![2]);
+    assert!(errors.last().copied().unwrap() < 1e-10);
+}


### PR DESCRIPTION
Summary
- Fix the tensor4all-quanticstci getting-started example to use the public i64 callback signature.
- Update the crate-level docs and function docs so the discrete callback is documented as receiving 1-indexed i64 values.
- Add a regression test that compiles and runs the README example.

Root cause
The README and crate docs had drifted from the actual quanticscrossinterpolate_discrete signature, which requires an i64 callback and an explicit initial_pivots argument.

Verification
- cargo test --release -p tensor4all-quanticstci --test readme_example --offline
- cargo test --release -p tensor4all-quanticstci --doc --offline
