### PR TITLE
Remove direct faer dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ bnum = "0.12"
 uint = "0.10"
 libc = "0.2"
 paste = "1.0"
-faer = "0.23"
 thiserror = "2.0"
 rand = "0.9"
 rand_chacha = "0.9"
@@ -53,7 +52,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5b1c8fc9e91b2415553d15206ee0ace7860fff8" }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -360,7 +360,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_lu_with_options::<T>(
         t,
@@ -385,7 +385,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_lu_with_options::<T>(t, left_inds, canonical, usize::MAX, 0.0)
 }
@@ -406,7 +406,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Unfold tensor into matrix
     let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
@@ -474,7 +474,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_ci_with_options::<T>(
         t,
@@ -499,7 +499,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_ci_with_options::<T>(t, left_inds, canonical, usize::MAX, 0.0)
 }
@@ -520,7 +520,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Unfold tensor into matrix
     let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)

--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -13,7 +13,7 @@ use quanticsgrids::DiscretizedGrid;
 use tensor4all_core::TensorElement;
 use tensor4all_simplett::{AbstractTensorTrain, TTScalar, TensorTrain};
 use tensor4all_simplett::{Tensor3, Tensor3Ops};
-use tensor4all_tcicore::{DenseFaerLuKernel, PivotKernel};
+use tensor4all_tcicore::{DenseLuKernel, PivotKernel};
 use tensor4all_treetci::materialize::FullPivLuScalar;
 
 use crate::options::QtciOptions;
@@ -217,7 +217,7 @@ pub fn quanticscrossinterpolate_batched<V, F>(
 where
     F: Fn(&[f64]) -> Vec<V> + 'static,
     V: TTScalar + Default + Clone + 'static + TensorElement + FullPivLuScalar,
-    DenseFaerLuKernel: PivotKernel<V>,
+    DenseLuKernel: PivotKernel<V>,
 {
     // Validate output_dims
     if output_dims.is_empty() {

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -9,7 +9,7 @@ use quanticsgrids::{DiscretizedGrid, InherentDiscreteGrid};
 use rand::Rng;
 use tensor4all_core::TensorDynLen;
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TTScalar, TensorTrain};
-use tensor4all_tcicore::{DenseFaerLuKernel, PivotKernel};
+use tensor4all_tcicore::{DenseLuKernel, PivotKernel};
 use tensor4all_treetci::materialize::{to_treetn, FullPivLuScalar};
 use tensor4all_treetci::{
     optimize_with_proposer, DefaultProposer, GlobalIndexBatch, TreeTCI2, TreeTciGraph,
@@ -447,7 +447,7 @@ pub fn quanticscrossinterpolate<V, F>(
 ) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
     V: TTScalar + Default + Clone + 'static + tensor4all_core::TensorElement + FullPivLuScalar,
-    DenseFaerLuKernel: PivotKernel<V>,
+    DenseLuKernel: PivotKernel<V>,
     F: Fn(&[f64]) -> V + 'static,
 {
     let local_dims = grid.local_dimensions();
@@ -614,7 +614,7 @@ pub fn quanticscrossinterpolate_from_arrays<V, F>(
 ) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
     V: TTScalar + Default + Clone + 'static + tensor4all_core::TensorElement + FullPivLuScalar,
-    DenseFaerLuKernel: PivotKernel<V>,
+    DenseLuKernel: PivotKernel<V>,
     F: Fn(&[f64]) -> V + 'static,
 {
     if xvals.is_empty() {
@@ -723,7 +723,7 @@ pub fn quanticscrossinterpolate_discrete<V, F>(
 ) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
     V: TTScalar + Default + Clone + 'static + tensor4all_core::TensorElement + FullPivLuScalar,
-    DenseFaerLuKernel: PivotKernel<V>,
+    DenseLuKernel: PivotKernel<V>,
     F: Fn(&[i64]) -> V + 'static,
 {
     // Validate sizes are powers of 2

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -163,7 +163,7 @@ fn factorize<T>(
 ) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
 where
     T: TTScalar + Scalar + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     let reltol = if tolerance > 0.0 { tolerance } else { 1e-14 };
     let abstol = 0.0;
@@ -399,7 +399,7 @@ impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
     pub fn compress(&mut self, options: &CompressionOptions) -> Result<()>
     where
         T: tensor4all_tcicore::MatrixLuciScalar,
-        tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+        tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
     {
         let n = self.len();
         if n <= 1 {
@@ -540,7 +540,7 @@ impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
     pub fn compressed(&self, options: &CompressionOptions) -> Result<Self>
     where
         T: tensor4all_tcicore::MatrixLuciScalar,
-        tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+        tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
     {
         let mut result = self.clone();
         result.compress(options)?;

--- a/crates/tensor4all-simplett/src/compression/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/compression/tests/mod.rs
@@ -6,7 +6,7 @@ use num_complex::Complex64;
 fn test_compress_constant_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     let tt = TensorTrain::<T>::constant(&[2, 3, 2], <T as Scalar>::from_f64(1.0));
     let original_sum = tt.sum();
@@ -23,7 +23,7 @@ where
 fn test_compress_preserves_values_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Create a simple tensor train
     let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 2);
@@ -67,7 +67,7 @@ where
 fn test_compress_with_max_bond_dim_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Create a tensor train with higher bond dimension
     let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 3);
@@ -136,7 +136,7 @@ fn test_compress_with_max_bond_dim_c64() {
 fn test_compress_svd_constant_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     let tt = TensorTrain::<T>::constant(&[2, 3, 2], <T as Scalar>::from_f64(1.0));
     let original_sum = tt.sum();
@@ -155,7 +155,7 @@ where
 fn test_compress_svd_with_truncation_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Create a rank-3 TT and compress with SVD to max_bond_dim=2
     let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 3);

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -296,7 +296,7 @@ pub fn factorize_lu<T>(
 ) -> Result<FactorizeResult<T>>
 where
     T: SVDScalar + tensor4all_tcicore::Scalar + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     use tensor4all_tcicore::{AbstractMatrixCI, MatrixLUCI, RrLUOptions};
 
@@ -361,7 +361,7 @@ pub fn factorize_ci<T>(
 where
     T: SVDScalar + tensor4all_tcicore::Scalar + tensor4all_tcicore::MatrixLuciScalar,
     <T as ComplexFloat>::Real: Into<f64>,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // CI uses the same LUCI implementation as LU
     factorize_lu(matrix, options)

--- a/crates/tensor4all-simplett/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/tensortrain/tests/mod.rs
@@ -532,7 +532,7 @@ fn test_svd_compression_tolerance_generic<
         + std::fmt::Debug,
 >()
 where
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     use crate::compression::{CompressionMethod, CompressionOptions};
 

--- a/crates/tensor4all-tcicore/Cargo.toml
+++ b/crates/tensor4all-tcicore/Cargo.toml
@@ -15,7 +15,6 @@ thiserror.workspace = true
 rand.workspace = true
 paste.workspace = true
 bnum.workspace = true
-faer.workspace = true
 tenferro-einsum.workspace = true
 tenferro-tensor.workspace = true
 tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
@@ -36,7 +35,7 @@ name = "cached_function"
 harness = false
 
 [[bench]]
-name = "dense_vs_faer"
+name = "dense_vs_tenferro"
 harness = false
 
 [[bench]]

--- a/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
+++ b/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use faer::MatRef;
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use tenferro_tensor::{cpu::CpuBackend, Tensor};
 use tensor4all_tcicore::matrixluci::{
-    DenseFaerLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions,
+    DenseLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions,
 };
 
 fn random_column_major(nrows: usize, ncols: usize, seed: u64) -> Vec<f64> {
@@ -18,9 +18,9 @@ fn random_column_major(nrows: usize, ncols: usize, seed: u64) -> Vec<f64> {
     data
 }
 
-fn bench_dense_vs_faer(c: &mut Criterion) {
-    let mut group = c.benchmark_group("dense_no_truncation_vs_faer");
-    let kernel = DenseFaerLuKernel;
+fn bench_dense_vs_tenferro(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dense_no_truncation_vs_tenferro");
+    let kernel = DenseLuKernel;
     let options = PivotKernelOptions::no_truncation();
 
     for &size in &[32usize, 64, 100, 128] {
@@ -33,13 +33,14 @@ fn bench_dense_vs_faer(c: &mut Criterion) {
             });
         });
 
+        let mut backend = CpuBackend::new();
         group.bench_with_input(
-            BenchmarkId::new("faer_full_piv_lu", size),
+            BenchmarkId::new("tenferro_full_piv_lu", size),
             &size,
             |b, &n| {
                 b.iter(|| {
-                    let mat = MatRef::from_column_major_slice(&data, n, n);
-                    black_box(mat.full_piv_lu());
+                    let mat = Tensor::from_vec(vec![n, n], data.clone());
+                    black_box(mat.full_piv_lu(&mut backend).unwrap());
                 });
             },
         );
@@ -48,5 +49,5 @@ fn bench_dense_vs_faer(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_dense_vs_faer);
+criterion_group!(benches, bench_dense_vs_tenferro);
 criterion_main!(benches);

--- a/crates/tensor4all-tcicore/benches/lazy_block_rook.rs
+++ b/crates/tensor4all-tcicore/benches/lazy_block_rook.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tensor4all_tcicore::matrixluci::{
-    DenseFaerLuKernel, DenseMatrixSource, LazyBlockRookKernel, LazyMatrixSource, PivotKernel,
+    DenseLuKernel, DenseMatrixSource, LazyBlockRookKernel, LazyMatrixSource, PivotKernel,
     PivotKernelOptions,
 };
 
@@ -45,7 +45,7 @@ fn materialize_expensive(n: usize) -> Vec<f64> {
 }
 
 fn bench_lazy_block_rook(c: &mut Criterion) {
-    let dense_kernel = DenseFaerLuKernel;
+    let dense_kernel = DenseLuKernel;
     let rook_kernel = LazyBlockRookKernel;
     let options = PivotKernelOptions {
         max_rank: 8,

--- a/crates/tensor4all-tcicore/benches/rrlu_bench.rs
+++ b/crates/tensor4all-tcicore/benches/rrlu_bench.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use faer::prelude::*;
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use tenferro_tensor::{cpu::CpuBackend, Tensor};
 use tensor4all_tcicore::matrix::{from_vec2d, Matrix};
 use tensor4all_tcicore::{rrlu_inplace, RrLUOptions};
 
@@ -15,10 +15,16 @@ fn random_matrix(n: usize, m: usize, seed: u64) -> Matrix<f64> {
     from_vec2d(data)
 }
 
-/// Generate a random faer Mat<f64>
-fn random_faer_matrix(n: usize, m: usize, seed: u64) -> Mat<f64> {
+/// Generate a random column-major tensor for the configured tensor backend.
+fn random_tenferro_matrix(n: usize, m: usize, seed: u64) -> Tensor {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    Mat::from_fn(n, m, |_, _| rng.random::<f64>())
+    let mut data = vec![0.0; n * m];
+    for col in 0..m {
+        for row in 0..n {
+            data[row + n * col] = rng.random::<f64>();
+        }
+    }
+    Tensor::from_vec(vec![n, m], data)
 }
 
 fn bench_rrlu(c: &mut Criterion) {
@@ -41,15 +47,20 @@ fn bench_rrlu(c: &mut Criterion) {
             );
         });
 
-        group.bench_with_input(BenchmarkId::new("faer_lu_fullpiv", size), &size, |b, &n| {
-            b.iter_batched(
-                || random_faer_matrix(n, n, 42),
-                |m| {
-                    m.full_piv_lu();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
+        let mut backend = CpuBackend::new();
+        group.bench_with_input(
+            BenchmarkId::new("tenferro_full_piv_lu", size),
+            &size,
+            |b, &n| {
+                b.iter_batched(
+                    || random_tenferro_matrix(n, n, 42),
+                    |m| {
+                        m.full_piv_lu(&mut backend).unwrap();
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
     }
 
     group.finish();

--- a/crates/tensor4all-tcicore/src/lib.rs
+++ b/crates/tensor4all-tcicore/src/lib.rs
@@ -73,7 +73,7 @@ pub mod scalar;
 pub mod traits;
 
 pub use self::matrixluci::{
-    CandidateMatrixSource, CrossFactors, DenseFaerLuKernel, DenseMatrixSource, DenseOwnedMatrix,
+    CandidateMatrixSource, CrossFactors, DenseLuKernel, DenseMatrixSource, DenseOwnedMatrix,
     LazyBlockRookKernel, LazyMatrixSource, MatrixLuciError, PivotKernel, PivotKernelOptions,
     PivotSelectionCore,
 };

--- a/crates/tensor4all-tcicore/src/matrix_luci.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci.rs
@@ -8,7 +8,7 @@ use crate::error::{MatrixCIError, Result};
 use crate::matrix::{submatrix, zeros, Matrix};
 use crate::matrixlu::RrLUOptions;
 use crate::matrixluci::{
-    CrossFactors, DenseFaerLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions,
+    CrossFactors, DenseLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions,
     PivotSelectionCore,
 };
 use crate::scalar::Scalar;
@@ -90,7 +90,7 @@ pub(crate) fn dense_selection_from_matrix<T>(
 ) -> Result<(PivotSelectionCore, CrossFactors<T>)>
 where
     T: Scalar + crate::matrixluci::Scalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
 {
     let data = to_column_major(a);
     let source = DenseMatrixSource::from_column_major(&data, a.nrows(), a.ncols());
@@ -101,7 +101,7 @@ where
         left_orthogonal: options.left_orthogonal,
     };
 
-    let selection = DenseFaerLuKernel
+    let selection = DenseLuKernel
         .factorize(&source, &kernel_options)
         .map_err(map_backend_error)?;
     let factors = CrossFactors::from_source(&source, &selection).map_err(map_backend_error)?;
@@ -111,7 +111,7 @@ where
 impl<T> MatrixLUCI<T>
 where
     T: Scalar + crate::matrixluci::Scalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
 {
     /// Create a MatrixLUCI from a dense row-major matrix.
     ///

--- a/crates/tensor4all-tcicore/src/matrixluci/block_rook/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/block_rook/tests.rs
@@ -1,5 +1,5 @@
 use crate::matrixluci::{
-    DenseFaerLuKernel, DenseMatrixSource, LazyBlockRookKernel, LazyMatrixSource, PivotKernel,
+    DenseLuKernel, DenseMatrixSource, LazyBlockRookKernel, LazyMatrixSource, PivotKernel,
     PivotKernelOptions,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -36,7 +36,7 @@ fn lazy_block_rook_kernel_matches_dense_kernel_on_unique_pivot_matrix() {
     let dense = DenseMatrixSource::from_column_major(&data, 4, 4);
     let lazy = dense_to_lazy(data.clone(), 4, 4);
 
-    let dense_out = DenseFaerLuKernel
+    let dense_out = DenseLuKernel
         .factorize(&dense, &PivotKernelOptions::no_truncation())
         .unwrap();
     let lazy_out = LazyBlockRookKernel
@@ -59,7 +59,7 @@ fn lazy_block_rook_kernel_matches_dense_kernel_for_abs_tol_stop() {
         ..PivotKernelOptions::default()
     };
 
-    let dense_out = DenseFaerLuKernel.factorize(&dense, &options).unwrap();
+    let dense_out = DenseLuKernel.factorize(&dense, &options).unwrap();
     let lazy_out = LazyBlockRookKernel.factorize(&lazy, &options).unwrap();
 
     assert_eq!(lazy_out.row_indices, dense_out.row_indices);

--- a/crates/tensor4all-tcicore/src/matrixluci/dense.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/dense.rs
@@ -3,42 +3,24 @@
 use crate::matrixluci::kernel::PivotKernel;
 use crate::matrixluci::scalar::Scalar;
 use crate::matrixluci::source::{materialize_source, CandidateMatrixSource};
-use crate::matrixluci::{PivotKernelOptions, PivotSelectionCore, Result};
-use faer::MatRef;
+use crate::matrixluci::{MatrixLuciError, PivotKernelOptions, PivotSelectionCore, Result};
+use crate::scalar::Scalar as LegacyScalar;
+use crate::{from_vec2d, rrlu, RrLUOptions};
 use num_complex::{Complex32, Complex64};
+use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorScalar};
 
-/// Dense full-pivoting LU kernel backed by faer.
+/// Dense full-pivoting LU kernel backed by the configured tensor backend.
 ///
-/// Materializes the source matrix and performs full-pivoting LU
-/// decomposition via the faer library. Suitable for small to moderate
-/// matrices where full materialization is acceptable.
+/// Materializes the source matrix and performs dense pivot selection. Square
+/// matrices use tenferro's complete-pivoting LU; rectangular matrices fall
+/// back to the internal rrLU implementation until tenferro exposes rectangular
+/// complete pivoting.
 #[derive(Default)]
-pub struct DenseFaerLuKernel;
+pub struct DenseLuKernel;
 
-impl DenseFaerLuKernel {
+impl DenseLuKernel {
     fn is_no_truncation(options: &PivotKernelOptions, full_rank: usize) -> bool {
         options.max_rank >= full_rank && options.rel_tol == 0.0 && options.abs_tol == 0.0
-    }
-
-    fn compute_no_truncation_pivot_errors<T: Scalar>(
-        u: &faer::MatRef<'_, T>,
-        full_rank: usize,
-    ) -> Vec<f64> {
-        let mut pivot_errors = Vec::with_capacity(full_rank + 1);
-        for i in 0..full_rank {
-            let pivot_abs = u[(i, i)].abs_val();
-            if pivot_abs < f64::EPSILON {
-                if pivot_errors.is_empty() {
-                    pivot_errors.push(pivot_abs);
-                } else {
-                    pivot_errors.push(0.0);
-                }
-                return pivot_errors;
-            }
-            pivot_errors.push(pivot_abs);
-        }
-        pivot_errors.push(0.0);
-        pivot_errors
     }
 
     fn compute_pivot_errors(
@@ -106,11 +88,112 @@ impl DenseFaerLuKernel {
         accepted.push(last_error);
         accepted
     }
+
+    fn factorize_with_rrlu<T: Scalar + LegacyScalar>(
+        data: &[T],
+        nrows: usize,
+        ncols: usize,
+        options: &PivotKernelOptions,
+    ) -> Result<PivotSelectionCore> {
+        let mut rows = Vec::with_capacity(nrows);
+        for row in 0..nrows {
+            let mut values = Vec::with_capacity(ncols);
+            for col in 0..ncols {
+                values.push(data[row + nrows * col]);
+            }
+            rows.push(values);
+        }
+
+        let lu_options = RrLUOptions {
+            max_rank: options.max_rank,
+            rel_tol: options.rel_tol,
+            abs_tol: options.abs_tol,
+            left_orthogonal: options.left_orthogonal,
+        };
+        let lu = rrlu(&from_vec2d(rows), Some(lu_options)).map_err(|err| {
+            MatrixLuciError::InvalidArgument {
+                message: format!("dense rrLU factorization failed: {err}"),
+            }
+        })?;
+
+        Ok(PivotSelectionCore {
+            row_indices: lu.row_indices(),
+            col_indices: lu.col_indices(),
+            pivot_errors: lu.pivot_errors(),
+            rank: lu.npivots(),
+        })
+    }
+
+    fn tensor_slice<'a, T: TensorScalar>(tensor: &'a Tensor, name: &str) -> Result<&'a [T]> {
+        tensor
+            .as_slice::<T>()
+            .ok_or_else(|| MatrixLuciError::InvalidArgument {
+                message: format!("tenferro full_piv_lu returned unexpected dtype for {name}"),
+            })
+    }
+
+    fn permutation_indices_from_matrix<T: Scalar>(
+        data: &[T],
+        n: usize,
+        name: &str,
+    ) -> Result<Vec<usize>> {
+        let mut indices = Vec::with_capacity(n);
+        for row in 0..n {
+            let mut selected = None;
+            for col in 0..n {
+                if data[row + n * col].abs_val() > 0.5 {
+                    if selected.replace(col).is_some() {
+                        return Err(MatrixLuciError::InvalidArgument {
+                            message: format!("{name} permutation row {row} has multiple entries"),
+                        });
+                    }
+                }
+            }
+            indices.push(selected.ok_or_else(|| MatrixLuciError::InvalidArgument {
+                message: format!("{name} permutation row {row} has no entry"),
+            })?);
+        }
+        Ok(indices)
+    }
+
+    fn factorize_square_with_tenferro<T: Scalar + TensorScalar>(
+        data: &[T],
+        n: usize,
+        options: &PivotKernelOptions,
+    ) -> Result<PivotSelectionCore> {
+        let mut backend = CpuBackend::new();
+        let matrix = Tensor::from_vec(vec![n, n], data.to_vec());
+        let (p, _l, u, q, _parity) =
+            matrix
+                .full_piv_lu(&mut backend)
+                .map_err(|err| MatrixLuciError::InvalidArgument {
+                    message: format!("tenferro full_piv_lu failed: {err}"),
+                })?;
+
+        let u_values = Self::tensor_slice::<T>(&u, "U")?;
+        let diag_abs = (0..n)
+            .map(|i| u_values[i + n * i].abs_val())
+            .collect::<Vec<_>>();
+        let pivot_errors = Self::compute_pivot_errors(&diag_abs, n, n, options);
+        let rank = pivot_errors.len().saturating_sub(1);
+
+        let row_perm =
+            Self::permutation_indices_from_matrix(Self::tensor_slice::<T>(&p, "P")?, n, "P")?;
+        let col_perm =
+            Self::permutation_indices_from_matrix(Self::tensor_slice::<T>(&q, "Q")?, n, "Q")?;
+
+        Ok(PivotSelectionCore {
+            row_indices: row_perm[..rank].to_vec(),
+            col_indices: col_perm[..rank].to_vec(),
+            pivot_errors,
+            rank,
+        })
+    }
 }
 
 macro_rules! impl_dense_kernel {
     ($t:ty) => {
-        impl PivotKernel<$t> for DenseFaerLuKernel {
+        impl PivotKernel<$t> for DenseLuKernel {
             fn factorize<S: CandidateMatrixSource<$t>>(
                 &self,
                 source: &S,
@@ -119,31 +202,11 @@ macro_rules! impl_dense_kernel {
                 let run = |data: &[$t]| -> Result<PivotSelectionCore> {
                     let nrows = source.nrows();
                     let ncols = source.ncols();
-                    let mat = MatRef::from_column_major_slice(data, nrows, ncols);
-                    let lu = mat.full_piv_lu();
-
-                    let rank_cap = nrows.min(ncols);
-                    let u = lu.U();
-                    let pivot_errors = if DenseFaerLuKernel::is_no_truncation(options, rank_cap) {
-                        DenseFaerLuKernel::compute_no_truncation_pivot_errors(&u, rank_cap)
+                    if nrows == ncols {
+                        DenseLuKernel::factorize_square_with_tenferro(data, nrows, options)
                     } else {
-                        let mut diag_abs = Vec::with_capacity(rank_cap);
-                        for i in 0..rank_cap {
-                            diag_abs.push(u[(i, i)].abs_val());
-                        }
-                        DenseFaerLuKernel::compute_pivot_errors(&diag_abs, nrows, ncols, options)
-                    };
-                    let rank = pivot_errors.len().saturating_sub(1);
-
-                    let (row_fwd, _) = lu.P().arrays();
-                    let (col_fwd, _) = lu.Q().arrays();
-
-                    Ok(PivotSelectionCore {
-                        row_indices: row_fwd[..rank].to_vec(),
-                        col_indices: col_fwd[..rank].to_vec(),
-                        pivot_errors,
-                        rank,
-                    })
+                        DenseLuKernel::factorize_with_rrlu(data, nrows, ncols, options)
+                    }
                 };
 
                 if let Some(data) = source.dense_column_major_slice() {

--- a/crates/tensor4all-tcicore/src/matrixluci/dense.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/dense.rs
@@ -141,12 +141,10 @@ impl DenseLuKernel {
         for row in 0..n {
             let mut selected = None;
             for col in 0..n {
-                if data[row + n * col].abs_val() > 0.5 {
-                    if selected.replace(col).is_some() {
-                        return Err(MatrixLuciError::InvalidArgument {
-                            message: format!("{name} permutation row {row} has multiple entries"),
-                        });
-                    }
+                if data[row + n * col].abs_val() > 0.5 && selected.replace(col).is_some() {
+                    return Err(MatrixLuciError::InvalidArgument {
+                        message: format!("{name} permutation row {row} has multiple entries"),
+                    });
                 }
             }
             indices.push(selected.ok_or_else(|| MatrixLuciError::InvalidArgument {

--- a/crates/tensor4all-tcicore/src/matrixluci/dense/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/dense/tests.rs
@@ -1,4 +1,4 @@
-use crate::matrixluci::{DenseFaerLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions};
+use crate::matrixluci::{DenseLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions};
 use crate::{from_vec2d, rrlu, RrLUOptions};
 use approx::assert_abs_diff_eq;
 
@@ -6,7 +6,7 @@ use approx::assert_abs_diff_eq;
 fn dense_kernel_recovers_identity_pivots() {
     let src =
         DenseMatrixSource::from_column_major(&[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0], 3, 3);
-    let kernel = DenseFaerLuKernel;
+    let kernel = DenseLuKernel;
     let out = kernel
         .factorize(&src, &PivotKernelOptions::no_truncation())
         .unwrap();
@@ -18,7 +18,7 @@ fn dense_kernel_recovers_identity_pivots() {
 #[test]
 fn dense_kernel_reports_zero_rank_for_zero_matrix() {
     let src = DenseMatrixSource::from_column_major(&[0.0; 9], 3, 3);
-    let kernel = DenseFaerLuKernel;
+    let kernel = DenseLuKernel;
     let out = kernel
         .factorize(&src, &PivotKernelOptions::no_truncation())
         .unwrap();
@@ -45,7 +45,7 @@ fn dense_factorize(
     let ncols = rows.first().map_or(0, Vec::len);
     let data = col_major_from_rows(rows);
     let src = DenseMatrixSource::from_column_major(&data, nrows, ncols);
-    DenseFaerLuKernel.factorize(&src, &options).unwrap()
+    DenseLuKernel.factorize(&src, &options).unwrap()
 }
 
 fn assert_pivot_parity(

--- a/crates/tensor4all-tcicore/src/matrixluci/factors/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/factors/tests.rs
@@ -1,5 +1,5 @@
 use crate::matrixluci::{
-    CandidateMatrixSource, CrossFactors, DenseFaerLuKernel, DenseMatrixSource, PivotKernel,
+    CandidateMatrixSource, CrossFactors, DenseLuKernel, DenseMatrixSource, PivotKernel,
     PivotKernelOptions,
 };
 use approx::assert_abs_diff_eq;
@@ -30,7 +30,7 @@ fn assert_dense_eq(
 fn reconstruct_cross_factors_matches_selected_submatrices() {
     let data = test_matrix_data();
     let src = DenseMatrixSource::from_column_major(&data, 4, 4);
-    let selection = DenseFaerLuKernel
+    let selection = DenseLuKernel
         .factorize(&src, &PivotKernelOptions::default())
         .unwrap();
 
@@ -58,7 +58,7 @@ fn reconstruct_cross_factors_matches_selected_submatrices() {
 fn reconstruct_cross_factors_can_form_inverse_scaled_factors() {
     let data = test_matrix_data();
     let src = DenseMatrixSource::from_column_major(&data, 4, 4);
-    let selection = DenseFaerLuKernel
+    let selection = DenseLuKernel
         .factorize(&src, &PivotKernelOptions::default())
         .unwrap();
 

--- a/crates/tensor4all-tcicore/src/matrixluci/kernel.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/kernel.rs
@@ -1,8 +1,8 @@
 //! Pivot-kernel traits.
 //!
 //! The [`PivotKernel`] trait abstracts pivot selection strategies.
-//! Implementations include [`DenseFaerLuKernel`](super::DenseFaerLuKernel)
-//! (full-pivoting LU via faer) and
+//! Implementations include [`DenseLuKernel`](super::DenseLuKernel)
+//! (dense full-pivoting LU through the configured tensor backend) and
 //! [`LazyBlockRookKernel`](super::LazyBlockRookKernel) (residual-based
 //! rook search for lazy sources).
 

--- a/crates/tensor4all-tcicore/src/matrixluci/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/mod.rs
@@ -1,9 +1,9 @@
 #![warn(missing_docs)]
 //! Low-level LUCI / rrLU substrate.
 //!
-//! The dense LU path in this crate is a tensor4all-owned port derived from
-//! `faer` full-pivoting LU ideas and primitives. Keep that attribution explicit
-//! in user-facing documentation.
+//! The dense LU path materializes candidate matrices for exact pivot selection.
+//! It uses the configured tensor backend for square complete-pivoting LU and
+//! the internal rrLU implementation for rectangular fallback coverage.
 
 pub mod block_rook;
 pub mod dense;
@@ -15,7 +15,7 @@ pub mod source;
 pub mod types;
 
 pub use block_rook::LazyBlockRookKernel;
-pub use dense::DenseFaerLuKernel;
+pub use dense::DenseLuKernel;
 pub use error::{MatrixLuciError, Result};
 pub use factors::CrossFactors;
 pub use kernel::PivotKernel;

--- a/crates/tensor4all-tcicore/src/matrixluci/types.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/types.rs
@@ -9,7 +9,7 @@ use std::ops::{Index, IndexMut};
 /// Simple owned dense matrix in column-major layout.
 ///
 /// Unlike [`Matrix`](crate::Matrix) which is row-major, this type stores
-/// data in column-major order for compatibility with LAPACK/faer.
+/// data in column-major order for compatibility with dense linear algebra backends.
 /// Access elements with `m[[row, col]]`.
 #[derive(Debug, Clone)]
 pub struct DenseOwnedMatrix<T: Scalar> {

--- a/crates/tensor4all-tensorci/src/integration.rs
+++ b/crates/tensor4all-tensorci/src/integration.rs
@@ -10,7 +10,7 @@ use crate::error::{Result, TCIError};
 use crate::tensorci2::{crossinterpolate2, TCI2Options};
 use tensor4all_simplett::{AbstractTensorTrain, TTScalar};
 use tensor4all_tcicore::{
-    DenseFaerLuKernel, LazyBlockRookKernel, MatrixLuciScalar, MultiIndex, PivotKernel, Scalar,
+    DenseLuKernel, LazyBlockRookKernel, MatrixLuciScalar, MultiIndex, PivotKernel, Scalar,
 };
 
 /// Gauss-Kronrod 15-point rule: nodes on [-1, 1]
@@ -186,7 +186,7 @@ pub fn integrate<T, F>(
 ) -> Result<T>
 where
     T: Scalar + TTScalar + Default + MatrixLuciScalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     LazyBlockRookKernel: PivotKernel<T>,
     F: Fn(&[f64]) -> T,
 {

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -14,9 +14,8 @@ use tensor4all_tcicore::matrix::zeros;
 use tensor4all_tcicore::MultiIndex;
 use tensor4all_tcicore::Scalar;
 use tensor4all_tcicore::{
-    rrlu, AbstractMatrixCI, CrossFactors, DenseFaerLuKernel, DenseMatrixSource,
-    LazyBlockRookKernel, LazyMatrixSource, MatrixLUCI, PivotKernel, PivotKernelOptions,
-    RrLUOptions,
+    rrlu, AbstractMatrixCI, CrossFactors, DenseLuKernel, DenseMatrixSource, LazyBlockRookKernel,
+    LazyMatrixSource, MatrixLUCI, PivotKernel, PivotKernelOptions, RrLUOptions,
 };
 
 /// Configuration for the TCI2 algorithm ([`crossinterpolate2`]).
@@ -283,7 +282,7 @@ pub struct TensorCI2<T: Scalar + TTScalar> {
 impl<T> TensorCI2<T>
 where
     T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     LazyBlockRookKernel: PivotKernel<T>,
 {
     /// Create a new empty TensorCI2
@@ -980,7 +979,7 @@ pub fn crossinterpolate2<T, F, B>(
 ) -> Result<(TensorCI2<T>, Vec<usize>, Vec<f64>)>
 where
     T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     LazyBlockRookKernel: PivotKernel<T>,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
@@ -1178,7 +1177,7 @@ fn update_pivots<T, F, B>(
 ) -> Result<()>
 where
     T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     LazyBlockRookKernel: PivotKernel<T>,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
@@ -1258,7 +1257,7 @@ where
             }
         }
         let source = DenseMatrixSource::from_column_major(&data, pi.nrows(), pi.ncols());
-        selection = DenseFaerLuKernel.factorize(&source, &lu_options)?;
+        selection = DenseLuKernel.factorize(&source, &lu_options)?;
         factors = CrossFactors::from_source(&source, &selection)?;
     } else {
         let evaluator = LazyPiEvaluator::new(

--- a/crates/tensor4all-treetci/Cargo.toml
+++ b/crates/tensor4all-treetci/Cargo.toml
@@ -14,9 +14,9 @@ description = "Tree Tensor Cross Interpolation on tree graphs"
 anyhow.workspace = true
 thiserror.workspace = true
 petgraph.workspace = true
-faer.workspace = true
 num-complex.workspace = true
 rand.workspace = true
+tenferro-tensor.workspace = true
 tensor4all-core = { path = "../tensor4all-core" }
 tensor4all-tcicore = { path = "../tensor4all-tcicore" }
 tensor4all-treetn = { path = "../tensor4all-treetn" }

--- a/crates/tensor4all-treetci/src/api.rs
+++ b/crates/tensor4all-treetci/src/api.rs
@@ -84,7 +84,7 @@ pub fn crossinterpolate2<T, F, P>(
 ) -> Result<TreeTciRunResult>
 where
     T: FullPivLuScalar,
-    tensor4all_tcicore::DenseFaerLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {

--- a/crates/tensor4all-treetci/src/materialize.rs
+++ b/crates/tensor4all-treetci/src/materialize.rs
@@ -3,16 +3,15 @@ use crate::{
     assemble_global_point, GlobalIndexBatch, SubtreeKey, TreeTCI2, TreeTciEdge,
 };
 use anyhow::{ensure, Result};
-use faer::prelude::Solve;
-use faer::MatRef;
 use num_complex::{Complex32, Complex64};
 use std::collections::HashMap;
+use tenferro_tensor::{cpu::CpuBackend, Tensor, TensorScalar};
 use tensor4all_core::{ColMajorArray, DynIndex, TensorDynLen, TensorElement};
 use tensor4all_tcicore::MatrixLuciScalar as Scalar;
 use tensor4all_treetn::TreeTN;
 
 #[doc(hidden)]
-pub trait FullPivLuScalar: Scalar + TensorElement {
+pub trait FullPivLuScalar: Scalar + TensorElement + TensorScalar {
     fn solve_right_full_piv_lu(
         lhs_values: &[Self],
         lhs_rows: usize,
@@ -51,18 +50,15 @@ macro_rules! impl_full_piv_lu_scalar {
 
                 let lhs_t = transpose_column_major(lhs_values, lhs_rows, lhs_cols);
                 let pivot_t = transpose_column_major(pivot_values, pivot_rows, pivot_cols);
-                let lu =
-                    MatRef::from_column_major_slice(&pivot_t, pivot_cols, pivot_rows).full_piv_lu();
-                let solved_t =
-                    lu.solve(MatRef::from_column_major_slice(&lhs_t, lhs_cols, lhs_rows));
+                let mut backend = CpuBackend::new();
+                let pivot_tensor = Tensor::from_vec(vec![pivot_cols, pivot_rows], pivot_t);
+                let lhs_tensor = Tensor::from_vec(vec![lhs_cols, lhs_rows], lhs_t);
+                let solved_t = pivot_tensor.full_piv_lu_solve(&lhs_tensor, &mut backend)?;
 
-                let mut solved_t_values = vec![<$t as Scalar>::from_f64(0.0); lhs_rows * lhs_cols];
-                for col in 0..lhs_rows {
-                    for row in 0..lhs_cols {
-                        solved_t_values[row + lhs_cols * col] = solved_t[(row, col)];
-                    }
-                }
-                Ok(transpose_column_major(&solved_t_values, lhs_cols, lhs_rows))
+                let solved_t_values = solved_t.as_slice::<Self>().ok_or_else(|| {
+                    anyhow::anyhow!("full_piv_lu_solve returned unexpected dtype")
+                })?;
+                Ok(transpose_column_major(solved_t_values, lhs_cols, lhs_rows))
             }
         }
     };

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use tensor4all_tcicore::{
-    DenseFaerLuKernel, MatrixLuciScalar as Scalar, PivotKernel, PivotKernelOptions,
+    DenseLuKernel, MatrixLuciScalar as Scalar, PivotKernel, PivotKernelOptions,
 };
 
 /// MVP optimization options for TreeTCI.
@@ -131,7 +131,7 @@ pub fn optimize_default<T, F>(
 ) -> Result<(Vec<usize>, Vec<f64>)>
 where
     T: Scalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
     optimize_with_proposer(state, evaluate, options, &crate::DefaultProposer)
@@ -186,7 +186,7 @@ pub fn optimize_with_proposer<T, F, P>(
 ) -> Result<(Vec<usize>, Vec<f64>)>
 where
     T: Scalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {

--- a/crates/tensor4all-treetci/src/update.rs
+++ b/crates/tensor4all-treetci/src/update.rs
@@ -7,8 +7,8 @@ use crate::{
 use anyhow::{ensure, Result};
 use tensor4all_core::ColMajorArray;
 use tensor4all_tcicore::{
-    DenseFaerLuKernel, DenseMatrixSource, MatrixLuciScalar as Scalar, PivotKernel,
-    PivotKernelOptions, PivotSelectionCore,
+    DenseLuKernel, DenseMatrixSource, MatrixLuciScalar as Scalar, PivotKernel, PivotKernelOptions,
+    PivotSelectionCore,
 };
 
 /// Update one edge bipartition using a batch evaluator and a pivot-candidate proposer.
@@ -28,7 +28,7 @@ pub fn update_edge<T, F, P>(
 ) -> Result<PivotSelectionCore>
 where
     T: Scalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
@@ -52,7 +52,7 @@ where
         left_candidates.len(),
         right_candidates.len(),
     );
-    let selection = DenseFaerLuKernel.factorize(&source, options)?;
+    let selection = DenseLuKernel.factorize(&source, options)?;
 
     // Build ColMajorArray from selected pivot indices
     let n_left_sites = left_key.as_slice().len();
@@ -93,7 +93,7 @@ pub fn update_edge_default<T, F>(
 ) -> Result<PivotSelectionCore>
 where
     T: Scalar,
-    DenseFaerLuKernel: PivotKernel<T>,
+    DenseLuKernel: PivotKernel<T>,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
     update_edge(state, edge, evaluate, options, &DefaultProposer)

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -16,7 +16,6 @@ num-complex.workspace = true
 dyn-clone.workspace = true
 rand.workspace = true
 kryst.workspace = true
-faer = { workspace = true }
 
 [dev-dependencies]
 rand_chacha.workspace = true


### PR DESCRIPTION
## Summary
- update `tenferro-rs` to `a523dbcbd1fd50055378b7c1685ff869db0f95f0` and remove the direct workspace `faer` dependency
- route dense square full-pivoting LU and TreeTCI solve paths through `tenferro-tensor`
- rename `DenseFaerLuKernel` to `DenseLuKernel` and update related benchmarks/tests/docs API output
- keep rectangular dense pivot selection on the existing internal rrLU path until tenferro exposes rectangular complete pivoting

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo run -p api-dump --release -- . -o docs/api`
- `cargo test --release -p tensor4all-tcicore`
- `cargo test --release -p tensor4all-treetci`

Closes #476