### PR TITLE
refactor: remove legacy DenseStorage/DiagStorage and mdarray (#321)

### DIFF
--- a/crates/tensor4all-simplett/Cargo.toml
+++ b/crates/tensor4all-simplett/Cargo.toml
@@ -21,7 +21,6 @@ num-traits.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 rand.workspace = true
-mdarray.workspace = true
 bnum.workspace = true
 matrixci = { path = "../matrixci" }
 tensor4all-core = { path = "../tensor4all-core" }

--- a/crates/tensor4all-simplett/src/lib.rs
+++ b/crates/tensor4all-simplett/src/lib.rs
@@ -34,6 +34,7 @@ pub mod compression;
 pub mod contraction;
 pub mod error;
 pub mod mpo;
+pub mod tensor;
 pub mod tensortrain;
 pub mod traits;
 pub mod types;

--- a/crates/tensor4all-simplett/src/mpo/environment.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment.rs
@@ -7,15 +7,7 @@ use super::error::{MPOError, Result};
 use super::factorize::SVDScalar;
 use super::mpo::MPO;
 use super::types::{Tensor4, Tensor4Ops};
-use mdarray::DTensor;
-
-/// Type alias for 2D matrix using mdarray
-pub type Matrix2<T> = DTensor<T, 2>;
-
-/// Helper function to create a zero-filled 2D tensor
-fn matrix2_zeros<T: Clone + Default>(rows: usize, cols: usize) -> Matrix2<T> {
-    DTensor::<T, 2>::from_elem([rows, cols], T::default())
-}
+use super::{matrix2_zeros, Matrix2};
 
 /// Contract two general tensors over specified indices
 ///

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -320,7 +320,7 @@ where
     let m = matrix.dim(0);
     let n = matrix.dim(1);
 
-    // Convert DTensor to matrixci::Matrix (temporary until matrixci migration)
+    // Convert Matrix2 to matrixci::Matrix (temporary until matrixci migration)
     let mut mat_ci: matrixci::Matrix<T> = matrixci::util::zeros(m, n);
     for i in 0..m {
         for j in 0..n {
@@ -340,7 +340,7 @@ where
     let right_ci = luci.right();
     let rank = luci.rank().max(1);
 
-    // Convert back to DTensor
+    // Convert back to Matrix2
     let left_m = matrixci::util::nrows(&left_ci);
     let left_n = matrixci::util::ncols(&left_ci);
     let mut left: Matrix2<T> = matrix2_zeros(left_m, left_n);

--- a/crates/tensor4all-simplett/src/mpo/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mod.rs
@@ -26,17 +26,15 @@
 //! let result = contract_naive(&mpo_a, &mpo_b, None)?;
 //! ```
 
-use mdarray::DTensor;
-
-/// Type alias for 2D matrix using mdarray
-pub type Matrix2<T> = DTensor<T, 2>;
+/// Type alias for 2D matrix.
+pub type Matrix2<T> = crate::tensor::Tensor2<T>;
 
 /// Helper function to create a zero-filled 2D tensor.
 ///
 /// This is a shared utility used across multiple MPO modules.
 #[inline]
 pub(crate) fn matrix2_zeros<T: Clone + Default>(rows: usize, cols: usize) -> Matrix2<T> {
-    DTensor::<T, 2>::from_elem([rows, cols], T::default())
+    crate::tensor::Tensor::from_elem([rows, cols], T::default())
 }
 
 pub mod contract_fit;

--- a/crates/tensor4all-simplett/src/mpo/types.rs
+++ b/crates/tensor4all-simplett/src/mpo/types.rs
@@ -6,17 +6,14 @@
 //! - `site_dim_2`: Physical index (e.g., column index, often contracted)
 //! - `right_bond`: Bond dimension connecting to the right neighbor
 
-use mdarray::DTensor;
+use crate::tensor::Tensor;
+pub use crate::tensor::Tensor4;
 
 /// Local index type (index within a single tensor site)
 pub type LocalIndex = usize;
 
 /// Multi-index type (indices across all sites)
 pub type MultiIndex = Vec<LocalIndex>;
-
-/// A 4D tensor represented using mdarray
-/// Shape is (left_dim, site_dim_1, site_dim_2, right_dim)
-pub type Tensor4<T> = DTensor<T, 4>;
 
 /// Helper functions for Tensor4 operations
 pub trait Tensor4Ops<T: Clone + Default> {
@@ -163,7 +160,7 @@ pub fn tensor4_zeros<T: Clone + Default>(
     site_dim_2: usize,
     right_dim: usize,
 ) -> Tensor4<T> {
-    Tensor4::from_elem([left_dim, site_dim_1, site_dim_2, right_dim], T::default())
+    Tensor::from_elem([left_dim, site_dim_1, site_dim_2, right_dim], T::default())
 }
 
 /// Create a Tensor4 from flat data (column-major order)
@@ -175,7 +172,7 @@ pub fn tensor4_from_data<T: Clone>(
     right_dim: usize,
 ) -> Tensor4<T> {
     assert_eq!(data.len(), left_dim * site_dim_1 * site_dim_2 * right_dim);
-    Tensor4::from_fn([left_dim, site_dim_1, site_dim_2, right_dim], |idx| {
+    Tensor::from_fn([left_dim, site_dim_1, site_dim_2, right_dim], |idx| {
         let l = idx[0];
         let s1 = idx[1];
         let s2 = idx[2];

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -1,0 +1,214 @@
+//! Fixed-rank tensor type backed by a flat `Vec<T>` with row-major layout.
+//!
+//! This module provides a simple tensor type that replaces the `mdarray::DTensor`
+//! dependency for the simplett crate.
+
+use std::ops::{Index, IndexMut};
+
+/// Rank-N tensor backed by a flat `Vec<T>` with row-major layout.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Tensor<T, const N: usize> {
+    data: Vec<T>,
+    dims: [usize; N],
+    /// Precomputed strides for row-major layout.
+    strides: [usize; N],
+}
+
+/// 2D tensor (matrix).
+pub type Tensor2<T> = Tensor<T, 2>;
+
+/// 3D tensor.
+pub type Tensor3<T> = Tensor<T, 3>;
+
+/// 4D tensor.
+pub type Tensor4<T> = Tensor<T, 4>;
+
+/// Compute row-major strides from dimensions.
+fn compute_strides<const N: usize>(dims: &[usize; N]) -> [usize; N] {
+    let mut strides = [0usize; N];
+    if N == 0 {
+        return strides;
+    }
+    strides[N - 1] = 1;
+    for i in (0..N - 1).rev() {
+        strides[i] = strides[i + 1] * dims[i + 1];
+    }
+    strides
+}
+
+impl<T, const N: usize> Tensor<T, N> {
+    /// Total number of elements.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Whether the tensor is empty (zero elements).
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Dimension along `axis`.
+    pub fn dim(&self, axis: usize) -> usize {
+        self.dims[axis]
+    }
+
+    /// All dimensions.
+    pub fn dims(&self) -> &[usize; N] {
+        &self.dims
+    }
+
+    /// View the underlying data as a slice.
+    pub fn as_slice(&self) -> &[T] {
+        &self.data
+    }
+
+    /// View the underlying data as a mutable slice.
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
+        &mut self.data
+    }
+
+    /// Convert a multi-index to a flat offset (row-major).
+    #[inline]
+    fn offset(&self, idx: &[usize; N]) -> usize {
+        let mut offset = 0;
+        for ((&i, &d), &s) in idx.iter().zip(self.dims.iter()).zip(self.strides.iter()) {
+            debug_assert!(i < d, "index out of bounds");
+            offset += i * s;
+        }
+        offset
+    }
+
+    /// Iterate over all elements in row-major order.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.data.iter()
+    }
+
+    /// Iterate mutably over all elements in row-major order.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        self.data.iter_mut()
+    }
+}
+
+impl<T: Clone, const N: usize> Tensor<T, N> {
+    /// Create a tensor filled with `value`.
+    pub fn from_elem(dims: [usize; N], value: T) -> Self {
+        let total: usize = dims.iter().product();
+        let strides = compute_strides(&dims);
+        Self {
+            data: vec![value; total],
+            dims,
+            strides,
+        }
+    }
+}
+
+impl<T, const N: usize> Tensor<T, N> {
+    /// Create a tensor by applying `f` to each multi-index (row-major order).
+    pub fn from_fn(dims: [usize; N], mut f: impl FnMut([usize; N]) -> T) -> Self {
+        let total: usize = dims.iter().product();
+        let strides = compute_strides(&dims);
+        let mut data = Vec::with_capacity(total);
+
+        // Iterate over all multi-indices in row-major order.
+        let mut idx = [0usize; N];
+        for _ in 0..total {
+            data.push(f(idx));
+            // Increment the multi-index (rightmost index increments first).
+            for k in (0..N).rev() {
+                idx[k] += 1;
+                if idx[k] < dims[k] {
+                    break;
+                }
+                idx[k] = 0;
+            }
+        }
+
+        Self {
+            data,
+            dims,
+            strides,
+        }
+    }
+}
+
+impl<T, const N: usize> Index<[usize; N]> for Tensor<T, N> {
+    type Output = T;
+
+    fn index(&self, idx: [usize; N]) -> &T {
+        let offset = self.offset(&idx);
+        &self.data[offset]
+    }
+}
+
+impl<T, const N: usize> IndexMut<[usize; N]> for Tensor<T, N> {
+    fn index_mut(&mut self, idx: [usize; N]) -> &mut T {
+        let offset = self.offset(&idx);
+        &mut self.data[offset]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensor2_from_elem() {
+        let t: Tensor2<f64> = Tensor2::from_elem([3, 4], 0.0);
+        assert_eq!(t.len(), 12);
+        assert_eq!(t.dim(0), 3);
+        assert_eq!(t.dim(1), 4);
+        assert_eq!(t[[0, 0]], 0.0);
+    }
+
+    #[test]
+    fn test_tensor2_indexing() {
+        let mut t: Tensor2<f64> = Tensor2::from_elem([2, 3], 0.0);
+        t[[0, 0]] = 1.0;
+        t[[0, 1]] = 2.0;
+        t[[0, 2]] = 3.0;
+        t[[1, 0]] = 4.0;
+        t[[1, 1]] = 5.0;
+        t[[1, 2]] = 6.0;
+        assert_eq!(t[[0, 0]], 1.0);
+        assert_eq!(t[[1, 2]], 6.0);
+        // Row-major: data layout is [1, 2, 3, 4, 5, 6]
+        assert_eq!(t.as_slice(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_tensor3_from_fn() {
+        let t: Tensor3<usize> = Tensor3::from_fn([2, 3, 4], |[i, j, k]| i * 100 + j * 10 + k);
+        assert_eq!(t[[0, 0, 0]], 0);
+        assert_eq!(t[[1, 2, 3]], 123);
+        assert_eq!(t[[0, 1, 2]], 12);
+        assert_eq!(t.dim(0), 2);
+        assert_eq!(t.dim(1), 3);
+        assert_eq!(t.dim(2), 4);
+        assert_eq!(t.len(), 24);
+    }
+
+    #[test]
+    fn test_tensor4_from_fn() {
+        let t: Tensor4<usize> =
+            Tensor4::from_fn([2, 3, 4, 5], |[i, j, k, l]| i * 1000 + j * 100 + k * 10 + l);
+        assert_eq!(t[[1, 2, 3, 4]], 1234);
+        assert_eq!(t.dim(0), 2);
+        assert_eq!(t.dim(1), 3);
+        assert_eq!(t.dim(2), 4);
+        assert_eq!(t.dim(3), 5);
+        assert_eq!(t.len(), 120);
+    }
+
+    #[test]
+    fn test_iter() {
+        let t: Tensor2<i32> = Tensor2::from_fn([2, 3], |[i, j]| (i * 3 + j) as i32);
+        let collected: Vec<i32> = t.iter().copied().collect();
+        assert_eq!(collected, vec![0, 1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_dims() {
+        let t: Tensor3<f64> = Tensor3::from_elem([2, 3, 4], 1.0);
+        assert_eq!(t.dims(), &[2, 3, 4]);
+    }
+}

--- a/crates/tensor4all-simplett/src/types.rs
+++ b/crates/tensor4all-simplett/src/types.rs
@@ -1,16 +1,13 @@
 //! Core types for tensor train operations
 
-use mdarray::DTensor;
+use crate::tensor::Tensor;
+pub use crate::tensor::Tensor3;
 
 /// Local index type (index within a single tensor site)
 pub type LocalIndex = usize;
 
 /// Multi-index type (indices across all sites)
 pub type MultiIndex = Vec<LocalIndex>;
-
-/// A 3D tensor represented using mdarray
-/// Shape is (left_dim, site_dim, right_dim)
-pub type Tensor3<T> = DTensor<T, 3>;
 
 /// Helper functions for Tensor3 operations
 pub trait Tensor3Ops<T: Clone + Default> {
@@ -120,7 +117,7 @@ pub fn tensor3_zeros<T: Clone + Default>(
     site_dim: usize,
     right_dim: usize,
 ) -> Tensor3<T> {
-    Tensor3::from_elem([left_dim, site_dim, right_dim], T::default())
+    Tensor::from_elem([left_dim, site_dim, right_dim], T::default())
 }
 
 /// Create a Tensor3 from flat data (column-major order)
@@ -131,7 +128,7 @@ pub fn tensor3_from_data<T: Clone>(
     right_dim: usize,
 ) -> Tensor3<T> {
     assert_eq!(data.len(), left_dim * site_dim * right_dim);
-    Tensor3::from_fn([left_dim, site_dim, right_dim], |idx| {
+    Tensor::from_fn([left_dim, site_dim, right_dim], |idx| {
         let l = idx[0];
         let s = idx[1];
         let r = idx[2];

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -16,7 +16,6 @@ backend-tenferro = []
 [dependencies]
 num-complex.workspace = true
 num-traits.workspace = true
-mdarray.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 rand.workspace = true

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -1,280 +1,7 @@
 use anyhow::{anyhow, ensure, Result};
-use mdarray::{DynRank, Shape, Tensor};
 use num_complex::{Complex64, ComplexFloat};
-use num_traits::{One, Zero};
-#[cfg(test)]
-use rand::Rng;
-#[cfg(test)]
-use rand_distr::{Distribution, StandardNormal};
-use std::borrow::Cow;
-use std::fmt::Debug;
-use std::ops::{Add, AddAssign, Deref, DerefMut, Mul};
+use std::ops::{Add, Mul};
 use std::sync::Arc;
-
-/// Trait for scalar types supported by legacy dense/diagonal kernels.
-pub(crate) trait DenseScalar:
-    Clone
-    + Copy
-    + Debug
-    + Default
-    + Zero
-    + One
-    + Add<Output = Self>
-    + Mul<Output = Self>
-    + AddAssign
-    + ComplexFloat
-    + Send
-    + Sync
-    + 'static
-{
-}
-
-impl DenseScalar for f64 {}
-impl DenseScalar for Complex64 {}
-
-/// Legacy dense kernel storage backed by mdarray's Tensor with dynamic rank.
-///
-/// This internal type keeps row-major physical kernels alive while higher-level
-/// callers move to `StructuredStorage`.
-#[derive(Debug, Clone)]
-pub(crate) struct DenseStorage<T>(Tensor<T, DynRank>);
-
-impl<T> DenseStorage<T> {
-    /// Create a new legacy dense kernel storage from a Vec with explicit shape.
-    ///
-    /// # Panics
-    /// Panics if the product of dims doesn't match vec.len().
-    pub(crate) fn from_vec_with_shape(vec: Vec<T>, dims: &[usize]) -> Self {
-        let expected_len: usize = dims.iter().product();
-        assert_eq!(
-            vec.len(),
-            expected_len,
-            "Vec length {} doesn't match shape {:?} (product {})",
-            vec.len(),
-            dims,
-            expected_len
-        );
-        let tensor = Tensor::from(vec).into_shape(DynRank::from_dims(dims));
-        Self(tensor)
-    }
-
-    /// Create a scalar (0-dimensional) storage from a single value.
-    #[cfg(test)]
-    pub(crate) fn from_scalar(val: T) -> Self {
-        let tensor = Tensor::from(vec![val]).into_shape(DynRank::from_dims(&[]));
-        Self(tensor)
-    }
-
-    /// Get the shape (dimensions) of the storage.
-    pub(crate) fn dims(&self) -> Vec<usize> {
-        self.0.shape().with_dims(|d| d.to_vec())
-    }
-
-    /// Get the rank (number of dimensions).
-    pub(crate) fn rank(&self) -> usize {
-        self.0.rank()
-    }
-
-    /// Get underlying data as a slice.
-    pub(crate) fn as_slice(&self) -> &[T] {
-        &self.0[..]
-    }
-
-    /// Get underlying data as a mutable slice.
-    #[cfg(test)]
-    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
-        &mut self.0[..]
-    }
-
-    /// Convert to Vec, consuming the storage.
-    #[cfg(test)]
-    pub(crate) fn into_vec(self) -> Vec<T> {
-        self.0.into_vec()
-    }
-
-    /// Get the total number of elements.
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Check if the storage is empty.
-    #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Get a reference to the underlying tensor.
-    #[cfg(test)]
-    pub(crate) fn tensor(&self) -> &Tensor<T, DynRank> {
-        &self.0
-    }
-
-    /// Get a mutable reference to the underlying tensor.
-    #[cfg(test)]
-    pub(crate) fn tensor_mut(&mut self) -> &mut Tensor<T, DynRank> {
-        &mut self.0
-    }
-
-    /// Consume and return the underlying tensor.
-    #[cfg(test)]
-    pub(crate) fn into_tensor(self) -> Tensor<T, DynRank> {
-        self.0
-    }
-
-    /// Create from an existing tensor.
-    #[cfg(test)]
-    pub(crate) fn from_tensor(tensor: Tensor<T, DynRank>) -> Self {
-        Self(tensor)
-    }
-
-    /// Iterate over elements.
-    #[cfg(test)]
-    pub(crate) fn iter(&self) -> std::slice::Iter<'_, T> {
-        self.as_slice().iter()
-    }
-}
-
-impl<T: Clone> DenseStorage<T> {
-    /// Get element at linear index.
-    #[cfg(test)]
-    pub(crate) fn get(&self, i: usize) -> T {
-        self.0[i].clone()
-    }
-}
-
-impl<T: Copy> DenseStorage<T> {
-    /// Set element at linear index.
-    #[cfg(test)]
-    pub(crate) fn set(&mut self, i: usize, val: T) {
-        self.0[i] = val;
-    }
-}
-
-impl<T> Deref for DenseStorage<T> {
-    type Target = Tensor<T, DynRank>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<T> DerefMut for DenseStorage<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<T: DenseScalar> DenseStorage<T> {
-    /// Permute the dense storage data according to the given permutation.
-    ///
-    /// Uses the internal shape information - no external dims parameter needed.
-    pub(crate) fn permute(&self, perm: &[usize]) -> Self {
-        assert_eq!(
-            perm.len(),
-            self.rank(),
-            "permutation length {} must match rank {}",
-            perm.len(),
-            self.rank()
-        );
-
-        // Use mdarray's permute functionality directly
-        let permuted = self.0.permute(perm).to_tensor();
-        Self(permuted)
-    }
-
-    /// Contract this dense storage with another dense storage.
-    ///
-    /// This method handles non-contiguous contracted axes by permuting the tensors
-    /// to make the contracted axes contiguous before GEMM-style contraction.
-    ///
-    /// Uses internal shape information - no external dims parameters needed.
-    pub(crate) fn contract(&self, axes: &[usize], other: &Self, other_axes: &[usize]) -> Self {
-        let dims = self.dims();
-        let other_dims = other.dims();
-
-        // For self: move contracted axes to end.
-        // For other: move contracted axes to front.
-        let (perm_self, new_axes_self, new_dims_self) =
-            compute_contraction_permutation(&dims, axes, false);
-        let (perm_other, new_axes_other, new_dims_other) =
-            compute_contraction_permutation(&other_dims, other_axes, true);
-
-        let storage_self = if perm_self.iter().enumerate().all(|(i, &p)| i == p) {
-            Cow::Borrowed(self)
-        } else {
-            Cow::Owned(self.permute(&perm_self))
-        };
-        let storage_other = if perm_other.iter().enumerate().all(|(i, &p)| i == p) {
-            Cow::Borrowed(other)
-        } else {
-            Cow::Owned(other.permute(&perm_other))
-        };
-
-        let result_vec = contract_via_gemm(
-            storage_self.as_slice(),
-            &new_dims_self,
-            &new_axes_self,
-            storage_other.as_slice(),
-            &new_dims_other,
-            &new_axes_other,
-        );
-
-        let result_dims = compute_result_dims(&dims, axes, &other_dims, other_axes);
-        Self::from_vec_with_shape(result_vec, &result_dims)
-    }
-}
-
-// Random generation for f64
-impl DenseStorage<f64> {
-    /// Create storage with random values from standard normal distribution.
-    ///
-    /// Creates a 1D storage with the given size.
-    #[cfg(test)]
-    pub(crate) fn random_1d<R: Rng>(rng: &mut R, size: usize) -> Self {
-        let data: Vec<f64> = (0..size).map(|_| StandardNormal.sample(rng)).collect();
-        Self::from_vec_with_shape(data, &[size])
-    }
-
-    /// Create storage with random values with explicit shape.
-    #[cfg(test)]
-    pub(crate) fn random<R: Rng>(rng: &mut R, dims: &[usize]) -> Self {
-        let size: usize = dims.iter().product();
-        let data: Vec<f64> = (0..size).map(|_| StandardNormal.sample(rng)).collect();
-        Self::from_vec_with_shape(data, dims)
-    }
-}
-
-// Random generation for Complex64
-impl DenseStorage<Complex64> {
-    /// Create storage with random complex values (re, im both from standard normal).
-    ///
-    /// Creates a 1D storage with the given size.
-    #[cfg(test)]
-    pub(crate) fn random_1d<R: Rng>(rng: &mut R, size: usize) -> Self {
-        let data: Vec<Complex64> = (0..size)
-            .map(|_| Complex64::new(StandardNormal.sample(rng), StandardNormal.sample(rng)))
-            .collect();
-        Self::from_vec_with_shape(data, &[size])
-    }
-
-    /// Create storage with random complex values with explicit shape.
-    #[cfg(test)]
-    pub(crate) fn random<R: Rng>(rng: &mut R, dims: &[usize]) -> Self {
-        let size: usize = dims.iter().product();
-        let data: Vec<Complex64> = (0..size)
-            .map(|_| Complex64::new(StandardNormal.sample(rng), StandardNormal.sample(rng)))
-            .collect();
-        Self::from_vec_with_shape(data, dims)
-    }
-}
-
-/// Type alias for f64 dense storage (for backward compatibility).
-#[doc(hidden)]
-pub(crate) type DenseStorageF64 = DenseStorage<f64>;
-
-/// Type alias for Complex64 dense storage (for backward compatibility).
-#[doc(hidden)]
-pub(crate) type DenseStorageC64 = DenseStorage<Complex64>;
 
 pub(crate) fn col_major_strides(dims: &[usize]) -> Vec<isize> {
     let mut strides = Vec::with_capacity(dims.len());
@@ -349,26 +76,6 @@ fn col_major_multi_index(mut linear: usize, dims: &[usize]) -> Vec<usize> {
         }
     }
     index
-}
-
-fn row_major_to_col_major_values<T: Clone>(data: &[T], dims: &[usize]) -> Vec<T> {
-    let total_len: usize = dims.iter().product();
-    if total_len == 0 {
-        return Vec::new();
-    }
-
-    let row_major_strides = compute_strides(dims);
-    (0..total_len)
-        .map(|linear| {
-            let index = col_major_multi_index(linear, dims);
-            let offset: usize = index
-                .iter()
-                .zip(row_major_strides.iter())
-                .map(|(&value, &stride)| value * stride)
-                .sum();
-            data[offset].clone()
-        })
-        .collect()
 }
 
 fn offset_from_strides(index: &[usize], strides: &[isize]) -> usize {
@@ -579,475 +286,10 @@ impl<T: Copy> StructuredStorage<T> {
     }
 }
 
-/// Compute the result dimensions after contraction.
-fn compute_result_dims(
-    dims_a: &[usize],
-    axes_a: &[usize],
-    dims_b: &[usize],
-    axes_b: &[usize],
-) -> Vec<usize> {
-    let mut result_dims = Vec::new();
-    for (axis, &dim) in dims_a.iter().enumerate() {
-        if !axes_a.contains(&axis) {
-            result_dims.push(dim);
-        }
-    }
-    for (axis, &dim) in dims_b.iter().enumerate() {
-        if !axes_b.contains(&axis) {
-            result_dims.push(dim);
-        }
-    }
-    result_dims
-}
-
-/// Contract two tensors via GEMM-style matrix multiplication.
-///
-/// This function assumes contracted axes are already contiguous:
-/// - For `a`: contracted axes are at the end.
-/// - For `b`: contracted axes are at the front.
-fn contract_via_gemm<T: DenseScalar>(
-    a: &[T],
-    dims_a: &[usize],
-    axes_a: &[usize],
-    b: &[T],
-    dims_b: &[usize],
-    axes_b: &[usize],
-) -> Vec<T> {
-    let naxes = axes_a.len();
-    assert_eq!(naxes, axes_b.len(), "Number of contracted axes must match");
-
-    let ndim_a = dims_a.len();
-
-    let m: usize = dims_a.iter().take(ndim_a - naxes).product::<usize>().max(1);
-    let k: usize = dims_a.iter().skip(ndim_a - naxes).product::<usize>().max(1);
-    let n: usize = dims_b.iter().skip(naxes).product::<usize>().max(1);
-
-    let k_b: usize = dims_b.iter().take(naxes).product::<usize>().max(1);
-    assert_eq!(
-        k, k_b,
-        "Contracted dimension sizes must match: {} vs {}",
-        k, k_b
-    );
-
-    let mut c = vec![T::zero(); m * n];
-    for i in 0..m {
-        for l in 0..k {
-            let a_il = a[i * k + l];
-            for j in 0..n {
-                c[i * n + j] += a_il * b[l * n + j];
-            }
-        }
-    }
-    c
-}
-
-/// Compute permutation to make contracted axes contiguous.
-///
-/// If `axes_at_front` is true, contracted axes are moved to the front.
-/// Otherwise, contracted axes are moved to the end.
-///
-/// Returns `(permutation, new_axes, new_dims)`.
-fn compute_contraction_permutation(
-    dims: &[usize],
-    axes: &[usize],
-    axes_at_front: bool,
-) -> (Vec<usize>, Vec<usize>, Vec<usize>) {
-    let ndim = dims.len();
-    let naxes = axes.len();
-    let non_contracted: Vec<usize> = (0..ndim).filter(|i| !axes.contains(i)).collect();
-
-    let perm: Vec<usize> = if axes_at_front {
-        axes.iter().chain(non_contracted.iter()).copied().collect()
-    } else {
-        non_contracted.iter().chain(axes.iter()).copied().collect()
-    };
-    let new_dims: Vec<usize> = perm.iter().map(|&i| dims[i]).collect();
-    let new_axes: Vec<usize> = if axes_at_front {
-        (0..naxes).collect()
-    } else {
-        (ndim - naxes..ndim).collect()
-    };
-    (perm, new_axes, new_dims)
-}
-
-/// Diagonal storage for tensor elements, generic over scalar type.
-#[derive(Debug, Clone)]
-pub(crate) struct DiagStorage<T>(Vec<T>);
-
-impl<T> DiagStorage<T> {
-    /// Create a new diagonal storage from a vector of diagonal elements.
-    pub(crate) fn from_vec(vec: Vec<T>) -> Self {
-        Self(vec)
-    }
-
-    /// Get a slice of the diagonal elements.
-    pub(crate) fn as_slice(&self) -> &[T] {
-        &self.0
-    }
-
-    /// Get a mutable slice of the diagonal elements.
-    #[cfg(test)]
-    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
-        &mut self.0
-    }
-
-    /// Consume the storage and return the underlying vector.
-    #[cfg(test)]
-    pub(crate) fn into_vec(self) -> Vec<T> {
-        self.0
-    }
-
-    /// Return the number of diagonal elements.
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Return true if the storage has no elements.
-    #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl<T: Clone> DiagStorage<T> {
-    /// Get a clone of the diagonal element at index `i`.
-    #[cfg(test)]
-    pub(crate) fn get(&self, i: usize) -> T {
-        self.0[i].clone()
-    }
-}
-
-impl<T: Copy> DiagStorage<T> {
-    /// Set the diagonal element at index `i` to `val`.
-    #[cfg(test)]
-    pub(crate) fn set(&mut self, i: usize, val: T) {
-        self.0[i] = val;
-    }
-}
-
-impl<T: DenseScalar> DiagStorage<T> {
-    /// Convert diagonal storage to a dense vector representation.
-    /// Creates a dense vector with diagonal elements set and off-diagonal elements as zero.
-    pub(crate) fn to_dense_vec(&self, dims: &[usize]) -> Vec<T> {
-        let total_size: usize = dims.iter().product();
-        let mut dense_vec = vec![T::zero(); total_size];
-        let mindim_val = mindim(dims);
-
-        // Set diagonal elements
-        // For a tensor with indices [i, j, k, ...] where all have dimension d,
-        // the diagonal elements are at positions where i == j == k == ...
-        // The linear index for position (i, i, i, ...) is computed as:
-        // i * (1 + stride_1 + stride_2 + ...)
-        // For a tensor with dimensions [d, d, d, ...], the stride for dimension k is d^(rank - k - 1)
-        let rank = dims.len();
-        if rank == 0 {
-            return vec![self.0[0]];
-        }
-
-        // Compute stride for each dimension
-        let mut strides = vec![1; rank];
-        for i in (0..rank - 1).rev() {
-            strides[i] = strides[i + 1] * dims[i + 1];
-        }
-
-        // Total stride for diagonal: sum of all strides
-        let diag_stride: usize = strides.iter().sum();
-
-        // Set diagonal elements
-        for i in 0..mindim_val.min(self.0.len()) {
-            let linear_idx = i * diag_stride;
-            if linear_idx < total_size {
-                dense_vec[linear_idx] = self.0[i];
-            }
-        }
-
-        dense_vec
-    }
-
-    /// Contract this diagonal storage with another diagonal storage of the same type.
-    /// Returns either a scalar (Dense with one element) or a diagonal storage.
-    pub(crate) fn contract_diag_diag(
-        &self,
-        dims: &[usize],
-        other: &Self,
-        other_dims: &[usize],
-        result_dims: &[usize],
-        make_dense: impl FnOnce(Vec<T>) -> Storage,
-        make_diag: impl FnOnce(Vec<T>) -> Storage,
-    ) -> Storage {
-        let mindim_a = mindim(dims);
-        let mindim_b = mindim(other_dims);
-        let min_len = mindim_a.min(mindim_b).min(self.0.len()).min(other.0.len());
-
-        if result_dims.is_empty() {
-            // All indices contracted: compute inner product (scalar result)
-            let scalar: T = (0..min_len).fold(T::zero(), |acc, i| acc + self.0[i] * other.0[i]);
-            make_dense(vec![scalar])
-        } else {
-            // Some indices remain: element-wise product (DiagTensor result)
-            let result_diag: Vec<T> = (0..min_len).map(|i| self.0[i] * other.0[i]).collect();
-            make_diag(result_diag)
-        }
-    }
-
-    /// Contract this diagonal storage with a dense storage.
-    ///
-    /// # Arguments
-    /// * `diag_dims` - Dimensions of the diagonal tensor (all must be equal)
-    /// * `axes_diag` - Axes of the diagonal tensor to contract
-    /// * `dense` - The dense storage to contract with
-    /// * `dense_dims` - Dimensions of the dense tensor
-    /// * `axes_dense` - Axes of the dense tensor to contract (must match axes_diag in length)
-    /// * `result_dims` - Dimensions of the result tensor
-    ///
-    /// # Returns
-    /// The contracted storage (always Dense, since Diag structure is generally lost)
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn contract_diag_dense(
-        &self,
-        diag_dims: &[usize],
-        axes_diag: &[usize],
-        dense: &DenseStorage<T>,
-        dense_dims: &[usize],
-        axes_dense: &[usize],
-        result_dims: &[usize],
-        make_storage: impl FnOnce(Vec<T>) -> Storage,
-    ) -> Storage {
-        contract_diag_dense_impl(
-            self.as_slice(),
-            diag_dims,
-            axes_diag,
-            dense.as_slice(),
-            dense_dims,
-            axes_dense,
-            result_dims,
-            make_storage,
-        )
-    }
-}
-
-/// Type alias for f64 diagonal storage (for backward compatibility).
-#[doc(hidden)]
-pub(crate) type DiagStorageF64 = DiagStorage<f64>;
-
-/// Type alias for Complex64 diagonal storage (for backward compatibility).
-#[doc(hidden)]
-pub(crate) type DiagStorageC64 = DiagStorage<Complex64>;
-
-/// Generic implementation of Diag × Dense contraction.
-///
-/// This function exploits the diagonal structure: for a diagonal tensor,
-/// all indices have the same value t (0 <= t < d). When contracting with
-/// a dense tensor, we only need to access the "diagonal slices" of the dense tensor.
-///
-/// Algorithm:
-/// 1. For each diagonal index t = 0..d:
-///    - Get diag[t]
-///    - Extract the slice of dense where all axes_dense have value t
-///    - Multiply and accumulate into result
-#[allow(clippy::too_many_arguments)]
-fn contract_diag_dense_impl<T: DenseScalar>(
-    diag: &[T],
-    diag_dims: &[usize],
-    axes_diag: &[usize],
-    dense: &[T],
-    dense_dims: &[usize],
-    axes_dense: &[usize],
-    result_dims: &[usize],
-    make_storage: impl FnOnce(Vec<T>) -> Storage,
-) -> Storage {
-    let diag_rank = diag_dims.len();
-    let dense_rank = dense_dims.len();
-    let _num_contracted = axes_diag.len();
-
-    // The diagonal dimension (all diag_dims should be equal)
-    let d = if diag_dims.is_empty() {
-        1
-    } else {
-        diag_dims[0]
-    };
-
-    // Compute the non-contracted axes for the result
-    let diag_non_contracted: Vec<usize> =
-        (0..diag_rank).filter(|i| !axes_diag.contains(i)).collect();
-    let dense_non_contracted: Vec<usize> = (0..dense_rank)
-        .filter(|i| !axes_dense.contains(i))
-        .collect();
-
-    // Result size
-    let result_size: usize = result_dims.iter().product();
-    let result_size = if result_size == 0 { 1 } else { result_size };
-
-    // Compute strides for dense tensor (row-major)
-    let dense_strides = compute_strides(dense_dims);
-
-    // Compute the size of the non-contracted part of dense
-    let dense_non_contracted_dims: Vec<usize> = dense_non_contracted
-        .iter()
-        .map(|&i| dense_dims[i])
-        .collect();
-    let dense_slice_size: usize = dense_non_contracted_dims.iter().product();
-    let dense_slice_size = if dense_slice_size == 0 {
-        1
-    } else {
-        dense_slice_size
-    };
-
-    // Compute strides for the non-contracted dense dimensions
-    let dense_non_contracted_strides = compute_strides(&dense_non_contracted_dims);
-
-    // If all diag axes are contracted, result has shape = dense_non_contracted_dims
-    // If some diag axes remain, result has shape = [d, d, ...] (diag non-contracted) + dense_non_contracted_dims
-    let diag_non_contracted_count = diag_non_contracted.len();
-
-    if diag_non_contracted_count == 0 {
-        // All diagonal indices contracted: result is purely from dense's non-contracted part
-        // For each t, we accumulate diag[t] * dense_slice[t] into result
-        let mut result = vec![T::zero(); result_size];
-
-        for (t, &diag_val) in diag.iter().enumerate().take(d.min(diag.len())) {
-            // Compute base offset in dense for this t (all contracted axes = t)
-            let base_offset: usize = axes_dense.iter().map(|&axis| t * dense_strides[axis]).sum();
-
-            // Iterate over all non-contracted positions in dense
-            for (flat_idx, result_item) in result.iter_mut().enumerate().take(dense_slice_size) {
-                // Convert flat_idx to multi-index for non-contracted dims
-                let mut offset = base_offset;
-                let mut remaining = flat_idx;
-                for (local_axis, &global_axis) in dense_non_contracted.iter().enumerate() {
-                    let idx = remaining / dense_non_contracted_strides[local_axis];
-                    remaining %= dense_non_contracted_strides[local_axis];
-                    offset += idx * dense_strides[global_axis];
-                }
-
-                *result_item += diag_val * dense[offset];
-            }
-        }
-
-        make_storage(result)
-    } else {
-        // Some diagonal indices remain: result has diagonal structure in those indices
-        // Result shape: [d, d, ...] (diag_non_contracted_count times) + dense_non_contracted_dims
-        // But since the diagonal indices must all equal, only the diagonal elements are non-zero
-        // Result is effectively: for each t, result[t,t,...,dense_indices] = diag[t] * dense_slice
-
-        // Compute result strides
-        let result_strides = compute_strides(result_dims);
-
-        let mut result = vec![T::zero(); result_size];
-
-        for (t, &diag_val) in diag.iter().enumerate().take(d.min(diag.len())) {
-            // Compute base offset in dense for this t
-            let base_offset_dense: usize =
-                axes_dense.iter().map(|&axis| t * dense_strides[axis]).sum();
-
-            // Compute base offset in result for diagonal position (t, t, ...)
-            let base_offset_result: usize = (0..diag_non_contracted_count)
-                .map(|i| t * result_strides[i])
-                .sum();
-
-            // Iterate over all non-contracted positions in dense
-            #[allow(clippy::needless_range_loop)]
-            for flat_idx in 0..dense_slice_size {
-                // Convert flat_idx to multi-index for non-contracted dims
-                let mut offset_dense = base_offset_dense;
-                let mut offset_result = base_offset_result;
-                let mut remaining = flat_idx;
-
-                for (local_axis, &global_axis) in dense_non_contracted.iter().enumerate() {
-                    let idx = remaining / dense_non_contracted_strides[local_axis];
-                    remaining %= dense_non_contracted_strides[local_axis];
-                    offset_dense += idx * dense_strides[global_axis];
-                    // In result, these come after the diagonal indices
-                    offset_result += idx * result_strides[diag_non_contracted_count + local_axis];
-                }
-
-                result[offset_result] = diag_val * dense[offset_dense];
-            }
-        }
-
-        make_storage(result)
-    }
-}
-
-/// Compute row-major strides for given dimensions.
-fn compute_strides(dims: &[usize]) -> Vec<usize> {
-    if dims.is_empty() {
-        return vec![];
-    }
-    let mut strides = vec![1; dims.len()];
-    for i in (0..dims.len() - 1).rev() {
-        strides[i] = strides[i + 1] * dims[i + 1];
-    }
-    strides
-}
-
-/// Helper for Dense × Diag contraction: compute as Diag × Dense and permute result.
-///
-/// This function handles the case where Dense appears first in the contraction.
-/// It computes the contraction using `contract_diag_dense_impl` (which assumes Diag first),
-/// then permutes the result to match the expected dimension order.
-#[allow(clippy::too_many_arguments)]
-fn contract_dense_diag_impl<T: DenseScalar>(
-    dense: &DenseStorage<T>,
-    dense_dims: &[usize],
-    axes_dense: &[usize],
-    diag: &DiagStorage<T>,
-    diag_dims: &[usize],
-    axes_diag: &[usize],
-    _result_dims: &[usize],
-    make_storage: impl FnOnce(Vec<T>, &[usize]) -> Storage,
-    make_permuted: impl FnOnce(Storage, &[usize]) -> Storage,
-) -> Storage {
-    let diag_rank = diag_dims.len();
-    let dense_rank = dense_dims.len();
-    let diag_non_contracted_count = diag_rank - axes_diag.len();
-    let dense_non_contracted_count = dense_rank - axes_dense.len();
-
-    // Build reordered result_dims: [diag_non_contracted..., dense_non_contracted...]
-    let diag_non_contracted_dims: Vec<usize> = (0..diag_rank)
-        .filter(|i| !axes_diag.contains(i))
-        .map(|i| diag_dims[i])
-        .collect();
-    let dense_non_contracted_dims: Vec<usize> = (0..dense_rank)
-        .filter(|i| !axes_dense.contains(i))
-        .map(|i| dense_dims[i])
-        .collect();
-    let swapped_result_dims: Vec<usize> = diag_non_contracted_dims
-        .iter()
-        .chain(dense_non_contracted_dims.iter())
-        .copied()
-        .collect();
-
-    let intermediate = contract_diag_dense_impl(
-        diag.as_slice(),
-        diag_dims,
-        axes_diag,
-        dense.as_slice(),
-        dense_dims,
-        axes_dense,
-        &swapped_result_dims,
-        |v| make_storage(v, &swapped_result_dims),
-    );
-
-    // Permute to get [dense_non_contracted..., diag_non_contracted...]
-    if diag_non_contracted_count > 0 && dense_non_contracted_count > 0 {
-        // Build permutation: move diag dims to end
-        let mut perm: Vec<usize> = (diag_non_contracted_count
-            ..(diag_non_contracted_count + dense_non_contracted_count))
-            .collect();
-        perm.extend(0..diag_non_contracted_count);
-        make_permuted(intermediate, &perm)
-    } else {
-        intermediate
-    }
-}
-
 /// Storage backend for tensor data.
 ///
 /// Public callers interact with this opaque wrapper through constructors and
-/// high-level query/materialization methods. Temporary dense/diagonal kernel
-/// variants stay crate-private during the structured-storage migration.
+/// high-level query/materialization methods.
 #[derive(Debug, Clone)]
 pub struct Storage(pub(crate) StorageRepr);
 
@@ -1060,22 +302,10 @@ pub(crate) struct NativePayload<T> {
 
 #[derive(Debug, Clone)]
 pub(crate) enum StorageRepr {
-    /// Dense storage with f64 elements.
-    #[doc(hidden)]
-    DenseF64(DenseStorageF64),
-    /// Dense storage with Complex64 elements.
-    #[doc(hidden)]
-    DenseC64(DenseStorageC64),
-    /// Diagonal storage with f64 elements.
-    #[doc(hidden)]
-    DiagF64(DiagStorageF64),
-    /// Diagonal storage with Complex64 elements.
-    #[doc(hidden)]
-    DiagC64(DiagStorageC64),
-    /// General structured storage with f64 elements.
-    StructuredF64(StructuredStorage<f64>),
-    /// General structured storage with Complex64 elements.
-    StructuredC64(StructuredStorage<Complex64>),
+    /// Storage with f64 elements.
+    F64(StructuredStorage<f64>),
+    /// Storage with Complex64 elements.
+    C64(StructuredStorage<Complex64>),
 }
 
 /// Types that can be computed as the result of a reduction over `Storage`.
@@ -1089,12 +319,8 @@ pub trait SumFromStorage: Sized {
 impl SumFromStorage for f64 {
     fn sum_from_storage(storage: &Storage) -> Self {
         match &storage.0 {
-            StorageRepr::DenseF64(v) => v.as_slice().iter().copied().sum(),
-            StorageRepr::DenseC64(v) => v.as_slice().iter().map(|z| z.re).sum(),
-            StorageRepr::DiagF64(v) => v.as_slice().iter().copied().sum(),
-            StorageRepr::DiagC64(v) => v.as_slice().iter().map(|z| z.re).sum(),
-            StorageRepr::StructuredF64(v) => v.data().iter().copied().sum(),
-            StorageRepr::StructuredC64(v) => v.data().iter().map(|z| z.re).sum(),
+            StorageRepr::F64(v) => v.data().iter().copied().sum(),
+            StorageRepr::C64(v) => v.data().iter().map(|z| z.re).sum(),
         }
     }
 }
@@ -1102,12 +328,8 @@ impl SumFromStorage for f64 {
 impl SumFromStorage for Complex64 {
     fn sum_from_storage(storage: &Storage) -> Self {
         match &storage.0 {
-            StorageRepr::DenseF64(v) => Complex64::new(v.as_slice().iter().copied().sum(), 0.0),
-            StorageRepr::DenseC64(v) => v.as_slice().iter().copied().sum(),
-            StorageRepr::DiagF64(v) => Complex64::new(v.as_slice().iter().copied().sum(), 0.0),
-            StorageRepr::DiagC64(v) => v.as_slice().iter().copied().sum(),
-            StorageRepr::StructuredF64(v) => Complex64::new(v.data().iter().copied().sum(), 0.0),
-            StorageRepr::StructuredC64(v) => v.data().iter().copied().sum(),
+            StorageRepr::F64(v) => Complex64::new(v.data().iter().copied().sum(), 0.0),
+            StorageRepr::C64(v) => v.data().iter().copied().sum(),
         }
     }
 }
@@ -1125,30 +347,6 @@ impl Storage {
         &self.0
     }
 
-    pub(crate) fn dense_f64_legacy(value: DenseStorageF64) -> Self {
-        Self(StorageRepr::DenseF64(value))
-    }
-
-    pub(crate) fn dense_c64_legacy(value: DenseStorageC64) -> Self {
-        Self(StorageRepr::DenseC64(value))
-    }
-
-    pub(crate) fn diag_f64_legacy(value: DiagStorageF64) -> Self {
-        Self(StorageRepr::DiagF64(value))
-    }
-
-    pub(crate) fn diag_c64_legacy(value: DiagStorageC64) -> Self {
-        Self(StorageRepr::DiagC64(value))
-    }
-
-    pub(crate) fn structured_f64(value: StructuredStorage<f64>) -> Self {
-        Self(StorageRepr::StructuredF64(value))
-    }
-
-    pub(crate) fn structured_c64(value: StructuredStorage<Complex64>) -> Self {
-        Self(StorageRepr::StructuredC64(value))
-    }
-
     fn validate_dense_len<T>(data: &[T], logical_dims: &[usize], label: &str) -> Result<()> {
         let expected_len: usize = logical_dims.iter().product();
         ensure!(
@@ -1161,34 +359,9 @@ impl Storage {
         Ok(())
     }
 
-    fn validate_diag_dims(payload_len: usize, logical_dims: &[usize], label: &str) -> Result<()> {
-        ensure!(
-            logical_dims.iter().all(|&dim| dim == payload_len),
-            "{label} payload len {payload_len} does not match logical dims {:?}",
-            logical_dims
-        );
-        Ok(())
-    }
-
     pub(crate) fn native_payload_f64(&self, logical_dims: &[usize]) -> Result<NativePayload<f64>> {
         match &self.0 {
-            StorageRepr::DenseF64(value) => {
-                Self::validate_dense_len(value.as_slice(), logical_dims, "dense f64 payload")?;
-                Ok(NativePayload {
-                    data: row_major_to_col_major_values(value.as_slice(), logical_dims),
-                    payload_dims: logical_dims.to_vec(),
-                    axis_classes: None,
-                })
-            }
-            StorageRepr::DiagF64(value) => {
-                Self::validate_diag_dims(value.len(), logical_dims, "diag f64")?;
-                Ok(NativePayload {
-                    data: value.as_slice().to_vec(),
-                    payload_dims: vec![value.len()],
-                    axis_classes: Some(vec![0; logical_dims.len()]),
-                })
-            }
-            StorageRepr::StructuredF64(value) => {
+            StorageRepr::F64(value) => {
                 ensure!(
                     value.logical_dims() == logical_dims,
                     "logical dims {:?} do not match structured f64 logical dims {:?}",
@@ -1206,11 +379,9 @@ impl Storage {
                     axis_classes,
                 })
             }
-            StorageRepr::DenseC64(_) | StorageRepr::DiagC64(_) | StorageRepr::StructuredC64(_) => {
-                Err(anyhow!(
-                    "complex storage cannot be converted to f64 native payload"
-                ))
-            }
+            StorageRepr::C64(_) => Err(anyhow!(
+                "complex storage cannot be converted to f64 native payload"
+            )),
         }
     }
 
@@ -1219,47 +390,7 @@ impl Storage {
         logical_dims: &[usize],
     ) -> Result<NativePayload<Complex64>> {
         match &self.0 {
-            StorageRepr::DenseC64(value) => {
-                Self::validate_dense_len(value.as_slice(), logical_dims, "dense c64 payload")?;
-                Ok(NativePayload {
-                    data: row_major_to_col_major_values(value.as_slice(), logical_dims),
-                    payload_dims: logical_dims.to_vec(),
-                    axis_classes: None,
-                })
-            }
-            StorageRepr::DiagC64(value) => {
-                Self::validate_diag_dims(value.len(), logical_dims, "diag c64")?;
-                Ok(NativePayload {
-                    data: value.as_slice().to_vec(),
-                    payload_dims: vec![value.len()],
-                    axis_classes: Some(vec![0; logical_dims.len()]),
-                })
-            }
-            StorageRepr::DenseF64(value) => {
-                Self::validate_dense_len(value.as_slice(), logical_dims, "dense f64 payload")?;
-                Ok(NativePayload {
-                    data: row_major_to_col_major_values(value.as_slice(), logical_dims)
-                        .into_iter()
-                        .map(|entry| Complex64::new(entry, 0.0))
-                        .collect(),
-                    payload_dims: logical_dims.to_vec(),
-                    axis_classes: None,
-                })
-            }
-            StorageRepr::DiagF64(value) => {
-                Self::validate_diag_dims(value.len(), logical_dims, "diag f64")?;
-                Ok(NativePayload {
-                    data: value
-                        .as_slice()
-                        .iter()
-                        .copied()
-                        .map(|entry| Complex64::new(entry, 0.0))
-                        .collect(),
-                    payload_dims: vec![value.len()],
-                    axis_classes: Some(vec![0; logical_dims.len()]),
-                })
-            }
-            StorageRepr::StructuredC64(value) => {
+            StorageRepr::C64(value) => {
                 ensure!(
                     value.logical_dims() == logical_dims,
                     "logical dims {:?} do not match structured c64 logical dims {:?}",
@@ -1277,7 +408,7 @@ impl Storage {
                     axis_classes,
                 })
             }
-            StorageRepr::StructuredF64(value) => {
+            StorageRepr::F64(value) => {
                 ensure!(
                     value.logical_dims() == logical_dims,
                     "logical dims {:?} do not match structured f64 logical dims {:?} for promotion",
@@ -1329,7 +460,7 @@ impl Storage {
     /// Create dense f64 storage from column-major logical values.
     pub fn from_dense_f64_col_major(data: Vec<f64>, logical_dims: &[usize]) -> Result<Self> {
         Self::validate_dense_len(&data, logical_dims, "dense f64 payload")?;
-        Ok(Self::from_repr(StorageRepr::StructuredF64(
+        Ok(Self::from_repr(StorageRepr::F64(
             StructuredStorage::from_dense_col_major(data, logical_dims),
         )))
     }
@@ -1337,21 +468,21 @@ impl Storage {
     /// Create dense Complex64 storage from column-major logical values.
     pub fn from_dense_c64_col_major(data: Vec<Complex64>, logical_dims: &[usize]) -> Result<Self> {
         Self::validate_dense_len(&data, logical_dims, "dense c64 payload")?;
-        Ok(Self::from_repr(StorageRepr::StructuredC64(
+        Ok(Self::from_repr(StorageRepr::C64(
             StructuredStorage::from_dense_col_major(data, logical_dims),
         )))
     }
 
     /// Create diagonal f64 storage from column-major diagonal payload values.
     pub fn from_diag_f64_col_major(diag_data: Vec<f64>, logical_rank: usize) -> Result<Self> {
-        Ok(Self::from_repr(StorageRepr::StructuredF64(
+        Ok(Self::from_repr(StorageRepr::F64(
             StructuredStorage::from_diag_col_major(diag_data, logical_rank),
         )))
     }
 
     /// Create diagonal Complex64 storage from column-major diagonal payload values.
     pub fn from_diag_c64_col_major(diag_data: Vec<Complex64>, logical_rank: usize) -> Result<Self> {
-        Ok(Self::from_repr(StorageRepr::StructuredC64(
+        Ok(Self::from_repr(StorageRepr::C64(
             StructuredStorage::from_diag_col_major(diag_data, logical_rank),
         )))
     }
@@ -1363,9 +494,12 @@ impl Storage {
         strides: Vec<isize>,
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
-        Ok(Self::from_repr(StorageRepr::StructuredF64(
-            StructuredStorage::new(data, payload_dims, strides, axis_classes)?,
-        )))
+        Ok(Self::from_repr(StorageRepr::F64(StructuredStorage::new(
+            data,
+            payload_dims,
+            strides,
+            axis_classes,
+        )?)))
     }
 
     /// Create a new structured Complex64 storage.
@@ -1375,45 +509,38 @@ impl Storage {
         strides: Vec<isize>,
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
-        Ok(Self::from_repr(StorageRepr::StructuredC64(
-            StructuredStorage::new(data, payload_dims, strides, axis_classes)?,
-        )))
+        Ok(Self::from_repr(StorageRepr::C64(StructuredStorage::new(
+            data,
+            payload_dims,
+            strides,
+            axis_classes,
+        )?)))
     }
 
     /// Check if this storage is logically dense.
     pub fn is_dense(&self) -> bool {
         match &self.0 {
-            StorageRepr::DenseF64(_) | StorageRepr::DenseC64(_) => true,
-            StorageRepr::DiagF64(_) | StorageRepr::DiagC64(_) => false,
-            StorageRepr::StructuredF64(value) => value.is_dense(),
-            StorageRepr::StructuredC64(value) => value.is_dense(),
+            StorageRepr::F64(value) => value.is_dense(),
+            StorageRepr::C64(value) => value.is_dense(),
         }
     }
 
     /// Check if this storage is a Diag storage type.
     pub fn is_diag(&self) -> bool {
         match &self.0 {
-            StorageRepr::DiagF64(_) | StorageRepr::DiagC64(_) => true,
-            StorageRepr::DenseF64(_) | StorageRepr::DenseC64(_) => false,
-            StorageRepr::StructuredF64(value) => value.is_diag(),
-            StorageRepr::StructuredC64(value) => value.is_diag(),
+            StorageRepr::F64(value) => value.is_diag(),
+            StorageRepr::C64(value) => value.is_diag(),
         }
     }
 
     /// Check if this storage uses f64 scalar type.
     pub fn is_f64(&self) -> bool {
-        matches!(
-            &self.0,
-            StorageRepr::DenseF64(_) | StorageRepr::DiagF64(_) | StorageRepr::StructuredF64(_)
-        )
+        matches!(&self.0, StorageRepr::F64(_))
     }
 
     /// Check if this storage uses Complex64 scalar type.
     pub fn is_c64(&self) -> bool {
-        matches!(
-            &self.0,
-            StorageRepr::DenseC64(_) | StorageRepr::DiagC64(_) | StorageRepr::StructuredC64(_)
-        )
+        matches!(&self.0, StorageRepr::C64(_))
     }
 
     /// Check if this storage uses complex scalar type.
@@ -1426,12 +553,8 @@ impl Storage {
     /// Get the length of the storage (number of elements).
     pub fn len(&self) -> usize {
         match &self.0 {
-            StorageRepr::DenseF64(v) => v.len(),
-            StorageRepr::DenseC64(v) => v.len(),
-            StorageRepr::DiagF64(v) => v.len(),
-            StorageRepr::DiagC64(v) => v.len(),
-            StorageRepr::StructuredF64(v) => v.len(),
-            StorageRepr::StructuredC64(v) => v.len(),
+            StorageRepr::F64(v) => v.len(),
+            StorageRepr::C64(v) => v.len(),
         }
     }
 
@@ -1456,48 +579,15 @@ impl Storage {
     /// `max(norm(z))`.
     pub fn max_abs(&self) -> f64 {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                v.as_slice().iter().map(|x| x.abs()).fold(0.0_f64, f64::max)
-            }
-            StorageRepr::DiagF64(v) => v.as_slice().iter().map(|x| x.abs()).fold(0.0_f64, f64::max),
-            StorageRepr::DenseC64(v) => v
-                .as_slice()
-                .iter()
-                .map(|z| z.norm())
-                .fold(0.0_f64, f64::max),
-            StorageRepr::DiagC64(v) => v
-                .as_slice()
-                .iter()
-                .map(|z| z.norm())
-                .fold(0.0_f64, f64::max),
-            StorageRepr::StructuredF64(v) => {
-                v.data().iter().map(|x| x.abs()).fold(0.0_f64, f64::max)
-            }
-            StorageRepr::StructuredC64(v) => {
-                v.data().iter().map(|z| z.norm()).fold(0.0_f64, f64::max)
-            }
+            StorageRepr::F64(v) => v.data().iter().map(|x| x.abs()).fold(0.0_f64, f64::max),
+            StorageRepr::C64(v) => v.data().iter().map(|z| z.norm()).fold(0.0_f64, f64::max),
         }
     }
 
     /// Materialize dense logical values as a column-major `f64` buffer.
     pub fn to_dense_f64_col_major_vec(&self, logical_dims: &[usize]) -> Result<Vec<f64>, String> {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                let expected_len: usize = logical_dims.iter().product();
-                if expected_len != v.len() {
-                    return Err(format!(
-                        "logical dims {:?} (len={expected_len}) do not match DenseF64 len {}",
-                        logical_dims,
-                        v.len()
-                    ));
-                }
-                Ok(row_major_to_col_major_values(v.as_slice(), logical_dims))
-            }
-            StorageRepr::DiagF64(v) => Ok(row_major_to_col_major_values(
-                &v.to_dense_vec(logical_dims),
-                logical_dims,
-            )),
-            StorageRepr::StructuredF64(v) => {
+            StorageRepr::F64(v) => {
                 let structured_dims = v.logical_dims();
                 if structured_dims != logical_dims {
                     return Err(format!(
@@ -1517,7 +607,7 @@ impl Storage {
                         .map_err(|err| err.to_string())
                 }
             }
-            StorageRepr::DenseC64(_) | StorageRepr::DiagC64(_) | StorageRepr::StructuredC64(_) => {
+            StorageRepr::C64(_) => {
                 Err("expected f64 storage when materializing dense f64 values".to_string())
             }
         }
@@ -1529,22 +619,7 @@ impl Storage {
         logical_dims: &[usize],
     ) -> Result<Vec<Complex64>, String> {
         match &self.0 {
-            StorageRepr::DenseC64(v) => {
-                let expected_len: usize = logical_dims.iter().product();
-                if expected_len != v.len() {
-                    return Err(format!(
-                        "logical dims {:?} (len={expected_len}) do not match DenseC64 len {}",
-                        logical_dims,
-                        v.len()
-                    ));
-                }
-                Ok(row_major_to_col_major_values(v.as_slice(), logical_dims))
-            }
-            StorageRepr::DiagC64(v) => Ok(row_major_to_col_major_values(
-                &v.to_dense_vec(logical_dims),
-                logical_dims,
-            )),
-            StorageRepr::StructuredC64(v) => {
+            StorageRepr::C64(v) => {
                 let structured_dims = v.logical_dims();
                 if structured_dims != logical_dims {
                     return Err(format!(
@@ -1564,7 +639,7 @@ impl Storage {
                         .map_err(|err| err.to_string())
                 }
             }
-            StorageRepr::DenseF64(_) | StorageRepr::DiagF64(_) | StorageRepr::StructuredF64(_) => {
+            StorageRepr::F64(_) => {
                 Err("expected Complex64 storage when materializing dense c64 values".to_string())
             }
         }
@@ -1591,18 +666,14 @@ impl Storage {
     }
 
     /// Permute the storage data according to the given permutation.
-    ///
-    /// Legacy dense kernels use their internal physical shape directly. The
-    /// `dims` parameter remains for diagonal payload compatibility.
     pub fn permute_storage(&self, _dims: &[usize], perm: &[usize]) -> Storage {
         match &self.0 {
-            StorageRepr::DenseF64(v) => Storage::dense_f64_legacy(v.permute(perm)),
-            StorageRepr::DenseC64(v) => Storage::dense_c64_legacy(v.permute(perm)),
-            // For Diag storage, permute is trivial: data doesn't change, only index order changes
-            StorageRepr::DiagF64(v) => Storage::diag_f64_legacy(v.clone()),
-            StorageRepr::DiagC64(v) => Storage::diag_c64_legacy(v.clone()),
-            StorageRepr::StructuredF64(v) => Storage::structured_f64(v.permute_logical_axes(perm)),
-            StorageRepr::StructuredC64(v) => Storage::structured_c64(v.permute_logical_axes(perm)),
+            StorageRepr::F64(v) => {
+                Storage::from_repr(StorageRepr::F64(v.permute_logical_axes(perm)))
+            }
+            StorageRepr::C64(v) => {
+                Storage::from_repr(StorageRepr::C64(v.permute_logical_axes(perm)))
+            }
         }
     }
 
@@ -1610,56 +681,17 @@ impl Storage {
     /// For f64 storage, returns a copy (clone).
     pub fn extract_real_part(&self) -> Storage {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                // Clone preserves shape
-                Storage::dense_f64_legacy(v.clone())
-            }
-            StorageRepr::DiagF64(d) => {
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(d.as_slice().to_vec()))
-            }
-            StorageRepr::DenseC64(v) => {
-                let dims = v.dims();
-                let real_vec: Vec<f64> = v.as_slice().iter().map(|z| z.re).collect();
-                Storage::dense_f64_legacy(DenseStorageF64::from_vec_with_shape(real_vec, &dims))
-            }
-            StorageRepr::DiagC64(d) => {
-                let real_vec: Vec<f64> = d.as_slice().iter().map(|z| z.re).collect();
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(real_vec))
-            }
-            StorageRepr::StructuredF64(v) => Storage::structured_f64(v.clone()),
-            StorageRepr::StructuredC64(v) => Storage::structured_f64(v.map_copy(|z| z.re)),
+            StorageRepr::F64(v) => Storage::from_repr(StorageRepr::F64(v.clone())),
+            StorageRepr::C64(v) => Storage::from_repr(StorageRepr::F64(v.map_copy(|z| z.re))),
         }
     }
 
     /// Extract imaginary part from Complex64 storage as f64 storage.
     /// For f64 storage, returns zero storage (will be resized appropriately).
-    pub fn extract_imag_part(&self, dims: &[usize]) -> Storage {
+    pub fn extract_imag_part(&self, _dims: &[usize]) -> Storage {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                // For real storage, imaginary part is zero, preserve shape
-                let d = v.dims();
-                let total_size: usize = d.iter().product();
-                Storage::dense_f64_legacy(DenseStorageF64::from_vec_with_shape(
-                    vec![0.0; total_size],
-                    &d,
-                ))
-            }
-            StorageRepr::DiagF64(_) => {
-                // For real diagonal storage, imaginary part is zero
-                let mindim_val = mindim(dims);
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(vec![0.0; mindim_val]))
-            }
-            StorageRepr::DenseC64(v) => {
-                let d = v.dims();
-                let imag_vec: Vec<f64> = v.as_slice().iter().map(|z| z.im).collect();
-                Storage::dense_f64_legacy(DenseStorageF64::from_vec_with_shape(imag_vec, &d))
-            }
-            StorageRepr::DiagC64(d) => {
-                let imag_vec: Vec<f64> = d.as_slice().iter().map(|z| z.im).collect();
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(imag_vec))
-            }
-            StorageRepr::StructuredF64(v) => Storage::structured_f64(v.map_copy(|_| 0.0)),
-            StorageRepr::StructuredC64(v) => Storage::structured_f64(v.map_copy(|z| z.im)),
+            StorageRepr::F64(v) => Storage::from_repr(StorageRepr::F64(v.map_copy(|_| 0.0))),
+            StorageRepr::C64(v) => Storage::from_repr(StorageRepr::F64(v.map_copy(|z| z.im))),
         }
     }
 
@@ -1667,34 +699,10 @@ impl Storage {
     /// For Complex64 storage, returns a clone.
     pub fn to_complex_storage(&self) -> Storage {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                let dims = v.dims();
-                let c64_vec: Vec<Complex64> = v
-                    .as_slice()
-                    .iter()
-                    .map(|&x| Complex64::new(x, 0.0))
-                    .collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(c64_vec, &dims))
+            StorageRepr::F64(v) => {
+                Storage::from_repr(StorageRepr::C64(v.map_copy(|x| Complex64::new(x, 0.0))))
             }
-            StorageRepr::DiagF64(d) => {
-                let c64_vec: Vec<Complex64> = d
-                    .as_slice()
-                    .iter()
-                    .map(|&x| Complex64::new(x, 0.0))
-                    .collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(c64_vec))
-            }
-            StorageRepr::DenseC64(v) => {
-                // Clone preserves shape
-                Storage::dense_c64_legacy(v.clone())
-            }
-            StorageRepr::DiagC64(d) => {
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(d.as_slice().to_vec()))
-            }
-            StorageRepr::StructuredF64(v) => {
-                Storage::structured_c64(v.map_copy(|x| Complex64::new(x, 0.0)))
-            }
-            StorageRepr::StructuredC64(v) => Storage::structured_c64(v.clone()),
+            StorageRepr::C64(v) => Storage::from_repr(StorageRepr::C64(v.clone())),
         }
     }
 
@@ -1718,25 +726,8 @@ impl Storage {
     /// ```
     pub fn conj(&self) -> Self {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                // Real numbers: conj(x) = x, clone preserves shape
-                Storage::dense_f64_legacy(v.clone())
-            }
-            StorageRepr::DenseC64(v) => {
-                let dims = v.dims();
-                let conj_vec: Vec<Complex64> = v.as_slice().iter().map(|z| z.conj()).collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(conj_vec, &dims))
-            }
-            StorageRepr::DiagF64(d) => {
-                // Real numbers: conj(x) = x
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(d.as_slice().to_vec()))
-            }
-            StorageRepr::DiagC64(d) => {
-                let conj_vec: Vec<Complex64> = d.as_slice().iter().map(|z| z.conj()).collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(conj_vec))
-            }
-            StorageRepr::StructuredF64(v) => Storage::structured_f64(v.clone()),
-            StorageRepr::StructuredC64(v) => Storage::structured_c64(v.map_copy(|z| z.conj())),
+            StorageRepr::F64(v) => Storage::from_repr(StorageRepr::F64(v.clone())),
+            StorageRepr::C64(v) => Storage::from_repr(StorageRepr::C64(v.map_copy(|z| z.conj()))),
         }
     }
 
@@ -1745,28 +736,25 @@ impl Storage {
     /// Formula: real + i * imag
     pub fn combine_to_complex(real_storage: &Storage, imag_storage: &Storage) -> Storage {
         match (&real_storage.0, &imag_storage.0) {
-            (StorageRepr::DenseF64(real), StorageRepr::DenseF64(imag)) => {
-                assert_eq!(real.len(), imag.len(), "Storage lengths must match");
-                let dims = real.dims();
-                let complex_vec: Vec<Complex64> = real
-                    .as_slice()
-                    .iter()
-                    .zip(imag.as_slice().iter())
-                    .map(|(&r, &i)| Complex64::new(r, i))
-                    .collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(complex_vec, &dims))
-            }
-            (StorageRepr::DiagF64(real), StorageRepr::DiagF64(imag)) => {
+            (StorageRepr::F64(real), StorageRepr::F64(imag)) => {
                 assert_eq!(real.len(), imag.len(), "Storage lengths must match");
                 let complex_vec: Vec<Complex64> = real
-                    .as_slice()
+                    .data()
                     .iter()
-                    .zip(imag.as_slice().iter())
+                    .zip(imag.data().iter())
                     .map(|(&r, &i)| Complex64::new(r, i))
                     .collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(complex_vec))
+                Storage::from_repr(StorageRepr::C64(
+                    StructuredStorage::new(
+                        complex_vec,
+                        real.payload_dims().to_vec(),
+                        real.strides().to_vec(),
+                        real.axis_classes().to_vec(),
+                    )
+                    .unwrap_or_else(|err| panic!("Storage::combine_to_complex failed: {err}")),
+                ))
             }
-            _ => panic!("Both storages must be the same type (DenseF64 or DiagF64)"),
+            _ => panic!("Both storages must be f64 for combine_to_complex"),
         }
     }
 
@@ -1780,45 +768,7 @@ impl Storage {
     /// - Storage lengths don't match
     pub fn try_add(&self, other: &Storage) -> Result<Storage, String> {
         match (&self.0, &other.0) {
-            (StorageRepr::DenseF64(a), StorageRepr::DenseF64(b)) => {
-                if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for addition: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
-                }
-                let dims = a.dims();
-                let sum_vec: Vec<f64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x + y)
-                    .collect();
-                Ok(Storage::dense_f64_legacy(
-                    DenseStorageF64::from_vec_with_shape(sum_vec, &dims),
-                ))
-            }
-            (StorageRepr::DenseC64(a), StorageRepr::DenseC64(b)) => {
-                if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for addition: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
-                }
-                let dims = a.dims();
-                let sum_vec: Vec<Complex64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x + y)
-                    .collect();
-                Ok(Storage::dense_c64_legacy(
-                    DenseStorageC64::from_vec_with_shape(sum_vec, &dims),
-                ))
-            }
-            (StorageRepr::DiagF64(a), StorageRepr::DiagF64(b)) => {
+            (StorageRepr::F64(a), StorageRepr::F64(b)) => {
                 if a.len() != b.len() {
                     return Err(format!(
                         "Storage lengths must match for addition: {} != {}",
@@ -1827,14 +777,22 @@ impl Storage {
                     ));
                 }
                 let sum_vec: Vec<f64> = a
-                    .as_slice()
+                    .data()
                     .iter()
-                    .zip(b.as_slice().iter())
+                    .zip(b.data().iter())
                     .map(|(&x, &y)| x + y)
                     .collect();
-                Ok(Storage::diag_f64_legacy(DiagStorageF64::from_vec(sum_vec)))
+                Ok(Storage::from_repr(StorageRepr::F64(
+                    StructuredStorage::new(
+                        sum_vec,
+                        a.payload_dims().to_vec(),
+                        a.strides().to_vec(),
+                        a.axis_classes().to_vec(),
+                    )
+                    .map_err(|err| err.to_string())?,
+                )))
             }
-            (StorageRepr::DiagC64(a), StorageRepr::DiagC64(b)) => {
+            (StorageRepr::C64(a), StorageRepr::C64(b)) => {
                 if a.len() != b.len() {
                     return Err(format!(
                         "Storage lengths must match for addition: {} != {}",
@@ -1843,12 +801,20 @@ impl Storage {
                     ));
                 }
                 let sum_vec: Vec<Complex64> = a
-                    .as_slice()
+                    .data()
                     .iter()
-                    .zip(b.as_slice().iter())
+                    .zip(b.data().iter())
                     .map(|(&x, &y)| x + y)
                     .collect();
-                Ok(Storage::diag_c64_legacy(DiagStorageC64::from_vec(sum_vec)))
+                Ok(Storage::from_repr(StorageRepr::C64(
+                    StructuredStorage::new(
+                        sum_vec,
+                        a.payload_dims().to_vec(),
+                        a.strides().to_vec(),
+                        a.axis_classes().to_vec(),
+                    )
+                    .map_err(|err| err.to_string())?,
+                )))
             }
             _ => Err(format!(
                 "Storage types must match for addition: {:?} vs {:?}",
@@ -1863,45 +829,7 @@ impl Storage {
     /// Returns an error if the storages have different types or lengths.
     pub fn try_sub(&self, other: &Storage) -> Result<Storage, String> {
         match (&self.0, &other.0) {
-            (StorageRepr::DenseF64(a), StorageRepr::DenseF64(b)) => {
-                if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for subtraction: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
-                }
-                let dims = a.dims();
-                let diff_vec: Vec<f64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x - y)
-                    .collect();
-                Ok(Storage::dense_f64_legacy(
-                    DenseStorageF64::from_vec_with_shape(diff_vec, &dims),
-                ))
-            }
-            (StorageRepr::DenseC64(a), StorageRepr::DenseC64(b)) => {
-                if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for subtraction: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
-                }
-                let dims = a.dims();
-                let diff_vec: Vec<Complex64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x - y)
-                    .collect();
-                Ok(Storage::dense_c64_legacy(
-                    DenseStorageC64::from_vec_with_shape(diff_vec, &dims),
-                ))
-            }
-            (StorageRepr::DiagF64(a), StorageRepr::DiagF64(b)) => {
+            (StorageRepr::F64(a), StorageRepr::F64(b)) => {
                 if a.len() != b.len() {
                     return Err(format!(
                         "Storage lengths must match for subtraction: {} != {}",
@@ -1910,14 +838,22 @@ impl Storage {
                     ));
                 }
                 let diff_vec: Vec<f64> = a
-                    .as_slice()
+                    .data()
                     .iter()
-                    .zip(b.as_slice().iter())
+                    .zip(b.data().iter())
                     .map(|(&x, &y)| x - y)
                     .collect();
-                Ok(Storage::diag_f64_legacy(DiagStorageF64::from_vec(diff_vec)))
+                Ok(Storage::from_repr(StorageRepr::F64(
+                    StructuredStorage::new(
+                        diff_vec,
+                        a.payload_dims().to_vec(),
+                        a.strides().to_vec(),
+                        a.axis_classes().to_vec(),
+                    )
+                    .map_err(|err| err.to_string())?,
+                )))
             }
-            (StorageRepr::DiagC64(a), StorageRepr::DiagC64(b)) => {
+            (StorageRepr::C64(a), StorageRepr::C64(b)) => {
                 if a.len() != b.len() {
                     return Err(format!(
                         "Storage lengths must match for subtraction: {} != {}",
@@ -1926,12 +862,20 @@ impl Storage {
                     ));
                 }
                 let diff_vec: Vec<Complex64> = a
-                    .as_slice()
+                    .data()
                     .iter()
-                    .zip(b.as_slice().iter())
+                    .zip(b.data().iter())
                     .map(|(&x, &y)| x - y)
                     .collect();
-                Ok(Storage::diag_c64_legacy(DiagStorageC64::from_vec(diff_vec)))
+                Ok(Storage::from_repr(StorageRepr::C64(
+                    StructuredStorage::new(
+                        diff_vec,
+                        a.payload_dims().to_vec(),
+                        a.strides().to_vec(),
+                        a.axis_classes().to_vec(),
+                    )
+                    .map_err(|err| err.to_string())?,
+                )))
             }
             _ => Err(format!(
                 "Storage types must match for subtraction: {:?} vs {:?}",
@@ -1970,60 +914,67 @@ impl Storage {
         // Determine if we need complex output
         let needs_complex = a.is_complex()
             || b.is_complex()
-            || matches!(&self.0, StorageRepr::DenseC64(_) | StorageRepr::DiagC64(_))
-            || matches!(&other.0, StorageRepr::DenseC64(_) | StorageRepr::DiagC64(_));
+            || matches!(&self.0, StorageRepr::C64(_))
+            || matches!(&other.0, StorageRepr::C64(_));
 
         if needs_complex {
             // Promote everything to complex
             let a_c: Complex64 = a.clone().into();
             let b_c: Complex64 = b.clone().into();
 
-            let (result, dims): (Vec<Complex64>, Vec<usize>) = match (&self.0, &other.0) {
-                (StorageRepr::DenseF64(x), StorageRepr::DenseF64(y)) => (
-                    x.as_slice()
+            let (result, payload_dims, strides, axis_classes): (
+                Vec<Complex64>,
+                Vec<usize>,
+                Vec<isize>,
+                Vec<usize>,
+            ) = match (&self.0, &other.0) {
+                (StorageRepr::F64(x), StorageRepr::F64(y)) => (
+                    x.data()
                         .iter()
-                        .zip(y.as_slice().iter())
+                        .zip(y.data().iter())
                         .map(|(&xi, &yi)| {
                             a_c * Complex64::new(xi, 0.0) + b_c * Complex64::new(yi, 0.0)
                         })
                         .collect(),
-                    x.dims(),
+                    x.payload_dims().to_vec(),
+                    x.strides().to_vec(),
+                    x.axis_classes().to_vec(),
                 ),
-                (StorageRepr::DenseF64(x), StorageRepr::DenseC64(y)) => (
-                    x.as_slice()
+                (StorageRepr::F64(x), StorageRepr::C64(y)) => (
+                    x.data()
                         .iter()
-                        .zip(y.as_slice().iter())
+                        .zip(y.data().iter())
                         .map(|(&xi, &yi)| a_c * Complex64::new(xi, 0.0) + b_c * yi)
                         .collect(),
-                    x.dims(),
+                    x.payload_dims().to_vec(),
+                    x.strides().to_vec(),
+                    x.axis_classes().to_vec(),
                 ),
-                (StorageRepr::DenseC64(x), StorageRepr::DenseF64(y)) => (
-                    x.as_slice()
+                (StorageRepr::C64(x), StorageRepr::F64(y)) => (
+                    x.data()
                         .iter()
-                        .zip(y.as_slice().iter())
+                        .zip(y.data().iter())
                         .map(|(&xi, &yi)| a_c * xi + b_c * Complex64::new(yi, 0.0))
                         .collect(),
-                    x.dims(),
+                    x.payload_dims().to_vec(),
+                    x.strides().to_vec(),
+                    x.axis_classes().to_vec(),
                 ),
-                (StorageRepr::DenseC64(x), StorageRepr::DenseC64(y)) => (
-                    x.as_slice()
+                (StorageRepr::C64(x), StorageRepr::C64(y)) => (
+                    x.data()
                         .iter()
-                        .zip(y.as_slice().iter())
+                        .zip(y.data().iter())
                         .map(|(&xi, &yi)| a_c * xi + b_c * yi)
                         .collect(),
-                    x.dims(),
+                    x.payload_dims().to_vec(),
+                    x.strides().to_vec(),
+                    x.axis_classes().to_vec(),
                 ),
-                _ => {
-                    return Err(format!(
-                        "axpby not supported for storage types: {:?} vs {:?}",
-                        std::mem::discriminant(&self.0),
-                        std::mem::discriminant(&other.0)
-                    ))
-                }
             };
-            Ok(Storage::dense_c64_legacy(
-                DenseStorageC64::from_vec_with_shape(result, &dims),
-            ))
+            Ok(Storage::from_repr(StorageRepr::C64(
+                StructuredStorage::new(result, payload_dims, strides, axis_classes)
+                    .map_err(|err| err.to_string())?,
+            )))
         } else {
             // All real
             if !a.is_real() || !b.is_real() {
@@ -2035,26 +986,22 @@ impl Storage {
             let b_f = b.real();
 
             match (&self.0, &other.0) {
-                (StorageRepr::DenseF64(x), StorageRepr::DenseF64(y)) => {
-                    let dims = x.dims();
+                (StorageRepr::F64(x), StorageRepr::F64(y)) => {
                     let result: Vec<f64> = x
-                        .as_slice()
+                        .data()
                         .iter()
-                        .zip(y.as_slice().iter())
+                        .zip(y.data().iter())
                         .map(|(&xi, &yi)| a_f * xi + b_f * yi)
                         .collect();
-                    Ok(Storage::dense_f64_legacy(
-                        DenseStorageF64::from_vec_with_shape(result, &dims),
-                    ))
-                }
-                (StorageRepr::DiagF64(x), StorageRepr::DiagF64(y)) => {
-                    let result: Vec<f64> = x
-                        .as_slice()
-                        .iter()
-                        .zip(y.as_slice().iter())
-                        .map(|(&xi, &yi)| a_f * xi + b_f * yi)
-                        .collect();
-                    Ok(Storage::diag_f64_legacy(DiagStorageF64::from_vec(result)))
+                    Ok(Storage::from_repr(StorageRepr::F64(
+                        StructuredStorage::new(
+                            result,
+                            x.payload_dims().to_vec(),
+                            x.strides().to_vec(),
+                            x.axis_classes().to_vec(),
+                        )
+                        .map_err(|err| err.to_string())?,
+                    )))
                 }
                 _ => Err(format!(
                     "axpby not supported for storage types: {:?} vs {:?}",
@@ -2079,9 +1026,8 @@ pub fn mindim(dims: &[usize]) -> usize {
 
 /// Contract two storage tensors along specified axes.
 ///
-/// This is an internal helper function that contracts two `Storage` tensors.
-/// For Dense tensors, uses dense contraction kernels.
-/// For Diag tensors, implements specialized diagonal contraction.
+/// All storage is StructuredStorage; contraction is delegated to the native
+/// tenferro backend.
 ///
 /// # Arguments
 /// * `storage_a` - First tensor storage
@@ -2116,198 +1062,16 @@ pub fn contract_storage(
         );
     }
 
-    if matches!(
-        &storage_a.0,
-        StorageRepr::StructuredF64(_) | StorageRepr::StructuredC64(_)
-    ) || matches!(
-        &storage_b.0,
-        StorageRepr::StructuredF64(_) | StorageRepr::StructuredC64(_)
-    ) {
-        return crate::tenferro_bridge::contract_storage_native(
-            storage_a,
-            dims_a,
-            axes_a,
-            storage_b,
-            dims_b,
-            axes_b,
-            result_dims,
-        )
-        .unwrap_or_else(|err| panic!("contract_storage structured fallback failed: {err}"));
-    }
-
-    match (&storage_a.0, &storage_b.0) {
-        // Same-type legacy dense kernels carry their physical shape internally.
-        (StorageRepr::DenseF64(a), StorageRepr::DenseF64(b)) => {
-            Storage::dense_f64_legacy(a.contract(axes_a, b, axes_b))
-        }
-        (StorageRepr::DenseC64(a), StorageRepr::DenseC64(b)) => {
-            Storage::dense_c64_legacy(a.contract(axes_a, b, axes_b))
-        }
-        (StorageRepr::DenseF64(a), StorageRepr::DenseC64(b)) => {
-            let promoted_a = promote_dense_to_c64(a);
-            Storage::dense_c64_legacy(promoted_a.contract(axes_a, b, axes_b))
-        }
-        (StorageRepr::DenseC64(a), StorageRepr::DenseF64(b)) => {
-            let promoted_b = promote_dense_to_c64(b);
-            Storage::dense_c64_legacy(a.contract(axes_a, &promoted_b, axes_b))
-        }
-        // DiagTensor × DiagTensor contraction
-        (StorageRepr::DiagF64(a), StorageRepr::DiagF64(b)) => a.contract_diag_diag(
-            dims_a,
-            b,
-            dims_b,
-            result_dims,
-            |v| Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, result_dims)),
-            |v| Storage::diag_f64_legacy(DiagStorage::from_vec(v)),
-        ),
-        (StorageRepr::DiagC64(a), StorageRepr::DiagC64(b)) => a.contract_diag_diag(
-            dims_a,
-            b,
-            dims_b,
-            result_dims,
-            |v| Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, result_dims)),
-            |v| Storage::diag_c64_legacy(DiagStorage::from_vec(v)),
-        ),
-
-        // Mixed Diag types: promote both to complex and recurse once.
-        (StorageRepr::DiagF64(_), StorageRepr::DiagC64(_))
-        | (StorageRepr::DiagC64(_), StorageRepr::DiagF64(_)) => {
-            let promoted_a = storage_a.to_complex_storage();
-            let promoted_b = storage_b.to_complex_storage();
-            contract_storage(
-                &promoted_a,
-                dims_a,
-                axes_a,
-                &promoted_b,
-                dims_b,
-                axes_b,
-                result_dims,
-            )
-        }
-
-        // DiagTensor × DenseTensor: use optimized contract_diag_dense
-        (StorageRepr::DiagF64(diag), StorageRepr::DenseF64(dense)) => {
-            diag.contract_diag_dense(dims_a, axes_a, dense, dims_b, axes_b, result_dims, |v| {
-                Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, result_dims))
-            })
-        }
-        (StorageRepr::DiagC64(diag), StorageRepr::DenseC64(dense)) => {
-            diag.contract_diag_dense(dims_a, axes_a, dense, dims_b, axes_b, result_dims, |v| {
-                Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, result_dims))
-            })
-        }
-
-        // DenseTensor × DiagTensor: use generic helper
-        (StorageRepr::DenseF64(dense), StorageRepr::DiagF64(diag)) => contract_dense_diag_impl(
-            dense,
-            dims_a,
-            axes_a,
-            diag,
-            dims_b,
-            axes_b,
-            result_dims,
-            |v, dims| Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, dims)),
-            |s, perm| s.permute_storage(&[], perm),
-        ),
-        (StorageRepr::DenseC64(dense), StorageRepr::DiagC64(diag)) => contract_dense_diag_impl(
-            dense,
-            dims_a,
-            axes_a,
-            diag,
-            dims_b,
-            axes_b,
-            result_dims,
-            |v, dims| Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, dims)),
-            |s, perm| s.permute_storage(&[], perm),
-        ),
-
-        // Mixed Diag/Dense with type promotion: promote f64 to Complex64
-        (StorageRepr::DiagF64(diag_f64), StorageRepr::DenseC64(dense_c64)) => {
-            // Diag<f64> × Dense<C64>: promote Diag to C64
-            let diag_c64 = promote_diag_to_c64(diag_f64);
-            diag_c64.contract_diag_dense(
-                dims_a,
-                axes_a,
-                dense_c64,
-                dims_b,
-                axes_b,
-                result_dims,
-                |v| Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, result_dims)),
-            )
-        }
-        (StorageRepr::DenseC64(dense_c64), StorageRepr::DiagF64(diag_f64)) => {
-            // Dense<C64> × Diag<f64>: promote Diag to C64, use helper
-            let diag_c64 = promote_diag_to_c64(diag_f64);
-            contract_dense_diag_impl(
-                dense_c64,
-                dims_a,
-                axes_a,
-                &diag_c64,
-                dims_b,
-                axes_b,
-                result_dims,
-                |v, dims| Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, dims)),
-                |s, perm| s.permute_storage(&[], perm),
-            )
-        }
-        (StorageRepr::DiagC64(diag_c64), StorageRepr::DenseF64(dense_f64)) => {
-            // Diag<C64> × Dense<f64>: promote Dense to C64
-            let dense_c64 = promote_dense_to_c64(dense_f64);
-            diag_c64.contract_diag_dense(
-                dims_a,
-                axes_a,
-                &dense_c64,
-                dims_b,
-                axes_b,
-                result_dims,
-                |v| Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, result_dims)),
-            )
-        }
-        (StorageRepr::DenseF64(dense_f64), StorageRepr::DiagC64(diag_c64)) => {
-            // Dense<f64> × Diag<C64>: promote Dense to C64, use helper
-            let dense_c64 = promote_dense_to_c64(dense_f64);
-            contract_dense_diag_impl(
-                &dense_c64,
-                dims_a,
-                axes_a,
-                diag_c64,
-                dims_b,
-                axes_b,
-                result_dims,
-                |v, dims| Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(v, dims)),
-                |s, perm| s.permute_storage(&[], perm),
-            )
-        }
-        (StorageRepr::StructuredF64(_), _)
-        | (StorageRepr::StructuredC64(_), _)
-        | (_, StorageRepr::StructuredF64(_))
-        | (_, StorageRepr::StructuredC64(_)) => {
-            unreachable!("structured storage cases are handled by the native fallback above")
-        }
-    }
-}
-
-/// Promote Diag<f64> to Diag<Complex64>
-fn promote_diag_to_c64(diag: &DiagStorage<f64>) -> DiagStorage<Complex64> {
-    DiagStorage::from_vec(
-        diag.as_slice()
-            .iter()
-            .map(|&x| Complex64::new(x, 0.0))
-            .collect(),
+    crate::tenferro_bridge::contract_storage_native(
+        storage_a,
+        dims_a,
+        axes_a,
+        storage_b,
+        dims_b,
+        axes_b,
+        result_dims,
     )
-}
-
-/// Promote Dense<f64> to Dense<Complex64>
-fn promote_dense_to_c64(dense: &DenseStorage<f64>) -> DenseStorage<Complex64> {
-    let dims = dense.dims();
-    DenseStorage::from_vec_with_shape(
-        dense
-            .as_slice()
-            .iter()
-            .map(|&x| Complex64::new(x, 0.0))
-            .collect(),
-        &dims,
-    )
+    .unwrap_or_else(|err| panic!("contract_storage failed: {err}"))
 }
 
 /// Add two storages element-wise.
@@ -2325,51 +1089,8 @@ impl Add<&Storage> for &Storage {
     type Output = Storage;
 
     fn add(self, rhs: &Storage) -> Self::Output {
-        match (&self.0, &rhs.0) {
-            (StorageRepr::DenseF64(a), StorageRepr::DenseF64(b)) => {
-                assert_eq!(a.len(), b.len(), "Storage lengths must match for addition");
-                let dims = a.dims();
-                let sum_vec: Vec<f64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x + y)
-                    .collect();
-                Storage::dense_f64_legacy(DenseStorageF64::from_vec_with_shape(sum_vec, &dims))
-            }
-            (StorageRepr::DenseC64(a), StorageRepr::DenseC64(b)) => {
-                assert_eq!(a.len(), b.len(), "Storage lengths must match for addition");
-                let dims = a.dims();
-                let sum_vec: Vec<Complex64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x + y)
-                    .collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(sum_vec, &dims))
-            }
-            (StorageRepr::DiagF64(a), StorageRepr::DiagF64(b)) => {
-                assert_eq!(a.len(), b.len(), "Storage lengths must match for addition");
-                let sum_vec: Vec<f64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x + y)
-                    .collect();
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(sum_vec))
-            }
-            (StorageRepr::DiagC64(a), StorageRepr::DiagC64(b)) => {
-                assert_eq!(a.len(), b.len(), "Storage lengths must match for addition");
-                let sum_vec: Vec<Complex64> = a
-                    .as_slice()
-                    .iter()
-                    .zip(b.as_slice().iter())
-                    .map(|(&x, &y)| x + y)
-                    .collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(sum_vec))
-            }
-            _ => panic!("Storage types must match for addition"),
-        }
+        self.try_add(rhs)
+            .unwrap_or_else(|err| panic!("Storage addition failed: {err}"))
     }
 }
 
@@ -2380,36 +1101,10 @@ impl Mul<f64> for &Storage {
 
     fn mul(self, scalar: f64) -> Self::Output {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                let dims = v.dims();
-                let scaled_vec: Vec<f64> = v.as_slice().iter().map(|&x| x * scalar).collect();
-                Storage::dense_f64_legacy(DenseStorageF64::from_vec_with_shape(scaled_vec, &dims))
-            }
-            StorageRepr::DenseC64(v) => {
-                let dims = v.dims();
-                let scaled_vec: Vec<Complex64> = v
-                    .as_slice()
-                    .iter()
-                    .map(|&z| z * Complex64::new(scalar, 0.0))
-                    .collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(scaled_vec, &dims))
-            }
-            StorageRepr::DiagF64(d) => {
-                let scaled_vec: Vec<f64> = d.as_slice().iter().map(|&x| x * scalar).collect();
-                Storage::diag_f64_legacy(DiagStorageF64::from_vec(scaled_vec))
-            }
-            StorageRepr::DiagC64(d) => {
-                let scaled_vec: Vec<Complex64> = d
-                    .as_slice()
-                    .iter()
-                    .map(|&z| z * Complex64::new(scalar, 0.0))
-                    .collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(scaled_vec))
-            }
-            StorageRepr::StructuredF64(v) => Storage::structured_f64(v.map_copy(|x| x * scalar)),
-            StorageRepr::StructuredC64(v) => {
-                Storage::structured_c64(v.map_copy(|z| z * Complex64::new(scalar, 0.0)))
-            }
+            StorageRepr::F64(v) => Storage::from_repr(StorageRepr::F64(v.map_copy(|x| x * scalar))),
+            StorageRepr::C64(v) => Storage::from_repr(StorageRepr::C64(
+                v.map_copy(|z| z * Complex64::new(scalar, 0.0)),
+            )),
         }
     }
 }
@@ -2420,38 +1115,10 @@ impl Mul<Complex64> for &Storage {
 
     fn mul(self, scalar: Complex64) -> Self::Output {
         match &self.0 {
-            StorageRepr::DenseF64(v) => {
-                // Promote f64 to Complex64
-                let dims = v.dims();
-                let scaled_vec: Vec<Complex64> = v
-                    .as_slice()
-                    .iter()
-                    .map(|&x| Complex64::new(x, 0.0) * scalar)
-                    .collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(scaled_vec, &dims))
-            }
-            StorageRepr::DenseC64(v) => {
-                let dims = v.dims();
-                let scaled_vec: Vec<Complex64> = v.as_slice().iter().map(|&z| z * scalar).collect();
-                Storage::dense_c64_legacy(DenseStorageC64::from_vec_with_shape(scaled_vec, &dims))
-            }
-            StorageRepr::DiagF64(d) => {
-                // Promote f64 to Complex64
-                let scaled_vec: Vec<Complex64> = d
-                    .as_slice()
-                    .iter()
-                    .map(|&x| Complex64::new(x, 0.0) * scalar)
-                    .collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(scaled_vec))
-            }
-            StorageRepr::DiagC64(d) => {
-                let scaled_vec: Vec<Complex64> = d.as_slice().iter().map(|&z| z * scalar).collect();
-                Storage::diag_c64_legacy(DiagStorageC64::from_vec(scaled_vec))
-            }
-            StorageRepr::StructuredF64(v) => {
-                Storage::structured_c64(v.map_copy(|x| Complex64::new(x, 0.0) * scalar))
-            }
-            StorageRepr::StructuredC64(v) => Storage::structured_c64(v.map_copy(|z| z * scalar)),
+            StorageRepr::F64(v) => Storage::from_repr(StorageRepr::C64(
+                v.map_copy(|x| Complex64::new(x, 0.0) * scalar),
+            )),
+            StorageRepr::C64(v) => Storage::from_repr(StorageRepr::C64(v.map_copy(|z| z * scalar))),
         }
     }
 }

--- a/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
@@ -3,322 +3,16 @@ use super::*;
 /// Helper to extract f64 data from storage
 fn extract_f64(storage: &Storage) -> Vec<f64> {
     match storage.repr() {
-        StorageRepr::DenseF64(ds) => ds.as_slice().to_vec(),
-        StorageRepr::StructuredF64(ds) => ds.data().to_vec(),
-        _ => panic!("Expected f64 dense-compatible storage"),
+        StorageRepr::F64(ds) => ds.data().to_vec(),
+        _ => panic!("Expected f64 storage"),
     }
 }
 
 /// Helper to extract Complex64 data from storage
 fn extract_c64(storage: &Storage) -> Vec<Complex64> {
     match storage.repr() {
-        StorageRepr::DenseC64(ds) => ds.as_slice().to_vec(),
-        StorageRepr::StructuredC64(ds) => ds.data().to_vec(),
-        _ => panic!("Expected c64 dense-compatible storage"),
-    }
-}
-
-// ===== Legacy diagonal kernel generic tests =====
-
-#[test]
-fn test_diag_storage_generic_f64() {
-    let diag: DiagStorage<f64> = DiagStorage::from_vec(vec![1.0, 2.0, 3.0]);
-    assert_eq!(diag.len(), 3);
-    assert_eq!(diag.get(0), 1.0);
-    assert_eq!(diag.get(1), 2.0);
-    assert_eq!(diag.get(2), 3.0);
-}
-
-#[test]
-fn test_diag_storage_generic_c64() {
-    let diag: DiagStorage<Complex64> =
-        DiagStorage::from_vec(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]);
-    assert_eq!(diag.len(), 2);
-    assert_eq!(diag.get(0), Complex64::new(1.0, 2.0));
-    assert_eq!(diag.get(1), Complex64::new(3.0, 4.0));
-}
-
-#[test]
-fn test_diag_to_dense_vec_2d() {
-    // 2D diagonal tensor [3, 3] with diag = [1, 2, 3]
-    let diag: DiagStorage<f64> = DiagStorage::from_vec(vec![1.0, 2.0, 3.0]);
-    let dense = diag.to_dense_vec(&[3, 3]);
-    // Expected: [[1,0,0], [0,2,0], [0,0,3]] in row-major
-    assert_eq!(dense, vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
-}
-
-#[test]
-fn test_diag_to_dense_vec_3d() {
-    // 3D diagonal tensor [2, 2, 2] with diag = [1, 2]
-    let diag: DiagStorage<f64> = DiagStorage::from_vec(vec![1.0, 2.0]);
-    let dense = diag.to_dense_vec(&[2, 2, 2]);
-    // Position (0,0,0) = 1.0, position (1,1,1) = 2.0, others = 0
-    // Row-major: [[[1,0],[0,0]], [[0,0],[0,2]]]
-    // Linear: 1,0,0,0,0,0,0,2
-    assert_eq!(dense, vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0]);
-}
-
-// ===== Diag × Dense contraction tests =====
-
-#[test]
-fn test_contract_diag_dense_2d_all_contracted() {
-    // Diag tensor [3, 3] with diag = [1, 2, 3]
-    // Dense tensor [3, 3] with all 1s
-    // Contract all axes: result = sum_t diag[t] * dense[t, t] = 1*1 + 2*1 + 3*1 = 6
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0, 3.0]));
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0; 9], &[3, 3]));
-
-    let result = contract_storage(&diag, &[3, 3], &[0, 1], &dense, &[3, 3], &[0, 1], &[]);
-
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 1);
-    assert!((data[0] - 6.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_contract_diag_dense_2d_one_axis() {
-    // Diag tensor [3, 3] with diag = [1, 2, 3]
-    // Dense tensor [3, 2]
-    // Contract axis 1 of diag with axis 0 of dense
-    // Result[i, j] = diag[i, i] * dense[i, j] (since diag is only non-zero when i=k)
-    //              = diag[i] * dense[i, j]
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0, 3.0]));
-    // Dense = [[1,2], [3,4], [5,6]] in row-major
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        &[3, 2],
-    ));
-
-    let result = contract_storage(&diag, &[3, 3], &[1], &dense, &[3, 2], &[0], &[3, 2]);
-
-    let data = extract_f64(&result);
-    // Result should be:
-    // [diag[0]*dense[0,:], diag[1]*dense[1,:], diag[2]*dense[2,:]]
-    // = [1*[1,2], 2*[3,4], 3*[5,6]]
-    // = [[1,2], [6,8], [15,18]]
-    // Row-major: [1, 2, 6, 8, 15, 18]
-    assert_eq!(data.len(), 6);
-    assert!((data[0] - 1.0).abs() < 1e-10);
-    assert!((data[1] - 2.0).abs() < 1e-10);
-    assert!((data[2] - 6.0).abs() < 1e-10);
-    assert!((data[3] - 8.0).abs() < 1e-10);
-    assert!((data[4] - 15.0).abs() < 1e-10);
-    assert!((data[5] - 18.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_contract_dense_diag_2d_one_axis() {
-    // Dense × Diag (reversed order)
-    // Dense tensor [2, 3]
-    // Diag tensor [3, 3] with diag = [1, 2, 3]
-    // Contract axis 1 of dense with axis 0 of diag
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        &[2, 3],
-    ));
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0, 3.0]));
-
-    let result = contract_storage(&dense, &[2, 3], &[1], &diag, &[3, 3], &[0], &[2, 3]);
-
-    let data = extract_f64(&result);
-    // Result[i, j] = dense[i, k] * diag[k, j] summed over k
-    // But diag is only non-zero when k=j, so:
-    // Result[i, j] = dense[i, j] * diag[j]
-    // = [[1*1, 2*2, 3*3], [4*1, 5*2, 6*3]]
-    // = [[1, 4, 9], [4, 10, 18]]
-    // Row-major: [1, 4, 9, 4, 10, 18]
-    assert_eq!(data.len(), 6);
-    assert!((data[0] - 1.0).abs() < 1e-10);
-    assert!((data[1] - 4.0).abs() < 1e-10);
-    assert!((data[2] - 9.0).abs() < 1e-10);
-    assert!((data[3] - 4.0).abs() < 1e-10);
-    assert!((data[4] - 10.0).abs() < 1e-10);
-    assert!((data[5] - 18.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_contract_diag_dense_3d() {
-    // Diag tensor [2, 2, 2] with diag = [1, 2]
-    // Dense tensor [2, 3]
-    // Contract axis 2 of diag with axis 0 of dense
-    // Result has shape [2, 2, 3] but only diagonal in first two indices is non-zero
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0]));
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        &[2, 3],
-    ));
-
-    let result = contract_storage(&diag, &[2, 2, 2], &[2], &dense, &[2, 3], &[0], &[2, 2, 3]);
-
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 12);
-    // Result shape [2, 2, 3]
-    // diag only non-zero at (t, t, t), so result[i, j, k] = diag[i] * dense[i, k] if i==j, else 0
-    // Result[0, 0, :] = diag[0] * dense[0, :] = 1 * [1, 2, 3] = [1, 2, 3]
-    // Result[0, 1, :] = 0 (diag is zero when i != j)
-    // Result[1, 0, :] = 0
-    // Result[1, 1, :] = diag[1] * dense[1, :] = 2 * [4, 5, 6] = [8, 10, 12]
-    // Row-major: [1,2,3, 0,0,0, 0,0,0, 8,10,12]
-    assert!((data[0] - 1.0).abs() < 1e-10);
-    assert!((data[1] - 2.0).abs() < 1e-10);
-    assert!((data[2] - 3.0).abs() < 1e-10);
-    assert!((data[3] - 0.0).abs() < 1e-10);
-    assert!((data[4] - 0.0).abs() < 1e-10);
-    assert!((data[5] - 0.0).abs() < 1e-10);
-    assert!((data[6] - 0.0).abs() < 1e-10);
-    assert!((data[7] - 0.0).abs() < 1e-10);
-    assert!((data[8] - 0.0).abs() < 1e-10);
-    assert!((data[9] - 8.0).abs() < 1e-10);
-    assert!((data[10] - 10.0).abs() < 1e-10);
-    assert!((data[11] - 12.0).abs() < 1e-10);
-}
-
-// ===== Type promotion tests =====
-
-#[test]
-fn test_contract_diag_f64_dense_c64() {
-    // Diag<f64> × Dense<Complex64> should produce Dense<Complex64>
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0]));
-    let dense = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
-        vec![
-            Complex64::new(1.0, 1.0),
-            Complex64::new(2.0, 2.0),
-            Complex64::new(3.0, 3.0),
-            Complex64::new(4.0, 4.0),
-        ],
-        &[2, 2],
-    ));
-
-    let result = contract_storage(&diag, &[2, 2], &[1], &dense, &[2, 2], &[0], &[2, 2]);
-
-    let data = extract_c64(&result);
-    assert_eq!(data.len(), 4);
-    // Result[i, j] = diag[i] * dense[i, j]
-    // Result[0, 0] = 1 * (1+1i) = 1+1i
-    // Result[0, 1] = 1 * (2+2i) = 2+2i
-    // Result[1, 0] = 2 * (3+3i) = 6+6i
-    // Result[1, 1] = 2 * (4+4i) = 8+8i
-    assert!((data[0] - Complex64::new(1.0, 1.0)).norm() < 1e-10);
-    assert!((data[1] - Complex64::new(2.0, 2.0)).norm() < 1e-10);
-    assert!((data[2] - Complex64::new(6.0, 6.0)).norm() < 1e-10);
-    assert!((data[3] - Complex64::new(8.0, 8.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_contract_diag_c64_dense_f64() {
-    // Diag<Complex64> × Dense<f64> should produce Dense<Complex64>
-    let diag = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![
-        Complex64::new(1.0, 1.0),
-        Complex64::new(2.0, 2.0),
-    ]));
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0],
-        &[2, 2],
-    ));
-
-    let result = contract_storage(&diag, &[2, 2], &[1], &dense, &[2, 2], &[0], &[2, 2]);
-
-    let data = extract_c64(&result);
-    assert_eq!(data.len(), 4);
-    // Result[i, j] = diag[i] * dense[i, j]
-    // Result[0, 0] = (1+1i) * 1 = 1+1i
-    // Result[0, 1] = (1+1i) * 2 = 2+2i
-    // Result[1, 0] = (2+2i) * 3 = 6+6i
-    // Result[1, 1] = (2+2i) * 4 = 8+8i
-    assert!((data[0] - Complex64::new(1.0, 1.0)).norm() < 1e-10);
-    assert!((data[1] - Complex64::new(2.0, 2.0)).norm() < 1e-10);
-    assert!((data[2] - Complex64::new(6.0, 6.0)).norm() < 1e-10);
-    assert!((data[3] - Complex64::new(8.0, 8.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_contract_dense_f64_diag_c64() {
-    // Dense<f64> × Diag<Complex64> should produce Dense<Complex64>
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0],
-        &[2, 2],
-    ));
-    let diag = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![
-        Complex64::new(1.0, 1.0),
-        Complex64::new(2.0, 2.0),
-    ]));
-
-    let result = contract_storage(&dense, &[2, 2], &[1], &diag, &[2, 2], &[0], &[2, 2]);
-
-    let data = extract_c64(&result);
-    assert_eq!(data.len(), 4);
-    // Result[i, j] = dense[i, j] * diag[j]
-    // Result[0, 0] = 1 * (1+1i) = 1+1i
-    // Result[0, 1] = 2 * (2+2i) = 4+4i
-    // Result[1, 0] = 3 * (1+1i) = 3+3i
-    // Result[1, 1] = 4 * (2+2i) = 8+8i
-    assert!((data[0] - Complex64::new(1.0, 1.0)).norm() < 1e-10);
-    assert!((data[1] - Complex64::new(4.0, 4.0)).norm() < 1e-10);
-    assert!((data[2] - Complex64::new(3.0, 3.0)).norm() < 1e-10);
-    assert!((data[3] - Complex64::new(8.0, 8.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_contract_dense_c64_diag_f64() {
-    // Dense<Complex64> × Diag<f64> should produce Dense<Complex64>
-    let dense = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
-        vec![
-            Complex64::new(1.0, 1.0),
-            Complex64::new(2.0, 2.0),
-            Complex64::new(3.0, 3.0),
-            Complex64::new(4.0, 4.0),
-        ],
-        &[2, 2],
-    ));
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0]));
-
-    let result = contract_storage(&dense, &[2, 2], &[1], &diag, &[2, 2], &[0], &[2, 2]);
-
-    let data = extract_c64(&result);
-    assert_eq!(data.len(), 4);
-    // Result[i, j] = dense[i, j] * diag[j]
-    // Result[0, 0] = (1+1i) * 1 = 1+1i
-    // Result[0, 1] = (2+2i) * 2 = 4+4i
-    // Result[1, 0] = (3+3i) * 1 = 3+3i
-    // Result[1, 1] = (4+4i) * 2 = 8+8i
-    assert!((data[0] - Complex64::new(1.0, 1.0)).norm() < 1e-10);
-    assert!((data[1] - Complex64::new(4.0, 4.0)).norm() < 1e-10);
-    assert!((data[2] - Complex64::new(3.0, 3.0)).norm() < 1e-10);
-    assert!((data[3] - Complex64::new(8.0, 8.0)).norm() < 1e-10);
-}
-
-// ===== Diag × Diag contraction tests =====
-
-#[test]
-fn test_contract_diag_diag_all_contracted() {
-    // Diag [3, 3] × Diag [3, 3] with all indices contracted
-    // Result = sum_t diag1[t] * diag2[t] (inner product)
-    let diag1 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0, 3.0]));
-    let diag2 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![4.0, 5.0, 6.0]));
-
-    let result = contract_storage(&diag1, &[3, 3], &[0, 1], &diag2, &[3, 3], &[0, 1], &[]);
-
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 1);
-    // 1*4 + 2*5 + 3*6 = 4 + 10 + 18 = 32
-    assert!((data[0] - 32.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_contract_diag_diag_partial() {
-    // Diag [3, 3] × Diag [3, 3] with one axis contracted
-    // Result is a diagonal tensor
-    let diag1 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0, 3.0]));
-    let diag2 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![4.0, 5.0, 6.0]));
-
-    let result = contract_storage(&diag1, &[3, 3], &[1], &diag2, &[3, 3], &[0], &[3, 3]);
-
-    // Result is element-wise product: [1*4, 2*5, 3*6] = [4, 10, 18]
-    match result.repr() {
-        StorageRepr::DiagF64(d) => {
-            assert_eq!(d.as_slice(), &[4.0, 10.0, 18.0]);
-        }
-        _ => panic!("Expected DiagF64"),
+        StorageRepr::C64(ds) => ds.data().to_vec(),
+        _ => panic!("Expected c64 storage"),
     }
 }
 
@@ -326,13 +20,11 @@ fn test_contract_diag_diag_partial() {
 
 #[test]
 fn test_is_f64() {
-    let dense_f64 = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
-    let dense_c64 = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
-        vec![Complex64::new(1.0, 0.0)],
-        &[1],
-    ));
-    let diag_f64 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0]));
-    let diag_c64 = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![Complex64::new(1.0, 0.0)]));
+    let dense_f64 = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
+    let dense_c64 =
+        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let diag_f64 = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
+    let diag_c64 = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
 
     assert!(dense_f64.is_f64());
     assert!(!dense_c64.is_f64());
@@ -342,13 +34,11 @@ fn test_is_f64() {
 
 #[test]
 fn test_is_c64() {
-    let dense_f64 = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
-    let dense_c64 = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
-        vec![Complex64::new(1.0, 0.0)],
-        &[1],
-    ));
-    let diag_f64 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0]));
-    let diag_c64 = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![Complex64::new(1.0, 0.0)]));
+    let dense_f64 = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
+    let dense_c64 =
+        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let diag_f64 = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
+    let diag_c64 = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
 
     assert!(!dense_f64.is_c64());
     assert!(dense_c64.is_c64());
@@ -358,13 +48,11 @@ fn test_is_c64() {
 
 #[test]
 fn test_is_complex() {
-    let dense_f64 = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
-    let dense_c64 = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
-        vec![Complex64::new(1.0, 0.0)],
-        &[1],
-    ));
-    let diag_f64 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0]));
-    let diag_c64 = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![Complex64::new(1.0, 0.0)]));
+    let dense_f64 = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
+    let dense_c64 =
+        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let diag_f64 = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
+    let diag_c64 = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
 
     // is_complex is an alias for is_c64
     assert!(!dense_f64.is_complex());
@@ -373,345 +61,12 @@ fn test_is_complex() {
     assert!(diag_c64.is_complex());
 }
 
-// ===== Legacy dense kernel tests =====
-
-#[test]
-fn test_dense_from_scalar() {
-    let ds = DenseStorage::from_scalar(42.0_f64);
-    assert_eq!(ds.rank(), 0);
-    assert_eq!(ds.len(), 1);
-    assert!(!ds.is_empty());
-    assert_eq!(ds.dims(), Vec::<usize>::new());
-    assert_eq!(ds.as_slice(), &[42.0]);
-}
-
-#[test]
-fn test_dense_from_scalar_c64() {
-    let val = Complex64::new(1.0, 2.0);
-    let ds = DenseStorage::from_scalar(val);
-    assert_eq!(ds.rank(), 0);
-    assert_eq!(ds.len(), 1);
-    assert_eq!(ds.as_slice(), &[val]);
-}
-
-#[test]
-fn test_dense_from_tensor_into_tensor_roundtrip() {
-    let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let ds = DenseStorage::from_vec_with_shape(data.clone(), &[2, 3]);
-    let tensor = ds.into_tensor();
-    assert_eq!(tensor.len(), 6);
-    let ds2 = DenseStorage::from_tensor(tensor);
-    assert_eq!(ds2.dims(), vec![2, 3]);
-    assert_eq!(ds2.as_slice(), &data[..]);
-}
-
-#[test]
-fn test_dense_get_set() {
-    let mut ds = DenseStorage::from_vec_with_shape(vec![10.0, 20.0, 30.0], &[3]);
-    assert_eq!(ds.get(0), 10.0);
-    assert_eq!(ds.get(1), 20.0);
-    assert_eq!(ds.get(2), 30.0);
-
-    ds.set(1, 99.0);
-    assert_eq!(ds.get(1), 99.0);
-}
-
-#[test]
-fn test_dense_len_is_empty_dims_rank() {
-    let ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
-    assert_eq!(ds.len(), 4);
-    assert!(!ds.is_empty());
-    assert_eq!(ds.dims(), vec![2, 2]);
-    assert_eq!(ds.rank(), 2);
-}
-
-#[test]
-fn test_dense_iter() {
-    let ds = DenseStorage::from_vec_with_shape(vec![5.0, 10.0, 15.0], &[3]);
-    let collected: Vec<f64> = ds.iter().copied().collect();
-    assert_eq!(collected, vec![5.0, 10.0, 15.0]);
-}
-
-#[test]
-fn test_dense_as_slice_as_mut_slice() {
-    let mut ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0], &[3]);
-    assert_eq!(ds.as_slice(), &[1.0, 2.0, 3.0]);
-
-    let slice = ds.as_mut_slice();
-    slice[0] = 100.0;
-    assert_eq!(ds.as_slice(), &[100.0, 2.0, 3.0]);
-}
-
-#[test]
-fn test_dense_into_vec() {
-    let ds = DenseStorage::from_vec_with_shape(vec![7.0, 8.0, 9.0], &[3]);
-    let v = ds.into_vec();
-    assert_eq!(v, vec![7.0, 8.0, 9.0]);
-}
-
-#[test]
-fn test_dense_permute() {
-    // 2x3 tensor, permute to 3x2
-    let ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
-    let permuted = ds.permute(&[1, 0]);
-    assert_eq!(permuted.dims(), vec![3, 2]);
-    // Original row-major [2,3]: [[1,2,3],[4,5,6]]
-    // Transposed row-major [3,2]: [[1,4],[2,5],[3,6]]
-    assert_eq!(permuted.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
-}
-
-#[test]
-fn test_dense_contract_matrix_multiply() {
-    // Matrix multiply: [2,3] x [3,2] -> [2,2]
-    let a = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
-    let b = DenseStorage::from_vec_with_shape(vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0], &[3, 2]);
-    let result = a.contract(&[1], &b, &[0]);
-    assert_eq!(result.dims(), vec![2, 2]);
-    // C[0,0] = 1*7 + 2*9 + 3*11 = 7+18+33 = 58
-    // C[0,1] = 1*8 + 2*10 + 3*12 = 8+20+36 = 64
-    // C[1,0] = 4*7 + 5*9 + 6*11 = 28+45+66 = 139
-    // C[1,1] = 4*8 + 5*10 + 6*12 = 32+50+72 = 154
-    let data = result.as_slice();
-    assert!((data[0] - 58.0).abs() < 1e-10);
-    assert!((data[1] - 64.0).abs() < 1e-10);
-    assert!((data[2] - 139.0).abs() < 1e-10);
-    assert!((data[3] - 154.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_dense_contract_inner_product() {
-    // Inner product: [3] x [3] -> scalar
-    let a = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0], &[3]);
-    let b = DenseStorage::from_vec_with_shape(vec![4.0, 5.0, 6.0], &[3]);
-    let result = a.contract(&[0], &b, &[0]);
-    // 1*4 + 2*5 + 3*6 = 4+10+18 = 32
-    assert_eq!(result.len(), 1);
-    assert!((result.as_slice()[0] - 32.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_dense_random_f64() {
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    let mut rng = StdRng::seed_from_u64(42);
-    let ds = DenseStorage::<f64>::random(&mut rng, &[3, 4]);
-    assert_eq!(ds.dims(), vec![3, 4]);
-    assert_eq!(ds.len(), 12);
-    // Values should not all be zero (with overwhelming probability)
-    let nonzero = ds.as_slice().iter().any(|&x| x.abs() > 1e-10);
-    assert!(nonzero);
-}
-
-#[test]
-fn test_dense_random_1d_f64() {
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    let mut rng = StdRng::seed_from_u64(123);
-    let ds = DenseStorage::<f64>::random_1d(&mut rng, 5);
-    assert_eq!(ds.dims(), vec![5]);
-    assert_eq!(ds.len(), 5);
-}
-
-#[test]
-fn test_dense_random_c64() {
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    let mut rng = StdRng::seed_from_u64(42);
-    let ds = DenseStorage::<Complex64>::random(&mut rng, &[2, 3]);
-    assert_eq!(ds.dims(), vec![2, 3]);
-    assert_eq!(ds.len(), 6);
-    // At least one element should have nonzero imaginary part
-    let has_imag = ds.as_slice().iter().any(|z| z.im.abs() > 1e-10);
-    assert!(has_imag);
-}
-
-#[test]
-fn test_dense_random_1d_c64() {
-    use rand::rngs::StdRng;
-    use rand::SeedableRng;
-    let mut rng = StdRng::seed_from_u64(99);
-    let ds = DenseStorage::<Complex64>::random_1d(&mut rng, 4);
-    assert_eq!(ds.dims(), vec![4]);
-    assert_eq!(ds.len(), 4);
-}
-
-// ===== Legacy diagonal kernel tests =====
-
-#[test]
-fn test_diag_as_slice_as_mut_slice() {
-    let mut diag = DiagStorage::from_vec(vec![10.0, 20.0, 30.0]);
-    assert_eq!(diag.as_slice(), &[10.0, 20.0, 30.0]);
-
-    let slice = diag.as_mut_slice();
-    slice[1] = 99.0;
-    assert_eq!(diag.as_slice(), &[10.0, 99.0, 30.0]);
-}
-
-#[test]
-fn test_diag_into_vec() {
-    let diag = DiagStorage::from_vec(vec![5.0, 6.0, 7.0]);
-    let v = diag.into_vec();
-    assert_eq!(v, vec![5.0, 6.0, 7.0]);
-}
-
-#[test]
-fn test_diag_is_empty() {
-    let empty: DiagStorage<f64> = DiagStorage::from_vec(vec![]);
-    assert!(empty.is_empty());
-    assert_eq!(empty.len(), 0);
-
-    let nonempty = DiagStorage::from_vec(vec![1.0]);
-    assert!(!nonempty.is_empty());
-}
-
-#[test]
-fn test_diag_set() {
-    let mut diag = DiagStorage::from_vec(vec![1.0, 2.0, 3.0]);
-    diag.set(0, 100.0);
-    diag.set(2, 300.0);
-    assert_eq!(diag.get(0), 100.0);
-    assert_eq!(diag.get(1), 2.0);
-    assert_eq!(diag.get(2), 300.0);
-}
-
-#[test]
-fn test_diag_to_dense_vec_1d() {
-    // 1D diagonal tensor [3] with diag = [1, 2, 3]
-    // This is just the vector itself
-    let diag = DiagStorage::from_vec(vec![1.0, 2.0, 3.0]);
-    let dense = diag.to_dense_vec(&[3]);
-    assert_eq!(dense, vec![1.0, 2.0, 3.0]);
-}
-
-#[test]
-fn test_diag_to_dense_vec_c64() {
-    let diag = DiagStorage::from_vec(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]);
-    let dense = diag.to_dense_vec(&[2, 2]);
-    // [[1+2i, 0], [0, 3+4i]] in row-major
-    assert_eq!(dense[0], Complex64::new(1.0, 2.0));
-    assert_eq!(dense[1], Complex64::zero());
-    assert_eq!(dense[2], Complex64::zero());
-    assert_eq!(dense[3], Complex64::new(3.0, 4.0));
-}
-
-#[test]
-fn test_diag_contract_diag_diag_scalar_result() {
-    // All indices contracted: inner product
-    let d1 = DiagStorage::from_vec(vec![1.0, 2.0, 3.0]);
-    let d2 = DiagStorage::from_vec(vec![4.0, 5.0, 6.0]);
-    let result = d1.contract_diag_diag(
-        &[3, 3],
-        &d2,
-        &[3, 3],
-        &[],
-        |v| Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, &[])),
-        |v| Storage::diag_f64_legacy(DiagStorage::from_vec(v)),
-    );
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 1);
-    // 1*4 + 2*5 + 3*6 = 32
-    assert!((data[0] - 32.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_diag_contract_diag_diag_diag_result() {
-    // Partial contraction: element-wise product
-    let d1 = DiagStorage::from_vec(vec![2.0, 3.0]);
-    let d2 = DiagStorage::from_vec(vec![5.0, 7.0]);
-    let result = d1.contract_diag_diag(
-        &[2, 2],
-        &d2,
-        &[2, 2],
-        &[2, 2],
-        |v| Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, &[2, 2])),
-        |v| Storage::diag_f64_legacy(DiagStorage::from_vec(v)),
-    );
-    match result.repr() {
-        StorageRepr::DiagF64(d) => {
-            assert_eq!(d.as_slice(), &[10.0, 21.0]);
-        }
-        _ => panic!("Expected DiagF64"),
-    }
-}
-
-#[test]
-fn test_diag_contract_diag_dense_basic() {
-    // Diag [2,2] diag=[1,2], Dense [2,3] = [[1,2,3],[4,5,6]]
-    // Contract axis 1 of diag with axis 0 of dense
-    // Result[i,j] = diag[i] * dense[i,j]
-    let diag = DiagStorage::from_vec(vec![1.0, 2.0]);
-    let dense = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
-    let result = diag.contract_diag_dense(&[2, 2], &[1], &dense, &[2, 3], &[0], &[2, 3], |v| {
-        Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, &[2, 3]))
-    });
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 6);
-    // Result = [[1*1, 1*2, 1*3], [2*4, 2*5, 2*6]] = [[1,2,3],[8,10,12]]
-    assert!((data[0] - 1.0).abs() < 1e-10);
-    assert!((data[1] - 2.0).abs() < 1e-10);
-    assert!((data[2] - 3.0).abs() < 1e-10);
-    assert!((data[3] - 8.0).abs() < 1e-10);
-    assert!((data[4] - 10.0).abs() < 1e-10);
-    assert!((data[5] - 12.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_dense_tensor_ref_and_mut() {
-    let mut ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0], &[3]);
-    // Test tensor() for read access
-    assert_eq!(ds.tensor().len(), 3);
-    // Test tensor_mut() for write access
-    ds.tensor_mut()[0] = 99.0;
-    assert_eq!(ds.get(0), 99.0);
-}
-
-#[test]
-fn test_dense_deref() {
-    let ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]);
-    // Deref gives access to tensor methods
-    let _len = ds.len();
-    assert_eq!(_len, 2);
-}
-
-#[test]
-fn test_dense_contract_c64() {
-    // Verify contraction works for Complex64 too
-    let a = DenseStorage::from_vec_with_shape(
-        vec![
-            Complex64::new(1.0, 0.0),
-            Complex64::new(0.0, 1.0),
-            Complex64::new(1.0, 1.0),
-            Complex64::new(2.0, 0.0),
-        ],
-        &[2, 2],
-    );
-    let b = DenseStorage::from_vec_with_shape(
-        vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)],
-        &[2],
-    );
-    let result = a.contract(&[1], &b, &[0]);
-    assert_eq!(result.dims(), vec![2]);
-    // C[0] = (1+0i)*(1+0i) + (0+1i)*(0+1i) = 1 + (-1) = 0
-    // C[1] = (1+1i)*(1+0i) + (2+0i)*(0+1i) = 1+1i + 0+2i = 1+3i
-    assert!((result.as_slice()[0] - Complex64::new(0.0, 0.0)).norm() < 1e-10);
-    assert!((result.as_slice()[1] - Complex64::new(1.0, 3.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_dense_permute_3d() {
-    // 3D tensor [2, 3, 1], permute to [3, 1, 2]
-    let ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3, 1]);
-    let permuted = ds.permute(&[1, 2, 0]);
-    assert_eq!(permuted.dims(), vec![3, 1, 2]);
-    assert_eq!(permuted.len(), 6);
-}
-
 // ===== Storage-level tests for is_diag =====
 
 #[test]
 fn test_storage_is_diag() {
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0]));
+    let dense = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
+    let diag = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
     assert!(!dense.is_diag());
     assert!(diag.is_diag());
 }
@@ -807,11 +162,11 @@ fn structured_storage_validates_payload_rank_and_required_len() {
 
 #[test]
 fn test_storage_len_is_empty() {
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]));
+    let dense = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
     assert_eq!(dense.len(), 2);
     assert!(!dense.is_empty());
 
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![]));
+    let diag = Storage::from_diag_f64_col_major(vec![], 2).unwrap();
     assert_eq!(diag.len(), 0);
     assert!(diag.is_empty());
 }
@@ -850,60 +205,59 @@ fn test_storage_from_dense_c64_col_major_zeros_with_shape() {
 
 #[test]
 fn test_sum_from_storage_f64() {
-    let s = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0], &[3]));
+    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     let sum: f64 = f64::sum_from_storage(&s);
     assert!((sum - 6.0).abs() < 1e-10);
 }
 
 #[test]
 fn test_sum_from_storage_diag_f64() {
-    let s = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![10.0, 20.0]));
+    let s = Storage::from_diag_f64_col_major(vec![10.0, 20.0], 2).unwrap();
     let sum: f64 = f64::sum_from_storage(&s);
     assert!((sum - 30.0).abs() < 1e-10);
 }
 
 #[test]
 fn test_storage_sum_f64_method() {
-    let s = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0], &[3]));
+    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     assert!((s.sum_f64() - 6.0).abs() < 1e-10);
 }
 
 #[test]
 fn test_storage_sum_c64_method() {
-    let s = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
+    let s = Storage::from_dense_c64_col_major(
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
         &[2],
-    ));
+    )
+    .unwrap();
     let sum = s.sum_c64();
     assert!((sum - Complex64::new(4.0, 6.0)).norm() < 1e-10);
 }
 
 #[test]
 fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
-    let dense_c64 = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
+    let dense_c64 = Storage::from_dense_c64_col_major(
         vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, -1.0)],
         &[2],
-    ));
+    )
+    .unwrap();
     assert!((dense_c64.max_abs() - 5.0).abs() < 1e-10);
     match dense_c64.to_dense_storage(&[2]).repr() {
-        StorageRepr::StructuredC64(ds) => assert_eq!(
+        StorageRepr::C64(ds) => assert_eq!(
             ds.payload_col_major_vec().as_slice(),
             &[Complex64::new(3.0, 4.0), Complex64::new(1.0, -1.0)]
         ),
-        StorageRepr::DenseC64(ds) => assert_eq!(
-            ds.as_slice(),
-            &[Complex64::new(3.0, 4.0), Complex64::new(1.0, -1.0)]
-        ),
-        other => panic!("expected DenseC64, got {other:?}"),
+        other => panic!("expected C64, got {other:?}"),
     }
 
-    let diag_c64 = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![
-        Complex64::new(0.0, 2.0),
-        Complex64::new(3.0, 4.0),
-    ]));
+    let diag_c64 = Storage::from_diag_c64_col_major(
+        vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, 4.0)],
+        2,
+    )
+    .unwrap();
     assert!((diag_c64.max_abs() - 5.0).abs() < 1e-10);
     match diag_c64.to_dense_storage(&[2, 2]).repr() {
-        StorageRepr::StructuredC64(ds) => {
+        StorageRepr::C64(ds) => {
             assert_eq!(
                 ds.payload_col_major_vec().as_slice(),
                 &[
@@ -914,286 +268,145 @@ fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
                 ]
             );
         }
-        StorageRepr::DenseC64(ds) => {
-            assert_eq!(
-                ds.as_slice(),
-                &[
-                    Complex64::new(0.0, 2.0),
-                    Complex64::new(0.0, 0.0),
-                    Complex64::new(0.0, 0.0),
-                    Complex64::new(3.0, 4.0),
-                ]
-            );
-        }
-        other => panic!("expected DenseC64, got {other:?}"),
+        other => panic!("expected C64, got {other:?}"),
     }
 }
 
 #[test]
 fn test_storage_projection_promotion_and_conjugation_helpers() {
-    let dense_c64 = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
+    let dense_c64 = Storage::from_dense_c64_col_major(
         vec![Complex64::new(1.0, -2.0), Complex64::new(3.0, 4.0)],
         &[2],
-    ));
+    )
+    .unwrap();
     match dense_c64.extract_real_part().repr() {
-        StorageRepr::DenseF64(ds) => assert_eq!(ds.as_slice(), &[1.0, 3.0]),
-        StorageRepr::StructuredF64(ds) => {
+        StorageRepr::F64(ds) => {
             assert_eq!(ds.payload_col_major_vec().as_slice(), &[1.0, 3.0])
         }
-        other => panic!("expected DenseF64, got {other:?}"),
+        other => panic!("expected F64, got {other:?}"),
     }
     match dense_c64.extract_imag_part(&[2]).repr() {
-        StorageRepr::DenseF64(ds) => assert_eq!(ds.as_slice(), &[-2.0, 4.0]),
-        StorageRepr::StructuredF64(ds) => {
+        StorageRepr::F64(ds) => {
             assert_eq!(ds.payload_col_major_vec().as_slice(), &[-2.0, 4.0])
         }
-        other => panic!("expected DenseF64, got {other:?}"),
+        other => panic!("expected F64, got {other:?}"),
     }
     match dense_c64.conj().repr() {
-        StorageRepr::DenseC64(ds) => {
-            assert_eq!(
-                ds.as_slice(),
-                &[Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)]
-            )
-        }
-        StorageRepr::StructuredC64(ds) => {
+        StorageRepr::C64(ds) => {
             assert_eq!(
                 ds.payload_col_major_vec().as_slice(),
                 &[Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)]
             )
         }
-        other => panic!("expected DenseC64, got {other:?}"),
+        other => panic!("expected C64, got {other:?}"),
     }
 
-    let diag_f64 = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![2.0, -1.0]));
+    let diag_f64 = Storage::from_diag_f64_col_major(vec![2.0, -1.0], 2).unwrap();
     match diag_f64.extract_imag_part(&[2, 2]).repr() {
-        StorageRepr::DiagF64(ds) => assert_eq!(ds.as_slice(), &[0.0, 0.0]),
-        StorageRepr::StructuredF64(ds) => {
+        StorageRepr::F64(ds) => {
             assert_eq!(ds.payload_col_major_vec().as_slice(), &[0.0, 0.0])
         }
-        other => panic!("expected DiagF64, got {other:?}"),
+        other => panic!("expected F64, got {other:?}"),
     }
     match diag_f64.to_complex_storage().repr() {
-        StorageRepr::DiagC64(ds) => {
-            assert_eq!(
-                ds.as_slice(),
-                &[Complex64::new(2.0, 0.0), Complex64::new(-1.0, 0.0)]
-            )
-        }
-        StorageRepr::StructuredC64(ds) => {
+        StorageRepr::C64(ds) => {
             assert_eq!(
                 ds.payload_col_major_vec().as_slice(),
                 &[Complex64::new(2.0, 0.0), Complex64::new(-1.0, 0.0)]
             )
         }
-        other => panic!("expected DiagC64, got {other:?}"),
+        other => panic!("expected C64, got {other:?}"),
     }
-    let real = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]));
-    let imag = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![0.5, -1.5], &[2]));
+    let real = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let imag = Storage::from_dense_f64_col_major(vec![0.5, -1.5], &[2]).unwrap();
     match Storage::combine_to_complex(&real, &imag).repr() {
-        StorageRepr::DenseC64(ds) => {
-            assert_eq!(
-                ds.as_slice(),
-                &[Complex64::new(1.0, 0.5), Complex64::new(2.0, -1.5)]
-            )
-        }
-        StorageRepr::StructuredC64(ds) => {
+        StorageRepr::C64(ds) => {
             assert_eq!(
                 ds.payload_col_major_vec().as_slice(),
                 &[Complex64::new(1.0, 0.5), Complex64::new(2.0, -1.5)]
             )
         }
-        other => panic!("expected DenseC64, got {other:?}"),
+        other => panic!("expected C64, got {other:?}"),
     }
 }
 
 #[test]
 fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
-    let dense_f64_a =
-        Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]));
-    let dense_f64_b =
-        Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![3.0, -1.0], &[2]));
+    let dense_f64_a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let dense_f64_b = Storage::from_dense_f64_col_major(vec![3.0, -1.0], &[2]).unwrap();
     match dense_f64_a.try_add(&dense_f64_b).unwrap().repr() {
-        StorageRepr::DenseF64(ds) => assert_eq!(ds.as_slice(), &[4.0, 1.0]),
-        other => panic!("expected DenseF64, got {other:?}"),
+        StorageRepr::F64(ds) => assert_eq!(ds.data(), &[4.0, 1.0]),
+        other => panic!("expected F64, got {other:?}"),
     }
     match dense_f64_a.try_sub(&dense_f64_b).unwrap().repr() {
-        StorageRepr::DenseF64(ds) => assert_eq!(ds.as_slice(), &[-2.0, 3.0]),
-        other => panic!("expected DenseF64, got {other:?}"),
+        StorageRepr::F64(ds) => assert_eq!(ds.data(), &[-2.0, 3.0]),
+        other => panic!("expected F64, got {other:?}"),
     }
 
-    let dense_c64_a = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
+    let dense_c64_a = Storage::from_dense_c64_col_major(
         vec![Complex64::new(1.0, 1.0), Complex64::new(0.0, -2.0)],
         &[2],
-    ));
-    let dense_c64_b = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
+    )
+    .unwrap();
+    let dense_c64_b = Storage::from_dense_c64_col_major(
         vec![Complex64::new(-1.0, 0.5), Complex64::new(3.0, 1.0)],
         &[2],
-    ));
+    )
+    .unwrap();
     assert!(matches!(
         dense_c64_a.try_add(&dense_c64_b).unwrap().repr(),
-        StorageRepr::DenseC64(_)
+        StorageRepr::C64(_)
     ));
     assert!(matches!(
         dense_c64_a.try_sub(&dense_c64_b).unwrap().repr(),
-        StorageRepr::DenseC64(_)
+        StorageRepr::C64(_)
     ));
 
-    let diag_f64_a = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0]));
-    let diag_f64_b = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![0.5, -3.0]));
+    let diag_f64_a = Storage::from_diag_f64_col_major(vec![1.0, 2.0], 2).unwrap();
+    let diag_f64_b = Storage::from_diag_f64_col_major(vec![0.5, -3.0], 2).unwrap();
     assert!(matches!(
         diag_f64_a.try_add(&diag_f64_b).unwrap().repr(),
-        StorageRepr::DiagF64(_)
+        StorageRepr::F64(_)
     ));
     assert!(matches!(
         diag_f64_a.try_sub(&diag_f64_b).unwrap().repr(),
-        StorageRepr::DiagF64(_)
+        StorageRepr::F64(_)
     ));
 
-    let diag_c64_a = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![
-        Complex64::new(1.0, -1.0),
-        Complex64::new(0.0, 2.0),
-    ]));
-    let diag_c64_b = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![
-        Complex64::new(0.5, 0.5),
-        Complex64::new(-3.0, 1.0),
-    ]));
+    let diag_c64_a = Storage::from_diag_c64_col_major(
+        vec![Complex64::new(1.0, -1.0), Complex64::new(0.0, 2.0)],
+        2,
+    )
+    .unwrap();
+    let diag_c64_b = Storage::from_diag_c64_col_major(
+        vec![Complex64::new(0.5, 0.5), Complex64::new(-3.0, 1.0)],
+        2,
+    )
+    .unwrap();
     assert!(matches!(
         diag_c64_a.try_add(&diag_c64_b).unwrap().repr(),
-        StorageRepr::DiagC64(_)
+        StorageRepr::C64(_)
     ));
     assert!(matches!(
         diag_c64_a.try_sub(&diag_c64_b).unwrap().repr(),
-        StorageRepr::DiagC64(_)
+        StorageRepr::C64(_)
     ));
 
-    let mismatched_len =
-        Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
+    let mismatched_len = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
     let err = dense_f64_a.try_add(&mismatched_len).unwrap_err();
     assert!(err.contains("Storage lengths must match for addition"));
     let err = dense_f64_a.try_sub(&mismatched_len).unwrap_err();
     assert!(err.contains("Storage lengths must match for subtraction"));
 
-    let mismatched_type = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
+    let mismatched_type = Storage::from_dense_c64_col_major(
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
         &[2],
-    ));
+    )
+    .unwrap();
     let err = dense_f64_a.try_add(&mismatched_type).unwrap_err();
     assert!(err.contains("Storage types must match for addition"));
     let err = dense_f64_a.try_sub(&mismatched_type).unwrap_err();
     assert!(err.contains("Storage types must match for subtraction"));
-}
-
-// ===== DenseStorage Deref / DerefMut coverage =====
-
-#[test]
-fn test_dense_deref_mut() {
-    let mut ds = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0], &[3]);
-    // DerefMut gives mutable access to underlying tensor
-    ds[0] = 42.0;
-    assert_eq!(ds.as_slice()[0], 42.0);
-}
-
-// ===== DenseStorage contract with non-contiguous axes =====
-
-#[test]
-fn test_dense_contract_non_contiguous_axes() {
-    // Contract axes [0, 2] of a 3D tensor with axes [0, 1] of a 2D tensor.
-    // This forces permutation of both tensors before GEMM.
-    // A has shape [2, 3, 2], B has shape [2, 2]
-    // Contract A axes [0, 2] with B axes [0, 1]
-    let a = DenseStorage::from_vec_with_shape((1..=12).map(|x| x as f64).collect(), &[2, 3, 2]);
-    let b = DenseStorage::from_vec_with_shape(vec![1.0, 0.0, 0.0, 1.0], &[2, 2]);
-    let result = a.contract(&[0, 2], &b, &[0, 1]);
-    // Result shape should be [3] (the non-contracted axis of A)
-    assert_eq!(result.dims(), vec![3]);
-    // Manually compute: sum over i,k of A[i,:,k] * B[i,k]
-    // A[0,:,0] = [1,3,5], A[0,:,1] = [2,4,6], A[1,:,0] = [7,9,11], A[1,:,1] = [8,10,12]
-    // B[0,0]=1, B[0,1]=0, B[1,0]=0, B[1,1]=1
-    // result[j] = A[0,j,0]*B[0,0] + A[0,j,1]*B[0,1] + A[1,j,0]*B[1,0] + A[1,j,1]*B[1,1]
-    //           = A[0,j,0]*1 + A[0,j,1]*0 + A[1,j,0]*0 + A[1,j,1]*1
-    //           = A[0,j,0] + A[1,j,1]
-    // result[0] = 1 + 8 = 9
-    // result[1] = 3 + 10 = 13
-    // result[2] = 5 + 12 = 17
-    assert!((result.as_slice()[0] - 9.0).abs() < 1e-10);
-    assert!((result.as_slice()[1] - 13.0).abs() < 1e-10);
-    assert!((result.as_slice()[2] - 17.0).abs() < 1e-10);
-}
-
-// ===== DiagStorage to_dense_vec rank=0 =====
-
-#[test]
-fn test_diag_to_dense_vec_rank0() {
-    let diag = DiagStorage::from_vec(vec![42.0]);
-    let dense = diag.to_dense_vec(&[]);
-    assert_eq!(dense, vec![42.0]);
-}
-
-// ===== SumFromStorage coverage for Diag and Structured variants =====
-
-#[test]
-fn test_sum_from_storage_diag_c64() {
-    let s = Storage::diag_c64_legacy(DiagStorage::from_vec(vec![
-        Complex64::new(1.0, 2.0),
-        Complex64::new(3.0, 4.0),
-    ]));
-    let sum_f64: f64 = f64::sum_from_storage(&s);
-    // real part sum: 1.0 + 3.0 = 4.0
-    assert!((sum_f64 - 4.0).abs() < 1e-10);
-
-    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
-    assert!((sum_c64 - Complex64::new(4.0, 6.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_sum_from_storage_structured_f64() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
-    let sum_f64: f64 = f64::sum_from_storage(&s);
-    assert!((sum_f64 - 6.0).abs() < 1e-10);
-
-    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
-    assert!((sum_c64 - Complex64::new(6.0, 0.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_sum_from_storage_structured_c64() {
-    let s = Storage::from_dense_c64_col_major(
-        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
-        &[2],
-    )
-    .unwrap();
-    let sum_f64: f64 = f64::sum_from_storage(&s);
-    // real part sum: 1.0 + 3.0 = 4.0
-    assert!((sum_f64 - 4.0).abs() < 1e-10);
-
-    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
-    assert!((sum_c64 - Complex64::new(4.0, 6.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_sum_from_storage_dense_c64_as_f64() {
-    let s = Storage::dense_c64_legacy(DenseStorage::from_vec_with_shape(
-        vec![Complex64::new(10.0, 5.0), Complex64::new(-3.0, 2.0)],
-        &[2],
-    ));
-    let sum_f64: f64 = f64::sum_from_storage(&s);
-    // real part sum: 10.0 + (-3.0) = 7.0
-    assert!((sum_f64 - 7.0).abs() < 1e-10);
-}
-
-#[test]
-fn test_sum_from_storage_dense_f64_as_c64() {
-    let s = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![2.0, 3.0], &[2]));
-    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
-    assert!((sum_c64 - Complex64::new(5.0, 0.0)).norm() < 1e-10);
-}
-
-#[test]
-fn test_sum_from_storage_diag_f64_as_c64() {
-    let s = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![10.0, 20.0]));
-    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
-    assert!((sum_c64 - Complex64::new(30.0, 0.0)).norm() < 1e-10);
 }
 
 // ===== StructuredStorage permute_logical_axes assertion path =====
@@ -1206,30 +419,11 @@ fn test_structured_storage_permute_logical_axes_basic() {
     assert_eq!(permuted.axis_classes(), &[0, 0]);
 }
 
-// ===== contract_dense_diag_impl intermediate fallthrough =====
-
-#[test]
-fn test_contract_dense_diag_all_diag_axes_contracted() {
-    // Dense [2, 3] x Diag [3, 3]: contract axis 1 of dense with both axes of diag.
-    // Since both diag axes are contracted, diag_non_contracted_count = 0,
-    // so the intermediate result is returned without permutation (line 1042).
-    let dense = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-        &[2, 3],
-    ));
-    let diag = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0, 3.0]));
-
-    let result = contract_storage(&dense, &[2, 3], &[1], &diag, &[3, 3], &[0], &[2, 3]);
-
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 6);
-}
-
 // ===== Storage::scale and Storage::axpby coverage =====
 
 #[test]
 fn test_storage_scale_f64() {
-    let s = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]));
+    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
     let scaled = s.scale(&crate::AnyScalar::new_real(3.0));
     let data = extract_f64(&scaled);
     assert!((data[0] - 3.0).abs() < 1e-10);
@@ -1238,8 +432,8 @@ fn test_storage_scale_f64() {
 
 #[test]
 fn test_storage_axpby_dense_f64() {
-    let a = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]));
-    let b = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![3.0, 4.0], &[2]));
+    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_f64_col_major(vec![3.0, 4.0], &[2]).unwrap();
     let result = a
         .axpby(
             &crate::AnyScalar::new_real(2.0),
@@ -1255,8 +449,8 @@ fn test_storage_axpby_dense_f64() {
 
 #[test]
 fn test_storage_axpby_diag_f64() {
-    let a = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![1.0, 2.0]));
-    let b = Storage::diag_f64_legacy(DiagStorage::from_vec(vec![3.0, 4.0]));
+    let a = Storage::from_diag_f64_col_major(vec![1.0, 2.0], 2).unwrap();
+    let b = Storage::from_diag_f64_col_major(vec![3.0, 4.0], 2).unwrap();
     let result = a
         .axpby(
             &crate::AnyScalar::new_real(2.0),
@@ -1265,18 +459,18 @@ fn test_storage_axpby_diag_f64() {
         )
         .unwrap();
     match result.repr() {
-        StorageRepr::DiagF64(d) => {
-            assert!((d.as_slice()[0] - 11.0).abs() < 1e-10);
-            assert!((d.as_slice()[1] - 16.0).abs() < 1e-10);
+        StorageRepr::F64(d) => {
+            assert!((d.data()[0] - 11.0).abs() < 1e-10);
+            assert!((d.data()[1] - 16.0).abs() < 1e-10);
         }
-        _ => panic!("Expected DiagF64"),
+        _ => panic!("Expected F64"),
     }
 }
 
 #[test]
 fn test_storage_axpby_complex_promotion() {
-    let a = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0, 2.0], &[2]));
-    let b = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![3.0, 4.0], &[2]));
+    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_f64_col_major(vec![3.0, 4.0], &[2]).unwrap();
     let result = a
         .axpby(
             &crate::AnyScalar::new_complex(1.0, 1.0),
@@ -1528,53 +722,134 @@ fn test_storage_new_structured_c64() {
 
 #[test]
 fn test_make_mut_storage() {
-    let storage = Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(vec![1.0], &[1]));
+    let storage = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
     let mut arc = Arc::new(storage);
     let _mutable = make_mut_storage(&mut arc);
     // Just verify it doesn't panic and returns a mutable ref
 }
 
-// ===== contract_diag_dense with all diag axes contracted (lines 918-921) =====
+// ===== SumFromStorage coverage for Structured variants =====
 
 #[test]
-fn test_contract_diag_dense_all_axes_contracted_multiaxis() {
-    // Diag [3, 3] x Dense [3, 3]: contract both axes of diag with dense
-    // This hits the branch where diag_non_contracted_count == 0
-    // and the inner loop iterates over dense non-contracted dims (lines 917-921)
-    let diag = DiagStorage::from_vec(vec![1.0, 2.0, 3.0]);
-    let dense = DenseStorage::from_vec_with_shape(
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-        &[3, 3],
-    );
-    // Contract both diag axes with both dense axes: trace-like operation
-    let result = diag.contract_diag_dense(&[3, 3], &[0, 1], &dense, &[3, 3], &[0, 1], &[], |v| {
-        Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, &[]))
-    });
-    let data = extract_f64(&result);
-    // sum_t diag[t] * dense[t, t] = 1*1 + 2*5 + 3*9 = 1 + 10 + 27 = 38
-    assert_eq!(data.len(), 1);
-    assert!((data[0] - 38.0).abs() < 1e-10);
+fn test_sum_from_storage_diag_c64() {
+    let s = Storage::from_diag_c64_col_major(
+        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
+        2,
+    )
+    .unwrap();
+    let sum_f64: f64 = f64::sum_from_storage(&s);
+    // real part sum: 1.0 + 3.0 = 4.0
+    assert!((sum_f64 - 4.0).abs() < 1e-10);
+
+    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
+    assert!((sum_c64 - Complex64::new(4.0, 6.0)).norm() < 1e-10);
 }
 
 #[test]
-fn test_contract_diag_dense_partial_contracted_with_free_dense_axes() {
-    // Diag [2, 2] x Dense [2, 3]: contract axis 1 of diag with axis 0 of dense
-    // diag_non_contracted_count = 1, dense non-contracted has dim [3]
-    // This hits the else branch (lines 928+) with the inner loop (lines 957-963)
-    let diag = DiagStorage::from_vec(vec![2.0, 5.0]);
-    let dense = DenseStorage::from_vec_with_shape(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
-    let result = diag.contract_diag_dense(&[2, 2], &[1], &dense, &[2, 3], &[0], &[2, 3], |v| {
-        Storage::dense_f64_legacy(DenseStorage::from_vec_with_shape(v, &[2, 3]))
-    });
-    let data = extract_f64(&result);
-    assert_eq!(data.len(), 6);
-    // Result[i, j] = diag[i] * dense[i, j]
-    // [0,0] = 2*1=2, [0,1] = 2*2=4, [0,2] = 2*3=6
-    // [1,0] = 5*4=20, [1,1] = 5*5=25, [1,2] = 5*6=30
-    assert!((data[0] - 2.0).abs() < 1e-10);
-    assert!((data[1] - 4.0).abs() < 1e-10);
-    assert!((data[2] - 6.0).abs() < 1e-10);
-    assert!((data[3] - 20.0).abs() < 1e-10);
-    assert!((data[4] - 25.0).abs() < 1e-10);
-    assert!((data[5] - 30.0).abs() < 1e-10);
+fn test_sum_from_storage_structured_f64() {
+    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let sum_f64: f64 = f64::sum_from_storage(&s);
+    assert!((sum_f64 - 6.0).abs() < 1e-10);
+
+    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
+    assert!((sum_c64 - Complex64::new(6.0, 0.0)).norm() < 1e-10);
+}
+
+#[test]
+fn test_sum_from_storage_structured_c64() {
+    let s = Storage::from_dense_c64_col_major(
+        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
+        &[2],
+    )
+    .unwrap();
+    let sum_f64: f64 = f64::sum_from_storage(&s);
+    // real part sum: 1.0 + 3.0 = 4.0
+    assert!((sum_f64 - 4.0).abs() < 1e-10);
+
+    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
+    assert!((sum_c64 - Complex64::new(4.0, 6.0)).norm() < 1e-10);
+}
+
+#[test]
+fn test_sum_from_storage_dense_c64_as_f64() {
+    let s = Storage::from_dense_c64_col_major(
+        vec![Complex64::new(10.0, 5.0), Complex64::new(-3.0, 2.0)],
+        &[2],
+    )
+    .unwrap();
+    let sum_f64: f64 = f64::sum_from_storage(&s);
+    // real part sum: 10.0 + (-3.0) = 7.0
+    assert!((sum_f64 - 7.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_sum_from_storage_dense_f64_as_c64() {
+    let s = Storage::from_dense_f64_col_major(vec![2.0, 3.0], &[2]).unwrap();
+    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
+    assert!((sum_c64 - Complex64::new(5.0, 0.0)).norm() < 1e-10);
+}
+
+#[test]
+fn test_sum_from_storage_diag_f64_as_c64() {
+    let s = Storage::from_diag_f64_col_major(vec![10.0, 20.0], 2).unwrap();
+    let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
+    assert!((sum_c64 - Complex64::new(30.0, 0.0)).norm() < 1e-10);
+}
+
+// ===== Contraction via native path =====
+
+#[test]
+fn test_contract_storage_dense_f64_matmul() {
+    // A = [[1,2],[3,4]] col-major: [1, 3, 2, 4]
+    // B = [[5,6],[7,8]] col-major: [5, 7, 6, 8]
+    // C = A @ B = [[19,22],[43,50]] col-major: [19, 43, 22, 50]
+    let a = Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+    let b = Storage::from_dense_f64_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
+
+    let result = contract_storage(&a, &[2, 2], &[1], &b, &[2, 2], &[0], &[2, 2]);
+
+    let data = result
+        .to_dense_f64_col_major_vec(&[2, 2])
+        .expect("materialization failed");
+    // col-major: [19, 43, 22, 50]
+    assert!((data[0] - 19.0).abs() < 1e-10);
+    assert!((data[1] - 43.0).abs() < 1e-10);
+    assert!((data[2] - 22.0).abs() < 1e-10);
+    assert!((data[3] - 50.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_contract_storage_diag_f64_partial() {
+    // Diag [3, 3] with diag = [1, 2, 3]
+    // Diag [3, 3] with diag = [4, 5, 6]
+    // Contract axis 1 of first with axis 0 of second
+    // Result should be element-wise product: [4, 10, 18] (diagonal)
+    let diag1 = Storage::from_diag_f64_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
+    let diag2 = Storage::from_diag_f64_col_major(vec![4.0, 5.0, 6.0], 2).unwrap();
+
+    let result = contract_storage(&diag1, &[3, 3], &[1], &diag2, &[3, 3], &[0], &[3, 3]);
+
+    // Materialize as dense to verify
+    let dense = result
+        .to_dense_f64_col_major_vec(&[3, 3])
+        .expect("materialization failed");
+    // Col-major [3,3]: diag = [4, 10, 18], rest = 0
+    assert!((dense[0] - 4.0).abs() < 1e-10); // (0,0)
+    assert!((dense[4] - 10.0).abs() < 1e-10); // (1,1) = col-major offset 1 + 1*3 = 4
+    assert!((dense[8] - 18.0).abs() < 1e-10); // (2,2) = col-major offset 2 + 2*3 = 8
+}
+
+#[test]
+fn test_contract_storage_inner_product() {
+    // [1, 2, 3] . [4, 5, 6] = 4 + 10 + 18 = 32
+    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let b = Storage::from_dense_f64_col_major(vec![4.0, 5.0, 6.0], &[3]).unwrap();
+
+    let result = contract_storage(&a, &[3], &[0], &b, &[3], &[0], &[]);
+
+    let data = result
+        .to_dense_f64_col_major_vec(&[])
+        .expect("materialization failed");
+    assert_eq!(data.len(), 1);
+    assert!((data[0] - 32.0).abs() < 1e-10);
 }

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -17,7 +17,7 @@ use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
 
 #[cfg(test)]
 use crate::storage::StorageRepr;
-use crate::storage::{col_major_strides, NativePayload, Storage, StructuredStorage};
+use crate::storage::{col_major_strides, NativePayload, Storage};
 use crate::tensor_element::TensorElement;
 use crate::AnyScalar;
 
@@ -226,12 +226,12 @@ fn snapshot_f64_to_storage(snap: &snapshot::DynTensor) -> Result<Storage> {
             .ok_or_else(|| anyhow!("expected f64 structured payload"))?;
         let data =
             materialize_col_major_values(payload, "f64 structured snapshot materialization")?;
-        Ok(Storage::structured_f64(StructuredStorage::new(
+        Storage::new_structured_f64(
             data,
             payload.dims().to_vec(),
             col_major_strides(payload.dims()),
             snap.axis_classes().to_vec(),
-        )?))
+        )
     }
 }
 
@@ -255,12 +255,12 @@ fn snapshot_c64_to_storage(snap: &snapshot::DynTensor) -> Result<Storage> {
             .ok_or_else(|| anyhow!("expected c64 structured payload"))?;
         let data =
             materialize_col_major_values(payload, "c64 structured snapshot materialization")?;
-        Ok(Storage::structured_c64(StructuredStorage::new(
+        Storage::new_structured_c64(
             data,
             payload.dims().to_vec(),
             col_major_strides(payload.dims()),
             snap.axis_classes().to_vec(),
-        )?))
+        )
     }
 }
 

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -3,27 +3,13 @@ use crate::storage::Storage;
 
 fn assert_storage_eq(lhs: &Storage, rhs: &Storage) {
     match (lhs.repr(), rhs.repr()) {
-        (StorageRepr::DenseF64(a), StorageRepr::DenseF64(b)) => {
-            assert_eq!(a.dims(), b.dims());
-            assert_eq!(a.as_slice(), b.as_slice());
-        }
-        (StorageRepr::DenseC64(a), StorageRepr::DenseC64(b)) => {
-            assert_eq!(a.dims(), b.dims());
-            assert_eq!(a.as_slice(), b.as_slice());
-        }
-        (StorageRepr::DiagF64(a), StorageRepr::DiagF64(b)) => {
-            assert_eq!(a.as_slice(), b.as_slice());
-        }
-        (StorageRepr::DiagC64(a), StorageRepr::DiagC64(b)) => {
-            assert_eq!(a.as_slice(), b.as_slice());
-        }
-        (StorageRepr::StructuredF64(a), StorageRepr::StructuredF64(b)) => {
+        (StorageRepr::F64(a), StorageRepr::F64(b)) => {
             assert_eq!(a.payload_dims(), b.payload_dims());
             assert_eq!(a.strides(), b.strides());
             assert_eq!(a.axis_classes(), b.axis_classes());
             assert_eq!(a.data(), b.data());
         }
-        (StorageRepr::StructuredC64(a), StorageRepr::StructuredC64(b)) => {
+        (StorageRepr::C64(a), StorageRepr::C64(b)) => {
             assert_eq!(a.payload_dims(), b.payload_dims());
             assert_eq!(a.strides(), b.strides());
             assert_eq!(a.axis_classes(), b.axis_classes());
@@ -89,11 +75,11 @@ fn storage_native_roundtrip_structured_preserves_axis_classes() {
     let roundtrip = storage_to_native_tensor(&storage, &[2, 2, 2]).unwrap();
 
     match storage.repr() {
-        StorageRepr::StructuredF64(value) => {
+        StorageRepr::F64(value) => {
             assert_eq!(value.axis_classes(), &[0, 1, 1]);
             assert_eq!(value.payload_dims(), &[2, 2]);
         }
-        other => panic!("expected StructuredF64 storage, got {other:?}"),
+        other => panic!("expected F64 storage, got {other:?}"),
     }
     assert_eq!(roundtrip.dims(), &[2, 2, 2]);
     assert_eq!(roundtrip.axis_classes(), &[0, 1, 1]);
@@ -355,10 +341,10 @@ fn storage_native_roundtrip_structured_c64_preserves_axis_classes() {
     let roundtrip = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
 
     match storage.repr() {
-        StorageRepr::StructuredC64(value) => {
+        StorageRepr::C64(value) => {
             assert_eq!(value.axis_classes(), &[0, 0]);
         }
-        other => panic!("expected StructuredC64 storage, got {other:?}"),
+        other => panic!("expected C64 storage, got {other:?}"),
     }
     assert_eq!(roundtrip.dims(), &[2, 2]);
     assert_eq!(roundtrip.axis_classes(), &[0, 0]);


### PR DESCRIPTION
## Summary

- Remove legacy `DenseStorage<T>` / `DiagStorage<T>` types and all 4 legacy `StorageRepr` variants from `tensor4all-tensorbackend`
- Simplify `StorageRepr` from 6 variants to 2: `F64(StructuredStorage<f64>)` and `C64(StructuredStorage<Complex64>)`
- `contract_storage` now delegates entirely to the native tenferro path
- Add lightweight `Tensor<T, N>` wrapper in `tensor4all-simplett` replacing `mdarray::DTensor`
- Remove `mdarray` dependency from both crates

**-2533 lines, +658 lines** net reduction.

## Test plan

- [x] `cargo nextest run --release -p tensor4all-tensorbackend` — 87 tests pass
- [x] `cargo nextest run --release -p tensor4all-simplett` — 191 tests pass
- [x] `cargo nextest run --release --workspace` — 1605 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)