### PR TITLE
docs+fix: Add mandatory C API rules and fix existing compliance issues

### DIFF
--- a/crates/tensor4all-capi/src/quanticstci.rs
+++ b/crates/tensor4all-capi/src/quanticstci.rs
@@ -66,6 +66,34 @@ pub extern "C" fn t4a_qtci_f64_release(ptr: *mut t4a_qtci_f64) {
     }
 }
 
+/// Check if the QuanticsTCI handle is assigned (non-null and dereferenceable).
+///
+/// # Returns
+/// 1 if valid, 0 otherwise
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_qtci_f64_is_assigned(ptr: *const t4a_qtci_f64) -> i32 {
+    if ptr.is_null() {
+        return 0;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        let _ = &*ptr;
+        1
+    }));
+
+    match result {
+        Ok(v) => v,
+        Err(panic) => {
+            let msg = crate::panic_message(&*panic);
+            crate::set_last_error(&msg);
+            0
+        }
+    }
+}
+
+// Note: t4a_qtci_f64_clone is NOT provided because QuanticsTensorCI2 internally
+// contains a TreeTCI2 which does not implement Clone.
+
 // ============================================================================
 // High-level interpolation functions
 // ============================================================================
@@ -367,7 +395,7 @@ pub extern "C" fn t4a_qtci_f64_integral(
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_qtci_f64_to_tensor_train(
     ptr: *const t4a_qtci_f64,
-) -> *mut crate::simplett::t4a_simplett_f64 {
+) -> *mut crate::types::t4a_simplett_f64 {
     if ptr.is_null() {
         return std::ptr::null_mut();
     }
@@ -375,7 +403,7 @@ pub extern "C" fn t4a_qtci_f64_to_tensor_train(
     let result = catch_unwind(AssertUnwindSafe(|| {
         let qtci = unsafe { &*ptr };
         let tt = qtci.inner().tensor_train();
-        Box::into_raw(Box::new(crate::simplett::t4a_simplett_f64::new(tt)))
+        Box::into_raw(Box::new(crate::types::t4a_simplett_f64::new(tt)))
     }));
 
     crate::unwrap_catch_ptr(result)

--- a/crates/tensor4all-capi/src/simplett.rs
+++ b/crates/tensor4all-capi/src/simplett.rs
@@ -3,57 +3,11 @@
 //! This provides a simpler TensorTrain interface designed for TCI operations.
 //! The tensors are stored as flat arrays with explicit dimensions.
 
-use crate::types::t4a_simplett_c64;
+use crate::types::{t4a_simplett_c64, t4a_simplett_f64};
 use crate::{StatusCode, T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS};
 use num_complex::Complex64;
-use std::ffi::c_void;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
-
-// ============================================================================
-// Opaque handle type
-// ============================================================================
-
-/// Opaque handle for a SimpleTT `TensorTrain<f64>`
-#[repr(C)]
-pub struct t4a_simplett_f64 {
-    _private: *const c_void,
-}
-
-#[allow(dead_code)]
-impl t4a_simplett_f64 {
-    pub(crate) fn new(tt: TensorTrain<f64>) -> Self {
-        Self {
-            _private: Box::into_raw(Box::new(tt)) as *const c_void,
-        }
-    }
-
-    pub(crate) fn inner(&self) -> &TensorTrain<f64> {
-        unsafe { &*(self._private as *const TensorTrain<f64>) }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn inner_mut(&mut self) -> &mut TensorTrain<f64> {
-        unsafe { &mut *(self._private as *mut TensorTrain<f64>) }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn into_inner(self) -> TensorTrain<f64> {
-        let ptr = self._private as *mut TensorTrain<f64>;
-        std::mem::forget(self);
-        unsafe { *Box::from_raw(ptr) }
-    }
-}
-
-impl Drop for t4a_simplett_f64 {
-    fn drop(&mut self) {
-        if !self._private.is_null() {
-            unsafe {
-                let _ = Box::from_raw(self._private as *mut TensorTrain<f64>);
-            }
-        }
-    }
-}
 
 // ============================================================================
 // Lifecycle functions
@@ -82,6 +36,31 @@ pub extern "C" fn t4a_simplett_f64_clone(ptr: *const t4a_simplett_f64) -> *mut t
     }));
 
     crate::unwrap_catch_ptr(result)
+}
+
+/// Check if the SimpleTT f64 handle is assigned (non-null and dereferenceable).
+///
+/// # Returns
+/// 1 if valid, 0 otherwise
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_simplett_f64_is_assigned(ptr: *const t4a_simplett_f64) -> i32 {
+    if ptr.is_null() {
+        return 0;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        let _ = &*ptr;
+        1
+    }));
+
+    match result {
+        Ok(v) => v,
+        Err(panic) => {
+            let msg = crate::panic_message(&*panic);
+            crate::set_last_error(&msg);
+            0
+        }
+    }
 }
 
 // ============================================================================
@@ -512,6 +491,31 @@ pub extern "C" fn t4a_simplett_c64_clone(ptr: *const t4a_simplett_c64) -> *mut t
     }));
 
     crate::unwrap_catch_ptr(result)
+}
+
+/// Check if the SimpleTT c64 handle is assigned (non-null and dereferenceable).
+///
+/// # Returns
+/// 1 if valid, 0 otherwise
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_simplett_c64_is_assigned(ptr: *const t4a_simplett_c64) -> i32 {
+    if ptr.is_null() {
+        return 0;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        let _ = &*ptr;
+        1
+    }));
+
+    match result {
+        Ok(v) => v,
+        Err(panic) => {
+            let msg = crate::panic_message(&*panic);
+            crate::set_last_error(&msg);
+            0
+        }
+    }
 }
 
 // ============================================================================

--- a/crates/tensor4all-capi/src/treetci.rs
+++ b/crates/tensor4all-capi/src/treetci.rs
@@ -43,6 +43,21 @@ pub type TreeTciEvalCallback = extern "C" fn(
 ) -> i32;
 
 /// Complex evaluation callback for TreeTCI.
+///
+/// Complex64 values are returned as interleaved f64 pairs: `[re0, im0, re1, im1, ...]`.
+/// The `results` buffer must hold `2 * n_points` doubles. For each evaluation point `i`,
+/// write the real part to `results[2*i]` and the imaginary part to `results[2*i + 1]`.
+///
+/// # Arguments
+/// * `batch_data` - Column-major (n_sites, n_points) index array.
+///   Element at (site, point) is at `batch_data[site + n_sites * point]`.
+/// * `n_sites` - Number of sites
+/// * `n_points` - Number of evaluation points
+/// * `results` - Output buffer for `2 * n_points` f64 values (interleaved re/im pairs)
+/// * `user_data` - User data pointer passed through from the calling function
+///
+/// # Returns
+/// 0 on success, non-zero on error
 pub type TreeTciEvalCallbackC64 = extern "C" fn(
     batch_data: *const libc::size_t,
     n_sites: libc::size_t,
@@ -261,6 +276,33 @@ pub extern "C" fn t4a_treetci_f64_release(ptr: *mut t4a_treetci_f64) {
     }
 }
 
+/// Check if the TreeTCI f64 handle is assigned (non-null and dereferenceable).
+///
+/// # Returns
+/// 1 if valid, 0 otherwise
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetci_f64_is_assigned(ptr: *const t4a_treetci_f64) -> i32 {
+    if ptr.is_null() {
+        return 0;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        let _ = &*ptr;
+        1
+    }));
+
+    match result {
+        Ok(v) => v,
+        Err(panic) => {
+            let msg = crate::panic_message(&*panic);
+            crate::set_last_error(&msg);
+            0
+        }
+    }
+}
+
+// Note: t4a_treetci_f64_clone is NOT provided because TreeTCI2 does not implement Clone.
+
 /// Create a new complex TreeTCI state.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetci_c64_new(
@@ -301,6 +343,33 @@ pub extern "C" fn t4a_treetci_c64_release(ptr: *mut t4a_treetci_c64) {
         }
     }
 }
+
+/// Check if the TreeTCI c64 handle is assigned (non-null and dereferenceable).
+///
+/// # Returns
+/// 1 if valid, 0 otherwise
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetci_c64_is_assigned(ptr: *const t4a_treetci_c64) -> i32 {
+    if ptr.is_null() {
+        return 0;
+    }
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+        let _ = &*ptr;
+        1
+    }));
+
+    match result {
+        Ok(v) => v,
+        Err(panic) => {
+            let msg = crate::panic_message(&*panic);
+            crate::set_last_error(&msg);
+            0
+        }
+    }
+}
+
+// Note: t4a_treetci_c64_clone is NOT provided because TreeTCI2 does not implement Clone.
 
 // ============================================================================
 // Pivot management

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -212,6 +212,58 @@ unsafe impl Sync for t4a_treetn {}
 // SimpleTT types
 // ============================================================================
 
+/// Opaque handle for a SimpleTT `TensorTrain<f64>`.
+#[repr(C)]
+pub struct t4a_simplett_f64 {
+    pub(crate) _private: *const c_void,
+}
+
+impl t4a_simplett_f64 {
+    /// Create a new `t4a_simplett_f64` from a `TensorTrain<f64>`.
+    pub(crate) fn new(tt: TensorTrain<f64>) -> Self {
+        Self {
+            _private: Box::into_raw(Box::new(tt)) as *const c_void,
+        }
+    }
+
+    /// Get a reference to the inner `TensorTrain<f64>`.
+    pub(crate) fn inner(&self) -> &TensorTrain<f64> {
+        unsafe { &*(self._private as *const TensorTrain<f64>) }
+    }
+
+    /// Get a mutable reference to the inner `TensorTrain<f64>`.
+    pub(crate) fn inner_mut(&mut self) -> &mut TensorTrain<f64> {
+        unsafe { &mut *(self._private as *mut TensorTrain<f64>) }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn into_inner(self) -> TensorTrain<f64> {
+        let ptr = self._private as *mut TensorTrain<f64>;
+        std::mem::forget(self);
+        unsafe { *Box::from_raw(ptr) }
+    }
+}
+
+impl Clone for t4a_simplett_f64 {
+    fn clone(&self) -> Self {
+        Self::new(self.inner().clone())
+    }
+}
+
+impl Drop for t4a_simplett_f64 {
+    fn drop(&mut self) {
+        if !self._private.is_null() {
+            unsafe {
+                let _ = Box::from_raw(self._private as *mut TensorTrain<f64>);
+            }
+        }
+    }
+}
+
+// Safety: t4a_simplett_f64 is Send + Sync because TensorTrain<f64> is Send + Sync
+unsafe impl Send for t4a_simplett_f64 {}
+unsafe impl Sync for t4a_simplett_f64 {}
+
 /// Opaque handle for a SimpleTT `TensorTrain<Complex64>`.
 #[repr(C)]
 pub struct t4a_simplett_c64 {

--- a/docs/CAPI_DESIGN.md
+++ b/docs/CAPI_DESIGN.md
@@ -7,20 +7,21 @@ This document describes the common design patterns and guidelines for C APIs in 
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [Naming Conventions](#naming-conventions)
-3. [Opaque Types](#opaque-types)
-4. [Ownership Model](#ownership-model)
-5. [Immutable vs Mutable Types](#immutable-vs-mutable-types)
-6. [Lifecycle Management](#lifecycle-management)
-7. [Error Handling](#error-handling)
-8. [Panic Safety](#panic-safety)
-9. [Buffer Management](#buffer-management)
-10. [Data Layout (Column-Major)](#data-layout-column-major)
-11. [Memory Contiguity Requirements](#memory-contiguity-requirements)
-12. [Language Binding Normalization](#language-binding-normalization)
-13. [Thread Safety](#thread-safety)
-14. [Function Export](#function-export)
-15. [Code Organization](#code-organization)
+2. [Mandatory Rules](#mandatory-rules)
+3. [Naming Conventions](#naming-conventions)
+4. [Opaque Types](#opaque-types)
+5. [Ownership Model](#ownership-model)
+6. [Immutable vs Mutable Types](#immutable-vs-mutable-types)
+7. [Lifecycle Management](#lifecycle-management)
+8. [Error Handling](#error-handling)
+9. [Panic Safety](#panic-safety)
+10. [Buffer Management](#buffer-management)
+11. [Data Layout (Column-Major)](#data-layout-column-major)
+12. [Memory Contiguity Requirements](#memory-contiguity-requirements)
+13. [Language Binding Normalization](#language-binding-normalization)
+14. [Thread Safety](#thread-safety)
+15. [Function Export](#function-export)
+16. [Code Organization](#code-organization)
 
 ## Overview
 
@@ -36,6 +37,89 @@ C APIs in tensor4all-rs follow patterns inspired by `sparse-ir-capi` and common 
 - **Boundary normalization** handled by language bindings when interoperating with row-major ecosystems such as NumPy
 
 **Note**: While this document uses examples from `tensor4all-capi` (with `t4a_` prefix), the patterns apply to all C-API crates in the tensor4all-rs project. Each crate should choose its own prefix to avoid naming conflicts.
+
+## Mandatory Rules
+
+This section consolidates the rules that MUST be followed for all C API types and functions. These rules take precedence over any guidance in later sections.
+
+### Rule 1: Type Mutability Classification
+
+Every opaque type must be classified as either **Immutable** or **Mutable**:
+
+- **Immutable types** (`Box<Arc<T>>`): Objects that are never modified after construction. `clone()` is cheap (Arc reference count increment). Only `inner()` is provided -- `inner_mut()` MUST NOT be defined.
+- **Mutable types** (`Box<T>`): Objects that support in-place modification. `clone()` is a deep copy. Both `inner()` and `inner_mut()` are available.
+
+#### Classification Table
+
+| Type | Mutability | Wraps | `clone()` | `inner_mut()` | Notes |
+|------|-----------|-------|-----------|---------------|-------|
+| `t4a_index` | Immutable | `DynIndex` | Yes (cheap) | No | |
+| `t4a_tensor` | Immutable | `TensorDynLen` | Yes (cheap) | No | |
+| `t4a_qgrid_disc` | Immutable | `DiscretizedGrid` | Yes (cheap) | No | |
+| `t4a_qgrid_int` | Immutable | `InherentDiscreteGrid` | Yes (cheap) | No | |
+| `t4a_linop` | Immutable | `LinearOperator<TensorDynLen, usize>` | Yes (cheap) | No | |
+| `t4a_qtci_f64` | Immutable | `QuanticsTensorCI2<f64>` | No | No | No `Clone` -- contains `TreeTCI2` |
+| `t4a_treetn` | Mutable | `DefaultTreeTN<usize>` | Yes (deep) | Yes | Orthogonalization, truncation |
+| `t4a_treetci_f64` | Mutable | `TreeTCI2<f64>` | No | Yes | No `Clone` -- `TreeTCI2` does not implement Clone |
+| `t4a_treetci_c64` | Mutable | `TreeTCI2<Complex64>` | No | Yes | No `Clone` -- `TreeTCI2` does not implement Clone |
+| `t4a_treetci_graph` | Immutable | `TreeTciGraph` | Yes (cheap) | No | |
+| `t4a_simplett_f64` | Mutable | `TensorTrain<f64>` | Yes (deep) | Yes | Compression |
+| `t4a_simplett_c64` | Mutable | `TensorTrain<Complex64>` | Yes (deep) | Yes | Compression |
+
+### Rule 2: Lifecycle Functions
+
+Every opaque type MUST provide:
+
+- `t4a_<TYPE>_release` -- mandatory for all types
+- `t4a_<TYPE>_clone` -- mandatory if `Clone` is possible; if `Clone` is impossible, document why and do NOT provide the function
+- `t4a_<TYPE>_is_assigned` -- mandatory for all types
+
+Prefer `impl_opaque_type_common!` macro which generates all three. When `Clone` is not available (e.g., `TreeTCI2`), implement `release` and `is_assigned` manually and add a comment explaining why `clone` is absent.
+
+#### Current Status
+
+| Type | `_release` | `_clone` | `_is_assigned` | Notes |
+|------|:---:|:---:|:---:|-------|
+| `t4a_index` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_tensor` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_treetn` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_qgrid_disc` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_qgrid_int` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_linop` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_treetci_graph` | Yes | Yes | Yes | `impl_opaque_type_common!` |
+| `t4a_simplett_f64` | Yes | Yes | Yes | Manual impl |
+| `t4a_simplett_c64` | Yes | Yes | Yes | Manual impl |
+| `t4a_qtci_f64` | Yes | -- | Yes | No `Clone`: contains `TreeTCI2` |
+| `t4a_treetci_f64` | Yes | -- | Yes | No `Clone`: `TreeTCI2` does not implement Clone |
+| `t4a_treetci_c64` | Yes | -- | Yes | No `Clone`: `TreeTCI2` does not implement Clone |
+
+### Rule 3: Thread Safety
+
+- All opaque types MUST implement `unsafe impl Send` and `unsafe impl Sync`
+- Concurrent reads on the same pointer are safe
+- Concurrent writes to the same pointer are undefined behavior (caller's responsibility)
+- Callbacks execute on the calling thread
+
+### Rule 4: Naming Conventions
+
+In addition to the conventions in the [Naming Conventions](#naming-conventions) section below:
+
+- **In-place operations on Mutable types**: no special suffix needed, as `*mut` pointer already signals mutation
+- **Scalar type suffix**: `_f64`, `_c64` for type-specialized functions (e.g., `t4a_simplett_f64_*`, `t4a_treetci_c64_*`)
+
+### Rule 5: Complex Number FFI Convention
+
+Complex64 values are passed as interleaved f64 pairs: `[re, im, re, im, ...]`.
+
+- For callback results returning `n_points` complex values, write `2 * n_points` doubles to the result buffer
+- Element at index `i` has real part at `results[2*i]` and imaginary part at `results[2*i + 1]`
+- This convention MUST be documented in all c64 callback type definitions
+
+### Rule 6: Type Definition Location
+
+- All opaque type struct definitions MUST be in `types.rs`
+- Type-specific logic (functions, tests) go in their own module files (e.g., `simplett.rs`, `treetci.rs`)
+- Enum definitions for C API parameters belong in `types.rs`
 
 ## Naming Conventions
 
@@ -374,16 +458,7 @@ impl_opaque_type_common!(index);
 
 ### Current Implementation Status (tensor4all-capi)
 
-| Type | `_release` | `_clone` | `_is_assigned` | Notes |
-|------|:---:|:---:|:---:|-------|
-| `t4a_index` | Yes | Yes | Yes | `impl_opaque_type_common!` |
-| `t4a_tensor` | Yes | Yes | Yes | `impl_opaque_type_common!` |
-| `t4a_treetn` | Yes | Yes | Yes | `impl_opaque_type_common!` |
-| `t4a_qgrid_disc` | Yes | Yes | Yes | `impl_opaque_type_common!` |
-| `t4a_qgrid_int` | Yes | Yes | Yes | `impl_opaque_type_common!` |
-| `t4a_linop` | Yes | Yes | Yes | `impl_opaque_type_common!` |
-| `t4a_simplett_f64` | Yes | Yes | No | Manual impl |
-| `t4a_qtci_f64` | No | No | No | No `Clone` impl |
+See the authoritative table in [Mandatory Rules -- Rule 2](#rule-2-lifecycle-functions).
 
 ### Manual Implementation
 
@@ -990,10 +1065,14 @@ When creating new C-API crates:
 | `t4a_tensor` | `TensorDynLen` | `tensor.rs` | Dynamic-rank tensor (dense or diagonal) |
 | `t4a_treetn` | `DefaultTreeTN<usize>` | `treetn.rs` | Tree tensor network (MPS, MPO, general TTN) |
 | `t4a_simplett_f64` | `TensorTrain<f64>` | `simplett.rs` | Simple tensor train (f64) |
+| `t4a_simplett_c64` | `TensorTrain<Complex64>` | `simplett.rs` | Simple tensor train (c64) |
 | `t4a_qtci_f64` | `QuanticsTensorCI2<f64>` | `quanticstci.rs` | Quantics TCI result (f64) |
 | `t4a_qgrid_disc` | `DiscretizedGrid` | `quanticsgrids.rs` | Discretized continuous grid |
 | `t4a_qgrid_int` | `InherentDiscreteGrid` | `quanticsgrids.rs` | Integer discrete grid |
 | `t4a_linop` | `LinearOperator<TensorDynLen, usize>` | `quanticstransform.rs` | Quantics linear operator (shift, flip, Fourier, etc.) |
+| `t4a_treetci_graph` | `TreeTciGraph` | `treetci.rs` | Tree graph for TreeTCI |
+| `t4a_treetci_f64` | `TreeTCI2<f64>` | `treetci.rs` | TreeTCI state (f64) |
+| `t4a_treetci_c64` | `TreeTCI2<Complex64>` | `treetci.rs` | TreeTCI state (c64) |
 
 ### Enums
 
@@ -1009,6 +1088,8 @@ When creating new C-API crates:
 |------|-----------|--------|-------------|
 | `QtciEvalCallbackF64` | `fn(coords: *const f64, n: size_t, result: *mut f64, user_data: *mut void) -> i32` | `quanticstci.rs` | QTCI continuous domain callback |
 | `QtciEvalCallbackI64` | `fn(indices: *const i64, n: size_t, result: *mut f64, user_data: *mut void) -> i32` | `quanticstci.rs` | QTCI discrete domain callback |
+| `TreeTciEvalCallback` | `fn(batch: *const size_t, n_sites: size_t, n_points: size_t, results: *mut f64, user_data: *mut void) -> i32` | `treetci.rs` | TreeTCI batch eval (f64) |
+| `TreeTciEvalCallbackC64` | `fn(batch: *const size_t, n_sites: size_t, n_points: size_t, results: *mut f64, user_data: *mut void) -> i32` | `treetci.rs` | TreeTCI batch eval (c64, interleaved re/im) |
 
 ### Module Overview
 
@@ -1021,6 +1102,7 @@ When creating new C-API crates:
 | `quanticsgrids.rs` | `t4a_qgrid_disc_*`, `t4a_qgrid_int_*` | Quantics grid coordinate conversions |
 | `quanticstci.rs` | `t4a_qtci_f64_*`, `t4a_quanticscrossinterpolate_*` | Quantics TCI interpolation |
 | `quanticstransform.rs` | `t4a_qtransform_*`, `t4a_linop_*` | Quantics transformation operators |
+| `treetci.rs` | `t4a_treetci_f64_*`, `t4a_treetci_c64_*`, `t4a_treetci_graph_*` | Tree-structured TCI |
 | `hdf5.rs` | `t4a_hdf5_*` | HDF5 serialization (ITensors.jl compatible) |
 
 ## References


### PR DESCRIPTION
## Summary
- Add "Mandatory Rules" section to `docs/CAPI_DESIGN.md` formalizing C API design requirements
- Fix existing code to comply with the new rules

## CAPI_DESIGN.md — New Rules

1. **Type Mutability Classification**: Every opaque type classified as Immutable (`Box<Arc<T>>`, no `inner_mut()`) or Mutable (`Box<T>`, `inner_mut()` allowed). Classification table for all 12 types.
2. **Lifecycle Functions**: `release`, `clone`, `is_assigned` mandatory for all types.
3. **Thread Safety**: All types must impl `Send + Sync`. Concurrent writes = UB.
4. **Naming Conventions**: `*mut` signals mutation (no `_inplace` suffix needed). `_f64`/`_c64` for scalar specialization.
5. **Complex Number FFI Convention**: Interleaved f64 pairs `[re, im, re, im, ...]`.
6. **Type Definition Location**: Struct definitions in `types.rs`.

## Code Fixes

- Move `t4a_simplett_f64` struct definition to `types.rs` (was in `simplett.rs`)
- Add `Clone`, `Send + Sync` to `t4a_simplett_f64`
- Add missing `is_assigned` functions: `simplett_f64`, `simplett_c64`, `qtci_f64`, `treetci_f64`, `treetci_c64`
- Document why `t4a_qtci_f64` cannot implement `clone` (TreeTCI2 not Clone)
- Document interleaved f64 convention on c64 callback types

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p tensor4all-capi --release` — all 100 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)