### PR TITLE
Use typed C API status enum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,16 +93,17 @@ Every public type, trait, and function **must** have doc comments with the follo
 - `anyhow` for internal error handling and context
 - `thiserror` for public API error types
 
-### C API Error Handling (Known Issue)
+### C API Error Handling
 
-**IMPORTANT**: The C API (`tensor4all-capi`) currently discards all error details at the FFI boundary. See [#228](https://github.com/tensor4all/tensor4all-rs/issues/228).
+The C API (`tensor4all-capi`) preserves error details through
+`t4a_last_error_message`. See `docs/CAPI_DESIGN.md` for the detailed ABI rules.
 
-- `catch_unwind` catches panics but the panic message is lost (`result.unwrap_or(T4A_INTERNAL_ERROR)`)
-- `Err(e)` variants are discarded (`Err(_) => T4A_INTERNAL_ERROR`)
-- FFI consumers (Julia, Python) only see a generic "Internal error" with no diagnostic info
-- **~76 `catch_unwind` sites** and **~47 `Err(_)` discard sites** across the capi crate need updating
-- **Do not add new `catch_unwind` / `Err(_) => T4A_INTERNAL_ERROR` patterns** without preserving error messages
-- When #228 is resolved, use the `t4a_last_error_message` API and `run_catching` helper for all new FFI functions
+- Fallible C API functions return `enum t4a_status_code`, not a bare `int`
+  or generic `StatusCode` typedef.
+- Use `run_catching`, `unwrap_catch`, `capi_error`, and `err_status` so
+  `Err(e)` values and panic payloads reach `t4a_last_error_message`.
+- **Do not add new `catch_unwind` / `Err(_) => T4A_INTERNAL_ERROR` patterns**
+  without preserving error messages.
 
 ## Testing
 

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -198,11 +198,22 @@
 - When removing code, check whether removed tests were the sole exerciser of
   any shared helper; add replacement coverage if so.
 
-## C API Error Handling
+## C API And Language-Binding ABI
 
+- `docs/CAPI_DESIGN.md` is the detailed design guide for C API shape,
+  ownership, error handling, header generation, and binding-facing conventions.
+  Read it before changing `tensor4all-capi` exported types or functions.
+- Fallible C ABI functions must return the generated `enum t4a_status_code`
+  status enum. Do not introduce bare `int` status returns, generic
+  `StatusCode` typedefs, or function-specific status integer types.
+- Status variants keep the `T4A_` prefix, for example `T4A_SUCCESS`,
+  `T4A_NULL_POINTER`, and `T4A_INTERNAL_ERROR`.
 - Do not add new C API paths that discard error details.
 - Avoid new `catch_unwind` / `Err(_) => T4A_INTERNAL_ERROR` patterns unless
   error messages are preserved at the FFI boundary.
+- Regenerate `crates/tensor4all-capi/include/tensor4all_capi.h` with
+  `cbindgen` whenever exported C API types, enums, constants, or function
+  signatures change.
 
 ## Language Bindings
 

--- a/crates/tensor4all-capi/README.md
+++ b/crates/tensor4all-capi/README.md
@@ -10,7 +10,7 @@ minimal Julia-facing surface.
 - **TreeTN API**: General tree tensor network accessors and core operations
 - **QTT layout API**: Canonical binary QTT layout descriptors for transform materialization
 - **Generated C header**: `include/tensor4all_capi.h` for downstream bindings
-- **Error handling**: `StatusCode + out` constructors/clones plus `t4a_last_error_message`
+- **Error handling**: `enum t4a_status_code + out` constructors/clones plus `t4a_last_error_message`
 - **Panic safety**: All exported functions catch Rust panics at the FFI boundary
 
 ## API Conventions

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -14,6 +14,58 @@
 #include <stdlib.h>
 
 /**
+ * Status code returned by fallible C API functions.
+ *
+ * The explicit enum keeps the ABI type-safe for C consumers while preserving
+ * the existing numeric values used by downstream bindings.
+ *
+ * # Examples
+ *
+ * ```
+ * use tensor4all_capi::{t4a_last_error_message, t4a_status_code, T4A_NULL_POINTER};
+ *
+ * let status = t4a_last_error_message(std::ptr::null_mut(), 0, std::ptr::null_mut());
+ * assert_eq!(status, t4a_status_code::T4A_NULL_POINTER);
+ * assert_eq!(status, T4A_NULL_POINTER);
+ * ```
+ *
+ */
+typedef enum t4a_status_code {
+  /**
+   * Operation completed successfully.
+   */
+  T4A_SUCCESS = 0,
+  /**
+   * A null pointer was passed where a valid pointer was required.
+   */
+  T4A_NULL_POINTER = -1,
+  /**
+   * An invalid argument was provided.
+   */
+  T4A_INVALID_ARGUMENT = -2,
+  /**
+   * Too many tags would be added to a fixed-capacity tag set.
+   */
+  T4A_TAG_OVERFLOW = -3,
+  /**
+   * A tag string exceeds a fixed-capacity tag storage limit.
+   */
+  T4A_TAG_TOO_LONG = -4,
+  /**
+   * The provided output buffer is too small for the result.
+   */
+  T4A_BUFFER_TOO_SMALL = -5,
+  /**
+   * An internal error occurred (e.g., a panic was caught).
+   */
+  T4A_INTERNAL_ERROR = -6,
+  /**
+   * The requested API exists but is not implemented yet.
+   */
+  T4A_NOT_IMPLEMENTED = -7,
+} t4a_status_code;
+
+/**
  * Boundary-condition choices for quantics transform materialization.
  */
 typedef enum t4a_boundary_condition {
@@ -201,11 +253,9 @@ typedef enum t4a_contract_method {
   /**
    * Naive dense/reference contraction for generic TreeTN contraction.
    *
-   * This materializes full dense tensors for `t4a_treetn_contract`; that entry
-   * point requires an explicit nonzero `max_dense_elements` limit when this
-   * method is selected. `t4a_treetn_apply_operator_chain` uses a dedicated
-   * local-exact apply path for this method instead of generic full-dense
-   * TreeTN contraction.
+   * `t4a_treetn_contract` requires an explicit nonzero dense-element limit
+   * for this method. `t4a_treetn_apply_operator_chain` uses a dedicated
+   * local-exact apply path instead of generic full-dense TreeTN contraction.
    */
   T4A_CONTRACT_METHOD_NAIVE = 2,
 } t4a_contract_method;
@@ -251,11 +301,6 @@ typedef enum t4a_canonical_form {
 } t4a_canonical_form;
 
 /**
- * Status code type for C API
- */
-typedef int StatusCode;
-
-/**
  * Opaque index type for the C API.
  */
 typedef struct t4a_index {
@@ -275,13 +320,6 @@ typedef struct t4a_qtt_layout {
 typedef struct t4a_treetn {
   const void *_private;
 } t4a_treetn;
-
-/**
- * Opaque reusable TreeTN evaluator type for the C API.
- */
-typedef struct t4a_treetn_evaluator {
-  const void *_private;
-} t4a_treetn_evaluator;
 
 /**
  * Opaque tensor type for the C API.
@@ -347,71 +385,45 @@ typedef struct t4a_svd_truncation_policy {
 } t4a_svd_truncation_policy;
 
 /**
- * The provided output buffer is too small for the result.
+ * Opaque reusable TreeTN evaluator type for the C API.
  */
-#define T4A_BUFFER_TOO_SMALL -5
-
-/**
- * An internal error occurred (e.g., a panic was caught).
- */
-#define T4A_INTERNAL_ERROR -6
-
-/**
- * An invalid argument was provided.
- */
-#define T4A_INVALID_ARGUMENT -2
-
-/**
- * The requested API exists but is not implemented yet.
- */
-#define T4A_NOT_IMPLEMENTED -7
-
-/**
- * A null pointer was passed where a valid pointer was required.
- */
-#define T4A_NULL_POINTER -1
-
-/**
- * Operation completed successfully.
- */
-#define T4A_SUCCESS 0
-
-/**
- * Too many tags would be added to a fixed-capacity tag set.
- */
-#define T4A_TAG_OVERFLOW -3
-
-/**
- * A tag string exceeds a fixed-capacity tag storage limit.
- */
-#define T4A_TAG_TOO_LONG -4
+typedef struct t4a_treetn_evaluator {
+  const void *_private;
+} t4a_treetn_evaluator;
 
 /**
  * Clone an index handle.
  */
-StatusCode t4a_index_clone(const struct t4a_index *src, struct t4a_index **out);
+enum t4a_status_code t4a_index_clone(const struct t4a_index *src, struct t4a_index **out);
 
 /**
  * Get the dimension of an index.
  */
-StatusCode t4a_index_dim(const struct t4a_index *ptr, size_t *out_dim);
+enum t4a_status_code t4a_index_dim(const struct t4a_index *ptr, size_t *out_dim);
 
 /**
  * Compare two full index handles for equality.
  */
-StatusCode t4a_index_equal(const struct t4a_index *lhs,
-                           const struct t4a_index *rhs,
-                           int32_t *out_equal);
+enum t4a_status_code t4a_index_equal(const struct t4a_index *lhs,
+                                     const struct t4a_index *rhs,
+                                     int32_t *out_equal);
 
 /**
  * Query whether an index has the provided tag.
  */
-StatusCode t4a_index_has_tag(const struct t4a_index *ptr, const char *tag, int32_t *out_has_tag);
+enum t4a_status_code t4a_index_has_tag(const struct t4a_index *ptr,
+                                       const char *tag,
+                                       int32_t *out_has_tag);
 
 /**
  * Hash the full index value for process-local hash tables.
  */
-StatusCode t4a_index_hash(const struct t4a_index *ptr, uint64_t *out_hash);
+enum t4a_status_code t4a_index_hash(const struct t4a_index *ptr, uint64_t *out_hash);
+
+/**
+ * Get the explicit identity of an index.
+ */
+enum t4a_status_code t4a_index_id(const struct t4a_index *ptr, uint64_t *out_id);
 
 /**
  * Check whether an index handle is assigned.
@@ -419,44 +431,36 @@ StatusCode t4a_index_hash(const struct t4a_index *ptr, uint64_t *out_hash);
 int32_t t4a_index_is_assigned(const struct t4a_index *obj);
 
 /**
- * Get the explicit identity of an index.
- */
-StatusCode t4a_index_id(const struct t4a_index *ptr, uint64_t *out_id);
-
-/**
  * Create a new index with explicit tags and prime level.
- *
- * Tags are provided as a comma-separated UTF-8 string and are preserved
- * losslessly by the default dynamic index tag storage.
  */
-StatusCode t4a_index_new(size_t dim, const char *tags_csv, int64_t plev, struct t4a_index **out);
+enum t4a_status_code t4a_index_new(size_t dim,
+                                   const char *tags_csv,
+                                   int64_t plev,
+                                   struct t4a_index **out);
 
 /**
  * Create a new index with explicit identity, tags, and prime level.
- *
- * Tags are provided as a comma-separated UTF-8 string and are preserved
- * losslessly by the default dynamic index tag storage.
  */
-StatusCode t4a_index_new_with_id(size_t dim,
-                                 uint64_t id,
-                                 const char *tags_csv,
-                                 int64_t plev,
-                                 struct t4a_index **out);
+enum t4a_status_code t4a_index_new_with_id(size_t dim,
+                                           uint64_t id,
+                                           const char *tags_csv,
+                                           int64_t plev,
+                                           struct t4a_index **out);
 
 /**
  * Return a new index handle with prime level reset to zero.
  */
-StatusCode t4a_index_noprime(const struct t4a_index *ptr, struct t4a_index **out);
+enum t4a_status_code t4a_index_noprime(const struct t4a_index *ptr, struct t4a_index **out);
 
 /**
  * Get the prime level of an index.
  */
-StatusCode t4a_index_plev(const struct t4a_index *ptr, int64_t *out_plev);
+enum t4a_status_code t4a_index_plev(const struct t4a_index *ptr, int64_t *out_plev);
 
 /**
  * Return a new index handle with prime level incremented by one.
  */
-StatusCode t4a_index_prime(const struct t4a_index *ptr, struct t4a_index **out);
+enum t4a_status_code t4a_index_prime(const struct t4a_index *ptr, struct t4a_index **out);
 
 /**
  * Release an index handle.
@@ -466,15 +470,17 @@ void t4a_index_release(struct t4a_index *obj);
 /**
  * Return a new index handle with an explicit prime level.
  */
-StatusCode t4a_index_set_plev(const struct t4a_index *ptr, int64_t plev, struct t4a_index **out);
+enum t4a_status_code t4a_index_set_plev(const struct t4a_index *ptr,
+                                        int64_t plev,
+                                        struct t4a_index **out);
 
 /**
  * Copy tags as a comma-separated UTF-8 string.
  */
-StatusCode t4a_index_tags(const struct t4a_index *ptr,
-                          uint8_t *buf,
-                          size_t buf_len,
-                          size_t *out_len);
+enum t4a_status_code t4a_index_tags(const struct t4a_index *ptr,
+                                    uint8_t *buf,
+                                    size_t buf_len,
+                                    size_t *out_len);
 
 /**
  * Retrieve the last error message.
@@ -490,7 +496,7 @@ StatusCode t4a_index_tags(const struct t4a_index *ptr,
  * * `T4A_NULL_POINTER` - `out_len` is null.
  * * `T4A_BUFFER_TOO_SMALL` - Buffer too small; `out_len` has the required size.
  */
-StatusCode t4a_last_error_message(uint8_t *buf, size_t buf_len, size_t *out_len);
+enum t4a_status_code t4a_last_error_message(uint8_t *buf, size_t buf_len, size_t *out_len);
 
 /**
  * Materialize the forward affine operator `y = A * x + b` as a chain-shaped
@@ -514,62 +520,63 @@ StatusCode t4a_last_error_message(uint8_t *buf, size_t buf_len, size_t *out_len)
  * Returns `T4A_INVALID_ARGUMENT` if `m == 0`, `n == 0`, `layout->kind()`
  * is not `Fused`, `b_den[i] == 0`, or `a_den[i + k * m] == 0`.
  */
-StatusCode t4a_qtransform_affine_materialize(const struct t4a_qtt_layout *layout,
-                                             const int64_t *a_num,
-                                             const int64_t *a_den,
-                                             const int64_t *b_num,
-                                             const int64_t *b_den,
-                                             size_t m,
-                                             size_t n,
-                                             const enum t4a_boundary_condition *bc,
-                                             struct t4a_treetn **out);
+enum t4a_status_code t4a_qtransform_affine_materialize(const struct t4a_qtt_layout *layout,
+                                                       const int64_t *a_num,
+                                                       const int64_t *a_den,
+                                                       const int64_t *b_num,
+                                                       const int64_t *b_den,
+                                                       size_t m,
+                                                       size_t n,
+                                                       const enum t4a_boundary_condition *bc,
+                                                       struct t4a_treetn **out);
 
 /**
  * Materialize a cumulative-sum transform directly as a chain-shaped TreeTN.
  */
-StatusCode t4a_qtransform_cumsum_materialize(const struct t4a_qtt_layout *layout,
-                                             size_t target_var,
-                                             struct t4a_treetn **out);
+enum t4a_status_code t4a_qtransform_cumsum_materialize(const struct t4a_qtt_layout *layout,
+                                                       size_t target_var,
+                                                       struct t4a_treetn **out);
 
 /**
  * Materialize a flip transform directly as a chain-shaped TreeTN.
  */
-StatusCode t4a_qtransform_flip_materialize(const struct t4a_qtt_layout *layout,
-                                           size_t target_var,
-                                           enum t4a_boundary_condition bc,
-                                           struct t4a_treetn **out);
+enum t4a_status_code t4a_qtransform_flip_materialize(const struct t4a_qtt_layout *layout,
+                                                     size_t target_var,
+                                                     enum t4a_boundary_condition bc,
+                                                     struct t4a_treetn **out);
 
 /**
  * Materialize a Fourier transform directly as a chain-shaped TreeTN.
  */
-StatusCode t4a_qtransform_fourier_materialize(const struct t4a_qtt_layout *layout,
-                                              size_t target_var,
-                                              int32_t forward,
-                                              size_t maxbonddim,
-                                              double tolerance,
-                                              struct t4a_treetn **out);
+enum t4a_status_code t4a_qtransform_fourier_materialize(const struct t4a_qtt_layout *layout,
+                                                        size_t target_var,
+                                                        int32_t forward,
+                                                        size_t maxbonddim,
+                                                        double tolerance,
+                                                        struct t4a_treetn **out);
 
 /**
  * Materialize a phase-rotation transform directly as a chain-shaped TreeTN.
  */
-StatusCode t4a_qtransform_phase_rotation_materialize(const struct t4a_qtt_layout *layout,
-                                                     size_t target_var,
-                                                     double theta,
-                                                     struct t4a_treetn **out);
+enum t4a_status_code t4a_qtransform_phase_rotation_materialize(const struct t4a_qtt_layout *layout,
+                                                               size_t target_var,
+                                                               double theta,
+                                                               struct t4a_treetn **out);
 
 /**
  * Materialize a shift transform directly as a chain-shaped TreeTN.
  */
-StatusCode t4a_qtransform_shift_materialize(const struct t4a_qtt_layout *layout,
-                                            size_t target_var,
-                                            int64_t offset,
-                                            enum t4a_boundary_condition bc,
-                                            struct t4a_treetn **out);
+enum t4a_status_code t4a_qtransform_shift_materialize(const struct t4a_qtt_layout *layout,
+                                                      size_t target_var,
+                                                      int64_t offset,
+                                                      enum t4a_boundary_condition bc,
+                                                      struct t4a_treetn **out);
 
 /**
  * Clone a QTT layout handle.
  */
-StatusCode t4a_qtt_layout_clone(const struct t4a_qtt_layout *src, struct t4a_qtt_layout **out);
+enum t4a_status_code t4a_qtt_layout_clone(const struct t4a_qtt_layout *src,
+                                          struct t4a_qtt_layout **out);
 
 /**
  * Check whether a QTT layout handle is assigned.
@@ -579,10 +586,10 @@ int32_t t4a_qtt_layout_is_assigned(const struct t4a_qtt_layout *obj);
 /**
  * Create an immutable canonical QTT layout descriptor.
  */
-StatusCode t4a_qtt_layout_new(enum t4a_qtt_layout_kind kind,
-                              size_t nvariables,
-                              const size_t *variable_resolutions,
-                              struct t4a_qtt_layout **out);
+enum t4a_status_code t4a_qtt_layout_new(enum t4a_qtt_layout_kind kind,
+                                        size_t nvariables,
+                                        const size_t *variable_resolutions,
+                                        struct t4a_qtt_layout **out);
 
 /**
  * Release a QTT layout handle.
@@ -592,70 +599,70 @@ void t4a_qtt_layout_release(struct t4a_qtt_layout *obj);
 /**
  * Copy logical-axis to payload-axis class mapping.
  */
-StatusCode t4a_tensor_axis_classes(const struct t4a_tensor *ptr,
-                                   size_t *buf,
-                                   size_t buf_len,
-                                   size_t *out_len);
+enum t4a_status_code t4a_tensor_axis_classes(const struct t4a_tensor *ptr,
+                                             size_t *buf,
+                                             size_t buf_len,
+                                             size_t *out_len);
 
 /**
  * Clone a tensor handle.
  */
-StatusCode t4a_tensor_clone(const struct t4a_tensor *src, struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_clone(const struct t4a_tensor *src, struct t4a_tensor **out);
 
 /**
  * Contract two tensors by matching common indices.
  */
-StatusCode t4a_tensor_contract(const struct t4a_tensor *a,
-                               const struct t4a_tensor *b,
-                               struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_contract(const struct t4a_tensor *a,
+                                         const struct t4a_tensor *b,
+                                         struct t4a_tensor **out);
 
 /**
  * Copy dense `Complex64` data as interleaved doubles in column-major order.
  */
-StatusCode t4a_tensor_copy_dense_c64(const struct t4a_tensor *ptr,
-                                     double *buf_interleaved,
-                                     size_t n_complex,
-                                     size_t *out_len);
+enum t4a_status_code t4a_tensor_copy_dense_c64(const struct t4a_tensor *ptr,
+                                               double *buf_interleaved,
+                                               size_t n_complex,
+                                               size_t *out_len);
 
 /**
  * Copy dense `f64` data in column-major order.
  */
-StatusCode t4a_tensor_copy_dense_f64(const struct t4a_tensor *ptr,
-                                     double *buf,
-                                     size_t buf_len,
-                                     size_t *out_len);
+enum t4a_status_code t4a_tensor_copy_dense_f64(const struct t4a_tensor *ptr,
+                                               double *buf,
+                                               size_t buf_len,
+                                               size_t *out_len);
 
 /**
  * Copy compact payload `Complex64` data as interleaved doubles.
  */
-StatusCode t4a_tensor_copy_payload_c64(const struct t4a_tensor *ptr,
-                                       double *buf_interleaved,
-                                       size_t n_complex,
-                                       size_t *out_len);
+enum t4a_status_code t4a_tensor_copy_payload_c64(const struct t4a_tensor *ptr,
+                                                 double *buf_interleaved,
+                                                 size_t n_complex,
+                                                 size_t *out_len);
 
 /**
  * Copy compact payload `f64` data in payload column-major order.
  */
-StatusCode t4a_tensor_copy_payload_f64(const struct t4a_tensor *ptr,
-                                       double *buf,
-                                       size_t buf_len,
-                                       size_t *out_len);
+enum t4a_status_code t4a_tensor_copy_payload_f64(const struct t4a_tensor *ptr,
+                                                 double *buf,
+                                                 size_t buf_len,
+                                                 size_t *out_len);
 
 /**
  * Copy tensor dimensions in index order.
  */
-StatusCode t4a_tensor_dims(const struct t4a_tensor *ptr,
-                           size_t *buf,
-                           size_t buf_len,
-                           size_t *out_len);
+enum t4a_status_code t4a_tensor_dims(const struct t4a_tensor *ptr,
+                                     size_t *buf,
+                                     size_t buf_len,
+                                     size_t *out_len);
 
 /**
  * Copy cloned index handles describing the tensor axes.
  */
-StatusCode t4a_tensor_indices(const struct t4a_tensor *ptr,
-                              struct t4a_index **buf,
-                              size_t buf_len,
-                              size_t *out_len);
+enum t4a_status_code t4a_tensor_indices(const struct t4a_tensor *ptr,
+                                        struct t4a_index **buf,
+                                        size_t buf_len,
+                                        size_t *out_len);
 
 /**
  * Check whether a tensor handle is assigned.
@@ -665,94 +672,94 @@ int32_t t4a_tensor_is_assigned(const struct t4a_tensor *obj);
 /**
  * Create a dense complex tensor from interleaved column-major data.
  */
-StatusCode t4a_tensor_new_dense_c64(size_t rank,
-                                    const struct t4a_index *const *index_ptrs,
-                                    const double *data_interleaved,
-                                    size_t n_complex,
-                                    struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_new_dense_c64(size_t rank,
+                                              const struct t4a_index *const *index_ptrs,
+                                              const double *data_interleaved,
+                                              size_t n_complex,
+                                              struct t4a_tensor **out);
 
 /**
  * Create a dense real tensor from column-major data.
  */
-StatusCode t4a_tensor_new_dense_f64(size_t rank,
-                                    const struct t4a_index *const *index_ptrs,
-                                    const double *data,
-                                    size_t data_len,
-                                    struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_new_dense_f64(size_t rank,
+                                              const struct t4a_index *const *index_ptrs,
+                                              const double *data,
+                                              size_t data_len,
+                                              struct t4a_tensor **out);
 
 /**
  * Create a complex diagonal tensor from compact diagonal payload data.
  */
-StatusCode t4a_tensor_new_diag_c64(size_t rank,
-                                   const struct t4a_index *const *index_ptrs,
-                                   const double *diag_data_interleaved,
-                                   size_t n_complex,
-                                   struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_new_diag_c64(size_t rank,
+                                             const struct t4a_index *const *index_ptrs,
+                                             const double *diag_data_interleaved,
+                                             size_t n_complex,
+                                             struct t4a_tensor **out);
 
 /**
  * Create a real diagonal tensor from compact diagonal payload data.
  */
-StatusCode t4a_tensor_new_diag_f64(size_t rank,
-                                   const struct t4a_index *const *index_ptrs,
-                                   const double *diag_data,
-                                   size_t diag_len,
-                                   struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_new_diag_f64(size_t rank,
+                                             const struct t4a_index *const *index_ptrs,
+                                             const double *diag_data,
+                                             size_t diag_len,
+                                             struct t4a_tensor **out);
 
 /**
  * Create a complex tensor from explicit compact structured storage.
  */
-StatusCode t4a_tensor_new_structured_c64(size_t rank,
-                                         const struct t4a_index *const *index_ptrs,
-                                         const double *data_interleaved,
-                                         size_t n_complex,
-                                         const size_t *payload_dims,
-                                         size_t payload_rank,
-                                         const ptrdiff_t *payload_strides,
-                                         size_t payload_strides_len,
-                                         const size_t *axis_classes,
-                                         size_t axis_classes_len,
-                                         struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_new_structured_c64(size_t rank,
+                                                   const struct t4a_index *const *index_ptrs,
+                                                   const double *data_interleaved,
+                                                   size_t n_complex,
+                                                   const size_t *payload_dims,
+                                                   size_t payload_rank,
+                                                   const ptrdiff_t *payload_strides,
+                                                   size_t payload_strides_len,
+                                                   const size_t *axis_classes,
+                                                   size_t axis_classes_len,
+                                                   struct t4a_tensor **out);
 
 /**
  * Create a real tensor from explicit compact structured storage.
  */
-StatusCode t4a_tensor_new_structured_f64(size_t rank,
-                                         const struct t4a_index *const *index_ptrs,
-                                         const double *data,
-                                         size_t data_len,
-                                         const size_t *payload_dims,
-                                         size_t payload_rank,
-                                         const ptrdiff_t *payload_strides,
-                                         size_t payload_strides_len,
-                                         const size_t *axis_classes,
-                                         size_t axis_classes_len,
-                                         struct t4a_tensor **out);
+enum t4a_status_code t4a_tensor_new_structured_f64(size_t rank,
+                                                   const struct t4a_index *const *index_ptrs,
+                                                   const double *data,
+                                                   size_t data_len,
+                                                   const size_t *payload_dims,
+                                                   size_t payload_rank,
+                                                   const ptrdiff_t *payload_strides,
+                                                   size_t payload_strides_len,
+                                                   const size_t *axis_classes,
+                                                   size_t axis_classes_len,
+                                                   struct t4a_tensor **out);
 
 /**
  * Copy compact payload dimensions.
  */
-StatusCode t4a_tensor_payload_dims(const struct t4a_tensor *ptr,
-                                   size_t *buf,
-                                   size_t buf_len,
-                                   size_t *out_len);
+enum t4a_status_code t4a_tensor_payload_dims(const struct t4a_tensor *ptr,
+                                             size_t *buf,
+                                             size_t buf_len,
+                                             size_t *out_len);
 
 /**
  * Get the compact payload length in scalar elements.
  */
-StatusCode t4a_tensor_payload_len(const struct t4a_tensor *ptr, size_t *out_len);
+enum t4a_status_code t4a_tensor_payload_len(const struct t4a_tensor *ptr, size_t *out_len);
 
 /**
  * Get the rank of the compact payload tensor.
  */
-StatusCode t4a_tensor_payload_rank(const struct t4a_tensor *ptr, size_t *out_rank);
+enum t4a_status_code t4a_tensor_payload_rank(const struct t4a_tensor *ptr, size_t *out_rank);
 
 /**
  * Copy compact payload strides in scalar elements.
  */
-StatusCode t4a_tensor_payload_strides(const struct t4a_tensor *ptr,
-                                      ptrdiff_t *buf,
-                                      size_t buf_len,
-                                      size_t *out_len);
+enum t4a_status_code t4a_tensor_payload_strides(const struct t4a_tensor *ptr,
+                                                ptrdiff_t *buf,
+                                                size_t buf_len,
+                                                size_t *out_len);
 
 /**
  * Compute the QR decomposition of a tensor split by the requested left indices.
@@ -789,17 +796,17 @@ StatusCode t4a_tensor_payload_strides(const struct t4a_tensor *ptr,
  * - `T4A_INTERNAL_ERROR` if the Rust implementation panics while processing
  *   the request.
  */
-StatusCode t4a_tensor_qr(const struct t4a_tensor *tensor,
-                         const struct t4a_index *const *left_inds,
-                         size_t n_left,
-                         double rtol,
-                         struct t4a_tensor **out_q,
-                         struct t4a_tensor **out_r);
+enum t4a_status_code t4a_tensor_qr(const struct t4a_tensor *tensor,
+                                   const struct t4a_index *const *left_inds,
+                                   size_t n_left,
+                                   double rtol,
+                                   struct t4a_tensor **out_q,
+                                   struct t4a_tensor **out_r);
 
 /**
  * Get the rank of a tensor.
  */
-StatusCode t4a_tensor_rank(const struct t4a_tensor *ptr, size_t *out_rank);
+enum t4a_status_code t4a_tensor_rank(const struct t4a_tensor *ptr, size_t *out_rank);
 
 /**
  * Release a tensor handle.
@@ -809,33 +816,44 @@ void t4a_tensor_release(struct t4a_tensor *obj);
 /**
  * Get the scalar kind of a tensor.
  */
-StatusCode t4a_tensor_scalar_kind(const struct t4a_tensor *ptr, enum t4a_scalar_kind *out_kind);
+enum t4a_status_code t4a_tensor_scalar_kind(const struct t4a_tensor *ptr,
+                                            enum t4a_scalar_kind *out_kind);
+
+/**
+ * Select fixed coordinates for tensor indices and drop those axes.
+ */
+enum t4a_status_code t4a_tensor_select_indices(const struct t4a_tensor *tensor,
+                                               size_t n_select,
+                                               const struct t4a_index *const *selected_indices,
+                                               const size_t *positions,
+                                               struct t4a_tensor **out);
 
 /**
  * Get the storage layout kind of a tensor.
  */
-StatusCode t4a_tensor_storage_kind(const struct t4a_tensor *ptr, enum t4a_storage_kind *out_kind);
+enum t4a_status_code t4a_tensor_storage_kind(const struct t4a_tensor *ptr,
+                                             enum t4a_storage_kind *out_kind);
 
 /**
  * Compute the SVD of a tensor split by the requested left indices.
  */
-StatusCode t4a_tensor_svd(const struct t4a_tensor *tensor,
-                          const struct t4a_index *const *left_inds,
-                          size_t n_left,
-                          const struct t4a_svd_truncation_policy *policy,
-                          size_t maxdim,
-                          struct t4a_tensor **out_u,
-                          struct t4a_tensor **out_s,
-                          struct t4a_tensor **out_v);
+enum t4a_status_code t4a_tensor_svd(const struct t4a_tensor *tensor,
+                                    const struct t4a_index *const *left_inds,
+                                    size_t n_left,
+                                    const struct t4a_svd_truncation_policy *policy,
+                                    size_t maxdim,
+                                    struct t4a_tensor **out_u,
+                                    struct t4a_tensor **out_s,
+                                    struct t4a_tensor **out_v);
 
 /**
  * Add two tree tensor networks, optionally truncating the result.
  */
-StatusCode t4a_treetn_add(const struct t4a_treetn *a,
-                          const struct t4a_treetn *b,
-                          const struct t4a_svd_truncation_policy *policy,
-                          size_t maxdim,
-                          struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_add(const struct t4a_treetn *a,
+                                    const struct t4a_treetn *b,
+                                    const struct t4a_svd_truncation_policy *policy,
+                                    size_t maxdim,
+                                    struct t4a_treetn **out);
 
 /**
  * Apply a chain-compatible operator TreeTN to a chain state TreeTN.
@@ -852,32 +870,32 @@ StatusCode t4a_treetn_add(const struct t4a_treetn *a,
  * `t4a_contract_method::Naive` uses the dedicated local-exact apply path here,
  * not the generic full-dense TreeTN contraction used by `t4a_treetn_contract`.
  */
-StatusCode t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
-                                           const struct t4a_treetn *state,
-                                           const size_t *mapped_positions,
-                                           size_t n_mapped_positions,
-                                           const struct t4a_index *const *internal_input_indices,
-                                           const struct t4a_index *const *internal_output_indices,
-                                           const struct t4a_index *const *true_output_indices,
-                                           enum t4a_contract_method method,
-                                           const struct t4a_svd_truncation_policy *policy,
-                                           size_t maxdim,
-                                           size_t nfullsweeps,
-                                           double convergence_tol,
-                                           struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_apply_operator_chain(const struct t4a_treetn *operator_,
+                                                     const struct t4a_treetn *state,
+                                                     const size_t *mapped_positions,
+                                                     size_t n_mapped_positions,
+                                                     const struct t4a_index *const *internal_input_indices,
+                                                     const struct t4a_index *const *internal_output_indices,
+                                                     const struct t4a_index *const *true_output_indices,
+                                                     enum t4a_contract_method method,
+                                                     const struct t4a_svd_truncation_policy *policy,
+                                                     size_t maxdim,
+                                                     size_t nfullsweeps,
+                                                     double convergence_tol,
+                                                     struct t4a_treetn **out);
 
 /**
  * Get the canonical region vertices, sorted ascending.
  */
-StatusCode t4a_treetn_canonical_region(const struct t4a_treetn *treetn,
-                                       size_t *buf,
-                                       size_t buf_len,
-                                       size_t *out_len);
+enum t4a_status_code t4a_treetn_canonical_region(const struct t4a_treetn *treetn,
+                                                 size_t *buf,
+                                                 size_t buf_len,
+                                                 size_t *out_len);
 
 /**
  * Clone a TreeTN handle.
  */
-StatusCode t4a_treetn_clone(const struct t4a_treetn *src, struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_clone(const struct t4a_treetn *src, struct t4a_treetn **out);
 
 /**
  * Contract two tree tensor networks with the requested method.
@@ -890,43 +908,43 @@ StatusCode t4a_treetn_clone(const struct t4a_treetn *src, struct t4a_treetn **ou
  * For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
  * default", which currently resolves to one variational sweep.
  */
-StatusCode t4a_treetn_contract(const struct t4a_treetn *a,
-                               const struct t4a_treetn *b,
-                               enum t4a_contract_method method,
-                               const struct t4a_svd_truncation_policy *policy,
-                               size_t maxdim,
-                               size_t nfullsweeps,
-                               double convergence_tol,
-                               enum t4a_factorize_alg factorize_alg,
-                               double qr_rtol,
-                               size_t max_dense_elements,
-                               struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_contract(const struct t4a_treetn *a,
+                                         const struct t4a_treetn *b,
+                                         enum t4a_contract_method method,
+                                         const struct t4a_svd_truncation_policy *policy,
+                                         size_t maxdim,
+                                         size_t nfullsweeps,
+                                         double convergence_tol,
+                                         enum t4a_factorize_alg factorize_alg,
+                                         double qr_rtol,
+                                         size_t max_dense_elements,
+                                         struct t4a_treetn **out);
 
 /**
  * Evaluate a TreeTN at one or more points using explicit index handles.
  */
-StatusCode t4a_treetn_evaluate(const struct t4a_treetn *treetn,
-                               const struct t4a_index *const *indices,
-                               size_t n_indices,
-                               const size_t *values_col_major,
-                               size_t n_points,
-                               double *out_re,
-                               double *out_im);
-
-/**
- * Clone a reusable TreeTN evaluator handle.
- */
-StatusCode t4a_treetn_evaluator_clone(const struct t4a_treetn_evaluator *src,
-                                      struct t4a_treetn_evaluator **out);
-
-/**
- * Evaluate one or more points using a reusable TreeTN evaluator.
- */
-StatusCode t4a_treetn_evaluator_evaluate(const struct t4a_treetn_evaluator *evaluator,
+enum t4a_status_code t4a_treetn_evaluate(const struct t4a_treetn *treetn,
+                                         const struct t4a_index *const *indices,
+                                         size_t n_indices,
                                          const size_t *values_col_major,
                                          size_t n_points,
                                          double *out_re,
                                          double *out_im);
+
+/**
+ * Clone a reusable TreeTN evaluator handle.
+ */
+enum t4a_status_code t4a_treetn_evaluator_clone(const struct t4a_treetn_evaluator *src,
+                                                struct t4a_treetn_evaluator **out);
+
+/**
+ * Evaluate one or more points using a reusable TreeTN evaluator.
+ */
+enum t4a_status_code t4a_treetn_evaluator_evaluate(const struct t4a_treetn_evaluator *evaluator,
+                                                   const size_t *values_col_major,
+                                                   size_t n_points,
+                                                   double *out_re,
+                                                   double *out_im);
 
 /**
  * Check whether a reusable TreeTN evaluator handle is assigned.
@@ -934,12 +952,12 @@ StatusCode t4a_treetn_evaluator_evaluate(const struct t4a_treetn_evaluator *eval
 int32_t t4a_treetn_evaluator_is_assigned(const struct t4a_treetn_evaluator *obj);
 
 /**
- * Create a reusable TreeTN evaluator for explicit index handles.
+ * Create a reusable TreeTN evaluator from explicit index handles.
  */
-StatusCode t4a_treetn_evaluator_new(const struct t4a_treetn *treetn,
-                                    const struct t4a_index *const *indices,
-                                    size_t n_indices,
-                                    struct t4a_treetn_evaluator **out);
+enum t4a_status_code t4a_treetn_evaluator_new(const struct t4a_treetn *treetn,
+                                              const struct t4a_index *const *indices,
+                                              size_t n_indices,
+                                              struct t4a_treetn_evaluator **out);
 
 /**
  * Release a reusable TreeTN evaluator handle.
@@ -949,23 +967,23 @@ void t4a_treetn_evaluator_release(struct t4a_treetn_evaluator *obj);
 /**
  * Fuse connected current-node groups into the requested target topology.
  */
-StatusCode t4a_treetn_fuse_to(const struct t4a_treetn *treetn,
-                              const size_t *target_vertices,
-                              size_t n_target_vertices,
-                              const struct t4a_index *const *target_siteinds,
-                              const size_t *target_siteinds_len,
-                              const size_t *target_edge_sources,
-                              const size_t *target_edge_targets,
-                              size_t n_target_edges,
-                              struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_fuse_to(const struct t4a_treetn *treetn,
+                                        const size_t *target_vertices,
+                                        size_t n_target_vertices,
+                                        const struct t4a_index *const *target_siteinds,
+                                        const size_t *target_siteinds_len,
+                                        const size_t *target_edge_sources,
+                                        const size_t *target_edge_targets,
+                                        size_t n_target_edges,
+                                        struct t4a_treetn **out);
 
 /**
  * Compute the inner product of two tree tensor networks.
  */
-StatusCode t4a_treetn_inner(const struct t4a_treetn *a,
-                            const struct t4a_treetn *b,
-                            double *out_re,
-                            double *out_im);
+enum t4a_status_code t4a_treetn_inner(const struct t4a_treetn *a,
+                                      const struct t4a_treetn *b,
+                                      double *out_re,
+                                      double *out_im);
 
 /**
  * Check whether a TreeTN handle is assigned.
@@ -975,10 +993,10 @@ int32_t t4a_treetn_is_assigned(const struct t4a_treetn *obj);
 /**
  * Get the bond index on the edge between two vertices.
  */
-StatusCode t4a_treetn_linkind(const struct t4a_treetn *treetn,
-                              size_t v1,
-                              size_t v2,
-                              struct t4a_index **out);
+enum t4a_status_code t4a_treetn_linkind(const struct t4a_treetn *treetn,
+                                        size_t v1,
+                                        size_t v2,
+                                        struct t4a_index **out);
 
 /**
  * Solve `(a0 + a1 * operator) * x = rhs` for `x` as a TreeTN.
@@ -996,52 +1014,52 @@ StatusCode t4a_treetn_linkind(const struct t4a_treetn *treetn,
  * operator's internal indices to those true indices, but they do not yet
  * support solving between distinct `init` and `rhs` true index spaces.
  */
-StatusCode t4a_treetn_linsolve(const struct t4a_treetn *operator_,
-                               const struct t4a_treetn *rhs,
-                               const struct t4a_treetn *init,
-                               size_t center_vertex,
-                               const size_t *mapped_vertices,
-                               size_t n_mapped_vertices,
-                               const struct t4a_index *const *true_input_indices,
-                               const struct t4a_index *const *internal_input_indices,
-                               const struct t4a_index *const *true_output_indices,
-                               const struct t4a_index *const *internal_output_indices,
-                               const struct t4a_svd_truncation_policy *policy,
-                               size_t maxdim,
-                               size_t nfullsweeps,
-                               double krylov_tol,
-                               size_t krylov_maxiter,
-                               size_t krylov_dim,
-                               double a0,
-                               double a1,
-                               double convergence_tol,
-                               struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_linsolve(const struct t4a_treetn *operator_,
+                                         const struct t4a_treetn *rhs,
+                                         const struct t4a_treetn *init,
+                                         size_t center_vertex,
+                                         const size_t *mapped_vertices,
+                                         size_t n_mapped_vertices,
+                                         const struct t4a_index *const *true_input_indices,
+                                         const struct t4a_index *const *internal_input_indices,
+                                         const struct t4a_index *const *true_output_indices,
+                                         const struct t4a_index *const *internal_output_indices,
+                                         const struct t4a_svd_truncation_policy *policy,
+                                         size_t maxdim,
+                                         size_t nfullsweeps,
+                                         double krylov_tol,
+                                         size_t krylov_maxiter,
+                                         size_t krylov_dim,
+                                         double a0,
+                                         double a1,
+                                         double convergence_tol,
+                                         struct t4a_treetn **out);
 
 /**
  * Get the neighbors of a vertex.
  */
-StatusCode t4a_treetn_neighbors(const struct t4a_treetn *treetn,
-                                size_t vertex,
-                                size_t *buf,
-                                size_t buf_len,
-                                size_t *out_len);
+enum t4a_status_code t4a_treetn_neighbors(const struct t4a_treetn *treetn,
+                                          size_t vertex,
+                                          size_t *buf,
+                                          size_t buf_len,
+                                          size_t *out_len);
 
 /**
  * Create a tree tensor network from an array of tensors.
  */
-StatusCode t4a_treetn_new(const struct t4a_tensor *const *tensors,
-                          size_t n_tensors,
-                          struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_new(const struct t4a_tensor *const *tensors,
+                                    size_t n_tensors,
+                                    struct t4a_treetn **out);
 
 /**
  * Compute the norm of the tree tensor network.
  */
-StatusCode t4a_treetn_norm(struct t4a_treetn *treetn, double *out_norm);
+enum t4a_status_code t4a_treetn_norm(struct t4a_treetn *treetn, double *out_norm);
 
 /**
  * Get the number of vertices in the tree tensor network.
  */
-StatusCode t4a_treetn_num_vertices(const struct t4a_treetn *treetn, size_t *out_n);
+enum t4a_status_code t4a_treetn_num_vertices(const struct t4a_treetn *treetn, size_t *out_n);
 
 /**
  * Orthogonalize the tree tensor network to a vertex using the requested form.
@@ -1051,10 +1069,47 @@ StatusCode t4a_treetn_num_vertices(const struct t4a_treetn *treetn, size_t *out_
  * - If the network is already canonicalized with a different form, the call returns
  *   `T4A_INVALID_ARGUMENT`. Pass a nonzero `force` to re-canonicalize with a different form.
  */
-StatusCode t4a_treetn_orthogonalize(struct t4a_treetn *treetn,
-                                    size_t vertex,
-                                    enum t4a_canonical_form form,
-                                    int force);
+enum t4a_status_code t4a_treetn_orthogonalize(struct t4a_treetn *treetn,
+                                              size_t vertex,
+                                              enum t4a_canonical_form form,
+                                              int force);
+
+/**
+ * Partially contract two tree tensor networks using explicit site-index pairs.
+ *
+ * `contract_*` pairs are summed over and removed from the result.
+ * `diagonal_*` pairs are linked by diagonal/copy structure while preserving
+ * the left-hand index as an external result leg. `output_order`, when nonempty,
+ * lists the surviving external indices in the requested result order.
+ *
+ * `t4a_contract_method::Naive` and mismatched-topology fallback paths are
+ * dense/reference operations. Pass a nonzero `max_dense_elements` to opt into
+ * those paths for small reference cases; each dense input and output tensor
+ * must fit under that limit.
+ *
+ * For `t4a_contract_method::Fit`, `nfullsweeps == 0` means "use the backend
+ * default", which currently resolves to one variational sweep.
+ */
+enum t4a_status_code t4a_treetn_partial_contract(const struct t4a_treetn *a,
+                                                 const struct t4a_treetn *b,
+                                                 size_t n_contract_pairs,
+                                                 const struct t4a_index *const *contract_left,
+                                                 const struct t4a_index *const *contract_right,
+                                                 size_t n_diagonal_pairs,
+                                                 const struct t4a_index *const *diagonal_left,
+                                                 const struct t4a_index *const *diagonal_right,
+                                                 size_t n_output_order,
+                                                 const struct t4a_index *const *output_order,
+                                                 size_t center,
+                                                 enum t4a_contract_method method,
+                                                 const struct t4a_svd_truncation_policy *policy,
+                                                 size_t maxdim,
+                                                 size_t nfullsweeps,
+                                                 double convergence_tol,
+                                                 enum t4a_factorize_alg factorize_alg,
+                                                 double qr_rtol,
+                                                 size_t max_dense_elements,
+                                                 struct t4a_treetn **out);
 
 /**
  * Release a TreeTN handle.
@@ -1064,91 +1119,91 @@ void t4a_treetn_release(struct t4a_treetn *obj);
 /**
  * Restructure a TreeTN using split, swap, and optional final truncation phases.
  */
-StatusCode t4a_treetn_restructure_to(const struct t4a_treetn *treetn,
-                                     const size_t *target_vertices,
-                                     size_t n_target_vertices,
-                                     const struct t4a_index *const *target_siteinds,
-                                     const size_t *target_siteinds_len,
-                                     const size_t *target_edge_sources,
-                                     const size_t *target_edge_targets,
-                                     size_t n_target_edges,
-                                     const struct t4a_svd_truncation_policy *split_policy,
-                                     size_t split_maxdim,
-                                     int split_final_sweep,
-                                     size_t swap_maxdim,
-                                     double swap_rtol,
-                                     const struct t4a_svd_truncation_policy *final_policy,
-                                     size_t final_maxdim,
-                                     struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_restructure_to(const struct t4a_treetn *treetn,
+                                               const size_t *target_vertices,
+                                               size_t n_target_vertices,
+                                               const struct t4a_index *const *target_siteinds,
+                                               const size_t *target_siteinds_len,
+                                               const size_t *target_edge_sources,
+                                               const size_t *target_edge_targets,
+                                               size_t n_target_edges,
+                                               const struct t4a_svd_truncation_policy *split_policy,
+                                               size_t split_maxdim,
+                                               int split_final_sweep,
+                                               size_t swap_maxdim,
+                                               double swap_rtol,
+                                               const struct t4a_svd_truncation_policy *final_policy,
+                                               size_t final_maxdim,
+                                               struct t4a_treetn **out);
 
 /**
  * Scale a tree tensor network by a complex scalar.
  */
-StatusCode t4a_treetn_scale(const struct t4a_treetn *treetn,
-                            double re,
-                            double im,
-                            struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_scale(const struct t4a_treetn *treetn,
+                                      double re,
+                                      double im,
+                                      struct t4a_treetn **out);
 
 /**
  * Replace the tensor at a specific vertex.
  */
-StatusCode t4a_treetn_set_tensor(struct t4a_treetn *treetn,
-                                 size_t vertex,
-                                 const struct t4a_tensor *tensor);
+enum t4a_status_code t4a_treetn_set_tensor(struct t4a_treetn *treetn,
+                                           size_t vertex,
+                                           const struct t4a_tensor *tensor);
 
 /**
  * Get the site indices attached to a vertex.
  */
-StatusCode t4a_treetn_siteinds(const struct t4a_treetn *treetn,
-                               size_t vertex,
-                               struct t4a_index **buf,
-                               size_t buf_len,
-                               size_t *out_len);
+enum t4a_status_code t4a_treetn_siteinds(const struct t4a_treetn *treetn,
+                                         size_t vertex,
+                                         struct t4a_index **buf,
+                                         size_t buf_len,
+                                         size_t *out_len);
 
 /**
  * Split current nodes to match the requested target topology.
  */
-StatusCode t4a_treetn_split_to(const struct t4a_treetn *treetn,
-                               const size_t *target_vertices,
-                               size_t n_target_vertices,
-                               const struct t4a_index *const *target_siteinds,
-                               const size_t *target_siteinds_len,
-                               const size_t *target_edge_sources,
-                               const size_t *target_edge_targets,
-                               size_t n_target_edges,
-                               const struct t4a_svd_truncation_policy *policy,
-                               size_t maxdim,
-                               int final_sweep,
-                               struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_split_to(const struct t4a_treetn *treetn,
+                                         const size_t *target_vertices,
+                                         size_t n_target_vertices,
+                                         const struct t4a_index *const *target_siteinds,
+                                         const size_t *target_siteinds_len,
+                                         const size_t *target_edge_sources,
+                                         const size_t *target_edge_targets,
+                                         size_t n_target_edges,
+                                         const struct t4a_svd_truncation_policy *policy,
+                                         size_t maxdim,
+                                         int final_sweep,
+                                         struct t4a_treetn **out);
 
 /**
  * Reassign site indices to target vertices using scheduled swap transport.
  */
-StatusCode t4a_treetn_swap_site_indices(const struct t4a_treetn *treetn,
-                                        const struct t4a_index *const *assignment_siteinds,
-                                        const size_t *assignment_target_vertices,
-                                        size_t n_assignments,
-                                        size_t maxdim,
-                                        double rtol,
-                                        struct t4a_treetn **out);
+enum t4a_status_code t4a_treetn_swap_site_indices(const struct t4a_treetn *treetn,
+                                                  const struct t4a_index *const *assignment_siteinds,
+                                                  const size_t *assignment_target_vertices,
+                                                  size_t n_assignments,
+                                                  size_t maxdim,
+                                                  double rtol,
+                                                  struct t4a_treetn **out);
 
 /**
  * Get the tensor at a specific vertex.
  */
-StatusCode t4a_treetn_tensor(const struct t4a_treetn *treetn,
-                             size_t vertex,
-                             struct t4a_tensor **out);
+enum t4a_status_code t4a_treetn_tensor(const struct t4a_treetn *treetn,
+                                       size_t vertex,
+                                       struct t4a_tensor **out);
 
 /**
  * Contract all bonds and materialize the TreeTN as a dense tensor.
  */
-StatusCode t4a_treetn_to_dense(const struct t4a_treetn *treetn, struct t4a_tensor **out);
+enum t4a_status_code t4a_treetn_to_dense(const struct t4a_treetn *treetn, struct t4a_tensor **out);
 
 /**
  * Truncate the tree tensor network bond dimensions using SVD-based truncation.
  */
-StatusCode t4a_treetn_truncate(struct t4a_treetn *treetn,
-                               const struct t4a_svd_truncation_policy *policy,
-                               size_t maxdim);
+enum t4a_status_code t4a_treetn_truncate(struct t4a_treetn *treetn,
+                                         const struct t4a_svd_truncation_policy *policy,
+                                         size_t maxdim);
 
 #endif  /* TENSOR4ALL_CAPI_H */

--- a/crates/tensor4all-capi/src/index.rs
+++ b/crates/tensor4all-capi/src/index.rs
@@ -8,7 +8,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use crate::types::{t4a_index, InternalIndex};
 use crate::{
     capi_error, clone_opaque, err_buffer_too_small, err_null_pointer, is_assigned_opaque,
-    panic_message, release_opaque, run_catching, set_last_error, CapiResult, StatusCode,
+    panic_message, release_opaque, run_catching, set_last_error, t4a_status_code, CapiResult,
     T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use tensor4all_core::index::{DynId, Index, TagSet};
@@ -22,7 +22,10 @@ pub extern "C" fn t4a_index_release(obj: *mut t4a_index) {
 
 /// Clone an index handle.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_clone(src: *const t4a_index, out: *mut *mut t4a_index) -> StatusCode {
+pub extern "C" fn t4a_index_clone(
+    src: *const t4a_index,
+    out: *mut *mut t4a_index,
+) -> t4a_status_code {
     clone_opaque(src, out)
 }
 
@@ -32,7 +35,9 @@ pub extern "C" fn t4a_index_is_assigned(obj: *const t4a_index) -> i32 {
     is_assigned_opaque(obj)
 }
 
-fn read_optional_tags_csv(tags_csv: *const c_char) -> Result<Option<String>, (StatusCode, String)> {
+fn read_optional_tags_csv(
+    tags_csv: *const c_char,
+) -> Result<Option<String>, (t4a_status_code, String)> {
     if tags_csv.is_null() {
         return Ok(None);
     }
@@ -48,7 +53,7 @@ fn build_index(
     dim: usize,
     tags_csv: *const c_char,
     plev: i64,
-) -> Result<InternalIndex, (StatusCode, String)> {
+) -> Result<InternalIndex, (t4a_status_code, String)> {
     if dim == 0 {
         return Err(capi_error(
             T4A_INVALID_ARGUMENT,
@@ -78,7 +83,7 @@ fn build_index_with_id(
     id: u64,
     tags_csv: *const c_char,
     plev: i64,
-) -> Result<InternalIndex, (StatusCode, String)> {
+) -> Result<InternalIndex, (t4a_status_code, String)> {
     if dim == 0 {
         return Err(capi_error(
             T4A_INVALID_ARGUMENT,
@@ -112,7 +117,7 @@ fn require_index<'a>(ptr: *const t4a_index, what: &str) -> CapiResult<&'a Intern
     Ok(unsafe { &*ptr }.inner())
 }
 
-fn run_value<T: Copy, F>(out: *mut T, f: F) -> StatusCode
+fn run_value<T: Copy, F>(out: *mut T, f: F) -> t4a_status_code
 where
     F: FnOnce() -> CapiResult<T>,
 {
@@ -144,7 +149,7 @@ pub extern "C" fn t4a_index_new(
     tags_csv: *const c_char,
     plev: i64,
     out: *mut *mut t4a_index,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         Ok(t4a_index::new(build_index(dim, tags_csv, plev)?))
     })
@@ -158,7 +163,7 @@ pub extern "C" fn t4a_index_new_with_id(
     tags_csv: *const c_char,
     plev: i64,
     out: *mut *mut t4a_index,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         Ok(t4a_index::new(build_index_with_id(
             dim, id, tags_csv, plev,
@@ -168,7 +173,7 @@ pub extern "C" fn t4a_index_new_with_id(
 
 /// Get the dimension of an index.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> StatusCode {
+pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("index");
     }
@@ -186,7 +191,7 @@ pub extern "C" fn t4a_index_dim(ptr: *const t4a_index, out_dim: *mut usize) -> S
 
 /// Get the explicit identity of an index.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_id(ptr: *const t4a_index, out_id: *mut u64) -> StatusCode {
+pub extern "C" fn t4a_index_id(ptr: *const t4a_index, out_id: *mut u64) -> t4a_status_code {
     run_value(out_id, || {
         let index = require_index(ptr, "index")?;
         Ok(index.id().value())
@@ -199,7 +204,7 @@ pub extern "C" fn t4a_index_equal(
     lhs: *const t4a_index,
     rhs: *const t4a_index,
     out_equal: *mut i32,
-) -> StatusCode {
+) -> t4a_status_code {
     run_value(out_equal, || {
         let lhs = require_index(lhs, "lhs")?;
         let rhs = require_index(rhs, "rhs")?;
@@ -209,7 +214,7 @@ pub extern "C" fn t4a_index_equal(
 
 /// Hash the full index value for process-local hash tables.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_hash(ptr: *const t4a_index, out_hash: *mut u64) -> StatusCode {
+pub extern "C" fn t4a_index_hash(ptr: *const t4a_index, out_hash: *mut u64) -> t4a_status_code {
     run_value(out_hash, || {
         let index = require_index(ptr, "index")?;
         let mut hasher = DefaultHasher::new();
@@ -220,7 +225,7 @@ pub extern "C" fn t4a_index_hash(ptr: *const t4a_index, out_hash: *mut u64) -> S
 
 /// Get the prime level of an index.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_plev(ptr: *const t4a_index, out_plev: *mut i64) -> StatusCode {
+pub extern "C" fn t4a_index_plev(ptr: *const t4a_index, out_plev: *mut i64) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("index");
     }
@@ -238,7 +243,10 @@ pub extern "C" fn t4a_index_plev(ptr: *const t4a_index, out_plev: *mut i64) -> S
 
 /// Return a new index handle with prime level incremented by one.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_prime(ptr: *const t4a_index, out: *mut *mut t4a_index) -> StatusCode {
+pub extern "C" fn t4a_index_prime(
+    ptr: *const t4a_index,
+    out: *mut *mut t4a_index,
+) -> t4a_status_code {
     run_catching(out, || {
         let index = require_index(ptr, "index")?;
         Ok(t4a_index::new(index.prime()))
@@ -247,7 +255,10 @@ pub extern "C" fn t4a_index_prime(ptr: *const t4a_index, out: *mut *mut t4a_inde
 
 /// Return a new index handle with prime level reset to zero.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_index_noprime(ptr: *const t4a_index, out: *mut *mut t4a_index) -> StatusCode {
+pub extern "C" fn t4a_index_noprime(
+    ptr: *const t4a_index,
+    out: *mut *mut t4a_index,
+) -> t4a_status_code {
     run_catching(out, || {
         let index = require_index(ptr, "index")?;
         Ok(t4a_index::new(index.noprime()))
@@ -260,7 +271,7 @@ pub extern "C" fn t4a_index_set_plev(
     ptr: *const t4a_index,
     plev: i64,
     out: *mut *mut t4a_index,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         if plev < 0 {
             return Err(capi_error(
@@ -280,7 +291,7 @@ pub extern "C" fn t4a_index_tags(
     buf: *mut u8,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("index");
     }
@@ -320,7 +331,7 @@ pub extern "C" fn t4a_index_has_tag(
     ptr: *const t4a_index,
     tag: *const c_char,
     out_has_tag: *mut i32,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("index");
     }
@@ -341,7 +352,7 @@ pub extern "C" fn t4a_index_has_tag(
         } else {
             0
         };
-        Ok::<StatusCode, StatusCode>(T4A_SUCCESS)
+        Ok::<t4a_status_code, t4a_status_code>(T4A_SUCCESS)
     }));
 
     match result {

--- a/crates/tensor4all-capi/src/lib.rs
+++ b/crates/tensor4all-capi/src/lib.rs
@@ -28,28 +28,51 @@ pub use tensor::*;
 pub use treetn::*;
 pub use types::*;
 
-/// Status code type for C API
-pub type StatusCode = libc::c_int;
+/// Status code returned by fallible C API functions.
+///
+/// The explicit enum keeps the ABI type-safe for C consumers while preserving
+/// the existing numeric values used by downstream bindings.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_capi::{t4a_last_error_message, t4a_status_code, T4A_NULL_POINTER};
+///
+/// let status = t4a_last_error_message(std::ptr::null_mut(), 0, std::ptr::null_mut());
+/// assert_eq!(status, t4a_status_code::T4A_NULL_POINTER);
+/// assert_eq!(status, T4A_NULL_POINTER);
+/// ```
+///
+/// cbindgen:prefix-with-name=false
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum t4a_status_code {
+    /// Operation completed successfully.
+    T4A_SUCCESS = 0,
+    /// A null pointer was passed where a valid pointer was required.
+    T4A_NULL_POINTER = -1,
+    /// An invalid argument was provided.
+    T4A_INVALID_ARGUMENT = -2,
+    /// Too many tags would be added to a fixed-capacity tag set.
+    T4A_TAG_OVERFLOW = -3,
+    /// A tag string exceeds a fixed-capacity tag storage limit.
+    T4A_TAG_TOO_LONG = -4,
+    /// The provided output buffer is too small for the result.
+    T4A_BUFFER_TOO_SMALL = -5,
+    /// An internal error occurred (e.g., a panic was caught).
+    T4A_INTERNAL_ERROR = -6,
+    /// The requested API exists but is not implemented yet.
+    T4A_NOT_IMPLEMENTED = -7,
+}
 
-/// Operation completed successfully.
-pub const T4A_SUCCESS: StatusCode = 0;
-/// A null pointer was passed where a valid pointer was required.
-pub const T4A_NULL_POINTER: StatusCode = -1;
-/// An invalid argument was provided.
-pub const T4A_INVALID_ARGUMENT: StatusCode = -2;
-/// Too many tags would be added to a fixed-capacity tag set.
-pub const T4A_TAG_OVERFLOW: StatusCode = -3;
-/// A tag string exceeds a fixed-capacity tag storage limit.
-pub const T4A_TAG_TOO_LONG: StatusCode = -4;
-/// The provided output buffer is too small for the result.
-pub const T4A_BUFFER_TOO_SMALL: StatusCode = -5;
-/// An internal error occurred (e.g., a panic was caught).
-pub const T4A_INTERNAL_ERROR: StatusCode = -6;
-/// The requested API exists but is not implemented yet.
-pub const T4A_NOT_IMPLEMENTED: StatusCode = -7;
+pub use t4a_status_code::{
+    T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NOT_IMPLEMENTED,
+    T4A_NULL_POINTER, T4A_SUCCESS, T4A_TAG_OVERFLOW, T4A_TAG_TOO_LONG,
+};
 
 /// Internal result type carrying both a status code and an error message.
-pub(crate) type CapiResult<T> = Result<T, (StatusCode, String)>;
+pub(crate) type CapiResult<T> = Result<T, (t4a_status_code, String)>;
 
 // ============================================================================
 // Thread-local error message storage
@@ -79,13 +102,13 @@ pub(crate) fn set_last_error(msg: &str) {
 }
 
 /// Store an error and return a status code.
-pub(crate) fn err_status<E: std::fmt::Display>(err: E, code: StatusCode) -> StatusCode {
+pub(crate) fn err_status<E: std::fmt::Display>(err: E, code: t4a_status_code) -> t4a_status_code {
     set_last_error(&err.to_string());
     code
 }
 
 /// Store a null-pointer diagnostic and return `T4A_NULL_POINTER`.
-pub(crate) fn err_null_pointer<E: std::fmt::Display>(what: E) -> StatusCode {
+pub(crate) fn err_null_pointer<E: std::fmt::Display>(what: E) -> t4a_status_code {
     err_status(format!("{what} is null"), T4A_NULL_POINTER)
 }
 
@@ -94,7 +117,7 @@ pub(crate) fn err_buffer_too_small(
     what: &str,
     required_len: usize,
     actual_len: usize,
-) -> StatusCode {
+) -> t4a_status_code {
     err_status(
         format!("{what} buffer too small: required {required_len}, got {actual_len}"),
         T4A_BUFFER_TOO_SMALL,
@@ -109,12 +132,15 @@ pub(crate) fn err_null<T, E: std::fmt::Display>(err: E) -> *mut T {
 }
 
 /// Pair a status code with an error message for `run_catching`.
-pub(crate) fn capi_error<E: std::fmt::Display>(code: StatusCode, err: E) -> (StatusCode, String) {
+pub(crate) fn capi_error<E: std::fmt::Display>(
+    code: t4a_status_code,
+    err: E,
+) -> (t4a_status_code, String) {
     (code, err.to_string())
 }
 
 /// Run a constructor-like closure and write the resulting handle to `out`.
-pub(crate) fn run_catching<T, F>(out: *mut *mut T, f: F) -> StatusCode
+pub(crate) fn run_catching<T, F>(out: *mut *mut T, f: F) -> t4a_status_code
 where
     F: FnOnce() -> CapiResult<T>,
 {
@@ -140,7 +166,7 @@ where
 }
 
 /// Clone an opaque wrapper through the constructor-style `out` pattern.
-pub(crate) fn clone_opaque<T: Clone>(src: *const T, out: *mut *mut T) -> StatusCode {
+pub(crate) fn clone_opaque<T: Clone>(src: *const T, out: *mut *mut T) -> t4a_status_code {
     if src.is_null() {
         return err_null_pointer("source handle");
     }
@@ -179,7 +205,7 @@ pub(crate) fn is_assigned_opaque<T>(obj: *const T) -> i32 {
 }
 
 /// Unwrap a `catch_unwind` result, storing any panic message.
-pub(crate) fn unwrap_catch(result: std::thread::Result<StatusCode>) -> StatusCode {
+pub(crate) fn unwrap_catch(result: std::thread::Result<t4a_status_code>) -> t4a_status_code {
     match result {
         Ok(code) => code,
         Err(panic) => {
@@ -230,7 +256,7 @@ pub extern "C" fn t4a_last_error_message(
     buf: *mut u8,
     buf_len: libc::size_t,
     out_len: *mut libc::size_t,
-) -> StatusCode {
+) -> t4a_status_code {
     if out_len.is_null() {
         return err_null_pointer("out_len");
     }

--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -6,7 +6,7 @@ use crate::types::{
 };
 use crate::{
     capi_error, clone_opaque, err_null_pointer, is_assigned_opaque, release_opaque, run_catching,
-    CapiResult, StatusCode, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER,
+    t4a_status_code, CapiResult, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER,
 };
 use num_complex::Complex64;
 use num_rational::Rational64;
@@ -27,7 +27,7 @@ pub extern "C" fn t4a_qtt_layout_release(obj: *mut t4a_qtt_layout) {
 pub extern "C" fn t4a_qtt_layout_clone(
     src: *const t4a_qtt_layout,
     out: *mut *mut t4a_qtt_layout,
-) -> StatusCode {
+) -> t4a_status_code {
     clone_opaque(src, out)
 }
 
@@ -141,7 +141,7 @@ impl SourceSite {
 
 fn require_layout_or_status<'a>(
     layout: *const t4a_qtt_layout,
-) -> std::result::Result<&'a InternalQttLayout, StatusCode> {
+) -> std::result::Result<&'a InternalQttLayout, t4a_status_code> {
     if layout.is_null() {
         return Err(err_null_pointer("layout"));
     }
@@ -517,7 +517,7 @@ pub extern "C" fn t4a_qtt_layout_new(
     nvariables: usize,
     variable_resolutions: *const usize,
     out: *mut *mut t4a_qtt_layout,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         if nvariables == 0 {
             return Err(capi_error(
@@ -544,7 +544,7 @@ pub extern "C" fn t4a_qtransform_shift_materialize(
     offset: i64,
     bc: t4a_boundary_condition,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
@@ -569,7 +569,7 @@ pub extern "C" fn t4a_qtransform_flip_materialize(
     target_var: usize,
     bc: t4a_boundary_condition,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
@@ -594,7 +594,7 @@ pub extern "C" fn t4a_qtransform_phase_rotation_materialize(
     target_var: usize,
     theta: f64,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
@@ -618,7 +618,7 @@ pub extern "C" fn t4a_qtransform_cumsum_materialize(
     layout: *const t4a_qtt_layout,
     target_var: usize,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
@@ -644,7 +644,7 @@ pub extern "C" fn t4a_qtransform_fourier_materialize(
     maxbonddim: usize,
     tolerance: f64,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {
@@ -704,7 +704,7 @@ pub extern "C" fn t4a_qtransform_affine_materialize(
     n: usize,
     bc: *const t4a_boundary_condition,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let layout_ref = require_layout_or_return!(layout);
 
     run_catching(out, || {

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -13,7 +13,7 @@ use crate::types::{
 };
 use crate::{
     capi_error, clone_opaque, err_buffer_too_small, err_null_pointer, is_assigned_opaque,
-    panic_message, release_opaque, run_catching, set_last_error, CapiResult, StatusCode,
+    panic_message, release_opaque, run_catching, set_last_error, t4a_status_code, CapiResult,
     T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 
@@ -28,7 +28,7 @@ pub extern "C" fn t4a_tensor_release(obj: *mut t4a_tensor) {
 pub extern "C" fn t4a_tensor_clone(
     src: *const t4a_tensor,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     clone_opaque(src, out)
 }
 
@@ -40,7 +40,7 @@ pub extern "C" fn t4a_tensor_select_indices(
     selected_indices: *const *const t4a_index,
     positions: *const usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(tensor)?;
         if out.is_null() {
@@ -72,7 +72,7 @@ pub extern "C" fn t4a_tensor_is_assigned(obj: *const t4a_tensor) -> i32 {
 fn read_indices_from_ptrs(
     rank: usize,
     index_ptrs: *const *const t4a_index,
-) -> Result<Vec<InternalIndex>, (StatusCode, String)> {
+) -> Result<Vec<InternalIndex>, (t4a_status_code, String)> {
     if rank == 0 {
         return Ok(Vec::new());
     }
@@ -102,7 +102,7 @@ fn read_plain_slice<T: Copy>(
     name: &str,
     ptr: *const T,
     len: usize,
-) -> Result<Vec<T>, (StatusCode, String)> {
+) -> Result<Vec<T>, (t4a_status_code, String)> {
     if len == 0 {
         return Ok(Vec::new());
     }
@@ -116,7 +116,7 @@ fn read_c64_slice(
     name: &str,
     ptr: *const f64,
     n_complex: usize,
-) -> Result<Vec<Complex64>, (StatusCode, String)> {
+) -> Result<Vec<Complex64>, (t4a_status_code, String)> {
     if n_complex == 0 {
         return Ok(Vec::new());
     }
@@ -209,7 +209,7 @@ fn copy_c64_interleaved(
     Ok(())
 }
 
-fn run_status<F>(f: F) -> StatusCode
+fn run_status<F>(f: F) -> t4a_status_code
 where
     F: FnOnce() -> CapiResult<()>,
 {
@@ -227,7 +227,7 @@ where
     }
 }
 
-fn require_tensor<'a>(ptr: *const t4a_tensor) -> Result<&'a t4a_tensor, (StatusCode, String)> {
+fn require_tensor<'a>(ptr: *const t4a_tensor) -> Result<&'a t4a_tensor, (t4a_status_code, String)> {
     if ptr.is_null() {
         return Err(capi_error(T4A_NULL_POINTER, "tensor is null"));
     }
@@ -257,7 +257,7 @@ fn box_tensor_handle(tensor: InternalTensor) -> *mut t4a_tensor {
 
 /// Get the rank of a tensor.
 #[unsafe(no_mangle)]
-pub extern "C" fn t4a_tensor_rank(ptr: *const t4a_tensor, out_rank: *mut usize) -> StatusCode {
+pub extern "C" fn t4a_tensor_rank(ptr: *const t4a_tensor, out_rank: *mut usize) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("tensor");
     }
@@ -280,7 +280,7 @@ pub extern "C" fn t4a_tensor_dims(
     buf: *mut usize,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("tensor");
     }
@@ -313,7 +313,7 @@ pub extern "C" fn t4a_tensor_indices(
     buf: *mut *mut t4a_index,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("tensor");
     }
@@ -346,7 +346,7 @@ pub extern "C" fn t4a_tensor_indices(
 pub extern "C" fn t4a_tensor_scalar_kind(
     ptr: *const t4a_tensor,
     out_kind: *mut t4a_scalar_kind,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("tensor");
     }
@@ -367,7 +367,7 @@ pub extern "C" fn t4a_tensor_scalar_kind(
 pub extern "C" fn t4a_tensor_storage_kind(
     ptr: *const t4a_tensor,
     out_kind: *mut t4a_storage_kind,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         if out_kind.is_null() {
@@ -385,7 +385,7 @@ pub extern "C" fn t4a_tensor_storage_kind(
 pub extern "C" fn t4a_tensor_payload_rank(
     ptr: *const t4a_tensor,
     out_rank: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         if out_rank.is_null() {
@@ -403,7 +403,7 @@ pub extern "C" fn t4a_tensor_payload_rank(
 pub extern "C" fn t4a_tensor_payload_len(
     ptr: *const t4a_tensor,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         if out_len.is_null() {
@@ -423,7 +423,7 @@ pub extern "C" fn t4a_tensor_payload_dims(
     buf: *mut usize,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         let storage = tensor.inner().storage();
@@ -444,7 +444,7 @@ pub extern "C" fn t4a_tensor_payload_strides(
     buf: *mut isize,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         let storage = tensor.inner().storage();
@@ -465,7 +465,7 @@ pub extern "C" fn t4a_tensor_axis_classes(
     buf: *mut usize,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         let storage = tensor.inner().storage();
@@ -486,7 +486,7 @@ pub extern "C" fn t4a_tensor_copy_dense_f64(
     buf: *mut f64,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("tensor");
     }
@@ -522,7 +522,7 @@ pub extern "C" fn t4a_tensor_copy_dense_c64(
     buf_interleaved: *mut f64,
     n_complex: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     if ptr.is_null() {
         return err_null_pointer("tensor");
     }
@@ -561,7 +561,7 @@ pub extern "C" fn t4a_tensor_copy_payload_f64(
     buf: *mut f64,
     buf_len: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         let data = tensor
@@ -580,7 +580,7 @@ pub extern "C" fn t4a_tensor_copy_payload_c64(
     buf_interleaved: *mut f64,
     n_complex: usize,
     out_len: *mut usize,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(ptr)?;
         let data = tensor
@@ -598,7 +598,7 @@ pub extern "C" fn t4a_tensor_contract(
     a: *const t4a_tensor,
     b: *const t4a_tensor,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     if a.is_null() {
         return err_null_pointer("a");
     }
@@ -622,7 +622,7 @@ pub extern "C" fn t4a_tensor_svd(
     out_u: *mut *mut t4a_tensor,
     out_s: *mut *mut t4a_tensor,
     out_v: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(tensor)?;
         if out_u.is_null() || out_s.is_null() || out_v.is_null() {
@@ -690,7 +690,7 @@ pub extern "C" fn t4a_tensor_qr(
     rtol: f64,
     out_q: *mut *mut t4a_tensor,
     out_r: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tensor = require_tensor(tensor)?;
         if out_q.is_null() || out_r.is_null() {
@@ -721,7 +721,7 @@ pub extern "C" fn t4a_tensor_new_dense_f64(
     data: *const f64,
     data_len: usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let indices = read_indices_from_ptrs(rank, index_ptrs)?;
         let expected_len: usize = dims_from_indices(&indices).iter().product();
@@ -750,7 +750,7 @@ pub extern "C" fn t4a_tensor_new_dense_c64(
     data_interleaved: *const f64,
     n_complex: usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let indices = read_indices_from_ptrs(rank, index_ptrs)?;
         let expected_len: usize = dims_from_indices(&indices).iter().product();
@@ -788,7 +788,7 @@ pub extern "C" fn t4a_tensor_new_structured_f64(
     axis_classes: *const usize,
     axis_classes_len: usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let indices = read_indices_from_ptrs(rank, index_ptrs)?;
         let values = read_plain_slice("data", data, data_len)?;
@@ -818,7 +818,7 @@ pub extern "C" fn t4a_tensor_new_structured_c64(
     axis_classes: *const usize,
     axis_classes_len: usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let indices = read_indices_from_ptrs(rank, index_ptrs)?;
         let values = read_c64_slice("data_interleaved", data_interleaved, n_complex)?;
@@ -842,7 +842,7 @@ pub extern "C" fn t4a_tensor_new_diag_f64(
     diag_data: *const f64,
     diag_len: usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let indices = read_indices_from_ptrs(rank, index_ptrs)?;
         let values = read_plain_slice("diag_data", diag_data, diag_len)?;
@@ -860,7 +860,7 @@ pub extern "C" fn t4a_tensor_new_diag_c64(
     diag_data_interleaved: *const f64,
     n_complex: usize,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let indices = read_indices_from_ptrs(rank, index_ptrs)?;
         let values = read_c64_slice("diag_data_interleaved", diag_data_interleaved, n_complex)?;

--- a/crates/tensor4all-capi/src/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tests/mod.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+#[test]
+fn test_generated_header_uses_named_status_enum() {
+    let header = include_str!("../../include/tensor4all_capi.h");
+
+    assert!(header.contains("typedef enum t4a_status_code {"));
+    assert!(header.contains("} t4a_status_code;"));
+    assert!(header.contains("enum t4a_status_code t4a_last_error_message("));
+    assert!(!header.contains("typedef int StatusCode;"));
+    assert!(!header.contains("StatusCode"));
+}
+
 /// Helper: read the last error message as a Rust String.
 fn read_last_error() -> String {
     let mut out_len: libc::size_t = 0;
@@ -90,13 +101,14 @@ fn test_clone_opaque_null_src_stores_message() {
 
 #[test]
 fn test_unwrap_catch_ok() {
-    let result: std::thread::Result<StatusCode> = Ok(T4A_SUCCESS);
+    let result: std::thread::Result<t4a_status_code> = Ok(T4A_SUCCESS);
     assert_eq!(unwrap_catch(result), T4A_SUCCESS);
 }
 
 #[test]
 fn test_unwrap_catch_panic() {
-    let result: std::thread::Result<StatusCode> = std::panic::catch_unwind(|| panic!("test panic"));
+    let result: std::thread::Result<t4a_status_code> =
+        std::panic::catch_unwind(|| panic!("test panic"));
     assert_eq!(unwrap_catch(result), T4A_INTERNAL_ERROR);
     assert_eq!(read_last_error(), "test panic");
 }

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -7,7 +7,7 @@ use crate::types::{
 };
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
-    set_last_error, CapiResult, StatusCode, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
+    set_last_error, t4a_status_code, CapiResult, T4A_BUFFER_TOO_SMALL, T4A_INTERNAL_ERROR,
     T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS,
 };
 use num_complex::Complex64;
@@ -32,7 +32,7 @@ pub extern "C" fn t4a_treetn_release(obj: *mut t4a_treetn) {
 pub extern "C" fn t4a_treetn_clone(
     src: *const t4a_treetn,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     clone_opaque(src, out)
 }
 
@@ -53,7 +53,7 @@ pub extern "C" fn t4a_treetn_evaluator_release(obj: *mut t4a_treetn_evaluator) {
 pub extern "C" fn t4a_treetn_evaluator_clone(
     src: *const t4a_treetn_evaluator,
     out: *mut *mut t4a_treetn_evaluator,
-) -> StatusCode {
+) -> t4a_status_code {
     clone_opaque(src, out)
 }
 
@@ -105,7 +105,7 @@ fn orthogonalize_error_message(force: libc::c_int, err: impl std::fmt::Display) 
     msg
 }
 
-fn run_status<F>(f: F) -> StatusCode
+fn run_status<F>(f: F) -> t4a_status_code
 where
     F: FnOnce() -> CapiResult<()>,
 {
@@ -835,7 +835,7 @@ pub extern "C" fn t4a_treetn_new(
     tensors: *const *const t4a_tensor,
     n_tensors: libc::size_t,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         if n_tensors == 0 {
             return Err(capi_error(
@@ -871,7 +871,7 @@ pub extern "C" fn t4a_treetn_new(
 pub extern "C" fn t4a_treetn_num_vertices(
     treetn: *const t4a_treetn,
     out_n: *mut libc::size_t,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree(treetn)?;
         if out_n.is_null() {
@@ -888,7 +888,7 @@ pub extern "C" fn t4a_treetn_tensor(
     treetn: *const t4a_treetn,
     vertex: libc::size_t,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     let tn = match require_tree(treetn) {
         Ok(tn) => tn,
         Err((code, msg)) => {
@@ -920,7 +920,7 @@ pub extern "C" fn t4a_treetn_set_tensor(
     treetn: *mut t4a_treetn,
     vertex: libc::size_t,
     tensor: *const t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
         if tensor.is_null() {
@@ -947,7 +947,7 @@ pub extern "C" fn t4a_treetn_neighbors(
     buf: *mut libc::size_t,
     buf_len: libc::size_t,
     out_len: *mut libc::size_t,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree(treetn)?;
         require_node(tn.inner(), vertex)?;
@@ -963,7 +963,7 @@ pub extern "C" fn t4a_treetn_canonical_region(
     buf: *mut libc::size_t,
     buf_len: libc::size_t,
     out_len: *mut libc::size_t,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree(treetn)?;
         let mut vertices: Vec<_> = tn.inner().canonical_region().iter().cloned().collect();
@@ -980,7 +980,7 @@ pub extern "C" fn t4a_treetn_siteinds(
     buf: *mut *mut t4a_index,
     buf_len: libc::size_t,
     out_len: *mut libc::size_t,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree(treetn)?;
         let node_idx = tn.inner().node_index(&vertex).ok_or_else(|| {
@@ -1041,7 +1041,7 @@ pub extern "C" fn t4a_treetn_linkind(
     v1: libc::size_t,
     v2: libc::size_t,
     out: *mut *mut t4a_index,
-) -> StatusCode {
+) -> t4a_status_code {
     let tn = match require_tree(treetn) {
         Ok(tn) => tn,
         Err((code, msg)) => {
@@ -1079,7 +1079,7 @@ pub extern "C" fn t4a_treetn_orthogonalize(
     vertex: libc::size_t,
     form: t4a_canonical_form,
     force: libc::c_int,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
         require_node(tn.inner(), vertex)?;
@@ -1107,7 +1107,7 @@ pub extern "C" fn t4a_treetn_truncate(
     treetn: *mut t4a_treetn,
     policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
 
@@ -1142,7 +1142,7 @@ pub extern "C" fn t4a_treetn_fuse_to(
     target_edge_targets: *const libc::size_t,
     n_target_edges: libc::size_t,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn = require_tree(treetn)?;
         let target = build_target_network(
@@ -1178,7 +1178,7 @@ pub extern "C" fn t4a_treetn_split_to(
     maxdim: libc::size_t,
     final_sweep: libc::c_int,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn = require_tree(treetn)?;
         let target = build_target_network(
@@ -1210,7 +1210,7 @@ pub extern "C" fn t4a_treetn_swap_site_indices(
     maxdim: libc::size_t,
     rtol: libc::c_double,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn = require_tree(treetn)?;
         let target_assignment = collect_target_assignment(
@@ -1247,7 +1247,7 @@ pub extern "C" fn t4a_treetn_restructure_to(
     final_policy: *const t4a_svd_truncation_policy,
     final_maxdim: libc::size_t,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn = require_tree(treetn)?;
         let target = build_target_network(
@@ -1285,7 +1285,7 @@ pub extern "C" fn t4a_treetn_evaluator_new(
     indices: *const *const t4a_index,
     n_indices: libc::size_t,
     out: *mut *mut t4a_treetn_evaluator,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn = require_tree(treetn)?;
         if n_indices == 0 {
@@ -1311,7 +1311,7 @@ pub extern "C" fn t4a_treetn_evaluator_evaluate(
     n_points: libc::size_t,
     out_re: *mut libc::c_double,
     out_im: *mut libc::c_double,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let evaluator = require_evaluator(evaluator)?;
         if n_points == 0 {
@@ -1352,7 +1352,7 @@ pub extern "C" fn t4a_treetn_evaluate(
     n_points: libc::size_t,
     out_re: *mut libc::c_double,
     out_im: *mut libc::c_double,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree(treetn)?;
         if n_indices == 0 {
@@ -1399,7 +1399,7 @@ pub extern "C" fn t4a_treetn_inner(
     b: *const t4a_treetn,
     out_re: *mut libc::c_double,
     out_im: *mut libc::c_double,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn_a = require_tree(a)?;
         let tn_b = require_tree(b)?;
@@ -1424,7 +1424,7 @@ pub extern "C" fn t4a_treetn_inner(
 pub extern "C" fn t4a_treetn_norm(
     treetn: *mut t4a_treetn,
     out_norm: *mut libc::c_double,
-) -> StatusCode {
+) -> t4a_status_code {
     run_status(|| {
         let tn = require_tree_mut(treetn)?;
         if out_norm.is_null() {
@@ -1447,7 +1447,7 @@ pub extern "C" fn t4a_treetn_scale(
     re: libc::c_double,
     im: libc::c_double,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn = require_tree(treetn)?;
         let mut result = tn.inner().clone();
@@ -1471,7 +1471,7 @@ pub extern "C" fn t4a_treetn_add(
     policy: *const t4a_svd_truncation_policy,
     maxdim: libc::size_t,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn_a = require_tree(a)?;
         let tn_b = require_tree(b)?;
@@ -1524,7 +1524,7 @@ pub extern "C" fn t4a_treetn_contract(
     qr_rtol: libc::c_double,
     max_dense_elements: libc::size_t,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let tn_a = match require_tree(a) {
         Ok(tn) => tn,
         Err((code, msg)) => {
@@ -1642,7 +1642,7 @@ pub extern "C" fn t4a_treetn_partial_contract(
     qr_rtol: libc::c_double,
     max_dense_elements: libc::size_t,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     run_catching(out, || {
         let tn_a = require_tree(a)?;
         let tn_b = require_tree(b)?;
@@ -1762,7 +1762,7 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
     nfullsweeps: libc::size_t,
     convergence_tol: libc::c_double,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let op = match require_tree(operator) {
         Ok(tn) => tn,
         Err((code, msg)) => {
@@ -1866,7 +1866,7 @@ pub extern "C" fn t4a_treetn_linsolve(
     a1: libc::c_double,
     convergence_tol: libc::c_double,
     out: *mut *mut t4a_treetn,
-) -> StatusCode {
+) -> t4a_status_code {
     let operator = match require_tree(operator) {
         Ok(tn) => tn,
         Err((code, msg)) => {
@@ -1974,7 +1974,7 @@ pub extern "C" fn t4a_treetn_linsolve(
 pub extern "C" fn t4a_treetn_to_dense(
     treetn: *const t4a_treetn,
     out: *mut *mut t4a_tensor,
-) -> StatusCode {
+) -> t4a_status_code {
     let tn = match require_tree(treetn) {
         Ok(tn) => tn,
         Err((code, msg)) => {

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -1186,6 +1186,49 @@ fn test_treetn_evaluator_reuses_index_order_for_multiple_batches() {
 }
 
 #[test]
+fn test_treetn_evaluator_clone_remains_usable_after_original_release() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let s0 = indices[0];
+    let s1 = indices[3];
+    let index_ptrs = [s0 as *const t4a_index, s1 as *const t4a_index];
+    let mut evaluator = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_evaluator_new(tt, index_ptrs.as_ptr(), 2, &mut evaluator),
+        T4A_SUCCESS
+    );
+    assert_eq!(t4a_treetn_evaluator_is_assigned(evaluator), 1);
+    assert_eq!(t4a_treetn_evaluator_is_assigned(std::ptr::null()), 0);
+
+    let mut clone = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_evaluator_clone(evaluator, &mut clone),
+        T4A_SUCCESS
+    );
+    assert!(!clone.is_null());
+    t4a_treetn_evaluator_release(evaluator);
+
+    let values = [
+        0usize, 0usize, // point 0
+        1usize, 1usize, // point 1
+    ];
+    let mut out = [0.0; 2];
+    assert_eq!(
+        t4a_treetn_evaluator_evaluate(
+            clone,
+            values.as_ptr(),
+            2,
+            out.as_mut_ptr(),
+            std::ptr::null_mut()
+        ),
+        T4A_SUCCESS
+    );
+    assert_eq!(out, [1.0, 4.0]);
+
+    t4a_treetn_evaluator_release(clone);
+    cleanup(tt, tensors, indices);
+}
+
+#[test]
 fn test_treetn_evaluator_new_rejects_incomplete_index_list() {
     let (tt, tensors, indices) = make_two_site_treetn();
     let s0 = indices[0];

--- a/docs/CAPI_DESIGN.md
+++ b/docs/CAPI_DESIGN.md
@@ -54,7 +54,10 @@ Prefer explicit `t4a_<type>_release`, `t4a_<type>_clone`, and
 
 ### Error Handling
 
-Functions that can fail return `StatusCode`:
+Functions that can fail return the generated `enum t4a_status_code` status
+enum. The public header defines it as `typedef enum t4a_status_code { ... }
+t4a_status_code;` so C consumers get a named status type rather than a bare
+`int`:
 
 - `T4A_SUCCESS`
 - `T4A_NULL_POINTER`
@@ -64,6 +67,11 @@ Functions that can fail return `StatusCode`:
 - `T4A_BUFFER_TOO_SMALL`
 - `T4A_INTERNAL_ERROR`
 - `T4A_NOT_IMPLEMENTED`
+
+Do not add new `int` status returns, generic `StatusCode` typedefs, or
+function-specific status integer types. Keep new status variants in the shared
+`t4a_status_code` enum unless there is a binding-level reason to introduce a
+new typed result channel.
 
 Error details are stored in thread-local storage and must be preserved across
 the FFI boundary. Do not discard `Err(e)` or panic payloads. New entry points
@@ -176,8 +184,9 @@ the error message returned to bindings.
 
 - Functions use the `t4a_` prefix
 - Status codes use the `T4A_` prefix
-- Opaque types and enums use `snake_case`
-- Constructor-style functions write to an `out` pointer and return `StatusCode`
+- Opaque types and enums use `snake_case`, including `t4a_status_code`
+- Constructor-style functions write to an `out` pointer and return
+  `enum t4a_status_code`
 
 Prefer type-generic names inside Rust. Scalar-specialized names are acceptable
 at the FFI boundary when the ABI needs concrete layouts.
@@ -205,7 +214,7 @@ signatures change.
 | `treetn.rs` | `t4a_treetn_*` | Tree tensor network inspection and core ops |
 | `quanticstransform.rs` | `t4a_qtt_layout_*`, `t4a_qtransform_*` | Canonical QTT layouts and transform materialization |
 | `types.rs` | exported enums and opaque handles | ABI-facing type definitions |
-| `lib.rs` | `t4a_last_error_message`, status codes | shared error/panic handling |
+| `lib.rs` | `t4a_status_code`, `t4a_last_error_message` | shared error/panic handling |
 
 ## Binding Notes
 

--- a/docs/book/src/julia-bindings.md
+++ b/docs/book/src/julia-bindings.md
@@ -21,9 +21,9 @@ exposes the pieces needed to build a Julia-native surface on top:
 - **Indices** — immutable index handles with IDs, tags, and prime levels
 - **Dense tensors** — `Float64` / complex tensor construction, export, and contraction
 - **Tree tensor networks** — topology queries, orthogonalization, truncation, evaluation, and dense export
-- **Canonical QTT layouts** — grouped, interleaved, and fused binary layouts
-- **Quantics transform materialization** — shift, flip, phase rotation, cumsum, Fourier, binary-op, and affine operators materialized directly as `TreeTN`
-- **Error reporting** — `StatusCode` plus `t4a_last_error_message`
+- **Canonical QTT layouts** — interleaved and fused binary layouts
+- **Quantics transform materialization** — shift, flip, phase rotation, cumsum, Fourier, and affine operators materialized directly as `TreeTN`
+- **Error reporting** — `enum t4a_status_code` plus `t4a_last_error_message`
 
 This split is deliberate: the Rust side owns performance-critical kernels and
 the Julia side owns higher-level ergonomics.


### PR DESCRIPTION
## Summary
- Replace the generated C API `StatusCode` alias with a named `t4a_status_code` enum.
- Update C API docs, repository rules, and binding notes to point status/error handling guidance at `docs/CAPI_DESIGN.md`.
- Add a header regression test so cbindgen output keeps returning the named status enum.

Closes #462

Note: #428 was already closed after confirming the removed C API symbols are gone and the Julia-side cleanup has merged.

## Verification
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tensor4all-capi --release`
- `cargo nextest run --release --workspace`
- `cargo test --doc --release --workspace`
- `cargo doc --workspace --no-deps`
- `./scripts/test-mdbook.sh`
- `cargo run -p api-dump --release -- . -o docs/api`