### PR TITLE
[codex] Add structured tensor storage surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Rust implementation of tensor networks: TCI, Quantics Tensor Train, and Tree T
 - **Tensor Cross Interpolation**: TCI2 algorithm for efficient high-dimensional function approximation
 - **Quantics Tensor Train**: Binary encoding of continuous variables with transformation operators
 - **Tree Tensor Networks**: Arbitrary topology with canonicalization, truncation, and contraction
-- **C API**: Minimal Julia-facing FFI surface for indices, tensors, TreeTN, and quantics materialization
+- **C API**: Minimal Julia-facing FFI surface for indices, structured tensors, TreeTN, and quantics materialization
 
 ## Quick Start
 
@@ -62,7 +62,7 @@ Inspired by [ITensors.jl](https://github.com/ITensor/ITensors.jl). We acknowledg
 
 **Citation:** If you use this code in research, please cite:
 
-> We used tensor4all-rs (https://github.com/tensor4all/tensor4all-rs), inspired by ITensors.jl.
+> We used tensor4all-rs (<https://github.com/tensor4all/tensor4all-rs>), inspired by ITensors.jl.
 >
 > M. Fishman, S. R. White, E. M. Stoudenmire, "The ITensor Software Library for Tensor Network Calculations", arXiv:2007.14822 (2020)
 

--- a/crates/tensor4all-capi/README.md
+++ b/crates/tensor4all-capi/README.md
@@ -6,7 +6,7 @@ minimal Julia-facing surface.
 ## Features
 
 - **Index API**: Immutable index handles with constructor/getter-only access
-- **Tensor API**: Dense `f64` / `Complex64` construction, export, and contraction
+- **Tensor API**: Dense, diagonal, and structured `f64` / `Complex64` construction, payload export, dense export, and contraction
 - **TreeTN API**: General tree tensor network accessors and core operations
 - **QTT layout API**: Canonical binary QTT layout descriptors for transform materialization
 - **Generated C header**: `include/tensor4all_capi.h` for downstream bindings
@@ -17,7 +17,7 @@ minimal Julia-facing surface.
 
 - Opaque pointers with lifecycle management (`*_new(..., out)`, `*_release`, `*_clone(..., out)`)
 - Status codes: `T4A_SUCCESS`, `T4A_NULL_POINTER`, `T4A_INVALID_ARGUMENT`, etc.
-- Column-major data layout for dense tensor data
+- Column-major data layout for dense logical tensor data and compact payload buffers
 - Complex buffers use interleaved doubles: `[re, im, re, im, ...]`
 
 ## Example (C)

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -56,6 +56,24 @@ typedef enum t4a_scalar_kind {
 } t4a_scalar_kind;
 
 /**
+ * Storage layout kind used by tensor payload inspection APIs.
+ */
+typedef enum t4a_storage_kind {
+  /**
+   * Dense storage whose payload axes match the logical tensor axes.
+   */
+  T4A_STORAGE_KIND_DENSE = 0,
+  /**
+   * Diagonal storage whose logical axes all share one payload axis.
+   */
+  T4A_STORAGE_KIND_DIAGONAL = 1,
+  /**
+   * General structured storage with explicit payload-axis classes.
+   */
+  T4A_STORAGE_KIND_STRUCTURED = 2,
+} t4a_storage_kind;
+
+/**
  * Threshold scaling used by the C API SVD truncation policy.
  *
  * Related types:
@@ -526,6 +544,14 @@ StatusCode t4a_qtt_layout_new(enum t4a_qtt_layout_kind kind,
 void t4a_qtt_layout_release(struct t4a_qtt_layout *obj);
 
 /**
+ * Copy logical-axis to payload-axis class mapping.
+ */
+StatusCode t4a_tensor_axis_classes(const struct t4a_tensor *ptr,
+                                   size_t *buf,
+                                   size_t buf_len,
+                                   size_t *out_len);
+
+/**
  * Clone a tensor handle.
  */
 StatusCode t4a_tensor_clone(const struct t4a_tensor *src, struct t4a_tensor **out);
@@ -552,6 +578,22 @@ StatusCode t4a_tensor_copy_dense_f64(const struct t4a_tensor *ptr,
                                      double *buf,
                                      size_t buf_len,
                                      size_t *out_len);
+
+/**
+ * Copy compact payload `Complex64` data as interleaved doubles.
+ */
+StatusCode t4a_tensor_copy_payload_c64(const struct t4a_tensor *ptr,
+                                       double *buf_interleaved,
+                                       size_t n_complex,
+                                       size_t *out_len);
+
+/**
+ * Copy compact payload `f64` data in payload column-major order.
+ */
+StatusCode t4a_tensor_copy_payload_f64(const struct t4a_tensor *ptr,
+                                       double *buf,
+                                       size_t buf_len,
+                                       size_t *out_len);
 
 /**
  * Copy tensor dimensions in index order.
@@ -591,6 +633,80 @@ StatusCode t4a_tensor_new_dense_f64(size_t rank,
                                     const double *data,
                                     size_t data_len,
                                     struct t4a_tensor **out);
+
+/**
+ * Create a complex diagonal tensor from compact diagonal payload data.
+ */
+StatusCode t4a_tensor_new_diag_c64(size_t rank,
+                                   const struct t4a_index *const *index_ptrs,
+                                   const double *diag_data_interleaved,
+                                   size_t n_complex,
+                                   struct t4a_tensor **out);
+
+/**
+ * Create a real diagonal tensor from compact diagonal payload data.
+ */
+StatusCode t4a_tensor_new_diag_f64(size_t rank,
+                                   const struct t4a_index *const *index_ptrs,
+                                   const double *diag_data,
+                                   size_t diag_len,
+                                   struct t4a_tensor **out);
+
+/**
+ * Create a complex tensor from explicit compact structured storage.
+ */
+StatusCode t4a_tensor_new_structured_c64(size_t rank,
+                                         const struct t4a_index *const *index_ptrs,
+                                         const double *data_interleaved,
+                                         size_t n_complex,
+                                         const size_t *payload_dims,
+                                         size_t payload_rank,
+                                         const ptrdiff_t *payload_strides,
+                                         size_t payload_strides_len,
+                                         const size_t *axis_classes,
+                                         size_t axis_classes_len,
+                                         struct t4a_tensor **out);
+
+/**
+ * Create a real tensor from explicit compact structured storage.
+ */
+StatusCode t4a_tensor_new_structured_f64(size_t rank,
+                                         const struct t4a_index *const *index_ptrs,
+                                         const double *data,
+                                         size_t data_len,
+                                         const size_t *payload_dims,
+                                         size_t payload_rank,
+                                         const ptrdiff_t *payload_strides,
+                                         size_t payload_strides_len,
+                                         const size_t *axis_classes,
+                                         size_t axis_classes_len,
+                                         struct t4a_tensor **out);
+
+/**
+ * Copy compact payload dimensions.
+ */
+StatusCode t4a_tensor_payload_dims(const struct t4a_tensor *ptr,
+                                   size_t *buf,
+                                   size_t buf_len,
+                                   size_t *out_len);
+
+/**
+ * Get the compact payload length in scalar elements.
+ */
+StatusCode t4a_tensor_payload_len(const struct t4a_tensor *ptr, size_t *out_len);
+
+/**
+ * Get the rank of the compact payload tensor.
+ */
+StatusCode t4a_tensor_payload_rank(const struct t4a_tensor *ptr, size_t *out_rank);
+
+/**
+ * Copy compact payload strides in scalar elements.
+ */
+StatusCode t4a_tensor_payload_strides(const struct t4a_tensor *ptr,
+                                      ptrdiff_t *buf,
+                                      size_t buf_len,
+                                      size_t *out_len);
 
 /**
  * Compute the QR decomposition of a tensor split by the requested left indices.
@@ -648,6 +764,11 @@ void t4a_tensor_release(struct t4a_tensor *obj);
  * Get the scalar kind of a tensor.
  */
 StatusCode t4a_tensor_scalar_kind(const struct t4a_tensor *ptr, enum t4a_scalar_kind *out_kind);
+
+/**
+ * Get the storage layout kind of a tensor.
+ */
+StatusCode t4a_tensor_storage_kind(const struct t4a_tensor *ptr, enum t4a_storage_kind *out_kind);
 
 /**
  * Compute the SVD of a tensor split by the requested left indices.

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -1,13 +1,14 @@
 //! C API for dense tensor construction, inspection, and contraction.
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
 
 use num_complex::Complex64;
-use tensor4all_core::{qr_with, svd_with, QrOptions, SvdOptions, SvdTruncationPolicy};
+use tensor4all_core::{qr_with, svd_with, QrOptions, Storage, SvdOptions, SvdTruncationPolicy};
 
 use crate::types::{
-    t4a_index, t4a_scalar_kind, t4a_svd_truncation_policy, t4a_tensor, InternalIndex,
-    InternalTensor,
+    t4a_index, t4a_scalar_kind, t4a_storage_kind, t4a_svd_truncation_policy, t4a_tensor,
+    InternalIndex, InternalTensor,
 };
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
@@ -63,6 +64,117 @@ fn read_indices_from_ptrs(
 
 fn dims_from_indices(indices: &[InternalIndex]) -> Vec<usize> {
     indices.iter().map(|index| index.size()).collect()
+}
+
+fn read_plain_slice<T: Copy>(
+    name: &str,
+    ptr: *const T,
+    len: usize,
+) -> Result<Vec<T>, (StatusCode, String)> {
+    if len == 0 {
+        return Ok(Vec::new());
+    }
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, format!("{name} is null")));
+    }
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec())
+}
+
+fn read_c64_slice(
+    name: &str,
+    ptr: *const f64,
+    n_complex: usize,
+) -> Result<Vec<Complex64>, (StatusCode, String)> {
+    if n_complex == 0 {
+        return Ok(Vec::new());
+    }
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, format!("{name} is null")));
+    }
+    let raw_len = n_complex.checked_mul(2).ok_or_else(|| {
+        capi_error(
+            T4A_INVALID_ARGUMENT,
+            format!("{name} length overflows usize"),
+        )
+    })?;
+    let raw = unsafe { std::slice::from_raw_parts(ptr, raw_len) };
+    Ok((0..n_complex)
+        .map(|i| Complex64::new(raw[2 * i], raw[2 * i + 1]))
+        .collect())
+}
+
+fn copy_plain_slice<T: Copy>(
+    name: &str,
+    values: &[T],
+    buf: *mut T,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> CapiResult<()> {
+    if out_len.is_null() {
+        return Err(capi_error(
+            T4A_NULL_POINTER,
+            format!("{name} out_len is null"),
+        ));
+    }
+    unsafe {
+        *out_len = values.len();
+    }
+
+    if buf.is_null() {
+        return Ok(());
+    }
+    if buf_len < values.len() {
+        return Err(capi_error(
+            T4A_BUFFER_TOO_SMALL,
+            format!(
+                "{name} buffer too small: required {}, got {buf_len}",
+                values.len()
+            ),
+        ));
+    }
+    unsafe {
+        std::ptr::copy_nonoverlapping(values.as_ptr(), buf, values.len());
+    }
+    Ok(())
+}
+
+fn copy_c64_interleaved(
+    name: &str,
+    values: &[Complex64],
+    buf_interleaved: *mut f64,
+    n_complex: usize,
+    out_len: *mut usize,
+) -> CapiResult<()> {
+    if out_len.is_null() {
+        return Err(capi_error(
+            T4A_NULL_POINTER,
+            format!("{name} out_len is null"),
+        ));
+    }
+    unsafe {
+        *out_len = values.len();
+    }
+
+    if buf_interleaved.is_null() {
+        return Ok(());
+    }
+    if n_complex < values.len() {
+        return Err(capi_error(
+            T4A_BUFFER_TOO_SMALL,
+            format!(
+                "{name} buffer too small: required {}, got {n_complex}",
+                values.len()
+            ),
+        ));
+    }
+
+    for (i, value) in values.iter().enumerate() {
+        unsafe {
+            *buf_interleaved.add(2 * i) = value.re;
+            *buf_interleaved.add(2 * i + 1) = value.im;
+        }
+    }
+    Ok(())
 }
 
 fn run_status<F>(f: F) -> StatusCode
@@ -206,6 +318,123 @@ pub extern "C" fn t4a_tensor_scalar_kind(
     crate::unwrap_catch(result)
 }
 
+/// Get the storage layout kind of a tensor.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_storage_kind(
+    ptr: *const t4a_tensor,
+    out_kind: *mut t4a_storage_kind,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        if out_kind.is_null() {
+            return Err(capi_error(T4A_NULL_POINTER, "out_kind is null"));
+        }
+        unsafe {
+            *out_kind = t4a_storage_kind::from(tensor.inner().storage().storage_kind());
+        }
+        Ok(())
+    })
+}
+
+/// Get the rank of the compact payload tensor.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_rank(
+    ptr: *const t4a_tensor,
+    out_rank: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        if out_rank.is_null() {
+            return Err(capi_error(T4A_NULL_POINTER, "out_rank is null"));
+        }
+        unsafe {
+            *out_rank = tensor.inner().storage().payload_dims().len();
+        }
+        Ok(())
+    })
+}
+
+/// Get the compact payload length in scalar elements.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_len(
+    ptr: *const t4a_tensor,
+    out_len: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        if out_len.is_null() {
+            return Err(capi_error(T4A_NULL_POINTER, "out_len is null"));
+        }
+        unsafe {
+            *out_len = tensor.inner().storage().payload_len();
+        }
+        Ok(())
+    })
+}
+
+/// Copy compact payload dimensions.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_dims(
+    ptr: *const t4a_tensor,
+    buf: *mut usize,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        let storage = tensor.inner().storage();
+        copy_plain_slice(
+            "payload_dims",
+            storage.payload_dims(),
+            buf,
+            buf_len,
+            out_len,
+        )
+    })
+}
+
+/// Copy compact payload strides in scalar elements.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_strides(
+    ptr: *const t4a_tensor,
+    buf: *mut isize,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        let storage = tensor.inner().storage();
+        copy_plain_slice(
+            "payload_strides",
+            storage.payload_strides(),
+            buf,
+            buf_len,
+            out_len,
+        )
+    })
+}
+
+/// Copy logical-axis to payload-axis class mapping.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_axis_classes(
+    ptr: *const t4a_tensor,
+    buf: *mut usize,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        let storage = tensor.inner().storage();
+        copy_plain_slice(
+            "axis_classes",
+            storage.axis_classes(),
+            buf,
+            buf_len,
+            out_len,
+        )
+    })
+}
+
 /// Copy dense `f64` data in column-major order.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_tensor_copy_dense_f64(
@@ -273,6 +502,44 @@ pub extern "C" fn t4a_tensor_copy_dense_c64(
     }));
 
     crate::unwrap_catch(result)
+}
+
+/// Copy compact payload `f64` data in payload column-major order.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_copy_payload_f64(
+    ptr: *const t4a_tensor,
+    buf: *mut f64,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        let data = tensor
+            .inner()
+            .storage()
+            .payload_f64_col_major_vec()
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        copy_plain_slice("payload_f64", &data, buf, buf_len, out_len)
+    })
+}
+
+/// Copy compact payload `Complex64` data as interleaved doubles.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_copy_payload_c64(
+    ptr: *const t4a_tensor,
+    buf_interleaved: *mut f64,
+    n_complex: usize,
+    out_len: *mut usize,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(ptr)?;
+        let data = tensor
+            .inner()
+            .storage()
+            .payload_c64_col_major_vec()
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        copy_c64_interleaved("payload_c64", &data, buf_interleaved, n_complex, out_len)
+    })
 }
 
 /// Contract two tensors by matching common indices.
@@ -450,6 +717,102 @@ pub extern "C" fn t4a_tensor_new_dense_c64(
             .collect::<Vec<_>>();
         let tensor = InternalTensor::from_dense(indices, values)
             .map_err(|e| capi_error(T4A_INVALID_ARGUMENT, e))?;
+        Ok(t4a_tensor::new(tensor))
+    })
+}
+
+/// Create a real tensor from explicit compact structured storage.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_structured_f64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    data: *const f64,
+    data_len: usize,
+    payload_dims: *const usize,
+    payload_rank: usize,
+    payload_strides: *const isize,
+    payload_strides_len: usize,
+    axis_classes: *const usize,
+    axis_classes_len: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_catching(out, || {
+        let indices = read_indices_from_ptrs(rank, index_ptrs)?;
+        let values = read_plain_slice("data", data, data_len)?;
+        let payload_dims = read_plain_slice("payload_dims", payload_dims, payload_rank)?;
+        let payload_strides =
+            read_plain_slice("payload_strides", payload_strides, payload_strides_len)?;
+        let axis_classes = read_plain_slice("axis_classes", axis_classes, axis_classes_len)?;
+        let storage = Storage::new_structured(values, payload_dims, payload_strides, axis_classes)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        let tensor = InternalTensor::from_structured_storage(indices, Arc::new(storage))
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_tensor::new(tensor))
+    })
+}
+
+/// Create a complex tensor from explicit compact structured storage.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_structured_c64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    data_interleaved: *const f64,
+    n_complex: usize,
+    payload_dims: *const usize,
+    payload_rank: usize,
+    payload_strides: *const isize,
+    payload_strides_len: usize,
+    axis_classes: *const usize,
+    axis_classes_len: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_catching(out, || {
+        let indices = read_indices_from_ptrs(rank, index_ptrs)?;
+        let values = read_c64_slice("data_interleaved", data_interleaved, n_complex)?;
+        let payload_dims = read_plain_slice("payload_dims", payload_dims, payload_rank)?;
+        let payload_strides =
+            read_plain_slice("payload_strides", payload_strides, payload_strides_len)?;
+        let axis_classes = read_plain_slice("axis_classes", axis_classes, axis_classes_len)?;
+        let storage = Storage::new_structured(values, payload_dims, payload_strides, axis_classes)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        let tensor = InternalTensor::from_structured_storage(indices, Arc::new(storage))
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_tensor::new(tensor))
+    })
+}
+
+/// Create a real diagonal tensor from compact diagonal payload data.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_diag_f64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    diag_data: *const f64,
+    diag_len: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_catching(out, || {
+        let indices = read_indices_from_ptrs(rank, index_ptrs)?;
+        let values = read_plain_slice("diag_data", diag_data, diag_len)?;
+        let tensor = InternalTensor::from_diag(indices, values)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_tensor::new(tensor))
+    })
+}
+
+/// Create a complex diagonal tensor from compact diagonal payload data.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_diag_c64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    diag_data_interleaved: *const f64,
+    n_complex: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_catching(out, || {
+        let indices = read_indices_from_ptrs(rank, index_ptrs)?;
+        let values = read_c64_slice("diag_data_interleaved", diag_data_interleaved, n_complex)?;
+        let tensor = InternalTensor::from_diag(indices, values)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
         Ok(t4a_tensor::new(tensor))
     })
 }

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::index::{t4a_index_new, t4a_index_release};
-use crate::types::{t4a_singular_value_measure, t4a_threshold_scale, t4a_truncation_rule};
+use crate::types::{
+    t4a_singular_value_measure, t4a_storage_kind, t4a_threshold_scale, t4a_truncation_rule,
+};
 use num_complex::Complex64;
 
 fn new_index(dim: usize) -> *mut t4a_index {
@@ -54,6 +56,76 @@ fn read_dense_f64(tensor: *const t4a_tensor) -> Vec<f64> {
     let mut data = vec![0.0; len];
     assert_eq!(
         t4a_tensor_copy_dense_f64(tensor, data.as_mut_ptr(), data.len(), &mut len),
+        T4A_SUCCESS
+    );
+    data
+}
+
+fn read_payload_dims(tensor: *const t4a_tensor) -> Vec<usize> {
+    let mut len = 0usize;
+    assert_eq!(
+        t4a_tensor_payload_dims(tensor, std::ptr::null_mut(), 0, &mut len),
+        T4A_SUCCESS
+    );
+    let mut dims = vec![0usize; len];
+    assert_eq!(
+        t4a_tensor_payload_dims(tensor, dims.as_mut_ptr(), dims.len(), &mut len),
+        T4A_SUCCESS
+    );
+    dims
+}
+
+fn read_payload_strides(tensor: *const t4a_tensor) -> Vec<isize> {
+    let mut len = 0usize;
+    assert_eq!(
+        t4a_tensor_payload_strides(tensor, std::ptr::null_mut(), 0, &mut len),
+        T4A_SUCCESS
+    );
+    let mut strides = vec![0isize; len];
+    assert_eq!(
+        t4a_tensor_payload_strides(tensor, strides.as_mut_ptr(), strides.len(), &mut len),
+        T4A_SUCCESS
+    );
+    strides
+}
+
+fn read_axis_classes(tensor: *const t4a_tensor) -> Vec<usize> {
+    let mut len = 0usize;
+    assert_eq!(
+        t4a_tensor_axis_classes(tensor, std::ptr::null_mut(), 0, &mut len),
+        T4A_SUCCESS
+    );
+    let mut classes = vec![0usize; len];
+    assert_eq!(
+        t4a_tensor_axis_classes(tensor, classes.as_mut_ptr(), classes.len(), &mut len),
+        T4A_SUCCESS
+    );
+    classes
+}
+
+fn read_payload_f64(tensor: *const t4a_tensor) -> Vec<f64> {
+    let mut len = 0usize;
+    assert_eq!(
+        t4a_tensor_copy_payload_f64(tensor, std::ptr::null_mut(), 0, &mut len),
+        T4A_SUCCESS
+    );
+    let mut data = vec![0.0; len];
+    assert_eq!(
+        t4a_tensor_copy_payload_f64(tensor, data.as_mut_ptr(), data.len(), &mut len),
+        T4A_SUCCESS
+    );
+    data
+}
+
+fn read_payload_c64(tensor: *const t4a_tensor) -> Vec<f64> {
+    let mut len = 0usize;
+    assert_eq!(
+        t4a_tensor_copy_payload_c64(tensor, std::ptr::null_mut(), 0, &mut len),
+        T4A_SUCCESS
+    );
+    let mut data = vec![0.0; 2 * len];
+    assert_eq!(
+        t4a_tensor_copy_payload_c64(tensor, data.as_mut_ptr(), len, &mut len),
         T4A_SUCCESS
     );
     data
@@ -197,6 +269,250 @@ fn test_tensor_dense_c64_roundtrip() {
     t4a_tensor_release(tensor);
     t4a_index_release(i);
     t4a_index_release(j);
+}
+
+#[test]
+fn test_tensor_diag_f64_storage_payload_roundtrip() {
+    let i = new_index(3);
+    let j = new_index(3);
+    let index_ptrs = [i as *const t4a_index, j as *const t4a_index];
+    let diag = [1.0, 2.0, 4.0];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_diag_f64(
+            2,
+            index_ptrs.as_ptr(),
+            diag.as_ptr(),
+            diag.len(),
+            &mut tensor
+        ),
+        T4A_SUCCESS
+    );
+    assert!(!tensor.is_null());
+
+    let mut kind = t4a_storage_kind::Dense;
+    assert_eq!(t4a_tensor_storage_kind(tensor, &mut kind), T4A_SUCCESS);
+    assert_eq!(kind, t4a_storage_kind::Diagonal);
+
+    let mut payload_rank = 0usize;
+    assert_eq!(
+        t4a_tensor_payload_rank(tensor, &mut payload_rank),
+        T4A_SUCCESS
+    );
+    assert_eq!(payload_rank, 1);
+
+    let mut payload_len = 0usize;
+    assert_eq!(
+        t4a_tensor_payload_len(tensor, &mut payload_len),
+        T4A_SUCCESS
+    );
+    assert_eq!(payload_len, 3);
+    assert_eq!(read_payload_dims(tensor), vec![3]);
+    assert_eq!(read_payload_strides(tensor), vec![1]);
+    assert_eq!(read_axis_classes(tensor), vec![0, 0]);
+    assert_eq!(read_payload_f64(tensor), diag);
+    assert_eq!(
+        read_dense_f64(tensor),
+        vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 4.0]
+    );
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(j);
+    t4a_index_release(i);
+}
+
+#[test]
+fn test_tensor_structured_f64_storage_payload_roundtrip() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(2);
+    let index_ptrs = [
+        i as *const t4a_index,
+        j as *const t4a_index,
+        k as *const t4a_index,
+    ];
+    let payload_dims = [2usize, 3];
+    let payload_strides = [1isize, 2];
+    let axis_classes = [0usize, 1, 0];
+    let payload = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_structured_f64(
+            3,
+            index_ptrs.as_ptr(),
+            payload.as_ptr(),
+            payload.len(),
+            payload_dims.as_ptr(),
+            payload_dims.len(),
+            payload_strides.as_ptr(),
+            payload_strides.len(),
+            axis_classes.as_ptr(),
+            axis_classes.len(),
+            &mut tensor,
+        ),
+        T4A_SUCCESS
+    );
+    assert!(!tensor.is_null());
+
+    let mut kind = t4a_storage_kind::Dense;
+    assert_eq!(t4a_tensor_storage_kind(tensor, &mut kind), T4A_SUCCESS);
+    assert_eq!(kind, t4a_storage_kind::Structured);
+    assert_eq!(read_payload_dims(tensor), payload_dims);
+    assert_eq!(read_payload_strides(tensor), payload_strides);
+    assert_eq!(read_axis_classes(tensor), axis_classes);
+    assert_eq!(read_payload_f64(tensor), payload);
+    assert_eq!(
+        read_dense_f64(tensor),
+        vec![1.0, 0.0, 3.0, 0.0, 5.0, 0.0, 0.0, 2.0, 0.0, 4.0, 0.0, 6.0]
+    );
+
+    t4a_tensor_release(tensor);
+    for index in [k, j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_structured_c64_storage_payload_roundtrip() {
+    let i = new_index(2);
+    let j = new_index(2);
+    let index_ptrs = [i as *const t4a_index, j as *const t4a_index];
+    let payload_dims = [2usize];
+    let payload_strides = [1isize];
+    let axis_classes = [0usize, 0];
+    let payload = [1.0, 0.5, 2.0, -1.5];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_structured_c64(
+            2,
+            index_ptrs.as_ptr(),
+            payload.as_ptr(),
+            payload.len() / 2,
+            payload_dims.as_ptr(),
+            payload_dims.len(),
+            payload_strides.as_ptr(),
+            payload_strides.len(),
+            axis_classes.as_ptr(),
+            axis_classes.len(),
+            &mut tensor,
+        ),
+        T4A_SUCCESS
+    );
+    assert!(!tensor.is_null());
+
+    let mut scalar_kind = t4a_scalar_kind::F64;
+    assert_eq!(
+        t4a_tensor_scalar_kind(tensor, &mut scalar_kind),
+        T4A_SUCCESS
+    );
+    assert_eq!(scalar_kind, t4a_scalar_kind::C64);
+
+    let mut storage_kind = t4a_storage_kind::Dense;
+    assert_eq!(
+        t4a_tensor_storage_kind(tensor, &mut storage_kind),
+        T4A_SUCCESS
+    );
+    assert_eq!(storage_kind, t4a_storage_kind::Diagonal);
+    assert_eq!(read_payload_c64(tensor), payload);
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(j);
+    t4a_index_release(i);
+}
+
+#[test]
+fn test_tensor_diag_c64_storage_payload_roundtrip() {
+    let i = new_index(2);
+    let j = new_index(2);
+    let index_ptrs = [i as *const t4a_index, j as *const t4a_index];
+    let diag = [3.0, 0.25, 4.0, -0.5];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_diag_c64(2, index_ptrs.as_ptr(), diag.as_ptr(), 2, &mut tensor),
+        T4A_SUCCESS
+    );
+    assert!(!tensor.is_null());
+    assert_eq!(read_payload_c64(tensor), diag);
+
+    let mut storage_kind = t4a_storage_kind::Dense;
+    assert_eq!(
+        t4a_tensor_storage_kind(tensor, &mut storage_kind),
+        T4A_SUCCESS
+    );
+    assert_eq!(storage_kind, t4a_storage_kind::Diagonal);
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(j);
+    t4a_index_release(i);
+}
+
+#[test]
+fn test_tensor_structured_constructor_rejects_logical_dim_mismatch() {
+    let i = new_index(2);
+    let j = new_index(4);
+    let k = new_index(2);
+    let index_ptrs = [
+        i as *const t4a_index,
+        j as *const t4a_index,
+        k as *const t4a_index,
+    ];
+    let payload_dims = [2usize, 3];
+    let payload_strides = [1isize, 2];
+    let axis_classes = [0usize, 1, 0];
+    let payload = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let mut tensor = std::ptr::null_mut();
+
+    assert_eq!(
+        t4a_tensor_new_structured_f64(
+            3,
+            index_ptrs.as_ptr(),
+            payload.as_ptr(),
+            payload.len(),
+            payload_dims.as_ptr(),
+            payload_dims.len(),
+            payload_strides.as_ptr(),
+            payload_strides.len(),
+            axis_classes.as_ptr(),
+            axis_classes.len(),
+            &mut tensor,
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(tensor.is_null());
+
+    for index in [k, j, i] {
+        t4a_index_release(index);
+    }
+}
+
+#[test]
+fn test_tensor_payload_readback_reports_buffer_and_type_errors() {
+    let i = new_index(2);
+    let tensor = new_tensor_f64(&[i as *const t4a_index], &[1.0, 2.0]);
+
+    let mut len = 0usize;
+    let mut dim = 0usize;
+    assert_eq!(
+        t4a_tensor_payload_dims(tensor, &mut dim, 0, &mut len),
+        T4A_BUFFER_TOO_SMALL
+    );
+    assert_eq!(len, 1);
+
+    let mut payload = [0.0_f64; 1];
+    assert_eq!(
+        t4a_tensor_copy_payload_f64(tensor, payload.as_mut_ptr(), payload.len(), &mut len),
+        T4A_BUFFER_TOO_SMALL
+    );
+    assert_eq!(len, 2);
+
+    let mut complex_len = 0usize;
+    assert_eq!(
+        t4a_tensor_copy_payload_c64(tensor, std::ptr::null_mut(), 0, &mut complex_len),
+        T4A_INVALID_ARGUMENT
+    );
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
 }
 
 #[test]

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -3,7 +3,7 @@
 use std::ffi::c_void;
 
 use tensor4all_core::{
-    DynIndex, FactorizeAlg, SingularValueMeasure, SvdTruncationPolicy, TensorDynLen,
+    DynIndex, FactorizeAlg, SingularValueMeasure, StorageKind, SvdTruncationPolicy, TensorDynLen,
     ThresholdScale, TruncationRule,
 };
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
@@ -75,6 +75,28 @@ impl t4a_scalar_kind {
             Self::C64
         } else {
             Self::F64
+        }
+    }
+}
+
+/// Storage layout kind used by tensor payload inspection APIs.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum t4a_storage_kind {
+    /// Dense storage whose payload axes match the logical tensor axes.
+    Dense = 0,
+    /// Diagonal storage whose logical axes all share one payload axis.
+    Diagonal = 1,
+    /// General structured storage with explicit payload-axis classes.
+    Structured = 2,
+}
+
+impl From<StorageKind> for t4a_storage_kind {
+    fn from(kind: StorageKind) -> Self {
+        match kind {
+            StorageKind::Dense => Self::Dense,
+            StorageKind::Diagonal => Self::Diagonal,
+            StorageKind::Structured => Self::Structured,
         }
     }
 }

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -112,7 +112,7 @@ impl AnyScalar {
     where
         E: fmt::Display,
     {
-        let result = f(lhs.tensor.inner.as_ref(), rhs.tensor.inner.as_ref())
+        let result = f(lhs.tensor.as_inner(), rhs.tensor.as_inner())
             .unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
         Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
     }
@@ -127,8 +127,8 @@ impl AnyScalar {
     where
         E: fmt::Display,
     {
-        let result = f(input.tensor.inner.as_ref())
-            .unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
+        let result =
+            f(input.tensor.as_inner()).unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
         Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
     }
 

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -749,6 +749,13 @@ impl TensorDynLen {
     pub fn permute_indices(&self, new_indices: &[DynIndex]) -> Self {
         // Compute permutation by matching IDs
         let perm = compute_permutation_from_indices(&self.indices, new_indices);
+        if perm.iter().copied().eq(0..perm.len()) {
+            return Self {
+                indices: new_indices.to_vec(),
+                storage: Arc::clone(&self.storage),
+                eager_cache: Arc::clone(&self.eager_cache),
+            };
+        }
 
         let permuted = self
             .materialized_inner()
@@ -793,6 +800,9 @@ impl TensorDynLen {
             self.indices.len(),
             "permutation length must match tensor rank"
         );
+        if perm.iter().copied().eq(0..perm.len()) {
+            return self.clone();
+        }
 
         // Permute indices
         let new_indices: Vec<DynIndex> = perm.iter().map(|&i| self.indices[i].clone()).collect();
@@ -1376,6 +1386,27 @@ impl TensorDynLen {
         } else {
             Self::dense_axis_classes(self.indices.len())
         };
+
+        let same_compact_layout = self.storage.payload_dims()
+            == other_aligned.storage.payload_dims()
+            && self.storage.payload_strides() == other_aligned.storage.payload_strides()
+            && self.storage.axis_classes() == other_aligned.storage.axis_classes();
+        if same_compact_layout
+            && !self.tracks_grad()
+            && !other_aligned.tracks_grad()
+            && !a.tracks_grad()
+            && !b.tracks_grad()
+        {
+            let combined = self
+                .storage
+                .axpby(
+                    &a.to_backend_scalar(),
+                    other_aligned.storage.as_ref(),
+                    &b.to_backend_scalar(),
+                )
+                .map_err(|e| anyhow::anyhow!("storage axpby failed: {e}"))?;
+            return Self::from_storage(self.indices.clone(), Arc::new(combined));
+        }
 
         if self.as_native().dtype() != other_aligned.as_native().dtype()
             || self.as_native().dtype() != a.as_tensor().as_native().dtype()

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -110,13 +110,15 @@ pub trait TensorAccess {
     fn indices(&self) -> &[DynIndex];
 }
 
-/// Dynamic-rank dense tensor -- the central data type of tensor4all.
+/// Dynamic-rank tensor with structured payload storage -- the central data type
+/// of tensor4all.
 ///
-/// `TensorDynLen` stores a multi-dimensional array of `f64` or `Complex64`
-/// values together with a list of [`DynIndex`] labels. The indices carry
-/// unique identities (UUIDs) so that contraction, addition, and other
-/// binary operations can automatically match legs by identity rather than
-/// position.
+/// `TensorDynLen` stores a logical multi-dimensional tensor of `f64` or
+/// `Complex64` values together with a list of [`DynIndex`] labels. The
+/// authoritative payload is compact [`Storage`], which may be dense, diagonal,
+/// or explicitly structured. The indices carry unique identities (UUIDs) so
+/// that contraction, addition, and other binary operations can automatically
+/// match legs by identity rather than position.
 ///
 /// # Key Operations
 ///
@@ -132,8 +134,10 @@ pub trait TensorAccess {
 ///
 /// # Data Layout
 ///
-/// Data is stored in **column-major** order (first index varies fastest),
-/// matching Fortran, Julia, and ITensors.jl conventions.
+/// Logical dense extraction uses **column-major** order (first index varies
+/// fastest), matching Fortran, Julia, and ITensors.jl conventions. Compact
+/// structured payloads additionally carry explicit payload dimensions, strides,
+/// and logical-axis classes.
 ///
 /// # Examples
 ///
@@ -1842,9 +1846,9 @@ impl std::fmt::Debug for TensorDynLen {
 /// * `indices` - The indices for the tensor (all must have the same dimension)
 /// * `diag_data` - The diagonal elements (length must equal the dimension of indices)
 ///
-/// The public native bridge currently materializes diagonal payloads densely, so
-/// the returned tensor is mathematically diagonal but may not report
-/// [`TensorDynLen::is_diag`] at the native-storage level.
+/// The returned tensor preserves compact diagonal payload metadata; use
+/// [`TensorDynLen::is_diag`] or [`TensorDynLen::storage`] to inspect that
+/// representation.
 ///
 /// # Panics
 /// Panics if indices have different dimensions, or if diag_data length doesn't match.
@@ -1858,6 +1862,7 @@ impl std::fmt::Debug for TensorDynLen {
 /// let j = DynIndex::new_dyn(3);
 /// let t = diag_tensor_dyn_len(vec![i, j], vec![1.0, 2.0, 3.0]);
 /// assert_eq!(t.dims(), vec![3, 3]);
+/// assert!(t.is_diag());
 /// ```
 pub fn diag_tensor_dyn_len(indices: Vec<DynIndex>, diag_data: Vec<f64>) -> TensorDynLen {
     TensorDynLen::from_diag(indices, diag_data)
@@ -2314,9 +2319,9 @@ impl TensorDynLen {
     /// that dimension. The resulting tensor has nonzero entries only on
     /// the multi-index diagonal (`T[i,i,...,i] = data[i]`).
     ///
-    /// The public native bridge currently materializes diagonal payloads densely, so
-    /// the returned tensor is mathematically diagonal but may not report
-    /// [`TensorDynLen::is_diag`] at the native-storage level.
+    /// The returned tensor preserves compact diagonal payload metadata; use
+    /// [`TensorDynLen::is_diag`] or [`TensorDynLen::storage`] to inspect that
+    /// representation.
     ///
     /// # Examples
     ///
@@ -2326,6 +2331,7 @@ impl TensorDynLen {
     /// let i = DynIndex::new_dyn(3);
     /// let j = DynIndex::new_dyn(3);
     /// let diag = TensorDynLen::from_diag(vec![i, j], vec![1.0, 2.0, 3.0]).unwrap();
+    /// assert!(diag.is_diag());
     ///
     /// let data = diag.to_vec::<f64>().unwrap();
     /// // 3x3 identity-like: [1,0,0, 0,2,0, 0,0,3] in column-major

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -10,7 +10,7 @@ use rand::Rng;
 use rand_distr::{Distribution, StandardNormal};
 use std::collections::HashSet;
 use std::ops::{Mul, Neg, Sub};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tenferro::eager_einsum::eager_einsum_ad;
 use tenferro::{CpuBackend, DType, EagerTensor, Tensor as NativeTensor};
 use tensor4all_tensorbackend::{
@@ -161,11 +161,10 @@ pub trait TensorAccess {
 pub struct TensorDynLen {
     /// Full index information (includes tags and other metadata).
     pub indices: Vec<DynIndex>,
-    /// Eager payload tensor. During the primal migration this is created as an
-    /// untracked eager leaf and will start carrying AD state again in Task 4.
-    pub(crate) inner: Arc<EagerTensor<CpuBackend>>,
-    /// Logical-to-payload axis classes. Repeated values encode diagonal axes.
-    pub(crate) axis_classes: Vec<usize>,
+    /// Authoritative compact payload storage.
+    pub(crate) storage: Arc<Storage>,
+    /// Lazily materialized eager payload for native execution and AD.
+    pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
 }
 
 impl TensorAccess for TensorDynLen {
@@ -205,7 +204,8 @@ impl TensorDynLen {
     }
 
     fn permute_axis_classes(&self, perm: &[usize]) -> Vec<usize> {
-        let permuted: Vec<usize> = perm.iter().map(|&index| self.axis_classes[index]).collect();
+        let axis_classes = self.storage.axis_classes();
+        let permuted: Vec<usize> = perm.iter().map(|&index| axis_classes[index]).collect();
         Self::canonicalize_axis_classes(&permuted)
     }
 
@@ -329,6 +329,69 @@ impl TensorDynLen {
         storage_to_native_tensor(storage, dims)
     }
 
+    fn empty_eager_cache() -> Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>> {
+        Arc::new(OnceLock::new())
+    }
+
+    fn eager_cache_with(
+        inner: EagerTensor<CpuBackend>,
+    ) -> Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>> {
+        let cache = Arc::new(OnceLock::new());
+        let _ = cache.set(Arc::new(inner));
+        cache
+    }
+
+    fn storage_from_native_with_axis_classes(
+        native: &NativeTensor,
+        axis_classes: &[usize],
+        logical_rank: usize,
+    ) -> Result<Storage> {
+        if Self::is_diag_axis_classes(axis_classes) {
+            match native.dtype() {
+                DType::F32 | DType::F64 => Storage::from_diag_col_major(
+                    native_tensor_primal_to_diag_f64(native)?,
+                    logical_rank,
+                ),
+                DType::C32 | DType::C64 => Storage::from_diag_col_major(
+                    native_tensor_primal_to_diag_c64(native)?,
+                    logical_rank,
+                ),
+            }
+        } else {
+            native_tensor_primal_to_storage(native)
+        }
+    }
+
+    fn validate_storage_matches_indices(indices: &[DynIndex], storage: &Storage) -> Result<()> {
+        let dims = Self::expected_dims_from_indices(indices);
+        let storage_dims = storage.logical_dims();
+        if storage_dims != dims {
+            return Err(anyhow::anyhow!(
+                "storage logical dims {:?} do not match indices dims {:?}",
+                storage_dims,
+                dims
+            ));
+        }
+        if storage.is_diag() {
+            Self::validate_diag_dims(&dims)?;
+        }
+        Ok(())
+    }
+
+    fn materialized_inner(&self) -> &EagerTensor<CpuBackend> {
+        self.eager_cache
+            .get_or_init(|| {
+                let native = Self::seed_native_payload(self.storage.as_ref(), &self.dims())
+                    .unwrap_or_else(|err| panic!("TensorDynLen materialization failed: {err}"));
+                Arc::new(EagerTensor::from_tensor_in(native, default_eager_ctx()))
+            })
+            .as_ref()
+    }
+
+    pub(crate) fn as_inner(&self) -> &EagerTensor<CpuBackend> {
+        self.materialized_inner()
+    }
+
     /// Compute dims from `indices` order.
     #[inline]
     fn expected_dims_from_indices(indices: &[DynIndex]) -> Vec<usize> {
@@ -404,7 +467,7 @@ impl TensorDynLen {
         Self::new(indices, storage)
     }
 
-    /// Create a tensor from explicit storage by seeding a canonical native payload.
+    /// Create a tensor from explicit compact storage.
     ///
     /// # Examples
     ///
@@ -419,18 +482,39 @@ impl TensorDynLen {
     /// assert_eq!(t.dims(), vec![2, 2]);
     /// ```
     pub fn from_storage(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
-        let dims = Self::expected_dims_from_indices(&indices);
         Self::validate_indices(&indices);
-        if storage.is_diag() {
-            Self::validate_diag_dims(&dims)?;
-        }
-        let native = Self::seed_native_payload(storage.as_ref(), &dims)?;
-        let axis_classes = if storage.is_diag() {
-            Self::diag_axis_classes(indices.len())
-        } else {
-            Self::dense_axis_classes(indices.len())
-        };
-        Self::from_native_with_axis_classes(indices, native, axis_classes)
+        Self::validate_storage_matches_indices(&indices, storage.as_ref())?;
+        Ok(Self {
+            indices,
+            storage,
+            eager_cache: Self::empty_eager_cache(),
+        })
+    }
+
+    /// Create a tensor from explicit structured storage.
+    ///
+    /// This is an alias for [`TensorDynLen::from_storage`] with a name that
+    /// emphasizes that compact structured metadata is preserved.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the storage logical dimensions do not match the
+    /// supplied indices, or if duplicate indices are provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_core::{DynIndex, Storage, StorageKind, TensorDynLen};
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(2);
+    /// let storage = Arc::new(Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap());
+    /// let tensor = TensorDynLen::from_structured_storage(vec![i, j], storage).unwrap();
+    /// assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
+    /// ```
+    pub fn from_structured_storage(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
+        Self::from_storage(indices, storage)
     }
 
     /// Create a tensor from a native tenferro payload.
@@ -476,10 +560,15 @@ impl TensorDynLen {
         if Self::is_diag_axis_classes(&axis_classes) {
             Self::validate_diag_dims(&dims)?;
         }
+        let storage = Self::storage_from_native_with_axis_classes(
+            inner.data(),
+            &axis_classes,
+            indices.len(),
+        )?;
         Ok(Self {
             indices,
-            inner: Arc::new(inner),
-            axis_classes,
+            storage: Arc::new(storage),
+            eager_cache: Self::eager_cache_with(inner),
         })
     }
 
@@ -490,7 +579,7 @@ impl TensorDynLen {
 
     /// Borrow the native payload.
     pub(crate) fn as_native(&self) -> &NativeTensor {
-        self.inner.data()
+        self.materialized_inner().data()
     }
 
     /// Enable reverse-mode AD tracking on this tensor by creating a tracked leaf.
@@ -498,25 +587,30 @@ impl TensorDynLen {
         let native = self.as_native().clone();
         Self {
             indices: self.indices,
-            inner: Arc::new(EagerTensor::requires_grad_in(native, default_eager_ctx())),
-            axis_classes: self.axis_classes,
+            storage: self.storage,
+            eager_cache: Self::eager_cache_with(EagerTensor::requires_grad_in(
+                native,
+                default_eager_ctx(),
+            )),
         }
     }
 
     /// Report whether this tensor participates in gradient tracking.
     pub fn tracks_grad(&self) -> bool {
-        self.inner.tracks_grad()
+        self.eager_cache
+            .get()
+            .is_some_and(|inner| inner.tracks_grad())
     }
 
     /// Return the accumulated gradient, if one has been stored.
     pub fn grad(&self) -> Result<Option<Self>> {
-        self.inner
+        self.materialized_inner()
             .grad()
             .map(|grad| {
                 Self::from_native_with_axis_classes(
                     self.indices.clone(),
                     grad.as_ref().clone(),
-                    self.axis_classes.clone(),
+                    self.storage.axis_classes().to_vec(),
                 )
             })
             .transpose()
@@ -524,13 +618,15 @@ impl TensorDynLen {
 
     /// Clear the accumulated gradient stored for this tensor.
     pub fn clear_grad(&self) -> Result<()> {
-        self.inner.clear_grad();
+        if let Some(inner) = self.eager_cache.get() {
+            inner.clear_grad();
+        }
         Ok(())
     }
 
     /// Run reverse-mode autodiff from this scalar tensor.
     pub fn backward(&self) -> Result<()> {
-        self.inner
+        self.materialized_inner()
             .backward()
             .map(|_| ())
             .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}"))
@@ -538,11 +634,12 @@ impl TensorDynLen {
 
     /// Detach this tensor from the reverse graph.
     pub fn detach(&self) -> Self {
-        Self {
-            indices: self.indices.clone(),
-            inner: Arc::new(self.inner.detach()),
-            axis_classes: self.axis_classes.clone(),
-        }
+        Self::from_inner_with_axis_classes(
+            self.indices.clone(),
+            self.materialized_inner().detach(),
+            self.storage.axis_classes().to_vec(),
+        )
+        .expect("TensorDynLen::detach returned invalid tensor")
     }
 
     /// Check if this tensor is already in canonical form.
@@ -552,27 +649,12 @@ impl TensorDynLen {
 
     /// Materialize the primal snapshot as storage.
     pub fn to_storage(&self) -> Result<Arc<Storage>> {
-        let storage = if self.is_diag() {
-            match self.as_native().dtype() {
-                DType::F32 | DType::F64 => Storage::from_diag_col_major(
-                    native_tensor_primal_to_diag_f64(self.as_native())?,
-                    self.indices.len(),
-                )?,
-                DType::C32 | DType::C64 => Storage::from_diag_col_major(
-                    native_tensor_primal_to_diag_c64(self.as_native())?,
-                    self.indices.len(),
-                )?,
-            }
-        } else {
-            native_tensor_primal_to_storage(self.as_native())?
-        };
-        Ok(Arc::new(storage))
+        Ok(Arc::clone(&self.storage))
     }
 
-    /// Materialize the primal snapshot as storage.
+    /// Returns the authoritative compact storage.
     pub fn storage(&self) -> Arc<Storage> {
-        self.to_storage()
-            .expect("TensorDynLen::storage snapshot materialization failed")
+        Arc::clone(&self.storage)
     }
 
     /// Sum all elements, returning `AnyScalar`.
@@ -593,7 +675,7 @@ impl TensorDynLen {
         }
         let axes: Vec<usize> = (0..self.indices.len()).collect();
         let reduced = self
-            .inner
+            .materialized_inner()
             .reduce_sum(&axes)
             .unwrap_or_else(|e| panic!("TensorDynLen::sum failed: {e}"));
         AnyScalar::from_tensor_unchecked(
@@ -669,7 +751,7 @@ impl TensorDynLen {
         let perm = compute_permutation_from_indices(&self.indices, new_indices);
 
         let permuted = self
-            .inner
+            .materialized_inner()
             .transpose(&perm)
             .unwrap_or_else(|e| panic!("TensorDynLen::permute_indices failed: {e}"));
         let axis_classes = self.permute_axis_classes(&perm);
@@ -715,7 +797,7 @@ impl TensorDynLen {
         // Permute indices
         let new_indices: Vec<DynIndex> = perm.iter().map(|&i| self.indices[i].clone()).collect();
         let permuted = self
-            .inner
+            .materialized_inner()
             .transpose(perm)
             .unwrap_or_else(|e| panic!("TensorDynLen::permute failed: {e}"));
         let axis_classes = self.permute_axis_classes(perm);
@@ -768,8 +850,8 @@ impl TensorDynLen {
 
         if self.indices.is_empty() && other.indices.is_empty() {
             let result = self
-                .inner
-                .mul(other.inner.as_ref())
+                .materialized_inner()
+                .mul(other.materialized_inner())
                 .unwrap_or_else(|e| panic!("TensorDynLen::contract scalar multiply failed: {e}"));
             return Self::from_inner(spec.result_indices, result)
                 .expect("TensorDynLen::contract returned invalid scalar");
@@ -794,8 +876,11 @@ impl TensorDynLen {
             &spec.axes_b,
         )
         .expect("TensorDynLen::contract failed to build einsum subscripts");
-        let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
-            .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"));
+        let result = eager_einsum_ad(
+            &[self.materialized_inner(), other.materialized_inner()],
+            &subscripts,
+        )
+        .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"));
         Self::from_inner(spec.result_indices, result)
             .expect("TensorDynLen::contract returned invalid tensor")
     }
@@ -886,8 +971,8 @@ impl TensorDynLen {
 
         if self.indices.is_empty() && other.indices.is_empty() {
             let result = self
-                .inner
-                .mul(other.inner.as_ref())
+                .materialized_inner()
+                .mul(other.materialized_inner())
                 .map_err(|e| anyhow::anyhow!("tensordot scalar multiply failed: {e}"))?;
             return Self::from_inner(spec.result_indices, result);
         }
@@ -908,8 +993,11 @@ impl TensorDynLen {
             other.indices.len(),
             &spec.axes_b,
         )?;
-        let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
-            .map_err(|e| anyhow::anyhow!("tensordot failed: {e}"))?;
+        let result = eager_einsum_ad(
+            &[self.materialized_inner(), other.materialized_inner()],
+            &subscripts,
+        )
+        .map_err(|e| anyhow::anyhow!("tensordot failed: {e}"))?;
         Self::from_inner(spec.result_indices, result)
     }
 
@@ -976,8 +1064,11 @@ impl TensorDynLen {
             other.indices.len(),
             &[],
         )?;
-        let result = eager_einsum_ad(&[self.inner.as_ref(), other.inner.as_ref()], &subscripts)
-            .map_err(|e| anyhow::anyhow!("outer_product failed: {e}"))?;
+        let result = eager_einsum_ad(
+            &[self.materialized_inner(), other.materialized_inner()],
+            &subscripts,
+        )
+        .map_err(|e| anyhow::anyhow!("outer_product failed: {e}"))?;
         Self::from_inner(result_indices, result)
     }
 }
@@ -1280,8 +1371,8 @@ impl TensorDynLen {
             ));
         }
 
-        let axis_classes = if self.axis_classes == other_aligned.axis_classes {
-            self.axis_classes.clone()
+        let axis_classes = if self.storage.axis_classes() == other_aligned.storage.axis_classes() {
+            self.storage.axis_classes().to_vec()
         } else {
             Self::dense_axis_classes(self.indices.len())
         };
@@ -1306,8 +1397,8 @@ impl TensorDynLen {
         let lhs = self.scale(a)?;
         let rhs = other_aligned.scale(b)?;
         let combined = lhs
-            .inner
-            .add(rhs.inner.as_ref())
+            .materialized_inner()
+            .add(rhs.materialized_inner())
             .map_err(|e| anyhow::anyhow!("tensor addition failed: {e}"))?;
         Self::from_inner_with_axis_classes(self.indices.clone(), combined, axis_classes)
     }
@@ -1332,23 +1423,30 @@ impl TensorDynLen {
             return Self::from_native_with_axis_classes(
                 self.indices.clone(),
                 scaled,
-                self.axis_classes.clone(),
+                self.storage.axis_classes().to_vec(),
             );
         }
 
         let scaled = if self.indices.is_empty() {
-            self.inner
-                .mul(scalar.as_tensor().inner.as_ref())
+            self.materialized_inner()
+                .mul(scalar.as_tensor().materialized_inner())
                 .map_err(|e| anyhow::anyhow!("scalar multiplication failed: {e}"))?
         } else {
             let subscripts = Self::scale_subscripts(self.indices.len())?;
             eager_einsum_ad(
-                &[self.inner.as_ref(), scalar.as_tensor().inner.as_ref()],
+                &[
+                    self.materialized_inner(),
+                    scalar.as_tensor().materialized_inner(),
+                ],
                 &subscripts,
             )
             .map_err(|e| anyhow::anyhow!("tensor scaling failed: {e}"))?
         };
-        Self::from_inner_with_axis_classes(self.indices.clone(), scaled, self.axis_classes.clone())
+        Self::from_inner_with_axis_classes(
+            self.indices.clone(),
+            scaled,
+            self.storage.axis_classes().to_vec(),
+        )
     }
 
     /// Inner product (dot product) of two tensors.
@@ -1447,8 +1545,8 @@ impl TensorDynLen {
 
         Self {
             indices: new_indices,
-            inner: self.inner.clone(),
-            axis_classes: self.axis_classes.clone(),
+            storage: Arc::clone(&self.storage),
+            eager_cache: Arc::clone(&self.eager_cache),
         }
     }
 
@@ -1522,8 +1620,8 @@ impl TensorDynLen {
 
         Self {
             indices: new_indices_vec,
-            inner: self.inner.clone(),
-            axis_classes: self.axis_classes.clone(),
+            storage: Arc::clone(&self.storage),
+            eager_cache: Arc::clone(&self.eager_cache),
         }
     }
 }
@@ -1561,11 +1659,15 @@ impl TensorDynLen {
         // for QSpace-compatible directed indices where conj() flips Ket <-> Bra
         let new_indices: Vec<DynIndex> = self.indices.iter().map(|idx| idx.conj()).collect();
         let conjugated = self
-            .inner
+            .materialized_inner()
             .conj()
             .unwrap_or_else(|e| panic!("TensorDynLen::conj failed: {e}"));
-        Self::from_inner_with_axis_classes(new_indices, conjugated, self.axis_classes.clone())
-            .expect("TensorDynLen::conj returned invalid tensor")
+        Self::from_inner_with_axis_classes(
+            new_indices,
+            conjugated,
+            self.storage.axis_classes().to_vec(),
+        )
+        .expect("TensorDynLen::conj returned invalid tensor")
     }
 }
 
@@ -2206,7 +2308,7 @@ impl TensorDynLen {
         Self::validate_indices(&indices);
         Self::validate_diag_payload_len(data.len(), &dims)?;
         let native = diag_native_tensor_from_col_major(&data, dims.len())?;
-        Self::from_native(indices, native)
+        Self::from_native_with_axis_classes(indices, native, Self::diag_axis_classes(dims.len()))
     }
 
     /// Create a diagonal tensor from diagonal payload data provided as
@@ -2446,7 +2548,7 @@ impl TensorDynLen {
     /// assert!(!tensor.is_complex());
     /// ```
     pub fn is_f64(&self) -> bool {
-        matches!(self.as_native().dtype(), DType::F64 | DType::F32)
+        self.storage.is_f64()
     }
 
     /// Check whether the tensor carries diagonal logical axis metadata.
@@ -2475,7 +2577,7 @@ impl TensorDynLen {
     /// assert!(diag.is_diag());
     /// ```
     pub fn is_diag(&self) -> bool {
-        Self::is_diag_axis_classes(&self.axis_classes)
+        self.storage.is_diag()
     }
 
     /// Check if the tensor has complex storage (C64).
@@ -2497,7 +2599,7 @@ impl TensorDynLen {
     /// assert!(complex_t.is_complex());
     /// ```
     pub fn is_complex(&self) -> bool {
-        matches!(self.as_native().dtype(), DType::C64 | DType::C32)
+        self.storage.is_complex()
     }
 }
 

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -65,8 +65,8 @@ pub use tagset::{Tag, TagSetError, TagSetLike};
 pub mod storage {
     //! Re-export of snapshot storage utilities.
     pub use tensor4all_tensorbackend::{
-        make_mut_storage, mindim, AnyScalar, Storage, StorageScalar, StructuredStorage,
-        SumFromStorage,
+        make_mut_storage, mindim, AnyScalar, Storage, StorageKind, StorageScalar,
+        StructuredStorage, SumFromStorage,
     };
 }
 pub mod tensor_index;
@@ -88,7 +88,9 @@ pub use defaults::tensordynlen::{
     compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, RandomScalar,
     TensorAccess, TensorDynLen,
 };
-pub use storage::{make_mut_storage, mindim, Storage, StructuredStorage, SumFromStorage};
+pub use storage::{
+    make_mut_storage, mindim, Storage, StorageKind, StructuredStorage, SumFromStorage,
+};
 pub use tensor4all_tensorbackend::TensorElement;
 pub use tensor4all_tensorbackend::{
     print_and_reset_native_einsum_profile, reset_native_einsum_profile,

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -30,7 +30,8 @@ where
     let j = Index::new_dyn(3);
     let tensor = TensorDynLen::from_diag(vec![i, j], data).unwrap();
     assert_eq!(tensor.dims(), vec![3, 3]);
-    assert!(!tensor.is_diag());
+    assert!(tensor.is_diag());
+    assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
 }
 
 #[test]

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -164,6 +164,49 @@ fn tensor_from_structured_storage_rejects_index_dim_mismatch() {
 }
 
 #[test]
+fn same_layout_axpby_preserves_structured_metadata() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let make = |offset| {
+        TensorDynLen::from_storage(
+            vec![i.clone(), j.clone(), k.clone()],
+            Arc::new(
+                Storage::new_structured(
+                    vec![
+                        1.0 + offset,
+                        2.0 + offset,
+                        3.0 + offset,
+                        4.0 + offset,
+                        5.0 + offset,
+                        6.0 + offset,
+                    ],
+                    vec![2, 3],
+                    vec![1, 2],
+                    vec![0, 1, 0],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let a = make(0.0);
+    let b = make(10.0);
+    let result = a
+        .axpby(AnyScalar::new_real(2.0), &b, AnyScalar::new_real(-1.0))
+        .unwrap();
+    let storage = result.storage();
+
+    assert_eq!(storage.storage_kind(), StorageKind::Structured);
+    assert_eq!(storage.axis_classes(), &[0, 1, 0]);
+    assert_eq!(
+        storage.payload_f64_col_major_vec().unwrap(),
+        vec![-9.0, -8.0, -7.0, -6.0, -5.0, -4.0]
+    );
+}
+
+#[test]
 fn test_tensor_shared_storage() {
     let indices = vec![Index::new_dyn(2)];
     let tensor1 = make_tensor_f64(indices.clone(), vec![1.0, 2.0]);

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -2,7 +2,7 @@ use num_complex::{Complex32, Complex64};
 use std::sync::Arc;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index::DynIndex;
-use tensor4all_core::{AnyScalar, Storage, TensorDynLen, TensorElement};
+use tensor4all_core::{AnyScalar, Storage, StorageKind, TensorDynLen, TensorElement};
 
 /// Helper to create DenseF64 storage with shape information
 fn make_dense_f64(data: Vec<f64>, dims: &[usize]) -> Storage {
@@ -113,6 +113,53 @@ fn test_tensor_dyn_len_creation() {
     assert_eq!(dims.len(), 2);
     assert_eq!(dims[0], 2);
     assert_eq!(dims[1], 3);
+}
+
+#[test]
+fn tensor_from_structured_storage_preserves_compact_payload() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let storage = Arc::new(
+        Storage::new_structured(
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 1, 0],
+        )
+        .unwrap(),
+    );
+
+    let tensor = TensorDynLen::from_storage(vec![i, j, k], Arc::clone(&storage)).unwrap();
+    let snapshot = tensor.storage();
+
+    assert_eq!(snapshot.storage_kind(), StorageKind::Structured);
+    assert_eq!(snapshot.payload_dims(), &[2, 3]);
+    assert_eq!(snapshot.payload_strides(), &[1, 2]);
+    assert_eq!(snapshot.axis_classes(), &[0, 1, 0]);
+    assert_eq!(
+        snapshot.payload_f64_col_major_vec().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
+    assert_eq!(tensor.dims(), vec![2, 3, 2]);
+}
+
+#[test]
+fn tensor_from_structured_storage_rejects_index_dim_mismatch() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(4);
+    let storage = Arc::new(
+        Storage::new_structured(
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 1],
+        )
+        .unwrap(),
+    );
+
+    let err = TensorDynLen::from_storage(vec![i, j], storage).unwrap_err();
+    assert!(err.to_string().contains("storage logical dims"));
 }
 
 #[test]

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -138,6 +138,21 @@ fn test_contract_no_common_indices_preserves_left_then_right_index_order_and_val
 }
 
 #[test]
+fn structured_tensor_contract_materializes_to_correct_dense_result() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let k = Index::new_dyn(2);
+    let diag = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![2.0_f64, 3.0]).unwrap();
+    assert!(diag.is_diag());
+    let dense = TensorDynLen::from_dense(vec![j, k.clone()], vec![5.0, 7.0, 11.0, 13.0]).unwrap();
+
+    let result = diag.contract(&dense);
+
+    let expected = TensorDynLen::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
+    assert!((&result - &expected).maxabs() < 1e-12);
+}
+
+#[test]
 fn test_contract_three_indices() {
     // Create A[i, j, k] and B[j, k, l]
     // Contract along j and k: result should be C[i, l]

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -181,6 +181,47 @@ fn from_diag_storage_roundtrip_uses_payload_not_dense_logical_values() {
 }
 
 #[test]
+fn diag_permute_scale_conj_and_replaceind_preserve_payload_metadata() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(3);
+    let tensor = TensorDynLen::from_diag(
+        vec![i.clone(), j.clone(), k.clone()],
+        vec![1.0_f64, -2.0, 4.0],
+    )
+    .unwrap();
+
+    let permuted = tensor.permute(&[2, 0, 1]);
+    assert!(permuted.is_diag());
+    assert_eq!(permuted.storage().axis_classes(), &[0, 0, 0]);
+    assert_eq!(
+        permuted.storage().payload_f64_col_major_vec().unwrap(),
+        vec![1.0, -2.0, 4.0]
+    );
+
+    let scaled = permuted.scale(AnyScalar::new_real(2.0)).unwrap();
+    assert!(scaled.is_diag());
+    assert_eq!(
+        scaled.storage().payload_f64_col_major_vec().unwrap(),
+        vec![2.0, -4.0, 8.0]
+    );
+
+    let replaced = scaled.replaceind(&k, &Index::new_dyn(3));
+    assert!(replaced.is_diag());
+    assert_eq!(
+        replaced.storage().payload_f64_col_major_vec().unwrap(),
+        vec![2.0, -4.0, 8.0]
+    );
+
+    let conjugated = replaced.conj();
+    assert!(conjugated.is_diag());
+    assert_eq!(
+        conjugated.storage().payload_f64_col_major_vec().unwrap(),
+        vec![2.0, -4.0, 8.0]
+    );
+}
+
+#[test]
 fn test_diag_tensor_rank3() {
     // Test DiagTensor with rank 3
     let i = Index::new_dyn(2);

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -268,7 +268,8 @@ fn test_diag_tensor_complex() {
 
     let tensor = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![2, 2]);
-    assert!(!tensor.is_diag());
+    assert!(tensor.is_diag());
+    assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
     assert_eq!(
         tensor.to_vec::<Complex64>().unwrap(),
         vec![
@@ -301,7 +302,8 @@ fn test_diag_tensor_complex_axpby_preserves_diagonal_values() {
     let b = AnyScalar::new_complex(-0.5, 1.0);
     let result = tensor_a.axpby(a, &tensor_b, b).unwrap();
 
-    assert!(!result.is_diag());
+    assert!(result.is_diag());
+    assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
     let b_c = Complex64::new(-0.5, 1.0);
     let expected_diag: Vec<Complex64> = diag_a
         .iter()

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -1,7 +1,7 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::TensorLike;
-use tensor4all_core::{diag_tensor_dyn_len, AnyScalar, TensorDynLen};
+use tensor4all_core::{diag_tensor_dyn_len, AnyScalar, StorageKind, TensorDynLen};
 
 #[test]
 fn test_diag_tensor_creation() {
@@ -11,7 +11,8 @@ fn test_diag_tensor_creation() {
 
     let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data.clone());
     assert_eq!(tensor.dims(), vec![3, 3]);
-    assert!(!tensor.is_diag());
+    assert!(tensor.is_diag());
+    assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
     assert_eq!(
         tensor.to_vec::<f64>().unwrap(),
         vec![
@@ -52,7 +53,8 @@ fn test_diag_tensor_scale_preserves_diagonal_values() {
 
     let scaled = tensor.scale(AnyScalar::new_real(-0.5)).unwrap();
 
-    assert!(!scaled.is_diag());
+    assert!(scaled.is_diag());
+    assert_eq!(scaled.storage().storage_kind(), StorageKind::Diagonal);
     let expected = diag_tensor_dyn_len(vec![i, j], vec![-0.5, 1.0, -2.0]);
     assert!(scaled.isapprox(&expected, 1e-12, 0.0));
 }
@@ -159,6 +161,26 @@ fn test_diag_tensor_convert_to_dense() {
 }
 
 #[test]
+fn from_diag_storage_roundtrip_uses_payload_not_dense_logical_values() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let tensor = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let storage = tensor.storage();
+
+    assert_eq!(storage.storage_kind(), StorageKind::Diagonal);
+    assert_eq!(storage.payload_dims(), &[3]);
+    assert_eq!(storage.axis_classes(), &[0, 0]);
+    assert_eq!(
+        storage.payload_f64_col_major_vec().unwrap(),
+        vec![1.0, 2.0, 3.0]
+    );
+    assert_eq!(
+        tensor.to_vec::<f64>().unwrap(),
+        vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]
+    );
+}
+
+#[test]
 fn test_diag_tensor_rank3() {
     // Test DiagTensor with rank 3
     let i = Index::new_dyn(2);
@@ -168,7 +190,8 @@ fn test_diag_tensor_rank3() {
 
     let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone());
     assert_eq!(tensor.dims(), vec![2, 2, 2]);
-    assert!(!tensor.is_diag());
+    assert!(tensor.is_diag());
+    assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
 
     // Sum should work
     let sum: AnyScalar = tensor.sum();

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -27,8 +27,8 @@ pub use any_scalar::AnyScalar;
 pub use backend::{qr_backend, svd_backend, BackendLinalgScalar, SvdResult};
 pub use context::{default_eager_ctx, with_default_backend};
 pub use storage::{
-    contract_storage, make_mut_storage, mindim, Storage, StorageScalar, StructuredStorage,
-    SumFromStorage,
+    contract_storage, make_mut_storage, mindim, Storage, StorageKind, StorageScalar,
+    StructuredStorage, SumFromStorage,
 };
 pub use tenferro_bridge::{
     axpby_native_tensor, axpby_storage_native, conj_native_tensor, contract_native_tensor,

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -696,6 +696,32 @@ impl<T: Copy + Default> StructuredStorage<T> {
 #[derive(Debug, Clone)]
 pub struct Storage(pub(crate) StorageRepr);
 
+/// Classifies the compact layout used by [`Storage`].
+///
+/// Use this to distinguish dense logical payloads from diagonal/copy payloads
+/// and general structured payloads without exposing the internal storage enum.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{Storage, StorageKind};
+///
+/// let dense = Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap();
+/// assert_eq!(dense.storage_kind(), StorageKind::Dense);
+///
+/// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+/// assert_eq!(diag.storage_kind(), StorageKind::Diagonal);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageKind {
+    /// Logical dense payload layout.
+    Dense,
+    /// Diagonal or copy-tensor payload layout.
+    Diagonal,
+    /// General structured payload layout with repeated axis classes.
+    Structured,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum StorageRepr {
     /// Storage with f64 elements.
@@ -993,6 +1019,204 @@ impl Storage {
         match &self.0 {
             StorageRepr::F64(value) => value.is_diag(),
             StorageRepr::C64(value) => value.is_diag(),
+        }
+    }
+
+    /// Returns the compact layout class for this storage.
+    ///
+    /// The return value is metadata-only and never materializes dense logical
+    /// values. Use it to choose whether to read compact payload metadata or
+    /// dense logical values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{Storage, StorageKind};
+    ///
+    /// let structured = Storage::new_structured(
+    ///     vec![1.0_f64, 2.0],
+    ///     vec![2],
+    ///     vec![1],
+    ///     vec![0, 0],
+    /// ).unwrap();
+    /// assert_eq!(structured.storage_kind(), StorageKind::Diagonal);
+    /// ```
+    pub fn storage_kind(&self) -> StorageKind {
+        if self.is_dense() {
+            StorageKind::Dense
+        } else if self.is_diag() {
+            StorageKind::Diagonal
+        } else {
+            StorageKind::Structured
+        }
+    }
+
+    /// Returns the logical tensor dimensions represented by this storage.
+    ///
+    /// The dimensions are derived from payload dimensions and `axis_classes`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+    /// assert_eq!(diag.logical_dims(), vec![2, 2]);
+    /// ```
+    pub fn logical_dims(&self) -> Vec<usize> {
+        match &self.0 {
+            StorageRepr::F64(value) => value.logical_dims(),
+            StorageRepr::C64(value) => value.logical_dims(),
+        }
+    }
+
+    /// Returns the logical tensor rank represented by this storage.
+    ///
+    /// This equals `axis_classes().len()`, not necessarily `payload_dims().len()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 3).unwrap();
+    /// assert_eq!(diag.logical_rank(), 3);
+    /// assert_eq!(diag.payload_dims(), &[2]);
+    /// ```
+    pub fn logical_rank(&self) -> usize {
+        match &self.0 {
+            StorageRepr::F64(value) => value.logical_rank(),
+            StorageRepr::C64(value) => value.logical_rank(),
+        }
+    }
+
+    /// Returns the compact payload dimensions.
+    ///
+    /// For dense storage these match logical dimensions. For diagonal storage
+    /// this is rank-1 even when the logical tensor has multiple axes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+    /// assert_eq!(diag.payload_dims(), &[2]);
+    /// ```
+    pub fn payload_dims(&self) -> &[usize] {
+        match &self.0 {
+            StorageRepr::F64(value) => value.payload_dims(),
+            StorageRepr::C64(value) => value.payload_dims(),
+        }
+    }
+
+    /// Returns the compact payload strides.
+    ///
+    /// Strides are measured in stored scalar elements and describe the compact
+    /// payload buffer, not the logical dense tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let dense = Storage::from_dense_col_major(vec![0.0_f64; 6], &[2, 3]).unwrap();
+    /// assert_eq!(dense.payload_strides(), &[1, 2]);
+    /// ```
+    pub fn payload_strides(&self) -> &[isize] {
+        match &self.0 {
+            StorageRepr::F64(value) => value.strides(),
+            StorageRepr::C64(value) => value.strides(),
+        }
+    }
+
+    /// Returns logical-axis equivalence classes for this storage.
+    ///
+    /// Repeated class labels mean the corresponding logical axes share one
+    /// payload axis. Dense storage has `[0, 1, ...]`; diagonal storage has
+    /// repeated zero labels.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+    /// assert_eq!(diag.axis_classes(), &[0, 0]);
+    /// ```
+    pub fn axis_classes(&self) -> &[usize] {
+        match &self.0 {
+            StorageRepr::F64(value) => value.axis_classes(),
+            StorageRepr::C64(value) => value.axis_classes(),
+        }
+    }
+
+    /// Returns the number of stored compact payload elements.
+    ///
+    /// For dense storage this equals the logical dense length. For diagonal and
+    /// structured storage this is the compact payload length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+    /// assert_eq!(diag.payload_len(), 2);
+    /// ```
+    pub fn payload_len(&self) -> usize {
+        self.len()
+    }
+
+    /// Copies the compact `f64` payload in column-major payload order.
+    ///
+    /// This does not materialize logical dense values. For diagonal storage the
+    /// returned vector contains only diagonal payload values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the storage scalar type is not `f64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+    /// assert_eq!(diag.payload_f64_col_major_vec().unwrap(), vec![1.0, 2.0]);
+    /// ```
+    pub fn payload_f64_col_major_vec(&self) -> Result<Vec<f64>, String> {
+        match &self.0 {
+            StorageRepr::F64(value) => Ok(value.payload_col_major_vec()),
+            StorageRepr::C64(_) => Err("expected f64 storage when copying f64 payload".to_string()),
+        }
+    }
+
+    /// Copies the compact `Complex64` payload in column-major payload order.
+    ///
+    /// This does not materialize logical dense values. Complex payloads are
+    /// returned as native Rust `Complex64` values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the storage scalar type is not `Complex64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_complex::Complex64;
+    /// use tensor4all_tensorbackend::Storage;
+    ///
+    /// let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)];
+    /// let diag = Storage::from_diag_col_major(data.clone(), 2).unwrap();
+    /// assert_eq!(diag.payload_c64_col_major_vec().unwrap(), data);
+    /// ```
+    pub fn payload_c64_col_major_vec(&self) -> Result<Vec<Complex64>, String> {
+        match &self.0 {
+            StorageRepr::C64(value) => Ok(value.payload_col_major_vec()),
+            StorageRepr::F64(_) => {
+                Err("expected Complex64 storage when copying c64 payload".to_string())
+            }
         }
     }
 

--- a/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
@@ -69,6 +69,54 @@ fn test_storage_is_diag() {
 }
 
 #[test]
+fn storage_kind_and_metadata_accessors_cover_dense_diag_and_structured() {
+    let dense = Storage::from_dense_col_major(vec![1.0_f64, 2.0, 3.0, 4.0], &[2, 2]).unwrap();
+    assert_eq!(dense.storage_kind(), StorageKind::Dense);
+    assert_eq!(dense.logical_dims(), vec![2, 2]);
+    assert_eq!(dense.logical_rank(), 2);
+    assert_eq!(dense.payload_dims(), &[2, 2]);
+    assert_eq!(dense.payload_strides(), &[1, 2]);
+    assert_eq!(dense.axis_classes(), &[0, 1]);
+    assert_eq!(dense.payload_len(), 4);
+    assert_eq!(
+        dense.payload_f64_col_major_vec().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0]
+    );
+
+    let diag = Storage::from_diag_col_major(vec![10.0_f64, 20.0], 2).unwrap();
+    assert_eq!(diag.storage_kind(), StorageKind::Diagonal);
+    assert_eq!(diag.logical_dims(), vec![2, 2]);
+    assert_eq!(diag.payload_dims(), &[2]);
+    assert_eq!(diag.axis_classes(), &[0, 0]);
+    assert_eq!(diag.payload_f64_col_major_vec().unwrap(), vec![10.0, 20.0]);
+
+    let structured = Storage::new_structured(
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        vec![2, 3],
+        vec![1, 2],
+        vec![0, 1, 0],
+    )
+    .unwrap();
+    assert_eq!(structured.storage_kind(), StorageKind::Structured);
+    assert_eq!(structured.logical_dims(), vec![2, 3, 2]);
+    assert_eq!(structured.payload_dims(), &[2, 3]);
+    assert_eq!(structured.payload_strides(), &[1, 2]);
+    assert_eq!(structured.axis_classes(), &[0, 1, 0]);
+}
+
+#[test]
+fn storage_payload_c64_readback_is_interpreted_as_payload_not_logical_dense() {
+    let data = vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)];
+    let storage = Storage::from_diag_col_major(data.clone(), 2).unwrap();
+    assert_eq!(storage.storage_kind(), StorageKind::Diagonal);
+    assert_eq!(storage.payload_c64_col_major_vec().unwrap(), data);
+    assert!(storage
+        .payload_f64_col_major_vec()
+        .unwrap_err()
+        .contains("expected f64"));
+}
+
+#[test]
 fn structured_storage_rejects_noncanonical_axis_classes() {
     let err = StructuredStorage::<f64>::new(
         vec![1.0, 2.0, 3.0, 4.0],

--- a/docs/book-tests/src/lib.rs
+++ b/docs/book-tests/src/lib.rs
@@ -11,6 +11,7 @@
 //! The repository root `README.md` is included here as well so its short
 //! runnable examples stay covered by CI.
 
+#[cfg(test)]
 const BOOK_INTRODUCTION: &str = include_str!("../../book/src/README.md");
 
 #[doc = include_str!("../../../README.md")]

--- a/docs/book-tests/src/lib.rs
+++ b/docs/book-tests/src/lib.rs
@@ -11,6 +11,8 @@
 //! The repository root `README.md` is included here as well so its short
 //! runnable examples stay covered by CI.
 
+const BOOK_INTRODUCTION: &str = include_str!("../../book/src/README.md");
+
 #[doc = include_str!("../../../README.md")]
 mod root_readme {}
 
@@ -40,3 +42,20 @@ mod quantics {}
 
 #[doc = include_str!("../../book/src/guides/qft.md")]
 mod qft {}
+
+#[cfg(test)]
+mod tests {
+    use super::BOOK_INTRODUCTION;
+
+    #[test]
+    fn introduction_uses_repo_relative_rustdoc_link() {
+        assert!(
+            BOOK_INTRODUCTION.contains("[rustdoc API reference](rustdoc/tensor4all_core/)"),
+            "top-level mdBook page must link to rustdoc within the published /tensor4all-rs/ site"
+        );
+        assert!(
+            !BOOK_INTRODUCTION.contains("[rustdoc API reference](../rustdoc/tensor4all_core/)"),
+            "top-level mdBook page must not climb above the published site root"
+        );
+    }
+}

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -23,7 +23,7 @@ examples live in this guide and the guide examples are exercised in CI.
 | Install and run my first example | [Getting Started](getting-started.md) |
 | Understand the crate structure | [Architecture & Crate Guide](architecture.md) |
 | Come from ITensors.jl and map types | [Conventions](conventions.md) |
-| Browse the full API reference | [rustdoc API reference](../rustdoc/tensor4all_core/) |
+| Browse the full API reference | [rustdoc API reference](rustdoc/tensor4all_core/) |
 | Use tensor4all-rs from Julia | [Julia Bindings](julia-bindings.md) |
 
 ---

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -46,9 +46,10 @@ assert_eq!(bra.plev(), 1);
 
 ## Tensor (TensorDynLen)
 
-`TensorDynLen` is a dynamic-rank dense tensor parameterized by a list of `Index`
-values. Each index uniquely identifies an axis; there is no fixed axis ordering in
-the abstract sense — operations match axes by index identity.
+`TensorDynLen` is a dynamic-rank tensor parameterized by a list of `Index`
+values and backed by compact storage that may be dense, diagonal, or explicitly
+structured. Each index uniquely identifies an axis; there is no fixed axis
+ordering in the abstract sense — operations match axes by index identity.
 
 ### Creating tensors
 

--- a/docs/plans/2026-04-22-issue-434-structured-tensor-design.md
+++ b/docs/plans/2026-04-22-issue-434-structured-tensor-design.md
@@ -1,0 +1,504 @@
+# Structured Tensor Storage Design (Issue #434)
+
+## Goal
+
+Make structured tensor storage a first-class `TensorDynLen` representation, then
+expose that representation through the C API for Tensor4all.jl.
+
+Issue [#434](https://github.com/tensor4all/tensor4all-rs/issues/434) asks for a
+C API path that can construct and inspect tensors from compact payload metadata:
+payload data, payload dimensions, payload strides, and logical-axis equivalence
+classes (`axis_classes`). The design should preserve compact diagonal and copy
+tensors instead of expanding them to dense storage during construction.
+
+## Context
+
+The Rust storage layer already has the right low-level representation:
+
+- `tensor4all_tensorbackend::StructuredStorage<T>` stores compact payload data,
+  `payload_dims`, `strides`, and `axis_classes`.
+- `Storage::new_structured(...)` constructs explicit structured storage for
+  `f64` and `Complex64`.
+- `Storage::from_diag_col_major(...)` constructs diagonal storage using a rank-1
+  payload and repeated axis classes.
+- `TensorDynLen::is_diag()` and the multi-tensor contraction path already use
+  diagonal metadata to treat diagonal axes as shared hyperedges.
+
+The current mismatch is in `TensorDynLen`. It stores a dense/native eager tensor
+as the primary payload and keeps only `axis_classes` as side metadata:
+
+```rust
+pub struct TensorDynLen {
+    pub indices: Vec<DynIndex>,
+    pub(crate) inner: Arc<EagerTensor<CpuBackend>>,
+    pub(crate) axis_classes: Vec<usize>,
+}
+```
+
+`TensorDynLen::from_storage(...)` therefore calls through
+`storage_to_native_tensor(...)`, which materializes structured storage into a
+dense tenferro tensor. This preserves mathematical values, but it does not make
+structured storage the tensor's primary representation.
+
+The earlier `tenferro-rs` implementation had the desired model:
+
+```rust
+pub struct StructuredTensor<T> {
+    payload: Tensor<T>,
+    logical_dims: Vec<usize>,
+    axis_classes: Vec<usize>,
+}
+```
+
+and its dynamic tensor enum stored `StructuredTensor<T>` variants directly. The
+same design principle should be applied here using the existing
+`StructuredStorage<T>` / `Storage` type instead of reintroducing a second
+structured tensor abstraction.
+
+## Non-Goals
+
+- Do not preserve the current `TensorDynLen` dense-native primary payload model.
+  The repository is in early development, so this can be a hard cut.
+- Do not make all tensor operations structured-native in one change. Operations
+  that cannot yet operate on compact storage may materialize explicitly and
+  return dense storage.
+- Do not add scalar-specific Rust APIs beyond the C API boundary. Rust library
+  code should remain generic where possible.
+- Do not redesign tenferro-rs in this issue. Tensor4all-rs can use its own
+  `Storage` as the structured source of truth and call tenferro only when dense
+  execution is needed.
+
+## Data Model
+
+Change `TensorDynLen` so structured storage is the canonical payload:
+
+```rust
+pub struct TensorDynLen {
+    indices: Vec<DynIndex>,
+    storage: Arc<Storage>,
+    eager_cache: OnceLock<Arc<EagerTensor<CpuBackend>>>,
+}
+```
+
+`storage` is the source of truth. It stores dense, diagonal, and general
+structured layouts uniformly through `StructuredStorage<T>`.
+
+`eager_cache` is optional and derived. It is populated only when an operation
+requires tenferro's native/eager representation, such as SVD, QR, AD-enabled
+einsum, or dense readback. The cache must never be required to answer structured
+metadata queries.
+
+If `OnceLock` is awkward because of clone semantics or existing `Arc`
+expectations, use:
+
+```rust
+pub struct TensorDynLen {
+    indices: Vec<DynIndex>,
+    storage: Arc<Storage>,
+    eager_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
+}
+```
+
+The important invariant is that `storage` is authoritative and `eager_cache` is
+discardable.
+
+## Storage Accessors
+
+Expose structured metadata through safe public `Storage` accessors rather than
+making the internal `StorageRepr` public.
+
+Add:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageKind {
+    Dense,
+    Structured,
+    Diagonal,
+}
+
+impl Storage {
+    pub fn storage_kind(&self) -> StorageKind;
+    pub fn logical_dims(&self) -> Vec<usize>;
+    pub fn logical_rank(&self) -> usize;
+    pub fn payload_dims(&self) -> &[usize];
+    pub fn payload_strides(&self) -> &[isize];
+    pub fn axis_classes(&self) -> &[usize];
+    pub fn payload_len(&self) -> usize;
+    pub fn payload_f64_col_major_vec(&self) -> Result<Vec<f64>, String>;
+    pub fn payload_c64_col_major_vec(&self) -> Result<Vec<Complex64>, String>;
+}
+```
+
+`payload_*_col_major_vec` returns the compact payload in payload column-major
+order. It does not materialize logical dense tensor values.
+
+Keep existing dense logical readback methods:
+
+- `to_dense_f64_col_major_vec(logical_dims)`
+- `to_dense_c64_col_major_vec(logical_dims)`
+
+Those methods are explicit materialization paths.
+
+## Validation Rules
+
+Structured validation should be centralized in the storage layer and reused by
+`TensorDynLen` and the C API.
+
+Required invariants:
+
+- `axis_classes.len() == logical_rank`.
+- `axis_classes` is canonical first-appearance form.
+- `payload_dims.len() == number_of_axis_classes`.
+- `strides.len() == payload_dims.len()`.
+- Every logical axis maps to a valid payload class.
+- Every logical axis in the same class has the same dimension.
+- `payload_dims[class_id] == logical_dim(axis)` for all axes in that class.
+- Payload length matches the storage length required by `payload_dims` and
+  `strides`.
+- For diagonal convenience constructors, logical rank should be at least 2 for
+  non-scalar diagonal tensors, and all logical dimensions must be equal.
+
+`StructuredStorage::new(...)` already validates most payload metadata. Add a
+`Storage` or `TensorDynLen` helper for validating logical index dimensions
+against the storage's `axis_classes`.
+
+## Tensor Construction
+
+### Dense
+
+`TensorDynLen::from_dense(indices, data)` should construct dense `Storage` and
+then call `from_storage`:
+
+```rust
+let dims = expected_dims_from_indices(&indices);
+let storage = Storage::from_dense_col_major(data, &dims)?;
+TensorDynLen::from_storage(indices, Arc::new(storage))
+```
+
+### Diagonal
+
+`TensorDynLen::from_diag(indices, data)` should stop using
+`diag_native_tensor_from_col_major(...)`. It should construct compact diagonal
+storage directly:
+
+```rust
+validate_diag_payload_len(data.len(), &dims)?;
+let storage = Storage::from_diag_col_major(data, indices.len())?;
+TensorDynLen::from_storage(indices, Arc::new(storage))
+```
+
+`TensorDynLen::from_diag_any(...)` and `copy_tensor(...)` should use this same
+path.
+
+### General Structured
+
+Add a Rust constructor for explicit structured storage:
+
+```rust
+pub fn from_structured_storage(
+    indices: Vec<DynIndex>,
+    storage: Arc<Storage>,
+) -> Result<Self>
+```
+
+This may initially be an alias for `from_storage`, but its name makes the
+intended public surface clear for callers that already have compact payload
+metadata.
+
+`from_storage` must:
+
+- validate unique indices,
+- validate index dimensions against `storage.logical_dims()`,
+- preserve `storage.axis_classes()`,
+- not call `storage_to_native_tensor(...)`.
+
+## Materialization
+
+Add an explicit private materialization method:
+
+```rust
+fn materialized_eager(&self) -> Result<Arc<EagerTensor<CpuBackend>>>;
+fn materialized_native(&self) -> Result<&NativeTensor>;
+```
+
+The method builds a dense native tensor from `self.storage` only when needed.
+All existing code paths that currently call `self.as_native()` should be
+classified:
+
+- metadata-only paths should use `self.storage`;
+- structured-preserving paths should operate on payload storage;
+- dense execution paths should call `materialized_eager()` explicitly.
+
+`as_native()` should either become private and materializing, or be renamed to
+make the densification obvious. Avoid a public API that silently hides the
+representation change.
+
+## Operation Policy
+
+### Must Preserve Structured Storage
+
+These operations must not materialize or densify:
+
+- `dims()`
+- `indices()`
+- `is_diag()`
+- `is_complex()`
+- `is_f64()`
+- `storage()`
+- `to_storage()`
+- C API metadata and compact payload readback
+
+### Should Preserve Structured Storage
+
+These operations can be implemented directly on compact payloads:
+
+- `permute(...)`
+- `permute_indices(...)`
+- `replaceind(...)`
+- `replaceinds(...)`
+- `conj()`
+- `scale(...)`
+- same-layout `add(...)`, `try_sub(...)`, and `axpby(...)`
+
+If two tensors have identical `axis_classes`, payload dimensions, payload
+strides, scalar type, and logical dimensions, elementwise operations can operate
+on payload values and keep the layout. If layouts differ, the initial
+implementation may materialize both operands and return dense storage.
+
+### May Materialize Explicitly
+
+These operations may materialize to dense/native storage in the first
+implementation:
+
+- `to_vec::<T>()`
+- `as_slice_f64()`
+- `as_slice_c64()`
+- `sum()` if no compact reduction helper exists yet
+- `maxabs()` if no compact reduction helper exists yet
+- SVD / QR / factorize
+- general dense tensor contraction cases
+- AD-enabled eager operations
+
+When an operation materializes, the returned tensor should have dense
+`Storage`, unless a structured-preserving result is deliberately reconstructed.
+
+### Contraction
+
+The existing `contract_multi_impl` already builds diagonal-aware hyperedges
+through `build_diag_union(...)`. Preserve that behavior, but avoid materializing
+diagonal tensors as full logical dense operands.
+
+For pure diagonal/copy tensors:
+
+- pass the compact rank-1 payload to the einsum backend,
+- map all repeated logical axes to the same internal ID,
+- keep the output dense unless a structured output layout is easy to prove.
+
+For general repeated `axis_classes` such as `[0, 0, 1]`, extend the same idea
+from pure diagonal groups to multiple equivalence classes:
+
+- each tensor operand should expose payload rank equal to the number of classes;
+- logical axis IDs that share a class should map to the same operand axis ID;
+- output indices remain logical indices selected from non-contracted IDs.
+
+This makes copy tensors and partial-copy tensors first-class rather than a
+special `is_diag()` only case.
+
+## C API Design
+
+Add a C-visible storage-kind enum:
+
+```rust
+#[repr(C)]
+pub enum t4a_tensor_storage_kind {
+    T4A_TENSOR_STORAGE_DENSE = 0,
+    T4A_TENSOR_STORAGE_STRUCTURED = 1,
+    T4A_TENSOR_STORAGE_DIAGONAL = 2,
+}
+```
+
+Add constructors:
+
+```c
+t4a_tensor_new_structured_f64(
+    size_t rank,
+    const t4a_index *const *index_ptrs,
+    const double *payload,
+    size_t payload_len,
+    const size_t *payload_dims,
+    size_t payload_rank,
+    const ptrdiff_t *strides,
+    size_t strides_len,
+    const size_t *axis_classes,
+    size_t axis_classes_len,
+    t4a_tensor **out);
+
+t4a_tensor_new_structured_c64(... interleaved payload ...);
+
+t4a_tensor_new_diag_f64(...);
+t4a_tensor_new_diag_c64(...);
+```
+
+Use `isize` on the Rust side and the corresponding generated C type from
+`cbindgen` for strides. If `ptrdiff_t` generation is not stable with cbindgen,
+use `intptr_t` explicitly in the Rust signature type and document it.
+
+Add metadata/readback functions:
+
+```c
+t4a_tensor_storage_kind(...)
+t4a_tensor_payload_rank(...)
+t4a_tensor_payload_dims(...)
+t4a_tensor_payload_strides(...)
+t4a_tensor_axis_classes(...)
+t4a_tensor_payload_len(...)
+t4a_tensor_copy_payload_f64(...)
+t4a_tensor_copy_payload_c64(...)
+```
+
+Existing dense readback functions keep their current behavior:
+
+- `t4a_tensor_copy_dense_f64(...)`
+- `t4a_tensor_copy_dense_c64(...)`
+
+Those functions explicitly return logical dense values and may materialize.
+
+## Error Handling
+
+All new C API functions must use `run_catching` / `run_status` patterns that
+preserve error details through `t4a_last_error_message`.
+
+Do not introduce new patterns that discard error details, such as:
+
+```rust
+Err(_) => T4A_INTERNAL_ERROR
+```
+
+Validation errors should return `T4A_INVALID_ARGUMENT` with messages that name
+the inconsistent field:
+
+- `payload_len mismatch`
+- `payload rank ... does not match axis_classes`
+- `axis class ... has inconsistent logical dimensions`
+- `payload dim mismatch for class ...`
+- `data pointer is null`
+- `index_ptrs[i] is null`
+
+## Testing Strategy
+
+Use TDD and keep each behavior small.
+
+### Core Storage Tests
+
+- `Storage::storage_kind()` distinguishes dense, structured, and diagonal.
+- `Storage` accessors return payload metadata without materializing dense values.
+- `payload_f64_col_major_vec()` and `payload_c64_col_major_vec()` reject wrong
+  dtypes with clear errors.
+- Structured validation rejects non-canonical `axis_classes`, payload-rank
+  mismatch, inconsistent class dimensions, stride-rank mismatch, and payload
+  length mismatch.
+
+### TensorDynLen Tests
+
+- `TensorDynLen::from_diag(...)` returns `is_diag() == true`.
+- `TensorDynLen::from_diag(...).storage().payload_len() == diagonal_len`.
+- `TensorDynLen::from_storage(...)` preserves general `axis_classes` such as
+  `[0, 0, 1]`.
+- `to_storage()` returns the same structured metadata and payload length without
+  dense expansion.
+- `to_vec::<f64>()` and `to_vec::<Complex64>()` still return correct logical
+  dense column-major values.
+- `permute(...)` preserves structured layout where possible.
+- `scale(...)` and `conj()` preserve compact payload layout.
+- same-layout `add/sub/axpby` preserve compact payload layout.
+- layout-mismatched elementwise operations materialize and return dense storage
+  if structured preservation is not implemented yet.
+
+### Contraction Tests
+
+- Contracting a C API-created diagonal tensor uses compact diagonal metadata and
+  matches the dense result.
+- Partial copy tensor with `axis_classes = [0, 0, 1]` contracts correctly
+  against dense tensors.
+- Mixed diagonal and dense contractions match dense reference tensors using
+  whole-tensor dense comparison, not element-by-element recontraction.
+
+### C API Tests
+
+- `t4a_tensor_new_diag_f64` and `t4a_tensor_new_diag_c64` create tensors with
+  diagonal storage kind and compact payload length.
+- `t4a_tensor_new_structured_f64` and `t4a_tensor_new_structured_c64` round-trip
+  payload dimensions, strides, axis classes, payload length, dtype, and compact
+  payload.
+- Metadata query functions support query-then-fill buffer conventions and return
+  `T4A_BUFFER_TOO_SMALL` when buffers are short.
+- Dense readback from structured tensors returns correct logical dense values.
+- Validation failures preserve error messages through `t4a_last_error_message`.
+
+## Migration Plan
+
+1. Add `StorageKind` and public `Storage` structured metadata/payload accessors.
+2. Refactor `TensorDynLen` to store `Arc<Storage>` as the source of truth.
+3. Rewire constructors (`from_dense`, `from_diag`, `from_storage`,
+   `from_dense_any`, `from_diag_any`, `copy_tensor`) through storage.
+4. Add explicit dense/eager materialization helpers and update internal
+   `as_native()` call sites.
+5. Preserve structured layouts for metadata-only and simple payload operations.
+6. Update contraction to consume compact payloads for diagonal and general
+   repeated-axis-class operands.
+7. Add C API structured constructors and compact metadata/readback functions.
+8. Regenerate `crates/tensor4all-capi/include/tensor4all_capi.h`.
+9. Update `docs/CAPI_DESIGN.md` and any README or mdBook references that still
+   describe tensors as dense-only.
+
+## Risks
+
+### AD and Eager Cache Semantics
+
+Current gradient APIs rely on `EagerTensor`. A storage-first tensor can still
+materialize to eager for AD, but once AD tracking is enabled, mutations to
+storage and eager cache must not diverge. The conservative rule is:
+
+- plain tensors use `storage` as source of truth;
+- AD-enabled tensors materialize once and operations that require AD return
+  dense storage unless structured preservation is explicitly implemented.
+
+### Performance Regression for Dense Workloads
+
+Dense tensors will still be represented as structured storage with dense
+`axis_classes = [0, 1, ...]`. Dense operations should fast-path contiguous dense
+storage and populate the eager cache lazily to avoid repeated conversions.
+
+### Contracting General Axis Classes
+
+Pure diagonal tensors are already handled by `is_diag()`. General axis classes
+such as `[0, 0, 1]` require extending the internal ID mapping beyond the pure
+diagonal special case. This should be implemented after storage preservation is
+tested, not mixed into the first constructor refactor.
+
+## Open Questions
+
+- Should `TensorDynLen::as_native()` remain as a private materializing helper,
+  or should it be renamed to make dense materialization explicit?
+- Should `StorageKind::Structured` include dense non-contiguous payloads, or
+  should storage kind distinguish `DenseContiguous`, `DenseStrided`,
+  `Structured`, and `Diagonal`?
+- Should scalar/rank-0 tensors be represented as dense storage or as structured
+  storage with empty `axis_classes` and scalar payload? The current
+  `StructuredStorage::from_diag_col_major(..., 0)` behavior needs review before
+  making rank-0 C API guarantees.
+- Should C API strides accept negative values now? `StructuredStorage::new`
+  currently uses `isize` strides, but negative-stride semantics and required
+  storage length need explicit tests before advertising support.
+
+## Success Criteria
+
+- `TensorDynLen::from_diag(...)` preserves compact diagonal storage.
+- `TensorDynLen::from_storage(...)` preserves arbitrary canonical
+  `axis_classes`.
+- `TensorDynLen::to_storage()` does not densify structured tensors.
+- C API can construct and inspect structured tensors, including compact payload
+  readback, without dense materialization.
+- Existing dense constructors and dense readback continue to work.
+- Diagonal/copy tensor contraction remains correct and uses structured metadata.

--- a/docs/plans/2026-04-22-issue-434-structured-tensor-plan.md
+++ b/docs/plans/2026-04-22-issue-434-structured-tensor-plan.md
@@ -1,0 +1,1297 @@
+# Structured Tensor Storage Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make structured tensor payload metadata first-class in `TensorDynLen` and expose construction/readback through the C API for issue #434.
+
+**Architecture:** `Storage` remains the structured source of truth for dense, diagonal, and general structured payloads. `TensorDynLen` stores `Arc<Storage>` as its canonical payload and lazily materializes a tenferro `EagerTensor` only for operations that need native execution or AD tracking. The C API constructs tensors through the same storage path and adds compact payload metadata/readback functions alongside existing dense logical readback.
+
+**Tech Stack:** Rust workspace, `tensor4all-tensorbackend`, `tensor4all-core`, `tensor4all-capi`, tenferro eager tensors, `anyhow`, `num_complex::Complex64`, `cbindgen`, cargo release tests.
+
+---
+
+## Prerequisites
+
+- Read `README.md` and `docs/plans/2026-04-22-issue-434-structured-tensor-design.md`.
+- Regenerate API docs before source exploration if public API context is stale:
+
+```bash
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+- Keep source code and docs in English.
+- Do not add new C API `catch_unwind` / `Err(_) => T4A_INTERNAL_ERROR` patterns that discard error details. Use `run_catching`, `run_status`, `capi_error`, or existing `unwrap_catch` helpers.
+- Run tests in release mode.
+
+## Task 1: Expose Storage Metadata Accessors
+
+**Files:**
+- Modify: `crates/tensor4all-tensorbackend/src/storage.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/lib.rs`
+- Modify: `crates/tensor4all-core/src/lib.rs`
+- Test: `crates/tensor4all-tensorbackend/src/storage/tests/mod.rs`
+
+**Step 1: Write the failing storage metadata tests**
+
+Add these tests near the existing storage type inspection tests:
+
+```rust
+#[test]
+fn storage_kind_and_metadata_accessors_cover_dense_diag_and_structured() {
+    let dense = Storage::from_dense_col_major(vec![1.0_f64, 2.0, 3.0, 4.0], &[2, 2]).unwrap();
+    assert_eq!(dense.storage_kind(), StorageKind::Dense);
+    assert_eq!(dense.logical_dims(), vec![2, 2]);
+    assert_eq!(dense.logical_rank(), 2);
+    assert_eq!(dense.payload_dims(), &[2, 2]);
+    assert_eq!(dense.payload_strides(), &[1, 2]);
+    assert_eq!(dense.axis_classes(), &[0, 1]);
+    assert_eq!(dense.payload_len(), 4);
+    assert_eq!(dense.payload_f64_col_major_vec().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+
+    let diag = Storage::from_diag_col_major(vec![10.0_f64, 20.0], 2).unwrap();
+    assert_eq!(diag.storage_kind(), StorageKind::Diagonal);
+    assert_eq!(diag.logical_dims(), vec![2, 2]);
+    assert_eq!(diag.payload_dims(), &[2]);
+    assert_eq!(diag.axis_classes(), &[0, 0]);
+    assert_eq!(diag.payload_f64_col_major_vec().unwrap(), vec![10.0, 20.0]);
+
+    let structured = Storage::new_structured(
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        vec![2, 3],
+        vec![1, 2],
+        vec![0, 1, 0],
+    )
+    .unwrap();
+    assert_eq!(structured.storage_kind(), StorageKind::Structured);
+    assert_eq!(structured.logical_dims(), vec![2, 3, 2]);
+    assert_eq!(structured.payload_dims(), &[2, 3]);
+    assert_eq!(structured.payload_strides(), &[1, 2]);
+    assert_eq!(structured.axis_classes(), &[0, 1, 0]);
+}
+
+#[test]
+fn storage_payload_c64_readback_is_interpreted_as_payload_not_logical_dense() {
+    let data = vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)];
+    let storage = Storage::from_diag_col_major(data.clone(), 2).unwrap();
+    assert_eq!(storage.storage_kind(), StorageKind::Diagonal);
+    assert_eq!(storage.payload_c64_col_major_vec().unwrap(), data);
+    assert!(storage.payload_f64_col_major_vec().unwrap_err().contains("expected f64"));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend storage_kind_and_metadata_accessors_cover_dense_diag_and_structured
+cargo test --release -p tensor4all-tensorbackend storage_payload_c64_readback_is_interpreted_as_payload_not_logical_dense
+```
+
+Expected: FAIL because `StorageKind` and the new accessor methods do not exist.
+
+**Step 3: Add `StorageKind` and public accessors**
+
+In `crates/tensor4all-tensorbackend/src/storage.rs`, add this public enum near `Storage`:
+
+```rust
+/// Classifies the compact layout used by [`Storage`].
+///
+/// `Dense` means every logical axis has its own payload axis. `Diagonal` means
+/// all logical axes share one payload axis. `Structured` covers all remaining
+/// axis-equivalence layouts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageKind {
+    /// Logical dense payload layout.
+    Dense,
+    /// Diagonal or copy-tensor payload layout.
+    Diagonal,
+    /// General structured payload layout with repeated axis classes.
+    Structured,
+}
+```
+
+Then add methods in `impl Storage` after `is_diag` or before scalar-kind helpers:
+
+```rust
+pub fn storage_kind(&self) -> StorageKind {
+    if self.is_dense() {
+        StorageKind::Dense
+    } else if self.is_diag() {
+        StorageKind::Diagonal
+    } else {
+        StorageKind::Structured
+    }
+}
+
+pub fn logical_dims(&self) -> Vec<usize> {
+    match &self.0 {
+        StorageRepr::F64(value) => value.logical_dims(),
+        StorageRepr::C64(value) => value.logical_dims(),
+    }
+}
+
+pub fn logical_rank(&self) -> usize {
+    match &self.0 {
+        StorageRepr::F64(value) => value.logical_rank(),
+        StorageRepr::C64(value) => value.logical_rank(),
+    }
+}
+
+pub fn payload_dims(&self) -> &[usize] {
+    match &self.0 {
+        StorageRepr::F64(value) => value.payload_dims(),
+        StorageRepr::C64(value) => value.payload_dims(),
+    }
+}
+
+pub fn payload_strides(&self) -> &[isize] {
+    match &self.0 {
+        StorageRepr::F64(value) => value.strides(),
+        StorageRepr::C64(value) => value.strides(),
+    }
+}
+
+pub fn axis_classes(&self) -> &[usize] {
+    match &self.0 {
+        StorageRepr::F64(value) => value.axis_classes(),
+        StorageRepr::C64(value) => value.axis_classes(),
+    }
+}
+
+pub fn payload_len(&self) -> usize {
+    self.len()
+}
+
+pub fn payload_f64_col_major_vec(&self) -> Result<Vec<f64>, String> {
+    match &self.0 {
+        StorageRepr::F64(value) => Ok(value.payload_col_major_vec()),
+        StorageRepr::C64(_) => Err("expected f64 storage when copying f64 payload".to_string()),
+    }
+}
+
+pub fn payload_c64_col_major_vec(&self) -> Result<Vec<Complex64>, String> {
+    match &self.0 {
+        StorageRepr::C64(value) => Ok(value.payload_col_major_vec()),
+        StorageRepr::F64(_) => {
+            Err("expected Complex64 storage when copying c64 payload".to_string())
+        }
+    }
+}
+```
+
+Add rustdoc comments and runnable examples for every public item to satisfy `#![warn(missing_docs)]`.
+
+**Step 4: Re-export `StorageKind`**
+
+In `crates/tensor4all-tensorbackend/src/lib.rs`, include `StorageKind` in the storage export list.
+
+In `crates/tensor4all-core/src/lib.rs`, include `StorageKind` in both the `storage` module re-export and the top-level `pub use storage::{...}` line.
+
+**Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend storage_kind_and_metadata_accessors_cover_dense_diag_and_structured
+cargo test --release -p tensor4all-tensorbackend storage_payload_c64_readback_is_interpreted_as_payload_not_logical_dense
+cargo test --doc --release -p tensor4all-tensorbackend StorageKind
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add crates/tensor4all-tensorbackend/src/storage.rs crates/tensor4all-tensorbackend/src/lib.rs crates/tensor4all-core/src/lib.rs crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+git commit -m "feat(storage): expose structured metadata accessors"
+```
+
+## Task 2: Add TensorDynLen Storage-First Regression Tests
+
+**Files:**
+- Modify: `crates/tensor4all-core/tests/tensor_basic.rs`
+- Modify: `crates/tensor4all-core/tests/tensor_diag.rs`
+
+**Step 1: Write failing `TensorDynLen::from_storage` tests**
+
+In `crates/tensor4all-core/tests/tensor_basic.rs`, add:
+
+```rust
+#[test]
+fn tensor_from_structured_storage_preserves_compact_payload() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let storage = Arc::new(
+        Storage::new_structured(
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 1, 0],
+        )
+        .unwrap(),
+    );
+
+    let tensor = TensorDynLen::from_storage(vec![i, j, k], Arc::clone(&storage)).unwrap();
+    let snapshot = tensor.storage();
+
+    assert_eq!(snapshot.storage_kind(), tensor4all_core::StorageKind::Structured);
+    assert_eq!(snapshot.payload_dims(), &[2, 3]);
+    assert_eq!(snapshot.payload_strides(), &[1, 2]);
+    assert_eq!(snapshot.axis_classes(), &[0, 1, 0]);
+    assert_eq!(
+        snapshot.payload_f64_col_major_vec().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
+    assert_eq!(tensor.dims(), vec![2, 3, 2]);
+}
+
+#[test]
+fn tensor_from_structured_storage_rejects_index_dim_mismatch() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(4);
+    let storage = Arc::new(
+        Storage::new_structured(
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 1],
+        )
+        .unwrap(),
+    );
+
+    let err = TensorDynLen::from_storage(vec![i, j], storage).unwrap_err();
+    assert!(err.to_string().contains("storage logical dims"));
+}
+```
+
+**Step 2: Write failing diagonal preservation tests**
+
+Update existing diagonal tests in `crates/tensor4all-core/tests/tensor_diag.rs` that currently assert `!tensor.is_diag()`. The new expected behavior is compact diagonal preservation.
+
+Change:
+
+```rust
+assert!(!tensor.is_diag());
+```
+
+to:
+
+```rust
+assert!(tensor.is_diag());
+assert_eq!(tensor.storage().storage_kind(), tensor4all_core::StorageKind::Diagonal);
+```
+
+Do this for:
+- `test_diag_tensor_creation`
+- `test_diag_tensor_scale_preserves_diagonal_values`
+- `test_diag_tensor_contract_diag_diag_partial` only if the result remains diagonal after the implementation task; if the operation still materializes, keep value assertions and add a separate preservation test instead.
+- `test_diag_tensor_rank3`
+
+Add a focused test:
+
+```rust
+#[test]
+fn from_diag_storage_roundtrip_uses_payload_not_dense_logical_values() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let tensor = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let storage = tensor.storage();
+
+    assert_eq!(storage.storage_kind(), tensor4all_core::StorageKind::Diagonal);
+    assert_eq!(storage.payload_dims(), &[3]);
+    assert_eq!(storage.axis_classes(), &[0, 0]);
+    assert_eq!(storage.payload_f64_col_major_vec().unwrap(), vec![1.0, 2.0, 3.0]);
+    assert_eq!(
+        tensor.to_vec::<f64>().unwrap(),
+        vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]
+    );
+}
+```
+
+**Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_basic tensor_from_structured_storage_preserves_compact_payload
+cargo test --release -p tensor4all-core --test tensor_basic tensor_from_structured_storage_rejects_index_dim_mismatch
+cargo test --release -p tensor4all-core --test tensor_diag from_diag_storage_roundtrip_uses_payload_not_dense_logical_values
+```
+
+Expected: FAIL because `TensorDynLen::from_storage` densifies and `from_diag` builds native dense storage.
+
+**Step 4: Commit failing tests**
+
+```bash
+git add crates/tensor4all-core/tests/tensor_basic.rs crates/tensor4all-core/tests/tensor_diag.rs
+git commit -m "test(core): cover structured tensor storage preservation"
+```
+
+## Task 3: Convert TensorDynLen To Storage-First Construction
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Test: `crates/tensor4all-core/tests/tensor_basic.rs`
+- Test: `crates/tensor4all-core/tests/tensor_diag.rs`
+
+**Step 1: Change the struct fields**
+
+Replace the existing fields:
+
+```rust
+pub(crate) inner: Arc<EagerTensor<CpuBackend>>,
+pub(crate) axis_classes: Vec<usize>,
+```
+
+with:
+
+```rust
+pub(crate) storage: Arc<Storage>,
+pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
+```
+
+Add imports:
+
+```rust
+use std::sync::{Arc, OnceLock};
+```
+
+Keep `indices` public for the current API surface.
+
+**Step 2: Add private cache/materialization helpers**
+
+Add helpers near `seed_native_payload`:
+
+```rust
+fn empty_eager_cache() -> Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>> {
+    Arc::new(OnceLock::new())
+}
+
+fn eager_cache_with(inner: EagerTensor<CpuBackend>) -> Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>> {
+    let cache = Arc::new(OnceLock::new());
+    let _ = cache.set(Arc::new(inner));
+    cache
+}
+
+fn storage_from_native_with_axis_classes(
+    native: &NativeTensor,
+    axis_classes: &[usize],
+    logical_rank: usize,
+) -> Result<Storage> {
+    if Self::is_diag_axis_classes(axis_classes) {
+        match native.dtype() {
+            DType::F32 | DType::F64 => {
+                Storage::from_diag_col_major(native_tensor_primal_to_diag_f64(native)?, logical_rank)
+            }
+            DType::C32 | DType::C64 => {
+                Storage::from_diag_col_major(native_tensor_primal_to_diag_c64(native)?, logical_rank)
+            }
+        }
+    } else {
+        native_tensor_primal_to_storage(native)
+    }
+}
+
+fn validate_storage_matches_indices(indices: &[DynIndex], storage: &Storage) -> Result<()> {
+    let dims = Self::expected_dims_from_indices(indices);
+    let storage_dims = storage.logical_dims();
+    if storage_dims != dims {
+        return Err(anyhow::anyhow!(
+            "storage logical dims {:?} do not match indices dims {:?}",
+            storage_dims,
+            dims
+        ));
+    }
+    if storage.is_diag() {
+        Self::validate_diag_dims(&dims)?;
+    }
+    Ok(())
+}
+
+fn materialized_inner(&self) -> &EagerTensor<CpuBackend> {
+    self.eager_cache
+        .get_or_init(|| {
+            let native = Self::seed_native_payload(self.storage.as_ref(), &self.dims())
+                .unwrap_or_else(|err| panic!("TensorDynLen materialization failed: {err}"));
+            Arc::new(EagerTensor::from_tensor_in(native, default_eager_ctx()))
+        })
+        .as_ref()
+}
+```
+
+If clippy rejects `panic!` in the cache path, split callers into a fallible `try_materialized_inner` and keep `as_native` as the only panic wrapper. The invariant is that materialization is infallible after `from_storage` validation.
+
+**Step 3: Update constructors**
+
+Update `from_storage` so it no longer calls `storage_to_native_tensor`:
+
+```rust
+pub fn from_storage(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
+    Self::validate_indices(&indices);
+    Self::validate_storage_matches_indices(&indices, storage.as_ref())?;
+    Ok(Self {
+        indices,
+        storage,
+        eager_cache: Self::empty_eager_cache(),
+    })
+}
+```
+
+Add the explicit alias:
+
+```rust
+pub fn from_structured_storage(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
+    Self::from_storage(indices, storage)
+}
+```
+
+Update `from_inner_with_axis_classes`:
+
+```rust
+let storage =
+    Self::storage_from_native_with_axis_classes(inner.data(), &axis_classes, indices.len())?;
+Ok(Self {
+    indices,
+    storage: Arc::new(storage),
+    eager_cache: Self::eager_cache_with(inner),
+})
+```
+
+Update `from_dense` to construct `Storage::from_dense_col_major(data, &dims)?` and call `from_storage`.
+
+Update `from_diag` to construct `Storage::from_diag_col_major(data, dims.len())?` and call `from_storage`. Keep `validate_diag_payload_len` before construction.
+
+**Step 4: Update storage and scalar metadata accessors**
+
+Change:
+
+```rust
+pub fn to_storage(&self) -> Result<Arc<Storage>> { ... }
+pub fn storage(&self) -> Arc<Storage> { ... }
+pub fn is_diag(&self) -> bool { ... }
+pub fn is_f64(&self) -> bool { ... }
+pub fn is_complex(&self) -> bool { ... }
+```
+
+to:
+
+```rust
+pub fn to_storage(&self) -> Result<Arc<Storage>> {
+    Ok(Arc::clone(&self.storage))
+}
+
+pub fn storage(&self) -> Arc<Storage> {
+    Arc::clone(&self.storage)
+}
+
+pub fn is_diag(&self) -> bool {
+    self.storage.is_diag()
+}
+
+pub fn is_f64(&self) -> bool {
+    self.storage.is_f64()
+}
+
+pub fn is_complex(&self) -> bool {
+    self.storage.is_complex()
+}
+```
+
+**Step 5: Replace direct `inner` and `axis_classes` reads enough to compile**
+
+Use the helpers:
+
+- `self.inner` -> `self.materialized_inner()`
+- `other.inner` -> `other.materialized_inner()`
+- `self.as_native()` can remain and should call `self.materialized_inner().data()`
+- `self.axis_classes` -> `self.storage.axis_classes()`
+- clone-preserving constructors should clone `storage` and `eager_cache`
+
+For `replaceind` and `replaceinds`, return:
+
+```rust
+Self {
+    indices: new_indices,
+    storage: Arc::clone(&self.storage),
+    eager_cache: Arc::clone(&self.eager_cache),
+}
+```
+
+For `enable_grad`, keep the same storage and seed the cache with a tracked eager leaf:
+
+```rust
+let native = self.as_native().clone();
+Self {
+    indices: self.indices,
+    storage: self.storage,
+    eager_cache: Self::eager_cache_with(EagerTensor::requires_grad_in(native, default_eager_ctx())),
+}
+```
+
+For `detach`, use the detached eager tensor and rebuild through `from_inner_with_axis_classes` using `self.storage.axis_classes().to_vec()`.
+
+**Step 6: Run targeted core tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_basic tensor_from_structured_storage_preserves_compact_payload
+cargo test --release -p tensor4all-core --test tensor_basic tensor_from_structured_storage_rejects_index_dim_mismatch
+cargo test --release -p tensor4all-core --test tensor_diag from_diag_storage_roundtrip_uses_payload_not_dense_logical_values
+cargo test --release -p tensor4all-core --test tensor_basic test_tensor_shared_storage
+```
+
+Expected: PASS.
+
+**Step 7: Commit**
+
+```bash
+git add crates/tensor4all-core/src/defaults/tensordynlen.rs crates/tensor4all-core/tests/tensor_basic.rs crates/tensor4all-core/tests/tensor_diag.rs
+git commit -m "feat(core): make TensorDynLen storage first"
+```
+
+## Task 4: Preserve Compact Storage Through Simple Tensor Operations
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Test: `crates/tensor4all-core/tests/tensor_diag.rs`
+- Test: `crates/tensor4all-core/tests/tensor_basic.rs`
+
+**Step 1: Add failing preservation tests**
+
+Add to `tensor_diag.rs`:
+
+```rust
+#[test]
+fn diag_permute_scale_conj_and_replaceind_preserve_payload_metadata() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(3);
+    let tensor = TensorDynLen::from_diag(
+        vec![i.clone(), j.clone(), k.clone()],
+        vec![1.0_f64, -2.0, 4.0],
+    )
+    .unwrap();
+
+    let permuted = tensor.permute(&[2, 0, 1]);
+    assert!(permuted.is_diag());
+    assert_eq!(permuted.storage().axis_classes(), &[0, 0, 0]);
+    assert_eq!(permuted.storage().payload_f64_col_major_vec().unwrap(), vec![1.0, -2.0, 4.0]);
+
+    let scaled = permuted.scale(AnyScalar::new_real(2.0)).unwrap();
+    assert!(scaled.is_diag());
+    assert_eq!(scaled.storage().payload_f64_col_major_vec().unwrap(), vec![2.0, -4.0, 8.0]);
+
+    let replaced = scaled.replaceind(&k, &Index::new_dyn(3));
+    assert!(replaced.is_diag());
+    assert_eq!(replaced.storage().payload_f64_col_major_vec().unwrap(), vec![2.0, -4.0, 8.0]);
+
+    let conjugated = replaced.conj();
+    assert!(conjugated.is_diag());
+    assert_eq!(conjugated.storage().payload_f64_col_major_vec().unwrap(), vec![2.0, -4.0, 8.0]);
+}
+```
+
+Add to `tensor_basic.rs`:
+
+```rust
+#[test]
+fn same_layout_axpby_preserves_structured_metadata() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let make = |offset| {
+        TensorDynLen::from_storage(
+            vec![i.clone(), j.clone(), k.clone()],
+            Arc::new(
+                Storage::new_structured(
+                    vec![1.0 + offset, 2.0 + offset, 3.0 + offset, 4.0 + offset, 5.0 + offset, 6.0 + offset],
+                    vec![2, 3],
+                    vec![1, 2],
+                    vec![0, 1, 0],
+                )
+                .unwrap(),
+            ),
+        )
+        .unwrap()
+    };
+
+    let a = make(0.0);
+    let b = make(10.0);
+    let result = a.axpby(AnyScalar::new_real(2.0), &b, AnyScalar::new_real(-1.0)).unwrap();
+    let storage = result.storage();
+
+    assert_eq!(storage.storage_kind(), tensor4all_core::StorageKind::Structured);
+    assert_eq!(storage.axis_classes(), &[0, 1, 0]);
+    assert_eq!(storage.payload_f64_col_major_vec().unwrap(), vec![-9.0, -8.0, -7.0, -6.0, -5.0, -4.0]);
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_diag diag_permute_scale_conj_and_replaceind_preserve_payload_metadata
+cargo test --release -p tensor4all-core --test tensor_basic same_layout_axpby_preserves_structured_metadata
+```
+
+Expected: FAIL where operations materialize dense native results or drop axis metadata.
+
+**Step 3: Implement storage-preserving operation branches**
+
+Update these methods to use storage methods when AD tracking is not active:
+
+- `permute_indices`
+- `permute`
+- `replaceind`
+- `replaceinds`
+- `conj`
+- `scale`
+- `axpby`
+
+Rules:
+
+- If `self.tracks_grad()` or another operand/scalar tracks grad, use the existing eager/native path.
+- If operation is metadata-only (`replaceind`, `replaceinds`), clone storage/cache.
+- For `permute`, use `self.storage.permute_storage(&self.dims(), perm)`.
+- For `conj`, use `self.storage.conj()`.
+- For `scale`, use `self.storage.scale(&scalar.to_backend_scalar() equivalent)` only through existing `Storage::scale(&tensor4all_tensorbackend::AnyScalar)` conversion already available. If scalar conversion is awkward, use `scalar.to_backend_scalar()` only at the backend boundary and add a small private conversion helper.
+- For `axpby`, only preserve structured storage when:
+  - both tensors have identical index order after alignment,
+  - both storages have identical `payload_dims`, `payload_strides`, and `axis_classes`,
+  - no involved tensor tracks grad.
+  Otherwise materialize through the existing eager/native path.
+
+Construct storage-preserving results through `TensorDynLen::from_storage(...)`.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_diag diag_permute_scale_conj_and_replaceind_preserve_payload_metadata
+cargo test --release -p tensor4all-core --test tensor_basic same_layout_axpby_preserves_structured_metadata
+cargo test --release -p tensor4all-core --test tensor_diag
+cargo test --release -p tensor4all-core --test tensor_basic
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-core/src/defaults/tensordynlen.rs crates/tensor4all-core/tests/tensor_diag.rs crates/tensor4all-core/tests/tensor_basic.rs
+git commit -m "feat(core): preserve structured storage in simple tensor ops"
+```
+
+## Task 5: Keep Dense Execution Paths Correct
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Test: `crates/tensor4all-core/tests/tensor_contraction.rs`
+- Test: `crates/tensor4all-core/tests/tensor_native_ad.rs`
+- Test: `crates/tensor4all-core/tests/linalg_svd.rs`
+- Test: `crates/tensor4all-core/tests/linalg_qr.rs`
+
+**Step 1: Add focused fallback tests**
+
+Add one test near existing contraction tests:
+
+```rust
+#[test]
+fn structured_tensor_contract_materializes_to_correct_dense_result() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let k = Index::new_dyn(2);
+    let diag = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![2.0_f64, 3.0]).unwrap();
+    let dense = TensorDynLen::from_dense(vec![j, k.clone()], vec![5.0, 7.0, 11.0, 13.0]).unwrap();
+
+    let result = diag.contract(&dense);
+
+    let expected = TensorDynLen::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
+    assert!((&result - &expected).maxabs() < 1e-12);
+}
+```
+
+If an equivalent test already exists, update it to assert `diag.is_diag()` before contraction and keep the dense whole-result comparison.
+
+**Step 2: Run fallback-heavy tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_contraction structured_tensor_contract_materializes_to_correct_dense_result
+cargo test --release -p tensor4all-core --test tensor_native_ad
+cargo test --release -p tensor4all-core --test linalg_svd
+cargo test --release -p tensor4all-core --test linalg_qr
+```
+
+Expected: PASS. If AD tests fail, inspect whether a storage-preserving branch skipped eager tracking. Fix by routing tracked tensors through eager/native code.
+
+**Step 3: Replace remaining direct field assumptions**
+
+Search:
+
+```bash
+rg -n "\\.inner|axis_classes" crates/tensor4all-core/src crates/tensor4all-core/tests
+```
+
+Allowed in `tensordynlen.rs`:
+- struct field declarations
+- cache helper internals
+- comments/doc examples
+- explicit `self.storage.axis_classes()` calls
+
+Disallowed:
+- downstream direct field access from other modules
+- operations comparing stale copied axis metadata rather than storage metadata
+
+**Step 4: Run the core crate**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-core/src/defaults/tensordynlen.rs crates/tensor4all-core/tests/tensor_contraction.rs crates/tensor4all-core/tests/tensor_native_ad.rs crates/tensor4all-core/tests/linalg_svd.rs crates/tensor4all-core/tests/linalg_qr.rs
+git commit -m "fix(core): keep native fallbacks correct with storage-first tensors"
+```
+
+## Task 6: Add C API Structured Tensor Surface
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/types.rs`
+- Modify: `crates/tensor4all-capi/src/tensor.rs`
+- Test: `crates/tensor4all-capi/src/tensor/tests/mod.rs`
+
+**Step 1: Add failing C API tests**
+
+In `crates/tensor4all-capi/src/tensor/tests/mod.rs`, add local helpers:
+
+```rust
+fn read_payload_dims(tensor: *const t4a_tensor) -> Vec<usize> {
+    let mut len = 0usize;
+    assert_eq!(t4a_tensor_payload_dims(tensor, std::ptr::null_mut(), 0, &mut len), T4A_SUCCESS);
+    let mut out = vec![0usize; len];
+    assert_eq!(t4a_tensor_payload_dims(tensor, out.as_mut_ptr(), out.len(), &mut len), T4A_SUCCESS);
+    out
+}
+
+fn read_axis_classes(tensor: *const t4a_tensor) -> Vec<usize> {
+    let mut len = 0usize;
+    assert_eq!(t4a_tensor_axis_classes(tensor, std::ptr::null_mut(), 0, &mut len), T4A_SUCCESS);
+    let mut out = vec![0usize; len];
+    assert_eq!(t4a_tensor_axis_classes(tensor, out.as_mut_ptr(), out.len(), &mut len), T4A_SUCCESS);
+    out
+}
+
+fn read_payload_f64(tensor: *const t4a_tensor) -> Vec<f64> {
+    let mut len = 0usize;
+    assert_eq!(t4a_tensor_copy_payload_f64(tensor, std::ptr::null_mut(), 0, &mut len), T4A_SUCCESS);
+    let mut out = vec![0.0; len];
+    assert_eq!(t4a_tensor_copy_payload_f64(tensor, out.as_mut_ptr(), out.len(), &mut len), T4A_SUCCESS);
+    out
+}
+```
+
+Add tests:
+
+```rust
+#[test]
+fn test_tensor_new_diag_f64_exposes_compact_payload() {
+    let i = new_index(3);
+    let j = new_index(3);
+    let indices = [i as *const t4a_index, j as *const t4a_index];
+    let mut tensor = std::ptr::null_mut();
+
+    assert_eq!(
+        t4a_tensor_new_diag_f64(2, indices.as_ptr(), [1.0, 2.0, 3.0].as_ptr(), 3, &mut tensor),
+        T4A_SUCCESS
+    );
+
+    let mut kind = t4a_storage_kind::Dense;
+    assert_eq!(t4a_tensor_storage_kind(tensor, &mut kind), T4A_SUCCESS);
+    assert_eq!(kind, t4a_storage_kind::Diagonal);
+    assert_eq!(read_payload_dims(tensor), vec![3]);
+    assert_eq!(read_axis_classes(tensor), vec![0, 0]);
+    assert_eq!(read_payload_f64(tensor), vec![1.0, 2.0, 3.0]);
+    assert_eq!(read_dense_f64(tensor), vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
+    t4a_index_release(j);
+}
+
+#[test]
+fn test_tensor_new_structured_f64_roundtrips_metadata() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(2);
+    let indices = [i as *const t4a_index, j as *const t4a_index, k as *const t4a_index];
+    let payload = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let payload_dims = [2usize, 3usize];
+    let payload_strides = [1isize, 2isize];
+    let axis_classes = [0usize, 1usize, 0usize];
+    let mut tensor = std::ptr::null_mut();
+
+    assert_eq!(
+        t4a_tensor_new_structured_f64(
+            3,
+            indices.as_ptr(),
+            payload.as_ptr(),
+            payload.len(),
+            payload_dims.as_ptr(),
+            payload_dims.len(),
+            payload_strides.as_ptr(),
+            payload_strides.len(),
+            axis_classes.as_ptr(),
+            axis_classes.len(),
+            &mut tensor,
+        ),
+        T4A_SUCCESS
+    );
+
+    let mut kind = t4a_storage_kind::Dense;
+    assert_eq!(t4a_tensor_storage_kind(tensor, &mut kind), T4A_SUCCESS);
+    assert_eq!(kind, t4a_storage_kind::Structured);
+    assert_eq!(read_payload_dims(tensor), vec![2, 3]);
+    assert_eq!(read_axis_classes(tensor), vec![0, 1, 0]);
+    assert_eq!(read_payload_f64(tensor), payload);
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
+    t4a_index_release(j);
+    t4a_index_release(k);
+}
+```
+
+Also add a buffer-too-small test for one metadata function and an invalid-axis test that checks `t4a_last_error_message` contains `axis_classes`.
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-capi --lib tensor_new_diag_f64_exposes_compact_payload
+cargo test --release -p tensor4all-capi --lib tensor_new_structured_f64_roundtrips_metadata
+```
+
+Expected: FAIL because the C symbols and enum do not exist.
+
+**Step 3: Add C-facing enum**
+
+In `crates/tensor4all-capi/src/types.rs`, add:
+
+```rust
+/// Compact tensor storage layout exposed by the C API.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum t4a_storage_kind {
+    /// Dense logical payload.
+    Dense = 0,
+    /// General structured payload.
+    Structured = 1,
+    /// Diagonal or copy-tensor payload.
+    Diagonal = 2,
+}
+
+impl From<tensor4all_core::StorageKind> for t4a_storage_kind {
+    fn from(kind: tensor4all_core::StorageKind) -> Self {
+        match kind {
+            tensor4all_core::StorageKind::Dense => Self::Dense,
+            tensor4all_core::StorageKind::Structured => Self::Structured,
+            tensor4all_core::StorageKind::Diagonal => Self::Diagonal,
+        }
+    }
+}
+```
+
+**Step 4: Add C API helpers in `tensor.rs`**
+
+Import `Storage`:
+
+```rust
+use tensor4all_core::{qr_with, svd_with, QrOptions, Storage, SvdOptions, SvdTruncationPolicy};
+```
+
+Add helpers:
+
+```rust
+fn read_usize_slice<'a>(
+    ptr: *const usize,
+    len: usize,
+    name: &str,
+) -> Result<&'a [usize], (StatusCode, String)> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, format!("{name} is null")));
+    }
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+}
+
+fn read_isize_slice<'a>(
+    ptr: *const isize,
+    len: usize,
+    name: &str,
+) -> Result<&'a [isize], (StatusCode, String)> {
+    if len == 0 {
+        return Ok(&[]);
+    }
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, format!("{name} is null")));
+    }
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len) })
+}
+```
+
+Add generic copy helper for metadata buffers if useful:
+
+```rust
+unsafe fn copy_slice_to_out<T: Copy>(
+    values: &[T],
+    buf: *mut T,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode {
+    *out_len = values.len();
+    if buf.is_null() {
+        return T4A_SUCCESS;
+    }
+    if buf_len < values.len() {
+        return T4A_BUFFER_TOO_SMALL;
+    }
+    std::ptr::copy_nonoverlapping(values.as_ptr(), buf, values.len());
+    T4A_SUCCESS
+}
+```
+
+**Step 5: Add metadata/readback functions**
+
+Add these exported functions using `run_status` and `require_tensor`:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_storage_kind(
+    ptr: *const t4a_tensor,
+    out_kind: *mut t4a_storage_kind,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_rank(
+    ptr: *const t4a_tensor,
+    out_rank: *mut usize,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_dims(
+    ptr: *const t4a_tensor,
+    buf: *mut usize,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_strides(
+    ptr: *const t4a_tensor,
+    buf: *mut isize,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_axis_classes(
+    ptr: *const t4a_tensor,
+    buf: *mut usize,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_payload_len(
+    ptr: *const t4a_tensor,
+    out_len: *mut usize,
+) -> StatusCode { ... }
+```
+
+Each function should read `let storage = tensor.inner().storage();` and copy from the storage accessor. Return `T4A_NULL_POINTER` with a useful last-error message through `run_status` if output pointers are null.
+
+Add payload copy functions:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_copy_payload_f64(
+    ptr: *const t4a_tensor,
+    buf: *mut f64,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_copy_payload_c64(
+    ptr: *const t4a_tensor,
+    buf_interleaved: *mut f64,
+    n_complex: usize,
+    out_len: *mut usize,
+) -> StatusCode { ... }
+```
+
+For `copy_payload_c64`, `out_len` is the number of complex values, matching `t4a_tensor_copy_dense_c64`.
+
+**Step 6: Add structured constructors**
+
+Add:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_structured_f64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    data: *const f64,
+    data_len: usize,
+    payload_dims: *const usize,
+    payload_rank: usize,
+    payload_strides: *const isize,
+    strides_len: usize,
+    axis_classes: *const usize,
+    axis_classes_len: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode { ... }
+```
+
+and the `c64` variant with interleaved data:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_structured_c64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    data_interleaved: *const f64,
+    n_complex: usize,
+    payload_dims: *const usize,
+    payload_rank: usize,
+    payload_strides: *const isize,
+    strides_len: usize,
+    axis_classes: *const usize,
+    axis_classes_len: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode { ... }
+```
+
+Validation rules:
+- `axis_classes_len == rank`, else `T4A_INVALID_ARGUMENT`.
+- `strides_len == payload_rank`, else `T4A_INVALID_ARGUMENT`.
+- Nonzero `data_len` / `n_complex` requires a non-null data pointer.
+- Nonzero `payload_rank` requires non-null dims and strides pointers.
+- Nonzero `axis_classes_len` requires non-null axis classes pointer.
+- Build `Storage::new_structured(...)`.
+- Build `InternalTensor::from_structured_storage(indices, Arc::new(storage))`.
+- Map all construction errors to `T4A_INVALID_ARGUMENT` with `capi_error`.
+
+Add diagonal constructors:
+
+```rust
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_diag_f64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    data: *const f64,
+    data_len: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode { ... }
+
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_new_diag_c64(
+    rank: usize,
+    index_ptrs: *const *const t4a_index,
+    data_interleaved: *const f64,
+    n_complex: usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode { ... }
+```
+
+These should call `InternalTensor::from_diag`.
+
+**Step 7: Run C API tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-capi --lib tensor_new_diag_f64_exposes_compact_payload
+cargo test --release -p tensor4all-capi --lib tensor_new_structured_f64_roundtrips_metadata
+cargo test --release -p tensor4all-capi --lib tensor
+```
+
+Expected: PASS.
+
+**Step 8: Commit**
+
+```bash
+git add crates/tensor4all-capi/src/types.rs crates/tensor4all-capi/src/tensor.rs crates/tensor4all-capi/src/tensor/tests/mod.rs
+git commit -m "feat(capi): expose structured tensor payloads"
+```
+
+## Task 7: Regenerate C Header And Public Docs
+
+**Files:**
+- Modify: `crates/tensor4all-capi/include/tensor4all_capi.h`
+- Modify: `crates/tensor4all-capi/README.md`
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/storage.rs`
+- Modify: `docs/api/*.md`
+
+**Step 1: Update stale rustdoc and README text**
+
+Update `TensorDynLen` rustdoc from "dynamic-rank dense tensor" to structured-storage wording. The key data layout note should say dense logical readback remains column-major, while compact storage may be dense, diagonal, or structured.
+
+Update `crates/tensor4all-capi/README.md` feature list from:
+
+```markdown
+- **Tensor API**: Dense `f64` / `Complex64` construction, export, and contraction
+```
+
+to:
+
+```markdown
+- **Tensor API**: Dense and structured `f64` / `Complex64` construction, export, and contraction
+```
+
+Add a short C example for `t4a_tensor_new_diag_f64` or structured metadata readback if the README stays concise.
+
+**Step 2: Regenerate the C header**
+
+Run:
+
+```bash
+mkdir -p crates/tensor4all-capi/include
+cbindgen crates/tensor4all-capi \
+  --config crates/tensor4all-capi/cbindgen.toml \
+  --output crates/tensor4all-capi/include/tensor4all_capi.h
+```
+
+Expected: header contains `t4a_storage_kind`, `t4a_tensor_new_structured_f64`, `t4a_tensor_copy_payload_f64`, and metadata functions.
+
+Verify:
+
+```bash
+rg -n "t4a_storage_kind|t4a_tensor_new_structured|t4a_tensor_copy_payload|t4a_tensor_axis_classes" crates/tensor4all-capi/include/tensor4all_capi.h
+```
+
+**Step 3: Regenerate API docs**
+
+Run:
+
+```bash
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+Expected: docs update for `StorageKind`, storage accessors, `TensorDynLen::from_structured_storage`, and new C API symbols if the dump covers C API exports.
+
+**Step 4: Run doc tests**
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-tensorbackend
+cargo test --doc --release -p tensor4all-core
+cargo test --doc --release -p tensor4all-capi
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-capi/include/tensor4all_capi.h crates/tensor4all-capi/README.md crates/tensor4all-core/src/defaults/tensordynlen.rs crates/tensor4all-tensorbackend/src/storage.rs docs/api
+git commit -m "docs: document structured tensor storage API"
+```
+
+## Task 8: Final Verification
+
+**Files:**
+- No new source changes expected unless verification finds defects.
+
+**Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all
+```
+
+Expected: no output or only formatted files.
+
+**Step 2: Lint**
+
+Run:
+
+```bash
+cargo clippy --workspace
+```
+
+Expected: PASS with no warnings that need code changes.
+
+**Step 3: Run targeted release tests**
+
+Run:
+
+```bash
+cargo nextest run --release -p tensor4all-tensorbackend
+cargo nextest run --release -p tensor4all-core
+cargo nextest run --release -p tensor4all-capi
+```
+
+Expected: PASS.
+
+**Step 4: Run full release suite if time allows**
+
+Run:
+
+```bash
+cargo nextest run --release --workspace
+```
+
+Expected: PASS. If this is too slow, record that targeted crate tests passed and full workspace was not run.
+
+**Step 5: Build rustdoc**
+
+Run:
+
+```bash
+cargo doc --workspace --no-deps
+```
+
+Expected: PASS.
+
+**Step 6: Check worktree**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: only intentional commits ahead of the base branch, no uncommitted files.
+
+**Step 7: Do not push without user approval**
+
+Stop after local commits and verification. Ask before pushing or opening a PR.
+
+## Implementation Notes
+
+- `Storage` metadata is the contract C API consumers need. Avoid exposing `StorageRepr`.
+- Existing dense C readback (`t4a_tensor_copy_dense_*`) remains logical dense materialization. New payload readback (`t4a_tensor_copy_payload_*`) returns compact payload values.
+- `TensorDynLen::storage()` must be cheap and must not materialize dense native tensors.
+- AD correctness takes priority over compact preservation in tracked operations. If a tensor tracks gradients, route through eager/native code and rebuild storage from the resulting primal snapshot.
+- When comparing dense whole results in tests, materialize once and compare with tensor subtraction plus `maxabs()`.
+- If a bug is found in one C API readback helper, inspect the dense readback functions for the same null/buffer/error handling issue before continuing.


### PR DESCRIPTION
## Summary
- Make `TensorDynLen` storage-first so dense, diagonal, and structured payload metadata can be preserved across core tensor operations.
- Add structured storage metadata and payload readback APIs, plus C API constructors/readback functions for diagonal and structured tensors.
- Regenerate the C header and update README/mdBook/rustdoc text for the structured storage surface.

## Why
Issue #434 needs tensors to treat structured storage as a first-class representation instead of immediately densifying diagonal or generalized structured payloads.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release -p tensor4all-tensorbackend`
- `cargo nextest run --release -p tensor4all-core`
- `cargo nextest run --release -p tensor4all-capi`
- `cargo test --doc --release --workspace`
- `./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`

Closes #434