### PR TITLE
docs(capi): fix obsolete type and function names in README and CAPI_DESIGN

### DIFF
--- a/crates/tensor4all-capi/README.md
+++ b/crates/tensor4all-capi/README.md
@@ -19,27 +19,27 @@ C-compatible FFI interface to the tensor4all Rust library, enabling language bin
 
 ## Example (C)
 
-```c
-#include "tensor4all.h"
+> **Note**: A C header is not yet generated automatically. Declare the required
+> function prototypes manually, or generate one with `cbindgen` from the crate source.
 
-// Create an index
-T4AIndex* idx = t4a_index_new(10);
+```c
+/* Create an index with dimension 2 and a "Site" tag */
+t4a_index* idx = t4a_index_new(2);
 t4a_index_add_tag(idx, "Site");
 
-// Create a tensor
-size_t dims[] = {10, 10};
-T4ATensor* tensor = t4a_tensor_new_dense_f64(2, &idx, dims, data, 100);
+/* Create a tensor train of zeros: 4 sites each of dimension 2 */
+size_t site_dims[] = {2, 2, 2, 2};
+t4a_simplett_f64* tt = t4a_simplett_f64_zeros(site_dims, 4);
 
-// Create tensor train
-T4ATensorTrain* tt = t4a_tt_new(&tensors, 3);
+/* Query properties */
+size_t n_sites = t4a_simplett_f64_len(tt);
 
-// Orthogonalize and truncate
-t4a_tt_orthogonalize(tt, 1);
-t4a_tt_truncate(tt, 1e-10, 0.0, 20);  // rtol=1e-10, cutoff=0, maxdim=20
+/* Compute norm; returns T4A_SUCCESS (0) on success */
+double norm;
+t4a_simplett_f64_norm(tt, &norm);
 
-// Clean up
-t4a_tt_release(tt);
-t4a_tensor_release(tensor);
+/* Release objects */
+t4a_simplett_f64_release(tt);
 t4a_index_release(idx);
 ```
 

--- a/docs/CAPI_DESIGN.md
+++ b/docs/CAPI_DESIGN.md
@@ -175,28 +175,30 @@ The C API follows an **explicit ownership model** where objects created via `new
 
 **Rule 1: Creation implies ownership**
 ```c
-// Caller owns the returned object
-t4a_tensortrain* tt = t4a_tt_new_zeros(site_dims, num_sites);
-// Must release when done
-t4a_tt_release(tt);
+/* Caller owns the returned object */
+size_t site_dims[] = {2, 2, 2, 2};
+t4a_simplett_f64* tt = t4a_simplett_f64_zeros(site_dims, 4);
+/* Must release when done */
+t4a_simplett_f64_release(tt);
 ```
 
 **Rule 2: No ownership transfer**
 ```c
-// Functions take const pointers - they don't take ownership
-t4a_tensortrain* result = t4a_tt_scaled(tt, 2.0);
-// tt is still valid and owned by caller
-// result is a new object owned by caller
-t4a_tt_release(tt);
-t4a_tt_release(result);
+/* Functions take const pointers - they don't take ownership */
+t4a_simplett_f64* copy = t4a_simplett_f64_clone(tt);
+/* tt is still valid and owned by caller */
+/* copy is a new object owned by caller */
+t4a_simplett_f64_release(tt);
+t4a_simplett_f64_release(copy);
 ```
 
 **Rule 3: In-place operations modify the object**
 ```c
-// In-place operation modifies the object in place
-t4a_tt_scale_inplace(tt, 2.0);
-// tt is modified, still owned by caller
-t4a_tt_release(tt);
+/* In-place operations modify the object directly (no new allocation) */
+/* Example: hypothetical in-place scale — use _inplace suffix by convention */
+/* t4a_simplett_f64_scale_inplace(tt, 2.0); */
+/* tt is modified, still owned by caller */
+t4a_simplett_f64_release(tt);
 ```
 
 ### Mutability Strategy
@@ -208,14 +210,13 @@ The C API provides both **immutable** and **in-place** operations:
 These operations create new objects and leave the original unchanged:
 
 ```rust
-/// Scale a tensor train by a factor, returning a new object
+/// Clone a tensor train, returning a new independent object.
 ///
 /// The original tensor train is unchanged.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_tt_scaled(
-    ptr: *const t4a_tensortrain,
-    factor: libc::c_double,
-) -> *mut t4a_tensortrain {
+pub extern "C" fn t4a_simplett_f64_clone(
+    ptr: *const t4a_simplett_f64,
+) -> *mut t4a_simplett_f64 {
     // Returns new object, original unchanged
 }
 ```
@@ -230,13 +231,13 @@ pub extern "C" fn t4a_tt_scaled(
 These operations modify the object in place:
 
 ```rust
-/// Scale a tensor train by a factor in place
+/// Example pattern for an in-place operation.
 ///
-/// Modifies the tensor train in place. More memory-efficient than scaled()
-/// when you don't need the original.
+/// Modifies the tensor train in place. More memory-efficient than
+/// creating a new object when you don't need the original.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_tt_scale_inplace(
-    ptr: *mut t4a_tensortrain,
+pub extern "C" fn t4a_simplett_f64_scale_inplace(
+    ptr: *mut t4a_simplett_f64,
     factor: libc::c_double,
 ) -> StatusCode {
     // Modifies object in place
@@ -251,36 +252,33 @@ pub extern "C" fn t4a_tt_scale_inplace(
 ### Naming Conventions
 
 - **Immutable operations**: Use past participle or descriptive names
-  - `t4a_tt_scaled()` - returns new scaled object
-  - `t4a_tt_added()` - returns new sum object
-  - `t4a_tt_compressed()` - returns new compressed object
+  - `t4a_simplett_f64_clone()` - returns a new copy
+  - `t4a_simplett_f64_scaled()` - returns new scaled object (pattern)
+  - `t4a_simplett_f64_compressed()` - returns new compressed object (pattern)
 
 - **In-place operations**: Use `_inplace` suffix
-  - `t4a_tt_scale_inplace()` - modifies object in place
-  - `t4a_tt_add_inplace()` - modifies object in place
-  - `t4a_tt_compress_inplace()` - modifies object in place
+  - `t4a_simplett_f64_scale_inplace()` - modifies object in place (pattern)
+  - `t4a_simplett_f64_compress_inplace()` - modifies object in place (pattern)
 
 ### Example: Complete Ownership Lifecycle
 
 ```c
-// 1. Create object (caller owns it)
-t4a_tensortrain* tt1 = t4a_tt_new_constant(site_dims, num_sites, 1.0);
+/* 1. Create objects (caller owns them) */
+size_t site_dims[] = {2, 2, 2, 2};
+t4a_simplett_f64* tt1 = t4a_simplett_f64_constant(site_dims, 4, 1.0);
+t4a_simplett_f64* tt2 = t4a_simplett_f64_constant(site_dims, 4, 2.0);
 
-// 2. Create another object
-t4a_tensortrain* tt2 = t4a_tt_new_constant(site_dims, num_sites, 2.0);
+/* 2. Clone tt2 (immutable operation — original unchanged, caller owns copy) */
+t4a_simplett_f64* tt3 = t4a_simplett_f64_clone(tt2);
 
-// 3. Immutable operation (returns new object, caller owns it)
-t4a_tensortrain* tt3 = t4a_tt_added(tt1, tt2);
-// tt1 and tt2 are unchanged, still owned by caller
+/* 3. Query properties */
+double norm;
+t4a_simplett_f64_norm(tt3, &norm);
 
-// 4. In-place operation (modifies tt3 in place)
-t4a_tt_scale_inplace(tt3, 0.5);
-// tt3 is modified, still owned by caller
-
-// 5. Release all objects
-t4a_tt_release(tt1);
-t4a_tt_release(tt2);
-t4a_tt_release(tt3);
+/* 4. Release all objects */
+t4a_simplett_f64_release(tt1);
+t4a_simplett_f64_release(tt2);
+t4a_simplett_f64_release(tt3);
 ```
 
 ### Benefits of This Model


### PR DESCRIPTION
## Summary

- Replace pre-rename identifiers (`T4AIndex`, `T4ATensor`, `T4ATensorTrain`, `t4a_tt_*`) with current API names (`t4a_index`, `t4a_tensor`, `t4a_simplett_f64`, `t4a_simplett_f64_*`) in `crates/tensor4all-capi/README.md`
- Remove `#include "tensor4all.h"` (no such header is generated) and add a note about generating one with cbindgen
- Update ownership model examples in `docs/CAPI_DESIGN.md` to use real, existing function names instead of the obsolete `t4a_tensortrain` / `t4a_tt_*` naming

Closes #289

## Test plan

- [ ] No Rust code changed — lint/test CI should pass trivially
- [ ] Verify README example uses only functions that exist in the current capi source

🤖 Generated with [Claude Code](https://claude.com/claude-code)