### PR TITLE
refactor: remove mdarray from quanticstransform, bump tenferro rev (#322)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ bnum = "0.12"
 uint = "0.10"
 libc = "0.2"
 paste = "1.0"
-mdarray = "0.7.2"
 faer = "0.23"
 thiserror = "2.0"
 rand = "0.9"
@@ -51,9 +50,9 @@ omeco = "0.2.1"
 hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs", rev = "cfc26f3103604c581c2da2bd8defb6abed2218f5" }
-tenferro-algebra = { git = "https://github.com/tensor4all/tenferro-rs", rev = "cfc26f3103604c581c2da2bd8defb6abed2218f5" }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs", rev = "cfc26f3103604c581c2da2bd8defb6abed2218f5" }
-tenferro-prims = { git = "https://github.com/tensor4all/tenferro-rs", rev = "cfc26f3103604c581c2da2bd8defb6abed2218f5" }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs", rev = "cfc26f3103604c581c2da2bd8defb6abed2218f5" }
-tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs", rev = "cfc26f3103604c581c2da2bd8defb6abed2218f5" }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs", rev = "8e8cc83" }
+tenferro-algebra = { git = "https://github.com/tensor4all/tenferro-rs", rev = "8e8cc83" }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs", rev = "8e8cc83" }
+tenferro-prims = { git = "https://github.com/tensor4all/tenferro-rs", rev = "8e8cc83" }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs", rev = "8e8cc83" }
+tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs", rev = "8e8cc83" }

--- a/crates/tensor4all-quanticstransform/Cargo.toml
+++ b/crates/tensor4all-quanticstransform/Cargo.toml
@@ -24,7 +24,6 @@ num-traits.workspace = true
 num-rational = "0.4"
 num-integer = "0.1"
 anyhow.workspace = true
-mdarray.workspace = true
 sprs = "0.11"
 
 [dev-dependencies]

--- a/crates/tensor4all-quanticstransform/src/affine.rs
+++ b/crates/tensor4all-quanticstransform/src/affine.rs
@@ -9,7 +9,6 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use mdarray::DTensor;
 use num_complex::Complex64;
 use num_integer::Integer;
 use num_rational::Rational64;
@@ -20,6 +19,7 @@ use tensor4all_simplett::{types::tensor3_zeros, AbstractTensorTrain, Tensor3Ops,
 use crate::common::{
     tensortrain_to_linear_operator_asymmetric, BoundaryCondition, QuanticsOperator,
 };
+use crate::dense_array::DenseArray;
 
 /// Affine transformation parameters.
 ///
@@ -381,7 +381,7 @@ pub fn affine_transform_tensors_unfused(
     r: usize,
     params: &AffineParams,
     bc: &[BoundaryCondition],
-) -> Result<Vec<DTensor<Complex64, 3>>> {
+) -> Result<Vec<DenseArray<Complex64>>> {
     if r == 0 {
         return Err(anyhow::anyhow!("Number of bits must be positive"));
     }
@@ -465,16 +465,19 @@ pub fn affine_transform_tensors_unfused(
             }
         }
 
-        // Create DTensor with shape [left_dim, site_dim, right_dim]
+        // Create DenseArray with shape [left_dim, site_dim, right_dim]
         // The caller can reshape this to [left_dim, 2, 2, ..., 2, right_dim]
         // with the understanding that the indices are ordered as (y0, y1, ..., x0, x1, ...)
-        let unfused_tensor =
-            DTensor::<Complex64, 3>::from_fn([left_dim, site_dim, right_dim], |idx| {
-                let l = idx[0];
-                let s = idx[1];
-                let r = idx[2];
-                unfused_data[l * site_dim * right_dim + s * right_dim + r]
-            });
+        let mut unfused_tensor =
+            DenseArray::from_elem(&[left_dim, site_dim, right_dim], Complex64::new(0.0, 0.0));
+        for l in 0..left_dim {
+            for s in 0..site_dim {
+                for r in 0..right_dim {
+                    unfused_tensor[[l, s, r]] =
+                        unfused_data[l * site_dim * right_dim + s * right_dim + r];
+                }
+            }
+        }
 
         unfused_tensors.push(unfused_tensor);
     }
@@ -645,7 +648,7 @@ fn affine_transform_tensors(
         // We process from outermost to innermost
         let mut current_weights = bc_weights;
         for ext_data in ext_data_list.iter().rev() {
-            let (_, num_cin, _) = *ext_data.tensor.shape();
+            let num_cin = ext_data.tensor.dims()[1];
             let mut new_weights = vec![0.0; num_cin];
             for (cin_idx, nw) in new_weights.iter_mut().enumerate() {
                 for (cout_idx, &w) in current_weights.iter().enumerate() {
@@ -688,7 +691,7 @@ fn affine_transform_tensors(
         // idx=0 corresponds to site R-1 (LSB), idx=R-1 corresponds to site 0 (MSB)
         let actual_site = r - 1 - idx;
         let num_carry_out = core_data.carries_out.len();
-        let (_, num_carry_in, _) = *core_data.tensor.shape();
+        let num_carry_in = core_data.tensor.dims()[1];
 
         // Tensor shape follows shift.rs pattern:
         // t[left, site, right] where left=carry_out (going left), right=carry_in (from right)
@@ -774,7 +777,7 @@ struct AffineCoreData {
     /// Possible outgoing carry vectors
     carries_out: Vec<Vec<i64>>,
     /// Tensor data: tensor[carry_out_idx, carry_in_idx, site_idx]
-    tensor: DTensor<bool, 3>,
+    tensor: DenseArray<bool>,
 }
 
 /// Compute a single core tensor for the affine transformation.
@@ -793,7 +796,7 @@ fn affine_transform_core(
     carries_in: &[Vec<i64>],
     activebit: bool,
 ) -> Result<AffineCoreData> {
-    let mut carry_out_map: HashMap<Vec<i64>, DTensor<bool, 2>> = HashMap::new();
+    let mut carry_out_map: HashMap<Vec<i64>, DenseArray<bool>> = HashMap::new();
     let x_range = if activebit { 1 << n } else { 1 };
     let y_range = if activebit { 1 << m } else { 1 };
     let site_dim = x_range * y_range;
@@ -839,9 +842,9 @@ fn affine_transform_core(
                 // Site index: y bits in lower positions, x bits in upper positions
                 let site_idx = y_bits | (x_bits << m);
 
-                let entry = carry_out_map.entry(carry_out).or_insert_with(|| {
-                    DTensor::<bool, 2>::from_elem([num_carry_in, site_dim], false)
-                });
+                let entry = carry_out_map
+                    .entry(carry_out)
+                    .or_insert_with(|| DenseArray::from_elem(&[num_carry_in, site_dim], false));
                 entry[[c_idx, site_idx]] = true;
             } else {
                 // Scale is even: z must be even for valid y
@@ -862,9 +865,9 @@ fn affine_transform_core(
 
                     let site_idx = y_bits | (x_bits << m);
 
-                    let entry = carry_out_map.entry(carry_out).or_insert_with(|| {
-                        DTensor::<bool, 2>::from_elem([num_carry_in, site_dim], false)
-                    });
+                    let entry = carry_out_map
+                        .entry(carry_out)
+                        .or_insert_with(|| DenseArray::from_elem(&[num_carry_in, site_dim], false));
                     entry[[c_idx, site_idx]] = true;
                 }
             }
@@ -878,7 +881,7 @@ fn affine_transform_core(
     let num_carry_out = carries_out.len();
 
     // Build 3D tensor: (num_carry_out, num_carry_in, site_dim)
-    let mut tensor = DTensor::<bool, 3>::from_elem([num_carry_out, num_carry_in, site_dim], false);
+    let mut tensor = DenseArray::from_elem(&[num_carry_out, num_carry_in, site_dim], false);
     for (cout_idx, carry) in carries_out.iter().enumerate() {
         let data_2d = &carry_out_map[carry];
         for cin_idx in 0..num_carry_in {

--- a/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
@@ -779,8 +779,8 @@ fn test_affine_unfused_basic() {
     // For M=1, N=1, site_dim = 2^2 = 4
     let site_dim = 4;
     // For identity transform y=x, carry is always 0, so bond dimension is 1
-    assert_eq!(*unfused[0].shape(), (1, site_dim, 1)); // First tensor: (1, 4, 1)
-    assert_eq!(*unfused[r - 1].shape(), (1, site_dim, 1)); // Last tensor: (1, 4, 1)
+    assert_eq!(unfused[0].dims(), &[1, site_dim, 1]); // First tensor: [1, 4, 1]
+    assert_eq!(unfused[r - 1].dims(), &[1, site_dim, 1]); // Last tensor: [1, 4, 1]
 }
 
 #[test]
@@ -797,7 +797,7 @@ fn test_affine_unfused_2d() {
     // For M=2, N=2, site_dim = 2^4 = 16
     let site_dim = 16;
     for tensor in &unfused {
-        assert_eq!(tensor.shape().1, site_dim);
+        assert_eq!(tensor.dims()[1], site_dim);
     }
 }
 
@@ -870,7 +870,8 @@ fn test_unfused_vs_fused_equivalence() {
 
                 let site_idx = y_bits | (x_bits << m);
                 let tensor = &unfused[site];
-                let (left_dim, _, right_dim) = *tensor.shape();
+                let left_dim = tensor.dims()[0];
+                let right_dim = tensor.dims()[2];
 
                 let mut new_vec = vec![Complex64::new(0.0, 0.0); right_dim];
                 for l in 0..left_dim.min(left_vec.len()) {

--- a/crates/tensor4all-quanticstransform/src/binaryop.rs
+++ b/crates/tensor4all-quanticstransform/src/binaryop.rs
@@ -5,12 +5,12 @@
 //! a, b ∈ {-1, 0, 1}.
 
 use anyhow::Result;
-use mdarray::DTensor;
 use num_complex::Complex64;
 use num_traits::{One, Zero};
 use tensor4all_simplett::{types::tensor3_zeros, Tensor3Ops, TensorTrain};
 
 use crate::common::{tensortrain_to_linear_operator, BoundaryCondition, QuanticsOperator};
+use crate::dense_array::DenseArray;
 
 /// Coefficients for binary operation.
 /// Each coefficient must be -1, 0, or 1.
@@ -237,14 +237,13 @@ fn binaryop_tensor_single(
     cin_on: bool,
     cout_on: bool,
     bc: i8,
-) -> DTensor<Complex64, 5> {
+) -> DenseArray<Complex64> {
     let cin_states: Vec<i8> = if cin_on { vec![-1, 0, 1] } else { vec![0] };
     let cin_size = cin_states.len();
     let cout_size = if cout_on { 3 } else { 1 };
 
     // tensor[cin, cout, x, y, out] - shape: (cin_size, cout_size, 2, 2, 2)
-    let mut tensor =
-        DTensor::<Complex64, 5>::from_elem([cin_size, cout_size, 2, 2, 2], Complex64::zero());
+    let mut tensor = DenseArray::from_elem(&[cin_size, cout_size, 2, 2, 2], Complex64::zero());
 
     for (idx_cin, &cin) in cin_states.iter().enumerate() {
         for x in 0..2i8 {

--- a/crates/tensor4all-quanticstransform/src/binaryop/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/binaryop/tests/mod.rs
@@ -22,7 +22,7 @@ fn test_binary_coeffs_invalid() {
 fn test_binaryop_tensor_single() {
     // Test (1, 1) coefficients (sum)
     let tensor = binaryop_tensor_single(1, 1, false, false, 1);
-    assert_eq!(*tensor.shape(), (1, 1, 2, 2, 2)); // (cin_size, cout_size, x, y, out)
+    assert_eq!(tensor.dims(), &[1, 1, 2, 2, 2]); // (cin_size, cout_size, x, y, out)
 
     // x=0, y=0: result=0, out=0
     assert_eq!(tensor[[0, 0, 0, 0, 0]], Complex64::one());

--- a/crates/tensor4all-quanticstransform/src/dense_array.rs
+++ b/crates/tensor4all-quanticstransform/src/dense_array.rs
@@ -1,0 +1,75 @@
+//! Simple dense multi-dimensional array with row-major storage.
+//!
+//! This is a lightweight local helper used internally to replace `mdarray::DTensor`.
+//! It supports arbitrary element types and dynamic rank with row-major indexing.
+
+use std::ops::{Index, IndexMut};
+
+/// A dense multi-dimensional array stored in row-major (C) order.
+///
+/// `DenseArray<T>` stores data in a flat `Vec<T>` with row-major strides.
+/// It supports arbitrary element types (no trait bounds on `T` for the struct itself).
+#[derive(Clone, Debug)]
+pub struct DenseArray<T> {
+    data: Vec<T>,
+    dims: Vec<usize>,
+    /// Row-major strides: strides[i] = product of dims[i+1..].
+    strides: Vec<usize>,
+}
+
+impl<T: Clone> DenseArray<T> {
+    /// Create a new array filled with `value`.
+    pub fn from_elem(dims: &[usize], value: T) -> Self {
+        let total: usize = dims.iter().product();
+        let strides = compute_row_major_strides(dims);
+        Self {
+            data: vec![value; total],
+            dims: dims.to_vec(),
+            strides,
+        }
+    }
+}
+
+impl<T> DenseArray<T> {
+    /// Return the dimensions (shape) of the array.
+    pub fn dims(&self) -> &[usize] {
+        &self.dims
+    }
+
+    /// Compute the flat index for a given multi-dimensional index.
+    fn flat_index(&self, idx: &[usize]) -> usize {
+        debug_assert_eq!(idx.len(), self.dims.len());
+        idx.iter()
+            .zip(self.strides.iter())
+            .map(|(&i, &s)| i * s)
+            .sum()
+    }
+}
+
+impl<T, const N: usize> Index<[usize; N]> for DenseArray<T> {
+    type Output = T;
+    fn index(&self, idx: [usize; N]) -> &T {
+        let flat = self.flat_index(&idx);
+        &self.data[flat]
+    }
+}
+
+impl<T, const N: usize> IndexMut<[usize; N]> for DenseArray<T> {
+    fn index_mut(&mut self, idx: [usize; N]) -> &mut T {
+        let flat = self.flat_index(&idx);
+        &mut self.data[flat]
+    }
+}
+
+/// Compute row-major strides for given dimensions.
+fn compute_row_major_strides(dims: &[usize]) -> Vec<usize> {
+    let rank = dims.len();
+    let mut strides = vec![0usize; rank];
+    if rank > 0 {
+        strides[rank - 1] = 1;
+        for i in (0..rank - 1).rev() {
+            strides[i] = strides[i + 1] * dims[i + 1];
+        }
+    }
+    strides
+}

--- a/crates/tensor4all-quanticstransform/src/fourier.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier.rs
@@ -5,7 +5,6 @@
 //! Discrete Fourier Transform as a Matrix Product Operator", arXiv:2404.03182.
 
 use anyhow::Result;
-use mdarray::DTensor;
 use num_complex::Complex64;
 use num_traits::Zero;
 use std::f64::consts::PI;
@@ -16,6 +15,7 @@ use tensor4all_simplett::{
 };
 
 use crate::common::{tensortrain_to_linear_operator, QuanticsOperator};
+use crate::dense_array::DenseArray;
 
 /// Options for Fourier transform construction.
 #[derive(Clone, Debug)]
@@ -289,11 +289,11 @@ fn lagrange_polynomial(grid: &[f64], bary_weights: &[f64], alpha: usize, x: f64)
 /// where x = (sigma + grid[beta]) / 2
 ///
 /// Returns tensor of shape (k+1, 2, 2, k+1)
-fn build_dft_core_tensor(grid: &[f64], bary_weights: &[f64], sign: f64) -> DTensor<Complex64, 4> {
+fn build_dft_core_tensor(grid: &[f64], bary_weights: &[f64], sign: f64) -> DenseArray<Complex64> {
     let k = grid.len() - 1;
 
     // tensor[alpha, tau, sigma, beta] - shape: (k+1, 2, 2, k+1)
-    let mut tensor = DTensor::<Complex64, 4>::from_elem([k + 1, 2, 2, k + 1], Complex64::zero());
+    let mut tensor = DenseArray::from_elem(&[k + 1, 2, 2, k + 1], Complex64::zero());
 
     for alpha in 0..=k {
         for tau in 0..2 {

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -33,10 +33,14 @@ mod affine;
 mod binaryop;
 mod common;
 mod cumsum;
+/// Simple dense multi-dimensional array helper.
+pub mod dense_array;
 mod flip;
 mod fourier;
 mod phase_rotation;
 mod shift;
+
+pub use dense_array::DenseArray;
 
 pub use affine::{
     affine_operator, affine_transform_matrix, affine_transform_tensors_unfused, AffineParams,

--- a/crates/tensor4all-simplett/src/mpo/contract_fit.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit.rs
@@ -9,6 +9,8 @@ use super::factorize::{FactorizeMethod, SVDScalar};
 use super::mpo::MPO;
 use super::site_mpo::SiteMPO;
 use super::types::{Tensor4, Tensor4Ops};
+use tenferro_linalg::LinalgScalar;
+use tenferro_tensor::KeepCountScalar;
 
 /// Options for the variational fit algorithm
 #[derive(Debug, Clone)]
@@ -59,6 +61,7 @@ pub fn contract_fit<T: SVDScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
+    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo_a.len() != mpo_b.len() {
         return Err(MPOError::LengthMismatch {

--- a/crates/tensor4all-simplett/src/mpo/contract_naive.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive.rs
@@ -10,6 +10,8 @@ use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
 use super::types::{tensor4_zeros, Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
+use tenferro_linalg::LinalgScalar;
+use tenferro_tensor::KeepCountScalar;
 
 /// Perform naive contraction of two MPOs
 ///
@@ -37,6 +39,7 @@ pub fn contract_naive<T: SVDScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
+    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo_a.len() != mpo_b.len() {
         return Err(MPOError::LengthMismatch {
@@ -92,6 +95,7 @@ where
 fn compress_mpo<T: SVDScalar>(mpo: &mut MPO<T>, options: &ContractionOptions) -> Result<()>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
+    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo.len() <= 1 {
         return Ok(());

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
@@ -9,6 +9,8 @@ use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
 use super::types::{tensor4_zeros, Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
+use tenferro_linalg::LinalgScalar;
+use tenferro_tensor::KeepCountScalar;
 
 /// Perform zip-up contraction of two MPOs
 ///
@@ -40,6 +42,7 @@ pub fn contract_zipup<T: SVDScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
+    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo_a.len() != mpo_b.len() {
         return Err(MPOError::LengthMismatch {

--- a/crates/tensor4all-simplett/src/mpo/dispatch.rs
+++ b/crates/tensor4all-simplett/src/mpo/dispatch.rs
@@ -22,6 +22,8 @@ use super::contraction::ContractionOptions;
 use super::error::Result;
 use super::factorize::SVDScalar;
 use super::mpo::MPO;
+use tenferro_linalg::LinalgScalar;
+use tenferro_tensor::KeepCountScalar;
 
 /// Unified contraction function with algorithm dispatch
 ///
@@ -62,6 +64,7 @@ pub fn contract<T: SVDScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
+    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     match algorithm {
         ContractionAlgorithm::Naive => contract_naive(mpo_a, mpo_b, Some(options.clone())),

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -8,7 +8,7 @@ use super::Matrix2;
 use num_complex::{Complex64, ComplexFloat};
 use tenferro_algebra::Scalar as TfScalar;
 use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
+use tenferro_tensor::{KeepCountScalar, MemoryOrder, Tensor as TypedTensor};
 use tensor4all_tensorbackend::{svd_backend, BackendLinalgScalar};
 
 /// Factorization method to use
@@ -113,7 +113,10 @@ impl SVDScalar for Complex64 {
 pub fn factorize<T: SVDScalar>(
     matrix: &Matrix2<T>,
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<T>> {
+) -> Result<FactorizeResult<T>>
+where
+    <T as LinalgScalar>::Real: KeepCountScalar,
+{
     match options.method {
         FactorizeMethod::SVD => factorize_svd(matrix, options),
         FactorizeMethod::RSVD => factorize_rsvd(matrix, options),
@@ -192,7 +195,10 @@ where
 fn factorize_svd<T: SVDScalar>(
     matrix: &Matrix2<T>,
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<T>> {
+) -> Result<FactorizeResult<T>>
+where
+    <T as LinalgScalar>::Real: KeepCountScalar,
+{
     let m = matrix.dim(0);
     let n = matrix.dim(1);
 

--- a/crates/tensor4all-simplett/src/vidal.rs
+++ b/crates/tensor4all-simplett/src/vidal.rs
@@ -17,7 +17,7 @@ use num_complex::ComplexFloat;
 use num_traits::ToPrimitive;
 use tenferro_algebra::Scalar as TfScalar;
 use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
+use tenferro_tensor::{KeepCountScalar, MemoryOrder, Tensor as TypedTensor};
 use tensor4all_tensorbackend::{svd_backend, BackendLinalgScalar};
 
 /// Compute QR decomposition
@@ -92,7 +92,7 @@ where
 fn svd_factorize_right_matrix<T>(matrix: &Matrix<T>) -> Result<(Matrix<T>, DiagMatrix, Matrix<T>)>
 where
     T: TTScalar + Scalar + Default + ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-    <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive,
+    <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
 {
     let rows = nrows(matrix);
     let cols = ncols(matrix);
@@ -198,7 +198,7 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
     pub fn from_tensor_train(tt: &TensorTrain<T>) -> Result<Self>
     where
         T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive,
+        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
     {
         Self::from_tensor_train_with_partition(tt, 0..tt.len())
     }
@@ -210,7 +210,7 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
     ) -> Result<Self>
     where
         T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive,
+        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
     {
         let n = tt.len();
         if n == 0 {
@@ -608,7 +608,7 @@ impl<T: TTScalar + Scalar + Default> InverseTensorTrain<T> {
     pub fn from_tensor_train(tt: &TensorTrain<T>) -> Result<Self>
     where
         T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive,
+        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
     {
         let vidal = VidalTensorTrain::from_tensor_train(tt)?;
         Self::from_vidal(&vidal)

--- a/crates/tensor4all-tensorbackend/src/backend.rs
+++ b/crates/tensor4all-tensorbackend/src/backend.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Result};
 use num_complex::ComplexFloat;
 use tenferro_algebra::Scalar as TfScalar;
 use tenferro_linalg::{qr as tenferro_qr, svd as tenferro_svd, KernelLinalgScalar, LinalgScalar};
-use tenferro_tensor::Tensor as TypedTensor;
+use tenferro_tensor::{KeepCountScalar, Tensor as TypedTensor};
 
 use crate::tenferro_bridge::with_tenferro_ctx;
 
@@ -35,7 +35,7 @@ impl<T> BackendLinalgScalar for T where T: LinalgScalar + KernelLinalgScalar {}
 pub fn svd_backend<T>(a: &TypedTensor<T>) -> Result<SvdResult<T>>
 where
     T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-    <T as LinalgScalar>::Real: TfScalar + Copy,
+    <T as LinalgScalar>::Real: TfScalar + Copy + KeepCountScalar,
 {
     let decomp = with_tenferro_ctx("svd", |ctx| {
         tenferro_svd(ctx, a, None)


### PR DESCRIPTION
## Summary

- Bump tenferro rev to `8e8cc83` (includes `Scalar` bound removal from `Tensor<T>`)
- Add lightweight `DenseArray<T>` helper for row-major multi-dimensional arrays (supports `bool`, `Complex64`, etc.)
- Replace all `mdarray::DTensor` usage in quanticstransform with `DenseArray`
- Remove `mdarray` from workspace dependencies — **no crate in the workspace uses mdarray anymore**

## Test plan

- [x] `cargo nextest run --release -p tensor4all-quanticstransform` — all tests pass
- [x] `cargo nextest run --release --workspace` — all tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)