### PR TITLE
feat: expose TreeTN backend options and restructuring C APIs

### DIFF
--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -606,6 +606,45 @@ StatusCode t4a_treetn_linkind(const struct t4a_treetn *treetn,
                               struct t4a_index **out);
 
 /**
+ * Solve `(a0 + a1 * operator) * x = rhs` for `x` as a TreeTN.
+ *
+ * The solver returns only the solution TreeTN. The Rust-side `SquareLinsolveResult`
+ * also tracks sweep metadata, but that is not yet exposed through the C ABI.
+ *
+ * `mapped_vertices` and the four index arrays provide optional per-vertex
+ * index mappings when the operator uses internal site indices distinct from
+ * the `init` / `rhs` site indices. Pass `n_mapped_vertices == 0` to disable
+ * mappings.
+ *
+ * Current limitation: the sweep-based backend still assumes that `init` and
+ * `rhs` share the same true site-index set. The mapping arrays bridge the
+ * operator's internal indices to those true indices, but they do not yet
+ * support solving between distinct `init` and `rhs` true index spaces.
+ */
+StatusCode t4a_treetn_linsolve(const struct t4a_treetn *operator_,
+                               const struct t4a_treetn *rhs,
+                               const struct t4a_treetn *init,
+                               size_t center_vertex,
+                               const size_t *mapped_vertices,
+                               size_t n_mapped_vertices,
+                               const struct t4a_index *const *true_input_indices,
+                               const struct t4a_index *const *internal_input_indices,
+                               const struct t4a_index *const *true_output_indices,
+                               const struct t4a_index *const *internal_output_indices,
+                               double rtol,
+                               double cutoff,
+                               size_t maxdim,
+                               enum t4a_canonical_form form,
+                               size_t nfullsweeps,
+                               double krylov_tol,
+                               size_t krylov_maxiter,
+                               size_t krylov_dim,
+                               double a0,
+                               double a1,
+                               double convergence_tol,
+                               struct t4a_treetn **out);
+
+/**
  * Get the neighbors of a vertex.
  */
 StatusCode t4a_treetn_neighbors(const struct t4a_treetn *treetn,

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -78,6 +78,28 @@ typedef enum t4a_contract_method {
 } t4a_contract_method;
 
 /**
+ * Factorization algorithms exposed through the C API.
+ */
+typedef enum t4a_factorize_alg {
+  /**
+   * Singular value decomposition.
+   */
+  T4A_FACTORIZE_ALG_SVD = 0,
+  /**
+   * QR decomposition.
+   */
+  T4A_FACTORIZE_ALG_QR = 1,
+  /**
+   * Rank-revealing LU decomposition.
+   */
+  T4A_FACTORIZE_ALG_LU = 2,
+  /**
+   * Cross interpolation.
+   */
+  T4A_FACTORIZE_ALG_CI = 3,
+} t4a_factorize_alg;
+
+/**
  * Canonical form used for orthogonalization/truncation.
  */
 typedef enum t4a_canonical_form {
@@ -402,10 +424,43 @@ StatusCode t4a_tensor_new_dense_f64(size_t rank,
 
 /**
  * Compute the QR decomposition of a tensor split by the requested left indices.
+ *
+ * The tensor is unfolded into a matrix by treating `left_inds[..n_left]` as row
+ * indices and all remaining tensor indices as columns, then factorized as
+ * `tensor = Q * R`.
+ *
+ * # Arguments
+ * * `tensor` - Input tensor handle to factorize.
+ * * `left_inds` - Pointers to the indices that should appear on the left side
+ *   of the factorization.
+ * * `n_left` - Number of entries in `left_inds`.
+ * * `rtol` - Relative truncation tolerance for QR row-norm truncation. Pass
+ *   `0.0` to disable truncation and keep the exact QR rank. Pass any other
+ *   finite, non-negative value to request truncation for this call.
+ * * `out_q` - Output slot that receives a newly allocated `Q` tensor handle on
+ *   success.
+ * * `out_r` - Output slot that receives a newly allocated `R` tensor handle on
+ *   success.
+ *
+ * # Returns
+ * Returns `T4A_SUCCESS` on success and writes owned tensor handles to
+ * `out_q` and `out_r`. The caller must release both handles with
+ * [`t4a_tensor_release`].
+ *
+ * # Errors
+ * Returns:
+ * - `T4A_NULL_POINTER` if `tensor`, any required index pointer, `out_q`, or
+ *   `out_r` is null.
+ * - `T4A_INVALID_ARGUMENT` if the index split is invalid, QR factorization
+ *   fails, or `rtol` is negative or non-finite (for example `NaN` or
+ *   `+/-inf`).
+ * - `T4A_INTERNAL_ERROR` if the Rust implementation panics while processing
+ *   the request.
  */
 StatusCode t4a_tensor_qr(const struct t4a_tensor *tensor,
                          const struct t4a_index *const *left_inds,
                          size_t n_left,
+                         double rtol,
                          struct t4a_tensor **out_q,
                          struct t4a_tensor **out_r);
 
@@ -456,6 +511,9 @@ StatusCode t4a_treetn_add(const struct t4a_treetn *a,
  * `internal_input_indices[i]` and `internal_output_indices[i]` must point to
  * those indices. Unmapped state nodes are filled with identities by
  * `apply_linear_operator`.
+ *
+ * For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
+ * default", which currently resolves to one variational sweep.
  */
 StatusCode t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
                                            const struct t4a_treetn *state,
@@ -468,6 +526,8 @@ StatusCode t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
                                            double rtol,
                                            double cutoff,
                                            size_t maxdim,
+                                           size_t nfullsweeps,
+                                           double convergence_tol,
                                            struct t4a_treetn **out);
 
 /**
@@ -485,6 +545,9 @@ StatusCode t4a_treetn_clone(const struct t4a_treetn *src, struct t4a_treetn **ou
 
 /**
  * Contract two tree tensor networks with the requested method.
+ *
+ * For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
+ * default", which currently resolves to one variational sweep.
  */
 StatusCode t4a_treetn_contract(const struct t4a_treetn *a,
                                const struct t4a_treetn *b,
@@ -492,6 +555,9 @@ StatusCode t4a_treetn_contract(const struct t4a_treetn *a,
                                double rtol,
                                double cutoff,
                                size_t maxdim,
+                               size_t nfullsweeps,
+                               double convergence_tol,
+                               enum t4a_factorize_alg factorize_alg,
                                struct t4a_treetn **out);
 
 /**
@@ -504,6 +570,19 @@ StatusCode t4a_treetn_evaluate(const struct t4a_treetn *treetn,
                                size_t n_points,
                                double *out_re,
                                double *out_im);
+
+/**
+ * Fuse connected current-node groups into the requested target topology.
+ */
+StatusCode t4a_treetn_fuse_to(const struct t4a_treetn *treetn,
+                              const size_t *target_vertices,
+                              size_t n_target_vertices,
+                              const struct t4a_index *const *target_siteinds,
+                              const size_t *target_siteinds_len,
+                              const size_t *target_edge_sources,
+                              const size_t *target_edge_targets,
+                              size_t n_target_edges,
+                              struct t4a_treetn **out);
 
 /**
  * Compute the inner product of two tree tensor networks.
@@ -554,15 +633,45 @@ StatusCode t4a_treetn_num_vertices(const struct t4a_treetn *treetn, size_t *out_
 
 /**
  * Orthogonalize the tree tensor network to a vertex using the requested form.
+ *
+ * When `force == 0`, this uses smart canonicalization:
+ * - If the network is already canonical at `vertex` with `form`, the call is a no-op.
+ * - If the network is already canonicalized with a different form, the call returns
+ *   `T4A_INVALID_ARGUMENT`. Pass a nonzero `force` to re-canonicalize with a different form.
  */
 StatusCode t4a_treetn_orthogonalize(struct t4a_treetn *treetn,
                                     size_t vertex,
-                                    enum t4a_canonical_form form);
+                                    enum t4a_canonical_form form,
+                                    int force);
 
 /**
  * Release a TreeTN handle.
  */
 void t4a_treetn_release(struct t4a_treetn *obj);
+
+/**
+ * Restructure a TreeTN using split, swap, and optional final truncation phases.
+ */
+StatusCode t4a_treetn_restructure_to(const struct t4a_treetn *treetn,
+                                     const size_t *target_vertices,
+                                     size_t n_target_vertices,
+                                     const struct t4a_index *const *target_siteinds,
+                                     const size_t *target_siteinds_len,
+                                     const size_t *target_edge_sources,
+                                     const size_t *target_edge_targets,
+                                     size_t n_target_edges,
+                                     double split_rtol,
+                                     double split_cutoff,
+                                     size_t split_maxdim,
+                                     enum t4a_canonical_form split_form,
+                                     int split_final_sweep,
+                                     size_t swap_maxdim,
+                                     double swap_rtol,
+                                     double final_rtol,
+                                     double final_cutoff,
+                                     size_t final_maxdim,
+                                     enum t4a_canonical_form final_form,
+                                     struct t4a_treetn **out);
 
 /**
  * Scale a tree tensor network by a complex scalar.
@@ -589,6 +698,35 @@ StatusCode t4a_treetn_siteinds(const struct t4a_treetn *treetn,
                                size_t *out_len);
 
 /**
+ * Split current nodes to match the requested target topology.
+ */
+StatusCode t4a_treetn_split_to(const struct t4a_treetn *treetn,
+                               const size_t *target_vertices,
+                               size_t n_target_vertices,
+                               const struct t4a_index *const *target_siteinds,
+                               const size_t *target_siteinds_len,
+                               const size_t *target_edge_sources,
+                               const size_t *target_edge_targets,
+                               size_t n_target_edges,
+                               double rtol,
+                               double cutoff,
+                               size_t maxdim,
+                               enum t4a_canonical_form form,
+                               int final_sweep,
+                               struct t4a_treetn **out);
+
+/**
+ * Reassign site indices to target vertices using scheduled swap transport.
+ */
+StatusCode t4a_treetn_swap_site_indices(const struct t4a_treetn *treetn,
+                                        const struct t4a_index *const *assignment_siteinds,
+                                        const size_t *assignment_target_vertices,
+                                        size_t n_assignments,
+                                        size_t maxdim,
+                                        double rtol,
+                                        struct t4a_treetn **out);
+
+/**
  * Get the tensor at a specific vertex.
  */
 StatusCode t4a_treetn_tensor(const struct t4a_treetn *treetn,
@@ -606,6 +744,7 @@ StatusCode t4a_treetn_to_dense(const struct t4a_treetn *treetn, struct t4a_tenso
 StatusCode t4a_treetn_truncate(struct t4a_treetn *treetn,
                                double rtol,
                                double cutoff,
-                               size_t maxdim);
+                               size_t maxdim,
+                               enum t4a_canonical_form form);
 
 #endif  /* TENSOR4ALL_CAPI_H */

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -180,7 +180,7 @@ fn c_operator_matrix(
         }
     }
 
-    for index in out_indices.into_iter().chain(in_indices.into_iter()) {
+    for index in out_indices.into_iter().chain(in_indices) {
         crate::index::t4a_index_release(index);
     }
     matrix

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -3,7 +3,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use num_complex::Complex64;
-use tensor4all_core::{qr, svd_with, SvdOptions, TruncationParams};
+use tensor4all_core::{qr_with, svd_with, QrOptions, SvdOptions, TruncationParams};
 
 use crate::types::{t4a_index, t4a_scalar_kind, t4a_tensor, InternalIndex, InternalTensor};
 use crate::{
@@ -98,6 +98,11 @@ fn build_svd_options(rtol: f64, cutoff: f64, maxdim: usize) -> SvdOptions {
         truncation = truncation.with_max_rank(maxdim);
     }
     SvdOptions { truncation }
+}
+
+fn build_qr_options(rtol: f64) -> QrOptions {
+    // `0.0` is the C-API sentinel for exact QR without truncation.
+    QrOptions::with_rtol(rtol)
 }
 
 fn box_tensor_handle(tensor: InternalTensor) -> *mut t4a_tensor {
@@ -324,11 +329,44 @@ pub extern "C" fn t4a_tensor_svd(
 }
 
 /// Compute the QR decomposition of a tensor split by the requested left indices.
+///
+/// The tensor is unfolded into a matrix by treating `left_inds[..n_left]` as row
+/// indices and all remaining tensor indices as columns, then factorized as
+/// `tensor = Q * R`.
+///
+/// # Arguments
+/// * `tensor` - Input tensor handle to factorize.
+/// * `left_inds` - Pointers to the indices that should appear on the left side
+///   of the factorization.
+/// * `n_left` - Number of entries in `left_inds`.
+/// * `rtol` - Relative truncation tolerance for QR row-norm truncation. Pass
+///   `0.0` to disable truncation and keep the exact QR rank. Pass any other
+///   finite, non-negative value to request truncation for this call.
+/// * `out_q` - Output slot that receives a newly allocated `Q` tensor handle on
+///   success.
+/// * `out_r` - Output slot that receives a newly allocated `R` tensor handle on
+///   success.
+///
+/// # Returns
+/// Returns `T4A_SUCCESS` on success and writes owned tensor handles to
+/// `out_q` and `out_r`. The caller must release both handles with
+/// [`t4a_tensor_release`].
+///
+/// # Errors
+/// Returns:
+/// - `T4A_NULL_POINTER` if `tensor`, any required index pointer, `out_q`, or
+///   `out_r` is null.
+/// - `T4A_INVALID_ARGUMENT` if the index split is invalid, QR factorization
+///   fails, or `rtol` is negative or non-finite (for example `NaN` or
+///   `+/-inf`).
+/// - `T4A_INTERNAL_ERROR` if the Rust implementation panics while processing
+///   the request.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_tensor_qr(
     tensor: *const t4a_tensor,
     left_inds: *const *const t4a_index,
     n_left: usize,
+    rtol: f64,
     out_q: *mut *mut t4a_tensor,
     out_r: *mut *mut t4a_tensor,
 ) -> StatusCode {
@@ -339,9 +377,10 @@ pub extern "C" fn t4a_tensor_qr(
         }
 
         let left_inds = read_indices_from_ptrs(n_left, left_inds)?;
+        let options = build_qr_options(rtol);
         let (q, r) = match t4a_scalar_kind::from_tensor(tensor.inner()) {
-            t4a_scalar_kind::F64 => qr::<f64>(tensor.inner(), &left_inds),
-            t4a_scalar_kind::C64 => qr::<Complex64>(tensor.inner(), &left_inds),
+            t4a_scalar_kind::F64 => qr_with::<f64>(tensor.inner(), &left_inds, &options),
+            t4a_scalar_kind::C64 => qr_with::<Complex64>(tensor.inner(), &left_inds, &options),
         }
         .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
 

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -386,7 +386,14 @@ fn test_tensor_qr_rank2() {
     let mut q = std::ptr::null_mut();
     let mut r = std::ptr::null_mut();
     assert_eq!(
-        t4a_tensor_qr(tensor, [i as *const t4a_index].as_ptr(), 1, &mut q, &mut r),
+        t4a_tensor_qr(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            0.0,
+            &mut q,
+            &mut r
+        ),
         T4A_SUCCESS
     );
 
@@ -429,6 +436,7 @@ fn test_tensor_qr_rank3() {
             tensor,
             [i as *const t4a_index, j as *const t4a_index].as_ptr(),
             2,
+            0.0,
             &mut q,
             &mut r
         ),
@@ -467,7 +475,14 @@ fn test_tensor_qr_rank2_c64() {
     let mut q = std::ptr::null_mut();
     let mut r = std::ptr::null_mut();
     assert_eq!(
-        t4a_tensor_qr(tensor, [i as *const t4a_index].as_ptr(), 1, &mut q, &mut r),
+        t4a_tensor_qr(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            0.0,
+            &mut q,
+            &mut r
+        ),
         T4A_SUCCESS
     );
 
@@ -476,6 +491,57 @@ fn test_tensor_qr_rank2_c64() {
     assert_tensors_close(&reconstructed, &expected, 1.0e-10);
 
     for handle in [r, q, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_qr_zero_rtol_disables_truncation() {
+    let i = new_index(2);
+    let j = new_index(2);
+    let tensor = new_tensor_f64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[1.0, 0.0, 0.0, 1.0e-16],
+    );
+
+    let mut q_exact = std::ptr::null_mut();
+    let mut r_exact = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_qr(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            0.0,
+            &mut q_exact,
+            &mut r_exact
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*q_exact).inner().dims() }, vec![2, 2]);
+    assert_eq!(unsafe { (*r_exact).inner().dims() }, vec![2, 2]);
+
+    let mut q_truncated = std::ptr::null_mut();
+    let mut r_truncated = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_qr(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            1.0e-12,
+            &mut q_truncated,
+            &mut r_truncated
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*q_truncated).inner().dims() }, vec![2, 1]);
+    assert_eq!(unsafe { (*r_truncated).inner().dims() }, vec![1, 2]);
+
+    for handle in [r_truncated, q_truncated, r_exact, q_exact, tensor] {
         t4a_tensor_release(handle);
     }
     for index in [j, i] {

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -249,8 +249,8 @@ fn collect_target_assignment(
     )?;
     let mut target_assignment = HashMap::with_capacity(n_assignments);
     for (siteind, target_vertex) in siteinds.into_iter().zip(target_vertices) {
-        let site_id = siteind.id().clone();
-        if let Some(previous_target) = target_assignment.insert(site_id.clone(), target_vertex) {
+        let site_id = *siteind.id();
+        if let Some(previous_target) = target_assignment.insert(site_id, target_vertex) {
             return Err(capi_error(
                 T4A_INVALID_ARGUMENT,
                 format!(
@@ -263,6 +263,7 @@ fn collect_target_assignment(
     Ok(target_assignment)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_target_network(
     target_vertices: *const libc::size_t,
     n_target_vertices: usize,
@@ -314,8 +315,8 @@ fn build_target_network(
         }
         let mut site_space = HashSet::with_capacity(len);
         for siteind in &flat_siteinds[offset..offset + len] {
-            let site_id = siteind.id().clone();
-            if let Some(previous_vertex) = seen_siteinds.insert(site_id.clone(), vertex) {
+            let site_id = *siteind.id();
+            if let Some(previous_vertex) = seen_siteinds.insert(site_id, vertex) {
                 return Err(capi_error(
                     T4A_INVALID_ARGUMENT,
                     format!(
@@ -644,6 +645,7 @@ type LinsolveMappings = (
     HashMap<usize, IndexMapping<InternalIndex>>,
 );
 
+#[allow(clippy::too_many_arguments)]
 fn build_linsolve_index_mappings(
     operator: &InternalTreeTN,
     rhs: &InternalTreeTN,
@@ -1569,7 +1571,6 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
                 rtol: resolve_rtol(rtol, cutoff),
                 nfullsweeps: fit_nfullsweeps,
                 convergence_tol: resolve_convergence_tol(convergence_tol),
-                ..Default::default()
             },
         )
         .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -15,8 +15,9 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike};
 use tensor4all_treetn::treetn::contraction::{self, ContractionMethod, ContractionOptions};
 use tensor4all_treetn::{
-    apply_linear_operator, ApplyOptions, CanonicalizationOptions, IndexMapping, LinearOperator,
-    RestructureOptions, SiteIndexNetwork, SplitOptions, SwapOptions, TruncationOptions,
+    apply_linear_operator, square_linsolve, ApplyOptions, CanonicalizationOptions, IndexMapping,
+    LinearOperator, LinsolveOptions, RestructureOptions, SiteIndexNetwork, SplitOptions,
+    SwapOptions, TruncationOptions,
 };
 
 /// Release a TreeTN handle.
@@ -636,6 +637,152 @@ fn build_chain_linear_operator(
         input_mapping,
         output_mapping,
     ))
+}
+
+type LinsolveMappings = (
+    HashMap<usize, IndexMapping<InternalIndex>>,
+    HashMap<usize, IndexMapping<InternalIndex>>,
+);
+
+fn build_linsolve_index_mappings(
+    operator: &InternalTreeTN,
+    rhs: &InternalTreeTN,
+    init: &InternalTreeTN,
+    mapped_vertices: *const libc::size_t,
+    n_mapped_vertices: usize,
+    true_input_indices: *const *const t4a_index,
+    internal_input_indices: *const *const t4a_index,
+    true_output_indices: *const *const t4a_index,
+    internal_output_indices: *const *const t4a_index,
+) -> CapiResult<Option<LinsolveMappings>> {
+    if n_mapped_vertices == 0 {
+        return Ok(None);
+    }
+
+    let mapped_vertices = collect_positions(mapped_vertices, n_mapped_vertices, "mapped_vertices")?;
+    let true_inputs = collect_indices(true_input_indices, n_mapped_vertices, "true_input_indices")?;
+    let internal_inputs = collect_indices(
+        internal_input_indices,
+        n_mapped_vertices,
+        "internal_input_indices",
+    )?;
+    let true_outputs = collect_indices(
+        true_output_indices,
+        n_mapped_vertices,
+        "true_output_indices",
+    )?;
+    let internal_outputs = collect_indices(
+        internal_output_indices,
+        n_mapped_vertices,
+        "internal_output_indices",
+    )?;
+
+    let mut input_mapping = HashMap::with_capacity(n_mapped_vertices);
+    let mut output_mapping = HashMap::with_capacity(n_mapped_vertices);
+
+    for slot in 0..n_mapped_vertices {
+        let vertex = mapped_vertices[slot];
+        require_node(operator, vertex)?;
+        require_node(rhs, vertex)?;
+        require_node(init, vertex)?;
+
+        let operator_site_space = operator.site_space(&vertex).ok_or_else(|| {
+            capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("operator vertex {vertex} has no site indices"),
+            )
+        })?;
+        let rhs_site_space = rhs.site_space(&vertex).ok_or_else(|| {
+            capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("rhs vertex {vertex} has no site indices"),
+            )
+        })?;
+        let init_site_space = init.site_space(&vertex).ok_or_else(|| {
+            capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("init vertex {vertex} has no site indices"),
+            )
+        })?;
+
+        let true_input = &true_inputs[slot];
+        let internal_input = &internal_inputs[slot];
+        let true_output = &true_outputs[slot];
+        let internal_output = &internal_outputs[slot];
+
+        if !init_site_space.contains(true_input) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("init vertex {vertex} does not contain the provided true input index"),
+            ));
+        }
+        if !rhs_site_space.contains(true_output) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("rhs vertex {vertex} does not contain the provided true output index"),
+            ));
+        }
+        if !operator_site_space.contains(internal_input) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!(
+                    "operator vertex {vertex} does not contain the provided internal input index"
+                ),
+            ));
+        }
+        if !operator_site_space.contains(internal_output) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!(
+                    "operator vertex {vertex} does not contain the provided internal output index"
+                ),
+            ));
+        }
+        if true_input.dim() != internal_input.dim() {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!(
+                    "input index dimension mismatch at vertex {vertex}: init has {}, operator internal input has {}",
+                    true_input.dim(),
+                    internal_input.dim()
+                ),
+            ));
+        }
+        if true_output.dim() != internal_output.dim() {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!(
+                    "output index dimension mismatch at vertex {vertex}: rhs has {}, operator internal output has {}",
+                    true_output.dim(),
+                    internal_output.dim()
+                ),
+            ));
+        }
+
+        if input_mapping.contains_key(&vertex) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("duplicate mapped vertex {vertex} in linsolve input mapping"),
+            ));
+        }
+
+        input_mapping.insert(
+            vertex,
+            IndexMapping {
+                true_index: true_input.clone(),
+                internal_index: internal_input.clone(),
+            },
+        );
+        output_mapping.insert(
+            vertex,
+            IndexMapping {
+                true_index: true_output.clone(),
+                internal_index: internal_output.clone(),
+            },
+        );
+    }
+
+    Ok(Some((input_mapping, output_mapping)))
 }
 
 /// Create a tree tensor network from an array of tensors.
@@ -1427,6 +1574,147 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
         )
         .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
         Ok(t4a_treetn::new(result))
+    })
+}
+
+/// Solve `(a0 + a1 * operator) * x = rhs` for `x` as a TreeTN.
+///
+/// The solver returns only the solution TreeTN. The Rust-side `SquareLinsolveResult`
+/// also tracks sweep metadata, but that is not yet exposed through the C ABI.
+///
+/// `mapped_vertices` and the four index arrays provide optional per-vertex
+/// index mappings when the operator uses internal site indices distinct from
+/// the `init` / `rhs` site indices. Pass `n_mapped_vertices == 0` to disable
+/// mappings.
+///
+/// Current limitation: the sweep-based backend still assumes that `init` and
+/// `rhs` share the same true site-index set. The mapping arrays bridge the
+/// operator's internal indices to those true indices, but they do not yet
+/// support solving between distinct `init` and `rhs` true index spaces.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_linsolve(
+    operator: *const t4a_treetn,
+    rhs: *const t4a_treetn,
+    init: *const t4a_treetn,
+    center_vertex: libc::size_t,
+    mapped_vertices: *const libc::size_t,
+    n_mapped_vertices: libc::size_t,
+    true_input_indices: *const *const t4a_index,
+    internal_input_indices: *const *const t4a_index,
+    true_output_indices: *const *const t4a_index,
+    internal_output_indices: *const *const t4a_index,
+    rtol: libc::c_double,
+    cutoff: libc::c_double,
+    maxdim: libc::size_t,
+    form: t4a_canonical_form,
+    nfullsweeps: libc::size_t,
+    krylov_tol: libc::c_double,
+    krylov_maxiter: libc::size_t,
+    krylov_dim: libc::size_t,
+    a0: libc::c_double,
+    a1: libc::c_double,
+    convergence_tol: libc::c_double,
+    out: *mut *mut t4a_treetn,
+) -> StatusCode {
+    let operator = match require_tree(operator) {
+        Ok(tn) => tn,
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            return code;
+        }
+    };
+    let rhs = match require_tree(rhs) {
+        Ok(tn) => tn,
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            return code;
+        }
+    };
+    let init = match require_tree(init) {
+        Ok(tn) => tn,
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            return code;
+        }
+    };
+
+    run_catching(out, || {
+        require_node(init.inner(), center_vertex)?;
+
+        if !krylov_tol.is_finite() || krylov_tol <= 0.0 {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("krylov_tol must be finite and > 0, got {krylov_tol}"),
+            ));
+        }
+        if krylov_maxiter == 0 {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                "krylov_maxiter must be >= 1",
+            ));
+        }
+        if krylov_dim == 0 {
+            return Err(capi_error(T4A_INVALID_ARGUMENT, "krylov_dim must be >= 1"));
+        }
+        if !a0.is_finite() || !a1.is_finite() {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("a0 and a1 must be finite, got a0={a0}, a1={a1}"),
+            ));
+        }
+        if !(convergence_tol == 0.0 || (convergence_tol.is_finite() && convergence_tol > 0.0)) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!(
+                    "convergence_tol must be 0.0 or a finite positive value, got {convergence_tol}"
+                ),
+            ));
+        }
+
+        let mappings = build_linsolve_index_mappings(
+            operator.inner(),
+            rhs.inner(),
+            init.inner(),
+            mapped_vertices,
+            n_mapped_vertices,
+            true_input_indices,
+            internal_input_indices,
+            true_output_indices,
+            internal_output_indices,
+        )?;
+
+        let mut options = LinsolveOptions::new(nfullsweeps)
+            .with_truncation(TruncationOptions::new().with_form(form.into()))
+            .with_krylov_tol(krylov_tol)
+            .with_krylov_maxiter(krylov_maxiter)
+            .with_krylov_dim(krylov_dim)
+            .with_coefficients(a0, a1);
+        if let Some(rtol) = resolve_rtol(rtol, cutoff) {
+            options = options.with_rtol(rtol);
+        }
+        if maxdim > 0 {
+            options = options.with_max_rank(maxdim);
+        }
+        if let Some(tol) = resolve_convergence_tol(convergence_tol) {
+            options = options.with_convergence_tol(tol);
+        }
+
+        let (input_mapping, output_mapping) = match mappings {
+            Some((input_mapping, output_mapping)) => (Some(input_mapping), Some(output_mapping)),
+            None => (None, None),
+        };
+
+        let result = square_linsolve(
+            operator.inner(),
+            rhs.inner(),
+            init.inner().clone(),
+            &center_vertex,
+            options,
+            input_mapping,
+            output_mapping,
+        )
+        .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_treetn::new(result.solution))
     })
 }
 

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -1,8 +1,8 @@
 //! C API for the reduced TreeTN surface.
 
 use crate::types::{
-    t4a_canonical_form, t4a_contract_method, t4a_index, t4a_tensor, t4a_treetn, InternalIndex,
-    InternalTreeTN,
+    t4a_canonical_form, t4a_contract_method, t4a_factorize_alg, t4a_index, t4a_tensor, t4a_treetn,
+    InternalIndex, InternalTreeTN,
 };
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
@@ -10,13 +10,13 @@ use crate::{
     T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use num_complex::Complex64;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike};
 use tensor4all_treetn::treetn::contraction::{self, ContractionMethod, ContractionOptions};
 use tensor4all_treetn::{
     apply_linear_operator, ApplyOptions, CanonicalizationOptions, IndexMapping, LinearOperator,
-    TruncationOptions,
+    RestructureOptions, SiteIndexNetwork, SplitOptions, SwapOptions, TruncationOptions,
 };
 
 /// Release a TreeTN handle.
@@ -70,6 +70,34 @@ fn resolve_rtol(rtol: f64, cutoff: f64) -> Option<f64> {
         Tol::Rtol(r) => Some(r),
         Tol::None => None,
     }
+}
+
+#[inline]
+fn resolve_convergence_tol(convergence_tol: f64) -> Option<f64> {
+    (convergence_tol > 0.0).then_some(convergence_tol)
+}
+
+#[inline]
+fn resolve_fit_nfullsweeps(nfullsweeps: usize) -> usize {
+    if nfullsweeps == 0 {
+        1
+    } else {
+        nfullsweeps
+    }
+}
+
+fn orthogonalize_error_message(force: libc::c_int, err: impl std::fmt::Display) -> String {
+    let mut msg = format!("{err:#}");
+    if force == 0 {
+        msg = msg.replace("CanonicalizationOptions::forced()", "force=1");
+        if msg == "canonicalize: form mismatch" {
+            msg.push_str(
+                ": The network is already canonicalized with a different form. \
+                 Pass force=1 to re-canonicalize with a different form.",
+            );
+        }
+    }
+    msg
 }
 
 fn run_status<F>(f: F) -> StatusCode
@@ -154,6 +182,9 @@ fn collect_indices(
     n_indices: usize,
     what: &str,
 ) -> CapiResult<Vec<InternalIndex>> {
+    if n_indices == 0 {
+        return Ok(Vec::new());
+    }
     if index_ptrs.is_null() {
         return Err(capi_error(T4A_NULL_POINTER, format!("{what} is null")));
     }
@@ -174,6 +205,9 @@ fn collect_positions(
     len: usize,
     what: &str,
 ) -> CapiResult<Vec<usize>> {
+    if len == 0 {
+        return Ok(Vec::new());
+    }
     if positions.is_null() {
         return Err(capi_error(T4A_NULL_POINTER, format!("{what} is null")));
     }
@@ -183,6 +217,174 @@ fn collect_positions(
         out.push(unsafe { *positions.add(i) });
     }
     Ok(out)
+}
+
+fn collect_edge_endpoints(
+    sources: *const libc::size_t,
+    targets: *const libc::size_t,
+    n_edges: usize,
+    what: &str,
+) -> CapiResult<Vec<(usize, usize)>> {
+    let sources = collect_positions(sources, n_edges, &format!("{what}.sources"))?;
+    let targets = collect_positions(targets, n_edges, &format!("{what}.targets"))?;
+    Ok(sources.into_iter().zip(targets).collect())
+}
+
+fn collect_target_assignment(
+    assignment_siteinds: *const *const t4a_index,
+    assignment_target_vertices: *const libc::size_t,
+    n_assignments: usize,
+    what: &str,
+) -> CapiResult<HashMap<<InternalIndex as IndexLike>::Id, usize>> {
+    let siteinds = collect_indices(
+        assignment_siteinds,
+        n_assignments,
+        &format!("{what}.siteinds"),
+    )?;
+    let target_vertices = collect_positions(
+        assignment_target_vertices,
+        n_assignments,
+        &format!("{what}.target_vertices"),
+    )?;
+    let mut target_assignment = HashMap::with_capacity(n_assignments);
+    for (siteind, target_vertex) in siteinds.into_iter().zip(target_vertices) {
+        let site_id = siteind.id().clone();
+        if let Some(previous_target) = target_assignment.insert(site_id.clone(), target_vertex) {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!(
+                    "{what}: duplicate site index assignment for {:?}: {} and {}",
+                    site_id, previous_target, target_vertex
+                ),
+            ));
+        }
+    }
+    Ok(target_assignment)
+}
+
+fn build_target_network(
+    target_vertices: *const libc::size_t,
+    n_target_vertices: usize,
+    target_siteinds: *const *const t4a_index,
+    target_siteinds_len: *const libc::size_t,
+    target_edge_sources: *const libc::size_t,
+    target_edge_targets: *const libc::size_t,
+    n_target_edges: usize,
+    what: &str,
+) -> CapiResult<SiteIndexNetwork<usize, InternalIndex>> {
+    if n_target_vertices == 0 {
+        return Err(capi_error(
+            T4A_INVALID_ARGUMENT,
+            format!("{what}: target must contain at least one vertex"),
+        ));
+    }
+
+    let vertices = collect_positions(
+        target_vertices,
+        n_target_vertices,
+        &format!("{what}.vertices"),
+    )?;
+    let siteind_lens = collect_positions(
+        target_siteinds_len,
+        n_target_vertices,
+        &format!("{what}.siteind_lens"),
+    )?;
+    let total_siteinds: usize = siteind_lens.iter().sum();
+    let flat_siteinds =
+        collect_indices(target_siteinds, total_siteinds, &format!("{what}.siteinds"))?;
+    let edges = collect_edge_endpoints(
+        target_edge_sources,
+        target_edge_targets,
+        n_target_edges,
+        &format!("{what}.edges"),
+    )?;
+
+    let mut network = SiteIndexNetwork::with_capacity(n_target_vertices, n_target_edges);
+    let mut seen_siteinds: HashMap<<InternalIndex as IndexLike>::Id, usize> =
+        HashMap::with_capacity(total_siteinds);
+    let mut offset = 0usize;
+    for (slot, &vertex) in vertices.iter().enumerate() {
+        let len = siteind_lens[slot];
+        if len == 0 {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("{what}: target vertex {vertex} must contain at least one site index"),
+            ));
+        }
+        let mut site_space = HashSet::with_capacity(len);
+        for siteind in &flat_siteinds[offset..offset + len] {
+            let site_id = siteind.id().clone();
+            if let Some(previous_vertex) = seen_siteinds.insert(site_id.clone(), vertex) {
+                return Err(capi_error(
+                    T4A_INVALID_ARGUMENT,
+                    format!(
+                        "{what}: duplicate site index {:?} appears in target vertices {} and {}",
+                        site_id, previous_vertex, vertex
+                    ),
+                ));
+            }
+            site_space.insert(siteind.clone());
+        }
+        offset += len;
+        network
+            .add_node(vertex, site_space)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, format!("{what}: {err}")))?;
+    }
+
+    for (source, target) in edges {
+        network
+            .add_edge(&source, &target)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, format!("{what}: {err}")))?;
+    }
+
+    Ok(network)
+}
+
+fn build_split_options(
+    rtol: f64,
+    cutoff: f64,
+    maxdim: usize,
+    form: t4a_canonical_form,
+    final_sweep: libc::c_int,
+) -> SplitOptions {
+    let mut options = SplitOptions::new()
+        .with_form(form.into())
+        .with_final_sweep(final_sweep != 0);
+    if maxdim > 0 {
+        options = options.with_max_rank(maxdim);
+    }
+    if let Some(rtol) = resolve_rtol(rtol, cutoff) {
+        options = options.with_rtol(rtol);
+    }
+    options
+}
+
+fn build_swap_options(maxdim: usize, rtol: f64) -> SwapOptions {
+    SwapOptions {
+        max_rank: (maxdim > 0).then_some(maxdim),
+        rtol: (rtol > 0.0).then_some(rtol),
+    }
+}
+
+fn build_final_truncation(
+    rtol: f64,
+    cutoff: f64,
+    maxdim: usize,
+    form: t4a_canonical_form,
+) -> Option<TruncationOptions> {
+    let resolved_rtol = resolve_rtol(rtol, cutoff);
+    if maxdim == 0 && resolved_rtol.is_none() {
+        return None;
+    }
+
+    let mut options = TruncationOptions::new().with_form(form.into());
+    if maxdim > 0 {
+        options = options.with_max_rank(maxdim);
+    }
+    if let Some(rtol) = resolved_rtol {
+        options = options.with_rtol(rtol);
+    }
+    Some(options)
 }
 
 fn require_chain_layout(tn: &InternalTreeTN, what: &str) -> CapiResult<usize> {
@@ -675,19 +877,35 @@ pub extern "C" fn t4a_treetn_linkind(
 }
 
 /// Orthogonalize the tree tensor network to a vertex using the requested form.
+///
+/// When `force == 0`, this uses smart canonicalization:
+/// - If the network is already canonical at `vertex` with `form`, the call is a no-op.
+/// - If the network is already canonicalized with a different form, the call returns
+///   `T4A_INVALID_ARGUMENT`. Pass a nonzero `force` to re-canonicalize with a different form.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_orthogonalize(
     treetn: *mut t4a_treetn,
     vertex: libc::size_t,
     form: t4a_canonical_form,
+    force: libc::c_int,
 ) -> StatusCode {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
         require_node(tn.inner(), vertex)?;
-        let options = CanonicalizationOptions::forced().with_form(form.into());
-        tn.inner_mut()
+        let mut options = CanonicalizationOptions::new().with_form(form.into());
+        if force != 0 {
+            options = options.force();
+        }
+        let mut canonicalized = tn.inner().clone();
+        canonicalized
             .canonicalize_mut(std::iter::once(vertex), options)
-            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+            .map_err(|err| {
+                capi_error(
+                    T4A_INVALID_ARGUMENT,
+                    orthogonalize_error_message(force, err),
+                )
+            })?;
+        *tn.inner_mut() = canonicalized;
         Ok(())
     })
 }
@@ -699,11 +917,12 @@ pub extern "C" fn t4a_treetn_truncate(
     rtol: libc::c_double,
     cutoff: libc::c_double,
     maxdim: libc::size_t,
+    form: t4a_canonical_form,
 ) -> StatusCode {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
 
-        let mut options = TruncationOptions::new();
+        let mut options = TruncationOptions::new().with_form(form.into());
         if let Some(rtol) = resolve_rtol(rtol, cutoff) {
             options = options.with_rtol(rtol);
         }
@@ -719,6 +938,164 @@ pub extern "C" fn t4a_treetn_truncate(
             .truncate_mut(std::iter::once(center), options)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
         Ok(())
+    })
+}
+
+/// Fuse connected current-node groups into the requested target topology.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_fuse_to(
+    treetn: *const t4a_treetn,
+    target_vertices: *const libc::size_t,
+    n_target_vertices: libc::size_t,
+    target_siteinds: *const *const t4a_index,
+    target_siteinds_len: *const libc::size_t,
+    target_edge_sources: *const libc::size_t,
+    target_edge_targets: *const libc::size_t,
+    n_target_edges: libc::size_t,
+    out: *mut *mut t4a_treetn,
+) -> StatusCode {
+    run_catching(out, || {
+        let tn = require_tree(treetn)?;
+        let target = build_target_network(
+            target_vertices,
+            n_target_vertices,
+            target_siteinds,
+            target_siteinds_len,
+            target_edge_sources,
+            target_edge_targets,
+            n_target_edges,
+            "target",
+        )?;
+        let result = tn
+            .inner()
+            .fuse_to(&target)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_treetn::new(result))
+    })
+}
+
+/// Split current nodes to match the requested target topology.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_split_to(
+    treetn: *const t4a_treetn,
+    target_vertices: *const libc::size_t,
+    n_target_vertices: libc::size_t,
+    target_siteinds: *const *const t4a_index,
+    target_siteinds_len: *const libc::size_t,
+    target_edge_sources: *const libc::size_t,
+    target_edge_targets: *const libc::size_t,
+    n_target_edges: libc::size_t,
+    rtol: libc::c_double,
+    cutoff: libc::c_double,
+    maxdim: libc::size_t,
+    form: t4a_canonical_form,
+    final_sweep: libc::c_int,
+    out: *mut *mut t4a_treetn,
+) -> StatusCode {
+    run_catching(out, || {
+        let tn = require_tree(treetn)?;
+        let target = build_target_network(
+            target_vertices,
+            n_target_vertices,
+            target_siteinds,
+            target_siteinds_len,
+            target_edge_sources,
+            target_edge_targets,
+            n_target_edges,
+            "target",
+        )?;
+        let options = build_split_options(rtol, cutoff, maxdim, form, final_sweep);
+        let result = tn
+            .inner()
+            .split_to(&target, &options)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_treetn::new(result))
+    })
+}
+
+/// Reassign site indices to target vertices using scheduled swap transport.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_swap_site_indices(
+    treetn: *const t4a_treetn,
+    assignment_siteinds: *const *const t4a_index,
+    assignment_target_vertices: *const libc::size_t,
+    n_assignments: libc::size_t,
+    maxdim: libc::size_t,
+    rtol: libc::c_double,
+    out: *mut *mut t4a_treetn,
+) -> StatusCode {
+    run_catching(out, || {
+        let tn = require_tree(treetn)?;
+        let target_assignment = collect_target_assignment(
+            assignment_siteinds,
+            assignment_target_vertices,
+            n_assignments,
+            "target_assignment",
+        )?;
+        let options = build_swap_options(maxdim, rtol);
+        let mut result = tn.inner().clone();
+        result
+            .swap_site_indices(&target_assignment, &options)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_treetn::new(result))
+    })
+}
+
+/// Restructure a TreeTN using split, swap, and optional final truncation phases.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_restructure_to(
+    treetn: *const t4a_treetn,
+    target_vertices: *const libc::size_t,
+    n_target_vertices: libc::size_t,
+    target_siteinds: *const *const t4a_index,
+    target_siteinds_len: *const libc::size_t,
+    target_edge_sources: *const libc::size_t,
+    target_edge_targets: *const libc::size_t,
+    n_target_edges: libc::size_t,
+    split_rtol: libc::c_double,
+    split_cutoff: libc::c_double,
+    split_maxdim: libc::size_t,
+    split_form: t4a_canonical_form,
+    split_final_sweep: libc::c_int,
+    swap_maxdim: libc::size_t,
+    swap_rtol: libc::c_double,
+    final_rtol: libc::c_double,
+    final_cutoff: libc::c_double,
+    final_maxdim: libc::size_t,
+    final_form: t4a_canonical_form,
+    out: *mut *mut t4a_treetn,
+) -> StatusCode {
+    run_catching(out, || {
+        let tn = require_tree(treetn)?;
+        let target = build_target_network(
+            target_vertices,
+            n_target_vertices,
+            target_siteinds,
+            target_siteinds_len,
+            target_edge_sources,
+            target_edge_targets,
+            n_target_edges,
+            "target",
+        )?;
+        let mut options = RestructureOptions::new()
+            .with_split(build_split_options(
+                split_rtol,
+                split_cutoff,
+                split_maxdim,
+                split_form,
+                split_final_sweep,
+            ))
+            .with_swap(build_swap_options(swap_maxdim, swap_rtol));
+        if let Some(final_truncation) =
+            build_final_truncation(final_rtol, final_cutoff, final_maxdim, final_form)
+        {
+            options = options.with_final_truncation(final_truncation);
+        }
+        let result = tn
+            .inner()
+            .restructure_to(&target, &options)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_treetn::new(result))
     })
 }
 
@@ -900,6 +1277,9 @@ pub extern "C" fn t4a_treetn_add(
 }
 
 /// Contract two tree tensor networks with the requested method.
+///
+/// For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
+/// default", which currently resolves to one variational sweep.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_contract(
     a: *const t4a_treetn,
@@ -908,6 +1288,9 @@ pub extern "C" fn t4a_treetn_contract(
     rtol: libc::c_double,
     cutoff: libc::c_double,
     maxdim: libc::size_t,
+    nfullsweeps: libc::size_t,
+    convergence_tol: libc::c_double,
+    factorize_alg: t4a_factorize_alg,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
     let tn_a = match require_tree(a) {
@@ -932,12 +1315,18 @@ pub extern "C" fn t4a_treetn_contract(
             })?;
 
         let rust_method: ContractionMethod = method.into();
-        let mut options = ContractionOptions::new(rust_method);
+        let fit_nfullsweeps = resolve_fit_nfullsweeps(nfullsweeps);
+        let mut options = ContractionOptions::new(rust_method)
+            .with_nfullsweeps(fit_nfullsweeps)
+            .with_factorize_alg(factorize_alg.into());
         if let Some(rtol) = resolve_rtol(rtol, cutoff) {
             options = options.with_rtol(rtol);
         }
         if maxdim > 0 {
             options = options.with_max_rank(maxdim);
+        }
+        if let Some(tol) = resolve_convergence_tol(convergence_tol) {
+            options = options.with_convergence_tol(tol);
         }
 
         let result = contraction::contract(tn_a.inner(), tn_b.inner(), &center, options)
@@ -954,6 +1343,9 @@ pub extern "C" fn t4a_treetn_contract(
 /// `internal_input_indices[i]` and `internal_output_indices[i]` must point to
 /// those indices. Unmapped state nodes are filled with identities by
 /// `apply_linear_operator`.
+///
+/// For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
+/// default", which currently resolves to one variational sweep.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_apply_operator_chain(
     operator: *const t4a_treetn,
@@ -967,6 +1359,8 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
     rtol: libc::c_double,
     cutoff: libc::c_double,
     maxdim: libc::size_t,
+    nfullsweeps: libc::size_t,
+    convergence_tol: libc::c_double,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
     let op = match require_tree(operator) {
@@ -1018,6 +1412,7 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
             &true_outputs,
         )?;
 
+        let fit_nfullsweeps = resolve_fit_nfullsweeps(nfullsweeps);
         let result = apply_linear_operator(
             &linear_operator,
             state.inner(),
@@ -1025,6 +1420,8 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
                 method: method.into(),
                 max_rank: (maxdim > 0).then_some(maxdim),
                 rtol: resolve_rtol(rtol, cutoff),
+                nfullsweeps: fit_nfullsweeps,
+                convergence_tol: resolve_convergence_tol(convergence_tol),
                 ..Default::default()
             },
         )

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -183,6 +183,79 @@ fn make_two_site_treetn() -> (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4
     (tt, vec![t0, t1], vec![s0, bond, bond_clone, s1])
 }
 
+fn make_two_site_identity_operator_with_shared_inputs(
+    input0: *const t4a_index,
+    input1: *const t4a_index,
+) -> (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>) {
+    let out0 = new_index(index_dim(input0));
+    let out1 = new_index(index_dim(input1));
+    let bond = new_index(1);
+    let mut bond_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(bond, &mut bond_clone),
+        T4A_SUCCESS
+    );
+
+    let t0 = new_tensor(
+        &[out0 as *const t4a_index, input0, bond as *const t4a_index],
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+    let t1 = new_tensor(
+        &[
+            bond_clone as *const t4a_index,
+            out1 as *const t4a_index,
+            input1,
+        ],
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+    let tt = new_treetn(&[t0 as *const t4a_tensor, t1 as *const t4a_tensor]);
+    (tt, vec![t0, t1], vec![out0, out1, bond, bond_clone])
+}
+
+fn make_two_site_identity_operator_with_internal_indices() -> (
+    *mut t4a_treetn,
+    Vec<*mut t4a_tensor>,
+    Vec<*mut t4a_index>,
+    [*mut t4a_index; 2],
+    [*mut t4a_index; 2],
+) {
+    let internal_inputs = [new_index(2), new_index(2)];
+    let internal_outputs = [new_index(2), new_index(2)];
+    let bond = new_index(1);
+    let mut bond_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(bond, &mut bond_clone),
+        T4A_SUCCESS
+    );
+
+    let t0 = new_tensor(
+        &[
+            internal_outputs[0] as *const t4a_index,
+            internal_inputs[0] as *const t4a_index,
+            bond as *const t4a_index,
+        ],
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+    let t1 = new_tensor(
+        &[
+            bond_clone as *const t4a_index,
+            internal_outputs[1] as *const t4a_index,
+            internal_inputs[1] as *const t4a_index,
+        ],
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+    let tt = new_treetn(&[t0 as *const t4a_tensor, t1 as *const t4a_tensor]);
+    let indices = vec![
+        internal_inputs[0],
+        internal_inputs[1],
+        internal_outputs[0],
+        internal_outputs[1],
+        bond,
+        bond_clone,
+    ];
+    (tt, vec![t0, t1], indices, internal_inputs, internal_outputs)
+}
+
 fn make_two_node_groups_of_two_treetn(
 ) -> (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>) {
     let x0 = new_index(2);
@@ -1626,4 +1699,190 @@ fn test_treetn_apply_operator_chain_rejects_unknown_internal_input_index() {
     t4a_index_release(internal_out);
     t4a_index_release(internal_in);
     t4a_index_release(state_site);
+}
+
+#[test]
+fn test_treetn_linsolve_two_site_identity_without_mapping_zero_sweeps() {
+    let (rhs_tt, rhs_tensors, mut rhs_indices) = make_two_site_treetn();
+    let expected = read_dense_f64_treetn(rhs_tt);
+
+    let rhs_site0 = read_siteinds(rhs_tt, 0).remove(0);
+    let rhs_site1 = read_siteinds(rhs_tt, 1).remove(0);
+    let (op_tt, op_tensors, op_indices) =
+        make_two_site_identity_operator_with_shared_inputs(rhs_site0, rhs_site1);
+
+    let mut result: *mut t4a_treetn = std::ptr::null_mut();
+    let status = t4a_treetn_linsolve(
+        op_tt,
+        rhs_tt,
+        rhs_tt,
+        0,
+        std::ptr::null(),
+        0,
+        std::ptr::null(),
+        std::ptr::null(),
+        std::ptr::null(),
+        std::ptr::null(),
+        0.0,
+        0.0,
+        0,
+        t4a_canonical_form::Unitary,
+        0,
+        1e-12,
+        30,
+        10,
+        0.0,
+        1.0,
+        0.0,
+        &mut result,
+    );
+    assert_eq!(status, T4A_SUCCESS, "{}", last_error());
+    assert_vec_close(&read_dense_f64_treetn(result), &expected, 1e-10);
+
+    t4a_treetn_release(result);
+    t4a_treetn_release(op_tt);
+    for tensor in op_tensors {
+        t4a_tensor_release(tensor);
+    }
+    for index in op_indices {
+        t4a_index_release(index);
+    }
+    t4a_index_release(rhs_site1);
+    t4a_index_release(rhs_site0);
+    cleanup(rhs_tt, rhs_tensors, std::mem::take(&mut rhs_indices));
+}
+
+#[test]
+fn test_treetn_linsolve_two_site_identity_with_explicit_mapping() {
+    let (rhs_tt, rhs_tensors, mut rhs_indices) = make_two_site_treetn();
+    let expected = read_dense_f64_treetn(rhs_tt);
+
+    let rhs_site0 = read_siteinds(rhs_tt, 0).remove(0);
+    let rhs_site1 = read_siteinds(rhs_tt, 1).remove(0);
+    let (op_tt, op_tensors, op_indices, internal_inputs, internal_outputs) =
+        make_two_site_identity_operator_with_internal_indices();
+
+    let mapped_vertices = [0usize, 1usize];
+    let true_inputs = [rhs_site0 as *const t4a_index, rhs_site1 as *const t4a_index];
+    let internal_inputs = [
+        internal_inputs[0] as *const t4a_index,
+        internal_inputs[1] as *const t4a_index,
+    ];
+    let true_outputs = [rhs_site0 as *const t4a_index, rhs_site1 as *const t4a_index];
+    let internal_outputs = [
+        internal_outputs[0] as *const t4a_index,
+        internal_outputs[1] as *const t4a_index,
+    ];
+
+    let mut result: *mut t4a_treetn = std::ptr::null_mut();
+    let status = t4a_treetn_linsolve(
+        op_tt,
+        rhs_tt,
+        rhs_tt,
+        0,
+        mapped_vertices.as_ptr(),
+        mapped_vertices.len(),
+        true_inputs.as_ptr(),
+        internal_inputs.as_ptr(),
+        true_outputs.as_ptr(),
+        internal_outputs.as_ptr(),
+        0.0,
+        0.0,
+        0,
+        t4a_canonical_form::Unitary,
+        3,
+        1e-12,
+        30,
+        10,
+        0.0,
+        1.0,
+        0.0,
+        &mut result,
+    );
+    assert_eq!(status, T4A_SUCCESS, "{}", last_error());
+    assert_vec_close(&read_dense_f64_treetn(result), &expected, 1e-10);
+
+    t4a_treetn_release(result);
+    t4a_treetn_release(op_tt);
+    for tensor in op_tensors {
+        t4a_tensor_release(tensor);
+    }
+    for index in op_indices {
+        t4a_index_release(index);
+    }
+    t4a_index_release(rhs_site1);
+    t4a_index_release(rhs_site0);
+    cleanup(rhs_tt, rhs_tensors, std::mem::take(&mut rhs_indices));
+}
+
+#[test]
+fn test_treetn_linsolve_rejects_mapping_true_output_not_on_rhs() {
+    let true_input = new_index(2);
+    let true_output = new_index(2);
+    let wrong_output = new_index(2);
+    let internal_input = new_index(2);
+    let internal_output = new_index(2);
+
+    let init = new_tensor(&[true_input as *const t4a_index], &[1.0, 1.0]);
+    let rhs = new_tensor(&[true_output as *const t4a_index], &[3.0, 4.0]);
+    let init_tt = new_treetn(&[init as *const t4a_tensor]);
+    let rhs_tt = new_treetn(&[rhs as *const t4a_tensor]);
+
+    let op = new_tensor(
+        &[
+            internal_output as *const t4a_index,
+            internal_input as *const t4a_index,
+        ],
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+    let op_tt = new_treetn(&[op as *const t4a_tensor]);
+
+    let mapped_vertices = [0usize];
+    let true_inputs = [true_input as *const t4a_index];
+    let internal_inputs = [internal_input as *const t4a_index];
+    let true_outputs = [wrong_output as *const t4a_index];
+    let internal_outputs = [internal_output as *const t4a_index];
+
+    let mut result: *mut t4a_treetn = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_linsolve(
+            op_tt,
+            rhs_tt,
+            init_tt,
+            0,
+            mapped_vertices.as_ptr(),
+            mapped_vertices.len(),
+            true_inputs.as_ptr(),
+            internal_inputs.as_ptr(),
+            true_outputs.as_ptr(),
+            internal_outputs.as_ptr(),
+            0.0,
+            0.0,
+            0,
+            t4a_canonical_form::Unitary,
+            4,
+            1e-12,
+            30,
+            10,
+            0.0,
+            1.0,
+            0.0,
+            &mut result
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(last_error().contains("true output"));
+    assert!(result.is_null());
+
+    t4a_treetn_release(op_tt);
+    t4a_treetn_release(rhs_tt);
+    t4a_treetn_release(init_tt);
+    t4a_tensor_release(op);
+    t4a_tensor_release(rhs);
+    t4a_tensor_release(init);
+    t4a_index_release(internal_output);
+    t4a_index_release(internal_input);
+    t4a_index_release(wrong_output);
+    t4a_index_release(true_output);
+    t4a_index_release(true_input);
 }

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -159,6 +159,8 @@ fn assert_vec_close(actual: &[f64], expected: &[f64], tol: f64) {
     }
 }
 
+type OwnedTreeTN = (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>);
+
 fn make_two_site_treetn() -> (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>) {
     let s0 = new_index(2);
     let bond = new_index(2);
@@ -346,10 +348,7 @@ fn flat_assignment(assignments: &[(*const t4a_index, usize)]) -> FlatAssignment 
     }
 }
 
-fn make_two_site_contract_operands() -> (
-    (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>),
-    (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>),
-) {
+fn make_two_site_contract_operands() -> (OwnedTreeTN, OwnedTreeTN) {
     let in0 = new_index(2);
     let in1 = new_index(2);
     let out0 = new_index(2);

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::index::{t4a_index_new, t4a_index_release};
+use crate::index::{t4a_index_dim, t4a_index_new, t4a_index_release};
 use crate::tensor::{
     t4a_tensor_copy_dense_f64, t4a_tensor_new_dense_c64, t4a_tensor_new_dense_f64, t4a_tensor_rank,
     t4a_tensor_release,
@@ -109,6 +109,45 @@ fn read_canonical_region(tt: *const t4a_treetn) -> Vec<usize> {
     vertices
 }
 
+fn index_dim(index: *const t4a_index) -> usize {
+    let mut dim = 0usize;
+    assert_eq!(t4a_index_dim(index, &mut dim), T4A_SUCCESS);
+    dim
+}
+
+fn evaluate_real_on_full_grid(tt: *const t4a_treetn, indices: &[*const t4a_index]) -> Vec<f64> {
+    let dims: Vec<usize> = indices.iter().map(|&index| index_dim(index)).collect();
+    let n_points: usize = dims.iter().product();
+    let n_indices = indices.len();
+    let mut values_col_major = vec![0usize; n_indices * n_points];
+    let mut coords = vec![0usize; n_indices];
+    for point in 0..n_points {
+        let mut linear = point;
+        for axis in (0..n_indices).rev() {
+            coords[axis] = linear % dims[axis];
+            linear /= dims[axis];
+        }
+        for axis in 0..n_indices {
+            values_col_major[axis + point * n_indices] = coords[axis];
+        }
+    }
+
+    let mut out_re = vec![0.0; n_points];
+    assert_eq!(
+        t4a_treetn_evaluate(
+            tt,
+            indices.as_ptr(),
+            n_indices,
+            values_col_major.as_ptr(),
+            n_points,
+            out_re.as_mut_ptr(),
+            std::ptr::null_mut()
+        ),
+        T4A_SUCCESS
+    );
+    out_re
+}
+
 fn assert_vec_close(actual: &[f64], expected: &[f64], tol: f64) {
     assert_eq!(actual.len(), expected.len());
     for (slot, (&a, &e)) in actual.iter().zip(expected.iter()).enumerate() {
@@ -142,6 +181,175 @@ fn make_two_site_treetn() -> (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4
     );
     let tt = new_treetn(&[t0 as *const t4a_tensor, t1 as *const t4a_tensor]);
     (tt, vec![t0, t1], vec![s0, bond, bond_clone, s1])
+}
+
+fn make_two_node_groups_of_two_treetn(
+) -> (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>) {
+    let x0 = new_index(2);
+    let x1 = new_index(2);
+    let y0 = new_index(2);
+    let y1 = new_index(2);
+    let bond = new_index(2);
+    let mut bond_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(bond, &mut bond_clone),
+        T4A_SUCCESS
+    );
+
+    let left = new_tensor(
+        &[
+            x0 as *const t4a_index,
+            x1 as *const t4a_index,
+            bond as *const t4a_index,
+        ],
+        &[1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+    );
+    let right = new_tensor(
+        &[
+            bond_clone as *const t4a_index,
+            y0 as *const t4a_index,
+            y1 as *const t4a_index,
+        ],
+        &[1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+    );
+    let tt = new_treetn(&[left as *const t4a_tensor, right as *const t4a_tensor]);
+    (
+        tt,
+        vec![left, right],
+        vec![x0, x1, y0, y1, bond, bond_clone],
+    )
+}
+
+struct FlatTargetNetwork {
+    vertices: Vec<usize>,
+    siteinds: Vec<*const t4a_index>,
+    siteind_lens: Vec<usize>,
+    edge_sources: Vec<usize>,
+    edge_targets: Vec<usize>,
+}
+
+fn flat_target_network(
+    vertices: &[usize],
+    site_groups: &[&[*const t4a_index]],
+    edges: &[(usize, usize)],
+) -> FlatTargetNetwork {
+    assert_eq!(vertices.len(), site_groups.len());
+    let mut siteinds = Vec::new();
+    let mut siteind_lens = Vec::with_capacity(site_groups.len());
+    for group in site_groups {
+        siteind_lens.push(group.len());
+        siteinds.extend(group.iter().copied());
+    }
+    let mut edge_sources = Vec::with_capacity(edges.len());
+    let mut edge_targets = Vec::with_capacity(edges.len());
+    for &(src, dst) in edges {
+        edge_sources.push(src);
+        edge_targets.push(dst);
+    }
+    FlatTargetNetwork {
+        vertices: vertices.to_vec(),
+        siteinds,
+        siteind_lens,
+        edge_sources,
+        edge_targets,
+    }
+}
+
+struct FlatAssignment {
+    siteinds: Vec<*const t4a_index>,
+    target_vertices: Vec<usize>,
+}
+
+fn flat_assignment(assignments: &[(*const t4a_index, usize)]) -> FlatAssignment {
+    let mut siteinds = Vec::with_capacity(assignments.len());
+    let mut target_vertices = Vec::with_capacity(assignments.len());
+    for &(index, target_vertex) in assignments {
+        siteinds.push(index);
+        target_vertices.push(target_vertex);
+    }
+    FlatAssignment {
+        siteinds,
+        target_vertices,
+    }
+}
+
+fn make_two_site_contract_operands() -> (
+    (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>),
+    (*mut t4a_treetn, Vec<*mut t4a_tensor>, Vec<*mut t4a_index>),
+) {
+    let in0 = new_index(2);
+    let in1 = new_index(2);
+    let out0 = new_index(2);
+    let out1 = new_index(2);
+
+    let state_bond = new_index(2);
+    let mut state_bond_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(state_bond, &mut state_bond_clone),
+        T4A_SUCCESS
+    );
+
+    let op_bond = new_index(2);
+    let mut op_bond_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(op_bond, &mut op_bond_clone),
+        T4A_SUCCESS
+    );
+
+    let mut in0_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(in0, &mut in0_clone),
+        T4A_SUCCESS
+    );
+    let mut in1_clone = std::ptr::null_mut();
+    assert_eq!(
+        crate::index::t4a_index_clone(in1, &mut in1_clone),
+        T4A_SUCCESS
+    );
+
+    let state_t0 = new_tensor(
+        &[in0 as *const t4a_index, state_bond as *const t4a_index],
+        &[1.0, 0.0, 0.0, 1.0],
+    );
+    let state_t1 = new_tensor(
+        &[
+            state_bond_clone as *const t4a_index,
+            in1 as *const t4a_index,
+        ],
+        &[1.0, 2.0, 3.0, 4.0],
+    );
+    let state_tt = new_treetn(&[state_t0 as *const t4a_tensor, state_t1 as *const t4a_tensor]);
+
+    let op_t0 = new_tensor(
+        &[
+            out0 as *const t4a_index,
+            in0_clone as *const t4a_index,
+            op_bond as *const t4a_index,
+        ],
+        &[1.0, 0.0, 0.5, -0.5, 0.0, 1.0, 1.5, 0.25],
+    );
+    let op_t1 = new_tensor(
+        &[
+            op_bond_clone as *const t4a_index,
+            out1 as *const t4a_index,
+            in1_clone as *const t4a_index,
+        ],
+        &[1.0, 2.0, 0.0, 1.0, 2.0, -1.0, 1.0, 0.5],
+    );
+    let op_tt = new_treetn(&[op_t0 as *const t4a_tensor, op_t1 as *const t4a_tensor]);
+
+    (
+        (
+            op_tt,
+            vec![op_t0, op_t1],
+            vec![out0, out1, in0_clone, in1_clone, op_bond, op_bond_clone],
+        ),
+        (
+            state_tt,
+            vec![state_t0, state_t1],
+            vec![in0, in1, state_bond, state_bond_clone],
+        ),
+    )
 }
 
 fn cleanup(tt: *mut t4a_treetn, tensors: Vec<*mut t4a_tensor>, indices: Vec<*mut t4a_index>) {
@@ -365,11 +573,272 @@ fn test_treetn_set_tensor_and_to_dense() {
 }
 
 #[test]
+fn test_treetn_fuse_to_merges_two_vertices() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let target = flat_target_network(
+        &[7],
+        &[&[
+            indices[0] as *const t4a_index,
+            indices[3] as *const t4a_index,
+        ]],
+        &[],
+    );
+
+    let mut fused = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_fuse_to(
+            tt,
+            target.vertices.as_ptr(),
+            target.vertices.len(),
+            target.siteinds.as_ptr(),
+            target.siteind_lens.as_ptr(),
+            target.edge_sources.as_ptr(),
+            target.edge_targets.as_ptr(),
+            target.edge_sources.len(),
+            &mut fused,
+        ),
+        T4A_SUCCESS
+    );
+
+    let dense_expected = read_dense_f64_treetn(tt);
+    let dense_actual = read_dense_f64_treetn(fused);
+    assert_vec_close(&dense_actual, &dense_expected, 1e-10);
+    assert_eq!(read_siteinds(fused, 7).len(), 2);
+
+    t4a_treetn_release(fused);
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_split_to_splits_fused_vertex() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let fuse_target = flat_target_network(
+        &[11],
+        &[&[
+            indices[0] as *const t4a_index,
+            indices[3] as *const t4a_index,
+        ]],
+        &[],
+    );
+    let mut fused = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_fuse_to(
+            tt,
+            fuse_target.vertices.as_ptr(),
+            fuse_target.vertices.len(),
+            fuse_target.siteinds.as_ptr(),
+            fuse_target.siteind_lens.as_ptr(),
+            fuse_target.edge_sources.as_ptr(),
+            fuse_target.edge_targets.as_ptr(),
+            fuse_target.edge_sources.len(),
+            &mut fused,
+        ),
+        T4A_SUCCESS
+    );
+
+    let split_target = flat_target_network(
+        &[3, 8],
+        &[
+            &[indices[0] as *const t4a_index],
+            &[indices[3] as *const t4a_index],
+        ],
+        &[(3, 8)],
+    );
+    let mut split = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_split_to(
+            fused,
+            split_target.vertices.as_ptr(),
+            split_target.vertices.len(),
+            split_target.siteinds.as_ptr(),
+            split_target.siteind_lens.as_ptr(),
+            split_target.edge_sources.as_ptr(),
+            split_target.edge_targets.as_ptr(),
+            split_target.edge_sources.len(),
+            0.0,
+            0.0,
+            0,
+            t4a_canonical_form::Unitary,
+            0,
+            &mut split,
+        ),
+        T4A_SUCCESS
+    );
+
+    let dense_expected = read_dense_f64_treetn(tt);
+    let dense_actual = read_dense_f64_treetn(split);
+    assert_vec_close(&dense_actual, &dense_expected, 1e-10);
+    assert_eq!(read_siteinds(split, 3).len(), 1);
+    assert_eq!(read_siteinds(split, 8).len(), 1);
+
+    t4a_treetn_release(split);
+    t4a_treetn_release(fused);
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_swap_site_indices_returns_reordered_copy() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let assignment = flat_assignment(&[
+        (indices[0] as *const t4a_index, 1),
+        (indices[3] as *const t4a_index, 0),
+    ]);
+
+    let mut swapped = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_swap_site_indices(
+            tt,
+            assignment.siteinds.as_ptr(),
+            assignment.target_vertices.as_ptr(),
+            assignment.siteinds.len(),
+            0,
+            0.0,
+            &mut swapped,
+        ),
+        T4A_SUCCESS
+    );
+
+    let eval_indices = [
+        indices[0] as *const t4a_index,
+        indices[3] as *const t4a_index,
+    ];
+    let dense_expected = evaluate_real_on_full_grid(tt, &eval_indices);
+    let dense_actual = evaluate_real_on_full_grid(swapped, &eval_indices);
+    assert_vec_close(&dense_actual, &dense_expected, 1e-10);
+    assert_eq!(read_siteinds(swapped, 0).len(), 1);
+    assert_eq!(read_siteinds(swapped, 1).len(), 1);
+
+    t4a_treetn_release(swapped);
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_swap_site_indices_rejects_duplicate_assignment() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let assignment = flat_assignment(&[
+        (indices[0] as *const t4a_index, 0),
+        (indices[0] as *const t4a_index, 1),
+    ]);
+
+    let mut swapped = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_swap_site_indices(
+            tt,
+            assignment.siteinds.as_ptr(),
+            assignment.target_vertices.as_ptr(),
+            assignment.siteinds.len(),
+            0,
+            0.0,
+            &mut swapped,
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(last_error().contains("duplicate site index assignment"));
+
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_restructure_to_mixed_case() {
+    let (tt, tensors, indices) = make_two_node_groups_of_two_treetn();
+    let target = flat_target_network(
+        &[10, 20, 30],
+        &[
+            &[indices[0] as *const t4a_index],
+            &[
+                indices[1] as *const t4a_index,
+                indices[2] as *const t4a_index,
+            ],
+            &[indices[3] as *const t4a_index],
+        ],
+        &[(10, 20), (20, 30)],
+    );
+
+    let mut result = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_restructure_to(
+            tt,
+            target.vertices.as_ptr(),
+            target.vertices.len(),
+            target.siteinds.as_ptr(),
+            target.siteind_lens.as_ptr(),
+            target.edge_sources.as_ptr(),
+            target.edge_targets.as_ptr(),
+            target.edge_sources.len(),
+            0.0,
+            0.0,
+            0,
+            t4a_canonical_form::Unitary,
+            0,
+            0,
+            0.0,
+            0.0,
+            0.0,
+            0,
+            t4a_canonical_form::Unitary,
+            &mut result,
+        ),
+        T4A_SUCCESS
+    );
+
+    let eval_indices = [
+        indices[0] as *const t4a_index,
+        indices[1] as *const t4a_index,
+        indices[2] as *const t4a_index,
+        indices[3] as *const t4a_index,
+    ];
+    let dense_expected = evaluate_real_on_full_grid(tt, &eval_indices);
+    let dense_actual = evaluate_real_on_full_grid(result, &eval_indices);
+    assert_vec_close(&dense_actual, &dense_expected, 1e-10);
+    assert_eq!(read_siteinds(result, 10).len(), 1);
+    assert_eq!(read_siteinds(result, 20).len(), 2);
+    assert_eq!(read_siteinds(result, 30).len(), 1);
+
+    t4a_treetn_release(result);
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_fuse_to_rejects_duplicate_target_site_index() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let target = flat_target_network(
+        &[5, 9],
+        &[
+            &[indices[0] as *const t4a_index],
+            &[
+                indices[0] as *const t4a_index,
+                indices[3] as *const t4a_index,
+            ],
+        ],
+        &[(5, 9)],
+    );
+
+    let mut fused = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_fuse_to(
+            tt,
+            target.vertices.as_ptr(),
+            target.vertices.len(),
+            target.siteinds.as_ptr(),
+            target.siteind_lens.as_ptr(),
+            target.edge_sources.as_ptr(),
+            target.edge_targets.as_ptr(),
+            target.edge_sources.len(),
+            &mut fused,
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(last_error().contains("duplicate site index"));
+
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
 fn test_treetn_orthogonalize_preserves_dense_tensor() {
     let (tt, tensors, indices) = make_two_site_treetn();
     let before = read_dense_f64_treetn(tt);
     assert_eq!(
-        t4a_treetn_orthogonalize(tt, 0, t4a_canonical_form::LU),
+        t4a_treetn_orthogonalize(tt, 0, t4a_canonical_form::LU, 1),
         T4A_SUCCESS
     );
     let after = read_dense_f64_treetn(tt);
@@ -382,11 +851,50 @@ fn test_treetn_canonical_region_query() {
     let (tt, tensors, indices) = make_two_site_treetn();
     assert_eq!(read_canonical_region(tt), Vec::<usize>::new());
 
+    let before = read_dense_f64_treetn(tt);
     assert_eq!(
-        t4a_treetn_orthogonalize(tt, 1, t4a_canonical_form::Unitary),
+        t4a_treetn_orthogonalize(tt, 1, t4a_canonical_form::Unitary, 0),
         T4A_SUCCESS
     );
     assert_eq!(read_canonical_region(tt), vec![1]);
+    let canonicalized = read_dense_f64_treetn(tt);
+    assert_eq!(canonicalized, before);
+
+    assert_eq!(
+        t4a_treetn_orthogonalize(tt, 1, t4a_canonical_form::Unitary, 0),
+        T4A_SUCCESS
+    );
+    assert_eq!(read_canonical_region(tt), vec![1]);
+    assert_eq!(read_dense_f64_treetn(tt), canonicalized);
+
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_orthogonalize_force_zero_form_mismatch_reports_c_api_hint() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    assert_eq!(
+        t4a_treetn_orthogonalize(tt, 1, t4a_canonical_form::Unitary, 0),
+        T4A_SUCCESS
+    );
+    let before = read_dense_f64_treetn(tt);
+
+    assert_eq!(
+        t4a_treetn_orthogonalize(tt, 1, t4a_canonical_form::LU, 0),
+        T4A_INVALID_ARGUMENT
+    );
+    let err = last_error();
+    assert!(
+        err.contains("force=1"),
+        "unexpected error message for force=0 form mismatch: {err}"
+    );
+    assert_eq!(read_dense_f64_treetn(tt), before);
+
+    assert_eq!(
+        t4a_treetn_orthogonalize(tt, 1, t4a_canonical_form::LU, 1),
+        T4A_SUCCESS
+    );
+    assert_eq!(read_dense_f64_treetn(tt), before);
 
     cleanup(tt, tensors, indices);
 }
@@ -426,13 +934,19 @@ fn link_dim(tt: *const t4a_treetn) -> usize {
 fn test_treetn_truncate_with_rtol_and_cutoff() {
     let (tt_rtol, tensors_rtol, indices_rtol) = make_truncatable_treetn();
     assert_eq!(link_dim(tt_rtol), 4);
-    assert_eq!(t4a_treetn_truncate(tt_rtol, 1e-12, 0.0, 1), T4A_SUCCESS);
+    assert_eq!(
+        t4a_treetn_truncate(tt_rtol, 1e-12, 0.0, 1, t4a_canonical_form::Unitary),
+        T4A_SUCCESS
+    );
     assert_eq!(link_dim(tt_rtol), 1);
     cleanup(tt_rtol, tensors_rtol, indices_rtol);
 
     let (tt_cutoff, tensors_cutoff, indices_cutoff) = make_truncatable_treetn();
     assert_eq!(link_dim(tt_cutoff), 4);
-    assert_eq!(t4a_treetn_truncate(tt_cutoff, 0.0, 1e-24, 1), T4A_SUCCESS);
+    assert_eq!(
+        t4a_treetn_truncate(tt_cutoff, 0.0, 1e-24, 1, t4a_canonical_form::LU),
+        T4A_SUCCESS
+    );
     assert_eq!(link_dim(tt_cutoff), 1);
     cleanup(tt_cutoff, tensors_cutoff, indices_cutoff);
 }
@@ -559,6 +1073,9 @@ fn test_treetn_contract_and_to_dense() {
             0.0,
             0.0,
             0,
+            1,
+            0.0,
+            t4a_factorize_alg::SVD,
             &mut result
         ),
         T4A_SUCCESS
@@ -573,6 +1090,102 @@ fn test_treetn_contract_and_to_dense() {
     t4a_index_release(in_clone);
     t4a_index_release(out_idx);
     t4a_index_release(in_idx);
+}
+
+#[test]
+fn test_treetn_contract_fit_zero_sweeps_uses_backend_default() {
+    let ((a, a_tensors, a_indices), (b, b_tensors, b_indices)) = make_two_site_contract_operands();
+
+    let mut baseline = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_contract(
+            a,
+            b,
+            t4a_contract_method::Fit,
+            1e-12,
+            0.0,
+            0,
+            1,
+            1e-30,
+            t4a_factorize_alg::LU,
+            &mut baseline
+        ),
+        T4A_SUCCESS
+    );
+
+    let mut uses_default = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_contract(
+            a,
+            b,
+            t4a_contract_method::Fit,
+            1e-12,
+            0.0,
+            0,
+            0,
+            1e-30,
+            t4a_factorize_alg::LU,
+            &mut uses_default
+        ),
+        T4A_SUCCESS
+    );
+
+    let baseline_dense = read_dense_f64_treetn(baseline);
+    let uses_default_dense = read_dense_f64_treetn(uses_default);
+    assert_vec_close(&uses_default_dense, &baseline_dense, 1e-10);
+
+    t4a_treetn_release(uses_default);
+    t4a_treetn_release(baseline);
+    cleanup(a, a_tensors, a_indices);
+    cleanup(b, b_tensors, b_indices);
+}
+
+#[test]
+fn test_treetn_contract_fit_accepts_iterative_options() {
+    let ((a, a_tensors, a_indices), (b, b_tensors, b_indices)) = make_two_site_contract_operands();
+
+    let mut expected = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_contract(
+            a,
+            b,
+            t4a_contract_method::Naive,
+            0.0,
+            0.0,
+            0,
+            1,
+            0.0,
+            t4a_factorize_alg::SVD,
+            &mut expected
+        ),
+        T4A_SUCCESS
+    );
+
+    let mut fitted = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_contract(
+            a,
+            b,
+            t4a_contract_method::Fit,
+            1e-12,
+            0.0,
+            0,
+            2,
+            1e-30,
+            t4a_factorize_alg::LU,
+            &mut fitted
+        ),
+        T4A_SUCCESS
+    );
+
+    let expected_dense = read_dense_f64_treetn(expected);
+    let fitted_dense = read_dense_f64_treetn(fitted);
+    assert_vec_close(&fitted_dense, &expected_dense, 1e-10);
+
+    t4a_treetn_release(fitted);
+    t4a_treetn_release(expected);
+    cleanup(a, a_tensors, a_indices);
+    cleanup(b, b_tensors, b_indices);
 }
 
 #[test]
@@ -612,6 +1225,8 @@ fn test_treetn_apply_operator_chain_identity_single_site() {
             0.0,
             0.0,
             0,
+            1,
+            0.0,
             &mut result
         ),
         T4A_SUCCESS
@@ -674,6 +1289,8 @@ fn test_treetn_apply_operator_chain_partial_operator() {
             0.0,
             0.0,
             0,
+            1,
+            0.0,
             &mut result
         ),
         T4A_SUCCESS
@@ -682,6 +1299,160 @@ fn test_treetn_apply_operator_chain_partial_operator() {
     assert_vec_close(&dense, &[2.0, 4.0, 15.0, 20.0], 1e-10);
 
     t4a_treetn_release(result);
+    t4a_treetn_release(op_tt);
+    t4a_tensor_release(op);
+    t4a_index_release(target_out);
+    t4a_index_release(internal_out);
+    t4a_index_release(internal_in);
+    cleanup(state_tt, state_tensors, std::mem::take(&mut state_indices));
+}
+
+#[test]
+fn test_treetn_apply_operator_chain_fit_zero_sweeps_uses_backend_default() {
+    let (state_tt, state_tensors, mut state_indices) = make_two_site_treetn();
+
+    let internal_in = new_index(2);
+    let internal_out = new_index(2);
+    let target_out = new_index(2);
+    let op = new_tensor(
+        &[
+            internal_out as *const t4a_index,
+            internal_in as *const t4a_index,
+        ],
+        &[2.0, 0.0, 0.0, 5.0],
+    );
+    let op_tt = new_treetn(&[op as *const t4a_tensor]);
+
+    let mapped_nodes = [1usize];
+    let input_indices = [internal_in as *const t4a_index];
+    let output_indices = [internal_out as *const t4a_index];
+    let true_output_indices = [target_out as *const t4a_index];
+
+    let mut baseline = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_apply_operator_chain(
+            op_tt,
+            state_tt,
+            mapped_nodes.as_ptr(),
+            mapped_nodes.len(),
+            input_indices.as_ptr(),
+            output_indices.as_ptr(),
+            true_output_indices.as_ptr(),
+            t4a_contract_method::Fit,
+            1e-12,
+            0.0,
+            0,
+            1,
+            1e-30,
+            &mut baseline
+        ),
+        T4A_SUCCESS
+    );
+
+    let mut uses_default = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_apply_operator_chain(
+            op_tt,
+            state_tt,
+            mapped_nodes.as_ptr(),
+            mapped_nodes.len(),
+            input_indices.as_ptr(),
+            output_indices.as_ptr(),
+            true_output_indices.as_ptr(),
+            t4a_contract_method::Fit,
+            1e-12,
+            0.0,
+            0,
+            0,
+            1e-30,
+            &mut uses_default
+        ),
+        T4A_SUCCESS
+    );
+
+    let baseline_dense = read_dense_f64_treetn(baseline);
+    let uses_default_dense = read_dense_f64_treetn(uses_default);
+    assert_vec_close(&uses_default_dense, &baseline_dense, 1e-10);
+
+    t4a_treetn_release(uses_default);
+    t4a_treetn_release(baseline);
+    t4a_treetn_release(op_tt);
+    t4a_tensor_release(op);
+    t4a_index_release(target_out);
+    t4a_index_release(internal_out);
+    t4a_index_release(internal_in);
+    cleanup(state_tt, state_tensors, std::mem::take(&mut state_indices));
+}
+
+#[test]
+fn test_treetn_apply_operator_chain_fit_accepts_iterative_options() {
+    let (state_tt, state_tensors, mut state_indices) = make_two_site_treetn();
+
+    let internal_in = new_index(2);
+    let internal_out = new_index(2);
+    let target_out = new_index(2);
+    let op = new_tensor(
+        &[
+            internal_out as *const t4a_index,
+            internal_in as *const t4a_index,
+        ],
+        &[2.0, 0.0, 0.0, 5.0],
+    );
+    let op_tt = new_treetn(&[op as *const t4a_tensor]);
+
+    let mapped_nodes = [1usize];
+    let input_indices = [internal_in as *const t4a_index];
+    let output_indices = [internal_out as *const t4a_index];
+    let true_output_indices = [target_out as *const t4a_index];
+
+    let mut expected = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_apply_operator_chain(
+            op_tt,
+            state_tt,
+            mapped_nodes.as_ptr(),
+            mapped_nodes.len(),
+            input_indices.as_ptr(),
+            output_indices.as_ptr(),
+            true_output_indices.as_ptr(),
+            t4a_contract_method::Naive,
+            0.0,
+            0.0,
+            0,
+            1,
+            0.0,
+            &mut expected
+        ),
+        T4A_SUCCESS
+    );
+
+    let mut fitted = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_apply_operator_chain(
+            op_tt,
+            state_tt,
+            mapped_nodes.as_ptr(),
+            mapped_nodes.len(),
+            input_indices.as_ptr(),
+            output_indices.as_ptr(),
+            true_output_indices.as_ptr(),
+            t4a_contract_method::Fit,
+            1e-12,
+            0.0,
+            0,
+            2,
+            1e-30,
+            &mut fitted
+        ),
+        T4A_SUCCESS
+    );
+
+    let expected_dense = read_dense_f64_treetn(expected);
+    let fitted_dense = read_dense_f64_treetn(fitted);
+    assert_vec_close(&fitted_dense, &expected_dense, 1e-10);
+
+    t4a_treetn_release(fitted);
+    t4a_treetn_release(expected);
     t4a_treetn_release(op_tt);
     t4a_tensor_release(op);
     t4a_index_release(target_out);
@@ -724,6 +1495,8 @@ fn test_treetn_apply_operator_chain_rejects_out_of_range_mapped_node() {
             0.0,
             0.0,
             0,
+            1,
+            0.0,
             &mut result
         ),
         T4A_INVALID_ARGUMENT
@@ -779,6 +1552,8 @@ fn test_treetn_apply_operator_chain_rejects_empty_mapping() {
             0.0,
             0.0,
             0,
+            1,
+            0.0,
             &mut result
         ),
         T4A_INVALID_ARGUMENT
@@ -833,6 +1608,8 @@ fn test_treetn_apply_operator_chain_rejects_unknown_internal_input_index() {
             0.0,
             0.0,
             0,
+            1,
+            0.0,
             &mut result
         ),
         T4A_INVALID_ARGUMENT

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::c_void;
 
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, FactorizeAlg, TensorDynLen};
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
 use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN};
@@ -187,6 +187,43 @@ impl From<t4a_canonical_form> for TreeCanonicalForm {
             t4a_canonical_form::Unitary => Self::Unitary,
             t4a_canonical_form::LU => Self::LU,
             t4a_canonical_form::CI => Self::CI,
+        }
+    }
+}
+
+/// Factorization algorithms exposed through the C API.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum t4a_factorize_alg {
+    /// Singular value decomposition.
+    #[default]
+    SVD = 0,
+    /// QR decomposition.
+    QR = 1,
+    /// Rank-revealing LU decomposition.
+    LU = 2,
+    /// Cross interpolation.
+    CI = 3,
+}
+
+impl From<FactorizeAlg> for t4a_factorize_alg {
+    fn from(alg: FactorizeAlg) -> Self {
+        match alg {
+            FactorizeAlg::SVD => Self::SVD,
+            FactorizeAlg::QR => Self::QR,
+            FactorizeAlg::LU => Self::LU,
+            FactorizeAlg::CI => Self::CI,
+        }
+    }
+}
+
+impl From<t4a_factorize_alg> for FactorizeAlg {
+    fn from(alg: t4a_factorize_alg) -> Self {
+        match alg {
+            t4a_factorize_alg::SVD => Self::SVD,
+            t4a_factorize_alg::QR => Self::QR,
+            t4a_factorize_alg::LU => Self::LU,
+            t4a_factorize_alg::CI => Self::CI,
         }
     }
 }

--- a/crates/tensor4all-capi/src/types/tests/mod.rs
+++ b/crates/tensor4all-capi/src/types/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tensor4all_core::FactorizeAlg;
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
 use tensor4all_treetn::CanonicalForm;
 
@@ -21,6 +22,20 @@ fn test_contract_method_roundtrip() {
         let ffi = t4a_contract_method::from(method);
         let roundtrip = ContractionMethod::from(ffi);
         assert_eq!(roundtrip, method);
+    }
+}
+
+#[test]
+fn test_factorize_alg_roundtrip() {
+    for alg in [
+        FactorizeAlg::SVD,
+        FactorizeAlg::QR,
+        FactorizeAlg::LU,
+        FactorizeAlg::CI,
+    ] {
+        let ffi = t4a_factorize_alg::from(alg);
+        let roundtrip = FactorizeAlg::from(ffi);
+        assert_eq!(roundtrip, alg);
     }
 }
 

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -23,6 +23,7 @@
 //! - This creates a hyperedge that the einsum optimizer handles correctly
 
 use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
 use std::time::{Duration, Instant};
@@ -95,7 +96,7 @@ pub fn print_and_reset_contract_profile() {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         state.borrow_mut().clear();
-        entries.sort_by(|(_, lhs), (_, rhs)| rhs.total_time.cmp(&lhs.total_time));
+        entries.sort_by_key(|(_, entry)| Reverse(entry.total_time));
 
         eprintln!("=== contract_multi Profile ===");
         for (idx, (signature, entry)) in entries.into_iter().take(20).enumerate() {

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -1,6 +1,7 @@
 //! Bridge helpers between tensor4all storage snapshots and tenferro tensors.
 
 use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
 use std::time::{Duration, Instant};
@@ -115,7 +116,7 @@ pub fn print_and_reset_native_einsum_profile() {
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         state.borrow_mut().clear();
-        entries.sort_by(|(_, lhs), (_, rhs)| rhs.total_time.cmp(&lhs.total_time));
+        entries.sort_by_key(|(_, entry)| Reverse(entry.total_time));
 
         eprintln!("=== native_einsum Profile ===");
         for (idx, (signature, entry)) in entries.into_iter().take(20).enumerate() {

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -1481,7 +1481,7 @@ where
         }
 
         let mut cache_ref = self.cache.borrow_mut();
-        for ((out_idx, row, col), value) in missing_entries.into_iter().zip(values.into_iter()) {
+        for ((out_idx, row, col), value) in missing_entries.into_iter().zip(values) {
             out[out_idx] = value;
             cache_ref.insert((row, col), value);
 

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -45,7 +45,7 @@ pub use operator::{
     compose_exclusive_linear_operators, ApplyOptions, ArcLinearOperator, IndexMapping,
     LinearOperator, Operator,
 };
-pub use options::{CanonicalizationOptions, SplitOptions, TruncationOptions};
+pub use options::{CanonicalizationOptions, RestructureOptions, SplitOptions, TruncationOptions};
 pub use random::{random_treetn, LinkSpace};
 pub use simplett_bridge::{
     tensor_train_to_treetn, tensor_train_to_treetn_with_names,

--- a/crates/tensor4all-treetn/src/node_name_network.rs
+++ b/crates/tensor4all-treetn/src/node_name_network.rs
@@ -564,7 +564,7 @@ where
             .map(|(&node, &d)| (node, d))
             .collect();
 
-        node_dist_pairs.sort_by(|a, b| b.1.cmp(&a.1)); // Descending by distance
+        node_dist_pairs.sort_by_key(|pair| std::cmp::Reverse(pair.1)); // Descending by distance
 
         let edges: Vec<(NodeIndex, NodeIndex)> = node_dist_pairs
             .iter()

--- a/crates/tensor4all-treetn/src/options.rs
+++ b/crates/tensor4all-treetn/src/options.rs
@@ -4,8 +4,10 @@
 //! - [`CanonicalizationOptions`]: Options for canonicalization
 //! - [`TruncationOptions`]: Options for truncation
 //! - [`SplitOptions`]: Options for split operations
+//! - [`RestructureOptions`]: Options for multi-phase restructure operations
 
 use crate::algorithm::CanonicalForm;
+use crate::treetn::SwapOptions;
 use tensor4all_core::truncation::{HasTruncationParams, TruncationParams};
 
 /// Options for canonicalization operations.
@@ -235,6 +237,177 @@ impl SplitOptions {
     /// Get max_rank (for backwards compatibility).
     pub fn max_rank(&self) -> Option<usize> {
         self.truncation.max_rank
+    }
+}
+
+/// Options for `TreeTN::restructure_to` multi-phase restructures.
+///
+/// `RestructureOptions` combines the three phases in the approved B2a design:
+/// a split/refinement phase, a site-transport phase, and an optional final
+/// truncation sweep after the target structure has been assembled.
+///
+/// Related types:
+/// - [`SplitOptions`] controls exact splitting plus any optional final sweep
+///   inside the split primitive.
+/// - [`SwapOptions`] controls bond truncation during site-index transport.
+/// - [`TruncationOptions`] can be applied once at the end of the full
+///   restructure to clean up bond dimensions on the final topology.
+///
+/// When in doubt, start with `RestructureOptions::default()`: exact splitting,
+/// exact transport, and no extra final truncation sweep.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::{
+///     RestructureOptions, SplitOptions, SwapOptions, TruncationOptions,
+/// };
+///
+/// let options = RestructureOptions::new()
+///     .with_split(SplitOptions::new().with_max_rank(32))
+///     .with_swap(SwapOptions {
+///         max_rank: Some(16),
+///         rtol: Some(1e-10),
+///     })
+///     .with_final_truncation(TruncationOptions::new().with_rtol(1e-12));
+///
+/// assert_eq!(options.split.max_rank(), Some(32));
+/// assert!(!options.split.final_sweep);
+/// assert_eq!(options.swap.max_rank, Some(16));
+/// assert_eq!(options.swap.rtol, Some(1e-10));
+/// assert_eq!(
+///     options
+///         .final_truncation
+///         .as_ref()
+///         .and_then(TruncationOptions::rtol),
+///     Some(1e-12)
+/// );
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct RestructureOptions {
+    /// Options for the split/refinement phase.
+    ///
+    /// These settings matter when a current node must be factored into multiple
+    /// fragments before any fragment movement can happen. Higher `max_rank`
+    /// and smaller `rtol` preserve more fidelity but can increase intermediate
+    /// bond dimensions. `final_sweep` should usually remain `false` here unless
+    /// a split-only workflow is being optimized in isolation.
+    pub split: SplitOptions,
+    /// Options for the site-transport / swap phase.
+    ///
+    /// This phase only moves already planned fragments across existing edges.
+    /// Leaving both fields unset keeps swaps exact. Setting `max_rank` or
+    /// `rtol` can control intermediate rank growth, but may introduce
+    /// approximation earlier than the optional final truncation sweep.
+    pub swap: SwapOptions,
+    /// Optional final truncation sweep on the fully restructured network.
+    ///
+    /// Use this when the split and swap phases should remain as exact as
+    /// possible, and compression should happen only after the target topology
+    /// and grouping have been reached. `None` disables this cleanup pass.
+    pub final_truncation: Option<TruncationOptions>,
+}
+
+impl RestructureOptions {
+    /// Create options with exact split/swap phases and no final cleanup sweep.
+    ///
+    /// # Returns
+    /// A `RestructureOptions` value equivalent to [`Default::default`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::RestructureOptions;
+    ///
+    /// let options = RestructureOptions::new();
+    ///
+    /// assert!(!options.split.final_sweep);
+    /// assert_eq!(options.swap.max_rank, None);
+    /// assert_eq!(options.swap.rtol, None);
+    /// assert!(options.final_truncation.is_none());
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the split-phase options.
+    ///
+    /// # Arguments
+    /// * `split` - Split/refinement settings used before fragment transport.
+    ///
+    /// # Returns
+    /// Updated restructure options using the provided split settings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::{RestructureOptions, SplitOptions};
+    ///
+    /// let options = RestructureOptions::new()
+    ///     .with_split(SplitOptions::new().with_max_rank(24).with_final_sweep(true));
+    ///
+    /// assert_eq!(options.split.max_rank(), Some(24));
+    /// assert!(options.split.final_sweep);
+    /// ```
+    pub fn with_split(mut self, split: SplitOptions) -> Self {
+        self.split = split;
+        self
+    }
+
+    /// Replace the swap/transport options.
+    ///
+    /// # Arguments
+    /// * `swap` - Truncation settings applied during fragment movement.
+    ///
+    /// # Returns
+    /// Updated restructure options using the provided swap settings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::{RestructureOptions, SwapOptions};
+    ///
+    /// let options = RestructureOptions::new().with_swap(SwapOptions {
+    ///     max_rank: Some(12),
+    ///     rtol: Some(1e-8),
+    /// });
+    ///
+    /// assert_eq!(options.swap.max_rank, Some(12));
+    /// assert_eq!(options.swap.rtol, Some(1e-8));
+    /// ```
+    pub fn with_swap(mut self, swap: SwapOptions) -> Self {
+        self.swap = swap;
+        self
+    }
+
+    /// Set the optional final truncation sweep.
+    ///
+    /// # Arguments
+    /// * `final_truncation` - Final cleanup sweep to run on the target
+    ///   topology.
+    ///
+    /// # Returns
+    /// Updated restructure options using the provided final sweep settings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::{RestructureOptions, TruncationOptions};
+    ///
+    /// let options = RestructureOptions::new()
+    ///     .with_final_truncation(TruncationOptions::new().with_max_rank(10));
+    ///
+    /// assert_eq!(
+    ///     options
+    ///         .final_truncation
+    ///         .as_ref()
+    ///         .and_then(TruncationOptions::max_rank),
+    ///     Some(10)
+    /// );
+    /// ```
+    pub fn with_final_truncation(mut self, final_truncation: TruncationOptions) -> Self {
+        self.final_truncation = Some(final_truncation);
+        self
     }
 }
 

--- a/crates/tensor4all-treetn/src/options/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/options/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::SwapOptions;
 
 #[test]
 fn test_canonicalization_options_default() {
@@ -99,4 +100,32 @@ fn test_split_options_has_truncation_params() {
     assert!(opts.truncation_params().max_rank.is_none());
     opts.truncation_params_mut().max_rank = Some(25);
     assert_eq!(opts.truncation_params().max_rank, Some(25));
+}
+
+#[test]
+fn test_restructure_options_default_and_builder() {
+    let opts = RestructureOptions::default();
+    assert_eq!(opts.split.form, CanonicalForm::Unitary);
+    assert!(!opts.split.final_sweep);
+    assert_eq!(opts.swap.max_rank, None);
+    assert_eq!(opts.swap.rtol, None);
+    assert!(opts.final_truncation.is_none());
+
+    let opts = RestructureOptions::new()
+        .with_split(SplitOptions::new().with_max_rank(16).with_final_sweep(true))
+        .with_swap(SwapOptions {
+            max_rank: Some(8),
+            rtol: Some(1e-9),
+        })
+        .with_final_truncation(TruncationOptions::new().with_rtol(1e-10));
+    assert_eq!(opts.split.max_rank(), Some(16));
+    assert!(opts.split.final_sweep);
+    assert_eq!(opts.swap.max_rank, Some(8));
+    assert_eq!(opts.swap.rtol, Some(1e-9));
+    assert_eq!(
+        opts.final_truncation
+            .as_ref()
+            .and_then(TruncationOptions::rtol),
+        Some(1e-10)
+    );
 }

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -252,7 +252,7 @@ where
 
         // Step 1: Add all tensors as nodes and collect NodeIndex mappings
         let mut node_indices = Vec::with_capacity(tensors.len());
-        for (tensor, node_name) in tensors.into_iter().zip(node_names.into_iter()) {
+        for (tensor, node_name) in tensors.into_iter().zip(node_names) {
             let node_idx = treetn.add_tensor_internal(node_name, tensor)?;
             node_indices.push(node_idx);
         }

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -15,6 +15,7 @@ mod localupdate;
 mod operator_impl;
 mod ops;
 pub mod partial_contraction;
+mod restructure;
 mod swap;
 mod tensor_like;
 mod transform;

--- a/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
@@ -31,6 +31,9 @@ struct FragmentNode<CurrentV, TargetV> {
     target: TargetV,
 }
 
+type SplitThenFuseTarget<CurrentV, TargetV, I> =
+    SiteIndexNetwork<FragmentNode<CurrentV, TargetV>, I>;
+
 #[derive(Debug, Clone)]
 enum RestructurePlanKind<CurrentV, TargetV, I>
 where
@@ -48,7 +51,7 @@ where
         target_assignment: HashMap<I::Id, CurrentV>,
     },
     SplitThenFuse {
-        split_target: SiteIndexNetwork<FragmentNode<CurrentV, TargetV>, I>,
+        split_target: Box<SplitThenFuseTarget<CurrentV, TargetV, I>>,
     },
 }
 
@@ -311,7 +314,7 @@ fn build_split_then_fuse_target<T, CurrentV, TargetV>(
     target: &SiteIndexNetwork<TargetV, T::Index>,
     site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
     site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
-) -> Result<Option<SiteIndexNetwork<FragmentNode<CurrentV, TargetV>, T::Index>>>
+) -> Result<Option<SplitThenFuseTarget<CurrentV, TargetV, T::Index>>>
 where
     T: TensorLike,
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -593,6 +596,13 @@ where
     signature
 }
 
+#[derive(Default)]
+struct IsomorphicMatchState {
+    current_cache: HashMap<(usize, Option<usize>), String>,
+    target_cache: HashMap<(usize, Option<usize>), String>,
+    mapping: HashMap<NodeIndex, NodeIndex>,
+}
+
 fn match_isomorphic_subtrees<CurrentV, TargetV>(
     current_topology: &NodeNameNetwork<CurrentV>,
     target_topology: &NodeNameNetwork<TargetV>,
@@ -600,15 +610,13 @@ fn match_isomorphic_subtrees<CurrentV, TargetV>(
     current_parent: Option<NodeIndex>,
     target_node: NodeIndex,
     target_parent: Option<NodeIndex>,
-    current_cache: &mut HashMap<(usize, Option<usize>), String>,
-    target_cache: &mut HashMap<(usize, Option<usize>), String>,
-    mapping: &mut HashMap<NodeIndex, NodeIndex>,
+    state: &mut IsomorphicMatchState,
 ) -> bool
 where
     CurrentV: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
     TargetV: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
 {
-    if let Some(existing) = mapping.insert(target_node, current_node) {
+    if let Some(existing) = state.mapping.insert(target_node, current_node) {
         if existing != current_node {
             return false;
         }
@@ -622,14 +630,23 @@ where
 
     let mut current_groups: HashMap<String, Vec<NodeIndex>> = HashMap::new();
     for child in current_children {
-        let signature =
-            rooted_signature(current_topology, child, Some(current_node), current_cache);
+        let signature = rooted_signature(
+            current_topology,
+            child,
+            Some(current_node),
+            &mut state.current_cache,
+        );
         current_groups.entry(signature).or_default().push(child);
     }
 
     let mut target_groups: HashMap<String, Vec<NodeIndex>> = HashMap::new();
     for child in target_children {
-        let signature = rooted_signature(target_topology, child, Some(target_node), target_cache);
+        let signature = rooted_signature(
+            target_topology,
+            child,
+            Some(target_node),
+            &mut state.target_cache,
+        );
         target_groups.entry(signature).or_default().push(child);
     }
 
@@ -663,9 +680,7 @@ where
                 Some(current_node),
                 target_child,
                 Some(target_node),
-                current_cache,
-                target_cache,
-                mapping,
+                state,
             ) {
                 return false;
             }
@@ -690,15 +705,12 @@ where
         return None;
     }
 
-    let mut current_cache = HashMap::new();
-    let mut target_cache = HashMap::new();
-
     let mut current_roots: Vec<(String, NodeIndex)> = current_topology
         .graph()
         .node_indices()
         .map(|node| {
             (
-                rooted_signature(current_topology, node, None, &mut current_cache),
+                rooted_signature(current_topology, node, None, &mut HashMap::new()),
                 node,
             )
         })
@@ -710,7 +722,7 @@ where
         .node_indices()
         .map(|node| {
             (
-                rooted_signature(target_topology, node, None, &mut target_cache),
+                rooted_signature(target_topology, node, None, &mut HashMap::new()),
                 node,
             )
         })
@@ -723,7 +735,7 @@ where
                 continue;
             }
 
-            let mut mapping = HashMap::new();
+            let mut state = IsomorphicMatchState::default();
             if match_isomorphic_subtrees(
                 current_topology,
                 target_topology,
@@ -731,12 +743,10 @@ where
                 None,
                 *target_root,
                 None,
-                &mut current_cache,
-                &mut target_cache,
-                &mut mapping,
-            ) && mapping.len() == target_topology.node_count()
+                &mut state,
+            ) && state.mapping.len() == target_topology.node_count()
             {
-                return Some(mapping);
+                return Some(state.mapping);
             }
         }
     }
@@ -890,7 +900,9 @@ where
         &site_to_current,
     )? {
         return Ok(RestructurePlan {
-            kind: RestructurePlanKind::SplitThenFuse { split_target },
+            kind: RestructurePlanKind::SplitThenFuse {
+                split_target: Box::new(split_target),
+            },
         });
     }
 
@@ -934,7 +946,7 @@ where
         }
         RestructurePlanKind::SplitThenFuse { split_target } => {
             let split = tree
-                .split_to(&split_target, &options.split)
+                .split_to(split_target.as_ref(), &options.split)
                 .context("restructure_to: split phase")?;
             split.fuse_to(target).context("restructure_to: fuse phase")
         }
@@ -1051,6 +1063,14 @@ mod tests {
 
     use super::*;
 
+    type FourSiteChainCase = (
+        TreeTN<TensorDynLen, String>,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+    );
+
     fn two_node_chain() -> anyhow::Result<(TreeTN<TensorDynLen, String>, DynIndex, DynIndex)> {
         let left = DynIndex::new_dyn(2);
         let right = DynIndex::new_dyn(2);
@@ -1064,13 +1084,7 @@ mod tests {
         Ok((treetn, left, right))
     }
 
-    fn two_node_groups_of_two() -> anyhow::Result<(
-        TreeTN<TensorDynLen, String>,
-        DynIndex,
-        DynIndex,
-        DynIndex,
-        DynIndex,
-    )> {
+    fn two_node_groups_of_two() -> anyhow::Result<FourSiteChainCase> {
         let x0 = DynIndex::new_dyn(2);
         let x1 = DynIndex::new_dyn(2);
         let y0 = DynIndex::new_dyn(2);
@@ -1091,13 +1105,7 @@ mod tests {
         Ok((treetn, x0, x1, y0, y1))
     }
 
-    fn three_node_chain_for_swap() -> anyhow::Result<(
-        TreeTN<TensorDynLen, String>,
-        DynIndex,
-        DynIndex,
-        DynIndex,
-        DynIndex,
-    )> {
+    fn three_node_chain_for_swap() -> anyhow::Result<FourSiteChainCase> {
         let s0 = DynIndex::new_dyn(2);
         let s1 = DynIndex::new_dyn(2);
         let s2 = DynIndex::new_dyn(2);
@@ -1120,13 +1128,7 @@ mod tests {
         Ok((treetn, s0, s1, s2, s3))
     }
 
-    fn four_node_interleaved_chain() -> anyhow::Result<(
-        TreeTN<TensorDynLen, String>,
-        DynIndex,
-        DynIndex,
-        DynIndex,
-        DynIndex,
-    )> {
+    fn four_node_interleaved_chain() -> anyhow::Result<FourSiteChainCase> {
         let x0 = DynIndex::new_dyn(2);
         let x1 = DynIndex::new_dyn(2);
         let y0 = DynIndex::new_dyn(2);

--- a/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
@@ -1,0 +1,1447 @@
+//! Public scaffolding for multi-phase TreeTN restructuring.
+//!
+//! The approved B2a design is plan-first:
+//! 1. Build a pure restructure plan from the current and target site-index networks.
+//! 2. Execute that plan through split, move, and fuse phases.
+//!
+//! The initial implementation currently supports fuse-only, split-only,
+//! swap-only, a conservative path-based swap-then-fuse mixed path, and a
+//! conservative split-then-fuse mixed path.
+//!
+//! Unsupported patterns are reported explicitly. In particular, mixed cases
+//! that require both splitting a node into multiple cross-node fragments and a
+//! subsequent swap/move phase may still remain staged behind placeholder
+//! errors.
+
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+use crate::node_name_network::NodeNameNetwork;
+use anyhow::{bail, Context, Result};
+use petgraph::stable_graph::NodeIndex;
+use tensor4all_core::{IndexLike, TensorLike};
+
+use super::TreeTN;
+use crate::{RestructureOptions, SiteIndexNetwork};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct FragmentNode<CurrentV, TargetV> {
+    current: CurrentV,
+    split_rank: usize,
+    target: TargetV,
+}
+
+#[derive(Debug, Clone)]
+enum RestructurePlanKind<CurrentV, TargetV, I>
+where
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    I: IndexLike,
+    I::Id: Eq + Hash,
+{
+    FuseOnly,
+    SplitOnly,
+    SwapOnly {
+        target_assignment: HashMap<I::Id, CurrentV>,
+    },
+    SwapThenFuse {
+        target_assignment: HashMap<I::Id, CurrentV>,
+    },
+    SplitThenFuse {
+        split_target: SiteIndexNetwork<FragmentNode<CurrentV, TargetV>, I>,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct RestructurePlan<CurrentV, TargetV, I>
+where
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    I: IndexLike,
+    I::Id: Eq + Hash,
+{
+    kind: RestructurePlanKind<CurrentV, TargetV, I>,
+}
+
+fn collect_site_targets<T, TargetV>(
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+) -> Result<HashMap<<T::Index as IndexLike>::Id, TargetV>>
+where
+    T: TensorLike,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let mut site_to_target = HashMap::new();
+    for target_node_name in target.node_names() {
+        let site_space = target.site_space(target_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target node {:?} has no registered site space",
+                target_node_name
+            )
+        })?;
+        for site_idx in site_space {
+            let existing = site_to_target.insert(site_idx.id().clone(), target_node_name.clone());
+            if let Some(previous_target) = existing {
+                bail!(
+                    "restructure_to: site index {:?} appears in both target nodes {:?} and {:?}",
+                    site_idx.id(),
+                    previous_target,
+                    target_node_name
+                );
+            }
+        }
+    }
+    Ok(site_to_target)
+}
+
+fn collect_current_site_ids<T, CurrentV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+) -> Result<HashSet<<T::Index as IndexLike>::Id>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let mut site_ids = HashSet::new();
+    for current_node_name in current.node_names() {
+        let site_space = current.site_space(current_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current node {:?} has no registered site space",
+                current_node_name
+            )
+        })?;
+        for site_idx in site_space {
+            site_ids.insert(site_idx.id().clone());
+        }
+    }
+    Ok(site_ids)
+}
+
+fn current_nodes_map_uniquely_to_targets<T, CurrentV, TargetV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+) -> Result<bool>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    for current_node_name in current.node_names() {
+        let site_space = current.site_space(current_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current node {:?} has no registered site space",
+                current_node_name
+            )
+        })?;
+        let target_names: HashSet<_> = site_space
+            .iter()
+            .map(|site_idx| {
+                site_to_target
+                    .get(site_idx.id())
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "restructure_to: site index {:?} is present in the current network but missing from the target",
+                            site_idx.id()
+                        )
+                    })
+            })
+            .collect::<Result<_>>()?;
+        if target_names.len() > 1 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn collect_site_currents<T, CurrentV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+) -> Result<HashMap<<T::Index as IndexLike>::Id, CurrentV>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let mut site_to_current = HashMap::new();
+    for current_node_name in current.node_names() {
+        let site_space = current.site_space(current_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current node {:?} has no registered site space",
+                current_node_name
+            )
+        })?;
+        for site_idx in site_space {
+            let existing = site_to_current.insert(site_idx.id().clone(), current_node_name.clone());
+            if let Some(previous_current) = existing {
+                bail!(
+                    "restructure_to: site index {:?} appears in both current nodes {:?} and {:?}",
+                    site_idx.id(),
+                    previous_current,
+                    current_node_name
+                );
+            }
+        }
+    }
+    Ok(site_to_current)
+}
+
+fn target_nodes_map_uniquely_to_currents<T, CurrentV, TargetV>(
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+) -> Result<bool>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    for target_node_name in target.node_names() {
+        let site_space = target.site_space(target_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target node {:?} has no registered site space",
+                target_node_name
+            )
+        })?;
+        let current_names: HashSet<_> = site_space
+            .iter()
+            .map(|site_idx| {
+                site_to_current
+                    .get(site_idx.id())
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "restructure_to: site index {:?} is present in the target but missing from the current network",
+                            site_idx.id()
+                        )
+                    })
+            })
+            .collect::<Result<_>>()?;
+        if current_names.len() > 1 {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn target_nodes_span_connected_currents<T, CurrentV, TargetV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+) -> Result<bool>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    for target_node_name in target.node_names() {
+        let site_space = target.site_space(target_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target node {:?} has no registered site space",
+                target_node_name
+            )
+        })?;
+        let current_nodes: HashSet<_> = site_space
+            .iter()
+            .map(|site_idx| {
+                let current_name = site_to_current.get(site_idx.id()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "restructure_to: site index {:?} is present in the target but missing from the current network",
+                        site_idx.id()
+                    )
+                })?;
+                current.node_index(current_name).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "restructure_to: current node {:?} is missing from the topology",
+                        current_name
+                    )
+                })
+            })
+            .collect::<Result<_>>()?;
+        if !current.is_connected_subset(&current_nodes) {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn collect_shared_targets<T, CurrentV, TargetV>(
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+) -> Result<HashSet<TargetV>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let mut shared_targets = HashSet::new();
+    for target_node_name in target.node_names() {
+        let site_space = target.site_space(target_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target node {:?} has no registered site space",
+                target_node_name
+            )
+        })?;
+        let current_names: HashSet<_> = site_space
+            .iter()
+            .map(|site_idx| {
+                site_to_current
+                    .get(site_idx.id())
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "restructure_to: site index {:?} is present in the target but missing from the current network",
+                            site_idx.id()
+                        )
+                    })
+            })
+            .collect::<Result<_>>()?;
+        if current_names.len() > 1 {
+            shared_targets.insert(target_node_name.clone());
+        }
+    }
+    Ok(shared_targets)
+}
+
+fn build_split_then_fuse_target<T, CurrentV, TargetV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+) -> Result<Option<SiteIndexNetwork<FragmentNode<CurrentV, TargetV>, T::Index>>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    if !target_nodes_span_connected_currents::<T, CurrentV, TargetV>(
+        current,
+        target,
+        site_to_current,
+    )? {
+        return Ok(None);
+    }
+
+    let shared_targets = collect_shared_targets::<T, CurrentV, TargetV>(target, site_to_current)?;
+    let mut split_target = SiteIndexNetwork::with_capacity(current.node_count(), 0);
+    let mut current_node_names: Vec<_> = current.node_names().into_iter().cloned().collect();
+    current_node_names.sort();
+
+    for current_node_name in current_node_names {
+        let site_space = current.site_space(&current_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current node {:?} has no registered site space",
+                current_node_name
+            )
+        })?;
+        let mut fragments: HashMap<TargetV, HashSet<T::Index>> = HashMap::new();
+        for site_idx in site_space {
+            let target_node_name = site_to_target.get(site_idx.id()).cloned().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "restructure_to: site index {:?} is present in the current network but missing from the target",
+                    site_idx.id()
+                )
+            })?;
+            fragments
+                .entry(target_node_name)
+                .or_default()
+                .insert(site_idx.clone());
+        }
+
+        let shared_targets_here: Vec<_> = fragments
+            .keys()
+            .filter(|target_name| shared_targets.contains(*target_name))
+            .cloned()
+            .collect();
+        if shared_targets_here.len() > 1 {
+            return Ok(None);
+        }
+        let boundary_target = shared_targets_here.first().cloned();
+
+        let mut fragments: Vec<_> = fragments.into_iter().collect();
+        fragments.sort_by(|(left_name, _), (right_name, _)| {
+            let left_is_boundary = boundary_target.as_ref() == Some(left_name);
+            let right_is_boundary = boundary_target.as_ref() == Some(right_name);
+            left_is_boundary
+                .cmp(&right_is_boundary)
+                .then_with(|| left_name.cmp(right_name))
+        });
+
+        for (split_rank, (target_node_name, fragment_site_space)) in
+            fragments.into_iter().enumerate()
+        {
+            split_target
+                .add_node(
+                    FragmentNode {
+                        current: current_node_name.clone(),
+                        split_rank,
+                        target: target_node_name,
+                    },
+                    fragment_site_space,
+                )
+                .map_err(anyhow::Error::msg)?;
+        }
+    }
+
+    Ok(Some(split_target))
+}
+
+fn ordered_path_nodes<V>(topology: &NodeNameNetwork<V>) -> Option<Vec<V>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let graph = topology.graph();
+    match topology.node_count() {
+        0 => return Some(Vec::new()),
+        1 => {
+            let node = graph.node_indices().next()?;
+            return Some(vec![topology.node_name(node)?.clone()]);
+        }
+        _ => {}
+    }
+
+    let mut leaves = Vec::new();
+    for node in graph.node_indices() {
+        let degree = graph.neighbors(node).count();
+        if degree > 2 {
+            return None;
+        }
+        if degree == 1 {
+            leaves.push(node);
+        }
+    }
+    if leaves.len() != 2 {
+        return None;
+    }
+
+    leaves.sort_by_key(|node| topology.node_name(*node).cloned());
+    let mut ordered = Vec::with_capacity(topology.node_count());
+    let mut previous = None;
+    let mut current = *leaves.first()?;
+
+    loop {
+        ordered.push(topology.node_name(current)?.clone());
+        let next = graph
+            .neighbors(current)
+            .find(|neighbor| Some(*neighbor) != previous);
+        let Some(next) = next else {
+            break;
+        };
+        previous = Some(current);
+        current = next;
+    }
+
+    if ordered.len() == topology.node_count() {
+        Some(ordered)
+    } else {
+        None
+    }
+}
+
+fn build_path_swap_then_fuse_assignment<T, CurrentV, TargetV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+) -> Result<Option<HashMap<<T::Index as IndexLike>::Id, CurrentV>>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let current_path = match ordered_path_nodes(current.topology()) {
+        Some(path) => path,
+        None => return Ok(None),
+    };
+    let target_path = match ordered_path_nodes(target.topology()) {
+        Some(path) => path,
+        None => return Ok(None),
+    };
+
+    let mut contributor_counts: HashMap<TargetV, usize> = HashMap::new();
+    for current_node_name in &current_path {
+        let site_space = current.site_space(current_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current node {:?} has no registered site space",
+                current_node_name
+            )
+        })?;
+        let mut target_names: Vec<_> = site_space
+            .iter()
+            .map(|site_idx| {
+                site_to_target
+                    .get(site_idx.id())
+                    .cloned()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "restructure_to: site index {:?} is present in the current network but missing from the target",
+                            site_idx.id()
+                        )
+                    })
+            })
+            .collect::<Result<_>>()?;
+        target_names.sort();
+        target_names.dedup();
+        if target_names.len() != 1 {
+            return Ok(None);
+        }
+        let target_name = target_names.into_iter().next().ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current node {:?} has no target mapping",
+                current_node_name
+            )
+        })?;
+        *contributor_counts.entry(target_name).or_default() += 1;
+    }
+
+    let total_contributors: usize = contributor_counts.values().sum();
+    if total_contributors != current_path.len() {
+        return Ok(None);
+    }
+
+    let mut contiguous_blocks: HashMap<TargetV, Vec<CurrentV>> = HashMap::new();
+    let mut cursor = 0usize;
+    for target_node_name in &target_path {
+        let block_len = *contributor_counts.get(target_node_name).unwrap_or(&0);
+        if block_len == 0 || cursor + block_len > current_path.len() {
+            return Ok(None);
+        }
+        contiguous_blocks.insert(
+            target_node_name.clone(),
+            current_path[cursor..cursor + block_len].to_vec(),
+        );
+        cursor += block_len;
+    }
+    if cursor != current_path.len() {
+        return Ok(None);
+    }
+
+    let mut target_assignment = HashMap::new();
+    for target_node_name in &target_path {
+        let block = contiguous_blocks.get(target_node_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: missing contiguous block for target {:?}",
+                target_node_name
+            )
+        })?;
+        let mut site_ids: Vec<_> = target
+            .site_space(target_node_name)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "restructure_to: target node {:?} has no registered site space",
+                    target_node_name
+                )
+            })?
+            .iter()
+            .map(|site_idx| site_idx.id().clone())
+            .collect();
+        site_ids.sort();
+        if site_ids.len() < block.len() {
+            return Ok(None);
+        }
+
+        for (position, site_id) in site_ids.into_iter().enumerate() {
+            let block_index = position.min(block.len() - 1);
+            target_assignment.insert(site_id, block[block_index].clone());
+        }
+    }
+
+    Ok(Some(target_assignment))
+}
+
+fn tree_children<V>(
+    topology: &NodeNameNetwork<V>,
+    node: NodeIndex,
+    parent: Option<NodeIndex>,
+) -> Vec<NodeIndex>
+where
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    topology
+        .graph()
+        .neighbors(node)
+        .filter(|neighbor| Some(*neighbor) != parent)
+        .collect()
+}
+
+fn rooted_signature<V>(
+    topology: &NodeNameNetwork<V>,
+    node: NodeIndex,
+    parent: Option<NodeIndex>,
+    cache: &mut HashMap<(usize, Option<usize>), String>,
+) -> String
+where
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    let key = (node.index(), parent.map(|p| p.index()));
+    if let Some(signature) = cache.get(&key) {
+        return signature.clone();
+    }
+
+    let mut child_signatures: Vec<String> = tree_children(topology, node, parent)
+        .into_iter()
+        .map(|child| rooted_signature(topology, child, Some(node), cache))
+        .collect();
+    child_signatures.sort();
+
+    let signature = format!("({})", child_signatures.concat());
+    cache.insert(key, signature.clone());
+    signature
+}
+
+fn match_isomorphic_subtrees<CurrentV, TargetV>(
+    current_topology: &NodeNameNetwork<CurrentV>,
+    target_topology: &NodeNameNetwork<TargetV>,
+    current_node: NodeIndex,
+    current_parent: Option<NodeIndex>,
+    target_node: NodeIndex,
+    target_parent: Option<NodeIndex>,
+    current_cache: &mut HashMap<(usize, Option<usize>), String>,
+    target_cache: &mut HashMap<(usize, Option<usize>), String>,
+    mapping: &mut HashMap<NodeIndex, NodeIndex>,
+) -> bool
+where
+    CurrentV: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    if let Some(existing) = mapping.insert(target_node, current_node) {
+        if existing != current_node {
+            return false;
+        }
+    }
+
+    let current_children = tree_children(current_topology, current_node, current_parent);
+    let target_children = tree_children(target_topology, target_node, target_parent);
+    if current_children.len() != target_children.len() {
+        return false;
+    }
+
+    let mut current_groups: HashMap<String, Vec<NodeIndex>> = HashMap::new();
+    for child in current_children {
+        let signature =
+            rooted_signature(current_topology, child, Some(current_node), current_cache);
+        current_groups.entry(signature).or_default().push(child);
+    }
+
+    let mut target_groups: HashMap<String, Vec<NodeIndex>> = HashMap::new();
+    for child in target_children {
+        let signature = rooted_signature(target_topology, child, Some(target_node), target_cache);
+        target_groups.entry(signature).or_default().push(child);
+    }
+
+    if current_groups.len() != target_groups.len() {
+        return false;
+    }
+
+    let mut signatures: Vec<String> = current_groups.keys().cloned().collect();
+    signatures.sort();
+    for signature in signatures {
+        let mut current_bucket = match current_groups.remove(&signature) {
+            Some(bucket) => bucket,
+            None => return false,
+        };
+        let mut target_bucket = match target_groups.remove(&signature) {
+            Some(bucket) => bucket,
+            None => return false,
+        };
+        if current_bucket.len() != target_bucket.len() {
+            return false;
+        }
+
+        current_bucket.sort_by_key(|node| node.index());
+        target_bucket.sort_by_key(|node| node.index());
+
+        for (current_child, target_child) in current_bucket.into_iter().zip(target_bucket) {
+            if !match_isomorphic_subtrees(
+                current_topology,
+                target_topology,
+                current_child,
+                Some(current_node),
+                target_child,
+                Some(target_node),
+                current_cache,
+                target_cache,
+                mapping,
+            ) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn match_tree_topologies<CurrentV, TargetV>(
+    current_topology: &NodeNameNetwork<CurrentV>,
+    target_topology: &NodeNameNetwork<TargetV>,
+) -> Option<HashMap<NodeIndex, NodeIndex>>
+where
+    CurrentV: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    if current_topology.node_count() != target_topology.node_count() {
+        return None;
+    }
+    if current_topology.edge_count() != target_topology.edge_count() {
+        return None;
+    }
+
+    let mut current_cache = HashMap::new();
+    let mut target_cache = HashMap::new();
+
+    let mut current_roots: Vec<(String, NodeIndex)> = current_topology
+        .graph()
+        .node_indices()
+        .map(|node| {
+            (
+                rooted_signature(current_topology, node, None, &mut current_cache),
+                node,
+            )
+        })
+        .collect();
+    current_roots.sort_by_key(|(signature, node)| (signature.clone(), node.index()));
+
+    let mut target_roots: Vec<(String, NodeIndex)> = target_topology
+        .graph()
+        .node_indices()
+        .map(|node| {
+            (
+                rooted_signature(target_topology, node, None, &mut target_cache),
+                node,
+            )
+        })
+        .collect();
+    target_roots.sort_by_key(|(signature, node)| (signature.clone(), node.index()));
+
+    for (target_signature, target_root) in &target_roots {
+        for (current_signature, current_root) in &current_roots {
+            if current_signature != target_signature {
+                continue;
+            }
+
+            let mut mapping = HashMap::new();
+            if match_isomorphic_subtrees(
+                current_topology,
+                target_topology,
+                *current_root,
+                None,
+                *target_root,
+                None,
+                &mut current_cache,
+                &mut target_cache,
+                &mut mapping,
+            ) && mapping.len() == target_topology.node_count()
+            {
+                return Some(mapping);
+            }
+        }
+    }
+
+    None
+}
+
+fn build_swap_assignment<T, CurrentV, TargetV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+) -> Result<Option<HashMap<<T::Index as IndexLike>::Id, CurrentV>>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let topology_mapping = match match_tree_topologies(current.topology(), target.topology()) {
+        Some(mapping) => mapping,
+        None => return Ok(None),
+    };
+
+    let mut assignment = HashMap::new();
+    for target_node in target.graph().node_indices() {
+        let target_name = target.node_name(target_node).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target topology mapping referenced a missing node index {:?}",
+                target_node
+            )
+        })?;
+        let current_node = *topology_mapping.get(&target_node).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target topology mapping did not assign a current node to {:?}",
+                target_name
+            )
+        })?;
+        let current_name = current.node_name(current_node).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: current topology mapping referenced a missing node index {:?}",
+                current_node
+            )
+        })?;
+        let site_space = target.site_space(target_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "restructure_to: target node {:?} has no registered site space",
+                target_name
+            )
+        })?;
+        for site_idx in site_space {
+            assignment.insert(site_idx.id().clone(), current_name.clone());
+        }
+    }
+
+    Ok(Some(assignment))
+}
+
+fn clone_tree<T, V>(tree: &TreeTN<T, V>) -> Result<TreeTN<T, V>>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    Ok(TreeTN {
+        graph: tree.graph.clone(),
+        canonical_region: tree.canonical_region.clone(),
+        canonical_form: tree.canonical_form,
+        site_index_network: tree.site_index_network.clone(),
+        link_index_network: tree.link_index_network.clone(),
+        ortho_towards: tree.ortho_towards.clone(),
+    })
+}
+
+fn apply_final_truncation<T, V>(
+    tree: TreeTN<T, V>,
+    options: &RestructureOptions,
+) -> Result<TreeTN<T, V>>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let Some(final_truncation) = options.final_truncation else {
+        return Ok(tree);
+    };
+    let center = tree
+        .node_names()
+        .into_iter()
+        .min()
+        .ok_or_else(|| anyhow::anyhow!("restructure_to: cannot truncate an empty network"))?;
+    tree.truncate([center], final_truncation)
+        .context("restructure_to: final truncation")
+}
+
+fn build_plan<T, CurrentV, TargetV>(
+    current: &SiteIndexNetwork<CurrentV, T::Index>,
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+) -> Result<RestructurePlan<CurrentV, TargetV, T::Index>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let site_to_target = collect_site_targets::<T, TargetV>(target)?;
+    let site_to_current = collect_site_currents::<T, CurrentV>(current)?;
+    let current_site_ids = collect_current_site_ids::<T, CurrentV>(current)?;
+    let target_site_ids: HashSet<_> = site_to_target.keys().cloned().collect();
+
+    if current_site_ids != target_site_ids {
+        bail!("restructure_to: current and target must contain the same site index ids");
+    }
+
+    if current_nodes_map_uniquely_to_targets::<T, CurrentV, TargetV>(current, &site_to_target)? {
+        if target_nodes_span_connected_currents::<T, CurrentV, TargetV>(
+            current,
+            target,
+            &site_to_current,
+        )? {
+            return Ok(RestructurePlan {
+                kind: RestructurePlanKind::FuseOnly,
+            });
+        }
+
+        if let Some(target_assignment) = build_path_swap_then_fuse_assignment::<T, CurrentV, TargetV>(
+            current,
+            target,
+            &site_to_target,
+        )? {
+            return Ok(RestructurePlan {
+                kind: RestructurePlanKind::SwapThenFuse { target_assignment },
+            });
+        }
+    }
+
+    if target_nodes_map_uniquely_to_currents::<T, CurrentV, TargetV>(target, &site_to_current)? {
+        return Ok(RestructurePlan {
+            kind: RestructurePlanKind::SplitOnly,
+        });
+    }
+
+    if let Some(target_assignment) = build_swap_assignment::<T, CurrentV, TargetV>(current, target)?
+    {
+        return Ok(RestructurePlan {
+            kind: RestructurePlanKind::SwapOnly { target_assignment },
+        });
+    }
+
+    if let Some(split_target) = build_split_then_fuse_target::<T, CurrentV, TargetV>(
+        current,
+        target,
+        &site_to_target,
+        &site_to_current,
+    )? {
+        return Ok(RestructurePlan {
+            kind: RestructurePlanKind::SplitThenFuse { split_target },
+        });
+    }
+
+    bail!(
+        "restructure_to: planner placeholder only; split/move/mixed restructure planning is not implemented yet"
+    )
+}
+
+fn execute_plan<T, CurrentV, TargetV>(
+    tree: &TreeTN<T, CurrentV>,
+    plan: RestructurePlan<CurrentV, TargetV, T::Index>,
+    target: &SiteIndexNetwork<TargetV, T::Index>,
+    options: &RestructureOptions,
+) -> Result<TreeTN<T, TargetV>>
+where
+    T: TensorLike,
+    CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+{
+    let result = match plan.kind {
+        RestructurePlanKind::FuseOnly => tree.fuse_to(target),
+        RestructurePlanKind::SplitOnly => tree.split_to(target, &options.split),
+        RestructurePlanKind::SwapOnly { target_assignment } => {
+            let mut working = clone_tree(tree)?;
+            working
+                .swap_site_indices(&target_assignment, &options.swap)
+                .context("restructure_to: swap phase")?;
+            Ok(working
+                .fuse_to(target)
+                .context("restructure_to: finalize after swap")?)
+        }
+        RestructurePlanKind::SwapThenFuse { target_assignment } => {
+            let mut working = clone_tree(tree)?;
+            working
+                .swap_site_indices(&target_assignment, &options.swap)
+                .context("restructure_to: swap phase")?;
+            Ok(working
+                .fuse_to(target)
+                .context("restructure_to: finalize after swap")?)
+        }
+        RestructurePlanKind::SplitThenFuse { split_target } => {
+            let split = tree
+                .split_to(&split_target, &options.split)
+                .context("restructure_to: split phase")?;
+            split.fuse_to(target).context("restructure_to: fuse phase")
+        }
+    }?;
+
+    apply_final_truncation(result, options)
+}
+
+impl<T, V> TreeTN<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    /// Restructure this TreeTN to match a target site-index network.
+    ///
+    /// This is the plan-first public entry point for Issue #423 B2a.
+    ///
+    /// The current staged implementation already handles:
+    /// - fuse-only restructures, where each current node maps to exactly one
+    ///   target node;
+    /// - split-only restructures, where each target node maps to exactly one
+    ///   current node;
+    /// - swap-only restructures, where the current and target topologies are
+    ///   tree-isomorphic and only the site assignments differ;
+    /// - conservative path-based swap-then-fuse restructures, where the
+    ///   current nodes already map uniquely to target nodes but their target
+    ///   groups must be rearranged into contiguous path blocks before fusing;
+    /// - conservative mixed split-then-fuse restructures, where each current
+    ///   node has at most one cross-node target fragment that must retain the
+    ///   original external bonds.
+    ///
+    /// Unsupported patterns are reported explicitly. In particular, mixed
+    /// cases that require both split planning and a subsequent move/swap phase
+    /// may still remain intentionally staged behind placeholder errors while
+    /// the pure planner is expanded.
+    ///
+    /// Related types:
+    /// - [`RestructureOptions`] configures the split, transport, and optional
+    ///   final truncation phases.
+    /// - [`SiteIndexNetwork`] describes the desired final topology plus site
+    ///   grouping.
+    /// - [`TreeTN::split_to`](crate::treetn::TreeTN::split_to) and
+    ///   [`TreeTN::swap_site_indices`](crate::treetn::TreeTN::swap_site_indices)
+    ///   remain the lower-level building blocks that the executor will use.
+    ///
+    /// # Arguments
+    /// * `target` - Desired final topology and site grouping.
+    /// * `options` - Phase-specific options for split, transport, and optional
+    ///   final truncation.
+    ///
+    /// # Returns
+    /// A new `TreeTN` with the target node naming and target site-index
+    /// network.
+    ///
+    /// # Errors
+    /// Returns an error when the target is structurally incompatible with the
+    /// current network, or when the requested restructure still needs the
+    /// staged planner paths for mixed split/move/fuse execution.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    ///
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_treetn::{RestructureOptions, SiteIndexNetwork, TreeTN};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let left = DynIndex::new_dyn(2);
+    /// let right = DynIndex::new_dyn(2);
+    /// let bond = DynIndex::new_dyn(1);
+    /// let t0 = TensorDynLen::from_dense(vec![left.clone(), bond.clone()], vec![1.0, 0.0])?;
+    /// let t1 = TensorDynLen::from_dense(vec![bond, right.clone()], vec![1.0, 0.0])?;
+    /// let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+    ///     vec![t0, t1],
+    ///     vec!["A".to_string(), "B".to_string()],
+    /// )?;
+    ///
+    /// let mut target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+    /// assert!(target
+    ///     .add_node("AB".to_string(), HashSet::from([left.clone(), right.clone()]))
+    ///     .is_ok());
+    ///
+    /// let result = treetn.restructure_to(&target, &RestructureOptions::default())?;
+    ///
+    /// assert_eq!(result.node_count(), 1);
+    /// let dense = result.contract_to_tensor()?;
+    /// let expected = treetn.contract_to_tensor()?;
+    /// assert!((&dense - &expected).maxabs() < 1e-12);
+    /// # Ok::<(), anyhow::Error>(())
+    /// # }
+    /// ```
+    pub fn restructure_to<TargetV>(
+        &self,
+        target: &SiteIndexNetwork<TargetV, T::Index>,
+        options: &RestructureOptions,
+    ) -> Result<TreeTN<T, TargetV>>
+    where
+        TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+        <T::Index as IndexLike>::Id:
+            Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    {
+        let plan = build_plan::<T, V, TargetV>(self.site_index_network(), target)
+            .context("restructure_to: build plan")?;
+        execute_plan(self, plan, target, options).context("restructure_to: execute plan")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+
+    use super::*;
+
+    fn two_node_chain() -> anyhow::Result<(TreeTN<TensorDynLen, String>, DynIndex, DynIndex)> {
+        let left = DynIndex::new_dyn(2);
+        let right = DynIndex::new_dyn(2);
+        let bond = DynIndex::new_dyn(1);
+        let t0 = TensorDynLen::from_dense(vec![left.clone(), bond.clone()], vec![1.0, 0.0])?;
+        let t1 = TensorDynLen::from_dense(vec![bond, right.clone()], vec![1.0, 0.0])?;
+        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+            vec![t0, t1],
+            vec!["A".to_string(), "B".to_string()],
+        )?;
+        Ok((treetn, left, right))
+    }
+
+    fn two_node_groups_of_two() -> anyhow::Result<(
+        TreeTN<TensorDynLen, String>,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+    )> {
+        let x0 = DynIndex::new_dyn(2);
+        let x1 = DynIndex::new_dyn(2);
+        let y0 = DynIndex::new_dyn(2);
+        let y1 = DynIndex::new_dyn(2);
+        let bond = DynIndex::new_dyn(2);
+        let left_tensor = TensorDynLen::from_dense(
+            vec![x0.clone(), x1.clone(), bond.clone()],
+            vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+        )?;
+        let right_tensor = TensorDynLen::from_dense(
+            vec![bond, y0.clone(), y1.clone()],
+            vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+        )?;
+        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+            vec![left_tensor, right_tensor],
+            vec!["Left".to_string(), "Right".to_string()],
+        )?;
+        Ok((treetn, x0, x1, y0, y1))
+    }
+
+    fn three_node_chain_for_swap() -> anyhow::Result<(
+        TreeTN<TensorDynLen, String>,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+    )> {
+        let s0 = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+        let s2 = DynIndex::new_dyn(2);
+        let s3 = DynIndex::new_dyn(2);
+        let b01 = DynIndex::new_dyn(2);
+        let b12 = DynIndex::new_dyn(2);
+        let t0 = TensorDynLen::from_dense(
+            vec![s0.clone(), s1.clone(), b01.clone()],
+            vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0],
+        )?;
+        let t1 = TensorDynLen::from_dense(
+            vec![b01.clone(), s2.clone(), b12.clone()],
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        )?;
+        let t2 = TensorDynLen::from_dense(vec![b12, s3.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
+        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+            vec![t0, t1, t2],
+            vec!["A".to_string(), "B".to_string(), "C".to_string()],
+        )?;
+        Ok((treetn, s0, s1, s2, s3))
+    }
+
+    fn four_node_interleaved_chain() -> anyhow::Result<(
+        TreeTN<TensorDynLen, String>,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+        DynIndex,
+    )> {
+        let x0 = DynIndex::new_dyn(2);
+        let x1 = DynIndex::new_dyn(2);
+        let y0 = DynIndex::new_dyn(2);
+        let y1 = DynIndex::new_dyn(2);
+        let b01 = DynIndex::new_dyn(2);
+        let b12 = DynIndex::new_dyn(2);
+        let b23 = DynIndex::new_dyn(2);
+        let t0 = TensorDynLen::from_dense(vec![x0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+        let t1 = TensorDynLen::from_dense(
+            vec![b01.clone(), x1.clone(), b12.clone()],
+            vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        )?;
+        let t2 = TensorDynLen::from_dense(
+            vec![b12.clone(), y0.clone(), b23.clone()],
+            vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        )?;
+        let t3 = TensorDynLen::from_dense(vec![b23, y1.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+            vec![t0, t1, t2, t3],
+            vec![
+                "0".to_string(),
+                "1".to_string(),
+                "2".to_string(),
+                "3".to_string(),
+            ],
+        )?;
+        Ok((treetn, x0, x1, y0, y1))
+    }
+
+    #[test]
+    fn test_restructure_to_fuse_only_matches_target_structure() -> anyhow::Result<()> {
+        let (treetn, left, right) = two_node_chain()?;
+
+        let mut target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        target
+            .add_node("AB".to_string(), HashSet::from([left, right]))
+            .map_err(anyhow::Error::msg)?;
+
+        let result = treetn.restructure_to(&target, &RestructureOptions::default())?;
+        let dense_expected = treetn.contract_to_tensor()?;
+        let dense_actual = result.contract_to_tensor()?;
+
+        assert_eq!(result.node_count(), 1);
+        assert_eq!(result.site_index_network().node_count(), 1);
+        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restructure_to_split_only_matches_target_structure() -> anyhow::Result<()> {
+        let (treetn, left, right) = two_node_chain()?;
+
+        let mut fused_target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        fused_target
+            .add_node(
+                "AB".to_string(),
+                HashSet::from([left.clone(), right.clone()]),
+            )
+            .map_err(anyhow::Error::msg)?;
+        let fused = treetn.restructure_to(&fused_target, &RestructureOptions::default())?;
+
+        let mut split_target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        split_target
+            .add_node("Left".to_string(), HashSet::from([left]))
+            .map_err(anyhow::Error::msg)?;
+        split_target
+            .add_node("Right".to_string(), HashSet::from([right]))
+            .map_err(anyhow::Error::msg)?;
+        split_target
+            .add_edge(&"Left".to_string(), &"Right".to_string())
+            .map_err(anyhow::Error::msg)?;
+
+        let result = fused.restructure_to(&split_target, &RestructureOptions::default())?;
+        let dense_expected = fused.contract_to_tensor()?;
+        let dense_actual = result.contract_to_tensor()?;
+
+        assert_eq!(result.node_count(), 2);
+        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restructure_to_swap_only_matches_target_structure() -> anyhow::Result<()> {
+        let (treetn, s0, s1, s2, s3) = three_node_chain_for_swap()?;
+
+        let mut target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        target
+            .add_node("X".to_string(), HashSet::from([s0.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_node("Y".to_string(), HashSet::from([s1.clone(), s2.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_node("Z".to_string(), HashSet::from([s3.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_edge(&"X".to_string(), &"Y".to_string())
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_edge(&"Y".to_string(), &"Z".to_string())
+            .map_err(anyhow::Error::msg)?;
+
+        let result = treetn.restructure_to(&target, &RestructureOptions::default())?;
+        let dense_expected = treetn.contract_to_tensor()?;
+        let dense_actual = result.contract_to_tensor()?;
+
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(s0.id())
+                .map(|name| name.as_str()),
+            Some("X")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(s1.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(s2.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(s3.id())
+                .map(|name| name.as_str()),
+            Some("Z")
+        );
+        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restructure_to_split_then_fuse_mixed_case() -> anyhow::Result<()> {
+        let (treetn, x0, x1, y0, y1) = two_node_groups_of_two()?;
+
+        let mut target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        target
+            .add_node("X".to_string(), HashSet::from([x0.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_node("Y".to_string(), HashSet::from([x1.clone(), y0.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_node("Z".to_string(), HashSet::from([y1.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_edge(&"X".to_string(), &"Y".to_string())
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_edge(&"Y".to_string(), &"Z".to_string())
+            .map_err(anyhow::Error::msg)?;
+
+        let result = treetn.restructure_to(&target, &RestructureOptions::default())?;
+        let dense_expected = treetn.contract_to_tensor()?;
+        let dense_actual = result.contract_to_tensor()?;
+
+        assert_eq!(result.node_count(), 3);
+        assert_eq!(result.edge_count(), 2);
+        assert!(result
+            .site_index_network()
+            .share_equivalent_site_index_network(&target));
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(x0.id())
+                .map(|name| name.as_str()),
+            Some("X")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(x1.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(y0.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(y1.id())
+                .map(|name| name.as_str()),
+            Some("Z")
+        );
+        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restructure_to_swap_then_fuse_mixed_case() -> anyhow::Result<()> {
+        let (treetn, x0, x1, y0, y1) = four_node_interleaved_chain()?;
+
+        let mut target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        target
+            .add_node("X".to_string(), HashSet::from([x0.clone(), y0.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_node("Y".to_string(), HashSet::from([x1.clone(), y1.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_edge(&"X".to_string(), &"Y".to_string())
+            .map_err(anyhow::Error::msg)?;
+
+        let result = treetn.restructure_to(&target, &RestructureOptions::default())?;
+        let dense_expected = treetn.contract_to_tensor()?;
+        let dense_actual = result.contract_to_tensor()?;
+
+        assert_eq!(result.node_count(), 2);
+        assert_eq!(result.edge_count(), 1);
+        assert!(result
+            .site_index_network()
+            .share_equivalent_site_index_network(&target));
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(x0.id())
+                .map(|name| name.as_str()),
+            Some("X")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(y0.id())
+                .map(|name| name.as_str()),
+            Some("X")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(x1.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(y1.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_restructure_to_two_node_swap_only_cross_pairing() -> anyhow::Result<()> {
+        let (treetn, x0, x1, y0, y1) = two_node_groups_of_two()?;
+
+        let mut target: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+        target
+            .add_node("X".to_string(), HashSet::from([x0.clone(), y0.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_node("Y".to_string(), HashSet::from([x1.clone(), y1.clone()]))
+            .map_err(anyhow::Error::msg)?;
+        target
+            .add_edge(&"X".to_string(), &"Y".to_string())
+            .map_err(anyhow::Error::msg)?;
+
+        let result = treetn.restructure_to(&target, &RestructureOptions::default())?;
+        let dense_expected = treetn.contract_to_tensor()?;
+        let dense_actual = result.contract_to_tensor()?;
+
+        assert_eq!(result.node_count(), 2);
+        assert_eq!(result.edge_count(), 1);
+        assert!(result
+            .site_index_network()
+            .share_equivalent_site_index_network(&target));
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(x0.id())
+                .map(|name| name.as_str()),
+            Some("X")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(y0.id())
+                .map(|name| name.as_str()),
+            Some("X")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(x1.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert_eq!(
+            result
+                .site_index_network()
+                .find_node_by_index_id(y1.id())
+                .map(|name| name.as_str()),
+            Some("Y")
+        );
+        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- expose missing C API knobs for TreeTN operator application, contraction, truncation, orthogonalization, and tensor QR used by downstream bindings
- add `RestructureOptions` and `TreeTN::restructure_to` with staged planner coverage for fuse/split/swap and conservative mixed cases, and document unsupported general split+move patterns
- add C API restructure entry points (`restructure_to`, `fuse_to`, `split_to`, `swap_site_indices`) plus validation tests and regenerated header
- track the deferred cutoff/rtol semantics and documentation cleanup separately in #424

## Test Plan
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release --workspace`
- `cargo doc --workspace --no-deps`
- `cargo test --doc --release --workspace`