### PR TITLE
fix(capi): c64 site_tensor buf_len check for interleaved doubles

### DIFF
--- a/crates/tensor4all-capi/src/simplett.rs
+++ b/crates/tensor4all-capi/src/simplett.rs
@@ -760,7 +760,7 @@ pub extern "C" fn t4a_simplett_c64_site_tensor(
         let right_dim = tensor.right_dim();
         let total_size = left_dim * site_dim * right_dim;
 
-        if buf_len < total_size {
+        if buf_len < 2 * total_size {
             return T4A_INVALID_ARGUMENT;
         }
 

--- a/crates/tensor4all-capi/src/simplett/tests/mod.rs
+++ b/crates/tensor4all-capi/src/simplett/tests/mod.rs
@@ -374,7 +374,7 @@ fn test_simplett_c64_constant_accessors_and_site_tensor() {
             tt,
             1,
             tensor_data.as_mut_ptr(),
-            3,
+            6,
             &mut left_dim,
             &mut site_dim,
             &mut right_dim,


### PR DESCRIPTION
## Summary

Fix buffer length check in `t4a_simplett_c64_site_tensor`. Each `Complex64` is written as two interleaved `f64` values `[re, im]`, so the buffer needs `2 * total_size` doubles. The old check `buf_len < total_size` allowed a buffer half the required size.

## Test plan
- [x] `cargo test -p tensor4all-capi --release -- simplett_c64` passes
- [x] Test updated: `buf_len` 3 → 6 for a (1,3,1) tensor

🤖 Generated with [Claude Code](https://claude.com/claude-code)