### PR TITLE
[codex] redesign svd truncation policy APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Every public type, trait, and function **must** have doc comments with the follo
 ### CI Verification
 
 - `cargo test --doc --release --workspace` must pass (rustdoc examples)
-- `mdbook test docs/book` must pass (mdBook guide examples)
+- `./scripts/test-mdbook.sh` must pass (mdBook guide examples; raw `mdbook test docs/book` does not receive the resolved `--extern` flags that the guide snippets need)
 
 ## Error Handling
 

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -60,6 +60,119 @@ typedef enum t4a_scalar_kind {
 } t4a_scalar_kind;
 
 /**
+ * Threshold scaling used by the C API SVD truncation policy.
+ *
+ * Related types:
+ * - [`t4a_singular_value_measure`] selects whether the threshold is applied to
+ *   singular values or squared singular values.
+ * - [`t4a_truncation_rule`] selects whether the threshold is checked per value
+ *   or against the discarded suffix sum.
+ * - [`t4a_svd_truncation_policy`] combines all three knobs with the numeric
+ *   threshold.
+ *
+ * # Examples
+ *
+ * ```
+ * use tensor4all_capi::t4a_threshold_scale;
+ * use tensor4all_core::ThresholdScale;
+ *
+ * assert_eq!(
+ *     ThresholdScale::from(t4a_threshold_scale::Relative),
+ *     ThresholdScale::Relative
+ * );
+ * assert_eq!(
+ *     ThresholdScale::from(t4a_threshold_scale::Absolute),
+ *     ThresholdScale::Absolute
+ * );
+ * ```
+ */
+typedef enum t4a_threshold_scale {
+  /**
+   * Compare the threshold to a singular-value-derived reference scale.
+   */
+  T4A_THRESHOLD_SCALE_RELATIVE = 0,
+  /**
+   * Compare the threshold directly to the measured singular-value quantity.
+   */
+  T4A_THRESHOLD_SCALE_ABSOLUTE = 1,
+} t4a_threshold_scale;
+
+/**
+ * Singular-value quantity used by the C API SVD truncation policy.
+ *
+ * Related types:
+ * - [`t4a_threshold_scale`] selects whether the threshold is relative or
+ *   absolute.
+ * - [`t4a_truncation_rule`] selects whether truncation is per value or based
+ *   on the discarded tail sum.
+ * - [`t4a_svd_truncation_policy`] stores the full C-facing SVD policy.
+ *
+ * # Examples
+ *
+ * ```
+ * use tensor4all_capi::t4a_singular_value_measure;
+ * use tensor4all_core::SingularValueMeasure;
+ *
+ * assert_eq!(
+ *     SingularValueMeasure::from(t4a_singular_value_measure::Value),
+ *     SingularValueMeasure::Value
+ * );
+ * assert_eq!(
+ *     SingularValueMeasure::from(t4a_singular_value_measure::SquaredValue),
+ *     SingularValueMeasure::SquaredValue
+ * );
+ * ```
+ */
+typedef enum t4a_singular_value_measure {
+  /**
+   * Measure singular values directly.
+   */
+  T4A_SINGULAR_VALUE_MEASURE_VALUE = 0,
+  /**
+   * Measure squared singular values.
+   */
+  T4A_SINGULAR_VALUE_MEASURE_SQUARED_VALUE = 1,
+} t4a_singular_value_measure;
+
+/**
+ * Rank-selection rule used by the C API SVD truncation policy.
+ *
+ * Related types:
+ * - [`t4a_threshold_scale`] sets whether the threshold is relative or
+ *   absolute.
+ * - [`t4a_singular_value_measure`] sets whether values or squared values are
+ *   measured.
+ * - [`t4a_svd_truncation_policy`] combines the rule with the other SVD
+ *   truncation knobs.
+ *
+ * # Examples
+ *
+ * ```
+ * use tensor4all_capi::t4a_truncation_rule;
+ * use tensor4all_core::TruncationRule;
+ *
+ * assert_eq!(
+ *     TruncationRule::from(t4a_truncation_rule::PerValue),
+ *     TruncationRule::PerValue
+ * );
+ * assert_eq!(
+ *     TruncationRule::from(t4a_truncation_rule::DiscardedTailSum),
+ *     TruncationRule::DiscardedTailSum
+ * );
+ * ```
+ */
+typedef enum t4a_truncation_rule {
+  /**
+   * Apply the threshold independently to each singular value.
+   */
+  T4A_TRUNCATION_RULE_PER_VALUE = 0,
+  /**
+   * Apply the threshold to the cumulative discarded tail.
+   */
+  T4A_TRUNCATION_RULE_DISCARDED_TAIL_SUM = 1,
+} t4a_truncation_rule;
+
+/**
  * TreeTN contraction method exposed through the C API.
  */
 typedef enum t4a_contract_method {
@@ -100,7 +213,7 @@ typedef enum t4a_factorize_alg {
 } t4a_factorize_alg;
 
 /**
- * Canonical form used for orthogonalization/truncation.
+ * Canonical form used for orthogonalization and canonicalization.
  */
 typedef enum t4a_canonical_form {
   /**
@@ -149,6 +262,62 @@ typedef struct t4a_treetn {
 typedef struct t4a_tensor {
   const void *_private;
 } t4a_tensor;
+
+/**
+ * Explicit SVD truncation policy exposed through the C API.
+ *
+ * This is the ABI-facing mirror of [`tensor4all_core::SvdTruncationPolicy`].
+ * Pass it to SVD-based C API entry points to choose the threshold value, the
+ * threshold scale, whether singular values are squared first, and whether the
+ * truncation rule is per value or tail-sum based.
+ *
+ * Related types:
+ * - [`t4a_threshold_scale`] controls relative vs absolute thresholding.
+ * - [`t4a_singular_value_measure`] controls value vs squared-value
+ *   measurement.
+ * - [`t4a_truncation_rule`] controls per-value vs discarded-tail-sum
+ *   truncation.
+ *
+ * # Examples
+ *
+ * ```
+ * use tensor4all_capi::{
+ *     t4a_singular_value_measure, t4a_svd_truncation_policy, t4a_threshold_scale,
+ *     t4a_truncation_rule,
+ * };
+ * use tensor4all_core::{SingularValueMeasure, SvdTruncationPolicy, ThresholdScale, TruncationRule};
+ *
+ * let ffi_policy = t4a_svd_truncation_policy {
+ *     threshold: 1e-8,
+ *     scale: t4a_threshold_scale::Absolute,
+ *     measure: t4a_singular_value_measure::SquaredValue,
+ *     rule: t4a_truncation_rule::DiscardedTailSum,
+ * };
+ * let core_policy = SvdTruncationPolicy::from(ffi_policy);
+ * assert_eq!(core_policy.threshold, 1e-8);
+ * assert_eq!(core_policy.scale, ThresholdScale::Absolute);
+ * assert_eq!(core_policy.measure, SingularValueMeasure::SquaredValue);
+ * assert_eq!(core_policy.rule, TruncationRule::DiscardedTailSum);
+ * ```
+ */
+typedef struct t4a_svd_truncation_policy {
+  /**
+   * Threshold value used by the selected scale/rule combination.
+   */
+  double threshold;
+  /**
+   * Relative or absolute threshold interpretation.
+   */
+  enum t4a_threshold_scale scale;
+  /**
+   * Singular-value quantity used for thresholding.
+   */
+  enum t4a_singular_value_measure measure;
+  /**
+   * Rank-selection rule.
+   */
+  enum t4a_truncation_rule rule;
+} t4a_svd_truncation_policy;
 
 /**
  * The provided output buffer is too small for the result.
@@ -503,8 +672,7 @@ StatusCode t4a_tensor_scalar_kind(const struct t4a_tensor *ptr, enum t4a_scalar_
 StatusCode t4a_tensor_svd(const struct t4a_tensor *tensor,
                           const struct t4a_index *const *left_inds,
                           size_t n_left,
-                          double rtol,
-                          double cutoff,
+                          const struct t4a_svd_truncation_policy *policy,
                           size_t maxdim,
                           struct t4a_tensor **out_u,
                           struct t4a_tensor **out_s,
@@ -515,8 +683,7 @@ StatusCode t4a_tensor_svd(const struct t4a_tensor *tensor,
  */
 StatusCode t4a_treetn_add(const struct t4a_treetn *a,
                           const struct t4a_treetn *b,
-                          double rtol,
-                          double cutoff,
+                          const struct t4a_svd_truncation_policy *policy,
                           size_t maxdim,
                           struct t4a_treetn **out);
 
@@ -541,8 +708,7 @@ StatusCode t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
                                            const struct t4a_index *const *internal_output_indices,
                                            const struct t4a_index *const *true_output_indices,
                                            enum t4a_contract_method method,
-                                           double rtol,
-                                           double cutoff,
+                                           const struct t4a_svd_truncation_policy *policy,
                                            size_t maxdim,
                                            size_t nfullsweeps,
                                            double convergence_tol,
@@ -570,12 +736,12 @@ StatusCode t4a_treetn_clone(const struct t4a_treetn *src, struct t4a_treetn **ou
 StatusCode t4a_treetn_contract(const struct t4a_treetn *a,
                                const struct t4a_treetn *b,
                                enum t4a_contract_method method,
-                               double rtol,
-                               double cutoff,
+                               const struct t4a_svd_truncation_policy *policy,
                                size_t maxdim,
                                size_t nfullsweeps,
                                double convergence_tol,
                                enum t4a_factorize_alg factorize_alg,
+                               double qr_rtol,
                                struct t4a_treetn **out);
 
 /**
@@ -649,10 +815,8 @@ StatusCode t4a_treetn_linsolve(const struct t4a_treetn *operator_,
                                const struct t4a_index *const *internal_input_indices,
                                const struct t4a_index *const *true_output_indices,
                                const struct t4a_index *const *internal_output_indices,
-                               double rtol,
-                               double cutoff,
+                               const struct t4a_svd_truncation_policy *policy,
                                size_t maxdim,
-                               enum t4a_canonical_form form,
                                size_t nfullsweeps,
                                double krylov_tol,
                                size_t krylov_maxiter,
@@ -717,17 +881,13 @@ StatusCode t4a_treetn_restructure_to(const struct t4a_treetn *treetn,
                                      const size_t *target_edge_sources,
                                      const size_t *target_edge_targets,
                                      size_t n_target_edges,
-                                     double split_rtol,
-                                     double split_cutoff,
+                                     const struct t4a_svd_truncation_policy *split_policy,
                                      size_t split_maxdim,
-                                     enum t4a_canonical_form split_form,
                                      int split_final_sweep,
                                      size_t swap_maxdim,
                                      double swap_rtol,
-                                     double final_rtol,
-                                     double final_cutoff,
+                                     const struct t4a_svd_truncation_policy *final_policy,
                                      size_t final_maxdim,
-                                     enum t4a_canonical_form final_form,
                                      struct t4a_treetn **out);
 
 /**
@@ -765,10 +925,8 @@ StatusCode t4a_treetn_split_to(const struct t4a_treetn *treetn,
                                const size_t *target_edge_sources,
                                const size_t *target_edge_targets,
                                size_t n_target_edges,
-                               double rtol,
-                               double cutoff,
+                               const struct t4a_svd_truncation_policy *policy,
                                size_t maxdim,
-                               enum t4a_canonical_form form,
                                int final_sweep,
                                struct t4a_treetn **out);
 
@@ -796,12 +954,10 @@ StatusCode t4a_treetn_tensor(const struct t4a_treetn *treetn,
 StatusCode t4a_treetn_to_dense(const struct t4a_treetn *treetn, struct t4a_tensor **out);
 
 /**
- * Truncate the tree tensor network bond dimensions.
+ * Truncate the tree tensor network bond dimensions using SVD-based truncation.
  */
 StatusCode t4a_treetn_truncate(struct t4a_treetn *treetn,
-                               double rtol,
-                               double cutoff,
-                               size_t maxdim,
-                               enum t4a_canonical_form form);
+                               const struct t4a_svd_truncation_policy *policy,
+                               size_t maxdim);
 
 #endif  /* TENSOR4ALL_CAPI_H */

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -3,9 +3,12 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use num_complex::Complex64;
-use tensor4all_core::{qr_with, svd_with, QrOptions, SvdOptions, TruncationParams};
+use tensor4all_core::{qr_with, svd_with, QrOptions, SvdOptions, SvdTruncationPolicy};
 
-use crate::types::{t4a_index, t4a_scalar_kind, t4a_tensor, InternalIndex, InternalTensor};
+use crate::types::{
+    t4a_index, t4a_scalar_kind, t4a_svd_truncation_policy, t4a_tensor, InternalIndex,
+    InternalTensor,
+};
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
     set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
@@ -87,22 +90,21 @@ fn require_tensor<'a>(ptr: *const t4a_tensor) -> Result<&'a t4a_tensor, (StatusC
     Ok(unsafe { &*ptr })
 }
 
-fn build_svd_options(rtol: f64, cutoff: f64, maxdim: usize) -> SvdOptions {
-    let mut truncation = TruncationParams::new();
-    if cutoff > 0.0 {
-        truncation = truncation.with_cutoff(cutoff);
-    } else if rtol > 0.0 {
-        truncation = truncation.with_rtol(rtol);
+fn build_svd_options(policy: *const t4a_svd_truncation_policy, maxdim: usize) -> SvdOptions {
+    let mut options = SvdOptions::new();
+    if !policy.is_null() {
+        let policy = unsafe { *policy };
+        options = options.with_policy(SvdTruncationPolicy::from(policy));
     }
     if maxdim > 0 {
-        truncation = truncation.with_max_rank(maxdim);
+        options = options.with_max_rank(maxdim);
     }
-    SvdOptions { truncation }
+    options
 }
 
 fn build_qr_options(rtol: f64) -> QrOptions {
     // `0.0` is the C-API sentinel for exact QR without truncation.
-    QrOptions::with_rtol(rtol)
+    QrOptions::new().with_rtol(rtol)
 }
 
 fn box_tensor_handle(tensor: InternalTensor) -> *mut t4a_tensor {
@@ -295,8 +297,7 @@ pub extern "C" fn t4a_tensor_svd(
     tensor: *const t4a_tensor,
     left_inds: *const *const t4a_index,
     n_left: usize,
-    rtol: f64,
-    cutoff: f64,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: usize,
     out_u: *mut *mut t4a_tensor,
     out_s: *mut *mut t4a_tensor,
@@ -312,7 +313,7 @@ pub extern "C" fn t4a_tensor_svd(
         }
 
         let left_inds = read_indices_from_ptrs(n_left, left_inds)?;
-        let options = build_svd_options(rtol, cutoff, maxdim);
+        let options = build_svd_options(policy, maxdim);
         let (u, s, v) = match t4a_scalar_kind::from_tensor(tensor.inner()) {
             t4a_scalar_kind::F64 => svd_with::<f64>(tensor.inner(), &left_inds, &options),
             t4a_scalar_kind::C64 => svd_with::<Complex64>(tensor.inner(), &left_inds, &options),

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::index::{t4a_index_new, t4a_index_release};
+use crate::types::{t4a_singular_value_measure, t4a_threshold_scale, t4a_truncation_rule};
 use num_complex::Complex64;
 
 fn new_index(dim: usize) -> *mut t4a_index {
@@ -252,8 +253,7 @@ fn test_tensor_svd_rank2() {
             tensor,
             [i as *const t4a_index].as_ptr(),
             1,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             &mut u,
             &mut s,
@@ -294,8 +294,7 @@ fn test_tensor_svd_truncation() {
             tensor,
             [i as *const t4a_index].as_ptr(),
             1,
-            0.0,
-            0.0,
+            std::ptr::null(),
             1,
             &mut u,
             &mut s,
@@ -349,8 +348,7 @@ fn test_tensor_svd_rank3() {
             tensor,
             [i as *const t4a_index, j as *const t4a_index].as_ptr(),
             2,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             &mut u,
             &mut s,
@@ -370,6 +368,50 @@ fn test_tensor_svd_rank3() {
         t4a_tensor_release(handle);
     }
     for index in [k, j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_svd_explicit_policy() {
+    let i = new_index(3);
+    let j = new_index(3);
+    let tensor = new_tensor_f64(
+        &[i as *const t4a_index, j as *const t4a_index],
+        &[4.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+    );
+    let policy = t4a_svd_truncation_policy {
+        threshold: 0.3,
+        scale: t4a_threshold_scale::Relative,
+        measure: t4a_singular_value_measure::Value,
+        rule: t4a_truncation_rule::PerValue,
+    };
+
+    let mut u = std::ptr::null_mut();
+    let mut s = std::ptr::null_mut();
+    let mut v = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_svd(
+            tensor,
+            [i as *const t4a_index].as_ptr(),
+            1,
+            &policy,
+            0,
+            &mut u,
+            &mut s,
+            &mut v
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*u).inner().dims() }, vec![3, 1]);
+    assert_eq!(unsafe { (*s).inner().dims() }, vec![1, 1]);
+    assert_eq!(unsafe { (*v).inner().dims() }, vec![3, 1]);
+
+    for handle in [v, s, u, tensor] {
+        t4a_tensor_release(handle);
+    }
+    for index in [j, i] {
         t4a_index_release(index);
     }
 }

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -1,8 +1,8 @@
 //! C API for the reduced TreeTN surface.
 
 use crate::types::{
-    t4a_canonical_form, t4a_contract_method, t4a_factorize_alg, t4a_index, t4a_tensor, t4a_treetn,
-    InternalIndex, InternalTreeTN,
+    t4a_canonical_form, t4a_contract_method, t4a_factorize_alg, t4a_index,
+    t4a_svd_truncation_policy, t4a_tensor, t4a_treetn, InternalIndex, InternalTreeTN,
 };
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
@@ -12,12 +12,12 @@ use crate::{
 use num_complex::Complex64;
 use std::collections::{HashMap, HashSet};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike, SvdTruncationPolicy};
 use tensor4all_treetn::treetn::contraction::{self, ContractionMethod, ContractionOptions};
 use tensor4all_treetn::{
-    apply_linear_operator, square_linsolve, ApplyOptions, CanonicalizationOptions, IndexMapping,
-    LinearOperator, LinsolveOptions, RestructureOptions, SiteIndexNetwork, SplitOptions,
-    SwapOptions, TruncationOptions,
+    apply_linear_operator, square_linsolve, ApplyOptions, CanonicalForm, CanonicalizationOptions,
+    IndexMapping, LinearOperator, LinsolveOptions, RestructureOptions, SiteIndexNetwork,
+    SplitOptions, SwapOptions, TruncationOptions,
 };
 
 /// Release a TreeTN handle.
@@ -41,36 +41,18 @@ pub extern "C" fn t4a_treetn_is_assigned(obj: *const t4a_treetn) -> i32 {
     is_assigned_opaque(obj)
 }
 
-#[derive(Clone, Copy, Debug)]
-enum Tol {
-    None,
-    Rtol(f64),
-    Cutoff(f64),
-}
-
 #[inline]
-fn select_tol(rtol: f64, cutoff: f64) -> Tol {
-    if cutoff > 0.0 {
-        Tol::Cutoff(cutoff)
-    } else if rtol > 0.0 {
-        Tol::Rtol(rtol)
+fn resolve_svd_policy(policy: *const t4a_svd_truncation_policy) -> Option<SvdTruncationPolicy> {
+    if policy.is_null() {
+        None
     } else {
-        Tol::None
+        Some(SvdTruncationPolicy::from(unsafe { *policy }))
     }
 }
 
 #[inline]
-fn cutoff_to_rtol(cutoff: f64) -> f64 {
-    cutoff.sqrt()
-}
-
-#[inline]
-fn resolve_rtol(rtol: f64, cutoff: f64) -> Option<f64> {
-    match select_tol(rtol, cutoff) {
-        Tol::Cutoff(c) => Some(cutoff_to_rtol(c)),
-        Tol::Rtol(r) => Some(r),
-        Tol::None => None,
-    }
+fn resolve_qr_rtol(qr_rtol: f64) -> Option<f64> {
+    (qr_rtol != 0.0).then_some(qr_rtol)
 }
 
 #[inline]
@@ -343,20 +325,18 @@ fn build_target_network(
 }
 
 fn build_split_options(
-    rtol: f64,
-    cutoff: f64,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: usize,
-    form: t4a_canonical_form,
     final_sweep: libc::c_int,
 ) -> SplitOptions {
     let mut options = SplitOptions::new()
-        .with_form(form.into())
+        .with_form(CanonicalForm::Unitary)
         .with_final_sweep(final_sweep != 0);
     if maxdim > 0 {
         options = options.with_max_rank(maxdim);
     }
-    if let Some(rtol) = resolve_rtol(rtol, cutoff) {
-        options = options.with_rtol(rtol);
+    if let Some(policy) = resolve_svd_policy(policy) {
+        options = options.with_svd_policy(policy);
     }
     options
 }
@@ -369,22 +349,20 @@ fn build_swap_options(maxdim: usize, rtol: f64) -> SwapOptions {
 }
 
 fn build_final_truncation(
-    rtol: f64,
-    cutoff: f64,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: usize,
-    form: t4a_canonical_form,
 ) -> Option<TruncationOptions> {
-    let resolved_rtol = resolve_rtol(rtol, cutoff);
-    if maxdim == 0 && resolved_rtol.is_none() {
+    let policy = resolve_svd_policy(policy);
+    if maxdim == 0 && policy.is_none() {
         return None;
     }
 
-    let mut options = TruncationOptions::new().with_form(form.into());
+    let mut options = TruncationOptions::new();
     if maxdim > 0 {
         options = options.with_max_rank(maxdim);
     }
-    if let Some(rtol) = resolved_rtol {
-        options = options.with_rtol(rtol);
+    if let Some(policy) = policy {
+        options = options.with_svd_policy(policy);
     }
     Some(options)
 }
@@ -1059,21 +1037,19 @@ pub extern "C" fn t4a_treetn_orthogonalize(
     })
 }
 
-/// Truncate the tree tensor network bond dimensions.
+/// Truncate the tree tensor network bond dimensions using SVD-based truncation.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_truncate(
     treetn: *mut t4a_treetn,
-    rtol: libc::c_double,
-    cutoff: libc::c_double,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
-    form: t4a_canonical_form,
 ) -> StatusCode {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
 
-        let mut options = TruncationOptions::new().with_form(form.into());
-        if let Some(rtol) = resolve_rtol(rtol, cutoff) {
-            options = options.with_rtol(rtol);
+        let mut options = TruncationOptions::new();
+        if let Some(policy) = resolve_svd_policy(policy) {
+            options = options.with_svd_policy(policy);
         }
         if maxdim > 0 {
             options = options.with_max_rank(maxdim);
@@ -1134,10 +1110,8 @@ pub extern "C" fn t4a_treetn_split_to(
     target_edge_sources: *const libc::size_t,
     target_edge_targets: *const libc::size_t,
     n_target_edges: libc::size_t,
-    rtol: libc::c_double,
-    cutoff: libc::c_double,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
-    form: t4a_canonical_form,
     final_sweep: libc::c_int,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
@@ -1153,7 +1127,7 @@ pub extern "C" fn t4a_treetn_split_to(
             n_target_edges,
             "target",
         )?;
-        let options = build_split_options(rtol, cutoff, maxdim, form, final_sweep);
+        let options = build_split_options(policy, maxdim, final_sweep);
         let result = tn
             .inner()
             .split_to(&target, &options)
@@ -1201,17 +1175,13 @@ pub extern "C" fn t4a_treetn_restructure_to(
     target_edge_sources: *const libc::size_t,
     target_edge_targets: *const libc::size_t,
     n_target_edges: libc::size_t,
-    split_rtol: libc::c_double,
-    split_cutoff: libc::c_double,
+    split_policy: *const t4a_svd_truncation_policy,
     split_maxdim: libc::size_t,
-    split_form: t4a_canonical_form,
     split_final_sweep: libc::c_int,
     swap_maxdim: libc::size_t,
     swap_rtol: libc::c_double,
-    final_rtol: libc::c_double,
-    final_cutoff: libc::c_double,
+    final_policy: *const t4a_svd_truncation_policy,
     final_maxdim: libc::size_t,
-    final_form: t4a_canonical_form,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
     run_catching(out, || {
@@ -1228,16 +1198,12 @@ pub extern "C" fn t4a_treetn_restructure_to(
         )?;
         let mut options = RestructureOptions::new()
             .with_split(build_split_options(
-                split_rtol,
-                split_cutoff,
+                split_policy,
                 split_maxdim,
-                split_form,
                 split_final_sweep,
             ))
             .with_swap(build_swap_options(swap_maxdim, swap_rtol));
-        if let Some(final_truncation) =
-            build_final_truncation(final_rtol, final_cutoff, final_maxdim, final_form)
-        {
+        if let Some(final_truncation) = build_final_truncation(final_policy, final_maxdim) {
             options = options.with_final_truncation(final_truncation);
         }
         let result = tn
@@ -1390,8 +1356,7 @@ pub extern "C" fn t4a_treetn_scale(
 pub extern "C" fn t4a_treetn_add(
     a: *const t4a_treetn,
     b: *const t4a_treetn,
-    rtol: libc::c_double,
-    cutoff: libc::c_double,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
@@ -1405,14 +1370,14 @@ pub extern "C" fn t4a_treetn_add(
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
 
         let mut options = TruncationOptions::new();
-        if let Some(rtol) = resolve_rtol(rtol, cutoff) {
-            options = options.with_rtol(rtol);
+        if let Some(policy) = resolve_svd_policy(policy) {
+            options = options.with_svd_policy(policy);
         }
         if maxdim > 0 {
             options = options.with_max_rank(maxdim);
         }
 
-        if options.rtol().is_some() || options.max_rank().is_some() {
+        if options.svd_policy().is_some() || options.max_rank().is_some() {
             let center = result.node_names().into_iter().min().ok_or_else(|| {
                 capi_error(T4A_INVALID_ARGUMENT, "cannot truncate an empty TreeTN")
             })?;
@@ -1434,12 +1399,12 @@ pub extern "C" fn t4a_treetn_contract(
     a: *const t4a_treetn,
     b: *const t4a_treetn,
     method: t4a_contract_method,
-    rtol: libc::c_double,
-    cutoff: libc::c_double,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
     nfullsweeps: libc::size_t,
     convergence_tol: libc::c_double,
     factorize_alg: t4a_factorize_alg,
+    qr_rtol: libc::c_double,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
     let tn_a = match require_tree(a) {
@@ -1468,8 +1433,43 @@ pub extern "C" fn t4a_treetn_contract(
         let mut options = ContractionOptions::new(rust_method)
             .with_nfullsweeps(fit_nfullsweeps)
             .with_factorize_alg(factorize_alg.into());
-        if let Some(rtol) = resolve_rtol(rtol, cutoff) {
-            options = options.with_rtol(rtol);
+        match factorize_alg {
+            t4a_factorize_alg::SVD => {
+                if qr_rtol != 0.0 {
+                    return Err(capi_error(
+                        T4A_INVALID_ARGUMENT,
+                        "qr_rtol is only supported when factorize_alg=QR",
+                    ));
+                }
+                if let Some(policy) = resolve_svd_policy(policy) {
+                    options = options.with_svd_policy(policy);
+                }
+            }
+            t4a_factorize_alg::QR => {
+                if !policy.is_null() {
+                    return Err(capi_error(
+                        T4A_INVALID_ARGUMENT,
+                        "policy is only supported when factorize_alg=SVD",
+                    ));
+                }
+                if let Some(rtol) = resolve_qr_rtol(qr_rtol) {
+                    options = options.with_qr_rtol(rtol);
+                }
+            }
+            t4a_factorize_alg::LU | t4a_factorize_alg::CI => {
+                if !policy.is_null() {
+                    return Err(capi_error(
+                        T4A_INVALID_ARGUMENT,
+                        "policy is only supported when factorize_alg=SVD",
+                    ));
+                }
+                if qr_rtol != 0.0 {
+                    return Err(capi_error(
+                        T4A_INVALID_ARGUMENT,
+                        "qr_rtol is only supported when factorize_alg=QR",
+                    ));
+                }
+            }
         }
         if maxdim > 0 {
             options = options.with_max_rank(maxdim);
@@ -1505,8 +1505,7 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
     internal_output_indices: *const *const t4a_index,
     true_output_indices: *const *const t4a_index,
     method: t4a_contract_method,
-    rtol: libc::c_double,
-    cutoff: libc::c_double,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
     nfullsweeps: libc::size_t,
     convergence_tol: libc::c_double,
@@ -1568,7 +1567,8 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
             ApplyOptions {
                 method: method.into(),
                 max_rank: (maxdim > 0).then_some(maxdim),
-                rtol: resolve_rtol(rtol, cutoff),
+                svd_policy: resolve_svd_policy(policy),
+                qr_rtol: None,
                 nfullsweeps: fit_nfullsweeps,
                 convergence_tol: resolve_convergence_tol(convergence_tol),
             },
@@ -1604,10 +1604,8 @@ pub extern "C" fn t4a_treetn_linsolve(
     internal_input_indices: *const *const t4a_index,
     true_output_indices: *const *const t4a_index,
     internal_output_indices: *const *const t4a_index,
-    rtol: libc::c_double,
-    cutoff: libc::c_double,
+    policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
-    form: t4a_canonical_form,
     nfullsweeps: libc::size_t,
     krylov_tol: libc::c_double,
     krylov_maxiter: libc::size_t,
@@ -1685,13 +1683,13 @@ pub extern "C" fn t4a_treetn_linsolve(
         )?;
 
         let mut options = LinsolveOptions::new(nfullsweeps)
-            .with_truncation(TruncationOptions::new().with_form(form.into()))
+            .with_truncation(TruncationOptions::new())
             .with_krylov_tol(krylov_tol)
             .with_krylov_maxiter(krylov_maxiter)
             .with_krylov_dim(krylov_dim)
             .with_coefficients(a0, a1);
-        if let Some(rtol) = resolve_rtol(rtol, cutoff) {
-            options = options.with_rtol(rtol);
+        if let Some(policy) = resolve_svd_policy(policy) {
+            options = options.with_svd_policy(policy);
         }
         if maxdim > 0 {
             options = options.with_max_rank(maxdim);

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -4,6 +4,7 @@ use crate::tensor::{
     t4a_tensor_copy_dense_f64, t4a_tensor_new_dense_c64, t4a_tensor_new_dense_f64, t4a_tensor_rank,
     t4a_tensor_release,
 };
+use crate::types::{t4a_singular_value_measure, t4a_threshold_scale, t4a_truncation_rule};
 
 fn last_error() -> String {
     let mut len = 0usize;
@@ -156,6 +157,24 @@ fn assert_vec_close(actual: &[f64], expected: &[f64], tol: f64) {
             err <= tol,
             "value mismatch at slot {slot}: actual={a}, expected={e}, err={err}, tol={tol}"
         );
+    }
+}
+
+fn relative_policy(threshold: f64) -> t4a_svd_truncation_policy {
+    t4a_svd_truncation_policy {
+        threshold,
+        scale: t4a_threshold_scale::Relative,
+        measure: t4a_singular_value_measure::Value,
+        rule: t4a_truncation_rule::PerValue,
+    }
+}
+
+fn squared_tail_policy(threshold: f64) -> t4a_svd_truncation_policy {
+    t4a_svd_truncation_policy {
+        threshold,
+        scale: t4a_threshold_scale::Relative,
+        measure: t4a_singular_value_measure::SquaredValue,
+        rule: t4a_truncation_rule::DiscardedTailSum,
     }
 }
 
@@ -727,10 +746,8 @@ fn test_treetn_split_to_splits_fused_vertex() {
             split_target.edge_sources.as_ptr(),
             split_target.edge_targets.as_ptr(),
             split_target.edge_sources.len(),
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
-            t4a_canonical_form::Unitary,
             0,
             &mut split,
         ),
@@ -837,17 +854,13 @@ fn test_treetn_restructure_to_mixed_case() {
             target.edge_sources.as_ptr(),
             target.edge_targets.as_ptr(),
             target.edge_sources.len(),
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
-            t4a_canonical_form::Unitary,
             0,
             0,
             0.0,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
-            t4a_canonical_form::Unitary,
             &mut result,
         ),
         T4A_SUCCESS
@@ -1006,17 +1019,16 @@ fn link_dim(tt: *const t4a_treetn) -> usize {
 fn test_treetn_truncate_with_rtol_and_cutoff() {
     let (tt_rtol, tensors_rtol, indices_rtol) = make_truncatable_treetn();
     assert_eq!(link_dim(tt_rtol), 4);
-    assert_eq!(
-        t4a_treetn_truncate(tt_rtol, 1e-12, 0.0, 1, t4a_canonical_form::Unitary),
-        T4A_SUCCESS
-    );
+    let rtol_policy = relative_policy(1e-12);
+    assert_eq!(t4a_treetn_truncate(tt_rtol, &rtol_policy, 1), T4A_SUCCESS);
     assert_eq!(link_dim(tt_rtol), 1);
     cleanup(tt_rtol, tensors_rtol, indices_rtol);
 
     let (tt_cutoff, tensors_cutoff, indices_cutoff) = make_truncatable_treetn();
     assert_eq!(link_dim(tt_cutoff), 4);
+    let cutoff_policy = squared_tail_policy(1e-24);
     assert_eq!(
-        t4a_treetn_truncate(tt_cutoff, 0.0, 1e-24, 1, t4a_canonical_form::LU),
+        t4a_treetn_truncate(tt_cutoff, &cutoff_policy, 1),
         T4A_SUCCESS
     );
     assert_eq!(link_dim(tt_cutoff), 1);
@@ -1032,7 +1044,10 @@ fn test_treetn_scale_and_add() {
     assert_eq!(read_dense_f64_treetn(scaled), vec![2.0, 4.0, 6.0, 8.0]);
 
     let mut sum = std::ptr::null_mut();
-    assert_eq!(t4a_treetn_add(tt, tt, 0.0, 0.0, 0, &mut sum), T4A_SUCCESS);
+    assert_eq!(
+        t4a_treetn_add(tt, tt, std::ptr::null(), 0, &mut sum),
+        T4A_SUCCESS
+    );
     assert_eq!(read_dense_f64_treetn(sum), vec![2.0, 4.0, 6.0, 8.0]);
 
     t4a_treetn_release(sum);
@@ -1044,9 +1059,10 @@ fn test_treetn_scale_and_add() {
 fn test_treetn_add_with_truncation() {
     let (tt, tensors, indices) = make_truncatable_treetn();
     let expected = read_dense_f64_treetn(tt);
+    let policy = relative_policy(1e-12);
 
     let mut sum = std::ptr::null_mut();
-    assert_eq!(t4a_treetn_add(tt, tt, 1e-12, 0.0, 1, &mut sum), T4A_SUCCESS);
+    assert_eq!(t4a_treetn_add(tt, tt, &policy, 1, &mut sum), T4A_SUCCESS);
     assert_eq!(link_dim(sum), 1);
 
     let dense = read_dense_f64_treetn(sum);
@@ -1142,12 +1158,12 @@ fn test_treetn_contract_and_to_dense() {
             op,
             state,
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
             t4a_factorize_alg::SVD,
+            0.0,
             &mut result
         ),
         T4A_SUCCESS
@@ -1174,12 +1190,12 @@ fn test_treetn_contract_fit_zero_sweeps_uses_backend_default() {
             a,
             b,
             t4a_contract_method::Fit,
-            1e-12,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             1e-30,
             t4a_factorize_alg::LU,
+            0.0,
             &mut baseline
         ),
         T4A_SUCCESS
@@ -1191,12 +1207,12 @@ fn test_treetn_contract_fit_zero_sweeps_uses_backend_default() {
             a,
             b,
             t4a_contract_method::Fit,
-            1e-12,
-            0.0,
+            std::ptr::null(),
             0,
             0,
             1e-30,
             t4a_factorize_alg::LU,
+            0.0,
             &mut uses_default
         ),
         T4A_SUCCESS
@@ -1222,12 +1238,12 @@ fn test_treetn_contract_fit_accepts_iterative_options() {
             a,
             b,
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
             t4a_factorize_alg::SVD,
+            0.0,
             &mut expected
         ),
         T4A_SUCCESS
@@ -1239,12 +1255,12 @@ fn test_treetn_contract_fit_accepts_iterative_options() {
             a,
             b,
             t4a_contract_method::Fit,
-            1e-12,
-            0.0,
+            std::ptr::null(),
             0,
             2,
             1e-30,
             t4a_factorize_alg::LU,
+            0.0,
             &mut fitted
         ),
         T4A_SUCCESS
@@ -1294,8 +1310,7 @@ fn test_treetn_apply_operator_chain_identity_single_site() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
@@ -1358,8 +1373,7 @@ fn test_treetn_apply_operator_chain_partial_operator() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
@@ -1399,6 +1413,7 @@ fn test_treetn_apply_operator_chain_fit_zero_sweeps_uses_backend_default() {
     let input_indices = [internal_in as *const t4a_index];
     let output_indices = [internal_out as *const t4a_index];
     let true_output_indices = [target_out as *const t4a_index];
+    let policy = relative_policy(1e-12);
 
     let mut baseline = std::ptr::null_mut();
     assert_eq!(
@@ -1411,8 +1426,7 @@ fn test_treetn_apply_operator_chain_fit_zero_sweeps_uses_backend_default() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Fit,
-            1e-12,
-            0.0,
+            &policy,
             0,
             1,
             1e-30,
@@ -1432,8 +1446,7 @@ fn test_treetn_apply_operator_chain_fit_zero_sweeps_uses_backend_default() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Fit,
-            1e-12,
-            0.0,
+            &policy,
             0,
             0,
             1e-30,
@@ -1476,6 +1489,7 @@ fn test_treetn_apply_operator_chain_fit_accepts_iterative_options() {
     let input_indices = [internal_in as *const t4a_index];
     let output_indices = [internal_out as *const t4a_index];
     let true_output_indices = [target_out as *const t4a_index];
+    let policy = relative_policy(1e-12);
 
     let mut expected = std::ptr::null_mut();
     assert_eq!(
@@ -1488,8 +1502,7 @@ fn test_treetn_apply_operator_chain_fit_accepts_iterative_options() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
@@ -1509,8 +1522,7 @@ fn test_treetn_apply_operator_chain_fit_accepts_iterative_options() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Fit,
-            1e-12,
-            0.0,
+            &policy,
             0,
             2,
             1e-30,
@@ -1564,8 +1576,7 @@ fn test_treetn_apply_operator_chain_rejects_out_of_range_mapped_node() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
@@ -1621,8 +1632,7 @@ fn test_treetn_apply_operator_chain_rejects_empty_mapping() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
@@ -1677,8 +1687,7 @@ fn test_treetn_apply_operator_chain_rejects_unknown_internal_input_index() {
             output_indices.as_ptr(),
             true_output_indices.as_ptr(),
             t4a_contract_method::Naive,
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
             1,
             0.0,
@@ -1722,10 +1731,8 @@ fn test_treetn_linsolve_two_site_identity_without_mapping_zero_sweeps() {
         std::ptr::null(),
         std::ptr::null(),
         std::ptr::null(),
-        0.0,
-        0.0,
+        std::ptr::null(),
         0,
-        t4a_canonical_form::Unitary,
         0,
         1e-12,
         30,
@@ -1785,10 +1792,8 @@ fn test_treetn_linsolve_two_site_identity_with_explicit_mapping() {
         internal_inputs.as_ptr(),
         true_outputs.as_ptr(),
         internal_outputs.as_ptr(),
-        0.0,
-        0.0,
+        std::ptr::null(),
         0,
-        t4a_canonical_form::Unitary,
         3,
         1e-12,
         30,
@@ -1855,10 +1860,8 @@ fn test_treetn_linsolve_rejects_mapping_true_output_not_on_rhs() {
             internal_inputs.as_ptr(),
             true_outputs.as_ptr(),
             internal_outputs.as_ptr(),
-            0.0,
-            0.0,
+            std::ptr::null(),
             0,
-            t4a_canonical_form::Unitary,
             4,
             1e-12,
             30,

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -2,7 +2,10 @@
 
 use std::ffi::c_void;
 
-use tensor4all_core::{DynIndex, FactorizeAlg, TensorDynLen};
+use tensor4all_core::{
+    DynIndex, FactorizeAlg, SingularValueMeasure, SvdTruncationPolicy, TensorDynLen,
+    ThresholdScale, TruncationRule,
+};
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
 use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN};
@@ -159,7 +162,7 @@ impl Drop for t4a_treetn {
 unsafe impl Send for t4a_treetn {}
 unsafe impl Sync for t4a_treetn {}
 
-/// Canonical form used for orthogonalization/truncation.
+/// Canonical form used for orthogonalization and canonicalization.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum t4a_canonical_form {
@@ -187,6 +190,240 @@ impl From<t4a_canonical_form> for TreeCanonicalForm {
             t4a_canonical_form::Unitary => Self::Unitary,
             t4a_canonical_form::LU => Self::LU,
             t4a_canonical_form::CI => Self::CI,
+        }
+    }
+}
+
+/// Threshold scaling used by the C API SVD truncation policy.
+///
+/// Related types:
+/// - [`t4a_singular_value_measure`] selects whether the threshold is applied to
+///   singular values or squared singular values.
+/// - [`t4a_truncation_rule`] selects whether the threshold is checked per value
+///   or against the discarded suffix sum.
+/// - [`t4a_svd_truncation_policy`] combines all three knobs with the numeric
+///   threshold.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_capi::t4a_threshold_scale;
+/// use tensor4all_core::ThresholdScale;
+///
+/// assert_eq!(
+///     ThresholdScale::from(t4a_threshold_scale::Relative),
+///     ThresholdScale::Relative
+/// );
+/// assert_eq!(
+///     ThresholdScale::from(t4a_threshold_scale::Absolute),
+///     ThresholdScale::Absolute
+/// );
+/// ```
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum t4a_threshold_scale {
+    /// Compare the threshold to a singular-value-derived reference scale.
+    #[default]
+    Relative = 0,
+    /// Compare the threshold directly to the measured singular-value quantity.
+    Absolute = 1,
+}
+
+impl From<ThresholdScale> for t4a_threshold_scale {
+    fn from(scale: ThresholdScale) -> Self {
+        match scale {
+            ThresholdScale::Relative => Self::Relative,
+            ThresholdScale::Absolute => Self::Absolute,
+        }
+    }
+}
+
+impl From<t4a_threshold_scale> for ThresholdScale {
+    fn from(scale: t4a_threshold_scale) -> Self {
+        match scale {
+            t4a_threshold_scale::Relative => Self::Relative,
+            t4a_threshold_scale::Absolute => Self::Absolute,
+        }
+    }
+}
+
+/// Singular-value quantity used by the C API SVD truncation policy.
+///
+/// Related types:
+/// - [`t4a_threshold_scale`] selects whether the threshold is relative or
+///   absolute.
+/// - [`t4a_truncation_rule`] selects whether truncation is per value or based
+///   on the discarded tail sum.
+/// - [`t4a_svd_truncation_policy`] stores the full C-facing SVD policy.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_capi::t4a_singular_value_measure;
+/// use tensor4all_core::SingularValueMeasure;
+///
+/// assert_eq!(
+///     SingularValueMeasure::from(t4a_singular_value_measure::Value),
+///     SingularValueMeasure::Value
+/// );
+/// assert_eq!(
+///     SingularValueMeasure::from(t4a_singular_value_measure::SquaredValue),
+///     SingularValueMeasure::SquaredValue
+/// );
+/// ```
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum t4a_singular_value_measure {
+    /// Measure singular values directly.
+    #[default]
+    Value = 0,
+    /// Measure squared singular values.
+    SquaredValue = 1,
+}
+
+impl From<SingularValueMeasure> for t4a_singular_value_measure {
+    fn from(measure: SingularValueMeasure) -> Self {
+        match measure {
+            SingularValueMeasure::Value => Self::Value,
+            SingularValueMeasure::SquaredValue => Self::SquaredValue,
+        }
+    }
+}
+
+impl From<t4a_singular_value_measure> for SingularValueMeasure {
+    fn from(measure: t4a_singular_value_measure) -> Self {
+        match measure {
+            t4a_singular_value_measure::Value => Self::Value,
+            t4a_singular_value_measure::SquaredValue => Self::SquaredValue,
+        }
+    }
+}
+
+/// Rank-selection rule used by the C API SVD truncation policy.
+///
+/// Related types:
+/// - [`t4a_threshold_scale`] sets whether the threshold is relative or
+///   absolute.
+/// - [`t4a_singular_value_measure`] sets whether values or squared values are
+///   measured.
+/// - [`t4a_svd_truncation_policy`] combines the rule with the other SVD
+///   truncation knobs.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_capi::t4a_truncation_rule;
+/// use tensor4all_core::TruncationRule;
+///
+/// assert_eq!(
+///     TruncationRule::from(t4a_truncation_rule::PerValue),
+///     TruncationRule::PerValue
+/// );
+/// assert_eq!(
+///     TruncationRule::from(t4a_truncation_rule::DiscardedTailSum),
+///     TruncationRule::DiscardedTailSum
+/// );
+/// ```
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum t4a_truncation_rule {
+    /// Apply the threshold independently to each singular value.
+    #[default]
+    PerValue = 0,
+    /// Apply the threshold to the cumulative discarded tail.
+    DiscardedTailSum = 1,
+}
+
+impl From<TruncationRule> for t4a_truncation_rule {
+    fn from(rule: TruncationRule) -> Self {
+        match rule {
+            TruncationRule::PerValue => Self::PerValue,
+            TruncationRule::DiscardedTailSum => Self::DiscardedTailSum,
+        }
+    }
+}
+
+impl From<t4a_truncation_rule> for TruncationRule {
+    fn from(rule: t4a_truncation_rule) -> Self {
+        match rule {
+            t4a_truncation_rule::PerValue => Self::PerValue,
+            t4a_truncation_rule::DiscardedTailSum => Self::DiscardedTailSum,
+        }
+    }
+}
+
+/// Explicit SVD truncation policy exposed through the C API.
+///
+/// This is the ABI-facing mirror of [`tensor4all_core::SvdTruncationPolicy`].
+/// Pass it to SVD-based C API entry points to choose the threshold value, the
+/// threshold scale, whether singular values are squared first, and whether the
+/// truncation rule is per value or tail-sum based.
+///
+/// Related types:
+/// - [`t4a_threshold_scale`] controls relative vs absolute thresholding.
+/// - [`t4a_singular_value_measure`] controls value vs squared-value
+///   measurement.
+/// - [`t4a_truncation_rule`] controls per-value vs discarded-tail-sum
+///   truncation.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_capi::{
+///     t4a_singular_value_measure, t4a_svd_truncation_policy, t4a_threshold_scale,
+///     t4a_truncation_rule,
+/// };
+/// use tensor4all_core::{SingularValueMeasure, SvdTruncationPolicy, ThresholdScale, TruncationRule};
+///
+/// let ffi_policy = t4a_svd_truncation_policy {
+///     threshold: 1e-8,
+///     scale: t4a_threshold_scale::Absolute,
+///     measure: t4a_singular_value_measure::SquaredValue,
+///     rule: t4a_truncation_rule::DiscardedTailSum,
+/// };
+/// let core_policy = SvdTruncationPolicy::from(ffi_policy);
+/// assert_eq!(core_policy.threshold, 1e-8);
+/// assert_eq!(core_policy.scale, ThresholdScale::Absolute);
+/// assert_eq!(core_policy.measure, SingularValueMeasure::SquaredValue);
+/// assert_eq!(core_policy.rule, TruncationRule::DiscardedTailSum);
+/// ```
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct t4a_svd_truncation_policy {
+    /// Threshold value used by the selected scale/rule combination.
+    pub threshold: f64,
+    /// Relative or absolute threshold interpretation.
+    pub scale: t4a_threshold_scale,
+    /// Singular-value quantity used for thresholding.
+    pub measure: t4a_singular_value_measure,
+    /// Rank-selection rule.
+    pub rule: t4a_truncation_rule,
+}
+
+impl Default for t4a_svd_truncation_policy {
+    fn default() -> Self {
+        Self::from(SvdTruncationPolicy::new(1e-12))
+    }
+}
+
+impl From<SvdTruncationPolicy> for t4a_svd_truncation_policy {
+    fn from(policy: SvdTruncationPolicy) -> Self {
+        Self {
+            threshold: policy.threshold,
+            scale: policy.scale.into(),
+            measure: policy.measure.into(),
+            rule: policy.rule.into(),
+        }
+    }
+}
+
+impl From<t4a_svd_truncation_policy> for SvdTruncationPolicy {
+    fn from(policy: t4a_svd_truncation_policy) -> Self {
+        SvdTruncationPolicy {
+            threshold: policy.threshold,
+            scale: policy.scale.into(),
+            measure: policy.measure.into(),
+            rule: policy.rule.into(),
         }
     }
 }

--- a/crates/tensor4all-capi/src/types/tests/mod.rs
+++ b/crates/tensor4all-capi/src/types/tests/mod.rs
@@ -1,5 +1,7 @@
 use super::*;
-use tensor4all_core::FactorizeAlg;
+use tensor4all_core::{
+    FactorizeAlg, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale, TruncationRule,
+};
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
 use tensor4all_treetn::CanonicalForm;
 
@@ -37,6 +39,47 @@ fn test_factorize_alg_roundtrip() {
         let roundtrip = FactorizeAlg::from(ffi);
         assert_eq!(roundtrip, alg);
     }
+}
+
+#[test]
+fn test_threshold_scale_roundtrip() {
+    for scale in [ThresholdScale::Relative, ThresholdScale::Absolute] {
+        let ffi = t4a_threshold_scale::from(scale);
+        let roundtrip = ThresholdScale::from(ffi);
+        assert_eq!(roundtrip, scale);
+    }
+}
+
+#[test]
+fn test_singular_value_measure_roundtrip() {
+    for measure in [
+        SingularValueMeasure::Value,
+        SingularValueMeasure::SquaredValue,
+    ] {
+        let ffi = t4a_singular_value_measure::from(measure);
+        let roundtrip = SingularValueMeasure::from(ffi);
+        assert_eq!(roundtrip, measure);
+    }
+}
+
+#[test]
+fn test_truncation_rule_roundtrip() {
+    for rule in [TruncationRule::PerValue, TruncationRule::DiscardedTailSum] {
+        let ffi = t4a_truncation_rule::from(rule);
+        let roundtrip = TruncationRule::from(ffi);
+        assert_eq!(roundtrip, rule);
+    }
+}
+
+#[test]
+fn test_svd_truncation_policy_roundtrip() {
+    let policy = SvdTruncationPolicy::new(1e-8)
+        .with_absolute()
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    let ffi = t4a_svd_truncation_policy::from(policy);
+    let roundtrip = SvdTruncationPolicy::from(ffi);
+    assert_eq!(roundtrip, policy);
 }
 
 #[test]

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -38,8 +38,9 @@ use num_complex::{Complex64, ComplexFloat};
 use tensor4all_tcicore::{rrlu, AbstractMatrixCI, MatrixLUCI, RrLUOptions, Scalar as MatrixScalar};
 use tensor4all_tensorbackend::TensorElement;
 
+use crate::defaults::svd::svd_for_factorize;
 use crate::qr::{qr_with, QrOptions};
-use crate::svd::{svd_for_factorize, SvdOptions};
+use crate::svd::SvdOptions;
 
 // Re-export types from tensor_like for backwards compatibility
 pub use crate::tensor_like::{

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -77,6 +77,8 @@ pub fn factorize(
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
 ) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    options.validate()?;
+
     if t.is_diag() {
         return Err(FactorizeError::UnsupportedStorage(
             "Diagonal storage not supported for factorize",
@@ -126,12 +128,12 @@ fn factorize_svd(
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
 ) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
-    let mut svd_options = SvdOptions::default();
-    if let Some(rtol) = options.rtol {
-        svd_options.truncation.rtol = Some(rtol);
+    let mut svd_options = SvdOptions::new();
+    if let Some(policy) = options.svd_policy {
+        svd_options = svd_options.with_policy(policy);
     }
     if let Some(max_rank) = options.max_rank {
-        svd_options.truncation.max_rank = Some(max_rank);
+        svd_options = svd_options.with_max_rank(max_rank);
     }
 
     let result = svd_for_factorize(t, left_inds, &svd_options)?;
@@ -183,10 +185,11 @@ fn factorize_qr(
         ));
     }
 
-    let mut qr_options = QrOptions::default();
-    if let Some(rtol) = options.rtol {
-        qr_options.truncation.rtol = Some(rtol);
-    }
+    let qr_options = if let Some(rtol) = options.qr_rtol {
+        QrOptions::new().with_rtol(rtol)
+    } else {
+        QrOptions::new()
+    };
 
     let (q, r) = qr_with::<f64>(t, left_inds, &qr_options)?;
 
@@ -233,7 +236,7 @@ where
     let left_orthogonal = options.canonical == Canonical::Left;
     let lu_options = RrLUOptions {
         max_rank: options.max_rank.unwrap_or(usize::MAX),
-        rel_tol: options.rtol.unwrap_or(1e-14),
+        rel_tol: 1e-14,
         abs_tol: 0.0,
         left_orthogonal,
     };
@@ -301,7 +304,7 @@ where
     let left_orthogonal = options.canonical == Canonical::Left;
     let lu_options = RrLUOptions {
         max_rank: options.max_rank.unwrap_or(usize::MAX),
-        rel_tol: options.rtol.unwrap_or(1e-14),
+        rel_tol: 1e-14,
         abs_tol: 0.0,
         left_orthogonal,
     };

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -47,4 +47,4 @@ pub use factorize::{
     factorize, Canonical, FactorizeAlg, FactorizeError, FactorizeOptions, FactorizeResult,
 };
 pub use qr::{default_qr_rtol, qr, qr_with, set_default_qr_rtol, QrError, QrOptions};
-pub use svd::{default_svd_rtol, set_default_svd_rtol, svd, svd_with, SvdError, SvdOptions};
+pub use svd::{svd, svd_with, SvdError, SvdOptions};

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -4,7 +4,6 @@
 
 use crate::defaults::DynIndex;
 use crate::global_default::GlobalDefault;
-use crate::truncation::TruncationParams;
 use crate::{unfold_split, TensorDynLen};
 use num_complex::ComplexFloat;
 use tenferro::DType;
@@ -39,7 +38,7 @@ pub enum QrError {
 /// let data: Vec<f64> = (0..9).map(|x| x as f64).collect();
 /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
-/// let opts = QrOptions::with_rtol(1e-10);
+/// let opts = QrOptions::new().with_rtol(1e-10);
 /// let (q, r) = qr_with::<f64>(&tensor, &[i], &opts).unwrap();
 ///
 /// // Q * R recovers the original tensor
@@ -48,21 +47,23 @@ pub enum QrError {
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct QrOptions {
-    /// Truncation parameters (rtol only for QR).
-    pub truncation: TruncationParams,
+    /// Relative tolerance for QR row-norm truncation.
+    /// If `None`, uses the global default.
+    pub rtol: Option<f64>,
 }
 
 impl QrOptions {
-    /// Create new QR options with the specified rtol.
-    pub fn with_rtol(rtol: f64) -> Self {
-        Self {
-            truncation: TruncationParams::new().with_rtol(rtol),
-        }
+    /// Create new QR options with no overrides.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Get rtol from options (for backwards compatibility).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
+    /// Set the QR truncation tolerance.
+    #[must_use]
+    pub fn with_rtol(mut self, rtol: f64) -> Self {
+        self.rtol = Some(rtol);
+        self
     }
 }
 
@@ -259,7 +260,7 @@ pub fn qr_with<T>(
     options: &QrOptions,
 ) -> Result<(TensorDynLen, TensorDynLen), QrError> {
     // Determine rtol to use
-    let rtol = options.truncation.effective_rtol(default_qr_rtol());
+    let rtol = options.rtol.unwrap_or(default_qr_rtol());
     if !rtol.is_finite() || rtol < 0.0 {
         return Err(QrError::InvalidRtol(rtol));
     }

--- a/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
@@ -68,9 +68,9 @@ fn set_default_qr_rtol_rejects_invalid_values() {
 #[test]
 fn qr_options_report_rtol_and_default_roundtrips() {
     let original = default_qr_rtol();
-    let options = QrOptions::with_rtol(1.0e-7);
-    assert_eq!(options.rtol(), Some(1.0e-7));
-    assert_eq!(QrOptions::default().rtol(), None);
+    let options = QrOptions::new().with_rtol(1.0e-7);
+    assert_eq!(options.rtol, Some(1.0e-7));
+    assert_eq!(QrOptions::new().rtol, None);
 
     set_default_qr_rtol(1.0e-9).unwrap();
     assert_eq!(default_qr_rtol(), 1.0e-9);
@@ -86,14 +86,14 @@ fn qr_with_invalid_rtol_is_rejected_before_linalg() {
     let nan = qr_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &QrOptions::with_rtol(f64::NAN),
+        &QrOptions::new().with_rtol(f64::NAN),
     );
     assert!(matches!(nan, Err(QrError::InvalidRtol(v)) if v.is_nan()));
 
     let negative = qr_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &QrOptions::with_rtol(-1.0),
+        &QrOptions::new().with_rtol(-1.0),
     );
     assert!(matches!(negative, Err(QrError::InvalidRtol(v)) if v == -1.0));
 }
@@ -110,7 +110,7 @@ fn qr_with_native_truncation_reduces_bond_dimension() {
     let (q, r) = qr_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &QrOptions::with_rtol(1.0e-10),
+        &QrOptions::new().with_rtol(1.0e-10),
     )
     .unwrap();
     assert_eq!(q.dims(), vec![2, 1]);
@@ -129,7 +129,7 @@ fn qr_with_complex_fallback_truncation_reduces_bond_dimension() {
     let (q, r) = qr_with::<Complex64>(
         &tensor,
         std::slice::from_ref(&i),
-        &QrOptions::with_rtol(1.0e-10),
+        &QrOptions::new().with_rtol(1.0e-10),
     )
     .unwrap();
     assert_eq!(q.dims(), vec![2, 1]);

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -117,16 +117,6 @@ pub fn set_default_svd_truncation_policy(policy: SvdTruncationPolicy) -> Result<
     Ok(())
 }
 
-#[doc(hidden)]
-pub fn default_svd_rtol() -> f64 {
-    default_svd_truncation_policy().threshold
-}
-
-#[doc(hidden)]
-pub fn set_default_svd_rtol(rtol: f64) -> Result<(), SvdError> {
-    set_default_svd_truncation_policy(SvdTruncationPolicy::new(rtol))
-}
-
 fn singular_value_measure(value: f64, measure: SingularValueMeasure) -> f64 {
     match measure {
         SingularValueMeasure::Value => value,

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -8,10 +8,13 @@
 //! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
 
 use crate::defaults::DynIndex;
-use crate::global_default::GlobalDefault;
 use crate::index_like::IndexLike;
-use crate::truncation::{HasTruncationParams, TruncationParams};
+use crate::truncation::{
+    validate_svd_truncation_policy, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale,
+    TruncationRule,
+};
 use crate::{unfold_split, TensorDynLen};
+use std::sync::Mutex;
 use tenferro::DType;
 use tensor4all_tensorbackend::{
     dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
@@ -26,9 +29,9 @@ pub enum SvdError {
     /// SVD computation failed.
     #[error("SVD computation failed: {0}")]
     ComputationError(#[from] anyhow::Error),
-    /// Invalid relative tolerance value (must be finite and non-negative).
-    #[error("Invalid rtol value: {0}. rtol must be finite and non-negative.")]
-    InvalidRtol(f64),
+    /// Invalid truncation threshold value (must be finite and non-negative).
+    #[error("Invalid SVD truncation threshold: {0}. Threshold must be finite and non-negative.")]
+    InvalidThreshold(f64),
 }
 
 /// Options for SVD decomposition with truncation control.
@@ -37,14 +40,14 @@ pub enum SvdError {
 ///
 /// ```
 /// use tensor4all_core::svd::{SvdOptions, svd_with};
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, SvdTruncationPolicy, TensorDynLen};
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
 /// let data: Vec<f64> = (0..9).map(|x| x as f64).collect();
 /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
-/// let opts = SvdOptions::with_rtol(1e-10);
+/// let opts = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
 /// let (u, s, v) = svd_with::<f64>(&tensor, &[i.clone()], &opts).unwrap();
 ///
 /// // U has left index + bond, S is diagonal bond x bond, V has right index + bond
@@ -53,97 +56,144 @@ pub enum SvdError {
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SvdOptions {
-    /// Truncation parameters (rtol, max_rank).
-    pub truncation: TruncationParams,
+    /// Maximum retained rank after policy-based truncation.
+    pub max_rank: Option<usize>,
+    /// Per-call SVD truncation policy.
+    /// If `None`, the global default policy is used.
+    pub policy: Option<SvdTruncationPolicy>,
 }
 
 impl SvdOptions {
-    /// Create new SVD options with the specified rtol.
-    pub fn with_rtol(rtol: f64) -> Self {
-        Self {
-            truncation: TruncationParams::new().with_rtol(rtol),
-        }
+    /// Create new SVD options with no overrides.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Create new SVD options with the specified max_rank.
-    pub fn with_max_rank(max_rank: usize) -> Self {
-        Self {
-            truncation: TruncationParams::new().with_max_rank(max_rank),
-        }
+    /// Set the maximum retained rank.
+    #[must_use]
+    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
+        self.max_rank = Some(max_rank);
+        self
     }
 
-    /// Get rtol from options (for backwards compatibility).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
-    }
-
-    /// Get max_rank from options (for backwards compatibility).
-    pub fn max_rank(&self) -> Option<usize> {
-        self.truncation.max_rank
+    /// Set the SVD truncation policy override.
+    #[must_use]
+    pub fn with_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.policy = Some(policy);
+        self
     }
 }
 
-impl HasTruncationParams for SvdOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
+fn default_policy_guard() -> std::sync::MutexGuard<'static, SvdTruncationPolicy> {
+    match DEFAULT_SVD_TRUNCATION_POLICY.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 
-// Global default rtol using the unified GlobalDefault type
-// Default value: 1e-12 (near machine precision)
-static DEFAULT_SVD_RTOL: GlobalDefault = GlobalDefault::new(1e-12);
+// Default value: relative per-value threshold 1e-12.
+static DEFAULT_SVD_TRUNCATION_POLICY: Mutex<SvdTruncationPolicy> =
+    Mutex::new(SvdTruncationPolicy::new(1e-12));
 
-/// Get the global default rtol for SVD truncation.
+/// Get the global default truncation policy for SVD.
 ///
-/// The default value is 1e-12 (near machine precision).
-pub fn default_svd_rtol() -> f64 {
-    DEFAULT_SVD_RTOL.get()
+/// The default policy is `SvdTruncationPolicy::new(1e-12)`.
+#[must_use]
+pub fn default_svd_truncation_policy() -> SvdTruncationPolicy {
+    *default_policy_guard()
 }
 
-/// Set the global default rtol for SVD truncation.
+/// Set the global default truncation policy for SVD.
 ///
 /// # Arguments
-/// * `rtol` - Relative Frobenius error tolerance (must be finite and non-negative)
+/// * `policy` - SVD truncation policy to use when `SvdOptions::policy` is `None`
 ///
 /// # Errors
-/// Returns `SvdError::InvalidRtol` if rtol is not finite or is negative.
-pub fn set_default_svd_rtol(rtol: f64) -> Result<(), SvdError> {
-    DEFAULT_SVD_RTOL
-        .set(rtol)
-        .map_err(|e| SvdError::InvalidRtol(e.0))
+/// Returns `SvdError::InvalidThreshold` if `policy.threshold` is invalid.
+pub fn set_default_svd_truncation_policy(policy: SvdTruncationPolicy) -> Result<(), SvdError> {
+    validate_svd_truncation_policy(policy).map_err(|e| SvdError::InvalidThreshold(e.0))?;
+    *default_policy_guard() = policy;
+    Ok(())
 }
 
-/// Compute the retained rank based on rtol (TSVD truncation).
-///
-/// This implements the truncation criterion:
-///   sum_{i>r} σ_i² / sum_i σ_i² <= rtol²
-fn compute_retained_rank(s_vec: &[f64], rtol: f64) -> usize {
+#[doc(hidden)]
+pub fn default_svd_rtol() -> f64 {
+    default_svd_truncation_policy().threshold
+}
+
+#[doc(hidden)]
+pub fn set_default_svd_rtol(rtol: f64) -> Result<(), SvdError> {
+    set_default_svd_truncation_policy(SvdTruncationPolicy::new(rtol))
+}
+
+fn singular_value_measure(value: f64, measure: SingularValueMeasure) -> f64 {
+    match measure {
+        SingularValueMeasure::Value => value,
+        SingularValueMeasure::SquaredValue => value * value,
+    }
+}
+
+/// Compute the retained rank based on an explicit SVD truncation policy.
+fn compute_retained_rank(s_vec: &[f64], policy: &SvdTruncationPolicy) -> usize {
     if s_vec.is_empty() {
         return 1;
     }
 
-    let total_sq_norm: f64 = s_vec.iter().map(|&s| s * s).sum();
-    if total_sq_norm == 0.0 {
+    let measured: Vec<f64> = s_vec
+        .iter()
+        .map(|&value| singular_value_measure(value, policy.measure))
+        .collect();
+    if measured.iter().all(|&value| value == 0.0) {
         return 1;
     }
 
-    let threshold = rtol * rtol * total_sq_norm;
-    let mut discarded_sq_norm = 0.0;
-    let mut r = s_vec.len();
-    for i in (0..s_vec.len()).rev() {
-        let s_sq = s_vec[i] * s_vec[i];
-        if discarded_sq_norm + s_sq <= threshold {
-            discarded_sq_norm += s_sq;
-            r = i;
-        } else {
-            break;
+    let retained = match (policy.scale, policy.rule) {
+        (ThresholdScale::Relative, TruncationRule::PerValue) => {
+            let reference = measured.iter().copied().fold(0.0_f64, f64::max);
+            measured
+                .iter()
+                .take_while(|&&value| reference > 0.0 && value / reference > policy.threshold)
+                .count()
         }
-    }
-    r.max(1)
+        (ThresholdScale::Absolute, TruncationRule::PerValue) => measured
+            .iter()
+            .take_while(|&&value| value > policy.threshold)
+            .count(),
+        (ThresholdScale::Relative, TruncationRule::DiscardedTailSum) => {
+            let total: f64 = measured.iter().sum();
+            if total == 0.0 {
+                1
+            } else {
+                let mut discarded = 0.0;
+                let mut keep = measured.len();
+                for (i, value) in measured.iter().enumerate().rev() {
+                    if (discarded + value) / total <= policy.threshold {
+                        discarded += value;
+                        keep = i;
+                    } else {
+                        break;
+                    }
+                }
+                keep
+            }
+        }
+        (ThresholdScale::Absolute, TruncationRule::DiscardedTailSum) => {
+            let mut discarded = 0.0;
+            let mut keep = measured.len();
+            for (i, value) in measured.iter().enumerate().rev() {
+                if discarded + value <= policy.threshold {
+                    discarded += value;
+                    keep = i;
+                } else {
+                    break;
+                }
+            }
+            keep
+        }
+    };
+
+    retained.max(1)
 }
 
 fn singular_values_from_native(tensor: &tenferro::Tensor) -> Result<Vec<f64>, SvdError> {
@@ -197,10 +247,8 @@ fn svd_truncated_native(
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<SvdTruncatedNativeResult, SvdError> {
-    let rtol = options.truncation.effective_rtol(default_svd_rtol());
-    if !rtol.is_finite() || rtol < 0.0 {
-        return Err(SvdError::InvalidRtol(rtol));
-    }
+    let policy = options.policy.unwrap_or_else(default_svd_truncation_policy);
+    validate_svd_truncation_policy(policy).map_err(|e| SvdError::InvalidThreshold(e.0))?;
 
     let (matrix_native, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
@@ -210,10 +258,11 @@ fn svd_truncated_native(
     let (mut u_native, mut s_native, mut vt_native) =
         svd_native_tensor(&matrix_native).map_err(SvdError::ComputationError)?;
     let s_full = singular_values_from_native(&s_native)?;
-    let mut r = compute_retained_rank(&s_full, rtol);
-    if let Some(max_rank) = options.truncation.max_rank {
+    let mut r = compute_retained_rank(&s_full, &policy);
+    if let Some(max_rank) = options.max_rank {
         r = r.min(max_rank);
     }
+    r = r.max(1);
     if r < k {
         match u_native.dtype() {
             DType::F64 => {
@@ -293,8 +342,8 @@ pub fn svd<T>(
 
 /// Compute SVD decomposition of a tensor with arbitrary rank, returning (U, S, V).
 ///
-/// This function allows per-call control of the truncation tolerance via `SvdOptions`.
-/// If `options.rtol` is `None`, uses the global default rtol.
+/// This function allows per-call control of the truncation policy via `SvdOptions`.
+/// If `options.policy` is `None`, it uses the global default policy.
 ///
 /// # Examples
 ///
@@ -309,13 +358,15 @@ pub fn svd<T>(
 /// data[0] = 1.0;
 /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
-/// // Truncate with tight tolerance => rank 1
-/// let opts = SvdOptions::with_rtol(1e-10);
+/// use tensor4all_core::SvdTruncationPolicy;
+///
+/// // Truncate with a relative per-value threshold => rank 1
+/// let opts = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
 /// let (u, s, _v) = svd_with::<f64>(&tensor, &[i.clone()], &opts).unwrap();
 /// assert_eq!(s.dims()[0], 1);  // rank-1
 ///
 /// // Truncate with max_rank => capped
-/// let opts = SvdOptions::with_max_rank(2);
+/// let opts = SvdOptions::new().with_max_rank(2);
 /// let (_u, s, _v) = svd_with::<f64>(&tensor, &[i.clone()], &opts).unwrap();
 /// assert!(s.dims()[0] <= 2);
 /// ```

--- a/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
@@ -1,14 +1,42 @@
 use super::*;
 use crate::index::DefaultIndex as Index;
+use crate::{SingularValueMeasure, SvdTruncationPolicy, ThresholdScale, TruncationRule};
 use num_complex::Complex64;
 use tenferro::Tensor as NativeTensor;
 
 #[test]
 fn compute_retained_rank_handles_edge_cases() {
-    assert_eq!(compute_retained_rank(&[], 1.0e-12), 1);
-    assert_eq!(compute_retained_rank(&[0.0, 0.0], 1.0e-6), 1);
-    assert_eq!(compute_retained_rank(&[5.0, 1.0e-9], 1.0e-6), 1);
-    assert_eq!(compute_retained_rank(&[5.0, 1.0], 1.0e-12), 2);
+    let per_value = SvdTruncationPolicy::new(1.0e-6);
+    assert_eq!(compute_retained_rank(&[], &per_value), 1);
+    assert_eq!(compute_retained_rank(&[0.0, 0.0], &per_value), 1);
+    assert_eq!(compute_retained_rank(&[5.0, 1.0e-9], &per_value), 1);
+    assert_eq!(
+        compute_retained_rank(&[5.0, 1.0], &SvdTruncationPolicy::new(1.0e-12)),
+        2
+    );
+}
+
+#[test]
+fn compute_retained_rank_supports_all_policy_axes() {
+    let absolute_per_value = SvdTruncationPolicy::new(1.5).with_absolute();
+    assert_eq!(compute_retained_rank(&[5.0, 1.0], &absolute_per_value), 1);
+
+    let relative_squared_tail = SvdTruncationPolicy::new(0.05)
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    assert_eq!(
+        compute_retained_rank(&[10.0, 1.0, 0.1], &relative_squared_tail),
+        1
+    );
+
+    let absolute_squared_tail = SvdTruncationPolicy::new(0.02)
+        .with_absolute()
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    assert_eq!(
+        compute_retained_rank(&[1.0, 0.1, 0.1], &absolute_squared_tail),
+        2
+    );
 }
 
 #[test]
@@ -27,22 +55,36 @@ fn singular_values_from_native_accepts_real_and_complex_dense() {
 }
 
 #[test]
-fn set_default_svd_rtol_rejects_invalid_values() {
-    let original = default_svd_rtol();
-    assert!(set_default_svd_rtol(f64::NAN).is_err());
-    assert!(set_default_svd_rtol(-1.0).is_err());
-    set_default_svd_rtol(original).unwrap();
+fn set_default_svd_truncation_policy_rejects_invalid_values() {
+    let original = default_svd_truncation_policy();
+    assert!(set_default_svd_truncation_policy(SvdTruncationPolicy::new(f64::NAN)).is_err());
+    assert!(set_default_svd_truncation_policy(SvdTruncationPolicy::new(-1.0)).is_err());
+    assert!(set_default_svd_truncation_policy(SvdTruncationPolicy::new(f64::INFINITY)).is_err());
+    set_default_svd_truncation_policy(original).unwrap();
 }
 
 #[test]
 fn svd_options_accessors_roundtrip() {
-    let by_rtol = SvdOptions::with_rtol(1.0e-5);
-    assert_eq!(by_rtol.rtol(), Some(1.0e-5));
-    assert_eq!(by_rtol.max_rank(), None);
+    let by_policy = SvdOptions::new().with_policy(
+        SvdTruncationPolicy::new(1.0e-5)
+            .with_absolute()
+            .with_squared_values()
+            .with_discarded_tail_sum(),
+    );
+    assert_eq!(
+        by_policy.policy,
+        Some(SvdTruncationPolicy {
+            threshold: 1.0e-5,
+            scale: ThresholdScale::Absolute,
+            measure: SingularValueMeasure::SquaredValue,
+            rule: TruncationRule::DiscardedTailSum,
+        })
+    );
+    assert_eq!(by_policy.max_rank, None);
 
-    let by_rank = SvdOptions::with_max_rank(7);
-    assert_eq!(by_rank.rtol(), None);
-    assert_eq!(by_rank.max_rank(), Some(7));
+    let by_rank = SvdOptions::new().with_max_rank(7);
+    assert_eq!(by_rank.policy, None);
+    assert_eq!(by_rank.max_rank, Some(7));
 }
 
 #[test]
@@ -64,7 +106,7 @@ fn svd_with_max_rank_truncates_native_outputs() {
     let (u, s, v) = svd_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &SvdOptions::with_max_rank(1),
+        &SvdOptions::new().with_max_rank(1),
     )
     .unwrap();
 
@@ -83,14 +125,14 @@ fn svd_with_invalid_rtol_is_rejected_before_linalg() {
     let nan = svd_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &SvdOptions::with_rtol(f64::NAN),
+        &SvdOptions::new().with_policy(SvdTruncationPolicy::new(f64::NAN)),
     );
-    assert!(matches!(nan, Err(SvdError::InvalidRtol(v)) if v.is_nan()));
+    assert!(matches!(nan, Err(SvdError::InvalidThreshold(v)) if v.is_nan()));
 
     let negative = svd_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &SvdOptions::with_rtol(-1.0),
+        &SvdOptions::new().with_policy(SvdTruncationPolicy::new(-1.0)),
     );
-    assert!(matches!(negative, Err(SvdError::InvalidRtol(v)) if v == -1.0));
+    assert!(matches!(negative, Err(SvdError::InvalidThreshold(v)) if v == -1.0));
 }

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -120,7 +120,10 @@ pub mod qr {
 }
 pub mod svd {
     //! Re-export of SVD decomposition operations.
-    pub use crate::defaults::svd::*;
+    pub use crate::defaults::svd::{
+        default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdError,
+        SvdOptions,
+    };
 }
 
 // Re-export linear algebra items for top-level access

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -128,9 +128,13 @@ pub use defaults::direct_sum::direct_sum;
 pub use defaults::factorize::factorize;
 pub use defaults::qr::{default_qr_rtol, qr, qr_with, set_default_qr_rtol, QrError, QrOptions};
 pub use defaults::svd::{
-    default_svd_rtol, set_default_svd_rtol, svd, svd_with, SvdError, SvdOptions,
+    default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdError,
+    SvdOptions,
 };
 
 // Global default and truncation utilities
 pub use global_default::{GlobalDefault, InvalidRtolError};
-pub use truncation::{DecompositionAlg, HasTruncationParams, TruncationParams};
+pub use truncation::{
+    DecompositionAlg, InvalidThresholdError, SingularValueMeasure, SvdTruncationPolicy,
+    ThresholdScale, TruncationRule,
+};

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -14,6 +14,7 @@
 
 use crate::any_scalar::AnyScalar;
 use crate::tensor_index::TensorIndex;
+use crate::truncation::SvdTruncationPolicy;
 use anyhow::Result;
 use std::fmt::Debug;
 
@@ -57,6 +58,12 @@ pub enum FactorizeError {
     InvalidRtol(
         /// The invalid rtol value
         f64,
+    ),
+    /// Invalid algorithm-specific option combination.
+    #[error("Invalid factorize options: {0}")]
+    InvalidOptions(
+        /// Description of the invalid option combination
+        &'static str,
     ),
     /// The storage type is not supported for this operation.
     #[error("Unsupported storage type: {0}")]
@@ -176,14 +183,15 @@ pub enum Canonical {
 ///
 /// - Algorithm: SVD
 /// - Canonical: Left (left factor is orthogonal)
-/// - rtol: `None` (uses the algorithm's global default)
 /// - max_rank: `None` (no rank limit)
+/// - svd_policy: `None` (uses the SVD global default policy)
+/// - qr_rtol: `None` (uses the QR global default tolerance)
 ///
 /// # Field Interactions
 ///
-/// - `rtol` and `max_rank` are independent: the retained rank is the
-///   **minimum** of the tolerance-based rank and `max_rank`.
-/// - When neither is set, the algorithm's global default tolerance is used.
+/// - `svd_policy` is only valid for `FactorizeAlg::SVD`.
+/// - `qr_rtol` is only valid for `FactorizeAlg::QR`.
+/// - `max_rank` is independent of the algorithm-specific tolerance settings.
 ///
 /// # Examples
 ///
@@ -198,13 +206,14 @@ pub enum Canonical {
 /// data[0] = 1.0;  // rank-1 matrix
 /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
-/// // SVD with tolerance truncation
-/// let opts = FactorizeOptions::svd().with_rtol(1e-10);
+/// // SVD with an explicit policy
+/// let opts = FactorizeOptions::svd()
+///     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10));
 /// let result = factorize(&tensor, &[i.clone()], &opts).unwrap();
 /// assert_eq!(result.rank, 1);
 ///
 /// // QR with max-rank truncation
-/// let opts = FactorizeOptions::qr().with_max_rank(2);
+/// let opts = FactorizeOptions::qr().with_qr_rtol(1e-8).with_max_rank(2);
 /// let result = factorize(&tensor, &[i.clone()], &opts).unwrap();
 /// assert!(result.rank <= 2);
 /// ```
@@ -214,12 +223,15 @@ pub struct FactorizeOptions {
     pub alg: FactorizeAlg,
     /// Canonical direction.
     pub canonical: Canonical,
-    /// Relative tolerance for truncation.
-    /// If `None`, uses the algorithm's default.
-    pub rtol: Option<f64>,
     /// Maximum rank for truncation.
     /// If `None`, no rank limit is applied.
     pub max_rank: Option<usize>,
+    /// SVD truncation policy.
+    /// If `None`, uses the SVD global default.
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// QR-specific relative tolerance.
+    /// If `None`, uses the QR global default.
+    pub qr_rtol: Option<f64>,
 }
 
 impl Default for FactorizeOptions {
@@ -227,8 +239,9 @@ impl Default for FactorizeOptions {
         Self {
             alg: FactorizeAlg::SVD,
             canonical: Canonical::Left,
-            rtol: None,
             max_rank: None,
+            svd_policy: None,
+            qr_rtol: None,
         }
     }
 }
@@ -317,18 +330,33 @@ impl FactorizeOptions {
         self
     }
 
-    /// Set relative tolerance.
+    /// Set the SVD truncation policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{FactorizeOptions, SvdTruncationPolicy};
+    ///
+    /// let opts = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1e-8));
+    /// assert_eq!(opts.svd_policy, Some(SvdTruncationPolicy::new(1e-8)));
+    /// ```
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set the QR-specific relative tolerance.
     ///
     /// # Examples
     ///
     /// ```
     /// use tensor4all_core::FactorizeOptions;
     ///
-    /// let opts = FactorizeOptions::svd().with_rtol(1e-8);
-    /// assert_eq!(opts.rtol, Some(1e-8));
+    /// let opts = FactorizeOptions::qr().with_qr_rtol(1e-8);
+    /// assert_eq!(opts.qr_rtol, Some(1e-8));
     /// ```
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.rtol = Some(rtol);
+    pub fn with_qr_rtol(mut self, rtol: f64) -> Self {
+        self.qr_rtol = Some(rtol);
         self
     }
 
@@ -345,6 +373,45 @@ impl FactorizeOptions {
     pub fn with_max_rank(mut self, max_rank: usize) -> Self {
         self.max_rank = Some(max_rank);
         self
+    }
+
+    /// Validate that the selected fields make sense for the chosen algorithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FactorizeError::InvalidOptions`] if an algorithm is paired with
+    /// unsupported algorithm-specific truncation settings.
+    pub fn validate(&self) -> std::result::Result<(), FactorizeError> {
+        match self.alg {
+            FactorizeAlg::SVD => {
+                if self.qr_rtol.is_some() {
+                    return Err(FactorizeError::InvalidOptions(
+                        "SVD factorization does not accept qr_rtol",
+                    ));
+                }
+            }
+            FactorizeAlg::QR => {
+                if self.svd_policy.is_some() {
+                    return Err(FactorizeError::InvalidOptions(
+                        "QR factorization does not accept svd_policy",
+                    ));
+                }
+            }
+            FactorizeAlg::LU | FactorizeAlg::CI => {
+                if self.svd_policy.is_some() {
+                    return Err(FactorizeError::InvalidOptions(
+                        "LU/CI factorization does not accept svd_policy",
+                    ));
+                }
+                if self.qr_rtol.is_some() {
+                    return Err(FactorizeError::InvalidOptions(
+                        "LU/CI factorization does not accept qr_rtol",
+                    ));
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/tensor4all-core/src/truncation.rs
+++ b/crates/tensor4all-core/src/truncation.rs
@@ -1,12 +1,15 @@
-//! Common truncation options and traits.
+//! Truncation policy types for decomposition algorithms.
 //!
-//! This module provides shared types and traits for truncation parameters
-//! used across tensor operations like SVD, QR, and tensor train compression.
+//! This module keeps algorithm selection separate from algorithm-specific
+//! truncation semantics. SVD-based routines use [`SvdTruncationPolicy`],
+//! while QR and other decompositions keep their own option types.
+
+use thiserror::Error;
 
 /// Decomposition/factorization algorithm.
 ///
 /// This enum unifies the algorithm choices across different crates
-/// (tensor4all-core, tensor4all-treetn, etc.).
+/// (`tensor4all-core`, `tensor4all-treetn`, etc.).
 ///
 /// # Examples
 ///
@@ -47,237 +50,176 @@ impl DecompositionAlg {
     }
 }
 
-/// Common truncation parameters.
+/// Threshold scaling for SVD truncation.
 ///
-/// This struct contains the core parameters used for rank truncation
-/// across various tensor decomposition and compression operations.
-///
-/// # Semantics
-///
-/// This crate uses **relative tolerance** (`rtol`) semantics:
-/// - Singular values are truncated when `σ_i / σ_max < rtol`
-///
-/// ITensorMPS.jl uses **cutoff** semantics:
-/// - Singular values are truncated when `σ_i² < cutoff`
-///
-/// **Conversion**: For normalized tensors (where `σ_max = 1`):
-/// - ITensorMPS.jl's `cutoff` = tensor4all-rs's `rtol²`
-/// - To match ITensorMPS.jl behavior: use `rtol = sqrt(cutoff)`
-/// - Example: ITensorMPS.jl `cutoff=1e-10` ↔ tensor4all-rs `rtol=1e-5`
+/// Relative thresholds compare against a scale derived from the singular values.
+/// Absolute thresholds compare directly against the configured cutoff.
 ///
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::TruncationParams;
+/// use tensor4all_core::ThresholdScale;
 ///
-/// // Builder pattern
-/// let params = TruncationParams::new()
-///     .with_rtol(1e-8)
-///     .with_max_rank(50);
-/// assert_eq!(params.rtol, Some(1e-8));
-/// assert_eq!(params.max_rank, Some(50));
-///
-/// // ITensorMPS.jl compatibility
-/// let params = TruncationParams::new().with_cutoff(1e-10);
-/// let rtol = params.rtol.unwrap();
-/// assert!((rtol - 1e-5).abs() < 1e-10);  // sqrt(1e-10) = 1e-5
-///
-/// // Effective values with defaults
-/// let params = TruncationParams::new();
-/// assert_eq!(params.effective_rtol(1e-12), 1e-12);  // uses default
-/// assert_eq!(params.effective_max_rank(), usize::MAX);  // no limit
+/// assert_eq!(ThresholdScale::default(), ThresholdScale::Relative);
 /// ```
-#[derive(Debug, Clone, Copy, Default)]
-pub struct TruncationParams {
-    /// Relative tolerance for truncation.
-    ///
-    /// Singular values satisfying `σ_i / σ_max < rtol` are truncated,
-    /// where `σ_max` is the largest singular value.
-    ///
-    /// If `None`, uses the algorithm's default tolerance.
-    pub rtol: Option<f64>,
-
-    /// Maximum rank (bond dimension).
-    ///
-    /// If `None`, no rank limit is applied.
-    pub max_rank: Option<usize>,
-
-    /// Cutoff value (ITensorMPS.jl convention).
-    ///
-    /// When set via [`with_cutoff`](TruncationParams::with_cutoff), `rtol` is
-    /// automatically set to `√cutoff`. This field tracks the original cutoff
-    /// value for inspection; `rtol` is always the authoritative tolerance.
-    ///
-    /// If `None`, cutoff was not used.
-    pub cutoff: Option<f64>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ThresholdScale {
+    /// Compare against a singular-value-derived reference scale.
+    #[default]
+    Relative,
+    /// Compare directly against the configured threshold.
+    Absolute,
 }
 
-impl TruncationParams {
-    /// Create new truncation parameters with default values.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
+/// Singular-value-derived quantity used for truncation.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::SingularValueMeasure;
+///
+/// assert_eq!(SingularValueMeasure::default(), SingularValueMeasure::Value);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SingularValueMeasure {
+    /// Compare using singular values `σ_i`.
+    #[default]
+    Value,
+    /// Compare using squared singular values `σ_i²`.
+    SquaredValue,
+}
 
-    /// Set the relative tolerance.
-    ///
-    /// Clears any previously set cutoff origin.
-    #[must_use]
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.rtol = Some(rtol);
-        self.cutoff = None;
-        self
-    }
+/// Rule used to map singular values to a retained rank.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::TruncationRule;
+///
+/// assert_eq!(TruncationRule::default(), TruncationRule::PerValue);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TruncationRule {
+    /// Keep values whose individual measure exceeds the threshold rule.
+    #[default]
+    PerValue,
+    /// Discard a suffix while the cumulative discarded measure stays below
+    /// the threshold rule.
+    DiscardedTailSum,
+}
 
-    /// Set the maximum rank.
-    #[must_use]
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
-        self
-    }
+/// Explicit truncation policy for SVD-based decompositions.
+///
+/// Use this type when you need to describe how singular values are measured,
+/// scaled, and turned into a retained rank. [`SvdOptions`](crate::SvdOptions)
+/// carries this policy plus an independent `max_rank` cap.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{
+///     SingularValueMeasure, SvdTruncationPolicy, ThresholdScale, TruncationRule,
+/// };
+///
+/// let policy = SvdTruncationPolicy::new(1e-12);
+/// assert_eq!(policy.scale, ThresholdScale::Relative);
+/// assert_eq!(policy.measure, SingularValueMeasure::Value);
+/// assert_eq!(policy.rule, TruncationRule::PerValue);
+///
+/// let tail_policy = SvdTruncationPolicy::new(1e-8)
+///     .with_absolute()
+///     .with_squared_values()
+///     .with_discarded_tail_sum();
+/// assert_eq!(tail_policy.scale, ThresholdScale::Absolute);
+/// assert_eq!(tail_policy.measure, SingularValueMeasure::SquaredValue);
+/// assert_eq!(tail_policy.rule, TruncationRule::DiscardedTailSum);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SvdTruncationPolicy {
+    /// Threshold value used by the selected scale/rule combination.
+    pub threshold: f64,
+    /// Whether the threshold is interpreted relatively or absolutely.
+    pub scale: ThresholdScale,
+    /// Whether the policy measures singular values or squared singular values.
+    pub measure: SingularValueMeasure,
+    /// Whether truncation is per value or based on a discarded tail sum.
+    pub rule: TruncationRule,
+}
 
-    /// Set cutoff (ITensorMPS.jl convention).
-    ///
-    /// Internally converted to `rtol = √cutoff`. Clears any previously set
-    /// `rtol` origin so `cutoff` becomes the authoritative tolerance source.
+impl SvdTruncationPolicy {
+    /// Create a policy with the default semantics:
+    /// relative threshold, singular values, and per-value truncation.
     #[must_use]
-    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
-        self.cutoff = Some(cutoff);
-        self.rtol = Some(cutoff.sqrt());
-        self
-    }
-
-    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
-    ///
-    /// This is provided for ITensorMPS.jl compatibility.
-    #[must_use]
-    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
-        self.max_rank = Some(maxdim);
-        self
-    }
-
-    /// Get the effective rtol, using the provided default if not set.
-    #[must_use]
-    pub fn effective_rtol(&self, default: f64) -> f64 {
-        self.rtol.unwrap_or(default)
-    }
-
-    /// Get the effective max_rank, using usize::MAX if not set.
-    #[must_use]
-    pub fn effective_max_rank(&self) -> usize {
-        self.max_rank.unwrap_or(usize::MAX)
-    }
-
-    /// Merge with another set of parameters, preferring self's values.
-    #[must_use]
-    pub fn merge(&self, other: &Self) -> Self {
+    pub const fn new(threshold: f64) -> Self {
         Self {
-            rtol: self.rtol.or(other.rtol),
-            max_rank: self.max_rank.or(other.max_rank),
-            cutoff: self.cutoff.or(other.cutoff),
+            threshold,
+            scale: ThresholdScale::Relative,
+            measure: SingularValueMeasure::Value,
+            rule: TruncationRule::PerValue,
         }
     }
-}
 
-/// Trait for types that contain truncation parameters.
-///
-/// This trait provides a common interface for accessing and modifying
-/// truncation parameters in various options structs (e.g., [`SvdOptions`](crate::SvdOptions),
-/// [`QrOptions`](crate::QrOptions)).
-///
-/// # Examples
-///
-/// ```
-/// use tensor4all_core::svd::SvdOptions;
-/// use tensor4all_core::HasTruncationParams;
-///
-/// let opts = SvdOptions::with_rtol(1e-6).with_max_rank(20);
-/// assert_eq!(opts.rtol(), Some(1e-6));
-/// assert_eq!(opts.max_rank(), Some(20));
-/// ```
-pub trait HasTruncationParams {
-    /// Get a reference to the truncation parameters.
-    fn truncation_params(&self) -> &TruncationParams;
-
-    /// Get a mutable reference to the truncation parameters.
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams;
-
-    /// Get the rtol value.
-    fn rtol(&self) -> Option<f64> {
-        self.truncation_params().rtol
-    }
-
-    /// Get the max_rank value.
-    fn max_rank(&self) -> Option<usize> {
-        self.truncation_params().max_rank
-    }
-
-    /// Set the rtol value (builder pattern).
-    ///
-    /// Clears any previously set cutoff origin.
-    fn with_rtol(mut self, rtol: f64) -> Self
-    where
-        Self: Sized,
-    {
-        let p = self.truncation_params_mut();
-        p.rtol = Some(rtol);
-        p.cutoff = None;
+    /// Use relative threshold scaling.
+    #[must_use]
+    pub const fn with_relative(mut self) -> Self {
+        self.scale = ThresholdScale::Relative;
         self
     }
 
-    /// Set the max_rank value (builder pattern).
-    fn with_max_rank(mut self, max_rank: usize) -> Self
-    where
-        Self: Sized,
-    {
-        self.truncation_params_mut().max_rank = Some(max_rank);
+    /// Use absolute threshold scaling.
+    #[must_use]
+    pub const fn with_absolute(mut self) -> Self {
+        self.scale = ThresholdScale::Absolute;
         self
     }
 
-    /// Set cutoff (ITensorMPS.jl convention, builder pattern).
-    ///
-    /// Internally converted to `rtol = √cutoff`.
-    fn with_cutoff(mut self, cutoff: f64) -> Self
-    where
-        Self: Sized,
-    {
-        let p = self.truncation_params_mut();
-        p.cutoff = Some(cutoff);
-        p.rtol = Some(cutoff.sqrt());
+    /// Measure singular values directly.
+    #[must_use]
+    pub const fn with_values(mut self) -> Self {
+        self.measure = SingularValueMeasure::Value;
         self
     }
 
-    /// Set maxdim (alias for max_rank, builder pattern).
-    fn with_maxdim(mut self, maxdim: usize) -> Self
-    where
-        Self: Sized,
-    {
-        self.truncation_params_mut().max_rank = Some(maxdim);
+    /// Measure squared singular values.
+    #[must_use]
+    pub const fn with_squared_values(mut self) -> Self {
+        self.measure = SingularValueMeasure::SquaredValue;
         self
     }
 
-    /// Set cutoff via mutable reference.
-    fn set_cutoff(&mut self, cutoff: f64) {
-        let p = self.truncation_params_mut();
-        p.cutoff = Some(cutoff);
-        p.rtol = Some(cutoff.sqrt());
+    /// Apply the threshold independently to each singular value.
+    #[must_use]
+    pub const fn with_per_value(mut self) -> Self {
+        self.rule = TruncationRule::PerValue;
+        self
     }
 
-    /// Set maxdim via mutable reference (alias for max_rank).
-    fn set_maxdim(&mut self, maxdim: usize) {
-        self.truncation_params_mut().max_rank = Some(maxdim);
+    /// Apply the threshold to the cumulative discarded tail.
+    #[must_use]
+    pub const fn with_discarded_tail_sum(mut self) -> Self {
+        self.rule = TruncationRule::DiscardedTailSum;
+        self
     }
 }
 
-// Implement HasTruncationParams for TruncationParams itself
-impl HasTruncationParams for TruncationParams {
-    fn truncation_params(&self) -> &TruncationParams {
-        self
-    }
+/// Error for invalid SVD truncation thresholds.
+#[derive(Debug, Error, Clone, Copy, PartialEq)]
+#[error("Invalid SVD truncation threshold: {0}. Threshold must be finite and non-negative.")]
+pub struct InvalidThresholdError(pub f64);
 
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        self
+/// Validate one threshold value.
+pub(crate) fn validate_threshold_value(threshold: f64) -> Result<(), InvalidThresholdError> {
+    if !threshold.is_finite() || threshold < 0.0 {
+        return Err(InvalidThresholdError(threshold));
     }
+    Ok(())
+}
+
+/// Validate one full SVD truncation policy.
+pub(crate) fn validate_svd_truncation_policy(
+    policy: SvdTruncationPolicy,
+) -> Result<(), InvalidThresholdError> {
+    validate_threshold_value(policy.threshold)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-core/src/truncation/tests/mod.rs
+++ b/crates/tensor4all-core/src/truncation/tests/mod.rs
@@ -1,41 +1,23 @@
 use super::*;
 
-/// A wrapper struct to test HasTruncationParams trait default methods.
-/// TruncationParams itself has inherent methods that shadow the trait defaults,
-/// so we need a separate type to exercise the trait default implementations.
-#[derive(Debug, Default)]
-struct TestOptions {
-    truncation: TruncationParams,
-    _extra: i32,
-}
-
-impl HasTruncationParams for TestOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
-    }
+#[test]
+fn test_svd_truncation_policy_defaults() {
+    let policy = SvdTruncationPolicy::new(1e-12);
+    assert_eq!(policy.threshold, 1e-12);
+    assert_eq!(policy.scale, ThresholdScale::Relative);
+    assert_eq!(policy.measure, SingularValueMeasure::Value);
+    assert_eq!(policy.rule, TruncationRule::PerValue);
 }
 
 #[test]
-fn test_truncation_params_builder() {
-    let params = TruncationParams::new().with_rtol(1e-10).with_max_rank(50);
-
-    assert_eq!(params.rtol, Some(1e-10));
-    assert_eq!(params.max_rank, Some(50));
-}
-
-#[test]
-fn test_effective_values() {
-    let params = TruncationParams::new();
-    assert_eq!(params.effective_rtol(1e-12), 1e-12);
-    assert_eq!(params.effective_max_rank(), usize::MAX);
-
-    let params = params.with_rtol(1e-8).with_max_rank(100);
-    assert_eq!(params.effective_rtol(1e-12), 1e-8);
-    assert_eq!(params.effective_max_rank(), 100);
+fn test_svd_truncation_policy_builders() {
+    let policy = SvdTruncationPolicy::new(1e-8)
+        .with_absolute()
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    assert_eq!(policy.scale, ThresholdScale::Absolute);
+    assert_eq!(policy.measure, SingularValueMeasure::SquaredValue);
+    assert_eq!(policy.rule, TruncationRule::DiscardedTailSum);
 }
 
 #[test]
@@ -57,105 +39,4 @@ fn test_decomposition_alg() {
 fn test_decomposition_alg_default() {
     let alg: DecompositionAlg = Default::default();
     assert_eq!(alg, DecompositionAlg::SVD);
-}
-
-#[test]
-fn test_truncation_params_merge() {
-    let params1 = TruncationParams::new().with_rtol(1e-10);
-    let params2 = TruncationParams::new().with_max_rank(50);
-    let merged = params1.merge(&params2);
-
-    assert_eq!(merged.rtol, Some(1e-10));
-    assert_eq!(merged.max_rank, Some(50));
-
-    // Self values take precedence
-    let params3 = TruncationParams::new().with_rtol(1e-8).with_max_rank(100);
-    let merged2 = params3.merge(&params2);
-    assert_eq!(merged2.rtol, Some(1e-8));
-    assert_eq!(merged2.max_rank, Some(100));
-}
-
-#[test]
-fn test_has_truncation_params_trait() {
-    let mut params = TruncationParams::new();
-
-    // Test trait methods
-    assert_eq!(params.rtol(), None);
-    assert_eq!(params.max_rank(), None);
-
-    // Test mutable access
-    params.truncation_params_mut().rtol = Some(1e-6);
-    assert_eq!(params.truncation_params().rtol, Some(1e-6));
-}
-
-#[test]
-fn test_with_cutoff() {
-    let params = TruncationParams::new().with_cutoff(1e-10);
-    assert_eq!(params.cutoff, Some(1e-10));
-    assert!((params.rtol.unwrap() - 1e-5).abs() < 1e-15);
-}
-
-#[test]
-fn test_with_maxdim() {
-    let params = TruncationParams::new().with_maxdim(50);
-    assert_eq!(params.max_rank, Some(50));
-}
-
-#[test]
-fn test_cutoff_rtol_priority_last_wins() {
-    // cutoff then rtol: rtol wins, cutoff cleared
-    let params = TruncationParams::new().with_cutoff(1e-10).with_rtol(1e-3);
-    assert_eq!(params.rtol, Some(1e-3));
-    assert_eq!(params.cutoff, None);
-
-    // rtol then cutoff: cutoff wins
-    let params = TruncationParams::new().with_rtol(1e-3).with_cutoff(1e-10);
-    assert_eq!(params.cutoff, Some(1e-10));
-    assert!((params.rtol.unwrap() - 1e-5).abs() < 1e-15);
-}
-
-#[test]
-fn test_has_truncation_params_cutoff() {
-    let mut params = TruncationParams::new();
-    params.set_cutoff(1e-8);
-    assert_eq!(params.cutoff, Some(1e-8));
-    assert!((params.rtol.unwrap() - 1e-4).abs() < 1e-15);
-
-    params.set_maxdim(100);
-    assert_eq!(params.max_rank, Some(100));
-}
-
-#[test]
-fn test_trait_default_with_rtol() {
-    // Exercise HasTruncationParams::with_rtol default implementation (lines 171-179)
-    let opts = TestOptions::default().with_rtol(1e-6);
-    assert_eq!(opts.truncation.rtol, Some(1e-6));
-    assert_eq!(opts.truncation.cutoff, None);
-
-    // Verify cutoff is cleared when rtol is set after cutoff
-    let opts = TestOptions::default().with_cutoff(1e-10).with_rtol(1e-3);
-    assert_eq!(opts.truncation.rtol, Some(1e-3));
-    assert_eq!(opts.truncation.cutoff, None);
-}
-
-#[test]
-fn test_trait_default_with_max_rank() {
-    // Exercise HasTruncationParams::with_max_rank default implementation (lines 182-188)
-    let opts = TestOptions::default().with_max_rank(42);
-    assert_eq!(opts.truncation.max_rank, Some(42));
-}
-
-#[test]
-fn test_trait_default_with_cutoff() {
-    // Exercise HasTruncationParams::with_cutoff default implementation (lines 193-201)
-    let opts = TestOptions::default().with_cutoff(1e-10);
-    assert_eq!(opts.truncation.cutoff, Some(1e-10));
-    assert!((opts.truncation.rtol.unwrap() - 1e-5).abs() < 1e-15);
-}
-
-#[test]
-fn test_trait_default_with_maxdim() {
-    // Exercise HasTruncationParams::with_maxdim default implementation (lines 204-210)
-    let opts = TestOptions::default().with_maxdim(200);
-    assert_eq!(opts.truncation.max_rank, Some(200));
 }

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -4,7 +4,7 @@ use tensor4all_core::index::Index;
 use tensor4all_core::{
     factorize, Canonical, DynIndex, FactorizeAlg, FactorizeError, FactorizeOptions,
 };
-use tensor4all_core::{TensorDynLen, TensorLike};
+use tensor4all_core::{SvdTruncationPolicy, TensorDynLen, TensorLike};
 
 // ============================================================================
 // Test Data Helpers
@@ -103,8 +103,9 @@ fn test_factorize_reconstruction_all_algorithms() {
             let options = FactorizeOptions {
                 alg,
                 canonical,
-                rtol: None,
                 max_rank: None,
+                svd_policy: None,
+                qr_rtol: None,
             };
             test_factorize_reconstruction(&options);
         }
@@ -125,8 +126,9 @@ fn test_factorize_shared_bond_index_all_algorithms() {
         let options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            rtol: None,
             max_rank: None,
+            svd_policy: None,
+            qr_rtol: None,
         };
         test_shared_bond_index(&options);
     }
@@ -205,8 +207,9 @@ fn test_factorize_lu_ci_no_singular_values() {
             let options = FactorizeOptions {
                 alg,
                 canonical,
-                rtol: None,
                 max_rank: None,
+                svd_policy: None,
+                qr_rtol: None,
             };
             let result = factorize(&tensor, &left_inds, &options).unwrap();
 
@@ -224,8 +227,9 @@ fn test_factorize_lu_ci_reconstruction_with_unit_dim_axis() {
         let options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            rtol: None,
             max_rank: None,
+            svd_policy: None,
+            qr_rtol: None,
         };
         let result = factorize(&tensor, &left_inds, &options).unwrap();
         let reconstructed = result.left.contract(&result.right);
@@ -242,8 +246,9 @@ fn test_factorize_lu_ci_reconstruction_with_col_major_matrix_input() {
         let options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            rtol: None,
             max_rank: None,
+            svd_policy: None,
+            qr_rtol: None,
         };
         let result = factorize(&tensor, &left_inds, &options).unwrap();
         let reconstructed = result.left.contract(&result.right);
@@ -269,6 +274,36 @@ fn test_factorize_with_max_rank() {
     let options = FactorizeOptions::svd().with_max_rank(1);
     let result = factorize(&tensor, &left_inds, &options).unwrap();
     assert!(result.rank >= 1);
+}
+
+#[test]
+fn test_factorize_rejects_mixed_algorithm_options() {
+    let tensor = create_test_matrix();
+    let left_inds = vec![tensor.indices[0].clone()];
+
+    let svd_with_qr = FactorizeOptions::svd().with_qr_rtol(1.0e-8);
+    assert!(matches!(
+        factorize(&tensor, &left_inds, &svd_with_qr),
+        Err(FactorizeError::InvalidOptions(_))
+    ));
+
+    let qr_with_svd = FactorizeOptions::qr().with_svd_policy(SvdTruncationPolicy::new(1.0e-8));
+    assert!(matches!(
+        factorize(&tensor, &left_inds, &qr_with_svd),
+        Err(FactorizeError::InvalidOptions(_))
+    ));
+
+    for options in [
+        FactorizeOptions::lu().with_qr_rtol(1.0e-8),
+        FactorizeOptions::lu().with_svd_policy(SvdTruncationPolicy::new(1.0e-8)),
+        FactorizeOptions::ci().with_qr_rtol(1.0e-8),
+        FactorizeOptions::ci().with_svd_policy(SvdTruncationPolicy::new(1.0e-8)),
+    ] {
+        assert!(matches!(
+            factorize(&tensor, &left_inds, &options),
+            Err(FactorizeError::InvalidOptions(_))
+        ));
+    }
 }
 
 // ============================================================================

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -1,6 +1,9 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::{default_svd_rtol, set_default_svd_rtol, svd, svd_with, SvdOptions};
+use tensor4all_core::{
+    default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdOptions,
+    SvdTruncationPolicy,
+};
 use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
 
 fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
@@ -294,7 +297,7 @@ fn test_svd_truncation() {
     let tensor = dense_f64(vec![i.clone(), j.clone()], data);
 
     // Use a more lenient rtol to ensure truncation happens
-    let options = SvdOptions::with_rtol(1e-10);
+    let options = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
     let (u, s, v) =
         svd_with::<f64>(&tensor, std::slice::from_ref(&i), &options).expect("SVD should succeed");
 
@@ -318,8 +321,8 @@ fn test_svd_truncation() {
 }
 
 #[test]
-fn test_svd_with_override() {
-    // Test that svd_with can override the global default rtol
+fn test_svd_with_policy_override() {
+    // Test that svd_with can override the global default truncation policy
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
 
@@ -332,15 +335,15 @@ fn test_svd_with_override() {
     let tensor = dense_f64(vec![i.clone(), j.clone()], data);
 
     // Save original default
-    let original_rtol = default_svd_rtol();
+    let original_policy = default_svd_truncation_policy();
 
-    // Test with lenient rtol (should truncate)
-    let lenient_options = SvdOptions::with_rtol(1e-4);
+    // Test with lenient threshold (should truncate)
+    let lenient_options = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-4));
     let (u1, s1, _v1) = svd_with::<f64>(&tensor, std::slice::from_ref(&i), &lenient_options)
         .expect("SVD should succeed");
 
-    // Test with strict rtol (should not truncate)
-    let strict_options = SvdOptions::with_rtol(1e-12);
+    // Test with strict threshold (should not truncate)
+    let strict_options = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-12));
     let (u2, s2, _v2) = svd_with::<f64>(&tensor, std::slice::from_ref(&i), &strict_options)
         .expect("SVD should succeed");
 
@@ -361,59 +364,41 @@ fn test_svd_with_override() {
     assert_eq!(s2_dims[0], 2, "Strict rtol should keep full rank");
 
     // Restore original default
-    set_default_svd_rtol(original_rtol).expect("Should restore original rtol");
+    set_default_svd_truncation_policy(original_policy).expect("Should restore original policy");
 }
 
 #[test]
-fn test_default_svd_rtol() {
-    // Test global default rtol getter and setter
-    // Note: Other tests may have changed the global default, so we restore it first
-    let original_rtol = default_svd_rtol();
+fn test_default_svd_truncation_policy() {
+    let original_policy = default_svd_truncation_policy();
 
-    // Restore to expected default (1e-12) for this test
-    set_default_svd_rtol(1e-12).expect("Should set default rtol");
-    let current_rtol = default_svd_rtol();
+    let expected_default = SvdTruncationPolicy::new(1e-12);
+    set_default_svd_truncation_policy(expected_default).expect("Should set default policy");
+    assert_eq!(default_svd_truncation_policy(), expected_default);
 
-    // Default should be 1e-12
+    let new_policy = SvdTruncationPolicy::new(1e-8).with_absolute();
+    set_default_svd_truncation_policy(new_policy).expect("Should set policy");
+    assert_eq!(default_svd_truncation_policy(), new_policy);
+
     assert!(
-        (current_rtol - 1e-12).abs() < 1e-15,
-        "Default rtol should be 1e-12, got {}",
-        current_rtol
-    );
-
-    // Test setting a new value
-    let new_rtol = 1e-8;
-    set_default_svd_rtol(new_rtol).expect("Should set rtol");
-    assert!(
-        (default_svd_rtol() - new_rtol).abs() < 1e-15,
-        "Should retrieve the set rtol value"
-    );
-
-    // Test invalid values
-    assert!(
-        set_default_svd_rtol(-1.0).is_err(),
-        "Negative rtol should be rejected"
+        set_default_svd_truncation_policy(SvdTruncationPolicy::new(-1.0)).is_err(),
+        "Negative threshold should be rejected"
     );
     assert!(
-        set_default_svd_rtol(f64::NAN).is_err(),
-        "NaN rtol should be rejected"
+        set_default_svd_truncation_policy(SvdTruncationPolicy::new(f64::NAN)).is_err(),
+        "NaN threshold should be rejected"
     );
     assert!(
-        set_default_svd_rtol(f64::INFINITY).is_err(),
-        "Infinite rtol should be rejected"
+        set_default_svd_truncation_policy(SvdTruncationPolicy::new(f64::INFINITY)).is_err(),
+        "Infinite threshold should be rejected"
     );
 
-    // Restore original
-    set_default_svd_rtol(original_rtol).expect("Should restore original rtol");
-    assert!(
-        (default_svd_rtol() - original_rtol).abs() < 1e-15,
-        "Should restore original rtol"
-    );
+    set_default_svd_truncation_policy(original_policy).expect("Should restore original policy");
+    assert_eq!(default_svd_truncation_policy(), original_policy);
 }
 
 #[test]
 fn test_svd_uses_global_default() {
-    // Test that svd() uses the global default rtol
+    // Test that svd() uses the global default truncation policy
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
 
@@ -422,22 +407,22 @@ fn test_svd_uses_global_default() {
     let tensor = dense_f64(vec![i.clone(), j.clone()], data);
 
     // Save original default
-    let original_rtol = default_svd_rtol();
+    let original_policy = default_svd_truncation_policy();
 
     // Change global default
-    set_default_svd_rtol(1e-6).expect("Should set rtol");
+    set_default_svd_truncation_policy(SvdTruncationPolicy::new(1e-6)).expect("Should set policy");
 
     // svd() should use the new global default
     let (u, s, _v) = svd::<f64>(&tensor, std::slice::from_ref(&i)).expect("SVD should succeed");
 
-    // With rtol=1e-6, identity matrix should keep full rank (both singular values are 1.0)
+    // With threshold=1e-6, identity matrix should keep full rank (both singular values are 1.0)
     let u_dims = u.dims();
     let s_dims = s.dims();
     assert_eq!(u_dims[1], 2, "Identity matrix should keep full rank");
     assert_eq!(s_dims[0], 2, "Identity matrix should keep full rank");
 
     // Restore original
-    set_default_svd_rtol(original_rtol).expect("Should restore original rtol");
+    set_default_svd_truncation_policy(original_policy).expect("Should restore original policy");
 }
 
 /// Helper: compute SVD reconstruction error for a given tensor and split.

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -6,7 +6,7 @@ ITensors.jl-inspired TensorTrain API with orthogonality tracking and multiple ca
 
 - `TensorTrain` — tensor train with orthogonality center tracking
 - `orthogonalize()` — move orthogonality center to a given site
-- `truncate()` — bond dimension truncation (SVD, LU, or CI)
+- `truncate()` — SVD-based bond dimension truncation
 - `inner()` — inner product `<self|other>` with complex conjugation on `self`
 - `norm()` — efficient norm via the orthogonality center
 
@@ -30,7 +30,7 @@ let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![1.0, 0.0, 0.0, 1.0])?;
 
 let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 tt.orthogonalize(1)?;
-tt.truncate(&TruncateOptions::svd().with_rtol(1e-10).with_max_rank(2))?;
+tt.truncate(&TruncateOptions::svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10)).with_max_rank(2))?;
 
 assert!(tt.isortho());
 let norm = tt.norm();

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
@@ -141,7 +141,7 @@ fn main() -> Result<()> {
     println!(
         "Options: method=Zipup, max_rank={}, rtol={:?}",
         max_rank,
-        options.rtol()
+        options.svd_policy().map(|policy| policy.threshold)
     );
     println!("Note: Each run copies MPOs and includes orthogonalization time");
     println!();

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
@@ -151,7 +151,7 @@ fn main() -> Result<()> {
         "Options: method=Fit, max_rank={}, nhalfsweeps={}, rtol={:?}",
         max_rank,
         n_half_sweeps,
-        options.rtol()
+        options.svd_policy().map(|policy| policy.threshold)
     );
     println!("Note: Each run copies MPOs and includes orthogonalization time");
     println!();

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
     println!(
         "Options: method=Zipup, max_rank={}, rtol={:?}",
         max_rank,
-        options.rtol()
+        options.svd_policy().map(|policy| policy.threshold)
     );
     println!();
 

--- a/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
+++ b/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
@@ -842,7 +842,9 @@ fn test_truncation_effect() -> anyhow::Result<()> {
     println!("r0 bond dims: {:?}", r0.bond_dims());
 
     // Apply truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     r0.truncate(&truncate_opts)?;
 
     println!("\n=== After truncation ===");
@@ -1227,7 +1229,9 @@ fn test_gmres_with_both(
 
     println!("\n--- GMRES WITH truncation ---");
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -1453,7 +1457,9 @@ fn apply_with_zipup(
     mpo: &TensorTrain,
     indices: &SharedIndices,
 ) -> anyhow::Result<TensorTrain> {
-    let options = ContractOptions::zipup().with_rtol(1e-10).with_max_rank(50);
+    let options = ContractOptions::zipup()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(50);
 
     let result = op
         .contract(mpo, &options)
@@ -1471,7 +1477,7 @@ fn apply_with_fit(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(50);
 
     let result = op
@@ -1490,10 +1496,12 @@ fn debug_contract_result(
 ) -> anyhow::Result<()> {
     println!("\n=== DEBUG: Contract result before replaceinds ===");
 
-    let options_zipup = ContractOptions::zipup().with_rtol(1e-10).with_max_rank(50);
+    let options_zipup = ContractOptions::zipup()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(50);
     let options_fit = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(50);
 
     let raw_zipup = op
@@ -1624,7 +1632,9 @@ fn debug_contract_result(
     let mut result_zipup_trunc = result_zipup.clone();
     let mut result_fit_trunc = result_fit.clone();
 
-    let trunc_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let trunc_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     result_zipup_trunc.truncate(&trunc_opts)?;
     result_fit_trunc.truncate(&trunc_opts)?;
 

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
@@ -474,7 +474,7 @@ fn apply_operator_for_block(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
     let result = op
         .contract(mpo, &options)
@@ -498,7 +498,7 @@ fn apply_cross_block_operator(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
     let result = op
         .contract(mpo, &options)
@@ -523,7 +523,7 @@ fn apply_cross_block_operator_full(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
     let result = op
         .contract(mpo, &options)
@@ -611,7 +611,9 @@ fn test_block_diagonal_identity() -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -706,7 +708,9 @@ fn test_block_diagonal_diagonal_operator() -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -845,7 +849,9 @@ fn test_block_upper_triangular() -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -932,7 +938,9 @@ fn test_restart_gmres_block_mpo() -> anyhow::Result<()> {
     println!("b = A * x_true computed, norm: {:.6}", b_norm);
 
     // Truncation with aggressive settings
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(10);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+        .with_max_rank(10);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -951,7 +959,10 @@ fn test_restart_gmres_block_mpo() -> anyhow::Result<()> {
     println!("\nRunning Restart GMRES...");
     println!(
         "Truncation: rtol={:.0e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
 
@@ -1091,7 +1102,9 @@ fn test_block_offdiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1247,7 +1260,9 @@ fn test_3x3_block_antidiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1369,7 +1384,9 @@ fn scaling_2x2_offdiagonal_mpo(n_sites: usize) -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1507,7 +1524,9 @@ fn scaling_3x3_antidiagonal_mpo(n_sites: usize) -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
@@ -430,7 +430,7 @@ fn apply_mpo_for_block(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
     let result = mpo
         .contract(mps, &options)
@@ -451,7 +451,7 @@ fn apply_cross_block_mpo(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
     let result = mpo
         .contract(mps, &options)
@@ -536,7 +536,9 @@ fn test_block_diagonal_identity() -> anyhow::Result<()> {
     };
 
     // Truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -633,7 +635,9 @@ fn test_block_diagonal_diagonal_mpo() -> anyhow::Result<()> {
     };
 
     // Truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -753,7 +757,9 @@ fn test_block_upper_triangular() -> anyhow::Result<()> {
     };
 
     // Truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -840,7 +846,9 @@ fn test_restart_gmres_block_mps() -> anyhow::Result<()> {
     println!("b = A * x_true computed, norm: {:.6}", b_norm);
 
     // Truncation with aggressive settings
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(10);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+        .with_max_rank(10);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -859,7 +867,10 @@ fn test_restart_gmres_block_mps() -> anyhow::Result<()> {
     println!("\nRunning Restart GMRES...");
     println!(
         "Truncation: rtol={:.0e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
 
@@ -973,7 +984,9 @@ fn test_block_offdiagonal_complex_pauli_x() -> anyhow::Result<()> {
     };
 
     // Truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1089,7 +1102,9 @@ fn test_3x3_block_antidiagonal_complex_pauli_x() -> anyhow::Result<()> {
     };
 
     // Truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1187,7 +1202,9 @@ fn scaling_offdiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1286,7 +1303,9 @@ fn scaling_3x3_antidiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };

--- a/crates/tensor4all-itensorlike/examples/test_gmres_identity_high_bonddim.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_identity_high_bonddim.rs
@@ -73,7 +73,9 @@ fn run_identity_gmres(b: &TensorTrain, max_outer_iters: usize) -> Result<(bool, 
 
     let apply_identity = |x: &TensorTrain| -> Result<TensorTrain> { Ok(x.clone()) };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(100);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(100);
     let truncate_fn = |x: &mut TensorTrain| -> Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
@@ -224,7 +224,9 @@ fn test_gmres_mpo_identity(n: usize) -> anyhow::Result<(f64, f64, usize)> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -317,7 +319,9 @@ fn test_gmres_mpo_pauli(n: usize) -> anyhow::Result<(f64, f64, usize)> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -403,7 +407,9 @@ fn test_gmres_mpo_imaginary(n: usize) -> anyhow::Result<(f64, f64, usize)> {
         check_true_residual: false,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -496,7 +502,9 @@ fn test_gmres_mpo_random(n: usize, max_iter: usize) -> anyhow::Result<(f64, f64,
         check_true_residual: true,
     };
 
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(50);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(50);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -739,7 +747,7 @@ fn apply_operator_to_mpo(
     // Contract operator with MPO using fit method
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(50);
 
     let result = op

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
@@ -235,7 +235,9 @@ fn test_gmres_mps(n: usize, operator: &str) -> anyhow::Result<(f64, f64, usize)>
     };
 
     // Truncation options: control bond dimension growth
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -248,7 +250,10 @@ fn test_gmres_mps(n: usize, operator: &str) -> anyhow::Result<(f64, f64, usize)>
     println!("rtol = {:.2e}", options.rtol);
     println!(
         "truncation: rtol={:.2e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
     let result = gmres_with_truncation(&apply_a, &b, &x0, &options, truncate_fn)?;
@@ -386,7 +391,7 @@ fn apply_mpo(
     // Use consistent truncation: rtol=1e-10, max_rank=20
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-8)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
         .with_max_rank(20);
     let result = mpo
         .contract(mps, &options)
@@ -506,7 +511,9 @@ fn test_gmres_mps_imaginary(n: usize, max_iter: usize) -> anyhow::Result<(f64, f
     };
 
     // Truncation options: control bond dimension growth
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(20);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -519,7 +526,10 @@ fn test_gmres_mps_imaginary(n: usize, max_iter: usize) -> anyhow::Result<(f64, f
     println!("rtol = {:.2e}", options.rtol);
     println!(
         "truncation: rtol={:.2e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
     let result = gmres_with_truncation(&apply_a, &b, &x0, &options, truncate_fn)?;
@@ -769,7 +779,9 @@ fn test_gmres_mps_random(n: usize, max_iter: usize) -> anyhow::Result<(f64, f64,
     };
 
     // Truncation options: control bond dimension growth
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-8).with_max_rank(50);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
+        .with_max_rank(50);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -782,7 +794,10 @@ fn test_gmres_mps_random(n: usize, max_iter: usize) -> anyhow::Result<(f64, f64,
     println!("rtol = {:.2e}", options.rtol);
     println!(
         "truncation: rtol={:.2e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
     let result = gmres_with_truncation(&apply_a, &b, &x0, &options, truncate_fn)?;

--- a/crates/tensor4all-itensorlike/examples/test_restart_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_restart_gmres_mpo.rs
@@ -142,7 +142,9 @@ fn test_restart_gmres_mpo(n: usize, operator: &str) -> anyhow::Result<(bool, usi
     println!("b = A(x_true), norm: {:.6}", b_norm);
 
     // Truncation options
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -210,7 +212,9 @@ fn test_restart_gmres_mpo_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
     println!("b = A(x_true), norm: {:.6}", b_norm);
 
     // AGGRESSIVE truncation to make the problem harder
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(5);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+        .with_max_rank(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -218,7 +222,10 @@ fn test_restart_gmres_mpo_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
 
     println!(
         "Truncation: rtol={:.0e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
 
@@ -290,7 +297,9 @@ fn test_restart_gmres_mpo_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, 
     println!("b = A(x_true), norm: {:.6}", b_norm);
 
     // Aggressive truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(5);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+        .with_max_rank(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -298,7 +307,10 @@ fn test_restart_gmres_mpo_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, 
 
     println!(
         "Truncation: rtol={:.0e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
 
@@ -500,7 +512,7 @@ fn apply_operator_to_mpo(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
 
     let result = op

--- a/crates/tensor4all-itensorlike/examples/test_restart_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_restart_gmres_mps.rs
@@ -141,7 +141,9 @@ fn test_restart_gmres(n: usize, operator: &str) -> anyhow::Result<(bool, usize, 
     println!("b = A * x_true, norm: {:.6}", b_norm);
 
     // Truncation options
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(30);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(30);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -257,7 +259,9 @@ fn test_restart_gmres_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
     println!("b = A * x_true, norm: {:.6}", b_norm);
 
     // AGGRESSIVE truncation to make the problem harder
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(5);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+        .with_max_rank(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -269,7 +273,10 @@ fn test_restart_gmres_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
     println!("Initial residual (x0=0): {:.6e}", initial_residual);
     println!(
         "Truncation: rtol={:.0e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
 
@@ -336,7 +343,9 @@ fn test_restart_gmres_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, usiz
     println!("b = A * x_true, norm: {:.6}", b_norm);
 
     // Aggressive truncation
-    let truncate_opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(5);
+    let truncate_opts = TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+        .with_max_rank(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -346,7 +355,10 @@ fn test_restart_gmres_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, usiz
 
     println!(
         "Truncation: rtol={:.0e}, max_rank={}",
-        truncate_opts.rtol().unwrap_or(0.0),
+        truncate_opts
+            .svd_policy()
+            .map(|policy| policy.threshold)
+            .unwrap_or(0.0),
         truncate_opts.max_rank().unwrap_or(0)
     );
 
@@ -530,7 +542,7 @@ fn apply_mpo(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
-        .with_rtol(1e-10)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
         .with_max_rank(30);
     let result = mpo
         .contract(mps, &options)

--- a/crates/tensor4all-itensorlike/src/contract.rs
+++ b/crates/tensor4all-itensorlike/src/contract.rs
@@ -9,9 +9,8 @@ use tensor4all_treetn::treetn::contraction::{
 use tensor4all_treetn::CanonicalForm;
 
 use crate::error::{Result, TensorTrainError};
-use crate::options::{validate_truncation_params, ContractMethod, ContractOptions};
+use crate::options::{validate_svd_truncation_options, ContractMethod, ContractOptions};
 use crate::tensortrain::TensorTrain;
-use tensor4all_core::truncation::HasTruncationParams;
 
 /// Contract two tensor trains, returning a new tensor train.
 ///
@@ -52,7 +51,7 @@ pub fn contract(
         });
     }
 
-    validate_truncation_params(options.truncation_params())?;
+    validate_svd_truncation_options(options.max_rank(), options.svd_policy())?;
 
     if matches!(options.method(), ContractMethod::Fit) && !options.nhalfsweeps().is_multiple_of(2) {
         return Err(TensorTrainError::OperationError {
@@ -80,14 +79,8 @@ pub fn contract(
         treetn_options
     };
 
-    let fit_normalized_rtol = if matches!(options.method(), ContractMethod::Fit) {
-        Some(options.rtol().unwrap_or(0.0))
-    } else {
-        options.rtol()
-    };
-
-    let treetn_options = if let Some(rtol) = fit_normalized_rtol {
-        treetn_options.with_rtol(rtol)
+    let treetn_options = if let Some(policy) = options.svd_policy() {
+        treetn_options.with_svd_policy(policy)
     } else {
         treetn_options
     };
@@ -101,7 +94,7 @@ pub fn contract(
                 b.as_treetn(),
                 &center,
                 CanonicalForm::Unitary,
-                options.rtol(),
+                options.svd_policy(),
                 options.max_rank(),
             )
             .map_err(|e| TensorTrainError::InvalidStructure {

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -79,7 +79,8 @@ fn test_contract_free_fn_invalid_rtol() {
     let tt1 = TensorTrain::new(vec![t0.clone()]).unwrap();
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
-    let options = ContractOptions::zipup().with_rtol(-1.0);
+    let options =
+        ContractOptions::zipup().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(-1.0));
     let err = contract(&tt1, &tt2, &options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }
@@ -150,7 +151,8 @@ fn test_contract_zipup_with_rtol() {
     let t2_1 = make_tensor(vec![l01_b.clone(), s1.clone()]);
     let tt2 = TensorTrain::new(vec![t2_0, t2_1]).unwrap();
 
-    let options = ContractOptions::zipup().with_rtol(1e-10);
+    let options =
+        ContractOptions::zipup().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10));
     let result = contract(&tt1, &tt2, &options).unwrap();
     assert_eq!(result.len(), 1);
     assert_matches_naive(&tt1, &tt2, &result);
@@ -395,7 +397,8 @@ fn test_contract_free_fn_nan_rtol() {
     let tt1 = TensorTrain::new(vec![t0.clone()]).unwrap();
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
-    let options = ContractOptions::zipup().with_rtol(f64::NAN);
+    let options = ContractOptions::zipup()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(f64::NAN));
     let err = contract(&tt1, &tt2, &options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }
@@ -407,7 +410,8 @@ fn test_contract_free_fn_inf_rtol() {
     let tt1 = TensorTrain::new(vec![t0.clone()]).unwrap();
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
-    let options = ContractOptions::zipup().with_rtol(f64::INFINITY);
+    let options = ContractOptions::zipup()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(f64::INFINITY));
     let err = contract(&tt1, &tt2, &options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -11,7 +11,7 @@ pub use contract::contract;
 pub use error::{Result, TensorTrainError};
 pub use linsolve::linsolve;
 pub use options::{
-    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TruncateAlg, TruncateOptions,
+    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TruncateOptions,
 };
 pub use tensortrain::TensorTrain;
 

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -8,13 +8,12 @@
 
 use std::collections::HashMap;
 
-use tensor4all_core::truncation::HasTruncationParams;
 use tensor4all_core::{DynIndex, IndexLike};
 use tensor4all_treetn::{square_linsolve, IndexMapping, TruncationOptions};
 
 use crate::error::{Result, TensorTrainError};
-use crate::options::{validate_truncation_params, LinsolveOptions};
-use crate::tensortrain::{truncate_alg_to_form, TensorTrain};
+use crate::options::{validate_svd_truncation_options, CanonicalForm, LinsolveOptions};
+use crate::tensortrain::TensorTrain;
 
 /// Solve `(a₀ + a₁ * A) * x = b` for `x`.
 ///
@@ -53,7 +52,7 @@ pub fn linsolve(
         });
     }
 
-    validate_truncation_params(options.truncation_params())?;
+    validate_svd_truncation_options(options.max_rank(), options.svd_policy())?;
 
     if !options.krylov_tol().is_finite() || options.krylov_tol() <= 0.0 {
         return Err(TensorTrainError::OperationError {
@@ -85,18 +84,17 @@ pub fn linsolve(
     }
 
     // Convert LinsolveOptions → treetn::LinsolveOptions
-    let form = truncate_alg_to_form(options.alg());
     let nfullsweeps = options.nhalfsweeps() / 2;
 
     let treetn_options = tensor4all_treetn::LinsolveOptions::new(nfullsweeps)
-        .with_truncation(TruncationOptions::new().with_form(form))
+        .with_truncation(TruncationOptions::new())
         .with_krylov_tol(options.krylov_tol())
         .with_krylov_maxiter(options.krylov_maxiter())
         .with_krylov_dim(options.krylov_dim())
         .with_coefficients(options.coefficients().0, options.coefficients().1);
 
-    let treetn_options = if let Some(rtol) = options.rtol() {
-        treetn_options.with_rtol(rtol)
+    let treetn_options = if let Some(policy) = options.svd_policy() {
+        treetn_options.with_svd_policy(policy)
     } else {
         treetn_options
     };
@@ -138,7 +136,7 @@ pub fn linsolve(
         message: format!("Linsolve failed: {}", e),
     })?;
 
-    TensorTrain::from_inner(result.solution, Some(form))
+    TensorTrain::from_inner(result.solution, Some(CanonicalForm::Unitary))
 }
 
 type SiteMappings = (

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -1,34 +1,30 @@
 //! Configuration options for tensor train operations.
 
 use std::ops::Range;
-use tensor4all_core::truncation::{HasTruncationParams, TruncationParams};
+
+use tensor4all_core::SvdTruncationPolicy;
 
 use crate::error::{Result, TensorTrainError};
 
-// Re-export CanonicalForm from treetn for convenience
+// Re-export CanonicalForm from treetn for convenience.
 pub use tensor4all_treetn::algorithm::CanonicalForm;
 
-// Re-export DecompositionAlg for convenience
-pub use tensor4all_core::truncation::DecompositionAlg;
-
-pub(crate) fn validate_truncation_params(p: &TruncationParams) -> Result<()> {
-    if let Some(cutoff) = p.cutoff {
-        if !cutoff.is_finite() || cutoff < 0.0 {
+pub(crate) fn validate_svd_truncation_options(
+    max_rank: Option<usize>,
+    svd_policy: Option<SvdTruncationPolicy>,
+) -> Result<()> {
+    if let Some(policy) = svd_policy {
+        if !policy.threshold.is_finite() || policy.threshold < 0.0 {
             return Err(TensorTrainError::OperationError {
-                message: format!("cutoff must be finite and >= 0, got {}", cutoff),
+                message: format!(
+                    "svd_policy.threshold must be finite and >= 0, got {}",
+                    policy.threshold
+                ),
             });
         }
     }
 
-    if let Some(rtol) = p.rtol {
-        if !rtol.is_finite() || rtol < 0.0 {
-            return Err(TensorTrainError::OperationError {
-                message: format!("rtol must be finite and >= 0, got {}", rtol),
-            });
-        }
-    }
-
-    if let Some(max_rank) = p.max_rank {
+    if let Some(max_rank) = max_rank {
         if max_rank == 0 {
             return Err(TensorTrainError::OperationError {
                 message: "max_rank/maxdim must be >= 1".to_string(),
@@ -39,170 +35,75 @@ pub(crate) fn validate_truncation_params(p: &TruncationParams) -> Result<()> {
     Ok(())
 }
 
-/// Truncation algorithm.
-///
-/// This specifies which algorithm to use for truncating bond dimensions.
-/// This is an alias for [`DecompositionAlg`] for backwards compatibility.
-pub type TruncateAlg = DecompositionAlg;
-
 /// Options for tensor train truncation.
 ///
-/// Inspired by ITensorMPS.jl's truncation interface, but using tensor4all-rs
-/// naming conventions (`rtol` instead of `cutoff`, `max_rank` instead of `maxdim`).
+/// Truncation is explicitly SVD-based. Canonicalization remains the API for
+/// LU/CI-style forms; truncate itself only accepts SVD truncation controls.
 ///
-/// # Difference from ITensorMPS.jl
-///
-/// This crate uses **relative tolerance** (`rtol`) semantics:
-/// - Singular values are truncated when `σ_i / σ_max < rtol`
-///
-/// ITensorMPS.jl uses **cutoff** semantics:
-/// - Singular values are truncated when `σ_i² < cutoff`
-///
-/// **Conversion**: For normalized tensors (where `σ_max = 1`):
-/// - ITensorMPS.jl's `cutoff` = tensor4all-rs's `rtol²`
-/// - To match ITensorMPS.jl behavior: use `rtol = sqrt(cutoff)`
-/// - Example: ITensorMPS.jl `cutoff=1e-10` ↔ tensor4all-rs `rtol=1e-5`
-///
-/// # Example
+/// # Examples
 ///
 /// ```
+/// use tensor4all_core::SvdTruncationPolicy;
 /// use tensor4all_itensorlike::TruncateOptions;
 ///
-/// // SVD with relative tolerance
-/// let opts = TruncateOptions::svd().with_rtol(1e-10);
+/// let opts = TruncateOptions::svd()
+///     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
+///     .with_max_rank(20)
+///     .with_site_range(0..4);
 ///
-/// // LU with max rank
-/// let opts = TruncateOptions::lu().with_max_rank(50);
-///
-/// // CI with both constraints
-/// let opts = TruncateOptions::ci()
-///     .with_rtol(1e-8)
-///     .with_max_rank(100);
+/// assert_eq!(opts.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
+/// assert_eq!(opts.max_rank(), Some(20));
+/// assert_eq!(opts.site_range(), Some(0..4));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TruncateOptions {
-    /// Algorithm to use for truncation.
-    alg: TruncateAlg,
-
-    /// Truncation parameters (rtol, max_rank).
-    truncation: TruncationParams,
-
-    /// Range of sites to truncate (0-indexed, exclusive end).
-    ///
-    /// If `None`, all bonds are truncated.
+    max_rank: Option<usize>,
+    svd_policy: Option<SvdTruncationPolicy>,
     site_range: Option<Range<usize>>,
-}
-
-impl Default for TruncateOptions {
-    fn default() -> Self {
-        Self {
-            alg: TruncateAlg::SVD,
-            truncation: TruncationParams::default(),
-            site_range: None,
-        }
-    }
-}
-
-impl HasTruncationParams for TruncateOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
-    }
 }
 
 impl TruncateOptions {
     /// Create options for SVD-based truncation.
     pub fn svd() -> Self {
-        Self {
-            alg: TruncateAlg::SVD,
-            ..Default::default()
-        }
+        Self::default()
     }
 
-    /// Create options for LU-based truncation.
-    pub fn lu() -> Self {
-        Self {
-            alg: TruncateAlg::LU,
-            ..Default::default()
-        }
-    }
-
-    /// Create options for CI-based truncation.
-    pub fn ci() -> Self {
-        Self {
-            alg: TruncateAlg::CI,
-            ..Default::default()
-        }
-    }
-
-    /// Set the relative tolerance for truncation.
-    ///
-    /// Clears any previously set cutoff origin.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.truncation.rtol = Some(rtol);
-        self.truncation.cutoff = None;
+    /// Set the explicit SVD truncation policy.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
         self
     }
 
-    /// Set the maximum rank (bond dimension).
+    /// Set the maximum retained bond dimension.
     pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.truncation.max_rank = Some(max_rank);
-        self
-    }
-
-    /// Set cutoff (ITensorMPS.jl convention). Converted to `rtol = √cutoff`.
-    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
-        self.truncation.cutoff = Some(cutoff);
-        self.truncation.rtol = Some(cutoff.sqrt());
-        self
-    }
-
-    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
-    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
-        self.truncation.max_rank = Some(maxdim);
+        self.max_rank = Some(max_rank);
         self
     }
 
     /// Set the site range for truncation.
     ///
     /// The range is 0-indexed with exclusive end.
-    /// For example, `0..5` truncates bonds between sites 0-1, 1-2, 2-3, 3-4.
     pub fn with_site_range(mut self, range: Range<usize>) -> Self {
         self.site_range = Some(range);
         self
     }
 
-    /// Get the truncation algorithm.
+    /// Get the SVD truncation policy override.
     #[inline]
-    pub fn alg(&self) -> TruncateAlg {
-        self.alg
+    pub fn svd_policy(&self) -> Option<SvdTruncationPolicy> {
+        self.svd_policy
     }
 
-    /// Get truncation parameters.
-    ///
-    /// This returns a copy because [`TruncationParams`] is cheap and `Copy`.
+    /// Get the maximum retained bond dimension.
     #[inline]
-    pub fn truncation(&self) -> TruncationParams {
-        self.truncation
+    pub fn max_rank(&self) -> Option<usize> {
+        self.max_rank
     }
 
     /// Get the site range for truncation.
     #[inline]
     pub fn site_range(&self) -> Option<Range<usize>> {
         self.site_range.clone()
-    }
-
-    /// Get rtol (for backwards compatibility).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
-    }
-
-    /// Get max_rank (for backwards compatibility).
-    pub fn max_rank(&self) -> Option<usize> {
-        self.truncation.max_rank
     }
 }
 
@@ -221,29 +122,26 @@ pub enum ContractMethod {
 
 /// Options for tensor train contraction.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
+/// use tensor4all_core::SvdTruncationPolicy;
 /// use tensor4all_itensorlike::ContractOptions;
 ///
-/// // Zipup with max rank
-/// let opts = ContractOptions::zipup().with_max_rank(50);
-///
-/// // Fit with relative tolerance
 /// let opts = ContractOptions::fit()
-///     .with_rtol(1e-10)
-///     .with_nhalfsweeps(10);  // 10 half-sweeps = 5 full sweeps
+///     .with_svd_policy(SvdTruncationPolicy::new(1e-8))
+///     .with_max_rank(50)
+///     .with_nsweeps(3);
+///
+/// assert_eq!(opts.max_rank(), Some(50));
+/// assert_eq!(opts.svd_policy(), Some(SvdTruncationPolicy::new(1e-8)));
+/// assert_eq!(opts.nhalfsweeps(), 6);
 /// ```
 #[derive(Debug, Clone)]
 pub struct ContractOptions {
-    /// Contraction method to use.
     method: ContractMethod,
-    /// Truncation parameters (rtol, max_rank).
-    truncation: TruncationParams,
-    /// Number of half-sweeps for Fit method.
-    ///
-    /// A half-sweep visits edges in one direction only (forward or backward).
-    /// This must be a multiple of 2 (each full sweep consists of 2 half-sweeps).
+    max_rank: Option<usize>,
+    svd_policy: Option<SvdTruncationPolicy>,
     nhalfsweeps: usize,
 }
 
@@ -251,19 +149,10 @@ impl Default for ContractOptions {
     fn default() -> Self {
         Self {
             method: ContractMethod::default(),
-            truncation: TruncationParams::default(),
+            max_rank: None,
+            svd_policy: None,
             nhalfsweeps: 2,
         }
-    }
-}
-
-impl HasTruncationParams for ContractOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
     }
 }
 
@@ -285,9 +174,6 @@ impl ContractOptions {
     }
 
     /// Create options for naive contraction.
-    ///
-    /// Note: Naive contraction is O(exp(n)) in memory and is primarily
-    /// useful for debugging and testing.
     pub fn naive() -> Self {
         Self {
             method: ContractMethod::Naive,
@@ -295,47 +181,27 @@ impl ContractOptions {
         }
     }
 
-    /// Set maximum bond dimension.
+    /// Set the maximum retained bond dimension.
     pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.truncation.max_rank = Some(max_rank);
+        self.max_rank = Some(max_rank);
         self
     }
 
-    /// Set relative tolerance.
-    ///
-    /// Clears any previously set cutoff origin.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.truncation.rtol = Some(rtol);
-        self.truncation.cutoff = None;
+    /// Set the explicit SVD truncation policy.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
         self
     }
 
-    /// Set cutoff (ITensorMPS.jl convention). Converted to `rtol = √cutoff`.
-    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
-        self.truncation.cutoff = Some(cutoff);
-        self.truncation.rtol = Some(cutoff.sqrt());
-        self
-    }
-
-    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
-    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
-        self.truncation.max_rank = Some(maxdim);
-        self
-    }
-
-    /// Set number of half-sweeps for Fit method.
-    ///
-    /// # Arguments
-    /// * `nhalfsweeps` - Number of half-sweeps (must be a multiple of 2)
+    /// Set number of half-sweeps for fit contraction.
     pub fn with_nhalfsweeps(mut self, nhalfsweeps: usize) -> Self {
         self.nhalfsweeps = nhalfsweeps;
         self
     }
 
-    /// Set number of full sweeps (ITensorMPS.jl convention).
+    /// Set number of full sweeps.
     ///
-    /// A full sweep = 2 half-sweeps (forward + backward).
-    /// Equivalent to `with_nhalfsweeps(nsweeps * 2)`.
+    /// A full sweep is two half-sweeps.
     pub fn with_nsweeps(mut self, nsweeps: usize) -> Self {
         self.nhalfsweeps = nsweeps * 2;
         self
@@ -347,20 +213,22 @@ impl ContractOptions {
         self.method
     }
 
+    /// Get the maximum retained bond dimension.
+    #[inline]
+    pub fn max_rank(&self) -> Option<usize> {
+        self.max_rank
+    }
+
+    /// Get the SVD truncation policy override.
+    #[inline]
+    pub fn svd_policy(&self) -> Option<SvdTruncationPolicy> {
+        self.svd_policy
+    }
+
     /// Get number of half-sweeps.
     #[inline]
     pub fn nhalfsweeps(&self) -> usize {
         self.nhalfsweeps
-    }
-
-    /// Get rtol (for backwards compatibility).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
-    }
-
-    /// Get max_rank (for backwards compatibility).
-    pub fn max_rank(&self) -> Option<usize> {
-        self.truncation.max_rank
     }
 }
 
@@ -368,50 +236,41 @@ impl ContractOptions {
 ///
 /// Solves `(a₀ + a₁ * A) * x = b` using DMRG-like sweeps with local GMRES.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
+/// use tensor4all_core::SvdTruncationPolicy;
 /// use tensor4all_itensorlike::LinsolveOptions;
 ///
-/// let opts = LinsolveOptions::default()
-///     .with_nsweeps(10)
-///     .with_cutoff(1e-10)
-///     .with_maxdim(100)
+/// let opts = LinsolveOptions::new(5)
+///     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
+///     .with_max_rank(64)
 ///     .with_krylov_tol(1e-8)
 ///     .with_coefficients(1.0, -1.0);
+///
+/// assert_eq!(opts.max_rank(), Some(64));
+/// assert_eq!(opts.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
+/// assert_eq!(opts.nhalfsweeps(), 10);
 /// ```
 #[derive(Debug, Clone)]
 pub struct LinsolveOptions {
-    /// Number of half-sweeps (must be a multiple of 2).
-    ///
-    /// Default: 10 (= 5 full sweeps).
     nhalfsweeps: usize,
-    /// Truncation parameters (rtol/cutoff, max_rank/maxdim).
-    truncation: TruncationParams,
-    /// Algorithm for truncation.
-    alg: TruncateAlg,
-    /// GMRES tolerance.
+    max_rank: Option<usize>,
+    svd_policy: Option<SvdTruncationPolicy>,
     krylov_tol: f64,
-    /// Maximum GMRES iterations per local solve.
     krylov_maxiter: usize,
-    /// Krylov subspace dimension (restart parameter).
     krylov_dim: usize,
-    /// Coefficient a₀ in (a₀ + a₁ * A) * x = b.
     a0: f64,
-    /// Coefficient a₁ in (a₀ + a₁ * A) * x = b.
     a1: f64,
-    /// Convergence tolerance for early termination.
-    ///
-    /// If `Some(tol)`, stop when relative residual < tol.
     convergence_tol: Option<f64>,
 }
 
 impl Default for LinsolveOptions {
     fn default() -> Self {
         Self {
-            nhalfsweeps: 10, // 5 full sweeps
-            truncation: TruncationParams::default(),
-            alg: TruncateAlg::SVD,
+            nhalfsweeps: 10,
+            max_rank: None,
+            svd_policy: None,
             krylov_tol: 1e-10,
             krylov_maxiter: 100,
             krylov_dim: 30,
@@ -422,18 +281,8 @@ impl Default for LinsolveOptions {
     }
 }
 
-impl HasTruncationParams for LinsolveOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
-    }
-}
-
 impl LinsolveOptions {
-    /// Create options with specified number of full sweeps.
+    /// Create options with the specified number of full sweeps.
     pub fn new(nsweeps: usize) -> Self {
         Self {
             nhalfsweeps: nsweeps * 2,
@@ -441,37 +290,15 @@ impl LinsolveOptions {
         }
     }
 
-    /// Set the relative tolerance for truncation.
-    ///
-    /// Clears any previously set cutoff origin.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.truncation.rtol = Some(rtol);
-        self.truncation.cutoff = None;
+    /// Set the explicit SVD truncation policy.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
         self
     }
 
-    /// Set the maximum rank (bond dimension).
+    /// Set the maximum retained bond dimension.
     pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.truncation.max_rank = Some(max_rank);
-        self
-    }
-
-    /// Set cutoff (ITensorMPS.jl convention). Converted to `rtol = √cutoff`.
-    pub fn with_cutoff(mut self, cutoff: f64) -> Self {
-        self.truncation.cutoff = Some(cutoff);
-        self.truncation.rtol = Some(cutoff.sqrt());
-        self
-    }
-
-    /// Set maxdim (alias for [`with_max_rank`](Self::with_max_rank)).
-    pub fn with_maxdim(mut self, maxdim: usize) -> Self {
-        self.truncation.max_rank = Some(maxdim);
-        self
-    }
-
-    /// Set the truncation algorithm.
-    pub fn with_alg(mut self, alg: TruncateAlg) -> Self {
-        self.alg = alg;
+        self.max_rank = Some(max_rank);
         self
     }
 
@@ -481,10 +308,7 @@ impl LinsolveOptions {
         self
     }
 
-    /// Set number of full sweeps (ITensorMPS.jl convention).
-    ///
-    /// A full sweep = 2 half-sweeps (forward + backward).
-    /// Equivalent to `with_nhalfsweeps(nsweeps * 2)`.
+    /// Set number of full sweeps.
     pub fn with_nsweeps(mut self, nsweeps: usize) -> Self {
         self.nhalfsweeps = nsweeps * 2;
         self
@@ -508,7 +332,7 @@ impl LinsolveOptions {
         self
     }
 
-    /// Set coefficients a₀ and a₁ in (a₀ + a₁ * A) * x = b.
+    /// Set coefficients `a₀` and `a₁` in `(a₀ + a₁ * A) * x = b`.
     pub fn with_coefficients(mut self, a0: f64, a1: f64) -> Self {
         self.a0 = a0;
         self.a1 = a1;
@@ -521,26 +345,22 @@ impl LinsolveOptions {
         self
     }
 
-    /// Get rtol (for convenience).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
+    /// Get the maximum retained bond dimension.
+    #[inline]
+    pub fn max_rank(&self) -> Option<usize> {
+        self.max_rank
     }
 
-    /// Get max_rank (for convenience).
-    pub fn max_rank(&self) -> Option<usize> {
-        self.truncation.max_rank
+    /// Get the SVD truncation policy override.
+    #[inline]
+    pub fn svd_policy(&self) -> Option<SvdTruncationPolicy> {
+        self.svd_policy
     }
 
     /// Get number of half-sweeps.
     #[inline]
     pub fn nhalfsweeps(&self) -> usize {
         self.nhalfsweeps
-    }
-
-    /// Get truncation algorithm.
-    #[inline]
-    pub fn alg(&self) -> TruncateAlg {
-        self.alg
     }
 
     /// Get GMRES tolerance.
@@ -561,7 +381,7 @@ impl LinsolveOptions {
         self.krylov_dim
     }
 
-    /// Get coefficients (a0, a1).
+    /// Get coefficients `(a0, a1)`.
     #[inline]
     pub fn coefficients(&self) -> (f64, f64) {
         (self.a0, self.a1)

--- a/crates/tensor4all-itensorlike/src/options/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/options/tests/mod.rs
@@ -1,82 +1,93 @@
 use super::*;
+use tensor4all_core::SvdTruncationPolicy;
+
+#[test]
+fn test_validate_svd_truncation_options_accepts_default_settings() {
+    assert!(validate_svd_truncation_options(None, None).is_ok());
+}
+
+#[test]
+fn test_validate_svd_truncation_options_rejects_negative_threshold() {
+    let err =
+        validate_svd_truncation_options(None, Some(SvdTruncationPolicy::new(-1.0))).unwrap_err();
+    assert!(err.to_string().contains("svd_policy.threshold"));
+}
+
+#[test]
+fn test_validate_svd_truncation_options_rejects_non_finite_threshold() {
+    let err = validate_svd_truncation_options(None, Some(SvdTruncationPolicy::new(f64::NAN)))
+        .unwrap_err();
+    assert!(err.to_string().contains("svd_policy.threshold"));
+}
+
+#[test]
+fn test_validate_svd_truncation_options_rejects_zero_max_rank() {
+    let err =
+        validate_svd_truncation_options(Some(0), Some(SvdTruncationPolicy::new(1e-8))).unwrap_err();
+    assert!(err.to_string().contains("max_rank/maxdim"));
+}
 
 #[test]
 fn test_truncate_options_builder() {
-    let opts = TruncateOptions::svd().with_rtol(1e-10).with_max_rank(50);
-    assert_eq!(opts.alg, TruncateAlg::SVD);
-    assert_eq!(opts.rtol(), Some(1e-10));
+    let policy = SvdTruncationPolicy::new(1e-10)
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    let opts = TruncateOptions::svd()
+        .with_svd_policy(policy)
+        .with_max_rank(50)
+        .with_site_range(0..5);
+
+    assert_eq!(opts.svd_policy(), Some(policy));
     assert_eq!(opts.max_rank(), Some(50));
-}
-
-#[test]
-fn test_truncate_options_algorithms() {
-    assert_eq!(TruncateOptions::svd().alg, TruncateAlg::SVD);
-    assert_eq!(TruncateOptions::lu().alg, TruncateAlg::LU);
-    assert_eq!(TruncateOptions::ci().alg, TruncateAlg::CI);
-}
-
-#[test]
-fn test_truncate_options_site_range() {
-    let opts = TruncateOptions::svd().with_site_range(0..5);
-    assert_eq!(opts.site_range, Some(0..5));
+    assert_eq!(opts.site_range(), Some(0..5));
 }
 
 #[test]
 fn test_truncate_options_default() {
     let opts = TruncateOptions::default();
-    assert_eq!(opts.alg, TruncateAlg::SVD);
-    assert_eq!(opts.rtol(), None);
+    assert_eq!(opts.svd_policy(), None);
     assert_eq!(opts.max_rank(), None);
-    assert!(opts.site_range.is_none());
-}
-
-#[test]
-fn test_truncate_options_has_truncation_params() {
-    let mut opts = TruncateOptions::svd();
-    assert!(opts.truncation_params().rtol.is_none());
-    opts.truncation_params_mut().rtol = Some(1e-8);
-    assert_eq!(opts.truncation_params().rtol, Some(1e-8));
+    assert_eq!(opts.site_range(), None);
 }
 
 #[test]
 fn test_contract_options_builder() {
+    let policy = SvdTruncationPolicy::new(1e-12);
     let opts = ContractOptions::zipup()
         .with_max_rank(100)
-        .with_rtol(1e-12)
-        .with_nhalfsweeps(6); // 6 half-sweeps = 3 full sweeps
-    assert_eq!(opts.method, ContractMethod::Zipup);
+        .with_svd_policy(policy)
+        .with_nhalfsweeps(6);
+
+    assert_eq!(opts.method(), ContractMethod::Zipup);
     assert_eq!(opts.max_rank(), Some(100));
-    assert_eq!(opts.rtol(), Some(1e-12));
-    assert_eq!(opts.nhalfsweeps, 6);
+    assert_eq!(opts.svd_policy(), Some(policy));
+    assert_eq!(opts.nhalfsweeps(), 6);
 }
 
 #[test]
 fn test_contract_options_methods() {
-    assert_eq!(ContractOptions::zipup().method, ContractMethod::Zipup);
-    assert_eq!(ContractOptions::fit().method, ContractMethod::Fit);
-    assert_eq!(ContractOptions::naive().method, ContractMethod::Naive);
+    assert_eq!(ContractOptions::zipup().method(), ContractMethod::Zipup);
+    assert_eq!(ContractOptions::fit().method(), ContractMethod::Fit);
+    assert_eq!(ContractOptions::naive().method(), ContractMethod::Naive);
 }
 
 #[test]
 fn test_contract_options_default() {
     let opts = ContractOptions::default();
-    assert_eq!(opts.method, ContractMethod::Zipup);
-    assert_eq!(opts.nhalfsweeps, 2);
-    assert_eq!(opts.rtol(), None);
+    assert_eq!(opts.method(), ContractMethod::Zipup);
+    assert_eq!(opts.nhalfsweeps(), 2);
+    assert_eq!(opts.svd_policy(), None);
     assert_eq!(opts.max_rank(), None);
 }
 
 #[test]
-fn test_contract_options_has_truncation_params() {
-    let mut opts = ContractOptions::zipup();
-    assert!(opts.truncation_params().rtol.is_none());
-    opts.truncation_params_mut().max_rank = Some(50);
-    assert_eq!(opts.truncation_params().max_rank, Some(50));
+fn test_contract_options_nsweeps() {
+    let opts = ContractOptions::fit().with_nsweeps(5);
+    assert_eq!(opts.nhalfsweeps(), 10);
 }
 
 #[test]
-fn test_contract_options_nhalfsweeps_must_be_multiple_of_2() {
-    // builder should not panic; validation happens at operation entry
+fn test_contract_options_odd_nhalfsweeps_allowed_in_builder() {
     let opts = ContractOptions::fit().with_nhalfsweeps(1);
     assert_eq!(opts.nhalfsweeps(), 1);
 }
@@ -88,76 +99,33 @@ fn test_contract_method_default() {
 }
 
 #[test]
-fn test_truncate_options_cutoff() {
-    let opts = TruncateOptions::svd().with_cutoff(1e-10);
-    assert!((opts.rtol().unwrap() - 1e-5).abs() < 1e-15);
-    assert_eq!(opts.truncation.cutoff, Some(1e-10));
-}
-
-#[test]
-fn test_truncate_options_maxdim() {
-    let opts = TruncateOptions::svd().with_maxdim(42);
-    assert_eq!(opts.max_rank(), Some(42));
-}
-
-#[test]
-fn test_contract_options_cutoff() {
-    let opts = ContractOptions::zipup().with_cutoff(1e-8);
-    assert!((opts.rtol().unwrap() - 1e-4).abs() < 1e-15);
-    assert_eq!(opts.truncation.cutoff, Some(1e-8));
-}
-
-#[test]
-fn test_contract_options_maxdim() {
-    let opts = ContractOptions::fit().with_maxdim(30);
-    assert_eq!(opts.max_rank(), Some(30));
-}
-
-#[test]
-fn test_contract_options_nsweeps() {
-    let opts = ContractOptions::fit().with_nsweeps(5);
-    assert_eq!(opts.nhalfsweeps, 10);
-}
-
-#[test]
-fn test_cutoff_rtol_last_wins_truncate() {
-    // cutoff then rtol: rtol wins
-    let opts = TruncateOptions::svd().with_cutoff(1e-10).with_rtol(1e-3);
-    assert_eq!(opts.rtol(), Some(1e-3));
-    assert_eq!(opts.truncation.cutoff, None);
-
-    // rtol then cutoff: cutoff wins
-    let opts = TruncateOptions::svd().with_rtol(1e-3).with_cutoff(1e-10);
-    assert!((opts.rtol().unwrap() - 1e-5).abs() < 1e-15);
-    assert_eq!(opts.truncation.cutoff, Some(1e-10));
-}
-
-#[test]
 fn test_linsolve_options_default() {
     let opts = LinsolveOptions::default();
-    assert_eq!(opts.nhalfsweeps, 10);
-    assert_eq!(opts.a0, 0.0);
-    assert_eq!(opts.a1, 1.0);
-    assert_eq!(opts.krylov_tol, 1e-10);
-    assert_eq!(opts.krylov_maxiter, 100);
-    assert_eq!(opts.krylov_dim, 30);
-    assert!(opts.convergence_tol.is_none());
-    assert_eq!(opts.rtol(), None);
+    assert_eq!(opts.nhalfsweeps(), 10);
+    assert_eq!(opts.coefficients(), (0.0, 1.0));
+    assert_eq!(opts.krylov_tol(), 1e-10);
+    assert_eq!(opts.krylov_maxiter(), 100);
+    assert_eq!(opts.krylov_dim(), 30);
+    assert_eq!(opts.convergence_tol(), None);
+    assert_eq!(opts.svd_policy(), None);
     assert_eq!(opts.max_rank(), None);
 }
 
 #[test]
 fn test_linsolve_options_new() {
     let opts = LinsolveOptions::new(5);
-    assert_eq!(opts.nhalfsweeps(), 10); // 5 full sweeps = 10 half-sweeps
+    assert_eq!(opts.nhalfsweeps(), 10);
 }
 
 #[test]
 fn test_linsolve_options_builder() {
+    let policy = SvdTruncationPolicy::new(1e-10)
+        .with_squared_values()
+        .with_discarded_tail_sum();
     let opts = LinsolveOptions::default()
         .with_nsweeps(10)
-        .with_cutoff(1e-10)
-        .with_maxdim(100)
+        .with_svd_policy(policy)
+        .with_max_rank(100)
         .with_krylov_tol(1e-8)
         .with_krylov_maxiter(200)
         .with_krylov_dim(50)
@@ -165,8 +133,7 @@ fn test_linsolve_options_builder() {
         .with_convergence_tol(1e-6);
 
     assert_eq!(opts.nhalfsweeps(), 20);
-    assert!((opts.rtol().unwrap() - 1e-5).abs() < 1e-15);
-    assert_eq!(opts.truncation_params().cutoff, Some(1e-10));
+    assert_eq!(opts.svd_policy(), Some(policy));
     assert_eq!(opts.max_rank(), Some(100));
     assert_eq!(opts.krylov_tol(), 1e-8);
     assert_eq!(opts.krylov_maxiter(), 200);
@@ -183,7 +150,6 @@ fn test_linsolve_options_nsweeps() {
 
 #[test]
 fn test_linsolve_options_odd_nhalfsweeps_allowed_in_builder() {
-    // builder should not panic; validation happens at operation entry
     let opts = LinsolveOptions::default().with_nhalfsweeps(3);
     assert_eq!(opts.nhalfsweeps(), 3);
 }

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -16,8 +16,7 @@ use tensor4all_core::{
 use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
 
 use crate::error::{Result, TensorTrainError};
-use crate::options::{validate_truncation_params, CanonicalForm, TruncateAlg, TruncateOptions};
-use tensor4all_core::truncation::HasTruncationParams;
+use crate::options::{validate_svd_truncation_options, CanonicalForm, TruncateOptions};
 
 /// Tensor Train with orthogonality tracking.
 ///
@@ -801,14 +800,16 @@ impl TensorTrain {
             return Ok(());
         }
 
-        validate_truncation_params(options.truncation_params())?;
+        validate_svd_truncation_options(options.max_rank(), options.svd_policy())?;
 
         // Convert TruncateOptions to TruncationOptions
-        let form = truncate_alg_to_form(options.alg());
-        let treetn_options = TruncationOptions {
-            form,
-            truncation: options.truncation(),
-        };
+        let mut treetn_options = TruncationOptions::new();
+        if let Some(policy) = options.svd_policy() {
+            treetn_options = treetn_options.with_svd_policy(policy);
+        }
+        if let Some(max_rank) = options.max_rank() {
+            treetn_options = treetn_options.with_max_rank(max_rank);
+        }
 
         // Truncate towards the last site (rightmost) as the canonical center
         // This matches ITensor convention where truncation sweeps left-to-right
@@ -820,7 +821,7 @@ impl TensorTrain {
                 message: format!("TreeTN truncation failed: {}", e),
             })?;
 
-        self.canonical_form = Some(form);
+        self.canonical_form = Some(CanonicalForm::Unitary);
 
         Ok(())
     }
@@ -1198,18 +1199,6 @@ impl TensorTrain {
 impl Default for TensorTrain {
     fn default() -> Self {
         Self::new(vec![]).expect("Failed to create empty TensorTrain")
-    }
-}
-
-/// Convert TruncateAlg to CanonicalForm.
-///
-/// Note: SVD truncation algorithm corresponds to Unitary canonical form
-/// because both produce orthogonal/isometric tensors.
-pub(crate) fn truncate_alg_to_form(alg: TruncateAlg) -> CanonicalForm {
-    match alg {
-        TruncateAlg::SVD | TruncateAlg::RSVD | TruncateAlg::QR => CanonicalForm::Unitary,
-        TruncateAlg::LU => CanonicalForm::LU,
-        TruncateAlg::CI => CanonicalForm::CI,
     }
 }
 

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -362,7 +362,8 @@ fn test_truncate_invalid_rtol_errors() {
     let t1 = make_tensor(vec![l01.clone(), s1.clone()]);
 
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
-    let options = TruncateOptions::svd().with_rtol(-1.0);
+    let options =
+        TruncateOptions::svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(-1.0));
     let err = tt.truncate(&options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }
@@ -1215,7 +1216,8 @@ fn test_truncate_with_rtol() {
 
     let mut tt = TensorTrain::new(vec![t0, t1, t2]).unwrap();
 
-    let options = TruncateOptions::svd().with_rtol(1e-10);
+    let options =
+        TruncateOptions::svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10));
     tt.truncate(&options).unwrap();
     assert!(tt.isortho() || tt.len() == 3);
 }

--- a/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
+++ b/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
@@ -114,7 +114,9 @@ fn bench_truncate() {
     eprintln!("\n=== truncate benchmark (main) ===");
     for &n in &[20, 45, 90] {
         let mut mps = make_random_mps(n, 2, 16, 123);
-        let opts = TruncateOptions::svd().with_rtol(1e-6).with_max_rank(8);
+        let opts = TruncateOptions::svd()
+            .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+            .with_max_rank(8);
         time_it(&format!("truncate({n} sites, bd=16→8)"), || {
             mps.truncate(&opts).unwrap();
         });
@@ -126,7 +128,9 @@ fn bench_contract_zipup() {
     eprintln!("\n=== contract zipup benchmark (main) ===");
     for &n in &[10, 20, 45] {
         let (a, b) = make_random_mpo_pair(n, 2, 8);
-        let opts = ContractOptions::zipup().with_rtol(1e-6).with_max_rank(16);
+        let opts = ContractOptions::zipup()
+            .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+            .with_max_rank(16);
         time_it(&format!("zipup({n} sites, bd=8)"), || {
             let _ = a.contract(&b, &opts).unwrap();
         });
@@ -138,7 +142,9 @@ fn bench_contract_fit() {
     eprintln!("\n=== contract fit benchmark (main) ===");
     for &n in &[10, 20, 45] {
         let (a, b) = make_random_mpo_pair(n, 2, 8);
-        let opts = ContractOptions::fit().with_rtol(1e-6).with_max_rank(16);
+        let opts = ContractOptions::fit()
+            .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
+            .with_max_rank(16);
         time_it(&format!("fit({n} sites, bd=8)"), || {
             let _ = a.contract(&b, &opts).unwrap();
         });

--- a/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
@@ -95,7 +95,11 @@ fn test_fit_bond_growth_with_rtol() {
 
     // Zipup with rtol: truncates significantly
     let result_zipup = mpo_a
-        .contract(&mpo_b, &ContractOptions::zipup().with_rtol(rtol))
+        .contract(
+            &mpo_b,
+            &ContractOptions::zipup()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
+        )
         .unwrap();
     let zipup_bd = result_zipup.maxbonddim();
     let zipup_err = result_zipup
@@ -116,7 +120,11 @@ fn test_fit_bond_growth_with_rtol() {
     // Expected: fit should be free to grow bonds during sweeps and achieve
     //           better accuracy than zipup alone (limited only by rtol).
     let result_fit = mpo_a
-        .contract(&mpo_b, &ContractOptions::fit().with_rtol(rtol))
+        .contract(
+            &mpo_b,
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
+        )
         .unwrap();
     let fit_bd = result_fit.maxbonddim();
     let fit_err = result_fit
@@ -130,7 +138,9 @@ fn test_fit_bond_growth_with_rtol() {
     let result_fit4 = mpo_a
         .contract(
             &mpo_b,
-            &ContractOptions::fit().with_rtol(rtol).with_nsweeps(4),
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
+                .with_nsweeps(4),
         )
         .unwrap();
     let fit4_bd = result_fit4.maxbonddim();
@@ -143,7 +153,11 @@ fn test_fit_bond_growth_with_rtol() {
 
     // Control: fit with small rtol (no truncation), no max_rank
     let result_fit_small_rtol = mpo_a
-        .contract(&mpo_b, &ContractOptions::fit().with_rtol(1e-12))
+        .contract(
+            &mpo_b,
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-12)),
+        )
         .unwrap();
     let fit_small_rtol_bd = result_fit_small_rtol.maxbonddim();
     let fit_small_rtol_err = result_fit_small_rtol

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -56,7 +56,7 @@ fn create_function_2d_tt(
     }
 
     let big = TensorDynLen::from_dense(all_sites.clone(), quantics_data).unwrap();
-    let opts = FactorizeOptions::qr().with_rtol(0.0);
+    let opts = FactorizeOptions::qr().with_qr_rtol(0.0);
     let n_sites = all_sites.len();
     let mut remaining = big;
     let mut tensors = Vec::with_capacity(n_sites);
@@ -301,7 +301,7 @@ fn test_fit_wrong_for_elementwise_structured() {
         &tt_a,
         &tt_b,
         &all_sites,
-        &ContractOptions::fit().with_rtol(1e-30),
+        &ContractOptions::fit().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-30)),
     );
     let fit_rtol_err = result_fit_rtol
         .axpby(1.0.into(), &result_ref, (-1.0).into())

--- a/crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs
@@ -2,7 +2,7 @@
 //! from axpby (direct sum).
 //!
 //! After axpby, the TT has inflated bond dimensions and is not in canonical
-//! form. Calling `truncate(svd().with_rtol(1e-15))` should remove only
+//! form. Calling `truncate(svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-15)))` should remove only
 //! near-zero singular values (effectively lossless for well-conditioned data).
 //! But truncate incorrectly drops significant singular values, changing the
 //! represented function.
@@ -121,7 +121,10 @@ fn test_truncate_drops_significant_singular_values() {
     // truncate with rtol=1e-15: should keep bonddim=2
     let mut f_truncated = f.clone();
     f_truncated
-        .truncate(&TruncateOptions::svd().with_rtol(1e-15))
+        .truncate(
+            &TruncateOptions::svd()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-15)),
+        )
         .unwrap();
 
     let f_dense_after = f_truncated.to_dense().unwrap();
@@ -140,7 +143,9 @@ fn test_truncate_drops_significant_singular_values() {
     // truncate with rtol=0.0 should also preserve the function
     let mut f_trunc0 = f.clone();
     f_trunc0
-        .truncate(&TruncateOptions::svd().with_rtol(0.0))
+        .truncate(
+            &TruncateOptions::svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(0.0)),
+        )
         .unwrap();
     let f_dense_0 = f_trunc0.to_dense().unwrap();
     let diff_0 = f_dense_before
@@ -198,7 +203,10 @@ fn test_truncate_drops_sv_various_sizes() {
 
         let mut f_truncated = f.clone();
         f_truncated
-            .truncate(&TruncateOptions::svd().with_rtol(1e-15))
+            .truncate(
+                &TruncateOptions::svd()
+                    .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-15)),
+            )
             .unwrap();
 
         let f_dense_after = f_truncated.to_dense().unwrap();

--- a/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
@@ -95,17 +95,24 @@ fn setup_test_mpos(length: usize, phys_dim: usize, bond_dim: usize) -> TestMPOs 
     }
 }
 
-/// fit() with rtol=0.0 explicit and fit() with no rtol should produce the same
-/// bond dimensions and accuracy. This ensures the API is consistent regardless
-/// of whether the user explicitly passes rtol=0.0 or omits it.
+/// fit() with an explicit zero-threshold policy should preserve the same bond
+/// dimensions as fit() without a policy override.
+///
+/// Unlike the removed `rtol=0` sentinel API, an explicit
+/// `SvdTruncationPolicy::new(0.0)` is now a real truncation policy. Small
+/// numerical differences in the final state are therefore acceptable, but the
+/// bond-dimension cap behavior should still match.
 #[test]
-fn test_fit_rtol_zero_matches_no_rtol() {
+fn test_fit_zero_threshold_matches_no_policy_bond_dims() {
     let t = setup_test_mpos(TEST_LENGTH, TEST_PHYS_DIM, TEST_BOND_DIM);
 
     let result_no_rtol = t.mpo_a.contract(&t.mpo_b, &ContractOptions::fit()).unwrap();
     let result_rtol_zero = t
         .mpo_a
-        .contract(&t.mpo_b, &ContractOptions::fit().with_rtol(0.0))
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(0.0)),
+        )
         .unwrap();
 
     let bd_no_rtol = result_no_rtol.maxbonddim();
@@ -118,14 +125,8 @@ fn test_fit_rtol_zero_matches_no_rtol() {
 
     assert_eq!(
         bd_no_rtol, bd_rtol_zero,
-        "fit(no rtol) and fit(rtol=0) should produce the same bond dims: \
+        "fit(no policy) and fit(threshold=0) should produce the same bond dims: \
          {bd_no_rtol} vs {bd_rtol_zero}"
-    );
-    let err_diff = (err_no_rtol - err_rtol_zero).abs();
-    assert!(
-        err_diff < 1e-10,
-        "fit(no rtol) and fit(rtol=0) should produce the same error: \
-         {err_no_rtol:.6e} vs {err_rtol_zero:.6e}"
     );
 }
 
@@ -141,7 +142,7 @@ fn test_fit_max_rank_caps_bonds() {
             &t.mpo_b,
             &ContractOptions::fit()
                 .with_max_rank(max_rank)
-                .with_rtol(1e-12),
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-12)),
         )
         .unwrap();
     let result_bd = result.maxbonddim();
@@ -168,7 +169,7 @@ fn test_fit_max_rank_overrides_rtol() {
             &t.mpo_b,
             &ContractOptions::fit()
                 .with_max_rank(max_rank)
-                .with_rtol(rtol),
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
         )
         .unwrap();
     let result_bd = result.maxbonddim();
@@ -176,7 +177,11 @@ fn test_fit_max_rank_overrides_rtol() {
     // Without max_rank, rtol=1e-12 produces large bonds
     let result_no_cap = t
         .mpo_a
-        .contract(&t.mpo_b, &ContractOptions::fit().with_rtol(rtol))
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
+        )
         .unwrap();
     let no_cap_bd = result_no_cap.maxbonddim();
 
@@ -204,11 +209,19 @@ fn test_fit_rtol_controls_bond_growth() {
 
     let result_large = t
         .mpo_a
-        .contract(&t.mpo_b, &ContractOptions::fit().with_rtol(rtol_large))
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol_large)),
+        )
         .unwrap();
     let result_small = t
         .mpo_a
-        .contract(&t.mpo_b, &ContractOptions::fit().with_rtol(rtol_small))
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol_small)),
+        )
         .unwrap();
 
     let bd_large = result_large.maxbonddim();
@@ -274,11 +287,19 @@ fn test_fit_not_worse_than_zipup_with_rtol() {
     for rtol in [0.3, 0.1] {
         let result_zipup = t
             .mpo_a
-            .contract(&t.mpo_b, &ContractOptions::zipup().with_rtol(rtol))
+            .contract(
+                &t.mpo_b,
+                &ContractOptions::zipup()
+                    .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
+            )
             .unwrap();
         let result_fit = t
             .mpo_a
-            .contract(&t.mpo_b, &ContractOptions::fit().with_rtol(rtol))
+            .contract(
+                &t.mpo_b,
+                &ContractOptions::fit()
+                    .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
+            )
             .unwrap();
 
         let zipup_err = relative_error(&result_zipup, &t.exact, t.exact_norm);
@@ -304,11 +325,22 @@ fn test_fit_cutoff_equivalent_to_rtol() {
 
     let result_cutoff = t
         .mpo_a
-        .contract(&t.mpo_b, &ContractOptions::fit().with_cutoff(cutoff))
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit().with_svd_policy(
+                tensor4all_core::SvdTruncationPolicy::new(cutoff)
+                    .with_squared_values()
+                    .with_discarded_tail_sum(),
+            ),
+        )
         .unwrap();
     let result_rtol = t
         .mpo_a
-        .contract(&t.mpo_b, &ContractOptions::fit().with_rtol(rtol))
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
+        )
         .unwrap();
 
     let bd_cutoff = result_cutoff.maxbonddim();
@@ -384,14 +416,18 @@ fn test_fit_more_sweeps_with_rtol_improves() {
         .mpo_a
         .contract(
             &t.mpo_b,
-            &ContractOptions::fit().with_rtol(rtol).with_nsweeps(1),
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
+                .with_nsweeps(1),
         )
         .unwrap();
     let result_4sw = t
         .mpo_a
         .contract(
             &t.mpo_b,
-            &ContractOptions::fit().with_rtol(rtol).with_nsweeps(4),
+            &ContractOptions::fit()
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
+                .with_nsweeps(4),
         )
         .unwrap();
 

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -265,8 +265,8 @@ impl PartitionedTT {
                     })?;
                     // Truncate after addition using the same truncation params as contraction
                     let mut truncate_opts = TruncateOptions::svd();
-                    if let Some(rtol) = options.rtol() {
-                        truncate_opts = truncate_opts.with_rtol(rtol);
+                    if let Some(policy) = options.svd_policy() {
+                        truncate_opts = truncate_opts.with_svd_policy(policy);
                     }
                     if let Some(max_rank) = options.max_rank() {
                         truncate_opts = truncate_opts.with_max_rank(max_rank);

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
@@ -582,7 +582,7 @@ fn test_partitioned_tt_contract_with_rtol_and_max_rank() {
     let partitioned2 = PartitionedTT::from_subdomains(vec![subdomain2_a, subdomain2_b]).unwrap();
 
     let options = ContractOptions::default()
-        .with_rtol(1e-12)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-12))
         .with_max_rank(10);
     let result = partitioned1.contract(&partitioned2, &options).unwrap();
 

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
@@ -217,7 +217,7 @@ fn main() -> anyhow::Result<()> {
 
     let apply_opts = ApplyOptions::zipup()
         .with_max_rank(max_rank)
-        .with_rtol(rtol);
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
     let linop_for_rhs =
         LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
     let rhs = apply_linear_operator(&linop_for_rhs, &x_true, apply_opts)?;
@@ -227,8 +227,7 @@ fn main() -> anyhow::Result<()> {
     // Use an isometric (unitary) canonical form (QR-based) to match standard MPS
     // algorithms more closely.
     let truncation = TruncationOptions::default()
-        .with_form(CanonicalForm::Unitary)
-        .with_rtol(rtol)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
         .with_max_rank(max_rank);
 
     let options = LinsolveOptions::default()

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
@@ -326,7 +326,7 @@ fn main() -> anyhow::Result<()> {
     // Compute b = A * x_true
     let apply_opts = ApplyOptions::zipup()
         .with_max_rank(max_rank)
-        .with_rtol(rtol);
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
     let linop_for_rhs = LinearOperator::new(
         operator_a.clone(),
         a_input_mapping.clone(),
@@ -337,8 +337,7 @@ fn main() -> anyhow::Result<()> {
     let center = make_node_name(n_sites / 2);
 
     let truncation = TruncationOptions::default()
-        .with_form(CanonicalForm::Unitary)
-        .with_rtol(rtol)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
         .with_max_rank(max_rank);
 
     let options = LinsolveOptions::default()

--- a/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
+++ b/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
@@ -375,8 +375,7 @@ fn main() -> anyhow::Result<()> {
     println!();
 
     let truncation = TruncationOptions::default()
-        .with_form(CanonicalForm::Unitary)
-        .with_rtol(rtol)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
         .with_max_rank(max_rank);
 
     let options = LinsolveOptions::default()

--- a/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
@@ -317,7 +317,7 @@ fn main() -> anyhow::Result<()> {
 
     let apply_opts = ApplyOptions::zipup()
         .with_max_rank(max_rank)
-        .with_rtol(rtol);
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
     let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
 
     let rhs = if rhs_kind == "ones" {
@@ -336,8 +336,7 @@ fn main() -> anyhow::Result<()> {
         .with_context(|| "failed to canonicalize initial x0=b")?;
 
     let truncation = TruncationOptions::default()
-        .with_form(CanonicalForm::Unitary)
-        .with_rtol(rtol)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
         .with_max_rank(max_rank);
 
     let options = LinsolveOptions::default()

--- a/crates/tensor4all-treetn/src/linsolve/common/options.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/options.rs
@@ -1,6 +1,7 @@
 //! Common options for linsolve algorithms.
 
 use crate::TruncationOptions;
+use tensor4all_core::SvdTruncationPolicy;
 
 /// Options for the linsolve algorithm.
 #[derive(Debug, Clone)]
@@ -68,9 +69,9 @@ impl LinsolveOptions {
         self
     }
 
-    /// Set relative tolerance for truncation.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.truncation = self.truncation.with_rtol(rtol);
+    /// Set the SVD truncation policy used by TreeTN truncation steps.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.truncation = self.truncation.with_svd_policy(policy);
         self
     }
 

--- a/crates/tensor4all-treetn/src/linsolve/common/options/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/options/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tensor4all_core::SvdTruncationPolicy;
 
 #[test]
 fn test_default_options() {
@@ -11,14 +12,19 @@ fn test_default_options() {
 
 #[test]
 fn test_builder_pattern() {
+    let policy = SvdTruncationPolicy::new(1e-9)
+        .with_squared_values()
+        .with_discarded_tail_sum();
     let opts = LinsolveOptions::new(5)
         .with_max_rank(100)
+        .with_svd_policy(policy)
         .with_krylov_tol(1e-8)
         .with_coefficients(1.0, -1.0)
         .with_convergence_tol(1e-6);
 
     assert_eq!(opts.nfullsweeps, 5);
     assert_eq!(opts.truncation.max_rank(), Some(100));
+    assert_eq!(opts.truncation.svd_policy(), Some(policy));
     assert_eq!(opts.krylov_tol, 1e-8);
     assert_eq!(opts.a0, 1.0);
     assert_eq!(opts.a1, -1.0);

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -752,8 +752,8 @@ where
         if let Some(max_rank) = self.options.truncation.max_rank() {
             factorize_options = factorize_options.with_max_rank(max_rank);
         }
-        if let Some(rtol) = self.options.truncation.rtol() {
-            factorize_options = factorize_options.with_rtol(rtol);
+        if let Some(policy) = self.options.truncation.svd_policy() {
+            factorize_options = factorize_options.with_svd_policy(policy);
         }
         // Force decomposition root to be consistent with the sweep plan's new center.
         // This keeps the norm-carrying tensor on the declared canonical center.

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -69,7 +69,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
-use tensor4all_core::{IndexLike, TensorIndex, TensorLike};
+use tensor4all_core::{IndexLike, SvdTruncationPolicy, TensorIndex, TensorLike};
 
 use super::index_mapping::IndexMapping;
 use super::linear_operator::LinearOperator;
@@ -89,7 +89,8 @@ use crate::treetn::TreeTN;
 ///
 /// - `method`: [`ContractionMethod::Zipup`] (single-sweep, no iteration)
 /// - `max_rank`: `None` (no rank limit)
-/// - `rtol`: `None` (no tolerance-based truncation)
+/// - `svd_policy`: `None` (uses the SVD global default policy)
+/// - `qr_rtol`: `None` (uses the QR global default tolerance)
 /// - `nfullsweeps`: `1` (only used by Fit method)
 /// - `convergence_tol`: `None` (only used by Fit method)
 ///
@@ -97,15 +98,18 @@ use crate::treetn::TreeTN;
 ///
 /// ```
 /// use tensor4all_treetn::ApplyOptions;
+/// use tensor4all_core::SvdTruncationPolicy;
 ///
 /// // Default: Zipup with no truncation
 /// let opts = ApplyOptions::default();
 /// assert_eq!(opts.max_rank, None);
 ///
 /// // Zipup with rank and tolerance limits
-/// let opts = ApplyOptions::zipup().with_max_rank(50).with_rtol(1e-8);
+/// let opts = ApplyOptions::zipup()
+///     .with_max_rank(50)
+///     .with_svd_policy(SvdTruncationPolicy::new(1e-8));
 /// assert_eq!(opts.max_rank, Some(50));
-/// assert_eq!(opts.rtol, Some(1e-8));
+/// assert_eq!(opts.svd_policy, Some(SvdTruncationPolicy::new(1e-8)));
 ///
 /// // Fit method with sweep control
 /// let opts = ApplyOptions::fit().with_nfullsweeps(3).with_max_rank(20);
@@ -121,8 +125,10 @@ pub struct ApplyOptions {
     pub method: ContractionMethod,
     /// Maximum bond dimension for truncation.
     pub max_rank: Option<usize>,
-    /// Relative tolerance for truncation.
-    pub rtol: Option<f64>,
+    /// Explicit SVD truncation policy.
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// QR-specific relative tolerance.
+    pub qr_rtol: Option<f64>,
     /// Number of full sweeps for Fit method.
     ///
     /// A full sweep visits each edge twice (forward and backward) using an Euler tour.
@@ -136,7 +142,8 @@ impl Default for ApplyOptions {
         Self {
             method: ContractionMethod::Zipup,
             max_rank: None,
-            rtol: None,
+            svd_policy: None,
+            qr_rtol: None,
             nfullsweeps: 1,
             convergence_tol: None,
         }
@@ -171,9 +178,15 @@ impl ApplyOptions {
         self
     }
 
-    /// Set relative tolerance.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.rtol = Some(rtol);
+    /// Set the SVD truncation policy.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set the QR-specific truncation tolerance.
+    pub fn with_qr_rtol(mut self, rtol: f64) -> Self {
+        self.qr_rtol = Some(rtol);
         self
     }
 
@@ -252,7 +265,9 @@ impl ApplyOptions {
 /// let truncated = apply_linear_operator(
 ///     &operator,
 ///     &state,
-///     ApplyOptions::zipup().with_max_rank(4).with_rtol(1e-10),
+///     ApplyOptions::zipup()
+///         .with_max_rank(4)
+///         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10)),
 /// )?;
 /// assert_eq!(truncated.node_count(), 1);
 /// # Ok(())
@@ -301,7 +316,8 @@ where
     let contraction_options = ContractionOptions {
         method: options.method,
         max_rank: options.max_rank,
-        rtol: options.rtol,
+        svd_policy: options.svd_policy,
+        qr_rtol: options.qr_rtol,
         nfullsweeps: options.nfullsweeps,
         convergence_tol: options.convergence_tol,
         ..Default::default()

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -3,7 +3,7 @@ use crate::random::{random_treetn, LinkSpace};
 use crate::SiteIndexNetwork;
 use std::collections::{HashMap, HashSet};
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::{SvdTruncationPolicy, TensorDynLen};
 
 type DynIndex = Index<DynId, TagSet>;
 
@@ -202,10 +202,16 @@ fn assert_identity_application(
 
 #[test]
 fn test_apply_options_builder() {
-    let opts = ApplyOptions::zipup().with_max_rank(50).with_rtol(1e-10);
+    let policy = SvdTruncationPolicy::new(1e-10)
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    let opts = ApplyOptions::zipup()
+        .with_max_rank(50)
+        .with_svd_policy(policy);
     assert_eq!(opts.method, ContractionMethod::Zipup);
     assert_eq!(opts.max_rank, Some(50));
-    assert_eq!(opts.rtol, Some(1e-10));
+    assert_eq!(opts.svd_policy, Some(policy));
+    assert_eq!(opts.qr_rtol, None);
 
     let fit = ApplyOptions::fit().with_nfullsweeps(3);
     assert_eq!(fit.method, ContractionMethod::Fit);

--- a/crates/tensor4all-treetn/src/options.rs
+++ b/crates/tensor4all-treetn/src/options.rs
@@ -8,7 +8,14 @@
 
 use crate::algorithm::CanonicalForm;
 use crate::treetn::SwapOptions;
-use tensor4all_core::truncation::{HasTruncationParams, TruncationParams};
+use tensor4all_core::SvdTruncationPolicy;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(crate) struct FactorizationToleranceOptions {
+    pub max_rank: Option<usize>,
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    pub qr_rtol: Option<f64>,
+}
 
 /// Options for canonicalization operations.
 ///
@@ -80,40 +87,29 @@ impl CanonicalizationOptions {
 /// # Builder Pattern
 ///
 /// ```
-/// use tensor4all_treetn::{CanonicalForm, TruncationOptions};
+/// use tensor4all_core::SvdTruncationPolicy;
+/// use tensor4all_treetn::TruncationOptions;
 ///
 /// let options = TruncationOptions::default()
 ///     .with_max_rank(50)
-///     .with_rtol(1e-10);
+///     .with_svd_policy(SvdTruncationPolicy::new(1e-10));
 ///
-/// assert!(matches!(options.form, CanonicalForm::Unitary));
 /// assert_eq!(options.max_rank(), Some(50));
-/// assert_eq!(options.rtol(), Some(1e-10));
+/// assert_eq!(options.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct TruncationOptions {
-    /// Canonical form / algorithm to use (SVD, LU, or CI)
-    pub form: CanonicalForm,
-    /// Truncation parameters (rtol, max_rank).
-    pub truncation: TruncationParams,
+    #[allow(dead_code)]
+    pub(crate) form: CanonicalForm,
+    pub(crate) truncation: FactorizationToleranceOptions,
 }
 
 impl Default for TruncationOptions {
     fn default() -> Self {
         Self {
             form: CanonicalForm::Unitary,
-            truncation: TruncationParams::default(),
+            truncation: FactorizationToleranceOptions::default(),
         }
-    }
-}
-
-impl HasTruncationParams for TruncationOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
     }
 }
 
@@ -129,24 +125,18 @@ impl TruncationOptions {
         self
     }
 
-    /// Create options with a relative tolerance.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.truncation.rtol = Some(rtol);
+    /// Set the SVD truncation policy used during the truncation sweep.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.truncation.svd_policy = Some(policy);
         self
     }
 
-    /// Set the canonical form / algorithm.
-    pub fn with_form(mut self, form: CanonicalForm) -> Self {
-        self.form = form;
-        self
+    /// Get the SVD truncation policy.
+    pub fn svd_policy(&self) -> Option<SvdTruncationPolicy> {
+        self.truncation.svd_policy
     }
 
-    /// Get rtol (for backwards compatibility).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
-    }
-
-    /// Get max_rank (for backwards compatibility).
+    /// Get max_rank.
     pub fn max_rank(&self) -> Option<usize> {
         self.truncation.max_rank
     }
@@ -157,24 +147,27 @@ impl TruncationOptions {
 /// # Builder Pattern
 ///
 /// ```
+/// use tensor4all_core::SvdTruncationPolicy;
 /// use tensor4all_treetn::{CanonicalForm, SplitOptions};
 ///
 /// let options = SplitOptions::default()
 ///     .with_max_rank(50)
-///     .with_rtol(1e-10)
+///     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
+///     .with_qr_rtol(1e-12)
 ///     .with_final_sweep(true);
 ///
 /// assert!(matches!(options.form, CanonicalForm::Unitary));
 /// assert_eq!(options.max_rank(), Some(50));
-/// assert_eq!(options.rtol(), Some(1e-10));
+/// assert_eq!(options.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
+/// assert_eq!(options.qr_rtol(), Some(1e-12));
 /// assert!(options.final_sweep);
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct SplitOptions {
     /// Canonical form / algorithm to use (SVD, QR, etc.)
     pub form: CanonicalForm,
-    /// Truncation parameters (rtol, max_rank).
-    pub truncation: TruncationParams,
+    /// Algorithm-aware factorization tolerances.
+    pub(crate) truncation: FactorizationToleranceOptions,
     /// Whether to perform a final sweep for global bond dimension optimization
     pub final_sweep: bool,
 }
@@ -183,19 +176,9 @@ impl Default for SplitOptions {
     fn default() -> Self {
         Self {
             form: CanonicalForm::Unitary,
-            truncation: TruncationParams::default(),
+            truncation: FactorizationToleranceOptions::default(),
             final_sweep: false,
         }
-    }
-}
-
-impl HasTruncationParams for SplitOptions {
-    fn truncation_params(&self) -> &TruncationParams {
-        &self.truncation
-    }
-
-    fn truncation_params_mut(&mut self) -> &mut TruncationParams {
-        &mut self.truncation
     }
 }
 
@@ -211,9 +194,15 @@ impl SplitOptions {
         self
     }
 
-    /// Create options with a relative tolerance.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.truncation.rtol = Some(rtol);
+    /// Set the SVD truncation policy used when `form` is unitary/SVD-based.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.truncation.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set the QR-specific relative tolerance used when `form` is QR-based.
+    pub fn with_qr_rtol(mut self, rtol: f64) -> Self {
+        self.truncation.qr_rtol = Some(rtol);
         self
     }
 
@@ -229,12 +218,17 @@ impl SplitOptions {
         self
     }
 
-    /// Get rtol (for backwards compatibility).
-    pub fn rtol(&self) -> Option<f64> {
-        self.truncation.rtol
+    /// Get the SVD truncation policy.
+    pub fn svd_policy(&self) -> Option<SvdTruncationPolicy> {
+        self.truncation.svd_policy
     }
 
-    /// Get max_rank (for backwards compatibility).
+    /// Get the QR-specific relative tolerance.
+    pub fn qr_rtol(&self) -> Option<f64> {
+        self.truncation.qr_rtol
+    }
+
+    /// Get max_rank.
     pub fn max_rank(&self) -> Option<usize> {
         self.truncation.max_rank
     }
@@ -262,6 +256,7 @@ impl SplitOptions {
 /// use tensor4all_treetn::{
 ///     RestructureOptions, SplitOptions, SwapOptions, TruncationOptions,
 /// };
+/// use tensor4all_core::SvdTruncationPolicy;
 ///
 /// let options = RestructureOptions::new()
 ///     .with_split(SplitOptions::new().with_max_rank(32))
@@ -269,7 +264,9 @@ impl SplitOptions {
 ///         max_rank: Some(16),
 ///         rtol: Some(1e-10),
 ///     })
-///     .with_final_truncation(TruncationOptions::new().with_rtol(1e-12));
+///     .with_final_truncation(
+///         TruncationOptions::new().with_svd_policy(SvdTruncationPolicy::new(1e-12)),
+///     );
 ///
 /// assert_eq!(options.split.max_rank(), Some(32));
 /// assert!(!options.split.final_sweep);
@@ -279,8 +276,8 @@ impl SplitOptions {
 ///     options
 ///         .final_truncation
 ///         .as_ref()
-///         .and_then(TruncationOptions::rtol),
-///     Some(1e-12)
+///         .and_then(TruncationOptions::svd_policy),
+///     Some(SvdTruncationPolicy::new(1e-12))
 /// );
 /// ```
 #[derive(Debug, Clone, Default)]
@@ -288,10 +285,11 @@ pub struct RestructureOptions {
     /// Options for the split/refinement phase.
     ///
     /// These settings matter when a current node must be factored into multiple
-    /// fragments before any fragment movement can happen. Higher `max_rank`
-    /// and smaller `rtol` preserve more fidelity but can increase intermediate
-    /// bond dimensions. `final_sweep` should usually remain `false` here unless
-    /// a split-only workflow is being optimized in isolation.
+    /// fragments before any fragment movement can happen. Higher `max_rank`,
+    /// stricter `svd_policy`, and smaller `qr_rtol` preserve more fidelity but
+    /// can increase intermediate bond dimensions. `final_sweep` should usually
+    /// remain `false` here unless a split-only workflow is being optimized in
+    /// isolation.
     pub split: SplitOptions,
     /// Options for the site-transport / swap phase.
     ///
@@ -393,9 +391,14 @@ impl RestructureOptions {
     ///
     /// ```
     /// use tensor4all_treetn::{RestructureOptions, TruncationOptions};
+    /// use tensor4all_core::SvdTruncationPolicy;
     ///
     /// let options = RestructureOptions::new()
-    ///     .with_final_truncation(TruncationOptions::new().with_max_rank(10));
+    ///     .with_final_truncation(
+    ///         TruncationOptions::new()
+    ///             .with_max_rank(10)
+    ///             .with_svd_policy(SvdTruncationPolicy::new(1e-10)),
+    ///     );
     ///
     /// assert_eq!(
     ///     options

--- a/crates/tensor4all-treetn/src/options/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/options/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::SwapOptions;
+use tensor4all_core::{SingularValueMeasure, SvdTruncationPolicy, TruncationRule};
 
 #[test]
 fn test_canonicalization_options_default() {
@@ -36,34 +37,39 @@ fn test_canonicalization_options_builder() {
 #[test]
 fn test_truncation_options_default() {
     let opts = TruncationOptions::default();
-    assert_eq!(opts.form, CanonicalForm::Unitary);
-    assert_eq!(opts.rtol(), None);
     assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.svd_policy(), None);
 }
 
 #[test]
 fn test_truncation_options_new() {
     let opts = TruncationOptions::new();
-    assert_eq!(opts.form, CanonicalForm::Unitary);
+    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.svd_policy(), None);
+}
+
+#[test]
+fn test_truncation_options_do_not_expose_form() {
+    let opts = TruncationOptions::new().with_max_rank(8);
+    assert_eq!(opts.max_rank(), Some(8));
+}
+
+#[test]
+fn test_tree_truncate_uses_svd_policy() {
+    let opts = TruncationOptions::new().with_svd_policy(SvdTruncationPolicy::new(1e-10));
+    assert_eq!(opts.svd_policy().unwrap().rule, TruncationRule::PerValue);
 }
 
 #[test]
 fn test_truncation_options_builder() {
+    let policy = SvdTruncationPolicy::new(1e-10)
+        .with_squared_values()
+        .with_discarded_tail_sum();
     let opts = TruncationOptions::new()
         .with_max_rank(50)
-        .with_rtol(1e-10)
-        .with_form(CanonicalForm::Unitary);
+        .with_svd_policy(policy);
     assert_eq!(opts.max_rank(), Some(50));
-    assert_eq!(opts.rtol(), Some(1e-10));
-    assert_eq!(opts.form, CanonicalForm::Unitary);
-}
-
-#[test]
-fn test_truncation_options_has_truncation_params() {
-    let mut opts = TruncationOptions::new();
-    assert!(opts.truncation_params().rtol.is_none());
-    opts.truncation_params_mut().rtol = Some(1e-8);
-    assert_eq!(opts.truncation_params().rtol, Some(1e-8));
+    assert_eq!(opts.svd_policy(), Some(policy));
 }
 
 #[test]
@@ -71,8 +77,9 @@ fn test_split_options_default() {
     let opts = SplitOptions::default();
     assert_eq!(opts.form, CanonicalForm::Unitary);
     assert!(!opts.final_sweep);
-    assert_eq!(opts.rtol(), None);
     assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.svd_policy(), None);
+    assert_eq!(opts.qr_rtol(), None);
 }
 
 #[test]
@@ -83,23 +90,30 @@ fn test_split_options_new() {
 
 #[test]
 fn test_split_options_builder() {
+    let policy = SvdTruncationPolicy::new(1e-12).with_squared_values();
     let opts = SplitOptions::new()
         .with_max_rank(100)
-        .with_rtol(1e-12)
+        .with_svd_policy(policy)
+        .with_qr_rtol(1e-12)
         .with_form(CanonicalForm::Unitary)
         .with_final_sweep(true);
     assert_eq!(opts.max_rank(), Some(100));
-    assert_eq!(opts.rtol(), Some(1e-12));
+    assert_eq!(opts.svd_policy(), Some(policy));
+    assert_eq!(opts.qr_rtol(), Some(1e-12));
     assert_eq!(opts.form, CanonicalForm::Unitary);
     assert!(opts.final_sweep);
 }
 
 #[test]
-fn test_split_options_has_truncation_params() {
-    let mut opts = SplitOptions::new();
-    assert!(opts.truncation_params().max_rank.is_none());
-    opts.truncation_params_mut().max_rank = Some(25);
-    assert_eq!(opts.truncation_params().max_rank, Some(25));
+fn test_split_options_policy_builders_are_independent() {
+    let opts = SplitOptions::new()
+        .with_svd_policy(SvdTruncationPolicy::new(1e-8).with_squared_values())
+        .with_qr_rtol(1e-6);
+    assert_eq!(
+        opts.svd_policy().map(|policy| policy.measure),
+        Some(SingularValueMeasure::SquaredValue)
+    );
+    assert_eq!(opts.qr_rtol(), Some(1e-6));
 }
 
 #[test]
@@ -111,13 +125,14 @@ fn test_restructure_options_default_and_builder() {
     assert_eq!(opts.swap.rtol, None);
     assert!(opts.final_truncation.is_none());
 
+    let final_policy = SvdTruncationPolicy::new(1e-10).with_discarded_tail_sum();
     let opts = RestructureOptions::new()
         .with_split(SplitOptions::new().with_max_rank(16).with_final_sweep(true))
         .with_swap(SwapOptions {
             max_rank: Some(8),
             rtol: Some(1e-9),
         })
-        .with_final_truncation(TruncationOptions::new().with_rtol(1e-10));
+        .with_final_truncation(TruncationOptions::new().with_svd_policy(final_policy));
     assert_eq!(opts.split.max_rank(), Some(16));
     assert!(opts.split.final_sweep);
     assert_eq!(opts.swap.max_rank, Some(8));
@@ -125,7 +140,7 @@ fn test_restructure_options_default_and_builder() {
     assert_eq!(
         opts.final_truncation
             .as_ref()
-            .and_then(TruncationOptions::rtol),
-        Some(1e-10)
+            .and_then(TruncationOptions::svd_policy),
+        Some(final_policy)
     );
 }

--- a/crates/tensor4all-treetn/src/treetn/canonicalize.rs
+++ b/crates/tensor4all-treetn/src/treetn/canonicalize.rs
@@ -142,8 +142,9 @@ where
         let factorize_options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            rtol: None,
             max_rank: None,
+            svd_policy: None,
+            qr_rtol: None,
         };
 
         // Process edges in order (leaves towards center)

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -15,7 +15,8 @@ use anyhow::{Context, Result};
 
 use crate::algorithm::CanonicalForm;
 use tensor4all_core::{
-    AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike,
+    AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, SvdTruncationPolicy,
+    TensorLike,
 };
 
 use super::TreeTN;
@@ -249,7 +250,7 @@ where
     /// # Arguments
     /// * `other` - The other TreeTN to contract with (must have same topology)
     /// * `center` - The center node name towards which to contract
-    /// * `rtol` - Optional relative tolerance for truncation
+    /// * `svd_policy` - Optional SVD truncation policy
     /// * `max_rank` - Optional maximum bond dimension
     ///
     /// # Returns
@@ -258,7 +259,7 @@ where
         &self,
         other: &Self,
         center: &V,
-        rtol: Option<f64>,
+        svd_policy: Option<SvdTruncationPolicy>,
         max_rank: Option<usize>,
     ) -> Result<Self>
     where
@@ -266,7 +267,7 @@ where
         <T::Index as IndexLike>::Id:
             Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
     {
-        self.contract_zipup_with(other, center, CanonicalForm::Unitary, rtol, max_rank)
+        self.contract_zipup_with(other, center, CanonicalForm::Unitary, svd_policy, max_rank)
     }
 
     /// Contract two TreeTNs with the same topology using the zip-up algorithm with a specified form.
@@ -277,7 +278,7 @@ where
         other: &Self,
         center: &V,
         form: CanonicalForm,
-        rtol: Option<f64>,
+        svd_policy: Option<SvdTruncationPolicy>,
         max_rank: Option<usize>,
     ) -> Result<Self>
     where
@@ -285,7 +286,7 @@ where
         <T::Index as IndexLike>::Id:
             Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
     {
-        self.contract_zipup_tree_accumulated(other, center, form, rtol, max_rank)
+        self.contract_zipup_tree_accumulated(other, center, form, svd_policy, max_rank)
     }
 
     /// Contract two TreeTNs using zip-up algorithm with accumulated intermediate tensors.
@@ -304,7 +305,7 @@ where
     /// * `other` - The other TreeTN to contract with (must have same topology)
     /// * `center` - The center node name towards which to contract
     /// * `form` - Canonical form (Unitary/LU/CI)
-    /// * `rtol` - Optional relative tolerance for truncation
+    /// * `svd_policy` - Optional SVD truncation policy
     /// * `max_rank` - Optional maximum bond dimension
     ///
     /// # Returns
@@ -314,7 +315,7 @@ where
         other: &Self,
         center: &V,
         form: CanonicalForm,
-        rtol: Option<f64>,
+        svd_policy: Option<SvdTruncationPolicy>,
         max_rank: Option<usize>,
     ) -> Result<Self>
     where
@@ -394,12 +395,23 @@ where
             CanonicalForm::CI => FactorizeAlg::CI,
         };
 
-        let factorize_options = FactorizeOptions {
-            alg,
-            canonical: Canonical::Left,
-            rtol,
-            max_rank,
-        };
+        let mut factorize_options = match alg {
+            FactorizeAlg::SVD => FactorizeOptions::svd(),
+            FactorizeAlg::QR => FactorizeOptions::qr(),
+            FactorizeAlg::LU => FactorizeOptions::lu(),
+            FactorizeAlg::CI => FactorizeOptions::ci(),
+        }
+        .with_canonical(Canonical::Left);
+
+        if let Some(max_rank) = max_rank {
+            factorize_options = factorize_options.with_max_rank(max_rank);
+        }
+        if let Some(policy) = svd_policy {
+            factorize_options = factorize_options.with_svd_policy(policy);
+        }
+        factorize_options
+            .validate()
+            .map_err(|err| anyhow::anyhow!("invalid zipup factorization options: {err}"))?;
 
         // 9. Process edges from leaves towards root
         for (source_name, destination_name) in &edges {
@@ -797,8 +809,10 @@ pub struct ContractionOptions {
     pub method: ContractionMethod,
     /// Maximum bond dimension (optional).
     pub max_rank: Option<usize>,
-    /// Relative tolerance for truncation (optional).
-    pub rtol: Option<f64>,
+    /// Explicit SVD truncation policy (optional).
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// QR-specific relative tolerance (optional).
+    pub qr_rtol: Option<f64>,
     /// Number of full sweeps for Fit method.
     ///
     /// A full sweep visits each edge twice (forward and backward) using an Euler tour.
@@ -814,7 +828,8 @@ impl Default for ContractionOptions {
         Self {
             method: ContractionMethod::default(),
             max_rank: None,
-            rtol: None,
+            svd_policy: None,
+            qr_rtol: None,
             nfullsweeps: 1,
             convergence_tol: None,
             factorize_alg: FactorizeAlg::default(),
@@ -847,9 +862,15 @@ impl ContractionOptions {
         self
     }
 
-    /// Set relative tolerance.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.rtol = Some(rtol);
+    /// Set the SVD truncation policy.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set the QR-specific relative tolerance.
+    pub fn with_qr_rtol(mut self, rtol: f64) -> Self {
+        self.qr_rtol = Some(rtol);
         self
     }
 
@@ -889,7 +910,7 @@ where
 {
     match options.method {
         ContractionMethod::Zipup => {
-            tn_a.contract_zipup(tn_b, center, options.rtol, options.max_rank)
+            tn_a.contract_zipup(tn_b, center, options.svd_policy, options.max_rank)
         }
         ContractionMethod::Fit => {
             let fit_options = FitContractionOptions::new(options.nfullsweeps)
@@ -899,10 +920,16 @@ where
             } else {
                 fit_options
             };
-            // For fit, unspecified rtol and explicit rtol=0.0 are intended to be
-            // identical. Normalize here so downstream code sees exactly the same
-            // option state in both cases.
-            let fit_options = fit_options.with_rtol(options.rtol.unwrap_or(0.0));
+            let fit_options = if let Some(policy) = options.svd_policy {
+                fit_options.with_svd_policy(policy)
+            } else {
+                fit_options
+            };
+            let fit_options = if let Some(qr_rtol) = options.qr_rtol {
+                fit_options.with_qr_rtol(qr_rtol)
+            } else {
+                fit_options
+            };
             let fit_options = if let Some(tol) = options.convergence_tol {
                 fit_options.with_convergence_tol(tol)
             } else {
@@ -910,9 +937,14 @@ where
             };
             super::fit::contract_fit(tn_a, tn_b, center, fit_options)
         }
-        ContractionMethod::Naive => {
-            contract_naive_to_treetn(tn_a, tn_b, center, options.max_rank, options.rtol)
-        }
+        ContractionMethod::Naive => contract_naive_to_treetn(
+            tn_a,
+            tn_b,
+            center,
+            options.max_rank,
+            options.svd_policy,
+            options.qr_rtol,
+        ),
     }
 }
 
@@ -930,7 +962,8 @@ pub fn contract_naive_to_treetn<T, V>(
     tn_b: &TreeTN<T, V>,
     center: &V,
     _max_rank: Option<usize>,
-    _rtol: Option<f64>,
+    _svd_policy: Option<SvdTruncationPolicy>,
+    _qr_rtol: Option<f64>,
 ) -> Result<TreeTN<T, V>>
 where
     T: TensorLike,

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IndexLike, SvdTruncationPolicy, TensorDynLen, TensorIndex};
 
 /// Helper to create a simple 2-node TreeTN: A -- bond -- B
 fn make_two_node_treetn() -> (TreeTN<TensorDynLen, String>, DynIndex, DynIndex, DynIndex) {
@@ -38,7 +38,8 @@ fn test_contraction_options_default() {
     let opts = ContractionOptions::default();
     assert_eq!(opts.method, ContractionMethod::Zipup);
     assert!(opts.max_rank.is_none());
-    assert!(opts.rtol.is_none());
+    assert!(opts.svd_policy.is_none());
+    assert!(opts.qr_rtol.is_none());
     assert_eq!(opts.nfullsweeps, 1);
     assert!(opts.convergence_tol.is_none());
 }
@@ -63,18 +64,33 @@ fn test_contraction_options_fit() {
 
 #[test]
 fn test_contraction_options_builders() {
+    let policy = SvdTruncationPolicy::new(1e-8)
+        .with_squared_values()
+        .with_discarded_tail_sum();
     let opts = ContractionOptions::zipup()
         .with_max_rank(10)
-        .with_rtol(1e-8)
+        .with_svd_policy(policy)
         .with_nfullsweeps(3)
         .with_convergence_tol(1e-6)
         .with_factorize_alg(FactorizeAlg::LU);
 
     assert_eq!(opts.max_rank, Some(10));
-    assert_eq!(opts.rtol, Some(1e-8));
+    assert_eq!(opts.svd_policy, Some(policy));
+    assert_eq!(opts.qr_rtol, None);
     assert_eq!(opts.nfullsweeps, 3);
     assert_eq!(opts.convergence_tol, Some(1e-6));
     assert_eq!(opts.factorize_alg, FactorizeAlg::LU);
+}
+
+#[test]
+fn test_contraction_options_qr_builder() {
+    let opts = ContractionOptions::fit()
+        .with_factorize_alg(FactorizeAlg::QR)
+        .with_qr_rtol(1e-7);
+
+    assert_eq!(opts.factorize_alg, FactorizeAlg::QR);
+    assert_eq!(opts.qr_rtol, Some(1e-7));
+    assert!(opts.svd_policy.is_none());
 }
 
 #[test]
@@ -260,7 +276,8 @@ fn test_naive_contraction_scalar_result() {
         TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     // Naive contraction: inner product = 1+2+3 = 6
-    let result = contract_naive_to_treetn(&tn_a, &tn_b, &"A".to_string(), None, None).unwrap();
+    let result =
+        contract_naive_to_treetn(&tn_a, &tn_b, &"A".to_string(), None, None, None).unwrap();
 
     assert_eq!(result.node_count(), 1);
     let dense = result.contract_to_tensor().unwrap();

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -35,7 +35,7 @@ use anyhow::Result;
 use tensor4all_core::{
     print_and_reset_contract_profile, print_and_reset_native_einsum_profile,
     reset_contract_profile, reset_native_einsum_profile, AllowedPairs, Canonical, FactorizeAlg,
-    FactorizeOptions, IndexLike, TensorLike,
+    FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorLike,
 };
 
 use super::localupdate::{LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater};
@@ -485,8 +485,12 @@ where
     pub envs: FitEnvironment<T, V>,
     /// Maximum bond dimension
     pub max_rank: Option<usize>,
-    /// Relative tolerance for truncation
-    pub rtol: Option<f64>,
+    /// Legacy relative tolerance retained for same-crate tests and call chains.
+    pub(crate) rtol: Option<f64>,
+    /// Explicit SVD truncation policy
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// QR-specific relative tolerance
+    pub qr_rtol: Option<f64>,
     /// Factorization algorithm
     pub factorize_alg: FactorizeAlg,
 }
@@ -503,7 +507,8 @@ where
     /// * `tn_a` - First input TreeTN
     /// * `tn_b` - Second input TreeTN
     /// * `max_rank` - Maximum bond dimension for truncation
-    /// * `rtol` - Relative tolerance for truncation
+    /// * `svd_policy` - Explicit SVD truncation policy
+    /// * `qr_rtol` - QR-specific relative tolerance
     ///
     /// Note: sim_internal_inds() should be called on tn_a and tn_b before passing
     /// if index collision is a concern. This is not done here because contraction
@@ -520,6 +525,8 @@ where
             envs: FitEnvironment::new(),
             max_rank,
             rtol,
+            svd_policy: rtol.map(SvdTruncationPolicy::new),
+            qr_rtol: None,
             factorize_alg: FactorizeAlg::SVD,
         }
     }
@@ -527,6 +534,19 @@ where
     /// Set the factorization algorithm.
     pub fn with_factorize_alg(mut self, alg: FactorizeAlg) -> Self {
         self.factorize_alg = alg;
+        self
+    }
+
+    /// Set the SVD truncation policy used by fit sweeps.
+    pub(crate) fn with_svd_policy(mut self, policy: Option<SvdTruncationPolicy>) -> Self {
+        self.rtol = policy.map(|value| value.threshold);
+        self.svd_policy = policy;
+        self
+    }
+
+    /// Set the QR-specific relative tolerance used by fit sweeps.
+    pub(crate) fn with_qr_rtol(mut self, qr_rtol: Option<f64>) -> Self {
+        self.qr_rtol = qr_rtol;
         self
     }
 }
@@ -664,23 +684,26 @@ where
         };
         options = options.with_canonical(Canonical::Left);
 
-        // Use user's explicit rtol if specified, otherwise rtol=0.
-        // We must NOT let the default_svd_rtol fallback (1e-12) be applied,
-        // so we always set an explicit value here.
-        options = options.with_rtol(self.rtol.unwrap_or(0.0));
+        if let Some(policy) = self.svd_policy {
+            options = options.with_svd_policy(policy);
+        }
+        if let Some(qr_rtol) = self.qr_rtol {
+            options = options.with_qr_rtol(qr_rtol);
+        }
+        options
+            .validate()
+            .map_err(|e| anyhow::anyhow!("invalid fit factorization options: {e}"))?;
 
         // Determine bond dimension cap for this factorization step.
         // - If max_rank is explicitly specified, use it.
-        // - If a positive rtol is specified (but max_rank is not), allow bonds
-        //   to grow freely — truncation is controlled only by rtol, matching
-        //   Julia's ITensorMPS.jl where maxdim defaults to typemax(Int).
-        // - Otherwise (neither specified, or rtol=0), cap at the existing bond
-        //   dimension to preserve the zipup initialization size. This ensures
-        //   that with_rtol(0.0) and no rtol behave identically (both cap bonds).
+        // - If an algorithm-specific tolerance is specified (but max_rank is not),
+        //   allow bonds to grow freely and let the factorization policy decide.
+        // - Otherwise, cap at the existing bond dimension to preserve the zipup
+        //   initialization size.
         let bond_cap = if self.max_rank.is_some() {
             self.max_rank
-        } else if self.rtol.is_some_and(|r| r > 0.0) {
-            None // positive rtol controls truncation; no bond cap
+        } else if self.svd_policy.is_some() || self.qr_rtol.is_some() {
+            None
         } else {
             subtree
                 .edge_between(node_u, node_v)
@@ -760,8 +783,12 @@ pub struct FitContractionOptions {
     pub nfullsweeps: usize,
     /// Maximum bond dimension.
     pub max_rank: Option<usize>,
-    /// Relative tolerance for truncation.
-    pub rtol: Option<f64>,
+    /// Legacy relative tolerance retained for same-crate tests and call chains.
+    pub(crate) rtol: Option<f64>,
+    /// Explicit SVD truncation policy.
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// QR-specific relative tolerance.
+    pub qr_rtol: Option<f64>,
     /// Factorization algorithm.
     pub factorize_alg: FactorizeAlg,
     /// Tolerance for early termination based on relative change.
@@ -776,6 +803,8 @@ impl Default for FitContractionOptions {
             nfullsweeps: 1,
             max_rank: None,
             rtol: None,
+            svd_policy: None,
+            qr_rtol: None,
             factorize_alg: FactorizeAlg::SVD,
             convergence_tol: None,
         }
@@ -797,10 +826,27 @@ impl FitContractionOptions {
         self
     }
 
-    /// Set relative tolerance.
-    pub fn with_rtol(mut self, rtol: f64) -> Self {
-        self.rtol = Some(rtol);
+    /// Set the SVD truncation policy.
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.rtol = Some(policy.threshold);
+        self.svd_policy = Some(policy);
         self
+    }
+
+    /// Set the QR-specific relative tolerance.
+    pub fn with_qr_rtol(mut self, rtol: f64) -> Self {
+        self.qr_rtol = Some(rtol);
+        self
+    }
+
+    /// Set relative tolerance as a per-value relative SVD policy.
+    pub(crate) fn with_rtol(self, rtol: f64) -> Self {
+        self.with_svd_policy(SvdTruncationPolicy::new(rtol))
+    }
+
+    /// Get the legacy SVD threshold value when represented as an rtol.
+    pub(crate) fn rtol(&self) -> Option<f64> {
+        self.svd_policy.map(|policy| policy.threshold)
     }
 
     /// Set factorization algorithm.
@@ -856,17 +902,13 @@ where
         ));
     }
 
-    // Initialize C using zipup (arguments: rtol, max_rank).
-    // When rtol is not specified, use 0.0 to prevent the default_svd_rtol
-    // fallback (1e-12) from being applied. This is consistent with how
-    // rtol is handled during sweeps.
-    let zipup_rtol = Some(options.rtol.unwrap_or(0.0));
+    // Initialize C using the SVD-based zipup contraction.
     let zipup_started = profile_enabled.then(Instant::now);
     let mut tn_c = tn_a.contract_zipup_tree_accumulated(
         tn_b,
         center,
         CanonicalForm::Unitary,
-        zipup_rtol,
+        options.svd_policy,
         options.max_rank,
     )?;
     if let Some(zipup_started) = zipup_started {
@@ -877,16 +919,17 @@ where
 
     // The zip-up initializer already returns a network centered at `center`.
 
-    // With neither max_rank nor a positive rtol, fit sweeps cannot change the
-    // bond cap and only introduce numerical drift relative to the zip-up
-    // initializer. Treat rtol=None and rtol=0.0 identically by returning the
-    // zip-up result directly in this regime.
-    if options.max_rank.is_none() && options.rtol.unwrap_or(0.0) <= 0.0 {
+    // With neither max_rank nor an algorithm-specific truncation override, fit
+    // sweeps cannot change the bond cap and only introduce numerical drift
+    // relative to the zip-up initializer.
+    if options.max_rank.is_none() && options.svd_policy.is_none() && options.qr_rtol.is_none() {
         return Ok(tn_c);
     }
 
     // Create FitUpdater (environments are computed lazily)
-    let mut updater = FitUpdater::new(tn_a.clone(), tn_b.clone(), options.max_rank, options.rtol)
+    let mut updater = FitUpdater::new(tn_a.clone(), tn_b.clone(), options.max_rank, None)
+        .with_svd_policy(options.svd_policy)
+        .with_qr_rtol(options.qr_rtol)
         .with_factorize_alg(options.factorize_alg);
 
     // Create sweep plan

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -446,6 +446,7 @@ use tensor4all_core::{Canonical, FactorizeOptions, SvdTruncationPolicy};
 /// let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
 /// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
 /// let mut treetn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
+/// treetn.canonicalize_mut(std::iter::once(0usize), Default::default())?;
 ///
 /// let plan = LocalUpdateSweepPlan::from_treetn(&treetn, &0usize, 2).unwrap();
 /// let mut updater = TruncateUpdater::new(

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -420,7 +420,7 @@ where
 // TruncateUpdater - LocalUpdater implementation for truncation
 // ============================================================================
 
-use tensor4all_core::{Canonical, FactorizeOptions};
+use tensor4all_core::{Canonical, FactorizeOptions, SvdTruncationPolicy};
 
 /// Truncation updater for nsite=2 sweeps.
 ///
@@ -435,7 +435,7 @@ use tensor4all_core::{Canonical, FactorizeOptions};
 /// 4. B is the orthogonality center (isometry pointing towards B)
 ///
 /// # Usage
-/// ```no_run
+/// ```
 /// use tensor4all_core::{DynIndex, TensorDynLen};
 /// use tensor4all_treetn::{apply_local_update_sweep, LocalUpdateSweepPlan, TreeTN, TruncateUpdater};
 ///
@@ -448,7 +448,10 @@ use tensor4all_core::{Canonical, FactorizeOptions};
 /// let mut treetn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
 ///
 /// let plan = LocalUpdateSweepPlan::from_treetn(&treetn, &0usize, 2).unwrap();
-/// let mut updater = TruncateUpdater::new(Some(4), Some(1e-10));
+/// let mut updater = TruncateUpdater::new(
+///     Some(4),
+///     Some(tensor4all_core::SvdTruncationPolicy::new(1e-10)),
+/// );
 /// apply_local_update_sweep(&mut treetn, &plan, &mut updater)?;
 ///
 /// assert_eq!(treetn.node_count(), 2);
@@ -459,8 +462,8 @@ use tensor4all_core::{Canonical, FactorizeOptions};
 pub struct TruncateUpdater {
     /// Maximum bond dimension after truncation.
     pub max_rank: Option<usize>,
-    /// Relative tolerance for truncation (singular values below rtol * max_sv are dropped).
-    pub rtol: Option<f64>,
+    /// Explicit SVD truncation policy.
+    pub svd_policy: Option<SvdTruncationPolicy>,
 }
 
 impl TruncateUpdater {
@@ -468,9 +471,12 @@ impl TruncateUpdater {
     ///
     /// # Arguments
     /// * `max_rank` - Maximum bond dimension (None for no limit)
-    /// * `rtol` - Relative tolerance for truncation (None for no tolerance-based truncation)
-    pub fn new(max_rank: Option<usize>, rtol: Option<f64>) -> Self {
-        Self { max_rank, rtol }
+    /// * `svd_policy` - SVD truncation policy override (None uses the global default)
+    pub fn new(max_rank: Option<usize>, svd_policy: Option<SvdTruncationPolicy>) -> Self {
+        Self {
+            max_rank,
+            svd_policy,
+        }
     }
 }
 
@@ -535,8 +541,8 @@ where
         if let Some(max_rank) = self.max_rank {
             options = options.with_max_rank(max_rank);
         }
-        if let Some(rtol) = self.rtol {
-            options = options.with_rtol(rtol);
+        if let Some(policy) = self.svd_policy {
+            options = options.with_svd_policy(policy);
         }
 
         // Factorize

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -1583,7 +1583,8 @@ where
             swap_factorize_options = swap_factorize_options.with_max_rank(mr);
         }
         if let Some(rtol) = options.rtol {
-            swap_factorize_options = swap_factorize_options.with_rtol(rtol);
+            swap_factorize_options = swap_factorize_options
+                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
         }
         let transport_factorize_options = FactorizeOptions::svd().with_canonical(Canonical::Left);
 

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -14,8 +14,8 @@ use super::contraction::{contract, ContractionOptions};
 use super::decompose::{factorize_tensor_to_treetn_with, TreeTopology};
 use super::TreeTN;
 use tensor4all_core::{
-    AllowedPairs, AnyScalar, DynIndex, FactorizeOptions, IndexLike, TensorDynLen, TensorIndex,
-    TensorLike,
+    AllowedPairs, AnyScalar, DynIndex, FactorizeAlg, FactorizeOptions, IndexLike, TensorDynLen,
+    TensorIndex, TensorLike,
 };
 
 type DiagonalPairApplication<V> = (
@@ -229,18 +229,28 @@ where
     Ok(())
 }
 
-fn factorize_options_from_contraction_options(options: &ContractionOptions) -> FactorizeOptions {
-    let mut factorize_options = FactorizeOptions {
-        alg: options.factorize_alg,
-        ..FactorizeOptions::default()
+fn factorize_options_from_contraction_options(
+    options: &ContractionOptions,
+) -> Result<FactorizeOptions> {
+    let mut factorize_options = match options.factorize_alg {
+        FactorizeAlg::SVD => FactorizeOptions::svd(),
+        FactorizeAlg::QR => FactorizeOptions::qr(),
+        FactorizeAlg::LU => FactorizeOptions::lu(),
+        FactorizeAlg::CI => FactorizeOptions::ci(),
     };
-    if let Some(rtol) = options.rtol {
-        factorize_options = factorize_options.with_rtol(rtol);
+    if let Some(policy) = options.svd_policy {
+        factorize_options = factorize_options.with_svd_policy(policy);
+    }
+    if let Some(rtol) = options.qr_rtol {
+        factorize_options = factorize_options.with_qr_rtol(rtol);
     }
     if let Some(max_rank) = options.max_rank {
         factorize_options = factorize_options.with_max_rank(max_rank);
     }
-    factorize_options
+    factorize_options.validate().map_err(|err| {
+        anyhow!("partial_contract: invalid contraction factorization options: {err}")
+    })?;
+    Ok(factorize_options)
 }
 
 fn union_result_topology<V>(
@@ -325,7 +335,7 @@ where
     }
 
     let topology = union_result_topology(a, b, &contracted_tensor)?;
-    let factorize_options = factorize_options_from_contraction_options(&options);
+    let factorize_options = factorize_options_from_contraction_options(&options)?;
     factorize_tensor_to_treetn_with(&contracted_tensor, &topology, factorize_options, center)
         .context("partial_contract: failed to factorize mismatched-topology dense result")
 }

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -450,8 +450,9 @@ where
             let factorize_options = FactorizeOptions {
                 alg: FactorizeAlg::QR,
                 canonical: Canonical::Left,
-                rtol: None,
                 max_rank: None,
+                svd_policy: None,
+                qr_rtol: None,
             };
 
             let factorize_result = remaining_tensor

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -15,12 +15,13 @@ use std::hash::Hash;
 
 use anyhow::{Context, Result};
 
-use crate::algorithm::CanonicalForm;
+use tensor4all_core::SvdTruncationPolicy;
 use tensor4all_core::{IndexLike, TensorLike};
 
 use super::localupdate::{apply_local_update_sweep, LocalUpdateSweepPlan, TruncateUpdater};
 use super::TreeTN;
 use crate::options::{CanonicalizationOptions, TruncationOptions};
+use crate::CanonicalForm;
 
 impl<T, V> TreeTN<T, V>
 where
@@ -31,7 +32,7 @@ where
     ///
     /// This is the recommended unified API for truncation. It accepts:
     /// - Center nodes specified by their node names (V)
-    /// - [`TruncationOptions`] to control the form, rtol, and max_rank
+    /// - [`TruncationOptions`] to control the SVD policy and max_rank
     ///
     /// # Algorithm
     /// 1. Canonicalize the network towards the center (required for truncation)
@@ -83,8 +84,7 @@ where
     {
         self.truncate_impl(
             canonical_region,
-            options.form,
-            options.truncation.rtol,
+            options.svd_policy(),
             options.truncation.max_rank,
             "truncate",
         )?;
@@ -105,8 +105,7 @@ where
     {
         self.truncate_impl(
             canonical_region,
-            options.form,
-            options.truncation.rtol,
+            options.svd_policy(),
             options.truncation.max_rank,
             "truncate_mut",
         )
@@ -118,8 +117,7 @@ where
     pub(crate) fn truncate_impl(
         &mut self,
         canonical_region: impl IntoIterator<Item = V>,
-        form: CanonicalForm,
-        rtol: Option<f64>,
+        svd_policy: Option<SvdTruncationPolicy>,
         max_rank: Option<usize>,
         context_name: &str,
     ) -> Result<()>
@@ -146,7 +144,8 @@ where
         let center_node = center_nodes.iter().next().unwrap().clone();
 
         // Step 1: Canonicalize towards the center (required before truncation sweep)
-        let canonicalize_options = CanonicalizationOptions::default().with_form(form);
+        let canonicalize_options =
+            CanonicalizationOptions::default().with_form(CanonicalForm::Unitary);
         self.canonicalize_impl(
             [center_node.clone()],
             canonicalize_options.form,
@@ -166,12 +165,12 @@ where
         }
 
         // Step 3: Apply truncation sweep
-        let mut updater = TruncateUpdater::new(max_rank, rtol);
+        let mut updater = TruncateUpdater::new(max_rank, svd_policy);
         apply_local_update_sweep(self, &plan, &mut updater)
             .context(format!("{}: truncation sweep failed", context_name))?;
 
         // The canonical form is maintained by the sweep
-        self.canonical_form = Some(form);
+        self.canonical_form = Some(CanonicalForm::Unitary);
 
         Ok(())
     }

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -849,7 +849,9 @@ fn test_truncate_three_node_chain() {
 }
 
 #[test]
-fn test_truncate_with_rtol() {
+fn test_truncate_with_svd_policy() {
+    use tensor4all_core::SvdTruncationPolicy;
+
     let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
@@ -872,11 +874,11 @@ fn test_truncate_with_rtol() {
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
 
-    // Truncate with rtol - should reduce rank significantly for low-rank data
+    // Truncate with an explicit SVD policy - should reduce rank for low-rank data
     let truncated = tn
         .truncate(
             std::iter::once(n2),
-            TruncationOptions::default().with_rtol(1e-10),
+            TruncationOptions::default().with_svd_policy(SvdTruncationPolicy::new(1e-10)),
         )
         .unwrap();
 
@@ -1800,13 +1802,19 @@ fn create_mpo_chain_for_fit() -> TreeTN<TensorDynLen, String> {
 
 #[test]
 fn test_fit_contraction_options() {
+    use tensor4all_core::SvdTruncationPolicy;
+
+    let policy = SvdTruncationPolicy::new(1e-8)
+        .with_squared_values()
+        .with_discarded_tail_sum();
     let options = FitContractionOptions::new(5)
         .with_max_rank(10)
-        .with_rtol(1e-8);
+        .with_svd_policy(policy);
 
-        assert_eq!(options.nfullsweeps, 5);
+    assert_eq!(options.nfullsweeps, 5);
     assert_eq!(options.max_rank, Some(10));
-    assert_eq!(options.rtol, Some(1e-8));
+    assert_eq!(options.svd_policy, Some(policy));
+    assert_eq!(options.qr_rtol, None);
 }
 
 // Note: test_fit_environment_basic was removed because FitEnvironment now uses

--- a/crates/tensor4all-treetn/tests/issue192_regression.rs
+++ b/crates/tensor4all-treetn/tests/issue192_regression.rs
@@ -200,8 +200,7 @@ fn issue192_regression_no_svd_nan_n5_identity_ones() -> anyhow::Result<()> {
         .context("failed to canonicalize initial x0=b")?;
 
     let truncation = TruncationOptions::default()
-        .with_form(CanonicalForm::Unitary)
-        .with_rtol(rtol)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
         .with_max_rank(bond_dim);
 
     let options = LinsolveOptions::default()

--- a/docs/book/src/guides/quantics.md
+++ b/docs/book/src/guides/quantics.md
@@ -138,6 +138,7 @@ Three methods are available, each with different tradeoffs:
 | `ApplyOptions::fit()` | Iterative variational optimization | Best compression; use when bond dim must be small |
 
 ```rust
+use tensor4all_core::SvdTruncationPolicy;
 use tensor4all_treetn::ApplyOptions;
 
 // Naive: exact but O(exp(n)) memory. Best for testing.
@@ -147,7 +148,7 @@ assert_eq!(opts.max_rank, None);
 // ZipUp (default): single-pass, controllable truncation.
 let opts = ApplyOptions::zipup()
     .with_max_rank(64)
-    .with_rtol(1e-10);
+    .with_svd_policy(SvdTruncationPolicy::new(1e-10));
 assert_eq!(opts.max_rank, Some(64));
 
 // Fit: iterative sweeps for best compression.

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -165,7 +165,7 @@ factor connected by a new bond index.
 ### SVD with truncation
 
 ```rust
-use tensor4all_core::{TensorDynLen, Index, factorize, FactorizeOptions};
+use tensor4all_core::{TensorDynLen, Index, factorize, FactorizeOptions, SvdTruncationPolicy};
 use tensor4all_core::index::DynId;
 
 let i = Index::new_dyn(4);
@@ -177,8 +177,8 @@ let mut rng = {
 };
 let t: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]);
 
-// SVD: split along i | j, discarding singular values below 1e-10.
-let opts = FactorizeOptions::svd().with_rtol(1e-10);
+// SVD: split along i | j, discarding singular values below the chosen policy threshold.
+let opts = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1e-10));
 let result = factorize(&t, &[i.clone()], &opts).unwrap();
 
 // result.left  has indices [i, bond]
@@ -188,7 +188,7 @@ let bond_dim = result.rank;
 println!("bond dimension after SVD: {bond_dim}");
 
 // Limit bond dimension explicitly.
-let opts_capped = FactorizeOptions::svd().with_rtol(0.0).with_max_rank(2);
+let opts_capped = FactorizeOptions::svd().with_max_rank(2);
 let result_capped = factorize(&t, &[i], &opts_capped).unwrap();
 assert!(result_capped.rank <= 2);
 ```
@@ -216,5 +216,7 @@ let result = factorize(&t, &[i], &opts).unwrap();
 ```
 
 Both `FactorizeOptions::svd()` and `FactorizeOptions::qr()` return builder
-structs. Chain `.with_rtol(tol)` and `.with_max_rank(n)` to configure truncation.
-For SVD, `result.singular_values` holds the retained singular values.
+structs. Use `.with_svd_policy(policy)` for SVD and `.with_qr_rtol(tol)` for
+QR-specific rank control. `with_max_rank(n)` remains available as an
+algorithm-independent hard cap. For SVD, `result.singular_values` holds the
+retained singular values.

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -214,14 +214,19 @@ After orthogonalization you can truncate bond dimensions by SVD:
 # )?;
 # let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 # tt.orthogonalize(1)?;
-tt.truncate(&TruncateOptions::svd().with_rtol(1e-10).with_max_rank(2))?;
+tt.truncate(
+    &TruncateOptions::svd()
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+        .with_max_rank(2),
+)?;
 assert!(tt.maxbonddim() <= 2);
 # Ok(())
 # }
 ```
 
-`rtol` is the relative truncation tolerance (equivalent to `√cutoff` in
-ITensorMPS.jl notation).
+`SvdTruncationPolicy::new(threshold)` uses the default relative per-value rule.
+To emulate ITensor-style discarded-weight cutoffs, use
+`.with_squared_values().with_discarded_tail_sum()`.
 
 ### Norm and inner product
 

--- a/docs/design/symbolic-shape-and-tenferro-migration.md
+++ b/docs/design/symbolic-shape-and-tenferro-migration.md
@@ -513,7 +513,7 @@ Each stage has explicit verification:
    `cargo fmt --all`
    `cargo clippy --workspace --all-targets`
    `cargo test --doc --release --workspace`
-   `mdbook test docs/book`
+   `./scripts/test-mdbook.sh`
    `cargo doc --workspace --no-deps`
 
 ## 6. Risks

--- a/docs/plans/2026-04-17-svd-truncation-policy-design.md
+++ b/docs/plans/2026-04-17-svd-truncation-policy-design.md
@@ -1,0 +1,392 @@
+# SVD Truncation Policy Design
+
+## Goal
+
+Replace the current `rtol/cutoff/max_rank` truncation interface for SVD-based
+operations with an explicit policy object that can represent:
+
+- singular-value vs squared-singular-value thresholds
+- per-value vs discarded-tail-sum rules
+- relative vs absolute scaling
+
+At the same time, remove the current API confusion that lets `truncate`
+superficially expose `LU/CI` even though the actual truncation sweep is SVD
+based.
+
+## Context
+
+The current design mixes together several concerns:
+
+- `TruncationParams` is shared across SVD, QR, and higher-level APIs even
+  though the semantics differ.
+- `cutoff` is only stored as a compatibility alias and is immediately collapsed
+  into `rtol = sqrt(cutoff)`.
+- `truncate` APIs expose `LU/CI` even though `TreeTN::truncate` ultimately uses
+  SVD in the truncation sweep.
+- `FactorizeOptions` has a single `rtol` field even though SVD, QR, and LU use
+  different truncation/rank-selection criteria.
+
+This prevents expressing the four intended SVD truncation semantics:
+
+1. value + per-value
+2. value + discarded-tail-sum
+3. squared-value + per-value
+4. squared-value + discarded-tail-sum
+
+## Non-Goals
+
+- Do not preserve backwards compatibility for `rtol`, `cutoff`, `maxdim`,
+  `TruncateOptions::lu()`, or `TruncateOptions::ci()`. This repository is in
+  early development and deprecated compatibility layers should be removed
+  immediately.
+- Do not force LU/CI to share the same truncation policy type as SVD. Their
+  rank selection is not based on singular values.
+- Do not redesign the C API in the same change. Rust APIs should be cleaned up
+  first, then FFI can follow in a separate pass.
+
+## Primary Type
+
+```rust
+pub struct SvdTruncationPolicy {
+    pub threshold: f64,
+    pub scale: ThresholdScale,
+    pub measure: SingularValueMeasure,
+    pub rule: TruncationRule,
+}
+
+pub enum ThresholdScale {
+    Relative,
+    Absolute,
+}
+
+pub enum SingularValueMeasure {
+    Value,
+    SquaredValue,
+}
+
+pub enum TruncationRule {
+    PerValue,
+    DiscardedTailSum,
+}
+```
+
+### Defaults
+
+`SvdTruncationPolicy::new(threshold)` uses:
+
+- `ThresholdScale::Relative`
+- `SingularValueMeasure::Value`
+- `TruncationRule::PerValue`
+
+This makes the default policy correspond to the current intuitive
+`sigma_i / sigma_max <= threshold` style API.
+
+### Builder Surface
+
+```rust
+impl SvdTruncationPolicy {
+    pub fn new(threshold: f64) -> Self;
+    pub fn with_relative(self) -> Self;
+    pub fn with_absolute(self) -> Self;
+    pub fn with_values(self) -> Self;
+    pub fn with_squared_values(self) -> Self;
+    pub fn with_per_value(self) -> Self;
+    pub fn with_discarded_tail_sum(self) -> Self;
+}
+```
+
+Examples:
+
+```rust
+let default_policy = SvdTruncationPolicy::new(1e-12);
+
+let squared_tail = SvdTruncationPolicy::new(1e-10)
+    .with_squared_values()
+    .with_discarded_tail_sum();
+
+let absolute_per_value = SvdTruncationPolicy::new(1e-8)
+    .with_absolute()
+    .with_values()
+    .with_per_value();
+```
+
+## Semantics
+
+Let `measure_i` denote either `sigma_i` or `sigma_i^2`, depending on
+`measure`.
+
+### Relative Per-Value
+
+`ThresholdScale::Relative + TruncationRule::PerValue`
+
+Keep the largest prefix such that:
+
+`measure_i / max(measure) > threshold`
+
+This uses the largest kept singular-value-derived quantity as the natural
+reference scale. This is the direct generalization of current `rtol` semantics.
+
+### Relative Discarded Tail Sum
+
+`ThresholdScale::Relative + TruncationRule::DiscardedTailSum`
+
+Discard from the smallest end while:
+
+`(discarded_sum + next_measure) / sum(all_measures) <= threshold`
+
+This is an early-exit suffix accumulation rule. It matches the current ITensor
+style definition for relative discarded weight when the measure is squared
+singular values.
+
+Reference:
+
+- docs: <https://itensor.github.io/ITensors.jl/stable/ITensorType.html>
+- implementation: <https://github.com/ITensor/ITensors.jl/blob/3a62e79627afec50afd63b5ca942c060da1c0c0e/NDTensors/src/truncate.jl>
+
+### Absolute Per-Value
+
+Keep values satisfying:
+
+`measure_i > threshold`
+
+### Absolute Discarded Tail Sum
+
+Discard from the smallest end while:
+
+`discarded_sum + next_measure <= threshold`
+
+### `max_rank` Interaction
+
+`max_rank` remains independent of the policy and is applied as a hard cap on
+the retained rank.
+
+The retained rank is:
+
+`min(rank_allowed_by_policy, max_rank.unwrap_or(usize::MAX))`
+
+At least rank 1 is kept for non-empty spectra.
+
+## API Restructuring
+
+### `tensor4all-core`
+
+#### `truncation.rs`
+
+Split the current shared truncation container into algorithm-specific concepts.
+
+- Remove `TruncationParams`
+- Remove `HasTruncationParams`
+- Keep `DecompositionAlg`
+- Add `SvdTruncationPolicy`
+
+This file becomes the home of algorithm-selection enums plus SVD policy types,
+not a forced common container for all decomposition families.
+
+#### `SvdOptions`
+
+Current:
+
+```rust
+pub struct SvdOptions {
+    pub truncation: TruncationParams,
+}
+```
+
+New:
+
+```rust
+pub struct SvdOptions {
+    pub max_rank: Option<usize>,
+    pub policy: Option<SvdTruncationPolicy>,
+}
+```
+
+`SvdOptions::with_rtol` and `SvdOptions::with_cutoff` are removed.
+
+New builder:
+
+```rust
+SvdOptions::new()
+    .with_max_rank(64)
+    .with_policy(SvdTruncationPolicy::new(1e-12));
+```
+
+Global default SVD truncation should become a default `SvdTruncationPolicy`
+instead of a bare `f64 rtol`.
+
+#### `QrOptions`
+
+QR retains its own semantics. It should not reuse `SvdTruncationPolicy`.
+
+Recommended shape:
+
+```rust
+pub struct QrOptions {
+    pub rtol: Option<f64>,
+}
+```
+
+This keeps QR rank selection independent and avoids smuggling SVD policy fields
+into QR.
+
+#### `FactorizeOptions`
+
+`FactorizeOptions` remains as a thin multi-algorithm facade:
+
+```rust
+pub struct FactorizeOptions {
+    pub alg: FactorizeAlg,
+    pub canonical: Canonical,
+    pub max_rank: Option<usize>,
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    pub qr_rtol: Option<f64>,
+}
+```
+
+Validation rules:
+
+- `SVD/RSVD`: allow `max_rank` and `svd_policy`; reject `qr_rtol`
+- `QR`: allow `max_rank` and `qr_rtol`; reject `svd_policy`
+- `LU/CI`: allow `max_rank`; reject `svd_policy` and `qr_rtol`
+
+This keeps the public surface pragmatic while making invalid combinations
+explicitly illegal.
+
+### `tensor4all-treetn`
+
+#### `CanonicalizationOptions`
+
+Keep `CanonicalForm::{Unitary, LU, CI}`. Canonicalization is where LU/CI belong.
+
+#### `TruncationOptions`
+
+Current `TruncationOptions` mixes canonical form and truncation settings.
+
+New shape:
+
+```rust
+pub struct TruncationOptions {
+    pub max_rank: Option<usize>,
+    pub svd_policy: Option<SvdTruncationPolicy>,
+}
+```
+
+Remove:
+
+- `form`
+- `with_form`
+- `with_rtol`
+- `with_cutoff`
+
+`TreeTN::truncate` is then honestly SVD-based.
+
+#### `SplitOptions`
+
+If split continues to be SVD-based when truncation is requested, it should also
+hold `svd_policy` explicitly instead of sharing the old `TruncationParams`.
+
+#### `ApplyOptions`, `ContractionOptions`, `FitContractionOptions`, `LinsolveOptions`
+
+Any high-level option that currently exposes `rtol` for an SVD-based truncation
+path should be updated to expose an `SvdTruncationPolicy` instead.
+
+For fit-style APIs that allow non-SVD factorization algorithms, the rule is:
+
+- SVD/RSVD: `svd_policy` is legal
+- QR: use `qr_rtol`
+- LU/CI: no SVD policy accepted
+
+### `tensor4all-itensorlike`
+
+#### `TruncateOptions`
+
+Restrict to SVD-based truncation only.
+
+Remove:
+
+- `TruncateOptions::lu()`
+- `TruncateOptions::ci()`
+- `with_rtol`
+- `with_cutoff`
+- `with_maxdim`
+
+New shape:
+
+```rust
+pub struct TruncateOptions {
+    svd_policy: Option<SvdTruncationPolicy>,
+    max_rank: Option<usize>,
+    site_range: Option<Range<usize>>,
+}
+```
+
+#### `ContractOptions` and `LinsolveOptions`
+
+Replace `rtol/cutoff` builders with:
+
+- `with_svd_policy(...)`
+- `with_max_rank(...)`
+
+and keep sweep-count / convergence settings as they are.
+
+## Validation Rules
+
+All policy-carrying APIs should reject:
+
+- non-finite thresholds
+- negative thresholds
+- `max_rank == 0`
+
+Algorithm-dependent validation should reject impossible field combinations
+before any numerical work starts.
+
+## Testing Strategy
+
+### Core Policy Tests
+
+Add focused unit tests for:
+
+- default policy values
+- builder overrides
+- retained-rank computation for all four measure/rule combinations
+- relative vs absolute semantics
+- `max_rank` cap interaction
+
+### API Cleanup Tests
+
+Add tests that:
+
+- verify `truncate` no longer exposes LU/CI
+- verify invalid `FactorizeOptions` combinations return errors
+- verify high-level APIs propagate `SvdTruncationPolicy` correctly
+
+### Regression Coverage
+
+Retain behavioral coverage for existing SVD truncation workflows by rewriting
+tests to use explicit policies instead of `rtol/cutoff`.
+
+## Risks
+
+### Builder Churn
+
+Many tests and examples currently use `with_rtol` and `with_cutoff`. This is
+expected and acceptable because backwards compatibility is explicitly out of
+scope.
+
+### Hidden QR Coupling
+
+`TruncationParams` currently leaks SVD terminology into QR. Careless refactors
+can accidentally break QR rank selection. QR must keep its own option path and
+tests.
+
+### High-Level Fit Semantics
+
+Some fit APIs intentionally treat omitted tolerance and explicit `0.0`
+similarly. That behavior needs to be re-expressed carefully once `rtol`
+disappears, likely by interpreting `None` as "no policy" and using explicit
+bond caps to keep current behavior where intended.
+
+## Follow-Up Work
+
+- Update the C API after the Rust API stabilizes.
+- Update Julia/Python bindings after the Rust and C surfaces are settled.

--- a/docs/plans/2026-04-17-svd-truncation-policy-design.md
+++ b/docs/plans/2026-04-17-svd-truncation-policy-design.md
@@ -41,8 +41,9 @@ This prevents expressing the four intended SVD truncation semantics:
   immediately.
 - Do not force LU/CI to share the same truncation policy type as SVD. Their
   rank selection is not based on singular values.
-- Do not redesign the C API in the same change. Rust APIs should be cleaned up
-  first, then FFI can follow in a separate pass.
+- Do not preserve the legacy C ABI that exposes `rtol/cutoff/form` for
+  SVD-based TreeTN operations. The C surface should move to the same explicit
+  policy model as the Rust APIs.
 
 ## Primary Type
 
@@ -329,6 +330,69 @@ Replace `rtol/cutoff` builders with:
 
 and keep sweep-count / convergence settings as they are.
 
+### `tensor4all-capi`
+
+#### Public policy types
+
+Expose the SVD truncation policy explicitly through the C ABI:
+
+```c
+typedef enum t4a_threshold_scale {
+    T4A_THRESHOLD_SCALE_RELATIVE = 0,
+    T4A_THRESHOLD_SCALE_ABSOLUTE = 1,
+} t4a_threshold_scale;
+
+typedef enum t4a_singular_value_measure {
+    T4A_SINGULAR_VALUE_MEASURE_VALUE = 0,
+    T4A_SINGULAR_VALUE_MEASURE_SQUARED_VALUE = 1,
+} t4a_singular_value_measure;
+
+typedef enum t4a_truncation_rule {
+    T4A_TRUNCATION_RULE_PER_VALUE = 0,
+    T4A_TRUNCATION_RULE_DISCARDED_TAIL_SUM = 1,
+} t4a_truncation_rule;
+
+typedef struct t4a_svd_truncation_policy {
+    double threshold;
+    enum t4a_threshold_scale scale;
+    enum t4a_singular_value_measure measure;
+    enum t4a_truncation_rule rule;
+} t4a_svd_truncation_policy;
+```
+
+`NULL` policy pointers continue to mean "use the backend default policy".
+
+#### Function families
+
+For SVD-based TreeTN operations, the C ABI should expose `policy + maxdim`
+directly and stop using `rtol/cutoff/form` shims:
+
+- `t4a_treetn_truncate`
+- `t4a_treetn_add`
+- `t4a_treetn_contract`
+- `t4a_treetn_apply_operator_chain`
+- `t4a_treetn_linsolve`
+- `t4a_treetn_split_to`
+- `t4a_treetn_restructure_to`
+
+These functions should follow the same algorithm split as the Rust API:
+
+- SVD truncation paths accept `const t4a_svd_truncation_policy *policy`
+- `maxdim` remains an independent hard cap
+- `form` remains available only for canonicalization-oriented APIs
+- QR-specific paths keep `qr_rtol` semantics instead of reusing SVD policy
+
+#### Canonicalization boundary
+
+`t4a_treetn_orthogonalize` and any future explicit canonicalization entry
+points keep `enum t4a_canonical_form`, because LU/CI are meaningful there.
+
+By contrast, truncation-facing functions should not pretend to support LU/CI:
+
+- remove `form` from truncate / linsolve / split-final-truncation entry points
+- reject impossible algorithm-policy combinations before calling Rust
+- document clearly that LU/CI are canonicalization forms, not truncation modes
+
 ## Validation Rules
 
 All policy-carrying APIs should reject:
@@ -359,6 +423,10 @@ Add tests that:
 - verify `truncate` no longer exposes LU/CI
 - verify invalid `FactorizeOptions` combinations return errors
 - verify high-level APIs propagate `SvdTruncationPolicy` correctly
+- verify C policy structs round-trip into Rust policy values
+- verify TreeTN C entry points accept explicit policy objects for all four
+  threshold modes
+- verify truncation-facing C APIs no longer expose canonical-form arguments
 
 ### Regression Coverage
 
@@ -378,6 +446,12 @@ scope.
 `TruncationParams` currently leaks SVD terminology into QR. Careless refactors
 can accidentally break QR rank selection. QR must keep its own option path and
 tests.
+
+### C Header Drift
+
+The Rust source and generated `tensor4all_capi.h` must stay synchronized.
+Changing the C-facing function signatures without regenerating the header would
+silently break downstream bindings.
 
 ### High-Level Fit Semantics
 

--- a/docs/plans/2026-04-17-svd-truncation-policy-plan.md
+++ b/docs/plans/2026-04-17-svd-truncation-policy-plan.md
@@ -1,0 +1,419 @@
+# SVD Truncation Policy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `rtol/cutoff`-based SVD truncation APIs with an explicit `SvdTruncationPolicy`, remove LU/CI from truncate APIs, and propagate the new policy through core, TreeTN, and itensorlike interfaces.
+
+**Architecture:** Introduce an SVD-only policy type in `tensor4all-core`, keep QR options independent, and make high-level truncation APIs explicitly SVD-based. Use `FactorizeOptions` as the only mixed-algorithm facade, with algorithm-specific validation to reject invalid field combinations.
+
+**Tech Stack:** Rust workspace crates (`tensor4all-core`, `tensor4all-treetn`, `tensor4all-itensorlike`), cargo test/doc tooling, rustdoc examples.
+
+---
+
+### Task 1: Replace shared truncation params with `SvdTruncationPolicy`
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/truncation.rs`
+- Modify: `crates/tensor4all-core/src/lib.rs`
+- Test: `crates/tensor4all-core/src/truncation/tests/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests covering:
+
+```rust
+#[test]
+fn test_svd_truncation_policy_defaults() {
+    let policy = SvdTruncationPolicy::new(1e-12);
+    assert_eq!(policy.threshold, 1e-12);
+    assert_eq!(policy.scale, ThresholdScale::Relative);
+    assert_eq!(policy.measure, SingularValueMeasure::Value);
+    assert_eq!(policy.rule, TruncationRule::PerValue);
+}
+
+#[test]
+fn test_svd_truncation_policy_builders() {
+    let policy = SvdTruncationPolicy::new(1e-8)
+        .with_absolute()
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    assert_eq!(policy.scale, ThresholdScale::Absolute);
+    assert_eq!(policy.measure, SingularValueMeasure::SquaredValue);
+    assert_eq!(policy.rule, TruncationRule::DiscardedTailSum);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-core truncation`
+
+Expected: FAIL with missing `SvdTruncationPolicy` / removed `TruncationParams` references.
+
+**Step 3: Write minimal implementation**
+
+- Remove `TruncationParams` and `HasTruncationParams`
+- Keep `DecompositionAlg`
+- Add `SvdTruncationPolicy`, `ThresholdScale`, `SingularValueMeasure`, `TruncationRule`
+- Add validation helpers for threshold values
+- Re-export the new types from `crates/tensor4all-core/src/lib.rs`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-core truncation`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-core/src/truncation.rs crates/tensor4all-core/src/truncation/tests/mod.rs crates/tensor4all-core/src/lib.rs
+git commit -m "refactor(core): add explicit svd truncation policy"
+```
+
+### Task 2: Refactor `SvdOptions` and retained-rank logic
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/svd.rs`
+- Test: `crates/tensor4all-core/src/defaults/svd/tests/mod.rs`
+- Test: `crates/tensor4all-core/tests/linalg_svd.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that check:
+
+```rust
+#[test]
+fn test_compute_retained_rank_relative_per_value() {
+    let s = [10.0, 1.0, 0.1];
+    let policy = SvdTruncationPolicy::new(0.2);
+    assert_eq!(compute_retained_rank(&s, &policy), 2);
+}
+
+#[test]
+fn test_compute_retained_rank_relative_squared_tail_sum() {
+    let s = [4.0, 2.0, 1.0];
+    let policy = SvdTruncationPolicy::new(0.05)
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    assert_eq!(compute_retained_rank(&s, &policy), 2);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-core svd`
+
+Expected: FAIL because `SvdOptions` and retained-rank helpers still use `rtol`.
+
+**Step 3: Write minimal implementation**
+
+- Change `SvdOptions` to:
+
+```rust
+pub struct SvdOptions {
+    pub max_rank: Option<usize>,
+    pub policy: Option<SvdTruncationPolicy>,
+}
+```
+
+- Replace `default_svd_rtol` with a default policy getter/setter
+- Implement retained-rank helpers for:
+  - relative/absolute
+  - value/squared-value
+  - per-value/discarded-tail-sum
+- Preserve early-exit suffix accumulation for `DiscardedTailSum`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-core svd`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-core/src/defaults/svd.rs crates/tensor4all-core/src/defaults/svd/tests/mod.rs crates/tensor4all-core/tests/linalg_svd.rs
+git commit -m "refactor(core): move svd truncation to explicit policy"
+```
+
+### Task 3: Decouple QR and validate mixed-algorithm factorization options
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/qr.rs`
+- Modify: `crates/tensor4all-core/src/tensor_like.rs`
+- Modify: `crates/tensor4all-core/src/defaults/factorize.rs`
+- Test: `crates/tensor4all-core/src/defaults/qr/tests/mod.rs`
+- Test: `crates/tensor4all-core/tests/linalg_factorize.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests such as:
+
+```rust
+#[test]
+fn test_factorize_options_reject_svd_policy_for_qr() {
+    let opts = FactorizeOptions::qr()
+        .with_svd_policy(SvdTruncationPolicy::new(1e-8));
+    let err = validate_factorize_options(&opts).unwrap_err();
+    assert!(err.to_string().contains("svd_policy"));
+}
+
+#[test]
+fn test_factorize_options_reject_qr_rtol_for_lu() {
+    let opts = FactorizeOptions::lu().with_qr_rtol(1e-8);
+    let err = validate_factorize_options(&opts).unwrap_err();
+    assert!(err.to_string().contains("qr_rtol"));
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-core linalg_factorize qr`
+
+Expected: FAIL because `FactorizeOptions` still only carries `rtol`.
+
+**Step 3: Write minimal implementation**
+
+- Refactor `QrOptions` to its own `rtol` field
+- Refactor `FactorizeOptions` to:
+
+```rust
+pub struct FactorizeOptions {
+    pub alg: FactorizeAlg,
+    pub canonical: Canonical,
+    pub max_rank: Option<usize>,
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    pub qr_rtol: Option<f64>,
+}
+```
+
+- Add validation before dispatch
+- Update `factorize_svd`, `factorize_qr`, and LU/CI paths to consume the new fields
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-core linalg_factorize qr`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-core/src/defaults/qr.rs crates/tensor4all-core/src/defaults/qr/tests/mod.rs crates/tensor4all-core/src/tensor_like.rs crates/tensor4all-core/src/defaults/factorize.rs crates/tensor4all-core/tests/linalg_factorize.rs
+git commit -m "refactor(core): validate factorize options by algorithm"
+```
+
+### Task 4: Make TreeTN truncation explicitly SVD-based
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/options.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/truncate.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/localupdate.rs`
+- Test: `crates/tensor4all-treetn/src/options/tests/mod.rs`
+- Test: `crates/tensor4all-treetn/tests/basic.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests asserting:
+
+```rust
+#[test]
+fn test_truncation_options_do_not_expose_form() {
+    let opts = TruncationOptions::new().with_max_rank(8);
+    assert_eq!(opts.max_rank(), Some(8));
+}
+
+#[test]
+fn test_tree_truncate_uses_svd_policy() {
+    let opts = TruncationOptions::new()
+        .with_svd_policy(SvdTruncationPolicy::new(1e-10));
+    assert_eq!(opts.svd_policy().unwrap().rule, TruncationRule::PerValue);
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-treetn options basic`
+
+Expected: FAIL because `TruncationOptions` still uses `form + rtol`.
+
+**Step 3: Write minimal implementation**
+
+- Remove `form` from `TruncationOptions`
+- Add `svd_policy: Option<SvdTruncationPolicy>`
+- Keep `CanonicalizationOptions` unchanged
+- Thread `svd_policy` through `truncate_impl` into `TruncateUpdater`
+- Replace `FactorizeOptions::svd().with_rtol(...)` in `TruncateUpdater` with `with_svd_policy(...)`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-treetn options basic`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/options.rs crates/tensor4all-treetn/src/options/tests/mod.rs crates/tensor4all-treetn/src/treetn/truncate.rs crates/tensor4all-treetn/src/treetn/localupdate.rs crates/tensor4all-treetn/tests/basic.rs
+git commit -m "refactor(treetn): make truncate explicitly svd-based"
+```
+
+### Task 5: Propagate policy through TreeTN apply, contract, partial contraction, and linsolve
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/operator/apply.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/contraction.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/partial_contraction.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/fit.rs`
+- Modify: `crates/tensor4all-treetn/src/linsolve/common/options.rs`
+- Test: `crates/tensor4all-treetn/src/operator/apply/tests/mod.rs`
+- Test: `crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs`
+- Test: `crates/tensor4all-treetn/src/linsolve/common/options/tests/mod.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that build high-level options with:
+
+```rust
+let policy = SvdTruncationPolicy::new(1e-10)
+    .with_squared_values()
+    .with_discarded_tail_sum();
+```
+
+and assert the policy survives conversion into lower-level factorization paths.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-treetn apply contraction linsolve`
+
+Expected: FAIL because these APIs still carry `rtol`.
+
+**Step 3: Write minimal implementation**
+
+- Replace `rtol` fields in SVD-based high-level options with `svd_policy`
+- Keep `factorize_alg` for fit, but validate that:
+  - SVD/RSVD accepts `svd_policy`
+  - QR accepts `qr_rtol`
+  - LU/CI reject `svd_policy`
+- Update helper conversions like `factorize_options_from_contraction_options`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-treetn apply contraction linsolve`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/operator/apply.rs crates/tensor4all-treetn/src/operator/apply/tests/mod.rs crates/tensor4all-treetn/src/treetn/contraction.rs crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs crates/tensor4all-treetn/src/treetn/partial_contraction.rs crates/tensor4all-treetn/src/treetn/fit.rs crates/tensor4all-treetn/src/linsolve/common/options.rs crates/tensor4all-treetn/src/linsolve/common/options/tests/mod.rs
+git commit -m "refactor(treetn): propagate svd truncation policy"
+```
+
+### Task 6: Remove legacy `rtol/cutoff` and LU/CI truncation from itensorlike
+
+**Files:**
+- Modify: `crates/tensor4all-itensorlike/src/options.rs`
+- Modify: `crates/tensor4all-itensorlike/src/tensortrain.rs`
+- Modify: `crates/tensor4all-itensorlike/src/contract.rs`
+- Modify: `crates/tensor4all-itensorlike/src/linsolve.rs`
+- Test: `crates/tensor4all-itensorlike/src/options/tests/mod.rs`
+- Test: `crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs`
+- Test: `crates/tensor4all-itensorlike/tests/fit_bond_capping.rs`
+- Test: `crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs`
+- Test: `crates/tensor4all-itensorlike/tests/linsolve_mpo.rs`
+
+**Step 1: Write the failing tests**
+
+Add tests that exercise:
+
+```rust
+let opts = TruncateOptions::svd()
+    .with_svd_policy(SvdTruncationPolicy::new(1e-10))
+    .with_max_rank(20);
+
+assert_eq!(opts.alg(), TruncateAlg::SVD);
+assert_eq!(opts.max_rank(), Some(20));
+```
+
+and update existing truncation/contract/linsolve tests to use explicit policy objects.
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-itensorlike`
+
+Expected: FAIL because the crate still exposes `with_rtol`, `with_cutoff`, and `TruncateOptions::lu/ci`.
+
+**Step 3: Write minimal implementation**
+
+- Remove `TruncateOptions::lu()` and `TruncateOptions::ci()`
+- Replace `TruncationParams` usage with:
+  - `max_rank`
+  - `svd_policy`
+- Update validators and conversion code into `tensor4all_treetn`
+- Rewrite examples and doctests to use explicit SVD policies
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-itensorlike`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-itensorlike/src/options.rs crates/tensor4all-itensorlike/src/options/tests/mod.rs crates/tensor4all-itensorlike/src/tensortrain.rs crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs crates/tensor4all-itensorlike/src/contract.rs crates/tensor4all-itensorlike/src/linsolve.rs crates/tensor4all-itensorlike/tests/fit_bond_capping.rs crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs crates/tensor4all-itensorlike/tests/linsolve_mpo.rs
+git commit -m "refactor(itensorlike): replace rtol and cutoff with svd policy"
+```
+
+### Task 7: Refresh docs, rustdoc examples, and workspace verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: crate-level docs and rustdoc examples touched in prior tasks
+- Modify: any affected API dump snapshots under `docs/api/` if intentionally regenerated
+
+**Step 1: Write the failing checks**
+
+No new tests are needed here. Treat the workspace checks as the failing signal.
+
+**Step 2: Run checks to find remaining breakage**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo clippy --workspace
+cargo test --doc --release --workspace
+mdbook test docs/book
+cargo nextest run --release --workspace
+```
+
+Expected: at least one failure from stale docs/examples before cleanup.
+
+**Step 3: Write minimal implementation**
+
+- Update rustdoc examples to use `SvdTruncationPolicy`
+- Remove all references to `with_rtol`, `with_cutoff`, `maxdim`, and LU/CI truncate builders
+- Ensure README and crate docs describe `truncate` as SVD-based and `canonicalize` as the LU/CI entry point
+
+**Step 4: Run checks to verify they pass**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo clippy --workspace
+cargo test --doc --release --workspace
+mdbook test docs/book
+cargo nextest run --release --workspace
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add README.md docs/book crates
+git commit -m "docs: update truncation APIs for explicit svd policy"
+```

--- a/docs/plans/2026-04-17-svd-truncation-policy-plan.md
+++ b/docs/plans/2026-04-17-svd-truncation-policy-plan.md
@@ -366,7 +366,65 @@ git add crates/tensor4all-itensorlike/src/options.rs crates/tensor4all-itensorli
 git commit -m "refactor(itensorlike): replace rtol and cutoff with svd policy"
 ```
 
-### Task 7: Refresh docs, rustdoc examples, and workspace verification
+### Task 7: Redesign the C API to expose explicit SVD truncation policies
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/types.rs`
+- Modify: `crates/tensor4all-capi/src/tensor.rs`
+- Modify: `crates/tensor4all-capi/src/treetn.rs`
+- Modify: `crates/tensor4all-capi/src/tensor/tests/mod.rs`
+- Modify: `crates/tensor4all-capi/src/treetn/tests/mod.rs`
+- Modify: `crates/tensor4all-capi/include/tensor4all_capi.h`
+
+**Step 1: Write the failing tests**
+
+Add C API tests that:
+
+```rust
+let policy = t4a_svd_truncation_policy {
+    threshold: 1e-10,
+    scale: t4a_threshold_scale::Relative,
+    measure: t4a_singular_value_measure::SquaredValue,
+    rule: t4a_truncation_rule::DiscardedTailSum,
+};
+```
+
+and verify:
+
+- `t4a_treetn_truncate` accepts `&policy` and `maxdim`
+- `t4a_treetn_add` accepts `&policy` and `maxdim`
+- `t4a_treetn_contract` accepts `policy` plus QR-specific `qr_rtol`
+- `t4a_treetn_linsolve` no longer takes `form`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run --release -p tensor4all-capi treetn tensor`
+
+Expected: FAIL because the TreeTN C entry points still expose legacy
+`rtol/cutoff/form` signatures.
+
+**Step 3: Write minimal implementation**
+
+- Remove legacy `rtol/cutoff/form` parameters from SVD-based TreeTN C entry points
+- Add `const t4a_svd_truncation_policy *policy` wherever SVD truncation is used
+- Keep `form` only on canonicalization APIs
+- Preserve separate `qr_rtol` inputs for QR-based paths
+- Regenerate `crates/tensor4all-capi/include/tensor4all_capi.h`
+
+**Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run --release -p tensor4all-capi treetn tensor`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-capi/src/types.rs crates/tensor4all-capi/src/tensor.rs crates/tensor4all-capi/src/treetn.rs crates/tensor4all-capi/src/tensor/tests/mod.rs crates/tensor4all-capi/src/treetn/tests/mod.rs crates/tensor4all-capi/include/tensor4all_capi.h
+git commit -m "refactor(capi): expose explicit svd truncation policies"
+```
+
+### Task 8: Refresh docs, rustdoc examples, and workspace verification
 
 **Files:**
 - Modify: `README.md`
@@ -385,8 +443,9 @@ Run:
 cargo fmt --all
 cargo clippy --workspace
 cargo test --doc --release --workspace
-mdbook test docs/book
+./scripts/test-mdbook.sh
 cargo nextest run --release --workspace
+cbindgen --config crates/tensor4all-capi/cbindgen.toml --crate tensor4all-capi --output crates/tensor4all-capi/include/tensor4all_capi.h
 ```
 
 Expected: at least one failure from stale docs/examples before cleanup.
@@ -405,8 +464,9 @@ Run:
 cargo fmt --all
 cargo clippy --workspace
 cargo test --doc --release --workspace
-mdbook test docs/book
+./scripts/test-mdbook.sh
 cargo nextest run --release --workspace
+cbindgen --config crates/tensor4all-capi/cbindgen.toml --crate tensor4all-capi --output crates/tensor4all-capi/include/tensor4all_capi.h
 ```
 
 Expected: PASS


### PR DESCRIPTION
## Summary

Redesign the SVD truncation API across core, TreeTN, itensorlike, and the C API.

This change removes the old mixed `rtol` / `cutoff` / LU-truncation surface from `truncate`-style APIs and replaces it with an explicit SVD truncation policy that can represent:

- relative vs absolute thresholds
- singular values vs squared singular values
- per-value vs discarded tail-sum rules

The default policy is relative, per-value, and based on singular values.

## What changed

- Introduce explicit SVD truncation policy types in `tensor4all-core`
- Split SVD truncation controls from QR tolerance in factorization options
- Keep LU available for canonicalization where appropriate, but remove it from `truncate`
- Propagate the explicit SVD policy through TreeTN apply/contract/linsolve/truncate paths
- Remove legacy `rtol` / `cutoff` / algorithm builders from the itensorlike truncation surface
- Redesign the C API so tensor and TreeTN entry points expose all supported SVD truncation modes explicitly
- Regenerate `tensor4all_capi.h`
- Update tests, examples, and docs to the new policy-based API
- Clarify mdBook verification instructions to use `./scripts/test-mdbook.sh`, which matches the CI harness

## Why

The previous API conflated several separate concerns:

- threshold scale semantics
- whether the comparison uses singular values or squared values
- whether truncation is per singular value or based on discarded tail weight
- SVD-based truncation vs QR/LU/CI factorization choices

That made some truncation modes impossible to express cleanly, and it forced the C API to expose an underspecified legacy surface.

This PR makes the truncation behavior explicit and composable while keeping canonicalization controls separate.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo build --workspace --release`
- `cargo nextest run --release --workspace`
- `cargo test --doc --release --workspace`
- `cargo test --doc -p book-tests --release`
- `./scripts/test-mdbook.sh`
