### PR TITLE
[codex] fix rustdoc API link on docs homepage

### DIFF
--- a/docs/book-tests/src/lib.rs
+++ b/docs/book-tests/src/lib.rs
@@ -11,6 +11,7 @@
 //! The repository root `README.md` is included here as well so its short
 //! runnable examples stay covered by CI.
 
+#[cfg(test)]
 const BOOK_INTRODUCTION: &str = include_str!("../../book/src/README.md");
 
 #[doc = include_str!("../../../README.md")]

--- a/docs/book-tests/src/lib.rs
+++ b/docs/book-tests/src/lib.rs
@@ -11,6 +11,8 @@
 //! The repository root `README.md` is included here as well so its short
 //! runnable examples stay covered by CI.
 
+const BOOK_INTRODUCTION: &str = include_str!("../../book/src/README.md");
+
 #[doc = include_str!("../../../README.md")]
 mod root_readme {}
 
@@ -40,3 +42,20 @@ mod quantics {}
 
 #[doc = include_str!("../../book/src/guides/qft.md")]
 mod qft {}
+
+#[cfg(test)]
+mod tests {
+    use super::BOOK_INTRODUCTION;
+
+    #[test]
+    fn introduction_uses_repo_relative_rustdoc_link() {
+        assert!(
+            BOOK_INTRODUCTION.contains("[rustdoc API reference](rustdoc/tensor4all_core/)"),
+            "top-level mdBook page must link to rustdoc within the published /tensor4all-rs/ site"
+        );
+        assert!(
+            !BOOK_INTRODUCTION.contains("[rustdoc API reference](../rustdoc/tensor4all_core/)"),
+            "top-level mdBook page must not climb above the published site root"
+        );
+    }
+}

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -23,7 +23,7 @@ examples live in this guide and the guide examples are exercised in CI.
 | Install and run my first example | [Getting Started](getting-started.md) |
 | Understand the crate structure | [Architecture & Crate Guide](architecture.md) |
 | Come from ITensors.jl and map types | [Conventions](conventions.md) |
-| Browse the full API reference | [rustdoc API reference](../rustdoc/tensor4all_core/) |
+| Browse the full API reference | [rustdoc API reference](rustdoc/tensor4all_core/) |
 | Use tensor4all-rs from Julia | [Julia Bindings](julia-bindings.md) |
 
 ---


### PR DESCRIPTION
## Summary
Fix the rustdoc API reference link on the published mdBook introduction page.

## What changed
- change the introduction page link from `../rustdoc/tensor4all_core/` to `rustdoc/tensor4all_core/`
- add a small `book-tests` regression test that asserts the introduction page keeps using the repo-relative rustdoc path

## Root cause
The mdBook introduction page is published at `/tensor4all-rs/index.html`. Using `../rustdoc/...` from that page resolves to `/rustdoc/...`, which drops the `/tensor4all-rs/` site prefix and breaks the public link.

## Impact
Users who click "rustdoc API reference" from the documentation homepage now land on the deployed rustdoc page under `/tensor4all-rs/rustdoc/...` instead of a broken top-level path.

## Validation
- `cargo test -p book-tests --release introduction_uses_repo_relative_rustdoc_link`
- `mdbook build docs/book` and confirmed the generated `index.html` contains `href="rustdoc/tensor4all_core/"`
