### PR TITLE
feat(capi): add t4a_tensor_svd and t4a_tensor_qr

### DIFF
--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -401,6 +401,15 @@ StatusCode t4a_tensor_new_dense_f64(size_t rank,
                                     struct t4a_tensor **out);
 
 /**
+ * Compute the QR decomposition of a tensor split by the requested left indices.
+ */
+StatusCode t4a_tensor_qr(const struct t4a_tensor *tensor,
+                         const struct t4a_index *const *left_inds,
+                         size_t n_left,
+                         struct t4a_tensor **out_q,
+                         struct t4a_tensor **out_r);
+
+/**
  * Get the rank of a tensor.
  */
 StatusCode t4a_tensor_rank(const struct t4a_tensor *ptr, size_t *out_rank);
@@ -414,6 +423,29 @@ void t4a_tensor_release(struct t4a_tensor *obj);
  * Get the scalar kind of a tensor.
  */
 StatusCode t4a_tensor_scalar_kind(const struct t4a_tensor *ptr, enum t4a_scalar_kind *out_kind);
+
+/**
+ * Compute the SVD of a tensor split by the requested left indices.
+ */
+StatusCode t4a_tensor_svd(const struct t4a_tensor *tensor,
+                          const struct t4a_index *const *left_inds,
+                          size_t n_left,
+                          double rtol,
+                          double cutoff,
+                          size_t maxdim,
+                          struct t4a_tensor **out_u,
+                          struct t4a_tensor **out_s,
+                          struct t4a_tensor **out_v);
+
+/**
+ * Add two tree tensor networks, optionally truncating the result.
+ */
+StatusCode t4a_treetn_add(const struct t4a_treetn *a,
+                          const struct t4a_treetn *b,
+                          double rtol,
+                          double cutoff,
+                          size_t maxdim,
+                          struct t4a_treetn **out);
 
 /**
  * Apply a chain-compatible operator TreeTN to a chain state TreeTN.
@@ -437,6 +469,14 @@ StatusCode t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
                                            double cutoff,
                                            size_t maxdim,
                                            struct t4a_treetn **out);
+
+/**
+ * Get the canonical region vertices, sorted ascending.
+ */
+StatusCode t4a_treetn_canonical_region(const struct t4a_treetn *treetn,
+                                       size_t *buf,
+                                       size_t buf_len,
+                                       size_t *out_len);
 
 /**
  * Clone a TreeTN handle.
@@ -496,15 +536,6 @@ StatusCode t4a_treetn_neighbors(const struct t4a_treetn *treetn,
                                 size_t *out_len);
 
 /**
- * Get the canonical region vertices, sorted ascending.
- * Call with buf=NULL to query required length via out_len.
- */
-StatusCode t4a_treetn_canonical_region(const struct t4a_treetn *treetn,
-                                       size_t *buf,
-                                       size_t buf_len,
-                                       size_t *out_len);
-
-/**
  * Create a tree tensor network from an array of tensors.
  */
 StatusCode t4a_treetn_new(const struct t4a_tensor *const *tensors,
@@ -515,26 +546,6 @@ StatusCode t4a_treetn_new(const struct t4a_tensor *const *tensors,
  * Compute the norm of the tree tensor network.
  */
 StatusCode t4a_treetn_norm(struct t4a_treetn *treetn, double *out_norm);
-
-/**
- * Scale a tree tensor network by a complex scalar.
- */
-StatusCode t4a_treetn_scale(const struct t4a_treetn *treetn,
-                            double re,
-                            double im,
-                            struct t4a_treetn **out);
-
-/**
- * Add two tree tensor networks (direct sum of bond dimensions).
- * Optional truncation: set rtol > 0, cutoff > 0, or maxdim > 0.
- * cutoff is converted to rtol = sqrt(cutoff).
- */
-StatusCode t4a_treetn_add(const struct t4a_treetn *a,
-                          const struct t4a_treetn *b,
-                          double rtol,
-                          double cutoff,
-                          size_t maxdim,
-                          struct t4a_treetn **out);
 
 /**
  * Get the number of vertices in the tree tensor network.
@@ -552,6 +563,14 @@ StatusCode t4a_treetn_orthogonalize(struct t4a_treetn *treetn,
  * Release a TreeTN handle.
  */
 void t4a_treetn_release(struct t4a_treetn *obj);
+
+/**
+ * Scale a tree tensor network by a complex scalar.
+ */
+StatusCode t4a_treetn_scale(const struct t4a_treetn *treetn,
+                            double re,
+                            double im,
+                            struct t4a_treetn **out);
 
 /**
  * Replace the tensor at a specific vertex.

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -3,11 +3,13 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use num_complex::Complex64;
+use tensor4all_core::{qr, svd_with, SvdOptions, TruncationParams};
 
 use crate::types::{t4a_index, t4a_scalar_kind, t4a_tensor, InternalIndex, InternalTensor};
 use crate::{
-    capi_error, clone_opaque, is_assigned_opaque, release_opaque, run_catching, StatusCode,
-    T4A_BUFFER_TOO_SMALL, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
+    capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
+    set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
+    T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 
 /// Release a tensor handle.
@@ -58,6 +60,48 @@ fn read_indices_from_ptrs(
 
 fn dims_from_indices(indices: &[InternalIndex]) -> Vec<usize> {
     indices.iter().map(|index| index.size()).collect()
+}
+
+fn run_status<F>(f: F) -> StatusCode
+where
+    F: FnOnce() -> CapiResult<()>,
+{
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(Ok(())) => T4A_SUCCESS,
+        Ok(Err((code, msg))) => {
+            set_last_error(&msg);
+            code
+        }
+        Err(panic) => {
+            let msg = panic_message(&*panic);
+            set_last_error(&msg);
+            T4A_INTERNAL_ERROR
+        }
+    }
+}
+
+fn require_tensor<'a>(ptr: *const t4a_tensor) -> Result<&'a t4a_tensor, (StatusCode, String)> {
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, "tensor is null"));
+    }
+    Ok(unsafe { &*ptr })
+}
+
+fn build_svd_options(rtol: f64, cutoff: f64, maxdim: usize) -> SvdOptions {
+    let mut truncation = TruncationParams::new();
+    if cutoff > 0.0 {
+        truncation = truncation.with_cutoff(cutoff);
+    } else if rtol > 0.0 {
+        truncation = truncation.with_rtol(rtol);
+    }
+    if maxdim > 0 {
+        truncation = truncation.with_max_rank(maxdim);
+    }
+    SvdOptions { truncation }
+}
+
+fn box_tensor_handle(tensor: InternalTensor) -> *mut t4a_tensor {
+    Box::into_raw(Box::new(t4a_tensor::new(tensor)))
 }
 
 /// Get the rank of a tensor.
@@ -237,6 +281,75 @@ pub extern "C" fn t4a_tensor_contract(
 
     run_catching(out, || unsafe {
         Ok(t4a_tensor::new((*a).inner().contract((*b).inner())))
+    })
+}
+
+/// Compute the SVD of a tensor split by the requested left indices.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_svd(
+    tensor: *const t4a_tensor,
+    left_inds: *const *const t4a_index,
+    n_left: usize,
+    rtol: f64,
+    cutoff: f64,
+    maxdim: usize,
+    out_u: *mut *mut t4a_tensor,
+    out_s: *mut *mut t4a_tensor,
+    out_v: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(tensor)?;
+        if out_u.is_null() || out_s.is_null() || out_v.is_null() {
+            return Err(capi_error(
+                T4A_NULL_POINTER,
+                "out_u, out_s, or out_v is null",
+            ));
+        }
+
+        let left_inds = read_indices_from_ptrs(n_left, left_inds)?;
+        let options = build_svd_options(rtol, cutoff, maxdim);
+        let (u, s, v) = match t4a_scalar_kind::from_tensor(tensor.inner()) {
+            t4a_scalar_kind::F64 => svd_with::<f64>(tensor.inner(), &left_inds, &options),
+            t4a_scalar_kind::C64 => svd_with::<Complex64>(tensor.inner(), &left_inds, &options),
+        }
+        .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+
+        unsafe {
+            *out_u = box_tensor_handle(u);
+            *out_s = box_tensor_handle(s);
+            *out_v = box_tensor_handle(v);
+        }
+        Ok(())
+    })
+}
+
+/// Compute the QR decomposition of a tensor split by the requested left indices.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_qr(
+    tensor: *const t4a_tensor,
+    left_inds: *const *const t4a_index,
+    n_left: usize,
+    out_q: *mut *mut t4a_tensor,
+    out_r: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(tensor)?;
+        if out_q.is_null() || out_r.is_null() {
+            return Err(capi_error(T4A_NULL_POINTER, "out_q or out_r is null"));
+        }
+
+        let left_inds = read_indices_from_ptrs(n_left, left_inds)?;
+        let (q, r) = match t4a_scalar_kind::from_tensor(tensor.inner()) {
+            t4a_scalar_kind::F64 => qr::<f64>(tensor.inner(), &left_inds),
+            t4a_scalar_kind::C64 => qr::<Complex64>(tensor.inner(), &left_inds),
+        }
+        .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+
+        unsafe {
+            *out_q = box_tensor_handle(q);
+            *out_r = box_tensor_handle(r);
+        }
+        Ok(())
     })
 }
 

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::index::{t4a_index_new, t4a_index_release};
+use num_complex::Complex64;
 
 fn new_index(dim: usize) -> *mut t4a_index {
     let mut out = std::ptr::null_mut();
@@ -27,6 +28,22 @@ fn new_tensor_f64(indices: &[*const t4a_index], data: &[f64]) -> *mut t4a_tensor
     out
 }
 
+fn new_tensor_c64(indices: &[*const t4a_index], data_interleaved: &[f64]) -> *mut t4a_tensor {
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_dense_c64(
+            indices.len(),
+            indices.as_ptr(),
+            data_interleaved.as_ptr(),
+            data_interleaved.len() / 2,
+            &mut out
+        ),
+        T4A_SUCCESS
+    );
+    assert!(!out.is_null());
+    out
+}
+
 fn read_dense_f64(tensor: *const t4a_tensor) -> Vec<f64> {
     let mut len = 0usize;
     assert_eq!(
@@ -39,6 +56,52 @@ fn read_dense_f64(tensor: *const t4a_tensor) -> Vec<f64> {
         T4A_SUCCESS
     );
     data
+}
+
+fn assert_tensors_close(actual: &InternalTensor, expected: &InternalTensor, tol: f64) {
+    let diff = actual - expected;
+    let maxabs = diff.maxabs();
+    assert!(
+        maxabs < tol,
+        "tensor maxabs diff {maxabs} exceeded tolerance {tol}"
+    );
+}
+
+fn reconstruct_svd(
+    u: *const t4a_tensor,
+    s: *const t4a_tensor,
+    v: *const t4a_tensor,
+) -> InternalTensor {
+    let v = unsafe { (*v).inner() };
+    let s = unsafe { (*s).inner() };
+    let mut perm = vec![v.indices.len() - 1];
+    perm.extend(0..(v.indices.len() - 1));
+    let vh = v.conj().permute(&perm);
+    let svh = s.contract(&vh);
+    let sim_bond = s.indices[1].clone();
+    let bond = v.indices[v.indices.len() - 1].clone();
+    let svh = svh.replaceind(&sim_bond, &bond);
+    unsafe { (*u).inner().contract(&svh) }
+}
+
+fn reconstruct_qr(q: *const t4a_tensor, r: *const t4a_tensor) -> InternalTensor {
+    unsafe { (*q).inner().contract((*r).inner()) }
+}
+
+fn internal_tensor_f64(indices: &[*const t4a_index], data: &[f64]) -> InternalTensor {
+    let indices = indices
+        .iter()
+        .map(|index| unsafe { (**index).inner().clone() })
+        .collect();
+    InternalTensor::from_dense(indices, data.to_vec()).unwrap()
+}
+
+fn internal_tensor_c64(indices: &[*const t4a_index], data: &[Complex64]) -> InternalTensor {
+    let indices = indices
+        .iter()
+        .map(|index| unsafe { (**index).inner().clone() })
+        .collect();
+    InternalTensor::from_dense(indices, data.to_vec()).unwrap()
 }
 
 #[test]
@@ -170,4 +233,252 @@ fn test_tensor_contract_matches_matrix_multiplication() {
     t4a_index_release(k);
     t4a_index_release(j);
     t4a_index_release(i);
+}
+
+#[test]
+fn test_tensor_svd_rank2() {
+    let i = new_index(3);
+    let j = new_index(4);
+    let tensor = new_tensor_f64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0],
+    );
+
+    let mut u = std::ptr::null_mut();
+    let mut s = std::ptr::null_mut();
+    let mut v = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_svd(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            0.0,
+            0.0,
+            0,
+            &mut u,
+            &mut s,
+            &mut v
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*u).inner().dims() }, vec![3, 3]);
+    assert_eq!(unsafe { (*s).inner().dims() }, vec![3, 3]);
+    assert_eq!(unsafe { (*v).inner().dims() }, vec![4, 3]);
+
+    let reconstructed = reconstruct_svd(u, s, v);
+    assert_tensors_close(&reconstructed, unsafe { (*tensor).inner() }, 1.0e-10);
+
+    for handle in [v, s, u, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_svd_truncation() {
+    let i = new_index(3);
+    let j = new_index(3);
+    let tensor = new_tensor_f64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[4.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+    );
+
+    let mut u = std::ptr::null_mut();
+    let mut s = std::ptr::null_mut();
+    let mut v = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_svd(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            0.0,
+            0.0,
+            1,
+            &mut u,
+            &mut s,
+            &mut v
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*u).inner().dims() }, vec![3, 1]);
+    assert_eq!(unsafe { (*s).inner().dims() }, vec![1, 1]);
+    assert_eq!(unsafe { (*v).inner().dims() }, vec![3, 1]);
+
+    let reconstructed = reconstruct_svd(u, s, v);
+    let expected = internal_tensor_f64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[4.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    );
+    assert_tensors_close(&reconstructed, &expected, 1.0e-10);
+
+    for handle in [v, s, u, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_svd_rank3() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(4);
+    let data = vec![
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ];
+    let tensor = new_tensor_f64(
+        &[
+            i as *const t4a_index,
+            j as *const t4a_index,
+            k as *const t4a_index,
+        ],
+        &data,
+    );
+
+    let mut u = std::ptr::null_mut();
+    let mut s = std::ptr::null_mut();
+    let mut v = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_svd(
+            tensor,
+            [i as *const t4a_index, j as *const t4a_index].as_ptr(),
+            2,
+            0.0,
+            0.0,
+            0,
+            &mut u,
+            &mut s,
+            &mut v
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*u).inner().dims() }, vec![2, 3, 4]);
+    assert_eq!(unsafe { (*s).inner().dims() }, vec![4, 4]);
+    assert_eq!(unsafe { (*v).inner().dims() }, vec![4, 4]);
+
+    let reconstructed = reconstruct_svd(u, s, v);
+    assert_tensors_close(&reconstructed, unsafe { (*tensor).inner() }, 1.0e-10);
+
+    for handle in [v, s, u, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [k, j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_qr_rank2() {
+    let i = new_index(3);
+    let j = new_index(4);
+    let tensor = new_tensor_f64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0],
+    );
+
+    let mut q = std::ptr::null_mut();
+    let mut r = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_qr(tensor, [i as *const t4a_index].as_ptr(), 1, &mut q, &mut r),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*q).inner().dims() }, vec![3, 3]);
+    assert_eq!(unsafe { (*r).inner().dims() }, vec![3, 4]);
+
+    let reconstructed = reconstruct_qr(q, r);
+    assert_tensors_close(&reconstructed, unsafe { (*tensor).inner() }, 1.0e-10);
+
+    for handle in [r, q, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_qr_rank3() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(4);
+    let data = vec![
+        1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+    ];
+    let tensor = new_tensor_f64(
+        &[
+            i as *const t4a_index,
+            j as *const t4a_index,
+            k as *const t4a_index,
+        ],
+        &data,
+    );
+
+    let mut q = std::ptr::null_mut();
+    let mut r = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_qr(
+            tensor,
+            [i as *const t4a_index, j as *const t4a_index].as_ptr(),
+            2,
+            &mut q,
+            &mut r
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*q).inner().dims() }, vec![2, 3, 4]);
+    assert_eq!(unsafe { (*r).inner().dims() }, vec![4, 4]);
+
+    let reconstructed = reconstruct_qr(q, r);
+    assert_tensors_close(&reconstructed, unsafe { (*tensor).inner() }, 1.0e-10);
+
+    for handle in [r, q, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [k, j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_qr_rank2_c64() {
+    let i = new_index(2);
+    let j = new_index(2);
+    let data = [
+        Complex64::new(1.0, 1.0),
+        Complex64::new(3.0, -0.5),
+        Complex64::new(2.0, -2.0),
+        Complex64::new(-1.0, 0.25),
+    ];
+    let tensor = new_tensor_c64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[1.0, 1.0, 3.0, -0.5, 2.0, -2.0, -1.0, 0.25],
+    );
+
+    let mut q = std::ptr::null_mut();
+    let mut r = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_qr(tensor, [i as *const t4a_index].as_ptr(), 1, &mut q, &mut r),
+        T4A_SUCCESS
+    );
+
+    let reconstructed = reconstruct_qr(q, r);
+    let expected = internal_tensor_c64(&[i as *const t4a_index, j as *const t4a_index], &data);
+    assert_tensors_close(&reconstructed, &expected, 1.0e-10);
+
+    for handle in [r, q, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [j, i] {
+        t4a_index_release(index);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `t4a_tensor_svd` — truncated SVD with rtol/cutoff/maxdim params, supports f64 and c64
- Add `t4a_tensor_qr` — QR factorization with left index selection

Both wrap existing `tensor4all_core` implementations and follow the standard C API handle patterns.

## Motivation

Required for Tensor4all.jl Phase 1 migration APIs (tensor factorization for BubbleTeaCI).

## Test plan

- [ ] `cargo nextest run --release --workspace` passes
- [ ] SVD: rank-2 reconstruct, truncation with maxdim, rank-3 tensor
- [ ] QR: rank-2 reconstruct, rank-3 tensor

🤖 Generated with [Claude Code](https://claude.com/claude-code)