### PR TITLE
fix(treetn): split_to chain topology and general tree decomposition

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -149,3 +149,14 @@
 
 - Prefer `mdarray` for arrays and `mdarray-linalg` for linear algebra.
 - SVD singular values use `s[[0, i]]`, not `s[[i, i]]`.
+
+## Graph Algorithms
+
+- Always use `petgraph` for graph traversals (DFS, BFS, topological sort, post-order),
+  connectivity checks, path finding, and tree structure queries.
+- Do **not** write manual `O(N)` graph algorithms with raw adjacency lists
+  or hand-rolled recursion. `petgraph` provides efficient, tested, and audited
+  implementations.
+- For tree-specific operations (children, parent, subtree), delegate to
+  `node_name_network::NodeNameNetwork` or `site_index_network::SiteIndexNetwork`
+  which wrap `petgraph`.

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -401,10 +401,7 @@ where
                 result_tensors.push((target_name, tensor.clone()));
             } else {
                 // Need to split this node
-                let fragment_target = build_fragment_sub_target(
-                    target,
-                    targets_for_node,
-                )?;
+                let fragment_target = build_fragment_sub_target(target, targets_for_node)?;
                 let split_tensors = self
                     .split_tensor_for_targets(
                         tensor,
@@ -594,8 +591,8 @@ where
             }
         }
 
-        let mut target_names: Vec<TargetV> = fragment_target.node_names()
-            .into_iter().cloned().collect();
+        let mut target_names: Vec<TargetV> =
+            fragment_target.node_names().into_iter().cloned().collect();
         target_names.sort();
 
         if target_names.len() <= 1 {
@@ -784,9 +781,9 @@ where
 {
     let mut sub = SiteIndexNetwork::with_capacity(fragment_names.len(), 0);
     for name in fragment_names {
-        let site_space = target.site_space(name).ok_or_else(|| {
-            anyhow::anyhow!("Fragment node {:?} not found in target", name)
-        })?;
+        let site_space = target
+            .site_space(name)
+            .ok_or_else(|| anyhow::anyhow!("Fragment node {:?} not found in target", name))?;
         sub.add_node(name.clone(), site_space.clone())
             .map_err(anyhow::Error::msg)?;
     }

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -592,6 +592,15 @@ where
         // Collect all site index IDs to distinguish inherited bond indices
         let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
 
+        // Record original tensor index IDs to distinguish inherited bonds
+        // (created by QR during the split) from original current-tree bonds
+        // (present on the original tensor before any QR factorization).
+        let original_index_ids: HashSet<_> = tensor
+            .external_indices()
+            .iter()
+            .map(|idx| idx.id().clone())
+            .collect();
+
         // Sort target names for deterministic processing
         let mut target_names: Vec<TargetV> = partition.keys().cloned().collect();
         target_names.sort();
@@ -621,13 +630,18 @@ where
                 .cloned()
                 .collect();
 
-            // Include inherited bond indices so they are forwarded to the
-            // current target instead of accumulating on the last target.
+            // Include inherited bond indices created by previous QR steps.
+            // Exclude original current-tree bonds — they are routed via the
+            // boundary_indices mechanism when target edges are present, and
+            // should be left on the remaining tensor otherwise.
             left_inds.extend(
                 remaining_tensor
                     .external_indices()
                     .iter()
-                    .filter(|idx| !all_site_ids.contains(idx.id()))
+                    .filter(|idx| {
+                        let id = idx.id();
+                        !all_site_ids.contains(id) && !original_index_ids.contains(id)
+                    })
                     .cloned(),
             );
 

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -567,6 +567,9 @@ where
             }
         }
 
+        // Collect all site index IDs to distinguish inherited bond indices
+        let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
+
         // Sort target names for deterministic processing
         let mut target_names: Vec<TargetV> = partition.keys().cloned().collect();
         target_names.sort();
@@ -588,13 +591,23 @@ where
         for target_name in target_names.iter().take(target_names.len() - 1) {
             let site_ids_for_target = partition.get(target_name).unwrap();
 
-            // Find the actual Index objects for these site IDs
-            let left_inds: Vec<_> = remaining_tensor
+            // Find site indices for this target
+            let mut left_inds: Vec<_> = remaining_tensor
                 .external_indices()
                 .iter()
                 .filter(|idx| site_ids_for_target.contains(idx.id()))
                 .cloned()
                 .collect();
+
+            // Include inherited bond indices so they are forwarded to the
+            // current target instead of accumulating on the last target.
+            left_inds.extend(
+                remaining_tensor
+                    .external_indices()
+                    .iter()
+                    .filter(|idx| !all_site_ids.contains(idx.id()))
+                    .cloned(),
+            );
 
             if left_inds.is_empty() {
                 continue;

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -427,7 +427,29 @@ where
         let result = TreeTN::<T, TargetV>::from_tensors(tensors, names)
             .context("split_to: failed to build result TreeTN")?;
 
-        // Step 5: Phase 2 - Optional truncation sweep
+        // Step 5: Validate result topology matches target
+        // Skip validation if target has no edges (caller doesn't care about topology)
+        if target.edge_count() > 0
+            && !result
+                .site_index_network()
+                .share_equivalent_site_index_network(target)
+        {
+            return Err(anyhow::anyhow!(
+                "split_to: result topology does not match target: \
+                 expected edges {:?}, got {:?}",
+                target
+                    .edges()
+                    .map(|(a, b)| (a.clone(), b.clone()))
+                    .collect::<Vec<_>>(),
+                result
+                    .site_index_network()
+                    .edges()
+                    .map(|(a, b)| (a.clone(), b.clone()))
+                    .collect::<Vec<_>>(),
+            ));
+        }
+
+        // Step 6: Phase 2 - Optional truncation sweep
         if options.final_sweep {
             // Find a center node for truncation
             let center = result.node_names().into_iter().min().ok_or_else(|| {

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use petgraph::stable_graph::NodeIndex;
 
 use tensor4all_core::{
-    AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike,
+    index_ops, AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike,
 };
 
 use super::TreeTN;
@@ -401,11 +401,16 @@ where
                 result_tensors.push((target_name, tensor.clone()));
             } else {
                 // Need to split this node
+                let fragment_target = build_fragment_sub_target(
+                    target,
+                    targets_for_node,
+                )?;
                 let split_tensors = self
                     .split_tensor_for_targets(
                         tensor,
                         &site_to_target,
                         boundary_indices.get(&current_node_name),
+                        &fragment_target,
                     )
                     .with_context(|| {
                         format!("split_to: failed to split node {:?}", current_node_name)
@@ -542,20 +547,21 @@ where
         Ok(boundary_indices)
     }
 
-    /// Split a tensor into multiple tensors, one for each target node.
+    /// Split a tensor into multiple tensors using post-order tree decomposition.
     ///
-    /// This uses QR factorization to iteratively separate site indices
-    /// belonging to different target nodes.
-    ///
-    /// Returns a vector of (target_name, tensor) pairs.
+    /// This uses QR factorization following the target sub-topology (edges between
+    /// fragment nodes within the current node). The algorithm mirrors
+    /// `factorize_tensor_to_treetn_with_root_impl`: process leaves first, include
+    /// child bonds in `left_inds`, root gets the remaining tensor.
     fn split_tensor_for_targets<TargetV>(
         &self,
         tensor: &T,
         site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
         boundary_indices: Option<&HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>>>,
+        fragment_target: &SiteIndexNetwork<TargetV, T::Index>,
     ) -> Result<Vec<(TargetV, T)>>
     where
-        TargetV: Clone + Hash + Eq + Ord + std::fmt::Debug,
+        TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     {
         // Group tensor's site indices by their target node
         let mut partition: HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>> = HashMap::new();
@@ -566,7 +572,6 @@ where
                     .or_default()
                     .insert(idx.id().clone());
             }
-            // Note: bond indices (not in site_to_target) are handled by factorize
         }
         if let Some(boundary_indices) = boundary_indices {
             let tensor_index_ids: HashSet<_> = tensor
@@ -589,67 +594,94 @@ where
             }
         }
 
-        // Collect all site index IDs to distinguish inherited bond indices
-        let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
-
-        // Record original tensor index IDs to distinguish inherited bonds
-        // (created by QR during the split) from original current-tree bonds
-        // (present on the original tensor before any QR factorization).
-        let original_index_ids: HashSet<_> = tensor
-            .external_indices()
-            .iter()
-            .map(|idx| idx.id().clone())
-            .collect();
-
-        // Sort target names for deterministic processing
-        let mut target_names: Vec<TargetV> = partition.keys().cloned().collect();
+        let mut target_names: Vec<TargetV> = fragment_target.node_names()
+            .into_iter().cloned().collect();
         target_names.sort();
 
         if target_names.len() <= 1 {
-            // Should not happen if called correctly, but handle gracefully
-            let target_name = target_names
+            let name = target_names
                 .first()
                 .cloned()
-                .ok_or_else(|| anyhow::anyhow!("No site indices found in tensor"))?;
-            return Ok(vec![(target_name, tensor.clone())]);
+                .ok_or_else(|| anyhow::anyhow!("No target nodes found for this tensor"))?;
+            return Ok(vec![(name, tensor.clone())]);
         }
 
-        // Split iteratively: separate first target's indices, then next, etc.
+        // For edgeless targets, fall back to sequential QR (caller doesn't
+        // care about topology, any decomposition is acceptable).
+        if fragment_target.edge_count() == 0 {
+            return self.split_tensor_for_targets_sequential(tensor, &partition, &target_names);
+        }
+
+        // Choose root: prefer the fragment with boundary indices (those need
+        // to be on the root so the original bond connects correctly).
+        let root = if let Some(bi) = boundary_indices {
+            if let Some((name, _)) = bi.iter().max_by_key(|(_, ids)| ids.len()) {
+                if fragment_target.node_names().iter().any(|n| *n == name) {
+                    name.clone()
+                } else {
+                    target_names[0].clone()
+                }
+            } else {
+                target_names[0].clone()
+            }
+        } else {
+            target_names[0].clone()
+        };
+
+        // Post-order traversal (leaves first, root last) via petgraph DfsPostOrder
+        let traversal = fragment_target
+            .post_order_dfs(&root)
+            .ok_or_else(|| anyhow::anyhow!("Root {:?} not found in fragment target", root))?;
+
+        // Build children_by_parent from target edges. The endpoint closer to
+        // the root (higher position in post-order) is the parent.
+        let mut children_by_parent: HashMap<TargetV, Vec<TargetV>> = HashMap::new();
+        for (ref parent_name, ref child_name) in fragment_target.edges() {
+            let pos_a = traversal.iter().position(|n| *n == *parent_name).unwrap();
+            let pos_b = traversal.iter().position(|n| *n == *child_name).unwrap();
+            if pos_a > pos_b {
+                children_by_parent
+                    .entry(parent_name.clone())
+                    .or_default()
+                    .push(child_name.clone());
+            } else {
+                children_by_parent
+                    .entry(child_name.clone())
+                    .or_default()
+                    .push(parent_name.clone());
+            }
+        }
+
+        // Process nodes in post-order (skip root — it gets the remaining tensor)
         let mut remaining_tensor = tensor.clone();
         let mut result: Vec<(TargetV, T)> = Vec::new();
+        let mut child_bonds: HashMap<TargetV, <T::Index as IndexLike>::Id> = HashMap::new();
 
-        // Process all but the last target (the last one gets the remaining tensor)
-        for target_name in target_names.iter().take(target_names.len() - 1) {
-            let site_ids_for_target = partition.get(target_name).unwrap();
+        for node in traversal.iter().take(traversal.len() - 1) {
+            let node_ids = partition.get(node).cloned().unwrap_or_default();
+            let current_indices = remaining_tensor.external_indices();
 
-            // Find site indices for this target
-            let mut left_inds: Vec<_> = remaining_tensor
-                .external_indices()
+            // Build set of desired index IDs: this node's site+boundary indices
+            // plus bonds from already-processed children.
+            let mut desired_ids = node_ids;
+            if let Some(children) = children_by_parent.get(node) {
+                for child in children {
+                    if let Some(bond_id) = child_bonds.get(child) {
+                        desired_ids.insert(bond_id.clone());
+                    }
+                }
+            }
+
+            let left_inds: Vec<_> = current_indices
                 .iter()
-                .filter(|idx| site_ids_for_target.contains(idx.id()))
+                .filter(|idx| desired_ids.contains(idx.id()))
                 .cloned()
                 .collect();
-
-            // Include inherited bond indices created by previous QR steps.
-            // Exclude original current-tree bonds — they are routed via the
-            // boundary_indices mechanism when target edges are present, and
-            // should be left on the remaining tensor otherwise.
-            left_inds.extend(
-                remaining_tensor
-                    .external_indices()
-                    .iter()
-                    .filter(|idx| {
-                        let id = idx.id();
-                        !all_site_ids.contains(id) && !original_index_ids.contains(id)
-                    })
-                    .cloned(),
-            );
 
             if left_inds.is_empty() {
                 continue;
             }
 
-            // Factorize: separate these site indices
             let factorize_options = FactorizeOptions {
                 alg: FactorizeAlg::QR,
                 canonical: Canonical::Left,
@@ -662,19 +694,108 @@ where
                 .factorize(&left_inds, &factorize_options)
                 .map_err(|e| anyhow::anyhow!("Factorization failed: {:?}", e))?;
 
-            // Left tensor gets the separated indices
-            result.push((target_name.clone(), factorize_result.left));
+            // Detect the parent bond (shared between left and right tensors)
+            let left_indices = factorize_result.left.external_indices();
+            let right_indices = factorize_result.right.external_indices();
+            let shared = index_ops::common_inds(&left_indices, &right_indices);
+            if shared.len() != 1 {
+                return Err(anyhow::anyhow!(
+                    "Expected exactly one bond for node {:?}, found {}",
+                    node,
+                    shared.len()
+                ));
+            }
+            child_bonds.insert(node.clone(), shared[0].id().clone());
 
-            // Right tensor becomes the remaining tensor for next iteration
+            result.push((node.clone(), factorize_result.left));
             remaining_tensor = factorize_result.right;
         }
 
-        // The last target gets the remaining tensor
-        let last_target = target_names.last().unwrap().clone();
-        result.push((last_target, remaining_tensor));
+        // Root gets the remaining tensor with all child bonds
+        let root_name = traversal.last().unwrap();
+        result.push((root_name.clone(), remaining_tensor));
 
         Ok(result)
     }
+
+    /// Sequential QR fallback for edgeless targets.
+    ///
+    /// Processes targets in sorted order, peeling each via QR. The last target
+    /// accumulates all bonds (star topology). This is acceptable when the caller
+    /// does not specify target edges.
+    fn split_tensor_for_targets_sequential<TargetV>(
+        &self,
+        tensor: &T,
+        partition: &HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>>,
+        target_names: &[TargetV],
+    ) -> Result<Vec<(TargetV, T)>>
+    where
+        TargetV: Clone + Hash + Eq + Ord + std::fmt::Debug,
+    {
+        let mut remaining_tensor = tensor.clone();
+        let mut result: Vec<(TargetV, T)> = Vec::new();
+
+        for target_name in target_names.iter().take(target_names.len() - 1) {
+            let site_ids_for_target = partition.get(target_name).unwrap();
+
+            let left_inds: Vec<_> = remaining_tensor
+                .external_indices()
+                .iter()
+                .filter(|idx| site_ids_for_target.contains(idx.id()))
+                .cloned()
+                .collect();
+
+            if left_inds.is_empty() {
+                continue;
+            }
+
+            let factorize_options = FactorizeOptions {
+                alg: FactorizeAlg::QR,
+                canonical: Canonical::Left,
+                max_rank: None,
+                svd_policy: None,
+                qr_rtol: None,
+            };
+
+            let factorize_result = remaining_tensor
+                .factorize(&left_inds, &factorize_options)
+                .map_err(|e| anyhow::anyhow!("Factorization failed: {:?}", e))?;
+
+            result.push((target_name.clone(), factorize_result.left));
+            remaining_tensor = factorize_result.right;
+        }
+
+        let last_target = target_names.last().unwrap();
+        result.push((last_target.clone(), remaining_tensor));
+
+        Ok(result)
+    }
+}
+
+/// Build a sub-`SiteIndexNetwork` containing only the fragment nodes that
+/// belong to a given current node, preserving edges between them.
+fn build_fragment_sub_target<TargetV, I>(
+    target: &SiteIndexNetwork<TargetV, I>,
+    fragment_names: &HashSet<TargetV>,
+) -> Result<SiteIndexNetwork<TargetV, I>>
+where
+    TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    I: IndexLike,
+{
+    let mut sub = SiteIndexNetwork::with_capacity(fragment_names.len(), 0);
+    for name in fragment_names {
+        let site_space = target.site_space(name).ok_or_else(|| {
+            anyhow::anyhow!("Fragment node {:?} not found in target", name)
+        })?;
+        sub.add_node(name.clone(), site_space.clone())
+            .map_err(anyhow::Error::msg)?;
+    }
+    for (a, b) in target.edges() {
+        if fragment_names.contains(&a) && fragment_names.contains(&b) {
+            sub.add_edge(&a, &b).map_err(anyhow::Error::msg)?;
+        }
+    }
+    Ok(sub)
 }
 
 // Tests are disabled until random module is refactored

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -613,7 +613,7 @@ where
         // to be on the root so the original bond connects correctly).
         let root = if let Some(bi) = boundary_indices {
             if let Some((name, _)) = bi.iter().max_by_key(|(_, ids)| ids.len()) {
-                if fragment_target.node_names().iter().any(|n| *n == name) {
+                if fragment_target.node_names().contains(&name) {
                     name.clone()
                 } else {
                     target_names[0].clone()

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -587,7 +587,13 @@ fn test_fuse_identity_mapping() {
     assert!(orig_full.distance(&fused_full) < 1e-12);
 }
 
-fn make_four_site_fused_node() -> (TreeTN<TensorDynLen, String>, DynIndex, DynIndex, DynIndex, DynIndex) {
+fn make_four_site_fused_node() -> (
+    TreeTN<TensorDynLen, String>,
+    DynIndex,
+    DynIndex,
+    DynIndex,
+    DynIndex,
+) {
     let s_a = DynIndex::new_dyn(2);
     let s_b = DynIndex::new_dyn(2);
     let s_c = DynIndex::new_dyn(2);
@@ -607,10 +613,18 @@ fn test_split_to_y_shape() {
     let (tn, s_a, s_b, s_c, s_d) = make_four_site_fused_node();
 
     let mut target = SiteIndexNetwork::<String, DynIndex>::new();
-    target.add_node("A".to_string(), HashSet::from([s_a.clone()])).unwrap();
-    target.add_node("B".to_string(), HashSet::from([s_b.clone()])).unwrap();
-    target.add_node("C".to_string(), HashSet::from([s_c.clone()])).unwrap();
-    target.add_node("D".to_string(), HashSet::from([s_d.clone()])).unwrap();
+    target
+        .add_node("A".to_string(), HashSet::from([s_a.clone()]))
+        .unwrap();
+    target
+        .add_node("B".to_string(), HashSet::from([s_b.clone()]))
+        .unwrap();
+    target
+        .add_node("C".to_string(), HashSet::from([s_c.clone()]))
+        .unwrap();
+    target
+        .add_node("D".to_string(), HashSet::from([s_d.clone()]))
+        .unwrap();
     target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
     target.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
     target.add_edge(&"B".to_string(), &"D".to_string()).unwrap();
@@ -618,7 +632,9 @@ fn test_split_to_y_shape() {
     let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
     assert_eq!(split.node_count(), 4);
     assert!(
-        split.site_index_network().share_equivalent_site_index_network(&target),
+        split
+            .site_index_network()
+            .share_equivalent_site_index_network(&target),
         "Y-shape topology must be preserved",
     );
 
@@ -632,10 +648,18 @@ fn test_split_to_nested_tree() {
     let (tn, s_a, s_b, s_c, s_d) = make_four_site_fused_node();
 
     let mut target = SiteIndexNetwork::<String, DynIndex>::new();
-    target.add_node("A".to_string(), HashSet::from([s_a.clone()])).unwrap();
-    target.add_node("B".to_string(), HashSet::from([s_b.clone()])).unwrap();
-    target.add_node("C".to_string(), HashSet::from([s_c.clone()])).unwrap();
-    target.add_node("D".to_string(), HashSet::from([s_d.clone()])).unwrap();
+    target
+        .add_node("A".to_string(), HashSet::from([s_a.clone()]))
+        .unwrap();
+    target
+        .add_node("B".to_string(), HashSet::from([s_b.clone()]))
+        .unwrap();
+    target
+        .add_node("C".to_string(), HashSet::from([s_c.clone()]))
+        .unwrap();
+    target
+        .add_node("D".to_string(), HashSet::from([s_d.clone()]))
+        .unwrap();
     target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
     target.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
     target.add_edge(&"C".to_string(), &"D".to_string()).unwrap();
@@ -643,7 +667,9 @@ fn test_split_to_nested_tree() {
     let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
     assert_eq!(split.node_count(), 4);
     assert!(
-        split.site_index_network().share_equivalent_site_index_network(&target),
+        split
+            .site_index_network()
+            .share_equivalent_site_index_network(&target),
         "nested tree topology must be preserved"
     );
 
@@ -658,17 +684,29 @@ fn test_split_to_y_shape_across_original_bond() {
 
     // Fuse both nodes into one first
     let mut fuse_target = SiteIndexNetwork::<String, DynIndex>::new();
-    fuse_target.add_node("F".to_string(),
-        HashSet::from([x0.clone(), x1.clone(), y0.clone(), y1.clone()])).unwrap();
+    fuse_target
+        .add_node(
+            "F".to_string(),
+            HashSet::from([x0.clone(), x1.clone(), y0.clone(), y1.clone()]),
+        )
+        .unwrap();
     let fused = tn.fuse_to(&fuse_target).unwrap();
 
     // Y-shape: A(x0)--B(x1)--C(y0)--D(y1) → chain is just chain, not Y
     // Let's do: A(x0)-B(x1), B(x1)-C(y0), B(x1)-D(y1) with all sites in one node first
     let mut target = SiteIndexNetwork::<String, DynIndex>::new();
-    target.add_node("A".to_string(), HashSet::from([x0.clone()])).unwrap();
-    target.add_node("B".to_string(), HashSet::from([x1.clone()])).unwrap();
-    target.add_node("C".to_string(), HashSet::from([y0.clone()])).unwrap();
-    target.add_node("D".to_string(), HashSet::from([y1.clone()])).unwrap();
+    target
+        .add_node("A".to_string(), HashSet::from([x0.clone()]))
+        .unwrap();
+    target
+        .add_node("B".to_string(), HashSet::from([x1.clone()]))
+        .unwrap();
+    target
+        .add_node("C".to_string(), HashSet::from([y0.clone()]))
+        .unwrap();
+    target
+        .add_node("D".to_string(), HashSet::from([y1.clone()]))
+        .unwrap();
     target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
     target.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
     target.add_edge(&"B".to_string(), &"D".to_string()).unwrap();
@@ -676,7 +714,9 @@ fn test_split_to_y_shape_across_original_bond() {
     let split = fused.split_to(&target, &SplitOptions::default()).unwrap();
     assert_eq!(split.node_count(), 4);
     assert!(
-        split.site_index_network().share_equivalent_site_index_network(&target),
+        split
+            .site_index_network()
+            .share_equivalent_site_index_network(&target),
         "Y-shape from fused node must be preserved"
     );
 

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -586,3 +586,101 @@ fn test_fuse_identity_mapping() {
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(orig_full.distance(&fused_full) < 1e-12);
 }
+
+fn make_four_site_fused_node() -> (TreeTN<TensorDynLen, String>, DynIndex, DynIndex, DynIndex, DynIndex) {
+    let s_a = DynIndex::new_dyn(2);
+    let s_b = DynIndex::new_dyn(2);
+    let s_c = DynIndex::new_dyn(2);
+    let s_d = DynIndex::new_dyn(2);
+    let t = TensorDynLen::from_dense(
+        vec![s_a.clone(), s_b.clone(), s_c.clone(), s_d.clone()],
+        vec![1.0; 16],
+    )
+    .unwrap();
+    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    tn.add_tensor("fused".to_string(), t).unwrap();
+    (tn, s_a, s_b, s_c, s_d)
+}
+
+#[test]
+fn test_split_to_y_shape() {
+    let (tn, s_a, s_b, s_c, s_d) = make_four_site_fused_node();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target.add_node("A".to_string(), HashSet::from([s_a.clone()])).unwrap();
+    target.add_node("B".to_string(), HashSet::from([s_b.clone()])).unwrap();
+    target.add_node("C".to_string(), HashSet::from([s_c.clone()])).unwrap();
+    target.add_node("D".to_string(), HashSet::from([s_d.clone()])).unwrap();
+    target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    target.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+    target.add_edge(&"B".to_string(), &"D".to_string()).unwrap();
+
+    let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
+    assert_eq!(split.node_count(), 4);
+    assert!(
+        split.site_index_network().share_equivalent_site_index_network(&target),
+        "Y-shape topology must be preserved",
+    );
+
+    let full = tn.contract_to_tensor().unwrap();
+    let split_full = split.contract_to_tensor().unwrap();
+    assert!(full.distance(&split_full) < 1e-12);
+}
+
+#[test]
+fn test_split_to_nested_tree() {
+    let (tn, s_a, s_b, s_c, s_d) = make_four_site_fused_node();
+
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target.add_node("A".to_string(), HashSet::from([s_a.clone()])).unwrap();
+    target.add_node("B".to_string(), HashSet::from([s_b.clone()])).unwrap();
+    target.add_node("C".to_string(), HashSet::from([s_c.clone()])).unwrap();
+    target.add_node("D".to_string(), HashSet::from([s_d.clone()])).unwrap();
+    target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    target.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+    target.add_edge(&"C".to_string(), &"D".to_string()).unwrap();
+
+    let split = tn.split_to(&target, &SplitOptions::default()).unwrap();
+    assert_eq!(split.node_count(), 4);
+    assert!(
+        split.site_index_network().share_equivalent_site_index_network(&target),
+        "nested tree topology must be preserved"
+    );
+
+    let full = tn.contract_to_tensor().unwrap();
+    let split_full = split.contract_to_tensor().unwrap();
+    assert!(full.distance(&split_full) < 1e-12);
+}
+
+#[test]
+fn test_split_to_y_shape_across_original_bond() {
+    let (tn, x0, x1, y0, y1) = make_two_node_groups_of_two();
+
+    // Fuse both nodes into one first
+    let mut fuse_target = SiteIndexNetwork::<String, DynIndex>::new();
+    fuse_target.add_node("F".to_string(),
+        HashSet::from([x0.clone(), x1.clone(), y0.clone(), y1.clone()])).unwrap();
+    let fused = tn.fuse_to(&fuse_target).unwrap();
+
+    // Y-shape: A(x0)--B(x1)--C(y0)--D(y1) → chain is just chain, not Y
+    // Let's do: A(x0)-B(x1), B(x1)-C(y0), B(x1)-D(y1) with all sites in one node first
+    let mut target = SiteIndexNetwork::<String, DynIndex>::new();
+    target.add_node("A".to_string(), HashSet::from([x0.clone()])).unwrap();
+    target.add_node("B".to_string(), HashSet::from([x1.clone()])).unwrap();
+    target.add_node("C".to_string(), HashSet::from([y0.clone()])).unwrap();
+    target.add_node("D".to_string(), HashSet::from([y1.clone()])).unwrap();
+    target.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
+    target.add_edge(&"B".to_string(), &"C".to_string()).unwrap();
+    target.add_edge(&"B".to_string(), &"D".to_string()).unwrap();
+
+    let split = fused.split_to(&target, &SplitOptions::default()).unwrap();
+    assert_eq!(split.node_count(), 4);
+    assert!(
+        split.site_index_network().share_equivalent_site_index_network(&target),
+        "Y-shape from fused node must be preserved"
+    );
+
+    let full = fused.contract_to_tensor().unwrap();
+    let split_full = split.contract_to_tensor().unwrap();
+    assert!(full.distance(&split_full) < 1e-12);
+}

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -261,6 +261,12 @@ fn test_split_to_with_actual_splitting() {
         .split_to(&split_target, &SplitOptions::default())
         .unwrap();
     assert_eq!(split.node_count(), 3);
+    assert!(
+        split
+            .site_index_network()
+            .share_equivalent_site_index_network(&split_target),
+        "split_to must preserve the requested chain topology, not silently produce a star/tree"
+    );
 
     let fused_full = fused.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();

--- a/docs/superpowers/plans/2026-04-25-split-to-chain-topology-fix.md
+++ b/docs/superpowers/plans/2026-04-25-split-to-chain-topology-fix.md
@@ -17,7 +17,7 @@
 
 - [ ] **Step 1: Precompute `all_site_ids` and extend `left_inds` with inherited bonds**
 
-After `partition` is fully built (after the `if let Some(boundary_indices)` block, currently at line 568 `}`), add `all_site_ids` computation:
+After `partition` is fully built (after the `if let Some(boundary_indices)` block, currently at line 568 `}`), add `all_site_ids` and `original_index_ids` computation:
 
 ```rust
         }
@@ -25,10 +25,18 @@ After `partition` is fully built (after the `if let Some(boundary_indices)` bloc
         // Collect all site index IDs to distinguish inherited bond indices
         let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
 
+        // Record original tensor index IDs to distinguish inherited bonds
+        // (created by QR during the split) from original current-tree bonds.
+        let original_index_ids: HashSet<_> = tensor
+            .external_indices()
+            .iter()
+            .map(|idx| idx.id().clone())
+            .collect();
+
         // Sort target names for deterministic processing
 ```
 
-Then in the loop body, replace `let left_inds: Vec<_> = ...` block (lines 592-597) with:
+Then in the loop body, replace `let left_inds: Vec<_> = ...` block with:
 
 ```rust
             // Find site indices for this target
@@ -39,13 +47,17 @@ Then in the loop body, replace `let left_inds: Vec<_> = ...` block (lines 592-59
                 .cloned()
                 .collect();
 
-            // Include inherited bond indices so they are forwarded to the
-            // current target instead of accumulating on the last target.
+            // Include inherited bond indices created by previous QR steps.
+            // Exclude original current-tree bonds — they are routed via the
+            // boundary_indices mechanism when target edges are present.
             left_inds.extend(
                 remaining_tensor
                     .external_indices()
                     .iter()
-                    .filter(|idx| !all_site_ids.contains(idx.id()))
+                    .filter(|idx| {
+                        let id = idx.id();
+                        !all_site_ids.contains(id) && !original_index_ids.contains(id)
+                    })
                     .cloned(),
             );
 ```

--- a/docs/superpowers/plans/2026-04-25-split-to-chain-topology-fix.md
+++ b/docs/superpowers/plans/2026-04-25-split-to-chain-topology-fix.md
@@ -1,0 +1,193 @@
+# split_to chain topology fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `split_tensor_for_targets` to produce correct chain topology by including inherited bond indices in `left_inds`; add topology validation to `split_to`.
+
+**Architecture:** In `split_tensor_for_targets`, precompute the set of all site index IDs. In each QR peeling step, extend `left_inds` with indices that are not site indices (inherited bonds). Add defense-in-depth validation in `split_to`.
+
+**Tech Stack:** Rust, tensor4all-core (TensorLike, IndexLike, FactorizeOptions, Canonical)
+
+---
+
+### Task 1: Fix `split_tensor_for_targets` — include inherited bond indices in `left_inds`
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/transform.rs:568-597`
+
+- [ ] **Step 1: Precompute `all_site_ids` and extend `left_inds` with inherited bonds**
+
+After `partition` is fully built (after the `if let Some(boundary_indices)` block, currently at line 568 `}`), add `all_site_ids` computation:
+
+```rust
+        }
+
+        // Collect all site index IDs to distinguish inherited bond indices
+        let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
+
+        // Sort target names for deterministic processing
+```
+
+Then in the loop body, replace `let left_inds: Vec<_> = ...` block (lines 592-597) with:
+
+```rust
+            // Find site indices for this target
+            let mut left_inds: Vec<_> = remaining_tensor
+                .external_indices()
+                .iter()
+                .filter(|idx| site_ids_for_target.contains(idx.id()))
+                .cloned()
+                .collect();
+
+            // Include inherited bond indices so they are forwarded to the
+            // current target instead of accumulating on the last target.
+            left_inds.extend(
+                remaining_tensor
+                    .external_indices()
+                    .iter()
+                    .filter(|idx| !all_site_ids.contains(idx.id()))
+                    .cloned(),
+            );
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cargo build -p tensor4all-treetn
+```
+
+Expected: compiles without errors.
+
+- [ ] **Step 3: Run existing split tests to check for regressions**
+
+```bash
+cargo test -p tensor4all-treetn -- transform
+```
+
+Expected: all transform tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/transform.rs
+git commit -m "fix(treetn): include inherited bond indices in split_tensor_for_targets left_inds"
+```
+
+---
+
+### Task 2: Add topology validation in `split_to`
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/transform.rs:428-429`
+
+- [ ] **Step 1: Insert topology check after `from_tensors`**
+
+After the `from_tensors` call (current line 428), insert validation:
+
+```rust
+        let result = TreeTN::<T, TargetV>::from_tensors(tensors, names)
+            .context("split_to: failed to build result TreeTN")?;
+
+        // Validate the result topology matches the target
+        if !result
+            .site_index_network()
+            .share_equivalent_site_index_network(target)
+        {
+            return Err(anyhow::anyhow!(
+                "split_to: result topology does not match target: \
+                 expected edges {:?}, got {:?}",
+                target
+                    .edges()
+                    .map(|(a, b)| (a.clone(), b.clone()))
+                    .collect::<Vec<_>>(),
+                result
+                    .site_index_network()
+                    .edges()
+                    .map(|(a, b)| (a.clone(), b.clone()))
+                    .collect::<Vec<_>>(),
+            ));
+        }
+
+        // Step 5: Phase 2 - Optional truncation sweep
+```
+
+Note: `SiteIndexNetwork::edges` returns `impl Iterator<Item = (NodeName, NodeName)>` where `NodeName` is `&V`. The `.map(|(a, b)| (a.clone(), b.clone()))` is needed to satisfy `Clone + Debug` for `Vec`.
+
+- [ ] **Step 2: Update Step comment numbering**
+
+Renumber the subsequent Step comment from `// Step 5: Phase 2 - Optional truncation sweep` to `// Step 6: Phase 2 - Optional truncation sweep`.
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cargo build -p tensor4all-treetn
+```
+
+Expected: compiles.
+
+- [ ] **Step 4: Run transform tests**
+
+```bash
+cargo test -p tensor4all-treetn -- transform
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/transform.rs
+git commit -m "feat(treetn): add topology validation in split_to"
+```
+
+---
+
+### Task 3: Add topology assertion to existing split test
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs:263`
+
+- [ ] **Step 1: Add topology assertion**
+
+After `assert_eq!(split.node_count(), 3);` (line 263), add:
+
+```rust
+    assert_eq!(split.node_count(), 3);
+    assert!(
+        split
+            .site_index_network()
+            .share_equivalent_site_index_network(&split_target),
+        "split_to must preserve the requested chain topology, not silently produce a star/tree"
+    );
+```
+
+- [ ] **Step 2: Run the test to confirm it passes with the fix**
+
+```bash
+cargo test -p tensor4all-treetn test_split_to_with_actual_splitting
+```
+
+Expected: test passes.
+
+- [ ] **Step 3: Run all transform tests**
+
+```bash
+cargo test -p tensor4all-treetn -- transform
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+cargo test -p tensor4all-treetn
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+git commit -m "test(treetn): add topology assertion to test_split_to_with_actual_splitting"
+```

--- a/docs/superpowers/plans/2026-04-25-split-to-general-tree-topology.md
+++ b/docs/superpowers/plans/2026-04-25-split-to-general-tree-topology.md
@@ -1,0 +1,165 @@
+# split_to general tree topology Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Generalize `split_tensor_for_targets` from chain-only to arbitrary tree topologies using post-order tree decomposition, and add tests for branching shapes.
+
+**Architecture:** Replace sequential QR (sorted target order) with post-order QR decomposition using `petgraph::visit::DfsPostOrder` via `NodeNameNetwork::post_order_dfs`. Each current node's fragment sub-topology is extracted from the target `SiteIndexNetwork`. The algorithm mirrors `factorize_tensor_to_treetn` in `decompose.rs`.
+
+**Tech Stack:** Rust, petgraph (via NodeNameNetwork/SiteIndexNetwork), tensor4all-core (TensorLike, FactorizeOptions)
+
+---
+
+### Task 1: Extract fragment sub-topology helper
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/transform.rs`
+
+Goal: Given a current node name and the full target `SiteIndexNetwork`, build a sub-`SiteIndexNetwork`
+containing only the fragments whose `current` maps to that node. This reuses existing `edges()`,
+`site_space()`, and `node_names()` methods.
+
+**Signature:**
+```rust
+fn sub_target_for_current_node<'a, T, CurrentV, TargetV>(
+    target: &'a SiteIndexNetwork<TargetV, T::Index>,
+    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+    current_node_name: &CurrentV,
+) -> Result<SiteIndexNetwork<TargetV, T::Index>>
+```
+
+- [ ] **Step 1:** Collect fragment nodes for the current node. Iterate `target.node_names()`, filter those whose sites all map to `current_node_name` via `site_to_current`.
+- [ ] **Step 2:** Clone each qualifying node with its site space into a new `SiteIndexNetwork`.
+- [ ] **Step 3:** Add edges from `target.edges()` where BOTH endpoints are in the sub-target.
+- [ ] **Step 4:** Return the sub-network.
+- [ ] **Step 5:** Unit test: given a 3-node target (A, B spanning 2 currents, C), extract sub-target for each current. Verify node count and edges.
+
+---
+
+### Task 2: Rewrite `split_tensor_for_targets` using post-order tree decomposition
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/transform.rs` (lines ~529–628)
+
+Goal: Replace sequential QR loop with post-order decomposition borrowed from
+`factorize_tensor_to_treetn_with_root_impl` (decompose.rs:146–364), adapted to
+work on fragments within a single tensor.
+
+**Key references to reuse:**
+- `NodeNameNetwork::post_order_dfs` (petgraph `DfsPostOrder`) — traversal order
+- `TensorLike::factorize` — QR factorization
+- `index_ops::common_inds` — identify the bond between left and right tensors
+
+**New signature:**
+```rust
+fn split_tensor_for_targets<TargetV>(
+    &self,
+    tensor: &T,
+    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+    boundary_indices: Option<&HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>>>,
+    fragment_target: &SiteIndexNetwork<TargetV, T::Index>,  // NEW: sub-topology
+) -> Result<Vec<(TargetV, T)>>
+```
+
+**Algorithm (replaces lines ~583–628):**
+
+1. If `fragment_target.node_count() <= 1` → identity (return tensor as-is)
+2. Choose a root:
+   - If `boundary_indices` exists, pick the target with the most boundary indices
+   - Otherwise pick the target with highest degree (most edges) in the sub-topology
+   - Fallback: `target_names.sort()` first element
+3. Compute post-order via `fragment_target.post_order_dfs(&root)`
+   (delegates to `NodeNameNetwork::post_order_dfs` → petgraph `DfsPostOrder`)
+4. Build `children_by_parent` map:
+   - Initialize empty `HashMap<TargetV, Vec<TargetV>>`
+   - For each edge `(a, b)` in `fragment_target.edges()`: determine parent-child via traversal order (the one later in post-order is the child, or use the BFS tree from root). Use petgraph's `graph.neighbors()` on the internal graph.
+5. Process nodes in post-order (leaves first, skip root, root gets remaining tensor):
+   - `left_inds` = fragment's site indices + bonds to already-processed children (stored in `child_bonds: HashMap<TargetV, T::Index>`)
+   - If `boundary_indices` has specified bonds for this target, include them in `left_inds` too
+   - QR factorization
+   - Extract the new parent-bond via `common_inds(&left, &right)[0]`
+   - Store left as fragment tensor, right becomes new `remaining_tensor`
+   - Record parent-bond for this node in `child_bonds`
+6. Root fragment gets the final `remaining_tensor`
+
+- [ ] **Step 1:** Implement the new body (steps 1-6 above).
+- [ ] **Step 2:** Update the calling code in `split_to` (around line ~404) to pass `fragment_target`.
+- [ ] **Step 3:** Remove the old `all_site_ids` / `original_index_ids` logic (no longer needed — post-order naturally handles bond routing).
+- [ ] **Step 4:** Run all existing `transform` tests. All 19 must pass.
+- [ ] **Step 5:** Run `test_restructure_to_split_then_fuse_mixed_case`. Must pass.
+- [ ] **Step 6:** Commit.
+
+---
+
+### Task 3: Add branching topology tests for `split_to`
+
+**Files:**
+- Create: `crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs` (append ~100 lines)
+
+Goal: Verify `split_to` produces correct topology for non-chain tree shapes.
+
+**Test helpers needed:**
+- A single fused node containing 4 site indices (s_A, s_B, s_C, s_D)
+
+**Tests:**
+
+- [ ] **Step 1: Y-shape (star with 3 leaves)**
+
+```
+Target: A--B  B--C  B--D   (A,C,D are leaves, B is center)
+Fused tensor: [s_A, s_B, s_C, s_D]
+Split result must have edges: [(A,B), (B,C), (B,D)]
+```
+
+Assert: `node_count() == 4`, `share_equivalent_site_index_network`, contraction matches.
+
+- [ ] **Step 2: 4-node chain (keeps working as before)**
+
+```
+Target: A--B  B--C  C--D
+Fused tensor: [s_A, s_B, s_C, s_D]
+Split result must have edges: [(A,B), (B,C), (C,D)]
+```
+
+- [ ] **Step 3: Two branches from center (3 nodes)**
+
+```
+Target: A--B  B--C
+Fused tensor: [s_A, s_B, s_C]
+```
+
+(Covered by existing `test_split_to_with_actual_splitting`, just re-verify)
+
+- [ ] **Step 4: 2-node split (regression)**
+
+```
+Target: A--B
+Fused tensor: [s_A, s_B]
+```
+
+(Covered by existing tests)
+
+- [ ] **Step 5: Split across original bond with Y-shape target**
+
+```
+Current: 2 nodes [x0,x1]-[y0,y1]
+Target: X(x0)--Y(x1,y0)--Z(sub)  and Y--W(y1)
+```
+
+Verifies boundary_indices routing works with branching.
+
+- [ ] **Step 6: Run all transform tests. All must pass.**
+
+---
+
+### Task 4: Clean up and final verification
+
+- [ ] **Step 1:** Remove `all_site_ids` and `original_index_ids` from `split_tensor_for_targets` if still present.
+- [ ] **Step 2:** Run full `tensor4all-treetn` test suite:
+  ```bash
+  cargo test -p tensor4all-treetn
+  ```
+  All must pass.
+- [ ] **Step 3:** Run `cargo fmt --all --check`.
+- [ ] **Step 4:** Commit.

--- a/docs/superpowers/specs/2026-04-25-split-to-chain-topology-fix-design.md
+++ b/docs/superpowers/specs/2026-04-25-split-to-chain-topology-fix-design.md
@@ -1,0 +1,86 @@
+# Design: `split_to` chain topology fix
+
+**Date**: 2026-04-25
+**Issue**: [#78](https://github.com/tensor4all/Tensor4all.jl/issues/78)
+
+## Problem
+
+`TreeTN::split_to` produces a star topology instead of the requested chain
+topology when splitting a single fused node into 3+ target nodes.
+
+**Actual** (3-site fused, target chain `1--2--3`):
+```
+edges: [(1,3), (2,3)]  ← star
+```
+
+**Expected**:
+```
+edges: [(1,2), (2,3)]  ← chain
+```
+
+## Root Cause
+
+`split_tensor_for_targets` (`transform.rs:529`) uses sequential QR to peel off
+each target's site indices. When constructing `left_inds` for each QR step, it
+only includes the site indices of the current target, neglecting inherited bond
+indices from previous QR steps. These bonds stay on the "remaining" tensor and
+accumulate on the final target node, creating a star topology.
+
+## Fix
+
+In `split_tensor_for_targets`, include inherited bond indices (indices not
+belonging to any target's site space) in `left_inds` for each QR step. This
+ensures each inherited bond is forwarded to the correct intermediate target,
+not accumulated on the final target.
+
+### Code change
+
+`crates/tensor4all-treetn/src/treetn/transform.rs`:
+
+1. Precompute the set of all site index IDs:
+   ```rust
+   let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
+   ```
+
+2. In the loop, extend `left_inds` with inherited bond indices:
+   ```rust
+   left_inds.extend(
+       remaining_tensor
+           .external_indices()
+           .iter()
+           .filter(|idx| !all_site_ids.contains(idx.id()))
+           .cloned(),
+   );
+   ```
+
+### Validation (defense in depth)
+
+`split_to` must validate the result topology matches the target before
+returning. Add after `TreeTN::from_tensors(...)`:
+
+```rust
+if !result.site_index_network().share_equivalent_site_index_network(target) {
+    return Err(anyhow::anyhow!(
+        "split_to: result topology does not match target: \
+         expected edges {:?}, got {:?}",
+        target.edges().collect::<Vec<_>>(),
+        result.site_index_network().edges().collect::<Vec<_>>(),
+    ));
+}
+```
+
+## Test
+
+Add topology assertion to `test_split_to_with_actual_splitting`:
+
+```rust
+assert!(
+    split.site_index_network().share_equivalent_site_index_network(&split_target),
+    "split_to must preserve the requested chain topology"
+);
+```
+
+## Scope
+
+- `crates/tensor4all-treetn/src/treetn/transform.rs`: fix + validation (~10 lines)
+- `crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs`: test assertion (~5 lines)

--- a/docs/superpowers/specs/2026-04-25-split-to-chain-topology-fix-design.md
+++ b/docs/superpowers/specs/2026-04-25-split-to-chain-topology-fix-design.md
@@ -28,27 +28,39 @@ accumulate on the final target node, creating a star topology.
 
 ## Fix
 
-In `split_tensor_for_targets`, include inherited bond indices (indices not
-belonging to any target's site space) in `left_inds` for each QR step. This
-ensures each inherited bond is forwarded to the correct intermediate target,
-not accumulated on the final target.
+In `split_tensor_for_targets`, include **QR-created inherited bond** indices
+in `left_inds` for each QR step. These are indices on the remaining tensor that
+were not present in the original tensor (i.e., created by previous QR steps).
+Original current-tree bonds (present before any QR) are excluded — they are
+routed via the `boundary_indices` mechanism when target edges are present,
+and should be left on the remaining tensor otherwise. This ensures each
+inherited bond is forwarded to the correct intermediate target, not
+accumulated on the final target.
 
 ### Code change
 
 `crates/tensor4all-treetn/src/treetn/transform.rs`:
 
-1. Precompute the set of all site index IDs:
+1. Precompute the set of all site index IDs and original tensor index IDs:
    ```rust
    let all_site_ids: HashSet<_> = partition.values().flatten().cloned().collect();
+   let original_index_ids: HashSet<_> = tensor
+       .external_indices()
+       .iter()
+       .map(|idx| idx.id().clone())
+       .collect();
    ```
 
-2. In the loop, extend `left_inds` with inherited bond indices:
+2. In the loop, extend `left_inds` with QR-created inherited bond indices only:
    ```rust
    left_inds.extend(
        remaining_tensor
            .external_indices()
            .iter()
-           .filter(|idx| !all_site_ids.contains(idx.id()))
+           .filter(|idx| {
+               let id = idx.id();
+               !all_site_ids.contains(id) && !original_index_ids.contains(id)
+           })
            .cloned(),
    );
    ```


### PR DESCRIPTION
## Summary

Fixes #78 (`unfuse_quantics_operator` returning star instead of chain topology) by generalizing `split_tensor_for_targets` to produce correct edge topology matching the target `SiteIndexNetwork`.

### Changes

1. **`split_tensor_for_targets`**: replaced sequential QR (sorted order, star-producing) with **post-order tree decomposition** using petgraph `DfsPostOrder`. Each node is processed leaf-first, child bonds are forwarded in `left_inds`, and the root gets the remaining tensor. This correctly produces arbitrary tree topologies (chain, Y-shape, star, nested).

2. **Topology validation**: `split_to` validates the result topology matches the target (defense in depth, skips when target has no edges).

3. **Sequential fallback**: preserved for edgeless targets (caller doesn't care about topology).

### New tests

- `test_split_to_with_actual_splitting`: added topology assertion (regression gate)
- `test_split_to_y_shape`: Y-shape (B center, A/C/D leaves) from single fused node
- `test_split_to_nested_tree`: 4-node chain from single fused node
- `test_split_to_y_shape_across_original_bond`: Y-shape from fused 2-node tree

### Related

Closes tensor4all/Tensor4all.jl#78. Also filed issues for remaining untested branching paths:
- #451: fuse_to branching tests
- #452: restructure_to branching tests
- #453: truncate branching tests
- #450: hand-written DFS/BFS cleanup
