### PR TITLE
Add issue templates and cross-repo development guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting this issue!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal code or steps to reproduce the issue.
+      render: rust
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust version
+      placeholder: "1.82.0"
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "Ubuntu 24.04 / macOS 15 / Windows 11"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your feature proposal!
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What do you want to add or change? (1-2 sentences)
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this needed? What use case does it serve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-approach
+    attributes:
+      label: Proposed approach (optional)
+      description: If you have an idea for how to implement this, describe it here.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: How do we know this is done? Use a checklist.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: false
+  - type: textarea
+    id: cross-repo
+    attributes:
+      label: Related Tensor4all.jl issue (optional)
+      description: If this is needed for a Tensor4all.jl feature, link the issue here.
+      placeholder: "tensor4all/Tensor4all.jl#00"
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,20 @@ See `docs/CAPI_DESIGN.md` for C API patterns. Bindings: [Tensor4all.jl](https://
 
 Truncation tolerance: support both `cutoff` (ITensors) and `rtol` (tensor4all-rs). Conversion: `rtol = √cutoff`.
 
+### Cross-repo development with Tensor4all.jl
+
+When a Tensor4all.jl feature requires new C API functions:
+
+1. Develop both sides locally. Tensor4all.jl's `deps/build.jl` can use a local
+   Rust build via `TENSOR4ALL_RS_PATH`.
+2. Test both sides locally until all tests pass.
+3. Create and merge the tensor4all-rs PR **first**.
+4. Then update the pin hash in Tensor4all.jl `deps/build.jl` to the merged
+   commit on remote and create the Tensor4all.jl PR.
+
+Issue templates are in `.github/ISSUE_TEMPLATE/`. Feature requests from
+Tensor4all.jl should link the related Julia-side issue.
+
 ## Dependencies
 
 - Prefer `mdarray` for arrays (row-major only), `mdarray-linalg` for linear algebra


### PR DESCRIPTION
## Summary
- Add GitHub issue templates (Feature Request, Bug Report)
- Feature Request template includes a field for linking related Tensor4all.jl issues
- Document cross-repo development workflow in AGENTS.md

## Related
- tensor4all/Tensor4all.jl — corresponding contribution workflow being added there

🤖 Generated with [Claude Code](https://claude.com/claude-code)