### PR TITLE
feat: expose affine pullback materialization via C API

### DIFF
--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -277,6 +277,24 @@ StatusCode t4a_qtransform_affine_materialize(const struct t4a_qtt_layout *layout
                                              struct t4a_treetn **out);
 
 /**
+ * Materialize an affine pullback operator (`g(x) -> g(A * y + b)`) as a
+ * chain-shaped TreeTN.
+ *
+ * `bc[i]` controls how source coordinate `i` is treated when `(A * y + b)[i]`
+ * leaves the valid interval. `Periodic` wraps the coordinate, while `Open`
+ * zero-extends it.
+ */
+StatusCode t4a_qtransform_affine_pullback_materialize(const struct t4a_qtt_layout *layout,
+                                                      const int64_t *a_num,
+                                                      const int64_t *a_den,
+                                                      const int64_t *b_num,
+                                                      const int64_t *b_den,
+                                                      size_t m,
+                                                      size_t n,
+                                                      const enum t4a_boundary_condition *bc,
+                                                      struct t4a_treetn **out);
+
+/**
  * Materialize a binary operator directly as a chain-shaped TreeTN.
  */
 StatusCode t4a_qtransform_binaryop_materialize(const struct t4a_qtt_layout *layout,

--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -12,10 +12,11 @@ use num_complex::Complex64;
 use num_rational::Rational64;
 use tensor4all_core::{IndexLike, TensorDynLen};
 use tensor4all_quanticstransform::{
-    affine_operator, binaryop_operator, cumsum_operator, flip_operator, phase_rotation_operator,
-    quantics_fourier_operator, shift_operator, AffineParams, BinaryCoeffs, BoundaryCondition,
-    FourierOptions,
+    affine_operator, affine_pullback_operator, binaryop_operator, cumsum_operator, flip_operator,
+    phase_rotation_operator, quantics_fourier_operator, shift_operator, AffineParams, BinaryCoeffs,
+    BoundaryCondition, FourierOptions,
 };
+use tensor4all_treetn::LinearOperator;
 
 /// Release a QTT layout handle.
 #[unsafe(no_mangle)]
@@ -644,6 +645,54 @@ fn parse_boundary_conditions(
         .collect())
 }
 
+#[derive(Clone, Copy)]
+struct AffineMaterializeArgs {
+    a_num: *const i64,
+    a_den: *const i64,
+    b_num: *const i64,
+    b_den: *const i64,
+    m: usize,
+    n: usize,
+    bc: *const t4a_boundary_condition,
+}
+
+fn materialize_affine_family<F, E>(
+    layout_ref: &InternalQttLayout,
+    args: AffineMaterializeArgs,
+    family_name: &str,
+    build_operator: F,
+) -> CapiResult<t4a_treetn>
+where
+    F: FnOnce(
+        usize,
+        &AffineParams,
+        &[BoundaryCondition],
+    ) -> Result<LinearOperator<TensorDynLen, usize>, E>,
+    E: std::fmt::Display,
+{
+    if args.m == 0 || args.n == 0 {
+        return Err(capi_error(
+            T4A_INVALID_ARGUMENT,
+            format!("{family_name} materialization requires m > 0 and n > 0"),
+        ));
+    }
+    if layout_ref.kind() != t4a_qtt_layout_kind::Fused {
+        return Err(capi_error(
+            T4A_INVALID_ARGUMENT,
+            format!("{family_name} materialization currently supports fused layouts only"),
+        ));
+    }
+
+    let a = parse_rationals(args.a_num, args.a_den, args.m * args.n, "a")?;
+    let b = parse_rationals(args.b_num, args.b_den, args.m, "b")?;
+    let bc = parse_boundary_conditions(args.bc, args.m)?;
+    let params = AffineParams::new(a, b, args.m, args.n)
+        .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+    let source = build_operator(layout_ref.nsites(), &params, &bc)
+        .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+    Ok(t4a_treetn::new(source.mpo))
+}
+
 /// Create an immutable canonical QTT layout descriptor.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_qtt_layout_new(
@@ -951,28 +1000,61 @@ pub extern "C" fn t4a_qtransform_affine_materialize(
     };
 
     run_catching(out, || {
-        if m == 0 || n == 0 {
-            return Err(capi_error(
-                T4A_INVALID_ARGUMENT,
-                "affine materialization requires m > 0 and n > 0",
-            ));
-        }
-        if layout_ref.kind() != t4a_qtt_layout_kind::Fused {
-            return Err(capi_error(
-                T4A_INVALID_ARGUMENT,
-                "affine materialization currently supports fused layouts only",
-            ));
-        }
+        let args = AffineMaterializeArgs {
+            a_num,
+            a_den,
+            b_num,
+            b_den,
+            m,
+            n,
+            bc,
+        };
+        materialize_affine_family(layout_ref, args, "affine", affine_operator)
+    })
+}
 
-        let a = parse_rationals(a_num, a_den, m * n, "a")?;
-        let b = parse_rationals(b_num, b_den, m, "b")?;
-        let bc = parse_boundary_conditions(bc, m)?;
-        let params =
-            AffineParams::new(a, b, m, n).map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        let r = layout_ref.nsites();
-        let source = affine_operator(r, &params, &bc)
-            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        Ok(t4a_treetn::new(source.mpo))
+/// Materialize an affine pullback operator (`g(x) -> g(A * y + b)`) as a
+/// chain-shaped TreeTN.
+///
+/// `bc[i]` controls how source coordinate `i` is treated when `(A * y + b)[i]`
+/// leaves the valid interval. `Periodic` wraps the coordinate, while `Open`
+/// zero-extends it.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_qtransform_affine_pullback_materialize(
+    layout: *const t4a_qtt_layout,
+    a_num: *const i64,
+    a_den: *const i64,
+    b_num: *const i64,
+    b_den: *const i64,
+    m: usize,
+    n: usize,
+    bc: *const t4a_boundary_condition,
+    out: *mut *mut t4a_treetn,
+) -> StatusCode {
+    let layout_ref = match require_layout(layout) {
+        Ok(layout) => layout,
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            return code;
+        }
+    };
+
+    run_catching(out, || {
+        let args = AffineMaterializeArgs {
+            a_num,
+            a_den,
+            b_num,
+            b_den,
+            m,
+            n,
+            bc,
+        };
+        materialize_affine_family(
+            layout_ref,
+            args,
+            "affine pullback",
+            affine_pullback_operator,
+        )
     })
 }
 

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -4,9 +4,9 @@ use num_complex::Complex64;
 use num_rational::Rational64;
 use tensor4all_core::{ColMajorArrayRef, TensorDynLen};
 use tensor4all_quanticstransform::{
-    affine_operator, binaryop_operator, cumsum_operator, flip_operator, phase_rotation_operator,
-    quantics_fourier_operator, shift_operator, AffineParams, BinaryCoeffs, BoundaryCondition,
-    FourierOptions,
+    affine_operator, affine_pullback_operator, binaryop_operator, cumsum_operator, flip_operator,
+    phase_rotation_operator, quantics_fourier_operator, shift_operator, AffineParams, BinaryCoeffs,
+    BoundaryCondition, FourierOptions,
 };
 use tensor4all_treetn::LinearOperator;
 
@@ -472,6 +472,105 @@ fn test_affine_fused_materialization_matches_rust_reference() {
 }
 
 #[test]
+fn test_affine_pullback_fused_materialization_matches_rust_reference() {
+    let layout = new_layout(t4a_qtt_layout_kind::Fused, &[2]);
+    let mut op = std::ptr::null_mut();
+    let a_num = [1i64];
+    let a_den = [1i64];
+    let b_num = [0i64];
+    let b_den = [1i64];
+    let bc = [t4a_boundary_condition::Periodic];
+    assert_eq!(
+        t4a_qtransform_affine_pullback_materialize(
+            layout,
+            a_num.as_ptr(),
+            a_den.as_ptr(),
+            b_num.as_ptr(),
+            b_den.as_ptr(),
+            1,
+            1,
+            bc.as_ptr(),
+            &mut op
+        ),
+        T4A_SUCCESS
+    );
+
+    let actual = c_operator_matrix(op, &[2, 2], &[2, 2]);
+    let params = AffineParams::new(
+        vec![Rational64::from_integer(1)],
+        vec![Rational64::from_integer(0)],
+        1,
+        1,
+    )
+    .unwrap();
+    let expected = rust_operator_matrix(
+        &affine_pullback_operator(2, &params, &[BoundaryCondition::Periodic]).unwrap(),
+        &[2, 2],
+        &[2, 2],
+    );
+    assert_matrix_close(&actual, &expected);
+
+    t4a_treetn_release(op);
+    t4a_qtt_layout_release(layout);
+}
+
+#[test]
+fn test_affine_pullback_fused_swap_matches_rust_reference() {
+    let layout = new_layout(t4a_qtt_layout_kind::Fused, &[1, 1]);
+    let mut op = std::ptr::null_mut();
+    let a_num = [0i64, 1i64, 1i64, 0i64];
+    let a_den = [1i64; 4];
+    let b_num = [0i64, 0i64];
+    let b_den = [1i64; 2];
+    let bc = [
+        t4a_boundary_condition::Periodic,
+        t4a_boundary_condition::Periodic,
+    ];
+    assert_eq!(
+        t4a_qtransform_affine_pullback_materialize(
+            layout,
+            a_num.as_ptr(),
+            a_den.as_ptr(),
+            b_num.as_ptr(),
+            b_den.as_ptr(),
+            2,
+            2,
+            bc.as_ptr(),
+            &mut op
+        ),
+        T4A_SUCCESS
+    );
+
+    let actual = c_operator_matrix(op, &[4], &[4]);
+    let params = AffineParams::new(
+        vec![
+            Rational64::from_integer(0),
+            Rational64::from_integer(1),
+            Rational64::from_integer(1),
+            Rational64::from_integer(0),
+        ],
+        vec![Rational64::from_integer(0), Rational64::from_integer(0)],
+        2,
+        2,
+    )
+    .unwrap();
+    let expected = rust_operator_matrix(
+        &affine_pullback_operator(
+            1,
+            &params,
+            &[BoundaryCondition::Periodic, BoundaryCondition::Periodic],
+        )
+        .unwrap(),
+        &[4],
+        &[4],
+    );
+    assert_matrix_close(&actual, &expected);
+
+    t4a_treetn_release(op);
+    t4a_qtt_layout_release(layout);
+}
+
+#[test]
 fn test_grouped_binaryop_is_rejected_with_explicit_message() {
     let layout = new_layout(t4a_qtt_layout_kind::Grouped, &[2, 2]);
     let mut op = std::ptr::null_mut();
@@ -530,6 +629,21 @@ fn test_layout_and_affine_validation_errors_are_reported() {
     let bc = [t4a_boundary_condition::Periodic];
     assert_eq!(
         t4a_qtransform_affine_materialize(
+            grouped,
+            a_num.as_ptr(),
+            a_den.as_ptr(),
+            b_num.as_ptr(),
+            b_den.as_ptr(),
+            1,
+            1,
+            bc.as_ptr(),
+            &mut op
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(last_error().contains("fused layouts only"));
+    assert_eq!(
+        t4a_qtransform_affine_pullback_materialize(
             grouped,
             a_num.as_ptr(),
             a_den.as_ptr(),

--- a/docs/plans/2026-04-17-issue-426-affine-pullback-design.md
+++ b/docs/plans/2026-04-17-issue-426-affine-pullback-design.md
@@ -1,0 +1,66 @@
+# Issue 426 Affine Pullback C API Design
+
+**Problem:** Tensor4all.jl can materialize the affine operator through the C API, but cannot yet materialize the symmetric affine pullback operator. This leaves `QuanticsTransform.affine_pullback_operator` as a Julia-side placeholder.
+
+**Goal:** Add `t4a_qtransform_affine_pullback_materialize` to the C API while keeping the affine-family implementation DRY and preserving the current fused-layout contract.
+
+## Requirements
+
+- Export `t4a_qtransform_affine_pullback_materialize`.
+- Reuse the existing affine-family parsing and validation path as much as possible.
+- Keep the current fused-layout restriction for affine-family materialization.
+- Document boundary-condition semantics in the pullback docstring.
+- Add C API tests covering identity pullback and dense-matrix correctness.
+
+## Design
+
+### Public API
+
+Add a new exported symbol in `crates/tensor4all-capi/src/quanticstransform.rs`:
+
+- `t4a_qtransform_affine_pullback_materialize(...) -> StatusCode`
+
+Its signature mirrors `t4a_qtransform_affine_materialize`.
+
+### Internal structure
+
+Extract the shared affine-family body behind a small helper that:
+
+- validates `m > 0`, `n > 0`
+- validates fused layout
+- parses `a`, `b`, and `bc`
+- constructs `AffineParams`
+- invokes the selected Rust quantics operator builder
+- wraps the result in `t4a_treetn`
+
+The two exported C functions become thin wrappers over that helper:
+
+- affine forward materialization
+- affine pullback materialization
+
+This avoids duplicating argument parsing, validation, and error mapping.
+
+### Boundary semantics
+
+The pullback docstring should explicitly state:
+
+- `bc[i]` refers to source coordinate `i`
+- when `(A * y + b)[i]` leaves the valid interval, `Periodic` wraps and `Open` zero-extends
+
+This matches the Rust-side `affine_pullback_operator` contract, where `bc.len() == params.m`.
+
+## Testing strategy
+
+Add C API tests in `crates/tensor4all-capi/src/quanticstransform/tests/mod.rs` that:
+
+- verify identity pullback materialization matches the Rust reference operator
+- verify a simple 1D pullback matches the expected dense matrix
+- reuse existing helpers for dense operator extraction and matrix comparison
+
+Keep tests fused-layout only, matching the current API contract.
+
+## Non-goals
+
+- No grouped/interleaved affine-family support in this issue.
+- No broader refactor of non-affine QTT materialization APIs.
+- No Tensor4all.jl changes in this repo; those follow after merge.

--- a/docs/plans/2026-04-17-issue-426-affine-pullback.md
+++ b/docs/plans/2026-04-17-issue-426-affine-pullback.md
@@ -1,0 +1,115 @@
+# Issue 426 Affine Pullback C API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `t4a_qtransform_affine_pullback_materialize` to the C API with a DRY affine-family implementation and C API coverage.
+
+**Architecture:** Keep the public C API surface explicit, but move affine-family parsing, validation, and `AffineParams` construction into a shared helper inside `tensor4all-capi::quanticstransform`. The forward affine and pullback affine entry points should differ only by the Rust quantics operator builder they call and their docstrings.
+
+**Tech Stack:** Rust, `tensor4all-capi`, `tensor4all-quanticstransform`, C-API unit tests, `cargo fmt`, `cargo nextest`, `cargo clippy`
+
+---
+
+### Task 1: Add the first failing pullback C API test
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/quanticstransform/tests/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add a test next to the existing affine materialization coverage that calls the new missing symbol and compares the materialized operator against `affine_pullback_operator(...)`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-capi test_affine_pullback_fused_materialization_matches_rust_reference`
+
+Expected: FAIL because the C symbol does not exist yet or returns the wrong behavior.
+
+**Step 3: Commit**
+
+Do not commit yet if the implementation immediately follows.
+
+### Task 2: Add one more failing behavior check
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/quanticstransform/tests/mod.rs`
+
+**Step 1: Write the failing test**
+
+Add a 1D dense-matrix comparison for a nontrivial pullback case, preferably a shift-like map, and verify the C API materialization matches the Rust pullback operator.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run --release -p tensor4all-capi test_affine_pullback`
+
+Expected: FAIL due to missing implementation.
+
+### Task 3: Implement the DRY affine-family helper
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/quanticstransform.rs`
+
+**Step 1: Extract shared logic**
+
+Introduce a helper for affine-family materialization that owns:
+
+- fused-layout validation
+- rational parsing
+- boundary parsing
+- `AffineParams::new`
+- `t4a_treetn` wrapping
+
+**Step 2: Add the pullback export**
+
+Implement `t4a_qtransform_affine_pullback_materialize` as a thin wrapper over the helper.
+
+**Step 3: Re-point the existing affine export**
+
+Update `t4a_qtransform_affine_materialize` to use the same helper so the implementation stays DRY.
+
+### Task 4: Document boundary semantics
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/quanticstransform.rs`
+
+**Step 1: Update rustdoc**
+
+Document the pullback semantics and make clear that `bc[i]` controls source coordinate `i` when `(A * y + b)[i]` leaves the valid interval.
+
+### Task 5: Verify green
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/quanticstransform.rs`
+- Modify: `crates/tensor4all-capi/src/quanticstransform/tests/mod.rs`
+
+**Step 1: Run focused tests**
+
+Run: `cargo nextest run --release -p tensor4all-capi test_affine_pullback`
+
+Expected: PASS
+
+**Step 2: Run crate verification**
+
+Run: `cargo nextest run --release -p tensor4all-capi`
+
+Expected: PASS
+
+**Step 3: Run formatting and lint**
+
+Run: `cargo fmt --all`
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+
+Expected: PASS
+
+### Task 6: Commit
+
+**Step 1: Create a focused commit**
+
+```bash
+git add docs/plans/2026-04-17-issue-426-affine-pullback-design.md \
+        docs/plans/2026-04-17-issue-426-affine-pullback.md \
+        crates/tensor4all-capi/src/quanticstransform.rs \
+        crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+git commit -m "feat(capi): expose affine pullback materialization"
+```


### PR DESCRIPTION
Closes #426.

## Summary
- add `t4a_qtransform_affine_pullback_materialize` to the C API for fused QTT layouts
- refactor affine-family materialization behind a shared helper so forward and pullback paths stay DRY
- add pullback materialization tests, regenerate the public C header, and record the design/implementation notes for the Tensor4all.jl follow-up

## Test Plan
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace`
- `cargo doc --workspace --no-deps`
- `cargo test --doc --release --workspace`
- `cargo run -p api-dump --release -- . -o docs/api`
- `cbindgen crates/tensor4all-capi --config crates/tensor4all-capi/cbindgen.toml --output crates/tensor4all-capi/include/tensor4all_capi.h`