### PR TITLE
docs: improve READMEs and re-export AbstractTensorTrain

### DIFF
--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -10,21 +10,29 @@ ITensors.jl-inspired high-level API for Tensor Train (MPS) operations with ortho
 - **Contraction**: Contract two tensor trains (zipup, fit, or naive method)
 - **Inner products**: Efficient norm and inner product computation
 
-## Usage
+## Important Conventions
 
-This low-level constructor takes `TensorDynLen` values from `tensor4all-core`.
+- **Column-major data layout**: `TensorDynLen::from_dense` expects data in column-major
+  (Fortran) order. For a 2x3 matrix, provide `[a00, a10, a01, a11, a02, a12]`.
+- **Inner product conjugation**: `inner()` computes `<self|other>` with complex conjugation
+  on `self` (the left argument).
+- **0-indexed sites**: Sites are 0-indexed (unlike Julia's 1-indexed convention).
+
+## Usage
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
+use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen, TensorLike};
+use tensor4all_itensorlike::{TensorTrain, TruncateOptions, CanonicalForm};
 
+// Create indices: site indices + bond indices
 let s0 = DynIndex::new_dyn(2);
 let s1 = DynIndex::new_dyn(2);
 let s2 = DynIndex::new_dyn(2);
 let b01 = DynIndex::new_bond(2)?;
 let b12 = DynIndex::new_bond(2)?;
 
+// Build tensors (column-major data layout)
 let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
 let t1 = TensorDynLen::from_dense(
     vec![b01.clone(), s1.clone(), b12.clone()],
@@ -32,12 +40,52 @@ let t1 = TensorDynLen::from_dense(
 )?;
 let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
 
+// Create tensor train and orthogonalize
 let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 tt.orthogonalize(1)?;
+
+// Truncate with SVD
 tt.truncate(&TruncateOptions::svd().with_rtol(1e-10).with_max_rank(2))?;
 
 assert!(tt.isortho());
-assert!(tt.norm().is_finite());
+
+// Norm and inner product
+let norm = tt.norm();
+assert!(norm.is_finite());
+
+// Inner product: <tt|tt> = norm^2
+let inner = tt.inner(&tt);
+assert!((inner.real() - norm * norm).abs() < 1e-10);
+# Ok(())
+# }
+```
+
+### Complex64 Example
+
+```rust
+# fn main() -> anyhow::Result<()> {
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_itensorlike::TensorTrain;
+
+let s0 = DynIndex::new_dyn(2);
+let s1 = DynIndex::new_dyn(2);
+let b = DynIndex::new_bond(2)?;
+
+let t0 = TensorDynLen::from_dense(
+    vec![s0, b.clone()],
+    vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0),
+         Complex64::new(0.0, -1.0), Complex64::new(1.0, 0.0)],
+)?;
+let t1 = TensorDynLen::from_dense(
+    vec![b, s1],
+    vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0),
+         Complex64::new(0.0, 0.0), Complex64::new(1.0, 0.0)],
+)?;
+
+let tt = TensorTrain::new(vec![t0, t1])?;
+let norm = tt.norm();
+assert!(norm > 0.0);
 # Ok(())
 # }
 ```
@@ -51,6 +99,7 @@ assert!(tt.norm().is_finite());
   - A half-sweep visits edges in one direction only (forward or backward)
   - `nhalfsweeps=2` means 1 full sweep (forward + backward)
   - This matches ITensorMPS.jl's `nsweeps` semantics when `reverse_step=false`
+- **Convenience**: `with_nsweeps(n)` is equivalent to `with_nhalfsweeps(2 * n)`
 
 ## License
 

--- a/crates/tensor4all-quanticstci/src/lib.rs
+++ b/crates/tensor4all-quanticstci/src/lib.rs
@@ -83,4 +83,5 @@ pub use quantics_tci::{
 
 // Re-export commonly used types from dependencies
 pub use quanticsgrids::{DiscretizedGrid, InherentDiscreteGrid, UnfoldingScheme};
+pub use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
 pub use tensor4all_tensorci::{PivotSearchStrategy, Scalar, TCI2Options, TensorCI2};

--- a/crates/tensor4all-quanticstransform/README.md
+++ b/crates/tensor4all-quanticstransform/README.md
@@ -18,6 +18,17 @@ This crate provides `LinearOperator` constructors for various transformations in
 
 All transformations return `LinearOperator` from `tensor4all-treetn` for consistent operator application to tensor train states.
 
+**Terminology**: The parameter `r` refers to the number of quantics bits (sites) per variable. A single variable is discretized on 2^r grid points.
+
+## Error Conditions
+
+All operator constructors return `Err` for invalid inputs:
+- `r == 0`: No sites to operate on
+- `r == 1` for `cumsum_operator`, `triangle_operator`, `quantics_fourier_operator`: Requires at least 2 sites
+- `r >= 64` for `shift_operator`: Would overflow 64-bit integer
+- NaN or Inf `theta` for `phase_rotation_operator`: Invalid rotation angle
+- `BinaryCoeffs(-1, -1)` for `binaryop_single_operator`: This combination is not supported
+
 ## Usage
 
 ```rust
@@ -173,6 +184,20 @@ let options = ApplyOptions::fit()
     .with_max_bond_dim(32)
     .with_max_iterations(100);
 ```
+
+## Fourier Transform Convention
+
+The quantics Fourier transform (`quantics_fourier_operator`) produces output in **bit-reversed order**. This is inherent to the QFT algorithm: the output site ordering corresponds to the bit-reversal of the frequency index.
+
+## Multi-Variable Encoding
+
+The `_multivar` variants (`flip_operator_multivar`, `shift_operator_multivar`, `phase_rotation_operator_multivar`) use **interleaved bit encoding** for multiple variables:
+
+```text
+site index s_n encodes: bit_var0 + 2 * bit_var1 + 4 * bit_var2 + ...
+```
+
+Each site holds one bit from each variable, packed into a single local dimension of size `2^num_vars`.
 
 ## Big-Endian Convention
 

--- a/crates/tensor4all-treetn/README.md
+++ b/crates/tensor4all-treetn/README.md
@@ -14,34 +14,104 @@ Tree tensor network (TreeTN) implementation for general tensor networks beyond l
 
 ## Usage
 
+### Creating a TreeTN with `from_tensors`
+
+The easiest way to build a TreeTN: provide tensors with shared bond indices
+and they are auto-connected.
+
 ```rust
-use anyhow::Result;
-use rand::rng;
-use tensor4all_core::index::{DynId, Index};
-use tensor4all_core::TensorDynLen;
-use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
+# fn main() -> anyhow::Result<()> {
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_treetn::TreeTN;
 
-// Build a simple 2-node TreeTN: A -- B (shared bond index)
-let bond = Index::<DynId>::new_dyn(10);
-let a_site = Index::<DynId>::new_dyn(2);
-let b_site = Index::<DynId>::new_dyn(2);
+// 3-site MPS chain: t0 -- t1 -- t2
+let s0 = DynIndex::new_dyn(2);
+let s1 = DynIndex::new_dyn(2);
+let s2 = DynIndex::new_dyn(2);
+let b01 = DynIndex::new_dyn(3);
+let b12 = DynIndex::new_dyn(3);
 
-let mut rng = rng();
-let a = TensorDynLen::random::<f64, _>(&mut rng, vec![a_site.clone(), bond.clone()]);
-let b = TensorDynLen::random::<f64, _>(&mut rng, vec![bond.clone(), b_site.clone()]);
+let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 6])?;
+let t1 = TensorDynLen::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 12])?;
+let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![1.0; 6])?;
 
-let mut ttn = TreeTN::<TensorDynLen, String>::new();
-let node_a = ttn.add_tensor("A".to_string(), a)?;
-let node_b = ttn.add_tensor("B".to_string(), b)?;
-ttn.connect(node_a, &bond, node_b, &bond)?;
+let ttn = TreeTN::<TensorDynLen, usize>::from_tensors(
+    vec![t0, t1, t2],
+    vec![0, 1, 2],
+)?;
+assert_eq!(ttn.node_count(), 3);
+assert_eq!(ttn.edge_count(), 2);
+# Ok(())
+# }
+```
 
-// Canonicalize towards center node B
-let ttn = ttn.canonicalize(["B".to_string()], CanonicalizationOptions::default())?;
+### Canonicalization and Truncation
+
+```rust
+# fn main() -> anyhow::Result<()> {
+# use tensor4all_core::{DynIndex, TensorDynLen};
+# use tensor4all_treetn::TreeTN;
+use tensor4all_treetn::{CanonicalizationOptions, TruncationOptions};
+# let s0 = DynIndex::new_dyn(2);
+# let s1 = DynIndex::new_dyn(2);
+# let b = DynIndex::new_dyn(4);
+# let t0 = TensorDynLen::from_dense(vec![s0, b.clone()], vec![1.0; 8])?;
+# let t1 = TensorDynLen::from_dense(vec![b, s1], vec![1.0; 8])?;
+# let ttn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
+
+// Canonicalize towards node 0
+let ttn = ttn.canonicalize([0], CanonicalizationOptions::default())?;
 
 // Truncate bond dimensions
-let ttn = ttn.truncate(["B".to_string()], TruncationOptions::default().with_max_rank(5))?;
+let ttn = ttn.truncate([0], TruncationOptions::default().with_max_rank(2))?;
+# Ok(())
+# }
+```
 
-# Ok::<(), anyhow::Error>(())
+### Norm and Dense Conversion
+
+```rust
+# fn main() -> anyhow::Result<()> {
+# use tensor4all_core::{DynIndex, TensorDynLen};
+# use tensor4all_treetn::TreeTN;
+# let s0 = DynIndex::new_dyn(2);
+# let b = DynIndex::new_dyn(2);
+# let s1 = DynIndex::new_dyn(2);
+# let t0 = TensorDynLen::from_dense(vec![s0, b.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+# let t1 = TensorDynLen::from_dense(vec![b, s1], vec![1.0, 0.0, 0.0, 1.0])?;
+# let mut ttn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
+
+// Compute norm (canonicalizes internally)
+let norm = ttn.norm()?;
+assert!(norm > 0.0);
+
+// Convert to a single dense tensor (contracts all bonds)
+let dense = ttn.to_dense()?;
+# Ok(())
+# }
+```
+
+### Addition
+
+```rust
+# fn main() -> anyhow::Result<()> {
+# use tensor4all_core::{DynIndex, TensorDynLen};
+# use tensor4all_treetn::TreeTN;
+# let s = DynIndex::new_dyn(2);
+# let b_a = DynIndex::new_dyn(2);
+# let b_b = DynIndex::new_dyn(2);
+# let ta0 = TensorDynLen::from_dense(vec![s.clone(), b_a.clone()], vec![1.0; 4])?;
+# let ta1 = TensorDynLen::from_dense(vec![b_a, s.clone()], vec![1.0; 4])?;
+# let tb0 = TensorDynLen::from_dense(vec![s.clone(), b_b.clone()], vec![2.0; 4])?;
+# let tb1 = TensorDynLen::from_dense(vec![b_b, s.clone()], vec![2.0; 4])?;
+# let tn_a = TreeTN::<TensorDynLen, usize>::from_tensors(vec![ta0, ta1], vec![0, 1])?;
+# let tn_b = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tb0, tb1], vec![0, 1])?;
+
+// Add two TreeTNs with same topology (uses direct sum on bonds)
+let sum = tn_a.add(&tn_b)?;
+// Bond dimension of sum = bond_dim(a) + bond_dim(b)
+# Ok(())
+# }
 ```
 
 ## Sweep Counting


### PR DESCRIPTION
## Summary

- **#368**: Re-export `AbstractTensorTrain` and `TensorTrain` from `tensor4all-quanticstci` so `tensor_train()` consumers don't need an explicit `tensor4all-simplett` dependency.
- **#350**: Expand treetn README with `from_tensors`, canonicalize/truncate, norm/to_dense, and addition examples.
- **#355**: Expand itensorlike README with column-major data layout convention, inner product conjugation, Complex64 example, and `with_nsweeps` note.
- **#361**: Add error conditions section, Fourier bit-reversal convention, multi-variable encoding, and terminology note to quanticstransform README.

Closes #350, #355, #361, #368

## Test plan

- [x] `cargo test --release --doc` passes for all modified crates
- [x] Full workspace: 1728 passed, 9 skipped
- [x] `cargo clippy --workspace --tests` clean
- [x] `cargo fmt --check --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)