### PR TITLE
fix: single-site TT add, scalar contraction, Python type check

### DIFF
--- a/crates/tensor4all-treetn/src/treetn/addition.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 
 use anyhow::Result;
 
-use tensor4all_core::{IndexLike, TensorLike};
+use tensor4all_core::{AnyScalar, IndexLike, TensorLike};
 
 use super::TreeTN;
 
@@ -201,6 +201,16 @@ where
 
                 bond_pairs.push((self_bond.clone(), other_bond.clone()));
                 neighbors_for_edges.push(neighbor);
+            }
+
+            // For nodes with no bonds (single-node network), use element-wise addition
+            // instead of direct_sum (which requires at least one index pair).
+            if bond_pairs.is_empty() {
+                let sum_tensor =
+                    tensor_a.axpby(AnyScalar::new_real(1.0), tensor_b, AnyScalar::new_real(1.0))?;
+                result_tensors.push(sum_tensor);
+                result_node_names.push(node_name);
+                continue;
             }
 
             // Compute direct sum

--- a/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
@@ -131,3 +131,28 @@ fn test_add_topology_mismatch() {
     let result = tn_a.add(&tn_b);
     assert!(result.is_err());
 }
+
+/// Regression test for #353: add() failed for single-site TTs (no bond indices).
+#[test]
+fn test_add_single_site() {
+    let s = DynIndex::new_dyn(3);
+
+    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = TensorDynLen::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0]).unwrap();
+
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+
+    let result = tn_a.add(&tn_b).unwrap();
+    assert_eq!(result.node_count(), 1);
+
+    let dense = result.contract_to_tensor().unwrap();
+    let expected = TensorDynLen::from_dense(vec![s.clone()], vec![11.0, 22.0, 33.0]).unwrap();
+    assert!(
+        dense.isapprox(&expected, 1e-10, 0.0),
+        "single-site add failed: maxabs diff = {}",
+        (&dense - &expected).maxabs()
+    );
+}

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -911,6 +911,14 @@ where
     // 1. Contract to full tensor using existing contract_naive
     let contracted_tensor = tn_a.contract_naive(tn_b)?;
 
+    // Handle rank-0 (scalar) result: wrap directly in a single-node TreeTN
+    if contracted_tensor.external_indices().is_empty() {
+        let mut tn = TreeTN::<T, V>::new();
+        tn.add_tensor(center.clone(), contracted_tensor)?;
+        tn.set_canonical_region([center.clone()])?;
+        return Ok(tn);
+    }
+
     // 2. Build topology from tn_a's structure and decompose
     use super::decompose::factorize_tensor_to_treetn_with;
 

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -244,3 +244,30 @@ fn test_find_common_indices_no_common() {
     let common = find_common_indices(&t_a, &t_b);
     assert_eq!(common.len(), 0);
 }
+
+/// Regression test for #352: naive contraction fails when result is rank 0 (scalar).
+#[test]
+fn test_naive_contraction_scalar_result() {
+    // Two single-site TreeTNs that share an index → contraction produces a scalar
+    let s = DynIndex::new_dyn(3);
+
+    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 1.0, 1.0]).unwrap();
+
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+
+    // Naive contraction: inner product = 1+2+3 = 6
+    let result = contract_naive_to_treetn(&tn_a, &tn_b, &"A".to_string(), None, None).unwrap();
+
+    assert_eq!(result.node_count(), 1);
+    let dense = result.contract_to_tensor().unwrap();
+    let val = dense.sum().real();
+    assert!(
+        (val - 6.0).abs() < 1e-10,
+        "scalar contraction expected 6.0, got {}",
+        val
+    );
+}

--- a/python/tensor4all/src/tensor4all/quanticstransform.py
+++ b/python/tensor4all/src/tensor4all/quanticstransform.py
@@ -38,14 +38,26 @@ class LinearOperator:
         Parameters
         ----------
         state : TreeTensorNetwork
-            Input MPS/TreeTN.
+            Input MPS/TreeTN. Note: SimpleTensorTrain is not directly
+            supported; convert to TreeTensorNetwork first.
         method : str
             "naive", "zipup", or "fit".
         rtol : float
             Relative tolerance (0.0 = default).
         maxdim : int
             Maximum bond dimension (0 = unlimited).
+
+        Raises
+        ------
+        TypeError
+            If state is not a TreeTensorNetwork (e.g. SimpleTensorTrain).
         """
+        if not isinstance(state, TreeTensorNetwork):
+            raise TypeError(
+                f"LinearOperator.apply() requires a TreeTensorNetwork, "
+                f"got {type(state).__name__}. "
+                f"Convert SimpleTensorTrain to TreeTensorNetwork first."
+            )
         lib = get_lib()
         method_int = {"naive": 0, "zipup": 1, "fit": 2}.get(method)
         if method_int is None:


### PR DESCRIPTION
## Summary

- **#353**: `TreeTN::add()` failed for single-site TTs (no bond indices) because `direct_sum` rejects empty index pairs. Now uses element-wise `axpby` for bondless nodes.
- **#352**: `contract_naive_to_treetn` failed when the contraction result is rank-0 (scalar). Now detects rank-0 and wraps directly in a single-node TreeTN.
- **#358**: Python `LinearOperator.apply()` gave `AttributeError` when passed a `SimpleTensorTrain` (has `_ptr`, not `_handle`). Now raises `TypeError` with a clear message.

Closes #352, #353, #358

## Test plan

- [x] Added regression test `test_add_single_site` (single-node TreeTN addition)
- [x] Added regression test `test_naive_contraction_scalar_result` (rank-0 contraction)
- [x] Full workspace: 1728 passed, 9 skipped
- [x] `cargo clippy --workspace --tests` clean
- [x] `cargo fmt --check --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)