### PR TITLE
Draft: consolidate issue fixes

### DIFF
--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -657,7 +657,13 @@ impl TensorTrain {
     ///
     /// This invalidates orthogonality tracking.
     fn set_tensor_raw(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
-        let node_idx = self.treetn.node_index(&site).expect("Site out of bounds");
+        let node_idx = self
+            .treetn
+            .node_index(&site)
+            .ok_or(TensorTrainError::SiteOutOfBounds {
+                site,
+                length: self.len(),
+            })?;
         self.treetn.replace_tensor(node_idx, tensor).map_err(|e| {
             TensorTrainError::InvalidStructure {
                 message: format!("Failed to replace tensor at site {}: {}", site, e),
@@ -669,12 +675,45 @@ impl TensorTrain {
     /// Replace the tensor at the given site.
     ///
     /// This invalidates orthogonality tracking.
-    pub fn set_tensor(&mut self, site: usize, tensor: TensorDynLen) {
-        self.set_tensor_raw(site, tensor)
-            .and_then(|()| self.normalize_site_tensor_order(site))
-            .unwrap_or_else(|e| panic!("TensorTrain::set_tensor failed: {}", e));
+    ///
+    /// # Arguments
+    ///
+    /// * `site` - The site index whose tensor should be replaced.
+    /// * `tensor` - The new tensor to store at `site`. Its structure must be
+    ///   compatible with the existing tensor-train topology.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(())` after the tensor is replaced and the local site tensor order is
+    /// normalized.
+    ///
+    /// # Errors
+    ///
+    /// Returns `TensorTrainError::SiteOutOfBounds` if `site` is not a valid
+    /// tensor-train site. Returns `TensorTrainError::InvalidStructure` if the
+    /// replacement tensor cannot be inserted without violating the tensor-train
+    /// structure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_itensorlike::TensorTrain;
+    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    ///
+    /// let site = Index::new_with_size(DynId(0), 2);
+    /// let tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap();
+    /// let replacement = TensorDynLen::from_dense(vec![site.clone()], vec![0.5, 0.5]).unwrap();
+    /// let mut tt = TensorTrain::new(vec![tensor]).unwrap();
+    ///
+    /// assert!(tt.set_tensor(0, replacement).is_ok());
+    /// assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![0.5, 0.5]);
+    /// ```
+    pub fn set_tensor(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
+        self.set_tensor_raw(site, tensor)?;
+        self.normalize_site_tensor_order(site)?;
         // Invalidate orthogonality
         let _ = self.treetn.set_canonical_region(Vec::<usize>::new());
+        Ok(())
     }
 
     /// Orthogonalize the tensor train to have orthogonality center at the given site.
@@ -1263,11 +1302,12 @@ impl TensorLike for TensorTrain {
 
     fn conj(&self) -> Self {
         // Clone and conjugate each site tensor
-        // Note: conj() cannot return Result, so we ensure this never fails
+        // Conjugation preserves the tensor-train structure, so mutate tensors
+        // in place without changing the topology or orthogonality metadata.
         let mut result = self.clone();
         for site in 0..result.len() {
             let t = result.tensor(site).conj();
-            result.set_tensor(site, t);
+            *result.tensor_mut(site) = t;
         }
         result
     }

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -665,7 +665,7 @@ fn test_set_tensor_invalidates_ortho() {
 
     // Replace tensor at site 0
     let new_tensor = make_tensor(vec![s0, l01]);
-    tt.set_tensor(0, new_tensor);
+    assert!(tt.set_tensor(0, new_tensor).is_ok());
     assert!(!tt.isortho());
 }
 

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -201,10 +201,10 @@ fn elementwise_mul(
             .unwrap();
 
         let t1 = as_diagonal(m1_prep.tensor(pos1), s, &s_result, &s_contract);
-        m1_prep.set_tensor(pos1, t1);
+        assert!(m1_prep.set_tensor(pos1, t1).is_ok());
 
         let t2 = as_diagonal(m2_prep.tensor(pos2), s, &s_contract, s);
-        m2_prep.set_tensor(pos2, t2);
+        assert!(m2_prep.set_tensor(pos2, t2).is_ok());
 
         maps.push((s.clone(), s_result));
     }
@@ -219,7 +219,7 @@ fn elementwise_mul(
             .unwrap();
         let t = result.tensor(pos);
         let extracted = extract_diagonal(t, original, s_result);
-        result.set_tensor(pos, extracted);
+        assert!(result.set_tensor(pos, extracted).is_ok());
     }
     result
 }

--- a/crates/tensor4all-itensorlike/tests/bug_set_tensor.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_set_tensor.rs
@@ -1,0 +1,29 @@
+use tensor4all_core::index::DefaultIndex as Index;
+use tensor4all_core::TensorDynLen;
+use tensor4all_itensorlike::{TensorTrain, TensorTrainError};
+
+#[test]
+fn set_tensor_returns_an_error_for_an_invalid_site() {
+    let site = Index::new_dyn(2);
+    let tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap();
+    let replacement = TensorDynLen::from_dense(vec![site.clone()], vec![0.5, 0.5]).unwrap();
+    let mut tt = TensorTrain::new(vec![tensor]).unwrap();
+
+    let result = tt.set_tensor(1, replacement);
+
+    assert!(matches!(
+        result,
+        Err(TensorTrainError::SiteOutOfBounds { site: 1, length: 1 })
+    ));
+}
+
+#[test]
+fn set_tensor_replaces_the_tensor_at_the_requested_site() {
+    let site = Index::new_dyn(2);
+    let tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap();
+    let replacement = TensorDynLen::from_dense(vec![site.clone()], vec![0.5, 0.5]).unwrap();
+    let mut tt = TensorTrain::new(vec![tensor]).unwrap();
+
+    assert!(tt.set_tensor(0, replacement).is_ok());
+    assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![0.5, 0.5]);
+}


### PR DESCRIPTION
This is a draft consolidation PR for the autonomous issue-fix batch.

Current included work:
- Related issue: 485. Makes `TensorTrain::set_tensor` fallible instead of panicking on invalid sites, with regression coverage.

Planned before marking ready:
- Continue batching additional related issue fixes on this branch.
- Do not close issue 485 until the remaining panic paths are handled or explicitly split.