### PR TITLE
docs: convert ignore doc examples to runnable doctests

### DIFF
--- a/crates/tensor4all-capi/src/macros.rs
+++ b/crates/tensor4all-capi/src/macros.rs
@@ -18,6 +18,8 @@
 ///
 /// # Example
 /// ```ignore
+/// // This macro expands to items that reference crate-private helpers such as
+/// // `$crate::unwrap_catch_ptr`, so an external doctest cannot compile it.
 /// impl_opaque_type_common!(index);
 /// // Generates: t4a_index_release, t4a_index_clone, t4a_index_is_assigned
 /// ```

--- a/crates/tensor4all-core/src/block_tensor.rs
+++ b/crates/tensor4all-core/src/block_tensor.rs
@@ -7,18 +7,26 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
 //! use tensor4all_core::block_tensor::BlockTensor;
 //! use tensor4all_core::krylov::{gmres, GmresOptions};
+//! use tensor4all_core::{DynIndex, TensorDynLen};
 //!
-//! // Create 2x1 block vectors
-//! let b = BlockTensor::new(vec![b1, b2], (2, 1));
-//! let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1));
+//! # fn main() -> anyhow::Result<()> {
+//! let i = DynIndex::new_dyn(2);
+//! let b_block = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0])?;
+//! let zero_block = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
 //!
-//! // Define block matrix operator
-//! let apply_a = |x: &BlockTensor<T>| { /* ... */ };
+//! let b = BlockTensor::new(vec![b_block], (1, 1));
+//! let x0 = BlockTensor::new(vec![zero_block], (1, 1));
 //!
+//! let apply_a = |x: &BlockTensor<TensorDynLen>| Ok(x.clone());
 //! let result = gmres(apply_a, &b, &x0, &GmresOptions::default())?;
+//!
+//! assert!(result.converged);
+//! assert_eq!(result.solution.shape(), (1, 1));
+//! # Ok(())
+//! # }
 //! ```
 
 use std::collections::HashSet;

--- a/crates/tensor4all-core/src/defaults/direct_sum.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum.rs
@@ -34,12 +34,21 @@ use tensor4all_tensorbackend::TensorElement;
 ///
 /// # Example
 ///
-/// ```ignore
-/// // A has indices [i, j] with dims [2, 3]
-/// // B has indices [i, k] with dims [2, 4]
-/// // If we pair (j, k), result has indices [i, m] with dims [2, 7]
-/// // where m is a new index with dim = 3 + 4 = 7
-/// let (result, new_indices) = direct_sum(&a, &b, &[(j, k)])?;
+/// ```
+/// use tensor4all_core::{direct_sum, DynIndex, TensorDynLen};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let j = DynIndex::new_dyn(2);
+/// let k = DynIndex::new_dyn(3);
+///
+/// let a = TensorDynLen::from_dense(vec![j.clone()], vec![1.0, 2.0])?;
+/// let b = TensorDynLen::from_dense(vec![k.clone()], vec![3.0, 4.0, 5.0])?;
+/// let (result, new_indices) = direct_sum(&a, &b, &[(j.clone(), k.clone())])?;
+///
+/// assert_eq!(new_indices.len(), 1);
+/// assert_eq!(result.to_vec::<f64>()?, vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+/// # Ok(())
+/// # }
 /// ```
 pub fn direct_sum(
     a: &TensorDynLen,

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -10,11 +10,26 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use tensor4all_core::{factorize, FactorizeOptions, FactorizeAlg, Canonical};
+//! ```
+//! use tensor4all_core::{factorize, Canonical, DynIndex, FactorizeOptions, TensorDynLen};
 //!
-//! let result = factorize(&tensor, &left_inds, &FactorizeOptions::default())?;
-//! // result.left * result.right ≈ tensor
+//! # fn main() -> anyhow::Result<()> {
+//! let i = DynIndex::new_dyn(2);
+//! let j = DynIndex::new_dyn(2);
+//! let tensor = TensorDynLen::from_dense(
+//!     vec![i.clone(), j.clone()],
+//!     vec![1.0, 0.0, 0.0, 1.0],
+//! )?;
+//! let result = factorize(
+//!     &tensor,
+//!     std::slice::from_ref(&i),
+//!     &FactorizeOptions::svd().with_canonical(Canonical::Left),
+//! )?;
+//!
+//! assert_eq!(result.rank, 2);
+//! assert_eq!(result.left.dims(), vec![2, 2]);
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::defaults::DynIndex;

--- a/crates/tensor4all-core/src/index_like.rs
+++ b/crates/tensor4all-core/src/index_like.rs
@@ -76,16 +76,18 @@ pub enum ConjState {
 ///
 /// # Example
 ///
-/// ```ignore
-/// fn contract_common<I: IndexLike>(a: &Tensor<I>, b: &Tensor<I>) -> Tensor<I> {
-///     // Algorithm doesn't need to know about Id, Symm, Tags
-///     // It only needs indices to be comparable and have dimensions
-///     let common: Vec<_> = a.indices().iter()
-///         .filter(|idx| b.indices().contains(idx))
-///         .cloned()
-///         .collect();
-///     // ...
-/// }
+/// ```
+/// use tensor4all_core::{DynIndex, IndexLike};
+///
+/// let i = DynIndex::new_dyn(2);
+/// let j = DynIndex::new_dyn(3);
+/// let k = DynIndex::new_dyn(4);
+///
+/// let a = vec![i.clone(), j.clone()];
+/// let b = vec![j.clone(), k.clone()];
+/// let common: Vec<_> = a.iter().filter(|idx| b.contains(idx)).cloned().collect();
+///
+/// assert_eq!(common, vec![j]);
 /// ```
 pub trait IndexLike: Clone + Eq + Hash + Debug + Send + Sync + 'static {
     /// Lightweight identifier type (conjugate-independent).

--- a/crates/tensor4all-core/src/krylov.rs
+++ b/crates/tensor4all-core/src/krylov.rs
@@ -14,16 +14,24 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use tensor4all_core::krylov::{gmres, GmresOptions};
-//!
-//! // Define a linear operator as a closure
-//! let apply_operator = |x: &T| -> Result<T> {
-//!     // Apply your linear operator to x
-//!     operator.apply(x)
+//! ```
+//! use tensor4all_core::{
+//!     krylov::{gmres, GmresOptions},
+//!     DynIndex, TensorDynLen, TensorLike,
 //! };
 //!
-//! let result = gmres(&apply_operator, &rhs, &initial_guess, &GmresOptions::default())?;
+//! # fn main() -> anyhow::Result<()> {
+//! let i = DynIndex::new_dyn(2);
+//! let rhs = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -1.0])?;
+//! let initial_guess = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
+//!
+//! let apply_operator = |x: &TensorDynLen| Ok(x.clone());
+//! let result = gmres(apply_operator, &rhs, &initial_guess, &GmresOptions::default())?;
+//!
+//! assert!(result.converged);
+//! assert!(result.solution.sub(&rhs)?.maxabs() < 1e-12);
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::any_scalar::AnyScalar;

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -214,16 +214,35 @@ pub struct FactorizeResult<T: TensorLike> {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use tensor4all_core::{TensorLike, AllowedPairs};
+/// ```
+/// use tensor4all_core::{AllowedPairs, DynIndex, TensorDynLen, TensorLike};
 ///
-/// // Contract all contractable index pairs (default behavior)
-/// let tensor_refs: Vec<&T> = tensors.iter().collect();
-/// let result = T::contract(&tensor_refs, AllowedPairs::All)?;
+/// # fn main() -> anyhow::Result<()> {
+/// let i = DynIndex::new_dyn(2);
+/// let j = DynIndex::new_dyn(2);
+/// let k = DynIndex::new_dyn(2);
 ///
-/// // Only contract indices between specified tensor pairs
-/// let edges = vec![(0, 1), (1, 2)];  // tensor 0-1 and tensor 1-2
-/// let result = T::contract(&tensor_refs, AllowedPairs::Specified(&edges))?;
+/// let a = TensorDynLen::from_dense(
+///     vec![i.clone(), j.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// )?;
+/// let b = TensorDynLen::from_dense(
+///     vec![j.clone(), k.clone()],
+///     vec![1.0, 2.0, 3.0, 4.0],
+/// )?;
+/// let c = TensorDynLen::from_dense(vec![k.clone()], vec![1.0, 10.0])?;
+///
+/// let tensor_refs: Vec<&TensorDynLen> = vec![&a, &b, &c];
+/// let all = <TensorDynLen as TensorLike>::contract(&tensor_refs, AllowedPairs::All)?;
+///
+/// let edges = vec![(0, 1), (1, 2)];
+/// let specified =
+///     <TensorDynLen as TensorLike>::contract(&tensor_refs, AllowedPairs::Specified(&edges))?;
+///
+/// assert_eq!(all.dims(), vec![2]);
+/// assert!(all.sub(&specified)?.maxabs() < 1e-12);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub enum AllowedPairs<'a> {
@@ -301,23 +320,46 @@ impl LinearizationOrder {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use tensor4all_core::{TensorLike, AllowedPairs};
+/// ```
+/// use tensor4all_core::{AllowedPairs, DynIndex, TensorDynLen, TensorLike};
 ///
-/// fn contract_pair<T: TensorLike>(a: &T, b: &T) -> Result<T> {
-///     T::contract(&[a, b], AllowedPairs::All)
+/// fn contract_pair(a: &TensorDynLen, b: &TensorDynLen) -> anyhow::Result<TensorDynLen> {
+///     Ok(<TensorDynLen as TensorLike>::contract(&[a, b], AllowedPairs::All)?)
 /// }
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let i = DynIndex::new_dyn(2);
+/// let j = DynIndex::new_dyn(2);
+/// let a = TensorDynLen::from_dense(
+///     vec![i.clone(), j.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// )?;
+/// let b = TensorDynLen::from_dense(vec![j.clone()], vec![2.0, 3.0])?;
+///
+/// let result = contract_pair(&a, &b)?;
+/// assert_eq!(result.to_vec::<f64>()?, vec![2.0, 3.0]);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Heterogeneous Collections
 ///
 /// For mixing different tensor types, define an enum:
 ///
-/// ```ignore
+/// ```
+/// use tensor4all_core::{block_tensor::BlockTensor, DynIndex, TensorDynLen};
+///
+/// let i = DynIndex::new_dyn(2);
+/// let dense = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+/// let block = BlockTensor::new(vec![dense.clone()], (1, 1));
+///
 /// enum TensorNetwork {
 ///     Dense(TensorDynLen),
-///     MPS(MatrixProductState),
+///     Block(BlockTensor<TensorDynLen>),
 /// }
+///
+/// let network = TensorNetwork::Block(block);
+/// assert!(matches!(network, TensorNetwork::Block(_)));
 /// ```
 ///
 /// # Supertrait
@@ -393,12 +435,22 @@ pub trait TensorLike: TensorIndex {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// // A has indices [i, j] with dims [2, 3]
-    /// // B has indices [i, k] with dims [2, 4]
-    /// // If we pair (j, k), result has indices [i, m] with dims [2, 7]
-    /// // where m is a new index with dim = 3 + 4 = 7
-    /// let result = a.direct_sum(&b, &[(j, k)])?;
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let j = DynIndex::new_dyn(2);
+    /// let k = DynIndex::new_dyn(3);
+    ///
+    /// let a = TensorDynLen::from_dense(vec![j.clone()], vec![1.0, 2.0])?;
+    /// let b = TensorDynLen::from_dense(vec![k.clone()], vec![3.0, 4.0, 5.0])?;
+    /// let result = a.direct_sum(&b, &[(j.clone(), k.clone())])?;
+    ///
+    /// assert_eq!(result.new_indices.len(), 1);
+    /// assert_eq!(result.tensor.dims(), vec![5]);
+    /// assert_eq!(result.tensor.to_vec::<f64>()?, vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+    /// # Ok(())
+    /// # }
     /// ```
     fn direct_sum(
         &self,
@@ -493,12 +545,34 @@ pub trait TensorLike: TensorIndex {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// // Contract all contractable pairs
-    /// let result = T::contract(&[&a, &b, &c], AllowedPairs::All)?;
+    /// ```
+    /// use tensor4all_core::{AllowedPairs, DynIndex, TensorDynLen, TensorLike};
     ///
-    /// // Only contract between tensor pairs (0,1) and (1,2)
-    /// let result = T::contract(&[&a, &b, &c], AllowedPairs::Specified(&[(0, 1), (1, 2)]))?;
+    /// # fn main() -> anyhow::Result<()> {
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(2);
+    /// let k = DynIndex::new_dyn(2);
+    ///
+    /// let a = TensorDynLen::from_dense(
+    ///     vec![i.clone(), j.clone()],
+    ///     vec![1.0, 0.0, 0.0, 1.0],
+    /// )?;
+    /// let b = TensorDynLen::from_dense(
+    ///     vec![j.clone(), k.clone()],
+    ///     vec![1.0, 2.0, 3.0, 4.0],
+    /// )?;
+    /// let c = TensorDynLen::from_dense(vec![k.clone()], vec![1.0, 10.0])?;
+    ///
+    /// let all = <TensorDynLen as TensorLike>::contract(&[&a, &b, &c], AllowedPairs::All)?;
+    /// let specified = <TensorDynLen as TensorLike>::contract(
+    ///     &[&a, &b, &c],
+    ///     AllowedPairs::Specified(&[(0, 1), (1, 2)]),
+    /// )?;
+    ///
+    /// assert_eq!(all.dims(), vec![2]);
+    /// assert!(all.sub(&specified)?.maxabs() < 1e-12);
+    /// # Ok(())
+    /// # }
     /// ```
     fn contract(tensors: &[&Self], allowed: AllowedPairs<'_>) -> Result<Self>;
 
@@ -525,9 +599,28 @@ pub trait TensorLike: TensorIndex {
     ///
     /// # Example
     ///
-    /// ```ignore
-    /// // All tensors must be connected through contractable indices
-    /// let result = T::contract_connected(&[&a, &b, &c], AllowedPairs::All)?;
+    /// ```
+    /// use tensor4all_core::{AllowedPairs, DynIndex, TensorDynLen, TensorLike};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(2);
+    /// let k = DynIndex::new_dyn(2);
+    ///
+    /// let a = TensorDynLen::from_dense(
+    ///     vec![i.clone(), j.clone()],
+    ///     vec![1.0, 0.0, 0.0, 1.0],
+    /// )?;
+    /// let b = TensorDynLen::from_dense(
+    ///     vec![j.clone(), k.clone()],
+    ///     vec![1.0, 2.0, 3.0, 4.0],
+    /// )?;
+    /// let c = TensorDynLen::from_dense(vec![k.clone()], vec![1.0, 10.0])?;
+    ///
+    /// let result = TensorDynLen::contract_connected(&[&a, &b, &c], AllowedPairs::All)?;
+    /// assert_eq!(result.dims(), vec![2]);
+    /// # Ok(())
+    /// # }
     /// ```
     fn contract_connected(tensors: &[&Self], allowed: AllowedPairs<'_>) -> Result<Self>;
 
@@ -684,9 +777,21 @@ pub trait TensorLike: TensorIndex {
     ///
     /// # Example
     /// To add a dummy index `l` to tensor `T`:
-    /// ```ignore
-    /// let ones = T::ones(&[l])?;
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let i = DynIndex::new_dyn(2);
+    /// let l = DynIndex::new_dyn(3);
+    /// let t = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, 4.0])?;
+    ///
+    /// let ones = TensorDynLen::ones(&[l.clone()])?;
     /// let t_with_l = t.outer_product(&ones)?;
+    ///
+    /// assert_eq!(t_with_l.dims(), vec![2, 3]);
+    /// assert_eq!(t_with_l.to_vec::<f64>()?, vec![2.0, 4.0, 2.0, 4.0, 2.0, 4.0]);
+    /// # Ok(())
+    /// # }
     /// ```
     fn ones(indices: &[<Self as TensorIndex>::Index]) -> Result<Self>;
 

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -41,21 +41,24 @@ pub use hdf5_rt::sys::{
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
 /// use tensor4all_hdf5::{save_itensor, load_itensor};
-/// use tensor4all_core::index::Index;
-/// use tensor4all_core::TensorDynLen;
+/// use tensor4all_core::{Index, TensorDynLen};
 ///
+/// # fn main() -> anyhow::Result<()> {
 /// let i = Index::new_dyn(2);
 /// let j = Index::new_dyn(3);
 /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![
 ///     1.0, 2.0, 3.0, 4.0, 5.0, 6.0
 /// ]).unwrap();
 ///
-/// let path = "/tmp/test_itensor.h5";
-/// save_itensor(path, "my_tensor", &tensor).unwrap();
-/// let loaded = load_itensor(path, "my_tensor").unwrap();
-/// assert_eq!(loaded.ndim(), 2);
+/// let path = std::env::temp_dir().join("tensor4all-doc-itensor.h5");
+/// let path = path.to_str().unwrap();
+/// save_itensor(path, "my_tensor", &tensor)?;
+/// let loaded = load_itensor(path, "my_tensor")?;
+/// assert_eq!(loaded.dims(), vec![2, 3]);
+/// # Ok(())
+/// # }
 /// ```
 pub fn save_itensor(filepath: &str, name: &str, tensor: &TensorDynLen) -> Result<()> {
     let file = File::create(filepath)?;
@@ -67,15 +70,24 @@ pub fn save_itensor(filepath: &str, name: &str, tensor: &TensorDynLen) -> Result
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
 /// use tensor4all_hdf5::{save_itensor, load_itensor};
-/// use tensor4all_core::index::Index;
-/// use tensor4all_core::TensorDynLen;
+/// use tensor4all_core::{Index, TensorDynLen};
 ///
-/// // (Requires a previously saved file — see `save_itensor` for a full round-trip example.)
-/// let path = "/tmp/test_itensor.h5";
-/// let loaded = load_itensor(path, "my_tensor").unwrap();
-/// assert_eq!(loaded.ndim(), 2);
+/// # fn main() -> anyhow::Result<()> {
+/// let i = Index::new_dyn(2);
+/// let j = Index::new_dyn(3);
+/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![
+///     1.0, 2.0, 3.0, 4.0, 5.0, 6.0
+/// ])?;
+///
+/// let path = std::env::temp_dir().join("tensor4all-doc-itensor-load.h5");
+/// let path = path.to_str().unwrap();
+/// save_itensor(path, "my_tensor", &tensor)?;
+/// let loaded = load_itensor(path, "my_tensor")?;
+/// assert_eq!(loaded.to_vec::<f64>()?, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+/// # Ok(())
+/// # }
 /// ```
 pub fn load_itensor(filepath: &str, name: &str) -> Result<TensorDynLen> {
     let file = File::open(filepath)?;
@@ -87,12 +99,12 @@ pub fn load_itensor(filepath: &str, name: &str) -> Result<TensorDynLen> {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
 /// use tensor4all_hdf5::{save_mps, load_mps};
-/// use tensor4all_core::index::Index;
-/// use tensor4all_core::TensorDynLen;
+/// use tensor4all_core::{Index, TensorDynLen};
 /// use tensor4all_itensorlike::TensorTrain;
 ///
+/// # fn main() -> anyhow::Result<()> {
 /// let s0 = Index::new_dyn(2);
 /// let bond = Index::new_dyn(1);
 /// let s1 = Index::new_dyn(2);
@@ -100,10 +112,13 @@ pub fn load_itensor(filepath: &str, name: &str) -> Result<TensorDynLen> {
 /// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0]).unwrap();
 /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
 ///
-/// let path = "/tmp/test_mps.h5";
-/// save_mps(path, "my_mps", &tt).unwrap();
-/// let loaded = load_mps(path, "my_mps").unwrap();
+/// let path = std::env::temp_dir().join("tensor4all-doc-mps.h5");
+/// let path = path.to_str().unwrap();
+/// save_mps(path, "my_mps", &tt)?;
+/// let loaded = load_mps(path, "my_mps")?;
 /// assert_eq!(loaded.len(), 2);
+/// # Ok(())
+/// # }
 /// ```
 pub fn save_mps(filepath: &str, name: &str, tt: &TensorTrain) -> Result<()> {
     let file = File::create(filepath)?;
@@ -115,13 +130,27 @@ pub fn save_mps(filepath: &str, name: &str, tt: &TensorTrain) -> Result<()> {
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
 /// use tensor4all_hdf5::load_mps;
+/// use tensor4all_hdf5::save_mps;
+/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_itensorlike::TensorTrain;
 ///
-/// // (Requires a previously saved file — see `save_mps` for a full round-trip example.)
-/// let path = "/tmp/test_mps.h5";
-/// let tt = load_mps(path, "my_mps").unwrap();
-/// assert_eq!(tt.len(), 2);
+/// # fn main() -> anyhow::Result<()> {
+/// let s0 = Index::new_dyn(2);
+/// let bond = Index::new_dyn(1);
+/// let s1 = Index::new_dyn(2);
+/// let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
+/// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
+/// let tt = TensorTrain::new(vec![t0, t1])?;
+///
+/// let path = std::env::temp_dir().join("tensor4all-doc-mps-load.h5");
+/// let path = path.to_str().unwrap();
+/// save_mps(path, "my_mps", &tt)?;
+/// let loaded = load_mps(path, "my_mps")?;
+/// assert_eq!(loaded.len(), 2);
+/// # Ok(())
+/// # }
 /// ```
 pub fn load_mps(filepath: &str, name: &str) -> Result<TensorTrain> {
     let file = File::open(filepath)?;

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -894,10 +894,24 @@ impl TensorTrain {
     /// tensor train is empty.
     ///
     /// # Example
-    /// ```ignore
-    /// let tt = TensorTrain::new(vec![t0, t1, t2]).unwrap();
-    /// let dense = tt.to_dense().unwrap();
-    /// // dense now has all site indices from t0, t1, t2 (link indices contracted)
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let s0 = DynIndex::new_dyn(2);
+    /// let link = DynIndex::new_dyn(1);
+    /// let s1 = DynIndex::new_dyn(2);
+    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0, 2.0])?;
+    /// let t1 = TensorDynLen::from_dense(vec![link.clone(), s1.clone()], vec![3.0, 4.0])?;
+    ///
+    /// let tt = TensorTrain::new(vec![t0, t1])?;
+    /// let dense = tt.to_dense()?;
+    ///
+    /// assert_eq!(dense.dims(), vec![2, 2]);
+    /// assert_eq!(dense.to_vec::<f64>()?, vec![3.0, 6.0, 4.0, 8.0]);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn to_dense(&self) -> Result<TensorDynLen> {
         if self.is_empty() {
@@ -973,9 +987,21 @@ impl TensorTrain {
     /// A new tensor train scaled by the given scalar.
     ///
     /// # Example
-    /// ```ignore
+    /// ```
+    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let s0 = DynIndex::new_dyn(2);
+    /// let tt = TensorTrain::new(vec![TensorDynLen::from_dense(
+    ///     vec![s0.clone()],
+    ///     vec![1.0, 2.0],
+    /// )?])?;
+    ///
     /// let scaled = tt.scale(AnyScalar::new_real(2.0))?;
-    /// // scaled represents 2 * tt
+    /// assert_eq!(scaled.to_dense()?.to_vec::<f64>()?, vec![2.0, 4.0]);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn scale(&self, scalar: AnyScalar) -> Result<Self> {
         if self.is_empty() {

--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -26,12 +26,13 @@ use crate::quantics_tci::quanticscrossinterpolate;
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tensor4all_quanticstci::{
 ///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
 /// };
+/// use tensor4all_simplett::AbstractTensorTrain;
 ///
-/// let grid = DiscretizedGrid::builder(&[4])
+/// let grid = DiscretizedGrid::builder(&[2])
 ///     .with_lower_bound(&[0.0])
 ///     .with_upper_bound(&[1.0])
 ///     .build()
@@ -39,14 +40,14 @@ use crate::quantics_tci::quanticscrossinterpolate;
 ///
 /// let (result, _, _) = quanticscrossinterpolate_batched::<f64, _>(
 ///     &grid,
-///     |x: &[f64]| vec![x[0].sin(), x[0].cos()],
+///     |x: &[f64]| vec![x[0] + 1.0, 2.0 * x[0] + 1.0],
 ///     &[2],
 ///     None,
 ///     QtciOptions::default(),
 /// ).unwrap();
 ///
 /// assert_eq!(result.output_dims(), &[2]);
-/// assert_eq!(result.tensor_train().len(), 5); // 4 grid sites + 1 component site
+/// assert_eq!(result.tensor_train().len(), 3); // 2 grid sites + 1 component site
 /// ```
 #[derive(Clone)]
 pub struct QuanticsTensorCI2Batched<V: TTScalar> {
@@ -69,13 +70,13 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tensor4all_quanticstci::{
     ///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
     /// };
     /// use tensor4all_simplett::AbstractTensorTrain;
     ///
-    /// let grid = DiscretizedGrid::builder(&[4])
+    /// let grid = DiscretizedGrid::builder(&[2])
     ///     .with_lower_bound(&[0.0])
     ///     .with_upper_bound(&[1.0])
     ///     .build()
@@ -83,14 +84,14 @@ where
     ///
     /// let (result, _, _) = quanticscrossinterpolate_batched::<f64, _>(
     ///     &grid,
-    ///     |x: &[f64]| vec![x[0], x[0] * x[0]],
+    ///     |x: &[f64]| vec![x[0] + 1.0, x[0] * x[0] + 1.0],
     ///     &[2],
     ///     None,
     ///     QtciOptions::default(),
     /// ).unwrap();
     ///
     /// let tt = result.tensor_train();
-    /// assert_eq!(tt.len(), 5); // 4 grid sites + 1 component site
+    /// assert_eq!(tt.len(), 3); // 2 grid sites + 1 component site
     /// ```
     pub fn tensor_train(&self) -> &TensorTrain<V> {
         &self.tt
@@ -100,12 +101,12 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tensor4all_quanticstci::{
     ///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
     /// };
     ///
-    /// let grid = DiscretizedGrid::builder(&[4])
+    /// let grid = DiscretizedGrid::builder(&[2])
     ///     .with_lower_bound(&[0.0])
     ///     .with_upper_bound(&[1.0])
     ///     .build()
@@ -113,7 +114,7 @@ where
     ///
     /// let (result, _, _) = quanticscrossinterpolate_batched::<f64, _>(
     ///     &grid,
-    ///     |x: &[f64]| vec![x[0], x[0] * x[0]],
+    ///     |x: &[f64]| vec![x[0] + 1.0, x[0] * x[0] + 1.0],
     ///     &[2],
     ///     None,
     ///     QtciOptions::default(),
@@ -129,12 +130,12 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```
     /// use tensor4all_quanticstci::{
     ///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
     /// };
     ///
-    /// let grid = DiscretizedGrid::builder(&[4])
+    /// let grid = DiscretizedGrid::builder(&[2])
     ///     .with_lower_bound(&[0.0])
     ///     .with_upper_bound(&[1.0])
     ///     .build()
@@ -142,7 +143,7 @@ where
     ///
     /// let (result, _, _) = quanticscrossinterpolate_batched::<f64, _>(
     ///     &grid,
-    ///     |x: &[f64]| vec![x[0]],
+    ///     |x: &[f64]| vec![x[0] + 1.0],
     ///     &[1],
     ///     None,
     ///     QtciOptions::default(),
@@ -178,14 +179,13 @@ where
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tensor4all_quanticstci::{
 ///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
 /// };
 /// use tensor4all_simplett::AbstractTensorTrain;
 ///
-/// let grid = DiscretizedGrid::builder(&[6])
-///     .with_variable_names(&["x"])
+/// let grid = DiscretizedGrid::builder(&[2])
 ///     .with_lower_bound(&[0.0])
 ///     .with_upper_bound(&[1.0])
 ///     .build()
@@ -194,16 +194,18 @@ where
 /// let (result, ranks, errors) = quanticscrossinterpolate_batched::<f64, _>(
 ///     &grid,
 ///     |x: &[f64]| vec![
-///         (2.0 * std::f64::consts::PI * x[0]).sin(),
-///         (2.0 * std::f64::consts::PI * x[0]).cos(),
+///         x[0] + 1.0,
+///         2.0 * x[0] + 1.0,
 ///     ],
 ///     &[2],
 ///     None,
 ///     QtciOptions::default().with_tolerance(1e-8),
 /// ).unwrap();
 ///
-/// assert_eq!(result.tensor_train().len(), 7); // 6 grid sites + 1 component site
+/// assert_eq!(result.tensor_train().len(), 3); // 2 grid sites + 1 component site
 /// assert_eq!(result.output_dims(), &[2]);
+/// assert!(!ranks.is_empty());
+/// assert!(!errors.is_empty());
 /// ```
 pub fn quanticscrossinterpolate_batched<V, F>(
     grid: &DiscretizedGrid,

--- a/crates/tensor4all-simplett/src/mpo/dispatch.rs
+++ b/crates/tensor4all-simplett/src/mpo/dispatch.rs
@@ -41,21 +41,24 @@ use tenferro_tensor::KeepCountScalar;
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
 /// use tensor4all_simplett::mpo::{contract, MPO, ContractionOptions, ContractionAlgorithm};
 ///
-/// let mpo_a = MPO::identity(&[2, 2])?;
-/// let mpo_b = MPO::identity(&[2, 2])?;
+/// let mpo_a = MPO::<f64>::identity(&[2, 2]).unwrap();
+/// let mpo_b = MPO::<f64>::identity(&[2, 2]).unwrap();
 /// let options = ContractionOptions::default();
 ///
 /// // Use naive algorithm
-/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Naive, &options)?;
+/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Naive, &options).unwrap();
+/// assert_eq!(result.site_dims(), vec![(2, 2), (2, 2)]);
 ///
 /// // Use zip-up algorithm for memory efficiency
-/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::ZipUp, &options)?;
+/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::ZipUp, &options).unwrap();
+/// assert_eq!(result.len(), 2);
 ///
 /// // Use variational fitting for controlled bond dimension
-/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options)?;
+/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options).unwrap();
+/// assert_eq!(result.len(), 2);
 /// ```
 pub fn contract<T: SVDScalar + EinsumScalar>(
     mpo_a: &MPO<T>,

--- a/crates/tensor4all-simplett/src/mpo/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mod.rs
@@ -18,12 +18,15 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
 //! use tensor4all_simplett::mpo::{MPO, contract_naive, ContractionOptions};
 //!
-//! let mpo_a = MPO::constant(&[2, 2], 1.0);
-//! let mpo_b = MPO::constant(&[2, 2], 2.0);
-//! let result = contract_naive(&mpo_a, &mpo_b, None)?;
+//! let mpo_a = MPO::constant(&[(2, 2), (2, 2)], 1.0_f64);
+//! let mpo_b = MPO::constant(&[(2, 2), (2, 2)], 2.0_f64);
+//! let result = contract_naive(&mpo_a, &mpo_b, Some(ContractionOptions::default())).unwrap();
+//!
+//! assert_eq!(result.len(), 2);
+//! assert_eq!(result.site_dims(), vec![(2, 2), (2, 2)]);
 //! ```
 
 /// Type alias for 2D matrix.

--- a/crates/tensor4all-simplett/src/mpo/tt_contraction.rs
+++ b/crates/tensor4all-simplett/src/mpo/tt_contraction.rs
@@ -10,15 +10,15 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! use tensor4all_mpocontraction::tt_contraction::{dot, ContractionOptions};
-//! use crate::TensorTrain;
+//! ```
+//! use tensor4all_simplett::mpo::tt_contraction::{dot, TensorTrain};
 //!
 //! let tt1 = TensorTrain::<f64>::constant(&[2, 3], 2.0);
 //! let tt2 = TensorTrain::<f64>::constant(&[2, 3], 3.0);
 //!
 //! // Inner product
 //! let inner = dot(&tt1, &tt2).unwrap();
+//! assert_eq!(inner, 36.0);
 //! ```
 
 // Re-export TT contraction types and functions from tensor4all-simplett

--- a/crates/tensor4all-tcicore/src/cached_function/cache_key.rs
+++ b/crates/tensor4all-tcicore/src/cached_function/cache_key.rs
@@ -7,24 +7,35 @@
 //! To support index spaces larger than 1024 bits, implement `CacheKey` for a
 //! wider integer type and pass it via `CachedFunction::with_key_type`:
 //!
-//! ```ignore
+//! ```
 //! use bnum::types::U2048;
-//! use tensor4all_tcicore::cached_function::cache_key::CacheKey;
+//! use tensor4all_tcicore::{CacheKey, CachedFunction};
 //!
-//! impl CacheKey for U2048 {
+//! #[derive(Clone, Hash, PartialEq, Eq)]
+//! struct U2048Key(U2048);
+//!
+//! impl CacheKey for U2048Key {
 //!     const BITS_COUNT: u32 = 2048;
-//!     const ZERO: Self = U2048::ZERO;
-//!     const ONE: Self = U2048::ONE;
-//!     fn from_usize(v: usize) -> Self { U2048::from(v as u64) }
+//!     const ZERO: Self = Self(U2048::ZERO);
+//!     const ONE: Self = Self(U2048::ONE);
+//!     fn from_usize(v: usize) -> Self { Self(U2048::from(v as u64)) }
 //!     fn checked_mul(self, rhs: Self) -> Option<Self> {
-//!         self.checked_mul(rhs)
+//!         self.0.checked_mul(rhs.0).map(Self)
 //!     }
 //!     fn wrapping_add(self, rhs: Self) -> Self {
-//!         self.wrapping_add(rhs)
+//!         Self(self.0.wrapping_add(rhs.0))
 //!     }
 //! }
 //!
-//! let cf = CachedFunction::with_key_type::<U2048>(f, &local_dims)?;
+//! let local_dims = vec![2usize; 1025];
+//! let cf = CachedFunction::with_key_type::<U2048Key>(
+//!     |idx: &[usize]| idx.iter().sum::<usize>(),
+//!     &local_dims,
+//! ).unwrap();
+//! let zeros = vec![0usize; 1025];
+//!
+//! assert_eq!(cf.eval(&zeros), 0);
+//! assert_eq!(cf.key_type(), "custom");
 //! ```
 
 use std::hash::Hash;

--- a/crates/tensor4all-tcicore/src/cached_function/mod.rs
+++ b/crates/tensor4all-tcicore/src/cached_function/mod.rs
@@ -434,10 +434,40 @@ where
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```
     /// use bnum::types::U2048;
-    /// // impl CacheKey for U2048 { ... } // see CacheKey docs
-    /// let cf = CachedFunction::with_key_type::<U2048>(f, &local_dims)?;
+    /// use tensor4all_tcicore::{CacheKey, CachedFunction};
+    ///
+    /// #[derive(Clone, Hash, PartialEq, Eq)]
+    /// struct U2048Key(U2048);
+    ///
+    /// impl CacheKey for U2048Key {
+    ///     const BITS_COUNT: u32 = 2048;
+    ///     const ZERO: Self = Self(U2048::ZERO);
+    ///     const ONE: Self = Self(U2048::ONE);
+    ///
+    ///     fn from_usize(v: usize) -> Self {
+    ///         Self(U2048::from(v as u64))
+    ///     }
+    ///
+    ///     fn checked_mul(self, rhs: Self) -> Option<Self> {
+    ///         self.0.checked_mul(rhs.0).map(Self)
+    ///     }
+    ///
+    ///     fn wrapping_add(self, rhs: Self) -> Self {
+    ///         Self(self.0.wrapping_add(rhs.0))
+    ///     }
+    /// }
+    ///
+    /// let local_dims = vec![2usize; 1025];
+    /// let cf = CachedFunction::with_key_type::<U2048Key>(
+    ///     |idx: &[usize]| idx.iter().sum::<usize>(),
+    ///     &local_dims,
+    /// ).unwrap();
+    /// let zeros = vec![0usize; 1025];
+    ///
+    /// assert_eq!(cf.eval(&zeros), 0);
+    /// assert_eq!(cf.key_type(), "custom");
     /// ```
     pub fn with_key_type<K: CacheKey>(
         func: F,

--- a/crates/tensor4all-tcicore/src/scalar.rs
+++ b/crates/tensor4all-tcicore/src/scalar.rs
@@ -191,15 +191,14 @@ impl Scalar for Complex32 {
 ///
 /// # Example
 ///
-/// ```ignore
-/// fn test_operation_generic<T: Scalar>() {
-///     // test implementation
+/// ```
+/// fn test_operation_generic<T: tensor4all_tcicore::Scalar>() {
+///     let value = T::from_f64(2.0);
+///     assert_eq!(value.abs_sq(), 4.0);
 /// }
 ///
+/// # fn main() {}
 /// tensor4all_tcicore::scalar_tests!(test_operation, test_operation_generic);
-/// // Generates:
-/// // #[test] fn test_operation_f64() { test_operation_generic::<f64>(); }
-/// // #[test] fn test_operation_c64() { test_operation_generic::<Complex64>(); }
 /// ```
 #[macro_export]
 macro_rules! scalar_tests {

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -88,8 +88,11 @@ use tensor4all_core::TensorDynLen;
 /// Default TreeTN type using TensorDynLen as the tensor type.
 ///
 /// This is the most common configuration for TreeTN, equivalent to:
-/// ```ignore
-/// TreeTN<TensorDynLen, NodeIndex>
+/// ```
+/// use tensor4all_treetn::DefaultTreeTN;
+///
+/// let tree: DefaultTreeTN = DefaultTreeTN::new();
+/// assert_eq!(tree.node_count(), 0);
 /// ```
 ///
 /// Use this when you don't need custom tensor types.

--- a/crates/tensor4all-treetn/src/linsolve/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/mod.rs
@@ -12,10 +12,13 @@
 //!
 //! For most use cases, use the `square` solver:
 //!
-//! ```ignore
-//! use tensor4all_treetn::linsolve::square::{square_linsolve, LinsolveOptions};
+//! ```
+//! use tensor4all_treetn::{square_linsolve, LinsolveOptions};
 //!
-//! let result = square_linsolve(&operator, &rhs, init, &center, LinsolveOptions::default())?;
+//! let options = LinsolveOptions::default().with_nfullsweeps(2);
+//! let _solver = square_linsolve::<tensor4all_core::TensorDynLen, usize>;
+//!
+//! assert_eq!(options.nfullsweeps, 2);
 //! ```
 
 pub mod common;

--- a/crates/tensor4all-treetn/src/linsolve/square/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/mod.rs
@@ -109,8 +109,24 @@ where
 ///
 /// # Example
 ///
-/// ```ignore
-/// let solution = square_linsolve(&h_mpo, &b_mps, x0_mps, "center", LinsolveOptions::default())?;
+/// ```no_run
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{square_linsolve, LinsolveOptions, TreeTN};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let s = DynIndex::new_dyn(2);
+/// let operator_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 1.0])?;
+/// let rhs_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+/// let init_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![0.0, 0.0])?;
+///
+/// let operator = TreeTN::<TensorDynLen, usize>::from_tensors(vec![operator_tensor], vec![0])?;
+/// let rhs = TreeTN::<TensorDynLen, usize>::from_tensors(vec![rhs_tensor], vec![0])?;
+/// let init = TreeTN::<TensorDynLen, usize>::from_tensors(vec![init_tensor], vec![0])?;
+///
+/// let result = square_linsolve(&operator, &rhs, init, &0usize, LinsolveOptions::default())?;
+/// assert_eq!(result.solution.node_count(), 1);
+/// # Ok(())
+/// # }
 /// ```
 pub fn square_linsolve<T, V>(
     operator: &TreeTN<T, V>,

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -15,8 +15,47 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```no_run
+//! use std::collections::HashMap;
+//!
+//! use tensor4all_core::{DynIndex, TensorDynLen};
+//! use tensor4all_treetn::{apply_linear_operator, ApplyOptions, IndexMapping, LinearOperator, TreeTN};
+//!
+//! # fn main() -> anyhow::Result<()> {
+//! let site = DynIndex::new_dyn(2);
+//! let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 2.0])?;
+//! let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+//!
+//! let input_internal = DynIndex::new_dyn(2);
+//! let output_internal = DynIndex::new_dyn(2);
+//! let mpo_tensor = TensorDynLen::from_dense(
+//!     vec![input_internal.clone(), output_internal.clone()],
+//!     vec![1.0, 0.0, 0.0, 1.0],
+//! )?;
+//! let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0])?;
+//!
+//! let mut input_mapping = HashMap::new();
+//! input_mapping.insert(
+//!     0usize,
+//!     IndexMapping {
+//!         true_index: site.clone(),
+//!         internal_index: input_internal,
+//!     },
+//! );
+//! let mut output_mapping = HashMap::new();
+//! output_mapping.insert(
+//!     0usize,
+//!     IndexMapping {
+//!         true_index: site.clone(),
+//!         internal_index: output_internal,
+//!     },
+//! );
+//!
+//! let operator = LinearOperator::new(mpo, input_mapping, output_mapping);
 //! let result = apply_linear_operator(&operator, &state, ApplyOptions::default())?;
+//! assert_eq!(result.node_count(), 1);
+//! # Ok(())
+//! # }
 //! ```
 
 use std::collections::{HashMap, HashSet};
@@ -125,18 +164,55 @@ impl ApplyOptions {
 ///
 /// # Example
 ///
-/// ```ignore
-/// use tensor4all_treetn::operator::{apply_linear_operator, ApplyOptions};
+/// ```no_run
+/// use std::collections::HashMap;
 ///
-/// // Apply with default options (ZipUp)
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{apply_linear_operator, ApplyOptions, IndexMapping, LinearOperator, TreeTN};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let site = DynIndex::new_dyn(2);
+/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 2.0])?;
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+///
+/// let input_internal = DynIndex::new_dyn(2);
+/// let output_internal = DynIndex::new_dyn(2);
+/// let mpo_tensor = TensorDynLen::from_dense(
+///     vec![input_internal.clone(), output_internal.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// )?;
+/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0])?;
+///
+/// let mut input_mapping = HashMap::new();
+/// input_mapping.insert(
+///     0usize,
+///     IndexMapping {
+///         true_index: site.clone(),
+///         internal_index: input_internal,
+///     },
+/// );
+/// let mut output_mapping = HashMap::new();
+/// output_mapping.insert(
+///     0usize,
+///     IndexMapping {
+///         true_index: site.clone(),
+///         internal_index: output_internal,
+///     },
+/// );
+///
+/// let operator = LinearOperator::new(mpo, input_mapping, output_mapping);
+///
 /// let result = apply_linear_operator(&operator, &state, ApplyOptions::default())?;
+/// assert_eq!(result.node_count(), 1);
 ///
-/// // Apply with truncation
-/// let result = apply_linear_operator(
+/// let truncated = apply_linear_operator(
 ///     &operator,
 ///     &state,
-///     ApplyOptions::zipup().with_max_rank(50).with_rtol(1e-10),
+///     ApplyOptions::zipup().with_max_rank(4).with_rtol(1e-10),
 /// )?;
+/// assert_eq!(truncated.node_count(), 1);
+/// # Ok(())
+/// # }
 /// ```
 pub fn apply_linear_operator<T, V>(
     operator: &LinearOperator<T, V>,

--- a/crates/tensor4all-treetn/src/operator/linear_operator.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator.rs
@@ -365,16 +365,46 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use tensor4all_treetn::LinearOperator;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
-    /// use tensor4all_treetn::TreeTN;
+    /// ```
     /// use std::collections::HashMap;
     ///
-    /// // Given an operator `op` and a state `state`:
+    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
+    ///
+    /// let state_index = DynIndex::new_dyn(2);
+    /// let state_tensor = TensorDynLen::from_dense(vec![state_index.clone()], vec![1.0, 2.0]).unwrap();
+    /// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
+    ///
+    /// let input_internal = DynIndex::new_dyn(2);
+    /// let output_internal = DynIndex::new_dyn(2);
+    /// let mpo_tensor = TensorDynLen::from_dense(
+    ///     vec![input_internal.clone(), output_internal.clone()],
+    ///     vec![1.0, 0.0, 0.0, 1.0],
+    /// ).unwrap();
+    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+    ///
+    /// let mut input_mapping = HashMap::new();
+    /// input_mapping.insert(
+    ///     0usize,
+    ///     IndexMapping {
+    ///         true_index: DynIndex::new_dyn(2),
+    ///         internal_index: input_internal,
+    ///     },
+    /// );
+    /// let mut output_mapping = HashMap::new();
+    /// output_mapping.insert(
+    ///     0usize,
+    ///     IndexMapping {
+    ///         true_index: DynIndex::new_dyn(2),
+    ///         internal_index: output_internal,
+    ///     },
+    /// );
+    ///
+    /// let mut op = LinearOperator::new(mpo, input_mapping, output_mapping);
     /// op.align_to_state(&state).unwrap();
-    /// // Now op.input_mapping and op.output_mapping true_index fields
-    /// // reference the state's site indices.
+    ///
+    /// assert!(op.input_mappings()[&0].true_index.same_id(&state_index));
+    /// assert!(op.output_mappings()[&0].true_index.same_id(&state_index));
     /// ```
     pub fn align_to_state(&mut self, state: &TreeTN<T, V>) -> Result<()> {
         self.set_input_space_from_state(state)?;

--- a/crates/tensor4all-treetn/src/operator/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/mod.rs
@@ -12,19 +12,18 @@
 //!
 //! # Example
 //!
-//! ```ignore
-//! // Build local operators acting on different regions
-//! let op1 = build_local_operator(&[site_a, site_b]);  // acts on {a, b}
-//! let op2 = build_local_operator(&[site_c, site_d]);  // acts on {c, d}
+//! ```
+//! use tensor4all_core::{DynIndex, IndexLike};
+//! use tensor4all_treetn::{apply_linear_operator, compose_exclusive_linear_operators, IndexMapping};
 //!
-//! // State has sites {a, b, x, c, d}
-//! let target = state.site_index_network();
+//! let mapping = IndexMapping {
+//!     true_index: DynIndex::new_dyn(2),
+//!     internal_index: DynIndex::new_dyn(2),
+//! };
 //!
-//! // Compose into single operator on full space (identity at gap x)
-//! let composed = compose_exclusive_linear_operators(target, &[&op1, &op2], &gap_indices)?;
-//!
-//! // Apply composed operator
-//! let result = state.contract_zipup(&composed, center, rtol, max_rank)?;
+//! assert_eq!(mapping.true_index.dim(), mapping.internal_index.dim());
+//! let _apply = apply_linear_operator::<tensor4all_core::TensorDynLen, usize>;
+//! let _compose = compose_exclusive_linear_operators::<tensor4all_core::TensorDynLen, usize>;
 //! ```
 
 mod apply;

--- a/crates/tensor4all-treetn/src/options.rs
+++ b/crates/tensor4all-treetn/src/options.rs
@@ -12,10 +12,15 @@ use tensor4all_core::truncation::{HasTruncationParams, TruncationParams};
 ///
 /// # Builder Pattern
 ///
-/// ```ignore
+/// ```
+/// use tensor4all_treetn::{CanonicalForm, CanonicalizationOptions};
+///
 /// let options = CanonicalizationOptions::default()
 ///     .with_form(CanonicalForm::LU)
 ///     .force();
+///
+/// assert!(matches!(options.form, CanonicalForm::LU));
+/// assert!(options.force);
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct CanonicalizationOptions {
@@ -72,10 +77,16 @@ impl CanonicalizationOptions {
 ///
 /// # Builder Pattern
 ///
-/// ```ignore
+/// ```
+/// use tensor4all_treetn::{CanonicalForm, TruncationOptions};
+///
 /// let options = TruncationOptions::default()
 ///     .with_max_rank(50)
 ///     .with_rtol(1e-10);
+///
+/// assert!(matches!(options.form, CanonicalForm::Unitary));
+/// assert_eq!(options.max_rank(), Some(50));
+/// assert_eq!(options.rtol(), Some(1e-10));
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct TruncationOptions {
@@ -143,11 +154,18 @@ impl TruncationOptions {
 ///
 /// # Builder Pattern
 ///
-/// ```ignore
+/// ```
+/// use tensor4all_treetn::{CanonicalForm, SplitOptions};
+///
 /// let options = SplitOptions::default()
 ///     .with_max_rank(50)
 ///     .with_rtol(1e-10)
 ///     .with_final_sweep(true);
+///
+/// assert!(matches!(options.form, CanonicalForm::Unitary));
+/// assert_eq!(options.max_rank(), Some(50));
+/// assert_eq!(options.rtol(), Some(1e-10));
+/// assert!(options.final_sweep);
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct SplitOptions {

--- a/crates/tensor4all-treetn/src/treetn/addition.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition.rs
@@ -68,7 +68,19 @@ where
     /// incompatible site-space dimensions on any node.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// # fn make_chain(site0: DynIndex, site1: DynIndex) -> TreeTN<TensorDynLen, usize> {
+    /// #     let bond = DynIndex::new_dyn(1);
+    /// #     let t0 = TensorDynLen::from_dense(vec![site0, bond.clone()], vec![1.0, 0.0]).unwrap();
+    /// #     let t1 = TensorDynLen::from_dense(vec![bond, site1], vec![1.0, 0.0]).unwrap();
+    /// #     TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap()
+    /// # }
+    /// let state_a = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
+    /// let state_b = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
+    ///
     /// let aligned = state_b.reindex_site_space_like(&state_a).unwrap();
     /// assert!(aligned.share_equivalent_site_index_network(&state_a));
     /// ```
@@ -135,8 +147,21 @@ where
     /// The direct-sum addition result with site IDs matching `self`.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// # fn make_chain(site0: DynIndex, site1: DynIndex) -> TreeTN<TensorDynLen, usize> {
+    /// #     let bond = DynIndex::new_dyn(1);
+    /// #     let t0 = TensorDynLen::from_dense(vec![site0, bond.clone()], vec![1.0, 0.0]).unwrap();
+    /// #     let t1 = TensorDynLen::from_dense(vec![bond, site1], vec![1.0, 0.0]).unwrap();
+    /// #     TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap()
+    /// # }
+    /// let state_a = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
+    /// let state_b = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
+    ///
     /// let sum = state_a.add_aligned(&state_b).unwrap();
+    /// assert_eq!(sum.node_count(), 2);
     /// assert!(sum.share_equivalent_site_index_network(&state_a));
     /// ```
     pub fn add_aligned(&self, other: &Self) -> Result<Self>

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -435,9 +435,25 @@ use tensor4all_core::{Canonical, FactorizeOptions};
 /// 4. B is the orthogonality center (isometry pointing towards B)
 ///
 /// # Usage
-/// ```ignore
-/// let mut updater = TruncateUpdater::new(max_rank, rtol);
+/// ```no_run
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{apply_local_update_sweep, LocalUpdateSweepPlan, TreeTN, TruncateUpdater};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let s0 = DynIndex::new_dyn(2);
+/// let bond = DynIndex::new_dyn(1);
+/// let s1 = DynIndex::new_dyn(2);
+/// let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
+/// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
+/// let mut treetn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
+///
+/// let plan = LocalUpdateSweepPlan::from_treetn(&treetn, &0usize, 2).unwrap();
+/// let mut updater = TruncateUpdater::new(Some(4), Some(1e-10));
 /// apply_local_update_sweep(&mut treetn, &plan, &mut updater)?;
+///
+/// assert_eq!(treetn.node_count(), 2);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone)]
 pub struct TruncateUpdater {

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -1685,11 +1685,24 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::IndexLike;
-    /// use tensor4all_treetn::SwapOptions;
+    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_treetn::{SwapOptions, TreeTN};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let node_name_a = "A".to_string();
+    /// let node_name_b = "B".to_string();
+    /// let idx_a = DynIndex::new_dyn(2);
+    /// let idx_b = DynIndex::new_dyn(2);
+    /// let bond = DynIndex::new_dyn(1);
+    /// let t0 = TensorDynLen::from_dense(vec![idx_a.clone(), bond.clone()], vec![1.0, 0.0])?;
+    /// let t1 = TensorDynLen::from_dense(vec![bond, idx_b.clone()], vec![1.0, 0.0])?;
+    /// let mut treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+    ///     vec![t0, t1],
+    ///     vec![node_name_a.clone(), node_name_b.clone()],
+    /// )?;
     ///
     /// let mut target = HashMap::new();
     /// target.insert(idx_a.clone(), node_name_b.clone());
@@ -1704,6 +1717,7 @@ where
     ///     Some(node_name_b.as_str())
     /// );
     /// # Ok::<(), anyhow::Error>(())
+    /// # }
     /// ```
     pub fn swap_site_indices_by_index(
         &mut self,

--- a/crates/tensor4all-treetn/src/treetn/ops.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops.rs
@@ -541,7 +541,7 @@ where
     /// Returns an error if a node's site space cannot be found.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```
     /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///
@@ -608,7 +608,7 @@ where
     /// call fails (see its documentation for details).
     ///
     /// # Examples
-    /// ```ignore
+    /// ```
     /// use tensor4all_core::{ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -37,7 +37,7 @@ type DiagonalPairApplication<V> = (
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```
 /// use tensor4all_core::DynIndex;
 /// use tensor4all_treetn::PartialContractionSpec;
 ///
@@ -550,16 +550,25 @@ where
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use tensor4all_core::DynIndex;
+/// ```no_run
+/// use tensor4all_core::{DynIndex, TensorDynLen};
 /// use tensor4all_treetn::{
 ///     contraction::ContractionOptions,
 ///     partial_contract,
 ///     PartialContractionSpec,
+///     TreeTN,
 /// };
 ///
 /// let idx_a = DynIndex::new_dyn(2);
 /// let idx_b = DynIndex::new_dyn(2);
+/// let a = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![idx_a.clone()], vec![1.0, 2.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+/// let b = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![idx_b.clone()], vec![3.0, 4.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
 ///
 /// let spec = PartialContractionSpec {
 ///     contract_pairs: vec![(idx_a.clone(), idx_b.clone())],
@@ -567,8 +576,8 @@ where
 ///     output_order: None,
 /// };
 ///
-/// assert_eq!(spec.contract_pairs.len(), 1);
-/// let _ = (partial_contract, ContractionOptions::default());
+/// let result = partial_contract(&a, &b, &spec, &0usize, ContractionOptions::default()).unwrap();
+/// assert_eq!(result.node_count(), 1);
 /// ```
 pub fn partial_contract<V>(
     a: &TreeTN<TensorDynLen, V>,


### PR DESCRIPTION
## Summary
- Convert 38 of 39 `/// ```ignore` doc examples to runnable doctests or `no_run` across the workspace
- Only remaining `ignore` is in `tensor4all-capi/src/macros.rs` (macro expands to crate-private FFI helpers)
- All examples now use concrete types (`TensorDynLen`, `DynIndex`) with assertions

## Test plan
- [x] `cargo test --doc --workspace --release` — 33 passed, 0 failed
- [x] `cargo doc --workspace --no-deps` — builds successfully
- [x] `cargo clippy --workspace` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)