### PR TITLE
[codex] Finish eager tensor migration

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -45,10 +45,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install mdBook
+        run: cargo install mdbook --version 0.5.2 --locked
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Run rustdoc tests
         run: cargo test --doc --release --workspace -j 8
+
+      - name: Run mdBook tests
+        run: ./scripts/test-mdbook.sh
 
   # testジョブ全体を無効化
   # test:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install mdBook
         run: cargo install mdbook --version 0.5.2 --locked
 
+      - name: Verify mdBook examples
+        run: ./scripts/test-mdbook.sh
+
       - name: Build mdBook
         run: mdbook build docs/book
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,8 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-algebra = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-prims = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
-tenferro-tensor-compute = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "c4e18845ba1735df4d37e122b808d75056b84b60" }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "adffa6515274a35054b9c6797e2adf319e2852c0" }
+tenferro-algebra = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "adffa6515274a35054b9c6797e2adf319e2852c0" }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "adffa6515274a35054b9c6797e2adf319e2852c0" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "adffa6515274a35054b9c6797e2adf319e2852c0" }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "adffa6515274a35054b9c6797e2adf319e2852c0" }

--- a/README.md
+++ b/README.md
@@ -22,23 +22,16 @@ tensor4all-simplett = "0.1"
 ```
 
 ```rust
-use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, TensorTrain};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
 
 let tt = TensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
-let value = tt.evaluate(&[0, 1, 2]).unwrap();
-assert!((value - 1.0).abs() < 1e-12);
-
-let total = tt.sum();
-assert!((total - 24.0).abs() < 1e-12);
-
-let options = CompressionOptions {
-    tolerance: 1e-10,
-    max_bond_dim: 20,
-    ..Default::default()
-};
-let compressed = tt.compressed(&options).unwrap();
-assert!((compressed.sum() - 24.0).abs() < 1e-10);
+assert!((tt.evaluate(&[0, 1, 2]).unwrap() - 1.0).abs() < 1e-12);
+assert!((tt.sum() - 24.0).abs() < 1e-12);
 ```
+
+The root `README.md` is kept intentionally short and its Rust snippets are
+validated in CI. Longer runnable examples live in the
+[User Guide](https://tensor4all.org/tensor4all-rs/).
 
 ## Crate Overview
 

--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -28,4 +28,4 @@ tenferro-tensor.workspace = true
 
 [dev-dependencies]
 rand_chacha.workspace = true
-tenferro-prims.workspace = true
+tenferro-tensor.workspace = true

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -1,0 +1,614 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use anyhow::{anyhow, Result};
+use num_complex::{Complex32, Complex64};
+use num_traits::{One, Zero};
+use tenferro::DType;
+use tensor4all_tensorbackend::AnyScalar as BackendScalar;
+
+use crate::defaults::tensordynlen::TensorDynLen;
+use crate::storage::{Storage, SumFromStorage};
+use crate::TensorElement;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum ScalarValue {
+    F32(f32),
+    F64(f64),
+    C32(Complex32),
+    C64(Complex64),
+}
+
+impl ScalarValue {
+    fn real(self) -> f64 {
+        match self {
+            Self::F32(value) => value as f64,
+            Self::F64(value) => value,
+            Self::C32(value) => value.re as f64,
+            Self::C64(value) => value.re,
+        }
+    }
+
+    fn imag(self) -> f64 {
+        match self {
+            Self::F32(_) | Self::F64(_) => 0.0,
+            Self::C32(value) => value.im as f64,
+            Self::C64(value) => value.im,
+        }
+    }
+
+    fn abs(self) -> f64 {
+        match self {
+            Self::F32(value) => value.abs() as f64,
+            Self::F64(value) => value.abs(),
+            Self::C32(value) => value.norm() as f64,
+            Self::C64(value) => value.norm(),
+        }
+    }
+
+    fn is_complex(self) -> bool {
+        matches!(self, Self::C32(_) | Self::C64(_))
+    }
+
+    fn is_zero(self) -> bool {
+        match self {
+            Self::F32(value) => value == 0.0,
+            Self::F64(value) => value == 0.0,
+            Self::C32(value) => value == Complex32::new(0.0, 0.0),
+            Self::C64(value) => value == Complex64::new(0.0, 0.0),
+        }
+    }
+
+    fn into_complex(self) -> Complex64 {
+        match self {
+            Self::F32(value) => Complex64::new(value as f64, 0.0),
+            Self::F64(value) => Complex64::new(value, 0.0),
+            Self::C32(value) => Complex64::new(value.re as f64, value.im as f64),
+            Self::C64(value) => value,
+        }
+    }
+}
+
+/// Dynamic scalar compatibility wrapper for tensor4all-core.
+///
+/// This owns a rank-0 [`TensorDynLen`] so that scalar values can participate in
+/// the same eager autodiff graph as tensors while preserving the existing
+/// dynamic scalar API shape.
+#[derive(Clone)]
+pub struct AnyScalar {
+    tensor: TensorDynLen,
+}
+
+#[allow(missing_docs)]
+impl AnyScalar {
+    fn wrap_tensor(tensor: TensorDynLen) -> Result<Self> {
+        let dims = tensor.dims();
+        anyhow::ensure!(
+            dims.is_empty(),
+            "AnyScalar requires a rank-0 tensor, got dims {:?}",
+            dims
+        );
+        Ok(Self { tensor })
+    }
+
+    fn from_tensor_result(tensor: Result<TensorDynLen>, op: &'static str) -> Self {
+        Self::wrap_tensor(
+            tensor
+                .unwrap_or_else(|e| panic!("AnyScalar::{op} returned invalid scalar tensor: {e}")),
+        )
+        .unwrap_or_else(|e| panic!("AnyScalar::{op} returned non-scalar tensor: {e}"))
+    }
+
+    fn from_eager_binary<E>(
+        lhs: &Self,
+        rhs: &Self,
+        op: &'static str,
+        f: impl FnOnce(
+            &tenferro::EagerTensor<tenferro::CpuBackend>,
+            &tenferro::EagerTensor<tenferro::CpuBackend>,
+        ) -> std::result::Result<tenferro::EagerTensor<tenferro::CpuBackend>, E>,
+    ) -> Self
+    where
+        E: fmt::Display,
+    {
+        let result = f(lhs.tensor.inner.as_ref(), rhs.tensor.inner.as_ref())
+            .unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
+        Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
+    }
+
+    fn from_eager_unary<E>(
+        input: &Self,
+        op: &'static str,
+        f: impl FnOnce(
+            &tenferro::EagerTensor<tenferro::CpuBackend>,
+        ) -> std::result::Result<tenferro::EagerTensor<tenferro::CpuBackend>, E>,
+    ) -> Self
+    where
+        E: fmt::Display,
+    {
+        let result = f(input.tensor.inner.as_ref())
+            .unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
+        Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
+    }
+
+    fn value(&self) -> ScalarValue {
+        match self.tensor.as_native().dtype() {
+            DType::F32 => ScalarValue::F32(
+                self.tensor
+                    .to_vec::<f32>()
+                    .unwrap_or_else(|e| panic!("failed to read f32 scalar value: {e}"))[0],
+            ),
+            DType::F64 => ScalarValue::F64(
+                self.tensor
+                    .to_vec::<f64>()
+                    .unwrap_or_else(|e| panic!("failed to read f64 scalar value: {e}"))[0],
+            ),
+            DType::C32 => ScalarValue::C32(
+                self.tensor
+                    .to_vec::<Complex32>()
+                    .unwrap_or_else(|e| panic!("failed to read c32 scalar value: {e}"))[0],
+            ),
+            DType::C64 => ScalarValue::C64(
+                self.tensor
+                    .to_vec::<Complex64>()
+                    .unwrap_or_else(|e| panic!("failed to read c64 scalar value: {e}"))[0],
+            ),
+        }
+    }
+
+    fn from_backend_scalar(value: BackendScalar) -> Self {
+        if let Some(value) = value.as_c64() {
+            Self::from_value(value)
+        } else {
+            Self::from_value(value.real())
+        }
+    }
+
+    pub(crate) fn from_tensor_unchecked(tensor: TensorDynLen) -> Self {
+        Self::wrap_tensor(tensor).unwrap_or_else(|e| panic!("AnyScalar tensor wrapper failed: {e}"))
+    }
+
+    pub(crate) fn as_tensor(&self) -> &TensorDynLen {
+        &self.tensor
+    }
+
+    pub fn from_value<T: TensorElement>(value: T) -> Self {
+        Self::from_tensor_result(TensorDynLen::scalar(value), "from_value")
+    }
+
+    pub fn from_real(x: f64) -> Self {
+        Self::from_value(x)
+    }
+
+    pub fn from_complex(re: f64, im: f64) -> Self {
+        Self::from_value(Complex64::new(re, im))
+    }
+
+    pub fn new_real(x: f64) -> Self {
+        Self::from_real(x)
+    }
+
+    pub fn new_complex(re: f64, im: f64) -> Self {
+        Self::from_complex(re, im)
+    }
+
+    pub fn primal(&self) -> Self {
+        self.detach()
+    }
+
+    pub fn enable_grad(self) -> Self {
+        Self::from_tensor_unchecked(self.tensor.enable_grad())
+    }
+
+    pub fn tracks_grad(&self) -> bool {
+        self.tensor.tracks_grad()
+    }
+
+    pub fn grad(&self) -> Result<Option<Self>> {
+        self.tensor
+            .grad()
+            .map(|maybe_grad| maybe_grad.map(Self::from_tensor_unchecked))
+    }
+
+    pub fn clear_grad(&self) -> Result<()> {
+        self.tensor.clear_grad()
+    }
+
+    pub fn backward(&self) -> Result<()> {
+        self.tensor.backward()
+    }
+
+    pub fn detach(&self) -> Self {
+        Self::from_tensor_unchecked(self.tensor.detach())
+    }
+
+    pub fn real(&self) -> f64 {
+        self.value().real()
+    }
+
+    pub fn imag(&self) -> f64 {
+        self.value().imag()
+    }
+
+    pub fn abs(&self) -> f64 {
+        self.value().abs()
+    }
+
+    pub fn is_complex(&self) -> bool {
+        self.value().is_complex()
+    }
+
+    pub fn is_real(&self) -> bool {
+        !self.is_complex()
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.value().is_zero()
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self.value() {
+            ScalarValue::F32(value) => Some(value as f64),
+            ScalarValue::F64(value) => Some(value),
+            ScalarValue::C32(_) | ScalarValue::C64(_) => None,
+        }
+    }
+
+    pub fn as_c64(&self) -> Option<Complex64> {
+        match self.value() {
+            ScalarValue::F32(_) | ScalarValue::F64(_) => None,
+            ScalarValue::C32(value) => Some(Complex64::new(value.re as f64, value.im as f64)),
+            ScalarValue::C64(value) => Some(value),
+        }
+    }
+
+    pub fn conj(&self) -> Self {
+        Self::from_eager_unary(self, "conj", |tensor| tensor.conj())
+    }
+
+    pub fn real_part(&self) -> Self {
+        Self::from_real(self.real())
+    }
+
+    pub fn imag_part(&self) -> Self {
+        Self::from_real(self.imag())
+    }
+
+    pub fn compose_complex(real: Self, imag: Self) -> Result<Self> {
+        if !real.is_real() || !imag.is_real() {
+            return Err(anyhow!(
+                "compose_complex requires real-valued inputs, got real={:?}, imag={:?}",
+                real.tensor.as_native().dtype(),
+                imag.tensor.as_native().dtype()
+            ));
+        }
+        let imag_term = &imag * &Self::new_complex(0.0, 1.0);
+        Ok(&real + &imag_term)
+    }
+
+    pub fn sqrt(&self) -> Self {
+        if self.is_complex() || self.real() < 0.0 {
+            Self::from_backend_scalar(self.to_backend_scalar().sqrt())
+        } else {
+            Self::from_eager_unary(self, "sqrt", |tensor| tensor.sqrt())
+        }
+    }
+
+    pub fn powf(&self, exponent: f64) -> Self {
+        Self::from_backend_scalar(self.to_backend_scalar().powf(exponent))
+    }
+
+    pub fn powi(&self, exponent: i32) -> Self {
+        if exponent == 0 {
+            return Self::one();
+        }
+
+        let mut base = self.clone();
+        let mut power = exponent.unsigned_abs();
+        let mut acc = Self::one();
+
+        while power > 0 {
+            if power % 2 == 1 {
+                acc = &acc * &base;
+            }
+            power /= 2;
+            if power > 0 {
+                base = &base * &base;
+            }
+        }
+
+        if exponent < 0 {
+            Self::one() / acc
+        } else {
+            acc
+        }
+    }
+
+    pub(crate) fn to_backend_scalar(&self) -> BackendScalar {
+        match self.value() {
+            ScalarValue::F32(value) => BackendScalar::from_value(value),
+            ScalarValue::F64(value) => BackendScalar::from_value(value),
+            ScalarValue::C32(value) => BackendScalar::from_value(value),
+            ScalarValue::C64(value) => BackendScalar::from_value(value),
+        }
+    }
+}
+
+impl SumFromStorage for AnyScalar {
+    fn sum_from_storage(storage: &Storage) -> Self {
+        Self::from_backend_scalar(BackendScalar::sum_from_storage(storage))
+    }
+}
+
+impl From<f32> for AnyScalar {
+    fn from(value: f32) -> Self {
+        Self::from_value(value)
+    }
+}
+
+impl From<f64> for AnyScalar {
+    fn from(value: f64) -> Self {
+        Self::from_value(value)
+    }
+}
+
+impl From<Complex32> for AnyScalar {
+    fn from(value: Complex32) -> Self {
+        Self::from_value(value)
+    }
+}
+
+impl From<Complex64> for AnyScalar {
+    fn from(value: Complex64) -> Self {
+        Self::from_value(value)
+    }
+}
+
+impl TryFrom<AnyScalar> for f64 {
+    type Error = &'static str;
+
+    fn try_from(value: AnyScalar) -> std::result::Result<Self, Self::Error> {
+        value.as_f64().ok_or("cannot convert complex scalar to f64")
+    }
+}
+
+impl From<AnyScalar> for Complex64 {
+    fn from(value: AnyScalar) -> Self {
+        value.value().into_complex()
+    }
+}
+
+impl Add<&AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn add(self, rhs: &AnyScalar) -> Self::Output {
+        AnyScalar::from_eager_binary(self, rhs, "add", |lhs, rhs| lhs.add(rhs))
+    }
+}
+
+impl Add<AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn add(self, rhs: AnyScalar) -> Self::Output {
+        Add::add(&self, &rhs)
+    }
+}
+
+impl Add<AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn add(self, rhs: AnyScalar) -> Self::Output {
+        Add::add(self, &rhs)
+    }
+}
+
+impl Add<&AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn add(self, rhs: &AnyScalar) -> Self::Output {
+        Add::add(&self, rhs)
+    }
+}
+
+impl Sub<&AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn sub(self, rhs: &AnyScalar) -> Self::Output {
+        Add::add(self, &Neg::neg(rhs))
+    }
+}
+
+impl Sub<AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn sub(self, rhs: AnyScalar) -> Self::Output {
+        Sub::sub(&self, &rhs)
+    }
+}
+
+impl Sub<AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn sub(self, rhs: AnyScalar) -> Self::Output {
+        Sub::sub(self, &rhs)
+    }
+}
+
+impl Sub<&AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn sub(self, rhs: &AnyScalar) -> Self::Output {
+        Sub::sub(&self, rhs)
+    }
+}
+
+impl Mul<&AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn mul(self, rhs: &AnyScalar) -> Self::Output {
+        AnyScalar::from_eager_binary(self, rhs, "mul", |lhs, rhs| lhs.mul(rhs))
+    }
+}
+
+impl Mul<AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn mul(self, rhs: AnyScalar) -> Self::Output {
+        Mul::mul(&self, &rhs)
+    }
+}
+
+impl Mul<AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn mul(self, rhs: AnyScalar) -> Self::Output {
+        Mul::mul(self, &rhs)
+    }
+}
+
+impl Mul<&AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn mul(self, rhs: &AnyScalar) -> Self::Output {
+        Mul::mul(&self, rhs)
+    }
+}
+
+impl Div<&AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn div(self, rhs: &AnyScalar) -> Self::Output {
+        if self.tensor.as_native().dtype() == rhs.tensor.as_native().dtype() {
+            AnyScalar::from_eager_binary(self, rhs, "div", |lhs, rhs| lhs.div(rhs))
+        } else {
+            AnyScalar::from_backend_scalar(self.to_backend_scalar() / rhs.to_backend_scalar())
+        }
+    }
+}
+
+impl Div<AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn div(self, rhs: AnyScalar) -> Self::Output {
+        Div::div(&self, &rhs)
+    }
+}
+
+impl Div<AnyScalar> for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn div(self, rhs: AnyScalar) -> Self::Output {
+        Div::div(self, &rhs)
+    }
+}
+
+impl Div<&AnyScalar> for AnyScalar {
+    type Output = AnyScalar;
+
+    fn div(self, rhs: &AnyScalar) -> Self::Output {
+        Div::div(&self, rhs)
+    }
+}
+
+impl Neg for &AnyScalar {
+    type Output = AnyScalar;
+
+    fn neg(self) -> Self::Output {
+        AnyScalar::from_eager_unary(self, "neg", |tensor| tensor.neg())
+    }
+}
+
+impl Neg for AnyScalar {
+    type Output = AnyScalar;
+
+    fn neg(self) -> Self::Output {
+        Neg::neg(&self)
+    }
+}
+
+impl Mul<AnyScalar> for f64 {
+    type Output = AnyScalar;
+
+    fn mul(self, rhs: AnyScalar) -> Self::Output {
+        AnyScalar::from_real(self) * rhs
+    }
+}
+
+impl Mul<AnyScalar> for Complex64 {
+    type Output = AnyScalar;
+
+    fn mul(self, rhs: AnyScalar) -> Self::Output {
+        AnyScalar::from(self) * rhs
+    }
+}
+
+impl Div<AnyScalar> for Complex64 {
+    type Output = AnyScalar;
+
+    fn div(self, rhs: AnyScalar) -> Self::Output {
+        AnyScalar::from(self) / rhs
+    }
+}
+
+impl Default for AnyScalar {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl Zero for AnyScalar {
+    fn zero() -> Self {
+        Self::from_real(0.0)
+    }
+
+    fn is_zero(&self) -> bool {
+        AnyScalar::is_zero(self)
+    }
+}
+
+impl One for AnyScalar {
+    fn one() -> Self {
+        Self::from_real(1.0)
+    }
+}
+
+impl PartialEq for AnyScalar {
+    fn eq(&self, other: &Self) -> bool {
+        self.tensor.as_native().dtype() == other.tensor.as_native().dtype()
+            && self.value() == other.value()
+    }
+}
+
+impl PartialOrd for AnyScalar {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self.value(), other.value()) {
+            (ScalarValue::F32(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&rhs),
+            (ScalarValue::F32(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
+            (ScalarValue::F64(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&(rhs as f64)),
+            (ScalarValue::F64(lhs), ScalarValue::F64(rhs)) => lhs.partial_cmp(&rhs),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for AnyScalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.value() {
+            ScalarValue::F32(value) => value.fmt(f),
+            ScalarValue::F64(value) => value.fmt(f),
+            ScalarValue::C32(value) => value.fmt(f),
+            ScalarValue::C64(value) => value.fmt(f),
+        }
+    }
+}
+
+impl fmt::Debug for AnyScalar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnyScalar")
+            .field("dtype", &self.tensor.as_native().dtype())
+            .field("value", &self.value())
+            .field("tracks_grad", &self.tracks_grad())
+            .finish()
+    }
+}

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -182,6 +182,17 @@ pub fn contract_multi(
         0 => Err(anyhow::anyhow!("No tensors to contract")),
         1 => Ok((*tensors[0]).clone()),
         _ => {
+            if matches!(allowed, AllowedPairs::All)
+                && tensors.iter().any(|tensor| tensor.tracks_grad())
+            {
+                let mut iter = tensors.iter();
+                let mut result = (*iter.next().unwrap()).clone();
+                for tensor in iter {
+                    result = result.contract(tensor);
+                }
+                return Ok(result);
+            }
+
             // Validate AllowedPairs::Specified pairs have contractable indices
             if let AllowedPairs::Specified(pairs) = allowed {
                 for &(i, j) in pairs {
@@ -281,6 +292,17 @@ pub fn contract_connected(
         0 => Err(anyhow::anyhow!("No tensors to contract")),
         1 => Ok((*tensors[0]).clone()),
         _ => {
+            if matches!(allowed, AllowedPairs::All)
+                && tensors.iter().any(|tensor| tensor.tracks_grad())
+            {
+                let mut iter = tensors.iter();
+                let mut result = (*iter.next().unwrap()).clone();
+                for tensor in iter {
+                    result = result.contract(tensor);
+                }
+                return Ok(result);
+            }
+
             // Check connectivity first
             let components = find_tensor_connected_components(tensors, allowed);
             if components.len() > 1 {

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -7,6 +7,7 @@ use crate::global_default::GlobalDefault;
 use crate::truncation::TruncationParams;
 use crate::{unfold_split, TensorDynLen};
 use num_complex::ComplexFloat;
+use tenferro::DType;
 use tensor4all_tensorbackend::{
     dense_native_tensor_from_col_major, native_tensor_primal_to_dense_c64_col_major,
     native_tensor_primal_to_dense_f64_col_major, qr_native_tensor, reshape_col_major_native_tensor,
@@ -270,13 +271,13 @@ pub fn qr_with<T>(
     let k = m.min(n);
     let (mut q_native, mut r_native) =
         qr_native_tensor(&matrix_native).map_err(QrError::ComputationError)?;
-    let r = match r_native.scalar_type() {
-        tenferro::ScalarType::F64 => {
+    let r = match r_native.dtype() {
+        DType::F64 => {
             let values = native_tensor_primal_to_dense_f64_col_major(&r_native)
                 .map_err(QrError::ComputationError)?;
             compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
         }
-        tenferro::ScalarType::C64 => {
+        DType::C64 => {
             let values = native_tensor_primal_to_dense_c64_col_major(&r_native)
                 .map_err(QrError::ComputationError)?;
             compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
@@ -288,8 +289,8 @@ pub fn qr_with<T>(
         }
     };
     if r < k {
-        match q_native.scalar_type() {
-            tenferro::ScalarType::F64 => {
+        match q_native.dtype() {
+            DType::F64 => {
                 let q_values = native_tensor_primal_to_dense_f64_col_major(&q_native)
                     .map_err(QrError::ComputationError)?;
                 let r_values = native_tensor_primal_to_dense_f64_col_major(&r_native)
@@ -299,7 +300,7 @@ pub fn qr_with<T>(
                 r_native =
                     truncate_matrix_rows(&r_values, k, n, r).map_err(QrError::ComputationError)?;
             }
-            tenferro::ScalarType::C64 => {
+            DType::C64 => {
                 let q_values = native_tensor_primal_to_dense_c64_col_major(&q_native)
                     .map_err(QrError::ComputationError)?;
                 let r_values = native_tensor_primal_to_dense_c64_col_major(&r_native)

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -12,6 +12,7 @@ use crate::global_default::GlobalDefault;
 use crate::index_like::IndexLike;
 use crate::truncation::{HasTruncationParams, TruncationParams};
 use crate::{unfold_split, TensorDynLen};
+use tenferro::DType;
 use tensor4all_tensorbackend::{
     dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
     native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
@@ -146,11 +147,11 @@ fn compute_retained_rank(s_vec: &[f64], rtol: f64) -> usize {
 }
 
 fn singular_values_from_native(tensor: &tenferro::Tensor) -> Result<Vec<f64>, SvdError> {
-    match tensor.scalar_type() {
-        tenferro::ScalarType::F64 => {
+    match tensor.dtype() {
+        DType::F64 => {
             native_tensor_primal_to_dense_f64_col_major(tensor).map_err(SvdError::ComputationError)
         }
-        tenferro::ScalarType::C64 => native_tensor_primal_to_dense_c64_col_major(tensor)
+        DType::C64 => native_tensor_primal_to_dense_c64_col_major(tensor)
             .map(|values| values.into_iter().map(|value| value.re).collect())
             .map_err(SvdError::ComputationError),
         other => Err(SvdError::ComputationError(anyhow::anyhow!(
@@ -214,8 +215,8 @@ fn svd_truncated_native(
         r = r.min(max_rank);
     }
     if r < k {
-        match u_native.scalar_type() {
-            tenferro::ScalarType::F64 => {
+        match u_native.dtype() {
+            DType::F64 => {
                 let u_values = native_tensor_primal_to_dense_f64_col_major(&u_native)
                     .map_err(SvdError::ComputationError)?;
                 let vt_values = native_tensor_primal_to_dense_f64_col_major(&vt_native)
@@ -225,7 +226,7 @@ fn svd_truncated_native(
                 vt_native = truncate_matrix_rows(&vt_values, k, n, r)
                     .map_err(SvdError::ComputationError)?;
             }
-            tenferro::ScalarType::C64 => {
+            DType::C64 => {
                 let u_values = native_tensor_primal_to_dense_c64_col_major(&u_native)
                     .map_err(SvdError::ComputationError)?;
                 let vt_values = native_tensor_primal_to_dense_c64_col_major(&vt_native)

--- a/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
@@ -13,12 +13,13 @@ fn compute_retained_rank_handles_edge_cases() {
 
 #[test]
 fn singular_values_from_native_accepts_real_and_complex_dense() {
-    let dense = NativeTensor::from_slice(&[3.0_f64, 1.5], &[2]).unwrap();
+    let dense = NativeTensor::new(vec![2], vec![3.0_f64, 1.5]);
     assert_eq!(singular_values_from_native(&dense).unwrap(), vec![3.0, 1.5]);
 
-    let complex =
-        NativeTensor::from_slice(&[Complex64::new(1.0, 2.0), Complex64::new(0.5, -4.0)], &[2])
-            .unwrap();
+    let complex = NativeTensor::new(
+        vec![2],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(0.5, -4.0)],
+    );
     assert_eq!(
         singular_values_from_native(&complex).unwrap(),
         vec![1.0, 0.5]
@@ -46,7 +47,7 @@ fn svd_options_accessors_roundtrip() {
 
 #[test]
 fn singular_values_from_native_rejects_unsupported_scalar_types() {
-    let tensor = NativeTensor::from_slice(&[1.0_f32, 2.0], &[2]).unwrap();
+    let tensor = NativeTensor::new(vec![2], vec![1.0_f32, 2.0]);
     let err = singular_values_from_native(&tensor).unwrap_err();
     assert!(err
         .to_string()

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -1,8 +1,8 @@
 use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::index_ops::{common_ind_positions, prepare_contraction, prepare_contraction_pairs};
-use crate::storage::{AnyScalar, Storage};
 use crate::tensor_like::LinearizationOrder;
+use crate::{storage::Storage, AnyScalar};
 use anyhow::Result;
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -11,13 +11,14 @@ use rand_distr::{Distribution, StandardNormal};
 use std::collections::HashSet;
 use std::ops::{Mul, Neg, Sub};
 use std::sync::Arc;
-use tenferro::{ScalarType as NativeScalarType, Tensor as NativeTensor};
+use tenferro::eager_einsum::eager_einsum_ad;
+use tenferro::{CpuBackend, DType, EagerTensor, Tensor as NativeTensor};
 use tensor4all_tensorbackend::{
-    axpby_native_tensor, conj_native_tensor, contract_native_tensor,
+    axpby_native_tensor, contract_native_tensor, default_eager_ctx,
     dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
-    native_tensor_primal_to_dense_col_major, native_tensor_primal_to_storage,
-    outer_product_native_tensor, permute_native_tensor, reshape_col_major_native_tensor,
-    scale_native_tensor, storage_to_native_tensor, sum_native_tensor, TensorElement,
+    native_tensor_primal_to_dense_col_major, native_tensor_primal_to_diag_c64,
+    native_tensor_primal_to_diag_f64, native_tensor_primal_to_storage,
+    reshape_col_major_native_tensor, scale_native_tensor, storage_to_native_tensor, TensorElement,
 };
 
 /// Trait for scalar types that can generate random values from a standard
@@ -160,8 +161,11 @@ pub trait TensorAccess {
 pub struct TensorDynLen {
     /// Full index information (includes tags and other metadata).
     pub indices: Vec<DynIndex>,
-    /// Canonical native payload preserving AD metadata.
-    native: Arc<NativeTensor>,
+    /// Eager payload tensor. During the primal migration this is created as an
+    /// untracked eager leaf and will start carrying AD state again in Task 4.
+    pub(crate) inner: Arc<EagerTensor<CpuBackend>>,
+    /// Logical-to-payload axis classes. Repeated values encode diagonal axes.
+    pub(crate) axis_classes: Vec<usize>,
 }
 
 impl TensorAccess for TensorDynLen {
@@ -171,6 +175,133 @@ impl TensorAccess for TensorDynLen {
 }
 
 impl TensorDynLen {
+    const EINSUM_LABELS: &'static [u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    fn dense_axis_classes(rank: usize) -> Vec<usize> {
+        (0..rank).collect()
+    }
+
+    fn diag_axis_classes(rank: usize) -> Vec<usize> {
+        if rank == 0 {
+            vec![]
+        } else {
+            vec![0; rank]
+        }
+    }
+
+    fn canonicalize_axis_classes(axis_classes: &[usize]) -> Vec<usize> {
+        let mut map = std::collections::HashMap::new();
+        let mut next = 0usize;
+        axis_classes
+            .iter()
+            .map(|&class_id| {
+                *map.entry(class_id).or_insert_with(|| {
+                    let canonical = next;
+                    next += 1;
+                    canonical
+                })
+            })
+            .collect()
+    }
+
+    fn permute_axis_classes(&self, perm: &[usize]) -> Vec<usize> {
+        let permuted: Vec<usize> = perm.iter().map(|&index| self.axis_classes[index]).collect();
+        Self::canonicalize_axis_classes(&permuted)
+    }
+
+    fn is_diag_axis_classes(axis_classes: &[usize]) -> bool {
+        axis_classes.len() >= 2 && axis_classes.iter().all(|&class_id| class_id == 0)
+    }
+
+    fn einsum_labels(ids: &[usize]) -> Result<String> {
+        let mut out = String::with_capacity(ids.len());
+        for &id in ids {
+            let label = Self::EINSUM_LABELS.get(id).ok_or_else(|| {
+                anyhow::anyhow!("einsum label {id} exceeds supported label range")
+            })?;
+            out.push(char::from(*label));
+        }
+        Ok(out)
+    }
+
+    fn build_binary_einsum_subscripts(
+        lhs_rank: usize,
+        axes_a: &[usize],
+        rhs_rank: usize,
+        axes_b: &[usize],
+    ) -> Result<String> {
+        anyhow::ensure!(
+            axes_a.len() == axes_b.len(),
+            "contract axis length mismatch: lhs {:?}, rhs {:?}",
+            axes_a,
+            axes_b
+        );
+
+        let mut lhs_ids = vec![usize::MAX; lhs_rank];
+        let mut rhs_ids = vec![usize::MAX; rhs_rank];
+        let mut next_id = 0usize;
+
+        let mut seen_lhs = vec![false; lhs_rank];
+        let mut seen_rhs = vec![false; rhs_rank];
+
+        for (&lhs_axis, &rhs_axis) in axes_a.iter().zip(axes_b.iter()) {
+            anyhow::ensure!(
+                lhs_axis < lhs_rank,
+                "lhs contract axis {lhs_axis} out of range"
+            );
+            anyhow::ensure!(
+                rhs_axis < rhs_rank,
+                "rhs contract axis {rhs_axis} out of range"
+            );
+            anyhow::ensure!(
+                !seen_lhs[lhs_axis],
+                "duplicate lhs contract axis {lhs_axis}"
+            );
+            anyhow::ensure!(
+                !seen_rhs[rhs_axis],
+                "duplicate rhs contract axis {rhs_axis}"
+            );
+            seen_lhs[lhs_axis] = true;
+            seen_rhs[rhs_axis] = true;
+            lhs_ids[lhs_axis] = next_id;
+            rhs_ids[rhs_axis] = next_id;
+            next_id += 1;
+        }
+
+        let mut output_ids = Vec::with_capacity(lhs_rank + rhs_rank - 2 * axes_a.len());
+        for id in &mut lhs_ids {
+            if *id == usize::MAX {
+                *id = next_id;
+                output_ids.push(next_id);
+                next_id += 1;
+            }
+        }
+        for id in &mut rhs_ids {
+            if *id == usize::MAX {
+                *id = next_id;
+                output_ids.push(next_id);
+                next_id += 1;
+            }
+        }
+
+        Ok(format!(
+            "{},{}->{}",
+            Self::einsum_labels(&lhs_ids)?,
+            Self::einsum_labels(&rhs_ids)?,
+            Self::einsum_labels(&output_ids)?,
+        ))
+    }
+
+    fn scale_subscripts(rank: usize) -> Result<String> {
+        if rank == 0 {
+            Ok("->".to_string())
+        } else {
+            let ids: Vec<usize> = (0..rank).collect();
+            let labels = Self::einsum_labels(&ids)?;
+            Ok(format!("{labels},->{labels}"))
+        }
+    }
+
     fn validate_indices(indices: &[DynIndex]) {
         let mut seen = HashSet::new();
         for idx in indices {
@@ -294,26 +425,61 @@ impl TensorDynLen {
             Self::validate_diag_dims(&dims)?;
         }
         let native = Self::seed_native_payload(storage.as_ref(), &dims)?;
-        Self::from_native(indices, native)
+        let axis_classes = if storage.is_diag() {
+            Self::diag_axis_classes(indices.len())
+        } else {
+            Self::dense_axis_classes(indices.len())
+        };
+        Self::from_native_with_axis_classes(indices, native, axis_classes)
     }
 
     /// Create a tensor from a native tenferro payload.
     pub(crate) fn from_native(indices: Vec<DynIndex>, native: NativeTensor) -> Result<Self> {
+        let axis_classes = Self::dense_axis_classes(indices.len());
+        Self::from_native_with_axis_classes(indices, native, axis_classes)
+    }
+
+    pub(crate) fn from_native_with_axis_classes(
+        indices: Vec<DynIndex>,
+        native: NativeTensor,
+        axis_classes: Vec<usize>,
+    ) -> Result<Self> {
+        Self::from_inner_with_axis_classes(
+            indices,
+            EagerTensor::from_tensor_in(native, default_eager_ctx()),
+            axis_classes,
+        )
+    }
+
+    pub(crate) fn from_inner(
+        indices: Vec<DynIndex>,
+        inner: EagerTensor<CpuBackend>,
+    ) -> Result<Self> {
+        let axis_classes = Self::dense_axis_classes(indices.len());
+        Self::from_inner_with_axis_classes(indices, inner, axis_classes)
+    }
+
+    pub(crate) fn from_inner_with_axis_classes(
+        indices: Vec<DynIndex>,
+        inner: EagerTensor<CpuBackend>,
+        axis_classes: Vec<usize>,
+    ) -> Result<Self> {
         let dims = Self::expected_dims_from_indices(&indices);
         Self::validate_indices(&indices);
-        if dims != native.dims() {
+        if dims != inner.data().shape() {
             return Err(anyhow::anyhow!(
                 "native payload dims {:?} do not match indices dims {:?}",
-                native.dims(),
+                inner.data().shape(),
                 dims
             ));
         }
-        if native.is_diag() {
+        if Self::is_diag_axis_classes(&axis_classes) {
             Self::validate_diag_dims(&dims)?;
         }
         Ok(Self {
             indices,
-            native: Arc::new(native),
+            inner: Arc::new(inner),
+            axis_classes,
         })
     }
 
@@ -324,58 +490,58 @@ impl TensorDynLen {
 
     /// Borrow the native payload.
     pub(crate) fn as_native(&self) -> &NativeTensor {
-        self.native.as_ref()
+        self.inner.data()
     }
 
-    /// Returns whether the tensor participates in reverse-mode AD.
-    pub fn requires_grad(&self) -> bool {
-        self.native.requires_grad()
+    /// Enable reverse-mode AD tracking on this tensor by creating a tracked leaf.
+    pub fn enable_grad(self) -> Self {
+        let native = self.as_native().clone();
+        Self {
+            indices: self.indices,
+            inner: Arc::new(EagerTensor::requires_grad_in(native, default_eager_ctx())),
+            axis_classes: self.axis_classes,
+        }
     }
 
-    /// Enables or disables reverse-mode gradient tracking.
-    pub fn set_requires_grad(&mut self, enabled: bool) -> Result<()> {
-        self.native = Arc::new(self.native.as_ref().detach().with_requires_grad(enabled));
-        Ok(())
+    /// Report whether this tensor participates in gradient tracking.
+    pub fn tracks_grad(&self) -> bool {
+        self.inner.tracks_grad()
     }
 
-    /// Returns the accumulated reverse gradient when available.
+    /// Return the accumulated gradient, if one has been stored.
     pub fn grad(&self) -> Result<Option<Self>> {
-        self.native
+        self.inner
             .grad()
-            .map_err(|e| anyhow::anyhow!("TensorDynLen::grad failed: {e}"))?
-            .map(|native| {
-                Self::from_native(self.indices.clone(), native).map_err(|e| {
-                    anyhow::anyhow!(
-                        "TensorDynLen::grad returned a tensor incompatible with indices: {e}"
-                    )
-                })
+            .map(|grad| {
+                Self::from_native_with_axis_classes(
+                    self.indices.clone(),
+                    grad.as_ref().clone(),
+                    self.axis_classes.clone(),
+                )
             })
             .transpose()
     }
 
-    /// Clears accumulated reverse gradients on reverse leaves.
-    pub fn zero_grad(&self) -> Result<()> {
-        self.native
-            .zero_grad()
-            .map_err(|e| anyhow::anyhow!("TensorDynLen::zero_grad failed: {e}"))
+    /// Clear the accumulated gradient stored for this tensor.
+    pub fn clear_grad(&self) -> Result<()> {
+        self.inner.clear_grad();
+        Ok(())
     }
 
-    /// Runs reverse-mode AD backward pass from this tensor.
-    ///
-    /// Accumulates gradients on all input tensors that have `requires_grad == true`.
-    ///
-    /// # Arguments
-    /// * `grad_output` - Optional gradient seed. Pass `None` for default (ones).
-    pub fn backward(&self, grad_output: Option<&Self>) -> Result<()> {
-        match grad_output {
-            Some(grad_output) => self
-                .native
-                .backward_with_seed(&grad_output.native)
-                .map_err(|e| anyhow::anyhow!("TensorDynLen::backward_with_seed failed: {e}")),
-            None => self
-                .native
-                .backward()
-                .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}")),
+    /// Run reverse-mode autodiff from this scalar tensor.
+    pub fn backward(&self) -> Result<()> {
+        self.inner
+            .backward()
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}"))
+    }
+
+    /// Detach this tensor from the reverse graph.
+    pub fn detach(&self) -> Self {
+        Self {
+            indices: self.indices.clone(),
+            inner: Arc::new(self.inner.detach()),
+            axis_classes: self.axis_classes.clone(),
         }
     }
 
@@ -386,9 +552,21 @@ impl TensorDynLen {
 
     /// Materialize the primal snapshot as storage.
     pub fn to_storage(&self) -> Result<Arc<Storage>> {
-        Ok(Arc::new(native_tensor_primal_to_storage(
-            self.native.as_ref(),
-        )?))
+        let storage = if self.is_diag() {
+            match self.as_native().dtype() {
+                DType::F32 | DType::F64 => Storage::from_diag_col_major(
+                    native_tensor_primal_to_diag_f64(self.as_native())?,
+                    self.indices.len(),
+                )?,
+                DType::C32 | DType::C64 => Storage::from_diag_col_major(
+                    native_tensor_primal_to_diag_c64(self.as_native())?,
+                    self.indices.len(),
+                )?,
+            }
+        } else {
+            native_tensor_primal_to_storage(self.as_native())?
+        };
+        Ok(Arc::new(storage))
     }
 
     /// Materialize the primal snapshot as storage.
@@ -410,7 +588,18 @@ impl TensorDynLen {
     /// assert!((s.real() - 6.0).abs() < 1e-12);
     /// ```
     pub fn sum(&self) -> AnyScalar {
-        sum_native_tensor(&self.native).expect("native sum failed")
+        if self.indices.is_empty() {
+            return AnyScalar::from_tensor_unchecked(self.clone());
+        }
+        let axes: Vec<usize> = (0..self.indices.len()).collect();
+        let reduced = self
+            .inner
+            .reduce_sum(&axes)
+            .unwrap_or_else(|e| panic!("TensorDynLen::sum failed: {e}"));
+        AnyScalar::from_tensor_unchecked(
+            Self::from_inner(Vec::new(), reduced)
+                .unwrap_or_else(|e| panic!("TensorDynLen::sum returned invalid scalar: {e}")),
+        )
     }
 
     /// Extract the scalar value from a 0-dimensional tensor (or 1-element tensor).
@@ -479,10 +668,13 @@ impl TensorDynLen {
         // Compute permutation by matching IDs
         let perm = compute_permutation_from_indices(&self.indices, new_indices);
 
-        let permuted_native =
-            permute_native_tensor(&self.native, &perm).expect("native permute_indices failed");
-        Self::from_native(new_indices.to_vec(), permuted_native)
-            .expect("native permute_indices snapshot failed")
+        let permuted = self
+            .inner
+            .transpose(&perm)
+            .unwrap_or_else(|e| panic!("TensorDynLen::permute_indices failed: {e}"));
+        let axis_classes = self.permute_axis_classes(&perm);
+        Self::from_inner_with_axis_classes(new_indices.to_vec(), permuted, axis_classes)
+            .expect("TensorDynLen::permute_indices returned invalid tensor")
     }
 
     /// Permute the tensor dimensions, returning a new tensor.
@@ -522,9 +714,13 @@ impl TensorDynLen {
 
         // Permute indices
         let new_indices: Vec<DynIndex> = perm.iter().map(|&i| self.indices[i].clone()).collect();
-        let permuted_native =
-            permute_native_tensor(&self.native, perm).expect("native permute failed");
-        Self::from_native(new_indices, permuted_native).expect("native permute snapshot failed")
+        let permuted = self
+            .inner
+            .transpose(perm)
+            .unwrap_or_else(|e| panic!("TensorDynLen::permute failed: {e}"));
+        let axis_classes = self.permute_axis_classes(perm);
+        Self::from_inner_with_axis_classes(new_indices, permuted, axis_classes)
+            .expect("TensorDynLen::permute returned invalid tensor")
     }
 
     /// Contract this tensor with another tensor along common indices.
@@ -570,11 +766,38 @@ impl TensorDynLen {
         let spec = prepare_contraction(&self.indices, &self_dims, &other.indices, &other_dims)
             .expect("contraction preparation failed");
 
-        let result_native =
-            contract_native_tensor(&self.native, &spec.axes_a, &other.native, &spec.axes_b)
-                .expect("native contract failed");
-        Self::from_native(spec.result_indices, result_native)
-            .expect("native contract snapshot failed")
+        if self.indices.is_empty() && other.indices.is_empty() {
+            let result = self
+                .inner
+                .mul(other.inner.as_ref())
+                .unwrap_or_else(|e| panic!("TensorDynLen::contract scalar multiply failed: {e}"));
+            return Self::from_inner(spec.result_indices, result)
+                .expect("TensorDynLen::contract returned invalid scalar");
+        }
+
+        if self.as_native().dtype() != other.as_native().dtype() {
+            let result_native = contract_native_tensor(
+                self.as_native(),
+                &spec.axes_a,
+                other.as_native(),
+                &spec.axes_b,
+            )
+            .unwrap_or_else(|e| panic!("TensorDynLen::contract native fallback failed: {e}"));
+            return Self::from_native(spec.result_indices, result_native)
+                .expect("TensorDynLen::contract native fallback returned invalid tensor");
+        }
+
+        let subscripts = Self::build_binary_einsum_subscripts(
+            self.indices.len(),
+            &spec.axes_a,
+            other.indices.len(),
+            &spec.axes_b,
+        )
+        .expect("TensorDynLen::contract failed to build einsum subscripts");
+        let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
+            .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"));
+        Self::from_inner(spec.result_indices, result)
+            .expect("TensorDynLen::contract returned invalid tensor")
     }
 
     /// Contract this tensor with another tensor along explicitly specified index pairs.
@@ -661,9 +884,33 @@ impl TensorDynLen {
             }
         })?;
 
-        let result_native =
-            contract_native_tensor(&self.native, &spec.axes_a, &other.native, &spec.axes_b)?;
-        Self::from_native(spec.result_indices, result_native)
+        if self.indices.is_empty() && other.indices.is_empty() {
+            let result = self
+                .inner
+                .mul(other.inner.as_ref())
+                .map_err(|e| anyhow::anyhow!("tensordot scalar multiply failed: {e}"))?;
+            return Self::from_inner(spec.result_indices, result);
+        }
+
+        if self.as_native().dtype() != other.as_native().dtype() {
+            let result_native = contract_native_tensor(
+                self.as_native(),
+                &spec.axes_a,
+                other.as_native(),
+                &spec.axes_b,
+            )?;
+            return Self::from_native(spec.result_indices, result_native);
+        }
+
+        let subscripts = Self::build_binary_einsum_subscripts(
+            self.indices.len(),
+            &spec.axes_a,
+            other.indices.len(),
+            &spec.axes_b,
+        )?;
+        let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
+            .map_err(|e| anyhow::anyhow!("tensordot failed: {e}"))?;
+        Self::from_inner(spec.result_indices, result)
     }
 
     /// Compute the outer product (tensor product) of two tensors.
@@ -717,9 +964,17 @@ impl TensorDynLen {
         // Build result indices and dimensions
         let mut result_indices = self.indices.clone();
         result_indices.extend(other.indices.iter().cloned());
-        let result_native = outer_product_native_tensor(&self.native, &other.native)
-            .expect("native outer product failed");
-        Self::from_native(result_indices, result_native)
+        if self.as_native().dtype() != other.as_native().dtype() {
+            let result_native =
+                contract_native_tensor(self.as_native(), &[], other.as_native(), &[])?;
+            return Self::from_native(result_indices, result_native);
+        }
+
+        let subscripts =
+            Self::build_binary_einsum_subscripts(self.indices.len(), &[], other.indices.len(), &[])?;
+        let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
+            .map_err(|e| anyhow::anyhow!("outer_product failed: {e}"))?;
+        Self::from_inner(result_indices, result)
     }
 }
 
@@ -1021,9 +1276,32 @@ impl TensorDynLen {
             ));
         }
 
-        // Reuse storage-level fused axpby to avoid materializing two scaled temporaries.
-        let combined = axpby_native_tensor(&self.native, &a, &other_aligned.native, &b)?;
-        Self::from_native(self.indices.clone(), combined)
+        let axis_classes = if self.axis_classes == other_aligned.axis_classes {
+            self.axis_classes.clone()
+        } else {
+            Self::dense_axis_classes(self.indices.len())
+        };
+
+        if self.as_native().dtype() != other_aligned.as_native().dtype()
+            || self.as_native().dtype() != a.as_tensor().as_native().dtype()
+            || other_aligned.as_native().dtype() != b.as_tensor().as_native().dtype()
+        {
+            let combined = axpby_native_tensor(
+                self.as_native(),
+                &a.to_backend_scalar(),
+                other_aligned.as_native(),
+                &b.to_backend_scalar(),
+            )?;
+            return Self::from_native_with_axis_classes(self.indices.clone(), combined, axis_classes);
+        }
+
+        let lhs = self.scale(a)?;
+        let rhs = other_aligned.scale(b)?;
+        let combined = lhs
+            .inner
+            .add(rhs.inner.as_ref())
+            .map_err(|e| anyhow::anyhow!("tensor addition failed: {e}"))?;
+        Self::from_inner_with_axis_classes(self.indices.clone(), combined, axis_classes)
     }
 
     /// Scalar multiplication.
@@ -1041,8 +1319,28 @@ impl TensorDynLen {
     /// assert_eq!(scaled.to_vec::<f64>().unwrap(), vec![2.0, 4.0, 6.0]);
     /// ```
     pub fn scale(&self, scalar: AnyScalar) -> Result<Self> {
-        let scaled = scale_native_tensor(&self.native, &scalar)?;
-        Self::from_native(self.indices.clone(), scaled)
+        if self.as_native().dtype() != scalar.as_tensor().as_native().dtype() {
+            let scaled = scale_native_tensor(self.as_native(), &scalar.to_backend_scalar())?;
+            return Self::from_native_with_axis_classes(
+                self.indices.clone(),
+                scaled,
+                self.axis_classes.clone(),
+            );
+        }
+
+        let scaled = if self.indices.is_empty() {
+            self.inner
+                .mul(scalar.as_tensor().inner.as_ref())
+                .map_err(|e| anyhow::anyhow!("scalar multiplication failed: {e}"))?
+        } else {
+            let subscripts = Self::scale_subscripts(self.indices.len())?;
+            eager_einsum_ad(
+                &[self.inner.as_ref(), scalar.as_tensor().inner.as_ref()],
+                &subscripts,
+            )
+            .map_err(|e| anyhow::anyhow!("tensor scaling failed: {e}"))?
+        };
+        Self::from_inner_with_axis_classes(self.indices.clone(), scaled, self.axis_classes.clone())
     }
 
     /// Inner product (dot product) of two tensors.
@@ -1068,11 +1366,8 @@ impl TensorDynLen {
             let other_set: HashSet<_> = other.indices.iter().collect();
             if self_set == other_set {
                 let other_aligned = other.permute_indices(&self.indices);
-                let conj_self = conj_native_tensor(&self.native)?;
-                let axes: Vec<usize> = (0..self.indices.len()).collect();
-                let result_native =
-                    contract_native_tensor(&conj_self, &axes, &other_aligned.native, &axes)?;
-                return sum_native_tensor(&result_native);
+                let result = self.conj().contract(&other_aligned);
+                return Ok(result.sum());
             }
         }
 
@@ -1144,7 +1439,8 @@ impl TensorDynLen {
 
         Self {
             indices: new_indices,
-            native: self.native.clone(),
+            inner: self.inner.clone(),
+            axis_classes: self.axis_classes.clone(),
         }
     }
 
@@ -1218,7 +1514,8 @@ impl TensorDynLen {
 
         Self {
             indices: new_indices_vec,
-            native: self.native.clone(),
+            inner: self.inner.clone(),
+            axis_classes: self.axis_classes.clone(),
         }
     }
 }
@@ -1255,8 +1552,12 @@ impl TensorDynLen {
         // For default undirected indices, conj() is a no-op, so this is future-proof
         // for QSpace-compatible directed indices where conj() flips Ket <-> Bra
         let new_indices: Vec<DynIndex> = self.indices.iter().map(|idx| idx.conj()).collect();
-        let conj_native = conj_native_tensor(&self.native).expect("native conjugation failed");
-        Self::from_native(new_indices, conj_native).expect("native conjugation snapshot failed")
+        let conjugated = self
+            .inner
+            .conj()
+            .unwrap_or_else(|e| panic!("TensorDynLen::conj failed: {e}"));
+        Self::from_inner_with_axis_classes(new_indices, conjugated, self.axis_classes.clone())
+            .expect("TensorDynLen::conj returned invalid tensor")
     }
 }
 
@@ -1389,7 +1690,7 @@ impl std::fmt::Debug for TensorDynLen {
         f.debug_struct("TensorDynLen")
             .field("indices", &self.indices)
             .field("dims", &self.dims())
-            .field("is_diag", &self.native.is_diag())
+            .field("is_diag", &self.is_diag())
             .finish()
     }
 }
@@ -2092,7 +2393,7 @@ impl TensorDynLen {
     /// assert_eq!(data, &[1.0, 2.0]);
     /// ```
     pub fn to_vec<T: TensorElement>(&self) -> Result<Vec<T>> {
-        native_tensor_primal_to_dense_col_major(&self.native)
+        native_tensor_primal_to_dense_col_major(self.as_native())
     }
 
     fn to_vec_any(&self) -> Result<Vec<AnyScalar>> {
@@ -2137,12 +2438,10 @@ impl TensorDynLen {
     /// assert!(!tensor.is_complex());
     /// ```
     pub fn is_f64(&self) -> bool {
-        self.native.scalar_type() == NativeScalarType::F64
+        matches!(self.as_native().dtype(), DType::F64 | DType::F32)
     }
 
-    /// Check whether the tensor currently uses native diagonal structured storage.
-    ///
-    /// This is a storage-level predicate, not a semantic diagonality check.
+    /// Check whether the tensor carries diagonal logical axis metadata.
     ///
     /// # Examples
     ///
@@ -2155,15 +2454,15 @@ impl TensorDynLen {
     /// let dense = TensorDynLen::from_dense(vec![i, j], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
     /// assert!(!dense.is_diag());
     ///
-    /// // Note: `from_diag` also materializes densely at the native level,
-    /// // so is_diag() returns false for tensors created via the public API.
+    /// // `from_diag` preserves diagonal logical metadata even though the eager
+    /// // payload tensor is currently materialized densely.
     /// let k = DynIndex::new_dyn(2);
     /// let l = DynIndex::new_dyn(2);
     /// let diag = TensorDynLen::from_diag(vec![k, l], vec![1.0, 2.0]).unwrap();
-    /// assert!(!diag.is_diag());
+    /// assert!(diag.is_diag());
     /// ```
     pub fn is_diag(&self) -> bool {
-        self.native.is_diag()
+        Self::is_diag_axis_classes(&self.axis_classes)
     }
 
     /// Check if the tensor has complex storage (C64).
@@ -2185,7 +2484,7 @@ impl TensorDynLen {
     /// assert!(complex_t.is_complex());
     /// ```
     pub fn is_complex(&self) -> bool {
-        self.native.scalar_type() == NativeScalarType::C64
+        matches!(self.as_native().dtype(), DType::C64 | DType::C32)
     }
 }
 

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -970,8 +970,12 @@ impl TensorDynLen {
             return Self::from_native(result_indices, result_native);
         }
 
-        let subscripts =
-            Self::build_binary_einsum_subscripts(self.indices.len(), &[], other.indices.len(), &[])?;
+        let subscripts = Self::build_binary_einsum_subscripts(
+            self.indices.len(),
+            &[],
+            other.indices.len(),
+            &[],
+        )?;
         let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
             .map_err(|e| anyhow::anyhow!("outer_product failed: {e}"))?;
         Self::from_inner(result_indices, result)
@@ -1292,7 +1296,11 @@ impl TensorDynLen {
                 other_aligned.as_native(),
                 &b.to_backend_scalar(),
             )?;
-            return Self::from_native_with_axis_classes(self.indices.clone(), combined, axis_classes);
+            return Self::from_native_with_axis_classes(
+                self.indices.clone(),
+                combined,
+                axis_classes,
+            );
         }
 
         let lhs = self.scale(a)?;
@@ -2446,7 +2454,7 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, Storage, TensorDynLen};
     ///
     /// // Tensors from `from_dense` use dense storage
     /// let i = DynIndex::new_dyn(2);
@@ -2454,11 +2462,16 @@ impl TensorDynLen {
     /// let dense = TensorDynLen::from_dense(vec![i, j], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
     /// assert!(!dense.is_diag());
     ///
-    /// // `from_diag` preserves diagonal logical metadata even though the eager
-    /// // payload tensor is currently materialized densely.
+    /// // Diagonal metadata is preserved when constructing from diagonal storage.
     /// let k = DynIndex::new_dyn(2);
     /// let l = DynIndex::new_dyn(2);
-    /// let diag = TensorDynLen::from_diag(vec![k, l], vec![1.0, 2.0]).unwrap();
+    /// let diag = TensorDynLen::from_storage(
+    ///     vec![k, l],
+    ///     Storage::from_diag_col_major(vec![1.0, 2.0], 2)
+    ///         .map(std::sync::Arc::new)
+    ///         .unwrap(),
+    /// )
+    /// .unwrap();
     /// assert!(diag.is_diag());
     /// ```
     pub fn is_diag(&self) -> bool {

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -27,6 +27,8 @@ pub mod col_major_array;
 pub use col_major_array::{ColMajorArray, ColMajorArrayMut, ColMajorArrayRef};
 
 // Common (tags, utilities, scalar)
+/// Dynamic scalar compatibility wrapper built on rank-0 `TensorDynLen`.
+pub mod any_scalar;
 pub mod global_default;
 pub mod index_like;
 pub mod scalar;
@@ -59,11 +61,7 @@ pub use index_ops::{
 pub use smallstring::{SmallChar, SmallString, SmallStringError};
 pub use tagset::{Tag, TagSetError, TagSetLike};
 
-// Tensor (storage, tensor types) - re-exported from tensor4all-tensorbackend
-pub mod any_scalar {
-    //! Re-export of dynamic scalar utilities.
-    pub use tensor4all_tensorbackend::AnyScalar;
-}
+// Tensor (storage, tensor types)
 pub mod storage {
     //! Re-export of snapshot storage utilities.
     pub use tensor4all_tensorbackend::{

--- a/crates/tensor4all-core/tests/ad_integration.rs
+++ b/crates/tensor4all-core/tests/ad_integration.rs
@@ -1,0 +1,29 @@
+use tensor4all_core::{Index, TensorDynLen};
+
+#[test]
+fn tensor_sum_returns_rank_zero_anyscalar_with_backward() {
+    let i = Index::new_dyn(3);
+    let x = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0])
+        .unwrap()
+        .enable_grad();
+
+    let loss = x.sum();
+    assert!(loss.tracks_grad());
+
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert_eq!(grad.to_vec::<f64>().unwrap(), vec![1.0, 1.0, 1.0]);
+}
+
+#[test]
+fn tensor_only_preserves_tracking_for_scalar_tensor() {
+    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad();
+
+    let scalar = x.only();
+    let loss = &scalar * &scalar;
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert!((grad.only().real() - 4.0).abs() < 1e-12);
+}

--- a/crates/tensor4all-core/tests/send_sync.rs
+++ b/crates/tensor4all-core/tests/send_sync.rs
@@ -1,0 +1,9 @@
+use tensor4all_core::TensorDynLen;
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn eager_tensor_and_tensordynlen_are_send_sync() {
+    assert_send_sync::<tenferro::EagerTensor<tenferro::CpuBackend>>();
+    assert_send_sync::<TensorDynLen>();
+}

--- a/crates/tensor4all-core/tests/tensor_any_scalar.rs
+++ b/crates/tensor4all-core/tests/tensor_any_scalar.rs
@@ -364,6 +364,85 @@ fn test_clone_shares_tracked_leaf_gradient_slot() {
 }
 
 #[test]
+fn test_owned_arithmetic_backward_with_moved_operands() {
+    let x = AnyScalar::new_real(2.0).enable_grad();
+    let y = AnyScalar::new_real(3.0).enable_grad();
+
+    let x_alias = x.clone();
+    let y_alias = y.clone();
+    let x_grad = x_alias.clone();
+    let y_grad = y_alias.clone();
+
+    let product = x * y;
+    let loss = product + x_alias;
+    loss.backward().unwrap();
+
+    let grad_x = x_grad.grad().unwrap().unwrap();
+    let grad_y = y_grad.grad().unwrap().unwrap();
+    assert!((grad_x.real() - 4.0).abs() < 1e-12);
+    assert!((grad_y.real() - 2.0).abs() < 1e-12);
+}
+
+#[test]
+fn test_clear_grad_resets_anyscalar_accumulation() {
+    let x = AnyScalar::new_real(2.0).enable_grad();
+    let y = AnyScalar::new_real(3.0).enable_grad();
+
+    let loss = &x * &y;
+    loss.backward().unwrap();
+
+    let loss = &x * &y;
+    loss.backward().unwrap();
+
+    let grad_x = x.grad().unwrap().unwrap();
+    let grad_y = y.grad().unwrap().unwrap();
+    assert!((grad_x.real() - 6.0).abs() < 1e-12);
+    assert!((grad_y.real() - 4.0).abs() < 1e-12);
+
+    x.clear_grad().unwrap();
+    y.clear_grad().unwrap();
+    assert!(x.grad().unwrap().is_none());
+    assert!(y.grad().unwrap().is_none());
+}
+
+#[test]
+fn test_detach_breaks_reverse_graph_for_anyscalar() {
+    let x = AnyScalar::new_real(3.0).enable_grad();
+    let y = AnyScalar::new_real(2.0).enable_grad();
+    let detached = x.detach();
+
+    assert!(!detached.tracks_grad());
+    assert!(x.tracks_grad());
+    assert!(y.tracks_grad());
+
+    let loss = &detached * &y;
+    assert!(loss.tracks_grad());
+    loss.backward().unwrap();
+
+    assert!(x.grad().unwrap().is_none());
+    let grad_y = y.grad().unwrap().unwrap();
+    assert!((grad_y.real() - 3.0).abs() < 1e-12);
+}
+
+#[test]
+fn test_primal_matches_detach_semantics_for_anyscalar() {
+    let x = AnyScalar::new_real(3.0).enable_grad();
+    let y = AnyScalar::new_real(2.0).enable_grad();
+    let primal = x.primal();
+
+    assert!(!primal.tracks_grad());
+    assert_eq!(primal.real(), 3.0);
+
+    let loss = &primal * &y;
+    assert!(loss.tracks_grad());
+    loss.backward().unwrap();
+
+    assert!(x.grad().unwrap().is_none());
+    let grad_y = y.grad().unwrap().unwrap();
+    assert!((grad_y.real() - 3.0).abs() < 1e-12);
+}
+
+#[test]
 fn test_function_api_takes_anyscalar_ref() {
     fn quadratic_plus_one(x: &AnyScalar) -> AnyScalar {
         let square = x * x;

--- a/crates/tensor4all-core/tests/tensor_any_scalar.rs
+++ b/crates/tensor4all-core/tests/tensor_any_scalar.rs
@@ -331,3 +331,49 @@ fn test_scalar_lhs_rhs_mixed_ops() {
     assert!((z.re - 2.0).abs() < 1e-12);
     assert!((z.im + 1.0).abs() < 1e-12);
 }
+
+#[test]
+fn test_enable_grad_and_borrow_arithmetic_backward() {
+    let x = AnyScalar::new_real(2.0).enable_grad();
+    let y = AnyScalar::new_real(3.0).enable_grad();
+
+    let product = &x * &y;
+    let loss = &product + &x;
+
+    assert!(loss.tracks_grad());
+    loss.backward().unwrap();
+
+    let grad_x = x.grad().unwrap().unwrap();
+    let grad_y = y.grad().unwrap().unwrap();
+    assert!((grad_x.real() - 4.0).abs() < 1e-12);
+    assert!((grad_y.real() - 2.0).abs() < 1e-12);
+}
+
+#[test]
+fn test_clone_shares_tracked_leaf_gradient_slot() {
+    let x = AnyScalar::new_real(2.0).enable_grad();
+    let alias = x.clone();
+
+    let loss = &x * &alias;
+    loss.backward().unwrap();
+
+    let grad_x = x.grad().unwrap().unwrap();
+    let grad_alias = alias.grad().unwrap().unwrap();
+    assert!((grad_x.real() - 4.0).abs() < 1e-12);
+    assert!((grad_alias.real() - 4.0).abs() < 1e-12);
+}
+
+#[test]
+fn test_function_api_takes_anyscalar_ref() {
+    fn quadratic_plus_one(x: &AnyScalar) -> AnyScalar {
+        let square = x * x;
+        &square + &AnyScalar::one()
+    }
+
+    let x = AnyScalar::new_real(3.0).enable_grad();
+    let loss = quadratic_plus_one(&x);
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert!((grad.real() - 6.0).abs() < 1e-12);
+}

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -85,3 +85,17 @@ fn tracks_grad_and_detach_report_leaf_state() {
     assert!(!detached.tracks_grad());
     assert!(tracked.tracks_grad());
 }
+
+#[test]
+fn clone_shares_tracked_leaf_gradient_slot() {
+    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad();
+    let alias = x.clone();
+
+    let loss = &x * &alias;
+    loss.backward().unwrap();
+
+    let grad_x = x.grad().unwrap().unwrap();
+    let grad_alias = alias.grad().unwrap().unwrap();
+    assert!((grad_x.only().real() - 4.0).abs() < 1e-12);
+    assert!((grad_alias.only().real() - 4.0).abs() < 1e-12);
+}

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -1,12 +1,5 @@
 use tensor4all_core::{contract_multi, AllowedPairs, Index, Storage, TensorDynLen};
 
-fn with_runtime<R>(f: impl FnOnce() -> R) -> R {
-    let _guard = tenferro::set_default_runtime(tenferro::RuntimeContext::Cpu(
-        tenferro_prims::CpuContext::new(1),
-    ));
-    f()
-}
-
 #[test]
 fn plain_dense_storage_auto_seeds_native_payload() {
     let i = Index::new_dyn(2);
@@ -19,11 +12,10 @@ fn plain_dense_storage_auto_seeds_native_payload() {
     .unwrap();
 
     assert_eq!(tensor.to_vec::<f64>().unwrap(), vec![1.0, 2.0]);
-    assert!(!tensor.requires_grad());
 }
 
 #[test]
-fn plain_diag_storage_auto_seeds_native_dense_payload() {
+fn plain_diag_storage_preserves_diag_metadata() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
     let tensor = TensorDynLen::from_storage(
@@ -42,70 +34,54 @@ fn plain_diag_storage_auto_seeds_native_dense_payload() {
             0.0, 0.0, 3.0,
         ]
     );
-    assert!(!tensor.is_diag());
+    assert!(tensor.is_diag());
 }
 
 #[test]
-fn backward_ad_contraction_accumulates_gradient() {
-    with_runtime(|| {
-        let i = Index::new_dyn(3);
+fn contraction_without_grad_returns_rank_zero_scalar() {
+    let i = Index::new_dyn(3);
+    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
 
-        let mut a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-        a.set_requires_grad(true).unwrap();
+    let result = contract_multi(&[&a, &ones], AllowedPairs::All).unwrap();
 
-        let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
-
-        let result = contract_multi(&[&a, &ones], AllowedPairs::All).unwrap();
-        assert!(
-            result.indices().is_empty(),
-            "contraction result should be rank-0"
-        );
-
-        result.backward(None).unwrap();
-
-        let grad = a.grad().unwrap().expect("gradient missing after backward");
-        let grad_vec = grad.to_vec::<f64>().unwrap();
-        for (j, &g) in grad_vec.iter().enumerate() {
-            assert!((g - 1.0).abs() < 1e-10, "grad[{j}] = {g}, expected 1.0");
-        }
-    });
+    assert!(result.indices().is_empty());
+    assert_eq!(result.to_vec::<f64>().unwrap(), vec![6.0]);
 }
 
 #[test]
-fn backward_ad_gradient_matches_finite_diff() {
-    with_runtime(|| {
-        let i = Index::new_dyn(2);
-        let j = Index::new_dyn(2);
-        let eps = 1e-6;
+fn backward_accumulates_until_clear_grad() {
+    let i = Index::new_dyn(3);
+    let x = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0])
+        .unwrap()
+        .enable_grad();
+    let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
 
-        let data = vec![1.0, 2.0, 3.0, 4.0];
+    let loss = contract_multi(&[&x, &ones], AllowedPairs::All).unwrap();
+    loss.backward().unwrap();
 
-        let mut a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
-        a.set_requires_grad(true).unwrap();
+    let grad = x.grad().unwrap().unwrap();
+    assert_eq!(grad.to_vec::<f64>().unwrap(), vec![1.0, 1.0, 1.0]);
 
-        let result = contract_multi(&[&a, &a], AllowedPairs::All).unwrap();
-        result.backward(None).unwrap();
+    let loss = contract_multi(&[&x, &ones], AllowedPairs::All).unwrap();
+    loss.backward().unwrap();
 
-        let grad = a.grad().unwrap().expect("gradient missing");
-        let grad_vec = grad.to_vec::<f64>().unwrap();
+    let grad = x.grad().unwrap().unwrap();
+    assert_eq!(grad.to_vec::<f64>().unwrap(), vec![2.0, 2.0, 2.0]);
 
-        for idx in 0..data.len() {
-            let f_eval = |delta: f64| -> f64 {
-                let mut d = data.clone();
-                d[idx] += delta;
-                let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], d).unwrap();
-                contract_multi(&[&t, &t], AllowedPairs::All)
-                    .unwrap()
-                    .to_vec::<f64>()
-                    .unwrap()[0]
-            };
-            let fd = (f_eval(eps) - f_eval(-eps)) / (2.0 * eps);
-            let ad = grad_vec[idx];
-            let err = (ad - fd).abs();
-            assert!(
-                err < 1e-4,
-                "backward grad[{idx}] = {ad}, finite diff = {fd}, err = {err}"
-            );
-        }
-    });
+    x.clear_grad().unwrap();
+    assert!(x.grad().unwrap().is_none());
+}
+
+#[test]
+fn tracks_grad_and_detach_report_leaf_state() {
+    let scalar = TensorDynLen::scalar(2.0).unwrap();
+    assert!(!scalar.tracks_grad());
+
+    let tracked = scalar.enable_grad();
+    assert!(tracked.tracks_grad());
+
+    let detached = tracked.detach();
+    assert!(!detached.tracks_grad());
+    assert!(tracked.tracks_grad());
 }

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -6,11 +6,12 @@
 //! Internally, TensorTrain is implemented as a thin wrapper around
 //! `TreeTN<TensorDynLen, usize>` where node names are site indices (0, 1, 2, ...).
 
+use num_complex::Complex64;
 use std::ops::Range;
 use tensor4all_core::{common_inds, hascommoninds, DynIndex, IndexLike};
 use tensor4all_core::{
-    AllowedPairs, AnyScalar, DirectSumResult, FactorizeError, FactorizeOptions, FactorizeResult,
-    TensorDynLen, TensorIndex, TensorLike,
+    AllowedPairs, AnyScalar, CommonScalar, DirectSumResult, FactorizeError, FactorizeOptions,
+    FactorizeResult, TensorDynLen, TensorElement, TensorIndex, TensorLike,
 };
 use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
 
@@ -73,6 +74,41 @@ pub struct TensorTrain {
     pub(crate) treetn: TreeTN<TensorDynLen, usize>,
     /// The canonical form used (if known).
     canonical_form: Option<CanonicalForm>,
+}
+
+#[derive(Debug)]
+struct PackedSiteTensor<T> {
+    left_dim: usize,
+    physical_dim: usize,
+    right_dim: usize,
+    data: Vec<T>,
+}
+
+impl<T: Copy> PackedSiteTensor<T> {
+    fn get(&self, left: usize, physical: usize, right: usize) -> T {
+        debug_assert!(left < self.left_dim);
+        debug_assert!(physical < self.physical_dim);
+        debug_assert!(right < self.right_dim);
+
+        let idx = left + self.left_dim * (physical + self.physical_dim * right);
+        self.data[idx]
+    }
+}
+
+trait NormAccumScalar: CommonScalar {
+    fn into_nonnegative_real(self) -> f64;
+}
+
+impl NormAccumScalar for f64 {
+    fn into_nonnegative_real(self) -> f64 {
+        self.max(0.0)
+    }
+}
+
+impl NormAccumScalar for Complex64 {
+    fn into_nonnegative_real(self) -> f64 {
+        self.re.max(0.0)
+    }
 }
 
 impl TensorTrain {
@@ -867,10 +903,13 @@ impl TensorTrain {
     /// Returns `<self | self>` = ||self||^2.
     ///
     /// # Note
-    /// Due to numerical errors, the inner product can be very slightly negative.
-    /// This method clamps the result to be non-negative.
+    /// For linear tensor trains with one site index per site, this uses a
+    /// specialized chain contraction instead of the generic inner-product path.
+    /// Due to numerical errors, the final scalar can be very slightly negative,
+    /// so the returned value is clamped to be non-negative.
     pub fn norm_squared(&self) -> f64 {
-        self.inner(self).real().max(0.0)
+        self.norm_squared_fast_path()
+            .unwrap_or_else(|| self.inner(self).real().max(0.0))
     }
 
     /// Compute the norm of the tensor train.
@@ -878,6 +917,111 @@ impl TensorTrain {
     /// Returns ||self|| = sqrt(<self | self>).
     pub fn norm(&self) -> f64 {
         self.norm_squared().sqrt()
+    }
+
+    fn norm_squared_fast_path(&self) -> Option<f64> {
+        if self.is_empty() {
+            return Some(0.0);
+        }
+        if !self.has_simple_linear_links() {
+            return None;
+        }
+        if self
+            .siteinds()
+            .iter()
+            .any(|site_indices| site_indices.len() != 1)
+        {
+            return None;
+        }
+
+        let mut normalized = self.clone();
+        normalized.normalize_site_tensor_orders().ok()?;
+
+        if let Some(sites) = Self::pack_normalized_sites::<f64>(&normalized) {
+            return Some(Self::norm_squared_from_packed_sites(&sites));
+        }
+        if let Some(sites) = Self::pack_normalized_sites::<Complex64>(&normalized) {
+            return Some(Self::norm_squared_from_packed_sites(&sites));
+        }
+
+        None
+    }
+
+    fn pack_normalized_sites<T: TensorElement>(tt: &Self) -> Option<Vec<PackedSiteTensor<T>>> {
+        let mut sites = Vec::with_capacity(tt.len());
+
+        for site in 0..tt.len() {
+            let tensor = tt.tensor(site);
+            let left_dim = if site == 0 {
+                1
+            } else {
+                tt.linkind(site - 1)?.size()
+            };
+            let right_dim = if site + 1 == tt.len() {
+                1
+            } else {
+                tt.linkind(site)?.size()
+            };
+            let total_size: usize = tensor.dims().iter().product();
+            let boundary_size = left_dim.checked_mul(right_dim)?;
+            if boundary_size == 0 || !total_size.is_multiple_of(boundary_size) {
+                return None;
+            }
+
+            sites.push(PackedSiteTensor {
+                left_dim,
+                physical_dim: total_size / boundary_size,
+                right_dim,
+                data: tensor.to_vec::<T>().ok()?,
+            });
+        }
+
+        Some(sites)
+    }
+
+    fn norm_squared_from_packed_sites<T: NormAccumScalar>(sites: &[PackedSiteTensor<T>]) -> f64 {
+        if sites.is_empty() {
+            return 0.0;
+        }
+
+        let first = &sites[0];
+        let mut current = vec![T::zero(); first.right_dim * first.right_dim];
+
+        for physical in 0..first.physical_dim {
+            for right in 0..first.right_dim {
+                let value = first.get(0, physical, right);
+                for right_conj in 0..first.right_dim {
+                    let idx = right * first.right_dim + right_conj;
+                    current[idx] = current[idx] + value * first.get(0, physical, right_conj).conj();
+                }
+            }
+        }
+
+        for site in &sites[1..] {
+            let mut next = vec![T::zero(); site.right_dim * site.right_dim];
+
+            for left in 0..site.left_dim {
+                for left_conj in 0..site.left_dim {
+                    let env = current[left * site.left_dim + left_conj];
+                    for physical in 0..site.physical_dim {
+                        for right in 0..site.right_dim {
+                            let value = site.get(left, physical, right);
+                            for right_conj in 0..site.right_dim {
+                                let idx = right * site.right_dim + right_conj;
+                                next[idx] = next[idx]
+                                    + env
+                                        * value
+                                        * site.get(left_conj, physical, right_conj).conj();
+                            }
+                        }
+                    }
+                }
+            }
+
+            current = next;
+        }
+
+        current[0].into_nonnegative_real()
     }
 
     /// Convert the tensor train to a single dense tensor.

--- a/crates/tensor4all-itensorlike/tests/bug_complex_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_complex_inner.rs
@@ -53,6 +53,8 @@ fn test_inner_wrong_with_nonstandard_index_order() {
     // inner(x, x) for both must be real, non-negative, and match dense norm²
     let inner_std = tt_std.inner(&tt_std);
     let inner_ns = tt_ns.inner(&tt_ns);
+    let norm_sq_std_tt = tt_std.norm_squared();
+    let norm_sq_ns_tt = tt_ns.norm_squared();
 
     eprintln!("inner std={:?}", inner_std);
     eprintln!("inner ns ={:?}", inner_ns);
@@ -66,6 +68,12 @@ fn test_inner_wrong_with_nonstandard_index_order() {
     assert!(
         (inner_std.real() - norm_sq_std).abs() / norm_sq_std < 1e-10,
         "std: inner mismatch"
+    );
+    assert!(
+        (norm_sq_std_tt - norm_sq_std).abs() / norm_sq_std < 1e-10,
+        "std: norm_squared mismatch: TT={:.6e}, dense={:.6e}",
+        norm_sq_std_tt,
+        norm_sq_std
     );
 
     assert!(
@@ -82,6 +90,12 @@ fn test_inner_wrong_with_nonstandard_index_order() {
         (inner_ns.real() - norm_sq_ns).abs() / norm_sq_ns < 1e-6,
         "ns: inner mismatch: TT={:.6e}, dense={:.6e}",
         inner_ns.real(),
+        norm_sq_ns
+    );
+    assert!(
+        (norm_sq_ns_tt - norm_sq_ns).abs() / norm_sq_ns < 1e-6,
+        "ns: norm_squared mismatch: TT={:.6e}, dense={:.6e}",
+        norm_sq_ns_tt,
         norm_sq_ns
     );
 }
@@ -117,6 +131,7 @@ fn test_inner_wrong_3site_nonstandard() {
     .unwrap();
 
     let inner = tt.inner(&tt);
+    let norm_sq_tt = tt.norm_squared();
     let dense = tt.to_dense().unwrap();
     let dense_norm_sq = dense.norm() * dense.norm();
 
@@ -136,6 +151,12 @@ fn test_inner_wrong_3site_nonstandard() {
         (inner.real() - dense_norm_sq).abs() / dense_norm_sq < 1e-6,
         "inner mismatch: TT={:.6e}, dense={:.6e}",
         inner.real(),
+        dense_norm_sq
+    );
+    assert!(
+        (norm_sq_tt - dense_norm_sq).abs() / dense_norm_sq < 1e-6,
+        "norm_squared mismatch: TT={:.6e}, dense={:.6e}",
+        norm_sq_tt,
         dense_norm_sq
     );
 }
@@ -177,6 +198,7 @@ fn test_inner_wrong_with_two_site_indices_per_site_nonstandard_order() {
     .unwrap();
 
     let inner = tt.inner(&tt);
+    let norm_sq_tt = tt.norm_squared();
     let dense = tt.to_dense().unwrap();
     let dense_norm_sq = dense.norm() * dense.norm();
 
@@ -189,6 +211,12 @@ fn test_inner_wrong_with_two_site_indices_per_site_nonstandard_order() {
         (inner.real() - dense_norm_sq).abs() / dense_norm_sq < 1e-10,
         "inner mismatch: TT={:.12e}, dense={:.12e}",
         inner.real(),
+        dense_norm_sq
+    );
+    assert!(
+        (norm_sq_tt - dense_norm_sq).abs() / dense_norm_sq < 1e-10,
+        "norm_squared mismatch: TT={:.12e}, dense={:.12e}",
+        norm_sq_tt,
         dense_norm_sq
     );
 }

--- a/crates/tensor4all-simplett/Cargo.toml
+++ b/crates/tensor4all-simplett/Cargo.toml
@@ -26,9 +26,8 @@ tensor4all-tcicore = { path = "../tensor4all-tcicore" }
 tensor4all-core = { path = "../tensor4all-core" }
 tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
 tenferro-algebra.workspace = true
-tenferro-linalg.workspace = true
+tenferro-einsum.workspace = true
 tenferro-tensor.workspace = true
-tenferro-tensor-compute.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -1,12 +1,11 @@
 //! Compression algorithms for tensor trains
 
+use crate::einsum_helper::{tensor_to_row_major_vec, typed_tensor_from_row_major_slice};
 use crate::error::Result;
 use crate::tensortrain::TensorTrain;
 use crate::traits::{AbstractTensorTrain, TTScalar};
 use crate::types::{tensor3_zeros, Tensor3, Tensor3Ops};
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::{KeepCountScalar, MemoryOrder, Tensor as TypedTensor};
+use tenferro_tensor::{TensorScalar, TypedTensor};
 use tensor4all_tcicore::matrix::{mat_mul, ncols, nrows, zeros, Matrix};
 use tensor4all_tcicore::Scalar;
 use tensor4all_tcicore::{rrlu, AbstractMatrixCI, MatrixLUCI, RrLUOptions};
@@ -201,33 +200,26 @@ where
 
 /// Trait bounds for SVD-compatible scalars in TT compression
 trait SVDCompressScalar:
-    TTScalar
-    + Scalar
-    + Default
-    + Copy
-    + BackendLinalgScalar
-    + TfScalar
-    + num_complex::ComplexFloat
-    + 'static
+    TTScalar + Scalar + Default + Copy + BackendLinalgScalar + num_complex::ComplexFloat + 'static
 {
-    fn sv_to_f64(real: <Self as LinalgScalar>::Real) -> f64;
-    fn from_sv(real: <Self as LinalgScalar>::Real) -> Self;
+    fn sv_to_f64(real: <Self as TensorScalar>::Real) -> f64;
+    fn from_sv(real: <Self as TensorScalar>::Real) -> Self;
 }
 
 impl SVDCompressScalar for f64 {
-    fn sv_to_f64(real: <Self as LinalgScalar>::Real) -> f64 {
+    fn sv_to_f64(real: <Self as TensorScalar>::Real) -> f64 {
         real
     }
-    fn from_sv(real: <Self as LinalgScalar>::Real) -> Self {
+    fn from_sv(real: <Self as TensorScalar>::Real) -> Self {
         real
     }
 }
 
 impl SVDCompressScalar for num_complex::Complex64 {
-    fn sv_to_f64(real: <Self as LinalgScalar>::Real) -> f64 {
+    fn sv_to_f64(real: <Self as TensorScalar>::Real) -> f64 {
         real
     }
-    fn from_sv(real: <Self as LinalgScalar>::Real) -> Self {
+    fn from_sv(real: <Self as TensorScalar>::Real) -> Self {
         num_complex::Complex64::new(real, 0.0)
     }
 }
@@ -272,18 +264,11 @@ fn svd_dispatch<T: TTScalar + Scalar>(
     })
 }
 
-/// Helper: extract row-major data from a TypedTensor
-fn typed_tensor_row_major<T: TfScalar + Copy>(
+/// Helper: extract row-major data from a TypedTensor.
+fn typed_tensor_row_major<T: TensorScalar>(
     tensor: &TypedTensor<T>,
-    name: &str,
 ) -> crate::error::Result<Vec<T>> {
-    let row_major = tensor.contiguous(MemoryOrder::RowMajor);
-    let data = row_major.buffer().as_slice().ok_or_else(|| {
-        crate::error::TensorTrainError::InvalidOperation {
-            message: format!("SVD {name}: non-CPU tensor"),
-        }
-    })?;
-    Ok(data.to_vec())
+    Ok(tensor_to_row_major_vec(tensor))
 }
 
 /// SVD-based factorization for TT compression
@@ -292,10 +277,7 @@ fn factorize_svd<T: SVDCompressScalar>(
     tolerance: f64,
     max_bond_dim: usize,
     left_orthogonal: bool,
-) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
-where
-    <T as LinalgScalar>::Real: KeepCountScalar,
-{
+) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)> {
     let m = nrows(matrix);
     let n = ncols(matrix);
 
@@ -312,12 +294,7 @@ where
             data[i * n + j] = matrix[[i, j]];
         }
     }
-    let a_tensor =
-        TypedTensor::<T>::from_slice(&data, &[m, n], MemoryOrder::RowMajor).map_err(|e| {
-            crate::error::TensorTrainError::InvalidOperation {
-                message: format!("SVD tensor creation failed: {e}"),
-            }
-        })?;
+    let a_tensor = typed_tensor_from_row_major_slice(&data, &[m, n]);
 
     let svd_result = tensor4all_tensorbackend::svd_backend(&a_tensor).map_err(|e| {
         crate::error::TensorTrainError::InvalidOperation {
@@ -326,11 +303,11 @@ where
     })?;
 
     // Extract U, S, Vt as row-major vectors
-    let u_data = typed_tensor_row_major(&svd_result.u, "U")?;
-    let u_cols = svd_result.u.dims()[1];
-    let s_data: Vec<<T as LinalgScalar>::Real> = typed_tensor_row_major(&svd_result.s, "S")?;
-    let vt_data = typed_tensor_row_major(&svd_result.vt, "Vt")?;
-    let vt_cols = svd_result.vt.dims()[1];
+    let u_data = typed_tensor_row_major(&svd_result.u)?;
+    let u_cols = svd_result.u.shape[1];
+    let s_data: Vec<<T as TensorScalar>::Real> = typed_tensor_row_major(&svd_result.s)?;
+    let vt_data = typed_tensor_row_major(&svd_result.vt)?;
+    let vt_cols = svd_result.vt.shape[1];
 
     // Determine rank based on tolerance and max_bond_dim
     let min_dim = m.min(n);

--- a/crates/tensor4all-simplett/src/contraction.rs
+++ b/crates/tensor4all-simplett/src/contraction.rs
@@ -4,12 +4,13 @@
 //! - `dot`: Inner product (returns scalar)
 
 use crate::compression::CompressionMethod;
-use crate::einsum_helper::{einsum_tensors, tensor_to_row_major_vec, EinsumScalar};
+use crate::einsum_helper::{
+    einsum_tensors, tensor_to_row_major_vec, typed_tensor_from_row_major_slice, EinsumScalar,
+};
 use crate::error::{Result, TensorTrainError};
 use crate::tensortrain::TensorTrain;
 use crate::traits::{AbstractTensorTrain, TTScalar};
 use crate::types::Tensor3Ops;
-use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
 use tensor4all_tcicore::matrix::Matrix;
 use tensor4all_tcicore::Scalar;
 
@@ -124,12 +125,10 @@ impl<T: TTScalar + Scalar + Default + EinsumScalar> TensorTrain<T> {
                 });
             }
 
-            let result_tf = TfTensor::from_slice(
+            let result_tf = typed_tensor_from_row_major_slice(
                 result.as_slice(),
                 &[result.nrows(), result.ncols()],
-                MemoryOrder::RowMajor,
-            )
-            .expect("dot intermediate matrix dimensions should match tenferro");
+            );
 
             result = Matrix::from_raw_vec(
                 a.right_dim(),

--- a/crates/tensor4all-simplett/src/contraction/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/contraction/tests/mod.rs
@@ -1,7 +1,8 @@
 use super::*;
-use crate::einsum_helper::{einsum_tensors, EinsumScalar};
+use crate::einsum_helper::{
+    einsum_tensors, tensor_to_row_major_vec, typed_tensor_from_row_major_slice, EinsumScalar,
+};
 use crate::types::{tensor3_zeros, Tensor3};
-use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
 
 #[test]
 fn test_dot_constant() {
@@ -150,13 +151,9 @@ fn test_dot_three_sites() {
 
 #[test]
 fn test_einsum_tensors_matmul() {
-    let a = TfTensor::from_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::RowMajor).unwrap();
-    let b = TfTensor::from_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2], MemoryOrder::RowMajor).unwrap();
+    let a = typed_tensor_from_row_major_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    let b = typed_tensor_from_row_major_slice(&[5.0, 6.0, 7.0, 8.0], &[2, 2]);
 
     let c = einsum_tensors("ij,jk->ik", &[&a, &b]);
-    let c_row_major = c.contiguous(MemoryOrder::RowMajor);
-    assert_eq!(
-        c_row_major.buffer().as_slice().unwrap(),
-        &[19.0, 22.0, 43.0, 50.0]
-    );
+    assert_eq!(tensor_to_row_major_vec(&c), &[19.0, 22.0, 43.0, 50.0]);
 }

--- a/crates/tensor4all-simplett/src/einsum_helper.rs
+++ b/crates/tensor4all-simplett/src/einsum_helper.rs
@@ -1,19 +1,80 @@
-use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
+use tenferro_einsum::typed_eager_einsum;
+use tenferro_tensor::{TensorScalar, TypedTensor};
+use tensor4all_tensorbackend::with_default_backend;
 
 pub(crate) fn einsum_tensors<T: EinsumScalar>(
     subscripts: &str,
-    operands: &[&TfTensor<T>],
-) -> TfTensor<T> {
-    T::einsum_dispatch(subscripts, operands)
+    operands: &[&TypedTensor<T>],
+) -> TypedTensor<T> {
+    with_default_backend(|backend| typed_eager_einsum(backend, operands, subscripts))
+        .expect("einsum failed")
 }
 
-pub(crate) fn tensor_to_row_major_vec<T: tenferro_algebra::Scalar>(tensor: &TfTensor<T>) -> Vec<T> {
-    tensor
-        .contiguous(MemoryOrder::RowMajor)
-        .buffer()
-        .as_slice()
-        .expect("einsum helper requires CPU-accessible tensors")
-        .to_vec()
+fn row_major_index_from_linear(shape: &[usize], mut linear: usize) -> Vec<usize> {
+    let mut idx = vec![0usize; shape.len()];
+    for axis in (0..shape.len()).rev() {
+        let dim = shape[axis];
+        if dim == 0 {
+            return idx;
+        }
+        idx[axis] = linear % dim;
+        linear /= dim;
+    }
+    idx
+}
+
+fn column_major_offset(indices: &[usize], shape: &[usize]) -> usize {
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (axis, &idx) in indices.iter().enumerate() {
+        offset += idx * stride;
+        stride *= shape[axis];
+    }
+    offset
+}
+
+fn row_major_to_col_major<T: Clone>(shape: &[usize], data: &[T]) -> Vec<T> {
+    assert_eq!(shape.iter().product::<usize>(), data.len());
+    let mut col_major = data.to_vec();
+    for (row_offset, value) in data.iter().cloned().enumerate() {
+        let indices = row_major_index_from_linear(shape, row_offset);
+        let col_offset = column_major_offset(&indices, shape);
+        col_major[col_offset] = value;
+    }
+    col_major
+}
+
+fn col_major_to_row_major<T: Clone>(shape: &[usize], data: &[T]) -> Vec<T> {
+    assert_eq!(shape.iter().product::<usize>(), data.len());
+    let mut row_major = data.to_vec();
+    for (row_offset, slot) in row_major.iter_mut().enumerate() {
+        let indices = row_major_index_from_linear(shape, row_offset);
+        let col_offset = column_major_offset(&indices, shape);
+        *slot = data[col_offset].clone();
+    }
+    row_major
+}
+
+pub(crate) fn typed_tensor_from_row_major_slice<T: TensorScalar>(
+    data: &[T],
+    shape: &[usize],
+) -> TypedTensor<T> {
+    TypedTensor::from_vec(shape.to_vec(), row_major_to_col_major(shape, data))
+}
+
+pub(crate) fn typed_tensor_reshape<T: TensorScalar>(
+    tensor: &TypedTensor<T>,
+    shape: &[usize],
+) -> TypedTensor<T> {
+    assert_eq!(
+        shape.iter().product::<usize>(),
+        tensor.shape.iter().product::<usize>()
+    );
+    TypedTensor::from_vec(shape.to_vec(), tensor.host_data().to_vec())
+}
+
+pub(crate) fn tensor_to_row_major_vec<T: TensorScalar>(tensor: &TypedTensor<T>) -> Vec<T> {
+    col_major_to_row_major(&tensor.shape, tensor.host_data())
 }
 
 pub(crate) fn row_vector_times_matrix<T: EinsumScalar>(
@@ -25,10 +86,8 @@ pub(crate) fn row_vector_times_matrix<T: EinsumScalar>(
     assert_eq!(vector.len(), rows);
     assert_eq!(matrix.len(), rows * cols);
 
-    let vector_tf = TfTensor::from_slice(vector, &[rows], MemoryOrder::RowMajor)
-        .expect("row vector dimensions should match einsum input");
-    let matrix_tf = TfTensor::from_slice(matrix, &[rows, cols], MemoryOrder::RowMajor)
-        .expect("matrix dimensions should match einsum input");
+    let vector_tf = typed_tensor_from_row_major_slice(vector, &[rows]);
+    let matrix_tf = typed_tensor_from_row_major_slice(matrix, &[rows, cols]);
 
     tensor_to_row_major_vec(&einsum_tensors("l,lr->r", &[&vector_tf, &matrix_tf]))
 }
@@ -42,34 +101,19 @@ pub(crate) fn matrix_times_col_vector<T: EinsumScalar>(
     assert_eq!(matrix.len(), rows * cols);
     assert_eq!(vector.len(), cols);
 
-    let matrix_tf = TfTensor::from_slice(matrix, &[rows, cols], MemoryOrder::RowMajor)
-        .expect("matrix dimensions should match einsum input");
-    let vector_tf = TfTensor::from_slice(vector, &[cols], MemoryOrder::RowMajor)
-        .expect("column vector dimensions should match einsum input");
+    let matrix_tf = typed_tensor_from_row_major_slice(matrix, &[rows, cols]);
+    let vector_tf = typed_tensor_from_row_major_slice(vector, &[cols]);
 
     tensor_to_row_major_vec(&einsum_tensors("lr,r->l", &[&matrix_tf, &vector_tf]))
 }
 
 /// Scalar types supported by the tenferro-backed einsum helpers used in
 /// `tensor4all-simplett`.
-pub trait EinsumScalar: tenferro_algebra::Scalar + Sized {
-    /// Execute an einsum on typed tenferro tensors.
-    fn einsum_dispatch(subscripts: &str, operands: &[&TfTensor<Self>]) -> TfTensor<Self>;
-}
+pub trait EinsumScalar: tenferro_algebra::Scalar + TensorScalar + Sized {}
 
 macro_rules! impl_einsum_scalar {
     ($($t:ty),*) => {
-        $(
-            impl EinsumScalar for $t {
-                fn einsum_dispatch(subscripts: &str, operands: &[&TfTensor<Self>]) -> TfTensor<Self> {
-                    use tenferro_tensor_compute::{einsum, CpuBackend, CpuContext, Standard};
-
-                    let mut ctx = CpuContext::new(1);
-                    einsum::<Standard<$t>, CpuBackend>(&mut ctx, subscripts, operands, None)
-                        .expect("einsum failed")
-                }
-            }
-        )*
+        $(impl EinsumScalar for $t {})*
     };
 }
 

--- a/crates/tensor4all-simplett/src/mpo/contract_fit.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit.rs
@@ -10,8 +10,6 @@ use super::mpo::MPO;
 use super::site_mpo::SiteMPO;
 use super::types::{Tensor4, Tensor4Ops};
 use crate::einsum_helper::EinsumScalar;
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::KeepCountScalar;
 
 /// Options for the variational fit algorithm
 #[derive(Debug, Clone)]
@@ -62,7 +60,6 @@ pub fn contract_fit<T: SVDScalar + EinsumScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
-    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo_a.len() != mpo_b.len() {
         return Err(MPOError::LengthMismatch {

--- a/crates/tensor4all-simplett/src/mpo/contract_naive.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive.rs
@@ -11,8 +11,6 @@ use super::mpo::MPO;
 use super::types::{tensor4_zeros, Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
 use crate::einsum_helper::EinsumScalar;
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::KeepCountScalar;
 
 /// Perform naive contraction of two MPOs
 ///
@@ -40,7 +38,6 @@ pub fn contract_naive<T: SVDScalar + EinsumScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
-    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo_a.len() != mpo_b.len() {
         return Err(MPOError::LengthMismatch {
@@ -96,7 +93,6 @@ where
 fn compress_mpo<T: SVDScalar>(mpo: &mut MPO<T>, options: &ContractionOptions) -> Result<()>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
-    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo.len() <= 1 {
         return Ok(());

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
@@ -9,8 +9,6 @@ use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
 use super::types::{tensor4_zeros, Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::KeepCountScalar;
 
 /// Perform zip-up contraction of two MPOs
 ///
@@ -42,7 +40,6 @@ pub fn contract_zipup<T: SVDScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
-    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     if mpo_a.len() != mpo_b.len() {
         return Err(MPOError::LengthMismatch {

--- a/crates/tensor4all-simplett/src/mpo/dispatch.rs
+++ b/crates/tensor4all-simplett/src/mpo/dispatch.rs
@@ -23,8 +23,6 @@ use super::error::Result;
 use super::factorize::SVDScalar;
 use super::mpo::MPO;
 use crate::einsum_helper::EinsumScalar;
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::KeepCountScalar;
 
 /// Unified contraction function with algorithm dispatch
 ///
@@ -68,7 +66,6 @@ pub fn contract<T: SVDScalar + EinsumScalar>(
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
-    <T as LinalgScalar>::Real: KeepCountScalar,
 {
     match algorithm {
         ContractionAlgorithm::Naive => contract_naive(mpo_a, mpo_b, Some(options.clone())),

--- a/crates/tensor4all-simplett/src/mpo/environment.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment.rs
@@ -3,15 +3,13 @@
 //! This module provides functions for computing left and right environments
 //! used in variational algorithms and efficient MPO evaluation.
 
-use crate::einsum_helper::{einsum_tensors, EinsumScalar};
+use crate::einsum_helper::{einsum_tensors, typed_tensor_reshape, EinsumScalar};
 
 use super::error::{MPOError, Result};
 use super::factorize::SVDScalar;
 use super::mpo::MPO;
 use super::types::{Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
-use tenferro_tensor::MemoryOrder;
-
 /// Contract two 4D site tensors over their shared physical index
 ///
 /// Given two 4D tensors:
@@ -59,13 +57,8 @@ where
     // TODO: Remove this materialization once tenferro supports reshaping
     // layout-compatible strided views directly.
     // Tracking issue: https://github.com/tensor4all/tenferro-rs/issues/575
-    let contracted = einsum_tensors("askr,bktq->bastqr", &[a.as_inner(), b.as_inner()])
-        .contiguous(MemoryOrder::ColumnMajor);
-    let reshaped = contracted
-        .reshape(&[new_left, new_s1, new_s2, new_right])
-        .map_err(|e| MPOError::InvalidOperation {
-            message: format!("Failed to reshape contracted site tensors: {e}"),
-        })?;
+    let contracted = einsum_tensors("askr,bktq->bastqr", &[a.as_inner(), b.as_inner()]);
+    let reshaped = typed_tensor_reshape(&contracted, &[new_left, new_s1, new_s2, new_right]);
 
     Ok(Tensor4::from_tenferro(reshaped))
 }

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -5,10 +5,9 @@
 
 use super::error::{MPOError, Result};
 use super::Matrix2;
+use crate::einsum_helper::{tensor_to_row_major_vec, typed_tensor_from_row_major_slice};
 use num_complex::{Complex64, ComplexFloat};
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::{KeepCountScalar, MemoryOrder, Tensor as TypedTensor};
+use tenferro_tensor::{TensorScalar, TypedTensor};
 use tensor4all_tensorbackend::{svd_backend, BackendLinalgScalar};
 
 /// Factorization method to use
@@ -57,7 +56,7 @@ impl Default for FactorizeOptions {
 
 /// Result of factorization
 #[derive(Debug, Clone)]
-pub struct FactorizeResult<T: TfScalar> {
+pub struct FactorizeResult<T: TensorScalar> {
     /// Left factor matrix (m x rank)
     pub left: Matrix2<T>,
     /// Right factor matrix (rank x n)
@@ -70,30 +69,30 @@ pub struct FactorizeResult<T: TfScalar> {
 
 /// Trait bounds for SVD-compatible scalars
 pub trait SVDScalar:
-    crate::traits::TTScalar + ComplexFloat + Default + Copy + BackendLinalgScalar + TfScalar + 'static
+    crate::traits::TTScalar + ComplexFloat + Default + Copy + BackendLinalgScalar + 'static
 {
     /// Convert a backend singular value into `f64` for truncation logic.
-    fn linalg_real_to_f64(real: <Self as LinalgScalar>::Real) -> f64;
+    fn linalg_real_to_f64(real: <Self as TensorScalar>::Real) -> f64;
     /// Promote a backend singular value into the matrix scalar type.
-    fn from_linalg_real(real: <Self as LinalgScalar>::Real) -> Self;
+    fn from_linalg_real(real: <Self as TensorScalar>::Real) -> Self;
 }
 
 impl SVDScalar for f64 {
-    fn linalg_real_to_f64(real: <Self as LinalgScalar>::Real) -> f64 {
+    fn linalg_real_to_f64(real: <Self as TensorScalar>::Real) -> f64 {
         real
     }
 
-    fn from_linalg_real(real: <Self as LinalgScalar>::Real) -> Self {
+    fn from_linalg_real(real: <Self as TensorScalar>::Real) -> Self {
         real
     }
 }
 
 impl SVDScalar for Complex64 {
-    fn linalg_real_to_f64(real: <Self as LinalgScalar>::Real) -> f64 {
+    fn linalg_real_to_f64(real: <Self as TensorScalar>::Real) -> f64 {
         real
     }
 
-    fn from_linalg_real(real: <Self as LinalgScalar>::Real) -> Self {
+    fn from_linalg_real(real: <Self as TensorScalar>::Real) -> Self {
         Complex64::new(real, 0.0)
     }
 }
@@ -113,10 +112,7 @@ impl SVDScalar for Complex64 {
 pub fn factorize<T: SVDScalar>(
     matrix: &Matrix2<T>,
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<T>>
-where
-    <T as LinalgScalar>::Real: KeepCountScalar,
-{
+) -> Result<FactorizeResult<T>> {
     match options.method {
         FactorizeMethod::SVD => factorize_svd(matrix, options),
         FactorizeMethod::RSVD => factorize_rsvd(matrix, options),
@@ -133,40 +129,29 @@ use super::matrix2_zeros;
 
 fn matrix2_to_typed_tensor<T>(matrix: &Matrix2<T>) -> Result<TypedTensor<T>>
 where
-    T: TfScalar + Copy,
+    T: TensorScalar,
 {
     let dims = [matrix.dim(0), matrix.dim(1)];
     let data: Vec<T> = matrix.iter().copied().collect();
-    TypedTensor::from_slice(&data, &dims, MemoryOrder::RowMajor).map_err(|e| {
-        MPOError::FactorizationError {
-            message: format!("failed to convert Matrix2 to tenferro tensor: {e}"),
-        }
-    })
+    Ok(typed_tensor_from_row_major_slice(&data, &dims))
 }
 
 fn typed_tensor_to_matrix2<T>(tensor: &TypedTensor<T>, op: &'static str) -> Result<Matrix2<T>>
 where
-    T: TfScalar + Copy + Default,
+    T: crate::traits::TTScalar + Default,
 {
-    if tensor.ndim() != 2 {
+    if tensor.shape.len() != 2 {
         return Err(MPOError::FactorizationError {
             message: format!(
                 "{op} returned rank-{} tensor, expected matrix",
-                tensor.ndim()
+                tensor.shape.len()
             ),
         });
     }
 
-    let dims = tensor.dims();
-    let rows = dims[0];
-    let cols = dims[1];
-    let row_major = tensor.contiguous(MemoryOrder::RowMajor);
-    let data = row_major
-        .buffer()
-        .as_slice()
-        .ok_or_else(|| MPOError::FactorizationError {
-            message: format!("{op} returned non-CPU tensor unexpectedly"),
-        })?;
+    let rows = tensor.shape[0];
+    let cols = tensor.shape[1];
+    let data = tensor_to_row_major_vec(tensor);
 
     let mut matrix = matrix2_zeros(rows, cols);
     for i in 0..rows {
@@ -179,26 +164,17 @@ where
 
 fn typed_row_major_values<T>(tensor: &TypedTensor<T>, op: &'static str) -> Result<Vec<T>>
 where
-    T: TfScalar + Copy,
+    T: TensorScalar,
 {
-    let row_major = tensor.contiguous(MemoryOrder::RowMajor);
-    let data = row_major
-        .buffer()
-        .as_slice()
-        .ok_or_else(|| MPOError::FactorizationError {
-            message: format!("{op} returned non-CPU tensor unexpectedly"),
-        })?;
-    Ok(data.to_vec())
+    let _ = op;
+    Ok(tensor_to_row_major_vec(tensor))
 }
 
 /// Factorize using SVD
 fn factorize_svd<T: SVDScalar>(
     matrix: &Matrix2<T>,
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<T>>
-where
-    <T as LinalgScalar>::Real: KeepCountScalar,
-{
+) -> Result<FactorizeResult<T>> {
     let m = matrix.dim(0);
     let n = matrix.dim(1);
 

--- a/crates/tensor4all-simplett/src/mpo/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mod.rs
@@ -36,7 +36,7 @@ pub type Matrix2<T> = crate::tensor::Tensor2<T>;
 ///
 /// This is a shared utility used across multiple MPO modules.
 #[inline]
-pub(crate) fn matrix2_zeros<T: tenferro_algebra::Scalar + Clone + Default>(
+pub(crate) fn matrix2_zeros<T: crate::traits::TTScalar + Default>(
     rows: usize,
     cols: usize,
 ) -> Matrix2<T> {

--- a/crates/tensor4all-simplett/src/mpo/types.rs
+++ b/crates/tensor4all-simplett/src/mpo/types.rs
@@ -8,8 +8,7 @@
 
 use crate::tensor::Tensor;
 pub use crate::tensor::Tensor4;
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
+use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
 
 /// Local index type (index within a single tensor site)
 pub type LocalIndex = usize;
@@ -53,7 +52,7 @@ pub trait Tensor4Ops<T: Clone + Default> {
     fn as_center_matrix(&self) -> (Vec<T>, usize, usize);
 }
 
-impl<T: Clone + Default + TfScalar> Tensor4Ops<T> for Tensor4<T> {
+impl<T: Clone + Default + TensorScalar> Tensor4Ops<T> for Tensor4<T> {
     fn left_dim(&self) -> usize {
         self.dim(0)
     }
@@ -156,7 +155,7 @@ impl<T: Clone + Default + TfScalar> Tensor4Ops<T> for Tensor4<T> {
 }
 
 /// Create a zero-filled Tensor4
-pub fn tensor4_zeros<T: Clone + Default + TfScalar>(
+pub fn tensor4_zeros<T: Clone + Default + TensorScalar>(
     left_dim: usize,
     site_dim_1: usize,
     site_dim_2: usize,
@@ -166,7 +165,7 @@ pub fn tensor4_zeros<T: Clone + Default + TfScalar>(
 }
 
 /// Create a Tensor4 from flat data (column-major order)
-pub fn tensor4_from_data<T: Clone + TfScalar>(
+pub fn tensor4_from_data<T: TensorScalar>(
     data: Vec<T>,
     left_dim: usize,
     site_dim_1: usize,
@@ -175,8 +174,7 @@ pub fn tensor4_from_data<T: Clone + TfScalar>(
 ) -> Tensor4<T> {
     assert_eq!(data.len(), left_dim * site_dim_1 * site_dim_2 * right_dim);
     let dims = [left_dim, site_dim_1, site_dim_2, right_dim];
-    let inner = TfTensor::from_slice(&data, &dims, MemoryOrder::ColumnMajor)
-        .expect("tensor4_from_data received invalid column-major data");
+    let inner = TfTensor::from_vec(dims.to_vec(), data);
     Tensor::from_tenferro(inner)
 }
 

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -1,20 +1,21 @@
-//! Fixed-rank tensor type backed by `tenferro_tensor::Tensor<T>`.
+//! Fixed-rank tensor type backed by `tenferro_tensor::TypedTensor<T>`.
 //!
 //! This wrapper preserves a compile-time rank while delegating storage and
-//! indexing to tenferro's dense tensor implementation.
+//! indexing to tenferro's typed dense tensor implementation.
 
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
+use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
 
-/// Rank-N tensor backed by `tenferro_tensor::Tensor<T>`.
+use crate::einsum_helper::{tensor_to_row_major_vec, typed_tensor_from_row_major_slice};
+
+/// Rank-N tensor backed by `tenferro_tensor::TypedTensor<T>`.
 #[derive(Debug)]
-pub struct Tensor<T: TfScalar, const N: usize>(TfTensor<T>);
+pub struct Tensor<T: TensorScalar, const N: usize>(TfTensor<T>);
 
 /// Iterator over tensor elements in row-major order.
-pub struct TensorIter<'a, T: TfScalar, const N: usize> {
+pub struct TensorIter<'a, T: TensorScalar, const N: usize> {
     tensor: &'a TfTensor<T>,
     dims: [usize; N],
     next: usize,
@@ -22,7 +23,7 @@ pub struct TensorIter<'a, T: TfScalar, const N: usize> {
 }
 
 /// Mutable iterator over tensor elements in row-major order.
-pub struct TensorIterMut<'a, T: TfScalar, const N: usize> {
+pub struct TensorIterMut<'a, T: TensorScalar, const N: usize> {
     tensor: *mut TfTensor<T>,
     dims: [usize; N],
     next: usize,
@@ -52,30 +53,29 @@ fn row_major_index_from_linear<const N: usize>(mut linear: usize, dims: &[usize;
     idx
 }
 
-fn row_major_data_to_tensor<T: TfScalar, const N: usize>(
+fn row_major_data_to_tensor<T: TensorScalar, const N: usize>(
     dims: [usize; N],
     data: Vec<T>,
 ) -> Tensor<T, N> {
-    let inner = TfTensor::from_row_major_slice(&data, &dims)
-        .expect("row-major tensor construction should match dims");
+    let inner = typed_tensor_from_row_major_slice(&data, &dims);
     Tensor::from_tenferro(inner)
 }
 
-impl<T: TfScalar, const N: usize> Clone for Tensor<T, N> {
+impl<T: TensorScalar, const N: usize> Clone for Tensor<T, N> {
     fn clone(&self) -> Self {
-        Self(self.0.deep_clone())
+        Self(self.0.clone())
     }
 }
 
-impl<T: TfScalar + PartialEq, const N: usize> PartialEq for Tensor<T, N> {
+impl<T: TensorScalar + PartialEq, const N: usize> PartialEq for Tensor<T, N> {
     fn eq(&self, other: &Self) -> bool {
         self.dims() == other.dims() && self.iter().eq(other.iter())
     }
 }
 
-impl<T: TfScalar + Eq, const N: usize> Eq for Tensor<T, N> {}
+impl<T: TensorScalar + Eq, const N: usize> Eq for Tensor<T, N> {}
 
-impl<'a, T: TfScalar, const N: usize> Iterator for TensorIter<'a, T, N> {
+impl<'a, T: TensorScalar, const N: usize> Iterator for TensorIter<'a, T, N> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -85,11 +85,7 @@ impl<'a, T: TfScalar, const N: usize> Iterator for TensorIter<'a, T, N> {
 
         let idx = row_major_index_from_linear(self.next, &self.dims);
         self.next += 1;
-        Some(
-            self.tensor
-                .get(&idx[..])
-                .expect("row-major iterator generated an invalid tensor index"),
-        )
+        Some(self.tensor.get(&idx[..]))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -98,9 +94,9 @@ impl<'a, T: TfScalar, const N: usize> Iterator for TensorIter<'a, T, N> {
     }
 }
 
-impl<'a, T: TfScalar, const N: usize> ExactSizeIterator for TensorIter<'a, T, N> {}
+impl<'a, T: TensorScalar, const N: usize> ExactSizeIterator for TensorIter<'a, T, N> {}
 
-impl<'a, T: TfScalar, const N: usize> Iterator for TensorIterMut<'a, T, N> {
+impl<'a, T: TensorScalar, const N: usize> Iterator for TensorIterMut<'a, T, N> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -114,9 +110,7 @@ impl<'a, T: TfScalar, const N: usize> Iterator for TensorIterMut<'a, T, N> {
         // Safety: each logical index is visited at most once, so returned
         // mutable references never alias each other.
         let tensor = unsafe { &mut *self.tensor };
-        let elem = tensor
-            .get_mut(&idx[..])
-            .expect("row-major iterator requires an exclusively owned CPU tensor");
+        let elem = tensor.get_mut(&idx[..]);
         let ptr = elem as *mut T;
         Some(unsafe { &mut *ptr })
     }
@@ -127,17 +121,17 @@ impl<'a, T: TfScalar, const N: usize> Iterator for TensorIterMut<'a, T, N> {
     }
 }
 
-impl<'a, T: TfScalar, const N: usize> ExactSizeIterator for TensorIterMut<'a, T, N> {}
+impl<'a, T: TensorScalar, const N: usize> ExactSizeIterator for TensorIterMut<'a, T, N> {}
 
-impl<T: TfScalar, const N: usize> Tensor<T, N> {
+impl<T: TensorScalar, const N: usize> Tensor<T, N> {
     /// Total number of elements.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.0.n_elements()
     }
 
     /// Whether the tensor is empty (zero elements).
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 
     /// Dimension along `axis`.
@@ -147,22 +141,17 @@ impl<T: TfScalar, const N: usize> Tensor<T, N> {
 
     /// All dimensions.
     pub fn dims(&self) -> &[usize; N] {
-        self.0.dims().try_into().unwrap_or_else(|_| {
+        self.0.shape.as_slice().try_into().unwrap_or_else(|_| {
             panic!(
                 "tensor rank mismatch: expected rank {N}, got {}",
-                self.0.ndim()
+                self.0.shape.len()
             )
         })
     }
 
     /// Export the tensor as a row-major flat vector.
     pub fn to_row_major_vec(&self) -> Vec<T> {
-        let row_major = self.0.contiguous(MemoryOrder::RowMajor);
-        row_major
-            .buffer()
-            .as_slice()
-            .expect("simplett tensors must remain CPU-accessible")
-            .to_vec()
+        tensor_to_row_major_vec(&self.0)
     }
 
     /// Iterate over all elements in row-major order.
@@ -203,18 +192,12 @@ impl<T: TfScalar, const N: usize> Tensor<T, N> {
 
     /// Wrap an existing tenferro tensor, panicking on rank mismatch.
     pub fn from_tenferro(tensor: TfTensor<T>) -> Self {
-        if tensor.ndim() != N {
+        if tensor.shape.len() != N {
             panic!(
                 "tensor rank mismatch: expected rank {N}, got {}",
-                tensor.ndim()
+                tensor.shape.len()
             );
         }
-
-        let tensor = if tensor.buffer().is_unique() {
-            tensor
-        } else {
-            tensor.deep_clone()
-        };
         Self(tensor)
     }
 
@@ -231,7 +214,7 @@ impl<T: TfScalar, const N: usize> Tensor<T, N> {
     }
 }
 
-impl<T: TfScalar + Clone, const N: usize> Tensor<T, N> {
+impl<T: TensorScalar, const N: usize> Tensor<T, N> {
     /// Create a tensor filled with `value`.
     pub fn from_elem(dims: [usize; N], value: T) -> Self {
         let total: usize = dims.iter().product();
@@ -239,28 +222,25 @@ impl<T: TfScalar + Clone, const N: usize> Tensor<T, N> {
     }
 }
 
-impl<T: TfScalar, const N: usize> Index<[usize; N]> for Tensor<T, N> {
+impl<T: TensorScalar, const N: usize> Index<[usize; N]> for Tensor<T, N> {
     type Output = T;
 
     fn index(&self, idx: [usize; N]) -> &T {
-        self.0
-            .get(&idx[..])
-            .expect("tensor index should be within bounds")
+        self.0.get(&idx[..])
     }
 }
 
-impl<T: TfScalar, const N: usize> IndexMut<[usize; N]> for Tensor<T, N> {
+impl<T: TensorScalar, const N: usize> IndexMut<[usize; N]> for Tensor<T, N> {
     fn index_mut(&mut self, idx: [usize; N]) -> &mut T {
-        self.0
-            .get_mut(&idx[..])
-            .expect("tensor mutation requires an in-bounds, exclusively owned CPU tensor")
+        self.0.get_mut(&idx[..])
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
+
+    use crate::einsum_helper::{tensor_to_row_major_vec, typed_tensor_from_row_major_slice};
 
     #[test]
     fn test_tensor2_from_elem() {
@@ -287,10 +267,11 @@ mod tests {
 
     #[test]
     fn test_tensor3_from_fn() {
-        let t: Tensor3<usize> = Tensor3::from_fn([2, 3, 4], |[i, j, k]| i * 100 + j * 10 + k);
-        assert_eq!(t[[0, 0, 0]], 0);
-        assert_eq!(t[[1, 2, 3]], 123);
-        assert_eq!(t[[0, 1, 2]], 12);
+        let t: Tensor3<f64> =
+            Tensor3::from_fn([2, 3, 4], |[i, j, k]| (i * 100 + j * 10 + k) as f64);
+        assert_eq!(t[[0, 0, 0]], 0.0);
+        assert_eq!(t[[1, 2, 3]], 123.0);
+        assert_eq!(t[[0, 1, 2]], 12.0);
         assert_eq!(t.dim(0), 2);
         assert_eq!(t.dim(1), 3);
         assert_eq!(t.dim(2), 4);
@@ -299,9 +280,10 @@ mod tests {
 
     #[test]
     fn test_tensor4_from_fn() {
-        let t: Tensor4<usize> =
-            Tensor4::from_fn([2, 3, 4, 5], |[i, j, k, l]| i * 1000 + j * 100 + k * 10 + l);
-        assert_eq!(t[[1, 2, 3, 4]], 1234);
+        let t: Tensor4<f64> = Tensor4::from_fn([2, 3, 4, 5], |[i, j, k, l]| {
+            (i * 1000 + j * 100 + k * 10 + l) as f64
+        });
+        assert_eq!(t[[1, 2, 3, 4]], 1234.0);
         assert_eq!(t.dim(0), 2);
         assert_eq!(t.dim(1), 3);
         assert_eq!(t.dim(2), 4);
@@ -324,8 +306,7 @@ mod tests {
 
     #[test]
     fn test_from_tenferro_roundtrip() {
-        let inner =
-            TfTensor::from_row_major_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+        let inner = typed_tensor_from_row_major_slice(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
         let tensor = Tensor2::from_tenferro(inner);
 
         assert_eq!(tensor.dims(), &[2, 3]);
@@ -335,9 +316,8 @@ mod tests {
         );
 
         let inner_again = tensor.clone().into_inner();
-        let row_major = inner_again.contiguous(MemoryOrder::RowMajor);
         assert_eq!(
-            row_major.buffer().as_slice().unwrap(),
+            tensor_to_row_major_vec(&inner_again),
             &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
         );
     }
@@ -345,7 +325,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "rank")]
     fn test_from_tenferro_rank_mismatch_panics() {
-        let inner = TfTensor::from_row_major_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]).unwrap();
+        let inner = typed_tensor_from_row_major_slice(&[1.0, 2.0, 3.0, 4.0], &[2, 2]);
         let _ = Tensor3::from_tenferro(inner);
     }
 

--- a/crates/tensor4all-simplett/src/traits.rs
+++ b/crates/tensor4all-simplett/src/traits.rs
@@ -3,6 +3,7 @@
 use crate::error::Result;
 use crate::types::{LocalIndex, Tensor3, Tensor3Ops};
 use tenferro_algebra::Scalar as TfScalar;
+use tenferro_tensor::TensorScalar;
 
 /// Scalar trait bound shared by all simplett tensor types.
 ///
@@ -27,9 +28,9 @@ use tenferro_algebra::Scalar as TfScalar;
 /// assert!((c.re - 1.0).abs() < 1e-15);
 /// assert!((c.im - 1.0).abs() < 1e-15);
 /// ```
-pub trait TTScalar: tensor4all_core::CommonScalar + TfScalar {}
+pub trait TTScalar: tensor4all_core::CommonScalar + TfScalar + TensorScalar {}
 
-impl<T> TTScalar for T where T: tensor4all_core::CommonScalar + TfScalar {}
+impl<T> TTScalar for T where T: tensor4all_core::CommonScalar + TfScalar + TensorScalar {}
 
 /// Common interface implemented by all tensor train representations.
 ///

--- a/crates/tensor4all-simplett/src/types.rs
+++ b/crates/tensor4all-simplett/src/types.rs
@@ -2,8 +2,7 @@
 
 use crate::tensor::Tensor;
 pub use crate::tensor::Tensor3;
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_tensor::{MemoryOrder, Tensor as TfTensor};
+use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
 
 /// Local index type (index within a single tensor site)
 pub type LocalIndex = usize;
@@ -61,7 +60,7 @@ pub trait Tensor3Ops<T: Clone + Default> {
     fn as_right_matrix(&self) -> (Vec<T>, usize, usize);
 }
 
-impl<T: Clone + Default + TfScalar> Tensor3Ops<T> for Tensor3<T> {
+impl<T: Clone + Default + TensorScalar> Tensor3Ops<T> for Tensor3<T> {
     fn left_dim(&self) -> usize {
         self.dim(0)
     }
@@ -146,7 +145,7 @@ impl<T: Clone + Default + TfScalar> Tensor3Ops<T> for Tensor3<T> {
 /// assert_eq!(t.right_dim(), 4);
 /// assert_eq!(*t.get3(0, 0, 0), 0.0);
 /// ```
-pub fn tensor3_zeros<T: Clone + Default + TfScalar>(
+pub fn tensor3_zeros<T: Clone + Default + TensorScalar>(
     left_dim: usize,
     site_dim: usize,
     right_dim: usize,
@@ -170,7 +169,7 @@ pub fn tensor3_zeros<T: Clone + Default + TfScalar>(
 /// assert_eq!(*t.get3(0, 0, 0), 10.0);
 /// assert_eq!(*t.get3(0, 1, 0), 20.0);
 /// ```
-pub fn tensor3_from_data<T: Clone + TfScalar>(
+pub fn tensor3_from_data<T: TensorScalar>(
     data: Vec<T>,
     left_dim: usize,
     site_dim: usize,
@@ -178,8 +177,7 @@ pub fn tensor3_from_data<T: Clone + TfScalar>(
 ) -> Tensor3<T> {
     assert_eq!(data.len(), left_dim * site_dim * right_dim);
     let dims = [left_dim, site_dim, right_dim];
-    let inner = TfTensor::from_slice(&data, &dims, MemoryOrder::ColumnMajor)
-        .expect("tensor3_from_data received invalid column-major data");
+    let inner = TfTensor::from_vec(dims.to_vec(), data);
     Tensor::from_tenferro(inner)
 }
 

--- a/crates/tensor4all-simplett/src/vidal.rs
+++ b/crates/tensor4all-simplett/src/vidal.rs
@@ -6,15 +6,14 @@
 
 use std::ops::Range;
 
+use crate::einsum_helper::{tensor_to_row_major_vec, typed_tensor_from_row_major_slice};
 use crate::error::{Result, TensorTrainError};
 use crate::tensortrain::TensorTrain;
 use crate::traits::{AbstractTensorTrain, TTScalar};
 use crate::types::{tensor3_zeros, Tensor3, Tensor3Ops};
 use num_complex::ComplexFloat;
 use num_traits::ToPrimitive;
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_linalg::LinalgScalar;
-use tenferro_tensor::{KeepCountScalar, MemoryOrder, Tensor as TypedTensor};
+use tenferro_tensor::{TensorScalar, TypedTensor};
 use tensor4all_tcicore::matrix::{mat_mul, ncols, nrows, zeros, Matrix};
 use tensor4all_tcicore::Scalar;
 use tensor4all_tcicore::{rrlu, RrLUOptions};
@@ -34,27 +33,20 @@ fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> (Matrix<T>, Matrix<T>)
 
 fn typed_tensor_to_matrix<T>(tensor: &TypedTensor<T>, op: &'static str) -> Result<Matrix<T>>
 where
-    T: TfScalar + Copy + Default,
+    T: TTScalar + Scalar + Default,
 {
-    if tensor.ndim() != 2 {
+    if tensor.shape.len() != 2 {
         return Err(TensorTrainError::InvalidOperation {
             message: format!(
                 "{op} returned rank-{} tensor, expected matrix",
-                tensor.ndim()
+                tensor.shape.len()
             ),
         });
     }
 
-    let dims = tensor.dims();
-    let rows = dims[0];
-    let cols = dims[1];
-    let row_major = tensor.contiguous(MemoryOrder::RowMajor);
-    let data = row_major
-        .buffer()
-        .as_slice()
-        .ok_or_else(|| TensorTrainError::InvalidOperation {
-            message: format!("{op} returned non-CPU tensor unexpectedly"),
-        })?;
+    let rows = tensor.shape[0];
+    let cols = tensor.shape[1];
+    let data = tensor_to_row_major_vec(tensor);
 
     let mut matrix = zeros(rows, cols);
     for i in 0..rows {
@@ -67,15 +59,9 @@ where
 
 fn typed_real_values_to_f64<R>(tensor: &TypedTensor<R>, op: &'static str) -> Result<Vec<f64>>
 where
-    R: TfScalar + Copy + ToPrimitive,
+    R: TensorScalar + ToPrimitive,
 {
-    let row_major = tensor.contiguous(MemoryOrder::RowMajor);
-    let data = row_major
-        .buffer()
-        .as_slice()
-        .ok_or_else(|| TensorTrainError::InvalidOperation {
-            message: format!("{op} returned non-CPU tensor unexpectedly"),
-        })?;
+    let data = tensor_to_row_major_vec(tensor);
     data.iter()
         .map(|value| {
             value
@@ -91,8 +77,8 @@ where
 
 fn svd_factorize_right_matrix<T>(matrix: &Matrix<T>) -> Result<(Matrix<T>, DiagMatrix, Matrix<T>)>
 where
-    T: TTScalar + Scalar + Default + ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-    <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
+    T: TTScalar + Scalar + Default + ComplexFloat + BackendLinalgScalar + Copy + 'static,
+    <T as TensorScalar>::Real: TensorScalar + ToPrimitive,
 {
     let rows = nrows(matrix);
     let cols = ncols(matrix);
@@ -109,12 +95,7 @@ where
         }
     }
 
-    let typed =
-        TypedTensor::from_slice(&data, &[rows, cols], MemoryOrder::RowMajor).map_err(|e| {
-            TensorTrainError::InvalidOperation {
-                message: format!("Failed to convert bond matrix to tenferro tensor: {e}"),
-            }
-        })?;
+    let typed = typed_tensor_from_row_major_slice(&data, &[rows, cols]);
     let decomp = svd_backend(&typed).map_err(|e| TensorTrainError::InvalidOperation {
         message: format!("Failed to compute Vidal bond SVD: {e}"),
     })?;
@@ -230,8 +211,8 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
     /// Create a VidalTensorTrain from a regular TensorTrain
     pub fn from_tensor_train(tt: &TensorTrain<T>) -> Result<Self>
     where
-        T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
+        T: ComplexFloat + BackendLinalgScalar + Copy + 'static,
+        <T as TensorScalar>::Real: TensorScalar + ToPrimitive,
     {
         Self::from_tensor_train_with_partition(tt, 0..tt.len())
     }
@@ -242,8 +223,8 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
         partition: Range<usize>,
     ) -> Result<Self>
     where
-        T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
+        T: ComplexFloat + BackendLinalgScalar + Copy + 'static,
+        <T as TensorScalar>::Real: TensorScalar + ToPrimitive,
     {
         let n = tt.len();
         if n == 0 {
@@ -660,8 +641,8 @@ impl<T: TTScalar + Scalar + Default> InverseTensorTrain<T> {
     /// Create an InverseTensorTrain from a regular TensorTrain
     pub fn from_tensor_train(tt: &TensorTrain<T>) -> Result<Self>
     where
-        T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-        <T as LinalgScalar>::Real: TfScalar + Copy + ToPrimitive + KeepCountScalar,
+        T: ComplexFloat + BackendLinalgScalar + Copy + 'static,
+        <T as TensorScalar>::Real: TensorScalar + ToPrimitive,
     {
         let vidal = VidalTensorTrain::from_tensor_train(tt)?;
         Self::from_vidal(&vidal)

--- a/crates/tensor4all-tcicore/Cargo.toml
+++ b/crates/tensor4all-tcicore/Cargo.toml
@@ -19,6 +19,7 @@ faer.workspace = true
 tenferro-algebra.workspace = true
 tenferro-einsum.workspace = true
 tenferro-tensor.workspace = true
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-tcicore/Cargo.toml
+++ b/crates/tensor4all-tcicore/Cargo.toml
@@ -16,7 +16,9 @@ rand.workspace = true
 paste.workspace = true
 bnum.workspace = true
 faer.workspace = true
-tenferro-tensor-compute.workspace = true
+tenferro-algebra.workspace = true
+tenferro-einsum.workspace = true
+tenferro-tensor.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-tcicore/src/matrix.rs
+++ b/crates/tensor4all-tcicore/src/matrix.rs
@@ -711,40 +711,53 @@ pub trait BlasMul: Sized {
     fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Matrix<Self>;
 }
 
+fn row_major_to_col_major<T: Copy>(data: &[T], nrows: usize, ncols: usize) -> Vec<T> {
+    let mut out = Vec::with_capacity(data.len());
+    for col in 0..ncols {
+        for row in 0..nrows {
+            out.push(data[row * ncols + col]);
+        }
+    }
+    out
+}
+
+fn col_major_to_row_major<T: Copy>(data: &[T], nrows: usize, ncols: usize) -> Vec<T> {
+    let mut out = Vec::with_capacity(data.len());
+    for row in 0..nrows {
+        for col in 0..ncols {
+            out.push(data[col * nrows + row]);
+        }
+    }
+    out
+}
+
 macro_rules! impl_blas_mul {
     ($($t:ty),*) => {
         $(
         impl BlasMul for $t {
             fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Matrix<Self> {
-                use tenferro_tensor_compute::{
-                    einsum, CpuBackend, CpuContext, MemoryOrder, Standard, Tensor,
-                };
+                use tenferro_einsum::typed_eager_einsum;
+                use tenferro_tensor::TypedTensor;
+                use tensor4all_tensorbackend::with_default_backend;
 
                 let m = a.nrows();
                 let k = a.ncols();
                 let n = b.ncols();
                 assert_eq!(b.nrows(), k);
 
-                let mut ctx = CpuContext::new(1);
-                let a_tensor =
-                    Tensor::<$t>::from_slice(a.as_slice(), &[m, k], MemoryOrder::RowMajor)
-                        .expect("invalid matrix dimensions");
-                let b_tensor =
-                    Tensor::<$t>::from_slice(b.as_slice(), &[k, n], MemoryOrder::RowMajor)
-                        .expect("invalid matrix dimensions");
-                let c = einsum::<Standard<$t>, CpuBackend>(
-                    &mut ctx,
-                    "ij,jk->ik",
-                    &[&a_tensor, &b_tensor],
-                    None,
-                )
+                let a_tensor = TypedTensor::<$t>::from_vec(
+                    vec![m, k],
+                    row_major_to_col_major(a.as_slice(), m, k),
+                );
+                let b_tensor = TypedTensor::<$t>::from_vec(
+                    vec![k, n],
+                    row_major_to_col_major(b.as_slice(), k, n),
+                );
+                let c = with_default_backend(|backend| {
+                    typed_eager_einsum(backend, &[&a_tensor, &b_tensor], "ij,jk->ik")
+                })
                 .expect("einsum failed");
-                let c_rm = c.contiguous(MemoryOrder::RowMajor);
-                let c_data = c_rm
-                    .buffer()
-                    .as_slice()
-                    .expect("CPU-only operation")
-                    .to_vec();
+                let c_data = col_major_to_row_major(c.as_slice(), m, n);
                 Matrix::from_raw_vec(m, n, c_data)
             }
         }

--- a/crates/tensor4all-tcicore/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix/tests/mod.rs
@@ -55,3 +55,17 @@ fn test_mat_mul() {
     assert_eq!(c[[1, 0]], 43.0);
     assert_eq!(c[[1, 1]], 50.0);
 }
+
+#[test]
+fn test_mat_mul_rectangular_preserves_row_major_layout() {
+    let a = from_vec2d(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
+    let b = from_vec2d(vec![vec![7.0, 8.0], vec![9.0, 10.0], vec![11.0, 12.0]]);
+    let c = mat_mul(&a, &b);
+
+    assert_eq!(c.nrows(), 2);
+    assert_eq!(c.ncols(), 2);
+    assert_eq!(c[[0, 0]], 58.0);
+    assert_eq!(c[[0, 1]], 64.0);
+    assert_eq!(c[[1, 0]], 139.0);
+    assert_eq!(c[[1, 1]], 154.0);
+}

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science", "mathematics"]
 [features]
 default = ["backend-tenferro"]
 backend-tenferro = []
-einsum-dispatch-profile = ["tenferro-einsum/profile-dispatch"]
+einsum-dispatch-profile = []
 
 [dependencies]
 num-complex.workspace = true
@@ -25,9 +25,7 @@ tenferro.workspace = true
 tenferro-algebra.workspace = true
 tenferro-device.workspace = true
 tenferro-einsum.workspace = true
-tenferro-prims.workspace = true
 tenferro-tensor.workspace = true
-tenferro-linalg.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-tensorbackend/src/any_scalar.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar.rs
@@ -5,10 +5,9 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 use anyhow::{anyhow, Result};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
-use tenferro::{ScalarType, Tensor as NativeTensor};
+use tenferro::{DType, Tensor as NativeTensor};
 
 use crate::storage::{Storage, SumFromStorage};
-use crate::tenferro_bridge::with_default_runtime;
 use crate::tensor_element::TensorElement;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -69,11 +68,6 @@ impl ScalarValue {
     }
 }
 
-fn rank0_real_tensor(value: f64) -> NativeTensor {
-    NativeTensor::from_slice(&[value], &[])
-        .unwrap_or_else(|e| panic!("failed to build rank-0 real tensor: {e}"))
-}
-
 fn scalar_value_from_storage(storage: &Storage) -> ScalarValue {
     if storage.is_f64() {
         ScalarValue::F64(f64::sum_from_storage(storage))
@@ -83,26 +77,30 @@ fn scalar_value_from_storage(storage: &Storage) -> ScalarValue {
 }
 
 fn scalar_value_from_native(native: &NativeTensor) -> ScalarValue {
-    match native.scalar_type() {
-        ScalarType::F32 => ScalarValue::F32(
+    match native.dtype() {
+        DType::F32 => ScalarValue::F32(
             native
-                .try_get::<f32>(&[])
-                .unwrap_or_else(|e| panic!("failed to read f32 scalar tensor value: {e}")),
+                .as_slice::<f32>()
+                .and_then(|values| values.first().copied())
+                .unwrap_or_else(|| panic!("failed to read f32 scalar tensor value")),
         ),
-        ScalarType::F64 => ScalarValue::F64(
+        DType::F64 => ScalarValue::F64(
             native
-                .try_get::<f64>(&[])
-                .unwrap_or_else(|e| panic!("failed to read f64 scalar tensor value: {e}")),
+                .as_slice::<f64>()
+                .and_then(|values| values.first().copied())
+                .unwrap_or_else(|| panic!("failed to read f64 scalar tensor value")),
         ),
-        ScalarType::C32 => ScalarValue::C32(
+        DType::C32 => ScalarValue::C32(
             native
-                .try_get::<Complex32>(&[])
-                .unwrap_or_else(|e| panic!("failed to read c32 scalar tensor value: {e}")),
+                .as_slice::<Complex32>()
+                .and_then(|values| values.first().copied())
+                .unwrap_or_else(|| panic!("failed to read c32 scalar tensor value")),
         ),
-        ScalarType::C64 => ScalarValue::C64(
+        DType::C64 => ScalarValue::C64(
             native
-                .try_get::<Complex64>(&[])
-                .unwrap_or_else(|e| panic!("failed to read c64 scalar tensor value: {e}")),
+                .as_slice::<Complex64>()
+                .and_then(|values| values.first().copied())
+                .unwrap_or_else(|| panic!("failed to read c64 scalar tensor value")),
         ),
     }
 }
@@ -124,39 +122,32 @@ fn neg_native(native: &NativeTensor) -> Result<NativeTensor> {
     })
 }
 
-pub(crate) fn promote_scalar_native(
-    native: &NativeTensor,
-    target: ScalarType,
-) -> Result<NativeTensor> {
+pub(crate) fn promote_scalar_native(native: &NativeTensor, target: DType) -> Result<NativeTensor> {
     let promoted = match (scalar_value_from_native(native), target) {
-        (ScalarValue::F32(value), ScalarType::F32) => Scalar::from_value(value),
-        (ScalarValue::F32(value), ScalarType::F64) => Scalar::from_value(value as f64),
-        (ScalarValue::F32(value), ScalarType::C32) => {
-            Scalar::from_value(Complex32::new(value, 0.0))
-        }
-        (ScalarValue::F32(value), ScalarType::C64) => {
+        (ScalarValue::F32(value), DType::F32) => Scalar::from_value(value),
+        (ScalarValue::F32(value), DType::F64) => Scalar::from_value(value as f64),
+        (ScalarValue::F32(value), DType::C32) => Scalar::from_value(Complex32::new(value, 0.0)),
+        (ScalarValue::F32(value), DType::C64) => {
             Scalar::from_value(Complex64::new(value as f64, 0.0))
         }
-        (ScalarValue::F64(value), ScalarType::F32) => Scalar::from_value(value as f32),
-        (ScalarValue::F64(value), ScalarType::F64) => Scalar::from_value(value),
-        (ScalarValue::F64(value), ScalarType::C32) => {
+        (ScalarValue::F64(value), DType::F32) => Scalar::from_value(value as f32),
+        (ScalarValue::F64(value), DType::F64) => Scalar::from_value(value),
+        (ScalarValue::F64(value), DType::C32) => {
             Scalar::from_value(Complex32::new(value as f32, 0.0))
         }
-        (ScalarValue::F64(value), ScalarType::C64) => {
-            Scalar::from_value(Complex64::new(value, 0.0))
-        }
-        (ScalarValue::C32(value), ScalarType::F32) => Scalar::from_value(value.re),
-        (ScalarValue::C32(value), ScalarType::F64) => Scalar::from_value(value.re as f64),
-        (ScalarValue::C32(value), ScalarType::C32) => Scalar::from_value(value),
-        (ScalarValue::C32(value), ScalarType::C64) => {
+        (ScalarValue::F64(value), DType::C64) => Scalar::from_value(Complex64::new(value, 0.0)),
+        (ScalarValue::C32(value), DType::F32) => Scalar::from_value(value.re),
+        (ScalarValue::C32(value), DType::F64) => Scalar::from_value(value.re as f64),
+        (ScalarValue::C32(value), DType::C32) => Scalar::from_value(value),
+        (ScalarValue::C32(value), DType::C64) => {
             Scalar::from_value(Complex64::new(value.re as f64, value.im as f64))
         }
-        (ScalarValue::C64(value), ScalarType::F32) => Scalar::from_value(value.re as f32),
-        (ScalarValue::C64(value), ScalarType::F64) => Scalar::from_value(value.re),
-        (ScalarValue::C64(value), ScalarType::C32) => {
+        (ScalarValue::C64(value), DType::F32) => Scalar::from_value(value.re as f32),
+        (ScalarValue::C64(value), DType::F64) => Scalar::from_value(value.re),
+        (ScalarValue::C64(value), DType::C32) => {
             Scalar::from_value(Complex32::new(value.re as f32, value.im as f32))
         }
-        (ScalarValue::C64(value), ScalarType::C64) => Scalar::from_value(value),
+        (ScalarValue::C64(value), DType::C64) => Scalar::from_value(value),
     };
     Ok(promoted.native)
 }
@@ -197,12 +188,12 @@ pub type AnyScalar = Scalar;
 
 impl Scalar {
     fn wrap_native(native: NativeTensor) -> Result<Self> {
-        if native.dims().is_empty() {
+        if native.shape().is_empty() {
             Ok(Self { native })
         } else {
             Err(anyhow!(
-                "Scalar requires a rank-0 tensor, got dims {:?}",
-                native.dims()
+                "Scalar requires a rank-0 tensor, got shape {:?}",
+                native.shape()
             ))
         }
     }
@@ -300,10 +291,7 @@ impl Scalar {
         Self::from_complex(re, im)
     }
 
-    /// Returns the detached primal value as a scalar.
-    ///
-    /// Strips any automatic differentiation (AD) metadata, returning only the
-    /// numerical value.
+    /// Returns the scalar's plain rank-0 tensor value.
     ///
     /// # Examples
     ///
@@ -315,123 +303,8 @@ impl Scalar {
     /// assert!((p.real() - 5.0).abs() < 1e-10);
     /// ```
     pub fn primal(&self) -> Self {
-        Self::wrap_native(self.native.detach())
+        Self::wrap_native(self.native.clone())
             .unwrap_or_else(|e| panic!("Scalar::primal returned a non-scalar tensor: {e}"))
-    }
-
-    /// Returns whether the scalar participates in reverse-mode AD.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::AnyScalar;
-    ///
-    /// let s = AnyScalar::new_real(1.0);
-    /// assert!(!s.requires_grad());
-    /// ```
-    pub fn requires_grad(&self) -> bool {
-        self.native.requires_grad()
-    }
-
-    /// Enables or disables reverse-mode gradient tracking.
-    ///
-    /// # Errors
-    ///
-    /// Currently infallible, but returns `Result` for future-proofing.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::AnyScalar;
-    ///
-    /// let mut s = AnyScalar::new_real(2.0);
-    /// assert!(!s.requires_grad());
-    /// s.set_requires_grad(true).unwrap();
-    /// assert!(s.requires_grad());
-    /// ```
-    pub fn set_requires_grad(&mut self, enabled: bool) -> Result<()> {
-        let placeholder = rank0_real_tensor(0.0);
-        let native = std::mem::replace(&mut self.native, placeholder);
-        self.native = native.with_requires_grad(enabled);
-        Ok(())
-    }
-
-    /// Returns accumulated reverse-mode gradient when available.
-    ///
-    /// Returns `None` if gradient tracking is not enabled or no gradients
-    /// have been accumulated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::AnyScalar;
-    ///
-    /// let s = AnyScalar::new_real(1.0);
-    /// assert!(s.grad().is_none());
-    /// ```
-    pub fn grad(&self) -> Option<Self> {
-        self.native.grad().ok().flatten().map(|native| {
-            Self::wrap_native(native)
-                .unwrap_or_else(|e| panic!("Scalar::grad returned a non-scalar tensor: {e}"))
-        })
-    }
-
-    /// Clears accumulated reverse-mode gradients.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if gradient zeroing fails in the backend.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::AnyScalar;
-    ///
-    /// let mut s = AnyScalar::new_real(1.0);
-    /// s.set_requires_grad(true).unwrap();
-    /// s.zero_grad().unwrap();
-    /// ```
-    pub fn zero_grad(&self) -> Result<()> {
-        self.native
-            .zero_grad()
-            .map_err(|e| anyhow!("Scalar::zero_grad failed: {e}"))
-    }
-
-    /// Accumulates reverse-mode gradients into `inputs`.
-    ///
-    /// Runs reverse-mode automatic differentiation from this scalar backward
-    /// through the computation graph. An optional `grad_output` seed can be
-    /// supplied; when `None`, a unit seed is used.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the backward pass fails in the backend.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::AnyScalar;
-    ///
-    /// let mut x = AnyScalar::new_real(3.0);
-    /// x.set_requires_grad(true).unwrap();
-    ///
-    /// // backward on a leaf scalar with unit seed gives gradient 1.0
-    /// x.backward(None, &[&x]).unwrap();
-    /// let grad = x.grad().expect("gradient should be available after backward");
-    /// assert!((grad.real() - 1.0).abs() < 1e-10);
-    /// ```
-    pub fn backward(&self, grad_output: Option<&Self>, inputs: &[&Self]) -> Result<()> {
-        let _ = inputs;
-        with_default_runtime("backward", || match grad_output {
-            Some(seed) => self
-                .native
-                .backward_with_seed(seed.as_native())
-                .map_err(|e| anyhow!("Scalar::backward failed: {e}")),
-            None => self
-                .native
-                .backward()
-                .map_err(|e| anyhow!("Scalar::backward failed: {e}")),
-        })
     }
 
     /// Returns the real part while intentionally dropping AD metadata.
@@ -660,8 +533,8 @@ impl Scalar {
         if !real.is_real() || !imag.is_real() {
             return Err(anyhow!(
                 "compose_complex requires real-valued inputs, got real={:?}, imag={:?}",
-                real.native.scalar_type(),
-                imag.native.scalar_type()
+                real.native.dtype(),
+                imag.native.dtype()
             ));
         }
         Ok(Self::from_complex(real.real(), imag.real()))
@@ -896,7 +769,7 @@ impl One for Scalar {
 
 impl PartialEq for Scalar {
     fn eq(&self, other: &Self) -> bool {
-        self.native.scalar_type() == other.native.scalar_type() && self.value() == other.value()
+        self.native.dtype() == other.native.dtype() && self.value() == other.value()
     }
 }
 
@@ -926,7 +799,7 @@ impl fmt::Display for Scalar {
 impl fmt::Debug for Scalar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Scalar")
-            .field("scalar_type", &self.native.scalar_type())
+            .field("dtype", &self.native.dtype())
             .field("value", &self.value())
             .finish()
     }
@@ -934,7 +807,9 @@ impl fmt::Debug for Scalar {
 
 impl Clone for Scalar {
     fn clone(&self) -> Self {
-        self.primal()
+        Self {
+            native: self.native.clone(),
+        }
     }
 }
 

--- a/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tenferro::DType;
 
 fn assert_scalar_close(actual: &Scalar, expected: &Scalar) {
     match (actual.as_f64(), expected.as_f64()) {
@@ -73,82 +74,82 @@ fn promote_scalar_native_covers_all_scalar_type_pairs() {
     let cases = vec![
         (
             Scalar::from_value(1.25_f32),
-            ScalarType::F32,
+            DType::F32,
             Scalar::from_value(1.25_f32),
         ),
         (
             Scalar::from_value(1.25_f32),
-            ScalarType::F64,
+            DType::F64,
             Scalar::from_value(1.25_f64),
         ),
         (
             Scalar::from_value(1.25_f32),
-            ScalarType::C32,
+            DType::C32,
             Scalar::from_value(Complex32::new(1.25, 0.0)),
         ),
         (
             Scalar::from_value(1.25_f32),
-            ScalarType::C64,
+            DType::C64,
             Scalar::from_value(Complex64::new(1.25, 0.0)),
         ),
         (
             Scalar::from_value(-2.5_f64),
-            ScalarType::F32,
+            DType::F32,
             Scalar::from_value(-2.5_f32),
         ),
         (
             Scalar::from_value(-2.5_f64),
-            ScalarType::F64,
+            DType::F64,
             Scalar::from_value(-2.5_f64),
         ),
         (
             Scalar::from_value(-2.5_f64),
-            ScalarType::C32,
+            DType::C32,
             Scalar::from_value(Complex32::new(-2.5, 0.0)),
         ),
         (
             Scalar::from_value(-2.5_f64),
-            ScalarType::C64,
+            DType::C64,
             Scalar::from_value(Complex64::new(-2.5, 0.0)),
         ),
         (
             Scalar::from_value(Complex32::new(3.0, -0.5)),
-            ScalarType::F32,
+            DType::F32,
             Scalar::from_value(3.0_f32),
         ),
         (
             Scalar::from_value(Complex32::new(3.0, -0.5)),
-            ScalarType::F64,
+            DType::F64,
             Scalar::from_value(3.0_f64),
         ),
         (
             Scalar::from_value(Complex32::new(3.0, -0.5)),
-            ScalarType::C32,
+            DType::C32,
             Scalar::from_value(Complex32::new(3.0, -0.5)),
         ),
         (
             Scalar::from_value(Complex32::new(3.0, -0.5)),
-            ScalarType::C64,
+            DType::C64,
             Scalar::from_value(Complex64::new(3.0, -0.5)),
         ),
         (
             Scalar::from_value(Complex64::new(-1.0, 2.0)),
-            ScalarType::F32,
+            DType::F32,
             Scalar::from_value(-1.0_f32),
         ),
         (
             Scalar::from_value(Complex64::new(-1.0, 2.0)),
-            ScalarType::F64,
+            DType::F64,
             Scalar::from_value(-1.0_f64),
         ),
         (
             Scalar::from_value(Complex64::new(-1.0, 2.0)),
-            ScalarType::C32,
+            DType::C32,
             Scalar::from_value(Complex32::new(-1.0, 2.0)),
         ),
         (
             Scalar::from_value(Complex64::new(-1.0, 2.0)),
-            ScalarType::C64,
+            DType::C64,
             Scalar::from_value(Complex64::new(-1.0, 2.0)),
         ),
     ];
@@ -157,7 +158,7 @@ fn promote_scalar_native_covers_all_scalar_type_pairs() {
         let promoted =
             Scalar::from_native(promote_scalar_native(source.as_native(), target).unwrap())
                 .expect("promoted scalar");
-        assert_eq!(promoted.native.scalar_type(), expected.native.scalar_type());
+        assert_eq!(promoted.native.dtype(), expected.native.dtype());
         assert_scalar_close(&promoted, &expected);
     }
 }
@@ -224,5 +225,5 @@ fn scalar_trait_helpers_cover_ordering_and_conversions() {
 
     let debug = format!("{:?}", Scalar::from_real(1.0));
     assert!(debug.contains("Scalar"));
-    assert!(debug.contains("scalar_type"));
+    assert!(debug.contains("dtype"));
 }

--- a/crates/tensor4all-tensorbackend/src/backend.rs
+++ b/crates/tensor4all-tensorbackend/src/backend.rs
@@ -1,137 +1,108 @@
 //! Backend dispatch helpers for linear algebra operations.
 //!
-//! This module exposes typed wrappers around `tenferro-linalg` while keeping
-//! tensor4all's canonical compute object in the dynamic `tenferro::Tensor`
-//! frontend.
+//! This module keeps tensor4all's typed factorization entry points thin while
+//! routing the actual work through the thread-local tenferro CPU backend.
 
 use anyhow::{anyhow, Result};
-use num_complex::ComplexFloat;
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_linalg::{qr as tenferro_qr, svd as tenferro_svd, KernelLinalgScalar, LinalgScalar};
-use tenferro_tensor::{KeepCountScalar, Tensor as TypedTensor};
+use tenferro::{DType, Tensor, TensorBackend, TensorScalar, TypedTensor};
 
-use crate::tenferro_bridge::with_tenferro_ctx;
+use crate::context::with_default_backend;
 
 /// Result of SVD decomposition `A = U * diag(S) * Vt`.
 ///
-/// Contains the three factors computed by [`svd_backend`]. The singular values
-/// `s` are stored as a 1-D tensor of real values, even when the input matrix
-/// is complex.
-///
-/// # Examples
-///
-/// ```
-/// use tensor4all_tensorbackend::{svd_backend, SvdResult};
-/// use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
-///
-/// // 2x3 real matrix (column-major)
-/// let a = TypedTensor::<f64>::from_slice(
-///     &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
-///     &[2, 3],
-///     MemoryOrder::ColumnMajor,
-/// ).unwrap();
-/// let result = svd_backend(&a).unwrap();
-/// assert_eq!(result.u.dims(), &[2, 2]);
-/// assert_eq!(result.s.dims(), &[2]);
-/// assert_eq!(result.vt.dims(), &[2, 3]);
-/// ```
-#[derive(Debug, Clone)]
-pub struct SvdResult<T>
-where
-    T: LinalgScalar,
-{
-    /// Left singular vectors (m x k matrix, where k = min(m, n)).
-    pub u: TypedTensor<T>,
-    /// Singular values (1-D tensor of length k).
-    pub s: TypedTensor<<T as LinalgScalar>::Real>,
-    /// Right singular vectors transposed (k x n matrix).
-    pub vt: TypedTensor<T>,
-}
-
-/// Scalar constraint for tensor4all linalg backend dispatch.
-///
-/// This is a convenience bound combining [`LinalgScalar`] (SVD/QR trait
-/// requirements) with [`KernelLinalgScalar`] (CPU kernel dispatch).
-/// Implemented automatically for any type satisfying both bounds, including
-/// `f64` and `Complex64`.
-pub trait BackendLinalgScalar: LinalgScalar + KernelLinalgScalar {}
-
-impl<T> BackendLinalgScalar for T where T: LinalgScalar + KernelLinalgScalar {}
-
-/// Compute SVD decomposition via tenferro backend.
-///
-/// Decomposes an m x n matrix `A` into `U * diag(S) * Vt`.
-///
-/// # Errors
-///
-/// Returns an error if the SVD computation fails (e.g., non-convergence).
+/// The singular values are stored in a real-valued typed tensor, even when the
+/// input matrix is complex.
 ///
 /// # Examples
 ///
 /// ```
 /// use tensor4all_tensorbackend::svd_backend;
-/// use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
+/// use tenferro::TypedTensor;
 ///
-/// let a = TypedTensor::<f64>::from_slice(
-///     &[1.0, 0.0, 0.0, 1.0],
-///     &[2, 2],
-///     MemoryOrder::ColumnMajor,
-/// ).unwrap();
+/// let a = TypedTensor::<f64>::from_vec(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]);
 /// let result = svd_backend(&a).unwrap();
-/// assert_eq!(result.u.dims(), &[2, 2]);
-/// assert_eq!(result.s.dims(), &[2]);  // 2 singular values
-/// assert_eq!(result.vt.dims(), &[2, 2]);
+///
+/// assert_eq!(result.u.shape, vec![2, 2]);
+/// assert_eq!(result.s.shape, vec![2]);
+/// assert_eq!(result.vt.shape, vec![2, 2]);
 /// ```
-pub fn svd_backend<T>(a: &TypedTensor<T>) -> Result<SvdResult<T>>
-where
-    T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
-    <T as LinalgScalar>::Real: TfScalar + Copy + KeepCountScalar,
-{
-    let decomp = with_tenferro_ctx("svd", |ctx| {
-        tenferro_svd(ctx, a, None)
-            .map_err(|e| anyhow!("SVD computation failed via tenferro-linalg: {e}"))
-    })?;
+#[derive(Debug, Clone)]
+pub struct SvdResult<T: TensorScalar> {
+    /// Left singular vectors.
+    pub u: TypedTensor<T>,
+    /// Singular values.
+    pub s: TypedTensor<T::Real>,
+    /// Right singular vectors transposed.
+    pub vt: TypedTensor<T>,
+}
 
-    Ok(SvdResult {
-        u: decomp.u,
-        s: decomp.s,
-        vt: decomp.vt,
+/// Scalar bound accepted by tensor4all's typed linalg wrappers.
+pub trait BackendLinalgScalar: TensorScalar {}
+
+impl<T: TensorScalar> BackendLinalgScalar for T {}
+
+fn tensor_scalar_dtype<T: TensorScalar>() -> DType {
+    T::into_tensor(vec![0], Vec::new()).dtype()
+}
+
+fn try_into_typed_result<T: TensorScalar>(
+    op: &'static str,
+    tensor: Tensor,
+) -> Result<TypedTensor<T>> {
+    let actual = tensor.dtype();
+    T::try_into_typed(tensor).ok_or_else(|| {
+        anyhow!(
+            "{op}: dtype mismatch lhs={actual:?} rhs={:?}",
+            tensor_scalar_dtype::<T>()
+        )
     })
 }
 
-/// Compute QR decomposition via tenferro backend.
-///
-/// Decomposes an m x n matrix `A` into an orthogonal/unitary matrix `Q` and
-/// an upper triangular matrix `R` such that `A = Q * R`.
+fn convert_for_typed<T: TensorScalar>(op: &'static str, tensor: Tensor) -> Result<TypedTensor<T>> {
+    let expected = tensor_scalar_dtype::<T>();
+    let tensor = if tensor.dtype() == expected {
+        tensor
+    } else {
+        with_default_backend(|backend| {
+            backend.with_exec_session(|exec| exec.convert(&tensor, expected))
+        })
+        .map_err(|e| anyhow!("{op}: dtype conversion to {expected:?} failed: {e}"))?
+    };
+    try_into_typed_result::<T>(op, tensor)
+}
+
+/// Compute a thin/economy SVD on a typed tensor.
 ///
 /// # Errors
 ///
-/// Returns an error if the QR computation fails.
+/// Returns an error if the backend rejects the input or the decomposition
+/// fails to converge.
+pub fn svd_backend<T>(a: &TypedTensor<T>) -> Result<SvdResult<T>>
+where
+    T: BackendLinalgScalar,
+{
+    let tensor = T::into_tensor(a.shape.clone(), a.host_data().to_vec());
+    let (u, s, vt) = with_default_backend(|backend| tensor.svd(backend))
+        .map_err(|e| anyhow!("SVD computation failed via tenferro-tensor: {e}"))?;
+    Ok(SvdResult {
+        u: convert_for_typed::<T>("svd", u)?,
+        s: convert_for_typed::<T::Real>("svd", s)?,
+        vt: convert_for_typed::<T>("svd", vt)?,
+    })
+}
+
+/// Compute a thin/economy QR decomposition on a typed tensor.
 ///
-/// # Examples
+/// # Errors
 ///
-/// ```
-/// use tensor4all_tensorbackend::qr_backend;
-/// use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
-///
-/// let a = TypedTensor::<f64>::from_slice(
-///     &[1.0, 0.0, 0.0, 1.0],
-///     &[2, 2],
-///     MemoryOrder::ColumnMajor,
-/// ).unwrap();
-/// let (q, r) = qr_backend(&a).unwrap();
-/// assert_eq!(q.dims(), &[2, 2]);
-/// assert_eq!(r.dims(), &[2, 2]);
-/// ```
+/// Returns an error if the backend rejects the input or the decomposition
+/// fails.
 pub fn qr_backend<T>(a: &TypedTensor<T>) -> Result<(TypedTensor<T>, TypedTensor<T>)>
 where
-    T: ComplexFloat + BackendLinalgScalar + TfScalar + Copy + 'static,
+    T: BackendLinalgScalar,
 {
-    with_tenferro_ctx("qr", |ctx| {
-        let decomp = tenferro_qr(ctx, a)
-            .map_err(|e| anyhow!("QR computation failed via tenferro-linalg: {e}"))?;
-        Ok((decomp.q, decomp.r))
-    })
+    with_default_backend(|backend| a.qr(backend))
+        .map_err(|e| anyhow!("QR computation failed via tenferro-tensor: {e}"))
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
@@ -1,29 +1,22 @@
 use super::*;
 use num_complex::Complex64;
 use num_traits::Zero;
-use tenferro::LogicalMemorySpace;
-use tenferro_algebra::Scalar as TfScalar;
-use tenferro_tensor::MemoryOrder;
 
 fn row_major_values<T>(tensor: &TypedTensor<T>) -> Vec<T>
 where
-    T: TfScalar + Copy,
+    T: Copy,
 {
-    let row_major = tensor.contiguous(MemoryOrder::RowMajor);
-    let row_major = if row_major.logical_memory_space() == LogicalMemorySpace::MainMemory {
-        row_major
-    } else {
-        row_major
-            .to_memory_space_async(LogicalMemorySpace::MainMemory)
-            .expect("tensor should be movable to host memory")
-    };
-    let offset = usize::try_from(row_major.offset()).expect("offset should be non-negative");
-    let len = row_major.len();
-    let values: &[T] = row_major
-        .buffer()
-        .as_slice()
-        .expect("tensor should expose contiguous host buffer");
-    values[offset..offset + len].to_vec()
+    assert_eq!(tensor.shape.len(), 2, "test helper expects a matrix");
+    let rows = tensor.shape[0];
+    let cols = tensor.shape[1];
+    let values = tensor.as_slice();
+    let mut out = Vec::with_capacity(values.len());
+    for row in 0..rows {
+        for col in 0..cols {
+            out.push(values[row + col * rows]);
+        }
+    }
+    out
 }
 
 fn matmul_row_major<T>(a: &[T], m: usize, k: usize, b: &[T], n: usize) -> Vec<T>
@@ -61,12 +54,11 @@ fn scale_columns_complex(
 
 #[test]
 fn qr_backend_reconstructs_real_matrix() {
-    let input =
-        TypedTensor::from_slice(&[1.0_f64, 2.0, 3.0, 4.0], &[2, 2], MemoryOrder::RowMajor).unwrap();
+    let input = TypedTensor::from_vec(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
 
     let (q, r) = qr_backend(&input).unwrap();
-    assert_eq!(q.dims(), &[2, 2]);
-    assert_eq!(r.dims(), &[2, 2]);
+    assert_eq!(q.shape, vec![2, 2]);
+    assert_eq!(r.shape, vec![2, 2]);
 
     let q_values = row_major_values(&q);
     let r_values = row_major_values(&r);
@@ -83,25 +75,23 @@ fn qr_backend_reconstructs_real_matrix() {
 
 #[test]
 fn svd_backend_reconstructs_complex_matrix() {
-    let input = TypedTensor::from_slice(
-        &[
+    let input = TypedTensor::from_vec(
+        vec![2, 2],
+        vec![
             Complex64::new(1.0, -0.5),
-            Complex64::new(2.0, 1.5),
             Complex64::new(-3.0, 0.25),
+            Complex64::new(2.0, 1.5),
             Complex64::new(4.0, -2.0),
         ],
-        &[2, 2],
-        MemoryOrder::RowMajor,
-    )
-    .unwrap();
+    );
 
     let decomp = svd_backend(&input).unwrap();
-    assert_eq!(decomp.u.dims(), &[2, 2]);
-    assert_eq!(decomp.s.dims(), &[2]);
-    assert_eq!(decomp.vt.dims(), &[2, 2]);
+    assert_eq!(decomp.u.shape, vec![2, 2]);
+    assert_eq!(decomp.s.shape, vec![2]);
+    assert_eq!(decomp.vt.shape, vec![2, 2]);
 
     let u = row_major_values(&decomp.u);
-    let s = row_major_values(&decomp.s);
+    let s = decomp.s.as_slice().to_vec();
     let vt = row_major_values(&decomp.vt);
     let us = scale_columns_complex(&u, 2, 2, &s);
     let reconstructed = matmul_row_major(&us, 2, 2, &vt, 2);

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -1,0 +1,36 @@
+//! Thread-local tenferro execution helpers.
+//!
+//! tensor4all-rs uses plain typed/untyped tensor ops and eager AD through
+//! separate thread-local objects. The current tenferro public API does not
+//! expose a way to share one exact `CpuBackend` instance with an
+//! `EagerContext<CpuBackend>`, so this module intentionally keeps them as
+//! paired but independent thread-local resources.
+
+use std::cell::RefCell;
+use std::sync::Arc;
+
+use tenferro::{CpuBackend, EagerContext};
+
+thread_local! {
+    static DEFAULT_BACKEND: RefCell<CpuBackend> = RefCell::new(CpuBackend::new());
+    static DEFAULT_EAGER_CTX: RefCell<Arc<EagerContext<CpuBackend>>> =
+        RefCell::new(EagerContext::with_backend(CpuBackend::new()));
+}
+
+/// Run a closure against the thread-local CPU backend.
+///
+/// This is the canonical entry point for typed and untyped tenferro tensor
+/// operations inside `tensor4all-tensorbackend`.
+pub fn with_default_backend<R>(f: impl FnOnce(&mut CpuBackend) -> R) -> R {
+    DEFAULT_BACKEND.with(|slot| {
+        let mut backend = slot.borrow_mut();
+        f(&mut backend)
+    })
+}
+
+/// Return the thread-local eager context used for reverse-mode AD.
+///
+/// This context is separate from the backend used by [`with_default_backend`].
+pub fn default_eager_ctx() -> Arc<EagerContext<CpuBackend>> {
+    DEFAULT_EAGER_CTX.with(|slot| slot.borrow().clone())
+}

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -15,6 +15,8 @@
 mod any_scalar;
 /// Backend dispatch for SVD and QR operations.
 mod backend;
+/// Thread-local tenferro execution helpers.
+mod context;
 /// Tensor snapshot storage types and low-level dense/diagonal kernels.
 mod storage;
 pub(crate) mod tenferro_bridge;
@@ -23,6 +25,7 @@ mod tensor_element;
 
 pub use any_scalar::AnyScalar;
 pub use backend::{qr_backend, svd_backend, BackendLinalgScalar, SvdResult};
+pub use context::{default_eager_ctx, with_default_backend};
 pub use storage::{
     contract_storage, make_mut_storage, mindim, Storage, StorageScalar, StructuredStorage,
     SumFromStorage,
@@ -39,5 +42,4 @@ pub use tenferro_bridge::{
     scale_native_tensor, scale_storage_native, storage_to_native_tensor, sum_native_tensor,
     svd_native_tensor, tangent_native_tensor,
 };
-pub use tenferro_prims::print_and_reset_contract_profile;
 pub use tensor_element::TensorElement;

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -697,13 +697,6 @@ impl<T: Copy + Default> StructuredStorage<T> {
 pub struct Storage(pub(crate) StorageRepr);
 
 #[derive(Debug, Clone)]
-pub(crate) struct NativePayload<T> {
-    pub(crate) data: Vec<T>,
-    pub(crate) payload_dims: Vec<usize>,
-    pub(crate) axis_classes: Option<Vec<usize>>,
-}
-
-#[derive(Debug, Clone)]
 pub(crate) enum StorageRepr {
     /// Storage with f64 elements.
     F64(StructuredStorage<f64>),
@@ -882,80 +875,6 @@ impl Storage {
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
         T::build_structured_storage(data, payload_dims, strides, axis_classes)
-    }
-
-    pub(crate) fn native_payload_f64(&self, logical_dims: &[usize]) -> Result<NativePayload<f64>> {
-        match &self.0 {
-            StorageRepr::F64(value) => {
-                ensure!(
-                    value.logical_dims() == logical_dims,
-                    "logical dims {:?} do not match structured f64 logical dims {:?}",
-                    logical_dims,
-                    value.logical_dims()
-                );
-                let axis_classes = if value.is_dense() {
-                    None
-                } else {
-                    Some(value.axis_classes().to_vec())
-                };
-                Ok(NativePayload {
-                    data: value.payload_col_major_vec(),
-                    payload_dims: value.payload_dims().to_vec(),
-                    axis_classes,
-                })
-            }
-            StorageRepr::C64(_) => Err(anyhow!(
-                "complex storage cannot be converted to f64 native payload"
-            )),
-        }
-    }
-
-    pub(crate) fn native_payload_c64(
-        &self,
-        logical_dims: &[usize],
-    ) -> Result<NativePayload<Complex64>> {
-        match &self.0 {
-            StorageRepr::C64(value) => {
-                ensure!(
-                    value.logical_dims() == logical_dims,
-                    "logical dims {:?} do not match structured c64 logical dims {:?}",
-                    logical_dims,
-                    value.logical_dims()
-                );
-                let axis_classes = if value.is_dense() {
-                    None
-                } else {
-                    Some(value.axis_classes().to_vec())
-                };
-                Ok(NativePayload {
-                    data: value.payload_col_major_vec(),
-                    payload_dims: value.payload_dims().to_vec(),
-                    axis_classes,
-                })
-            }
-            StorageRepr::F64(value) => {
-                ensure!(
-                    value.logical_dims() == logical_dims,
-                    "logical dims {:?} do not match structured f64 logical dims {:?} for promotion",
-                    logical_dims,
-                    value.logical_dims()
-                );
-                let axis_classes = if value.is_dense() {
-                    None
-                } else {
-                    Some(value.axis_classes().to_vec())
-                };
-                Ok(NativePayload {
-                    data: value
-                        .payload_col_major_vec()
-                        .into_iter()
-                        .map(|entry| Complex64::new(entry, 0.0))
-                        .collect(),
-                    payload_dims: value.payload_dims().to_vec(),
-                    axis_classes,
-                })
-            }
-        }
     }
 
     /// Create dense f64 storage from column-major logical values.

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -1,47 +1,25 @@
-//! Runtime bridge for tenferro-backed execution.
-//!
-//! This module keeps tensor4all's storage/materialization boundary separate
-//! from the canonical compute object: [`tenferro::Tensor`].
+//! Bridge helpers between tensor4all storage snapshots and tenferro tensors.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Result};
-use num_complex::Complex64;
-use tenferro::{set_default_runtime, RuntimeContext, ScalarType, Tensor as NativeTensor};
-use tenferro_prims::CpuContext;
-use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
+use anyhow::{anyhow, ensure, Result};
+use num_complex::{Complex32, Complex64};
+use tenferro::eager_einsum::eager_einsum;
+use tenferro::{DType, Tensor as NativeTensor, TensorBackend};
 
 use crate::any_scalar::promote_scalar_native;
+use crate::context::with_default_backend;
+use crate::storage::Storage;
 #[cfg(test)]
 use crate::storage::StorageRepr;
-use crate::storage::{NativePayload, Storage};
 use crate::tensor_element::TensorElement;
 use crate::AnyScalar;
+
 #[cfg(test)]
 use std::cell::Cell;
-
-/// Runtime kind for tenferro execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RuntimeKind {
-    /// CPU runtime.
-    Cpu,
-    /// CUDA runtime (reserved).
-    Cuda,
-    /// ROCm runtime (reserved).
-    Rocm,
-}
-
-struct CachedCpuContext {
-    cpu_threads: usize,
-    ctx: CpuContext,
-}
-
-struct CachedCpuContextLease {
-    cached: Option<CachedCpuContext>,
-}
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 enum NativeEinsumPath {
@@ -50,10 +28,9 @@ enum NativeEinsumPath {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 struct NativeOperandSignature {
-    dims: Vec<usize>,
+    shape: Vec<usize>,
     ids: Vec<u32>,
-    is_dense: bool,
-    is_diag: bool,
+    dtype: DType,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -70,87 +47,13 @@ struct NativeEinsumProfileEntry {
 }
 
 thread_local! {
-    static CACHED_CPU_CONTEXT: RefCell<Option<CachedCpuContext>> = const { RefCell::new(None) };
     static NATIVE_EINSUM_PROFILE_STATE: RefCell<HashMap<NativeEinsumSignature, NativeEinsumProfileEntry>> =
         RefCell::new(HashMap::new());
 }
 
 #[cfg(test)]
 thread_local! {
-    static DEFAULT_RUNTIME_INSTALLS: Cell<usize> = const { Cell::new(0) };
-    static CPU_CONTEXT_INSTALLS: Cell<usize> = const { Cell::new(0) };
     static FORCE_NATIVE_EINSUM_PROFILE: Cell<bool> = const { Cell::new(false) };
-}
-
-#[cfg(test)]
-fn note_default_runtime_install() {
-    DEFAULT_RUNTIME_INSTALLS.with(|count| count.set(count.get() + 1));
-}
-
-#[cfg(not(test))]
-fn note_default_runtime_install() {}
-
-#[cfg(test)]
-fn note_cpu_context_install() {
-    CPU_CONTEXT_INSTALLS.with(|count| count.set(count.get() + 1));
-}
-
-#[cfg(not(test))]
-fn note_cpu_context_install() {}
-
-#[cfg(test)]
-pub(crate) fn reset_runtime_caches_for_tests() {
-    CACHED_CPU_CONTEXT.with(|slot| {
-        slot.borrow_mut().take();
-    });
-    NATIVE_EINSUM_PROFILE_STATE.with(|state| state.borrow_mut().clear());
-    DEFAULT_RUNTIME_INSTALLS.with(|count| count.set(0));
-    CPU_CONTEXT_INSTALLS.with(|count| count.set(0));
-    FORCE_NATIVE_EINSUM_PROFILE.with(|slot| slot.set(false));
-}
-
-#[cfg(test)]
-pub(crate) fn default_runtime_install_count_for_tests() -> usize {
-    DEFAULT_RUNTIME_INSTALLS.with(Cell::get)
-}
-
-#[cfg(test)]
-pub(crate) fn cpu_context_install_count_for_tests() -> usize {
-    CPU_CONTEXT_INSTALLS.with(Cell::get)
-}
-
-fn parse_runtime_kind() -> RuntimeKind {
-    match env::var("T4A_TENFERRO_RUNTIME") {
-        Ok(value) => match value.to_ascii_lowercase().as_str() {
-            "cpu" => RuntimeKind::Cpu,
-            "cuda" => RuntimeKind::Cuda,
-            "rocm" => RuntimeKind::Rocm,
-            _ => RuntimeKind::Cpu,
-        },
-        Err(_) => RuntimeKind::Cpu,
-    }
-}
-
-fn cpu_threads_from_env_value(value: Option<&str>) -> Result<usize> {
-    match value {
-        Some(raw) => {
-            let parsed = raw
-                .parse::<usize>()
-                .map_err(|e| anyhow!("T4A_TENFERRO_CPU_THREADS must be a positive integer: {e}"))?;
-            if parsed == 0 {
-                return Err(anyhow!(
-                    "T4A_TENFERRO_CPU_THREADS must be >= 1 when explicitly set"
-                ));
-            }
-            Ok(parsed)
-        }
-        None => Ok(CpuContext::default_num_threads()),
-    }
-}
-
-fn cpu_threads() -> Result<usize> {
-    let raw = env::var("T4A_TENFERRO_CPU_THREADS").ok();
-    cpu_threads_from_env_value(raw.as_deref())
 }
 
 fn native_einsum_profile_enabled() -> bool {
@@ -166,20 +69,10 @@ pub(crate) fn set_native_einsum_profile_enabled_for_tests(enabled: bool) {
     FORCE_NATIVE_EINSUM_PROFILE.with(|slot| slot.set(enabled));
 }
 
-fn native_operand_signature(tensor: &NativeTensor, ids: &[u32]) -> NativeOperandSignature {
-    NativeOperandSignature {
-        dims: tensor.dims().to_vec(),
-        ids: ids.to_vec(),
-        is_dense: tensor.is_dense(),
-        is_diag: tensor.is_diag(),
-    }
-}
-
 fn record_native_einsum_profile(
     path: NativeEinsumPath,
     operands: &[(&NativeTensor, &[usize])],
-    input_ids_u32: &[Vec<u32>],
-    output_ids_u32: &[u32],
+    output_ids: &[u32],
     elapsed: Duration,
 ) {
     if !native_einsum_profile_enabled() {
@@ -189,10 +82,13 @@ fn record_native_einsum_profile(
         path,
         operands: operands
             .iter()
-            .zip(input_ids_u32.iter())
-            .map(|((tensor, _), ids)| native_operand_signature(tensor, ids))
+            .map(|(tensor, ids)| NativeOperandSignature {
+                shape: tensor.shape().to_vec(),
+                ids: ids.iter().map(|&id| id as u32).collect(),
+                dtype: tensor.dtype(),
+            })
             .collect(),
-        output_ids: output_ids_u32.to_vec(),
+        output_ids: output_ids.to_vec(),
     };
     NATIVE_EINSUM_PROFILE_STATE.with(|state| {
         let mut state = state.borrow_mut();
@@ -233,226 +129,120 @@ pub fn print_and_reset_native_einsum_profile() {
             );
             for operand in signature.operands {
                 eprintln!(
-                    "     dims={:?} ids={:?} dense={} diag={}",
-                    operand.dims, operand.ids, operand.is_dense, operand.is_diag,
+                    "     shape={:?} ids={:?} dtype={:?}",
+                    operand.shape, operand.ids, operand.dtype
                 );
             }
         }
     });
 }
 
-fn retry_with_default_runtime_if_needed<R>(
-    op: &'static str,
-    f: impl FnOnce() -> Result<R>,
-) -> Result<R> {
-    with_default_runtime(op, f)
-}
-
-/// Run a typed tenferro op against the currently selected runtime.
-pub fn with_tenferro_ctx<R>(
-    op: &'static str,
-    f: impl FnOnce(&mut CpuContext) -> Result<R>,
-) -> Result<R> {
-    match parse_runtime_kind() {
-        RuntimeKind::Cpu => CACHED_CPU_CONTEXT.with(|slot| {
-            let cpu_threads = cpu_threads()?;
-            let mut slot = slot.borrow_mut();
-            let recreate = slot
-                .as_ref()
-                .is_none_or(|cached| cached.cpu_threads != cpu_threads);
-            let cached = if recreate {
-                slot.take();
-                note_cpu_context_install();
-                CachedCpuContext {
-                    cpu_threads,
-                    ctx: CpuContext::new(cpu_threads),
-                }
-            } else {
-                slot.take()
-                    .ok_or_else(|| anyhow!("{op}: missing cached CPU context"))?
-            };
-            drop(slot);
-
-            let mut lease = CachedCpuContextLease {
-                cached: Some(cached),
-            };
-            f(lease.ctx_mut())
-        }),
-        RuntimeKind::Cuda => Err(anyhow!(
-            "{op}: CUDA runtime is not yet wired in tensor4all tenferro backend"
-        )),
-        RuntimeKind::Rocm => Err(anyhow!(
-            "{op}: ROCm runtime is not yet wired in tensor4all tenferro backend"
-        )),
+fn common_dtype(dtypes: &[DType]) -> DType {
+    let has_f64 = dtypes.contains(&DType::F64);
+    let has_c64 = dtypes.contains(&DType::C64);
+    let has_c32 = dtypes.contains(&DType::C32);
+    let has_complex = has_c64 || has_c32;
+    if has_c64 || (has_f64 && has_complex) {
+        DType::C64
+    } else if has_c32 {
+        DType::C32
+    } else if has_f64 {
+        DType::F64
+    } else {
+        DType::F32
     }
 }
 
-pub(crate) fn with_default_runtime<R>(
-    op: &'static str,
-    f: impl FnOnce() -> Result<R>,
-) -> Result<R> {
-    match parse_runtime_kind() {
-        RuntimeKind::Cpu => {
-            let cpu_threads = cpu_threads()?;
-            note_default_runtime_install();
-            let _guard = set_default_runtime(RuntimeContext::Cpu(CpuContext::new(cpu_threads)));
-            f()
-        }
-        RuntimeKind::Cuda => Err(anyhow!(
-            "{op}: CUDA runtime is not yet wired in tensor4all tenferro backend"
-        )),
-        RuntimeKind::Rocm => Err(anyhow!(
-            "{op}: ROCm runtime is not yet wired in tensor4all tenferro backend"
-        )),
+fn convert_tensor(tensor: &NativeTensor, to: DType) -> Result<NativeTensor> {
+    if tensor.dtype() == to {
+        return Ok(tensor.clone());
     }
+    with_default_backend(|backend| backend.with_exec_session(|exec| exec.convert(tensor, to)))
+        .map_err(|e| anyhow!("tensor conversion to {to:?} failed: {e}"))
 }
 
-impl CachedCpuContextLease {
-    fn ctx_mut(&mut self) -> &mut CpuContext {
-        &mut self
-            .cached
-            .as_mut()
-            .expect("cached CPU context lease must contain a context")
-            .ctx
+fn ids_to_subscript(ids: &[u32]) -> Result<String> {
+    const LETTERS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let mut out = String::with_capacity(ids.len());
+    for &id in ids {
+        let idx = usize::try_from(id).unwrap_or(usize::MAX);
+        let letter = LETTERS
+            .get(idx)
+            .ok_or_else(|| anyhow!("einsum label {id} exceeds supported label range"))?;
+        out.push(char::from(*letter));
     }
+    Ok(out)
 }
 
-impl Drop for CachedCpuContextLease {
-    fn drop(&mut self) {
-        if let Some(cached) = self.cached.take() {
-            CACHED_CPU_CONTEXT.with(|slot| {
-                *slot.borrow_mut() = Some(cached);
-            });
-        }
-    }
-}
-
-fn native_tensor_from_f64_payload(payload: NativePayload<f64>) -> Result<NativeTensor> {
-    let typed = TypedTensor::from_slice(
-        &payload.data,
-        &payload.payload_dims,
-        MemoryOrder::ColumnMajor,
-    )
-    .map_err(|e| anyhow!("failed to build f64 tensor from storage payload: {e}"))?;
-    let _ = payload.axis_classes;
-    Ok(NativeTensor::from(typed))
-}
-
-fn native_tensor_from_c64_payload(payload: NativePayload<Complex64>) -> Result<NativeTensor> {
-    let typed = TypedTensor::from_slice(
-        &payload.data,
-        &payload.payload_dims,
-        MemoryOrder::ColumnMajor,
-    )
-    .map_err(|e| anyhow!("failed to build c64 tensor from storage payload: {e}"))?;
-    let _ = payload.axis_classes;
-    Ok(NativeTensor::from(typed))
-}
-
-/// Build a native dense tensor from column-major boundary data.
-pub fn dense_native_tensor_from_col_major<T: TensorElement>(
-    data: &[T],
-    logical_dims: &[usize],
-) -> Result<NativeTensor> {
-    T::dense_native_tensor_from_col_major(data, logical_dims)
-}
-
-/// Build a native diagonal tensor from column-major diagonal payload data.
-pub fn diag_native_tensor_from_col_major<T: TensorElement>(
-    data: &[T],
-    logical_rank: usize,
-) -> Result<NativeTensor> {
-    T::diag_native_tensor_from_col_major(data, logical_rank)
-}
-
-fn labels_to_notation(inputs: &[Vec<usize>], output: &[usize]) -> Result<String> {
-    let mut id_to_char = HashMap::new();
-    let mut next_code = 'a' as u32;
-
-    let mut alloc_label = |id: usize| -> Result<char> {
-        if let Some(&ch) = id_to_char.get(&id) {
-            return Ok(ch);
-        }
-        loop {
-            let Some(ch) = char::from_u32(next_code) else {
-                return Err(anyhow!("ran out of einsum label codepoints"));
-            };
-            next_code += 1;
-            if ch.is_alphanumeric() {
-                id_to_char.insert(id, ch);
-                return Ok(ch);
-            }
-        }
-    };
-
-    let input_terms: Result<Vec<String>> = inputs
+fn build_einsum_subscripts(operands: &[&[u32]], output_ids: &[u32]) -> Result<String> {
+    let inputs = operands
         .iter()
-        .map(|ids| ids.iter().map(|&id| alloc_label(id)).collect())
-        .collect();
-    let output_term: Result<String> = output.iter().map(|&id| alloc_label(id)).collect();
-
-    Ok(format!("{}->{}", input_terms?.join(","), output_term?))
+        .map(|ids| ids_to_subscript(ids))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(format!(
+        "{}->{}",
+        inputs.join(","),
+        ids_to_subscript(output_ids)?
+    ))
 }
 
-fn labels_to_u32(labels: &[usize], op: &'static str) -> Result<Vec<u32>> {
-    labels
-        .iter()
-        .map(|&label| {
-            u32::try_from(label).map_err(|_| anyhow!("{op}: label {label} exceeds u32 range"))
-        })
-        .collect()
-}
-
-fn build_binary_einsum_ids(
-    rank_a: usize,
+/// Build native einsum ids for a binary contraction.
+pub(crate) fn build_binary_einsum_ids(
+    lhs_rank: usize,
     axes_a: &[usize],
-    rank_b: usize,
+    rhs_rank: usize,
     axes_b: &[usize],
-) -> Result<(Vec<usize>, Vec<usize>, Vec<usize>)> {
-    if axes_a.len() != axes_b.len() {
-        return Err(anyhow!(
-            "binary contraction axes length mismatch: lhs={}, rhs={}",
-            axes_a.len(),
-            axes_b.len()
-        ));
-    }
+) -> Result<(Vec<u32>, Vec<u32>, Vec<u32>)> {
+    ensure!(
+        axes_a.len() == axes_b.len(),
+        "contract axis length mismatch: lhs {:?}, rhs {:?}",
+        axes_a,
+        axes_b
+    );
 
-    let mut lhs_ids = vec![usize::MAX; rank_a];
-    let mut rhs_ids = vec![usize::MAX; rank_b];
-    let mut next_id = 0usize;
+    let mut lhs_ids = vec![u32::MAX; lhs_rank];
+    let mut rhs_ids = vec![u32::MAX; rhs_rank];
+    let mut next_id = 0u32;
+
+    let mut seen_lhs = vec![false; lhs_rank];
+    let mut seen_rhs = vec![false; rhs_rank];
 
     for (&lhs_axis, &rhs_axis) in axes_a.iter().zip(axes_b.iter()) {
-        if lhs_axis >= rank_a || rhs_axis >= rank_b {
-            return Err(anyhow!(
-                "binary contraction axis out of range: lhs_axis={}, rhs_axis={}, lhs_rank={}, rhs_rank={}",
-                lhs_axis,
-                rhs_axis,
-                rank_a,
-                rank_b
-            ));
-        }
-        if lhs_ids[lhs_axis] != usize::MAX || rhs_ids[rhs_axis] != usize::MAX {
-            return Err(anyhow!(
-                "duplicate contraction axis in native binary contraction: lhs_axis={}, rhs_axis={}",
-                lhs_axis,
-                rhs_axis
-            ));
-        }
+        ensure!(
+            lhs_axis < lhs_rank,
+            "lhs contract axis {lhs_axis} out of range"
+        );
+        ensure!(
+            rhs_axis < rhs_rank,
+            "rhs contract axis {rhs_axis} out of range"
+        );
+        ensure!(
+            !seen_lhs[lhs_axis],
+            "duplicate lhs contract axis {lhs_axis}"
+        );
+        ensure!(
+            !seen_rhs[rhs_axis],
+            "duplicate rhs contract axis {rhs_axis}"
+        );
+        seen_lhs[lhs_axis] = true;
+        seen_rhs[rhs_axis] = true;
         lhs_ids[lhs_axis] = next_id;
         rhs_ids[rhs_axis] = next_id;
         next_id += 1;
     }
 
-    let mut output_ids = Vec::with_capacity(rank_a + rank_b - 2 * axes_a.len());
-    for slot in &mut lhs_ids {
-        if *slot == usize::MAX {
+    let mut output_ids = Vec::with_capacity(lhs_rank + rhs_rank - 2 * axes_a.len());
+    for (axis, slot) in lhs_ids.iter_mut().enumerate() {
+        if *slot == u32::MAX {
             *slot = next_id;
             output_ids.push(next_id);
             next_id += 1;
+        } else {
+            let _ = axis;
         }
     }
     for slot in &mut rhs_ids {
-        if *slot == usize::MAX {
+        if *slot == u32::MAX {
             *slot = next_id;
             output_ids.push(next_id);
             next_id += 1;
@@ -462,392 +252,474 @@ fn build_binary_einsum_ids(
     Ok((lhs_ids, rhs_ids, output_ids))
 }
 
-/// Convert legacy [`Storage`] into a primal-mode [`tenferro::Tensor`].
+/// Build a dense native tensor from column-major data.
+pub fn dense_native_tensor_from_col_major<T: TensorElement>(
+    data: &[T],
+    logical_dims: &[usize],
+) -> Result<NativeTensor> {
+    T::dense_native_tensor_from_col_major(data, logical_dims)
+}
+
+/// Build a dense native tensor whose logical values are diagonal.
+pub fn diag_native_tensor_from_col_major<T: TensorElement>(
+    data: &[T],
+    logical_rank: usize,
+) -> Result<NativeTensor> {
+    T::diag_native_tensor_from_col_major(data, logical_rank)
+}
+
+/// Convert storage to a dense native tensor.
 pub fn storage_to_native_tensor(storage: &Storage, logical_dims: &[usize]) -> Result<NativeTensor> {
-    if !storage.is_dense() {
-        let dense = storage.to_dense_storage(logical_dims);
-        return storage_to_native_tensor(&dense, logical_dims);
-    }
     if storage.is_c64() {
-        native_tensor_from_c64_payload(storage.native_payload_c64(logical_dims)?)
+        dense_native_tensor_from_col_major(
+            &storage
+                .to_dense_c64_col_major_vec(logical_dims)
+                .map_err(|e| anyhow!("dense c64 materialization failed: {e}"))?,
+            logical_dims,
+        )
     } else {
-        native_tensor_from_f64_payload(storage.native_payload_f64(logical_dims)?)
+        dense_native_tensor_from_col_major(
+            &storage
+                .to_dense_f64_col_major_vec(logical_dims)
+                .map_err(|e| anyhow!("dense f64 materialization failed: {e}"))?,
+            logical_dims,
+        )
     }
 }
 
-/// Materialize the primal payload of a native tensor back into [`Storage`].
-///
-/// AD metadata is intentionally dropped at this bridge boundary.
+/// Materialize a native tensor into dense storage.
 pub fn native_tensor_primal_to_storage(tensor: &NativeTensor) -> Result<Storage> {
-    match tensor.scalar_type() {
-        ScalarType::F32 | ScalarType::C32 => Err(anyhow!(
-            "tensor4all native bridge currently supports only f64/Complex64 tensors"
-        )),
-        ScalarType::F64 => {
-            if tensor.is_diag() && tensor.ndim() >= 2 {
-                Storage::from_diag_col_major(
-                    <f64 as TensorElement>::diag_values_from_native_temp(tensor)?,
-                    tensor.ndim(),
-                )
-            } else {
-                Storage::from_dense_col_major(
-                    <f64 as TensorElement>::dense_values_from_native_col_major(tensor)?,
-                    tensor.dims(),
-                )
-            }
-        }
-        ScalarType::C64 => {
-            if tensor.is_diag() && tensor.ndim() >= 2 {
-                Storage::from_diag_col_major(
-                    <Complex64 as TensorElement>::diag_values_from_native_temp(tensor)?,
-                    tensor.ndim(),
-                )
-            } else {
-                Storage::from_dense_col_major(
-                    <Complex64 as TensorElement>::dense_values_from_native_col_major(tensor)?,
-                    tensor.dims(),
-                )
-            }
-        }
+    match tensor.dtype() {
+        DType::F32 => Storage::from_dense_col_major(
+            tensor
+                .as_slice::<f32>()
+                .ok_or_else(|| anyhow!("failed to read f32 native tensor"))?
+                .iter()
+                .map(|&value| value as f64)
+                .collect::<Vec<_>>(),
+            tensor.shape(),
+        ),
+        DType::F64 => Storage::from_dense_col_major(
+            tensor
+                .as_slice::<f64>()
+                .ok_or_else(|| anyhow!("failed to read f64 native tensor"))?
+                .to_vec(),
+            tensor.shape(),
+        ),
+        DType::C32 => Storage::from_dense_col_major(
+            tensor
+                .as_slice::<Complex32>()
+                .ok_or_else(|| anyhow!("failed to read c32 native tensor"))?
+                .iter()
+                .map(|&value| Complex64::new(value.re as f64, value.im as f64))
+                .collect::<Vec<_>>(),
+            tensor.shape(),
+        ),
+        DType::C64 => Storage::from_dense_col_major(
+            tensor
+                .as_slice::<Complex64>()
+                .ok_or_else(|| anyhow!("failed to read c64 native tensor"))?
+                .to_vec(),
+            tensor.shape(),
+        ),
+    }
+    .map_err(|e| anyhow!("native tensor snapshot materialization failed: {e}"))
+}
+
+/// Materialize dense f64 values from a native tensor.
+pub fn native_tensor_primal_to_dense_f64_col_major(tensor: &NativeTensor) -> Result<Vec<f64>> {
+    match tensor.dtype() {
+        DType::F32 => Ok(tensor
+            .as_slice::<f32>()
+            .ok_or_else(|| anyhow!("failed to read f32 native tensor"))?
+            .iter()
+            .map(|&value| value as f64)
+            .collect()),
+        DType::F64 => <f64 as TensorElement>::dense_values_from_native_col_major(tensor),
+        other => Err(anyhow!("expected real native tensor, got dtype {other:?}")),
     }
 }
 
-/// Materialize the dense primal payload of a native tensor as column-major `f64`.
-pub fn native_tensor_primal_to_dense_f64_col_major(tensor: &NativeTensor) -> Result<Vec<f64>> {
-    retry_with_default_runtime_if_needed("native_tensor_primal_to_dense_f64_col_major", || {
-        <f64 as TensorElement>::dense_values_from_native_col_major(tensor)
-    })
-}
-
-/// Materialize the dense primal payload of a native tensor as column-major `Complex64`.
+/// Materialize dense Complex64 values from a native tensor.
 pub fn native_tensor_primal_to_dense_c64_col_major(
     tensor: &NativeTensor,
 ) -> Result<Vec<Complex64>> {
-    retry_with_default_runtime_if_needed("native_tensor_primal_to_dense_c64_col_major", || {
-        <Complex64 as TensorElement>::dense_values_from_native_col_major(tensor)
-    })
+    match tensor.dtype() {
+        DType::C32 => Ok(tensor
+            .as_slice::<Complex32>()
+            .ok_or_else(|| anyhow!("failed to read c32 native tensor"))?
+            .iter()
+            .map(|&value| Complex64::new(value.re as f64, value.im as f64))
+            .collect()),
+        DType::C64 => <Complex64 as TensorElement>::dense_values_from_native_col_major(tensor),
+        other => Err(anyhow!(
+            "expected complex native tensor, got dtype {other:?}"
+        )),
+    }
 }
 
-/// Materialize the dense primal payload of a native tensor (generic over element type).
-///
-/// This is the generic equivalent of [`native_tensor_primal_to_dense_f64_col_major`]
-/// and [`native_tensor_primal_to_dense_c64_col_major`].
+/// Materialize dense column-major values from a native tensor.
 pub fn native_tensor_primal_to_dense_col_major<T: TensorElement>(
     tensor: &NativeTensor,
 ) -> Result<Vec<T>> {
-    retry_with_default_runtime_if_needed("native_tensor_primal_to_dense_col_major", || {
-        T::dense_values_from_native_col_major(tensor)
-    })
+    T::dense_values_from_native_col_major(tensor)
 }
 
-/// Materialize the diagonal payload of a native diagonal tensor as `f64`.
+/// Extract the diagonal payload from a real native tensor.
 pub fn native_tensor_primal_to_diag_f64(tensor: &NativeTensor) -> Result<Vec<f64>> {
-    retry_with_default_runtime_if_needed("native_tensor_primal_to_diag_f64", || {
-        <f64 as TensorElement>::diag_values_from_native_temp(tensor)
-    })
-}
-
-/// Materialize the diagonal payload of a native diagonal tensor as `Complex64`.
-pub fn native_tensor_primal_to_diag_c64(tensor: &NativeTensor) -> Result<Vec<Complex64>> {
-    retry_with_default_runtime_if_needed("native_tensor_primal_to_diag_c64", || {
-        <Complex64 as TensorElement>::diag_values_from_native_temp(tensor)
-    })
-}
-
-/// Extract the forward tangent of a native tensor as a primal tensor.
-pub fn tangent_native_tensor(tensor: &NativeTensor) -> Option<NativeTensor> {
-    let _ = tensor;
-    None
-}
-
-/// Reshape a native tensor using tensor4all's column-major semantics.
-pub fn reshape_col_major_native_tensor(
-    tensor: &NativeTensor,
-    new_dims: &[usize],
-) -> Result<NativeTensor> {
-    match tensor.scalar_type() {
-        ScalarType::F32 | ScalarType::C32 => Err(anyhow!(
-            "tensor4all native bridge currently supports only f64/Complex64 tensors"
-        )),
-        ScalarType::F64 => dense_native_tensor_from_col_major(
-            &native_tensor_primal_to_dense_col_major::<f64>(tensor)?,
-            new_dims,
-        ),
-        ScalarType::C64 => dense_native_tensor_from_col_major(
-            &native_tensor_primal_to_dense_col_major::<Complex64>(tensor)?,
-            new_dims,
-        ),
+    match tensor.dtype() {
+        DType::F32 => {
+            let promoted = convert_tensor(tensor, DType::F64)?;
+            <f64 as TensorElement>::diag_values_from_native_temp(&promoted)
+        }
+        DType::F64 => <f64 as TensorElement>::diag_values_from_native_temp(tensor),
+        other => Err(anyhow!("expected real native tensor, got dtype {other:?}")),
     }
 }
 
-/// Compute native QR while preserving AD metadata when supported by upstream.
-pub fn qr_native_tensor(tensor: &NativeTensor) -> Result<(NativeTensor, NativeTensor)> {
-    with_default_runtime("native_qr", || {
-        let out = tensor.qr().map_err(|e| anyhow!("native qr failed: {e}"))?;
-        Ok((out.q, out.r))
-    })
+/// Extract the diagonal payload from a complex native tensor.
+pub fn native_tensor_primal_to_diag_c64(tensor: &NativeTensor) -> Result<Vec<Complex64>> {
+    match tensor.dtype() {
+        DType::C32 => {
+            let promoted = convert_tensor(tensor, DType::C64)?;
+            <Complex64 as TensorElement>::diag_values_from_native_temp(&promoted)
+        }
+        DType::C64 => <Complex64 as TensorElement>::diag_values_from_native_temp(tensor),
+        other => Err(anyhow!(
+            "expected complex native tensor, got dtype {other:?}"
+        )),
+    }
 }
 
-/// Compute native SVD while preserving AD metadata when supported by upstream.
+/// Reshape a native tensor without changing its column-major linearization.
+pub fn reshape_col_major_native_tensor(
+    tensor: &NativeTensor,
+    logical_dims: &[usize],
+) -> Result<NativeTensor> {
+    with_default_backend(|backend| tensor.reshape(logical_dims, backend))
+        .map_err(|e| anyhow!("native reshape failed: {e}"))
+}
+
+/// Compute a QR decomposition on a native tensor.
+pub fn qr_native_tensor(tensor: &NativeTensor) -> Result<(NativeTensor, NativeTensor)> {
+    with_default_backend(|backend| tensor.qr(backend)).map_err(|e| anyhow!("native QR failed: {e}"))
+}
+
+/// Compute an SVD on a native tensor.
 pub fn svd_native_tensor(
     tensor: &NativeTensor,
 ) -> Result<(NativeTensor, NativeTensor, NativeTensor)> {
-    with_default_runtime("native_svd", || {
-        let out = tensor
-            .svd(None)
-            .map_err(|e| anyhow!("native svd failed: {e}"))?;
-        Ok((out.u, out.s, out.vt))
-    })
+    with_default_backend(|backend| tensor.svd(backend))
+        .map_err(|e| anyhow!("native SVD failed: {e}"))
 }
 
-/// Sum all elements of a native tensor, preserving AD metadata.
+/// Sum all elements of a native tensor, returning a dynamic scalar.
 pub fn sum_native_tensor(tensor: &NativeTensor) -> Result<AnyScalar> {
-    with_default_runtime("native_sum", || {
-        let reduced = tensor
-            .sum()
-            .map_err(|e| anyhow!("native sum failed: {e}"))?;
-        AnyScalar::from_native(reduced)
-    })
+    let reduced = if tensor.shape().is_empty() {
+        tensor.clone()
+    } else {
+        let axes: Vec<usize> = (0..tensor.shape().len()).collect();
+        with_default_backend(|backend| tensor.reduce_sum(&axes, backend))
+            .map_err(|e| anyhow!("native sum failed: {e}"))?
+    };
+    AnyScalar::from_native(reduced)
 }
 
-fn supported_bridge_scalar_type(tensor: &NativeTensor, op: &'static str) -> Result<ScalarType> {
-    match tensor.scalar_type() {
-        ScalarType::F64 | ScalarType::C64 => Ok(tensor.scalar_type()),
-        ScalarType::F32 | ScalarType::C32 => Err(anyhow!(
-            "{op}: tensor4all native bridge currently supports only f64/Complex64 tensors"
-        )),
-    }
+/// Return the tangent tensor when present.
+///
+/// Plain `Tensor` values do not carry tangent storage, so this bridge returns
+/// `None`.
+pub fn tangent_native_tensor(_tensor: &NativeTensor) -> Option<NativeTensor> {
+    None
 }
 
-fn shared_tensor_scalar_type(
-    lhs: &NativeTensor,
-    rhs: &NativeTensor,
-    op: &'static str,
-) -> Result<ScalarType> {
-    let lhs_ty = supported_bridge_scalar_type(lhs, op)?;
-    let rhs_ty = supported_bridge_scalar_type(rhs, op)?;
-    if lhs_ty != rhs_ty {
-        return Err(anyhow!(
-            "{op}: native tensors must share a dtype, got lhs={lhs_ty:?}, rhs={rhs_ty:?}"
-        ));
-    }
-    Ok(lhs_ty)
-}
-
-fn common_operand_scalar_type(
-    operands: &[(&NativeTensor, &[usize])],
-    op: &'static str,
-) -> Result<ScalarType> {
-    let mut target = ScalarType::F64;
-    for (tensor, _) in operands {
-        match supported_bridge_scalar_type(tensor, op)? {
-            ScalarType::C64 => target = ScalarType::C64,
-            ScalarType::F64 => {}
-            ScalarType::F32 | ScalarType::C32 => unreachable!("unsupported dtype filtered above"),
-        }
-    }
-    Ok(target)
-}
-
-fn promote_detached_tensor_to_dtype(
-    tensor: &NativeTensor,
-    target: ScalarType,
-    op: &'static str,
-) -> Result<NativeTensor> {
-    let source = supported_bridge_scalar_type(tensor, op)?;
-    if source == target {
-        return Err(anyhow!(
-            "{op}: internal promotion bug, source and target dtypes already match"
-        ));
-    }
-    if tensor.requires_grad() {
-        return Err(anyhow!(
-            "{op}: cannot promote a reverse-tracked tensor from {source:?} to {target:?} without losing autodiff metadata"
-        ));
-    }
-    match (source, target) {
-        (ScalarType::F64, ScalarType::C64) => {
-            if tensor.is_diag() && tensor.ndim() >= 2 {
-                let diag = native_tensor_primal_to_diag_f64(tensor)?
-                    .into_iter()
-                    .map(|value| Complex64::new(value, 0.0))
-                    .collect::<Vec<_>>();
-                diag_native_tensor_from_col_major(&diag, tensor.ndim())
-            } else {
-                let dense = native_tensor_primal_to_dense_f64_col_major(tensor)?
-                    .into_iter()
-                    .map(|value| Complex64::new(value, 0.0))
-                    .collect::<Vec<_>>();
-                dense_native_tensor_from_col_major(&dense, tensor.dims())
-            }
-        }
-        (lhs, rhs) => Err(anyhow!(
-            "{op}: unsupported dtype promotion from {lhs:?} to {rhs:?}"
-        )),
-    }
-}
-
-/// Scale a native tensor with a tensor4all scalar while preserving AD metadata.
+/// Multiply a native tensor by a dynamic scalar.
 pub fn scale_native_tensor(tensor: &NativeTensor, scalar: &AnyScalar) -> Result<NativeTensor> {
-    let scalar_native = promote_scalar_native(
-        scalar.as_native(),
-        supported_bridge_scalar_type(tensor, "native_scale")?,
-    )?;
-    let output_ids = (0..tensor.ndim()).collect::<Vec<_>>();
-    einsum_native_tensors(&[(&scalar_native, &[]), (tensor, &output_ids)], &output_ids)
+    let target = common_dtype(&[tensor.dtype(), scalar.as_native().dtype()]);
+    let tensor = convert_tensor(tensor, target)?;
+    let scalar = promote_scalar_native(scalar.as_native(), target)?;
+
+    match target {
+        DType::F32 => {
+            let factor = scalar
+                .as_slice::<f32>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted f32 scalar"))?;
+            let values = tensor
+                .as_slice::<f32>()
+                .ok_or_else(|| anyhow!("failed to read promoted f32 tensor"))?
+                .iter()
+                .map(|&value| value * factor)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(tensor.shape().to_vec(), values))
+        }
+        DType::F64 => {
+            let factor = scalar
+                .as_slice::<f64>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted f64 scalar"))?;
+            let values = tensor
+                .as_slice::<f64>()
+                .ok_or_else(|| anyhow!("failed to read promoted f64 tensor"))?
+                .iter()
+                .map(|&value| value * factor)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(tensor.shape().to_vec(), values))
+        }
+        DType::C32 => {
+            let factor = scalar
+                .as_slice::<Complex32>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted c32 scalar"))?;
+            let values = tensor
+                .as_slice::<Complex32>()
+                .ok_or_else(|| anyhow!("failed to read promoted c32 tensor"))?
+                .iter()
+                .map(|&value| value * factor)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(tensor.shape().to_vec(), values))
+        }
+        DType::C64 => {
+            let factor = scalar
+                .as_slice::<Complex64>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted c64 scalar"))?;
+            let values = tensor
+                .as_slice::<Complex64>()
+                .ok_or_else(|| anyhow!("failed to read promoted c64 tensor"))?
+                .iter()
+                .map(|&value| value * factor)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(tensor.shape().to_vec(), values))
+        }
+    }
 }
 
-/// Compute `a * lhs + b * rhs` on native tensors while preserving AD metadata.
+/// Compute `a * lhs + b * rhs`.
 pub fn axpby_native_tensor(
     lhs: &NativeTensor,
     a: &AnyScalar,
     rhs: &NativeTensor,
     b: &AnyScalar,
 ) -> Result<NativeTensor> {
-    let target = shared_tensor_scalar_type(lhs, rhs, "native_axpby")?;
-    let a_native = promote_scalar_native(a.as_native(), target)?;
-    let b_native = promote_scalar_native(b.as_native(), target)?;
-    let lhs_scaled = {
-        let output_ids = (0..lhs.ndim()).collect::<Vec<_>>();
-        einsum_native_tensors(&[(&a_native, &[]), (lhs, &output_ids)], &output_ids)?
-    };
-    let rhs_scaled = {
-        let output_ids = (0..rhs.ndim()).collect::<Vec<_>>();
-        einsum_native_tensors(&[(&b_native, &[]), (rhs, &output_ids)], &output_ids)?
-    };
-    with_default_runtime("native_axpby", || {
-        lhs_scaled
-            .add(&rhs_scaled)
-            .map_err(|e| anyhow!("native axpby failed: {e}"))
-    })
+    ensure!(
+        lhs.shape() == rhs.shape(),
+        "axpby requires matching tensor shapes, got lhs {:?} and rhs {:?}",
+        lhs.shape(),
+        rhs.shape()
+    );
+
+    let target = common_dtype(&[
+        lhs.dtype(),
+        rhs.dtype(),
+        a.as_native().dtype(),
+        b.as_native().dtype(),
+    ]);
+    let lhs = convert_tensor(lhs, target)?;
+    let rhs = convert_tensor(rhs, target)?;
+    let a = promote_scalar_native(a.as_native(), target)?;
+    let b = promote_scalar_native(b.as_native(), target)?;
+
+    match target {
+        DType::F32 => {
+            let a = a
+                .as_slice::<f32>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted f32 scalar a"))?;
+            let b = b
+                .as_slice::<f32>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted f32 scalar b"))?;
+            let lhs_values = lhs
+                .as_slice::<f32>()
+                .ok_or_else(|| anyhow!("failed to read promoted f32 lhs"))?;
+            let rhs_values = rhs
+                .as_slice::<f32>()
+                .ok_or_else(|| anyhow!("failed to read promoted f32 rhs"))?;
+            let values = lhs_values
+                .iter()
+                .zip(rhs_values.iter())
+                .map(|(&x, &y)| a * x + b * y)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(lhs.shape().to_vec(), values))
+        }
+        DType::F64 => {
+            let a = a
+                .as_slice::<f64>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted f64 scalar a"))?;
+            let b = b
+                .as_slice::<f64>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted f64 scalar b"))?;
+            let lhs_values = lhs
+                .as_slice::<f64>()
+                .ok_or_else(|| anyhow!("failed to read promoted f64 lhs"))?;
+            let rhs_values = rhs
+                .as_slice::<f64>()
+                .ok_or_else(|| anyhow!("failed to read promoted f64 rhs"))?;
+            let values = lhs_values
+                .iter()
+                .zip(rhs_values.iter())
+                .map(|(&x, &y)| a * x + b * y)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(lhs.shape().to_vec(), values))
+        }
+        DType::C32 => {
+            let a = a
+                .as_slice::<Complex32>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted c32 scalar a"))?;
+            let b = b
+                .as_slice::<Complex32>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted c32 scalar b"))?;
+            let lhs_values = lhs
+                .as_slice::<Complex32>()
+                .ok_or_else(|| anyhow!("failed to read promoted c32 lhs"))?;
+            let rhs_values = rhs
+                .as_slice::<Complex32>()
+                .ok_or_else(|| anyhow!("failed to read promoted c32 rhs"))?;
+            let values = lhs_values
+                .iter()
+                .zip(rhs_values.iter())
+                .map(|(&x, &y)| a * x + b * y)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(lhs.shape().to_vec(), values))
+        }
+        DType::C64 => {
+            let a = a
+                .as_slice::<Complex64>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted c64 scalar a"))?;
+            let b = b
+                .as_slice::<Complex64>()
+                .and_then(|values| values.first().copied())
+                .ok_or_else(|| anyhow!("failed to read promoted c64 scalar b"))?;
+            let lhs_values = lhs
+                .as_slice::<Complex64>()
+                .ok_or_else(|| anyhow!("failed to read promoted c64 lhs"))?;
+            let rhs_values = rhs
+                .as_slice::<Complex64>()
+                .ok_or_else(|| anyhow!("failed to read promoted c64 rhs"))?;
+            let values = lhs_values
+                .iter()
+                .zip(rhs_values.iter())
+                .map(|(&x, &y)| a * x + b * y)
+                .collect::<Vec<_>>();
+            Ok(NativeTensor::new(lhs.shape().to_vec(), values))
+        }
+    }
 }
 
-/// Execute native structured einsum on multiple tensors.
+/// Execute an eager einsum over native tensors.
 pub fn einsum_native_tensors(
     operands: &[(&NativeTensor, &[usize])],
     output_ids: &[usize],
 ) -> Result<NativeTensor> {
-    if operands.is_empty() {
-        return Err(anyhow!("native einsum requires at least one operand"));
+    ensure!(
+        !operands.is_empty(),
+        "native einsum requires at least one operand"
+    );
+    for (tensor, ids) in operands {
+        ensure!(
+            tensor.shape().len() == ids.len(),
+            "einsum id list {:?} does not match tensor shape {:?}",
+            ids,
+            tensor.shape()
+        );
     }
 
-    let target = common_operand_scalar_type(operands, "native_einsum")?;
-    let promoted = operands
+    let target = common_dtype(
+        &operands
+            .iter()
+            .map(|(tensor, _)| tensor.dtype())
+            .collect::<Vec<_>>(),
+    );
+    let converted = operands
         .iter()
-        .map(|(tensor, _)| {
-            let source = supported_bridge_scalar_type(tensor, "native_einsum")?;
-            if source == target {
-                Ok(None)
-            } else {
-                promote_detached_tensor_to_dtype(tensor, target, "native_einsum").map(Some)
-            }
-        })
+        .map(|(tensor, _)| convert_tensor(tensor, target))
         .collect::<Result<Vec<_>>>()?;
+    let refs = converted.iter().collect::<Vec<_>>();
+    let subscripts = build_einsum_subscripts(
+        &operands
+            .iter()
+            .map(|(_, ids)| ids.iter().map(|&id| id as u32).collect::<Vec<_>>())
+            .collect::<Vec<_>>()
+            .iter()
+            .map(Vec::as_slice)
+            .collect::<Vec<_>>(),
+        &output_ids.iter().map(|&id| id as u32).collect::<Vec<_>>(),
+    )?;
 
-    let input_ids_u32: Vec<Vec<u32>> = operands
-        .iter()
-        .map(|(_, ids)| labels_to_u32(ids, "native_einsum"))
-        .collect::<Result<_>>()?;
-    let output_ids_u32 = labels_to_u32(output_ids, "native_einsum")?;
-    let profile_started = native_einsum_profile_enabled().then(Instant::now);
-
-    let input_ids: Vec<Vec<usize>> = operands.iter().map(|(_, ids)| ids.to_vec()).collect();
-    let final_operands: Vec<&NativeTensor> = operands
-        .iter()
-        .zip(promoted.iter())
-        .map(|((tensor, _), promoted)| promoted.as_ref().unwrap_or(tensor))
-        .collect();
-    let notation = labels_to_notation(&input_ids, output_ids)?;
-
-    with_default_runtime("native_einsum", || {
-        let out = NativeTensor::einsum(&notation, &final_operands)
-            .map_err(|e| anyhow!("native einsum failed: {e}"))?;
-        if let Some(started) = profile_started.as_ref() {
-            record_native_einsum_profile(
-                NativeEinsumPath::FrontendFallback,
-                operands,
-                &input_ids_u32,
-                &output_ids_u32,
-                started.elapsed(),
-            );
-        }
-        Ok(out)
-    })
+    let started = Instant::now();
+    let result = with_default_backend(|backend| eager_einsum(backend, &refs, &subscripts))
+        .map_err(|e| anyhow!("native einsum failed: {e}"))?;
+    record_native_einsum_profile(
+        NativeEinsumPath::FrontendFallback,
+        operands,
+        &output_ids.iter().map(|&id| id as u32).collect::<Vec<_>>(),
+        started.elapsed(),
+    );
+    Ok(result)
 }
 
-/// Permute a native tensor through tenferro frontend operations.
+/// Permute axes of a native tensor.
 pub fn permute_native_tensor(tensor: &NativeTensor, perm: &[usize]) -> Result<NativeTensor> {
-    let input_ids = (0..tensor.ndim()).collect::<Vec<_>>();
-    let output_ids = perm
-        .iter()
-        .map(|&axis| {
-            input_ids
-                .get(axis)
-                .copied()
-                .ok_or_else(|| anyhow!("native permute axis {axis} out of bounds"))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    einsum_native_tensors(&[(tensor, &input_ids)], &output_ids)
+    with_default_backend(|backend| tensor.transpose(perm, backend))
+        .map_err(|e| anyhow!("native permute failed: {e}"))
 }
 
-/// Contract two native tensors with AD-preserving einsum execution.
+/// Contract two native tensors along matching axes.
 pub fn contract_native_tensor(
     lhs: &NativeTensor,
-    axes_lhs: &[usize],
+    axes_a: &[usize],
     rhs: &NativeTensor,
-    axes_rhs: &[usize],
+    axes_b: &[usize],
 ) -> Result<NativeTensor> {
     let (lhs_ids, rhs_ids, output_ids) =
-        build_binary_einsum_ids(lhs.ndim(), axes_lhs, rhs.ndim(), axes_rhs)?;
-    einsum_native_tensors(&[(lhs, &lhs_ids), (rhs, &rhs_ids)], &output_ids)
+        build_binary_einsum_ids(lhs.shape().len(), axes_a, rhs.shape().len(), axes_b)?;
+    let lhs_ids_usize = lhs_ids.iter().map(|&id| id as usize).collect::<Vec<_>>();
+    let rhs_ids_usize = rhs_ids.iter().map(|&id| id as usize).collect::<Vec<_>>();
+    let output_ids_usize = output_ids.iter().map(|&id| id as usize).collect::<Vec<_>>();
+    let operands = [
+        (lhs, lhs_ids_usize.as_slice()),
+        (rhs, rhs_ids_usize.as_slice()),
+    ];
+    einsum_native_tensors(&operands, &output_ids_usize)
 }
 
-/// Compute outer product of two native tensors.
+/// Compute the outer product of two native tensors.
 pub fn outer_product_native_tensor(lhs: &NativeTensor, rhs: &NativeTensor) -> Result<NativeTensor> {
     contract_native_tensor(lhs, &[], rhs, &[])
 }
 
-/// Conjugate a native tensor while preserving AD metadata.
+/// Conjugate a native tensor.
 pub fn conj_native_tensor(tensor: &NativeTensor) -> Result<NativeTensor> {
-    match tensor.scalar_type() {
-        ScalarType::F32 | ScalarType::C32 => Err(anyhow!(
-            "tensor4all native bridge currently supports only f64/Complex64 tensors"
+    match tensor.dtype() {
+        DType::F32 | DType::F64 => Ok(tensor.clone()),
+        DType::C32 => Ok(NativeTensor::new(
+            tensor.shape().to_vec(),
+            tensor
+                .as_slice::<Complex32>()
+                .ok_or_else(|| anyhow!("failed to read c32 native tensor"))?
+                .iter()
+                .map(|&value| value.conj())
+                .collect::<Vec<_>>(),
         )),
-        ScalarType::F64 => {
-            if tensor.is_diag() && tensor.ndim() >= 2 {
-                diag_native_tensor_from_col_major(
-                    &native_tensor_primal_to_diag_f64(tensor)?,
-                    tensor.ndim(),
-                )
-            } else {
-                dense_native_tensor_from_col_major(
-                    &native_tensor_primal_to_dense_f64_col_major(tensor)?,
-                    tensor.dims(),
-                )
-            }
-        }
-        ScalarType::C64 => {
-            let data = if tensor.is_diag() && tensor.ndim() >= 2 {
-                native_tensor_primal_to_diag_c64(tensor)?
-                    .into_iter()
-                    .map(|value| value.conj())
-                    .collect::<Vec<_>>()
-            } else {
-                native_tensor_primal_to_dense_c64_col_major(tensor)?
-                    .into_iter()
-                    .map(|value| value.conj())
-                    .collect::<Vec<_>>()
-            };
-            if tensor.is_diag() && tensor.ndim() >= 2 {
-                diag_native_tensor_from_col_major(&data, tensor.ndim())
-            } else {
-                dense_native_tensor_from_col_major(&data, tensor.dims())
-            }
-        }
+        DType::C64 => Ok(NativeTensor::new(
+            tensor.shape().to_vec(),
+            tensor
+                .as_slice::<Complex64>()
+                .ok_or_else(|| anyhow!("failed to read c64 native tensor"))?
+                .iter()
+                .map(|&value| value.conj())
+                .collect::<Vec<_>>(),
+        )),
     }
 }
 
-/// Permute storage through native tenferro execution.
+/// Permute storage by round-tripping through native tensors.
 pub fn permute_storage_native(
     storage: &Storage,
     logical_dims: &[usize],
@@ -858,7 +730,7 @@ pub fn permute_storage_native(
     native_tensor_primal_to_storage(&permuted)
 }
 
-/// Contract two storages through native tenferro execution.
+/// Contract storages via native tensors.
 pub fn contract_storage_native(
     storage_a: &Storage,
     dims_a: &[usize],
@@ -866,17 +738,15 @@ pub fn contract_storage_native(
     storage_b: &Storage,
     dims_b: &[usize],
     axes_b: &[usize],
-    result_dims: &[usize],
+    _result_dims: &[usize],
 ) -> Result<Storage> {
     let lhs = storage_to_native_tensor(storage_a, dims_a)?;
     let rhs = storage_to_native_tensor(storage_b, dims_b)?;
     let result = contract_native_tensor(&lhs, axes_a, &rhs, axes_b)?;
-    let storage = native_tensor_primal_to_storage(&result)?;
-    let _ = result_dims;
-    Ok(storage)
+    native_tensor_primal_to_storage(&result)
 }
 
-/// Compute an outer product through native tenferro execution.
+/// Outer-product storages via native tensors.
 pub fn outer_product_storage_native(
     lhs: &Storage,
     lhs_dims: &[usize],
@@ -890,7 +760,7 @@ pub fn outer_product_storage_native(
     native_tensor_primal_to_storage(&result)
 }
 
-/// Apply native tenferro mixed scalar/tensor scaling at the storage boundary.
+/// Scale storage by a scalar via native tensors.
 pub fn scale_storage_native(
     storage: &Storage,
     logical_dims: &[usize],
@@ -901,7 +771,7 @@ pub fn scale_storage_native(
     native_tensor_primal_to_storage(&scaled)
 }
 
-/// Apply native tenferro fused `a * lhs + b * rhs` at the storage boundary.
+/// Compute `a * lhs + b * rhs` over storages via native tensors.
 pub fn axpby_storage_native(
     lhs: &Storage,
     lhs_dims: &[usize],

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::storage::Storage;
-use num_complex::Complex64;
+use crate::tensor_element::TensorElement;
+use num_complex::{Complex32, Complex64};
 
 fn assert_storage_eq(lhs: &Storage, rhs: &Storage) {
     match (lhs.repr(), rhs.repr()) {
@@ -106,6 +107,55 @@ fn diag_native_tensor_from_col_major_f64_roundtrip() {
 }
 
 #[test]
+fn dense_native_tensor_from_col_major_f32_roundtrip() {
+    let native = dense_native_tensor_from_col_major(&[1.25_f32, -2.5_f32], &[2]).unwrap();
+    let values = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
+    let snapshot = native_tensor_primal_to_storage(&native).unwrap();
+
+    assert_eq!(values, vec![1.25, -2.5]);
+    assert_storage_eq(
+        &snapshot,
+        &Storage::from_dense_col_major(vec![1.25, -2.5], &[2]).unwrap(),
+    );
+}
+
+#[test]
+fn diag_native_tensor_from_col_major_c32_promotes_to_c64_values() {
+    let data = vec![Complex32::new(1.0, -0.5), Complex32::new(-2.0, 0.25)];
+    let native = diag_native_tensor_from_col_major(&data, 2).unwrap();
+    let diag_values = native_tensor_primal_to_diag_c64(&native).unwrap();
+    let dense_values = native_tensor_primal_to_dense_c64_col_major(&native).unwrap();
+    let snapshot = native_tensor_primal_to_storage(&native).unwrap();
+
+    assert_eq!(
+        diag_values,
+        vec![Complex64::new(1.0, -0.5), Complex64::new(-2.0, 0.25)]
+    );
+    assert_eq!(
+        dense_values,
+        vec![
+            Complex64::new(1.0, -0.5),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(-2.0, 0.25),
+        ]
+    );
+    assert_storage_eq(
+        &snapshot,
+        &Storage::from_dense_col_major(
+            vec![
+                Complex64::new(1.0, -0.5),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(-2.0, 0.25),
+            ],
+            &[2, 2],
+        )
+        .unwrap(),
+    );
+}
+
+#[test]
 fn sum_native_tensor_returns_rank0_scalar() {
     let storage = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, -1.0), Complex64::new(-0.5, 2.0)],
@@ -118,6 +168,14 @@ fn sum_native_tensor_returns_rank0_scalar() {
 
     assert!(sum.is_complex());
     assert_eq!(sum.as_c64(), Some(Complex64::new(0.5, 1.0)));
+}
+
+#[test]
+fn sum_native_tensor_preserves_rank0_scalar() {
+    let native = Complex64::scalar_native_tensor(Complex64::new(1.5, -0.25)).unwrap();
+    let sum = sum_native_tensor(&native).unwrap();
+
+    assert_eq!(sum.as_c64(), Some(Complex64::new(1.5, -0.25)));
 }
 
 #[test]
@@ -263,6 +321,26 @@ fn scale_native_tensor_promotes_real_scalar_for_complex_tensor() {
 }
 
 #[test]
+fn scale_and_axpby_native_tensor_cover_f32_paths() {
+    let lhs = dense_native_tensor_from_col_major(&[1.0_f32, -2.0_f32], &[2]).unwrap();
+    let rhs = dense_native_tensor_from_col_major(&[0.5_f32, 4.0_f32], &[2]).unwrap();
+
+    let scaled = scale_native_tensor(&lhs, &crate::AnyScalar::from_value(0.5_f32)).unwrap();
+    let scaled_values = native_tensor_primal_to_dense_f64_col_major(&scaled).unwrap();
+    assert_eq!(scaled_values, vec![0.5, -1.0]);
+
+    let combined = axpby_native_tensor(
+        &lhs,
+        &crate::AnyScalar::from_value(2.0_f32),
+        &rhs,
+        &crate::AnyScalar::from_value(-1.0_f32),
+    )
+    .unwrap();
+    let combined_values = native_tensor_primal_to_dense_f64_col_major(&combined).unwrap();
+    assert_eq!(combined_values, vec![1.5, -8.0]);
+}
+
+#[test]
 fn axpby_native_tensor_promotes_real_scalars_for_complex_tensors() {
     let lhs = dense_native_tensor_from_col_major(
         &[Complex64::new(1.0, 2.0), Complex64::new(-1.0, 0.5)],
@@ -338,6 +416,29 @@ fn tangent_native_tensor_returns_none_for_primal() {
 }
 
 #[test]
+fn dense_and_diag_extractors_reject_wrong_dtypes() {
+    let real = dense_native_tensor_from_col_major(&[1.0_f64, 2.0], &[2]).unwrap();
+    let complex = dense_native_tensor_from_col_major(&[Complex64::new(1.0, -1.0)], &[1]).unwrap();
+
+    assert!(native_tensor_primal_to_dense_f64_col_major(&complex)
+        .unwrap_err()
+        .to_string()
+        .contains("expected real native tensor"));
+    assert!(native_tensor_primal_to_dense_c64_col_major(&real)
+        .unwrap_err()
+        .to_string()
+        .contains("expected complex native tensor"));
+    assert!(native_tensor_primal_to_diag_f64(&complex)
+        .unwrap_err()
+        .to_string()
+        .contains("expected real native tensor"));
+    assert!(native_tensor_primal_to_diag_c64(&real)
+        .unwrap_err()
+        .to_string()
+        .contains("expected complex native tensor"));
+}
+
+#[test]
 fn einsum_native_tensors_rejects_empty_operands() {
     let result = einsum_native_tensors(&[], &[]);
     assert!(result.is_err());
@@ -348,10 +449,32 @@ fn einsum_native_tensors_rejects_empty_operands() {
 }
 
 #[test]
+fn ids_to_subscript_and_build_einsum_subscripts_cover_helper_paths() {
+    assert_eq!(ids_to_subscript(&[0, 25, 51]).unwrap(), "azZ");
+    assert_eq!(
+        build_einsum_subscripts(&[&[0, 1], &[2, 1]], &[0, 2]).unwrap(),
+        "ab,cb->ac"
+    );
+    assert!(ids_to_subscript(&[52])
+        .unwrap_err()
+        .to_string()
+        .contains("exceeds supported label range"));
+}
+
+#[test]
 fn build_binary_einsum_ids_rejects_mismatched_axes_len() {
     let result = build_binary_einsum_ids(2, &[0], 2, &[0, 1]);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("length mismatch"));
+}
+
+#[test]
+fn build_binary_einsum_ids_success_assigns_free_axes_after_contract_axes() {
+    let (lhs_ids, rhs_ids, output_ids) = build_binary_einsum_ids(3, &[1], 2, &[0]).unwrap();
+
+    assert_eq!(lhs_ids, vec![1, 0, 2]);
+    assert_eq!(rhs_ids, vec![0, 3]);
+    assert_eq!(output_ids, vec![1, 2, 3]);
 }
 
 #[test]

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::storage::Storage;
+use num_complex::Complex64;
 
 fn assert_storage_eq(lhs: &Storage, rhs: &Storage) {
     match (lhs.repr(), rhs.repr()) {
@@ -37,111 +38,71 @@ fn recorded_native_einsum_call_count(path: NativeEinsumPath) -> usize {
 #[test]
 fn storage_native_roundtrip_dense_f64() {
     let storage = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-
     let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
     let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
-
-    let expected = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-    assert_storage_eq(&roundtrip, &expected);
+    assert_storage_eq(&roundtrip, &storage);
 }
 
 #[test]
 fn storage_native_roundtrip_diag_densifies_at_public_bridge() {
     let storage = Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
-
     let native = storage_to_native_tensor(&storage, &[3, 3]).unwrap();
     let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
+    let expected = storage.to_dense_storage(&[3, 3]);
 
-    assert!(!native.is_diag());
-    let expected = Storage::from_dense_col_major(
-        vec![
-            2.0, 0.0, 0.0, //
-            0.0, -1.0, 0.0, //
-            0.0, 0.0, 4.0,
-        ],
-        &[3, 3],
-    )
-    .unwrap();
+    assert_eq!(native.shape(), &[3, 3]);
     assert_storage_eq(&roundtrip, &expected);
 }
 
 #[test]
-fn native_dense_materialization_sets_default_runtime_if_needed() {
-    reset_runtime_caches_for_tests();
-    let native = storage_to_native_tensor(
-        &Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap(),
-        &[3, 3],
+fn storage_native_roundtrip_structured_c64_densifies_at_public_bridge() {
+    let storage = Storage::new_structured(
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+        vec![2],
+        vec![1],
+        vec![0, 0],
     )
     .unwrap();
+    let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
+    let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
+    let expected = storage.to_dense_storage(&[2, 2]);
 
+    assert_eq!(native.shape(), &[2, 2]);
+    assert_storage_eq(&roundtrip, &expected);
+}
+
+#[test]
+fn dense_native_tensor_column_major_roundtrip_preserves_linearization() {
+    let native =
+        dense_native_tensor_from_col_major(&[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
+    let values = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
+    assert_eq!(values, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+}
+
+#[test]
+fn dense_native_tensor_from_col_major_c64_roundtrip() {
+    let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)];
+    let native = dense_native_tensor_from_col_major(&data, &[2]).unwrap();
+    let values = native_tensor_primal_to_dense_c64_col_major(&native).unwrap();
+    assert_eq!(values, data);
+}
+
+#[test]
+fn diag_native_tensor_from_col_major_f64_roundtrip() {
+    let data = vec![1.0_f64, 2.0, 3.0];
+    let native = diag_native_tensor_from_col_major(&data, 2).unwrap();
+    let diag_values = native_tensor_primal_to_diag_f64(&native).unwrap();
     let dense = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
 
+    assert_eq!(diag_values, data);
     assert_eq!(
         dense,
         vec![
-            2.0, 0.0, 0.0, //
-            0.0, -1.0, 0.0, //
-            0.0, 0.0, 4.0,
+            1.0, 0.0, 0.0, //
+            0.0, 2.0, 0.0, //
+            0.0, 0.0, 3.0,
         ]
     );
-    assert_eq!(default_runtime_install_count_for_tests(), 1);
-}
-
-#[test]
-fn native_dense_materialization_reinstalls_scoped_default_runtime_per_call() {
-    reset_runtime_caches_for_tests();
-    let native = storage_to_native_tensor(
-        &Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap(),
-        &[3, 3],
-    )
-    .unwrap();
-
-    let first = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
-    let installs_after_first = default_runtime_install_count_for_tests();
-    let second = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
-
-    assert_eq!(first, second);
-    assert_eq!(installs_after_first, 1);
-    assert_eq!(default_runtime_install_count_for_tests(), 2);
-}
-
-#[test]
-fn native_dense_materialization_survives_external_runtime_scope_changes() {
-    reset_runtime_caches_for_tests();
-    let native = storage_to_native_tensor(
-        &Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap(),
-        &[3, 3],
-    )
-    .unwrap();
-
-    let outer_guard = tenferro::set_default_runtime(tenferro::RuntimeContext::Cpu(
-        tenferro_prims::CpuContext::new(2),
-    ));
-    let first = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
-    drop(outer_guard);
-
-    let second = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
-
-    assert_eq!(first, second);
-}
-
-#[test]
-fn storage_native_roundtrip_structured_densifies_at_public_bridge() {
-    let storage = Storage::new_structured(
-        vec![1.0_f64, 2.0, 3.0, 4.0],
-        vec![2, 2],
-        vec![1, 2],
-        vec![0, 1, 1],
-    )
-    .unwrap();
-
-    let native = storage_to_native_tensor(&storage, &[2, 2, 2]).unwrap();
-    let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
-    let expected = storage.to_dense_storage(&[2, 2, 2]);
-
-    assert_eq!(native.dims(), &[2, 2, 2]);
-    assert!(native.is_dense());
-    assert_storage_eq(&roundtrip, &expected);
 }
 
 #[test]
@@ -172,7 +133,6 @@ fn native_snapshot_materializes_lazy_conjugation() {
     )
     .unwrap();
     let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
-
     let conjugated = conj_native_tensor(&native).unwrap();
     let snapshot = native_tensor_primal_to_storage(&conjugated).unwrap();
 
@@ -212,30 +172,7 @@ fn native_einsum_accepts_unsorted_nonfirst_operand_labels() {
 }
 
 #[test]
-fn native_einsum_promotes_detached_real_operands_for_complex_result() {
-    let lhs = dense_native_tensor_from_col_major(
-        &[
-            Complex64::new(1.0, 2.0),
-            Complex64::new(0.0, 0.0),
-            Complex64::new(0.0, 0.0),
-            Complex64::new(3.0, -1.0),
-        ],
-        &[2, 2],
-    )
-    .unwrap();
-    let rhs = dense_native_tensor_from_col_major(&[2.0_f64, -1.0], &[2]).unwrap();
-
-    let out = einsum_native_tensors(&[(&lhs, &[0, 1]), (&rhs, &[1])], &[0]).unwrap();
-    let values = native_tensor_primal_to_dense_c64_col_major(&out).unwrap();
-
-    assert_eq!(
-        values,
-        vec![Complex64::new(2.0, 4.0), Complex64::new(-3.0, 1.0)]
-    );
-}
-
-#[test]
-fn einsum_native_tensors_dense_primal_binary_routes_through_frontend_fallback() {
+fn einsum_native_tensors_dense_binary_records_frontend_fallback_profile() {
     struct ProfileGuard;
 
     impl Drop for ProfileGuard {
@@ -245,25 +182,17 @@ fn einsum_native_tensors_dense_primal_binary_routes_through_frontend_fallback() 
         }
     }
 
-    reset_runtime_caches_for_tests();
     reset_native_einsum_profile();
     set_native_einsum_profile_enabled_for_tests(true);
     let _guard = ProfileGuard;
+
     let lhs = dense_native_tensor_from_col_major(&[1.0_f64, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
     let rhs =
         dense_native_tensor_from_col_major(&[10.0_f64, 30.0, 50.0, 20.0, 40.0, 60.0], &[3, 2])
             .unwrap();
-
     let out = einsum_native_tensors(&[(&lhs, &[0, 1]), (&rhs, &[2, 1])], &[0, 2]).unwrap();
-    let snapshot = native_tensor_primal_to_storage(&out).unwrap();
-    let expected =
-        Storage::from_dense_col_major(vec![50.0, 110.0, 110.0, 250.0, 170.0, 390.0], &[2, 3])
-            .unwrap();
 
-    assert_eq!(out.dims(), &[2, 3]);
-    assert_storage_eq(&snapshot, &expected);
-    assert_eq!(cpu_context_install_count_for_tests(), 0);
-    assert_eq!(default_runtime_install_count_for_tests(), 1);
+    assert_eq!(out.shape(), &[2, 3]);
     assert_eq!(
         recorded_native_einsum_call_count(NativeEinsumPath::FrontendFallback),
         1
@@ -272,7 +201,6 @@ fn einsum_native_tensors_dense_primal_binary_routes_through_frontend_fallback() 
 
 #[test]
 fn contract_native_tensor_restores_rhs_free_axis_order() {
-    reset_runtime_caches_for_tests();
     let lhs = storage_to_native_tensor(
         &Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap(),
         &[2, 2],
@@ -286,90 +214,23 @@ fn contract_native_tensor_restores_rhs_free_axis_order() {
 
     let out = contract_native_tensor(&lhs, &[1], &rhs, &[1]).unwrap();
     let snapshot = native_tensor_primal_to_storage(&out).unwrap();
-
     let expected = Storage::from_dense_col_major(vec![50.0, 110.0, 110.0, 250.0], &[2, 2]).unwrap();
+
     assert_storage_eq(&snapshot, &expected);
-}
-
-#[test]
-fn with_tenferro_ctx_reuses_cached_cpu_context() {
-    reset_runtime_caches_for_tests();
-
-    let a = tenferro_tensor::Tensor::<f64>::from_slice(
-        &[1.0, 3.0, 2.0, 4.0],
-        &[2, 2],
-        tenferro_tensor::MemoryOrder::ColumnMajor,
-    )
-    .unwrap();
-
-    let first = with_tenferro_ctx("test_qr", |ctx| {
-        tenferro_linalg::qr(ctx, &a).map_err(|e| anyhow::anyhow!("qr failed: {e}"))
-    })
-    .unwrap();
-    let installs_after_first = cpu_context_install_count_for_tests();
-    let second = with_tenferro_ctx("test_qr", |ctx| {
-        tenferro_linalg::qr(ctx, &a).map_err(|e| anyhow::anyhow!("qr failed: {e}"))
-    })
-    .unwrap();
-
-    assert_eq!(first.q.dims(), second.q.dims());
-    assert_eq!(first.r.dims(), second.r.dims());
-    assert_eq!(cpu_context_install_count_for_tests(), installs_after_first);
-    assert_eq!(installs_after_first, 1);
-}
-
-#[test]
-fn with_tenferro_ctx_allows_same_thread_nested_calls() {
-    reset_runtime_caches_for_tests();
-
-    let nested = std::panic::catch_unwind(|| {
-        with_tenferro_ctx("outer", |_outer| {
-            with_tenferro_ctx("inner", |_inner| Ok::<_, anyhow::Error>(()))
-        })
-    });
-
-    assert!(nested.is_ok(), "nested with_tenferro_ctx panicked");
-    assert!(nested.unwrap().is_ok());
-}
-
-#[test]
-fn cpu_threads_uses_tenferro_default_when_env_is_unset() {
-    assert_eq!(
-        cpu_threads_from_env_value(None).unwrap(),
-        CpuContext::default_num_threads()
-    );
-}
-
-#[test]
-fn cpu_threads_rejects_zero_override() {
-    let err = cpu_threads_from_env_value(Some("0")).expect_err("zero override must be rejected");
-    assert!(err.to_string().contains("T4A_TENFERRO_CPU_THREADS"));
-}
-
-#[test]
-fn dense_native_tensor_column_major_roundtrip_preserves_linearization() {
-    let native =
-        dense_native_tensor_from_col_major(&[1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]).unwrap();
-
-    let values = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
-
-    assert_eq!(values, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 }
 
 #[test]
 fn permute_storage_native_dense_matches_expected_data() {
     let storage =
         Storage::from_dense_col_major(vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0], &[2, 3]).unwrap();
-
-    let native = permute_storage_native(&storage, &[2, 3], &[1, 0]).unwrap();
-
+    let permuted = permute_storage_native(&storage, &[2, 3], &[1, 0]).unwrap();
     let expected =
         Storage::from_dense_col_major(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[3, 2]).unwrap();
-    assert_storage_eq(&native, &expected);
+    assert_storage_eq(&permuted, &expected);
 }
 
 #[test]
-fn reshape_col_major_native_tensor_handles_noncontiguous_permuted_input() {
+fn reshape_col_major_native_tensor_handles_permuted_input() {
     let native = dense_native_tensor_from_col_major(
         &(1..=24).map(|x| x as f64).collect::<Vec<_>>(),
         &[2, 3, 2, 2],
@@ -384,50 +245,6 @@ fn reshape_col_major_native_tensor_handles_noncontiguous_permuted_input() {
     assert_eq!(reshaped_values, permuted_values);
 }
 
-// ===== contract_storage_native =====
-
-#[test]
-fn contract_storage_native_dense_f64() {
-    let a = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-    let b = Storage::from_dense_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
-
-    let result = contract_storage_native(&a, &[2, 2], &[1], &b, &[2, 2], &[0], &[2, 2]).unwrap();
-
-    // A = [[1,2],[3,4]], B = [[5,6],[7,8]], C = A@B = [[19,22],[43,50]]
-    // col-major: [19, 43, 22, 50]
-    let expected = Storage::from_dense_col_major(vec![19.0, 43.0, 22.0, 50.0], &[2, 2]).unwrap();
-    assert_storage_eq(&result, &expected);
-}
-
-// ===== outer_product_storage_native =====
-
-#[test]
-fn outer_product_storage_native_produces_correct_shape() {
-    let a = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let b = Storage::from_dense_col_major(vec![3.0, 4.0, 5.0], &[3]).unwrap();
-
-    let result = outer_product_storage_native(&a, &[2], &b, &[3], &[2, 3]).unwrap();
-
-    // a[i] * b[j]: col-major [2,3]
-    // [1*3, 2*3, 1*4, 2*4, 1*5, 2*5] = [3, 6, 4, 8, 5, 10]
-    let expected =
-        Storage::from_dense_col_major(vec![3.0, 6.0, 4.0, 8.0, 5.0, 10.0], &[2, 3]).unwrap();
-    assert_storage_eq(&result, &expected);
-}
-
-// ===== scale_storage_native =====
-
-#[test]
-fn scale_storage_native_scales_elements() {
-    let s = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
-    let scalar = crate::AnyScalar::new_real(2.0);
-
-    let result = scale_storage_native(&s, &[3], &scalar).unwrap();
-
-    let expected = Storage::from_dense_col_major(vec![2.0, 4.0, 6.0], &[3]).unwrap();
-    assert_storage_eq(&result, &expected);
-}
-
 #[test]
 fn scale_native_tensor_promotes_real_scalar_for_complex_tensor() {
     let native = dense_native_tensor_from_col_major(
@@ -436,7 +253,6 @@ fn scale_native_tensor_promotes_real_scalar_for_complex_tensor() {
     )
     .unwrap();
     let scalar = crate::AnyScalar::new_real(2.0);
-
     let scaled = scale_native_tensor(&native, &scalar).unwrap();
     let values = native_tensor_primal_to_dense_c64_col_major(&scaled).unwrap();
 
@@ -444,22 +260,6 @@ fn scale_native_tensor_promotes_real_scalar_for_complex_tensor() {
         values,
         vec![Complex64::new(2.0, 4.0), Complex64::new(-1.0, 2.0)]
     );
-}
-
-// ===== axpby_storage_native =====
-
-#[test]
-fn axpby_storage_native_linear_combination() {
-    let lhs = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
-    let rhs = Storage::from_dense_col_major(vec![3.0, 4.0], &[2]).unwrap();
-    let a = crate::AnyScalar::new_real(2.0);
-    let b = crate::AnyScalar::new_real(3.0);
-
-    let result = axpby_storage_native(&lhs, &[2], &a, &rhs, &[2], &b).unwrap();
-
-    // 2*1 + 3*3 = 11, 2*2 + 3*4 = 16
-    let expected = Storage::from_dense_col_major(vec![11.0, 16.0], &[2]).unwrap();
-    assert_storage_eq(&result, &expected);
 }
 
 #[test]
@@ -476,7 +276,6 @@ fn axpby_native_tensor_promotes_real_scalars_for_complex_tensors() {
     .unwrap();
     let a = crate::AnyScalar::new_real(2.0);
     let b = crate::AnyScalar::new_real(-1.0);
-
     let combined = axpby_native_tensor(&lhs, &a, &rhs, &b).unwrap();
     let values = native_tensor_primal_to_dense_c64_col_major(&combined).unwrap();
 
@@ -486,112 +285,57 @@ fn axpby_native_tensor_promotes_real_scalars_for_complex_tensors() {
     );
 }
 
-// ===== native_tensor_primal_to_diag =====
-
 #[test]
-fn native_tensor_primal_to_diag_f64_extracts_diagonal() {
-    let storage = Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
-    let native = storage_to_native_tensor(&storage, &[3, 3]).unwrap();
+fn scale_and_axpby_storage_native_roundtrip() {
+    let storage = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
+    let scalar = crate::AnyScalar::new_real(2.0);
+    let scaled = scale_storage_native(&storage, &[3], &scalar).unwrap();
+    let expected_scaled = Storage::from_dense_col_major(vec![2.0, 4.0, 6.0], &[3]).unwrap();
+    assert_storage_eq(&scaled, &expected_scaled);
 
-    let diag_values = native_tensor_primal_to_diag_f64(&native).unwrap();
-
-    assert_eq!(diag_values, vec![2.0, -1.0, 4.0]);
-}
-
-#[test]
-fn native_tensor_primal_to_diag_c64_extracts_diagonal() {
-    let storage =
-        Storage::from_diag_col_major(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)], 2)
-            .unwrap();
-    let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
-
-    let diag_values = native_tensor_primal_to_diag_c64(&native).unwrap();
-
-    assert_eq!(
-        diag_values,
-        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]
-    );
-}
-
-// ===== dense_native_tensor_from_col_major for c64 =====
-
-#[test]
-fn dense_native_tensor_from_col_major_c64_roundtrip() {
-    let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)];
-    let native = dense_native_tensor_from_col_major(&data, &[2]).unwrap();
-
-    let values = native_tensor_primal_to_dense_c64_col_major(&native).unwrap();
-
-    assert_eq!(values, data);
-}
-
-// ===== diag_native_tensor_from_col_major =====
-
-#[test]
-fn diag_native_tensor_from_col_major_f64_roundtrip() {
-    let data = vec![1.0_f64, 2.0, 3.0];
-    let native = diag_native_tensor_from_col_major(&data, 2).unwrap();
-
-    assert!(!native.is_diag());
-    let diag_values = native_tensor_primal_to_diag_f64(&native).unwrap();
-    assert_eq!(diag_values, data);
-    let dense = native_tensor_primal_to_dense_f64_col_major(&native).unwrap();
-    assert_eq!(
-        dense,
-        vec![
-            1.0, 0.0, 0.0, //
-            0.0, 2.0, 0.0, //
-            0.0, 0.0, 3.0,
-        ]
-    );
-}
-
-// ===== structured storage roundtrip for c64 =====
-
-#[test]
-fn storage_native_roundtrip_structured_c64_densifies_at_public_bridge() {
-    let storage = Storage::new_structured(
-        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
-        vec![2],
-        vec![1],
-        vec![0, 0],
+    let rhs = Storage::from_dense_col_major(vec![3.0, 4.0, 5.0], &[3]).unwrap();
+    let combined = axpby_storage_native(
+        &storage,
+        &[3],
+        &crate::AnyScalar::new_real(2.0),
+        &rhs,
+        &[3],
+        &crate::AnyScalar::new_real(3.0),
     )
     .unwrap();
-
-    let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
-    let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
-    let expected = storage.to_dense_storage(&[2, 2]);
-
-    assert_eq!(native.dims(), &[2, 2]);
-    assert!(native.is_dense());
-    assert_storage_eq(&roundtrip, &expected);
+    let expected_combined = Storage::from_dense_col_major(vec![11.0, 16.0, 21.0], &[3]).unwrap();
+    assert_storage_eq(&combined, &expected_combined);
 }
-
-// ===== sum_native_tensor for f64 =====
 
 #[test]
-fn sum_native_tensor_returns_f64_scalar() {
-    let storage = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
-    let native = storage_to_native_tensor(&storage, &[3]).unwrap();
-
-    let sum = sum_native_tensor(&native).unwrap();
-
-    assert!(sum.is_real());
-    assert_eq!(sum.real(), 6.0);
+fn outer_product_storage_native_produces_correct_shape() {
+    let a = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0, 4.0, 5.0], &[3]).unwrap();
+    let result = outer_product_storage_native(&a, &[2], &b, &[3], &[2, 3]).unwrap();
+    let expected =
+        Storage::from_dense_col_major(vec![3.0, 6.0, 4.0, 8.0, 5.0, 10.0], &[2, 3]).unwrap();
+    assert_storage_eq(&result, &expected);
 }
 
-// ===== tangent_native_tensor =====
+#[test]
+fn qr_and_svd_native_tensor_return_expected_shapes() {
+    let native = dense_native_tensor_from_col_major(&[1.0_f64, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+
+    let (q, r) = qr_native_tensor(&native).unwrap();
+    assert_eq!(q.shape(), &[2, 2]);
+    assert_eq!(r.shape(), &[2, 2]);
+
+    let (u, s, vt) = svd_native_tensor(&native).unwrap();
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+}
 
 #[test]
 fn tangent_native_tensor_returns_none_for_primal() {
     let native = dense_native_tensor_from_col_major(&[1.0_f64, 2.0], &[2]).unwrap();
-
-    let tangent = tangent_native_tensor(&native);
-
-    assert!(tangent.is_none());
+    assert!(tangent_native_tensor(&native).is_none());
 }
-
-// ===== einsum with empty operands =====
 
 #[test]
 fn einsum_native_tensors_rejects_empty_operands() {
@@ -602,35 +346,6 @@ fn einsum_native_tensors_rejects_empty_operands() {
         .to_string()
         .contains("at least one operand"));
 }
-
-#[test]
-fn qr_native_tensor_dense_primal_uses_default_runtime_path() {
-    reset_runtime_caches_for_tests();
-    let native = dense_native_tensor_from_col_major(&[1.0_f64, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-
-    let (q, r) = qr_native_tensor(&native).unwrap();
-
-    assert_eq!(q.dims(), &[2, 2]);
-    assert_eq!(r.dims(), &[2, 2]);
-    assert_eq!(cpu_context_install_count_for_tests(), 0);
-    assert_eq!(default_runtime_install_count_for_tests(), 1);
-}
-
-#[test]
-fn svd_native_tensor_dense_primal_uses_default_runtime_path() {
-    reset_runtime_caches_for_tests();
-    let native = dense_native_tensor_from_col_major(&[1.0_f64, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
-
-    let (u, s, vt) = svd_native_tensor(&native).unwrap();
-
-    assert_eq!(u.dims(), &[2, 2]);
-    assert_eq!(s.dims(), &[2]);
-    assert_eq!(vt.dims(), &[2, 2]);
-    assert_eq!(cpu_context_install_count_for_tests(), 0);
-    assert_eq!(default_runtime_install_count_for_tests(), 1);
-}
-
-// ===== build_binary_einsum_ids error paths =====
 
 #[test]
 fn build_binary_einsum_ids_rejects_mismatched_axes_len() {

--- a/crates/tensor4all-tensorbackend/src/tensor_element.rs
+++ b/crates/tensor4all-tensorbackend/src/tensor_element.rs
@@ -1,76 +1,53 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use num_complex::{Complex32, Complex64};
-use tenferro::Tensor as NativeTensor;
-use tenferro_tensor::{MemoryOrder, Tensor as TypedTensor};
+use tenferro::{DType, Tensor as NativeTensor, TensorScalar};
 
 /// Public scalar element types supported by tensor4all dense/diag constructors.
 ///
-/// Implemented for `f32`, `f64`, `Complex32`, and `Complex64`. Provides
-/// constructors to build native tensors from array data and extractors to
-/// materialize tensor values back into Rust vectors.
+/// Implemented for `f32`, `f64`, `Complex32`, and `Complex64`.
 ///
 /// # Examples
 ///
 /// ```
 /// use tensor4all_tensorbackend::TensorElement;
 ///
-/// // Build a 2-element dense native tensor from f64 data
 /// let t = f64::dense_native_tensor_from_col_major(&[1.0, 2.0], &[2]).unwrap();
-/// assert_eq!(t.dims(), &[2]);
+/// assert_eq!(t.shape(), &[2]);
 ///
-/// // Extract values back
 /// let vals = f64::dense_values_from_native_col_major(&t).unwrap();
 /// assert_eq!(vals, vec![1.0, 2.0]);
 /// ```
-pub trait TensorElement: Copy + Send + Sync + 'static {
-    /// Build a native tensor from column-major dense data.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `data.len()` does not match the product of `dims`.
+pub trait TensorElement: TensorScalar + Copy + Send + Sync + 'static {
+    /// Build a dense native tensor from column-major data.
     fn dense_native_tensor_from_col_major(data: &[Self], dims: &[usize]) -> Result<NativeTensor>;
 
-    /// Build a native diagonal tensor from column-major diagonal payload data.
-    ///
-    /// Creates a tensor with `logical_rank` axes, each of size `data.len()`.
-    /// Internally stores only the diagonal entries.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `logical_rank` is zero.
+    /// Build a diagonal native tensor from column-major diagonal payload data.
     fn diag_native_tensor_from_col_major(
         data: &[Self],
         logical_rank: usize,
     ) -> Result<NativeTensor>;
 
-    /// Build a rank-0 native tensor (scalar tensor).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if tensor construction fails.
+    /// Build a rank-0 native tensor.
     fn scalar_native_tensor(value: Self) -> Result<NativeTensor>;
 
-    /// Materialize dense column-major primal values from a native tensor.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the tensor's scalar type does not match `Self`.
+    /// Materialize dense column-major values from a native tensor.
     fn dense_values_from_native_col_major(tensor: &NativeTensor) -> Result<Vec<Self>>;
 
-    /// Materialize diagonal payload values from a native diagonal tensor.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the tensor is not square or rank < 1.
+    /// Materialize diagonal values from a dense native tensor.
     fn diag_values_from_native_temp(tensor: &NativeTensor) -> Result<Vec<Self>>;
 }
 
-fn diagonal_multi_index(rank: usize, value: usize) -> Vec<usize> {
-    vec![value; rank]
+fn tensor_dtype_name(dtype: DType) -> &'static str {
+    match dtype {
+        DType::F32 => "f32",
+        DType::F64 => "f64",
+        DType::C32 => "c32",
+        DType::C64 => "c64",
+    }
 }
 
 fn dense_diagonal_values<T: Copy + Default>(diag: &[T], logical_rank: usize) -> Result<Vec<T>> {
-    anyhow::ensure!(
+    ensure!(
         logical_rank >= 1,
         "diagonal tensor construction requires at least one logical axis"
     );
@@ -78,14 +55,13 @@ fn dense_diagonal_values<T: Copy + Default>(diag: &[T], logical_rank: usize) -> 
     let dims = vec![diag_len; logical_rank];
     let total_len = dims.iter().product::<usize>();
     let mut dense = vec![T::default(); total_len];
-    let stride_prefix = (0..logical_rank)
-        .scan(1usize, |state, _| {
-            let current = *state;
-            *state = state.saturating_mul(diag_len);
+    let diagonal_stride = (0..logical_rank)
+        .scan(1usize, |stride, _| {
+            let current = *stride;
+            *stride = stride.saturating_mul(diag_len);
             Some(current)
         })
-        .collect::<Vec<_>>();
-    let diagonal_stride = stride_prefix.iter().sum::<usize>();
+        .sum::<usize>();
     for (i, value) in diag.iter().copied().enumerate() {
         dense[i * diagonal_stride] = value;
     }
@@ -93,15 +69,21 @@ fn dense_diagonal_values<T: Copy + Default>(diag: &[T], logical_rank: usize) -> 
 }
 
 macro_rules! impl_tensor_element {
-    ($ty:ty, $variant:ident, $payload:ident) => {
+    ($ty:ty, $dtype:expr) => {
         impl TensorElement for $ty {
             fn dense_native_tensor_from_col_major(
                 data: &[Self],
                 dims: &[usize],
             ) -> Result<NativeTensor> {
-                let typed = TypedTensor::<Self>::from_slice(data, dims, MemoryOrder::ColumnMajor)
-                    .map_err(|e| anyhow!("failed to build native dense tensor: {e}"))?;
-                Ok(NativeTensor::from(typed))
+                let expected_len: usize = dims.iter().product();
+                ensure!(
+                    data.len() == expected_len,
+                    "dense tensor len {} does not match dims {:?} (expected {})",
+                    data.len(),
+                    dims,
+                    expected_len
+                );
+                Ok(NativeTensor::new(dims.to_vec(), data.to_vec()))
             }
 
             fn diag_native_tensor_from_col_major(
@@ -114,47 +96,49 @@ macro_rules! impl_tensor_element {
             }
 
             fn scalar_native_tensor(value: Self) -> Result<NativeTensor> {
-                let typed =
-                    TypedTensor::<Self>::from_slice(&[value], &[], MemoryOrder::ColumnMajor)
-                        .map_err(|e| anyhow!("failed to build native rank-0 tensor: {e}"))?;
-                Ok(NativeTensor::from(typed))
+                Ok(NativeTensor::new(vec![], vec![value]))
             }
 
             fn dense_values_from_native_col_major(tensor: &NativeTensor) -> Result<Vec<Self>> {
-                let dense = if tensor.is_dense() {
-                    tensor.try_to_vec::<Self>()
-                } else {
-                    tensor.to_dense()?.try_to_vec::<Self>()
-                }
-                .map_err(|e| anyhow!("dense native tensor extraction failed: {e}"))?;
-                Ok(dense)
+                tensor
+                    .as_slice::<Self>()
+                    .map(|values| values.to_vec())
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "tensor dtype mismatch: expected {}, got {}",
+                            tensor_dtype_name($dtype),
+                            tensor_dtype_name(tensor.dtype())
+                        )
+                    })
             }
 
             fn diag_values_from_native_temp(tensor: &NativeTensor) -> Result<Vec<Self>> {
-                let rank = tensor.ndim();
-                anyhow::ensure!(rank >= 1, "diagonal native tensor rank must be at least 1");
-                let diag_len = tensor.dims()[0];
-                anyhow::ensure!(
-                    tensor.dims().iter().all(|&dim| dim == diag_len),
-                    "expected square/equal logical dims for diagonal extraction, got {:?}",
-                    tensor.dims()
+                let shape = tensor.shape();
+                ensure!(
+                    !shape.is_empty(),
+                    "diagonal extraction requires rank >= 1, got scalar tensor"
                 );
-                let mut values = Vec::with_capacity(diag_len);
-                for i in 0..diag_len {
-                    let index = diagonal_multi_index(rank, i);
-                    values.push(
-                        tensor.try_get::<Self>(&index).map_err(|e| {
-                            anyhow!("diagonal native tensor extraction failed: {e}")
-                        })?,
-                    );
-                }
-                Ok(values)
+                let diag_len = shape[0];
+                ensure!(
+                    shape.iter().all(|&dim| dim == diag_len),
+                    "expected square/equal dims for diagonal extraction, got {:?}",
+                    shape
+                );
+                let dense = Self::dense_values_from_native_col_major(tensor)?;
+                let diagonal_stride = (0..shape.len())
+                    .scan(1usize, |stride, _| {
+                        let current = *stride;
+                        *stride = stride.saturating_mul(diag_len);
+                        Some(current)
+                    })
+                    .sum::<usize>();
+                Ok((0..diag_len).map(|i| dense[i * diagonal_stride]).collect())
             }
         }
     };
 }
 
-impl_tensor_element!(f32, F32, payload);
-impl_tensor_element!(f64, F64, payload);
-impl_tensor_element!(Complex32, C32, payload);
-impl_tensor_element!(Complex64, C64, payload);
+impl_tensor_element!(f32, DType::F32);
+impl_tensor_element!(f64, DType::F64);
+impl_tensor_element!(Complex32, DType::C32);
+impl_tensor_element!(Complex64, DType::C64);

--- a/crates/tensor4all-tensorbackend/tests/bench_einsum_native.rs
+++ b/crates/tensor4all-tensorbackend/tests/bench_einsum_native.rs
@@ -7,7 +7,8 @@ use std::hint::black_box;
 use std::time::{Duration, Instant};
 
 use tensor4all_tensorbackend::{
-    dense_native_tensor_from_col_major, einsum_native_tensors, print_and_reset_contract_profile,
+    dense_native_tensor_from_col_major, einsum_native_tensors,
+    print_and_reset_native_einsum_profile, reset_native_einsum_profile,
 };
 
 const PHYS_DIM: usize = 2;
@@ -44,26 +45,24 @@ fn time_best_of<R>(label: &str, repeats: usize, mut f: impl FnMut() -> R) -> Dur
 
 #[cfg(feature = "einsum-dispatch-profile")]
 fn reset_dispatch_profile() {
-    tenferro_einsum::print_and_reset_profile();
-    print_and_reset_contract_profile();
+    reset_native_einsum_profile();
 }
 
 #[cfg(not(feature = "einsum-dispatch-profile"))]
 fn reset_dispatch_profile() {
-    print_and_reset_contract_profile();
+    reset_native_einsum_profile();
 }
 
 #[cfg(feature = "einsum-dispatch-profile")]
 fn print_dispatch_profile(label: &str) {
     eprintln!("  dispatch profile for {label}:");
-    tenferro_einsum::print_and_reset_profile();
-    print_and_reset_contract_profile();
+    print_and_reset_native_einsum_profile();
 }
 
 #[cfg(not(feature = "einsum-dispatch-profile"))]
 fn print_dispatch_profile(label: &str) {
     eprintln!("  dispatch profile for {label}:");
-    print_and_reset_contract_profile();
+    print_and_reset_native_einsum_profile();
 }
 
 fn run_dispatch_profile<R>(label: &str, repeats: usize, mut f: impl FnMut() -> R) {
@@ -89,13 +88,13 @@ fn bench_native_einsum_arity() {
     assert_eq!(
         einsum_native_tensors(&[(&lhs, &[0, 1]), (&rhs, &[1, 2])], &[0, 2])
             .unwrap()
-            .dims(),
+            .shape(),
         &[BOND_DIM, BOND_DIM]
     );
     assert_eq!(
         einsum_native_tensors(&[(&a, &[0, 1]), (&b, &[0, 2]), (&c, &[0, 3])], &[1, 2, 3])
             .unwrap()
-            .dims(),
+            .shape(),
         &[BOND_DIM, BOND_DIM, BOND_DIM]
     );
     assert_eq!(
@@ -104,7 +103,7 @@ fn bench_native_einsum_arity() {
             &[1, 2, 3, 4]
         )
         .unwrap()
-        .dims(),
+        .shape(),
         &[BOND_DIM, BOND_DIM, BOND_DIM, BOND_DIM]
     );
 

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -21,4 +21,4 @@ faer = { workspace = true }
 [dev-dependencies]
 rand_chacha.workspace = true
 tenferro.workspace = true
-tenferro-prims.workspace = true
+tenferro-tensor.workspace = true

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -20,5 +20,3 @@ faer = { workspace = true }
 
 [dev-dependencies]
 rand_chacha.workspace = true
-tenferro.workspace = true
-tenferro-tensor.workspace = true

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -943,6 +943,9 @@ where
         eprintln!("replace/update:    {:?}", profile.replace_time);
         eprintln!("invalidate:        {:?}", profile.invalidate_time);
     }
+    // These are tensor4all-owned profiling hooks, intentionally kept during the
+    // migration so fit profiling still works without the removed tenferro
+    // runtime APIs.
     print_and_reset_contract_profile();
     print_and_reset_native_einsum_profile();
 

--- a/crates/tensor4all-treetn/tests/ad_treetn.rs
+++ b/crates/tensor4all-treetn/tests/ad_treetn.rs
@@ -25,111 +25,168 @@ fn make_three_site_mps_data() -> (Vec<Vec<DynIndex>>, Vec<Vec<f64>>) {
     (index_sets, data)
 }
 
-fn with_runtime<R>(f: impl FnOnce() -> R) -> R {
-    let _guard = tenferro::set_default_runtime(tenferro::RuntimeContext::Cpu(
-        tenferro_prims::CpuContext::new(1),
-    ));
-    f()
-}
-
 #[test]
 fn backward_ad_to_dense_propagates_gradients() {
-    with_runtime(|| {
-        let (index_sets, data) = make_three_site_mps_data();
+    let (index_sets, data) = make_three_site_mps_data();
 
-        let tensors: Vec<TensorDynLen> = index_sets
-            .iter()
-            .zip(&data)
-            .map(|(idx, d)| {
-                let mut t = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
-                t.set_requires_grad(true).unwrap();
-                t
-            })
-            .collect();
+    let tensors: Vec<TensorDynLen> = index_sets
+        .iter()
+        .zip(&data)
+        .map(|(idx, d)| {
+            TensorDynLen::from_dense(idx.clone(), d.clone())
+                .unwrap()
+                .enable_grad()
+        })
+        .collect();
 
-        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
-        let dense = ttn.to_dense().unwrap();
+    let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+    let dense = ttn.to_dense().unwrap();
 
-        // Contract dense with ones to get scalar = sum(dense)
-        let ones = TensorDynLen::from_dense(
-            dense.indices().to_vec(),
-            vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
-        )
-        .unwrap();
-        let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
+    // Contract dense with ones to get scalar = sum(dense)
+    let ones = TensorDynLen::from_dense(
+        dense.indices().to_vec(),
+        vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
+    )
+    .unwrap();
+    let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
 
-        scalar.backward(None).unwrap();
+    scalar.backward().unwrap();
 
-        for (i, &ni) in ttn.node_indices().iter().enumerate() {
-            let grad = ttn.tensor(ni).unwrap().grad().unwrap();
-            assert!(grad.is_some(), "node {i} has no gradient after backward");
-        }
-    });
+    for (i, &ni) in ttn.node_indices().iter().enumerate() {
+        let grad = ttn.tensor(ni).unwrap().grad().unwrap();
+        assert!(grad.is_some(), "node {i} has no gradient after backward");
+    }
 }
 
 #[test]
 fn backward_ad_gradient_matches_finite_diff() {
-    with_runtime(|| {
-        let (index_sets, data) = make_three_site_mps_data();
-        let eps = 1e-6;
+    let (index_sets, data) = make_three_site_mps_data();
+    let eps = 1e-6;
 
-        let tensors: Vec<TensorDynLen> = index_sets
-            .iter()
-            .zip(&data)
-            .map(|(idx, d)| {
-                let mut t = TensorDynLen::from_dense(idx.clone(), d.clone()).unwrap();
-                t.set_requires_grad(true).unwrap();
-                t
-            })
-            .collect();
+    let tensors: Vec<TensorDynLen> = index_sets
+        .iter()
+        .zip(&data)
+        .map(|(idx, d)| {
+            TensorDynLen::from_dense(idx.clone(), d.clone())
+                .unwrap()
+                .enable_grad()
+        })
+        .collect();
 
-        let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
-        let dense = ttn.to_dense().unwrap();
+    let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+    let dense = ttn.to_dense().unwrap();
 
-        let ones = TensorDynLen::from_dense(
-            dense.indices().to_vec(),
-            vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
-        )
-        .unwrap();
-        let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
+    let ones = TensorDynLen::from_dense(
+        dense.indices().to_vec(),
+        vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
+    )
+    .unwrap();
+    let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
 
-        scalar.backward(None).unwrap();
+    scalar.backward().unwrap();
 
-        // Verify gradient of first node vs finite difference
-        let node_0 = ttn.node_index(&0).unwrap();
-        let grad_t0 = ttn
-            .tensor(node_0)
+    // Verify gradient of first node vs finite difference
+    let node_0 = ttn.node_index(&0).unwrap();
+    let grad_t0 = ttn
+        .tensor(node_0)
+        .unwrap()
+        .grad()
+        .unwrap()
+        .expect("t0 gradient missing");
+    let grad_t0_vec = grad_t0.to_vec::<f64>().unwrap();
+
+    for elem_idx in 0..data[0].len() {
+        let make_perturbed_sum = |delta: f64| -> f64 {
+            let tensors: Vec<TensorDynLen> = index_sets
+                .iter()
+                .zip(&data)
+                .enumerate()
+                .map(|(i, (idx, d))| {
+                    let mut d = d.clone();
+                    if i == 0 {
+                        d[elem_idx] += delta;
+                    }
+                    TensorDynLen::from_dense(idx.clone(), d).unwrap()
+                })
+                .collect();
+            let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+            ttn.to_dense().unwrap().sum().real()
+        };
+
+        let fd = (make_perturbed_sum(eps) - make_perturbed_sum(-eps)) / (2.0 * eps);
+        let ad = grad_t0_vec[elem_idx];
+        let err = (ad - fd).abs();
+        assert!(
+            err < 1e-4,
+            "backward grad[0][{elem_idx}] = {ad}, finite diff = {fd}, err = {err}"
+        );
+    }
+}
+
+#[test]
+fn backward_accumulates_until_clear_grad_across_treetn_nodes() {
+    let (index_sets, data) = make_three_site_mps_data();
+
+    let tensors: Vec<TensorDynLen> = index_sets
+        .iter()
+        .zip(&data)
+        .map(|(idx, d)| {
+            TensorDynLen::from_dense(idx.clone(), d.clone())
+                .unwrap()
+                .enable_grad()
+        })
+        .collect();
+
+    let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
+    let dense = ttn.to_dense().unwrap();
+    let ones = TensorDynLen::from_dense(
+        dense.indices().to_vec(),
+        vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
+    )
+    .unwrap();
+
+    let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
+    scalar.backward().unwrap();
+
+    let first_grads: Vec<Vec<f64>> = ttn
+        .node_indices()
+        .iter()
+        .map(|&ni| {
+            ttn.tensor(ni)
+                .unwrap()
+                .grad()
+                .unwrap()
+                .expect("missing gradient after first backward")
+                .to_vec::<f64>()
+                .unwrap()
+        })
+        .collect();
+
+    let scalar = contract_multi(&[&dense, &ones], AllowedPairs::All).unwrap();
+    scalar.backward().unwrap();
+
+    for (node_pos, (&ni, first_grad)) in ttn.node_indices().iter().zip(&first_grads).enumerate() {
+        let grad = ttn
+            .tensor(ni)
             .unwrap()
             .grad()
             .unwrap()
-            .expect("t0 gradient missing");
-        let grad_t0_vec = grad_t0.to_vec::<f64>().unwrap();
-
-        for elem_idx in 0..data[0].len() {
-            let make_perturbed_sum = |delta: f64| -> f64 {
-                let tensors: Vec<TensorDynLen> = index_sets
-                    .iter()
-                    .zip(&data)
-                    .enumerate()
-                    .map(|(i, (idx, d))| {
-                        let mut d = d.clone();
-                        if i == 0 {
-                            d[elem_idx] += delta;
-                        }
-                        TensorDynLen::from_dense(idx.clone(), d).unwrap()
-                    })
-                    .collect();
-                let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
-                ttn.to_dense().unwrap().sum().real()
-            };
-
-            let fd = (make_perturbed_sum(eps) - make_perturbed_sum(-eps)) / (2.0 * eps);
-            let ad = grad_t0_vec[elem_idx];
-            let err = (ad - fd).abs();
+            .expect("missing gradient after second backward")
+            .to_vec::<f64>()
+            .unwrap();
+        assert_eq!(grad.len(), first_grad.len());
+        for (elem_pos, (&got, &expected_once)) in grad.iter().zip(first_grad).enumerate() {
+            let expected = 2.0 * expected_once;
+            let err = (got - expected).abs();
             assert!(
-                err < 1e-4,
-                "backward grad[0][{elem_idx}] = {ad}, finite diff = {fd}, err = {err}"
+                err < 1e-10,
+                "node {node_pos} grad[{elem_pos}] = {got}, expected {expected}, err = {err}"
             );
         }
-    });
+    }
+
+    for ni in ttn.node_indices() {
+        ttn.tensor(ni).unwrap().clear_grad().unwrap();
+        assert!(ttn.tensor(ni).unwrap().grad().unwrap().is_none());
+    }
 }

--- a/docs/book-tests/Cargo.toml
+++ b/docs/book-tests/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 # This crate exists solely to test mdBook guide code examples.
 # Code blocks in the markdown files are tested as doctests via
 # `cargo test --doc -p book-tests --release`.
+# The standalone mdBook harness reuses this crate's resolved `--extern` flags
+# through `scripts/test-mdbook.sh`.
 
 [dependencies]
 tensor4all-core = { path = "../../crates/tensor4all-core" }

--- a/docs/book-tests/src/lib.rs
+++ b/docs/book-tests/src/lib.rs
@@ -1,8 +1,18 @@
 //! Test harness for mdBook guide code examples.
 //!
-//! Each module embeds a markdown guide file via `include_str!`. Running
+//! Each module embeds a markdown file via `include_str!`. Running
 //! `cargo test --doc -p book-tests` executes every fenced Rust code block
 //! in these files as a doctest.
+//!
+//! `scripts/test-mdbook.sh` reuses this crate's resolved `--extern` flags to
+//! run the same snippets through `mdbook test docs/book`, avoiding ambiguous
+//! dependency resolution from the workspace-wide `target/release/deps` cache.
+//!
+//! The repository root `README.md` is included here as well so its short
+//! runnable examples stay covered by CI.
+
+#[doc = include_str!("../../../README.md")]
+mod root_readme {}
 
 #[doc = include_str!("../../book/src/getting-started.md")]
 mod getting_started {}

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -10,6 +10,9 @@ The library is structured as a workspace of independent crates under `crates/`, 
 
 Source code and issue tracker: [github.com/tensor4all/tensor4all-rs](https://github.com/tensor4all/tensor4all-rs)
 
+The repository root `README.md` stays intentionally concise. Longer runnable
+examples live in this guide and the guide examples are exercised in CI.
+
 ---
 
 ## Where to start

--- a/docs/design/review-eagertensor-migration-v2.md
+++ b/docs/design/review-eagertensor-migration-v2.md
@@ -1,0 +1,192 @@
+# Review Refresh: EagerTensor Migration Design v2
+
+Date: 2026-04-13
+Reviewer: Codex CLI
+Design doc: `docs/design/symbolic-shape-and-tenferro-migration.md`
+
+---
+
+## Resolved Upstream Blockers
+
+The original v2 review identified several upstream tenferro gaps. Those are no
+longer blockers if tensor4all-rs re-pins to the tenferro-rs revision merged on
+2026-04-13 (or any later descendant):
+
+1. `EagerTensor::tracks_grad()` now exists as a public query.
+2. `EagerTensor::clear_grad()` and `EagerContext::clear_grads()` now exist as
+   public reset APIs.
+3. `EagerTensor::backward()` now uses PyTorch-style accumulation semantics
+   instead of implicitly clearing gradients first.
+4. `EagerTensor<CpuBackend>` is now Send+Sync-safe via Arc/Mutex internals.
+
+These upstream changes should be treated as required migration baseline, not as
+optional follow-up work.
+
+---
+
+## High Priority
+
+### 1. tensor4all-rs should align its public AD names with the final upstream API
+
+The rewritten design should use:
+
+- `enable_grad(self) -> Self`
+- `tracks_grad(&self) -> bool`
+- `grad(&self) -> Result<Option<TensorDynLen>>`
+- `clear_grad(&self) -> Result<()>`
+- `backward(&self) -> Result<()>`
+- `detach(&self) -> Self`
+
+It should *not* preserve or reintroduce:
+
+- `requires_grad(&self) -> bool`
+- `set_requires_grad(...)`
+- `zero_grad(...)`
+- `backward_with_seed(...)`
+- `has_grad(...)`
+
+`has_grad` is especially problematic because it sounds like "a gradient value is
+present now," while the upstream API's `tracks_grad` means "this tensor
+participates in gradient tracking."
+
+This naming alignment should apply to both `TensorDynLen` and the eventual
+core-owned `tensor4all_core::AnyScalar` wrapper. The backend-layer
+`tensor4all_tensorbackend::AnyScalar` should remain primal-only and must not be
+treated as the public compatibility layer once AD is reintroduced.
+
+### 2. Actual tensor4all-rs code still uses the legacy AD surface and re-exports the wrong AnyScalar
+
+Current uses that the implementation plan must remove or rewrite:
+
+| File | Legacy API usage |
+|------|------------------|
+| `crates/tensor4all-core/src/lib.rs` | re-exports backend `AnyScalar`; plan should replace this with a core-owned rank-0 `TensorDynLen` wrapper |
+| `crates/tensor4all-core/src/defaults/tensordynlen.rs` | `requires_grad`, `set_requires_grad`, `zero_grad`, `backward_with_seed` |
+| `crates/tensor4all-tensorbackend/src/any_scalar.rs` | `requires_grad`, `set_requires_grad`, `zero_grad`, `backward_with_seed`, `grad`, `detach` |
+| `crates/tensor4all-core/tests/tensor_native_ad.rs` | legacy tensor-level AD API names |
+| `crates/tensor4all-treetn/tests/ad_treetn.rs` | `set_requires_grad` expectations on migrated tensors |
+| `crates/tensor4all-tensorbackend/src/tenferro_bridge.rs` | `tensor.requires_grad()` assumptions on legacy native tensors |
+
+The old review text mentioned `with_requires_grad(...)`, but the actual
+tensor4all-rs wrapper method to remove is `set_requires_grad(...)`.
+
+### 3. The plan must treat accumulation and explicit clearing as first-class behavior
+
+Now that upstream eager AD accumulates gradients by default, tensor4all-rs
+should add explicit tests and docs for:
+
+- repeated `backward()` accumulation
+- `clear_grad()` resetting one tracked tensor
+- `grad()` returning the accumulated gradient
+- `tracks_grad()` reporting tracking state, not gradient presence
+
+If these behaviors are not exercised directly, users are likely to infer the
+old overwrite-on-backward semantics.
+
+### 4. The public AnyScalar contract should be explicit
+
+The design should document the following instead of leaving scalar behavior
+implicit:
+
+- `tensor4all_core::AnyScalar` is a core-owned wrapper over rank-0
+  `TensorDynLen`
+- named-value arithmetic in docs/tests uses the borrow-based contract
+  `&x * &y + &x`
+- function APIs take `&AnyScalar`
+- `Clone` is a shared-handle clone, not detach or deep copy
+- dropping a handle is not gradient clearing, and `close()` should not be a
+  value-producing public API
+
+Without this, the migration leaves the most user-visible scalar semantics
+underspecified.
+
+### 5. The context wording must stay honest
+
+`TypedTensor` operations use a mutable `CpuBackend`, while eager graphs own
+their backend through `EagerContext<CpuBackend>`. The design should therefore
+describe these as paired thread-local execution objects, not as one shared
+backend instance, unless the implementation can actually prove single-instance
+sharing.
+
+---
+
+## Medium Priority
+
+### 6. Memory order risk remains unchanged and still needs an explicit audit
+
+`TypedTensor::from_vec(...)` stores data as-is. The design and plan correctly
+need an audited migration rather than a blind rename. The highest-risk call
+sites remain:
+
+- `crates/tensor4all-tcicore/src/matrix.rs`
+- `crates/tensor4all-simplett/src/einsum_helper.rs`
+- `crates/tensor4all-simplett/src/contraction.rs`
+- `crates/tensor4all-simplett/src/compression.rs`
+- `crates/tensor4all-simplett/src/vidal.rs`
+- `crates/tensor4all-simplett/src/mpo/factorize.rs`
+- `crates/tensor4all-simplett/src/tensor.rs`
+
+### 7. Verification guidance should grep for the APIs that actually exist today
+
+The migration sweep should include:
+
+```bash
+rg -n "ScalarType|MemoryOrder|contiguous\\(|buffer\\(|from_row_major_slice|from_slice\\(|set_default_runtime|RuntimeContext::Cpu|print_and_reset_contract_profile|requires_grad\\(|set_requires_grad|zero_grad\\(|backward_with_seed" crates
+```
+
+The earlier grep pattern missed `set_requires_grad`, which is the real wrapper
+API still present in tensor4all-rs.
+
+### 8. Send + Sync assertions are now meaningful and should be added
+
+Because upstream eager tensors are now Send+Sync, the plan should add static
+assertions for:
+
+- `tenferro::EagerTensor<tenferro::CpuBackend>`
+- `tensor4all_core::defaults::TensorDynLen`
+
+This is especially relevant for FFI-facing tensor handles.
+
+---
+
+## API Spot Checks (Verified Against Current tenferro-rs)
+
+| Symbol | Status |
+|--------|--------|
+| `Tensor::new(shape, data)` | OK |
+| `tensor.dtype()` / `DType{F32,F64,C32,C64}` | OK |
+| `tensor.as_slice::<T>() -> Option<&[T]>` | OK |
+| `tensor.shape() -> &[usize]` | OK |
+| `TypedTensor::from_vec(shape, data)` | OK |
+| `TypedTensor::svd(&self, ctx: &mut CpuBackend)` | OK |
+| `TypedTensor::qr(&self, ctx: &mut CpuBackend)` | OK |
+| `CpuContext::with_threads(n)` | OK |
+| `EagerContext::with_backend()` -> `Arc<Self>` | OK |
+| `EagerTensor::from_tensor_in(tensor, Arc<EagerContext<B>>)` | OK |
+| `EagerTensor::requires_grad_in(tensor, ctx)` | OK |
+| `EagerTensor::tracks_grad()` | OK |
+| `EagerTensor::clear_grad()` | OK |
+| `EagerContext::clear_grads()` | OK |
+| `EagerTensor::backward()` accumulates | OK |
+
+### Path / signature corrections
+
+| Design assumption | Actual API |
+|------------------|-----------|
+| `eager_einsum_ad` is at crate root | `tenferro::eager_einsum::eager_einsum_ad` |
+| `typed_eager_einsum` takes `&mut CpuBackend` specifically | it accepts `&mut impl TensorBackend` |
+
+---
+
+## Scope Guardrails
+
+The rewritten design correctly keeps the following in scope and they should not
+be dropped during implementation:
+
+- `crates/tensor4all-core/src/defaults/svd.rs`
+- `crates/tensor4all-core/src/defaults/qr.rs`
+- `crates/tensor4all-simplett/src/tensor.rs`
+- `crates/tensor4all-simplett/src/types.rs`
+- `crates/tensor4all-simplett/src/contraction.rs`
+- `crates/tensor4all-tensorbackend/tests/bench_einsum_native.rs`
+- `crates/tensor4all-treetn/tests/ad_treetn.rs`

--- a/docs/design/symbolic-shape-and-tenferro-migration.md
+++ b/docs/design/symbolic-shape-and-tenferro-migration.md
@@ -1,0 +1,534 @@
+# EagerTensor-Based Migration — Design Document
+
+Date: 2026-04-13
+Repositories: tenferro-rs, tensor4all-rs
+
+---
+
+## 1. Problem Statement
+
+tensor4all-rs depends on an old tenferro-rs revision (`c4e18845`) where
+`tenferro::Tensor` was a rich type with AD, structure info, element access,
+and operations. The new tenferro-rs has a clean separation:
+
+```
+Old:  Tensor = data + AD + structure + ops (one type does everything)
+
+New:  TypedTensor<T> = data + shape only
+      Tensor         = enum{F32|F64|C32|C64} + basic ops (via TensorBackend)
+      EagerTensor    = Arc<Tensor> + AD (backward, grad)
+```
+
+Additionally, several tenferro crates were merged/removed:
+
+| Old crate | New location |
+|-----------|-------------|
+| `tenferro-linalg` | `tenferro-tensor` (TypedTensor::svd/qr methods) |
+| `tenferro-prims` | `tenferro-tensor::cpu` (CpuContext, CpuBackend) |
+| `tenferro-tensor-compute` | `tenferro-einsum` (typed_eager_einsum) |
+
+Key symbol mapping:
+
+| Old symbol | New symbol |
+|-----------|-----------|
+| `tenferro::ScalarType` | `tenferro_tensor::DType` |
+| `tensor.scalar_type()` | `tensor.dtype()` |
+| `tensor.dims()` | `tensor.shape()` |
+| `tensor.ndim()` | `tensor.shape().len()` |
+| `tensor.try_get::<T>(&idx)` | `tensor.as_slice::<T>()` + index |
+| `tensor.try_to_vec::<T>()` | `tensor.as_slice::<T>().map(\|s\| s.to_vec())` |
+| `tensor.is_dense()` | always true (no diagonal in new Tensor) |
+| `tensor.to_dense()` | identity (already dense) |
+| `Tensor::from_slice(data, dims, order)` | `Tensor::new(shape, data)` |
+| `TypedTensor::from_slice(data, dims, order)` | `TypedTensor::from_vec(shape, data)` |
+| `NativeTensor::from(typed)` | `Tensor::from(typed)` (unchanged) |
+| `tensor.requires_grad()` | `EagerTensor::tracks_grad()` |
+| `tensor.zero_grad()` | `EagerTensor::clear_grad()` |
+| `tensor.backward()` | moved to `EagerTensor::backward()` |
+| `tensor.backward_with_seed(seed)` | removed; initial migration exposes scalar-loss `backward()` only |
+| `tensor.grad()` | `EagerTensor::grad()` (accumulated until cleared) |
+| `tenferro_linalg::LinalgScalar` | removed (use `TensorScalar`) |
+| `tenferro_linalg::svd(ctx, tensor)` | `TypedTensor::svd(&self, ctx)` |
+| `tenferro_linalg::qr(ctx, tensor)` | `TypedTensor::qr(&self, ctx)` |
+| `tenferro_prims::CpuContext` | `tenferro_tensor::cpu::CpuContext` |
+| `tenferro_tensor_compute::einsum` | `tenferro_einsum::typed_eager_einsum` |
+| `tenferro_prims::print_and_reset_contract_profile` | removed |
+
+Target migration baseline: re-pin to a tenferro-rs revision at or after the
+2026-04-13 merge that introduced the final eager AD surface used here:
+`EagerTensor::tracks_grad()`, `EagerTensor::clear_grad()`,
+`EagerContext::clear_grads()`, Send+Sync eager tensors, and PyTorch-style
+gradient accumulation in `EagerTensor::backward()`.
+
+## 2. Design Principles
+
+1. **Eager execution** -- every operation produces a concrete result immediately.
+2. **AD is optional** -- `EagerTensor` with `requires_grad=false` (default)
+   has zero overhead. Only primal computation runs.
+3. **Selective public compatibility** -- preserve
+   `tensor4all_core::AnyScalar` as the public dynamic scalar entry point, but
+   do not preserve legacy AD method names. AD-facing APIs adopt the eager
+   naming (`enable_grad`, `tracks_grad`, `clear_grad`, ...) instead of legacy
+   shims such as `set_requires_grad` or `zero_grad`.
+4. **Two-tier tensor types:**
+   - `TensorDynLen` wraps `EagerTensor` (index labels, dynamic dtype,
+     optional AD, diagonal structure)
+   - SimpleTT `Tensor<T,N>` wraps `TypedTensor<T>` (no index labels,
+     static dtype, no AD)
+5. **Paired thread-local execution objects** -- tensor4all-rs uses one
+   thread-local `CpuBackend` for `TypedTensor` operations and one
+   thread-local `EagerContext<CpuBackend>` for eager graphs. They are paired
+   by thread, but they are not the same backend instance.
+6. **Explicit gradient lifecycle** -- `backward()` accumulates gradients;
+   callers clear them explicitly with clear APIs. The migration must not
+   reintroduce implicit gradient clearing.
+7. **Bottom-up migration** -- migrate by crate dependency order:
+   tensorbackend -> tcicore -> core -> simplett -> higher crates -> capi.
+
+## 3. Migration by Crate (Bottom-Up)
+
+### 3.1 tensorbackend
+
+The bridge layer between tenferro and tensor4all-rs. Four files need changes:
+
+#### 3.1.1 Cargo.toml
+
+Remove: `tenferro-prims`, `tenferro-linalg`.
+Add: `tenferro` (for EagerTensor, EagerContext).
+Keep: `tenferro-tensor`, `tenferro-einsum`, `tenferro-algebra`.
+
+#### 3.1.2 any_scalar.rs (backend AnyScalar)
+
+`tensor4all_tensorbackend::AnyScalar` wraps a rank-0 `tenferro::Tensor` for
+dynamic scalar values. It remains a backend helper for storage conversion and
+primal scalar arithmetic; it is not the final public compatibility layer for
+`tensor4all_core::AnyScalar`.
+
+**Changes:**
+- `ScalarType` -> `DType`, `.scalar_type()` -> `.dtype()`
+- `NativeTensor::from_slice(&[value], &[])` -> `Tensor::new(vec![], vec![value])`
+- `.try_get::<T>(&[])` -> `.as_slice::<T>().unwrap()[0]`
+- `.dims()` -> `.shape()`
+- Remove AD methods from backend `AnyScalar` entirely:
+  `requires_grad`, `set_requires_grad`, `zero_grad`, `backward`,
+  `backward_with_seed`, `grad`, and `detach`.
+  Core-level AD is reintroduced later through a core-owned
+  `tensor4all_core::AnyScalar` wrapper around rank-0 `TensorDynLen`.
+  Backend `AnyScalar` becomes a pure primal-value type.
+
+**Resulting backend AnyScalar:**
+```rust
+pub struct Scalar {
+    native: Tensor,  // rank-0, always primal
+}
+```
+
+No AD methods. Construction, real/imag/abs/arithmetic stay the same
+but updated for the new Tensor API. This type remains useful for
+`Storage`/backend interop even after `tensor4all_core::AnyScalar` stops
+re-exporting it directly.
+
+#### 3.1.3 tensor_element.rs (TensorElement trait)
+
+Trait for type-dispatched tensor construction and extraction.
+
+**Changes:**
+- `TypedTensor::<T>::from_slice(data, dims, MemoryOrder::ColumnMajor)`
+  -> `TypedTensor::<T>::from_vec(shape, data)` (data must be in
+  column-major order already; TypedTensor stores data as-is)
+- `NativeTensor::from(typed)` -> `Tensor::from(typed)` (same)
+- `.is_dense()` -> remove (always true in new Tensor)
+- `.try_to_vec::<T>()` -> `.as_slice::<T>().map(|s| s.to_vec())`
+- `.to_dense()` -> remove (no-op)
+- `.ndim()` -> `.shape().len()`
+- `.dims()` -> `.shape()`
+- `.try_get::<T>(&index)` -> index into `.as_slice::<T>()`
+
+#### 3.1.4 backend.rs (SVD/QR backend)
+
+**Changes:**
+- Remove `tenferro_linalg` dependency entirely.
+- `LinalgScalar` -> `TensorScalar` (from `tenferro_tensor`)
+- `KernelLinalgScalar` -> remove
+- `BackendLinalgScalar` -> simplify to just `TensorScalar` bound
+- `svd_backend()`: `tenferro_linalg::svd(ctx, tensor)` ->
+  `TypedTensor::svd(&self, ctx: &mut CpuBackend)`
+- `qr_backend()`: `tenferro_linalg::qr(ctx, tensor)` ->
+  `TypedTensor::qr(&self, ctx: &mut CpuBackend)`
+- `with_tenferro_ctx(...)` -> `with_default_backend(...)` (shared context)
+- `SvdResult<T>`: singular values type uses `T::Real`
+  (from `TensorScalar::Real` associated type)
+
+#### 3.1.5 tenferro_bridge.rs
+
+Most functions become thin wrappers or are removed. The bridge was needed
+because the old Tensor had a complex API. The new Tensor is simple enough
+for direct use.
+
+**Keep (updated):**
+- `storage_to_native_tensor()` -- conversion from Storage to Tensor
+- `native_tensor_primal_to_storage()` -- conversion from Tensor to Storage
+- `dense_native_tensor_from_col_major()` -- construction helper
+- `diag_native_tensor_from_col_major()` -- construction helper
+- `native_tensor_primal_to_dense_*_col_major()` -- extraction helpers
+- `native_tensor_primal_to_diag_*()` -- extraction helpers
+- Profiling infrastructure (einsum profiling)
+
+**Remove (replaced by EagerTensor/TypedTensor methods):**
+- `with_tenferro_ctx()` -- replaced by shared context
+- `contract_native_tensor()` -- replaced by `eager_einsum_ad`
+- `outer_product_native_tensor()` -- replaced by `eager_einsum_ad`
+- `svd_native_tensor()` -- replaced by `EagerTensor::svd()`
+- `qr_native_tensor()` -- replaced by `EagerTensor::qr()`
+- `scale_native_tensor()` -- replaced by `EagerTensor::mul()`
+- `axpby_native_tensor()` -- replaced by EagerTensor arithmetic
+- `permute_native_tensor()` -- replaced by `EagerTensor::transpose()`
+- `reshape_col_major_native_tensor()` -- replaced by `EagerTensor::reshape()`
+- `conj_native_tensor()` -- replaced by `EagerTensor::conj()`
+- `sum_native_tensor()` -- replaced by `EagerTensor::reduce_sum()`
+- `tangent_native_tensor()` -- AD moved to EagerTensor
+- All `*_storage_native()` variants -- can be reimplemented via
+  Storage -> Tensor -> operation -> Storage if still needed
+
+**Update (API changes):**
+- `CpuContext::new(n)` -> `CpuContext::with_threads(n)`
+- `CpuContext::default_num_threads()` -> `tenferro_tensor::cpu::available_parallelism()`
+- All `dims()` -> `shape()`, `scalar_type()` -> `dtype()`
+- `Tensor::from_slice()` -> `Tensor::new()`
+
+#### 3.1.6 lib.rs
+
+- Remove `print_and_reset_contract_profile` re-export (symbol removed)
+- Remove re-exports of deleted bridge functions
+- Add re-export of context module
+
+#### 3.1.7 New: context.rs (paired thread-local execution objects)
+
+```rust
+use std::cell::RefCell;
+use std::sync::Arc;
+use tenferro::{CpuBackend, EagerContext};
+
+thread_local! {
+    static DEFAULT_CPU_BACKEND: RefCell<CpuBackend> =
+        RefCell::new(CpuBackend::new());
+    static DEFAULT_EAGER_CTX: Arc<EagerContext<CpuBackend>> =
+        EagerContext::with_backend(CpuBackend::new());
+}
+
+pub fn with_default_backend<R>(f: impl FnOnce(&mut CpuBackend) -> R) -> R {
+    DEFAULT_CPU_BACKEND.with(|b| f(&mut b.borrow_mut()))
+}
+
+pub fn default_eager_ctx() -> Arc<EagerContext<CpuBackend>> {
+    DEFAULT_EAGER_CTX.with(Arc::clone)
+}
+```
+
+This is intentionally *not* documented as "one shared backend instance."
+`TypedTensor` APIs need a mutable `CpuBackend`, while `EagerTensor` owns its
+backend through `EagerContext`. The migration should keep that distinction
+explicit in both code and docs.
+
+### 3.2 tcicore
+
+#### 3.2.1 Cargo.toml
+
+Remove: `tenferro-tensor-compute`.
+Add: `tenferro-einsum`, `tenferro-tensor`, `tenferro-algebra`.
+
+#### 3.2.2 matrix.rs
+
+- `tenferro_tensor_compute::einsum::<Standard<T>, CpuBackend>(...)` ->
+  `tenferro_einsum::typed_eager_einsum(&mut backend, inputs, subscripts)`
+- Use `with_default_backend()` for the CpuBackend.
+
+### 3.3 core (TensorDynLen)
+
+#### 3.3.1 Cargo.toml
+
+Remove: `tenferro-prims` (dev-dep).
+Add: `tenferro` (for `EagerTensor`, `EagerContext`, and eager einsum).
+
+#### 3.3.2 tensordynlen.rs
+
+**Struct change:**
+```rust
+// Old:
+pub struct TensorDynLen {
+    pub indices: Vec<DynIndex>,
+    native: Arc<NativeTensor>,
+}
+
+// New:
+pub struct TensorDynLen {
+    pub indices: Vec<DynIndex>,
+    inner: EagerTensor<CpuBackend>,
+    axis_classes: Vec<usize>,
+}
+```
+
+**Data access pattern:**
+```rust
+// Old: &*self.native  or  self.native.as_ref()
+// New: self.inner.data()  (returns &Tensor)
+```
+
+**Construction pattern:**
+```rust
+let ctx = tensor4all_tensorbackend::default_eager_ctx();
+let inner = EagerTensor::from_tensor_in(native_tensor, ctx);
+```
+
+**Core primal operations use eager APIs directly:**
+- contraction: `tenferro::eager_einsum::eager_einsum_ad(&[...], subscripts)`
+- factorization staging: reshape/transposition on `EagerTensor`
+- SVD/QR on reshaped payload tensors
+- permutation: `transpose`
+- scaling and elementwise ops: eager arithmetic
+- norms/reductions: eager reductions over the primal payload
+
+#### 3.3.3 any_scalar.rs (core-owned AnyScalar compatibility wrapper)
+
+`tensor4all_core::AnyScalar` should stop re-exporting
+`tensor4all_tensorbackend::AnyScalar`. Because `tensor4all-core` depends on
+`tensor4all-tensorbackend`, the public scalar compatibility layer must live in
+core and wrap rank-0 `TensorDynLen`; otherwise reintroducing AD would require a
+reverse crate dependency.
+
+```rust
+pub struct AnyScalar {
+    inner: TensorDynLen,  // invariant: rank 0
+}
+```
+
+Required surface:
+- Preserve the public type name `tensor4all_core::AnyScalar`.
+- Preserve scalar constructors and primal helpers such as `new_real`,
+  `new_complex`, `from_value`, `real`, `imag`, `abs`, `is_real`,
+  `is_complex`, `is_zero`, `conj`, and arithmetic.
+- Reintroduce AD only on this core-owned wrapper, using the eager names:
+  - `enable_grad(self) -> Self`
+  - `tracks_grad(&self) -> bool`
+  - `grad(&self) -> Result<Option<AnyScalar>>`
+  - `clear_grad(&self) -> Result<()>`
+  - `backward(&self) -> Result<()>`
+  - `detach(&self) -> Self`
+- Add tensor interop helpers:
+  - `try_from_tensor(TensorDynLen) -> Result<Self>`
+  - `as_tensor(&self) -> &TensorDynLen`
+  - `into_tensor(self) -> TensorDynLen`
+
+Recommended usage contract:
+
+```rust
+fn affine(x: &AnyScalar, y: &AnyScalar) -> AnyScalar {
+    x * y + x
+}
+
+let x = AnyScalar::new_real(2.0).enable_grad();
+let y = AnyScalar::new_real(3.0).enable_grad();
+let loss = &x * &y + &x;
+loss.backward()?;
+let dx = x.grad()?.unwrap();
+```
+
+Ownership and handle rules:
+- For named owned values, the documented arithmetic contract is borrow-based:
+  `&x * &y + &x`. The migration does not promise `x * y + x` for owned
+  variables.
+- Function parameters should normally be `&AnyScalar`; inside those functions
+  `x * y + x` is acceptable because the bindings are already references.
+- `Clone` is a shared-handle clone of the same tracked rank-0 tensor. It does
+  not detach and it does not deep-copy the payload.
+- Dropping one handle only destroys that handle. It does not clear gradients on
+  other live clones, and there is no value-returning `close()` expression in
+  the public API.
+
+#### 3.3.4 defaults/svd.rs and defaults/qr.rs
+
+These public entry points must be migrated explicitly. They currently depend on
+legacy `ScalarType` dispatch and therefore belong in the main migration plan,
+not in a later cleanup pass.
+
+**Changes:**
+- Replace `tenferro::ScalarType` dispatch with the new dtype path
+  (`tenferro_tensor::DType` or local typed helpers).
+- Keep the tensor4all public entry points stable while routing the payload
+  through the new eager/typed backend path.
+- Audit any shape/materialization assumptions while moving from old
+  `NativeTensor` helpers to the new eager payload accessors.
+
+#### 3.3.5 AD surface on TensorDynLen
+
+The migrated wrapper should align with the final tenferro eager API names
+instead of preserving ambiguous legacy names.
+
+```rust
+impl TensorDynLen {
+    pub fn enable_grad(self) -> Self { ... }
+    pub fn tracks_grad(&self) -> bool { ... }
+    pub fn grad(&self) -> Result<Option<TensorDynLen>> { ... }
+    pub fn clear_grad(&self) -> Result<()> { ... }
+    pub fn backward(&self) -> Result<()> { ... }   // scalar loss only
+    pub fn detach(&self) -> Self { ... }
+}
+```
+
+Design rules:
+- `enable_grad(self)` rebuilds a tracked eager leaf in the default eager context.
+- `tracks_grad()` mirrors tenferro naming. It means the tensor participates in
+  gradient tracking, not that an accumulated gradient value is currently present.
+- `backward()` uses tenferro's accumulation semantics. Repeated calls add into
+  the existing stored gradient until the caller clears it explicitly.
+- `clear_grad()` is the explicit reset operation on the current tensor.
+- `backward_with_seed(...)` is intentionally dropped from the public wrapper.
+  Initial migration supports scalar-loss reverse mode only.
+- `tensor4all_core::AnyScalar` mirrors the same naming and accumulation rules
+  on top of a rank-0 `TensorDynLen` wrapper.
+
+**Diagonal structure (`axis_classes`):**
+- Dense tensors: `axis_classes = [0, 1, 2, ...]`
+- Diagonal: `axis_classes = [0, 0]`
+- Payload tensor has one axis per equivalence class
+- Initial migration can keep payloads dense while preserving
+  `axis_classes` metadata in tensor4all-rs
+
+#### 3.3.6 tests/tensor_native_ad.rs and new AD integration coverage
+
+- Replace legacy AD tests that rely on `set_requires_grad`, `zero_grad`, and
+  seeded backward.
+- Add new tests for:
+  - `enable_grad` / `tracks_grad`
+  - `grad`
+  - repeated `backward()` accumulation
+  - `clear_grad()`
+  - `detach()`
+- Extend `tensor_any_scalar.rs` to cover:
+  - borrow-based named-value arithmetic (`&x * &y + &x`)
+  - function-by-reference usage
+  - rank-0 tensor conversion helpers
+  - shared-handle `Clone` semantics for tracked scalars
+- Add compile-time Send+Sync assertions for `EagerTensor<CpuBackend>` and
+  `TensorDynLen`.
+
+### 3.4 simplett
+
+#### 3.4.1 Cargo.toml
+
+Remove: `tenferro-linalg`, `tenferro-tensor-compute`.
+Add: `tenferro-einsum`.
+
+#### 3.4.2 einsum_helper.rs
+
+Replace the old helper path:
+- remove `EinsumScalar` trait and macro
+- remove per-call `CpuContext::new(1)`
+- use `with_default_backend()` + `typed_eager_einsum()`
+- remove row-major helper code that depended on old tensor APIs
+
+#### 3.4.3 compression.rs
+
+- `LinalgScalar` -> `TensorScalar`
+- `svd_backend()` -> `TypedTensor::svd(&self, ctx)` via `with_default_backend()`
+- remove `MemoryOrder` / `contiguous()` calls
+- `TypedTensor::from_slice()` -> `TypedTensor::from_vec()`
+
+#### 3.4.4 tensor.rs, types.rs, contraction.rs, vidal.rs, mpo/*.rs
+
+The migration scope must explicitly include the simplett files that still use
+legacy tenferro tensor constructors, layout helpers, or linalg traits:
+
+- `src/tensor.rs`
+- `src/types.rs`
+- `src/contraction.rs`
+- `src/vidal.rs`
+- `src/mpo/environment.rs`
+- `src/mpo/factorize.rs`
+- `src/mpo/types.rs`
+
+Expected changes:
+- remove `from_row_major_slice`, `MemoryOrder`, `contiguous()`, `buffer()`,
+  and `is_unique()`
+- use explicit row-major <-> column-major relayout helpers where needed
+- replace old linalg trait bounds with `TensorScalar` or local typed helpers
+- keep layout conversion visible and named rather than hidden behind blind
+  `from_slice -> from_vec` renames
+
+### 3.5 Higher-level crates (treetn, treetci, quanticstci, etc.)
+
+Should compile without changes once lower crates are fixed, unless they
+directly import removed symbols. Quick grep and fix pass.
+
+#### 3.5.1 treetn
+
+- `tenferro-prims` dev-dep -> `tenferro-tensor`
+- `tenferro_prims::CpuContext::new(1)` -> `tenferro_tensor::cpu::CpuContext::with_threads(1)`
+
+### 3.6 capi
+
+The C API uses opaque handles to TensorDynLen. Since TensorDynLen's public
+API is preserved, the C API should compile without changes.
+
+**Thread safety:** With Arc/Mutex in EagerTensor (tenferro-rs change),
+`TensorDynLen` remains `Send + Sync`, so `t4a_tensor` safety is preserved.
+
+## 4. Implementation Order
+
+Strict bottom-up. Each stage must compile and pass its crate-local tests
+before the next stage starts.
+
+```text
+Step 1: tensorbackend foundations + repin
+Step 2: tcicore typed einsum migration
+Step 3: core primal migration (TensorDynLen storage + contract/factorize + defaults/svd.rs + defaults/qr.rs)
+Step 4: core AD surface + core AnyScalar compatibility wrapper
+Step 5: simplett typed-tensor + layout migration
+Step 6: higher crates, benches, and Send+Sync / FFI-facing invariants
+Step 7: full workspace verification and cleanup
+```
+
+## 5. Testing Strategy
+
+Each stage has explicit verification:
+
+1. **tensorbackend**:
+   `cargo check -p tensor4all-tensorbackend --all-targets`
+   `cargo nextest run --release -p tensor4all-tensorbackend`
+2. **tcicore**:
+   `cargo check -p tensor4all-tcicore --all-targets`
+   `cargo nextest run --release -p tensor4all-tcicore`
+3. **core primal + AD + AnyScalar**:
+   `cargo check -p tensor4all-core --all-targets`
+   `cargo nextest run --release -p tensor4all-core`
+   plus dedicated accumulation/reset tests for the new AD surface and
+   `tensor4all_core::AnyScalar`
+4. **simplett**:
+   `cargo check -p tensor4all-simplett --all-targets`
+   `cargo nextest run --release -p tensor4all-simplett`
+5. **Workspace sweep**:
+   `cargo check --workspace --all-targets`
+   `cargo nextest run --release --workspace`
+6. **Final verification**:
+   `cargo fmt --all`
+   `cargo clippy --workspace --all-targets`
+   `cargo test --doc --release --workspace`
+   `mdbook test docs/book`
+   `cargo doc --workspace --no-deps`
+
+## 6. Risks
+
+1. **Memory order:** `TypedTensor::from_vec()` stores data as-is. Every
+   migrated call site must make layout explicit.
+2. **Diagonal tensors:** the new tenferro `Tensor` is always dense. tensor4all
+   must preserve diagonal semantics in its own metadata (`axis_classes`,
+   `Storage`) rather than expecting structural tensor support upstream.
+3. **Gradient lifecycle confusion:** eager backward now accumulates like
+   PyTorch. The tensor4all wrappers (`TensorDynLen` and core `AnyScalar`) must
+   expose explicit clear APIs and tests so users do not infer legacy overwrite
+   semantics.
+4. **Execution-context wording:** tensor4all-rs must not claim that eager and
+   typed operations share one backend instance unless that is demonstrably true.
+5. **Performance:** `typed_eager_einsum` and typed linalg still copy through
+   tenferro's current internal representations. These are upstream costs, not
+   migration-specific regressions.

--- a/docs/superpowers/plans/2026-04-13-eagertensor-migration.md
+++ b/docs/superpowers/plans/2026-04-13-eagertensor-migration.md
@@ -1,0 +1,511 @@
+# EagerTensor Migration Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate tensor4all-rs from the legacy tenferro API to the new split API (`Tensor`, `TypedTensor<T>`, `EagerTensor`) while removing deprecated AD shims, adopting explicit accumulation/reset semantics for eager gradients, and restoring `tensor4all_core::AnyScalar` as a core-owned rank-0 `TensorDynLen` wrapper.
+
+**Architecture:** Execute strictly bottom-up by actual crate dependencies: update the workspace pin and tensorbackend first, then migrate tcicore, then migrate tensor4all-core primal operations and public SVD/QR entry points, then reintroduce the renamed AD surface on `TensorDynLen` plus a core-owned `AnyScalar` compatibility wrapper, then migrate simplett's typed-tensor paths and memory-layout handling, and finally sweep higher crates, tests, benches, and FFI invariants.
+
+**Tech Stack:** Rust, tenferro, tenferro-tensor, tenferro-einsum, tenferro-algebra, cargo-nextest, mdBook
+
+**Primary references:**
+- `docs/design/symbolic-shape-and-tenferro-migration.md`
+- `docs/design/review-eagertensor-migration-v2.md`
+
+**Non-goals:**
+- Preserve deprecated AD method names on `AnyScalar` or `TensorDynLen`.
+- Keep removed tenferro re-exports such as `print_and_reset_contract_profile` alive via compatibility shims.
+- Perform blind `from_slice -> from_vec` renames without auditing memory order at each call site.
+- Reintroduce seeded backward or implicit gradient clearing semantics that are absent from the target tenferro API.
+
+**Execution rules:**
+- Run `cargo fmt --all` before every commit.
+- Run at least `cargo check -p <crate> --all-targets` for the crate touched in each task.
+- Do not relax numerical tolerances without explicit user approval.
+- If a required tenferro API is missing, stop, land that API upstream, repin, and then resume. Do not reach into private fields or add local hacks around missing upstream behavior.
+
+---
+
+## Task 1: Re-pin tenferro and migrate tensorbackend foundations
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `crates/tensor4all-tensorbackend/Cargo.toml`
+- Create: `crates/tensor4all-tensorbackend/src/context.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/lib.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/any_scalar.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/tensor_element.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/backend.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/tenferro_bridge.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs`
+- Modify: `crates/tensor4all-tensorbackend/tests/bench_einsum_native.rs`
+
+- [ ] **Step 1: Update the workspace pin and direct dependencies**
+
+Update all tenferro workspace dependencies in `Cargo.toml` from the old revision to a tenferro-rs revision at or after the 2026-04-13 eager-AD merge (the revision that includes `tracks_grad`, `clear_grad`, `clear_grads`, Send+Sync eager tensors, and accumulating `backward()`). In `crates/tensor4all-tensorbackend/Cargo.toml`, remove obsolete direct dependencies (`tenferro-prims`, `tenferro-linalg`) where no longer needed and add `tenferro.workspace = true`.
+
+- [ ] **Step 2: Capture the expected tensorbackend breakage on the new pin**
+
+Run:
+
+```bash
+cargo check -p tensor4all-tensorbackend --all-targets
+```
+
+Expected: FAIL with unresolved imports or method errors around `ScalarType`, `tenferro_linalg`, `tenferro_prims`, old tensor accessors (`dims`, `scalar_type`, `try_get`, `try_to_vec`), old runtime helpers, and AnyScalar AD methods.
+
+- [ ] **Step 3: Resolve the execution-context model and implement tensorbackend migration**
+
+Make the following changes in one coherent pass:
+
+- Create `src/context.rs` and expose thread-local execution helpers.
+- Verify whether the pinned tenferro API can make `TypedTensor` ops and `EagerTensor` ops share the exact same `CpuBackend` instance.
+- If exact single-instance sharing is supported, implement it and document that invariant.
+- If exact single-instance sharing is not supported, implement paired thread-local execution objects (`with_default_backend`, `default_eager_ctx`) and update the doc comments to avoid claiming a single shared backend instance.
+- Remove AD behavior from backend `AnyScalar` entirely. Delete deprecated methods such as `requires_grad`, `set_requires_grad`, `zero_grad`, `backward_with_seed`, `grad`, and `detach`. The public `tensor4all_core::AnyScalar` compatibility layer is reintroduced later in Task 4 as a core-owned rank-0 `TensorDynLen` wrapper.
+- Update `tensor_element.rs` for `DType`, `shape()`, `as_slice()`, and explicit column-major `TypedTensor::from_vec(...)` construction.
+- Update `backend.rs` to use `TensorScalar` plus `TypedTensor::{svd, qr}` through `with_default_backend(...)`.
+- Simplify `tenferro_bridge.rs` to the conversion and profiling helpers still needed by downstream crates, and update it to `Tensor::new(...)`, `dtype()`, and `shape()`.
+- Update tests and benches to stop depending on removed runtime/profile APIs from old tenferro.
+
+- [ ] **Step 4: Verify tensorbackend**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p tensor4all-tensorbackend --all-targets
+cargo nextest run --release -p tensor4all-tensorbackend
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/tensor4all-tensorbackend/
+git commit -m "refactor: migrate tensorbackend to new tenferro foundations"
+```
+
+---
+
+## Task 2: Migrate tcicore to typed_eager_einsum and audited layout conversions
+
+**Files:**
+- Modify: `crates/tensor4all-tcicore/Cargo.toml`
+- Modify: `crates/tensor4all-tcicore/src/matrix.rs`
+
+- [ ] **Step 1: Remove the old compute dependency and confirm the failure mode**
+
+Update `crates/tensor4all-tcicore/Cargo.toml` to remove `tenferro-tensor-compute` and add any now-required tenferro crates.
+
+Run:
+
+```bash
+cargo check -p tensor4all-tcicore --all-targets
+```
+
+Expected: FAIL around `tenferro_tensor_compute::einsum`, `MemoryOrder`, and old tensor materialization helpers.
+
+- [ ] **Step 2: Replace the einsum path**
+
+In `src/matrix.rs`, replace the old compute call with `tenferro_einsum::typed_eager_einsum(...)` using `tensor4all_tensorbackend::with_default_backend(...)`.
+
+- [ ] **Step 3: Fix row-major assumptions explicitly**
+
+Audit every tensor construction and extraction in `src/matrix.rs`.
+
+- When source data is row-major, relayout it intentionally before `TypedTensor::from_vec(...)`.
+- When extracting dense results, materialize once and convert layout once.
+- Do not rely on `MemoryOrder`, `contiguous(...)`, or `buffer()` APIs that do not exist on the new tenferro path.
+
+- [ ] **Step 4: Verify tcicore**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p tensor4all-tcicore --all-targets
+cargo nextest run --release -p tensor4all-tcicore
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tensor4all-tcicore/
+git commit -m "refactor: migrate tcicore einsum to new tenferro API"
+```
+
+---
+
+## Task 3: Migrate tensor4all-core primal tensor operations and public factorization entry points
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Modify: `crates/tensor4all-core/src/defaults/contract.rs`
+- Modify: `crates/tensor4all-core/src/defaults/factorize.rs`
+- Modify: `crates/tensor4all-core/src/defaults/svd.rs`
+- Modify: `crates/tensor4all-core/src/defaults/qr.rs`
+- Modify: `crates/tensor4all-core/tests/tensor_native_ad.rs`
+
+- [ ] **Step 1: Capture the current core failures**
+
+Run:
+
+```bash
+cargo check -p tensor4all-core --all-targets
+```
+
+Expected: FAIL around old `ScalarType` dispatch, old `TensorDynLen` internals (`Arc<NativeTensor>`), and the removed pre-migration AD methods.
+
+- [ ] **Step 2: Change `TensorDynLen` to the new storage model**
+
+In `tensordynlen.rs`:
+
+- Replace `native: Arc<NativeTensor>` with `inner: EagerTensor<CpuBackend>`.
+- Add `axis_classes: Vec<usize>` and initialize it in every constructor and result-building path.
+- Keep diagonal bookkeeping in tensor4all-core rather than expecting structural tensor support from new tenferro.
+- Update all primal data accessors and conversions to read from `self.inner.data()`.
+
+- [ ] **Step 3: Remove deprecated AD surface during the primal migration**
+
+Delete the obsolete tensor-level AD methods that cannot be supported on the new API surface:
+
+- `requires_grad(&self) -> bool`
+- `set_requires_grad(...)`
+- `zero_grad(...)`
+- `backward_with_seed(...)`
+
+Because AD-method backward compatibility is not required, do not leave compatibility wrappers behind. Update or temporarily replace the old test coverage in `tests/tensor_native_ad.rs` so that `--all-targets` compiles cleanly before the new AD surface and core-owned `AnyScalar` wrapper are added in Task 4.
+
+- [ ] **Step 4: Migrate primal ops and public SVD/QR entry points**
+
+Make the core operations use the new primitives directly:
+
+- Contraction and outer-product paths should use `tenferro::eager_einsum::eager_einsum_ad(...)`.
+- Factorization should reshape through `EagerTensor` and call `svd()` / `qr()` directly.
+- `defaults/svd.rs` and `defaults/qr.rs` must stop dispatching on `tenferro::ScalarType` and instead use the new dtype path (`DType` or internal typed helpers).
+
+- [ ] **Step 5: Verify tensor4all-core primal behavior**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p tensor4all-core --all-targets
+cargo nextest run --release -p tensor4all-core
+```
+
+Expected: PASS, with AD tests either removed or rewritten to target the new API names only.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tensor4all-core/
+git commit -m "refactor: migrate core primal tensor ops to EagerTensor"
+```
+
+---
+
+## Task 4: Add the new TensorDynLen AD surface and restore core AnyScalar compatibility
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Create: `crates/tensor4all-core/src/any_scalar.rs`
+- Modify: `crates/tensor4all-core/src/lib.rs`
+- Modify: `crates/tensor4all-core/tests/tensor_native_ad.rs`
+- Modify: `crates/tensor4all-core/tests/tensor_any_scalar.rs`
+- Create: `crates/tensor4all-core/tests/ad_integration.rs`
+
+- [ ] **Step 1: Confirm the required tenferro AD API exists**
+
+Before changing tensor4all-core, confirm on the pinned tenferro revision that the following are available as public APIs:
+
+- create grad-tracking tensors
+- run scalar-loss `backward()`
+- fetch accumulated `grad()`
+- clear a single tensor's accumulated gradient via `clear_grad()`
+- detach from the graph
+- query whether a tensor tracks gradients via `tracks_grad()`
+
+If the pinned revision does not include this public API surface, stop here and repin before changing tensor4all-core. Do not inspect private fields from tensor4all-rs.
+
+- [ ] **Step 2: Write the failing tests for the new API and the new AnyScalar contract**
+
+Replace old AD test expectations with the new surface:
+
+- `enable_grad(self) -> Self`
+- `tracks_grad(&self) -> bool`
+- `grad(&self) -> Result<Option<TensorDynLen>>`
+- `clear_grad(&self) -> Result<()>`
+- `backward(&self) -> Result<()>`
+- `detach(&self) -> Self`
+
+Also add explicit failing tests for:
+
+- repeated `backward()` accumulation
+- `clear_grad()` resetting the accumulated gradient
+- `tracks_grad()` on tracked vs detached tensors
+- core `AnyScalar` rank-0 conversion and forwarding to `TensorDynLen`
+- borrow-based named-value arithmetic such as `&x * &y + &x`
+- function APIs that take `&AnyScalar`
+- shared-handle `Clone` behavior for tracked scalars
+
+Run:
+
+```bash
+cargo nextest run --release -p tensor4all-core --test tensor_native_ad
+cargo nextest run --release -p tensor4all-core --test tensor_any_scalar
+cargo nextest run --release -p tensor4all-core --test ad_integration
+```
+
+Expected: FAIL before implementation.
+
+- [ ] **Step 3: Implement the new AD surface and core-owned AnyScalar without reviving removed APIs**
+
+In `tensordynlen.rs` and the new `any_scalar.rs`:
+
+- Implement `enable_grad`, `tracks_grad`, `grad`, `clear_grad`, `backward`, and `detach`.
+- Do not reintroduce `zero_grad` or `backward_with_seed`.
+- Preserve `axis_classes` and index metadata across gradient and detach paths.
+- Ensure scalar-loss backward is the only supported public entry point.
+- Preserve tenferro's accumulation semantics instead of clearing gradients implicitly inside the wrapper.
+- Replace the `tensor4all-core` re-export of backend `AnyScalar` with a core-owned wrapper around rank-0 `TensorDynLen`.
+- Preserve the public type name `tensor4all_core::AnyScalar` plus primal helpers such as `new_real`, `new_complex`, `from_value`, `real`, `imag`, `abs`, `is_real`, `is_complex`, `is_zero`, and arithmetic.
+- Implement the documented borrow-based operator contract for named values. Function APIs should take `&AnyScalar`; the plan does not require owned-variable `x * y + x`.
+- Make `Clone` a shared-handle clone of the same tracked scalar. Do not add a value-returning `close()` API.
+
+- [ ] **Step 4: Verify core AD**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p tensor4all-core --all-targets
+cargo nextest run --release -p tensor4all-core --test tensor_native_ad
+cargo nextest run --release -p tensor4all-core --test tensor_any_scalar
+cargo nextest run --release -p tensor4all-core --test ad_integration
+cargo nextest run --release -p tensor4all-core
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tensor4all-core/
+git commit -m "feat: add EagerTensor AD surface for TensorDynLen and AnyScalar"
+```
+
+---
+
+## Task 5: Migrate simplett to TypedTensor plus explicit layout helpers
+
+**Files:**
+- Modify: `crates/tensor4all-simplett/Cargo.toml`
+- Modify: `crates/tensor4all-simplett/src/einsum_helper.rs`
+- Modify: `crates/tensor4all-simplett/src/compression.rs`
+- Modify: `crates/tensor4all-simplett/src/contraction.rs`
+- Modify: `crates/tensor4all-simplett/src/tensor.rs`
+- Modify: `crates/tensor4all-simplett/src/types.rs`
+- Modify: `crates/tensor4all-simplett/src/vidal.rs`
+- Modify: `crates/tensor4all-simplett/src/mpo/environment.rs`
+- Modify: `crates/tensor4all-simplett/src/mpo/factorize.rs`
+- Modify: `crates/tensor4all-simplett/src/mpo/types.rs`
+- Modify: `crates/tensor4all-simplett/src/contraction/tests/mod.rs`
+
+- [ ] **Step 1: Confirm the simplett failure set**
+
+Run:
+
+```bash
+cargo check -p tensor4all-simplett --all-targets
+```
+
+Expected: FAIL around `tenferro-linalg`, `tenferro-tensor-compute`, `from_row_major_slice`, `MemoryOrder`, `contiguous(...)`, `buffer()`, `is_unique()`, and old trait bounds such as `KeepCountScalar`.
+
+- [ ] **Step 2: Update dependencies and common helpers**
+
+In `Cargo.toml`, remove obsolete tenferro crates and add `tenferro-einsum` if needed. Replace the old `einsum_helper.rs` implementation with a `typed_eager_einsum(...)` path via `with_default_backend(...)`.
+
+- [ ] **Step 3: Introduce explicit layout conversion helpers**
+
+Create or reuse local helpers so layout handling is visible and audited:
+
+- Convert row-major source slices to column-major buffers before `TypedTensor::from_vec(...)`.
+- When returning row-major dense data to existing simplett code paths, convert once in a named helper instead of repeatedly materializing via removed tenferro APIs.
+- Prefer algorithm changes that avoid row-major round-trips entirely when practical, especially in `contraction.rs`.
+
+- [ ] **Step 4: Update all known old-API call sites**
+
+Migrate the files identified by the review and grep sweep:
+
+- `src/tensor.rs`
+- `src/types.rs`
+- `src/contraction.rs`
+- `src/compression.rs`
+- `src/vidal.rs`
+- `src/mpo/factorize.rs`
+- `src/mpo/environment.rs`
+- `src/mpo/types.rs`
+- `src/contraction/tests/mod.rs`
+
+Do not stop after `einsum_helper.rs` and `compression.rs`; the old plan was incomplete here.
+
+- [ ] **Step 5: Verify simplett**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check -p tensor4all-simplett --all-targets
+cargo nextest run --release -p tensor4all-simplett
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tensor4all-simplett/
+git commit -m "refactor: migrate simplett to TypedTensor and explicit layouts"
+```
+
+---
+
+## Task 6: Sweep higher crates, benches, and FFI-facing invariants
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/tests/ad_treetn.rs`
+- Modify: any workspace files found by the sweep below
+- Create: `crates/tensor4all-core/tests/send_sync.rs`
+
+- [ ] **Step 1: Run a workspace-wide grep sweep for legacy APIs**
+
+Run:
+
+```bash
+rg -n "ScalarType|MemoryOrder|contiguous\\(|buffer\\(|from_row_major_slice|from_slice\\(|set_default_runtime|RuntimeContext::Cpu|print_and_reset_contract_profile|requires_grad\\(|set_requires_grad|zero_grad\\(|backward_with_seed" crates
+```
+
+Expected: only intentional compatibility uses remain. Every production hit must either be migrated in this task or explained in a code comment with a strong reason.
+
+- [ ] **Step 2: Fix remaining direct uses in higher crates and tests**
+
+At minimum, update:
+
+- `crates/tensor4all-treetn/tests/ad_treetn.rs`
+- any remaining bench/test files that still rely on removed tenferro runtime or profiling APIs
+
+If the grep reveals additional production files outside the earlier tasks, migrate them now instead of adding TODOs.
+
+- [ ] **Step 3: Add Send + Sync compile-time assertions**
+
+Create `crates/tensor4all-core/tests/send_sync.rs` with static assertions for:
+
+- `tenferro::EagerTensor<tenferro::CpuBackend>`
+- `tensor4all_core::defaults::TensorDynLen`
+
+If the FFI handle types in `tensor4all-capi` expose a similarly testable public type, add an assertion there too.
+
+- [ ] **Step 4: Verify workspace compilation and tests**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo check --workspace --all-targets
+cargo nextest run --release --workspace
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/
+git commit -m "test: finish migration sweep across higher crates and invariants"
+```
+
+---
+
+## Task 7: Final verification, rustdoc, and mdBook checks
+
+**Files:**
+- Modify: any files required to fix verification failures
+
+- [ ] **Step 1: Run formatting and linting**
+
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full compile and test matrix**
+
+```bash
+cargo check --workspace --all-targets
+cargo nextest run --release --workspace
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run rustdoc and mdBook verification**
+
+```bash
+cargo test --doc --release --workspace
+mdbook test docs/book
+cargo doc --workspace --no-deps
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the final cleanup**
+
+```bash
+git add -A
+git commit -m "chore: finalize EagerTensor migration"
+```
+
+---
+
+## Dependency Graph
+
+```text
+Task 1: tensorbackend foundations + workspace pin
+  |
+  v
+Task 2: tcicore
+  |
+  v
+Task 3: core primal migration
+  |
+  v
+Task 4: core AD surface + core AnyScalar compatibility
+  |
+  v
+Task 5: simplett
+  |
+  v
+Task 6: higher crates + benches + FFI invariants
+  |
+  v
+Task 7: full verification
+```
+
+## Stop Conditions
+
+Stop and update the plan before proceeding if any of the following happen:
+
+- The pinned tenferro revision is older than the eager-AD merge required by this plan or otherwise lacks `tracks_grad()`, `clear_grad()`, `clear_grads()`, or accumulating `backward()`.
+- The context model cannot honestly support the design's paired execution-object wording; in that case, fix the design text before continuing.
+- A remaining row-major call site cannot be migrated safely without changing algorithm structure; in that case, document the exact layout invariant and update the design before continuing.
+
+## Parallelism Guidance
+
+Do not reuse the old parallel split. `tensor4all-simplett` depends on both `tensor4all-core` and `tensor4all-tcicore`, so Tasks 2 through 5 are sequential. The only safe parallel work is small verification or grep-based cleanup that does not edit overlapping files after Task 5 is green.

--- a/scripts/test-mdbook.sh
+++ b/scripts/test-mdbook.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+probe_log="$(mktemp)"
+rustdoc_wrapper_dir="$(mktemp -d)"
+trap 'rm -f "$probe_log"; rm -rf "$rustdoc_wrapper_dir"' EXIT
+
+# Force a fresh book-tests rustc invocation so cargo prints the exact --extern
+# paths that its doctest harness resolves for the guide snippets.
+probe_metadata="mdbook_probe_$(date +%s%N)"
+cargo rustc -p book-tests --release --lib -vv -- -Cmetadata="$probe_metadata" >"$probe_log" 2>&1
+
+rustc_line="$(grep -- '--crate-name book_tests' "$probe_log" | tail -n 1 || true)"
+if [[ -z "$rustc_line" ]]; then
+    echo "failed to locate the book-tests rustc command" >&2
+    tail -n 200 "$probe_log" >&2 || true
+    exit 1
+fi
+
+extern_args="$(printf '%s\n' "$rustc_line" | grep -oE -- '--extern [^ ]+' | sed 's/^--extern //')"
+if [[ -z "$extern_args" ]]; then
+    echo "failed to extract --extern flags from the book-tests rustc command" >&2
+    tail -n 200 "$probe_log" >&2 || true
+    exit 1
+fi
+
+real_rustdoc="$(rustup which rustdoc)"
+{
+    echo '#!/usr/bin/env bash'
+    echo 'set -euo pipefail'
+    printf 'exec %q ' "$real_rustdoc"
+    while IFS= read -r extern_arg; do
+        [[ -n "$extern_arg" ]] || continue
+        crate_name="${extern_arg%%=*}"
+        crate_path="${extern_arg#*=}"
+        if [[ "$crate_path" == *.rmeta ]]; then
+            rlib_path="${crate_path%.rmeta}.rlib"
+            if [[ -f "$rlib_path" ]]; then
+                crate_path="$rlib_path"
+            fi
+        fi
+        printf '%q %q ' --extern "${crate_name}=${crate_path}"
+    done <<< "$extern_args"
+    echo '"$@"'
+} > "$rustdoc_wrapper_dir/rustdoc"
+chmod +x "$rustdoc_wrapper_dir/rustdoc"
+
+PATH="$rustdoc_wrapper_dir:$PATH" mdbook test docs/book -L "$repo_root/target/release/deps" "$@"


### PR DESCRIPTION
## Summary
- finish the eager tenferro migration across `tensor4all-simplett` and the remaining TreeTN call sites
- migrate docs and CI so the root `README.md` and mdBook examples are exercised in CI
- expand AD regression coverage for `AnyScalar`, `TensorDynLen`, and TreeTN accumulation semantics

## Why
The workspace still had a few remaining call sites and tests tied to the older eager AD surface. This PR finishes the migration to the new eager tensor model, aligns the docs and examples with the current API, and fixes CI coverage gaps around mdBook and the root README.

## Main changes
- update `tensor4all-simplett` to the current eager tensor / typed tensor APIs
- refresh TreeTN AD tests and remove obsolete dependencies in `tensor4all-treetn`
- add AD tests for accumulation, clear-grad, detach/primal semantics, and clone aliasing in `tensor4all-core`
- add `Send + Sync` coverage for the eager tensor-backed core types
- add `scripts/test-mdbook.sh` and wire CI/docs deployment to run mdBook tests with resolved extern flags
- keep the root `README.md` short while making its Rust snippets part of CI via `docs/book-tests`

## Validation
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace`
- `cargo doc --workspace --no-deps`
- `cargo test --doc --release --workspace`
- `./scripts/test-mdbook.sh`

## Notes
- `cargo doc --workspace --no-deps` still emits pre-existing rustdoc warnings in other crates, but it completes successfully.