### PR TITLE
[codex] Normalize quantics transform constraint rows

### DIFF
--- a/crates/tensor4all-quanticstransform/README.md
+++ b/crates/tensor4all-quanticstransform/README.md
@@ -9,6 +9,7 @@ Quantics transformation operators for tensor train methods. Port of Quantics.jl.
 - `flip_operator()` — reflection: f(x) = g(2^R - x)
 - `quantics_fourier_operator()` — Quantics Fourier Transform (QFT)
 - `affine_operator()` — affine transform y = A·x + b with rational coefficients
+- `LinearConstraintRow` — primitive integer row normalization for scale-invariant constraints
 
 ## Conventions
 
@@ -18,6 +19,9 @@ Quantics transformation operators for tensor train methods. Port of Quantics.jl.
   `site = bit_var0 + 2 * bit_var1 + ...`.
 - QFT output is in bit-reversed frequency order.
 - Affine matrices are column-major.
+- `LinearConstraintRow` is for equality or halfspace constraints such as
+  `16*x <= 64`; it is not a simplification step for affine maps such as
+  `y = A*x + b`.
 - Dense materialization is for small reference/debug checks only.
 
 ## Example

--- a/crates/tensor4all-quanticstransform/src/affine.rs
+++ b/crates/tensor4all-quanticstransform/src/affine.rs
@@ -63,6 +63,137 @@ impl<const N: usize> BoolTensor<N> {
     }
 }
 
+/// A primitive integer row for a linear equality or inequality constraint.
+///
+/// Use this type when a row is scale-invariant, such as `a*x == rhs` or
+/// `a*x <= rhs`, and the row will be used to derive affine or halfspace
+/// transform operators. It is intentionally separate from [`AffineParams`]
+/// because an affine map `y = A*x + b` is not invariant under row scaling.
+///
+/// Related types: [`AffineParams`] stores affine-map parameters for
+/// [`affine_operator`]; this type stores normalized constraint rows that can be
+/// used before constructing a constraint-derived operator.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_quanticstransform::LinearConstraintRow;
+///
+/// let row = LinearConstraintRow::from_integers(vec![16], 64);
+/// assert_eq!(row.coefficients, vec![1]);
+/// assert_eq!(row.rhs, 4);
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LinearConstraintRow {
+    /// Integer coefficients in primitive form.
+    ///
+    /// The row is normalized by clearing rational denominators when needed and
+    /// then dividing all coefficients and the right-hand side by their positive
+    /// greatest common divisor. Use these coefficients when a constraint row is
+    /// scale-invariant, such as `a*x <= rhs` or `a*x == rhs`.
+    pub coefficients: Vec<i64>,
+    /// Integer right-hand side in primitive form.
+    ///
+    /// This value is reduced with [`Self::coefficients`]. For example,
+    /// `16*x <= 64` is represented as `coefficients = [1]` and `rhs = 4`.
+    pub rhs: i64,
+}
+
+impl LinearConstraintRow {
+    /// Create a primitive integer constraint row.
+    ///
+    /// # Arguments
+    ///
+    /// * `coefficients` - Coefficients of the left-hand side. The entries may
+    ///   share a positive common factor with `rhs`; that factor is removed.
+    /// * `rhs` - Right-hand side of the equality or inequality constraint.
+    ///
+    /// # Returns
+    ///
+    /// A row with the same represented equality or inequality set under
+    /// positive scaling. If all coefficients and `rhs` are zero, the zero row
+    /// is returned unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_quanticstransform::LinearConstraintRow;
+    ///
+    /// let row = LinearConstraintRow::from_integers(vec![16], 64);
+    /// assert_eq!(row.coefficients, vec![1]);
+    /// assert_eq!(row.rhs, 4);
+    ///
+    /// let negative = LinearConstraintRow::from_integers(vec![-16], -64);
+    /// assert_eq!(negative.coefficients, vec![-1]);
+    /// assert_eq!(negative.rhs, -4);
+    /// ```
+    pub fn from_integers(coefficients: Vec<i64>, rhs: i64) -> Self {
+        let common_factor = coefficients
+            .iter()
+            .chain(std::iter::once(&rhs))
+            .fold(0i64, |factor, value| factor.gcd(value))
+            .abs();
+
+        if common_factor > 1 {
+            Self {
+                coefficients: coefficients
+                    .into_iter()
+                    .map(|coefficient| coefficient / common_factor)
+                    .collect(),
+                rhs: rhs / common_factor,
+            }
+        } else {
+            Self { coefficients, rhs }
+        }
+    }
+
+    /// Create a primitive constraint row from rational values.
+    ///
+    /// # Arguments
+    ///
+    /// * `coefficients` - Rational coefficients of the left-hand side. The
+    ///   least common multiple of all denominators is used to clear
+    ///   denominators before gcd reduction.
+    /// * `rhs` - Rational right-hand side of the equality or inequality
+    ///   constraint.
+    ///
+    /// # Returns
+    ///
+    /// A primitive integer row equivalent to the rational constraint under
+    /// positive scaling. Use this for constraint rows before deriving
+    /// affine/halfspace projector operators; do not use it to simplify a
+    /// general affine map `y = A*x + b`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use num_rational::Rational64;
+    /// use tensor4all_quanticstransform::LinearConstraintRow;
+    ///
+    /// let row = LinearConstraintRow::from_rationals(
+    ///     vec![Rational64::new(2, 3), Rational64::new(4, 3)],
+    ///     Rational64::from_integer(2),
+    /// );
+    /// assert_eq!(row.coefficients, vec![1, 2]);
+    /// assert_eq!(row.rhs, 3);
+    /// ```
+    pub fn from_rationals(coefficients: Vec<Rational64>, rhs: Rational64) -> Self {
+        let mut denominator_lcm = 1i64;
+        for coefficient in &coefficients {
+            denominator_lcm = denominator_lcm.lcm(coefficient.denom());
+        }
+        denominator_lcm = denominator_lcm.lcm(rhs.denom());
+
+        let integer_coefficients = coefficients
+            .iter()
+            .map(|coefficient| (coefficient * denominator_lcm).to_integer())
+            .collect();
+        let integer_rhs = (rhs * denominator_lcm).to_integer();
+
+        Self::from_integers(integer_coefficients, integer_rhs)
+    }
+}
+
 /// Affine transformation parameters.
 ///
 /// Represents the transformation y = A*x + b where:

--- a/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
@@ -54,6 +54,52 @@ fn test_affine_params_to_integer_scaled() {
 }
 
 #[test]
+fn test_linear_constraint_row_from_integers_divides_common_factor() {
+    let row = LinearConstraintRow::from_integers(vec![16], 64);
+
+    assert_eq!(row.coefficients, vec![1]);
+    assert_eq!(row.rhs, 4);
+}
+
+#[test]
+fn test_linear_constraint_row_from_rationals_clears_denominators_then_reduces() {
+    let row = LinearConstraintRow::from_rationals(
+        vec![Rational64::new(2, 3), Rational64::new(4, 3)],
+        Rational64::from_integer(2),
+    );
+
+    assert_eq!(row.coefficients, vec![1, 2]);
+    assert_eq!(row.rhs, 3);
+}
+
+#[test]
+fn test_linear_constraint_row_uses_positive_gcd_for_negative_rows() {
+    let row = LinearConstraintRow::from_integers(vec![-16], -64);
+
+    assert_eq!(row.coefficients, vec![-1]);
+    assert_eq!(row.rhs, -4);
+}
+
+#[test]
+fn test_linear_constraint_row_preserves_all_zero_row() {
+    let row = LinearConstraintRow::from_integers(vec![0, 0], 0);
+
+    assert_eq!(row.coefficients, vec![0, 0]);
+    assert_eq!(row.rhs, 0);
+}
+
+#[test]
+fn test_affine_params_to_integer_scaled_does_not_normalize_constraint_rows() {
+    let params = AffineParams::from_integers(vec![16], vec![64], 1, 1).unwrap();
+
+    let (a_int, b_int, scale) = params.to_integer_scaled();
+
+    assert_eq!(a_int, vec![16]);
+    assert_eq!(b_int, vec![64]);
+    assert_eq!(scale, 1);
+}
+
+#[test]
 fn test_affine_transform_identity() {
     // Identity transformation: y = x
     let a = vec![1i64];

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -23,6 +23,8 @@
 //! - **Cumulative Sum**: y_i = Σ_{j<i} x_j
 //! - **Fourier Transform**: Quantics Fourier Transform (QFT)
 //! - **Affine Transform**: y = A*x + b with rational coefficients
+//! - **Constraint Row Normalization**: primitive integer rows for equality or
+//!   halfspace constraints before deriving transform operators
 //!
 //! # Conventions
 //!
@@ -66,7 +68,7 @@ mod shift;
 
 pub use affine::{
     affine_operator, affine_transform_matrix, affine_transform_tensors_unfused, AffineParams,
-    UnfusedTensorInfo,
+    LinearConstraintRow, UnfusedTensorInfo,
 };
 pub use common::{BoundaryCondition, CarryDirection};
 pub use cumsum::{cumsum_operator, triangle_operator, TriangleType};

--- a/docs/plans/2026-05-15-batch-issues-464-475-design.md
+++ b/docs/plans/2026-05-15-batch-issues-464-475-design.md
@@ -1,0 +1,52 @@
+# Batch Issues 464 and 475 Design
+
+## Goal
+
+Address the approved batch prefix for issues #464 and #475 on one branch:
+verify the TreeTN cached evaluator surface from #464, and add a safe constraint
+row normalization substrate for #475.
+
+## Context
+
+Issue #464 asks for an allocation-light batched TreeTN evaluator. Current
+`origin/main` already exposes `TreeTNCachedEvaluator`, `CachedEvaluatorOptions`,
+C API evaluator handles, tests, and benchmarks. The batch should verify that
+surface instead of duplicating it.
+
+Issue #475 asks for normalization of affine/halfspace constraint rows such as
+`16*x <= 64` to the primitive row `x <= 4` before those rows drive quantics
+operator construction. This is not the same operation as normalizing an affine
+map `y = A*x + b`: changing `y = 16*x + 64` into `y = x + 4` would be a
+behavioral regression. The safe Rust-side addition is a dedicated constraint
+row normalization API that callers and future constraint-operator builders can
+use before constructing affine/halfspace transform operators.
+
+## Approach
+
+1. Keep `affine_operator` semantics unchanged. It represents an affine map, not
+   a scale-invariant constraint.
+2. Add a small public constraint-row type in `tensor4all-quanticstransform`.
+   It clears rational denominators, divides coefficients and RHS by a positive
+   row gcd, and preserves the represented equality or inequality set under
+   positive scaling.
+3. Export the type from the crate root and document when to use it. The docs
+   must explicitly say it is for constraints, not affine maps.
+4. Verify #464 with focused TreeTN/C API evaluator tests. If those tests pass
+   without new code, record #464 as already implemented on the base branch.
+
+## Testing
+
+The #475 implementation uses TDD:
+
+- Add failing tests for integer normalization, rational denominator clearing
+  plus gcd reduction, negative rows with positive gcd, zero rows, and the
+  guarantee that `AffineParams::to_integer_scaled` is not constraint-normalized.
+- Implement the minimal normalization helper.
+- Run focused `tensor4all-quanticstransform` tests.
+
+The #464 close-out uses focused evaluator tests:
+
+- `cargo nextest run --release -p tensor4all-treetn cached_evaluator`
+- `cargo nextest run --release -p tensor4all-capi treetn_evaluator`
+
+No test tolerances or coverage thresholds are changed.

--- a/docs/plans/2026-05-15-batch-issues-464-475-plan.md
+++ b/docs/plans/2026-05-15-batch-issues-464-475-plan.md
@@ -1,0 +1,178 @@
+# Batch Issues 464 and 475 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Verify issue #464's cached evaluator surface and implement issue #475's constraint-row normalization substrate without changing affine-map semantics.
+
+**Architecture:** Keep the existing affine map API unchanged. Add a dedicated `LinearConstraintRow` API in `tensor4all-quanticstransform` that stores primitive integer coefficients and RHS after rational denominator clearing and positive gcd reduction. Export and document it so future affine/halfspace projector builders can normalize constraints before operator construction.
+
+**Tech Stack:** Rust, `num-rational::Rational64`, `num-integer::Integer`, cargo nextest, rustdoc.
+
+---
+
+### Task 1: Verify #464 Cached Evaluator Surface
+
+**Files:**
+- Read: `docs/api/tensor4all_treetn.md`
+- Read: `docs/api/tensor4all_capi.md`
+- Test: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+- Test: `crates/tensor4all-capi/src/treetn/tests/mod.rs`
+
+**Step 1: Run focused TreeTN evaluator tests**
+
+Run:
+
+```bash
+cargo nextest run --release -p tensor4all-treetn cached_evaluator
+```
+
+Expected: PASS. This verifies `TreeTNCachedEvaluator` correctness and validation paths.
+
+**Step 2: Run focused C API evaluator tests**
+
+Run:
+
+```bash
+cargo nextest run --release -p tensor4all-capi treetn_evaluator
+```
+
+Expected: PASS. This verifies the handle-based C API evaluator surface.
+
+**Step 3: Record result**
+
+If both pass, mark #464 as already implemented by the base branch in the final batch report. Do not add artificial code.
+
+### Task 2: Add Failing Tests for #475 Constraint Normalization
+
+**Files:**
+- Modify: `crates/tensor4all-quanticstransform/src/affine/tests/mod.rs`
+
+**Step 1: Write tests**
+
+Add tests for:
+
+- `LinearConstraintRow::from_integers(vec![16], 64)` returns coefficients `[1]` and RHS `4`.
+- `LinearConstraintRow::from_rationals(vec![2/3, 4/3], 2)` returns coefficients `[1, 2]` and RHS `3`.
+- `LinearConstraintRow::from_integers(vec![-16], -64)` returns coefficients `[-1]` and RHS `-4`.
+- `LinearConstraintRow::from_integers(vec![0, 0], 0)` stays `[0, 0]`, `0`.
+- `AffineParams::from_integers(vec![16], vec![64], 1, 1).unwrap().to_integer_scaled()` still returns `[16]`, `[64]`, `1`.
+
+**Step 2: Verify RED**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-quanticstransform linear_constraint
+```
+
+Expected: FAIL because `LinearConstraintRow` does not exist.
+
+### Task 3: Implement `LinearConstraintRow`
+
+**Files:**
+- Modify: `crates/tensor4all-quanticstransform/src/affine.rs`
+- Modify: `crates/tensor4all-quanticstransform/src/lib.rs`
+
+**Step 1: Add the type**
+
+Add a public `LinearConstraintRow` with fields:
+
+```rust
+pub struct LinearConstraintRow {
+    pub coefficients: Vec<i64>,
+    pub rhs: i64,
+}
+```
+
+**Step 2: Add constructors**
+
+Add:
+
+```rust
+pub fn from_integers(coefficients: Vec<i64>, rhs: i64) -> Self
+pub fn from_rationals(coefficients: Vec<Rational64>, rhs: Rational64) -> Self
+```
+
+The rational constructor clears denominators using a row-local LCM, then calls
+the integer constructor. The integer constructor divides by a positive gcd of
+all coefficients and the RHS. If the row is all zero, it returns the zero row.
+
+**Step 3: Export**
+
+Export `LinearConstraintRow` from `crates/tensor4all-quanticstransform/src/lib.rs`.
+
+**Step 4: Verify GREEN**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-quanticstransform linear_constraint
+```
+
+Expected: PASS.
+
+### Task 4: Focused Verification and Formatting
+
+**Files:**
+- Modified files from Tasks 2 and 3
+
+**Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all
+```
+
+**Step 2: Run focused tests**
+
+Run:
+
+```bash
+cargo nextest run --release -p tensor4all-quanticstransform affine
+cargo nextest run --release -p tensor4all-treetn cached_evaluator
+cargo nextest run --release -p tensor4all-capi treetn_evaluator
+```
+
+Expected: PASS.
+
+**Step 3: Run rustdoc for changed crate if public API changed**
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-quanticstransform
+```
+
+Expected: PASS.
+
+### Task 5: Commit Locally
+
+**Files:**
+- `docs/plans/2026-05-15-batch-issues-464-475-design.md`
+- `docs/plans/2026-05-15-batch-issues-464-475-plan.md`
+- `crates/tensor4all-quanticstransform/src/affine.rs`
+- `crates/tensor4all-quanticstransform/src/affine/tests/mod.rs`
+- `crates/tensor4all-quanticstransform/src/lib.rs`
+
+**Step 1: Inspect diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- crates/tensor4all-quanticstransform/src/affine.rs
+```
+
+**Step 2: Commit**
+
+Run:
+
+```bash
+git add docs/plans/2026-05-15-batch-issues-464-475-design.md \
+        docs/plans/2026-05-15-batch-issues-464-475-plan.md \
+        crates/tensor4all-quanticstransform/src/affine.rs \
+        crates/tensor4all-quanticstransform/src/affine/tests/mod.rs \
+        crates/tensor4all-quanticstransform/src/lib.rs
+git commit -m "feat(quanticstransform): normalize linear constraint rows"
+```


### PR DESCRIPTION
## Summary

- Add `LinearConstraintRow` to normalize scale-invariant linear equality/halfspace constraint rows by clearing rational denominators and dividing by the positive row gcd.
- Document that constraint-row normalization is separate from `AffineParams`, because affine maps `y = A*x + b` are not row-scale invariant.
- Verify the TreeTN cached evaluator and C API evaluator surface that already exists on the current base branch.

## Issue Status

- Refs #464: cached TreeTN evaluator surface verified with focused TreeTN and C API evaluator tests.
- Refs #475: adds the Rust normalization substrate for primitive constraint rows without changing affine-map semantics.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p tensor4all-quanticstransform --all-targets -- -D warnings`
- `cargo test --doc --release -p tensor4all-quanticstransform`
- `cargo nextest run --release -p tensor4all-quanticstransform affine`
- `cargo nextest run --release -p tensor4all-quanticstransform`
- `cargo nextest run --release -p tensor4all-treetn cached_evaluator`
- `cargo nextest run --release -p tensor4all-capi treetn_evaluator`
- `cargo nextest run --release --workspace`