### PR TITLE
[codex] Fix canonicalization full-rank factorization

### DIFF
--- a/crates/tensor4all-core/src/block_tensor.rs
+++ b/crates/tensor4all-core/src/block_tensor.rs
@@ -499,6 +499,17 @@ impl<T: TensorLike> TensorLike for BlockTensor<T> {
         )))
     }
 
+    fn factorize_full_rank(
+        &self,
+        _left_inds: &[<Self as TensorIndex>::Index],
+        _alg: crate::FactorizeAlg,
+        _canonical: crate::Canonical,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        Err(FactorizeError::ComputationError(anyhow::anyhow!(
+            "BlockTensor does not support factorize_full_rank"
+        )))
+    }
+
     fn direct_sum(
         &self,
         _other: &Self,

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -97,6 +97,74 @@ pub fn factorize(
     }
 }
 
+/// Factorize a tensor without applying algorithm-specific truncation options.
+///
+/// This path is intended for canonicalization and other exact tensor-network
+/// rewrites where the decomposition must preserve the represented tensor rather
+/// than obey global SVD/QR/LU rank-dropping defaults.
+///
+/// # Arguments
+/// * `t` - Input tensor.
+/// * `left_inds` - Indices to place on the left side.
+/// * `alg` - Decomposition algorithm to use.
+/// * `canonical` - Which factor should carry the canonical form.
+///
+/// # Returns
+/// A factorization whose contracted factors reconstruct `t` up to numerical
+/// roundoff, with no tolerance-based or maximum-rank truncation applied.
+///
+/// # Errors
+/// Returns [`FactorizeError`] if the storage type is unsupported, the canonical
+/// direction is unsupported for the selected algorithm, or the underlying
+/// decomposition fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{
+///     factorize_full_rank, Canonical, DynIndex, FactorizeAlg, TensorDynLen, TensorLike,
+/// };
+///
+/// let i = DynIndex::new_dyn(2);
+/// let j = DynIndex::new_dyn(2);
+/// let tensor = TensorDynLen::from_dense(
+///     vec![i.clone(), j.clone()],
+///     vec![1.0_f64, 0.0, 0.0, 1.0e-16],
+/// )?;
+///
+/// let result = factorize_full_rank(
+///     &tensor,
+///     std::slice::from_ref(&i),
+///     FactorizeAlg::QR,
+///     Canonical::Left,
+/// )?;
+/// let reconstructed = result.left.contract(&result.right);
+/// assert!((tensor - reconstructed).maxabs() < 1.0e-18);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn factorize_full_rank(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    alg: FactorizeAlg,
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    if t.is_diag() {
+        return Err(FactorizeError::UnsupportedStorage(
+            "Diagonal storage not supported for factorize",
+        ));
+    }
+
+    if t.is_f64() {
+        factorize_impl_f64_full_rank(t, left_inds, alg, canonical)
+    } else if t.is_complex() {
+        factorize_impl_c64_full_rank(t, left_inds, alg, canonical)
+    } else {
+        Err(FactorizeError::UnsupportedStorage(
+            "factorize currently supports only f64 and Complex64 tensors",
+        ))
+    }
+}
+
 fn factorize_impl_f64(
     t: &TensorDynLen,
     left_inds: &[DynIndex],
@@ -110,6 +178,20 @@ fn factorize_impl_f64(
     }
 }
 
+fn factorize_impl_f64_full_rank(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    alg: FactorizeAlg,
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    match alg {
+        FactorizeAlg::SVD => factorize_svd_full_rank(t, left_inds, canonical),
+        FactorizeAlg::QR => factorize_qr_full_rank(t, left_inds, canonical),
+        FactorizeAlg::LU => factorize_lu_full_rank::<f64>(t, left_inds, canonical),
+        FactorizeAlg::CI => factorize_ci_full_rank::<f64>(t, left_inds, canonical),
+    }
+}
+
 fn factorize_impl_c64(
     t: &TensorDynLen,
     left_inds: &[DynIndex],
@@ -120,6 +202,20 @@ fn factorize_impl_c64(
         FactorizeAlg::QR => factorize_qr(t, left_inds, options),
         FactorizeAlg::LU => factorize_lu::<Complex64>(t, left_inds, options),
         FactorizeAlg::CI => factorize_ci::<Complex64>(t, left_inds, options),
+    }
+}
+
+fn factorize_impl_c64_full_rank(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    alg: FactorizeAlg,
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    match alg {
+        FactorizeAlg::SVD => factorize_svd_full_rank(t, left_inds, canonical),
+        FactorizeAlg::QR => factorize_qr_full_rank(t, left_inds, canonical),
+        FactorizeAlg::LU => factorize_lu_full_rank::<Complex64>(t, left_inds, canonical),
+        FactorizeAlg::CI => factorize_ci_full_rank::<Complex64>(t, left_inds, canonical),
     }
 }
 
@@ -137,7 +233,25 @@ fn factorize_svd(
         svd_options = svd_options.with_max_rank(max_rank);
     }
 
-    let result = svd_for_factorize(t, left_inds, &svd_options)?;
+    factorize_svd_with_options(t, left_inds, options.canonical, &svd_options)
+}
+
+fn factorize_svd_full_rank(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    let svd_options = SvdOptions::full_rank();
+    factorize_svd_with_options(t, left_inds, canonical, &svd_options)
+}
+
+fn factorize_svd_with_options(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+    svd_options: &SvdOptions,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    let result = svd_for_factorize(t, left_inds, svd_options)?;
     let u = result.u;
     let s = result.s;
     let vh = result.vh;
@@ -146,7 +260,7 @@ fn factorize_svd(
     let rank = result.rank;
     let sim_bond_index = s.indices[1].clone();
 
-    match options.canonical {
+    match canonical {
         Canonical::Left => {
             // L = U (orthogonal), R = S * V^H
             let right_contracted = s.contract(&vh);
@@ -192,7 +306,29 @@ fn factorize_qr(
         QrOptions::new()
     };
 
-    let (q, r) = qr_with::<f64>(t, left_inds, &qr_options)?;
+    factorize_qr_with_options(t, left_inds, &qr_options)
+}
+
+fn factorize_qr_full_rank(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    if canonical == Canonical::Right {
+        return Err(FactorizeError::UnsupportedCanonical(
+            "QR only supports Canonical::Left (would need LQ for right)",
+        ));
+    }
+
+    factorize_qr_with_options(t, left_inds, &QrOptions::full_rank())
+}
+
+fn factorize_qr_with_options(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    qr_options: &QrOptions,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+    let (q, r) = qr_with::<f64>(t, left_inds, qr_options)?;
 
     // Get bond index from Q tensor (last index)
     let bond_index = q.indices.last().unwrap().clone();
@@ -226,6 +362,52 @@ where
     <T as ComplexFloat>::Real: Into<f64> + 'static,
     tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
+    factorize_lu_with_options::<T>(
+        t,
+        left_inds,
+        options.canonical,
+        options.max_rank.unwrap_or(usize::MAX),
+        1e-14,
+    )
+}
+
+fn factorize_lu_full_rank<T>(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+where
+    T: TensorElement
+        + ComplexFloat
+        + Default
+        + From<<T as ComplexFloat>::Real>
+        + MatrixScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + 'static,
+    <T as ComplexFloat>::Real: Into<f64> + 'static,
+    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+{
+    factorize_lu_with_options::<T>(t, left_inds, canonical, usize::MAX, 0.0)
+}
+
+fn factorize_lu_with_options<T>(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+    max_rank: usize,
+    rel_tol: f64,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+where
+    T: TensorElement
+        + ComplexFloat
+        + Default
+        + From<<T as ComplexFloat>::Real>
+        + MatrixScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + 'static,
+    <T as ComplexFloat>::Real: Into<f64> + 'static,
+    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+{
     // Unfold tensor into matrix
     let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))?;
@@ -234,10 +416,10 @@ where
     let a_matrix = native_tensor_to_matrix::<T>(&a_tensor, m, n)?;
 
     // Set up LU options
-    let left_orthogonal = options.canonical == Canonical::Left;
+    let left_orthogonal = canonical == Canonical::Left;
     let lu_options = RrLUOptions {
-        max_rank: options.max_rank.unwrap_or(usize::MAX),
-        rel_tol: 1e-14,
+        max_rank,
+        rel_tol,
         abs_tol: 0.0,
         left_orthogonal,
     };
@@ -294,6 +476,52 @@ where
     <T as ComplexFloat>::Real: Into<f64> + 'static,
     tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
+    factorize_ci_with_options::<T>(
+        t,
+        left_inds,
+        options.canonical,
+        options.max_rank.unwrap_or(usize::MAX),
+        1e-14,
+    )
+}
+
+fn factorize_ci_full_rank<T>(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+where
+    T: TensorElement
+        + ComplexFloat
+        + Default
+        + From<<T as ComplexFloat>::Real>
+        + MatrixScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + 'static,
+    <T as ComplexFloat>::Real: Into<f64> + 'static,
+    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+{
+    factorize_ci_with_options::<T>(t, left_inds, canonical, usize::MAX, 0.0)
+}
+
+fn factorize_ci_with_options<T>(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+    canonical: Canonical,
+    max_rank: usize,
+    rel_tol: f64,
+) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+where
+    T: TensorElement
+        + ComplexFloat
+        + Default
+        + From<<T as ComplexFloat>::Real>
+        + MatrixScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + 'static,
+    <T as ComplexFloat>::Real: Into<f64> + 'static,
+    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+{
     // Unfold tensor into matrix
     let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))?;
@@ -302,10 +530,10 @@ where
     let a_matrix = native_tensor_to_matrix::<T>(&a_tensor, m, n)?;
 
     // Set up LU options for CI
-    let left_orthogonal = options.canonical == Canonical::Left;
+    let left_orthogonal = canonical == Canonical::Left;
     let lu_options = RrLUOptions {
-        max_rank: options.max_rank.unwrap_or(usize::MAX),
-        rel_tol: 1e-14,
+        max_rank,
+        rel_tol,
         abs_tol: 0.0,
         left_orthogonal,
     };

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -45,18 +45,28 @@ pub enum QrError {
 /// let recovered = q.contract(&r);
 /// assert!(tensor.distance(&recovered) < 1e-12);
 /// ```
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct QrOptions {
     /// Relative tolerance for QR row-norm truncation.
     /// If `None`, uses the global default.
     pub rtol: Option<f64>,
+    truncate: bool,
+}
+
+impl Default for QrOptions {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl QrOptions {
     /// Create new QR options with no overrides.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            rtol: None,
+            truncate: true,
+        }
     }
 
     /// Set the QR truncation tolerance.
@@ -64,6 +74,13 @@ impl QrOptions {
     pub fn with_rtol(mut self, rtol: f64) -> Self {
         self.rtol = Some(rtol);
         self
+    }
+
+    pub(crate) fn full_rank() -> Self {
+        Self {
+            rtol: None,
+            truncate: false,
+        }
     }
 }
 
@@ -259,12 +276,6 @@ pub fn qr_with<T>(
     left_inds: &[DynIndex],
     options: &QrOptions,
 ) -> Result<(TensorDynLen, TensorDynLen), QrError> {
-    // Determine rtol to use
-    let rtol = options.rtol.unwrap_or(default_qr_rtol());
-    if !rtol.is_finite() || rtol < 0.0 {
-        return Err(QrError::InvalidRtol(rtol));
-    }
-
     // Unfold tensor into a native rank-2 tensor.
     let (matrix_native, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
@@ -272,22 +283,33 @@ pub fn qr_with<T>(
     let k = m.min(n);
     let (mut q_native, mut r_native) =
         qr_native_tensor(&matrix_native).map_err(QrError::ComputationError)?;
-    let r = match r_native.dtype() {
-        DType::F64 => {
-            let values = native_tensor_primal_to_dense_f64_col_major(&r_native)
-                .map_err(QrError::ComputationError)?;
-            compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
+
+    let r = if options.truncate {
+        // Determine rtol to use
+        let rtol = options.rtol.unwrap_or(default_qr_rtol());
+        if !rtol.is_finite() || rtol < 0.0 {
+            return Err(QrError::InvalidRtol(rtol));
         }
-        DType::C64 => {
-            let values = native_tensor_primal_to_dense_c64_col_major(&r_native)
-                .map_err(QrError::ComputationError)?;
-            compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
+
+        match r_native.dtype() {
+            DType::F64 => {
+                let values = native_tensor_primal_to_dense_f64_col_major(&r_native)
+                    .map_err(QrError::ComputationError)?;
+                compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
+            }
+            DType::C64 => {
+                let values = native_tensor_primal_to_dense_c64_col_major(&r_native)
+                    .map_err(QrError::ComputationError)?;
+                compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
+            }
+            other => {
+                return Err(QrError::ComputationError(anyhow::anyhow!(
+                    "native QR returned unsupported scalar type {other:?}"
+                )));
+            }
         }
-        other => {
-            return Err(QrError::ComputationError(anyhow::anyhow!(
-                "native QR returned unsupported scalar type {other:?}"
-            )));
-        }
+    } else {
+        k
     };
     if r < k {
         match q_native.dtype() {

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -54,20 +54,31 @@ pub enum SvdError {
 /// assert_eq!(u.dims()[0], 3);
 /// assert_eq!(s.dims().len(), 2);
 /// ```
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub struct SvdOptions {
     /// Maximum retained rank after policy-based truncation.
     pub max_rank: Option<usize>,
     /// Per-call SVD truncation policy.
     /// If `None`, the global default policy is used.
     pub policy: Option<SvdTruncationPolicy>,
+    truncate: bool,
+}
+
+impl Default for SvdOptions {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SvdOptions {
     /// Create new SVD options with no overrides.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            max_rank: None,
+            policy: None,
+            truncate: true,
+        }
     }
 
     /// Set the maximum retained rank.
@@ -82,6 +93,14 @@ impl SvdOptions {
     pub fn with_policy(mut self, policy: SvdTruncationPolicy) -> Self {
         self.policy = Some(policy);
         self
+    }
+
+    pub(crate) fn full_rank() -> Self {
+        Self {
+            max_rank: None,
+            policy: None,
+            truncate: false,
+        }
     }
 }
 
@@ -237,9 +256,6 @@ fn svd_truncated_native(
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<SvdTruncatedNativeResult, SvdError> {
-    let policy = options.policy.unwrap_or_else(default_svd_truncation_policy);
-    validate_svd_truncation_policy(policy).map_err(|e| SvdError::InvalidThreshold(e.0))?;
-
     let (matrix_native, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(SvdError::ComputationError)?;
@@ -248,11 +264,19 @@ fn svd_truncated_native(
     let (mut u_native, mut s_native, mut vt_native) =
         svd_native_tensor(&matrix_native).map_err(SvdError::ComputationError)?;
     let s_full = singular_values_from_native(&s_native)?;
-    let mut r = compute_retained_rank(&s_full, &policy);
-    if let Some(max_rank) = options.max_rank {
-        r = r.min(max_rank);
-    }
-    r = r.max(1);
+    let mut r = if options.truncate {
+        let policy = options.policy.unwrap_or_else(default_svd_truncation_policy);
+        validate_svd_truncation_policy(policy).map_err(|e| SvdError::InvalidThreshold(e.0))?;
+
+        let mut retained = compute_retained_rank(&s_full, &policy);
+        if let Some(max_rank) = options.max_rank {
+            retained = retained.min(max_rank);
+        }
+        retained.max(1)
+    } else {
+        k.max(1)
+    };
+    r = r.min(s_full.len());
     if r < k {
         match u_native.dtype() {
             DType::F64 => {

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -2592,6 +2592,15 @@ impl TensorLike for TensorDynLen {
         crate::factorize::factorize(self, left_inds, options)
     }
 
+    fn factorize_full_rank(
+        &self,
+        left_inds: &[DynIndex],
+        alg: crate::FactorizeAlg,
+        canonical: crate::Canonical,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        crate::factorize::factorize_full_rank(self, left_inds, alg, canonical)
+    }
+
     fn conj(&self) -> Self {
         // Delegate to the inherent method (complex conjugate for dense tensors)
         TensorDynLen::conj(self)

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -132,7 +132,7 @@ pub mod svd {
 
 // Re-export linear algebra items for top-level access
 pub use defaults::direct_sum::direct_sum;
-pub use defaults::factorize::factorize;
+pub use defaults::factorize::{factorize, factorize_full_rank};
 pub use defaults::qr::{default_qr_rtol, qr, qr_with, set_default_qr_rtol, QrError, QrOptions};
 pub use defaults::svd::{
     default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdError,

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -656,6 +656,58 @@ pub trait TensorLike: TensorIndex {
         options: &FactorizeOptions,
     ) -> std::result::Result<FactorizeResult<Self>, FactorizeError>;
 
+    /// Factorize this tensor without applying truncation controls.
+    ///
+    /// Use this for exact tensor rewrites such as canonicalization, where the
+    /// contracted factors must preserve the represented tensor up to numerical
+    /// roundoff. Unlike [`Self::factorize`], this method must not consult global
+    /// SVD/QR/LU truncation defaults or apply maximum-rank limits.
+    ///
+    /// # Arguments
+    /// * `left_inds` - Indices to place on the left side.
+    /// * `alg` - Decomposition algorithm to use.
+    /// * `canonical` - Which factor should carry the canonical form.
+    ///
+    /// # Returns
+    /// A `FactorizeResult` containing the left and right factors, bond index,
+    /// singular values for SVD, and retained exact numerical rank.
+    ///
+    /// # Errors
+    /// Returns [`FactorizeError`] if:
+    /// - the storage type is not supported,
+    /// - the requested canonical direction is unsupported for the algorithm, or
+    /// - the underlying decomposition fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{
+    ///     Canonical, DynIndex, FactorizeAlg, TensorDynLen, TensorLike,
+    /// };
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(
+    ///     vec![i.clone(), j.clone()],
+    ///     vec![1.0_f64, 0.0, 0.0, 1.0e-16],
+    /// )?;
+    ///
+    /// let result = tensor.factorize_full_rank(
+    ///     std::slice::from_ref(&i),
+    ///     FactorizeAlg::QR,
+    ///     Canonical::Left,
+    /// )?;
+    /// let reconstructed = result.left.contract(&result.right);
+    /// assert!((tensor - reconstructed).maxabs() < 1.0e-18);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    fn factorize_full_rank(
+        &self,
+        left_inds: &[<Self as TensorIndex>::Index],
+        alg: FactorizeAlg,
+        canonical: Canonical,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError>;
+
     /// Tensor conjugate operation.
     ///
     /// This is a generalized conjugate operation that depends on the tensor type:

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -2,7 +2,8 @@
 
 use tensor4all_core::index::Index;
 use tensor4all_core::{
-    factorize, Canonical, DynIndex, FactorizeAlg, FactorizeError, FactorizeOptions,
+    factorize, factorize_full_rank, Canonical, DynIndex, FactorizeAlg, FactorizeError,
+    FactorizeOptions,
 };
 use tensor4all_core::{SvdTruncationPolicy, TensorDynLen, TensorLike};
 
@@ -274,6 +275,26 @@ fn test_factorize_with_max_rank() {
     let options = FactorizeOptions::svd().with_max_rank(1);
     let result = factorize(&tensor, &left_inds, &options).unwrap();
     assert!(result.rank >= 1);
+}
+
+#[test]
+fn test_factorize_full_rank_preserves_near_dependent_components() {
+    let i: DynIndex = Index::new_dyn(2);
+    let j: DynIndex = Index::new_dyn(2);
+    let tensor =
+        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 0.0, 0.0, 1.0e-16]).unwrap();
+
+    for alg in [FactorizeAlg::SVD, FactorizeAlg::QR, FactorizeAlg::LU] {
+        let result =
+            factorize_full_rank(&tensor, std::slice::from_ref(&i), alg, Canonical::Left).unwrap();
+        assert_eq!(
+            result.rank, 2,
+            "{alg:?} full-rank factorization dropped a near-dependent component"
+        );
+
+        let reconstructed = result.left.contract(&result.right);
+        assert_tensors_approx_equal(&tensor, &reconstructed, 1.0e-18);
+    }
 }
 
 #[test]

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -10,8 +10,9 @@ use num_complex::Complex64;
 use std::ops::Range;
 use tensor4all_core::{common_inds, hascommoninds, DynIndex, IndexLike};
 use tensor4all_core::{
-    AllowedPairs, AnyScalar, CommonScalar, DirectSumResult, FactorizeError, FactorizeOptions,
-    FactorizeResult, LinearizationOrder, TensorDynLen, TensorElement, TensorIndex, TensorLike,
+    AllowedPairs, AnyScalar, Canonical, CommonScalar, DirectSumResult, FactorizeAlg,
+    FactorizeError, FactorizeOptions, FactorizeResult, LinearizationOrder, TensorDynLen,
+    TensorElement, TensorIndex, TensorLike,
 };
 use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
 
@@ -1282,6 +1283,17 @@ impl TensorLike for TensorTrain {
     ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
         Err(FactorizeError::UnsupportedStorage(
             "TensorTrain does not support factorize; use orthogonalize() instead",
+        ))
+    }
+
+    fn factorize_full_rank(
+        &self,
+        _left_inds: &[Self::Index],
+        _alg: FactorizeAlg,
+        _canonical: Canonical,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        Err(FactorizeError::UnsupportedStorage(
+            "TensorTrain does not support factorize_full_rank; use orthogonalize() instead",
         ))
     }
 

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -499,8 +499,15 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
             break;
         }
 
-        // Guard against near-zero pivot to prevent NaN from division
-        if pivot_abs < f64::EPSILON {
+        // Guard against tiny pivots to prevent NaN from division. A caller that
+        // sets both tolerances to zero is requesting a non-truncating
+        // decomposition, so only an exactly zero pivot stops the factorization.
+        let min_pivot_abs = if opts.rel_tol == 0.0 && opts.abs_tol == 0.0 {
+            0.0
+        } else {
+            f64::EPSILON
+        };
+        if pivot_abs <= min_pivot_abs {
             if lu.n_pivot == 0 {
                 // First pivot is near-zero: the matrix is effectively zero
                 lu.error = pivot_abs;

--- a/crates/tensor4all-treetn/src/treetn/canonicalize.rs
+++ b/crates/tensor4all-treetn/src/treetn/canonicalize.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 use anyhow::{Context, Result};
 
 use crate::algorithm::CanonicalForm;
-use tensor4all_core::{Canonical, FactorizeAlg, FactorizeOptions, TensorLike};
+use tensor4all_core::{Canonical, FactorizeAlg, TensorLike};
 
 use super::TreeTN;
 use crate::options::CanonicalizationOptions;
@@ -138,18 +138,9 @@ where
             None => return Ok(()),
         };
 
-        // Set up factorization options (no truncation for canonicalization)
-        let factorize_options = FactorizeOptions {
-            alg,
-            canonical: Canonical::Left,
-            max_rank: None,
-            svd_policy: None,
-            qr_rtol: None,
-        };
-
         // Process edges in order (leaves towards center)
         for (src, dst) in &sweep_ctx.edges {
-            self.sweep_edge(*src, *dst, &factorize_options, context_name)?;
+            self.sweep_edge_full_rank(*src, *dst, alg, Canonical::Left, context_name)?;
         }
 
         // Set the canonical form

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -30,7 +30,9 @@ use std::hash::Hash;
 use anyhow::{Context, Result};
 
 use crate::algorithm::CanonicalForm;
-use tensor4all_core::{AllowedPairs, Canonical, FactorizeOptions, IndexLike, TensorLike};
+use tensor4all_core::{
+    AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, TensorLike,
+};
 
 use crate::named_graph::NamedGraph;
 use crate::site_index_network::SiteIndexNetwork;
@@ -49,6 +51,14 @@ pub use partial_contraction::{partial_contract, PartialContractionSpec};
 
 // Re-export swap types
 pub use swap::{ScheduledSwapStep, SwapOptions, SwapSchedule};
+
+enum SweepFactorization<'a> {
+    Options(&'a FactorizeOptions),
+    FullRank {
+        alg: FactorizeAlg,
+        canonical: Canonical,
+    },
+}
 
 /// Tree Tensor Network structure (inspired by ITensorNetworks.jl's TreeTensorNetwork).
 ///
@@ -571,6 +581,42 @@ where
         factorize_options: &FactorizeOptions,
         context_name: &str,
     ) -> Result<()> {
+        self.sweep_edge_impl(
+            src,
+            dst,
+            SweepFactorization::Options(factorize_options),
+            context_name,
+        )
+    }
+
+    /// Process one edge during an exact sweep operation.
+    ///
+    /// This is the canonicalization variant of [`Self::sweep_edge`]. It uses
+    /// the requested decomposition algorithm without passing truncation controls
+    /// or consulting global rank-dropping defaults.
+    pub(crate) fn sweep_edge_full_rank(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        alg: FactorizeAlg,
+        canonical: Canonical,
+        context_name: &str,
+    ) -> Result<()> {
+        self.sweep_edge_impl(
+            src,
+            dst,
+            SweepFactorization::FullRank { alg, canonical },
+            context_name,
+        )
+    }
+
+    fn sweep_edge_impl(
+        &mut self,
+        src: NodeIndex,
+        dst: NodeIndex,
+        factorization: SweepFactorization<'_>,
+        context_name: &str,
+    ) -> Result<()> {
         // Find edge between src and dst
         let edge = {
             let g = self.graph.graph();
@@ -656,10 +702,14 @@ where
         }
 
         // Perform factorization
-        let factorize_result = tensor_src
-            .factorize(&left_inds, factorize_options)
-            .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
-            .with_context(|| format!("{}: factorization failed", context_name))?;
+        let factorize_result = match factorization {
+            SweepFactorization::Options(options) => tensor_src.factorize(&left_inds, options),
+            SweepFactorization::FullRank { alg, canonical } => {
+                tensor_src.factorize_full_rank(&left_inds, alg, canonical)
+            }
+        }
+        .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
+        .with_context(|| format!("{}: factorization failed", context_name))?;
 
         let left_tensor = factorize_result.left;
         let right_tensor = factorize_result.right;

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -596,6 +596,48 @@ fn test_canonicalize_simple() {
     assert!(tn_canon.validate_ortho_consistency().is_ok());
 }
 
+#[test]
+fn canonicalize_preserves_near_dependent_components() {
+    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+
+    let left = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let right = DynIndex::new_dyn(2);
+
+    let tensor1 = TensorDynLen::from_dense(
+        vec![left.clone(), bond.clone()],
+        vec![1.0, 0.0, 0.0, 1.0e-16],
+    )
+    .unwrap();
+    let n1 = tn.add_tensor_auto_name(tensor1);
+
+    let tensor2 =
+        TensorDynLen::from_dense(vec![bond.clone(), right.clone()], vec![1.0, 0.0, 0.0, 1.0])
+            .unwrap();
+    let n2 = tn.add_tensor_auto_name(tensor2);
+
+    tn.connect(n1, &bond, n2, &bond).unwrap();
+    let expected = tn.contract_to_tensor().unwrap();
+
+    for form in [CanonicalForm::Unitary, CanonicalForm::LU] {
+        let actual = tn
+            .clone()
+            .canonicalize(
+                std::iter::once(n2),
+                CanonicalizationOptions::default().with_form(form),
+            )
+            .unwrap()
+            .contract_to_tensor()
+            .unwrap();
+
+        let error = (&actual - &expected).maxabs();
+        assert!(
+            error < 1.0e-18,
+            "{form:?} canonicalization changed the represented tensor: maxabs diff = {error}"
+        );
+    }
+}
+
 // ============================================================================
 // Contraction Tests
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #460.

- Route TreeTN canonicalization through a full-rank factorization path that accepts only the decomposition algorithm and canonical side, without passing truncation options.
- Add full-rank SVD/QR/LU/CI factorization support for exact tensor-network rewrites.
- Prevent full-rank LU from dropping near-zero but nonzero pivots via the internal epsilon safety threshold.
- Add regression coverage for near-dependent components in both core factorization and TreeTN canonicalization.

## Root Cause

Canonicalization used `FactorizeOptions` with `None` values, but those `None` values meant "use global defaults" for QR/SVD truncation rather than "do not truncate". LU also had an internal near-zero pivot guard that could truncate even with zero tolerances.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p tensor4all-core --release test_factorize_full_rank_preserves_near_dependent_components -- --nocapture`
- `cargo test -p tensor4all-treetn --release canonicalize_preserves_near_dependent_components -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --doc -p tensor4all-core --release`
- `cargo doc --workspace --no-deps`
- `git diff --check`