### PR TITLE
[codex] Use Index handles across TreeTN APIs

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -121,10 +121,17 @@
   metadata remain distinct.
 - Maps and sets that represent index identity must be keyed by the full index
   value, not by `IndexLike::Id`.
-- Pure ID comparisons are allowed only when the operation is explicitly about
-  logical-site lookup, compatibility, or contraction pairing. In those cases,
-  name the API or local variable to make the ID-based semantics explicit, such
-  as `find_*_by_id`, `*_ids`, or `target_assignment_by_id`.
+- Public and internal APIs that select a concrete tensor leg, TreeTN site,
+  edge, topology assignment, replacement target, split/fuse target, or
+  restructure target must accept the full `Index` value, not an index ID. Shape
+  APIs around index identity so callers can pass the index they mean.
+- Pure ID comparisons are allowed only inside implementation details that are
+  explicitly about logical-site lookup, compatibility, or contraction pairing.
+  Do not expose ID-based public APIs for selecting concrete indices. If a
+  temporary internal ID map is unavoidable, name the local variable to make the
+  ID-based semantics explicit, such as `logical_site_ids` or
+  `contraction_pair_ids`, and reject ambiguous same-ID inputs instead of
+  choosing one silently.
 - When changing tensor, TreeTN, contraction, direct-sum, replacement, or
   reindexing code, add a regression test with same-ID indices that differ by
   prime level or tags.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -125,6 +125,10 @@
   edge, topology assignment, replacement target, split/fuse target, or
   restructure target must accept the full `Index` value, not an index ID. Shape
   APIs around index identity so callers can pass the index they mean.
+- C API and language-binding-facing APIs must follow the same rule: accept
+  `Index` handles for concrete index selection, expose full-index
+  equality/hash helpers when bindings need map keys, and do not expose ID-only
+  constructors, selectors, or identity getters as public API.
 - Pure ID comparisons are allowed only inside implementation details that are
   explicitly about logical-site lookup, compatibility, or contraction pairing.
   Do not expose ID-based public APIs for selecting concrete indices. If a

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -113,6 +113,22 @@
   the appropriate high-level API rather than exposing or reaching into internal
   details.
 
+## Index Identity Semantics
+
+- Do not use `index.id()` alone to decide whether two indices are the same
+  index object. Full index equality must be used for identity comparisons so
+  same-ID indices with different prime levels, tags, directions, or other
+  metadata remain distinct.
+- Maps and sets that represent index identity must be keyed by the full index
+  value, not by `IndexLike::Id`.
+- Pure ID comparisons are allowed only when the operation is explicitly about
+  logical-site lookup, compatibility, or contraction pairing. In those cases,
+  name the API or local variable to make the ID-based semantics explicit, such
+  as `find_*_by_id`, `*_ids`, or `target_assignment_by_id`.
+- When changing tensor, TreeTN, contraction, direct-sum, replacement, or
+  reindexing code, add a regression test with same-ID indices that differ by
+  prime level or tags.
+
 ## No Ad Hoc Fixes
 
 - Do not add ad hoc fixes that violate DRY, KISS, or layering.

--- a/crates/tensor4all-capi/README.md
+++ b/crates/tensor4all-capi/README.md
@@ -5,7 +5,7 @@ minimal Julia-facing surface.
 
 ## Features
 
-- **Index API**: Immutable index handles with constructor/getter-only access
+- **Index API**: Immutable index handles with full-index equality, hashing, and prime-level transforms
 - **Tensor API**: Dense, diagonal, and structured `f64` / `Complex64` construction, payload export, dense export, and contraction
 - **TreeTN API**: General tree tensor network accessors and core operations
 - **QTT layout API**: Canonical binary QTT layout descriptors for transform materialization

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -384,14 +384,21 @@ StatusCode t4a_index_clone(const struct t4a_index *src, struct t4a_index **out);
 StatusCode t4a_index_dim(const struct t4a_index *ptr, size_t *out_dim);
 
 /**
+ * Compare two full index handles for equality.
+ */
+StatusCode t4a_index_equal(const struct t4a_index *lhs,
+                           const struct t4a_index *rhs,
+                           int32_t *out_equal);
+
+/**
  * Query whether an index has the provided tag.
  */
 StatusCode t4a_index_has_tag(const struct t4a_index *ptr, const char *tag, int32_t *out_has_tag);
 
 /**
- * Get the 64-bit ID of an index.
+ * Hash the full index value for process-local hash tables.
  */
-StatusCode t4a_index_id(const struct t4a_index *ptr, uint64_t *out_id);
+StatusCode t4a_index_hash(const struct t4a_index *ptr, uint64_t *out_hash);
 
 /**
  * Check whether an index handle is assigned.
@@ -404,13 +411,9 @@ int32_t t4a_index_is_assigned(const struct t4a_index *obj);
 StatusCode t4a_index_new(size_t dim, const char *tags_csv, int64_t plev, struct t4a_index **out);
 
 /**
- * Create a new index with an explicit 64-bit ID.
+ * Return a new index handle with prime level reset to zero.
  */
-StatusCode t4a_index_new_with_id(size_t dim,
-                                 uint64_t id,
-                                 const char *tags_csv,
-                                 int64_t plev,
-                                 struct t4a_index **out);
+StatusCode t4a_index_noprime(const struct t4a_index *ptr, struct t4a_index **out);
 
 /**
  * Get the prime level of an index.
@@ -418,9 +421,19 @@ StatusCode t4a_index_new_with_id(size_t dim,
 StatusCode t4a_index_plev(const struct t4a_index *ptr, int64_t *out_plev);
 
 /**
+ * Return a new index handle with prime level incremented by one.
+ */
+StatusCode t4a_index_prime(const struct t4a_index *ptr, struct t4a_index **out);
+
+/**
  * Release an index handle.
  */
 void t4a_index_release(struct t4a_index *obj);
+
+/**
+ * Return a new index handle with an explicit prime level.
+ */
+StatusCode t4a_index_set_plev(const struct t4a_index *ptr, int64_t plev, struct t4a_index **out);
 
 /**
  * Copy tags as a comma-separated UTF-8 string.

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -406,9 +406,23 @@ StatusCode t4a_index_hash(const struct t4a_index *ptr, uint64_t *out_hash);
 int32_t t4a_index_is_assigned(const struct t4a_index *obj);
 
 /**
+ * Get the explicit identity of an index.
+ */
+StatusCode t4a_index_id(const struct t4a_index *ptr, uint64_t *out_id);
+
+/**
  * Create a new index with explicit tags and prime level.
  */
 StatusCode t4a_index_new(size_t dim, const char *tags_csv, int64_t plev, struct t4a_index **out);
+
+/**
+ * Create a new index with explicit identity, tags, and prime level.
+ */
+StatusCode t4a_index_new_with_id(size_t dim,
+                                 uint64_t id,
+                                 const char *tags_csv,
+                                 int64_t plev,
+                                 struct t4a_index **out);
 
 /**
  * Return a new index handle with prime level reset to zero.

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -159,7 +159,9 @@ pub extern "C" fn t4a_index_new_with_id(
     out: *mut *mut t4a_index,
 ) -> StatusCode {
     run_catching(out, || {
-        Ok(t4a_index::new(build_index_with_id(dim, id, tags_csv, plev)?))
+        Ok(t4a_index::new(build_index_with_id(
+            dim, id, tags_csv, plev,
+        )?))
     })
 }
 

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -11,7 +11,7 @@ use crate::{
     set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
     T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
-use tensor4all_core::index::Index;
+use tensor4all_core::index::{DynId, Index, TagSet};
 
 /// Release an index handle.
 #[unsafe(no_mangle)]
@@ -72,6 +72,38 @@ fn build_index(
     Ok(index.set_plev(plev))
 }
 
+fn build_index_with_id(
+    dim: usize,
+    id: u64,
+    tags_csv: *const c_char,
+    plev: i64,
+) -> Result<InternalIndex, (StatusCode, String)> {
+    if dim == 0 {
+        return Err(capi_error(
+            T4A_INVALID_ARGUMENT,
+            "dim must be greater than zero",
+        ));
+    }
+    if plev < 0 {
+        return Err(capi_error(
+            T4A_INVALID_ARGUMENT,
+            "plev must be greater than or equal to zero",
+        ));
+    }
+
+    let id = DynId(id);
+    let tags = read_optional_tags_csv(tags_csv)?;
+    let index = match tags {
+        Some(tags) => {
+            let tags = TagSet::from_str(&tags).map_err(|e| capi_error(T4A_INVALID_ARGUMENT, e))?;
+            Index::new_with_tags(id, dim, tags)
+        }
+        None => Index::new(id, dim),
+    };
+
+    Ok(index.set_plev(plev))
+}
+
 fn require_index<'a>(ptr: *const t4a_index, what: &str) -> CapiResult<&'a InternalIndex> {
     if ptr.is_null() {
         return Err(capi_error(T4A_NULL_POINTER, format!("{what} is null")));
@@ -117,6 +149,20 @@ pub extern "C" fn t4a_index_new(
     })
 }
 
+/// Create a new index with explicit identity, tags, and prime level.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_index_new_with_id(
+    dim: usize,
+    id: u64,
+    tags_csv: *const c_char,
+    plev: i64,
+    out: *mut *mut t4a_index,
+) -> StatusCode {
+    run_catching(out, || {
+        Ok(t4a_index::new(build_index_with_id(dim, id, tags_csv, plev)?))
+    })
+}
+
 /// Get the dimension of an index.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> StatusCode {
@@ -130,6 +176,15 @@ pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> S
     }));
 
     crate::unwrap_catch(result)
+}
+
+/// Get the explicit identity of an index.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_index_id(ptr: *const t4a_index, out_id: *mut u64) -> StatusCode {
+    run_value(out_id, || {
+        let index = require_index(ptr, "index")?;
+        Ok(index.id.0)
+    })
 }
 
 /// Compare two full index handles for equality.

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -1,11 +1,15 @@
 //! C API for immutable `Index` handles.
 
+use std::collections::hash_map::DefaultHasher;
 use std::ffi::{c_char, CStr};
+use std::hash::{Hash, Hasher};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::types::{t4a_index, InternalIndex};
 use crate::{
-    capi_error, clone_opaque, is_assigned_opaque, release_opaque, run_catching, StatusCode,
-    T4A_BUFFER_TOO_SMALL, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
+    capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
+    set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
+    T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use tensor4all_core::index::Index;
 
@@ -68,6 +72,38 @@ fn build_index(
     Ok(index.set_plev(plev))
 }
 
+fn require_index<'a>(ptr: *const t4a_index, what: &str) -> CapiResult<&'a InternalIndex> {
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, format!("{what} is null")));
+    }
+    Ok(unsafe { &*ptr }.inner())
+}
+
+fn run_value<T: Copy, F>(out: *mut T, f: F) -> StatusCode
+where
+    F: FnOnce() -> CapiResult<T>,
+{
+    if out.is_null() {
+        return T4A_NULL_POINTER;
+    }
+
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(Ok(value)) => {
+            unsafe { *out = value };
+            T4A_SUCCESS
+        }
+        Ok(Err((code, msg))) => {
+            set_last_error(&msg);
+            code
+        }
+        Err(panic) => {
+            let msg = panic_message(&*panic);
+            set_last_error(&msg);
+            T4A_INTERNAL_ERROR
+        }
+    }
+}
+
 /// Create a new index with explicit tags and prime level.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_index_new(
@@ -78,40 +114,6 @@ pub extern "C" fn t4a_index_new(
 ) -> StatusCode {
     run_catching(out, || {
         Ok(t4a_index::new(build_index(dim, tags_csv, plev)?))
-    })
-}
-
-/// Create a new index with an explicit 64-bit ID.
-#[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_new_with_id(
-    dim: usize,
-    id: u64,
-    tags_csv: *const c_char,
-    plev: i64,
-    out: *mut *mut t4a_index,
-) -> StatusCode {
-    if dim == 0 {
-        return crate::err_status("dim must be greater than zero", T4A_INVALID_ARGUMENT);
-    }
-    if plev < 0 {
-        return crate::err_status(
-            "plev must be greater than or equal to zero",
-            T4A_INVALID_ARGUMENT,
-        );
-    }
-
-    use tensor4all_core::index::{DynId, TagSet};
-
-    run_catching(out, || {
-        let tags = match read_optional_tags_csv(tags_csv)? {
-            Some(tags) => {
-                TagSet::from_str(&tags).map_err(|e| capi_error(T4A_INVALID_ARGUMENT, e))?
-            }
-            None => TagSet::new(),
-        };
-
-        let index = Index::new_with_size_and_tags(DynId(id), dim, tags).set_plev(plev);
-        Ok(t4a_index::new(index))
     })
 }
 
@@ -130,19 +132,29 @@ pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> S
     crate::unwrap_catch(result)
 }
 
-/// Get the 64-bit ID of an index.
+/// Compare two full index handles for equality.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_id(ptr: *const t4a_index, out_id: *mut u64) -> StatusCode {
-    if ptr.is_null() || out_id.is_null() {
-        return T4A_NULL_POINTER;
-    }
+pub extern "C" fn t4a_index_equal(
+    lhs: *const t4a_index,
+    rhs: *const t4a_index,
+    out_equal: *mut i32,
+) -> StatusCode {
+    run_value(out_equal, || {
+        let lhs = require_index(lhs, "lhs")?;
+        let rhs = require_index(rhs, "rhs")?;
+        Ok((lhs == rhs) as i32)
+    })
+}
 
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
-        *out_id = (*ptr).inner().id.0;
-        T4A_SUCCESS
-    }));
-
-    crate::unwrap_catch(result)
+/// Hash the full index value for process-local hash tables.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_index_hash(ptr: *const t4a_index, out_hash: *mut u64) -> StatusCode {
+    run_value(out_hash, || {
+        let index = require_index(ptr, "index")?;
+        let mut hasher = DefaultHasher::new();
+        index.hash(&mut hasher);
+        Ok(hasher.finish())
+    })
 }
 
 /// Get the prime level of an index.
@@ -158,6 +170,43 @@ pub extern "C" fn t4a_index_plev(ptr: *const t4a_index, out_plev: *mut i64) -> S
     }));
 
     crate::unwrap_catch(result)
+}
+
+/// Return a new index handle with prime level incremented by one.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_index_prime(ptr: *const t4a_index, out: *mut *mut t4a_index) -> StatusCode {
+    run_catching(out, || {
+        let index = require_index(ptr, "index")?;
+        Ok(t4a_index::new(index.prime()))
+    })
+}
+
+/// Return a new index handle with prime level reset to zero.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_index_noprime(ptr: *const t4a_index, out: *mut *mut t4a_index) -> StatusCode {
+    run_catching(out, || {
+        let index = require_index(ptr, "index")?;
+        Ok(t4a_index::new(index.noprime()))
+    })
+}
+
+/// Return a new index handle with an explicit prime level.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_index_set_plev(
+    ptr: *const t4a_index,
+    plev: i64,
+    out: *mut *mut t4a_index,
+) -> StatusCode {
+    run_catching(out, || {
+        if plev < 0 {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                "plev must be greater than or equal to zero",
+            ));
+        }
+        let index = require_index(ptr, "index")?;
+        Ok(t4a_index::new(index.set_plev(plev)))
+    })
 }
 
 /// Copy tags as a comma-separated UTF-8 string.

--- a/crates/tensor4all-capi/src/index/tests/mod.rs
+++ b/crates/tensor4all-capi/src/index/tests/mod.rs
@@ -57,6 +57,21 @@ fn new_index(dim: usize, tags: Option<&str>, plev: i64) -> *mut t4a_index {
     out
 }
 
+fn new_index_with_id(dim: usize, id: u64, tags: Option<&str>, plev: i64) -> *mut t4a_index {
+    let tags = tags.map(|s| CString::new(s).unwrap());
+    let mut out = std::ptr::null_mut();
+    let status = t4a_index_new_with_id(
+        dim,
+        id,
+        tags.as_ref().map_or(std::ptr::null(), |s| s.as_ptr()),
+        plev,
+        &mut out,
+    );
+    assert_eq!(status, T4A_SUCCESS);
+    assert!(!out.is_null());
+    out
+}
+
 fn index_equal(a: *const t4a_index, b: *const t4a_index) -> bool {
     let mut equal = -1i32;
     assert_eq!(t4a_index_equal(a, b, &mut equal), T4A_SUCCESS);
@@ -67,6 +82,12 @@ fn index_hash(index: *const t4a_index) -> u64 {
     let mut hash = 0u64;
     assert_eq!(t4a_index_hash(index, &mut hash), T4A_SUCCESS);
     hash
+}
+
+fn index_id(index: *const t4a_index) -> u64 {
+    let mut id = 0u64;
+    assert_eq!(t4a_index_id(index, &mut id), T4A_SUCCESS);
+    id
 }
 
 #[test]
@@ -149,6 +170,29 @@ fn test_index_clone_preserves_metadata() {
 
     t4a_index_release(cloned);
     t4a_index_release(index);
+}
+
+#[test]
+fn test_index_new_with_id_roundtrips_identity() {
+    let a = new_index_with_id(5, 42, Some("Left,Link"), 7);
+    let b = new_index_with_id(5, 42, Some("Left,Link"), 7);
+    let different_plev = new_index_with_id(5, 42, Some("Left,Link"), 8);
+    let different_tags = new_index_with_id(5, 42, Some("Left,Other"), 7);
+    let different_id = new_index_with_id(5, 43, Some("Left,Link"), 7);
+
+    assert_eq!(index_id(a), 42);
+    assert_eq!(index_id(b), 42);
+    assert!(index_equal(a, b));
+    assert_eq!(index_hash(a), index_hash(b));
+    assert!(!index_equal(a, different_plev));
+    assert!(!index_equal(a, different_tags));
+    assert!(!index_equal(a, different_id));
+
+    t4a_index_release(different_id);
+    t4a_index_release(different_tags);
+    t4a_index_release(different_plev);
+    t4a_index_release(b);
+    t4a_index_release(a);
 }
 
 #[test]

--- a/crates/tensor4all-capi/src/index/tests/mod.rs
+++ b/crates/tensor4all-capi/src/index/tests/mod.rs
@@ -57,6 +57,18 @@ fn new_index(dim: usize, tags: Option<&str>, plev: i64) -> *mut t4a_index {
     out
 }
 
+fn index_equal(a: *const t4a_index, b: *const t4a_index) -> bool {
+    let mut equal = -1i32;
+    assert_eq!(t4a_index_equal(a, b, &mut equal), T4A_SUCCESS);
+    equal != 0
+}
+
+fn index_hash(index: *const t4a_index) -> u64 {
+    let mut hash = 0u64;
+    assert_eq!(t4a_index_hash(index, &mut hash), T4A_SUCCESS);
+    hash
+}
+
 #[test]
 fn test_index_new_rejects_zero_dim() {
     let mut out = std::ptr::null_mut();
@@ -121,40 +133,67 @@ fn test_index_clone_preserves_metadata() {
 
     let mut dims = [0usize; 2];
     let mut plevs = [0i64; 2];
-    let mut ids = [0u64; 2];
     for (slot, ptr) in [index as *const t4a_index, cloned as *const t4a_index]
         .into_iter()
         .enumerate()
     {
         assert_eq!(t4a_index_dim(ptr, &mut dims[slot]), T4A_SUCCESS);
         assert_eq!(t4a_index_plev(ptr, &mut plevs[slot]), T4A_SUCCESS);
-        assert_eq!(t4a_index_id(ptr, &mut ids[slot]), T4A_SUCCESS);
     }
 
     assert_eq!(dims, [5, 5]);
     assert_eq!(plevs, [9, 9]);
-    assert_eq!(ids[0], ids[1]);
     assert_eq!(read_tags(index), read_tags(cloned));
+    assert!(index_equal(index, cloned));
+    assert_eq!(index_hash(index), index_hash(cloned));
 
     t4a_index_release(cloned);
     t4a_index_release(index);
 }
 
 #[test]
-fn test_index_new_with_id_uses_explicit_id() {
-    let tags = CString::new("Custom").unwrap();
-    let mut out = std::ptr::null_mut();
-    let status = t4a_index_new_with_id(4, 0x1234_5678_9abc_def0, tags.as_ptr(), 2, &mut out);
-    assert_eq!(status, T4A_SUCCESS);
-    assert!(!out.is_null());
+fn test_index_plev_transforms_preserve_identity_but_use_full_equality() {
+    let index = new_index(4, Some("Custom"), 0);
 
-    let mut id = 0u64;
-    let mut plev = 0i64;
-    assert_eq!(t4a_index_id(out, &mut id), T4A_SUCCESS);
-    assert_eq!(t4a_index_plev(out, &mut plev), T4A_SUCCESS);
-    assert_eq!(id, 0x1234_5678_9abc_def0);
-    assert_eq!(plev, 2);
-    assert_eq!(read_tags(out), ["Custom".to_string()].into_iter().collect());
+    let mut primed: *mut t4a_index = std::ptr::null_mut();
+    assert_eq!(t4a_index_prime(index, &mut primed), T4A_SUCCESS);
+    assert!(!primed.is_null());
 
-    t4a_index_release(out);
+    let mut explicit: *mut t4a_index = std::ptr::null_mut();
+    assert_eq!(t4a_index_set_plev(index, 1, &mut explicit), T4A_SUCCESS);
+    assert!(!explicit.is_null());
+
+    let mut unprimed: *mut t4a_index = std::ptr::null_mut();
+    assert_eq!(t4a_index_noprime(primed, &mut unprimed), T4A_SUCCESS);
+    assert!(!unprimed.is_null());
+
+    let mut plev = -1i64;
+    assert_eq!(t4a_index_plev(primed, &mut plev), T4A_SUCCESS);
+    assert_eq!(plev, 1);
+    assert_eq!(read_tags(index), read_tags(primed));
+    assert!(!index_equal(index, primed));
+    assert_ne!(index_hash(index), index_hash(primed));
+    assert!(index_equal(primed, explicit));
+    assert_eq!(index_hash(primed), index_hash(explicit));
+    assert!(index_equal(index, unprimed));
+    assert_eq!(index_hash(index), index_hash(unprimed));
+
+    t4a_index_release(unprimed);
+    t4a_index_release(explicit);
+    t4a_index_release(primed);
+    t4a_index_release(index);
+}
+
+#[test]
+fn test_index_set_plev_rejects_negative_plev() {
+    let index = new_index(4, None, 0);
+    let mut out: *mut t4a_index = std::ptr::null_mut();
+
+    let status = t4a_index_set_plev(index, -1, &mut out);
+
+    assert_eq!(status, T4A_INVALID_ARGUMENT);
+    assert!(out.is_null());
+    assert!(last_error().contains("plev"));
+
+    t4a_index_release(index);
 }

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -218,7 +218,7 @@ fn collect_target_assignment(
     assignment_target_vertices: *const libc::size_t,
     n_assignments: usize,
     what: &str,
-) -> CapiResult<HashMap<<InternalIndex as IndexLike>::Id, usize>> {
+) -> CapiResult<HashMap<InternalIndex, usize>> {
     let siteinds = collect_indices(
         assignment_siteinds,
         n_assignments,
@@ -231,13 +231,12 @@ fn collect_target_assignment(
     )?;
     let mut target_assignment = HashMap::with_capacity(n_assignments);
     for (siteind, target_vertex) in siteinds.into_iter().zip(target_vertices) {
-        let site_id = *siteind.id();
-        if let Some(previous_target) = target_assignment.insert(site_id, target_vertex) {
+        if let Some(previous_target) = target_assignment.insert(siteind.clone(), target_vertex) {
             return Err(capi_error(
                 T4A_INVALID_ARGUMENT,
                 format!(
                     "{what}: duplicate site index assignment for {:?}: {} and {}",
-                    site_id, previous_target, target_vertex
+                    siteind, previous_target, target_vertex
                 ),
             ));
         }
@@ -284,8 +283,7 @@ fn build_target_network(
     )?;
 
     let mut network = SiteIndexNetwork::with_capacity(n_target_vertices, n_target_edges);
-    let mut seen_siteinds: HashMap<<InternalIndex as IndexLike>::Id, usize> =
-        HashMap::with_capacity(total_siteinds);
+    let mut seen_siteinds: HashMap<InternalIndex, usize> = HashMap::with_capacity(total_siteinds);
     let mut offset = 0usize;
     for (slot, &vertex) in vertices.iter().enumerate() {
         let len = siteind_lens[slot];
@@ -297,13 +295,12 @@ fn build_target_network(
         }
         let mut site_space = HashSet::with_capacity(len);
         for siteind in &flat_siteinds[offset..offset + len] {
-            let site_id = *siteind.id();
-            if let Some(previous_vertex) = seen_siteinds.insert(site_id, vertex) {
+            if let Some(previous_vertex) = seen_siteinds.insert(siteind.clone(), vertex) {
                 return Err(capi_error(
                     T4A_INVALID_ARGUMENT,
                     format!(
                         "{what}: duplicate site index {:?} appears in target vertices {} and {}",
-                        site_id, previous_vertex, vertex
+                        siteind, previous_vertex, vertex
                     ),
                 ));
             }

--- a/crates/tensor4all-core/src/block_tensor.rs
+++ b/crates/tensor4all-core/src/block_tensor.rs
@@ -32,7 +32,6 @@
 use std::collections::HashSet;
 
 use crate::any_scalar::AnyScalar;
-use crate::index_like::IndexLike;
 use crate::tensor_index::TensorIndex;
 use crate::tensor_like::{
     AllowedPairs, DirectSumResult, FactorizeError, FactorizeOptions, FactorizeResult,
@@ -299,25 +298,25 @@ impl<T: TensorLike> BlockTensor<T> {
             );
         }
 
-        // Same row: blocks should share some common index IDs (output indices)
+        // Same row: blocks should share at least one full output index.
         for row in 0..rows {
-            let ref_ids: HashSet<_> = self
+            let ref_indices: HashSet<_> = self
                 .get(row, 0)
                 .external_indices()
                 .iter()
-                .map(|idx| idx.id().clone())
+                .cloned()
                 .collect();
             for col in 1..cols {
-                let ids: HashSet<_> = self
+                let indices: HashSet<_> = self
                     .get(row, col)
                     .external_indices()
                     .iter()
-                    .map(|idx| idx.id().clone())
+                    .cloned()
                     .collect();
-                let common_count = ref_ids.intersection(&ids).count();
+                let common_count = ref_indices.intersection(&indices).count();
                 anyhow::ensure!(
                     common_count > 0,
-                    "Matrix row {}: blocks ({},{}) and ({},{}) share no index IDs",
+                    "Matrix row {}: blocks ({},{}) and ({},{}) share no common indices",
                     row,
                     row,
                     0,
@@ -327,25 +326,25 @@ impl<T: TensorLike> BlockTensor<T> {
             }
         }
 
-        // Same column: blocks should share some common index IDs (input indices)
+        // Same column: blocks should share at least one full input index.
         for col in 0..cols {
-            let ref_ids: HashSet<_> = self
+            let ref_indices: HashSet<_> = self
                 .get(0, col)
                 .external_indices()
                 .iter()
-                .map(|idx| idx.id().clone())
+                .cloned()
                 .collect();
             for row in 1..rows {
-                let ids: HashSet<_> = self
+                let indices: HashSet<_> = self
                     .get(row, col)
                     .external_indices()
                     .iter()
-                    .map(|idx| idx.id().clone())
+                    .cloned()
                     .collect();
-                let common_count = ref_ids.intersection(&ids).count();
+                let common_count = ref_indices.intersection(&indices).count();
                 anyhow::ensure!(
                     common_count > 0,
-                    "Matrix col {}: blocks ({},{}) and ({},{}) share no index IDs",
+                    "Matrix col {}: blocks ({},{}) and ({},{}) share no common indices",
                     col,
                     0,
                     col,
@@ -367,12 +366,12 @@ impl<T: TensorLike> TensorIndex for BlockTensor<T> {
     type Index = T::Index;
 
     fn external_indices(&self) -> Vec<Self::Index> {
-        // Collect unique external indices across all blocks (deduplicated by ID).
+        // Collect unique external indices across all blocks (deduplicated by full index).
         let mut seen = HashSet::new();
         let mut result = Vec::new();
         for block in &self.blocks {
             for idx in block.external_indices() {
-                if seen.insert(idx.id().clone()) {
+                if seen.insert(idx.clone()) {
                     result.push(idx);
                 }
             }

--- a/crates/tensor4all-core/src/block_tensor/tests/mod.rs
+++ b/crates/tensor4all-core/src/block_tensor/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::defaults::tensordynlen::TensorDynLen;
 use crate::defaults::DynIndex;
+use crate::index_like::IndexLike;
 use crate::krylov::{gmres, GmresOptions};
 
 /// Helper to create a 1D tensor (vector) with given data and shared index.
@@ -416,13 +417,25 @@ fn test_validate_indices_matrix_shared() {
 
 #[test]
 fn test_validate_indices_matrix_no_row_sharing() {
-    // 2x2 matrix: all indices independent → should fail (no common IDs in same row)
+    // 2x2 matrix: all indices independent → should fail (no common indices in same row)
     let b00 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
     let b01 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
     let b10 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
     let b11 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
 
     let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2));
+    assert!(block.validate_indices().is_err());
+}
+
+#[test]
+fn test_validate_indices_matrix_same_id_prime_is_not_shared_index() {
+    let row = DynIndex::new_dyn(2);
+    let row_prime = row.prime();
+    let b00 = TensorDynLen::from_dense(vec![row], vec![0.0; 2]).unwrap();
+    let b01 = TensorDynLen::from_dense(vec![row_prime], vec![0.0; 2]).unwrap();
+
+    let block = BlockTensor::new(vec![b00, b01], (1, 2));
+
     assert!(block.validate_indices().is_err());
 }
 
@@ -436,6 +449,19 @@ fn test_external_indices_deduplication() {
     let ext = block.external_indices();
     assert_eq!(ext.len(), 1, "Shared index should appear once");
     assert!(ext[0].same_id(&idx));
+}
+
+#[test]
+fn test_external_indices_preserves_same_id_prime_pair() {
+    let idx = DynIndex::new_dyn(2);
+    let idx_prime = idx.prime();
+    let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
+    let b2 = make_vector_with_index(vec![3.0, 4.0], &idx_prime);
+    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+
+    let ext = block.external_indices();
+
+    assert_eq!(ext, vec![idx, idx_prime]);
 }
 
 #[test]

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -896,9 +896,9 @@ fn build_contraction_plan(
     options: ContractionOptions<'_>,
     diag_uf: &mut AxisUnionFind,
 ) -> Result<ContractionPlan> {
-    let retained_ids: HashSet<DynId> = options.retain_indices.iter().map(|idx| *idx.id()).collect();
+    let retained_indices: HashSet<DynIndex> = options.retain_indices.iter().cloned().collect();
     let (input_ids, internal_id_to_original) =
-        build_internal_ids(tensors, options.allowed, diag_uf, &retained_ids)?;
+        build_internal_ids(tensors, options.allowed, diag_uf, &retained_indices)?;
 
     let mut counts: HashMap<usize, usize> = HashMap::new();
     for ids in &input_ids {
@@ -913,17 +913,17 @@ fn build_contraction_plan(
     for (tensor_idx, tensor) in tensors.iter().enumerate() {
         for (axis, idx) in tensor.indices.iter().enumerate() {
             let internal_id = input_ids[tensor_idx][axis];
-            let should_output = counts[&internal_id] == 1 || retained_ids.contains(idx.id());
+            let should_output = counts[&internal_id] == 1 || retained_indices.contains(idx);
             if should_output && seen_output.insert(internal_id) {
                 output_ids.push(internal_id);
             }
-            if retained_ids.contains(idx.id()) {
-                found_retained.insert(*idx.id());
+            if retained_indices.contains(idx) {
+                found_retained.insert(idx.clone());
             }
         }
     }
 
-    for retained in retained_ids {
+    for retained in retained_indices {
         if !found_retained.contains(&retained) {
             return Err(anyhow::anyhow!(
                 "Retained index {:?} does not appear in the input tensors",
@@ -958,7 +958,7 @@ fn validate_retained_indices_exist(
     for retain in retain_indices {
         let found = tensors
             .iter()
-            .any(|tensor| tensor.indices().iter().any(|idx| idx.id() == retain.id()));
+            .any(|tensor| tensor.indices().iter().any(|idx| idx == retain));
         if !found {
             return Err(anyhow::anyhow!(
                 "Retained index {:?} does not appear in the input tensors",
@@ -977,12 +977,12 @@ fn retained_indices_for_component(
     let mut seen = HashSet::new();
     let mut retained = Vec::new();
     for retain in retain_indices {
-        if seen.insert(*retain.id())
+        if seen.insert(retain.clone())
             && component.iter().any(|&tensor_idx| {
                 tensors[tensor_idx]
                     .indices()
                     .iter()
-                    .any(|idx| idx.id() == retain.id())
+                    .any(|idx| idx == retain)
             })
         {
             retained.push(retain.clone());
@@ -994,7 +994,7 @@ fn retained_indices_for_component(
 fn validate_unique_output_indices(indices: &[DynIndex]) -> Result<()> {
     let mut seen = HashSet::new();
     for idx in indices {
-        if !seen.insert(*idx.id()) {
+        if !seen.insert(idx.clone()) {
             return Err(anyhow::anyhow!(
                 "Contraction result would contain duplicate output indices"
             ));
@@ -1089,11 +1089,12 @@ fn output_axis_classes(
 fn build_internal_ids(
     tensors: &[&TensorDynLen],
     allowed: AllowedPairs<'_>,
-    diag_uf: &mut AxisUnionFind,
-    retained_ids: &HashSet<DynId>,
+    _diag_uf: &mut AxisUnionFind,
+    retained_indices: &HashSet<DynIndex>,
 ) -> Result<(Vec<Vec<usize>>, HashMap<usize, (usize, usize)>)> {
     let mut next_id = 0usize;
-    let mut dynid_to_internal: HashMap<DynId, usize> = HashMap::new();
+    let mut index_to_internal: HashMap<DynIndex, usize> = HashMap::new();
+    let mut retained_index_to_internal: HashMap<DynIndex, usize> = HashMap::new();
     let mut assigned: HashMap<(usize, usize), usize> = HashMap::new();
     let mut internal_id_to_original: HashMap<usize, (usize, usize)> = HashMap::new();
 
@@ -1118,34 +1119,30 @@ fn build_internal_ids(
                     let key_i = (ti, pi);
                     let key_j = (tj, pj);
 
-                    let remapped_i = diag_uf.find(*idx_i.id());
-                    let remapped_j = diag_uf.find(*idx_j.id());
-
                     match (assigned.get(&key_i).copied(), assigned.get(&key_j).copied()) {
                         (None, None) => {
-                            let internal_id = if let Some(&id) = dynid_to_internal.get(&remapped_i)
-                            {
+                            let internal_id = if let Some(&id) = index_to_internal.get(idx_i) {
                                 id
                             } else {
                                 let id = next_id;
                                 next_id += 1;
-                                dynid_to_internal.insert(remapped_i, id);
+                                index_to_internal.insert(idx_i.clone(), id);
                                 internal_id_to_original.insert(id, key_i);
                                 id
                             };
                             assigned.insert(key_i, internal_id);
                             assigned.insert(key_j, internal_id);
-                            if remapped_i != remapped_j {
-                                dynid_to_internal.insert(remapped_j, internal_id);
+                            if idx_i != idx_j {
+                                index_to_internal.insert(idx_j.clone(), internal_id);
                             }
                         }
                         (Some(id), None) => {
                             assigned.insert(key_j, id);
-                            dynid_to_internal.insert(remapped_j, id);
+                            index_to_internal.insert(idx_j.clone(), id);
                         }
                         (None, Some(id)) => {
                             assigned.insert(key_i, id);
-                            dynid_to_internal.insert(remapped_i, id);
+                            index_to_internal.insert(idx_i.clone(), id);
                         }
                         (Some(_id_i), Some(_id_j)) => {
                             // Both already assigned
@@ -1161,14 +1158,13 @@ fn build_internal_ids(
         for (pos, idx) in tensor.indices.iter().enumerate() {
             let key = (tensor_idx, pos);
             if let std::collections::hash_map::Entry::Vacant(e) = assigned.entry(key) {
-                let remapped_id = diag_uf.find(*idx.id());
-                let internal_id = if retained_ids.contains(&remapped_id) {
-                    if let Some(&id) = dynid_to_internal.get(&remapped_id) {
+                let internal_id = if retained_indices.contains(idx) {
+                    if let Some(&id) = retained_index_to_internal.get(idx) {
                         id
                     } else {
                         let id = next_id;
                         next_id += 1;
-                        dynid_to_internal.insert(remapped_id, id);
+                        retained_index_to_internal.insert(idx.clone(), id);
                         internal_id_to_original.insert(id, key);
                         id
                     }
@@ -1300,8 +1296,8 @@ fn find_tensor_connected_components_with_retained(
 
 fn shares_retained_index(a: &TensorDynLen, b: &TensorDynLen, retain_indices: &[DynIndex]) -> bool {
     retain_indices.iter().any(|retain| {
-        a.indices().iter().any(|idx_a| idx_a.id() == retain.id())
-            && b.indices().iter().any(|idx_b| idx_b.id() == retain.id())
+        a.indices().iter().any(|idx_a| idx_a == retain)
+            && b.indices().iter().any(|idx_b| idx_b == retain)
     })
 }
 

--- a/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
@@ -269,6 +269,32 @@ fn test_tensor_contract_with_options_retains_shared_index() {
 }
 
 #[test]
+fn test_contract_retains_exact_same_id_prime_index() {
+    let batch = Index::new(DynId(64), 2);
+    let batch_prime = batch.prime();
+    let k = Index::new(DynId(65), 3);
+
+    let a = make_test_tensor_from_data(
+        &[2, 2, 3],
+        vec![batch.clone(), batch_prime.clone(), k.clone()],
+        vec![1.0; 12],
+    );
+    let b = make_test_tensor_from_data(
+        &[2, 2, 3],
+        vec![batch.clone(), batch_prime.clone(), k.clone()],
+        vec![1.0; 12],
+    );
+
+    let retain_indices = [batch_prime.clone()];
+    let options = ContractionOptions::new(AllowedPairs::All).with_retain_indices(&retain_indices);
+    let result = contract_multi_with_options(&[&a, &b], options).unwrap();
+
+    assert_eq!(result.indices(), &[batch_prime]);
+    assert_eq!(result.dims(), vec![2]);
+    assert_eq!(result.to_vec::<f64>().unwrap(), vec![6.0, 6.0]);
+}
+
+#[test]
 fn test_contract_multi_with_options_supports_three_way_retained_label() {
     let batch = Index::new(DynId(20), 2);
     let i = Index::new(DynId(21), 2);

--- a/crates/tensor4all-core/src/defaults/direct_sum.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum.rs
@@ -17,7 +17,7 @@ use tensor4all_tensorbackend::TensorElement;
 ///
 /// For tensors A and B with indices to be summed specified as pairs,
 /// creates a new tensor C where each paired index has dimension = dim_A + dim_B.
-/// Non-paired indices must match exactly between A and B (same ID).
+/// Non-paired indices must match exactly between A and B.
 ///
 /// # Arguments
 ///
@@ -90,7 +90,6 @@ fn setup_direct_sum(
     b: &TensorDynLen,
     pairs: &[(DynIndex, DynIndex)],
 ) -> Result<DirectSumSetup> {
-    use crate::defaults::DynId;
     use std::collections::HashMap;
 
     if pairs.is_empty() {
@@ -99,37 +98,40 @@ fn setup_direct_sum(
         ));
     }
 
-    // Build maps from index IDs to positions
-    let a_idx_map: HashMap<&DynId, usize> = a
+    // Build maps from full index metadata to positions. Same-id indices that
+    // differ by prime level or tags are distinct axes.
+    let a_idx_map: HashMap<&DynIndex, usize> = a
         .indices
         .iter()
         .enumerate()
-        .map(|(i, idx)| (idx.id(), i))
+        .map(|(i, idx)| (idx, i))
         .collect();
-    let b_idx_map: HashMap<&DynId, usize> = b
+    let b_idx_map: HashMap<&DynIndex, usize> = b
         .indices
         .iter()
         .enumerate()
-        .map(|(i, idx)| (idx.id(), i))
+        .map(|(i, idx)| (idx, i))
         .collect();
 
-    // Build set of paired index IDs
-    let mut a_paired_ids: std::collections::HashSet<&DynId> = std::collections::HashSet::new();
-    let mut b_paired_ids: std::collections::HashSet<&DynId> = std::collections::HashSet::new();
+    // Build set of paired indices.
+    let mut a_paired_indices: std::collections::HashSet<&DynIndex> =
+        std::collections::HashSet::new();
+    let mut b_paired_indices: std::collections::HashSet<&DynIndex> =
+        std::collections::HashSet::new();
 
     for (a_idx, b_idx) in pairs {
-        if !a_idx_map.contains_key(a_idx.id()) {
+        if !a_idx_map.contains_key(a_idx) {
             return Err(anyhow::anyhow!(
                 "Index not found in first tensor (direct_sum)"
             ));
         }
-        if !b_idx_map.contains_key(b_idx.id()) {
+        if !b_idx_map.contains_key(b_idx) {
             return Err(anyhow::anyhow!(
                 "Index not found in second tensor (direct_sum)"
             ));
         }
-        a_paired_ids.insert(a_idx.id());
-        b_paired_ids.insert(b_idx.id());
+        a_paired_indices.insert(a_idx);
+        b_paired_indices.insert(b_idx);
     }
 
     // Identify common (non-paired) indices
@@ -138,12 +140,11 @@ fn setup_direct_sum(
     let mut common_a_positions: Vec<usize> = Vec::new();
     let mut common_b_positions: Vec<usize> = Vec::new();
     for (a_pos, a_idx) in a.indices.iter().enumerate() {
-        let a_id = a_idx.id();
-        if a_paired_ids.contains(a_id) {
+        if a_paired_indices.contains(a_idx) {
             continue;
         }
-        if let Some(&b_pos) = b_idx_map.get(a_id) {
-            if b_paired_ids.contains(a_id) {
+        if let Some(&b_pos) = b_idx_map.get(a_idx) {
+            if b_paired_indices.contains(a_idx) {
                 continue;
             }
             let a_dims = a.dims();
@@ -161,14 +162,8 @@ fn setup_direct_sum(
     }
 
     // Build paired positions and dimensions
-    let paired_a_positions: Vec<usize> = pairs
-        .iter()
-        .map(|(a_idx, _)| a_idx_map[a_idx.id()])
-        .collect();
-    let paired_b_positions: Vec<usize> = pairs
-        .iter()
-        .map(|(_, b_idx)| b_idx_map[b_idx.id()])
-        .collect();
+    let paired_a_positions: Vec<usize> = pairs.iter().map(|(a_idx, _)| a_idx_map[a_idx]).collect();
+    let paired_b_positions: Vec<usize> = pairs.iter().map(|(_, b_idx)| b_idx_map[b_idx]).collect();
     let a_dims = a.dims();
     let b_dims = b.dims();
     let paired_dims_a: Vec<usize> = paired_a_positions.iter().map(|&p| a_dims[p]).collect();
@@ -187,7 +182,7 @@ fn setup_direct_sum(
     let mut result_indices: Vec<DynIndex> = Vec::new();
     let mut result_dims: Vec<usize> = Vec::new();
 
-    // Common indices first
+    // Common indices first.
     let a_dims = a.dims();
     for &a_pos in &common_a_positions {
         result_indices.push(a.indices[a_pos].clone());

--- a/crates/tensor4all-core/src/defaults/direct_sum/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum/tests/mod.rs
@@ -78,6 +78,41 @@ fn test_direct_sum_multiple_pairs() {
 }
 
 #[test]
+fn test_direct_sum_preserves_same_id_prime_pair_common_indices() {
+    let i = DynIndex::new_dyn(2);
+    let i_prime = i.prime();
+    let j_a = DynIndex::new_dyn(2);
+    let j_b = DynIndex::new_dyn(3);
+
+    let a = TensorDynLen::from_dense(
+        vec![i.clone(), i_prime.clone(), j_a.clone()],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+    )
+    .unwrap();
+    let b = TensorDynLen::from_dense(
+        vec![i.clone(), i_prime.clone(), j_b.clone()],
+        vec![
+            10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0,
+        ],
+    )
+    .unwrap();
+
+    let (result, new_indices) = direct_sum(&a, &b, &[(j_a, j_b)]).unwrap();
+
+    assert_eq!(result.indices()[0], i);
+    assert_eq!(result.indices()[1], i_prime);
+    assert_eq!(result.indices()[2], new_indices[0]);
+    assert_eq!(result.dims(), vec![2, 2, 5]);
+
+    let data = result.to_vec::<f64>().unwrap();
+    assert_eq!(&data[0..8], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+    assert_eq!(
+        &data[8..],
+        &[10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0]
+    );
+}
+
+#[test]
 fn test_direct_sum_c64() {
     // Test the complex64 code path
     let i = DynIndex::new_dyn(2);

--- a/crates/tensor4all-core/src/defaults/index/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/index/tests/mod.rs
@@ -62,6 +62,52 @@ fn test_index_like_basic() {
 }
 
 #[test]
+fn test_tagset_wrapper_trait_methods() {
+    let mut tags = TagSet::new();
+    assert!(tags.is_empty());
+    assert_eq!(std::sync::Arc::strong_count(tags.inner()), 1);
+    assert_eq!(TagSetLike::len(&tags), 0);
+    assert_eq!(TagSetLike::capacity(&tags), 4);
+    assert_eq!(TagSetLike::get(&tags, 0), None);
+
+    TagSetLike::add_tag(&mut tags, "Site").unwrap();
+    TagSetLike::add_tag(&mut tags, "Link").unwrap();
+
+    assert!(!tags.is_empty());
+    assert_eq!(TagSetLike::len(&tags), 2);
+    assert!(TagSetLike::has_tag(&tags, "Site"));
+    assert_eq!(TagSetLike::get(&tags, 0), Some("Link".to_string()));
+    assert_eq!(
+        TagSetLike::iter(&tags).collect::<Vec<_>>(),
+        vec!["Link".to_string(), "Site".to_string()]
+    );
+    assert!(TagSetLike::remove_tag(&mut tags, "Site"));
+    assert!(!TagSetLike::remove_tag(&mut tags, "Missing"));
+    assert!(!TagSetLike::has_tag(&tags, "Site"));
+}
+
+#[test]
+fn test_index_generic_constructors_with_tags() {
+    let tags = TagSet::from_tags(&["Site", "Link"]).unwrap();
+
+    let with_tags = Index::new_with_tags(DynId(11), 4, tags.clone());
+    assert_eq!(with_tags.id, DynId(11));
+    assert_eq!(with_tags.size(), 4);
+    assert_eq!(with_tags.plev(), 0);
+    assert_eq!(with_tags.tags(), &tags);
+
+    let with_size = Index::<DynId>::new_with_size(DynId(12), 5);
+    assert_eq!(with_size.id, DynId(12));
+    assert_eq!(with_size.size(), 5);
+    assert!(with_size.tags().is_empty());
+
+    let with_size_and_tags = Index::new_with_size_and_tags(DynId(13), 6, tags.clone());
+    assert_eq!(with_size_and_tags.id, DynId(13));
+    assert_eq!(with_size_and_tags.size(), 6);
+    assert_eq!(with_size_and_tags.tags(), &tags);
+}
+
+#[test]
 fn test_index_like_id_methods() {
     let i1: DynIndex = Index::new_dyn(5);
     let i2 = i1.clone();

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -410,7 +410,7 @@ impl TensorDynLen {
         for idx in indices {
             assert!(
                 seen.insert(idx.clone()),
-                "Tensor indices must all be unique (no duplicate IDs)"
+                "Tensor indices must all be unique"
             );
         }
     }
@@ -3038,18 +3038,18 @@ impl TensorDynLen {
         );
 
         let old_dims = self.dims();
-        let mut seen_ids = HashSet::new();
+        let mut seen_indices = HashSet::new();
         let mut old_axes = Vec::with_capacity(old_indices.len());
         for old_index in old_indices {
             anyhow::ensure!(
-                seen_ids.insert(*old_index.id()),
+                seen_indices.insert(old_index),
                 "duplicate index in old_indices"
             );
             let axis = self
                 .indices
                 .iter()
-                .position(|idx| idx.id() == old_index.id())
-                .ok_or_else(|| anyhow::anyhow!("index {:?} not found in tensor", old_index.id()))?;
+                .position(|idx| idx == old_index)
+                .ok_or_else(|| anyhow::anyhow!("index {:?} not found in tensor", old_index))?;
             anyhow::ensure!(
                 old_index.dim() == old_dims[axis],
                 "old index dimension does not match tensor axis dimension"
@@ -3083,8 +3083,8 @@ impl TensorDynLen {
         let mut result_seen = HashSet::new();
         for index in &result_indices {
             anyhow::ensure!(
-                result_seen.insert(*index.id()),
-                "fuse_indices result would contain duplicate index ID"
+                result_seen.insert(index),
+                "fuse_indices result would contain duplicate index"
             );
         }
         Self::validate_indices(&result_indices);
@@ -3157,8 +3157,8 @@ impl TensorDynLen {
         let axis = self
             .indices
             .iter()
-            .position(|idx| idx.id() == old_index.id())
-            .ok_or_else(|| anyhow::anyhow!("index {:?} not found in tensor", old_index.id()))?;
+            .position(|idx| idx == old_index)
+            .ok_or_else(|| anyhow::anyhow!("index {:?} not found in tensor", old_index))?;
 
         let replacement_dims: Vec<usize> = new_indices.iter().map(DynIndex::dim).collect();
         let replacement_product = checked_product(&replacement_dims)?;

--- a/crates/tensor4all-core/src/index_ops.rs
+++ b/crates/tensor4all-core/src/index_ops.rs
@@ -35,7 +35,7 @@ impl std::fmt::Display for ReplaceIndsError {
             } => {
                 write!(
                     f,
-                    "Duplicate indices found: index at position {} has the same ID as index at position {}",
+                    "Duplicate indices found: index at position {} equals index at position {}",
                     duplicate_pos, first_pos
                 )
             }
@@ -45,7 +45,7 @@ impl std::fmt::Display for ReplaceIndsError {
 
 impl std::error::Error for ReplaceIndsError {}
 
-/// Check if a collection of indices contains any duplicates (by ID).
+/// Check if a collection of indices contains any duplicate full indices.
 ///
 /// # Arguments
 /// * `indices` - Collection of indices to check
@@ -68,28 +68,28 @@ impl std::error::Error for ReplaceIndsError {}
 /// ```
 pub fn check_unique_indices<I: IndexLike>(indices: &[I]) -> Result<(), ReplaceIndsError> {
     use std::collections::HashMap;
-    let mut seen: HashMap<&I::Id, usize> = HashMap::with_capacity(indices.len());
+    let mut seen: HashMap<&I, usize> = HashMap::with_capacity(indices.len());
     for (pos, idx) in indices.iter().enumerate() {
-        if let Some(&first_pos) = seen.get(idx.id()) {
+        if let Some(&first_pos) = seen.get(idx) {
             return Err(ReplaceIndsError::DuplicateIndices {
                 first_pos,
                 duplicate_pos: pos,
             });
         }
-        seen.insert(idx.id(), pos);
+        seen.insert(idx, pos);
     }
     Ok(())
 }
 
-/// Replace indices in a collection based on ID matching.
+/// Replace indices in a collection based on full-index matching.
 ///
 /// This corresponds to ITensors.jl's `replaceinds` function. It replaces indices
-/// in `indices` that match (by ID) any of the `(old, new)` pairs in `replacements`.
+/// in `indices` that equal any of the `(old, new)` pairs in `replacements`.
 /// The replacement index must have the same dimension as the original.
 ///
 /// # Arguments
 /// * `indices` - Collection of indices to modify
-/// * `replacements` - Pairs of `(old_index, new_index)` where indices matching `old_index.id` are replaced with `new_index`
+/// * `replacements` - Pairs of `(old_index, new_index)` where indices equal to `old_index` are replaced with `new_index`
 ///
 /// # Returns
 /// A new vector with replacements applied, or an error if any replacement has a dimension mismatch.
@@ -121,7 +121,7 @@ pub fn replaceinds<I: IndexLike>(
     // Check for duplicates in input indices
     check_unique_indices(&indices)?;
 
-    // Build a map from old ID to new index for fast lookup
+    // Build a map from old index to new index for fast lookup.
     let mut replacement_map = std::collections::HashMap::with_capacity(replacements.len());
     for (old, new) in replacements {
         // Validate dimension match
@@ -131,13 +131,13 @@ pub fn replaceinds<I: IndexLike>(
                 to_dim: new.dim(),
             });
         }
-        replacement_map.insert(old.id(), new);
+        replacement_map.insert(old.clone(), new);
     }
 
     // Apply replacements
     let mut result = Vec::with_capacity(indices.len());
     for idx in indices {
-        if let Some(new_idx) = replacement_map.get(idx.id()) {
+        if let Some(new_idx) = replacement_map.get(&idx) {
             result.push((*new_idx).clone());
         } else {
             result.push(idx);
@@ -149,14 +149,14 @@ pub fn replaceinds<I: IndexLike>(
     Ok(result)
 }
 
-/// Replace indices in-place based on ID matching.
+/// Replace indices in-place based on full-index matching.
 ///
 /// This is an in-place variant of `replaceinds` that modifies the input slice directly.
 /// Useful for performance-critical code where you want to avoid allocations.
 ///
 /// # Arguments
 /// * `indices` - Mutable slice of indices to modify
-/// * `replacements` - Pairs of `(old_index, new_index)` where indices matching `old_index.id` are replaced with `new_index`
+/// * `replacements` - Pairs of `(old_index, new_index)` where indices equal to `old_index` are replaced with `new_index`
 ///
 /// # Returns
 /// `Ok(())` on success, or an error if any replacement has a dimension mismatch.
@@ -187,7 +187,7 @@ pub fn replaceinds_in_place<I: IndexLike>(
     // Check for duplicates in input indices
     check_unique_indices(indices)?;
 
-    // Build a map from old ID to new index for fast lookup
+    // Build a map from old index to new index for fast lookup.
     let mut replacement_map = std::collections::HashMap::with_capacity(replacements.len());
     for (old, new) in replacements {
         // Validate dimension match
@@ -197,12 +197,12 @@ pub fn replaceinds_in_place<I: IndexLike>(
                 to_dim: new.dim(),
             });
         }
-        replacement_map.insert(old.id(), new);
+        replacement_map.insert(old.clone(), new);
     }
 
     // Apply replacements in-place
     for idx in indices.iter_mut() {
-        if let Some(new_idx) = replacement_map.get(idx.id()) {
+        if let Some(new_idx) = replacement_map.get(idx) {
             *idx = (*new_idx).clone();
         }
     }
@@ -214,7 +214,7 @@ pub fn replaceinds_in_place<I: IndexLike>(
 
 /// Find indices that are unique to the first collection (set difference A \ B).
 ///
-/// Returns indices that appear in `indices_a` but not in `indices_b` (matched by ID).
+/// Returns indices that appear in `indices_a` but not in `indices_b` (matched by full index).
 /// This corresponds to ITensors.jl's `uniqueinds` function.
 ///
 /// # Arguments
@@ -241,10 +241,9 @@ pub fn replaceinds_in_place<I: IndexLike>(
 /// assert_eq!(unique[0].id, i.id);
 /// ```
 pub fn unique_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
-    let b_ids: std::collections::HashSet<_> = indices_b.iter().map(|idx| idx.id()).collect();
     indices_a
         .iter()
-        .filter(|idx| !b_ids.contains(idx.id()))
+        .filter(|idx| !indices_b.iter().any(|other| other == *idx))
         .cloned()
         .collect()
 }
@@ -252,7 +251,7 @@ pub fn unique_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
 /// Find indices that are not common between two collections (symmetric difference).
 ///
 /// Returns indices that appear in either `indices_a` or `indices_b` but not in both
-/// (matched by ID). This corresponds to ITensors.jl's `noncommoninds` function.
+/// (matched by full index). This corresponds to ITensors.jl's `noncommoninds` function.
 ///
 /// Time complexity: O(n + m) where n = len(indices_a), m = len(indices_b).
 ///
@@ -280,9 +279,6 @@ pub fn unique_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
 /// assert_eq!(noncommon.len(), 2);  // i and k
 /// ```
 pub fn noncommon_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
-    let a_ids: std::collections::HashSet<_> = indices_a.iter().map(|idx| idx.id()).collect();
-    let b_ids: std::collections::HashSet<_> = indices_b.iter().map(|idx| idx.id()).collect();
-
     // Pre-allocate with estimated capacity (worst case: no common indices)
     let mut result = Vec::with_capacity(indices_a.len() + indices_b.len());
 
@@ -290,14 +286,14 @@ pub fn noncommon_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> 
     result.extend(
         indices_a
             .iter()
-            .filter(|idx| !b_ids.contains(idx.id()))
+            .filter(|idx| !indices_b.iter().any(|other| other == *idx))
             .cloned(),
     );
     // Add indices from B that are not in A
     result.extend(
         indices_b
             .iter()
-            .filter(|idx| !a_ids.contains(idx.id()))
+            .filter(|idx| !indices_a.iter().any(|other| other == *idx))
             .cloned(),
     );
     result
@@ -305,7 +301,7 @@ pub fn noncommon_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> 
 
 /// Find the union of two index collections.
 ///
-/// Returns all unique indices from both collections (matched by ID).
+/// Returns all unique indices from both collections (matched by full index).
 /// This corresponds to ITensors.jl's `unioninds` function.
 ///
 /// Time complexity: O(n + m) where n = len(indices_a), m = len(indices_b).
@@ -333,24 +329,24 @@ pub fn noncommon_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> 
 /// assert_eq!(union.len(), 3);  // i, j, k
 /// ```
 pub fn union_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
-    let mut seen: std::collections::HashSet<&I::Id> =
+    let mut seen: std::collections::HashSet<&I> =
         std::collections::HashSet::with_capacity(indices_a.len() + indices_b.len());
     let mut result = Vec::with_capacity(indices_a.len() + indices_b.len());
 
     for idx in indices_a {
-        if seen.insert(idx.id()) {
+        if seen.insert(idx) {
             result.push(idx.clone());
         }
     }
     for idx in indices_b {
-        if seen.insert(idx.id()) {
+        if seen.insert(idx) {
             result.push(idx.clone());
         }
     }
     result
 }
 
-/// Check if a collection contains a specific index (by ID).
+/// Check if a collection contains a specific full index.
 ///
 /// This corresponds to ITensors.jl's `hasind` function.
 ///
@@ -377,7 +373,7 @@ pub fn hasind<I: IndexLike>(indices: &[I], index: &I) -> bool {
     indices.iter().any(|idx| idx == index)
 }
 
-/// Check if a collection contains all of the specified indices (by ID).
+/// Check if a collection contains all of the specified full indices.
 ///
 /// This corresponds to ITensors.jl's `hasinds` function.
 ///
@@ -386,7 +382,7 @@ pub fn hasind<I: IndexLike>(indices: &[I], index: &I) -> bool {
 /// * `targets` - The indices to look for
 ///
 /// # Returns
-/// `true` if all target indices (by ID) are found, `false` otherwise.
+/// `true` if all target indices are found, `false` otherwise.
 ///
 /// # Example
 /// ```
@@ -402,11 +398,12 @@ pub fn hasind<I: IndexLike>(indices: &[I], index: &I) -> bool {
 /// assert!(!hasinds(&indices, &[i.clone(), Index::new_dyn(5)]));
 /// ```
 pub fn hasinds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
-    let index_ids: std::collections::HashSet<_> = indices.iter().map(|idx| idx.id()).collect();
-    targets.iter().all(|target| index_ids.contains(target.id()))
+    targets
+        .iter()
+        .all(|target| indices.iter().any(|idx| idx == target))
 }
 
-/// Check if two collections have any common indices (by ID).
+/// Check if two collections have any common full indices.
 ///
 /// This corresponds to ITensors.jl's `hascommoninds` function.
 ///
@@ -415,7 +412,7 @@ pub fn hasinds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
 /// * `indices_b` - Second collection of indices
 ///
 /// # Returns
-/// `true` if there is at least one common index (by ID), `false` otherwise.
+/// `true` if there is at least one common index, `false` otherwise.
 ///
 /// # Example
 /// ```
@@ -433,8 +430,9 @@ pub fn hasinds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
 /// assert!(!hascommoninds(&[i.clone()], &[k.clone()]));
 /// ```
 pub fn hascommoninds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> bool {
-    let b_ids: std::collections::HashSet<_> = indices_b.iter().map(|idx| idx.id()).collect();
-    indices_a.iter().any(|idx| b_ids.contains(idx.id()))
+    indices_a
+        .iter()
+        .any(|idx| indices_b.iter().any(|other| other == idx))
 }
 
 /// Find common indices between two index collections.
@@ -449,7 +447,7 @@ pub fn hascommoninds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> bool {
 /// * `indices_b` - Second collection of indices
 ///
 /// # Returns
-/// A vector containing indices that are common to both collections (matched by ID).
+/// A vector containing indices that are common to both collections (matched by full index).
 ///
 /// # Example
 /// ```
@@ -468,10 +466,9 @@ pub fn hascommoninds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> bool {
 /// assert_eq!(common[0].id, j.id);
 /// ```
 pub fn common_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> Vec<I> {
-    let b_ids: std::collections::HashSet<_> = indices_b.iter().map(|idx| idx.id()).collect();
     indices_a
         .iter()
-        .filter(|idx| b_ids.contains(idx.id()))
+        .filter(|idx| indices_b.iter().any(|other| other == *idx))
         .cloned()
         .collect()
 }
@@ -709,15 +706,16 @@ pub fn prepare_contraction_pairs<I: IndexLike>(
         return Err(ContractionError::NoCommonIndices);
     }
 
-    // Check for batch contraction (common indices not in pairs)
-    let contracted_a_ids: HashSet<_> = pairs.iter().map(|(idx, _)| idx.id()).collect();
-    let contracted_b_ids: HashSet<_> = pairs.iter().map(|(_, idx)| idx.id()).collect();
+    // Check for batch contraction (common indices not in pairs). The explicit
+    // pair list identifies axes by full index metadata, not by ID alone.
+    let contracted_a_indices: HashSet<_> = pairs.iter().map(|(idx, _)| idx).collect();
+    let contracted_b_indices: HashSet<_> = pairs.iter().map(|(_, idx)| idx).collect();
 
     let common_positions = common_ind_positions(indices_a, indices_b);
     for (pos_a, pos_b) in &common_positions {
-        let id_a = indices_a[*pos_a].id();
-        let id_b = indices_b[*pos_b].id();
-        if !contracted_a_ids.contains(id_a) || !contracted_b_ids.contains(id_b) {
+        let idx_a = &indices_a[*pos_a];
+        let idx_b = &indices_b[*pos_b];
+        if !contracted_a_indices.contains(idx_a) || !contracted_b_indices.contains(idx_b) {
             return Err(ContractionError::BatchContractionNotImplemented);
         }
     }
@@ -729,12 +727,12 @@ pub fn prepare_contraction_pairs<I: IndexLike>(
     for (idx_a, idx_b) in pairs {
         let pos_a = indices_a
             .iter()
-            .position(|idx| idx.id() == idx_a.id())
+            .position(|idx| idx == idx_a)
             .ok_or(ContractionError::IndexNotFound { tensor: "self" })?;
 
         let pos_b = indices_b
             .iter()
-            .position(|idx| idx.id() == idx_b.id())
+            .position(|idx| idx == idx_b)
             .ok_or(ContractionError::IndexNotFound { tensor: "other" })?;
 
         // Verify dimensions match

--- a/crates/tensor4all-core/tests/common_duplicate_indices.rs
+++ b/crates/tensor4all-core/tests/common_duplicate_indices.rs
@@ -30,6 +30,14 @@ fn test_check_unique_indices_duplicate() {
 }
 
 #[test]
+fn test_check_unique_indices_allows_same_id_prime_pair() {
+    let i = Index::new_dyn(2);
+    let i_prime = i.prime();
+    let indices = vec![i, i_prime];
+    assert!(check_unique_indices(&indices).is_ok());
+}
+
+#[test]
 fn test_replaceinds_duplicate_input() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);

--- a/crates/tensor4all-core/tests/common_index_ops.rs
+++ b/crates/tensor4all-core/tests/common_index_ops.rs
@@ -207,9 +207,15 @@ fn test_index_ops_distinguish_same_id_prime_pair() {
     assert!(hasind(&indices, &i));
     assert!(hasind(&indices, &i_prime));
     assert!(hasinds(&indices, &[i.clone(), i_prime.clone()]));
-    assert!(!hascommoninds(&[i.clone()], &[i_prime.clone()]));
-    assert!(common_inds(&[i.clone()], &[i_prime.clone()]).is_empty());
-    assert_eq!(unique_inds(&indices, &[i_prime.clone()]), vec![i.clone()]);
+    assert!(!hascommoninds(
+        std::slice::from_ref(&i),
+        std::slice::from_ref(&i_prime)
+    ));
+    assert!(common_inds(std::slice::from_ref(&i), std::slice::from_ref(&i_prime)).is_empty());
+    assert_eq!(
+        unique_inds(&indices, std::slice::from_ref(&i_prime)),
+        vec![i.clone()]
+    );
 
     let replaced = replaceinds(indices, &[(i_prime.clone(), replacement.clone())]).unwrap();
     assert_eq!(replaced, vec![i, replacement]);

--- a/crates/tensor4all-core/tests/common_index_ops.rs
+++ b/crates/tensor4all-core/tests/common_index_ops.rs
@@ -1,7 +1,7 @@
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index_ops::{
-    common_inds, hascommoninds, hasind, hasinds, noncommon_inds, replaceinds, replaceinds_in_place,
-    union_inds, unique_inds, ReplaceIndsError,
+    common_inds, hascommoninds, hasind, hasinds, noncommon_inds, prepare_contraction_pairs,
+    replaceinds, replaceinds_in_place, union_inds, unique_inds, ReplaceIndsError,
 };
 use tensor4all_core::IndexLike;
 
@@ -195,6 +195,42 @@ fn test_common_inds_integration() {
 
     // Verify hascommoninds matches
     assert!(hascommoninds(&indices_a, &indices_b));
+}
+
+#[test]
+fn test_index_ops_distinguish_same_id_prime_pair() {
+    let i = Index::new_dyn(2);
+    let i_prime = i.prime();
+    let replacement = i_prime.sim();
+    let indices = vec![i.clone(), i_prime.clone()];
+
+    assert!(hasind(&indices, &i));
+    assert!(hasind(&indices, &i_prime));
+    assert!(hasinds(&indices, &[i.clone(), i_prime.clone()]));
+    assert!(!hascommoninds(&[i.clone()], &[i_prime.clone()]));
+    assert!(common_inds(&[i.clone()], &[i_prime.clone()]).is_empty());
+    assert_eq!(unique_inds(&indices, &[i_prime.clone()]), vec![i.clone()]);
+
+    let replaced = replaceinds(indices, &[(i_prime.clone(), replacement.clone())]).unwrap();
+    assert_eq!(replaced, vec![i, replacement]);
+}
+
+#[test]
+fn test_prepare_contraction_pairs_selects_exact_same_id_prime_index() {
+    let i = Index::new_dyn(2);
+    let i_prime = i.prime();
+    let spec = prepare_contraction_pairs(
+        &[i.clone(), i_prime.clone()],
+        &[2, 2],
+        std::slice::from_ref(&i_prime),
+        &[2],
+        &[(i_prime.clone(), i_prime.clone())],
+    )
+    .unwrap();
+
+    assert_eq!(spec.axes_a, vec![1]);
+    assert_eq!(spec.axes_b, vec![0]);
+    assert_eq!(spec.result_indices, vec![i]);
 }
 
 #[test]

--- a/crates/tensor4all-core/tests/tensor_unfuse.rs
+++ b/crates/tensor4all-core/tests/tensor_unfuse.rs
@@ -1,5 +1,7 @@
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, IndexLike, LinearizationOrder, TensorDynLen, TensorLike};
+use tensor4all_core::{
+    DynIndex, IndexLike, LinearizationOrder, TensorDynLen, TensorIndex, TensorLike,
+};
 
 #[test]
 fn unfuse_index_column_major_preserves_column_major_layout() {
@@ -291,17 +293,35 @@ fn fuse_indices_rejects_duplicate_result_index() {
 }
 
 #[test]
-fn fuse_indices_rejects_duplicate_result_id_from_primed_index() {
+fn fuse_indices_allows_same_id_prime_pair_in_result() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let tensor =
         TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
-    let err = tensor
+    let result = tensor
         .fuse_indices(&[i], j.prime(), LinearizationOrder::ColumnMajor)
-        .unwrap_err();
+        .unwrap();
 
-    assert!(err
-        .to_string()
-        .contains("fuse_indices result would contain duplicate index ID"));
+    assert_eq!(result.external_indices(), vec![j.prime(), j]);
+}
+
+#[test]
+fn unfuse_index_selects_exact_same_id_prime_index() {
+    let fused = DynIndex::new_dyn(4);
+    let fused_prime = fused.prime();
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let data: Vec<f64> = (0..16).map(|value| value as f64).collect();
+    let tensor = TensorDynLen::from_dense(vec![fused.clone(), fused_prime.clone()], data).unwrap();
+
+    let result = tensor
+        .unfuse_index(
+            &fused_prime,
+            &[i.clone(), j.clone()],
+            LinearizationOrder::ColumnMajor,
+        )
+        .unwrap();
+
+    assert_eq!(result.external_indices(), vec![fused, i, j]);
 }

--- a/crates/tensor4all-treetci/src/materialize/tests.rs
+++ b/crates/tensor4all-treetci/src/materialize/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::Result;
 use num_complex::Complex64;
 use std::collections::HashMap as StdHashMap;
-use tensor4all_core::{ColMajorArray, ColMajorArrayRef, IndexLike};
+use tensor4all_core::{ColMajorArray, ColMajorArrayRef};
 
 fn two_site_graph() -> TreeTciGraph {
     TreeTciGraph::new(2, &[TreeTciEdge::new(0, 1)]).unwrap()
@@ -42,23 +42,29 @@ fn to_treetn_preserves_two_site_identity_evaluations() {
 
     let tn = to_treetn(&tci, batch_eval, Some(0)).unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
     let pos0 = {
-        let site_id = *tn.site_space(&0usize).unwrap().iter().next().unwrap().id();
-        index_ids.iter().position(|id| *id == site_id).unwrap()
+        let site_index = tn.site_space(&0usize).unwrap().iter().next().unwrap();
+        indices
+            .iter()
+            .position(|index| index == site_index)
+            .unwrap()
     };
     let pos1 = {
-        let site_id = *tn.site_space(&1usize).unwrap().iter().next().unwrap().id();
-        index_ids.iter().position(|id| *id == site_id).unwrap()
+        let site_index = tn.site_space(&1usize).unwrap().iter().next().unwrap();
+        indices
+            .iter()
+            .position(|index| index == site_index)
+            .unwrap()
     };
 
     let eval = |i: usize, j: usize| -> f64 {
-        let mut data = vec![0usize; index_ids.len()];
+        let mut data = vec![0usize; indices.len()];
         data[pos0] = i;
         data[pos1] = j;
-        let shape = [index_ids.len(), 1];
+        let shape = [indices.len(), 1];
         let values = ColMajorArrayRef::new(&data, &shape);
-        tn.evaluate(&index_ids, values).unwrap()[0].real()
+        tn.evaluate(&indices, values).unwrap()[0].real()
     };
 
     assert_scalar_close(eval(0, 0), 1.0, 1.0, 1e-12);

--- a/crates/tensor4all-treetci/tests/advanced_quantics.rs
+++ b/crates/tensor4all-treetci/tests/advanced_quantics.rs
@@ -3,7 +3,7 @@ mod common;
 use anyhow::Result;
 use common::assert_real_samples_close;
 use quanticsgrids::{DiscretizedGrid, UnfoldingScheme};
-use tensor4all_core::{ColMajorArrayRef, IndexLike};
+use tensor4all_core::ColMajorArrayRef;
 use tensor4all_treetci::{
     crossinterpolate2, GlobalIndexBatch, SimpleProposer, TreeTciEdge, TreeTciGraph, TreeTciOptions,
 };
@@ -27,17 +27,20 @@ fn evaluate_treetn(
     tn: &tensor4all_treetn::TreeTN<tensor4all_core::TensorDynLen, usize>,
     point: &[usize],
 ) -> f64 {
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
-    // Build position map: vertex -> position in index_ids
-    let mut data = vec![0usize; index_ids.len()];
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
+    // Build position map: vertex -> position in indices
+    let mut data = vec![0usize; indices.len()];
     for (site, &value) in point.iter().enumerate() {
-        let site_id = *tn.site_space(&site).unwrap().iter().next().unwrap().id();
-        let pos = index_ids.iter().position(|id| *id == site_id).unwrap();
+        let site_index = tn.site_space(&site).unwrap().iter().next().unwrap();
+        let pos = indices
+            .iter()
+            .position(|index| index == site_index)
+            .unwrap();
         data[pos] = value;
     }
-    let shape = [index_ids.len(), 1];
+    let shape = [indices.len(), 1];
     let values = ColMajorArrayRef::new(&data, &shape);
-    tn.evaluate(&index_ids, values).unwrap()[0].real()
+    tn.evaluate(&indices, values).unwrap()[0].real()
 }
 
 fn batch_eval_from_point<T: Clone>(

--- a/crates/tensor4all-treetci/tests/simple_parity.rs
+++ b/crates/tensor4all-treetci/tests/simple_parity.rs
@@ -3,7 +3,7 @@ mod common;
 use anyhow::Result;
 use common::{assert_complex_samples_close, assert_real_samples_close};
 use num_complex::Complex64;
-use tensor4all_core::{ColMajorArrayRef, IndexLike};
+use tensor4all_core::ColMajorArrayRef;
 use tensor4all_treetci::{
     crossinterpolate2, DefaultProposer, GlobalIndexBatch, SimpleProposer, TreeTciEdge,
     TreeTciGraph, TreeTciOptions,
@@ -63,23 +63,26 @@ fn simple_tree_parity_matches_reference_points() {
     )
     .unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
-    // Build position map: vertex -> position in index_ids
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
+    // Build position map: vertex -> position in indices
     let pos: Vec<usize> = (0..7)
         .map(|v| {
-            let site_id = *tn.site_space(&v).unwrap().iter().next().unwrap().id();
-            index_ids.iter().position(|id| *id == site_id).unwrap()
+            let site_index = tn.site_space(&v).unwrap().iter().next().unwrap();
+            indices
+                .iter()
+                .position(|index| index == site_index)
+                .unwrap()
         })
         .collect();
 
     let eval = |point: [usize; 7]| -> f64 {
-        let mut data = vec![0usize; index_ids.len()];
+        let mut data = vec![0usize; indices.len()];
         for (v, &val) in point.iter().enumerate() {
             data[pos[v]] = val;
         }
-        let shape = [index_ids.len(), 1];
+        let shape = [indices.len(), 1];
         let values = ColMajorArrayRef::new(&data, &shape);
-        tn.evaluate(&index_ids, values).unwrap()[0].real()
+        tn.evaluate(&indices, values).unwrap()[0].real()
     };
 
     let got = [
@@ -116,22 +119,25 @@ fn simple_tree_product_function_is_exact_on_branching_tree() {
     )
     .unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
     let pos: Vec<usize> = (0..7)
         .map(|v| {
-            let site_id = *tn.site_space(&v).unwrap().iter().next().unwrap().id();
-            index_ids.iter().position(|id| *id == site_id).unwrap()
+            let site_index = tn.site_space(&v).unwrap().iter().next().unwrap();
+            indices
+                .iter()
+                .position(|index| index == site_index)
+                .unwrap()
         })
         .collect();
 
     let eval = |point: [usize; 7]| -> f64 {
-        let mut data = vec![0usize; index_ids.len()];
+        let mut data = vec![0usize; indices.len()];
         for (v, &val) in point.iter().enumerate() {
             data[pos[v]] = val;
         }
-        let shape = [index_ids.len(), 1];
+        let shape = [indices.len(), 1];
         let values = ColMajorArrayRef::new(&data, &shape);
-        tn.evaluate(&index_ids, values).unwrap()[0].real()
+        tn.evaluate(&indices, values).unwrap()[0].real()
     };
 
     let got = [
@@ -172,22 +178,25 @@ fn simple_tree_complex_product_function_is_exact_on_branching_tree() {
     )
     .unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
     let pos: Vec<usize> = (0..7)
         .map(|v| {
-            let site_id = *tn.site_space(&v).unwrap().iter().next().unwrap().id();
-            index_ids.iter().position(|id| *id == site_id).unwrap()
+            let site_index = tn.site_space(&v).unwrap().iter().next().unwrap();
+            indices
+                .iter()
+                .position(|index| index == site_index)
+                .unwrap()
         })
         .collect();
 
     let eval = |point: [usize; 7]| {
-        let mut data = vec![0usize; index_ids.len()];
+        let mut data = vec![0usize; indices.len()];
         for (v, &val) in point.iter().enumerate() {
             data[pos[v]] = val;
         }
-        let shape = [index_ids.len(), 1];
+        let shape = [indices.len(), 1];
         let values = ColMajorArrayRef::new(&data, &shape);
-        tn.evaluate(&index_ids, values)
+        tn.evaluate(&indices, values)
             .unwrap()
             .into_iter()
             .next()
@@ -236,25 +245,28 @@ fn simple_tree_complex_product_function_is_exact_on_two_site_tree() {
     )
     .unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
     let pos: Vec<usize> = (0..2)
         .map(|v| {
-            let site_id = *tn.site_space(&v).unwrap().iter().next().unwrap().id();
-            index_ids.iter().position(|id| *id == site_id).unwrap()
+            let site_index = tn.site_space(&v).unwrap().iter().next().unwrap();
+            indices
+                .iter()
+                .position(|index| index == site_index)
+                .unwrap()
         })
         .collect();
 
     let got = [[0, 0], [0, 1], [1, 0], [1, 1]]
         .into_iter()
         .map(|point| {
-            let mut data = vec![0usize; index_ids.len()];
+            let mut data = vec![0usize; indices.len()];
             for (v, &val) in point.iter().enumerate() {
                 data[pos[v]] = val;
             }
-            let shape = [index_ids.len(), 1];
+            let shape = [indices.len(), 1];
             let values = ColMajorArrayRef::new(&data, &shape);
             let value = tn
-                .evaluate(&index_ids, values)
+                .evaluate(&indices, values)
                 .unwrap()
                 .into_iter()
                 .next()

--- a/crates/tensor4all-treetn/examples/bench_swap_interleave_r45.rs
+++ b/crates/tensor4all-treetn/examples/bench_swap_interleave_r45.rs
@@ -7,10 +7,7 @@ use tensor4all_treetn::{SwapOptions, TreeTN};
 fn build_tn(
     r: usize,
     bond_dim: usize,
-) -> (
-    TreeTN<TensorDynLen, String>,
-    HashMap<<DynIndex as IndexLike>::Id, String>,
-) {
+) -> (TreeTN<TensorDynLen, String>, HashMap<DynIndex, String>) {
     let n = 2 * r;
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
     let mut tn = TreeTN::<TensorDynLen, String>::new();
@@ -45,8 +42,8 @@ fn build_tn(
     }
     let mut target = HashMap::new();
     for k in 0..r {
-        target.insert(x_inds[k].id().to_owned(), (2 * k).to_string());
-        target.insert(y_inds[k].id().to_owned(), (2 * k + 1).to_string());
+        target.insert(x_inds[k].clone(), (2 * k).to_string());
+        target.insert(y_inds[k].clone(), (2 * k + 1).to_string());
     }
     (tn, target)
 }

--- a/crates/tensor4all-treetn/src/link_index_network.rs
+++ b/crates/tensor4all-treetn/src/link_index_network.rs
@@ -1,6 +1,6 @@
 //! Link Index Network for bond/link index management.
 //!
-//! Provides efficient reverse lookup from index ID to edge.
+//! Provides efficient reverse lookup from full index metadata to edge.
 //! This complements `SiteIndexNetwork` (which handles site/physical indices)
 //! by handling link/bond indices between nodes.
 
@@ -11,7 +11,7 @@ use tensor4all_core::IndexLike;
 
 /// Link Index Network: manages bond/link indices with reverse lookup.
 ///
-/// Provides O(1) lookup from index ID to the edge containing that index.
+/// Provides O(1) lookup from an index to the edge containing that index.
 /// This is essential for efficient `replaceind` operations on TreeTN.
 ///
 /// # Type Parameters
@@ -21,8 +21,8 @@ pub struct LinkIndexNetwork<I>
 where
     I: IndexLike,
 {
-    /// Reverse lookup: index ID → edge containing this index
-    index_to_edge: HashMap<I::Id, EdgeIndex>,
+    /// Reverse lookup: full index metadata → edge containing this index.
+    index_to_edge: HashMap<I, EdgeIndex>,
 }
 
 impl<I> Default for LinkIndexNetwork<I>
@@ -58,7 +58,7 @@ where
     /// * `edge` - The edge index
     /// * `index` - The link index on this edge
     pub fn insert(&mut self, edge: EdgeIndex, index: &I) {
-        self.index_to_edge.insert(index.id().clone(), edge);
+        self.index_to_edge.insert(index.clone(), edge);
     }
 
     /// Remove a link index registration.
@@ -69,7 +69,7 @@ where
     /// # Returns
     /// The edge that was associated with this index, if any.
     pub fn remove(&mut self, index: &I) -> Option<EdgeIndex> {
-        self.index_to_edge.remove(index.id())
+        self.index_to_edge.remove(index)
     }
 
     /// Find the edge containing a given index.
@@ -80,22 +80,24 @@ where
     /// # Returns
     /// The edge containing this index, or None if not found.
     pub fn find_edge(&self, index: &I) -> Option<EdgeIndex> {
-        self.index_to_edge.get(index.id()).copied()
+        self.index_to_edge.get(index).copied()
     }
 
     /// Find the edge containing an index by ID.
     pub fn find_edge_by_id(&self, id: &I::Id) -> Option<EdgeIndex> {
-        self.index_to_edge.get(id).copied()
+        self.index_to_edge
+            .iter()
+            .find_map(|(index, edge)| (index.id() == id).then_some(*edge))
     }
 
     /// Check if an index is registered.
     pub fn contains(&self, index: &I) -> bool {
-        self.index_to_edge.contains_key(index.id())
+        self.index_to_edge.contains_key(index)
     }
 
     /// Check if an index ID is registered.
     pub fn contains_id(&self, id: &I::Id) -> bool {
-        self.index_to_edge.contains_key(id)
+        self.index_to_edge.keys().any(|index| index.id() == id)
     }
 
     /// Update the index for an edge (e.g., after SVD creates new bond index).
@@ -113,17 +115,17 @@ where
         new_index: &I,
         edge: EdgeIndex,
     ) -> Result<(), String> {
-        match self.index_to_edge.remove(old_index.id()) {
+        match self.index_to_edge.remove(old_index) {
             Some(old_edge) => {
                 if old_edge != edge {
                     // Restore and return error
-                    self.index_to_edge.insert(old_index.id().clone(), old_edge);
+                    self.index_to_edge.insert(old_index.clone(), old_edge);
                     return Err(format!(
                         "Edge mismatch: old_index was on edge {:?}, not {:?}",
                         old_edge, edge
                     ));
                 }
-                self.index_to_edge.insert(new_index.id().clone(), edge);
+                self.index_to_edge.insert(new_index.clone(), edge);
                 Ok(())
             }
             None => Err(format!(
@@ -148,8 +150,8 @@ where
         self.index_to_edge.clear();
     }
 
-    /// Iterate over all (index_id, edge) pairs.
-    pub fn iter(&self) -> impl Iterator<Item = (&I::Id, &EdgeIndex)> {
+    /// Iterate over all (index, edge) pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&I, &EdgeIndex)> {
         self.index_to_edge.iter()
     }
 }

--- a/crates/tensor4all-treetn/src/link_index_network.rs
+++ b/crates/tensor4all-treetn/src/link_index_network.rs
@@ -83,21 +83,9 @@ where
         self.index_to_edge.get(index).copied()
     }
 
-    /// Find the edge containing an index by ID.
-    pub fn find_edge_by_id(&self, id: &I::Id) -> Option<EdgeIndex> {
-        self.index_to_edge
-            .iter()
-            .find_map(|(index, edge)| (index.id() == id).then_some(*edge))
-    }
-
     /// Check if an index is registered.
     pub fn contains(&self, index: &I) -> bool {
         self.index_to_edge.contains_key(index)
-    }
-
-    /// Check if an index ID is registered.
-    pub fn contains_id(&self, id: &I::Id) -> bool {
-        self.index_to_edge.keys().any(|index| index.id() == id)
     }
 
     /// Update the index for an edge (e.g., after SVD creates new bond index).

--- a/crates/tensor4all-treetn/src/link_index_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/link_index_network/tests/mod.rs
@@ -51,36 +51,6 @@ fn test_remove() {
 }
 
 #[test]
-fn test_find_edge_by_id() {
-    let mut network: LinkIndexNetwork<DynIndex> = LinkIndexNetwork::new();
-
-    let idx = DynIndex::new_dyn(4);
-    let edge = EdgeIndex::new(0);
-
-    network.insert(edge, &idx);
-    assert_eq!(network.find_edge_by_id(idx.id()), Some(edge));
-
-    // Non-existent ID
-    let other = DynIndex::new_dyn(4);
-    assert_eq!(network.find_edge_by_id(other.id()), None);
-}
-
-#[test]
-fn test_contains_id() {
-    let mut network: LinkIndexNetwork<DynIndex> = LinkIndexNetwork::new();
-
-    let idx = DynIndex::new_dyn(4);
-    let edge = EdgeIndex::new(0);
-
-    assert!(!network.contains_id(idx.id()));
-    network.insert(edge, &idx);
-    assert!(network.contains_id(idx.id()));
-
-    let other = DynIndex::new_dyn(4);
-    assert!(!network.contains_id(other.id()));
-}
-
-#[test]
 fn test_with_capacity() {
     let network: LinkIndexNetwork<DynIndex> = LinkIndexNetwork::with_capacity(10);
     assert!(network.is_empty());

--- a/crates/tensor4all-treetn/src/link_index_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/link_index_network/tests/mod.rs
@@ -123,8 +123,8 @@ fn test_iter() {
     assert_eq!(items.len(), 2);
 
     // Verify both entries are present
-    let has_idx1 = items.iter().any(|(id, &e)| *id == idx1.id() && e == edge1);
-    let has_idx2 = items.iter().any(|(id, &e)| *id == idx2.id() && e == edge2);
+    let has_idx1 = items.iter().any(|(idx, &e)| *idx == &idx1 && e == edge1);
+    let has_idx2 = items.iter().any(|(idx, &e)| *idx == &idx2 && e == edge2);
     assert!(has_idx1);
     assert!(has_idx2);
 }

--- a/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
@@ -227,11 +227,7 @@ where
                     Some(b) => b.clone(),
                     None => continue,
                 };
-                if contracted
-                    .external_indices()
-                    .iter()
-                    .any(|i| i.id() == bra_bond.id())
-                {
+                if contracted.external_indices().iter().any(|i| i == &bra_bond) {
                     contracted = contracted.replaceind(&bra_bond, &ket_bond)?;
                 }
             }
@@ -240,9 +236,11 @@ where
         // Align result to v's index order
         let v_inds = v.external_indices();
         let res_inds = contracted.external_indices();
-        let v_ids: std::collections::HashSet<_> = v_inds.iter().map(|i| i.id()).collect();
-        let res_ids: std::collections::HashSet<_> = res_inds.iter().map(|i| i.id()).collect();
-        if v_ids == res_ids && v_inds.len() == res_inds.len() {
+        let v_index_keys: std::collections::HashSet<_> =
+            v_inds.iter().map(|i| (i.clone(), i.dim())).collect();
+        let res_index_keys: std::collections::HashSet<_> =
+            res_inds.iter().map(|i| (i.clone(), i.dim())).collect();
+        if v_index_keys == res_index_keys && v_inds.len() == res_inds.len() {
             contracted = contracted.permuteinds(&v_inds)?;
         }
 

--- a/crates/tensor4all-treetn/src/linsolve/square/local_linop.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/local_linop.rs
@@ -116,12 +116,8 @@ where
                         None => continue,
                     };
 
-                    // Only replace if hx actually contains the bra bond
-                    if hx
-                        .external_indices()
-                        .iter()
-                        .any(|idx| idx.id() == bra_bond.id())
-                    {
+                    // Only replace if hx actually contains the exact bra bond.
+                    if hx.external_indices().iter().any(|idx| idx == bra_bond) {
                         hx = hx.replaceind(bra_bond, ket_bond)?;
                     }
                 }
@@ -133,25 +129,27 @@ where
             return hx.scale(self.a1.clone());
         }
 
-        // Align hx indices to match x's index order for axpby
-        // Check that hx and x have the same index structure (by ID and count)
+        // Align hx indices to match x's index order for axpby.
+        // Check that hx and x have the same full index structure.
         let x_indices = x.external_indices();
         let hx_indices = hx.external_indices();
-        let x_ids: std::collections::HashSet<_> = x_indices.iter().map(|i| i.id()).collect();
-        let hx_ids: std::collections::HashSet<_> = hx_indices.iter().map(|i| i.id()).collect();
+        let x_index_keys: std::collections::HashSet<_> =
+            x_indices.iter().map(|i| (i.clone(), i.dim())).collect();
+        let hx_index_keys: std::collections::HashSet<_> =
+            hx_indices.iter().map(|i| (i.clone(), i.dim())).collect();
 
-        let hx_aligned = if x_ids == hx_ids && x_indices.len() == hx_indices.len() {
+        let hx_aligned = if x_index_keys == hx_index_keys && x_indices.len() == hx_indices.len() {
             // Same index set and count - permute to match order
             hx.permuteinds(&x_indices)?
         } else {
             return Err(anyhow::anyhow!(
-                "LocalLinOp::apply: index structure mismatch between operator output (hx) and input (x):\n  x has {} indices: {:?}\n  hx has {} indices: {:?}\n  x IDs: {:?}\n  hx IDs: {:?}\n\nThis suggests the projected operator application produced output with different index structure than expected.",
+                "LocalLinOp::apply: index structure mismatch between operator output (hx) and input (x):\n  x has {} indices: {:?}\n  hx has {} indices: {:?}\n  x index keys: {:?}\n  hx index keys: {:?}\n\nThis suggests the projected operator application produced output with different index structure than expected.",
                 x_indices.len(),
                 x_indices.iter().map(|i| format!("{:?}:{}", i.id(), i.dim())).collect::<Vec<_>>(),
                 hx_indices.len(),
                 hx_indices.iter().map(|i| format!("{:?}:{}", i.id(), i.dim())).collect::<Vec<_>>(),
-                x_ids.iter().collect::<Vec<_>>(),
-                hx_ids.iter().collect::<Vec<_>>(),
+                x_index_keys.iter().map(|(i, dim)| format!("{i:?}:{dim}")).collect::<Vec<_>>(),
+                hx_index_keys.iter().map(|(i, dim)| format!("{i:?}:{dim}")).collect::<Vec<_>>(),
             ));
         };
 

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -372,30 +372,30 @@ where
 
     /// Build TreeTopology for the subtree region from the solved tensor.
     ///
-    /// Maps each node to the index IDs belonging to it in the solved tensor.
+    /// Maps each node to the indices belonging to it in the solved tensor.
     fn build_subtree_topology(
         &self,
         solved_tensor: &T,
         region: &[V],
         full_treetn: &TreeTN<T, V>,
-    ) -> Result<TreeTopology<V, <T::Index as IndexLike>::Id>> {
+    ) -> Result<TreeTopology<V, T::Index>> {
         use std::collections::HashMap;
 
-        let mut nodes: HashMap<V, Vec<<T::Index as IndexLike>::Id>> = HashMap::new();
+        let mut nodes: HashMap<V, Vec<T::Index>> = HashMap::new();
         let mut edges: Vec<(V, V)> = Vec::new();
 
         let solved_indices = solved_tensor.external_indices();
 
-        // For each node in the region, find which index IDs belong to it
+        // For each node in the region, find which indices belong to it.
         for node in region {
-            let mut ids = Vec::new();
+            let mut indices = Vec::new();
 
             // Get site indices for this node
             if let Some(site_indices) = full_treetn.site_space(node) {
                 for site_idx in site_indices {
-                    // Verify the index exists in solved_tensor and collect its ID
-                    if solved_indices.iter().any(|idx| idx.id() == site_idx.id()) {
-                        ids.push(site_idx.id().clone());
+                    // Verify the index exists in solved_tensor and collect it.
+                    if solved_indices.iter().any(|idx| idx == site_idx) {
+                        indices.push(site_idx.clone());
                     }
                 }
             }
@@ -406,15 +406,15 @@ where
                     // This is an external neighbor - the bond belongs to this node
                     if let Some(edge) = full_treetn.edge_between(node, &neighbor) {
                         if let Some(bond) = full_treetn.bond_index(edge) {
-                            if solved_indices.iter().any(|idx| idx.id() == bond.id()) {
-                                ids.push(bond.id().clone());
+                            if solved_indices.iter().any(|idx| idx == bond) {
+                                indices.push(bond.clone());
                             }
                         }
                     }
                 }
             }
 
-            nodes.insert(node.clone(), ids);
+            nodes.insert(node.clone(), indices);
         }
 
         // Build edges between nodes in the region
@@ -439,10 +439,10 @@ where
     ) -> Result<()> {
         use std::collections::HashMap;
 
-        // Phase 1: Build a mapping from decomposed bond IDs to new bond indices
+        // Phase 1: Build a mapping from decomposed bonds to new bond indices
         // For internal bonds, we create a single new bond index that will be used
         // for both nodes sharing that edge
-        let mut bond_mapping: HashMap<<T::Index as IndexLike>::Id, T::Index> = HashMap::new();
+        let mut bond_mapping: HashMap<T::Index, T::Index> = HashMap::new();
 
         for (i, node_a) in region.iter().enumerate() {
             for node_b in region.iter().skip(i + 1) {
@@ -453,7 +453,7 @@ where
                         // Use sim() once for this edge to avoid ID collisions.
                         if let Some(orig_edge) = subtree.edge_between(node_a, node_b) {
                             let new_bond = decomp_bond.sim();
-                            bond_mapping.insert(decomp_bond.id().clone(), new_bond.clone());
+                            bond_mapping.insert(decomp_bond.clone(), new_bond.clone());
 
                             // Update the edge bond in subtree
                             subtree.replace_edge_bond(orig_edge, new_bond)?;
@@ -479,7 +479,7 @@ where
                     // Internal bond - use the mapped bond
                     if let Some(decomp_edge) = decomposed.edge_between(node, &neighbor) {
                         if let Some(decomp_bond) = decomposed.bond_index(decomp_edge) {
-                            if let Some(new_bond) = bond_mapping.get(decomp_bond.id()) {
+                            if let Some(new_bond) = bond_mapping.get(decomp_bond) {
                                 new_tensor = new_tensor.replaceind(decomp_bond, new_bond)?;
                             }
                         }
@@ -514,20 +514,20 @@ where
         // the current `state`. For GMRES operations (like b - A*x), they must match.
         //
         // For MPO cases, external indices should match (validated earlier), but the order
-        // may differ. We use ID-based matching to align them.
+        // may differ. Use full index matching to align them.
         let init_indices = init.external_indices();
         let rhs_indices = rhs_local_raw.external_indices();
 
         let rhs_local = if self.index_sets_match(&init_indices, &rhs_indices) {
-            // Same set of indices (by ID) and same count - check if order matches
+            // Same set of indices and same count - check if order matches
             let indices_match = init_indices
                 .iter()
                 .zip(rhs_indices.iter())
-                .all(|(ii, ri)| ii.id() == ri.id() && ii.dim() == ri.dim());
+                .all(|(ii, ri)| ii == ri && ii.dim() == ri.dim());
             if indices_match {
                 rhs_local_raw
             } else {
-                // Permute RHS indices to init index order (matched by ID)
+                // Permute RHS indices to init index order.
                 // Note: permuteinds requires same length, which we've already checked
                 rhs_local_raw.permuteinds(&init_indices)?
             }
@@ -588,13 +588,12 @@ where
         // Extract updated region from ket_state
         let ket_region = ket_state.extract_subtree(&step.nodes)?;
 
-        // Build mapping from ket bond IDs to reference bond indices for *all* bonds incident to the region.
+        // Build mapping from ket bonds to reference bond indices for *all* bonds incident to the region.
         //
-        // Important: reference_state bond IDs must remain stable across steps, even when an edge alternates
+        // Important: reference_state bonds must remain stable across steps, even when an edge alternates
         // between being a boundary edge and an internal edge in different steps (as happens in sweeps).
-        // Therefore, we always reuse the current reference_state bond indices, and never create fresh IDs here.
-        let mut ket_to_ref_bond_map: HashMap<<T::Index as IndexLike>::Id, T::Index> =
-            HashMap::new();
+        // Therefore, we always reuse the current reference_state bond indices, and never create fresh bonds here.
+        let mut ket_to_ref_bond_map: HashMap<T::Index, T::Index> = HashMap::new();
 
         // Populate mapping for all edges incident to region nodes.
         // - Boundary edges (region ↔ outside): use reference_state's existing bond IDs for cache stability
@@ -626,7 +625,7 @@ where
                         None => continue,
                     }
                 };
-                ket_to_ref_bond_map.insert(ket_bond.id().clone(), ref_bond);
+                ket_to_ref_bond_map.insert(ket_bond.clone(), ref_bond);
             }
         }
 
@@ -660,7 +659,7 @@ where
             for neighbor in neighbors {
                 if let Some(edge) = ref_region.edge_between(node, &neighbor) {
                     if let Some(bond) = ref_region.bond_index(edge) {
-                        if let Some(new_bond) = ket_to_ref_bond_map.get(bond.id()) {
+                        if let Some(new_bond) = ket_to_ref_bond_map.get(bond) {
                             edges_to_update.push((node.clone(), neighbor, new_bond.clone()));
                         }
                     }
@@ -683,10 +682,10 @@ where
 
                     for ket_idx in &tensor_indices {
                         // Replace if this index is one of the region's bond indices (internal or boundary)
-                        if let Some(ref_bond) = ket_to_ref_bond_map.get(ket_idx.id()) {
+                        if let Some(ref_bond) = ket_to_ref_bond_map.get(ket_idx) {
                             new_tensor = new_tensor.replaceind(ket_idx, ref_bond)?;
                         }
-                        // Site indices are kept as-is (same IDs in reference and ket)
+                        // Site indices are kept as-is.
                     }
 
                     ref_region.replace_tensor(node_idx, new_tensor)?;
@@ -821,9 +820,11 @@ where
         if init_indices.len() != rhs_indices.len() {
             return false;
         }
-        let init_ids: std::collections::HashSet<_> = init_indices.iter().map(|i| i.id()).collect();
-        let rhs_ids: std::collections::HashSet<_> = rhs_indices.iter().map(|i| i.id()).collect();
-        init_ids == rhs_ids
+        let init_keys: std::collections::HashSet<_> =
+            init_indices.iter().map(|i| (i.clone(), i.dim())).collect();
+        let rhs_keys: std::collections::HashSet<_> =
+            rhs_indices.iter().map(|i| (i.clone(), i.dim())).collect();
+        init_keys == rhs_keys
     }
 
     fn index_structure_mismatch_message(
@@ -833,27 +834,17 @@ where
         header: &str,
         footer: &str,
     ) -> String {
-        let init_ids: std::collections::HashSet<_> = init_indices.iter().map(|i| i.id()).collect();
-        let rhs_ids: std::collections::HashSet<_> = rhs_indices.iter().map(|i| i.id()).collect();
-        let extra_in_rhs: Vec<_> = rhs_ids
-            .difference(&init_ids)
-            .map(|id| {
-                rhs_indices
-                    .iter()
-                    .find(|i| i.id() == *id)
-                    .map(|i| format!("{:?}:{}", id, i.dim()))
-                    .unwrap_or_else(|| format!("{:?}:?", id))
-            })
+        let init_keys: std::collections::HashSet<_> =
+            init_indices.iter().map(|i| (i.clone(), i.dim())).collect();
+        let rhs_keys: std::collections::HashSet<_> =
+            rhs_indices.iter().map(|i| (i.clone(), i.dim())).collect();
+        let extra_in_rhs: Vec<_> = rhs_keys
+            .difference(&init_keys)
+            .map(|(idx, dim)| format!("{idx:?}:{dim}"))
             .collect();
-        let missing_in_rhs: Vec<_> = init_ids
-            .difference(&rhs_ids)
-            .map(|id| {
-                init_indices
-                    .iter()
-                    .find(|i| i.id() == *id)
-                    .map(|i| format!("{:?}:{}", id, i.dim()))
-                    .unwrap_or_else(|| format!("{:?}:?", id))
-            })
+        let missing_in_rhs: Vec<_> = init_keys
+            .difference(&rhs_keys)
+            .map(|(idx, dim)| format!("{idx:?}:{dim}"))
             .collect();
 
         format!(
@@ -988,5 +979,26 @@ where
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tensor4all_core::{DynIndex, TensorDynLen};
+
+    use super::*;
+
+    #[test]
+    fn index_sets_match_distinguishes_same_id_prime_pair() {
+        let updater = SquareLinsolveUpdater::<TensorDynLen, usize>::new(
+            TreeTN::new(),
+            TreeTN::new(),
+            LinsolveOptions::default(),
+        );
+        let i = DynIndex::new_dyn(2);
+        let i_prime = i.prime();
+
+        assert!(updater.index_sets_match(std::slice::from_ref(&i), std::slice::from_ref(&i)));
+        assert!(!updater.index_sets_match(&[i], &[i_prime]));
     }
 }

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -1021,7 +1021,7 @@ where
 
         // Check input mappings
         for (node, mapping) in &self.input_mapping {
-            if mapping.true_index.same_id(old_index) {
+            if mapping.true_index == *old_index && mapping.true_index.dim() == old_index.dim() {
                 result.input_mapping.insert(
                     node.clone(),
                     IndexMapping {
@@ -1035,7 +1035,7 @@ where
 
         // Check output mappings
         for (node, mapping) in &self.output_mapping {
-            if mapping.true_index.same_id(old_index) {
+            if mapping.true_index == *old_index && mapping.true_index.dim() == old_index.dim() {
                 result.output_mapping.insert(
                     node.clone(),
                     IndexMapping {

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -449,6 +449,10 @@ fn test_linear_operator_tensor_index() {
     let new_idx = make_index(2);
     let replaced = lin_op.replaceind(&true_s0, &new_idx).unwrap();
     assert!(replaced.get_input_mapping(&"N0".to_string()).is_some());
+
+    let same_id_prime = true_s0.prime();
+    let wrong_prime = lin_op.replaceind(&same_id_prime, &make_index(2));
+    assert!(wrong_prime.is_err());
 }
 
 #[test]
@@ -900,9 +904,9 @@ fn test_apply_linear_operator_partial_shift_factorized_rooted_state_intermediate
     .unwrap();
 
     let mut nodes = HashMap::new();
-    nodes.insert(0usize, vec![*s0.id()]);
-    nodes.insert(1usize, vec![*s1.id()]);
-    nodes.insert(2usize, vec![*spectator.id()]);
+    nodes.insert(0usize, vec![s0.clone()]);
+    nodes.insert(1usize, vec![s1.clone()]);
+    nodes.insert(2usize, vec![spectator.clone()]);
     let topology = crate::TreeTopology::new(nodes, vec![(0usize, 1usize), (1usize, 2usize)]);
     let state = crate::factorize_tensor_to_treetn(&dense, &topology, &2usize).unwrap();
     let mut state_edges = state.site_index_network().edges().collect::<Vec<_>>();

--- a/crates/tensor4all-treetn/src/site_index_network.rs
+++ b/crates/tensor4all-treetn/src/site_index_network.rs
@@ -159,16 +159,6 @@ where
         self.index_to_node.get(index)
     }
 
-    /// Find the node containing an index by ID.
-    pub fn find_node_by_index_id(&self, id: &I::Id) -> Option<&NodeName> {
-        self.site_spaces.iter().find_map(|(node_name, site_space)| {
-            site_space
-                .iter()
-                .any(|index| index.id() == id)
-                .then_some(node_name)
-        })
-    }
-
     /// Check if a site index is registered.
     pub fn contains_index(&self, index: &I) -> bool {
         self.index_to_node.contains_key(index)

--- a/crates/tensor4all-treetn/src/site_index_network.rs
+++ b/crates/tensor4all-treetn/src/site_index_network.rs
@@ -61,8 +61,8 @@ where
     topology: NodeNameNetwork<NodeName>,
     /// Site space (physical indices) for each node.
     site_spaces: HashMap<NodeName, HashSet<I>>,
-    /// Reverse lookup: index ID → node name containing this index.
-    index_to_node: HashMap<I::Id, NodeName>,
+    /// Reverse lookup: full index metadata → node name containing this index.
+    index_to_node: HashMap<I, NodeName>,
 }
 
 impl<NodeName, I> SiteIndexNetwork<NodeName, I>
@@ -102,10 +102,9 @@ where
     ) -> Result<NodeIndex, String> {
         let node_idx = self.topology.add_node(node_name.clone())?;
         let site_space_set = site_space.into();
-        // Update reverse lookup for all indices
+        // Update reverse lookup for all indices.
         for idx in &site_space_set {
-            self.index_to_node
-                .insert(idx.id().clone(), node_name.clone());
+            self.index_to_node.insert(idx.clone(), node_name.clone());
         }
         self.site_spaces.insert(node_name, site_space_set);
         Ok(node_idx)
@@ -128,8 +127,7 @@ where
             .ok_or_else(|| format!("Node {:?} not found", old_name))?;
         self.topology.rename_node(old_name, new_name.clone())?;
         for index in &site_space {
-            self.index_to_node
-                .insert(index.id().clone(), new_name.clone());
+            self.index_to_node.insert(index.clone(), new_name.clone());
         }
         self.site_spaces.insert(new_name, site_space);
         Ok(())
@@ -158,17 +156,22 @@ where
     /// # Returns
     /// The node name containing this index, or None if not found.
     pub fn find_node_by_index(&self, index: &I) -> Option<&NodeName> {
-        self.index_to_node.get(index.id())
+        self.index_to_node.get(index)
     }
 
     /// Find the node containing an index by ID.
     pub fn find_node_by_index_id(&self, id: &I::Id) -> Option<&NodeName> {
-        self.index_to_node.get(id)
+        self.site_spaces.iter().find_map(|(node_name, site_space)| {
+            site_space
+                .iter()
+                .any(|index| index.id() == id)
+                .then_some(node_name)
+        })
     }
 
     /// Check if a site index is registered.
     pub fn contains_index(&self, index: &I) -> bool {
-        self.index_to_node.contains_key(index.id())
+        self.index_to_node.contains_key(index)
     }
 
     /// Add a site index to a node's site space.
@@ -180,8 +183,7 @@ where
             .get_mut(node_name)
             .ok_or_else(|| format!("Node {:?} not found", node_name))?;
         site_space.insert(index.clone());
-        self.index_to_node
-            .insert(index.id().clone(), node_name.clone());
+        self.index_to_node.insert(index, node_name.clone());
         Ok(())
     }
 
@@ -195,7 +197,7 @@ where
             .ok_or_else(|| format!("Node {:?} not found", node_name))?;
         let removed = site_space.remove(index);
         if removed {
-            self.index_to_node.remove(index.id());
+            self.index_to_node.remove(index);
         }
         Ok(removed)
     }
@@ -220,10 +222,9 @@ where
                 node_name
             ));
         }
-        self.index_to_node.remove(old_index.id());
+        self.index_to_node.remove(old_index);
         site_space.insert(new_index.clone());
-        self.index_to_node
-            .insert(new_index.id().clone(), node_name.clone());
+        self.index_to_node.insert(new_index, node_name.clone());
         Ok(())
     }
 
@@ -243,15 +244,15 @@ where
 
         // Remove old indices from index_to_node
         for old_idx in site_space.iter() {
-            if self.index_to_node.get(old_idx.id()) == Some(node_name) {
-                self.index_to_node.remove(old_idx.id());
+            if self.index_to_node.get(old_idx) == Some(node_name) {
+                self.index_to_node.remove(old_idx);
             }
         }
 
         // Add new indices to index_to_node
         for new_idx in &new_indices {
             self.index_to_node
-                .insert(new_idx.id().clone(), node_name.clone());
+                .insert(new_idx.clone(), node_name.clone());
         }
 
         // Replace site space

--- a/crates/tensor4all-treetn/src/site_index_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/site_index_network/tests/mod.rs
@@ -465,16 +465,6 @@ fn test_site_space_mut() {
 }
 
 #[test]
-fn test_find_node_by_index_id() {
-    let mut net: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
-    let idx = DynIndex::new_dyn(2);
-    net.add_node("A".to_string(), HashSet::from([idx.clone()]))
-        .unwrap();
-
-    assert_eq!(net.find_node_by_index_id(idx.id()).unwrap(), "A");
-}
-
-#[test]
 fn test_edges_iterator() {
     let mut net: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
     let empty: HashSet<DynIndex> = HashSet::new();

--- a/crates/tensor4all-treetn/src/treetn/addition.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition.rs
@@ -45,7 +45,9 @@ where
         indices.sort_by(|left, right| {
             left.dim()
                 .cmp(&right.dim())
+                .then_with(|| left.plev().cmp(&right.plev()))
                 .then_with(|| left.id().cmp(right.id()))
+                .then_with(|| format!("{left:?}").cmp(&format!("{right:?}")))
         });
         indices
     }

--- a/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
@@ -88,6 +88,51 @@ fn make_two_matching_treetns_different_site_ids(
     (tn_a, tn_b)
 }
 
+fn make_same_id_prime_pair_mpo_like_indices() -> (Vec<DynIndex>, Vec<DynIndex>, Vec<DynIndex>) {
+    let inputs: Vec<_> = (0..3).map(|_| DynIndex::new_dyn(3)).collect();
+    let outputs: Vec<_> = inputs.iter().map(DynIndex::prime).collect();
+    let links = vec![
+        DynIndex::new_link(2).unwrap(),
+        DynIndex::new_link(2).unwrap(),
+    ];
+    (inputs, outputs, links)
+}
+
+fn scaled_sequence(scale: f64, len: usize) -> Vec<f64> {
+    (1..=len).map(|n| scale * n as f64).collect()
+}
+
+fn make_same_id_prime_pair_mpo_like_treetn(
+    scale: f64,
+    inputs: &[DynIndex],
+    outputs: &[DynIndex],
+    links: &[DynIndex],
+) -> TreeTN<TensorDynLen, usize> {
+    let tensors = vec![
+        TensorDynLen::from_dense(
+            vec![inputs[0].clone(), outputs[0].clone(), links[0].clone()],
+            scaled_sequence(scale, 18),
+        )
+        .unwrap(),
+        TensorDynLen::from_dense(
+            vec![
+                links[0].clone(),
+                inputs[1].clone(),
+                outputs[1].clone(),
+                links[1].clone(),
+            ],
+            scaled_sequence(scale, 36),
+        )
+        .unwrap(),
+        TensorDynLen::from_dense(
+            vec![links[1].clone(), inputs[2].clone(), outputs[2].clone()],
+            scaled_sequence(scale, 18),
+        )
+        .unwrap(),
+    ];
+    TreeTN::<TensorDynLen, usize>::from_tensors(tensors, vec![0, 1, 2]).unwrap()
+}
+
 #[test]
 fn test_compute_merged_bond_indices() {
     let (tn_a, tn_b, _s0, _s1) = make_two_matching_treetns();
@@ -230,5 +275,46 @@ fn test_add_aligned_accepts_equivalent_site_space_with_different_ids() {
         dense_sum.isapprox(&dense_expected, 1e-10, 0.0),
         "add_aligned failed: maxabs diff = {}",
         (&dense_sum - &dense_expected).maxabs()
+    );
+}
+
+#[test]
+fn test_add_preserves_same_id_prime_pair_site_indices() {
+    let (inputs, outputs, links) = make_same_id_prime_pair_mpo_like_indices();
+    let tn_a = make_same_id_prime_pair_mpo_like_treetn(1.0, &inputs, &outputs, &links);
+    let tn_b = make_same_id_prime_pair_mpo_like_treetn(-0.5, &inputs, &outputs, &links);
+
+    for site in 0..3 {
+        let site_space = tn_a.site_space(&site).unwrap();
+        assert_eq!(site_space.len(), 2);
+        assert!(site_space.contains(&inputs[site]));
+        assert!(site_space.contains(&outputs[site]));
+    }
+
+    let result = tn_a.add(&tn_b).unwrap();
+
+    assert_eq!(result.node_count(), 3);
+    assert_eq!(result.edge_count(), 2);
+    for site in 0..3 {
+        let site_space = result.site_space(&site).unwrap();
+        assert_eq!(site_space.len(), 2);
+        assert!(site_space.contains(&inputs[site]));
+        assert!(site_space.contains(&outputs[site]));
+    }
+
+    let dense_result = result.contract_to_tensor().unwrap();
+    let dense_expected = tn_a
+        .contract_to_tensor()
+        .unwrap()
+        .axpby(
+            tensor4all_core::AnyScalar::new_real(1.0),
+            &tn_b.contract_to_tensor().unwrap(),
+            tensor4all_core::AnyScalar::new_real(1.0),
+        )
+        .unwrap();
+    assert!(
+        dense_result.isapprox(&dense_expected, 1e-10, 0.0),
+        "same-id prime-pair MPO-like add failed: maxabs diff = {}",
+        (&dense_result - &dense_expected).maxabs()
     );
 }

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -767,19 +767,15 @@ where
 // Helper functions
 // ============================================================================
 
-/// Find common indices between two tensors (by ID).
+/// Find common indices between two tensors by exact index identity.
 fn find_common_indices<T: TensorLike>(a: &T, b: &T) -> Vec<T::Index>
 where
-    <T::Index as IndexLike>::Id: Eq + std::hash::Hash,
+    T::Index: Eq + std::hash::Hash,
 {
-    let a_ids: HashSet<_> = a
-        .external_indices()
-        .iter()
-        .map(|i| i.id().clone())
-        .collect();
+    let a_indices: HashSet<_> = a.external_indices().into_iter().collect();
     b.external_indices()
         .into_iter()
-        .filter(|i| a_ids.contains(i.id()))
+        .filter(|i| a_indices.contains(i))
         .collect()
 }
 
@@ -988,28 +984,25 @@ where
     // 2. Build topology from tn_a's structure and decompose
     use super::decompose::factorize_tensor_to_treetn_with;
 
-    // Build topology using index IDs (not positions).
+    // Build topology using full indices (not positions).
     // Consider site indices from BOTH tn_a and tn_b, since the contracted result
     // may contain indices from either network (non-contracted ones remain).
-    let mut nodes: HashMap<V, Vec<<T::Index as IndexLike>::Id>> = HashMap::new();
+    let mut nodes: HashMap<V, Vec<T::Index>> = HashMap::new();
     let contracted_indices = contracted_tensor.external_indices();
-    let contracted_ids: HashSet<_> = contracted_indices
-        .iter()
-        .map(|ci| ci.id().clone())
-        .collect();
+    let contracted_index_set: HashSet<_> = contracted_indices.iter().cloned().collect();
 
     // Collect node names in sorted order for deterministic assignment
     let mut node_names: Vec<_> = tn_a.node_names();
     node_names.sort();
 
     for node_name in &node_names {
-        let mut ids: Vec<<T::Index as IndexLike>::Id> = Vec::new();
+        let mut indices: Vec<T::Index> = Vec::new();
 
         // Collect remaining site indices from tn_a at this node
         if let Some(site_space_a) = tn_a.site_index_network.site_space(node_name) {
             for site_idx in site_space_a {
-                if contracted_ids.contains(site_idx.id()) {
-                    ids.push(site_idx.id().clone());
+                if contracted_index_set.contains(site_idx) {
+                    indices.push(site_idx.clone());
                 }
             }
         }
@@ -1017,13 +1010,13 @@ where
         // Also collect remaining site indices from tn_b at the same node
         if let Some(site_space_b) = tn_b.site_index_network.site_space(node_name) {
             for site_idx in site_space_b {
-                if contracted_ids.contains(site_idx.id()) && !ids.contains(site_idx.id()) {
-                    ids.push(site_idx.id().clone());
+                if contracted_index_set.contains(site_idx) && !indices.contains(site_idx) {
+                    indices.push(site_idx.clone());
                 }
             }
         }
 
-        nodes.insert(node_name.clone(), ids);
+        nodes.insert(node_name.clone(), indices);
     }
 
     // Get edges from the graph

--- a/crates/tensor4all-treetn/src/treetn/decompose.rs
+++ b/crates/tensor4all-treetn/src/treetn/decompose.rs
@@ -16,14 +16,15 @@ use super::TreeTN;
 // TreeTopology specification
 // ============================================================================
 
-/// Specification for tree topology: defines nodes and index ID assignments.
+/// Specification for tree topology: defines nodes and index assignments.
 ///
-/// `I` is the index ID type (e.g., `DynId`). Each node maps to the IDs of its
-/// physical indices in the input tensor. This ensures correct index lookup
-/// regardless of tensor index ordering, which can change during factorization.
+/// `I` is the full index type. Each node maps to the physical indices in the
+/// input tensor. This ensures correct index lookup regardless of tensor index
+/// ordering, which can change during factorization, while preserving distinct
+/// same-ID indices with different prime levels, tags, or directions.
 #[derive(Debug, Clone)]
 pub struct TreeTopology<V, I> {
-    /// Nodes in the tree (node name -> list of index IDs belonging to this node)
+    /// Nodes in the tree (node name -> list of indices belonging to this node)
     pub nodes: HashMap<V, Vec<I>>,
     /// Edges in the tree: (node_a, node_b)
     pub edges: Vec<(V, V)>,
@@ -33,7 +34,7 @@ impl<V: Clone + Hash + Eq, I: Clone + Eq> TreeTopology<V, I> {
     /// Create a new tree topology with the given nodes and edges.
     ///
     /// # Arguments
-    /// * `nodes` - Map from node name to the index IDs belonging to that node
+    /// * `nodes` - Map from node name to the indices belonging to that node
     /// * `edges` - List of edges as (node_a, node_b) pairs
     pub fn new(nodes: HashMap<V, Vec<I>>, edges: Vec<(V, V)>) -> Self {
         Self { nodes, edges }
@@ -94,7 +95,7 @@ impl<V: Clone + Hash + Eq, I: Clone + Eq> TreeTopology<V, I> {
 /// - Factorization fails
 pub fn factorize_tensor_to_treetn<T, V>(
     tensor: &T,
-    topology: &TreeTopology<V, <T::Index as IndexLike>::Id>,
+    topology: &TreeTopology<V, T::Index>,
     root: &V,
 ) -> Result<TreeTN<T, V>>
 where
@@ -131,7 +132,7 @@ where
 /// - Factorization fails
 pub fn factorize_tensor_to_treetn_with<T, V>(
     tensor: &T,
-    topology: &TreeTopology<V, <T::Index as IndexLike>::Id>,
+    topology: &TreeTopology<V, T::Index>,
     options: FactorizeOptions,
     root: &V,
 ) -> Result<TreeTN<T, V>>
@@ -145,7 +146,7 @@ where
 
 fn factorize_tensor_to_treetn_with_root_impl<T, V>(
     tensor: &T,
-    topology: &TreeTopology<V, <T::Index as IndexLike>::Id>,
+    topology: &TreeTopology<V, T::Index>,
     options: FactorizeOptions,
     root: &V,
 ) -> Result<TreeTN<T, V>>
@@ -170,14 +171,14 @@ where
         return Ok(tn);
     }
 
-    // Validate that all index IDs exist in the tensor
-    let tensor_ids: HashSet<_> = tensor_indices.iter().map(|idx| idx.id().clone()).collect();
-    for (node, ids) in &topology.nodes {
-        for id in ids {
-            if !tensor_ids.contains(id) {
+    // Validate that all requested indices exist in the tensor.
+    let tensor_index_set: HashSet<_> = tensor_indices.iter().cloned().collect();
+    for (node, indices) in &topology.nodes {
+        for index in indices {
+            if !tensor_index_set.contains(index) {
                 return Err(anyhow::anyhow!(
-                    "Index ID {:?} for node {:?} not found in tensor (tensor has {} indices)",
-                    id,
+                    "Index {:?} for node {:?} not found in tensor (tensor has {} indices)",
+                    index,
                     node,
                     tensor_indices.len()
                 ));
@@ -185,16 +186,16 @@ where
         }
     }
 
-    // Validate that each physical index ID is assigned to at most one node.
+    // Validate that each physical index is assigned to at most one node.
     // Duplicate assignment is almost always a topology specification bug and will
     // lead to ambiguous/missing node tensors during decomposition.
-    let mut assigned_ids: HashSet<<T::Index as IndexLike>::Id> = HashSet::new();
-    for (node, ids) in &topology.nodes {
-        for id in ids {
-            if !assigned_ids.insert(id.clone()) {
+    let mut assigned_indices: HashSet<T::Index> = HashSet::new();
+    for (node, indices) in &topology.nodes {
+        for index in indices {
+            if !assigned_indices.insert(index.clone()) {
                 return Err(anyhow::anyhow!(
-                    "Index ID {:?} is assigned to multiple nodes (at least {:?})",
-                    id,
+                    "Index {:?} is assigned to multiple nodes (at least {:?})",
+                    index,
                     node
                 ));
             }
@@ -275,15 +276,14 @@ where
     #[allow(clippy::needless_range_loop)]
     for i in 0..traversal_order.len() - 1 {
         let (node, _parent) = &traversal_order[i];
-        // Get the index IDs for this node
-        let node_ids = topology.nodes.get(node).unwrap();
+        // Get the indices for this node.
+        let node_indices = topology.nodes.get(node).unwrap();
 
         // Keep this node's physical indices and the bonds to already-factorized
         // children on the left side. This preserves the requested tree topology
         // instead of collapsing all processed children directly into the root.
         let current_indices = current_tensor.external_indices();
-        let mut desired_ids: HashSet<<T::Index as IndexLike>::Id> =
-            node_ids.iter().cloned().collect();
+        let mut desired_indices: HashSet<T::Index> = node_indices.iter().cloned().collect();
         if let Some(children) = children_by_parent.get(node) {
             for child in children {
                 let bond = child_bonds.get(child).ok_or_else(|| {
@@ -293,12 +293,12 @@ where
                         node
                     )
                 })?;
-                desired_ids.insert(bond.id().clone());
+                desired_indices.insert(bond.clone());
             }
         }
         let left_inds: Vec<_> = current_indices
             .iter()
-            .filter(|idx| desired_ids.contains(idx.id()))
+            .filter(|idx| desired_indices.contains(*idx))
             .cloned()
             .collect();
 
@@ -307,13 +307,10 @@ where
             // Previously we "skipped" such nodes, but that can lead to missing tensors and
             // panics later when building the TreeTN.
             return Err(anyhow::anyhow!(
-                "No physical indices found for node {:?} (requested ids={:?}) in current tensor indices={:?}",
+                "No physical indices found for node {:?} (requested indices={:?}) in current tensor indices={:?}",
                 node,
-                node_ids,
+                node_indices,
                 current_indices
-                    .iter()
-                    .map(|idx| idx.id().clone())
-                    .collect::<Vec<_>>()
             ));
         }
 
@@ -348,8 +345,8 @@ where
     let (root_node, _) = &traversal_order.last().unwrap();
     node_tensors.insert(root_node.clone(), current_tensor);
 
-    // Build the TreeTN using from_tensors (auto-connection by matching index IDs)
-    // Since factorize() returns shared bond_index, tensors already have matching index IDs
+    // Build the TreeTN using from_tensors (auto-connection by contractable indices).
+    // Since factorize() returns shared bond_index, tensors already have matching bonds.
     // IMPORTANT: Sort node_names to ensure deterministic ordering (HashMap iteration is non-deterministic)
     let mut node_names: Vec<V> = topology.nodes.keys().cloned().collect();
     node_names.sort();

--- a/crates/tensor4all-treetn/src/treetn/decompose/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/decompose/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::collections::HashMap;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{DynIndex, TensorDynLen};
 
 #[test]
 fn test_tree_topology_validate() {
@@ -42,15 +42,15 @@ fn test_tree_topology_validate() {
 }
 
 #[test]
-fn test_factorize_tensor_to_treetn_rejects_duplicate_index_ids() {
+fn test_factorize_tensor_to_treetn_rejects_duplicate_index_assignment() {
     let i0 = DynIndex::new_dyn(2);
     let i1 = DynIndex::new_dyn(2);
     let tensor =
         TensorDynLen::from_dense(vec![i0.clone(), i1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
-    let mut nodes: HashMap<String, Vec<<DynIndex as IndexLike>::Id>> = HashMap::new();
-    nodes.insert("node0".to_string(), vec![*i0.id()]);
-    nodes.insert("node1".to_string(), vec![*i0.id()]); // duplicate on purpose
+    let mut nodes: HashMap<String, Vec<DynIndex>> = HashMap::new();
+    nodes.insert("node0".to_string(), vec![i0.clone()]);
+    nodes.insert("node1".to_string(), vec![i0.clone()]); // duplicate on purpose
 
     let topo = TreeTopology::new(nodes, vec![("node0".to_string(), "node1".to_string())]);
 
@@ -75,9 +75,9 @@ fn test_factorize_tensor_to_treetn_preserves_requested_chain_topology_for_nonroo
     .unwrap();
 
     let mut nodes = HashMap::new();
-    nodes.insert(0usize, vec![*s0.id()]);
-    nodes.insert(1usize, vec![*s1.id()]);
-    nodes.insert(2usize, vec![*s2.id()]);
+    nodes.insert(0usize, vec![s0.clone()]);
+    nodes.insert(1usize, vec![s1.clone()]);
+    nodes.insert(2usize, vec![s2.clone()]);
     let topology = TreeTopology::new(nodes, vec![(0usize, 1usize), (1usize, 2usize)]);
 
     let tn = factorize_tensor_to_treetn(&tensor, &topology, &2usize).unwrap();
@@ -85,4 +85,33 @@ fn test_factorize_tensor_to_treetn_preserves_requested_chain_topology_for_nonroo
     edges.sort();
 
     assert_eq!(edges, vec![(0usize, 1usize), (1usize, 2usize)]);
+}
+
+#[test]
+fn test_factorize_tensor_to_treetn_accepts_full_index_topology_for_same_id_prime_pair() {
+    let i = DynIndex::new_dyn(2);
+    let i_prime = i.prime();
+    let tensor =
+        TensorDynLen::from_dense(vec![i.clone(), i_prime.clone()], vec![1.0, 0.0, 0.0, 1.0])
+            .unwrap();
+
+    let mut nodes: HashMap<String, Vec<DynIndex>> = HashMap::new();
+    nodes.insert("input".to_string(), vec![i.clone()]);
+    nodes.insert("output".to_string(), vec![i_prime.clone()]);
+    let topology = TreeTopology::new(nodes, vec![("input".to_string(), "output".to_string())]);
+
+    let tn = factorize_tensor_to_treetn(&tensor, &topology, &"output".to_string()).unwrap();
+
+    assert_eq!(
+        tn.site_index_network()
+            .find_node_by_index(&i)
+            .map(|name| name.as_str()),
+        Some("input")
+    );
+    assert_eq!(
+        tn.site_index_network()
+            .find_node_by_index(&i_prime)
+            .map(|name| name.as_str()),
+        Some("output")
+    );
 }

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -653,7 +653,7 @@ where
             .iter()
             .filter(|idx| {
                 // Keep site indices of u and link indices to u's other neighbors
-                site_c_u.iter().any(|s| s.same_id(*idx))
+                site_c_u.contains(*idx)
                     || full_treetn
                         .site_index_network()
                         .neighbors(node_u)
@@ -662,7 +662,7 @@ where
                             full_treetn
                                 .edge_between(node_u, &neighbor)
                                 .and_then(|e| full_treetn.bond_index(e))
-                                .map(|b| b.same_id(*idx))
+                                .map(|b| b == *idx)
                                 .unwrap_or(false)
                         })
             })

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -1520,60 +1520,21 @@ where
         Ok(())
     }
 
-    /// Reorder site indices so that each index id ends up at the target node.
-    ///
-    /// This is an ID-based convenience API. If multiple current site indices
-    /// share the requested ID, use [`swap_site_indices_by_index`](Self::swap_site_indices_by_index)
-    /// so the target is identified by full index metadata.
+    /// Reorder site indices so that each full index ends up at the target node.
     ///
     /// Builds a pre-computed schedule from the topology plus current and target
     /// site assignments, canonicalizes the network to the schedule root, then
-    /// executes the scheduled transport and swap steps.
-    /// Partial assignment is supported: indices not listed in
-    /// `target_assignment` stay on their current side of every visited edge.
+    /// executes the scheduled transport and swap steps. Partial assignment is
+    /// supported: indices not listed in `target_assignment` stay on their
+    /// current side of every visited edge.
     ///
     /// # Arguments
-    /// * `target_assignment` - Map from site index id to target node name.
+    /// * `target_assignment` - Map from full site index to target node name.
     /// * `options` - Truncation options for each SVD (default: no truncation, exact).
     ///
     /// # Errors
-    /// Returns an error if target nodes are missing, an index id is unknown, or sweep fails.
+    /// Returns an error if target nodes are missing, an index is unknown, or sweep fails.
     pub fn swap_site_indices(
-        &mut self,
-        target_assignment: &HashMap<<T::Index as IndexLike>::Id, V>,
-        options: &swap::SwapOptions,
-    ) -> Result<()>
-    where
-        <T::Index as IndexLike>::Id:
-            Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
-        V: Ord,
-    {
-        let current = swap::current_site_assignment(self);
-        let mut target_by_index = HashMap::with_capacity(target_assignment.len());
-        for (target_id, target_node) in target_assignment {
-            let mut matches = current
-                .keys()
-                .filter(|index| index.id() == target_id)
-                .cloned();
-            let Some(index) = matches.next() else {
-                return Err(anyhow::anyhow!(
-                    "swap_site_indices: target_assignment contains index id {:?} which is not in the network",
-                    target_id
-                ));
-            };
-            if matches.next().is_some() {
-                return Err(anyhow::anyhow!(
-                    "swap_site_indices: index id {:?} is ambiguous; use swap_site_indices_by_index",
-                    target_id
-                ));
-            }
-            target_by_index.insert(index, target_node.clone());
-        }
-
-        self.swap_site_indices_by_index(&target_by_index, options)
-    }
-
-    fn swap_site_indices_exact(
         &mut self,
         target_assignment: &HashMap<T::Index, V>,
         options: &swap::SwapOptions,
@@ -1593,14 +1554,14 @@ where
             .node_names()
             .into_iter()
             .min()
-            .ok_or_else(|| anyhow::anyhow!("swap_site_indices_by_index: empty network"))?;
+            .ok_or_else(|| anyhow::anyhow!("swap_site_indices: empty network"))?;
         let schedule = swap::SwapSchedule::build(
             self.site_index_network().topology(),
             &current,
             target_assignment,
             &root,
         )
-        .context("swap_site_indices_by_index: build schedule")?;
+        .context("swap_site_indices: build schedule")?;
 
         if schedule.steps.is_empty() {
             return Ok(());
@@ -1610,7 +1571,7 @@ where
             std::iter::once(schedule.root.clone()),
             crate::options::CanonicalizationOptions::default(),
         )
-        .context("swap_site_indices_by_index: canonicalize")?;
+        .context("swap_site_indices: canonicalize")?;
 
         let mut swap_factorize_options = FactorizeOptions::svd().with_canonical(Canonical::Left);
         if let Some(mr) = options.max_rank {
@@ -1627,16 +1588,10 @@ where
                 let src_name = &edge[0];
                 let dst_name = &edge[1];
                 let src_idx = self.node_index(src_name).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "swap_site_indices_by_index: transport node {:?} not found",
-                        src_name
-                    )
+                    anyhow::anyhow!("swap_site_indices: transport node {:?} not found", src_name)
                 })?;
                 let dst_idx = self.node_index(dst_name).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "swap_site_indices_by_index: transport node {:?} not found",
-                        dst_name
-                    )
+                    anyhow::anyhow!("swap_site_indices: transport node {:?} not found", dst_name)
                 })?;
                 self.sweep_edge(
                     src_idx,
@@ -1644,20 +1599,14 @@ where
                     &transport_factorize_options,
                     "swap_transport",
                 )
-                .context("swap_site_indices_by_index: transport")?;
+                .context("swap_site_indices: transport")?;
             }
 
             let a_idx = self.node_index(&step.node_a).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "swap_site_indices_by_index: node {:?} not found",
-                    step.node_a
-                )
+                anyhow::anyhow!("swap_site_indices: node {:?} not found", step.node_a)
             })?;
             let b_idx = self.node_index(&step.node_b).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "swap_site_indices_by_index: node {:?} not found",
-                    step.node_b
-                )
+                anyhow::anyhow!("swap_site_indices: node {:?} not found", step.node_b)
             })?;
             self.swap_on_edge(
                 a_idx,
@@ -1666,9 +1615,9 @@ where
                 &step.b_side_sites,
                 &swap_factorize_options,
             )
-            .context("swap_site_indices_by_index: swap_on_edge")?;
+            .context("swap_site_indices: swap_on_edge")?;
             self.set_canonical_region([step.node_b.clone()])
-                .context("swap_site_indices_by_index: set_canonical_region")?;
+                .context("swap_site_indices: set_canonical_region")?;
         }
 
         Ok(())
@@ -1676,8 +1625,7 @@ where
 
     /// Reorder site indices so that each index ends up at the target node.
     ///
-    /// Index-based version of [`swap_site_indices`](Self::swap_site_indices).
-    /// Accepts `T::Index` keys instead of `T::Index::Id`.
+    /// Alias for [`swap_site_indices`](Self::swap_site_indices).
     ///
     /// # Examples
     ///
@@ -1703,7 +1651,7 @@ where
     /// let mut target = HashMap::new();
     /// target.insert(idx_a.clone(), node_name_b.clone());
     ///
-    /// treetn.swap_site_indices_by_index(&target, &SwapOptions::default())?;
+    /// treetn.swap_site_indices(&target, &SwapOptions::default())?;
     ///
     /// assert_eq!(
     ///     treetn
@@ -1727,7 +1675,7 @@ where
         T::Index: Hash + Eq,
         V: Ord,
     {
-        self.swap_site_indices_exact(target_assignment, options)
+        self.swap_site_indices(target_assignment, options)
     }
 
     /// Verify internal data consistency by checking structural invariants and reconstructing the TreeTN.

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -257,13 +257,9 @@ where
             node_indices.push(node_idx);
         }
 
-        // Step 2: Build a map from index ID to (node_index, index) pairs in O(n) time
-        // Key: index ID, Value: vector of (NodeIndex, Index) pairs
-        #[allow(clippy::type_complexity)]
-        let mut index_map: HashMap<
-            <T::Index as IndexLike>::Id,
-            Vec<(NodeIndex, T::Index)>,
-        > = HashMap::new();
+        // Step 2: Build a map from full index metadata to (node_index, index) pairs in O(n) time.
+        // Same-id indices that differ by prime level or tags are distinct site legs.
+        let mut index_map: HashMap<T::Index, Vec<(NodeIndex, T::Index)>> = HashMap::new();
 
         for node_idx in &node_indices {
             let tensor = treetn
@@ -272,15 +268,15 @@ where
 
             for index in tensor.external_indices() {
                 index_map
-                    .entry(index.id().clone())
+                    .entry(index.clone())
                     .or_insert_with(Vec::new)
                     .push((*node_idx, index.clone()));
             }
         }
 
-        // Step 3: Connect nodes that share the same index ID
-        // For TreeTN (tree structure), each index ID should appear in exactly 2 tensors
-        for (index_id, nodes_with_index) in index_map {
+        // Step 3: Connect nodes that share the same full index.
+        // For TreeTN (tree structure), each bond index should appear in exactly 2 tensors.
+        for (shared_index, nodes_with_index) in index_map {
             match nodes_with_index.len() {
                 0 => unreachable!(),
                 1 => {
@@ -296,16 +292,16 @@ where
                         .connect_internal(*node_a, index_a, *node_b, index_b)
                         .with_context(|| {
                             format!(
-                                "Failed to connect nodes {:?} and {:?} via index ID {:?}",
-                                node_a, node_b, index_id
+                                "Failed to connect nodes {:?} and {:?} via index {:?}",
+                                node_a, node_b, shared_index
                             )
                         })?;
                 }
                 n => {
                     // Index appears in more than 2 tensors - this violates tree structure
                     return Err(anyhow::anyhow!(
-                        "Index ID {:?} appears in {} tensors, but TreeTN requires exactly 2 (tree structure)",
-                        index_id, n
+                        "Index {:?} appears in {} tensors, but TreeTN requires exactly 2 (tree structure)",
+                        shared_index, n
                     ))
                     .context("TreeTN::from_tensors: each bond index must connect exactly 2 nodes");
                 }
@@ -348,7 +344,7 @@ where
 
     /// Connect two tensors via a specified pair of indices.
     ///
-    /// The indices must have the same ID (Einsum mode).
+    /// The indices must match as full index values.
     ///
     /// # Arguments
     /// * `node_a` - First node
@@ -403,7 +399,7 @@ where
 
     /// Internal method to connect two tensors.
     ///
-    /// In Einsum mode, `index_a` and `index_b` must have the same ID.
+    /// In Einsum mode, `index_a` and `index_b` must be the same full index.
     pub(crate) fn connect_internal(
         &mut self,
         node_a: NodeIndex,
@@ -411,12 +407,12 @@ where
         node_b: NodeIndex,
         index_b: &T::Index,
     ) -> Result<EdgeIndex> {
-        // Validate that indices have the same ID (Einsum mode requirement)
-        if index_a.id() != index_b.id() {
+        // Validate that indices have the same full metadata (Einsum mode requirement).
+        if index_a != index_b {
             return Err(anyhow::anyhow!(
-                "Index IDs must match in Einsum mode: {:?} != {:?}",
-                index_a.id(),
-                index_b.id()
+                "Indices must match in Einsum mode: {:?} != {:?}",
+                index_a,
+                index_b
             ))
             .context("Failed to connect tensors");
         }
@@ -448,11 +444,11 @@ where
                 .context("Failed to connect: index_b must exist in tensor_b");
         }
 
-        // Clone the bond index (same ID, use index_a)
+        // Clone the bond index.
         let bond_index = tensor_a
             .external_indices()
             .iter()
-            .find(|idx| idx.same_id(index_a))
+            .find(|idx| *idx == index_a)
             .unwrap()
             .clone();
 
@@ -909,7 +905,7 @@ where
                 .ok_or_else(|| anyhow::anyhow!("Bond index not found for edge {:?}", edge))? =
                 new_bond.clone();
 
-            // Update endpoint tensors by matching the old bond by ID.
+            // Update endpoint tensors by matching the old bond as a full index.
             let (node_a, node_b) = self
                 .graph
                 .graph()
@@ -922,18 +918,18 @@ where
                 let old_in_tensor = tensor
                     .external_indices()
                     .iter()
-                    .find(|idx| idx.id() == old_bond.id())
+                    .find(|idx| *idx == &old_bond)
                     .ok_or_else(|| anyhow::anyhow!("Bond index not found in endpoint tensor"))?
                     .clone();
                 let new_tensor = tensor.replaceind(&old_in_tensor, &new_bond)?;
                 self.replace_tensor(node, new_tensor)?;
             }
 
-            // Update ortho_towards key for this bond (if present), matched by ID.
+            // Update ortho_towards key for this bond (if present).
             if let Some((key, dir)) = self
                 .ortho_towards
                 .iter()
-                .find(|(k, _)| k.id() == old_bond.id())
+                .find(|(k, _)| *k == &old_bond)
                 .map(|(k, v)| (k.clone(), v.clone()))
             {
                 self.ortho_towards.remove(&key);
@@ -1423,8 +1419,8 @@ where
         &mut self,
         node_a_idx: NodeIndex,
         node_b_idx: NodeIndex,
-        a_side_sites: &HashSet<<T::Index as IndexLike>::Id>,
-        b_side_sites: &HashSet<<T::Index as IndexLike>::Id>,
+        a_side_sites: &HashSet<T::Index>,
+        b_side_sites: &HashSet<T::Index>,
         factorize_options: &FactorizeOptions,
     ) -> Result<()>
     where
@@ -1448,20 +1444,18 @@ where
             .ok_or_else(|| anyhow::anyhow!("swap_on_edge: bond not found"))?
             .clone();
 
-        // Structural bond ids of A and B (bonds other than bond_ab)
-        let other_bond_ids_a: HashSet<<T::Index as IndexLike>::Id> = self
+        // Structural bonds of A and B (bonds other than bond_ab).
+        let other_bonds_a: HashSet<T::Index> = self
             .edges_for_node(node_a_idx)
             .iter()
             .filter_map(|(e, _)| self.bond_index(*e).cloned())
-            .filter(|b| b.id() != bond_ab.id())
-            .map(|b| b.id().to_owned())
+            .filter(|b| b != &bond_ab)
             .collect();
-        let other_bond_ids_b: HashSet<<T::Index as IndexLike>::Id> = self
+        let other_bonds_b: HashSet<T::Index> = self
             .edges_for_node(node_b_idx)
             .iter()
             .filter_map(|(e, _)| self.bond_index(*e).cloned())
-            .filter(|b| b.id() != bond_ab.id())
-            .map(|b| b.id().to_owned())
+            .filter(|b| b != &bond_ab)
             .collect();
 
         let tensor_a = self
@@ -1473,28 +1467,28 @@ where
             .ok_or_else(|| anyhow::anyhow!("swap_on_edge: tensor_b not found"))?
             .clone();
 
-        // Site ids currently at each node (all non-bond indices)
-        let site_ids_a: HashSet<<T::Index as IndexLike>::Id> = tensor_a
+        // Sites currently at each node (all non-bond indices).
+        let site_indices_a: HashSet<T::Index> = tensor_a
             .external_indices()
             .iter()
-            .filter(|i| i.id() != bond_ab.id() && !other_bond_ids_a.contains(i.id()))
-            .map(|i| i.id().to_owned())
+            .filter(|i| *i != &bond_ab && !other_bonds_a.contains(*i))
+            .cloned()
             .collect();
-        let site_ids_b: HashSet<<T::Index as IndexLike>::Id> = tensor_b
+        let site_indices_b: HashSet<T::Index> = tensor_b
             .external_indices()
             .iter()
-            .filter(|i| i.id() != bond_ab.id() && !other_bond_ids_b.contains(i.id()))
-            .map(|i| i.id().to_owned())
+            .filter(|i| *i != &bond_ab && !other_bonds_b.contains(*i))
+            .cloned()
             .collect();
-        let all_site_ids: HashSet<_> = site_ids_a.union(&site_ids_b).cloned().collect();
-        let assigned_site_ids: HashSet<_> = a_side_sites.union(b_side_sites).cloned().collect();
+        let all_site_indices: HashSet<_> = site_indices_a.union(&site_indices_b).cloned().collect();
+        let assigned_site_indices: HashSet<_> = a_side_sites.union(b_side_sites).cloned().collect();
 
         if !a_side_sites.is_disjoint(b_side_sites) {
             return Err(anyhow::anyhow!(
                 "swap_on_edge: a_side_sites and b_side_sites overlap"
             ));
         }
-        if assigned_site_ids != all_site_ids {
+        if assigned_site_indices != all_site_indices {
             return Err(anyhow::anyhow!(
                 "swap_on_edge: scheduled site partition does not match current edge sites"
             ));
@@ -1506,7 +1500,7 @@ where
         let ab_indices = tensor_ab.external_indices();
         let left_inds: Vec<T::Index> = ab_indices
             .iter()
-            .filter(|i| other_bond_ids_a.contains(i.id()) || a_side_sites.contains(i.id()))
+            .filter(|i| other_bonds_a.contains(*i) || a_side_sites.contains(*i))
             .cloned()
             .collect();
 
@@ -1527,6 +1521,10 @@ where
     }
 
     /// Reorder site indices so that each index id ends up at the target node.
+    ///
+    /// This is an ID-based convenience API. If multiple current site indices
+    /// share the requested ID, use [`swap_site_indices_by_index`](Self::swap_site_indices_by_index)
+    /// so the target is identified by full index metadata.
     ///
     /// Builds a pre-computed schedule from the topology plus current and target
     /// site assignments, canonicalizes the network to the schedule root, then
@@ -1550,6 +1548,42 @@ where
             Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
         V: Ord,
     {
+        let current = swap::current_site_assignment(self);
+        let mut target_by_index = HashMap::with_capacity(target_assignment.len());
+        for (target_id, target_node) in target_assignment {
+            let mut matches = current
+                .keys()
+                .filter(|index| index.id() == target_id)
+                .cloned();
+            let Some(index) = matches.next() else {
+                return Err(anyhow::anyhow!(
+                    "swap_site_indices: target_assignment contains index id {:?} which is not in the network",
+                    target_id
+                ));
+            };
+            if matches.next().is_some() {
+                return Err(anyhow::anyhow!(
+                    "swap_site_indices: index id {:?} is ambiguous; use swap_site_indices_by_index",
+                    target_id
+                ));
+            }
+            target_by_index.insert(index, target_node.clone());
+        }
+
+        self.swap_site_indices_by_index(&target_by_index, options)
+    }
+
+    fn swap_site_indices_exact(
+        &mut self,
+        target_assignment: &HashMap<T::Index, V>,
+        options: &swap::SwapOptions,
+    ) -> Result<()>
+    where
+        <T::Index as IndexLike>::Id:
+            Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+        T::Index: Hash + Eq,
+        V: Ord,
+    {
         if target_assignment.is_empty() {
             return Ok(());
         }
@@ -1559,14 +1593,14 @@ where
             .node_names()
             .into_iter()
             .min()
-            .ok_or_else(|| anyhow::anyhow!("swap_site_indices: empty network"))?;
+            .ok_or_else(|| anyhow::anyhow!("swap_site_indices_by_index: empty network"))?;
         let schedule = swap::SwapSchedule::build(
             self.site_index_network().topology(),
             &current,
             target_assignment,
             &root,
         )
-        .context("swap_site_indices: build schedule")?;
+        .context("swap_site_indices_by_index: build schedule")?;
 
         if schedule.steps.is_empty() {
             return Ok(());
@@ -1576,7 +1610,7 @@ where
             std::iter::once(schedule.root.clone()),
             crate::options::CanonicalizationOptions::default(),
         )
-        .context("swap_site_indices: canonicalize")?;
+        .context("swap_site_indices_by_index: canonicalize")?;
 
         let mut swap_factorize_options = FactorizeOptions::svd().with_canonical(Canonical::Left);
         if let Some(mr) = options.max_rank {
@@ -1593,10 +1627,16 @@ where
                 let src_name = &edge[0];
                 let dst_name = &edge[1];
                 let src_idx = self.node_index(src_name).ok_or_else(|| {
-                    anyhow::anyhow!("swap_site_indices: transport node {:?} not found", src_name)
+                    anyhow::anyhow!(
+                        "swap_site_indices_by_index: transport node {:?} not found",
+                        src_name
+                    )
                 })?;
                 let dst_idx = self.node_index(dst_name).ok_or_else(|| {
-                    anyhow::anyhow!("swap_site_indices: transport node {:?} not found", dst_name)
+                    anyhow::anyhow!(
+                        "swap_site_indices_by_index: transport node {:?} not found",
+                        dst_name
+                    )
                 })?;
                 self.sweep_edge(
                     src_idx,
@@ -1604,14 +1644,20 @@ where
                     &transport_factorize_options,
                     "swap_transport",
                 )
-                .context("swap_site_indices: transport")?;
+                .context("swap_site_indices_by_index: transport")?;
             }
 
             let a_idx = self.node_index(&step.node_a).ok_or_else(|| {
-                anyhow::anyhow!("swap_site_indices: node {:?} not found", step.node_a)
+                anyhow::anyhow!(
+                    "swap_site_indices_by_index: node {:?} not found",
+                    step.node_a
+                )
             })?;
             let b_idx = self.node_index(&step.node_b).ok_or_else(|| {
-                anyhow::anyhow!("swap_site_indices: node {:?} not found", step.node_b)
+                anyhow::anyhow!(
+                    "swap_site_indices_by_index: node {:?} not found",
+                    step.node_b
+                )
             })?;
             self.swap_on_edge(
                 a_idx,
@@ -1620,9 +1666,9 @@ where
                 &step.b_side_sites,
                 &swap_factorize_options,
             )
-            .context("swap_site_indices: swap_on_edge")?;
+            .context("swap_site_indices_by_index: swap_on_edge")?;
             self.set_canonical_region([step.node_b.clone()])
-                .context("swap_site_indices: set_canonical_region")?;
+                .context("swap_site_indices_by_index: set_canonical_region")?;
         }
 
         Ok(())
@@ -1662,7 +1708,7 @@ where
     /// assert_eq!(
     ///     treetn
     ///         .site_index_network()
-    ///         .find_node_by_index_id(idx_a.id())
+    ///         .find_node_by_index(&idx_a)
     ///         .map(|name| name.as_str()),
     ///     Some(node_name_b.as_str())
     /// );
@@ -1681,12 +1727,7 @@ where
         T::Index: Hash + Eq,
         V: Ord,
     {
-        let id_assignment: HashMap<_, _> = target_assignment
-            .iter()
-            .map(|(idx, node)| (idx.id().clone(), node.clone()))
-            .collect();
-
-        self.swap_site_indices(&id_assignment, options)
+        self.swap_site_indices_exact(target_assignment, options)
     }
 
     /// Verify internal data consistency by checking structural invariants and reconstructing the TreeTN.
@@ -1738,31 +1779,29 @@ where
             }
         }
 
-        // Step 0b: Verify non-adjacent tensors don't share index IDs
-        // Build a map from index ID to nodes that have that index
-        let mut index_id_to_nodes: HashMap<<T::Index as IndexLike>::Id, Vec<NodeIndex>> =
-            HashMap::new();
+        // Step 0b: Verify non-adjacent tensors don't share full bond indices.
+        let mut index_to_nodes: HashMap<T::Index, Vec<NodeIndex>> = HashMap::new();
         for node_idx in self.graph.graph().node_indices() {
             if let Some(tensor) = self.tensor(node_idx) {
                 for index in tensor.external_indices() {
-                    index_id_to_nodes
-                        .entry(index.id().clone())
+                    index_to_nodes
+                        .entry(index.clone())
                         .or_default()
                         .push(node_idx);
                 }
             }
         }
 
-        // Check each index ID - if shared by multiple nodes, they must be adjacent
-        for (index_id, nodes) in &index_id_to_nodes {
+        // Check each index - if shared by multiple nodes, they must be adjacent.
+        for (index, nodes) in &index_to_nodes {
             if nodes.len() > 2 {
-                // More than 2 nodes share the same index ID - always invalid for tree structure
+                // More than 2 nodes share the same index - always invalid for tree structure.
                 return Err(anyhow::anyhow!(
-                    "Index ID {:?} is shared by {} nodes, but tree structure allows at most 2",
-                    index_id,
+                    "Index {:?} is shared by {} nodes, but tree structure allows at most 2",
+                    index,
                     nodes.len()
                 ))
-                .context("verify_internal_consistency: index ID shared by too many nodes");
+                .context("verify_internal_consistency: index shared by too many nodes");
             }
             if nodes.len() == 2 {
                 // Two nodes share the index - they must be adjacent (connected by an edge)
@@ -1774,13 +1813,13 @@ where
                     let name_a = self.graph.node_name(node_a);
                     let name_b = self.graph.node_name(node_b);
                     return Err(anyhow::anyhow!(
-                        "Non-adjacent nodes {:?} and {:?} share index ID {:?}. \
-                        Only adjacent (edge-connected) nodes may share index IDs.",
+                        "Non-adjacent nodes {:?} and {:?} share index {:?}. \
+                        Only adjacent (edge-connected) nodes may share full bond indices.",
                         name_a,
                         name_b,
-                        index_id
+                        index
                     ))
-                    .context("verify_internal_consistency: non-adjacent nodes share index ID");
+                    .context("verify_internal_consistency: non-adjacent nodes share index");
                 }
             }
         }
@@ -1882,10 +1921,9 @@ where
 
 /// Find common indices between two slices of indices.
 pub(crate) fn common_inds<I: IndexLike>(inds_a: &[I], inds_b: &[I]) -> Vec<I> {
-    let set_b: HashSet<_> = inds_b.iter().map(|idx| idx.id()).collect();
     inds_a
         .iter()
-        .filter(|idx| set_b.contains(idx.id()))
+        .filter(|idx| inds_b.iter().any(|other| other == *idx))
         .cloned()
         .collect()
 }

--- a/crates/tensor4all-treetn/src/treetn/ops.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops.rs
@@ -8,8 +8,7 @@
 //! - `norm`, `norm_squared` for computing the Frobenius norm
 //! - `inner` for computing inner products of two TreeTNs
 //! - `to_dense` for contracting to a single tensor
-//! - `evaluate` for evaluating at specific index values
-//! - `evaluate_at` for evaluating using `Index` objects instead of raw IDs
+//! - `evaluate` for evaluating at specific index values using full indices
 //! - `all_site_indices` for retrieving all site indices and their owning vertices
 
 use std::collections::{HashMap, HashSet};
@@ -508,43 +507,14 @@ where
             .context("to_dense: failed to contract network to tensor")
     }
 
-    /// Returns all site index IDs and their owning vertex names.
-    ///
-    /// Returns `(index_ids, vertex_names)` where `index_ids[i]` belongs to
-    /// vertex `vertex_names[i]`. Order is unspecified but consistent
-    /// between the two vectors.
-    ///
-    /// For [`evaluate()`](Self::evaluate), pass `index_ids` and arrange
-    /// values in the same order.
-    #[allow(clippy::type_complexity)]
-    pub fn all_site_index_ids(&self) -> Result<(Vec<<T::Index as IndexLike>::Id>, Vec<V>)>
-    where
-        V: Clone,
-        <T::Index as IndexLike>::Id: Clone,
-    {
-        let mut ids = Vec::new();
-        let mut vertex_names = Vec::new();
-        for node_name in self.node_names() {
-            let site_space = self
-                .site_space(&node_name)
-                .ok_or_else(|| anyhow::anyhow!("Site space not found for node {:?}", node_name))
-                .context("all_site_index_ids: site space must exist")?;
-            for index in site_space {
-                ids.push(index.id().clone());
-                vertex_names.push(node_name.clone());
-            }
-        }
-        Ok((ids, vertex_names))
-    }
-
     /// Evaluate the TreeTN at multiple multi-indices (batch).
     ///
     /// # Arguments
-    /// * `index_ids` - Identifies each site index by its ID (from
-    ///   [`all_site_index_ids()`](Self::all_site_index_ids)).
+    /// * `indices` - Identifies each site index by full `Index` value (from
+    ///   [`all_site_indices()`](Self::all_site_indices)).
     ///   Must enumerate every site index exactly once.
     /// * `values` - Column-major array of shape `[n_indices, n_points]`.
-    ///   `values.get(&[i, p])` is the value of `index_ids[i]` at point `p`.
+    ///   `values.get(&[i, p])` is the value of `indices[i]` at point `p`.
     ///
     /// # Returns
     /// A `Vec<AnyScalar>` of length `n_points`.
@@ -552,24 +522,25 @@ where
     /// # Errors
     /// Returns an error if:
     /// - The network is empty
-    /// - `values` shape is inconsistent with `index_ids`
-    /// - An index ID is unknown
+    /// - `values` shape is inconsistent with `indices`
+    /// - An index is unknown
     /// - Index values are out of bounds
     /// - Contraction fails
     pub fn evaluate(
         &self,
-        index_ids: &[<T::Index as IndexLike>::Id],
+        indices: &[T::Index],
         values: ColMajorArrayRef<'_, usize>,
     ) -> Result<Vec<AnyScalar>>
     where
-        <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+        T::Index: Clone + Hash + Eq,
+        <T::Index as IndexLike>::Id: Ord,
     {
         if self.node_count() == 0 {
             return Err(anyhow::anyhow!("Cannot evaluate empty TreeTN"))
                 .context("evaluate: network must have at least one node");
         }
 
-        let n_indices = index_ids.len();
+        let n_indices = indices.len();
         anyhow::ensure!(
             values.shape().len() == 2,
             "evaluate: values must be 2D, got {}D",
@@ -577,15 +548,15 @@ where
         );
         anyhow::ensure!(
             values.shape()[0] == n_indices,
-            "evaluate: values.shape()[0] ({}) != index_ids.len() ({})",
+            "evaluate: values.shape()[0] ({}) != indices.len() ({})",
             values.shape()[0],
             n_indices
         );
         let n_points = values.shape()[1];
 
-        // Build index_id -> position lookup (Vec-based linear scan is fine for
+        // Build index -> position lookup (Vec-based linear scan is fine for
         // the small number of site indices typical in practice).
-        let mut known_ids: HashSet<<T::Index as IndexLike>::Id> = HashSet::new();
+        let mut known_indices: HashSet<T::Index> = HashSet::new();
         let mut total_site_indices: usize = 0;
         for node_name in self.node_names() {
             let site_space = self
@@ -593,44 +564,44 @@ where
                 .ok_or_else(|| anyhow::anyhow!("Site space not found for node {:?}", node_name))
                 .context("evaluate: site space must exist")?;
             for index in site_space {
-                known_ids.insert(index.id().clone());
+                known_indices.insert(index.clone());
                 total_site_indices += 1;
             }
         }
 
-        // Validate: index_ids.len() must equal total number of site indices.
+        // Validate: indices.len() must equal total number of site indices.
         anyhow::ensure!(
             n_indices == total_site_indices,
-            "evaluate: index_ids.len() ({}) != total site indices ({})",
+            "evaluate: indices.len() ({}) != total site indices ({})",
             n_indices,
             total_site_indices
         );
 
-        // Validate: no duplicate index IDs.
+        // Validate: no duplicate indices.
         {
             let mut seen = HashSet::with_capacity(n_indices);
-            for id in index_ids {
-                anyhow::ensure!(seen.insert(id), "evaluate: duplicate index ID {:?}", id);
+            for index in indices {
+                anyhow::ensure!(seen.insert(index), "evaluate: duplicate index {:?}", index);
             }
         }
 
-        // Validate: all provided IDs must be known (exist in the network).
-        for id in index_ids {
+        // Validate: all provided indices must be known (exist in the network).
+        for index in indices {
             anyhow::ensure!(
-                known_ids.contains(id),
-                "evaluate: unknown index ID {:?}",
-                id
+                known_indices.contains(index),
+                "evaluate: unknown index {:?}",
+                index
             );
         }
 
         // Pre-compute per-node data: (node_name, node_index, tensor_ref,
-        //   site_entries: Vec<(Index, position_in_index_ids)>)
+        //   site_entries: Vec<(Index, position_in_indices)>)
         // This avoids HashMap lookups and repeated node_index/tensor lookups
         // inside the per-point loop.
         struct NodeEntry<'a, T: TensorLike, V> {
             name: V,
             tensor: &'a T,
-            /// (site_index, position in `index_ids`)
+            /// (site_index, position in `indices`)
             site_entries: Vec<(T::Index, usize)>,
         }
 
@@ -652,12 +623,11 @@ where
             let mut site_entries = Vec::new();
             if let Some(space) = site_space {
                 for index in space {
-                    let id = index.id();
-                    let pos = index_ids
+                    let pos = indices
                         .iter()
-                        .position(|x| x == id)
-                        .ok_or_else(|| anyhow::anyhow!("Index ID {:?} not found in index_ids", id))
-                        .context("evaluate: all site indices must be covered by index_ids")?;
+                        .position(|x| x == index)
+                        .ok_or_else(|| anyhow::anyhow!("Index {:?} not found in indices", index))
+                        .context("evaluate: all site indices must be covered by indices")?;
                     site_entries.push((index.clone(), pos));
                 }
             }
@@ -725,16 +695,12 @@ where
     /// vertex `vertex_names[i]`. Order is unspecified but consistent
     /// between the two vectors.
     ///
-    /// This is the `Index`-based counterpart of
-    /// [`all_site_index_ids()`](Self::all_site_index_ids), returning
-    /// full `Index` objects instead of raw IDs.
-    ///
     /// # Errors
     /// Returns an error if a node's site space cannot be found.
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s0 = DynIndex::new_dyn(2);
@@ -753,9 +719,8 @@ where
     /// assert_eq!(vertices.len(), 2);
     ///
     /// // The returned indices contain both s0 and s1
-    /// let id_set: std::collections::HashSet<_> = indices.iter().map(|i| *i.id()).collect();
-    /// assert!(id_set.contains(s0.id()));
-    /// assert!(id_set.contains(s1.id()));
+    /// assert!(indices.contains(&s0));
+    /// assert!(indices.contains(&s1));
     /// ```
     #[allow(clippy::type_complexity)]
     pub fn all_site_indices(&self) -> Result<(Vec<T::Index>, Vec<V>)>
@@ -778,12 +743,9 @@ where
         Ok((indices, node_names))
     }
 
-    /// Evaluate the TreeTN at multiple multi-indices (batch), using
-    /// `Index` objects instead of raw IDs.
+    /// Evaluate the TreeTN at multiple multi-indices (batch).
     ///
-    /// This is a convenience wrapper around [`evaluate()`](Self::evaluate)
-    /// that accepts `&[T::Index]` directly, extracting the IDs
-    /// internally.
+    /// Alias for [`evaluate()`](Self::evaluate).
     ///
     /// # Arguments
     /// * `indices` - Identifies each site index by its `Index` object
@@ -797,7 +759,7 @@ where
     ///
     /// # Errors
     /// Returns an error if the underlying [`evaluate()`](Self::evaluate)
-    /// call fails (see its documentation for details).
+    /// call fails.
     ///
     /// # Examples
     /// ```
@@ -823,10 +785,10 @@ where
         values: ColMajorArrayRef<'_, usize>,
     ) -> Result<Vec<AnyScalar>>
     where
-        <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+        T::Index: Clone + Hash + Eq,
+        <T::Index as IndexLike>::Id: Ord,
     {
-        let index_ids: Vec<_> = indices.iter().map(|idx| idx.id().clone()).collect();
-        self.evaluate(&index_ids, values)
+        self.evaluate(indices, values)
     }
 }
 

--- a/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
@@ -1,5 +1,5 @@
 use num_complex::Complex64;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, TensorDynLen};
 
 use crate::TreeTN;
 
@@ -66,4 +66,27 @@ fn test_inner_preserves_complex_phase() {
 
     assert!((inner.real() + 5.0).abs() < 1.0e-10);
     assert!((inner.imag() - 2.0).abs() < 1.0e-10);
+}
+
+#[test]
+fn test_evaluate_accepts_full_indices_for_same_id_prime_pair() {
+    let input = DynIndex::new_dyn(2);
+    let output = input.prime();
+    let tensor = TensorDynLen::from_dense(
+        vec![input.clone(), output.clone()],
+        vec![10.0, 20.0, 30.0, 40.0],
+    )
+    .unwrap();
+    let tn = TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap();
+
+    let indices = vec![input, output];
+    let values = [0usize, 0usize, 1usize, 1usize];
+    let shape = [2usize, 2usize];
+    let result = tn
+        .evaluate(&indices, ColMajorArrayRef::new(&values, &shape))
+        .unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!((result[0].real() - 10.0).abs() < 1.0e-10);
+    assert!((result[1].real() - 40.0).abs() < 1.0e-10);
 }

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -83,19 +83,11 @@ where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <T::Index as IndexLike>::Id: Clone + Hash + Eq + Debug + Send + Sync + Ord,
 {
-    let a_external_ids: HashSet<_> = a
-        .external_indices()
-        .into_iter()
-        .map(|idx| idx.id().clone())
-        .collect();
-    let b_external_ids: HashSet<_> = b
-        .external_indices()
-        .into_iter()
-        .map(|idx| idx.id().clone())
-        .collect();
+    let a_external_indices: HashSet<_> = a.external_indices().into_iter().collect();
+    let b_external_indices: HashSet<_> = b.external_indices().into_iter().collect();
 
-    let mut seen_a_ids = HashSet::new();
-    let mut seen_b_ids = HashSet::new();
+    let mut seen_a_indices = HashSet::new();
+    let mut seen_b_indices = HashSet::new();
 
     for (kind, pairs) in [
         ("contract_pairs", &spec.contract_pairs),
@@ -111,31 +103,31 @@ where
                 );
             }
 
-            if !a_external_ids.contains(idx_a.id()) {
+            if !a_external_indices.contains(idx_a) {
                 bail!(
                     "partial_contract: {:?} from {} not found in first TreeTN external indices",
-                    idx_a.id(),
+                    idx_a,
                     kind
                 );
             }
-            if !b_external_ids.contains(idx_b.id()) {
+            if !b_external_indices.contains(idx_b) {
                 bail!(
                     "partial_contract: {:?} from {} not found in second TreeTN external indices",
-                    idx_b.id(),
+                    idx_b,
                     kind
                 );
             }
 
-            if !seen_a_ids.insert(idx_a.id().clone()) {
+            if !seen_a_indices.insert(idx_a.clone()) {
                 bail!(
                     "partial_contract: first TreeTN index {:?} appears in multiple pairs",
-                    idx_a.id()
+                    idx_a
                 );
             }
-            if !seen_b_ids.insert(idx_b.id().clone()) {
+            if !seen_b_indices.insert(idx_b.clone()) {
                 bail!(
                     "partial_contract: second TreeTN index {:?} appears in multiple pairs",
-                    idx_b.id()
+                    idx_b
                 );
             }
         }
@@ -257,7 +249,7 @@ fn union_result_topology<V>(
     a: &TreeTN<TensorDynLen, V>,
     b: &TreeTN<TensorDynLen, V>,
     contracted_tensor: &TensorDynLen,
-) -> Result<TreeTopology<V, <DynIndex as IndexLike>::Id>>
+) -> Result<TreeTopology<V, DynIndex>>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -269,33 +261,29 @@ where
     union_edges.dedup();
     validate_union_topology(&node_names, &union_edges)?;
 
-    let surviving_ids: HashSet<_> = contracted_tensor
-        .external_indices()
-        .into_iter()
-        .map(|idx| *idx.id())
-        .collect();
+    let surviving_indices: HashSet<_> = contracted_tensor.external_indices().into_iter().collect();
 
     let mut nodes = HashMap::new();
     for node_name in &node_names {
-        let mut ids = Vec::new();
+        let mut indices = Vec::new();
 
         if let Some(site_space_a) = a.site_index_network().site_space(node_name) {
             for site_idx in site_space_a {
-                if surviving_ids.contains(site_idx.id()) {
-                    ids.push(*site_idx.id());
+                if surviving_indices.contains(site_idx) {
+                    indices.push(site_idx.clone());
                 }
             }
         }
 
         if let Some(site_space_b) = b.site_index_network().site_space(node_name) {
             for site_idx in site_space_b {
-                if surviving_ids.contains(site_idx.id()) && !ids.contains(site_idx.id()) {
-                    ids.push(*site_idx.id());
+                if surviving_indices.contains(site_idx) && !indices.contains(site_idx) {
+                    indices.push(site_idx.clone());
                 }
             }
         }
 
-        nodes.insert(node_name.clone(), ids);
+        nodes.insert(node_name.clone(), indices);
     }
 
     Ok(TreeTopology::new(nodes, union_edges))
@@ -356,9 +344,9 @@ where
         );
     }
 
-    let current_ids: HashSet<_> = current_indices.iter().map(|idx| idx.id().clone()).collect();
-    let requested_ids: HashSet<_> = output_order.iter().map(|idx| idx.id().clone()).collect();
-    if current_ids != requested_ids {
+    let current_index_set: HashSet<_> = current_indices.iter().cloned().collect();
+    let requested_index_set: HashSet<_> = output_order.iter().cloned().collect();
+    if current_index_set != requested_index_set {
         bail!("partial_contract: output_order must contain exactly the surviving external indices");
     }
 
@@ -367,7 +355,7 @@ where
         let node = result.site_index_network().find_node_by_index(index).ok_or_else(|| {
             anyhow!(
                 "partial_contract: current result index {:?} is not present in the site index network",
-                index.id()
+                index
             )
         })?;
         current_nodes.push(node.clone());
@@ -385,7 +373,7 @@ where
     let mut ordered_node_set = HashSet::new();
 
     for index in output_order {
-        if !seen_requested.insert(index.id().clone()) {
+        if !seen_requested.insert(index.clone()) {
             bail!("partial_contract: output_order contains duplicate indices");
         }
         let current_node = result
@@ -394,7 +382,7 @@ where
             .ok_or_else(|| {
                 anyhow!(
                     "partial_contract: output_order index {:?} is not present in the result",
-                    index.id()
+                    index
                 )
             })?;
         if !ordered_node_set.insert(current_node.clone()) {

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -561,9 +561,9 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
 
     let topology_a = TreeTopology::new(
         [
-            (0usize, vec![*x_a.id()]),
-            (1usize, vec![*w_a.id()]),
-            (2usize, vec![*i_a.id()]),
+            (0usize, vec![x_a.clone()]),
+            (1usize, vec![w_a.clone()]),
+            (2usize, vec![i_a.clone()]),
         ]
         .into_iter()
         .collect(),
@@ -571,11 +571,11 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
     );
     let topology_b = TreeTopology::new(
         [
-            (0usize, vec![*x_b.id()]),
-            (1usize, vec![*w_b.id()]),
-            (2usize, vec![*z_b.id()]),
-            (3usize, vec![*i_b.id()]),
-            (4usize, vec![*j_b.id()]),
+            (0usize, vec![x_b.clone()]),
+            (1usize, vec![w_b.clone()]),
+            (2usize, vec![z_b.clone()]),
+            (3usize, vec![i_b.clone()]),
+            (4usize, vec![j_b.clone()]),
         ]
         .into_iter()
         .collect(),

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::treetn::contraction::{ContractionMethod, ContractionOptions};
 use crate::{factorize_tensor_to_treetn, TreeTopology};
+use num_complex::Complex64;
 use tensor4all_core::{DynIndex, TensorDynLen};
 
 struct PartialContractionInputs {
@@ -191,6 +192,68 @@ fn test_partial_contract_rejects_index_not_in_network() {
 }
 
 #[test]
+fn test_partial_contract_rejects_index_not_in_second_network() {
+    let PartialContractionInputs {
+        tn_a,
+        tn_b,
+        s_contract_a,
+        ..
+    } = make_partial_contraction_inputs();
+
+    let unknown = DynIndex::new_dyn(2);
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![(s_contract_a, unknown)],
+        diagonal_pairs: vec![],
+        output_order: None,
+    };
+    let result = partial_contract(
+        &tn_a,
+        &tn_b,
+        &spec,
+        &"A".to_string(),
+        ContractionOptions::default(),
+    );
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("not found in second TreeTN"));
+}
+
+#[test]
+fn test_partial_contract_rejects_duplicate_second_index_usage() {
+    let PartialContractionInputs {
+        tn_a,
+        tn_b,
+        s_contract_a,
+        s_contract_b,
+        s_multiply_a,
+        ..
+    } = make_partial_contraction_inputs();
+
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![
+            (s_contract_a, s_contract_b.clone()),
+            (s_multiply_a, s_contract_b),
+        ],
+        diagonal_pairs: vec![],
+        output_order: None,
+    };
+    let result = partial_contract(
+        &tn_a,
+        &tn_b,
+        &spec,
+        &"A".to_string(),
+        ContractionOptions::default(),
+    );
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("second TreeTN index"));
+}
+
+#[test]
 fn test_partial_contract_contract_only() {
     // Contract s_contract pair, no multiply. Sites on different nodes.
     let s_a = DynIndex::new_dyn(3);
@@ -254,6 +317,71 @@ fn test_partial_contract_empty_spec() {
 
     // Both s_a and s_b remain as external
     assert_eq!(result.external_indices().len(), 2);
+}
+
+#[test]
+fn test_partial_contract_rejects_bad_output_order_length() {
+    let s_a = DynIndex::new_dyn(2);
+    let s_b = DynIndex::new_dyn(3);
+
+    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
+    let t_b = TensorDynLen::from_dense(vec![s_b], vec![2.0; 3]).unwrap();
+
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![],
+        diagonal_pairs: vec![],
+        output_order: Some(vec![s_a]),
+    };
+    let result = partial_contract(
+        &tn_a,
+        &tn_b,
+        &spec,
+        &"A".to_string(),
+        ContractionOptions::new(ContractionMethod::Naive),
+    );
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("output_order length"));
+}
+
+#[test]
+fn test_partial_contract_rejects_unknown_output_order_index() {
+    let s_a = DynIndex::new_dyn(2);
+    let s_b = DynIndex::new_dyn(3);
+    let unknown = DynIndex::new_dyn(3);
+
+    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
+    let t_b = TensorDynLen::from_dense(vec![s_b], vec![2.0; 3]).unwrap();
+
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![],
+        diagonal_pairs: vec![],
+        output_order: Some(vec![s_a, unknown]),
+    };
+    let result = partial_contract(
+        &tn_a,
+        &tn_b,
+        &spec,
+        &"A".to_string(),
+        ContractionOptions::new(ContractionMethod::Naive),
+    );
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("output_order must contain exactly"));
 }
 
 #[test]
@@ -403,6 +531,43 @@ fn test_partial_contract_rejects_incompatible_topology_union() {
 }
 
 #[test]
+fn test_partial_contract_mismatched_topology_scalar_result() {
+    let s_a = DynIndex::new_dyn(2);
+    let s_b = DynIndex::new_dyn(2);
+    let bond_b = DynIndex::new_dyn(1);
+
+    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0, 2.0]).unwrap();
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+
+    let t_b0 = TensorDynLen::from_dense(vec![s_b.clone(), bond_b.clone()], vec![3.0, 4.0]).unwrap();
+    let t_b1 = TensorDynLen::from_dense(vec![bond_b], vec![1.0]).unwrap();
+    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![t_b0, t_b1],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![(s_a, s_b)],
+        diagonal_pairs: vec![],
+        output_order: None,
+    };
+    let result = partial_contract(
+        &tn_a,
+        &tn_b,
+        &spec,
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap();
+
+    assert!(result.external_indices().is_empty());
+    let dense = result.contract_to_tensor().unwrap();
+    assert_eq!(dense.as_slice_f64().unwrap(), vec![11.0]);
+}
+
+#[test]
 fn test_partial_contract_honors_output_order() {
     let a0 = DynIndex::new_dyn(2);
     let a1 = DynIndex::new_dyn(2);
@@ -469,6 +634,50 @@ fn test_partial_contract_honors_output_order() {
     assert_eq!(indices.len(), 2);
     assert_eq!(indices[0].id(), a2.id());
     assert_eq!(indices[1].id(), a0.id());
+}
+
+#[test]
+fn test_partial_contract_complex_diagonal_pair_keeps_left_leg() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+
+    let a = TensorDynLen::from_dense(
+        vec![i.clone()],
+        vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
+    )
+    .unwrap();
+    let b = TensorDynLen::from_dense(
+        vec![j.clone()],
+        vec![Complex64::new(3.0, 0.5), Complex64::new(-1.0, 4.0)],
+    )
+    .unwrap();
+
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![b], vec!["A".to_string()]).unwrap();
+
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![],
+        diagonal_pairs: vec![(i.clone(), j.clone())],
+        output_order: Some(vec![i.clone()]),
+    };
+    let result = partial_contract(
+        &tn_a,
+        &tn_b,
+        &spec,
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap();
+
+    let dense = result.contract_to_tensor().unwrap();
+    let expected = TensorDynLen::from_dense(
+        vec![i],
+        vec![Complex64::new(2.5, 3.5), Complex64::new(2.0, 9.0)],
+    )
+    .unwrap();
+    assert!(dense.isapprox(&expected, 1e-12, 0.0));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
@@ -41,15 +41,14 @@ where
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     I: IndexLike,
-    I::Id: Eq + Hash,
 {
     FuseOnly,
     SplitOnly,
     SwapOnly {
-        target_assignment: HashMap<I::Id, CurrentV>,
+        target_assignment: HashMap<I, CurrentV>,
     },
     SwapThenFuse {
-        target_assignment: HashMap<I::Id, CurrentV>,
+        target_assignment: HashMap<I, CurrentV>,
     },
     SplitThenFuse {
         split_target: Box<SplitThenFuseTarget<CurrentV, TargetV, I>>,
@@ -62,14 +61,13 @@ where
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     I: IndexLike,
-    I::Id: Eq + Hash,
 {
     kind: RestructurePlanKind<CurrentV, TargetV, I>,
 }
 
 fn collect_site_targets<T, TargetV>(
     target: &SiteIndexNetwork<TargetV, T::Index>,
-) -> Result<HashMap<<T::Index as IndexLike>::Id, TargetV>>
+) -> Result<HashMap<T::Index, TargetV>>
 where
     T: TensorLike,
     TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -84,11 +82,11 @@ where
             )
         })?;
         for site_idx in site_space {
-            let existing = site_to_target.insert(site_idx.id().clone(), target_node_name.clone());
+            let existing = site_to_target.insert(site_idx.clone(), target_node_name.clone());
             if let Some(previous_target) = existing {
                 bail!(
                     "restructure_to: site index {:?} appears in both target nodes {:?} and {:?}",
-                    site_idx.id(),
+                    site_idx,
                     previous_target,
                     target_node_name
                 );
@@ -98,15 +96,15 @@ where
     Ok(site_to_target)
 }
 
-fn collect_current_site_ids<T, CurrentV>(
+fn collect_current_site_indices<T, CurrentV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
-) -> Result<HashSet<<T::Index as IndexLike>::Id>>
+) -> Result<HashSet<T::Index>>
 where
     T: TensorLike,
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
 {
-    let mut site_ids = HashSet::new();
+    let mut site_indices = HashSet::new();
     for current_node_name in current.node_names() {
         let site_space = current.site_space(current_node_name).ok_or_else(|| {
             anyhow::anyhow!(
@@ -115,15 +113,15 @@ where
             )
         })?;
         for site_idx in site_space {
-            site_ids.insert(site_idx.id().clone());
+            site_indices.insert(site_idx.clone());
         }
     }
-    Ok(site_ids)
+    Ok(site_indices)
 }
 
 fn current_nodes_map_uniquely_to_targets<T, CurrentV, TargetV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
-    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
+    site_to_target: &HashMap<T::Index, TargetV>,
 ) -> Result<bool>
 where
     T: TensorLike,
@@ -142,12 +140,12 @@ where
             .iter()
             .map(|site_idx| {
                 site_to_target
-                    .get(site_idx.id())
+                    .get(site_idx)
                     .cloned()
                     .ok_or_else(|| {
                         anyhow::anyhow!(
                             "restructure_to: site index {:?} is present in the current network but missing from the target",
-                            site_idx.id()
+                            site_idx
                         )
                     })
             })
@@ -161,7 +159,7 @@ where
 
 fn collect_site_currents<T, CurrentV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
-) -> Result<HashMap<<T::Index as IndexLike>::Id, CurrentV>>
+) -> Result<HashMap<T::Index, CurrentV>>
 where
     T: TensorLike,
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -176,11 +174,11 @@ where
             )
         })?;
         for site_idx in site_space {
-            let existing = site_to_current.insert(site_idx.id().clone(), current_node_name.clone());
+            let existing = site_to_current.insert(site_idx.clone(), current_node_name.clone());
             if let Some(previous_current) = existing {
                 bail!(
                     "restructure_to: site index {:?} appears in both current nodes {:?} and {:?}",
-                    site_idx.id(),
+                    site_idx,
                     previous_current,
                     current_node_name
                 );
@@ -192,7 +190,7 @@ where
 
 fn target_nodes_map_uniquely_to_currents<T, CurrentV, TargetV>(
     target: &SiteIndexNetwork<TargetV, T::Index>,
-    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+    site_to_current: &HashMap<T::Index, CurrentV>,
 ) -> Result<bool>
 where
     T: TensorLike,
@@ -211,12 +209,12 @@ where
             .iter()
             .map(|site_idx| {
                 site_to_current
-                    .get(site_idx.id())
+                    .get(site_idx)
                     .cloned()
                     .ok_or_else(|| {
                         anyhow::anyhow!(
                             "restructure_to: site index {:?} is present in the target but missing from the current network",
-                            site_idx.id()
+                            site_idx
                         )
                     })
             })
@@ -231,7 +229,7 @@ where
 fn target_nodes_span_connected_currents<T, CurrentV, TargetV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
     target: &SiteIndexNetwork<TargetV, T::Index>,
-    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+    site_to_current: &HashMap<T::Index, CurrentV>,
     full_graph: &NamedGraph<CurrentV, T, T::Index>,
 ) -> Result<bool>
 where
@@ -250,10 +248,10 @@ where
         let current_names: HashSet<CurrentV> = site_space
             .iter()
             .map(|site_idx| {
-                site_to_current.get(site_idx.id()).cloned().ok_or_else(|| {
+                site_to_current.get(site_idx).cloned().ok_or_else(|| {
                     anyhow::anyhow!(
                         "restructure_to: site index {:?} is present in the target but missing from the current network",
-                        site_idx.id()
+                        site_idx
                     )
                 })
             })
@@ -298,7 +296,7 @@ where
 
 fn collect_shared_targets<T, CurrentV, TargetV>(
     target: &SiteIndexNetwork<TargetV, T::Index>,
-    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+    site_to_current: &HashMap<T::Index, CurrentV>,
 ) -> Result<HashSet<TargetV>>
 where
     T: TensorLike,
@@ -318,12 +316,12 @@ where
             .iter()
             .map(|site_idx| {
                 site_to_current
-                    .get(site_idx.id())
+                    .get(site_idx)
                     .cloned()
                     .ok_or_else(|| {
                         anyhow::anyhow!(
                             "restructure_to: site index {:?} is present in the target but missing from the current network",
-                            site_idx.id()
+                            site_idx
                         )
                     })
             })
@@ -338,8 +336,8 @@ where
 fn build_split_then_fuse_target<T, CurrentV, TargetV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
     target: &SiteIndexNetwork<TargetV, T::Index>,
-    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
-    site_to_current: &HashMap<<T::Index as IndexLike>::Id, CurrentV>,
+    site_to_target: &HashMap<T::Index, TargetV>,
+    site_to_current: &HashMap<T::Index, CurrentV>,
     full_graph: &NamedGraph<CurrentV, T, T::Index>,
 ) -> Result<Option<SplitThenFuseTarget<CurrentV, TargetV, T::Index>>>
 where
@@ -371,10 +369,10 @@ where
         })?;
         let mut fragments: HashMap<TargetV, HashSet<T::Index>> = HashMap::new();
         for site_idx in site_space {
-            let target_node_name = site_to_target.get(site_idx.id()).cloned().ok_or_else(|| {
+            let target_node_name = site_to_target.get(site_idx).cloned().ok_or_else(|| {
                 anyhow::anyhow!(
                     "restructure_to: site index {:?} is present in the current network but missing from the target",
-                    site_idx.id()
+                    site_idx
                 )
             })?;
             fragments
@@ -476,8 +474,8 @@ where
 fn build_path_swap_then_fuse_assignment<T, CurrentV, TargetV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
     target: &SiteIndexNetwork<TargetV, T::Index>,
-    site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
-) -> Result<Option<HashMap<<T::Index as IndexLike>::Id, CurrentV>>>
+    site_to_target: &HashMap<T::Index, TargetV>,
+) -> Result<Option<HashMap<T::Index, CurrentV>>>
 where
     T: TensorLike,
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -505,12 +503,12 @@ where
             .iter()
             .map(|site_idx| {
                 site_to_target
-                    .get(site_idx.id())
+                    .get(site_idx)
                     .cloned()
                     .ok_or_else(|| {
                         anyhow::anyhow!(
                             "restructure_to: site index {:?} is present in the current network but missing from the target",
-                            site_idx.id()
+                            site_idx
                         )
                     })
             })
@@ -559,7 +557,7 @@ where
                 target_node_name
             )
         })?;
-        let mut site_ids: Vec<_> = target
+        let mut site_indices: Vec<_> = target
             .site_space(target_node_name)
             .ok_or_else(|| {
                 anyhow::anyhow!(
@@ -568,16 +566,16 @@ where
                 )
             })?
             .iter()
-            .map(|site_idx| site_idx.id().clone())
+            .cloned()
             .collect();
-        site_ids.sort();
-        if site_ids.len() < block.len() {
+        site_indices.sort_by_key(|idx| format!("{:?}", idx));
+        if site_indices.len() < block.len() {
             return Ok(None);
         }
 
-        for (position, site_id) in site_ids.into_iter().enumerate() {
+        for (position, site_index) in site_indices.into_iter().enumerate() {
             let block_index = position.min(block.len() - 1);
-            target_assignment.insert(site_id, block[block_index].clone());
+            target_assignment.insert(site_index, block[block_index].clone());
         }
     }
 
@@ -785,7 +783,7 @@ where
 fn build_swap_assignment<T, CurrentV, TargetV>(
     current: &SiteIndexNetwork<CurrentV, T::Index>,
     target: &SiteIndexNetwork<TargetV, T::Index>,
-) -> Result<Option<HashMap<<T::Index as IndexLike>::Id, CurrentV>>>
+) -> Result<Option<HashMap<T::Index, CurrentV>>>
 where
     T: TensorLike,
     CurrentV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -824,7 +822,7 @@ where
             )
         })?;
         for site_idx in site_space {
-            assignment.insert(site_idx.id().clone(), current_name.clone());
+            assignment.insert(site_idx.clone(), current_name.clone());
         }
     }
 
@@ -880,11 +878,11 @@ where
 {
     let site_to_target = collect_site_targets::<T, TargetV>(target)?;
     let site_to_current = collect_site_currents::<T, CurrentV>(current)?;
-    let current_site_ids = collect_current_site_ids::<T, CurrentV>(current)?;
-    let target_site_ids: HashSet<_> = site_to_target.keys().cloned().collect();
+    let current_site_indices = collect_current_site_indices::<T, CurrentV>(current)?;
+    let target_site_indices: HashSet<_> = site_to_target.keys().cloned().collect();
 
-    if current_site_ids != target_site_ids {
-        bail!("restructure_to: current and target must contain the same site index ids");
+    if current_site_indices != target_site_indices {
+        bail!("restructure_to: current and target must contain the same site indices");
     }
 
     if current_nodes_map_uniquely_to_targets::<T, CurrentV, TargetV>(current, &site_to_target)? {
@@ -1090,7 +1088,7 @@ where
 mod tests {
     use std::collections::HashSet;
 
-    use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    use tensor4all_core::{DynIndex, TensorDynLen};
 
     use super::*;
 
@@ -1271,28 +1269,28 @@ mod tests {
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(s0.id())
+                .find_node_by_index(&s0)
                 .map(|name| name.as_str()),
             Some("X")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(s1.id())
+                .find_node_by_index(&s1)
                 .map(|name| name.as_str()),
             Some("Y")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(s2.id())
+                .find_node_by_index(&s2)
                 .map(|name| name.as_str()),
             Some("Y")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(s3.id())
+                .find_node_by_index(&s3)
                 .map(|name| name.as_str()),
             Some("Z")
         );
@@ -1334,28 +1332,28 @@ mod tests {
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(x0.id())
+                .find_node_by_index(&x0)
                 .map(|name| name.as_str()),
             Some("X")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(x1.id())
+                .find_node_by_index(&x1)
                 .map(|name| name.as_str()),
             Some("Y")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(y0.id())
+                .find_node_by_index(&y0)
                 .map(|name| name.as_str()),
             Some("Y")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(y1.id())
+                .find_node_by_index(&y1)
                 .map(|name| name.as_str()),
             Some("Z")
         );
@@ -1391,28 +1389,28 @@ mod tests {
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(x0.id())
+                .find_node_by_index(&x0)
                 .map(|name| name.as_str()),
             Some("X")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(y0.id())
+                .find_node_by_index(&y0)
                 .map(|name| name.as_str()),
             Some("X")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(x1.id())
+                .find_node_by_index(&x1)
                 .map(|name| name.as_str()),
             Some("Y")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(y1.id())
+                .find_node_by_index(&y1)
                 .map(|name| name.as_str()),
             Some("Y")
         );
@@ -1448,28 +1446,28 @@ mod tests {
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(x0.id())
+                .find_node_by_index(&x0)
                 .map(|name| name.as_str()),
             Some("X")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(y0.id())
+                .find_node_by_index(&y0)
                 .map(|name| name.as_str()),
             Some("X")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(x1.id())
+                .find_node_by_index(&x1)
                 .map(|name| name.as_str()),
             Some("Y")
         );
         assert_eq!(
             result
                 .site_index_network()
-                .find_node_by_index_id(y1.id())
+                .find_node_by_index(&y1)
                 .map(|name| name.as_str()),
             Some("Y")
         );

--- a/crates/tensor4all-treetn/src/treetn/swap.rs
+++ b/crates/tensor4all-treetn/src/treetn/swap.rs
@@ -159,9 +159,9 @@ where
     pub node_a: V,
     /// The second node in the directed sweep edge.
     pub node_b: V,
-    /// Site index IDs that should live on `node_a`'s side after this step.
+    /// Site index keys that should live on `node_a`'s side after this step.
     pub a_side_sites: HashSet<Id>,
-    /// Site index IDs that should live on `node_b`'s side after this step.
+    /// Site index keys that should live on `node_b`'s side after this step.
     pub b_side_sites: HashSet<Id>,
 }
 
@@ -227,7 +227,7 @@ where
     ///
     /// # Arguments
     /// * `topology` - Tree topology whose nodes are named by `V`.
-    /// * `current_assignment` - Current node for every site index ID in the network.
+    /// * `current_assignment` - Current node for every site index key in the network.
     /// * `target_assignment` - Partial target map; indices not listed keep their current side.
     /// * `root` - Sweep root and assumed initial canonical center.
     ///
@@ -235,7 +235,7 @@ where
     /// A [`SwapSchedule`] containing the ordered local updates needed to realize `target_assignment`.
     ///
     /// # Errors
-    /// Returns an error if `root` is missing, an index ID in `target_assignment`
+    /// Returns an error if `root` is missing, an index key in `target_assignment`
     /// is unknown, a referenced node is missing from `topology`, no tree path
     /// exists between required nodes, or the simulated sweeps fail to satisfy
     /// the requested target assignment within the tree-diameter pass bound.
@@ -470,19 +470,18 @@ where
 // Helpers: current assignment
 // ============================================================================
 
-/// Build index id -> node name from a TreeTN (all site indices).
-pub(crate) fn current_site_assignment<T, V>(
-    treetn: &TreeTN<T, V>,
-) -> HashMap<<T::Index as IndexLike>::Id, V>
+/// Build full site index -> node name from a TreeTN (all site indices).
+pub(crate) fn current_site_assignment<T, V>(treetn: &TreeTN<T, V>) -> HashMap<T::Index, V>
 where
     T: TensorLike,
+    T::Index: Hash + Eq,
     V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
 {
-    let mut out: HashMap<<T::Index as IndexLike>::Id, V> = HashMap::new();
+    let mut out: HashMap<T::Index, V> = HashMap::new();
     for node_name in treetn.node_names() {
         if let Some(site_space) = treetn.site_space(&node_name) {
             for idx in site_space {
-                out.insert(idx.id().to_owned(), node_name.clone());
+                out.insert(idx.clone(), node_name.clone());
             }
         }
     }

--- a/crates/tensor4all-treetn/src/treetn/swap.rs
+++ b/crates/tensor4all-treetn/src/treetn/swap.rs
@@ -1,7 +1,7 @@
 //! Site index swap: reorder which node holds which site index.
 //!
 //! Implements swapping site indices between adjacent nodes along the tree
-//! so that the network reaches a target assignment (index id -> node name).
+//! so that the network reaches a target assignment (index -> node name).
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::Hash;
@@ -146,9 +146,9 @@ pub struct SwapOptions {
 /// assert!(step.b_side_sites.contains("s0"));
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ScheduledSwapStep<V, Id>
+pub struct ScheduledSwapStep<V, K>
 where
-    Id: Eq + Hash,
+    K: Eq + Hash,
 {
     /// Path to transport the canonical center before the swap.
     ///
@@ -160,9 +160,9 @@ where
     /// The second node in the directed sweep edge.
     pub node_b: V,
     /// Site index keys that should live on `node_a`'s side after this step.
-    pub a_side_sites: HashSet<Id>,
+    pub a_side_sites: HashSet<K>,
     /// Site index keys that should live on `node_b`'s side after this step.
-    pub b_side_sites: HashSet<Id>,
+    pub b_side_sites: HashSet<K>,
 }
 
 // ============================================================================
@@ -203,20 +203,20 @@ where
 /// assert_eq!(schedule.steps[0].node_b, "B");
 /// ```
 #[derive(Debug, Clone)]
-pub struct SwapSchedule<V, Id>
+pub struct SwapSchedule<V, K>
 where
-    Id: Eq + Hash,
+    K: Eq + Hash,
 {
     /// Root used for the base Euler sweep and initial canonicalization.
     pub root: V,
     /// Fully expanded sequence of swap steps.
-    pub steps: Vec<ScheduledSwapStep<V, Id>>,
+    pub steps: Vec<ScheduledSwapStep<V, K>>,
 }
 
-impl<V, Id> SwapSchedule<V, Id>
+impl<V, K> SwapSchedule<V, K>
 where
     V: Clone + Hash + Eq + std::fmt::Debug + Send + Sync,
-    Id: Clone + Hash + Eq + std::fmt::Debug,
+    K: Clone + Hash + Eq + std::fmt::Debug,
 {
     /// Build a swap schedule from topology plus current and target assignments.
     ///
@@ -241,8 +241,8 @@ where
     /// the requested target assignment within the tree-diameter pass bound.
     pub fn build(
         topology: &NodeNameNetwork<V>,
-        current_assignment: &HashMap<Id, V>,
-        target_assignment: &HashMap<Id, V>,
+        current_assignment: &HashMap<K, V>,
+        target_assignment: &HashMap<K, V>,
         root: &V,
     ) -> Result<Self> {
         if !topology.has_node(root) {
@@ -252,28 +252,28 @@ where
             ));
         }
 
-        for (index_id, current_node) in current_assignment {
+        for (index, current_node) in current_assignment {
             if !topology.has_node(current_node) {
                 return Err(anyhow::anyhow!(
                     "SwapSchedule::build: current node {:?} for index {:?} is not in the topology",
                     current_node,
-                    index_id
+                    index
                 ));
             }
         }
 
-        for (index_id, target_node) in target_assignment {
-            if !current_assignment.contains_key(index_id) {
+        for (index, target_node) in target_assignment {
+            if !current_assignment.contains_key(index) {
                 return Err(anyhow::anyhow!(
-                    "SwapSchedule::build: target_assignment contains index id {:?} which is not in the network",
-                    index_id
+                    "SwapSchedule::build: target_assignment contains index {:?} which is not in the network",
+                    index
                 ));
             }
             if !topology.has_node(target_node) {
                 return Err(anyhow::anyhow!(
                     "SwapSchedule::build: target node {:?} for index {:?} is not in the topology",
                     target_node,
-                    index_id
+                    index
                 ));
             }
         }
@@ -307,29 +307,29 @@ where
                 let mut any_crossing = false;
                 let mut any_site_on_edge = false;
 
-                for (index_id, current_node) in &position {
+                for (index, current_node) in &position {
                     if current_node != &node_a && current_node != &node_b {
                         continue;
                     }
 
                     any_site_on_edge = true;
 
-                    if let Some(target_node) = target_assignment.get(index_id) {
+                    if let Some(target_node) = target_assignment.get(index) {
                         if oracle.is_target_on_a_side(&node_a, &node_b, target_node) {
-                            a_side_sites.insert(index_id.clone());
+                            a_side_sites.insert(index.clone());
                             if current_node == &node_b {
                                 any_crossing = true;
                             }
                         } else {
-                            b_side_sites.insert(index_id.clone());
+                            b_side_sites.insert(index.clone());
                             if current_node == &node_a {
                                 any_crossing = true;
                             }
                         }
                     } else if current_node == &node_a {
-                        a_side_sites.insert(index_id.clone());
+                        a_side_sites.insert(index.clone());
                     } else {
-                        b_side_sites.insert(index_id.clone());
+                        b_side_sites.insert(index.clone());
                     }
                 }
 
@@ -351,11 +351,11 @@ where
                     b_side_sites: b_side_sites.clone(),
                 });
 
-                for index_id in &a_side_sites {
-                    position.insert(index_id.clone(), node_a.clone());
+                for index in &a_side_sites {
+                    position.insert(index.clone(), node_a.clone());
                 }
-                for index_id in &b_side_sites {
-                    position.insert(index_id.clone(), node_b.clone());
+                for index in &b_side_sites {
+                    position.insert(index.clone(), node_b.clone());
                 }
 
                 center = node_b;
@@ -381,19 +381,17 @@ where
     }
 }
 
-fn positions_satisfy_targets<V, Id>(
-    position: &HashMap<Id, V>,
-    target_assignment: &HashMap<Id, V>,
+fn positions_satisfy_targets<V, K>(
+    position: &HashMap<K, V>,
+    target_assignment: &HashMap<K, V>,
 ) -> bool
 where
     V: Eq,
-    Id: Hash + Eq,
+    K: Hash + Eq,
 {
-    target_assignment.iter().all(|(index_id, target_node)| {
-        position
-            .get(index_id)
-            .is_some_and(|node| node == target_node)
-    })
+    target_assignment
+        .iter()
+        .all(|(index, target_node)| position.get(index).is_some_and(|node| node == target_node))
 }
 
 fn tree_path<V>(topology: &NodeNameNetwork<V>, from: &V, to: &V) -> Result<Vec<V>>

--- a/crates/tensor4all-treetn/src/treetn/tensor_like.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like.rs
@@ -98,7 +98,7 @@ where
             let old_in_tensor = tensor
                 .external_indices()
                 .iter()
-                .find(|idx| idx.id() == old_index.id())
+                .find(|idx| *idx == old_index)
                 .ok_or_else(|| {
                     anyhow::anyhow!("Index not found in tensor at node {:?}", node_name)
                 })?
@@ -135,7 +135,7 @@ where
                 let old_in_tensor = tensor
                     .external_indices()
                     .iter()
-                    .find(|idx| idx.id() == old_index.id())
+                    .find(|idx| *idx == old_index)
                     .ok_or_else(|| anyhow::anyhow!("Bond index not found in endpoint tensor"))?
                     .clone();
                 let new_tensor = tensor.replaceind(&old_in_tensor, new_index)?;

--- a/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
@@ -76,6 +76,28 @@ fn test_replaceind_site_index() {
 }
 
 #[test]
+fn test_replaceind_matches_same_id_prime_pair_site_index_exactly() {
+    let i = DynIndex::new_dyn(2);
+    let i_prime = i.prime();
+    let replacement = i_prime.sim();
+    let t = TensorDynLen::from_dense(vec![i.clone(), i_prime.clone()], vec![1.0, 2.0, 3.0, 4.0])
+        .unwrap();
+    let tn = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
+
+    let replaced = tn.replaceind(&i_prime, &replacement).unwrap();
+    let site_space = replaced.site_space(&"A".to_string()).unwrap();
+    assert!(site_space.contains(&i));
+    assert!(!site_space.contains(&i_prime));
+    assert!(site_space.contains(&replacement));
+
+    let tensor_indices = replaced
+        .tensor(replaced.node_index(&"A".to_string()).unwrap())
+        .unwrap()
+        .external_indices();
+    assert_eq!(tensor_indices, vec![i, replacement]);
+}
+
+#[test]
 fn test_replaceind_link_index_via_sim_linkinds() {
     let (tn, s0, bond, s1) = make_two_node_treetn();
 

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -18,7 +18,7 @@ use super::TreeTN;
 use crate::options::SplitOptions;
 use crate::site_index_network::SiteIndexNetwork;
 
-type SplitBoundaryIndices<V, TargetV, Id> = HashMap<V, HashMap<TargetV, HashSet<Id>>>;
+type SplitBoundaryIndices<V, TargetV, I> = HashMap<V, HashMap<TargetV, HashSet<I>>>;
 
 /// Compute the Steiner tree in the full graph spanning a set of terminal nodes.
 ///
@@ -113,12 +113,12 @@ where
     where
         TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     {
-        // Step 1: Build a mapping from site index ID to current node name
-        let mut site_to_current_node: HashMap<<T::Index as IndexLike>::Id, V> = HashMap::new();
+        // Step 1: Build a mapping from site index to current node name
+        let mut site_to_current_node: HashMap<T::Index, V> = HashMap::new();
         for current_node_name in self.node_names() {
             if let Some(site_space) = self.site_space(&current_node_name) {
                 for site_idx in site_space {
-                    site_to_current_node.insert(site_idx.id().clone(), current_node_name.clone());
+                    site_to_current_node.insert(site_idx.clone(), current_node_name.clone());
                 }
             }
         }
@@ -134,7 +134,7 @@ where
 
             let mut current_nodes_for_target: HashSet<V> = HashSet::new();
             for target_site_idx in target_site_space {
-                if let Some(current_node) = site_to_current_node.get(target_site_idx.id()) {
+                if let Some(current_node) = site_to_current_node.get(target_site_idx) {
                     current_nodes_for_target.insert(current_node.clone());
                 }
             }
@@ -342,7 +342,7 @@ where
     /// # Algorithm (Two-Phase Approach)
     ///
     /// **Phase 1: Exact factorization (no truncation)**
-    /// 1. Build mapping: site index ID -> target node name
+    /// 1. Build mapping: site index -> target node name
     /// 2. For each current node, check if its site indices map to multiple target nodes
     /// 3. If so, split the node using QR factorization
     /// 4. Repeat until all nodes match the target structure
@@ -377,17 +377,17 @@ where
     where
         TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     {
-        // Step 1: Build mapping from site index ID to target node name
-        let mut site_to_target: HashMap<<T::Index as IndexLike>::Id, TargetV> = HashMap::new();
+        // Step 1: Build mapping from site index to target node name
+        let mut site_to_target: HashMap<T::Index, TargetV> = HashMap::new();
         for target_node_name in target.node_names() {
             if let Some(site_space) = target.site_space(target_node_name) {
                 for site_idx in site_space {
-                    site_to_target.insert(site_idx.id().clone(), target_node_name.clone());
+                    site_to_target.insert(site_idx.clone(), target_node_name.clone());
                 }
             }
         }
 
-        let mut site_to_current: HashMap<<T::Index as IndexLike>::Id, V> = HashMap::new();
+        let mut site_to_current: HashMap<T::Index, V> = HashMap::new();
         for current_node_name in self.node_names() {
             let site_space = self.site_space(&current_node_name).ok_or_else(|| {
                 anyhow::anyhow!(
@@ -396,7 +396,7 @@ where
                 )
             })?;
             for site_idx in site_space {
-                site_to_current.insert(site_idx.id().clone(), current_node_name.clone());
+                site_to_current.insert(site_idx.clone(), current_node_name.clone());
             }
         }
 
@@ -411,10 +411,10 @@ where
             let current_names: HashSet<_> = site_space
                 .iter()
                 .map(|site_idx| {
-                    site_to_current.get(site_idx.id()).cloned().ok_or_else(|| {
+                    site_to_current.get(site_idx).cloned().ok_or_else(|| {
                         anyhow::anyhow!(
                             "split_to: target site index {:?} is missing from the current network",
-                            site_idx.id()
+                            site_idx
                         )
                     })
                 })
@@ -448,12 +448,12 @@ where
             if let Some(site_space) = self.site_space(&current_node_name) {
                 let mut targets_for_node: HashSet<TargetV> = HashSet::new();
                 for site_idx in site_space {
-                    if let Some(target_name) = site_to_target.get(site_idx.id()) {
+                    if let Some(target_name) = site_to_target.get(site_idx) {
                         targets_for_node.insert(target_name.clone());
                     } else {
                         return Err(anyhow::anyhow!(
                             "Site index {:?} in current node {:?} has no corresponding target node",
-                            site_idx.id(),
+                            site_idx,
                             current_node_name
                         ))
                         .context("split_to: incompatible target structure");
@@ -559,12 +559,11 @@ where
         &self,
         target: &SiteIndexNetwork<TargetV, T::Index>,
         target_to_current: &HashMap<TargetV, V>,
-    ) -> Result<SplitBoundaryIndices<V, TargetV, <T::Index as IndexLike>::Id>>
+    ) -> Result<SplitBoundaryIndices<V, TargetV, T::Index>>
     where
         TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     {
-        let mut boundary_indices: SplitBoundaryIndices<V, TargetV, <T::Index as IndexLike>::Id> =
-            HashMap::new();
+        let mut boundary_indices: SplitBoundaryIndices<V, TargetV, T::Index> = HashMap::new();
 
         for edge in self.graph.graph().edge_indices() {
             let (node_a, node_b) = self.graph.graph().edge_endpoints(edge).ok_or_else(|| {
@@ -616,13 +615,13 @@ where
                 .or_default()
                 .entry(target_for_a.clone())
                 .or_default()
-                .insert(bond_index.id().clone());
+                .insert(bond_index.clone());
             boundary_indices
                 .entry(current_b)
                 .or_default()
                 .entry(target_for_b.clone())
                 .or_default()
-                .insert(bond_index.id().clone());
+                .insert(bond_index.clone());
         }
 
         Ok(boundary_indices)
@@ -637,40 +636,36 @@ where
     fn split_tensor_for_targets<TargetV>(
         &self,
         tensor: &T,
-        site_to_target: &HashMap<<T::Index as IndexLike>::Id, TargetV>,
-        boundary_indices: Option<&HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>>>,
+        site_to_target: &HashMap<T::Index, TargetV>,
+        boundary_indices: Option<&HashMap<TargetV, HashSet<T::Index>>>,
         fragment_target: &SiteIndexNetwork<TargetV, T::Index>,
     ) -> Result<Vec<(TargetV, T)>>
     where
         TargetV: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     {
         // Group tensor's site indices by their target node
-        let mut partition: HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>> = HashMap::new();
+        let mut partition: HashMap<TargetV, HashSet<T::Index>> = HashMap::new();
         for idx in tensor.external_indices() {
-            if let Some(target_name) = site_to_target.get(idx.id()) {
+            if let Some(target_name) = site_to_target.get(&idx) {
                 partition
                     .entry(target_name.clone())
                     .or_default()
-                    .insert(idx.id().clone());
+                    .insert(idx);
             }
         }
         if let Some(boundary_indices) = boundary_indices {
-            let tensor_index_ids: HashSet<_> = tensor
-                .external_indices()
-                .iter()
-                .map(|idx| idx.id().clone())
-                .collect();
-            for (target_name, index_ids) in boundary_indices {
+            let tensor_index_set: HashSet<_> = tensor.external_indices().into_iter().collect();
+            for (target_name, indices) in boundary_indices {
                 let target_partition = partition.entry(target_name.clone()).or_default();
-                for index_id in index_ids {
-                    if !tensor_index_ids.contains(index_id) {
+                for index in indices {
+                    if !tensor_index_set.contains(index) {
                         return Err(anyhow::anyhow!(
                             "split_to: boundary index {:?} is not present in the tensor for target {:?}",
-                            index_id,
+                            index,
                             target_name
                         ));
                     }
-                    target_partition.insert(index_id.clone());
+                    target_partition.insert(index.clone());
                 }
             }
         }
@@ -736,26 +731,26 @@ where
         // Process nodes in post-order (skip root — it gets the remaining tensor)
         let mut remaining_tensor = tensor.clone();
         let mut result: Vec<(TargetV, T)> = Vec::new();
-        let mut child_bonds: HashMap<TargetV, <T::Index as IndexLike>::Id> = HashMap::new();
+        let mut child_bonds: HashMap<TargetV, T::Index> = HashMap::new();
 
         for node in traversal.iter().take(traversal.len() - 1) {
-            let node_ids = partition.get(node).cloned().unwrap_or_default();
+            let node_indices = partition.get(node).cloned().unwrap_or_default();
             let current_indices = remaining_tensor.external_indices();
 
-            // Build set of desired index IDs: this node's site+boundary indices
+            // Build set of desired indices: this node's site+boundary indices
             // plus bonds from already-processed children.
-            let mut desired_ids = node_ids;
+            let mut desired_indices = node_indices;
             if let Some(children) = children_by_parent.get(node) {
                 for child in children {
-                    if let Some(bond_id) = child_bonds.get(child) {
-                        desired_ids.insert(bond_id.clone());
+                    if let Some(bond) = child_bonds.get(child) {
+                        desired_indices.insert(bond.clone());
                     }
                 }
             }
 
             let left_inds: Vec<_> = current_indices
                 .iter()
-                .filter(|idx| desired_ids.contains(idx.id()))
+                .filter(|idx| desired_indices.contains(*idx))
                 .cloned()
                 .collect();
 
@@ -786,7 +781,7 @@ where
                     shared.len()
                 ));
             }
-            child_bonds.insert(node.clone(), shared[0].id().clone());
+            child_bonds.insert(node.clone(), shared[0].clone());
 
             result.push((node.clone(), factorize_result.left));
             remaining_tensor = factorize_result.right;
@@ -807,7 +802,7 @@ where
     fn split_tensor_for_targets_sequential<TargetV>(
         &self,
         tensor: &T,
-        partition: &HashMap<TargetV, HashSet<<T::Index as IndexLike>::Id>>,
+        partition: &HashMap<TargetV, HashSet<T::Index>>,
         target_names: &[TargetV],
     ) -> Result<Vec<(TargetV, T)>>
     where
@@ -817,12 +812,12 @@ where
         let mut result: Vec<(TargetV, T)> = Vec::new();
 
         for target_name in target_names.iter().take(target_names.len() - 1) {
-            let site_ids_for_target = partition.get(target_name).unwrap();
+            let site_indices_for_target = partition.get(target_name).unwrap();
 
             let left_inds: Vec<_> = remaining_tensor
                 .external_indices()
                 .iter()
-                .filter(|idx| site_ids_for_target.contains(idx.id()))
+                .filter(|idx| site_indices_for_target.contains(*idx))
                 .cloned()
                 .collect();
 

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -321,28 +321,28 @@ fn test_split_to_allows_edgeless_intermediate_fragments() {
     assert_eq!(
         split
             .site_index_network()
-            .find_node_by_index_id(x0.id())
+            .find_node_by_index(&x0)
             .map(|name| name.as_str()),
         Some("left_x")
     );
     assert_eq!(
         split
             .site_index_network()
-            .find_node_by_index_id(x1.id())
+            .find_node_by_index(&x1)
             .map(|name| name.as_str()),
         Some("left_y")
     );
     assert_eq!(
         split
             .site_index_network()
-            .find_node_by_index_id(y0.id())
+            .find_node_by_index(&y0)
             .map(|name| name.as_str()),
         Some("right_y")
     );
     assert_eq!(
         split
             .site_index_network()
-            .find_node_by_index_id(y1.id())
+            .find_node_by_index(&y1)
             .map(|name| name.as_str()),
         Some("right_z")
     );

--- a/crates/tensor4all-treetn/tests/bug_swap_values.rs
+++ b/crates/tensor4all-treetn/tests/bug_swap_values.rs
@@ -67,10 +67,10 @@ fn test_swap_preserves_values_nontrivial_data() {
     let mut treetn: TreeTN<TensorDynLen, usize> =
         TreeTN::from_tensors(tensors, node_names).unwrap();
     let mut target = HashMap::new();
-    target.insert(z1_1.id().to_owned(), 0usize);
-    target.insert(z2_1.id().to_owned(), 1usize);
-    target.insert(z1_2.id().to_owned(), 2usize);
-    target.insert(z2_2.id().to_owned(), 3usize);
+    target.insert(z1_1.clone(), 0usize);
+    target.insert(z2_1.clone(), 1usize);
+    target.insert(z1_2.clone(), 2usize);
+    target.insert(z2_2.clone(), 3usize);
     treetn
         .swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
@@ -331,10 +331,10 @@ fn test_swap_preserves_values_plain_mps() {
     let mut treetn: TreeTN<TensorDynLen, usize> =
         TreeTN::from_tensors(tensors, node_names).unwrap();
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), 0usize);
-    target.insert(s2.id().to_owned(), 1usize);
-    target.insert(s1.id().to_owned(), 2usize);
-    target.insert(s3.id().to_owned(), 3usize);
+    target.insert(s0.clone(), 0usize);
+    target.insert(s2.clone(), 1usize);
+    target.insert(s1.clone(), 2usize);
+    target.insert(s3.clone(), 3usize);
     treetn
         .swap_site_indices(&target, &SwapOptions::default())
         .unwrap();

--- a/crates/tensor4all-treetn/tests/ops.rs
+++ b/crates/tensor4all-treetn/tests/ops.rs
@@ -89,17 +89,17 @@ fn create_three_node_named() -> (
 }
 
 fn build_col_major_data(
-    ordered_ids: &[<DynIndex as IndexLike>::Id],
-    point_values: &std::collections::HashMap<<DynIndex as IndexLike>::Id, Vec<usize>>,
+    ordered_indices: &[DynIndex],
+    point_values: &std::collections::HashMap<DynIndex, Vec<usize>>,
 ) -> Vec<usize> {
     let n_points = point_values.values().next().map(Vec::len).unwrap_or(0);
-    let mut data = vec![0; ordered_ids.len() * n_points];
+    let mut data = vec![0; ordered_indices.len() * n_points];
 
-    for (row, id) in ordered_ids.iter().enumerate() {
-        let per_index_values = point_values.get(id).unwrap();
+    for (row, index) in ordered_indices.iter().enumerate() {
+        let per_index_values = point_values.get(index).unwrap();
         assert_eq!(per_index_values.len(), n_points);
         for (col, value) in per_index_values.iter().enumerate() {
-            data[row + ordered_ids.len() * col] = *value;
+            data[row + ordered_indices.len() * col] = *value;
         }
     }
 
@@ -276,61 +276,50 @@ fn test_to_dense_empty() {
 }
 
 // ============================================================================
-// Tests for all_site_index_ids
+// Tests for all_site_indices
 // ============================================================================
 
 #[test]
-fn test_all_site_index_ids_single_node() {
+fn test_all_site_indices_single_node_returns_indices() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![1.0, 2.0, 3.0]);
     let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
-    let (ids, vertices) = tn.all_site_index_ids().unwrap();
-    assert_eq!(ids.len(), 1);
+    let (indices, vertices) = tn.all_site_indices().unwrap();
+    assert_eq!(indices.len(), 1);
     assert_eq!(vertices.len(), 1);
-    assert_eq!(ids[0], *s0.id());
+    assert_eq!(indices[0], s0);
     assert_eq!(vertices[0], 0);
 }
 
 #[test]
-fn test_all_site_index_ids_two_nodes() {
+fn test_all_site_indices_two_nodes_returns_indices() {
     let (tn, s0, _bond, s1) = create_two_node_named();
 
-    let (ids, vertices) = tn.all_site_index_ids().unwrap();
-    assert_eq!(ids.len(), 2);
+    let (indices, vertices) = tn.all_site_indices().unwrap();
+    assert_eq!(indices.len(), 2);
     assert_eq!(vertices.len(), 2);
 
-    // Check that both site index IDs are present with correct vertex associations
-    let id_vertex_set: std::collections::HashSet<_> = ids.iter().zip(vertices.iter()).collect();
-    assert!(id_vertex_set.contains(&(s0.id(), &0)));
-    assert!(id_vertex_set.contains(&(s1.id(), &1)));
+    // Check that both site indices are present with correct vertex associations
+    let index_vertex_set: std::collections::HashSet<_> =
+        indices.iter().zip(vertices.iter()).collect();
+    assert!(index_vertex_set.contains(&(&s0, &0)));
+    assert!(index_vertex_set.contains(&(&s1, &1)));
 }
 
 #[test]
-fn test_all_site_index_ids_three_nodes() {
+fn test_all_site_indices_three_nodes_returns_indices() {
     let (tn, s0, s1, s2) = create_three_node_named();
 
-    let (ids, vertices) = tn.all_site_index_ids().unwrap();
-    assert_eq!(ids.len(), 3);
+    let (indices, vertices) = tn.all_site_indices().unwrap();
+    assert_eq!(indices.len(), 3);
     assert_eq!(vertices.len(), 3);
 
-    let id_vertex_set: std::collections::HashSet<_> = ids.iter().zip(vertices.iter()).collect();
-    assert!(id_vertex_set.contains(&(s0.id(), &0)));
-    assert!(id_vertex_set.contains(&(s1.id(), &1)));
-    assert!(id_vertex_set.contains(&(s2.id(), &2)));
-}
-
-#[test]
-fn test_all_site_indices_matches_ids() {
-    let (tn, _, _, _) = create_three_node_named();
-
-    let (index_ids, id_vertices) = tn.all_site_index_ids().unwrap();
-    let (indices, index_vertices) = tn.all_site_indices().unwrap();
-
-    let ids_from_indices: Vec<_> = indices.iter().map(|index| *index.id()).collect();
-
-    assert_eq!(ids_from_indices, index_ids);
-    assert_eq!(index_vertices, id_vertices);
+    let index_vertex_set: std::collections::HashSet<_> =
+        indices.iter().zip(vertices.iter()).collect();
+    assert!(index_vertex_set.contains(&(&s0, &0)));
+    assert!(index_vertex_set.contains(&(&s1, &1)));
+    assert!(index_vertex_set.contains(&(&s2, &2)));
 }
 
 // ============================================================================
@@ -343,13 +332,13 @@ fn test_evaluate_single_node() {
     let t0 = make_tensor(vec![s0.clone()], vec![10.0, 20.0, 30.0]);
     let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
 
     // Evaluate at index 0
     let data = [0usize];
-    let shape = [index_ids.len(), 1];
+    let shape = [indices.len(), 1];
     let values = ColMajorArrayRef::new(&data, &shape);
-    let vals = tn.evaluate(&index_ids, values).unwrap();
+    let vals = tn.evaluate(&indices, values).unwrap();
     assert!(
         (vals[0].real() - 10.0).abs() < 1e-10,
         "evaluate at [0] = {}, expected 10.0",
@@ -359,7 +348,7 @@ fn test_evaluate_single_node() {
     // Evaluate at index 2
     let data = [2usize];
     let values = ColMajorArrayRef::new(&data, &shape);
-    let vals = tn.evaluate(&index_ids, values).unwrap();
+    let vals = tn.evaluate(&indices, values).unwrap();
     assert!(
         (vals[0].real() - 30.0).abs() < 1e-10,
         "evaluate at [2] = {}, expected 30.0",
@@ -378,20 +367,20 @@ fn test_evaluate_two_nodes() {
     let dim0 = s0.dim();
     let dim1 = s1.dim();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
-    // Find positions of s0 and s1 in index_ids
-    let pos0 = index_ids.iter().position(|id| id == s0.id()).unwrap();
-    let pos1 = index_ids.iter().position(|id| id == s1.id()).unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
+    // Find positions of s0 and s1 in indices
+    let pos0 = indices.iter().position(|index| index == &s0).unwrap();
+    let pos1 = indices.iter().position(|index| index == &s1).unwrap();
 
     // Evaluate at each combination and verify against dense
     for i in 0..dim0 {
         for j in 0..dim1 {
-            let mut data = vec![0usize; index_ids.len()];
+            let mut data = vec![0usize; indices.len()];
             data[pos0] = i;
             data[pos1] = j;
-            let shape = [index_ids.len(), 1];
+            let shape = [indices.len(), 1];
             let values = ColMajorArrayRef::new(&data, &shape);
-            let vals = tn.evaluate(&index_ids, values).unwrap();
+            let vals = tn.evaluate(&indices, values).unwrap();
 
             // Get the expected value from dense tensor
             let flat_idx = i + dim0 * j;
@@ -421,9 +410,9 @@ fn test_evaluate_two_nodes_complex() {
     let t1 = make_complex_tensor(vec![bond.clone(), s1.clone()], vec![b[0], b[1]]);
     let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
-    let pos0 = index_ids.iter().position(|id| id == s0.id()).unwrap();
-    let pos1 = index_ids.iter().position(|id| id == s1.id()).unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
+    let pos0 = indices.iter().position(|index| index == &s0).unwrap();
+    let pos1 = indices.iter().position(|index| index == &s1).unwrap();
 
     let max_sample = a
         .iter()
@@ -433,12 +422,12 @@ fn test_evaluate_two_nodes_complex() {
     let mut max_diff = 0.0_f64;
     for (i, a_i) in a.iter().enumerate() {
         for (j, b_j) in b.iter().enumerate() {
-            let mut data = vec![0usize; index_ids.len()];
+            let mut data = vec![0usize; indices.len()];
             data[pos0] = i;
             data[pos1] = j;
-            let shape = [index_ids.len(), 1];
+            let shape = [indices.len(), 1];
             let values = ColMajorArrayRef::new(&data, &shape);
-            let vals = tn.evaluate(&index_ids, values).unwrap();
+            let vals = tn.evaluate(&indices, values).unwrap();
             let expected = *a_i * *b_j;
             let got = Complex64::new(vals[0].real(), vals[0].imag());
             max_diff = max_diff.max((got - expected).norm());
@@ -464,20 +453,20 @@ fn test_evaluate_three_nodes() {
     let dim0 = s0.dim();
     let dim1 = s1.dim();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
-    let pos0 = index_ids.iter().position(|id| id == s0.id()).unwrap();
-    let pos1 = index_ids.iter().position(|id| id == s1.id()).unwrap();
-    let pos2 = index_ids.iter().position(|id| id == s2.id()).unwrap();
+    let (indices, _vertices) = tn.all_site_indices().unwrap();
+    let pos0 = indices.iter().position(|index| index == &s0).unwrap();
+    let pos1 = indices.iter().position(|index| index == &s1).unwrap();
+    let pos2 = indices.iter().position(|index| index == &s2).unwrap();
 
     // Spot-check a few values
     for (i, j, k) in [(0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1), (1, 1, 1)] {
-        let mut data = vec![0usize; index_ids.len()];
+        let mut data = vec![0usize; indices.len()];
         data[pos0] = i;
         data[pos1] = j;
         data[pos2] = k;
-        let shape = [index_ids.len(), 1];
+        let shape = [indices.len(), 1];
         let values = ColMajorArrayRef::new(&data, &shape);
-        let vals = tn.evaluate(&index_ids, values).unwrap();
+        let vals = tn.evaluate(&indices, values).unwrap();
 
         let flat_idx = i + dim0 * (j + dim1 * k);
         let expected = dense_data[flat_idx];
@@ -498,23 +487,21 @@ fn test_evaluate_three_nodes() {
 fn test_evaluate_at_matches_evaluate() {
     let (tn, s0, s1, s2) = create_three_node_named();
 
-    let (index_ids, _vertices) = tn.all_site_index_ids().unwrap();
     let (indices, _node_names) = tn.all_site_indices().unwrap();
 
     let point_values = std::collections::HashMap::from([
-        (*s0.id(), vec![0usize, 1, 1]),
-        (*s1.id(), vec![0usize, 1, 0]),
-        (*s2.id(), vec![1usize, 0, 1]),
+        (s0.clone(), vec![0usize, 1, 1]),
+        (s1.clone(), vec![0usize, 1, 0]),
+        (s2.clone(), vec![1usize, 0, 1]),
     ]);
 
-    let shape = [index_ids.len(), 3];
+    let shape = [indices.len(), 3];
 
-    let evaluate_data = build_col_major_data(&index_ids, &point_values);
+    let evaluate_data = build_col_major_data(&indices, &point_values);
     let evaluate_values = ColMajorArrayRef::new(&evaluate_data, &shape);
-    let evaluate_result = tn.evaluate(&index_ids, evaluate_values).unwrap();
+    let evaluate_result = tn.evaluate(&indices, evaluate_values).unwrap();
 
-    let index_order_ids: Vec<_> = indices.iter().map(|index| *index.id()).collect();
-    let evaluate_at_data = build_col_major_data(&index_order_ids, &point_values);
+    let evaluate_at_data = build_col_major_data(&indices, &point_values);
     let evaluate_at_values = ColMajorArrayRef::new(&evaluate_at_data, &shape);
     let evaluate_at_result = tn.evaluate_at(&indices, evaluate_at_values).unwrap();
 
@@ -541,16 +528,16 @@ fn test_evaluate_empty() {
 // ============================================================================
 
 #[test]
-fn test_evaluate_rejects_duplicate_index_ids() {
+fn test_evaluate_rejects_duplicate_indices() {
     let (tn, s0, _, _s1) = create_two_node_named();
 
-    // Use the same index ID twice instead of both distinct site IDs
-    let dup_ids = vec![*s0.id(), *s0.id()];
+    // Use the same index twice instead of both distinct site indices.
+    let dup_indices = vec![s0.clone(), s0.clone()];
     let data = [0usize, 0];
     let shape = [2, 1];
     let values = ColMajorArrayRef::new(&data, &shape);
-    let result = tn.evaluate(&dup_ids, values);
-    assert!(result.is_err(), "should reject duplicate index IDs");
+    let result = tn.evaluate(&dup_indices, values);
+    assert!(result.is_err(), "should reject duplicate indices");
     let msg = format!("{}", result.unwrap_err());
     assert!(
         msg.contains("duplicate"),
@@ -559,17 +546,17 @@ fn test_evaluate_rejects_duplicate_index_ids() {
 }
 
 #[test]
-fn test_evaluate_rejects_unknown_index_ids() {
+fn test_evaluate_rejects_unknown_indices() {
     let (tn, s0, _, _s1) = create_two_node_named();
 
-    // Use one real ID and one fabricated ID that does not exist in the network
+    // Use one real index and one fabricated index that does not exist in the network.
     let unknown = idx(2);
-    let fake_ids = vec![*s0.id(), *unknown.id()];
+    let fake_indices = vec![s0.clone(), unknown];
     let data = [0usize, 0];
     let shape = [2, 1];
     let values = ColMajorArrayRef::new(&data, &shape);
-    let result = tn.evaluate(&fake_ids, values);
-    assert!(result.is_err(), "should reject unknown index IDs");
+    let result = tn.evaluate(&fake_indices, values);
+    assert!(result.is_err(), "should reject unknown indices");
     let msg = format!("{}", result.unwrap_err());
     assert!(
         msg.contains("unknown"),
@@ -578,16 +565,16 @@ fn test_evaluate_rejects_unknown_index_ids() {
 }
 
 #[test]
-fn test_evaluate_rejects_missing_index_ids() {
+fn test_evaluate_rejects_missing_indices() {
     let (tn, s0, _, _s1) = create_two_node_named();
 
-    // Provide only one of the two required site index IDs
-    let partial_ids = vec![*s0.id()];
+    // Provide only one of the two required site indices.
+    let partial_indices = vec![s0.clone()];
     let data = [0usize];
     let shape = [1, 1];
     let values = ColMajorArrayRef::new(&data, &shape);
-    let result = tn.evaluate(&partial_ids, values);
-    assert!(result.is_err(), "should reject missing index IDs");
+    let result = tn.evaluate(&partial_indices, values);
+    assert!(result.is_err(), "should reject missing indices");
     let msg = format!("{}", result.unwrap_err());
     assert!(
         msg.contains("total site indices"),
@@ -631,28 +618,21 @@ fn test_all_site_indices_two_nodes() {
 }
 
 #[test]
-fn test_all_site_indices_consistent_with_ids() {
+fn test_all_site_indices_has_matching_vertices() {
     let (tn, _, _, _) = create_three_node_named();
 
-    // all_site_indices and all_site_index_ids should return the same IDs
     let (indices, idx_vertices) = tn.all_site_indices().unwrap();
-    let (ids, id_vertices) = tn.all_site_index_ids().unwrap();
 
-    assert_eq!(indices.len(), ids.len());
+    assert_eq!(indices.len(), idx_vertices.len());
 
-    // Build sets of (id, vertex) for comparison
+    // Build a set of (index, vertex) pairs to ensure ownership is represented.
     let idx_set: std::collections::HashSet<_> = indices
         .iter()
-        .map(|i| *i.id())
+        .cloned()
         .zip(idx_vertices.iter().cloned())
         .collect();
-    let id_set: std::collections::HashSet<_> = ids
-        .iter()
-        .cloned()
-        .zip(id_vertices.iter().cloned())
-        .collect();
 
-    assert_eq!(idx_set, id_set);
+    assert_eq!(idx_set.len(), 3);
 }
 
 // ============================================================================
@@ -735,11 +715,6 @@ fn test_evaluate_at_consistent_with_evaluate() {
     let (tn, s0, _, s1) = create_two_node_named();
 
     let (indices, _vertices) = tn.all_site_indices().unwrap();
-    let (_index_ids, _id_vertices) = tn.all_site_index_ids().unwrap();
-
-    // Build matching ID order: for each index in `indices`, find the
-    // corresponding ID to ensure positions align.
-    let ordered_ids: Vec<_> = indices.iter().map(|i| *i.id()).collect();
 
     let dim0 = s0.dim();
     let dim1 = s1.dim();
@@ -755,15 +730,15 @@ fn test_evaluate_at_consistent_with_evaluate() {
             let values = ColMajorArrayRef::new(&data, &shape);
 
             let vals_at = tn.evaluate_at(&indices, values).unwrap();
-            let vals_id = tn.evaluate(&ordered_ids, values).unwrap();
+            let vals = tn.evaluate(&indices, values).unwrap();
 
             assert!(
-                (vals_at[0].real() - vals_id[0].real()).abs() < 1e-15,
+                (vals_at[0].real() - vals[0].real()).abs() < 1e-15,
                 "evaluate_at and evaluate differ at [{}, {}]: {} vs {}",
                 i,
                 j,
                 vals_at[0].real(),
-                vals_id[0].real()
+                vals[0].real()
             );
         }
     }

--- a/crates/tensor4all-treetn/tests/swap_test.rs
+++ b/crates/tensor4all-treetn/tests/swap_test.rs
@@ -498,6 +498,65 @@ fn test_swap_by_index_matches_id_based_generic<T: TensorElement + From<f64>>() {
     assert_eq!(net.find_node_by_index(&s2).map(|n| n.as_str()), Some("1"));
 }
 
+#[test]
+fn test_swap_by_index_distinguishes_same_id_prime_pair() {
+    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let s = tensor4all_core::DynIndex::new_dyn(2);
+    let s_prime = s.prime();
+    let t = tensor4all_core::DynIndex::new_dyn(2);
+    let bond = tensor4all_core::DynIndex::new_dyn(1);
+    let a = TensorDynLen::from_dense(
+        vec![s.clone(), s_prime.clone(), bond.clone()],
+        vec![1.0, 2.0, 3.0, 4.0],
+    )
+    .unwrap();
+    let b = TensorDynLen::from_dense(vec![bond.clone(), t.clone()], vec![1.0, 1.0]).unwrap();
+    tn.add_tensor("A".to_string(), a).unwrap();
+    tn.add_tensor("B".to_string(), b).unwrap();
+    let na = tn.node_index(&"A".to_string()).unwrap();
+    let nb = tn.node_index(&"B".to_string()).unwrap();
+    tn.connect(na, &bond, nb, &bond).unwrap();
+
+    let mut target = HashMap::new();
+    target.insert(s_prime.clone(), "B".to_string());
+    tn.swap_site_indices_by_index(&target, &SwapOptions::default())
+        .unwrap();
+
+    let net = tn.site_index_network();
+    assert_eq!(net.find_node_by_index(&s).map(|n| n.as_str()), Some("A"));
+    assert_eq!(
+        net.find_node_by_index(&s_prime).map(|n| n.as_str()),
+        Some("B")
+    );
+}
+
+#[test]
+fn test_swap_by_id_rejects_ambiguous_same_id_prime_pair() {
+    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let s = tensor4all_core::DynIndex::new_dyn(2);
+    let s_prime = s.prime();
+    let bond = tensor4all_core::DynIndex::new_dyn(1);
+    let a = TensorDynLen::from_dense(
+        vec![s.clone(), s_prime, bond.clone()],
+        vec![1.0, 2.0, 3.0, 4.0],
+    )
+    .unwrap();
+    let b = TensorDynLen::from_dense(vec![bond.clone()], vec![1.0]).unwrap();
+    tn.add_tensor("A".to_string(), a).unwrap();
+    tn.add_tensor("B".to_string(), b).unwrap();
+    let na = tn.node_index(&"A".to_string()).unwrap();
+    let nb = tn.node_index(&"B".to_string()).unwrap();
+    tn.connect(na, &bond, nb, &bond).unwrap();
+
+    let mut target = HashMap::new();
+    target.insert(s.id().to_owned(), "B".to_string());
+    let err = tn
+        .swap_site_indices(&target, &SwapOptions::default())
+        .unwrap_err();
+
+    assert!(err.to_string().contains("ambiguous"));
+}
+
 // ============================================================================
 // f64 tests
 // ============================================================================

--- a/crates/tensor4all-treetn/tests/swap_test.rs
+++ b/crates/tensor4all-treetn/tests/swap_test.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use num_complex::Complex64;
-use tensor4all_core::{IndexLike, TensorDynLen, TensorElement};
+use tensor4all_core::{TensorDynLen, TensorElement};
 use tensor4all_treetn::{SwapOptions, TreeTN};
 
 // ============================================================================
@@ -265,102 +265,60 @@ fn y_shape_tree<T: TensorElement + From<f64>>() -> (
 fn test_swap_two_node_chain_generic<T: TensorElement + From<f64>>() {
     let (mut tn, s0, s1) = two_node_chain::<T>();
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("A")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("B")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("A"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("B"));
 
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "B".to_string());
-    target.insert(s1.id().to_owned(), "A".to_string());
+    target.insert(s0.clone(), "B".to_string());
+    target.insert(s1.clone(), "A".to_string());
 
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
 
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("B")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("A")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("B"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("A"));
 }
 
 fn test_swap_three_node_chain_generic<T: TensorElement + From<f64>>() {
     let (mut tn, s0, s1, s2) = three_node_chain::<T>();
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("0")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("1")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s2.id()).map(|n| n.as_str()),
-        Some("2")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("0"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("1"));
+    assert_eq!(net.find_node_by_index(&s2).map(|n| n.as_str()), Some("2"));
 
     // Swap so that s0->"2", s1->"0", s2->"1"
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "2".to_string());
-    target.insert(s1.id().to_owned(), "0".to_string());
-    target.insert(s2.id().to_owned(), "1".to_string());
+    target.insert(s0.clone(), "2".to_string());
+    target.insert(s1.clone(), "0".to_string());
+    target.insert(s2.clone(), "1".to_string());
 
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
 
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("2")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("0")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s2.id()).map(|n| n.as_str()),
-        Some("1")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("2"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("0"));
+    assert_eq!(net.find_node_by_index(&s2).map(|n| n.as_str()), Some("1"));
 }
 
 fn test_swap_four_node_chain_generic<T: TensorElement + From<f64>>() {
     let (mut tn, s0, s1, s2, s3) = four_node_chain::<T>();
     // Swap adjacent pairs: (0,1) and (2,3) so s0<->s1, s2<->s3
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "1".to_string());
-    target.insert(s1.id().to_owned(), "0".to_string());
-    target.insert(s2.id().to_owned(), "3".to_string());
-    target.insert(s3.id().to_owned(), "2".to_string());
+    target.insert(s0.clone(), "1".to_string());
+    target.insert(s1.clone(), "0".to_string());
+    target.insert(s2.clone(), "3".to_string());
+    target.insert(s3.clone(), "2".to_string());
 
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
 
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("1")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("0")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s2.id()).map(|n| n.as_str()),
-        Some("3")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s3.id()).map(|n| n.as_str()),
-        Some("2")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("1"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("0"));
+    assert_eq!(net.find_node_by_index(&s2).map(|n| n.as_str()), Some("3"));
+    assert_eq!(net.find_node_by_index(&s3).map(|n| n.as_str()), Some("2"));
 }
 
 fn test_swap_2r_interleave_generic<T: TensorElement + From<f64>>() {
@@ -369,31 +327,19 @@ fn test_swap_2r_interleave_generic<T: TensorElement + From<f64>>() {
 
     // Target: x0 at "0", y0 at "1", x1 at "2", y1 at "3" (interleaved)
     let mut target = HashMap::new();
-    target.insert(x0.id().to_owned(), "0".to_string());
-    target.insert(y0.id().to_owned(), "1".to_string());
-    target.insert(x1.id().to_owned(), "2".to_string());
-    target.insert(y1.id().to_owned(), "3".to_string());
+    target.insert(x0.clone(), "0".to_string());
+    target.insert(y0.clone(), "1".to_string());
+    target.insert(x1.clone(), "2".to_string());
+    target.insert(y1.clone(), "3".to_string());
 
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
 
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(x0.id()).map(|n| n.as_str()),
-        Some("0")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(y0.id()).map(|n| n.as_str()),
-        Some("1")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(x1.id()).map(|n| n.as_str()),
-        Some("2")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(y1.id()).map(|n| n.as_str()),
-        Some("3")
-    );
+    assert_eq!(net.find_node_by_index(&x0).map(|n| n.as_str()), Some("0"));
+    assert_eq!(net.find_node_by_index(&y0).map(|n| n.as_str()), Some("1"));
+    assert_eq!(net.find_node_by_index(&x1).map(|n| n.as_str()), Some("2"));
+    assert_eq!(net.find_node_by_index(&y1).map(|n| n.as_str()), Some("3"));
 
     let after = tn.contract_to_tensor().unwrap();
     let diff = &before - &after;
@@ -408,25 +354,16 @@ fn test_swap_y_shape_generic<T: TensorElement + From<f64>>() {
     let (mut tn, s0, s1, s2) = y_shape_tree::<T>();
     // Swap s0 and s1 between L0 and L1 (path crosses center)
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "L1".to_string());
-    target.insert(s1.id().to_owned(), "L0".to_string());
+    target.insert(s0.clone(), "L1".to_string());
+    target.insert(s1.clone(), "L0".to_string());
 
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
 
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("L1")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("L0")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s2.id()).map(|n| n.as_str()),
-        Some("L2")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("L1"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("L0"));
+    assert_eq!(net.find_node_by_index(&s2).map(|n| n.as_str()), Some("L2"));
 }
 
 fn test_swap_y_shape_contract_and_canonical_form_generic<T: TensorElement + From<f64>>() {
@@ -434,8 +371,8 @@ fn test_swap_y_shape_contract_and_canonical_form_generic<T: TensorElement + From
     let before = tn.contract_to_tensor().unwrap();
 
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "L1".to_string());
-    target.insert(s1.id().to_owned(), "L0".to_string());
+    target.insert(s0.clone(), "L1".to_string());
+    target.insert(s1.clone(), "L0".to_string());
 
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
@@ -455,8 +392,8 @@ fn test_swap_correctness_contract_generic<T: TensorElement + From<f64>>() {
     let before = tn.contract_to_tensor().unwrap();
 
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "B".to_string());
-    target.insert(s1.id().to_owned(), "A".to_string());
+    target.insert(s0.clone(), "B".to_string());
+    target.insert(s1.clone(), "A".to_string());
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
 
@@ -469,15 +406,10 @@ fn test_swap_correctness_contract_generic<T: TensorElement + From<f64>>() {
     );
 }
 
-fn test_swap_by_index_matches_id_based_generic<T: TensorElement + From<f64>>() {
+fn test_swap_by_index_alias_matches_swap_site_indices_generic<T: TensorElement + From<f64>>() {
     let (tn, s0, s1, s2) = three_node_chain::<T>();
-    let mut tn_by_id = tn.clone();
+    let mut tn_primary = tn.clone();
     let mut tn_by_index = tn;
-
-    let mut target_by_id = HashMap::new();
-    target_by_id.insert(s0.id().to_owned(), "2".to_string());
-    target_by_id.insert(s1.id().to_owned(), "0".to_string());
-    target_by_id.insert(s2.id().to_owned(), "1".to_string());
 
     let mut target_by_index = HashMap::new();
     target_by_index.insert(s0.clone(), "2".to_string());
@@ -485,12 +417,14 @@ fn test_swap_by_index_matches_id_based_generic<T: TensorElement + From<f64>>() {
     target_by_index.insert(s2.clone(), "1".to_string());
 
     let options = SwapOptions::default();
-    tn_by_id.swap_site_indices(&target_by_id, &options).unwrap();
+    tn_primary
+        .swap_site_indices(&target_by_index, &options)
+        .unwrap();
     tn_by_index
         .swap_site_indices_by_index(&target_by_index, &options)
         .unwrap();
 
-    assert!(tn_by_id.same_appearance(&tn_by_index));
+    assert!(tn_primary.same_appearance(&tn_by_index));
 
     let net = tn_by_index.site_index_network();
     assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("2"));
@@ -530,33 +464,6 @@ fn test_swap_by_index_distinguishes_same_id_prime_pair() {
     );
 }
 
-#[test]
-fn test_swap_by_id_rejects_ambiguous_same_id_prime_pair() {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
-    let s = tensor4all_core::DynIndex::new_dyn(2);
-    let s_prime = s.prime();
-    let bond = tensor4all_core::DynIndex::new_dyn(1);
-    let a = TensorDynLen::from_dense(
-        vec![s.clone(), s_prime, bond.clone()],
-        vec![1.0, 2.0, 3.0, 4.0],
-    )
-    .unwrap();
-    let b = TensorDynLen::from_dense(vec![bond.clone()], vec![1.0]).unwrap();
-    tn.add_tensor("A".to_string(), a).unwrap();
-    tn.add_tensor("B".to_string(), b).unwrap();
-    let na = tn.node_index(&"A".to_string()).unwrap();
-    let nb = tn.node_index(&"B".to_string()).unwrap();
-    tn.connect(na, &bond, nb, &bond).unwrap();
-
-    let mut target = HashMap::new();
-    target.insert(s.id().to_owned(), "B".to_string());
-    let err = tn
-        .swap_site_indices(&target, &SwapOptions::default())
-        .unwrap_err();
-
-    assert!(err.to_string().contains("ambiguous"));
-}
-
 // ============================================================================
 // f64 tests
 // ============================================================================
@@ -579,18 +486,12 @@ fn test_swap_partial() {
     let (mut tn, s0, s1) = two_node_chain::<f64>();
     // Only move s0 to B; s1 is not targeted and stays on its current side.
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "B".to_string());
+    target.insert(s0.clone(), "B".to_string());
     tn.swap_site_indices(&target, &SwapOptions::default())
         .unwrap();
     let net = tn.site_index_network();
-    assert_eq!(
-        net.find_node_by_index_id(s0.id()).map(|n| n.as_str()),
-        Some("B")
-    );
-    assert_eq!(
-        net.find_node_by_index_id(s1.id()).map(|n| n.as_str()),
-        Some("B")
-    );
+    assert_eq!(net.find_node_by_index(&s0).map(|n| n.as_str()), Some("B"));
+    assert_eq!(net.find_node_by_index(&s1).map(|n| n.as_str()), Some("B"));
 }
 
 #[test]
@@ -619,8 +520,8 @@ fn test_swap_correctness_contract() {
 }
 
 #[test]
-fn test_swap_by_index_matches_id_based() {
-    test_swap_by_index_matches_id_based_generic::<f64>();
+fn test_swap_by_index_alias_matches_swap_site_indices() {
+    test_swap_by_index_alias_matches_swap_site_indices_generic::<f64>();
 }
 
 #[test]
@@ -675,7 +576,7 @@ fn test_swap_y_shape_contract_and_canonical_form_c64() {
 fn test_swap_invalid_target_nonexistent_node() {
     let (mut tn, s0, _s1) = two_node_chain::<f64>();
     let mut target = HashMap::new();
-    target.insert(s0.id().to_owned(), "Z".to_string()); // "Z" does not exist
+    target.insert(s0.clone(), "Z".to_string()); // "Z" does not exist
     let result = tn.swap_site_indices(&target, &SwapOptions::default());
     assert!(
         result.is_err(),
@@ -684,14 +585,14 @@ fn test_swap_invalid_target_nonexistent_node() {
 }
 
 #[test]
-fn test_swap_invalid_target_unknown_index_id() {
+fn test_swap_invalid_target_unknown_index() {
     let (mut tn, _s0, _s1) = two_node_chain::<f64>();
-    let unknown_id = tensor4all_core::DynIndex::new_dyn(2).id().to_owned();
+    let unknown_index = tensor4all_core::DynIndex::new_dyn(2);
     let mut target = HashMap::new();
-    target.insert(unknown_id, "A".to_string());
+    target.insert(unknown_index, "A".to_string());
     let result = tn.swap_site_indices(&target, &SwapOptions::default());
     assert!(
         result.is_err(),
-        "swap_site_indices must fail for unknown index id"
+        "swap_site_indices must fail for unknown index"
     );
 }

--- a/docs/superpowers/plans/2026-04-08-issues-404-405-plan.md
+++ b/docs/superpowers/plans/2026-04-08-issues-404-405-plan.md
@@ -1584,14 +1584,13 @@ Part of #405"
 - Modify: `crates/tensor4all-treetn/src/treetn/ops.rs` — add `all_site_indices`
 - Modify: `crates/tensor4all-treetn/src/treetn/mod.rs` — add Index-based swap_site_indices
 
-- [ ] **Step 1: Add all_site_indices (Index-based alternative to all_site_index_ids)**
+- [ ] **Step 1: Add all_site_indices**
 
 In `crates/tensor4all-treetn/src/treetn/ops.rs`:
 
 ```rust
     /// Returns all site indices and their associated node names.
     ///
-    /// This is the Index-based version of [`all_site_index_ids`](Self::all_site_index_ids).
     /// Returns `(indices, node_names)` where `indices[i]` belongs to `node_names[i]`.
     pub fn all_site_indices(&self) -> Result<(Vec<T::Index>, Vec<V>)>
     where

--- a/docs/superpowers/specs/2026-04-08-issues-404-405-design.md
+++ b/docs/superpowers/specs/2026-04-08-issues-404-405-design.md
@@ -248,13 +248,13 @@ Several treetn public APIs use raw `T::Index::Id` instead of `T::Index`, divergi
 
 | Current Signature | Location |
 |-------------------|----------|
-| `evaluate(&self, index_ids: &[T::Index::Id], values: ColMajorArrayRef)` | `ops.rs:367` |
-| `all_site_index_ids(&self) -> (Vec<T::Index::Id>, Vec<V>)` | `ops.rs:326` |
-| `swap_site_indices(&mut self, target: &HashMap<T::Index::Id, V>, ...)` | `mod.rs:1551` |
-| `swap_on_edge(&mut self, ..., target: &HashMap<T::Index::Id, V>, ...)` | `mod.rs:1385` |
-| `factorize_tensor_to_treetn(..., topology: &TreeTopology<V, T::Index::Id>)` | `decompose.rs:97` |
-| `SwapOptions { index_to_second: Option<I::Id>, ... }` | `swap.rs:48-50` |
-| Transform functions using `HashMap<T::Index::Id, V>` | `transform.rs` |
+| `evaluate(&self, indices: &[T::Index], values: ColMajorArrayRef)` | `ops.rs` |
+| `all_site_indices(&self) -> (Vec<T::Index>, Vec<V>)` | `ops.rs` |
+| `swap_site_indices(&mut self, target: &HashMap<T::Index, V>, ...)` | `mod.rs` |
+| `swap_on_edge(&mut self, ..., target: &HashMap<T::Index, V>, ...)` | `mod.rs` |
+| `factorize_tensor_to_treetn(..., topology: &TreeTopology<V, T::Index>)` | `decompose.rs` |
+| `SwapOptions { index_to_second: Option<I>, ... }` | `swap.rs` |
+| Transform functions using `HashMap<T::Index, V>` | `transform.rs` |
 
 ### Approach
 

--- a/plan/swap-site-indices-perf.md
+++ b/plan/swap-site-indices-perf.md
@@ -103,8 +103,8 @@ let oracle = SubtreeOracle::new(topology, &root)?;
 let sweep_plan = LocalUpdateSweepPlan::from_treetn(self, &root, 2)?;
 let factorize_options = FactorizeOptions::svd().with_canonical(Canonical::Left);
 
-let is_satisfied = |me: &Self| target_assignment.iter().all(|(id, target)| {
-    me.site_index_network().find_node_by_index_id(id) == Some(target)
+let is_satisfied = |me: &Self| target_assignment.iter().all(|(index, target)| {
+    me.site_index_network().find_node_by_index(index) == Some(target)
 });
 
 let max_passes = self.node_count().max(4);  // 修正済み


### PR DESCRIPTION
## Summary

- replace TreeTN topology, swap, restructure, evaluate, and partial-contraction APIs that selected concrete indices by ID with full `Index`-based selection
- remove C API raw index ID constructor/getter and add full-index equality, hashing, and prime-level transform helpers
- update linsolve/operator internals and repository rules so index identity maps/sets use full indices instead of IDs

## Why

Comparing or selecting concrete tensor legs by raw index ID is unsafe when indices share an ID but differ by prime level, tags, direction, or future metadata. The public and language-binding-facing surfaces should let callers pass the exact `Index` they mean.

## Validation

- `cargo test -p tensor4all-treetn --release`
- `cargo test -p tensor4all-capi --release`
- `cargo test -p tensor4all-core --release`
- `cargo test -p tensor4all-treetn --release --doc`
- `git diff --check`
- searched for removed ID-only C API names and production ID-keyed HashMap/HashSet patterns