### PR TITLE
[codex] Document source dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ A Rust implementation of tensor networks: TCI, Quantics Tensor Train, and Tree T
 
 ## Quick Start
 
-Add to your `Cargo.toml`:
+The crates are not published to crates.io yet. Use git dependencies from an
+external project:
 
 ```toml
 [dependencies]
-tensor4all-simplett = "0.1"
+tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-simplett" }
+```
+
+When working from a local checkout, use a path dependency instead:
+
+```toml
+[dependencies]
+tensor4all-simplett = { path = "../tensor4all-rs/crates/tensor4all-simplett" }
 ```
 
 ```rust

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -6,24 +6,36 @@ You need the Rust toolchain. If you do not have it installed, follow the instruc
 
 ## Adding tensor4all-rs to Your Project
 
-tensor4all-rs is a collection of crates. Add the ones you need to your `Cargo.toml`:
+tensor4all-rs is a collection of crates. The crates are not published to
+crates.io yet, so use git dependencies from an external project:
 
 ```toml
 [dependencies]
 # Basic tensor train construction and manipulation
-tensor4all-simplett = "0.1"
+tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-simplett" }
 
 # Tensor Cross Interpolation (TCI)
-tensor4all-tensorci = "0.1"
+tensor4all-tensorci = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-tensorci" }
 
 # Quantics TCI (combines quantics encoding with TCI)
-tensor4all-quanticstci = "0.1"
+tensor4all-quanticstci = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-quanticstci" }
 
 # Tree tensor networks
-tensor4all-treetn = "0.1"
+tensor4all-treetn = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-treetn" }
 ```
 
 You do not need to add all of them — only include the crates relevant to your use case.
+
+When working from a local checkout, use path dependencies instead. Paths are
+relative to your project's `Cargo.toml`; adjust `../tensor4all-rs` as needed:
+
+```toml
+[dependencies]
+tensor4all-simplett = { path = "../tensor4all-rs/crates/tensor4all-simplett" }
+tensor4all-tensorci = { path = "../tensor4all-rs/crates/tensor4all-tensorci" }
+tensor4all-quanticstci = { path = "../tensor4all-rs/crates/tensor4all-quanticstci" }
+tensor4all-treetn = { path = "../tensor4all-rs/crates/tensor4all-treetn" }
+```
 
 ## First Example: Tensor Trains
 

--- a/docs/book/src/guides/quantics.md
+++ b/docs/book/src/guides/quantics.md
@@ -5,12 +5,21 @@ applying transformations to functions represented as quantics tensor trains.
 It is a Rust port of the transformation functionality from
 [Quantics.jl](https://github.com/tensor4all/Quantics.jl).
 
-Add it to your `Cargo.toml`:
+If you have not set up dependencies yet, add the transform and TreeTN crates to
+your `Cargo.toml`. Use git dependencies from an external project:
 
 ```toml
 [dependencies]
-tensor4all-quanticstransform = "0.1"
-tensor4all-treetn = "0.1"
+tensor4all-quanticstransform = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-quanticstransform" }
+tensor4all-treetn = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-treetn" }
+```
+
+Or use path dependencies when working from a local checkout:
+
+```toml
+[dependencies]
+tensor4all-quanticstransform = { path = "../tensor4all-rs/crates/tensor4all-quanticstransform" }
+tensor4all-treetn = { path = "../tensor4all-rs/crates/tensor4all-treetn" }
 ```
 
 ---

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -3,11 +3,19 @@
 This guide covers the `tensor4all-core` crate, which provides the foundation for
 all tensor operations: indices, tensors, contraction, and factorization.
 
-Add it to your `Cargo.toml`:
+If you have not set up a dependency yet, add `tensor4all-core` to your
+`Cargo.toml`. Use a git dependency from an external project:
 
 ```toml
 [dependencies]
-tensor4all-core = "0.1"
+tensor4all-core = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-core" }
+```
+
+Or use a path dependency when working from a local checkout:
+
+```toml
+[dependencies]
+tensor4all-core = { path = "../tensor4all-rs/crates/tensor4all-core" }
 ```
 
 ## Index


### PR DESCRIPTION
## Summary
- replace crates.io-only dependency snippets with git dependency examples
- add local checkout path dependency examples
- update related guide dependency setup snippets

## Root Cause
The docs advertised `tensor4all-* = "0.1"` crates.io dependencies, but these crates are not published there yet, so fresh users fail before compiling.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo nextest run --release --workspace` (1853 passed, 7 skipped)
- `cargo doc --workspace --no-deps`
- `cargo test --doc -p book-tests --release` (45 passed)
- `./scripts/test-mdbook.sh` (run in a temporary repo copy so build outputs could be deleted afterward)
- `git diff --check`