### PR TITLE
feat: add TensorDynLen::backward() and TreeTN AD integration tests

### DIFF
--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -28,3 +28,4 @@ tenferro-tensor.workspace = true
 
 [dev-dependencies]
 rand_chacha.workspace = true
+tenferro-prims.workspace = true

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -262,6 +262,26 @@ impl TensorDynLen {
             .map_err(|e| anyhow::anyhow!("TensorDynLen::zero_grad failed: {e}"))
     }
 
+    /// Runs reverse-mode AD backward pass from this tensor.
+    ///
+    /// Accumulates gradients on all input tensors that have `requires_grad == true`.
+    ///
+    /// # Arguments
+    /// * `grad_output` - Optional gradient seed. Pass `None` for default (ones).
+    /// * `inputs` - Leaf tensors to accumulate gradients on. After this call,
+    ///   each input's `.grad()` will contain the accumulated gradient.
+    pub fn backward(&self, grad_output: Option<&Self>, inputs: &[&Self]) -> Result<()> {
+        let grad_native = grad_output.map(|g| &g.native);
+        let input_natives: Vec<&NativeTensor> = inputs.iter().map(|t| &t.native).collect();
+        self.native
+            .backward(
+                grad_native,
+                &input_natives,
+                tenferro::BackwardOptions::default(),
+            )
+            .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}"))
+    }
+
     /// Check if this tensor is already in canonical form.
     pub fn is_simple(&self) -> bool {
         true

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -217,3 +217,84 @@ fn plain_diag_storage_auto_seeds_native_diag_payload() {
     assert_eq!(tensor.mode(), AdMode::Primal);
     assert!(is_diag_tensor(&tensor));
 }
+
+// ---------------------------------------------------------------------------
+// Backward (reverse-mode) AD tests
+// ---------------------------------------------------------------------------
+
+use tensor4all_core::{contract_multi, AllowedPairs};
+
+fn with_runtime<R>(f: impl FnOnce() -> R) -> R {
+    let _guard = tenferro::set_default_runtime(tenferro::RuntimeContext::Cpu(
+        tenferro_prims::CpuContext::new(1),
+    ));
+    f()
+}
+
+#[test]
+fn backward_ad_contraction_accumulates_gradient() {
+    with_runtime(|| {
+        let i = Index::new_dyn(3);
+
+        let mut a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+        a.set_requires_grad(true).unwrap();
+
+        let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
+
+        // f = contract(a, ones) = dot product = 1+2+3 = 6; df/da = [1,1,1]
+        let result = contract_multi(&[&a, &ones], AllowedPairs::All).unwrap();
+        assert!(
+            result.indices().is_empty(),
+            "contraction result should be rank-0"
+        );
+
+        result.backward(None, &[&a]).unwrap();
+
+        let grad = a.grad().expect("gradient missing after backward");
+        let grad_vec = grad.to_vec::<f64>().unwrap();
+        for (j, &g) in grad_vec.iter().enumerate() {
+            assert!((g - 1.0).abs() < 1e-10, "grad[{j}] = {g}, expected 1.0");
+        }
+    });
+}
+
+#[test]
+fn backward_ad_gradient_matches_finite_diff() {
+    with_runtime(|| {
+        let i = Index::new_dyn(2);
+        let j = Index::new_dyn(2);
+        let eps = 1e-6;
+
+        // f(A) = contract(A, A) over all indices = sum(|a_ij|^2)
+        // df/da_ij = 2 * conj(a_ij) = 2 * a_ij (real case)
+        let data = vec![1.0, 2.0, 3.0, 4.0];
+
+        let mut a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
+        a.set_requires_grad(true).unwrap();
+
+        let result = contract_multi(&[&a, &a], AllowedPairs::All).unwrap();
+        result.backward(None, &[&a]).unwrap();
+
+        let grad = a.grad().expect("gradient missing");
+        let grad_vec = grad.to_vec::<f64>().unwrap();
+
+        for idx in 0..data.len() {
+            let f_eval = |delta: f64| -> f64 {
+                let mut d = data.clone();
+                d[idx] += delta;
+                let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], d).unwrap();
+                contract_multi(&[&t, &t], AllowedPairs::All)
+                    .unwrap()
+                    .to_vec::<f64>()
+                    .unwrap()[0]
+            };
+            let fd = (f_eval(eps) - f_eval(-eps)) / (2.0 * eps);
+            let ad = grad_vec[idx];
+            let err = (ad - fd).abs();
+            assert!(
+                err < 1e-4,
+                "backward grad[{idx}] = {ad}, finite diff = {fd}, err = {err}"
+            );
+        }
+    });
+}

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -19,4 +19,6 @@ faer = { workspace = true }
 
 [dev-dependencies]
 rand_chacha.workspace = true
+tenferro.workspace = true
+tenferro-prims.workspace = true
 

--- a/crates/tensor4all-treetn/tests/ad_treetn.rs
+++ b/crates/tensor4all-treetn/tests/ad_treetn.rs
@@ -1,0 +1,302 @@
+//! Tests for automatic differentiation through TreeTN operations.
+//!
+//! Forward-mode: verifies tangent propagation through canonicalize, truncate, to_dense.
+//! Backward-mode: verifies gradient accumulation through to_dense.
+
+use tensor4all_core::{
+    contract_multi, forward_ad, AllowedPairs, DynIndex, IndexLike, TensorDynLen,
+};
+use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
+
+fn make_three_site_mps_data() -> (Vec<Vec<DynIndex>>, Vec<Vec<f64>>) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let bond01 = DynIndex::new_dyn(2);
+    let bond12 = DynIndex::new_dyn(2);
+
+    let index_sets = vec![
+        vec![s0, bond01.clone()],
+        vec![bond01, s1, bond12.clone()],
+        vec![bond12, s2],
+    ];
+
+    let data = vec![
+        vec![1.0, 0.5, 0.3, 2.0],
+        vec![3.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, 2.0],
+        vec![1.5, 0.2, 0.4, 1.0],
+    ];
+
+    (index_sets, data)
+}
+
+fn with_runtime<R>(f: impl FnOnce() -> R) -> R {
+    let _guard = tenferro::set_default_runtime(tenferro::RuntimeContext::Cpu(
+        tenferro_prims::CpuContext::new(1),
+    ));
+    f()
+}
+
+// ---------------------------------------------------------------------------
+// Forward-mode AD tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn forward_ad_to_dense_preserves_tangent() {
+    let (index_sets, data) = make_three_site_mps_data();
+
+    forward_ad::dual_level(|fw| {
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .map(|(idx, d)| {
+                let primal = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
+                let tangent = TensorDynLen::from_dense(idx.clone(), vec![1.0; d.len()]).unwrap();
+                fw.make_dual(&primal, &tangent).unwrap()
+            })
+            .collect();
+
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        let dense = ttn.to_dense().unwrap();
+
+        let (_primal, tangent) = fw.unpack_dual(&dense)?;
+        assert!(tangent.is_some(), "to_dense lost tangent");
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn forward_ad_canonicalize_preserves_tangent() {
+    let (index_sets, data) = make_three_site_mps_data();
+
+    forward_ad::dual_level(|fw| {
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .map(|(idx, d)| {
+                let primal = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
+                let tangent = TensorDynLen::from_dense(idx.clone(), vec![0.1; d.len()]).unwrap();
+                fw.make_dual(&primal, &tangent).unwrap()
+            })
+            .collect();
+
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        let ttn = ttn.canonicalize([1], CanonicalizationOptions::default())?;
+
+        for node_idx in ttn.node_indices() {
+            let tensor = ttn.tensor(node_idx).unwrap();
+            let (_primal, tangent) = fw.unpack_dual(tensor)?;
+            assert!(
+                tangent.is_some(),
+                "canonicalize lost tangent at {:?}",
+                node_idx
+            );
+        }
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn forward_ad_truncate_preserves_tangent() {
+    let (index_sets, data) = make_three_site_mps_data();
+
+    forward_ad::dual_level(|fw| {
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .map(|(idx, d)| {
+                let primal = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
+                let tangent = TensorDynLen::from_dense(idx.clone(), vec![0.1; d.len()]).unwrap();
+                fw.make_dual(&primal, &tangent).unwrap()
+            })
+            .collect();
+
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        let ttn = ttn.truncate([1], TruncationOptions::default().with_max_rank(1))?;
+
+        for node_idx in ttn.node_indices() {
+            let tensor = ttn.tensor(node_idx).unwrap();
+            let (_primal, tangent) = fw.unpack_dual(tensor)?;
+            assert!(tangent.is_some(), "truncate lost tangent at {:?}", node_idx);
+        }
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn forward_ad_dense_value_matches_finite_diff() {
+    let (index_sets, data) = make_three_site_mps_data();
+    let eps = 1e-7;
+    let perturb_idx = 0;
+    let perturb_dir: Vec<f64> = vec![1.0, 0.0, 0.0, 0.0];
+
+    let tangent_sum = forward_ad::dual_level(|fw| {
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .enumerate()
+            .map(|(i, (idx, d))| {
+                let primal = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
+                let tangent_data = if i == perturb_idx {
+                    perturb_dir.clone()
+                } else {
+                    vec![0.0; d.len()]
+                };
+                let tangent = TensorDynLen::from_dense(idx.clone(), tangent_data).unwrap();
+                fw.make_dual(&primal, &tangent).unwrap()
+            })
+            .collect();
+
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        let dense = ttn.to_dense().unwrap();
+        let (_primal, tangent) = fw.unpack_dual(&dense)?;
+        Ok(tangent.expect("tangent missing").sum())
+    })
+    .unwrap();
+
+    let make_mps_sum = |perturbation: f64| -> f64 {
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .enumerate()
+            .map(|(i, (idx, d))| {
+                let mut d = d.clone();
+                if i == perturb_idx {
+                    for (j, val) in d.iter_mut().enumerate() {
+                        *val += perturbation * perturb_dir[j];
+                    }
+                }
+                TensorDynLen::from_dense(idx.clone(), d).unwrap()
+            })
+            .collect();
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        ttn.to_dense().unwrap().sum().real()
+    };
+
+    let fd = (make_mps_sum(eps) - make_mps_sum(-eps)) / (2.0 * eps);
+    let ad = tangent_sum.real();
+    let err = (ad - fd).abs();
+    assert!(
+        err < 1e-5,
+        "forward AD ({ad}) vs finite diff ({fd}): err={err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Backward-mode AD tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backward_ad_to_dense_propagates_gradients() {
+    with_runtime(|| {
+        let (index_sets, data) = make_three_site_mps_data();
+
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .map(|(idx, d)| {
+                let mut t = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
+                t.set_requires_grad(true).unwrap();
+                t
+            })
+            .collect();
+
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        let dense = ttn.to_dense().unwrap();
+
+        // Contract dense with ones to get scalar = sum(dense)
+        let ones = TensorDynLen::from_dense(
+            dense.indices().to_vec(),
+            vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
+        )
+        .unwrap();
+        let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
+
+        // Collect input tensors from inside the TreeTN
+        let node_tensors: Vec<&TensorDynLen> = ttn
+            .node_indices()
+            .iter()
+            .map(|&ni| ttn.tensor(ni).unwrap())
+            .collect();
+        scalar.backward(None, &node_tensors).unwrap();
+
+        for (i, &ni) in ttn.node_indices().iter().enumerate() {
+            let grad = ttn.tensor(ni).unwrap().grad();
+            assert!(grad.is_some(), "node {i} has no gradient after backward");
+        }
+    });
+}
+
+#[test]
+fn backward_ad_gradient_matches_finite_diff() {
+    with_runtime(|| {
+        let (index_sets, data) = make_three_site_mps_data();
+        let eps = 1e-6;
+
+        let tensors: Vec<TensorDynLen> = index_sets
+            .iter()
+            .zip(&data)
+            .map(|(idx, d)| {
+                let mut t = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
+                t.set_requires_grad(true).unwrap();
+                t
+            })
+            .collect();
+
+        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+        let dense = ttn.to_dense().unwrap();
+
+        let ones = TensorDynLen::from_dense(
+            dense.indices().to_vec(),
+            vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
+        )
+        .unwrap();
+        let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
+
+        let node_tensors: Vec<&TensorDynLen> = ttn
+            .node_indices()
+            .iter()
+            .map(|&ni| ttn.tensor(ni).unwrap())
+            .collect();
+        scalar.backward(None, &node_tensors).unwrap();
+
+        // Verify gradient of first node vs finite difference
+        let node_0 = ttn.node_index(&0).unwrap();
+        let grad_t0 = ttn
+            .tensor(node_0)
+            .unwrap()
+            .grad()
+            .expect("t0 gradient missing");
+        let grad_t0_vec = grad_t0.to_vec::<f64>().unwrap();
+
+        for elem_idx in 0..data[0].len() {
+            let make_perturbed_sum = |delta: f64| -> f64 {
+                let tensors: Vec<TensorDynLen> = index_sets
+                    .iter()
+                    .zip(&data)
+                    .enumerate()
+                    .map(|(i, (idx, d))| {
+                        let mut d = d.clone();
+                        if i == 0 {
+                            d[elem_idx] += delta;
+                        }
+                        TensorDynLen::from_dense(idx.clone(), d).unwrap()
+                    })
+                    .collect();
+                let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+                ttn.to_dense().unwrap().sum().real()
+            };
+
+            let fd = (make_perturbed_sum(eps) - make_perturbed_sum(-eps)) / (2.0 * eps);
+            let ad = grad_t0_vec[elem_idx];
+            let err = (ad - fd).abs();
+            assert!(
+                err < 1e-4,
+                "backward grad[0][{elem_idx}] = {ad}, finite diff = {fd}, err = {err}"
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Summary

- **#359**: Add `TensorDynLen::backward()` method for reverse-mode AD. Delegates to tenferro's native backward pass, accepting optional gradient seed and input tensors to accumulate gradients on.
- **#362**: Add comprehensive AD integration tests for TreeTN:
  - **Forward-mode** (4 tests): tangent propagation through `to_dense`, `canonicalize`, `truncate`, and finite-difference validation
  - **Backward-mode** (2 tests): gradient propagation through `to_dense` and finite-difference validation against all elements of the first tensor
- Add backward AD tests for `tensor4all-core` (contraction gradient accumulation, finite-difference validation)

Closes #359, #362

## Test plan

- [x] 8 new AD tests (2 core backward + 4 treetn forward + 2 treetn backward)
- [x] Full workspace: 1736 passed, 9 skipped
- [x] `cargo clippy --workspace --tests` clean
- [x] `cargo fmt --check --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)