### PR TITLE
Support structured selection and reusable TreeTN evaluation

### DIFF
--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -271,6 +271,13 @@ typedef struct t4a_treetn {
 } t4a_treetn;
 
 /**
+ * Opaque reusable TreeTN evaluator type for the C API.
+ */
+typedef struct t4a_treetn_evaluator {
+  const void *_private;
+} t4a_treetn_evaluator;
+
+/**
  * Opaque tensor type for the C API.
  */
 typedef struct t4a_tensor {
@@ -885,6 +892,39 @@ StatusCode t4a_treetn_evaluate(const struct t4a_treetn *treetn,
                                size_t n_points,
                                double *out_re,
                                double *out_im);
+
+/**
+ * Clone a reusable TreeTN evaluator handle.
+ */
+StatusCode t4a_treetn_evaluator_clone(const struct t4a_treetn_evaluator *src,
+                                      struct t4a_treetn_evaluator **out);
+
+/**
+ * Evaluate one or more points using a reusable TreeTN evaluator.
+ */
+StatusCode t4a_treetn_evaluator_evaluate(const struct t4a_treetn_evaluator *evaluator,
+                                         const size_t *values_col_major,
+                                         size_t n_points,
+                                         double *out_re,
+                                         double *out_im);
+
+/**
+ * Check whether a reusable TreeTN evaluator handle is assigned.
+ */
+int32_t t4a_treetn_evaluator_is_assigned(const struct t4a_treetn_evaluator *obj);
+
+/**
+ * Create a reusable TreeTN evaluator for explicit index handles.
+ */
+StatusCode t4a_treetn_evaluator_new(const struct t4a_treetn *treetn,
+                                    const struct t4a_index *const *indices,
+                                    size_t n_indices,
+                                    struct t4a_treetn_evaluator **out);
+
+/**
+ * Release a reusable TreeTN evaluator handle.
+ */
+void t4a_treetn_evaluator_release(struct t4a_treetn_evaluator *obj);
 
 /**
  * Fuse connected current-node groups into the requested target topology.

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -383,7 +383,7 @@ fn test_tensor_select_indices_rejects_invalid_inputs() {
 }
 
 #[test]
-fn test_tensor_select_indices_rejects_structured_storage() {
+fn test_tensor_select_indices_accepts_diagonal_storage() {
     let i = new_index(3);
     let j = new_index(3);
     let diag = [1.0, 2.0, 4.0];
@@ -405,10 +405,13 @@ fn test_tensor_select_indices_rejects_structured_storage() {
     let mut out = std::ptr::null_mut();
     assert_eq!(
         t4a_tensor_select_indices(tensor, 1, selected.as_ptr(), positions.as_ptr(), &mut out),
-        T4A_INVALID_ARGUMENT
+        T4A_SUCCESS
     );
-    assert!(out.is_null());
+    assert_eq!(read_dense_f64(out), vec![0.0, 2.0, 0.0]);
+    assert_eq!(read_payload_dims(out), vec![3]);
+    assert_eq!(read_payload_f64(out), vec![0.0, 2.0, 0.0]);
 
+    t4a_tensor_release(out);
     t4a_tensor_release(tensor);
     t4a_index_release(i);
     t4a_index_release(j);

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -2,7 +2,8 @@
 
 use crate::types::{
     t4a_canonical_form, t4a_contract_method, t4a_factorize_alg, t4a_index,
-    t4a_svd_truncation_policy, t4a_tensor, t4a_treetn, InternalIndex, InternalTreeTN,
+    t4a_svd_truncation_policy, t4a_tensor, t4a_treetn, t4a_treetn_evaluator, InternalIndex,
+    InternalTreeTN,
 };
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
@@ -38,6 +39,27 @@ pub extern "C" fn t4a_treetn_clone(
 /// Check whether a TreeTN handle is assigned.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_is_assigned(obj: *const t4a_treetn) -> i32 {
+    is_assigned_opaque(obj)
+}
+
+/// Release a reusable TreeTN evaluator handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_evaluator_release(obj: *mut t4a_treetn_evaluator) {
+    release_opaque(obj);
+}
+
+/// Clone a reusable TreeTN evaluator handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_evaluator_clone(
+    src: *const t4a_treetn_evaluator,
+    out: *mut *mut t4a_treetn_evaluator,
+) -> StatusCode {
+    clone_opaque(src, out)
+}
+
+/// Check whether a reusable TreeTN evaluator handle is assigned.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_evaluator_is_assigned(obj: *const t4a_treetn_evaluator) -> i32 {
     is_assigned_opaque(obj)
 }
 
@@ -113,6 +135,13 @@ fn require_tree_mut<'a>(ptr: *mut t4a_treetn) -> CapiResult<&'a mut t4a_treetn> 
         return Err(capi_error(T4A_NULL_POINTER, "treetn is null"));
     }
     Ok(unsafe { &mut *ptr })
+}
+
+fn require_evaluator<'a>(ptr: *const t4a_treetn_evaluator) -> CapiResult<&'a t4a_treetn_evaluator> {
+    if ptr.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, "treetn evaluator is null"));
+    }
+    Ok(unsafe { &*ptr })
 }
 
 fn require_node(tn: &InternalTreeTN, vertex: usize) -> CapiResult<()> {
@@ -211,6 +240,33 @@ fn collect_edge_endpoints(
     let sources = collect_positions(sources, n_edges, &format!("{what}.sources"))?;
     let targets = collect_positions(targets, n_edges, &format!("{what}.targets"))?;
     Ok(sources.into_iter().zip(targets).collect())
+}
+
+fn write_evaluation_results(
+    results: &[AnyScalar],
+    out_re: *mut libc::c_double,
+    out_im: *mut libc::c_double,
+) -> CapiResult<()> {
+    if out_re.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, "out_re is null"));
+    }
+
+    for (i, scalar) in results.iter().enumerate() {
+        let z: Complex64 = scalar.clone().into();
+        unsafe { *out_re.add(i) = z.re };
+        if z.im != 0.0 {
+            if out_im.is_null() {
+                return Err(capi_error(
+                    T4A_NULL_POINTER,
+                    "out_im is required for complex-valued evaluation results",
+                ));
+            }
+            unsafe { *out_im.add(i) = z.im };
+        } else if !out_im.is_null() {
+            unsafe { *out_im.add(i) = 0.0 };
+        }
+    }
+    Ok(())
 }
 
 fn collect_target_assignment(
@@ -1211,6 +1267,70 @@ pub extern "C" fn t4a_treetn_restructure_to(
     })
 }
 
+/// Create a reusable TreeTN evaluator from explicit index handles.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_evaluator_new(
+    treetn: *const t4a_treetn,
+    indices: *const *const t4a_index,
+    n_indices: libc::size_t,
+    out: *mut *mut t4a_treetn_evaluator,
+) -> StatusCode {
+    run_catching(out, || {
+        let tn = require_tree(treetn)?;
+        if n_indices == 0 {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                "t4a_treetn_evaluator_new requires n_indices > 0",
+            ));
+        }
+        let indices = collect_indices(indices, n_indices, "indices")?;
+        let evaluator = tn
+            .inner()
+            .evaluator(&indices)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_treetn_evaluator::new(evaluator))
+    })
+}
+
+/// Evaluate one or more points using a reusable TreeTN evaluator.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_treetn_evaluator_evaluate(
+    evaluator: *const t4a_treetn_evaluator,
+    values_col_major: *const libc::size_t,
+    n_points: libc::size_t,
+    out_re: *mut libc::c_double,
+    out_im: *mut libc::c_double,
+) -> StatusCode {
+    run_status(|| {
+        let evaluator = require_evaluator(evaluator)?;
+        if n_points == 0 {
+            return Err(capi_error(
+                T4A_INVALID_ARGUMENT,
+                "t4a_treetn_evaluator_evaluate requires n_points > 0",
+            ));
+        }
+        if values_col_major.is_null() {
+            return Err(capi_error(T4A_NULL_POINTER, "values_col_major is null"));
+        }
+
+        let n_indices = evaluator.inner().input_count();
+        let n_values = n_indices.checked_mul(n_points).ok_or_else(|| {
+            capi_error(
+                T4A_INVALID_ARGUMENT,
+                "t4a_treetn_evaluator_evaluate value array size overflowed size_t",
+            )
+        })?;
+        let values_slice = unsafe { std::slice::from_raw_parts(values_col_major, n_values) };
+        let shape = [n_indices, n_points];
+        let values = ColMajorArrayRef::new(values_slice, &shape);
+        let results = evaluator
+            .inner()
+            .evaluate_batch(values)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        write_evaluation_results(&results, out_re, out_im)
+    })
+}
+
 /// Evaluate a TreeTN at one or more points using explicit index handles.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_evaluate(
@@ -1239,9 +1359,6 @@ pub extern "C" fn t4a_treetn_evaluate(
         if values_col_major.is_null() {
             return Err(capi_error(T4A_NULL_POINTER, "values_col_major is null"));
         }
-        if out_re.is_null() {
-            return Err(capi_error(T4A_NULL_POINTER, "out_re is null"));
-        }
 
         let indices = collect_indices(indices, n_indices, "indices")?;
         let n_values = n_indices.checked_mul(n_points).ok_or_else(|| {
@@ -1255,25 +1372,12 @@ pub extern "C" fn t4a_treetn_evaluate(
         let values = ColMajorArrayRef::new(values_slice, &shape);
         let results = tn
             .inner()
-            .evaluate_at(&indices, values)
+            .evaluator(&indices)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?
+            .evaluate_batch(values)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
 
-        for (i, scalar) in results.iter().enumerate() {
-            let z: Complex64 = scalar.clone().into();
-            unsafe { *out_re.add(i) = z.re };
-            if z.im != 0.0 {
-                if out_im.is_null() {
-                    return Err(capi_error(
-                        T4A_NULL_POINTER,
-                        "out_im is required for complex-valued evaluation results",
-                    ));
-                }
-                unsafe { *out_im.add(i) = z.im };
-            } else if !out_im.is_null() {
-                unsafe { *out_im.add(i) = 0.0 };
-            }
-        }
-        Ok(())
+        write_evaluation_results(&results, out_re, out_im)
     })
 }
 

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -1135,6 +1135,73 @@ fn test_treetn_evaluate_complex_requires_out_im_buffer() {
 }
 
 #[test]
+fn test_treetn_evaluator_reuses_index_order_for_multiple_batches() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let s0 = indices[0];
+    let s1 = indices[3];
+    let index_ptrs = [s0 as *const t4a_index, s1 as *const t4a_index];
+    let mut evaluator = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_evaluator_new(tt, index_ptrs.as_ptr(), 2, &mut evaluator),
+        T4A_SUCCESS
+    );
+    assert!(!evaluator.is_null());
+
+    let first_values = [
+        0usize, 0usize, // point 0
+        1usize, 1usize, // point 1
+    ];
+    let mut first_out = [0.0; 2];
+    assert_eq!(
+        t4a_treetn_evaluator_evaluate(
+            evaluator,
+            first_values.as_ptr(),
+            2,
+            first_out.as_mut_ptr(),
+            std::ptr::null_mut()
+        ),
+        T4A_SUCCESS
+    );
+    assert_eq!(first_out, [1.0, 4.0]);
+
+    let second_values = [
+        1usize, 0usize, // point 0
+        0usize, 1usize, // point 1
+    ];
+    let mut second_out = [0.0; 2];
+    assert_eq!(
+        t4a_treetn_evaluator_evaluate(
+            evaluator,
+            second_values.as_ptr(),
+            2,
+            second_out.as_mut_ptr(),
+            std::ptr::null_mut()
+        ),
+        T4A_SUCCESS
+    );
+    assert_eq!(second_out, [2.0, 3.0]);
+
+    t4a_treetn_evaluator_release(evaluator);
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_evaluator_new_rejects_incomplete_index_list() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let s0 = indices[0];
+    let index_ptrs = [s0 as *const t4a_index];
+    let mut evaluator = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_evaluator_new(tt, index_ptrs.as_ptr(), 1, &mut evaluator),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(last_error().contains("indices.len()"));
+    assert!(evaluator.is_null());
+
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
 fn test_treetn_contract_and_to_dense() {
     let in_idx = new_index(2);
     let out_idx = new_index(2);

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -8,7 +8,7 @@ use tensor4all_core::{
 };
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
-use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN};
+use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN, TreeTNEvaluator};
 
 /// Internal dynamic index type wrapped by `t4a_index`.
 pub(crate) type InternalIndex = DynIndex;
@@ -18,6 +18,9 @@ pub(crate) type InternalTensor = TensorDynLen;
 
 /// Internal tree tensor network type wrapped by `t4a_treetn`.
 pub(crate) type InternalTreeTN = DefaultTreeTN<usize>;
+
+/// Internal reusable TreeTN evaluator type wrapped by `t4a_treetn_evaluator`.
+pub(crate) type InternalTreeTNEvaluator = TreeTNEvaluator<InternalTensor, usize>;
 
 /// Opaque index type for the C API.
 #[repr(C)]
@@ -183,6 +186,45 @@ impl Drop for t4a_treetn {
 
 unsafe impl Send for t4a_treetn {}
 unsafe impl Sync for t4a_treetn {}
+
+/// Opaque reusable TreeTN evaluator type for the C API.
+#[repr(C)]
+pub struct t4a_treetn_evaluator {
+    pub(crate) _private: *const c_void,
+}
+
+impl t4a_treetn_evaluator {
+    /// Create a wrapper from an internal reusable evaluator value.
+    pub(crate) fn new(evaluator: InternalTreeTNEvaluator) -> Self {
+        Self {
+            _private: Box::into_raw(Box::new(evaluator)) as *const c_void,
+        }
+    }
+
+    /// Borrow the wrapped reusable evaluator.
+    pub(crate) fn inner(&self) -> &InternalTreeTNEvaluator {
+        unsafe { &*(self._private as *const InternalTreeTNEvaluator) }
+    }
+}
+
+impl Clone for t4a_treetn_evaluator {
+    fn clone(&self) -> Self {
+        Self::new(self.inner().clone())
+    }
+}
+
+impl Drop for t4a_treetn_evaluator {
+    fn drop(&mut self) {
+        if !self._private.is_null() {
+            unsafe {
+                let _ = Box::from_raw(self._private as *mut InternalTreeTNEvaluator);
+            }
+        }
+    }
+}
+
+unsafe impl Send for t4a_treetn_evaluator {}
+unsafe impl Sync for t4a_treetn_evaluator {}
 
 /// Canonical form used for orthogonalization and canonicalization.
 #[repr(C)]

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -777,6 +777,65 @@ impl TensorDynLen {
         }
     }
 
+    fn dense_selected_diag_payload<T: TensorElement + Copy + Zero>(
+        payload: Vec<T>,
+        kept_dims: &[usize],
+        selected_positions: &[usize],
+    ) -> Vec<T> {
+        let output_len = kept_dims.iter().product::<usize>();
+        let mut data = vec![T::zero(); output_len];
+        if output_len == 0 {
+            return data;
+        }
+
+        let Some((&first_position, rest)) = selected_positions.split_first() else {
+            return data;
+        };
+        if rest.iter().any(|&position| position != first_position) {
+            return data;
+        }
+
+        let value = payload[first_position];
+        if kept_dims.is_empty() {
+            data[0] = value;
+            return data;
+        }
+
+        let mut offset = 0usize;
+        let mut stride = 1usize;
+        for &dim in kept_dims {
+            offset += first_position * stride;
+            stride *= dim;
+        }
+        data[offset] = value;
+        data
+    }
+
+    fn select_diag_indices(
+        &self,
+        kept_indices: Vec<DynIndex>,
+        kept_dims: Vec<usize>,
+        positions: &[usize],
+    ) -> Result<Self> {
+        if self.storage.is_f64() {
+            let payload = self
+                .storage
+                .payload_f64_col_major_vec()
+                .map_err(anyhow::Error::msg)?;
+            let data = Self::dense_selected_diag_payload(payload, &kept_dims, positions);
+            Self::from_dense(kept_indices, data)
+        } else if self.storage.is_c64() {
+            let payload = self
+                .storage
+                .payload_c64_col_major_vec()
+                .map_err(anyhow::Error::msg)?;
+            let data = Self::dense_selected_diag_payload(payload, &kept_dims, positions);
+            Self::from_dense(kept_indices, data)
+        } else {
+            Err(anyhow::anyhow!("unsupported diagonal storage scalar type"))
+        }
+    }
+
     fn validate_storage_matches_indices(indices: &[DynIndex], storage: &Storage) -> Result<()> {
         let dims = Self::expected_dims_from_indices(indices);
         let storage_dims = storage.logical_dims();
@@ -857,15 +916,16 @@ impl TensorDynLen {
     ///
     /// A dense tensor over the unselected indices. Selecting no indices returns
     /// a clone of the original tensor. Selecting all indices returns a rank-0
-    /// scalar tensor.
+    /// scalar tensor. Diagonal tensors are sliced from their compact diagonal
+    /// payload without materializing the original full tensor.
     ///
     /// # Errors
     ///
     /// Returns an error if the argument lengths differ, a selected index is not
     /// present, a selected index is duplicated, a coordinate is out of range,
-    /// or the tensor uses structured storage. Structured storage is rejected
-    /// because selecting a dense slice would otherwise require hidden
-    /// full-tensor materialization.
+    /// or the tensor uses unsupported structured storage. General structured
+    /// storage is rejected because selecting a dense slice would otherwise
+    /// require hidden full-tensor materialization.
     ///
     /// # Examples
     ///
@@ -896,12 +956,6 @@ impl TensorDynLen {
         if selected_indices.is_empty() {
             return Ok(self.clone());
         }
-        if self.storage.storage_kind() != StorageKind::Dense {
-            return Err(anyhow::anyhow!(
-                "select_indices currently supports dense storage only, got {:?}",
-                self.storage.storage_kind()
-            ));
-        }
 
         let mut selected_axes = Vec::with_capacity(selected_indices.len());
         let mut seen_axes = HashSet::with_capacity(selected_indices.len());
@@ -923,6 +977,28 @@ impl TensorDynLen {
             selected_axes.push(axis);
         }
 
+        let kept_indices = self
+            .indices
+            .iter()
+            .enumerate()
+            .filter(|(axis, _)| !seen_axes.contains(axis))
+            .map(|(_, index)| index.clone())
+            .collect::<Vec<_>>();
+        let kept_dims = kept_indices
+            .iter()
+            .map(|index| index.dim())
+            .collect::<Vec<_>>();
+
+        if self.storage.storage_kind() == StorageKind::Diagonal {
+            return self.select_diag_indices(kept_indices, kept_dims, positions);
+        }
+        if self.storage.storage_kind() != StorageKind::Dense {
+            return Err(anyhow::anyhow!(
+                "select_indices currently supports dense and diagonal storage only, got {:?}",
+                self.storage.storage_kind()
+            ));
+        }
+
         let rank = self.indices.len();
         let mut starts = vec![0_i64; rank];
         let mut slice_sizes = self.dims();
@@ -939,17 +1015,6 @@ impl TensorDynLen {
         let sliced = self
             .materialized_inner()
             .dynamic_slice(&starts_tensor, &slice_sizes)?;
-        let kept_indices = self
-            .indices
-            .iter()
-            .enumerate()
-            .filter(|(axis, _)| !seen_axes.contains(axis))
-            .map(|(_, index)| index.clone())
-            .collect::<Vec<_>>();
-        let kept_dims = kept_indices
-            .iter()
-            .map(|index| index.dim())
-            .collect::<Vec<_>>();
         Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?)
     }
 

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -76,6 +76,37 @@ fn test_diag_tensor_permute() {
 }
 
 #[test]
+fn diag_tensor_select_index_returns_dense_slice_from_payload() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 5.0, 7.0]);
+
+    let selected = tensor.select_indices(&[j], &[1]).unwrap();
+
+    assert_eq!(selected.dims(), vec![3]);
+    assert_eq!(selected.storage().storage_kind(), StorageKind::Dense);
+    assert_eq!(selected.to_vec::<f64>().unwrap(), vec![0.0, 5.0, 0.0]);
+}
+
+#[test]
+fn diag_tensor_select_multiple_indices_requires_matching_coordinates() {
+    let i = Index::new_dyn(3);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(3);
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], vec![2.0, 5.0, 7.0]);
+
+    let matching = tensor
+        .select_indices(&[i.clone(), k.clone()], &[2, 2])
+        .unwrap();
+    assert_eq!(matching.dims(), vec![3]);
+    assert_eq!(matching.to_vec::<f64>().unwrap(), vec![0.0, 0.0, 7.0]);
+
+    let mismatched = tensor.select_indices(&[i, k], &[1, 2]).unwrap();
+    assert_eq!(mismatched.dims(), vec![3]);
+    assert_eq!(mismatched.to_vec::<f64>().unwrap(), vec![0.0, 0.0, 0.0]);
+}
+
+#[test]
 fn test_diag_tensor_contract_diag_diag_all_contracted() {
     // Create two 2x2 DiagTensors and contract all indices
     let i = Index::new_dyn(2);

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -71,6 +71,7 @@ pub use treetn::{
     SwapSchedule,
     // Core type
     TreeTN,
+    TreeTNEvaluator,
     TreeTopology,
     TruncateUpdater,
 };

--- a/crates/tensor4all-treetn/src/site_index_network.rs
+++ b/crates/tensor4all-treetn/src/site_index_network.rs
@@ -164,6 +164,28 @@ where
         self.index_to_node.contains_key(index)
     }
 
+    /// Return the number of registered site indices.
+    ///
+    /// This uses the reverse index lookup and does not scan every node's site
+    /// space. Use it when validating a complete site-index assignment.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashSet;
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_treetn::SiteIndexNetwork;
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let mut network = SiteIndexNetwork::<&str, DynIndex>::new();
+    /// network.add_node("A", HashSet::from([i])).unwrap();
+    ///
+    /// assert_eq!(network.site_index_count(), 1);
+    /// ```
+    pub fn site_index_count(&self) -> usize {
+        self.index_to_node.len()
+    }
+
     /// Add a site index to a node's site space.
     ///
     /// Updates both the site space and the reverse lookup.

--- a/crates/tensor4all-treetn/src/treetn/evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/evaluator.rs
@@ -1,0 +1,327 @@
+use anyhow::{Context, Result};
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike, TensorLike};
+
+use super::TreeTN;
+
+#[derive(Debug, Clone)]
+struct EvaluatorSiteEntry<I> {
+    index: I,
+    input_position: usize,
+    local_axis: usize,
+}
+
+#[derive(Debug, Clone)]
+struct EvaluatorNodeEntry<T, V>
+where
+    T: TensorLike,
+{
+    name: V,
+    tensor: T,
+    site_entries: Vec<EvaluatorSiteEntry<T::Index>>,
+}
+
+/// Reusable evaluator for batched [`TreeTN`] point evaluation.
+///
+/// `TreeTNEvaluator` validates a complete site-index order once and precomputes
+/// the mapping from each input row to the owning TreeTN node. Reuse it when the
+/// same network and site-index order are evaluated repeatedly, for example in
+/// TCI-style sampling loops.
+///
+/// Related convenience methods such as [`TreeTN::evaluate`] and
+/// [`TreeTN::evaluate_at`] construct a temporary evaluator internally.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
+///
+/// let s = DynIndex::new_dyn(3);
+/// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0])?;
+/// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+///
+/// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
+/// let values = [0usize, 2usize];
+/// let shape = [1usize, 2usize];
+/// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+///
+/// assert_eq!(result.len(), 2);
+/// assert!((result[0].real() - 10.0).abs() < 1.0e-12);
+/// assert!((result[1].real() - 30.0).abs() < 1.0e-12);
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct TreeTNEvaluator<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    node_entries: Vec<EvaluatorNodeEntry<T, V>>,
+    n_indices: usize,
+}
+
+impl<T, V> TreeTNEvaluator<T, V>
+where
+    T: TensorLike,
+    T::Index: Clone + Hash + Eq,
+    <T::Index as IndexLike>::Id: Ord,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    /// Create a reusable evaluator for a complete site-index ordering.
+    ///
+    /// `indices` must enumerate every site index of `tree` exactly once. The
+    /// evaluator uses full index equality, so indices with the same ID but
+    /// different tags, prime levels, or other metadata are distinct.
+    ///
+    /// # Arguments
+    ///
+    /// * `tree` - Tree tensor network whose local tensors and index mapping
+    ///   are captured by the evaluator.
+    /// * `indices` - Complete input row order for future batch value arrays.
+    ///
+    /// # Returns
+    ///
+    /// A reusable evaluator that can evaluate many value batches with shape
+    /// `[indices.len(), n_points]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tree is empty, `indices` is incomplete, contains
+    /// duplicates, contains an unknown site index, or a site index is not found
+    /// on its owning node tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    ///
+    /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
+    /// assert_eq!(evaluator.input_count(), 1);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn new(tree: &TreeTN<T, V>, indices: &[T::Index]) -> Result<Self> {
+        if tree.node_count() == 0 {
+            return Err(anyhow::anyhow!("Cannot evaluate empty TreeTN"))
+                .context("TreeTNEvaluator::new: network must have at least one node");
+        }
+
+        let n_indices = indices.len();
+        let total_site_indices = tree.site_index_network.site_index_count();
+        anyhow::ensure!(
+            n_indices == total_site_indices,
+            "TreeTNEvaluator::new: indices.len() ({}) != total site indices ({})",
+            n_indices,
+            total_site_indices
+        );
+
+        let mut seen = HashSet::with_capacity(n_indices);
+        for index in indices {
+            anyhow::ensure!(
+                seen.insert(index),
+                "TreeTNEvaluator::new: duplicate index {:?}",
+                index
+            );
+        }
+
+        let mut entries_by_node: HashMap<V, Vec<EvaluatorSiteEntry<T::Index>>> = HashMap::new();
+        let mut tensor_indices_by_node: HashMap<V, Vec<T::Index>> = HashMap::new();
+        for (input_position, index) in indices.iter().enumerate() {
+            let node_name = tree
+                .site_index_network
+                .find_node_by_index(index)
+                .ok_or_else(|| anyhow::anyhow!("unknown index {:?}", index))?
+                .clone();
+            let node_idx = tree
+                .node_index(&node_name)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))
+                .context("TreeTNEvaluator::new: node must exist")?;
+            let tensor = tree
+                .tensor(node_idx)
+                .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node_name))
+                .context("TreeTNEvaluator::new: tensor must exist")?;
+            let tensor_indices = tensor_indices_by_node
+                .entry(node_name.clone())
+                .or_insert_with(|| tensor.external_indices());
+            let local_axis = tensor_indices
+                .iter()
+                .position(|tensor_index| tensor_index == index)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "site index {:?} is registered on node {:?} but not present in its tensor",
+                        index,
+                        node_name
+                    )
+                })
+                .context("TreeTNEvaluator::new: site index metadata is inconsistent")?;
+            entries_by_node
+                .entry(node_name)
+                .or_default()
+                .push(EvaluatorSiteEntry {
+                    index: index.clone(),
+                    input_position,
+                    local_axis,
+                });
+        }
+
+        let node_names = tree.node_names();
+        let mut node_entries = Vec::with_capacity(node_names.len());
+        for node_name in node_names {
+            let node_idx = tree
+                .node_index(&node_name)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))
+                .context("TreeTNEvaluator::new: node must exist")?;
+            let tensor = tree
+                .tensor(node_idx)
+                .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node_name))
+                .context("TreeTNEvaluator::new: tensor must exist")?;
+            let mut site_entries = entries_by_node.remove(&node_name).unwrap_or_default();
+            site_entries.sort_by_key(|entry| entry.local_axis);
+            node_entries.push(EvaluatorNodeEntry {
+                name: node_name,
+                tensor: tensor.clone(),
+                site_entries,
+            });
+        }
+
+        Ok(Self {
+            node_entries,
+            n_indices,
+        })
+    }
+
+    /// Return the number of site-index rows expected by this evaluator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
+    ///
+    /// assert_eq!(evaluator.input_count(), 1);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn input_count(&self) -> usize {
+        self.n_indices
+    }
+
+    /// Evaluate all points in a column-major batch value array.
+    ///
+    /// `values` must have shape `[self.input_count(), n_points]`, and
+    /// `values.get(&[i, p])` is the coordinate for input site index `i` at
+    /// point `p`.
+    ///
+    /// # Arguments
+    ///
+    /// * `values` - Column-major coordinate array with one row per evaluator
+    ///   input index and one column per point.
+    ///
+    /// # Returns
+    ///
+    /// One scalar value per point.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values` is not rank-2, has the wrong leading
+    /// dimension, contains out-of-range coordinates, or contraction fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![4.0, 9.0])?;
+    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
+    /// let values = [1usize];
+    /// let shape = [1usize, 1usize];
+    ///
+    /// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+    /// assert!((result[0].real() - 9.0).abs() < 1.0e-12);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn evaluate_batch(&self, values: ColMajorArrayRef<'_, usize>) -> Result<Vec<AnyScalar>> {
+        anyhow::ensure!(
+            values.shape().len() == 2,
+            "TreeTNEvaluator::evaluate_batch: values must be 2D, got {}D",
+            values.shape().len()
+        );
+        anyhow::ensure!(
+            values.shape()[0] == self.n_indices,
+            "TreeTNEvaluator::evaluate_batch: values.shape()[0] ({}) != indices.len() ({})",
+            values.shape()[0],
+            self.n_indices
+        );
+        let n_points = values.shape()[1];
+
+        let mut results = Vec::with_capacity(n_points);
+        for point in 0..n_points {
+            results.push(self.evaluate_point(values, point)?);
+        }
+        Ok(results)
+    }
+
+    fn evaluate_point(
+        &self,
+        values: ColMajorArrayRef<'_, usize>,
+        point: usize,
+    ) -> Result<AnyScalar> {
+        let mut contracted_tensors: Vec<T> = Vec::with_capacity(self.node_entries.len());
+        let mut contracted_names: Vec<V> = Vec::with_capacity(self.node_entries.len());
+
+        for entry in &self.node_entries {
+            if entry.site_entries.is_empty() {
+                contracted_tensors.push(entry.tensor.clone());
+                contracted_names.push(entry.name.clone());
+                continue;
+            }
+
+            let index_vals: Vec<(T::Index, usize)> = entry
+                .site_entries
+                .iter()
+                .map(|site| {
+                    let val = *values.get(&[site.input_position, point]).unwrap();
+                    (site.index.clone(), val)
+                })
+                .collect();
+
+            let onehot = T::onehot(&index_vals)
+                .context("TreeTNEvaluator::evaluate_batch: failed to create one-hot tensor")?;
+
+            let result = T::contract(
+                &[&entry.tensor, &onehot],
+                tensor4all_core::AllowedPairs::All,
+            )
+            .context("TreeTNEvaluator::evaluate_batch: failed to contract tensor with one-hot")?;
+
+            contracted_tensors.push(result);
+            contracted_names.push(entry.name.clone());
+        }
+
+        let temp_tn = TreeTN::<T, V>::from_tensors(contracted_tensors, contracted_names)
+            .context("TreeTNEvaluator::evaluate_batch: failed to build temporary TreeTN")?;
+        let result_tensor = temp_tn
+            .contract_to_tensor()
+            .context("TreeTNEvaluator::evaluate_batch: failed to contract to scalar")?;
+
+        let scalar_one =
+            T::scalar_one().context("TreeTNEvaluator::evaluate_batch: failed to create scalar")?;
+        scalar_one
+            .inner_product(&result_tensor)
+            .context("TreeTNEvaluator::evaluate_batch: failed to extract scalar value")
+    }
+}

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -10,6 +10,7 @@ mod addition;
 mod canonicalize;
 pub mod contraction;
 mod decompose;
+mod evaluator;
 mod fit;
 mod localupdate;
 mod operator_impl;
@@ -39,6 +40,9 @@ use crate::site_index_network::SiteIndexNetwork;
 
 // Re-export the decomposition functions and types
 pub use decompose::{factorize_tensor_to_treetn, factorize_tensor_to_treetn_with, TreeTopology};
+
+// Re-export evaluator types
+pub use evaluator::TreeTNEvaluator;
 
 // Re-export local update types
 pub use localupdate::{

--- a/crates/tensor4all-treetn/src/treetn/ops.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops.rs
@@ -11,12 +11,12 @@
 //! - `evaluate` for evaluating at specific index values using full indices
 //! - `all_site_indices` for retrieving all site indices and their owning vertices
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::hash::Hash;
 
 use tensor4all_core::{AllowedPairs, AnyScalar, ColMajorArrayRef, IndexLike, TensorLike};
 
-use super::TreeTN;
+use super::{TreeTN, TreeTNEvaluator};
 
 // ============================================================================
 // Default implementation
@@ -507,7 +507,54 @@ where
             .context("to_dense: failed to contract network to tensor")
     }
 
+    /// Create a reusable evaluator for repeated batched point evaluation.
+    ///
+    /// This is a convenience wrapper around [`TreeTNEvaluator::new`]. Use the
+    /// returned evaluator when repeatedly evaluating the same TreeTN with the
+    /// same site-index order.
+    ///
+    /// # Arguments
+    ///
+    /// * `indices` - Complete site-index order used as the row order of future
+    ///   batch value arrays.
+    ///
+    /// # Returns
+    ///
+    /// A reusable evaluator bound to this TreeTN.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the TreeTN is empty or `indices` is not a complete,
+    /// duplicate-free list of this TreeTN's site indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    ///
+    /// let evaluator = tree.evaluator(&[s])?;
+    /// assert_eq!(evaluator.input_count(), 1);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn evaluator(&self, indices: &[T::Index]) -> Result<TreeTNEvaluator<T, V>>
+    where
+        T::Index: Clone + Hash + Eq,
+        <T::Index as IndexLike>::Id: Ord,
+    {
+        TreeTNEvaluator::new(self, indices)
+    }
+
     /// Evaluate the TreeTN at multiple multi-indices (batch).
+    ///
+    /// This is a convenience method that constructs a temporary
+    /// [`TreeTNEvaluator`]. For repeated calls with the same site-index order,
+    /// create an evaluator once with [`Self::evaluator`] and call
+    /// [`TreeTNEvaluator::evaluate_batch`].
     ///
     /// # Arguments
     /// * `indices` - Identifies each site index by full `Index` value (from
@@ -535,158 +582,7 @@ where
         T::Index: Clone + Hash + Eq,
         <T::Index as IndexLike>::Id: Ord,
     {
-        if self.node_count() == 0 {
-            return Err(anyhow::anyhow!("Cannot evaluate empty TreeTN"))
-                .context("evaluate: network must have at least one node");
-        }
-
-        let n_indices = indices.len();
-        anyhow::ensure!(
-            values.shape().len() == 2,
-            "evaluate: values must be 2D, got {}D",
-            values.shape().len()
-        );
-        anyhow::ensure!(
-            values.shape()[0] == n_indices,
-            "evaluate: values.shape()[0] ({}) != indices.len() ({})",
-            values.shape()[0],
-            n_indices
-        );
-        let n_points = values.shape()[1];
-
-        // Build index -> position lookup (Vec-based linear scan is fine for
-        // the small number of site indices typical in practice).
-        let mut known_indices: HashSet<T::Index> = HashSet::new();
-        let mut total_site_indices: usize = 0;
-        for node_name in self.node_names() {
-            let site_space = self
-                .site_space(&node_name)
-                .ok_or_else(|| anyhow::anyhow!("Site space not found for node {:?}", node_name))
-                .context("evaluate: site space must exist")?;
-            for index in site_space {
-                known_indices.insert(index.clone());
-                total_site_indices += 1;
-            }
-        }
-
-        // Validate: indices.len() must equal total number of site indices.
-        anyhow::ensure!(
-            n_indices == total_site_indices,
-            "evaluate: indices.len() ({}) != total site indices ({})",
-            n_indices,
-            total_site_indices
-        );
-
-        // Validate: no duplicate indices.
-        {
-            let mut seen = HashSet::with_capacity(n_indices);
-            for index in indices {
-                anyhow::ensure!(seen.insert(index), "evaluate: duplicate index {:?}", index);
-            }
-        }
-
-        // Validate: all provided indices must be known (exist in the network).
-        for index in indices {
-            anyhow::ensure!(
-                known_indices.contains(index),
-                "evaluate: unknown index {:?}",
-                index
-            );
-        }
-
-        // Pre-compute per-node data: (node_name, node_index, tensor_ref,
-        //   site_entries: Vec<(Index, position_in_indices)>)
-        // This avoids HashMap lookups and repeated node_index/tensor lookups
-        // inside the per-point loop.
-        struct NodeEntry<'a, T: TensorLike, V> {
-            name: V,
-            tensor: &'a T,
-            /// (site_index, position in `indices`)
-            site_entries: Vec<(T::Index, usize)>,
-        }
-
-        let node_names = self.node_names();
-        let mut node_entries: Vec<NodeEntry<'_, T, V>> = Vec::with_capacity(node_names.len());
-
-        for node_name in &node_names {
-            let node_idx = self
-                .node_index(node_name)
-                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))
-                .context("evaluate: node must exist")?;
-
-            let tensor = self
-                .tensor(node_idx)
-                .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node_name))
-                .context("evaluate: tensor must exist")?;
-
-            let site_space = self.site_space(node_name);
-            let mut site_entries = Vec::new();
-            if let Some(space) = site_space {
-                for index in space {
-                    let pos = indices
-                        .iter()
-                        .position(|x| x == index)
-                        .ok_or_else(|| anyhow::anyhow!("Index {:?} not found in indices", index))
-                        .context("evaluate: all site indices must be covered by indices")?;
-                    site_entries.push((index.clone(), pos));
-                }
-            }
-
-            node_entries.push(NodeEntry {
-                name: node_name.clone(),
-                tensor,
-                site_entries,
-            });
-        }
-
-        let mut results = Vec::with_capacity(n_points);
-        for point in 0..n_points {
-            let mut contracted_tensors: Vec<T> = Vec::with_capacity(node_entries.len());
-            let mut contracted_names: Vec<V> = Vec::with_capacity(node_entries.len());
-
-            for entry in &node_entries {
-                if entry.site_entries.is_empty() {
-                    // No site indices - just use the tensor as is
-                    contracted_tensors.push(entry.tensor.clone());
-                    contracted_names.push(entry.name.clone());
-                    continue;
-                }
-
-                let index_vals: Vec<(T::Index, usize)> = entry
-                    .site_entries
-                    .iter()
-                    .map(|(idx, pos)| {
-                        let val = *values.get(&[*pos, point]).unwrap();
-                        (idx.clone(), val)
-                    })
-                    .collect();
-
-                let onehot =
-                    T::onehot(&index_vals).context("evaluate: failed to create one-hot tensor")?;
-
-                let result =
-                    T::contract(&[entry.tensor, &onehot], tensor4all_core::AllowedPairs::All)
-                        .context("evaluate: failed to contract tensor with one-hot")?;
-
-                contracted_tensors.push(result);
-                contracted_names.push(entry.name.clone());
-            }
-
-            // Build a temporary TreeTN from the contracted tensors and contract to scalar
-            let temp_tn = TreeTN::<T, V>::from_tensors(contracted_tensors, contracted_names)
-                .context("evaluate: failed to build temporary TreeTN")?;
-            let result_tensor = temp_tn
-                .contract_to_tensor()
-                .context("evaluate: failed to contract to scalar")?;
-
-            let scalar_one = T::scalar_one().context("evaluate: failed to create scalar_one")?;
-            let scalar = scalar_one
-                .inner_product(&result_tensor)
-                .context("evaluate: failed to extract scalar value")?;
-            results.push(scalar);
-        }
-
-        Ok(results)
+        TreeTNEvaluator::new(self, indices)?.evaluate_batch(values)
     }
 
     /// Returns all site indices and their owning vertex names.

--- a/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
@@ -1,7 +1,7 @@
 use num_complex::Complex64;
 use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, TensorDynLen};
 
-use crate::TreeTN;
+use crate::{TreeTN, TreeTNEvaluator};
 
 fn make_three_node_chain() -> TreeTN<TensorDynLen, usize> {
     let s0 = DynIndex::new_dyn(2);
@@ -89,4 +89,34 @@ fn test_evaluate_accepts_full_indices_for_same_id_prime_pair() {
     assert_eq!(result.len(), 2);
     assert!((result[0].real() - 10.0).abs() < 1.0e-10);
     assert!((result[1].real() - 40.0).abs() < 1.0e-10);
+}
+
+#[test]
+fn evaluator_evaluate_batch_matches_evaluate_at_sugar() {
+    let tn = make_three_node_chain();
+    let (indices, _) = tn.all_site_indices().unwrap();
+    let values = [0usize, 0, 0, 1, 1, 1, 0, 1, 0];
+    let shape = [indices.len(), 3usize];
+    let values_ref = ColMajorArrayRef::new(&values, &shape);
+
+    let evaluator = TreeTNEvaluator::new(&tn, &indices).unwrap();
+    let direct = evaluator.evaluate_batch(values_ref).unwrap();
+    let sugar = tn.evaluate_at(&indices, values_ref).unwrap();
+
+    assert_eq!(direct.len(), 3);
+    assert_eq!(sugar.len(), 3);
+    for (left, right) in direct.iter().zip(sugar.iter()) {
+        assert!((left.real() - right.real()).abs() < 1.0e-12);
+        assert!((left.imag() - right.imag()).abs() < 1.0e-12);
+    }
+}
+
+#[test]
+fn evaluator_rejects_incomplete_site_index_list() {
+    let tn = make_three_node_chain();
+    let (indices, _) = tn.all_site_indices().unwrap();
+
+    let err = TreeTNEvaluator::new(&tn, &indices[..indices.len() - 1]).unwrap_err();
+
+    assert!(err.to_string().contains("indices.len()"));
 }

--- a/docs/plans/2026-04-28-structured-select-indices-design.md
+++ b/docs/plans/2026-04-28-structured-select-indices-design.md
@@ -1,0 +1,197 @@
+# Structured Select Indices Design
+
+## Goal
+
+Make `TensorDynLen::select_indices` work for general structured storage while
+preserving compact storage metadata and avoiding full logical dense
+materialization of the input tensor.
+
+The design introduces an internal structured-zero constructor first. Selection
+can then represent impossible equality constraints as compact zero tensors
+instead of falling back to dense zeros.
+
+## Background
+
+`Storage` represents dense, diagonal, and copy-like tensors with one structured
+model:
+
+- dense: `axis_classes = [0, 1, ...]`
+- diagonal: `axis_classes = [0, 0, ...]`
+- general structured: repeated classes such as `[0, 1, 0, 2]`
+
+A structured tensor with payload `P`, logical dimensions `dims`, and
+`axis_classes` represents:
+
+```text
+T[i0, i1, ...] =
+    P[j0, j1, ...] if all logical axes in the same class have equal indices
+    0              otherwise
+```
+
+where `jc` is the common coordinate for payload class `c`.
+
+`select_indices` fixes one or more logical axes and drops them. For structured
+storage, this operation should become a payload slice plus metadata
+canonicalization, not a full logical dense slice.
+
+## Non-Goals
+
+- Do not expose a new public API in this change. Start with `pub(crate)`
+  helpers.
+- Do not change the observable `select_indices` value semantics.
+- Do not add support for arbitrary sparse storage.
+- Do not materialize the full input logical tensor.
+
+## Structured Zero
+
+Add internal helpers:
+
+```rust
+TensorDynLen::structured_zeros<T>(
+    indices: Vec<DynIndex>,
+    axis_classes: Vec<usize>,
+) -> Result<TensorDynLen>
+where
+    T: TensorElement + Zero + Clone;
+```
+
+and, if it keeps responsibilities cleaner:
+
+```rust
+Storage::structured_zeros<T>(
+    payload_dims: Vec<usize>,
+    axis_classes: Vec<usize>,
+) -> Result<Storage>
+where
+    T: StorageScalar + Zero + Clone;
+```
+
+The helper computes compact payload dimensions from logical dimensions and
+`axis_classes`. All logical axes sharing one class must have the same dimension.
+The payload data is zero-filled with length `product(payload_dims)`, and strides
+are compact column-major strides.
+
+The storage kind remains derived from metadata:
+
+- distinct classes for all logical axes may be `StorageKind::Dense`;
+- all logical axes sharing one class may be `StorageKind::Diagonal`;
+- mixed repeated classes are `StorageKind::Structured`.
+
+The helper name can still be `structured_zeros`; the resulting storage kind need
+not always be `Structured`.
+
+## Selection Semantics
+
+Selection is defined by mapping selected logical axes to payload classes.
+
+For each selected logical axis:
+
+1. Find the logical axis by full `DynIndex` equality.
+2. Read `class_id = storage.axis_classes()[axis]`.
+3. Record `(class_id, selected_position)`.
+
+If the same `class_id` is selected more than once with different positions, the
+logical slice is all zeros. Return `structured_zeros::<T>(kept_indices,
+kept_axis_classes)` after canonicalizing the kept classes.
+
+If the positions agree, that payload class is fixed to that coordinate.
+
+## Metadata Algorithm
+
+Given:
+
+- input `indices`
+- input `axis_classes`
+- selected axes and positions
+
+Compute:
+
+1. `kept_axes`: logical axes not selected.
+2. `kept_indices`: indices for those axes, preserving logical order.
+3. `old_kept_classes`: input classes for kept axes.
+4. `fixed_classes`: map from selected class to fixed coordinate.
+5. `remaining_payload_classes`: old classes that appear in `old_kept_classes`.
+6. Canonicalize `old_kept_classes` by first appearance to produce
+   `new_axis_classes`.
+7. Compute `new_payload_dims` from the kept logical dimensions and
+   `new_axis_classes`.
+
+Selected classes that do not appear in kept axes become payload slice axes that
+are removed from the output payload. Selected classes that still appear in kept
+axes constrain the corresponding output payload coordinate to the fixed value.
+
+Example:
+
+```text
+axis_classes = [0, 1, 0, 2]
+select logical axis 1 at p
+
+kept classes      = [0, 0, 2]
+fixed classes     = {1: p}
+new axis_classes  = [0, 0, 1]
+```
+
+## Payload Algorithm
+
+The output payload is built by iterating over the new compact payload, not over
+the full output logical dense tensor.
+
+For each new payload coordinate:
+
+1. Map it back to old payload classes that remain in output.
+2. Fill fixed selected classes from `fixed_classes`.
+3. Compute the old payload offset with `payload_strides`.
+4. Copy the payload value into the new compact payload.
+
+This is `O(product(new_payload_dims))` in memory and time. It does not depend on
+`product(input logical dims)` except through the compact payload dimensions.
+
+## Scalar Types
+
+Implement the algorithm generically over payload scalar type where possible.
+`TensorDynLen` may dispatch through existing `Storage` payload accessors:
+
+- `payload_f64_col_major_vec`
+- `payload_c64_col_major_vec`
+
+The implementation should not add scalar-specific public Rust entry points.
+
+## AD
+
+Initial implementation may reject tracked structured AD values if preserving AD
+metadata is not yet straightforward. The important rule is to avoid silently
+densifying tracked structured payloads.
+
+If AD is supported in the same change, the selected payload should be built from
+the tracked compact payload tensor rather than from snapshot storage, and the
+result should keep tracked structured AD metadata.
+
+## Error Handling
+
+Return errors for:
+
+- argument length mismatch;
+- selected index not present;
+- duplicated selected index;
+- coordinate out of range;
+- invalid or non-canonical axis classes;
+- inconsistent dimensions within one payload class;
+- unsupported scalar type.
+
+Do not return an error for equality conflicts caused by selection positions.
+Those are valid slices whose value is exactly zero.
+
+## Testing
+
+Tests should cover:
+
+- structured zero helper for f64 and Complex64;
+- invalid shared-class dimensions;
+- select on structured `[0, 1, 0]` preserving `[0, 0]`;
+- select on structured `[0, 1, 0]` with conflicting selected axes returning
+  compact zero;
+- select all axes returning rank-0 storage;
+- same-ID different-prime indices select the exact full index;
+- no full input dense materialization by using dimensions that would be too
+  large to materialize densely but have small compact payload.
+

--- a/docs/plans/2026-04-28-structured-select-indices-plan.md
+++ b/docs/plans/2026-04-28-structured-select-indices-plan.md
@@ -1,0 +1,354 @@
+# Structured Select Indices Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add general structured-storage support to `TensorDynLen::select_indices` while preserving compact structure and avoiding full input dense materialization.
+
+**Architecture:** First add internal structured-zero construction for compact zero tensors. Then implement structured selection as payload slicing plus axis-class canonicalization. Keep the API surface private and add representation-level regression tests.
+
+**Tech Stack:** Rust, `tensor4all-core::TensorDynLen`, `tensor4all_tensorbackend::Storage`, `StorageKind`, structured `axis_classes`, `cargo test --release`.
+
+---
+
+### Task 1: Add structured zero tests
+
+**Files:**
+- Modify: `crates/tensor4all-core/tests/tensor_diag.rs`
+
+**Step 1: Write failing tests**
+
+Add tests near the structured/diagonal storage tests:
+
+```rust
+#[test]
+fn structured_zeros_preserves_copy_structure() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let k = Index::new_dyn(3);
+
+    let tensor = TensorDynLen::structured_zeros::<f64>(
+        vec![i, j, k],
+        vec![0, 0, 1],
+    )
+    .unwrap();
+
+    assert_eq!(tensor.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(tensor.storage().payload_dims(), &[2, 3]);
+    assert_eq!(tensor.storage().axis_classes(), &[0, 0, 1]);
+    assert_eq!(
+        tensor.storage().payload_f64_col_major_vec().unwrap(),
+        vec![0.0; 6],
+    );
+    assert!(tensor.to_vec::<f64>().unwrap().iter().all(|&x| x == 0.0));
+}
+
+#[test]
+fn structured_zeros_rejects_mismatched_shared_class_dims() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+
+    let err = TensorDynLen::structured_zeros::<f64>(vec![i, j], vec![0, 0])
+        .unwrap_err();
+
+    assert!(err.to_string().contains("same structured axis class"));
+}
+```
+
+These tests call a new `pub(crate)` helper, so place them in a source-level
+`#[cfg(test)]` module if integration tests cannot access the helper. If keeping
+the helper private, move equivalent tests into
+`crates/tensor4all-core/src/defaults/tensordynlen.rs`.
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test -p tensor4all-core --release structured_zeros -- --nocapture
+```
+
+Expected: fail because `structured_zeros` does not exist yet.
+
+### Task 2: Implement private structured zero helper
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+
+**Step 1: Add helper**
+
+Implement:
+
+```rust
+pub(crate) fn structured_zeros<T>(
+    indices: Vec<DynIndex>,
+    axis_classes: Vec<usize>,
+) -> Result<Self>
+where
+    T: TensorElement + Zero + Clone,
+{
+    let dims = Self::expected_dims_from_indices(&indices);
+    let payload_dims = Self::payload_dims_from_axis_classes(&dims, &axis_classes)?;
+    let payload_len = payload_dims.iter().product::<usize>();
+    let strides = tensor4all_tensorbackend::col_major_strides(&payload_dims);
+    let storage = Storage::new_structured(
+        vec![T::zero(); payload_len],
+        payload_dims,
+        strides,
+        axis_classes,
+    )?;
+    Self::from_storage(indices, Arc::new(storage))
+}
+```
+
+If `col_major_strides` is not public, either add a small local checked helper in
+`tensordynlen.rs` or add a crate-visible backend helper with focused tests.
+
+**Step 2: Add dimension helper**
+
+Implement a private helper:
+
+```rust
+fn payload_dims_from_axis_classes(
+    logical_dims: &[usize],
+    axis_classes: &[usize],
+) -> Result<Vec<usize>>
+```
+
+Rules:
+
+- `axis_classes.len() == logical_dims.len()`;
+- classes must be canonical first-appearance form;
+- all logical axes in the same class have the same dimension;
+- return payload dimensions in class order.
+
+**Step 3: Verify GREEN**
+
+Run:
+
+```bash
+cargo test -p tensor4all-core --release structured_zeros -- --nocapture
+```
+
+Expected: structured-zero tests pass.
+
+### Task 3: Add structured select tests
+
+**Files:**
+- Modify: `crates/tensor4all-core/tests/tensor_diag.rs`
+
+**Step 1: Write failing tests**
+
+Add tests for general structured selection. Use `Storage::new_structured` and
+`TensorDynLen::from_structured_storage` to construct the input:
+
+```rust
+#[test]
+fn structured_select_preserves_repeated_kept_axis_class() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let k = Index::new_dyn(2);
+    let l = Index::new_dyn(5);
+    let storage = Arc::new(
+        Storage::new_structured(
+            (0..30).map(|x| x as f64).collect(),
+            vec![2, 3, 5],
+            vec![1, 2, 6],
+            vec![0, 1, 0, 2],
+        )
+        .unwrap(),
+    );
+    let tensor = TensorDynLen::from_structured_storage(
+        vec![i.clone(), j.clone(), k.clone(), l.clone()],
+        storage,
+    )
+    .unwrap();
+
+    let selected = tensor.select_indices(&[j], &[1]).unwrap();
+
+    assert_eq!(selected.indices(), &[i, k, l]);
+    assert_eq!(selected.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(selected.storage().payload_dims(), &[2, 5]);
+    assert_eq!(selected.storage().axis_classes(), &[0, 0, 1]);
+}
+
+#[test]
+fn structured_select_conflicting_fixed_class_returns_compact_zero() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let k = Index::new_dyn(3);
+    let storage = Arc::new(
+        Storage::new_structured(
+            vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
+            vec![2, 3],
+            vec![1, 2],
+            vec![0, 0, 1],
+        )
+        .unwrap(),
+    );
+    let tensor = TensorDynLen::from_structured_storage(
+        vec![i.clone(), j.clone(), k.clone()],
+        storage,
+    )
+    .unwrap();
+
+    let selected = tensor.select_indices(&[i, j], &[0, 1]).unwrap();
+
+    assert_eq!(selected.indices(), &[k]);
+    assert_eq!(selected.storage().payload_dims(), &[3]);
+    assert_eq!(selected.storage().payload_f64_col_major_vec().unwrap(), vec![0.0; 3]);
+    assert!(selected.to_vec::<f64>().unwrap().iter().all(|&x| x == 0.0));
+}
+```
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test -p tensor4all-core --release structured_select -- --nocapture
+```
+
+Expected: fail because `select_indices` still rejects general structured storage.
+
+### Task 4: Implement structured select metadata planning
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+
+**Step 1: Add a plan struct**
+
+Add private struct:
+
+```rust
+struct StructuredSelectPlan {
+    kept_indices: Vec<DynIndex>,
+    new_axis_classes: Vec<usize>,
+    old_class_for_new_payload_axis: Vec<usize>,
+    fixed_old_class_positions: Vec<Option<usize>>,
+    conflict: bool,
+}
+```
+
+Adjust fields as needed, but keep the plan explicit and testable.
+
+**Step 2: Add planner**
+
+Implement a private helper that takes selected axes/positions and storage
+metadata, then:
+
+- groups selected positions by old class;
+- detects conflicts;
+- canonicalizes kept old classes into new axis classes;
+- records mapping from new payload axes to old payload classes.
+
+**Step 3: Unit-test planner if useful**
+
+If planner complexity grows, test it in a `#[cfg(test)]` module in
+`tensordynlen.rs`.
+
+### Task 5: Implement compact payload selection
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+
+**Step 1: Add typed payload helper**
+
+Implement:
+
+```rust
+fn select_structured_payload<T>(
+    payload: Vec<T>,
+    old_payload_dims: &[usize],
+    old_payload_strides: &[isize],
+    new_payload_dims: &[usize],
+    plan: &StructuredSelectPlan,
+) -> Result<Vec<T>>
+where
+    T: TensorElement + Copy + Zero;
+```
+
+Iterate over `product(new_payload_dims)`, decode each column-major coordinate,
+map it to an old payload coordinate, fill fixed classes, compute old offset, and
+copy the value.
+
+**Step 2: Build output storage**
+
+For f64 and Complex64 storage:
+
+- get payload via existing payload accessors;
+- call `select_structured_payload`;
+- build `Storage::new_structured(data, new_payload_dims, new_strides, new_axis_classes)`;
+- wrap with `TensorDynLen::from_structured_storage`.
+
+**Step 3: Handle conflict**
+
+If the planner reports conflict, return:
+
+```rust
+TensorDynLen::structured_zeros::<T>(kept_indices, new_axis_classes)
+```
+
+using the scalar type of the input storage.
+
+### Task 6: Replace structured rejection in `select_indices`
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+
+**Step 1: Route storage kinds**
+
+Make `select_indices` dispatch:
+
+- `Dense`: existing dynamic-slice path;
+- `Diagonal`: either keep the current specialized path or replace it with the
+  general structured path;
+- `Structured`: new structured path.
+
+Prefer using the general structured path for diagonal too if it stays simple and
+keeps tests green. Otherwise keep diagonal special-case for clarity.
+
+**Step 2: Update rustdoc**
+
+Update `select_indices` docs to state that structured layouts are preserved when
+possible and that full input dense materialization is avoided.
+
+### Task 7: Verification
+
+**Files:**
+- Test: `crates/tensor4all-core/tests/tensor_diag.rs`
+- Test: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+
+**Step 1: Run focused tests**
+
+```bash
+cargo test -p tensor4all-core --release structured_zeros -- --nocapture
+cargo test -p tensor4all-core --release structured_select -- --nocapture
+cargo test -p tensor4all-core --release diag_tensor_select -- --nocapture
+```
+
+Expected: all focused tests pass.
+
+**Step 2: Run core diag test file**
+
+```bash
+cargo test -p tensor4all-core --release --test tensor_diag
+```
+
+Expected: all tests pass.
+
+**Step 3: Format**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no diff.
+
+**Step 4: Optional wider check**
+
+```bash
+cargo test -p tensor4all-core --release
+```
+
+Expected: all core tests pass.
+


### PR DESCRIPTION
## Summary

- add diagonal/structured-aware `select_indices` coverage and structured-select design notes
- add a reusable `TreeTNEvaluator` that resolves full site `Index` handles once and keeps `TreeTN::evaluate` / `evaluate_at` as sugar
- expose a reusable C API evaluator handle (`t4a_treetn_evaluator_*`) and route one-shot C evaluation through the same evaluator path
- update C API select-index coverage now that diagonal/structured storage is accepted rather than rejected

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --doc --release -p tensor4all-treetn`
- `cargo test -p tensor4all-treetn --release --lib -- --nocapture`
- `cargo test -p tensor4all-capi --release --lib -- --nocapture`
- `cargo nextest run --release --workspace` (1952 passed, 7 skipped)
