### PR TITLE
[codex] Match ITensors tag separator rules

### DIFF
--- a/crates/tensor4all-core/src/tagset.rs
+++ b/crates/tensor4all-core/src/tagset.rs
@@ -77,14 +77,14 @@ pub trait TagSetLike: Default + Clone + PartialEq + Eq {
 
     /// Create a tag set from a comma-separated string.
     ///
-    /// Whitespace is ignored (similar to ITensors.jl).
+    /// ASCII spaces are ignored (matching ITensors.jl).
     /// Tags are automatically sorted.
     fn from_str(s: &str) -> Result<Self, TagSetError> {
         let mut tagset = Self::default();
 
-        // Parse comma-separated tags, trimming whitespace
+        // Parse comma-separated tags, ignoring ASCII spaces like ITensors.jl.
         for tag in s.split(',') {
-            let trimmed: String = tag.chars().filter(|c| !c.is_whitespace()).collect();
+            let trimmed: String = tag.chars().filter(|c| *c != ' ').collect();
             if !trimmed.is_empty() {
                 tagset.add_tag(&trimmed)?;
             }
@@ -171,7 +171,7 @@ impl<const MAX_TAGS: usize, const MAX_TAG_LEN: usize, C: SmallChar>
 
     /// Create a TagSet from a comma-separated string.
     ///
-    /// Whitespace is ignored (similar to ITensors.jl).
+    /// ASCII spaces are ignored (matching ITensors.jl).
     /// Tags are automatically sorted.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Result<Self, TagSetError> {

--- a/crates/tensor4all-core/tests/common_tagset.rs
+++ b/crates/tensor4all-core/tests/common_tagset.rs
@@ -91,10 +91,22 @@ fn test_tagset_whitespace_ignored() {
     let ts = TagSet::<4, 16>::from_str(" aaa , bb bb  , ccc    ").unwrap();
     assert_eq!(ts.len(), 3);
 
-    // Whitespace should be removed
+    // ITensors.jl's TagSet constructor ignores ASCII spaces inside tags.
     assert!(ts.has_tag("aaa"));
     assert!(ts.has_tag("bbbb"));
     assert!(ts.has_tag("ccc"));
+}
+
+#[test]
+fn test_tagset_uses_itensors_separator_rules() {
+    let ts = TagSet::<4, 16>::from_str("a\tb, c\u{00a0}d, e\u{3000}f").unwrap();
+    assert_eq!(ts.len(), 3);
+
+    // Commas separate tags. ASCII spaces are ignored, but Unicode whitespace
+    // and tabs are part of the tag, matching ITensors.jl's TagSet parser.
+    assert!(ts.has_tag("a\tb"));
+    assert!(ts.has_tag("c\u{00a0}d"));
+    assert!(ts.has_tag("e\u{3000}f"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Treat comma as the only tag separator in `TagSet::from_str`.
- Ignore ASCII space characters only, matching ITensors.jl, instead of removing all Unicode whitespace.
- Add coverage for tabs, non-breaking spaces, and ideographic spaces as tag contents.

## Root Cause

The Rust parser used `char::is_whitespace()`, so tabs and Unicode whitespace were stripped from tags. ITensors.jl only ignores the ASCII space character (`' '`) and uses comma as the separator. This made the Rust and Julia tag conventions diverge at the C API boundary.

## Validation

- `cargo test -p tensor4all-core --test common_tagset`
- `cargo test -p tensor4all-capi index`
- `cargo fmt --check`
- `git diff --check`

Downstream local validation with the companion Tensor4all.jl changes:

- `julia --startup-file=no --project=/tmp/btci-debug-env -e 'include("/home/shinaoka/tensor4all/Tensor4all.jl/test/core/tensor_contract.jl")'`
- `julia --startup-file=no --project=/tmp/btci-debug-env -e 'include("/home/shinaoka/tensor4all/Tensor4all.jl/test/tensornetworks/restructure.jl")'`
- `julia --startup-file=no --project=/tmp/btci-debug-env -e 'include("/home/shinaoka/tensor4all/Tensor4all.jl/test/quanticstransform/materialize.jl")'`
- `/usr/bin/time -v julia --startup-file=no --project=/tmp/btci-debug-env -e 'include("test/testimports.jl"); ITensors.disable_warn_order(); include("test/tests/test_ttfunction.jl")'` in BubbleTeaCI