### PR TITLE
Add tenferro provider-inject feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a523dbcbd1fd50055378b7c1685ff869db0f95f0" }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393", default-features = false }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393", default-features = false }

--- a/crates/tensor4all-capi/Cargo.toml
+++ b/crates/tensor4all-capi/Cargo.toml
@@ -7,14 +7,27 @@ license.workspace = true
 repository.workspace = true
 description = "C API for tensor4all (Rust) core types"
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-quanticstransform/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-quanticstransform/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
+]
+
 [lib]
 name = "tensor4all_capi"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-treetn = { path = "../tensor4all-treetn" }
-tensor4all-quanticstransform = { path = "../tensor4all-quanticstransform" }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
+tensor4all-quanticstransform = { path = "../tensor4all-quanticstransform", default-features = false }
 libc.workspace = true
 paste.workspace = true
 num-complex.workspace = true

--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -8,12 +8,24 @@ repository.workspace = true
 description = "Core tensor types, indices, and operations (SVD, QR, contraction) for tensor4all"
 
 [features]
-default = ["backend-tenferro"]
+default = ["backend-tenferro", "tenferro-cpu-faer"]
 backend-tenferro = ["tensor4all-tensorbackend/backend-tenferro"]
+tenferro-cpu-faer = [
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tenferro/cpu-faer",
+    "tenferro-tensor/cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tenferro/cpu-blas",
+    "tenferro-tensor/provider-inject",
+]
 
 [dependencies]
-tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
-tensor4all-tcicore = { path = "../tensor4all-tcicore" }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
 num-complex.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -1,6 +1,91 @@
 use super::*;
+use crate::{DynIndex, TensorDynLen};
 
 // Compile-time check that TensorLike requires Sized (no dyn TensorLike)
 fn _assert_sized<T: TensorLike>() {
     // This confirms T: Sized is required
+}
+
+#[test]
+fn factorize_options_builders_and_validation_accept_supported_fields() {
+    let svd = FactorizeOptions::svd()
+        .with_canonical(Canonical::Right)
+        .with_svd_policy(SvdTruncationPolicy::new(1.0e-8))
+        .with_max_rank(4);
+    assert_eq!(svd.alg, FactorizeAlg::SVD);
+    assert_eq!(svd.canonical, Canonical::Right);
+    assert_eq!(svd.max_rank, Some(4));
+    assert_eq!(svd.svd_policy, Some(SvdTruncationPolicy::new(1.0e-8)));
+    svd.validate().unwrap();
+
+    let qr = FactorizeOptions::qr().with_qr_rtol(0.0).with_max_rank(3);
+    assert_eq!(qr.alg, FactorizeAlg::QR);
+    assert_eq!(qr.qr_rtol, Some(0.0));
+    assert_eq!(qr.max_rank, Some(3));
+    qr.validate().unwrap();
+
+    let lu = FactorizeOptions::lu();
+    assert_eq!(lu.alg, FactorizeAlg::LU);
+    lu.validate().unwrap();
+
+    let ci = FactorizeOptions::ci();
+    assert_eq!(ci.alg, FactorizeAlg::CI);
+    ci.validate().unwrap();
+}
+
+#[test]
+fn factorize_options_validation_rejects_algorithm_specific_mismatches() {
+    assert!(matches!(
+        FactorizeOptions::svd().with_qr_rtol(1.0e-8).validate(),
+        Err(FactorizeError::InvalidOptions(
+            "SVD factorization does not accept qr_rtol"
+        ))
+    ));
+    assert!(matches!(
+        FactorizeOptions::qr()
+            .with_svd_policy(SvdTruncationPolicy::new(1.0e-8))
+            .validate(),
+        Err(FactorizeError::InvalidOptions(
+            "QR factorization does not accept svd_policy"
+        ))
+    ));
+    assert!(matches!(
+        FactorizeOptions::lu()
+            .with_svd_policy(SvdTruncationPolicy::new(1.0e-8))
+            .validate(),
+        Err(FactorizeError::InvalidOptions(
+            "LU/CI factorization does not accept svd_policy"
+        ))
+    ));
+    assert!(matches!(
+        FactorizeOptions::ci().with_qr_rtol(1.0e-8).validate(),
+        Err(FactorizeError::InvalidOptions(
+            "LU/CI factorization does not accept qr_rtol"
+        ))
+    ));
+}
+
+#[test]
+fn linearization_order_labels_are_stable() {
+    assert_eq!(LinearizationOrder::ColumnMajor.as_str(), "column-major");
+    assert_eq!(LinearizationOrder::RowMajor.as_str(), "row-major");
+}
+
+#[test]
+fn tensor_like_default_neg_and_delta_helpers_work() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+    let k = DynIndex::new_dyn(2);
+    let l = DynIndex::new_dyn(3);
+
+    let tensor = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, -3.0]).unwrap();
+    let negated = tensor.neg().unwrap();
+    assert_eq!(negated.to_vec::<f64>().unwrap(), vec![-2.0, 3.0]);
+
+    let delta = TensorDynLen::delta(&[i.clone(), j.clone()], &[k, l]).unwrap();
+    assert_eq!(delta.dims(), vec![2, 2, 3, 3]);
+    assert!((delta.sum().real() - 6.0).abs() < 1.0e-12);
+
+    let err = TensorDynLen::delta(&[i], &[]).unwrap_err();
+    assert!(err.to_string().contains("Number of input indices"));
 }

--- a/crates/tensor4all-hdf5/Cargo.toml
+++ b/crates/tensor4all-hdf5/Cargo.toml
@@ -7,13 +7,21 @@ license.workspace = true
 description = "HDF5 serialization for tensor4all-rs (ITensors.jl compatible format)"
 
 [features]
-default = ["link"]
+default = ["link", "tenferro-cpu-faer"]
 link = ["dep:hdf5-metno"]
 runtime-loading = ["dep:hdf5-rt"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-itensorlike/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-itensorlike/tenferro-provider-inject",
+]
 
 [dependencies]
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-itensorlike = { path = "../tensor4all-itensorlike" }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-itensorlike = { path = "../tensor4all-itensorlike", default-features = false }
 hdf5-metno = { workspace = true, default-features = false, features = ["complex"], optional = true }
 hdf5-rt = { workspace = true, default-features = false, features = ["complex"], optional = true }
 num-complex = { workspace = true }

--- a/crates/tensor4all-itensorlike/Cargo.toml
+++ b/crates/tensor4all-itensorlike/Cargo.toml
@@ -10,9 +10,20 @@ readme = "README.md"
 keywords = ["tensor", "itensor", "tensor-network"]
 categories = ["science", "mathematics"]
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
+]
+
 [dependencies]
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-treetn = { path = "../tensor4all-treetn" }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
 num-complex.workspace = true
 thiserror.workspace = true
 petgraph.workspace = true
@@ -21,4 +32,4 @@ anyhow.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
-tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false, features = ["tenferro-cpu-faer"] }

--- a/crates/tensor4all-partitionedtt/Cargo.toml
+++ b/crates/tensor4all-partitionedtt/Cargo.toml
@@ -7,13 +7,24 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-itensorlike/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-itensorlike/tenferro-provider-inject",
+]
+
 [dependencies]
 num-complex.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-itensorlike = { path = "../tensor4all-itensorlike" }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-itensorlike = { path = "../tensor4all-itensorlike", default-features = false }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-quanticstci/Cargo.toml
+++ b/crates/tensor4all-quanticstci/Cargo.toml
@@ -11,12 +11,29 @@ license.workspace = true
 repository.workspace = true
 description = "High-level Quantics TCI interface for function interpolation"
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-simplett/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tensor4all-treetci/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-simplett/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tensor4all-treetci/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
+]
+
 [dependencies]
-tensor4all-tcicore = { path = "../tensor4all-tcicore" }
-tensor4all-treetci = { path = "../tensor4all-treetci" }
-tensor4all-simplett = { path = "../tensor4all-simplett" }
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-treetn = { path = "../tensor4all-treetn" }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-treetci = { path = "../tensor4all-treetci", default-features = false }
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
 quanticsgrids.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true
@@ -25,4 +42,4 @@ rand.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
-tensor4all-quanticstransform = { path = "../tensor4all-quanticstransform" }
+tensor4all-quanticstransform = { path = "../tensor4all-quanticstransform", default-features = false, features = ["tenferro-cpu-faer"] }

--- a/crates/tensor4all-quanticstransform/Cargo.toml
+++ b/crates/tensor4all-quanticstransform/Cargo.toml
@@ -14,10 +14,23 @@ license.workspace = true
 repository.workspace = true
 description = "Quantics transformation operators for tensor train methods"
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-simplett/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-simplett/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
+]
+
 [dependencies]
-tensor4all-treetn = { path = "../tensor4all-treetn" }
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-simplett = { path = "../tensor4all-simplett" }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
 quanticsgrids.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true

--- a/crates/tensor4all-simplett/Cargo.toml
+++ b/crates/tensor4all-simplett/Cargo.toml
@@ -12,8 +12,22 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["backend-tenferro"]
+default = ["backend-tenferro", "tenferro-cpu-faer"]
 backend-tenferro = ["tensor4all-tensorbackend/backend-tenferro"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+    "tenferro-einsum/cpu-faer",
+    "tenferro-tensor/cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+    "tenferro-einsum/cpu-blas",
+    "tenferro-tensor/provider-inject",
+]
 
 [dependencies]
 num-complex.workspace = true
@@ -22,9 +36,9 @@ anyhow.workspace = true
 thiserror.workspace = true
 rand.workspace = true
 bnum.workspace = true
-tensor4all-tcicore = { path = "../tensor4all-tcicore" }
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 tenferro-einsum.workspace = true
 tenferro-tensor.workspace = true
 

--- a/crates/tensor4all-tcicore/Cargo.toml
+++ b/crates/tensor4all-tcicore/Cargo.toml
@@ -7,6 +7,19 @@ authors = ["tensor4all contributors"]
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+    "tenferro-einsum/cpu-faer",
+    "tenferro-tensor/cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+    "tenferro-einsum/cpu-blas",
+    "tenferro-tensor/provider-inject",
+]
+
 [dependencies]
 num-complex.workspace = true
 num-traits.workspace = true
@@ -17,13 +30,13 @@ paste.workspace = true
 bnum.workspace = true
 tenferro-einsum.workspace = true
 tenferro-tensor.workspace = true
-tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend" }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 
 [dev-dependencies]
 approx.workspace = true
 criterion.workspace = true
 rand_chacha.workspace = true
-tensor4all-tensorci = { path = "../tensor4all-tensorci" }
+tensor4all-tensorci = { path = "../tensor4all-tensorci", default-features = false, features = ["tenferro-cpu-faer"] }
 uint.workspace = true
 
 [[bench]]

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -10,8 +10,10 @@ keywords = ["tensor", "storage", "backend", "linear-algebra"]
 categories = ["science", "mathematics"]
 
 [features]
-default = ["backend-tenferro"]
+default = ["backend-tenferro", "tenferro-cpu-faer"]
 backend-tenferro = []
+tenferro-cpu-faer = ["tenferro/cpu-faer"]
+tenferro-provider-inject = ["tenferro/cpu-blas", "tenferro-tensor/provider-inject"]
 einsum-dispatch-profile = []
 
 [dependencies]

--- a/crates/tensor4all-tensorci/Cargo.toml
+++ b/crates/tensor4all-tensorci/Cargo.toml
@@ -7,14 +7,25 @@ authors = ["Marc Ritter <Ritter.Marc@physik.uni-muenchen.de>", "Hiroshi Shinaoka
 license.workspace = true
 repository.workspace = true
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-simplett/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-simplett/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+]
+
 [dependencies]
 num-complex.workspace = true
 num-traits.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 rand.workspace = true
-tensor4all-tcicore = { path = "../tensor4all-tcicore" }
-tensor4all-simplett = { path = "../tensor4all-simplett" }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-treetci/Cargo.toml
+++ b/crates/tensor4all-treetci/Cargo.toml
@@ -10,6 +10,21 @@ license.workspace = true
 repository.workspace = true
 description = "Tree Tensor Cross Interpolation on tree graphs"
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
+    "tenferro-tensor/cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
+    "tenferro-tensor/provider-inject",
+]
+
 [dependencies]
 anyhow.workspace = true
 thiserror.workspace = true
@@ -17,9 +32,9 @@ petgraph.workspace = true
 num-complex.workspace = true
 rand.workspace = true
 tenferro-tensor.workspace = true
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-tcicore = { path = "../tensor4all-tcicore" }
-tensor4all-treetn = { path = "../tensor4all-treetn" }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -7,9 +7,20 @@ license.workspace = true
 repository.workspace = true
 description = "Tree tensor networks with arbitrary graph topology for tensor4all"
 
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-simplett/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-simplett/tenferro-provider-inject",
+]
+
 [dependencies]
-tensor4all-core = { path = "../tensor4all-core" }
-tensor4all-simplett = { path = "../tensor4all-simplett" }
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
 petgraph.workspace = true
 anyhow.workspace = true
 num-complex.workspace = true

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -763,7 +763,7 @@ where
                 canonical: Canonical::Left,
                 max_rank: None,
                 svd_policy: None,
-                qr_rtol: None,
+                qr_rtol: Some(0.0),
             };
 
             let factorize_result = remaining_tensor
@@ -830,7 +830,7 @@ where
                 canonical: Canonical::Left,
                 max_rank: None,
                 svd_policy: None,
-                qr_rtol: None,
+                qr_rtol: Some(0.0),
             };
 
             let factorize_result = remaining_tensor

--- a/crates/tensor4all-treetn/tests/unfuse.rs
+++ b/crates/tensor4all-treetn/tests/unfuse.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use tensor4all_core::{DynIndex, IndexLike, LinearizationOrder, TensorDynLen};
-use tensor4all_treetn::TreeTN;
+use tensor4all_treetn::{SiteIndexNetwork, TreeTN};
 
 #[test]
 fn replace_site_index_with_indices_preserves_dense_tensor_values() {
@@ -30,4 +30,39 @@ fn replace_site_index_with_indices_preserves_dense_tensor_values() {
     assert_eq!(site_indices.len(), 2);
     assert!(site_id_set.contains(left.id()));
     assert!(site_id_set.contains(right.id()));
+}
+
+#[test]
+fn split_to_preserves_sparse_tensor_with_zero_leading_qr_row() {
+    let out0 = DynIndex::new_dyn(2);
+    let out1 = DynIndex::new_dyn(2);
+    let in0 = DynIndex::new_dyn(2);
+    let in1 = DynIndex::new_dyn(2);
+
+    let mut data = vec![0.0; 16];
+    data[6] = 1.0;
+    let tensor = TensorDynLen::from_dense(
+        vec![out0.clone(), out1.clone(), in0.clone(), in1.clone()],
+        data,
+    )
+    .unwrap();
+    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+
+    let mut target = SiteIndexNetwork::<usize, DynIndex>::new();
+    target
+        .add_node(0, HashSet::from([out0.clone(), in0.clone()]))
+        .unwrap();
+    target
+        .add_node(1, HashSet::from([out1.clone(), in1.clone()]))
+        .unwrap();
+    target.add_edge(&0, &1).unwrap();
+
+    let split = tn.split_to(&target, &Default::default()).unwrap();
+    let dense = split.contract_to_tensor().unwrap();
+    let expected = tn.contract_to_tensor().unwrap();
+
+    assert!(
+        dense.distance(&expected) < 1.0e-12,
+        "exact split_to must not drop rows when QR produces a zero leading row"
+    );
 }

--- a/docs/tutorial-code/src/bin/qtt_affine.rs
+++ b/docs/tutorial-code/src/bin/qtt_affine.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .with_tolerance(config.tolerance)
         .with_maxbonddim(config.maxbonddim)
         .with_maxiter(config.maxiter)
-        .with_nrandominitpivot(5)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Fused)
         .with_verbosity(0);
 
@@ -41,8 +41,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         let v = (grid_1based[1] - 1) as usize;
         source_function(u, v, n)
     };
-    let (source, _ranks, _errors) =
-        quanticscrossinterpolate_discrete(&source_grid, source_callback, None, source_options)?;
+    let initial_pivots = vec![
+        vec![1, 1],
+        vec![(n / 2) as i64, (n / 2) as i64],
+        vec![n as i64, n as i64],
+    ];
+    let (source, _ranks, _errors) = quanticscrossinterpolate_discrete(
+        &source_grid,
+        source_callback,
+        Some(initial_pivots),
+        source_options,
+    )?;
 
     // `AffineParams::from_integers(...)` encodes the affine map used in the tutorial.
     let affine_params = AffineParams::from_integers(vec![1, 0, 1, 1], vec![0, 0], 2, 2)?;

--- a/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
+++ b/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
@@ -232,7 +232,7 @@ where
     let options = QtciOptions::default()
         .with_tolerance(TOLERANCE)
         .with_maxbonddim(MAX_BOND_DIM)
-        .with_nrandominitpivot(3)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
@@ -243,8 +243,13 @@ where
         target_fn(x)
     };
 
+    let initial_pivots = vec![vec![2], vec![(NPOINTS / 2) as i64], vec![NPOINTS as i64]];
+
     Ok(quanticscrossinterpolate_discrete(
-        &sizes, callback, None, options,
+        &sizes,
+        callback,
+        Some(initial_pivots),
+        options,
     )?)
 }
 

--- a/docs/tutorial-code/src/bin/qtt_function.rs
+++ b/docs/tutorial-code/src/bin/qtt_function.rs
@@ -95,12 +95,12 @@ where
     let sizes = [NPOINTS];
 
     // The options below mirror the notebook-style workflow: a tight tolerance,
-    // a reasonable maximum bond dimension, and a small number of random initial
-    // pivots to stabilize interpolation.
+    // a reasonable maximum bond dimension, and deterministic initial pivots so
+    // tutorial smoke tests are reproducible.
     let options = QtciOptions::default()
         .with_tolerance(TOLERANCE)
         .with_maxbonddim(MAX_BOND_DIM)
-        .with_nrandominitpivot(3)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
@@ -111,7 +111,14 @@ where
         target_fn(x)
     };
 
-    Ok(quanticscrossinterpolate_discrete(&sizes, f, None, options)?)
+    let initial_pivots = vec![vec![2], vec![(NPOINTS / 2) as i64], vec![NPOINTS as i64]];
+
+    Ok(quanticscrossinterpolate_discrete(
+        &sizes,
+        f,
+        Some(initial_pivots),
+        options,
+    )?)
 }
 
 /// Default target function used by the demo.

--- a/docs/tutorial-code/src/bin/qtt_multivariate.rs
+++ b/docs/tutorial-code/src/bin/qtt_multivariate.rs
@@ -15,7 +15,7 @@ use tensor4all_quanticstci::{
 use tensor4all_tutorial_code::output_paths;
 use tensor4all_tutorial_code::qtt_multivariate_common::{
     collect_bond_dims, collect_samples, print_summary, write_bond_dims_csv, write_samples_csv,
-    LayoutSummary, MultivariateTutorialConfig, DEFAULT_MULTIVARIATE_CONFIG, N_RANDOM_INIT_PIVOT,
+    LayoutSummary, MultivariateTutorialConfig, DEFAULT_MULTIVARIATE_CONFIG,
 };
 
 const BITS_ENV: &str = "QTT_MULTIVARIATE_BITS";
@@ -89,18 +89,28 @@ fn main() -> Result<(), Box<dyn Error>> {
         .with_tolerance(config.tolerance)
         .with_maxbonddim(config.maxbonddim)
         .with_maxiter(config.maxiter)
-        .with_nrandominitpivot(N_RANDOM_INIT_PIVOT)
+        .with_nrandominitpivot(0)
         .with_verbosity(0);
 
     // `quanticscrossinterpolate` receives physical coordinates from the grid.
     let target = |coords: &[f64]| -> f64 { multivariate_target(coords[0], coords[1]) };
+    let npoints = 1_i64 << config.bits;
+    let initial_pivots = vec![
+        vec![1, 1],
+        vec![npoints / 2, npoints / 2],
+        vec![npoints, npoints],
+    ];
 
     // Build two QTT approximations of the same physical function using different layouts.
-    let (interleaved, interleaved_ranks, interleaved_errors) =
-        quanticscrossinterpolate(&interleaved_grid, target, None, options.clone())?;
+    let (interleaved, interleaved_ranks, interleaved_errors) = quanticscrossinterpolate(
+        &interleaved_grid,
+        target,
+        Some(initial_pivots.clone()),
+        options.clone(),
+    )?;
 
     let (grouped, grouped_ranks, grouped_errors) =
-        quanticscrossinterpolate(&grouped_grid, target, None, options)?;
+        quanticscrossinterpolate(&grouped_grid, target, Some(initial_pivots), options)?;
 
     // Reconstruct both QTTs on the full Cartesian grid for heatmaps and error plots.
     let samples = collect_samples(&interleaved, &grouped, multivariate_target)?;

--- a/docs/tutorial-code/src/bin/qtt_r_sweep.rs
+++ b/docs/tutorial-code/src/bin/qtt_r_sweep.rs
@@ -140,7 +140,7 @@ where
     let options = QtciOptions::default()
         .with_tolerance(TOLERANCE)
         .with_maxbonddim(MAX_BOND_DIM)
-        .with_nrandominitpivot(3)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
@@ -150,8 +150,13 @@ where
         target_fn(x)
     };
 
+    let initial_pivots = vec![vec![2], vec![(npoints / 2) as i64], vec![npoints as i64]];
+
     Ok(quanticscrossinterpolate_discrete(
-        &sizes, callback, None, options,
+        &sizes,
+        callback,
+        Some(initial_pivots),
+        options,
     )?)
 }
 

--- a/docs/tutorial-code/src/qtt_affine_common.rs
+++ b/docs/tutorial-code/src/qtt_affine_common.rs
@@ -75,8 +75,6 @@ pub type AffineTransformOutput = (TreeTN<TensorDynLen, usize>, Vec<SiteIndex>);
 /// Result of building the source QTT.
 pub type AffineQttOutput = (QuanticsTensorCI2<f64>, Vec<usize>, Vec<f64>);
 
-const N_RANDOM_INIT_PIVOT: usize = 5;
-
 /// Number of grid points per direction.
 pub fn point_count(bits: usize) -> usize {
     1usize << bits
@@ -115,7 +113,7 @@ pub fn build_source_qtt(config: &AffineTutorialConfig) -> Result<AffineQttOutput
         .with_tolerance(config.tolerance)
         .with_maxbonddim(config.maxbonddim)
         .with_maxiter(config.maxiter)
-        .with_nrandominitpivot(N_RANDOM_INIT_PIVOT)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Fused)
         .with_verbosity(0);
 
@@ -125,8 +123,17 @@ pub fn build_source_qtt(config: &AffineTutorialConfig) -> Result<AffineQttOutput
         source_function(u, v, n)
     };
 
+    let initial_pivots = vec![
+        vec![1, 1],
+        vec![(n / 2) as i64, (n / 2) as i64],
+        vec![n as i64, n as i64],
+    ];
+
     Ok(quanticscrossinterpolate_discrete(
-        &sizes, callback, None, options,
+        &sizes,
+        callback,
+        Some(initial_pivots),
+        options,
     )?)
 }
 

--- a/docs/tutorial-code/src/qtt_fourier_common.rs
+++ b/docs/tutorial-code/src/qtt_fourier_common.rs
@@ -45,7 +45,6 @@ pub const DEFAULT_FOURIER_CONFIG: FourierTutorialConfig = FourierTutorialConfig 
     maxbonddim: 32,
 };
 
-const N_RANDOM_INIT_PIVOT: usize = 3;
 /// QTT construction result returned by the Fourier helper.
 pub type FourierQttOutput = (QuanticsTensorCI2<f64>, Vec<usize>, Vec<f64>);
 /// Transformed Fourier state and the site indices needed for evaluation.
@@ -111,12 +110,20 @@ pub fn build_gaussian_qtt(
     let options = QtciOptions::default()
         .with_tolerance(config.tolerance)
         .with_maxbonddim(config.maxbonddim)
-        .with_nrandominitpivot(N_RANDOM_INIT_PIVOT)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
     let f = |coords: &[f64]| -> f64 { gaussian_target(coords[0]) };
-    Ok(quanticscrossinterpolate(grid, f, None, options)?)
+    let npoints = 1_i64 << config.bits;
+    let initial_pivots = vec![vec![1], vec![npoints / 2], vec![npoints]];
+
+    Ok(quanticscrossinterpolate(
+        grid,
+        f,
+        Some(initial_pivots),
+        options,
+    )?)
 }
 
 /// Build the quantics Fourier operator.

--- a/docs/tutorial-code/src/qtt_interval_common.rs
+++ b/docs/tutorial-code/src/qtt_interval_common.rs
@@ -63,7 +63,7 @@ pub fn build_interval_grid(
 pub fn build_interval_qtt<F>(
     grid: &DiscretizedGrid,
     target_fn: F,
-    _config: &IntervalTutorialConfig,
+    config: &IntervalTutorialConfig,
 ) -> Result<IntervalQttOutput, Box<dyn Error>>
 where
     F: Fn(f64) -> f64 + 'static,
@@ -71,11 +71,18 @@ where
     let options = QtciOptions::default()
         .with_tolerance(TOLERANCE)
         .with_maxbonddim(MAX_BOND_DIM)
-        .with_nrandominitpivot(3)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
     let f = move |coords: &[f64]| -> f64 { target_fn(coords[0]) };
+    let npoints = 1_i64 << config.bits;
+    let initial_pivots = vec![vec![1], vec![npoints / 2], vec![npoints]];
 
-    Ok(quanticscrossinterpolate(grid, f, None, options)?)
+    Ok(quanticscrossinterpolate(
+        grid,
+        f,
+        Some(initial_pivots),
+        options,
+    )?)
 }

--- a/docs/tutorial-code/src/qtt_multivariate_common.rs
+++ b/docs/tutorial-code/src/qtt_multivariate_common.rs
@@ -45,8 +45,6 @@ pub fn point_count(config: &MultivariateTutorialConfig) -> usize {
     1usize << config.bits
 }
 
-pub const N_RANDOM_INIT_PIVOT: usize = 5;
-
 /// Build the two-dimensional discretized grid used by the tutorial.
 pub fn build_multivariate_grid(
     config: &MultivariateTutorialConfig,
@@ -73,11 +71,23 @@ where
         .with_tolerance(config.tolerance)
         .with_maxbonddim(config.maxbonddim)
         .with_maxiter(config.maxiter)
-        .with_nrandominitpivot(N_RANDOM_INIT_PIVOT)
+        .with_nrandominitpivot(0)
         .with_verbosity(0);
 
     let f = move |coords: &[f64]| -> f64 { target_fn(coords[0], coords[1]) };
-    Ok(quanticscrossinterpolate(grid, f, None, options)?)
+    let npoints = point_count(config) as i64;
+    let initial_pivots = vec![
+        vec![1, 1],
+        vec![npoints / 2, npoints / 2],
+        vec![npoints, npoints],
+    ];
+
+    Ok(quanticscrossinterpolate(
+        grid,
+        f,
+        Some(initial_pivots),
+        options,
+    )?)
 }
 
 /// One sample row in the exported dense table.

--- a/docs/tutorial-code/tests/verification.rs
+++ b/docs/tutorial-code/tests/verification.rs
@@ -95,7 +95,7 @@ fn build_function_qtt(target_fn: fn(f64) -> f64) -> Result<QttDemoOutput, Box<dy
     let options = QtciOptions::default()
         .with_tolerance(FUNCTION_TOLERANCE)
         .with_maxbonddim(FUNCTION_MAX_BOND_DIM)
-        .with_nrandominitpivot(3)
+        .with_nrandominitpivot(0)
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
@@ -104,8 +104,17 @@ fn build_function_qtt(target_fn: fn(f64) -> f64) -> Result<QttDemoOutput, Box<dy
         target_fn(x)
     };
 
+    let initial_pivots = vec![
+        vec![1],
+        vec![(FUNCTION_NPOINTS / 2) as i64],
+        vec![FUNCTION_NPOINTS as i64],
+    ];
+
     Ok(quanticscrossinterpolate_discrete(
-        &sizes, callback, None, options,
+        &sizes,
+        callback,
+        Some(initial_pivots),
+        options,
     )?)
 }
 
@@ -701,11 +710,19 @@ fn qtt_elementwise_product_demo_tracks_the_pointwise_product() -> Result<(), Box
         .iter()
         .map(|sample| sample.abs_error_compressed)
         .fold(0.0_f64, f64::max);
+    let max_raw_vs_factor_error = samples
+        .iter()
+        .map(|sample| (sample.cosh_qtt * sample.factor_b_qtt - sample.product_raw).abs())
+        .fold(0.0_f64, f64::max);
 
     assert!(!cosh_ranks.is_empty());
     assert!(!factor_b_ranks.is_empty());
     assert!(!cosh_errors.is_empty());
     assert!(!factor_b_errors.is_empty());
+    assert!(
+        max_raw_vs_factor_error < 1e-12,
+        "raw TreeTN product differs from QTT factor product: {max_raw_vs_factor_error}"
+    );
     assert!(
         max_raw_error < 1e-14,
         "raw TreeTN product error was too large: {max_raw_error}"


### PR DESCRIPTION
## Summary
- pin tenferro-rs to the merged provider-inject singleton QR/GEMM fixes
- add tenferro-cpu-faer and tenferro-provider-inject feature forwarding across tensor4all crates
- make TreeTN split_to use exact QR where no truncation is intended, with a sparse zero-leading-row regression
- make tutorial QTCI initialization deterministic so coverage smoke binaries cannot fail on all-zero random pivots
- add tensor_like helper coverage

Closes #479.
Related: tensor4all/tenferro-rs#756.

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo nextest run --release --workspace
- cargo test --doc --release --workspace
- cargo llvm-cov --workspace --release --json --output-path coverage.json
- cargo llvm-cov --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- ./scripts/test-mdbook.sh
- cargo check -p tensor4all-capi --release --no-default-features --features tenferro-provider-inject
- cargo test -p tensor4all-tutorial-code --test tutorial_binaries -- --nocapture
