### PR TITLE
[codex] Add TreeTN cached batch evaluator

### DIFF
--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -3,7 +3,7 @@ use crate::index_like::IndexLike;
 use crate::index_ops::{common_ind_positions, prepare_contraction, prepare_contraction_pairs};
 use crate::tensor_like::LinearizationOrder;
 use crate::AnyScalar;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use num_complex::Complex64;
 use num_traits::Zero;
 use rand::Rng;
@@ -1758,10 +1758,15 @@ impl TensorDynLen {
     }
 
     pub(crate) fn contract_pairwise_default(&self, other: &Self) -> Self {
+        self.try_contract_pairwise_default(other)
+            .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"))
+    }
+
+    pub(crate) fn try_contract_pairwise_default(&self, other: &Self) -> Result<Self> {
         let self_dims = Self::expected_dims_from_indices(&self.indices);
         let other_dims = Self::expected_dims_from_indices(&other.indices);
         let spec = prepare_contraction(&self.indices, &self_dims, &other.indices, &other_dims)
-            .expect("contraction preparation failed");
+            .context("contraction preparation failed")?;
         let result_axis_classes = Self::binary_contraction_axis_classes(
             self.storage.axis_classes(),
             &spec.axes_a,
@@ -1770,23 +1775,17 @@ impl TensorDynLen {
         );
 
         if self.should_use_structured_payload_contract(other) {
-            return self
-                .contract_structured_payloads(
-                    other,
-                    spec.result_indices,
-                    &spec.axes_a,
-                    &spec.axes_b,
-                )
-                .expect("TensorDynLen::contract structured payload path failed");
+            return self.contract_structured_payloads(
+                other,
+                spec.result_indices,
+                &spec.axes_a,
+                &spec.axes_b,
+            );
         }
 
         if self.indices.is_empty() && other.indices.is_empty() {
-            let result = self
-                .materialized_inner()
-                .mul(other.materialized_inner())
-                .unwrap_or_else(|e| panic!("TensorDynLen::contract scalar multiply failed: {e}"));
-            return Self::from_inner(spec.result_indices, result)
-                .expect("TensorDynLen::contract returned invalid scalar");
+            let result = self.materialized_inner().mul(other.materialized_inner())?;
+            return Self::from_inner(spec.result_indices, result);
         }
 
         if self.as_native().dtype() != other.as_native().dtype() {
@@ -1795,14 +1794,12 @@ impl TensorDynLen {
                 &spec.axes_a,
                 other.as_native(),
                 &spec.axes_b,
-            )
-            .unwrap_or_else(|e| panic!("TensorDynLen::contract native fallback failed: {e}"));
+            )?;
             return Self::from_native_with_axis_classes(
                 spec.result_indices,
                 result_native,
                 result_axis_classes,
-            )
-            .expect("TensorDynLen::contract native fallback returned invalid tensor");
+            );
         }
 
         let subscripts = Self::build_binary_einsum_subscripts(
@@ -1810,15 +1807,12 @@ impl TensorDynLen {
             &spec.axes_a,
             other.indices.len(),
             &spec.axes_b,
-        )
-        .expect("TensorDynLen::contract failed to build einsum subscripts");
+        )?;
         let result = eager_einsum_ad(
             &[self.materialized_inner(), other.materialized_inner()],
             &subscripts,
-        )
-        .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"));
+        )?;
         Self::from_inner_with_axis_classes(spec.result_indices, result, result_axis_classes)
-            .expect("TensorDynLen::contract returned invalid tensor")
     }
 
     /// Contract this tensor with another tensor along explicitly specified index pairs.
@@ -3046,9 +3040,17 @@ impl TensorLike for TensorDynLen {
         super::contract::contract_multi(tensors, allowed)
     }
 
+    fn contract_pair(&self, other: &Self) -> Result<Self> {
+        self.try_contract_pairwise_default(other)
+    }
+
     fn contract_connected(tensors: &[&Self], allowed: crate::AllowedPairs<'_>) -> Result<Self> {
         // Delegate to contract_connected which requires connected graph
         super::contract::contract_connected(tensors, allowed)
+    }
+
+    fn select_indices(&self, selected_indices: &[DynIndex], positions: &[usize]) -> Result<Self> {
+        TensorDynLen::select_indices(self, selected_indices, positions)
     }
 
     fn axpby(&self, a: crate::AnyScalar, other: &Self, b: crate::AnyScalar) -> Result<Self> {

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -13,9 +13,11 @@
 //! For heterogeneous tensor collections, use an enum wrapper.
 
 use crate::any_scalar::AnyScalar;
+use crate::index_like::IndexLike;
 use crate::tensor_index::TensorIndex;
 use crate::truncation::SvdTruncationPolicy;
 use anyhow::Result;
+use std::collections::HashSet;
 use std::fmt::Debug;
 
 // ============================================================================
@@ -953,6 +955,49 @@ pub trait TensorLike: TensorIndex {
     /// ```
     fn contract(tensors: &[&Self], allowed: AllowedPairs<'_>) -> Result<Self>;
 
+    /// Contract this tensor with one other tensor using default pairwise semantics.
+    ///
+    /// This contracts all compatible common indices between `self` and `other`.
+    /// Implementations may override it with a specialized two-tensor path. The
+    /// default implementation calls [`Self::contract`] with two inputs and
+    /// [`AllowedPairs::All`].
+    ///
+    /// # Arguments
+    /// * `other` - The tensor to contract with. It should share at least one
+    ///   compatible common index unless the implementation supports outer
+    ///   products through its default pairwise semantics.
+    ///
+    /// # Returns
+    /// The tensor produced by contracting `self` and `other`.
+    ///
+    /// # Errors
+    /// Returns an error if pairwise contraction cannot be performed, for example
+    /// because common indices have incompatible dimensions or the contraction
+    /// executor fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(2);
+    /// let k = DynIndex::new_dyn(2);
+    /// let a = TensorDynLen::from_dense(
+    ///     vec![i.clone(), j.clone()],
+    ///     vec![1.0_f64, 0.0, 0.0, 1.0],
+    /// )?;
+    /// let b = TensorDynLen::from_dense(vec![j.clone(), k.clone()], vec![2.0, 3.0, 4.0, 5.0])?;
+    ///
+    /// let result = a.contract_pair(&b)?;
+    /// assert_eq!(result.dims(), vec![2, 2]);
+    /// assert_eq!(result.to_vec::<f64>()?, vec![2.0, 3.0, 4.0, 5.0]);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    fn contract_pair(&self, other: &Self) -> Result<Self> {
+        Self::contract(&[self, other], AllowedPairs::All)
+    }
+
     /// Contract multiple tensors that must form a connected graph.
     ///
     /// This is the core contraction method that requires all tensors to be
@@ -1260,6 +1305,85 @@ pub trait TensorLike: TensorIndex {
     /// # }
     /// ```
     fn ones(indices: &[<Self as TensorIndex>::Index]) -> Result<Self>;
+
+    /// Select fixed coordinates for a subset of this tensor's external indices.
+    ///
+    /// This returns a new tensor with `selected_indices` removed and the
+    /// corresponding coordinates fixed to `positions`. Implementations may
+    /// override this with direct slicing. The default implementation contracts
+    /// with a one-hot tensor, so it works for any tensor type that supports
+    /// [`Self::onehot`] and [`Self::contract`].
+    ///
+    /// # Arguments
+    /// * `selected_indices` - External indices to fix. Each index must appear
+    ///   at most once and should be present in the tensor.
+    /// * `positions` - Zero-based coordinates, one for each selected index.
+    ///
+    /// # Returns
+    /// A tensor with the selected indices removed. If no indices are selected,
+    /// this returns a clone of `self`.
+    ///
+    /// # Errors
+    /// Returns an error if the argument lengths differ, if an index is repeated,
+    /// if a coordinate is outside the index dimension, or if the one-hot
+    /// contraction fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(3);
+    /// let tensor = TensorDynLen::from_dense(
+    ///     vec![i.clone(), j.clone()],
+    ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    /// )?;
+    ///
+    /// let selected =
+    ///     <TensorDynLen as TensorLike>::select_indices(&tensor, &[j], &[1])?;
+    /// assert_eq!(selected.dims(), vec![2]);
+    /// assert_eq!(selected.to_vec::<f64>()?, vec![3.0, 4.0]);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    fn select_indices(
+        &self,
+        selected_indices: &[<Self as TensorIndex>::Index],
+        positions: &[usize],
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            selected_indices.len() == positions.len(),
+            "selected_indices length {} does not match positions length {}",
+            selected_indices.len(),
+            positions.len()
+        );
+        if selected_indices.is_empty() {
+            return Ok(self.clone());
+        }
+
+        let mut seen = HashSet::with_capacity(selected_indices.len());
+        for (index, &position) in selected_indices.iter().zip(positions.iter()) {
+            anyhow::ensure!(
+                seen.insert(index.clone()),
+                "selected index appears more than once"
+            );
+            anyhow::ensure!(
+                position < index.dim(),
+                "selected coordinate {} is out of range for index {:?} with dim {}",
+                position,
+                index,
+                index.dim()
+            );
+        }
+
+        let index_vals = selected_indices
+            .iter()
+            .cloned()
+            .zip(positions.iter().copied())
+            .collect::<Vec<_>>();
+        let onehot = Self::onehot(&index_vals)?;
+        Self::contract(&[self, &onehot], AllowedPairs::All)
+    }
 
     /// Create a one-hot tensor with value 1.0 at the specified index positions.
     ///

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -30,4 +30,9 @@ kryst.workspace = true
 
 [dev-dependencies]
 tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+criterion.workspace = true
 rand_chacha.workspace = true
+
+[[bench]]
+name = "cached_evaluator"
+harness = false

--- a/crates/tensor4all-treetn/benches/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/benches/cached_evaluator.rs
@@ -1,0 +1,206 @@
+//! Benchmark cached TreeTN batch evaluation against TTCache and uncached TreeTN evaluation.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use tensor4all_core::ColMajorArrayRef;
+use tensor4all_simplett::{tensor3_zeros, MultiIndex, TTCache, Tensor3, Tensor3Ops, TensorTrain};
+use tensor4all_treetn::{tensor_train_to_treetn, CachedEvaluatorOptions, TreeTNCachedEvaluator};
+
+fn generate_tci_like_indices(
+    n_left: usize,
+    n_right: usize,
+    n_sites: usize,
+    local_dim: usize,
+    split: usize,
+    seed: u64,
+) -> Vec<MultiIndex> {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+
+    let left_parts: Vec<Vec<usize>> = (0..n_left)
+        .map(|_| (0..split).map(|_| rng.random_range(0..local_dim)).collect())
+        .collect();
+    let right_parts: Vec<Vec<usize>> = (0..n_right)
+        .map(|_| {
+            (0..n_sites - split)
+                .map(|_| rng.random_range(0..local_dim))
+                .collect()
+        })
+        .collect();
+
+    let mut indices = Vec::with_capacity(n_left * n_right);
+    for left in &left_parts {
+        for right in &right_parts {
+            let mut index = left.clone();
+            index.extend(right.iter().copied());
+            indices.push(index);
+        }
+    }
+    indices
+}
+
+fn create_tt_with_bond_dim(n_sites: usize, local_dim: usize, bond_dim: usize) -> TensorTrain<f64> {
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
+    let mut tensors: Vec<Tensor3<f64>> = Vec::with_capacity(n_sites);
+
+    for site in 0..n_sites {
+        let left_dim = if site == 0 { 1 } else { bond_dim };
+        let right_dim = if site == n_sites - 1 { 1 } else { bond_dim };
+        let mut tensor = tensor3_zeros(left_dim, local_dim, right_dim);
+        for left in 0..left_dim {
+            for local in 0..local_dim {
+                for right in 0..right_dim {
+                    tensor.set3(left, local, right, rng.random::<f64>());
+                }
+            }
+        }
+        tensors.push(tensor);
+    }
+
+    TensorTrain::new(tensors).unwrap()
+}
+
+fn multi_indices_to_col_major(indices: &[MultiIndex], n_sites: usize) -> Vec<usize> {
+    let mut values = vec![0usize; n_sites * indices.len()];
+    for (point, index) in indices.iter().enumerate() {
+        for (site, value) in index.iter().copied().enumerate() {
+            values[site + n_sites * point] = value;
+        }
+    }
+    values
+}
+
+fn bench_chain_size_scaling(c: &mut Criterion) {
+    const LOCAL_DIM: usize = 2;
+    const BOND_DIM: usize = 16;
+    const N_LEFT: usize = 20;
+    const N_RIGHT: usize = 20;
+
+    let mut group = c.benchmark_group("treetn_cached_chain_size");
+    group.sample_size(10);
+
+    for n_sites in [16usize, 32, 64, 128] {
+        let tt = create_tt_with_bond_dim(n_sites, LOCAL_DIM, BOND_DIM);
+        let (tree, site_indices) = tensor_train_to_treetn(&tt).unwrap();
+        let indices = generate_tci_like_indices(
+            N_LEFT,
+            N_RIGHT,
+            n_sites,
+            LOCAL_DIM,
+            n_sites / 2,
+            n_sites as u64,
+        );
+        let values = multi_indices_to_col_major(&indices, n_sites);
+        let shape = [n_sites, indices.len()];
+
+        group.bench_with_input(
+            BenchmarkId::new("ttcache", n_sites),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut cache = TTCache::new(&tt);
+                    cache.evaluate_many(black_box(indices), None).unwrap()
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("treetn_cached", n_sites),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let mut evaluator = TreeTNCachedEvaluator::new(
+                        &tree,
+                        &site_indices,
+                        CachedEvaluatorOptions::<usize>::default(),
+                    )
+                    .unwrap();
+                    evaluator.evaluate_batch(points).unwrap()
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("treetn_uncached", n_sites),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    tree.evaluate(&site_indices, points).unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_batch_size_scaling(c: &mut Criterion) {
+    const N_SITES: usize = 64;
+    const LOCAL_DIM: usize = 2;
+    const BOND_DIM: usize = 16;
+
+    let tt = create_tt_with_bond_dim(N_SITES, LOCAL_DIM, BOND_DIM);
+    let (tree, site_indices) = tensor_train_to_treetn(&tt).unwrap();
+    let mut group = c.benchmark_group("treetn_cached_batch_size");
+    group.sample_size(10);
+
+    for (n_left, n_right) in [(10usize, 10usize), (20, 20), (40, 40)] {
+        let indices = generate_tci_like_indices(
+            n_left,
+            n_right,
+            N_SITES,
+            LOCAL_DIM,
+            N_SITES / 2,
+            (n_left * n_right) as u64,
+        );
+        let values = multi_indices_to_col_major(&indices, N_SITES);
+        let shape = [N_SITES, indices.len()];
+        let label = format!("{}x{}", n_left, n_right);
+
+        group.bench_with_input(
+            BenchmarkId::new("ttcache", &label),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut cache = TTCache::new(&tt);
+                    cache.evaluate_many(black_box(indices), None).unwrap()
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("treetn_cached", &label),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let mut evaluator = TreeTNCachedEvaluator::new(
+                        &tree,
+                        &site_indices,
+                        CachedEvaluatorOptions::<usize>::default(),
+                    )
+                    .unwrap();
+                    evaluator.evaluate_batch(points).unwrap()
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("treetn_uncached", &label),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    tree.evaluate(&site_indices, points).unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_chain_size_scaling, bench_batch_size_scaling);
+criterion_main!(benches);

--- a/crates/tensor4all-treetn/benches/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/benches/cached_evaluator.rs
@@ -202,5 +202,59 @@ fn bench_batch_size_scaling(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_chain_size_scaling, bench_batch_size_scaling);
+fn bench_bond_dim_scaling(c: &mut Criterion) {
+    const N_SITES: usize = 128;
+    const LOCAL_DIM: usize = 2;
+    const N_LEFT: usize = 10;
+    const N_RIGHT: usize = 10;
+
+    let indices = generate_tci_like_indices(N_LEFT, N_RIGHT, N_SITES, LOCAL_DIM, N_SITES / 2, 2026);
+    let values = multi_indices_to_col_major(&indices, N_SITES);
+    let shape = [N_SITES, indices.len()];
+
+    let mut group = c.benchmark_group("treetn_cached_bond_dim");
+    group.sample_size(10);
+
+    for bond_dim in [4usize, 8, 16, 32, 64] {
+        let tt = create_tt_with_bond_dim(N_SITES, LOCAL_DIM, bond_dim);
+        let (tree, site_indices) = tensor_train_to_treetn(&tt).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("ttcache", bond_dim),
+            &indices,
+            |b, indices| {
+                b.iter(|| {
+                    let mut cache = TTCache::new(&tt);
+                    cache.evaluate_many(black_box(indices), None).unwrap()
+                })
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("treetn_cached", bond_dim),
+            &values,
+            |b, values| {
+                b.iter(|| {
+                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let mut evaluator = TreeTNCachedEvaluator::new(
+                        &tree,
+                        &site_indices,
+                        CachedEvaluatorOptions::<usize>::default(),
+                    )
+                    .unwrap();
+                    evaluator.evaluate_batch(points).unwrap()
+                })
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_chain_size_scaling,
+    bench_batch_size_scaling,
+    bench_bond_dim_scaling
+);
 criterion_main!(benches);

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -61,6 +61,10 @@ pub use treetn::{
     get_boundary_edges,
     partial_contract,
     BoundaryEdge,
+    CachedEvaluatorOptions,
+    CenterSearchResult,
+    // Core type
+    GreedyCenterSearch,
     LocalUpdateStep,
     LocalUpdateSweepPlan,
     LocalUpdater,
@@ -69,8 +73,8 @@ pub use treetn::{
     ScheduledSwapStep,
     SwapOptions,
     SwapSchedule,
-    // Core type
     TreeTN,
+    TreeTNCachedEvaluator,
     TreeTNEvaluator,
     TreeTopology,
     TruncateUpdater,

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -10,6 +10,8 @@ use tensor4all_core::{AllowedPairs, AnyScalar, ColMajorArrayRef, IndexLike, Tens
 use super::TreeTN;
 
 type KeyId = usize;
+type EntryOffsets<I, V> = HashMap<V, Vec<(SiteEntry<I>, usize)>>;
+type ParentMap<V> = HashMap<V, Option<V>>;
 
 #[derive(Clone, Debug)]
 struct SiteEntry<I> {
@@ -52,7 +54,7 @@ struct ComponentBatch<I, V> {
     neighbor: V,
     nodes: Vec<V>,
     entries: Vec<SiteEntry<I>>,
-    entry_offsets_by_node: HashMap<V, Vec<(SiteEntry<I>, usize)>>,
+    entry_offsets_by_node: EntryOffsets<I, V>,
     point_to_assignment: Vec<usize>,
     assignments: Vec<ComponentAssignment>,
 }
@@ -709,8 +711,7 @@ where
             }
             entries.sort_by_key(|entry| entry.input_position);
 
-            let mut entry_offsets_by_node: HashMap<V, Vec<(SiteEntry<T::Index>, usize)>> =
-                HashMap::new();
+            let mut entry_offsets_by_node: EntryOffsets<T::Index, V> = HashMap::new();
             for (offset, entry) in entries.iter().cloned().enumerate() {
                 let owner = self
                     .tree
@@ -1060,10 +1061,7 @@ where
     map
 }
 
-fn rooted_tree<V>(
-    neighbors: &HashMap<V, Vec<V>>,
-    root: &V,
-) -> Result<(HashMap<V, Option<V>>, Vec<V>)>
+fn rooted_tree<V>(neighbors: &HashMap<V, Vec<V>>, root: &V) -> Result<(ParentMap<V>, Vec<V>)>
 where
     V: Clone + Eq + Hash + Ord + Debug,
 {

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -5,12 +5,13 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use anyhow::{bail, Context, Result};
-use tensor4all_core::{AllowedPairs, AnyScalar, ColMajorArrayRef, IndexLike, TensorLike};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike, TensorLike};
 
 use super::TreeTN;
 
 type KeyId = usize;
-type EntryOffsets<I, V> = HashMap<V, Vec<(SiteEntry<I>, usize)>>;
+type EnvironmentCache<T, V> = HashMap<V, Vec<T>>;
+type CacheBuildResult<T, V> = (Vec<ComponentBatch<V>>, EnvironmentCache<T, V>);
 type ParentMap<V> = HashMap<V, Option<V>>;
 
 #[derive(Clone, Debug)]
@@ -44,24 +45,28 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct ComponentAssignment {
-    values: Vec<usize>,
+#[derive(Clone, Debug)]
+struct AssignmentBatch {
+    point_to_assignment: Vec<usize>,
+    first_points: Vec<usize>,
 }
 
 #[derive(Clone, Debug)]
-struct ComponentBatch<I, V> {
+struct ComponentBatch<V> {
     neighbor: V,
-    nodes: Vec<V>,
-    entries: Vec<SiteEntry<I>>,
-    entry_offsets_by_node: EntryOffsets<I, V>,
     point_to_assignment: Vec<usize>,
-    assignments: Vec<ComponentAssignment>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct CachedEvaluationStats {
     subtree_environment_count: usize,
+    directed_message_count: usize,
+}
+
+#[derive(Clone, Debug)]
+struct RootedMessagePlan<V> {
+    children: HashMap<V, Vec<V>>,
+    postorder: Vec<V>,
 }
 
 #[derive(Debug)]
@@ -279,6 +284,46 @@ fn intern_component_keys(
         keys.push(interner.intern(tuple));
     }
     keys
+}
+
+impl<V> RootedMessagePlan<V>
+where
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    fn new<T>(tree: &TreeTN<T, V>, center: &V) -> Result<Self>
+    where
+        T: TensorLike,
+    {
+        let neighbors = sorted_neighbors(tree);
+        let (parent, order) = rooted_tree(&neighbors, center)?;
+
+        let mut children = HashMap::<V, Vec<V>>::new();
+        for node in neighbors.keys() {
+            children.insert(node.clone(), Vec::new());
+        }
+        for (node, parent_node) in &parent {
+            if let Some(parent_node) = parent_node {
+                children
+                    .get_mut(parent_node)
+                    .ok_or_else(|| anyhow::anyhow!("missing rooted parent {:?}", parent_node))?
+                    .push(node.clone());
+            }
+        }
+        for node_children in children.values_mut() {
+            node_children.sort();
+        }
+
+        let postorder = order
+            .into_iter()
+            .rev()
+            .filter(|node| node != center)
+            .collect::<Vec<_>>();
+
+        Ok(Self {
+            children,
+            postorder,
+        })
+    }
 }
 
 /// Options controlling cached batch evaluation for [`TreeTN`].
@@ -674,8 +719,8 @@ where
             "TreeTNCachedEvaluator::evaluate_batch",
         )?;
         let center = self.ensure_center(values)?.clone();
-        let component_batches = self.build_component_batches(&center, values)?;
-        let environment_cache = self.build_environment_cache(&center, &component_batches)?;
+        let (component_batches, environment_cache) =
+            self.build_environment_cache(&center, values)?;
         self.contract_center_for_points(&center, values, &component_batches, &environment_cache)
     }
 
@@ -690,146 +735,185 @@ where
         Ok(self.center.as_ref().unwrap())
     }
 
-    fn build_component_batches(
-        &self,
-        center: &V,
-        values: ColMajorArrayRef<'_, usize>,
-    ) -> Result<Vec<ComponentBatch<T::Index, V>>> {
-        let mut batches = Vec::new();
-        let n_points = values.shape()[1];
-        for neighbor in sorted_neighbors(self.tree)
-            .get(center)
-            .cloned()
-            .unwrap_or_default()
-        {
-            let nodes = component_nodes(self.tree, &neighbor, center)?;
-            let mut entries = Vec::new();
-            for node in &nodes {
-                if let Some(node_entries) = self.layout.entries_by_node.get(node) {
-                    entries.extend(node_entries.iter().cloned());
-                }
-            }
-            entries.sort_by_key(|entry| entry.input_position);
-
-            let mut entry_offsets_by_node: EntryOffsets<T::Index, V> = HashMap::new();
-            for (offset, entry) in entries.iter().cloned().enumerate() {
-                let owner = self
-                    .tree
-                    .site_index_network()
-                    .find_node_by_index(&entry.index)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "TreeTNCachedEvaluator::evaluate_batch: unknown index {:?}",
-                            entry.index
-                        )
-                    })?
-                    .clone();
-                entry_offsets_by_node
-                    .entry(owner)
-                    .or_default()
-                    .push((entry, offset));
-            }
-
-            let mut assignment_ids = HashMap::<ComponentAssignment, usize>::new();
-            let mut assignments = Vec::<ComponentAssignment>::new();
-            let mut point_to_assignment = Vec::with_capacity(n_points);
-            for point in 0..n_points {
-                let assignment = ComponentAssignment {
-                    values: entries
-                        .iter()
-                        .map(|entry| *values.get(&[entry.input_position, point]).unwrap())
-                        .collect(),
-                };
-                validate_entry_values(
-                    &entries,
-                    &assignment.values,
-                    "TreeTNCachedEvaluator::evaluate_batch",
-                )?;
-                let next_id = assignment_ids.len();
-                let assignment_id =
-                    *assignment_ids.entry(assignment.clone()).or_insert_with(|| {
-                        assignments.push(assignment);
-                        next_id
-                    });
-                point_to_assignment.push(assignment_id);
-            }
-
-            batches.push(ComponentBatch {
-                neighbor,
-                nodes,
-                entries,
-                entry_offsets_by_node,
-                point_to_assignment,
-                assignments,
-            });
-        }
-        Ok(batches)
-    }
-
     fn build_environment_cache(
         &mut self,
         center: &V,
-        component_batches: &[ComponentBatch<T::Index, V>],
-    ) -> Result<HashMap<V, Vec<T>>> {
-        let mut cache = HashMap::new();
-        let mut count = 0usize;
-        for batch in component_batches {
-            let mut environments = Vec::with_capacity(batch.assignments.len());
-            for assignment in &batch.assignments {
-                environments.push(self.compute_component_environment(center, batch, assignment)?);
-                count += 1;
+        values: ColMajorArrayRef<'_, usize>,
+    ) -> Result<CacheBuildResult<T, V>> {
+        self.last_stats = CachedEvaluationStats::default();
+        let plan = RootedMessagePlan::new(self.tree, center)?;
+        let assignment_batches = self.build_message_assignment_batches(&plan, values)?;
+
+        let mut messages = HashMap::<V, Vec<T>>::new();
+        let mut directed_message_count = 0usize;
+        for node in &plan.postorder {
+            let assignment_batch = assignment_batches
+                .get(node)
+                .ok_or_else(|| anyhow::anyhow!("missing assignment batch for node {:?}", node))?;
+            let mut node_messages = Vec::with_capacity(assignment_batch.first_points.len());
+            for point in assignment_batch.first_points.iter().copied() {
+                node_messages.push(self.compute_directed_message(
+                    node,
+                    point,
+                    values,
+                    &plan,
+                    &assignment_batches,
+                    &messages,
+                )?);
+                directed_message_count += 1;
             }
-            cache.insert(batch.neighbor.clone(), environments);
+            messages.insert(node.clone(), node_messages);
         }
-        self.last_stats.subtree_environment_count = count;
-        Ok(cache)
+
+        let mut component_batches = Vec::new();
+        let mut cache = HashMap::new();
+        let mut subtree_environment_count = 0usize;
+        for neighbor in plan.children.get(center).cloned().unwrap_or_default() {
+            let assignment_batch = assignment_batches.get(&neighbor).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::evaluate_batch: missing assignments for neighbor {:?}",
+                    neighbor
+                )
+            })?;
+            let environments = messages.remove(&neighbor).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::evaluate_batch: missing messages for neighbor {:?}",
+                    neighbor
+                )
+            })?;
+            subtree_environment_count += environments.len();
+            cache.insert(neighbor.clone(), environments);
+            component_batches.push(ComponentBatch {
+                neighbor,
+                point_to_assignment: assignment_batch.point_to_assignment.clone(),
+            });
+        }
+        self.last_stats.subtree_environment_count = subtree_environment_count;
+        self.last_stats.directed_message_count = directed_message_count;
+        Ok((component_batches, cache))
     }
 
-    fn compute_component_environment(
+    fn build_message_assignment_batches(
         &self,
-        _center: &V,
-        batch: &ComponentBatch<T::Index, V>,
-        assignment: &ComponentAssignment,
-    ) -> Result<T> {
-        let mut tensors = Vec::with_capacity(batch.nodes.len());
-        let mut names = Vec::with_capacity(batch.nodes.len());
-        for node in &batch.nodes {
-            let tensor = tensor_for_node(self.tree, node)?;
-            let index_vals = batch
-                .entry_offsets_by_node
+        plan: &RootedMessagePlan<V>,
+        values: ColMajorArrayRef<'_, usize>,
+    ) -> Result<HashMap<V, AssignmentBatch>> {
+        let n_points = values.shape()[1];
+        let mut local_interner = KeyInterner::<Vec<usize>>::default();
+        let mut local_keys = HashMap::<V, Vec<KeyId>>::new();
+
+        let mut node_names = self.tree.node_names();
+        node_names.sort();
+        for node in &node_names {
+            let entries = self
+                .layout
+                .entries_by_node
                 .get(node)
-                .map(|offsets| {
-                    offsets
-                        .iter()
-                        .map(|(entry, offset)| (entry.index.clone(), assignment.values[*offset]))
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            tensors.push(slice_tensor(tensor, &index_vals).with_context(|| {
-                format!(
-                    "TreeTNCachedEvaluator::evaluate_batch: failed to slice component node {:?}",
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let mut keys = Vec::with_capacity(n_points);
+            for point in 0..n_points {
+                let key = entries
+                    .iter()
+                    .map(|entry| *values.get(&[entry.input_position, point]).unwrap())
+                    .collect::<Vec<_>>();
+                validate_entry_values(entries, &key, "TreeTNCachedEvaluator::evaluate_batch")?;
+                keys.push(local_interner.intern(key));
+            }
+            local_keys.insert(node.clone(), keys);
+        }
+
+        let mut assignment_batches = HashMap::<V, AssignmentBatch>::new();
+        for node in &plan.postorder {
+            let local_keys = local_keys.get(node).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::evaluate_batch: missing local keys for {:?}",
                     node
                 )
-            })?);
-            names.push(node.clone());
+            })?;
+            let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+            let child_batches = children
+                .iter()
+                .map(|child| {
+                    assignment_batches.get(child).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "TreeTNCachedEvaluator::evaluate_batch: missing child assignments for {:?}",
+                            child
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let assignment_batch =
+                build_compact_assignment_batch(local_keys, &child_batches, n_points);
+            assignment_batches.insert(node.clone(), assignment_batch);
         }
 
-        if tensors.len() == 1 {
-            return Ok(tensors.remove(0));
+        Ok(assignment_batches)
+    }
+
+    fn compute_directed_message(
+        &self,
+        node: &V,
+        point: usize,
+        values: ColMajorArrayRef<'_, usize>,
+        plan: &RootedMessagePlan<V>,
+        assignment_batches: &HashMap<V, AssignmentBatch>,
+        messages: &HashMap<V, Vec<T>>,
+    ) -> Result<T> {
+        let tensor = tensor_for_node(self.tree, node)?;
+        let index_vals = self.index_vals_for_point(node, values, point);
+        let local_message = slice_tensor(tensor, &index_vals).with_context(|| {
+            format!(
+                "TreeTNCachedEvaluator::evaluate_batch: failed to slice message node {:?}",
+                node
+            )
+        })?;
+
+        let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+        if children.is_empty() {
+            return Ok(local_message);
         }
 
-        TreeTN::<T, V>::from_tensors(tensors, names)
-            .context("TreeTNCachedEvaluator::evaluate_batch: failed to build component TreeTN")?
-            .contract_to_tensor()
-            .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract component")
+        let mut child_messages = Vec::with_capacity(children.len());
+        for child in children {
+            let assignment_batch = assignment_batches.get(child).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::evaluate_batch: missing child assignments for {:?}",
+                    child
+                )
+            })?;
+            let assignment_id = assignment_batch
+                .point_to_assignment
+                .get(point)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("missing child assignment for point {point}"))?;
+            let child_message = messages
+                .get(child)
+                .and_then(|node_messages| node_messages.get(assignment_id))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "TreeTNCachedEvaluator::evaluate_batch: missing child message for {:?}",
+                        child
+                    )
+                })?;
+            child_messages.push(child_message.clone());
+        }
+
+        let mut message = local_message;
+        for child_message in child_messages {
+            message = message.contract_pair(&child_message).context(
+                "TreeTNCachedEvaluator::evaluate_batch: failed to contract directed message",
+            )?;
+        }
+        Ok(message)
     }
 
     fn contract_center_for_points(
         &self,
         center: &V,
         values: ColMajorArrayRef<'_, usize>,
-        component_batches: &[ComponentBatch<T::Index, V>],
-        environment_cache: &HashMap<V, Vec<T>>,
+        component_batches: &[ComponentBatch<V>],
+        environment_cache: &EnvironmentCache<T, V>,
     ) -> Result<Vec<AnyScalar>> {
         let n_points = values.shape()[1];
         let center_entries = self
@@ -855,8 +939,7 @@ where
             let center_partial = slice_tensor(center_tensor, &center_index_vals)
                 .context("TreeTNCachedEvaluator::evaluate_batch: failed to slice center tensor")?;
 
-            let mut tensor_refs = Vec::with_capacity(1 + component_batches.len());
-            tensor_refs.push(&center_partial);
+            let mut result_tensor = center_partial;
             for batch in component_batches {
                 let assignment_id = batch.point_to_assignment[point];
                 let environment = environment_cache
@@ -867,11 +950,11 @@ where
                             "TreeTNCachedEvaluator::evaluate_batch: missing cached environment"
                         )
                     })?;
-                tensor_refs.push(environment);
+                result_tensor = result_tensor
+                    .contract_pair(environment)
+                    .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center")?;
             }
 
-            let result_tensor = T::contract(&tensor_refs, AllowedPairs::All)
-                .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center")?;
             results.push(
                 scalar_one
                     .inner_product(&result_tensor)
@@ -880,6 +963,27 @@ where
         }
 
         Ok(results)
+    }
+
+    fn index_vals_for_point(
+        &self,
+        node: &V,
+        values: ColMajorArrayRef<'_, usize>,
+        point: usize,
+    ) -> Vec<(T::Index, usize)> {
+        self.layout
+            .entries_by_node
+            .get(node)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .map(|entry| {
+                        let value = *values.get(&[entry.input_position, point]).unwrap();
+                        (entry.index.clone(), value)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     #[cfg(test)]
@@ -963,6 +1067,38 @@ where
     })
 }
 
+fn build_compact_assignment_batch(
+    local_keys: &[KeyId],
+    child_batches: &[&AssignmentBatch],
+    n_points: usize,
+) -> AssignmentBatch {
+    let mut assignment_ids = HashMap::<Vec<KeyId>, usize>::new();
+    let mut first_points = Vec::<usize>::new();
+    let mut point_to_assignment = Vec::with_capacity(n_points);
+    for (point, &local_key) in local_keys.iter().enumerate().take(n_points) {
+        let mut assignment = Vec::with_capacity(1 + child_batches.len());
+        assignment.push(local_key);
+        for child_batch in child_batches {
+            assignment.push(child_batch.point_to_assignment[point]);
+        }
+
+        let assignment_id = if let Some(&assignment_id) = assignment_ids.get(&assignment) {
+            assignment_id
+        } else {
+            let assignment_id = assignment_ids.len();
+            assignment_ids.insert(assignment, assignment_id);
+            first_points.push(point);
+            assignment_id
+        };
+        point_to_assignment.push(assignment_id);
+    }
+
+    AssignmentBatch {
+        point_to_assignment,
+        first_points,
+    }
+}
+
 fn validate_values_shape(
     values: ColMajorArrayRef<'_, usize>,
     n_indices: usize,
@@ -1041,8 +1177,15 @@ where
         return Ok(tensor.clone());
     }
     validate_index_vals(index_vals, "slice_tensor")?;
-    let onehot = T::onehot(index_vals)?;
-    T::contract(&[tensor, &onehot], AllowedPairs::All)
+    let selected_indices = index_vals
+        .iter()
+        .map(|(index, _)| index.clone())
+        .collect::<Vec<_>>();
+    let positions = index_vals
+        .iter()
+        .map(|(_, position)| *position)
+        .collect::<Vec<_>>();
+    tensor.select_indices(&selected_indices, &positions)
 }
 
 fn sorted_neighbors<T, V>(tree: &TreeTN<T, V>) -> HashMap<V, Vec<V>>
@@ -1096,30 +1239,6 @@ where
     Ok((parent, order))
 }
 
-fn component_nodes<T, V>(tree: &TreeTN<T, V>, start: &V, blocked: &V) -> Result<Vec<V>>
-where
-    T: TensorLike,
-    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
-{
-    let neighbors = sorted_neighbors(tree);
-    let mut nodes = Vec::new();
-    let mut seen = HashSet::new();
-    let mut stack = vec![start.clone()];
-    while let Some(node) = stack.pop() {
-        if &node == blocked || !seen.insert(node.clone()) {
-            continue;
-        }
-        nodes.push(node.clone());
-        for neighbor in neighbors.get(&node).cloned().unwrap_or_default() {
-            if &neighbor != blocked && !seen.contains(&neighbor) {
-                stack.push(neighbor);
-            }
-        }
-    }
-    nodes.sort();
-    Ok(nodes)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1165,6 +1284,37 @@ mod tests {
         let t2 = TensorDynLen::from_dense(vec![b12, s2.clone()], vec![1.0_f64; 4]).unwrap();
         let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap();
         (tree, vec![s0, s1, s2])
+    }
+
+    fn five_node_chain() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+        let sites: Vec<DynIndex> = (0..5).map(|_| DynIndex::new_dyn(2)).collect();
+        let bonds: Vec<DynIndex> = (0..4).map(|_| DynIndex::new_dyn(2)).collect();
+
+        let t0 =
+            TensorDynLen::from_dense(vec![sites[0].clone(), bonds[0].clone()], vec![1.0_f64; 4])
+                .unwrap();
+        let t1 = TensorDynLen::from_dense(
+            vec![bonds[0].clone(), sites[1].clone(), bonds[1].clone()],
+            vec![1.0_f64; 8],
+        )
+        .unwrap();
+        let t2 = TensorDynLen::from_dense(
+            vec![bonds[1].clone(), sites[2].clone(), bonds[2].clone()],
+            vec![1.0_f64; 8],
+        )
+        .unwrap();
+        let t3 = TensorDynLen::from_dense(
+            vec![bonds[2].clone(), sites[3].clone(), bonds[3].clone()],
+            vec![1.0_f64; 8],
+        )
+        .unwrap();
+        let t4 =
+            TensorDynLen::from_dense(vec![bonds[3].clone(), sites[4].clone()], vec![1.0_f64; 4])
+                .unwrap();
+
+        let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1, t2, t3, t4], vec![0, 1, 2, 3, 4])
+            .unwrap();
+        (tree, sites)
     }
 
     fn star_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
@@ -1341,6 +1491,34 @@ mod tests {
 
         assert_scalars_close(&actual, &expected);
         assert_eq!(evaluator.stats_for_test().subtree_environment_count, 4);
+    }
+
+    #[test]
+    fn cached_evaluator_reuses_directed_messages_inside_components() {
+        let (tree, indices) = five_node_chain();
+        let values = vec![
+            0, 0, 0, 0, 0, //
+            0, 1, 0, 0, 1, //
+            1, 0, 1, 1, 0, //
+            1, 1, 1, 1, 1,
+        ];
+        let shape = [5, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+        assert_eq!(evaluator.stats_for_test().directed_message_count, 12);
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -1,0 +1,1417 @@
+//! Cached batch evaluation for tree tensor networks.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use anyhow::{bail, Context, Result};
+use tensor4all_core::{AllowedPairs, AnyScalar, ColMajorArrayRef, IndexLike, TensorLike};
+
+use super::TreeTN;
+
+type KeyId = usize;
+
+#[derive(Clone, Debug)]
+struct SiteEntry<I> {
+    index: I,
+    input_position: usize,
+    local_axis: usize,
+}
+
+#[derive(Clone, Debug)]
+struct EvaluatorLayout<I, V> {
+    entries_by_node: HashMap<V, Vec<SiteEntry<I>>>,
+    n_indices: usize,
+}
+
+#[derive(Default)]
+struct KeyInterner<T>
+where
+    T: Clone + Eq + Hash,
+{
+    ids: HashMap<T, KeyId>,
+}
+
+impl<T> KeyInterner<T>
+where
+    T: Clone + Eq + Hash,
+{
+    fn intern(&mut self, key: T) -> KeyId {
+        let next = self.ids.len();
+        *self.ids.entry(key).or_insert(next)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ComponentAssignment {
+    values: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+struct ComponentBatch<I, V> {
+    neighbor: V,
+    nodes: Vec<V>,
+    entries: Vec<SiteEntry<I>>,
+    entry_offsets_by_node: HashMap<V, Vec<(SiteEntry<I>, usize)>>,
+    point_to_assignment: Vec<usize>,
+    assignments: Vec<ComponentAssignment>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct CachedEvaluationStats {
+    subtree_environment_count: usize,
+}
+
+#[derive(Debug)]
+struct ComponentCostIndex<V> {
+    neighbors: HashMap<V, Vec<V>>,
+    directed_counts: HashMap<(V, V), usize>,
+    node_costs: Option<HashMap<V, usize>>,
+}
+
+impl<V> ComponentCostIndex<V>
+where
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    fn new<T>(
+        tree: &TreeTN<T, V>,
+        indices: &[T::Index],
+        values: ColMajorArrayRef<'_, usize>,
+    ) -> Result<Self>
+    where
+        T: TensorLike,
+        T::Index: Clone + Eq + Hash,
+        <T::Index as IndexLike>::Id: Ord,
+    {
+        let layout = build_layout(tree, indices)?;
+        Self::from_layout(tree, &layout, values)
+    }
+
+    fn from_layout<T>(
+        tree: &TreeTN<T, V>,
+        layout: &EvaluatorLayout<T::Index, V>,
+        values: ColMajorArrayRef<'_, usize>,
+    ) -> Result<Self>
+    where
+        T: TensorLike,
+        T::Index: Clone + Eq + Hash,
+        <T::Index as IndexLike>::Id: Ord,
+    {
+        validate_values_shape(values, layout.n_indices, "ComponentCostIndex::new")?;
+        let n_points = values.shape()[1];
+
+        let neighbors = sorted_neighbors(tree);
+        if neighbors.is_empty() {
+            return Ok(Self {
+                neighbors,
+                directed_counts: HashMap::new(),
+                node_costs: None,
+            });
+        }
+
+        let mut node_names: Vec<V> = neighbors.keys().cloned().collect();
+        node_names.sort();
+        let root = node_names[0].clone();
+
+        let (parent, order) = rooted_tree(&neighbors, &root)?;
+        let mut local_interner = KeyInterner::<Vec<usize>>::default();
+        let mut local_keys: HashMap<V, Vec<KeyId>> = HashMap::with_capacity(node_names.len());
+        for node in &node_names {
+            let entries = layout
+                .entries_by_node
+                .get(node)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let mut keys = Vec::with_capacity(n_points);
+            for point in 0..n_points {
+                let key = entries
+                    .iter()
+                    .map(|entry| *values.get(&[entry.input_position, point]).unwrap())
+                    .collect::<Vec<_>>();
+                validate_entry_values(entries, &key, "ComponentCostIndex::new")?;
+                keys.push(local_interner.intern(key));
+            }
+            local_keys.insert(node.clone(), keys);
+        }
+
+        let mut component_interner = KeyInterner::<Vec<KeyId>>::default();
+        let mut directed_keys: HashMap<(V, V), Vec<KeyId>> =
+            HashMap::with_capacity(tree.edge_count() * 2);
+
+        for node in order.iter().rev() {
+            let Some(parent_node) = parent.get(node).and_then(Clone::clone) else {
+                continue;
+            };
+            let incoming = neighbors
+                .get(node)
+                .unwrap()
+                .iter()
+                .filter(|neighbor| *neighbor != &parent_node)
+                .map(|neighbor| {
+                    directed_keys
+                        .get(&(neighbor.clone(), node.clone()))
+                        .with_context(|| {
+                            format!(
+                                "ComponentCostIndex::new: missing child key {:?}->{:?}",
+                                neighbor, node
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let keys = intern_component_keys(
+                local_keys.get(node).unwrap(),
+                &incoming,
+                n_points,
+                &mut component_interner,
+            );
+            directed_keys.insert((node.clone(), parent_node), keys);
+        }
+
+        for node in &order {
+            for child in neighbors.get(node).unwrap().iter().filter(|neighbor| {
+                parent.get(*neighbor).and_then(Clone::clone) == Some(node.clone())
+            }) {
+                let incoming = neighbors
+                    .get(node)
+                    .unwrap()
+                    .iter()
+                    .filter(|neighbor| *neighbor != child)
+                    .map(|neighbor| {
+                        directed_keys
+                            .get(&(neighbor.clone(), node.clone()))
+                            .with_context(|| {
+                                format!(
+                                    "ComponentCostIndex::new: missing incoming key {:?}->{:?}",
+                                    neighbor, node
+                                )
+                            })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let keys = intern_component_keys(
+                    local_keys.get(node).unwrap(),
+                    &incoming,
+                    n_points,
+                    &mut component_interner,
+                );
+                directed_keys.insert((node.clone(), child.clone()), keys);
+            }
+        }
+
+        let directed_counts = directed_keys
+            .into_iter()
+            .map(|(edge, keys)| {
+                let count = keys.into_iter().collect::<HashSet<_>>().len();
+                (edge, count)
+            })
+            .collect();
+
+        Ok(Self {
+            neighbors,
+            directed_counts,
+            node_costs: None,
+        })
+    }
+
+    fn all_nodes(&self) -> Vec<V> {
+        let mut nodes: Vec<V> = self.neighbors.keys().cloned().collect();
+        nodes.sort();
+        nodes
+    }
+
+    fn component_count(&self, edge: &(V, V)) -> Option<usize> {
+        self.directed_counts.get(edge).copied()
+    }
+
+    fn center_cost(&self, center: &V) -> Result<usize> {
+        if let Some(node_costs) = &self.node_costs {
+            return node_costs.get(center).copied().ok_or_else(|| {
+                anyhow::anyhow!("center {:?} is not present in cost index", center)
+            });
+        }
+        let neighbors = self
+            .neighbors
+            .get(center)
+            .ok_or_else(|| anyhow::anyhow!("center {:?} is not present in cost index", center))?;
+        neighbors.iter().try_fold(0usize, |acc, neighbor| {
+            self.component_count(&(neighbor.clone(), center.clone()))
+                .map(|count| acc + count)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "missing component cost for directed edge {:?}->{:?}",
+                        neighbor,
+                        center
+                    )
+                })
+        })
+    }
+
+    #[cfg(test)]
+    fn from_parts_for_test(
+        mut neighbors: HashMap<V, Vec<V>>,
+        node_costs: HashMap<V, usize>,
+    ) -> Self {
+        for neighbor_list in neighbors.values_mut() {
+            neighbor_list.sort();
+        }
+        Self {
+            neighbors,
+            directed_counts: HashMap::new(),
+            node_costs: Some(node_costs),
+        }
+    }
+}
+
+fn intern_component_keys(
+    local_keys: &[KeyId],
+    incoming: &[&Vec<KeyId>],
+    n_points: usize,
+    interner: &mut KeyInterner<Vec<KeyId>>,
+) -> Vec<KeyId> {
+    let mut keys = Vec::with_capacity(n_points);
+    for point in 0..n_points {
+        let mut tuple = Vec::with_capacity(1 + incoming.len());
+        tuple.push(local_keys[point]);
+        for incoming_keys in incoming {
+            tuple.push(incoming_keys[point]);
+        }
+        keys.push(interner.intern(tuple));
+    }
+    keys
+}
+
+/// Options controlling cached batch evaluation for [`TreeTN`].
+///
+/// Use this to pin the contraction center or to configure the greedy automatic
+/// center search. When in doubt, leave all fields at their defaults.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::CachedEvaluatorOptions;
+///
+/// let options = CachedEvaluatorOptions::<usize>::default();
+/// assert!(options.center.is_none());
+/// assert!(options.initial_centers.is_empty());
+/// assert!(options.max_greedy_steps_per_start.is_none());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CachedEvaluatorOptions<V> {
+    /// Fixed center node for evaluation.
+    ///
+    /// When set, greedy center search is skipped. Use this when the caller
+    /// already knows where repeated batch structure is concentrated.
+    pub center: Option<V>,
+    /// Candidate starting centers for greedy automatic center search.
+    ///
+    /// Empty means all nodes are eligible as starts. Supplying a short list can
+    /// reduce center-search overhead for large trees.
+    pub initial_centers: Vec<V>,
+    /// Maximum number of greedy moves from each initial center.
+    ///
+    /// `None` means no explicit step limit; the search stops at a local minimum.
+    pub max_greedy_steps_per_start: Option<usize>,
+}
+
+impl<V> Default for CachedEvaluatorOptions<V> {
+    fn default() -> Self {
+        Self {
+            center: None,
+            initial_centers: Vec::new(),
+            max_greedy_steps_per_start: None,
+        }
+    }
+}
+
+/// Result of greedy center search for cached TreeTN evaluation.
+///
+/// The result records the selected node, its estimated cost, and the path taken
+/// by greedy descent from the chosen start.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::CenterSearchResult;
+///
+/// let result = CenterSearchResult {
+///     center: 2_usize,
+///     cost: 7,
+///     path: vec![0, 1, 2],
+/// };
+/// assert_eq!(result.center, 2);
+/// assert_eq!(result.cost, 7);
+/// assert_eq!(result.path.last(), Some(&2));
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CenterSearchResult<V> {
+    /// Selected center node.
+    pub center: V,
+    /// Estimated cache cost at `center`.
+    pub cost: usize,
+    /// Greedy descent path that produced `center`.
+    pub path: Vec<V>,
+}
+
+/// Greedy local search for TreeTN cached-evaluation centers.
+///
+/// This type is intentionally separate from [`TreeTNCachedEvaluator`] so future
+/// center-selection algorithms can share the same cost model.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::GreedyCenterSearch;
+///
+/// let search = GreedyCenterSearch::<usize>::default();
+/// assert!(search.max_steps().is_none());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GreedyCenterSearch<V> {
+    max_steps: Option<usize>,
+    _marker: std::marker::PhantomData<V>,
+}
+
+impl<V> Default for GreedyCenterSearch<V> {
+    fn default() -> Self {
+        Self {
+            max_steps: None,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<V> GreedyCenterSearch<V> {
+    /// Creates a greedy center search with an optional step limit.
+    ///
+    /// `max_steps` limits the number of edge moves from each start. `None`
+    /// searches until no neighbor has lower cost.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::GreedyCenterSearch;
+    ///
+    /// let search = GreedyCenterSearch::<usize>::with_max_steps(Some(3));
+    /// assert_eq!(search.max_steps(), Some(3));
+    /// ```
+    pub fn with_max_steps(max_steps: Option<usize>) -> Self {
+        Self {
+            max_steps,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns the optional greedy-step limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::GreedyCenterSearch;
+    ///
+    /// let search = GreedyCenterSearch::<usize>::with_max_steps(None);
+    /// assert_eq!(search.max_steps(), None);
+    /// ```
+    pub fn max_steps(&self) -> Option<usize> {
+        self.max_steps
+    }
+}
+
+impl<V> GreedyCenterSearch<V>
+where
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    fn search(
+        &self,
+        cost_index: &ComponentCostIndex<V>,
+        starts: &[V],
+    ) -> Result<CenterSearchResult<V>> {
+        let owned_starts;
+        let starts = if starts.is_empty() {
+            owned_starts = cost_index.all_nodes();
+            owned_starts.as_slice()
+        } else {
+            starts
+        };
+        if starts.is_empty() {
+            bail!("GreedyCenterSearch::search: cost index has no nodes");
+        }
+
+        let mut best: Option<CenterSearchResult<V>> = None;
+        for start in starts {
+            if !cost_index.neighbors.contains_key(start) {
+                bail!(
+                    "GreedyCenterSearch::search: initial center {:?} is not present in TreeTN",
+                    start
+                );
+            }
+            let result = self.descend_from(cost_index, start)?;
+            match &best {
+                None => best = Some(result),
+                Some(current) => {
+                    if (result.cost, result.center.clone()) < (current.cost, current.center.clone())
+                    {
+                        best = Some(result);
+                    }
+                }
+            }
+        }
+
+        best.ok_or_else(|| anyhow::anyhow!("GreedyCenterSearch::search: no start centers"))
+    }
+
+    fn descend_from(
+        &self,
+        cost_index: &ComponentCostIndex<V>,
+        start: &V,
+    ) -> Result<CenterSearchResult<V>> {
+        let mut center = start.clone();
+        let mut cost = cost_index.center_cost(&center)?;
+        let mut path = vec![center.clone()];
+        let mut steps = 0usize;
+
+        loop {
+            if self.max_steps.is_some_and(|max_steps| steps >= max_steps) {
+                break;
+            }
+
+            let mut candidates = Vec::new();
+            for neighbor in cost_index.neighbors.get(&center).unwrap() {
+                candidates.push((cost_index.center_cost(neighbor)?, neighbor.clone()));
+            }
+            candidates.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+            let Some((next_cost, next_center)) = candidates.into_iter().next() else {
+                break;
+            };
+            if next_cost >= cost {
+                break;
+            }
+
+            center = next_center;
+            cost = next_cost;
+            path.push(center.clone());
+            steps += 1;
+        }
+
+        Ok(CenterSearchResult { center, cost, path })
+    }
+}
+
+/// Cached batch evaluator for [`TreeTN`].
+///
+/// Use this when many batch points share repeated assignments on subtrees. It
+/// chooses a center node and caches contractions from neighboring components
+/// into that center.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+///
+/// let s = DynIndex::new_dyn(2);
+/// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![4.0_f64, 6.0])?;
+/// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
+/// let values = [0usize, 1usize];
+/// let shape = [1usize, 2usize];
+/// let points = ColMajorArrayRef::new(&values, &shape);
+///
+/// let mut evaluator = TreeTNCachedEvaluator::new(
+///     &tree,
+///     &[s],
+///     CachedEvaluatorOptions::<usize>::default(),
+/// )?;
+/// let result = evaluator.evaluate_batch(points)?;
+/// assert_eq!(result.len(), 2);
+/// assert_eq!(result[0].real(), 4.0);
+/// assert_eq!(result[1].real(), 6.0);
+/// assert_eq!(evaluator.center(), Some(&0));
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+pub struct TreeTNCachedEvaluator<'a, T, V>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    tree: &'a TreeTN<T, V>,
+    layout: EvaluatorLayout<T::Index, V>,
+    options: CachedEvaluatorOptions<V>,
+    center: Option<V>,
+    last_stats: CachedEvaluationStats,
+}
+
+impl<'a, T, V> TreeTNCachedEvaluator<'a, T, V>
+where
+    T: TensorLike,
+    T::Index: Clone + Eq + Hash,
+    <T::Index as IndexLike>::Id: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    /// Creates a cached evaluator for `tree` and the requested physical indices.
+    ///
+    /// If `options.center` is set, that node is used directly. Otherwise, the
+    /// first call to [`Self::evaluate_batch`] chooses a center with greedy search
+    /// using that batch's repeated-subtree structure.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `indices` are not all present in `tree`, when the
+    /// tree is empty, or when a fixed or initial center does not exist.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0])?;
+    /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![5])?;
+    /// let evaluator = TreeTNCachedEvaluator::new(
+    ///     &tree,
+    ///     &[s],
+    ///     CachedEvaluatorOptions { center: Some(5), ..Default::default() },
+    /// )?;
+    /// assert_eq!(evaluator.center(), Some(&5));
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn new(
+        tree: &'a TreeTN<T, V>,
+        indices: &[T::Index],
+        options: CachedEvaluatorOptions<V>,
+    ) -> Result<Self> {
+        let layout = build_layout(tree, indices)?;
+        if let Some(center) = &options.center {
+            ensure_node_exists(tree, center, "TreeTNCachedEvaluator::new: center")?;
+        }
+        for initial_center in &options.initial_centers {
+            ensure_node_exists(
+                tree,
+                initial_center,
+                "TreeTNCachedEvaluator::new: initial center",
+            )?;
+        }
+        let center = options.center.clone();
+        Ok(Self {
+            tree,
+            layout,
+            options,
+            center,
+            last_stats: CachedEvaluationStats::default(),
+        })
+    }
+
+    /// Returns the selected center node, if one has been selected.
+    ///
+    /// A fixed center is available immediately after [`Self::new`]. An automatic
+    /// center is selected during the first [`Self::evaluate_batch`] call.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0])?;
+    /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let mut evaluator = TreeTNCachedEvaluator::new(
+    ///     &tree,
+    ///     &[s],
+    ///     CachedEvaluatorOptions::<usize>::default(),
+    /// )?;
+    /// assert_eq!(evaluator.center(), None);
+    /// let values = [0usize];
+    /// let shape = [1usize, 1usize];
+    /// let _ = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+    /// assert_eq!(evaluator.center(), Some(&0));
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn center(&self) -> Option<&V> {
+        self.center.as_ref()
+    }
+
+    /// Evaluates all batch points using cached subtree environments.
+    ///
+    /// `values` must have shape `[indices.len(), n_points]` in column-major
+    /// layout. The returned vector contains one scalar per column.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values` has the wrong row count, if any site value
+    /// is outside the corresponding index dimension, or if tensor contraction
+    /// fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![4.0_f64, 6.0])?;
+    /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let values = [0usize, 1usize];
+    /// let shape = [1usize, 2usize];
+    /// let mut evaluator = TreeTNCachedEvaluator::new(
+    ///     &tree,
+    ///     &[s],
+    ///     CachedEvaluatorOptions::<usize>::default(),
+    /// )?;
+    /// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+    /// assert_eq!(result.len(), 2);
+    /// assert_eq!(result[0].real(), 4.0);
+    /// assert_eq!(result[1].real(), 6.0);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn evaluate_batch(
+        &mut self,
+        values: ColMajorArrayRef<'_, usize>,
+    ) -> Result<Vec<AnyScalar>> {
+        validate_values_shape(
+            values,
+            self.layout.n_indices,
+            "TreeTNCachedEvaluator::evaluate_batch",
+        )?;
+        let center = self.ensure_center(values)?.clone();
+        let component_batches = self.build_component_batches(&center, values)?;
+        let environment_cache = self.build_environment_cache(&center, &component_batches)?;
+        self.contract_center_for_points(&center, values, &component_batches, &environment_cache)
+    }
+
+    fn ensure_center(&mut self, values: ColMajorArrayRef<'_, usize>) -> Result<&V> {
+        if self.center.is_none() {
+            let cost_index = ComponentCostIndex::from_layout(self.tree, &self.layout, values)?;
+            let search =
+                GreedyCenterSearch::<V>::with_max_steps(self.options.max_greedy_steps_per_start);
+            let result = search.search(&cost_index, &self.options.initial_centers)?;
+            self.center = Some(result.center);
+        }
+        Ok(self.center.as_ref().unwrap())
+    }
+
+    fn build_component_batches(
+        &self,
+        center: &V,
+        values: ColMajorArrayRef<'_, usize>,
+    ) -> Result<Vec<ComponentBatch<T::Index, V>>> {
+        let mut batches = Vec::new();
+        let n_points = values.shape()[1];
+        for neighbor in sorted_neighbors(self.tree)
+            .get(center)
+            .cloned()
+            .unwrap_or_default()
+        {
+            let nodes = component_nodes(self.tree, &neighbor, center)?;
+            let mut entries = Vec::new();
+            for node in &nodes {
+                if let Some(node_entries) = self.layout.entries_by_node.get(node) {
+                    entries.extend(node_entries.iter().cloned());
+                }
+            }
+            entries.sort_by_key(|entry| entry.input_position);
+
+            let mut entry_offsets_by_node: HashMap<V, Vec<(SiteEntry<T::Index>, usize)>> =
+                HashMap::new();
+            for (offset, entry) in entries.iter().cloned().enumerate() {
+                let owner = self
+                    .tree
+                    .site_index_network()
+                    .find_node_by_index(&entry.index)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "TreeTNCachedEvaluator::evaluate_batch: unknown index {:?}",
+                            entry.index
+                        )
+                    })?
+                    .clone();
+                entry_offsets_by_node
+                    .entry(owner)
+                    .or_default()
+                    .push((entry, offset));
+            }
+
+            let mut assignment_ids = HashMap::<ComponentAssignment, usize>::new();
+            let mut assignments = Vec::<ComponentAssignment>::new();
+            let mut point_to_assignment = Vec::with_capacity(n_points);
+            for point in 0..n_points {
+                let assignment = ComponentAssignment {
+                    values: entries
+                        .iter()
+                        .map(|entry| *values.get(&[entry.input_position, point]).unwrap())
+                        .collect(),
+                };
+                validate_entry_values(
+                    &entries,
+                    &assignment.values,
+                    "TreeTNCachedEvaluator::evaluate_batch",
+                )?;
+                let next_id = assignment_ids.len();
+                let assignment_id =
+                    *assignment_ids.entry(assignment.clone()).or_insert_with(|| {
+                        assignments.push(assignment);
+                        next_id
+                    });
+                point_to_assignment.push(assignment_id);
+            }
+
+            batches.push(ComponentBatch {
+                neighbor,
+                nodes,
+                entries,
+                entry_offsets_by_node,
+                point_to_assignment,
+                assignments,
+            });
+        }
+        Ok(batches)
+    }
+
+    fn build_environment_cache(
+        &mut self,
+        center: &V,
+        component_batches: &[ComponentBatch<T::Index, V>],
+    ) -> Result<HashMap<V, Vec<T>>> {
+        let mut cache = HashMap::new();
+        let mut count = 0usize;
+        for batch in component_batches {
+            let mut environments = Vec::with_capacity(batch.assignments.len());
+            for assignment in &batch.assignments {
+                environments.push(self.compute_component_environment(center, batch, assignment)?);
+                count += 1;
+            }
+            cache.insert(batch.neighbor.clone(), environments);
+        }
+        self.last_stats.subtree_environment_count = count;
+        Ok(cache)
+    }
+
+    fn compute_component_environment(
+        &self,
+        _center: &V,
+        batch: &ComponentBatch<T::Index, V>,
+        assignment: &ComponentAssignment,
+    ) -> Result<T> {
+        let mut tensors = Vec::with_capacity(batch.nodes.len());
+        let mut names = Vec::with_capacity(batch.nodes.len());
+        for node in &batch.nodes {
+            let tensor = tensor_for_node(self.tree, node)?;
+            let index_vals = batch
+                .entry_offsets_by_node
+                .get(node)
+                .map(|offsets| {
+                    offsets
+                        .iter()
+                        .map(|(entry, offset)| (entry.index.clone(), assignment.values[*offset]))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            tensors.push(slice_tensor(tensor, &index_vals).with_context(|| {
+                format!(
+                    "TreeTNCachedEvaluator::evaluate_batch: failed to slice component node {:?}",
+                    node
+                )
+            })?);
+            names.push(node.clone());
+        }
+
+        if tensors.len() == 1 {
+            return Ok(tensors.remove(0));
+        }
+
+        TreeTN::<T, V>::from_tensors(tensors, names)
+            .context("TreeTNCachedEvaluator::evaluate_batch: failed to build component TreeTN")?
+            .contract_to_tensor()
+            .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract component")
+    }
+
+    fn contract_center_for_points(
+        &self,
+        center: &V,
+        values: ColMajorArrayRef<'_, usize>,
+        component_batches: &[ComponentBatch<T::Index, V>],
+        environment_cache: &HashMap<V, Vec<T>>,
+    ) -> Result<Vec<AnyScalar>> {
+        let n_points = values.shape()[1];
+        let center_entries = self
+            .layout
+            .entries_by_node
+            .get(center)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let center_tensor = tensor_for_node(self.tree, center)?;
+        let scalar_one = T::scalar_one()
+            .context("TreeTNCachedEvaluator::evaluate_batch: failed to create scalar")?;
+
+        let mut results = Vec::with_capacity(n_points);
+        for point in 0..n_points {
+            let center_index_vals = center_entries
+                .iter()
+                .map(|entry| {
+                    let value = *values.get(&[entry.input_position, point]).unwrap();
+                    (entry.index.clone(), value)
+                })
+                .collect::<Vec<_>>();
+            validate_index_vals(&center_index_vals, "TreeTNCachedEvaluator::evaluate_batch")?;
+            let center_partial = slice_tensor(center_tensor, &center_index_vals)
+                .context("TreeTNCachedEvaluator::evaluate_batch: failed to slice center tensor")?;
+
+            let mut tensor_refs = Vec::with_capacity(1 + component_batches.len());
+            tensor_refs.push(&center_partial);
+            for batch in component_batches {
+                let assignment_id = batch.point_to_assignment[point];
+                let environment = environment_cache
+                    .get(&batch.neighbor)
+                    .and_then(|environments| environments.get(assignment_id))
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "TreeTNCachedEvaluator::evaluate_batch: missing cached environment"
+                        )
+                    })?;
+                tensor_refs.push(environment);
+            }
+
+            let result_tensor = T::contract(&tensor_refs, AllowedPairs::All)
+                .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center")?;
+            results.push(
+                scalar_one
+                    .inner_product(&result_tensor)
+                    .context("TreeTNCachedEvaluator::evaluate_batch: failed to extract scalar")?,
+            );
+        }
+
+        Ok(results)
+    }
+
+    #[cfg(test)]
+    fn stats_for_test(&self) -> CachedEvaluationStats {
+        self.last_stats.clone()
+    }
+}
+
+fn build_layout<T, V>(
+    tree: &TreeTN<T, V>,
+    indices: &[T::Index],
+) -> Result<EvaluatorLayout<T::Index, V>>
+where
+    T: TensorLike,
+    T::Index: Clone + Eq + Hash,
+    <T::Index as IndexLike>::Id: Ord,
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    if tree.node_count() == 0 {
+        bail!("TreeTNCachedEvaluator::new: network must have at least one node");
+    }
+
+    let total_site_indices = tree.site_index_network().site_index_count();
+    anyhow::ensure!(
+        indices.len() == total_site_indices,
+        "TreeTNCachedEvaluator::new: indices.len() ({}) != total site indices ({})",
+        indices.len(),
+        total_site_indices
+    );
+
+    let mut seen = HashSet::with_capacity(indices.len());
+    for index in indices {
+        anyhow::ensure!(
+            seen.insert(index.clone()),
+            "TreeTNCachedEvaluator::new: duplicate index {:?}",
+            index
+        );
+    }
+
+    let mut entries_by_node: HashMap<V, Vec<SiteEntry<T::Index>>> = HashMap::new();
+    let mut tensor_indices_by_node: HashMap<V, Vec<T::Index>> = HashMap::new();
+    for (input_position, index) in indices.iter().enumerate() {
+        let node_name = tree
+            .site_index_network()
+            .find_node_by_index(index)
+            .ok_or_else(|| {
+                anyhow::anyhow!("TreeTNCachedEvaluator::new: unknown index {:?}", index)
+            })?
+            .clone();
+        let tensor = tensor_for_node(tree, &node_name)?;
+        let tensor_indices = tensor_indices_by_node
+            .entry(node_name.clone())
+            .or_insert_with(|| tensor.external_indices());
+        let local_axis = tensor_indices
+            .iter()
+            .position(|tensor_index| tensor_index == index)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::new: site index {:?} is registered on node {:?} but not present in its tensor",
+                    index,
+                    node_name
+                )
+            })?;
+        entries_by_node
+            .entry(node_name)
+            .or_default()
+            .push(SiteEntry {
+                index: index.clone(),
+                input_position,
+                local_axis,
+            });
+    }
+
+    for entries in entries_by_node.values_mut() {
+        entries.sort_by_key(|entry| entry.local_axis);
+    }
+
+    Ok(EvaluatorLayout {
+        entries_by_node,
+        n_indices: indices.len(),
+    })
+}
+
+fn validate_values_shape(
+    values: ColMajorArrayRef<'_, usize>,
+    n_indices: usize,
+    context: &str,
+) -> Result<()> {
+    anyhow::ensure!(
+        values.shape().len() == 2,
+        "{context}: values must be 2D, got {}D",
+        values.shape().len()
+    );
+    anyhow::ensure!(
+        values.shape()[0] == n_indices,
+        "{context}: row count {} does not match indices.len() {}",
+        values.shape()[0],
+        n_indices
+    );
+    Ok(())
+}
+
+fn validate_entry_values<I>(entries: &[SiteEntry<I>], values: &[usize], context: &str) -> Result<()>
+where
+    I: IndexLike,
+{
+    let index_vals = entries
+        .iter()
+        .zip(values.iter().copied())
+        .map(|(entry, value)| (entry.index.clone(), value))
+        .collect::<Vec<_>>();
+    validate_index_vals(&index_vals, context)
+}
+
+fn validate_index_vals<I>(index_vals: &[(I, usize)], context: &str) -> Result<()>
+where
+    I: IndexLike,
+{
+    for (index, value) in index_vals {
+        anyhow::ensure!(
+            *value < index.dim(),
+            "{context}: coordinate {} is out of range for index {:?} with dim {}",
+            value,
+            index,
+            index.dim()
+        );
+    }
+    Ok(())
+}
+
+fn ensure_node_exists<T, V>(tree: &TreeTN<T, V>, node: &V, context: &str) -> Result<()>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Debug + Send + Sync,
+{
+    if tree.node_index(node).is_none() {
+        bail!("{context} {:?} is not present in TreeTN", node);
+    }
+    Ok(())
+}
+
+fn tensor_for_node<'a, T, V>(tree: &'a TreeTN<T, V>, node: &V) -> Result<&'a T>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Debug + Send + Sync,
+{
+    let node_idx = tree
+        .node_index(node)
+        .ok_or_else(|| anyhow::anyhow!("node {:?} is not present in TreeTN", node))?;
+    tree.tensor(node_idx)
+        .ok_or_else(|| anyhow::anyhow!("tensor for node {:?} is not present", node))
+}
+
+fn slice_tensor<T>(tensor: &T, index_vals: &[(T::Index, usize)]) -> Result<T>
+where
+    T: TensorLike,
+{
+    if index_vals.is_empty() {
+        return Ok(tensor.clone());
+    }
+    validate_index_vals(index_vals, "slice_tensor")?;
+    let onehot = T::onehot(index_vals)?;
+    T::contract(&[tensor, &onehot], AllowedPairs::All)
+}
+
+fn sorted_neighbors<T, V>(tree: &TreeTN<T, V>) -> HashMap<V, Vec<V>>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    let mut map = HashMap::new();
+    let mut node_names = tree.node_names();
+    node_names.sort();
+    for node in node_names {
+        let mut neighbors: Vec<V> = tree.site_index_network().neighbors(&node).collect();
+        neighbors.sort();
+        map.insert(node, neighbors);
+    }
+    map
+}
+
+fn rooted_tree<V>(
+    neighbors: &HashMap<V, Vec<V>>,
+    root: &V,
+) -> Result<(HashMap<V, Option<V>>, Vec<V>)>
+where
+    V: Clone + Eq + Hash + Ord + Debug,
+{
+    let mut parent = HashMap::<V, Option<V>>::new();
+    let mut order = Vec::<V>::new();
+    let mut stack = vec![(root.clone(), None)];
+    while let Some((node, parent_node)) = stack.pop() {
+        if parent.contains_key(&node) {
+            continue;
+        }
+        parent.insert(node.clone(), parent_node.clone());
+        order.push(node.clone());
+        let mut children = neighbors
+            .get(&node)
+            .ok_or_else(|| anyhow::anyhow!("node {:?} is missing from neighbor map", node))?
+            .iter()
+            .filter(|neighbor| Some(*neighbor) != parent_node.as_ref())
+            .cloned()
+            .collect::<Vec<_>>();
+        children.sort_by(|a, b| b.cmp(a));
+        for child in children {
+            stack.push((child, Some(node.clone())));
+        }
+    }
+
+    anyhow::ensure!(
+        parent.len() == neighbors.len(),
+        "TreeTN topology is disconnected: reached {} of {} nodes",
+        parent.len(),
+        neighbors.len()
+    );
+    Ok((parent, order))
+}
+
+fn component_nodes<T, V>(tree: &TreeTN<T, V>, start: &V, blocked: &V) -> Result<Vec<V>>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
+{
+    let neighbors = sorted_neighbors(tree);
+    let mut nodes = Vec::new();
+    let mut seen = HashSet::new();
+    let mut stack = vec![start.clone()];
+    while let Some(node) = stack.pop() {
+        if &node == blocked || !seen.insert(node.clone()) {
+            continue;
+        }
+        nodes.push(node.clone());
+        for neighbor in neighbors.get(&node).cloned().unwrap_or_default() {
+            if &neighbor != blocked && !seen.contains(&neighbor) {
+                stack.push(neighbor);
+            }
+        }
+    }
+    nodes.sort();
+    Ok(nodes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+
+    fn assert_scalars_close(actual: &[AnyScalar], expected: &[AnyScalar]) {
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
+            assert!(
+                (actual.real() - expected.real()).abs() < 1.0e-12,
+                "actual={} expected={}",
+                actual.real(),
+                expected.real()
+            );
+        }
+    }
+
+    fn two_node_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+        let s0 = DynIndex::new_dyn(2);
+        let bond = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+
+        let t0 =
+            TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0_f64, 2.0, 3.0, 4.0])
+                .unwrap();
+        let t1 =
+            TensorDynLen::from_dense(vec![bond, s1.clone()], vec![0.5_f64, 1.5, 2.5, 3.5]).unwrap();
+
+        let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+        (tree, vec![s0, s1])
+    }
+
+    fn three_node_chain() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+        let s0 = DynIndex::new_dyn(2);
+        let b01 = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+        let b12 = DynIndex::new_dyn(2);
+        let s2 = DynIndex::new_dyn(2);
+
+        let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0_f64; 4]).unwrap();
+        let t1 =
+            TensorDynLen::from_dense(vec![b01, s1.clone(), b12.clone()], vec![1.0_f64; 8]).unwrap();
+        let t2 = TensorDynLen::from_dense(vec![b12, s2.clone()], vec![1.0_f64; 4]).unwrap();
+        let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap();
+        (tree, vec![s0, s1, s2])
+    }
+
+    fn star_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+        let sc = DynIndex::new_dyn(2);
+        let s0 = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+        let s2 = DynIndex::new_dyn(2);
+        let b0 = DynIndex::new_dyn(2);
+        let b1 = DynIndex::new_dyn(2);
+        let b2 = DynIndex::new_dyn(2);
+        let center_data: Vec<f64> = (0..16).map(|value| value as f64 + 1.0).collect();
+        let center = TensorDynLen::from_dense(
+            vec![sc.clone(), b0.clone(), b1.clone(), b2.clone()],
+            center_data,
+        )
+        .unwrap();
+        let leaf0 =
+            TensorDynLen::from_dense(vec![b0, s0.clone()], vec![1.0_f64, 0.5, 1.5, 2.0]).unwrap();
+        let leaf1 =
+            TensorDynLen::from_dense(vec![b1, s1.clone()], vec![0.25_f64, 1.0, 1.25, 2.0]).unwrap();
+        let leaf2 =
+            TensorDynLen::from_dense(vec![b2, s2.clone()], vec![2.0_f64, 1.0, 0.75, 1.5]).unwrap();
+        let tree =
+            TreeTN::<_, usize>::from_tensors(vec![center, leaf0, leaf1, leaf2], vec![0, 1, 2, 3])
+                .unwrap();
+        (tree, vec![sc, s0, s1, s2])
+    }
+
+    #[test]
+    fn cached_evaluator_matches_tree_evaluate_on_two_node_chain() {
+        let (tree, indices) = two_node_tree();
+        let values = vec![0, 0, 1, 0, 0, 1, 1, 1];
+        let shape = [2, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let options = CachedEvaluatorOptions {
+            center: Some(0),
+            ..CachedEvaluatorOptions::default()
+        };
+        let mut evaluator = TreeTNCachedEvaluator::new(&tree, &indices, options).unwrap();
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+        assert_eq!(evaluator.center(), Some(&0));
+    }
+
+    #[test]
+    fn component_cost_index_counts_unique_directed_components() {
+        let (tree, indices) = three_node_chain();
+        let values = vec![0, 0, 0, 0, 1, 1, 1, 1, 1];
+        let shape = [3, 3];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let cost_index = ComponentCostIndex::new(&tree, &indices, points).unwrap();
+
+        assert_eq!(cost_index.component_count(&(0, 1)).unwrap(), 2);
+        assert_eq!(cost_index.component_count(&(1, 0)).unwrap(), 2);
+        assert_eq!(cost_index.component_count(&(1, 2)).unwrap(), 3);
+        assert_eq!(cost_index.component_count(&(2, 1)).unwrap(), 2);
+        assert_eq!(cost_index.center_cost(&0).unwrap(), 2);
+        assert_eq!(cost_index.center_cost(&1).unwrap(), 4);
+        assert_eq!(cost_index.center_cost(&2).unwrap(), 3);
+    }
+
+    #[test]
+    fn component_cost_index_rejects_wrong_batch_row_count() {
+        let (tree, indices) = three_node_chain();
+        let values = vec![0, 1, 1, 0];
+        let shape = [2, 2];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let err = ComponentCostIndex::new(&tree, &indices, points)
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("row count"));
+    }
+
+    #[test]
+    fn greedy_center_search_descends_to_lower_cost_neighbor() {
+        let cost_index = ComponentCostIndex::from_parts_for_test(
+            HashMap::from([(0, vec![1]), (1, vec![0, 2]), (2, vec![1, 3]), (3, vec![2])]),
+            HashMap::from([(0, 40), (1, 20), (2, 10), (3, 15)]),
+        );
+
+        let result = GreedyCenterSearch::<usize>::default()
+            .search(&cost_index, &[0])
+            .unwrap();
+
+        assert_eq!(result.center, 2);
+        assert_eq!(result.cost, 10);
+        assert_eq!(result.path, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn greedy_center_search_uses_best_of_multiple_starts() {
+        let cost_index = ComponentCostIndex::from_parts_for_test(
+            HashMap::from([
+                ("a", vec!["b"]),
+                ("b", vec!["a", "c"]),
+                ("c", vec!["b", "d"]),
+                ("d", vec!["c"]),
+            ]),
+            HashMap::from([("a", 8), ("b", 6), ("c", 5), ("d", 2)]),
+        );
+
+        let result = GreedyCenterSearch::<&str>::with_max_steps(Some(1))
+            .search(&cost_index, &["a", "d"])
+            .unwrap();
+
+        assert_eq!(result.center, "d");
+        assert_eq!(result.cost, 2);
+    }
+
+    #[test]
+    fn cached_evaluator_selects_greedy_center_when_center_is_not_fixed() {
+        let (tree, indices) = three_node_chain();
+        let values = vec![0, 0, 0, 0, 1, 1, 1, 1, 1];
+        let shape = [3, 3];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                initial_centers: vec![1],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_eq!(evaluator.center(), Some(&0));
+        assert_scalars_close(&actual, &expected);
+    }
+
+    #[test]
+    fn cached_evaluator_rejects_unknown_initial_center() {
+        let (tree, indices) = three_node_chain();
+        let err = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                initial_centers: vec![99],
+                ..Default::default()
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert!(err.to_string().contains("initial center"));
+    }
+
+    #[test]
+    fn cached_evaluator_computes_one_environment_per_unique_subtree_assignment() {
+        let (tree, indices) = three_node_chain();
+        let values = vec![0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1];
+        let shape = [3, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+        assert_eq!(evaluator.stats_for_test().subtree_environment_count, 4);
+    }
+
+    #[test]
+    fn cached_evaluator_rejects_wrong_value_row_count() {
+        let (tree, indices) = two_node_tree();
+        let values = vec![0, 1, 1];
+        let shape = [1, 3];
+        let points = ColMajorArrayRef::new(&values, &shape);
+        let mut evaluator =
+            TreeTNCachedEvaluator::new(&tree, &indices, CachedEvaluatorOptions::default()).unwrap();
+
+        let err = evaluator.evaluate_batch(points).unwrap_err();
+        assert!(err.to_string().contains("row count"));
+    }
+
+    #[test]
+    fn cached_evaluator_rejects_out_of_range_site_value() {
+        let (tree, indices) = two_node_tree();
+        let values = vec![0, 2];
+        let shape = [2, 1];
+        let points = ColMajorArrayRef::new(&values, &shape);
+        let mut evaluator =
+            TreeTNCachedEvaluator::new(&tree, &indices, CachedEvaluatorOptions::default()).unwrap();
+
+        let err = evaluator.evaluate_batch(points).unwrap_err();
+        assert!(err.to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn cached_evaluator_handles_repeated_points_without_changing_order() {
+        let (tree, indices) = two_node_tree();
+        let values = vec![0, 0, 1, 1, 0, 0, 1, 1];
+        let shape = [2, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator =
+            TreeTNCachedEvaluator::new(&tree, &indices, CachedEvaluatorOptions::default()).unwrap();
+
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+        assert_eq!(actual[0].real(), actual[2].real());
+        assert_eq!(actual[1].real(), actual[3].real());
+    }
+
+    #[test]
+    fn cached_evaluator_matches_tree_evaluate_on_star_tree() {
+        let (tree, indices) = star_tree();
+        let values = vec![
+            0, 0, 0, 0, //
+            1, 0, 1, 0, //
+            0, 1, 0, 1, //
+            1, 1, 1, 1,
+        ];
+        let shape = [4, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+    }
+}

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -7,6 +7,7 @@
 #![allow(dead_code)]
 
 mod addition;
+mod cached_evaluator;
 mod canonicalize;
 pub mod contraction;
 mod decompose;
@@ -40,6 +41,11 @@ use crate::site_index_network::SiteIndexNetwork;
 
 // Re-export the decomposition functions and types
 pub use decompose::{factorize_tensor_to_treetn, factorize_tensor_to_treetn_with, TreeTopology};
+
+// Re-export cached evaluator types
+pub use cached_evaluator::{
+    CachedEvaluatorOptions, CenterSearchResult, GreedyCenterSearch, TreeTNCachedEvaluator,
+};
 
 // Re-export evaluator types
 pub use evaluator::TreeTNEvaluator;

--- a/docs/plans/2026-05-14-treetn-cached-evaluator-design.md
+++ b/docs/plans/2026-05-14-treetn-cached-evaluator-design.md
@@ -1,0 +1,218 @@
+# TreeTN Cached Evaluator Design
+
+## Goal
+
+Add an allocation-light TreeTN batch evaluator that extends the `TTCache::evaluate_many` idea from chain tensor trains to arbitrary tree topologies. The evaluator should reuse subtree environments across repeated batch points, choose a useful center automatically, and include benchmarks that compare scaling against the chain `TTCache` baseline.
+
+This design primarily addresses issue #464. It also provides the efficient approximate-evaluation building block needed by TreeTCI global pivot search in issues #380 and #383.
+
+## Context
+
+`TreeTN::evaluate` already accepts a column-major batch coordinate array and returns one scalar per point. Internally, however, `TreeTNEvaluator::evaluate_batch` loops over points and each point builds one-hot tensors, contracts each local tensor with those one-hots, constructs a temporary `TreeTN`, and contracts that temporary network to a scalar.
+
+`tensor4all-simplett::TTCache` is more efficient for chain tensor trains. It caches left and right partial contractions, groups repeated left and right index assignments in a batch, and evaluates each point by combining cached environments. The TreeTN version should preserve that scaling property for chains while supporting general trees.
+
+## Non-Goals
+
+- Do not change `TreeTN::evaluate` semantics in the first pass.
+- Do not implement center-edge evaluation unless benchmarks show center-node evaluation is insufficient.
+- Do not add dense full-network materialization to production evaluation paths.
+- Do not introduce row-major batch layout. Batch coordinates remain column-major with shape `[n_sites, n_points]`.
+
+## API Shape
+
+Add a new reusable evaluator in `tensor4all-treetn`, separate from the current point-loop evaluator:
+
+```rust
+pub struct TreeTNCachedEvaluator<T, V>
+where
+    T: TensorLike,
+{
+    center: V,
+    // private precomputed node/site/topology data
+}
+
+impl<T, V> TreeTNCachedEvaluator<T, V>
+where
+    T: TensorLike,
+{
+    pub fn new(tree: &TreeTN<T, V>, indices: &[T::Index], options: CachedEvaluatorOptions<V>) -> Result<Self>;
+
+    pub fn center(&self) -> &V;
+
+    pub fn evaluate_batch(&mut self, values: ColMajorArrayRef<'_, usize>) -> Result<Vec<AnyScalar>>;
+}
+```
+
+Add an options type:
+
+```rust
+pub struct CachedEvaluatorOptions<V> {
+    pub center: Option<V>,
+    pub initial_centers: Vec<V>,
+    pub max_greedy_steps_per_start: Option<usize>,
+}
+```
+
+When `center` is provided, the evaluator uses it directly. When it is absent, it runs greedy center search from `initial_centers`. A later helper can populate deterministic default starts from the canonical center, minimum node name, diameter endpoints, and diameter midpoint.
+
+Keep `TreeTNEvaluator` unchanged in this first pass. The cached evaluator is a new API so existing behavior remains stable.
+
+## Center Cost Model
+
+Given a batch with `B` points and a TreeTN with `N` tensor nodes, define a directed edge component count:
+
+```text
+component_count[(u, v)] =
+    number of unique batch assignments restricted to the component containing u
+    after removing edge u-v
+```
+
+For a center node `c`, define:
+
+```text
+center_cost(c) = sum over neighbors n of c: component_count[(n, c)]
+```
+
+This approximates the number of unique subtree environments that must be computed and cached when all environments are collected into `c`.
+
+The scaling target for center search is:
+
+```text
+precompute: O(B * N)
+greedy:     O(S * H * average_degree), with no batch rescan
+memory:     O(B * N) or lower
+```
+
+where `S` is the number of initial centers and `H` is the number of greedy steps per start. The implementation must avoid recomputing full batch projections for every center candidate, which would be `O(B * N^2)` on large trees.
+
+## Component Cost Index
+
+Introduce an internal precomputed structure:
+
+```rust
+struct ComponentCostIndex<V> {
+    counts: HashMap<(V, V), usize>,
+}
+```
+
+It exposes:
+
+```rust
+fn component_count(&self, from: &V, to: &V) -> Option<usize>;
+fn center_cost(&self, center: &V, topology: &NodeNameNetwork<V>) -> Result<usize>;
+```
+
+The construction should read the batch coordinates a bounded number of times and produce all directed edge component counts. A straightforward first implementation may be clearer than maximally optimized code, but it must not perform an independent full projection scan per candidate center.
+
+## Greedy Center Search
+
+Keep greedy search separate from evaluator construction:
+
+```rust
+pub struct GreedyCenterSearch<V> {
+    pub initial_centers: Vec<V>,
+    pub max_steps_per_start: Option<usize>,
+}
+
+pub struct CenterSearchResult<V> {
+    pub center: V,
+    pub cost: usize,
+    pub start: V,
+    pub steps: usize,
+}
+```
+
+For each start:
+
+```text
+c = start
+loop:
+    current = center_cost(c)
+    best = neighbor of c with minimum center_cost(neighbor)
+    if center_cost(best) < current:
+        c = best
+    else:
+        stop
+```
+
+Return the terminal result with the lowest cost across all starts. Tie-breaking must be deterministic, using node ordering where available.
+
+This search is a heuristic. It can stop at a local minimum, so the API should keep the initial-center list explicit. Tests should cover multi-start behavior rather than claiming global optimality.
+
+## Cached Evaluation Algorithm
+
+The cached evaluator stores node ownership, local site-axis mapping, topology, and selected center. It evaluates a batch as follows:
+
+1. Validate `values` has shape `[input_count, n_points]`.
+2. For each neighbor subtree of the center:
+   - Project each batch point to the site rows in that subtree.
+   - Deduplicate projected assignments.
+   - Compute one environment tensor per unique assignment.
+   - Store a mapping from point index to unique environment index.
+3. For the center node:
+   - Slice or contract the center tensor according to center-owned site coordinates for each point.
+   - Combine the center slice with the cached neighbor environments to produce a scalar.
+
+The cache key must be based on full site assignment values for the relevant subtree. It does not need to persist across unrelated TreeTN objects. A single evaluator may retain its environment cache between calls when the same assignments recur.
+
+## Correctness Requirements
+
+- Results must match `TreeTN::evaluate` for:
+  - one-node networks,
+  - two-node chains,
+  - longer chains,
+  - star trees,
+  - balanced trees.
+- Batch coordinate layout must remain column-major.
+- Site index identity must use full `Index` equality, not index IDs.
+- Invalid values shape, duplicate indices, missing indices, unknown center, and out-of-range coordinates must return errors.
+- Tests should compare whole result vectors against the existing evaluator for small networks.
+
+## Benchmark Requirements
+
+Add benchmark coverage that demonstrates both absolute runtime and size dependence:
+
+- Chain `TensorTrain` evaluated by `TTCache::evaluate_many`.
+- Equivalent linear-chain `TreeTN` evaluated by `TreeTNCachedEvaluator`.
+- Current `TreeTN::evaluate` as the allocation-heavy baseline.
+- Optional star and balanced-tree cases to show non-chain behavior.
+
+Use sizes such as:
+
+```text
+N in {16, 32, 64, 128}
+B in {100, 1_000, 10_000}
+physical_dim = 2
+controlled bond dimension
+TCI-like batches with repeated subtree assignments
+```
+
+Acceptance criteria:
+
+- Linear-chain `TreeTNCachedEvaluator` should show the same qualitative scaling as `TTCache::evaluate_many`.
+- Current `TreeTN::evaluate` should be visibly worse for large `B` because it allocates per point.
+- Center search overhead should be small compared with cached evaluation for large batches.
+- Benchmark output should include Criterion medians or equivalent timing tables for `N` and `B` dependence.
+
+## Test Strategy
+
+Use test-driven development. Start with a failing behavior test that calls the planned public cached evaluator API on a small chain and compares against `TreeTN::evaluate`. Then add tests for center selection and error paths before broadening to more topologies.
+
+Focused verification commands:
+
+```bash
+cargo test --release -p tensor4all-treetn treetn::cached_evaluator
+cargo bench -p tensor4all-treetn --bench cached_evaluator
+cargo test --release -p tensor4all-simplett cache
+```
+
+Full pre-PR verification remains the repository standard:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --release --workspace
+cargo doc --workspace --no-deps
+```

--- a/docs/plans/2026-05-14-treetn-cached-evaluator-plan.md
+++ b/docs/plans/2026-05-14-treetn-cached-evaluator-plan.md
@@ -1,0 +1,1161 @@
+# TreeTN Cached Evaluator Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a cached batch evaluator for `TreeTN` with greedy center selection, correctness tests, and benchmarks comparing TreeTN chain performance with `TTCache`.
+
+**Architecture:** The implementation adds a public `TreeTNCachedEvaluator` API under `treetn::cached_evaluator`. Center selection is separated into a reusable greedy search over an internal component-cost index, and evaluation caches subtree environments for repeated batch restrictions around the selected center. Benchmarks compare current uncached `TreeTN::evaluate`, new cached TreeTN evaluation on a linear tree, and `TTCache::evaluate_many`.
+
+**Tech Stack:** Rust, `tensor4all-core` tensor abstractions, existing `TreeTN`/`TreeTNEvaluator`, `tensor4all-simplett::cache::TTCache`, `criterion`, `cargo nextest`.
+
+---
+
+### Task 1: Add the public API shape with a failing correctness test
+
+**Files:**
+- Create: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/mod.rs`
+- Modify: `crates/tensor4all-treetn/src/lib.rs`
+
+**Step 1: Write the failing test**
+
+Add this test module at the bottom of `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+    use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen, TensorLike};
+
+    fn two_node_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+        let s0 = DynIndex::new_dyn(2);
+        let bond = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+
+        let t0 = TensorDynLen::from_dense(
+            vec![s0.clone(), bond.clone()],
+            vec![1.0_f64, 2.0, 3.0, 4.0],
+        )
+        .unwrap();
+        let t1 = TensorDynLen::from_dense(
+            vec![bond.clone(), s1.clone()],
+            vec![0.5_f64, 1.5, 2.5, 3.5],
+        )
+        .unwrap();
+
+        let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+        (tree, vec![s0, s1])
+    }
+
+    #[test]
+    fn cached_evaluator_matches_tree_evaluate_on_two_node_chain() {
+        let (tree, indices) = two_node_tree();
+        let values = vec![0, 0, 1, 0, 0, 1, 1, 1];
+        let points = ColMajorArrayRef::new(&values, &[2, 4]).unwrap();
+
+        let expected = tree.evaluate(&indices, points.clone()).unwrap();
+        let options = CachedEvaluatorOptions {
+            center: Some(0),
+            ..CachedEvaluatorOptions::default()
+        };
+        let mut evaluator = TreeTNCachedEvaluator::new(&tree, &indices, options).unwrap();
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
+            assert_abs_diff_eq!(actual.real(), expected.real(), epsilon = 1e-12);
+        }
+        assert_eq!(evaluator.center(), &0);
+    }
+}
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator_matches_tree_evaluate_on_two_node_chain
+```
+
+Expected: FAIL to compile because `cached_evaluator`, `TreeTNCachedEvaluator`, and `CachedEvaluatorOptions` do not exist.
+
+**Step 3: Add the minimal public module and fallback implementation**
+
+In `crates/tensor4all-treetn/src/treetn/mod.rs`, add:
+
+```rust
+mod cached_evaluator;
+pub use cached_evaluator::{
+    CachedEvaluatorOptions, CenterSearchResult, GreedyCenterSearch, TreeTNCachedEvaluator,
+};
+```
+
+In `crates/tensor4all-treetn/src/lib.rs`, add these names to the existing `pub use treetn::{ ... }` list:
+
+```rust
+CachedEvaluatorOptions,
+CenterSearchResult,
+GreedyCenterSearch,
+TreeTNCachedEvaluator,
+```
+
+Create `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` with the minimal API and rustdoc:
+
+```rust
+//! Cached batch evaluation for tree tensor networks.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use anyhow::{bail, Result};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, TensorLike};
+
+use super::{TreeTN, TreeTNEvaluator};
+
+/// Options controlling cached batch evaluation for [`TreeTN`].
+///
+/// Use this to pin the contraction center or to configure the greedy automatic
+/// center search. When in doubt, leave all fields at their defaults.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::CachedEvaluatorOptions;
+///
+/// let options = CachedEvaluatorOptions::<usize>::default();
+/// assert!(options.center.is_none());
+/// assert!(options.initial_centers.is_empty());
+/// assert!(options.max_greedy_steps_per_start.is_none());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CachedEvaluatorOptions<V> {
+    /// Fixed center node for evaluation.
+    ///
+    /// When set, greedy center search is skipped. Use this when the caller
+    /// already knows where repeated batch structure is concentrated.
+    pub center: Option<V>,
+    /// Candidate starting centers for greedy automatic center search.
+    ///
+    /// Empty means all nodes are eligible as starts. Supplying a short list
+    /// can reduce center-search overhead for large trees.
+    pub initial_centers: Vec<V>,
+    /// Maximum number of greedy moves from each initial center.
+    ///
+    /// `None` means no explicit step limit; the search stops at a local minimum.
+    pub max_greedy_steps_per_start: Option<usize>,
+}
+
+impl<V> Default for CachedEvaluatorOptions<V> {
+    fn default() -> Self {
+        Self {
+            center: None,
+            initial_centers: Vec::new(),
+            max_greedy_steps_per_start: None,
+        }
+    }
+}
+
+/// Result of greedy center search for cached TreeTN evaluation.
+///
+/// The result records the selected node, its estimated cost, and the path taken
+/// by greedy descent from the chosen start.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::CenterSearchResult;
+///
+/// let result = CenterSearchResult {
+///     center: 2_usize,
+///     cost: 7,
+///     path: vec![0, 1, 2],
+/// };
+/// assert_eq!(result.center, 2);
+/// assert_eq!(result.cost, 7);
+/// assert_eq!(result.path.last(), Some(&2));
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CenterSearchResult<V> {
+    /// Selected center node.
+    pub center: V,
+    /// Estimated cache cost at `center`.
+    pub cost: usize,
+    /// Greedy descent path that produced `center`.
+    pub path: Vec<V>,
+}
+
+/// Greedy local search for TreeTN cached-evaluation centers.
+///
+/// This type is intentionally separate from [`TreeTNCachedEvaluator`] so future
+/// center-selection algorithms can share the same cost model.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::GreedyCenterSearch;
+///
+/// let search = GreedyCenterSearch::<usize>::default();
+/// assert!(search.max_steps().is_none());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GreedyCenterSearch<V> {
+    max_steps: Option<usize>,
+    _marker: std::marker::PhantomData<V>,
+}
+
+impl<V> Default for GreedyCenterSearch<V> {
+    fn default() -> Self {
+        Self {
+            max_steps: None,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<V> GreedyCenterSearch<V> {
+    /// Creates a greedy center search with an optional step limit.
+    ///
+    /// `max_steps` limits the number of edge moves from each start. `None`
+    /// searches until no neighbor has lower cost.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::GreedyCenterSearch;
+    ///
+    /// let search = GreedyCenterSearch::<usize>::with_max_steps(Some(3));
+    /// assert_eq!(search.max_steps(), Some(3));
+    /// ```
+    pub fn with_max_steps(max_steps: Option<usize>) -> Self {
+        Self {
+            max_steps,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns the optional greedy-step limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_treetn::GreedyCenterSearch;
+    ///
+    /// let search = GreedyCenterSearch::<usize>::with_max_steps(None);
+    /// assert_eq!(search.max_steps(), None);
+    /// ```
+    pub fn max_steps(&self) -> Option<usize> {
+        self.max_steps
+    }
+}
+
+/// Cached batch evaluator for [`TreeTN`].
+///
+/// Use this when many batch points share repeated assignments on subtrees. It
+/// chooses a center node and caches contractions from neighboring components
+/// into that center.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen, TensorLike};
+/// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+///
+/// let s0 = DynIndex::new_dyn(2);
+/// let s1 = DynIndex::new_dyn(2);
+/// let t0 = TensorDynLen::from_dense(vec![s0.clone()], vec![2.0_f64, 3.0]).unwrap();
+/// let t1 = TensorDynLen::from_dense(vec![s1.clone()], vec![5.0_f64, 7.0]).unwrap();
+/// let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+/// let indices = vec![s0, s1];
+/// let values = vec![0, 0, 1, 1];
+/// let points = ColMajorArrayRef::new(&values, &[2, 2]).unwrap();
+///
+/// let mut evaluator = TreeTNCachedEvaluator::new(
+///     &tree,
+///     &indices,
+///     CachedEvaluatorOptions { center: Some(0), ..Default::default() },
+/// ).unwrap();
+/// let result = evaluator.evaluate_batch(points).unwrap();
+/// assert_eq!(result.len(), 2);
+/// assert_eq!(evaluator.center(), &0);
+/// ```
+pub struct TreeTNCachedEvaluator<'a, T, V>
+where
+    T: TensorLike,
+{
+    evaluator: TreeTNEvaluator<'a, T, V>,
+    center: V,
+}
+
+impl<'a, T, V> TreeTNCachedEvaluator<'a, T, V>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Ord + Debug,
+{
+    /// Creates a cached evaluator for `tree` and the requested physical indices.
+    ///
+    /// If `options.center` is set, that node is used directly. Otherwise, this
+    /// initially uses the first tree node; later tasks replace this fallback with
+    /// greedy center selection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `indices` are not all present in `tree`, when the
+    /// tree is empty, or when a fixed center does not exist in the tree.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();
+    /// let tree = TreeTN::<_, usize>::from_tensors(vec![t], vec![5]).unwrap();
+    /// let evaluator = TreeTNCachedEvaluator::new(
+    ///     &tree,
+    ///     &[s],
+    ///     CachedEvaluatorOptions { center: Some(5), ..Default::default() },
+    /// ).unwrap();
+    /// assert_eq!(evaluator.center(), &5);
+    /// ```
+    pub fn new(
+        tree: &'a TreeTN<T, V>,
+        indices: &[T::Index],
+        options: CachedEvaluatorOptions<V>,
+    ) -> Result<Self> {
+        let evaluator = TreeTNEvaluator::new(tree, indices)?;
+        let center = if let Some(center) = options.center {
+            if !tree.contains_node(&center) {
+                bail!("center node {:?} is not present in TreeTN", center);
+            }
+            center
+        } else {
+            tree.node_names()
+                .into_iter()
+                .next()
+                .ok_or_else(|| anyhow::anyhow!("cannot create cached evaluator for empty TreeTN"))?
+        };
+        Ok(Self { evaluator, center })
+    }
+
+    /// Returns the center node used by this evaluator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();
+    /// let tree = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
+    /// let evaluator = TreeTNCachedEvaluator::new(
+    ///     &tree,
+    ///     &[s],
+    ///     CachedEvaluatorOptions::<usize>::default(),
+    /// ).unwrap();
+    /// assert_eq!(evaluator.center(), &0);
+    /// ```
+    pub fn center(&self) -> &V {
+        &self.center
+    }
+
+    /// Evaluates all batch points.
+    ///
+    /// `values` must have shape `[indices.len(), n_points]` in column-major
+    /// layout. The returned vector contains one scalar per column.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values` has the wrong row count or if any site value
+    /// is outside the corresponding index dimension.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
+    ///
+    /// let s = DynIndex::new_dyn(2);
+    /// let t = TensorDynLen::from_dense(vec![s.clone()], vec![4.0_f64, 6.0]).unwrap();
+    /// let tree = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
+    /// let values = vec![0, 1];
+    /// let points = ColMajorArrayRef::new(&values, &[1, 2]).unwrap();
+    /// let mut evaluator = TreeTNCachedEvaluator::new(
+    ///     &tree,
+    ///     &[s],
+    ///     CachedEvaluatorOptions::<usize>::default(),
+    /// ).unwrap();
+    /// let result = evaluator.evaluate_batch(points).unwrap();
+    /// assert_eq!(result.len(), 2);
+    /// assert_eq!(result[0].real(), 4.0);
+    /// assert_eq!(result[1].real(), 6.0);
+    /// ```
+    pub fn evaluate_batch(&mut self, values: ColMajorArrayRef<'_, usize>) -> Result<Vec<AnyScalar>> {
+        self.evaluator.evaluate_batch(values)
+    }
+}
+```
+
+If `tree.contains_node` or `tree.node_names` do not exist with these exact names, use the existing public accessors from `TreeTN` and keep the API behavior identical.
+
+**Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator_matches_tree_evaluate_on_two_node_chain
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs crates/tensor4all-treetn/src/treetn/mod.rs crates/tensor4all-treetn/src/lib.rs
+git commit -m "feat(treetn): add cached evaluator API"
+```
+
+### Task 2: Add exact component-cost precomputation
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing tests for component counts**
+
+Add private tests in the existing test module:
+
+```rust
+#[test]
+fn component_cost_index_counts_unique_directed_components() {
+    let (tree, indices) = three_node_chain();
+    let values = vec![
+        0, 0, 0,
+        0, 1, 1,
+        1, 1, 1,
+    ];
+    let points = ColMajorArrayRef::new(&values, &[3, 3]).unwrap();
+
+    let cost_index = ComponentCostIndex::new(&tree, &indices, points).unwrap();
+
+    assert_eq!(cost_index.component_count(&(0, 1)).unwrap(), 2);
+    assert_eq!(cost_index.component_count(&(1, 0)).unwrap(), 2);
+    assert_eq!(cost_index.component_count(&(1, 2)).unwrap(), 3);
+    assert_eq!(cost_index.component_count(&(2, 1)).unwrap(), 2);
+    assert_eq!(cost_index.center_cost(&0).unwrap(), 2);
+    assert_eq!(cost_index.center_cost(&1).unwrap(), 4);
+    assert_eq!(cost_index.center_cost(&2).unwrap(), 3);
+}
+
+#[test]
+fn component_cost_index_rejects_wrong_batch_row_count() {
+    let (tree, indices) = three_node_chain();
+    let values = vec![0, 1, 1, 0];
+    let points = ColMajorArrayRef::new(&values, &[2, 2]).unwrap();
+
+    let err = ComponentCostIndex::new(&tree, &indices, points).unwrap_err();
+    assert!(err.to_string().contains("row count"));
+}
+```
+
+Add this helper:
+
+```rust
+fn three_node_chain() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+    let s0 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let b12 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+
+    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0_f64; 4]).unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![b01, s1.clone(), b12.clone()],
+        vec![1.0_f64; 8],
+    )
+    .unwrap();
+    let t2 = TensorDynLen::from_dense(vec![b12, s2.clone()], vec![1.0_f64; 4]).unwrap();
+    let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap();
+    (tree, vec![s0, s1, s2])
+}
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn component_cost_index
+```
+
+Expected: FAIL because `ComponentCostIndex` does not exist.
+
+**Step 3: Implement exact component-cost indexing**
+
+Add a private exact key interner and `ComponentCostIndex`:
+
+```rust
+type KeyId = usize;
+
+#[derive(Default)]
+struct KeyInterner<T>
+where
+    T: Eq + Hash + Clone,
+{
+    ids: HashMap<T, KeyId>,
+}
+
+impl<T> KeyInterner<T>
+where
+    T: Eq + Hash + Clone,
+{
+    fn intern(&mut self, key: T) -> KeyId {
+        let next = self.ids.len();
+        *self.ids.entry(key).or_insert(next)
+    }
+}
+
+struct ComponentCostIndex<V> {
+    neighbors: HashMap<V, Vec<V>>,
+    directed_counts: HashMap<(V, V), usize>,
+}
+```
+
+Implementation requirements:
+
+- Validate `values.shape()[0] == indices.len()`.
+- Build a deterministic map from each requested index to the owning TreeTN node using the same ownership rules as `TreeTNEvaluator`.
+- For each tree node and batch point, intern the node-local site assignment into a `KeyId`.
+- Root the tree at the smallest node name (`Ord`) for deterministic traversal.
+- Compute exact component keys for all child-to-parent directed edges in postorder.
+- Compute exact component keys for all parent-to-child directed edges in preorder using parent outside keys plus sibling child keys.
+- Count unique `KeyId` values per directed edge.
+- Define `center_cost(center)` as the sum of `component_count((neighbor, center))` for every neighbor of `center`.
+- The implementation may store `Vec<KeyId>` per directed edge during construction, but only `directed_counts` is needed after construction.
+- Do not use hash-only fingerprints as semantic keys; interning must compare exact tuples so collisions cannot change costs.
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn component_cost_index
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): add cached evaluator component costs"
+```
+
+### Task 3: Implement reusable greedy center search
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing greedy-search tests**
+
+Add:
+
+```rust
+#[test]
+fn greedy_center_search_descends_to_lower_cost_neighbor() {
+    let cost_index = ComponentCostIndex::from_parts_for_test(
+        HashMap::from([
+            (0, vec![1]),
+            (1, vec![0, 2]),
+            (2, vec![1, 3]),
+            (3, vec![2]),
+        ]),
+        HashMap::from([(0, 40), (1, 20), (2, 10), (3, 15)]),
+    );
+
+    let result = GreedyCenterSearch::<usize>::default()
+        .search(&cost_index, &[0])
+        .unwrap();
+
+    assert_eq!(result.center, 2);
+    assert_eq!(result.cost, 10);
+    assert_eq!(result.path, vec![0, 1, 2]);
+}
+
+#[test]
+fn greedy_center_search_uses_best_of_multiple_starts() {
+    let cost_index = ComponentCostIndex::from_parts_for_test(
+        HashMap::from([
+            ("a", vec!["b"]),
+            ("b", vec!["a", "c"]),
+            ("c", vec!["b", "d"]),
+            ("d", vec!["c"]),
+        ]),
+        HashMap::from([("a", 8), ("b", 6), ("c", 5), ("d", 2)]),
+    );
+
+    let result = GreedyCenterSearch::<&str>::with_max_steps(Some(1))
+        .search(&cost_index, &["a", "d"])
+        .unwrap();
+
+    assert_eq!(result.center, "d");
+    assert_eq!(result.cost, 2);
+}
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn greedy_center_search
+```
+
+Expected: FAIL because `search` and the test-only constructor do not exist.
+
+**Step 3: Implement search**
+
+Add:
+
+```rust
+impl<V> GreedyCenterSearch<V>
+where
+    V: Clone + Eq + Hash + Ord + Debug,
+{
+    pub(crate) fn search(
+        &self,
+        cost_index: &ComponentCostIndex<V>,
+        starts: &[V],
+    ) -> Result<CenterSearchResult<V>> {
+        // For each start, repeatedly move to the lowest-cost neighbor when it
+        // is strictly lower than the current center cost. Break ties by node
+        // order for deterministic results.
+        // Return the best terminal result among all starts.
+    }
+}
+```
+
+Rules:
+
+- Empty `starts` means use all nodes in sorted order.
+- A start not present in the tree is an error.
+- Only move on strict cost improvement; equal-cost neighbors do not move.
+- Tie-break terminal candidates by `(cost, center)` in ascending order.
+- Respect `max_steps` when set.
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn greedy_center_search
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): add greedy center search"
+```
+
+### Task 4: Wire automatic center selection into `TreeTNCachedEvaluator`
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing center-selection integration tests**
+
+Add:
+
+```rust
+#[test]
+fn cached_evaluator_selects_greedy_center_when_center_is_not_fixed() {
+    let (tree, indices) = three_node_chain();
+    let values = vec![
+        0, 0, 0,
+        0, 1, 1,
+        1, 1, 1,
+    ];
+    let points = ColMajorArrayRef::new(&values, &[3, 3]).unwrap();
+
+    let expected = tree.evaluate(&indices, points.clone()).unwrap();
+    let mut evaluator = TreeTNCachedEvaluator::new(
+        &tree,
+        &indices,
+        CachedEvaluatorOptions {
+            initial_centers: vec![1],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let actual = evaluator.evaluate_batch(points).unwrap();
+
+    assert_eq!(evaluator.center(), &0);
+    for (actual, expected) in actual.iter().zip(expected.iter()) {
+        assert_abs_diff_eq!(actual.real(), expected.real(), epsilon = 1e-12);
+    }
+}
+
+#[test]
+fn cached_evaluator_rejects_unknown_initial_center() {
+    let (tree, indices) = three_node_chain();
+    let err = TreeTNCachedEvaluator::new(
+        &tree,
+        &indices,
+        CachedEvaluatorOptions {
+            initial_centers: vec![99],
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("initial center"));
+}
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator_selects_greedy_center
+```
+
+Expected: FAIL because `TreeTNCachedEvaluator::new` still uses the first node instead of cost-based center selection.
+
+**Step 3: Implement center selection**
+
+Update `TreeTNCachedEvaluator::new`:
+
+- If `options.center` is `Some`, validate it and use it.
+- If `options.center` is `None`, delay center selection until the first `evaluate_batch`, because the cost model depends on the batch values.
+- Store `options` in the evaluator.
+- Change the struct fields to:
+
+```rust
+pub struct TreeTNCachedEvaluator<'a, T, V>
+where
+    T: TensorLike,
+{
+    evaluator: TreeTNEvaluator<'a, T, V>,
+    options: CachedEvaluatorOptions<V>,
+    center: Option<V>,
+}
+```
+
+- Change `center(&self)` to return `Option<&V>` or keep `&V` only if `new` computes a provisional center. Prefer preserving the planned API `center(&self) -> &V` by computing the center in `new` only for fixed-center construction and requiring the first `evaluate_batch` test to inspect `center()` after evaluation. If this is too awkward, add `selected_center(&self) -> Option<&V>` and keep `center()` only after selection with a documented panic. Avoid panics in normal API; the preferred public API is:
+
+```rust
+pub fn center(&self) -> Option<&V> {
+    self.center.as_ref()
+}
+```
+
+Update rustdoc examples and Task 1 assertions accordingly.
+
+- In `evaluate_batch`, when `center` is `None`, build `ComponentCostIndex`, run `GreedyCenterSearch`, and set `self.center`.
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): select cached evaluator center greedily"
+```
+
+### Task 5: Replace fallback evaluation with cached subtree environments
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing tests proving environment reuse**
+
+Add a private test-only stats accessor:
+
+```rust
+#[cfg(test)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct CachedEvaluationStats {
+    subtree_environment_count: usize,
+}
+```
+
+Add tests:
+
+```rust
+#[test]
+fn cached_evaluator_computes_one_environment_per_unique_subtree_assignment() {
+    let (tree, indices) = three_node_chain();
+    let values = vec![
+        0, 0, 0,
+        1, 0, 0,
+        0, 1, 1,
+        1, 1, 1,
+    ];
+    let points = ColMajorArrayRef::new(&values, &[3, 4]).unwrap();
+
+    let mut evaluator = TreeTNCachedEvaluator::new(
+        &tree,
+        &indices,
+        CachedEvaluatorOptions {
+            center: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let expected = tree.evaluate(&indices, points.clone()).unwrap();
+    let actual = evaluator.evaluate_batch(points).unwrap();
+
+    for (actual, expected) in actual.iter().zip(expected.iter()) {
+        assert_abs_diff_eq!(actual.real(), expected.real(), epsilon = 1e-12);
+    }
+    assert_eq!(evaluator.stats_for_test().subtree_environment_count, 4);
+}
+```
+
+For this batch and center `1`, the left component has two unique assignments and the right component has two unique assignments, so the cached evaluator should build four subtree environments instead of eight point-wise neighbor environments.
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator_computes_one_environment
+```
+
+Expected: FAIL because fallback evaluation does not compute or report cached environments.
+
+**Step 3: Implement cached evaluation**
+
+Add internal structures:
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ComponentAssignment {
+    values: Vec<usize>,
+}
+
+struct ComponentBatch<V> {
+    neighbor: V,
+    nodes: Vec<V>,
+    point_to_assignment: Vec<usize>,
+    assignments: Vec<ComponentAssignment>,
+}
+```
+
+Implementation requirements:
+
+- For the selected center, enumerate each neighbor component with DFS from the neighbor while excluding the center.
+- For each component, collect requested index rows owned by nodes in that component in deterministic node/index order.
+- Deduplicate each point's component assignment with `HashMap<ComponentAssignment, usize>`.
+- For each unique assignment, compute exactly one environment tensor from the component into the center.
+- For each batch point, contract the center tensor sliced by center-owned physical indices with the matching neighbor environments.
+- Keep using existing `TensorLike` and `TreeTNEvaluator` helpers where possible; do not access low-level tensor internals from another crate.
+- It is acceptable to introduce private helper methods in `TreeTNEvaluator` if they are the correct abstraction for mapping requested indices to nodes and slicing node tensors.
+- Do not add public scalar-specific APIs.
+- Preserve the public `evaluate_batch` result order and error behavior.
+
+Suggested helper layout:
+
+```rust
+impl<'a, T, V> TreeTNCachedEvaluator<'a, T, V>
+where
+    T: TensorLike,
+    V: Clone + Eq + Hash + Ord + Debug,
+{
+    fn evaluate_with_cache(&mut self, values: ColMajorArrayRef<'_, usize>) -> Result<Vec<AnyScalar>> {
+        let center = self.ensure_center(values.clone())?.clone();
+        let component_batches = self.build_component_batches(&center, values.clone())?;
+        let environment_cache = self.build_environment_cache(&center, &component_batches)?;
+        self.contract_center_for_points(&center, values, &component_batches, &environment_cache)
+    }
+}
+```
+
+**Step 4: Run focused tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): cache batch subtree environments"
+```
+
+### Task 6: Add error-path and layout tests
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn cached_evaluator_rejects_wrong_value_row_count() { /* wrong rows */ }
+
+#[test]
+fn cached_evaluator_rejects_out_of_range_site_value() { /* value == dim */ }
+
+#[test]
+fn cached_evaluator_handles_repeated_points_without_changing_order() { /* duplicate columns */ }
+
+#[test]
+fn cached_evaluator_matches_tree_evaluate_on_star_tree() { /* center with degree > 2 */ }
+```
+
+Each test should compare error messages or compare full result vectors to `TreeTN::evaluate` using `AnyScalar::real()` and `assert_abs_diff_eq!`.
+
+**Step 2: Run tests**
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator
+```
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "test(treetn): cover cached evaluator edge cases"
+```
+
+### Task 7: Add TreeTN cached evaluator benchmark
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/Cargo.toml`
+- Create: `crates/tensor4all-treetn/benches/cached_evaluator.rs`
+
+**Step 1: Update Cargo manifest**
+
+Add to `[dev-dependencies]`:
+
+```toml
+criterion.workspace = true
+```
+
+Add:
+
+```toml
+[[bench]]
+name = "cached_evaluator"
+harness = false
+```
+
+**Step 2: Create benchmark**
+
+Implement `crates/tensor4all-treetn/benches/cached_evaluator.rs` with:
+
+- `create_tt_with_bond_dim(n_sites, local_dim, bond_dim) -> TensorTrain<f64>` copied from the existing simplett cache benchmark, adjusted only as needed.
+- `generate_tci_like_indices(n_left, n_right, n_sites, local_dim, split, seed) -> Vec<Vec<usize>>`.
+- `multi_indices_to_col_major(indices: &[Vec<usize>]) -> Vec<usize>`.
+- `bench_chain_size_scaling`: for `n_sites in [16, 32, 64, 128]`, compare:
+  - `TTCache::evaluate_many(&indices, None)`
+  - `TreeTNCachedEvaluator::new(...).evaluate_batch(...)`
+  - current `tree.evaluate(&site_indices, values_ref)`
+- `bench_batch_size_scaling`: for `(n_left, n_right) in [(10, 10), (30, 30), (100, 100)]`, compare the same three methods on fixed `n_sites = 64`.
+- Use `tensor_train_to_treetn` to build the equivalent linear-chain TreeTN.
+- Use `criterion_group!` and `criterion_main!`.
+
+Keep sample sizes small enough for local iteration:
+
+```rust
+let mut group = c.benchmark_group("chain_size_scaling");
+group.sample_size(10);
+```
+
+**Step 3: Compile and smoke-run the benchmark**
+
+Run:
+
+```bash
+cargo bench -p tensor4all-treetn --bench cached_evaluator -- --sample-size 10
+```
+
+Expected: benchmark compiles and emits Criterion timing output. If it is too slow locally, reduce only benchmark sample sizes or benchmark matrix sizes; do not weaken correctness tests.
+
+**Step 4: Commit**
+
+```bash
+git add crates/tensor4all-treetn/Cargo.toml crates/tensor4all-treetn/benches/cached_evaluator.rs
+git commit -m "bench(treetn): compare cached batch evaluation"
+```
+
+### Task 8: Add or update rustdoc and API exports
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+- Modify: `crates/tensor4all-treetn/src/lib.rs`
+- Modify if needed: `README.md`
+
+**Step 1: Audit public docs**
+
+Verify every new public item has rustdoc with runnable examples and assertions:
+
+- `CachedEvaluatorOptions`
+- `CenterSearchResult`
+- `GreedyCenterSearch`
+- `TreeTNCachedEvaluator`
+- public methods on these types
+
+If the examples from Task 1 changed because `center()` returns `Option<&V>`, update every example to assert `Some(&center)`.
+
+**Step 2: Run doctests**
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-treetn
+```
+
+Expected: PASS.
+
+**Step 3: Run rustdoc build**
+
+Run:
+
+```bash
+cargo doc --workspace --no-deps
+```
+
+Expected: PASS without missing-doc warnings from the new public API.
+
+**Step 4: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs crates/tensor4all-treetn/src/lib.rs README.md
+git commit -m "docs(treetn): document cached evaluator API"
+```
+
+### Task 9: Final verification before PR
+
+**Files:**
+- No code changes expected unless verification reveals an issue.
+
+**Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+Expected: PASS.
+
+If formatting changed files, commit them:
+
+```bash
+git add crates/tensor4all-treetn
+git commit -m "style: format cached evaluator changes"
+```
+
+**Step 2: Run focused checks**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator
+cargo test --release -p tensor4all-simplett cache
+cargo test --doc --release -p tensor4all-treetn
+```
+
+Expected: PASS.
+
+**Step 3: Run lint**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: PASS.
+
+**Step 4: Run full release test suite if time allows**
+
+Run:
+
+```bash
+cargo nextest run --release --workspace
+```
+
+Expected: PASS. If this is too slow for the current turn, run the focused checks above and state clearly in the PR body that full workspace nextest was not run locally.
+
+**Step 5: Commit any verification fixes**
+
+If any code or docs changed during verification:
+
+```bash
+git add <changed-files>
+git commit -m "fix(treetn): address cached evaluator verification"
+```
+
+### Task 10: Push and open a draft PR
+
+**Files:**
+- No source edits expected.
+
+**Step 1: Inspect final diff and status**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --stat origin/main...HEAD
+```
+
+Expected: branch contains only the design doc, implementation plan, TreeTN cached evaluator code/tests/docs, and benchmark changes.
+
+**Step 2: Push**
+
+Run:
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+Expected: push succeeds.
+
+**Step 3: Create draft PR**
+
+Use the GitHub app if possible, otherwise fallback to:
+
+```bash
+gh pr create --draft --base main --head "$(git branch --show-current)" --title "[codex] Add TreeTN cached batch evaluator" --body-file /tmp/treetn-cached-evaluator-pr.md
+```
+
+PR body must include:
+
+- Summary of the cached evaluator API and greedy center search.
+- Benchmark coverage and what the benchmark compares.
+- Tests/checks run.
+- Mention that this is part of the batch issue-fix branch and addresses issue `#464`; mention `#380/#383` only if the final implementation directly changes their behavior.
+
+**Step 4: Report**
+
+Report branch, PR URL, commits, checks run, and any checks not run.

--- a/docs/plans/2026-05-14-treetn-directed-message-cache-design.md
+++ b/docs/plans/2026-05-14-treetn-directed-message-cache-design.md
@@ -1,0 +1,61 @@
+# TreeTN Directed Message Cache Design
+
+## Goal
+
+Improve `TreeTNCachedEvaluator` performance without adding a chain-specific fast
+path. The cached evaluator should reuse intermediate contractions inside each
+subtree, so a linear-chain TreeTN follows the same cache shape as `TTCache`
+while still working for arbitrary tree topology.
+
+## Root Cause
+
+The first cached evaluator caches one tensor per unique neighbor-component
+assignment. For each unique assignment it slices every node in the component,
+builds a temporary `TreeTN`, and calls `contract_to_tensor`. This is correct but
+expensive: benchmark breakdowns showed environment construction dominated the
+runtime.
+
+`TTCache` is faster because it does not recompute a whole prefix or suffix for
+every unique half-assignment. It memoizes intermediate prefix and suffix vectors
+recursively, so related assignments share work.
+
+## Approach
+
+Root the tree at the selected evaluation center. For each non-center node, build
+a directed message from that node to its parent. A message key is the assignment
+restricted to the node's entire rooted subtree. A message value is the contracted
+environment tensor from that subtree into the parent bond.
+
+Messages are computed postorder:
+
+1. Slice the local node tensor by the node's site values.
+2. Recursively fetch child messages for the same subtree assignment.
+3. Contract the sliced local tensor with the child messages.
+4. Cache the resulting parent-facing message by `(node, parent, subtree key)`.
+
+The final point evaluation contracts the center tensor, sliced by center-owned
+site values, with the selected child messages. This keeps the public API
+unchanged and preserves the existing generic `TensorLike` abstraction.
+
+## Tensor Slicing
+
+Add a high-level `TensorLike::select_indices` method with a default
+implementation using `onehot + contract`. Override it for `TensorDynLen` to call
+the existing dense `select_indices` method. This avoids ad hoc downcasts in
+TreeTN and benefits both the cached evaluator and existing evaluators.
+
+## Tests
+
+- A new internal cached-evaluator test constructs a 3-node chain with repeated
+  subtree assignments and asserts the directed-message compute count is lower
+  than the old component-environment count.
+- Existing correctness tests continue to compare against `TreeTN::evaluate`.
+- Rustdoc examples for `TensorLike::select_indices` must be runnable.
+
+## Expected Performance
+
+The TreeTN cached evaluator should still be slower than `TTCache` because it
+uses generic tensor contractions rather than rank-vector matrix-vector kernels.
+However, environment construction should scale with unique directed subtree
+messages instead of unique whole component assignments, closing the largest
+current gap in a topology-generic way.

--- a/docs/plans/2026-05-14-treetn-directed-message-cache-plan.md
+++ b/docs/plans/2026-05-14-treetn-directed-message-cache-plan.md
@@ -1,0 +1,77 @@
+# TreeTN Directed Message Cache Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace whole-component cached TreeTN evaluation with directed message caching that reuses intermediate subtree contractions.
+
+**Architecture:** Add a generic `TensorLike::select_indices` API, then update `TreeTNCachedEvaluator` to root the tree at the chosen center and compute cached child-to-parent messages in postorder. Keep the public `TreeTNCachedEvaluator` API unchanged.
+
+**Tech Stack:** Rust, `tensor4all-core::TensorLike`, existing `TensorDynLen::select_indices`, `TreeTN`, Criterion benchmarks.
+
+---
+
+### Task 1: Add TensorLike slicing API
+
+**Files:**
+- Modify: `crates/tensor4all-core/src/tensor_like.rs`
+- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+
+**Steps:**
+1. Add a default `fn select_indices(&self, selected_indices: &[Self::Index], positions: &[usize]) -> Result<Self>` to `TensorLike`.
+2. Default implementation validates lengths, builds one-hot pairs, and contracts `self` with the one-hot tensor.
+3. Override the method in `impl TensorLike for TensorDynLen` by calling the existing inherent `TensorDynLen::select_indices`.
+4. Add rustdoc examples with assertions.
+5. Verify with `cargo test --doc --release -p tensor4all-core`.
+
+### Task 2: Add failing message-cache behavior test
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Steps:**
+1. Extend the test-only stats assertion to expect a directed-message count.
+2. Add a 3-node chain test where center `1` has two neighbor components, four unique component assignments, but only four directed messages total including internal reuse. The current implementation should fail because it has no directed-message stats.
+3. Run `cargo test --release -p tensor4all-treetn cached_evaluator_reuses_directed_messages --lib` and verify failure.
+
+### Task 3: Implement rooted message planning
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Steps:**
+1. Add private `RootedMessagePlan<V>` with `parent`, `children`, and postorder node list for a selected center.
+2. Add helpers for collecting subtree nodes from the rooted plan.
+3. Keep existing center search and component-cost code unchanged.
+4. Add tests for deterministic parent/child layout if needed.
+
+### Task 4: Replace component environment construction
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Steps:**
+1. Replace `compute_component_environment` with recursive `compute_message(node, assignment, plan, cache)`.
+2. Message keys are exact `ComponentAssignment` values for the rooted subtree at `node`.
+3. Slice local tensors with `TensorLike::select_indices`.
+4. Contract local slices with child messages using `T::contract`.
+5. Store messages in `HashMap<(V, ComponentAssignment), T>` per child node.
+6. Update test-only stats for message compute count.
+7. Verify cached evaluator tests pass.
+
+### Task 5: Re-run benchmarks and validation
+
+**Commands:**
+- `cargo fmt --all -- --check`
+- `cargo test --release -p tensor4all-treetn cached_evaluator --lib`
+- `cargo test --doc --release -p tensor4all-core`
+- `cargo test --doc --release -p tensor4all-treetn`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo bench --no-run -p tensor4all-treetn --bench cached_evaluator`
+- short Criterion runs for `treetn_cached_batch_size/treetn_cached` and `treetn_cached_chain_size/treetn_cached`
+
+### Task 6: Push PR update
+
+**Steps:**
+1. Commit implementation and docs.
+2. Push `codex/batch-issues-2026-05-14`.
+3. Comment on PR #501 with updated benchmark results and the root-cause summary.


### PR DESCRIPTION
## Summary

- Adds `TreeTNCachedEvaluator` with reusable `CachedEvaluatorOptions`, `GreedyCenterSearch`, and `CenterSearchResult` exports.
- Implements greedy batch-dependent center selection from exact directed component costs.
- Replaces whole-component cached contractions with bottom-up directed message caching and compact recursive assignment keys.
- Adds generic `TensorLike::select_indices` and `TensorLike::contract_pair` seams, with optimized `TensorDynLen` implementations for cached evaluation.
- Adds TreeTN benchmarks comparing `TTCache::evaluate_many`, cached TreeTN evaluation on equivalent chains, existing uncached `TreeTN::evaluate`, and bond-dimension scaling.
- Adds design and implementation plan docs for the TreeTN cached evaluator work.

Addresses #464.
Follow-up: #502 tracks retained-index batched message contractions.

## Benchmark Notes

Short Criterion run: `--sample-size 10 --measurement-time 1 --warm-up-time 1`, same generated TT converted to TreeTN.

Batch-size scaling, `n_sites=64`, `bond_dim=16`, `local_dim=2`:

| batch | TTCache | TreeTN cached |
| --- | ---: | ---: |
| 10x10 | 23.3 ms | 82.9 ms |
| 20x20 | 46.8 ms | 210 ms |
| 40x40 | 87.9 ms | 626 ms |

Chain-size scaling, `batch=20x20`, `bond_dim=16`, `local_dim=2`:

| n_sites | TTCache | TreeTN cached |
| --- | ---: | ---: |
| 16 | 8.43 ms | 103 ms |
| 32 | 22.4 ms | 143 ms |
| 64 | 46.3 ms | 226 ms |
| 128 | 96.2 ms | 373 ms |

Bond-dimension scaling, `n_sites=128`, `batch=10x10`, `local_dim=2`:

| bond_dim | TTCache | TreeTN cached | ratio |
| --- | ---: | ---: | ---: |
| 4 | 41.7 ms | 143 ms | 3.4x |
| 8 | 43.0 ms | 151 ms | 3.5x |
| 16 | 49.4 ms | 174 ms | 3.5x |
| 32 | 54.8 ms | 213 ms | 3.9x |
| 64 | 87.2 ms | 376 ms | 4.3x |

The remaining gap is mostly generic `TensorDynLen` contraction overhead versus `TTCache`'s specialized rank-vector matrix/vector kernels. #502 tracks the more principled retained-index batched message-contraction optimization.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --release -p tensor4all-treetn --lib`
- `cargo test --doc --release --workspace`
- `cargo doc --workspace --no-deps`
- `cargo nextest run --release --workspace` (2071 passed, 12 skipped)
- `cargo bench --no-run -p tensor4all-treetn --bench cached_evaluator`
- `cargo bench -p tensor4all-treetn --bench cached_evaluator -- treetn_cached_batch_size/{ttcache,treetn_cached} --sample-size 10 --measurement-time 1 --warm-up-time 1`
- `cargo bench -p tensor4all-treetn --bench cached_evaluator -- treetn_cached_chain_size/{ttcache,treetn_cached} --sample-size 10 --measurement-time 1 --warm-up-time 1`
- `cargo bench -p tensor4all-treetn --bench cached_evaluator -- treetn_cached_bond_dim/{ttcache,treetn_cached} --sample-size 10 --measurement-time 1 --warm-up-time 1`
