### PR TITLE
[codex] Fix split_to target edge preservation

### DIFF
--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -18,6 +18,8 @@ use super::TreeTN;
 use crate::options::SplitOptions;
 use crate::site_index_network::SiteIndexNetwork;
 
+type SplitBoundaryIndices<V, TargetV, Id> = HashMap<V, HashMap<TargetV, HashSet<Id>>>;
+
 impl<T, V> TreeTN<T, V>
 where
     T: TensorLike,
@@ -301,6 +303,60 @@ where
             }
         }
 
+        let mut site_to_current: HashMap<<T::Index as IndexLike>::Id, V> = HashMap::new();
+        for current_node_name in self.node_names() {
+            let site_space = self.site_space(&current_node_name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "split_to: current node {:?} has no registered site space",
+                    current_node_name
+                )
+            })?;
+            for site_idx in site_space {
+                site_to_current.insert(site_idx.id().clone(), current_node_name.clone());
+            }
+        }
+
+        let mut target_to_current: HashMap<TargetV, V> = HashMap::new();
+        for target_node_name in target.node_names() {
+            let site_space = target.site_space(target_node_name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "split_to: target node {:?} has no registered site space",
+                    target_node_name
+                )
+            })?;
+            let current_names: HashSet<_> = site_space
+                .iter()
+                .map(|site_idx| {
+                    site_to_current.get(site_idx.id()).cloned().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "split_to: target site index {:?} is missing from the current network",
+                            site_idx.id()
+                        )
+                    })
+                })
+                .collect::<Result<_>>()?;
+            if current_names.len() != 1 {
+                return Err(anyhow::anyhow!(
+                    "split_to: target node {:?} spans multiple current nodes; use restructure_to for mixed regrouping",
+                    target_node_name
+                ));
+            }
+            let current_name = current_names.into_iter().next().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "split_to: target node {:?} has no current owner",
+                    target_node_name
+                )
+            })?;
+            target_to_current.insert(target_node_name.clone(), current_name);
+        }
+
+        let boundary_indices = if target.edge_count() == 0 {
+            HashMap::new()
+        } else {
+            self.split_boundary_indices_by_target(target, &target_to_current)
+                .context("split_to: assign current bonds to target boundary fragments")?
+        };
+
         // Step 2: For each current node, determine which target nodes it maps to
         // and validate the mapping
         let mut current_to_targets: HashMap<V, HashSet<TargetV>> = HashMap::new();
@@ -346,7 +402,11 @@ where
             } else {
                 // Need to split this node
                 let split_tensors = self
-                    .split_tensor_for_targets(tensor, &site_to_target)
+                    .split_tensor_for_targets(
+                        tensor,
+                        &site_to_target,
+                        boundary_indices.get(&current_node_name),
+                    )
                     .with_context(|| {
                         format!("split_to: failed to split node {:?}", current_node_name)
                     })?;
@@ -387,6 +447,79 @@ where
         Ok(result)
     }
 
+    fn split_boundary_indices_by_target<TargetV>(
+        &self,
+        target: &SiteIndexNetwork<TargetV, T::Index>,
+        target_to_current: &HashMap<TargetV, V>,
+    ) -> Result<SplitBoundaryIndices<V, TargetV, <T::Index as IndexLike>::Id>>
+    where
+        TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    {
+        let mut boundary_indices: SplitBoundaryIndices<V, TargetV, <T::Index as IndexLike>::Id> =
+            HashMap::new();
+
+        for edge in self.graph.graph().edge_indices() {
+            let (node_a, node_b) = self.graph.graph().edge_endpoints(edge).ok_or_else(|| {
+                anyhow::anyhow!("split_to: current edge {:?} has missing endpoints", edge)
+            })?;
+            let current_a = self.graph.node_name(node_a).cloned().ok_or_else(|| {
+                anyhow::anyhow!("split_to: current edge {:?} has missing source node", edge)
+            })?;
+            let current_b = self.graph.node_name(node_b).cloned().ok_or_else(|| {
+                anyhow::anyhow!("split_to: current edge {:?} has missing target node", edge)
+            })?;
+            let bond_index = self.graph.graph().edge_weight(edge).ok_or_else(|| {
+                anyhow::anyhow!("split_to: current edge {:?} has no bond index", edge)
+            })?;
+
+            let mut crossing_edges = Vec::new();
+            for (target_a, target_b) in target.edges() {
+                let owner_a = target_to_current.get(&target_a).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "split_to: target edge references node {:?} without a current owner",
+                        target_a
+                    )
+                })?;
+                let owner_b = target_to_current.get(&target_b).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "split_to: target edge references node {:?} without a current owner",
+                        target_b
+                    )
+                })?;
+
+                if owner_a == &current_a && owner_b == &current_b {
+                    crossing_edges.push((target_a, target_b));
+                } else if owner_a == &current_b && owner_b == &current_a {
+                    crossing_edges.push((target_b, target_a));
+                }
+            }
+
+            let [(target_for_a, target_for_b)] = crossing_edges.as_slice() else {
+                return Err(anyhow::anyhow!(
+                    "split_to: expected exactly one target edge crossing current edge {:?}-{:?}, found {}",
+                    current_a,
+                    current_b,
+                    crossing_edges.len()
+                ));
+            };
+
+            boundary_indices
+                .entry(current_a)
+                .or_default()
+                .entry(target_for_a.clone())
+                .or_default()
+                .insert(bond_index.id().clone());
+            boundary_indices
+                .entry(current_b)
+                .or_default()
+                .entry(target_for_b.clone())
+                .or_default()
+                .insert(bond_index.id().clone());
+        }
+
+        Ok(boundary_indices)
+    }
+
     /// Split a tensor into multiple tensors, one for each target node.
     ///
     /// This uses QR factorization to iteratively separate site indices
@@ -397,6 +530,7 @@ where
         &self,
         tensor: &T,
         site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+        boundary_indices: Option<&HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>>>,
     ) -> Result<Vec<(TargetV, T)>>
     where
         TargetV: Clone + Hash + Eq + Ord + std::fmt::Debug,
@@ -411,6 +545,26 @@ where
                     .insert(idx.id().clone());
             }
             // Note: bond indices (not in site_to_target) are handled by factorize
+        }
+        if let Some(boundary_indices) = boundary_indices {
+            let tensor_index_ids: HashSet<_> = tensor
+                .external_indices()
+                .iter()
+                .map(|idx| idx.id().clone())
+                .collect();
+            for (target_name, index_ids) in boundary_indices {
+                let target_partition = partition.entry(target_name.clone()).or_default();
+                for index_id in index_ids {
+                    if !tensor_index_ids.contains(index_id) {
+                        return Err(anyhow::anyhow!(
+                            "split_to: boundary index {:?} is not present in the tensor for target {:?}",
+                            index_id,
+                            target_name
+                        ));
+                    }
+                    target_partition.insert(index_id.clone());
+                }
+            }
         }
 
         // Sort target names for deterministic processing

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -128,6 +128,42 @@ fn make_three_node_chain() -> (
     (tn, s0, s1, s2)
 }
 
+fn make_two_node_groups_of_two() -> (
+    TreeTN<TensorDynLen, String>,
+    DynIndex,
+    DynIndex,
+    DynIndex,
+    DynIndex,
+) {
+    let x0 = DynIndex::new_dyn(2);
+    let x1 = DynIndex::new_dyn(2);
+    let y0 = DynIndex::new_dyn(2);
+    let y1 = DynIndex::new_dyn(2);
+    let old_bond = DynIndex::new_dyn(2);
+
+    let left = TensorDynLen::from_dense(
+        vec![x0.clone(), x1.clone(), old_bond.clone()],
+        vec![1.0; 2 * 2 * 2],
+    )
+    .unwrap();
+    let right =
+        TensorDynLen::from_dense(vec![old_bond, y0.clone(), y1.clone()], vec![1.0; 2 * 2 * 2])
+            .unwrap();
+    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![left, right],
+        vec!["left".to_string(), "right".to_string()],
+    )
+    .unwrap();
+
+    (tn, x0, x1, y0, y1)
+}
+
+fn error_chain_contains(error: &anyhow::Error, needle: &str) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().contains(needle))
+}
+
 #[test]
 fn test_fuse_to_three_nodes_pairwise() {
     let (tn, s0, s1, s2) = make_three_node_chain();
@@ -229,6 +265,242 @@ fn test_split_to_with_actual_splitting() {
     let fused_full = fused.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
     assert!(fused_full.distance(&split_full) < 1e-12);
+}
+
+#[test]
+fn test_split_to_preserves_requested_chain_edges_across_original_bond() {
+    let (tn, s11, s12, s21, s22) = make_two_node_groups_of_two();
+
+    let mut target = SiteIndexNetwork::<usize, DynIndex>::new();
+    target.add_node(0, HashSet::from([s11.clone()])).unwrap();
+    target.add_node(1, HashSet::from([s12.clone()])).unwrap();
+    target.add_node(2, HashSet::from([s21.clone()])).unwrap();
+    target.add_node(3, HashSet::from([s22.clone()])).unwrap();
+    target.add_edge(&0, &1).unwrap();
+    target.add_edge(&1, &2).unwrap();
+    target.add_edge(&2, &3).unwrap();
+
+    let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
+
+    assert_eq!(split.node_count(), 4);
+    assert!(
+        split
+            .site_index_network()
+            .share_equivalent_site_index_network(&target),
+        "split_to must preserve the requested target site grouping and chain topology"
+    );
+}
+
+#[test]
+fn test_split_to_allows_edgeless_intermediate_fragments() {
+    let (tn, x0, x1, y0, y1) = make_two_node_groups_of_two();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target
+        .add_node("left_x".to_string(), HashSet::from([x0.clone()]))
+        .unwrap();
+    target
+        .add_node("left_y".to_string(), HashSet::from([x1.clone()]))
+        .unwrap();
+    target
+        .add_node("right_y".to_string(), HashSet::from([y0.clone()]))
+        .unwrap();
+    target
+        .add_node("right_z".to_string(), HashSet::from([y1.clone()]))
+        .unwrap();
+
+    let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
+
+    assert_eq!(split.node_count(), 4);
+    assert_eq!(
+        split
+            .site_index_network()
+            .find_node_by_index_id(x0.id())
+            .map(|name| name.as_str()),
+        Some("left_x")
+    );
+    assert_eq!(
+        split
+            .site_index_network()
+            .find_node_by_index_id(x1.id())
+            .map(|name| name.as_str()),
+        Some("left_y")
+    );
+    assert_eq!(
+        split
+            .site_index_network()
+            .find_node_by_index_id(y0.id())
+            .map(|name| name.as_str()),
+        Some("right_y")
+    );
+    assert_eq!(
+        split
+            .site_index_network()
+            .find_node_by_index_id(y1.id())
+            .map(|name| name.as_str()),
+        Some("right_z")
+    );
+    assert!(
+        tn.contract_to_tensor()
+            .unwrap()
+            .distance(&split.contract_to_tensor().unwrap())
+            < 1e-12
+    );
+}
+
+#[test]
+fn test_split_to_rejects_missing_explicit_target_boundary_edge() {
+    let (tn, x0, x1, y0, y1) = make_two_node_groups_of_two();
+
+    let mut target = SiteIndexNetwork::<usize, DynIndex>::new();
+    target.add_node(0, HashSet::from([x0])).unwrap();
+    target.add_node(1, HashSet::from([x1])).unwrap();
+    target.add_node(2, HashSet::from([y0])).unwrap();
+    target.add_node(3, HashSet::from([y1])).unwrap();
+    target.add_edge(&0, &1).unwrap();
+    target.add_edge(&2, &3).unwrap();
+
+    let error = tn.split_to(&target, &SplitOptions::default()).unwrap_err();
+
+    assert!(error_chain_contains(
+        &error,
+        "expected exactly one target edge crossing current edge"
+    ));
+}
+
+#[test]
+fn test_split_to_rejects_ambiguous_explicit_target_boundary_edges() {
+    let (tn, x0, x1, y0, y1) = make_two_node_groups_of_two();
+
+    let mut target = SiteIndexNetwork::<usize, DynIndex>::new();
+    target.add_node(0, HashSet::from([x0])).unwrap();
+    target.add_node(1, HashSet::from([x1])).unwrap();
+    target.add_node(2, HashSet::from([y0])).unwrap();
+    target.add_node(3, HashSet::from([y1])).unwrap();
+    target.add_edge(&0, &2).unwrap();
+    target.add_edge(&1, &3).unwrap();
+
+    let error = tn.split_to(&target, &SplitOptions::default()).unwrap_err();
+
+    assert!(error_chain_contains(
+        &error,
+        "expected exactly one target edge crossing current edge"
+    ));
+}
+
+#[test]
+fn test_fuse_to_rejects_ambiguous_current_node_mapping() {
+    let (tn, s0, s1) = make_two_node_chain();
+
+    let mut fuse_target = SiteIndexNetwork::<String, DynIndex>::new();
+    fuse_target
+        .add_node("AB".to_string(), HashSet::from([s0.clone(), s1.clone()]))
+        .unwrap();
+    let fused = tn.fuse_to(&fuse_target).unwrap();
+
+    let mut incompatible_target = SiteIndexNetwork::<String, DynIndex>::new();
+    incompatible_target
+        .add_node("A".to_string(), HashSet::from([s0.clone()]))
+        .unwrap();
+    incompatible_target
+        .add_node("B".to_string(), HashSet::from([s1.clone()]))
+        .unwrap();
+    incompatible_target
+        .add_edge(&"A".to_string(), &"B".to_string())
+        .unwrap();
+
+    let error = fused.fuse_to(&incompatible_target).unwrap_err();
+
+    assert!(error_chain_contains(&error, "ambiguous mapping"));
+}
+
+#[test]
+fn test_fuse_to_rejects_disconnected_current_group() {
+    let (tn, s0, s1, s2) = make_three_node_chain();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target
+        .add_node("AC".to_string(), HashSet::from([s0.clone(), s2.clone()]))
+        .unwrap();
+    target
+        .add_node("B".to_string(), HashSet::from([s1.clone()]))
+        .unwrap();
+    target
+        .add_edge(&"AC".to_string(), &"B".to_string())
+        .unwrap();
+
+    let error = tn.fuse_to(&target).unwrap_err();
+
+    assert!(error_chain_contains(&error, "failed to contract nodes"));
+    assert!(error_chain_contains(&error, "connected subtree"));
+}
+
+#[test]
+fn test_split_to_identity_preserves_explicit_edge() {
+    let (tn, s0, s1) = make_two_node_chain();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target
+        .add_node("A".to_string(), HashSet::from([s0.clone()]))
+        .unwrap();
+    target
+        .add_node("B".to_string(), HashSet::from([s1.clone()]))
+        .unwrap();
+    target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+
+    let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
+
+    assert_eq!(split.node_count(), 2);
+    assert!(split
+        .site_index_network()
+        .share_equivalent_site_index_network(&target));
+    assert!(
+        tn.contract_to_tensor()
+            .unwrap()
+            .distance(&split.contract_to_tensor().unwrap())
+            < 1e-12
+    );
+}
+
+#[test]
+fn test_split_to_rejects_target_node_spanning_current_nodes() {
+    let (tn, x0, x1, y0, y1) = make_two_node_groups_of_two();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target
+        .add_node("mixed".to_string(), HashSet::from([x0.clone(), y0.clone()]))
+        .unwrap();
+    target
+        .add_node("left_tail".to_string(), HashSet::from([x1.clone()]))
+        .unwrap();
+    target
+        .add_node("right_tail".to_string(), HashSet::from([y1.clone()]))
+        .unwrap();
+
+    let error = tn.split_to(&target, &SplitOptions::default()).unwrap_err();
+
+    assert!(error_chain_contains(&error, "spans multiple current nodes"));
+}
+
+#[test]
+fn test_split_to_rejects_current_site_missing_from_target() {
+    let (tn, s0, _s1) = make_two_node_chain();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target
+        .add_node("A".to_string(), HashSet::from([s0.clone()]))
+        .unwrap();
+
+    let error = tn.split_to(&target, &SplitOptions::default()).unwrap_err();
+
+    assert!(error_chain_contains(
+        &error,
+        "has no corresponding target node"
+    ));
+    assert!(error_chain_contains(
+        &error,
+        "incompatible target structure"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix `TreeTN::split_to` so split-only restructuring preserves explicitly requested target edges across an original bond.

This addresses the Rust-side root cause behind tensor4all/Tensor4all.jl#76: the C API receives the requested target chain edges, but the Rust split path previously let the old current bond remain attached to the wrong target fragments and then relied on `TreeTN::from_tensors` to infer topology from shared indices.

## Changes

- Assign each current boundary bond to the target fragments connected by the corresponding target edge before factorizing a current tensor.
- Preserve the existing edge-less intermediate split behavior used by the conservative `SplitThenFuse` mixed restructure path.
- Add regressions covering the requested four-node chain, edgeless intermediate split fragments, invalid explicit target topologies with missing or ambiguous boundary edges, and additional error/no-op branches that protect the transform coverage gate.

## Coverage

The focused transform test set now has 19 tests and covers the new explicit-target-edge success path, the edgeless intermediate compatibility path, both `0` and `>1` crossing-edge error paths, identity split with an explicit edge, ambiguous fuse mappings, disconnected fuse groups, target nodes spanning multiple current nodes, and missing target-site mappings.

Local coverage checks:

- Focused transform coverage: `transform.rs` at `332/415 = 80.00%` line coverage.
- Workspace coverage gate: `Coverage check: 148/148 files passed`.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo test --release -p tensor4all-treetn treetn::transform::tests -- --nocapture`
- `cargo llvm-cov --release -p tensor4all-treetn --lib --summary-only --json --output-path target/llvm-cov-transform-summary.json -- treetn::transform::tests`
- `cargo llvm-cov --workspace --exclude tensor4all-hdf5 --json --output-path target/coverage-pr449.json && python3 scripts/check-coverage.py target/coverage-pr449.json`
- `cargo test --release -p tensor4all-capi test_treetn_restructure_to_mixed_case -- --nocapture`
- `cargo nextest run --release --workspace`
- `cargo doc --workspace --no-deps`

## Notes

The broader virtual-scaffold cost-descent algorithm discussed in tensor4all/Tensor4all.jl#76 is not implemented here. That should remain a fallback for mixed topology-changing restructures that the current simple planner cannot cover.