### PR TITLE
feat(treetn): non-contiguous partial apply via Steiner tree

### DIFF
--- a/crates/tensor4all-treetn/src/node_name_network.rs
+++ b/crates/tensor4all-treetn/src/node_name_network.rs
@@ -340,6 +340,52 @@ where
         seen.len() == nodes.len()
     }
 
+    /// Compute the Steiner tree nodes spanning a set of terminal nodes.
+    ///
+    /// For tree graphs, the Steiner tree is the union of the unique paths from
+    /// one terminal to every other terminal.
+    ///
+    /// # Arguments
+    /// * `terminals` - Terminal node indices to span
+    ///
+    /// # Returns
+    /// The set of nodes in the minimal connected subtree spanning `terminals`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use tensor4all_treetn::NodeNameNetwork;
+    ///
+    /// let mut net: NodeNameNetwork<String> = NodeNameNetwork::new();
+    /// let a = net.add_node("A".to_string()).unwrap();
+    /// let b = net.add_node("B".to_string()).unwrap();
+    /// let c = net.add_node("C".to_string()).unwrap();
+    /// net.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    /// net.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+    ///
+    /// let steiner = net.steiner_tree_nodes(&[a, c].into_iter().collect::<HashSet<_>>());
+    /// assert_eq!(steiner, [a, b, c].into_iter().collect());
+    /// ```
+    pub fn steiner_tree_nodes(&self, terminals: &HashSet<NodeIndex>) -> HashSet<NodeIndex> {
+        if terminals.len() <= 1 {
+            return terminals.clone();
+        }
+
+        let terminals_vec: Vec<NodeIndex> = terminals.iter().copied().collect();
+        let root = terminals_vec[0];
+        let mut result = HashSet::new();
+        result.insert(root);
+
+        for &terminal in &terminals_vec[1..] {
+            if let Some(path) = self.path_between(root, terminal) {
+                result.extend(path);
+            }
+        }
+
+        result
+    }
+
     /// Convert a node sequence to an edge sequence.
     fn nodes_to_edges(nodes: &[NodeIndex]) -> CanonicalizeEdges {
         if nodes.len() < 2 {

--- a/crates/tensor4all-treetn/src/node_name_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/node_name_network/tests/mod.rs
@@ -62,6 +62,57 @@ fn test_is_connected_subset() {
 }
 
 #[test]
+fn test_steiner_tree_nodes_chain() {
+    let mut net: NodeNameNetwork<String> = NodeNameNetwork::new();
+
+    let n0 = net.add_node("N0".to_string()).unwrap();
+    let n1 = net.add_node("N1".to_string()).unwrap();
+    let n2 = net.add_node("N2".to_string()).unwrap();
+    let n3 = net.add_node("N3".to_string()).unwrap();
+    let n4 = net.add_node("N4".to_string()).unwrap();
+    net.add_edge(&"N0".to_string(), &"N1".to_string()).unwrap();
+    net.add_edge(&"N1".to_string(), &"N2".to_string()).unwrap();
+    net.add_edge(&"N2".to_string(), &"N3".to_string()).unwrap();
+    net.add_edge(&"N3".to_string(), &"N4".to_string()).unwrap();
+
+    let steiner = net.steiner_tree_nodes(&[n0, n2, n4].into());
+    assert_eq!(steiner, [n0, n1, n2, n3, n4].into());
+
+    let steiner = net.steiner_tree_nodes(&[n1, n3].into());
+    assert_eq!(steiner, [n1, n2, n3].into());
+}
+
+#[test]
+fn test_steiner_tree_nodes_tree() {
+    let mut net: NodeNameNetwork<String> = NodeNameNetwork::new();
+
+    let a = net.add_node("A".to_string()).unwrap();
+    let b = net.add_node("B".to_string()).unwrap();
+    let _c = net.add_node("C".to_string()).unwrap();
+    let d = net.add_node("D".to_string()).unwrap();
+    let e = net.add_node("E".to_string()).unwrap();
+    net.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    net.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+    net.add_edge(&"B".to_string(), &"D".to_string()).unwrap();
+    net.add_edge(&"D".to_string(), &"E".to_string()).unwrap();
+
+    let steiner = net.steiner_tree_nodes(&[a, e].into());
+    assert_eq!(steiner, [a, b, d, e].into());
+}
+
+#[test]
+fn test_steiner_tree_nodes_single_and_adjacent() {
+    let mut net: NodeNameNetwork<String> = NodeNameNetwork::new();
+
+    let a = net.add_node("A".to_string()).unwrap();
+    let b = net.add_node("B".to_string()).unwrap();
+    net.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+
+    assert_eq!(net.steiner_tree_nodes(&[a].into()), [a].into());
+    assert_eq!(net.steiner_tree_nodes(&[a, b].into()), [a, b].into());
+}
+
+#[test]
 fn test_same_topology() {
     let mut net1: NodeNameNetwork<String> = NodeNameNetwork::new();
     net1.add_node("A".to_string()).unwrap();

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -30,7 +30,9 @@ use tensor4all_core::{IndexLike, TensorIndex, TensorLike};
 use super::index_mapping::IndexMapping;
 use super::linear_operator::LinearOperator;
 use super::Operator;
-use crate::operator::compose_exclusive_linear_operators;
+use crate::operator::compose::{
+    compose_exclusive_linear_operators, compose_exclusive_linear_operators_unchecked,
+};
 use crate::treetn::contraction::{contract, ContractionMethod, ContractionOptions};
 use crate::treetn::TreeTN;
 
@@ -201,7 +203,8 @@ where
 
 /// Extend a partial operator to cover the full state space.
 ///
-/// Uses `compose_exclusive_linear_operators` to fill gap nodes with identity operators.
+/// Uses the operator support's Steiner tree to detect disconnected regions and
+/// fills all missing nodes with identity operators.
 /// For gap nodes, creates proper index mappings where:
 /// - True indices = state's actual site indices
 /// - Internal indices = new simulated indices for the MPO tensor
@@ -218,6 +221,19 @@ where
     let state_network = state.site_index_network();
     let op_nodes: HashSet<V> = operator.node_names();
     let state_nodes: HashSet<V> = state.node_names().into_iter().collect();
+    let mut op_node_indices: HashSet<petgraph::stable_graph::NodeIndex> = HashSet::new();
+    for name in &op_nodes {
+        let node_index = state_network.node_index(name).ok_or_else(|| {
+            anyhow::anyhow!("Operator node {:?} is missing from the state network", name)
+        })?;
+        op_node_indices.insert(node_index);
+    }
+
+    let steiner_tree_nodes = state_network.steiner_tree_nodes(&op_node_indices);
+    let steiner_gap_nodes: HashSet<_> = steiner_tree_nodes
+        .difference(&op_node_indices)
+        .copied()
+        .collect();
     let gap_nodes: Vec<V> = state_nodes.difference(&op_nodes).cloned().collect();
 
     // Build gap site indices: for each gap node, create internal indices for the identity tensor.
@@ -268,10 +284,15 @@ where
         gap_site_indices.insert(gap_name.clone(), pairs);
     }
 
-    // Compose the operator with identity at gaps
-    let mut composed =
+    // If the operator support is already connected in the state topology, use the
+    // checked compose path. Otherwise, let the gap identities bridge the Steiner tree.
+    let compose_result = if steiner_gap_nodes.is_empty() {
         compose_exclusive_linear_operators(state_network, &[operator], &gap_site_indices)
-            .context("Failed to compose operator with identity gaps")?;
+    } else {
+        compose_exclusive_linear_operators_unchecked(state_network, &[operator], &gap_site_indices)
+    };
+
+    let mut composed = compose_result.context("Failed to compose operator with identity gaps")?;
 
     // Override the mappings for gap nodes to use the correct true indices
     // (compose_exclusive_linear_operators uses the internal indices as true indices for gaps)

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::random::{random_treetn, LinkSpace};
 use crate::SiteIndexNetwork;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use tensor4all_core::index::{DynId, Index, TagSet};
 use tensor4all_core::TensorDynLen;
 
@@ -9,6 +9,136 @@ type DynIndex = Index<DynId, TagSet>;
 
 fn make_index(dim: usize) -> DynIndex {
     Index::new_dyn(dim)
+}
+
+fn build_identity_operator(sites: &[(String, DynIndex)]) -> LinearOperator<TensorDynLen, String> {
+    let mut mpo = TreeTN::new();
+    let mut input_mapping = HashMap::new();
+    let mut output_mapping = HashMap::new();
+
+    for (name, true_index) in sites {
+        let internal_input = make_index(true_index.dim());
+        let internal_output = make_index(true_index.dim());
+        let tensor = TensorDynLen::from_dense(
+            vec![internal_output.clone(), internal_input.clone()],
+            vec![1.0, 0.0, 0.0, 1.0],
+        )
+        .unwrap();
+
+        mpo.add_tensor(name.clone(), tensor).unwrap();
+        input_mapping.insert(
+            name.clone(),
+            IndexMapping {
+                true_index: true_index.clone(),
+                internal_index: internal_input,
+            },
+        );
+        output_mapping.insert(
+            name.clone(),
+            IndexMapping {
+                true_index: true_index.clone(),
+                internal_index: internal_output,
+            },
+        );
+    }
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn build_chain_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>) {
+    let s0 = make_index(2);
+    let s1 = make_index(2);
+    let s2 = make_index(2);
+    let s3 = make_index(2);
+    let b01 = make_index(2);
+    let b12 = make_index(2);
+    let b23 = make_index(2);
+
+    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t1 =
+        TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
+    let t2 =
+        TensorDynLen::from_dense(vec![b12.clone(), s2.clone(), b23.clone()], vec![1.0; 8]).unwrap();
+    let t3 = TensorDynLen::from_dense(vec![b23.clone(), s3.clone()], vec![1.0; 4]).unwrap();
+
+    let state = TreeTN::from_tensors(
+        vec![t0, t1, t2, t3],
+        vec![
+            "site0".to_string(),
+            "site1".to_string(),
+            "site2".to_string(),
+            "site3".to_string(),
+        ],
+    )
+    .unwrap();
+
+    (
+        state,
+        vec![
+            ("site0".to_string(), s0),
+            ("site1".to_string(), s1),
+            ("site2".to_string(), s2),
+            ("site3".to_string(), s3),
+        ],
+    )
+}
+
+fn build_tree_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>) {
+    let s_a = make_index(2);
+    let s_b = make_index(2);
+    let s_c = make_index(2);
+    let s_d = make_index(2);
+    let s_e = make_index(2);
+    let b_ab = make_index(2);
+    let b_bc = make_index(2);
+    let b_bd = make_index(2);
+    let b_be = make_index(2);
+
+    let t_a = TensorDynLen::from_dense(vec![s_a.clone(), b_ab.clone()], vec![1.0; 4]).unwrap();
+    let t_b = TensorDynLen::from_dense(
+        vec![b_ab.clone(), s_b.clone(), b_bc.clone(), b_bd.clone()],
+        vec![1.0; 16],
+    )
+    .unwrap();
+    let t_c = TensorDynLen::from_dense(vec![b_bc.clone(), s_c.clone()], vec![1.0; 4]).unwrap();
+    let t_d = TensorDynLen::from_dense(vec![b_bd.clone(), s_d.clone(), b_be.clone()], vec![1.0; 8])
+        .unwrap();
+    let t_e = TensorDynLen::from_dense(vec![b_be.clone(), s_e.clone()], vec![1.0; 4]).unwrap();
+
+    let state = TreeTN::from_tensors(
+        vec![t_a, t_b, t_c, t_d, t_e],
+        vec![
+            "A".to_string(),
+            "B".to_string(),
+            "C".to_string(),
+            "D".to_string(),
+            "E".to_string(),
+        ],
+    )
+    .unwrap();
+
+    (
+        state,
+        vec![
+            ("A".to_string(), s_a),
+            ("B".to_string(), s_b),
+            ("C".to_string(), s_c),
+            ("D".to_string(), s_d),
+            ("E".to_string(), s_e),
+        ],
+    )
+}
+
+fn assert_identity_application(
+    state: &TreeTN<TensorDynLen, String>,
+    operator: &LinearOperator<TensorDynLen, String>,
+) {
+    use crate::operator::apply_linear_operator;
+
+    let result = apply_linear_operator(operator, state, ApplyOptions::default()).unwrap();
+    let result_dense = result.to_dense().unwrap();
+    let state_dense = state.to_dense().unwrap();
+    assert!((&result_dense - &state_dense).maxabs() < 1e-10);
 }
 
 #[test]
@@ -265,6 +395,22 @@ fn test_apply_linear_operator_partial() {
     // Test apply with partial operator (should extend with identity on site2)
     let result = apply_linear_operator(&operator, &state, ApplyOptions::default()).unwrap();
     assert_eq!(result.node_count(), 3);
+}
+
+#[test]
+fn test_apply_linear_operator_non_contiguous_chain() {
+    let (state, sites) = build_chain_state();
+    let operator = build_identity_operator(&[sites[0].clone(), sites[2].clone()]);
+
+    assert_identity_application(&state, &operator);
+}
+
+#[test]
+fn test_apply_linear_operator_non_contiguous_tree() {
+    let (state, sites) = build_tree_state();
+    let operator = build_identity_operator(&[sites[0].clone(), sites[4].clone()]);
+
+    assert_identity_application(&state, &operator);
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/operator/compose.rs
+++ b/crates/tensor4all-treetn/src/operator/compose.rs
@@ -176,8 +176,39 @@ where
     <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
+    compose_exclusive_linear_operators_inner(target, operators, gap_site_indices, true)
+}
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn compose_exclusive_linear_operators_unchecked<T, V>(
+    target: &SiteIndexNetwork<V, T::Index>,
+    operators: &[&LinearOperator<T, V>],
+    gap_site_indices: &HashMap<V, Vec<(T::Index, T::Index)>>,
+) -> Result<LinearOperator<T, V>>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq + Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    compose_exclusive_linear_operators_inner(target, operators, gap_site_indices, false)
+}
+
+#[allow(clippy::type_complexity)]
+fn compose_exclusive_linear_operators_inner<T, V>(
+    target: &SiteIndexNetwork<V, T::Index>,
+    operators: &[&LinearOperator<T, V>],
+    gap_site_indices: &HashMap<V, Vec<(T::Index, T::Index)>>,
+    validate_exclusivity: bool,
+) -> Result<LinearOperator<T, V>>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq + Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
     // 1. Validate exclusivity
-    if !are_exclusive_operators::<T, V, _>(target, operators) {
+    if validate_exclusivity && !are_exclusive_operators::<T, V, _>(target, operators) {
         return Err(anyhow::anyhow!(
             "Operators are not exclusive: they may overlap or not form connected subtrees"
         ))

--- a/crates/tensor4all-treetn/src/site_index_network.rs
+++ b/crates/tensor4all-treetn/src/site_index_network.rs
@@ -369,6 +369,31 @@ where
         self.topology.path_between(from, to)
     }
 
+    /// Compute the Steiner tree nodes spanning a set of terminal nodes.
+    ///
+    /// Delegates to [`NodeNameNetwork::steiner_tree_nodes`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_treetn::SiteIndexNetwork;
+    ///
+    /// let mut net: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+    /// let a = net.add_node("A".to_string(), HashSet::<DynIndex>::new()).unwrap();
+    /// let b = net.add_node("B".to_string(), HashSet::<DynIndex>::new()).unwrap();
+    /// let c = net.add_node("C".to_string(), HashSet::<DynIndex>::new()).unwrap();
+    /// net.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    /// net.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+    ///
+    /// let steiner = net.steiner_tree_nodes(&[a, c].into_iter().collect::<HashSet<_>>());
+    /// assert_eq!(steiner, [a, b, c].into_iter().collect());
+    /// ```
+    pub fn steiner_tree_nodes(&self, terminals: &HashSet<NodeIndex>) -> HashSet<NodeIndex> {
+        self.topology.steiner_tree_nodes(terminals)
+    }
+
     /// Check if a subset of nodes forms a connected subgraph.
     pub fn is_connected_subset(&self, nodes: &HashSet<NodeIndex>) -> bool {
         self.topology.is_connected_subset(nodes)

--- a/crates/tensor4all-treetn/src/site_index_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/site_index_network/tests/mod.rs
@@ -91,6 +91,20 @@ fn test_is_connected_subset() {
 }
 
 #[test]
+fn test_steiner_tree_nodes_forwarding() {
+    let mut net: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+
+    let empty: HashSet<DynIndex> = HashSet::new();
+    let a = net.add_node("A".to_string(), empty.clone()).unwrap();
+    let b = net.add_node("B".to_string(), empty.clone()).unwrap();
+    let c = net.add_node("C".to_string(), empty.clone()).unwrap();
+    net.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    net.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+
+    assert_eq!(net.steiner_tree_nodes(&[a, c].into()), [a, b, c].into());
+}
+
+#[test]
 fn test_share_equivalent_site_index_network() {
     let mut net1: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
     let site1: HashSet<_> = [DynIndex::new_dyn(2)].into();


### PR DESCRIPTION
## Summary

- Add `steiner_tree_nodes` to `NodeNameNetwork` and `SiteIndexNetwork` for computing the minimal connected subtree containing a set of terminal nodes
- Modify `extend_operator_to_full_space` to handle non-contiguous operator node sets by inserting identity tensors at intermediate Steiner tree nodes
- This generalizes Julia's `matchsiteinds` (from Quantics.jl) to tree tensor networks

## Motivation

Enables applying a 1D operator (e.g., Fourier transform) to non-contiguous sites in interleaved quantics encoding. Previously, `apply_linear_operator` required operator nodes to form a connected subtree, blocking interleaved layouts like `[x₁, y₁, x₂, y₂, ...]`.

## Test plan

- [x] `steiner_tree_nodes` unit tests (chain + branching tree topologies)
- [x] Non-contiguous partial apply test on 4-site chain
- [x] Non-contiguous partial apply test on branching tree
- [x] All 366 existing treetn tests pass
- [x] Full workspace tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)