### PR TITLE
Expose tensor select-index C API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "81b02bbe0c53e336214db2fe35e0a197f767f219" }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "81b02bbe0c53e336214db2fe35e0a197f767f219" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "81b02bbe0c53e336214db2fe35e0a197f767f219" }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "81b02bbe0c53e336214db2fe35e0a197f767f219" }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -31,6 +31,37 @@ pub extern "C" fn t4a_tensor_clone(
     clone_opaque(src, out)
 }
 
+/// Select fixed coordinates for tensor indices and drop those axes.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_select_indices(
+    tensor: *const t4a_tensor,
+    n_select: usize,
+    selected_indices: *const *const t4a_index,
+    positions: *const usize,
+    out: *mut *mut t4a_tensor,
+) -> StatusCode {
+    run_status(|| {
+        let tensor = require_tensor(tensor)?;
+        if out.is_null() {
+            return Err(capi_error(T4A_NULL_POINTER, "out is null"));
+        }
+        unsafe {
+            *out = std::ptr::null_mut();
+        }
+
+        let selected_indices = read_indices_from_ptrs(n_select, selected_indices)?;
+        let positions = read_plain_slice("positions", positions, n_select)?;
+        let result = tensor
+            .inner()
+            .select_indices(&selected_indices, &positions)
+            .map_err(|e| capi_error(T4A_INVALID_ARGUMENT, format!("select_indices failed: {e}")))?;
+        unsafe {
+            *out = box_tensor_handle(result);
+        }
+        Ok(())
+    })
+}
+
 /// Check whether a tensor handle is assigned.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_tensor_is_assigned(obj: *const t4a_tensor) -> i32 {

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -272,6 +272,149 @@ fn test_tensor_dense_c64_roundtrip() {
 }
 
 #[test]
+fn test_tensor_select_indices_f64_drops_selected_axes() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(4);
+    let data: Vec<f64> = (0..24).map(|value| value as f64).collect();
+    let tensor = new_tensor_f64(&[i, j, k], &data);
+
+    let selected = [i as *const t4a_index, k as *const t4a_index];
+    let positions = [1usize, 2usize];
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_select_indices(tensor, 2, selected.as_ptr(), positions.as_ptr(), &mut out),
+        T4A_SUCCESS
+    );
+    assert!(!out.is_null());
+
+    let mut dims_len = 0usize;
+    assert_eq!(
+        t4a_tensor_dims(out, std::ptr::null_mut(), 0, &mut dims_len),
+        T4A_SUCCESS
+    );
+    let mut dims = vec![0usize; dims_len];
+    assert_eq!(
+        t4a_tensor_dims(out, dims.as_mut_ptr(), dims.len(), &mut dims_len),
+        T4A_SUCCESS
+    );
+    assert_eq!(dims, vec![3]);
+    assert_eq!(read_dense_f64(out), vec![13.0, 15.0, 17.0]);
+
+    t4a_tensor_release(out);
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
+    t4a_index_release(j);
+    t4a_index_release(k);
+}
+
+#[test]
+fn test_tensor_select_indices_c64_drops_one_axis() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let data = [
+        0.0, 10.0, 1.0, 11.0, 2.0, 12.0, 3.0, 13.0, 4.0, 14.0, 5.0, 15.0,
+    ];
+    let tensor = new_tensor_c64(&[i, j], &data);
+
+    let selected = [j as *const t4a_index];
+    let positions = [1usize];
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_select_indices(tensor, 1, selected.as_ptr(), positions.as_ptr(), &mut out),
+        T4A_SUCCESS
+    );
+    assert!(!out.is_null());
+    assert_eq!(read_payload_c64(out), vec![2.0, 12.0, 3.0, 13.0]);
+
+    t4a_tensor_release(out);
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
+    t4a_index_release(j);
+}
+
+#[test]
+fn test_tensor_select_indices_rejects_invalid_inputs() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(4);
+    let tensor = new_tensor_f64(&[i, j], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let mut out = std::ptr::null_mut();
+
+    let selected = [k as *const t4a_index];
+    let positions = [0usize];
+    assert_eq!(
+        t4a_tensor_select_indices(tensor, 1, selected.as_ptr(), positions.as_ptr(), &mut out),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(out.is_null());
+
+    let selected = [j as *const t4a_index];
+    let positions = [3usize];
+    assert_eq!(
+        t4a_tensor_select_indices(tensor, 1, selected.as_ptr(), positions.as_ptr(), &mut out),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(out.is_null());
+
+    let selected = [i as *const t4a_index, i as *const t4a_index];
+    let positions = [0usize, 1usize];
+    assert_eq!(
+        t4a_tensor_select_indices(tensor, 2, selected.as_ptr(), positions.as_ptr(), &mut out),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(out.is_null());
+
+    assert_eq!(
+        t4a_tensor_select_indices(
+            tensor,
+            1,
+            selected.as_ptr(),
+            positions.as_ptr(),
+            std::ptr::null_mut()
+        ),
+        T4A_NULL_POINTER
+    );
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
+    t4a_index_release(j);
+    t4a_index_release(k);
+}
+
+#[test]
+fn test_tensor_select_indices_rejects_structured_storage() {
+    let i = new_index(3);
+    let j = new_index(3);
+    let diag = [1.0, 2.0, 4.0];
+    let index_ptrs = [i as *const t4a_index, j as *const t4a_index];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_diag_f64(
+            2,
+            index_ptrs.as_ptr(),
+            diag.as_ptr(),
+            diag.len(),
+            &mut tensor
+        ),
+        T4A_SUCCESS
+    );
+
+    let selected = [i as *const t4a_index];
+    let positions = [1usize];
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_select_indices(tensor, 1, selected.as_ptr(), positions.as_ptr(), &mut out),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(out.is_null());
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
+    t4a_index_release(j);
+}
+
+#[test]
 fn test_tensor_diag_f64_storage_payload_roundtrip() {
     let i = new_index(3);
     let j = new_index(3);

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -16,6 +16,7 @@ use crate::TensorElement;
 enum ScalarValue {
     F32(f32),
     F64(f64),
+    I64(i64),
     C32(Complex32),
     C64(Complex64),
 }
@@ -25,6 +26,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value as f64,
             Self::F64(value) => value,
+            Self::I64(value) => value as f64,
             Self::C32(value) => value.re as f64,
             Self::C64(value) => value.re,
         }
@@ -32,7 +34,7 @@ impl ScalarValue {
 
     fn imag(self) -> f64 {
         match self {
-            Self::F32(_) | Self::F64(_) => 0.0,
+            Self::F32(_) | Self::F64(_) | Self::I64(_) => 0.0,
             Self::C32(value) => value.im as f64,
             Self::C64(value) => value.im,
         }
@@ -42,6 +44,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value.abs() as f64,
             Self::F64(value) => value.abs(),
+            Self::I64(value) => value.abs() as f64,
             Self::C32(value) => value.norm() as f64,
             Self::C64(value) => value.norm(),
         }
@@ -55,6 +58,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value == 0.0,
             Self::F64(value) => value == 0.0,
+            Self::I64(value) => value == 0,
             Self::C32(value) => value == Complex32::new(0.0, 0.0),
             Self::C64(value) => value == Complex64::new(0.0, 0.0),
         }
@@ -64,6 +68,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => Complex64::new(value as f64, 0.0),
             Self::F64(value) => Complex64::new(value, 0.0),
+            Self::I64(value) => Complex64::new(value as f64, 0.0),
             Self::C32(value) => Complex64::new(value.re as f64, value.im as f64),
             Self::C64(value) => value,
         }
@@ -143,6 +148,13 @@ impl AnyScalar {
                 self.tensor
                     .to_vec::<f64>()
                     .unwrap_or_else(|e| panic!("failed to read f64 scalar value: {e}"))[0],
+            ),
+            DType::I64 => ScalarValue::I64(
+                self.tensor
+                    .as_native()
+                    .as_slice::<i64>()
+                    .and_then(|values| values.first().copied())
+                    .unwrap_or_else(|| panic!("failed to read i64 scalar value")),
             ),
             DType::C32 => ScalarValue::C32(
                 self.tensor
@@ -251,13 +263,14 @@ impl AnyScalar {
         match self.value() {
             ScalarValue::F32(value) => Some(value as f64),
             ScalarValue::F64(value) => Some(value),
+            ScalarValue::I64(value) => Some(value as f64),
             ScalarValue::C32(_) | ScalarValue::C64(_) => None,
         }
     }
 
     pub fn as_c64(&self) -> Option<Complex64> {
         match self.value() {
-            ScalarValue::F32(_) | ScalarValue::F64(_) => None,
+            ScalarValue::F32(_) | ScalarValue::F64(_) | ScalarValue::I64(_) => None,
             ScalarValue::C32(value) => Some(Complex64::new(value.re as f64, value.im as f64)),
             ScalarValue::C64(value) => Some(value),
         }
@@ -329,6 +342,7 @@ impl AnyScalar {
         match self.value() {
             ScalarValue::F32(value) => BackendScalar::from_value(value),
             ScalarValue::F64(value) => BackendScalar::from_value(value),
+            ScalarValue::I64(value) => BackendScalar::from_value(value as f64),
             ScalarValue::C32(value) => BackendScalar::from_value(value),
             ScalarValue::C64(value) => BackendScalar::from_value(value),
         }
@@ -585,8 +599,17 @@ impl PartialOrd for AnyScalar {
         match (self.value(), other.value()) {
             (ScalarValue::F32(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&rhs),
             (ScalarValue::F32(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
+            (ScalarValue::F32(lhs), ScalarValue::I64(rhs)) => {
+                (lhs as f64).partial_cmp(&(rhs as f64))
+            }
             (ScalarValue::F64(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&(rhs as f64)),
             (ScalarValue::F64(lhs), ScalarValue::F64(rhs)) => lhs.partial_cmp(&rhs),
+            (ScalarValue::F64(lhs), ScalarValue::I64(rhs)) => lhs.partial_cmp(&(rhs as f64)),
+            (ScalarValue::I64(lhs), ScalarValue::F32(rhs)) => {
+                (lhs as f64).partial_cmp(&(rhs as f64))
+            }
+            (ScalarValue::I64(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
+            (ScalarValue::I64(lhs), ScalarValue::I64(rhs)) => lhs.partial_cmp(&rhs),
             _ => None,
         }
     }
@@ -597,6 +620,7 @@ impl fmt::Display for AnyScalar {
         match self.value() {
             ScalarValue::F32(value) => value.fmt(f),
             ScalarValue::F64(value) => value.fmt(f),
+            ScalarValue::I64(value) => value.fmt(f),
             ScalarValue::C32(value) => value.fmt(f),
             ScalarValue::C64(value) => value.fmt(f),
         }

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -763,7 +763,7 @@ impl TensorDynLen {
     ) -> Result<Storage> {
         if Self::is_diag_axis_classes(axis_classes) {
             match native.dtype() {
-                DType::F32 | DType::F64 => Storage::from_diag_col_major(
+                DType::F32 | DType::F64 | DType::I64 => Storage::from_diag_col_major(
                     native_tensor_primal_to_diag_f64(native)?,
                     logical_rank,
                 ),

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -2,7 +2,7 @@ use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::index_ops::{common_ind_positions, prepare_contraction, prepare_contraction_pairs};
 use crate::tensor_like::LinearizationOrder;
-use crate::{storage::Storage, AnyScalar};
+use crate::{storage::Storage, storage::StorageKind, AnyScalar};
 use anyhow::Result;
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -838,6 +838,119 @@ impl TensorDynLen {
     /// ```
     pub fn dims(&self) -> Vec<usize> {
         Self::expected_dims_from_indices(&self.indices)
+    }
+
+    /// Select fixed coordinates for tensor indices and drop those axes.
+    ///
+    /// The `selected_indices` slice identifies tensor axes by index identity,
+    /// and `positions` gives the zero-based coordinate to take on each
+    /// selected axis. Unselected indices are preserved in their original order.
+    ///
+    /// # Arguments
+    ///
+    /// * `selected_indices` - Indices to fix and remove from the result. Each
+    ///   index must appear exactly once in this tensor.
+    /// * `positions` - Coordinates for `selected_indices`. Each coordinate must
+    ///   be less than the corresponding index dimension.
+    ///
+    /// # Returns
+    ///
+    /// A dense tensor over the unselected indices. Selecting no indices returns
+    /// a clone of the original tensor. Selecting all indices returns a rank-0
+    /// scalar tensor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the argument lengths differ, a selected index is not
+    /// present, a selected index is duplicated, a coordinate is out of range,
+    /// or the tensor uses structured storage. Structured storage is rejected
+    /// because selecting a dense slice would otherwise require hidden
+    /// full-tensor materialization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(3);
+    /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+    ///
+    /// let selected = tensor.select_indices(&[j], &[1]).unwrap();
+    /// assert_eq!(selected.dims(), vec![2]);
+    /// assert_eq!(selected.to_vec::<f64>().unwrap(), vec![3.0, 4.0]);
+    /// ```
+    pub fn select_indices(
+        &self,
+        selected_indices: &[DynIndex],
+        positions: &[usize],
+    ) -> Result<Self> {
+        if selected_indices.len() != positions.len() {
+            return Err(anyhow::anyhow!(
+                "selected_indices length {} does not match positions length {}",
+                selected_indices.len(),
+                positions.len()
+            ));
+        }
+        if selected_indices.is_empty() {
+            return Ok(self.clone());
+        }
+        if self.storage.storage_kind() != StorageKind::Dense {
+            return Err(anyhow::anyhow!(
+                "select_indices currently supports dense storage only, got {:?}",
+                self.storage.storage_kind()
+            ));
+        }
+
+        let mut selected_axes = Vec::with_capacity(selected_indices.len());
+        let mut seen_axes = HashSet::with_capacity(selected_indices.len());
+        for (selected, &position) in selected_indices.iter().zip(positions.iter()) {
+            let axis = self
+                .indices
+                .iter()
+                .position(|index| index == selected)
+                .ok_or_else(|| anyhow::anyhow!("selected index is not present in tensor"))?;
+            if !seen_axes.insert(axis) {
+                return Err(anyhow::anyhow!("selected index appears more than once"));
+            }
+            let dim = self.indices[axis].dim();
+            if position >= dim {
+                return Err(anyhow::anyhow!(
+                    "selected coordinate {position} is out of range for axis {axis} with dim {dim}"
+                ));
+            }
+            selected_axes.push(axis);
+        }
+
+        let rank = self.indices.len();
+        let mut starts = vec![0_i64; rank];
+        let mut slice_sizes = self.dims();
+        for (&axis, &position) in selected_axes.iter().zip(positions.iter()) {
+            starts[axis] = i64::try_from(position)
+                .map_err(|_| anyhow::anyhow!("selected coordinate does not fit in i64"))?;
+            slice_sizes[axis] = 1;
+        }
+
+        let starts_tensor = EagerTensor::from_tensor_in(
+            NativeTensor::from_vec(vec![rank], starts),
+            default_eager_ctx(),
+        );
+        let sliced = self
+            .materialized_inner()
+            .dynamic_slice(&starts_tensor, &slice_sizes)?;
+        let kept_indices = self
+            .indices
+            .iter()
+            .enumerate()
+            .filter(|(axis, _)| !seen_axes.contains(axis))
+            .map(|(_, index)| index.clone())
+            .collect::<Vec<_>>();
+        let kept_dims = kept_indices
+            .iter()
+            .map(|index| index.dim())
+            .collect::<Vec<_>>();
+        Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?)
     }
 
     /// Create a new tensor with dynamic rank.

--- a/crates/tensor4all-tensorbackend/src/any_scalar.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar.rs
@@ -14,6 +14,7 @@ use crate::tensor_element::TensorElement;
 enum ScalarValue {
     F32(f32),
     F64(f64),
+    I64(i64),
     C32(Complex32),
     C64(Complex64),
 }
@@ -23,6 +24,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value as f64,
             Self::F64(value) => value,
+            Self::I64(value) => value as f64,
             Self::C32(value) => value.re as f64,
             Self::C64(value) => value.re,
         }
@@ -30,7 +32,7 @@ impl ScalarValue {
 
     fn imag(self) -> f64 {
         match self {
-            Self::F32(_) | Self::F64(_) => 0.0,
+            Self::F32(_) | Self::F64(_) | Self::I64(_) => 0.0,
             Self::C32(value) => value.im as f64,
             Self::C64(value) => value.im,
         }
@@ -40,6 +42,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value.abs() as f64,
             Self::F64(value) => value.abs(),
+            Self::I64(value) => value.abs() as f64,
             Self::C32(value) => value.norm() as f64,
             Self::C64(value) => value.norm(),
         }
@@ -53,6 +56,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value == 0.0,
             Self::F64(value) => value == 0.0,
+            Self::I64(value) => value == 0,
             Self::C32(value) => value == Complex32::new(0.0, 0.0),
             Self::C64(value) => value == Complex64::new(0.0, 0.0),
         }
@@ -62,6 +66,7 @@ impl ScalarValue {
         match self {
             Self::F32(value) => Complex64::new(value as f64, 0.0),
             Self::F64(value) => Complex64::new(value, 0.0),
+            Self::I64(value) => Complex64::new(value as f64, 0.0),
             Self::C32(value) => Complex64::new(value.re as f64, value.im as f64),
             Self::C64(value) => value,
         }
@@ -90,6 +95,12 @@ fn scalar_value_from_native(native: &NativeTensor) -> ScalarValue {
                 .and_then(|values| values.first().copied())
                 .unwrap_or_else(|| panic!("failed to read f64 scalar tensor value")),
         ),
+        DType::I64 => ScalarValue::I64(
+            native
+                .as_slice::<i64>()
+                .and_then(|values| values.first().copied())
+                .unwrap_or_else(|| panic!("failed to read i64 scalar tensor value")),
+        ),
         DType::C32 => ScalarValue::C32(
             native
                 .as_slice::<Complex32>()
@@ -117,6 +128,7 @@ fn neg_native(native: &NativeTensor) -> Result<NativeTensor> {
     Ok(match scalar_value_from_native(native) {
         ScalarValue::F32(value) => Scalar::from_value(-value).native,
         ScalarValue::F64(value) => Scalar::from_value(-value).native,
+        ScalarValue::I64(value) => NativeTensor::from_vec(vec![], vec![-value]),
         ScalarValue::C32(value) => Scalar::from_value(-value).native,
         ScalarValue::C64(value) => Scalar::from_value(-value).native,
     })
@@ -130,20 +142,47 @@ pub(crate) fn promote_scalar_native(native: &NativeTensor, target: DType) -> Res
         (ScalarValue::F32(value), DType::C64) => {
             Scalar::from_value(Complex64::new(value as f64, 0.0))
         }
+        (ScalarValue::F32(_), DType::I64) => {
+            return Err(anyhow!(
+                "cannot promote f32 scalar to i64 without truncation"
+            ));
+        }
         (ScalarValue::F64(value), DType::F32) => Scalar::from_value(value as f32),
         (ScalarValue::F64(value), DType::F64) => Scalar::from_value(value),
+        (ScalarValue::F64(_), DType::I64) => {
+            return Err(anyhow!(
+                "cannot promote f64 scalar to i64 without truncation"
+            ));
+        }
         (ScalarValue::F64(value), DType::C32) => {
             Scalar::from_value(Complex32::new(value as f32, 0.0))
         }
         (ScalarValue::F64(value), DType::C64) => Scalar::from_value(Complex64::new(value, 0.0)),
+        (ScalarValue::I64(value), DType::F32) => Scalar::from_value(value as f32),
+        (ScalarValue::I64(value), DType::F64) => Scalar::from_value(value as f64),
+        (ScalarValue::I64(value), DType::I64) => Scalar {
+            native: NativeTensor::from_vec(vec![], vec![value]),
+        },
+        (ScalarValue::I64(value), DType::C32) => {
+            Scalar::from_value(Complex32::new(value as f32, 0.0))
+        }
+        (ScalarValue::I64(value), DType::C64) => {
+            Scalar::from_value(Complex64::new(value as f64, 0.0))
+        }
         (ScalarValue::C32(value), DType::F32) => Scalar::from_value(value.re),
         (ScalarValue::C32(value), DType::F64) => Scalar::from_value(value.re as f64),
+        (ScalarValue::C32(_), DType::I64) => {
+            return Err(anyhow!("cannot promote c32 scalar to i64"));
+        }
         (ScalarValue::C32(value), DType::C32) => Scalar::from_value(value),
         (ScalarValue::C32(value), DType::C64) => {
             Scalar::from_value(Complex64::new(value.re as f64, value.im as f64))
         }
         (ScalarValue::C64(value), DType::F32) => Scalar::from_value(value.re as f32),
         (ScalarValue::C64(value), DType::F64) => Scalar::from_value(value.re),
+        (ScalarValue::C64(_), DType::I64) => {
+            return Err(anyhow!("cannot promote c64 scalar to i64"));
+        }
         (ScalarValue::C64(value), DType::C32) => {
             Scalar::from_value(Complex32::new(value.re as f32, value.im as f32))
         }
@@ -420,6 +459,7 @@ impl Scalar {
         match self.value() {
             ScalarValue::F32(value) => Some(value as f64),
             ScalarValue::F64(value) => Some(value),
+            ScalarValue::I64(value) => Some(value as f64),
             ScalarValue::C32(_) | ScalarValue::C64(_) => None,
         }
     }
@@ -442,7 +482,7 @@ impl Scalar {
     /// ```
     pub fn as_c64(&self) -> Option<Complex64> {
         match self.value() {
-            ScalarValue::F32(_) | ScalarValue::F64(_) => None,
+            ScalarValue::F32(_) | ScalarValue::F64(_) | ScalarValue::I64(_) => None,
             ScalarValue::C32(value) => Some(Complex64::new(value.re as f64, value.im as f64)),
             ScalarValue::C64(value) => Some(value),
         }
@@ -469,6 +509,10 @@ impl Scalar {
         match self.value() {
             ScalarValue::F32(value) => Self::from_value(value),
             ScalarValue::F64(value) => Self::from_value(value),
+            ScalarValue::I64(value) => {
+                Self::wrap_native(NativeTensor::from_vec(vec![], vec![value]))
+                    .unwrap_or_else(|e| panic!("Scalar::conj returned a non-scalar tensor: {e}"))
+            }
             ScalarValue::C32(value) => Self::from_value(value.conj()),
             ScalarValue::C64(value) => Self::from_value(value.conj()),
         }
@@ -613,6 +657,11 @@ impl SumFromStorage for Scalar {
         match scalar_value_from_storage(storage) {
             ScalarValue::F32(value) => Self::from_value(value),
             ScalarValue::F64(value) => Self::from_value(value),
+            ScalarValue::I64(value) => {
+                Self::wrap_native(NativeTensor::from_vec(vec![], vec![value])).unwrap_or_else(|e| {
+                    panic!("Scalar::sum_from_storage returned a non-scalar tensor: {e}")
+                })
+            }
             ScalarValue::C32(value) => Self::from_value(value),
             ScalarValue::C64(value) => Self::from_value(value),
         }
@@ -650,6 +699,7 @@ impl TryFrom<Scalar> for f64 {
         match value.value() {
             ScalarValue::F32(real) => Ok(real as f64),
             ScalarValue::F64(real) => Ok(real),
+            ScalarValue::I64(real) => Ok(real as f64),
             ScalarValue::C32(_) | ScalarValue::C64(_) => {
                 Err("cannot convert complex scalar to f64")
             }
@@ -778,8 +828,17 @@ impl PartialOrd for Scalar {
         match (self.value(), other.value()) {
             (ScalarValue::F32(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&rhs),
             (ScalarValue::F32(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
+            (ScalarValue::F32(lhs), ScalarValue::I64(rhs)) => {
+                (lhs as f64).partial_cmp(&(rhs as f64))
+            }
             (ScalarValue::F64(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&(rhs as f64)),
             (ScalarValue::F64(lhs), ScalarValue::F64(rhs)) => lhs.partial_cmp(&rhs),
+            (ScalarValue::F64(lhs), ScalarValue::I64(rhs)) => lhs.partial_cmp(&(rhs as f64)),
+            (ScalarValue::I64(lhs), ScalarValue::F32(rhs)) => {
+                (lhs as f64).partial_cmp(&(rhs as f64))
+            }
+            (ScalarValue::I64(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
+            (ScalarValue::I64(lhs), ScalarValue::I64(rhs)) => lhs.partial_cmp(&rhs),
             _ => None,
         }
     }
@@ -790,6 +849,7 @@ impl fmt::Display for Scalar {
         match self.value() {
             ScalarValue::F32(value) => value.fmt(f),
             ScalarValue::F64(value) => value.fmt(f),
+            ScalarValue::I64(value) => value.fmt(f),
             ScalarValue::C32(value) => value.fmt(f),
             ScalarValue::C64(value) => value.fmt(f),
         }

--- a/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
@@ -164,6 +164,95 @@ fn promote_scalar_native_covers_all_scalar_type_pairs() {
 }
 
 #[test]
+fn i64_native_scalar_is_supported_without_public_tensor_element() {
+    let scalar = Scalar::from_native(NativeTensor::from_vec(vec![], vec![-3_i64]))
+        .expect("i64 native scalar");
+    let zero =
+        Scalar::from_native(NativeTensor::from_vec(vec![], vec![0_i64])).expect("i64 zero scalar");
+
+    assert_eq!(scalar.native.dtype(), DType::I64);
+    assert_eq!(scalar.real(), -3.0);
+    assert_eq!(scalar.imag(), 0.0);
+    assert_eq!(scalar.abs(), 3.0);
+    assert!(!scalar.is_complex());
+    assert!(scalar.is_real());
+    assert!(!scalar.is_zero());
+    assert!(zero.is_zero());
+    assert_eq!(scalar.as_f64(), Some(-3.0));
+    assert_eq!(scalar.as_c64(), None);
+    assert_eq!(Complex64::from(scalar.clone()), Complex64::new(-3.0, 0.0));
+    assert_eq!((-scalar).as_f64(), Some(3.0));
+    assert_eq!(format!("{}", zero), "0");
+}
+
+#[test]
+fn promote_i64_native_scalar_covers_supported_targets_and_rejections() {
+    let i64_scalar =
+        Scalar::from_native(NativeTensor::from_vec(vec![], vec![7_i64])).expect("i64 scalar");
+
+    let promoted_f32 =
+        Scalar::from_native(promote_scalar_native(i64_scalar.as_native(), DType::F32).unwrap())
+            .expect("promoted f32");
+    let promoted_f64 =
+        Scalar::from_native(promote_scalar_native(i64_scalar.as_native(), DType::F64).unwrap())
+            .expect("promoted f64");
+    let promoted_i64 =
+        Scalar::from_native(promote_scalar_native(i64_scalar.as_native(), DType::I64).unwrap())
+            .expect("promoted i64");
+    let promoted_c32 =
+        Scalar::from_native(promote_scalar_native(i64_scalar.as_native(), DType::C32).unwrap())
+            .expect("promoted c32");
+    let promoted_c64 =
+        Scalar::from_native(promote_scalar_native(i64_scalar.as_native(), DType::C64).unwrap())
+            .expect("promoted c64");
+
+    assert_eq!(promoted_f32.native.dtype(), DType::F32);
+    assert_eq!(promoted_f32.as_f64(), Some(7.0));
+    assert_eq!(promoted_f64.native.dtype(), DType::F64);
+    assert_eq!(promoted_f64.as_f64(), Some(7.0));
+    assert_eq!(promoted_i64.native.dtype(), DType::I64);
+    assert_eq!(promoted_i64.as_f64(), Some(7.0));
+    assert_eq!(promoted_c32.native.dtype(), DType::C32);
+    assert_eq!(promoted_c32.as_c64(), Some(Complex64::new(7.0, 0.0)));
+    assert_eq!(promoted_c64.native.dtype(), DType::C64);
+    assert_eq!(promoted_c64.as_c64(), Some(Complex64::new(7.0, 0.0)));
+
+    assert!(promote_scalar_native(Scalar::from_value(1.25_f32).as_native(), DType::I64).is_err());
+    assert!(promote_scalar_native(Scalar::from_value(1.25_f64).as_native(), DType::I64).is_err());
+    assert!(promote_scalar_native(
+        Scalar::from_value(Complex32::new(1.0, 0.0)).as_native(),
+        DType::I64
+    )
+    .is_err());
+    assert!(promote_scalar_native(
+        Scalar::from_value(Complex64::new(1.0, 0.0)).as_native(),
+        DType::I64
+    )
+    .is_err());
+}
+
+#[test]
+fn i64_native_scalar_participates_in_real_ordering() {
+    let i64_scalar =
+        Scalar::from_native(NativeTensor::from_vec(vec![], vec![3_i64])).expect("i64 scalar");
+
+    assert_eq!(
+        i64_scalar.partial_cmp(&Scalar::from_value(2.5_f32)),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        i64_scalar.partial_cmp(&Scalar::from_value(3.5_f64)),
+        Some(Ordering::Less)
+    );
+    assert_eq!(
+        i64_scalar.partial_cmp(
+            &Scalar::from_native(NativeTensor::from_vec(vec![], vec![3_i64])).unwrap()
+        ),
+        Some(Ordering::Equal)
+    );
+}
+
+#[test]
 fn scalar_utility_methods_cover_real_and_complex_cases() {
     let zero = Scalar::zero();
     let real = Scalar::from_real(-4.0);

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -142,12 +142,13 @@ fn common_dtype(dtypes: &[DType]) -> DType {
     let has_f64 = dtypes.contains(&DType::F64);
     let has_c64 = dtypes.contains(&DType::C64);
     let has_c32 = dtypes.contains(&DType::C32);
+    let has_i64 = dtypes.contains(&DType::I64);
     let has_complex = has_c64 || has_c32;
     if has_c64 || (has_f64 && has_complex) {
         DType::C64
     } else if has_c32 {
         DType::C32
-    } else if has_f64 {
+    } else if has_f64 || has_i64 {
         DType::F64
     } else {
         DType::F32
@@ -307,6 +308,15 @@ pub fn native_tensor_primal_to_storage(tensor: &NativeTensor) -> Result<Storage>
                 .to_vec(),
             tensor.shape(),
         ),
+        DType::I64 => Storage::from_dense_col_major(
+            tensor
+                .as_slice::<i64>()
+                .ok_or_else(|| anyhow!("failed to read i64 native tensor"))?
+                .iter()
+                .map(|&value| value as f64)
+                .collect::<Vec<_>>(),
+            tensor.shape(),
+        ),
         DType::C32 => Storage::from_dense_col_major(
             tensor
                 .as_slice::<Complex32>()
@@ -337,6 +347,12 @@ pub fn native_tensor_primal_to_dense_f64_col_major(tensor: &NativeTensor) -> Res
             .map(|&value| value as f64)
             .collect()),
         DType::F64 => <f64 as TensorElement>::dense_values_from_native_col_major(tensor),
+        DType::I64 => Ok(tensor
+            .as_slice::<i64>()
+            .ok_or_else(|| anyhow!("failed to read i64 native tensor"))?
+            .iter()
+            .map(|&value| value as f64)
+            .collect()),
         other => Err(anyhow!("expected real native tensor, got dtype {other:?}")),
     }
 }
@@ -374,6 +390,10 @@ pub fn native_tensor_primal_to_diag_f64(tensor: &NativeTensor) -> Result<Vec<f64
             <f64 as TensorElement>::diag_values_from_native_temp(&promoted)
         }
         DType::F64 => <f64 as TensorElement>::diag_values_from_native_temp(tensor),
+        DType::I64 => {
+            let promoted = convert_tensor(tensor, DType::F64)?;
+            <f64 as TensorElement>::diag_values_from_native_temp(&promoted)
+        }
         other => Err(anyhow!("expected real native tensor, got dtype {other:?}")),
     }
 }
@@ -493,6 +513,7 @@ pub fn scale_native_tensor(tensor: &NativeTensor, scalar: &AnyScalar) -> Result<
                 .collect::<Vec<_>>();
             Ok(NativeTensor::from_vec(tensor.shape().to_vec(), values))
         }
+        DType::I64 => Err(anyhow!("scale_native_tensor does not support i64 tensors")),
     }
 }
 
@@ -610,6 +631,7 @@ pub fn axpby_native_tensor(
                 .collect::<Vec<_>>();
             Ok(NativeTensor::from_vec(lhs.shape().to_vec(), values))
         }
+        DType::I64 => Err(anyhow!("axpby_native_tensor does not support i64 tensors")),
     }
 }
 
@@ -741,7 +763,7 @@ pub fn outer_product_native_tensor(lhs: &NativeTensor, rhs: &NativeTensor) -> Re
 /// Conjugate a native tensor.
 pub fn conj_native_tensor(tensor: &NativeTensor) -> Result<NativeTensor> {
     match tensor.dtype() {
-        DType::F32 | DType::F64 => Ok(tensor.clone()),
+        DType::F32 | DType::F64 | DType::I64 => Ok(tensor.clone()),
         DType::C32 => Ok(NativeTensor::from_vec(
             tensor.shape().to_vec(),
             tensor

--- a/crates/tensor4all-tensorbackend/src/tensor_element.rs
+++ b/crates/tensor4all-tensorbackend/src/tensor_element.rs
@@ -41,6 +41,7 @@ fn tensor_dtype_name(dtype: DType) -> &'static str {
     match dtype {
         DType::F32 => "f32",
         DType::F64 => "f64",
+        DType::I64 => "i64",
         DType::C32 => "c32",
         DType::C64 => "c64",
     }


### PR DESCRIPTION
## Summary

- Update the tenferro dependency to the integer-index tensor support commit from tensor4all/tenferro-rs#754.
- Add `TensorDynLen::select_indices` for fixing selected index coordinates and dropping those axes.
- Expose `t4a_tensor_select_indices` in the C API for Julia one-hot application support.

## Behavior

- Dense real and complex tensors are supported.
- Unknown indices, out-of-range coordinates, duplicate selected indices, null output pointers, and structured storage return clear C API errors.
- Structured storage is currently rejected to avoid hidden full dense materialization.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p tensor4all-capi --release`
- `cargo test --doc --release -p tensor4all-core`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run -p api-dump --release -- . -o docs/api`

Depends on tensor4all/tenferro-rs#754.

Closes #469