### PR TITLE
[codex] Batch TreeTN cached evaluator contractions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16", default-features = false }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "34750e9ca7f6285ce8c81aaa691bb240d570db16", default-features = false }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb", default-features = false }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb", default-features = false }

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -958,7 +958,7 @@ enum t4a_status_code t4a_treetn_evaluator_clone(const struct t4a_treetn_evaluato
 /**
  * Evaluate one or more points using a reusable TreeTN evaluator.
  */
-enum t4a_status_code t4a_treetn_evaluator_evaluate(const struct t4a_treetn_evaluator *evaluator,
+enum t4a_status_code t4a_treetn_evaluator_evaluate(struct t4a_treetn_evaluator *evaluator,
                                                    const size_t *values_col_major,
                                                    size_t n_points,
                                                    double *out_re,

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -16,9 +16,10 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike, SvdTruncationPolicy};
 use tensor4all_treetn::treetn::contraction::{self, ContractionMethod, ContractionOptions};
 use tensor4all_treetn::{
-    apply_linear_operator, partial_contract, square_linsolve, ApplyOptions, CanonicalForm,
-    CanonicalizationOptions, IndexMapping, LinearOperator, LinsolveOptions, PartialContractionSpec,
-    RestructureOptions, SiteIndexNetwork, SplitOptions, SwapOptions, TruncationOptions,
+    apply_linear_operator, partial_contract, square_linsolve, ApplyOptions, CachedEvaluatorOptions,
+    CanonicalForm, CanonicalizationOptions, IndexMapping, LinearOperator, LinsolveOptions,
+    PartialContractionSpec, RestructureOptions, SiteIndexNetwork, SplitOptions, SwapOptions,
+    TreeTNCachedEvaluator, TruncationOptions,
 };
 
 /// Release a TreeTN handle.
@@ -137,11 +138,13 @@ fn require_tree_mut<'a>(ptr: *mut t4a_treetn) -> CapiResult<&'a mut t4a_treetn> 
     Ok(unsafe { &mut *ptr })
 }
 
-fn require_evaluator<'a>(ptr: *const t4a_treetn_evaluator) -> CapiResult<&'a t4a_treetn_evaluator> {
+fn require_evaluator_mut<'a>(
+    ptr: *mut t4a_treetn_evaluator,
+) -> CapiResult<&'a mut t4a_treetn_evaluator> {
     if ptr.is_null() {
         return Err(capi_error(T4A_NULL_POINTER, "treetn evaluator is null"));
     }
-    Ok(unsafe { &*ptr })
+    Ok(unsafe { &mut *ptr })
 }
 
 fn require_node(tn: &InternalTreeTN, vertex: usize) -> CapiResult<()> {
@@ -1318,12 +1321,12 @@ pub extern "C" fn t4a_treetn_evaluator_new(
             ));
         }
         let indices = collect_indices(indices, n_indices, "indices")?;
-        let evaluator = tn
-            .inner()
-            .evaluator(&indices)
+        TreeTNCachedEvaluator::new(tn.inner(), &indices, CachedEvaluatorOptions::default())
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
         Ok(t4a_treetn_evaluator::new(InternalTreeTNEvaluatorHandle {
-            evaluator,
+            tree: tn.inner().clone(),
+            indices,
+            center: None,
             scalar_kind: treetn_scalar_kind(tn.inner()),
         }))
     })
@@ -1332,14 +1335,14 @@ pub extern "C" fn t4a_treetn_evaluator_new(
 /// Evaluate one or more points using a reusable TreeTN evaluator.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_treetn_evaluator_evaluate(
-    evaluator: *const t4a_treetn_evaluator,
+    evaluator: *mut t4a_treetn_evaluator,
     values_col_major: *const libc::size_t,
     n_points: libc::size_t,
     out_re: *mut libc::c_double,
     out_im: *mut libc::c_double,
 ) -> t4a_status_code {
     run_status(|| {
-        let evaluator = require_evaluator(evaluator)?;
+        let evaluator = require_evaluator_mut(evaluator)?;
         if n_points == 0 {
             return Err(capi_error(
                 T4A_INVALID_ARGUMENT,
@@ -1350,8 +1353,8 @@ pub extern "C" fn t4a_treetn_evaluator_evaluate(
             return Err(capi_error(T4A_NULL_POINTER, "values_col_major is null"));
         }
 
-        let handle = evaluator.inner();
-        let n_indices = handle.evaluator.input_count();
+        let handle = evaluator.inner_mut();
+        let n_indices = handle.indices.len();
         let n_values = n_indices.checked_mul(n_points).ok_or_else(|| {
             capi_error(
                 T4A_INVALID_ARGUMENT,
@@ -1361,11 +1364,25 @@ pub extern "C" fn t4a_treetn_evaluator_evaluate(
         let values_slice = unsafe { std::slice::from_raw_parts(values_col_major, n_values) };
         let shape = [n_indices, n_points];
         let values = ColMajorArrayRef::new(values_slice, &shape);
-        let results = handle
-            .evaluator
+
+        let scalar_kind = handle.scalar_kind;
+        let mut cached = TreeTNCachedEvaluator::new(
+            &handle.tree,
+            &handle.indices,
+            CachedEvaluatorOptions {
+                center: handle.center,
+                ..Default::default()
+            },
+        )
+        .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        let results = cached
             .evaluate_batch(values)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        write_evaluation_results(&results, handle.scalar_kind, out_re, out_im)
+        let center = cached.center().copied();
+        drop(cached);
+        handle.center = center;
+
+        write_evaluation_results(&results, scalar_kind, out_re, out_im)
     })
 }
 
@@ -1409,10 +1426,10 @@ pub extern "C" fn t4a_treetn_evaluate(
         let shape = [n_indices, n_points];
         let values = ColMajorArrayRef::new(values_slice, &shape);
         let scalar_kind = treetn_scalar_kind(tn.inner());
-        let results = tn
-            .inner()
-            .evaluator(&indices)
-            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?
+        let mut evaluator =
+            TreeTNCachedEvaluator::new(tn.inner(), &indices, CachedEvaluatorOptions::default())
+                .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        let results = evaluator
             .evaluate_batch(values)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
 

--- a/crates/tensor4all-capi/src/treetn/tests/mod.rs
+++ b/crates/tensor4all-capi/src/treetn/tests/mod.rs
@@ -1168,6 +1168,17 @@ fn test_treetn_evaluate_complex_requires_out_im_even_for_real_value() {
 }
 
 #[test]
+fn test_treetn_evaluator_evaluate_requires_mutable_handle_signature() {
+    let _evaluate: extern "C" fn(
+        *mut t4a_treetn_evaluator,
+        *const libc::size_t,
+        libc::size_t,
+        *mut libc::c_double,
+        *mut libc::c_double,
+    ) -> t4a_status_code = t4a_treetn_evaluator_evaluate;
+}
+
+#[test]
 fn test_treetn_evaluator_reuses_index_order_for_multiple_batches() {
     let (tt, tensors, indices) = make_two_site_treetn();
     let s0 = indices[0];
@@ -1216,6 +1227,47 @@ fn test_treetn_evaluator_reuses_index_order_for_multiple_batches() {
 
     t4a_treetn_evaluator_release(evaluator);
     cleanup(tt, tensors, indices);
+}
+
+#[test]
+fn test_treetn_evaluator_owns_tree_after_original_release() {
+    let (tt, tensors, indices) = make_two_site_treetn();
+    let s0 = indices[0];
+    let s1 = indices[3];
+    let index_ptrs = [s0 as *const t4a_index, s1 as *const t4a_index];
+    let mut evaluator = std::ptr::null_mut();
+    assert_eq!(
+        t4a_treetn_evaluator_new(tt, index_ptrs.as_ptr(), 2, &mut evaluator),
+        T4A_SUCCESS
+    );
+    assert!(!evaluator.is_null());
+
+    t4a_treetn_release(tt);
+
+    let values = [
+        0usize, 0usize, // point 0
+        1usize, 1usize, // point 1
+    ];
+    let mut out = [0.0; 2];
+    assert_eq!(
+        t4a_treetn_evaluator_evaluate(
+            evaluator,
+            values.as_ptr(),
+            2,
+            out.as_mut_ptr(),
+            std::ptr::null_mut()
+        ),
+        T4A_SUCCESS
+    );
+    assert_eq!(out, [1.0, 4.0]);
+
+    t4a_treetn_evaluator_release(evaluator);
+    for tensor in tensors {
+        t4a_tensor_release(tensor);
+    }
+    for index in indices {
+        t4a_index_release(index);
+    }
 }
 
 #[test]

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -9,7 +9,7 @@ use tensor4all_core::{
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
 use tensor4all_tensorbackend::StorageKind;
 use tensor4all_treetn::treetn::contraction::ContractionMethod;
-use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN, TreeTNEvaluator};
+use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN};
 
 /// Internal dynamic index type wrapped by `t4a_index`.
 pub(crate) type InternalIndex = DynIndex;
@@ -20,13 +20,12 @@ pub(crate) type InternalTensor = TensorDynLen;
 /// Internal tree tensor network type wrapped by `t4a_treetn`.
 pub(crate) type InternalTreeTN = DefaultTreeTN<usize>;
 
-/// Internal reusable TreeTN evaluator type wrapped by `t4a_treetn_evaluator`.
-pub(crate) type InternalTreeTNEvaluator = TreeTNEvaluator<InternalTensor, usize>;
-
 /// Internal C API evaluator handle state.
 #[derive(Clone)]
 pub(crate) struct InternalTreeTNEvaluatorHandle {
-    pub(crate) evaluator: InternalTreeTNEvaluator,
+    pub(crate) tree: InternalTreeTN,
+    pub(crate) indices: Vec<InternalIndex>,
+    pub(crate) center: Option<usize>,
     pub(crate) scalar_kind: t4a_scalar_kind,
 }
 
@@ -202,16 +201,21 @@ pub struct t4a_treetn_evaluator {
 }
 
 impl t4a_treetn_evaluator {
-    /// Create a wrapper from an internal reusable evaluator value.
+    /// Create a wrapper from internal reusable evaluator state.
     pub(crate) fn new(handle: InternalTreeTNEvaluatorHandle) -> Self {
         Self {
             _private: Box::into_raw(Box::new(handle)) as *const c_void,
         }
     }
 
-    /// Borrow the wrapped reusable evaluator.
+    /// Borrow the wrapped reusable evaluator state.
     pub(crate) fn inner(&self) -> &InternalTreeTNEvaluatorHandle {
         unsafe { &*(self._private as *const InternalTreeTNEvaluatorHandle) }
+    }
+
+    /// Mutably borrow the wrapped reusable evaluator state.
+    pub(crate) fn inner_mut(&mut self) -> &mut InternalTreeTNEvaluatorHandle {
+        unsafe { &mut *(self._private as *mut InternalTreeTNEvaluatorHandle) }
     }
 }
 

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -217,6 +217,19 @@ impl TensorDynLen {
         Self::canonicalize_axis_classes(&permuted)
     }
 
+    fn normalize_insert_axis(op: &str, axis: isize, rank: usize) -> Result<usize> {
+        let normalized = if axis < 0 {
+            rank as isize + 1 + axis
+        } else {
+            axis
+        };
+        anyhow::ensure!(
+            normalized >= 0 && normalized <= rank as isize,
+            "{op}: axis {axis} is out of bounds for inserting into rank {rank}"
+        );
+        Ok(normalized as usize)
+    }
+
     fn is_diag_axis_classes(axis_classes: &[usize]) -> bool {
         axis_classes.len() >= 2 && axis_classes.iter().all(|&class_id| class_id == 0)
     }
@@ -448,6 +461,19 @@ impl TensorDynLen {
     fn compact_payload_is_logical_dense(&self, payload_dims: &[usize]) -> bool {
         self.storage.axis_classes() == Self::dense_axis_classes(self.indices.len())
             && payload_dims == self.dims()
+    }
+
+    fn uses_tracked_compact_storage(&self) -> bool {
+        self.tracked_compact_payload_value()
+            .is_some_and(|value| !self.compact_payload_is_logical_dense(&value.payload_dims))
+    }
+
+    fn ensure_shape_packing_preserves_ad(&self, op_name: &str) -> Result<()> {
+        anyhow::ensure!(
+            !self.uses_tracked_compact_storage(),
+            "{op_name}: structured AD tensors with compact storage are not supported because materializing compact storage would detach gradients"
+        );
+        Ok(())
     }
 
     fn build_binary_contraction_labels(
@@ -1229,6 +1255,144 @@ impl TensorDynLen {
             .materialized_inner()
             .dynamic_slice(&starts_tensor, &slice_sizes)?;
         Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?)
+    }
+
+    /// Stack tensors along a newly inserted index.
+    ///
+    /// Each input must have exactly the same index order and dimensions. The
+    /// `new_index` dimension must match the number of input tensors. The
+    /// `axis` argument follows tenferro/PyTorch-style insertion semantics:
+    /// `0` inserts before the first existing axis and `-1` appends a trailing
+    /// axis. Use `axis = -1` for batched contractions because tenferro uses
+    /// trailing batch dimensions as the canonical batched-GEMM layout.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no tensors are provided, the new index dimension
+    /// does not match the number of tensors, an input has a different index
+    /// order, `axis` is outside the valid insertion range, or a tracked
+    /// structured-AD tensor uses compact storage that would need dense
+    /// materialization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let batch = DynIndex::new_dyn(2);
+    /// let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    /// let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+    ///
+    /// let stacked = TensorDynLen::stack_along_new_index(&[&a, &b], batch.clone(), -1).unwrap();
+    ///
+    /// assert_eq!(stacked.indices(), &[i, batch]);
+    /// assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+    /// ```
+    pub fn stack_along_new_index(
+        tensors: &[&Self],
+        new_index: DynIndex,
+        axis: isize,
+    ) -> Result<Self> {
+        let first = tensors
+            .first()
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("stack_along_new_index requires at least one tensor"))?;
+        anyhow::ensure!(
+            new_index.dim() == tensors.len(),
+            "stack_along_new_index: new index dim {} does not match tensor count {}",
+            new_index.dim(),
+            tensors.len()
+        );
+
+        let base_indices = first.indices.clone();
+        for tensor in tensors.iter().copied().skip(1) {
+            anyhow::ensure!(
+                tensor.indices == base_indices,
+                "stack_along_new_index: input tensors must have identical index order"
+            );
+        }
+        for &tensor in tensors {
+            tensor.ensure_shape_packing_preserves_ad("stack_along_new_index")?;
+        }
+
+        let insert_axis =
+            Self::normalize_insert_axis("stack_along_new_index", axis, base_indices.len())?;
+        let mut result_indices = base_indices;
+        result_indices.insert(insert_axis, new_index);
+
+        let inner_refs = tensors
+            .iter()
+            .map(|tensor| tensor.materialized_inner())
+            .collect::<Vec<_>>();
+        let stacked = EagerTensor::stack(&inner_refs, axis)?;
+        Self::from_inner(result_indices, stacked)
+    }
+
+    /// Select positions along one index and replace it with a new index.
+    ///
+    /// This is the retained-axis counterpart to [`Self::select_indices`]:
+    /// instead of fixing one coordinate and removing the index, it gathers a
+    /// list of positions and keeps the gathered axis under `target_index`.
+    /// Repeated positions are allowed; reverse-mode AD accumulates repeated
+    /// cotangents through tenferro's scatter-add gather transpose.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `source_index` is not present, `target_index.dim()`
+    /// differs from `positions.len()`, or any position is out of range for the
+    /// source index. A tracked structured-AD tensor with compact storage is
+    /// also rejected because dense materialization would detach gradients.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    ///
+    /// let source = DynIndex::new_dyn(3);
+    /// let target = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(
+    ///     vec![source.clone()],
+    ///     vec![10.0_f64, 20.0, 30.0],
+    /// ).unwrap();
+    ///
+    /// let selected = tensor.index_select(&source, target.clone(), &[2, 0]).unwrap();
+    ///
+    /// assert_eq!(selected.indices(), &[target]);
+    /// assert_eq!(selected.to_vec::<f64>().unwrap(), vec![30.0, 10.0]);
+    /// ```
+    pub fn index_select(
+        &self,
+        source_index: &DynIndex,
+        target_index: DynIndex,
+        positions: &[usize],
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            target_index.dim() == positions.len(),
+            "index_select: target index dim {} does not match position count {}",
+            target_index.dim(),
+            positions.len()
+        );
+        let axis = self
+            .indices
+            .iter()
+            .position(|index| index == source_index)
+            .ok_or_else(|| anyhow::anyhow!("index_select: source index is not present"))?;
+        let source_dim = self.indices[axis].dim();
+        for &position in positions {
+            anyhow::ensure!(
+                position < source_dim,
+                "index_select: position {position} is out of range for source dim {source_dim}"
+            );
+        }
+        self.ensure_shape_packing_preserves_ad("index_select")?;
+
+        let axis = isize::try_from(axis)
+            .map_err(|_| anyhow::anyhow!("index_select: axis does not fit in isize"))?;
+        let selected = self.materialized_inner().index_select(axis, positions)?;
+        let mut result_indices = self.indices.clone();
+        result_indices[axis as usize] = target_index;
+        Self::from_inner(result_indices, selected)
     }
 
     /// Create a new tensor with dynamic rank.

--- a/crates/tensor4all-core/tests/tensor_shape_packing.rs
+++ b/crates/tensor4all-core/tests/tensor_shape_packing.rs
@@ -1,0 +1,100 @@
+use tensor4all_core::{DynIndex, TensorDynLen};
+
+#[test]
+fn stack_along_new_index_uses_trailing_column_major_batch_axis() {
+    let batch = DynIndex::new_dyn(2);
+    let i = DynIndex::new_dyn(2);
+    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+
+    let stacked = TensorDynLen::stack_along_new_index(&[&a, &b], batch.clone(), -1).unwrap();
+
+    assert_eq!(stacked.indices(), &[i, batch]);
+    assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn index_select_replaces_trailing_index_and_allows_repeated_positions() {
+    let source_batch = DynIndex::new_dyn(3);
+    let target_batch = DynIndex::new_dyn(4);
+    let i = DynIndex::new_dyn(2);
+    let source = TensorDynLen::from_dense(
+        vec![i.clone(), source_batch.clone()],
+        vec![10.0_f64, 11.0, 20.0, 21.0, 30.0, 31.0],
+    )
+    .unwrap();
+
+    let selected = source
+        .index_select(&source_batch, target_batch.clone(), &[2, 0, 2, 1])
+        .unwrap();
+
+    assert_eq!(selected.indices(), &[i, target_batch]);
+    assert_eq!(
+        selected.to_vec::<f64>().unwrap(),
+        vec![30.0, 31.0, 10.0, 11.0, 30.0, 31.0, 20.0, 21.0]
+    );
+}
+
+#[test]
+fn index_select_backward_scatter_adds_repeated_positions() {
+    let source = DynIndex::new_dyn(3);
+    let target = DynIndex::new_dyn(3);
+    let x = TensorDynLen::from_dense(vec![source.clone()], vec![1.0_f64, 2.0, 3.0])
+        .unwrap()
+        .enable_grad();
+    let weights =
+        TensorDynLen::from_dense(vec![target.clone()], vec![10.0_f64, 20.0, 30.0]).unwrap();
+
+    let y = x.index_select(&source, target, &[1, 1, 2]).unwrap();
+    let loss = y.inner_product(&weights).unwrap();
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert_eq!(grad.indices(), &[source]);
+    assert_eq!(grad.to_vec::<f64>().unwrap(), vec![0.0, 30.0, 30.0]);
+}
+
+#[test]
+fn stack_along_new_index_backward_splits_cotangent_to_inputs() {
+    let batch = DynIndex::new_dyn(2);
+    let x0 = TensorDynLen::scalar(2.0).unwrap().enable_grad();
+    let x1 = TensorDynLen::scalar(3.0).unwrap().enable_grad();
+    let weights = TensorDynLen::from_dense(vec![batch.clone()], vec![10.0_f64, 20.0]).unwrap();
+
+    let stacked = TensorDynLen::stack_along_new_index(&[&x0, &x1], batch, -1).unwrap();
+    let loss = stacked.inner_product(&weights).unwrap();
+    loss.backward().unwrap();
+
+    let grad0 = x0.grad().unwrap().unwrap();
+    let grad1 = x1.grad().unwrap().unwrap();
+    assert!((grad0.only().real() - 10.0).abs() < 1.0e-12);
+    assert!((grad1.only().real() - 20.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn stack_along_new_index_rejects_tracked_compact_storage() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let batch = DynIndex::new_dyn(1);
+    let diag = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0])
+        .unwrap()
+        .enable_grad();
+
+    let err = TensorDynLen::stack_along_new_index(&[&diag], batch, -1).unwrap_err();
+
+    assert!(err.to_string().contains("structured AD"));
+}
+
+#[test]
+fn index_select_rejects_tracked_compact_storage() {
+    let source = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let target = DynIndex::new_dyn(1);
+    let diag = TensorDynLen::from_diag(vec![source.clone(), j], vec![1.0_f64, 2.0])
+        .unwrap()
+        .enable_grad();
+
+    let err = diag.index_select(&source, target, &[0]).unwrap_err();
+
+    assert!(err.to_string().contains("structured AD"));
+}

--- a/crates/tensor4all-tcicore/src/matrixluci/scalar/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/scalar/tests.rs
@@ -73,30 +73,6 @@ where
     assert_identity2_factor_shapes(&lazy);
 }
 
-fn test_matrix_luci_factor_dispatch_dense_error_lazy_success<T>()
-where
-    T: Scalar + crate::scalar::Scalar,
-{
-    let matrix = identity2::<T>();
-    let dense = <T as Scalar>::matrix_luci_factors_from_matrix(&matrix, options());
-    assert!(dense.is_err());
-
-    let lazy = <T as Scalar>::matrix_luci_factors_from_blocks(
-        matrix.nrows(),
-        matrix.ncols(),
-        |rows, cols, out| {
-            for (j, &col) in cols.iter().enumerate() {
-                for (i, &row) in rows.iter().enumerate() {
-                    out[i + rows.len() * j] = matrix[[row, col]];
-                }
-            }
-        },
-        options(),
-    )
-    .unwrap();
-    assert_identity2_factor_shapes(&lazy);
-}
-
 #[test]
 fn test_scalar_f64() {
     test_scalar_generic::<f64>();
@@ -124,7 +100,7 @@ fn test_scalar_f32() {
 
 #[test]
 fn test_matrix_luci_factor_dispatch_f32() {
-    test_matrix_luci_factor_dispatch_dense_error_lazy_success::<f32>();
+    test_matrix_luci_factor_dispatch_supported::<f32>();
 }
 
 #[test]
@@ -172,5 +148,5 @@ fn test_scalar_c32() {
 
 #[test]
 fn test_matrix_luci_factor_dispatch_c32() {
-    test_matrix_luci_factor_dispatch_dense_error_lazy_success::<Complex32>();
+    test_matrix_luci_factor_dispatch_supported::<Complex32>();
 }

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -7,13 +7,14 @@ use std::hash::Hash;
 use anyhow::{bail, Context, Result};
 use num_complex::Complex64;
 use tensor4all_core::{
-    AnyScalar, ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen, TensorIndex, TensorLike,
+    contract_multi_with_options, AllowedPairs, AnyScalar, ColMajorArrayRef, ContractionOptions,
+    DynIndex, IndexLike, TensorDynLen, TensorIndex, TensorLike,
 };
 
 use super::TreeTN;
 
 type KeyId = usize;
-type EnvironmentCache<V> = HashMap<V, Vec<TensorDynLen>>;
+type EnvironmentCache<V> = HashMap<V, StackedMessage>;
 type CacheBuildResult<V> = (Vec<ComponentBatch<V>>, EnvironmentCache<V>);
 type ParentMap<V> = HashMap<V, Option<V>>;
 
@@ -60,10 +61,17 @@ struct ComponentBatch<V> {
     point_to_assignment: Vec<usize>,
 }
 
+#[derive(Clone, Debug)]
+struct StackedMessage {
+    assignment_index: DynIndex,
+    tensor: TensorDynLen,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct CachedEvaluationStats {
     subtree_environment_count: usize,
     directed_message_count: usize,
+    batched_message_contract_count: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -730,25 +738,18 @@ where
         let plan = RootedMessagePlan::new(self.tree, center)?;
         let assignment_batches = self.build_message_assignment_batches(&plan, values)?;
 
-        let mut messages = HashMap::<V, Vec<TensorDynLen>>::new();
+        let mut messages = HashMap::<V, StackedMessage>::new();
         let mut directed_message_count = 0usize;
+        let mut batched_message_contract_count = 0usize;
         for node in &plan.postorder {
             let assignment_batch = assignment_batches
                 .get(node)
                 .ok_or_else(|| anyhow::anyhow!("missing assignment batch for node {:?}", node))?;
-            let mut node_messages = Vec::with_capacity(assignment_batch.first_points.len());
-            for point in assignment_batch.first_points.iter().copied() {
-                node_messages.push(self.compute_directed_message(
-                    node,
-                    point,
-                    values,
-                    &plan,
-                    &assignment_batches,
-                    &messages,
-                )?);
-                directed_message_count += 1;
-            }
-            messages.insert(node.clone(), node_messages);
+            directed_message_count += assignment_batch.first_points.len();
+            let node_message =
+                self.compute_stacked_message(node, values, &plan, &assignment_batches, &messages)?;
+            batched_message_contract_count += 1;
+            messages.insert(node.clone(), node_message);
         }
 
         let mut component_batches = Vec::new();
@@ -761,14 +762,14 @@ where
                     neighbor
                 )
             })?;
-            let environments = messages.remove(&neighbor).ok_or_else(|| {
+            let environment = messages.remove(&neighbor).ok_or_else(|| {
                 anyhow::anyhow!(
                     "TreeTNCachedEvaluator::evaluate_batch: missing messages for neighbor {:?}",
                     neighbor
                 )
             })?;
-            subtree_environment_count += environments.len();
-            cache.insert(neighbor.clone(), environments);
+            subtree_environment_count += assignment_batch.first_points.len();
+            cache.insert(neighbor.clone(), environment);
             component_batches.push(ComponentBatch {
                 neighbor,
                 point_to_assignment: assignment_batch.point_to_assignment.clone(),
@@ -776,6 +777,7 @@ where
         }
         self.last_stats.subtree_environment_count = subtree_environment_count;
         self.last_stats.directed_message_count = directed_message_count;
+        self.last_stats.batched_message_contract_count = batched_message_contract_count;
         Ok((component_batches, cache))
     }
 
@@ -837,61 +839,95 @@ where
         Ok(assignment_batches)
     }
 
-    fn compute_directed_message(
+    fn compute_stacked_message(
         &self,
         node: &V,
-        point: usize,
         values: ColMajorArrayRef<'_, usize>,
         plan: &RootedMessagePlan<V>,
         assignment_batches: &HashMap<V, AssignmentBatch>,
-        messages: &HashMap<V, Vec<TensorDynLen>>,
-    ) -> Result<TensorDynLen> {
+        messages: &HashMap<V, StackedMessage>,
+    ) -> Result<StackedMessage> {
+        let assignment_batch = assignment_batches.get(node).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::evaluate_batch: missing assignments for {:?}",
+                node
+            )
+        })?;
+        let assignment_index = DynIndex::new_dyn(assignment_batch.first_points.len());
         let tensor = tensor_for_node(self.tree, node)?;
-        let index_vals = self.index_vals_for_point(node, values, point);
-        let local_message = slice_tensor(tensor, &index_vals).with_context(|| {
+        let mut local_slices = Vec::with_capacity(assignment_batch.first_points.len());
+        for point in assignment_batch.first_points.iter().copied() {
+            let index_vals = self.index_vals_for_point(node, values, point);
+            local_slices.push(slice_tensor(tensor, &index_vals).with_context(|| {
+                format!(
+                    "TreeTNCachedEvaluator::evaluate_batch: failed to slice message node {:?}",
+                    node
+                )
+            })?);
+        }
+        let local_message = stack_tensors_with_assignment_index(&assignment_index, &local_slices)
+            .with_context(|| {
             format!(
-                "TreeTNCachedEvaluator::evaluate_batch: failed to slice message node {:?}",
+                "TreeTNCachedEvaluator::evaluate_batch: failed to stack message node {:?}",
                 node
             )
         })?;
 
         let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
         if children.is_empty() {
-            return Ok(local_message);
+            return Ok(StackedMessage {
+                assignment_index,
+                tensor: local_message,
+            });
         }
 
-        let mut child_messages = Vec::with_capacity(children.len());
+        let mut operands = Vec::with_capacity(1 + children.len());
+        operands.push(local_message);
         for child in children {
-            let assignment_batch = assignment_batches.get(child).ok_or_else(|| {
+            let child_assignment_batch = assignment_batches.get(child).ok_or_else(|| {
                 anyhow::anyhow!(
                     "TreeTNCachedEvaluator::evaluate_batch: missing child assignments for {:?}",
                     child
                 )
             })?;
-            let assignment_id = assignment_batch
-                .point_to_assignment
-                .get(point)
-                .copied()
-                .ok_or_else(|| anyhow::anyhow!("missing child assignment for point {point}"))?;
-            let child_message = messages
-                .get(child)
-                .and_then(|node_messages| node_messages.get(assignment_id))
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "TreeTNCachedEvaluator::evaluate_batch: missing child message for {:?}",
-                        child
-                    )
-                })?;
-            child_messages.push(child_message.clone());
+            let selected_assignments = assignment_batch
+                .first_points
+                .iter()
+                .map(|&point| {
+                    child_assignment_batch
+                        .point_to_assignment
+                        .get(point)
+                        .copied()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("missing child assignment for point {point}")
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let child_message = messages.get(child).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "TreeTNCachedEvaluator::evaluate_batch: missing child message for {:?}",
+                    child
+                )
+            })?;
+            operands.push(gather_stacked_tensor(
+                &child_message.tensor,
+                &child_message.assignment_index,
+                &assignment_index,
+                &selected_assignments,
+            )?);
         }
 
-        let mut message = local_message;
-        for child_message in child_messages {
-            message = message.contract_pair(&child_message).context(
-                "TreeTNCachedEvaluator::evaluate_batch: failed to contract directed message",
-            )?;
-        }
-        Ok(message)
+        let retain = [assignment_index.clone()];
+        let options = ContractionOptions::new(AllowedPairs::All).with_retain_indices(&retain);
+        let operand_refs = operands.iter().collect::<Vec<_>>();
+        let tensor = contract_multi_with_options(&operand_refs, options).context(
+            "TreeTNCachedEvaluator::evaluate_batch: failed to contract batched directed message",
+        )?;
+        let tensor = ensure_assignment_axis_first(tensor, &assignment_index)?;
+        Ok(StackedMessage {
+            assignment_index,
+            tensor,
+        })
     }
 
     fn contract_center_for_points(
@@ -928,16 +964,22 @@ where
             let mut result_tensor = center_partial;
             for batch in component_batches {
                 let assignment_id = batch.point_to_assignment[point];
-                let environment = environment_cache
-                    .get(&batch.neighbor)
-                    .and_then(|environments| environments.get(assignment_id))
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "TreeTNCachedEvaluator::evaluate_batch: missing cached environment"
-                        )
-                    })?;
+                let environment = environment_cache.get(&batch.neighbor).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "TreeTNCachedEvaluator::evaluate_batch: missing cached environment"
+                    )
+                })?;
+                let environment = environment
+                    .tensor
+                    .select_indices(
+                        std::slice::from_ref(&environment.assignment_index),
+                        &[assignment_id],
+                    )
+                    .context(
+                        "TreeTNCachedEvaluator::evaluate_batch: failed to select cached environment",
+                    )?;
                 result_tensor = result_tensor
-                    .contract_pair(environment)
+                    .contract_pair(&environment)
                     .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center")?;
             }
 
@@ -1265,6 +1307,30 @@ fn gather_stacked_tensor(
     indices.push(target_assignment_index.clone());
     indices.extend_from_slice(&stacked.indices()[1..]);
     TensorDynLen::from_dense_any(indices, gathered)
+}
+
+fn ensure_assignment_axis_first(
+    tensor: TensorDynLen,
+    assignment_index: &DynIndex,
+) -> Result<TensorDynLen> {
+    if tensor.indices().first() == Some(assignment_index) {
+        return Ok(tensor);
+    }
+    anyhow::ensure!(
+        tensor.indices().contains(assignment_index),
+        "batched contraction result is missing assignment index {:?}",
+        assignment_index
+    );
+    let mut new_order = Vec::with_capacity(tensor.indices().len());
+    new_order.push(assignment_index.clone());
+    new_order.extend(
+        tensor
+            .indices()
+            .iter()
+            .filter(|index| *index != assignment_index)
+            .cloned(),
+    );
+    tensor.permuteinds(&new_order)
 }
 
 fn sorted_neighbors<T, V>(tree: &TreeTN<T, V>) -> HashMap<V, Vec<V>>
@@ -1632,6 +1698,35 @@ mod tests {
 
         assert_scalars_close(&actual, &expected);
         assert_eq!(evaluator.stats_for_test().directed_message_count, 12);
+    }
+
+    #[test]
+    fn cached_evaluator_batches_directed_messages() {
+        let (tree, indices) = five_node_chain();
+        let values = vec![
+            0, 0, 0, 0, 0, //
+            0, 1, 0, 0, 1, //
+            1, 0, 1, 1, 0, //
+            1, 1, 1, 1, 1,
+        ];
+        let shape = [5, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(2),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let actual = evaluator.evaluate_batch(points).unwrap();
+        let stats = evaluator.stats_for_test();
+
+        assert_scalars_close(&actual, &expected);
+        assert!(stats.batched_message_contract_count < stats.directed_message_count);
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -5,7 +5,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use anyhow::{bail, Context, Result};
-use tensor4all_core::{AnyScalar, ColMajorArrayRef, IndexLike, TensorLike};
+use num_complex::Complex64;
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen, TensorLike};
 
 use super::TreeTN;
 
@@ -1188,6 +1189,110 @@ where
     tensor.select_indices(&selected_indices, &positions)
 }
 
+fn tensor_values_any(tensor: &TensorDynLen) -> Result<Vec<AnyScalar>> {
+    if tensor.is_complex() {
+        tensor.to_vec::<Complex64>().map(|values| {
+            values
+                .into_iter()
+                .map(|value| AnyScalar::new_complex(value.re, value.im))
+                .collect()
+        })
+    } else {
+        tensor
+            .to_vec::<f64>()
+            .map(|values| values.into_iter().map(AnyScalar::new_real).collect())
+    }
+}
+
+fn stack_tensors_with_assignment_index(
+    assignment_index: &DynIndex,
+    tensors: &[TensorDynLen],
+) -> Result<TensorDynLen> {
+    anyhow::ensure!(
+        !tensors.is_empty(),
+        "stack_tensors_with_assignment_index requires at least one tensor"
+    );
+    anyhow::ensure!(
+        assignment_index.dim() == tensors.len(),
+        "assignment index dim {} does not match tensor count {}",
+        assignment_index.dim(),
+        tensors.len()
+    );
+
+    let base_indices = tensors[0].indices().to_vec();
+    let mut tensor_values = Vec::with_capacity(tensors.len());
+    for tensor in tensors {
+        anyhow::ensure!(
+            tensor.indices() == base_indices.as_slice(),
+            "stacked tensors must have identical index order"
+        );
+        tensor_values.push(tensor_values_any(tensor)?);
+    }
+
+    let rest_len = tensor_values[0].len();
+    let batch_dim = assignment_index.dim();
+    let mut stacked = Vec::with_capacity(batch_dim * rest_len);
+    for rest_offset in 0..rest_len {
+        for values in &tensor_values {
+            stacked.push(values[rest_offset].clone());
+        }
+    }
+
+    let mut indices = Vec::with_capacity(1 + base_indices.len());
+    indices.push(assignment_index.clone());
+    indices.extend(base_indices);
+    TensorDynLen::from_dense_any(indices, stacked)
+}
+
+fn gather_stacked_tensor(
+    stacked: &TensorDynLen,
+    source_assignment_index: &DynIndex,
+    target_assignment_index: &DynIndex,
+    selected_assignments: &[usize],
+) -> Result<TensorDynLen> {
+    anyhow::ensure!(
+        stacked.indices().first() == Some(source_assignment_index),
+        "source assignment index must be the first stacked axis"
+    );
+    anyhow::ensure!(
+        selected_assignments.len() == target_assignment_index.dim(),
+        "selected assignment count {} does not match target assignment dim {}",
+        selected_assignments.len(),
+        target_assignment_index.dim()
+    );
+
+    let source_dim = source_assignment_index.dim();
+    for &assignment in selected_assignments {
+        anyhow::ensure!(
+            assignment < source_dim,
+            "selected assignment {} is out of range for source dim {}",
+            assignment,
+            source_dim
+        );
+    }
+
+    let values = tensor_values_any(stacked)?;
+    anyhow::ensure!(
+        values.len() % source_dim == 0,
+        "stacked tensor payload length {} is not divisible by source dim {}",
+        values.len(),
+        source_dim
+    );
+    let rest_len = values.len() / source_dim;
+    let target_dim = target_assignment_index.dim();
+    let mut gathered = Vec::with_capacity(target_dim * rest_len);
+    for rest_offset in 0..rest_len {
+        for &assignment in selected_assignments {
+            gathered.push(values[assignment + source_dim * rest_offset].clone());
+        }
+    }
+
+    let mut indices = Vec::with_capacity(stacked.indices().len());
+    indices.push(target_assignment_index.clone());
+    indices.extend_from_slice(&stacked.indices()[1..]);
+    TensorDynLen::from_dense_any(indices, gathered)
+}
+
 fn sorted_neighbors<T, V>(tree: &TreeTN<T, V>) -> HashMap<V, Vec<V>>
 where
     T: TensorLike,
@@ -1254,6 +1359,40 @@ mod tests {
                 expected.real()
             );
         }
+    }
+
+    #[test]
+    fn stack_tensors_adds_assignment_axis_in_column_major_order() {
+        let batch = DynIndex::new_dyn(2);
+        let i = DynIndex::new_dyn(2);
+        let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+        let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+
+        let stacked = stack_tensors_with_assignment_index(&batch, &[a, b]).unwrap();
+
+        assert_eq!(stacked.indices(), &[batch, i]);
+        assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 3.0, 2.0, 4.0]);
+    }
+
+    #[test]
+    fn gather_stacked_tensor_remaps_assignment_axis() {
+        let source_batch = DynIndex::new_dyn(3);
+        let target_batch = DynIndex::new_dyn(4);
+        let i = DynIndex::new_dyn(2);
+        let stacked = TensorDynLen::from_dense(
+            vec![source_batch.clone(), i.clone()],
+            vec![10.0_f64, 20.0, 30.0, 11.0, 21.0, 31.0],
+        )
+        .unwrap();
+
+        let gathered =
+            gather_stacked_tensor(&stacked, &source_batch, &target_batch, &[2, 0, 2, 1]).unwrap();
+
+        assert_eq!(gathered.indices(), &[target_batch, i]);
+        assert_eq!(
+            gathered.to_vec::<f64>().unwrap(),
+            vec![30.0, 10.0, 30.0, 20.0, 31.0, 11.0, 31.0, 21.0]
+        );
     }
 
     fn two_node_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -72,6 +72,7 @@ struct CachedEvaluationStats {
     subtree_environment_count: usize,
     directed_message_count: usize,
     batched_message_contract_count: usize,
+    batched_center_contract_count: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -712,10 +713,21 @@ where
             self.layout.n_indices,
             "TreeTNCachedEvaluator::evaluate_batch",
         )?;
+        if values.shape()[1] == 0 {
+            self.last_stats = CachedEvaluationStats::default();
+            return Ok(Vec::new());
+        }
         let center = self.ensure_center(values)?.clone();
         let (component_batches, environment_cache) =
             self.build_environment_cache(&center, values)?;
-        self.contract_center_for_points(&center, values, &component_batches, &environment_cache)
+        let results = self.contract_center_for_points(
+            &center,
+            values,
+            &component_batches,
+            &environment_cache,
+        )?;
+        self.last_stats.batched_center_contract_count = 1;
+        Ok(results)
     }
 
     fn ensure_center(&mut self, values: ColMajorArrayRef<'_, usize>) -> Result<&V> {
@@ -938,6 +950,9 @@ where
         environment_cache: &EnvironmentCache<V>,
     ) -> Result<Vec<AnyScalar>> {
         let n_points = values.shape()[1];
+        if n_points == 0 {
+            return Ok(Vec::new());
+        }
         let center_entries = self
             .layout
             .entries_by_node
@@ -945,10 +960,8 @@ where
             .map(Vec::as_slice)
             .unwrap_or(&[]);
         let center_tensor = tensor_for_node(self.tree, center)?;
-        let scalar_one = TensorDynLen::scalar_one()
-            .context("TreeTNCachedEvaluator::evaluate_batch: failed to create scalar")?;
-
-        let mut results = Vec::with_capacity(n_points);
+        let point_index = DynIndex::new_dyn(n_points);
+        let mut center_slices = Vec::with_capacity(n_points);
         for point in 0..n_points {
             let center_index_vals = center_entries
                 .iter()
@@ -958,39 +971,53 @@ where
                 })
                 .collect::<Vec<_>>();
             validate_index_vals(&center_index_vals, "TreeTNCachedEvaluator::evaluate_batch")?;
-            let center_partial = slice_tensor(center_tensor, &center_index_vals)
-                .context("TreeTNCachedEvaluator::evaluate_batch: failed to slice center tensor")?;
-
-            let mut result_tensor = center_partial;
-            for batch in component_batches {
-                let assignment_id = batch.point_to_assignment[point];
-                let environment = environment_cache.get(&batch.neighbor).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "TreeTNCachedEvaluator::evaluate_batch: missing cached environment"
-                    )
-                })?;
-                let environment = environment
-                    .tensor
-                    .select_indices(
-                        std::slice::from_ref(&environment.assignment_index),
-                        &[assignment_id],
-                    )
-                    .context(
-                        "TreeTNCachedEvaluator::evaluate_batch: failed to select cached environment",
-                    )?;
-                result_tensor = result_tensor
-                    .contract_pair(&environment)
-                    .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center")?;
-            }
-
-            results.push(
-                scalar_one
-                    .inner_product(&result_tensor)
-                    .context("TreeTNCachedEvaluator::evaluate_batch: failed to extract scalar")?,
+            center_slices.push(
+                slice_tensor(center_tensor, &center_index_vals).context(
+                    "TreeTNCachedEvaluator::evaluate_batch: failed to slice center tensor",
+                )?,
             );
         }
 
-        Ok(results)
+        let mut operands = Vec::with_capacity(1 + component_batches.len());
+        operands.push(
+            stack_tensors_with_assignment_index(&point_index, &center_slices)
+                .context("TreeTNCachedEvaluator::evaluate_batch: failed to stack center tensor")?,
+        );
+
+        for batch in component_batches {
+            let environment = environment_cache.get(&batch.neighbor).ok_or_else(|| {
+                anyhow::anyhow!("TreeTNCachedEvaluator::evaluate_batch: missing cached environment")
+            })?;
+            operands.push(
+                gather_stacked_tensor(
+                    &environment.tensor,
+                    &environment.assignment_index,
+                    &point_index,
+                    &batch.point_to_assignment,
+                )
+                .context(
+                    "TreeTNCachedEvaluator::evaluate_batch: failed to gather center environment",
+                )?,
+            );
+        }
+
+        let result_tensor = if operands.len() == 1 {
+            operands.remove(0)
+        } else {
+            let retain = [point_index.clone()];
+            let options = ContractionOptions::new(AllowedPairs::All).with_retain_indices(&retain);
+            let operand_refs = operands.iter().collect::<Vec<_>>();
+            contract_multi_with_options(&operand_refs, options)
+                .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center batch")?
+        };
+        let result_tensor = ensure_assignment_axis_first(result_tensor, &point_index)?;
+        anyhow::ensure!(
+            result_tensor.indices() == std::slice::from_ref(&point_index),
+            "TreeTNCachedEvaluator::evaluate_batch: center contraction left non-scalar indices {:?}",
+            result_tensor.indices()
+        );
+
+        tensor_values_any(&result_tensor)
     }
 
     fn index_vals_for_point(
@@ -1797,5 +1824,33 @@ mod tests {
         let actual = evaluator.evaluate_batch(points).unwrap();
 
         assert_scalars_close(&actual, &expected);
+    }
+
+    #[test]
+    fn cached_evaluator_batches_center_contraction() {
+        let (tree, indices) = star_tree();
+        let values = vec![
+            0, 0, 0, 0, //
+            1, 0, 1, 0, //
+            0, 1, 0, 1, //
+            1, 1, 1, 1,
+        ];
+        let shape = [4, 4];
+        let points = ColMajorArrayRef::new(&values, &shape);
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let actual = evaluator.evaluate_batch(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+        assert_eq!(evaluator.stats_for_test().batched_center_contract_count, 1);
     }
 }

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -6,25 +6,27 @@ use std::hash::Hash;
 
 use anyhow::{bail, Context, Result};
 use num_complex::Complex64;
-use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen, TensorLike};
+use tensor4all_core::{
+    AnyScalar, ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen, TensorIndex, TensorLike,
+};
 
 use super::TreeTN;
 
 type KeyId = usize;
-type EnvironmentCache<T, V> = HashMap<V, Vec<T>>;
-type CacheBuildResult<T, V> = (Vec<ComponentBatch<V>>, EnvironmentCache<T, V>);
+type EnvironmentCache<V> = HashMap<V, Vec<TensorDynLen>>;
+type CacheBuildResult<V> = (Vec<ComponentBatch<V>>, EnvironmentCache<V>);
 type ParentMap<V> = HashMap<V, Option<V>>;
 
 #[derive(Clone, Debug)]
-struct SiteEntry<I> {
-    index: I,
+struct SiteEntry {
+    index: DynIndex,
     input_position: usize,
     local_axis: usize,
 }
 
 #[derive(Clone, Debug)]
-struct EvaluatorLayout<I, V> {
-    entries_by_node: HashMap<V, Vec<SiteEntry<I>>>,
+struct EvaluatorLayout<V> {
+    entries_by_node: HashMap<V, Vec<SiteEntry>>,
     n_indices: usize,
 }
 
@@ -81,30 +83,20 @@ impl<V> ComponentCostIndex<V>
 where
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
-    fn new<T>(
-        tree: &TreeTN<T, V>,
-        indices: &[T::Index],
+    fn new(
+        tree: &TreeTN<TensorDynLen, V>,
+        indices: &[DynIndex],
         values: ColMajorArrayRef<'_, usize>,
-    ) -> Result<Self>
-    where
-        T: TensorLike,
-        T::Index: Clone + Eq + Hash,
-        <T::Index as IndexLike>::Id: Ord,
-    {
+    ) -> Result<Self> {
         let layout = build_layout(tree, indices)?;
         Self::from_layout(tree, &layout, values)
     }
 
-    fn from_layout<T>(
-        tree: &TreeTN<T, V>,
-        layout: &EvaluatorLayout<T::Index, V>,
+    fn from_layout(
+        tree: &TreeTN<TensorDynLen, V>,
+        layout: &EvaluatorLayout<V>,
         values: ColMajorArrayRef<'_, usize>,
-    ) -> Result<Self>
-    where
-        T: TensorLike,
-        T::Index: Clone + Eq + Hash,
-        <T::Index as IndexLike>::Id: Ord,
-    {
+    ) -> Result<Self> {
         validate_values_shape(values, layout.n_indices, "ComponentCostIndex::new")?;
         let n_points = values.shape()[1];
 
@@ -291,10 +283,7 @@ impl<V> RootedMessagePlan<V>
 where
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
-    fn new<T>(tree: &TreeTN<T, V>, center: &V) -> Result<Self>
-    where
-        T: TensorLike,
-    {
+    fn new(tree: &TreeTN<TensorDynLen, V>, center: &V) -> Result<Self> {
         let neighbors = sorted_neighbors(tree);
         let (parent, order) = rooted_tree(&neighbors, center)?;
 
@@ -574,23 +563,19 @@ where
 /// assert_eq!(evaluator.center(), Some(&0));
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub struct TreeTNCachedEvaluator<'a, T, V>
+pub struct TreeTNCachedEvaluator<'a, V>
 where
-    T: TensorLike,
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
-    tree: &'a TreeTN<T, V>,
-    layout: EvaluatorLayout<T::Index, V>,
+    tree: &'a TreeTN<TensorDynLen, V>,
+    layout: EvaluatorLayout<V>,
     options: CachedEvaluatorOptions<V>,
     center: Option<V>,
     last_stats: CachedEvaluationStats,
 }
 
-impl<'a, T, V> TreeTNCachedEvaluator<'a, T, V>
+impl<'a, V> TreeTNCachedEvaluator<'a, V>
 where
-    T: TensorLike,
-    T::Index: Clone + Eq + Hash,
-    <T::Index as IndexLike>::Id: Clone + Eq + Hash + Ord + Debug + Send + Sync,
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
     /// Creates a cached evaluator for `tree` and the requested physical indices.
@@ -622,8 +607,8 @@ where
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn new(
-        tree: &'a TreeTN<T, V>,
-        indices: &[T::Index],
+        tree: &'a TreeTN<TensorDynLen, V>,
+        indices: &[DynIndex],
         options: CachedEvaluatorOptions<V>,
     ) -> Result<Self> {
         let layout = build_layout(tree, indices)?;
@@ -740,12 +725,12 @@ where
         &mut self,
         center: &V,
         values: ColMajorArrayRef<'_, usize>,
-    ) -> Result<CacheBuildResult<T, V>> {
+    ) -> Result<CacheBuildResult<V>> {
         self.last_stats = CachedEvaluationStats::default();
         let plan = RootedMessagePlan::new(self.tree, center)?;
         let assignment_batches = self.build_message_assignment_batches(&plan, values)?;
 
-        let mut messages = HashMap::<V, Vec<T>>::new();
+        let mut messages = HashMap::<V, Vec<TensorDynLen>>::new();
         let mut directed_message_count = 0usize;
         for node in &plan.postorder {
             let assignment_batch = assignment_batches
@@ -859,8 +844,8 @@ where
         values: ColMajorArrayRef<'_, usize>,
         plan: &RootedMessagePlan<V>,
         assignment_batches: &HashMap<V, AssignmentBatch>,
-        messages: &HashMap<V, Vec<T>>,
-    ) -> Result<T> {
+        messages: &HashMap<V, Vec<TensorDynLen>>,
+    ) -> Result<TensorDynLen> {
         let tensor = tensor_for_node(self.tree, node)?;
         let index_vals = self.index_vals_for_point(node, values, point);
         let local_message = slice_tensor(tensor, &index_vals).with_context(|| {
@@ -914,7 +899,7 @@ where
         center: &V,
         values: ColMajorArrayRef<'_, usize>,
         component_batches: &[ComponentBatch<V>],
-        environment_cache: &EnvironmentCache<T, V>,
+        environment_cache: &EnvironmentCache<V>,
     ) -> Result<Vec<AnyScalar>> {
         let n_points = values.shape()[1];
         let center_entries = self
@@ -924,7 +909,7 @@ where
             .map(Vec::as_slice)
             .unwrap_or(&[]);
         let center_tensor = tensor_for_node(self.tree, center)?;
-        let scalar_one = T::scalar_one()
+        let scalar_one = TensorDynLen::scalar_one()
             .context("TreeTNCachedEvaluator::evaluate_batch: failed to create scalar")?;
 
         let mut results = Vec::with_capacity(n_points);
@@ -971,7 +956,7 @@ where
         node: &V,
         values: ColMajorArrayRef<'_, usize>,
         point: usize,
-    ) -> Vec<(T::Index, usize)> {
+    ) -> Vec<(DynIndex, usize)> {
         self.layout
             .entries_by_node
             .get(node)
@@ -993,14 +978,11 @@ where
     }
 }
 
-fn build_layout<T, V>(
-    tree: &TreeTN<T, V>,
-    indices: &[T::Index],
-) -> Result<EvaluatorLayout<T::Index, V>>
+fn build_layout<V>(
+    tree: &TreeTN<TensorDynLen, V>,
+    indices: &[DynIndex],
+) -> Result<EvaluatorLayout<V>>
 where
-    T: TensorLike,
-    T::Index: Clone + Eq + Hash,
-    <T::Index as IndexLike>::Id: Ord,
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
     if tree.node_count() == 0 {
@@ -1024,8 +1006,8 @@ where
         );
     }
 
-    let mut entries_by_node: HashMap<V, Vec<SiteEntry<T::Index>>> = HashMap::new();
-    let mut tensor_indices_by_node: HashMap<V, Vec<T::Index>> = HashMap::new();
+    let mut entries_by_node: HashMap<V, Vec<SiteEntry>> = HashMap::new();
+    let mut tensor_indices_by_node: HashMap<V, Vec<DynIndex>> = HashMap::new();
     for (input_position, index) in indices.iter().enumerate() {
         let node_name = tree
             .site_index_network()
@@ -1119,10 +1101,7 @@ fn validate_values_shape(
     Ok(())
 }
 
-fn validate_entry_values<I>(entries: &[SiteEntry<I>], values: &[usize], context: &str) -> Result<()>
-where
-    I: IndexLike,
-{
+fn validate_entry_values(entries: &[SiteEntry], values: &[usize], context: &str) -> Result<()> {
     let index_vals = entries
         .iter()
         .zip(values.iter().copied())
@@ -1147,9 +1126,8 @@ where
     Ok(())
 }
 
-fn ensure_node_exists<T, V>(tree: &TreeTN<T, V>, node: &V, context: &str) -> Result<()>
+fn ensure_node_exists<V>(tree: &TreeTN<TensorDynLen, V>, node: &V, context: &str) -> Result<()>
 where
-    T: TensorLike,
     V: Clone + Eq + Hash + Debug + Send + Sync,
 {
     if tree.node_index(node).is_none() {
@@ -1158,9 +1136,8 @@ where
     Ok(())
 }
 
-fn tensor_for_node<'a, T, V>(tree: &'a TreeTN<T, V>, node: &V) -> Result<&'a T>
+fn tensor_for_node<'a, V>(tree: &'a TreeTN<TensorDynLen, V>, node: &V) -> Result<&'a TensorDynLen>
 where
-    T: TensorLike,
     V: Clone + Eq + Hash + Debug + Send + Sync,
 {
     let node_idx = tree
@@ -1170,10 +1147,7 @@ where
         .ok_or_else(|| anyhow::anyhow!("tensor for node {:?} is not present", node))
 }
 
-fn slice_tensor<T>(tensor: &T, index_vals: &[(T::Index, usize)]) -> Result<T>
-where
-    T: TensorLike,
-{
+fn slice_tensor(tensor: &TensorDynLen, index_vals: &[(DynIndex, usize)]) -> Result<TensorDynLen> {
     if index_vals.is_empty() {
         return Ok(tensor.clone());
     }

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -935,7 +935,7 @@ where
         let tensor = contract_multi_with_options(&operand_refs, options).context(
             "TreeTNCachedEvaluator::evaluate_batch: failed to contract batched directed message",
         )?;
-        let tensor = ensure_assignment_axis_first(tensor, &assignment_index)?;
+        let tensor = ensure_assignment_axis_last(tensor, &assignment_index)?;
         Ok(StackedMessage {
             assignment_index,
             tensor,
@@ -1010,7 +1010,7 @@ where
             contract_multi_with_options(&operand_refs, options)
                 .context("TreeTNCachedEvaluator::evaluate_batch: failed to contract center batch")?
         };
-        let result_tensor = ensure_assignment_axis_first(result_tensor, &point_index)?;
+        let result_tensor = ensure_assignment_axis_last(result_tensor, &point_index)?;
         anyhow::ensure!(
             result_tensor.indices() == std::slice::from_ref(&point_index),
             "TreeTNCachedEvaluator::evaluate_batch: center contraction left non-scalar indices {:?}",
@@ -1262,29 +1262,8 @@ fn stack_tensors_with_assignment_index(
         tensors.len()
     );
 
-    let base_indices = tensors[0].indices().to_vec();
-    let mut tensor_values = Vec::with_capacity(tensors.len());
-    for tensor in tensors {
-        anyhow::ensure!(
-            tensor.indices() == base_indices.as_slice(),
-            "stacked tensors must have identical index order"
-        );
-        tensor_values.push(tensor_values_any(tensor)?);
-    }
-
-    let rest_len = tensor_values[0].len();
-    let batch_dim = assignment_index.dim();
-    let mut stacked = Vec::with_capacity(batch_dim * rest_len);
-    for rest_offset in 0..rest_len {
-        for values in &tensor_values {
-            stacked.push(values[rest_offset].clone());
-        }
-    }
-
-    let mut indices = Vec::with_capacity(1 + base_indices.len());
-    indices.push(assignment_index.clone());
-    indices.extend(base_indices);
-    TensorDynLen::from_dense_any(indices, stacked)
+    let tensor_refs = tensors.iter().collect::<Vec<_>>();
+    TensorDynLen::stack_along_new_index(&tensor_refs, assignment_index.clone(), -1)
 }
 
 fn gather_stacked_tensor(
@@ -1294,8 +1273,8 @@ fn gather_stacked_tensor(
     selected_assignments: &[usize],
 ) -> Result<TensorDynLen> {
     anyhow::ensure!(
-        stacked.indices().first() == Some(source_assignment_index),
-        "source assignment index must be the first stacked axis"
+        stacked.indices().last() == Some(source_assignment_index),
+        "source assignment index must be the last stacked axis"
     );
     anyhow::ensure!(
         selected_assignments.len() == target_assignment_index.dim(),
@@ -1304,43 +1283,18 @@ fn gather_stacked_tensor(
         target_assignment_index.dim()
     );
 
-    let source_dim = source_assignment_index.dim();
-    for &assignment in selected_assignments {
-        anyhow::ensure!(
-            assignment < source_dim,
-            "selected assignment {} is out of range for source dim {}",
-            assignment,
-            source_dim
-        );
-    }
-
-    let values = tensor_values_any(stacked)?;
-    anyhow::ensure!(
-        values.len() % source_dim == 0,
-        "stacked tensor payload length {} is not divisible by source dim {}",
-        values.len(),
-        source_dim
-    );
-    let rest_len = values.len() / source_dim;
-    let target_dim = target_assignment_index.dim();
-    let mut gathered = Vec::with_capacity(target_dim * rest_len);
-    for rest_offset in 0..rest_len {
-        for &assignment in selected_assignments {
-            gathered.push(values[assignment + source_dim * rest_offset].clone());
-        }
-    }
-
-    let mut indices = Vec::with_capacity(stacked.indices().len());
-    indices.push(target_assignment_index.clone());
-    indices.extend_from_slice(&stacked.indices()[1..]);
-    TensorDynLen::from_dense_any(indices, gathered)
+    stacked.index_select(
+        source_assignment_index,
+        target_assignment_index.clone(),
+        selected_assignments,
+    )
 }
 
-fn ensure_assignment_axis_first(
+fn ensure_assignment_axis_last(
     tensor: TensorDynLen,
     assignment_index: &DynIndex,
 ) -> Result<TensorDynLen> {
-    if tensor.indices().first() == Some(assignment_index) {
+    if tensor.indices().last() == Some(assignment_index) {
         return Ok(tensor);
     }
     anyhow::ensure!(
@@ -1349,7 +1303,6 @@ fn ensure_assignment_axis_first(
         assignment_index
     );
     let mut new_order = Vec::with_capacity(tensor.indices().len());
-    new_order.push(assignment_index.clone());
     new_order.extend(
         tensor
             .indices()
@@ -1357,6 +1310,7 @@ fn ensure_assignment_axis_first(
             .filter(|index| *index != assignment_index)
             .cloned(),
     );
+    new_order.push(assignment_index.clone());
     tensor.permuteinds(&new_order)
 }
 
@@ -1429,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn stack_tensors_adds_assignment_axis_in_column_major_order() {
+    fn stack_tensors_adds_trailing_assignment_axis_in_column_major_order() {
         let batch = DynIndex::new_dyn(2);
         let i = DynIndex::new_dyn(2);
         let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
@@ -1437,28 +1391,28 @@ mod tests {
 
         let stacked = stack_tensors_with_assignment_index(&batch, &[a, b]).unwrap();
 
-        assert_eq!(stacked.indices(), &[batch, i]);
-        assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 3.0, 2.0, 4.0]);
+        assert_eq!(stacked.indices(), &[i, batch]);
+        assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
     }
 
     #[test]
-    fn gather_stacked_tensor_remaps_assignment_axis() {
+    fn gather_stacked_tensor_remaps_trailing_assignment_axis() {
         let source_batch = DynIndex::new_dyn(3);
         let target_batch = DynIndex::new_dyn(4);
         let i = DynIndex::new_dyn(2);
         let stacked = TensorDynLen::from_dense(
-            vec![source_batch.clone(), i.clone()],
-            vec![10.0_f64, 20.0, 30.0, 11.0, 21.0, 31.0],
+            vec![i.clone(), source_batch.clone()],
+            vec![10.0_f64, 11.0, 20.0, 21.0, 30.0, 31.0],
         )
         .unwrap();
 
         let gathered =
             gather_stacked_tensor(&stacked, &source_batch, &target_batch, &[2, 0, 2, 1]).unwrap();
 
-        assert_eq!(gathered.indices(), &[target_batch, i]);
+        assert_eq!(gathered.indices(), &[i, target_batch]);
         assert_eq!(
             gathered.to_vec::<f64>().unwrap(),
-            vec![30.0, 10.0, 30.0, 20.0, 31.0, 11.0, 31.0, 21.0]
+            vec![30.0, 31.0, 10.0, 11.0, 30.0, 31.0, 20.0, 21.0]
         );
     }
 

--- a/docs/plans/2026-05-14-treetn-cached-batch-dim-capi-design.md
+++ b/docs/plans/2026-05-14-treetn-cached-batch-dim-capi-design.md
@@ -1,0 +1,84 @@
+# TreeTN Cached Batch-Dim C API Design
+
+## Goal
+
+Optimize `TreeTNCachedEvaluator` by batching repeated directed-message
+contractions over an explicit retained assignment index, and make the optimized
+batch evaluator the C API evaluator path.
+
+## Scope
+
+Backward compatibility is not required. The existing
+`t4a_treetn_evaluator` C handle should be repurposed for cached batch
+evaluation instead of adding a parallel uncached handle family. The Rust
+`TreeTNEvaluator` can remain as a reference/simple Rust API, but C bindings
+should use the cached evaluator by default.
+
+## Rust Evaluation Design
+
+The current directed-message cache computes each unique message by slicing one
+local tensor and then contracting it with selected child messages one assignment
+at a time. This has the right cache structure, but it pays repeated
+`TensorDynLen` setup, allocation, and index bookkeeping costs.
+
+The batch-dim path should group messages with the same local contraction shape:
+
+1. Build compact assignment batches as today.
+2. For each message node, create a fresh assignment index whose dimension is the
+   number of unique subtree assignments for that node.
+3. Stack the sliced local tensors along that assignment index.
+4. Gather child-message tensors according to the child assignment map, also
+   carrying the same assignment index.
+5. Contract the stacked local tensor and gathered child tensors while retaining
+   the assignment index.
+6. Store the resulting stacked message tensor and slice rows from it when the
+   center contraction needs one point.
+
+This should use `ContractionOptions::with_retain_indices` for `TensorDynLen`
+instead of TreeTN-specific dense loops. A generic `TensorLike` seam is acceptable
+only if it has a correct default implementation and a specialized
+`TensorDynLen` implementation.
+
+## C API Design
+
+Replace the internal contents of `t4a_treetn_evaluator` with owned cached
+evaluation state:
+
+- cloned `InternalTreeTN`
+- ordered site indices
+- selected cached center, if already chosen
+- scalar kind
+
+`t4a_treetn_evaluator_new` validates and stores the tree and index order.
+`t4a_treetn_evaluator_evaluate` constructs a temporary
+`TreeTNCachedEvaluator` borrowing the stored tree, evaluates the batch, then
+stores the selected center back into the C handle. This avoids self-referential
+Rust structs while preserving center reuse across repeated C calls.
+
+Because compatibility is not required, `t4a_treetn_evaluator_evaluate` may take
+a mutable evaluator pointer if that makes the cached state explicit. The one-shot
+`t4a_treetn_evaluate` should call the same cached evaluator path internally.
+
+The C API must preserve current error-detail behavior through `run_catching`,
+`run_status`, and `t4a_last_error_message`. Regenerate
+`crates/tensor4all-capi/include/tensor4all_capi.h` if any signature changes.
+
+## Testing
+
+Add Rust tests before implementation:
+
+- `TreeTNCachedEvaluator` matches `TreeTN::evaluate` on chains and branching
+  trees when the batched message path is enabled.
+- A shape-sensitive test verifies that retained assignment indices survive
+  child-message contraction and are removed only at scalar extraction.
+- C API evaluator tests cover repeated batches, clone/release behavior,
+  out-of-range coordinates, null pointers, and complex output requirements.
+- Header generation is checked after C API changes.
+
+## Benchmarks
+
+Extend `crates/tensor4all-treetn/benches/cached_evaluator.rs` to report the
+batched message path alongside `TTCache` and the pre-batch cached path when
+useful. The key acceptance data is bond-dimension scaling for equivalent chains:
+the TreeTN/TTCache ratio should decrease as `bond_dim` grows, or profiling
+output should identify the remaining dominant cost.

--- a/docs/plans/2026-05-14-treetn-cached-batch-dim-capi-plan.md
+++ b/docs/plans/2026-05-14-treetn-cached-batch-dim-capi-plan.md
@@ -1,0 +1,434 @@
+# TreeTN Cached Batch-Dim C API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Batch `TreeTNCachedEvaluator` message contractions over an explicit retained assignment index and make the C API TreeTN evaluator use that cached path.
+
+**Architecture:** Specialize `TreeTNCachedEvaluator` for `TensorDynLen` so it can create `DynIndex` assignment axes and call `ContractionOptions::with_retain_indices`. Keep greedy center selection and compact assignment batches, but compute each node's messages as one stacked tensor per node instead of one tensor per unique assignment. Replace the C API evaluator internals with owned cached-evaluation state and route both reusable and one-shot C evaluation through the cached path.
+
+**Tech Stack:** Rust, `tensor4all-core::TensorDynLen`, retained-index `contract_multi_with_options`, `TreeTN`, `tensor4all-capi`, cbindgen, Criterion.
+
+---
+
+### Task 1: Add failing TensorDynLen stack/gather tests
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing helper tests**
+
+Add tests inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn stack_tensors_adds_assignment_axis_in_column_major_order() {
+    let batch = DynIndex::new_dyn(2);
+    let i = DynIndex::new_dyn(2);
+    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+
+    let stacked = stack_tensors_with_assignment_index(&batch, &[a, b]).unwrap();
+
+    assert_eq!(stacked.indices(), &[batch, i]);
+    assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 3.0, 2.0, 4.0]);
+}
+
+#[test]
+fn gather_stacked_tensor_remaps_assignment_axis() {
+    let source_batch = DynIndex::new_dyn(3);
+    let target_batch = DynIndex::new_dyn(4);
+    let i = DynIndex::new_dyn(2);
+    let stacked = TensorDynLen::from_dense(
+        vec![source_batch.clone(), i.clone()],
+        vec![10.0_f64, 20.0, 30.0, 11.0, 21.0, 31.0],
+    ).unwrap();
+
+    let gathered =
+        gather_stacked_tensor(&stacked, &source_batch, &target_batch, &[2, 0, 2, 1]).unwrap();
+
+    assert_eq!(gathered.indices(), &[target_batch, i]);
+    assert_eq!(gathered.to_vec::<f64>().unwrap(), vec![30.0, 10.0, 30.0, 20.0, 31.0, 11.0, 31.0, 21.0]);
+}
+```
+
+**Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn stack_tensors_adds_assignment_axis_in_column_major_order --lib
+cargo test --release -p tensor4all-treetn gather_stacked_tensor_remaps_assignment_axis --lib
+```
+
+Expected: FAIL to compile because the helper functions do not exist.
+
+**Step 3: Implement minimal helpers**
+
+Add private helpers near `slice_tensor`:
+
+- `stack_tensors_with_assignment_index(batch_index: &DynIndex, tensors: &[TensorDynLen]) -> Result<TensorDynLen>`
+- `gather_stacked_tensor(stacked: &TensorDynLen, source_batch: &DynIndex, target_batch: &DynIndex, selected_assignments: &[usize]) -> Result<TensorDynLen>`
+- `tensor_values_any(tensor: &TensorDynLen) -> Result<Vec<AnyScalar>>`
+
+Both helpers should require the assignment axis to be the first axis in stacked
+tensors. Use column-major indexing: with batch first, flat offset is
+`batch_value + batch_dim * rest_offset`.
+
+**Step 4: Run tests to verify green**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn stack_tensors_adds_assignment_axis_in_column_major_order --lib
+cargo test --release -p tensor4all-treetn gather_stacked_tensor_remaps_assignment_axis --lib
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "test(treetn): cover stacked cached evaluator tensors"
+```
+
+### Task 2: Specialize cached evaluator around TensorDynLen
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+- Modify: `crates/tensor4all-treetn/src/lib.rs` only if public re-exports need signature updates
+
+**Step 1: Write failing compile-targeted tests**
+
+Update existing rustdoc examples and tests to instantiate
+`TreeTNCachedEvaluator<'_, V>` rather than `TreeTNCachedEvaluator<'_, T, V>` if
+the type signature changes. Add a test that calls `center()` before and after
+evaluation to ensure the public behavior remains.
+
+**Step 2: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator --lib
+```
+
+Expected: existing generic signatures fail until the implementation is updated.
+
+**Step 3: Refactor type signatures**
+
+Change cached evaluator internals from generic `T: TensorLike` to
+`TensorDynLen`/`DynIndex`:
+
+- `EvaluatorLayout<DynIndex, V>`
+- `EnvironmentCache<V> = HashMap<V, TensorDynLen>`
+- `TreeTNCachedEvaluator<'a, V> { tree: &'a TreeTN<TensorDynLen, V>, ... }`
+- `ComponentCostIndex::new` and `from_layout` should accept
+  `TreeTN<TensorDynLen, V>`
+
+Keep `GreedyCenterSearch<V>`, `CenterSearchResult<V>`, and
+`CachedEvaluatorOptions<V>` generic over node names.
+
+**Step 4: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator --lib
+cargo test --doc --release -p tensor4all-treetn TreeTNCachedEvaluator
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs crates/tensor4all-treetn/src/lib.rs
+git commit -m "refactor(treetn): specialize cached evaluator tensors"
+```
+
+### Task 3: Batch directed message construction
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing behavior test**
+
+Add a test on `five_node_chain()` that evaluates the same points as
+`cached_evaluator_reuses_directed_messages_inside_components`, then asserts a
+new test stat such as `batched_message_contract_count` is smaller than
+`directed_message_count`.
+
+```rust
+assert!(stats.batched_message_contract_count < stats.directed_message_count);
+```
+
+**Step 2: Run red test**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator_batches_directed_messages --lib
+```
+
+Expected: FAIL to compile because the stat and batched path do not exist.
+
+**Step 3: Implement stacked message tensors**
+
+Replace `EnvironmentCache<V> = HashMap<V, Vec<TensorDynLen>>` with stacked
+message storage:
+
+```rust
+struct StackedMessage {
+    assignment_index: DynIndex,
+    tensor: TensorDynLen,
+}
+type EnvironmentCache<V> = HashMap<V, StackedMessage>;
+```
+
+For each non-center node in postorder:
+
+1. Create `assignment_index = DynIndex::new_dyn(assignment_batch.first_points.len())`.
+2. Build local slices for each `first_point`.
+3. Stack them with `stack_tensors_with_assignment_index`.
+4. For each child, gather the child's stacked message onto the node assignment
+   index using the child assignment selected at each `first_point`.
+5. Contract local stack and gathered child stacks with:
+
+```rust
+let retain = [assignment_index.clone()];
+let options = ContractionOptions::new(AllowedPairs::All).with_retain_indices(&retain);
+contract_multi_with_options(&tensor_refs, options)
+```
+
+6. Store the result as that node's `StackedMessage`.
+
+**Step 4: Run green tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator --lib
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "perf(treetn): batch cached directed messages"
+```
+
+### Task 4: Batch center contraction and scalar extraction
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+
+**Step 1: Write failing test**
+
+Add a star-tree test that evaluates four points, checks values against
+`TreeTN::evaluate`, and asserts `batched_center_contract_count == 1`.
+
+**Step 2: Run red test**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator_batches_center_contraction --lib
+```
+
+Expected: FAIL before the center batched path is implemented.
+
+**Step 3: Implement center stack**
+
+In `contract_center_for_points`:
+
+1. Create a point assignment index `DynIndex::new_dyn(n_points)`.
+2. Stack sliced center tensors for each point.
+3. For each neighbor environment, gather the neighbor stacked message using
+   `component_batches[*].point_to_assignment`.
+4. Contract all stacked operands retaining the point index.
+5. Convert the resulting rank-1 tensor to `Vec<AnyScalar>`.
+
+**Step 4: Run green tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-treetn cached_evaluator --lib
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "perf(treetn): batch cached center contraction"
+```
+
+### Task 5: Replace C API evaluator internals with cached state
+
+**Files:**
+- Modify: `crates/tensor4all-capi/src/types.rs`
+- Modify: `crates/tensor4all-capi/src/treetn.rs`
+- Modify: `crates/tensor4all-capi/src/treetn/tests/mod.rs`
+- Regenerate: `crates/tensor4all-capi/include/tensor4all_capi.h`
+
+**Step 1: Write failing C API tests**
+
+Update existing evaluator tests so `t4a_treetn_evaluator_evaluate` takes
+`*mut t4a_treetn_evaluator`. Add a new test that releases the original TreeTN
+after creating an evaluator, then evaluates successfully through the evaluator.
+This proves the handle owns enough state.
+
+**Step 2: Run red test**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-capi test_treetn_evaluator_reuses_index_order_for_multiple_batches --lib
+```
+
+Expected: FAIL to compile until the C function signature and handle state are updated.
+
+**Step 3: Update handle state**
+
+In `types.rs`, replace `InternalTreeTNEvaluatorHandle` with:
+
+```rust
+#[derive(Clone)]
+pub(crate) struct InternalTreeTNEvaluatorHandle {
+    pub(crate) tree: InternalTreeTN,
+    pub(crate) indices: Vec<InternalIndex>,
+    pub(crate) center: Option<usize>,
+    pub(crate) scalar_kind: t4a_scalar_kind,
+}
+```
+
+Remove the `InternalTreeTNEvaluator` type alias if unused.
+
+**Step 4: Route C evaluation through TreeTNCachedEvaluator**
+
+In `treetn.rs`:
+
+- `t4a_treetn_evaluator_new` stores `tn.inner().clone()`, collected indices,
+  `center: None`, and scalar kind.
+- `require_evaluator_mut` accepts `*mut t4a_treetn_evaluator`.
+- `t4a_treetn_evaluator_evaluate` takes `*mut t4a_treetn_evaluator`.
+- It constructs `TreeTNCachedEvaluator::new(&handle.tree, &handle.indices, CachedEvaluatorOptions { center: handle.center, ..Default::default() })`.
+- After evaluation, write `handle.center = evaluator.center().copied()`.
+- `t4a_treetn_evaluate` uses the same cached evaluator path for one-shot calls.
+
+**Step 5: Regenerate header**
+
+Run:
+
+```bash
+mkdir -p crates/tensor4all-capi/include
+cbindgen crates/tensor4all-capi --config crates/tensor4all-capi/cbindgen.toml --output crates/tensor4all-capi/include/tensor4all_capi.h
+```
+
+Expected: header signature changes for `t4a_treetn_evaluator_evaluate`.
+
+**Step 6: Run C API tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-capi treetn_evaluator --lib
+```
+
+Expected: PASS.
+
+**Step 7: Commit**
+
+```bash
+git add crates/tensor4all-capi/src/types.rs crates/tensor4all-capi/src/treetn.rs crates/tensor4all-capi/src/treetn/tests/mod.rs crates/tensor4all-capi/include/tensor4all_capi.h
+git commit -m "feat(capi): use cached TreeTN evaluator"
+```
+
+### Task 6: Benchmark and validate
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/benches/cached_evaluator.rs`
+- Modify: PR body after benchmark data is collected
+
+**Step 1: Update benchmark labels if needed**
+
+Keep `treetn_cached` as the optimized cached evaluator. Add a temporary
+`treetn_uncached` baseline where it is already present. Do not keep a duplicate
+old cached implementation unless profiling shows it is necessary.
+
+**Step 2: Run validation**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --release -p tensor4all-treetn cached_evaluator --lib
+cargo test --release -p tensor4all-capi treetn_evaluator --lib
+cargo test --doc --release --workspace
+cargo nextest run --release --workspace
+cargo bench --no-run -p tensor4all-treetn --bench cached_evaluator
+```
+
+Expected: PASS.
+
+**Step 3: Run short benchmarks**
+
+Run:
+
+```bash
+cargo bench -p tensor4all-treetn --bench cached_evaluator -- treetn_cached_bond_dim/{ttcache,treetn_cached} --sample-size 10 --measurement-time 1 --warm-up-time 1
+cargo bench -p tensor4all-treetn --bench cached_evaluator -- treetn_cached_chain_size/{ttcache,treetn_cached} --sample-size 10 --measurement-time 1 --warm-up-time 1
+```
+
+Expected: report TreeTN/TTCache ratio and whether it decreases as `bond_dim`
+grows.
+
+**Step 4: Commit benchmark/docs updates**
+
+```bash
+git add crates/tensor4all-treetn/benches/cached_evaluator.rs
+git commit -m "bench(treetn): report cached batch-dim scaling"
+```
+
+### Task 7: Push and open PR
+
+**Files:**
+- No source changes unless PR body is saved to a temp file.
+
+**Step 1: Check branch state**
+
+Run:
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/main HEAD
+git status --short --branch
+```
+
+Expected: branch contains current `origin/main`, working tree clean.
+
+**Step 2: Push branch**
+
+Run:
+
+```bash
+git push -u origin codex/treetn-batch-dim-capi
+```
+
+**Step 3: Create PR**
+
+Run:
+
+```bash
+gh pr create --base main --head codex/treetn-batch-dim-capi --title "[codex] Batch TreeTN cached evaluator contractions" --body-file /tmp/treetn-batch-dim-capi-pr.md
+```
+
+The PR body must mention issue #502, C API signature changes, benchmark data,
+and validation commands.


### PR DESCRIPTION
## Summary
- Implements TreeTN cached batch evaluation over explicit retained assignment indices for directed messages and center contractions.
- Moves batch shape packing into `TensorDynLen::stack_along_new_index` and `TensorDynLen::index_select`, backed by tenferro `EagerTensor::stack` / `index_select` instead of TreeTN-local scalar buffer packing.
- Keeps TreeTN assignment axes trailing to match tenferro's batched-GEMM layout convention.
- Routes the C API TreeTN evaluator through the cached evaluator path; `t4a_treetn_evaluator_evaluate` now takes a mutable evaluator handle so the selected center can be retained in the handle.
- Adds AD coverage for stack/gather and rejects tracked compact structured storage where implicit materialization would detach gradients.
- Updates Matrix LUCI scalar dispatch tests for the newer tenferro f32/c32 dense factorization support.

Closes #502.

## C API impact
- `t4a_treetn_evaluator` now owns a cloned TreeTN, input index order, selected center, and scalar kind.
- `t4a_treetn_evaluator_evaluate` signature changed from `const struct t4a_treetn_evaluator *` to `struct t4a_treetn_evaluator *`.
- One-shot `t4a_treetn_evaluate` also uses the cached evaluator path.

## Benchmarks
Short Criterion runs, `--sample-size 10 --measurement-time 1 --warm-up-time 1`, same chain converted to TreeTN and compared with `TTCache`.

Bond dimension scaling, `N_SITES=128`, `N_LEFT=N_RIGHT=10`:

| bond dim | old TreeTN cached median | new TreeTN cached median |
| --- | ---: | ---: |
| 4 | 141.67 ms | 129.78 ms |
| 8 | 325.88 ms | 138.65 ms |
| 16 | 882.81 ms | 159.75 ms |
| 32 | 3.4939 s | 283.33 ms |
| 64 | 17.810 s | 648.24 ms |

Chain size scaling, `BOND_DIM=16`, `N_LEFT=N_RIGHT=20`:

| length | old TreeTN cached median | new TreeTN cached median |
| --- | ---: | ---: |
| 16 | 610.73 ms | 81.67 ms |
| 32 | 761.83 ms | 121.22 ms |
| 64 | 1.2841 s | 197.42 ms |
| 128 | 2.2439 s | 368.40 ms |

The TreeTN path is still more general than specialized `TTCache`, but the large bond-dimension blow-up from scalar buffer stack/gather is removed.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --release -p tensor4all-core --test tensor_shape_packing`
- `cargo clippy -p tensor4all-core -p tensor4all-treetn --all-targets -- -D warnings`
- `cargo test --doc --release -p tensor4all-core`
- `cargo test -p tensor4all-tcicore --lib test_matrix_luci_factor_dispatch`
- `cargo llvm-cov --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`