### PR TITLE
[codex] Honor positive fit sweep counts

### DIFF
--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -41,6 +41,9 @@ use tensor4all_core::{
 use super::localupdate::{LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater};
 use super::TreeTN;
 
+#[cfg(test)]
+use std::cell::Cell;
+
 #[derive(Debug, Default, Clone)]
 struct FitProfile {
     zipup_init_time: Duration,
@@ -66,8 +69,22 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
 }
 
+#[cfg(test)]
+thread_local! {
+    static FORCE_FIT_PROFILE: Cell<bool> = const { Cell::new(false) };
+}
+
 fn fit_profile_enabled() -> bool {
+    #[cfg(test)]
+    if FORCE_FIT_PROFILE.with(Cell::get) {
+        return true;
+    }
     std::env::var("T4A_PROFILE_FIT").is_ok()
+}
+
+#[cfg(test)]
+fn set_fit_profile_enabled_for_tests(enabled: bool) {
+    FORCE_FIT_PROFILE.with(|slot| slot.set(enabled));
 }
 
 fn fit_profile_reset() {
@@ -919,10 +936,10 @@ where
 
     // The zip-up initializer already returns a network centered at `center`.
 
-    // With neither max_rank nor an algorithm-specific truncation override, fit
-    // sweeps cannot change the bond cap and only introduce numerical drift
-    // relative to the zip-up initializer.
-    if options.max_rank.is_none() && options.svd_policy.is_none() && options.qr_rtol.is_none() {
+    // Zero sweeps means "use the zip-up initializer as-is". Positive sweep
+    // counts are honored even when no truncation override is provided, so
+    // callers can explicitly exercise the variational update path.
+    if options.nfullsweeps == 0 {
         return Ok(tn_c);
     }
 

--- a/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
@@ -326,3 +326,34 @@ fn test_contract_fit_matches_naive_contraction_on_two_node_tree() {
     let expected_dense = tn_a.contract_naive(&tn_b).unwrap();
     assert!((&fitted_dense - &expected_dense).maxabs() < 1e-10);
 }
+
+#[test]
+fn test_contract_fit_positive_sweeps_do_not_skip_without_truncation_options() {
+    set_fit_profile_enabled_for_tests(true);
+    FIT_PROFILE_STATE.with(|state| {
+        *state.borrow_mut() = None;
+    });
+
+    let tn_a = make_two_node_treetn();
+    let tn_b = make_two_node_treetn();
+
+    let fitted = contract_fit(
+        &tn_a,
+        &tn_b,
+        &"A".to_string(),
+        FitContractionOptions::new(1),
+    )
+    .unwrap();
+
+    set_fit_profile_enabled_for_tests(false);
+
+    let dangling_profile = FIT_PROFILE_STATE.with(|state| state.borrow().is_some());
+    assert!(
+        !dangling_profile,
+        "positive-sweep contract_fit should run the sweep path and consume fit profile state"
+    );
+
+    let fitted_dense = fitted.to_dense().unwrap();
+    let expected_dense = tn_a.contract_naive(&tn_b).unwrap();
+    assert!((&fitted_dense - &expected_dense).maxabs() < 1e-10);
+}


### PR DESCRIPTION
## Summary

- change `TreeTN` fit contraction so only `nfullsweeps == 0` returns the zip-up initializer directly
- honor positive sweep counts even when no rank or tolerance override is supplied
- add regression coverage proving positive-sweep `contract_fit` reaches the sweep path

## Root cause

`contract_fit` initialized from zip-up, then skipped all variational sweeps whenever `max_rank`, `svd_policy`, and `qr_rtol` were all unset. That made positive sweep counts surprising: `ContractOptions::fit()` could effectively behave as zip-up, and explicit sweep requests could be ignored unless a truncation option was also present.

## Validation

- `cargo fmt --check`
- `env RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 cargo test -p tensor4all-treetn treetn::fit::tests -- --nocapture`
- `env RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 BLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 TENSOR4ALL_NUM_THREADS=1 cargo test -p tensor4all-itensorlike --test bug_fit_elementwise -- --nocapture`

Closes #463.