### PR TITLE
Pin tenferro published inject deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a", default-features = false }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "5fed678d7bcda3f9026f8541c9cb2b9522ce816a", default-features = false }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16", default-features = false }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16", default-features = false }


### PR DESCRIPTION
## Summary
- pin tenferro workspace dependencies to tensor4all/tenferro-rs@34750e9ca7f6285ce8c81aaa691bb240d570db16
- carry the published cblas-inject 0.1.1 / lapack-inject 0.1.2 dependency source into tensor4all-rs

## Verification
- cargo fmt --all -- --check
- cargo check -p tensor4all-capi --release --no-default-features --features tenferro-provider-inject
- cargo test -p tensor4all-capi --release