### PR TITLE
refactor: remove non-generic f64/c64 Rust APIs (#300)

### DIFF
--- a/benchmarks/rust/benchmark_contract.rs
+++ b/benchmarks/rust/benchmark_contract.rs
@@ -53,7 +53,7 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random_f64(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-core/src/block_tensor/tests/mod.rs
+++ b/crates/tensor4all-core/src/block_tensor/tests/mod.rs
@@ -146,7 +146,7 @@ fn test_gmres_diagonal_block() {
         let x2 = x.get(1, 0);
 
         // Apply D1 to x1
-        let x1_data = x1.to_vec_f64()?;
+        let x1_data = x1.to_vec::<f64>()?;
         let y1_data: Vec<f64> = x1_data
             .iter()
             .zip(diag1.iter())
@@ -155,7 +155,7 @@ fn test_gmres_diagonal_block() {
         let y1 = TensorDynLen::from_dense(x1.indices.clone(), y1_data).unwrap();
 
         // Apply D2 to x2
-        let x2_data = x2.to_vec_f64()?;
+        let x2_data = x2.to_vec::<f64>()?;
         let y2_data: Vec<f64> = x2_data
             .iter()
             .zip(diag2.iter())
@@ -432,7 +432,7 @@ fn test_get_mut() {
     let blk = block.get_mut(1, 0);
     *blk = make_vector_with_index(vec![10.0, 20.0], &idx);
 
-    let data = block.get(1, 0).to_vec_f64().unwrap();
+    let data = block.get(1, 0).to_vec::<f64>().unwrap();
     assert!((data[0] - 10.0).abs() < 1e-10);
     assert!((data[1] - 20.0).abs() < 1e-10);
 }
@@ -449,7 +449,7 @@ fn test_blocks_and_blocks_mut() {
 
     // blocks_mut() returns mutable slice
     block.blocks_mut()[0] = make_vector_with_index(vec![10.0, 20.0], &idx);
-    let data = block.get(0, 0).to_vec_f64().unwrap();
+    let data = block.get(0, 0).to_vec::<f64>().unwrap();
     assert!((data[0] - 10.0).abs() < 1e-10);
 }
 
@@ -462,7 +462,7 @@ fn test_into_blocks() {
 
     let blocks = block.into_blocks();
     assert_eq!(blocks.len(), 2);
-    let data = blocks[1].to_vec_f64().unwrap();
+    let data = blocks[1].to_vec::<f64>().unwrap();
     assert!((data[0] - 3.0).abs() < 1e-10);
 }
 
@@ -486,7 +486,7 @@ fn test_replaceind() {
         assert!(ext[0].same_id(&new_idx));
     }
     // Data should be preserved
-    let data = replaced.get(0, 0).to_vec_f64().unwrap();
+    let data = replaced.get(0, 0).to_vec::<f64>().unwrap();
     assert!((data[0] - 1.0).abs() < 1e-10);
     assert!((data[1] - 2.0).abs() < 1e-10);
 }

--- a/crates/tensor4all-core/src/defaults/direct_sum.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum.rs
@@ -10,7 +10,8 @@ use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::tensor::TensorDynLen;
 use anyhow::Result;
-use num_complex::Complex64;
+use num_traits::Zero;
+use tensor4all_tensorbackend::TensorElement;
 
 /// Compute the direct sum of two tensors along specified index pairs.
 ///
@@ -46,9 +47,9 @@ pub fn direct_sum(
     pairs: &[(DynIndex, DynIndex)],
 ) -> Result<(TensorDynLen, Vec<DynIndex>)> {
     if a.is_f64() && b.is_f64() {
-        direct_sum_f64(a, b, pairs)
+        direct_sum_typed::<f64>(a, b, pairs)
     } else if a.is_complex() && b.is_complex() {
-        direct_sum_c64(a, b, pairs)
+        direct_sum_typed::<num_complex::Complex64>(a, b, pairs)
     } else {
         Err(anyhow::anyhow!(
             "direct_sum requires both tensors to have the same dense scalar type (f64 or Complex64)"
@@ -243,16 +244,16 @@ fn multi_to_linear(multi: &[usize], strides: &[usize]) -> usize {
     multi.iter().zip(strides).map(|(&m, &s)| m * s).sum()
 }
 
-fn direct_sum_f64(
+fn direct_sum_typed<T: TensorElement + Zero>(
     a: &TensorDynLen,
     b: &TensorDynLen,
     pairs: &[(DynIndex, DynIndex)],
 ) -> Result<(TensorDynLen, Vec<DynIndex>)> {
     let setup = setup_direct_sum(a, b, pairs)?;
-    let a_data = a.to_vec_f64()?;
-    let b_data = b.to_vec_f64()?;
+    let a_data = a.to_vec::<T>()?;
+    let b_data = b.to_vec::<T>()?;
 
-    let mut result_data: Vec<f64> = vec![0.0; setup.result_total];
+    let mut result_data: Vec<T> = vec![T::zero(); setup.result_total];
 
     #[allow(clippy::needless_range_loop)]
     for result_linear in 0..setup.result_total {
@@ -292,63 +293,7 @@ fn direct_sum_f64(
             let b_linear = multi_to_linear(&b_multi, &setup.b_strides);
             result_data[result_linear] = b_data[b_linear];
         }
-        // else: mixed case stays 0.0
-    }
-
-    let result = TensorDynLen::from_dense(setup.result_indices, result_data)?;
-    Ok((result, setup.new_indices))
-}
-
-fn direct_sum_c64(
-    a: &TensorDynLen,
-    b: &TensorDynLen,
-    pairs: &[(DynIndex, DynIndex)],
-) -> Result<(TensorDynLen, Vec<DynIndex>)> {
-    let setup = setup_direct_sum(a, b, pairs)?;
-    let a_data = a.to_vec_c64()?;
-    let b_data = b.to_vec_c64()?;
-
-    let mut result_data: Vec<Complex64> = vec![Complex64::new(0.0, 0.0); setup.result_total];
-
-    #[allow(clippy::needless_range_loop)]
-    for result_linear in 0..setup.result_total {
-        let result_multi = linear_to_multi(result_linear, &setup.result_dims);
-        let common_multi: Vec<usize> = result_multi[..setup.n_common].to_vec();
-        let paired_multi: Vec<usize> = result_multi[setup.n_common..].to_vec();
-
-        let all_from_a = paired_multi
-            .iter()
-            .enumerate()
-            .all(|(i, &pm)| pm < setup.paired_dims_a[i]);
-        let all_from_b = paired_multi
-            .iter()
-            .enumerate()
-            .all(|(i, &pm)| pm >= setup.paired_dims_a[i]);
-
-        if all_from_a {
-            let a_dims = a.dims();
-            let mut a_multi = vec![0usize; a_dims.len()];
-            for (i, &cp) in setup.common_a_positions.iter().enumerate() {
-                a_multi[cp] = common_multi[i];
-            }
-            for (i, &pp) in setup.paired_a_positions.iter().enumerate() {
-                a_multi[pp] = paired_multi[i];
-            }
-            let a_linear = multi_to_linear(&a_multi, &setup.a_strides);
-            result_data[result_linear] = a_data[a_linear];
-        } else if all_from_b {
-            let b_dims = b.dims();
-            let mut b_multi = vec![0usize; b_dims.len()];
-            for (i, &cp) in setup.common_b_positions.iter().enumerate() {
-                b_multi[cp] = common_multi[i];
-            }
-            for (i, &pp) in setup.paired_b_positions.iter().enumerate() {
-                b_multi[pp] = paired_multi[i] - setup.paired_dims_a[i];
-            }
-            let b_linear = multi_to_linear(&b_multi, &setup.b_strides);
-            result_data[result_linear] = b_data[b_linear];
-        }
-        // else: mixed case stays 0.0
+        // else: mixed case stays T::zero()
     }
 
     let result = TensorDynLen::from_dense(setup.result_indices, result_data)?;

--- a/crates/tensor4all-core/src/defaults/direct_sum/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use num_complex::Complex64;
 
 #[test]
 fn test_direct_sum_simple() {
@@ -39,7 +40,7 @@ fn test_direct_sum_simple() {
     assert_eq!(new_indices[0].dim(), 7);
 
     // Check column-major logical values.
-    let data = result.to_vec_f64().unwrap();
+    let data = result.to_vec::<f64>().unwrap();
     assert_eq!(
         data,
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0,]
@@ -120,7 +121,7 @@ fn test_direct_sum_c64() {
     assert_eq!(new_indices[0].dim(), 5);
 
     // Verify the data is complex
-    let data = result.to_vec_c64().unwrap();
+    let data = result.to_vec::<Complex64>().unwrap();
     assert_eq!(data.len(), 10);
     // First block comes from A (j indices 0..2)
     assert_eq!(data[0], Complex64::new(1.0, 0.5));

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -36,8 +36,8 @@ pub use contract::{
 };
 pub use index::{DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet};
 pub use tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor,
-    unfold_split, TensorAccess, TensorDynLen,
+    compute_permutation_from_indices, diag_tensor_dyn_len, is_diag_tensor, unfold_split,
+    RandomScalar, TensorAccess, TensorDynLen,
 };
 
 // Re-export linear algebra functions and types
@@ -45,7 +45,5 @@ pub use direct_sum::direct_sum;
 pub use factorize::{
     factorize, Canonical, FactorizeAlg, FactorizeError, FactorizeOptions, FactorizeResult,
 };
-pub use qr::{default_qr_rtol, qr, qr_c64, qr_with, set_default_qr_rtol, QrError, QrOptions};
-pub use svd::{
-    default_svd_rtol, set_default_svd_rtol, svd, svd_c64, svd_with, SvdError, SvdOptions,
-};
+pub use qr::{default_qr_rtol, qr, qr_with, set_default_qr_rtol, QrError, QrOptions};
+pub use svd::{default_svd_rtol, set_default_svd_rtol, svd, svd_with, SvdError, SvdOptions};

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -6,7 +6,7 @@ use crate::defaults::DynIndex;
 use crate::global_default::GlobalDefault;
 use crate::truncation::TruncationParams;
 use crate::{unfold_split, TensorDynLen};
-use num_complex::{Complex64, ComplexFloat};
+use num_complex::ComplexFloat;
 use tensor4all_tensorbackend::{
     native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
     qr_native_tensor, reshape_col_major_native_tensor,
@@ -256,24 +256,6 @@ pub fn qr_with<T>(
     let r = TensorDynLen::from_native(r_indices, r_reshaped).map_err(QrError::ComputationError)?;
 
     Ok((q, r))
-}
-
-/// Compute QR decomposition of a complex tensor with arbitrary rank, returning (Q, R).
-///
-/// This is a convenience wrapper around the generic `qr` function for `Complex64` tensors.
-///
-/// For the mathematical convention:
-/// \[ A = Q * R \]
-/// where Q is unitary and R is upper triangular.
-///
-/// The input tensor can have any rank >= 2, and indices are split into left and right groups.
-/// The tensor is unfolded into a matrix by grouping left indices as rows and right indices as columns.
-#[inline]
-pub fn qr_c64(
-    t: &TensorDynLen,
-    left_inds: &[DynIndex],
-) -> Result<(TensorDynLen, TensorDynLen), QrError> {
-    qr::<Complex64>(t, left_inds)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::index::DefaultIndex as Index;
+use num_complex::Complex64;
 use tensor4all_tensorbackend::native_tensor_primal_to_dense_f64_col_major;
 
 #[test]

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -7,7 +7,6 @@ use crate::global_default::GlobalDefault;
 use crate::index_like::IndexLike;
 use crate::truncation::{HasTruncationParams, TruncationParams};
 use crate::{unfold_split, TensorDynLen};
-use num_complex::Complex64;
 use tensor4all_tensorbackend::{
     native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
     reshape_col_major_native_tensor, svd_native_tensor,
@@ -213,15 +212,6 @@ pub fn svd_with<T>(
     let v = vh.conj().permute(&perm);
 
     Ok((u, s, v))
-}
-
-/// Compute SVD decomposition of a complex tensor with arbitrary rank, returning (U, S, V).
-#[inline]
-pub fn svd_c64(
-    t: &TensorDynLen,
-    left_inds: &[DynIndex],
-) -> Result<(TensorDynLen, TensorDynLen, TensorDynLen), SvdError> {
-    svd::<Complex64>(t, left_inds)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::index::DefaultIndex as Index;
+use num_complex::Complex64;
 use tenferro::Tensor as NativeTensor;
 
 #[test]

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -5,6 +5,7 @@ use crate::storage::{AnyScalar, Storage};
 use anyhow::Result;
 use num_complex::Complex64;
 use num_traits::Zero;
+use rand::Rng;
 use rand_distr::{Distribution, StandardNormal};
 use std::collections::HashSet;
 use std::ops::{Mul, Neg, Sub};
@@ -13,11 +14,31 @@ use tenferro::{AdMode, ScalarType as NativeScalarType, Tensor as NativeTensor};
 use tensor4all_tensorbackend::{
     axpby_native_tensor, conj_native_tensor, contract_native_tensor,
     dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
-    native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
-    native_tensor_primal_to_storage, outer_product_native_tensor, permute_native_tensor,
-    reshape_col_major_native_tensor, scale_native_tensor, storage_to_native_tensor,
-    sum_native_tensor, TensorElement,
+    native_tensor_primal_to_dense_col_major, native_tensor_primal_to_storage,
+    outer_product_native_tensor, permute_native_tensor, reshape_col_major_native_tensor,
+    scale_native_tensor, storage_to_native_tensor, sum_native_tensor, TensorElement,
 };
+
+/// Trait for scalar types that can generate random values from a standard
+/// normal distribution.
+///
+/// This enables the generic [`TensorDynLen::random`] constructor.
+pub trait RandomScalar: TensorElement {
+    /// Generate a random value from the standard normal distribution.
+    fn random_value<R: Rng>(rng: &mut R) -> Self;
+}
+
+impl RandomScalar for f64 {
+    fn random_value<R: Rng>(rng: &mut R) -> Self {
+        StandardNormal.sample(rng)
+    }
+}
+
+impl RandomScalar for Complex64 {
+    fn random_value<R: Rng>(rng: &mut R) -> Self {
+        Complex64::new(StandardNormal.sample(rng), StandardNormal.sample(rng))
+    }
+}
 
 /// Compute the permutation array from original indices to new indices.
 ///
@@ -260,11 +281,6 @@ impl TensorDynLen {
     /// Sum all elements, returning `AnyScalar`.
     pub fn sum(&self) -> AnyScalar {
         sum_native_tensor(&self.native).expect("native sum failed")
-    }
-
-    /// Sum all elements as f64.
-    pub fn sum_f64(&self) -> f64 {
-        self.sum().real()
     }
 
     /// Extract the scalar value from a 0-dimensional tensor (or 1-element tensor).
@@ -582,7 +598,14 @@ impl TensorDynLen {
 // ============================================================================
 
 impl TensorDynLen {
-    /// Create a random f64 tensor with values from standard normal distribution.
+    /// Create a random tensor with values from standard normal distribution (generic over scalar type).
+    ///
+    /// For `f64`, each element is drawn from the standard normal distribution.
+    /// For `Complex64`, both real and imaginary parts are drawn independently.
+    ///
+    /// # Type Parameters
+    /// * `T` - The scalar element type (must implement [`RandomScalar`])
+    /// * `R` - The random number generator type
     ///
     /// # Arguments
     /// * `rng` - Random number generator
@@ -598,44 +621,14 @@ impl TensorDynLen {
     /// let mut rng = ChaCha8Rng::seed_from_u64(42);
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
-    /// let tensor: TensorDynLen = TensorDynLen::random_f64(&mut rng, vec![i, j]);
+    /// let tensor: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i, j]);
     /// assert_eq!(tensor.dims(), vec![2, 3]);
     /// ```
-    pub fn random_f64<R: rand::Rng>(rng: &mut R, indices: Vec<DynIndex>) -> Self {
+    pub fn random<T: RandomScalar, R: Rng>(rng: &mut R, indices: Vec<DynIndex>) -> Self {
         let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
         let size: usize = dims.iter().product();
-        let data: Vec<f64> = (0..size).map(|_| StandardNormal.sample(rng)).collect();
-        Self::from_dense(indices, data).expect("TensorDynLen::random_f64 failed")
-    }
-
-    /// Create a random Complex64 tensor with values from standard normal distribution.
-    ///
-    /// Both real and imaginary parts are drawn from standard normal distribution.
-    ///
-    /// # Arguments
-    /// * `rng` - Random number generator
-    /// * `indices` - The indices for the tensor
-    ///
-    /// # Example
-    /// ```
-    /// use tensor4all_core::TensorDynLen;
-    /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
-    /// use rand::SeedableRng;
-    /// use rand_chacha::ChaCha8Rng;
-    ///
-    /// let mut rng = ChaCha8Rng::seed_from_u64(42);
-    /// let i = Index::new_dyn(2);
-    /// let j = Index::new_dyn(3);
-    /// let tensor: TensorDynLen = TensorDynLen::random_c64(&mut rng, vec![i, j]);
-    /// assert_eq!(tensor.dims(), vec![2, 3]);
-    /// ```
-    pub fn random_c64<R: rand::Rng>(rng: &mut R, indices: Vec<DynIndex>) -> Self {
-        let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
-        let size: usize = dims.iter().product();
-        let data: Vec<Complex64> = (0..size)
-            .map(|_| Complex64::new(StandardNormal.sample(rng), StandardNormal.sample(rng)))
-            .collect();
-        Self::from_dense(indices, data).expect("TensorDynLen::random_c64 failed")
+        let data: Vec<T> = (0..size).map(|_| T::random_value(rng)).collect();
+        Self::from_dense(indices, data).expect("TensorDynLen::random failed")
     }
 }
 
@@ -1229,12 +1222,6 @@ pub fn diag_tensor_dyn_len(indices: Vec<DynIndex>, diag_data: Vec<f64>) -> Tenso
         .unwrap_or_else(|err| panic!("diag_tensor_dyn_len failed: {err}"))
 }
 
-/// Create a DiagTensor with dynamic rank from complex diagonal data.
-pub fn diag_tensor_dyn_len_c64(indices: Vec<DynIndex>, diag_data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_diag(indices, diag_data)
-        .unwrap_or_else(|err| panic!("diag_tensor_dyn_len_c64 failed: {err}"))
-}
-
 /// Unfold a tensor into a matrix by splitting indices into left and right groups.
 ///
 /// This function validates the split, permutes the tensor so that left indices
@@ -1657,13 +1644,16 @@ impl TensorDynLen {
 // ============================================================================
 
 impl TensorDynLen {
-    /// Extract tensor data as a column-major `Vec<f64>`.
+    /// Extract tensor data as a column-major `Vec<T>`.
+    ///
+    /// # Type Parameters
+    /// * `T` - The scalar element type (`f64` or `Complex64`).
     ///
     /// # Returns
     /// A vector of the tensor data in column-major order.
     ///
     /// # Errors
-    /// Returns an error if the storage is not DenseF64.
+    /// Returns an error if the tensor's scalar type does not match `T`.
     ///
     /// # Example
     /// ```
@@ -1672,44 +1662,27 @@ impl TensorDynLen {
     ///
     /// let i = Index::new_dyn(2);
     /// let tensor = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
-    /// let data = tensor.as_slice_f64().unwrap();
+    /// let data = tensor.to_vec::<f64>().unwrap();
     /// assert_eq!(data, &[1.0, 2.0]);
     /// ```
+    pub fn to_vec<T: TensorElement>(&self) -> Result<Vec<T>> {
+        native_tensor_primal_to_dense_col_major(&self.native)
+    }
+
+    /// Extract tensor data as a column-major `Vec<f64>`.
+    ///
+    /// Prefer the generic [`to_vec::<f64>()`](Self::to_vec) method.
+    /// This wrapper is kept for C API compatibility.
     pub fn as_slice_f64(&self) -> Result<Vec<f64>> {
-        self.to_vec_f64()
+        self.to_vec::<f64>()
     }
 
     /// Extract tensor data as a column-major `Vec<Complex64>`.
     ///
-    /// # Returns
-    /// A vector of the tensor data in column-major order.
-    ///
-    /// # Errors
-    /// Returns an error if the storage is not DenseC64.
+    /// Prefer the generic [`to_vec::<Complex64>()`](Self::to_vec) method.
+    /// This wrapper is kept for C API compatibility.
     pub fn as_slice_c64(&self) -> Result<Vec<Complex64>> {
-        self.to_vec_c64()
-    }
-
-    /// Convert tensor data to a column-major `Vec<f64>`.
-    ///
-    /// # Returns
-    /// A vector containing a copy of the tensor data.
-    ///
-    /// # Errors
-    /// Returns an error if the storage is not DenseF64.
-    pub fn to_vec_f64(&self) -> Result<Vec<f64>> {
-        native_tensor_primal_to_dense_f64_col_major(&self.native)
-    }
-
-    /// Convert tensor data to a column-major `Vec<Complex64>`.
-    ///
-    /// # Returns
-    /// A vector containing a copy of the tensor data.
-    ///
-    /// # Errors
-    /// Returns an error if the storage is not DenseC64.
-    pub fn to_vec_c64(&self) -> Result<Vec<Complex64>> {
-        native_tensor_primal_to_dense_c64_col_major(&self.native)
+        self.to_vec::<Complex64>()
     }
 
     /// Check if the tensor has f64 storage.

--- a/crates/tensor4all-core/src/krylov/tests/mod.rs
+++ b/crates/tensor4all-core/src/krylov/tests/mod.rs
@@ -7,7 +7,7 @@ fn make_vector_with_index(data: Vec<f64>, idx: &DynIndex) -> TensorDynLen {
 }
 
 fn scale_vector_f64(x: &TensorDynLen, diag: &[f64]) -> Result<TensorDynLen> {
-    let x_data = x.to_vec_f64()?;
+    let x_data = x.to_vec::<f64>()?;
     let result_data: Vec<f64> = x_data
         .iter()
         .zip(diag.iter())
@@ -17,7 +17,7 @@ fn scale_vector_f64(x: &TensorDynLen, diag: &[f64]) -> Result<TensorDynLen> {
 }
 
 fn apply_matrix2_f64(x: &TensorDynLen, a_data: &[f64; 4]) -> Result<TensorDynLen> {
-    let x_data = x.to_vec_f64()?;
+    let x_data = x.to_vec::<f64>()?;
     let result_data = vec![
         a_data[0] * x_data[0] + a_data[1] * x_data[1],
         a_data[2] * x_data[0] + a_data[3] * x_data[1],
@@ -316,7 +316,7 @@ fn test_gmres_diagonal_c64() {
     let expected = make_vector_c64_with_index(x_true.to_vec(), &idx);
 
     let apply_a = move |x: &TensorDynLen| -> Result<TensorDynLen> {
-        let x_data = x.to_vec_c64()?;
+        let x_data = x.to_vec::<Complex64>()?;
         let result_data: Vec<Complex64> = x_data
             .iter()
             .zip(diag.iter())
@@ -835,7 +835,7 @@ fn test_restart_gmres_stagnation_detection() {
     // Truncation that rounds to 1 decimal place - the exact solution [1/3, 1/7, 1/11]
     // gets rounded to [0.3, 0.1, 0.1], preventing convergence below the rounding error.
     let truncate = |x: &mut TensorDynLen| -> Result<()> {
-        let data = x.to_vec_f64()?;
+        let data = x.to_vec::<f64>()?;
         let new_data: Vec<f64> = data.iter().map(|&v| (v * 10.0).round() / 10.0).collect();
         *x = TensorDynLen::from_dense(x.indices.clone(), new_data).unwrap();
         Ok(())
@@ -948,7 +948,7 @@ fn test_restart_gmres_stagnation_verbose() {
     let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
 
     let truncate = |x: &mut TensorDynLen| -> Result<()> {
-        let data = x.to_vec_f64()?;
+        let data = x.to_vec::<f64>()?;
         let new_data: Vec<f64> = data.iter().map(|&v| (v * 100.0).round() / 100.0).collect();
         *x = TensorDynLen::from_dense(x.indices.clone(), new_data).unwrap();
         Ok(())

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -64,7 +64,8 @@ pub mod any_scalar {
 pub mod storage {
     //! Re-export of snapshot storage utilities.
     pub use tensor4all_tensorbackend::{
-        make_mut_storage, mindim, AnyScalar, Storage, StructuredStorage, SumFromStorage,
+        make_mut_storage, mindim, AnyScalar, Storage, StorageScalar, StructuredStorage,
+        SumFromStorage,
     };
 }
 pub mod tensor_index;
@@ -83,8 +84,8 @@ pub use defaults::tensordynlen as tensor;
 
 pub use any_scalar::AnyScalar;
 pub use defaults::tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor,
-    unfold_split, TensorAccess, TensorDynLen,
+    compute_permutation_from_indices, diag_tensor_dyn_len, is_diag_tensor, unfold_split,
+    RandomScalar, TensorAccess, TensorDynLen,
 };
 pub use storage::{make_mut_storage, mindim, Storage, StructuredStorage, SumFromStorage};
 pub use tensor4all_tensorbackend::TensorElement;
@@ -119,11 +120,9 @@ pub mod svd {
 // Re-export linear algebra items for top-level access
 pub use defaults::direct_sum::direct_sum;
 pub use defaults::factorize::factorize;
-pub use defaults::qr::{
-    default_qr_rtol, qr, qr_c64, qr_with, set_default_qr_rtol, QrError, QrOptions,
-};
+pub use defaults::qr::{default_qr_rtol, qr, qr_with, set_default_qr_rtol, QrError, QrOptions};
 pub use defaults::svd::{
-    default_svd_rtol, set_default_svd_rtol, svd, svd_c64, svd_with, SvdError, SvdOptions,
+    default_svd_rtol, set_default_svd_rtol, svd, svd_with, SvdError, SvdOptions,
 };
 
 // Global default and truncation utilities

--- a/crates/tensor4all-core/tests/bug_qr_after_permute.rs
+++ b/crates/tensor4all-core/tests/bug_qr_after_permute.rs
@@ -7,7 +7,7 @@
 //! SVD gives ~1e-14 on the same data.
 
 use num_complex::Complex64;
-use tensor4all_core::{factorize, svd_c64, DynIndex, FactorizeOptions, TensorDynLen};
+use tensor4all_core::{factorize, svd, DynIndex, FactorizeOptions, TensorDynLen};
 
 /// Create a [5,2,2,5] tensor with data that triggers the QR bug.
 fn make_buggy_tensor() -> TensorDynLen {
@@ -135,7 +135,7 @@ fn reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex], opts: &Factori
 }
 
 fn svd_reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
-    let (u, s, v) = svd_c64(t, left_inds).unwrap();
+    let (u, s, v) = svd::<Complex64>(t, left_inds).unwrap();
     let mut perm = vec![v.indices.len() - 1];
     perm.extend(0..v.indices.len() - 1);
     let vh = v.conj().permute(&perm);
@@ -160,9 +160,11 @@ fn test_qr_reconstruction_regression() {
 
     let matrix_i = DynIndex::new_dyn_with_tag(10, "row").unwrap();
     let matrix_j = DynIndex::new_dyn_with_tag(10, "col").unwrap();
-    let matrix =
-        TensorDynLen::from_dense(vec![matrix_i.clone(), matrix_j], t.to_vec_c64().unwrap())
-            .unwrap();
+    let matrix = TensorDynLen::from_dense(
+        vec![matrix_i.clone(), matrix_j],
+        t.to_vec::<Complex64>().unwrap(),
+    )
+    .unwrap();
 
     let matrix_svd_err = svd_reconstruction_error(&matrix, &[matrix_i]);
     let direct_svd_err = svd_reconstruction_error(&t, &left_inds);

--- a/crates/tensor4all-core/tests/linalg_qr.rs
+++ b/crates/tensor4all-core/tests/linalg_qr.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::{qr, qr_c64, DynIndex};
+use tensor4all_core::{qr, DynIndex};
 use tensor4all_core::{TensorDynLen, TensorLike};
 
 fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
@@ -204,7 +204,8 @@ fn test_qr_complex_reconstruction() {
     ];
     let tensor = dense_c64(vec![i_idx.clone(), j_idx.clone()], data.clone());
 
-    let (q, r) = qr_c64(&tensor, std::slice::from_ref(&i_idx)).expect("Complex QR should succeed");
+    let (q, r) =
+        qr::<Complex64>(&tensor, std::slice::from_ref(&i_idx)).expect("Complex QR should succeed");
 
     let reconstructed = q.contract(&r);
     assert!(
@@ -226,7 +227,7 @@ fn qr_reconstruction_error_f64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 
 }
 
 fn qr_reconstruction_error_c64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
-    let (q, r) = qr_c64(t, left_inds).expect("QR should succeed");
+    let (q, r) = qr::<Complex64>(t, left_inds).expect("QR should succeed");
     let recon = q.contract(&r);
     let neg = recon
         .scale(tensor4all_core::AnyScalar::new_real(-1.0))

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::{default_svd_rtol, set_default_svd_rtol, svd, svd_c64, svd_with, SvdOptions};
+use tensor4all_core::{default_svd_rtol, set_default_svd_rtol, svd, svd_with, SvdOptions};
 use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
 
 fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
@@ -240,8 +240,8 @@ fn test_svd_complex_reconstruction() {
     ];
     let tensor = dense_c64(vec![i_idx.clone(), j_idx.clone()], data.clone());
 
-    let (u, s, v) =
-        svd_c64(&tensor, std::slice::from_ref(&i_idx)).expect("Complex SVD should succeed");
+    let (u, s, v) = svd::<Complex64>(&tensor, std::slice::from_ref(&i_idx))
+        .expect("Complex SVD should succeed");
 
     let reconstructed = reconstruct_from_svd(&u, &s, &v);
     assert!(
@@ -266,8 +266,8 @@ fn test_svd_complex_rectangular_reconstruction() {
     ];
     let tensor = dense_c64(vec![i.clone(), j.clone()], data);
 
-    let (u, s, v) =
-        svd_c64(&tensor, std::slice::from_ref(&i)).expect("Complex rectangular SVD should succeed");
+    let (u, s, v) = svd::<Complex64>(&tensor, std::slice::from_ref(&i))
+        .expect("Complex rectangular SVD should succeed");
     let reconstructed = reconstruct_from_svd(&u, &s, &v);
 
     assert!(

--- a/crates/tensor4all-core/tests/readme_contraction_example.rs
+++ b/crates/tensor4all-core/tests/readme_contraction_example.rs
@@ -58,9 +58,9 @@ fn core_readme_contraction_flow_runs_against_public_api() {
     let l = Index::<DynId>::new_dyn_with_tag(5, "l").unwrap();
 
     let mut rng = rng();
-    let a = TensorDynLen::random_f64(&mut rng, vec![i.clone(), j.clone()]);
-    let b = TensorDynLen::random_f64(&mut rng, vec![j.clone(), k.clone()]);
-    let c = TensorDynLen::random_f64(&mut rng, vec![k.clone(), l.clone()]);
+    let a = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]);
+    let b = TensorDynLen::random::<f64, _>(&mut rng, vec![j.clone(), k.clone()]);
+    let c = TensorDynLen::random::<f64, _>(&mut rng, vec![k.clone(), l.clone()]);
 
     let result_all = contract_multi(&[&a, &b, &c], AllowedPairs::All).unwrap();
     let pairs = [(0, 1), (1, 2)];

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -6,12 +6,12 @@ use tensor4all_core::{AnyScalar, Storage, TensorDynLen, TensorElement};
 
 /// Helper to create DenseF64 storage with shape information
 fn make_dense_f64(data: Vec<f64>, dims: &[usize]) -> Storage {
-    Storage::from_dense_f64_col_major(data, dims).unwrap()
+    Storage::from_dense_col_major(data, dims).unwrap()
 }
 
 /// Helper to create DenseC64 storage with shape information
 fn make_dense_c64(data: Vec<Complex64>, dims: &[usize]) -> Storage {
-    Storage::from_dense_c64_col_major(data, dims).unwrap()
+    Storage::from_dense_col_major(data, dims).unwrap()
 }
 
 fn make_tensor_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
@@ -25,11 +25,11 @@ fn make_tensor_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen
 #[test]
 fn test_storage_dense_f64() {
     // Create a zero-initialized tensor with 10 elements
-    let storage = Storage::new_dense_f64(10);
+    let storage = Storage::new_dense::<f64>(10);
     assert_eq!(storage.len(), 10);
     assert!(storage.is_dense());
     assert!(storage.is_f64());
-    assert_eq!(storage.sum_f64(), 0.0);
+    assert_eq!(storage.sum::<f64>(), 0.0);
     assert_eq!(
         storage.to_dense_f64_col_major_vec(&[10]).unwrap(),
         vec![0.0; 10]
@@ -39,11 +39,11 @@ fn test_storage_dense_f64() {
 #[test]
 fn test_storage_dense_c64() {
     // Create a zero-initialized tensor with 10 elements
-    let storage = Storage::new_dense_c64(10);
+    let storage = Storage::new_dense::<Complex64>(10);
     assert_eq!(storage.len(), 10);
     assert!(storage.is_dense());
     assert!(storage.is_c64());
-    assert_eq!(storage.sum_c64(), Complex64::new(0.0, 0.0));
+    assert_eq!(storage.sum::<Complex64>(), Complex64::new(0.0, 0.0));
     assert_eq!(
         storage.to_dense_c64_col_major_vec(&[10]).unwrap(),
         vec![Complex64::new(0.0, 0.0); 10]
@@ -52,7 +52,7 @@ fn test_storage_dense_c64() {
 
 #[test]
 fn test_storage_factory_f64() {
-    let storage = Storage::new_dense_f64(7);
+    let storage = Storage::new_dense::<f64>(7);
     assert!(storage.is_dense());
     assert!(storage.is_f64());
     assert_eq!(storage.len(), 7);
@@ -64,7 +64,7 @@ fn test_storage_factory_f64() {
 
 #[test]
 fn test_storage_factory_c64() {
-    let storage = Storage::new_dense_c64(9);
+    let storage = Storage::new_dense::<Complex64>(9);
     assert!(storage.is_dense());
     assert!(storage.is_c64());
     assert_eq!(storage.len(), 9);
@@ -94,7 +94,7 @@ fn test_cow_storage() {
 #[test]
 fn test_tensor_dyn_len_creation() {
     let indices = vec![Index::new_dyn(2), Index::new_dyn(3)];
-    let storage = Arc::new(Storage::from_dense_f64_col_major(vec![0.0; 6], &[2, 3]).unwrap());
+    let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap());
 
     let tensor: TensorDynLen = TensorDynLen::new(indices, storage);
     assert_eq!(tensor.indices.len(), 2);
@@ -111,10 +111,16 @@ fn test_tensor_shared_storage() {
     let tensor2 = make_tensor_f64(indices, vec![1.0, 2.0]);
 
     // Canonical payload is native; storage snapshots need not share allocation.
-    assert_eq!(tensor1.to_vec_f64().unwrap(), tensor2.to_vec_f64().unwrap());
+    assert_eq!(
+        tensor1.to_vec::<f64>().unwrap(),
+        tensor2.to_vec::<f64>().unwrap()
+    );
 
     let cloned = tensor1.clone();
-    assert_eq!(tensor1.to_vec_f64().unwrap(), cloned.to_vec_f64().unwrap());
+    assert_eq!(
+        tensor1.to_vec::<f64>().unwrap(),
+        cloned.to_vec::<f64>().unwrap()
+    );
 
     // Check that both tensors have the expected storage
     assert!(tensor1.storage().is_dense());
@@ -125,7 +131,7 @@ fn test_tensor_shared_storage() {
 fn test_tensor_sum_f64_no_match() {
     let indices = vec![Index::new_dyn(3)];
     let t = make_tensor_f64(indices, vec![1.0, 2.0, 3.0]);
-    let sum_f64 = t.sum_f64();
+    let sum_f64 = t.sum().real();
     assert_eq!(sum_f64, 6.0);
 
     let sum_any: AnyScalar = t.sum();
@@ -154,7 +160,7 @@ fn test_tensor_duplicate_indices_new() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone(), i.clone()]; // duplicate i
-    let storage = Arc::new(Storage::from_dense_f64_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
+    let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
 
     let _tensor: TensorDynLen = TensorDynLen::new(indices, storage);
 }
@@ -165,7 +171,7 @@ fn test_tensor_duplicate_indices_from_indices() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone(), i.clone()]; // duplicate i
-    let storage = Arc::new(Storage::from_dense_f64_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
+    let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
 
     let _tensor: TensorDynLen = TensorDynLen::from_indices(indices, storage);
 }
@@ -193,7 +199,10 @@ fn test_replaceind_basic() {
     assert_eq!(replaced.indices[1].id, j.id);
     // Check that dimensions are unchanged
     assert_eq!(replaced.dims(), vec![2, 3]);
-    assert_eq!(tensor.to_vec_f64().unwrap(), replaced.to_vec_f64().unwrap());
+    assert_eq!(
+        tensor.to_vec::<f64>().unwrap(),
+        replaced.to_vec::<f64>().unwrap()
+    );
 }
 
 #[test]
@@ -338,7 +347,7 @@ fn test_replaceinds_does_not_reorder_data() {
     // CRITICAL: replaceinds does NOT reorder data
     // The storage data should remain unchanged
     assert_eq!(
-        replaced.to_vec_f64().unwrap(),
+        replaced.to_vec::<f64>().unwrap(),
         data,
         "replaceinds should not reorder data"
     );
@@ -376,7 +385,7 @@ fn test_replaceinds_with_different_order_does_not_reorder_data() {
     // CRITICAL: replaceinds does NOT reorder data
     // The storage data remains unchanged
     assert_eq!(
-        replaced.to_vec_f64().unwrap(),
+        replaced.to_vec::<f64>().unwrap(),
         data,
         "replaceinds should not reorder data"
     );
@@ -410,7 +419,7 @@ fn test_permuteinds_reorders_data() {
     // Permuted logical values: [[1, 2], [3, 4], [5, 6]] with shape [3, 2]
     // Column-major linearized data: [1, 3, 5, 2, 4, 6]
     assert_eq!(
-        permuted.to_vec_f64().unwrap(),
+        permuted.to_vec::<f64>().unwrap(),
         vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0],
         "permuteinds should reorder data to match new index order"
     );
@@ -439,13 +448,13 @@ fn test_replaceinds_vs_permuteinds_comparison() {
     // In practice, you should use permuteinds when you need to change index order
     let replaced = tensor.replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()]);
     assert_eq!(replaced.dims(), vec![2, 3]);
-    let replaced_data = replaced.to_vec_f64().unwrap();
+    let replaced_data = replaced.to_vec::<f64>().unwrap();
 
     // Method 2: permuteinds (CORRECT when order changes)
     // This changes both index order AND data order
     let permuted = tensor.permute_indices(&[j.clone(), i.clone()]);
     assert_eq!(permuted.dims(), vec![3, 2]);
-    let permuted_data = permuted.to_vec_f64().unwrap();
+    let permuted_data = permuted.to_vec::<f64>().unwrap();
 
     // The data should be DIFFERENT because permuteinds reorders data
     // replaced: [1, 2, 3, 4, 5, 6] (unchanged, same shape [2, 3])
@@ -499,7 +508,7 @@ fn test_storage_conj_c64() {
 #[test]
 fn test_storage_conj_diag_c64() {
     let data = vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -2.0)];
-    let storage = Storage::from_diag_c64_col_major(data, 2).unwrap();
+    let storage = Storage::from_diag_col_major(data, 2).unwrap();
     let conj_storage = storage.conj();
 
     assert!(conj_storage.is_diag());
@@ -527,7 +536,7 @@ fn test_tensor_conj_f64() {
     // Dims should be the same
     assert_eq!(conj_tensor.dims(), vec![2]);
     // Data should be the same (real conj is identity)
-    assert_eq!(conj_tensor.to_vec_f64().unwrap(), data);
+    assert_eq!(conj_tensor.to_vec::<f64>().unwrap(), data);
 }
 
 #[test]
@@ -560,7 +569,7 @@ fn test_tensor_conj_c64() {
         Complex64::new(-1.0, -1.0),
         Complex64::new(5.0, -5.0),
     ];
-    assert_eq!(conj_tensor.to_vec_c64().unwrap(), expected);
+    assert_eq!(conj_tensor.to_vec::<Complex64>().unwrap(), expected);
 }
 
 // ============================================================================
@@ -577,8 +586,8 @@ fn test_from_dense_f64() {
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(tensor.is_f64());
     assert!(!tensor.is_complex());
-    assert_eq!(tensor.as_slice_f64().unwrap(), &data[..]);
-    assert_eq!(tensor.to_vec_f64().unwrap(), data);
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), &data[..]);
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), data);
 }
 
 #[test]
@@ -593,8 +602,8 @@ fn test_from_dense_c64() {
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(!tensor.is_f64());
     assert!(tensor.is_complex());
-    assert_eq!(tensor.as_slice_c64().unwrap(), &data[..]);
-    assert_eq!(tensor.to_vec_c64().unwrap(), data);
+    assert_eq!(tensor.to_vec::<Complex64>().unwrap(), &data[..]);
+    assert_eq!(tensor.to_vec::<Complex64>().unwrap(), data);
 }
 
 fn assert_dense_constructor_dims<T>(data: Vec<T>)
@@ -638,7 +647,7 @@ fn test_from_dense_generic_preserves_column_major_input_order() {
 
     let permuted = tensor.permute_indices(&[j, i]);
     assert_eq!(
-        permuted.to_vec_f64().unwrap(),
+        permuted.to_vec::<f64>().unwrap(),
         vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
     );
 }
@@ -718,7 +727,7 @@ fn test_scalar_f64() {
     let scalar = TensorDynLen::scalar(42.0).unwrap();
     assert_eq!(scalar.dims(), Vec::<usize>::new());
     assert!(scalar.is_f64());
-    assert_eq!(scalar.as_slice_f64().unwrap(), &[42.0]);
+    assert_eq!(scalar.to_vec::<f64>().unwrap(), &[42.0]);
 }
 
 #[test]
@@ -727,7 +736,7 @@ fn test_scalar_c64() {
     let scalar = TensorDynLen::scalar(z).unwrap();
     assert_eq!(scalar.dims(), Vec::<usize>::new());
     assert!(scalar.is_complex());
-    assert_eq!(scalar.as_slice_c64().unwrap(), &[z]);
+    assert_eq!(scalar.to_vec::<Complex64>().unwrap(), &[z]);
 }
 
 #[test]
@@ -738,7 +747,7 @@ fn test_zeros_f64() {
 
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(tensor.is_f64());
-    let data = tensor.as_slice_f64().unwrap();
+    let data = tensor.to_vec::<f64>().unwrap();
     assert!(data.iter().all(|&x| x == 0.0));
 }
 
@@ -750,7 +759,7 @@ fn test_zeros_c64() {
 
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(tensor.is_complex());
-    let data = tensor.as_slice_c64().unwrap();
+    let data = tensor.to_vec::<Complex64>().unwrap();
     assert!(data.iter().all(|&x| x == Complex64::new(0.0, 0.0)));
 }
 
@@ -759,8 +768,8 @@ fn test_as_slice_error_on_wrong_type() {
     let i = Index::new_dyn(2);
     // Create f64 tensor but try to get c64 slice
     let tensor_f64 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    assert!(tensor_f64.as_slice_c64().is_err());
-    assert!(tensor_f64.to_vec_c64().is_err());
+    assert!(tensor_f64.to_vec::<Complex64>().is_err());
+    assert!(tensor_f64.to_vec::<Complex64>().is_err());
 
     // Create c64 tensor but try to get f64 slice
     let tensor_c64 = TensorDynLen::from_dense(
@@ -768,6 +777,6 @@ fn test_as_slice_error_on_wrong_type() {
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
     )
     .unwrap();
-    assert!(tensor_c64.as_slice_f64().is_err());
-    assert!(tensor_c64.to_vec_f64().is_err());
+    assert!(tensor_c64.to_vec::<f64>().is_err());
+    assert!(tensor_c64.to_vec::<f64>().is_err());
 }

--- a/crates/tensor4all-core/tests/tensor_comparison.rs
+++ b/crates/tensor4all-core/tests/tensor_comparison.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::{diag_tensor_dyn_len, diag_tensor_dyn_len_c64, TensorDynLen, TensorLike};
+use tensor4all_core::{diag_tensor_dyn_len, TensorDynLen, TensorLike};
 
 #[test]
 fn test_sub_identical_tensors_is_zero() {
@@ -24,7 +24,7 @@ fn test_sub_different_tensors() {
     let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
 
     let diff = &a - &b;
-    let data = diff.to_vec_f64().unwrap();
+    let data = diff.to_vec::<f64>().unwrap();
     assert!((data[0] - 2.0).abs() < 1e-14);
     assert!((data[1] - 3.0).abs() < 1e-14);
 }
@@ -55,7 +55,7 @@ fn test_neg() {
     let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0]).unwrap();
 
     let neg_a = -&a;
-    let data = neg_a.to_vec_f64().unwrap();
+    let data = neg_a.to_vec::<f64>().unwrap();
     assert!((data[0] - (-1.0)).abs() < 1e-14);
     assert!((data[1] - 2.0).abs() < 1e-14);
     assert!((data[2] - (-3.0)).abs() < 1e-14);
@@ -86,14 +86,15 @@ fn test_maxabs_diag_f64() {
 fn test_maxabs_diag_c64() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let d = diag_tensor_dyn_len_c64(
+    let d = TensorDynLen::from_diag(
         vec![i, j],
         vec![
             Complex64::new(3.0, 4.0),  // |z| = 5
             Complex64::new(-1.0, 1.0), // |z| = sqrt(2)
             Complex64::new(0.0, -2.0), // |z| = 2
         ],
-    );
+    )
+    .unwrap();
     assert!((d.maxabs() - 5.0).abs() < 1e-14);
 }
 
@@ -147,7 +148,7 @@ fn test_sub_operator_owned() {
 
     // owned - owned
     let diff = a.clone() - b.clone();
-    let data = diff.to_vec_f64().unwrap();
+    let data = diff.to_vec::<f64>().unwrap();
     assert!((data[0] - 4.0).abs() < 1e-14);
     assert!((data[1] - 7.0).abs() < 1e-14);
 

--- a/crates/tensor4all-core/tests/tensor_contract_multi_pair_equivalence.rs
+++ b/crates/tensor4all-core/tests/tensor_contract_multi_pair_equivalence.rs
@@ -167,7 +167,7 @@ fn test_zipup_zero_masked_root_multi_matches_sequential_binary_contract() {
     let permuted_leaf = leaf.permute_indices(&[s0.clone(), s1.clone(), l01.clone(), l12.clone()]);
     let expected_permuted = TensorDynLen::from_dense(
         vec![s0.clone(), s1.clone(), l01.clone(), l12.clone()],
-        permute_col_major(&leaf.to_vec_f64().unwrap(), &leaf.dims(), &[0, 2, 1, 3]),
+        permute_col_major(&leaf.to_vec::<f64>().unwrap(), &leaf.dims(), &[0, 2, 1, 3]),
     )
     .unwrap();
     assert!(

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -12,7 +12,7 @@ fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
 }
 
 fn assert_all_f64(tensor: &TensorDynLen, expected_len: usize, expected_value: f64) {
-    let data = tensor.to_vec_f64().unwrap();
+    let data = tensor.to_vec::<f64>().unwrap();
     assert_eq!(data.len(), expected_len);
     for value in data {
         assert_eq!(value, expected_value);
@@ -194,7 +194,7 @@ fn test_contract_mixed_f64_c64() {
     assert_eq!(result.indices[1].id, k.id);
 
     assert_eq!(
-        result.to_vec_c64().unwrap(),
+        result.to_vec::<Complex64>().unwrap(),
         vec![
             Complex64::new(6.0, 8.0),
             Complex64::new(6.0, 8.0),
@@ -238,7 +238,7 @@ fn test_contract_mixed_c64_f64() {
     assert_eq!(result.dims(), vec![2, 2]);
 
     assert_eq!(
-        result.to_vec_c64().unwrap(),
+        result.to_vec::<Complex64>().unwrap(),
         vec![
             Complex64::new(4.0, 6.0),
             Complex64::new(12.0, 14.0),
@@ -435,7 +435,7 @@ fn test_scalar_times_tensor() {
 
     let result = scalar.contract(&tensor);
     assert_eq!(result.dims(), vec![2, 3]);
-    assert_eq!(result.to_vec_f64().unwrap(), data);
+    assert_eq!(result.to_vec::<f64>().unwrap(), data);
 }
 
 #[test]
@@ -448,7 +448,7 @@ fn test_tensor_times_scalar() {
 
     let result = tensor.contract(&scalar);
     assert_eq!(result.dims(), vec![2]);
-    assert_eq!(result.to_vec_f64().unwrap(), data);
+    assert_eq!(result.to_vec::<f64>().unwrap(), data);
 }
 
 #[test]
@@ -458,7 +458,7 @@ fn test_scalar_times_scalar() {
 
     let result = s1.contract(&s2);
     assert_eq!(result.dims().len(), 0);
-    let val = result.to_vec_f64().unwrap();
+    let val = result.to_vec::<f64>().unwrap();
     assert_eq!(val.len(), 1);
     assert!((val[0] - 15.0).abs() < 1e-10);
 }
@@ -473,7 +473,7 @@ fn test_mul_operator_scalar_times_tensor() {
 
     let result = &scalar * &tensor;
     assert_eq!(result.dims(), vec![3]);
-    assert_eq!(result.to_vec_f64().unwrap(), data);
+    assert_eq!(result.to_vec::<f64>().unwrap(), data);
 }
 
 #[test]
@@ -490,7 +490,7 @@ fn test_foldl_sequential_contraction() {
 
     // a[i,j] * b[j,i] = sum_j(a[i,j]*b[j,i]) summed over both → scalar
     assert_eq!(acc.dims().len(), 0);
-    let val = acc.to_vec_f64().unwrap();
+    let val = acc.to_vec::<f64>().unwrap();
     // All elements are 1.0*2.0 = 2.0, summed over 2*3 = 6 elements → 12.0
     assert!((val[0] - 12.0).abs() < 1e-10);
 }

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -1,9 +1,7 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::TensorLike;
-use tensor4all_core::{
-    diag_tensor_dyn_len, diag_tensor_dyn_len_c64, is_diag_tensor, AnyScalar, TensorDynLen,
-};
+use tensor4all_core::{diag_tensor_dyn_len, is_diag_tensor, AnyScalar, TensorDynLen};
 
 #[test]
 fn test_diag_tensor_creation() {
@@ -138,7 +136,8 @@ fn test_diag_tensor_convert_to_dense() {
 
     let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data);
     let dense_tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], tensor.to_vec_f64().unwrap()).unwrap();
+        TensorDynLen::from_dense(vec![i.clone(), j.clone()], tensor.to_vec::<f64>().unwrap())
+            .unwrap();
     let expected = TensorDynLen::from_dense(
         vec![i, j],
         vec![
@@ -175,7 +174,7 @@ fn test_diag_tensor_complex() {
     let j = Index::new_dyn(2);
     let diag_data = vec![Complex64::new(1.0, 0.5), Complex64::new(2.0, 1.0)];
 
-    let tensor = diag_tensor_dyn_len_c64(vec![i.clone(), j.clone()], diag_data.clone());
+    let tensor = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![2, 2]);
     assert!(is_diag_tensor(&tensor));
 
@@ -194,8 +193,8 @@ fn test_diag_tensor_complex_axpby_preserves_diag_structure() {
     let diag_a = vec![Complex64::new(1.0, 0.5), Complex64::new(-2.0, 1.0)];
     let diag_b = vec![Complex64::new(0.5, -1.0), Complex64::new(3.0, 0.25)];
 
-    let tensor_a = diag_tensor_dyn_len_c64(vec![i.clone(), j.clone()], diag_a.clone());
-    let tensor_b = diag_tensor_dyn_len_c64(vec![i.clone(), j.clone()], diag_b.clone());
+    let tensor_a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_a.clone()).unwrap();
+    let tensor_b = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_b.clone()).unwrap();
 
     let a = AnyScalar::new_real(2.0);
     let b = AnyScalar::new_complex(-0.5, 1.0);
@@ -208,7 +207,7 @@ fn test_diag_tensor_complex_axpby_preserves_diag_structure() {
         .zip(diag_b.iter())
         .map(|(&x, &y)| Complex64::new(2.0, 0.0) * x + b_c * y)
         .collect();
-    let expected = diag_tensor_dyn_len_c64(vec![i, j], expected_diag);
+    let expected = TensorDynLen::from_diag(vec![i, j], expected_diag).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0));
 }
 

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -1,3 +1,4 @@
+use num_complex::Complex64;
 use tenferro::AdMode;
 use tensor4all_core::{
     factorize, forward_ad, is_diag_tensor, qr, svd, AnyScalar, Canonical, FactorizeOptions, Index,
@@ -14,9 +15,12 @@ fn assert_same_tensor_data(lhs: &TensorDynLen, rhs: &TensorDynLen) {
     assert_eq!(lhs.is_f64(), rhs.is_f64());
     assert_eq!(lhs.is_complex(), rhs.is_complex());
     if lhs.is_f64() {
-        assert_eq!(lhs.to_vec_f64().unwrap(), rhs.to_vec_f64().unwrap());
+        assert_eq!(lhs.to_vec::<f64>().unwrap(), rhs.to_vec::<f64>().unwrap());
     } else {
-        assert_eq!(lhs.to_vec_c64().unwrap(), rhs.to_vec_c64().unwrap());
+        assert_eq!(
+            lhs.to_vec::<Complex64>().unwrap(),
+            rhs.to_vec::<Complex64>().unwrap()
+        );
     }
 }
 
@@ -180,7 +184,7 @@ fn rank1_native_snapshots_stay_dense() {
 
     assert!(snapshot.is_dense());
     assert!(!snapshot.is_diag());
-    assert_eq!(scaled.to_vec_f64().unwrap(), vec![2.0, 4.0, 6.0]);
+    assert_eq!(scaled.to_vec::<f64>().unwrap(), vec![2.0, 4.0, 6.0]);
 }
 
 #[test]
@@ -188,14 +192,14 @@ fn plain_dense_storage_auto_seeds_native_payload() {
     let i = Index::new_dyn(2);
     let tensor = TensorDynLen::from_storage(
         vec![i],
-        Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2])
+        Storage::from_dense_col_major(vec![1.0, 2.0], &[2])
             .map(std::sync::Arc::new)
             .unwrap(),
     )
     .unwrap();
 
     assert_eq!(tensor.mode(), AdMode::Primal);
-    assert_eq!(tensor.to_vec_f64().unwrap(), vec![1.0, 2.0]);
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), vec![1.0, 2.0]);
 }
 
 #[test]
@@ -204,7 +208,7 @@ fn plain_diag_storage_auto_seeds_native_diag_payload() {
     let j = Index::new_dyn(3);
     let tensor = TensorDynLen::from_storage(
         vec![i, j],
-        Storage::from_diag_f64_col_major(vec![1.0, 2.0, 3.0], 2)
+        Storage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2)
             .map(std::sync::Arc::new)
             .unwrap(),
     )

--- a/crates/tensor4all-core/tests/tensor_permute.rs
+++ b/crates/tensor4all-core/tests/tensor_permute.rs
@@ -116,7 +116,7 @@ fn test_permute_dyn_f64_2d() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
     assert_eq!(
-        permuted.to_vec_f64().unwrap(),
+        permuted.to_vec::<f64>().unwrap(),
         permute_col_major(&data, &dims, &[1, 0])
     );
 }
@@ -143,7 +143,7 @@ fn test_permute_dyn_c64_2d() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
     assert_eq!(
-        permuted.to_vec_c64().unwrap(),
+        permuted.to_vec::<Complex64>().unwrap(),
         permute_col_major(&data, &dims, &[1, 0])
     );
 }
@@ -166,7 +166,7 @@ fn test_permute_dyn_f64_3d() {
     assert_eq!(permuted.indices[1].id, i.id);
     assert_eq!(permuted.indices[2].id, j.id);
     assert_eq!(
-        permuted.to_vec_f64().unwrap(),
+        permuted.to_vec::<f64>().unwrap(),
         permute_col_major(&data, &dims, &[2, 0, 1])
     );
 }
@@ -184,7 +184,7 @@ fn test_permute_identity() {
     assert_eq!(permuted.dims(), vec![2, 3]);
     assert_eq!(permuted.indices[0].id, i.id);
     assert_eq!(permuted.indices[1].id, j.id);
-    assert_eq!(permuted.to_vec_f64().unwrap(), data);
+    assert_eq!(permuted.to_vec::<f64>().unwrap(), data);
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn test_permute_indices_dyn_f64_2d() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
     assert_eq!(
-        permuted.to_vec_f64().unwrap(),
+        permuted.to_vec::<f64>().unwrap(),
         permute_col_major(&data, &dims, &[1, 0])
     );
 }
@@ -229,7 +229,7 @@ fn test_permute_indices_c64() {
     assert_eq!(permuted.indices[0].id, j.id);
     assert_eq!(permuted.indices[1].id, i.id);
     assert_eq!(
-        permuted.to_vec_c64().unwrap(),
+        permuted.to_vec::<Complex64>().unwrap(),
         permute_col_major(&data, &dims, &[1, 0])
     );
 }

--- a/crates/tensor4all-core/tests/tensor_tensor_like.rs
+++ b/crates/tensor4all-core/tests/tensor_tensor_like.rs
@@ -216,7 +216,7 @@ fn test_onehot_1d() {
     let i = Index::new_dyn(3);
     let t = TensorDynLen::onehot(&[(i.clone(), 0)]).unwrap();
     assert_eq!(t.dims(), vec![3]);
-    let data = t.to_vec_f64().unwrap();
+    let data = t.to_vec::<f64>().unwrap();
     assert_eq!(data, vec![1.0, 0.0, 0.0]);
 }
 
@@ -226,7 +226,7 @@ fn test_onehot_2d() {
     let j = Index::new_dyn(4);
     let t = TensorDynLen::onehot(&[(i.clone(), 1), (j.clone(), 2)]).unwrap();
     assert_eq!(t.dims(), vec![3, 4]);
-    let data = t.to_vec_f64().unwrap();
+    let data = t.to_vec::<f64>().unwrap();
     // Column-major: position (1,2) in 3×4 = 1 + 3*2 = 7
     let mut expected = vec![0.0; 12];
     expected[7] = 1.0;
@@ -239,7 +239,7 @@ fn test_onehot_boundary() {
     let j = Index::new_dyn(4);
     // Last position in the first dimension, nontrivial column in the second.
     let t = TensorDynLen::onehot(&[(i.clone(), 2), (j.clone(), 1)]).unwrap();
-    let data = t.to_vec_f64().unwrap();
+    let data = t.to_vec::<f64>().unwrap();
     // Column-major: position (2,1) in 3×4 = 2 + 3*1 = 5
     let mut expected = vec![0.0; 12];
     expected[5] = 1.0;
@@ -281,7 +281,7 @@ fn test_onehot_contraction() {
     // Contract: V(i) * A(i,j) = A[1,:]
     let result = <TensorDynLen as TensorLike>::contract(&[&v, &a], AllowedPairs::All).unwrap();
     assert_eq!(result.dims(), vec![4]);
-    let data = result.to_vec_f64().unwrap();
+    let data = result.to_vec::<f64>().unwrap();
     // Row i=1 of the column-major 3×4 matrix: [1, 4, 7, 10]
     assert_eq!(data, vec![1.0, 4.0, 7.0, 10.0]);
 }

--- a/crates/tensor4all-hdf5/src/itensor.rs
+++ b/crates/tensor4all-hdf5/src/itensor.rs
@@ -28,7 +28,9 @@ pub(crate) fn write_itensor(group: &Group, tensor: &TensorDynLen) -> Result<()> 
     // Write storage
     let storage_group = group.create_group("storage")?;
     if tensor.is_f64() {
-        let data = tensor.to_vec_f64().context("Failed to extract f64 data")?;
+        let data = tensor
+            .to_vec::<f64>()
+            .context("Failed to extract f64 data")?;
 
         schema::write_type_version(&storage_group, "Dense{Float64}", 1)?;
 
@@ -38,7 +40,9 @@ pub(crate) fn write_itensor(group: &Group, tensor: &TensorDynLen) -> Result<()> 
             .create("data")?;
         data_ds.as_writer().write(&data)?;
     } else if tensor.is_complex() {
-        let data = tensor.to_vec_c64().context("Failed to extract c64 data")?;
+        let data = tensor
+            .to_vec::<Complex64>()
+            .context("Failed to extract c64 data")?;
 
         schema::write_type_version(&storage_group, "Dense{ComplexF64}", 1)?;
 

--- a/crates/tensor4all-hdf5/tests/test_hdf5.rs
+++ b/crates/tensor4all-hdf5/tests/test_hdf5.rs
@@ -58,8 +58,8 @@ fn test_itensor_f64_roundtrip() {
     }
 
     // Check data
-    let orig_data = tensor.to_vec_f64().unwrap();
-    let loaded_data = loaded.to_vec_f64().unwrap();
+    let orig_data = tensor.to_vec::<f64>().unwrap();
+    let loaded_data = loaded.to_vec::<f64>().unwrap();
     for (a, b) in orig_data.iter().zip(loaded_data.iter()) {
         assert_abs_diff_eq!(a, b, epsilon = 1e-15);
     }
@@ -84,7 +84,7 @@ fn test_itensor_f64_storage_dataset_uses_column_major_linearization() {
         .unwrap()
         .to_vec();
 
-    assert_eq!(stored, tensor.to_vec_f64().unwrap());
+    assert_eq!(stored, tensor.to_vec::<f64>().unwrap());
 
     std::fs::remove_file(&path).ok();
 }
@@ -101,8 +101,8 @@ fn test_itensor_c64_roundtrip() {
     assert_eq!(tensor.dims(), loaded.dims());
 
     // Check data
-    let orig_data = tensor.to_vec_c64().unwrap();
-    let loaded_data = loaded.to_vec_c64().unwrap();
+    let orig_data = tensor.to_vec::<Complex64>().unwrap();
+    let loaded_data = loaded.to_vec::<Complex64>().unwrap();
     for (a, b) in orig_data.iter().zip(loaded_data.iter()) {
         assert_abs_diff_eq!(a.re, b.re, epsilon = 1e-15);
         assert_abs_diff_eq!(a.im, b.im, epsilon = 1e-15);
@@ -128,7 +128,7 @@ fn test_itensor_c64_storage_dataset_uses_column_major_linearization() {
         .unwrap()
         .to_vec();
 
-    assert_eq!(stored, tensor.to_vec_c64().unwrap());
+    assert_eq!(stored, tensor.to_vec::<Complex64>().unwrap());
 
     std::fs::remove_file(&path).ok();
 }
@@ -147,7 +147,7 @@ fn test_itensor_3d_roundtrip() {
     let loaded = load_itensor(&path, "tensor3d").unwrap();
 
     assert_eq!(tensor.dims(), loaded.dims());
-    let loaded_data = loaded.to_vec_f64().unwrap();
+    let loaded_data = loaded.to_vec::<f64>().unwrap();
     for (a, b) in data.iter().zip(loaded_data.iter()) {
         assert_abs_diff_eq!(a, b, epsilon = 1e-15);
     }
@@ -228,8 +228,8 @@ fn test_mps_roundtrip() {
         }
 
         // Check data
-        let orig_data = orig.to_vec_f64().unwrap();
-        let loaded_data = loaded_t.to_vec_f64().unwrap();
+        let orig_data = orig.to_vec::<f64>().unwrap();
+        let loaded_data = loaded_t.to_vec::<f64>().unwrap();
         for (a, b) in orig_data.iter().zip(loaded_data.iter()) {
             assert_abs_diff_eq!(a, b, epsilon = 1e-15);
         }

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
@@ -50,7 +50,7 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random_f64(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
@@ -29,7 +29,7 @@ fn create_random_mpo(
             indices.push(link_indices[i].clone());
         }
 
-        let tensor = TensorDynLen::random_f64(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
@@ -50,7 +50,7 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random_f64(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
@@ -29,7 +29,7 @@ fn create_random_mpo(
             indices.push(link_indices[i].clone());
         }
 
-        let tensor = TensorDynLen::random_f64(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
+++ b/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
@@ -810,8 +810,8 @@ fn debug_solution_update() -> anyhow::Result<()> {
 
     // Check actual values
     println!("\nSite 0 data comparison:");
-    println!("x_new_zipup: {:?}", x_new_zipup.tensor(0).to_vec_f64()?);
-    println!("x_new_fit:   {:?}", x_new_fit.tensor(0).to_vec_f64()?);
+    println!("x_new_zipup: {:?}", x_new_zipup.tensor(0).to_vec::<f64>()?);
+    println!("x_new_fit:   {:?}", x_new_fit.tensor(0).to_vec::<f64>()?);
 
     Ok(())
 }
@@ -974,8 +974,8 @@ fn detailed_debug_n3() -> anyhow::Result<()> {
         );
 
         // Compare dense data
-        let data_zipup = t_zipup.to_vec_f64()?;
-        let data_fit = t_fit.to_vec_f64()?;
+        let data_zipup = t_zipup.to_vec::<f64>()?;
+        let data_fit = t_fit.to_vec::<f64>()?;
 
         println!("zipup data: {:?}", data_zipup);
         println!("fit data:   {:?}", data_fit);

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -314,8 +314,8 @@ fn test_contract_method_uses_tt_contract() {
     assert_matches_naive(&tt1, &tt2, &result_method);
 
     // Both should produce identical dense results
-    let free_data = result_free.to_dense().unwrap().to_vec_f64().unwrap();
-    let method_data = result_method.to_dense().unwrap().to_vec_f64().unwrap();
+    let free_data = result_free.to_dense().unwrap().to_vec::<f64>().unwrap();
+    let method_data = result_method.to_dense().unwrap().to_vec::<f64>().unwrap();
     assert_eq!(free_data.len(), method_data.len());
     for (i, (&a, &b)) in free_data.iter().zip(method_data.iter()).enumerate() {
         assert!(
@@ -368,8 +368,8 @@ fn test_contract_zipup_with_truncation() {
 
     // Compare with naive (exact) result — should be approximate, not exact
     let naive_result = tt1.to_dense().unwrap().contract(&tt2.to_dense().unwrap());
-    let naive_data = naive_result.to_vec_f64().unwrap();
-    let result_data = result.to_dense().unwrap().to_vec_f64().unwrap();
+    let naive_data = naive_result.to_vec::<f64>().unwrap();
+    let result_data = result.to_dense().unwrap().to_vec::<f64>().unwrap();
 
     assert_eq!(result_data.len(), naive_data.len());
     let naive_norm: f64 = naive_data.iter().map(|x| x * x).sum::<f64>().sqrt();

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -406,8 +406,8 @@ fn test_to_dense() {
     let expected = t0.contract(&t1);
 
     // Compare results
-    let dense_data = dense.as_slice_f64().unwrap();
-    let expected_data = expected.as_slice_f64().unwrap();
+    let dense_data = dense.to_vec::<f64>().unwrap();
+    let expected_data = expected.to_vec::<f64>().unwrap();
 
     assert_eq!(dense_data.len(), expected_data.len());
     for (i, (&d, &e)) in dense_data.iter().zip(expected_data.iter()).enumerate() {
@@ -430,8 +430,8 @@ fn test_to_dense_single_site() {
     let tt = TensorTrain::new(vec![t0.clone()]).unwrap();
     let dense = tt.to_dense().unwrap();
 
-    let dense_data = dense.as_slice_f64().unwrap();
-    let expected_data = t0.as_slice_f64().unwrap();
+    let dense_data = dense.to_vec::<f64>().unwrap();
+    let expected_data = t0.to_vec::<f64>().unwrap();
 
     assert_eq!(dense_data.len(), expected_data.len());
     for (i, (&d, &e)) in dense_data.iter().zip(expected_data.iter()).enumerate() {
@@ -464,8 +464,8 @@ fn test_to_dense_three_sites() {
     // Expected: contract t0, t1, t2 sequentially
     let expected = t0.contract(&t1).contract(&t2);
 
-    let dense_data = dense.as_slice_f64().unwrap();
-    let expected_data = expected.as_slice_f64().unwrap();
+    let dense_data = dense.to_vec::<f64>().unwrap();
+    let expected_data = expected.to_vec::<f64>().unwrap();
 
     assert_eq!(dense_data.len(), expected_data.len());
     for (i, (&d, &e)) in dense_data.iter().zip(expected_data.iter()).enumerate() {
@@ -514,9 +514,9 @@ fn test_add_simple() {
     let tt1_dense = tt1.to_dense().unwrap();
     let tt2_dense = tt2.to_dense().unwrap();
 
-    let sum_data = sum_dense.as_slice_f64().unwrap();
-    let tt1_data = tt1_dense.as_slice_f64().unwrap();
-    let tt2_data = tt2_dense.as_slice_f64().unwrap();
+    let sum_data = sum_dense.to_vec::<f64>().unwrap();
+    let tt1_data = tt1_dense.to_vec::<f64>().unwrap();
+    let tt2_data = tt2_dense.to_vec::<f64>().unwrap();
 
     assert_eq!(sum_data.len(), tt1_data.len());
     for i in 0..sum_data.len() {
@@ -667,7 +667,7 @@ fn test_tensors_mut_returns_all_sites_in_order() {
         *tensors[0] = replacement.clone();
     }
 
-    assert_eq!(tt.tensor(0).as_slice_f64().unwrap(), vec![42.0; 6]);
+    assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![42.0; 6]);
 }
 
 #[test]
@@ -723,8 +723,8 @@ fn test_axpby() {
     let result_dense = result.to_dense().unwrap();
     let tt1_dense = tt1.to_dense().unwrap();
 
-    let result_data = result_dense.as_slice_f64().unwrap();
-    let tt1_data = tt1_dense.as_slice_f64().unwrap();
+    let result_data = result_dense.to_vec::<f64>().unwrap();
+    let tt1_data = tt1_dense.to_vec::<f64>().unwrap();
 
     assert_eq!(result_data.len(), tt1_data.len());
     for i in 0..result_data.len() {
@@ -900,8 +900,8 @@ fn test_sim_linkinds_single_site() {
     let simmed = tt.sim_linkinds();
     assert_eq!(simmed.len(), 1);
     // Should have same data
-    let orig_data = tt.tensor(0).as_slice_f64().unwrap();
-    let sim_data = simmed.tensor(0).as_slice_f64().unwrap();
+    let orig_data = tt.tensor(0).to_vec::<f64>().unwrap();
+    let sim_data = simmed.tensor(0).to_vec::<f64>().unwrap();
     assert_eq!(orig_data, sim_data);
 }
 
@@ -1040,8 +1040,8 @@ fn test_sim_linkinds_three_sites() {
     // Dense contraction should give same values
     let orig_dense = tt.to_dense().unwrap();
     let sim_dense = simmed.to_dense().unwrap();
-    let orig_data = orig_dense.as_slice_f64().unwrap();
-    let sim_data = sim_dense.as_slice_f64().unwrap();
+    let orig_data = orig_dense.to_vec::<f64>().unwrap();
+    let sim_data = sim_dense.to_vec::<f64>().unwrap();
     assert_eq!(orig_data.len(), sim_data.len());
     for (a, b) in orig_data.iter().zip(sim_data.iter()) {
         assert!((a - b).abs() < 1e-10);
@@ -1162,8 +1162,8 @@ fn test_tensor_like_conj() {
     let orig_dense = tt.to_dense().unwrap();
     let conj_dense = conj_tt.to_dense().unwrap();
 
-    let orig_data = orig_dense.as_slice_f64().unwrap();
-    let conj_data = conj_dense.as_slice_f64().unwrap();
+    let orig_data = orig_dense.to_vec::<f64>().unwrap();
+    let conj_data = conj_dense.to_vec::<f64>().unwrap();
 
     assert_eq!(orig_data.len(), conj_data.len());
     for (a, b) in orig_data.iter().zip(conj_data.iter()) {

--- a/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
@@ -35,7 +35,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random_f64(rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(rng, indices);
         tensors.push(tensor);
     }
     TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -102,7 +102,7 @@ fn as_diagonal(
     new_dims.splice(s_pos..s_pos + 1, vec![dim, dim]);
 
     let total_new: usize = new_dims.iter().product();
-    let data = tensor.to_vec_f64().unwrap();
+    let data = tensor.to_vec::<f64>().unwrap();
     let mut new_data = vec![0.0f64; total_new];
 
     for (flat, &val) in data.iter().enumerate() {
@@ -141,7 +141,7 @@ fn extract_diagonal(tensor: &TensorDynLen, s: &DynIndex, s_result: &DynIndex) ->
         .collect();
     let new_dims: Vec<usize> = new_indices.iter().map(|idx| idx.dim()).collect();
     let new_total: usize = new_dims.iter().product();
-    let data = tensor.to_vec_f64().unwrap();
+    let data = tensor.to_vec::<f64>().unwrap();
     let mut new_data = vec![0.0f64; new_total];
 
     for (flat, &val) in data.iter().enumerate() {

--- a/crates/tensor4all-itensorlike/tests/bug_norm_after_fit_cancellation.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_norm_after_fit_cancellation.rs
@@ -20,7 +20,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        tensors.push(TensorDynLen::random_f64(rng, indices));
+        tensors.push(TensorDynLen::random::<f64, _>(rng, indices));
     }
     TensorTrain::new(tensors).unwrap()
 }

--- a/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
@@ -33,7 +33,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random_f64(rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(rng, indices);
         tensors.push(tensor);
     }
     TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
@@ -27,7 +27,7 @@ impl TestScalar for f64 {
     }
 
     fn extract_slice(tensor: &TensorDynLen) -> Vec<Self> {
-        tensor.as_slice_f64().unwrap()
+        tensor.to_vec::<f64>().unwrap()
     }
 }
 
@@ -41,7 +41,7 @@ impl TestScalar for Complex64 {
     }
 
     fn extract_slice(tensor: &TensorDynLen) -> Vec<Self> {
-        tensor.as_slice_c64().unwrap()
+        tensor.to_vec::<Complex64>().unwrap()
     }
 }
 

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
@@ -186,7 +186,7 @@ fn project_dense_tensor_at_index(
     let dims: Vec<usize> = indices.iter().map(|idx| idx.dim).collect();
     let axis_stride = dims[..axis].iter().copied().product::<usize>().max(1);
     let axis_dim = dims[axis];
-    let src_data = tensor.as_slice_f64().unwrap();
+    let src_data = tensor.to_vec::<f64>().unwrap();
     let mut projected_data = vec![0.0_f64; src_data.len()];
 
     for (flat_idx, value) in src_data.iter().copied().enumerate() {
@@ -227,7 +227,7 @@ fn test_partitioned_tt_contract_numerical() {
     // Verify each subdomain numerically
     for (proj, subdomain) in result.iter() {
         let contracted_full = subdomain.data().to_dense().unwrap();
-        let contracted_data = contracted_full.as_slice_f64().unwrap();
+        let contracted_data = contracted_full.to_vec::<f64>().unwrap();
 
         // Get the projected values
         let s0_val = proj.get(&s0).unwrap();
@@ -246,7 +246,7 @@ fn test_partitioned_tt_contract_numerical() {
         let t2_proj = project_dense_tensor_at_index(&t2_full, &s2, s2_val);
 
         let expected = t1_proj.contract(&t2_proj);
-        let expected_data = expected.as_slice_f64().unwrap();
+        let expected_data = expected.to_vec::<f64>().unwrap();
 
         assert_eq!(
             contracted_data.len(),
@@ -274,7 +274,7 @@ fn test_subdomain_tt_norm_with_projector() {
     // Create TT and get its full tensor
     let tt = make_tt_with_indices(&site_inds, &link_ind);
     let full_tensor = tt.to_dense().unwrap();
-    let full_data = full_tensor.as_slice_f64().unwrap();
+    let full_data = full_tensor.to_vec::<f64>().unwrap();
 
     // Create SubDomainTT with projector s0=0
     let projector = Projector::from_pairs([(site_inds[0].clone(), 0)]);
@@ -323,11 +323,11 @@ fn test_partitioned_tt_add_same_structure() {
     let proj = Projector::from_pairs([(site_inds[0].clone(), 0)]);
     let summed = result.get(&proj).unwrap();
     let summed_dense = summed.data().to_dense().unwrap();
-    let summed_data = summed_dense.as_slice_f64().unwrap();
+    let summed_data = summed_dense.to_vec::<f64>().unwrap();
 
     let original = make_tt_with_indices(&site_inds, &link_ind);
     let original_dense = original.to_dense().unwrap();
-    let original_data = original_dense.as_slice_f64().unwrap();
+    let original_data = original_dense.to_vec::<f64>().unwrap();
 
     for (i, (&s, &o)) in summed_data.iter().zip(original_data.iter()).enumerate() {
         assert!(

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
@@ -195,7 +195,7 @@ impl SubDomainTT {
 
             // Create result tensor based on scalar type
             if tensor.is_f64() {
-                let src_data = tensor.as_slice_f64().unwrap_or_default();
+                let src_data = tensor.to_vec::<f64>().unwrap_or_default();
                 let mut result_data = vec![0.0_f64; total_size];
 
                 for flat_idx in 0..total_size {
@@ -207,7 +207,7 @@ impl SubDomainTT {
 
                 TensorDynLen::from_dense(indices.to_vec(), result_data).unwrap()
             } else {
-                let src_data = tensor.as_slice_c64().unwrap_or_default();
+                let src_data = tensor.to_vec::<Complex64>().unwrap_or_default();
                 let mut result_data = vec![Complex64::new(0.0, 0.0); total_size];
 
                 for flat_idx in 0..total_size {

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt/tests/mod.rs
@@ -64,13 +64,13 @@ fn test_subdomain_tt_project() {
 fn test_subdomain_tt_project_value_one_numeric() {
     let (tt, site_inds, _) = make_simple_tt();
     let full = tt.to_dense().unwrap();
-    let full_data = full.as_slice_f64().unwrap();
+    let full_data = full.to_vec::<f64>().unwrap();
 
     let subdomain = SubDomainTT::from_tt(tt);
     let projector = Projector::from_pairs([(site_inds[0].clone(), 1)]);
     let projected = subdomain.project(&projector).unwrap();
     let projected_full = projected.data().to_dense().unwrap();
-    let projected_data = projected_full.as_slice_f64().unwrap();
+    let projected_data = projected_full.to_vec::<f64>().unwrap();
 
     assert_eq!(projected_data.len(), full_data.len());
     assert_eq!(projected_data[0], 0.0);

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -198,7 +198,7 @@ fn contract_treetn_to_vector(
 
     // Get data from storage
     let data = full_tensor
-        .as_slice_c64()
+        .to_vec::<Complex64>()
         .expect("Expected DenseC64 storage");
     let dims = full_tensor.dims();
 
@@ -286,7 +286,7 @@ fn contract_operator_to_dense_matrix(
 
     let ext_indices = &dense_tensor.indices;
     let data = dense_tensor
-        .as_slice_c64()
+        .to_vec::<Complex64>()
         .expect("Expected DenseC64 storage");
     let tensor_dims = dense_tensor.dims();
     let ndims = tensor_dims.len();

--- a/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
@@ -16,8 +16,8 @@ fn scalar_from_value_supports_all_supported_element_types() {
 
 #[test]
 fn any_scalar_sum_from_real_storage_stays_real() {
-    let dense = Storage::from_dense_f64_col_major(vec![1.0, -2.5], &[2]).unwrap();
-    let diag = Storage::from_diag_f64_col_major(vec![3.0, 4.5], 2).unwrap();
+    let dense = Storage::from_dense_col_major(vec![1.0, -2.5], &[2]).unwrap();
+    let diag = Storage::from_diag_col_major(vec![3.0, 4.5], 2).unwrap();
 
     let dense_sum = AnyScalar::sum_from_storage(&dense);
     let diag_sum = AnyScalar::sum_from_storage(&diag);
@@ -30,7 +30,7 @@ fn any_scalar_sum_from_real_storage_stays_real() {
 
 #[test]
 fn any_scalar_sum_from_complex_storage_stays_complex() {
-    let dense = Storage::from_dense_c64_col_major(
+    let dense = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, -1.0), Complex64::new(-0.5, 2.0)],
         &[2],
     )

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -24,15 +24,17 @@ mod tensor_element;
 pub use any_scalar::AnyScalar;
 pub use backend::{qr_backend, svd_backend, BackendLinalgScalar, SvdResult};
 pub use storage::{
-    contract_storage, make_mut_storage, mindim, Storage, StructuredStorage, SumFromStorage,
+    contract_storage, make_mut_storage, mindim, Storage, StorageScalar, StructuredStorage,
+    SumFromStorage,
 };
 pub use tenferro_bridge::{
     axpby_native_tensor, axpby_storage_native, conj_native_tensor, contract_native_tensor,
     contract_storage_native, dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
     einsum_native_tensors, native_tensor_primal_to_dense_c64_col_major,
-    native_tensor_primal_to_dense_f64_col_major, native_tensor_primal_to_diag_c64,
-    native_tensor_primal_to_diag_f64, native_tensor_primal_to_storage, outer_product_native_tensor,
-    outer_product_storage_native, permute_native_tensor, permute_storage_native, qr_native_tensor,
+    native_tensor_primal_to_dense_col_major, native_tensor_primal_to_dense_f64_col_major,
+    native_tensor_primal_to_diag_c64, native_tensor_primal_to_diag_f64,
+    native_tensor_primal_to_storage, outer_product_native_tensor, outer_product_storage_native,
+    permute_native_tensor, permute_storage_native, qr_native_tensor,
     reshape_col_major_native_tensor, scale_native_tensor, scale_storage_native,
     storage_to_native_tensor, sum_native_tensor, svd_native_tensor, tangent_native_tensor,
 };

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -3,6 +3,72 @@ use num_complex::{Complex64, ComplexFloat};
 use std::ops::{Add, Mul};
 use std::sync::Arc;
 
+/// Trait for scalar types that can be stored in [`Storage`].
+///
+/// This enables generic constructors such as [`Storage::from_dense_col_major`]
+/// and [`Storage::from_diag_col_major`].
+pub trait StorageScalar: Clone + Send + Sync + 'static {
+    /// Build a dense [`Storage`] from column-major data.
+    fn build_dense_storage(data: Vec<Self>, logical_dims: &[usize]) -> Result<Storage>;
+    /// Build a diagonal [`Storage`] from diagonal payload data.
+    fn build_diag_storage(diag_data: Vec<Self>, logical_rank: usize) -> Result<Storage>;
+    /// Build a structured [`Storage`] from explicit payload metadata.
+    fn build_structured_storage(
+        data: Vec<Self>,
+        payload_dims: Vec<usize>,
+        strides: Vec<isize>,
+        axis_classes: Vec<usize>,
+    ) -> Result<Storage>;
+}
+
+impl StorageScalar for f64 {
+    fn build_dense_storage(data: Vec<Self>, logical_dims: &[usize]) -> Result<Storage> {
+        Storage::validate_dense_len(&data, logical_dims, "dense f64 payload")?;
+        Ok(Storage::from_repr(StorageRepr::F64(
+            StructuredStorage::from_dense_col_major(data, logical_dims),
+        )))
+    }
+    fn build_diag_storage(diag_data: Vec<Self>, logical_rank: usize) -> Result<Storage> {
+        Ok(Storage::from_repr(StorageRepr::F64(
+            StructuredStorage::from_diag_col_major(diag_data, logical_rank),
+        )))
+    }
+    fn build_structured_storage(
+        data: Vec<Self>,
+        payload_dims: Vec<usize>,
+        strides: Vec<isize>,
+        axis_classes: Vec<usize>,
+    ) -> Result<Storage> {
+        Ok(Storage::from_repr(StorageRepr::F64(
+            StructuredStorage::new(data, payload_dims, strides, axis_classes)?,
+        )))
+    }
+}
+
+impl StorageScalar for Complex64 {
+    fn build_dense_storage(data: Vec<Self>, logical_dims: &[usize]) -> Result<Storage> {
+        Storage::validate_dense_len(&data, logical_dims, "dense c64 payload")?;
+        Ok(Storage::from_repr(StorageRepr::C64(
+            StructuredStorage::from_dense_col_major(data, logical_dims),
+        )))
+    }
+    fn build_diag_storage(diag_data: Vec<Self>, logical_rank: usize) -> Result<Storage> {
+        Ok(Storage::from_repr(StorageRepr::C64(
+            StructuredStorage::from_diag_col_major(diag_data, logical_rank),
+        )))
+    }
+    fn build_structured_storage(
+        data: Vec<Self>,
+        payload_dims: Vec<usize>,
+        strides: Vec<isize>,
+        axis_classes: Vec<usize>,
+    ) -> Result<Storage> {
+        Ok(Storage::from_repr(StorageRepr::C64(
+            StructuredStorage::new(data, payload_dims, strides, axis_classes)?,
+        )))
+    }
+}
+
 pub(crate) fn col_major_strides(dims: &[usize]) -> Vec<isize> {
     let mut strides = Vec::with_capacity(dims.len());
     let mut stride = 1isize;
@@ -359,6 +425,46 @@ impl Storage {
         Ok(())
     }
 
+    /// Create dense storage from column-major logical values (generic over scalar type).
+    ///
+    /// The scalar type is inferred from the `data` argument.
+    pub fn from_dense_col_major<T: StorageScalar>(
+        data: Vec<T>,
+        logical_dims: &[usize],
+    ) -> Result<Self> {
+        T::build_dense_storage(data, logical_dims)
+    }
+
+    /// Create diagonal storage from column-major diagonal payload values (generic over scalar type).
+    pub fn from_diag_col_major<T: StorageScalar>(
+        diag_data: Vec<T>,
+        logical_rank: usize,
+    ) -> Result<Self> {
+        T::build_diag_storage(diag_data, logical_rank)
+    }
+
+    /// Create a new 1D zero-initialized dense storage (generic over scalar type).
+    pub fn new_dense<T: StorageScalar + Default>(size: usize) -> Self {
+        Self::from_dense_col_major(vec![T::default(); size], &[size])
+            .unwrap_or_else(|err| panic!("Storage::new_dense failed: {err}"))
+    }
+
+    /// Create a new diagonal storage with the given diagonal data (generic over scalar type).
+    pub fn new_diag<T: StorageScalar>(diag_data: Vec<T>) -> Self {
+        Self::from_diag_col_major(diag_data, 2)
+            .unwrap_or_else(|err| panic!("Storage::new_diag failed: {err}"))
+    }
+
+    /// Create a new structured storage (generic over scalar type).
+    pub fn new_structured<T: StorageScalar>(
+        data: Vec<T>,
+        payload_dims: Vec<usize>,
+        strides: Vec<isize>,
+        axis_classes: Vec<usize>,
+    ) -> Result<Self> {
+        T::build_structured_storage(data, payload_dims, strides, axis_classes)
+    }
+
     pub(crate) fn native_payload_f64(&self, logical_dims: &[usize]) -> Result<NativePayload<f64>> {
         match &self.0 {
             StorageRepr::F64(value) => {
@@ -433,30 +539,6 @@ impl Storage {
         }
     }
 
-    /// Create a new 1D zero-initialized DenseF64 storage with the given size.
-    pub fn new_dense_f64(size: usize) -> Self {
-        Self::from_dense_f64_col_major(vec![0.0; size], &[size])
-            .unwrap_or_else(|err| panic!("Storage::new_dense_f64 failed: {err}"))
-    }
-
-    /// Create a new 1D zero-initialized DenseC64 storage with the given size.
-    pub fn new_dense_c64(size: usize) -> Self {
-        Self::from_dense_c64_col_major(vec![Complex64::new(0.0, 0.0); size], &[size])
-            .unwrap_or_else(|err| panic!("Storage::new_dense_c64 failed: {err}"))
-    }
-
-    /// Create a new DiagF64 storage with the given diagonal data.
-    pub fn new_diag_f64(diag_data: Vec<f64>) -> Self {
-        Self::from_diag_f64_col_major(diag_data, 2)
-            .unwrap_or_else(|err| panic!("Storage::new_diag_f64 failed: {err}"))
-    }
-
-    /// Create a new DiagC64 storage with the given diagonal data.
-    pub fn new_diag_c64(diag_data: Vec<Complex64>) -> Self {
-        Self::from_diag_c64_col_major(diag_data, 2)
-            .unwrap_or_else(|err| panic!("Storage::new_diag_c64 failed: {err}"))
-    }
-
     /// Create dense f64 storage from column-major logical values.
     pub fn from_dense_f64_col_major(data: Vec<f64>, logical_dims: &[usize]) -> Result<Self> {
         Self::validate_dense_len(&data, logical_dims, "dense f64 payload")?;
@@ -485,36 +567,6 @@ impl Storage {
         Ok(Self::from_repr(StorageRepr::C64(
             StructuredStorage::from_diag_col_major(diag_data, logical_rank),
         )))
-    }
-
-    /// Create a new structured f64 storage.
-    pub fn new_structured_f64(
-        data: Vec<f64>,
-        payload_dims: Vec<usize>,
-        strides: Vec<isize>,
-        axis_classes: Vec<usize>,
-    ) -> Result<Self> {
-        Ok(Self::from_repr(StorageRepr::F64(StructuredStorage::new(
-            data,
-            payload_dims,
-            strides,
-            axis_classes,
-        )?)))
-    }
-
-    /// Create a new structured Complex64 storage.
-    pub fn new_structured_c64(
-        data: Vec<Complex64>,
-        payload_dims: Vec<usize>,
-        strides: Vec<isize>,
-        axis_classes: Vec<usize>,
-    ) -> Result<Self> {
-        Ok(Self::from_repr(StorageRepr::C64(StructuredStorage::new(
-            data,
-            payload_dims,
-            strides,
-            axis_classes,
-        )?)))
     }
 
     /// Check if this storage is logically dense.
@@ -563,14 +615,16 @@ impl Storage {
         self.len() == 0
     }
 
-    /// Sum all elements as f64.
-    pub fn sum_f64(&self) -> f64 {
-        f64::sum_from_storage(self)
-    }
-
-    /// Sum all elements as Complex64.
-    pub fn sum_c64(&self) -> Complex64 {
-        Complex64::sum_from_storage(self)
+    /// Sum all elements, converting to type `T`.
+    ///
+    /// # Example
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    /// let s = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    /// assert_eq!(s.sum::<f64>(), 6.0);
+    /// ```
+    pub fn sum<T: SumFromStorage>(&self) -> T {
+        T::sum_from_storage(self)
     }
 
     /// Maximum absolute value over all stored elements.
@@ -654,13 +708,13 @@ impl Storage {
             let values = self
                 .to_dense_f64_col_major_vec(dims)
                 .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"));
-            Storage::from_dense_f64_col_major(values, dims)
+            Storage::from_dense_col_major(values, dims)
                 .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"))
         } else {
             let values = self
                 .to_dense_c64_col_major_vec(dims)
                 .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"));
-            Storage::from_dense_c64_col_major(values, dims)
+            Storage::from_dense_col_major(values, dims)
                 .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"))
         }
     }
@@ -719,7 +773,7 @@ impl Storage {
     /// use num_complex::Complex64;
     ///
     /// let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)];
-    /// let storage = Storage::from_dense_c64_col_major(data, &[2]).unwrap();
+    /// let storage = Storage::from_dense_col_major(data, &[2]).unwrap();
     /// let conj_storage = storage.conj();
     ///
     /// // conj(1+2i) = 1-2i, conj(3-4i) = 3+4i

--- a/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
@@ -20,11 +20,10 @@ fn extract_c64(storage: &Storage) -> Vec<Complex64> {
 
 #[test]
 fn test_is_f64() {
-    let dense_f64 = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
-    let dense_c64 =
-        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
-    let diag_f64 = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
-    let diag_c64 = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
+    let dense_f64 = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
+    let dense_c64 = Storage::from_dense_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let diag_f64 = Storage::from_diag_col_major(vec![1.0], 2).unwrap();
+    let diag_c64 = Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
 
     assert!(dense_f64.is_f64());
     assert!(!dense_c64.is_f64());
@@ -34,11 +33,10 @@ fn test_is_f64() {
 
 #[test]
 fn test_is_c64() {
-    let dense_f64 = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
-    let dense_c64 =
-        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
-    let diag_f64 = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
-    let diag_c64 = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
+    let dense_f64 = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
+    let dense_c64 = Storage::from_dense_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let diag_f64 = Storage::from_diag_col_major(vec![1.0], 2).unwrap();
+    let diag_c64 = Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
 
     assert!(!dense_f64.is_c64());
     assert!(dense_c64.is_c64());
@@ -48,11 +46,10 @@ fn test_is_c64() {
 
 #[test]
 fn test_is_complex() {
-    let dense_f64 = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
-    let dense_c64 =
-        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
-    let diag_f64 = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
-    let diag_c64 = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
+    let dense_f64 = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
+    let dense_c64 = Storage::from_dense_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let diag_f64 = Storage::from_diag_col_major(vec![1.0], 2).unwrap();
+    let diag_c64 = Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
 
     // is_complex is an alias for is_c64
     assert!(!dense_f64.is_complex());
@@ -65,8 +62,8 @@ fn test_is_complex() {
 
 #[test]
 fn test_storage_is_diag() {
-    let dense = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
-    let diag = Storage::from_diag_f64_col_major(vec![1.0], 2).unwrap();
+    let dense = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
+    let diag = Storage::from_diag_col_major(vec![1.0], 2).unwrap();
     assert!(!dense.is_diag());
     assert!(diag.is_diag());
 }
@@ -162,11 +159,11 @@ fn structured_storage_validates_payload_rank_and_required_len() {
 
 #[test]
 fn test_storage_len_is_empty() {
-    let dense = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let dense = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     assert_eq!(dense.len(), 2);
     assert!(!dense.is_empty());
 
-    let diag = Storage::from_diag_f64_col_major(vec![], 2).unwrap();
+    let diag = Storage::from_diag_col_major(vec![0.0f64; 0], 2).unwrap();
     assert_eq!(diag.len(), 0);
     assert!(diag.is_empty());
 }
@@ -175,7 +172,7 @@ fn test_storage_len_is_empty() {
 
 #[test]
 fn test_storage_new_dense_f64() {
-    let s = Storage::new_dense_f64(3);
+    let s = Storage::new_dense::<f64>(3);
     assert_eq!(s.len(), 3);
     assert!(s.is_f64());
     let data = extract_f64(&s);
@@ -184,20 +181,20 @@ fn test_storage_new_dense_f64() {
 
 #[test]
 fn test_storage_new_dense_c64() {
-    let s = Storage::new_dense_c64(2);
+    let s = Storage::new_dense::<Complex64>(2);
     assert_eq!(s.len(), 2);
     assert!(s.is_c64());
 }
 
 #[test]
 fn test_storage_from_dense_f64_col_major_zeros_with_shape() {
-    let s = Storage::from_dense_f64_col_major(vec![0.0; 6], &[2, 3]).unwrap();
+    let s = Storage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap();
     assert_eq!(s.len(), 6);
 }
 
 #[test]
 fn test_storage_from_dense_c64_col_major_zeros_with_shape() {
-    let s = Storage::from_dense_c64_col_major(vec![Complex64::new(0.0, 0.0); 6], &[3, 2]).unwrap();
+    let s = Storage::from_dense_col_major(vec![Complex64::new(0.0, 0.0); 6], &[3, 2]).unwrap();
     assert_eq!(s.len(), 6);
 }
 
@@ -205,38 +202,38 @@ fn test_storage_from_dense_c64_col_major_zeros_with_shape() {
 
 #[test]
 fn test_sum_from_storage_f64() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     let sum: f64 = f64::sum_from_storage(&s);
     assert!((sum - 6.0).abs() < 1e-10);
 }
 
 #[test]
 fn test_sum_from_storage_diag_f64() {
-    let s = Storage::from_diag_f64_col_major(vec![10.0, 20.0], 2).unwrap();
+    let s = Storage::from_diag_col_major(vec![10.0, 20.0], 2).unwrap();
     let sum: f64 = f64::sum_from_storage(&s);
     assert!((sum - 30.0).abs() < 1e-10);
 }
 
 #[test]
 fn test_storage_sum_f64_method() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
-    assert!((s.sum_f64() - 6.0).abs() < 1e-10);
+    let s = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    assert!((s.sum::<f64>() - 6.0).abs() < 1e-10);
 }
 
 #[test]
 fn test_storage_sum_c64_method() {
-    let s = Storage::from_dense_c64_col_major(
+    let s = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
         &[2],
     )
     .unwrap();
-    let sum = s.sum_c64();
+    let sum = s.sum::<Complex64>();
     assert!((sum - Complex64::new(4.0, 6.0)).norm() < 1e-10);
 }
 
 #[test]
 fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
-    let dense_c64 = Storage::from_dense_c64_col_major(
+    let dense_c64 = Storage::from_dense_col_major(
         vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, -1.0)],
         &[2],
     )
@@ -250,11 +247,9 @@ fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
         other => panic!("expected C64, got {other:?}"),
     }
 
-    let diag_c64 = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, 4.0)],
-        2,
-    )
-    .unwrap();
+    let diag_c64 =
+        Storage::from_diag_col_major(vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, 4.0)], 2)
+            .unwrap();
     assert!((diag_c64.max_abs() - 5.0).abs() < 1e-10);
     match diag_c64.to_dense_storage(&[2, 2]).repr() {
         StorageRepr::C64(ds) => {
@@ -274,7 +269,7 @@ fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
 
 #[test]
 fn test_storage_projection_promotion_and_conjugation_helpers() {
-    let dense_c64 = Storage::from_dense_c64_col_major(
+    let dense_c64 = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, -2.0), Complex64::new(3.0, 4.0)],
         &[2],
     )
@@ -301,7 +296,7 @@ fn test_storage_projection_promotion_and_conjugation_helpers() {
         other => panic!("expected C64, got {other:?}"),
     }
 
-    let diag_f64 = Storage::from_diag_f64_col_major(vec![2.0, -1.0], 2).unwrap();
+    let diag_f64 = Storage::from_diag_col_major(vec![2.0, -1.0], 2).unwrap();
     match diag_f64.extract_imag_part(&[2, 2]).repr() {
         StorageRepr::F64(ds) => {
             assert_eq!(ds.payload_col_major_vec().as_slice(), &[0.0, 0.0])
@@ -317,8 +312,8 @@ fn test_storage_projection_promotion_and_conjugation_helpers() {
         }
         other => panic!("expected C64, got {other:?}"),
     }
-    let real = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let imag = Storage::from_dense_f64_col_major(vec![0.5, -1.5], &[2]).unwrap();
+    let real = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let imag = Storage::from_dense_col_major(vec![0.5, -1.5], &[2]).unwrap();
     match Storage::combine_to_complex(&real, &imag).repr() {
         StorageRepr::C64(ds) => {
             assert_eq!(
@@ -332,8 +327,8 @@ fn test_storage_projection_promotion_and_conjugation_helpers() {
 
 #[test]
 fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
-    let dense_f64_a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let dense_f64_b = Storage::from_dense_f64_col_major(vec![3.0, -1.0], &[2]).unwrap();
+    let dense_f64_a = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let dense_f64_b = Storage::from_dense_col_major(vec![3.0, -1.0], &[2]).unwrap();
     match dense_f64_a.try_add(&dense_f64_b).unwrap().repr() {
         StorageRepr::F64(ds) => assert_eq!(ds.data(), &[4.0, 1.0]),
         other => panic!("expected F64, got {other:?}"),
@@ -343,12 +338,12 @@ fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
         other => panic!("expected F64, got {other:?}"),
     }
 
-    let dense_c64_a = Storage::from_dense_c64_col_major(
+    let dense_c64_a = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 1.0), Complex64::new(0.0, -2.0)],
         &[2],
     )
     .unwrap();
-    let dense_c64_b = Storage::from_dense_c64_col_major(
+    let dense_c64_b = Storage::from_dense_col_major(
         vec![Complex64::new(-1.0, 0.5), Complex64::new(3.0, 1.0)],
         &[2],
     )
@@ -362,8 +357,8 @@ fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
         StorageRepr::C64(_)
     ));
 
-    let diag_f64_a = Storage::from_diag_f64_col_major(vec![1.0, 2.0], 2).unwrap();
-    let diag_f64_b = Storage::from_diag_f64_col_major(vec![0.5, -3.0], 2).unwrap();
+    let diag_f64_a = Storage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
+    let diag_f64_b = Storage::from_diag_col_major(vec![0.5, -3.0], 2).unwrap();
     assert!(matches!(
         diag_f64_a.try_add(&diag_f64_b).unwrap().repr(),
         StorageRepr::F64(_)
@@ -373,16 +368,12 @@ fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
         StorageRepr::F64(_)
     ));
 
-    let diag_c64_a = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(1.0, -1.0), Complex64::new(0.0, 2.0)],
-        2,
-    )
-    .unwrap();
-    let diag_c64_b = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(0.5, 0.5), Complex64::new(-3.0, 1.0)],
-        2,
-    )
-    .unwrap();
+    let diag_c64_a =
+        Storage::from_diag_col_major(vec![Complex64::new(1.0, -1.0), Complex64::new(0.0, 2.0)], 2)
+            .unwrap();
+    let diag_c64_b =
+        Storage::from_diag_col_major(vec![Complex64::new(0.5, 0.5), Complex64::new(-3.0, 1.0)], 2)
+            .unwrap();
     assert!(matches!(
         diag_c64_a.try_add(&diag_c64_b).unwrap().repr(),
         StorageRepr::C64(_)
@@ -392,13 +383,13 @@ fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
         StorageRepr::C64(_)
     ));
 
-    let mismatched_len = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
+    let mismatched_len = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
     let err = dense_f64_a.try_add(&mismatched_len).unwrap_err();
     assert!(err.contains("Storage lengths must match for addition"));
     let err = dense_f64_a.try_sub(&mismatched_len).unwrap_err();
     assert!(err.contains("Storage lengths must match for subtraction"));
 
-    let mismatched_type = Storage::from_dense_c64_col_major(
+    let mismatched_type = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
         &[2],
     )
@@ -423,7 +414,7 @@ fn test_structured_storage_permute_logical_axes_basic() {
 
 #[test]
 fn test_storage_scale_f64() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     let scaled = s.scale(&crate::AnyScalar::new_real(3.0));
     let data = extract_f64(&scaled);
     assert!((data[0] - 3.0).abs() < 1e-10);
@@ -432,8 +423,8 @@ fn test_storage_scale_f64() {
 
 #[test]
 fn test_storage_axpby_dense_f64() {
-    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let b = Storage::from_dense_f64_col_major(vec![3.0, 4.0], &[2]).unwrap();
+    let a = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0, 4.0], &[2]).unwrap();
     let result = a
         .axpby(
             &crate::AnyScalar::new_real(2.0),
@@ -449,8 +440,8 @@ fn test_storage_axpby_dense_f64() {
 
 #[test]
 fn test_storage_axpby_diag_f64() {
-    let a = Storage::from_diag_f64_col_major(vec![1.0, 2.0], 2).unwrap();
-    let b = Storage::from_diag_f64_col_major(vec![3.0, 4.0], 2).unwrap();
+    let a = Storage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
+    let b = Storage::from_diag_col_major(vec![3.0, 4.0], 2).unwrap();
     let result = a
         .axpby(
             &crate::AnyScalar::new_real(2.0),
@@ -469,8 +460,8 @@ fn test_storage_axpby_diag_f64() {
 
 #[test]
 fn test_storage_axpby_complex_promotion() {
-    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let b = Storage::from_dense_f64_col_major(vec![3.0, 4.0], &[2]).unwrap();
+    let a = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0, 4.0], &[2]).unwrap();
     let result = a
         .axpby(
             &crate::AnyScalar::new_complex(1.0, 1.0),
@@ -488,7 +479,7 @@ fn test_storage_axpby_complex_promotion() {
 
 #[test]
 fn test_storage_new_diag_f64() {
-    let s = Storage::new_diag_f64(vec![1.0, 2.0, 3.0]);
+    let s = Storage::new_diag::<f64>(vec![1.0, 2.0, 3.0]);
     assert_eq!(s.len(), 3);
     assert!(s.is_f64());
     assert!(s.is_diag());
@@ -496,7 +487,8 @@ fn test_storage_new_diag_f64() {
 
 #[test]
 fn test_storage_new_diag_c64() {
-    let s = Storage::new_diag_c64(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]);
+    let s =
+        Storage::new_diag::<Complex64>(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]);
     assert_eq!(s.len(), 2);
     assert!(s.is_c64());
     assert!(s.is_diag());
@@ -506,22 +498,22 @@ fn test_storage_new_diag_c64() {
 
 #[test]
 fn test_storage_is_dense_structured() {
-    let dense = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let dense = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     assert!(dense.is_dense());
     assert!(!dense.is_diag());
 
-    let diag = Storage::from_diag_f64_col_major(vec![1.0, 2.0], 2).unwrap();
+    let diag = Storage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     assert!(!diag.is_dense());
     assert!(diag.is_diag());
 }
 
 #[test]
 fn test_storage_is_dense_structured_c64() {
-    let dense = Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+    let dense = Storage::from_dense_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
     assert!(dense.is_dense());
     assert!(!dense.is_diag());
 
-    let diag = Storage::from_diag_c64_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
+    let diag = Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0)], 2).unwrap();
     assert!(!diag.is_dense());
     assert!(diag.is_diag());
 }
@@ -530,18 +522,16 @@ fn test_storage_is_dense_structured_c64() {
 
 #[test]
 fn test_storage_from_diag_f64_col_major() {
-    let s = Storage::from_diag_f64_col_major(vec![5.0, 10.0], 3).unwrap();
+    let s = Storage::from_diag_col_major(vec![5.0, 10.0], 3).unwrap();
     assert!(s.is_diag());
     assert!(s.is_f64());
 }
 
 #[test]
 fn test_storage_from_diag_c64_col_major() {
-    let s = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(5.0, 1.0), Complex64::new(10.0, 2.0)],
-        3,
-    )
-    .unwrap();
+    let s =
+        Storage::from_diag_col_major(vec![Complex64::new(5.0, 1.0), Complex64::new(10.0, 2.0)], 3)
+            .unwrap();
     assert!(s.is_diag());
     assert!(s.is_c64());
 }
@@ -550,10 +540,10 @@ fn test_storage_from_diag_c64_col_major() {
 
 #[test]
 fn test_storage_max_abs_structured() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, -5.0, 3.0], &[3]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, -5.0, 3.0], &[3]).unwrap();
     assert!((s.max_abs() - 5.0).abs() < 1e-10);
 
-    let s_c64 = Storage::from_dense_c64_col_major(
+    let s_c64 = Storage::from_dense_col_major(
         vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
         &[2],
     )
@@ -566,7 +556,7 @@ fn test_storage_max_abs_structured() {
 #[test]
 fn test_storage_permute_storage_structured_diag() {
     // Diagonal structured storage: permuting is trivial (data doesn't change).
-    let s = Storage::from_diag_f64_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
+    let s = Storage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
     let permuted = s.permute_storage(&[3, 3], &[1, 0]);
     assert!(permuted.is_f64());
     assert!(permuted.is_diag());
@@ -574,11 +564,9 @@ fn test_storage_permute_storage_structured_diag() {
 
 #[test]
 fn test_storage_permute_storage_structured_diag_c64() {
-    let s = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
-        2,
-    )
-    .unwrap();
+    let s =
+        Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)], 2)
+            .unwrap();
     let permuted = s.permute_storage(&[2, 2], &[1, 0]);
     assert!(permuted.is_c64());
     assert!(permuted.is_diag());
@@ -588,14 +576,14 @@ fn test_storage_permute_storage_structured_diag_c64() {
 
 #[test]
 fn test_storage_conj_structured_f64() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, -2.0], &[2]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, -2.0], &[2]).unwrap();
     let conj = s.conj();
     assert!(conj.is_f64());
 }
 
 #[test]
 fn test_storage_conj_structured_c64() {
-    let s = Storage::from_dense_c64_col_major(
+    let s = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)],
         &[2],
     )
@@ -608,7 +596,7 @@ fn test_storage_conj_structured_c64() {
 
 #[test]
 fn test_storage_extract_real_structured() {
-    let s = Storage::from_dense_c64_col_major(
+    let s = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
         &[2],
     )
@@ -616,14 +604,14 @@ fn test_storage_extract_real_structured() {
     let real = s.extract_real_part();
     assert!(real.is_f64());
 
-    let f64_s = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let f64_s = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     let real2 = f64_s.extract_real_part();
     assert!(real2.is_f64());
 }
 
 #[test]
 fn test_storage_extract_imag_structured() {
-    let s = Storage::from_dense_c64_col_major(
+    let s = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
         &[2],
     )
@@ -631,19 +619,19 @@ fn test_storage_extract_imag_structured() {
     let imag = s.extract_imag_part(&[2]);
     assert!(imag.is_f64());
 
-    let f64_s = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let f64_s = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     let imag2 = f64_s.extract_imag_part(&[2]);
     assert!(imag2.is_f64());
 }
 
 #[test]
 fn test_storage_to_complex_structured() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     let c = s.to_complex_storage();
     assert!(c.is_c64());
 
     let already_complex =
-        Storage::from_dense_c64_col_major(vec![Complex64::new(1.0, 2.0)], &[1]).unwrap();
+        Storage::from_dense_col_major(vec![Complex64::new(1.0, 2.0)], &[1]).unwrap();
     let c2 = already_complex.to_complex_storage();
     assert!(c2.is_c64());
 }
@@ -652,7 +640,7 @@ fn test_storage_to_complex_structured() {
 
 #[test]
 fn test_storage_to_dense_storage_structured_f64() {
-    let s = Storage::from_diag_f64_col_major(vec![1.0, 2.0], 2).unwrap();
+    let s = Storage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     let dense = s.to_dense_storage(&[2, 2]);
     assert!(dense.is_dense());
     assert!(dense.is_f64());
@@ -660,11 +648,9 @@ fn test_storage_to_dense_storage_structured_f64() {
 
 #[test]
 fn test_storage_to_dense_storage_structured_c64() {
-    let s = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
-        2,
-    )
-    .unwrap();
+    let s =
+        Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)], 2)
+            .unwrap();
     let dense = s.to_dense_storage(&[2, 2]);
     assert!(dense.is_dense());
     assert!(dense.is_c64());
@@ -675,7 +661,7 @@ fn test_storage_to_dense_storage_structured_c64() {
 #[test]
 fn test_storage_to_dense_f64_col_major_vec_structured_non_contiguous() {
     // Create a structured storage that is not dense - a diagonal
-    let s = Storage::from_diag_f64_col_major(vec![3.0, 7.0], 2).unwrap();
+    let s = Storage::from_diag_col_major(vec![3.0, 7.0], 2).unwrap();
     let values = s.to_dense_f64_col_major_vec(&[2, 2]).unwrap();
     // Col-major for [[3,0],[0,7]]: [3, 0, 0, 7]
     assert_eq!(values.len(), 4);
@@ -685,11 +671,9 @@ fn test_storage_to_dense_f64_col_major_vec_structured_non_contiguous() {
 
 #[test]
 fn test_storage_to_dense_c64_col_major_vec_structured_non_contiguous() {
-    let s = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(3.0, 1.0), Complex64::new(7.0, 2.0)],
-        2,
-    )
-    .unwrap();
+    let s =
+        Storage::from_diag_col_major(vec![Complex64::new(3.0, 1.0), Complex64::new(7.0, 2.0)], 2)
+            .unwrap();
     let values = s.to_dense_c64_col_major_vec(&[2, 2]).unwrap();
     assert_eq!(values.len(), 4);
     assert!((values[0] - Complex64::new(3.0, 1.0)).norm() < 1e-10);
@@ -700,14 +684,14 @@ fn test_storage_to_dense_c64_col_major_vec_structured_non_contiguous() {
 
 #[test]
 fn test_storage_new_structured_f64() {
-    let s = Storage::new_structured_f64(vec![1.0, 2.0], vec![2], vec![1], vec![0, 0]).unwrap();
+    let s = Storage::new_structured::<f64>(vec![1.0, 2.0], vec![2], vec![1], vec![0, 0]).unwrap();
     assert!(s.is_f64());
     assert!(s.is_diag());
 }
 
 #[test]
 fn test_storage_new_structured_c64() {
-    let s = Storage::new_structured_c64(
+    let s = Storage::new_structured::<Complex64>(
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
         vec![2],
         vec![1],
@@ -722,7 +706,7 @@ fn test_storage_new_structured_c64() {
 
 #[test]
 fn test_make_mut_storage() {
-    let storage = Storage::from_dense_f64_col_major(vec![1.0], &[1]).unwrap();
+    let storage = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
     let mut arc = Arc::new(storage);
     let _mutable = make_mut_storage(&mut arc);
     // Just verify it doesn't panic and returns a mutable ref
@@ -732,11 +716,9 @@ fn test_make_mut_storage() {
 
 #[test]
 fn test_sum_from_storage_diag_c64() {
-    let s = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
-        2,
-    )
-    .unwrap();
+    let s =
+        Storage::from_diag_col_major(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)], 2)
+            .unwrap();
     let sum_f64: f64 = f64::sum_from_storage(&s);
     // real part sum: 1.0 + 3.0 = 4.0
     assert!((sum_f64 - 4.0).abs() < 1e-10);
@@ -747,7 +729,7 @@ fn test_sum_from_storage_diag_c64() {
 
 #[test]
 fn test_sum_from_storage_structured_f64() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     let sum_f64: f64 = f64::sum_from_storage(&s);
     assert!((sum_f64 - 6.0).abs() < 1e-10);
 
@@ -757,7 +739,7 @@ fn test_sum_from_storage_structured_f64() {
 
 #[test]
 fn test_sum_from_storage_structured_c64() {
-    let s = Storage::from_dense_c64_col_major(
+    let s = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
         &[2],
     )
@@ -772,7 +754,7 @@ fn test_sum_from_storage_structured_c64() {
 
 #[test]
 fn test_sum_from_storage_dense_c64_as_f64() {
-    let s = Storage::from_dense_c64_col_major(
+    let s = Storage::from_dense_col_major(
         vec![Complex64::new(10.0, 5.0), Complex64::new(-3.0, 2.0)],
         &[2],
     )
@@ -784,14 +766,14 @@ fn test_sum_from_storage_dense_c64_as_f64() {
 
 #[test]
 fn test_sum_from_storage_dense_f64_as_c64() {
-    let s = Storage::from_dense_f64_col_major(vec![2.0, 3.0], &[2]).unwrap();
+    let s = Storage::from_dense_col_major(vec![2.0, 3.0], &[2]).unwrap();
     let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
     assert!((sum_c64 - Complex64::new(5.0, 0.0)).norm() < 1e-10);
 }
 
 #[test]
 fn test_sum_from_storage_diag_f64_as_c64() {
-    let s = Storage::from_diag_f64_col_major(vec![10.0, 20.0], 2).unwrap();
+    let s = Storage::from_diag_col_major(vec![10.0, 20.0], 2).unwrap();
     let sum_c64: Complex64 = Complex64::sum_from_storage(&s);
     assert!((sum_c64 - Complex64::new(30.0, 0.0)).norm() < 1e-10);
 }
@@ -803,8 +785,8 @@ fn test_contract_storage_dense_f64_matmul() {
     // A = [[1,2],[3,4]] col-major: [1, 3, 2, 4]
     // B = [[5,6],[7,8]] col-major: [5, 7, 6, 8]
     // C = A @ B = [[19,22],[43,50]] col-major: [19, 43, 22, 50]
-    let a = Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-    let b = Storage::from_dense_f64_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
+    let a = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
 
     let result = contract_storage(&a, &[2, 2], &[1], &b, &[2, 2], &[0], &[2, 2]);
 
@@ -824,8 +806,8 @@ fn test_contract_storage_diag_f64_partial() {
     // Diag [3, 3] with diag = [4, 5, 6]
     // Contract axis 1 of first with axis 0 of second
     // Result should be element-wise product: [4, 10, 18] (diagonal)
-    let diag1 = Storage::from_diag_f64_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
-    let diag2 = Storage::from_diag_f64_col_major(vec![4.0, 5.0, 6.0], 2).unwrap();
+    let diag1 = Storage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
+    let diag2 = Storage::from_diag_col_major(vec![4.0, 5.0, 6.0], 2).unwrap();
 
     let result = contract_storage(&diag1, &[3, 3], &[1], &diag2, &[3, 3], &[0], &[3, 3]);
 
@@ -842,8 +824,8 @@ fn test_contract_storage_diag_f64_partial() {
 #[test]
 fn test_contract_storage_inner_product() {
     // [1, 2, 3] . [4, 5, 6] = 4 + 10 + 18 = 32
-    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
-    let b = Storage::from_dense_f64_col_major(vec![4.0, 5.0, 6.0], &[3]).unwrap();
+    let a = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let b = Storage::from_dense_col_major(vec![4.0, 5.0, 6.0], &[3]).unwrap();
 
     let result = contract_storage(&a, &[3], &[0], &b, &[3], &[0], &[]);
 

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -167,7 +167,7 @@ fn dense_f64_storage_from_col_major(
     logical_dims: &[usize],
 ) -> Result<Storage> {
     let data = materialize_col_major_values(tensor, "f64 dense snapshot materialization")?;
-    Storage::from_dense_f64_col_major(data, logical_dims)
+    Storage::from_dense_col_major(data, logical_dims)
 }
 
 fn dense_c64_storage_from_col_major(
@@ -175,7 +175,7 @@ fn dense_c64_storage_from_col_major(
     logical_dims: &[usize],
 ) -> Result<Storage> {
     let data = materialize_col_major_values(tensor, "c64 dense snapshot materialization")?;
-    Storage::from_dense_c64_col_major(data, logical_dims)
+    Storage::from_dense_col_major(data, logical_dims)
 }
 
 fn materialize_col_major_values<T>(tensor: &TypedTensor<T>, op: &'static str) -> Result<Vec<T>>
@@ -212,7 +212,7 @@ fn snapshot_f64_to_storage(snap: &snapshot::DynTensor) -> Result<Storage> {
             .payload_f64()
             .ok_or_else(|| anyhow!("expected f64 diagonal payload"))?;
         let data = materialize_col_major_values(payload, "f64 diagonal snapshot materialization")?;
-        return Storage::from_diag_f64_col_major(data, snap.dims().len());
+        return Storage::from_diag_col_major(data, snap.dims().len());
     }
 
     if snap.is_dense() {
@@ -226,7 +226,7 @@ fn snapshot_f64_to_storage(snap: &snapshot::DynTensor) -> Result<Storage> {
             .ok_or_else(|| anyhow!("expected f64 structured payload"))?;
         let data =
             materialize_col_major_values(payload, "f64 structured snapshot materialization")?;
-        Storage::new_structured_f64(
+        Storage::new_structured::<f64>(
             data,
             payload.dims().to_vec(),
             col_major_strides(payload.dims()),
@@ -241,7 +241,7 @@ fn snapshot_c64_to_storage(snap: &snapshot::DynTensor) -> Result<Storage> {
             .payload_c64()
             .ok_or_else(|| anyhow!("expected c64 diagonal payload"))?;
         let data = materialize_col_major_values(payload, "c64 diagonal snapshot materialization")?;
-        return Storage::from_diag_c64_col_major(data, snap.dims().len());
+        return Storage::from_diag_col_major(data, snap.dims().len());
     }
 
     if snap.is_dense() {
@@ -255,7 +255,7 @@ fn snapshot_c64_to_storage(snap: &snapshot::DynTensor) -> Result<Storage> {
             .ok_or_else(|| anyhow!("expected c64 structured payload"))?;
         let data =
             materialize_col_major_values(payload, "c64 structured snapshot materialization")?;
-        Storage::new_structured_c64(
+        Storage::new_structured::<Complex64>(
             data,
             payload.dims().to_vec(),
             col_major_strides(payload.dims()),
@@ -387,6 +387,18 @@ pub fn native_tensor_primal_to_dense_c64_col_major(
 ) -> Result<Vec<Complex64>> {
     retry_with_default_runtime_if_needed("native_tensor_primal_to_dense_c64_col_major", || {
         <Complex64 as TensorElement>::dense_values_from_native_col_major(tensor)
+    })
+}
+
+/// Materialize the dense primal payload of a native tensor (generic over element type).
+///
+/// This is the generic equivalent of [`native_tensor_primal_to_dense_f64_col_major`]
+/// and [`native_tensor_primal_to_dense_c64_col_major`].
+pub fn native_tensor_primal_to_dense_col_major<T: TensorElement>(
+    tensor: &NativeTensor,
+) -> Result<Vec<T>> {
+    retry_with_default_runtime_if_needed("native_tensor_primal_to_dense_col_major", || {
+        T::dense_values_from_native_col_major(tensor)
     })
 }
 

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -25,31 +25,31 @@ fn assert_storage_eq(lhs: &Storage, rhs: &Storage) {
 
 #[test]
 fn storage_native_roundtrip_dense_f64() {
-    let storage = Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+    let storage = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
 
     let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
     let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
 
-    let expected = Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+    let expected = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
     assert_storage_eq(&roundtrip, &expected);
 }
 
 #[test]
 fn storage_native_roundtrip_diag_preserves_diag_layout() {
-    let storage = Storage::from_diag_f64_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
+    let storage = Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
 
     let native = storage_to_native_tensor(&storage, &[3, 3]).unwrap();
     let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
 
     assert!(native.is_diag());
-    let expected = Storage::from_diag_f64_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
+    let expected = Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
     assert_storage_eq(&roundtrip, &expected);
 }
 
 #[test]
 fn native_dense_materialization_sets_default_runtime_if_needed() {
     let native = storage_to_native_tensor(
-        &Storage::from_diag_f64_col_major(vec![2.0, -1.0, 4.0], 2).unwrap(),
+        &Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap(),
         &[3, 3],
     )
     .unwrap();
@@ -89,7 +89,7 @@ fn storage_native_roundtrip_structured_preserves_axis_classes() {
 
 #[test]
 fn sum_native_tensor_returns_rank0_scalar() {
-    let storage = Storage::from_dense_c64_col_major(
+    let storage = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, -1.0), Complex64::new(-0.5, 2.0)],
         &[2],
     )
@@ -104,7 +104,7 @@ fn sum_native_tensor_returns_rank0_scalar() {
 
 #[test]
 fn native_snapshot_materializes_lazy_conjugation() {
-    let storage = Storage::from_dense_c64_col_major(
+    let storage = Storage::from_dense_col_major(
         vec![
             Complex64::new(1.0, 2.0),
             Complex64::new(0.0, -1.0),
@@ -119,7 +119,7 @@ fn native_snapshot_materializes_lazy_conjugation() {
     let conjugated = conj_native_tensor(&native).unwrap();
     let snapshot = native_tensor_primal_to_storage(&conjugated).unwrap();
 
-    let expected = Storage::from_dense_c64_col_major(
+    let expected = Storage::from_dense_col_major(
         vec![
             Complex64::new(1.0, -2.0),
             Complex64::new(0.0, 1.0),
@@ -135,13 +135,12 @@ fn native_snapshot_materializes_lazy_conjugation() {
 #[test]
 fn native_einsum_accepts_unsorted_nonfirst_operand_labels() {
     let lhs = storage_to_native_tensor(
-        &Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap(),
+        &Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap(),
         &[2, 2],
     )
     .unwrap();
     let rhs = storage_to_native_tensor(
-        &Storage::from_dense_f64_col_major(vec![10.0, 30.0, 50.0, 20.0, 40.0, 60.0], &[3, 2])
-            .unwrap(),
+        &Storage::from_dense_col_major(vec![10.0, 30.0, 50.0, 20.0, 40.0, 60.0], &[3, 2]).unwrap(),
         &[3, 2],
     )
     .unwrap();
@@ -150,7 +149,7 @@ fn native_einsum_accepts_unsorted_nonfirst_operand_labels() {
     let snapshot = native_tensor_primal_to_storage(&out).unwrap();
 
     let expected =
-        Storage::from_dense_f64_col_major(vec![50.0, 110.0, 110.0, 250.0, 170.0, 390.0], &[2, 3])
+        Storage::from_dense_col_major(vec![50.0, 110.0, 110.0, 250.0, 170.0, 390.0], &[2, 3])
             .unwrap();
     assert_storage_eq(&snapshot, &expected);
 }
@@ -158,12 +157,12 @@ fn native_einsum_accepts_unsorted_nonfirst_operand_labels() {
 #[test]
 fn contract_native_tensor_restores_rhs_free_axis_order() {
     let lhs = storage_to_native_tensor(
-        &Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap(),
+        &Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap(),
         &[2, 2],
     )
     .unwrap();
     let rhs = storage_to_native_tensor(
-        &Storage::from_dense_f64_col_major(vec![10.0, 30.0, 20.0, 40.0], &[2, 2]).unwrap(),
+        &Storage::from_dense_col_major(vec![10.0, 30.0, 20.0, 40.0], &[2, 2]).unwrap(),
         &[2, 2],
     )
     .unwrap();
@@ -171,8 +170,7 @@ fn contract_native_tensor_restores_rhs_free_axis_order() {
     let out = contract_native_tensor(&lhs, &[1], &rhs, &[1]).unwrap();
     let snapshot = native_tensor_primal_to_storage(&out).unwrap();
 
-    let expected =
-        Storage::from_dense_f64_col_major(vec![50.0, 110.0, 110.0, 250.0], &[2, 2]).unwrap();
+    let expected = Storage::from_dense_col_major(vec![50.0, 110.0, 110.0, 250.0], &[2, 2]).unwrap();
     assert_storage_eq(&snapshot, &expected);
 }
 
@@ -189,12 +187,12 @@ fn dense_native_tensor_column_major_roundtrip_preserves_linearization() {
 #[test]
 fn permute_storage_native_dense_matches_expected_data() {
     let storage =
-        Storage::from_dense_f64_col_major(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], &[2, 3]).unwrap();
+        Storage::from_dense_col_major(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], &[2, 3]).unwrap();
 
     let native = permute_storage_native(&storage, &[2, 3], &[1, 0]).unwrap();
 
     let expected =
-        Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]).unwrap();
+        Storage::from_dense_col_major(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]).unwrap();
     assert_storage_eq(&native, &expected);
 }
 
@@ -218,15 +216,14 @@ fn reshape_col_major_native_tensor_handles_noncontiguous_permuted_input() {
 
 #[test]
 fn contract_storage_native_dense_f64() {
-    let a = Storage::from_dense_f64_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-    let b = Storage::from_dense_f64_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
+    let a = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
 
     let result = contract_storage_native(&a, &[2, 2], &[1], &b, &[2, 2], &[0], &[2, 2]).unwrap();
 
     // A = [[1,2],[3,4]], B = [[5,6],[7,8]], C = A@B = [[19,22],[43,50]]
     // col-major: [19, 43, 22, 50]
-    let expected =
-        Storage::from_dense_f64_col_major(vec![19.0, 43.0, 22.0, 50.0], &[2, 2]).unwrap();
+    let expected = Storage::from_dense_col_major(vec![19.0, 43.0, 22.0, 50.0], &[2, 2]).unwrap();
     assert_storage_eq(&result, &expected);
 }
 
@@ -234,15 +231,15 @@ fn contract_storage_native_dense_f64() {
 
 #[test]
 fn outer_product_storage_native_produces_correct_shape() {
-    let a = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let b = Storage::from_dense_f64_col_major(vec![3.0, 4.0, 5.0], &[3]).unwrap();
+    let a = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0, 4.0, 5.0], &[3]).unwrap();
 
     let result = outer_product_storage_native(&a, &[2], &b, &[3], &[2, 3]).unwrap();
 
     // a[i] * b[j]: col-major [2,3]
     // [1*3, 2*3, 1*4, 2*4, 1*5, 2*5] = [3, 6, 4, 8, 5, 10]
     let expected =
-        Storage::from_dense_f64_col_major(vec![3.0, 6.0, 4.0, 8.0, 5.0, 10.0], &[2, 3]).unwrap();
+        Storage::from_dense_col_major(vec![3.0, 6.0, 4.0, 8.0, 5.0, 10.0], &[2, 3]).unwrap();
     assert_storage_eq(&result, &expected);
 }
 
@@ -250,12 +247,12 @@ fn outer_product_storage_native_produces_correct_shape() {
 
 #[test]
 fn scale_storage_native_scales_elements() {
-    let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let s = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     let scalar = crate::AnyScalar::new_real(2.0);
 
     let result = scale_storage_native(&s, &[3], &scalar).unwrap();
 
-    let expected = Storage::from_dense_f64_col_major(vec![2.0, 4.0, 6.0], &[3]).unwrap();
+    let expected = Storage::from_dense_col_major(vec![2.0, 4.0, 6.0], &[3]).unwrap();
     assert_storage_eq(&result, &expected);
 }
 
@@ -263,15 +260,15 @@ fn scale_storage_native_scales_elements() {
 
 #[test]
 fn axpby_storage_native_linear_combination() {
-    let lhs = Storage::from_dense_f64_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let rhs = Storage::from_dense_f64_col_major(vec![3.0, 4.0], &[2]).unwrap();
+    let lhs = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let rhs = Storage::from_dense_col_major(vec![3.0, 4.0], &[2]).unwrap();
     let a = crate::AnyScalar::new_real(2.0);
     let b = crate::AnyScalar::new_real(3.0);
 
     let result = axpby_storage_native(&lhs, &[2], &a, &rhs, &[2], &b).unwrap();
 
     // 2*1 + 3*3 = 11, 2*2 + 3*4 = 16
-    let expected = Storage::from_dense_f64_col_major(vec![11.0, 16.0], &[2]).unwrap();
+    let expected = Storage::from_dense_col_major(vec![11.0, 16.0], &[2]).unwrap();
     assert_storage_eq(&result, &expected);
 }
 
@@ -279,7 +276,7 @@ fn axpby_storage_native_linear_combination() {
 
 #[test]
 fn native_tensor_primal_to_diag_f64_extracts_diagonal() {
-    let storage = Storage::from_diag_f64_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
+    let storage = Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
     let native = storage_to_native_tensor(&storage, &[3, 3]).unwrap();
 
     let diag_values = native_tensor_primal_to_diag_f64(&native).unwrap();
@@ -289,11 +286,9 @@ fn native_tensor_primal_to_diag_f64_extracts_diagonal() {
 
 #[test]
 fn native_tensor_primal_to_diag_c64_extracts_diagonal() {
-    let storage = Storage::from_diag_c64_col_major(
-        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
-        2,
-    )
-    .unwrap();
+    let storage =
+        Storage::from_diag_col_major(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)], 2)
+            .unwrap();
     let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
 
     let diag_values = native_tensor_primal_to_diag_c64(&native).unwrap();
@@ -354,7 +349,7 @@ fn storage_native_roundtrip_structured_c64_preserves_axis_classes() {
 
 #[test]
 fn sum_native_tensor_returns_f64_scalar() {
-    let storage = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let storage = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     let native = storage_to_native_tensor(&storage, &[3]).unwrap();
 
     let sum = sum_native_tensor(&native).unwrap();

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
@@ -16,10 +16,9 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use tensor4all_core::{index::DynId, DynIndex, IndexLike, TensorDynLen, TensorIndex, TensorLike};
 use tensor4all_treetn::{
-    apply_linear_operator, apply_local_update_sweep, random_treetn_f64, ApplyOptions,
-    CanonicalForm, CanonicalizationOptions, IndexMapping, LinearOperator, LinkSpace,
-    LinsolveOptions, LocalUpdateSweepPlan, SiteIndexNetwork, SquareLinsolveUpdater, TreeTN,
-    TruncationOptions,
+    apply_linear_operator, apply_local_update_sweep, random_treetn, ApplyOptions, CanonicalForm,
+    CanonicalizationOptions, IndexMapping, LinearOperator, LinkSpace, LinsolveOptions,
+    LocalUpdateSweepPlan, SiteIndexNetwork, SquareLinsolveUpdater, TreeTN, TruncationOptions,
 };
 
 /// Create an N-site all-ones MPS on a simple chain topology.
@@ -104,7 +103,7 @@ fn create_random_chain_mpo_with_internal_indices(
     }
 
     let mut rng = StdRng::seed_from_u64(seed);
-    let mpo = random_treetn_f64(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim));
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim));
     (mpo, s_in_tmp, s_out_tmp)
 }
 
@@ -270,9 +269,9 @@ fn main() -> anyhow::Result<()> {
         let x_aligned = x_full.permuteinds(&order_x)?;
         let ax_aligned = ax_full.permuteinds(&order_ax)?;
 
-        let ax_vec = ax_aligned.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_aligned.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
@@ -198,7 +198,7 @@ fn create_random_mpo_operator(
         let node_name = make_node_name(i);
 
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
-        let t = TensorDynLen::random_f64(rng, indices);
+        let t = TensorDynLen::random::<f64, _>(rng, indices);
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);
@@ -385,9 +385,9 @@ fn main() -> anyhow::Result<()> {
         let x_aligned = x_full.permuteinds(&order_x)?;
         let ax_aligned = ax_full.permuteinds(&order_ax)?;
 
-        let ax_vec = ax_aligned.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_aligned.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
 
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");

--- a/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
+++ b/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
@@ -327,9 +327,9 @@ fn compute_residual(
     let x_aligned = x_full.permuteinds(&order_x)?;
     let ax_aligned = ax_full.permuteinds(&order_ax)?;
 
-    let b_vec = b_full.to_vec_f64()?;
-    let x_vec = x_aligned.to_vec_f64()?;
-    let ax_vec = ax_aligned.to_vec_f64()?;
+    let b_vec = b_full.to_vec::<f64>()?;
+    let x_vec = x_aligned.to_vec::<f64>()?;
+    let ax_vec = ax_aligned.to_vec::<f64>()?;
     anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
     anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
+++ b/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
@@ -102,7 +102,7 @@ fn create_random_mps_chain_with_sites(
         } else {
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
-        let t = TensorDynLen::random_f64(rng, indices);
+        let t = TensorDynLen::random::<f64, _>(rng, indices);
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }

--- a/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
@@ -186,7 +186,7 @@ fn create_random_operator(
     for i in 0..n {
         let node_name = make_node_name(i);
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
-        let t = TensorDynLen::random_f64(rng, indices);
+        let t = TensorDynLen::random::<f64, _>(rng, indices);
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);
@@ -348,9 +348,9 @@ fn compute_rel_residual(
     let x_aligned = x_full.permuteinds(&order_x)?;
     let ax_aligned = ax_full.permuteinds(&order_ax)?;
 
-    let ax_vec = ax_aligned.to_vec_f64()?;
-    let x_vec = x_aligned.to_vec_f64()?;
-    let b_vec = b_full.to_vec_f64()?;
+    let ax_vec = ax_aligned.to_vec::<f64>()?;
+    let x_vec = x_aligned.to_vec::<f64>()?;
+    let b_vec = b_full.to_vec::<f64>()?;
 
     anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
     anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");

--- a/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
@@ -30,10 +30,9 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 use tensor4all_core::{DynIndex, TensorDynLen};
 use tensor4all_treetn::{
-    apply_linear_operator, apply_local_update_sweep, random_treetn_f64, ApplyOptions,
-    CanonicalForm, CanonicalizationOptions, IndexMapping, LinearOperator, LinkSpace,
-    LinsolveOptions, LocalUpdateSweepPlan, SiteIndexNetwork, SquareLinsolveUpdater, TreeTN,
-    TruncationOptions,
+    apply_linear_operator, apply_local_update_sweep, random_treetn, ApplyOptions, CanonicalForm,
+    CanonicalizationOptions, IndexMapping, LinearOperator, LinkSpace, LinsolveOptions,
+    LocalUpdateSweepPlan, SiteIndexNetwork, SquareLinsolveUpdater, TreeTN, TruncationOptions,
 };
 
 fn create_n_site_ones_mps(
@@ -178,7 +177,7 @@ fn create_random_chain_mpo_with_internal_indices(
     }
 
     let mut rng = StdRng::seed_from_u64(seed);
-    let mpo = random_treetn_f64(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim));
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim));
     (mpo, s_in_tmp, s_out_tmp)
 }
 
@@ -231,9 +230,9 @@ fn compute_rel_residual(
     let x_full = x.contract_to_tensor()?;
     let b_full = rhs.contract_to_tensor()?;
 
-    let ax_vec = ax_full.to_vec_f64()?;
-    let x_vec = x_full.to_vec_f64()?;
-    let b_vec = b_full.to_vec_f64()?;
+    let ax_vec = ax_full.to_vec::<f64>()?;
+    let x_vec = x_full.to_vec::<f64>()?;
+    let b_vec = b_full.to_vec::<f64>()?;
 
     anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
     anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
@@ -143,17 +143,17 @@ fn create_random_mps_with_same_sites(
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -414,9 +414,9 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
         let ax_full = ax.contract_to_tensor()?;
         let x_full = x.contract_to_tensor()?;
         let b_full = rhs.contract_to_tensor()?;
-        let ax_vec = ax_full.to_vec_f64()?;
-        let x_vec = x_full.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_full.to_vec::<f64>()?;
+        let x_vec = x_full.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
@@ -247,17 +247,17 @@ fn create_random_mps_with_same_sites(
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -477,7 +477,7 @@ fn run_test_case(
 
     // Print the actual vector representation of b
     let b_full = rhs.contract_to_tensor()?;
-    let b_vec = b_full.to_vec_f64()?;
+    let b_vec = b_full.to_vec::<f64>()?;
     println!("b (RHS) vector: {:?}", b_vec);
 
     // A = Pauli-X operator (non-diagonal, bit-flip operator)
@@ -525,9 +525,9 @@ fn run_test_case(
         let ax_full = ax.contract_to_tensor()?;
         let x_full = x.contract_to_tensor()?;
         let b_full = rhs.contract_to_tensor()?;
-        let ax_vec = ax_full.to_vec_f64()?;
-        let x_vec = x_full.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_full.to_vec::<f64>()?;
+        let x_vec = x_full.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
@@ -226,17 +226,17 @@ fn create_random_mps_with_same_sites(
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -504,8 +504,8 @@ fn run_test_case(
 
         let x_exact_full = x_exact.contract_to_tensor()?;
         let x_exact_x_full = x_exact_x.contract_to_tensor()?;
-        let x_exact_vec = x_exact_full.to_vec_f64()?;
-        let x_exact_x_vec = x_exact_x_full.to_vec_f64()?;
+        let x_exact_vec = x_exact_full.to_vec::<f64>()?;
+        let x_exact_x_vec = x_exact_x_full.to_vec::<f64>()?;
         anyhow::ensure!(
             x_exact_vec.len() == x_exact_x_vec.len(),
             "vector length mismatch"
@@ -627,9 +627,9 @@ fn run_test_case(
         let ax_full = ax.contract_to_tensor()?;
         let x_full = x.contract_to_tensor()?;
         let b_full = rhs.contract_to_tensor()?;
-        let ax_vec = ax_full.to_vec_f64()?;
-        let x_vec = x_full.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_full.to_vec::<f64>()?;
+        let x_vec = x_full.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 
@@ -652,8 +652,8 @@ fn run_test_case(
     let compute_exact_error = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
         let x_full = x.contract_to_tensor()?;
         let x_exact_full = x_exact.contract_to_tensor()?;
-        let x_vec = x_full.to_vec_f64()?;
-        let x_exact_vec = x_exact_full.to_vec_f64()?;
+        let x_vec = x_full.to_vec::<f64>()?;
+        let x_exact_vec = x_exact_full.to_vec::<f64>()?;
         anyhow::ensure!(x_vec.len() == x_exact_vec.len(), "vector length mismatch");
 
         let mut diff2 = 0.0_f64;

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
@@ -119,17 +119,17 @@ fn create_random_mps_with_same_sites(
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -309,9 +309,9 @@ fn run_test_case(init_mode: &str, bond_dim: usize) -> anyhow::Result<()> {
         let ax_full = ax.contract_to_tensor()?;
         let x_full = x.contract_to_tensor()?;
         let b_full = rhs.contract_to_tensor()?;
-        let ax_vec = ax_full.to_vec_f64()?;
-        let x_vec = x_full.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_full.to_vec::<f64>()?;
+        let x_vec = x_full.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
@@ -119,17 +119,17 @@ fn create_random_mps_with_same_sites(
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random_f64(
+            TensorDynLen::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -321,7 +321,7 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
 
     // Print the actual vector representation of b
     let b_full = rhs.contract_to_tensor()?;
-    let b_vec = b_full.to_vec_f64()?;
+    let b_vec = b_full.to_vec::<f64>()?;
     println!("b (RHS) vector: {:?}", b_vec);
 
     // A = I (diagonal MPO with ones)
@@ -369,9 +369,9 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
         let ax_full = ax.contract_to_tensor()?;
         let x_full = x.contract_to_tensor()?;
         let b_full = rhs.contract_to_tensor()?;
-        let ax_vec = ax_full.to_vec_f64()?;
-        let x_vec = x_full.to_vec_f64()?;
-        let b_vec = b_full.to_vec_f64()?;
+        let ax_vec = ax_full.to_vec::<f64>()?;
+        let x_vec = x_full.to_vec::<f64>()?;
+        let b_vec = b_full.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
@@ -185,7 +185,7 @@ fn create_random_mpo_matching_structure(
         let node_idx = mpo.node_index(&node_name).unwrap();
         let t = mpo.tensor(node_idx).unwrap();
         let indices = t.external_indices();
-        let new_t = TensorDynLen::random_f64(&mut rng, indices);
+        let new_t = TensorDynLen::random::<f64, _>(&mut rng, indices);
         mpo.replace_tensor(node_idx, new_t)?;
     }
     Ok(mpo)
@@ -203,7 +203,7 @@ fn create_random_mpo_matching_structure_c64(
         let node_idx = mpo.node_index(&node_name).unwrap();
         let t = mpo.tensor(node_idx).unwrap();
         let indices = t.external_indices();
-        let new_t = TensorDynLen::random_c64(&mut rng, indices);
+        let new_t = TensorDynLen::random::<Complex64, _>(&mut rng, indices);
         mpo.replace_tensor(node_idx, new_t)?;
     }
     Ok(mpo)
@@ -371,9 +371,9 @@ fn compute_residual(
     let x_aligned = x_full.permuteinds(&order_x)?;
     let ax_aligned = ax_full.permuteinds(&order_ax)?;
     if b_full.is_complex() {
-        let b_vec = b_full.to_vec_c64()?;
-        let x_vec = x_aligned.to_vec_c64()?;
-        let ax_vec = ax_aligned.to_vec_c64()?;
+        let b_vec = b_full.to_vec::<Complex64>()?;
+        let x_vec = x_aligned.to_vec::<Complex64>()?;
+        let ax_vec = ax_aligned.to_vec::<Complex64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 
@@ -389,9 +389,9 @@ fn compute_residual(
         let rel_res = if b2 > 0.0 { (r2 / b2).sqrt() } else { abs_res };
         Ok((abs_res, rel_res))
     } else {
-        let b_vec = b_full.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
-        let ax_vec = ax_aligned.to_vec_f64()?;
+        let b_vec = b_full.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
+        let ax_vec = ax_aligned.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
@@ -236,7 +236,7 @@ fn create_random_mpo_state_c64(
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
 
         // Create random complex tensor with shape [external, s_out, s_in]
-        let random_tensor = TensorDynLen::random_c64(
+        let random_tensor = TensorDynLen::random::<Complex64, _>(
             &mut rng,
             vec![
                 true_site_indices[i].clone(), // external index
@@ -548,7 +548,7 @@ fn print_operator_dense_matrix(
 
     println!("{label} (dense matrix {dim_out}x{dim_in}):");
     if t.is_complex() {
-        let data = t.to_vec_c64()?;
+        let data = t.to_vec::<Complex64>()?;
         anyhow::ensure!(
             data.len() == expected_len,
             "matrix print: length mismatch (got {}, expected {})",
@@ -568,7 +568,7 @@ fn print_operator_dense_matrix(
             println!("]");
         }
     } else {
-        let data = t.to_vec_f64()?;
+        let data = t.to_vec::<f64>()?;
         anyhow::ensure!(
             data.len() == expected_len,
             "matrix print: length mismatch (got {}, expected {})",
@@ -628,9 +628,9 @@ fn compute_residual(
     let x_aligned = x_full.permuteinds(&order_x)?;
     let ax_aligned = ax_full.permuteinds(&order_ax)?;
     if b_full.is_complex() {
-        let b_vec = b_full.to_vec_c64()?;
-        let x_vec = x_aligned.to_vec_c64()?;
-        let ax_vec = ax_aligned.to_vec_c64()?;
+        let b_vec = b_full.to_vec::<Complex64>()?;
+        let x_vec = x_aligned.to_vec::<Complex64>()?;
+        let ax_vec = ax_aligned.to_vec::<Complex64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 
@@ -646,9 +646,9 @@ fn compute_residual(
         let rel_res = if b2 > 0.0 { (r2 / b2).sqrt() } else { abs_res };
         Ok((abs_res, rel_res))
     } else {
-        let b_vec = b_full.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
-        let ax_vec = ax_aligned.to_vec_f64()?;
+        let b_vec = b_full.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
+        let ax_vec = ax_aligned.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 
@@ -695,8 +695,8 @@ fn compute_state_error(
     let x_aligned = x_full.permuteinds(&order_x)?;
 
     if x_true_full.is_complex() {
-        let x_true_vec = x_true_full.to_vec_c64()?;
-        let x_vec = x_aligned.to_vec_c64()?;
+        let x_true_vec = x_true_full.to_vec::<Complex64>()?;
+        let x_vec = x_aligned.to_vec::<Complex64>()?;
         anyhow::ensure!(x_vec.len() == x_true_vec.len(), "vector length mismatch");
 
         let mut diff2 = 0.0_f64;
@@ -714,8 +714,8 @@ fn compute_state_error(
         };
         Ok((abs_err, rel_err))
     } else {
-        let x_true_vec = x_true_full.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
+        let x_true_vec = x_true_full.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
         anyhow::ensure!(x_vec.len() == x_true_vec.len(), "vector length mismatch");
 
         let mut diff2 = 0.0_f64;
@@ -791,7 +791,7 @@ fn main() -> anyhow::Result<()> {
 
     // Display the vector representation of x_true
     let x_true_tensor = x_true_c64.contract_to_tensor()?;
-    let x_true_vec = x_true_tensor.to_vec_c64()?;
+    let x_true_vec = x_true_tensor.to_vec::<Complex64>()?;
 
     // Display x_true as matrix (n=2 sites with phys_dim=2 each gives 4x4 matrix)
     println!(

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
@@ -9,6 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use num_complex::Complex64;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tensor4all_core::{
@@ -313,7 +314,7 @@ fn create_random_mpo_state(
         // where external = true_site_indices[i] is the index that remains open.
         //
         // Create random tensor with shape [external, s_out, s_in]
-        let random_tensor = TensorDynLen::random_f64(
+        let random_tensor = TensorDynLen::random::<f64, _>(
             &mut rng,
             vec![
                 true_site_indices[i].clone(), // external index
@@ -443,9 +444,9 @@ fn compute_residual(
     let x_aligned = x_full.permuteinds(&order_x)?;
     let ax_aligned = ax_full.permuteinds(&order_ax)?;
     if b_full.is_complex() {
-        let b_vec = b_full.to_vec_c64()?;
-        let x_vec = x_aligned.to_vec_c64()?;
-        let ax_vec = ax_aligned.to_vec_c64()?;
+        let b_vec = b_full.to_vec::<Complex64>()?;
+        let x_vec = x_aligned.to_vec::<Complex64>()?;
+        let ax_vec = ax_aligned.to_vec::<Complex64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 
@@ -461,9 +462,9 @@ fn compute_residual(
         let rel_res = if b2 > 0.0 { (r2 / b2).sqrt() } else { abs_res };
         Ok((abs_res, rel_res))
     } else {
-        let b_vec = b_full.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
-        let ax_vec = ax_aligned.to_vec_f64()?;
+        let b_vec = b_full.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
+        let ax_vec = ax_aligned.to_vec::<f64>()?;
         anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
         anyhow::ensure!(x_vec.len() == b_vec.len(), "vector length mismatch");
 
@@ -510,8 +511,8 @@ fn compute_state_error(
     let x_aligned = x_full.permuteinds(&order_x)?;
 
     if x_true_full.is_complex() {
-        let x_true_vec = x_true_full.to_vec_c64()?;
-        let x_vec = x_aligned.to_vec_c64()?;
+        let x_true_vec = x_true_full.to_vec::<Complex64>()?;
+        let x_vec = x_aligned.to_vec::<Complex64>()?;
         anyhow::ensure!(x_vec.len() == x_true_vec.len(), "vector length mismatch");
 
         let mut diff2 = 0.0_f64;
@@ -529,8 +530,8 @@ fn compute_state_error(
         };
         Ok((abs_err, rel_err))
     } else {
-        let x_true_vec = x_true_full.to_vec_f64()?;
-        let x_vec = x_aligned.to_vec_f64()?;
+        let x_true_vec = x_true_full.to_vec::<f64>()?;
+        let x_vec = x_aligned.to_vec::<f64>()?;
         anyhow::ensure!(x_vec.len() == x_true_vec.len(), "vector length mismatch");
 
         let mut diff2 = 0.0_f64;

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use num_complex::Complex64;
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -56,7 +57,7 @@ fn create_random_mps_chain_with_sites_c64(
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
 
-        let t = TensorDynLen::random_c64(rng, indices);
+        let t = TensorDynLen::random::<Complex64, _>(rng, indices);
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -225,8 +226,8 @@ fn compute_residual(
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
     let ax_full = ax.contract_to_tensor()?;
     let b_full = rhs.contract_to_tensor()?;
-    let ax_vec = ax_full.to_vec_c64()?;
-    let b_vec = b_full.to_vec_c64()?;
+    let ax_vec = ax_full.to_vec::<Complex64>()?;
+    let b_vec = b_full.to_vec::<Complex64>()?;
     anyhow::ensure!(ax_vec.len() == b_vec.len(), "len mismatch");
     let mut diff2 = 0.0_f64;
     let mut b2 = 0.0_f64;

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
@@ -209,7 +209,7 @@ fn create_random_mps_chain_with_sites_c64(
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
 
-        let t = TensorDynLen::random_c64(rng, indices);
+        let t = TensorDynLen::random::<Complex64, _>(rng, indices);
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -298,8 +298,8 @@ fn compute_residual(
     let ax_order = order_for(&ax_full)?;
     let ax_aligned = ax_full.permuteinds(&ax_order)?;
 
-    let ax_vec = ax_aligned.to_vec_c64()?;
-    let b_vec = b_full.to_vec_c64()?;
+    let ax_vec = ax_aligned.to_vec::<Complex64>()?;
+    let b_vec = b_full.to_vec::<Complex64>()?;
     anyhow::ensure!(ax_vec.len() == b_vec.len(), "vector length mismatch");
 
     let mut diff2 = 0.0_f64;
@@ -345,8 +345,8 @@ fn compute_state_error(
     let x_order = order_for(&x_full)?;
     let x_aligned = x_full.permuteinds(&x_order)?;
 
-    let x_vec = x_aligned.to_vec_c64()?;
-    let x_true_vec = x_true_full.to_vec_c64()?;
+    let x_vec = x_aligned.to_vec::<Complex64>()?;
+    let x_true_vec = x_true_full.to_vec::<Complex64>()?;
     anyhow::ensure!(x_vec.len() == x_true_vec.len(), "vector length mismatch");
 
     let mut diff2 = 0.0_f64;

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -40,11 +40,11 @@ pub use named_graph::NamedGraph;
 pub use node_name_network::{CanonicalizeEdges, NodeNameNetwork};
 pub use operator::{
     apply_linear_operator, are_exclusive_operators, build_identity_operator_tensor,
-    build_identity_operator_tensor_c64, compose_exclusive_linear_operators, ApplyOptions,
-    ArcLinearOperator, IndexMapping, LinearOperator, Operator,
+    compose_exclusive_linear_operators, ApplyOptions, ArcLinearOperator, IndexMapping,
+    LinearOperator, Operator,
 };
 pub use options::{CanonicalizationOptions, SplitOptions, TruncationOptions};
-pub use random::{random_treetn_c64, random_treetn_f64, LinkSpace};
+pub use random::{random_treetn, LinkSpace};
 pub use site_index_network::SiteIndexNetwork;
 pub use treetn::{
     // Local update

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::random::{random_treetn_f64, LinkSpace};
+use crate::random::{random_treetn, LinkSpace};
 use crate::SiteIndexNetwork;
 use std::collections::HashSet;
 use tensor4all_core::index::{DynId, Index, TagSet};
@@ -35,7 +35,7 @@ fn test_linear_operator_tensor_index() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo = random_treetn_f64(&mut rng, &net, link_space);
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space);
 
     let true_s0 = make_index(2);
     let mut input_mapping = HashMap::new();
@@ -80,7 +80,7 @@ fn test_arc_linear_operator_cow() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo = random_treetn_f64(&mut rng, &net, link_space);
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space);
 
     let arc_op = ArcLinearOperator::new(mpo, HashMap::new(), HashMap::new());
 
@@ -361,7 +361,7 @@ fn test_linear_operator_replaceinds() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo = random_treetn_f64(&mut rng, &net, link_space);
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space);
 
     let true_s0 = make_index(2);
     let mut input_mapping = HashMap::new();

--- a/crates/tensor4all-treetn/src/operator/compose/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/compose/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::random::{random_treetn_f64, LinkSpace};
+use crate::random::{random_treetn, LinkSpace};
 use tensor4all_core::index::{DynId, Index, TagSet};
 use tensor4all_core::TensorDynLen;
 
@@ -79,8 +79,8 @@ fn test_are_exclusive_disjoint() {
     // Create TreeTNs with these networks
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let op1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let op2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     // Test exclusivity
     let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
@@ -109,8 +109,8 @@ fn test_are_exclusive_overlapping() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let op1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let op2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
     assert!(!result, "Overlapping operators should not be exclusive");
@@ -130,8 +130,8 @@ fn test_are_exclusive_single_node_operators() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let op1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let op2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
     assert!(result, "Single-node disjoint operators should be exclusive");
@@ -203,8 +203,8 @@ fn test_compose_exclusive_linear_operators_basic() {
     // Create TreeTNs for the operators
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     // True site indices (what the composed operator maps from/to)
     let true_s0 = make_index(2);
@@ -310,8 +310,8 @@ fn test_compose_exclusive_linear_operators_single_operators() {
     // Create TreeTNs
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     // True site indices
     let true_s0 = make_index(2);
@@ -384,8 +384,8 @@ fn test_compose_exclusive_linear_operators_no_gap() {
     // Create TreeTNs
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     // True site indices
     let true_s0 = make_index(2);
@@ -466,8 +466,8 @@ fn test_compose_exclusive_linear_operators_overlap_error() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     let lin_op1 = LinearOperator::new(mpo1, HashMap::new(), HashMap::new());
     let lin_op2 = LinearOperator::new(mpo2, HashMap::new(), HashMap::new());
@@ -518,8 +518,8 @@ fn test_compose_gap_identity_tensor_is_diagonal() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn_f64(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn_f64(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
 
     let true_s0 = make_index(2);
     let true_s2 = make_index(2);
@@ -571,7 +571,7 @@ fn test_compose_gap_identity_tensor_is_diagonal() {
     );
 
     // Check it's effectively an identity (only diagonal elements are non-zero)
-    let data = n1_tensor.as_slice_f64().expect("Expected DenseF64");
+    let data = n1_tensor.to_vec::<f64>().expect("Expected DenseF64");
 
     // For identity with dim-1 dummy links, data is still [1,0,0, 0,1,0, 0,0,1]
     let expected = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];

--- a/crates/tensor4all-treetn/src/operator/identity.rs
+++ b/crates/tensor4all-treetn/src/operator/identity.rs
@@ -6,9 +6,8 @@
 //! This module provides convenience wrappers around `TensorLike::delta()`.
 
 use anyhow::Result;
-use num_complex::Complex64;
 
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorLike};
+use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
 
 /// Build an identity operator tensor for a gap node.
 ///
@@ -39,81 +38,6 @@ pub fn build_identity_operator_tensor(
     output_site_indices: &[DynIndex],
 ) -> Result<TensorDynLen> {
     TensorDynLen::delta(site_indices, output_site_indices)
-}
-
-/// Build an identity operator tensor with complex data type.
-///
-/// Same as [`build_identity_operator_tensor`] but returns a complex tensor.
-pub fn build_identity_operator_tensor_c64(
-    site_indices: &[DynIndex],
-    output_site_indices: &[DynIndex],
-) -> Result<TensorDynLen> {
-    // Validate same number of input and output indices
-    if site_indices.len() != output_site_indices.len() {
-        return Err(anyhow::anyhow!(
-            "Number of input indices ({}) must match output indices ({})",
-            site_indices.len(),
-            output_site_indices.len()
-        ));
-    }
-
-    // Validate dimensions match
-    for (inp, out) in site_indices.iter().zip(output_site_indices.iter()) {
-        if inp.dim() != out.dim() {
-            return Err(anyhow::anyhow!(
-                "Dimension mismatch: input index has dim {}, output has dim {}",
-                inp.dim(),
-                out.dim(),
-            ));
-        }
-    }
-
-    if site_indices.is_empty() {
-        return Ok(TensorDynLen::scalar(Complex64::new(1.0, 0.0)).unwrap());
-    }
-
-    // Build combined index list
-    let mut all_indices: Vec<DynIndex> = Vec::with_capacity(site_indices.len() * 2);
-    let mut dims: Vec<usize> = Vec::with_capacity(site_indices.len() * 2);
-
-    for (inp, out) in site_indices.iter().zip(output_site_indices.iter()) {
-        all_indices.push(inp.clone());
-        all_indices.push(out.clone());
-        let dim = inp.dim();
-        dims.push(dim);
-        dims.push(dim);
-    }
-
-    let total_size: usize = dims.iter().product();
-
-    let n_pairs = site_indices.len();
-    let input_dims: Vec<usize> = site_indices.iter().map(|i| i.dim()).collect();
-    let input_total: usize = input_dims.iter().product();
-
-    let mut data = vec![Complex64::new(0.0, 0.0); total_size];
-
-    for input_linear in 0..input_total {
-        let mut input_multi = vec![0usize; n_pairs];
-        let mut remaining = input_linear;
-        for i in 0..n_pairs {
-            input_multi[i] = remaining % input_dims[i];
-            remaining /= input_dims[i];
-        }
-
-        let mut full_multi = vec![0usize; n_pairs * 2];
-        for i in 0..n_pairs {
-            full_multi[2 * i] = input_multi[i];
-            full_multi[2 * i + 1] = input_multi[i];
-        }
-
-        let mut linear_idx = 0usize;
-        for i in (0..full_multi.len()).rev() {
-            linear_idx = linear_idx * dims[i] + full_multi[i];
-        }
-        data[linear_idx] = Complex64::new(1.0, 0.0);
-    }
-
-    Ok(TensorDynLen::from_dense(all_indices, data).unwrap())
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-treetn/src/operator/identity/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/identity/tests/mod.rs
@@ -6,11 +6,7 @@ fn make_index(dim: usize) -> DynIndex {
 }
 
 fn get_f64_data(tensor: &TensorDynLen) -> Vec<f64> {
-    tensor.as_slice_f64().expect("Expected DenseF64 storage")
-}
-
-fn get_c64_data(tensor: &TensorDynLen) -> Vec<Complex64> {
-    tensor.as_slice_c64().expect("Expected DenseC64 storage")
+    tensor.to_vec::<f64>().expect("Expected DenseF64 storage")
 }
 
 #[test]
@@ -88,44 +84,44 @@ fn test_identity_empty() {
 }
 
 #[test]
-fn test_identity_c64() {
+fn test_identity_single_site_values() {
+    // The identity operator uses delta() which produces f64 tensors.
+    // Verify the values match the expected identity matrix pattern.
     let s_in = make_index(2);
     let s_out = make_index(2);
 
-    let tensor = build_identity_operator_tensor_c64(
-        std::slice::from_ref(&s_in),
-        std::slice::from_ref(&s_out),
-    )
-    .unwrap();
+    let tensor =
+        build_identity_operator_tensor(std::slice::from_ref(&s_in), std::slice::from_ref(&s_out))
+            .unwrap();
 
-    let data = get_c64_data(&tensor);
-    assert_eq!(data[0], Complex64::new(1.0, 0.0));
-    assert_eq!(data[1], Complex64::new(0.0, 0.0));
-    assert_eq!(data[2], Complex64::new(0.0, 0.0));
-    assert_eq!(data[3], Complex64::new(1.0, 0.0));
+    let data = get_f64_data(&tensor);
+    assert_eq!(data[0], 1.0);
+    assert_eq!(data[1], 0.0);
+    assert_eq!(data[2], 0.0);
+    assert_eq!(data[3], 1.0);
 }
 
 #[test]
-fn test_identity_c64_multi_site() {
-    // Test with multiple sites to cover the main loop in build_identity_operator_tensor_c64
+fn test_identity_multi_site_values() {
+    // Test with multiple sites to cover the delta() behavior for multi-site identity.
     let s1_in = make_index(2);
     let s1_out = make_index(2);
     let s2_in = make_index(2);
     let s2_out = make_index(2);
 
-    let tensor = build_identity_operator_tensor_c64(&[s1_in, s2_in], &[s1_out, s2_out]).unwrap();
+    let tensor = build_identity_operator_tensor(&[s1_in, s2_in], &[s1_out, s2_out]).unwrap();
 
     // Shape should be [2, 2, 2, 2] = 16 elements
     assert_eq!(tensor.dims(), vec![2, 2, 2, 2]);
-    let data = get_c64_data(&tensor);
+    let data = get_f64_data(&tensor);
     assert_eq!(data.len(), 16);
 
     // Diagonal elements should be 1, others 0
     // In identity operator, data[i, i, j, j] = 1 for all i, j
     // Linear index: (i1, o1, i2, o2) -> i1*8 + o1*4 + i2*2 + o2
     // (0,0,0,0)=0, (0,0,1,1)=3, (1,1,0,0)=12, (1,1,1,1)=15
-    assert_eq!(data[0], Complex64::new(1.0, 0.0));
-    assert_eq!(data[3], Complex64::new(1.0, 0.0));
-    assert_eq!(data[12], Complex64::new(1.0, 0.0));
-    assert_eq!(data[15], Complex64::new(1.0, 0.0));
+    assert_eq!(data[0], 1.0);
+    assert_eq!(data[3], 1.0);
+    assert_eq!(data[12], 1.0);
+    assert_eq!(data[15], 1.0);
 }

--- a/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
@@ -138,7 +138,7 @@ fn test_linear_operator_apply_local_identity() {
     let result = op.apply_local(&local_tensor, &["A".to_string()]).unwrap();
 
     // Identity operator should preserve the state
-    let result_data = result.to_vec_f64().unwrap();
+    let result_data = result.to_vec::<f64>().unwrap();
     assert_eq!(result_data.len(), 2);
     // Values should be approximately [1, 0]
     assert!((result_data[0] - 1.0).abs() < 1e-10);
@@ -357,7 +357,7 @@ fn test_apply_local_multi_node_region() {
         .unwrap();
 
     // Identity operator should preserve the state
-    let result_data = result.to_vec_f64().unwrap();
+    let result_data = result.to_vec::<f64>().unwrap();
     assert_eq!(result_data.len(), 4);
     assert!((result_data[0] - 1.0).abs() < 1e-10);
     for &v in &result_data[1..] {

--- a/crates/tensor4all-treetn/src/operator/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/mod.rs
@@ -35,7 +35,7 @@ mod linear_operator;
 
 pub use apply::{apply_linear_operator, ApplyOptions, ArcLinearOperator};
 pub use compose::{are_exclusive_operators, compose_exclusive_linear_operators};
-pub use identity::{build_identity_operator_tensor, build_identity_operator_tensor_c64};
+pub use identity::build_identity_operator_tensor;
 pub use index_mapping::IndexMapping;
 pub use linear_operator::LinearOperator;
 

--- a/crates/tensor4all-treetn/src/random.rs
+++ b/crates/tensor4all-treetn/src/random.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::{RandomScalar, TensorDynLen};
 
 /// Specification for link (bond) dimensions.
 ///
@@ -59,24 +59,25 @@ impl<V: Clone + Ord + Hash> LinkSpace<V> {
 /// Type alias for the default index type used in random generation.
 pub type DefaultIndex = Index<DynId, TagSet>;
 
-/// Create a random f64 TreeTN from a site index network.
+/// Create a random TreeTN from a site index network (generic over scalar type).
 ///
 /// Generates random tensors at each node with:
 /// - Site indices from the `site_network`
 /// - Link indices created according to `link_space`
+///
+/// # Type Parameters
+/// * `T` - Scalar type (e.g. `f64` or `Complex64`)
+/// * `R` - RNG type
+/// * `V` - Node name type
 ///
 /// # Arguments
 /// * `rng` - Random number generator for tensor data
 /// * `site_network` - Network topology and site (physical) indices
 /// * `link_space` - Specification for bond dimensions
 ///
-/// # Type Parameters
-/// * `R` - RNG type
-/// * `V` - Node name type
-///
 /// # Example
 /// ```
-/// use tensor4all_treetn::{SiteIndexNetwork, random_treetn_f64, LinkSpace};
+/// use tensor4all_treetn::{SiteIndexNetwork, random_treetn, LinkSpace};
 /// use tensor4all_core::index::{Index, DynId, TagSet};
 /// use rand::SeedableRng;
 /// use rand_chacha::ChaCha8Rng;
@@ -91,51 +92,17 @@ pub type DefaultIndex = Index<DynId, TagSet>;
 /// site_network.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
 ///
 /// let mut rng = ChaCha8Rng::seed_from_u64(42);
-/// let treetn = random_treetn_f64(&mut rng, &site_network, LinkSpace::uniform(4));
+/// let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::uniform(4));
 ///
 /// assert_eq!(treetn.node_count(), 2);
 /// ```
-pub fn random_treetn_f64<R, V>(
+pub fn random_treetn<T, R, V>(
     rng: &mut R,
     site_network: &SiteIndexNetwork<V, DefaultIndex>,
     link_space: LinkSpace<V>,
 ) -> TreeTN<TensorDynLen, V>
 where
-    R: Rng,
-    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
-{
-    random_treetn_impl(rng, site_network, link_space, false)
-}
-
-/// Create a random Complex64 TreeTN from a site index network.
-///
-/// Similar to [`random_treetn_f64`], but generates complex-valued tensors
-/// where both real and imaginary parts are drawn from standard normal distribution.
-///
-/// # Arguments
-/// * `rng` - Random number generator for tensor data
-/// * `site_network` - Network topology and site (physical) indices
-/// * `link_space` - Specification for bond dimensions
-pub fn random_treetn_c64<R, V>(
-    rng: &mut R,
-    site_network: &SiteIndexNetwork<V, DefaultIndex>,
-    link_space: LinkSpace<V>,
-) -> TreeTN<TensorDynLen, V>
-where
-    R: Rng,
-    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
-{
-    random_treetn_impl(rng, site_network, link_space, true)
-}
-
-/// Internal implementation for creating random TreeTN.
-fn random_treetn_impl<R, V>(
-    rng: &mut R,
-    site_network: &SiteIndexNetwork<V, DefaultIndex>,
-    link_space: LinkSpace<V>,
-    is_complex: bool,
-) -> TreeTN<TensorDynLen, V>
-where
+    T: RandomScalar,
     R: Rng,
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
@@ -189,11 +156,7 @@ where
         }
 
         // Create random tensor
-        let tensor = if is_complex {
-            TensorDynLen::random_c64(rng, all_indices)
-        } else {
-            TensorDynLen::random_f64(rng, all_indices)
-        };
+        let tensor = TensorDynLen::random::<T, R>(rng, all_indices);
 
         tensors.push(tensor);
         node_names.push(node_name);

--- a/crates/tensor4all-treetn/src/random/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/random/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use num_complex::Complex64;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use std::collections::HashSet;
@@ -20,7 +21,7 @@ fn test_random_treetn_f64_two_nodes() {
         .unwrap();
 
     let mut rng = ChaCha8Rng::seed_from_u64(42);
-    let treetn = random_treetn_f64(&mut rng, &site_network, LinkSpace::uniform(4));
+    let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::uniform(4));
 
     assert_eq!(treetn.node_count(), 2);
     assert_eq!(treetn.edge_count(), 1);
@@ -38,7 +39,7 @@ fn test_random_treetn_c64_chain() {
     site_network.add_edge(&1, &2).unwrap();
 
     let mut rng = ChaCha8Rng::seed_from_u64(123);
-    let treetn = random_treetn_c64(&mut rng, &site_network, LinkSpace::uniform(3));
+    let treetn = random_treetn::<Complex64, _, _>(&mut rng, &site_network, LinkSpace::uniform(3));
 
     assert_eq!(treetn.node_count(), 3);
     assert_eq!(treetn.edge_count(), 2);
@@ -68,7 +69,7 @@ fn test_link_space_per_edge() {
     dims.insert(("B".to_string(), "C".to_string()), 10);
 
     let mut rng = ChaCha8Rng::seed_from_u64(42);
-    let treetn = random_treetn_f64(&mut rng, &site_network, LinkSpace::per_edge(dims));
+    let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::per_edge(dims));
 
     assert_eq!(treetn.node_count(), 3);
     assert_eq!(treetn.edge_count(), 2);

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -100,7 +100,7 @@ fn test_contract_to_tensor_single_node() {
     assert_eq!(result.external_indices().len(), 2);
 
     // Verify the contracted single-node TN returns the tensor data itself
-    let result_data = result.to_vec_f64().unwrap();
+    let result_data = result.to_vec::<f64>().unwrap();
     let expected = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     assert_eq!(result_data.len(), expected.len());
     for (i, (&got, &exp)) in result_data.iter().zip(expected.iter()).enumerate() {
@@ -136,9 +136,9 @@ fn test_contract_to_tensor_two_nodes() {
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
-    let expected = t0.contract(&t1).to_vec_f64().unwrap();
+    let expected = t0.contract(&t1).to_vec::<f64>().unwrap();
 
-    let result_data = result.to_vec_f64().unwrap();
+    let result_data = result.to_vec::<f64>().unwrap();
     assert_eq!(result_data.len(), expected.len());
     for (i, (&got, &exp)) in result_data.iter().zip(expected.iter()).enumerate() {
         assert!(

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -1079,8 +1079,8 @@ fn test_contract_zipup_basic_api() {
 
     let mut rng1 = ChaCha8Rng::seed_from_u64(42);
     let mut rng2 = ChaCha8Rng::seed_from_u64(123);
-    let tn1 = random_treetn_f64(&mut rng1, &site_network1, LinkSpace::uniform(4));
-    let tn2 = random_treetn_f64(&mut rng2, &site_network2, LinkSpace::uniform(4));
+    let tn1 = random_treetn::<f64, _, _>(&mut rng1, &site_network1, LinkSpace::uniform(4));
+    let tn2 = random_treetn::<f64, _, _>(&mut rng2, &site_network2, LinkSpace::uniform(4));
 
     // Verify same_topology works
     assert!(tn1.same_topology(&tn2));
@@ -1282,8 +1282,8 @@ fn compare_contract_vs_naive(
     // Create two random TreeTNs
     let mut rng1 = ChaCha8Rng::seed_from_u64(seed1);
     let mut rng2 = ChaCha8Rng::seed_from_u64(seed2);
-    let tn1 = random_treetn_f64(&mut rng1, site_network, link_space.clone());
-    let tn2 = random_treetn_f64(&mut rng2, site_network, link_space);
+    let tn1 = random_treetn::<f64, _, _>(&mut rng1, site_network, link_space.clone());
+    let tn2 = random_treetn::<f64, _, _>(&mut rng2, site_network, link_space);
 
     // Contract using naive method (reference)
     let naive_result = tn1

--- a/crates/tensor4all-treetn/tests/issue192_regression.rs
+++ b/crates/tensor4all-treetn/tests/issue192_regression.rs
@@ -229,15 +229,15 @@ fn issue192_regression_no_svd_nan_n5_identity_ones() -> anyhow::Result<()> {
     }
 
     // Ensure the final state is finite.
-    // If NaN/Inf sneaks in, contract_to_tensor().to_vec_f64() should reveal it.
+    // If NaN/Inf sneaks in, contract_to_tensor().to_vec::<f64>() should reveal it.
     let x_full = x.contract_to_tensor().context("failed to contract x")?;
-    let x_vec = x_full.to_vec_f64().context("failed to materialize x")?;
+    let x_vec = x_full.to_vec::<f64>().context("failed to materialize x")?;
     anyhow::ensure!(x_vec.iter().all(|v| v.is_finite()), "x contains NaN/Inf");
 
     // Also ensure applying the linear operator does not introduce NaN/Inf.
     let ax = tensor4all_treetn::apply_linear_operator(&linop, &x, ApplyOptions::default())?;
     let ax_full = ax.contract_to_tensor()?;
-    let ax_vec = ax_full.to_vec_f64()?;
+    let ax_vec = ax_full.to_vec::<f64>()?;
     anyhow::ensure!(ax_vec.iter().all(|v| v.is_finite()), "Ax contains NaN/Inf");
 
     Ok(())

--- a/crates/tensor4all-treetn/tests/linsolve.rs
+++ b/crates/tensor4all-treetn/tests/linsolve.rs
@@ -519,7 +519,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
     let contracted = x.contract_to_tensor().unwrap();
 
     // Extract solution values
-    let solution_values: Vec<f64> = contracted.to_vec_f64().unwrap();
+    let solution_values: Vec<f64> = contracted.to_vec::<f64>().unwrap();
 
     // Compare with exact solution.
     // `TreeTN::contract_to_tensor` permutes indices into canonical site order, so
@@ -1025,7 +1025,7 @@ fn test_linear_operator_apply_local() {
 
     // Check values - the diagonal operator at site0 has value 2.0
     // D|0⟩ = 2.0 * |0⟩ = [2.0, 0.0]
-    let values: Vec<f64> = result_tensor.to_vec_f64().unwrap();
+    let values: Vec<f64> = result_tensor.to_vec::<f64>().unwrap();
 
     // Output shape is (phys_dim, bond_dim) = (2, 1) so values has 2 elements
     assert!(
@@ -1117,7 +1117,7 @@ fn test_linear_operator_apply_local_two_sites() {
     assert!(has_site1, "Result should have site1's true index");
 
     // Check values
-    let values: Vec<f64> = result_tensor.to_vec_f64().unwrap();
+    let values: Vec<f64> = result_tensor.to_vec::<f64>().unwrap();
 
     // D|00⟩ = 6.0 * |00⟩
     assert!(
@@ -1287,7 +1287,7 @@ fn test_linsolve_with_index_mappings_diagonal() {
     // Expected solution: D*x = b => x = b/6 = [1, 0, 0, 0]
     // Contract solution to get full tensor using contract_to_tensor
     let contracted = x.contract_to_tensor().unwrap();
-    let values: Vec<f64> = contracted.to_vec_f64().unwrap();
+    let values: Vec<f64> = contracted.to_vec::<f64>().unwrap();
 
     // Solution should be approximately [1, 0, 0, 0]
     assert!(
@@ -1635,7 +1635,7 @@ fn test_linsolve_pauli_x() {
     let contracted = x.contract_to_tensor().unwrap();
 
     // Extract solution values
-    let solution_values: Vec<f64> = contracted.to_vec_f64().unwrap();
+    let solution_values: Vec<f64> = contracted.to_vec::<f64>().unwrap();
 
     // Compare with exact solution
     assert_eq!(
@@ -1804,7 +1804,7 @@ fn test_linsolve_general_matrix() {
     let contracted = x.contract_to_tensor().unwrap();
 
     // Extract solution values
-    let solution_values: Vec<f64> = contracted.to_vec_f64().unwrap();
+    let solution_values: Vec<f64> = contracted.to_vec::<f64>().unwrap();
 
     // Compare with exact solution
     assert_eq!(
@@ -1887,7 +1887,7 @@ fn test_linsolve_general_matrix_nonsymmetric() {
     }
 
     let contracted = x.contract_to_tensor().unwrap();
-    let solution_values: Vec<f64> = contracted.to_vec_f64().unwrap();
+    let solution_values: Vec<f64> = contracted.to_vec::<f64>().unwrap();
 
     assert_eq!(solution_values.len(), exact_solution.len());
 

--- a/crates/tensor4all-treetn/tests/ops.rs
+++ b/crates/tensor4all-treetn/tests/ops.rs
@@ -288,7 +288,7 @@ fn test_evaluate_two_nodes() {
 
     // Get the dense representation for reference
     let dense = tn.to_dense().unwrap();
-    let dense_data = dense.as_slice_f64().unwrap();
+    let dense_data = dense.to_vec::<f64>().unwrap();
 
     // Get ordered site indices to know mapping
     let site_inds_0 = tn
@@ -337,7 +337,7 @@ fn test_evaluate_three_nodes() {
 
     // Get dense for reference
     let dense = tn.to_dense().unwrap();
-    let dense_data = dense.as_slice_f64().unwrap();
+    let dense_data = dense.to_vec::<f64>().unwrap();
 
     let dim0 = tn.site_space(&0).unwrap().iter().next().unwrap().dim();
     let dim1 = tn.site_space(&1).unwrap().iter().next().unwrap().dim();


### PR DESCRIPTION
## Summary

- Add `StorageScalar` trait and generic `Storage::from_dense_col_major<T>`, `from_diag_col_major<T>`, `new_dense<T>`, `new_diag<T>`, `new_structured<T>`, `sum<T>()`
- Add `RandomScalar` trait and generic `TensorDynLen::to_vec<T>()`, `TensorDynLen::random<T, R>()`
- Add generic `random_treetn<T, R, V>()`
- Remove scalar-specific wrappers: `to_vec_f64/c64`, `sum_f64`, `random_f64/c64`, `qr_c64`, `svd_c64`, `diag_tensor_dyn_len_c64`, `random_treetn_f64/c64`, `build_identity_operator_tensor_c64`, `Storage::new_dense_f64/c64`, `new_diag_f64/c64`, `new_structured_f64/c64`, `sum_f64/c64`
- Migrate all callers across 78 files (~730 insertions, ~890 deletions)
- C API (`tensor4all-capi`) left unchanged (out of scope per issue)

## Test plan

- [x] `cargo nextest run --release --workspace` — 1605 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test --release --workspace --doc` — all doc tests pass

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)