### PR TITLE
[codex] Expose retained C API contraction and typed TreeTN evaluation

### DIFF
--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -617,6 +617,24 @@ enum t4a_status_code t4a_tensor_contract(const struct t4a_tensor *a,
                                          struct t4a_tensor **out);
 
 /**
+ * Contract multiple tensors while retaining selected shared indices as output legs.
+ */
+enum t4a_status_code t4a_tensor_contract_multi(const struct t4a_tensor *const *tensors,
+                                               size_t n_tensors,
+                                               const struct t4a_index *const *retain_indices,
+                                               size_t n_retain,
+                                               struct t4a_tensor **out);
+
+/**
+ * Contract two tensors while retaining selected shared indices as output legs.
+ */
+enum t4a_status_code t4a_tensor_contract_retain(const struct t4a_tensor *a,
+                                                const struct t4a_tensor *b,
+                                                const struct t4a_index *const *retain_indices,
+                                                size_t n_retain,
+                                                struct t4a_tensor **out);
+
+/**
  * Copy dense `Complex64` data as interleaved doubles in column-major order.
  */
 enum t4a_status_code t4a_tensor_copy_dense_c64(const struct t4a_tensor *ptr,

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -4,7 +4,10 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use num_complex::Complex64;
-use tensor4all_core::{qr_with, svd_with, QrOptions, SvdOptions, SvdTruncationPolicy};
+use tensor4all_core::{
+    contract_multi_with_options, qr_with, svd_with, AllowedPairs, ContractionOptions, QrOptions,
+    SvdOptions, SvdTruncationPolicy,
+};
 use tensor4all_tensorbackend::Storage;
 
 use crate::types::{
@@ -232,6 +235,31 @@ fn require_tensor<'a>(ptr: *const t4a_tensor) -> Result<&'a t4a_tensor, (t4a_sta
         return Err(capi_error(T4A_NULL_POINTER, "tensor is null"));
     }
     Ok(unsafe { &*ptr })
+}
+
+fn read_tensor_refs<'a>(
+    tensors: *const *const t4a_tensor,
+    n_tensors: usize,
+) -> Result<Vec<&'a InternalTensor>, (t4a_status_code, String)> {
+    if n_tensors == 0 {
+        return Ok(Vec::new());
+    }
+    if tensors.is_null() {
+        return Err(capi_error(T4A_NULL_POINTER, "tensors is null"));
+    }
+
+    let mut refs = Vec::with_capacity(n_tensors);
+    for i in 0..n_tensors {
+        let tensor = unsafe { *tensors.add(i) };
+        if tensor.is_null() {
+            return Err(capi_error(
+                T4A_NULL_POINTER,
+                format!("tensors[{i}] is null"),
+            ));
+        }
+        refs.push(unsafe { (&*tensor).inner() });
+    }
+    Ok(refs)
 }
 
 fn build_svd_options(policy: *const t4a_svd_truncation_policy, maxdim: usize) -> SvdOptions {
@@ -608,6 +636,49 @@ pub extern "C" fn t4a_tensor_contract(
 
     run_catching(out, || unsafe {
         Ok(t4a_tensor::new((*a).inner().contract((*b).inner())))
+    })
+}
+
+/// Contract two tensors while retaining selected shared indices as output legs.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_contract_retain(
+    a: *const t4a_tensor,
+    b: *const t4a_tensor,
+    retain_indices: *const *const t4a_index,
+    n_retain: usize,
+    out: *mut *mut t4a_tensor,
+) -> t4a_status_code {
+    run_catching(out, || {
+        let a = require_tensor(a)?;
+        let b = require_tensor(b)?;
+        let retain_indices = read_indices_from_ptrs(n_retain, retain_indices)?;
+        let options =
+            ContractionOptions::new(AllowedPairs::All).with_retain_indices(&retain_indices);
+        let result = a
+            .inner()
+            .contract_with_options(b.inner(), options)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_tensor::new(result))
+    })
+}
+
+/// Contract multiple tensors while retaining selected shared indices as output legs.
+#[unsafe(no_mangle)]
+pub extern "C" fn t4a_tensor_contract_multi(
+    tensors: *const *const t4a_tensor,
+    n_tensors: usize,
+    retain_indices: *const *const t4a_index,
+    n_retain: usize,
+    out: *mut *mut t4a_tensor,
+) -> t4a_status_code {
+    run_catching(out, || {
+        let tensors = read_tensor_refs(tensors, n_tensors)?;
+        let retain_indices = read_indices_from_ptrs(n_retain, retain_indices)?;
+        let options =
+            ContractionOptions::new(AllowedPairs::All).with_retain_indices(&retain_indices);
+        let result = contract_multi_with_options(&tensors, options)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_tensor::new(result))
     })
 }
 

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -799,6 +799,98 @@ fn test_tensor_contract_matches_matrix_multiplication() {
 }
 
 #[test]
+fn test_tensor_contract_retain_preserves_shared_index() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(2);
+
+    let mut j_clone = std::ptr::null_mut();
+    assert_eq!(crate::index::t4a_index_clone(j, &mut j_clone), T4A_SUCCESS);
+
+    let a = new_tensor_f64(&[i, j], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = new_tensor_f64(
+        &[j_clone as *const t4a_index, k],
+        &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+    );
+
+    let retain = [j as *const t4a_index];
+    let mut c = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_contract_retain(a, b, retain.as_ptr(), retain.len(), &mut c),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*c).inner().dims() }, vec![2, 3, 2]);
+    assert_eq!(
+        read_dense_f64(c),
+        vec![7.0, 14.0, 24.0, 32.0, 45.0, 54.0, 10.0, 20.0, 33.0, 44.0, 60.0, 72.0]
+    );
+
+    t4a_tensor_release(c);
+    t4a_tensor_release(b);
+    t4a_tensor_release(a);
+    t4a_index_release(j_clone);
+    t4a_index_release(k);
+    t4a_index_release(j);
+    t4a_index_release(i);
+}
+
+#[test]
+fn test_tensor_contract_multi_retain_preserves_batch_index() {
+    let i = new_index(2);
+    let j = new_index(3);
+    let k = new_index(2);
+    let l = new_index(2);
+
+    let mut j_clone = std::ptr::null_mut();
+    assert_eq!(crate::index::t4a_index_clone(j, &mut j_clone), T4A_SUCCESS);
+    let mut k_clone = std::ptr::null_mut();
+    assert_eq!(crate::index::t4a_index_clone(k, &mut k_clone), T4A_SUCCESS);
+
+    let a = new_tensor_f64(&[i, j], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let b = new_tensor_f64(
+        &[j_clone as *const t4a_index, k],
+        &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
+    );
+    let c = new_tensor_f64(&[k_clone as *const t4a_index, l], &[2.0, 3.0, 4.0, 5.0]);
+
+    let tensors = [
+        a as *const t4a_tensor,
+        b as *const t4a_tensor,
+        c as *const t4a_tensor,
+    ];
+    let retain = [j as *const t4a_index];
+    let mut out = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_contract_multi(
+            tensors.as_ptr(),
+            tensors.len(),
+            retain.as_ptr(),
+            retain.len(),
+            &mut out
+        ),
+        T4A_SUCCESS
+    );
+
+    assert_eq!(unsafe { (*out).inner().dims() }, vec![2, 3, 2]);
+    assert_eq!(
+        read_dense_f64(out),
+        vec![44.0, 88.0, 147.0, 196.0, 270.0, 324.0, 78.0, 156.0, 261.0, 348.0, 480.0, 576.0,]
+    );
+
+    t4a_tensor_release(out);
+    t4a_tensor_release(c);
+    t4a_tensor_release(b);
+    t4a_tensor_release(a);
+    t4a_index_release(k_clone);
+    t4a_index_release(j_clone);
+    t4a_index_release(l);
+    t4a_index_release(k);
+    t4a_index_release(j);
+    t4a_index_release(i);
+}
+
+#[test]
 fn test_tensor_svd_rank2() {
     let i = new_index(3);
     let j = new_index(4);

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -1,9 +1,9 @@
 //! C API for the reduced TreeTN surface.
 
 use crate::types::{
-    t4a_canonical_form, t4a_contract_method, t4a_factorize_alg, t4a_index,
+    t4a_canonical_form, t4a_contract_method, t4a_factorize_alg, t4a_index, t4a_scalar_kind,
     t4a_svd_truncation_policy, t4a_tensor, t4a_treetn, t4a_treetn_evaluator, InternalIndex,
-    InternalTreeTN,
+    InternalTreeTN, InternalTreeTNEvaluatorHandle,
 };
 use crate::{
     capi_error, clone_opaque, is_assigned_opaque, panic_message, release_opaque, run_catching,
@@ -255,6 +255,7 @@ fn collect_edge_endpoints(
 
 fn write_evaluation_results(
     results: &[AnyScalar],
+    scalar_kind: t4a_scalar_kind,
     out_re: *mut libc::c_double,
     out_im: *mut libc::c_double,
 ) -> CapiResult<()> {
@@ -262,22 +263,44 @@ fn write_evaluation_results(
         return Err(capi_error(T4A_NULL_POINTER, "out_re is null"));
     }
 
-    for (i, scalar) in results.iter().enumerate() {
-        let z: Complex64 = scalar.clone().into();
-        unsafe { *out_re.add(i) = z.re };
-        if z.im != 0.0 {
+    match scalar_kind {
+        t4a_scalar_kind::F64 => {
+            for (i, scalar) in results.iter().enumerate() {
+                unsafe { *out_re.add(i) = scalar.real() };
+                if !out_im.is_null() {
+                    unsafe { *out_im.add(i) = 0.0 };
+                }
+            }
+        }
+        t4a_scalar_kind::C64 => {
             if out_im.is_null() {
                 return Err(capi_error(
                     T4A_NULL_POINTER,
                     "out_im is required for complex-valued evaluation results",
                 ));
             }
-            unsafe { *out_im.add(i) = z.im };
-        } else if !out_im.is_null() {
-            unsafe { *out_im.add(i) = 0.0 };
+            for (i, scalar) in results.iter().enumerate() {
+                let z: Complex64 = scalar.clone().into();
+                unsafe {
+                    *out_re.add(i) = z.re;
+                    *out_im.add(i) = z.im;
+                }
+            }
         }
     }
     Ok(())
+}
+
+fn treetn_scalar_kind(tn: &InternalTreeTN) -> t4a_scalar_kind {
+    if tn
+        .node_indices()
+        .into_iter()
+        .any(|node| tn.tensor(node).is_some_and(|tensor| tensor.is_complex()))
+    {
+        t4a_scalar_kind::C64
+    } else {
+        t4a_scalar_kind::F64
+    }
 }
 
 fn collect_target_assignment(
@@ -1299,7 +1322,10 @@ pub extern "C" fn t4a_treetn_evaluator_new(
             .inner()
             .evaluator(&indices)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        Ok(t4a_treetn_evaluator::new(evaluator))
+        Ok(t4a_treetn_evaluator::new(InternalTreeTNEvaluatorHandle {
+            evaluator,
+            scalar_kind: treetn_scalar_kind(tn.inner()),
+        }))
     })
 }
 
@@ -1324,7 +1350,8 @@ pub extern "C" fn t4a_treetn_evaluator_evaluate(
             return Err(capi_error(T4A_NULL_POINTER, "values_col_major is null"));
         }
 
-        let n_indices = evaluator.inner().input_count();
+        let handle = evaluator.inner();
+        let n_indices = handle.evaluator.input_count();
         let n_values = n_indices.checked_mul(n_points).ok_or_else(|| {
             capi_error(
                 T4A_INVALID_ARGUMENT,
@@ -1334,11 +1361,11 @@ pub extern "C" fn t4a_treetn_evaluator_evaluate(
         let values_slice = unsafe { std::slice::from_raw_parts(values_col_major, n_values) };
         let shape = [n_indices, n_points];
         let values = ColMajorArrayRef::new(values_slice, &shape);
-        let results = evaluator
-            .inner()
+        let results = handle
+            .evaluator
             .evaluate_batch(values)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        write_evaluation_results(&results, out_re, out_im)
+        write_evaluation_results(&results, handle.scalar_kind, out_re, out_im)
     })
 }
 
@@ -1381,6 +1408,7 @@ pub extern "C" fn t4a_treetn_evaluate(
         let values_slice = unsafe { std::slice::from_raw_parts(values_col_major, n_values) };
         let shape = [n_indices, n_points];
         let values = ColMajorArrayRef::new(values_slice, &shape);
+        let scalar_kind = treetn_scalar_kind(tn.inner());
         let results = tn
             .inner()
             .evaluator(&indices)
@@ -1388,7 +1416,7 @@ pub extern "C" fn t4a_treetn_evaluate(
             .evaluate_batch(values)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
 
-        write_evaluation_results(&results, out_re, out_im)
+        write_evaluation_results(&results, scalar_kind, out_re, out_im)
     })
 }
 

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -1135,6 +1135,39 @@ fn test_treetn_evaluate_complex_requires_out_im_buffer() {
 }
 
 #[test]
+fn test_treetn_evaluate_complex_requires_out_im_even_for_real_value() {
+    let s = new_index(2);
+    let index_ptrs = [s as *const t4a_index];
+    let interleaved = [1.0, 2.0, 3.0, 0.0];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_dense_c64(1, index_ptrs.as_ptr(), interleaved.as_ptr(), 2, &mut tensor),
+        T4A_SUCCESS
+    );
+
+    let tt = new_treetn(&[tensor as *const t4a_tensor]);
+    let values = [1usize];
+    let mut out_re = 0.0;
+    assert_eq!(
+        t4a_treetn_evaluate(
+            tt,
+            index_ptrs.as_ptr(),
+            1,
+            values.as_ptr(),
+            1,
+            &mut out_re,
+            std::ptr::null_mut()
+        ),
+        T4A_NULL_POINTER
+    );
+    assert!(last_error().contains("out_im is required"));
+
+    t4a_treetn_release(tt);
+    t4a_tensor_release(tensor);
+    t4a_index_release(s);
+}
+
+#[test]
 fn test_treetn_evaluator_reuses_index_order_for_multiple_batches() {
     let (tt, tensors, indices) = make_two_site_treetn();
     let s0 = indices[0];
@@ -1183,6 +1216,44 @@ fn test_treetn_evaluator_reuses_index_order_for_multiple_batches() {
 
     t4a_treetn_evaluator_release(evaluator);
     cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_evaluator_complex_requires_out_im_even_for_real_value() {
+    let s = new_index(2);
+    let index_ptrs = [s as *const t4a_index];
+    let interleaved = [1.0, 2.0, 3.0, 0.0];
+    let mut tensor = std::ptr::null_mut();
+    assert_eq!(
+        t4a_tensor_new_dense_c64(1, index_ptrs.as_ptr(), interleaved.as_ptr(), 2, &mut tensor),
+        T4A_SUCCESS
+    );
+    let tt = new_treetn(&[tensor as *const t4a_tensor]);
+
+    let mut evaluator = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_evaluator_new(tt, index_ptrs.as_ptr(), 1, &mut evaluator),
+        T4A_SUCCESS
+    );
+
+    let values = [1usize];
+    let mut out_re = 0.0;
+    assert_eq!(
+        t4a_treetn_evaluator_evaluate(
+            evaluator,
+            values.as_ptr(),
+            1,
+            &mut out_re,
+            std::ptr::null_mut()
+        ),
+        T4A_NULL_POINTER
+    );
+    assert!(last_error().contains("out_im is required"));
+
+    t4a_treetn_evaluator_release(evaluator);
+    t4a_treetn_release(tt);
+    t4a_tensor_release(tensor);
+    t4a_index_release(s);
 }
 
 #[test]

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -23,6 +23,13 @@ pub(crate) type InternalTreeTN = DefaultTreeTN<usize>;
 /// Internal reusable TreeTN evaluator type wrapped by `t4a_treetn_evaluator`.
 pub(crate) type InternalTreeTNEvaluator = TreeTNEvaluator<InternalTensor, usize>;
 
+/// Internal C API evaluator handle state.
+#[derive(Clone)]
+pub(crate) struct InternalTreeTNEvaluatorHandle {
+    pub(crate) evaluator: InternalTreeTNEvaluator,
+    pub(crate) scalar_kind: t4a_scalar_kind,
+}
+
 /// Opaque index type for the C API.
 #[repr(C)]
 pub struct t4a_index {
@@ -196,15 +203,15 @@ pub struct t4a_treetn_evaluator {
 
 impl t4a_treetn_evaluator {
     /// Create a wrapper from an internal reusable evaluator value.
-    pub(crate) fn new(evaluator: InternalTreeTNEvaluator) -> Self {
+    pub(crate) fn new(handle: InternalTreeTNEvaluatorHandle) -> Self {
         Self {
-            _private: Box::into_raw(Box::new(evaluator)) as *const c_void,
+            _private: Box::into_raw(Box::new(handle)) as *const c_void,
         }
     }
 
     /// Borrow the wrapped reusable evaluator.
-    pub(crate) fn inner(&self) -> &InternalTreeTNEvaluator {
-        unsafe { &*(self._private as *const InternalTreeTNEvaluator) }
+    pub(crate) fn inner(&self) -> &InternalTreeTNEvaluatorHandle {
+        unsafe { &*(self._private as *const InternalTreeTNEvaluatorHandle) }
     }
 }
 
@@ -218,7 +225,7 @@ impl Drop for t4a_treetn_evaluator {
     fn drop(&mut self) {
         if !self._private.is_null() {
             unsafe {
-                let _ = Box::from_raw(self._private as *mut InternalTreeTNEvaluator);
+                let _ = Box::from_raw(self._private as *mut InternalTreeTNEvaluatorHandle);
             }
         }
     }

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -61,6 +61,16 @@ mod tests {
     }
 
     #[test]
+    fn eager_context_is_shared_across_threads() {
+        let main_context = default_eager_ctx();
+        let worker_context = std::thread::spawn(default_eager_ctx)
+            .join()
+            .expect("worker thread should complete");
+
+        assert!(Arc::ptr_eq(&main_context, &worker_context));
+    }
+
+    #[test]
     fn default_backend_is_shared_across_threads() {
         let main_threads = with_default_backend(|backend| backend.num_threads());
         let worker_threads =


### PR DESCRIPTION
## Summary

- Add retained-index C API tensor contraction entry points for pairwise and multi-tensor contractions.
- Make TreeTN C API evaluation output validation depend on the TreeTN scalar kind instead of whether each evaluated value has a nonzero imaginary part.
- Preserve the reusable TreeTN evaluator scalar kind in its C API handle.
- Add a cross-thread eager context regression test and regenerate the C header.

## Issues

Closes #495
Closes #465
Closes #466
Closes #467

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tensor4all-capi --release`
- `cargo test -p tensor4all-tensorbackend --release eager_context_is_shared_across_threads`
- `cargo clippy -p tensor4all-capi --all-targets -- -D warnings`
- `cargo clippy -p tensor4all-tensorbackend --all-targets -- -D warnings`