### PR TITLE
[codex] implement structured contraction layout preservation

### DIFF
--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -1,7 +1,7 @@
 //! Multi-tensor contraction with optimal contraction order.
 //!
 //! This module provides functions to contract multiple tensors efficiently
-//! using hyperedge-aware einsum optimization via the tensorbackend
+//! using einsum optimization via the tensorbackend
 //! (tenferro-backed implementation).
 //!
 //! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
@@ -13,14 +13,10 @@
 //!
 //! # Diag Tensor Handling
 //!
-//! When Diag tensors share indices, their diagonal axes are unified to create
-//! hyperedges in the einsum optimizer.
-//!
-//! Example: `Diag(i,j) * Diag(j,k)`:
-//! - Diag(i,j) has diagonal axes i and j (same index)
-//! - Diag(j,k) has diagonal axes j and k (same index)
-//! - After union-find: i, j, k all map to the same representative ID
-//! - This creates a hyperedge that the einsum optimizer handles correctly
+//! Diagonal tensors are materialized as dense native operands for contraction,
+//! so numeric einsum labels must keep uncontracted logical axes distinct.
+//! Diagonal/structured equality metadata is propagated separately onto the
+//! result when the contraction leaves equal axes behind.
 
 use std::cell::RefCell;
 use std::cmp::Reverse;
@@ -241,8 +237,7 @@ pub fn contract_multi(
 
 /// Contract multiple tensors that form a connected graph.
 ///
-/// Uses hyperedge-aware einsum optimization via tensorbackend.
-/// This correctly handles Diag tensors by treating their diagonal axes as hyperedges.
+/// Uses einsum optimization via tensorbackend.
 ///
 /// # Arguments
 /// * `tensors` - Slice of tensors to contract (must form a connected graph)
@@ -261,7 +256,7 @@ pub fn contract_multi(
 /// # Behavior by N
 /// - N=0: Error
 /// - N=1: Clone of input
-/// - N>=2: Optimal order via hyperedge-aware greedy optimizer
+/// - N>=2: Optimized order via the tensorbackend einsum path
 ///
 /// # Examples
 ///
@@ -404,14 +399,14 @@ impl Default for AxisUnionFind {
 }
 
 // ============================================================================
-// Diag union-find builders
+// Axis helper builders
 // ============================================================================
 
 /// Build a union-find structure from a collection of tensors.
 ///
-/// For each Diag tensor component, all its indices are unified (they share the same
-/// diagonal dimension). This creates hyperedges when multiple Diag tensors
-/// share indices.
+/// This helper is kept for callers that need to group diagonal axes by index ID.
+/// Numeric contraction currently keeps dense logical axes distinct and propagates
+/// diagonal result metadata separately.
 pub fn build_diag_union(tensors: &[&TensorDynLen]) -> AxisUnionFind {
     let mut uf = AxisUnionFind::new();
 
@@ -471,8 +466,8 @@ pub fn collect_sizes(tensors: &[&TensorDynLen], uf: &mut AxisUnionFind) -> HashM
 
 /// Internal implementation of multi-tensor contraction.
 ///
-/// For Diag tensors, we pass them as 1D tensors (the diagonal elements) with
-/// a single hyperedge ID. The einsum hyperedge optimizer will handle them correctly.
+/// Diagonal tensors are passed as dense native operands for numeric contraction.
+/// Their compact equality metadata is propagated separately onto the result.
 ///
 /// This implementation preserves storage type: if all inputs are F64, the result
 /// is F64; if any input is C64, the result is C64.
@@ -484,10 +479,12 @@ fn contract_multi_impl(
     allowed: AllowedPairs<'_>,
     _skip_connectivity_check: bool,
 ) -> Result<TensorDynLen> {
-    // 1. Build union-find from Diag tensors to unify diagonal axes
-    let mut diag_uf = build_diag_union(tensors);
+    // 1. Build union-find over exact matching index IDs. Diagonal equality is
+    // encoded in the dense native values and should not collapse uncontracted
+    // logical axes in the numeric einsum.
+    let mut diag_uf = AxisUnionFind::new();
 
-    // 2. Build internal IDs with Diag-awareness
+    // 2. Build internal IDs for numeric contraction.
     let (ixs, internal_id_to_original) = build_internal_ids(tensors, allowed, &mut diag_uf)?;
 
     // 3. Output = count == 1 internal IDs (external indices)
@@ -542,6 +539,7 @@ fn contract_multi_impl(
     if let (Some(signature), Some(started)) = (profile_signature, profile_started) {
         record_contract_profile(signature, started.elapsed());
     }
+    let result_axis_classes = output_axis_classes(tensors, &ixs, &output, &internal_id_to_original);
     let final_indices = if output.is_empty() {
         vec![]
     } else {
@@ -553,12 +551,89 @@ fn contract_multi_impl(
             })
             .collect()
     };
-    TensorDynLen::from_native(final_indices, result_native)
+    TensorDynLen::from_native_with_axis_classes(final_indices, result_native, result_axis_classes)
 }
 
-/// Build internal IDs with Diag-awareness.
+fn output_axis_classes(
+    tensors: &[&TensorDynLen],
+    ixs: &[Vec<usize>],
+    output: &[usize],
+    internal_id_to_original: &HashMap<usize, (usize, usize)>,
+) -> Vec<usize> {
+    fn find(parent: &mut [usize], value: usize) -> usize {
+        if parent[value] != value {
+            parent[value] = find(parent, parent[value]);
+        }
+        parent[value]
+    }
+
+    fn union(parent: &mut [usize], lhs: usize, rhs: usize) {
+        let lhs_root = find(parent, lhs);
+        let rhs_root = find(parent, rhs);
+        if lhs_root != rhs_root {
+            parent[rhs_root] = lhs_root;
+        }
+    }
+
+    let mut class_offsets = Vec::with_capacity(tensors.len());
+    let mut next_node = 0usize;
+    for tensor in tensors {
+        class_offsets.push(next_node);
+        let payload_rank = tensor
+            .storage()
+            .axis_classes()
+            .iter()
+            .copied()
+            .max()
+            .map(|value| value + 1)
+            .unwrap_or(0);
+        next_node += payload_rank;
+    }
+    let mut parent: Vec<usize> = (0..next_node).collect();
+    let mut axes_by_internal_id: HashMap<usize, Vec<usize>> = HashMap::new();
+
+    for (tensor_idx, tensor) in tensors.iter().enumerate() {
+        for (axis, &internal_id) in ixs[tensor_idx].iter().enumerate() {
+            let class_id = tensor.storage().axis_classes()[axis];
+            let node = class_offsets[tensor_idx] + class_id;
+            axes_by_internal_id
+                .entry(internal_id)
+                .or_default()
+                .push(node);
+        }
+    }
+
+    for nodes in axes_by_internal_id.values() {
+        if let Some((&first, rest)) = nodes.split_first() {
+            for &node in rest {
+                union(&mut parent, first, node);
+            }
+        }
+    }
+
+    let mut root_to_class = HashMap::new();
+    let mut next_class = 0usize;
+    output
+        .iter()
+        .map(|internal_id| {
+            let (tensor_idx, axis) = internal_id_to_original[internal_id];
+            let class_id = tensors[tensor_idx].storage().axis_classes()[axis];
+            let node = class_offsets[tensor_idx] + class_id;
+            let root = find(&mut parent, node);
+            *root_to_class.entry(root).or_insert_with(|| {
+                let class = next_class;
+                next_class += 1;
+                class
+            })
+        })
+        .collect()
+}
+
+/// Build internal IDs for numeric contraction.
 ///
-/// Uses the union-find to ensure diagonal axes from Diag tensors share the same internal ID.
+/// Uses the union-find to merge IDs that have already been proven equivalent by
+/// the caller. Diagonal logical-axis metadata is intentionally handled outside
+/// this numeric labeling step.
 ///
 /// Returns: (ixs, internal_id_to_original)
 #[allow(clippy::type_complexity)]

--- a/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::defaults::Index;
+use crate::tensor_like::TensorLike;
+use crate::StorageKind;
 use num_complex::Complex64;
 use std::ffi::OsString;
 use std::time::Duration;
@@ -70,6 +72,25 @@ fn test_contract_multi_pair() {
     let b = make_test_tensor(&[3, 4], &[2, 3]); // j=2, k=3
     let result = contract_multi(&[&a, &b], AllowedPairs::All).unwrap();
     assert_eq!(result.dims(), vec![2, 4]); // i, k
+}
+
+#[test]
+fn test_contract_multi_diag_diag_partial_preserves_diagonal_storage() {
+    let i = Index::new(DynId(1), 3);
+    let j = Index::new(DynId(2), 3);
+    let k = Index::new(DynId(3), 3);
+
+    let a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = TensorDynLen::from_diag(vec![j, k.clone()], vec![4.0_f64, 5.0, 6.0]).unwrap();
+
+    let result = contract_multi(&[&a, &b], AllowedPairs::All).unwrap();
+
+    assert_eq!(result.dims(), vec![3, 3]);
+    assert!(result.is_diag());
+    assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
+
+    let expected = TensorDynLen::from_diag(vec![i, k], vec![4.0_f64, 10.0, 18.0]).unwrap();
+    assert!(result.isapprox(&expected, 1e-12, 0.0));
 }
 
 #[test]

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -23,6 +23,7 @@ pub mod tensordynlen;
 
 // Contraction
 pub mod contract;
+pub(crate) mod structured_contraction;
 
 // Linear algebra modules
 pub mod direct_sum;

--- a/crates/tensor4all-core/src/defaults/structured_contraction.rs
+++ b/crates/tensor4all-core/src/defaults/structured_contraction.rs
@@ -1,0 +1,530 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::Storage;
+use anyhow::{anyhow, ensure, Result};
+use num_complex::Complex64;
+use tenferro::{DType, Tensor as NativeTensor};
+use tensor4all_tensorbackend::einsum_native_tensors;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OperandLayout {
+    pub(crate) logical_dims: Vec<usize>,
+    pub(crate) axis_classes: Vec<usize>,
+}
+
+impl OperandLayout {
+    pub(crate) fn new(logical_dims: Vec<usize>, axis_classes: Vec<usize>) -> Result<Self> {
+        ensure!(
+            logical_dims.len() == axis_classes.len(),
+            "logical_dims rank {} does not match axis_classes rank {}",
+            logical_dims.len(),
+            axis_classes.len()
+        );
+        validate_axis_classes(&axis_classes)?;
+
+        let mut dims_by_class = HashMap::new();
+        for (&dim, &class_id) in logical_dims.iter().zip(axis_classes.iter()) {
+            if let Some(&expected) = dims_by_class.get(&class_id) {
+                ensure!(
+                    expected == dim,
+                    "axis class {class_id} has inconsistent dimensions {expected} and {dim}"
+                );
+            } else {
+                dims_by_class.insert(class_id, dim);
+            }
+        }
+
+        Ok(Self {
+            logical_dims,
+            axis_classes,
+        })
+    }
+
+    fn payload_rank(&self) -> usize {
+        self.axis_classes
+            .iter()
+            .copied()
+            .max()
+            .map(|value| value + 1)
+            .unwrap_or(0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StructuredContractionSpec {
+    pub(crate) input_labels: Vec<Vec<usize>>,
+    pub(crate) output_labels: Vec<usize>,
+    pub(crate) retained_labels: HashSet<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OperandPayloadPlan {
+    pub(crate) class_roots: Vec<usize>,
+    pub(crate) normalized_class_roots: Vec<usize>,
+}
+
+impl OperandPayloadPlan {
+    #[cfg(test)]
+    pub(crate) fn has_repeated_roots(&self) -> bool {
+        self.class_roots.len() != self.normalized_class_roots.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StructuredContractionPlan {
+    pub(crate) operand_plans: Vec<OperandPayloadPlan>,
+    pub(crate) output_axis_classes: Vec<usize>,
+    pub(crate) output_payload_roots: Vec<usize>,
+    pub(crate) output_payload_dims: Vec<usize>,
+}
+
+impl StructuredContractionPlan {
+    pub(crate) fn new(
+        operands: &[OperandLayout],
+        spec: &StructuredContractionSpec,
+    ) -> Result<Self> {
+        ensure!(
+            operands.len() == spec.input_labels.len(),
+            "operand count {} does not match input label count {}",
+            operands.len(),
+            spec.input_labels.len()
+        );
+
+        let offsets = node_offsets(operands);
+        let total_nodes = offsets.last().copied().unwrap_or(0);
+        let mut uf = UnionFind::new(total_nodes);
+        let mut label_nodes: HashMap<usize, Vec<usize>> = HashMap::new();
+        let mut label_dims: HashMap<usize, usize> = HashMap::new();
+
+        for (operand_idx, operand) in operands.iter().enumerate() {
+            let labels = &spec.input_labels[operand_idx];
+            ensure!(
+                labels.len() == operand.logical_dims.len(),
+                "input label rank {} does not match operand {operand_idx} rank {}",
+                labels.len(),
+                operand.logical_dims.len()
+            );
+
+            for (axis, (&label, &dim)) in labels.iter().zip(operand.logical_dims.iter()).enumerate()
+            {
+                if let Some(&expected) = label_dims.get(&label) {
+                    ensure!(
+                        expected == dim,
+                        "label {label} has inconsistent dimensions {expected} and {dim}"
+                    );
+                } else {
+                    label_dims.insert(label, dim);
+                }
+
+                let class_id = operand.axis_classes[axis];
+                let node = offsets[operand_idx] + class_id;
+                label_nodes.entry(label).or_default().push(node);
+            }
+        }
+
+        for nodes in label_nodes.values() {
+            if let Some((&first, rest)) = nodes.split_first() {
+                for &node in rest {
+                    uf.union(first, node);
+                }
+            }
+        }
+
+        let node_roots = canonical_roots(&mut uf, total_nodes);
+        let root_dims = root_dimensions(operands, &offsets, &node_roots)?;
+
+        let mut operand_plans = Vec::with_capacity(operands.len());
+        for (operand_idx, operand) in operands.iter().enumerate() {
+            let class_roots: Vec<usize> = (0..operand.payload_rank())
+                .map(|class_id| node_roots[offsets[operand_idx] + class_id])
+                .collect();
+            let normalized_class_roots = unique_first_appearance(&class_roots);
+            operand_plans.push(OperandPayloadPlan {
+                class_roots,
+                normalized_class_roots,
+            });
+        }
+
+        let mut output_roots = Vec::with_capacity(spec.output_labels.len());
+        for &label in &spec.output_labels {
+            let nodes = label_nodes
+                .get(&label)
+                .ok_or_else(|| anyhow!("output label {label} is not present in inputs"))?;
+            output_roots.push(node_roots[nodes[0]]);
+        }
+
+        let output_axis_classes = canonicalize_sequence(&output_roots);
+        let output_payload_roots = unique_first_appearance(&output_roots);
+        let output_payload_dims = output_payload_roots
+            .iter()
+            .map(|root| root_dims[*root])
+            .collect();
+
+        // Future retained-label options are interpreted by choosing output_labels.
+        // Reading the set here keeps the field semantically live.
+        for retained in &spec.retained_labels {
+            ensure!(
+                label_nodes.contains_key(retained),
+                "retained label {retained} is not present in inputs"
+            );
+        }
+
+        Ok(Self {
+            operand_plans,
+            output_axis_classes,
+            output_payload_roots,
+            output_payload_dims,
+        })
+    }
+}
+
+fn validate_axis_classes(axis_classes: &[usize]) -> Result<()> {
+    let mut next = 0usize;
+    for &class_id in axis_classes {
+        ensure!(
+            class_id <= next,
+            "axis_classes must be canonical first-appearance labels, got {axis_classes:?}"
+        );
+        if class_id == next {
+            next += 1;
+        }
+    }
+    Ok(())
+}
+
+fn node_offsets(operands: &[OperandLayout]) -> Vec<usize> {
+    let mut offsets = Vec::with_capacity(operands.len() + 1);
+    let mut next = 0usize;
+    offsets.push(next);
+    for operand in operands {
+        next += operand.payload_rank();
+        offsets.push(next);
+    }
+    offsets
+}
+
+fn canonical_roots(uf: &mut UnionFind, total_nodes: usize) -> Vec<usize> {
+    let mut root_to_id = HashMap::new();
+    let mut next_id = 0usize;
+    (0..total_nodes)
+        .map(|node| {
+            let root = uf.find(node);
+            *root_to_id.entry(root).or_insert_with(|| {
+                let id = next_id;
+                next_id += 1;
+                id
+            })
+        })
+        .collect()
+}
+
+fn root_dimensions(
+    operands: &[OperandLayout],
+    offsets: &[usize],
+    node_roots: &[usize],
+) -> Result<Vec<usize>> {
+    let mut dims_by_root = HashMap::new();
+    for (operand_idx, operand) in operands.iter().enumerate() {
+        for (axis, &dim) in operand.logical_dims.iter().enumerate() {
+            let class_id = operand.axis_classes[axis];
+            let root = node_roots[offsets[operand_idx] + class_id];
+            if let Some(&expected) = dims_by_root.get(&root) {
+                ensure!(
+                    expected == dim,
+                    "merged root {root} has inconsistent dimensions {expected} and {dim}"
+                );
+            } else {
+                dims_by_root.insert(root, dim);
+            }
+        }
+    }
+
+    let len = dims_by_root
+        .keys()
+        .copied()
+        .max()
+        .map(|root| root + 1)
+        .unwrap_or(0);
+    let mut dims = vec![1; len];
+    for (root, dim) in dims_by_root {
+        dims[root] = dim;
+    }
+    Ok(dims)
+}
+
+fn unique_first_appearance(values: &[usize]) -> Vec<usize> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for &value in values {
+        if seen.insert(value) {
+            result.push(value);
+        }
+    }
+    result
+}
+
+pub(crate) fn normalize_payload_for_roots(
+    payload: &NativeTensor,
+    roots: &[usize],
+) -> Result<(NativeTensor, Vec<usize>)> {
+    ensure!(
+        payload.shape().len() == roots.len(),
+        "payload rank {} does not match root label count {}",
+        payload.shape().len(),
+        roots.len()
+    );
+
+    if unique_first_appearance(roots).len() == roots.len() {
+        return Ok((payload.clone(), roots.to_vec()));
+    }
+
+    let mut current_payload = payload.clone();
+    let mut current_roots = roots.to_vec();
+    while let Some((axis_a, axis_b)) = first_duplicate_pair(&current_roots) {
+        let mut input_ids: Vec<usize> = (0..current_roots.len()).collect();
+        input_ids[axis_b] = input_ids[axis_a];
+        let output_ids: Vec<usize> = input_ids
+            .iter()
+            .enumerate()
+            .filter_map(|(axis, &label)| (axis != axis_b).then_some(label))
+            .collect();
+
+        current_payload = einsum_native_tensors(&[(&current_payload, &input_ids)], &output_ids)?;
+        current_roots.remove(axis_b);
+    }
+
+    Ok((current_payload, current_roots))
+}
+
+pub(crate) fn storage_payload_native(storage: &Storage) -> Result<NativeTensor> {
+    if storage.is_f64() {
+        Ok(NativeTensor::new(
+            storage.payload_dims().to_vec(),
+            storage
+                .payload_f64_col_major_vec()
+                .map_err(anyhow::Error::msg)?,
+        ))
+    } else if storage.is_c64() {
+        Ok(NativeTensor::new(
+            storage.payload_dims().to_vec(),
+            storage
+                .payload_c64_col_major_vec()
+                .map_err(anyhow::Error::msg)?,
+        ))
+    } else {
+        Err(anyhow!("unsupported storage scalar type"))
+    }
+}
+
+pub(crate) fn storage_from_payload_native(
+    payload: NativeTensor,
+    output_payload_dims: &[usize],
+    output_axis_classes: Vec<usize>,
+) -> Result<Storage> {
+    ensure!(
+        payload.shape() == output_payload_dims,
+        "payload shape {:?} does not match planned payload dims {:?}",
+        payload.shape(),
+        output_payload_dims
+    );
+    let strides = col_major_strides(output_payload_dims)?;
+    match payload.dtype() {
+        DType::F64 => {
+            let values = payload
+                .as_slice::<f64>()
+                .ok_or_else(|| anyhow!("failed to read f64 payload tensor"))?
+                .to_vec();
+            Storage::new_structured(
+                values,
+                output_payload_dims.to_vec(),
+                strides,
+                output_axis_classes,
+            )
+        }
+        DType::C64 => {
+            let values = payload
+                .as_slice::<Complex64>()
+                .ok_or_else(|| anyhow!("failed to read Complex64 payload tensor"))?
+                .to_vec();
+            Storage::new_structured(
+                values,
+                output_payload_dims.to_vec(),
+                strides,
+                output_axis_classes,
+            )
+        }
+        dtype => Err(anyhow!(
+            "unsupported structured payload dtype {dtype:?}; expected f64 or Complex64"
+        )),
+    }
+}
+
+fn col_major_strides(dims: &[usize]) -> Result<Vec<isize>> {
+    let mut stride = 1isize;
+    let mut strides = Vec::with_capacity(dims.len());
+    for &dim in dims {
+        strides.push(stride);
+        stride = stride
+            .checked_mul(dim as isize)
+            .ok_or_else(|| anyhow!("payload stride overflow for dims {dims:?}"))?;
+    }
+    Ok(strides)
+}
+
+fn first_duplicate_pair(values: &[usize]) -> Option<(usize, usize)> {
+    let mut first_axis_by_value = HashMap::new();
+    for (axis, &value) in values.iter().enumerate() {
+        if let Some(&first_axis) = first_axis_by_value.get(&value) {
+            return Some((first_axis, axis));
+        }
+        first_axis_by_value.insert(value, axis);
+    }
+    None
+}
+
+fn canonicalize_sequence(values: &[usize]) -> Vec<usize> {
+    let mut id_by_value = HashMap::new();
+    let mut next = 0usize;
+    values
+        .iter()
+        .map(|value| {
+            *id_by_value.entry(*value).or_insert_with(|| {
+                let id = next;
+                next += 1;
+                id
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+struct UnionFind {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+}
+
+impl UnionFind {
+    fn new(len: usize) -> Self {
+        Self {
+            parent: (0..len).collect(),
+            rank: vec![0; len],
+        }
+    }
+
+    fn find(&mut self, value: usize) -> usize {
+        if self.parent[value] != value {
+            let root = self.find(self.parent[value]);
+            self.parent[value] = root;
+        }
+        self.parent[value]
+    }
+
+    fn union(&mut self, lhs: usize, rhs: usize) {
+        let lhs_root = self.find(lhs);
+        let rhs_root = self.find(rhs);
+        if lhs_root == rhs_root {
+            return;
+        }
+
+        match self.rank[lhs_root].cmp(&self.rank[rhs_root]) {
+            std::cmp::Ordering::Less => self.parent[lhs_root] = rhs_root,
+            std::cmp::Ordering::Greater => self.parent[rhs_root] = lhs_root,
+            std::cmp::Ordering::Equal => {
+                self.parent[rhs_root] = lhs_root;
+                self.rank[lhs_root] = self.rank[lhs_root].saturating_add(1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plans_diag_diag_partial_as_diag_output() {
+        let operands = vec![
+            OperandLayout::new(vec![3, 3], vec![0, 0]).unwrap(),
+            OperandLayout::new(vec![3, 3], vec![0, 0]).unwrap(),
+        ];
+        let spec = StructuredContractionSpec {
+            input_labels: vec![vec![0, 1], vec![1, 2]],
+            output_labels: vec![0, 2],
+            retained_labels: Default::default(),
+        };
+
+        let plan = StructuredContractionPlan::new(&operands, &spec).unwrap();
+        assert_eq!(plan.output_axis_classes, vec![0, 0]);
+        assert_eq!(plan.output_payload_roots.len(), 1);
+    }
+
+    #[test]
+    fn plans_general_structured_output_classes() {
+        let operands = vec![
+            OperandLayout::new(vec![2, 2, 3], vec![0, 0, 1]).unwrap(),
+            OperandLayout::new(vec![3, 5, 5], vec![0, 1, 1]).unwrap(),
+        ];
+        let spec = StructuredContractionSpec {
+            input_labels: vec![vec![0, 1, 2], vec![2, 3, 4]],
+            output_labels: vec![0, 1, 3, 4],
+            retained_labels: Default::default(),
+        };
+
+        let plan = StructuredContractionPlan::new(&operands, &spec).unwrap();
+        assert_eq!(plan.output_axis_classes, vec![0, 0, 1, 1]);
+        assert_eq!(plan.output_payload_dims, vec![2, 5]);
+    }
+
+    #[test]
+    fn detects_payload_repeated_labels() {
+        let operands = vec![
+            OperandLayout::new(vec![3, 3], vec![0, 1]).unwrap(),
+            OperandLayout::new(vec![3, 3], vec![0, 0]).unwrap(),
+        ];
+        let spec = StructuredContractionSpec {
+            input_labels: vec![vec![0, 1], vec![0, 1]],
+            output_labels: vec![],
+            retained_labels: Default::default(),
+        };
+
+        let plan = StructuredContractionPlan::new(&operands, &spec).unwrap();
+        assert!(plan.operand_plans[0].has_repeated_roots());
+    }
+
+    #[test]
+    fn normalizes_repeated_payload_roots_by_extracting_diagonal() {
+        let payload = tenferro::Tensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+        let (normalized, roots) = normalize_payload_for_roots(&payload, &[0, 0]).unwrap();
+
+        assert_eq!(normalized.shape(), &[2]);
+        assert_eq!(normalized.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
+        assert_eq!(roots, vec![0]);
+    }
+
+    #[test]
+    fn storage_payload_native_roundtrip_preserves_compact_payload() {
+        let storage = crate::Storage::new_structured(
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 1, 0],
+        )
+        .unwrap();
+
+        let native = storage_payload_native(&storage).unwrap();
+        assert_eq!(native.shape(), &[2, 3]);
+        assert_eq!(
+            native.as_slice::<f64>().unwrap(),
+            &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        );
+
+        let rebuilt = storage_from_payload_native(native, &[2, 3], vec![0, 1, 0]).unwrap();
+        assert_eq!(rebuilt.storage_kind(), crate::StorageKind::Structured);
+        assert_eq!(rebuilt.payload_dims(), &[2, 3]);
+        assert_eq!(rebuilt.axis_classes(), &[0, 1, 0]);
+        assert_eq!(
+            rebuilt.payload_f64_col_major_vec().unwrap(),
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+        );
+    }
+}

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -21,6 +21,11 @@ use tensor4all_tensorbackend::{
     reshape_col_major_native_tensor, scale_native_tensor, storage_to_native_tensor, TensorElement,
 };
 
+use super::structured_contraction::{
+    normalize_payload_for_roots, storage_from_payload_native, storage_payload_native,
+    OperandLayout, StructuredContractionPlan, StructuredContractionSpec,
+};
+
 /// Trait for scalar types that can generate random values from a standard
 /// normal distribution.
 ///
@@ -110,6 +115,13 @@ pub trait TensorAccess {
     fn indices(&self) -> &[DynIndex];
 }
 
+#[derive(Clone)]
+pub(crate) struct StructuredAdValue {
+    payload: Arc<EagerTensor<CpuBackend>>,
+    payload_dims: Vec<usize>,
+    axis_classes: Vec<usize>,
+}
+
 /// Dynamic-rank tensor with structured payload storage -- the central data type
 /// of tensor4all.
 ///
@@ -167,6 +179,8 @@ pub struct TensorDynLen {
     pub indices: Vec<DynIndex>,
     /// Authoritative compact payload storage.
     pub(crate) storage: Arc<Storage>,
+    /// Optional tracked compact payload used to preserve structured AD layouts.
+    pub(crate) structured_ad: Option<Arc<StructuredAdValue>>,
     /// Lazily materialized eager payload for native execution and AD.
     pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
 }
@@ -296,6 +310,91 @@ impl TensorDynLen {
         ))
     }
 
+    fn binary_contraction_axis_classes(
+        lhs_axis_classes: &[usize],
+        axes_a: &[usize],
+        rhs_axis_classes: &[usize],
+        axes_b: &[usize],
+    ) -> Vec<usize> {
+        debug_assert_eq!(axes_a.len(), axes_b.len());
+
+        fn find(parent: &mut [usize], value: usize) -> usize {
+            if parent[value] != value {
+                parent[value] = find(parent, parent[value]);
+            }
+            parent[value]
+        }
+
+        fn union(parent: &mut [usize], lhs: usize, rhs: usize) {
+            let lhs_root = find(parent, lhs);
+            let rhs_root = find(parent, rhs);
+            if lhs_root != rhs_root {
+                parent[rhs_root] = lhs_root;
+            }
+        }
+
+        let lhs_payload_rank = lhs_axis_classes
+            .iter()
+            .copied()
+            .max()
+            .map(|value| value + 1)
+            .unwrap_or(0);
+        let rhs_payload_rank = rhs_axis_classes
+            .iter()
+            .copied()
+            .max()
+            .map(|value| value + 1)
+            .unwrap_or(0);
+        let rhs_offset = lhs_payload_rank;
+        let mut parent: Vec<usize> = (0..lhs_payload_rank + rhs_payload_rank).collect();
+
+        for (&lhs_axis, &rhs_axis) in axes_a.iter().zip(axes_b.iter()) {
+            union(
+                &mut parent,
+                lhs_axis_classes[lhs_axis],
+                rhs_offset + rhs_axis_classes[rhs_axis],
+            );
+        }
+
+        let mut lhs_contracted = vec![false; lhs_axis_classes.len()];
+        for &axis in axes_a {
+            lhs_contracted[axis] = true;
+        }
+        let mut rhs_contracted = vec![false; rhs_axis_classes.len()];
+        for &axis in axes_b {
+            rhs_contracted[axis] = true;
+        }
+
+        let mut root_to_class = std::collections::HashMap::new();
+        let mut next_class = 0usize;
+        let mut axis_classes = Vec::new();
+
+        for (axis, &class_id) in lhs_axis_classes.iter().enumerate() {
+            if !lhs_contracted[axis] {
+                let root = find(&mut parent, class_id);
+                let class = *root_to_class.entry(root).or_insert_with(|| {
+                    let value = next_class;
+                    next_class += 1;
+                    value
+                });
+                axis_classes.push(class);
+            }
+        }
+        for (axis, &class_id) in rhs_axis_classes.iter().enumerate() {
+            if !rhs_contracted[axis] {
+                let root = find(&mut parent, rhs_offset + class_id);
+                let class = *root_to_class.entry(root).or_insert_with(|| {
+                    let value = next_class;
+                    next_class += 1;
+                    value
+                });
+                axis_classes.push(class);
+            }
+        }
+
+        axis_classes
+    }
+
     fn scale_subscripts(rank: usize) -> Result<String> {
         if rank == 0 {
             Ok("->".to_string())
@@ -345,6 +444,318 @@ impl TensorDynLen {
         cache
     }
 
+    fn compact_payload_inner(&self) -> Result<EagerTensor<CpuBackend>> {
+        Ok(EagerTensor::from_tensor_in(
+            storage_payload_native(self.storage.as_ref())?,
+            default_eager_ctx(),
+        ))
+    }
+
+    fn tracked_compact_payload_value(&self) -> Option<&StructuredAdValue> {
+        self.structured_ad.as_deref()
+    }
+
+    fn compact_payload_is_logical_dense(&self, payload_dims: &[usize]) -> bool {
+        self.storage.axis_classes() == Self::dense_axis_classes(self.indices.len())
+            && payload_dims == self.dims()
+    }
+
+    fn build_binary_contraction_labels(
+        lhs_rank: usize,
+        axes_a: &[usize],
+        rhs_rank: usize,
+        axes_b: &[usize],
+    ) -> Result<(Vec<usize>, Vec<usize>, Vec<usize>)> {
+        anyhow::ensure!(
+            axes_a.len() == axes_b.len(),
+            "contract axis length mismatch: lhs {:?}, rhs {:?}",
+            axes_a,
+            axes_b
+        );
+
+        let mut lhs_ids = vec![usize::MAX; lhs_rank];
+        let mut rhs_ids = vec![usize::MAX; rhs_rank];
+        let mut next_id = 0usize;
+
+        let mut seen_lhs = vec![false; lhs_rank];
+        let mut seen_rhs = vec![false; rhs_rank];
+
+        for (&lhs_axis, &rhs_axis) in axes_a.iter().zip(axes_b.iter()) {
+            anyhow::ensure!(
+                lhs_axis < lhs_rank,
+                "lhs contract axis {lhs_axis} out of range"
+            );
+            anyhow::ensure!(
+                rhs_axis < rhs_rank,
+                "rhs contract axis {rhs_axis} out of range"
+            );
+            anyhow::ensure!(
+                !seen_lhs[lhs_axis],
+                "duplicate lhs contract axis {lhs_axis}"
+            );
+            anyhow::ensure!(
+                !seen_rhs[rhs_axis],
+                "duplicate rhs contract axis {rhs_axis}"
+            );
+            seen_lhs[lhs_axis] = true;
+            seen_rhs[rhs_axis] = true;
+            lhs_ids[lhs_axis] = next_id;
+            rhs_ids[rhs_axis] = next_id;
+            next_id += 1;
+        }
+
+        let mut output_ids = Vec::with_capacity(lhs_rank + rhs_rank - 2 * axes_a.len());
+        for id in &mut lhs_ids {
+            if *id == usize::MAX {
+                *id = next_id;
+                output_ids.push(next_id);
+                next_id += 1;
+            }
+        }
+        for id in &mut rhs_ids {
+            if *id == usize::MAX {
+                *id = next_id;
+                output_ids.push(next_id);
+                next_id += 1;
+            }
+        }
+
+        Ok((lhs_ids, rhs_ids, output_ids))
+    }
+
+    fn build_payload_einsum_subscripts(
+        input_roots: &[Vec<usize>],
+        output_roots: &[usize],
+    ) -> Result<String> {
+        let input_labels = input_roots
+            .iter()
+            .map(|roots| Self::einsum_labels(roots))
+            .collect::<Result<Vec<_>>>()?;
+        let output = Self::einsum_labels(output_roots)?;
+        Ok(format!("{}->{}", input_labels.join(","), output))
+    }
+
+    fn normalize_eager_payload_for_roots(
+        payload: &EagerTensor<CpuBackend>,
+        roots: &[usize],
+    ) -> Result<(Option<EagerTensor<CpuBackend>>, Vec<usize>)> {
+        anyhow::ensure!(
+            payload.data().shape().len() == roots.len(),
+            "payload rank {} does not match root label count {}",
+            payload.data().shape().len(),
+            roots.len()
+        );
+
+        let mut current_payload = None;
+        let mut current_roots = roots.to_vec();
+        while let Some((axis_a, axis_b)) = Self::first_duplicate_pair(&current_roots) {
+            let source = current_payload.as_ref().unwrap_or(payload);
+            current_payload = Some(source.extract_diag(axis_a, axis_b)?);
+            current_roots.remove(axis_b);
+        }
+
+        Ok((current_payload, current_roots))
+    }
+
+    fn first_duplicate_pair(values: &[usize]) -> Option<(usize, usize)> {
+        let mut first_axis_by_value = std::collections::HashMap::new();
+        for (axis, &value) in values.iter().enumerate() {
+            if let Some(&first_axis) = first_axis_by_value.get(&value) {
+                return Some((first_axis, axis));
+            }
+            first_axis_by_value.insert(value, axis);
+        }
+        None
+    }
+
+    fn binary_structured_contraction_plan(
+        &self,
+        other: &Self,
+        axes_a: &[usize],
+        axes_b: &[usize],
+    ) -> Result<(StructuredContractionPlan, Vec<Vec<usize>>, Vec<usize>)> {
+        let (lhs_labels, rhs_labels, output_labels) = Self::build_binary_contraction_labels(
+            self.indices.len(),
+            axes_a,
+            other.indices.len(),
+            axes_b,
+        )?;
+        let operands = vec![
+            OperandLayout::new(self.dims(), self.storage.axis_classes().to_vec())?,
+            OperandLayout::new(other.dims(), other.storage.axis_classes().to_vec())?,
+        ];
+        let spec = StructuredContractionSpec {
+            input_labels: vec![lhs_labels, rhs_labels],
+            output_labels,
+            retained_labels: Default::default(),
+        };
+        let plan = StructuredContractionPlan::new(&operands, &spec)?;
+        Ok((plan, spec.input_labels, spec.output_labels))
+    }
+
+    fn from_structured_payload_inner(
+        indices: Vec<DynIndex>,
+        payload_inner: EagerTensor<CpuBackend>,
+        payload_dims: Vec<usize>,
+        axis_classes: Vec<usize>,
+    ) -> Result<Self> {
+        Self::validate_indices(&indices);
+        if payload_inner.data().shape() != payload_dims {
+            return Err(anyhow::anyhow!(
+                "structured payload dims {:?} do not match planned payload dims {:?}",
+                payload_inner.data().shape(),
+                payload_dims
+            ));
+        }
+        let storage = storage_from_payload_native(
+            payload_inner.data().clone(),
+            &payload_dims,
+            axis_classes.clone(),
+        )?;
+        Self::validate_storage_matches_indices(&indices, &storage)?;
+        Ok(Self {
+            indices,
+            storage: Arc::new(storage),
+            structured_ad: Some(Arc::new(StructuredAdValue {
+                payload: Arc::new(payload_inner),
+                payload_dims,
+                axis_classes,
+            })),
+            eager_cache: Self::empty_eager_cache(),
+        })
+    }
+
+    fn contract_structured_payloads(
+        &self,
+        other: &Self,
+        result_indices: Vec<DynIndex>,
+        axes_a: &[usize],
+        axes_b: &[usize],
+    ) -> Result<Self> {
+        let (plan, _, _) = self.binary_structured_contraction_plan(other, axes_a, axes_b)?;
+        let lhs_roots = plan.operand_plans[0].class_roots.clone();
+        let rhs_roots = plan.operand_plans[1].class_roots.clone();
+        let scalar_multiply =
+            lhs_roots.is_empty() && rhs_roots.is_empty() && plan.output_payload_roots.is_empty();
+
+        if let (Some(lhs_ad), Some(rhs_ad)) = (
+            self.tracked_compact_payload_value(),
+            other.tracked_compact_payload_value(),
+        ) {
+            if lhs_ad.payload.data().dtype() != rhs_ad.payload.data().dtype() {
+                return Err(anyhow::anyhow!(
+                    "structured AD contraction requires matching payload dtypes"
+                ));
+            }
+            let (lhs_normalized, lhs_labels) =
+                Self::normalize_eager_payload_for_roots(lhs_ad.payload.as_ref(), &lhs_roots)?;
+            let (rhs_normalized, rhs_labels) =
+                Self::normalize_eager_payload_for_roots(rhs_ad.payload.as_ref(), &rhs_roots)?;
+            let lhs_payload = lhs_normalized
+                .as_ref()
+                .unwrap_or_else(|| lhs_ad.payload.as_ref());
+            let rhs_payload = rhs_normalized
+                .as_ref()
+                .unwrap_or_else(|| rhs_ad.payload.as_ref());
+            let payload = if scalar_multiply {
+                lhs_payload.mul(rhs_payload)?
+            } else {
+                let subscripts = Self::build_payload_einsum_subscripts(
+                    &[lhs_labels, rhs_labels],
+                    &plan.output_payload_roots,
+                )?;
+                eager_einsum_ad(&[lhs_payload, rhs_payload], &subscripts)?
+            };
+            return Self::from_structured_payload_inner(
+                result_indices,
+                payload,
+                plan.output_payload_dims,
+                plan.output_axis_classes,
+            );
+        }
+
+        if self.tracked_compact_payload_value().is_some()
+            || other.tracked_compact_payload_value().is_some()
+        {
+            let lhs_owned = if self.tracked_compact_payload_value().is_some() {
+                None
+            } else {
+                Some(self.compact_payload_inner()?)
+            };
+            let rhs_owned = if other.tracked_compact_payload_value().is_some() {
+                None
+            } else {
+                Some(other.compact_payload_inner()?)
+            };
+            let lhs = if let Some(value) = self.tracked_compact_payload_value() {
+                value.payload.as_ref()
+            } else {
+                lhs_owned.as_ref().unwrap()
+            };
+            let rhs = if let Some(value) = other.tracked_compact_payload_value() {
+                value.payload.as_ref()
+            } else {
+                rhs_owned.as_ref().unwrap()
+            };
+            if lhs.data().dtype() != rhs.data().dtype() {
+                return Err(anyhow::anyhow!(
+                    "structured AD contraction requires matching payload dtypes"
+                ));
+            }
+            let (lhs_normalized, lhs_labels) =
+                Self::normalize_eager_payload_for_roots(lhs, &lhs_roots)?;
+            let (rhs_normalized, rhs_labels) =
+                Self::normalize_eager_payload_for_roots(rhs, &rhs_roots)?;
+            let lhs_payload = lhs_normalized.as_ref().unwrap_or(lhs);
+            let rhs_payload = rhs_normalized.as_ref().unwrap_or(rhs);
+            let payload = if scalar_multiply {
+                lhs_payload.mul(rhs_payload)?
+            } else {
+                let subscripts = Self::build_payload_einsum_subscripts(
+                    &[lhs_labels, rhs_labels],
+                    &plan.output_payload_roots,
+                )?;
+                eager_einsum_ad(&[lhs_payload, rhs_payload], &subscripts)?
+            };
+            return Self::from_structured_payload_inner(
+                result_indices,
+                payload,
+                plan.output_payload_dims,
+                plan.output_axis_classes,
+            );
+        }
+
+        let lhs = storage_payload_native(self.storage.as_ref())?;
+        let rhs = storage_payload_native(other.storage.as_ref())?;
+        if lhs.dtype() != rhs.dtype() {
+            return Err(anyhow::anyhow!(
+                "structured payload contraction requires matching payload dtypes"
+            ));
+        }
+        let (lhs, lhs_labels) = normalize_payload_for_roots(&lhs, &lhs_roots)?;
+        let (rhs, rhs_labels) = normalize_payload_for_roots(&rhs, &rhs_roots)?;
+        let payload = tensor4all_tensorbackend::einsum_native_tensors(
+            &[(&lhs, lhs_labels.as_slice()), (&rhs, rhs_labels.as_slice())],
+            &plan.output_payload_roots,
+        )?;
+        let storage = storage_from_payload_native(
+            payload,
+            &plan.output_payload_dims,
+            plan.output_axis_classes,
+        )?;
+        Self::from_storage(result_indices, Arc::new(storage))
+    }
+
+    fn should_use_structured_payload_contract(&self, other: &Self) -> bool {
+        let same_payload_dtype = self.storage.is_f64() == other.storage.is_f64()
+            && self.storage.is_complex() == other.storage.is_complex();
+        same_payload_dtype
+            && (self.tracked_compact_payload_value().is_some()
+                || other.tracked_compact_payload_value().is_some()
+                || self.storage.axis_classes() != Self::dense_axis_classes(self.indices.len())
+                || other.storage.axis_classes() != Self::dense_axis_classes(other.indices.len()))
+    }
+
     fn storage_from_native_with_axis_classes(
         native: &NativeTensor,
         axis_classes: &[usize],
@@ -383,6 +794,11 @@ impl TensorDynLen {
     }
 
     fn materialized_inner(&self) -> &EagerTensor<CpuBackend> {
+        if let Some(value) = self.tracked_compact_payload_value() {
+            if self.compact_payload_is_logical_dense(&value.payload_dims) {
+                return value.payload.as_ref();
+            }
+        }
         self.eager_cache
             .get_or_init(|| {
                 let native = Self::seed_native_payload(self.storage.as_ref(), &self.dims())
@@ -491,6 +907,7 @@ impl TensorDynLen {
         Ok(Self {
             indices,
             storage,
+            structured_ad: None,
             eager_cache: Self::empty_eager_cache(),
         })
     }
@@ -572,6 +989,7 @@ impl TensorDynLen {
         Ok(Self {
             indices,
             storage: Arc::new(storage),
+            structured_ad: None,
             eager_cache: Self::eager_cache_with(inner),
         })
     }
@@ -588,26 +1006,49 @@ impl TensorDynLen {
 
     /// Enable reverse-mode AD tracking on this tensor by creating a tracked leaf.
     pub fn enable_grad(self) -> Self {
-        let native = self.as_native().clone();
+        let payload = storage_payload_native(self.storage.as_ref())
+            .unwrap_or_else(|err| panic!("TensorDynLen::enable_grad failed: {err}"));
+        let payload_dims = self.storage.payload_dims().to_vec();
+        let axis_classes = self.storage.axis_classes().to_vec();
         Self {
             indices: self.indices,
             storage: self.storage,
-            eager_cache: Self::eager_cache_with(EagerTensor::requires_grad_in(
-                native,
-                default_eager_ctx(),
-            )),
+            structured_ad: Some(Arc::new(StructuredAdValue {
+                payload: Arc::new(EagerTensor::requires_grad_in(payload, default_eager_ctx())),
+                payload_dims,
+                axis_classes,
+            })),
+            eager_cache: Self::empty_eager_cache(),
         }
     }
 
     /// Report whether this tensor participates in gradient tracking.
     pub fn tracks_grad(&self) -> bool {
-        self.eager_cache
-            .get()
-            .is_some_and(|inner| inner.tracks_grad())
+        self.structured_ad
+            .as_ref()
+            .is_some_and(|value| value.payload.tracks_grad())
+            || self
+                .eager_cache
+                .get()
+                .is_some_and(|inner| inner.tracks_grad())
     }
 
     /// Return the accumulated gradient, if one has been stored.
     pub fn grad(&self) -> Result<Option<Self>> {
+        if let Some(value) = self.tracked_compact_payload_value() {
+            return value
+                .payload
+                .grad()
+                .map(|grad| {
+                    let storage = storage_from_payload_native(
+                        grad.as_ref().clone(),
+                        &value.payload_dims,
+                        value.axis_classes.clone(),
+                    )?;
+                    Self::from_storage(self.indices.clone(), Arc::new(storage))
+                })
+                .transpose();
+        }
         self.materialized_inner()
             .grad()
             .map(|grad| {
@@ -622,6 +1063,9 @@ impl TensorDynLen {
 
     /// Clear the accumulated gradient stored for this tensor.
     pub fn clear_grad(&self) -> Result<()> {
+        if let Some(value) = self.tracked_compact_payload_value() {
+            value.payload.clear_grad();
+        }
         if let Some(inner) = self.eager_cache.get() {
             inner.clear_grad();
         }
@@ -630,6 +1074,13 @@ impl TensorDynLen {
 
     /// Run reverse-mode autodiff from this scalar tensor.
     pub fn backward(&self) -> Result<()> {
+        if let Some(value) = self.tracked_compact_payload_value() {
+            return value
+                .payload
+                .backward()
+                .map(|_| ())
+                .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}"));
+        }
         self.materialized_inner()
             .backward()
             .map(|_| ())
@@ -638,6 +1089,10 @@ impl TensorDynLen {
 
     /// Detach this tensor from the reverse graph.
     pub fn detach(&self) -> Self {
+        if self.tracked_compact_payload_value().is_some() {
+            return Self::from_storage(self.indices.clone(), Arc::clone(&self.storage))
+                .expect("TensorDynLen::detach returned invalid tensor");
+        }
         Self::from_inner_with_axis_classes(
             self.indices.clone(),
             self.materialized_inner().detach(),
@@ -757,6 +1212,7 @@ impl TensorDynLen {
             return Self {
                 indices: new_indices.to_vec(),
                 storage: Arc::clone(&self.storage),
+                structured_ad: self.structured_ad.clone(),
                 eager_cache: Arc::clone(&self.eager_cache),
             };
         }
@@ -861,6 +1317,23 @@ impl TensorDynLen {
         let other_dims = Self::expected_dims_from_indices(&other.indices);
         let spec = prepare_contraction(&self.indices, &self_dims, &other.indices, &other_dims)
             .expect("contraction preparation failed");
+        let result_axis_classes = Self::binary_contraction_axis_classes(
+            self.storage.axis_classes(),
+            &spec.axes_a,
+            other.storage.axis_classes(),
+            &spec.axes_b,
+        );
+
+        if self.should_use_structured_payload_contract(other) {
+            return self
+                .contract_structured_payloads(
+                    other,
+                    spec.result_indices,
+                    &spec.axes_a,
+                    &spec.axes_b,
+                )
+                .expect("TensorDynLen::contract structured payload path failed");
+        }
 
         if self.indices.is_empty() && other.indices.is_empty() {
             let result = self
@@ -879,8 +1352,12 @@ impl TensorDynLen {
                 &spec.axes_b,
             )
             .unwrap_or_else(|e| panic!("TensorDynLen::contract native fallback failed: {e}"));
-            return Self::from_native(spec.result_indices, result_native)
-                .expect("TensorDynLen::contract native fallback returned invalid tensor");
+            return Self::from_native_with_axis_classes(
+                spec.result_indices,
+                result_native,
+                result_axis_classes,
+            )
+            .expect("TensorDynLen::contract native fallback returned invalid tensor");
         }
 
         let subscripts = Self::build_binary_einsum_subscripts(
@@ -895,7 +1372,7 @@ impl TensorDynLen {
             &subscripts,
         )
         .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"));
-        Self::from_inner(spec.result_indices, result)
+        Self::from_inner_with_axis_classes(spec.result_indices, result, result_axis_classes)
             .expect("TensorDynLen::contract returned invalid tensor")
     }
 
@@ -982,6 +1459,21 @@ impl TensorDynLen {
                 anyhow::anyhow!("tensordot: Duplicate axis {} in {} tensor", pos, tensor)
             }
         })?;
+        let result_axis_classes = Self::binary_contraction_axis_classes(
+            self.storage.axis_classes(),
+            &spec.axes_a,
+            other.storage.axis_classes(),
+            &spec.axes_b,
+        );
+
+        if self.should_use_structured_payload_contract(other) {
+            return self.contract_structured_payloads(
+                other,
+                spec.result_indices,
+                &spec.axes_a,
+                &spec.axes_b,
+            );
+        }
 
         if self.indices.is_empty() && other.indices.is_empty() {
             let result = self
@@ -998,7 +1490,11 @@ impl TensorDynLen {
                 other.as_native(),
                 &spec.axes_b,
             )?;
-            return Self::from_native(spec.result_indices, result_native);
+            return Self::from_native_with_axis_classes(
+                spec.result_indices,
+                result_native,
+                result_axis_classes,
+            );
         }
 
         let subscripts = Self::build_binary_einsum_subscripts(
@@ -1012,7 +1508,7 @@ impl TensorDynLen {
             &subscripts,
         )
         .map_err(|e| anyhow::anyhow!("tensordot failed: {e}"))?;
-        Self::from_inner(spec.result_indices, result)
+        Self::from_inner_with_axis_classes(spec.result_indices, result, result_axis_classes)
     }
 
     /// Compute the outer product (tensor product) of two tensors.
@@ -1066,10 +1562,23 @@ impl TensorDynLen {
         // Build result indices and dimensions
         let mut result_indices = self.indices.clone();
         result_indices.extend(other.indices.iter().cloned());
+        let result_axis_classes = Self::binary_contraction_axis_classes(
+            self.storage.axis_classes(),
+            &[],
+            other.storage.axis_classes(),
+            &[],
+        );
+        if self.should_use_structured_payload_contract(other) {
+            return self.contract_structured_payloads(other, result_indices, &[], &[]);
+        }
         if self.as_native().dtype() != other.as_native().dtype() {
             let result_native =
                 contract_native_tensor(self.as_native(), &[], other.as_native(), &[])?;
-            return Self::from_native(result_indices, result_native);
+            return Self::from_native_with_axis_classes(
+                result_indices,
+                result_native,
+                result_axis_classes,
+            );
         }
 
         let subscripts = Self::build_binary_einsum_subscripts(
@@ -1083,7 +1592,7 @@ impl TensorDynLen {
             &subscripts,
         )
         .map_err(|e| anyhow::anyhow!("outer_product failed: {e}"))?;
-        Self::from_inner(result_indices, result)
+        Self::from_inner_with_axis_classes(result_indices, result, result_axis_classes)
     }
 }
 
@@ -1581,6 +2090,7 @@ impl TensorDynLen {
         Self {
             indices: new_indices,
             storage: Arc::clone(&self.storage),
+            structured_ad: self.structured_ad.clone(),
             eager_cache: Arc::clone(&self.eager_cache),
         }
     }
@@ -1656,6 +2166,7 @@ impl TensorDynLen {
         Self {
             indices: new_indices_vec,
             storage: Arc::clone(&self.storage),
+            structured_ad: self.structured_ad.clone(),
             eager_cache: Arc::clone(&self.eager_cache),
         }
     }

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -1,7 +1,7 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index_ops::common_inds;
-use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+use tensor4all_core::{DynIndex, Storage, StorageKind, TensorDynLen, TensorLike};
 
 fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
     TensorDynLen::from_dense(indices, data).unwrap()
@@ -150,6 +150,45 @@ fn structured_tensor_contract_materializes_to_correct_dense_result() {
 
     let expected = TensorDynLen::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
     assert!((&result - &expected).maxabs() < 1e-12);
+}
+
+#[test]
+fn general_structured_contract_preserves_output_axis_classes() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let l = Index::new_dyn(2);
+    let structured = TensorDynLen::from_storage(
+        vec![i.clone(), j.clone(), k.clone()],
+        Storage::new_structured(
+            vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 1, 0],
+        )
+        .map(std::sync::Arc::new)
+        .unwrap(),
+    )
+    .unwrap();
+    let dense = TensorDynLen::from_dense(
+        vec![j, l.clone()],
+        vec![10.0, 20.0, 30.0, 100.0, 200.0, 300.0],
+    )
+    .unwrap();
+
+    let result = structured.contract(&dense);
+
+    assert_eq!(result.indices, vec![i, k, l]);
+    assert_eq!(result.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(result.storage().axis_classes(), &[0, 0, 1]);
+    assert_eq!(
+        result.storage().payload_f64_col_major_vec().unwrap(),
+        vec![220.0, 280.0, 2200.0, 2800.0]
+    );
+    assert_eq!(
+        result.to_vec::<f64>().unwrap(),
+        vec![220.0, 0.0, 0.0, 280.0, 2200.0, 0.0, 0.0, 2800.0]
+    );
 }
 
 #[test]

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -110,10 +110,56 @@ fn test_diag_tensor_contract_diag_diag_partial() {
     let result = tensor_a.contract(&tensor_b);
 
     assert_eq!(result.dims(), vec![3, 3]);
-    assert!(!result.is_diag());
+    assert!(result.is_diag());
+    assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
 
     // Result diagonal should be element-wise product: [1*4, 2*5, 3*6] = [4, 10, 18]
     let expected = diag_tensor_dyn_len(vec![i, k], vec![4.0, 10.0, 18.0]);
+    assert!(result.isapprox(&expected, 1e-12, 0.0));
+}
+
+#[test]
+fn tracked_diag_partial_contraction_preserves_diag_result_and_grad() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(3);
+    let a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 3.0, 5.0]).enable_grad();
+    let b = diag_tensor_dyn_len(vec![j, k.clone()], vec![7.0, 11.0, 13.0]);
+
+    let c = a.contract(&b);
+    assert_eq!(c.storage().storage_kind(), StorageKind::Diagonal);
+
+    let ones = diag_tensor_dyn_len(vec![i, k], vec![1.0, 1.0, 1.0]);
+    let loss = c.contract(&ones);
+    loss.backward().unwrap();
+
+    let grad = a.grad().unwrap().unwrap();
+    assert_eq!(grad.storage().storage_kind(), StorageKind::Diagonal);
+    assert_eq!(
+        grad.storage().payload_f64_col_major_vec().unwrap(),
+        vec![7.0, 11.0, 13.0]
+    );
+}
+
+#[test]
+fn test_diag_tensor_tensordot_diag_diag_partial_preserves_diagonal_storage() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(3);
+    let l = Index::new_dyn(3);
+
+    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0]);
+    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], vec![4.0, 5.0, 6.0]);
+
+    let result = tensor_a
+        .tensordot(&tensor_b, &[(j, k)])
+        .expect("diag-diag tensordot should succeed");
+
+    assert_eq!(result.dims(), vec![3, 3]);
+    assert!(result.is_diag());
+    assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
+
+    let expected = diag_tensor_dyn_len(vec![i, l], vec![4.0, 10.0, 18.0]);
     assert!(result.isapprox(&expected, 1e-12, 0.0));
 }
 
@@ -372,7 +418,8 @@ fn test_diag_tensor_contract_rank3() {
     let result = tensor_a.contract(&tensor_b);
 
     assert_eq!(result.dims(), vec![2, 2, 2]);
-    assert!(!result.is_diag());
+    assert!(result.is_diag());
+    assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
 
     // Result diagonal should be element-wise product: [1*3, 2*4] = [3, 8]
     let expected = diag_tensor_dyn_len(vec![i, j, l], vec![3.0, 8.0]);

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -1,4 +1,4 @@
-use tensor4all_core::{contract_multi, AllowedPairs, Index, Storage, TensorDynLen};
+use tensor4all_core::{contract_multi, AllowedPairs, Index, Storage, StorageKind, TensorDynLen};
 
 #[test]
 fn plain_dense_storage_auto_seeds_native_payload() {
@@ -71,6 +71,36 @@ fn backward_accumulates_until_clear_grad() {
 
     x.clear_grad().unwrap();
     assert!(x.grad().unwrap().is_none());
+}
+
+#[test]
+fn general_structured_grad_preserves_input_axis_classes() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let storage = Storage::new_structured(
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        vec![2, 3],
+        vec![1, 2],
+        vec![0, 1, 0],
+    )
+    .map(std::sync::Arc::new)
+    .unwrap();
+    let x = TensorDynLen::from_storage(vec![i.clone(), j.clone(), k.clone()], storage)
+        .unwrap()
+        .enable_grad();
+    let ones = TensorDynLen::from_dense(vec![i, j, k], vec![1.0; 12]).unwrap();
+
+    let loss = contract_multi(&[&x, &ones], AllowedPairs::All).unwrap();
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert_eq!(grad.storage().axis_classes(), &[0, 1, 0]);
+    assert_eq!(grad.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(
+        grad.storage().payload_f64_col_major_vec().unwrap(),
+        vec![1.0; 6]
+    );
 }
 
 #[test]

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -457,7 +457,7 @@ impl Default for RrLUOptions {
 ///
 /// # Errors
 ///
-/// Returns [`MatrixCIError::NaNEncountered`](crate::error::MatrixCIError::NaNEncountered)
+/// Returns [`MatrixCIError::NaNEncountered`]
 /// if NaN values appear in the L or U factors.
 ///
 /// # Examples
@@ -617,7 +617,7 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
 ///
 /// # Errors
 ///
-/// Returns [`MatrixCIError::NaNEncountered`](crate::error::MatrixCIError::NaNEncountered)
+/// Returns [`MatrixCIError::NaNEncountered`]
 /// if NaN values appear in the L or U factors.
 ///
 /// # Examples

--- a/crates/tensor4all-tcicore/src/matrixluci/factors.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/factors.rs
@@ -1,7 +1,7 @@
 //! Cross-factor reconstruction helpers.
 //!
 //! [`CrossFactors`] gathers the pivot block, pivot columns, and pivot rows
-//! from a [`CandidateMatrixSource`](super::CandidateMatrixSource), and
+//! from a [`CandidateMatrixSource`], and
 //! provides methods to compute the left and right CI factors.
 
 use crate::matrixluci::error::MatrixLuciError;

--- a/crates/tensor4all-tcicore/src/scalar.rs
+++ b/crates/tensor4all-tcicore/src/scalar.rs
@@ -4,7 +4,7 @@
 //! in matrix cross interpolation and tensor train operations. It is
 //! implemented for [`f64`], [`f32`], [`Complex64`], and [`Complex32`].
 //!
-//! The [`scalar_tests!`] macro generates dual `f64`/`Complex64` test
+//! The `scalar_tests!` macro generates dual `f64`/`Complex64` test
 //! variants from a single generic test function.
 
 use crate::matrix::BlasMul;

--- a/docs/plans/2026-04-23-general-structured-contraction-design.md
+++ b/docs/plans/2026-04-23-general-structured-contraction-design.md
@@ -1,0 +1,269 @@
+# General Structured Contraction Design
+
+## Goal
+
+Implement contraction for dense, diagonal, and general structured
+`TensorDynLen` values while preserving the strongest sound output structure.
+
+The core operation is not only value computation. It must also compute the
+logical-axis equivalence classes of the result, execute on compact payloads
+whenever possible, and preserve the same compact layout through reverse-mode AD.
+
+## Background
+
+`Storage` already models every layout as structured storage:
+
+- dense: `axis_classes = [0, 1, ...]`
+- diagonal: `axis_classes = [0, 0, ...]`
+- general structured: repeated classes such as `[0, 1, 0, 2]`
+
+The current contraction path has a metadata-only propagation step for diagonal
+and structured equality classes, but numeric contraction still generally goes
+through materialized dense native tensors. That is acceptable as a temporary
+value fallback, but it is not the intended implementation because it loses
+general compact structure and makes AD gradients dense too easily.
+
+Older `tenferro-rs` had the right architectural model:
+
+- `StructuredTensor<T>` stored `payload`, `logical_dims`, and `axis_classes`.
+- Its `Differentiable::Tangent` was `StructuredTensor<T>`, so zero tangents,
+  seed cotangents, and accumulated gradients kept the same layout.
+- `structured/einsum.rs` planned output axis classes with
+  `plan_axis_classes_for_subscripts`.
+- It normalized repeated compact labels with `normalize_payload_for_roots`
+  before calling dense payload einsum.
+
+This design ports those ideas to `tensor4all-rs` using the current
+`Storage`/`TensorDynLen` representation.
+
+## Non-Goals
+
+- Do not silently densify tracked structured tensors in contraction AD.
+- Do not implement every tensor operation as structured-native in this change.
+  The target operation is contraction and the structural helpers needed by its
+  forward and reverse paths.
+- Do not expose scalar-specific Rust APIs. Keep Rust APIs generic over `Storage`
+  and `TensorDynLen`; scalar-specific handling remains an FFI detail.
+- Do not depend on tenferro strict-binary/GEMM lowering for repeated labels.
+  Public tenferro eager einsum accepts repeated labels, but strict GEMM lowering
+  may decline them as a fast-path applicability rule.
+
+## Semantics
+
+A structured tensor with payload `P`, logical dimensions `dims`, and
+`axis_classes` represents the logical tensor
+
+```text
+T[i0, i1, ...] =
+    P[j0, j1, ...] if all logical axes in the same class have equal indices
+    0              otherwise
+```
+
+where `jc` is the shared logical index value for class `c`.
+
+Contraction adds equality constraints between logical axes. The result structure
+is determined by taking the transitive closure of:
+
+1. each operand's existing `axis_classes`, and
+2. each contracted or retained shared label relation.
+
+The output `axis_classes` are the canonicalized equivalence-class roots of the
+logical output axes. Roots that have no output axis are closed summation roots.
+
+This rule is maximal but sound: it preserves every equality forced by the input
+layouts and contraction relations, and it does not invent new equality classes
+when no relation forces them.
+
+## Metadata Algorithm
+
+The planner works over payload-class nodes, not dense logical coordinates.
+
+1. For every operand, create one union-find node per payload class.
+2. For every logical axis, remember `(operand, logical_axis) -> payload_node`.
+3. Union nodes for all contracted label occurrences.
+4. Union nodes for retained shared labels as equality constraints, but do not
+   remove those labels from output.
+5. Validate that every merged root has one consistent dimension.
+6. For each output logical axis, map its payload node to its root.
+7. Canonicalize output roots in output-axis order to produce result
+   `axis_classes`.
+8. Record distinct output roots in first-appearance order. These become the
+   compact result payload axes.
+
+For `contract` and current `contract_multi`, "contracted" means labels that
+appear in multiple inputs and are not retained. For the future API in issue
+[#436](https://github.com/tensor4all/tensor4all-rs/issues/436), retained labels
+come from `ContractOptions` / `ContractMultiOptions`.
+
+## Compact Payload Algorithm
+
+The compact payload contraction is an einsum over payload axes.
+
+For each operand:
+
+1. Take the operand payload axes in payload-class order.
+2. Map each payload class to the global union-find root.
+3. Use the root id as the compact einsum label.
+
+If one operand maps two different payload axes to the same root, the operand
+gets repeated compact labels. This is not an error. It means the payload must be
+diagonalized over those payload axes before the main contraction.
+
+There are two valid ways to handle this:
+
+- call tenferro public eager einsum, which explicitly handles repeated labels;
+- or normalize first with the old tenferro algorithm:
+  repeatedly extract the diagonal of the first duplicate pair and remove one
+  duplicate payload axis.
+
+The tensor4all implementation should keep this normalization explicit in its
+planner/executor. That makes repeated-label behavior local and prevents a future
+strict GEMM path from accidentally receiving repeated labels.
+
+The compact output labels are the distinct output roots in first-appearance
+order. The resulting payload is wrapped in `Storage::new_structured` with:
+
+- `payload_dims`: dimensions of those distinct output roots;
+- `strides`: compact column-major strides;
+- `axis_classes`: result logical `axis_classes`.
+
+If the result has no output roots, the payload is scalar storage.
+
+## AD Semantics
+
+AD must preserve structure. A structured tensor's tangent space has the same
+logical dimensions and the same `axis_classes` as the primal.
+
+The old tenferro rule is the target:
+
+```text
+Tangent(StructuredTensor(payload, dims, axis_classes))
+    = StructuredTensor(tangent_payload, dims, axis_classes)
+```
+
+Therefore:
+
+- `enable_grad()` must track the compact payload, not a dense logical
+  materialization.
+- `grad()` must return a `TensorDynLen` with the same `axis_classes` and compact
+  payload shape as the primal.
+- tangent accumulation must require matching logical dims and matching
+  `axis_classes`.
+- contraction forward with AD must call compact payload `eager_einsum_ad` and
+  wrap the compact output payload with the planned result layout.
+- no tracked contraction path may call `as_native()` as a hidden densification
+  step.
+
+If a dense cotangent enters a structured reverse path, it must be compressed
+back into the expected layout before accumulation. The old tenferro helper
+`compress_dense_to_layout_in_ctx` did this by using einsum from logical
+`axis_classes` to payload class labels. Tensor4all should add the same helper
+for `Storage`.
+
+## TensorDynLen Representation Impact
+
+The current `eager_cache` is a dense logical `EagerTensor`. That is the wrong
+cache for structured AD. Replace or split it into two concepts:
+
+```rust
+struct TensorDynLen {
+    indices: Vec<DynIndex>,
+    storage: Arc<Storage>,
+    ad: Option<Arc<StructuredAdValue>>,
+    materialized_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
+}
+
+struct StructuredAdValue {
+    payload: EagerTensor<CpuBackend>,
+    payload_dims: Vec<usize>,
+    axis_classes: Vec<usize>,
+}
+```
+
+The materialized cache is only a value cache. It is never the reverse-mode leaf
+for structured tensors. Dense tensors are just the special case where payload
+dims equal logical dims and `axis_classes = [0, 1, ...]`.
+
+## Randomized Thought Experiments
+
+### Diagonal by diagonal partial contraction
+
+Input layouts:
+
+```text
+A(i, j): axis_classes [0, 0]
+B(j, k): axis_classes [0, 0]
+contract j
+output i, k
+```
+
+The contracted `j` relation unions `A` class 0 with `B` class 0. Output roots
+for `i` and `k` are equal, so result `axis_classes = [0, 0]`.
+
+### General structured result
+
+Input layouts:
+
+```text
+A(a, b, c): axis_classes [0, 0, 1]
+B(c, d, e): axis_classes [0, 1, 1]
+contract c
+output a, b, d, e
+```
+
+The `c` contraction unions only `A` class 1 with `B` class 0. Output roots are
+`A0, A0, B1, B1`, so result `axis_classes = [0, 0, 1, 1]`.
+
+### Payload repeated label
+
+Input layouts:
+
+```text
+A(i, l): dense axis_classes [0, 1]
+B(j, k): diagonal axis_classes [0, 0]
+contract i with j and l with k
+output none
+```
+
+Both payload classes of `A` become the same global root through `B`'s diagonal
+constraint. The compact payload labels for `A` are repeated. The executor must
+extract the diagonal of `A`'s payload or call a repeated-label-safe public
+einsum path.
+
+### Retained batch label
+
+Input layouts:
+
+```text
+A(b, i, j): dense [0, 1, 2]
+B(b, j, k): B has j == k, axis_classes [0, 1, 1]
+retain b
+contract j
+output b, i, k
+```
+
+The retained `b` roots remain output roots. The `j` contraction unions `A`'s
+`j` root with `B`'s `j/k` root, so output `i` and `k` share a root only if
+another relation forces it. Here the result layout is `[0, 1, 2]`: batched
+matrix-like output, not diagonal over `i` and `k`.
+
+## Testing Strategy
+
+Test metadata planning separately from numeric execution:
+
+- pairwise diagonal/diagonal partial contraction -> output diagonal;
+- general `[0, 0, 1]` by `[0, 1, 1]` -> output `[0, 0, 1, 1]`;
+- repeated payload labels are normalized to unique labels before the final
+  payload einsum;
+- dimension mismatches inside a merged root return errors;
+- retained labels remain in output and are not reduced.
+
+Then test value and AD behavior:
+
+- compare structured compact results against dense materialization;
+- verify result `storage_kind()` and `axis_classes()`;
+- enable grad on diagonal and general structured inputs, contract to a scalar,
+  call `backward()`, and verify `grad().storage().axis_classes()` matches the
+  input layout;
+- verify gradient payload values against dense whole-result comparisons.
+

--- a/docs/plans/2026-04-23-general-structured-contraction-plan.md
+++ b/docs/plans/2026-04-23-general-structured-contraction-plan.md
@@ -1,0 +1,492 @@
+# General Structured Contraction Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement structured contraction and contraction AD so dense, diagonal, and general structured tensors keep compact storage and sound output axis classes.
+
+**Architecture:** Add a metadata planner that computes union-find roots over operand payload classes, then execute contraction over compact payload tensors. Refactor `TensorDynLen` AD so tracked leaves own compact payload `EagerTensor`s with layout metadata; contraction AD runs on compact payloads and returns structured gradients with the same layout as the primal.
+
+**Tech Stack:** Rust, `tensor4all-core`, `tensor4all-tensorbackend::Storage`, tenferro `EagerTensor`, public tenferro eager einsum for payload execution, `anyhow`, release-mode cargo tests.
+
+---
+
+## Prerequisites
+
+- Read `README.md`.
+- Read `docs/plans/2026-04-22-issue-434-structured-tensor-design.md`.
+- Read `docs/plans/2026-04-23-general-structured-contraction-design.md`.
+- Run targeted tests in release mode.
+- Keep docs and code comments in English.
+
+## Task 1: Add Metadata Planner Tests
+
+**Files:**
+- Create: `crates/tensor4all-core/src/defaults/structured_contraction.rs`
+- Modify: `crates/tensor4all-core/src/defaults/mod.rs`
+
+**Step 1: Write failing unit tests**
+
+Create a `#[cfg(test)]` module in `structured_contraction.rs` with tests for:
+
+```rust
+#[test]
+fn plans_diag_diag_partial_as_diag_output() {
+    let operands = vec![
+        OperandLayout::new(vec![3, 3], vec![0, 0]).unwrap(),
+        OperandLayout::new(vec![3, 3], vec![0, 0]).unwrap(),
+    ];
+    let spec = StructuredContractionSpec {
+        input_labels: vec![vec![0, 1], vec![1, 2]],
+        output_labels: vec![0, 2],
+        retained_labels: Default::default(),
+    };
+
+    let plan = StructuredContractionPlan::new(&operands, &spec).unwrap();
+    assert_eq!(plan.output_axis_classes, vec![0, 0]);
+    assert_eq!(plan.output_payload_roots.len(), 1);
+}
+
+#[test]
+fn plans_general_structured_output_classes() {
+    let operands = vec![
+        OperandLayout::new(vec![2, 2, 3], vec![0, 0, 1]).unwrap(),
+        OperandLayout::new(vec![3, 5, 5], vec![0, 1, 1]).unwrap(),
+    ];
+    let spec = StructuredContractionSpec {
+        input_labels: vec![vec![0, 1, 2], vec![2, 3, 4]],
+        output_labels: vec![0, 1, 3, 4],
+        retained_labels: Default::default(),
+    };
+
+    let plan = StructuredContractionPlan::new(&operands, &spec).unwrap();
+    assert_eq!(plan.output_axis_classes, vec![0, 0, 1, 1]);
+    assert_eq!(plan.output_payload_dims, vec![2, 5]);
+}
+
+#[test]
+fn detects_payload_repeated_labels() {
+    let operands = vec![
+        OperandLayout::new(vec![3, 3], vec![0, 1]).unwrap(),
+        OperandLayout::new(vec![3, 3], vec![0, 0]).unwrap(),
+    ];
+    let spec = StructuredContractionSpec {
+        input_labels: vec![vec![0, 1], vec![0, 1]],
+        output_labels: vec![],
+        retained_labels: Default::default(),
+    };
+
+    let plan = StructuredContractionPlan::new(&operands, &spec).unwrap();
+    assert!(plan.operand_plans[0].has_repeated_roots());
+}
+```
+
+**Step 2: Run tests to verify failure**
+
+```bash
+cargo test --release -p tensor4all-core structured_contraction::tests -- --nocapture
+```
+
+Expected: compile failure because the planner types do not exist.
+
+**Step 3: Implement planner data types**
+
+Add private types:
+
+```rust
+pub(crate) struct OperandLayout {
+    pub(crate) logical_dims: Vec<usize>,
+    pub(crate) axis_classes: Vec<usize>,
+}
+
+pub(crate) struct StructuredContractionSpec {
+    pub(crate) input_labels: Vec<Vec<usize>>,
+    pub(crate) output_labels: Vec<usize>,
+    pub(crate) retained_labels: HashSet<usize>,
+}
+
+pub(crate) struct StructuredContractionPlan {
+    pub(crate) operand_plans: Vec<OperandPayloadPlan>,
+    pub(crate) output_axis_classes: Vec<usize>,
+    pub(crate) output_payload_roots: Vec<usize>,
+    pub(crate) output_payload_dims: Vec<usize>,
+}
+```
+
+Implement the union-find algorithm from the design doc. Validate rank and
+dimension mismatches with `anyhow::Result`.
+
+**Step 4: Run tests**
+
+```bash
+cargo test --release -p tensor4all-core structured_contraction::tests -- --nocapture
+```
+
+Expected: PASS.
+
+## Task 2: Add Compact Payload Normalization
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/structured_contraction.rs`
+- Test: same file
+
+**Step 1: Write failing tests for repeated payload roots**
+
+Add a test that normalizes `roots = [0, 0]` for a 2x2 payload and verifies the
+payload becomes rank 1 with diagonal values.
+
+```rust
+#[test]
+fn normalizes_repeated_payload_roots_by_extracting_diagonal() {
+    let payload = NativeTensor::new(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let (normalized, roots) =
+        normalize_payload_for_roots(&payload, &[0, 0]).unwrap();
+
+    assert_eq!(normalized.shape(), &[2]);
+    assert_eq!(normalized.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
+    assert_eq!(roots, vec![0]);
+}
+```
+
+**Step 2: Run test**
+
+```bash
+cargo test --release -p tensor4all-core normalizes_repeated_payload_roots_by_extracting_diagonal
+```
+
+Expected: FAIL.
+
+**Step 3: Implement normalization**
+
+Implement the old tenferro algorithm:
+
+- find the first duplicate root pair;
+- build a unary repeated-label einsum such as `aa->a`;
+- call public `einsum_native_tensors`;
+- remove the duplicate root;
+- repeat until roots are unique.
+
+Do not call strict binary/GEMM lowering directly.
+
+**Step 4: Run tests**
+
+```bash
+cargo test --release -p tensor4all-core structured_contraction::tests -- --nocapture
+```
+
+Expected: PASS.
+
+## Task 3: Add Storage Payload Native Helpers
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/structured_contraction.rs`
+- Modify if needed: `crates/tensor4all-tensorbackend/src/storage.rs`
+- Test: `crates/tensor4all-core/src/defaults/structured_contraction.rs`
+
+**Step 1: Write failing tests**
+
+Test that a `Storage::new_structured` payload can be converted to a compact
+`NativeTensor` without logical dense materialization, and rebuilt as structured
+storage after payload einsum.
+
+**Step 2: Implement helpers**
+
+Add private helpers:
+
+```rust
+fn storage_payload_native(storage: &Storage) -> Result<NativeTensor>;
+
+fn storage_from_payload_native(
+    payload: NativeTensor,
+    output_payload_dims: &[usize],
+    output_axis_classes: Vec<usize>,
+) -> Result<Storage>;
+```
+
+Use `payload_f64_col_major_vec`, `payload_c64_col_major_vec`,
+`Storage::new_structured`, and compact column-major strides.
+
+**Step 3: Run tests**
+
+```bash
+cargo test --release -p tensor4all-core structured_contraction::tests -- --nocapture
+```
+
+Expected: PASS.
+
+## Task 4: Refactor TensorDynLen AD To Track Compact Payloads
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Test: `crates/tensor4all-core/tests/tensor_native_ad.rs`
+- Test: `crates/tensor4all-core/tests/tensor_diag.rs`
+
+**Step 1: Write failing structured AD tests**
+
+Add tests that currently fail because `enable_grad()` uses `as_native()`:
+
+```rust
+#[test]
+fn general_structured_grad_preserves_input_axis_classes() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let storage = Storage::new_structured(
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+        vec![2, 3],
+        vec![1, 2],
+        vec![0, 1, 0],
+    )
+    .map(std::sync::Arc::new)
+    .unwrap();
+    let x = TensorDynLen::from_storage(vec![i.clone(), j.clone(), k.clone()], storage)
+        .unwrap()
+        .enable_grad();
+    let ones = TensorDynLen::from_dense(
+        vec![i, j, k],
+        vec![1.0; 12],
+    )
+    .unwrap();
+
+    let loss = contract_multi(&[&x, &ones], AllowedPairs::All).unwrap();
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert_eq!(grad.storage().axis_classes(), &[0, 1, 0]);
+    assert_eq!(grad.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(grad.storage().payload_f64_col_major_vec().unwrap(), vec![1.0; 6]);
+}
+```
+
+Also add a diagonal test for a tracked partial contraction:
+
+```rust
+#[test]
+fn tracked_diag_partial_contraction_preserves_diag_result_and_grad() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(3);
+    let a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 3.0, 5.0])
+        .unwrap()
+        .enable_grad();
+    let b = diag_tensor_dyn_len(vec![j, k.clone()], vec![7.0, 11.0, 13.0]).unwrap();
+
+    let c = a.contract(&b);
+    assert_eq!(c.storage().storage_kind(), StorageKind::Diagonal);
+
+    let ones = diag_tensor_dyn_len(vec![i, k], vec![1.0, 1.0, 1.0]).unwrap();
+    let loss = contract_multi(&[&c, &ones], AllowedPairs::All).unwrap();
+    loss.backward().unwrap();
+
+    let grad = a.grad().unwrap().unwrap();
+    assert_eq!(grad.storage().storage_kind(), StorageKind::Diagonal);
+    assert_eq!(grad.storage().payload_f64_col_major_vec().unwrap(), vec![7.0, 11.0, 13.0]);
+}
+```
+
+**Step 2: Run tests to verify failure**
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_native_ad general_structured_grad_preserves_input_axis_classes
+cargo test --release -p tensor4all-core --test tensor_diag tracked_diag_partial_contraction_preserves_diag_result_and_grad
+```
+
+Expected: at least the general structured test fails because gradients are
+materialized as dense storage.
+
+**Step 3: Add structured AD value**
+
+Replace the dense-only AD cache with a compact payload AD value. Keep a dense
+materialization cache for non-AD value operations.
+
+```rust
+struct StructuredAdValue {
+    payload: EagerTensor<CpuBackend>,
+    payload_dims: Vec<usize>,
+    axis_classes: Vec<usize>,
+}
+```
+
+`enable_grad()` must:
+
+- build a compact payload native tensor from `self.storage`;
+- call `EagerTensor::requires_grad_in(payload_native, default_eager_ctx())`;
+- store layout metadata next to that payload leaf;
+- not call `as_native()`.
+
+`grad()` must:
+
+- read `ad.payload.grad()`;
+- rebuild `Storage` from the gradient payload and original layout;
+- return `TensorDynLen::from_storage(self.indices.clone(), Arc::new(storage))`.
+
+`tracks_grad()`, `clear_grad()`, `backward()`, and `detach()` must use the
+structured AD value when present.
+
+**Step 4: Run AD tests**
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_native_ad
+cargo test --release -p tensor4all-core --test tensor_diag tracked_diag_partial_contraction_preserves_diag_result_and_grad
+```
+
+Expected: PASS after later contraction integration; intermediate compile/test
+failures are expected until Task 5 is complete.
+
+## Task 5: Integrate Compact Structured Contraction
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Modify: `crates/tensor4all-core/src/defaults/contract.rs`
+- Modify: `crates/tensor4all-core/src/defaults/structured_contraction.rs`
+- Test: `crates/tensor4all-core/tests/tensor_diag.rs`
+- Test: `crates/tensor4all-core/src/defaults/contract/tests/mod.rs`
+
+**Step 1: Add failing value tests**
+
+Add tests for:
+
+- pairwise diagonal/diagonal partial contraction returns diagonal storage;
+- `contract_multi` diagonal/diagonal partial contraction returns diagonal storage;
+- general structured contraction returns `StorageKind::Structured` with expected
+  `axis_classes = [0, 0, 1, 1]`;
+- dense materialization of the structured result matches the old dense path.
+
+**Step 2: Build compact payload specs**
+
+For pairwise contraction, map `prepare_contraction` / `prepare_contraction_pairs`
+into `StructuredContractionSpec`.
+
+For `contract_multi`, map the existing internal ids into labels:
+
+- output labels are existing `output`;
+- retained labels come from future options; initially empty;
+- input labels are `ixs`.
+
+**Step 3: Execute compact payload contraction**
+
+For each operand:
+
+- get compact payload native tensor from storage or structured AD value;
+- normalize repeated roots;
+- collect normalized root labels.
+
+Call:
+
+- `eager_einsum_ad` when any operand tracks grad;
+- `einsum_native_tensors` when no operand tracks grad.
+
+Wrap the output payload into `Storage::new_structured` using the planned output
+payload dims and axis classes. For AD, also store the output compact
+`EagerTensor` in the result's structured AD value.
+
+**Step 4: Remove dense structured contraction fallback from tracked paths**
+
+`contract`, `tensordot`, `outer_product`, and `contract_multi_impl` should not
+call `as_native()` merely to execute a structured contraction when a compact
+plan is available.
+
+Dense materialization is allowed only for explicitly unsupported operations or
+for readback APIs.
+
+**Step 5: Run tests**
+
+```bash
+cargo test --release -p tensor4all-core --test tensor_diag
+cargo test --release -p tensor4all-core defaults::contract::tests
+cargo test --release -p tensor4all-core --test tensor_native_ad
+```
+
+Expected: PASS.
+
+## Task 6: Add Retained-Index Option Surface
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/contract.rs`
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Modify: public exports as needed in `crates/tensor4all-core/src/lib.rs`
+- Test: `crates/tensor4all-core/src/defaults/contract/tests/mod.rs`
+
+**Step 1: Add API tests**
+
+Add tests for issue #436:
+
+- `contract_multi_with_options` keeps a shared batch index;
+- retained labels are not reduced;
+- retained labels still union structured classes;
+- default options preserve current behavior.
+
+**Step 2: Add option types**
+
+Add:
+
+```rust
+pub struct ContractOptions {
+    pub retained_indices: Vec<DynIndex>,
+}
+
+pub struct ContractMultiOptions {
+    pub retained_indices: Vec<DynIndex>,
+}
+```
+
+Add `contract_with_options`, `tensordot_with_options` if needed, and
+`contract_multi_with_options`. Existing APIs delegate with empty retained sets.
+
+**Step 3: Wire retained labels into planner**
+
+Map retained `DynIndex` ids to internal contraction labels and pass them into
+`StructuredContractionSpec.retained_labels`.
+
+**Step 4: Run tests**
+
+```bash
+cargo test --release -p tensor4all-core defaults::contract::tests
+cargo test --release -p tensor4all-core --test tensor_diag
+```
+
+Expected: PASS.
+
+## Task 7: Full Verification
+
+**Files:**
+- All touched files
+
+**Step 1: Format**
+
+```bash
+cargo fmt --all
+```
+
+Expected: no formatting diff after running.
+
+**Step 2: Run focused suite**
+
+```bash
+cargo nextest run --release -p tensor4all-core --test tensor_diag
+cargo nextest run --release -p tensor4all-core --test tensor_native_ad
+cargo nextest run --release -p tensor4all-core defaults::contract::tests
+```
+
+Expected: all pass.
+
+**Step 3: Run crate suite**
+
+```bash
+cargo nextest run --release -p tensor4all-core
+cargo clippy -p tensor4all-core --all-targets
+git diff --check
+```
+
+Expected: all pass.
+
+**Step 4: Update docs if public API changed**
+
+If retained-index options are public, update rustdoc examples and any stale
+README/user-guide claims. Then run:
+
+```bash
+cargo test --doc --release -p tensor4all-core
+```
+
+Expected: PASS.
+


### PR DESCRIPTION
## Summary

- Add a general structured contraction planner that computes output axis equivalence classes over compact payload roots.
- Execute structured contractions on compact payload tensors, including explicit repeated-root normalization via diagonal extraction.
- Preserve diagonal/general structured storage through contraction AD by tracking compact payload `EagerTensor`s and rebuilding gradients with the primal layout.
- Add design and implementation plan docs for the structured contraction algorithm.

## Why

Partial contractions between diagonal or generally structured tensors were able to lose compact layout information, especially once AD was involved. This keeps contraction results and gradients in the strongest sound structured layout instead of falling back to dense logical tensors.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release --workspace` (1853 passed, 7 skipped)
- `cargo doc --workspace --no-deps`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`