### PR TITLE
Fix batched docs, dense guards, and C API diagnostics

### DIFF
--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -371,12 +371,12 @@ typedef struct t4a_svd_truncation_policy {
 #define T4A_SUCCESS 0
 
 /**
- * Too many tags would be added to a TagSet (exceeds maximum).
+ * Too many tags would be added to a fixed-capacity tag set.
  */
 #define T4A_TAG_OVERFLOW -3
 
 /**
- * A tag string exceeds the maximum allowed length.
+ * A tag string exceeds a fixed-capacity tag storage limit.
  */
 #define T4A_TAG_TOO_LONG -4
 
@@ -419,11 +419,17 @@ StatusCode t4a_index_id(const struct t4a_index *ptr, uint64_t *out_id);
 
 /**
  * Create a new index with explicit tags and prime level.
+ *
+ * Tags are provided as a comma-separated UTF-8 string and are preserved
+ * losslessly by the default dynamic index tag storage.
  */
 StatusCode t4a_index_new(size_t dim, const char *tags_csv, int64_t plev, struct t4a_index **out);
 
 /**
  * Create a new index with explicit identity, tags, and prime level.
+ *
+ * Tags are provided as a comma-separated UTF-8 string and are preserved
+ * losslessly by the default dynamic index tag storage.
  */
 StatusCode t4a_index_new_with_id(size_t dim,
                                  uint64_t id,

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -199,7 +199,13 @@ typedef enum t4a_contract_method {
    */
   T4A_CONTRACT_METHOD_FIT = 1,
   /**
-   * Naive dense contraction.
+   * Naive dense/reference contraction for generic TreeTN contraction.
+   *
+   * This materializes full dense tensors for `t4a_treetn_contract`; that entry
+   * point requires an explicit nonzero `max_dense_elements` limit when this
+   * method is selected. `t4a_treetn_apply_operator_chain` uses a dedicated
+   * local-exact apply path for this method instead of generic full-dense
+   * TreeTN contraction.
    */
   T4A_CONTRACT_METHOD_NAIVE = 2,
 } t4a_contract_method;
@@ -843,6 +849,8 @@ StatusCode t4a_treetn_add(const struct t4a_treetn *a,
  *
  * For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
  * default", which currently resolves to one variational sweep.
+ * `t4a_contract_method::Naive` uses the dedicated local-exact apply path here,
+ * not the generic full-dense TreeTN contraction used by `t4a_treetn_contract`.
  */
 StatusCode t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
                                            const struct t4a_treetn *state,
@@ -874,6 +882,11 @@ StatusCode t4a_treetn_clone(const struct t4a_treetn *src, struct t4a_treetn **ou
 /**
  * Contract two tree tensor networks with the requested method.
  *
+ * `t4a_contract_method::Naive` is a dense/reference method that materializes
+ * both TreeTNs and the contracted result as full tensors. Pass a nonzero
+ * `max_dense_elements` to opt into this path for small reference cases; each
+ * dense input and output tensor must fit under that limit.
+ *
  * For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
  * default", which currently resolves to one variational sweep.
  */
@@ -886,6 +899,7 @@ StatusCode t4a_treetn_contract(const struct t4a_treetn *a,
                                double convergence_tol,
                                enum t4a_factorize_alg factorize_alg,
                                double qr_rtol,
+                               size_t max_dense_elements,
                                struct t4a_treetn **out);
 
 /**

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -12,7 +12,7 @@ use crate::{
     T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::IndexLike;
+use tensor4all_core::{IndexLike, TagSetLike};
 
 /// Release an index handle.
 #[unsafe(no_mangle)]

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -7,9 +7,9 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::types::{t4a_index, InternalIndex};
 use crate::{
-    capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
-    set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
-    T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
+    capi_error, clone_opaque, err_buffer_too_small, err_null_pointer, is_assigned_opaque,
+    panic_message, release_opaque, run_catching, set_last_error, CapiResult, StatusCode,
+    T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use tensor4all_core::index::{DynId, Index, TagSet};
 use tensor4all_core::{IndexLike, TagSetLike};
@@ -117,7 +117,7 @@ where
     F: FnOnce() -> CapiResult<T>,
 {
     if out.is_null() {
-        return T4A_NULL_POINTER;
+        return err_null_pointer("out");
     }
 
     match catch_unwind(AssertUnwindSafe(f)) {
@@ -169,8 +169,11 @@ pub extern "C" fn t4a_index_new_with_id(
 /// Get the dimension of an index.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> StatusCode {
-    if ptr.is_null() || out_dim.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("index");
+    }
+    if out_dim.is_null() {
+        return err_null_pointer("out_dim");
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
@@ -218,8 +221,11 @@ pub extern "C" fn t4a_index_hash(ptr: *const t4a_index, out_hash: *mut u64) -> S
 /// Get the prime level of an index.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_index_plev(ptr: *const t4a_index, out_plev: *mut i64) -> StatusCode {
-    if ptr.is_null() || out_plev.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("index");
+    }
+    if out_plev.is_null() {
+        return err_null_pointer("out_plev");
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
@@ -275,8 +281,11 @@ pub extern "C" fn t4a_index_tags(
     buf_len: usize,
     out_len: *mut usize,
 ) -> StatusCode {
-    if ptr.is_null() || out_len.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("index");
+    }
+    if out_len.is_null() {
+        return err_null_pointer("out_len");
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
@@ -294,7 +303,7 @@ pub extern "C" fn t4a_index_tags(
             return T4A_SUCCESS;
         }
         if buf_len < required_len {
-            return T4A_BUFFER_TOO_SMALL;
+            return err_buffer_too_small("index tags", required_len, buf_len);
         }
 
         std::ptr::copy_nonoverlapping(tags.as_ptr(), buf, tags.len());
@@ -312,8 +321,14 @@ pub extern "C" fn t4a_index_has_tag(
     tag: *const c_char,
     out_has_tag: *mut i32,
 ) -> StatusCode {
-    if ptr.is_null() || tag.is_null() || out_has_tag.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("index");
+    }
+    if tag.is_null() {
+        return err_null_pointer("tag");
+    }
+    if out_has_tag.is_null() {
+        return err_null_pointer("out_has_tag");
     }
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {

--- a/crates/tensor4all-capi/src/index/tests/mod.rs
+++ b/crates/tensor4all-capi/src/index/tests/mod.rs
@@ -145,6 +145,25 @@ fn test_index_tags_roundtrip_and_has_tag() {
 }
 
 #[test]
+fn test_index_accepts_long_tags_losslessly() {
+    let long_tag = "Site3_Site4_Site5";
+    let index = new_index(2, Some(long_tag), 0);
+
+    let tags = read_tags(index);
+    assert_eq!(tags, [long_tag.to_string()].into_iter().collect());
+
+    let long_tag_c = CString::new(long_tag).unwrap();
+    let mut has_tag = -1i32;
+    assert_eq!(
+        t4a_index_has_tag(index, long_tag_c.as_ptr(), &mut has_tag),
+        T4A_SUCCESS
+    );
+    assert_eq!(has_tag, 1);
+
+    t4a_index_release(index);
+}
+
+#[test]
 fn test_index_clone_preserves_metadata() {
     let index = new_index(5, Some("Left,Link"), 9);
 

--- a/crates/tensor4all-capi/src/index/tests/mod.rs
+++ b/crates/tensor4all-capi/src/index/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::T4A_BUFFER_TOO_SMALL;
 use std::collections::BTreeSet;
 use std::ffi::{CStr, CString};
 
@@ -140,6 +141,25 @@ fn test_index_tags_roundtrip_and_has_tag() {
         T4A_SUCCESS
     );
     assert_eq!(has_tag, 0);
+
+    t4a_index_release(index);
+}
+
+#[test]
+fn test_index_query_failures_set_last_error() {
+    let mut dim = 0usize;
+    assert_eq!(t4a_index_dim(std::ptr::null(), &mut dim), T4A_NULL_POINTER);
+    assert_eq!(last_error(), "index is null");
+
+    let index = new_index(2, Some("Site"), 0);
+    let mut len = 0usize;
+    let mut short = [0u8; 2];
+    assert_eq!(
+        t4a_index_tags(index, short.as_mut_ptr(), short.len(), &mut len),
+        T4A_BUFFER_TOO_SMALL
+    );
+    assert_eq!(len, "Site".len() + 1);
+    assert!(last_error().contains("index tags buffer too small"));
 
     t4a_index_release(index);
 }

--- a/crates/tensor4all-capi/src/lib.rs
+++ b/crates/tensor4all-capi/src/lib.rs
@@ -37,9 +37,9 @@ pub const T4A_SUCCESS: StatusCode = 0;
 pub const T4A_NULL_POINTER: StatusCode = -1;
 /// An invalid argument was provided.
 pub const T4A_INVALID_ARGUMENT: StatusCode = -2;
-/// Too many tags would be added to a TagSet (exceeds maximum).
+/// Too many tags would be added to a fixed-capacity tag set.
 pub const T4A_TAG_OVERFLOW: StatusCode = -3;
-/// A tag string exceeds the maximum allowed length.
+/// A tag string exceeds a fixed-capacity tag storage limit.
 pub const T4A_TAG_TOO_LONG: StatusCode = -4;
 /// The provided output buffer is too small for the result.
 pub const T4A_BUFFER_TOO_SMALL: StatusCode = -5;

--- a/crates/tensor4all-capi/src/lib.rs
+++ b/crates/tensor4all-capi/src/lib.rs
@@ -84,6 +84,23 @@ pub(crate) fn err_status<E: std::fmt::Display>(err: E, code: StatusCode) -> Stat
     code
 }
 
+/// Store a null-pointer diagnostic and return `T4A_NULL_POINTER`.
+pub(crate) fn err_null_pointer<E: std::fmt::Display>(what: E) -> StatusCode {
+    err_status(format!("{what} is null"), T4A_NULL_POINTER)
+}
+
+/// Store a buffer-size diagnostic and return `T4A_BUFFER_TOO_SMALL`.
+pub(crate) fn err_buffer_too_small(
+    what: &str,
+    required_len: usize,
+    actual_len: usize,
+) -> StatusCode {
+    err_status(
+        format!("{what} buffer too small: required {required_len}, got {actual_len}"),
+        T4A_BUFFER_TOO_SMALL,
+    )
+}
+
 /// Store an error and return a null pointer.
 #[allow(dead_code)]
 pub(crate) fn err_null<T, E: std::fmt::Display>(err: E) -> *mut T {
@@ -102,7 +119,7 @@ where
     F: FnOnce() -> CapiResult<T>,
 {
     if out.is_null() {
-        return T4A_NULL_POINTER;
+        return err_null_pointer("out");
     }
 
     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
@@ -125,7 +142,7 @@ where
 /// Clone an opaque wrapper through the constructor-style `out` pattern.
 pub(crate) fn clone_opaque<T: Clone>(src: *const T, out: *mut *mut T) -> StatusCode {
     if src.is_null() {
-        return T4A_NULL_POINTER;
+        return err_null_pointer("source handle");
     }
 
     run_catching(out, || unsafe { Ok((&*src).clone()) })
@@ -215,11 +232,11 @@ pub extern "C" fn t4a_last_error_message(
     out_len: *mut libc::size_t,
 ) -> StatusCode {
     if out_len.is_null() {
-        return T4A_NULL_POINTER;
+        return err_null_pointer("out_len");
     }
 
     LAST_ERROR.with(|cell| {
-        let msg = cell.borrow();
+        let msg = cell.borrow().clone();
         let required_len = msg.len() + 1; // +1 for null terminator
 
         unsafe { *out_len = required_len };
@@ -229,7 +246,7 @@ pub extern "C" fn t4a_last_error_message(
         }
 
         if buf_len < required_len {
-            return T4A_BUFFER_TOO_SMALL;
+            return err_buffer_too_small("last_error_message", required_len, buf_len);
         }
 
         unsafe {

--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -5,7 +5,7 @@ use crate::types::{
     InternalQttLayout, InternalTreeTN,
 };
 use crate::{
-    capi_error, clone_opaque, is_assigned_opaque, release_opaque, run_catching, set_last_error,
+    capi_error, clone_opaque, err_null_pointer, is_assigned_opaque, release_opaque, run_catching,
     CapiResult, StatusCode, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER,
 };
 use num_complex::Complex64;
@@ -143,8 +143,7 @@ fn require_layout_or_status<'a>(
     layout: *const t4a_qtt_layout,
 ) -> std::result::Result<&'a InternalQttLayout, StatusCode> {
     if layout.is_null() {
-        set_last_error("layout is null");
-        return Err(T4A_NULL_POINTER);
+        return Err(err_null_pointer("layout"));
     }
     Ok(unsafe { (&*layout).inner() })
 }

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -12,9 +12,9 @@ use crate::types::{
     InternalIndex, InternalTensor,
 };
 use crate::{
-    capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
-    set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
-    T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
+    capi_error, clone_opaque, err_buffer_too_small, err_null_pointer, is_assigned_opaque,
+    panic_message, release_opaque, run_catching, set_last_error, CapiResult, StatusCode,
+    T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 
 /// Release a tensor handle.
@@ -258,8 +258,11 @@ fn box_tensor_handle(tensor: InternalTensor) -> *mut t4a_tensor {
 /// Get the rank of a tensor.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_tensor_rank(ptr: *const t4a_tensor, out_rank: *mut usize) -> StatusCode {
-    if ptr.is_null() || out_rank.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("tensor");
+    }
+    if out_rank.is_null() {
+        return err_null_pointer("out_rank");
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
@@ -278,8 +281,11 @@ pub extern "C" fn t4a_tensor_dims(
     buf_len: usize,
     out_len: *mut usize,
 ) -> StatusCode {
-    if ptr.is_null() || out_len.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("tensor");
+    }
+    if out_len.is_null() {
+        return err_null_pointer("out_len");
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
@@ -290,7 +296,7 @@ pub extern "C" fn t4a_tensor_dims(
             return T4A_SUCCESS;
         }
         if buf_len < dims.len() {
-            return T4A_BUFFER_TOO_SMALL;
+            return err_buffer_too_small("tensor dims", dims.len(), buf_len);
         }
 
         std::ptr::copy_nonoverlapping(dims.as_ptr(), buf, dims.len());
@@ -308,8 +314,11 @@ pub extern "C" fn t4a_tensor_indices(
     buf_len: usize,
     out_len: *mut usize,
 ) -> StatusCode {
-    if ptr.is_null() || out_len.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("tensor");
+    }
+    if out_len.is_null() {
+        return err_null_pointer("out_len");
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
@@ -320,7 +329,7 @@ pub extern "C" fn t4a_tensor_indices(
             return T4A_SUCCESS;
         }
         if buf_len < indices.len() {
-            return T4A_BUFFER_TOO_SMALL;
+            return err_buffer_too_small("tensor indices", indices.len(), buf_len);
         }
 
         for (i, index) in indices.iter().enumerate() {
@@ -338,8 +347,11 @@ pub extern "C" fn t4a_tensor_scalar_kind(
     ptr: *const t4a_tensor,
     out_kind: *mut t4a_scalar_kind,
 ) -> StatusCode {
-    if ptr.is_null() || out_kind.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("tensor");
+    }
+    if out_kind.is_null() {
+        return err_null_pointer("out_kind");
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
@@ -475,8 +487,11 @@ pub extern "C" fn t4a_tensor_copy_dense_f64(
     buf_len: usize,
     out_len: *mut usize,
 ) -> StatusCode {
-    if ptr.is_null() || out_len.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("tensor");
+    }
+    if out_len.is_null() {
+        return err_null_pointer("out_len");
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
@@ -490,7 +505,7 @@ pub extern "C" fn t4a_tensor_copy_dense_f64(
             return T4A_SUCCESS;
         }
         if buf_len < data.len() {
-            return T4A_BUFFER_TOO_SMALL;
+            return err_buffer_too_small("tensor dense f64", data.len(), buf_len);
         }
 
         std::ptr::copy_nonoverlapping(data.as_ptr(), buf, data.len());
@@ -508,8 +523,11 @@ pub extern "C" fn t4a_tensor_copy_dense_c64(
     n_complex: usize,
     out_len: *mut usize,
 ) -> StatusCode {
-    if ptr.is_null() || out_len.is_null() {
-        return T4A_NULL_POINTER;
+    if ptr.is_null() {
+        return err_null_pointer("tensor");
+    }
+    if out_len.is_null() {
+        return err_null_pointer("out_len");
     }
 
     let result = catch_unwind(AssertUnwindSafe(|| unsafe {
@@ -523,7 +541,7 @@ pub extern "C" fn t4a_tensor_copy_dense_c64(
             return T4A_SUCCESS;
         }
         if n_complex < data.len() {
-            return T4A_BUFFER_TOO_SMALL;
+            return err_buffer_too_small("tensor dense c64", data.len(), n_complex);
         }
 
         for (i, value) in data.iter().enumerate() {
@@ -581,8 +599,11 @@ pub extern "C" fn t4a_tensor_contract(
     b: *const t4a_tensor,
     out: *mut *mut t4a_tensor,
 ) -> StatusCode {
-    if a.is_null() || b.is_null() {
-        return T4A_NULL_POINTER;
+    if a.is_null() {
+        return err_null_pointer("a");
+    }
+    if b.is_null() {
+        return err_null_pointer("b");
     }
 
     run_catching(out, || unsafe {

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -4,6 +4,25 @@ use crate::types::{
     t4a_singular_value_measure, t4a_storage_kind, t4a_threshold_scale, t4a_truncation_rule,
 };
 use num_complex::Complex64;
+use std::ffi::CStr;
+
+fn last_error() -> String {
+    let mut len = 0usize;
+    assert_eq!(
+        crate::t4a_last_error_message(std::ptr::null_mut(), 0, &mut len),
+        T4A_SUCCESS
+    );
+    let mut buf = vec![0u8; len];
+    assert_eq!(
+        crate::t4a_last_error_message(buf.as_mut_ptr(), buf.len(), &mut len),
+        T4A_SUCCESS
+    );
+    CStr::from_bytes_until_nul(&buf)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string()
+}
 
 fn new_index(dim: usize) -> *mut t4a_index {
     let mut out = std::ptr::null_mut();
@@ -59,6 +78,30 @@ fn read_dense_f64(tensor: *const t4a_tensor) -> Vec<f64> {
         T4A_SUCCESS
     );
     data
+}
+
+#[test]
+fn test_tensor_query_failures_set_last_error() {
+    let mut rank = 0usize;
+    assert_eq!(
+        t4a_tensor_rank(std::ptr::null(), &mut rank),
+        T4A_NULL_POINTER
+    );
+    assert_eq!(last_error(), "tensor is null");
+
+    let i = new_index(2);
+    let tensor = new_tensor_f64(&[i], &[1.0, 2.0]);
+    let mut len = 0usize;
+    let mut short = [0usize; 0];
+    assert_eq!(
+        t4a_tensor_dims(tensor, short.as_mut_ptr(), short.len(), &mut len),
+        T4A_BUFFER_TOO_SMALL
+    );
+    assert_eq!(len, 1);
+    assert!(last_error().contains("tensor dims buffer too small"));
+
+    t4a_tensor_release(tensor);
+    t4a_index_release(i);
 }
 
 fn read_payload_dims(tensor: *const t4a_tensor) -> Vec<usize> {

--- a/crates/tensor4all-capi/src/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tests/mod.rs
@@ -24,6 +24,7 @@ fn read_last_error() -> String {
 fn test_last_error_message_null_out_len() {
     let status = t4a_last_error_message(std::ptr::null_mut(), 0, std::ptr::null_mut());
     assert_eq!(status, T4A_NULL_POINTER);
+    assert_eq!(read_last_error(), "out_len is null");
 }
 
 #[test]
@@ -45,6 +46,7 @@ fn test_last_error_message_buffer_too_small() {
     );
     assert_eq!(status, T4A_BUFFER_TOO_SMALL);
     assert_eq!(out_len, 6); // "hello" + null
+    assert!(read_last_error().contains("last_error_message buffer too small"));
 }
 
 #[test]
@@ -68,6 +70,22 @@ fn test_err_null_stores_message() {
     let ptr: *mut u8 = err_null("null error");
     assert!(ptr.is_null());
     assert_eq!(read_last_error(), "null error");
+}
+
+#[test]
+fn test_run_catching_null_out_stores_message() {
+    let status = run_catching::<u8, _>(std::ptr::null_mut(), || Ok(1));
+    assert_eq!(status, T4A_NULL_POINTER);
+    assert_eq!(read_last_error(), "out is null");
+}
+
+#[test]
+fn test_clone_opaque_null_src_stores_message() {
+    let mut out = std::ptr::null_mut();
+    let status = clone_opaque::<u8>(std::ptr::null(), &mut out);
+    assert_eq!(status, T4A_NULL_POINTER);
+    assert!(out.is_null());
+    assert_eq!(read_last_error(), "source handle is null");
 }
 
 #[test]

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -1504,6 +1504,11 @@ pub extern "C" fn t4a_treetn_add(
 
 /// Contract two tree tensor networks with the requested method.
 ///
+/// `t4a_contract_method::Naive` is a dense/reference method that materializes
+/// both TreeTNs and the contracted result as full tensors. Pass a nonzero
+/// `max_dense_elements` to opt into this path for small reference cases; each
+/// dense input and output tensor must fit under that limit.
+///
 /// For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
 /// default", which currently resolves to one variational sweep.
 #[unsafe(no_mangle)]
@@ -1517,6 +1522,7 @@ pub extern "C" fn t4a_treetn_contract(
     convergence_tol: libc::c_double,
     factorize_alg: t4a_factorize_alg,
     qr_rtol: libc::c_double,
+    max_dense_elements: libc::size_t,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
     let tn_a = match require_tree(a) {
@@ -1589,6 +1595,9 @@ pub extern "C" fn t4a_treetn_contract(
         if let Some(tol) = resolve_convergence_tol(convergence_tol) {
             options = options.with_convergence_tol(tol);
         }
+        if max_dense_elements > 0 {
+            options = options.with_dense_reference_limit(max_dense_elements);
+        }
 
         let result = contraction::contract(tn_a.inner(), tn_b.inner(), &center, options)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
@@ -1602,6 +1611,11 @@ pub extern "C" fn t4a_treetn_contract(
 /// `diagonal_*` pairs are linked by diagonal/copy structure while preserving
 /// the left-hand index as an external result leg. `output_order`, when nonempty,
 /// lists the surviving external indices in the requested result order.
+///
+/// `t4a_contract_method::Naive` and mismatched-topology fallback paths are
+/// dense/reference operations. Pass a nonzero `max_dense_elements` to opt into
+/// those paths for small reference cases; each dense input and output tensor
+/// must fit under that limit.
 ///
 /// For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
 /// default", which currently resolves to one variational sweep.
@@ -1626,6 +1640,7 @@ pub extern "C" fn t4a_treetn_partial_contract(
     convergence_tol: libc::c_double,
     factorize_alg: t4a_factorize_alg,
     qr_rtol: libc::c_double,
+    max_dense_elements: libc::size_t,
     out: *mut *mut t4a_treetn,
 ) -> StatusCode {
     run_catching(out, || {
@@ -1702,6 +1717,11 @@ pub extern "C" fn t4a_treetn_partial_contract(
         if let Some(tol) = resolve_convergence_tol(convergence_tol) {
             options = options.with_convergence_tol(tol);
         }
+        if max_dense_elements > 0 {
+            options = options
+                .with_dense_reference_limit(max_dense_elements)
+                .with_mismatched_topology_dense_limit(max_dense_elements);
+        }
 
         let spec = PartialContractionSpec {
             contract_pairs,
@@ -1725,6 +1745,8 @@ pub extern "C" fn t4a_treetn_partial_contract(
 ///
 /// For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
 /// default", which currently resolves to one variational sweep.
+/// `t4a_contract_method::Naive` uses the dedicated local-exact apply path here,
+/// not the generic full-dense TreeTN contraction used by `t4a_treetn_contract`.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_apply_operator_chain(
     operator: *const t4a_treetn,

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -1231,6 +1231,7 @@ fn test_treetn_contract_and_to_dense() {
             0.0,
             t4a_factorize_alg::SVD,
             0.0,
+            4,
             &mut result
         ),
         T4A_SUCCESS
@@ -1245,6 +1246,53 @@ fn test_treetn_contract_and_to_dense() {
     t4a_index_release(in_clone);
     t4a_index_release(out_idx);
     t4a_index_release(in_idx);
+}
+
+#[test]
+fn test_treetn_contract_naive_requires_dense_limit() {
+    let ((a, a_tensors, a_indices), (b, b_tensors, b_indices)) = make_two_site_contract_operands();
+
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_contract(
+            a,
+            b,
+            t4a_contract_method::Naive,
+            std::ptr::null(),
+            0,
+            1,
+            0.0,
+            t4a_factorize_alg::SVD,
+            0.0,
+            0,
+            &mut out
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(out.is_null());
+    assert!(last_error().contains("explicit dense/reference limit"));
+
+    assert_eq!(
+        t4a_treetn_contract(
+            a,
+            b,
+            t4a_contract_method::Naive,
+            std::ptr::null(),
+            0,
+            1,
+            0.0,
+            t4a_factorize_alg::SVD,
+            0.0,
+            3,
+            &mut out
+        ),
+        T4A_INVALID_ARGUMENT
+    );
+    assert!(out.is_null());
+    assert!(last_error().contains("exceeding limit 3"));
+
+    cleanup(a, a_tensors, a_indices);
+    cleanup(b, b_tensors, b_indices);
 }
 
 #[test]
@@ -1288,6 +1336,7 @@ fn test_treetn_partial_contract_elementwise_diagonal_pairs() {
             0.0,
             t4a_factorize_alg::SVD,
             0.0,
+            0,
             &mut out,
         ),
         T4A_SUCCESS
@@ -1324,6 +1373,7 @@ fn test_treetn_contract_fit_zero_sweeps_uses_backend_default() {
             1e-30,
             t4a_factorize_alg::LU,
             0.0,
+            0,
             &mut baseline
         ),
         T4A_SUCCESS
@@ -1341,6 +1391,7 @@ fn test_treetn_contract_fit_zero_sweeps_uses_backend_default() {
             1e-30,
             t4a_factorize_alg::LU,
             0.0,
+            0,
             &mut uses_default
         ),
         T4A_SUCCESS
@@ -1372,6 +1423,7 @@ fn test_treetn_contract_fit_accepts_iterative_options() {
             0.0,
             t4a_factorize_alg::SVD,
             0.0,
+            1024,
             &mut expected
         ),
         T4A_SUCCESS
@@ -1389,6 +1441,7 @@ fn test_treetn_contract_fit_accepts_iterative_options() {
             1e-30,
             t4a_factorize_alg::LU,
             0.0,
+            0,
             &mut fitted
         ),
         T4A_SUCCESS

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -539,7 +539,11 @@ pub enum t4a_contract_method {
     Zipup = 0,
     /// Variational fit-based contraction.
     Fit = 1,
-    /// Naive dense contraction.
+    /// Naive dense/reference contraction for generic TreeTN contraction.
+    ///
+    /// `t4a_treetn_contract` requires an explicit nonzero dense-element limit
+    /// for this method. `t4a_treetn_apply_operator_chain` uses a dedicated
+    /// local-exact apply path instead of generic full-dense TreeTN contraction.
     Naive = 2,
 }
 

--- a/crates/tensor4all-core/src/block_tensor.rs
+++ b/crates/tensor4all-core/src/block_tensor.rs
@@ -421,11 +421,14 @@ impl<T: TensorLike> TensorLike for BlockTensor<T> {
         self.blocks.iter().map(|b| b.norm_squared()).sum()
     }
 
-    fn maxabs(&self) -> f64 {
+    fn try_maxabs(&self) -> Result<f64> {
         self.blocks
             .iter()
-            .map(|b| b.maxabs())
-            .fold(0.0_f64, f64::max)
+            .try_fold(0.0_f64, |acc, block| Ok(acc.max(block.try_maxabs()?)))
+    }
+
+    fn maxabs(&self) -> f64 {
+        self.try_maxabs().unwrap_or(f64::NAN)
     }
 
     fn scale(&self, scalar: AnyScalar) -> Result<Self> {

--- a/crates/tensor4all-core/src/defaults/index.rs
+++ b/crates/tensor4all-core/src/defaults/index.rs
@@ -48,12 +48,10 @@ impl DynId {
 
 /// Tag set wrapper using `Arc` for efficient cloning.
 ///
-/// This wraps the underlying tag storage in an `Arc` for cheap cloning (reference count increment only).
-/// Tags are immutable and shared across indices with the same tag set.
-///
-/// # Size comparison
-/// - Inline storage: 168 bytes (Copy)
-/// - `TagSet` (Arc): 8 bytes (Clone only)
+/// This wraps the underlying default tag storage in an `Arc` for cheap cloning
+/// (reference count increment only). Tags are immutable and shared across
+/// indices with the same tag set. The default storage is string-backed so
+/// descriptive tags from language bindings are preserved losslessly.
 ///
 /// # Example
 /// ```
@@ -159,7 +157,7 @@ impl TagSetLike for TagSet {
 
     fn add_tag(&mut self, tag: &str) -> Result<(), TagSetError> {
         // Arc is immutable, so we need to clone and replace
-        let mut inner = *self.0;
+        let mut inner = self.0.as_ref().clone();
         inner.add_tag(tag)?;
         self.0 = Arc::new(inner);
         Ok(())
@@ -167,7 +165,7 @@ impl TagSetLike for TagSet {
 
     fn remove_tag(&mut self, tag: &str) -> bool {
         // Arc is immutable, so we need to clone and replace
-        let mut inner = *self.0;
+        let mut inner = self.0.as_ref().clone();
         let removed = inner.remove_tag(tag);
         if removed {
             self.0 = Arc::new(inner);

--- a/crates/tensor4all-core/src/defaults/index/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/index/tests/mod.rs
@@ -67,7 +67,7 @@ fn test_tagset_wrapper_trait_methods() {
     assert!(tags.is_empty());
     assert_eq!(std::sync::Arc::strong_count(tags.inner()), 1);
     assert_eq!(TagSetLike::len(&tags), 0);
-    assert_eq!(TagSetLike::capacity(&tags), 4);
+    assert_eq!(TagSetLike::capacity(&tags), usize::MAX);
     assert_eq!(TagSetLike::get(&tags, 0), None);
 
     TagSetLike::add_tag(&mut tags, "Site").unwrap();

--- a/crates/tensor4all-core/src/smallstring/tests/mod.rs
+++ b/crates/tensor4all-core/src/smallstring/tests/mod.rs
@@ -49,6 +49,31 @@ fn test_smallstring_ordering() {
 }
 
 #[test]
+fn test_smallstring_accessors_default_and_display() {
+    let empty = SmallString::<4>::default();
+    assert!(empty.is_empty());
+    assert_eq!(empty.len(), 0);
+    assert_eq!(empty.capacity(), 4);
+    assert_eq!(empty.get(0), None);
+    assert_eq!(empty.as_slice(), &[] as &[u16]);
+    assert_eq!(empty.to_string(), "");
+
+    let s = SmallString::<4>::from_str("ab").unwrap();
+    assert!(!s.is_empty());
+    assert_eq!(s.capacity(), 4);
+    assert_eq!(s.get(0), Some('a'));
+    assert_eq!(s.get(1), Some('b'));
+    assert_eq!(s.get(2), None);
+    assert_eq!(s.as_slice(), &[b'a' as u16, b'b' as u16]);
+    assert_eq!(s.to_string(), "ab");
+}
+
+#[test]
+fn test_smallchar_u16_invalid_code_unit_uses_replacement_char() {
+    assert_eq!(<u16 as SmallChar>::to_char(0xD800), '\u{FFFD}');
+}
+
+#[test]
 fn test_smallstring_size() {
     // u16 version: 16 * 2 + 8 = 40 bytes
     assert_eq!(std::mem::size_of::<SmallString<16, u16>>(), 40);

--- a/crates/tensor4all-core/src/tagset.rs
+++ b/crates/tensor4all-core/src/tagset.rs
@@ -1,4 +1,5 @@
 use crate::smallstring::{SmallChar, SmallString, SmallStringError};
+use std::cmp::Ordering;
 
 /// Trait for tag set implementations.
 ///
@@ -362,9 +363,145 @@ impl<const MAX_TAGS: usize, const MAX_TAG_LEN: usize, C: SmallChar> std::hash::H
     }
 }
 
+/// A sorted tag set backed by owned strings.
+///
+/// Use this when tags must be preserved losslessly across language boundaries
+/// or when a fixed inline string capacity would reject valid user-facing tags.
+/// Tags are sorted, duplicate insertion is a no-op, and commas are rejected
+/// because comma is the textual separator used by [`TagSetLike::from_str`].
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::tagset::{DynamicTagSet, TagSetLike};
+///
+/// let mut tags = DynamicTagSet::from_str("Site3_Site4_Site5,Link")?;
+/// tags.add_tag("LongDescriptiveTagName")?;
+///
+/// assert!(tags.has_tag("Site3_Site4_Site5"));
+/// assert!(tags.has_tag("LongDescriptiveTagName"));
+/// assert_eq!(tags.len(), 3);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct DynamicTagSet {
+    tags: Vec<String>,
+}
+
+impl DynamicTagSet {
+    /// Create an empty dynamic tag set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::tagset::{DynamicTagSet, TagSetLike};
+    ///
+    /// let tags = DynamicTagSet::new();
+    /// assert!(tags.is_empty());
+    /// assert_eq!(tags.capacity(), usize::MAX);
+    /// ```
+    pub fn new() -> Self {
+        Self { tags: Vec::new() }
+    }
+
+    /// Create a dynamic tag set from a comma-separated string.
+    ///
+    /// ASCII spaces are ignored, matching [`TagSetLike::from_str`].
+    ///
+    /// # Errors
+    /// Returns an error if a parsed tag violates dynamic tag-set rules.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::tagset::{DynamicTagSet, TagSetLike};
+    ///
+    /// let tags = DynamicTagSet::from_str("Site3_Site4_Site5, Link")?;
+    /// assert!(tags.has_tag("Site3_Site4_Site5"));
+    /// assert!(tags.has_tag("Link"));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Result<Self, TagSetError> {
+        <Self as TagSetLike>::from_str(s)
+    }
+}
+
+impl TagSetLike for DynamicTagSet {
+    fn len(&self) -> usize {
+        self.tags.len()
+    }
+
+    fn capacity(&self) -> usize {
+        usize::MAX
+    }
+
+    fn get(&self, index: usize) -> Option<String> {
+        self.tags.get(index).cloned()
+    }
+
+    fn iter(&self) -> TagSetIterator<'_> {
+        Box::new(self.tags.iter().cloned())
+    }
+
+    fn has_tag(&self, tag: &str) -> bool {
+        self.tags
+            .binary_search_by(|existing| existing.as_str().cmp(tag))
+            .is_ok()
+    }
+
+    fn add_tag(&mut self, tag: &str) -> Result<(), TagSetError> {
+        if tag.contains(',') {
+            return Err(TagSetError::TagContainsComma {
+                tag: tag.to_string(),
+            });
+        }
+
+        match self
+            .tags
+            .binary_search_by(|existing| existing.as_str().cmp(tag))
+        {
+            Ok(_) => Ok(()),
+            Err(position) => {
+                self.tags.insert(position, tag.to_string());
+                Ok(())
+            }
+        }
+    }
+
+    fn remove_tag(&mut self, tag: &str) -> bool {
+        match self
+            .tags
+            .binary_search_by(|existing| existing.as_str().cmp(tag))
+        {
+            Ok(position) => {
+                self.tags.remove(position);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+}
+
+impl PartialOrd for DynamicTagSet {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DynamicTagSet {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.tags.cmp(&other.tags)
+    }
+}
+
 /// Default tag type (max 16 characters, u16 storage, matching ITensors.jl's `SmallString`).
 pub type Tag = SmallString<16>;
 
-/// Inline TagSet with fixed capacity (used internally by Arc-wrapped TagSet).
-/// For public API, use `tensor4all_core::TagSet` (Arc-wrapped) instead.
-pub type DefaultTagSet = TagSet<4, 16>;
+/// Default tag set for public dynamic indices.
+///
+/// This is string-backed so FFI and language bindings preserve descriptive
+/// tags losslessly instead of truncating or rejecting tags that exceed the
+/// fixed inline [`Tag`] capacity. Use [`TagSet`] directly when a fixed inline
+/// capacity is required.
+pub type DefaultTagSet = DynamicTagSet;

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -1023,7 +1023,42 @@ pub trait TensorLike: TensorIndex {
         self.norm_squared().sqrt()
     }
 
+    /// Try to compute the maximum absolute value of all tensor elements.
+    ///
+    /// This is the error-aware form of [`Self::maxabs`]. Tensor
+    /// implementations should return an error when an exact elementwise maximum
+    /// would require hidden full-network materialization or another unsupported
+    /// operation.
+    ///
+    /// # Returns
+    /// The L-infinity norm when it is available without violating the tensor
+    /// representation's scalability contract.
+    ///
+    /// # Errors
+    /// Returns an error when the tensor type cannot compute an exact maximum
+    /// absolute value through a safe/scalable implementation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    ///
+    /// let i = DynIndex::new_dyn(3);
+    /// let tensor = TensorDynLen::from_dense(vec![i], vec![1.0, -3.0, 2.0])?;
+    /// assert_eq!(tensor.try_maxabs()?, 3.0);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    fn try_maxabs(&self) -> Result<f64> {
+        Ok(self.maxabs())
+    }
+
     /// Maximum absolute value of all elements (L-infinity norm).
+    ///
+    /// This infallible method is kept for dense/reference tensor code. Generic
+    /// code should prefer [`Self::try_maxabs`] so tensor-network
+    /// implementations can report that exact elementwise maxima are
+    /// unsupported instead of hiding dense materialization. Implementations
+    /// that cannot compute this value safely may return `NaN`.
     fn maxabs(&self) -> f64;
 
     /// Element-wise subtraction: `self - other`.

--- a/crates/tensor4all-core/tests/common_tagset.rs
+++ b/crates/tensor4all-core/tests/common_tagset.rs
@@ -1,5 +1,5 @@
 use tensor4all_core::smallstring::{SmallString, SmallStringError};
-use tensor4all_core::tagset::{DefaultTagSet, Tag, TagSet, TagSetError, TagSetLike};
+use tensor4all_core::tagset::{DefaultTagSet, DynamicTagSet, Tag, TagSet, TagSetError, TagSetLike};
 
 #[test]
 fn test_smallstring_new() {
@@ -178,8 +178,23 @@ fn test_default_types() {
     let tag: Tag = SmallString::<16>::from_str("test").unwrap();
     assert_eq!(tag.as_str(), "test");
 
-    let ts: DefaultTagSet = TagSet::<4, 16>::from_str("t1,t2").unwrap();
+    let ts: DefaultTagSet = DynamicTagSet::from_str("t1,t2").unwrap();
     assert_eq!(ts.len(), 2);
+}
+
+#[test]
+fn test_dynamic_tagset_preserves_long_tags() {
+    let long_tag = "Site3_Site4_Site5";
+    let mut tags = DynamicTagSet::from_str(long_tag).unwrap();
+    tags.add_tag("Link").unwrap();
+
+    assert_eq!(tags.capacity(), usize::MAX);
+    assert!(tags.has_tag(long_tag));
+    assert!(tags.has_tag("Link"));
+    assert_eq!(
+        TagSetLike::iter(&tags).collect::<Vec<_>>(),
+        vec!["Link".to_string(), long_tag.to_string()]
+    );
 }
 
 #[test]

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -10,11 +10,29 @@ ITensors.jl-inspired TensorTrain API with orthogonality tracking and multiple ca
 - `inner()` — inner product `<self|other>` with complex conjugation on `self`
 - `norm()` — efficient norm via the orthogonality center
 
+## Conventions
+
+- Dense data passed to `TensorDynLen::from_dense` is **column-major**: the
+  last listed index varies fastest.
+- Complex tensors use `num_complex::Complex64`; `inner()` conjugates the left
+  operand, so `tt.inner(&tt)` equals `tt.norm().powi(2)` for real and complex
+  tensor trains.
+- Import `tensor4all_core::IndexLike` when calling trait methods such as
+  `.dim()` on dynamic indices.
+- Use `DynIndex::new_dyn(dim)` for ordinary site indices and
+  `DynIndex::new_bond(dim)?` for bond indices; bond creation is fallible because
+  bond metadata is validated.
+- `ContractOptions` and `LinsolveOptions` provide
+  `with_nsweeps(n)` as a convenience wrapper for `with_nhalfsweeps(2 * n)`.
+- `truncate()` uses SVD truncation and leaves the tensor train in unitary
+  canonical form; use `orthogonalize_with(site, CanonicalForm::...)` when you
+  need LU or CI canonicalization instead.
+
 ## Example
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
 use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
 
 // Build a 3-site tensor train
@@ -25,20 +43,45 @@ let b01 = DynIndex::new_bond(2)?;
 let b12 = DynIndex::new_bond(2)?;
 
 let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
-let t1 = TensorDynLen::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 8])?;
+let t1 = TensorDynLen::from_dense(vec![b01, s1.clone(), b12.clone()], vec![1.0; 8])?;
 let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![1.0, 0.0, 0.0, 1.0])?;
 
 let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 tt.orthogonalize(1)?;
-tt.truncate(&TruncateOptions::svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10)).with_max_rank(2))?;
+tt.truncate(&TruncateOptions::svd()
+    .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+    .with_max_rank(2))?;
 
 assert!(tt.isortho());
+assert_eq!(s1.dim(), 2);
 let norm = tt.norm();
 assert!(norm.is_finite());
 
 // Inner product: <tt|tt> = norm^2
 let inner = tt.inner(&tt);
 assert!((inner.real() - norm * norm).abs() < 1e-10);
+# Ok(())
+# }
+```
+
+## Complex Values
+
+```rust
+# fn main() -> anyhow::Result<()> {
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_itensorlike::TensorTrain;
+
+let site = DynIndex::new_dyn(2);
+let tensor = TensorDynLen::from_dense(
+    vec![site],
+    vec![Complex64::new(1.0, 2.0), Complex64::new(0.0, -1.0)],
+)?;
+let tt = TensorTrain::new(vec![tensor])?;
+
+let inner = tt.inner(&tt);
+assert!((inner.real() - 6.0).abs() < 1e-12);
+assert!(inner.imag().abs() < 1e-12);
 # Ok(())
 # }
 ```

--- a/crates/tensor4all-itensorlike/src/contract.rs
+++ b/crates/tensor4all-itensorlike/src/contract.rs
@@ -84,6 +84,11 @@ pub fn contract(
     } else {
         treetn_options
     };
+    let treetn_options = if let Some(limit) = options.dense_reference_limit() {
+        treetn_options.with_dense_reference_limit(limit)
+    } else {
+        treetn_options
+    };
 
     // Use the last site as the canonical center (consistent with existing behavior)
     let center = a.len() - 1;

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -242,7 +242,7 @@ fn test_contract_naive_single_site() {
     let t2 = make_tensor(vec![s0.clone()]);
     let tt2 = TensorTrain::new(vec![t2]).unwrap();
 
-    let options = ContractOptions::naive();
+    let options = ContractOptions::naive().with_dense_reference_limit(3);
     let result = contract(&tt1, &tt2, &options).unwrap();
     assert_eq!(result.len(), 1);
     assert_matches_naive(&tt1, &tt2, &result);

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -144,6 +144,7 @@ pub struct ContractOptions {
     max_rank: Option<usize>,
     svd_policy: Option<SvdTruncationPolicy>,
     nhalfsweeps: usize,
+    dense_reference_limit: Option<usize>,
 }
 
 impl Default for ContractOptions {
@@ -153,6 +154,7 @@ impl Default for ContractOptions {
             max_rank: None,
             svd_policy: None,
             nhalfsweeps: 2,
+            dense_reference_limit: None,
         }
     }
 }
@@ -175,6 +177,24 @@ impl ContractOptions {
     }
 
     /// Create options for naive contraction.
+    ///
+    /// Naive contraction is a dense/reference path. Call
+    /// [`ContractOptions::with_dense_reference_limit`] before use to bound full
+    /// dense materialization.
+    ///
+    /// # Returns
+    /// Options configured for the dense/reference contraction method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_itensorlike::{ContractMethod, ContractOptions};
+    ///
+    /// let opts = ContractOptions::naive().with_dense_reference_limit(16);
+    ///
+    /// assert_eq!(opts.method(), ContractMethod::Naive);
+    /// assert_eq!(opts.dense_reference_limit(), Some(16));
+    /// ```
     pub fn naive() -> Self {
         Self {
             method: ContractMethod::Naive,
@@ -208,6 +228,30 @@ impl ContractOptions {
         self
     }
 
+    /// Set the maximum dense elements allowed for naive dense/reference contraction.
+    ///
+    /// # Arguments
+    /// * `max_elements` - Maximum element count allowed for each dense input
+    ///   and output tensor materialized by the reference path. Use small,
+    ///   test-sized values unless you have explicitly budgeted memory.
+    ///
+    /// # Returns
+    /// Updated options with the dense/reference limit enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_itensorlike::ContractOptions;
+    ///
+    /// let opts = ContractOptions::naive().with_dense_reference_limit(32);
+    ///
+    /// assert_eq!(opts.dense_reference_limit(), Some(32));
+    /// ```
+    pub fn with_dense_reference_limit(mut self, max_elements: usize) -> Self {
+        self.dense_reference_limit = Some(max_elements);
+        self
+    }
+
     /// Get the contraction method.
     #[inline]
     pub fn method(&self) -> ContractMethod {
@@ -230,6 +274,26 @@ impl ContractOptions {
     #[inline]
     pub fn nhalfsweeps(&self) -> usize {
         self.nhalfsweeps
+    }
+
+    /// Get the dense/reference element limit for naive contraction.
+    ///
+    /// # Returns
+    /// `Some(max_elements)` when a dense/reference limit has been configured,
+    /// otherwise `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_itensorlike::ContractOptions;
+    ///
+    /// let opts = ContractOptions::naive().with_dense_reference_limit(8);
+    ///
+    /// assert_eq!(opts.dense_reference_limit(), Some(8));
+    /// ```
+    #[inline]
+    pub fn dense_reference_limit(&self) -> Option<usize> {
+        self.dense_reference_limit
     }
 }
 

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -115,8 +115,9 @@ pub enum ContractMethod {
     Zipup,
     /// Fit/variational contraction (iterative optimization).
     Fit,
-    /// Naive contraction: contract to full tensor, then decompose back.
-    /// Useful for debugging and testing, but O(exp(n)) in memory.
+    /// Dense/reference contraction: contract to a full tensor, then decompose back.
+    /// Useful only for small debugging and testing cases; memory scales as the
+    /// product of external dimensions.
     Naive,
 }
 

--- a/crates/tensor4all-itensorlike/src/options/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/options/tests/mod.rs
@@ -56,12 +56,14 @@ fn test_contract_options_builder() {
     let opts = ContractOptions::zipup()
         .with_max_rank(100)
         .with_svd_policy(policy)
-        .with_nhalfsweeps(6);
+        .with_nhalfsweeps(6)
+        .with_dense_reference_limit(256);
 
     assert_eq!(opts.method(), ContractMethod::Zipup);
     assert_eq!(opts.max_rank(), Some(100));
     assert_eq!(opts.svd_policy(), Some(policy));
     assert_eq!(opts.nhalfsweeps(), 6);
+    assert_eq!(opts.dense_reference_limit(), Some(256));
 }
 
 #[test]
@@ -78,6 +80,7 @@ fn test_contract_options_default() {
     assert_eq!(opts.nhalfsweeps(), 2);
     assert_eq!(opts.svd_policy(), None);
     assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.dense_reference_limit(), None);
 }
 
 #[test]

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -1073,6 +1073,40 @@ impl TensorTrain {
             })
     }
 
+    /// Compute an explicit dense maximum absolute value.
+    ///
+    /// This method first materializes the full tensor train with
+    /// [`Self::to_dense`], then computes the dense tensor's L-infinity norm.
+    /// Use it only for small reference/debug checks. Long tensor-train
+    /// comparisons should use scalable residual norms such as
+    /// `tt1.axpby(1, tt2, -1)?.norm() / tt2.norm()`.
+    ///
+    /// # Returns
+    /// The maximum absolute element in the dense tensor represented by this
+    /// tensor train.
+    ///
+    /// # Errors
+    /// Returns an error when the tensor train is empty or dense materialization
+    /// fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let site = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![site], vec![-2.0, 3.0])?;
+    /// let tt = TensorTrain::new(vec![tensor])?;
+    /// assert_eq!(tt.dense_maxabs()?, 3.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn dense_maxabs(&self) -> Result<f64> {
+        self.to_dense().map(|t| t.maxabs())
+    }
+
     /// Add two tensor trains using direct-sum construction.
     ///
     /// This creates a new tensor train where each tensor is the direct sum of the
@@ -1257,8 +1291,14 @@ impl TensorLike for TensorTrain {
         TensorTrain::norm_squared(self)
     }
 
+    fn try_maxabs(&self) -> anyhow::Result<f64> {
+        anyhow::bail!(
+            "TensorTrain does not support TensorLike::maxabs without explicit dense materialization; use TensorTrain::dense_maxabs() for small reference checks or norm-based residuals for long tensor trains"
+        )
+    }
+
     fn maxabs(&self) -> f64 {
-        self.to_dense().map(|t| t.maxabs()).unwrap_or(0.0)
+        f64::NAN
     }
 
     fn conj(&self) -> Self {

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -1142,7 +1142,24 @@ fn test_maxbonddim_single_site() {
 }
 
 #[test]
-fn test_tensor_like_maxabs() {
+fn test_dense_maxabs_is_explicit_dense_reference_api() {
+    let s0 = idx(0, 2);
+    let l01 = idx(1, 3);
+    let s1 = idx(2, 2);
+
+    let t0 = make_tensor(vec![s0.clone(), l01.clone()]);
+    let t1 = make_tensor(vec![l01.clone(), s1.clone()]);
+
+    let tt = TensorTrain::new(vec![t0, t1]).unwrap();
+
+    let maxabs = tt.dense_maxabs().unwrap();
+    let dense = tt.to_dense().unwrap();
+    let dense_maxabs = dense.maxabs();
+    assert!((maxabs - dense_maxabs).abs() < 1e-10);
+}
+
+#[test]
+fn test_tensor_like_maxabs_is_not_hidden_dense_for_tensor_train() {
     use tensor4all_core::TensorLike;
 
     let s0 = idx(0, 2);
@@ -1154,13 +1171,9 @@ fn test_tensor_like_maxabs() {
 
     let tt = TensorTrain::new(vec![t0, t1]).unwrap();
 
-    let maxabs = TensorLike::maxabs(&tt);
-    assert!(maxabs > 0.0);
-
-    // Compare with dense maxabs
-    let dense = tt.to_dense().unwrap();
-    let dense_maxabs = dense.maxabs();
-    assert!((maxabs - dense_maxabs).abs() < 1e-10);
+    let err = TensorLike::try_maxabs(&tt).unwrap_err();
+    assert!(err.to_string().contains("explicit dense materialization"));
+    assert!(TensorLike::maxabs(&tt).is_nan());
 }
 
 #[test]

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -316,7 +316,7 @@ fn test_contract_with_naive_method() {
     let tt2 = TensorTrain::new(vec![t2]).unwrap();
 
     // Test contract with Naive method
-    let options = ContractOptions::naive();
+    let options = ContractOptions::naive().with_dense_reference_limit(2);
     let result = tt1.contract(&tt2, &options);
     assert!(result.is_ok());
     let result_tt = result.unwrap();

--- a/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
+++ b/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
@@ -84,6 +84,7 @@ fn time_it<F: FnOnce() -> R, R>(label: &str, f: F) -> R {
 }
 
 #[test]
+#[ignore = "benchmark-only timing test"]
 fn bench_norm() {
     eprintln!("\n=== norm benchmark (main) ===");
     for &n in &[20, 45, 90] {
@@ -95,6 +96,7 @@ fn bench_norm() {
 }
 
 #[test]
+#[ignore = "benchmark-only timing test"]
 fn bench_inner() {
     eprintln!("\n=== inner benchmark (main) ===");
     for &n in &[20, 45, 90] {
@@ -110,6 +112,7 @@ fn bench_inner() {
 }
 
 #[test]
+#[ignore = "benchmark-only timing test"]
 fn bench_truncate() {
     eprintln!("\n=== truncate benchmark (main) ===");
     for &n in &[20, 45, 90] {
@@ -124,6 +127,7 @@ fn bench_truncate() {
 }
 
 #[test]
+#[ignore = "benchmark-only timing test"]
 fn bench_contract_zipup() {
     eprintln!("\n=== contract zipup benchmark (main) ===");
     for &n in &[10, 20, 45] {
@@ -138,6 +142,7 @@ fn bench_contract_zipup() {
 }
 
 #[test]
+#[ignore = "benchmark-only timing test"]
 fn bench_contract_fit() {
     eprintln!("\n=== contract fit benchmark (main) ===");
     for &n in &[10, 20, 45] {

--- a/crates/tensor4all-itensorlike/tests/bug_norm_oom_large_tt.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_norm_oom_large_tt.rs
@@ -1,28 +1,11 @@
-//! Regression test: TensorTrain::norm() is exponentially slow for large tensor trains.
+//! Regression tests for scalable TensorTrain norms and residual checks.
 //!
-//! After the tenferro refactor (8798c98), `inner()` delegates to `TreeTN::inner()`
-//! which uses `contract_naive`. This contracts all nodes without exploiting the
-//! chain structure, causing cost to scale exponentially with the number of sites.
-//!
-//! For a TT with N sites of physical dimension d and bond dimension D,
-//! the efficient algorithm costs O(N * D^2 * d), completing in microseconds.
-//! The current implementation scales as O(d^N), making it unusable for N >= ~25.
-//!
-//! Measured on Apple M4 Max (--release), bond dim = 2, physical dim = 2:
-//!
-//!   | N sites | before 8798c98 | after 8798c98 (main) |
-//!   |---------|----------------|----------------------|
-//!   |       4 |       < 0.01s  |             < 0.01s  |
-//!   |      20 |         0.005s |               0.008s |
-//!   |      25 |         0.006s |               0.18s  |
-//!   |      40 |        ~0.01s  |             > 60s    |
-//!   |      90 |         0.015s |        OOM (SIGKILL) |
-//!
-//! Root cause: `TreeTN::inner()` calls `contract_naive` instead of
-//! efficient sequential bra-ket contraction along the chain.
+//! Long tensor-train tests must not rely on wall-clock thresholds or dense
+//! `maxabs()` comparisons. They use local transfer-matrix references, structural
+//! assertions, and norm-based residuals instead.
 
 use tensor4all_core::defaults::tensordynlen::TensorDynLen;
-use tensor4all_core::DynIndex;
+use tensor4all_core::{AnyScalar, DynIndex, IndexLike};
 use tensor4all_itensorlike::TensorTrain;
 
 /// Create a TT with `n_sites` sites, each of physical dimension 2,
@@ -55,6 +38,104 @@ fn make_tt(n_sites: usize) -> TensorTrain {
     TensorTrain::new(tensors).expect("Failed to create TensorTrain")
 }
 
+fn local_tensor_value(
+    data: &[f64],
+    left_dim: usize,
+    physical_dim: usize,
+    left: usize,
+    physical: usize,
+    right: usize,
+) -> f64 {
+    data[left + left_dim * (physical + physical_dim * right)]
+}
+
+fn reference_norm_squared(tt: &TensorTrain) -> f64 {
+    assert!(!tt.is_empty());
+
+    let mut current = Vec::new();
+    for site in 0..tt.len() {
+        let tensor = tt.tensor(site);
+        let data = tensor.to_vec::<f64>().unwrap();
+        let left_dim = if site == 0 {
+            1
+        } else {
+            tt.linkind(site - 1).unwrap().dim()
+        };
+        let right_dim = if site + 1 == tt.len() {
+            1
+        } else {
+            tt.linkind(site).unwrap().dim()
+        };
+        let physical_dim = tensor.dims().iter().product::<usize>() / (left_dim * right_dim);
+
+        if site == 0 {
+            current = vec![0.0; right_dim * right_dim];
+            for physical in 0..physical_dim {
+                for right in 0..right_dim {
+                    let value =
+                        local_tensor_value(&data, left_dim, physical_dim, 0, physical, right);
+                    for right_conj in 0..right_dim {
+                        let idx = right * right_dim + right_conj;
+                        current[idx] += value
+                            * local_tensor_value(
+                                &data,
+                                left_dim,
+                                physical_dim,
+                                0,
+                                physical,
+                                right_conj,
+                            );
+                    }
+                }
+            }
+            continue;
+        }
+
+        let mut next = vec![0.0; right_dim * right_dim];
+        for left in 0..left_dim {
+            for left_conj in 0..left_dim {
+                let env = current[left * left_dim + left_conj];
+                for physical in 0..physical_dim {
+                    for right in 0..right_dim {
+                        let value = local_tensor_value(
+                            &data,
+                            left_dim,
+                            physical_dim,
+                            left,
+                            physical,
+                            right,
+                        );
+                        for right_conj in 0..right_dim {
+                            let idx = right * right_dim + right_conj;
+                            next[idx] += env
+                                * value
+                                * local_tensor_value(
+                                    &data,
+                                    left_dim,
+                                    physical_dim,
+                                    left_conj,
+                                    physical,
+                                    right_conj,
+                                );
+                        }
+                    }
+                }
+            }
+        }
+        current = next;
+    }
+
+    current[0].max(0.0)
+}
+
+fn assert_close_relative(actual: f64, expected: f64) {
+    let scale = expected.abs().max(1.0);
+    assert!(
+        (actual - expected).abs() <= 1e-10 * scale,
+        "actual={actual:.12e}, expected={expected:.12e}"
+    );
+}
+
 /// Sanity check: norm() on a small TT returns a positive finite value.
 #[test]
 fn test_norm_small_tt_works() {
@@ -62,43 +143,37 @@ fn test_norm_small_tt_works() {
     let n = tt.norm();
     assert!(n > 0.0, "norm should be positive, got {n}");
     assert!(n.is_finite(), "norm should be finite, got {n}");
+    assert_close_relative(n * n, reference_norm_squared(&tt));
 }
 
-/// Regression test: norm() on a 25-site TT must complete in under 0.1s.
-/// The efficient O(N*D^2*d) algorithm achieves this easily.
 #[test]
-fn test_norm_25_site_tt_should_be_fast() {
+fn test_norm_25_site_tt_matches_local_reference() {
     let tt = make_tt(25);
-    let start = std::time::Instant::now();
     let n = tt.norm();
-    let elapsed = start.elapsed().as_secs_f64();
-    eprintln!("25 sites: norm={n:.6e}, elapsed={elapsed:.3}s");
     assert!(n > 0.0, "norm should be positive, got {n}");
     assert!(n.is_finite(), "norm should be finite, got {n}");
-    assert!(
-        elapsed < 0.1,
-        "norm() on 25-site TT with bond dim 2 took {elapsed:.3}s; \
-         efficient implementation should take < 0.01s"
-    );
+    assert_close_relative(n * n, reference_norm_squared(&tt));
 }
 
-/// Regression test: norm() on a 90-site TT must not OOM.
-/// The efficient algorithm needs O(90 * 4 * 2) = 720 operations.
 #[test]
-fn test_norm_large_tt_no_oom() {
+fn test_norm_90_site_tt_uses_scalable_structured_path() {
     let tt = make_tt(90);
     assert_eq!(tt.len(), 90);
     assert_eq!(tt.maxbonddim(), 2);
 
-    let start = std::time::Instant::now();
     let n = tt.norm();
-    let elapsed = start.elapsed().as_secs_f64();
-    eprintln!("90 sites: norm={n:.6e}, elapsed={elapsed:.3}s");
     assert!(n > 0.0, "norm should be positive, got {n}");
     assert!(n.is_finite(), "norm should be finite, got {n}");
-    assert!(
-        elapsed < 1.0,
-        "norm() on 90-site TT with bond dim 2 took {elapsed:.1}s; \
-         efficient implementation should take < 0.1s"
-    );
+    assert_close_relative(n * n, reference_norm_squared(&tt));
+}
+
+#[test]
+fn test_long_tt_residual_uses_norm_without_dense_maxabs() {
+    let tt = make_tt(25);
+    let residual = tt
+        .axpby(AnyScalar::new_real(1.0), &tt, AnyScalar::new_real(-1.0))
+        .unwrap();
+
+    assert_eq!(residual.len(), tt.len());
+    assert!(residual.norm() <= 1e-12 * tt.norm().max(1.0));
 }

--- a/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
@@ -81,6 +81,10 @@ fn make_tt_generic<T: TestScalar>(
     TensorTrain::new(vec![t0, t1]).unwrap()
 }
 
+fn naive_reference_options() -> ContractOptions {
+    ContractOptions::naive().with_dense_reference_limit(4)
+}
+
 fn project_dense_tensor_at_index<T: TestScalar>(
     tensor: &TensorDynLen,
     index: &DynIndex,
@@ -265,7 +269,7 @@ fn test_contract_numerical_correctness_generic<T: TestScalar>() {
     let m1 = SubDomainTT::from_tt(tt1);
     let m2 = SubDomainTT::from_tt(tt2);
     // Use Naive method for exact results (no approximation)
-    let options = ContractOptions::naive();
+    let options = naive_reference_options();
     let result = contract(&m1, &m2, &options).unwrap().unwrap();
     let contracted_tt = result.data();
 
@@ -331,7 +335,7 @@ fn test_contract_with_projectors_numerical_correctness_generic<T: TestScalar>() 
 
     // Contract
     // Use Naive method for exact results (no approximation)
-    let options = ContractOptions::naive();
+    let options = naive_reference_options();
     let result = contract(&m1, &m2, &options).unwrap().unwrap();
     let contracted_tt = result.data();
 
@@ -467,7 +471,7 @@ fn test_contract_with_projector_on_contracted_index_generic<T: TestScalar>() {
     let m2 = SubDomainTT::new(tt2, proj2);
 
     // Use Naive method for exact results (no approximation)
-    let options = ContractOptions::naive();
+    let options = naive_reference_options();
     let result = contract(&m1, &m2, &options).unwrap().unwrap();
     let contracted_tt = result.data();
 
@@ -524,7 +528,7 @@ fn test_contract_one_side_has_projector_generic<T: TestScalar>() {
     let m2 = SubDomainTT::from_tt(tt2);
 
     // Use Naive method for exact results (no approximation)
-    let options = ContractOptions::naive();
+    let options = naive_reference_options();
     let result = contract(&m1, &m2, &options).unwrap().unwrap();
 
     // Result should have projector on s0 only
@@ -580,7 +584,7 @@ fn test_proj_contract_numerical_correctness_generic<T: TestScalar>() {
     // proj_contract with projector that projects s0=0 and s2=1
     let proj = Projector::from_pairs([(s0.clone(), 0), (s2.clone(), 1)]);
     // Use Naive method for exact results (no approximation)
-    let options = ContractOptions::naive();
+    let options = naive_reference_options();
     let result = proj_contract(&m1, &m2, &proj, &options).unwrap().unwrap();
 
     // Verify projectors

--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -27,9 +27,8 @@ use crate::quantics_tci::quanticscrossinterpolate;
 ///
 /// ```
 /// use tensor4all_quanticstci::{
-///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
+///     quanticscrossinterpolate_batched, AbstractTensorTrain, DiscretizedGrid, QtciOptions,
 /// };
-/// use tensor4all_simplett::AbstractTensorTrain;
 ///
 /// let grid = DiscretizedGrid::builder(&[2])
 ///     .with_lower_bound(&[0.0])
@@ -71,9 +70,8 @@ where
     ///
     /// ```
     /// use tensor4all_quanticstci::{
-    ///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
+    ///     quanticscrossinterpolate_batched, AbstractTensorTrain, DiscretizedGrid, QtciOptions,
     /// };
-    /// use tensor4all_simplett::AbstractTensorTrain;
     ///
     /// let grid = DiscretizedGrid::builder(&[2])
     ///     .with_lower_bound(&[0.0])
@@ -180,9 +178,8 @@ where
 ///
 /// ```
 /// use tensor4all_quanticstci::{
-///     quanticscrossinterpolate_batched, QtciOptions, DiscretizedGrid,
+///     quanticscrossinterpolate_batched, AbstractTensorTrain, DiscretizedGrid, QtciOptions,
 /// };
-/// use tensor4all_simplett::AbstractTensorTrain;
 ///
 /// let grid = DiscretizedGrid::builder(&[2])
 ///     .with_lower_bound(&[0.0])

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -244,8 +244,9 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
-    /// use tensor4all_simplett::AbstractTensorTrain;
+    /// use tensor4all_quanticstci::{
+    ///     quanticscrossinterpolate_discrete, AbstractTensorTrain, QtciOptions,
+    /// };
     ///
     /// let f = |idx: &[i64]| idx[0] as f64;
     /// let (qtci, _, _) = quanticscrossinterpolate_discrete::<f64, _>(

--- a/crates/tensor4all-quanticstransform/README.md
+++ b/crates/tensor4all-quanticstransform/README.md
@@ -5,23 +5,37 @@ Quantics transformation operators for tensor train methods. Port of Quantics.jl.
 ## Key Types
 
 - `LinearOperator` — operator in TreeTN form; returned by all constructor functions
-- `shift_operator()` — cyclic shift: f(x) = g(x + offset) mod 2^R
+- `shift_operator()` — basis shift `|x> -> |x + offset>`; as a matrix action, `(M g)[x] = g[x - offset]`
 - `flip_operator()` — reflection: f(x) = g(2^R - x)
 - `quantics_fourier_operator()` — Quantics Fourier Transform (QFT)
 - `affine_operator()` — affine transform y = A·x + b with rational coefficients
 
+## Conventions
+
+- Operators carry their own input and output indices. Replace a state site's
+  index with the operator input index before applying it.
+- Multi-variable operators use interleaved bit encoding:
+  `site = bit_var0 + 2 * bit_var1 + ...`.
+- QFT output is in bit-reversed frequency order.
+- Affine matrices are column-major.
+- Dense materialization is for small reference/debug checks only.
+
 ## Example
 
-```rust,ignore
-use tensor4all_quanticstransform::{shift_operator, flip_operator, BoundaryCondition};
+```rust
+# fn main() -> anyhow::Result<()> {
+use tensor4all_quanticstransform::{flip_operator, shift_operator, BoundaryCondition};
 
 // Create operators for R=4 sites (2^4 = 16 grid points)
 let r = 4;
 let shift_op = shift_operator(r, 3, BoundaryCondition::Periodic)?;
-let flip_op = flip_operator(r)?;
+let flip_op = flip_operator(r, BoundaryCondition::Periodic)?;
 
-// Operators are LinearOperator (TreeTN form) — apply to a TreeTN with
-// tensor4all_treetn::apply_linear_operator()
+// Operators are LinearOperator (TreeTN form).
+assert_eq!(shift_op.mpo.node_count(), r);
+assert_eq!(flip_op.mpo.node_count(), r);
+# Ok(())
+# }
 ```
 
 ## Documentation

--- a/crates/tensor4all-quanticstransform/src/affine.rs
+++ b/crates/tensor4all-quanticstransform/src/affine.rs
@@ -118,6 +118,9 @@ impl AffineParams {
     /// * `m` - Number of output dimensions
     /// * `n` - Number of input dimensions
     ///
+    /// # Errors
+    /// Returns an error when `a.len() != m * n` or `b.len() != m`.
+    ///
     /// # Examples
     ///
     /// ```
@@ -161,6 +164,9 @@ impl AffineParams {
     /// Create affine parameters from integer matrix and vector.
     ///
     /// Convenience method that converts integer values to rationals.
+    ///
+    /// # Errors
+    /// Returns an error when `a.len() != m * n` or `b.len() != m`.
     ///
     /// # Examples
     ///
@@ -368,6 +374,9 @@ pub fn affine_operator(
 /// # Note
 /// This is only practical for small R due to exponential size.
 /// Use for testing/verification only.
+///
+/// # Errors
+/// Returns an error when `r == 0` or when `bc.len() != params.m`.
 pub fn affine_transform_matrix(
     r: usize,
     params: &AffineParams,
@@ -494,6 +503,10 @@ fn affine_transform_mpo(
 ///
 /// # Returns
 /// Vector of R tensors with unfused physical indices.
+///
+/// # Errors
+/// Returns an error when `r == 0`, when `bc.len() != params.m`, or when affine
+/// tensor construction fails.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
@@ -489,10 +489,24 @@ fn affine_matrix_to_dense_tensor(
 /// Assert that the MPO representation matches the direct sparse matrix computation
 /// for all elements. This is the primary correctness check: two independent algorithms
 /// (carry-based MPO vs direct enumeration) must agree.
+const AFFINE_DENSE_REFERENCE_MAX_ELEMENTS: usize = 1 << 20;
+
+fn affine_dense_reference_element_count(r: usize, m: usize, n: usize) -> Option<usize> {
+    let local_bits = m.checked_add(n)?;
+    let total_bits = r.checked_mul(local_bits)?;
+    let shift = u32::try_from(total_bits).ok()?;
+    1usize.checked_shl(shift)
+}
+
 #[allow(clippy::needless_range_loop)]
 fn assert_affine_mpo_matches_matrix(r: usize, params: &AffineParams, bc: &[BoundaryCondition]) {
     let m = params.m;
     let n = params.n;
+    let dense_elements = affine_dense_reference_element_count(r, m, n).unwrap_or(usize::MAX);
+    assert!(
+        dense_elements <= AFFINE_DENSE_REFERENCE_MAX_ELEMENTS,
+        "affine dense reference helper is limited to {AFFINE_DENSE_REFERENCE_MAX_ELEMENTS} elements, requested {dense_elements} [r={r}, m={m}, n={n}]"
+    );
 
     let matrix = affine_transform_matrix(r, params, bc).unwrap();
     let op = affine_operator(r, params, bc).unwrap();
@@ -510,6 +524,14 @@ fn assert_affine_mpo_matches_matrix(r: usize, params: &AffineParams, bc: &[Bound
         n,
         bc
     );
+}
+
+#[test]
+#[should_panic(expected = "affine dense reference helper is limited")]
+fn test_affine_dense_reference_helper_rejects_large_cases() {
+    let params = AffineParams::from_integers(vec![1], vec![0], 1, 1).unwrap();
+    let bc = vec![BoundaryCondition::Periodic];
+    assert_affine_mpo_matches_matrix(21, &params, &bc);
 }
 
 /// Assert that affine_transform_matrix produces correct results by independently

--- a/crates/tensor4all-quanticstransform/src/cumsum.rs
+++ b/crates/tensor4all-quanticstransform/src/cumsum.rs
@@ -53,6 +53,10 @@ pub enum TriangleType {
 /// # Returns
 /// LinearOperator representing the cumulative sum
 ///
+/// # Errors
+/// Returns an error when `r < 2` or when internal MPO/operator construction
+/// fails.
+///
 /// # Examples
 ///
 /// ```
@@ -83,6 +87,10 @@ pub fn cumsum_operator(r: usize) -> Result<QuanticsOperator> {
 /// # Arguments
 /// * `r` - Number of bits (sites). Must be at least 2.
 /// * `triangle` - Which triangle to use
+///
+/// # Errors
+/// Returns an error when `r < 2` or when internal MPO/operator construction
+/// fails.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-quanticstransform/src/flip.rs
+++ b/crates/tensor4all-quanticstransform/src/flip.rs
@@ -23,6 +23,10 @@ use crate::common::{
 /// # Returns
 /// LinearOperator representing the flip transformation
 ///
+/// # Errors
+/// Returns an error when `r` is zero, when one-site flip construction is
+/// requested, or when internal MPO/operator construction fails.
+///
 /// # Examples
 ///
 /// ```
@@ -60,6 +64,10 @@ pub fn flip_operator(r: usize, bc: BoundaryCondition) -> Result<QuanticsOperator
 /// * `bc` - Boundary condition
 /// * `nvariables` - Total number of variables (must be at least 2)
 /// * `target_var` - Which variable to flip (0-indexed, must be < nvariables)
+///
+/// # Errors
+/// Returns an error when `r` is zero or one, when `nvariables` or `target_var`
+/// is invalid, or when embedding/operator construction fails.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-quanticstransform/src/fourier.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier.rs
@@ -113,6 +113,9 @@ pub struct FTCore {
 
 impl FTCore {
     /// Create a new FTCore for r bits.
+    ///
+    /// # Errors
+    /// Returns an error when `r < 2` or when Fourier MPO construction fails.
     pub fn new(r: usize, options: FourierOptions) -> Result<Self> {
         if r < 2 {
             anyhow::bail!("Number of sites must be at least 2, got {r}");
@@ -130,12 +133,20 @@ impl FTCore {
     }
 
     /// Get the forward Fourier transform operator.
+    ///
+    /// # Errors
+    /// Returns an error when converting the cached Fourier MPO to a linear
+    /// operator fails.
     pub fn forward(&self) -> Result<QuanticsOperator> {
         let site_dims = vec![2; self.r];
         tensortrain_to_linear_operator(&self.forward_mpo, &site_dims)
     }
 
     /// Get the backward (inverse) Fourier transform operator.
+    ///
+    /// # Errors
+    /// Returns an error when inverse Fourier MPO construction or conversion to
+    /// a linear operator fails.
     pub fn backward(&self) -> Result<QuanticsOperator> {
         let inverse_options = FourierOptions {
             sign: 1.0,
@@ -172,6 +183,10 @@ impl FTCore {
 ///
 /// # Returns
 /// LinearOperator representing the QFT
+///
+/// # Errors
+/// Returns an error when `r < 2` or when Fourier MPO/operator construction
+/// fails.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -9,15 +9,42 @@
 //!
 //! All transformations return `LinearOperator` from tensor4all-treetn for
 //! consistent operator application to tensor train states.
+//! Operators use their own input and output indices. Before applying an
+//! operator to an existing state, replace the state's site indices with the
+//! operator input indices from `get_input_mapping()`. The result then carries
+//! the operator output indices.
 //!
 //! ## Available Transformations
 //!
 //! - **Flip**: f(x) = g(2^R - x)
-//! - **Shift**: f(x) = g(x + offset) mod 2^R
+//! - **Shift**: maps basis states as `|x> -> |x + offset>`; as a matrix action,
+//!   `(M g)[x] = g[x - offset]` with the selected boundary condition
 //! - **Phase Rotation**: f(x) = exp(i*θ*x) * g(x)
 //! - **Cumulative Sum**: y_i = Σ_{j<i} x_j
 //! - **Fourier Transform**: Quantics Fourier Transform (QFT)
 //! - **Affine Transform**: y = A*x + b with rational coefficients
+//!
+//! # Conventions
+//!
+//! - Quantics bits are big-endian by site: site 0 stores the most significant
+//!   bit unless a function documents a different output ordering.
+//! - The QFT output uses bit-reversed frequency order. A site configuration
+//!   `(b_0, ..., b_{R-1})` corresponds to frequency
+//!   `b_{R-1} * 2^{R-1} + ... + b_0`.
+//! - Multi-variable operators use interleaved quantics encoding. At each bit
+//!   site, the local index is `bit_var0 + 2 * bit_var1 + ...`.
+//! - `AffineParams::a` is column-major: `[[1, 2], [3, 4]]` is stored as
+//!   `[1, 3, 2, 4]`.
+//! - Dense materialization is appropriate only for small reference checks and
+//!   debugging. Production-size tensor-network workflows should use local
+//!   operator application and scalable residual checks.
+//!
+//! # Errors
+//!
+//! Constructors return an error when dimensions are invalid, a bit count would
+//! overflow an integer representation, an affine matrix/vector shape is
+//! inconsistent, boundary-condition restrictions cannot be satisfied, or an
+//! internal tensor-train/operator conversion fails.
 //!
 //! # Example
 //!

--- a/crates/tensor4all-quanticstransform/src/phase_rotation.rs
+++ b/crates/tensor4all-quanticstransform/src/phase_rotation.rs
@@ -30,6 +30,10 @@ use crate::common::{
 /// # Returns
 /// LinearOperator representing the phase rotation
 ///
+/// # Errors
+/// Returns an error when `r` is zero, when `theta` is not finite, or when
+/// internal MPO/operator construction fails.
+///
 /// # Examples
 ///
 /// ```
@@ -72,6 +76,11 @@ pub fn phase_rotation_operator(r: usize, theta: f64) -> Result<QuanticsOperator>
 /// * `theta` - Phase angle in radians
 /// * `nvariables` - Total number of variables
 /// * `target_var` - Which variable to apply phase rotation to (0-indexed)
+///
+/// # Errors
+/// Returns an error when `r` is zero, when `theta` is not finite, when
+/// `nvariables` or `target_var` is invalid, or when embedding/operator
+/// construction fails.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-quanticstransform/src/shift.rs
+++ b/crates/tensor4all-quanticstransform/src/shift.rs
@@ -1,6 +1,8 @@
-//! Shift operator: f(x) = g(x + offset) mod 2^R
+//! Shift operator for basis-state translations.
 //!
-//! This transformation shifts the argument by a constant offset.
+//! The operator maps basis states as `|x> -> |x + offset>`. As a matrix action
+//! on sampled values, `(M g)[x] = g[x - offset]` with the selected boundary
+//! condition.
 
 use anyhow::Result;
 use num_complex::Complex64;
@@ -12,9 +14,10 @@ use crate::common::{
     tensortrain_to_linear_operator_asymmetric, BoundaryCondition, QuanticsOperator,
 };
 
-/// Create a shift operator: f(x) = g(x + offset) mod 2^R
+/// Create a shift operator for `|x> -> |x + offset>`.
 ///
-/// This MPO transforms a function g(x) to f(x) = g(x + offset) for x = 0, 1, ..., 2^R - 1.
+/// As a matrix acting on a value vector `g`, the output satisfies
+/// `(M g)[x] = g[x - offset]` for `x = 0, 1, ..., 2^R - 1`, subject to `bc`.
 ///
 /// # Arguments
 /// * `r` - Number of bits (sites)
@@ -23,6 +26,10 @@ use crate::common::{
 ///
 /// # Returns
 /// LinearOperator representing the shift transformation
+///
+/// # Errors
+/// Returns an error when `r` is zero, when `r > 63` would overflow the integer
+/// index representation, or when internal MPO/operator construction fails.
 ///
 /// # Examples
 ///
@@ -57,6 +64,10 @@ pub fn shift_operator(r: usize, offset: i64, bc: BoundaryCondition) -> Result<Qu
 /// * `bc` - Boundary condition
 /// * `nvariables` - Total number of variables (must be at least 2)
 /// * `target_var` - Which variable to shift (0-indexed, must be < nvariables)
+///
+/// # Errors
+/// Returns an error when `r` is zero, when `r > 63`, when `nvariables` or
+/// `target_var` is invalid, or when embedding/operator construction fails.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result};
 use crate::algorithm::CanonicalForm;
 use tensor4all_core::{
     AllowedPairs, Canonical, FactorizeAlg, FactorizeOptions, IndexLike, SvdTruncationPolicy,
-    TensorLike,
+    TensorIndex, TensorLike,
 };
 
 use super::TreeTN;
@@ -821,6 +821,13 @@ pub struct ContractionOptions {
     pub convergence_tol: Option<f64>,
     /// Factorization algorithm for Fit method.
     pub factorize_alg: FactorizeAlg,
+    /// Maximum dense elements allowed for generic Naive dense/reference
+    /// contraction.
+    ///
+    /// `None` rejects the generic dense/reference path. Set this only for
+    /// small debugging or reference cases where full dense materialization of
+    /// both inputs and the contracted result is expected and bounded.
+    pub dense_reference_limit: Option<usize>,
     /// Maximum dense elements allowed for explicit mismatched-topology
     /// reference fallback in `partial_contract`.
     ///
@@ -839,6 +846,7 @@ impl Default for ContractionOptions {
             nfullsweeps: 1,
             convergence_tol: None,
             factorize_alg: FactorizeAlg::default(),
+            dense_reference_limit: None,
             mismatched_topology_dense_limit: None,
         }
     }
@@ -899,6 +907,29 @@ impl ContractionOptions {
         self
     }
 
+    /// Allow generic Naive dense/reference contraction up to `max_elements`.
+    ///
+    /// # Arguments
+    /// * `max_elements` - Maximum number of elements allowed in each full dense
+    ///   input tensor and in the dense contracted result. Typical values should
+    ///   remain small and test-sized.
+    ///
+    /// # Returns
+    /// Updated options with the dense/reference contraction limit enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::contraction::ContractionOptions;
+    ///
+    /// let options = ContractionOptions::default().with_dense_reference_limit(1024);
+    /// assert_eq!(options.dense_reference_limit, Some(1024));
+    /// ```
+    pub fn with_dense_reference_limit(mut self, max_elements: usize) -> Self {
+        self.dense_reference_limit = Some(max_elements);
+        self
+    }
+
     /// Allow `partial_contract` to use its mismatched-topology dense reference
     /// fallback up to `max_elements` elements.
     ///
@@ -923,6 +954,75 @@ impl ContractionOptions {
         self.mismatched_topology_dense_limit = Some(max_elements);
         self
     }
+}
+
+fn dense_element_count<I: IndexLike>(indices: &[I], context: &str) -> Result<usize> {
+    indices.iter().try_fold(1usize, |acc, index| {
+        acc.checked_mul(index.dim()).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{context}: dense/reference element count overflowed while checking limit"
+            )
+        })
+    })
+}
+
+fn dense_contract_output_indices<I: IndexLike>(a_indices: &[I], b_indices: &[I]) -> Vec<I> {
+    let mut b_remaining = b_indices.to_vec();
+    let mut output = Vec::new();
+
+    for idx_a in a_indices {
+        if let Some(position) = b_remaining
+            .iter()
+            .position(|idx_b| idx_a.is_contractable(idx_b))
+        {
+            b_remaining.remove(position);
+        } else {
+            output.push(idx_a.clone());
+        }
+    }
+
+    output.extend(b_remaining);
+    output
+}
+
+fn ensure_dense_reference_limit<I: IndexLike>(
+    context: &str,
+    label: &str,
+    indices: &[I],
+    max_elements: usize,
+) -> Result<()> {
+    let elements = dense_element_count(indices, context)?;
+    if elements > max_elements {
+        anyhow::bail!(
+            "{context}: Naive dense/reference contraction would materialize {label} with {elements} elements, exceeding limit {max_elements}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_naive_dense_reference_limit<T, V>(
+    tn_a: &TreeTN<T, V>,
+    tn_b: &TreeTN<T, V>,
+    options: &ContractionOptions,
+) -> Result<()>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let Some(max_elements) = options.dense_reference_limit else {
+        anyhow::bail!(
+            "contract: Naive dense/reference contraction requires an explicit dense/reference limit; call ContractionOptions::with_dense_reference_limit(max_elements) for small reference cases"
+        );
+    };
+
+    let a_external = tn_a.external_indices();
+    let b_external = tn_b.external_indices();
+    let output = dense_contract_output_indices(&a_external, &b_external);
+
+    ensure_dense_reference_limit("contract", "first TreeTN", &a_external, max_elements)?;
+    ensure_dense_reference_limit("contract", "second TreeTN", &b_external, max_elements)?;
+    ensure_dense_reference_limit("contract", "contracted result", &output, max_elements)
 }
 
 /// Contract two TreeTNs using the specified method.
@@ -969,14 +1069,17 @@ where
             };
             super::fit::contract_fit(tn_a, tn_b, center, fit_options)
         }
-        ContractionMethod::Naive => contract_naive_to_treetn(
-            tn_a,
-            tn_b,
-            center,
-            options.max_rank,
-            options.svd_policy,
-            options.qr_rtol,
-        ),
+        ContractionMethod::Naive => {
+            validate_naive_dense_reference_limit(tn_a, tn_b, &options)?;
+            contract_naive_to_treetn(
+                tn_a,
+                tn_b,
+                center,
+                options.max_rank,
+                options.svd_policy,
+                options.qr_rtol,
+            )
+        }
     }
 }
 

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -821,6 +821,12 @@ pub struct ContractionOptions {
     pub convergence_tol: Option<f64>,
     /// Factorization algorithm for Fit method.
     pub factorize_alg: FactorizeAlg,
+    /// Maximum dense elements allowed for explicit mismatched-topology
+    /// reference fallback in `partial_contract`.
+    ///
+    /// `None` rejects the fallback. Set this only for small reference/debug
+    /// cases where full dense materialization is expected and bounded.
+    pub mismatched_topology_dense_limit: Option<usize>,
 }
 
 impl Default for ContractionOptions {
@@ -833,6 +839,7 @@ impl Default for ContractionOptions {
             nfullsweeps: 1,
             convergence_tol: None,
             factorize_alg: FactorizeAlg::default(),
+            mismatched_topology_dense_limit: None,
         }
     }
 }
@@ -889,6 +896,31 @@ impl ContractionOptions {
     /// Set factorization algorithm for Fit method.
     pub fn with_factorize_alg(mut self, alg: FactorizeAlg) -> Self {
         self.factorize_alg = alg;
+        self
+    }
+
+    /// Allow `partial_contract` to use its mismatched-topology dense reference
+    /// fallback up to `max_elements` elements.
+    ///
+    /// # Arguments
+    /// * `max_elements` - Maximum number of elements allowed in each dense
+    ///   intermediate and in the dense contracted result. Typical values should
+    ///   remain small and test-sized.
+    ///
+    /// # Returns
+    /// Updated options with the dense/reference fallback limit enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::contraction::ContractionOptions;
+    ///
+    /// let options = ContractionOptions::default()
+    ///     .with_mismatched_topology_dense_limit(1024);
+    /// assert_eq!(options.mismatched_topology_dense_limit, Some(1024));
+    /// ```
+    pub fn with_mismatched_topology_dense_limit(mut self, max_elements: usize) -> Self {
+        self.mismatched_topology_dense_limit = Some(max_elements);
         self
     }
 }

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -42,6 +42,8 @@ fn test_contraction_options_default() {
     assert!(opts.qr_rtol.is_none());
     assert_eq!(opts.nfullsweeps, 1);
     assert!(opts.convergence_tol.is_none());
+    assert!(opts.dense_reference_limit.is_none());
+    assert!(opts.mismatched_topology_dense_limit.is_none());
 }
 
 #[test]
@@ -72,7 +74,9 @@ fn test_contraction_options_builders() {
         .with_svd_policy(policy)
         .with_nfullsweeps(3)
         .with_convergence_tol(1e-6)
-        .with_factorize_alg(FactorizeAlg::LU);
+        .with_factorize_alg(FactorizeAlg::LU)
+        .with_dense_reference_limit(128)
+        .with_mismatched_topology_dense_limit(64);
 
     assert_eq!(opts.max_rank, Some(10));
     assert_eq!(opts.svd_policy, Some(policy));
@@ -80,6 +84,8 @@ fn test_contraction_options_builders() {
     assert_eq!(opts.nfullsweeps, 3);
     assert_eq!(opts.convergence_tol, Some(1e-6));
     assert_eq!(opts.factorize_alg, FactorizeAlg::LU);
+    assert_eq!(opts.dense_reference_limit, Some(128));
+    assert_eq!(opts.mismatched_topology_dense_limit, Some(64));
 }
 
 #[test]
@@ -233,6 +239,55 @@ fn test_contract_zipup_topology_mismatch() {
 
     let result = tn1.contract_zipup(&tn2, &"A".to_string(), None, None);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_contract_naive_requires_dense_reference_limit() {
+    let s = DynIndex::new_dyn(3);
+    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = TensorDynLen::from_dense(vec![s], vec![1.0, 1.0, 1.0]).unwrap();
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+
+    let err = contract(
+        &tn_a,
+        &tn_b,
+        &"A".to_string(),
+        ContractionOptions::new(ContractionMethod::Naive),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("explicit dense/reference limit"));
+}
+
+#[test]
+fn test_contract_naive_dense_reference_limit_bounds_materialization() {
+    let s = DynIndex::new_dyn(3);
+    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = TensorDynLen::from_dense(vec![s], vec![1.0, 1.0, 1.0]).unwrap();
+    let tn_a =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+
+    let err = contract(
+        &tn_a,
+        &tn_b,
+        &"A".to_string(),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(2),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("exceeding limit 2"));
+
+    let result = contract(
+        &tn_a,
+        &tn_b,
+        &"A".to_string(),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(3),
+    )
+    .unwrap();
+    assert_eq!(result.node_count(), 1);
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -289,6 +289,87 @@ where
     Ok(TreeTopology::new(nodes, union_edges))
 }
 
+fn validate_mismatched_union_topology<V>(
+    a: &TreeTN<TensorDynLen, V>,
+    b: &TreeTN<TensorDynLen, V>,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
+{
+    let node_names = compatible_union_node_names(a, b);
+    let mut union_edges = sorted_edge_set(a);
+    union_edges.extend(sorted_edge_set(b));
+    union_edges.sort();
+    union_edges.dedup();
+    validate_union_topology(&node_names, &union_edges)
+}
+
+fn dense_element_count(indices: &[DynIndex]) -> Result<usize> {
+    indices.iter().try_fold(1usize, |acc, index| {
+        acc.checked_mul(index.dim()).ok_or_else(|| {
+            anyhow!(
+                "partial_contract: dense/reference element count overflowed for mismatched-topology fallback"
+            )
+        })
+    })
+}
+
+fn dense_contract_output_indices(a_indices: &[DynIndex], b_indices: &[DynIndex]) -> Vec<DynIndex> {
+    let mut b_remaining = b_indices.to_vec();
+    let mut output = Vec::new();
+
+    for idx_a in a_indices {
+        if let Some(position) = b_remaining
+            .iter()
+            .position(|idx_b| idx_a.is_contractable(idx_b))
+        {
+            b_remaining.remove(position);
+        } else {
+            output.push(idx_a.clone());
+        }
+    }
+
+    output.extend(b_remaining);
+    output
+}
+
+fn ensure_dense_reference_limit(
+    label: &str,
+    indices: &[DynIndex],
+    max_elements: usize,
+) -> Result<()> {
+    let elements = dense_element_count(indices)?;
+    if elements > max_elements {
+        bail!(
+            "partial_contract: mismatched-topology dense/reference fallback would materialize {label} with {elements} elements, exceeding limit {max_elements}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_mismatched_dense_reference_fallback<V>(
+    a: &TreeTN<TensorDynLen, V>,
+    b: &TreeTN<TensorDynLen, V>,
+    options: &ContractionOptions,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
+{
+    let Some(max_elements) = options.mismatched_topology_dense_limit else {
+        bail!(
+            "partial_contract: mismatched topologies require an explicit dense/reference limit; call ContractionOptions::with_mismatched_topology_dense_limit(max_elements) for small reference cases"
+        );
+    };
+
+    let a_external = a.external_indices();
+    let b_external = b.external_indices();
+    let output = dense_contract_output_indices(&a_external, &b_external);
+
+    ensure_dense_reference_limit("first TreeTN", &a_external, max_elements)?;
+    ensure_dense_reference_limit("second TreeTN", &b_external, max_elements)?;
+    ensure_dense_reference_limit("contracted result", &output, max_elements)
+}
+
 fn contract_mismatched_topologies<V>(
     a: &TreeTN<TensorDynLen, V>,
     b: &TreeTN<TensorDynLen, V>,
@@ -299,6 +380,9 @@ where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
 {
+    validate_mismatched_union_topology(a, b)?;
+    validate_mismatched_dense_reference_fallback(a, b, &options)?;
+
     let a_dense = a
         .sim_internal_inds()
         .contract_to_tensor()

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -468,7 +468,7 @@ fn test_partial_contract_allows_compatible_topology_mismatch_with_gap_leaf() {
         &tn_b,
         &spec,
         &"A".to_string(),
-        ContractionOptions::default(),
+        ContractionOptions::default().with_mismatched_topology_dense_limit(64),
     );
     assert!(result.is_ok(), "{result:?}");
 
@@ -478,6 +478,47 @@ fn test_partial_contract_allows_compatible_topology_mismatch_with_gap_leaf() {
     assert!(external.iter().any(|idx| idx.id() == s_a.id()));
     assert!(external.iter().any(|idx| idx.id() == s_b.id()));
     assert!(external.iter().any(|idx| idx.id() == s_b2.id()));
+}
+
+#[test]
+fn test_partial_contract_rejects_mismatched_topology_dense_fallback_without_explicit_limit() {
+    fn binary_chain(node_count: usize) -> TreeTN<TensorDynLen, usize> {
+        let mut tensors = Vec::with_capacity(node_count);
+        let mut names = Vec::with_capacity(node_count);
+        let mut left_bond: Option<DynIndex> = None;
+
+        for site in 0..node_count {
+            let site_index = DynIndex::new_dyn(2);
+            let right_bond = (site + 1 < node_count).then(|| DynIndex::new_dyn(1));
+            let mut indices = Vec::new();
+            if let Some(bond) = left_bond.take() {
+                indices.push(bond);
+            }
+            indices.push(site_index);
+            if let Some(bond) = &right_bond {
+                indices.push(bond.clone());
+            }
+
+            let element_count = indices.iter().map(IndexLike::dim).product();
+            tensors.push(TensorDynLen::from_dense(indices, vec![1.0; element_count]).unwrap());
+            names.push(site);
+            left_bond = right_bond;
+        }
+
+        TreeTN::<TensorDynLen, usize>::from_tensors(tensors, names).unwrap()
+    }
+
+    let tn_a = binary_chain(24);
+    let tn_b = binary_chain(25);
+    let spec = PartialContractionSpec {
+        contract_pairs: vec![],
+        diagonal_pairs: vec![],
+        output_order: None,
+    };
+
+    let err =
+        partial_contract(&tn_a, &tn_b, &spec, &0usize, ContractionOptions::default()).unwrap_err();
+    assert!(err.to_string().contains("explicit dense/reference limit"));
 }
 
 #[test]
@@ -558,7 +599,7 @@ fn test_partial_contract_mismatched_topology_scalar_result() {
         &tn_b,
         &spec,
         &"A".to_string(),
-        ContractionOptions::default(),
+        ContractionOptions::default().with_mismatched_topology_dense_limit(64),
     )
     .unwrap();
 
@@ -809,7 +850,7 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
         &tn_b,
         &spec,
         &1usize,
-        ContractionOptions::new(ContractionMethod::Naive),
+        ContractionOptions::new(ContractionMethod::Naive).with_mismatched_topology_dense_limit(128),
     )
     .unwrap();
     let result_dense = result.to_dense().unwrap();

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -102,7 +102,7 @@ fn test_partial_contract_allows_same_node_contract_and_diagonal() {
         &tn_b,
         &spec,
         &"B".to_string(),
-        ContractionOptions::new(ContractionMethod::Naive),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(128),
     );
     assert!(result.is_ok());
 }
@@ -279,7 +279,7 @@ fn test_partial_contract_contract_only() {
         &tn_b,
         &spec,
         &"A".to_string(),
-        ContractionOptions::new(ContractionMethod::Naive),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(128),
     )
     .unwrap();
 
@@ -311,7 +311,7 @@ fn test_partial_contract_empty_spec() {
         &tn_b,
         &spec,
         &"A".to_string(),
-        ContractionOptions::new(ContractionMethod::Naive),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(128),
     )
     .unwrap();
 
@@ -342,7 +342,7 @@ fn test_partial_contract_rejects_bad_output_order_length() {
         &tn_b,
         &spec,
         &"A".to_string(),
-        ContractionOptions::new(ContractionMethod::Naive),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(128),
     );
     assert!(result.is_err());
     assert!(result
@@ -375,7 +375,7 @@ fn test_partial_contract_rejects_unknown_output_order_index() {
         &tn_b,
         &spec,
         &"A".to_string(),
-        ContractionOptions::new(ContractionMethod::Naive),
+        ContractionOptions::new(ContractionMethod::Naive).with_dense_reference_limit(128),
     );
     assert!(result.is_err());
     assert!(result
@@ -850,7 +850,9 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
         &tn_b,
         &spec,
         &1usize,
-        ContractionOptions::new(ContractionMethod::Naive).with_mismatched_topology_dense_limit(128),
+        ContractionOptions::new(ContractionMethod::Naive)
+            .with_dense_reference_limit(128)
+            .with_mismatched_topology_dense_limit(128),
     )
     .unwrap();
     let result_dense = result.to_dense().unwrap();

--- a/docs/book/src/guides/qft.md
+++ b/docs/book/src/guides/qft.md
@@ -89,13 +89,16 @@ for i in 0..r {
     state = state.replaceind(&site_indices[i], &op_input).unwrap();
 }
 
-// Apply the QFT with local exact naive apply.
+// Apply the QFT with local exact naive apply. This can grow bond dimensions as
+// state/operator products, so use it for small exact/debug cases.
 let result = apply_linear_operator(&qft_op, &state, ApplyOptions::naive()).unwrap();
 
 // The result should exist and have the same number of nodes
 assert_eq!(result.node_count(), r);
 
-// This example is small, so dense verification is acceptable.
+// This example is intentionally small, so dense verification is acceptable.
+// For production-size networks, prefer scalable residual norms or sampled
+// `evaluate()` checks rather than `contract_to_tensor()`.
 let dense = result.contract_to_tensor().unwrap();
 let data = dense.to_vec::<Complex64>().unwrap();
 

--- a/docs/book/src/guides/quantics.md
+++ b/docs/book/src/guides/quantics.md
@@ -140,7 +140,7 @@ Three methods are available, each with different tradeoffs:
 
 | Method | Algorithm | When to use |
 |--------|-----------|-------------|
-| `ApplyOptions::naive()` | Local exact operator-state apply with product links | Exactness required and bond growth is acceptable |
+| `ApplyOptions::naive()` | Local exact operator-state apply with product links | Small exact/debug cases; bond dimensions may grow as products |
 | `ApplyOptions::zipup()` | Single-sweep contraction with SVD truncation | Default choice; fast, good accuracy |
 | `ApplyOptions::fit()` | Iterative variational optimization | Best compression; use when bond dim must be small |
 
@@ -149,7 +149,8 @@ use tensor4all_core::SvdTruncationPolicy;
 use tensor4all_treetn::ApplyOptions;
 
 // Naive: local exact apply with no truncation or full dense materialization.
-// Output bond dimensions can grow as state/operator bond products.
+// Use for small exact/debug cases; output bond dimensions can grow as
+// state/operator bond products.
 let opts = ApplyOptions::naive();
 assert_eq!(opts.max_rank, None);
 

--- a/docs/plans/2026-02-15-tensor-comparison-design.md
+++ b/docs/plans/2026-02-15-tensor-comparison-design.md
@@ -1,5 +1,11 @@
 # Tensor Comparison Utilities Design
 
+> Historical note: this early design treats `maxabs()` as a general
+> `TensorLike` primitive. Current repository rules reserve dense `maxabs()`
+> comparisons for small dense/reference tensors. Long TT/TN checks should use
+> scalable residual norms, sampled `evaluate()` checks, or structural
+> invariants instead.
+
 ## Problem
 
 Test code across tensor4all-rs uses verbose element-wise loops to verify tensor accuracy:

--- a/docs/plans/2026-04-23-general-structured-contraction-design.md
+++ b/docs/plans/2026-04-23-general-structured-contraction-design.md
@@ -1,5 +1,10 @@
 # General Structured Contraction Design
 
+> Historical note: this design predates the current repository rule that
+> production paths must preserve compact structured representations and avoid
+> hidden full dense materialization. Mentions of dense fallback below describe a
+> temporary reference/debug path, not current production guidance.
+
 ## Goal
 
 Implement contraction for dense, diagonal, and general structured
@@ -266,4 +271,3 @@ Then test value and AD behavior:
   call `backward()`, and verify `grad().storage().axis_classes()` matches the
   input layout;
 - verify gradient payload values against dense whole-result comparisons.
-

--- a/docs/plans/2026-04-24-contraction-nary-einsum-unification.md
+++ b/docs/plans/2026-04-24-contraction-nary-einsum-unification.md
@@ -1,5 +1,10 @@
 # N-ary Contraction Pipeline Unification Implementation Plan
 
+> Historical note: this planning document predates the current repository rule
+> that production tensor-network paths must not silently dense-materialize full
+> tensors. Treat any dense fallback discussed here as small/reference/debug
+> behavior only, not production guidance.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Make tensor4all-core contractions express retained shared indices, route dense contraction execution through tenferro-rs N-ary eager einsum, and remove the semantic drift between AD and non-AD paths.
@@ -732,4 +737,3 @@ Suggested checkpoints:
 3. `feat: unify ad and native contraction execution`
 4. `feat: add owned contraction entrypoints`
 5. `docs: document retained contraction options`
-

--- a/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
+++ b/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
@@ -130,7 +130,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Library call: exact TreeTN-level partial contraction.
     // `partial_contract` performs the pointwise product on the paired sites.
-    let raw_product_options = ContractionOptions::new(ContractionMethod::Naive);
+    let raw_product_options = ContractionOptions::new(ContractionMethod::Naive)
+        .with_dense_reference_limit(NPOINTS * NPOINTS);
     let product_raw_tn = partial_contract(
         &square_treetn,
         &factor_b_treetn,

--- a/docs/tutorial-code/tests/verification.rs
+++ b/docs/tutorial-code/tests/verification.rs
@@ -674,7 +674,8 @@ fn qtt_elementwise_product_demo_tracks_the_pointwise_product() -> Result<(), Box
     center_nodes.sort();
     let center = center_nodes[center_nodes.len() / 2];
 
-    let raw_product_options = ContractionOptions::new(ContractionMethod::Naive);
+    let raw_product_options = ContractionOptions::new(ContractionMethod::Naive)
+        .with_dense_reference_limit(FUNCTION_NPOINTS * FUNCTION_NPOINTS);
     let product_raw_tn = partial_contract(
         &cosh_treetn,
         &factor_b_treetn,


### PR DESCRIPTION
## Summary

- Clarify Quantics tutorial wording and ITensor-like guide examples.
- Add dense whole-result comparison helpers and mismatched-topology guards.
- Preserve long index tags through Rust and C APIs.
- Preserve C API last-error diagnostics across null/status/panic paths.
- Require explicit dense/reference limits for generic TreeTN Naive contraction and C API dense reference paths, with tests and tutorial updates.

## Issues

Closes #368
Closes #355
Closes #361
Closes #447
Closes #443
Closes #446
Closes #442
Closes #471
Closes #444
Closes #445

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace` (2024 passed, 12 skipped)
- `cargo test --doc --release --workspace`
- `./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`
- `git diff --check`

Merge strategy requested for this batch: non-squash merge.