### PR TITLE
Address AGENTS audit cleanup issues #486-#490

### DIFF
--- a/crates/tensor4all-capi/Cargo.toml
+++ b/crates/tensor4all-capi/Cargo.toml
@@ -13,11 +13,13 @@ tenferro-cpu-faer = [
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-quanticstransform/tenferro-cpu-faer",
     "tensor4all-treetn/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-quanticstransform/tenferro-provider-inject",
     "tensor4all-treetn/tenferro-provider-inject",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
 ]
 
 [lib]
@@ -26,6 +28,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
 tensor4all-quanticstransform = { path = "../tensor4all-quanticstransform", default-features = false }
 libc.workspace = true

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -12,6 +12,7 @@ use crate::{
     T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use tensor4all_core::index::{DynId, Index, TagSet};
+use tensor4all_core::IndexLike;
 
 /// Release an index handle.
 #[unsafe(no_mangle)]
@@ -185,7 +186,7 @@ pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> S
 pub extern "C" fn t4a_index_id(ptr: *const t4a_index, out_id: *mut u64) -> StatusCode {
     run_value(out_id, || {
         let index = require_index(ptr, "index")?;
-        Ok(index.id.0)
+        Ok(index.id().value())
     })
 }
 
@@ -222,7 +223,7 @@ pub extern "C" fn t4a_index_plev(ptr: *const t4a_index, out_plev: *mut i64) -> S
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
-        *out_plev = (*ptr).inner().plev;
+        *out_plev = (*ptr).inner().plev();
         T4A_SUCCESS
     }));
 

--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -139,11 +139,25 @@ impl SourceSite {
     }
 }
 
-fn require_layout<'a>(layout: *const t4a_qtt_layout) -> CapiResult<&'a InternalQttLayout> {
+fn require_layout_or_status<'a>(
+    layout: *const t4a_qtt_layout,
+) -> std::result::Result<&'a InternalQttLayout, StatusCode> {
     if layout.is_null() {
-        return Err(capi_error(T4A_NULL_POINTER, "layout is null"));
+        set_last_error("layout is null");
+        return Err(T4A_NULL_POINTER);
     }
     Ok(unsafe { (&*layout).inner() })
+}
+
+macro_rules! require_layout_or_return {
+    ($layout:expr) => {{
+        match require_layout_or_status($layout) {
+            Ok(layout) => layout,
+            Err(code) => {
+                return code;
+            }
+        }
+    }};
 }
 
 fn bit_dim(bits: usize, what: &str) -> CapiResult<usize> {
@@ -532,13 +546,7 @@ pub extern "C" fn t4a_qtransform_shift_materialize(
     bc: t4a_boundary_condition,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
-    let layout_ref = match require_layout(layout) {
-        Ok(layout) => layout,
-        Err((code, msg)) => {
-            set_last_error(&msg);
-            return code;
-        }
-    };
+    let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
         if target_var >= layout_ref.nvariables() {
@@ -563,13 +571,7 @@ pub extern "C" fn t4a_qtransform_flip_materialize(
     bc: t4a_boundary_condition,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
-    let layout_ref = match require_layout(layout) {
-        Ok(layout) => layout,
-        Err((code, msg)) => {
-            set_last_error(&msg);
-            return code;
-        }
-    };
+    let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
         if target_var >= layout_ref.nvariables() {
@@ -594,13 +596,7 @@ pub extern "C" fn t4a_qtransform_phase_rotation_materialize(
     theta: f64,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
-    let layout_ref = match require_layout(layout) {
-        Ok(layout) => layout,
-        Err((code, msg)) => {
-            set_last_error(&msg);
-            return code;
-        }
-    };
+    let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
         if target_var >= layout_ref.nvariables() {
@@ -624,13 +620,7 @@ pub extern "C" fn t4a_qtransform_cumsum_materialize(
     target_var: usize,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
-    let layout_ref = match require_layout(layout) {
-        Ok(layout) => layout,
-        Err((code, msg)) => {
-            set_last_error(&msg);
-            return code;
-        }
-    };
+    let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
         if target_var >= layout_ref.nvariables() {
@@ -656,13 +646,7 @@ pub extern "C" fn t4a_qtransform_fourier_materialize(
     tolerance: f64,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
-    let layout_ref = match require_layout(layout) {
-        Ok(layout) => layout,
-        Err((code, msg)) => {
-            set_last_error(&msg);
-            return code;
-        }
-    };
+    let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
         if target_var >= layout_ref.nvariables() {
@@ -722,13 +706,7 @@ pub extern "C" fn t4a_qtransform_affine_materialize(
     bc: *const t4a_boundary_condition,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
-    let layout_ref = match require_layout(layout) {
-        Ok(layout) => layout,
-        Err((code, msg)) => {
-            set_last_error(&msg);
-            return code;
-        }
-    };
+    let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
         if m == 0 || n == 0 {

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{t4a_index, t4a_treetn_release, T4A_INVALID_ARGUMENT, T4A_SUCCESS};
+use crate::{t4a_index, t4a_treetn_release, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS};
 use num_complex::Complex64;
 use num_rational::Rational64;
 use tensor4all_core::{ColMajorArrayRef, TensorDynLen};
@@ -361,6 +361,19 @@ fn test_layout_and_affine_validation_errors_are_reported() {
         T4A_INVALID_ARGUMENT
     );
     assert!(last_error().contains("target_var must be smaller than nvariables"));
+
+    assert_eq!(
+        t4a_qtransform_shift_materialize(
+            std::ptr::null(),
+            0,
+            0,
+            t4a_boundary_condition::Periodic,
+            &mut op
+        ),
+        T4A_NULL_POINTER
+    );
+    let err = last_error();
+    assert!(err.contains("layout") || err.contains("null"), "{err}");
 
     let interleaved = new_layout(t4a_qtt_layout_kind::Interleaved, &resolutions);
     let a_num = [1i64];

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -262,7 +262,7 @@ pub extern "C" fn t4a_tensor_rank(ptr: *const t4a_tensor, out_rank: *mut usize) 
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
-        *out_rank = (*ptr).inner().indices.len();
+        *out_rank = (*ptr).inner().indices().len();
         T4A_SUCCESS
     }));
 
@@ -312,7 +312,7 @@ pub extern "C" fn t4a_tensor_indices(
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
-        let indices = &(*ptr).inner().indices;
+        let indices = (*ptr).inner().indices();
         *out_len = indices.len();
 
         if buf.is_null() {

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -4,7 +4,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use num_complex::Complex64;
-use tensor4all_core::{qr_with, svd_with, QrOptions, Storage, SvdOptions, SvdTruncationPolicy};
+use tensor4all_core::{qr_with, svd_with, QrOptions, SvdOptions, SvdTruncationPolicy};
+use tensor4all_tensorbackend::Storage;
 
 use crate::types::{
     t4a_index, t4a_scalar_kind, t4a_storage_kind, t4a_svd_truncation_policy, t4a_tensor,

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -1002,7 +1002,7 @@ pub extern "C" fn t4a_treetn_siteinds(
             )
         })?;
         let ordered_indices: Vec<_> = tensor
-            .indices
+            .indices()
             .iter()
             .filter(|index| site_space.contains(*index))
             .cloned()

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -3,10 +3,11 @@
 use std::ffi::c_void;
 
 use tensor4all_core::{
-    DynIndex, FactorizeAlg, SingularValueMeasure, StorageKind, SvdTruncationPolicy, TensorDynLen,
+    DynIndex, FactorizeAlg, SingularValueMeasure, SvdTruncationPolicy, TensorDynLen,
     ThresholdScale, TruncationRule,
 };
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
+use tensor4all_tensorbackend::StorageKind;
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
 use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN, TreeTNEvaluator};
 

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -85,7 +85,6 @@ pub struct AnyScalar {
     tensor: TensorDynLen,
 }
 
-#[allow(missing_docs)]
 impl AnyScalar {
     fn wrap_tensor(tensor: TensorDynLen) -> Result<Self> {
         let dims = tensor.dims();
@@ -185,80 +184,419 @@ impl AnyScalar {
         &self.tensor
     }
 
+    /// Creates an `AnyScalar` from a tensor element.
+    ///
+    /// Use this when you already have a scalar value that implements
+    /// [`TensorElement`] and want to lift it into the dynamic scalar wrapper.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The scalar value to wrap.
+    ///
+    /// # Returns
+    ///
+    /// A rank-0 `AnyScalar` containing `value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::from_value(3.0f64);
+    /// assert_eq!(scalar.real(), 3.0);
+    /// assert!(scalar.is_real());
+    /// ```
     pub fn from_value<T: TensorElement>(value: T) -> Self {
         Self::from_tensor_result(TensorDynLen::scalar(value), "from_value")
     }
 
+    /// Creates a real-valued `AnyScalar`.
+    ///
+    /// This is a convenience wrapper around [`AnyScalar::from_value`].
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The real scalar value to wrap.
+    ///
+    /// # Returns
+    ///
+    /// A rank-0 `AnyScalar` with real dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::from_real(1.25);
+    /// assert_eq!(scalar.as_f64(), Some(1.25));
+    /// assert!(scalar.is_real());
+    /// ```
     pub fn from_real(x: f64) -> Self {
         Self::from_value(x)
     }
 
+    /// Creates a complex-valued `AnyScalar`.
+    ///
+    /// This is a convenience wrapper around [`AnyScalar::from_value`].
+    ///
+    /// # Arguments
+    ///
+    /// * `re` - The real part of the complex value.
+    /// * `im` - The imaginary part of the complex value.
+    ///
+    /// # Returns
+    ///
+    /// A rank-0 `AnyScalar` containing the requested complex number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::from_complex(1.0, -2.0);
+    /// assert_eq!(scalar.as_c64().map(|z| (z.re, z.im)), Some((1.0, -2.0)));
+    /// assert!(scalar.is_complex());
+    /// ```
     pub fn from_complex(re: f64, im: f64) -> Self {
         Self::from_value(Complex64::new(re, im))
     }
 
+    /// Creates a real-valued `AnyScalar`.
+    ///
+    /// This is an alias for [`AnyScalar::from_real`].
+    ///
+    /// # Arguments
+    ///
+    /// * `x` - The real scalar value to wrap.
+    ///
+    /// # Returns
+    ///
+    /// A rank-0 `AnyScalar` with real dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_real(2.5);
+    /// assert_eq!(scalar.real(), 2.5);
+    /// assert!(scalar.is_real());
+    /// ```
     pub fn new_real(x: f64) -> Self {
         Self::from_real(x)
     }
 
+    /// Creates a complex-valued `AnyScalar`.
+    ///
+    /// This is an alias for [`AnyScalar::from_complex`].
+    ///
+    /// # Arguments
+    ///
+    /// * `re` - The real part of the complex value.
+    /// * `im` - The imaginary part of the complex value.
+    ///
+    /// # Returns
+    ///
+    /// A rank-0 `AnyScalar` containing the requested complex number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(2.0, 3.0);
+    /// assert_eq!(scalar.as_c64().map(|z| (z.re, z.im)), Some((2.0, 3.0)));
+    /// assert!(scalar.is_complex());
+    /// ```
     pub fn new_complex(re: f64, im: f64) -> Self {
         Self::from_complex(re, im)
     }
 
+    /// Returns the detached primal value of this scalar.
+    ///
+    /// This is an alias for [`AnyScalar::detach`].
+    ///
+    /// # Returns
+    ///
+    /// A scalar with the same value and no gradient tracking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let primal = AnyScalar::new_real(5.0).enable_grad().primal();
+    /// assert_eq!(primal.real(), 5.0);
+    /// assert!(!primal.tracks_grad());
+    /// ```
     pub fn primal(&self) -> Self {
         self.detach()
     }
 
+    /// Enables gradient tracking for this scalar.
+    ///
+    /// # Returns
+    ///
+    /// A new scalar that shares the same value but participates in autodiff.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_real(2.0).enable_grad();
+    /// assert!(scalar.tracks_grad());
+    /// ```
     pub fn enable_grad(self) -> Self {
         Self::from_tensor_unchecked(self.tensor.enable_grad())
     }
 
+    /// Returns whether this scalar tracks gradients.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the scalar participates in autodiff and can accumulate a
+    /// gradient, otherwise `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_real(1.0);
+    /// assert!(!scalar.tracks_grad());
+    /// ```
     pub fn tracks_grad(&self) -> bool {
         self.tensor.tracks_grad()
     }
 
+    /// Returns the stored gradient, if any.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(_))` when a gradient is available, `Ok(None)` when no gradient
+    /// has been recorded, or an error if the backend cannot read it.
+    ///
+    /// # Errors
+    ///
+    /// Propagates autodiff or tensor access failures from the underlying
+    /// tensor runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let x = AnyScalar::new_real(2.0).enable_grad();
+    /// let y = &x * &x;
+    /// y.backward().unwrap();
+    ///
+    /// let grad = x.grad().unwrap().unwrap();
+    /// assert_eq!(grad.real(), 4.0);
+    /// ```
     pub fn grad(&self) -> Result<Option<Self>> {
         self.tensor
             .grad()
             .map(|maybe_grad| maybe_grad.map(Self::from_tensor_unchecked))
     }
 
+    /// Clears the stored gradient for this scalar.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when the gradient buffer was cleared successfully.
+    ///
+    /// # Errors
+    ///
+    /// Propagates tensor runtime failures from the underlying autodiff state.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let x = AnyScalar::new_real(2.0).enable_grad();
+    /// let y = &x * &x;
+    /// y.backward().unwrap();
+    /// assert!(x.grad().unwrap().is_some());
+    ///
+    /// x.clear_grad().unwrap();
+    /// assert!(x.grad().unwrap().is_none());
+    /// ```
     pub fn clear_grad(&self) -> Result<()> {
         self.tensor.clear_grad()
     }
 
+    /// Runs reverse-mode autodiff starting from this scalar.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` when gradients were accumulated successfully.
+    ///
+    /// # Errors
+    ///
+    /// Propagates failures from the underlying tensor autodiff engine.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let x = AnyScalar::new_real(2.0).enable_grad();
+    /// let y = &x * &x;
+    /// y.backward().unwrap();
+    ///
+    /// let grad = x.grad().unwrap().unwrap();
+    /// assert_eq!(grad.real(), 4.0);
+    /// ```
     pub fn backward(&self) -> Result<()> {
         self.tensor.backward()
     }
 
+    /// Returns a detached copy of this scalar.
+    ///
+    /// # Returns
+    ///
+    /// A scalar with the same value but without gradient tracking.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let detached = AnyScalar::new_real(7.0).enable_grad().detach();
+    /// assert_eq!(detached.real(), 7.0);
+    /// assert!(!detached.tracks_grad());
+    /// ```
     pub fn detach(&self) -> Self {
         Self::from_tensor_unchecked(self.tensor.detach())
     }
 
+    /// Returns the real part of this scalar.
+    ///
+    /// # Returns
+    ///
+    /// The real component as an `f64`, regardless of the underlying storage
+    /// type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(3.0, -4.0);
+    /// assert_eq!(scalar.real(), 3.0);
+    /// ```
     pub fn real(&self) -> f64 {
         self.value().real()
     }
 
+    /// Returns the imaginary part of this scalar.
+    ///
+    /// # Returns
+    ///
+    /// The imaginary component as an `f64`. Real-valued scalars return `0.0`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(3.0, -4.0);
+    /// assert_eq!(scalar.imag(), -4.0);
+    /// ```
     pub fn imag(&self) -> f64 {
         self.value().imag()
     }
 
+    /// Returns the magnitude of this scalar.
+    ///
+    /// # Returns
+    ///
+    /// The absolute value for real scalars or the complex norm for complex
+    /// scalars.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(3.0, -4.0);
+    /// assert_eq!(scalar.abs(), 5.0);
+    /// ```
     pub fn abs(&self) -> f64 {
         self.value().abs()
     }
 
+    /// Returns whether this scalar is complex-valued.
+    ///
+    /// # Returns
+    ///
+    /// `true` for complex dtypes and `false` for real or integer dtypes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// assert!(AnyScalar::new_complex(1.0, 2.0).is_complex());
+    /// assert!(!AnyScalar::new_real(1.0).is_complex());
+    /// ```
     pub fn is_complex(&self) -> bool {
         self.value().is_complex()
     }
 
+    /// Returns whether this scalar is real-valued.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the scalar is not complex-valued.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// assert!(AnyScalar::new_real(1.0).is_real());
+    /// assert!(!AnyScalar::new_complex(1.0, 2.0).is_real());
+    /// ```
     pub fn is_real(&self) -> bool {
         !self.is_complex()
     }
 
+    /// Returns whether this scalar is exactly zero.
+    ///
+    /// # Returns
+    ///
+    /// `true` for exact zeros and `false` for any nonzero value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// assert!(AnyScalar::new_real(0.0).is_zero());
+    /// assert!(!AnyScalar::new_complex(0.0, 1.0).is_zero());
+    /// ```
     pub fn is_zero(&self) -> bool {
         self.value().is_zero()
     }
 
+    /// Returns this scalar as an `f64` when it is real-valued.
+    ///
+    /// # Returns
+    ///
+    /// `Some(value)` for real and integer scalars, or `None` for complex
+    /// scalars.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// assert_eq!(AnyScalar::new_real(2.5).as_f64(), Some(2.5));
+    /// assert_eq!(AnyScalar::new_complex(2.5, 1.0).as_f64(), None);
+    /// ```
     pub fn as_f64(&self) -> Option<f64> {
         match self.value() {
             ScalarValue::F32(value) => Some(value as f64),
@@ -268,6 +606,22 @@ impl AnyScalar {
         }
     }
 
+    /// Returns this scalar as a `Complex64` when it is complex-valued.
+    ///
+    /// # Returns
+    ///
+    /// `Some(value)` for complex scalars or `None` for real and integer
+    /// scalars.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(2.5, 1.0);
+    /// assert_eq!(scalar.as_c64().map(|z| (z.re, z.im)), Some((2.5, 1.0)));
+    /// assert_eq!(AnyScalar::new_real(2.5).as_c64(), None);
+    /// ```
     pub fn as_c64(&self) -> Option<Complex64> {
         match self.value() {
             ScalarValue::F32(_) | ScalarValue::F64(_) | ScalarValue::I64(_) => None,
@@ -276,18 +630,90 @@ impl AnyScalar {
         }
     }
 
+    /// Returns the complex conjugate of this scalar.
+    ///
+    /// # Returns
+    ///
+    /// The conjugated scalar. Real-valued inputs are returned unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(3.0, -4.0).conj();
+    /// assert_eq!(scalar.as_c64().map(|z| (z.re, z.im)), Some((3.0, 4.0)));
+    /// ```
     pub fn conj(&self) -> Self {
         Self::from_eager_unary(self, "conj", |tensor| tensor.conj())
     }
 
+    /// Returns the real part as a real-valued scalar.
+    ///
+    /// # Returns
+    ///
+    /// A real-valued scalar containing the real component of `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(3.0, -4.0).real_part();
+    /// assert_eq!(scalar.real(), 3.0);
+    /// assert!(scalar.is_real());
+    /// ```
     pub fn real_part(&self) -> Self {
         Self::from_real(self.real())
     }
 
+    /// Returns the imaginary part as a real-valued scalar.
+    ///
+    /// # Returns
+    ///
+    /// A real-valued scalar containing the imaginary component of `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_complex(3.0, -4.0).imag_part();
+    /// assert_eq!(scalar.real(), -4.0);
+    /// assert!(scalar.is_real());
+    /// ```
     pub fn imag_part(&self) -> Self {
         Self::from_real(self.imag())
     }
 
+    /// Combines two real-valued scalars into a complex scalar.
+    ///
+    /// # Arguments
+    ///
+    /// * `real` - The real component.
+    /// * `imag` - The imaginary component.
+    ///
+    /// # Returns
+    ///
+    /// A complex `AnyScalar` whose real and imaginary parts come from the
+    /// inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either input is not real-valued.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::compose_complex(
+    ///     AnyScalar::new_real(3.0),
+    ///     AnyScalar::new_real(-4.0),
+    /// )
+    /// .unwrap();
+    /// assert_eq!(scalar.as_c64().map(|z| (z.re, z.im)), Some((3.0, -4.0)));
+    /// ```
     pub fn compose_complex(real: Self, imag: Self) -> Result<Self> {
         if !real.is_real() || !imag.is_real() {
             return Err(anyhow!(
@@ -300,6 +726,22 @@ impl AnyScalar {
         Ok(&real + &imag_term)
     }
 
+    /// Returns the square root of this scalar.
+    ///
+    /// # Returns
+    ///
+    /// The principal square root. Negative real inputs and complex inputs use
+    /// complex arithmetic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_real(9.0).sqrt();
+    /// assert_eq!(scalar.real(), 3.0);
+    /// assert!(scalar.is_real());
+    /// ```
     pub fn sqrt(&self) -> Self {
         if self.is_complex() || self.real() < 0.0 {
             Self::from_backend_scalar(self.to_backend_scalar().sqrt())
@@ -308,10 +750,47 @@ impl AnyScalar {
         }
     }
 
+    /// Raises this scalar to a floating-point power.
+    ///
+    /// # Arguments
+    ///
+    /// * `exponent` - The exponent to apply.
+    ///
+    /// # Returns
+    ///
+    /// The value of `self^exponent`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// let scalar = AnyScalar::new_real(2.0).powf(3.0);
+    /// assert_eq!(scalar.real(), 8.0);
+    /// ```
     pub fn powf(&self, exponent: f64) -> Self {
         Self::from_backend_scalar(self.to_backend_scalar().powf(exponent))
     }
 
+    /// Raises this scalar to an integer power.
+    ///
+    /// # Arguments
+    ///
+    /// * `exponent` - The integer exponent to apply. Negative exponents return
+    ///   the reciprocal power.
+    ///
+    /// # Returns
+    ///
+    /// The value of `self^exponent`. Zero exponents return `1`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::AnyScalar;
+    ///
+    /// assert_eq!(AnyScalar::new_real(2.0).powi(3).real(), 8.0);
+    /// assert_eq!(AnyScalar::new_real(2.0).powi(-1).real(), 0.5);
+    /// ```
     pub fn powi(&self, exponent: i32) -> Self {
         if exponent == 0 {
             return Self::one();

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -9,8 +9,8 @@ use tenferro::DType;
 use tensor4all_tensorbackend::AnyScalar as BackendScalar;
 
 use crate::defaults::tensordynlen::TensorDynLen;
-use crate::storage::{Storage, SumFromStorage};
 use crate::TensorElement;
+use tensor4all_tensorbackend::{Storage, SumFromStorage};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum ScalarValue {

--- a/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::defaults::Index;
 use crate::tensor_like::TensorLike;
-use crate::StorageKind;
 use num_complex::Complex64;
 use std::ffi::OsString;
 use std::time::Duration;
+use tensor4all_tensorbackend::StorageKind;
 
 struct ScopedEnvVar {
     key: &'static str,

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -360,7 +360,6 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_lu_with_options::<T>(
         t,
@@ -385,7 +384,6 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_lu_with_options::<T>(t, left_inds, canonical, usize::MAX, 0.0)
 }
@@ -406,7 +404,6 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Unfold tensor into matrix
     let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
@@ -474,7 +471,6 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_ci_with_options::<T>(
         t,
@@ -499,7 +495,6 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     factorize_ci_with_options::<T>(t, left_inds, canonical, usize::MAX, 0.0)
 }
@@ -520,7 +515,6 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Unfold tensor into matrix
     let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)

--- a/crates/tensor4all-core/src/defaults/index.rs
+++ b/crates/tensor4all-core/src/defaults/index.rs
@@ -26,6 +26,26 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DynId(pub u64);
 
+impl DynId {
+    /// Return the numeric ID value used for ITensors-compatible serialization.
+    ///
+    /// Prefer full [`Index`](crate::Index) equality for tensor index identity.
+    /// This accessor exists for stable serialization and FFI query paths that
+    /// must expose the raw numeric identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynId;
+    ///
+    /// let id = DynId(42);
+    /// assert_eq!(id.value(), 42);
+    /// ```
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
 /// Tag set wrapper using `Arc` for efficient cloning.
 ///
 /// This wraps the underlying tag storage in an `Arc` for cheap cloning (reference count increment only).

--- a/crates/tensor4all-core/src/defaults/index.rs
+++ b/crates/tensor4all-core/src/defaults/index.rs
@@ -29,7 +29,7 @@ pub struct DynId(pub u64);
 impl DynId {
     /// Return the numeric ID value used for ITensors-compatible serialization.
     ///
-    /// Prefer full [`Index`](crate::Index) equality for tensor index identity.
+    /// Prefer full [`Index`] equality for tensor index identity.
     /// This accessor exists for stable serialization and FFI query paths that
     /// must expose the raw numeric identifier.
     ///

--- a/crates/tensor4all-core/src/defaults/index/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/index/tests/mod.rs
@@ -321,6 +321,12 @@ fn test_is_contractable_undirected() {
 }
 
 #[test]
+fn test_dyn_id_value_accessor() {
+    let id = DynId(42);
+    assert_eq!(id.value(), 42);
+}
+
+#[test]
 fn test_is_contractable_same_id_dim() {
     let i1: DynIndex = Index::new_dyn(5);
     let i2 = i1.clone();

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -39,8 +39,7 @@ pub use contract::{
 };
 pub use index::{DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet};
 pub use tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, RandomScalar,
-    TensorAccess, TensorDynLen,
+    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, TensorDynLen,
 };
 
 // Re-export linear algebra functions and types

--- a/crates/tensor4all-core/src/defaults/structured_contraction.rs
+++ b/crates/tensor4all-core/src/defaults/structured_contraction.rs
@@ -1,10 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::Storage;
 use anyhow::{anyhow, ensure, Result};
 use num_complex::Complex64;
 use tenferro::{DType, Tensor as NativeTensor};
-use tensor4all_tensorbackend::einsum_native_tensors;
+use tensor4all_tensorbackend::{einsum_native_tensors, Storage};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct OperandLayout {
@@ -440,6 +439,7 @@ impl UnionFind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tensor4all_tensorbackend::StorageKind;
 
     #[test]
     fn plans_diag_diag_partial_as_diag_output() {
@@ -503,7 +503,7 @@ mod tests {
 
     #[test]
     fn storage_payload_native_roundtrip_preserves_compact_payload() {
-        let storage = crate::Storage::new_structured(
+        let storage = Storage::new_structured(
             vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
             vec![2, 3],
             vec![1, 2],
@@ -519,7 +519,7 @@ mod tests {
         );
 
         let rebuilt = storage_from_payload_native(native, &[2, 3], vec![0, 1, 0]).unwrap();
-        assert_eq!(rebuilt.storage_kind(), crate::StorageKind::Structured);
+        assert_eq!(rebuilt.storage_kind(), StorageKind::Structured);
         assert_eq!(rebuilt.payload_dims(), &[2, 3]);
         assert_eq!(rebuilt.axis_classes(), &[0, 1, 0]);
         assert_eq!(

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -111,12 +111,6 @@ pub fn compute_permutation_from_indices(
     perm
 }
 
-/// Trait for accessing tensor index metadata.
-pub trait TensorAccess {
-    /// Get a reference to the indices.
-    fn indices(&self) -> &[DynIndex];
-}
-
 #[derive(Clone)]
 pub(crate) struct StructuredAdValue {
     payload: Arc<EagerTensor<CpuBackend>>,
@@ -185,12 +179,6 @@ pub struct TensorDynLen {
     pub(crate) structured_ad: Option<Arc<StructuredAdValue>>,
     /// Lazily materialized eager payload for native execution and AD.
     pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
-}
-
-impl TensorAccess for TensorDynLen {
-    fn indices(&self) -> &[DynIndex] {
-        &self.indices
-    }
 }
 
 impl TensorDynLen {

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -2,7 +2,7 @@ use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::index_ops::{common_ind_positions, prepare_contraction, prepare_contraction_pairs};
 use crate::tensor_like::LinearizationOrder;
-use crate::{storage::Storage, storage::StorageKind, AnyScalar};
+use crate::AnyScalar;
 use anyhow::Result;
 use num_complex::Complex64;
 use num_traits::Zero;
@@ -21,6 +21,7 @@ use tensor4all_tensorbackend::{
     reshape_col_major_native_tensor, scale_native_tensor, storage_to_native_tensor, StorageScalar,
     TensorElement,
 };
+use tensor4all_tensorbackend::{Storage, StorageKind};
 
 use super::structured_contraction::{
     normalize_payload_for_roots, storage_from_payload_native, storage_payload_native,
@@ -1251,7 +1252,8 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen, Storage};
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_tensorbackend::Storage;
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(3);
@@ -1277,7 +1279,8 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen, Storage};
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_tensorbackend::Storage;
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(4);
@@ -1294,7 +1297,8 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen, Storage};
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_tensorbackend::Storage;
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(2);
@@ -1328,7 +1332,8 @@ impl TensorDynLen {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tensor4all_core::{DynIndex, Storage, StorageKind, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_tensorbackend::{Storage, StorageKind};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
@@ -3720,7 +3725,8 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, Storage, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_tensorbackend::Storage;
     ///
     /// // Tensors from `from_dense` use dense storage
     /// let i = DynIndex::new_dyn(2);

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -62,13 +62,6 @@ pub use smallstring::{SmallChar, SmallString, SmallStringError};
 pub use tagset::{Tag, TagSetError, TagSetLike};
 
 // Tensor (storage, tensor types)
-pub mod storage {
-    //! Re-export of snapshot storage utilities.
-    pub use tensor4all_tensorbackend::{
-        make_mut_storage, mindim, AnyScalar, Storage, StorageKind, StorageScalar,
-        StructuredStorage, SumFromStorage,
-    };
-}
 pub mod tensor_index;
 pub mod tensor_like;
 
@@ -85,11 +78,7 @@ pub use defaults::tensordynlen as tensor;
 
 pub use any_scalar::AnyScalar;
 pub use defaults::tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, RandomScalar,
-    TensorAccess, TensorDynLen,
-};
-pub use storage::{
-    make_mut_storage, mindim, Storage, StorageKind, StructuredStorage, SumFromStorage,
+    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, TensorDynLen,
 };
 pub use tensor4all_tensorbackend::TensorElement;
 pub use tensor4all_tensorbackend::{

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -2,7 +2,8 @@ use num_complex::{Complex32, Complex64};
 use std::sync::Arc;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index::DynIndex;
-use tensor4all_core::{AnyScalar, Storage, StorageKind, TensorDynLen, TensorElement};
+use tensor4all_core::{AnyScalar, TensorDynLen, TensorElement};
+use tensor4all_tensorbackend::{Storage, StorageKind};
 
 /// Helper to create DenseF64 storage with shape information
 fn make_dense_f64(data: Vec<f64>, dims: &[usize]) -> Storage {

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -1,7 +1,8 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index_ops::common_inds;
-use tensor4all_core::{DynIndex, Storage, StorageKind, TensorDynLen, TensorLike};
+use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+use tensor4all_tensorbackend::{Storage, StorageKind};
 
 fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
     TensorDynLen::from_dense(indices, data).unwrap()

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -1,7 +1,8 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::TensorLike;
-use tensor4all_core::{diag_tensor_dyn_len, AnyScalar, StorageKind, TensorDynLen};
+use tensor4all_core::{diag_tensor_dyn_len, AnyScalar, TensorDynLen};
+use tensor4all_tensorbackend::StorageKind;
 
 #[test]
 fn test_diag_tensor_creation() {

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -1,7 +1,8 @@
 use tensor4all_core::{
-    contract_multi, contract_multi_with_options, AllowedPairs, ContractionOptions, Index, Storage,
-    StorageKind, TensorDynLen,
+    contract_multi, contract_multi_with_options, AllowedPairs, ContractionOptions, Index,
+    TensorDynLen,
 };
+use tensor4all_tensorbackend::{Storage, StorageKind};
 
 #[test]
 fn plain_dense_storage_auto_seeds_native_payload() {

--- a/crates/tensor4all-hdf5/src/index.rs
+++ b/crates/tensor4all-hdf5/src/index.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use std::str::FromStr;
 use tensor4all_core::index::{DynId, DynIndex, Index, TagSet};
 use tensor4all_core::tagset::TagSetLike;
+use tensor4all_core::IndexLike;
 
 use crate::schema;
 
@@ -91,21 +92,21 @@ pub(crate) fn write_index(group: &Group, index: &DynIndex) -> Result<()> {
 
     // Datasets
     let id_ds = group.new_dataset::<u64>().shape(()).create("id")?;
-    id_ds.as_writer().write_scalar(&index.id.0)?;
+    id_ds.as_writer().write_scalar(&index.id().value())?;
 
     let dim_ds = group.new_dataset::<i64>().shape(()).create("dim")?;
-    dim_ds.as_writer().write_scalar(&(index.dim as i64))?;
+    dim_ds.as_writer().write_scalar(&(index.dim() as i64))?;
 
     // dir: always 0 (direction is unused in tensor4all-rs)
     let dir_ds = group.new_dataset::<i64>().shape(()).create("dir")?;
     dir_ds.as_writer().write_scalar(&0i64)?;
 
     let plev_ds = group.new_dataset::<i64>().shape(()).create("plev")?;
-    plev_ds.as_writer().write_scalar(&index.plev)?;
+    plev_ds.as_writer().write_scalar(&index.plev())?;
 
     // Tags subgroup
     let tags_group = group.create_group("tags")?;
-    write_tagset(&tags_group, &index.tags)?;
+    write_tagset(&tags_group, index.tags())?;
 
     Ok(())
 }
@@ -146,8 +147,7 @@ pub(crate) fn read_index(group: &Group) -> Result<DynIndex> {
     let tags_group = group.group("tags")?;
     let tags = read_tagset(&tags_group)?;
 
-    let mut idx = Index::new_with_tags(DynId(id), dim as usize, tags);
-    idx.plev = plev;
+    let idx = Index::new_with_tags(DynId(id), dim as usize, tags).set_plev(plev);
     Ok(idx)
 }
 

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -198,10 +198,8 @@ pub fn save_itensor(filepath: &str, name: &str, tensor: &TensorDynLen) -> Result
 /// // Index dimensions are preserved
 /// assert_eq!(loaded.dims(), vec![2, 3]);
 ///
-/// // Index IDs are preserved
-/// let orig_ids: Vec<_> = tensor.indices().iter().map(|idx| idx.id).collect();
-/// let loaded_ids: Vec<_> = loaded.indices().iter().map(|idx| idx.id).collect();
-/// assert_eq!(orig_ids, loaded_ids);
+/// // Index identity and metadata are preserved
+/// assert_eq!(loaded.indices(), tensor.indices());
 /// # Ok(())
 /// # }
 /// ```

--- a/crates/tensor4all-hdf5/tests/test_hdf5.rs
+++ b/crates/tensor4all-hdf5/tests/test_hdf5.rs
@@ -275,6 +275,34 @@ fn test_mps_canonical_form_roundtrip() {
 }
 
 #[test]
+fn test_roundtrip_preserves_same_id_distinct_metadata_indices() -> anyhow::Result<()> {
+    use tensor4all_core::{DynId, Index, TagSet, TensorDynLen};
+    use tensor4all_hdf5::{load_itensor, save_itensor};
+
+    let tags_a = TagSet::from_str("Site,A")?;
+    let tags_b = TagSet::from_str("Site,B")?;
+    let i = Index::new_with_tags(DynId(7), 2, tags_a);
+    let j = Index::new_with_tags(DynId(7), 3, tags_b).set_plev(1);
+    assert_ne!(i, j);
+
+    let tensor = TensorDynLen::from_dense(
+        vec![i.clone(), j.clone()],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    )?;
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("same_id_metadata.h5");
+    let path = path.to_str().unwrap();
+
+    save_itensor(path, "tensor", &tensor)?;
+    let loaded = load_itensor(path, "tensor")?;
+
+    assert_eq!(loaded.indices(), tensor.indices());
+    assert_eq!(loaded.to_vec::<f64>()?, tensor.to_vec::<f64>()?);
+    Ok(())
+}
+
+#[test]
 fn test_type_mismatch_error() {
     // Write an ITensor, then try to load it as MPS → should get a clear error
     let path = temp_path("type_mismatch");

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -118,10 +118,7 @@ pub fn linsolve(
     // site indices. For each site, the MPO has 2 site indices while the MPS has 1.
     // We find the MPO index that shares an ID with init's site index (input) and
     // the remaining one (output).
-    let (input_mapping, output_mapping) =
-        infer_index_mappings(operator, &init).map_err(|e| TensorTrainError::OperationError {
-            message: format!("Failed to infer index mappings: {}", e),
-        })?;
+    let (input_mapping, output_mapping) = infer_index_mappings(operator, &init)?;
 
     let result = square_linsolve(
         operator.as_treetn(),
@@ -150,10 +147,7 @@ type SiteMappings = (
 /// finds the operator index sharing an ID with init's index (input) and the
 /// remaining one (output). Returns `(None, None)` when no mappings are needed
 /// (operator and init share all site indices).
-fn infer_index_mappings(
-    operator: &TensorTrain,
-    init: &TensorTrain,
-) -> std::result::Result<SiteMappings, String> {
+fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<SiteMappings> {
     let op_treetn = operator.as_treetn();
     let init_treetn = init.as_treetn();
     let nsites = init.len();
@@ -184,13 +178,15 @@ fn infer_index_mappings(
                         needs_mapping = true;
                     }
                 } else {
-                    return Err(format!(
-                        "Site {}: operator has 2 site indices but none share an ID with init's \
-                         site index {:?}. Cannot auto-infer index mappings. \
-                         Use the treetn-level API with explicit IndexMapping.",
-                        site,
-                        init_idx.id()
-                    ));
+                    return Err(TensorTrainError::OperationError {
+                        message: format!(
+                            "Site {}: operator has 2 site indices but none share an ID with init's \
+                             site index {:?}. Cannot auto-infer index mappings. \
+                             Use the treetn-level API with explicit IndexMapping.",
+                            site,
+                            init_idx.id()
+                        ),
+                    });
                 }
             }
         }
@@ -247,5 +243,35 @@ impl TensorTrain {
     /// See [`linsolve`] for details.
     pub fn linsolve(&self, rhs: &Self, init: Self, options: &LinsolveOptions) -> Result<Self> {
         linsolve(self, rhs, init, options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::{DynIndex, TensorDynLen};
+
+    fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
+        TensorDynLen::from_dense(indices, data).unwrap()
+    }
+
+    #[test]
+    fn infer_index_mappings_returns_typed_error() {
+        let op_in = DynIndex::new_dyn(2);
+        let op_out = DynIndex::new_dyn(2);
+        let init_site = DynIndex::new_dyn(2);
+
+        let operator = TensorTrain::new(vec![make_tensor(
+            vec![op_in, op_out],
+            vec![1.0, 0.0, 0.0, 1.0],
+        )])
+        .unwrap();
+        let init = TensorTrain::new(vec![make_tensor(vec![init_site], vec![1.0, 2.0])]).unwrap();
+
+        let result: crate::error::Result<_> = infer_index_mappings(&operator, &init);
+        let err = result.unwrap_err();
+
+        assert!(matches!(err, TensorTrainError::OperationError { .. }));
+        assert!(err.to_string().contains("Cannot auto-infer index mappings"));
     }
 }

--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -13,7 +13,6 @@ use quanticsgrids::DiscretizedGrid;
 use tensor4all_core::TensorElement;
 use tensor4all_simplett::{AbstractTensorTrain, TTScalar, TensorTrain};
 use tensor4all_simplett::{Tensor3, Tensor3Ops};
-use tensor4all_tcicore::{DenseLuKernel, PivotKernel};
 use tensor4all_treetci::materialize::FullPivLuScalar;
 
 use crate::options::QtciOptions;
@@ -217,7 +216,6 @@ pub fn quanticscrossinterpolate_batched<V, F>(
 where
     F: Fn(&[f64]) -> Vec<V> + 'static,
     V: TTScalar + Default + Clone + 'static + TensorElement + FullPivLuScalar,
-    DenseLuKernel: PivotKernel<V>,
 {
     // Validate output_dims
     if output_dims.is_empty() {

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -9,7 +9,6 @@ use quanticsgrids::{DiscretizedGrid, InherentDiscreteGrid};
 use rand::Rng;
 use tensor4all_core::TensorDynLen;
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TTScalar, TensorTrain};
-use tensor4all_tcicore::{DenseLuKernel, PivotKernel};
 use tensor4all_treetci::materialize::{to_treetn, FullPivLuScalar};
 use tensor4all_treetci::{
     optimize_with_proposer, DefaultProposer, GlobalIndexBatch, TreeTCI2, TreeTciGraph,
@@ -447,7 +446,6 @@ pub fn quanticscrossinterpolate<V, F>(
 ) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
     V: TTScalar + Default + Clone + 'static + tensor4all_core::TensorElement + FullPivLuScalar,
-    DenseLuKernel: PivotKernel<V>,
     F: Fn(&[f64]) -> V + 'static,
 {
     let local_dims = grid.local_dimensions();
@@ -614,7 +612,6 @@ pub fn quanticscrossinterpolate_from_arrays<V, F>(
 ) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
     V: TTScalar + Default + Clone + 'static + tensor4all_core::TensorElement + FullPivLuScalar,
-    DenseLuKernel: PivotKernel<V>,
     F: Fn(&[f64]) -> V + 'static,
 {
     if xvals.is_empty() {
@@ -723,7 +720,6 @@ pub fn quanticscrossinterpolate_discrete<V, F>(
 ) -> Result<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
     V: TTScalar + Default + Clone + 'static + tensor4all_core::TensorElement + FullPivLuScalar,
-    DenseLuKernel: PivotKernel<V>,
     F: Fn(&[i64]) -> V + 'static,
 {
     // Validate sizes are powers of 2

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -163,7 +163,6 @@ fn factorize<T>(
 ) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
 where
     T: TTScalar + Scalar + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     let reltol = if tolerance > 0.0 { tolerance } else { 1e-14 };
     let abstol = 0.0;
@@ -399,7 +398,6 @@ impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
     pub fn compress(&mut self, options: &CompressionOptions) -> Result<()>
     where
         T: tensor4all_tcicore::MatrixLuciScalar,
-        tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
     {
         let n = self.len();
         if n <= 1 {
@@ -540,7 +538,6 @@ impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
     pub fn compressed(&self, options: &CompressionOptions) -> Result<Self>
     where
         T: tensor4all_tcicore::MatrixLuciScalar,
-        tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
     {
         let mut result = self.clone();
         result.compress(options)?;

--- a/crates/tensor4all-simplett/src/compression/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/compression/tests/mod.rs
@@ -6,7 +6,6 @@ use num_complex::Complex64;
 fn test_compress_constant_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     let tt = TensorTrain::<T>::constant(&[2, 3, 2], <T as Scalar>::from_f64(1.0));
     let original_sum = tt.sum();
@@ -23,7 +22,6 @@ where
 fn test_compress_preserves_values_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Create a simple tensor train
     let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 2);
@@ -67,7 +65,6 @@ where
 fn test_compress_with_max_bond_dim_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Create a tensor train with higher bond dimension
     let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 3);
@@ -136,7 +133,6 @@ fn test_compress_with_max_bond_dim_c64() {
 fn test_compress_svd_constant_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     let tt = TensorTrain::<T>::constant(&[2, 3, 2], <T as Scalar>::from_f64(1.0));
     let original_sum = tt.sum();
@@ -155,7 +151,6 @@ where
 fn test_compress_svd_with_truncation_generic<T>()
 where
     T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // Create a rank-3 TT and compress with SVD to max_bond_dim=2
     let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 3);

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -296,7 +296,6 @@ pub fn factorize_lu<T>(
 ) -> Result<FactorizeResult<T>>
 where
     T: SVDScalar + tensor4all_tcicore::Scalar + tensor4all_tcicore::MatrixLuciScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     use tensor4all_tcicore::{AbstractMatrixCI, MatrixLUCI, RrLUOptions};
 
@@ -361,7 +360,6 @@ pub fn factorize_ci<T>(
 where
     T: SVDScalar + tensor4all_tcicore::Scalar + tensor4all_tcicore::MatrixLuciScalar,
     <T as ComplexFloat>::Real: Into<f64>,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
 {
     // CI uses the same LUCI implementation as LU
     factorize_lu(matrix, options)

--- a/crates/tensor4all-simplett/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/tensortrain/tests/mod.rs
@@ -530,10 +530,7 @@ fn test_svd_compression_tolerance_generic<
         + tensor4all_tcicore::MatrixLuciScalar
         + Default
         + std::fmt::Debug,
->()
-where
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
-{
+>() {
     use crate::compression::{CompressionMethod, CompressionOptions};
 
     // Build a random-ish TT with known structure: sum of two rank-1 terms

--- a/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
+++ b/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
@@ -3,9 +3,7 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tenferro_tensor::{cpu::CpuBackend, Tensor};
-use tensor4all_tcicore::matrixluci::{
-    DenseLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions,
-};
+use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
 
 fn random_column_major(nrows: usize, ncols: usize, seed: u64) -> Vec<f64> {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -20,16 +18,25 @@ fn random_column_major(nrows: usize, ncols: usize, seed: u64) -> Vec<f64> {
 
 fn bench_dense_vs_tenferro(c: &mut Criterion) {
     let mut group = c.benchmark_group("dense_no_truncation_vs_tenferro");
-    let kernel = DenseLuKernel;
-    let options = PivotKernelOptions::no_truncation();
+    let options = RrLUOptions {
+        max_rank: usize::MAX,
+        rel_tol: 0.0,
+        abs_tol: 0.0,
+        left_orthogonal: true,
+    };
 
     for &size in &[32usize, 64, 100, 128] {
         let data = random_column_major(size, size, 42);
 
         group.bench_with_input(BenchmarkId::new("matrixluci", size), &size, |b, &n| {
             b.iter(|| {
-                let src = DenseMatrixSource::from_column_major(&data, n, n);
-                black_box(kernel.factorize(&src, &options).unwrap());
+                let mut matrix = tensor4all_tcicore::matrix::zeros(n, n);
+                for col in 0..n {
+                    for row in 0..n {
+                        matrix[[row, col]] = data[row + n * col];
+                    }
+                }
+                black_box(matrix_luci_factors_from_matrix(&matrix, Some(options.clone())).unwrap());
             });
         });
 

--- a/crates/tensor4all-tcicore/benches/end_to_end_chain_tci.rs
+++ b/crates/tensor4all-tcicore/benches/end_to_end_chain_tci.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use tensor4all_tensorci::{crossinterpolate2, MultiIndex, PivotSearchStrategy, TCI2Options};
+use tensor4all_tcicore::MultiIndex;
+use tensor4all_tensorci::{crossinterpolate2, PivotSearchStrategy, TCI2Options};
 
 fn chain_value(idx: &MultiIndex) -> f64 {
     let local = idx

--- a/crates/tensor4all-tcicore/benches/lazy_block_rook.rs
+++ b/crates/tensor4all-tcicore/benches/lazy_block_rook.rs
@@ -2,9 +2,8 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_tcicore::matrixluci::{
-    DenseLuKernel, DenseMatrixSource, LazyBlockRookKernel, LazyMatrixSource, PivotKernel,
-    PivotKernelOptions,
+use tensor4all_tcicore::{
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, RrLUOptions,
 };
 
 fn random_column_major(nrows: usize, ncols: usize, seed: u64) -> Vec<f64> {
@@ -45,11 +44,11 @@ fn materialize_expensive(n: usize) -> Vec<f64> {
 }
 
 fn bench_lazy_block_rook(c: &mut Criterion) {
-    let dense_kernel = DenseLuKernel;
-    let rook_kernel = LazyBlockRookKernel;
-    let options = PivotKernelOptions {
+    let options = RrLUOptions {
         max_rank: 8,
-        ..PivotKernelOptions::no_truncation()
+        rel_tol: 0.0,
+        abs_tol: 0.0,
+        left_orthogonal: true,
     };
 
     let mut cheap_group = c.benchmark_group("lazy_block_rook_cheap_callback");
@@ -62,18 +61,32 @@ fn bench_lazy_block_rook(c: &mut Criterion) {
             |b, &n| {
                 b.iter(|| {
                     let materialized = data.clone();
-                    let source = DenseMatrixSource::from_column_major(&materialized, n, n);
-                    black_box(dense_kernel.factorize(&source, &options).unwrap());
+                    let mut matrix = tensor4all_tcicore::matrix::zeros(n, n);
+                    for col in 0..n {
+                        for row in 0..n {
+                            matrix[[row, col]] = materialized[row + n * col];
+                        }
+                    }
+                    black_box(
+                        matrix_luci_factors_from_matrix(&matrix, Some(options.clone())).unwrap(),
+                    );
                 });
             },
         );
 
         cheap_group.bench_with_input(BenchmarkId::new("lazy_rook", size), &size, |b, &n| {
             b.iter(|| {
-                let source = LazyMatrixSource::new(n, n, |rows, cols, out: &mut [f64]| {
-                    fill_from_dense(&data, n, rows, cols, out);
-                });
-                black_box(rook_kernel.factorize(&source, &options).unwrap());
+                black_box(
+                    matrix_luci_factors_from_blocks(
+                        n,
+                        n,
+                        |rows, cols, out: &mut [f64]| {
+                            fill_from_dense(&data, n, rows, cols, out);
+                        },
+                        options.clone(),
+                    )
+                    .unwrap(),
+                );
             });
         });
     }
@@ -87,22 +100,36 @@ fn bench_lazy_block_rook(c: &mut Criterion) {
             |b, &n| {
                 b.iter(|| {
                     let materialized = materialize_expensive(n);
-                    let source = DenseMatrixSource::from_column_major(&materialized, n, n);
-                    black_box(dense_kernel.factorize(&source, &options).unwrap());
+                    let mut matrix = tensor4all_tcicore::matrix::zeros(n, n);
+                    for col in 0..n {
+                        for row in 0..n {
+                            matrix[[row, col]] = materialized[row + n * col];
+                        }
+                    }
+                    black_box(
+                        matrix_luci_factors_from_matrix(&matrix, Some(options.clone())).unwrap(),
+                    );
                 });
             },
         );
 
         expensive_group.bench_with_input(BenchmarkId::new("lazy_rook", size), &size, |b, &n| {
             b.iter(|| {
-                let source = LazyMatrixSource::new(n, n, |rows, cols, out: &mut [f64]| {
-                    for (j, &col) in cols.iter().enumerate() {
-                        for (i, &row) in rows.iter().enumerate() {
-                            out[i + rows.len() * j] = expensive_entry(row, col);
-                        }
-                    }
-                });
-                black_box(rook_kernel.factorize(&source, &options).unwrap());
+                black_box(
+                    matrix_luci_factors_from_blocks(
+                        n,
+                        n,
+                        |rows, cols, out: &mut [f64]| {
+                            for (j, &col) in cols.iter().enumerate() {
+                                for (i, &row) in rows.iter().enumerate() {
+                                    out[i + rows.len() * j] = expensive_entry(row, col);
+                                }
+                            }
+                        },
+                        options.clone(),
+                    )
+                    .unwrap(),
+                );
             });
         });
     }

--- a/crates/tensor4all-tcicore/src/lib.rs
+++ b/crates/tensor4all-tcicore/src/lib.rs
@@ -72,12 +72,7 @@ pub mod matrixluci;
 pub mod scalar;
 pub mod traits;
 
-pub use self::matrixluci::{
-    CandidateMatrixSource, CrossFactors, DenseLuKernel, DenseMatrixSource, DenseOwnedMatrix,
-    LazyBlockRookKernel, LazyMatrixSource, MatrixLuciError, PivotKernel, PivotKernelOptions,
-    PivotSelectionCore,
-};
-pub use self::matrixluci::{Result as MatrixLuciResult, Scalar as MatrixLuciScalar};
+pub use self::matrixluci::Scalar as MatrixLuciScalar;
 pub use cached_function::cache_key::CacheKey;
 pub use cached_function::error::CacheKeyError;
 pub use cached_function::index_int::IndexInt;
@@ -85,7 +80,9 @@ pub use cached_function::CachedFunction;
 pub use error::{MatrixCIError, Result};
 pub use indexset::{IndexSet, LocalIndex, MultiIndex};
 pub use matrix::{from_vec2d, Matrix};
-pub use matrix_luci::MatrixLUCI;
+pub use matrix_luci::{
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, MatrixLUCI, MatrixLuciFactors,
+};
 pub use matrixaca::MatrixACA;
 pub use matrixlu::{rrlu, rrlu_inplace, RrLU, RrLUOptions};
 pub use scalar::Scalar;

--- a/crates/tensor4all-tcicore/src/matrix_luci.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci.rs
@@ -7,10 +7,12 @@
 use crate::error::{MatrixCIError, Result};
 use crate::matrix::{submatrix, zeros, Matrix};
 use crate::matrixlu::RrLUOptions;
-use crate::matrixluci::{
-    CrossFactors, DenseLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions,
-    PivotSelectionCore,
-};
+use crate::matrixluci::block_rook::LazyBlockRookKernel;
+use crate::matrixluci::dense::DenseLuKernel;
+use crate::matrixluci::factors::CrossFactors;
+use crate::matrixluci::source::{DenseMatrixSource, LazyMatrixSource};
+use crate::matrixluci::types::{PivotKernelOptions, PivotSelectionCore};
+use crate::matrixluci::PivotKernel;
 use crate::scalar::Scalar;
 use crate::traits::AbstractMatrixCI;
 
@@ -43,7 +45,7 @@ use crate::traits::AbstractMatrixCI;
 /// }
 /// ```
 #[derive(Debug, Clone)]
-pub struct MatrixLUCI<T: Scalar + crate::matrixluci::Scalar> {
+pub struct MatrixLUCI<T: Scalar + crate::MatrixLuciScalar> {
     nrows: usize,
     ncols: usize,
     row_indices: Vec<usize>,
@@ -51,6 +53,48 @@ pub struct MatrixLUCI<T: Scalar + crate::matrixluci::Scalar> {
     left: Matrix<T>,
     right: Matrix<T>,
     pivot_errors: Vec<f64>,
+}
+
+/// High-level factors produced by MatrixLUCI.
+///
+/// This is the public result of the LUCI factorization facade. It exposes
+/// the selected pivot metadata and the row-major left and right factors
+/// needed by higher-level tensor-network code without exposing the low-level
+/// pivot kernel substrate.
+///
+/// Related types: [`MatrixLUCI`] is the owning row-major CI wrapper, while
+/// [`MatrixACA`](crate::MatrixACA) and [`RrLU`](crate::RrLU) are related
+/// matrix factorization entry points.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tcicore::{from_vec2d, matrix_luci_factors_from_matrix};
+///
+/// let m = from_vec2d(vec![
+///     vec![1.0_f64, 2.0],
+///     vec![3.0, 4.0],
+/// ]);
+/// let factors = matrix_luci_factors_from_matrix(&m, None).unwrap();
+/// assert!(factors.rank >= 1);
+/// assert_eq!(factors.row_indices.len(), factors.rank);
+/// assert_eq!(factors.left.nrows(), m.nrows());
+/// assert_eq!(factors.right.ncols(), m.ncols());
+/// ```
+#[derive(Debug, Clone)]
+pub struct MatrixLuciFactors<T> {
+    /// Selected row indices.
+    pub row_indices: Vec<usize>,
+    /// Selected column indices.
+    pub col_indices: Vec<usize>,
+    /// Pivot error history.
+    pub pivot_errors: Vec<f64>,
+    /// Selected rank.
+    pub rank: usize,
+    /// Left factor in row-major layout.
+    pub left: Matrix<T>,
+    /// Right factor in row-major layout.
+    pub right: Matrix<T>,
 }
 
 pub(crate) fn map_backend_error(err: crate::matrixluci::MatrixLuciError) -> MatrixCIError {
@@ -72,7 +116,7 @@ pub(crate) fn to_column_major<T: Scalar>(matrix: &Matrix<T>) -> Vec<T> {
     out
 }
 
-pub(crate) fn to_row_major<T: Scalar + crate::matrixluci::Scalar>(
+pub(crate) fn to_row_major<T: Scalar + crate::MatrixLuciScalar>(
     matrix: &crate::matrixluci::DenseOwnedMatrix<T>,
 ) -> Matrix<T> {
     let mut out = zeros(matrix.nrows(), matrix.ncols());
@@ -84,12 +128,41 @@ pub(crate) fn to_row_major<T: Scalar + crate::matrixluci::Scalar>(
     out
 }
 
-pub(crate) fn dense_selection_from_matrix<T>(
+fn factors_to_public<T>(
+    selection: PivotSelectionCore,
+    factors: CrossFactors<T>,
+    left_orthogonal: bool,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let left = if left_orthogonal {
+        to_row_major(&factors.cols_times_pivot_inv().map_err(map_backend_error)?)
+    } else {
+        to_row_major(&factors.pivot_cols)
+    };
+    let right = if left_orthogonal {
+        to_row_major(&factors.pivot_rows)
+    } else {
+        to_row_major(&factors.pivot_inv_times_rows().map_err(map_backend_error)?)
+    };
+
+    Ok(MatrixLuciFactors {
+        row_indices: selection.row_indices,
+        col_indices: selection.col_indices,
+        pivot_errors: selection.pivot_errors,
+        rank: selection.rank,
+        left,
+        right,
+    })
+}
+
+pub(crate) fn dense_matrix_luci_factors_from_matrix<T>(
     a: &Matrix<T>,
     options: RrLUOptions,
-) -> Result<(PivotSelectionCore, CrossFactors<T>)>
+) -> Result<MatrixLuciFactors<T>>
 where
-    T: Scalar + crate::matrixluci::Scalar,
+    T: Scalar + crate::MatrixLuciScalar,
     DenseLuKernel: PivotKernel<T>,
 {
     let data = to_column_major(a);
@@ -105,13 +178,142 @@ where
         .factorize(&source, &kernel_options)
         .map_err(map_backend_error)?;
     let factors = CrossFactors::from_source(&source, &selection).map_err(map_backend_error)?;
-    Ok((selection, factors))
+    factors_to_public(selection, factors, options.left_orthogonal)
+}
+
+pub(crate) fn lazy_matrix_luci_factors_from_blocks<T, F>(
+    nrows: usize,
+    ncols: usize,
+    fill_block: F,
+    options: RrLUOptions,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+    F: Fn(&[usize], &[usize], &mut [T]),
+    LazyBlockRookKernel: PivotKernel<T>,
+{
+    let source = LazyMatrixSource::new(nrows, ncols, fill_block);
+    let kernel_options = PivotKernelOptions {
+        max_rank: options.max_rank,
+        rel_tol: options.rel_tol,
+        abs_tol: options.abs_tol,
+        left_orthogonal: options.left_orthogonal,
+    };
+
+    let selection = LazyBlockRookKernel
+        .factorize(&source, &kernel_options)
+        .map_err(map_backend_error)?;
+    let factors = CrossFactors::from_source(&source, &selection).map_err(map_backend_error)?;
+    factors_to_public(selection, factors, options.left_orthogonal)
+}
+
+/// Factorize a dense row-major matrix with MatrixLUCI.
+///
+/// Returns the selected pivot metadata together with row-major left and
+/// right factors. This is the public facade used by higher-level crates.
+///
+/// # Arguments
+///
+/// * `a` - Dense row-major matrix to factorize.
+/// * `options` - Optional rank and tolerance controls. `None` uses the
+///   default LUCI settings.
+///
+/// # Returns
+///
+/// A [`MatrixLuciFactors`] value containing the selected pivot indices,
+/// error history, rank, and row-major factors.
+///
+/// # Errors
+///
+/// Returns a [`MatrixCIError`] if the factorization fails, for example if the
+/// pivot block is singular or the backend rejects the input.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tcicore::{from_vec2d, matrix_luci_factors_from_matrix};
+///
+/// let m = from_vec2d(vec![
+///     vec![1.0_f64, 0.0],
+///     vec![0.0, 2.0],
+/// ]);
+/// let factors = matrix_luci_factors_from_matrix(&m, None).unwrap();
+/// assert_eq!(factors.left.nrows(), 2);
+/// assert_eq!(factors.right.ncols(), 2);
+/// assert_eq!(factors.row_indices.len(), factors.rank);
+/// ```
+pub fn matrix_luci_factors_from_matrix<T>(
+    a: &Matrix<T>,
+    options: Option<RrLUOptions>,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    <T as crate::MatrixLuciScalar>::matrix_luci_factors_from_matrix(a, options.unwrap_or_default())
+}
+
+/// Factorize a lazily supplied matrix with MatrixLUCI block-rook search.
+///
+/// The caller provides a block-fill closure that receives row and column
+/// index lists and writes the corresponding matrix block in column-major
+/// order.
+///
+/// # Arguments
+///
+/// * `nrows` - Number of matrix rows.
+/// * `ncols` - Number of matrix columns.
+/// * `fill_block` - Closure that fills `out` with `A[rows, cols]` in
+///   column-major order.
+/// * `options` - Rank and tolerance controls.
+///
+/// # Returns
+///
+/// A [`MatrixLuciFactors`] value containing the pivot metadata and row-major
+/// factors.
+///
+/// # Errors
+///
+/// Returns a [`MatrixCIError`] if the lazy factorization fails or if the
+/// block callback is inconsistent.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tcicore::matrix_luci_factors_from_blocks;
+/// use tensor4all_tcicore::RrLUOptions;
+///
+/// let factors = matrix_luci_factors_from_blocks(
+///     2,
+///     2,
+///     |rows, cols, out| {
+///         for (j, &col) in cols.iter().enumerate() {
+///             for (i, &row) in rows.iter().enumerate() {
+///                 out[i + rows.len() * j] = if row == col { 1.0 } else { 0.0 };
+///             }
+///         }
+///     },
+///     RrLUOptions::default(),
+/// ).unwrap();
+/// assert_eq!(factors.rank, 2);
+/// ```
+pub fn matrix_luci_factors_from_blocks<T, F>(
+    nrows: usize,
+    ncols: usize,
+    fill_block: F,
+    options: RrLUOptions,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+    F: Fn(&[usize], &[usize], &mut [T]),
+{
+    <T as crate::MatrixLuciScalar>::matrix_luci_factors_from_blocks(
+        nrows, ncols, fill_block, options,
+    )
 }
 
 impl<T> MatrixLUCI<T>
 where
-    T: Scalar + crate::matrixluci::Scalar,
-    DenseLuKernel: PivotKernel<T>,
+    T: Scalar + crate::MatrixLuciScalar,
 {
     /// Create a MatrixLUCI from a dense row-major matrix.
     ///
@@ -128,29 +330,16 @@ where
     /// assert!(ci.rank() >= 1);
     /// ```
     pub fn from_matrix(a: &Matrix<T>, options: Option<RrLUOptions>) -> Result<Self> {
-        let options = options.unwrap_or_default();
-        let left_orthogonal = options.left_orthogonal;
-        let (selection, factors) = dense_selection_from_matrix(a, options)?;
-
-        let left = if left_orthogonal {
-            to_row_major(&factors.cols_times_pivot_inv().map_err(map_backend_error)?)
-        } else {
-            to_row_major(&factors.pivot_cols)
-        };
-        let right = if left_orthogonal {
-            to_row_major(&factors.pivot_rows)
-        } else {
-            to_row_major(&factors.pivot_inv_times_rows().map_err(map_backend_error)?)
-        };
+        let factors = matrix_luci_factors_from_matrix(a, options)?;
 
         Ok(Self {
             nrows: a.nrows(),
             ncols: a.ncols(),
-            row_indices: selection.row_indices,
-            col_indices: selection.col_indices,
-            left,
-            right,
-            pivot_errors: selection.pivot_errors,
+            row_indices: factors.row_indices,
+            col_indices: factors.col_indices,
+            left: factors.left,
+            right: factors.right,
+            pivot_errors: factors.pivot_errors,
         })
     }
 
@@ -244,7 +433,7 @@ where
 
 impl<T> AbstractMatrixCI<T> for MatrixLUCI<T>
 where
-    T: Scalar + crate::matrixluci::Scalar,
+    T: Scalar + crate::MatrixLuciScalar,
 {
     fn nrows(&self) -> usize {
         self.nrows

--- a/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
@@ -74,6 +74,39 @@ fn test_matrixluci_rank2_iplusj_left_orthogonal() {
 }
 
 #[test]
+fn test_matrixluci_rank2_iplusj_right_orthogonal() {
+    let m = from_vec2d(vec![
+        vec![0.0, 1.0, 2.0, 3.0],
+        vec![1.0, 2.0, 3.0, 4.0],
+        vec![2.0, 3.0, 4.0, 5.0],
+        vec![3.0, 4.0, 5.0, 6.0],
+    ]);
+
+    let opts = RrLUOptions {
+        left_orthogonal: false,
+        ..Default::default()
+    };
+    let luci = MatrixLUCI::from_matrix(&m, Some(opts)).unwrap();
+    assert_eq!(luci.rank(), 2);
+
+    let reconstructed = mat_mul(&luci.left(), &luci.right());
+    for i in 0..4 {
+        for j in 0..4 {
+            let diff = (m[[i, j]] - reconstructed[[i, j]]).abs();
+            assert!(
+                diff < 1e-10,
+                "Reconstruction error at ({}, {}): expected {} got {} (diff {})",
+                i,
+                j,
+                m[[i, j]],
+                reconstructed[[i, j]],
+                diff
+            );
+        }
+    }
+}
+
+#[test]
 fn test_matrixluci_rank_deficient() {
     // Rank-1 matrix
     let m = from_vec2d(vec![

--- a/crates/tensor4all-tcicore/src/matrixluci/error.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 /// Errors that can occur during matrix LUCI operations.
 #[derive(Debug, Error)]
-pub enum MatrixLuciError {
+pub(crate) enum MatrixLuciError {
     /// Invalid argument.
     #[error("Invalid argument: {message}")]
     InvalidArgument {
@@ -17,4 +17,4 @@ pub enum MatrixLuciError {
 }
 
 /// Result type for matrixluci operations.
-pub type Result<T> = std::result::Result<T, MatrixLuciError>;
+pub(crate) type Result<T> = std::result::Result<T, MatrixLuciError>;

--- a/crates/tensor4all-tcicore/src/matrixluci/factors.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/factors.rs
@@ -135,7 +135,7 @@ pub(crate) fn invert_square<T: Scalar>(
 /// right CI factors for the cross interpolation approximation
 /// `A ~ A[:, J] * A[I, J]^{-1} * A[I, :]`.
 #[derive(Debug, Clone)]
-pub struct CrossFactors<T: Scalar> {
+pub(crate) struct CrossFactors<T: Scalar> {
     /// Pivot block `A[I, J]`.
     pub pivot: DenseOwnedMatrix<T>,
     /// Columns through selected pivot columns `A[:, J]`.
@@ -146,6 +146,7 @@ pub struct CrossFactors<T: Scalar> {
 
 impl<T: Scalar> CrossFactors<T> {
     /// Gather a dense block from a source.
+    #[cfg(test)]
     pub fn gather<S: CandidateMatrixSource<T>>(
         source: &S,
         rows: &[usize],

--- a/crates/tensor4all-tcicore/src/matrixluci/kernel.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/kernel.rs
@@ -14,7 +14,7 @@ use crate::matrixluci::types::{PivotKernelOptions, PivotSelectionCore};
 ///
 /// Different implementations choose pivots using different strategies
 /// (dense full-pivoting LU, lazy rook search, etc.).
-pub trait PivotKernel<T: Scalar> {
+pub(crate) trait PivotKernel<T: Scalar> {
     /// Factorize the candidate matrix and return pivot-only output.
     fn factorize<S: CandidateMatrixSource<T>>(
         &self,

--- a/crates/tensor4all-tcicore/src/matrixluci/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/mod.rs
@@ -5,20 +5,27 @@
 //! It uses the configured tensor backend for square complete-pivoting LU and
 //! the internal rrLU implementation for rectangular fallback coverage.
 
-pub mod block_rook;
-pub mod dense;
-pub mod error;
-pub mod factors;
-pub mod kernel;
-pub mod scalar;
-pub mod source;
-pub mod types;
+pub(crate) mod block_rook;
+pub(crate) mod dense;
+pub(crate) mod error;
+pub(crate) mod factors;
+pub(crate) mod kernel;
+pub(crate) mod scalar;
+pub(crate) mod source;
+pub(crate) mod types;
 
-pub use block_rook::LazyBlockRookKernel;
-pub use dense::DenseLuKernel;
-pub use error::{MatrixLuciError, Result};
-pub use factors::CrossFactors;
-pub use kernel::PivotKernel;
+#[allow(unused_imports)]
+pub(crate) use block_rook::LazyBlockRookKernel;
+#[allow(unused_imports)]
+pub(crate) use dense::DenseLuKernel;
+#[allow(unused_imports)]
+pub(crate) use error::{MatrixLuciError, Result};
+#[allow(unused_imports)]
+pub(crate) use factors::CrossFactors;
+#[allow(unused_imports)]
+pub(crate) use kernel::PivotKernel;
 pub use scalar::Scalar;
-pub use source::{CandidateMatrixSource, DenseMatrixSource, LazyMatrixSource};
-pub use types::{DenseOwnedMatrix, PivotKernelOptions, PivotSelectionCore};
+#[allow(unused_imports)]
+pub(crate) use source::{CandidateMatrixSource, DenseMatrixSource, LazyMatrixSource};
+#[allow(unused_imports)]
+pub(crate) use types::{DenseOwnedMatrix, PivotKernelOptions, PivotSelectionCore};

--- a/crates/tensor4all-tcicore/src/matrixluci/scalar.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/scalar.rs
@@ -3,6 +3,11 @@
 use num_complex::{Complex32, Complex64};
 use num_traits::{Float, One, Zero};
 
+use crate::error::Result;
+use crate::matrix::Matrix;
+use crate::matrix_luci::MatrixLuciFactors;
+use crate::matrixlu::RrLUOptions;
+
 /// Common scalar trait for matrix LUCI operations.
 pub trait Scalar:
     Clone
@@ -43,6 +48,25 @@ pub trait Scalar:
     fn epsilon() -> f64 {
         f64::EPSILON
     }
+
+    #[doc(hidden)]
+    fn matrix_luci_factors_from_matrix(
+        a: &Matrix<Self>,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>>
+    where
+        Self: Sized + crate::scalar::Scalar;
+
+    #[doc(hidden)]
+    fn matrix_luci_factors_from_blocks<F>(
+        nrows: usize,
+        ncols: usize,
+        fill_block: F,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>>
+    where
+        F: Fn(&[usize], &[usize], &mut [Self]),
+        Self: Sized + crate::scalar::Scalar;
 }
 
 impl Scalar for f64 {
@@ -68,6 +92,25 @@ impl Scalar for f64 {
 
     fn is_nan(self) -> bool {
         Float::is_nan(self)
+    }
+
+    fn matrix_luci_factors_from_matrix(
+        a: &Matrix<Self>,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>> {
+        crate::matrix_luci::dense_matrix_luci_factors_from_matrix(a, options)
+    }
+
+    fn matrix_luci_factors_from_blocks<F>(
+        nrows: usize,
+        ncols: usize,
+        fill_block: F,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>>
+    where
+        F: Fn(&[usize], &[usize], &mut [Self]),
+    {
+        crate::matrix_luci::lazy_matrix_luci_factors_from_blocks(nrows, ncols, fill_block, options)
     }
 }
 
@@ -95,6 +138,25 @@ impl Scalar for f32 {
     fn is_nan(self) -> bool {
         Float::is_nan(self)
     }
+
+    fn matrix_luci_factors_from_matrix(
+        a: &Matrix<Self>,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>> {
+        crate::matrix_luci::dense_matrix_luci_factors_from_matrix(a, options)
+    }
+
+    fn matrix_luci_factors_from_blocks<F>(
+        nrows: usize,
+        ncols: usize,
+        fill_block: F,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>>
+    where
+        F: Fn(&[usize], &[usize], &mut [Self]),
+    {
+        crate::matrix_luci::lazy_matrix_luci_factors_from_blocks(nrows, ncols, fill_block, options)
+    }
 }
 
 impl Scalar for Complex64 {
@@ -121,6 +183,25 @@ impl Scalar for Complex64 {
     fn is_nan(self) -> bool {
         self.re.is_nan() || self.im.is_nan()
     }
+
+    fn matrix_luci_factors_from_matrix(
+        a: &Matrix<Self>,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>> {
+        crate::matrix_luci::dense_matrix_luci_factors_from_matrix(a, options)
+    }
+
+    fn matrix_luci_factors_from_blocks<F>(
+        nrows: usize,
+        ncols: usize,
+        fill_block: F,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>>
+    where
+        F: Fn(&[usize], &[usize], &mut [Self]),
+    {
+        crate::matrix_luci::lazy_matrix_luci_factors_from_blocks(nrows, ncols, fill_block, options)
+    }
 }
 
 impl Scalar for Complex32 {
@@ -146,6 +227,25 @@ impl Scalar for Complex32 {
 
     fn is_nan(self) -> bool {
         self.re.is_nan() || self.im.is_nan()
+    }
+
+    fn matrix_luci_factors_from_matrix(
+        a: &Matrix<Self>,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>> {
+        crate::matrix_luci::dense_matrix_luci_factors_from_matrix(a, options)
+    }
+
+    fn matrix_luci_factors_from_blocks<F>(
+        nrows: usize,
+        ncols: usize,
+        fill_block: F,
+        options: RrLUOptions,
+    ) -> Result<MatrixLuciFactors<Self>>
+    where
+        F: Fn(&[usize], &[usize], &mut [Self]),
+    {
+        crate::matrix_luci::lazy_matrix_luci_factors_from_blocks(nrows, ncols, fill_block, options)
     }
 }
 

--- a/crates/tensor4all-tcicore/src/matrixluci/scalar/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/scalar/tests.rs
@@ -1,4 +1,19 @@
 use super::*;
+use crate::matrix::Matrix;
+use crate::matrix_luci::MatrixLuciFactors;
+
+fn identity2<T: Scalar>() -> Matrix<T> {
+    Matrix::from_raw_vec(
+        2,
+        2,
+        vec![
+            <T as Scalar>::from_f64(1.0),
+            <T as Scalar>::from_f64(0.0),
+            <T as Scalar>::from_f64(0.0),
+            <T as Scalar>::from_f64(1.0),
+        ],
+    )
+}
 
 fn test_scalar_generic<T: Scalar>() {
     let one = T::from_f64(1.0);
@@ -14,6 +29,74 @@ fn test_scalar_generic<T: Scalar>() {
     assert!(T::epsilon() > 0.0);
 }
 
+fn options() -> crate::matrixlu::RrLUOptions {
+    crate::matrixlu::RrLUOptions {
+        max_rank: 2,
+        rel_tol: 0.0,
+        abs_tol: 0.0,
+        left_orthogonal: true,
+    }
+}
+
+fn assert_identity2_factor_shapes<T>(factors: &MatrixLuciFactors<T>) {
+    assert_eq!(factors.rank, 2);
+    assert_eq!(factors.row_indices.len(), factors.rank);
+    assert_eq!(factors.col_indices.len(), factors.rank);
+    assert!(factors.pivot_errors.len() >= factors.rank);
+    assert_eq!(factors.left.nrows(), 2);
+    assert_eq!(factors.left.ncols(), factors.rank);
+    assert_eq!(factors.right.nrows(), factors.rank);
+    assert_eq!(factors.right.ncols(), 2);
+}
+
+fn test_matrix_luci_factor_dispatch_supported<T>()
+where
+    T: Scalar + crate::scalar::Scalar,
+{
+    let matrix = identity2::<T>();
+    let dense = <T as Scalar>::matrix_luci_factors_from_matrix(&matrix, options()).unwrap();
+    assert_identity2_factor_shapes(&dense);
+
+    let lazy = <T as Scalar>::matrix_luci_factors_from_blocks(
+        matrix.nrows(),
+        matrix.ncols(),
+        |rows, cols, out| {
+            for (j, &col) in cols.iter().enumerate() {
+                for (i, &row) in rows.iter().enumerate() {
+                    out[i + rows.len() * j] = matrix[[row, col]];
+                }
+            }
+        },
+        options(),
+    )
+    .unwrap();
+    assert_identity2_factor_shapes(&lazy);
+}
+
+fn test_matrix_luci_factor_dispatch_dense_error_lazy_success<T>()
+where
+    T: Scalar + crate::scalar::Scalar,
+{
+    let matrix = identity2::<T>();
+    let dense = <T as Scalar>::matrix_luci_factors_from_matrix(&matrix, options());
+    assert!(dense.is_err());
+
+    let lazy = <T as Scalar>::matrix_luci_factors_from_blocks(
+        matrix.nrows(),
+        matrix.ncols(),
+        |rows, cols, out| {
+            for (j, &col) in cols.iter().enumerate() {
+                for (i, &row) in rows.iter().enumerate() {
+                    out[i + rows.len() * j] = matrix[[row, col]];
+                }
+            }
+        },
+        options(),
+    )
+    .unwrap();
+    assert_identity2_factor_shapes(&lazy);
+}
+
 #[test]
 fn test_scalar_f64() {
     test_scalar_generic::<f64>();
@@ -25,6 +108,11 @@ fn test_scalar_f64() {
 }
 
 #[test]
+fn test_matrix_luci_factor_dispatch_f64() {
+    test_matrix_luci_factor_dispatch_supported::<f64>();
+}
+
+#[test]
 fn test_scalar_f32() {
     test_scalar_generic::<f32>();
 
@@ -32,6 +120,11 @@ fn test_scalar_f32() {
     assert!((Scalar::abs(x) - 2.5).abs() < 1e-6);
     assert!((x.abs_val() - 2.5).abs() < 1e-6);
     assert!(f32::from_f64(f64::NAN).is_nan());
+}
+
+#[test]
+fn test_matrix_luci_factor_dispatch_f32() {
+    test_matrix_luci_factor_dispatch_dense_error_lazy_success::<f32>();
 }
 
 #[test]
@@ -54,6 +147,11 @@ fn test_scalar_c64() {
 }
 
 #[test]
+fn test_matrix_luci_factor_dispatch_c64() {
+    test_matrix_luci_factor_dispatch_supported::<Complex64>();
+}
+
+#[test]
 fn test_scalar_c32() {
     test_scalar_generic::<Complex32>();
 
@@ -70,4 +168,9 @@ fn test_scalar_c32() {
     assert!((z_conj.im + 4.0).abs() < 1e-5);
 
     assert!(Complex32::from_f64(f64::NAN).is_nan());
+}
+
+#[test]
+fn test_matrix_luci_factor_dispatch_c32() {
+    test_matrix_luci_factor_dispatch_dense_error_lazy_success::<Complex32>();
 }

--- a/crates/tensor4all-tcicore/src/matrixluci/source.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/source.rs
@@ -12,7 +12,7 @@ use std::marker::PhantomData;
 ///
 /// Implementors provide block-level access (filling column-major sub-blocks)
 /// so that kernels can select pivots without materializing the full matrix.
-pub trait CandidateMatrixSource<T: Scalar> {
+pub(crate) trait CandidateMatrixSource<T: Scalar> {
     /// Number of rows.
     fn nrows(&self) -> usize;
 
@@ -28,6 +28,7 @@ pub trait CandidateMatrixSource<T: Scalar> {
     }
 
     /// Read a single matrix entry.
+    #[cfg(test)]
     fn get(&self, row: usize, col: usize) -> T {
         let mut out = [T::zero(); 1];
         self.get_block(&[row], &[col], &mut out);
@@ -38,7 +39,7 @@ pub trait CandidateMatrixSource<T: Scalar> {
 /// Borrowed dense matrix source with column-major layout.
 ///
 /// Wraps a column-major data slice for use with pivot kernels.
-pub struct DenseMatrixSource<'a, T: Scalar> {
+pub(crate) struct DenseMatrixSource<'a, T: Scalar> {
     data: &'a [T],
     nrows: usize,
     ncols: usize,
@@ -49,7 +50,7 @@ pub struct DenseMatrixSource<'a, T: Scalar> {
 /// Evaluates matrix blocks on demand via a user-supplied closure,
 /// avoiding full materialization. The closure fills a column-major
 /// output buffer for a given set of rows and columns.
-pub struct LazyMatrixSource<T: Scalar, F> {
+pub(crate) struct LazyMatrixSource<T: Scalar, F> {
     nrows: usize,
     ncols: usize,
     fill_block: F,

--- a/crates/tensor4all-tcicore/src/matrixluci/types.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/types.rs
@@ -12,7 +12,7 @@ use std::ops::{Index, IndexMut};
 /// data in column-major order for compatibility with dense linear algebra backends.
 /// Access elements with `m[[row, col]]`.
 #[derive(Debug, Clone)]
-pub struct DenseOwnedMatrix<T: Scalar> {
+pub(crate) struct DenseOwnedMatrix<T: Scalar> {
     pub(crate) data: Vec<T>,
     pub(crate) nrows: usize,
     pub(crate) ncols: usize,
@@ -23,7 +23,7 @@ pub struct DenseOwnedMatrix<T: Scalar> {
 /// Controls rank truncation, tolerance thresholds, and the normalization
 /// convention (left-orthogonal vs. right-orthogonal).
 #[derive(Debug, Clone)]
-pub struct PivotKernelOptions {
+pub(crate) struct PivotKernelOptions {
     /// Relative tolerance.
     pub rel_tol: f64,
     /// Absolute tolerance.
@@ -36,7 +36,7 @@ pub struct PivotKernelOptions {
 
 /// Result of pivot selection: chosen row/column indices, rank, and error history.
 #[derive(Debug, Clone)]
-pub struct PivotSelectionCore {
+pub(crate) struct PivotSelectionCore {
     /// Selected row indices.
     pub row_indices: Vec<usize>,
     /// Selected column indices.
@@ -77,11 +77,6 @@ impl<T: Scalar> DenseOwnedMatrix<T> {
     pub fn as_slice(&self) -> &[T] {
         &self.data
     }
-
-    /// Mutably borrow the underlying column-major data.
-    pub fn as_mut_slice(&mut self) -> &mut [T] {
-        &mut self.data
-    }
 }
 
 impl<T: Scalar> Index<[usize; 2]> for DenseOwnedMatrix<T> {
@@ -100,6 +95,7 @@ impl<T: Scalar> IndexMut<[usize; 2]> for DenseOwnedMatrix<T> {
 
 impl PivotKernelOptions {
     /// Canonical options for dense no-truncation behavior.
+    #[cfg(test)]
     pub fn no_truncation() -> Self {
         Self {
             rel_tol: 0.0,

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -27,8 +27,8 @@ pub use any_scalar::AnyScalar;
 pub use backend::{qr_backend, svd_backend, BackendLinalgScalar, SvdResult};
 pub use context::{default_eager_ctx, with_default_backend};
 pub use storage::{
-    contract_storage, make_mut_storage, mindim, Storage, StorageKind, StorageScalar,
-    StructuredStorage, SumFromStorage,
+    contract_storage, make_mut_storage, mindim, Storage, StorageError, StorageKind, StorageResult,
+    StorageScalar, StructuredStorage, SumFromStorage,
 };
 pub use tenferro_bridge::{
     axpby_native_tensor, axpby_storage_native, conj_native_tensor, contract_native_tensor,

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -722,12 +722,83 @@ pub enum StorageKind {
     Structured,
 }
 
+/// Errors returned by storage payload and elementwise operations.
+///
+/// Use this to distinguish scalar-kind mismatches, length mismatches, and
+/// invalid structured-storage metadata from general backend failures.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{Storage, StorageError};
+///
+/// let storage = Storage::from_dense_col_major(vec![1.0_f64], &[1]).unwrap();
+/// let err = storage.payload_c64_col_major_vec().unwrap_err();
+/// assert!(matches!(err, StorageError::ScalarKindMismatch { .. }));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    /// The storage scalar kind did not match the requested operation.
+    #[error("expected {expected} storage when {operation}, got {actual}")]
+    ScalarKindMismatch {
+        /// The scalar kind that the caller requested.
+        expected: &'static str,
+        /// The scalar kind actually stored.
+        actual: &'static str,
+        /// Human-readable operation description.
+        operation: &'static str,
+    },
+    /// Two storages had different payload lengths for an elementwise operation.
+    #[error("storage lengths must match for {operation}: {left} != {right}")]
+    LengthMismatch {
+        /// Name of the operation being performed.
+        operation: &'static str,
+        /// Left-hand payload length.
+        left: usize,
+        /// Right-hand payload length.
+        right: usize,
+    },
+    /// Structured storage metadata was invalid after an operation.
+    #[error("invalid structured storage: {0}")]
+    InvalidStructuredStorage(String),
+    /// The requested operation does not support the provided storage kinds.
+    #[error("storage types are not supported for {operation}: {left} vs {right}")]
+    OperationNotSupported {
+        /// Name of the operation being performed.
+        operation: &'static str,
+        /// Left-hand storage kind.
+        left: &'static str,
+        /// Right-hand storage kind.
+        right: &'static str,
+    },
+    /// The requested operation requires real scalars but at least one scalar was complex.
+    #[error("expected real scalars in {operation} branch: a={a}, b={b}")]
+    RealScalarRequired {
+        /// Name of the operation being performed.
+        operation: &'static str,
+        /// Left scalar display string.
+        a: String,
+        /// Right scalar display string.
+        b: String,
+    },
+}
+
+/// Result type returned by storage methods that can fail with [`StorageError`].
+pub type StorageResult<T> = std::result::Result<T, StorageError>;
+
 #[derive(Debug, Clone)]
 pub(crate) enum StorageRepr {
     /// Storage with f64 elements.
     F64(StructuredStorage<f64>),
     /// Storage with Complex64 elements.
     C64(StructuredStorage<Complex64>),
+}
+
+fn storage_scalar_kind(repr: &StorageRepr) -> &'static str {
+    match repr {
+        StorageRepr::F64(_) => "f64",
+        StorageRepr::C64(_) => "Complex64",
+    }
 }
 
 /// Types that can be computed as the result of a reduction over `Storage`.
@@ -1185,10 +1256,14 @@ impl Storage {
     /// let diag = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
     /// assert_eq!(diag.payload_f64_col_major_vec().unwrap(), vec![1.0, 2.0]);
     /// ```
-    pub fn payload_f64_col_major_vec(&self) -> Result<Vec<f64>, String> {
+    pub fn payload_f64_col_major_vec(&self) -> StorageResult<Vec<f64>> {
         match &self.0 {
             StorageRepr::F64(value) => Ok(value.payload_col_major_vec()),
-            StorageRepr::C64(_) => Err("expected f64 storage when copying f64 payload".to_string()),
+            StorageRepr::C64(_) => Err(StorageError::ScalarKindMismatch {
+                expected: "f64",
+                actual: storage_scalar_kind(&self.0),
+                operation: "copying f64 payload",
+            }),
         }
     }
 
@@ -1211,12 +1286,14 @@ impl Storage {
     /// let diag = Storage::from_diag_col_major(data.clone(), 2).unwrap();
     /// assert_eq!(diag.payload_c64_col_major_vec().unwrap(), data);
     /// ```
-    pub fn payload_c64_col_major_vec(&self) -> Result<Vec<Complex64>, String> {
+    pub fn payload_c64_col_major_vec(&self) -> StorageResult<Vec<Complex64>> {
         match &self.0 {
             StorageRepr::C64(value) => Ok(value.payload_col_major_vec()),
-            StorageRepr::F64(_) => {
-                Err("expected Complex64 storage when copying c64 payload".to_string())
-            }
+            StorageRepr::F64(_) => Err(StorageError::ScalarKindMismatch {
+                expected: "Complex64",
+                actual: storage_scalar_kind(&self.0),
+                operation: "copying c64 payload",
+            }),
         }
     }
 
@@ -1364,21 +1441,23 @@ impl Storage {
     /// let dense = s.to_dense_f64_col_major_vec(&[2, 2]).unwrap();
     /// assert_eq!(dense, vec![1.0, 2.0, 3.0, 4.0]);
     /// ```
-    pub fn to_dense_f64_col_major_vec(&self, logical_dims: &[usize]) -> Result<Vec<f64>, String> {
+    pub fn to_dense_f64_col_major_vec(&self, logical_dims: &[usize]) -> StorageResult<Vec<f64>> {
         match &self.0 {
             StorageRepr::F64(v) => {
                 let structured_dims = v.logical_dims();
                 if structured_dims != logical_dims {
-                    return Err(format!(
+                    return Err(StorageError::InvalidStructuredStorage(format!(
                         "logical dims {:?} do not match StructuredF64 logical dims {:?}",
                         logical_dims, structured_dims
-                    ));
+                    )));
                 }
                 Ok(v.logical_dense_col_major_vec())
             }
-            StorageRepr::C64(_) => {
-                Err("expected f64 storage when materializing dense f64 values".to_string())
-            }
+            StorageRepr::C64(_) => Err(StorageError::ScalarKindMismatch {
+                expected: "f64",
+                actual: storage_scalar_kind(&self.0),
+                operation: "materializing dense f64 values",
+            }),
         }
     }
 
@@ -1403,21 +1482,23 @@ impl Storage {
     pub fn to_dense_c64_col_major_vec(
         &self,
         logical_dims: &[usize],
-    ) -> Result<Vec<Complex64>, String> {
+    ) -> StorageResult<Vec<Complex64>> {
         match &self.0 {
             StorageRepr::C64(v) => {
                 let structured_dims = v.logical_dims();
                 if structured_dims != logical_dims {
-                    return Err(format!(
+                    return Err(StorageError::InvalidStructuredStorage(format!(
                         "logical dims {:?} do not match StructuredC64 logical dims {:?}",
                         logical_dims, structured_dims
-                    ));
+                    )));
                 }
                 Ok(v.logical_dense_col_major_vec())
             }
-            StorageRepr::F64(_) => {
-                Err("expected Complex64 storage when materializing dense c64 values".to_string())
-            }
+            StorageRepr::F64(_) => Err(StorageError::ScalarKindMismatch {
+                expected: "Complex64",
+                actual: storage_scalar_kind(&self.0),
+                operation: "materializing dense c64 values",
+            }),
         }
     }
 
@@ -1639,15 +1720,15 @@ impl Storage {
     /// let c = a.try_add(&b).unwrap();
     /// assert_eq!(c.to_dense_f64_col_major_vec(&[2]).unwrap(), vec![4.0, 6.0]);
     /// ```
-    pub fn try_add(&self, other: &Storage) -> Result<Storage, String> {
+    pub fn try_add(&self, other: &Storage) -> StorageResult<Storage> {
         match (&self.0, &other.0) {
             (StorageRepr::F64(a), StorageRepr::F64(b)) => {
                 if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for addition: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
+                    return Err(StorageError::LengthMismatch {
+                        operation: "addition",
+                        left: a.len(),
+                        right: b.len(),
+                    });
                 }
                 let sum_vec: Vec<f64> = a
                     .data()
@@ -1662,16 +1743,16 @@ impl Storage {
                         a.strides().to_vec(),
                         a.axis_classes().to_vec(),
                     )
-                    .map_err(|err| err.to_string())?,
+                    .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?,
                 )))
             }
             (StorageRepr::C64(a), StorageRepr::C64(b)) => {
                 if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for addition: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
+                    return Err(StorageError::LengthMismatch {
+                        operation: "addition",
+                        left: a.len(),
+                        right: b.len(),
+                    });
                 }
                 let sum_vec: Vec<Complex64> = a
                     .data()
@@ -1686,14 +1767,14 @@ impl Storage {
                         a.strides().to_vec(),
                         a.axis_classes().to_vec(),
                     )
-                    .map_err(|err| err.to_string())?,
+                    .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?,
                 )))
             }
-            _ => Err(format!(
-                "Storage types must match for addition: {:?} vs {:?}",
-                std::mem::discriminant(&self.0),
-                std::mem::discriminant(&other.0)
-            )),
+            _ => Err(StorageError::OperationNotSupported {
+                operation: "addition",
+                left: storage_scalar_kind(&self.0),
+                right: storage_scalar_kind(&other.0),
+            }),
         }
     }
 
@@ -1713,15 +1794,15 @@ impl Storage {
     /// let c = a.try_sub(&b).unwrap();
     /// assert_eq!(c.to_dense_f64_col_major_vec(&[2]).unwrap(), vec![4.0, 4.0]);
     /// ```
-    pub fn try_sub(&self, other: &Storage) -> Result<Storage, String> {
+    pub fn try_sub(&self, other: &Storage) -> StorageResult<Storage> {
         match (&self.0, &other.0) {
             (StorageRepr::F64(a), StorageRepr::F64(b)) => {
                 if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for subtraction: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
+                    return Err(StorageError::LengthMismatch {
+                        operation: "subtraction",
+                        left: a.len(),
+                        right: b.len(),
+                    });
                 }
                 let diff_vec: Vec<f64> = a
                     .data()
@@ -1736,16 +1817,16 @@ impl Storage {
                         a.strides().to_vec(),
                         a.axis_classes().to_vec(),
                     )
-                    .map_err(|err| err.to_string())?,
+                    .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?,
                 )))
             }
             (StorageRepr::C64(a), StorageRepr::C64(b)) => {
                 if a.len() != b.len() {
-                    return Err(format!(
-                        "Storage lengths must match for subtraction: {} != {}",
-                        a.len(),
-                        b.len()
-                    ));
+                    return Err(StorageError::LengthMismatch {
+                        operation: "subtraction",
+                        left: a.len(),
+                        right: b.len(),
+                    });
                 }
                 let diff_vec: Vec<Complex64> = a
                     .data()
@@ -1760,14 +1841,14 @@ impl Storage {
                         a.strides().to_vec(),
                         a.axis_classes().to_vec(),
                     )
-                    .map_err(|err| err.to_string())?,
+                    .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?,
                 )))
             }
-            _ => Err(format!(
-                "Storage types must match for subtraction: {:?} vs {:?}",
-                std::mem::discriminant(&self.0),
-                std::mem::discriminant(&other.0)
-            )),
+            _ => Err(StorageError::OperationNotSupported {
+                operation: "subtraction",
+                left: storage_scalar_kind(&self.0),
+                right: storage_scalar_kind(&other.0),
+            }),
         }
     }
 
@@ -1813,14 +1894,14 @@ impl Storage {
         a: &crate::AnyScalar,
         other: &Storage,
         b: &crate::AnyScalar,
-    ) -> Result<Storage, String> {
+    ) -> StorageResult<Storage> {
         // First check lengths match
         if self.len() != other.len() {
-            return Err(format!(
-                "Storage lengths must match for axpby: {} != {}",
-                self.len(),
-                other.len()
-            ));
+            return Err(StorageError::LengthMismatch {
+                operation: "axpby",
+                left: self.len(),
+                right: other.len(),
+            });
         }
 
         // Determine if we need complex output
@@ -1885,14 +1966,16 @@ impl Storage {
             };
             Ok(Storage::from_repr(StorageRepr::C64(
                 StructuredStorage::new(result, payload_dims, strides, axis_classes)
-                    .map_err(|err| err.to_string())?,
+                    .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?,
             )))
         } else {
             // All real
             if !a.is_real() || !b.is_real() {
-                return Err(format!(
-                    "expected real scalars in real axpby branch: a={a}, b={b}"
-                ));
+                return Err(StorageError::RealScalarRequired {
+                    operation: "real axpby",
+                    a: a.to_string(),
+                    b: b.to_string(),
+                });
             }
             let a_f = a.real();
             let b_f = b.real();
@@ -1912,14 +1995,14 @@ impl Storage {
                             x.strides().to_vec(),
                             x.axis_classes().to_vec(),
                         )
-                        .map_err(|err| err.to_string())?,
+                        .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?,
                     )))
                 }
-                _ => Err(format!(
-                    "axpby not supported for storage types: {:?} vs {:?}",
-                    std::mem::discriminant(&self.0),
-                    std::mem::discriminant(&other.0)
-                )),
+                _ => Err(StorageError::OperationNotSupported {
+                    operation: "axpby",
+                    left: storage_scalar_kind(&self.0),
+                    right: storage_scalar_kind(&other.0),
+                }),
             }
         }
     }

--- a/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
@@ -110,10 +110,49 @@ fn storage_payload_c64_readback_is_interpreted_as_payload_not_logical_dense() {
     let storage = Storage::from_diag_col_major(data.clone(), 2).unwrap();
     assert_eq!(storage.storage_kind(), StorageKind::Diagonal);
     assert_eq!(storage.payload_c64_col_major_vec().unwrap(), data);
-    assert!(storage
-        .payload_f64_col_major_vec()
-        .unwrap_err()
-        .contains("expected f64"));
+    match storage.payload_f64_col_major_vec().unwrap_err() {
+        StorageError::ScalarKindMismatch {
+            expected, actual, ..
+        } => {
+            assert_eq!(expected, "f64");
+            assert_eq!(actual, "Complex64");
+        }
+        err => panic!("unexpected error: {err}"),
+    }
+}
+
+#[test]
+fn payload_f64_reports_scalar_kind_mismatch() {
+    let storage = Storage::from_dense_col_major(vec![Complex64::new(1.0, 0.0)], &[1]).unwrap();
+
+    match storage.payload_f64_col_major_vec().unwrap_err() {
+        StorageError::ScalarKindMismatch {
+            expected, actual, ..
+        } => {
+            assert_eq!(expected, "f64");
+            assert_eq!(actual, "Complex64");
+        }
+        err => panic!("unexpected error: {err}"),
+    }
+}
+
+#[test]
+fn try_add_reports_length_mismatch() {
+    let a = Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0_f64], &[1]).unwrap();
+
+    match a.try_add(&b).unwrap_err() {
+        StorageError::LengthMismatch {
+            operation,
+            left,
+            right,
+        } => {
+            assert_eq!(operation, "addition");
+            assert_eq!(left, 2);
+            assert_eq!(right, 1);
+        }
+        err => panic!("unexpected error: {err}"),
+    }
 }
 
 #[test]
@@ -432,20 +471,44 @@ fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
     ));
 
     let mismatched_len = Storage::from_dense_col_major(vec![1.0], &[1]).unwrap();
-    let err = dense_f64_a.try_add(&mismatched_len).unwrap_err();
-    assert!(err.contains("Storage lengths must match for addition"));
-    let err = dense_f64_a.try_sub(&mismatched_len).unwrap_err();
-    assert!(err.contains("Storage lengths must match for subtraction"));
+    assert!(matches!(
+        dense_f64_a.try_add(&mismatched_len).unwrap_err(),
+        StorageError::LengthMismatch {
+            operation: "addition",
+            left: 2,
+            right: 1
+        }
+    ));
+    assert!(matches!(
+        dense_f64_a.try_sub(&mismatched_len).unwrap_err(),
+        StorageError::LengthMismatch {
+            operation: "subtraction",
+            left: 2,
+            right: 1
+        }
+    ));
 
     let mismatched_type = Storage::from_dense_col_major(
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
         &[2],
     )
     .unwrap();
-    let err = dense_f64_a.try_add(&mismatched_type).unwrap_err();
-    assert!(err.contains("Storage types must match for addition"));
-    let err = dense_f64_a.try_sub(&mismatched_type).unwrap_err();
-    assert!(err.contains("Storage types must match for subtraction"));
+    assert!(matches!(
+        dense_f64_a.try_add(&mismatched_type).unwrap_err(),
+        StorageError::OperationNotSupported {
+            operation: "addition",
+            left: "f64",
+            right: "Complex64"
+        }
+    ));
+    assert!(matches!(
+        dense_f64_a.try_sub(&mismatched_type).unwrap_err(),
+        StorageError::OperationNotSupported {
+            operation: "subtraction",
+            left: "f64",
+            right: "Complex64"
+        }
+    ));
 }
 
 // ===== StructuredStorage permute_logical_axes assertion path =====

--- a/crates/tensor4all-tensorci/src/error.rs
+++ b/crates/tensor4all-tensorci/src/error.rs
@@ -57,10 +57,6 @@ pub enum TCIError {
     #[error("Matrix CI error: {0}")]
     MatrixCIError(#[from] tensor4all_tcicore::MatrixCIError),
 
-    /// Matrix LUCI substrate error
-    #[error("Matrix LUCI error: {0}")]
-    MatrixLuciError(#[from] tensor4all_tcicore::MatrixLuciError),
-
     /// Tensor train error
     #[error("Tensor train error: {0}")]
     TensorTrainError(#[from] tensor4all_simplett::TensorTrainError),

--- a/crates/tensor4all-tensorci/src/integration.rs
+++ b/crates/tensor4all-tensorci/src/integration.rs
@@ -9,9 +9,7 @@
 use crate::error::{Result, TCIError};
 use crate::tensorci2::{crossinterpolate2, TCI2Options};
 use tensor4all_simplett::{AbstractTensorTrain, TTScalar};
-use tensor4all_tcicore::{
-    DenseLuKernel, LazyBlockRookKernel, MatrixLuciScalar, MultiIndex, PivotKernel, Scalar,
-};
+use tensor4all_tcicore::{MatrixLuciScalar, MultiIndex, Scalar};
 
 /// Gauss-Kronrod 15-point rule: nodes on [-1, 1]
 const GK15_NODES: [f64; 15] = [
@@ -186,8 +184,6 @@ pub fn integrate<T, F>(
 ) -> Result<T>
 where
     T: Scalar + TTScalar + Default + MatrixLuciScalar,
-    DenseLuKernel: PivotKernel<T>,
-    LazyBlockRookKernel: PivotKernel<T>,
     F: Fn(&[f64]) -> T,
 {
     if a.len() != b.len() {

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -52,7 +52,7 @@
 //! # Related crates
 //!
 //! - [`tensor4all_tcicore`] -- low-level matrix CI primitives and
-//!   [`CachedFunction`]
+//!   [`CachedFunction`](tensor4all_tcicore::CachedFunction)
 //! - [`tensor4all_simplett`] -- the [`TensorTrain`](tensor4all_simplett::TensorTrain)
 //!   data structure produced by TCI
 //! - `tensor4all-quanticstci` -- higher-level quantics TCI on discrete

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -79,7 +79,3 @@ pub use tensorci1::{crossinterpolate1, SweepStrategy, TCI1Options, TensorCI1};
 pub use tensorci2::{
     crossinterpolate2, PivotSearchStrategy, Sweep2Strategy, TCI2Options, TensorCI2,
 };
-
-pub use tensor4all_tcicore::{
-    CacheKey, CacheKeyError, CachedFunction, IndexInt, IndexSet, LocalIndex, MultiIndex, Scalar,
-};

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -11,11 +11,9 @@ use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use tensor4all_simplett::{tensor3_zeros, TTScalar, Tensor3, Tensor3Ops, TensorTrain};
 use tensor4all_tcicore::matrix::zeros;
-use tensor4all_tcicore::MultiIndex;
-use tensor4all_tcicore::Scalar;
 use tensor4all_tcicore::{
-    rrlu, AbstractMatrixCI, CrossFactors, DenseLuKernel, DenseMatrixSource, LazyBlockRookKernel,
-    LazyMatrixSource, MatrixLUCI, PivotKernel, PivotKernelOptions, RrLUOptions,
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, rrlu, MatrixLuciScalar,
+    MultiIndex, RrLUOptions, Scalar,
 };
 
 /// Configuration for the TCI2 algorithm ([`crossinterpolate2`]).
@@ -281,9 +279,7 @@ pub struct TensorCI2<T: Scalar + TTScalar> {
 
 impl<T> TensorCI2<T>
 where
-    T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    DenseLuKernel: PivotKernel<T>,
-    LazyBlockRookKernel: PivotKernel<T>,
+    T: Scalar + TTScalar + Default + MatrixLuciScalar,
 {
     /// Create a new empty TensorCI2
     pub fn new(local_dims: Vec<usize>) -> Result<Self> {
@@ -643,10 +639,10 @@ where
             abs_tol: config.abs_tol,
             left_orthogonal: forward,
         };
-        let luci = MatrixLUCI::from_matrix(&pi, Some(lu_options))?;
+        let factors = matrix_luci_factors_from_matrix(&pi, Some(lu_options))?;
 
-        let row_indices = luci.row_indices();
-        let col_indices = luci.col_indices();
+        let row_indices = &factors.row_indices;
+        let col_indices = &factors.col_indices;
 
         // Update I/J sets
         if forward {
@@ -659,11 +655,15 @@ where
 
         // Update site tensor
         if config.update_tensors {
-            let mat = if forward { luci.left() } else { luci.right() };
+            let mat = if forward {
+                factors.left.clone()
+            } else {
+                factors.right.clone()
+            };
             let local_dim = self.local_dims[b];
             if forward {
                 let left_dim = if b == 0 { 1 } else { self.i_set[b].len() };
-                let right_dim = luci.rank().max(1);
+                let right_dim = factors.rank.max(1);
                 let mut tensor = tensor3_zeros(left_dim, local_dim, right_dim);
                 for l in 0..left_dim {
                     for s in 0..local_dim {
@@ -677,7 +677,7 @@ where
                 }
                 self.site_tensors[b] = tensor;
             } else {
-                let left_dim = luci.rank().max(1);
+                let left_dim = factors.rank.max(1);
                 let right_dim = if b == self.len() - 1 {
                     1
                 } else {
@@ -699,12 +699,12 @@ where
         }
 
         // Update errors
-        let errors = luci.pivot_errors();
+        let errors = &factors.pivot_errors;
         if !errors.is_empty() {
             let bond_idx = if forward { b } else { b - 1 };
             self.bond_errors[bond_idx] = *errors.last().unwrap_or(&0.0);
         }
-        self.update_pivot_errors(&errors);
+        self.update_pivot_errors(errors);
 
         Ok(())
     }
@@ -978,9 +978,7 @@ pub fn crossinterpolate2<T, F, B>(
     options: TCI2Options,
 ) -> Result<(TensorCI2<T>, Vec<usize>, Vec<f64>)>
 where
-    T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    DenseLuKernel: PivotKernel<T>,
-    LazyBlockRookKernel: PivotKernel<T>,
+    T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
 {
@@ -1176,9 +1174,7 @@ fn update_pivots<T, F, B>(
     context: PivotUpdateContext<'_, B>,
 ) -> Result<()>
 where
-    T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
-    DenseLuKernel: PivotKernel<T>,
-    LazyBlockRookKernel: PivotKernel<T>,
+    T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
 {
@@ -1202,17 +1198,7 @@ where
         return Ok(());
     }
 
-    // Apply LU-based cross interpolation
-    let lu_options = PivotKernelOptions {
-        max_rank: context.options.max_bond_dim,
-        rel_tol: context.options.tolerance,
-        abs_tol: 0.0,
-        left_orthogonal: context.left_orthogonal,
-    };
-
-    let selection;
-    let factors;
-    if context.options.pivot_search == PivotSearchStrategy::Full {
+    let factors = if context.options.pivot_search == PivotSearchStrategy::Full {
         let mut pi = zeros(i_combined.len(), j_combined.len());
 
         if let Some(ref batch_fn) = context.batched_f {
@@ -1250,15 +1236,15 @@ where
             }
         }
 
-        let mut data = Vec::with_capacity(pi.nrows() * pi.ncols());
-        for col in 0..pi.ncols() {
-            for row in 0..pi.nrows() {
-                data.push(pi[[row, col]]);
-            }
-        }
-        let source = DenseMatrixSource::from_column_major(&data, pi.nrows(), pi.ncols());
-        selection = DenseLuKernel.factorize(&source, &lu_options)?;
-        factors = CrossFactors::from_source(&source, &selection)?;
+        matrix_luci_factors_from_matrix(
+            &pi,
+            Some(RrLUOptions {
+                max_rank: context.options.max_bond_dim,
+                rel_tol: context.options.tolerance,
+                abs_tol: 0.0,
+                left_orthogonal: context.left_orthogonal,
+            }),
+        )?
     } else {
         let evaluator = LazyPiEvaluator::new(
             &i_combined,
@@ -1267,30 +1253,29 @@ where
             context.batched_f,
             tci.max_sample_value,
         );
-        let source = LazyMatrixSource::new(
+        let factors_result = matrix_luci_factors_from_blocks(
             i_combined.len(),
             j_combined.len(),
             |rows, cols, out: &mut [T]| {
                 evaluator.fill_block(rows, cols, out);
             },
+            RrLUOptions {
+                max_rank: context.options.max_bond_dim,
+                rel_tol: context.options.tolerance,
+                abs_tol: 0.0,
+                left_orthogonal: context.left_orthogonal,
+            },
         );
-        let selection_result = LazyBlockRookKernel.factorize(&source, &lu_options);
         if let Some(err) = evaluator.take_error() {
             return Err(err);
         }
-        selection = selection_result?;
-
-        let factors_result = CrossFactors::from_source(&source, &selection);
-        if let Some(err) = evaluator.take_error() {
-            return Err(err);
-        }
-        factors = factors_result?;
         tci.max_sample_value = evaluator.sampled_max();
-    }
+        factors_result?
+    };
 
     // Update I and J sets
-    let row_indices = &selection.row_indices;
-    let col_indices = &selection.col_indices;
+    let row_indices = &factors.row_indices;
+    let col_indices = &factors.col_indices;
 
     tci.i_set[b + 1] = row_indices.iter().map(|&i| i_combined[i].clone()).collect();
     tci.j_set[b] = col_indices.iter().map(|&j| j_combined[j].clone()).collect();
@@ -1299,7 +1284,7 @@ where
     // filled separately by fill_site_tensors after the sweep).
     if !context.extra_i_set.is_empty() || !context.extra_j_set.is_empty() {
         // Update bond error only
-        let errors = &selection.pivot_errors;
+        let errors = &factors.pivot_errors;
         if !errors.is_empty() {
             tci.bond_errors[b] = *errors.last().unwrap_or(&0.0);
         }
@@ -1307,29 +1292,18 @@ where
     }
 
     // Update site tensors
-    let left = if context.left_orthogonal {
-        factors.cols_times_pivot_inv()?
-    } else {
-        factors.pivot_cols.clone()
-    };
-    let right = if context.left_orthogonal {
-        factors.pivot_rows.clone()
-    } else {
-        factors.pivot_inv_times_rows()?
-    };
-
     // Convert left matrix to tensor at site b
     let left_dim = if b == 0 { 1 } else { tci.i_set[b].len() };
     let site_dim_b = tci.local_dims[b];
-    let new_bond_dim = selection.rank.max(1);
+    let new_bond_dim = factors.rank.max(1);
 
     let mut tensor_b = tensor3_zeros(left_dim, site_dim_b, new_bond_dim);
     for l in 0..left_dim {
         for s in 0..site_dim_b {
             for r in 0..new_bond_dim {
                 let row = l * site_dim_b + s;
-                if row < left.nrows() && r < left.ncols() {
-                    tensor_b.set3(l, s, r, left[[row, r]]);
+                if row < factors.left.nrows() && r < factors.left.ncols() {
+                    tensor_b.set3(l, s, r, factors.left[[row, r]]);
                 }
             }
         }
@@ -1349,8 +1323,8 @@ where
         for s in 0..site_dim_bp1 {
             for r in 0..right_dim {
                 let col = s * right_dim + r;
-                if l < right.nrows() && col < right.ncols() {
-                    tensor_bp1.set3(l, s, r, right[[l, col]]);
+                if l < factors.right.nrows() && col < factors.right.ncols() {
+                    tensor_bp1.set3(l, s, r, factors.right[[l, col]]);
                 }
             }
         }
@@ -1358,8 +1332,8 @@ where
     tci.site_tensors[b + 1] = tensor_bp1;
 
     // Update bond error
-    if !selection.pivot_errors.is_empty() {
-        tci.bond_errors[b] = *selection.pivot_errors.last().unwrap_or(&0.0);
+    if !factors.pivot_errors.is_empty() {
+        tci.bond_errors[b] = *factors.pivot_errors.last().unwrap_or(&0.0);
     }
 
     Ok(())
@@ -1393,7 +1367,7 @@ fn callback_length_mismatch(actual: usize, expected: usize) -> TCIError {
 
 struct LazyPiEvaluator<'a, T, F, B>
 where
-    T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
+    T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
 {
@@ -1408,7 +1382,7 @@ where
 
 impl<'a, T, F, B> LazyPiEvaluator<'a, T, F, B>
 where
-    T: Scalar + TTScalar + Default + tensor4all_tcicore::MatrixLuciScalar,
+    T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
 {

--- a/crates/tensor4all-treetci/src/api.rs
+++ b/crates/tensor4all-treetci/src/api.rs
@@ -4,6 +4,7 @@ use crate::{
     TreeTciGraph, TreeTciOptions,
 };
 use anyhow::{ensure, Result};
+use tensor4all_core::CommonScalar;
 use tensor4all_treetn::TreeTN;
 
 /// High-level TreeTCI return type:
@@ -83,8 +84,7 @@ pub fn crossinterpolate2<T, F, P>(
     proposer: &P,
 ) -> Result<TreeTciRunResult>
 where
-    T: FullPivLuScalar,
-    tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
+    T: FullPivLuScalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
@@ -111,7 +111,7 @@ where
     let init_vals = evaluate(batch)?;
     tci.max_sample_value = init_vals
         .iter()
-        .map(|v| T::abs_val(*v))
+        .map(|v| CommonScalar::abs_val(*v))
         .fold(0.0f64, f64::max);
     ensure!(
         tci.max_sample_value > 0.0,

--- a/crates/tensor4all-treetci/src/lib.rs
+++ b/crates/tensor4all-treetci/src/lib.rs
@@ -90,5 +90,4 @@ pub use proposer::{
 #[allow(deprecated)]
 pub use state::SimpleTreeTci;
 pub use state::TreeTCI2;
-pub use update::update_edge;
 pub use visitor::{AllEdges, EdgeVisitor};

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -2,9 +2,8 @@ use crate::{
     update::update_edge, AllEdges, EdgeVisitor, GlobalIndexBatch, PivotCandidateProposer, TreeTCI2,
 };
 use anyhow::{ensure, Result};
-use tensor4all_tcicore::{
-    DenseLuKernel, MatrixLuciScalar as Scalar, PivotKernel, PivotKernelOptions,
-};
+use tensor4all_core::CommonScalar;
+use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
 
 /// MVP optimization options for TreeTCI.
 ///
@@ -130,8 +129,7 @@ pub fn optimize_default<T, F>(
     options: &TreeTciOptions,
 ) -> Result<(Vec<usize>, Vec<f64>)>
 where
-    T: Scalar,
-    DenseLuKernel: PivotKernel<T>,
+    T: Scalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
     optimize_with_proposer(state, evaluate, options, &crate::DefaultProposer)
@@ -185,8 +183,7 @@ pub fn optimize_with_proposer<T, F, P>(
     proposer: &P,
 ) -> Result<(Vec<usize>, Vec<f64>)>
 where
-    T: Scalar,
-    DenseLuKernel: PivotKernel<T>,
+    T: Scalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
@@ -211,7 +208,7 @@ where
             } else {
                 1.0
             };
-            let kernel_options = PivotKernelOptions {
+            let kernel_options = RrLUOptions {
                 rel_tol: 1e-14,
                 abs_tol: options.tolerance * error_scale,
                 max_rank: options.max_bond_dim,

--- a/crates/tensor4all-treetci/src/update.rs
+++ b/crates/tensor4all-treetci/src/update.rs
@@ -2,14 +2,16 @@ use crate::{
     assemble::{assemble_points_column_major, MultiIndex},
     assemble_global_point,
     batch::GlobalIndexBatch,
-    DefaultProposer, PivotCandidateProposer, TreeTCI2, TreeTciEdge,
+    PivotCandidateProposer, TreeTCI2, TreeTciEdge,
 };
 use anyhow::{ensure, Result};
-use tensor4all_core::ColMajorArray;
+use tensor4all_core::{ColMajorArray, CommonScalar};
 use tensor4all_tcicore::{
-    DenseLuKernel, DenseMatrixSource, MatrixLuciScalar as Scalar, PivotKernel, PivotKernelOptions,
-    PivotSelectionCore,
+    matrix_luci_factors_from_matrix, MatrixLuciFactors, MatrixLuciScalar as Scalar, RrLUOptions,
 };
+
+#[cfg(test)]
+use crate::DefaultProposer;
 
 /// Update one edge bipartition using a batch evaluator and a pivot-candidate proposer.
 ///
@@ -19,16 +21,15 @@ use tensor4all_tcicore::{
 ///
 /// This is a low-level building block; prefer [`optimize_default`](crate::optimize_default)
 /// or [`crossinterpolate2`](crate::crossinterpolate2) for typical usage.
-pub fn update_edge<T, F, P>(
+pub(crate) fn update_edge<T, F, P>(
     state: &mut TreeTCI2<T>,
     edge: TreeTciEdge,
     evaluate: F,
-    options: &PivotKernelOptions,
+    options: &RrLUOptions,
     proposer: &P,
-) -> Result<PivotSelectionCore>
+) -> Result<MatrixLuciFactors<T>>
 where
-    T: Scalar,
-    DenseLuKernel: PivotKernel<T>,
+    T: Scalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
@@ -44,15 +45,17 @@ where
     )?;
 
     for value in &values {
-        state.max_sample_value = state.max_sample_value.max(value.abs_val());
+        state.max_sample_value = state.max_sample_value.max(CommonScalar::abs_val(*value));
     }
 
-    let source = DenseMatrixSource::from_column_major(
-        &values,
-        left_candidates.len(),
-        right_candidates.len(),
-    );
-    let selection = DenseLuKernel.factorize(&source, options)?;
+    let mut matrix =
+        tensor4all_tcicore::matrix::zeros(left_candidates.len(), right_candidates.len());
+    for col in 0..right_candidates.len() {
+        for row in 0..left_candidates.len() {
+            matrix[[row, col]] = values[row + left_candidates.len() * col];
+        }
+    }
+    let selection = matrix_luci_factors_from_matrix(&matrix, Some(options.clone()))?;
 
     // Build ColMajorArray from selected pivot indices
     let n_left_sites = left_key.as_slice().len();
@@ -85,15 +88,15 @@ where
 /// Update one edge using the default proposer.
 ///
 /// Convenience wrapper around [`update_edge`] that uses [`DefaultProposer`].
-pub fn update_edge_default<T, F>(
+#[cfg(test)]
+pub(crate) fn update_edge_default<T, F>(
     state: &mut TreeTCI2<T>,
     edge: TreeTciEdge,
     evaluate: F,
-    options: &PivotKernelOptions,
-) -> Result<PivotSelectionCore>
+    options: &RrLUOptions,
+) -> Result<MatrixLuciFactors<T>>
 where
-    T: Scalar,
-    DenseLuKernel: PivotKernel<T>,
+    T: Scalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
     update_edge(state, edge, evaluate, options, &DefaultProposer)
@@ -108,7 +111,7 @@ fn evaluate_candidate_matrix<T, F>(
     evaluate: F,
 ) -> Result<Vec<T>>
 where
-    T: Scalar,
+    T: Scalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
     let mut points = Vec::with_capacity(left_candidates.len() * right_candidates.len());

--- a/crates/tensor4all-treetci/src/update/tests.rs
+++ b/crates/tensor4all-treetci/src/update/tests.rs
@@ -3,7 +3,16 @@ use crate::test_support::assert_scalar_close;
 use crate::{GlobalIndexBatch, TreeTCI2, TreeTciEdge, TreeTciGraph};
 use anyhow::Result;
 use tensor4all_core::ColMajorArray;
-use tensor4all_tcicore::PivotKernelOptions;
+use tensor4all_tcicore::RrLUOptions;
+
+fn no_truncation_options() -> RrLUOptions {
+    RrLUOptions {
+        max_rank: usize::MAX,
+        rel_tol: 0.0,
+        abs_tol: 0.0,
+        left_orthogonal: true,
+    }
+}
 
 fn two_site_graph() -> TreeTciGraph {
     TreeTciGraph::new(2, &[TreeTciEdge::new(0, 1)]).unwrap()
@@ -29,7 +38,7 @@ fn update_edge_selects_identity_pivots_on_two_site_tree() {
         &mut tci,
         TreeTciEdge::new(0, 1),
         batch_eval,
-        &PivotKernelOptions::no_truncation(),
+        &no_truncation_options(),
     )
     .unwrap();
 
@@ -63,7 +72,7 @@ fn update_edge_rejects_bad_batch_length() {
         &mut tci,
         TreeTciEdge::new(0, 1),
         bad_eval,
-        &PivotKernelOptions::no_truncation(),
+        &no_truncation_options(),
     );
 
     assert!(result.is_err());

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -29,4 +29,5 @@ rand.workspace = true
 kryst.workspace = true
 
 [dev-dependencies]
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 rand_chacha.workspace = true

--- a/crates/tensor4all-treetn/src/named_graph.rs
+++ b/crates/tensor4all-treetn/src/named_graph.rs
@@ -4,6 +4,7 @@
 //! Provides a mapping between arbitrary node name types (NodeName) and internal NodeIndex.
 //! This allows using meaningful identifiers (coordinates, strings, etc.) instead of raw indices.
 
+use anyhow::Result;
 use petgraph::stable_graph::{EdgeIndex, NodeIndex, StableGraph};
 use petgraph::EdgeType;
 use petgraph::Undirected;
@@ -62,9 +63,9 @@ where
     /// Add a node with the given name and data.
     ///
     /// Returns an error if the node already exists.
-    pub fn add_node(&mut self, node_name: NodeName, data: NodeData) -> Result<NodeIndex, String> {
+    pub fn add_node(&mut self, node_name: NodeName, data: NodeData) -> Result<NodeIndex> {
         if self.node_name_to_index.contains_key(&node_name) {
-            return Err(format!("Node already exists: {:?}", node_name));
+            return Err(anyhow::anyhow!("Node already exists: {:?}", node_name));
         }
         let node = self.graph.add_node(data);
         self.node_name_to_index.insert(node_name.clone(), node);
@@ -90,18 +91,18 @@ where
     /// Rename an existing node without changing its data or incident edges.
     ///
     /// Returns an error if the old node doesn't exist or the new name is already in use.
-    pub fn rename_node(&mut self, old_name: &NodeName, new_name: NodeName) -> Result<(), String> {
+    pub fn rename_node(&mut self, old_name: &NodeName, new_name: NodeName) -> Result<()> {
         if old_name == &new_name {
             return Ok(());
         }
         if self.node_name_to_index.contains_key(&new_name) {
-            return Err(format!("Node already exists: {:?}", new_name));
+            return Err(anyhow::anyhow!("Node already exists: {:?}", new_name));
         }
 
         let node_idx = self
             .node_name_to_index
             .remove(old_name)
-            .ok_or_else(|| format!("Node not found: {:?}", old_name))?;
+            .ok_or_else(|| anyhow::anyhow!("Node not found: {:?}", old_name))?;
 
         self.node_name_to_index.insert(new_name.clone(), node_idx);
         self.index_to_node_name.insert(node_idx, new_name);
@@ -135,23 +136,18 @@ where
     /// Add an edge between two nodes.
     ///
     /// Returns an error if either node doesn't exist.
-    pub fn add_edge(
-        &mut self,
-        n1: &NodeName,
-        n2: &NodeName,
-        weight: EdgeData,
-    ) -> Result<EdgeIndex, String>
+    pub fn add_edge(&mut self, n1: &NodeName, n2: &NodeName, weight: EdgeData) -> Result<EdgeIndex>
     where
         EdgeData: Clone,
     {
         let node1 = self
             .node_name_to_index
             .get(n1)
-            .ok_or_else(|| format!("Node not found: {:?}", n1))?;
+            .ok_or_else(|| anyhow::anyhow!("Node not found: {:?}", n1))?;
         let node2 = self
             .node_name_to_index
             .get(n2)
-            .ok_or_else(|| format!("Node not found: {:?}", n2))?;
+            .ok_or_else(|| anyhow::anyhow!("Node not found: {:?}", n2))?;
         Ok(self.graph.add_edge(*node1, *node2, weight))
     }
 

--- a/crates/tensor4all-treetn/src/named_graph/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/named_graph/tests/mod.rs
@@ -125,3 +125,14 @@ fn test_euler_tour_single_node() {
     let vertices = g.euler_tour_vertices(&"A".to_string()).unwrap();
     assert_eq!(vertices, vec![a]);
 }
+
+#[test]
+fn test_named_graph_add_node_returns_anyhow_error() {
+    let mut g: NamedGraph<String, i32, ()> = NamedGraph::new();
+    g.add_node("A".to_string(), 1).unwrap();
+
+    let result: anyhow::Result<_> = g.add_node("A".to_string(), 2);
+    let err = result.unwrap_err();
+
+    assert_eq!(err.to_string(), "Node already exists: \"A\"");
+}

--- a/crates/tensor4all-treetn/src/node_name_network.rs
+++ b/crates/tensor4all-treetn/src/node_name_network.rs
@@ -8,6 +8,7 @@
 //! when only the graph structure (without index information) is needed.
 
 use crate::named_graph::NamedGraph;
+use anyhow::Result;
 use petgraph::algo::astar;
 use petgraph::stable_graph::{EdgeIndex, NodeIndex, StableGraph};
 use petgraph::visit::{Bfs, DfsPostOrder};
@@ -150,7 +151,7 @@ where
     /// Add a node to the network.
     ///
     /// Returns an error if the node already exists.
-    pub fn add_node(&mut self, node_name: NodeName) -> Result<NodeIndex, String> {
+    pub fn add_node(&mut self, node_name: NodeName) -> Result<NodeIndex> {
         self.graph.add_node(node_name, ())
     }
 
@@ -162,7 +163,7 @@ where
     /// Add an edge between two nodes.
     ///
     /// Returns an error if either node doesn't exist.
-    pub fn add_edge(&mut self, n1: &NodeName, n2: &NodeName) -> Result<EdgeIndex, String> {
+    pub fn add_edge(&mut self, n1: &NodeName, n2: &NodeName) -> Result<EdgeIndex> {
         self.graph.add_edge(n1, n2, ())
     }
 
@@ -177,7 +178,7 @@ where
     }
 
     /// Rename an existing node.
-    pub fn rename_node(&mut self, old_name: &NodeName, new_name: NodeName) -> Result<(), String> {
+    pub fn rename_node(&mut self, old_name: &NodeName, new_name: NodeName) -> Result<()> {
         self.graph.rename_node(old_name, new_name)
     }
 

--- a/crates/tensor4all-treetn/src/node_name_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/node_name_network/tests/mod.rs
@@ -211,6 +211,17 @@ fn test_euler_tour_single_node() {
 }
 
 #[test]
+fn test_node_name_network_add_node_returns_anyhow_error() {
+    let mut net: NodeNameNetwork<String> = NodeNameNetwork::new();
+    net.add_node("A".to_string()).unwrap();
+
+    let result: anyhow::Result<_> = net.add_node("A".to_string());
+    let err = result.unwrap_err();
+
+    assert_eq!(err.to_string(), "Node already exists: \"A\"");
+}
+
+#[test]
 fn test_euler_tour_star() {
     // Star: center C connected to A, B, D, E
     //     A

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -3,7 +3,8 @@ use crate::random::{random_treetn, LinkSpace};
 use crate::SiteIndexNetwork;
 use std::collections::{HashMap, HashSet};
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{ColMajorArrayRef, StorageKind, SvdTruncationPolicy, TensorDynLen};
+use tensor4all_core::{ColMajorArrayRef, SvdTruncationPolicy, TensorDynLen};
+use tensor4all_tensorbackend::StorageKind;
 
 type DynIndex = Index<DynId, TagSet>;
 type ChainStateAndIdentity = (

--- a/crates/tensor4all-treetn/src/random.rs
+++ b/crates/tensor4all-treetn/src/random.rs
@@ -11,7 +11,8 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{RandomScalar, TensorDynLen};
+use tensor4all_core::tensor::RandomScalar;
+use tensor4all_core::TensorDynLen;
 
 /// Specification for link (bond) dimensions.
 ///

--- a/crates/tensor4all-treetn/src/site_index_network.rs
+++ b/crates/tensor4all-treetn/src/site_index_network.rs
@@ -8,6 +8,7 @@
 //! enabling topology and site space comparison independent of tensor values.
 
 use crate::node_name_network::{CanonicalizeEdges, NodeNameNetwork};
+use anyhow::Result;
 use petgraph::stable_graph::{EdgeIndex, NodeIndex, StableGraph};
 use petgraph::Undirected;
 use std::collections::{HashMap, HashSet};
@@ -99,7 +100,7 @@ where
         &mut self,
         node_name: NodeName,
         site_space: impl Into<HashSet<I>>,
-    ) -> Result<NodeIndex, String> {
+    ) -> Result<NodeIndex> {
         let node_idx = self.topology.add_node(node_name.clone())?;
         let site_space_set = site_space.into();
         // Update reverse lookup for all indices.
@@ -116,7 +117,7 @@ where
     }
 
     /// Rename an existing node and preserve its site-space metadata.
-    pub fn rename_node(&mut self, old_name: &NodeName, new_name: NodeName) -> Result<(), String> {
+    pub fn rename_node(&mut self, old_name: &NodeName, new_name: NodeName) -> Result<()> {
         if old_name == &new_name {
             return Ok(());
         }
@@ -124,7 +125,7 @@ where
         let site_space = self
             .site_spaces
             .remove(old_name)
-            .ok_or_else(|| format!("Node {:?} not found", old_name))?;
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", old_name))?;
         self.topology.rename_node(old_name, new_name.clone())?;
         for index in &site_space {
             self.index_to_node.insert(index.clone(), new_name.clone());
@@ -189,11 +190,11 @@ where
     /// Add a site index to a node's site space.
     ///
     /// Updates both the site space and the reverse lookup.
-    pub fn add_site_index(&mut self, node_name: &NodeName, index: I) -> Result<(), String> {
+    pub fn add_site_index(&mut self, node_name: &NodeName, index: I) -> Result<()> {
         let site_space = self
             .site_spaces
             .get_mut(node_name)
-            .ok_or_else(|| format!("Node {:?} not found", node_name))?;
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))?;
         site_space.insert(index.clone());
         self.index_to_node.insert(index, node_name.clone());
         Ok(())
@@ -202,11 +203,11 @@ where
     /// Remove a site index from a node's site space.
     ///
     /// Updates both the site space and the reverse lookup.
-    pub fn remove_site_index(&mut self, node_name: &NodeName, index: &I) -> Result<bool, String> {
+    pub fn remove_site_index(&mut self, node_name: &NodeName, index: &I) -> Result<bool> {
         let site_space = self
             .site_spaces
             .get_mut(node_name)
-            .ok_or_else(|| format!("Node {:?} not found", node_name))?;
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))?;
         let removed = site_space.remove(index);
         if removed {
             self.index_to_node.remove(index);
@@ -222,13 +223,13 @@ where
         node_name: &NodeName,
         old_index: &I,
         new_index: I,
-    ) -> Result<(), String> {
+    ) -> Result<()> {
         let site_space = self
             .site_spaces
             .get_mut(node_name)
-            .ok_or_else(|| format!("Node {:?} not found", node_name))?;
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))?;
         if !site_space.remove(old_index) {
-            return Err(format!(
+            return Err(anyhow::anyhow!(
                 "Index {:?} not found in node {:?}",
                 old_index.id(),
                 node_name
@@ -244,15 +245,11 @@ where
     ///
     /// Updates both the site space and the reverse lookup.
     /// This is an atomic operation that removes all old indices and adds all new ones.
-    pub fn set_site_space(
-        &mut self,
-        node_name: &NodeName,
-        new_indices: HashSet<I>,
-    ) -> Result<(), String> {
+    pub fn set_site_space(&mut self, node_name: &NodeName, new_indices: HashSet<I>) -> Result<()> {
         let site_space = self
             .site_spaces
             .get_mut(node_name)
-            .ok_or_else(|| format!("Node {:?} not found", node_name))?;
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found", node_name))?;
 
         // Remove old indices from index_to_node
         for old_idx in site_space.iter() {
@@ -282,7 +279,7 @@ where
     /// Add an edge between two nodes.
     ///
     /// Returns an error if either node doesn't exist.
-    pub fn add_edge(&mut self, n1: &NodeName, n2: &NodeName) -> Result<EdgeIndex, String> {
+    pub fn add_edge(&mut self, n1: &NodeName, n2: &NodeName) -> Result<EdgeIndex> {
         self.topology.add_edge(n1, n2)
     }
 
@@ -494,7 +491,7 @@ where
     ///
     /// # Returns
     /// - `Ok(SiteIndexNetwork)` - The resulting state's site index network after the operator acts
-    /// - `Err(String)` - Error message if the operator cannot act on this state
+    /// - `Err(anyhow::Error)` - Error message if the operator cannot act on this state
     ///
     /// # Note
     /// This is a simplified version that assumes the operator's output indices
@@ -502,10 +499,10 @@ where
     /// site index structure as the original state). For more complex operators
     /// with different input/output dimensions, a more sophisticated approach
     /// would be needed.
-    pub fn apply_operator_topology(&self, operator: &Self) -> Result<Self, String> {
+    pub fn apply_operator_topology(&self, operator: &Self) -> Result<Self> {
         // Check topology match
         if !self.topology.same_topology(&operator.topology) {
-            return Err(format!(
+            return Err(anyhow::anyhow!(
                 "Operator and state have different topologies. State nodes: {:?}, Operator nodes: {:?}",
                 self.node_names(),
                 operator.node_names()

--- a/crates/tensor4all-treetn/src/site_index_network/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/site_index_network/tests/mod.rs
@@ -519,3 +519,15 @@ fn test_compatible_different_topology() {
 
     assert!(!net1.compatible_site_dimensions(&net2));
 }
+
+#[test]
+fn test_site_index_network_add_node_returns_anyhow_error() {
+    let mut net: SiteIndexNetwork<String, DynIndex> = SiteIndexNetwork::new();
+    let site: HashSet<_> = [DynIndex::new_dyn(2)].into();
+    net.add_node("A".to_string(), site).unwrap();
+
+    let result: anyhow::Result<_> = net.add_node("A".to_string(), HashSet::new());
+    let err = result.unwrap_err();
+
+    assert_eq!(err.to_string(), "Node already exists: \"A\"");
+}

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -398,15 +398,11 @@ where
         let physical_indices: HashSet<T::Index> = tensor.external_indices().into_iter().collect();
 
         // Add to graph
-        let node_idx = self
-            .graph
-            .add_node(node_name.clone(), tensor)
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let node_idx = self.graph.add_node(node_name.clone(), tensor)?;
 
         // Add to site_index_network
         self.site_index_network
-            .add_node(node_name, physical_indices)
-            .map_err(|e| anyhow::anyhow!("Failed to add node to site_index_network: {}", e))?;
+            .add_node(node_name, physical_indices)?;
 
         Ok(node_idx)
     }
@@ -486,8 +482,7 @@ where
 
         // Add edge to site_index_network
         self.site_index_network
-            .add_edge(&node_name_a, &node_name_b)
-            .map_err(|e| anyhow::anyhow!("Failed to add edge to site_index_network: {}", e))?;
+            .add_edge(&node_name_a, &node_name_b)?;
 
         // Update physical indices: remove bond index from physical indices
         // Use remove_site_index to also update the index_to_node reverse lookup
@@ -827,8 +822,7 @@ where
         // Update site_index_network with new physical indices
         // This properly updates both the site_space and the index_to_node mapping
         self.site_index_network
-            .set_site_space(&node_name, new_physical_indices)
-            .map_err(|e| anyhow::anyhow!("Failed to update site_index_network: {}", e))?;
+            .set_site_space(&node_name, new_physical_indices)?;
 
         Ok(old_tensor)
     }
@@ -1156,11 +1150,9 @@ where
 
         self.graph
             .rename_node(old_name, new_name.clone())
-            .map_err(|e| anyhow::anyhow!(e))
             .context("rename_node: failed to rename graph node")?;
         self.site_index_network
             .rename_node(old_name, new_name.clone())
-            .map_err(|e| anyhow::anyhow!(e))
             .context("rename_node: failed to rename site-index node")?;
 
         if self.canonical_region.remove(old_name) {

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -863,12 +863,11 @@ where
         let site_space = target
             .site_space(name)
             .ok_or_else(|| anyhow::anyhow!("Fragment node {:?} not found in target", name))?;
-        sub.add_node(name.clone(), site_space.clone())
-            .map_err(anyhow::Error::msg)?;
+        sub.add_node(name.clone(), site_space.clone())?;
     }
     for (a, b) in target.edges() {
         if fragment_names.contains(&a) && fragment_names.contains(&b) {
-            sub.add_edge(&a, &b).map_err(anyhow::Error::msg)?;
+            sub.add_edge(&a, &b)?;
         }
     }
     Ok(sub)

--- a/docs/plans/2026-05-02-issue-487-layering-cleanup-design.md
+++ b/docs/plans/2026-05-02-issue-487-layering-cleanup-design.md
@@ -1,0 +1,118 @@
+# Issue #487 Layering Cleanup Design
+
+## Spec
+
+Issue: [#487](https://github.com/tensor4all/tensor4all-rs/issues/487)
+
+Downstream crates should not read or write the representation fields of
+`tensor4all-core` types directly. The immediate scope is the direct field access
+reported in `tensor4all-hdf5` and `tensor4all-capi`, plus the HDF5 rustdoc
+example duplicated in [#490](https://github.com/tensor4all/tensor4all-rs/issues/490).
+
+The user-visible behavior must stay unchanged:
+
+- HDF5 round trips preserve index ID, dimension, prime level, and tags.
+- C API index and tensor query functions return the same values and status
+  codes as before, except any diagnostics improved by separate C API cleanup.
+- Public examples show high-level APIs rather than encouraging representation
+  access.
+
+Acceptance criteria:
+
+- `tensor4all-hdf5` no longer reads or writes `DynIndex` fields directly outside
+  `tensor4all-core`.
+- `tensor4all-capi` no longer reads `TensorDynLen.indices` or `DynIndex.plev`
+  directly.
+- The HDF5 rustdoc example compares index identity through public methods.
+- New or updated tests cover same-ID indices that differ by prime level or tags
+  where the changed code could otherwise collapse identity to ID-only behavior.
+- `cargo test --release -p tensor4all-hdf5` and
+  `cargo test --release -p tensor4all-capi` pass for the affected tests.
+
+Non-goals:
+
+- Do not make index fields private in this change. That is a larger public API
+  hardening step and belongs after downstream crate usage is removed.
+- Do not redesign tag storage or index identity semantics.
+- Do not change C API signatures for this issue.
+
+## Design
+
+Use `IndexLike` and existing high-level methods wherever they already express
+the needed data:
+
+- `idx.dim()` for dimensions.
+- `idx.plev()` for prime levels.
+- `idx.tags()` for tag sets.
+- `tensor.indices()` for tensor index slices.
+- Full `DynIndex` equality for identity-preserving comparisons in examples and
+  tests.
+
+`DynId` currently exposes only a tuple field, and HDF5 serialization must write
+the numeric ITensors-compatible ID. Add a narrow public accessor on `DynId`,
+for example:
+
+```rust
+impl DynId {
+    /// Return the numeric ID value used by ITensors-compatible serialization.
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+```
+
+This accessor is intentionally less general than exposing mutable access. It
+supports stable serialization and C API query needs while keeping all callers
+read-only.
+
+For deserialization, continue constructing `DynIndex` through
+`Index::new_with_tags(DynId(id), dim, tags)`, then use the existing
+`set_plev(plev)` method instead of mutating `idx.plev`.
+
+The HDF5 example should stop building ID vectors through `idx.id`. Prefer
+comparing the whole index list:
+
+```rust
+assert_eq!(loaded.indices(), tensor.indices());
+```
+
+This verifies the ID and all metadata, matching repository rules that index
+identity is the full `Index` value, not the ID alone.
+
+## Files
+
+- Modify `crates/tensor4all-core/src/defaults/index.rs` to add the `DynId`
+  accessor and its rustdoc example.
+- Modify `crates/tensor4all-hdf5/src/index.rs` to use `id().value()`, `dim()`,
+  `plev()`, `tags()`, and `set_plev()`.
+- Modify `crates/tensor4all-hdf5/src/lib.rs` to update the rustdoc example.
+- Modify `crates/tensor4all-capi/src/index.rs` to use `id().value()` and
+  `plev()`.
+- Modify `crates/tensor4all-capi/src/tensor.rs` and any TreeTN helper path that
+  directly reads `.indices` to use `indices()`.
+
+## Testing
+
+Add focused regression coverage rather than broad snapshots:
+
+- HDF5 round trip with two indices that share `DynId` but differ by `plev` or
+  tags, asserting the loaded indices equal the originals exactly.
+- C API tensor rank/index query tests should continue to pass after switching
+  to `indices()`.
+- A `DynId::value()` doc example with an assertion.
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core defaults::index
+cargo test --release -p tensor4all-hdf5
+cargo test --release -p tensor4all-capi
+cargo test --doc --release -p tensor4all-core
+cargo test --doc --release -p tensor4all-hdf5
+```
+
+## PR Handling
+
+This chunk can close #487 and cover the HDF5 example item in #490. It may reduce
+some direct representation usage counted by #484 or #485, but those umbrella
+issues should not be closed by this PR.

--- a/docs/plans/2026-05-02-issue-488-core-public-surface-design.md
+++ b/docs/plans/2026-05-02-issue-488-core-public-surface-design.md
@@ -1,0 +1,132 @@
+# Issue #488 Core Public Surface Design
+
+## Spec
+
+Issue: [#488](https://github.com/tensor4all/tensor4all-rs/issues/488)
+
+`tensor4all-core` currently re-exports several backend or implementation-detail
+items as stable-looking public API. Because the project is in early development,
+the cleanup should remove deprecated or accidental public surface immediately
+instead of adding compatibility shims.
+
+The cleanup must reduce public exposure without breaking internal crate
+compilation:
+
+- Remove direct public access to backend storage internals through
+  `tensor4all_core::storage`.
+- Stop re-exporting helper traits intended for `TensorDynLen` implementation
+  details.
+- Review backwards-compatibility top-level module re-exports and keep only
+  modules that are intentionally part of the user-facing API.
+
+Acceptance criteria:
+
+- `tensor4all_core::storage::*` is no longer a public re-export path.
+- `RandomScalar` and `TensorAccess` are not exported from the crate root.
+- Downstream crates in the workspace compile by importing intended crates or
+  using higher-level `tensor4all-core` methods.
+- Rustdoc public API no longer advertises the removed internal paths after
+  regenerating `docs/api`.
+- README and guide snippets do not rely on removed paths.
+
+Non-goals:
+
+- Do not redesign `Storage` itself.
+- Do not remove public `TensorDynLen::storage()` or `to_storage()` in this
+  chunk; those are broader API design decisions.
+- Do not add compatibility aliases. The repository rules explicitly allow
+  immediate removal during early development.
+
+## Design
+
+Make the public API boundary explicit in `crates/tensor4all-core/src/lib.rs`.
+
+### Storage Re-exports
+
+Delete the public `storage` module and root-level storage re-exports that come
+from `tensor4all_tensorbackend` unless an item is intentionally public at the
+core level. Internal code that needs backend storage should import from
+`tensor4all-tensorbackend` directly inside the crate or use local module paths.
+
+Expected removals from the core crate root:
+
+- `storage::{make_mut_storage, mindim, Storage, StorageKind, StructuredStorage,
+  SumFromStorage}`
+- `tensor4all_core::storage::*`
+
+If workspace crates outside `tensor4all-core` require storage internals, the
+preferred fix is one of:
+
+- add an appropriate high-level `TensorDynLen` method; or
+- add a direct dependency on `tensor4all-tensorbackend` only if the crate is
+  intentionally working at backend-storage level.
+
+Do not work around missing access by reaching into fields.
+
+### TensorDynLen Implementation Helpers
+
+Stop root re-exporting:
+
+- `RandomScalar`
+- `TensorAccess`
+
+`TensorDynLen::random` can keep its generic bound in the implementation module.
+If callers need random tensor construction, they should call
+`TensorDynLen::random` with supported scalar types and should not depend on the
+helper trait as public API. If rustdoc requires the trait to be public because
+it appears in a public signature, prefer making the method signature use an
+existing public scalar trait or moving the trait documentation into the
+`tensor` module rather than exporting it from the root.
+
+`TensorAccess` is an implementation helper. Public callers should use inherent
+methods such as `TensorDynLen::indices()`.
+
+### Backwards Compatibility Modules
+
+Review the flattened modules:
+
+- `tensor4all_core::direct_sum`
+- `tensor4all_core::factorize`
+- `tensor4all_core::qr`
+- `tensor4all_core::svd`
+
+Keep the top-level function and type re-exports that are already documented as
+the intended public API, such as `svd`, `svd_with`, `SvdOptions`, `qr`,
+`qr_with`, `FactorizeOptions`, and `direct_sum`. Remove only module aliases
+that expose internal module structure rather than user-facing capabilities.
+
+This keeps user-facing operations discoverable while avoiding the
+`defaults/` module layout becoming a public compatibility contract.
+
+## Files
+
+- Modify `crates/tensor4all-core/src/lib.rs`.
+- Modify downstream imports that fail after the public re-export cleanup.
+- Regenerate `docs/api` if public API docs are part of the PR.
+- Check `README.md`, `docs/book/src/`, and examples for stale import paths.
+
+## Testing
+
+Run targeted compile checks first:
+
+```bash
+cargo check --release -p tensor4all-core
+cargo check --release --workspace
+```
+
+Then run the relevant public-surface checks:
+
+```bash
+cargo test --doc --release -p tensor4all-core
+cargo test --release -p tensor4all-core
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+If any downstream crate needs a removed item, add or use a high-level API before
+falling back to direct backend imports.
+
+## PR Handling
+
+This chunk can close #488 if the removed paths match the issue scope and the API
+dump confirms the public surface changed as intended. It should be reviewed as
+an API cleanup, not as a compatibility migration.

--- a/docs/plans/2026-05-02-issue-489-tci-public-surface-design.md
+++ b/docs/plans/2026-05-02-issue-489-tci-public-surface-design.md
@@ -1,0 +1,232 @@
+# Issue #489 TCI Public Surface Design
+
+## Spec
+
+Issue: [#489](https://github.com/tensor4all/tensor4all-rs/issues/489)
+
+TCI-related crates expose too many low-level implementation details through
+crate-root re-exports. The goal is to make each crate advertise only the API it
+owns, while internal implementations keep direct imports from their real
+dependencies.
+
+Immediate scope:
+
+- `tensor4all-tensorci` should not re-export foundational `tensor4all-tcicore`
+  cache/index/scalar types unless they are part of the TensorCI user contract.
+- `tensor4all-tcicore` should not publicly expose low-level MatrixLUCI kernels
+  and pivot internals as top-level API.
+- Similar re-export chains in `tensor4all-quanticstci` and
+  `tensor4all-partitionedtt` should be audited and trimmed if they are
+  accidental rather than intentional.
+
+Decision:
+
+- Close #489 only with a real public-surface cleanup, not with a top-level
+  `pub use` shuffle. `DenseLuKernel`, `LazyBlockRookKernel`, `PivotKernel`, and
+  `PivotSelectionCore` must disappear from public signatures as well as from
+  crate-root re-exports.
+- Keep #489 focused on `tensor4all-tensorci` and `tensor4all-tcicore`.
+  `tensor4all-quanticstci` and `tensor4all-partitionedtt` re-exports are
+  audited in this PR, but trimmed only if the change is mechanical. Otherwise
+  record a follow-up issue or PR note.
+
+Acceptance criteria:
+
+- Crate-root re-exports are limited to user-facing types and functions owned by
+  each crate.
+- No public function or impl in workspace user-facing crates requires callers
+  to name `DenseLuKernel`, `LazyBlockRookKernel`, or `PivotKernel` in a where
+  clause.
+- Workspace code compiles after switching internal imports to direct dependency
+  paths.
+- Public docs and examples import types from their owning crates instead of
+  relying on transitive re-exports.
+- `docs/api` no longer lists removed implementation types under the downstream
+  crate roots after regeneration.
+
+Non-goals:
+
+- Do not remove modules or types that are still used internally.
+- Do not redesign MatrixLUCI, TCI2, or quantics algorithms.
+- Do not add compatibility `pub use` shims or `doc(hidden)` aliases unless a
+  type remains genuinely necessary for a public signature.
+
+## Design
+
+Use a strict ownership rule:
+
+- A crate may publicly export the domain types it defines and expects users to
+  name.
+- A crate may publicly export dependency types only when those types appear in a
+  public signature that cannot reasonably be hidden.
+- Otherwise callers should import dependency types from the dependency crate
+  directly.
+
+### `tensor4all-tensorci`
+
+Current root-level re-export:
+
+```rust
+pub use tensor4all_tcicore::{
+    CacheKey, CacheKeyError, CachedFunction, IndexInt, IndexSet,
+    LocalIndex, MultiIndex, Scalar,
+};
+```
+
+Remove this block unless a specific item appears in the public TensorCI API and
+must be documented there. Public examples should import `IndexSet` or
+`MultiIndex` from `tensor4all-tcicore` if those types are actually required by
+the example.
+
+`MultiIndex`, `IndexSet`, and `Scalar` may still appear in TensorCI public
+signatures because the current algorithm is parameterized by those `tcicore`
+concepts. That is acceptable for this PR. The important boundary is that users
+must import those types from `tensor4all-tcicore`, the crate that owns them, not
+through `tensor4all-tensorci`.
+
+### `tensor4all-tcicore`
+
+Current MatrixLUCI re-exports include both user-facing algorithm types and
+kernel internals:
+
+```rust
+CandidateMatrixSource, CrossFactors, DenseLuKernel, DenseMatrixSource,
+DenseOwnedMatrix, LazyBlockRookKernel, LazyMatrixSource, MatrixLuciError,
+PivotKernel, PivotKernelOptions, PivotSelectionCore
+```
+
+Keep public high-level MatrixCI types:
+
+- `MatrixLUCI`
+- `MatrixACA`
+- `RrLU`, `RrLUOptions`, `rrlu`, `rrlu_inplace`
+- `Matrix`, `from_vec2d`
+- `AbstractMatrixCI`
+- `MatrixLuciScalar` if generic callers still need a scalar capability bound
+
+Do not keep low-level MatrixLUCI substrate types public:
+
+- kernel dispatch: `DenseLuKernel`, `LazyBlockRookKernel`, `PivotKernel`
+- source plumbing: `CandidateMatrixSource`, `DenseMatrixSource`,
+  `LazyMatrixSource`
+- internal factor/result storage: `DenseOwnedMatrix`, `CrossFactors`,
+  `PivotSelectionCore`
+- kernel-only options/errors: `PivotKernelOptions`, `MatrixLuciError`,
+  `MatrixLuciResult`
+
+The current workspace leaks these types through public where clauses such as:
+
+```rust
+DenseLuKernel: PivotKernel<T>,
+LazyBlockRookKernel: PivotKernel<T>,
+```
+
+Those bounds must be removed from public signatures. Replace them with a
+high-level scalar capability bound, normally `T: MatrixLuciScalar`, and move the
+kernel dispatch behind `tensor4all-tcicore` facade functions.
+
+Add a small public facade only if downstream crates need lazy/dense pivot
+factorization outside `MatrixLUCI::from_matrix`. The facade should return a
+domain-level result, not the low-level `CrossFactors` and `PivotSelectionCore`
+types. A shape like this is acceptable:
+
+```rust
+pub struct MatrixLuciFactors<T> {
+    pub row_indices: Vec<usize>,
+    pub col_indices: Vec<usize>,
+    pub pivot_errors: Vec<f64>,
+    pub rank: usize,
+    pub cols_times_pivot_inv: Matrix<T>,
+    pub pivot_inv_times_rows: Matrix<T>,
+}
+```
+
+The exact name can change, but the result type must expose what TensorCI needs
+without exposing how MatrixLUCI selected pivots internally. Dense and lazy
+construction functions can live in `tensor4all-tcicore` and use private
+`matrixluci` kernel implementations.
+
+### Related Crates
+
+Audit these root-level re-exports:
+
+- `tensor4all-quanticstci`: `tensor4all_simplett::{AbstractTensorTrain,
+  TensorTrain}` and `tensor4all_treetci::{DefaultProposer, TreeTciGraph,
+  TreeTciOptions}`
+- `tensor4all-partitionedtt`: `tensor4all_core::{DynIndex, TensorDynLen}` and
+  `tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions}`
+
+For each item, decide whether the downstream crate owns the public concept. If
+not, remove the re-export and update examples to import from the owning crate.
+For this PR, the decision is:
+
+- `tensor4all-quanticstci`: do not block #489 on removing these re-exports.
+  They are convenience exports of higher-level user-facing dependencies, not
+  the low-level kernel leak that makes #489 risky.
+- `tensor4all-partitionedtt`: do not block #489 on removing these re-exports.
+  They should be cleaned up separately with examples/docs because removing them
+  is user-facing import churn.
+- Record both as follow-up cleanup unless the implementation diff is trivial
+  after the `tcicore` facade lands.
+
+## Files
+
+- Modify `crates/tensor4all-tensorci/src/lib.rs`.
+- Modify `crates/tensor4all-tcicore/src/lib.rs`.
+- Modify `crates/tensor4all-tcicore/src/matrix_luci.rs` and the
+  `crates/tensor4all-tcicore/src/matrixluci/` module boundary so kernel types
+  are private implementation details.
+- Modify public functions in `tensor4all-core`, `tensor4all-simplett`,
+  `tensor4all-tensorci`, and `tensor4all-quanticstci` that currently expose
+  `DenseLuKernel: PivotKernel<T>` or `LazyBlockRookKernel: PivotKernel<T>`
+  bounds.
+- Audit `crates/tensor4all-quanticstci/src/lib.rs` and
+  `crates/tensor4all-partitionedtt/src/lib.rs`; trim only if trivial, otherwise
+  record follow-up.
+- Update tests, examples, rustdoc snippets, and mdBook imports that relied on
+  removed paths.
+- Regenerate `docs/api`.
+
+## Testing
+
+Start with API and import checks:
+
+```bash
+cargo check --release -p tensor4all-tcicore
+cargo check --release -p tensor4all-tensorci
+cargo check --release -p tensor4all-core
+cargo check --release -p tensor4all-simplett
+cargo check --release -p tensor4all-quanticstci
+cargo check --release -p tensor4all-partitionedtt
+```
+
+Then verify examples and documentation:
+
+```bash
+cargo test --doc --release -p tensor4all-tcicore
+cargo test --doc --release -p tensor4all-tensorci
+cargo test --doc --release -p tensor4all-quanticstci
+cargo test --doc --release -p tensor4all-partitionedtt
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+If public examples change in `docs/book`, also run:
+
+```bash
+./scripts/test-mdbook.sh
+```
+
+## PR Handling
+
+This chunk can close #489 only if:
+
+- `tensor4all-tensorci` no longer re-exports `tcicore` foundational types from
+  its crate root;
+- MatrixLUCI kernel/source/factor internals are not public through
+  `tensor4all-tcicore` crate-root or public workspace signatures;
+- `docs/api` no longer advertises the low-level kernel path as user-facing API;
+- related `quanticstci` and `partitionedtt` convenience re-exports are audited
+  and either trimmed or explicitly recorded as follow-up.
+
+If implementation stops at deleting root `pub use` lines while public where
+clauses still mention `DenseLuKernel` or `PivotKernel`, do not close #489.

--- a/docs/plans/2026-05-02-issues-486-490-error-doc-cleanup-design.md
+++ b/docs/plans/2026-05-02-issues-486-490-error-doc-cleanup-design.md
@@ -1,0 +1,214 @@
+# Issues #486 and #490 Error and Documentation Cleanup Design
+
+## Spec
+
+Issues:
+
+- [#486](https://github.com/tensor4all/tensor4all-rs/issues/486)
+- [#490](https://github.com/tensor4all/tensor4all-rs/issues/490)
+
+This chunk handles the smaller error-type and documentation cleanup that fits in
+the same PR as the public-surface audit:
+
+- Replace selected `Result<_, String>` public/internal error returns with
+  appropriate typed or contextual errors.
+- Remove the broad `#[allow(missing_docs)]` suppression from
+  `tensor4all-core::AnyScalar` public methods by documenting the methods.
+- Deduplicate repeated C API `require_layout()` error handling in
+  `quanticstransform.rs`.
+
+The issue #490 HDF5 doc-example item belongs to the #487 layering chunk, not
+this chunk.
+
+Acceptance criteria:
+
+- `tensor4all-tensorbackend::Storage` methods listed in #486 return a
+  `thiserror`-based `StorageError` instead of `String`.
+- `tensor4all-itensorlike::linsolve::infer_index_mappings` uses the crate error
+  type instead of plain `String`.
+- `tensor4all-treetn` graph helper modules return `anyhow::Result` or a
+  typed tree-network error rather than `Result<_, String>`.
+- `AnyScalar` public methods have rustdoc that meets repository standards
+  without using `ignore` or `no_run` examples.
+- `quanticstransform.rs` has one reusable helper or macro for
+  `require_layout()` error propagation.
+- No new C API path discards error text.
+
+Non-goals:
+
+- Do not attempt to eliminate all `unwrap()`, `expect()`, or `panic!()` calls in
+  the workspace. That belongs to #484 and #485.
+- Do not rewrite the C API last-error architecture; preserve the current
+  `set_last_error` and `run_catching` model.
+- Do not relax test tolerances.
+
+## Design
+
+### `tensor4all-tensorbackend` Storage Errors
+
+Add a public error enum in the backend crate, for example in a new
+`storage_error.rs` module or near `storage.rs` if that is the local convention:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("expected {expected} storage, got {actual}")]
+    ScalarKindMismatch {
+        expected: &'static str,
+        actual: &'static str,
+    },
+    #[error("storage lengths must match for {operation}: {left} != {right}")]
+    LengthMismatch {
+        operation: &'static str,
+        left: usize,
+        right: usize,
+    },
+    #[error("invalid structured storage: {0}")]
+    InvalidStructuredStorage(String),
+}
+```
+
+Use a crate-local result alias if it improves readability:
+
+```rust
+pub type StorageResult<T> = std::result::Result<T, StorageError>;
+```
+
+Update these methods first:
+
+- `payload_f64_col_major_vec`
+- `payload_c64_col_major_vec`
+- `to_dense_f64_col_major_vec`
+- `to_dense_c64_col_major_vec`
+- `try_add`
+- `try_sub`
+- `axpby` or the method currently reported as `try_mul` in #486, depending on
+  the current source name.
+
+When wrapping `StructuredStorage::new` errors, preserve the original message in
+`StorageError::InvalidStructuredStorage` rather than converting to an untyped
+`String`.
+
+### `tensor4all-itensorlike` Linsolve Errors
+
+Change `infer_index_mappings` to return the local
+`tensor4all_itensorlike::error::Result<SiteMappings>` or directly
+`Result<SiteMappings, TensorTrainError>`.
+
+Use existing variants where they fit:
+
+- `TensorTrainError::InvalidStructure` for missing or incompatible site
+  structure.
+- `TensorTrainError::OperationError` only for residual operation failures that
+  do not have a more precise variant.
+
+Remove call-site `map_err(|e| TensorTrainError::OperationError { message: e })`
+wrappers that become redundant after the helper returns the crate error type.
+
+### `tensor4all-treetn` Graph Helper Errors
+
+The graph helper modules are internal library infrastructure. Move
+`Result<_, String>` to `anyhow::Result<_>` for:
+
+- `node_name_network.rs`
+- `named_graph.rs`
+- `site_index_network.rs`
+
+Use `anyhow::bail!`, `anyhow::ensure!`, and `.with_context(...)` to preserve
+diagnostic details. Do not turn these into panics.
+
+If a public API exposes these error types and rustdoc becomes less clear, add
+function docs that describe the error conditions instead of exposing an enum
+prematurely.
+
+### `AnyScalar` Documentation
+
+Remove `#[allow(missing_docs)]` from the `impl AnyScalar` block and document the
+public methods it contains. Every doc example must run and include assertions.
+
+Examples should use the public constructors:
+
+- `AnyScalar::new_real`
+- `AnyScalar::new_complex`
+
+Do not match on enum variants in examples unless the method is explicitly about
+variant-level behavior.
+
+Minimum method groups to document:
+
+- constructors and conversions: `from_value`, `from_real`, `new_real`,
+  `new_complex`;
+- accessors: `real`, `imag`, `abs`, `is_complex`;
+- arithmetic helpers: `conj`, `sqrt`, `powf`;
+- tensor conversion helpers if they are public.
+
+### C API `require_layout()` Deduplication
+
+Introduce a helper that preserves the existing status-code and last-error
+behavior:
+
+```rust
+fn require_layout_or_status(
+    layout: *const t4a_qtt_layout,
+) -> Result<&'static InternalQttLayout, StatusCode> {
+    match require_layout(layout) {
+        Ok(layout) => Ok(layout),
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            Err(code)
+        }
+    }
+}
+```
+
+The exact lifetime should follow the current `require_layout` signature; if the
+layout borrow cannot be expressed cleanly with a helper function, use a local
+macro that expands to the existing early-return pattern.
+
+The key rule is behavior preservation: null layout still returns the same status
+code and sets the same last-error message.
+
+## Files
+
+- Modify `crates/tensor4all-tensorbackend/src/storage.rs` and possibly
+  `crates/tensor4all-tensorbackend/src/lib.rs`.
+- Modify `crates/tensor4all-itensorlike/src/linsolve.rs`.
+- Modify `crates/tensor4all-treetn/src/node_name_network.rs`.
+- Modify `crates/tensor4all-treetn/src/named_graph.rs`.
+- Modify `crates/tensor4all-treetn/src/site_index_network.rs`.
+- Modify `crates/tensor4all-core/src/any_scalar.rs`.
+- Modify `crates/tensor4all-capi/src/quanticstransform.rs`.
+- Update `docs/api` after public API changes.
+
+## Testing
+
+Add tests where behavior changes from string errors to typed/contextual errors:
+
+- Storage scalar-kind mismatch for f64/c64 payload access.
+- Storage length mismatch for addition/subtraction/axpby.
+- Linsolve index mapping error branch.
+- TreeTN graph duplicate node, missing node, and invalid topology branches.
+- C API null layout path still sets `t4a_last_error_message`.
+- AnyScalar doc examples through rustdoc.
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend
+cargo test --release -p tensor4all-itensorlike linsolve
+cargo test --release -p tensor4all-treetn
+cargo test --release -p tensor4all-capi quanticstransform
+cargo test --doc --release -p tensor4all-core
+cargo test --doc --release --workspace
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+## PR Handling
+
+This chunk can close #486 if all listed non-C-API `Result<_, String>` targets
+are converted. It can close the remaining #490 items if AnyScalar docs,
+`require_layout()` deduplication, and the HDF5 doc-example cleanup from the
+#487 chunk all land in the same PR.
+
+#484 and #485 should be referenced only as partially addressed if the local
+cleanup removes any `unwrap()`, `expect()`, or `panic!()` incidentally.

--- a/docs/plans/2026-05-02-issues-486-490-implementation-plan.md
+++ b/docs/plans/2026-05-02-issues-486-490-implementation-plan.md
@@ -1,0 +1,1386 @@
+# Issues 486-490 Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement the AGENTS.md audit cleanup for issues #486, #487, #488, #489, and #490 in one branch while keeping each change reviewable.
+
+**Architecture:** Treat the work as four independently reviewable chunks: layering cleanup, core public-surface cleanup, TCI public-surface cleanup, and error/documentation cleanup. Each chunk starts with a focused regression or API check, then makes the minimal code change, then runs crate-local verification before moving to the next chunk.
+
+**Tech Stack:** Rust workspace, Cargo release-mode tests, rustdoc examples, `api-dump`, `cargo fmt`, `rg`, and existing tensor4all crate APIs.
+
+---
+
+## Execution Rules
+
+- Work from branch `issues-486-490-spec-design` or a branch based on current `origin/main`.
+- Do not push or create a PR without explicit user approval.
+- Keep each task as a separate commit if committing during execution.
+- Run `cargo fmt --all` before any commit and before final verification.
+- Regenerate `docs/api` after public API changes:
+
+```bash
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+- Do not close #484 or #485 from this PR. Mention them only as partially addressed if local cleanup removes relevant `unwrap`, `expect`, or `panic` paths.
+
+## Task 1: Establish Baseline And Public Surface Inventory
+
+**Files:**
+- Read: `crates/tensor4all-core/src/lib.rs`
+- Read: `crates/tensor4all-tensorci/src/lib.rs`
+- Read: `crates/tensor4all-tcicore/src/lib.rs`
+- Read: `crates/tensor4all-core/src/defaults/index.rs`
+- Read: `crates/tensor4all-tensorbackend/src/storage.rs`
+
+**Step 1: Capture baseline search output**
+
+Run:
+
+```bash
+rg -n "pub mod storage|RandomScalar|TensorAccess|pub use tensor4all_tcicore|DenseLuKernel|LazyBlockRookKernel|PivotKernel|Result<[^>]*String|allow\\(missing_docs\\)|Err\\(\\(code, msg\\)\\)" crates
+```
+
+Expected: matches in the issue docs, including `tensor4all-core/src/lib.rs`, `tensor4all-tensorci/src/lib.rs`, `tensor4all-tcicore/src/lib.rs`, `tensor4all-tensorbackend/src/storage.rs`, `tensor4all-core/src/any_scalar.rs`, and `tensor4all-capi/src/quanticstransform.rs`.
+
+**Step 2: Check current compile before edits**
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-core
+cargo check --release -p tensor4all-tcicore
+cargo check --release -p tensor4all-tensorci
+```
+
+Expected: PASS. If baseline fails, stop and record the failure before editing.
+
+**Step 3: Commit design docs only if requested**
+
+If the design docs should be committed separately:
+
+```bash
+git add docs/plans/2026-05-02-issue-487-layering-cleanup-design.md \
+        docs/plans/2026-05-02-issue-488-core-public-surface-design.md \
+        docs/plans/2026-05-02-issue-489-tci-public-surface-design.md \
+        docs/plans/2026-05-02-issues-486-490-error-doc-cleanup-design.md \
+        docs/plans/2026-05-02-issues-486-490-implementation-plan.md
+git commit -m "docs: plan AGENTS audit cleanup"
+```
+
+Expected: commit succeeds. Skip this step if the user wants all docs and implementation in one commit.
+
+## Task 2: Add `DynId::value` And Layering Tests (#487)
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/index.rs`
+- Modify: `crates/tensor4all-hdf5/tests/test_hdf5.rs`
+- Test: `crates/tensor4all-core/src/defaults/index/tests/mod.rs`
+
+**Step 1: Add a failing test for public ID access**
+
+Add to `crates/tensor4all-core/src/defaults/index/tests/mod.rs`:
+
+```rust
+#[test]
+fn test_dyn_id_value_accessor() {
+    let id = DynId(42);
+    assert_eq!(id.value(), 42);
+}
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core test_dyn_id_value_accessor
+```
+
+Expected: FAIL with no method named `value`.
+
+**Step 2: Implement `DynId::value`**
+
+In `crates/tensor4all-core/src/defaults/index.rs`, add below `pub struct DynId(pub u64);`:
+
+```rust
+impl DynId {
+    /// Return the numeric ID value used for ITensors-compatible serialization.
+    ///
+    /// Prefer full [`Index`](crate::Index) equality for tensor index identity.
+    /// This accessor exists for stable serialization and FFI query paths that
+    /// must expose the raw numeric identifier.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynId;
+    ///
+    /// let id = DynId(42);
+    /// assert_eq!(id.value(), 42);
+    /// ```
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core test_dyn_id_value_accessor
+cargo test --doc --release -p tensor4all-core DynId
+```
+
+Expected: PASS.
+
+**Step 3: Add HDF5 full-index identity regression**
+
+Add a test to `crates/tensor4all-hdf5/tests/test_hdf5.rs`:
+
+```rust
+#[test]
+fn test_roundtrip_preserves_same_id_distinct_metadata_indices() -> anyhow::Result<()> {
+    use tensor4all_core::{DynId, Index, TagSet, TensorDynLen};
+    use tensor4all_hdf5::{load_itensor, save_itensor};
+
+    let tags_a = TagSet::from_str("Site,A")?;
+    let tags_b = TagSet::from_str("Site,B")?;
+    let i = Index::new_with_tags(DynId(7), 2, tags_a);
+    let j = Index::new_with_tags(DynId(7), 3, tags_b).set_plev(1);
+    assert_ne!(i, j);
+
+    let tensor = TensorDynLen::from_dense(
+        vec![i.clone(), j.clone()],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    )?;
+
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("same_id_metadata.h5");
+    let path = path.to_str().unwrap();
+
+    save_itensor(path, "tensor", &tensor)?;
+    let loaded = load_itensor(path, "tensor")?;
+
+    assert_eq!(loaded.indices(), tensor.indices());
+    assert_eq!(loaded.to_vec::<f64>()?, tensor.to_vec::<f64>()?);
+    Ok(())
+}
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-hdf5 test_roundtrip_preserves_same_id_distinct_metadata_indices
+```
+
+Expected: PASS before the production cleanup may already pass, but it must remain passing after removing field access.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-core/src/defaults/index.rs crates/tensor4all-hdf5/tests/test_hdf5.rs
+git commit -m "feat: add public DynId value accessor"
+```
+
+Expected: commit succeeds.
+
+## Task 3: Remove Downstream Direct Field Access (#487, part of #490)
+
+**Files:**
+- Modify: `crates/tensor4all-hdf5/src/index.rs`
+- Modify: `crates/tensor4all-hdf5/src/lib.rs`
+- Modify: `crates/tensor4all-capi/src/index.rs`
+- Modify: `crates/tensor4all-capi/src/tensor.rs`
+- Modify: `crates/tensor4all-capi/src/treetn.rs`
+
+**Step 1: Replace HDF5 index field reads/writes**
+
+In `crates/tensor4all-hdf5/src/index.rs`, use this pattern:
+
+```rust
+use tensor4all_core::IndexLike;
+```
+
+Replace direct fields:
+
+```rust
+id_ds.as_writer().write_scalar(&index.id().value())?;
+dim_ds.as_writer().write_scalar(&(index.dim() as i64))?;
+plev_ds.as_writer().write_scalar(&index.plev())?;
+write_tagset(&tags_group, index.tags())?;
+```
+
+Replace deserialization mutation:
+
+```rust
+let idx = Index::new_with_tags(DynId(id), dim as usize, tags).set_plev(plev);
+Ok(idx)
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-hdf5 test_roundtrip_preserves_same_id_distinct_metadata_indices
+```
+
+Expected: PASS.
+
+**Step 2: Update HDF5 rustdoc example**
+
+In `crates/tensor4all-hdf5/src/lib.rs`, replace ID-vector comparison with:
+
+```rust
+/// // Index identity and metadata are preserved
+/// assert_eq!(loaded.indices(), tensor.indices());
+```
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-hdf5
+```
+
+Expected: PASS.
+
+**Step 3: Replace C API index direct field reads**
+
+In `crates/tensor4all-capi/src/index.rs`, import `IndexLike` if needed and replace:
+
+```rust
+Ok(index.id().value())
+```
+
+and:
+
+```rust
+*out_plev = (*ptr).inner().plev();
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-capi index
+```
+
+Expected: PASS.
+
+**Step 4: Replace tensor index field reads**
+
+In `crates/tensor4all-capi/src/tensor.rs`, replace:
+
+```rust
+(*ptr).inner().indices.len()
+```
+
+with:
+
+```rust
+(*ptr).inner().indices().len()
+```
+
+and replace:
+
+```rust
+let indices = &(*ptr).inner().indices;
+```
+
+with:
+
+```rust
+let indices = (*ptr).inner().indices();
+```
+
+In `crates/tensor4all-capi/src/treetn.rs`, replace any `tensor.indices` access on `TensorDynLen` values with `tensor.indices()`.
+
+Run:
+
+```bash
+rg -n "\\.id\\b|\\.dim\\b|\\.plev\\b|\\.tags\\b|\\.indices\\b" crates/tensor4all-hdf5/src crates/tensor4all-capi/src
+cargo test --release -p tensor4all-capi tensor
+```
+
+Expected: remaining `rg` matches should be legitimate methods like `.dim()` or tests using local structs, not direct representation reads from `tensor4all-core`; tests pass.
+
+**Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-hdf5/src/index.rs crates/tensor4all-hdf5/src/lib.rs \
+        crates/tensor4all-capi/src/index.rs crates/tensor4all-capi/src/tensor.rs \
+        crates/tensor4all-capi/src/treetn.rs
+git commit -m "fix: use public index and tensor accessors"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Remove Core Accidental Re-exports (#488)
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/lib.rs`
+- Modify: downstream files reported by `cargo check`
+
+**Step 1: Remove accidental exports from core root**
+
+In `crates/tensor4all-core/src/lib.rs`, delete the public `storage` module:
+
+```rust
+pub mod storage {
+    //! Re-export of snapshot storage utilities.
+    pub use tensor4all_tensorbackend::{
+        make_mut_storage, mindim, AnyScalar, Storage, StorageKind, StorageScalar,
+        StructuredStorage, SumFromStorage,
+    };
+}
+```
+
+Delete the root-level storage re-export:
+
+```rust
+pub use storage::{
+    make_mut_storage, mindim, Storage, StorageKind, StructuredStorage, SumFromStorage,
+};
+```
+
+Change the tensor export block from:
+
+```rust
+pub use defaults::tensordynlen::{
+    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, RandomScalar,
+    TensorAccess, TensorDynLen,
+};
+```
+
+to:
+
+```rust
+pub use defaults::tensordynlen::{
+    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, TensorDynLen,
+};
+```
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-core
+```
+
+Expected: compile errors identify internal imports that relied on root re-exports.
+
+**Step 2: Fix imports without restoring public root exports**
+
+For code inside `tensor4all-core`, import backend types directly from `tensor4all_tensorbackend`:
+
+```rust
+use tensor4all_tensorbackend::{Storage, StorageKind, StructuredStorage};
+```
+
+For workspace crates outside core, prefer high-level `TensorDynLen` methods. If a crate genuinely manipulates backend storage, add or use its direct dependency on `tensor4all-tensorbackend`.
+
+Run:
+
+```bash
+cargo check --release --workspace
+```
+
+Expected: PASS or only failures in #489-related public bounds that will be handled next.
+
+**Step 3: Decide flattened module aliases**
+
+Run:
+
+```bash
+rg -n "tensor4all_core::(direct_sum|factorize|qr|svd)::|crate::(direct_sum|factorize|qr|svd)::" crates docs/book README.md
+```
+
+If no user-facing examples require these module aliases, remove the `pub mod direct_sum`, `pub mod factorize`, `pub mod qr`, and `pub mod svd` compatibility modules while keeping top-level function/type re-exports. If many docs use them, leave module alias removal for a follow-up and record that in the PR.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-core/src/lib.rs
+git add <downstream-import-files>
+git commit -m "fix: trim tensor4all-core public re-exports"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Add MatrixLUCI Public Facade And Hide Kernel Types (#489)
+
+**Files:**
+- Modify: `crates/tensor4all-tcicore/src/lib.rs`
+- Modify: `crates/tensor4all-tcicore/src/matrix_luci.rs`
+- Modify: `crates/tensor4all-tcicore/src/matrixluci/mod.rs`
+- Modify: `crates/tensor4all-tensorci/src/tensorci2.rs`
+
+**Step 1: Add public facade result in `matrix_luci.rs`**
+
+Add after `pub struct MatrixLUCI<T...>`:
+
+```rust
+/// High-level MatrixLUCI factors used by tensor cross interpolation.
+///
+/// This type exposes the selected pivot metadata and reconstructed dense
+/// factors without exposing the low-level pivot kernel implementation.
+#[derive(Debug, Clone)]
+pub struct MatrixLuciFactors<T: Scalar> {
+    /// Selected row indices.
+    pub row_indices: Vec<usize>,
+    /// Selected column indices.
+    pub col_indices: Vec<usize>,
+    /// Pivot error history.
+    pub pivot_errors: Vec<f64>,
+    /// Selected rank.
+    pub rank: usize,
+    /// Column factor multiplied by the inverse pivot block.
+    pub cols_times_pivot_inv: Matrix<T>,
+    /// Inverse pivot block multiplied by the row factor.
+    pub pivot_inv_times_rows: Matrix<T>,
+}
+```
+
+Add a private converter near existing helper functions:
+
+```rust
+fn factors_to_public<T>(
+    selection: crate::matrixluci::PivotSelectionCore,
+    factors: crate::matrixluci::CrossFactors<T>,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::matrixluci::Scalar,
+{
+    Ok(MatrixLuciFactors {
+        row_indices: selection.row_indices,
+        col_indices: selection.col_indices,
+        pivot_errors: selection.pivot_errors,
+        rank: selection.rank,
+        cols_times_pivot_inv: to_row_major(&factors.cols_times_pivot_inv()?),
+        pivot_inv_times_rows: to_row_major(&factors.pivot_inv_times_rows()?),
+    })
+}
+```
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-tcicore
+```
+
+Expected: PASS or missing imports that are fixed in the same file.
+
+**Step 2: Add dense and lazy facade functions**
+
+Add public functions in `crates/tensor4all-tcicore/src/matrix_luci.rs`:
+
+```rust
+/// Factorize a dense row-major candidate matrix with MatrixLUCI.
+pub fn matrix_luci_factors_from_matrix<T>(
+    a: &Matrix<T>,
+    options: Option<RrLUOptions>,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::matrixluci::Scalar,
+{
+    let options = options.unwrap_or_default();
+    let (selection, factors) = dense_selection_from_matrix(a, options)?;
+    factors_to_public(selection, factors)
+}
+
+/// Factorize a lazy candidate matrix with MatrixLUCI block-rook pivot search.
+pub fn matrix_luci_factors_from_blocks<T, F>(
+    nrows: usize,
+    ncols: usize,
+    fill_block: F,
+    options: RrLUOptions,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::matrixluci::Scalar,
+    F: Fn(&[usize], &[usize], &mut [T]),
+{
+    let source = crate::matrixluci::LazyMatrixSource::new(nrows, ncols, fill_block);
+    let kernel_options = crate::matrixluci::PivotKernelOptions {
+        max_rank: options.max_rank,
+        rel_tol: options.rel_tol,
+        abs_tol: options.abs_tol,
+        left_orthogonal: options.left_orthogonal,
+    };
+    let selection = crate::matrixluci::LazyBlockRookKernel
+        .factorize(&source, &kernel_options)
+        .map_err(map_backend_error)?;
+    let factors = crate::matrixluci::CrossFactors::from_source(&source, &selection)
+        .map_err(map_backend_error)?;
+    factors_to_public(selection, factors)
+}
+```
+
+If the exact `RrLUOptions` fields differ, use the existing field names from `dense_selection_from_matrix`.
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-tcicore
+```
+
+Expected: PASS.
+
+**Step 3: Re-export only high-level facade**
+
+In `crates/tensor4all-tcicore/src/lib.rs`, replace:
+
+```rust
+pub use self::matrixluci::{
+    CandidateMatrixSource, CrossFactors, DenseLuKernel, DenseMatrixSource, DenseOwnedMatrix,
+    LazyBlockRookKernel, LazyMatrixSource, MatrixLuciError, PivotKernel, PivotKernelOptions,
+    PivotSelectionCore,
+};
+pub use self::matrixluci::{Result as MatrixLuciResult, Scalar as MatrixLuciScalar};
+```
+
+with:
+
+```rust
+pub use self::matrixluci::Scalar as MatrixLuciScalar;
+```
+
+and extend the MatrixLUCI re-export:
+
+```rust
+pub use matrix_luci::{
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, MatrixLUCI,
+    MatrixLuciFactors,
+};
+```
+
+In `crates/tensor4all-tcicore/src/matrixluci/mod.rs`, keep submodules usable inside the crate. If direct external module access remains public through `pub mod matrixluci`, convert implementation submodules to `pub(crate) mod` where possible. If this causes rustdoc link breakage, keep the module public temporarily but ensure low-level items are not re-exported from crate root or public signatures.
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-tcicore
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-tcicore/src/lib.rs crates/tensor4all-tcicore/src/matrix_luci.rs \
+        crates/tensor4all-tcicore/src/matrixluci/mod.rs
+git commit -m "feat: add MatrixLUCI public facade"
+```
+
+Expected: commit succeeds.
+
+## Task 6: Remove Kernel Bounds From Public Signatures (#489)
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/defaults/factorize.rs`
+- Modify: `crates/tensor4all-simplett/src/compression.rs`
+- Modify: `crates/tensor4all-simplett/src/mpo/factorize.rs`
+- Modify: `crates/tensor4all-tensorci/src/tensorci2.rs`
+- Modify: `crates/tensor4all-tensorci/src/integration.rs`
+- Modify: `crates/tensor4all-quanticstci/src/quantics_tci.rs`
+- Modify: `crates/tensor4all-quanticstci/src/batched/mod.rs`
+
+**Step 1: Remove public where-clause leaks**
+
+Replace bounds like:
+
+```rust
+tensor4all_tcicore::DenseLuKernel: tensor4all_tcicore::PivotKernel<T>,
+```
+
+and:
+
+```rust
+DenseLuKernel: PivotKernel<T>,
+LazyBlockRookKernel: PivotKernel<T>,
+```
+
+with no bound. Keep scalar capability bounds:
+
+```rust
+T: tensor4all_tcicore::MatrixLuciScalar
+```
+
+Run:
+
+```bash
+rg -n "DenseLuKernel:|LazyBlockRookKernel:|PivotKernel<" crates/tensor4all-core/src/defaults/factorize.rs crates/tensor4all-simplett/src crates/tensor4all-tensorci/src crates/tensor4all-quanticstci/src
+```
+
+Expected: only internal `tcicore` implementation files should mention these types after the task is complete.
+
+**Step 2: Update dense MatrixLUCI callers**
+
+Replace direct `MatrixLUCI::from_matrix` usage only where it no longer compiles because of hidden kernel bounds. Prefer:
+
+```rust
+let luci = MatrixLUCI::from_matrix(matrix, Some(options))?;
+```
+
+if `MatrixLUCI::from_matrix` no longer exposes the kernel bound. Otherwise use:
+
+```rust
+let factors = tensor4all_tcicore::matrix_luci_factors_from_matrix(matrix, Some(options))?;
+```
+
+and consume `factors.row_indices`, `factors.col_indices`, `factors.pivot_errors`,
+`factors.cols_times_pivot_inv`, and `factors.pivot_inv_times_rows`.
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-core
+cargo check --release -p tensor4all-simplett
+```
+
+Expected: PASS.
+
+**Step 3: Update TensorCI2 pivot update**
+
+In `crates/tensor4all-tensorci/src/tensorci2.rs`, replace the direct low-level imports:
+
+```rust
+use tensor4all_tcicore::{
+    rrlu, AbstractMatrixCI, CrossFactors, DenseLuKernel, DenseMatrixSource, LazyBlockRookKernel,
+    LazyMatrixSource, MatrixLUCI, PivotKernel, PivotKernelOptions, RrLUOptions,
+};
+```
+
+with high-level imports:
+
+```rust
+use tensor4all_tcicore::{
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, rrlu, AbstractMatrixCI,
+    MatrixLUCI, RrLUOptions,
+};
+```
+
+In `update_pivots`, replace the low-level dense branch with:
+
+```rust
+let factors = matrix_luci_factors_from_matrix(&pi, Some(RrLUOptions {
+    max_rank: context.options.max_bond_dim,
+    rel_tol: context.options.tolerance,
+    abs_tol: 0.0,
+    left_orthogonal: context.left_orthogonal,
+}))?;
+```
+
+Replace the lazy branch with:
+
+```rust
+let factors_result = matrix_luci_factors_from_blocks(
+    i_combined.len(),
+    j_combined.len(),
+    |rows, cols, out: &mut [T]| {
+        evaluator.fill_block(rows, cols, out);
+    },
+    RrLUOptions {
+        max_rank: context.options.max_bond_dim,
+        rel_tol: context.options.tolerance,
+        abs_tol: 0.0,
+        left_orthogonal: context.left_orthogonal,
+    },
+);
+if let Some(err) = evaluator.take_error() {
+    return Err(err);
+}
+let factors = factors_result?;
+```
+
+Then replace references to `selection` and `CrossFactors` with fields on `factors`.
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-tensorci
+```
+
+Expected: PASS.
+
+**Step 4: Remove TensorCI transitive re-export**
+
+In `crates/tensor4all-tensorci/src/lib.rs`, delete:
+
+```rust
+pub use tensor4all_tcicore::{
+    CacheKey, CacheKeyError, CachedFunction, IndexInt, IndexSet, LocalIndex, MultiIndex, Scalar,
+};
+```
+
+Update rustdoc examples or tests that imported these from `tensor4all_tensorci`:
+
+```rust
+use tensor4all_tcicore::MultiIndex;
+```
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-tensorci
+cargo check --release -p tensor4all-tensorci
+```
+
+Expected: PASS.
+
+**Step 5: Verify public-surface removal**
+
+Run:
+
+```bash
+rg -n "tensor4all_tcicore::(DenseLuKernel|LazyBlockRookKernel|PivotKernel)|DenseLuKernel:|LazyBlockRookKernel:|PivotKernel<" crates docs/book README.md
+```
+
+Expected: matches only inside `crates/tensor4all-tcicore/src/matrixluci/` implementation and internal tests. No public workspace crate signature should mention these names.
+
+**Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-core/src/defaults/factorize.rs \
+        crates/tensor4all-simplett/src/compression.rs \
+        crates/tensor4all-simplett/src/mpo/factorize.rs \
+        crates/tensor4all-tensorci/src/tensorci2.rs \
+        crates/tensor4all-tensorci/src/integration.rs \
+        crates/tensor4all-tensorci/src/lib.rs \
+        crates/tensor4all-quanticstci/src/quantics_tci.rs \
+        crates/tensor4all-quanticstci/src/batched/mod.rs
+git commit -m "fix: hide MatrixLUCI kernel implementation types"
+```
+
+Expected: commit succeeds.
+
+## Task 7: Convert Storage String Errors To `StorageError` (#486)
+
+**Files:**
+- Modify: `crates/tensor4all-tensorbackend/src/storage.rs`
+- Modify: `crates/tensor4all-tensorbackend/src/lib.rs`
+- Test: `crates/tensor4all-tensorbackend/src/storage/tests.rs` or existing storage test module
+
+**Step 1: Add failing typed-error tests**
+
+Add tests near existing storage tests:
+
+```rust
+#[test]
+fn payload_f64_reports_scalar_kind_mismatch() {
+    let storage = Storage::from_dense_col_major(
+        vec![num_complex::Complex64::new(1.0, 0.0)],
+        &[1],
+    )
+    .unwrap();
+    let err = storage.payload_f64_col_major_vec().unwrap_err();
+    assert!(err.to_string().contains("expected f64 storage"));
+}
+
+#[test]
+fn try_add_reports_length_mismatch() {
+    let a = Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0_f64], &[1]).unwrap();
+    let err = a.try_add(&b).unwrap_err();
+    assert!(err.to_string().contains("addition"));
+    assert!(err.to_string().contains("2 != 1"));
+}
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend payload_f64_reports_scalar_kind_mismatch try_add_reports_length_mismatch
+```
+
+Expected: tests may pass with `String`, but they become the safety net for the typed conversion.
+
+**Step 2: Define `StorageError`**
+
+In `crates/tensor4all-tensorbackend/src/storage.rs`, add:
+
+```rust
+/// Errors returned by snapshot storage operations.
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    /// Storage scalar kind did not match the requested operation.
+    #[error("expected {expected} storage, got {actual}")]
+    ScalarKindMismatch {
+        /// Expected scalar kind.
+        expected: &'static str,
+        /// Actual scalar kind.
+        actual: &'static str,
+    },
+    /// Storage payload lengths must match for an elementwise operation.
+    #[error("storage lengths must match for {operation}: {left} != {right}")]
+    LengthMismatch {
+        /// Operation name.
+        operation: &'static str,
+        /// Left storage payload length.
+        left: usize,
+        /// Right storage payload length.
+        right: usize,
+    },
+    /// Structured storage metadata was invalid after an operation.
+    #[error("invalid structured storage: {0}")]
+    InvalidStructuredStorage(String),
+}
+
+type StorageResult<T> = std::result::Result<T, StorageError>;
+```
+
+Re-export in `crates/tensor4all-tensorbackend/src/lib.rs`:
+
+```rust
+pub use storage::{
+    contract_storage, make_mut_storage, mindim, Storage, StorageError, StorageKind,
+    StorageScalar, StructuredStorage, SumFromStorage,
+};
+```
+
+**Step 3: Change target method signatures**
+
+Change:
+
+```rust
+pub fn payload_f64_col_major_vec(&self) -> Result<Vec<f64>, String>
+```
+
+to:
+
+```rust
+pub fn payload_f64_col_major_vec(&self) -> StorageResult<Vec<f64>>
+```
+
+Repeat for:
+
+- `payload_c64_col_major_vec`
+- `to_dense_f64_col_major_vec`
+- `to_dense_c64_col_major_vec`
+- `try_add`
+- `try_sub`
+- `axpby`
+
+Replace `Err("...".to_string())` with `StorageError` variants. Replace `.map_err(|err| err.to_string())?` with:
+
+```rust
+.map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))?
+```
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend
+cargo check --release --workspace
+```
+
+Expected: PASS after downstream `?` conversions are adjusted.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-tensorbackend/src/storage.rs crates/tensor4all-tensorbackend/src/lib.rs
+git commit -m "fix: use typed storage errors"
+```
+
+Expected: commit succeeds.
+
+## Task 8: Convert Linsolve And TreeTN String Errors (#486)
+
+**Files:**
+- Modify: `crates/tensor4all-itensorlike/src/linsolve.rs`
+- Modify: `crates/tensor4all-treetn/src/node_name_network.rs`
+- Modify: `crates/tensor4all-treetn/src/named_graph.rs`
+- Modify: `crates/tensor4all-treetn/src/site_index_network.rs`
+
+**Step 1: Convert `infer_index_mappings`**
+
+In `crates/tensor4all-itensorlike/src/linsolve.rs`, change:
+
+```rust
+) -> std::result::Result<SiteMappings, String> {
+```
+
+to:
+
+```rust
+) -> crate::error::Result<SiteMappings> {
+```
+
+Replace string errors with:
+
+```rust
+return Err(TensorTrainError::InvalidStructure {
+    message: "explain the incompatible index mapping".to_string(),
+});
+```
+
+Remove redundant call-site wrappers that convert `String` into `OperationError`.
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-itensorlike linsolve
+```
+
+Expected: PASS.
+
+**Step 2: Convert TreeTN graph helper returns**
+
+In the three TreeTN graph helper files, add:
+
+```rust
+use anyhow::{bail, ensure, Result};
+```
+
+Change signatures from:
+
+```rust
+pub fn add_node(...) -> Result<NodeIndex, String>
+```
+
+to:
+
+```rust
+pub fn add_node(...) -> Result<NodeIndex>
+```
+
+Replace:
+
+```rust
+return Err(format!("node {node_name:?} already exists"));
+```
+
+with:
+
+```rust
+bail!("node {node_name:?} already exists");
+```
+
+Replace boolean checks with `ensure!` where clearer.
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn node_name_network named_graph site_index_network
+```
+
+Expected: PASS.
+
+**Step 3: Check no remaining targeted `Result<_, String>`**
+
+Run:
+
+```bash
+rg -n "Result<[^>]*String|std::result::Result<[^>]*String" \
+  crates/tensor4all-itensorlike/src/linsolve.rs \
+  crates/tensor4all-treetn/src/node_name_network.rs \
+  crates/tensor4all-treetn/src/named_graph.rs \
+  crates/tensor4all-treetn/src/site_index_network.rs
+```
+
+Expected: no matches.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-itensorlike/src/linsolve.rs \
+        crates/tensor4all-treetn/src/node_name_network.rs \
+        crates/tensor4all-treetn/src/named_graph.rs \
+        crates/tensor4all-treetn/src/site_index_network.rs
+git commit -m "fix: replace string errors in graph and linsolve helpers"
+```
+
+Expected: commit succeeds.
+
+## Task 9: Document `AnyScalar` Public Methods (#490)
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/any_scalar.rs`
+
+**Step 1: Remove the suppression**
+
+Delete:
+
+```rust
+#[allow(missing_docs)]
+```
+
+from the public `impl AnyScalar` block.
+
+Run:
+
+```bash
+cargo check --release -p tensor4all-core
+```
+
+Expected: FAIL with missing docs for public methods in `AnyScalar`.
+
+**Step 2: Add runnable docs with assertions**
+
+For constructors, use snippets like:
+
+```rust
+/// Create a real scalar value.
+///
+/// # Arguments
+///
+/// * `x` - Real value to store.
+///
+/// # Returns
+///
+/// A scalar whose real part is `x` and imaginary part is zero.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::AnyScalar;
+///
+/// let x = AnyScalar::new_real(2.5);
+/// assert_eq!(x.real(), 2.5);
+/// assert_eq!(x.imag(), 0.0);
+/// assert!(!x.is_complex());
+/// ```
+```
+
+For complex constructors:
+
+```rust
+/// ```
+/// use tensor4all_core::AnyScalar;
+///
+/// let z = AnyScalar::new_complex(2.0, -3.0);
+/// assert_eq!(z.real(), 2.0);
+/// assert_eq!(z.imag(), -3.0);
+/// assert!(z.is_complex());
+/// ```
+```
+
+For arithmetic helpers:
+
+```rust
+/// ```
+/// use tensor4all_core::AnyScalar;
+///
+/// let z = AnyScalar::new_complex(3.0, 4.0);
+/// assert_eq!(z.abs(), 5.0);
+/// assert_eq!(z.conj().imag(), -4.0);
+/// ```
+```
+
+Document every public method in the impl. Do not use `ignore` or `no_run`.
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-core AnyScalar
+cargo check --release -p tensor4all-core
+```
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-core/src/any_scalar.rs
+git commit -m "docs: document AnyScalar public methods"
+```
+
+Expected: commit succeeds.
+
+## Task 10: Deduplicate QuanticsTransform C API Layout Handling (#490)
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/quanticstransform.rs`
+- Test: existing `crates/tensor4all-capi/src/quanticstransform/tests/` or module tests
+
+**Step 1: Add helper or macro**
+
+Prefer a helper if lifetimes compile:
+
+```rust
+fn require_layout_or_status(
+    layout: *const t4a_qtt_layout,
+) -> std::result::Result<&'static InternalQttLayout, StatusCode> {
+    match require_layout(layout) {
+        Ok(layout) => Ok(layout),
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            Err(code)
+        }
+    }
+}
+```
+
+If the borrow lifetime is tied to the input pointer, use:
+
+```rust
+fn require_layout_or_status<'a>(
+    layout: *const t4a_qtt_layout,
+) -> std::result::Result<&'a InternalQttLayout, StatusCode> {
+    match require_layout(layout) {
+        Ok(layout) => Ok(layout),
+        Err((code, msg)) => {
+            set_last_error(&msg);
+            Err(code)
+        }
+    }
+}
+```
+
+If neither compiles cleanly, use a local macro:
+
+```rust
+macro_rules! require_layout_or_return {
+    ($layout:expr) => {
+        match require_layout($layout) {
+            Ok(layout) => layout,
+            Err((code, msg)) => {
+                set_last_error(&msg);
+                return code;
+            }
+        }
+    };
+}
+```
+
+**Step 2: Replace repeated match blocks**
+
+Replace each repeated pattern:
+
+```rust
+let layout_ref = match require_layout(layout) {
+    Ok(layout) => layout,
+    Err((code, msg)) => {
+        set_last_error(&msg);
+        return code;
+    }
+};
+```
+
+with:
+
+```rust
+let layout_ref = match require_layout_or_status(layout) {
+    Ok(layout) => layout,
+    Err(code) => return code,
+};
+```
+
+or:
+
+```rust
+let layout_ref = require_layout_or_return!(layout);
+```
+
+Run:
+
+```bash
+rg -n "Err\\(\\(code, msg\\)\\)" crates/tensor4all-capi/src/quanticstransform.rs
+cargo test --release -p tensor4all-capi quanticstransform
+```
+
+Expected: no repeated `Err((code, msg))` matches remain in this file; tests pass.
+
+**Step 3: Add last-error regression if missing**
+
+Add a test that calls one materialize function with a null layout pointer and asserts:
+
+```rust
+assert_ne!(status, T4A_SUCCESS);
+let msg = last_error_string();
+assert!(msg.contains("layout") || msg.contains("null"));
+```
+
+Use the existing test helper for `t4a_last_error_message` rather than adding a new C API helper.
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-capi quanticstransform
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-capi/src/quanticstransform.rs
+git commit -m "refactor: deduplicate qtransform layout errors"
+```
+
+Expected: commit succeeds.
+
+## Task 11: Regenerate API Docs And Fix Drift
+
+**Files:**
+- Modify: `docs/api/*.md`
+- Modify: stale docs or examples found by search
+
+**Step 1: Regenerate API dump**
+
+Run:
+
+```bash
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+Expected: generated files update.
+
+**Step 2: Search for stale public paths**
+
+Run:
+
+```bash
+rg -n "tensor4all_tensorci::(CacheKey|CachedFunction|IndexSet|MultiIndex|Scalar)|tensor4all_core::storage|DenseLuKernel|LazyBlockRookKernel|PivotKernel|PivotSelectionCore|RandomScalar|TensorAccess" README.md docs crates --glob '!target/**'
+```
+
+Expected:
+
+- No user-facing docs import `tcicore` types through `tensor4all_tensorci`.
+- No docs advertise `tensor4all_core::storage`.
+- Low-level MatrixLUCI kernel names appear only in internal implementation docs/tests if they remain visible at all.
+
+**Step 3: Update docs if needed**
+
+For each stale import, change it to the owning crate:
+
+```rust
+use tensor4all_tcicore::MultiIndex;
+```
+
+or remove the import entirely if it is no longer public.
+
+Run:
+
+```bash
+cargo test --doc --release --workspace
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add docs/api README.md docs/book crates
+git commit -m "docs: update API references after cleanup"
+```
+
+Expected: commit succeeds. If no docs changed beyond `docs/api`, commit only generated docs.
+
+## Task 12: Final Verification
+
+**Files:**
+- All changed files
+
+**Step 1: Format and dry-check formatting**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+Expected: PASS.
+
+**Step 2: Run crate checks**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+**Step 3: Run targeted release tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-core
+cargo test --release -p tensor4all-hdf5
+cargo test --release -p tensor4all-capi
+cargo test --release -p tensor4all-tensorbackend
+cargo test --release -p tensor4all-itensorlike linsolve
+cargo test --release -p tensor4all-treetn
+cargo test --release -p tensor4all-tcicore
+cargo test --release -p tensor4all-tensorci
+cargo test --release -p tensor4all-simplett
+cargo test --release -p tensor4all-quanticstci
+cargo test --release -p tensor4all-partitionedtt
+```
+
+Expected: PASS.
+
+**Step 4: Run doc and guide checks**
+
+Run:
+
+```bash
+cargo test --doc --release --workspace
+./scripts/test-mdbook.sh
+cargo doc --workspace --no-deps
+```
+
+Expected: PASS.
+
+**Step 5: Run full suite if time allows**
+
+Run:
+
+```bash
+cargo nextest run --release --workspace
+```
+
+Expected: PASS.
+
+**Step 6: Final public-surface audit**
+
+Run:
+
+```bash
+rg -n "tensor4all_core::storage|pub mod storage|RandomScalar|TensorAccess|DenseLuKernel:|LazyBlockRookKernel:|PivotKernel<|pub use tensor4all_tcicore" crates docs/api README.md
+```
+
+Expected:
+
+- No `tensor4all_core::storage` user-facing path.
+- No root `RandomScalar` or `TensorAccess` re-export.
+- No public where-clause leak of MatrixLUCI kernels.
+- No `tensor4all-tensorci` re-export of `tcicore` foundational types.
+
+**Step 7: Prepare PR summary**
+
+Draft PR body:
+
+```markdown
+Closes #486.
+Closes #487.
+Closes #488.
+Closes #489.
+Closes #490.
+
+Partially addresses #484 and #485 only where local cleanup removed existing unwrap/expect/panic patterns.
+
+## Summary
+- Removed downstream direct field access to core index/tensor representations.
+- Trimmed accidental core and TCI public re-exports.
+- Hid MatrixLUCI kernel internals behind public facade APIs.
+- Replaced targeted `Result<_, String>` paths with typed/contextual errors.
+- Added rustdoc for AnyScalar and deduplicated qtransform layout error handling.
+
+## Verification
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --doc --release --workspace`
+- `./scripts/test-mdbook.sh`
+- `cargo nextest run --release --workspace`
+```
+
+Do not push or create the PR until the user approves.


### PR DESCRIPTION
Closes #486.
Closes #487.
Closes #488.
Closes #489.
Closes #490.

## Summary
- Removed downstream direct field access to core index/tensor representations and added the public `DynId::value()` accessor for serialization/FFI paths.
- Trimmed accidental core and TensorCI public re-exports, including backend storage paths, helper traits, and low-level MatrixLUCI kernel types.
- Added MatrixLUCI facade APIs, typed/contextual errors for targeted `Result<_, String>` paths, complete `AnyScalar` rustdoc, and deduplicated qtransform layout error handling.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Targeted release tests for changed crates, including `tensor4all-core`, `tensor4all-hdf5`, `tensor4all-capi`, `tensor4all-tensorbackend`, `tensor4all-itensorlike linsolve`, `tensor4all-treetn`, `tensor4all-tcicore`, `tensor4all-tensorci`, `tensor4all-simplett`, `tensor4all-quanticstci`, and `tensor4all-partitionedtt`
- `cargo test --doc --release --workspace`
- `./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`
- `cargo nextest run --release --workspace` (2012 passed, 7 skipped)

## Notes
- `cargo run -p api-dump --release -- . -o docs/api` was run after public API changes.
- Public-surface audit still finds MatrixLUCI kernel names only in `tensor4all-tcicore` internal implementation files; no downstream public signature exposes them.