### PR TITLE
Pin tenferro provider-inject runtime ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393", default-features = false }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "04923d24b1dcc7b8ee834e8a7eb547846d98b393", default-features = false }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a", default-features = false }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a", default-features = false }


### PR DESCRIPTION
## Summary

- Pin tenferro dependencies to tensor4all/tenferro-rs#761, which adds provider-inject runtime ABI registration.
- Keeps tensor4all-rs `tenferro-provider-inject` feature usable without local path patching.

## Validation

- `cargo check -p tensor4all-capi --release --no-default-features --features tenferro-provider-inject`
- Tensor4all.jl local build smoke using this branch with `TENSOR4ALL_LINALG_BACKEND=julia-blas`
- Tensor4all.jl local build smoke using this branch with `TENSOR4ALL_LINALG_BACKEND=faer`
