### PR TITLE
Use ubuntu-22.04 for ci-maintainer

### DIFF
--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -46,7 +46,8 @@ jobs:
   ci-maintainer:
     name: CI (same-repo PR / self-hosted heavy)
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, x64]
+    # runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-22.04
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/../target
       CARGO_PROFILE_RELEASE_DEBUG: 0

--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -46,7 +46,7 @@ jobs:
   ci-maintainer:
     name: CI (same-repo PR / self-hosted heavy)
     if: github.event.pull_request.head.repo.full_name == github.repository
-    # runs-on: [self-hosted, linux, x64]
+    # runs-on: [self-hosted, linux, x64] # self-host-runner
     runs-on: ubuntu-22.04
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/../target
@@ -54,6 +54,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Note: Disable this step when runs-on is self-hosted
+      - name: Install HDF5
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
 
       # 必要に応じてセットアップを追加
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The self-hosted runner is not working, so I will use the standard runners provided by GitHub Actions instead.