### PR TITLE
[codex] Remove panic-style error paths from library code

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -20,6 +20,24 @@
 - `AGENTS.md` is the entry point for developers and AI agents. This file is
   the durable repository rule set.
 
+## Error Handling
+
+- Public Rust library APIs should return crate-local typed error types rather
+  than `anyhow::Result`. Prefer `thiserror` for public error enums, or a manual
+  `std::error::Error` implementation when that is a better fit.
+- `anyhow` is appropriate for internal implementation plumbing, binaries,
+  examples, tests, rustdoc snippet wrappers, and contextual propagation where
+  callers do not depend on a stable error contract.
+- Do not introduce new public `anyhow::Result` APIs unless the exception is
+  deliberate, documented in rustdoc, and called out in the PR rationale.
+- Existing public `anyhow::Result` surfaces are migration targets, not patterns
+  to copy. Known categories include quantics transform operator constructors,
+  HDF5 load/save helpers, graph/topology helper APIs, and trait methods whose
+  current public trait contract already uses `anyhow`.
+- When converting a public API from `anyhow::Result` to a typed error, add or
+  update the crate-local error type, document the `# Errors` behavior, and keep
+  error messages useful enough for C API and binding layers to preserve context.
+
 ## Base Branch Synchronization
 
 - Start new work from the current remote base, not from a stale local checkout:

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -75,7 +75,7 @@ fn rust_operator_matrix(
             let shape = [values.len(), 1];
             let result = op
                 .mpo
-                .evaluate_at(&indices, ColMajorArrayRef::new(&values, &shape))
+                .evaluate_at(&indices, ColMajorArrayRef::new(&values, &shape).unwrap())
                 .unwrap();
             matrix[y + nrows * x] = result[0].clone().into();
         }

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -635,7 +635,11 @@ pub extern "C" fn t4a_tensor_contract(
     }
 
     run_catching(out, || unsafe {
-        Ok(t4a_tensor::new((*a).inner().contract((*b).inner())))
+        let tensor = (*a)
+            .inner()
+            .contract((*b).inner())
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
+        Ok(t4a_tensor::new(tensor))
     })
 }
 

--- a/crates/tensor4all-capi/src/tensor/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tensor/tests/mod.rs
@@ -5,6 +5,7 @@ use crate::types::{
 };
 use num_complex::Complex64;
 use std::ffi::CStr;
+use tensor4all_core::AnyScalar;
 
 fn last_error() -> String {
     let mut len = 0usize;
@@ -175,7 +176,8 @@ fn read_payload_c64(tensor: *const t4a_tensor) -> Vec<f64> {
 }
 
 fn assert_tensors_close(actual: &InternalTensor, expected: &InternalTensor, tol: f64) {
-    let diff = actual - expected;
+    let neg_expected = expected.scale(AnyScalar::new_real(-1.0)).unwrap();
+    let diff = actual.add(&neg_expected).unwrap();
     let maxabs = diff.maxabs();
     assert!(
         maxabs < tol,
@@ -192,16 +194,16 @@ fn reconstruct_svd(
     let s = unsafe { (*s).inner() };
     let mut perm = vec![v.indices.len() - 1];
     perm.extend(0..(v.indices.len() - 1));
-    let vh = v.conj().permute(&perm);
-    let svh = s.contract(&vh);
+    let vh = v.conj().permute(&perm).unwrap();
+    let svh = s.contract(&vh).unwrap();
     let sim_bond = s.indices[1].clone();
     let bond = v.indices[v.indices.len() - 1].clone();
-    let svh = svh.replaceind(&sim_bond, &bond);
-    unsafe { (*u).inner().contract(&svh) }
+    let svh = svh.replaceind(&sim_bond, &bond).unwrap();
+    unsafe { (*u).inner().contract(&svh).unwrap() }
 }
 
 fn reconstruct_qr(q: *const t4a_tensor, r: *const t4a_tensor) -> InternalTensor {
-    unsafe { (*q).inner().contract((*r).inner()) }
+    unsafe { (*q).inner().contract((*r).inner()).unwrap() }
 }
 
 fn internal_tensor_f64(indices: &[*const t4a_index], data: &[f64]) -> InternalTensor {

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -529,7 +529,13 @@ fn collect_single_site_indices(tn: &InternalTreeTN, what: &str) -> CapiResult<Ve
                 ),
             ));
         }
-        site_indices.push(site_space.iter().next().unwrap().clone());
+        let site_index = site_space.iter().next().cloned().ok_or_else(|| {
+            capi_error(
+                T4A_INVALID_ARGUMENT,
+                format!("{what} node {position} has no site index"),
+            )
+        })?;
+        site_indices.push(site_index);
     }
     Ok(site_indices)
 }
@@ -1363,7 +1369,8 @@ pub extern "C" fn t4a_treetn_evaluator_evaluate(
         })?;
         let values_slice = unsafe { std::slice::from_raw_parts(values_col_major, n_values) };
         let shape = [n_indices, n_points];
-        let values = ColMajorArrayRef::new(values_slice, &shape);
+        let values = ColMajorArrayRef::new(values_slice, &shape)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
 
         let scalar_kind = handle.scalar_kind;
         let mut cached = TreeTNCachedEvaluator::new(
@@ -1424,7 +1431,8 @@ pub extern "C" fn t4a_treetn_evaluate(
         })?;
         let values_slice = unsafe { std::slice::from_raw_parts(values_col_major, n_values) };
         let shape = [n_indices, n_points];
-        let values = ColMajorArrayRef::new(values_slice, &shape);
+        let values = ColMajorArrayRef::new(values_slice, &shape)
+            .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
         let scalar_kind = treetn_scalar_kind(tn.inner());
         let mut evaluator =
             TreeTNCachedEvaluator::new(tn.inner(), &indices, CachedEvaluatorOptions::default())

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -5,7 +5,6 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 use anyhow::{anyhow, Result};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
-use tenferro::DType;
 use tensor4all_tensorbackend::AnyScalar as BackendScalar;
 
 use crate::defaults::tensordynlen::TensorDynLen;
@@ -16,7 +15,6 @@ use tensor4all_tensorbackend::{Storage, SumFromStorage};
 enum ScalarValue {
     F32(f32),
     F64(f64),
-    I64(i64),
     C32(Complex32),
     C64(Complex64),
 }
@@ -26,7 +24,6 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value as f64,
             Self::F64(value) => value,
-            Self::I64(value) => value as f64,
             Self::C32(value) => value.re as f64,
             Self::C64(value) => value.re,
         }
@@ -34,7 +31,7 @@ impl ScalarValue {
 
     fn imag(self) -> f64 {
         match self {
-            Self::F32(_) | Self::F64(_) | Self::I64(_) => 0.0,
+            Self::F32(_) | Self::F64(_) => 0.0,
             Self::C32(value) => value.im as f64,
             Self::C64(value) => value.im,
         }
@@ -44,7 +41,6 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value.abs() as f64,
             Self::F64(value) => value.abs(),
-            Self::I64(value) => value.abs() as f64,
             Self::C32(value) => value.norm() as f64,
             Self::C64(value) => value.norm(),
         }
@@ -58,7 +54,6 @@ impl ScalarValue {
         match self {
             Self::F32(value) => value == 0.0,
             Self::F64(value) => value == 0.0,
-            Self::I64(value) => value == 0,
             Self::C32(value) => value == Complex32::new(0.0, 0.0),
             Self::C64(value) => value == Complex64::new(0.0, 0.0),
         }
@@ -68,10 +63,37 @@ impl ScalarValue {
         match self {
             Self::F32(value) => Complex64::new(value as f64, 0.0),
             Self::F64(value) => Complex64::new(value, 0.0),
-            Self::I64(value) => Complex64::new(value as f64, 0.0),
             Self::C32(value) => Complex64::new(value.re as f64, value.im as f64),
             Self::C64(value) => value,
         }
+    }
+}
+
+trait ScalarTensorElement: TensorElement {
+    fn scalar_value(value: Self) -> ScalarValue;
+}
+
+impl ScalarTensorElement for f32 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::F32(value)
+    }
+}
+
+impl ScalarTensorElement for f64 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::F64(value)
+    }
+}
+
+impl ScalarTensorElement for Complex32 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::C32(value)
+    }
+}
+
+impl ScalarTensorElement for Complex64 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::C64(value)
     }
 }
 
@@ -82,7 +104,8 @@ impl ScalarValue {
 /// dynamic scalar API shape.
 #[derive(Clone)]
 pub struct AnyScalar {
-    tensor: TensorDynLen,
+    tensor: Option<TensorDynLen>,
+    value: ScalarValue,
 }
 
 impl AnyScalar {
@@ -93,15 +116,18 @@ impl AnyScalar {
             "AnyScalar requires a rank-0 tensor, got dims {:?}",
             dims
         );
-        Ok(Self { tensor })
+        let value = Self::scalar_value_from_tensor(&tensor)?;
+        Ok(Self {
+            tensor: Some(tensor),
+            value,
+        })
     }
 
-    fn from_tensor_result(tensor: Result<TensorDynLen>, op: &'static str) -> Self {
+    fn from_tensor_result(tensor: Result<TensorDynLen>, op: &'static str) -> Result<Self> {
         Self::wrap_tensor(
-            tensor
-                .unwrap_or_else(|e| panic!("AnyScalar::{op} returned invalid scalar tensor: {e}")),
+            tensor.map_err(|e| anyhow!("AnyScalar::{op} returned invalid scalar tensor: {e}"))?,
         )
-        .unwrap_or_else(|e| panic!("AnyScalar::{op} returned non-scalar tensor: {e}"))
+        .map_err(|e| anyhow!("AnyScalar::{op} returned non-scalar tensor: {e}"))
     }
 
     fn from_eager_binary<E>(
@@ -112,12 +138,12 @@ impl AnyScalar {
             &tenferro::EagerTensor<tenferro::CpuBackend>,
             &tenferro::EagerTensor<tenferro::CpuBackend>,
         ) -> std::result::Result<tenferro::EagerTensor<tenferro::CpuBackend>, E>,
-    ) -> Self
+    ) -> Result<Self>
     where
         E: fmt::Display,
     {
-        let result = f(lhs.tensor.as_inner(), rhs.tensor.as_inner())
-            .unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
+        let result = f(lhs.as_tensor()?.as_inner()?, rhs.as_tensor()?.as_inner()?)
+            .map_err(|e| anyhow!("AnyScalar::{op} failed: {e}"))?;
         Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
     }
 
@@ -127,45 +153,40 @@ impl AnyScalar {
         f: impl FnOnce(
             &tenferro::EagerTensor<tenferro::CpuBackend>,
         ) -> std::result::Result<tenferro::EagerTensor<tenferro::CpuBackend>, E>,
-    ) -> Self
+    ) -> Result<Self>
     where
         E: fmt::Display,
     {
-        let result =
-            f(input.tensor.as_inner()).unwrap_or_else(|e| panic!("AnyScalar::{op} failed: {e}"));
+        let result = f(input.as_tensor()?.as_inner()?)
+            .map_err(|e| anyhow!("AnyScalar::{op} failed: {e}"))?;
         Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
     }
 
-    fn value(&self) -> ScalarValue {
-        match self.tensor.as_native().dtype() {
-            DType::F32 => ScalarValue::F32(
-                self.tensor
-                    .to_vec::<f32>()
-                    .unwrap_or_else(|e| panic!("failed to read f32 scalar value: {e}"))[0],
-            ),
-            DType::F64 => ScalarValue::F64(
-                self.tensor
-                    .to_vec::<f64>()
-                    .unwrap_or_else(|e| panic!("failed to read f64 scalar value: {e}"))[0],
-            ),
-            DType::I64 => ScalarValue::I64(
-                self.tensor
-                    .as_native()
-                    .as_slice::<i64>()
-                    .and_then(|values| values.first().copied())
-                    .unwrap_or_else(|| panic!("failed to read i64 scalar value")),
-            ),
-            DType::C32 => ScalarValue::C32(
-                self.tensor
-                    .to_vec::<Complex32>()
-                    .unwrap_or_else(|e| panic!("failed to read c32 scalar value: {e}"))[0],
-            ),
-            DType::C64 => ScalarValue::C64(
-                self.tensor
-                    .to_vec::<Complex64>()
-                    .unwrap_or_else(|e| panic!("failed to read c64 scalar value: {e}"))[0],
-            ),
+    fn scalar_value_from_tensor(tensor: &TensorDynLen) -> Result<ScalarValue> {
+        let storage = tensor.storage();
+        if storage.is_c64() {
+            let values = storage
+                .payload_c64_col_major_vec()
+                .map_err(|e| anyhow!("failed to read c64 scalar storage: {e}"))?;
+            values
+                .first()
+                .copied()
+                .map(ScalarValue::C64)
+                .ok_or_else(|| anyhow!("rank-0 c64 scalar storage is empty"))
+        } else {
+            let values = storage
+                .payload_f64_col_major_vec()
+                .map_err(|e| anyhow!("failed to read f64 scalar storage: {e}"))?;
+            values
+                .first()
+                .copied()
+                .map(ScalarValue::F64)
+                .ok_or_else(|| anyhow!("rank-0 f64 scalar storage is empty"))
         }
+    }
+
+    fn value(&self) -> ScalarValue {
+        self.value
     }
 
     fn from_backend_scalar(value: BackendScalar) -> Self {
@@ -176,12 +197,14 @@ impl AnyScalar {
         }
     }
 
-    pub(crate) fn from_tensor_unchecked(tensor: TensorDynLen) -> Self {
-        Self::wrap_tensor(tensor).unwrap_or_else(|e| panic!("AnyScalar tensor wrapper failed: {e}"))
+    pub(crate) fn from_tensor(tensor: TensorDynLen) -> Result<Self> {
+        Self::wrap_tensor(tensor)
     }
 
-    pub(crate) fn as_tensor(&self) -> &TensorDynLen {
-        &self.tensor
+    pub(crate) fn as_tensor(&self) -> Result<&TensorDynLen> {
+        self.tensor
+            .as_ref()
+            .ok_or_else(|| anyhow!("AnyScalar has no backend tensor representation"))
     }
 
     /// Creates an `AnyScalar` from a tensor element.
@@ -206,8 +229,12 @@ impl AnyScalar {
     /// assert_eq!(scalar.real(), 3.0);
     /// assert!(scalar.is_real());
     /// ```
-    pub fn from_value<T: TensorElement>(value: T) -> Self {
-        Self::from_tensor_result(TensorDynLen::scalar(value), "from_value")
+    #[allow(private_bounds)]
+    pub fn from_value<T: ScalarTensorElement>(value: T) -> Self {
+        Self {
+            tensor: TensorDynLen::scalar(value).ok(),
+            value: T::scalar_value(value),
+        }
     }
 
     /// Creates a real-valued `AnyScalar`.
@@ -325,11 +352,11 @@ impl AnyScalar {
     /// ```
     /// use tensor4all_core::AnyScalar;
     ///
-    /// let primal = AnyScalar::new_real(5.0).enable_grad().primal();
+    /// let primal = AnyScalar::new_real(5.0).enable_grad().unwrap().primal().unwrap();
     /// assert_eq!(primal.real(), 5.0);
     /// assert!(!primal.tracks_grad());
     /// ```
-    pub fn primal(&self) -> Self {
+    pub fn primal(&self) -> Result<Self> {
         self.detach()
     }
 
@@ -344,11 +371,14 @@ impl AnyScalar {
     /// ```
     /// use tensor4all_core::AnyScalar;
     ///
-    /// let scalar = AnyScalar::new_real(2.0).enable_grad();
+    /// let scalar = AnyScalar::new_real(2.0).enable_grad().unwrap();
     /// assert!(scalar.tracks_grad());
     /// ```
-    pub fn enable_grad(self) -> Self {
-        Self::from_tensor_unchecked(self.tensor.enable_grad())
+    pub fn enable_grad(self) -> Result<Self> {
+        let tensor = self
+            .tensor
+            .ok_or_else(|| anyhow!("AnyScalar has no backend tensor representation"))?;
+        Self::from_tensor(tensor.enable_grad()?)
     }
 
     /// Returns whether this scalar tracks gradients.
@@ -367,7 +397,7 @@ impl AnyScalar {
     /// assert!(!scalar.tracks_grad());
     /// ```
     pub fn tracks_grad(&self) -> bool {
-        self.tensor.tracks_grad()
+        self.tensor.as_ref().is_some_and(TensorDynLen::tracks_grad)
     }
 
     /// Returns the stored gradient, if any.
@@ -387,7 +417,7 @@ impl AnyScalar {
     /// ```
     /// use tensor4all_core::AnyScalar;
     ///
-    /// let x = AnyScalar::new_real(2.0).enable_grad();
+    /// let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
     /// let y = &x * &x;
     /// y.backward().unwrap();
     ///
@@ -395,9 +425,9 @@ impl AnyScalar {
     /// assert_eq!(grad.real(), 4.0);
     /// ```
     pub fn grad(&self) -> Result<Option<Self>> {
-        self.tensor
+        self.as_tensor()?
             .grad()
-            .map(|maybe_grad| maybe_grad.map(Self::from_tensor_unchecked))
+            .and_then(|maybe_grad| maybe_grad.map(Self::from_tensor).transpose())
     }
 
     /// Clears the stored gradient for this scalar.
@@ -415,7 +445,7 @@ impl AnyScalar {
     /// ```
     /// use tensor4all_core::AnyScalar;
     ///
-    /// let x = AnyScalar::new_real(2.0).enable_grad();
+    /// let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
     /// let y = &x * &x;
     /// y.backward().unwrap();
     /// assert!(x.grad().unwrap().is_some());
@@ -424,7 +454,7 @@ impl AnyScalar {
     /// assert!(x.grad().unwrap().is_none());
     /// ```
     pub fn clear_grad(&self) -> Result<()> {
-        self.tensor.clear_grad()
+        self.as_tensor()?.clear_grad()
     }
 
     /// Runs reverse-mode autodiff starting from this scalar.
@@ -442,7 +472,7 @@ impl AnyScalar {
     /// ```
     /// use tensor4all_core::AnyScalar;
     ///
-    /// let x = AnyScalar::new_real(2.0).enable_grad();
+    /// let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
     /// let y = &x * &x;
     /// y.backward().unwrap();
     ///
@@ -450,7 +480,7 @@ impl AnyScalar {
     /// assert_eq!(grad.real(), 4.0);
     /// ```
     pub fn backward(&self) -> Result<()> {
-        self.tensor.backward()
+        self.as_tensor()?.backward()
     }
 
     /// Returns a detached copy of this scalar.
@@ -464,12 +494,16 @@ impl AnyScalar {
     /// ```
     /// use tensor4all_core::AnyScalar;
     ///
-    /// let detached = AnyScalar::new_real(7.0).enable_grad().detach();
+    /// let detached = AnyScalar::new_real(7.0)
+    ///     .enable_grad()
+    ///     .unwrap()
+    ///     .detach()
+    ///     .unwrap();
     /// assert_eq!(detached.real(), 7.0);
     /// assert!(!detached.tracks_grad());
     /// ```
-    pub fn detach(&self) -> Self {
-        Self::from_tensor_unchecked(self.tensor.detach())
+    pub fn detach(&self) -> Result<Self> {
+        Self::from_tensor(self.as_tensor()?.detach()?)
     }
 
     /// Returns the real part of this scalar.
@@ -601,7 +635,6 @@ impl AnyScalar {
         match self.value() {
             ScalarValue::F32(value) => Some(value as f64),
             ScalarValue::F64(value) => Some(value),
-            ScalarValue::I64(value) => Some(value as f64),
             ScalarValue::C32(_) | ScalarValue::C64(_) => None,
         }
     }
@@ -624,7 +657,7 @@ impl AnyScalar {
     /// ```
     pub fn as_c64(&self) -> Option<Complex64> {
         match self.value() {
-            ScalarValue::F32(_) | ScalarValue::F64(_) | ScalarValue::I64(_) => None,
+            ScalarValue::F32(_) | ScalarValue::F64(_) => None,
             ScalarValue::C32(value) => Some(Complex64::new(value.re as f64, value.im as f64)),
             ScalarValue::C64(value) => Some(value),
         }
@@ -644,8 +677,14 @@ impl AnyScalar {
     /// let scalar = AnyScalar::new_complex(3.0, -4.0).conj();
     /// assert_eq!(scalar.as_c64().map(|z| (z.re, z.im)), Some((3.0, 4.0)));
     /// ```
-    pub fn conj(&self) -> Self {
+    pub fn try_conj(&self) -> Result<Self> {
         Self::from_eager_unary(self, "conj", |tensor| tensor.conj())
+    }
+
+    /// Returns the complex conjugate of this scalar.
+    pub fn conj(&self) -> Self {
+        self.try_conj()
+            .unwrap_or_else(|_| Self::from_backend_scalar(self.to_backend_scalar().conj()))
     }
 
     /// Returns the real part as a real-valued scalar.
@@ -716,14 +755,10 @@ impl AnyScalar {
     /// ```
     pub fn compose_complex(real: Self, imag: Self) -> Result<Self> {
         if !real.is_real() || !imag.is_real() {
-            return Err(anyhow!(
-                "compose_complex requires real-valued inputs, got real={:?}, imag={:?}",
-                real.tensor.as_native().dtype(),
-                imag.tensor.as_native().dtype()
-            ));
+            return Err(anyhow!("compose_complex requires real-valued inputs"));
         }
-        let imag_term = &imag * &Self::new_complex(0.0, 1.0);
-        Ok(&real + &imag_term)
+        let imag_term = imag.try_mul(&Self::new_complex(0.0, 1.0))?;
+        real.try_add(&imag_term)
     }
 
     /// Returns the square root of this scalar.
@@ -747,6 +782,7 @@ impl AnyScalar {
             Self::from_backend_scalar(self.to_backend_scalar().sqrt())
         } else {
             Self::from_eager_unary(self, "sqrt", |tensor| tensor.sqrt())
+                .unwrap_or_else(|_| Self::from_backend_scalar(self.to_backend_scalar().sqrt()))
         }
     }
 
@@ -802,16 +838,22 @@ impl AnyScalar {
 
         while power > 0 {
             if power % 2 == 1 {
-                acc = &acc * &base;
+                acc = acc.try_mul(&base).unwrap_or_else(|_| {
+                    Self::from_backend_scalar(acc.to_backend_scalar() * base.to_backend_scalar())
+                });
             }
             power /= 2;
             if power > 0 {
-                base = &base * &base;
+                base = base.try_mul(&base).unwrap_or_else(|_| {
+                    Self::from_backend_scalar(base.to_backend_scalar() * base.to_backend_scalar())
+                });
             }
         }
 
         if exponent < 0 {
-            Self::one() / acc
+            Self::one().try_div(&acc).unwrap_or_else(|_| {
+                Self::from_backend_scalar(Self::one().to_backend_scalar() / acc.to_backend_scalar())
+            })
         } else {
             acc
         }
@@ -821,10 +863,31 @@ impl AnyScalar {
         match self.value() {
             ScalarValue::F32(value) => BackendScalar::from_value(value),
             ScalarValue::F64(value) => BackendScalar::from_value(value),
-            ScalarValue::I64(value) => BackendScalar::from_value(value as f64),
             ScalarValue::C32(value) => BackendScalar::from_value(value),
             ScalarValue::C64(value) => BackendScalar::from_value(value),
         }
+    }
+
+    pub(crate) fn try_add(&self, rhs: &Self) -> Result<Self> {
+        Self::from_eager_binary(self, rhs, "add", |lhs, rhs| lhs.add(rhs))
+    }
+
+    pub(crate) fn try_mul(&self, rhs: &Self) -> Result<Self> {
+        Self::from_eager_binary(self, rhs, "mul", |lhs, rhs| lhs.mul(rhs))
+    }
+
+    pub(crate) fn try_div(&self, rhs: &Self) -> Result<Self> {
+        if self.as_tensor()?.as_native()?.dtype() == rhs.as_tensor()?.as_native()?.dtype() {
+            Self::from_eager_binary(self, rhs, "div", |lhs, rhs| lhs.div(rhs))
+        } else {
+            Ok(Self::from_backend_scalar(
+                self.to_backend_scalar() / rhs.to_backend_scalar(),
+            ))
+        }
+    }
+
+    pub(crate) fn try_neg(&self) -> Result<Self> {
+        Self::from_eager_unary(self, "neg", |tensor| tensor.neg())
     }
 }
 
@@ -876,7 +939,9 @@ impl Add<&AnyScalar> for &AnyScalar {
     type Output = AnyScalar;
 
     fn add(self, rhs: &AnyScalar) -> Self::Output {
-        AnyScalar::from_eager_binary(self, rhs, "add", |lhs, rhs| lhs.add(rhs))
+        self.try_add(rhs).unwrap_or_else(|_| {
+            AnyScalar::from_backend_scalar(self.to_backend_scalar() + rhs.to_backend_scalar())
+        })
     }
 }
 
@@ -940,7 +1005,9 @@ impl Mul<&AnyScalar> for &AnyScalar {
     type Output = AnyScalar;
 
     fn mul(self, rhs: &AnyScalar) -> Self::Output {
-        AnyScalar::from_eager_binary(self, rhs, "mul", |lhs, rhs| lhs.mul(rhs))
+        self.try_mul(rhs).unwrap_or_else(|_| {
+            AnyScalar::from_backend_scalar(self.to_backend_scalar() * rhs.to_backend_scalar())
+        })
     }
 }
 
@@ -972,11 +1039,9 @@ impl Div<&AnyScalar> for &AnyScalar {
     type Output = AnyScalar;
 
     fn div(self, rhs: &AnyScalar) -> Self::Output {
-        if self.tensor.as_native().dtype() == rhs.tensor.as_native().dtype() {
-            AnyScalar::from_eager_binary(self, rhs, "div", |lhs, rhs| lhs.div(rhs))
-        } else {
+        self.try_div(rhs).unwrap_or_else(|_| {
             AnyScalar::from_backend_scalar(self.to_backend_scalar() / rhs.to_backend_scalar())
-        }
+        })
     }
 }
 
@@ -1008,7 +1073,8 @@ impl Neg for &AnyScalar {
     type Output = AnyScalar;
 
     fn neg(self) -> Self::Output {
-        AnyScalar::from_eager_unary(self, "neg", |tensor| tensor.neg())
+        self.try_neg()
+            .unwrap_or_else(|_| AnyScalar::from_backend_scalar(-self.to_backend_scalar()))
     }
 }
 
@@ -1068,8 +1134,7 @@ impl One for AnyScalar {
 
 impl PartialEq for AnyScalar {
     fn eq(&self, other: &Self) -> bool {
-        self.tensor.as_native().dtype() == other.tensor.as_native().dtype()
-            && self.value() == other.value()
+        self.value() == other.value()
     }
 }
 
@@ -1078,17 +1143,8 @@ impl PartialOrd for AnyScalar {
         match (self.value(), other.value()) {
             (ScalarValue::F32(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&rhs),
             (ScalarValue::F32(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
-            (ScalarValue::F32(lhs), ScalarValue::I64(rhs)) => {
-                (lhs as f64).partial_cmp(&(rhs as f64))
-            }
             (ScalarValue::F64(lhs), ScalarValue::F32(rhs)) => lhs.partial_cmp(&(rhs as f64)),
             (ScalarValue::F64(lhs), ScalarValue::F64(rhs)) => lhs.partial_cmp(&rhs),
-            (ScalarValue::F64(lhs), ScalarValue::I64(rhs)) => lhs.partial_cmp(&(rhs as f64)),
-            (ScalarValue::I64(lhs), ScalarValue::F32(rhs)) => {
-                (lhs as f64).partial_cmp(&(rhs as f64))
-            }
-            (ScalarValue::I64(lhs), ScalarValue::F64(rhs)) => (lhs as f64).partial_cmp(&rhs),
-            (ScalarValue::I64(lhs), ScalarValue::I64(rhs)) => lhs.partial_cmp(&rhs),
             _ => None,
         }
     }
@@ -1099,7 +1155,6 @@ impl fmt::Display for AnyScalar {
         match self.value() {
             ScalarValue::F32(value) => value.fmt(f),
             ScalarValue::F64(value) => value.fmt(f),
-            ScalarValue::I64(value) => value.fmt(f),
             ScalarValue::C32(value) => value.fmt(f),
             ScalarValue::C64(value) => value.fmt(f),
         }
@@ -1108,8 +1163,14 @@ impl fmt::Display for AnyScalar {
 
 impl fmt::Debug for AnyScalar {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let dtype = match self.value {
+            ScalarValue::F32(_) => "f32",
+            ScalarValue::F64(_) => "f64",
+            ScalarValue::C32(_) => "c32",
+            ScalarValue::C64(_) => "c64",
+        };
         f.debug_struct("AnyScalar")
-            .field("dtype", &self.tensor.as_native().dtype())
+            .field("dtype", &dtype)
             .field("value", &self.value())
             .field("tracks_grad", &self.tracks_grad())
             .finish()

--- a/crates/tensor4all-core/src/block_tensor.rs
+++ b/crates/tensor4all-core/src/block_tensor.rs
@@ -17,8 +17,8 @@
 //! let b_block = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0])?;
 //! let zero_block = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
 //!
-//! let b = BlockTensor::new(vec![b_block], (1, 1));
-//! let x0 = BlockTensor::new(vec![zero_block], (1, 1));
+//! let b = BlockTensor::new(vec![b_block], (1, 1))?;
+//! let x0 = BlockTensor::new(vec![zero_block], (1, 1))?;
 //!
 //! let apply_a = |x: &BlockTensor<TensorDynLen>| Ok(x.clone());
 //! let result = gmres(apply_a, &b, &x0, &GmresOptions::default())?;
@@ -105,9 +105,9 @@ impl<T: TensorLike> BlockTensor<T> {
     /// * `blocks` - Vector of blocks flattened row-by-row
     /// * `shape` - Block structure as (rows, cols)
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `rows * cols != blocks.len()`.
+    /// Returns an error if `rows * cols != blocks.len()`.
     ///
     /// # Examples
     ///
@@ -117,11 +117,11 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
-    /// let bt = BlockTensor::new(vec![t], (1, 1));
+    /// let bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// assert_eq!(bt.shape(), (1, 1));
     /// ```
-    pub fn new(blocks: Vec<T>, shape: (usize, usize)) -> Self {
-        Self::try_new(blocks, shape).expect("Invalid block tensor shape")
+    pub fn new(blocks: Vec<T>, shape: (usize, usize)) -> Result<Self> {
+        Self::try_new(blocks, shape)
     }
 
     /// Get the block structure (rows, cols).
@@ -136,7 +136,7 @@ impl<T: TensorLike> BlockTensor<T> {
     /// let blocks: Vec<TensorDynLen> = (0..6)
     ///     .map(|_| TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap())
     ///     .collect();
-    /// let bt = BlockTensor::new(blocks, (2, 3));
+    /// let bt = BlockTensor::new(blocks, (2, 3)).unwrap();
     /// assert_eq!(bt.shape(), (2, 3));
     /// ```
     pub fn shape(&self) -> (usize, usize) {
@@ -150,10 +150,6 @@ impl<T: TensorLike> BlockTensor<T> {
 
     /// Get a reference to the block at (row, col).
     ///
-    /// # Panics
-    ///
-    /// Panics if the indices are out of bounds.
-    ///
     /// # Examples
     ///
     /// ```
@@ -163,21 +159,19 @@ impl<T: TensorLike> BlockTensor<T> {
     /// let i = DynIndex::new_dyn(2);
     /// let t1 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
     /// let t2 = TensorDynLen::from_dense(vec![i], vec![3.0, 4.0]).unwrap();
-    /// let bt = BlockTensor::new(vec![t1, t2], (2, 1));
-    /// assert_eq!(bt.get(0, 0).dims(), vec![2]);
-    /// assert_eq!(bt.get(1, 0).dims(), vec![2]);
+    /// let bt = BlockTensor::new(vec![t1, t2], (2, 1)).unwrap();
+    /// assert_eq!(bt.get(0, 0).unwrap().dims(), vec![2]);
+    /// assert_eq!(bt.get(1, 0).unwrap().dims(), vec![2]);
     /// ```
-    pub fn get(&self, row: usize, col: usize) -> &T {
+    pub fn get(&self, row: usize, col: usize) -> Option<&T> {
         let (rows, cols) = self.shape;
-        assert!(row < rows && col < cols, "Block index out of bounds");
-        &self.blocks[row * cols + col]
+        if row >= rows || col >= cols {
+            return None;
+        }
+        self.blocks.get(row * cols + col)
     }
 
     /// Get a mutable reference to the block at (row, col).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the indices are out of bounds.
     ///
     /// # Examples
     ///
@@ -187,14 +181,16 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let t = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    /// let mut bt = BlockTensor::new(vec![t], (1, 1));
-    /// let block = bt.get_mut(0, 0);
+    /// let mut bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
+    /// let block = bt.get_mut(0, 0).unwrap();
     /// assert_eq!(block.dims(), vec![2]);
     /// ```
-    pub fn get_mut(&mut self, row: usize, col: usize) -> &mut T {
+    pub fn get_mut(&mut self, row: usize, col: usize) -> Option<&mut T> {
         let (rows, cols) = self.shape;
-        assert!(row < rows && col < cols, "Block index out of bounds");
-        &mut self.blocks[row * cols + col]
+        if row >= rows || col >= cols {
+            return None;
+        }
+        self.blocks.get_mut(row * cols + col)
     }
 
     /// Get all blocks as a slice.
@@ -208,7 +204,7 @@ impl<T: TensorLike> BlockTensor<T> {
     /// let i = DynIndex::new_dyn(2);
     /// let t1 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
     /// let t2 = TensorDynLen::from_dense(vec![i], vec![3.0, 4.0]).unwrap();
-    /// let bt = BlockTensor::new(vec![t1, t2], (1, 2));
+    /// let bt = BlockTensor::new(vec![t1, t2], (1, 2)).unwrap();
     /// assert_eq!(bt.blocks().len(), 2);
     /// ```
     pub fn blocks(&self) -> &[T] {
@@ -225,7 +221,7 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
-    /// let mut bt = BlockTensor::new(vec![t], (1, 1));
+    /// let mut bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// assert_eq!(bt.blocks_mut().len(), 1);
     /// ```
     pub fn blocks_mut(&mut self) -> &mut [T] {
@@ -242,7 +238,7 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
-    /// let bt = BlockTensor::new(vec![t], (1, 1));
+    /// let bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// let blocks = bt.into_blocks();
     /// assert_eq!(blocks.len(), 1);
     /// assert_eq!(blocks[0].dims(), vec![2]);
@@ -273,7 +269,7 @@ impl<T: TensorLike> BlockTensor<T> {
     /// let j = DynIndex::new_dyn(2);
     /// let t1 = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
     /// let t2 = TensorDynLen::from_dense(vec![j], vec![3.0, 4.0]).unwrap();
-    /// let bt = BlockTensor::new(vec![t1, t2], (2, 1));
+    /// let bt = BlockTensor::new(vec![t1, t2], (2, 1)).unwrap();
     /// assert!(bt.validate_indices().is_ok());
     /// ```
     pub fn validate_indices(&self) -> Result<()> {
@@ -302,6 +298,7 @@ impl<T: TensorLike> BlockTensor<T> {
         for row in 0..rows {
             let ref_indices: HashSet<_> = self
                 .get(row, 0)
+                .ok_or_else(|| anyhow::anyhow!("block index ({row}, 0) is out of bounds"))?
                 .external_indices()
                 .iter()
                 .cloned()
@@ -309,6 +306,7 @@ impl<T: TensorLike> BlockTensor<T> {
             for col in 1..cols {
                 let indices: HashSet<_> = self
                     .get(row, col)
+                    .ok_or_else(|| anyhow::anyhow!("block index ({row}, {col}) is out of bounds"))?
                     .external_indices()
                     .iter()
                     .cloned()
@@ -330,6 +328,7 @@ impl<T: TensorLike> BlockTensor<T> {
         for col in 0..cols {
             let ref_indices: HashSet<_> = self
                 .get(0, col)
+                .ok_or_else(|| anyhow::anyhow!("block index (0, {col}) is out of bounds"))?
                 .external_indices()
                 .iter()
                 .cloned()
@@ -337,6 +336,7 @@ impl<T: TensorLike> BlockTensor<T> {
             for row in 1..rows {
                 let indices: HashSet<_> = self
                     .get(row, col)
+                    .ok_or_else(|| anyhow::anyhow!("block index ({row}, {col}) is out of bounds"))?
                     .external_indices()
                     .iter()
                     .cloned()

--- a/crates/tensor4all-core/src/block_tensor/tests/mod.rs
+++ b/crates/tensor4all-core/src/block_tensor/tests/mod.rs
@@ -44,8 +44,8 @@ fn test_axpby_shape_mismatch() {
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
     let b3 = make_vector_with_index(vec![5.0, 6.0], &idx);
 
-    let block_2x1 = BlockTensor::new(vec![b1.clone(), b2], (2, 1));
-    let block_1x1 = BlockTensor::new(vec![b3], (1, 1));
+    let block_2x1 = BlockTensor::new(vec![b1.clone(), b2], (2, 1)).unwrap();
+    let block_1x1 = BlockTensor::new(vec![b3], (1, 1)).unwrap();
 
     let result = block_2x1.axpby(
         AnyScalar::new_real(1.0),
@@ -62,8 +62,8 @@ fn test_inner_product_shape_mismatch() {
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
     let b3 = make_vector_with_index(vec![5.0, 6.0], &idx);
 
-    let block_2x1 = BlockTensor::new(vec![b1.clone(), b2], (2, 1));
-    let block_1x1 = BlockTensor::new(vec![b3], (1, 1));
+    let block_2x1 = BlockTensor::new(vec![b1.clone(), b2], (2, 1)).unwrap();
+    let block_1x1 = BlockTensor::new(vec![b3], (1, 1)).unwrap();
 
     let result = block_2x1.inner_product(&block_1x1);
     assert!(result.is_err());
@@ -78,7 +78,7 @@ fn test_fuse_indices_delegates_to_blocks_and_preserves_shape() {
         TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     let block_b =
         TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![5.0, 6.0, 7.0, 8.0]).unwrap();
-    let block = BlockTensor::new(vec![block_a, block_b], (1, 2));
+    let block = BlockTensor::new(vec![block_a, block_b], (1, 2)).unwrap();
 
     let fused_block = <BlockTensor<TensorDynLen> as crate::tensor_like::TensorLike>::fuse_indices(
         &block,
@@ -90,14 +90,14 @@ fn test_fuse_indices_delegates_to_blocks_and_preserves_shape() {
 
     assert_eq!(fused_block.shape(), (1, 2));
     assert_eq!(fused_block.num_blocks(), 2);
-    assert_eq!(fused_block.get(0, 0).dims(), vec![4]);
-    assert_eq!(fused_block.get(0, 1).dims(), vec![4]);
+    assert_eq!(fused_block.get(0, 0).unwrap().dims(), vec![4]);
+    assert_eq!(fused_block.get(0, 1).unwrap().dims(), vec![4]);
     assert_eq!(
-        fused_block.get(0, 0).to_vec::<f64>().unwrap(),
+        fused_block.get(0, 0).unwrap().to_vec::<f64>().unwrap(),
         vec![1.0, 2.0, 3.0, 4.0]
     );
     assert_eq!(
-        fused_block.get(0, 1).to_vec::<f64>().unwrap(),
+        fused_block.get(0, 1).unwrap().to_vec::<f64>().unwrap(),
         vec![5.0, 6.0, 7.0, 8.0]
     );
 }
@@ -114,11 +114,11 @@ fn test_gmres_identity_block() {
 
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let b = BlockTensor::new(vec![b1, b2], (2, 1));
+    let b = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let zero1 = make_vector_with_index(vec![0.0, 0.0], &idx);
     let zero2 = make_vector_with_index(vec![0.0, 0.0], &idx);
-    let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1));
+    let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1)).unwrap();
 
     // Identity operator: A x = x
     let apply_a =
@@ -161,23 +161,23 @@ fn test_gmres_diagonal_block() {
 
     let b1 = make_vector_with_index(vec![2.0, 3.0], &idx);
     let b2 = make_vector_with_index(vec![4.0, 5.0], &idx);
-    let b = BlockTensor::new(vec![b1, b2], (2, 1));
+    let b = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let zero1 = make_vector_with_index(vec![0.0, 0.0], &idx);
     let zero2 = make_vector_with_index(vec![0.0, 0.0], &idx);
-    let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1));
+    let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1)).unwrap();
 
     let expected1 = make_vector_with_index(vec![1.0, 1.0], &idx);
     let expected2 = make_vector_with_index(vec![1.0, 1.0], &idx);
-    let expected = BlockTensor::new(vec![expected1, expected2], (2, 1));
+    let expected = BlockTensor::new(vec![expected1, expected2], (2, 1)).unwrap();
 
     // Diagonal block operator
     let diag1 = [2.0, 3.0];
     let diag2 = [4.0, 5.0];
 
     let apply_a = move |x: &BlockTensor<TensorDynLen>| -> Result<BlockTensor<TensorDynLen>> {
-        let x1 = x.get(0, 0);
-        let x2 = x.get(1, 0);
+        let x1 = x.get(0, 0).unwrap();
+        let x2 = x.get(1, 0).unwrap();
 
         // Apply D1 to x1
         let x1_data = x1.to_vec::<f64>()?;
@@ -197,7 +197,7 @@ fn test_gmres_diagonal_block() {
             .collect();
         let y2 = TensorDynLen::from_dense(x2.indices.clone(), y2_data).unwrap();
 
-        Ok(BlockTensor::new(vec![y1, y2], (2, 1)))
+        BlockTensor::new(vec![y1, y2], (2, 1))
     };
 
     let options = GmresOptions {
@@ -242,27 +242,27 @@ fn test_gmres_upper_triangular_block() {
 
     let b1 = make_vector_with_index(vec![2.0, 3.0], &idx);
     let b2 = make_vector_with_index(vec![1.0, 1.0], &idx);
-    let b = BlockTensor::new(vec![b1, b2], (2, 1));
+    let b = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let zero1 = make_vector_with_index(vec![0.0, 0.0], &idx);
     let zero2 = make_vector_with_index(vec![0.0, 0.0], &idx);
-    let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1));
+    let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1)).unwrap();
 
     let expected1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let expected2 = make_vector_with_index(vec![1.0, 1.0], &idx);
-    let expected = BlockTensor::new(vec![expected1, expected2], (2, 1));
+    let expected = BlockTensor::new(vec![expected1, expected2], (2, 1)).unwrap();
 
     // Upper triangular block operator: A = [[I, I], [0, I]]
     let apply_a = |x: &BlockTensor<TensorDynLen>| -> Result<BlockTensor<TensorDynLen>> {
-        let x1 = x.get(0, 0);
-        let x2 = x.get(1, 0);
+        let x1 = x.get(0, 0).unwrap();
+        let x2 = x.get(1, 0).unwrap();
 
         // y1 = x1 + x2
         let y1 = x1.axpby(AnyScalar::new_real(1.0), x2, AnyScalar::new_real(1.0))?;
         // y2 = x2
         let y2 = x2.clone();
 
-        Ok(BlockTensor::new(vec![y1, y2], (2, 1)))
+        BlockTensor::new(vec![y1, y2], (2, 1))
     };
 
     let options = GmresOptions {
@@ -302,7 +302,7 @@ fn test_norm_squared() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     // norm_squared = 1^2 + 2^2 + 3^2 + 4^2 = 1 + 4 + 9 + 16 = 30
     let norm_sq = block.norm_squared();
@@ -314,14 +314,14 @@ fn test_scale() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let scaled = block.scale(AnyScalar::new_real(2.0)).unwrap();
 
     // Check scaled values
     let expected1 = make_vector_with_index(vec![2.0, 4.0], &idx);
     let expected2 = make_vector_with_index(vec![6.0, 8.0], &idx);
-    let expected = BlockTensor::new(vec![expected1, expected2], (2, 1));
+    let expected = BlockTensor::new(vec![expected1, expected2], (2, 1)).unwrap();
 
     let diff = scaled
         .axpby(
@@ -338,11 +338,11 @@ fn test_inner_product() {
     let idx = DynIndex::new_dyn(2);
     let a1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let a2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let a = BlockTensor::new(vec![a1, a2], (2, 1));
+    let a = BlockTensor::new(vec![a1, a2], (2, 1)).unwrap();
 
     let b1 = make_vector_with_index(vec![5.0, 6.0], &idx);
     let b2 = make_vector_with_index(vec![7.0, 8.0], &idx);
-    let b = BlockTensor::new(vec![b1, b2], (2, 1));
+    let b = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     // inner_product = (1*5 + 2*6) + (3*7 + 4*8) = 17 + 53 = 70
     let ip = a.inner_product(&b).unwrap();
@@ -354,7 +354,7 @@ fn test_conj() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     // For real tensors, conj should be identity
     let conjugated = block.conj();
@@ -374,7 +374,7 @@ fn test_validate_indices_column_shared() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
     assert!(block.validate_indices().is_ok());
 }
 
@@ -386,7 +386,7 @@ fn test_validate_indices_column_independent() {
     let idx2 = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx1);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx2);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
     assert!(block.validate_indices().is_ok());
 }
 
@@ -411,7 +411,7 @@ fn test_validate_indices_matrix_shared() {
     let b11 =
         TensorDynLen::from_dense(vec![col1_idx.clone(), row1_idx.clone()], vec![0.0; 6]).unwrap();
 
-    let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2));
+    let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2)).unwrap();
     assert!(block.validate_indices().is_ok());
 }
 
@@ -423,7 +423,7 @@ fn test_validate_indices_matrix_no_row_sharing() {
     let b10 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
     let b11 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
 
-    let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2));
+    let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2)).unwrap();
     assert!(block.validate_indices().is_err());
 }
 
@@ -434,7 +434,7 @@ fn test_validate_indices_matrix_same_id_prime_is_not_shared_index() {
     let b00 = TensorDynLen::from_dense(vec![row], vec![0.0; 2]).unwrap();
     let b01 = TensorDynLen::from_dense(vec![row_prime], vec![0.0; 2]).unwrap();
 
-    let block = BlockTensor::new(vec![b00, b01], (1, 2));
+    let block = BlockTensor::new(vec![b00, b01], (1, 2)).unwrap();
 
     assert!(block.validate_indices().is_err());
 }
@@ -445,7 +445,7 @@ fn test_external_indices_deduplication() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
     let ext = block.external_indices();
     assert_eq!(ext.len(), 1, "Shared index should appear once");
     assert!(ext[0].same_id(&idx));
@@ -457,7 +457,7 @@ fn test_external_indices_preserves_same_id_prime_pair() {
     let idx_prime = idx.prime();
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx_prime);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let ext = block.external_indices();
 
@@ -471,7 +471,7 @@ fn test_external_indices_independent() {
     let idx2 = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx1);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx2);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
     let ext = block.external_indices();
     assert_eq!(ext.len(), 2, "Independent indices should both appear");
 }
@@ -485,13 +485,13 @@ fn test_get_mut() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let mut block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let mut block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     // Mutate block (1, 0) via get_mut
-    let blk = block.get_mut(1, 0);
+    let blk = block.get_mut(1, 0).unwrap();
     *blk = make_vector_with_index(vec![10.0, 20.0], &idx);
 
-    let data = block.get(1, 0).to_vec::<f64>().unwrap();
+    let data = block.get(1, 0).unwrap().to_vec::<f64>().unwrap();
     assert!((data[0] - 10.0).abs() < 1e-10);
     assert!((data[1] - 20.0).abs() < 1e-10);
 }
@@ -501,14 +501,14 @@ fn test_blocks_and_blocks_mut() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let mut block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let mut block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     // blocks() returns immutable slice
     assert_eq!(block.blocks().len(), 2);
 
     // blocks_mut() returns mutable slice
     block.blocks_mut()[0] = make_vector_with_index(vec![10.0, 20.0], &idx);
-    let data = block.get(0, 0).to_vec::<f64>().unwrap();
+    let data = block.get(0, 0).unwrap().to_vec::<f64>().unwrap();
     assert!((data[0] - 10.0).abs() < 1e-10);
 }
 
@@ -517,7 +517,7 @@ fn test_into_blocks() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let blocks = block.into_blocks();
     assert_eq!(blocks.len(), 2);
@@ -535,7 +535,7 @@ fn test_replaceind() {
     let new_idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let replaced = block.replaceind(&idx, &new_idx).unwrap();
 
@@ -545,7 +545,7 @@ fn test_replaceind() {
         assert!(ext[0].same_id(&new_idx));
     }
     // Data should be preserved
-    let data = replaced.get(0, 0).to_vec::<f64>().unwrap();
+    let data = replaced.get(0, 0).unwrap().to_vec::<f64>().unwrap();
     assert!((data[0] - 1.0).abs() < 1e-10);
     assert!((data[1] - 2.0).abs() < 1e-10);
 }
@@ -559,7 +559,7 @@ fn test_replaceinds() {
 
     let b1 = TensorDynLen::from_dense(vec![idx1.clone(), idx2.clone()], vec![0.0; 6]).unwrap();
     let b2 = TensorDynLen::from_dense(vec![idx1.clone(), idx2.clone()], vec![1.0; 6]).unwrap();
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let replaced = block
         .replaceinds(
@@ -587,7 +587,7 @@ fn test_maxabs() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, -5.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block = BlockTensor::new(vec![b1, b2], (2, 1));
+    let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let m = block.maxabs();
     assert!((m - 5.0).abs() < 1e-10);
@@ -601,7 +601,7 @@ fn test_maxabs() {
 fn test_factorize_unsupported() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
-    let block = BlockTensor::new(vec![b1], (1, 1));
+    let block = BlockTensor::new(vec![b1], (1, 1)).unwrap();
 
     let result = block.factorize(&[idx], &FactorizeOptions::default());
     assert!(result.is_err());
@@ -612,8 +612,8 @@ fn test_direct_sum_unsupported() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block1 = BlockTensor::new(vec![b1], (1, 1));
-    let block2 = BlockTensor::new(vec![b2], (1, 1));
+    let block1 = BlockTensor::new(vec![b1], (1, 1)).unwrap();
+    let block2 = BlockTensor::new(vec![b2], (1, 1)).unwrap();
 
     let result = block1.direct_sum(&block2, &[(idx.clone(), idx.clone())]);
     assert!(result.is_err());
@@ -624,8 +624,8 @@ fn test_outer_product_unsupported() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let b2 = make_vector_with_index(vec![3.0, 4.0], &idx);
-    let block1 = BlockTensor::new(vec![b1], (1, 1));
-    let block2 = BlockTensor::new(vec![b2], (1, 1));
+    let block1 = BlockTensor::new(vec![b1], (1, 1)).unwrap();
+    let block2 = BlockTensor::new(vec![b2], (1, 1)).unwrap();
 
     let result = block1.outer_product(&block2);
     assert!(result.is_err());
@@ -635,7 +635,7 @@ fn test_outer_product_unsupported() {
 fn test_permuteinds_unsupported() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
-    let block = BlockTensor::new(vec![b1], (1, 1));
+    let block = BlockTensor::new(vec![b1], (1, 1)).unwrap();
 
     let result = block.permuteinds(&[idx]);
     assert!(result.is_err());
@@ -645,7 +645,7 @@ fn test_permuteinds_unsupported() {
 fn test_contract_unsupported() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
-    let block = BlockTensor::new(vec![b1], (1, 1));
+    let block = BlockTensor::new(vec![b1], (1, 1)).unwrap();
 
     let result = BlockTensor::<TensorDynLen>::contract(&[&block], AllowedPairs::All);
     assert!(result.is_err());
@@ -655,7 +655,7 @@ fn test_contract_unsupported() {
 fn test_contract_connected_unsupported() {
     let idx = DynIndex::new_dyn(2);
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
-    let block = BlockTensor::new(vec![b1], (1, 1));
+    let block = BlockTensor::new(vec![b1], (1, 1)).unwrap();
 
     let result = BlockTensor::<TensorDynLen>::contract_connected(&[&block], AllowedPairs::All);
     assert!(result.is_err());

--- a/crates/tensor4all-core/src/col_major_array.rs
+++ b/crates/tensor4all-core/src/col_major_array.rs
@@ -326,12 +326,20 @@ impl<T> ColMajorArray<T> {
 
     /// Number of rows, or `None` when the array is not 2D.
     pub fn nrows(&self) -> Option<usize> {
-        (self.ndim() == 2).then_some(self.shape[0])
+        if self.ndim() == 2 {
+            Some(self.shape[0])
+        } else {
+            None
+        }
     }
 
     /// Number of columns, or `None` when the array is not 2D.
     pub fn ncols(&self) -> Option<usize> {
-        (self.ndim() == 2).then_some(self.shape[1])
+        if self.ndim() == 2 {
+            Some(self.shape[1])
+        } else {
+            None
+        }
     }
 
     /// Return a slice for column `j` of a 2D array, or `None` if `j` is out
@@ -643,6 +651,8 @@ mod tests {
         assert!(arr.is_empty());
         assert_eq!(arr.len(), 0);
         assert_eq!(arr.ndim(), 1);
+        assert_eq!(arr.nrows(), None);
+        assert_eq!(arr.ncols(), None);
     }
 
     #[test]

--- a/crates/tensor4all-core/src/col_major_array.rs
+++ b/crates/tensor4all-core/src/col_major_array.rs
@@ -61,10 +61,6 @@ fn checked_shape_numel(shape: &[usize]) -> Option<usize> {
         .try_fold(1usize, |acc, d| acc.checked_mul(d))
 }
 
-fn shape_numel(shape: &[usize]) -> usize {
-    checked_shape_numel(shape).expect("shape product overflows usize")
-}
-
 /// Compute the flat offset for a column-major multi-index, using checked
 /// arithmetic. Returns `None` if any index is out of bounds or on overflow.
 fn flat_offset(shape: &[usize], index: &[usize]) -> Option<usize> {
@@ -100,19 +96,23 @@ pub struct ColMajorArrayRef<'a, T> {
 impl<'a, T> ColMajorArrayRef<'a, T> {
     /// Create a new borrowed array view.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `data.len() != shape.iter().product()`.
-    pub fn new(data: &'a [T], shape: &'a [usize]) -> Self {
-        let expected = shape_numel(shape);
-        assert_eq!(
-            data.len(),
-            expected,
-            "ColMajorArrayRef::new: data length {} != shape product {}",
-            data.len(),
-            expected,
-        );
-        Self { data, shape }
+    /// Returns an error if `data.len()` does not match the product of `shape`,
+    /// or if the shape product overflows `usize`.
+    pub fn new(data: &'a [T], shape: &'a [usize]) -> Result<Self, ColMajorArrayError> {
+        let expected =
+            checked_shape_numel(shape).ok_or_else(|| ColMajorArrayError::ShapeOverflow {
+                shape: shape.to_vec(),
+            })?;
+        if data.len() != expected {
+            return Err(ColMajorArrayError::ShapeMismatch {
+                shape: shape.to_vec(),
+                expected,
+                actual: data.len(),
+            });
+        }
+        Ok(Self { data, shape })
     }
 
     /// Number of dimensions.
@@ -162,19 +162,23 @@ pub struct ColMajorArrayMut<'a, T> {
 impl<'a, T> ColMajorArrayMut<'a, T> {
     /// Create a new mutable borrowed array view.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `data.len() != shape.iter().product()`.
-    pub fn new(data: &'a mut [T], shape: &'a [usize]) -> Self {
-        let expected = shape_numel(shape);
-        assert_eq!(
-            data.len(),
-            expected,
-            "ColMajorArrayMut::new: data length {} != shape product {}",
-            data.len(),
-            expected,
-        );
-        Self { data, shape }
+    /// Returns an error if `data.len()` does not match the product of `shape`,
+    /// or if the shape product overflows `usize`.
+    pub fn new(data: &'a mut [T], shape: &'a [usize]) -> Result<Self, ColMajorArrayError> {
+        let expected =
+            checked_shape_numel(shape).ok_or_else(|| ColMajorArrayError::ShapeOverflow {
+                shape: shape.to_vec(),
+            })?;
+        if data.len() != expected {
+            return Err(ColMajorArrayError::ShapeMismatch {
+                shape: shape.to_vec(),
+                expected,
+                actual: data.len(),
+            });
+        }
+        Ok(Self { data, shape })
     }
 
     /// Number of dimensions.
@@ -320,22 +324,22 @@ impl<T> ColMajorArray<T> {
 
     // -- 2D helpers ---------------------------------------------------------
 
-    /// Number of rows (panics if not 2D).
-    pub fn nrows(&self) -> usize {
-        assert_eq!(self.ndim(), 2, "nrows() requires a 2D array");
-        self.shape[0]
+    /// Number of rows, or `None` when the array is not 2D.
+    pub fn nrows(&self) -> Option<usize> {
+        (self.ndim() == 2).then_some(self.shape[0])
     }
 
-    /// Number of columns (panics if not 2D).
-    pub fn ncols(&self) -> usize {
-        assert_eq!(self.ndim(), 2, "ncols() requires a 2D array");
-        self.shape[1]
+    /// Number of columns, or `None` when the array is not 2D.
+    pub fn ncols(&self) -> Option<usize> {
+        (self.ndim() == 2).then_some(self.shape[1])
     }
 
     /// Return a slice for column `j` of a 2D array, or `None` if `j` is out
-    /// of range. Panics if the array is not 2D.
+    /// of range or if the array is not 2D.
     pub fn column(&self, j: usize) -> Option<&[T]> {
-        assert_eq!(self.ndim(), 2, "column() requires a 2D array");
+        if self.ndim() != 2 {
+            return None;
+        }
         let nrows = self.shape[0];
         if j >= self.shape[1] {
             return None;
@@ -513,10 +517,10 @@ mod tests {
     #[test]
     fn test_push_column() {
         let mut arr = ColMajorArray::new(vec![1, 2, 3, 4], vec![2, 2]).unwrap();
-        assert_eq!(arr.ncols(), 2);
+        assert_eq!(arr.ncols(), Some(2));
 
         arr.push_column(&[5, 6]).unwrap();
-        assert_eq!(arr.ncols(), 3);
+        assert_eq!(arr.ncols(), Some(3));
         assert_eq!(arr.shape(), &[2, 3]);
         assert_eq!(arr.len(), 6);
         assert_eq!(arr.get(&[0, 2]), Some(&5));
@@ -646,8 +650,8 @@ mod tests {
         let arr: ColMajorArray<i32> = ColMajorArray::new(vec![], vec![3, 0]).unwrap();
         assert!(arr.is_empty());
         assert_eq!(arr.len(), 0);
-        assert_eq!(arr.nrows(), 3);
-        assert_eq!(arr.ncols(), 0);
+        assert_eq!(arr.nrows(), Some(3));
+        assert_eq!(arr.ncols(), Some(0));
     }
 
     // -- ColMajorArrayRef construction --------------------------------------
@@ -656,7 +660,7 @@ mod tests {
     fn test_ref_new() {
         let data = [1, 2, 3, 4, 5, 6];
         let shape = [2, 3];
-        let view = ColMajorArrayRef::new(&data, &shape);
+        let view = ColMajorArrayRef::new(&data, &shape).unwrap();
         assert_eq!(view.ndim(), 2);
         assert_eq!(view.len(), 6);
         assert_eq!(view.get(&[1, 2]), Some(&6));
@@ -668,7 +672,7 @@ mod tests {
     fn test_mut_new() {
         let mut data = [1, 2, 3, 4, 5, 6];
         let shape = [2, 3];
-        let mut view = ColMajorArrayMut::new(&mut data, &shape);
+        let mut view = ColMajorArrayMut::new(&mut data, &shape).unwrap();
         assert_eq!(view.ndim(), 2);
         assert_eq!(view.len(), 6);
         *view.get_mut(&[0, 0]).unwrap() = 100;

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -415,12 +415,12 @@ pub fn contract_multi_owned(
                 .into_iter()
                 .enumerate()
                 .map(|(tensor_idx, tensor)| {
-                    (
-                        tensor.as_native().clone(),
+                    Ok((
+                        tensor.as_native()?.clone(),
                         plan.input_ids[tensor_idx].clone(),
-                    )
+                    ))
                 })
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>>>()?;
             let result_native = einsum_native_tensors_owned(native_operands, &plan.output_ids)?;
             TensorDynLen::from_native_with_axis_classes(
                 plan.result_indices,
@@ -794,10 +794,17 @@ fn execute_contraction_plan(
     has_retained_indices: bool,
 ) -> Result<TensorDynLen> {
     let any_grad = tensors.iter().any(|tensor| tensor.tracks_grad());
-    let first_dtype = tensors[0].as_native().dtype();
+    let first_dtype = tensors[0].as_native()?.dtype();
     let same_dtype = tensors
         .iter()
-        .all(|tensor| tensor.as_native().dtype() == first_dtype);
+        .map(|tensor| {
+            tensor
+                .as_native()
+                .map(|native| native.dtype() == first_dtype)
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .all(|same| same);
     let has_non_dense_axis_classes = tensors.iter().any(|tensor| {
         tensor
             .storage()
@@ -823,7 +830,7 @@ fn execute_contraction_plan(
         };
         let mut result = (*first).clone();
         for tensor in iter {
-            result = result.contract_pairwise_default(tensor);
+            result = result.try_contract_pairwise_default(tensor)?;
         }
         return Ok(result);
     }
@@ -832,7 +839,7 @@ fn execute_contraction_plan(
         let operands = tensors
             .iter()
             .map(|tensor| tensor.as_inner())
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
         let subscripts = build_einsum_subscripts_from_usize_ids(&plan.input_ids, &plan.output_ids)?;
         let result = eager_einsum_ad(&operands, &subscripts)?;
         return TensorDynLen::from_inner_with_axis_classes(
@@ -845,8 +852,10 @@ fn execute_contraction_plan(
     let native_operands: Vec<_> = tensors
         .iter()
         .enumerate()
-        .map(|(tensor_idx, tensor)| (tensor.as_native(), plan.input_ids[tensor_idx].as_slice()))
-        .collect();
+        .map(|(tensor_idx, tensor)| {
+            Ok((tensor.as_native()?, plan.input_ids[tensor_idx].as_slice()))
+        })
+        .collect::<Result<Vec<_>>>()?;
     let result_native = einsum_native_tensors(&native_operands, &plan.output_ids)?;
     TensorDynLen::from_native_with_axis_classes(
         plan.result_indices.clone(),

--- a/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
@@ -556,7 +556,8 @@ fn test_contract_multi_owned_falls_back_to_borrowed_for_grad_tensors() {
         vec![batch.clone(), i.clone(), k.clone()],
         (1..=12).map(|value| value as f64).collect(),
     )
-    .enable_grad();
+    .enable_grad()
+    .unwrap();
     let y = make_test_tensor_from_data(
         &[2, 3, 2],
         vec![batch.clone(), k.clone(), j.clone()],

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -11,7 +11,7 @@
 //! # Example
 //!
 //! ```
-//! use tensor4all_core::{factorize, Canonical, DynIndex, FactorizeOptions, TensorDynLen};
+//! use tensor4all_core::{factorize, Canonical, DynIndex, FactorizeOptions, TensorDynLen, TensorLike};
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! let i = DynIndex::new_dyn(2);
@@ -138,8 +138,8 @@ pub fn factorize(
 ///     FactorizeAlg::QR,
 ///     Canonical::Left,
 /// )?;
-/// let reconstructed = result.left.contract(&result.right);
-/// assert!((tensor - reconstructed).maxabs() < 1.0e-18);
+/// let reconstructed = result.left.contract(&result.right).unwrap();
+/// assert!(tensor.sub(&reconstructed)?.maxabs() < 1.0e-18);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn factorize_full_rank(
@@ -263,8 +263,8 @@ fn factorize_svd_with_options(
     match canonical {
         Canonical::Left => {
             // L = U (orthogonal), R = S * V^H
-            let right_contracted = s.contract(&vh);
-            let right = right_contracted.replaceind(&sim_bond_index, &bond_index);
+            let right_contracted = s.contract(&vh)?;
+            let right = right_contracted.replaceind(&sim_bond_index, &bond_index)?;
             Ok(FactorizeResult {
                 left: u,
                 right,
@@ -275,8 +275,8 @@ fn factorize_svd_with_options(
         }
         Canonical::Right => {
             // L = U * S, R = V^H
-            let left_contracted = u.contract(&s);
-            let left = left_contracted.replaceind(&sim_bond_index, &bond_index);
+            let left_contracted = u.contract(&s)?;
+            let left = left_contracted.replaceind(&sim_bond_index, &bond_index)?;
             Ok(FactorizeResult {
                 left,
                 right: vh,
@@ -331,10 +331,16 @@ fn factorize_qr_with_options(
     let (q, r) = qr_with::<f64>(t, left_inds, qr_options)?;
 
     // Get bond index from Q tensor (last index)
-    let bond_index = q.indices.last().unwrap().clone();
+    let bond_index = q
+        .indices
+        .last()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("QR factorization returned a rank-0 Q tensor"))?;
     // Rank is the last dimension of Q
     let q_dims = q.dims();
-    let rank = *q_dims.last().unwrap();
+    let rank = *q_dims
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("QR factorization returned Q with no dimensions"))?;
 
     Ok(FactorizeResult {
         left: q,

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -42,8 +42,8 @@ pub enum QrError {
 /// let (q, r) = qr_with::<f64>(&tensor, &[i], &opts).unwrap();
 ///
 /// // Q * R recovers the original tensor
-/// let recovered = q.contract(&r);
-/// assert!(tensor.distance(&recovered) < 1e-12);
+/// let recovered = q.contract(&r).unwrap();
+/// assert!(tensor.distance(&recovered).unwrap() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct QrOptions {

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -414,7 +414,10 @@ pub fn svd_with<T>(
     let vh =
         TensorDynLen::from_native(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
     let perm: Vec<usize> = (1..vh.indices.len()).chain(std::iter::once(0)).collect();
-    let v = vh.conj().permute(&perm);
+    let v = vh
+        .conj()
+        .permute(&perm)
+        .map_err(SvdError::ComputationError)?;
 
     Ok((u, s, v))
 }

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -9,7 +9,6 @@ use num_traits::Zero;
 use rand::Rng;
 use rand_distr::{Distribution, StandardNormal};
 use std::collections::HashSet;
-use std::ops::{Mul, Neg, Sub};
 use std::sync::{Arc, OnceLock};
 use tenferro::eager_einsum::eager_einsum_ad;
 use tenferro::{CpuBackend, DType, EagerTensor, Tensor as NativeTensor};
@@ -63,9 +62,10 @@ impl RandomScalar for Complex64 {
 /// A `Vec<usize>` representing the permutation: `perm[i]` is the position in
 /// `original_indices` of the index that should be at position `i` in `new_indices`.
 ///
-/// # Panics
-/// Panics if any index ID in `new_indices` doesn't match an index in `original_indices`,
-/// or if there are duplicate indices in `new_indices`.
+/// # Errors
+/// Returns an error if the slices have different lengths, if `new_indices`
+/// is not a permutation of `original_indices`, or if `new_indices` contains
+/// duplicate indices.
 ///
 /// # Example
 /// ```
@@ -77,16 +77,15 @@ impl RandomScalar for Complex64 {
 /// let original = vec![i.clone(), j.clone()];
 /// let new_order = vec![j.clone(), i.clone()];
 ///
-/// let perm = compute_permutation_from_indices(&original, &new_order);
+/// let perm = compute_permutation_from_indices(&original, &new_order).unwrap();
 /// assert_eq!(perm, vec![1, 0]);  // j is at position 1, i is at position 0
 /// ```
 pub fn compute_permutation_from_indices(
     original_indices: &[DynIndex],
     new_indices: &[DynIndex],
-) -> Vec<usize> {
-    assert_eq!(
-        new_indices.len(),
-        original_indices.len(),
+) -> Result<Vec<usize>> {
+    anyhow::ensure!(
+        new_indices.len() == original_indices.len(),
         "new_indices length must match original_indices length"
     );
 
@@ -99,16 +98,15 @@ pub fn compute_permutation_from_indices(
         let pos = original_indices
             .iter()
             .position(|old_idx| old_idx == new_idx)
-            .expect("new_indices must be a permutation of original_indices");
+            .ok_or_else(|| {
+                anyhow::anyhow!("new_indices must be a permutation of original_indices")
+            })?;
 
-        if used.contains(&pos) {
-            panic!("duplicate index in new_indices");
-        }
-        used.insert(pos);
+        anyhow::ensure!(used.insert(pos), "duplicate index in new_indices");
         perm.push(pos);
     }
 
-    perm
+    Ok(perm)
 }
 
 #[derive(Clone)]
@@ -134,8 +132,8 @@ pub(crate) struct StructuredAdValue {
 /// |-----------|--------|
 /// | Create from data | [`from_dense`](Self::from_dense), [`from_diag`](Self::from_diag), [`zeros`](Self::zeros) |
 /// | Extract data | [`to_vec`](Self::to_vec), [`sum`](Self::sum), [`only`](Self::only) |
-/// | Contraction | [`contract`](Self::contract), `*` operator |
-/// | Arithmetic | [`add`](Self::add), [`scale`](Self::scale), [`axpby`](Self::axpby), `-` operator |
+/// | Contraction | [`contract`](Self::contract) |
+/// | Arithmetic | [`add`](Self::add), [`scale`](Self::scale), [`axpby`](Self::axpby) |
 /// | Factorization | via [`TensorLike::factorize`] |
 /// | Norms | [`norm`](Self::norm), [`norm_squared`](Self::norm_squared), [`maxabs`](Self::maxabs) |
 /// | Index ops | [`replaceind`](Self::replaceind), [`permute_indices`](Self::permute_indices) |
@@ -162,7 +160,7 @@ pub(crate) struct StructuredAdValue {
 /// assert!(t.is_f64());
 ///
 /// // Sum all elements: 1+2+3+4+5+6 = 21
-/// let s = t.sum();
+/// let s = t.sum().unwrap();
 /// assert!((s.real() - 21.0).abs() < 1e-12);
 ///
 /// // Extract data back out
@@ -408,14 +406,15 @@ impl TensorDynLen {
         }
     }
 
-    fn validate_indices(indices: &[DynIndex]) {
+    fn validate_indices(indices: &[DynIndex]) -> Result<()> {
         let mut seen = HashSet::new();
         for idx in indices {
-            assert!(
+            anyhow::ensure!(
                 seen.insert(idx.clone()),
                 "Tensor indices must all be unique"
             );
         }
+        Ok(())
     }
 
     fn validate_diag_dims(dims: &[usize]) -> Result<()> {
@@ -615,7 +614,7 @@ impl TensorDynLen {
         payload_dims: Vec<usize>,
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
-        Self::validate_indices(&indices);
+        Self::validate_indices(&indices)?;
         if payload_inner.data().shape() != payload_dims {
             return Err(anyhow::anyhow!(
                 "structured payload dims {:?} do not match planned payload dims {:?}",
@@ -706,12 +705,16 @@ impl TensorDynLen {
             let lhs = if let Some(value) = self.tracked_compact_payload_value() {
                 value.payload.as_ref()
             } else {
-                lhs_owned.as_ref().unwrap()
+                lhs_owned
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("missing untracked left compact payload"))?
             };
             let rhs = if let Some(value) = other.tracked_compact_payload_value() {
                 value.payload.as_ref()
             } else {
-                rhs_owned.as_ref().unwrap()
+                rhs_owned
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("missing untracked right compact payload"))?
             };
             if lhs.data().dtype() != rhs.data().dtype() {
                 return Err(anyhow::anyhow!(
@@ -1079,23 +1082,30 @@ impl TensorDynLen {
         Ok(())
     }
 
-    fn materialized_inner(&self) -> &EagerTensor<CpuBackend> {
+    fn try_materialized_inner(&self) -> Result<&EagerTensor<CpuBackend>> {
         if let Some(value) = self.tracked_compact_payload_value() {
             if self.compact_payload_is_logical_dense(&value.payload_dims) {
-                return value.payload.as_ref();
+                return Ok(value.payload.as_ref());
             }
         }
+        if self.eager_cache.get().is_none() {
+            let native = Self::seed_native_payload(self.storage.as_ref(), &self.dims())
+                .context("TensorDynLen materialization failed")?;
+            let _ = self.eager_cache.set(Arc::new(EagerTensor::from_tensor_in(
+                native,
+                default_eager_ctx(),
+            )));
+        }
         self.eager_cache
-            .get_or_init(|| {
-                let native = Self::seed_native_payload(self.storage.as_ref(), &self.dims())
-                    .unwrap_or_else(|err| panic!("TensorDynLen materialization failed: {err}"));
-                Arc::new(EagerTensor::from_tensor_in(native, default_eager_ctx()))
+            .get()
+            .map(|inner| inner.as_ref())
+            .ok_or_else(|| {
+                anyhow::anyhow!("TensorDynLen materialization cache was not initialized")
             })
-            .as_ref()
     }
 
-    pub(crate) fn as_inner(&self) -> &EagerTensor<CpuBackend> {
-        self.materialized_inner()
+    pub(crate) fn as_inner(&self) -> Result<&EagerTensor<CpuBackend>> {
+        self.try_materialized_inner()
     }
 
     /// Compute dims from `indices` order.
@@ -1252,7 +1262,7 @@ impl TensorDynLen {
             default_eager_ctx(),
         );
         let sliced = self
-            .materialized_inner()
+            .try_materialized_inner()?
             .dynamic_slice(&starts_tensor, &slice_sizes)?;
         Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?)
     }
@@ -1323,8 +1333,8 @@ impl TensorDynLen {
 
         let inner_refs = tensors
             .iter()
-            .map(|tensor| tensor.materialized_inner())
-            .collect::<Vec<_>>();
+            .map(|tensor| tensor.try_materialized_inner())
+            .collect::<Result<Vec<_>>>()?;
         let stacked = EagerTensor::stack(&inner_refs, axis)?;
         Self::from_inner(result_indices, stacked)
     }
@@ -1389,7 +1399,9 @@ impl TensorDynLen {
 
         let axis = isize::try_from(axis)
             .map_err(|_| anyhow::anyhow!("index_select: axis does not fit in isize"))?;
-        let selected = self.materialized_inner().index_select(axis, positions)?;
+        let selected = self
+            .try_materialized_inner()?
+            .index_select(axis, positions)?;
         let mut result_indices = self.indices.clone();
         result_indices[axis as usize] = target_index;
         Self::from_inner(result_indices, selected)
@@ -1397,9 +1409,10 @@ impl TensorDynLen {
 
     /// Create a new tensor with dynamic rank.
     ///
-    /// # Panics
-    /// Panics if the storage is Diag and not all indices have the same dimension.
-    /// Panics if there are duplicate indices.
+    /// # Errors
+    /// Returns an error if the storage logical dimensions do not match the
+    /// supplied indices, if diagonal storage has unequal logical dimensions,
+    /// or if duplicate indices are provided.
     ///
     /// # Examples
     ///
@@ -1409,24 +1422,22 @@ impl TensorDynLen {
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(3);
-    /// let storage = Arc::new(Storage::new_dense::<f64>(3));
-    /// let t = TensorDynLen::new(vec![i], storage);
+    /// let storage = Arc::new(Storage::new_dense::<f64>(3).unwrap());
+    /// let t = TensorDynLen::new(vec![i], storage).unwrap();
     /// assert_eq!(t.dims(), vec![3]);
     /// ```
-    pub fn new(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Self {
-        match Self::from_storage(indices, storage) {
-            Ok(tensor) => tensor,
-            Err(err) => panic!("TensorDynLen::new failed: {err}"),
-        }
+    pub fn new(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
+        Self::from_storage(indices, storage)
     }
 
     /// Create a new tensor with dynamic rank, automatically computing dimensions from indices.
     ///
     /// This is a convenience constructor that extracts dimensions from indices using `IndexLike::dim()`.
     ///
-    /// # Panics
-    /// Panics if the storage is Diag and not all indices have the same dimension.
-    /// Panics if there are duplicate indices.
+    /// # Errors
+    /// Returns an error if the storage logical dimensions do not match the
+    /// supplied indices, if diagonal storage has unequal logical dimensions,
+    /// or if duplicate indices are provided.
     ///
     /// # Examples
     ///
@@ -1436,11 +1447,11 @@ impl TensorDynLen {
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(4);
-    /// let storage = Arc::new(Storage::new_dense::<f64>(4));
-    /// let t = TensorDynLen::from_indices(vec![i], storage);
+    /// let storage = Arc::new(Storage::new_dense::<f64>(4).unwrap());
+    /// let t = TensorDynLen::from_indices(vec![i], storage).unwrap();
     /// assert_eq!(t.dims(), vec![4]);
     /// ```
-    pub fn from_indices(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Self {
+    pub fn from_indices(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
         Self::new(indices, storage)
     }
 
@@ -1455,12 +1466,12 @@ impl TensorDynLen {
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
-    /// let storage = Arc::new(Storage::new_diag(vec![1.0_f64, 2.0]));
+    /// let storage = Arc::new(Storage::new_diag(vec![1.0_f64, 2.0]).unwrap());
     /// let t = TensorDynLen::from_storage(vec![i, j], storage).unwrap();
     /// assert_eq!(t.dims(), vec![2, 2]);
     /// ```
     pub fn from_storage(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
-        Self::validate_indices(&indices);
+        Self::validate_indices(&indices)?;
         Self::validate_storage_matches_indices(&indices, storage.as_ref())?;
         Ok(Self {
             indices,
@@ -1529,7 +1540,7 @@ impl TensorDynLen {
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
         let dims = Self::expected_dims_from_indices(&indices);
-        Self::validate_indices(&indices);
+        Self::validate_indices(&indices)?;
         if dims != inner.data().shape() {
             return Err(anyhow::anyhow!(
                 "native payload dims {:?} do not match indices dims {:?}",
@@ -1559,17 +1570,17 @@ impl TensorDynLen {
     }
 
     /// Borrow the native payload.
-    pub(crate) fn as_native(&self) -> &NativeTensor {
-        self.materialized_inner().data()
+    pub(crate) fn as_native(&self) -> Result<&NativeTensor> {
+        Ok(self.try_materialized_inner()?.data())
     }
 
     /// Enable reverse-mode AD tracking on this tensor by creating a tracked leaf.
-    pub fn enable_grad(self) -> Self {
+    pub fn enable_grad(self) -> Result<Self> {
         let payload = storage_payload_native(self.storage.as_ref())
-            .unwrap_or_else(|err| panic!("TensorDynLen::enable_grad failed: {err}"));
+            .context("TensorDynLen::enable_grad failed")?;
         let payload_dims = self.storage.payload_dims().to_vec();
         let axis_classes = self.storage.axis_classes().to_vec();
-        Self {
+        Ok(Self {
             indices: self.indices,
             storage: self.storage,
             structured_ad: Some(Arc::new(StructuredAdValue {
@@ -1578,7 +1589,7 @@ impl TensorDynLen {
                 axis_classes,
             })),
             eager_cache: Self::empty_eager_cache(),
-        }
+        })
     }
 
     /// Report whether this tensor participates in gradient tracking.
@@ -1608,7 +1619,7 @@ impl TensorDynLen {
                 })
                 .transpose();
         }
-        self.materialized_inner()
+        self.try_materialized_inner()?
             .grad()
             .map(|grad| {
                 Self::from_native_with_axis_classes(
@@ -1640,24 +1651,22 @@ impl TensorDynLen {
                 .map(|_| ())
                 .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}"));
         }
-        self.materialized_inner()
+        self.try_materialized_inner()?
             .backward()
             .map(|_| ())
             .map_err(|e| anyhow::anyhow!("TensorDynLen::backward failed: {e}"))
     }
 
     /// Detach this tensor from the reverse graph.
-    pub fn detach(&self) -> Self {
+    pub fn detach(&self) -> Result<Self> {
         if self.tracked_compact_payload_value().is_some() {
-            return Self::from_storage(self.indices.clone(), Arc::clone(&self.storage))
-                .expect("TensorDynLen::detach returned invalid tensor");
+            return Self::from_storage(self.indices.clone(), Arc::clone(&self.storage));
         }
         Self::from_inner_with_axis_classes(
             self.indices.clone(),
-            self.materialized_inner().detach(),
+            self.try_materialized_inner()?.detach(),
             self.storage.axis_classes().to_vec(),
         )
-        .expect("TensorDynLen::detach returned invalid tensor")
     }
 
     /// Check if this tensor is already in canonical form.
@@ -1684,22 +1693,16 @@ impl TensorDynLen {
     ///
     /// let i = DynIndex::new_dyn(3);
     /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
-    /// let s = t.sum();
+    /// let s = t.sum().unwrap();
     /// assert!((s.real() - 6.0).abs() < 1e-12);
     /// ```
-    pub fn sum(&self) -> AnyScalar {
+    pub fn sum(&self) -> Result<AnyScalar> {
         if self.indices.is_empty() {
-            return AnyScalar::from_tensor_unchecked(self.clone());
+            return AnyScalar::from_tensor(self.clone());
         }
         let axes: Vec<usize> = (0..self.indices.len()).collect();
-        let reduced = self
-            .materialized_inner()
-            .reduce_sum(&axes)
-            .unwrap_or_else(|e| panic!("TensorDynLen::sum failed: {e}"));
-        AnyScalar::from_tensor_unchecked(
-            Self::from_inner(Vec::new(), reduced)
-                .unwrap_or_else(|e| panic!("TensorDynLen::sum returned invalid scalar: {e}")),
-        )
+        let reduced = self.try_materialized_inner()?.reduce_sum(&axes)?;
+        AnyScalar::from_tensor(Self::from_inner(Vec::new(), reduced)?)
     }
 
     /// Extract the scalar value from a 0-dimensional tensor (or 1-element tensor).
@@ -1720,12 +1723,12 @@ impl TensorDynLen {
     /// let indices: Vec<Index<DynId>> = vec![];
     /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![42.0]).unwrap();
     ///
-    /// assert_eq!(tensor.only().real(), 42.0);
+    /// assert_eq!(tensor.only().unwrap().real(), 42.0);
     /// ```
-    pub fn only(&self) -> AnyScalar {
+    pub fn only(&self) -> Result<AnyScalar> {
         let dims = self.dims();
-        let total_size: usize = dims.iter().product();
-        assert!(
+        let total_size = checked_product(&dims)?;
+        anyhow::ensure!(
             total_size == 1 || dims.is_empty(),
             "only() requires a scalar tensor (1 element), got {} elements with dims {:?}",
             if dims.is_empty() { 1 } else { total_size },
@@ -1761,28 +1764,24 @@ impl TensorDynLen {
     /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Permute to 3×2: swap the two dimensions by providing new indices order
-    /// let permuted = tensor.permute_indices(&[j, i]);
+    /// let permuted = tensor.permute_indices(&[j, i]).unwrap();
     /// assert_eq!(permuted.dims(), vec![3, 2]);
     /// ```
-    pub fn permute_indices(&self, new_indices: &[DynIndex]) -> Self {
+    pub fn permute_indices(&self, new_indices: &[DynIndex]) -> Result<Self> {
         // Compute permutation by matching IDs
-        let perm = compute_permutation_from_indices(&self.indices, new_indices);
+        let perm = compute_permutation_from_indices(&self.indices, new_indices)?;
         if perm.iter().copied().eq(0..perm.len()) {
-            return Self {
+            return Ok(Self {
                 indices: new_indices.to_vec(),
                 storage: Arc::clone(&self.storage),
                 structured_ad: self.structured_ad.clone(),
                 eager_cache: Arc::clone(&self.eager_cache),
-            };
+            });
         }
 
-        let permuted = self
-            .materialized_inner()
-            .transpose(&perm)
-            .unwrap_or_else(|e| panic!("TensorDynLen::permute_indices failed: {e}"));
+        let permuted = self.try_materialized_inner()?.transpose(&perm)?;
         let axis_classes = self.permute_axis_classes(&perm);
         Self::from_inner_with_axis_classes(new_indices.to_vec(), permuted, axis_classes)
-            .expect("TensorDynLen::permute_indices returned invalid tensor")
     }
 
     /// Permute the tensor dimensions, returning a new tensor.
@@ -1810,28 +1809,31 @@ impl TensorDynLen {
     /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Permute to 3×2: swap the two dimensions
-    /// let permuted = tensor.permute(&[1, 0]);
+    /// let permuted = tensor.permute(&[1, 0]).unwrap();
     /// assert_eq!(permuted.dims(), vec![3, 2]);
     /// ```
-    pub fn permute(&self, perm: &[usize]) -> Self {
-        assert_eq!(
-            perm.len(),
-            self.indices.len(),
+    pub fn permute(&self, perm: &[usize]) -> Result<Self> {
+        anyhow::ensure!(
+            perm.len() == self.indices.len(),
             "permutation length must match tensor rank"
         );
+        let mut seen = HashSet::new();
+        for &axis in perm {
+            anyhow::ensure!(
+                axis < self.indices.len(),
+                "permutation axis {axis} out of range"
+            );
+            anyhow::ensure!(seen.insert(axis), "duplicate axis {axis} in permutation");
+        }
         if perm.iter().copied().eq(0..perm.len()) {
-            return self.clone();
+            return Ok(self.clone());
         }
 
         // Permute indices
         let new_indices: Vec<DynIndex> = perm.iter().map(|&i| self.indices[i].clone()).collect();
-        let permuted = self
-            .materialized_inner()
-            .transpose(perm)
-            .unwrap_or_else(|e| panic!("TensorDynLen::permute failed: {e}"));
+        let permuted = self.try_materialized_inner()?.transpose(perm)?;
         let axis_classes = self.permute_axis_classes(perm);
         Self::from_inner_with_axis_classes(new_indices, permuted, axis_classes)
-            .expect("TensorDynLen::permute returned invalid tensor")
     }
 
     /// Contract this tensor with another tensor along common indices.
@@ -1868,11 +1870,11 @@ impl TensorDynLen {
     /// let tensor_b: TensorDynLen = TensorDynLen::from_dense(indices_b, vec![0.0; 12]).unwrap();
     ///
     /// // Contract along j with the default pairwise semantics: result is C[i, k]
-    /// let result = tensor_a.contract(&tensor_b);
+    /// let result = tensor_a.contract(&tensor_b).unwrap();
     /// assert_eq!(result.dims(), vec![2, 4]);
     /// ```
-    pub fn contract(&self, other: &Self) -> Self {
-        self.contract_pairwise_default(other)
+    pub fn contract(&self, other: &Self) -> Result<Self> {
+        self.try_contract_pairwise_default(other)
     }
 
     /// Contract this tensor with another tensor using explicit contraction options.
@@ -1921,11 +1923,6 @@ impl TensorDynLen {
         crate::defaults::contract::contract_multi_with_options(&[self, other], options)
     }
 
-    pub(crate) fn contract_pairwise_default(&self, other: &Self) -> Self {
-        self.try_contract_pairwise_default(other)
-            .unwrap_or_else(|e| panic!("TensorDynLen::contract failed: {e}"))
-    }
-
     pub(crate) fn try_contract_pairwise_default(&self, other: &Self) -> Result<Self> {
         let self_dims = Self::expected_dims_from_indices(&self.indices);
         let other_dims = Self::expected_dims_from_indices(&other.indices);
@@ -1948,17 +1945,17 @@ impl TensorDynLen {
         }
 
         if self.indices.is_empty() && other.indices.is_empty() {
-            let result = self.materialized_inner().mul(other.materialized_inner())?;
+            let result = self
+                .try_materialized_inner()?
+                .mul(other.try_materialized_inner()?)?;
             return Self::from_inner(spec.result_indices, result);
         }
 
-        if self.as_native().dtype() != other.as_native().dtype() {
-            let result_native = contract_native_tensor(
-                self.as_native(),
-                &spec.axes_a,
-                other.as_native(),
-                &spec.axes_b,
-            )?;
+        let self_native = self.as_native()?;
+        let other_native = other.as_native()?;
+        if self_native.dtype() != other_native.dtype() {
+            let result_native =
+                contract_native_tensor(self_native, &spec.axes_a, other_native, &spec.axes_b)?;
             return Self::from_native_with_axis_classes(
                 spec.result_indices,
                 result_native,
@@ -1973,7 +1970,10 @@ impl TensorDynLen {
             &spec.axes_b,
         )?;
         let result = eager_einsum_ad(
-            &[self.materialized_inner(), other.materialized_inner()],
+            &[
+                self.try_materialized_inner()?,
+                other.try_materialized_inner()?,
+            ],
             &subscripts,
         )?;
         Self::from_inner_with_axis_classes(spec.result_indices, result, result_axis_classes)
@@ -2080,19 +2080,17 @@ impl TensorDynLen {
 
         if self.indices.is_empty() && other.indices.is_empty() {
             let result = self
-                .materialized_inner()
-                .mul(other.materialized_inner())
+                .try_materialized_inner()?
+                .mul(other.try_materialized_inner()?)
                 .map_err(|e| anyhow::anyhow!("tensordot scalar multiply failed: {e}"))?;
             return Self::from_inner(spec.result_indices, result);
         }
 
-        if self.as_native().dtype() != other.as_native().dtype() {
-            let result_native = contract_native_tensor(
-                self.as_native(),
-                &spec.axes_a,
-                other.as_native(),
-                &spec.axes_b,
-            )?;
+        let self_native = self.as_native()?;
+        let other_native = other.as_native()?;
+        if self_native.dtype() != other_native.dtype() {
+            let result_native =
+                contract_native_tensor(self_native, &spec.axes_a, other_native, &spec.axes_b)?;
             return Self::from_native_with_axis_classes(
                 spec.result_indices,
                 result_native,
@@ -2107,7 +2105,10 @@ impl TensorDynLen {
             &spec.axes_b,
         )?;
         let result = eager_einsum_ad(
-            &[self.materialized_inner(), other.materialized_inner()],
+            &[
+                self.try_materialized_inner()?,
+                other.try_materialized_inner()?,
+            ],
             &subscripts,
         )
         .map_err(|e| anyhow::anyhow!("tensordot failed: {e}"))?;
@@ -2174,9 +2175,10 @@ impl TensorDynLen {
         if self.should_use_structured_payload_contract(other) {
             return self.contract_structured_payloads(other, result_indices, &[], &[]);
         }
-        if self.as_native().dtype() != other.as_native().dtype() {
-            let result_native =
-                contract_native_tensor(self.as_native(), &[], other.as_native(), &[])?;
+        let self_native = self.as_native()?;
+        let other_native = other.as_native()?;
+        if self_native.dtype() != other_native.dtype() {
+            let result_native = contract_native_tensor(self_native, &[], other_native, &[])?;
             return Self::from_native_with_axis_classes(
                 result_indices,
                 result_native,
@@ -2191,7 +2193,10 @@ impl TensorDynLen {
             &[],
         )?;
         let result = eager_einsum_ad(
-            &[self.materialized_inner(), other.materialized_inner()],
+            &[
+                self.try_materialized_inner()?,
+                other.try_materialized_inner()?,
+            ],
             &subscripts,
         )
         .map_err(|e| anyhow::anyhow!("outer_product failed: {e}"))?;
@@ -2227,130 +2232,14 @@ impl TensorDynLen {
     /// let mut rng = ChaCha8Rng::seed_from_u64(42);
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
-    /// let tensor: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i, j]);
+    /// let tensor: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i, j]).unwrap();
     /// assert_eq!(tensor.dims(), vec![2, 3]);
     /// ```
-    pub fn random<T: RandomScalar, R: Rng>(rng: &mut R, indices: Vec<DynIndex>) -> Self {
+    pub fn random<T: RandomScalar, R: Rng>(rng: &mut R, indices: Vec<DynIndex>) -> Result<Self> {
         let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
-        let size: usize = dims.iter().product();
+        let size = checked_product(&dims)?;
         let data: Vec<T> = (0..size).map(|_| T::random_value(rng)).collect();
-        Self::from_dense(indices, data).expect("TensorDynLen::random failed")
-    }
-}
-
-/// Implement multiplication operator for tensor contraction.
-///
-/// The `*` operator performs tensor contraction along common indices.
-/// This is equivalent to calling the `contract` method.
-///
-/// # Example
-/// ```
-/// use tensor4all_core::TensorDynLen;
-/// use tensor4all_core::index::{DefaultIndex as Index, DynId};
-///
-/// // Create two tensors: A[i, j] and B[j, k]
-/// let i = Index::new_dyn(2);
-/// let j = Index::new_dyn(3);
-/// let k = Index::new_dyn(4);
-///
-/// let indices_a = vec![i.clone(), j.clone()];
-/// let tensor_a: TensorDynLen = TensorDynLen::from_dense(indices_a, vec![0.0; 6]).unwrap();
-///
-/// let indices_b = vec![j.clone(), k.clone()];
-/// let tensor_b: TensorDynLen = TensorDynLen::from_dense(indices_b, vec![0.0; 12]).unwrap();
-///
-/// // Contract along j using * operator: result is C[i, k]
-/// let result = &tensor_a * &tensor_b;
-/// assert_eq!(result.dims(), vec![2, 4]);
-/// ```
-impl Mul<&TensorDynLen> for &TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn mul(self, other: &TensorDynLen) -> Self::Output {
-        self.contract(other)
-    }
-}
-
-/// Implement multiplication operator for tensor contraction (owned version).
-///
-/// This allows using `tensor_a * tensor_b` when both tensors are owned.
-impl Mul<TensorDynLen> for TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn mul(self, other: TensorDynLen) -> Self::Output {
-        self.contract(&other)
-    }
-}
-
-/// Implement multiplication operator for tensor contraction (mixed reference/owned).
-impl Mul<TensorDynLen> for &TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn mul(self, other: TensorDynLen) -> Self::Output {
-        self.contract(&other)
-    }
-}
-
-/// Implement multiplication operator for tensor contraction (mixed owned/reference).
-impl Mul<&TensorDynLen> for TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn mul(self, other: &TensorDynLen) -> Self::Output {
-        self.contract(other)
-    }
-}
-
-impl Sub<&TensorDynLen> for &TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn sub(self, other: &TensorDynLen) -> Self::Output {
-        TensorDynLen::axpby(
-            self,
-            AnyScalar::new_real(1.0),
-            other,
-            AnyScalar::new_real(-1.0),
-        )
-        .expect("tensor subtraction failed")
-    }
-}
-
-impl Sub<TensorDynLen> for TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn sub(self, other: TensorDynLen) -> Self::Output {
-        Sub::sub(&self, &other)
-    }
-}
-
-impl Sub<TensorDynLen> for &TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn sub(self, other: TensorDynLen) -> Self::Output {
-        Sub::sub(self, &other)
-    }
-}
-
-impl Sub<&TensorDynLen> for TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn sub(self, other: &TensorDynLen) -> Self::Output {
-        Sub::sub(&self, other)
-    }
-}
-
-impl Neg for &TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn neg(self) -> Self::Output {
-        TensorDynLen::scale(self, AnyScalar::new_real(-1.0)).expect("tensor negation failed")
-    }
-}
-
-impl Neg for TensorDynLen {
-    type Output = TensorDynLen;
-
-    fn neg(self) -> Self::Output {
-        Neg::neg(&self)
+        Self::from_dense(indices, data)
     }
 }
 
@@ -2409,7 +2298,7 @@ impl TensorDynLen {
         }
 
         // Permute other to match self's index order (no-op if already aligned)
-        let other_aligned = other.permute_indices(&self.indices);
+        let other_aligned = other.permute_indices(&self.indices)?;
 
         // Validate dimensions match after alignment
         let self_expected_dims = Self::expected_dims_from_indices(&self.indices);
@@ -2484,7 +2373,7 @@ impl TensorDynLen {
         }
 
         // Align other tensor axis order to self.
-        let other_aligned = other.permute_indices(&self.indices);
+        let other_aligned = other.permute_indices(&self.indices)?;
 
         // Validate dimensions match after alignment.
         let self_expected_dims = Self::expected_dims_from_indices(&self.indices);
@@ -2524,14 +2413,18 @@ impl TensorDynLen {
             return Self::from_storage(self.indices.clone(), Arc::new(combined));
         }
 
-        if self.as_native().dtype() != other_aligned.as_native().dtype()
-            || self.as_native().dtype() != a.as_tensor().as_native().dtype()
-            || other_aligned.as_native().dtype() != b.as_tensor().as_native().dtype()
+        let self_native = self.as_native()?;
+        let other_native = other_aligned.as_native()?;
+        let a_native = a.as_tensor()?.as_native()?;
+        let b_native = b.as_tensor()?.as_native()?;
+        if self_native.dtype() != other_native.dtype()
+            || self_native.dtype() != a_native.dtype()
+            || other_native.dtype() != b_native.dtype()
         {
             let combined = axpby_native_tensor(
-                self.as_native(),
+                self_native,
                 &a.to_backend_scalar(),
-                other_aligned.as_native(),
+                other_native,
                 &b.to_backend_scalar(),
             )?;
             return Self::from_native_with_axis_classes(
@@ -2544,8 +2437,8 @@ impl TensorDynLen {
         let lhs = self.scale(a)?;
         let rhs = other_aligned.scale(b)?;
         let combined = lhs
-            .materialized_inner()
-            .add(rhs.materialized_inner())
+            .try_materialized_inner()?
+            .add(rhs.try_materialized_inner()?)
             .map_err(|e| anyhow::anyhow!("tensor addition failed: {e}"))?;
         Self::from_inner_with_axis_classes(self.indices.clone(), combined, axis_classes)
     }
@@ -2565,8 +2458,10 @@ impl TensorDynLen {
     /// assert_eq!(scaled.to_vec::<f64>().unwrap(), vec![2.0, 4.0, 6.0]);
     /// ```
     pub fn scale(&self, scalar: AnyScalar) -> Result<Self> {
-        if self.as_native().dtype() != scalar.as_tensor().as_native().dtype() {
-            let scaled = scale_native_tensor(self.as_native(), &scalar.to_backend_scalar())?;
+        let self_native = self.as_native()?;
+        let scalar_native = scalar.as_tensor()?.as_native()?;
+        if self_native.dtype() != scalar_native.dtype() {
+            let scaled = scale_native_tensor(self_native, &scalar.to_backend_scalar())?;
             return Self::from_native_with_axis_classes(
                 self.indices.clone(),
                 scaled,
@@ -2575,15 +2470,15 @@ impl TensorDynLen {
         }
 
         let scaled = if self.indices.is_empty() {
-            self.materialized_inner()
-                .mul(scalar.as_tensor().materialized_inner())
+            self.try_materialized_inner()?
+                .mul(scalar.as_tensor()?.try_materialized_inner()?)
                 .map_err(|e| anyhow::anyhow!("scalar multiplication failed: {e}"))?
         } else {
             let subscripts = Self::scale_subscripts(self.indices.len())?;
             eager_einsum_ad(
                 &[
-                    self.materialized_inner(),
-                    scalar.as_tensor().materialized_inner(),
+                    self.try_materialized_inner()?,
+                    scalar.as_tensor()?.try_materialized_inner()?,
                 ],
                 &subscripts,
             )
@@ -2618,9 +2513,9 @@ impl TensorDynLen {
             let self_set: HashSet<_> = self.indices.iter().collect();
             let other_set: HashSet<_> = other.indices.iter().collect();
             if self_set == other_set {
-                let other_aligned = other.permute_indices(&self.indices);
-                let result = self.conj().contract(&other_aligned);
-                return Ok(result.sum());
+                let other_aligned = other.permute_indices(&self.indices)?;
+                let result = self.conj().contract(&other_aligned)?;
+                return result.sum();
             }
         }
 
@@ -2629,7 +2524,7 @@ impl TensorDynLen {
         let result =
             super::contract::contract_multi(&[&conj_self, other], crate::AllowedPairs::All)?;
         // Result should be a scalar (no indices)
-        Ok(result.sum())
+        result.sum()
     }
 }
 
@@ -2651,6 +2546,9 @@ impl TensorDynLen {
     /// A new tensor with the index replaced. If no index matches `old_index`,
     /// returns a clone of the original tensor.
     ///
+    /// # Errors
+    /// Returns an error if the replacement index has a different dimension.
+    ///
     /// # Example
     /// ```
     /// use tensor4all_core::TensorDynLen;
@@ -2664,18 +2562,18 @@ impl TensorDynLen {
     /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Replace index i with new_i
-    /// let replaced = tensor.replaceind(&i, &new_i);
+    /// let replaced = tensor.replaceind(&i, &new_i).unwrap();
     /// assert_eq!(replaced.indices[0].id, new_i.id);
     /// assert_eq!(replaced.indices[1].id, j.id);
     /// ```
-    pub fn replaceind(&self, old_index: &DynIndex, new_index: &DynIndex) -> Self {
+    pub fn replaceind(&self, old_index: &DynIndex, new_index: &DynIndex) -> Result<Self> {
         // Validate dimension match
         if old_index.dim() != new_index.dim() {
-            panic!(
+            return Err(anyhow::anyhow!(
                 "Index space mismatch: cannot replace index with dimension {} with index of dimension {}",
                 old_index.dim(),
                 new_index.dim()
-            );
+            ));
         }
 
         let new_indices: Vec<_> = self
@@ -2690,12 +2588,12 @@ impl TensorDynLen {
             })
             .collect();
 
-        Self {
+        Ok(Self {
             indices: new_indices,
             storage: Arc::clone(&self.storage),
             structured_ad: self.structured_ad.clone(),
             eager_cache: Arc::clone(&self.eager_cache),
-        }
+        })
     }
 
     /// Replace multiple indices in the tensor.
@@ -2707,12 +2605,13 @@ impl TensorDynLen {
     /// * `old_indices` - The indices to replace (matched by ID)
     /// * `new_indices` - The new indices to use
     ///
-    /// # Panics
-    /// Panics if `old_indices` and `new_indices` have different lengths.
-    ///
     /// # Returns
     /// A new tensor with the indices replaced. Indices not found in `old_indices`
     /// are kept unchanged.
+    ///
+    /// # Errors
+    /// Returns an error if `old_indices` and `new_indices` have different
+    /// lengths or if any replacement index has a different dimension.
     ///
     /// # Example
     /// ```
@@ -2728,25 +2627,26 @@ impl TensorDynLen {
     /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Replace both indices
-    /// let replaced = tensor.replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()]);
+    /// let replaced = tensor
+    ///     .replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()])
+    ///     .unwrap();
     /// assert_eq!(replaced.indices[0].id, new_i.id);
     /// assert_eq!(replaced.indices[1].id, new_j.id);
     /// ```
-    pub fn replaceinds(&self, old_indices: &[DynIndex], new_indices: &[DynIndex]) -> Self {
-        assert_eq!(
-            old_indices.len(),
-            new_indices.len(),
+    pub fn replaceinds(&self, old_indices: &[DynIndex], new_indices: &[DynIndex]) -> Result<Self> {
+        anyhow::ensure!(
+            old_indices.len() == new_indices.len(),
             "old_indices and new_indices must have the same length"
         );
 
         // Validate dimension matches for all replacements
         for (old, new) in old_indices.iter().zip(new_indices.iter()) {
             if old.dim() != new.dim() {
-                panic!(
+                return Err(anyhow::anyhow!(
                     "Index space mismatch: cannot replace index with dimension {} with index of dimension {}",
                     old.dim(),
                     new.dim()
-                );
+                ));
             }
         }
 
@@ -2766,12 +2666,12 @@ impl TensorDynLen {
             })
             .collect();
 
-        Self {
+        Ok(Self {
             indices: new_indices_vec,
             storage: Arc::clone(&self.storage),
             structured_ad: self.structured_ad.clone(),
             eager_cache: Arc::clone(&self.eager_cache),
-        }
+        })
     }
 }
 
@@ -2807,16 +2707,27 @@ impl TensorDynLen {
         // For default undirected indices, conj() is a no-op, so this is future-proof
         // for QSpace-compatible directed indices where conj() flips Ket <-> Bra
         let new_indices: Vec<DynIndex> = self.indices.iter().map(|idx| idx.conj()).collect();
-        let conjugated = self
-            .materialized_inner()
-            .conj()
-            .unwrap_or_else(|e| panic!("TensorDynLen::conj failed: {e}"));
-        Self::from_inner_with_axis_classes(
-            new_indices,
-            conjugated,
-            self.storage.axis_classes().to_vec(),
-        )
-        .expect("TensorDynLen::conj returned invalid tensor")
+        let structured_ad = self.tracked_compact_payload_value().and_then(|value| {
+            value.payload.conj().ok().map(|payload| {
+                Arc::new(StructuredAdValue {
+                    payload: Arc::new(payload),
+                    payload_dims: value.payload_dims.clone(),
+                    axis_classes: value.axis_classes.clone(),
+                })
+            })
+        });
+        let eager_cache = self
+            .eager_cache
+            .get()
+            .and_then(|inner| inner.conj().ok())
+            .map(Self::eager_cache_with)
+            .unwrap_or_else(Self::empty_eager_cache);
+        Self {
+            indices: new_indices,
+            storage: Arc::new(self.storage.conj()),
+            structured_ad,
+            eager_cache,
+        }
     }
 }
 
@@ -2843,21 +2754,29 @@ impl TensorDynLen {
     /// assert!((tensor.norm_squared() - 91.0).abs() < 1e-10);
     /// ```
     pub fn norm_squared(&self) -> f64 {
+        self.try_norm_squared().unwrap_or(f64::NAN)
+    }
+
+    /// Try to compute the squared Frobenius norm of the tensor.
+    ///
+    /// # Errors
+    /// Returns an error if conjugation, contraction, or scalar extraction fails.
+    pub fn try_norm_squared(&self) -> Result<f64> {
         // Special case: scalar tensor (no indices)
         if self.indices.is_empty() {
             // For a scalar, ||T||² = |value|²
-            let value = self.sum();
+            let value = self.sum()?;
             let abs_val = value.abs();
-            return abs_val * abs_val;
+            return Ok(abs_val * abs_val);
         }
 
         // Contract tensor with its conjugate over all indices → scalar
         // ||T||² = Σ T_ijk... * conj(T_ijk...) = Σ |T_ijk...|²
         let conj = self.conj();
-        let scalar = self.contract(&conj);
+        let scalar = self.contract(&conj)?;
         // The mathematical result is nonnegative and real. Clamp tiny negative
         // roundoff so downstream `sqrt` stays well-defined for complex tensors.
-        scalar.sum().real().max(0.0)
+        Ok(scalar.sum()?.real().max(0.0))
     }
 
     /// Compute the Frobenius norm of the tensor: ||T|| = sqrt(Σ|T_ijk...|²)
@@ -2922,24 +2841,20 @@ impl TensorDynLen {
     /// let tensor_a: TensorDynLen = TensorDynLen::from_dense(vec![i.clone()], data_a).unwrap();
     /// let tensor_b: TensorDynLen = TensorDynLen::from_dense(vec![i.clone()], data_b).unwrap();
     ///
-    /// assert!(tensor_a.distance(&tensor_b) < 1e-10);  // Zero distance
+    /// assert!(tensor_a.distance(&tensor_b).unwrap() < 1e-10);  // Zero distance
     /// ```
-    pub fn distance(&self, other: &Self) -> f64 {
+    pub fn distance(&self, other: &Self) -> Result<f64> {
         let norm_self = self.norm();
 
         // Compute A - B = A + (-1) * B
-        let neg_other = other
-            .scale(AnyScalar::new_real(-1.0))
-            .expect("distance: tensor scaling failed");
-        let diff = self
-            .add(&neg_other)
-            .expect("distance: tensors must have same indices");
+        let neg_other = other.scale(AnyScalar::new_real(-1.0))?;
+        let diff = self.add(&neg_other)?;
         let norm_diff = diff.norm();
 
         if norm_self > 0.0 {
-            norm_diff / norm_self
+            Ok(norm_diff / norm_self)
         } else {
-            norm_diff
+            Ok(norm_diff)
         }
     }
 }
@@ -2974,13 +2889,12 @@ impl std::fmt::Debug for TensorDynLen {
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
-/// let t = diag_tensor_dyn_len(vec![i, j], vec![1.0, 2.0, 3.0]);
+/// let t = diag_tensor_dyn_len(vec![i, j], vec![1.0, 2.0, 3.0]).unwrap();
 /// assert_eq!(t.dims(), vec![3, 3]);
 /// assert!(t.is_diag());
 /// ```
-pub fn diag_tensor_dyn_len(indices: Vec<DynIndex>, diag_data: Vec<f64>) -> TensorDynLen {
+pub fn diag_tensor_dyn_len(indices: Vec<DynIndex>, diag_data: Vec<f64>) -> Result<TensorDynLen> {
     TensorDynLen::from_diag(indices, diag_data)
-        .unwrap_or_else(|err| panic!("diag_tensor_dyn_len failed: {err}"))
 }
 
 /// Unfold a tensor into a matrix by splitting indices into left and right groups.
@@ -3082,14 +2996,14 @@ pub fn unfold_split(
     new_indices.extend_from_slice(&right_inds);
 
     // Permute tensor to have left indices first, then right indices
-    let unfolded = t.permute_indices(&new_indices);
+    let unfolded = t.permute_indices(&new_indices)?;
 
     // Compute matrix dimensions
     let unfolded_dims = unfolded.dims();
     let m: usize = unfolded_dims[..left_len].iter().product();
     let n: usize = unfolded_dims[left_len..].iter().product();
 
-    let matrix_tensor = reshape_col_major_native_tensor(unfolded.as_native(), &[m, n])?;
+    let matrix_tensor = reshape_col_major_native_tensor(unfolded.as_native()?, &[m, n])?;
 
     Ok((
         matrix_tensor,
@@ -3121,12 +3035,12 @@ impl TensorIndex for TensorDynLen {
 
     fn replaceind(&self, old_index: &DynIndex, new_index: &DynIndex) -> Result<Self> {
         // Delegate to the inherent method
-        Ok(TensorDynLen::replaceind(self, old_index, new_index))
+        TensorDynLen::replaceind(self, old_index, new_index)
     }
 
     fn replaceinds(&self, old_indices: &[DynIndex], new_indices: &[DynIndex]) -> Result<Self> {
         // Delegate to the inherent method
-        Ok(TensorDynLen::replaceinds(self, old_indices, new_indices))
+        TensorDynLen::replaceinds(self, old_indices, new_indices)
     }
 }
 
@@ -3187,7 +3101,7 @@ impl TensorLike for TensorDynLen {
 
     fn permuteinds(&self, new_order: &[DynIndex]) -> Result<Self> {
         // Delegate to the inherent method
-        Ok(TensorDynLen::permute_indices(self, new_order))
+        TensorDynLen::permute_indices(self, new_order)
     }
 
     fn fuse_indices(
@@ -3411,7 +3325,7 @@ impl TensorDynLen {
     /// ```
     pub fn from_dense<T: TensorElement>(indices: Vec<DynIndex>, data: Vec<T>) -> Result<Self> {
         let dims = Self::expected_dims_from_indices(&indices);
-        Self::validate_indices(&indices);
+        Self::validate_indices(&indices)?;
         Self::validate_dense_payload_len(data.len(), &dims)?;
         let native = dense_native_tensor_from_col_major(&data, &dims)?;
         Self::from_native(indices, native)
@@ -3479,7 +3393,7 @@ impl TensorDynLen {
     /// ```
     pub fn from_diag<T: TensorElement>(indices: Vec<DynIndex>, data: Vec<T>) -> Result<Self> {
         let dims = Self::expected_dims_from_indices(&indices);
-        Self::validate_indices(&indices);
+        Self::validate_indices(&indices)?;
         Self::validate_diag_payload_len(data.len(), &dims)?;
         let native = diag_native_tensor_from_col_major(&data, dims.len())?;
         Self::from_native_with_axis_classes(indices, native, Self::diag_axis_classes(dims.len()))
@@ -3657,7 +3571,7 @@ impl TensorDynLen {
                 "fuse_indices result would contain duplicate index"
             );
         }
-        Self::validate_indices(&result_indices);
+        Self::validate_indices(&result_indices)?;
 
         let mut new_dims = Vec::with_capacity(old_dims.len() - old_indices.len() + 1usize);
         for (axis, dim) in old_dims.iter().copied().enumerate() {
@@ -3742,7 +3656,7 @@ impl TensorDynLen {
         result_indices.extend_from_slice(&self.indices[..axis]);
         result_indices.extend(new_indices.iter().cloned());
         result_indices.extend_from_slice(&self.indices[axis + 1..]);
-        Self::validate_indices(&result_indices);
+        Self::validate_indices(&result_indices)?;
 
         let old_dims = self.dims();
         let mut new_dims = Vec::with_capacity(old_dims.len() - 1usize + replacement_dims.len());
@@ -3774,7 +3688,7 @@ impl TensorDynLen {
     ///
     /// let scalar = TensorDynLen::scalar(42.0).unwrap();
     /// assert_eq!(scalar.dims(), Vec::<usize>::new());
-    /// assert_eq!(scalar.only().real(), 42.0);
+    /// assert_eq!(scalar.only().unwrap().real(), 42.0);
     /// ```
     pub fn scalar<T: TensorElement>(value: T) -> Result<Self> {
         Self::from_dense(vec![], vec![value])
@@ -3826,7 +3740,7 @@ impl TensorDynLen {
     /// assert_eq!(data, &[1.0, 2.0]);
     /// ```
     pub fn to_vec<T: TensorElement>(&self) -> Result<Vec<T>> {
-        native_tensor_primal_to_dense_col_major(self.as_native())
+        native_tensor_primal_to_dense_col_major(self.as_native()?)
     }
 
     fn to_vec_any(&self) -> Result<Vec<AnyScalar>> {

--- a/crates/tensor4all-core/src/krylov/tests/mod.rs
+++ b/crates/tensor4all-core/src/krylov/tests/mod.rs
@@ -931,7 +931,7 @@ fn test_restart_gmres_zero_rhs_with_x0() {
     assert!(result.converged);
     assert_eq!(result.iterations, 0);
     // Solution should be x0 when b is zero
-    assert!(result.solution.distance(&x0) < 1e-12);
+    assert!(result.solution.distance(&x0).unwrap() < 1e-12);
 }
 
 #[test]

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -157,9 +157,9 @@ pub enum FactorizeAlg {
 /// ).unwrap();
 ///
 /// // Both recover the same tensor
-/// let recovered_left = left_result.left.contract(&left_result.right);
-/// let recovered_right = right_result.left.contract(&right_result.right);
-/// assert!(recovered_left.distance(&recovered_right) < 1e-12);
+/// let recovered_left = left_result.left.contract(&left_result.right).unwrap();
+/// let recovered_right = right_result.left.contract(&right_result.right).unwrap();
+/// assert!(recovered_left.distance(&recovered_right).unwrap() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Canonical {
@@ -436,8 +436,8 @@ impl FactorizeOptions {
 /// let result = factorize(&tensor, &[i.clone()], &FactorizeOptions::svd()).unwrap();
 ///
 /// // Contracting left * right recovers the original tensor
-/// let recovered = result.left.contract(&result.right);
-/// assert!(tensor.distance(&recovered) < 1e-12);
+/// let recovered = result.left.contract(&result.right).unwrap();
+/// assert!(tensor.distance(&recovered).unwrap() < 1e-12);
 ///
 /// // SVD provides singular values
 /// assert!(result.singular_values.is_some());
@@ -606,7 +606,7 @@ impl LinearizationOrder {
 ///
 /// let i = DynIndex::new_dyn(2);
 /// let dense = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-/// let block = BlockTensor::new(vec![dense.clone()], (1, 1));
+/// let block = BlockTensor::new(vec![dense.clone()], (1, 1)).unwrap();
 ///
 /// enum TensorNetwork {
 ///     Dense(TensorDynLen),
@@ -699,8 +699,8 @@ pub trait TensorLike: TensorIndex {
     ///     FactorizeAlg::QR,
     ///     Canonical::Left,
     /// )?;
-    /// let reconstructed = result.left.contract(&result.right);
-    /// assert!((tensor - reconstructed).maxabs() < 1.0e-18);
+    /// let reconstructed = result.left.contract(&result.right)?;
+    /// assert!(tensor.distance(&reconstructed)? < 1.0e-18);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     fn factorize_full_rank(
@@ -1277,7 +1277,7 @@ pub trait TensorLike: TensorIndex {
     ///
     /// let one = TensorDynLen::scalar_one().unwrap();
     /// assert_eq!(one.dims(), Vec::<usize>::new());
-    /// assert!((one.only().real() - 1.0).abs() < 1e-12);
+    /// assert!((one.only().unwrap().real() - 1.0).abs() < 1e-12);
     /// ```
     fn scalar_one() -> Result<Self>;
 
@@ -1410,7 +1410,7 @@ pub trait TensorLike: TensorIndex {
     /// let data = t.to_vec::<f64>().unwrap();
     /// // column-major 3x2: element at (1,0) = index 1
     /// assert!((data[1] - 1.0).abs() < 1e-12);
-    /// assert!((t.sum().real() - 1.0).abs() < 1e-12);  // exactly one non-zero
+    /// assert!((t.sum().unwrap().real() - 1.0).abs() < 1e-12);  // exactly one non-zero
     /// ```
     fn onehot(index_vals: &[(<Self as TensorIndex>::Index, usize)]) -> Result<Self>;
 }

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -84,7 +84,7 @@ fn tensor_like_default_neg_and_delta_helpers_work() {
 
     let delta = TensorDynLen::delta(&[i.clone(), j.clone()], &[k, l]).unwrap();
     assert_eq!(delta.dims(), vec![2, 2, 3, 3]);
-    assert!((delta.sum().real() - 6.0).abs() < 1.0e-12);
+    assert!((delta.sum().unwrap().real() - 6.0).abs() < 1.0e-12);
 
     let err = TensorDynLen::delta(&[i], &[]).unwrap_err();
     assert!(err.to_string().contains("Number of input indices"));

--- a/crates/tensor4all-core/tests/ad_integration.rs
+++ b/crates/tensor4all-core/tests/ad_integration.rs
@@ -5,9 +5,10 @@ fn tensor_sum_returns_rank_zero_anyscalar_with_backward() {
     let i = Index::new_dyn(3);
     let x = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0])
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
 
-    let loss = x.sum();
+    let loss = x.sum().unwrap();
     assert!(loss.tracks_grad());
 
     loss.backward().unwrap();
@@ -18,12 +19,12 @@ fn tensor_sum_returns_rank_zero_anyscalar_with_backward() {
 
 #[test]
 fn tensor_only_preserves_tracking_for_scalar_tensor() {
-    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad();
+    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad().unwrap();
 
-    let scalar = x.only();
+    let scalar = x.only().unwrap();
     let loss = &scalar * &scalar;
     loss.backward().unwrap();
 
     let grad = x.grad().unwrap().unwrap();
-    assert!((grad.only().real() - 4.0).abs() < 1e-12);
+    assert!((grad.only().unwrap().real() - 4.0).abs() < 1e-12);
 }

--- a/crates/tensor4all-core/tests/bug_qr_after_permute.rs
+++ b/crates/tensor4all-core/tests/bug_qr_after_permute.rs
@@ -126,7 +126,7 @@ fn make_buggy_tensor() -> TensorDynLen {
 
 fn reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex], opts: &FactorizeOptions) -> f64 {
     let result = factorize(t, left_inds, opts).unwrap();
-    let recon = result.left.contract(&result.right);
+    let recon = result.left.contract(&result.right).unwrap();
     let neg = recon
         .scale(tensor4all_core::AnyScalar::new_real(-1.0))
         .unwrap();
@@ -138,11 +138,13 @@ fn svd_reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
     let (u, s, v) = svd::<Complex64>(t, left_inds).unwrap();
     let mut perm = vec![v.indices.len() - 1];
     perm.extend(0..v.indices.len() - 1);
-    let vh = v.conj().permute(&perm);
+    let vh = v.conj().permute(&perm).unwrap();
     let svh = s
         .contract(&vh)
-        .replaceind(&s.indices[1], &u.indices[u.indices.len() - 1]);
-    let recon = u.contract(&svh);
+        .unwrap()
+        .replaceind(&s.indices[1], &u.indices[u.indices.len() - 1])
+        .unwrap();
+    let recon = u.contract(&svh).unwrap();
     let neg = recon
         .scale(tensor4all_core::AnyScalar::new_real(-1.0))
         .unwrap();

--- a/crates/tensor4all-core/tests/error_paths.rs
+++ b/crates/tensor4all-core/tests/error_paths.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+
+use tensor4all_core::block_tensor::BlockTensor;
+use tensor4all_core::col_major_array::{ColMajorArrayError, ColMajorArrayRef};
+use tensor4all_core::index_like::IndexLike;
+use tensor4all_core::{
+    compute_permutation_from_indices, diag_tensor_dyn_len, DynIndex, TensorDynLen,
+};
+use tensor4all_tensorbackend::Storage;
+
+#[test]
+fn permutation_helper_rejects_non_permutation() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let k = DynIndex::new_dyn(2);
+
+    let err = compute_permutation_from_indices(&[i, j.clone()], &[j, k]).unwrap_err();
+
+    assert!(err.to_string().contains("permutation"));
+}
+
+#[test]
+fn tensor_new_rejects_duplicate_indices() {
+    let i = DynIndex::new_dyn(2);
+    let storage = Arc::new(Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap());
+
+    let err = TensorDynLen::new(vec![i.clone(), i], storage).unwrap_err();
+
+    assert!(err.to_string().contains("unique"));
+}
+
+#[test]
+fn tensor_permute_rejects_invalid_axis_order() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+    let tensor = TensorDynLen::from_dense(
+        vec![i.clone(), j.clone()],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    )
+    .unwrap();
+
+    let err = tensor.permute_indices(&[j, i.clone(), i]).unwrap_err();
+
+    assert!(err.to_string().contains("length"));
+}
+
+#[test]
+fn tensor_contract_rejects_mismatched_common_dimension() {
+    let shared_left = DynIndex::new_dyn(2);
+    let shared_right = DynIndex::new_with_tags(*shared_left.id(), 3, shared_left.tags().clone());
+    let a = TensorDynLen::from_dense(vec![shared_left], vec![1.0_f64, 2.0]).unwrap();
+    let b = TensorDynLen::from_dense(vec![shared_right], vec![1.0_f64, 2.0, 3.0]).unwrap();
+
+    let err = a.contract(&b).unwrap_err();
+
+    let message = err.to_string();
+    assert!(
+        message.contains("contraction")
+            || message.contains("Dimension mismatch")
+            || message.contains("unique")
+    );
+}
+
+#[test]
+fn random_rejects_duplicate_indices() {
+    let i = DynIndex::new_dyn(2);
+    let mut rng = rand::rng();
+
+    let err = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), i]).unwrap_err();
+
+    assert!(err.to_string().contains("unique"));
+}
+
+#[test]
+fn block_tensor_new_rejects_shape_mismatch() {
+    let i = DynIndex::new_dyn(2);
+    let block = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
+
+    let err = BlockTensor::new(vec![block], (2, 1)).unwrap_err();
+
+    assert!(err.to_string().contains("Block count mismatch"));
+}
+
+#[test]
+fn col_major_ref_new_rejects_overflow_shape() {
+    let data = [0usize];
+    let err = ColMajorArrayRef::new(&data, &[usize::MAX, 2]).unwrap_err();
+
+    assert_eq!(
+        err,
+        ColMajorArrayError::ShapeOverflow {
+            shape: vec![usize::MAX, 2]
+        }
+    );
+}
+
+#[test]
+fn diag_tensor_helper_rejects_dimension_mismatch() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+
+    let err = diag_tensor_dyn_len(vec![i, j], vec![1.0, 2.0]).unwrap_err();
+
+    assert!(err.to_string().contains("same dimension"));
+}

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -62,7 +62,7 @@ fn test_factorize_reconstruction(options: &FactorizeOptions) {
     let result = factorize(&tensor, &left_inds, options).unwrap();
 
     // Verify reconstruction: left * right ≈ original
-    let reconstructed = result.left.contract(&result.right);
+    let reconstructed = result.left.contract(&result.right).unwrap();
     assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
 }
 
@@ -163,7 +163,7 @@ fn test_factorize_svd_rank3() {
     let options = FactorizeOptions::svd();
     let result = factorize(&tensor, &left_inds, &options).unwrap();
 
-    let reconstructed = result.left.contract(&result.right);
+    let reconstructed = result.left.contract(&result.right).unwrap();
     assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
 }
 
@@ -233,7 +233,7 @@ fn test_factorize_lu_ci_reconstruction_with_unit_dim_axis() {
             qr_rtol: None,
         };
         let result = factorize(&tensor, &left_inds, &options).unwrap();
-        let reconstructed = result.left.contract(&result.right);
+        let reconstructed = result.left.contract(&result.right).unwrap();
         assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
     }
 }
@@ -252,7 +252,7 @@ fn test_factorize_lu_ci_reconstruction_with_col_major_matrix_input() {
             qr_rtol: None,
         };
         let result = factorize(&tensor, &left_inds, &options).unwrap();
-        let reconstructed = result.left.contract(&result.right);
+        let reconstructed = result.left.contract(&result.right).unwrap();
         assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
     }
 }
@@ -292,7 +292,7 @@ fn test_factorize_full_rank_preserves_near_dependent_components() {
             "{alg:?} full-rank factorization dropped a near-dependent component"
         );
 
-        let reconstructed = result.left.contract(&result.right);
+        let reconstructed = result.left.contract(&result.right).unwrap();
         assert_tensors_approx_equal(&tensor, &reconstructed, 1.0e-18);
     }
 }
@@ -356,10 +356,10 @@ fn test_diag_dense_contraction_svd_internals() {
     assert!(common_found, "S and V should share a common index");
 
     // Contractions should work
-    let sv = s.contract(&v);
+    let sv = s.contract(&v).unwrap();
     assert_eq!(sv.dims().len(), 2, "S*V should be a 2D tensor");
 
-    let us = u.contract(&s);
+    let us = u.contract(&s).unwrap();
     assert_eq!(us.dims().len(), 2, "U*S should be a 2D tensor");
 }
 
@@ -371,6 +371,6 @@ fn assert_tensors_approx_equal(a: &TensorDynLen, b: &TensorDynLen, tol: f64) {
     assert!(
         a.isapprox(b, tol, 0.0),
         "Tensors differ: maxabs diff = {}",
-        (a - b).maxabs()
+        a.sub(b).unwrap().maxabs()
     );
 }

--- a/crates/tensor4all-core/tests/linalg_qr.rs
+++ b/crates/tensor4all-core/tests/linalg_qr.rs
@@ -84,13 +84,13 @@ fn test_qr_reconstruction() {
     let (q, r) = qr::<f64>(&tensor, std::slice::from_ref(&i)).expect("QR should succeed");
 
     // Reconstruct: A = Q * R
-    let reconstructed = q.contract(&r);
+    let reconstructed = q.contract(&r).unwrap();
 
     // Check reconstruction accuracy
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "QR reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
@@ -181,12 +181,12 @@ fn test_qr_nontrivial_split_reconstruction() {
     let tensor = dense_f64(vec![i.clone(), j.clone(), k.clone(), l.clone()], data);
 
     let (q, r) = qr::<f64>(&tensor, &[i.clone(), k.clone()]).expect("QR should succeed");
-    let reconstructed = q.contract(&r);
+    let reconstructed = q.contract(&r).unwrap();
 
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "QR nontrivial split reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
@@ -207,18 +207,18 @@ fn test_qr_complex_reconstruction() {
     let (q, r) =
         qr::<Complex64>(&tensor, std::slice::from_ref(&i_idx)).expect("Complex QR should succeed");
 
-    let reconstructed = q.contract(&r);
+    let reconstructed = q.contract(&r).unwrap();
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "Complex QR reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
 /// Helper: compute ||Q*R - T|| via tensor contraction for any tensor shape.
 fn qr_reconstruction_error_f64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
     let (q, r) = qr::<f64>(t, left_inds).expect("QR should succeed");
-    let recon = q.contract(&r);
+    let recon = q.contract(&r).unwrap();
     let neg = recon
         .scale(tensor4all_core::AnyScalar::new_real(-1.0))
         .unwrap();
@@ -228,7 +228,7 @@ fn qr_reconstruction_error_f64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 
 
 fn qr_reconstruction_error_c64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
     let (q, r) = qr::<Complex64>(t, left_inds).expect("QR should succeed");
-    let recon = q.contract(&r);
+    let recon = q.contract(&r).unwrap();
     let neg = recon
         .scale(tensor4all_core::AnyScalar::new_real(-1.0))
         .unwrap();

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -23,16 +23,16 @@ fn vh_from_v(v: &TensorDynLen) -> TensorDynLen {
     let ndim = v_conj.indices.len();
     let mut perm = vec![ndim - 1];
     perm.extend(0..(ndim - 1));
-    v_conj.permute(&perm)
+    v_conj.permute(&perm).unwrap()
 }
 
 fn reconstruct_from_svd(u: &TensorDynLen, s: &TensorDynLen, v: &TensorDynLen) -> TensorDynLen {
     let vh = vh_from_v(v);
-    let svh = s.contract(&vh);
+    let svh = s.contract(&vh).unwrap();
     let sim_bond = s.indices[1].clone();
     let bond = v.indices[v.indices.len() - 1].clone();
-    let svh = svh.replaceind(&sim_bond, &bond);
-    u.contract(&svh)
+    let svh = svh.replaceind(&sim_bond, &bond).unwrap();
+    u.contract(&svh).unwrap()
 }
 
 #[test]
@@ -62,7 +62,7 @@ fn test_svd_identity() {
 
     // For identity matrix, singular values should be [1, 1].
     // We avoid direct storage slice inspection and verify through tensor invariants.
-    assert!((s.sum().real() - 2.0).abs() < 1e-10);
+    assert!((s.sum().unwrap().real() - 2.0).abs() < 1e-10);
     assert!((s.norm_squared() - 2.0).abs() < 1e-10);
 }
 
@@ -121,7 +121,7 @@ fn test_svd_reconstruction() {
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "SVD reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
@@ -224,7 +224,7 @@ fn test_svd_nontrivial_split_reconstruction() {
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "SVD nontrivial split reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
@@ -250,7 +250,7 @@ fn test_svd_complex_reconstruction() {
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "Complex SVD reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
@@ -276,7 +276,7 @@ fn test_svd_complex_rectangular_reconstruction() {
     assert!(
         tensor.isapprox(&reconstructed, 1e-8, 0.0),
         "Complex rectangular SVD reconstruction failed: maxabs diff = {}",
-        (&tensor - &reconstructed).maxabs()
+        tensor.sub(&reconstructed).unwrap().maxabs()
     );
 }
 
@@ -316,7 +316,7 @@ fn test_svd_truncation() {
     assert_eq!(v.dims(), vec![2, 1], "V should be truncated to rank 1");
 
     // Retained singular value should be approximately 1.0
-    assert!((s.sum().real() - 1.0).abs() < 1e-10);
+    assert!((s.sum().unwrap().real() - 1.0).abs() < 1e-10);
     assert!((s.norm_squared() - 1.0).abs() < 1e-10);
 }
 
@@ -483,7 +483,7 @@ fn test_svd_tall_matrix_preserves_left_axis_order() {
     assert!(
         u.isapprox(&expected, 1e-10, 0.0),
         "left-axis order changed in tall-matrix SVD: maxabs diff = {}",
-        (&u - &expected).maxabs()
+        u.sub(&expected).unwrap().maxabs()
     );
 }
 

--- a/crates/tensor4all-core/tests/tensor_any_scalar.rs
+++ b/crates/tensor4all-core/tests/tensor_any_scalar.rs
@@ -334,8 +334,8 @@ fn test_scalar_lhs_rhs_mixed_ops() {
 
 #[test]
 fn test_enable_grad_and_borrow_arithmetic_backward() {
-    let x = AnyScalar::new_real(2.0).enable_grad();
-    let y = AnyScalar::new_real(3.0).enable_grad();
+    let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
+    let y = AnyScalar::new_real(3.0).enable_grad().unwrap();
 
     let product = &x * &y;
     let loss = &product + &x;
@@ -351,7 +351,7 @@ fn test_enable_grad_and_borrow_arithmetic_backward() {
 
 #[test]
 fn test_clone_shares_tracked_leaf_gradient_slot() {
-    let x = AnyScalar::new_real(2.0).enable_grad();
+    let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
     let alias = x.clone();
 
     let loss = &x * &alias;
@@ -365,8 +365,8 @@ fn test_clone_shares_tracked_leaf_gradient_slot() {
 
 #[test]
 fn test_owned_arithmetic_backward_with_moved_operands() {
-    let x = AnyScalar::new_real(2.0).enable_grad();
-    let y = AnyScalar::new_real(3.0).enable_grad();
+    let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
+    let y = AnyScalar::new_real(3.0).enable_grad().unwrap();
 
     let x_alias = x.clone();
     let y_alias = y.clone();
@@ -385,8 +385,8 @@ fn test_owned_arithmetic_backward_with_moved_operands() {
 
 #[test]
 fn test_clear_grad_resets_anyscalar_accumulation() {
-    let x = AnyScalar::new_real(2.0).enable_grad();
-    let y = AnyScalar::new_real(3.0).enable_grad();
+    let x = AnyScalar::new_real(2.0).enable_grad().unwrap();
+    let y = AnyScalar::new_real(3.0).enable_grad().unwrap();
 
     let loss = &x * &y;
     loss.backward().unwrap();
@@ -407,9 +407,9 @@ fn test_clear_grad_resets_anyscalar_accumulation() {
 
 #[test]
 fn test_detach_breaks_reverse_graph_for_anyscalar() {
-    let x = AnyScalar::new_real(3.0).enable_grad();
-    let y = AnyScalar::new_real(2.0).enable_grad();
-    let detached = x.detach();
+    let x = AnyScalar::new_real(3.0).enable_grad().unwrap();
+    let y = AnyScalar::new_real(2.0).enable_grad().unwrap();
+    let detached = x.detach().unwrap();
 
     assert!(!detached.tracks_grad());
     assert!(x.tracks_grad());
@@ -426,9 +426,9 @@ fn test_detach_breaks_reverse_graph_for_anyscalar() {
 
 #[test]
 fn test_primal_matches_detach_semantics_for_anyscalar() {
-    let x = AnyScalar::new_real(3.0).enable_grad();
-    let y = AnyScalar::new_real(2.0).enable_grad();
-    let primal = x.primal();
+    let x = AnyScalar::new_real(3.0).enable_grad().unwrap();
+    let y = AnyScalar::new_real(2.0).enable_grad().unwrap();
+    let primal = x.primal().unwrap();
 
     assert!(!primal.tracks_grad());
     assert_eq!(primal.real(), 3.0);
@@ -449,7 +449,7 @@ fn test_function_api_takes_anyscalar_ref() {
         &square + &AnyScalar::one()
     }
 
-    let x = AnyScalar::new_real(3.0).enable_grad();
+    let x = AnyScalar::new_real(3.0).enable_grad().unwrap();
     let loss = quadratic_plus_one(&x);
     loss.backward().unwrap();
 

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -38,7 +38,7 @@ where
 #[test]
 fn test_storage_dense_f64() {
     // Create a zero-initialized tensor with 10 elements
-    let storage = Storage::new_dense::<f64>(10);
+    let storage = Storage::new_dense::<f64>(10).unwrap();
     assert_eq!(storage.len(), 10);
     assert!(storage.is_dense());
     assert!(storage.is_f64());
@@ -52,7 +52,7 @@ fn test_storage_dense_f64() {
 #[test]
 fn test_storage_dense_c64() {
     // Create a zero-initialized tensor with 10 elements
-    let storage = Storage::new_dense::<Complex64>(10);
+    let storage = Storage::new_dense::<Complex64>(10).unwrap();
     assert_eq!(storage.len(), 10);
     assert!(storage.is_dense());
     assert!(storage.is_c64());
@@ -65,7 +65,7 @@ fn test_storage_dense_c64() {
 
 #[test]
 fn test_storage_factory_f64() {
-    let storage = Storage::new_dense::<f64>(7);
+    let storage = Storage::new_dense::<f64>(7).unwrap();
     assert!(storage.is_dense());
     assert!(storage.is_f64());
     assert_eq!(storage.len(), 7);
@@ -77,7 +77,7 @@ fn test_storage_factory_f64() {
 
 #[test]
 fn test_storage_factory_c64() {
-    let storage = Storage::new_dense::<Complex64>(9);
+    let storage = Storage::new_dense::<Complex64>(9).unwrap();
     assert!(storage.is_dense());
     assert!(storage.is_c64());
     assert_eq!(storage.len(), 9);
@@ -109,7 +109,7 @@ fn test_tensor_dyn_len_creation() {
     let indices = vec![Index::new_dyn(2), Index::new_dyn(3)];
     let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap());
 
-    let tensor: TensorDynLen = TensorDynLen::new(indices, storage);
+    let tensor: TensorDynLen = TensorDynLen::new(indices, storage).unwrap();
     assert_eq!(tensor.indices.len(), 2);
     let dims = tensor.dims();
     assert_eq!(dims.len(), 2);
@@ -306,10 +306,10 @@ fn test_tensor_shared_storage() {
 fn test_tensor_sum_f64_no_match() {
     let indices = vec![Index::new_dyn(3)];
     let t = make_tensor_f64(indices, vec![1.0, 2.0, 3.0]);
-    let sum_f64 = t.sum().real();
+    let sum_f64 = t.sum().unwrap().real();
     assert_eq!(sum_f64, 6.0);
 
-    let sum_any: AnyScalar = t.sum();
+    let sum_any: AnyScalar = t.sum().unwrap();
     assert!(!sum_any.is_complex());
     assert!((sum_any.real() - 6.0).abs() < 1e-10);
 }
@@ -322,7 +322,7 @@ fn test_tensor_sum_c64() {
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -1.0)],
     );
 
-    let sum_any: AnyScalar = t.sum();
+    let sum_any: AnyScalar = t.sum().unwrap();
     assert!(sum_any.is_complex());
     let z: Complex64 = sum_any.into();
     assert!((z.re - 4.0).abs() < 1e-10);
@@ -330,25 +330,25 @@ fn test_tensor_sum_c64() {
 }
 
 #[test]
-#[should_panic(expected = "Tensor indices must all be unique")]
 fn test_tensor_duplicate_indices_new() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone(), i.clone()]; // duplicate i
     let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
 
-    let _tensor: TensorDynLen = TensorDynLen::new(indices, storage);
+    let err = TensorDynLen::new(indices, storage).unwrap_err();
+    assert!(err.to_string().contains("unique"));
 }
 
 #[test]
-#[should_panic(expected = "Tensor indices must all be unique")]
 fn test_tensor_duplicate_indices_from_indices() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone(), i.clone()]; // duplicate i
     let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
 
-    let _tensor: TensorDynLen = TensorDynLen::from_indices(indices, storage);
+    let err = TensorDynLen::from_indices(indices, storage).unwrap_err();
+    assert!(err.to_string().contains("unique"));
 }
 
 // ============================================================================
@@ -366,7 +366,7 @@ fn test_replaceind_basic() {
     let tensor = make_tensor_f64(indices, data);
 
     // Replace index i with new_i
-    let replaced = tensor.replaceind(&i, &new_i);
+    let replaced = tensor.replaceind(&i, &new_i).unwrap();
 
     // Check that the first index was replaced
     assert_eq!(replaced.indices[0].id, new_i.id);
@@ -392,7 +392,7 @@ fn test_replaceind_no_match() {
     let tensor = make_tensor_f64(indices, data);
 
     // Replace index k (not in tensor) - should return unchanged tensor
-    let replaced = tensor.replaceind(&k, &new_k);
+    let replaced = tensor.replaceind(&k, &new_k).unwrap();
 
     // Check that indices are unchanged
     assert_eq!(replaced.indices[0].id, i.id);
@@ -413,10 +413,12 @@ fn test_replaceinds_basic() {
     let tensor = make_tensor_f64(indices, data);
 
     // Replace all indices
-    let replaced = tensor.replaceinds(
-        &[i.clone(), j.clone(), k.clone()],
-        &[new_i.clone(), new_j.clone(), new_k.clone()],
-    );
+    let replaced = tensor
+        .replaceinds(
+            &[i.clone(), j.clone(), k.clone()],
+            &[new_i.clone(), new_j.clone(), new_k.clone()],
+        )
+        .unwrap();
 
     // Check that all indices were replaced
     assert_eq!(replaced.indices[0].id, new_i.id);
@@ -439,7 +441,9 @@ fn test_replaceinds_partial() {
     let tensor = make_tensor_f64(indices, data);
 
     // Replace only i
-    let replaced = tensor.replaceinds(std::slice::from_ref(&i), std::slice::from_ref(&new_i));
+    let replaced = tensor
+        .replaceinds(std::slice::from_ref(&i), std::slice::from_ref(&new_i))
+        .unwrap();
 
     // Check that i was replaced
     assert_eq!(replaced.indices[0].id, new_i.id);
@@ -449,7 +453,6 @@ fn test_replaceinds_partial() {
 }
 
 #[test]
-#[should_panic(expected = "old_indices and new_indices must have the same length")]
 fn test_replaceinds_length_mismatch() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
@@ -460,12 +463,13 @@ fn test_replaceinds_length_mismatch() {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let tensor = make_tensor_f64(indices, data);
 
-    // Should panic - length mismatch
-    let _replaced = tensor.replaceinds(std::slice::from_ref(&i), &[new_i, new_j]);
+    let err = tensor
+        .replaceinds(std::slice::from_ref(&i), &[new_i, new_j])
+        .unwrap_err();
+    assert!(err.to_string().contains("same length"));
 }
 
 #[test]
-#[should_panic(expected = "Index space mismatch")]
 fn test_replaceind_dimension_mismatch() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
@@ -475,12 +479,11 @@ fn test_replaceind_dimension_mismatch() {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let tensor = make_tensor_f64(indices, data);
 
-    // Should panic - dimension mismatch
-    let _replaced = tensor.replaceind(&i, &wrong_size);
+    let err = tensor.replaceind(&i, &wrong_size).unwrap_err();
+    assert!(err.to_string().contains("Index space mismatch"));
 }
 
 #[test]
-#[should_panic(expected = "Index space mismatch")]
 fn test_replaceinds_dimension_mismatch() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
@@ -491,8 +494,10 @@ fn test_replaceinds_dimension_mismatch() {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let tensor = make_tensor_f64(indices, data);
 
-    // Should panic - dimension mismatch
-    let _replaced = tensor.replaceinds(&[i.clone(), j.clone()], &[new_i, wrong_size]);
+    let err = tensor
+        .replaceinds(&[i.clone(), j.clone()], &[new_i, wrong_size])
+        .unwrap_err();
+    assert!(err.to_string().contains("Index space mismatch"));
 }
 
 #[test]
@@ -512,7 +517,9 @@ fn test_replaceinds_does_not_reorder_data() {
     let new_j = Index::new_dyn(3);
 
     // Use replaceinds to change index IDs (but keep same order)
-    let replaced = tensor.replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()]);
+    let replaced = tensor
+        .replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()])
+        .unwrap();
 
     // Check indices were replaced
     assert_eq!(replaced.indices[0].id, new_i.id);
@@ -549,7 +556,9 @@ fn test_replaceinds_with_different_order_does_not_reorder_data() {
     // NOTE: replaceinds requires matching dimensions, so we can't directly swap i and j
     // This test demonstrates that replaceinds doesn't reorder data even when used correctly
     // For actual index reordering, use permuteinds instead
-    let replaced = tensor.replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()]);
+    let replaced = tensor
+        .replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()])
+        .unwrap();
 
     // Check indices were replaced (order unchanged, just IDs changed)
     assert_eq!(replaced.indices[0].id, new_i.id);
@@ -580,7 +589,7 @@ fn test_permuteinds_reorders_data() {
 
     // Use permuteinds to swap indices: [j, i] instead of [i, j]
     // This should reorder both indices AND data
-    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]);
+    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]).unwrap();
 
     // Check indices were permuted
     assert_eq!(permuted.indices[0].id, j.id);
@@ -621,13 +630,15 @@ fn test_replaceinds_vs_permuteinds_comparison() {
     // Note: replaceinds requires matching dimensions, so we can't swap i and j directly
     // This test demonstrates that replaceinds doesn't reorder data
     // In practice, you should use permuteinds when you need to change index order
-    let replaced = tensor.replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()]);
+    let replaced = tensor
+        .replaceinds(&[i.clone(), j.clone()], &[new_i.clone(), new_j.clone()])
+        .unwrap();
     assert_eq!(replaced.dims(), vec![2, 3]);
     let replaced_data = replaced.to_vec::<f64>().unwrap();
 
     // Method 2: permuteinds (CORRECT when order changes)
     // This changes both index order AND data order
-    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]);
+    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]).unwrap();
     assert_eq!(permuted.dims(), vec![3, 2]);
     let permuted_data = permuted.to_vec::<f64>().unwrap();
 
@@ -820,7 +831,7 @@ fn test_from_dense_generic_preserves_column_major_input_order() {
     )
     .unwrap();
 
-    let permuted = tensor.permute_indices(&[j, i]);
+    let permuted = tensor.permute_indices(&[j, i]).unwrap();
     assert_eq!(
         permuted.to_vec::<f64>().unwrap(),
         vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0]

--- a/crates/tensor4all-core/tests/tensor_comparison.rs
+++ b/crates/tensor4all-core/tests/tensor_comparison.rs
@@ -12,7 +12,7 @@ fn test_sub_identical_tensors_is_zero() {
     )
     .unwrap();
 
-    let diff = &a - &a;
+    let diff = a.sub(&a).unwrap();
     assert!(diff.norm() < 1e-14);
     assert!(diff.maxabs() < 1e-14);
 }
@@ -23,7 +23,7 @@ fn test_sub_different_tensors() {
     let a = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 5.0]).unwrap();
     let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
 
-    let diff = &a - &b;
+    let diff = a.sub(&b).unwrap();
     let data = diff.to_vec::<f64>().unwrap();
     assert!((data[0] - 2.0).abs() < 1e-14);
     assert!((data[1] - 3.0).abs() < 1e-14);
@@ -45,7 +45,7 @@ fn test_sub_permuted_indices() {
     )
     .unwrap();
 
-    let diff = &a - &b;
+    let diff = a.sub(&b).unwrap();
     assert!(diff.maxabs() < 1e-14);
 }
 
@@ -54,7 +54,7 @@ fn test_neg() {
     let i = Index::new_dyn(3);
     let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0]).unwrap();
 
-    let neg_a = -&a;
+    let neg_a = a.neg().unwrap();
     let data = neg_a.to_vec::<f64>().unwrap();
     assert!((data[0] - (-1.0)).abs() < 1e-14);
     assert!((data[1] - 2.0).abs() < 1e-14);
@@ -78,7 +78,7 @@ fn test_maxabs_scalar() {
 fn test_maxabs_diag_f64() {
     let i = Index::new_dyn(4);
     let j = Index::new_dyn(4);
-    let d = diag_tensor_dyn_len(vec![i, j], vec![1.0, -5.0, 3.0, -2.0]);
+    let d = diag_tensor_dyn_len(vec![i, j], vec![1.0, -5.0, 3.0, -2.0]).unwrap();
     assert!((d.maxabs() - 5.0).abs() < 1e-14);
 }
 
@@ -147,16 +147,16 @@ fn test_sub_operator_owned() {
     let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 3.0]).unwrap();
 
     // owned - owned
-    let diff = a.clone() - b.clone();
+    let diff = a.sub(&b).unwrap();
     let data = diff.to_vec::<f64>().unwrap();
     assert!((data[0] - 4.0).abs() < 1e-14);
     assert!((data[1] - 7.0).abs() < 1e-14);
 
     // owned - ref
-    let diff2 = a.clone() - &b;
+    let diff2 = a.sub(&b).unwrap();
     assert!(diff2.isapprox(&diff, 1e-14, 0.0));
 
     // ref - owned
-    let diff3 = &a - b.clone();
+    let diff3 = a.sub(&b).unwrap();
     assert!(diff3.isapprox(&diff, 1e-14, 0.0));
 }

--- a/crates/tensor4all-core/tests/tensor_contract_multi_pair_equivalence.rs
+++ b/crates/tensor4all-core/tests/tensor_contract_multi_pair_equivalence.rs
@@ -63,14 +63,14 @@ fn test_contract_multi_pair_matches_binary_contract() {
         &[3, 2],
     );
 
-    let binary = t1.contract(&t2);
+    let binary = t1.contract(&t2).unwrap();
     let multi =
         <TensorDynLen as TensorLike>::contract(&[&t1, &t2], AllowedPairs::All).expect("contract");
 
     assert!(
         multi.isapprox(&binary, 1e-12, 0.0),
         "multi-contract and binary contract differ: maxabs diff = {}",
-        (&multi - &binary).maxabs()
+        multi.sub(&binary).unwrap().maxabs()
     );
 }
 
@@ -98,14 +98,14 @@ fn test_contract_multi_three_matches_sequential_binary_contract() {
         &[3, 2],
     );
 
-    let sequential = t0.contract(&t1).contract(&t2);
+    let sequential = t0.contract(&t1).unwrap().contract(&t2).unwrap();
     let multi = <TensorDynLen as TensorLike>::contract(&[&t0, &t1, &t2], AllowedPairs::All)
         .expect("contract");
 
     assert!(
         multi.isapprox(&sequential, 1e-12, 0.0),
         "3-tensor multi-contract and sequential contract differ: maxabs diff = {}",
-        (&multi - &sequential).maxabs()
+        multi.sub(&sequential).unwrap().maxabs()
     );
 }
 
@@ -122,14 +122,14 @@ fn test_contract_multi_pair_matches_binary_contract_for_zero_masked_inputs() {
     );
     let t1 = make_tensor(vec![l01, s1], (1..=6).map(|x| x as f64).collect(), &[3, 2]);
 
-    let binary = t0.contract(&t1);
+    let binary = t0.contract(&t1).unwrap();
     let multi =
         <TensorDynLen as TensorLike>::contract(&[&t0, &t1], AllowedPairs::All).expect("contract");
 
     assert!(
         multi.isapprox(&binary, 1e-12, 0.0),
         "zero-masked multi-contract and binary contract differ: maxabs diff = {}",
-        (&multi - &binary).maxabs()
+        multi.sub(&binary).unwrap().maxabs()
     );
 }
 
@@ -164,7 +164,9 @@ fn test_zipup_zero_masked_root_multi_matches_sequential_binary_contract() {
 
     let leaf = <TensorDynLen as TensorLike>::contract(&[&a0, &b0], AllowedPairs::All)
         .expect("leaf contract");
-    let permuted_leaf = leaf.permute_indices(&[s0.clone(), s1.clone(), l01.clone(), l12.clone()]);
+    let permuted_leaf = leaf
+        .permute_indices(&[s0.clone(), s1.clone(), l01.clone(), l12.clone()])
+        .unwrap();
     let expected_permuted = TensorDynLen::from_dense(
         vec![s0.clone(), s1.clone(), l01.clone(), l12.clone()],
         permute_col_major(&leaf.to_vec::<f64>().unwrap(), &leaf.dims(), &[0, 2, 1, 3]),
@@ -173,21 +175,23 @@ fn test_zipup_zero_masked_root_multi_matches_sequential_binary_contract() {
     assert!(
         permuted_leaf.isapprox(&expected_permuted, 1e-12, 0.0),
         "native permute for leaf does not match tensor-level column-major expectation: maxabs diff = {}",
-        (&permuted_leaf - &expected_permuted).maxabs()
+        permuted_leaf.sub(&expected_permuted).unwrap().maxabs()
     );
 
     let (u, s, v) = svd::<f64>(&leaf, &[s0.clone(), s1.clone()]).expect("svd");
-    let vh = v.conj().permute(&[2, 0, 1]);
-    let svh = s.contract(&vh);
-    let svh = svh.replaceind(
-        &s.indices[1].clone(),
-        &v.indices[v.indices.len() - 1].clone(),
-    );
-    let svd_reconstructed = u.contract(&svh);
+    let vh = v.conj().permute(&[2, 0, 1]).unwrap();
+    let svh = s.contract(&vh).unwrap();
+    let svh = svh
+        .replaceind(
+            &s.indices[1].clone(),
+            &v.indices[v.indices.len() - 1].clone(),
+        )
+        .unwrap();
+    let svd_reconstructed = u.contract(&svh).unwrap();
     assert!(
         svd_reconstructed.isapprox(&leaf, 1e-10, 0.0),
         "svd leaf does not reconstruct: maxabs diff = {}",
-        (&svd_reconstructed - &leaf).maxabs()
+        svd_reconstructed.sub(&leaf).unwrap().maxabs()
     );
 
     let factorized = factorize(
@@ -197,14 +201,19 @@ fn test_zipup_zero_masked_root_multi_matches_sequential_binary_contract() {
     )
     .expect("factorize");
 
-    let reconstructed_leaf = factorized.left.contract(&factorized.right);
+    let reconstructed_leaf = factorized.left.contract(&factorized.right).unwrap();
     assert!(
         reconstructed_leaf.isapprox(&leaf, 1e-10, 0.0),
         "factorized leaf does not reconstruct: maxabs diff = {}",
-        (&reconstructed_leaf - &leaf).maxabs()
+        reconstructed_leaf.sub(&leaf).unwrap().maxabs()
     );
 
-    let sequential = factorized.right.contract(&a1).contract(&b1);
+    let sequential = factorized
+        .right
+        .contract(&a1)
+        .unwrap()
+        .contract(&b1)
+        .unwrap();
     let multi =
         <TensorDynLen as TensorLike>::contract(&[&factorized.right, &a1, &b1], AllowedPairs::All)
             .expect("root contract");
@@ -212,6 +221,6 @@ fn test_zipup_zero_masked_root_multi_matches_sequential_binary_contract() {
     assert!(
         multi.isapprox(&sequential, 1e-10, 0.0),
         "zipup root multi-contract and sequential binary contract differ: maxabs diff = {}",
-        (&multi - &sequential).maxabs()
+        multi.sub(&sequential).unwrap().maxabs()
     );
 }

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -49,7 +49,7 @@ fn test_contract_dyn_len_matrix_multiplication() {
     let tensor_b = dense_f64(vec![j.clone(), k.clone()], vec![1.0; 12]);
 
     // Contract along j: result should be C[i, k] with all 3.0 (since each element is sum of 3 ones)
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 4]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -74,7 +74,7 @@ fn test_mul_operator_contraction() {
     let tensor_b = dense_f64(vec![j.clone(), k.clone()], vec![1.0; 12]);
 
     // Contract along j using * operator: result should be C[i, k] with all 3.0
-    let result = &tensor_a * &tensor_b;
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 4]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -95,7 +95,7 @@ fn test_mul_operator_owned() {
     let tensor_b = dense_f64(vec![j.clone(), k.clone()], vec![1.0; 12]);
 
     // Use * operator with owned tensors
-    let result = tensor_a * tensor_b;
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 4]);
     assert_eq!(result.indices.len(), 2);
 }
@@ -111,7 +111,7 @@ fn test_contract_no_common_indices_gives_outer_product() {
     let tensor_b = TensorDynLen::zeros::<f64>(vec![k.clone()]).unwrap();
 
     // No common indices → outer product
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 3, 4]);
     assert_eq!(result.indices.len(), 3);
 }
@@ -124,7 +124,7 @@ fn test_contract_no_common_indices_preserves_left_then_right_index_order_and_val
     let tensor_a = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, -1.0]).unwrap();
     let tensor_b = TensorDynLen::from_dense(vec![j.clone()], vec![3.0, 4.0, -2.0]).unwrap();
 
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
 
     assert_eq!(result.indices, vec![i, j]);
     let expected = TensorDynLen::from_dense(
@@ -147,10 +147,10 @@ fn structured_tensor_contract_materializes_to_correct_dense_result() {
     assert!(diag.is_diag());
     let dense = TensorDynLen::from_dense(vec![j, k.clone()], vec![5.0, 7.0, 11.0, 13.0]).unwrap();
 
-    let result = diag.contract(&dense);
+    let result = diag.contract(&dense).unwrap();
 
     let expected = TensorDynLen::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
-    assert!((&result - &expected).maxabs() < 1e-12);
+    assert!(result.sub(&expected).unwrap().maxabs() < 1e-12);
 }
 
 #[test]
@@ -177,7 +177,7 @@ fn general_structured_contract_preserves_output_axis_classes() {
     )
     .unwrap();
 
-    let result = structured.contract(&dense);
+    let result = structured.contract(&dense).unwrap();
 
     assert_eq!(result.indices, vec![i, k, l]);
     assert_eq!(result.storage().storage_kind(), StorageKind::Structured);
@@ -208,7 +208,7 @@ fn test_contract_three_indices() {
     let tensor_b = dense_f64(vec![j.clone(), k.clone(), l.clone()], vec![1.0; 60]);
 
     // Contract along j and k: result should be C[i, l] with all 12.0 (3 * 4 = 12)
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 5]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -242,7 +242,7 @@ fn test_contract_mixed_f64_c64() {
     // Contract along j: result should be C[i, k] (Complex64)
     // Expected result: [[1+2i + 5+6i, 3+4i + 7+8i], [1+2i + 5+6i, 3+4i + 7+8i]]
     //                  = [[6+8i, 10+12i], [6+8i, 10+12i]]
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 2]);
     assert_eq!(result.indices.len(), 2);
     assert_eq!(result.indices[0].id, i.id);
@@ -289,7 +289,7 @@ fn test_contract_mixed_c64_f64() {
     // C[0,1] = (1+2i)*1 + (3+4i)*1 = 4+6i
     // C[1,0] = (5+6i)*1 + (7+8i)*1 = 12+14i
     // C[1,1] = (5+6i)*1 + (7+8i)*1 = 12+14i
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
     assert_eq!(result.dims(), vec![2, 2]);
 
     assert_eq!(
@@ -488,7 +488,7 @@ fn test_scalar_times_tensor() {
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
 
-    let result = scalar.contract(&tensor);
+    let result = scalar.contract(&tensor).unwrap();
     assert_eq!(result.dims(), vec![2, 3]);
     assert_eq!(result.to_vec::<f64>().unwrap(), data);
 }
@@ -501,7 +501,7 @@ fn test_tensor_times_scalar() {
     let data = vec![10.0, 20.0];
     let tensor = TensorDynLen::from_dense(vec![i.clone()], data.clone()).unwrap();
 
-    let result = tensor.contract(&scalar);
+    let result = tensor.contract(&scalar).unwrap();
     assert_eq!(result.dims(), vec![2]);
     assert_eq!(result.to_vec::<f64>().unwrap(), data);
 }
@@ -511,7 +511,7 @@ fn test_scalar_times_scalar() {
     let s1 = TensorDynLen::scalar(3.0).unwrap();
     let s2 = TensorDynLen::scalar(5.0).unwrap();
 
-    let result = s1.contract(&s2);
+    let result = s1.contract(&s2).unwrap();
     assert_eq!(result.dims().len(), 0);
     let val = result.to_vec::<f64>().unwrap();
     assert_eq!(val.len(), 1);
@@ -526,7 +526,7 @@ fn test_mul_operator_scalar_times_tensor() {
     let data = vec![1.0, 2.0, 3.0];
     let tensor = TensorDynLen::from_dense(vec![i.clone()], data.clone()).unwrap();
 
-    let result = &scalar * &tensor;
+    let result = scalar.contract(&tensor).unwrap();
     assert_eq!(result.dims(), vec![3]);
     assert_eq!(result.to_vec::<f64>().unwrap(), data);
 }
@@ -540,8 +540,8 @@ fn test_foldl_sequential_contraction() {
     let b = TensorDynLen::from_dense(vec![j.clone(), i.clone()], vec![2.0; 6]).unwrap();
 
     let mut acc = TensorDynLen::scalar_one().unwrap();
-    acc = &acc * &a; // acc = a (outer product with scalar)
-    acc = &acc * &b; // acc = contract(a, b) over i and j
+    acc = acc.contract(&a).unwrap(); // acc = a (outer product with scalar)
+    acc = acc.contract(&b).unwrap(); // acc = contract(a, b) over i and j
 
     // a[i,j] * b[j,i] = sum_j(a[i,j]*b[j,i]) summed over both → scalar
     assert_eq!(acc.dims().len(), 0);

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -10,7 +10,7 @@ fn test_diag_tensor_creation() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data.clone());
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![3, 3]);
     assert!(tensor.is_diag());
     assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
@@ -25,13 +25,13 @@ fn test_diag_tensor_creation() {
 }
 
 #[test]
-#[should_panic(expected = "DiagTensor requires all indices to have the same dimension")]
 fn test_diag_tensor_validation_different_dims() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0];
 
-    let _tensor = diag_tensor_dyn_len(vec![i, j], diag_data);
+    let err = diag_tensor_dyn_len(vec![i, j], diag_data).unwrap_err();
+    assert!(err.to_string().contains("same dimension"));
 }
 
 #[test]
@@ -40,8 +40,8 @@ fn test_diag_tensor_sum() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data);
-    let sum: AnyScalar = tensor.sum();
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data).unwrap();
+    let sum: AnyScalar = tensor.sum().unwrap();
     assert!(!sum.is_complex());
     assert!((sum.real() - 6.0).abs() < 1e-10);
 }
@@ -50,13 +50,13 @@ fn test_diag_tensor_sum() {
 fn test_diag_tensor_scale_preserves_diagonal_values() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, -2.0, 4.0]);
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, -2.0, 4.0]).unwrap();
 
     let scaled = tensor.scale(AnyScalar::new_real(-0.5)).unwrap();
 
     assert!(scaled.is_diag());
     assert_eq!(scaled.storage().storage_kind(), StorageKind::Diagonal);
-    let expected = diag_tensor_dyn_len(vec![i, j], vec![-0.5, 1.0, -2.0]);
+    let expected = diag_tensor_dyn_len(vec![i, j], vec![-0.5, 1.0, -2.0]).unwrap();
     assert!(scaled.isapprox(&expected, 1e-12, 0.0));
 }
 
@@ -67,12 +67,13 @@ fn test_diag_tensor_permute() {
     let k = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone());
+    let tensor =
+        diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone()).unwrap();
 
     // Permute: data should not change for DiagTensor
-    let permuted = tensor.permute(&[2, 0, 1]);
+    let permuted = tensor.permute(&[2, 0, 1]).unwrap();
     assert_eq!(permuted.dims(), vec![3, 3, 3]);
-    let expected = diag_tensor_dyn_len(vec![k, i, j], diag_data);
+    let expected = diag_tensor_dyn_len(vec![k, i, j], diag_data).unwrap();
     assert!(permuted.isapprox(&expected, 1e-12, 0.0));
 }
 
@@ -80,7 +81,7 @@ fn test_diag_tensor_permute() {
 fn diag_tensor_select_index_returns_dense_slice_from_payload() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 5.0, 7.0]);
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 5.0, 7.0]).unwrap();
 
     let selected = tensor.select_indices(&[j], &[1]).unwrap();
 
@@ -94,7 +95,8 @@ fn diag_tensor_select_multiple_indices_requires_matching_coordinates() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(3);
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], vec![2.0, 5.0, 7.0]);
+    let tensor =
+        diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], vec![2.0, 5.0, 7.0]).unwrap();
 
     let matching = tensor
         .select_indices(&[i.clone(), k.clone()], &[2, 2])
@@ -115,15 +117,15 @@ fn test_diag_tensor_contract_diag_diag_all_contracted() {
     let diag_a = vec![1.0, 2.0];
     let diag_b = vec![3.0, 4.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a);
-    let tensor_b = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_b);
+    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a).unwrap();
+    let tensor_b = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_b).unwrap();
 
     // Contract all indices: result should be scalar (inner product)
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
 
     // Result should be scalar: 1*3 + 2*4 = 11
     assert_eq!(result.dims().len(), 0);
-    assert!((result.only().real() - 11.0).abs() < 1e-12);
+    assert!((result.only().unwrap().real() - 11.0).abs() < 1e-12);
 }
 
 #[test]
@@ -135,18 +137,18 @@ fn test_diag_tensor_contract_diag_diag_partial() {
     let diag_a = vec![1.0, 2.0, 3.0];
     let diag_b = vec![4.0, 5.0, 6.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a);
-    let tensor_b = diag_tensor_dyn_len(vec![j.clone(), k.clone()], diag_b);
+    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a).unwrap();
+    let tensor_b = diag_tensor_dyn_len(vec![j.clone(), k.clone()], diag_b).unwrap();
 
     // Contract along j: result should be DiagTensor[i, k]
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
 
     assert_eq!(result.dims(), vec![3, 3]);
     assert!(result.is_diag());
     assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
 
     // Result diagonal should be element-wise product: [1*4, 2*5, 3*6] = [4, 10, 18]
-    let expected = diag_tensor_dyn_len(vec![i, k], vec![4.0, 10.0, 18.0]);
+    let expected = diag_tensor_dyn_len(vec![i, k], vec![4.0, 10.0, 18.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0));
 }
 
@@ -155,14 +157,17 @@ fn tracked_diag_partial_contraction_preserves_diag_result_and_grad() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(3);
-    let a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 3.0, 5.0]).enable_grad();
-    let b = diag_tensor_dyn_len(vec![j, k.clone()], vec![7.0, 11.0, 13.0]);
+    let a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 3.0, 5.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+    let b = diag_tensor_dyn_len(vec![j, k.clone()], vec![7.0, 11.0, 13.0]).unwrap();
 
-    let c = a.contract(&b);
+    let c = a.contract(&b).unwrap();
     assert_eq!(c.storage().storage_kind(), StorageKind::Diagonal);
 
-    let ones = diag_tensor_dyn_len(vec![i, k], vec![1.0, 1.0, 1.0]);
-    let loss = c.contract(&ones);
+    let ones = diag_tensor_dyn_len(vec![i, k], vec![1.0, 1.0, 1.0]).unwrap();
+    let loss = c.contract(&ones).unwrap();
     loss.backward().unwrap();
 
     let grad = a.grad().unwrap().unwrap();
@@ -180,8 +185,8 @@ fn test_diag_tensor_tensordot_diag_diag_partial_preserves_diagonal_storage() {
     let k = Index::new_dyn(3);
     let l = Index::new_dyn(3);
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0]);
-    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], vec![4.0, 5.0, 6.0]);
+    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], vec![4.0, 5.0, 6.0]).unwrap();
 
     let result = tensor_a
         .tensordot(&tensor_b, &[(j, k)])
@@ -191,7 +196,7 @@ fn test_diag_tensor_tensordot_diag_diag_partial_preserves_diagonal_storage() {
     assert!(result.is_diag());
     assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
 
-    let expected = diag_tensor_dyn_len(vec![i, l], vec![4.0, 10.0, 18.0]);
+    let expected = diag_tensor_dyn_len(vec![i, l], vec![4.0, 10.0, 18.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0));
 }
 
@@ -203,13 +208,13 @@ fn test_diag_tensor_contract_diag_dense() {
     let k = Index::new_dyn(2);
     let diag_a = vec![1.0, 2.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a);
+    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a).unwrap();
 
     // Create DenseTensor B[j, k] with all ones
     let tensor_b = TensorDynLen::from_dense(vec![j.clone(), k.clone()], vec![1.0; 4]).unwrap();
 
     // Contract along j: result should be DenseTensor[i, k]
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
 
     assert_eq!(result.dims(), vec![2, 2]);
     let expected = TensorDynLen::from_dense(vec![i, k], vec![1.0, 2.0, 1.0, 2.0]).unwrap();
@@ -222,7 +227,7 @@ fn test_diag_tensor_convert_to_dense() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data);
+    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data).unwrap();
     let dense_tensor =
         TensorDynLen::from_dense(vec![i.clone(), j.clone()], tensor.to_vec::<f64>().unwrap())
             .unwrap();
@@ -309,7 +314,7 @@ fn diag_permute_scale_conj_and_replaceind_preserve_payload_metadata() {
     )
     .unwrap();
 
-    let permuted = tensor.permute(&[2, 0, 1]);
+    let permuted = tensor.permute(&[2, 0, 1]).unwrap();
     assert!(permuted.is_diag());
     assert_eq!(permuted.storage().axis_classes(), &[0, 0, 0]);
     assert_eq!(
@@ -324,7 +329,7 @@ fn diag_permute_scale_conj_and_replaceind_preserve_payload_metadata() {
         vec![2.0, -4.0, 8.0]
     );
 
-    let replaced = scaled.replaceind(&k, &Index::new_dyn(3));
+    let replaced = scaled.replaceind(&k, &Index::new_dyn(3)).unwrap();
     assert!(replaced.is_diag());
     assert_eq!(
         replaced.storage().payload_f64_col_major_vec().unwrap(),
@@ -347,13 +352,14 @@ fn test_diag_tensor_rank3() {
     let k = Index::new_dyn(2);
     let diag_data = vec![1.0, 2.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone());
+    let tensor =
+        diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![2, 2, 2]);
     assert!(tensor.is_diag());
     assert_eq!(tensor.storage().storage_kind(), StorageKind::Diagonal);
 
     // Sum should work
-    let sum: AnyScalar = tensor.sum();
+    let sum: AnyScalar = tensor.sum().unwrap();
     assert!(!sum.is_complex());
     assert!((sum.real() - 3.0).abs() < 1e-10);
 }
@@ -440,7 +446,7 @@ fn test_diag_tensor_complex() {
     );
 
     // Sum should work
-    let sum: AnyScalar = tensor.sum();
+    let sum: AnyScalar = tensor.sum().unwrap();
     assert!(sum.is_complex());
     let z: Complex64 = sum.into();
     assert!((z.re - 3.0).abs() < 1e-10);
@@ -483,17 +489,17 @@ fn test_diag_tensor_contract_rank3() {
     let diag_a = vec![1.0, 2.0];
     let diag_b = vec![3.0, 4.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_a);
-    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], diag_b);
+    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_a).unwrap();
+    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], diag_b).unwrap();
 
     // Contract along k: result should be DiagTensor[i, j, l]
-    let result = tensor_a.contract(&tensor_b);
+    let result = tensor_a.contract(&tensor_b).unwrap();
 
     assert_eq!(result.dims(), vec![2, 2, 2]);
     assert!(result.is_diag());
     assert_eq!(result.storage().storage_kind(), StorageKind::Diagonal);
 
     // Result diagonal should be element-wise product: [1*3, 2*4] = [3, 8]
-    let expected = diag_tensor_dyn_len(vec![i, j, l], vec![3.0, 8.0]);
+    let expected = diag_tensor_dyn_len(vec![i, j, l], vec![3.0, 8.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0));
 }

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -58,7 +58,8 @@ fn backward_accumulates_until_clear_grad() {
     let i = Index::new_dyn(3);
     let x = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0])
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
     let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
 
     let loss = contract_multi(&[&x, &ones], AllowedPairs::All).unwrap();
@@ -92,7 +93,8 @@ fn general_structured_grad_preserves_input_axis_classes() {
     .unwrap();
     let x = TensorDynLen::from_storage(vec![i.clone(), j.clone(), k.clone()], storage)
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
     let ones = TensorDynLen::from_dense(vec![i, j, k], vec![1.0; 12]).unwrap();
 
     let loss = contract_multi(&[&x, &ones], AllowedPairs::All).unwrap();
@@ -113,25 +115,26 @@ fn tracks_grad_and_detach_report_leaf_state() {
     assert!(!scalar.tracks_grad());
 
     let tracked = scalar.enable_grad();
+    let tracked = tracked.unwrap();
     assert!(tracked.tracks_grad());
 
-    let detached = tracked.detach();
+    let detached = tracked.detach().unwrap();
     assert!(!detached.tracks_grad());
     assert!(tracked.tracks_grad());
 }
 
 #[test]
 fn clone_shares_tracked_leaf_gradient_slot() {
-    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad();
+    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad().unwrap();
     let alias = x.clone();
 
-    let loss = &x * &alias;
+    let loss = x.contract(&alias).unwrap();
     loss.backward().unwrap();
 
     let grad_x = x.grad().unwrap().unwrap();
     let grad_alias = alias.grad().unwrap().unwrap();
-    assert!((grad_x.only().real() - 4.0).abs() < 1e-12);
-    assert!((grad_alias.only().real() - 4.0).abs() < 1e-12);
+    assert!((grad_x.only().unwrap().real() - 4.0).abs() < 1e-12);
+    assert!((grad_alias.only().unwrap().real() - 4.0).abs() < 1e-12);
 }
 
 #[test]
@@ -146,7 +149,8 @@ fn retained_multi_contraction_preserves_grad_path() {
         (1..=12).map(|value| value as f64).collect(),
     )
     .unwrap()
-    .enable_grad();
+    .enable_grad()
+    .unwrap();
     let y =
         TensorDynLen::from_dense(vec![batch.clone(), k.clone(), j.clone()], vec![1.0; 12]).unwrap();
     let retain_indices = [batch.clone()];
@@ -184,7 +188,8 @@ fn structured_retained_multi_contraction_errors_before_detaching_grad() {
     .unwrap();
     let x = TensorDynLen::from_storage(vec![batch.clone(), i.clone(), k.clone()], storage)
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
     let y =
         TensorDynLen::from_dense(vec![batch.clone(), k.clone(), j.clone()], vec![1.0; 8]).unwrap();
     let retain_indices = [batch.clone()];

--- a/crates/tensor4all-core/tests/tensor_permute.rs
+++ b/crates/tensor4all-core/tests/tensor_permute.rs
@@ -55,27 +55,26 @@ fn test_compute_permutation_from_indices() {
 
     // Test identity permutation
     let new_order1 = vec![i.clone(), j.clone(), k.clone()];
-    let perm1 = compute_permutation_from_indices(&original, &new_order1);
+    let perm1 = compute_permutation_from_indices(&original, &new_order1).unwrap();
     assert_eq!(perm1, vec![0, 1, 2]);
 
     // Test swap first two
     let new_order2 = vec![j.clone(), i.clone(), k.clone()];
-    let perm2 = compute_permutation_from_indices(&original, &new_order2);
+    let perm2 = compute_permutation_from_indices(&original, &new_order2).unwrap();
     assert_eq!(perm2, vec![1, 0, 2]);
 
     // Test reverse
     let new_order3 = vec![k.clone(), j.clone(), i.clone()];
-    let perm3 = compute_permutation_from_indices(&original, &new_order3);
+    let perm3 = compute_permutation_from_indices(&original, &new_order3).unwrap();
     assert_eq!(perm3, vec![2, 1, 0]);
 
     // Test rotation
     let new_order4 = vec![j.clone(), k.clone(), i.clone()];
-    let perm4 = compute_permutation_from_indices(&original, &new_order4);
+    let perm4 = compute_permutation_from_indices(&original, &new_order4).unwrap();
     assert_eq!(perm4, vec![1, 2, 0]);
 }
 
 #[test]
-#[should_panic(expected = "new_indices must be a permutation of original_indices")]
 fn test_compute_permutation_from_indices_invalid() {
     // Test with invalid index (ID doesn't match)
     let i = Index::new_dyn(2);
@@ -85,11 +84,11 @@ fn test_compute_permutation_from_indices_invalid() {
     let original = vec![i.clone(), j.clone()];
     let new_order = vec![i.clone(), invalid];
 
-    compute_permutation_from_indices(&original, &new_order);
+    let err = compute_permutation_from_indices(&original, &new_order).unwrap_err();
+    assert!(err.to_string().contains("permutation"));
 }
 
 #[test]
-#[should_panic(expected = "duplicate index in new_indices")]
 fn test_compute_permutation_from_indices_duplicate() {
     // Test with duplicate indices
     let i = Index::new_dyn(2);
@@ -98,7 +97,8 @@ fn test_compute_permutation_from_indices_duplicate() {
     let original = vec![i.clone(), j.clone()];
     let new_order = vec![i.clone(), i.clone()]; // Duplicate
 
-    compute_permutation_from_indices(&original, &new_order);
+    let err = compute_permutation_from_indices(&original, &new_order).unwrap_err();
+    assert!(err.to_string().contains("duplicate"));
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn test_permute_dyn_f64_2d() {
     let data = vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0];
     let tensor = dense_f64(indices, data.clone());
 
-    let permuted = tensor.permute(&[1, 0]);
+    let permuted = tensor.permute(&[1, 0]).unwrap();
 
     assert_eq!(permuted.dims(), vec![3, 2]);
     assert_eq!(permuted.indices[0].id, j.id);
@@ -137,7 +137,7 @@ fn test_permute_dyn_c64_2d() {
     ];
     let tensor = dense_c64(indices, data.clone());
 
-    let permuted = tensor.permute(&[1, 0]);
+    let permuted = tensor.permute(&[1, 0]).unwrap();
 
     assert_eq!(permuted.dims(), vec![3, 2]);
     assert_eq!(permuted.indices[0].id, j.id);
@@ -159,7 +159,7 @@ fn test_permute_dyn_f64_3d() {
     let data: Vec<f64> = (1..=24).map(|i| i as f64).collect();
     let tensor = dense_f64(indices, data.clone());
 
-    let permuted = tensor.permute(&[2, 0, 1]);
+    let permuted = tensor.permute(&[2, 0, 1]).unwrap();
 
     assert_eq!(permuted.dims(), vec![4, 2, 3]);
     assert_eq!(permuted.indices[0].id, k.id);
@@ -179,7 +179,7 @@ fn test_permute_identity() {
     let data = vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0];
     let tensor = dense_f64(indices, data.clone());
 
-    let permuted = tensor.permute(&[0, 1]);
+    let permuted = tensor.permute(&[0, 1]).unwrap();
 
     assert_eq!(permuted.dims(), vec![2, 3]);
     assert_eq!(permuted.indices[0].id, i.id);
@@ -196,7 +196,7 @@ fn test_permute_indices_dyn_f64_2d() {
     let data = vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0];
     let tensor = dense_f64(indices, data.clone());
 
-    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]);
+    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]).unwrap();
 
     assert_eq!(permuted.dims(), vec![3, 2]);
     assert_eq!(permuted.indices[0].id, j.id);
@@ -223,7 +223,7 @@ fn test_permute_indices_c64() {
     ];
     let tensor = dense_c64(indices, data.clone());
 
-    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]);
+    let permuted = tensor.permute_indices(&[j.clone(), i.clone()]).unwrap();
 
     assert_eq!(permuted.dims(), vec![3, 2]);
     assert_eq!(permuted.indices[0].id, j.id);

--- a/crates/tensor4all-core/tests/tensor_shape_packing.rs
+++ b/crates/tensor4all-core/tests/tensor_shape_packing.rs
@@ -41,7 +41,8 @@ fn index_select_backward_scatter_adds_repeated_positions() {
     let target = DynIndex::new_dyn(3);
     let x = TensorDynLen::from_dense(vec![source.clone()], vec![1.0_f64, 2.0, 3.0])
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
     let weights =
         TensorDynLen::from_dense(vec![target.clone()], vec![10.0_f64, 20.0, 30.0]).unwrap();
 
@@ -57,8 +58,8 @@ fn index_select_backward_scatter_adds_repeated_positions() {
 #[test]
 fn stack_along_new_index_backward_splits_cotangent_to_inputs() {
     let batch = DynIndex::new_dyn(2);
-    let x0 = TensorDynLen::scalar(2.0).unwrap().enable_grad();
-    let x1 = TensorDynLen::scalar(3.0).unwrap().enable_grad();
+    let x0 = TensorDynLen::scalar(2.0).unwrap().enable_grad().unwrap();
+    let x1 = TensorDynLen::scalar(3.0).unwrap().enable_grad().unwrap();
     let weights = TensorDynLen::from_dense(vec![batch.clone()], vec![10.0_f64, 20.0]).unwrap();
 
     let stacked = TensorDynLen::stack_along_new_index(&[&x0, &x1], batch, -1).unwrap();
@@ -67,8 +68,8 @@ fn stack_along_new_index_backward_splits_cotangent_to_inputs() {
 
     let grad0 = x0.grad().unwrap().unwrap();
     let grad1 = x1.grad().unwrap().unwrap();
-    assert!((grad0.only().real() - 10.0).abs() < 1.0e-12);
-    assert!((grad1.only().real() - 20.0).abs() < 1.0e-12);
+    assert!((grad0.only().unwrap().real() - 10.0).abs() < 1.0e-12);
+    assert!((grad1.only().unwrap().real() - 20.0).abs() < 1.0e-12);
 }
 
 #[test]
@@ -78,7 +79,8 @@ fn stack_along_new_index_rejects_tracked_compact_storage() {
     let batch = DynIndex::new_dyn(1);
     let diag = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0])
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
 
     let err = TensorDynLen::stack_along_new_index(&[&diag], batch, -1).unwrap_err();
 
@@ -92,7 +94,8 @@ fn index_select_rejects_tracked_compact_storage() {
     let target = DynIndex::new_dyn(1);
     let diag = TensorDynLen::from_diag(vec![source.clone(), j], vec![1.0_f64, 2.0])
         .unwrap()
-        .enable_grad();
+        .enable_grad()
+        .unwrap();
 
     let err = diag.index_select(&source, target, &[0]).unwrap_err();
 

--- a/crates/tensor4all-hdf5/src/itensor.rs
+++ b/crates/tensor4all-hdf5/src/itensor.rs
@@ -91,7 +91,8 @@ pub(crate) fn read_itensor(group: &Group) -> Result<TensorDynLen> {
             .read_1d()
             .context("Failed to read f64 data")?
             .to_vec();
-        Ok(TensorDynLen::from_dense(indices, col_major_data).unwrap())
+        TensorDynLen::from_dense(indices, col_major_data)
+            .context("Failed to build f64 TensorDynLen from HDF5 data")
     } else if storage_type_str.contains("Dense{ComplexF64}") {
         let data_ds = storage_group.dataset("data")?;
         // Read as native HDF5 compound type (Complex64)
@@ -100,7 +101,8 @@ pub(crate) fn read_itensor(group: &Group) -> Result<TensorDynLen> {
             .read_1d()
             .context("Failed to read complex data")?
             .to_vec();
-        Ok(TensorDynLen::from_dense(indices, col_major_data).unwrap())
+        TensorDynLen::from_dense(indices, col_major_data)
+            .context("Failed to build complex TensorDynLen from HDF5 data")
     } else {
         bail!(
             "Unsupported storage type: {}. Only Dense{{Float64}} and Dense{{ComplexF64}} are supported.",

--- a/crates/tensor4all-interpolativeqtt/src/interpolation.rs
+++ b/crates/tensor4all-interpolativeqtt/src/interpolation.rs
@@ -1153,7 +1153,8 @@ fn invert_stage1(tt: &TensorTrain<f64>, basis: &LagrangePolynomials) -> Result<M
             decode.ncols()
         )));
     }
-    Ok(mat_mul(&current, &decode))
+    mat_mul(&current, &decode)
+        .map_err(|err| invalid_argument(format!("decode multiply failed: {err}")))
 }
 
 fn build_restriction(basis: &LagrangePolynomials) -> Result<(Matrix<f64>, Matrix<f64>)> {

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -58,7 +58,7 @@ let norm = tt.norm();
 assert!(norm.is_finite());
 
 // Inner product: <tt|tt> = norm^2
-let inner = tt.inner(&tt);
+let inner = tt.inner(&tt)?;
 assert!((inner.real() - norm * norm).abs() < 1e-10);
 # Ok(())
 # }
@@ -79,7 +79,7 @@ let tensor = TensorDynLen::from_dense(
 )?;
 let tt = TensorTrain::new(vec![tensor])?;
 
-let inner = tt.inner(&tt);
+let inner = tt.inner(&tt)?;
 assert!((inner.real() - 6.0).abs() < 1e-12);
 assert!(inner.imag().abs() < 1e-12);
 # Ok(())

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
@@ -10,8 +10,9 @@
 use rand::rng;
 use std::time::Instant;
 
+use anyhow::Result;
 use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{CanonicalForm, ContractOptions, Result, TensorTrain};
+use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
 ///
@@ -50,11 +51,11 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 
-    TensorTrain::new(tensors)
+    Ok(TensorTrain::new(tensors)?)
 }
 
 fn main() -> Result<()> {

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
@@ -3,8 +3,9 @@
 use rand::rng;
 use std::time::Instant;
 
+use anyhow::Result;
 use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{CanonicalForm, ContractOptions, Result, TensorTrain};
+use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
 fn create_random_mpo(
@@ -29,11 +30,11 @@ fn create_random_mpo(
             indices.push(link_indices[i].clone());
         }
 
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 
-    TensorTrain::new(tensors)
+    Ok(TensorTrain::new(tensors)?)
 }
 
 fn main() -> Result<()> {

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
@@ -10,8 +10,9 @@
 use rand::rng;
 use std::time::Instant;
 
+use anyhow::Result;
 use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{CanonicalForm, ContractOptions, Result, TensorTrain};
+use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
 ///
@@ -50,11 +51,11 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 
-    TensorTrain::new(tensors)
+    Ok(TensorTrain::new(tensors)?)
 }
 
 fn main() -> Result<()> {

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_one_shot.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_one_shot.rs
@@ -1,8 +1,9 @@
 use rand::rng;
 use std::time::Instant;
 
+use anyhow::Result;
 use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{CanonicalForm, ContractOptions, Result, TensorTrain};
+use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 fn create_random_mpo(
     length: usize,
@@ -23,13 +24,13 @@ fn create_random_mpo(
         if i + 1 < length {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 
     let _ = phys_dim;
     let _ = bond_dim;
-    TensorTrain::new(tensors)
+    Ok(TensorTrain::new(tensors)?)
 }
 
 fn run_zipup(length: usize, phys_dim: usize, bond_dim: usize, max_rank: usize) -> Result<()> {

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
@@ -3,8 +3,9 @@
 use rand::rng;
 use std::time::Instant;
 
+use anyhow::Result;
 use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{ContractOptions, Result, TensorTrain};
+use tensor4all_itensorlike::{ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
 fn create_random_mpo(
@@ -29,11 +30,11 @@ fn create_random_mpo(
             indices.push(link_indices[i].clone());
         }
 
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 
-    TensorTrain::new(tensors)
+    Ok(TensorTrain::new(tensors)?)
 }
 
 fn main() -> Result<()> {

--- a/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
+++ b/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
@@ -116,8 +116,8 @@ fn main() -> anyhow::Result<()> {
         );
 
         // Inner products with identity
-        let inner_zipup = result_zipup.inner(&result_zipup);
-        let inner_fit = result_fit.inner(&result_fit);
+        let inner_zipup = result_zipup.inner(&result_zipup)?;
+        let inner_fit = result_fit.inner(&result_fit)?;
         println!("\n[zipup] <result, result> = {:?}", inner_zipup);
         println!("[fit]   <result, result> = {:?}", inner_fit);
 
@@ -208,7 +208,7 @@ fn trace_arnoldi_n3() -> anyhow::Result<()> {
     println!("||v1|| = {:.6}", v1.norm());
 
     // Check: <v1, v1> should be 1
-    let v1v1 = v1.inner(&v1);
+    let v1v1 = v1.inner(&v1)?;
     println!("<v1, v1> = {:?}", v1v1);
 
     // w = A(v1)
@@ -216,7 +216,7 @@ fn trace_arnoldi_n3() -> anyhow::Result<()> {
     println!("||w|| = ||A(v1)|| = {:.6}", w.norm());
 
     // h11 = <w, v1>
-    let h11 = w.inner(&v1);
+    let h11 = w.inner(&v1)?;
     println!("h11 = <A(v1), v1> = {:?}", h11);
     let h11_val = h11.real();
 
@@ -230,7 +230,7 @@ fn trace_arnoldi_n3() -> anyhow::Result<()> {
     println!("||v2|| = {:.6}", v2.norm());
 
     // Check orthogonality
-    let v1v2 = v1.inner(&v2);
+    let v1v2 = v1.inner(&v2)?;
     println!("<v1, v2> = {:?}", v1v2);
 
     // w2 = A(v2)
@@ -238,8 +238,8 @@ fn trace_arnoldi_n3() -> anyhow::Result<()> {
     println!("||w2|| = ||A(v2)|| = {:.6}", w2.norm());
 
     // h12 = <w2, v1>, h22 = <w2, v2>
-    let h12 = w2.inner(&v1);
-    let h22 = w2.inner(&v2);
+    let h12 = w2.inner(&v1)?;
+    let h22 = w2.inner(&v2)?;
     println!("h12 = <A(v2), v1> = {:?}", h12);
     println!("h22 = <A(v2), v2> = {:?}", h22);
     let h12_val = h12.real();
@@ -328,8 +328,8 @@ fn trace_arnoldi_n3() -> anyhow::Result<()> {
     println!("||x_sol - x_true|| = {:.6e}", sol_error.norm());
 
     // Check inner product with x_true
-    let inner_sol_true = x_sol.inner(&x_true);
-    let inner_true_true = x_true.inner(&x_true);
+    let inner_sol_true = x_sol.inner(&x_true)?;
+    let inner_true_true = x_true.inner(&x_true)?;
     println!("<x_sol, x_true> = {:?}", inner_sol_true);
     println!("<x_true, x_true> = {:?}", inner_true_true);
 
@@ -423,7 +423,7 @@ fn debug_gmres_internal() -> anyhow::Result<()> {
     println!("||A*v0|| = {:.6}", w.norm());
 
     // h00 = <v0, w>
-    let h00 = v0.inner(&w);
+    let h00 = v0.inner(&w)?;
     println!("h00 = <v0, A*v0> = {:?}", h00);
     let h00_val = h00.real();
 
@@ -435,15 +435,15 @@ fn debug_gmres_internal() -> anyhow::Result<()> {
     // v1 = w_orth / h10
     let v1 = w_orth.scale(AnyScalar::new_real(1.0 / h10))?;
     println!("||v1|| = {:.6}", v1.norm());
-    println!("<v0, v1> = {:?}", v0.inner(&v1));
+    println!("<v0, v1> = {:?}", v0.inner(&v1)?);
 
     // Arnoldi iteration 2
     println!("\n=== Arnoldi iteration 2 ===");
     let w2 = apply_a(&v1)?;
     println!("||A*v1|| = {:.6}", w2.norm());
 
-    let h01 = v0.inner(&w2);
-    let h11 = v1.inner(&w2);
+    let h01 = v0.inner(&w2)?;
+    let h11 = v1.inner(&w2)?;
     println!("h01 = <v0, A*v1> = {:?}", h01);
     println!("h11 = <v1, A*v1> = {:?}", h11);
     let h01_val = h01.real();
@@ -653,8 +653,8 @@ fn debug_solution_update() -> anyhow::Result<()> {
     // Check index structure of x0
     println!("\n=== Index structure ===");
     for site in 0..n {
-        let t_zipup = x0_zipup.tensor(site);
-        let t_fit = x0_fit.tensor(site);
+        let t_zipup = x0_zipup.tensor(site)?;
+        let t_fit = x0_fit.tensor(site)?;
         println!(
             "Site {} x0_zipup indices: {:?}",
             site,
@@ -694,7 +694,7 @@ fn debug_solution_update() -> anyhow::Result<()> {
     println!(
         "v0_zipup Site 0 indices: {:?}",
         v0_zipup
-            .tensor(0)
+            .tensor(0)?
             .indices()
             .iter()
             .map(|i| i.id())
@@ -703,7 +703,7 @@ fn debug_solution_update() -> anyhow::Result<()> {
     println!(
         "x0_zipup Site 0 indices: {:?}",
         x0_zipup
-            .tensor(0)
+            .tensor(0)?
             .indices()
             .iter()
             .map(|i| i.id())
@@ -712,14 +712,14 @@ fn debug_solution_update() -> anyhow::Result<()> {
 
     // Check if they share physical indices (required for axpby)
     let v0_phys_ids: std::collections::HashSet<_> = v0_zipup
-        .tensor(0)
+        .tensor(0)?
         .indices()
         .iter()
         .filter(|i| i.dim() == 2)
         .map(|i| i.id())
         .collect();
     let x0_phys_ids: std::collections::HashSet<_> = x0_zipup
-        .tensor(0)
+        .tensor(0)?
         .indices()
         .iter()
         .filter(|i| i.dim() == 2)
@@ -750,7 +750,7 @@ fn debug_solution_update() -> anyhow::Result<()> {
     println!(
         "x_new Site 0 indices: {:?}",
         x_new_zipup
-            .tensor(0)
+            .tensor(0)?
             .indices()
             .iter()
             .map(|i| (i.id(), i.dim()))
@@ -773,14 +773,14 @@ fn debug_solution_update() -> anyhow::Result<()> {
     println!("v0_fit bond dims: {:?}", v0_fit.bond_dims());
 
     let v0_fit_phys_ids: std::collections::HashSet<_> = v0_fit
-        .tensor(0)
+        .tensor(0)?
         .indices()
         .iter()
         .filter(|i| i.dim() == 2)
         .map(|i| i.id())
         .collect();
     let x0_fit_phys_ids: std::collections::HashSet<_> = x0_fit
-        .tensor(0)
+        .tensor(0)?
         .indices()
         .iter()
         .filter(|i| i.dim() == 2)
@@ -810,8 +810,8 @@ fn debug_solution_update() -> anyhow::Result<()> {
 
     // Check actual values
     println!("\nSite 0 data comparison:");
-    println!("x_new_zipup: {:?}", x_new_zipup.tensor(0).to_vec::<f64>()?);
-    println!("x_new_fit:   {:?}", x_new_fit.tensor(0).to_vec::<f64>()?);
+    println!("x_new_zipup: {:?}", x_new_zipup.tensor(0)?.to_vec::<f64>()?);
+    println!("x_new_fit:   {:?}", x_new_fit.tensor(0)?.to_vec::<f64>()?);
 
     Ok(())
 }
@@ -867,7 +867,7 @@ fn test_truncation_effect() -> anyhow::Result<()> {
     println!("w norm: {:.6}", w.norm());
 
     // h10 = <v0, w>
-    let h10 = v0.inner(&w);
+    let h10 = v0.inner(&w)?;
     println!("h10 = <v0, w>: {:?}", h10);
     let h10_val = h10.real();
 
@@ -875,13 +875,13 @@ fn test_truncation_effect() -> anyhow::Result<()> {
     let mut w_orth = w.axpby(AnyScalar::new_real(1.0), &v0, AnyScalar::new_real(-h10_val))?;
     println!("\n=== w_orth before truncation ===");
     println!("w_orth norm: {:.6}", w_orth.norm());
-    println!("<v0, w_orth>: {:?}", v0.inner(&w_orth));
+    println!("<v0, w_orth>: {:?}", v0.inner(&w_orth)?);
 
     // Truncate w_orth
     w_orth.truncate(&truncate_opts)?;
     println!("\n=== w_orth after truncation ===");
     println!("w_orth norm: {:.6}", w_orth.norm());
-    println!("<v0, w_orth>: {:?}", v0.inner(&w_orth)); // Should still be ~0 if truncation preserves orthogonality
+    println!("<v0, w_orth>: {:?}", v0.inner(&w_orth)?); // Should still be ~0 if truncation preserves orthogonality
 
     let h20 = w_orth.norm();
     let mut v1 = w_orth.scale(AnyScalar::new_real(1.0 / h20))?;
@@ -891,7 +891,7 @@ fn test_truncation_effect() -> anyhow::Result<()> {
 
     println!("\n=== v1 after truncation and renormalization ===");
     println!("v1 norm: {:.6}", v1.norm());
-    println!("<v0, v1>: {:?}", v0.inner(&v1)); // This should be ~0, but may not be!
+    println!("<v0, v1>: {:?}", v0.inner(&v1)?); // This should be ~0, but may not be!
 
     // Now check if Arnoldi relation holds
     // A*v0 should = h10*v0 + h20*v1
@@ -908,8 +908,8 @@ fn test_truncation_effect() -> anyhow::Result<()> {
 
     // Second iteration
     let w2 = apply_with_zipup(&pauli_x, &v1, &indices)?;
-    let h11 = v0.inner(&w2);
-    let h21 = v1.inner(&w2);
+    let h11 = v0.inner(&w2)?;
+    let h21 = v1.inner(&w2)?;
     println!("\n=== Second iteration ===");
     println!("h11 = <v0, A*v1>: {:?}", h11);
     println!("h21 = <v1, A*v1>: {:?}", h21);
@@ -925,8 +925,8 @@ fn test_truncation_effect() -> anyhow::Result<()> {
     println!("w2_orth norm after trunc:  {:.6}", w2_orth.norm());
 
     // Check orthogonality after truncation
-    println!("<v0, w2_orth>: {:?}", v0.inner(&w2_orth));
-    println!("<v1, w2_orth>: {:?}", v1.inner(&w2_orth));
+    println!("<v0, w2_orth>: {:?}", v0.inner(&w2_orth)?);
+    println!("<v1, w2_orth>: {:?}", v1.inner(&w2_orth)?);
 
     Ok(())
 }
@@ -949,8 +949,8 @@ fn detailed_debug_n3() -> anyhow::Result<()> {
     // Print tensor data at each site
     for site in 0..n {
         println!("\n--- Site {} tensor data ---", site);
-        let t_zipup = result_zipup.tensor(site);
-        let t_fit = result_fit.tensor(site);
+        let t_zipup = result_zipup.tensor(site)?;
+        let t_fit = result_fit.tensor(site)?;
 
         println!(
             "zipup shape: {:?}",
@@ -1010,10 +1010,10 @@ fn detailed_debug_n3() -> anyhow::Result<()> {
 
     println!("\n=== Step 2: Check inner product computation ===");
     // Test inner product between zipup and fit results
-    let inner_zz = result_zipup.inner(&result_zipup);
-    let inner_ff = result_fit.inner(&result_fit);
-    let inner_zf = result_zipup.inner(&result_fit);
-    let inner_fz = result_fit.inner(&result_zipup);
+    let inner_zz = result_zipup.inner(&result_zipup)?;
+    let inner_ff = result_fit.inner(&result_fit)?;
+    let inner_zf = result_zipup.inner(&result_fit)?;
+    let inner_fz = result_fit.inner(&result_zipup)?;
 
     println!("<zipup, zipup> = {:?}", inner_zz);
     println!("<fit, fit>     = {:?}", inner_ff);
@@ -1079,15 +1079,15 @@ fn detailed_debug_n3() -> anyhow::Result<()> {
     println!("w_fit = A(v1_fit) norm:     {:.6}", w_fit.norm());
 
     // h11 = <w, v1> - this is where the issue might be
-    let h11_zipup = w_zipup.inner(&v1_zipup);
-    let h11_fit = w_fit.inner(&v1_fit);
+    let h11_zipup = w_zipup.inner(&v1_zipup)?;
+    let h11_fit = w_fit.inner(&v1_fit)?;
 
     println!("\nh11_zipup = <w, v1>: {:?}", h11_zipup);
     println!("h11_fit = <w, v1>:   {:?}", h11_fit);
 
     // Check cross inner products
-    let cross1 = w_zipup.inner(&v1_fit);
-    let cross2 = w_fit.inner(&v1_zipup);
+    let cross1 = w_zipup.inner(&v1_fit)?;
+    let cross2 = w_fit.inner(&v1_zipup)?;
     println!("<w_zipup, v1_fit>: {:?}", cross1);
     println!("<w_fit, v1_zipup>: {:?}", cross2);
 
@@ -1120,8 +1120,8 @@ fn detailed_debug_n3() -> anyhow::Result<()> {
     println!("v2_fit norm:   {:.6}", v2_fit.norm());
 
     // Check orthogonality <v1, v2>
-    let v1v2_zipup = v1_zipup.inner(&v2_zipup);
-    let v1v2_fit = v1_fit.inner(&v2_fit);
+    let v1v2_zipup = v1_zipup.inner(&v2_zipup)?;
+    let v1v2_fit = v1_fit.inner(&v2_fit)?;
     println!("\n<v1, v2> zipup: {:?}", v1v2_zipup);
     println!("<v1, v2> fit:   {:?}", v1v2_fit);
 
@@ -1135,10 +1135,10 @@ fn detailed_debug_n3() -> anyhow::Result<()> {
     println!("w2_fit = A(v2) norm:   {:.6}", w2_fit.norm());
 
     // h12 = <w2, v1>, h22 = <w2, v2>
-    let h12_zipup = w2_zipup.inner(&v1_zipup);
-    let h12_fit = w2_fit.inner(&v1_fit);
-    let h22_zipup = w2_zipup.inner(&v2_zipup);
-    let h22_fit = w2_fit.inner(&v2_fit);
+    let h12_zipup = w2_zipup.inner(&v1_zipup)?;
+    let h12_fit = w2_fit.inner(&v1_fit)?;
+    let h22_zipup = w2_zipup.inner(&v2_zipup)?;
+    let h22_fit = w2_fit.inner(&v2_fit)?;
 
     println!("\nh12_zipup = <w2, v1>: {:?}", h12_zipup);
     println!("h12_fit = <w2, v1>:   {:?}", h12_fit);
@@ -1271,9 +1271,9 @@ fn test_gmres_with_both(
     );
 
     // Check inner products with x_true
-    let inner_sol_true_zipup = result_zipup.solution.inner(x_true);
-    let inner_sol_true_fit = result_fit.solution.inner(x_true);
-    let expected_inner = x_true.inner(x_true);
+    let inner_sol_true_zipup = result_zipup.solution.inner(x_true)?;
+    let inner_sol_true_fit = result_fit.solution.inner(x_true)?;
+    let expected_inner = x_true.inner(x_true)?;
     println!(
         "[zipup] <x_sol, x_true>: {:?} (expected: {:?})",
         inner_sol_true_zipup, expected_inner
@@ -1335,8 +1335,8 @@ fn test_gmres_like_operations(
     println!("||r0|| fit: {:.6e}", r0_fit.norm());
 
     // Compute inner products
-    let inner_r0_r0_zipup = r0_zipup.inner(&r0_zipup);
-    let inner_r0_r0_fit = r0_fit.inner(&r0_fit);
+    let inner_r0_r0_zipup = r0_zipup.inner(&r0_zipup)?;
+    let inner_r0_r0_fit = r0_fit.inner(&r0_fit)?;
     println!("<r0, r0> zipup: {:?}", inner_r0_r0_zipup);
     println!("<r0, r0> fit: {:?}", inner_r0_r0_fit);
 
@@ -1348,8 +1348,8 @@ fn test_gmres_like_operations(
     println!("||A(r0)|| fit: {:.6e}", ar0_fit.norm());
 
     // Check <A(r0), r0>
-    let inner_ar0_r0_zipup = ar0_zipup.inner(&r0_zipup);
-    let inner_ar0_r0_fit = ar0_fit.inner(&r0_fit);
+    let inner_ar0_r0_zipup = ar0_zipup.inner(&r0_zipup)?;
+    let inner_ar0_r0_fit = ar0_fit.inner(&r0_fit)?;
     println!("<A(r0), r0> zipup: {:?}", inner_ar0_r0_zipup);
     println!("<A(r0), r0> fit: {:?}", inner_ar0_r0_fit);
 
@@ -1357,9 +1357,9 @@ fn test_gmres_like_operations(
     println!("\n--- Index structure check ---");
     println!(
         "b_zipup indices at site 0: {:?}",
-        b_zipup.tensor(0).indices()
+        b_zipup.tensor(0)?.indices()
     );
-    println!("b_fit indices at site 0: {:?}", b_fit.tensor(0).indices());
+    println!("b_fit indices at site 0: {:?}", b_fit.tensor(0)?.indices());
 
     Ok(())
 }
@@ -1522,8 +1522,8 @@ fn debug_contract_result(
 
     for site in 0..3 {
         println!("\n--- Raw result Site {} ---", site);
-        let t_zipup = raw_zipup.tensor(site);
-        let t_fit = raw_fit.tensor(site);
+        let t_zipup = raw_zipup.tensor(site)?;
+        let t_fit = raw_fit.tensor(site)?;
 
         println!(
             "zipup indices: {:?}",
@@ -1547,7 +1547,7 @@ fn debug_contract_result(
     println!("\n--- Bond index comparison ---");
     println!("zipup link indices:");
     for site in 0..2 {
-        let t = raw_zipup.tensor(site);
+        let t = raw_zipup.tensor(site)?;
         let link_idx = t.indices().iter().find(|i| {
             i.dim() == 1 && site == 0 || t.indices().last().map(|x| x.id()) == Some(i.id())
         });
@@ -1558,7 +1558,7 @@ fn debug_contract_result(
 
     println!("fit link indices:");
     for site in 0..2 {
-        let t = raw_fit.tensor(site);
+        let t = raw_fit.tensor(site)?;
         for idx in t.indices() {
             if idx.dim() == 1 {
                 println!("  Site {} bond dim=1: {:?}", site, idx.id());
@@ -1571,8 +1571,8 @@ fn debug_contract_result(
     println!("TensorTrain expects: [left_bond, physical..., right_bond]");
     println!("");
     for site in 0..3 {
-        let t_zipup = raw_zipup.tensor(site);
-        let t_fit = raw_fit.tensor(site);
+        let t_zipup = raw_zipup.tensor(site)?;
+        let t_fit = raw_fit.tensor(site)?;
 
         let zipup_dims: Vec<_> = t_zipup.indices().iter().map(|i| i.dim()).collect();
         let fit_dims: Vec<_> = t_fit.indices().iter().map(|i| i.dim()).collect();
@@ -1607,7 +1607,7 @@ fn debug_contract_result(
 
     // Check if Site 1 has duplicate bond IDs
     println!("\n=== Site 1 bond ID analysis ===");
-    let t1_fit = raw_fit.tensor(1);
+    let t1_fit = raw_fit.tensor(1)?;
     let bond_ids: Vec<_> = t1_fit
         .indices()
         .iter()
@@ -1642,7 +1642,7 @@ fn debug_contract_result(
     println!(
         "  zipup Site 1: {:?}",
         result_zipup
-            .tensor(1)
+            .tensor(1)?
             .indices()
             .iter()
             .map(|i| i.dim())
@@ -1651,7 +1651,7 @@ fn debug_contract_result(
     println!(
         "  fit Site 1:   {:?}",
         result_fit
-            .tensor(1)
+            .tensor(1)?
             .indices()
             .iter()
             .map(|i| i.dim())
@@ -1662,7 +1662,7 @@ fn debug_contract_result(
     println!(
         "  zipup Site 1: {:?}",
         result_zipup_trunc
-            .tensor(1)
+            .tensor(1)?
             .indices()
             .iter()
             .map(|i| i.dim())
@@ -1671,7 +1671,7 @@ fn debug_contract_result(
     println!(
         "  fit Site 1:   {:?}",
         result_fit_trunc
-            .tensor(1)
+            .tensor(1)?
             .indices()
             .iter()
             .map(|i| i.dim())

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
@@ -539,6 +539,15 @@ fn apply_cross_block_operator_full(
     Ok(result)
 }
 
+fn block_entry(
+    x: &BlockTensor<TensorTrain>,
+    row: usize,
+    col: usize,
+) -> anyhow::Result<&TensorTrain> {
+    x.get(row, col)
+        .ok_or_else(|| anyhow::anyhow!("missing block ({row}, {col})"))
+}
+
 // ============================================================================
 // Truncation helper
 // ============================================================================
@@ -587,7 +596,7 @@ fn test_block_diagonal_identity() -> anyhow::Result<()> {
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
         let mut result_blocks = Vec::with_capacity(indices.num_blocks);
         for (block_idx, op) in identity_ops.iter().enumerate() {
-            let block = x.get(block_idx / block_cols, block_idx % block_cols);
+            let block = block_entry(x, block_idx / block_cols, block_idx % block_cols)?;
             let result = apply_operator_for_block(op, block, &indices, block_idx)?;
             result_blocks.push(result);
         }
@@ -678,7 +687,7 @@ fn test_block_diagonal_diagonal_operator() -> anyhow::Result<()> {
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
         let mut result_blocks = Vec::with_capacity(indices.num_blocks);
         for (block_idx, op) in diagonal_ops.iter().enumerate() {
-            let block = x.get(block_idx / block_cols, block_idx % block_cols);
+            let block = block_entry(x, block_idx / block_cols, block_idx % block_cols)?;
             let result = apply_operator_for_block(op, block, &indices, block_idx)?;
             result_blocks.push(result);
         }
@@ -794,12 +803,12 @@ fn test_block_upper_triangular() -> anyhow::Result<()> {
         for row in 0..block_rows {
             for (col, cross_op) in cross_block_ops.iter().enumerate() {
                 let flat = indices.flat_idx(row, col);
-                let x_rc = x.get(row, col);
+                let x_rc = block_entry(x, row, col)?;
 
                 if row == 0 {
                     // y_{0,j} = I * x_{0,j} + B * x_{1,j}
                     let i_x = apply_operator_for_block(&identity_ops[flat], x_rc, &indices, flat)?;
-                    let x_1j = x.get(1, col);
+                    let x_1j = block_entry(x, 1, col)?;
                     let b_x = apply_cross_block_operator(cross_op, x_1j, &indices, flat)?;
                     let y = i_x.axpby(AnyScalar::new_real(1.0), &b_x, AnyScalar::new_real(1.0))?;
                     result_blocks.push(y);
@@ -925,7 +934,7 @@ fn test_restart_gmres_block_mpo() -> anyhow::Result<()> {
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
         let mut result_blocks = Vec::with_capacity(indices.num_blocks);
         for (block_idx, op) in diagonal_ops.iter().enumerate() {
-            let block = x.get(block_idx / block_cols, block_idx % block_cols);
+            let block = block_entry(x, block_idx / block_cols, block_idx % block_cols)?;
             let result = apply_operator_for_block(op, block, &indices, block_idx)?;
             result_blocks.push(result);
         }
@@ -1062,7 +1071,7 @@ fn test_block_offdiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
 
         for (col, op) in ops_1to0.iter().enumerate() {
             // y_{0,j} = i*σ_x * x_{1,j}
-            let x_1j = x.get(1, col);
+            let x_1j = block_entry(x, 1, col)?;
             let src = indices.flat_idx(1, col);
             let dst = indices.flat_idx(0, col);
             let y = apply_cross_block_operator_full(op, x_1j, &indices, src, dst)?;
@@ -1070,7 +1079,7 @@ fn test_block_offdiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
         }
         for (col, op) in ops_0to1.iter().enumerate() {
             // y_{1,j} = i*σ_x * x_{0,j}
-            let x_0j = x.get(0, col);
+            let x_0j = block_entry(x, 0, col)?;
             let src = indices.flat_idx(0, col);
             let dst = indices.flat_idx(1, col);
             let y = apply_cross_block_operator_full(op, x_0j, &indices, src, dst)?;
@@ -1212,7 +1221,7 @@ fn test_3x3_block_antidiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
 
         // Row 0: y_{0,j} = i*σ_x * x_{2,j}
         for (col, op) in ops_2to0.iter().enumerate() {
-            let x_2j = x.get(2, col);
+            let x_2j = block_entry(x, 2, col)?;
             let src = indices.flat_idx(2, col);
             let dst = indices.flat_idx(0, col);
             let y = apply_cross_block_operator_full(op, x_2j, &indices, src, dst)?;
@@ -1220,7 +1229,7 @@ fn test_3x3_block_antidiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
         }
         // Row 1: y_{1,j} = i*σ_x * x_{1,j}
         for (col, op) in ops_1to1.iter().enumerate() {
-            let x_1j = x.get(1, col);
+            let x_1j = block_entry(x, 1, col)?;
             let src = indices.flat_idx(1, col);
             let dst = indices.flat_idx(1, col);
             let y = apply_cross_block_operator_full(op, x_1j, &indices, src, dst)?;
@@ -1228,7 +1237,7 @@ fn test_3x3_block_antidiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
         }
         // Row 2: y_{2,j} = i*σ_x * x_{0,j}
         for (col, op) in ops_0to2.iter().enumerate() {
-            let x_0j = x.get(0, col);
+            let x_0j = block_entry(x, 0, col)?;
             let src = indices.flat_idx(0, col);
             let dst = indices.flat_idx(2, col);
             let y = apply_cross_block_operator_full(op, x_0j, &indices, src, dst)?;
@@ -1349,14 +1358,14 @@ fn scaling_2x2_offdiagonal_mpo(n_sites: usize) -> anyhow::Result<()> {
         let mut result_blocks = Vec::with_capacity(indices.num_blocks);
 
         for (col, op) in ops_1to0.iter().enumerate() {
-            let x_1j = x.get(1, col);
+            let x_1j = block_entry(x, 1, col)?;
             let src = indices.flat_idx(1, col);
             let dst = indices.flat_idx(0, col);
             let y = apply_cross_block_operator_full(op, x_1j, &indices, src, dst)?;
             result_blocks.push(y);
         }
         for (col, op) in ops_0to1.iter().enumerate() {
-            let x_0j = x.get(0, col);
+            let x_0j = block_entry(x, 0, col)?;
             let src = indices.flat_idx(0, col);
             let dst = indices.flat_idx(1, col);
             let y = apply_cross_block_operator_full(op, x_0j, &indices, src, dst)?;
@@ -1482,21 +1491,21 @@ fn scaling_3x3_antidiagonal_mpo(n_sites: usize) -> anyhow::Result<()> {
         let mut result_blocks = Vec::with_capacity(indices.num_blocks);
 
         for (col, op) in ops_2to0.iter().enumerate() {
-            let x_2j = x.get(2, col);
+            let x_2j = block_entry(x, 2, col)?;
             let src = indices.flat_idx(2, col);
             let dst = indices.flat_idx(0, col);
             let y = apply_cross_block_operator_full(op, x_2j, &indices, src, dst)?;
             result_blocks.push(y);
         }
         for (col, op) in ops_1to1.iter().enumerate() {
-            let x_1j = x.get(1, col);
+            let x_1j = block_entry(x, 1, col)?;
             let src = indices.flat_idx(1, col);
             let dst = indices.flat_idx(1, col);
             let y = apply_cross_block_operator_full(op, x_1j, &indices, src, dst)?;
             result_blocks.push(y);
         }
         for (col, op) in ops_0to2.iter().enumerate() {
-            let x_0j = x.get(0, col);
+            let x_0j = block_entry(x, 0, col)?;
             let src = indices.flat_idx(0, col);
             let dst = indices.flat_idx(2, col);
             let y = apply_cross_block_operator_full(op, x_0j, &indices, src, dst)?;

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
@@ -463,6 +463,15 @@ fn apply_cross_block_mpo(
     Ok(result)
 }
 
+fn block_entry(
+    x: &BlockTensor<TensorTrain>,
+    row: usize,
+    col: usize,
+) -> anyhow::Result<&TensorTrain> {
+    x.get(row, col)
+        .ok_or_else(|| anyhow::anyhow!("missing block ({row}, {col})"))
+}
+
 // ============================================================================
 // Truncation helper for BlockTensor<TensorTrain>
 // ============================================================================
@@ -510,7 +519,7 @@ fn test_block_diagonal_identity() -> anyhow::Result<()> {
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
         let mut result_blocks = Vec::with_capacity(num_blocks);
         for (block_idx, mpo) in identity_mpos.iter().enumerate() {
-            let block = x.get(block_idx, 0);
+            let block = block_entry(x, block_idx, 0)?;
             let result = apply_mpo_for_block(mpo, block, &indices, block_idx)?;
             result_blocks.push(result);
         }
@@ -603,7 +612,7 @@ fn test_block_diagonal_diagonal_mpo() -> anyhow::Result<()> {
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
         let mut result_blocks = Vec::with_capacity(num_blocks);
         for (block_idx, mpo) in diagonal_mpos.iter().enumerate() {
-            let block = x.get(block_idx, 0);
+            let block = block_entry(x, block_idx, 0)?;
             let result = apply_mpo_for_block(mpo, block, &indices, block_idx)?;
             result_blocks.push(result);
         }
@@ -708,8 +717,8 @@ fn test_block_upper_triangular() -> anyhow::Result<()> {
     // Define upper triangular operator: A = [[I, B], [0, I]]
     // Ax = [I*x1 + B*x2, I*x2]^T
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
-        let x1 = x.get(0, 0);
-        let x2 = x.get(1, 0);
+        let x1 = block_entry(x, 0, 0)?;
+        let x2 = block_entry(x, 1, 0)?;
 
         // y2 = I * x2
         let y2 = apply_mpo_for_block(&identity_mpo_1, x2, &indices, 1)?;
@@ -833,7 +842,7 @@ fn test_restart_gmres_block_mps() -> anyhow::Result<()> {
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
         let mut result_blocks = Vec::with_capacity(num_blocks);
         for (block_idx, mpo) in diagonal_mpos.iter().enumerate() {
-            let block = x.get(block_idx, 0);
+            let block = block_entry(x, block_idx, 0)?;
             let result = apply_mpo_for_block(mpo, block, &indices, block_idx)?;
             result_blocks.push(result);
         }
@@ -943,14 +952,14 @@ fn test_block_offdiagonal_complex_pauli_x() -> anyhow::Result<()> {
     // A * x_true = [i*σ_x * 2i*ones, i*σ_x * i*ones]^T = [-2*ones, -ones]^T
     let x1_true = create_complex_ones_mps_for_block(&indices, 0, Complex64::new(0.0, 1.0))?;
     let x2_true = create_complex_ones_mps_for_block(&indices, 1, Complex64::new(0.0, 2.0))?;
-    let x_true = BlockTensor::new(vec![x1_true, x2_true], (num_blocks, 1));
+    let x_true = BlockTensor::new(vec![x1_true, x2_true], (num_blocks, 1))?;
     println!("x_true created, norm: {:.6}", x_true.norm());
 
     // Define off-diagonal block operator: A = [[0, i*σ_x], [i*σ_x, 0]]
     // y1 = i*σ_x * x2, y2 = i*σ_x * x1
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
-        let x1 = x.get(0, 0);
-        let x2 = x.get(1, 0);
+        let x1 = block_entry(x, 0, 0)?;
+        let x2 = block_entry(x, 1, 0)?;
 
         // y1 = i*σ_x * x2 (cross-block: src=1 -> dst=0)
         let y1 = apply_cross_block_mpo(&mpo_1to0, x2, &indices, 0)?;
@@ -971,7 +980,7 @@ fn test_block_offdiagonal_complex_pauli_x() -> anyhow::Result<()> {
             create_complex_ones_mps_for_block(&indices, block_idx, Complex64::new(0.0, 0.0))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1));
+    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1))?;
     println!("x0 (complex zero) created, norm: {:.6}", x0.norm());
 
     // GMRES options
@@ -1061,15 +1070,15 @@ fn test_3x3_block_antidiagonal_complex_pauli_x() -> anyhow::Result<()> {
     let x0_true = create_complex_ones_mps_for_block(&indices, 0, Complex64::new(0.0, 1.0))?;
     let x1_true = create_complex_ones_mps_for_block(&indices, 1, Complex64::new(0.0, 2.0))?;
     let x2_true = create_complex_ones_mps_for_block(&indices, 2, Complex64::new(0.0, 3.0))?;
-    let x_true = BlockTensor::new(vec![x0_true, x1_true, x2_true], (num_blocks, 1));
+    let x_true = BlockTensor::new(vec![x0_true, x1_true, x2_true], (num_blocks, 1))?;
     println!("x_true created, norm: {:.6}", x_true.norm());
 
     // Define anti-diagonal block operator:
     // y0 = i*σ_x * x2, y1 = i*σ_x * x1, y2 = i*σ_x * x0
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
-        let x0 = x.get(0, 0);
-        let x1 = x.get(1, 0);
-        let x2 = x.get(2, 0);
+        let x0 = block_entry(x, 0, 0)?;
+        let x1 = block_entry(x, 1, 0)?;
+        let x2 = block_entry(x, 2, 0)?;
 
         let y0 = apply_cross_block_mpo(&mpo_2to0, x2, &indices, 0)?;
         let y1 = apply_cross_block_mpo(&mpo_1to1, x1, &indices, 1)?;
@@ -1089,7 +1098,7 @@ fn test_3x3_block_antidiagonal_complex_pauli_x() -> anyhow::Result<()> {
             create_complex_ones_mps_for_block(&indices, block_idx, Complex64::new(0.0, 0.0))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1));
+    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1))?;
     println!("x0 (complex zero) created, norm: {:.6}", x0.norm());
 
     // GMRES options
@@ -1172,12 +1181,12 @@ fn scaling_offdiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()> {
     // x_true = [i*ones, 2i*ones]^T
     let x1_true = create_complex_ones_mps_for_block(&indices, 0, Complex64::new(0.0, 1.0))?;
     let x2_true = create_complex_ones_mps_for_block(&indices, 1, Complex64::new(0.0, 2.0))?;
-    let x_true = BlockTensor::new(vec![x1_true, x2_true], (num_blocks, 1));
+    let x_true = BlockTensor::new(vec![x1_true, x2_true], (num_blocks, 1))?;
 
     // A = [[0, i*σ_x], [i*σ_x, 0]]
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
-        let x1 = x.get(0, 0);
-        let x2 = x.get(1, 0);
+        let x1 = block_entry(x, 0, 0)?;
+        let x2 = block_entry(x, 1, 0)?;
         let y1 = apply_cross_block_mpo(&mpo_1to0, x2, &indices, 0)?;
         let y2 = apply_cross_block_mpo(&mpo_0to1, x1, &indices, 1)?;
         BlockTensor::try_new(vec![y1, y2], (num_blocks, 1))
@@ -1192,7 +1201,7 @@ fn scaling_offdiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()> {
             create_complex_ones_mps_for_block(&indices, block_idx, Complex64::new(0.0, 0.0))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1));
+    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1))?;
 
     let options = GmresOptions {
         max_iter: 30,
@@ -1271,13 +1280,13 @@ fn scaling_3x3_antidiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()
     let x0_true = create_complex_ones_mps_for_block(&indices, 0, Complex64::new(0.0, 1.0))?;
     let x1_true = create_complex_ones_mps_for_block(&indices, 1, Complex64::new(0.0, 2.0))?;
     let x2_true = create_complex_ones_mps_for_block(&indices, 2, Complex64::new(0.0, 3.0))?;
-    let x_true = BlockTensor::new(vec![x0_true, x1_true, x2_true], (num_blocks, 1));
+    let x_true = BlockTensor::new(vec![x0_true, x1_true, x2_true], (num_blocks, 1))?;
 
     // A = [[0, 0, i*σ_x], [0, i*σ_x, 0], [i*σ_x, 0, 0]]
     let apply_a = |x: &BlockTensor<TensorTrain>| -> anyhow::Result<BlockTensor<TensorTrain>> {
-        let x0 = x.get(0, 0);
-        let x1 = x.get(1, 0);
-        let x2 = x.get(2, 0);
+        let x0 = block_entry(x, 0, 0)?;
+        let x1 = block_entry(x, 1, 0)?;
+        let x2 = block_entry(x, 2, 0)?;
         let y0 = apply_cross_block_mpo(&mpo_2to0, x2, &indices, 0)?;
         let y1 = apply_cross_block_mpo(&mpo_1to1, x1, &indices, 1)?;
         let y2 = apply_cross_block_mpo(&mpo_0to2, x0, &indices, 2)?;
@@ -1293,7 +1302,7 @@ fn scaling_3x3_antidiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()
             create_complex_ones_mps_for_block(&indices, block_idx, Complex64::new(0.0, 0.0))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1));
+    let x0 = BlockTensor::new(x0_blocks, (num_blocks, 1))?;
 
     let options = GmresOptions {
         max_iter: 30,

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -20,12 +20,16 @@ fn idx(id: u64, size: usize) -> DynIndex {
 /// Converts both TTs to dense, contracts the dense tensors, then compares
 /// with the TT contraction result using `isapprox`.
 fn assert_matches_naive(tt1: &TensorTrain, tt2: &TensorTrain, result: &TensorTrain) {
-    let naive_result = tt1.to_dense().unwrap().contract(&tt2.to_dense().unwrap());
+    let naive_result = tt1
+        .to_dense()
+        .unwrap()
+        .contract(&tt2.to_dense().unwrap())
+        .unwrap();
     let result_dense = result.to_dense().unwrap();
     assert!(
         result_dense.isapprox(&naive_result, 1e-10, 0.0),
         "TT contraction result does not match naive: maxabs diff = {}",
-        (&result_dense - &naive_result).maxabs()
+        result_dense.distance(&naive_result).unwrap()
     );
 }
 
@@ -369,7 +373,11 @@ fn test_contract_zipup_with_truncation() {
     }
 
     // Compare with naive (exact) result — should be approximate, not exact
-    let naive_result = tt1.to_dense().unwrap().contract(&tt2.to_dense().unwrap());
+    let naive_result = tt1
+        .to_dense()
+        .unwrap()
+        .contract(&tt2.to_dense().unwrap())
+        .unwrap();
     let naive_data = naive_result.to_vec::<f64>().unwrap();
     let result_data = result.to_dense().unwrap().to_vec::<f64>().unwrap();
 

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -162,7 +162,13 @@ fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<Si
         if let (Some(op_indices), Some(init_indices)) = (op_site, init_site) {
             if op_indices.len() == 2 && init_indices.len() == 1 {
                 // MPO-like site: check if we need mappings
-                let init_idx = init_indices.iter().next().unwrap();
+                let init_idx =
+                    init_indices
+                        .iter()
+                        .next()
+                        .ok_or_else(|| TensorTrainError::OperationError {
+                            message: format!("Site {site}: init site space is empty"),
+                        })?;
                 let has_shared = op_indices.iter().any(|idx| idx.same_id(init_idx));
                 if has_shared {
                     // The shared index exists but may differ by plev → need mapping
@@ -206,13 +212,32 @@ fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<Si
 
         if let (Some(op_indices), Some(init_indices)) = (op_site, init_site) {
             if op_indices.len() == 2 && init_indices.len() == 1 {
-                let init_idx = init_indices.iter().next().unwrap();
+                let init_idx =
+                    init_indices
+                        .iter()
+                        .next()
+                        .ok_or_else(|| TensorTrainError::OperationError {
+                            message: format!("Site {site}: init site space is empty"),
+                        })?;
 
-                let op_input = op_indices.iter().find(|idx| idx.same_id(init_idx)).unwrap();
+                let op_input = op_indices
+                    .iter()
+                    .find(|idx| idx.same_id(init_idx))
+                    .ok_or_else(|| TensorTrainError::OperationError {
+                        message: format!(
+                            "Site {site}: operator has no input index sharing an ID with init index {:?}",
+                            init_idx.id()
+                        ),
+                    })?;
                 let op_output = op_indices
                     .iter()
                     .find(|idx| !idx.same_id(init_idx))
-                    .unwrap();
+                    .ok_or_else(|| TensorTrainError::OperationError {
+                        message: format!(
+                            "Site {site}: operator has no output index distinct from init index {:?}",
+                            init_idx.id()
+                        ),
+                    })?;
 
                 input_mapping.insert(
                     site,

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -345,7 +345,7 @@ impl TensorTrain {
         let region = self.treetn.canonical_region();
         if region.len() == 1 {
             // Node name IS the site index since V = usize
-            Some(*region.iter().next().unwrap())
+            region.iter().next().copied()
         } else {
             None
         }
@@ -370,11 +370,13 @@ impl TensorTrain {
     /// Panics if `site >= len()`.
     #[inline]
     pub fn tensor(&self, site: usize) -> &TensorDynLen {
-        let node_idx = self.treetn.node_index(&site).expect("Site out of bounds");
-        self.treetn.tensor(node_idx).expect("Tensor not found")
+        self.tensor_checked(site)
+            .unwrap_or_else(|err| panic!("TensorTrain::tensor failed: {err}"))
     }
 
     /// Get a reference to the tensor at the given site.
+    ///
+    /// # Errors
     ///
     /// Returns `Err` if `site >= len()`.
     pub fn tensor_checked(&self, site: usize) -> Result<&TensorDynLen> {
@@ -406,8 +408,49 @@ impl TensorTrain {
     /// Panics if `site >= len()`.
     #[inline]
     pub fn tensor_mut(&mut self, site: usize) -> &mut TensorDynLen {
-        let node_idx = self.treetn.node_index(&site).expect("Site out of bounds");
-        self.treetn.tensor_mut(node_idx).expect("Tensor not found")
+        self.tensor_mut_checked(site)
+            .unwrap_or_else(|err| panic!("TensorTrain::tensor_mut failed: {err}"))
+    }
+
+    /// Get a mutable reference to the tensor at the given site.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if `site >= len()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// let s0 = Index::new_with_size(DynId(0), 2);
+    /// let link = Index::new_with_size(DynId(1), 3);
+    /// let s1 = Index::new_with_size(DynId(2), 2);
+    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = TensorDynLen::from_dense(vec![link, s1], vec![2.0; 6]).unwrap();
+    /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+    ///
+    /// assert_eq!(tt.tensor_mut_checked(0).unwrap().indices()[0], s0);
+    /// assert!(tt.tensor_mut_checked(2).is_err());
+    /// ```
+    pub fn tensor_mut_checked(&mut self, site: usize) -> Result<&mut TensorDynLen> {
+        if site >= self.len() {
+            return Err(TensorTrainError::SiteOutOfBounds {
+                site,
+                length: self.len(),
+            });
+        }
+        let length = self.len();
+        let node_idx = self
+            .treetn
+            .node_index(&site)
+            .ok_or(TensorTrainError::SiteOutOfBounds { site, length })?;
+        self.treetn
+            .tensor_mut(node_idx)
+            .ok_or_else(|| TensorTrainError::InvalidStructure {
+                message: format!("missing tensor storage for site {site}"),
+            })
     }
 
     /// Get a reference to all tensors.
@@ -424,12 +467,50 @@ impl TensorTrain {
     /// Get a mutable reference to all tensors.
     #[inline]
     pub fn tensors_mut(&mut self) -> Vec<&mut TensorDynLen> {
-        let node_indices: Vec<_> = (0..self.len())
-            .map(|site| self.treetn.node_index(&site).expect("Site out of bounds"))
-            .collect();
+        self.tensors_mut_checked()
+            .unwrap_or_else(|err| panic!("TensorTrain::tensors_mut failed: {err}"))
+    }
+
+    /// Get mutable references to all tensors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the internal site-to-node mapping is inconsistent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// let s0 = Index::new_with_size(DynId(0), 2);
+    /// let link = Index::new_with_size(DynId(1), 3);
+    /// let s1 = Index::new_with_size(DynId(2), 2);
+    /// let t0 = TensorDynLen::from_dense(vec![s0, link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = TensorDynLen::from_dense(vec![link, s1], vec![2.0; 6]).unwrap();
+    /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+    ///
+    /// let tensors = tt.tensors_mut_checked().unwrap();
+    /// assert_eq!(tensors.len(), 2);
+    /// assert_eq!(tensors[0].indices().len(), 2);
+    /// assert_eq!(tensors[1].indices().len(), 2);
+    /// ```
+    pub fn tensors_mut_checked(&mut self) -> Result<Vec<&mut TensorDynLen>> {
+        let length = self.len();
+        let node_indices: Vec<_> = (0..length)
+            .map(|site| {
+                self.treetn
+                    .node_index(&site)
+                    .ok_or(TensorTrainError::SiteOutOfBounds { site, length })
+            })
+            .collect::<Result<_>>()?;
         let mut tensor_ptrs = Vec::with_capacity(node_indices.len());
-        for node_idx in node_indices {
-            let tensor = self.treetn.tensor_mut(node_idx).expect("Tensor not found");
+        for (site, node_idx) in node_indices.into_iter().enumerate() {
+            let tensor = self.treetn.tensor_mut(node_idx).ok_or_else(|| {
+                TensorTrainError::InvalidStructure {
+                    message: format!("missing tensor storage for site {site}"),
+                }
+            })?;
             tensor_ptrs.push(tensor as *mut TensorDynLen);
         }
 
@@ -437,7 +518,7 @@ impl TensorTrain {
         // distinct TreeTN node. We collect at most one pointer per node and do
         // not mutate the network structure before converting those pointers back
         // into mutable references.
-        unsafe { tensor_ptrs.into_iter().map(|tensor| &mut *tensor).collect() }
+        Ok(unsafe { tensor_ptrs.into_iter().map(|tensor| &mut *tensor).collect() })
     }
 
     /// Get the link index between sites `i` and `i+1`.
@@ -657,7 +738,13 @@ impl TensorTrain {
     ///
     /// This invalidates orthogonality tracking.
     fn set_tensor_raw(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
-        let node_idx = self.treetn.node_index(&site).expect("Site out of bounds");
+        let node_idx =
+            self.treetn
+                .node_index(&site)
+                .ok_or_else(|| TensorTrainError::SiteOutOfBounds {
+                    site,
+                    length: self.len(),
+                })?;
         self.treetn.replace_tensor(node_idx, tensor).map_err(|e| {
             TensorTrainError::InvalidStructure {
                 message: format!("Failed to replace tensor at site {}: {}", site, e),
@@ -669,12 +756,69 @@ impl TensorTrain {
     /// Replace the tensor at the given site.
     ///
     /// This invalidates orthogonality tracking.
-    pub fn set_tensor(&mut self, site: usize, tensor: TensorDynLen) {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `site >= len()` or if replacing the tensor makes the
+    /// tensor train structure invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// let s0 = Index::new_with_size(DynId(0), 2);
+    /// let link = Index::new_with_size(DynId(1), 3);
+    /// let s1 = Index::new_with_size(DynId(2), 2);
+    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = TensorDynLen::from_dense(vec![link.clone(), s1], vec![2.0; 6]).unwrap();
+    /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+    ///
+    /// let replacement = TensorDynLen::from_dense(vec![s0, link], vec![3.0; 6]).unwrap();
+    /// tt.set_tensor(0, replacement).unwrap();
+    /// assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![3.0; 6]);
+    /// ```
+    pub fn set_tensor(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
+        self.set_tensor_checked(site, tensor)
+    }
+
+    /// Replace the tensor at the given site.
+    ///
+    /// This invalidates orthogonality tracking.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `site >= len()` or if replacing the tensor makes the
+    /// tensor train structure invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_itensorlike::TensorTrain;
+    ///
+    /// let s0 = Index::new_with_size(DynId(0), 2);
+    /// let link = Index::new_with_size(DynId(1), 3);
+    /// let s1 = Index::new_with_size(DynId(2), 2);
+    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = TensorDynLen::from_dense(vec![link.clone(), s1], vec![2.0; 6]).unwrap();
+    /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+    ///
+    /// let replacement = TensorDynLen::from_dense(vec![s0, link], vec![4.0; 6]).unwrap();
+    /// tt.set_tensor_checked(0, replacement).unwrap();
+    /// assert!(tt.set_tensor_checked(2, tt.tensor(0).clone()).is_err());
+    /// ```
+    pub fn set_tensor_checked(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
         self.set_tensor_raw(site, tensor)
-            .and_then(|()| self.normalize_site_tensor_order(site))
-            .unwrap_or_else(|e| panic!("TensorTrain::set_tensor failed: {}", e));
+            .and_then(|()| self.normalize_site_tensor_order(site))?;
         // Invalidate orthogonality
-        let _ = self.treetn.set_canonical_region(Vec::<usize>::new());
+        self.treetn
+            .set_canonical_region(Vec::<usize>::new())
+            .map_err(|e| TensorTrainError::InvalidStructure {
+                message: format!("Failed to clear canonical region: {}", e),
+            })?;
+        Ok(())
     }
 
     /// Orthogonalize the tensor train to have orthogonality center at the given site.
@@ -1233,7 +1377,10 @@ impl TensorTrain {
 // Implement Default for TensorTrain to allow std::mem::take
 impl Default for TensorTrain {
     fn default() -> Self {
-        Self::new(vec![]).expect("Failed to create empty TensorTrain")
+        Self {
+            treetn: TreeTN::new(),
+            canonical_form: None,
+        }
     }
 }
 
@@ -1307,7 +1454,9 @@ impl TensorLike for TensorTrain {
         let mut result = self.clone();
         for site in 0..result.len() {
             let t = result.tensor(site).conj();
-            result.set_tensor(site, t);
+            result
+                .set_tensor(site, t)
+                .unwrap_or_else(|err| panic!("TensorTrain::conj failed: {err}"));
         }
         result
     }

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -365,13 +365,12 @@ impl TensorTrain {
 
     /// Get a reference to the tensor at the given site.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `site >= len()`.
+    /// Returns `Err` if `site >= len()`.
     #[inline]
-    pub fn tensor(&self, site: usize) -> &TensorDynLen {
+    pub fn tensor(&self, site: usize) -> Result<&TensorDynLen> {
         self.tensor_checked(site)
-            .unwrap_or_else(|err| panic!("TensorTrain::tensor failed: {err}"))
     }
 
     /// Get a reference to the tensor at the given site.
@@ -403,13 +402,12 @@ impl TensorTrain {
 
     /// Get a mutable reference to the tensor at the given site.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `site >= len()`.
+    /// Returns `Err` if `site >= len()`.
     #[inline]
-    pub fn tensor_mut(&mut self, site: usize) -> &mut TensorDynLen {
+    pub fn tensor_mut(&mut self, site: usize) -> Result<&mut TensorDynLen> {
         self.tensor_mut_checked(site)
-            .unwrap_or_else(|err| panic!("TensorTrain::tensor_mut failed: {err}"))
     }
 
     /// Get a mutable reference to the tensor at the given site.
@@ -465,10 +463,13 @@ impl TensorTrain {
     }
 
     /// Get a mutable reference to all tensors.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the internal site-to-node mapping is inconsistent.
     #[inline]
-    pub fn tensors_mut(&mut self) -> Vec<&mut TensorDynLen> {
+    pub fn tensors_mut(&mut self) -> Result<Vec<&mut TensorDynLen>> {
         self.tensors_mut_checked()
-            .unwrap_or_else(|err| panic!("TensorTrain::tensors_mut failed: {err}"))
     }
 
     /// Get mutable references to all tensors.
@@ -551,9 +552,18 @@ impl TensorTrain {
     /// This is useful for computing inner products where two tensor trains
     /// share link indices. By simulating (replacing) the link indices in one
     /// of the tensor trains, they can be contracted over site indices only.
-    pub fn sim_linkinds(&self) -> Self {
+    ///
+    /// # Returns
+    ///
+    /// A tensor train with the same site indices and fresh link indices.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tensor train's internal site mapping is
+    /// inconsistent or rebuilding the tensor train fails.
+    pub fn sim_linkinds(&self) -> Result<Self> {
         if self.len() <= 1 {
-            return self.clone();
+            return Ok(self.clone());
         }
 
         // Build replacement pairs: (old_link, new_link) for each link index
@@ -568,15 +578,19 @@ impl TensorTrain {
         // Replace link indices in each tensor and rebuild
         let mut new_tensors = Vec::with_capacity(self.len());
         for site in 0..self.len() {
-            let tensor = self.tensor(site);
+            let tensor = self.tensor_checked(site)?;
             let mut new_tensor = tensor.clone();
             for (old_idx, new_idx) in &replacements {
-                new_tensor = new_tensor.replaceind(old_idx, new_idx);
+                new_tensor = new_tensor.replaceind(old_idx, new_idx).map_err(|err| {
+                    TensorTrainError::OperationError {
+                        message: format!("failed to replace simulated link index: {err}"),
+                    }
+                })?;
             }
             new_tensors.push(new_tensor);
         }
 
-        Self::new(new_tensors).expect("sim_linkinds: failed to create new tensor train")
+        Self::new(new_tensors)
     }
 
     fn normalize_site_tensor_orders(&mut self) -> Result<()> {
@@ -592,20 +606,32 @@ impl TensorTrain {
         }
 
         (0..self.len() - 1).all(|site| {
-            let left = self.tensor(site);
-            let right = self.tensor(site + 1);
+            let (Ok(left), Ok(right)) = (self.tensor_checked(site), self.tensor_checked(site + 1))
+            else {
+                return false;
+            };
             common_inds(left.indices(), right.indices()).len() <= 1
         })
     }
 
     fn can_normalize_site_tensor_order(&self, site: usize) -> bool {
         let left_ok = if site > 0 {
-            common_inds(self.tensor(site - 1).indices(), self.tensor(site).indices()).len() <= 1
+            let (Ok(left), Ok(current)) =
+                (self.tensor_checked(site - 1), self.tensor_checked(site))
+            else {
+                return false;
+            };
+            common_inds(left.indices(), current.indices()).len() <= 1
         } else {
             true
         };
         let right_ok = if site + 1 < self.len() {
-            common_inds(self.tensor(site).indices(), self.tensor(site + 1).indices()).len() <= 1
+            let (Ok(current), Ok(right)) =
+                (self.tensor_checked(site), self.tensor_checked(site + 1))
+            else {
+                return false;
+            };
+            common_inds(current.indices(), right.indices()).len() <= 1
         } else {
             true
         };
@@ -672,7 +698,9 @@ impl TensorTrain {
         let mut result = Vec::with_capacity(self.len());
 
         for i in 0..self.len() {
-            let tensor = self.tensor(i);
+            let Ok(tensor) = self.tensor_checked(i) else {
+                return Vec::new();
+            };
             let mut site_inds: Vec<DynIndex> = tensor.indices().to_vec();
 
             // Remove link to left neighbor
@@ -777,7 +805,7 @@ impl TensorTrain {
     ///
     /// let replacement = TensorDynLen::from_dense(vec![s0, link], vec![3.0; 6]).unwrap();
     /// tt.set_tensor(0, replacement).unwrap();
-    /// assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![3.0; 6]);
+    /// assert_eq!(tt.tensor(0).unwrap().to_vec::<f64>().unwrap(), vec![3.0; 6]);
     /// ```
     pub fn set_tensor(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
         self.set_tensor_checked(site, tensor)
@@ -807,7 +835,7 @@ impl TensorTrain {
     ///
     /// let replacement = TensorDynLen::from_dense(vec![s0, link], vec![4.0; 6]).unwrap();
     /// tt.set_tensor_checked(0, replacement).unwrap();
-    /// assert!(tt.set_tensor_checked(2, tt.tensor(0).clone()).is_err());
+    /// assert!(tt.set_tensor_checked(2, tt.tensor(0).unwrap().clone()).is_err());
     /// ```
     pub fn set_tensor_checked(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
         self.set_tensor_raw(site, tensor)
@@ -978,6 +1006,12 @@ impl TensorTrain {
     /// Both tensor trains must have the same site indices (same IDs).
     /// Link indices may differ between the two tensor trains.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the tensor trains have different lengths, if the
+    /// internal site mapping is inconsistent, or if the final contraction does
+    /// not produce a scalar.
+    ///
     /// # Examples
     ///
     /// ```
@@ -994,54 +1028,95 @@ impl TensorTrain {
     /// let tt = TensorTrain::new(vec![t]).unwrap();
     ///
     /// // <tt | tt> = 1.0^2 + 0.0^2 = 1.0
-    /// let result = tt.inner(&tt);
+    /// let result = tt.inner(&tt).unwrap();
     /// assert!((result.real() - 1.0).abs() < 1e-10);
     /// ```
-    pub fn inner(&self, other: &Self) -> AnyScalar {
-        assert_eq!(
-            self.len(),
-            other.len(),
-            "Tensor trains must have the same length for inner product"
-        );
+    pub fn inner(&self, other: &Self) -> Result<AnyScalar> {
+        if self.len() != other.len() {
+            return Err(TensorTrainError::InvalidStructure {
+                message: format!(
+                    "Tensor trains must have the same length for inner product: {} vs {}",
+                    self.len(),
+                    other.len()
+                ),
+            });
+        }
 
         if self.is_empty() {
-            return AnyScalar::new_real(0.0);
+            return Ok(AnyScalar::new_real(0.0));
         }
 
         // Sequential bra-ket contraction along the chain: O(N·D²·d).
         // TreeTN::inner() uses contract_naive which is O(d^N) and OOMs for large N.
         let other_sim = other.treetn.sim_internal_inds();
 
-        let n = self.len();
         let node_idx = |ttn: &TreeTN<TensorDynLen, usize>, site: usize| {
-            ttn.node_index(&site).expect("node not found")
+            ttn.node_index(&site)
+                .ok_or_else(|| TensorTrainError::InvalidStructure {
+                    message: format!("missing node for site {site}"),
+                })
         };
 
         // Start with leftmost tensors - contract over site indices only
         let mut env = {
-            let a0_conj = self.tensor(0).conj();
+            let a0_conj = self.tensor_checked(0)?.conj();
+            let b0_node = node_idx(&other_sim, 0)?;
             let b0 = other_sim
-                .tensor(node_idx(&other_sim, 0))
-                .expect("tensor not found")
+                .tensor(b0_node)
+                .ok_or_else(|| TensorTrainError::InvalidStructure {
+                    message: "missing tensor for site 0 in simulated right operand".to_string(),
+                })?
                 .clone();
-            a0_conj.contract(&b0)
+            a0_conj
+                .contract(&b0)
+                .map_err(|err| TensorTrainError::OperationError {
+                    message: format!("failed to contract leftmost tensors: {err}"),
+                })?
         };
 
         // Sweep through remaining sites
-        for i in 1..n {
-            let ai_conj = self.tensor(i).conj();
-            let bi = other_sim
-                .tensor(node_idx(&other_sim, i))
-                .expect("tensor not found");
+        for i in 1..self.len() {
+            let ai_conj = self.tensor_checked(i)?.conj();
+            let bi_node = node_idx(&other_sim, i)?;
+            let bi =
+                other_sim
+                    .tensor(bi_node)
+                    .ok_or_else(|| TensorTrainError::InvalidStructure {
+                        message: format!("missing tensor for site {i} in simulated right operand"),
+                    })?;
 
             // Contract: env * conj(A_i) (over self's link index)
-            env = env.contract(&ai_conj);
+            env = env
+                .contract(&ai_conj)
+                .map_err(|err| TensorTrainError::OperationError {
+                    message: format!("failed to contract environment with site {i}: {err}"),
+                })?;
             // Contract: result * B_i (over other's link index and site indices)
-            env = env.contract(bi);
+            env = env
+                .contract(bi)
+                .map_err(|err| TensorTrainError::OperationError {
+                    message: format!("failed to contract right operand at site {i}: {err}"),
+                })?;
         }
 
         // Result should be a scalar (0-dimensional tensor)
-        env.only()
+        let dims = env.dims();
+        let total_size: usize = if dims.is_empty() {
+            1
+        } else {
+            dims.iter().product()
+        };
+        if total_size != 1 {
+            return Err(TensorTrainError::InvalidStructure {
+                message: format!(
+                    "inner product did not contract to a scalar: got dims {:?}",
+                    dims
+                ),
+            });
+        }
+        env.sum().map_err(|err| TensorTrainError::OperationError {
+            message: format!("failed to sum scalar inner-product tensor: {err}"),
+        })
     }
 
     /// Compute the squared norm of the tensor train.
@@ -1054,8 +1129,13 @@ impl TensorTrain {
     /// Due to numerical errors, the final scalar can be very slightly negative,
     /// so the returned value is clamped to be non-negative.
     pub fn norm_squared(&self) -> f64 {
-        self.norm_squared_fast_path()
-            .unwrap_or_else(|| self.inner(self).real().max(0.0))
+        match self.norm_squared_fast_path() {
+            Some(value) => value,
+            None => self
+                .inner(self)
+                .map(|value| value.real().max(0.0))
+                .unwrap_or(f64::NAN),
+        }
     }
 
     /// Compute the norm of the tensor train.
@@ -1097,7 +1177,7 @@ impl TensorTrain {
         let mut sites = Vec::with_capacity(tt.len());
 
         for site in 0..tt.len() {
-            let tensor = tt.tensor(site);
+            let tensor = tt.tensor_checked(site).ok()?;
             let left_dim = if site == 0 {
                 1
             } else {
@@ -1334,7 +1414,7 @@ impl TensorTrain {
 
         let mut tensors = Vec::with_capacity(self.len());
         for site in 0..self.len() {
-            let tensor = self.tensor(site);
+            let tensor = self.tensor_checked(site)?;
             if site == 0 {
                 // Scale only the first tensor
                 let scaled =
@@ -1431,7 +1511,7 @@ impl TensorLike for TensorTrain {
     }
 
     fn inner_product(&self, other: &Self) -> anyhow::Result<AnyScalar> {
-        Ok(self.inner(other))
+        self.inner(other).map_err(|e| anyhow::anyhow!("{}", e))
     }
 
     fn norm_squared(&self) -> f64 {
@@ -1449,14 +1529,12 @@ impl TensorLike for TensorTrain {
     }
 
     fn conj(&self) -> Self {
-        // Clone and conjugate each site tensor
-        // Note: conj() cannot return Result, so we ensure this never fails
         let mut result = self.clone();
-        for site in 0..result.len() {
-            let t = result.tensor(site).conj();
-            result
-                .set_tensor(site, t)
-                .unwrap_or_else(|err| panic!("TensorTrain::conj failed: {err}"));
+        if let Ok(tensors) = result.tensors_mut_checked() {
+            for tensor in tensors {
+                let conjugated = tensor.conj();
+                *tensor = conjugated;
+            }
         }
         result
     }

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -424,7 +424,7 @@ fn test_to_dense() {
     let dense = tt.to_dense().unwrap();
 
     // Expected: contract t0 and t1 along l01
-    let expected = t0.contract(&t1);
+    let expected = t0.contract(&t1).unwrap();
 
     // Compare results
     let dense_data = dense.to_vec::<f64>().unwrap();
@@ -483,7 +483,7 @@ fn test_to_dense_three_sites() {
     let dense = tt.to_dense().unwrap();
 
     // Expected: contract t0, t1, t2 sequentially
-    let expected = t0.contract(&t1).contract(&t2);
+    let expected = t0.contract(&t1).unwrap().contract(&t2).unwrap();
 
     let dense_data = dense.to_vec::<f64>().unwrap();
     let expected_data = expected.to_vec::<f64>().unwrap();
@@ -720,12 +720,15 @@ fn test_tensors_mut_returns_all_sites_in_order() {
         TensorDynLen::from_dense(vec![s0, l01], vec![42.0; 6]).expect("valid replacement");
 
     {
-        let mut tensors = tt.tensors_mut();
+        let mut tensors = tt.tensors_mut().unwrap();
         assert_eq!(tensors.len(), 2);
         *tensors[0] = replacement.clone();
     }
 
-    assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![42.0; 6]);
+    assert_eq!(
+        tt.tensor(0).unwrap().to_vec::<f64>().unwrap(),
+        vec![42.0; 6]
+    );
 }
 
 #[test]
@@ -747,7 +750,10 @@ fn test_tensors_mut_checked_returns_all_sites_in_order() {
         *tensors[0] = replacement.clone();
     }
 
-    assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![42.0; 6]);
+    assert_eq!(
+        tt.tensor(0).unwrap().to_vec::<f64>().unwrap(),
+        vec![42.0; 6]
+    );
 }
 
 #[test]
@@ -863,7 +869,7 @@ fn test_tensor_like_inner_product() {
 
     // TensorLike::inner_product should equal TensorTrain::inner
     let inner_via_trait = TensorLike::inner_product(&tt, &tt).unwrap();
-    let inner_direct = tt.inner(&tt);
+    let inner_direct = tt.inner(&tt).unwrap();
 
     assert!(
         (inner_via_trait.real() - inner_direct.real()).abs() < 1e-10,
@@ -945,7 +951,7 @@ fn test_tensor_mut() {
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
 
     // Mutate tensor at site 0
-    let t = tt.tensor_mut(0);
+    let t = tt.tensor_mut(0).unwrap();
     assert_eq!(t.indices().len(), 2);
     // Just verify we can get a mutable reference without panic
     let _ = t.indices();
@@ -977,11 +983,11 @@ fn test_sim_linkinds_single_site() {
     let t0 = make_tensor(vec![s0.clone()]);
     let tt = TensorTrain::new(vec![t0]).unwrap();
 
-    let simmed = tt.sim_linkinds();
+    let simmed = tt.sim_linkinds().unwrap();
     assert_eq!(simmed.len(), 1);
     // Should have same data
-    let orig_data = tt.tensor(0).to_vec::<f64>().unwrap();
-    let sim_data = simmed.tensor(0).to_vec::<f64>().unwrap();
+    let orig_data = tt.tensor(0).unwrap().to_vec::<f64>().unwrap();
+    let sim_data = simmed.tensor(0).unwrap().to_vec::<f64>().unwrap();
     assert_eq!(orig_data, sim_data);
 }
 
@@ -995,7 +1001,7 @@ fn test_sim_linkinds_two_sites() {
     let t1 = make_tensor(vec![l01.clone(), s1.clone()]);
 
     let tt = TensorTrain::new(vec![t0, t1]).unwrap();
-    let simmed = tt.sim_linkinds();
+    let simmed = tt.sim_linkinds().unwrap();
 
     assert_eq!(simmed.len(), 2);
     assert_eq!(simmed.bond_dims(), vec![3]);
@@ -1104,7 +1110,7 @@ fn test_sim_linkinds_three_sites() {
     let t2 = make_tensor(vec![l12.clone(), s2.clone()]);
 
     let tt = TensorTrain::new(vec![t0, t1, t2]).unwrap();
-    let simmed = tt.sim_linkinds();
+    let simmed = tt.sim_linkinds().unwrap();
 
     assert_eq!(simmed.len(), 3);
     assert_eq!(simmed.bond_dims().len(), 2);

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -665,8 +665,45 @@ fn test_set_tensor_invalidates_ortho() {
 
     // Replace tensor at site 0
     let new_tensor = make_tensor(vec![s0, l01]);
-    tt.set_tensor(0, new_tensor);
+    tt.set_tensor(0, new_tensor).unwrap();
     assert!(!tt.isortho());
+}
+
+#[test]
+fn test_set_tensor_checked_invalid_site_errors() {
+    let s0 = idx(0, 2);
+    let l01 = idx(1, 3);
+    let s1 = idx(2, 2);
+
+    let t0 = make_tensor(vec![s0.clone(), l01.clone()]);
+    let t1 = make_tensor(vec![l01.clone(), s1]);
+    let replacement = make_tensor(vec![s0, l01]);
+
+    let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+
+    let err = tt.set_tensor_checked(2, replacement).unwrap_err();
+    assert!(matches!(
+        err,
+        TensorTrainError::SiteOutOfBounds { site: 2, length: 2 }
+    ));
+}
+
+#[test]
+fn test_tensor_mut_checked_invalid_site_errors() {
+    let s0 = idx(0, 2);
+    let l01 = idx(1, 3);
+    let s1 = idx(2, 2);
+
+    let t0 = make_tensor(vec![s0, l01.clone()]);
+    let t1 = make_tensor(vec![l01, s1]);
+
+    let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+
+    let err = tt.tensor_mut_checked(2).unwrap_err();
+    assert!(matches!(
+        err,
+        TensorTrainError::SiteOutOfBounds { site: 2, length: 2 }
+    ));
 }
 
 #[test]
@@ -684,6 +721,28 @@ fn test_tensors_mut_returns_all_sites_in_order() {
 
     {
         let mut tensors = tt.tensors_mut();
+        assert_eq!(tensors.len(), 2);
+        *tensors[0] = replacement.clone();
+    }
+
+    assert_eq!(tt.tensor(0).to_vec::<f64>().unwrap(), vec![42.0; 6]);
+}
+
+#[test]
+fn test_tensors_mut_checked_returns_all_sites_in_order() {
+    let s0 = idx(0, 2);
+    let l01 = idx(1, 3);
+    let s1 = idx(2, 2);
+
+    let t0 = make_tensor(vec![s0.clone(), l01.clone()]);
+    let t1 = make_tensor(vec![l01.clone(), s1.clone()]);
+    let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
+
+    let replacement =
+        TensorDynLen::from_dense(vec![s0, l01], vec![42.0; 6]).expect("valid replacement");
+
+    {
+        let mut tensors = tt.tensors_mut_checked().unwrap();
         assert_eq!(tensors.len(), 2);
         *tensors[0] = replacement.clone();
     }

--- a/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
+++ b/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
@@ -106,7 +106,7 @@ fn bench_inner() {
         let b_sites: Vec<DynIndex> = b.siteinds().into_iter().flatten().collect();
         let b = b.replaceinds(&b_sites, &a_sites).unwrap();
         time_it(&format!("inner({n} sites, bd=16)"), || {
-            let _ = a.inner(&b);
+            let _ = a.inner(&b).unwrap();
         });
     }
 }

--- a/crates/tensor4all-itensorlike/tests/bug_complex_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_complex_inner.rs
@@ -51,8 +51,8 @@ fn test_inner_wrong_with_nonstandard_index_order() {
     eprintln!("dense norm² std={:.6e}, ns={:.6e}", norm_sq_std, norm_sq_ns);
 
     // inner(x, x) for both must be real, non-negative, and match dense norm²
-    let inner_std = tt_std.inner(&tt_std);
-    let inner_ns = tt_ns.inner(&tt_ns);
+    let inner_std = tt_std.inner(&tt_std).unwrap();
+    let inner_ns = tt_ns.inner(&tt_ns).unwrap();
     let norm_sq_std_tt = tt_std.norm_squared();
     let norm_sq_ns_tt = tt_ns.norm_squared();
 
@@ -130,7 +130,7 @@ fn test_inner_wrong_3site_nonstandard() {
     ])
     .unwrap();
 
-    let inner = tt.inner(&tt);
+    let inner = tt.inner(&tt).unwrap();
     let norm_sq_tt = tt.norm_squared();
     let dense = tt.to_dense().unwrap();
     let dense_norm_sq = dense.norm() * dense.norm();
@@ -197,7 +197,7 @@ fn test_inner_wrong_with_two_site_indices_per_site_nonstandard_order() {
     ])
     .unwrap();
 
-    let inner = tt.inner(&tt);
+    let inner = tt.inner(&tt).unwrap();
     let norm_sq_tt = tt.norm_squared();
     let dense = tt.to_dense().unwrap();
     let dense_norm_sq = dense.norm() * dense.norm();

--- a/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
@@ -35,7 +35,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(rng, indices).unwrap();
         tensors.push(tensor);
     }
     TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -200,10 +200,10 @@ fn elementwise_mul(
             .position(|inds| inds.iter().any(|idx| idx.id() == s.id()))
             .unwrap();
 
-        let t1 = as_diagonal(m1_prep.tensor(pos1), s, &s_result, &s_contract);
+        let t1 = as_diagonal(m1_prep.tensor(pos1).unwrap(), s, &s_result, &s_contract);
         m1_prep.set_tensor(pos1, t1).unwrap();
 
-        let t2 = as_diagonal(m2_prep.tensor(pos2), s, &s_contract, s);
+        let t2 = as_diagonal(m2_prep.tensor(pos2).unwrap(), s, &s_contract, s);
         m2_prep.set_tensor(pos2, t2).unwrap();
 
         maps.push((s.clone(), s_result));
@@ -217,7 +217,7 @@ fn elementwise_mul(
             .iter()
             .position(|inds| inds.iter().any(|idx| idx.id() == original.id()))
             .unwrap();
-        let t = result.tensor(pos);
+        let t = result.tensor(pos).unwrap();
         let extracted = extract_diagonal(t, original, s_result);
         result.set_tensor(pos, extracted).unwrap();
     }

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -201,10 +201,10 @@ fn elementwise_mul(
             .unwrap();
 
         let t1 = as_diagonal(m1_prep.tensor(pos1), s, &s_result, &s_contract);
-        m1_prep.set_tensor(pos1, t1);
+        m1_prep.set_tensor(pos1, t1).unwrap();
 
         let t2 = as_diagonal(m2_prep.tensor(pos2), s, &s_contract, s);
-        m2_prep.set_tensor(pos2, t2);
+        m2_prep.set_tensor(pos2, t2).unwrap();
 
         maps.push((s.clone(), s_result));
     }
@@ -219,7 +219,7 @@ fn elementwise_mul(
             .unwrap();
         let t = result.tensor(pos);
         let extracted = extract_diagonal(t, original, s_result);
-        result.set_tensor(pos, extracted);
+        result.set_tensor(pos, extracted).unwrap();
     }
     result
 }

--- a/crates/tensor4all-itensorlike/tests/bug_norm_oom_large_tt.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_norm_oom_large_tt.rs
@@ -54,7 +54,7 @@ fn reference_norm_squared(tt: &TensorTrain) -> f64 {
 
     let mut current = Vec::new();
     for site in 0..tt.len() {
-        let tensor = tt.tensor(site);
+        let tensor = tt.tensor(site).unwrap();
         let data = tensor.to_vec::<f64>().unwrap();
         let left_dim = if site == 0 {
             1

--- a/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
@@ -33,7 +33,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices);
+        let tensor = TensorDynLen::random::<f64, _>(rng, indices).unwrap();
         tensors.push(tensor);
     }
     TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-itensorlike/tests/panic_paths.rs
+++ b/crates/tensor4all-itensorlike/tests/panic_paths.rs
@@ -1,0 +1,45 @@
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_itensorlike::{TensorTrain, TensorTrainError};
+
+fn site_tensor(size: usize, data: Vec<f64>) -> TensorDynLen {
+    let site = DynIndex::new_dyn(size);
+    TensorDynLen::from_dense(vec![site], data).unwrap()
+}
+
+#[test]
+fn tensor_accessors_report_invalid_sites() {
+    let mut tt = TensorTrain::default();
+
+    let err = tt.tensor(0).unwrap_err();
+    assert!(matches!(
+        err,
+        TensorTrainError::SiteOutOfBounds { site: 0, length: 0 }
+    ));
+
+    let err = tt.tensor_mut(0).unwrap_err();
+    assert!(matches!(
+        err,
+        TensorTrainError::SiteOutOfBounds { site: 0, length: 0 }
+    ));
+}
+
+#[test]
+fn inner_reports_length_mismatch() {
+    let left = TensorTrain::new(vec![site_tensor(2, vec![1.0, 2.0])]).unwrap();
+    let right = TensorTrain::default();
+
+    let err = left.inner(&right).unwrap_err();
+    assert!(err.to_string().contains("same length"));
+}
+
+#[test]
+fn sim_linkinds_reports_success_without_panic_wrapper() {
+    let tt = TensorTrain::new(vec![site_tensor(2, vec![1.0, 2.0])]).unwrap();
+    let simmed = tt.sim_linkinds().unwrap();
+
+    assert_eq!(simmed.len(), 1);
+    assert_eq!(
+        simmed.tensor(0).unwrap().to_vec::<f64>().unwrap(),
+        vec![1.0, 2.0]
+    );
+}

--- a/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
@@ -10,7 +10,7 @@ fn test_inner_empty_tensor_trains() {
     let tt1 = TensorTrain::new(vec![]).unwrap();
     let tt2 = TensorTrain::new(vec![]).unwrap();
 
-    let result = tt1.inner(&tt2);
+    let result = tt1.inner(&tt2).unwrap();
     assert_eq!(result.real(), 0.0);
 }
 
@@ -39,11 +39,11 @@ fn test_inner_single_site() {
     let tt2 = TensorTrain::new(vec![t2.clone()]).unwrap();
 
     // Orthogonal vectors: inner product should be 0
-    let result = tt1.inner(&tt2);
+    let result = tt1.inner(&tt2).unwrap();
     assert!((result.real() - 0.0).abs() < 1e-10);
 
     // Same vector: inner product should be 1
     let tt3 = TensorTrain::new(vec![t1.clone()]).unwrap();
-    let result2 = tt1.inner(&tt3);
+    let result2 = tt1.inner(&tt3).unwrap();
     assert!((result2.real() - 1.0).abs() < 1e-10);
 }

--- a/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
@@ -279,7 +279,7 @@ fn test_contract_numerical_correctness_generic<T: TestScalar>() {
     // Manually compute expected contraction: R = T1 * T2 (contracting s1)
     // T1 has indices [s0, s1], T2 has indices [s1, s2]
     // Result R has indices [s0, s2]
-    let expected = t1_full.contract(&t2_full);
+    let expected = t1_full.contract(&t2_full).unwrap();
 
     // Compare: both should have the same data
     let contracted_data = T::extract_slice(&contracted_full);
@@ -361,7 +361,7 @@ fn test_contract_with_projectors_numerical_correctness_generic<T: TestScalar>() 
     let t2_proj = project_dense_tensor_at_index::<T>(&t2_full, &s2, 1);
 
     // Contract projected tensors
-    let expected = t1_proj.contract(&t2_proj);
+    let expected = t1_proj.contract(&t2_proj).unwrap();
 
     // Compare
     let contracted_data = T::extract_slice(&contracted_full);
@@ -419,7 +419,7 @@ fn test_contract_with_projectors_numerical_correctness_default_zipup_generic<T: 
             let t1_proj = project_dense_tensor_at_index::<T>(&t1_full, &s0, s0_val);
             let t2_proj = project_dense_tensor_at_index::<T>(&t2_full, &s2, s2_val);
 
-            let expected = t1_proj.contract(&t2_proj);
+            let expected = t1_proj.contract(&t2_proj).unwrap();
 
             let contracted_data = T::extract_slice(&contracted_full);
             let expected_data = T::extract_slice(&expected);
@@ -484,7 +484,7 @@ fn test_contract_with_projector_on_contracted_index_generic<T: TestScalar>() {
     let t1_proj = project_dense_tensor_at_index::<T>(&t1_full, &s1, 0);
     let t2_proj = project_dense_tensor_at_index::<T>(&t2_full, &s1, 0);
 
-    let expected = t1_proj.contract(&t2_proj);
+    let expected = t1_proj.contract(&t2_proj).unwrap();
 
     let contracted_data = T::extract_slice(&contracted_full);
     let expected_data = T::extract_slice(&expected);
@@ -540,7 +540,7 @@ fn test_contract_one_side_has_projector_generic<T: TestScalar>() {
     // Compute expected: project t1 to s0=1, t2 unchanged
     let t1_proj = project_dense_tensor_at_index::<T>(&t1_full, &s0, 1);
 
-    let expected = t1_proj.contract(&t2_full);
+    let expected = t1_proj.contract(&t2_full).unwrap();
 
     let contracted_data = T::extract_slice(&contracted_full);
     let expected_data = T::extract_slice(&expected);
@@ -597,7 +597,7 @@ fn test_proj_contract_numerical_correctness_generic<T: TestScalar>() {
     let t1_proj = project_dense_tensor_at_index::<T>(&t1_full, &s0, 0);
     let t2_proj = project_dense_tensor_at_index::<T>(&t2_full, &s2, 1);
 
-    let expected = t1_proj.contract(&t2_proj);
+    let expected = t1_proj.contract(&t2_proj).unwrap();
 
     let contracted_data = T::extract_slice(&contracted_full);
     let expected_data = T::extract_slice(&expected);

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -420,7 +420,7 @@ impl PartitionedTT {
         sorted.sort_by(|(p1, _), (p2, _)| Self::projector_cmp(p1, p2));
 
         let mut iter = sorted.into_iter().map(|(_, subdomain)| subdomain);
-        let first = iter.next().unwrap();
+        let first = iter.next().ok_or(PartitionedTTError::Empty)?;
         let mut result = first.data().clone();
 
         for subdomain in iter {
@@ -451,16 +451,6 @@ impl PartitionedTT {
         b_pairs.sort();
 
         a_pairs.cmp(&b_pairs)
-    }
-}
-
-impl std::ops::Index<&Projector> for PartitionedTT {
-    type Output = SubDomainTT;
-
-    fn index(&self, projector: &Projector) -> &Self::Output {
-        self.data
-            .get(projector)
-            .expect("Projector not found in PartitionedTT")
     }
 }
 

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
@@ -145,7 +145,7 @@ fn test_partitioned_tt_index() {
     let partitioned = PartitionedTT::from_subdomain(subdomain);
 
     // Access by projector
-    let retrieved = &partitioned[&projector];
+    let retrieved = partitioned.get(&projector).unwrap();
     assert_eq!(retrieved.projector(), &projector);
 }
 
@@ -245,7 +245,7 @@ fn test_partitioned_tt_contract_numerical() {
         // Project t2 to s2=s2_val
         let t2_proj = project_dense_tensor_at_index(&t2_full, &s2, s2_val);
 
-        let expected = t1_proj.contract(&t2_proj);
+        let expected = t1_proj.contract(&t2_proj).unwrap();
         let expected_data = expected.to_vec::<f64>().unwrap();
 
         assert_eq!(
@@ -466,7 +466,7 @@ fn test_partitioned_tt_to_tensor_train_single() {
     let combined = partitioned.to_tensor_train().unwrap();
     let combined_dense = combined.to_dense().unwrap();
 
-    let diff = (&combined_dense - &expected_dense).maxabs();
+    let diff = combined_dense.distance(&expected_dense).unwrap();
     assert!(diff < 1e-10);
 }
 
@@ -494,7 +494,7 @@ fn test_partitioned_tt_to_tensor_train_multiple() {
     let combined_dense = combined.to_dense().unwrap();
     let expected_dense = expected.to_dense().unwrap();
 
-    let diff = (&combined_dense - &expected_dense).maxabs();
+    let diff = combined_dense.distance(&expected_dense).unwrap();
     assert!(diff < 1e-10);
 }
 

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
@@ -149,14 +149,14 @@ impl SubDomainTT {
         let mut new_tensors = Vec::with_capacity(self.data.len());
 
         for (site, site_indices) in siteinds.iter().enumerate() {
-            let tensor = self.data.tensor(site);
+            let tensor = self.data.tensor(site).ok()?;
 
             // Check if any site index is projected
             let mut projected_tensor = tensor.clone();
             for idx in site_indices {
                 if let Some(projected_value) = projector.get(idx) {
                     projected_tensor =
-                        Self::project_tensor_at_index(&projected_tensor, idx, projected_value);
+                        Self::project_tensor_at_index(&projected_tensor, idx, projected_value)?;
                 }
             }
             new_tensors.push(projected_tensor);
@@ -170,7 +170,7 @@ impl SubDomainTT {
         tensor: &TensorDynLen,
         index: &DynIndex,
         projected_value: usize,
-    ) -> TensorDynLen {
+    ) -> Option<TensorDynLen> {
         use num_complex::Complex64;
 
         // Find the axis corresponding to this index
@@ -186,10 +186,9 @@ impl SubDomainTT {
             if projected_value >= dim {
                 // Invalid projection - zero out entire tensor
                 if tensor.is_f64() {
-                    return TensorDynLen::zeros::<f64>(indices.to_vec()).unwrap();
+                    return TensorDynLen::zeros::<f64>(indices.to_vec()).ok();
                 } else {
-                    return TensorDynLen::zeros::<num_complex::Complex64>(indices.to_vec())
-                        .unwrap();
+                    return TensorDynLen::zeros::<num_complex::Complex64>(indices.to_vec()).ok();
                 }
             }
 
@@ -205,7 +204,7 @@ impl SubDomainTT {
                     }
                 }
 
-                TensorDynLen::from_dense(indices.to_vec(), result_data).unwrap()
+                TensorDynLen::from_dense(indices.to_vec(), result_data).ok()
             } else {
                 let src_data = tensor.to_vec::<Complex64>().unwrap_or_default();
                 let mut result_data = vec![Complex64::new(0.0, 0.0); total_size];
@@ -217,11 +216,11 @@ impl SubDomainTT {
                     }
                 }
 
-                TensorDynLen::from_dense(indices.to_vec(), result_data).unwrap()
+                TensorDynLen::from_dense(indices.to_vec(), result_data).ok()
             }
         } else {
             // Index not found - return tensor unchanged
-            tensor.clone()
+            Some(tensor.clone())
         }
     }
 
@@ -316,8 +315,10 @@ impl SubDomainTT {
     }
 
     /// Inner product with another SubDomainTT.
-    pub fn inner(&self, other: &Self) -> AnyScalar {
-        self.data.inner(other.data())
+    pub fn inner(&self, other: &Self) -> Result<AnyScalar> {
+        self.data
+            .inner(other.data())
+            .map_err(|err| PartitionedTTError::TensorTrainError(err.to_string()))
     }
 }
 

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -16,6 +16,20 @@ use tensor4all_treetci::{
 
 use crate::options::QtciOptions;
 
+fn point_from_batch(batch: GlobalIndexBatch<'_>, point: usize) -> Result<Vec<usize>> {
+    (0..batch.n_sites())
+        .map(|site| {
+            batch.get(site, point).ok_or_else(|| {
+                anyhow!(
+                    "invalid batch index: site {site}, point {point}, batch shape {}x{}",
+                    batch.n_sites(),
+                    batch.n_points()
+                )
+            })
+        })
+        .collect()
+}
+
 /// TCI result wrapped with grid information.
 ///
 /// Combines a [`TensorTrain`] approximation with grid metadata so you
@@ -340,7 +354,7 @@ where
         if n_sites == 1 {
             // Single site: tensor has only site index, shape (site_dim,)
             // Need: (1, site_dim, 1)
-            tensors.push(tensor3_from_data(data, 1, site_dim, 1));
+            tensors.push(tensor3_from_data(data, 1, site_dim, 1)?);
         } else if site == 0 {
             // Root (leftmost): indices = [site, bond_01]
             // Data is column-major with shape (site_dim, bond_dim)
@@ -349,7 +363,7 @@ where
             let bond_dim = dims[1];
             // Column-major (site, bond): data[s + site_dim * b]
             // Target (1, site, bond): data[0 + 1*(s + site_dim * b)] — same layout
-            tensors.push(tensor3_from_data(data, 1, site_dim, bond_dim));
+            tensors.push(tensor3_from_data(data, 1, site_dim, bond_dim)?);
         } else if site == n_sites - 1 {
             // Leaf (rightmost): indices = [site, bond_{n-2,n-1}]
             // Data is column-major with shape (site_dim, left_bond)
@@ -363,7 +377,7 @@ where
                     permuted[l + left_bond * s] = data[s + site_dim * l];
                 }
             }
-            tensors.push(tensor3_from_data(permuted, left_bond, site_dim, 1));
+            tensors.push(tensor3_from_data(permuted, left_bond, site_dim, 1)?);
         } else {
             // Middle node: indices = [site, bond_{k,k+1}, bond_{k-1,k}]
             // Data is column-major with shape (site_dim, right_bond, left_bond)
@@ -396,7 +410,9 @@ where
                     }
                 }
             }
-            tensors.push(tensor3_from_data(permuted, left_bond, site_dim, right_bond));
+            tensors.push(tensor3_from_data(
+                permuted, left_bond, site_dim, right_bond,
+            )?);
         }
     }
 
@@ -489,12 +505,9 @@ where
     // Batch adapter: treetci expects Fn(GlobalIndexBatch) -> Result<Vec<V>>
     let batch_eval = move |batch: GlobalIndexBatch<'_>| -> Result<Vec<V>> {
         let n_points = batch.n_points();
-        let n = batch.n_sites();
         let mut results = Vec::with_capacity(n_points);
         for p in 0..n_points {
-            let point: Vec<usize> = (0..n)
-                .map(|s| batch.get(s, p).expect("valid batch index"))
-                .collect();
+            let point = point_from_batch(batch, p)?;
             results.push(qf(&point));
         }
         Ok(results)
@@ -757,34 +770,33 @@ where
 
     // Wrap function to accept quantics indices (usize 0-indexed for TCI)
     let grid_clone = grid.clone();
-    let qf = move |q: &Vec<usize>| -> V {
+    let qf = move |q: &[usize]| -> Result<V> {
         // Convert 0-indexed TCI values to 1-indexed for quanticsgrids
         let q_i64: Vec<i64> = q.iter().map(|&x| (x + 1) as i64).collect();
 
         // Check cache first
         if let Some(v) = cache_clone.borrow().get(&q_i64) {
             #[allow(clippy::clone_on_copy)]
-            return v.clone();
+            return Ok(v.clone());
         }
 
         // Compute and cache
-        let grididx = grid_clone.quantics_to_grididx(&q_i64).unwrap();
+        let grididx = grid_clone
+            .quantics_to_grididx(&q_i64)
+            .map_err(|err| anyhow!("failed to convert quantics index {q_i64:?}: {err}"))?;
         let value = f(&grididx);
         #[allow(clippy::clone_on_copy)]
         cache_clone.borrow_mut().insert(q_i64, value.clone());
-        value
+        Ok(value)
     };
 
     // Batch adapter: treetci expects Fn(GlobalIndexBatch) -> Result<Vec<V>>
     let batch_eval = move |batch: GlobalIndexBatch<'_>| -> Result<Vec<V>> {
         let n_points = batch.n_points();
-        let n = batch.n_sites();
         let mut results = Vec::with_capacity(n_points);
         for p in 0..n_points {
-            let point: Vec<usize> = (0..n)
-                .map(|s| batch.get(s, p).expect("valid batch index"))
-                .collect();
-            results.push(qf(&point));
+            let point = point_from_batch(batch, p)?;
+            results.push(qf(&point)?);
         }
         Ok(results)
     };

--- a/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
@@ -3,6 +3,17 @@ use approx::assert_relative_eq;
 use quanticsgrids::UnfoldingScheme;
 
 #[test]
+fn point_from_batch_rejects_out_of_bounds_point() {
+    let data = vec![0, 1];
+    let batch = GlobalIndexBatch::new(&data, 2, 1).unwrap();
+    let err = point_from_batch(batch, 1).unwrap_err();
+
+    assert!(err.to_string().contains("invalid batch index"));
+    assert!(err.to_string().contains("site 0"));
+    assert!(err.to_string().contains("point 1"));
+}
+
+#[test]
 fn test_discrete_simple_function() {
     // f(i, j) = i + j (grididx are 1-indexed)
     // Use 4x4 grid which gives 2 sites with Fused scheme

--- a/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
@@ -558,8 +558,7 @@ fn assert_affine_mpo_matches_matrix(r: usize, params: &AffineParams, bc: &[Bound
     let op = affine_operator(r, params, bc).unwrap();
     let actual = op.mpo.contract_to_tensor().unwrap();
     let expected = affine_matrix_to_dense_tensor(&matrix, &op, r, m, n, &actual);
-    let diff = &actual - &expected;
-    let maxabs = diff.maxabs();
+    let maxabs = actual.distance(&expected).unwrap();
 
     assert!(
         maxabs < 1e-10,

--- a/crates/tensor4all-quanticstransform/src/common.rs
+++ b/crates/tensor4all-quanticstransform/src/common.rs
@@ -217,7 +217,7 @@ pub fn tensortrain_to_linear_operator(
             }
         }
 
-        let tensor_dyn = TensorDynLen::from_dense(indices, data).unwrap();
+        let tensor_dyn = TensorDynLen::from_dense(indices, data)?;
         tensors.push(tensor_dyn);
         node_names.push(i);
     }
@@ -396,7 +396,7 @@ pub fn tensortrain_to_linear_operator_asymmetric(
             }
         }
 
-        let tensor_dyn = TensorDynLen::from_dense(indices, data).unwrap();
+        let tensor_dyn = TensorDynLen::from_dense(indices, data)?;
         tensors.push(tensor_dyn);
         node_names.push(i);
     }

--- a/crates/tensor4all-simplett/src/cache.rs
+++ b/crates/tensor4all-simplett/src/cache.rs
@@ -351,19 +351,61 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
         flat
     }
 
+    fn flat_site_dim(&self, site: usize) -> Result<usize> {
+        self.site_dims[site]
+            .iter()
+            .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+            .ok_or_else(|| TensorTrainError::InvalidOperation {
+                message: format!("Site dimension product overflowed at site {site}"),
+            })
+    }
+
+    fn validate_partial_indices(&self, start: usize, indices: &[LocalIndex]) -> Result<()> {
+        let end =
+            start
+                .checked_add(indices.len())
+                .ok_or_else(|| TensorTrainError::InvalidOperation {
+                    message: "Partial index range overflowed usize".to_string(),
+                })?;
+        if end > self.len() {
+            return Err(TensorTrainError::IndexLengthMismatch {
+                expected: self.len(),
+                got: end,
+            });
+        }
+
+        for (offset, &index) in indices.iter().enumerate() {
+            let site = start + offset;
+            let max = self.flat_site_dim(site)?;
+            if index >= max {
+                return Err(TensorTrainError::IndexOutOfBounds { site, index, max });
+            }
+        }
+
+        Ok(())
+    }
+
     /// Evaluate from the left up to (but not including) site `end`
     ///
     /// Returns a vector of size `link_dim(end-1)` (or 1 if end == 0)
-    pub fn evaluate_left(&mut self, indices: &[LocalIndex]) -> Vec<T> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `indices` spans more sites than the tensor train, if
+    /// any index is out of bounds for its site, or if the tenferro-backed
+    /// matrix-vector contraction fails.
+    pub fn evaluate_left(&mut self, indices: &[LocalIndex]) -> Result<Vec<T>> {
         let ell = indices.len();
+        self.validate_partial_indices(0, indices)?;
+
         if ell == 0 {
-            return vec![T::one()];
+            return Ok(vec![T::one()]);
         }
 
         // Check cache
         let key: MultiIndex = indices.to_vec();
         if let Some(cached) = self.cache_left[ell - 1].get(&key) {
-            return cached.clone();
+            return Ok(cached.clone());
         }
 
         // Compute recursively
@@ -374,35 +416,53 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
             tensor.slice_site(flat_idx)
         } else {
             // Recursive case: left[0..ell-1] * tensor[ell-1][:, idx, :]
-            let left = self.evaluate_left(&indices[0..ell - 1]);
+            let left = self.evaluate_left(&indices[0..ell - 1])?;
             let flat_idx = self.multi_to_flat(ell - 1, &indices[ell - 1..ell]);
             let tensor = &self.tensors[ell - 1];
             let slice = tensor.slice_site(flat_idx);
-            row_vector_times_matrix(&left, &slice, tensor.left_dim(), tensor.right_dim())
+            row_vector_times_matrix(&left, &slice, tensor.left_dim(), tensor.right_dim()).map_err(
+                |err| TensorTrainError::InvalidOperation {
+                    message: format!("Failed to evaluate left environment at site {ell}: {err}"),
+                },
+            )?
         };
 
         // Cache and return
         self.cache_left[ell - 1].insert(key, result.clone());
-        result
+        Ok(result)
     }
 
     /// Evaluate from the right starting at site `start`
     ///
     /// `indices` contains indices for sites `start` to `n-1`
     /// Returns a vector of size `link_dim(start-1)` (or 1 if start == n)
-    pub fn evaluate_right(&mut self, indices: &[LocalIndex]) -> Vec<T> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `indices` spans more sites than the tensor train, if
+    /// any index is out of bounds for its site, or if the tenferro-backed
+    /// matrix-vector contraction fails.
+    pub fn evaluate_right(&mut self, indices: &[LocalIndex]) -> Result<Vec<T>> {
         let n = self.len();
         let ell = indices.len();
+        if ell > n {
+            return Err(TensorTrainError::IndexLengthMismatch {
+                expected: n,
+                got: ell,
+            });
+        }
+
         if ell == 0 {
-            return vec![T::one()];
+            return Ok(vec![T::one()]);
         }
 
         let start = n - ell;
+        self.validate_partial_indices(start, indices)?;
 
         // Check cache
         let key: MultiIndex = indices.to_vec();
         if let Some(cached) = self.cache_right[start].get(&key) {
-            return cached.clone();
+            return Ok(cached.clone());
         }
 
         // Compute recursively
@@ -413,16 +473,20 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
             tensor.slice_site(flat_idx)
         } else {
             // Recursive case: tensor[start][:, idx, :] * right[1..]
-            let right = self.evaluate_right(&indices[1..]);
+            let right = self.evaluate_right(&indices[1..])?;
             let flat_idx = self.multi_to_flat(start, &indices[0..1]);
             let tensor = &self.tensors[start];
             let slice = tensor.slice_site(flat_idx);
-            matrix_times_col_vector(&slice, tensor.left_dim(), tensor.right_dim(), &right)
+            matrix_times_col_vector(&slice, tensor.left_dim(), tensor.right_dim(), &right).map_err(
+                |err| TensorTrainError::InvalidOperation {
+                    message: format!("Failed to evaluate right environment at site {start}: {err}"),
+                },
+            )?
         };
 
         // Cache and return
         self.cache_right[start].insert(key, result.clone());
-        result
+        Ok(result)
     }
 
     /// Evaluate the tensor train at a given index set using cache
@@ -441,8 +505,8 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
 
         // Split at midpoint for efficiency
         let mid = n / 2;
-        let left = self.evaluate_left(&indices[0..mid]);
-        let right = self.evaluate_right(&indices[mid..]);
+        let left = self.evaluate_left(&indices[0..mid])?;
+        let right = self.evaluate_right(&indices[mid..])?;
 
         // Contract left and right
         if left.len() != right.len() {
@@ -487,6 +551,15 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
         if n == 0 {
             return Err(TensorTrainError::Empty);
         }
+        for idx in indices {
+            if idx.len() != n {
+                return Err(TensorTrainError::IndexLengthMismatch {
+                    expected: n,
+                    got: idx.len(),
+                });
+            }
+            self.validate_partial_indices(0, idx)?;
+        }
 
         // Determine split position
         let split = match split {
@@ -501,7 +574,9 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
         }
 
         // Get local dimensions for flat index computation
-        let local_dims: Vec<usize> = self.site_dims.iter().map(|d| d.iter().product()).collect();
+        let local_dims: Vec<usize> = (0..n)
+            .map(|site| self.flat_site_dim(site))
+            .collect::<Result<Vec<_>>>()?;
 
         // Build index mapper with appropriate key type for each half
         let mut mapper =
@@ -525,13 +600,16 @@ impl<T: TTScalar + EinsumScalar> TTCache<T> {
             .collect();
 
         // Compute left environments for all unique left parts
-        let left_envs: Vec<Vec<T>> = unique_left.iter().map(|l| self.evaluate_left(l)).collect();
+        let left_envs: Vec<Vec<T>> = unique_left
+            .iter()
+            .map(|l| self.evaluate_left(l))
+            .collect::<Result<Vec<_>>>()?;
 
         // Compute right environments for all unique right parts
         let right_envs: Vec<Vec<T>> = unique_right
             .iter()
             .map(|r| self.evaluate_right(r))
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         // Compute results using position mappings
         let results: Vec<T> = mapper

--- a/crates/tensor4all-simplett/src/cache/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/cache/tests/mod.rs
@@ -177,6 +177,15 @@ fn test_ttcache_evaluate_wrong_length() {
 }
 
 #[test]
+fn test_ttcache_partial_environment_wrong_length_errors() {
+    let tt = TensorTrain::<f64>::constant(&[2, 3], 1.0);
+    let mut cache = TTCache::new(&tt);
+
+    assert!(cache.evaluate_left(&[0, 0, 0]).is_err());
+    assert!(cache.evaluate_right(&[0, 0, 0]).is_err());
+}
+
+#[test]
 fn test_ttcache_evaluate_many_invalid_split() {
     let tt = TensorTrain::<f64>::constant(&[2, 3], 1.0);
     let mut cache = TTCache::new(&tt);
@@ -185,6 +194,15 @@ fn test_ttcache_evaluate_many_invalid_split() {
     assert!(cache.evaluate_many(&indices, Some(0)).is_err());
     // split > n is invalid
     assert!(cache.evaluate_many(&indices, Some(10)).is_err());
+}
+
+#[test]
+fn test_ttcache_evaluate_many_wrong_index_length_errors() {
+    let tt = TensorTrain::<f64>::constant(&[2, 3], 1.0);
+    let mut cache = TTCache::new(&tt);
+
+    assert!(cache.evaluate_many(&[vec![0]], Some(1)).is_err());
+    assert!(cache.evaluate_many(&[vec![0, 0, 0]], Some(1)).is_err());
 }
 
 #[test]

--- a/crates/tensor4all-simplett/src/canonical.rs
+++ b/crates/tensor4all-simplett/src/canonical.rs
@@ -15,22 +15,24 @@ use tensor4all_tcicore::{rrlu, RrLUOptions};
 use tensor4all_tensorbackend::{mat_mul, transpose, Matrix};
 
 /// Compute QR decomposition using rank-revealing LU with left-orthogonal output
-fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> (Matrix<T>, Matrix<T>) {
+fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> Result<(Matrix<T>, Matrix<T>)> {
     let options = RrLUOptions {
         max_rank: matrix.ncols().min(matrix.nrows()),
         rel_tol: 0.0, // No truncation
         abs_tol: 0.0,
         left_orthogonal: true,
     };
-    let lu = rrlu(matrix, Some(options)).expect("rrlu failed in QR decomposition");
-    (lu.left(true), lu.right(true))
+    let lu = rrlu(matrix, Some(options)).map_err(|err| TensorTrainError::InvalidOperation {
+        message: format!("QR decomposition failed: {err}"),
+    })?;
+    Ok((lu.left(true), lu.right(true)))
 }
 
 /// Compute LQ decomposition (transpose, QR, transpose)
-fn lq_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> (Matrix<T>, Matrix<T>) {
+fn lq_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> Result<(Matrix<T>, Matrix<T>)> {
     let at = transpose(matrix);
-    let (qt, lt) = qr_decomp(&at);
-    (transpose(&lt), transpose(&qt))
+    let (qt, lt) = qr_decomp(&at)?;
+    Ok((transpose(&lt), transpose(&qt)))
 }
 
 /// Convert Tensor3 to Matrix with left dimensions flattened
@@ -131,7 +133,7 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
             center,
             partition: 0..n,
         };
-        result.canonicalize();
+        result.canonicalize()?;
         Ok(result)
     }
 
@@ -157,27 +159,28 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
     }
 
     /// Canonicalize the tensor train around the center
-    fn canonicalize(&mut self) {
+    fn canonicalize(&mut self) -> Result<()> {
         let n = self.len();
         if n <= 1 {
-            return;
+            return Ok(());
         }
 
         // Left sweep: make tensors [0..center) left-orthogonal
         for i in 0..self.center {
-            self.make_left_orthogonal(i);
+            self.make_left_orthogonal(i)?;
         }
 
         // Right sweep: make tensors (center..n] right-orthogonal
         for i in (self.center + 1..n).rev() {
-            self.make_right_orthogonal(i);
+            self.make_right_orthogonal(i)?;
         }
+        Ok(())
     }
 
     /// Make tensor at site i left-orthogonal, pushing R to site i+1
-    fn make_left_orthogonal(&mut self, i: usize) {
+    fn make_left_orthogonal(&mut self, i: usize) -> Result<()> {
         if i >= self.len() - 1 {
-            return;
+            return Ok(());
         }
 
         let left_dim = self.tensors[i].left_dim();
@@ -185,7 +188,7 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
 
         // Reshape to (left_dim * site_dim, right_dim)
         let mat = tensor3_to_left_matrix(&self.tensors[i]);
-        let (q, r) = qr_decomp(&mat);
+        let (q, r) = qr_decomp(&mat)?;
 
         let new_bond_dim = q.ncols();
 
@@ -221,12 +224,13 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
             }
         }
         self.tensors[i + 1] = new_next_tensor;
+        Ok(())
     }
 
     /// Make tensor at site i right-orthogonal, pushing L to site i-1
-    fn make_right_orthogonal(&mut self, i: usize) {
+    fn make_right_orthogonal(&mut self, i: usize) -> Result<()> {
         if i == 0 {
-            return;
+            return Ok(());
         }
 
         let site_dim = self.tensors[i].site_dim();
@@ -234,7 +238,7 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
 
         // Reshape to (left_dim, site_dim * right_dim)
         let mat = tensor3_to_right_matrix(&self.tensors[i]);
-        let (l_mat, q) = lq_decomp(&mat);
+        let (l_mat, q) = lq_decomp(&mat)?;
 
         let new_bond_dim = q.nrows();
 
@@ -267,6 +271,7 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
             }
         }
         self.tensors[i - 1] = new_prev_tensor;
+        Ok(())
     }
 
     /// Move the center one position to the right
@@ -277,7 +282,7 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
             });
         }
 
-        self.make_left_orthogonal(self.center);
+        self.make_left_orthogonal(self.center)?;
         self.center += 1;
         Ok(())
     }
@@ -290,7 +295,7 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
             });
         }
 
-        self.make_right_orthogonal(self.center);
+        self.make_right_orthogonal(self.center)?;
         self.center -= 1;
         Ok(())
     }
@@ -382,20 +387,24 @@ impl<T: TTScalar + Scalar + Default> AbstractTensorTrain<T> for SiteTensorTrain<
 /// let mut tensors: Vec<_> = tt.site_tensors().to_vec();
 ///
 /// // Canonicalize around site 1.
-/// center_canonicalize(&mut tensors, 1);
+/// center_canonicalize(&mut tensors, 1).unwrap();
 ///
 /// // Rebuild TT from the canonicalized tensors; values are preserved.
 /// let tt2 = TensorTrain::new(tensors).unwrap();
 /// let val = tt2.evaluate(&[0, 1, 0]).unwrap();
 /// assert!((val - 1.0).abs() < 1e-12);
 /// ```
+///
+/// # Errors
+///
+/// Returns an error if the underlying QR/LQ factorization fails.
 pub fn center_canonicalize<T: TTScalar + Scalar + Default>(
     tensors: &mut [Tensor3<T>],
     center: usize,
-) {
+) -> Result<()> {
     let n = tensors.len();
     if n <= 1 || center >= n {
-        return;
+        return Ok(());
     }
 
     // Left sweep: make tensors [0..center) left-orthogonal
@@ -404,7 +413,7 @@ pub fn center_canonicalize<T: TTScalar + Scalar + Default>(
         let site_dim = tensors[i].site_dim();
 
         let mat = tensor3_to_left_matrix(&tensors[i]);
-        let (q, r) = qr_decomp(&mat);
+        let (q, r) = qr_decomp(&mat)?;
 
         let new_bond_dim = q.ncols();
 
@@ -453,7 +462,7 @@ pub fn center_canonicalize<T: TTScalar + Scalar + Default>(
         let right_dim = tensors[i].right_dim();
 
         let mat = tensor3_to_right_matrix(&tensors[i]);
-        let (l_mat, q) = lq_decomp(&mat);
+        let (l_mat, q) = lq_decomp(&mat)?;
 
         let new_bond_dim = q.nrows();
 
@@ -487,6 +496,7 @@ pub fn center_canonicalize<T: TTScalar + Scalar + Default>(
             tensors[i - 1] = new_prev_tensor;
         }
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/canonical.rs
+++ b/crates/tensor4all-simplett/src/canonical.rs
@@ -212,7 +212,10 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
         let next_mat = tensor3_to_right_matrix(&self.tensors[i + 1]);
 
         // R * next_mat
-        let contracted = mat_mul(&r, &next_mat);
+        let contracted =
+            mat_mul(&r, &next_mat).map_err(|err| TensorTrainError::InvalidOperation {
+                message: format!("left-orthogonalization matrix multiply failed: {err}"),
+            })?;
 
         // Update next tensor
         let mut new_next_tensor = tensor3_zeros(new_bond_dim, next_site_dim, next_right_dim);
@@ -259,7 +262,10 @@ impl<T: TTScalar + Scalar + Default> SiteTensorTrain<T> {
         let prev_mat = tensor3_to_left_matrix(&self.tensors[i - 1]);
 
         // prev_mat * L
-        let contracted = mat_mul(&prev_mat, &l_mat);
+        let contracted =
+            mat_mul(&prev_mat, &l_mat).map_err(|err| TensorTrainError::InvalidOperation {
+                message: format!("right-orthogonalization matrix multiply failed: {err}"),
+            })?;
 
         // Update previous tensor
         let mut new_prev_tensor = tensor3_zeros(prev_left_dim, prev_site_dim, new_bond_dim);
@@ -437,7 +443,10 @@ pub fn center_canonicalize<T: TTScalar + Scalar + Default>(
             let next_right_dim = tensors[i + 1].right_dim();
             let next_mat = tensor3_to_right_matrix(&tensors[i + 1]);
 
-            let contracted = mat_mul(&r, &next_mat);
+            let contracted =
+                mat_mul(&r, &next_mat).map_err(|err| TensorTrainError::InvalidOperation {
+                    message: format!("left sweep matrix multiply failed: {err}"),
+                })?;
 
             let mut new_next_tensor = tensor3_zeros(new_bond_dim, next_site_dim, next_right_dim);
             for l in 0..new_bond_dim {
@@ -483,7 +492,10 @@ pub fn center_canonicalize<T: TTScalar + Scalar + Default>(
             let prev_site_dim = tensors[i - 1].site_dim();
             let prev_mat = tensor3_to_left_matrix(&tensors[i - 1]);
 
-            let contracted = mat_mul(&prev_mat, &l_mat);
+            let contracted =
+                mat_mul(&prev_mat, &l_mat).map_err(|err| TensorTrainError::InvalidOperation {
+                    message: format!("right sweep matrix multiply failed: {err}"),
+                })?;
 
             let mut new_prev_tensor = tensor3_zeros(prev_left_dim, prev_site_dim, new_bond_dim);
             for l in 0..prev_left_dim {

--- a/crates/tensor4all-simplett/src/canonical/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/canonical/tests/mod.rs
@@ -78,7 +78,7 @@ fn test_center_canonicalize_function_generic<T: TTScalar + Scalar + Default>() {
 
     let original_sum = tt.sum();
 
-    center_canonicalize(&mut tensors, 1);
+    center_canonicalize(&mut tensors, 1).unwrap();
 
     // Reconstruct and verify sum
     let tt_new = TensorTrain::from_tensors_unchecked(tensors);
@@ -119,6 +119,32 @@ fn test_evaluate_matches_original_generic<T: TTScalar + Scalar + Default>() {
             );
         }
     }
+}
+
+#[test]
+fn test_site_tensor_train_from_tensor_train_reports_qr_failure() {
+    let mut left = tensor3_zeros(1, 2, 1);
+    left.set3(0, 0, 0, f64::NAN);
+    left.set3(0, 1, 0, 1.0);
+    let right = tensor3_zeros(1, 2, 1);
+    let tt = TensorTrain::new(vec![left, right]).unwrap();
+
+    let err = SiteTensorTrain::from_tensor_train(&tt, 1).unwrap_err();
+
+    assert!(err.to_string().contains("QR decomposition failed"));
+}
+
+#[test]
+fn test_center_canonicalize_reports_qr_failure() {
+    let mut left = tensor3_zeros(1, 2, 1);
+    left.set3(0, 0, 0, f64::NAN);
+    left.set3(0, 1, 0, 1.0);
+    let right = tensor3_zeros(1, 2, 1);
+    let mut tensors = vec![left, right];
+
+    let err = center_canonicalize(&mut tensors, 1).unwrap_err();
+
+    assert!(err.to_string().contains("QR decomposition failed"));
 }
 
 // f64 tests

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -1,7 +1,7 @@
 //! Compression algorithms for tensor trains
 
 use crate::einsum_helper::{tensor_to_col_major_vec, typed_tensor_from_col_major_slice};
-use crate::error::Result;
+use crate::error::{Result, TensorTrainError};
 use crate::tensortrain::TensorTrain;
 use crate::traits::{AbstractTensorTrain, TTScalar};
 use crate::types::{tensor3_zeros, Tensor3, Tensor3Ops};
@@ -219,7 +219,10 @@ where
         });
     }
 
-    let a_tensor = typed_tensor_from_col_major_slice(matrix.as_col_major_slice(), &[m, n]);
+    let a_tensor = typed_tensor_from_col_major_slice(matrix.as_col_major_slice(), &[m, n])
+        .map_err(|err| TensorTrainError::InvalidOperation {
+            message: format!("Failed to prepare SVD input matrix: {err}"),
+        })?;
 
     let svd_result = tensor4all_tensorbackend::svd_backend(&a_tensor).map_err(|e| {
         crate::error::TensorTrainError::InvalidOperation {
@@ -375,7 +378,11 @@ impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
             let next_mat = tensor3_to_right_matrix(&tensors[ell + 1]);
 
             // Multiply: right_factor * next_mat
-            let contracted = mat_mul(&right_factor, &next_mat);
+            let contracted = mat_mul(&right_factor, &next_mat).map_err(|err| {
+                TensorTrainError::InvalidOperation {
+                    message: format!("left-to-right compression multiply failed: {err}"),
+                }
+            })?;
 
             // Update next tensor
             let mut new_next_tensor = tensor3_zeros(new_bond_dim, next_site_dim, next_right_dim);
@@ -425,7 +432,11 @@ impl<T: TTScalar + Scalar + Default> TensorTrain<T> {
             let prev_mat = tensor3_to_left_matrix(&tensors[ell - 1]);
 
             // Multiply: prev_mat * left_factor
-            let contracted = mat_mul(&prev_mat, &left_factor);
+            let contracted = mat_mul(&prev_mat, &left_factor).map_err(|err| {
+                TensorTrainError::InvalidOperation {
+                    message: format!("right-to-left compression multiply failed: {err}"),
+                }
+            })?;
 
             // Update prev tensor
             let mut new_prev_tensor = tensor3_zeros(prev_left_dim, prev_site_dim, new_bond_dim);

--- a/crates/tensor4all-simplett/src/contraction.rs
+++ b/crates/tensor4all-simplett/src/contraction.rs
@@ -14,6 +14,12 @@ use crate::types::Tensor3Ops;
 use tensor4all_tcicore::Scalar;
 use tensor4all_tensorbackend::Matrix;
 
+fn contraction_helper_error(context: &str, err: impl std::fmt::Display) -> TensorTrainError {
+    TensorTrainError::InvalidOperation {
+        message: format!("{context}: {err}"),
+    }
+}
+
 /// Options for MPO-MPO contraction with on-the-fly compression.
 ///
 /// # Examples
@@ -103,10 +109,11 @@ impl<T: TTScalar + Scalar + Default + EinsumScalar> TensorTrain<T> {
         let mut result = Matrix::from_col_major_vec(
             a0.right_dim(),
             b0.right_dim(),
-            tensor_to_col_major_vec(&einsum_tensors(
-                "asr,ast->rt",
-                &[a0.as_inner(), b0.as_inner()],
-            )),
+            tensor_to_col_major_vec(
+                &einsum_tensors("asr,ast->rt", &[a0.as_inner(), b0.as_inner()]).map_err(|err| {
+                    contraction_helper_error("Failed to contract first dot site", err)
+                })?,
+            ),
         );
 
         // Contract through remaining sites
@@ -128,15 +135,23 @@ impl<T: TTScalar + Scalar + Default + EinsumScalar> TensorTrain<T> {
             let result_tf = typed_tensor_from_col_major_slice(
                 result.as_col_major_slice(),
                 &[result.nrows(), result.ncols()],
-            );
+            )
+            .map_err(|err| {
+                contraction_helper_error("Failed to prepare intermediate dot environment", err)
+            })?;
 
             result = Matrix::from_col_major_vec(
                 a.right_dim(),
                 b.right_dim(),
-                tensor_to_col_major_vec(&einsum_tensors(
-                    "ij,isk,jsl->kl",
-                    &[&result_tf, a.as_inner(), b.as_inner()],
-                )),
+                tensor_to_col_major_vec(
+                    &einsum_tensors("ij,isk,jsl->kl", &[&result_tf, a.as_inner(), b.as_inner()])
+                        .map_err(|err| {
+                            contraction_helper_error(
+                                &format!("Failed to contract dot site {i}"),
+                                err,
+                            )
+                        })?,
+                ),
             );
         }
 

--- a/crates/tensor4all-simplett/src/contraction/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/contraction/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::einsum_helper::{
-    einsum_tensors, tensor_to_col_major_vec, typed_tensor_from_col_major_slice, EinsumScalar,
+    einsum_tensors, row_vector_times_matrix, tensor_to_col_major_vec,
+    typed_tensor_from_col_major_slice, EinsumScalar,
 };
 use crate::types::{tensor3_zeros, Tensor3};
 
@@ -151,9 +152,27 @@ fn test_dot_three_sites() {
 
 #[test]
 fn test_einsum_tensors_matmul() {
-    let a = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]);
-    let b = typed_tensor_from_col_major_slice(&[5.0, 7.0, 6.0, 8.0], &[2, 2]);
+    let a = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+    let b = typed_tensor_from_col_major_slice(&[5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
 
-    let c = einsum_tensors("ij,jk->ik", &[&a, &b]);
+    let c = einsum_tensors("ij,jk->ik", &[&a, &b]).unwrap();
     assert_eq!(tensor_to_col_major_vec(&c), &[19.0, 43.0, 22.0, 50.0]);
+}
+
+#[test]
+fn test_einsum_tensors_reports_backend_error() {
+    let a = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
+
+    let err = einsum_tensors("ij,jk->ik", &[&a]).unwrap_err();
+    assert!(err.to_string().contains("einsum failed"));
+    assert!(err.to_string().contains("ij,jk->ik"));
+}
+
+#[test]
+fn test_row_vector_times_matrix_reports_shape_error() {
+    let err = row_vector_times_matrix::<f64>(&[1.0], &[1.0, 2.0, 3.0, 4.0], 2, 2).unwrap_err();
+
+    assert!(err.to_string().contains("row vector length mismatch"));
+    assert!(err.to_string().contains("expected 2"));
+    assert!(err.to_string().contains("got 1"));
 }

--- a/crates/tensor4all-simplett/src/contraction/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/contraction/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::einsum_helper::{
-    einsum_tensors, row_vector_times_matrix, tensor_to_col_major_vec,
-    typed_tensor_from_col_major_slice, EinsumScalar,
+    einsum_tensors, matrix_times_col_vector, row_vector_times_matrix, tensor_to_col_major_vec,
+    typed_tensor_from_col_major_slice, typed_tensor_reshape, EinsumScalar,
 };
 use crate::types::{tensor3_zeros, Tensor3};
 
@@ -71,14 +71,20 @@ fn test_dot_different_tensors() {
 fn test_dot_length_mismatch() {
     let tt1 = TensorTrain::<f64>::constant(&[2, 3], 1.0);
     let tt2 = TensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
-    assert!(tt1.dot(&tt2).is_err());
+    let err = tt1.dot(&tt2).unwrap_err();
+    assert!(err.to_string().contains("different lengths"));
+    assert!(err.to_string().contains("2 vs 3"));
 }
 
 #[test]
 fn test_dot_site_dim_mismatch() {
     let tt1 = TensorTrain::<f64>::constant(&[2, 3], 1.0);
     let tt2 = TensorTrain::<f64>::constant(&[2, 4], 1.0);
-    assert!(tt1.dot(&tt2).is_err());
+    let err = tt1.dot(&tt2).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("Site dimensions mismatch at site 1"));
+    assert!(err.to_string().contains("3 vs 4"));
 }
 
 #[test]
@@ -99,7 +105,11 @@ fn test_dot_site_dim_mismatch_middle() {
 
     let tt_a = TensorTrain::new(vec![t0.clone(), t1_a]).unwrap();
     let tt_b = TensorTrain::new(vec![t0, t1_b]).unwrap();
-    assert!(tt_a.dot(&tt_b).is_err());
+    let err = tt_a.dot(&tt_b).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("Site dimensions mismatch at site 1"));
+    assert!(err.to_string().contains("3 vs 4"));
 }
 
 #[test]
@@ -141,6 +151,22 @@ fn test_dot_convenience_function() {
 }
 
 #[test]
+fn test_contraction_options_default_values() {
+    let opts = ContractionOptions::default();
+    assert!((opts.tolerance - 1e-12).abs() < 1e-15);
+    assert_eq!(opts.max_bond_dim, usize::MAX);
+    assert!(matches!(opts.method, CompressionMethod::LU));
+}
+
+#[test]
+fn test_contraction_helper_error_formats_context() {
+    let err = contraction_helper_error("while contracting", "backend rejected labels");
+    let message = err.to_string();
+    assert!(message.contains("while contracting"));
+    assert!(message.contains("backend rejected labels"));
+}
+
+#[test]
 fn test_dot_three_sites() {
     // Test dot product with 3 sites to exercise the inner loop more fully
     let tt1 = TensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
@@ -175,4 +201,34 @@ fn test_row_vector_times_matrix_reports_shape_error() {
     assert!(err.to_string().contains("row vector length mismatch"));
     assert!(err.to_string().contains("expected 2"));
     assert!(err.to_string().contains("got 1"));
+}
+
+#[test]
+fn test_einsum_helper_error_paths_report_context() {
+    let err = typed_tensor_from_col_major_slice::<f64>(&[], &[usize::MAX, 2]).unwrap_err();
+    assert!(err.to_string().contains("shape element count overflow"));
+
+    let err = typed_tensor_from_col_major_slice::<f64>(&[1.0, 2.0], &[3]).unwrap_err();
+    assert!(err.to_string().contains("tensor data length mismatch"));
+    assert!(err.to_string().contains("expected 3"));
+    assert!(err.to_string().contains("got 2"));
+
+    let tensor = typed_tensor_from_col_major_slice::<f64>(&[1.0, 2.0], &[2]).unwrap();
+    let err = typed_tensor_reshape(&tensor, &[3]).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("tensor reshape element count mismatch"));
+
+    let err = row_vector_times_matrix::<f64>(&[1.0, 2.0], &[1.0, 2.0, 3.0], 2, 2).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("row vector times matrix length mismatch"));
+
+    let err = matrix_times_col_vector::<f64>(&[1.0, 2.0, 3.0], 2, 2, &[1.0, 2.0]).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("matrix times column vector length mismatch"));
+
+    let err = matrix_times_col_vector::<f64>(&[1.0, 2.0, 3.0, 4.0], 2, 2, &[1.0]).unwrap_err();
+    assert!(err.to_string().contains("column vector length mismatch"));
 }

--- a/crates/tensor4all-simplett/src/einsum_helper.rs
+++ b/crates/tensor4all-simplett/src/einsum_helper.rs
@@ -1,32 +1,139 @@
+use std::error::Error;
+use std::fmt;
+
 use tenferro_einsum::typed_eager_einsum;
 use tenferro_tensor::{TensorScalar, TypedTensor};
 use tensor4all_tensorbackend::with_default_backend;
 
+pub(crate) type Result<T> = std::result::Result<T, EinsumHelperError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EinsumHelperError {
+    ShapeElementCountOverflow {
+        shape: Vec<usize>,
+    },
+    DataLengthMismatch {
+        shape: Vec<usize>,
+        expected: usize,
+        got: usize,
+    },
+    ReshapeElementCountMismatch {
+        source_shape: Vec<usize>,
+        target_shape: Vec<usize>,
+        source_elements: usize,
+        target_elements: usize,
+    },
+    VectorLengthMismatch {
+        op: &'static str,
+        expected: usize,
+        got: usize,
+    },
+    MatrixLengthMismatch {
+        op: &'static str,
+        expected: usize,
+        got: usize,
+    },
+    Backend {
+        subscripts: String,
+        message: String,
+    },
+}
+
+impl fmt::Display for EinsumHelperError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ShapeElementCountOverflow { shape } => {
+                write!(f, "shape element count overflow for shape {shape:?}")
+            }
+            Self::DataLengthMismatch {
+                shape,
+                expected,
+                got,
+            } => write!(
+                f,
+                "tensor data length mismatch for shape {shape:?}: expected {expected}, got {got}"
+            ),
+            Self::ReshapeElementCountMismatch {
+                source_shape,
+                target_shape,
+                source_elements,
+                target_elements,
+            } => write!(
+                f,
+                "tensor reshape element count mismatch from {source_shape:?} to {target_shape:?}: source has {source_elements}, target has {target_elements}"
+            ),
+            Self::VectorLengthMismatch { op, expected, got } => {
+                write!(f, "{op} length mismatch: expected {expected}, got {got}")
+            }
+            Self::MatrixLengthMismatch { op, expected, got } => {
+                write!(f, "{op} length mismatch: expected {expected}, got {got}")
+            }
+            Self::Backend {
+                subscripts,
+                message,
+            } => write!(f, "einsum failed for '{subscripts}': {message}"),
+        }
+    }
+}
+
+impl Error for EinsumHelperError {}
+
+fn shape_element_count(shape: &[usize]) -> Result<usize> {
+    shape.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| EinsumHelperError::ShapeElementCountOverflow {
+                shape: shape.to_vec(),
+            })
+    })
+}
+
 pub(crate) fn einsum_tensors<T: EinsumScalar>(
     subscripts: &str,
     operands: &[&TypedTensor<T>],
-) -> TypedTensor<T> {
-    with_default_backend(|backend| typed_eager_einsum(backend, operands, subscripts))
-        .expect("einsum failed")
+) -> Result<TypedTensor<T>> {
+    with_default_backend(|backend| typed_eager_einsum(backend, operands, subscripts)).map_err(
+        |err| EinsumHelperError::Backend {
+            subscripts: subscripts.to_string(),
+            message: err.to_string(),
+        },
+    )
 }
 
 pub(crate) fn typed_tensor_from_col_major_slice<T: TensorScalar>(
     data: &[T],
     shape: &[usize],
-) -> TypedTensor<T> {
-    assert_eq!(shape.iter().product::<usize>(), data.len());
-    TypedTensor::from_vec(shape.to_vec(), data.to_vec())
+) -> Result<TypedTensor<T>> {
+    let expected = shape_element_count(shape)?;
+    if expected != data.len() {
+        return Err(EinsumHelperError::DataLengthMismatch {
+            shape: shape.to_vec(),
+            expected,
+            got: data.len(),
+        });
+    }
+
+    Ok(TypedTensor::from_vec(shape.to_vec(), data.to_vec()))
 }
 
 pub(crate) fn typed_tensor_reshape<T: TensorScalar>(
     tensor: &TypedTensor<T>,
     shape: &[usize],
-) -> TypedTensor<T> {
-    assert_eq!(
-        shape.iter().product::<usize>(),
-        tensor.shape.iter().product::<usize>()
-    );
-    TypedTensor::from_vec(shape.to_vec(), tensor.host_data().to_vec())
+) -> Result<TypedTensor<T>> {
+    let target_elements = shape_element_count(shape)?;
+    let source_elements = shape_element_count(&tensor.shape)?;
+    if target_elements != source_elements {
+        return Err(EinsumHelperError::ReshapeElementCountMismatch {
+            source_shape: tensor.shape.clone(),
+            target_shape: shape.to_vec(),
+            source_elements,
+            target_elements,
+        });
+    }
+
+    Ok(TypedTensor::from_vec(
+        shape.to_vec(),
+        tensor.host_data().to_vec(),
+    ))
 }
 
 pub(crate) fn tensor_to_col_major_vec<T: TensorScalar>(tensor: &TypedTensor<T>) -> Vec<T> {
@@ -38,14 +145,35 @@ pub(crate) fn row_vector_times_matrix<T: EinsumScalar>(
     matrix: &[T],
     rows: usize,
     cols: usize,
-) -> Vec<T> {
-    assert_eq!(vector.len(), rows);
-    assert_eq!(matrix.len(), rows * cols);
+) -> Result<Vec<T>> {
+    if vector.len() != rows {
+        return Err(EinsumHelperError::VectorLengthMismatch {
+            op: "row vector",
+            expected: rows,
+            got: vector.len(),
+        });
+    }
 
-    let vector_tf = typed_tensor_from_col_major_slice(vector, &[rows]);
-    let matrix_tf = typed_tensor_from_col_major_slice(matrix, &[rows, cols]);
+    let expected_matrix_len =
+        rows.checked_mul(cols)
+            .ok_or_else(|| EinsumHelperError::ShapeElementCountOverflow {
+                shape: vec![rows, cols],
+            })?;
+    if matrix.len() != expected_matrix_len {
+        return Err(EinsumHelperError::MatrixLengthMismatch {
+            op: "row vector times matrix",
+            expected: expected_matrix_len,
+            got: matrix.len(),
+        });
+    }
 
-    tensor_to_col_major_vec(&einsum_tensors("l,lr->r", &[&vector_tf, &matrix_tf]))
+    let vector_tf = typed_tensor_from_col_major_slice(vector, &[rows])?;
+    let matrix_tf = typed_tensor_from_col_major_slice(matrix, &[rows, cols])?;
+
+    Ok(tensor_to_col_major_vec(&einsum_tensors(
+        "l,lr->r",
+        &[&vector_tf, &matrix_tf],
+    )?))
 }
 
 pub(crate) fn matrix_times_col_vector<T: EinsumScalar>(
@@ -53,14 +181,34 @@ pub(crate) fn matrix_times_col_vector<T: EinsumScalar>(
     rows: usize,
     cols: usize,
     vector: &[T],
-) -> Vec<T> {
-    assert_eq!(matrix.len(), rows * cols);
-    assert_eq!(vector.len(), cols);
+) -> Result<Vec<T>> {
+    let expected_matrix_len =
+        rows.checked_mul(cols)
+            .ok_or_else(|| EinsumHelperError::ShapeElementCountOverflow {
+                shape: vec![rows, cols],
+            })?;
+    if matrix.len() != expected_matrix_len {
+        return Err(EinsumHelperError::MatrixLengthMismatch {
+            op: "matrix times column vector",
+            expected: expected_matrix_len,
+            got: matrix.len(),
+        });
+    }
+    if vector.len() != cols {
+        return Err(EinsumHelperError::VectorLengthMismatch {
+            op: "column vector",
+            expected: cols,
+            got: vector.len(),
+        });
+    }
 
-    let matrix_tf = typed_tensor_from_col_major_slice(matrix, &[rows, cols]);
-    let vector_tf = typed_tensor_from_col_major_slice(vector, &[cols]);
+    let matrix_tf = typed_tensor_from_col_major_slice(matrix, &[rows, cols])?;
+    let vector_tf = typed_tensor_from_col_major_slice(vector, &[cols])?;
 
-    tensor_to_col_major_vec(&einsum_tensors("lr,r->l", &[&matrix_tf, &vector_tf]))
+    Ok(tensor_to_col_major_vec(&einsum_tensors(
+        "lr,r->l",
+        &[&matrix_tf, &vector_tf],
+    )?))
 }
 
 /// Scalar types supported by the tenferro-backed einsum helpers used in

--- a/crates/tensor4all-simplett/src/error.rs
+++ b/crates/tensor4all-simplett/src/error.rs
@@ -60,6 +60,15 @@ pub enum TensorTrainError {
     #[error("Tensor train is empty")]
     Empty,
 
+    /// Flat tensor data did not match the requested shape.
+    #[error("Tensor data length mismatch: expected {expected} elements, got {got}")]
+    DataLengthMismatch {
+        /// The element count implied by the requested shape.
+        expected: usize,
+        /// The number of elements supplied by the caller.
+        got: usize,
+    },
+
     /// Invalid operation
     #[error("Invalid operation: {message}")]
     InvalidOperation {

--- a/crates/tensor4all-simplett/src/mpo/contract_fit.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit.rs
@@ -116,12 +116,14 @@ where
 
     // Build initial right environments
     for i in (1..n).rev() {
-        right_envs[i - 1] = Some(build_right_environment(
+        let next_env = require_environment(&right_envs, i, "right")?;
+        let env = build_right_environment(
             mpo_a.site_tensor(i),
             mpo_b.site_tensor(i),
             result.site_tensor(i),
-            right_envs[i].as_ref().unwrap(),
-        )?);
+            next_env,
+        )?;
+        right_envs[i - 1] = Some(env);
     }
 
     let mut current = result;
@@ -143,12 +145,14 @@ where
             )?;
 
             // Update left environment at i+1
-            left_envs[i + 1] = Some(build_left_environment(
+            let prev_env = require_environment(&left_envs, i, "left")?;
+            let env = build_left_environment(
                 mpo_a.site_tensor(i),
                 mpo_b.site_tensor(i),
                 current.site_tensor(i),
-                left_envs[i].as_ref().unwrap(),
-            )?);
+                prev_env,
+            )?;
+            left_envs[i + 1] = Some(env);
         }
 
         // Backward sweep (right to left)
@@ -166,12 +170,14 @@ where
 
             // Update right environment at i-1
             if i > 0 {
-                right_envs[i - 1] = Some(build_right_environment(
+                let next_env = require_environment(&right_envs, i, "right")?;
+                let env = build_right_environment(
                     mpo_a.site_tensor(i),
                     mpo_b.site_tensor(i),
                     current.site_tensor(i),
-                    right_envs[i].as_ref().unwrap(),
-                )?);
+                    next_env,
+                )?;
+                right_envs[i - 1] = Some(env);
             }
         }
 
@@ -222,6 +228,18 @@ where
     fn set(&mut self, r: usize, a: usize, b: usize, val: T) {
         self.data[(r * self.dim_a + a) * self.dim_b + b] = val;
     }
+}
+
+fn require_environment<'a, T>(
+    envs: &'a [Option<Environment<T>>],
+    site: usize,
+    side: &'static str,
+) -> Result<&'a Environment<T>> {
+    envs.get(site)
+        .and_then(Option::as_ref)
+        .ok_or_else(|| MPOError::InvalidOperation {
+            message: format!("missing {side} environment at site {site}"),
+        })
 }
 
 /// Build left environment by extending from previous environment

--- a/crates/tensor4all-simplett/src/mpo/contract_fit/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit/tests/mod.rs
@@ -3,7 +3,7 @@ use super::super::types::tensor4_from_data;
 use super::*;
 
 fn scalar_tensor4(value: f64) -> Tensor4<f64> {
-    tensor4_from_data(vec![value], 1, 1, 1, 1)
+    tensor4_from_data(vec![value], 1, 1, 1, 1).unwrap()
 }
 
 #[test]
@@ -66,6 +66,17 @@ fn test_environment_identity_get_and_set() {
 
     let scalar_env = Environment::<f64>::identity(1, 1, 1);
     assert_eq!(scalar_env.get(0, 0, 0), 1.0);
+}
+
+#[test]
+fn missing_environment_returns_typed_error() {
+    let envs: Vec<Option<Environment<f64>>> = vec![None];
+    let err = require_environment(&envs, 0, "left").unwrap_err();
+
+    assert!(matches!(err, MPOError::InvalidOperation { .. }));
+    assert!(err
+        .to_string()
+        .contains("missing left environment at site 0"));
 }
 
 #[test]

--- a/crates/tensor4all-simplett/src/mpo/environment.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment.rs
@@ -60,7 +60,7 @@ where
     let contracted = einsum_tensors("askr,bktq->bastqr", &[a.as_inner(), b.as_inner()]);
     let reshaped = typed_tensor_reshape(&contracted, &[new_left, new_s1, new_s2, new_right]);
 
-    Ok(Tensor4::from_tenferro(reshaped))
+    Ok(Tensor4::from_tenferro_unchecked(reshaped))
 }
 
 /// Compute the left environment at site i for MPO contraction
@@ -94,8 +94,8 @@ where
     }
 
     // Check cache
-    if site <= cache.len() && cache[site - 1].is_some() {
-        return Ok(cache[site - 1].as_ref().unwrap().clone());
+    if let Some(Some(cached)) = cache.get(site - 1) {
+        return Ok(cached.clone());
     }
 
     // Recursively compute from the left
@@ -120,7 +120,7 @@ where
         });
     }
 
-    let new_env = Matrix2::from_tenferro(einsum_tensors(
+    let new_env = Matrix2::from_tenferro_unchecked(einsum_tensors(
         "ab,asdr,bsdt->rt",
         &[prev_env.as_inner(), a.as_inner(), b.as_inner()],
     ));
@@ -168,8 +168,8 @@ where
 
     // Check cache
     let cache_idx = n - site - 2;
-    if cache_idx < cache.len() && cache[cache_idx].is_some() {
-        return Ok(cache[cache_idx].as_ref().unwrap().clone());
+    if let Some(Some(cached)) = cache.get(cache_idx) {
+        return Ok(cached.clone());
     }
 
     // Recursively compute from the right
@@ -194,7 +194,7 @@ where
         });
     }
 
-    let new_env = Matrix2::from_tenferro(einsum_tensors(
+    let new_env = Matrix2::from_tenferro_unchecked(einsum_tensors(
         "rt,asdr,bsdt->ab",
         &[prev_env.as_inner(), a.as_inner(), b.as_inner()],
     ));

--- a/crates/tensor4all-simplett/src/mpo/environment.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment.rs
@@ -10,6 +10,13 @@ use super::factorize::SVDScalar;
 use super::mpo::MPO;
 use super::types::{Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
+
+fn mpo_helper_error(context: &str, err: impl std::fmt::Display) -> MPOError {
+    MPOError::InvalidOperation {
+        message: format!("{context}: {err}"),
+    }
+}
+
 /// Contract two 4D site tensors over their shared physical index
 ///
 /// Given two 4D tensors:
@@ -57,10 +64,13 @@ where
     // TODO: Remove this materialization once tenferro supports reshaping
     // layout-compatible strided views directly.
     // Tracking issue: https://github.com/tensor4all/tenferro-rs/issues/575
-    let contracted = einsum_tensors("askr,bktq->bastqr", &[a.as_inner(), b.as_inner()]);
-    let reshaped = typed_tensor_reshape(&contracted, &[new_left, new_s1, new_s2, new_right]);
+    let contracted = einsum_tensors("askr,bktq->bastqr", &[a.as_inner(), b.as_inner()])
+        .map_err(|err| mpo_helper_error("Failed to contract MPO site tensors", err))?;
+    let reshaped = typed_tensor_reshape(&contracted, &[new_left, new_s1, new_s2, new_right])
+        .map_err(|err| mpo_helper_error("Failed to reshape contracted MPO site tensor", err))?;
 
-    Ok(Tensor4::from_tenferro_unchecked(reshaped))
+    Tensor4::from_tenferro(reshaped)
+        .map_err(|err| mpo_helper_error("Contracted MPO site tensor has invalid rank", err))
 }
 
 /// Compute the left environment at site i for MPO contraction
@@ -120,10 +130,13 @@ where
         });
     }
 
-    let new_env = Matrix2::from_tenferro_unchecked(einsum_tensors(
+    let new_env_tensor = einsum_tensors(
         "ab,asdr,bsdt->rt",
         &[prev_env.as_inner(), a.as_inner(), b.as_inner()],
-    ));
+    )
+    .map_err(|err| mpo_helper_error("Failed to compute left MPO environment", err))?;
+    let new_env = Matrix2::from_tenferro(new_env_tensor)
+        .map_err(|err| mpo_helper_error("Left MPO environment has invalid rank", err))?;
 
     // Update cache
     while cache.len() < site {
@@ -194,10 +207,13 @@ where
         });
     }
 
-    let new_env = Matrix2::from_tenferro_unchecked(einsum_tensors(
+    let new_env_tensor = einsum_tensors(
         "rt,asdr,bsdt->ab",
         &[prev_env.as_inner(), a.as_inner(), b.as_inner()],
-    ));
+    )
+    .map_err(|err| mpo_helper_error("Failed to compute right MPO environment", err))?;
+    let new_env = Matrix2::from_tenferro(new_env_tensor)
+        .map_err(|err| mpo_helper_error("Right MPO environment has invalid rank", err))?;
 
     // Update cache
     while cache.len() <= cache_idx {

--- a/crates/tensor4all-simplett/src/mpo/environment/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment/tests/mod.rs
@@ -29,6 +29,17 @@ fn test_contract_site_tensors() {
 }
 
 #[test]
+fn test_contract_site_tensors_rejects_shared_dimension_mismatch() {
+    let a: Tensor4<f64> = tensor4_zeros(1, 2, 3, 1);
+    let b: Tensor4<f64> = tensor4_zeros(1, 4, 2, 1);
+
+    let err = contract_site_tensors(&a, &b).unwrap_err();
+    assert!(err.to_string().contains("Shared dimension mismatch"));
+    assert!(err.to_string().contains("3"));
+    assert!(err.to_string().contains("4"));
+}
+
+#[test]
 fn test_contract_site_tensors_preserves_combined_bond_order() {
     let mut a: Tensor4<f64> = tensor4_zeros(2, 1, 2, 2);
     let mut b: Tensor4<f64> = tensor4_zeros(2, 2, 1, 2);
@@ -87,6 +98,9 @@ fn test_left_environment() {
     let env1 = left_environment(&mpo_a, &mpo_b, 1, &mut cache).unwrap();
     // Each element contributes 1*1 = 1, sum over 2*2=4 physical indices
     assert!((env1[[0, 0]] - 4.0).abs() < 1e-10);
+
+    let cached = left_environment(&mpo_a, &mpo_b, 1, &mut cache).unwrap();
+    assert_eq!(cached[[0, 0]], env1[[0, 0]]);
 }
 
 #[test]
@@ -104,4 +118,39 @@ fn test_right_environment() {
     let env0 = right_environment(&mpo_a, &mpo_b, 0, &mut cache).unwrap();
     // Each element contributes 1*1 = 1, sum over 2*2=4 physical indices
     assert!((env0[[0, 0]] - 4.0).abs() < 1e-10);
+
+    let cached = right_environment(&mpo_a, &mpo_b, 0, &mut cache).unwrap();
+    assert_eq!(cached[[0, 0]], env0[[0, 0]]);
+}
+
+#[test]
+fn test_environment_reports_length_and_dimension_errors() {
+    let mpo_a = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+    let mpo_short = MPO::<f64>::constant(&[(2, 2)], 1.0);
+    let mut cache = Vec::new();
+
+    let err = left_environment(&mpo_a, &mpo_short, 1, &mut cache).unwrap_err();
+    assert!(err.to_string().contains("length mismatch"));
+
+    let mut cache = Vec::new();
+    let err = right_environment(&mpo_a, &mpo_short, 0, &mut cache).unwrap_err();
+    assert!(err.to_string().contains("length mismatch"));
+
+    let mpo_mismatch = MPO::<f64>::constant(&[(2, 3), (2, 2)], 1.0);
+    let mut cache = Vec::new();
+    let err = left_environment(&mpo_a, &mpo_mismatch, 1, &mut cache).unwrap_err();
+    assert!(err.to_string().contains("Shared dimension mismatch"));
+
+    let mpo_mismatch_right = MPO::<f64>::constant(&[(2, 2), (2, 3)], 1.0);
+    let mut cache = Vec::new();
+    let err = right_environment(&mpo_a, &mpo_mismatch_right, 0, &mut cache).unwrap_err();
+    assert!(err.to_string().contains("Shared dimension mismatch"));
+}
+
+#[test]
+fn test_mpo_helper_error_formats_context() {
+    let err = mpo_helper_error("while building environment", "invalid rank");
+    let message = err.to_string();
+    assert!(message.contains("while building environment"));
+    assert!(message.contains("invalid rank"));
 }

--- a/crates/tensor4all-simplett/src/mpo/error.rs
+++ b/crates/tensor4all-simplett/src/mpo/error.rs
@@ -61,6 +61,15 @@ pub enum MPOError {
     #[error("MPO is empty")]
     Empty,
 
+    /// Flat tensor data did not match the requested shape.
+    #[error("Tensor data length mismatch: expected {expected} elements, got {got}")]
+    DataLengthMismatch {
+        /// The element count implied by the requested shape.
+        expected: usize,
+        /// The number of elements supplied by the caller.
+        got: usize,
+    },
+
     /// Invalid boundary conditions
     #[error("Invalid boundary conditions: first tensor must have left_dim=1, last tensor must have right_dim=1")]
     InvalidBoundary,

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -147,7 +147,7 @@ where
         });
     }
 
-    Ok(Matrix2::from_tenferro(tensor.clone()))
+    Ok(Matrix2::from_tenferro_unchecked(tensor.clone()))
 }
 
 fn typed_col_major_values<T>(tensor: &TypedTensor<T>, op: &'static str) -> Result<Vec<T>>

--- a/crates/tensor4all-simplett/src/mpo/inverse_mpo/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/inverse_mpo/tests/mod.rs
@@ -2,7 +2,7 @@ use super::super::types::tensor4_from_data;
 use super::*;
 
 fn sample_tensor4(scale: f64) -> Tensor4<f64> {
-    tensor4_from_data(vec![scale, scale + 1.0], 1, 1, 2, 1)
+    tensor4_from_data(vec![scale, scale + 1.0], 1, 1, 2, 1).unwrap()
 }
 
 #[test]

--- a/crates/tensor4all-simplett/src/mpo/mpo.rs
+++ b/crates/tensor4all-simplett/src/mpo/mpo.rs
@@ -279,7 +279,10 @@ impl<T: TTScalar> MPO<T> {
 
             let slice = tensor.slice_site(i_k, j_k);
             current =
-                row_vector_times_matrix(&current, &slice, tensor.left_dim(), tensor.right_dim());
+                row_vector_times_matrix(&current, &slice, tensor.left_dim(), tensor.right_dim())
+                    .map_err(|err| MPOError::InvalidOperation {
+                        message: format!("Failed to evaluate MPO at site {site}: {err}"),
+                    })?;
         }
 
         // Should have a single element
@@ -296,29 +299,70 @@ impl<T: TTScalar> MPO<T> {
     }
 
     /// Sum over all indices of the MPO
+    ///
+    /// Returns the scalar sum of every matrix-product-operator entry. Use this
+    /// for small validation checks or algorithms that need the total operator
+    /// weight without materializing the full operator.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a tenferro-backed contraction fails or if an
+    /// internally constructed MPO has inconsistent bond dimensions.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_simplett::mpo::MPO;
+    ///
+    /// let mpo = MPO::<f64>::constant(&[(2, 2)], 3.0);
+    /// let sum = mpo.sum().unwrap();
+    /// assert!((sum - 12.0).abs() < 1e-10);
+    /// ```
     #[allow(clippy::needless_range_loop)]
-    pub fn sum(&self) -> T
+    pub fn sum(&self) -> Result<T>
     where
         T: EinsumScalar,
     {
         if self.is_empty() {
-            return T::zero();
+            return Ok(T::zero());
         }
 
         // Start with sum over first tensor
         let first = &self.tensors[0];
-        let mut current = tensor_to_col_major_vec(&einsum_tensors("lstr->r", &[first.as_inner()]));
+        let mut current =
+            tensor_to_col_major_vec(&einsum_tensors("lstr->r", &[first.as_inner()]).map_err(
+                |err| MPOError::InvalidOperation {
+                    message: format!("Failed to sum first MPO site: {err}"),
+                },
+            )?);
 
         // Contract with sums of remaining tensors
         for site in 1..self.len() {
             let tensor = &self.tensors[site];
-            let site_sum =
-                tensor_to_col_major_vec(&einsum_tensors("lstr->lr", &[tensor.as_inner()]));
+            let site_sum = tensor_to_col_major_vec(
+                &einsum_tensors("lstr->lr", &[tensor.as_inner()]).map_err(|err| {
+                    MPOError::InvalidOperation {
+                        message: format!("Failed to sum MPO site {site}: {err}"),
+                    }
+                })?,
+            );
             current =
-                row_vector_times_matrix(&current, &site_sum, tensor.left_dim(), tensor.right_dim());
+                row_vector_times_matrix(&current, &site_sum, tensor.left_dim(), tensor.right_dim())
+                    .map_err(|err| MPOError::InvalidOperation {
+                        message: format!("Failed to accumulate MPO sum at site {site}: {err}"),
+                    })?;
         }
 
-        current[0]
+        if current.len() != 1 {
+            return Err(MPOError::InvalidOperation {
+                message: format!(
+                    "Final MPO sum contraction resulted in {} elements, expected 1",
+                    current.len()
+                ),
+            });
+        }
+
+        Ok(current[0])
     }
 
     /// Multiply the MPO by a scalar

--- a/crates/tensor4all-simplett/src/mpo/mpo.rs
+++ b/crates/tensor4all-simplett/src/mpo/mpo.rs
@@ -48,8 +48,10 @@ impl<T: TTScalar> MPO<T> {
         }
 
         // Last tensor should have right_dim = 1
-        if !tensors.is_empty() && tensors.last().unwrap().right_dim() != 1 {
-            return Err(MPOError::InvalidBoundary);
+        if let Some(last) = tensors.last() {
+            if last.right_dim() != 1 {
+                return Err(MPOError::InvalidBoundary);
+            }
         }
 
         Ok(Self { tensors })

--- a/crates/tensor4all-simplett/src/mpo/mpo/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mpo/tests/mod.rs
@@ -19,6 +19,46 @@ fn test_mpo_constant() {
 }
 
 #[test]
+fn test_mpo_new_rejects_invalid_structure() {
+    let left: Tensor4<f64> = tensor4_zeros(1, 2, 2, 2);
+    let right: Tensor4<f64> = tensor4_zeros(3, 2, 2, 1);
+    let err = MPO::new(vec![left, right]).unwrap_err();
+    assert!(err.to_string().contains("Bond dimension mismatch"));
+
+    let bad_left: Tensor4<f64> = tensor4_zeros(2, 2, 2, 1);
+    let err = MPO::new(vec![bad_left]).unwrap_err();
+    assert!(err.to_string().contains("Invalid boundary"));
+
+    let bad_right: Tensor4<f64> = tensor4_zeros(1, 2, 2, 2);
+    let err = MPO::new(vec![bad_right]).unwrap_err();
+    assert!(err.to_string().contains("Invalid boundary"));
+}
+
+#[test]
+fn test_mpo_empty_and_single_site_constructors() {
+    let empty = MPO::<f64>::constant(&[], 3.0);
+    assert!(empty.is_empty());
+    assert_eq!(empty.link_dims(), Vec::<usize>::new());
+    assert_eq!(empty.rank(), 1);
+    assert_eq!(empty.fulltensor(), (Vec::new(), Vec::new()));
+    assert_eq!(empty.sum().unwrap(), 0.0);
+    assert!(empty
+        .evaluate(&[])
+        .unwrap_err()
+        .to_string()
+        .contains("MPO is empty"));
+
+    let single = MPO::<f64>::constant(&[(2, 3)], 4.0);
+    assert_eq!(single.site_dim(0), (2, 3));
+    assert_eq!(single.link_dims(), Vec::<usize>::new());
+    assert_eq!(single.evaluate(&[1, 2]).unwrap(), 4.0);
+    assert_eq!(single.scaled(0.5).evaluate(&[1, 2]).unwrap(), 2.0);
+
+    let identity_empty = MPO::<f64>::identity(&[]).unwrap();
+    assert!(identity_empty.is_empty());
+}
+
+#[test]
 fn test_mpo_identity() {
     let mpo = MPO::<f64>::identity(&[2, 3]).unwrap();
     assert_eq!(mpo.len(), 2);
@@ -54,6 +94,30 @@ fn test_mpo_evaluate() {
     assert!((mpo.evaluate(&[0, 0, 0, 0]).unwrap() - 1.0).abs() < 1e-10);
     // evaluate([1, 1, 0, 1]) = t0[0, 1, 1, 0] * t1[0, 0, 1, 0] = 4 * 0.5 = 2
     assert!((mpo.evaluate(&[1, 1, 0, 1]).unwrap() - 2.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_mpo_evaluate_reports_invalid_indices() {
+    let mpo = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+
+    let err = mpo.evaluate(&[0, 0, 0]).unwrap_err();
+    assert!(err.to_string().contains("Expected 4 indices"));
+
+    let err = mpo.evaluate(&[2, 0, 0, 0]).unwrap_err();
+    assert!(err.to_string().contains("Index out of bounds"));
+    assert!(err.to_string().contains("site 0"));
+
+    let err = mpo.evaluate(&[0, 0, 0, 2]).unwrap_err();
+    assert!(err.to_string().contains("Index out of bounds"));
+    assert!(err.to_string().contains("site 1"));
+}
+
+#[test]
+fn test_mpo_fulltensor_zero_dimension_returns_shape() {
+    let mpo = MPO::<f64>::zeros(&[(0, 2)]);
+    let (data, shape) = mpo.fulltensor();
+    assert!(data.is_empty());
+    assert_eq!(shape, vec![0, 2]);
 }
 
 #[test]

--- a/crates/tensor4all-simplett/src/mpo/mpo/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mpo/tests/mod.rs
@@ -14,7 +14,7 @@ fn test_mpo_constant() {
     assert_eq!(mpo.len(), 2);
 
     // Sum should be 5.0 * (2*2) * (2*2) = 5.0 * 4 * 4 = 80.0
-    let sum = mpo.sum();
+    let sum = mpo.sum().unwrap();
     assert!((sum - 80.0).abs() < 1e-10);
 }
 
@@ -62,7 +62,7 @@ fn test_mpo_scale() {
     mpo.scale(3.0);
 
     // Sum should be 3.0 * (2*2) * (2*2) = 3.0 * 16 = 48.0
-    let sum = mpo.sum();
+    let sum = mpo.sum().unwrap();
     assert!((sum - 48.0).abs() < 1e-10);
 }
 

--- a/crates/tensor4all-simplett/src/mpo/site_mpo/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/site_mpo/tests/mod.rs
@@ -70,14 +70,14 @@ fn test_set_center_out_of_bounds() {
 #[test]
 fn test_into_mpo_round_trip() {
     let mpo = MPO::<f64>::constant(&[(2, 2), (3, 3)], 5.0);
-    let original_sum = mpo.sum();
+    let original_sum = mpo.sum().unwrap();
     let original_dims = mpo.site_dims();
 
     let site_mpo = SiteMPO::from_mpo(mpo, 0).unwrap();
     let recovered = site_mpo.into_mpo();
 
     assert_eq!(recovered.site_dims(), original_dims);
-    assert!((recovered.sum() - original_sum).abs() < 1e-10);
+    assert!((recovered.sum().unwrap() - original_sum).abs() < 1e-10);
 }
 
 #[test]

--- a/crates/tensor4all-simplett/src/mpo/types.rs
+++ b/crates/tensor4all-simplett/src/mpo/types.rs
@@ -10,6 +10,8 @@ use crate::tensor::Tensor;
 pub use crate::tensor::Tensor4;
 use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
 
+use super::error::{MPOError, Result};
+
 /// Local index type (index within a single tensor site)
 pub type LocalIndex = usize;
 
@@ -172,11 +174,17 @@ pub fn tensor4_from_data<T: TensorScalar>(
     site_dim_1: usize,
     site_dim_2: usize,
     right_dim: usize,
-) -> Tensor4<T> {
-    assert_eq!(data.len(), left_dim * site_dim_1 * site_dim_2 * right_dim);
+) -> Result<Tensor4<T>> {
+    let expected = left_dim * site_dim_1 * site_dim_2 * right_dim;
+    if data.len() != expected {
+        return Err(MPOError::DataLengthMismatch {
+            expected,
+            got: data.len(),
+        });
+    }
     let dims = [left_dim, site_dim_1, site_dim_2, right_dim];
     let inner = TfTensor::from_vec(dims.to_vec(), data);
-    Tensor::from_tenferro_unchecked(inner)
+    Ok(Tensor::from_tenferro_unchecked(inner))
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/types.rs
+++ b/crates/tensor4all-simplett/src/mpo/types.rs
@@ -176,7 +176,7 @@ pub fn tensor4_from_data<T: TensorScalar>(
     assert_eq!(data.len(), left_dim * site_dim_1 * site_dim_2 * right_dim);
     let dims = [left_dim, site_dim_1, site_dim_2, right_dim];
     let inner = TfTensor::from_vec(dims.to_vec(), data);
-    Tensor::from_tenferro(inner)
+    Tensor::from_tenferro_unchecked(inner)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/types/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/types/tests/mod.rs
@@ -31,7 +31,7 @@ fn test_tensor4_get_set() {
 #[test]
 fn test_tensor4_from_data() {
     let data: Vec<f64> = (0..24).map(|x| x as f64).collect();
-    let t = tensor4_from_data(data, 2, 3, 2, 2);
+    let t = tensor4_from_data(data, 2, 3, 2, 2).unwrap();
 
     assert_eq!(t.left_dim(), 2);
     assert_eq!(t.site_dim_1(), 3);
@@ -45,6 +45,14 @@ fn test_tensor4_from_data() {
     assert_eq!(*t.get4(0, 0, 1, 0), 6.0);
     assert_eq!(*t.get4(0, 0, 0, 1), 12.0);
     assert_eq!(*t.get4(1, 2, 1, 1), 23.0);
+}
+
+#[test]
+fn tensor4_from_data_rejects_length_mismatch() {
+    let err = tensor4_from_data(vec![1.0, 2.0], 1, 2, 2, 1).unwrap_err();
+
+    assert!(err.to_string().contains("expected 4 elements"));
+    assert!(err.to_string().contains("got 2"));
 }
 
 #[test]
@@ -66,7 +74,8 @@ fn test_slice_site() {
 
 #[test]
 fn test_as_left_matrix() {
-    let t: Tensor4<f64> = tensor4_from_data((0..24).map(|x| x as f64).collect(), 2, 3, 2, 2);
+    let t: Tensor4<f64> =
+        tensor4_from_data((0..24).map(|x| x as f64).collect(), 2, 3, 2, 2).unwrap();
 
     let (mat, rows, cols) = t.as_left_matrix();
     assert_eq!(rows, 12); // 2 * 3 * 2
@@ -76,7 +85,8 @@ fn test_as_left_matrix() {
 
 #[test]
 fn test_as_right_matrix() {
-    let t: Tensor4<f64> = tensor4_from_data((0..24).map(|x| x as f64).collect(), 2, 3, 2, 2);
+    let t: Tensor4<f64> =
+        tensor4_from_data((0..24).map(|x| x as f64).collect(), 2, 3, 2, 2).unwrap();
 
     let (mat, rows, cols) = t.as_right_matrix();
     assert_eq!(rows, 2);
@@ -86,7 +96,8 @@ fn test_as_right_matrix() {
 
 #[test]
 fn test_as_center_matrix() {
-    let t: Tensor4<f64> = tensor4_from_data((0..24).map(|x| x as f64).collect(), 2, 3, 2, 2);
+    let t: Tensor4<f64> =
+        tensor4_from_data((0..24).map(|x| x as f64).collect(), 2, 3, 2, 2).unwrap();
 
     let (mat, rows, cols) = t.as_center_matrix();
     assert_eq!(rows, 6); // 2 * 3

--- a/crates/tensor4all-simplett/src/mpo/vidal_mpo/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/vidal_mpo/tests/mod.rs
@@ -2,7 +2,7 @@ use super::super::types::tensor4_from_data;
 use super::*;
 
 fn sample_tensor4(scale: f64) -> Tensor4<f64> {
-    tensor4_from_data(vec![scale, scale + 1.0], 1, 1, 2, 1)
+    tensor4_from_data(vec![scale, scale + 1.0], 1, 1, 2, 1).unwrap()
 }
 
 #[test]

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -8,7 +8,7 @@ use std::ops::{Index, IndexMut};
 
 use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
 
-use crate::einsum_helper::{tensor_to_col_major_vec, typed_tensor_from_col_major_slice};
+use crate::einsum_helper::tensor_to_col_major_vec;
 use crate::error::{Result, TensorTrainError};
 
 /// Rank-N tensor backed by `tenferro_tensor::TypedTensor<T>`.
@@ -61,7 +61,7 @@ fn col_major_data_to_tensor<T: TensorScalar, const N: usize>(
     dims: [usize; N],
     data: Vec<T>,
 ) -> Tensor<T, N> {
-    let inner = typed_tensor_from_col_major_slice(&data, &dims);
+    let inner = TfTensor::from_vec(dims.to_vec(), data);
     Tensor::from_tenferro_unchecked(inner)
 }
 
@@ -381,7 +381,8 @@ mod tests {
 
     #[test]
     fn test_from_tenferro_roundtrip() {
-        let inner = typed_tensor_from_col_major_slice(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], &[2, 3]);
+        let inner =
+            typed_tensor_from_col_major_slice(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], &[2, 3]).unwrap();
         let tensor = Tensor2::from_tenferro(inner).unwrap();
 
         assert_eq!(tensor.dims(), &[2, 3]);
@@ -398,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_from_tenferro_rank_mismatch_errors() {
-        let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]);
+        let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
         let err = Tensor3::from_tenferro(inner).unwrap_err();
 
         assert!(err.to_string().contains("expected rank 3"));
@@ -407,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_try_from_tenferro_rank_mismatch_errors() {
-        let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]);
+        let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
         let err = Tensor3::try_from_tenferro(inner).unwrap_err();
 
         assert!(err.to_string().contains("expected rank 3"));

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -9,6 +9,7 @@ use std::ops::{Index, IndexMut};
 use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
 
 use crate::einsum_helper::{tensor_to_col_major_vec, typed_tensor_from_col_major_slice};
+use crate::error::{Result, TensorTrainError};
 
 /// Rank-N tensor backed by `tenferro_tensor::TypedTensor<T>`.
 #[derive(Debug)]
@@ -190,15 +191,45 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
         self.0
     }
 
-    /// Wrap an existing tenferro tensor, panicking on rank mismatch.
-    pub fn from_tenferro(tensor: TfTensor<T>) -> Self {
+    /// Try to wrap an existing tenferro tensor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tensor rank does not match `N`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_simplett::tensor::{Tensor2, Tensor3};
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let rank_2 = TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// let tensor = Tensor2::try_from_tenferro(rank_2).unwrap();
+    /// assert_eq!(tensor.dims(), &[2, 2]);
+    ///
+    /// let rank_2 = TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// assert!(Tensor3::try_from_tenferro(rank_2).is_err());
+    /// ```
+    pub fn try_from_tenferro(tensor: TfTensor<T>) -> Result<Self> {
         if tensor.shape.len() != N {
-            panic!(
-                "tensor rank mismatch: expected rank {N}, got {}",
-                tensor.shape.len()
-            );
+            return Err(TensorTrainError::InvalidOperation {
+                message: format!(
+                    "tensor rank mismatch: expected rank {N}, got {}",
+                    tensor.shape.len()
+                ),
+            });
         }
-        Self(tensor)
+        Ok(Self(tensor))
+    }
+
+    /// Wrap an existing tenferro tensor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tensor rank does not match `N`. Use
+    /// [`Tensor::try_from_tenferro`] to handle rank mismatch as an error.
+    pub fn from_tenferro(tensor: TfTensor<T>) -> Self {
+        Self::try_from_tenferro(tensor).unwrap_or_else(|err| panic!("{err}"))
     }
 
     /// Create a tensor by applying `f` to each multi-index (column-major order).
@@ -326,6 +357,15 @@ mod tests {
     fn test_from_tenferro_rank_mismatch_panics() {
         let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]);
         let _ = Tensor3::from_tenferro(inner);
+    }
+
+    #[test]
+    fn test_try_from_tenferro_rank_mismatch_errors() {
+        let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]);
+        let err = Tensor3::try_from_tenferro(inner).unwrap_err();
+
+        assert!(err.to_string().contains("expected rank 3"));
+        assert!(err.to_string().contains("got 2"));
     }
 
     #[test]

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -13,7 +13,10 @@ use crate::error::{Result, TensorTrainError};
 
 /// Rank-N tensor backed by `tenferro_tensor::TypedTensor<T>`.
 #[derive(Debug)]
-pub struct Tensor<T: TensorScalar, const N: usize>(TfTensor<T>);
+pub struct Tensor<T: TensorScalar, const N: usize> {
+    inner: TfTensor<T>,
+    dims: [usize; N],
+}
 
 /// Iterator over tensor elements in column-major order.
 pub struct TensorIter<'a, T: TensorScalar, const N: usize> {
@@ -64,7 +67,10 @@ fn col_major_data_to_tensor<T: TensorScalar, const N: usize>(
 
 impl<T: TensorScalar, const N: usize> Clone for Tensor<T, N> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            inner: self.inner.clone(),
+            dims: self.dims,
+        }
     }
 }
 
@@ -132,12 +138,19 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
             "tensor rank mismatch: expected rank {N}, got {}",
             tensor.shape.len()
         );
-        Self(tensor)
+        let mut dims = [0usize; N];
+        for (dim, value) in dims.iter_mut().zip(tensor.shape.iter().copied()) {
+            *dim = value;
+        }
+        Self {
+            inner: tensor,
+            dims,
+        }
     }
 
     /// Total number of elements.
     pub fn len(&self) -> usize {
-        self.0.n_elements()
+        self.inner.n_elements()
     }
 
     /// Whether the tensor is empty (zero elements).
@@ -152,23 +165,18 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
 
     /// All dimensions.
     pub fn dims(&self) -> &[usize; N] {
-        self.0.shape.as_slice().try_into().unwrap_or_else(|_| {
-            panic!(
-                "tensor rank mismatch: expected rank {N}, got {}",
-                self.0.shape.len()
-            )
-        })
+        &self.dims
     }
 
     /// Export the tensor as a column-major flat vector.
     pub fn to_col_major_vec(&self) -> Vec<T> {
-        tensor_to_col_major_vec(&self.0)
+        tensor_to_col_major_vec(&self.inner)
     }
 
     /// Iterate over all elements in column-major order.
     pub fn iter(&self) -> TensorIter<'_, T, N> {
         TensorIter {
-            tensor: &self.0,
+            tensor: &self.inner,
             dims: *self.dims(),
             next: 0,
             len: self.len(),
@@ -178,7 +186,7 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
     /// Iterate mutably over all elements in column-major order.
     pub fn iter_mut(&mut self) -> TensorIterMut<'_, T, N> {
         TensorIterMut {
-            tensor: &mut self.0,
+            tensor: &mut self.inner,
             dims: *self.dims(),
             next: 0,
             len: self.len(),
@@ -188,17 +196,17 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
 
     /// Borrow the wrapped tenferro tensor.
     pub fn as_inner(&self) -> &TfTensor<T> {
-        &self.0
+        &self.inner
     }
 
     /// Mutably borrow the wrapped tenferro tensor.
     pub fn as_inner_mut(&mut self) -> &mut TfTensor<T> {
-        &mut self.0
+        &mut self.inner
     }
 
     /// Consume this wrapper and return the inner tenferro tensor.
     pub fn into_inner(self) -> TfTensor<T> {
-        self.0
+        self.inner
     }
 
     /// Try to wrap an existing tenferro tensor.
@@ -252,7 +260,12 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
                 ),
             });
         }
-        Ok(Self(tensor))
+        let mut dims = [0usize; N];
+        dims.copy_from_slice(&tensor.shape);
+        Ok(Self {
+            inner: tensor,
+            dims,
+        })
     }
 
     /// Create a tensor by applying `f` to each multi-index (column-major order).
@@ -280,13 +293,13 @@ impl<T: TensorScalar, const N: usize> Index<[usize; N]> for Tensor<T, N> {
     type Output = T;
 
     fn index(&self, idx: [usize; N]) -> &T {
-        self.0.get(&idx[..])
+        self.inner.get(&idx[..])
     }
 }
 
 impl<T: TensorScalar, const N: usize> IndexMut<[usize; N]> for Tensor<T, N> {
     fn index_mut(&mut self, idx: [usize; N]) -> &mut T {
-        self.0.get_mut(&idx[..])
+        self.inner.get_mut(&idx[..])
     }
 }
 
@@ -356,6 +369,14 @@ mod tests {
     fn test_dims() {
         let t: Tensor3<f64> = Tensor3::from_elem([2, 3, 4], 1.0);
         assert_eq!(t.dims(), &[2, 3, 4]);
+    }
+
+    #[test]
+    fn dims_remain_available_after_inner_shape_mutation() {
+        let mut t: Tensor2<f64> = Tensor2::from_elem([2, 3], 1.0);
+        t.as_inner_mut().shape.push(4);
+
+        assert_eq!(t.dims(), &[2, 3]);
     }
 
     #[test]

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -59,7 +59,7 @@ fn col_major_data_to_tensor<T: TensorScalar, const N: usize>(
     data: Vec<T>,
 ) -> Tensor<T, N> {
     let inner = typed_tensor_from_col_major_slice(&data, &dims);
-    Tensor::from_tenferro(inner)
+    Tensor::from_tenferro_unchecked(inner)
 }
 
 impl<T: TensorScalar, const N: usize> Clone for Tensor<T, N> {
@@ -125,6 +125,16 @@ impl<'a, T: TensorScalar, const N: usize> Iterator for TensorIterMut<'a, T, N> {
 impl<'a, T: TensorScalar, const N: usize> ExactSizeIterator for TensorIterMut<'a, T, N> {}
 
 impl<T: TensorScalar, const N: usize> Tensor<T, N> {
+    pub(crate) fn from_tenferro_unchecked(tensor: TfTensor<T>) -> Self {
+        debug_assert_eq!(
+            tensor.shape.len(),
+            N,
+            "tensor rank mismatch: expected rank {N}, got {}",
+            tensor.shape.len()
+        );
+        Self(tensor)
+    }
+
     /// Total number of elements.
     pub fn len(&self) -> usize {
         self.0.n_elements()
@@ -211,6 +221,29 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
     /// assert!(Tensor3::try_from_tenferro(rank_2).is_err());
     /// ```
     pub fn try_from_tenferro(tensor: TfTensor<T>) -> Result<Self> {
+        Self::from_tenferro(tensor)
+    }
+
+    /// Wrap an existing tenferro tensor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tensor rank does not match `N`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_simplett::tensor::{Tensor2, Tensor3};
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let rank_2 = TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// let tensor = Tensor2::from_tenferro(rank_2).unwrap();
+    /// assert_eq!(tensor.dims(), &[2, 2]);
+    ///
+    /// let rank_2 = TypedTensor::from_vec(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    /// assert!(Tensor3::from_tenferro(rank_2).is_err());
+    /// ```
+    pub fn from_tenferro(tensor: TfTensor<T>) -> Result<Self> {
         if tensor.shape.len() != N {
             return Err(TensorTrainError::InvalidOperation {
                 message: format!(
@@ -220,16 +253,6 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
             });
         }
         Ok(Self(tensor))
-    }
-
-    /// Wrap an existing tenferro tensor.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the tensor rank does not match `N`. Use
-    /// [`Tensor::try_from_tenferro`] to handle rank mismatch as an error.
-    pub fn from_tenferro(tensor: TfTensor<T>) -> Self {
-        Self::try_from_tenferro(tensor).unwrap_or_else(|err| panic!("{err}"))
     }
 
     /// Create a tensor by applying `f` to each multi-index (column-major order).
@@ -338,7 +361,7 @@ mod tests {
     #[test]
     fn test_from_tenferro_roundtrip() {
         let inner = typed_tensor_from_col_major_slice(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], &[2, 3]);
-        let tensor = Tensor2::from_tenferro(inner);
+        let tensor = Tensor2::from_tenferro(inner).unwrap();
 
         assert_eq!(tensor.dims(), &[2, 3]);
         assert_eq!(
@@ -353,10 +376,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "rank")]
-    fn test_from_tenferro_rank_mismatch_panics() {
+    fn test_from_tenferro_rank_mismatch_errors() {
         let inner = typed_tensor_from_col_major_slice(&[1.0, 3.0, 2.0, 4.0], &[2, 2]);
-        let _ = Tensor3::from_tenferro(inner);
+        let err = Tensor3::from_tenferro(inner).unwrap_err();
+
+        assert!(err.to_string().contains("expected rank 3"));
+        assert!(err.to_string().contains("got 2"));
     }
 
     #[test]

--- a/crates/tensor4all-simplett/src/tensortrain.rs
+++ b/crates/tensor4all-simplett/src/tensortrain.rs
@@ -110,10 +110,12 @@ impl<T: TTScalar> TensorTrain<T> {
         }
 
         // Last tensor should have right_dim = 1
-        if !tensors.is_empty() && tensors.last().unwrap().right_dim() != 1 {
-            return Err(TensorTrainError::InvalidOperation {
-                message: "Last tensor must have right dimension 1".to_string(),
-            });
+        if let Some(last) = tensors.last() {
+            if last.right_dim() != 1 {
+                return Err(TensorTrainError::InvalidOperation {
+                    message: "Last tensor must have right dimension 1".to_string(),
+                });
+            }
         }
 
         Ok(Self { tensors })
@@ -496,7 +498,7 @@ impl<T: TTScalar> TensorTrain<T> {
         }
 
         // Contract final Tprod into last result tensor
-        let last = result_tensors.last().unwrap();
+        let last = result_tensors.last().ok_or(TensorTrainError::Empty)?;
         let last_left = last.left_dim();
         let last_site = last.site_dim();
         let last_right = last.right_dim();
@@ -524,7 +526,7 @@ impl<T: TTScalar> TensorTrain<T> {
                 }
             }
         }
-        *result_tensors.last_mut().unwrap() = new_last;
+        *result_tensors.last_mut().ok_or(TensorTrainError::Empty)? = new_last;
 
         TensorTrain::new(result_tensors)
     }

--- a/crates/tensor4all-simplett/src/tensortrain.rs
+++ b/crates/tensor4all-simplett/src/tensortrain.rs
@@ -453,7 +453,11 @@ impl<T: TTScalar> TensorTrain<T> {
                     }
                 }
                 // Tprod = Tprod * site_sum
-                tprod = mat_mul(&tprod, &site_sum);
+                tprod = mat_mul(&tprod, &site_sum).map_err(|err| {
+                    TensorTrainError::InvalidOperation {
+                        message: format!("dimension summation matrix multiply failed: {err}"),
+                    }
+                })?;
             } else {
                 // Keep this dimension: multiply Tprod into the site tensor
                 // Tprod (tprod_rows, left_dim) * T reshaped to (left_dim, site_dim * right_dim)
@@ -466,7 +470,11 @@ impl<T: TTScalar> TensorTrain<T> {
                         }
                     }
                 }
-                let product = mat_mul(&tprod, &t_reshaped);
+                let product = mat_mul(&tprod, &t_reshaped).map_err(|err| {
+                    TensorTrainError::InvalidOperation {
+                        message: format!("dimension retention matrix multiply failed: {err}"),
+                    }
+                })?;
 
                 // Reshape product (tprod_rows, site_dim * right_dim)
                 // into tensor (tprod_rows, site_dim, right_dim)
@@ -515,7 +523,10 @@ impl<T: TTScalar> TensorTrain<T> {
         }
 
         // Multiply: last_mat * Tprod → (last_left * last_site, tprod_cols)
-        let contracted = mat_mul(&last_mat, &tprod);
+        let contracted =
+            mat_mul(&last_mat, &tprod).map_err(|err| TensorTrainError::InvalidOperation {
+                message: format!("final dimension summation multiply failed: {err}"),
+            })?;
 
         // Reshape back to tensor (last_left, last_site, tprod_cols)
         let mut new_last = tensor3_zeros(last_left, last_site, tprod_cols);

--- a/crates/tensor4all-simplett/src/types.rs
+++ b/crates/tensor4all-simplett/src/types.rs
@@ -1,5 +1,6 @@
 //! Core types for tensor train operations
 
+use crate::error::{Result, TensorTrainError};
 use crate::tensor::Tensor;
 pub use crate::tensor::Tensor3;
 use tenferro_tensor::{TensorScalar, TypedTensor as TfTensor};
@@ -155,9 +156,9 @@ pub fn tensor3_zeros<T: Clone + Default + TensorScalar>(
 
 /// Create a rank-3 tensor from flat data in **column-major** order.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if `data.len() != left_dim * site_dim * right_dim`.
+/// Returns an error if `data.len() != left_dim * site_dim * right_dim`.
 ///
 /// # Examples
 ///
@@ -165,7 +166,7 @@ pub fn tensor3_zeros<T: Clone + Default + TensorScalar>(
 /// use tensor4all_simplett::{tensor3_from_data, Tensor3Ops};
 ///
 /// // 1 x 2 x 1 tensor, column-major data: [10.0, 20.0]
-/// let t = tensor3_from_data(vec![10.0, 20.0], 1, 2, 1);
+/// let t = tensor3_from_data(vec![10.0, 20.0], 1, 2, 1).unwrap();
 /// assert_eq!(*t.get3(0, 0, 0), 10.0);
 /// assert_eq!(*t.get3(0, 1, 0), 20.0);
 /// ```
@@ -174,11 +175,17 @@ pub fn tensor3_from_data<T: TensorScalar>(
     left_dim: usize,
     site_dim: usize,
     right_dim: usize,
-) -> Tensor3<T> {
-    assert_eq!(data.len(), left_dim * site_dim * right_dim);
+) -> Result<Tensor3<T>> {
+    let expected = left_dim * site_dim * right_dim;
+    if data.len() != expected {
+        return Err(TensorTrainError::DataLengthMismatch {
+            expected,
+            got: data.len(),
+        });
+    }
     let dims = [left_dim, site_dim, right_dim];
     let inner = TfTensor::from_vec(dims.to_vec(), data);
-    Tensor::from_tenferro_unchecked(inner)
+    Ok(Tensor::from_tenferro_unchecked(inner))
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/types.rs
+++ b/crates/tensor4all-simplett/src/types.rs
@@ -178,7 +178,7 @@ pub fn tensor3_from_data<T: TensorScalar>(
     assert_eq!(data.len(), left_dim * site_dim * right_dim);
     let dims = [left_dim, site_dim, right_dim];
     let inner = TfTensor::from_vec(dims.to_vec(), data);
-    Tensor::from_tenferro(inner)
+    Tensor::from_tenferro_unchecked(inner)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/types/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/types/tests/mod.rs
@@ -19,7 +19,7 @@ fn test_tensor3_zeros() {
 #[test]
 fn test_tensor3_from_data() {
     let data: Vec<f64> = (0..24).map(|x| x as f64).collect();
-    let t = tensor3_from_data(data, 2, 3, 4);
+    let t = tensor3_from_data(data, 2, 3, 4).unwrap();
 
     assert_eq!(t.left_dim(), 2);
     assert_eq!(t.site_dim(), 3);
@@ -31,6 +31,14 @@ fn test_tensor3_from_data() {
     assert_eq!(*t.get3(0, 0, 1), 6.0);
     assert_eq!(*t.get3(0, 0, 3), 18.0);
     assert_eq!(*t.get3(1, 2, 3), 23.0);
+}
+
+#[test]
+fn tensor3_from_data_rejects_length_mismatch() {
+    let err = tensor3_from_data(vec![1.0, 2.0], 2, 2, 1).unwrap_err();
+
+    assert!(err.to_string().contains("expected 4 elements"));
+    assert!(err.to_string().contains("got 2"));
 }
 
 #[test]
@@ -70,7 +78,7 @@ fn test_slice_site() {
 #[test]
 fn test_as_left_matrix() {
     let data: Vec<f64> = (0..24).map(|x| x as f64).collect();
-    let t = tensor3_from_data(data, 2, 3, 4);
+    let t = tensor3_from_data(data, 2, 3, 4).unwrap();
 
     let (mat, rows, cols) = t.as_left_matrix();
     assert_eq!(rows, 6); // 2 * 3
@@ -89,7 +97,7 @@ fn test_as_left_matrix() {
 #[test]
 fn test_as_right_matrix() {
     let data: Vec<f64> = (0..24).map(|x| x as f64).collect();
-    let t = tensor3_from_data(data, 2, 3, 4);
+    let t = tensor3_from_data(data, 2, 3, 4).unwrap();
 
     let (mat, rows, cols) = t.as_right_matrix();
     assert_eq!(rows, 2); // left_dim

--- a/crates/tensor4all-simplett/src/vidal.rs
+++ b/crates/tensor4all-simplett/src/vidal.rs
@@ -19,15 +19,17 @@ use tensor4all_tcicore::{rrlu, RrLUOptions};
 use tensor4all_tensorbackend::{mat_mul, svd_backend, BackendLinalgScalar, Matrix};
 
 /// Compute QR decomposition
-fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> (Matrix<T>, Matrix<T>) {
+fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> Result<(Matrix<T>, Matrix<T>)> {
     let options = RrLUOptions {
         max_rank: matrix.ncols().min(matrix.nrows()),
         rel_tol: 0.0,
         abs_tol: 0.0,
         left_orthogonal: true,
     };
-    let lu = rrlu(matrix, Some(options)).expect("rrlu failed in QR decomposition");
-    (lu.left(true), lu.right(true))
+    let lu = rrlu(matrix, Some(options)).map_err(|err| TensorTrainError::InvalidOperation {
+        message: format!("QR decomposition failed: {err}"),
+    })?;
+    Ok((lu.left(true), lu.right(true)))
 }
 
 fn typed_tensor_to_matrix<T>(tensor: &TypedTensor<T>, op: &'static str) -> Result<Matrix<T>>
@@ -241,7 +243,7 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
             let site_dim = tensors[i].site_dim();
 
             let mat = tensor3_to_left_matrix(&tensors[i]);
-            let (q, r) = qr_decomp(&mat);
+            let (q, r) = qr_decomp(&mat)?;
 
             let new_bond_dim = q.ncols();
 

--- a/crates/tensor4all-simplett/src/vidal.rs
+++ b/crates/tensor4all-simplett/src/vidal.rs
@@ -85,7 +85,10 @@ where
         });
     }
 
-    let typed = typed_tensor_from_col_major_slice(matrix.as_col_major_slice(), &[rows, cols]);
+    let typed = typed_tensor_from_col_major_slice(matrix.as_col_major_slice(), &[rows, cols])
+        .map_err(|err| TensorTrainError::InvalidOperation {
+            message: format!("Failed to prepare Vidal bond SVD input matrix: {err}"),
+        })?;
     let decomp = svd_backend(&typed).map_err(|e| TensorTrainError::InvalidOperation {
         message: format!("Failed to compute Vidal bond SVD: {e}"),
     })?;
@@ -266,7 +269,10 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
             let next_right_dim = tensors[i + 1].right_dim();
             let next_mat = tensor3_to_right_matrix(&tensors[i + 1]);
 
-            let contracted = mat_mul(&r, &next_mat);
+            let contracted =
+                mat_mul(&r, &next_mat).map_err(|err| TensorTrainError::InvalidOperation {
+                    message: format!("Vidal left sweep matrix multiply failed: {err}"),
+                })?;
 
             let mut new_next_tensor = tensor3_zeros(new_bond_dim, next_site_dim, next_right_dim);
             for l in 0..new_bond_dim {
@@ -314,7 +320,10 @@ impl<T: TTScalar + Scalar + Default> VidalTensorTrain<T> {
                 let prev_left_dim = tensors[i - 1].left_dim();
                 let prev_site_dim = tensors[i - 1].site_dim();
                 let prev_mat = tensor3_to_left_matrix(&tensors[i - 1]);
-                let contracted = mat_mul(&prev_mat, &us);
+                let contracted =
+                    mat_mul(&prev_mat, &us).map_err(|err| TensorTrainError::InvalidOperation {
+                        message: format!("Vidal right sweep matrix multiply failed: {err}"),
+                    })?;
 
                 let mut new_prev_tensor = tensor3_zeros(prev_left_dim, prev_site_dim, new_bond_dim);
                 for l in 0..prev_left_dim {

--- a/crates/tensor4all-simplett/src/vidal/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/vidal/tests/mod.rs
@@ -139,6 +139,19 @@ fn test_vidal_partition_exceeds_length() {
 }
 
 #[test]
+fn test_vidal_from_tensor_train_reports_qr_failure() {
+    let mut left = tensor3_zeros(1, 2, 1);
+    left.set3(0, 0, 0, f64::NAN);
+    left.set3(0, 1, 0, 1.0);
+    let right = tensor3_zeros(1, 2, 1);
+    let tt = TensorTrain::new(vec![left, right]).unwrap();
+
+    let err = VidalTensorTrain::from_tensor_train(&tt).unwrap_err();
+
+    assert!(err.to_string().contains("QR decomposition failed"));
+}
+
+#[test]
 fn test_vidal_round_trip_evaluations() {
     // Test that Vidal round-trip preserves individual element values
     let mut t0: Tensor3<f64> = tensor3_zeros(1, 2, 2);

--- a/crates/tensor4all-tcicore/src/matrix_luci.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci.rs
@@ -14,7 +14,7 @@ use crate::matrixluci::types::{PivotKernelOptions, PivotSelectionCore};
 use crate::matrixluci::PivotKernel;
 use crate::scalar::Scalar;
 use crate::traits::AbstractMatrixCI;
-use tensor4all_tensorbackend::{mat_mul, submatrix, Matrix};
+use tensor4all_tensorbackend::Matrix;
 
 /// Matrix LU-based Cross Interpolation.
 ///
@@ -338,7 +338,7 @@ where
     ///     vec![3.0, 4.0],
     /// ]);
     /// let ci = MatrixLUCI::from_matrix(&m, None).unwrap();
-    /// let reconstructed = mat_mul(&ci.left(), &ci.right());
+    /// let reconstructed = mat_mul(&ci.left(), &ci.right()).unwrap();
     /// for i in 0..2 {
     ///     for j in 0..2 {
     ///         assert!((reconstructed[[i, j]] - m[[i, j]]).abs() < 1e-10);
@@ -365,7 +365,7 @@ where
     /// assert_eq!(r.nrows(), ci.rank());
     /// assert_eq!(r.ncols(), ci.ncols());
     /// // left * right reconstructs the matrix
-    /// let recon = mat_mul(&ci.left(), &r);
+    /// let recon = mat_mul(&ci.left(), &r).unwrap();
     /// for i in 0..2 {
     ///     for j in 0..2 {
     ///         assert!((recon[[i, j]] - m[[i, j]]).abs() < 1e-10);
@@ -449,10 +449,17 @@ where
 
     fn submatrix(&self, rows: &[usize], cols: &[usize]) -> Matrix<T> {
         let r = self.rank();
-        let left_sub = submatrix(&self.left, rows, &(0..r).collect::<Vec<_>>());
-        let right_sub = submatrix(&self.right, &(0..r).collect::<Vec<_>>(), cols);
-
-        mat_mul(&left_sub, &right_sub)
+        let mut result = Matrix::zeros(rows.len(), cols.len());
+        for (j_out, &col) in cols.iter().enumerate() {
+            for (i_out, &row) in rows.iter().enumerate() {
+                let mut sum = T::zero();
+                for k in 0..r {
+                    sum = sum + self.left[[row, k]] * self.right[[k, col]];
+                }
+                result[[i_out, j_out]] = sum;
+            }
+        }
+        result
     }
 }
 

--- a/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
@@ -56,7 +56,7 @@ fn test_matrixluci_rank2_iplusj_left_orthogonal() {
     // Check left() * right() = Pi
     let left = luci.left();
     let right = luci.right();
-    let reconstructed = mat_mul(&left, &right);
+    let reconstructed = mat_mul(&left, &right).unwrap();
     for i in 0..4 {
         for j in 0..4 {
             let diff = (m[[i, j]] - reconstructed[[i, j]]).abs();
@@ -89,7 +89,7 @@ fn test_matrixluci_rank2_iplusj_right_orthogonal() {
     let luci = MatrixLUCI::from_matrix(&m, Some(opts)).unwrap();
     assert_eq!(luci.rank(), 2);
 
-    let reconstructed = mat_mul(&luci.left(), &luci.right());
+    let reconstructed = mat_mul(&luci.left(), &luci.right()).unwrap();
     for i in 0..4 {
         for j in 0..4 {
             let diff = (m[[i, j]] - reconstructed[[i, j]]).abs();

--- a/crates/tensor4all-tcicore/src/matrixaca.rs
+++ b/crates/tensor4all-tcicore/src/matrixaca.rs
@@ -8,7 +8,7 @@
 use crate::error::{MatrixCIError, Result};
 use crate::scalar::Scalar;
 use crate::traits::AbstractMatrixCI;
-use tensor4all_tensorbackend::{mat_mul, submatrix, submatrix_argmax, Matrix};
+use tensor4all_tensorbackend::{submatrix_argmax, Matrix};
 
 fn matrix_row<T: Scalar>(m: &Matrix<T>, i: usize) -> Vec<T> {
     (0..m.ncols()).map(|j| m[[i, j]]).collect()
@@ -590,15 +590,17 @@ impl<T: Scalar> AbstractMatrixCI<T> for MatrixACA<T> {
         }
 
         let r = self.rank();
-        let pivot_indices: Vec<usize> = (0..r).collect();
-        let mut left = submatrix(&self.u, rows, &pivot_indices);
-        for i in 0..rows.len() {
-            for k in 0..r {
-                left[[i, k]] = left[[i, k]] * self.alpha[k];
+        let mut result = Matrix::zeros(rows.len(), cols.len());
+        for (j_out, &col) in cols.iter().enumerate() {
+            for (i_out, &row) in rows.iter().enumerate() {
+                let mut sum = T::zero();
+                for k in 0..r {
+                    sum = sum + self.u[[row, k]] * self.alpha[k] * self.v[[k, col]];
+                }
+                result[[i_out, j_out]] = sum;
             }
         }
-        let right = submatrix(&self.v, &pivot_indices, cols);
-        mat_mul(&left, &right)
+        result
     }
 }
 

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -54,7 +54,7 @@ use tensor4all_tensorbackend::{submatrix_argmax, swap_cols, swap_rows, transpose
 /// // Verify L * U reconstructs the permuted matrix
 /// let l = lu.left(false);
 /// let u = lu.right(false);
-/// let reconstructed = mat_mul(&l, &u);
+/// let reconstructed = mat_mul(&l, &u).unwrap();
 ///
 /// // Check reconstruction matches the permuted matrix
 /// for i in 0..3 {
@@ -251,7 +251,7 @@ impl<T: Scalar> RrLU<T> {
     /// // Unpermuted: L * U reconstructs the row/col-permuted matrix
     /// let l = lu.left(false);
     /// let u = lu.right(false);
-    /// let prod = mat_mul(&l, &u);
+    /// let prod = mat_mul(&l, &u).unwrap();
     /// for i in 0..2 {
     ///     for j in 0..2 {
     ///         let ri = lu.row_permutation()[i];
@@ -289,7 +289,7 @@ impl<T: Scalar> RrLU<T> {
     /// assert_eq!(u.nrows(), lu.npivots());
     /// assert_eq!(u.ncols(), lu.ncols());
     /// // L * U reconstructs the permuted matrix
-    /// let prod = mat_mul(&l, &u);
+    /// let prod = mat_mul(&l, &u).unwrap();
     /// assert!((prod[[0, 0]] - m[[lu.row_permutation()[0], lu.col_permutation()[0]]]).abs() < 1e-10);
     /// ```
     pub fn right(&self, permute: bool) -> Matrix<T> {

--- a/crates/tensor4all-tcicore/src/matrixlu/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu/tests/mod.rs
@@ -55,7 +55,7 @@ fn test_rrlu_reconstruct() {
     let u = lu.right(true);
 
     // Reconstruct: L * U should approximate original matrix
-    let reconstructed = mat_mul(&l, &u);
+    let reconstructed = mat_mul(&l, &u).unwrap();
 
     for i in 0..2 {
         for j in 0..2 {
@@ -134,7 +134,7 @@ fn test_rrlu_4x4_reconstruct() {
     // L * U (permuted) should reconstruct original matrix
     let l_perm = lu.left(true);
     let u_perm = lu.right(true);
-    let reconstructed = mat_mul(&l_perm, &u_perm);
+    let reconstructed = mat_mul(&l_perm, &u_perm).unwrap();
     for i in 0..4 {
         for j in 0..4 {
             assert!(
@@ -209,7 +209,7 @@ fn test_rrlu_exact_low_rank() {
         ],
     ]);
 
-    let a = mat_mul(&p, &q);
+    let a = mat_mul(&p, &q).unwrap();
     let lu = rrlu(&a, None).unwrap();
 
     assert_eq!(lu.npivots(), 3);
@@ -217,7 +217,7 @@ fn test_rrlu_exact_low_rank() {
     // Reconstruct
     let l = lu.left(true);
     let u = lu.right(true);
-    let reconstructed = mat_mul(&l, &u);
+    let reconstructed = mat_mul(&l, &u).unwrap();
     for i in 0..a.nrows() {
         for j in 0..a.ncols() {
             assert!(
@@ -336,7 +336,7 @@ fn test_rrlu_transpose() {
 
     let l = tlu.left(true);
     let u = tlu.right(true);
-    let reconstructed = mat_mul(&l, &u);
+    let reconstructed = mat_mul(&l, &u).unwrap();
     let mt = transpose(&m);
 
     for i in 0..mt.nrows() {

--- a/crates/tensor4all-tcicore/src/matrixluci/block_rook.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/block_rook.rs
@@ -1,5 +1,6 @@
 //! Lazy pivot-kernel implementations.
 
+use crate::matrixluci::error::MatrixLuciError;
 use crate::matrixluci::factors::{invert_square, load_block, subtract_inplace};
 use crate::matrixluci::kernel::PivotKernel;
 use crate::matrixluci::scalar::Scalar;
@@ -24,18 +25,25 @@ fn residual_block<T: Scalar, S: CandidateMatrixSource<T>>(
     selected_rows: &[usize],
     selected_cols: &[usize],
     pivot_inv: Option<&Matrix<T>>,
-) -> Matrix<T> {
+) -> Result<Matrix<T>> {
     let mut residual = load_block(source, rows, cols);
     if selected_rows.is_empty() {
-        return residual;
+        return Ok(residual);
     }
 
+    let pivot_inv = pivot_inv.ok_or_else(|| MatrixLuciError::InvalidArgument {
+        message: "pivot inverse is required after pivots have been selected".to_string(),
+    })?;
     let a_rj = load_block(source, rows, selected_cols);
     let a_ic = load_block(source, selected_rows, cols);
-    let temp = mat_mul(&a_rj, pivot_inv.unwrap());
-    let approx = mat_mul(&temp, &a_ic);
+    let temp = mat_mul(&a_rj, pivot_inv).map_err(|err| MatrixLuciError::InvalidArgument {
+        message: format!("residual left multiplication failed: {err}"),
+    })?;
+    let approx = mat_mul(&temp, &a_ic).map_err(|err| MatrixLuciError::InvalidArgument {
+        message: format!("residual right multiplication failed: {err}"),
+    })?;
     subtract_inplace(&mut residual, &approx);
-    residual
+    Ok(residual)
 }
 
 fn argmax_abs<T: Scalar>(matrix: &Matrix<T>) -> (usize, usize, f64) {
@@ -70,7 +78,7 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
     selected_rows: &[usize],
     selected_cols: &[usize],
     pivot_inv: Option<&Matrix<T>>,
-) -> (usize, usize, f64) {
+) -> Result<(usize, usize, f64)> {
     let mut current_col = remaining_cols[0];
     let mut current_row = remaining_rows[0];
     let max_steps = remaining_rows.len() + remaining_cols.len() + 1;
@@ -83,7 +91,7 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
             selected_rows,
             selected_cols,
             pivot_inv,
-        );
+        )?;
         let (best_row_pos, _, _) = argmax_abs(&col_residual);
         current_row = remaining_rows[best_row_pos];
 
@@ -94,12 +102,12 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
             selected_rows,
             selected_cols,
             pivot_inv,
-        );
+        )?;
         let (_, best_col_pos, best_abs) = argmax_abs(&row_residual);
         let next_col = remaining_cols[best_col_pos];
 
         if next_col == current_col {
-            return (current_row, current_col, best_abs);
+            return Ok((current_row, current_col, best_abs));
         }
         current_col = next_col;
     }
@@ -111,9 +119,9 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
         selected_rows,
         selected_cols,
         pivot_inv,
-    );
+    )?;
     let (_, best_col_pos, best_abs) = argmax_abs(&row_residual);
-    (current_row, remaining_cols[best_col_pos], best_abs)
+    Ok((current_row, remaining_cols[best_col_pos], best_abs))
 }
 
 fn factorize_lazy<T: Scalar, S: CandidateMatrixSource<T>>(
@@ -160,7 +168,7 @@ fn factorize_lazy<T: Scalar, S: CandidateMatrixSource<T>>(
             &selected_rows,
             &selected_cols,
             pivot_inv.as_ref(),
-        );
+        )?;
         last_error = pivot_abs;
 
         if !selected_rows.is_empty()

--- a/crates/tensor4all-tcicore/src/matrixluci/factors.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/factors.rs
@@ -101,13 +101,17 @@ impl<T: Scalar> CrossFactors<T> {
     /// Form `A[:, J] * A[I, J]^{-1}`.
     pub fn cols_times_pivot_inv(&self) -> Result<Matrix<T>> {
         let pivot_inv = self.pivot_inverse()?;
-        Ok(mat_mul(&self.pivot_cols, &pivot_inv))
+        mat_mul(&self.pivot_cols, &pivot_inv).map_err(|err| MatrixLuciError::InvalidArgument {
+            message: format!("left factor multiplication failed: {err}"),
+        })
     }
 
     /// Form `A[I, J]^{-1} * A[I, :]`.
     pub fn pivot_inv_times_rows(&self) -> Result<Matrix<T>> {
         let pivot_inv = self.pivot_inverse()?;
-        Ok(mat_mul(&pivot_inv, &self.pivot_rows))
+        mat_mul(&pivot_inv, &self.pivot_rows).map_err(|err| MatrixLuciError::InvalidArgument {
+            message: format!("right factor multiplication failed: {err}"),
+        })
     }
 }
 

--- a/crates/tensor4all-tensorbackend/src/any_scalar.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 use tenferro::{DType, Tensor as NativeTensor};
@@ -81,61 +81,72 @@ fn scalar_value_from_storage(storage: &Storage) -> ScalarValue {
     }
 }
 
-fn scalar_value_from_native(native: &NativeTensor) -> ScalarValue {
+fn scalar_value_from_native(native: &NativeTensor) -> Result<ScalarValue> {
+    ensure!(
+        native.shape().is_empty(),
+        "expected rank-0 scalar tensor, got shape {:?}",
+        native.shape()
+    );
+
     match native.dtype() {
-        DType::F32 => ScalarValue::F32(
-            native
-                .as_slice::<f32>()
-                .and_then(|values| values.first().copied())
-                .unwrap_or_else(|| panic!("failed to read f32 scalar tensor value")),
-        ),
-        DType::F64 => ScalarValue::F64(
-            native
-                .as_slice::<f64>()
-                .and_then(|values| values.first().copied())
-                .unwrap_or_else(|| panic!("failed to read f64 scalar tensor value")),
-        ),
-        DType::I64 => ScalarValue::I64(
-            native
-                .as_slice::<i64>()
-                .and_then(|values| values.first().copied())
-                .unwrap_or_else(|| panic!("failed to read i64 scalar tensor value")),
-        ),
-        DType::C32 => ScalarValue::C32(
-            native
-                .as_slice::<Complex32>()
-                .and_then(|values| values.first().copied())
-                .unwrap_or_else(|| panic!("failed to read c32 scalar tensor value")),
-        ),
-        DType::C64 => ScalarValue::C64(
-            native
-                .as_slice::<Complex64>()
-                .and_then(|values| values.first().copied())
-                .unwrap_or_else(|| panic!("failed to read c64 scalar tensor value")),
-        ),
+        DType::F32 => native
+            .as_slice::<f32>()
+            .and_then(|values| values.first().copied())
+            .map(ScalarValue::F32)
+            .ok_or_else(|| anyhow!("failed to read f32 scalar tensor value")),
+        DType::F64 => native
+            .as_slice::<f64>()
+            .and_then(|values| values.first().copied())
+            .map(ScalarValue::F64)
+            .ok_or_else(|| anyhow!("failed to read f64 scalar tensor value")),
+        DType::I64 => native
+            .as_slice::<i64>()
+            .and_then(|values| values.first().copied())
+            .map(ScalarValue::I64)
+            .ok_or_else(|| anyhow!("failed to read i64 scalar tensor value")),
+        DType::C32 => native
+            .as_slice::<Complex32>()
+            .and_then(|values| values.first().copied())
+            .map(ScalarValue::C32)
+            .ok_or_else(|| anyhow!("failed to read c32 scalar tensor value")),
+        DType::C64 => native
+            .as_slice::<Complex64>()
+            .and_then(|values| values.first().copied())
+            .map(ScalarValue::C64)
+            .ok_or_else(|| anyhow!("failed to read c64 scalar tensor value")),
     }
 }
 
-fn scalar_tensor_result(op: &'static str, native: Result<NativeTensor>) -> Scalar {
-    match native {
-        Ok(native) => Scalar::wrap_native(native)
-            .unwrap_or_else(|e| panic!("Scalar::{op} returned a non-scalar tensor: {e}")),
-        Err(err) => panic!("Scalar::{op} failed: {err}"),
+trait ScalarTensorElement: TensorElement {
+    fn scalar_value(value: Self) -> ScalarValue;
+}
+
+impl ScalarTensorElement for f32 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::F32(value)
     }
 }
 
-fn neg_native(native: &NativeTensor) -> Result<NativeTensor> {
-    Ok(match scalar_value_from_native(native) {
-        ScalarValue::F32(value) => Scalar::from_value(-value).native,
-        ScalarValue::F64(value) => Scalar::from_value(-value).native,
-        ScalarValue::I64(value) => NativeTensor::from_vec(vec![], vec![-value]),
-        ScalarValue::C32(value) => Scalar::from_value(-value).native,
-        ScalarValue::C64(value) => Scalar::from_value(-value).native,
-    })
+impl ScalarTensorElement for f64 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::F64(value)
+    }
+}
+
+impl ScalarTensorElement for Complex32 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::C32(value)
+    }
+}
+
+impl ScalarTensorElement for Complex64 {
+    fn scalar_value(value: Self) -> ScalarValue {
+        ScalarValue::C64(value)
+    }
 }
 
 pub(crate) fn promote_scalar_native(native: &NativeTensor, target: DType) -> Result<NativeTensor> {
-    let promoted = match (scalar_value_from_native(native), target) {
+    let promoted = match (scalar_value_from_native(native)?, target) {
         (ScalarValue::F32(value), DType::F32) => Scalar::from_value(value),
         (ScalarValue::F32(value), DType::F64) => Scalar::from_value(value as f64),
         (ScalarValue::F32(value), DType::C32) => Scalar::from_value(Complex32::new(value, 0.0)),
@@ -160,9 +171,7 @@ pub(crate) fn promote_scalar_native(native: &NativeTensor, target: DType) -> Res
         (ScalarValue::F64(value), DType::C64) => Scalar::from_value(Complex64::new(value, 0.0)),
         (ScalarValue::I64(value), DType::F32) => Scalar::from_value(value as f32),
         (ScalarValue::I64(value), DType::F64) => Scalar::from_value(value as f64),
-        (ScalarValue::I64(value), DType::I64) => Scalar {
-            native: NativeTensor::from_vec(vec![], vec![value]),
-        },
+        (ScalarValue::I64(value), DType::I64) => Scalar::from_i64(value),
         (ScalarValue::I64(value), DType::C32) => {
             Scalar::from_value(Complex32::new(value as f32, 0.0))
         }
@@ -220,6 +229,7 @@ pub(crate) fn promote_scalar_native(native: &NativeTensor, target: DType) -> Res
 /// ```
 pub struct Scalar {
     native: NativeTensor,
+    value: ScalarValue,
 }
 
 /// Backward-compatible scalar type name used across tensor4all APIs.
@@ -228,7 +238,8 @@ pub type AnyScalar = Scalar;
 impl Scalar {
     fn wrap_native(native: NativeTensor) -> Result<Self> {
         if native.shape().is_empty() {
-            Ok(Self { native })
+            let value = scalar_value_from_native(&native)?;
+            Ok(Self { native, value })
         } else {
             Err(anyhow!(
                 "Scalar requires a rank-0 tensor, got shape {:?}",
@@ -238,7 +249,14 @@ impl Scalar {
     }
 
     fn value(&self) -> ScalarValue {
-        scalar_value_from_native(&self.native)
+        self.value
+    }
+
+    fn from_i64(value: i64) -> Self {
+        Self {
+            native: NativeTensor::from_vec(vec![], vec![value]),
+            value: ScalarValue::I64(value),
+        }
     }
 
     pub(crate) fn from_native(value: NativeTensor) -> Result<Self> {
@@ -265,10 +283,13 @@ impl Scalar {
     /// assert!((z.real() - 1.0).abs() < 1e-10);
     /// assert!((z.imag() - 2.0).abs() < 1e-10);
     /// ```
-    pub fn from_value<T: TensorElement>(value: T) -> Self {
-        let native = T::scalar_native_tensor(value)
-            .unwrap_or_else(|e| panic!("failed to build scalar native tensor: {e}"));
-        Self { native }
+    #[allow(private_bounds)]
+    pub fn from_value<T: ScalarTensorElement>(value: T) -> Self {
+        let native = NativeTensor::from_vec(vec![], vec![value]);
+        Self {
+            native,
+            value: T::scalar_value(value),
+        }
     }
 
     /// Creates a real scalar from an `f64` value.
@@ -342,8 +363,7 @@ impl Scalar {
     /// assert!((p.real() - 5.0).abs() < 1e-10);
     /// ```
     pub fn primal(&self) -> Self {
-        Self::wrap_native(self.native.clone())
-            .unwrap_or_else(|e| panic!("Scalar::primal returned a non-scalar tensor: {e}"))
+        self.clone()
     }
 
     /// Returns the real part while intentionally dropping AD metadata.
@@ -509,10 +529,7 @@ impl Scalar {
         match self.value() {
             ScalarValue::F32(value) => Self::from_value(value),
             ScalarValue::F64(value) => Self::from_value(value),
-            ScalarValue::I64(value) => {
-                Self::wrap_native(NativeTensor::from_vec(vec![], vec![value]))
-                    .unwrap_or_else(|e| panic!("Scalar::conj returned a non-scalar tensor: {e}"))
-            }
+            ScalarValue::I64(value) => Self::from_i64(value),
             ScalarValue::C32(value) => Self::from_value(value.conj()),
             ScalarValue::C64(value) => Self::from_value(value.conj()),
         }
@@ -657,11 +674,7 @@ impl SumFromStorage for Scalar {
         match scalar_value_from_storage(storage) {
             ScalarValue::F32(value) => Self::from_value(value),
             ScalarValue::F64(value) => Self::from_value(value),
-            ScalarValue::I64(value) => {
-                Self::wrap_native(NativeTensor::from_vec(vec![], vec![value])).unwrap_or_else(|e| {
-                    panic!("Scalar::sum_from_storage returned a non-scalar tensor: {e}")
-                })
-            }
+            ScalarValue::I64(value) => Self::from_i64(value),
             ScalarValue::C32(value) => Self::from_value(value),
             ScalarValue::C64(value) => Self::from_value(value),
         }
@@ -767,7 +780,13 @@ impl Neg for Scalar {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        scalar_tensor_result("neg", neg_native(&self.native))
+        match self.value() {
+            ScalarValue::F32(value) => Self::from_value(-value),
+            ScalarValue::F64(value) => Self::from_value(-value),
+            ScalarValue::I64(value) => Self::from_i64(-value),
+            ScalarValue::C32(value) => Self::from_value(-value),
+            ScalarValue::C64(value) => Self::from_value(-value),
+        }
     }
 }
 
@@ -869,6 +888,7 @@ impl Clone for Scalar {
     fn clone(&self) -> Self {
         Self {
             native: self.native.clone(),
+            value: self.value,
         }
     }
 }

--- a/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/any_scalar/tests/mod.rs
@@ -232,6 +232,15 @@ fn promote_i64_native_scalar_covers_supported_targets_and_rejections() {
 }
 
 #[test]
+fn promote_scalar_native_rejects_non_scalar_tensor() {
+    let tensor = NativeTensor::from_vec(vec![2], vec![1.0_f64, 2.0]);
+
+    let err = promote_scalar_native(&tensor, DType::F64).unwrap_err();
+
+    assert!(err.to_string().contains("rank-0 scalar"));
+}
+
+#[test]
 fn i64_native_scalar_participates_in_real_ordering() {
     let i64_scalar =
         Scalar::from_native(NativeTensor::from_vec(vec![], vec![3_i64])).expect("i64 scalar");

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -19,6 +19,7 @@
 //! assert_eq!(m[[1, 0]], 3.0);
 //! ```
 
+use anyhow::{ensure, Context, Result};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 use std::ops::{Index, IndexMut};
@@ -348,14 +349,14 @@ pub fn submatrix_argmax<T: MatrixScalar>(
 /// types cannot implement it.
 pub trait BlasMul: Sized {
     #[doc(hidden)]
-    fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Matrix<Self>;
+    fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>>;
 }
 
 macro_rules! impl_blas_mul {
     ($($t:ty),*) => {
         $(
         impl BlasMul for $t {
-            fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Matrix<Self> {
+            fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>> {
                 use tenferro_einsum::typed_eager_einsum;
                 use tenferro_tensor::TypedTensor;
                 use crate::with_default_backend;
@@ -363,7 +364,14 @@ macro_rules! impl_blas_mul {
                 let m = a.nrows();
                 let k = a.ncols();
                 let n = b.ncols();
-                assert_eq!(b.nrows(), k);
+                ensure!(
+                    b.nrows() == k,
+                    "matrix dimensions must agree for multiplication: left is {}x{}, right is {}x{}",
+                    m,
+                    k,
+                    b.nrows(),
+                    n
+                );
 
                 let a_tensor = TypedTensor::<$t>::from_vec(
                     vec![m, k],
@@ -376,8 +384,20 @@ macro_rules! impl_blas_mul {
                 let c = with_default_backend(|backend| {
                     typed_eager_einsum(backend, &[&a_tensor, &b_tensor], "ij,jk->ik")
                 })
-                .expect("einsum failed");
-                Matrix::from_col_major_vec(m, n, c.as_slice().to_vec())
+                .context("matrix multiplication einsum failed")?;
+                let data = c.as_slice().to_vec();
+                ensure!(
+                    data.len() == m * n,
+                    "matrix multiplication returned {} values for expected shape {}x{}",
+                    data.len(),
+                    m,
+                    n
+                );
+                Ok(Matrix {
+                    data,
+                    nrows: m,
+                    ncols: n,
+                })
             }
         }
         )*
@@ -439,9 +459,9 @@ impl MatrixScalar for Complex32 {
 ///
 /// Uses BLAS-backed einsum via tenferro for high performance.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if `a.ncols() != b.nrows()`.
+/// Returns an error if `a.ncols() != b.nrows()` or the backend einsum fails.
 ///
 /// # Examples
 ///
@@ -450,13 +470,13 @@ impl MatrixScalar for Complex32 {
 ///
 /// let a = from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0]]);
 /// let b = from_vec2d(vec![vec![5.0, 6.0], vec![7.0, 8.0]]);
-/// let c = mat_mul(&a, &b);
+/// let c = mat_mul(&a, &b).unwrap();
 /// assert!((c[[0, 0]] - 19.0).abs() < 1e-10);
 /// assert!((c[[0, 1]] - 22.0).abs() < 1e-10);
 /// assert!((c[[1, 0]] - 43.0).abs() < 1e-10);
 /// assert!((c[[1, 1]] - 50.0).abs() < 1e-10);
 /// ```
-pub fn mat_mul<T: BlasMul>(a: &Matrix<T>, b: &Matrix<T>) -> Matrix<T> {
+pub fn mat_mul<T: BlasMul>(a: &Matrix<T>, b: &Matrix<T>) -> Result<Matrix<T>> {
     T::blas_mat_mul(a, b)
 }
 

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -53,7 +53,7 @@ fn test_submatrix_argmax() {
 fn test_mat_mul() {
     let a = from_vec2d(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
     let b = from_vec2d(vec![vec![5.0, 6.0], vec![7.0, 8.0]]);
-    let c = mat_mul(&a, &b);
+    let c = mat_mul(&a, &b).unwrap();
 
     assert_eq!(c[[0, 0]], 19.0);
     assert_eq!(c[[0, 1]], 22.0);
@@ -65,7 +65,7 @@ fn test_mat_mul() {
 fn test_mat_mul_rectangular_preserves_column_major_layout() {
     let a = from_vec2d(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
     let b = from_vec2d(vec![vec![7.0, 8.0], vec![9.0, 10.0], vec![11.0, 12.0]]);
-    let c = mat_mul(&a, &b);
+    let c = mat_mul(&a, &b).unwrap();
 
     assert_eq!(c.nrows(), 2);
     assert_eq!(c.ncols(), 2);
@@ -74,4 +74,14 @@ fn test_mat_mul_rectangular_preserves_column_major_layout() {
     assert_eq!(c[[1, 0]], 139.0);
     assert_eq!(c[[1, 1]], 154.0);
     assert_eq!(c.as_col_major_slice(), &[58.0, 139.0, 64.0, 154.0]);
+}
+
+#[test]
+fn mat_mul_reports_dimension_mismatch() {
+    let a = Matrix::from_col_major_vec(2, 3, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let b = Matrix::from_col_major_vec(2, 2, vec![1.0, 3.0, 2.0, 4.0]);
+
+    let err = mat_mul(&a, &b).unwrap_err();
+
+    assert!(err.to_string().contains("matrix dimensions"));
 }

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, ensure, Result};
 use num_complex::{Complex64, ComplexFloat};
-use std::ops::{Add, Mul};
+use std::ops::Mul;
 use std::sync::Arc;
 
 /// Trait for scalar types that can be stored in [`Storage`].
@@ -42,12 +42,12 @@ impl StorageScalar for f64 {
     fn build_dense_storage(data: Vec<Self>, logical_dims: &[usize]) -> Result<Storage> {
         Storage::validate_dense_len(&data, logical_dims, "dense f64 payload")?;
         Ok(Storage::from_repr(StorageRepr::F64(
-            StructuredStorage::from_dense_col_major(data, logical_dims),
+            StructuredStorage::from_dense_col_major(data, logical_dims)?,
         )))
     }
     fn build_diag_storage(diag_data: Vec<Self>, logical_rank: usize) -> Result<Storage> {
         Ok(Storage::from_repr(StorageRepr::F64(
-            StructuredStorage::from_diag_col_major(diag_data, logical_rank),
+            StructuredStorage::from_diag_col_major(diag_data, logical_rank)?,
         )))
     }
     fn build_structured_storage(
@@ -66,12 +66,12 @@ impl StorageScalar for Complex64 {
     fn build_dense_storage(data: Vec<Self>, logical_dims: &[usize]) -> Result<Storage> {
         Storage::validate_dense_len(&data, logical_dims, "dense c64 payload")?;
         Ok(Storage::from_repr(StorageRepr::C64(
-            StructuredStorage::from_dense_col_major(data, logical_dims),
+            StructuredStorage::from_dense_col_major(data, logical_dims)?,
         )))
     }
     fn build_diag_storage(diag_data: Vec<Self>, logical_rank: usize) -> Result<Storage> {
         Ok(Storage::from_repr(StorageRepr::C64(
-            StructuredStorage::from_diag_col_major(diag_data, logical_rank),
+            StructuredStorage::from_diag_col_major(diag_data, logical_rank)?,
         )))
     }
     fn build_structured_storage(
@@ -86,16 +86,18 @@ impl StorageScalar for Complex64 {
     }
 }
 
-pub(crate) fn col_major_strides(dims: &[usize]) -> Vec<isize> {
+pub(crate) fn col_major_strides(dims: &[usize]) -> Result<Vec<isize>> {
     let mut strides = Vec::with_capacity(dims.len());
     let mut stride = 1isize;
     for &dim in dims {
         strides.push(stride);
+        let dim = isize::try_from(dim)
+            .map_err(|_| anyhow!("column-major stride overflow for dims {dims:?}"))?;
         stride = stride
-            .checked_mul(dim as isize)
-            .unwrap_or_else(|| panic!("column-major stride overflow for dims {dims:?}"));
+            .checked_mul(dim)
+            .ok_or_else(|| anyhow!("column-major stride overflow for dims {dims:?}"))?;
     }
-    strides
+    Ok(strides)
 }
 
 fn validate_canonical_axis_classes(axis_classes: &[usize]) -> Result<()> {
@@ -188,14 +190,14 @@ fn offset_from_strides(index: &[usize], strides: &[isize]) -> usize {
 /// // Dense 2x3 storage, column-major: [[1,3,5],[2,4,6]]
 /// let dense = StructuredStorage::from_dense_col_major(
 ///     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3],
-/// );
+/// ).unwrap();
 /// assert!(dense.is_dense());
 /// assert!(!dense.is_diag());
 /// assert_eq!(dense.logical_rank(), 2);
 /// assert_eq!(dense.logical_dims(), vec![2, 3]);
 ///
 /// // Diagonal 3x3 storage
-/// let diag = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2);
+/// let diag = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
 /// assert!(diag.is_diag());
 /// assert_eq!(diag.logical_dims(), vec![3, 3]);
 /// assert_eq!(diag.len(), 3);
@@ -282,25 +284,25 @@ impl<T> StructuredStorage<T> {
 
     /// Creates a dense structured snapshot from column-major logical data.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `data.len()` does not equal the product of `logical_dims`.
+    /// Returns an error if `data.len()` does not equal the product of
+    /// `logical_dims`, or if column-major stride computation overflows.
     ///
     /// # Examples
     ///
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![10.0, 20.0, 30.0, 40.0], &[2, 2]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![10.0, 20.0, 30.0, 40.0], &[2, 2]).unwrap();
     /// assert!(s.is_dense());
     /// assert_eq!(s.data(), &[10.0, 20.0, 30.0, 40.0]);
     /// ```
-    pub fn from_dense_col_major(data: Vec<T>, logical_dims: &[usize]) -> Self {
+    pub fn from_dense_col_major(data: Vec<T>, logical_dims: &[usize]) -> Result<Self> {
         let payload_dims = logical_dims.to_vec();
-        let strides = col_major_strides(&payload_dims);
+        let strides = col_major_strides(&payload_dims)?;
         let axis_classes = (0..logical_dims.len()).collect();
         Self::new(data, payload_dims, strides, axis_classes)
-            .unwrap_or_else(|err| panic!("StructuredStorage::from_dense_col_major failed: {err}"))
     }
 
     /// Creates a diagonal structured snapshot from column-major diagonal data.
@@ -308,30 +310,30 @@ impl<T> StructuredStorage<T> {
     /// The resulting tensor has `logical_rank` axes, each of size `diag_data.len()`.
     /// Only the diagonal entries are stored.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `logical_rank` is zero and data is non-empty.
+    /// Returns an error if `logical_rank` is zero and the data does not contain
+    /// exactly one scalar value, or if column-major stride computation overflows.
     ///
     /// # Examples
     ///
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
     /// assert!(d.is_diag());
     /// assert_eq!(d.logical_dims(), vec![3, 3]);
     /// assert_eq!(d.data(), &[1.0, 2.0, 3.0]);
     /// ```
-    pub fn from_diag_col_major(diag_data: Vec<T>, logical_rank: usize) -> Self {
+    pub fn from_diag_col_major(diag_data: Vec<T>, logical_rank: usize) -> Result<Self> {
         let payload_dims = if logical_rank == 0 {
             vec![]
         } else {
             vec![diag_data.len()]
         };
-        let strides = col_major_strides(&payload_dims);
+        let strides = col_major_strides(&payload_dims)?;
         let axis_classes = vec![0; logical_rank];
         Self::new(diag_data, payload_dims, strides, axis_classes)
-            .unwrap_or_else(|err| panic!("StructuredStorage::from_diag_col_major failed: {err}"))
     }
 
     /// Returns the payload data buffer as a slice.
@@ -341,7 +343,7 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0], &[2]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     /// assert_eq!(s.data(), &[1.0, 2.0]);
     /// ```
     pub fn data(&self) -> &[T] {
@@ -359,10 +361,10 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![0.0; 6], &[2, 3]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap();
     /// assert_eq!(s.payload_dims(), &[2, 3]);
     ///
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 3);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 3).unwrap();
     /// assert_eq!(d.payload_dims(), &[2]);
     /// ```
     pub fn payload_dims(&self) -> &[usize] {
@@ -377,7 +379,7 @@ impl<T> StructuredStorage<T> {
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
     /// // Column-major 2x3: strides are [1, 2]
-    /// let s = StructuredStorage::from_dense_col_major(vec![0.0; 6], &[2, 3]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap();
     /// assert_eq!(s.strides(), &[1, 2]);
     /// ```
     pub fn strides(&self) -> &[isize] {
@@ -394,10 +396,10 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let dense = StructuredStorage::from_dense_col_major(vec![0.0; 4], &[2, 2]);
+    /// let dense = StructuredStorage::from_dense_col_major(vec![0.0; 4], &[2, 2]).unwrap();
     /// assert_eq!(dense.axis_classes(), &[0, 1]);
     ///
-    /// let diag = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2);
+    /// let diag = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     /// assert_eq!(diag.axis_classes(), &[0, 0]);
     /// ```
     pub fn axis_classes(&self) -> &[usize] {
@@ -411,7 +413,7 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 3);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 3).unwrap();
     /// assert_eq!(d.logical_dims(), vec![3, 3, 3]);
     /// ```
     pub fn logical_dims(&self) -> Vec<usize> {
@@ -425,7 +427,7 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![0.0; 6], &[2, 3]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap();
     /// assert_eq!(s.logical_rank(), 2);
     /// ```
     pub fn logical_rank(&self) -> usize {
@@ -440,10 +442,10 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0], &[2]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     /// assert!(s.is_dense());
     ///
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     /// assert!(!d.is_dense());
     /// ```
     pub fn is_dense(&self) -> bool {
@@ -461,10 +463,10 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     /// assert!(d.is_diag());
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0], &[2]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     /// assert!(!s.is_diag());
     /// ```
     pub fn is_diag(&self) -> bool {
@@ -478,10 +480,10 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let dense = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]);
+    /// let dense = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     /// assert_eq!(dense.len(), 3);
     ///
-    /// let diag = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2);
+    /// let diag = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     /// assert_eq!(diag.len(), 2);
     /// ```
     pub fn len(&self) -> usize {
@@ -495,10 +497,10 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let empty = StructuredStorage::from_dense_col_major(Vec::<f64>::new(), &[0]);
+    /// let empty = StructuredStorage::from_dense_col_major(Vec::<f64>::new(), &[0]).unwrap();
     /// assert!(empty.is_empty());
     ///
-    /// let non_empty = StructuredStorage::from_dense_col_major(vec![1.0], &[1]);
+    /// let non_empty = StructuredStorage::from_dense_col_major(vec![1.0], &[1]).unwrap();
     /// assert!(!non_empty.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -515,14 +517,16 @@ impl<T> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     /// assert_eq!(s.dense_col_major_view_if_contiguous(), Some(&[1.0, 2.0, 3.0][..]));
     ///
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     /// assert_eq!(d.dense_col_major_view_if_contiguous(), None);
     /// ```
     pub fn dense_col_major_view_if_contiguous(&self) -> Option<&[T]> {
-        if self.is_dense() && self.strides == col_major_strides(&self.payload_dims) {
+        if self.is_dense()
+            && matches!(col_major_strides(&self.payload_dims), Ok(strides) if strides == self.strides)
+        {
             Some(&self.data)
         } else {
             None
@@ -540,7 +544,7 @@ impl<T: Clone> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]).unwrap();
     /// assert_eq!(s.payload_col_major_vec(), vec![1.0, 2.0, 3.0, 4.0]);
     /// ```
     pub fn payload_col_major_vec(&self) -> Vec<T> {
@@ -548,7 +552,7 @@ impl<T: Clone> StructuredStorage<T> {
         if payload_len == 0 {
             return Vec::new();
         }
-        if self.strides == col_major_strides(&self.payload_dims) {
+        if matches!(col_major_strides(&self.payload_dims), Ok(strides) if strides == self.strides) {
             return self.data.clone();
         }
 
@@ -563,9 +567,9 @@ impl<T: Clone> StructuredStorage<T> {
 
     /// Returns a copy of the storage with logical axes permuted.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `perm.len()` does not equal the logical rank.
+    /// Returns an error if `perm` is not a valid permutation of the logical axes.
     ///
     /// # Examples
     ///
@@ -573,28 +577,39 @@ impl<T: Clone> StructuredStorage<T> {
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
     /// // Diagonal 3x3x3 tensor; permute axes (identity for diag is always valid)
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 3);
-    /// let p = d.permute_logical_axes(&[2, 0, 1]);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0, 3.0], 3).unwrap();
+    /// let p = d.permute_logical_axes(&[2, 0, 1]).unwrap();
     /// // Diagonal: all axes share the same dimension, so dims stay the same
     /// assert_eq!(p.logical_dims(), vec![3, 3, 3]);
     /// assert!(p.is_diag());
     /// ```
-    pub fn permute_logical_axes(&self, perm: &[usize]) -> Self {
-        assert_eq!(
-            perm.len(),
-            self.axis_classes.len(),
+    pub fn permute_logical_axes(&self, perm: &[usize]) -> Result<Self> {
+        ensure!(
+            perm.len() == self.axis_classes.len(),
             "logical permutation length {} must match logical rank {}",
             perm.len(),
             self.axis_classes.len()
         );
-        let axis_classes = perm.iter().map(|&index| self.axis_classes[index]).collect();
+        let mut seen = vec![false; self.axis_classes.len()];
+        let axis_classes = perm
+            .iter()
+            .map(|&index| {
+                ensure!(
+                    index < self.axis_classes.len(),
+                    "logical permutation axis {index} is out of range for rank {}",
+                    self.axis_classes.len()
+                );
+                ensure!(!seen[index], "logical permutation repeats axis {index}");
+                seen[index] = true;
+                Ok(self.axis_classes[index])
+            })
+            .collect::<Result<Vec<_>>>()?;
         Self::new(
             self.data.clone(),
             self.payload_dims.clone(),
             self.strides.clone(),
             axis_classes,
         )
-        .unwrap_or_else(|err| panic!("StructuredStorage::permute_logical_axes failed: {err}"))
     }
 }
 
@@ -606,18 +621,17 @@ impl<T: Copy> StructuredStorage<T> {
     /// ```
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
-    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]);
+    /// let s = StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     /// let doubled = s.map_copy(|x| x * 2.0);
     /// assert_eq!(doubled.data(), &[2.0, 4.0, 6.0]);
     /// ```
     pub fn map_copy<U>(&self, mut f: impl FnMut(T) -> U) -> StructuredStorage<U> {
-        StructuredStorage::new(
-            self.data.iter().copied().map(&mut f).collect(),
-            self.payload_dims.clone(),
-            self.strides.clone(),
-            self.axis_classes.clone(),
-        )
-        .unwrap_or_else(|err| panic!("StructuredStorage::map_copy failed: {err}"))
+        StructuredStorage {
+            data: self.data.iter().copied().map(&mut f).collect(),
+            payload_dims: self.payload_dims.clone(),
+            strides: self.strides.clone(),
+            axis_classes: self.axis_classes.clone(),
+        }
     }
 }
 
@@ -634,7 +648,7 @@ impl<T: Copy + Default> StructuredStorage<T> {
     /// use tensor4all_tensorbackend::StructuredStorage;
     ///
     /// // Diagonal [1, 2] in 2x2 becomes [1, 0, 0, 2] column-major
-    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2);
+    /// let d = StructuredStorage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
     /// assert_eq!(d.logical_dense_col_major_vec(), vec![1.0, 0.0, 0.0, 2.0]);
     /// ```
     pub fn logical_dense_col_major_vec(&self) -> Vec<T> {
@@ -690,7 +704,7 @@ impl<T: Copy + Default> StructuredStorage<T> {
 /// assert!(!s.is_complex());
 ///
 /// // Diagonal storage: 2x2 identity-like diagonal
-/// let diag = Storage::new_diag(vec![1.0_f64, 2.0]);
+/// let diag = Storage::new_diag(vec![1.0_f64, 2.0]).unwrap();
 /// assert!(diag.is_f64());
 /// ```
 #[derive(Debug, Clone)]
@@ -846,6 +860,10 @@ impl Storage {
         Self(repr)
     }
 
+    fn invalid_storage_error(err: anyhow::Error) -> StorageError {
+        StorageError::InvalidStructuredStorage(err.to_string())
+    }
+
     #[cfg(test)]
     pub(crate) fn repr(&self) -> &StorageRepr {
         &self.0
@@ -866,6 +884,10 @@ impl Storage {
     /// Create dense storage from column-major logical values (generic over scalar type).
     ///
     /// The scalar type is inferred from the `data` argument.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the requested dense metadata overflows.
     ///
     /// # Examples
     ///
@@ -918,30 +940,33 @@ impl Storage {
     /// ```
     /// use tensor4all_tensorbackend::Storage;
     ///
-    /// let s = Storage::new_dense::<f64>(5);
+    /// let s = Storage::new_dense::<f64>(5).unwrap();
     /// assert!(s.is_dense());
     /// assert_eq!(s.len(), 5);
     /// assert!((s.max_abs()).abs() < 1e-10);
     /// ```
-    pub fn new_dense<T: StorageScalar + Default>(size: usize) -> Self {
+    pub fn new_dense<T: StorageScalar + Default>(size: usize) -> StorageResult<Self> {
         Self::from_dense_col_major(vec![T::default(); size], &[size])
-            .unwrap_or_else(|err| panic!("Storage::new_dense failed: {err}"))
+            .map_err(Self::invalid_storage_error)
     }
 
     /// Create a new diagonal storage with the given diagonal data (generic over scalar type).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if diagonal metadata is invalid.
     ///
     /// # Examples
     ///
     /// ```
     /// use tensor4all_tensorbackend::Storage;
     ///
-    /// let s = Storage::new_diag(vec![1.0_f64, 2.0, 3.0]);
+    /// let s = Storage::new_diag(vec![1.0_f64, 2.0, 3.0]).unwrap();
     /// assert!(s.is_diag());
     /// assert!(s.is_f64());
     /// ```
-    pub fn new_diag<T: StorageScalar>(diag_data: Vec<T>) -> Self {
-        Self::from_diag_col_major(diag_data, 2)
-            .unwrap_or_else(|err| panic!("Storage::new_diag failed: {err}"))
+    pub fn new_diag<T: StorageScalar>(diag_data: Vec<T>) -> StorageResult<Self> {
+        Self::from_diag_col_major(diag_data, 2).map_err(Self::invalid_storage_error)
     }
 
     /// Create a new structured storage (generic over scalar type).
@@ -992,7 +1017,7 @@ impl Storage {
     pub fn from_dense_f64_col_major(data: Vec<f64>, logical_dims: &[usize]) -> Result<Self> {
         Self::validate_dense_len(&data, logical_dims, "dense f64 payload")?;
         Ok(Self::from_repr(StorageRepr::F64(
-            StructuredStorage::from_dense_col_major(data, logical_dims),
+            StructuredStorage::from_dense_col_major(data, logical_dims)?,
         )))
     }
 
@@ -1016,7 +1041,7 @@ impl Storage {
     pub fn from_dense_c64_col_major(data: Vec<Complex64>, logical_dims: &[usize]) -> Result<Self> {
         Self::validate_dense_len(&data, logical_dims, "dense c64 payload")?;
         Ok(Self::from_repr(StorageRepr::C64(
-            StructuredStorage::from_dense_col_major(data, logical_dims),
+            StructuredStorage::from_dense_col_major(data, logical_dims)?,
         )))
     }
 
@@ -1033,7 +1058,7 @@ impl Storage {
     /// ```
     pub fn from_diag_f64_col_major(diag_data: Vec<f64>, logical_rank: usize) -> Result<Self> {
         Ok(Self::from_repr(StorageRepr::F64(
-            StructuredStorage::from_diag_col_major(diag_data, logical_rank),
+            StructuredStorage::from_diag_col_major(diag_data, logical_rank)?,
         )))
     }
 
@@ -1052,7 +1077,7 @@ impl Storage {
     /// ```
     pub fn from_diag_c64_col_major(diag_data: Vec<Complex64>, logical_rank: usize) -> Result<Self> {
         Ok(Self::from_repr(StorageRepr::C64(
-            StructuredStorage::from_diag_col_major(diag_data, logical_rank),
+            StructuredStorage::from_diag_col_major(diag_data, logical_rank)?,
         )))
     }
 
@@ -1066,7 +1091,7 @@ impl Storage {
     /// let s = Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap();
     /// assert!(s.is_dense());
     ///
-    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]);
+    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]).unwrap();
     /// assert!(!d.is_dense());
     /// ```
     pub fn is_dense(&self) -> bool {
@@ -1083,7 +1108,7 @@ impl Storage {
     /// ```
     /// use tensor4all_tensorbackend::Storage;
     ///
-    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]);
+    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]).unwrap();
     /// assert!(d.is_diag());
     /// ```
     pub fn is_diag(&self) -> bool {
@@ -1364,7 +1389,7 @@ impl Storage {
     /// let s = Storage::from_dense_col_major(vec![1.0_f64, 2.0, 3.0], &[3]).unwrap();
     /// assert_eq!(s.len(), 3);
     ///
-    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]);
+    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]).unwrap();
     /// assert_eq!(d.len(), 2);
     /// ```
     pub fn len(&self) -> usize {
@@ -1381,10 +1406,10 @@ impl Storage {
     /// ```
     /// use tensor4all_tensorbackend::Storage;
     ///
-    /// let s = Storage::new_dense::<f64>(0);
+    /// let s = Storage::new_dense::<f64>(0).unwrap();
     /// assert!(s.is_empty());
     ///
-    /// let s2 = Storage::new_dense::<f64>(3);
+    /// let s2 = Storage::new_dense::<f64>(3).unwrap();
     /// assert!(!s2.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -1507,34 +1532,29 @@ impl Storage {
     /// For Diag storage, creates a Dense storage with diagonal elements set
     /// and off-diagonal elements as zero. For Dense storage, returns a copy.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `dims` does not match the stored logical dimensions.
+    /// Returns an error if `dims` does not match the stored logical dimensions
+    /// or if dense storage construction fails.
     ///
     /// # Examples
     ///
     /// ```
     /// use tensor4all_tensorbackend::Storage;
     ///
-    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]);
-    /// let dense = d.to_dense_storage(&[2, 2]);
+    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]).unwrap();
+    /// let dense = d.to_dense_storage(&[2, 2]).unwrap();
     /// assert!(dense.is_dense());
     /// let vals = dense.to_dense_f64_col_major_vec(&[2, 2]).unwrap();
     /// assert_eq!(vals, vec![1.0, 0.0, 0.0, 2.0]);
     /// ```
-    pub fn to_dense_storage(&self, dims: &[usize]) -> Storage {
+    pub fn to_dense_storage(&self, dims: &[usize]) -> StorageResult<Storage> {
         if self.is_f64() {
-            let values = self
-                .to_dense_f64_col_major_vec(dims)
-                .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"));
-            Storage::from_dense_col_major(values, dims)
-                .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"))
+            let values = self.to_dense_f64_col_major_vec(dims)?;
+            Storage::from_dense_col_major(values, dims).map_err(Self::invalid_storage_error)
         } else {
-            let values = self
-                .to_dense_c64_col_major_vec(dims)
-                .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"));
-            Storage::from_dense_col_major(values, dims)
-                .unwrap_or_else(|err| panic!("Storage::to_dense_storage failed: {err}"))
+            let values = self.to_dense_c64_col_major_vec(dims)?;
+            Storage::from_dense_col_major(values, dims).map_err(Self::invalid_storage_error)
         }
     }
 
@@ -1548,18 +1568,20 @@ impl Storage {
     /// use tensor4all_tensorbackend::Storage;
     ///
     /// // Diagonal 2x2 tensor, permute axes (identity perm for diag is valid)
-    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]);
-    /// let t = d.permute_storage(&[2, 2], &[1, 0]);
+    /// let d = Storage::new_diag(vec![1.0_f64, 2.0]).unwrap();
+    /// let t = d.permute_storage(&[2, 2], &[1, 0]).unwrap();
     /// assert!(t.is_diag());
     /// ```
-    pub fn permute_storage(&self, _dims: &[usize], perm: &[usize]) -> Storage {
+    pub fn permute_storage(&self, _dims: &[usize], perm: &[usize]) -> StorageResult<Storage> {
         match &self.0 {
-            StorageRepr::F64(v) => {
-                Storage::from_repr(StorageRepr::F64(v.permute_logical_axes(perm)))
-            }
-            StorageRepr::C64(v) => {
-                Storage::from_repr(StorageRepr::C64(v.permute_logical_axes(perm)))
-            }
+            StorageRepr::F64(v) => Ok(Storage::from_repr(StorageRepr::F64(
+                v.permute_logical_axes(perm)
+                    .map_err(Self::invalid_storage_error)?,
+            ))),
+            StorageRepr::C64(v) => Ok(Storage::from_repr(StorageRepr::C64(
+                v.permute_logical_axes(perm)
+                    .map_err(Self::invalid_storage_error)?,
+            ))),
         }
     }
 
@@ -1660,9 +1682,10 @@ impl Storage {
     /// `real_storage` becomes the real part, `imag_storage` becomes the imaginary part.
     /// Formula: `real + i * imag`.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if either storage is not f64, or if their lengths differ.
+    /// Returns an error if either storage is not `f64`, if their payload lengths
+    /// differ, or if the result metadata is invalid.
     ///
     /// # Examples
     ///
@@ -1672,33 +1695,46 @@ impl Storage {
     ///
     /// let re = Storage::from_dense_col_major(vec![1.0_f64, 3.0], &[2]).unwrap();
     /// let im = Storage::from_dense_col_major(vec![2.0_f64, 4.0], &[2]).unwrap();
-    /// let c = Storage::combine_to_complex(&re, &im);
+    /// let c = Storage::combine_to_complex(&re, &im).unwrap();
     /// assert!(c.is_c64());
     /// let vals = c.to_dense_c64_col_major_vec(&[2]).unwrap();
     /// assert_eq!(vals[0], Complex64::new(1.0, 2.0));
     /// assert_eq!(vals[1], Complex64::new(3.0, 4.0));
     /// ```
-    pub fn combine_to_complex(real_storage: &Storage, imag_storage: &Storage) -> Storage {
+    pub fn combine_to_complex(
+        real_storage: &Storage,
+        imag_storage: &Storage,
+    ) -> StorageResult<Storage> {
         match (&real_storage.0, &imag_storage.0) {
             (StorageRepr::F64(real), StorageRepr::F64(imag)) => {
-                assert_eq!(real.len(), imag.len(), "Storage lengths must match");
+                if real.len() != imag.len() {
+                    return Err(StorageError::LengthMismatch {
+                        operation: "combine_to_complex",
+                        left: real.len(),
+                        right: imag.len(),
+                    });
+                }
                 let complex_vec: Vec<Complex64> = real
                     .data()
                     .iter()
                     .zip(imag.data().iter())
                     .map(|(&r, &i)| Complex64::new(r, i))
                     .collect();
-                Storage::from_repr(StorageRepr::C64(
+                Ok(Storage::from_repr(StorageRepr::C64(
                     StructuredStorage::new(
                         complex_vec,
                         real.payload_dims().to_vec(),
                         real.strides().to_vec(),
                         real.axis_classes().to_vec(),
                     )
-                    .unwrap_or_else(|err| panic!("Storage::combine_to_complex failed: {err}")),
-                ))
+                    .map_err(Self::invalid_storage_error)?,
+                )))
             }
-            _ => panic!("Both storages must be f64 for combine_to_complex"),
+            _ => Err(StorageError::OperationNotSupported {
+                operation: "combine_to_complex",
+                left: storage_scalar_kind(&real_storage.0),
+                right: storage_scalar_kind(&imag_storage.0),
+            }),
         }
     }
 
@@ -2067,10 +2103,10 @@ pub fn mindim(dims: &[usize]) -> usize {
 /// # Returns
 /// A new `Storage` containing the contracted result.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the contracted dimensions don't match, or if the storage types
-/// are incompatible.
+/// Returns an error if axes are invalid, contracted dimensions do not match, or
+/// the native backend rejects the contraction.
 ///
 /// # Examples
 ///
@@ -2082,7 +2118,7 @@ pub fn mindim(dims: &[usize]) -> usize {
 ///     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3],
 /// ).unwrap();
 /// let v = Storage::from_dense_col_major(vec![1.0, 1.0, 1.0], &[3]).unwrap();
-/// let result = contract_storage(&a, &[2, 3], &[1], &v, &[3], &[0], &[2]);
+/// let result = contract_storage(&a, &[2, 3], &[1], &v, &[3], &[0], &[2]).unwrap();
 /// // Row sums: [1+3+5, 2+4+6] = [9, 12]
 /// let vals = result.to_dense_f64_col_major_vec(&[2]).unwrap();
 /// assert!((vals[0] - 9.0).abs() < 1e-10);
@@ -2096,14 +2132,51 @@ pub fn contract_storage(
     dims_b: &[usize],
     axes_b: &[usize],
     result_dims: &[usize],
-) -> Storage {
-    // Verify that contracted dimensions match
-    for (a_axis, b_axis) in axes_a.iter().zip(axes_b.iter()) {
-        assert_eq!(
-            dims_a[*a_axis], dims_b[*b_axis],
-            "Contracted dimensions must match: dims_a[{}] = {} != dims_b[{}] = {}",
-            a_axis, dims_a[*a_axis], b_axis, dims_b[*b_axis]
-        );
+) -> StorageResult<Storage> {
+    try_contract_storage(
+        storage_a,
+        dims_a,
+        axes_a,
+        storage_b,
+        dims_b,
+        axes_b,
+        result_dims,
+    )
+}
+
+fn try_contract_storage(
+    storage_a: &Storage,
+    dims_a: &[usize],
+    axes_a: &[usize],
+    storage_b: &Storage,
+    dims_b: &[usize],
+    axes_b: &[usize],
+    result_dims: &[usize],
+) -> StorageResult<Storage> {
+    if axes_a.len() != axes_b.len() {
+        return Err(StorageError::InvalidStructuredStorage(format!(
+            "contract axes lengths must match: {} != {}",
+            axes_a.len(),
+            axes_b.len()
+        )));
+    }
+
+    for (&a_axis, &b_axis) in axes_a.iter().zip(axes_b.iter()) {
+        let Some(&a_dim) = dims_a.get(a_axis) else {
+            return Err(StorageError::InvalidStructuredStorage(format!(
+                "contract axis {a_axis} is out of range for left dims {dims_a:?}"
+            )));
+        };
+        let Some(&b_dim) = dims_b.get(b_axis) else {
+            return Err(StorageError::InvalidStructuredStorage(format!(
+                "contract axis {b_axis} is out of range for right dims {dims_b:?}"
+            )));
+        };
+        if a_dim != b_dim {
+            return Err(StorageError::InvalidStructuredStorage(format!(
+                "contracted dimensions must match: dims_a[{a_axis}] = {a_dim} != dims_b[{b_axis}] = {b_dim}"
+            )));
+        }
     }
 
     crate::tenferro_bridge::contract_storage_native(
@@ -2115,27 +2188,7 @@ pub fn contract_storage(
         axes_b,
         result_dims,
     )
-    .unwrap_or_else(|err| panic!("contract_storage failed: {err}"))
-}
-
-/// Add two storages element-wise.
-/// Both storages must have the same type and length.
-///
-/// # Panics
-///
-/// Panics if storage types don't match or lengths differ.
-///
-/// # Note
-///
-/// **Prefer using [`Storage::try_add`]** which returns a `Result` instead of panicking.
-/// This trait implementation is kept for convenience but may panic on invalid inputs.
-impl Add<&Storage> for &Storage {
-    type Output = Storage;
-
-    fn add(self, rhs: &Storage) -> Self::Output {
-        self.try_add(rhs)
-            .unwrap_or_else(|err| panic!("Storage addition failed: {err}"))
-    }
+    .map_err(|err| StorageError::InvalidStructuredStorage(err.to_string()))
 }
 
 /// Multiply storage by a scalar (f64).

--- a/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
@@ -156,6 +156,58 @@ fn try_add_reports_length_mismatch() {
 }
 
 #[test]
+fn dense_storage_materialization_reports_dimension_mismatch() {
+    let storage = Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap();
+
+    let err = storage.to_dense_storage(&[2, 3]).unwrap_err();
+
+    assert!(matches!(err, StorageError::InvalidStructuredStorage(_)));
+    assert!(err.to_string().contains("logical dims"));
+}
+
+#[test]
+fn combine_to_complex_reports_invalid_inputs() {
+    let real = Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap();
+    let short_imag = Storage::from_dense_col_major(vec![3.0_f64], &[1]).unwrap();
+    let complex_imag =
+        Storage::from_dense_col_major(vec![Complex64::new(0.0, 1.0); 2], &[2]).unwrap();
+
+    assert!(matches!(
+        Storage::combine_to_complex(&real, &short_imag).unwrap_err(),
+        StorageError::LengthMismatch {
+            operation: "combine_to_complex",
+            left: 2,
+            right: 1,
+        }
+    ));
+    assert!(matches!(
+        Storage::combine_to_complex(&real, &complex_imag).unwrap_err(),
+        StorageError::OperationNotSupported {
+            operation: "combine_to_complex",
+            left: "f64",
+            right: "Complex64",
+        }
+    ));
+}
+
+#[test]
+fn contract_storage_reports_invalid_axes_and_dimensions() {
+    let a = Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap();
+    let b = Storage::from_dense_col_major(vec![3.0_f64, 4.0, 5.0], &[3]).unwrap();
+
+    let dim_err = contract_storage(&a, &[2], &[0], &b, &[3], &[0], &[]).unwrap_err();
+    assert!(matches!(dim_err, StorageError::InvalidStructuredStorage(_)));
+    assert!(dim_err.to_string().contains("contracted dimensions"));
+
+    let axis_err = contract_storage(&a, &[2], &[1], &b, &[3], &[0], &[]).unwrap_err();
+    assert!(matches!(
+        axis_err,
+        StorageError::InvalidStructuredStorage(_)
+    ));
+    assert!(axis_err.to_string().contains("axis"));
+}
+
+#[test]
 fn structured_storage_rejects_noncanonical_axis_classes() {
     let err = StructuredStorage::<f64>::new(
         vec![1.0, 2.0, 3.0, 4.0],
@@ -171,7 +223,8 @@ fn structured_storage_rejects_noncanonical_axis_classes() {
 #[test]
 fn structured_storage_column_major_helpers_cover_contiguous_padded_and_empty_payloads() {
     let dense =
-        StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3]);
+        StructuredStorage::from_dense_col_major(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0], &[2, 3])
+            .unwrap();
     assert_eq!(dense.logical_dims(), vec![2, 3]);
     assert!(dense.is_dense());
     assert!(!dense.is_diag());
@@ -197,7 +250,7 @@ fn structured_storage_column_major_helpers_cover_contiguous_padded_and_empty_pay
         vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
     );
 
-    let empty = StructuredStorage::from_dense_col_major(Vec::<f64>::new(), &[0, 3]);
+    let empty = StructuredStorage::from_dense_col_major(Vec::<f64>::new(), &[0, 3]).unwrap();
     assert!(empty.is_empty());
     assert_eq!(empty.payload_col_major_vec(), Vec::<f64>::new());
 }
@@ -213,7 +266,7 @@ fn structured_storage_permute_and_map_copy_preserve_metadata() {
     .unwrap();
     assert_eq!(storage.logical_dims(), vec![2, 3, 2]);
 
-    let permuted = storage.permute_logical_axes(&[0, 2, 1]);
+    let permuted = storage.permute_logical_axes(&[0, 2, 1]).unwrap();
     assert_eq!(permuted.axis_classes(), &[0, 0, 1]);
     assert_eq!(permuted.logical_dims(), vec![2, 2, 3]);
 
@@ -234,7 +287,7 @@ fn structured_storage_validates_payload_rank_and_required_len() {
         .unwrap_err();
     assert!(len_err.to_string().contains("required len"));
 
-    let scalar_diag = StructuredStorage::from_diag_col_major(vec![42.0], 0);
+    let scalar_diag = StructuredStorage::from_diag_col_major(vec![42.0], 0).unwrap();
     assert_eq!(scalar_diag.payload_dims(), &[] as &[usize]);
     assert_eq!(scalar_diag.logical_rank(), 0);
     assert!(scalar_diag.is_dense());
@@ -259,7 +312,7 @@ fn test_storage_len_is_empty() {
 
 #[test]
 fn test_storage_new_dense_f64() {
-    let s = Storage::new_dense::<f64>(3);
+    let s = Storage::new_dense::<f64>(3).unwrap();
     assert_eq!(s.len(), 3);
     assert!(s.is_f64());
     let data = extract_f64(&s);
@@ -268,7 +321,7 @@ fn test_storage_new_dense_f64() {
 
 #[test]
 fn test_storage_new_dense_c64() {
-    let s = Storage::new_dense::<Complex64>(2);
+    let s = Storage::new_dense::<Complex64>(2).unwrap();
     assert_eq!(s.len(), 2);
     assert!(s.is_c64());
 }
@@ -326,7 +379,7 @@ fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
     )
     .unwrap();
     assert!((dense_c64.max_abs() - 5.0).abs() < 1e-10);
-    match dense_c64.to_dense_storage(&[2]).repr() {
+    match dense_c64.to_dense_storage(&[2]).unwrap().repr() {
         StorageRepr::C64(ds) => assert_eq!(
             ds.payload_col_major_vec().as_slice(),
             &[Complex64::new(3.0, 4.0), Complex64::new(1.0, -1.0)]
@@ -338,7 +391,7 @@ fn test_storage_max_abs_and_to_dense_storage_cover_complex_and_diag() {
         Storage::from_diag_col_major(vec![Complex64::new(0.0, 2.0), Complex64::new(3.0, 4.0)], 2)
             .unwrap();
     assert!((diag_c64.max_abs() - 5.0).abs() < 1e-10);
-    match diag_c64.to_dense_storage(&[2, 2]).repr() {
+    match diag_c64.to_dense_storage(&[2, 2]).unwrap().repr() {
         StorageRepr::C64(ds) => {
             assert_eq!(
                 ds.payload_col_major_vec().as_slice(),
@@ -401,7 +454,7 @@ fn test_storage_projection_promotion_and_conjugation_helpers() {
     }
     let real = Storage::from_dense_col_major(vec![1.0, 2.0], &[2]).unwrap();
     let imag = Storage::from_dense_col_major(vec![0.5, -1.5], &[2]).unwrap();
-    match Storage::combine_to_complex(&real, &imag).repr() {
+    match Storage::combine_to_complex(&real, &imag).unwrap().repr() {
         StorageRepr::C64(ds) => {
             assert_eq!(
                 ds.payload_col_major_vec().as_slice(),
@@ -516,7 +569,7 @@ fn test_storage_try_add_and_try_sub_cover_all_variants_and_errors() {
 #[test]
 fn test_structured_storage_permute_logical_axes_basic() {
     let storage = StructuredStorage::new(vec![1.0, 2.0], vec![2], vec![1], vec![0, 0]).unwrap();
-    let permuted = storage.permute_logical_axes(&[1, 0]);
+    let permuted = storage.permute_logical_axes(&[1, 0]).unwrap();
     // Permuting a diagonal storage: axis_classes should be swapped but are the same
     assert_eq!(permuted.axis_classes(), &[0, 0]);
 }
@@ -590,7 +643,7 @@ fn test_storage_axpby_complex_promotion() {
 
 #[test]
 fn test_storage_new_diag_f64() {
-    let s = Storage::new_diag::<f64>(vec![1.0, 2.0, 3.0]);
+    let s = Storage::new_diag::<f64>(vec![1.0, 2.0, 3.0]).unwrap();
     assert_eq!(s.len(), 3);
     assert!(s.is_f64());
     assert!(s.is_diag());
@@ -599,7 +652,8 @@ fn test_storage_new_diag_f64() {
 #[test]
 fn test_storage_new_diag_c64() {
     let s =
-        Storage::new_diag::<Complex64>(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]);
+        Storage::new_diag::<Complex64>(vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)])
+            .unwrap();
     assert_eq!(s.len(), 2);
     assert!(s.is_c64());
     assert!(s.is_diag());
@@ -668,7 +722,7 @@ fn test_storage_max_abs_structured() {
 fn test_storage_permute_storage_structured_diag() {
     // Diagonal structured storage: permuting is trivial (data doesn't change).
     let s = Storage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
-    let permuted = s.permute_storage(&[3, 3], &[1, 0]);
+    let permuted = s.permute_storage(&[3, 3], &[1, 0]).unwrap();
     assert!(permuted.is_f64());
     assert!(permuted.is_diag());
 }
@@ -678,7 +732,7 @@ fn test_storage_permute_storage_structured_diag_c64() {
     let s =
         Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)], 2)
             .unwrap();
-    let permuted = s.permute_storage(&[2, 2], &[1, 0]);
+    let permuted = s.permute_storage(&[2, 2], &[1, 0]).unwrap();
     assert!(permuted.is_c64());
     assert!(permuted.is_diag());
 }
@@ -752,7 +806,7 @@ fn test_storage_to_complex_structured() {
 #[test]
 fn test_storage_to_dense_storage_structured_f64() {
     let s = Storage::from_diag_col_major(vec![1.0, 2.0], 2).unwrap();
-    let dense = s.to_dense_storage(&[2, 2]);
+    let dense = s.to_dense_storage(&[2, 2]).unwrap();
     assert!(dense.is_dense());
     assert!(dense.is_f64());
 }
@@ -762,7 +816,7 @@ fn test_storage_to_dense_storage_structured_c64() {
     let s =
         Storage::from_diag_col_major(vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)], 2)
             .unwrap();
-    let dense = s.to_dense_storage(&[2, 2]);
+    let dense = s.to_dense_storage(&[2, 2]).unwrap();
     assert!(dense.is_dense());
     assert!(dense.is_c64());
 }
@@ -899,7 +953,7 @@ fn test_contract_storage_dense_f64_matmul() {
     let a = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
     let b = Storage::from_dense_col_major(vec![5.0, 7.0, 6.0, 8.0], &[2, 2]).unwrap();
 
-    let result = contract_storage(&a, &[2, 2], &[1], &b, &[2, 2], &[0], &[2, 2]);
+    let result = contract_storage(&a, &[2, 2], &[1], &b, &[2, 2], &[0], &[2, 2]).unwrap();
 
     let data = result
         .to_dense_f64_col_major_vec(&[2, 2])
@@ -920,7 +974,7 @@ fn test_contract_storage_diag_f64_partial() {
     let diag1 = Storage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2).unwrap();
     let diag2 = Storage::from_diag_col_major(vec![4.0, 5.0, 6.0], 2).unwrap();
 
-    let result = contract_storage(&diag1, &[3, 3], &[1], &diag2, &[3, 3], &[0], &[3, 3]);
+    let result = contract_storage(&diag1, &[3, 3], &[1], &diag2, &[3, 3], &[0], &[3, 3]).unwrap();
 
     // Materialize as dense to verify
     let dense = result
@@ -938,7 +992,7 @@ fn test_contract_storage_inner_product() {
     let a = Storage::from_dense_col_major(vec![1.0, 2.0, 3.0], &[3]).unwrap();
     let b = Storage::from_dense_col_major(vec![4.0, 5.0, 6.0], &[3]).unwrap();
 
-    let result = contract_storage(&a, &[3], &[0], &b, &[3], &[0], &[]);
+    let result = contract_storage(&a, &[3], &[0], &b, &[3], &[0], &[]).unwrap();
 
     let data = result
         .to_dense_f64_col_major_vec(&[])

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -49,7 +49,7 @@ fn storage_native_roundtrip_diag_densifies_at_public_bridge() {
     let storage = Storage::from_diag_col_major(vec![2.0, -1.0, 4.0], 2).unwrap();
     let native = storage_to_native_tensor(&storage, &[3, 3]).unwrap();
     let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
-    let expected = storage.to_dense_storage(&[3, 3]);
+    let expected = storage.to_dense_storage(&[3, 3]).unwrap();
 
     assert_eq!(native.shape(), &[3, 3]);
     assert_storage_eq(&roundtrip, &expected);
@@ -66,7 +66,7 @@ fn storage_native_roundtrip_structured_c64_densifies_at_public_bridge() {
     .unwrap();
     let native = storage_to_native_tensor(&storage, &[2, 2]).unwrap();
     let roundtrip = native_tensor_primal_to_storage(&native).unwrap();
-    let expected = storage.to_dense_storage(&[2, 2]);
+    let expected = storage.to_dense_storage(&[2, 2]).unwrap();
 
     assert_eq!(native.shape(), &[2, 2]);
     assert_storage_eq(&roundtrip, &expected);

--- a/crates/tensor4all-treetci/src/lib.rs
+++ b/crates/tensor4all-treetci/src/lib.rs
@@ -109,3 +109,22 @@ pub use proposer::{
 pub use state::SimpleTreeTci;
 pub use state::TreeTCI2;
 pub use visitor::{AllEdges, EdgeVisitor};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::ColMajorArray;
+
+    #[test]
+    fn two_dimensional_column_helpers_report_shape_errors() {
+        let one_dimensional = ColMajorArray::new(vec![1usize, 2, 3], vec![3]).unwrap();
+        let err = ncols_2d(&one_dimensional).unwrap_err();
+        assert!(err.to_string().contains("expected 2D ColMajorArray"));
+        assert!(err.to_string().contains("[3]"));
+
+        let matrix = ColMajorArray::new(vec![1usize, 2, 3, 4], vec![2, 2]).unwrap();
+        let err = column_2d(&matrix, 2).unwrap_err();
+        assert!(err.to_string().contains("column 2 is out of range"));
+        assert!(err.to_string().contains("[2, 2]"));
+    }
+}

--- a/crates/tensor4all-treetci/src/lib.rs
+++ b/crates/tensor4all-treetci/src/lib.rs
@@ -51,6 +51,24 @@
 
 #![warn(missing_docs)]
 
+pub(crate) fn ncols_2d<T>(array: &tensor4all_core::ColMajorArray<T>) -> anyhow::Result<usize> {
+    array
+        .ncols()
+        .ok_or_else(|| anyhow::anyhow!("expected 2D ColMajorArray, got shape {:?}", array.shape()))
+}
+
+pub(crate) fn column_2d<T>(
+    array: &tensor4all_core::ColMajorArray<T>,
+    column: usize,
+) -> anyhow::Result<&[T]> {
+    array.column(column).ok_or_else(|| {
+        anyhow::anyhow!(
+            "column {column} is out of range for shape {:?}",
+            array.shape()
+        )
+    })
+}
+
 /// High-level TreeTCI entry points.
 pub mod api;
 /// Assembly helpers from subtree-local pivots to global site-order indices.

--- a/crates/tensor4all-treetci/src/materialize.rs
+++ b/crates/tensor4all-treetci/src/materialize.rs
@@ -1,6 +1,7 @@
 use crate::{
     assemble::{assemble_points_column_major, MultiIndex},
-    assemble_global_point, GlobalIndexBatch, SubtreeKey, TreeTCI2, TreeTciEdge,
+    assemble_global_point, column_2d, ncols_2d, GlobalIndexBatch, SubtreeKey, TreeTCI2,
+    TreeTciEdge,
 };
 use anyhow::{ensure, Result};
 use num_complex::{Complex32, Complex64};
@@ -96,8 +97,18 @@ where
     let mut bond_indices = HashMap::new();
     for edge in state.graph.edges() {
         let (left_key, right_key) = state.graph.subregion_vertices(edge)?;
-        let left_rank = state.ijset.get(&left_key).map_or(0, |arr| arr.ncols());
-        let right_rank = state.ijset.get(&right_key).map_or(0, |arr| arr.ncols());
+        let left_rank = state
+            .ijset
+            .get(&left_key)
+            .map(ncols_2d)
+            .transpose()?
+            .unwrap_or(0);
+        let right_rank = state
+            .ijset
+            .get(&right_key)
+            .map(ncols_2d)
+            .transpose()?
+            .unwrap_or(0);
         ensure!(
             left_rank == right_rank,
             "bond ranks disagree across edge {:?}: left {}, right {}",
@@ -189,8 +200,8 @@ where
     let p_rows = state
         .ijset
         .get(&site_side_key)
-        .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", site_side_key))?
-        .ncols();
+        .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", site_side_key))
+        .and_then(ncols_2d)?;
     ensure!(
         p_rows == cols,
         "pivot matrix for site {} is not square: {} x {}",
@@ -223,8 +234,8 @@ fn product_pivot_dims<T>(state: &TreeTCI2<T>, keys: &[SubtreeKey]) -> Result<usi
         let dim = state
             .ijset
             .get(key)
-            .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", key))?
-            .ncols();
+            .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", key))
+            .and_then(ncols_2d)?;
         product = product.saturating_mul(dim.max(1));
     }
     Ok(product)
@@ -291,9 +302,9 @@ fn cartesian_entries(
             let arr = ijset
                 .get(key)
                 .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", key))?;
-            let columns: Vec<MultiIndex> = (0..arr.ncols())
-                .map(|j| arr.column(j).expect("column index in range").to_vec())
-                .collect();
+            let columns: Vec<MultiIndex> = (0..ncols_2d(arr)?)
+                .map(|j| column_2d(arr, j).map(|column| column.to_vec()))
+                .collect::<Result<_>>()?;
             Ok(columns)
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/tensor4all-treetci/src/materialize/tests.rs
+++ b/crates/tensor4all-treetci/src/materialize/tests.rs
@@ -63,7 +63,7 @@ fn to_treetn_preserves_two_site_identity_evaluations() {
         data[pos0] = i;
         data[pos1] = j;
         let shape = [indices.len(), 1];
-        let values = ColMajorArrayRef::new(&data, &shape);
+        let values = ColMajorArrayRef::new(&data, &shape).unwrap();
         tn.evaluate(&indices, values).unwrap()[0].real()
     };
 

--- a/crates/tensor4all-treetci/src/proposer.rs
+++ b/crates/tensor4all-treetci/src/proposer.rs
@@ -1,4 +1,4 @@
-use crate::{assemble::MultiIndex, SubtreeKey, TreeTCI2, TreeTciEdge};
+use crate::{assemble::MultiIndex, column_2d, ncols_2d, SubtreeKey, TreeTCI2, TreeTciEdge};
 use anyhow::{ensure, Result};
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
@@ -69,8 +69,8 @@ impl PivotCandidateProposer for DefaultProposer {
         let jset = kronecker(&jpivots, jsite_index, state.local_dims[vq]);
 
         let history = state.ijset_history.last();
-        let icombined = union_with_history(iset, history, &ikey);
-        let jcombined = union_with_history(jset, history, &jkey);
+        let icombined = union_with_history(iset, history, &ikey)?;
+        let jcombined = union_with_history(jset, history, &jkey)?;
         Ok((icombined, jcombined))
     }
 }
@@ -127,27 +127,25 @@ impl PivotCandidateProposer for SimpleProposer {
     ) -> Result<(Vec<MultiIndex>, Vec<MultiIndex>)> {
         let (vp, vq) = state.graph.separate_vertices(edge)?;
         let (ikey, jkey) = state.graph.subregion_vertices(edge)?;
-        let mut rng = rng_for_edge(state, edge, self.seed, "simple");
+        let mut rng = rng_for_edge(state, edge, self.seed, "simple")?;
 
-        let ichi = state.local_dims[vp]
-            * state
-                .ijset
-                .get(&ikey)
-                .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", ikey))?
-                .ncols();
-        let jchi = state.local_dims[vq]
-            * state
-                .ijset
-                .get(&jkey)
-                .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", jkey))?
-                .ncols();
+        let ichi =
+            state.local_dims[vp]
+                * ncols_2d(state.ijset.get(&ikey).ok_or_else(|| {
+                    anyhow::anyhow!("missing pivot set for subtree key {:?}", ikey)
+                })?)?;
+        let jchi =
+            state.local_dims[vq]
+                * ncols_2d(state.ijset.get(&jkey).ok_or_else(|| {
+                    anyhow::anyhow!("missing pivot set for subtree key {:?}", jkey)
+                })?)?;
 
         let iset = random_candidates(&mut rng, state.local_dims.as_slice(), &ikey, ichi);
         let jset = random_candidates(&mut rng, state.local_dims.as_slice(), &jkey, jchi);
 
         let history = state.ijset_history.last();
-        let icombined = union_with_history(iset, history, &ikey);
-        let jcombined = union_with_history(jset, history, &jkey);
+        let icombined = union_with_history(iset, history, &ikey)?;
+        let jcombined = union_with_history(jset, history, &jkey)?;
         Ok((icombined, jcombined))
     }
 }
@@ -202,20 +200,18 @@ impl PivotCandidateProposer for TruncatedDefaultProposer {
         let (vp, vq) = state.graph.separate_vertices(edge)?;
         let (ikey, jkey) = state.graph.subregion_vertices(edge)?;
         let (default_i, default_j) = DefaultProposer.candidates(state, edge)?;
-        let mut rng = rng_for_edge(state, edge, self.seed, "truncated_default");
+        let mut rng = rng_for_edge(state, edge, self.seed, "truncated_default")?;
 
-        let ichi = state.local_dims[vp]
-            * state
-                .ijset
-                .get(&ikey)
-                .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", ikey))?
-                .ncols();
-        let jchi = state.local_dims[vq]
-            * state
-                .ijset
-                .get(&jkey)
-                .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", jkey))?
-                .ncols();
+        let ichi =
+            state.local_dims[vp]
+                * ncols_2d(state.ijset.get(&ikey).ok_or_else(|| {
+                    anyhow::anyhow!("missing pivot set for subtree key {:?}", ikey)
+                })?)?;
+        let jchi =
+            state.local_dims[vq]
+                * ncols_2d(state.ijset.get(&jkey).ok_or_else(|| {
+                    anyhow::anyhow!("missing pivot set for subtree key {:?}", jkey)
+                })?)?;
 
         Ok((
             sample_ordered_candidates(&default_i, ichi, &mut rng),
@@ -235,7 +231,7 @@ fn union_with_history(
     values: Vec<MultiIndex>,
     history: Option<&HashMap<SubtreeKey, ColMajorArray<usize>>>,
     key: &SubtreeKey,
-) -> Vec<MultiIndex> {
+) -> Result<Vec<MultiIndex>> {
     let mut unique = Vec::with_capacity(values.len());
     for candidate in values {
         if !unique.contains(&candidate) {
@@ -243,14 +239,14 @@ fn union_with_history(
         }
     }
     if let Some(arr) = history.and_then(|history| history.get(key)) {
-        for j in 0..arr.ncols() {
-            let col = arr.column(j).expect("column index in range").to_vec();
+        for j in 0..ncols_2d(arr)? {
+            let col = column_2d(arr, j)?.to_vec();
             if !unique.contains(&col) {
                 unique.push(col);
             }
         }
     }
-    unique
+    Ok(unique)
 }
 
 fn pivot_set(
@@ -267,8 +263,8 @@ fn pivot_set(
             .ok_or_else(|| anyhow::anyhow!("missing pivot set for subtree key {:?}", in_key))?;
         let mut next = Vec::new();
         for base in &pivots {
-            for j in 0..incoming.ncols() {
-                let index = incoming.column(j).expect("column index in range");
+            for j in 0..ncols_2d(incoming)? {
+                let index = column_2d(incoming, j)?;
                 ensure!(
                     index.len() == in_key.as_slice().len(),
                     "pivot length {} does not match subtree key length {}",
@@ -317,11 +313,13 @@ fn random_candidates(
         .collect()
 }
 
-fn rng_for_edge<T>(state: &TreeTCI2<T>, edge: TreeTciEdge, seed: u64, tag: &str) -> SmallRng {
-    let (ikey, jkey) = state
-        .graph
-        .subregion_vertices(edge)
-        .expect("edge must belong to the tree graph");
+fn rng_for_edge<T>(
+    state: &TreeTCI2<T>,
+    edge: TreeTciEdge,
+    seed: u64,
+    tag: &str,
+) -> Result<SmallRng> {
+    let (ikey, jkey) = state.graph.subregion_vertices(edge)?;
     let mut hasher = DefaultHasher::new();
     seed.hash(&mut hasher);
     tag.hash(&mut hasher);
@@ -330,14 +328,18 @@ fn rng_for_edge<T>(state: &TreeTCI2<T>, edge: TreeTciEdge, seed: u64, tag: &str)
     state
         .ijset
         .get(&ikey)
-        .map_or(0usize, |arr| arr.ncols())
+        .map(ncols_2d)
+        .transpose()?
+        .unwrap_or(0)
         .hash(&mut hasher);
     state
         .ijset
         .get(&jkey)
-        .map_or(0usize, |arr| arr.ncols())
+        .map(ncols_2d)
+        .transpose()?
+        .unwrap_or(0)
         .hash(&mut hasher);
-    SmallRng::seed_from_u64(hasher.finish())
+    Ok(SmallRng::seed_from_u64(hasher.finish()))
 }
 
 fn sample_ordered_candidates(

--- a/crates/tensor4all-treetci/src/state.rs
+++ b/crates/tensor4all-treetci/src/state.rs
@@ -1,5 +1,6 @@
-use crate::{assemble::MultiIndex, SubtreeKey, TreeTciEdge, TreeTciGraph};
+use crate::{assemble::MultiIndex, column_2d, ncols_2d, SubtreeKey, TreeTciEdge, TreeTciGraph};
 use anyhow::{ensure, Result};
+use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::marker::PhantomData;
 use tensor4all_core::ColMajorArray;
@@ -104,25 +105,33 @@ impl<T> TreeTCI2<T> {
                 let right_projection = project_pivot(pivot, &right_key);
                 let n_left = left_key.as_slice().len();
                 let n_right = right_key.as_slice().len();
-                push_unique_column(
-                    self.ijset
-                        .entry(left_key)
-                        .or_insert_with(|| empty_2d(n_left)),
-                    &left_projection,
-                );
-                push_unique_column(
-                    self.ijset
-                        .entry(right_key)
-                        .or_insert_with(|| empty_2d(n_right)),
-                    &right_projection,
-                );
+                match self.ijset.entry(left_key) {
+                    Entry::Occupied(mut entry) => {
+                        push_unique_column(entry.get_mut(), &left_projection)?;
+                    }
+                    Entry::Vacant(entry) => {
+                        let mut array = empty_2d(n_left)?;
+                        push_unique_column(&mut array, &left_projection)?;
+                        entry.insert(array);
+                    }
+                }
+                match self.ijset.entry(right_key) {
+                    Entry::Occupied(mut entry) => {
+                        push_unique_column(entry.get_mut(), &right_projection)?;
+                    }
+                    Entry::Vacant(entry) => {
+                        let mut array = empty_2d(n_right)?;
+                        push_unique_column(&mut array, &right_projection)?;
+                        entry.insert(array);
+                    }
+                }
             }
         }
 
         let full_key = SubtreeKey::new((0..n_sites).collect());
-        self.ijset
-            .entry(full_key)
-            .or_insert_with(|| empty_2d(n_sites));
+        if let Entry::Vacant(entry) = self.ijset.entry(full_key) {
+            entry.insert(empty_2d(n_sites)?);
+        }
         Ok(())
     }
 
@@ -154,7 +163,7 @@ impl<T> TreeTCI2<T> {
     pub fn max_rank(&self) -> usize {
         self.ijset
             .values()
-            .map(|arr| arr.ncols())
+            .filter_map(|arr| arr.ncols())
             .max()
             .unwrap_or(0)
     }
@@ -165,20 +174,19 @@ fn project_pivot(pivot: &MultiIndex, key: &SubtreeKey) -> MultiIndex {
 }
 
 /// Create an empty 2D ColMajorArray with shape [nrows, 0].
-fn empty_2d(nrows: usize) -> ColMajorArray<usize> {
-    ColMajorArray::new(vec![], vec![nrows, 0]).expect("empty 2D array creation should not fail")
+fn empty_2d(nrows: usize) -> Result<ColMajorArray<usize>> {
+    Ok(ColMajorArray::new(vec![], vec![nrows, 0])?)
 }
 
 /// Push a column to a ColMajorArray if it is not already present.
-pub(crate) fn push_unique_column(array: &mut ColMajorArray<usize>, column: &[usize]) {
-    for j in 0..array.ncols() {
-        if array.column(j) == Some(column) {
-            return; // duplicate
+pub(crate) fn push_unique_column(array: &mut ColMajorArray<usize>, column: &[usize]) -> Result<()> {
+    for j in 0..ncols_2d(array)? {
+        if column_2d(array, j)? == column {
+            return Ok(()); // duplicate
         }
     }
-    array
-        .push_column(column)
-        .expect("push_column should not fail for matching nrows");
+    array.push_column(column)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-treetci/tests/advanced_quantics.rs
+++ b/crates/tensor4all-treetci/tests/advanced_quantics.rs
@@ -39,7 +39,7 @@ fn evaluate_treetn(
         data[pos] = value;
     }
     let shape = [indices.len(), 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     tn.evaluate(&indices, values).unwrap()[0].real()
 }
 

--- a/crates/tensor4all-treetci/tests/simple_parity.rs
+++ b/crates/tensor4all-treetci/tests/simple_parity.rs
@@ -81,7 +81,7 @@ fn simple_tree_parity_matches_reference_points() {
             data[pos[v]] = val;
         }
         let shape = [indices.len(), 1];
-        let values = ColMajorArrayRef::new(&data, &shape);
+        let values = ColMajorArrayRef::new(&data, &shape).unwrap();
         tn.evaluate(&indices, values).unwrap()[0].real()
     };
 
@@ -136,7 +136,7 @@ fn simple_tree_product_function_is_exact_on_branching_tree() {
             data[pos[v]] = val;
         }
         let shape = [indices.len(), 1];
-        let values = ColMajorArrayRef::new(&data, &shape);
+        let values = ColMajorArrayRef::new(&data, &shape).unwrap();
         tn.evaluate(&indices, values).unwrap()[0].real()
     };
 
@@ -195,7 +195,7 @@ fn simple_tree_complex_product_function_is_exact_on_branching_tree() {
             data[pos[v]] = val;
         }
         let shape = [indices.len(), 1];
-        let values = ColMajorArrayRef::new(&data, &shape);
+        let values = ColMajorArrayRef::new(&data, &shape).unwrap();
         tn.evaluate(&indices, values)
             .unwrap()
             .into_iter()
@@ -264,7 +264,7 @@ fn simple_tree_complex_product_function_is_exact_on_two_site_tree() {
                 data[pos[v]] = val;
             }
             let shape = [indices.len(), 1];
-            let values = ColMajorArrayRef::new(&data, &shape);
+            let values = ColMajorArrayRef::new(&data, &shape).unwrap();
             let value = tn
                 .evaluate(&indices, values)
                 .unwrap()

--- a/crates/tensor4all-treetn/benches/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/benches/cached_evaluator.rs
@@ -109,7 +109,7 @@ fn bench_chain_size_scaling(c: &mut Criterion) {
             &values,
             |b, values| {
                 b.iter(|| {
-                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let points = ColMajorArrayRef::new(black_box(values), &shape).unwrap();
                     let mut evaluator = TreeTNCachedEvaluator::new(
                         &tree,
                         &site_indices,
@@ -126,7 +126,7 @@ fn bench_chain_size_scaling(c: &mut Criterion) {
             &values,
             |b, values| {
                 b.iter(|| {
-                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let points = ColMajorArrayRef::new(black_box(values), &shape).unwrap();
                     tree.evaluate(&site_indices, points).unwrap()
                 })
             },
@@ -175,7 +175,7 @@ fn bench_batch_size_scaling(c: &mut Criterion) {
             &values,
             |b, values| {
                 b.iter(|| {
-                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let points = ColMajorArrayRef::new(black_box(values), &shape).unwrap();
                     let mut evaluator = TreeTNCachedEvaluator::new(
                         &tree,
                         &site_indices,
@@ -192,7 +192,7 @@ fn bench_batch_size_scaling(c: &mut Criterion) {
             &values,
             |b, values| {
                 b.iter(|| {
-                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let points = ColMajorArrayRef::new(black_box(values), &shape).unwrap();
                     tree.evaluate(&site_indices, points).unwrap()
                 })
             },
@@ -235,7 +235,7 @@ fn bench_bond_dim_scaling(c: &mut Criterion) {
             &values,
             |b, values| {
                 b.iter(|| {
-                    let points = ColMajorArrayRef::new(black_box(values), &shape);
+                    let points = ColMajorArrayRef::new(black_box(values), &shape).unwrap();
                     let mut evaluator = TreeTNCachedEvaluator::new(
                         &tree,
                         &site_indices,

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
@@ -103,7 +103,7 @@ fn create_random_chain_mpo_with_internal_indices(
     }
 
     let mut rng = StdRng::seed_from_u64(seed);
-    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim));
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim)).unwrap();
     (mpo, s_in_tmp, s_out_tmp)
 }
 

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
@@ -198,7 +198,7 @@ fn create_random_mpo_operator(
         let node_name = make_node_name(i);
 
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
-        let t = TensorDynLen::random::<f64, _>(rng, indices);
+        let t = TensorDynLen::random::<f64, _>(rng, indices)?;
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);

--- a/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
+++ b/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
@@ -102,7 +102,7 @@ fn create_random_mps_chain_with_sites(
         } else {
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
-        let t = TensorDynLen::random::<f64, _>(rng, indices);
+        let t = TensorDynLen::random::<f64, _>(rng, indices)?;
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }

--- a/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
@@ -186,7 +186,7 @@ fn create_random_operator(
     for i in 0..n {
         let node_name = make_node_name(i);
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
-        let t = TensorDynLen::random::<f64, _>(rng, indices);
+        let t = TensorDynLen::random::<f64, _>(rng, indices)?;
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);

--- a/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
@@ -177,7 +177,7 @@ fn create_random_chain_mpo_with_internal_indices(
     }
 
     let mut rng = StdRng::seed_from_u64(seed);
-    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim));
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, LinkSpace::uniform(mpo_bond_dim)).unwrap();
     (mpo, s_in_tmp, s_out_tmp)
 }
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
@@ -161,7 +161,7 @@ fn create_random_mps_with_same_sites(
                     bond_indices[i].clone(),
                 ],
             )
-        };
+        }?;
         mps.add_tensor(name, tensor).unwrap();
     }
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
@@ -265,7 +265,7 @@ fn create_random_mps_with_same_sites(
                     bond_indices[i].clone(),
                 ],
             )
-        };
+        }?;
         mps.add_tensor(name, tensor).unwrap();
     }
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
@@ -244,7 +244,7 @@ fn create_random_mps_with_same_sites(
                     bond_indices[i].clone(),
                 ],
             )
-        };
+        }?;
         mps.add_tensor(name, tensor).unwrap();
     }
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
@@ -137,7 +137,7 @@ fn create_random_mps_with_same_sites(
                     bond_indices[i].clone(),
                 ],
             )
-        };
+        }?;
         mps.add_tensor(name, tensor).unwrap();
     }
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
@@ -137,7 +137,7 @@ fn create_random_mps_with_same_sites(
                     bond_indices[i].clone(),
                 ],
             )
-        };
+        }?;
         mps.add_tensor(name, tensor).unwrap();
     }
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
@@ -185,7 +185,7 @@ fn create_random_mpo_matching_structure(
         let node_idx = mpo.node_index(&node_name).unwrap();
         let t = mpo.tensor(node_idx).unwrap();
         let indices = t.external_indices();
-        let new_t = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let new_t = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
         mpo.replace_tensor(node_idx, new_t)?;
     }
     Ok(mpo)
@@ -203,7 +203,7 @@ fn create_random_mpo_matching_structure_c64(
         let node_idx = mpo.node_index(&node_name).unwrap();
         let t = mpo.tensor(node_idx).unwrap();
         let indices = t.external_indices();
-        let new_t = TensorDynLen::random::<Complex64, _>(&mut rng, indices);
+        let new_t = TensorDynLen::random::<Complex64, _>(&mut rng, indices)?;
         mpo.replace_tensor(node_idx, new_t)?;
     }
     Ok(mpo)

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
@@ -243,7 +243,7 @@ fn create_random_mpo_state_c64(
                 s_out_tmp[i].clone(),
                 s_in_tmp[i].clone(),
             ],
-        );
+        )?;
 
         let t = if indices.len() == 2 {
             // n == 1 case: [external, s_out, s_in]

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
@@ -321,7 +321,7 @@ fn create_random_mpo_state(
                 s_out_tmp[i].clone(),
                 s_in_tmp[i].clone(),
             ],
-        );
+        )?;
 
         let t = if indices.len() == 2 {
             // n == 1 case: [external, s_out, s_in]

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
@@ -57,7 +57,7 @@ fn create_random_mps_chain_with_sites_c64(
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
 
-        let t = TensorDynLen::random::<Complex64, _>(rng, indices);
+        let t = TensorDynLen::random::<Complex64, _>(rng, indices)?;
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
@@ -209,7 +209,7 @@ fn create_random_mps_chain_with_sites_c64(
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
 
-        let t = TensorDynLen::random::<Complex64, _>(rng, indices);
+        let t = TensorDynLen::random::<Complex64, _>(rng, indices)?;
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }

--- a/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
@@ -146,14 +146,20 @@ where
 
             let mut transformed_v = v.clone();
             for (node, (temp_in, _temp_out, _)) in region.iter().zip(per_node.iter()) {
-                let im = input_mapping.get(node).unwrap();
+                let im = input_mapping
+                    .get(node)
+                    .ok_or_else(|| anyhow::anyhow!("Missing input_mapping for node {:?}", node))?;
                 transformed_v = transformed_v.replaceind(&im.true_index, temp_in)?;
             }
             all_tensors.push(transformed_v);
 
             for (node, (temp_in, temp_out, true_idx)) in region.iter().zip(per_node.iter()) {
-                let im = input_mapping.get(node).unwrap();
-                let om = output_mapping.get(node).unwrap();
+                let im = input_mapping
+                    .get(node)
+                    .ok_or_else(|| anyhow::anyhow!("Missing input_mapping for node {:?}", node))?;
+                let om = output_mapping
+                    .get(node)
+                    .ok_or_else(|| anyhow::anyhow!("Missing output_mapping for node {:?}", node))?;
                 let node_idx = self
                     .operator
                     .node_index(node)

--- a/crates/tensor4all-treetn/src/node_name_network.rs
+++ b/crates/tensor4all-treetn/src/node_name_network.rs
@@ -325,7 +325,9 @@ where
         // DFS within the subset only: petgraph's Dfs visits all reachable
         // nodes, but we must restrict traversal to edges whose both endpoints
         // are in the subset.
-        let start = *nodes.iter().next().unwrap();
+        let Some(&start) = nodes.iter().next() else {
+            return true;
+        };
         let mut seen = HashSet::new();
         let mut stack = vec![start];
         seen.insert(start);
@@ -627,7 +629,9 @@ where
         // Check edges match (by checking neighbors for each node)
         let self_graph = self.graph.graph();
         for name in self.node_names() {
-            let self_idx = self.node_index(name).unwrap();
+            let Some(self_idx) = self.node_index(name) else {
+                return false;
+            };
             let other_idx = match other.node_index(name) {
                 Some(idx) => idx,
                 None => return false,

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -58,7 +58,7 @@
 //! // Applying identity preserves the state
 //! let result_dense = result.to_dense()?;
 //! let state_dense = state.to_dense()?;
-//! assert!((&result_dense - &state_dense).maxabs() < 1e-12);
+//! assert!(result_dense.distance(&state_dense).unwrap() < 1e-12);
 //! # Ok(())
 //! # }
 //! ```
@@ -279,7 +279,7 @@ impl ApplyOptions {
 /// // Applying identity preserves the state
 /// let result_dense = result.to_dense()?;
 /// let state_dense = state.to_dense()?;
-/// assert!((&result_dense - &state_dense).maxabs() < 1e-12);
+/// assert!(result_dense.distance(&state_dense).unwrap() < 1e-12);
 ///
 /// let truncated = apply_linear_operator(
 ///     &operator,

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -378,7 +378,7 @@ fn assert_identity_application(
     let result = apply_linear_operator(operator, state, ApplyOptions::default()).unwrap();
     let result_dense = result.to_dense().unwrap();
     let state_dense = state.to_dense().unwrap();
-    assert!((&result_dense - &state_dense).maxabs() < 1e-10);
+    assert!(result_dense.distance(&state_dense).unwrap() < 1e-10);
 }
 
 #[test]
@@ -418,7 +418,7 @@ fn test_linear_operator_tensor_index() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space);
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space).unwrap();
 
     let true_s0 = make_index(2);
     let mut input_mapping = HashMap::new();
@@ -479,7 +479,7 @@ fn test_arc_linear_operator_cow() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space);
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space).unwrap();
 
     let arc_op = ArcLinearOperator::new(mpo, HashMap::new(), HashMap::new());
 
@@ -637,7 +637,7 @@ fn naive_apply_preserves_product_link_space_for_redundant_mpo_bond() {
 
     let result_dense = result.to_dense().unwrap();
     let state_dense = state.to_dense().unwrap();
-    assert!((&result_dense - &state_dense).maxabs() < 1e-10);
+    assert!(result_dense.distance(&state_dense).unwrap() < 1e-10);
 }
 
 #[test]
@@ -652,7 +652,7 @@ fn naive_apply_full_product_identity_embeds_on_state_topology() {
 
     let result_dense = result.to_dense().unwrap();
     let state_dense = state.to_dense().unwrap();
-    assert!((&result_dense - &state_dense).maxabs() < 1e-10);
+    assert!(result_dense.distance(&state_dense).unwrap() < 1e-10);
 }
 
 #[test]
@@ -675,7 +675,7 @@ fn naive_apply_noncontiguous_bonded_identity_uses_compact_bridge_delta() {
     let result = apply_linear_operator(&operator, &state, ApplyOptions::naive()).unwrap();
     let result_dense = result.to_dense().unwrap();
     let state_dense = state.to_dense().unwrap();
-    assert!((&result_dense - &state_dense).maxabs() < 1e-10);
+    assert!(result_dense.distance(&state_dense).unwrap() < 1e-10);
 }
 
 #[test]
@@ -713,7 +713,7 @@ fn naive_apply_long_identity_chain_keeps_local_bonds_bounded() {
         values.extend(point.iter().copied());
     }
     let shape = [length, sample_points.len()];
-    let value_ref = ColMajorArrayRef::new(&values, &shape);
+    let value_ref = ColMajorArrayRef::new(&values, &shape).unwrap();
     let state_values = state.evaluate_at(&site_indices, value_ref).unwrap();
     let result_values = result.evaluate_at(&site_indices, value_ref).unwrap();
 
@@ -1369,7 +1369,7 @@ fn test_linear_operator_replaceinds() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space);
+    let mpo = random_treetn::<f64, _, _>(&mut rng, &net, link_space).unwrap();
 
     let true_s0 = make_index(2);
     let mut input_mapping = HashMap::new();

--- a/crates/tensor4all-treetn/src/operator/compose/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/compose/tests/mod.rs
@@ -79,8 +79,8 @@ fn test_are_exclusive_disjoint() {
     // Create TreeTNs with these networks
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     // Test exclusivity
     let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
@@ -109,8 +109,8 @@ fn test_are_exclusive_overlapping() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
     assert!(!result, "Overlapping operators should not be exclusive");
@@ -130,8 +130,8 @@ fn test_are_exclusive_single_node_operators() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
     assert!(result, "Single-node disjoint operators should be exclusive");
@@ -203,8 +203,8 @@ fn test_compose_exclusive_linear_operators_basic() {
     // Create TreeTNs for the operators
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     // True site indices (what the composed operator maps from/to)
     let true_s0 = make_index(2);
@@ -310,8 +310,8 @@ fn test_compose_exclusive_linear_operators_single_operators() {
     // Create TreeTNs
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     // True site indices
     let true_s0 = make_index(2);
@@ -384,8 +384,8 @@ fn test_compose_exclusive_linear_operators_no_gap() {
     // Create TreeTNs
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     // True site indices
     let true_s0 = make_index(2);
@@ -466,8 +466,8 @@ fn test_compose_exclusive_linear_operators_overlap_error() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     let lin_op1 = LinearOperator::new(mpo1, HashMap::new(), HashMap::new());
     let lin_op2 = LinearOperator::new(mpo2, HashMap::new(), HashMap::new());
@@ -518,8 +518,8 @@ fn test_compose_gap_identity_tensor_is_diagonal() {
 
     let link_space = LinkSpace::uniform(2);
     let mut rng = rand::rng();
-    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone());
-    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone());
+    let mpo1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
+    let mpo2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     let true_s0 = make_index(2);
     let true_s2 = make_index(2);

--- a/crates/tensor4all-treetn/src/random.rs
+++ b/crates/tensor4all-treetn/src/random.rs
@@ -6,6 +6,7 @@
 
 use crate::site_index_network::SiteIndexNetwork;
 use crate::treetn::TreeTN;
+use anyhow::{anyhow, Result};
 use rand::Rng;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -93,7 +94,7 @@ pub type DefaultIndex = Index<DynId, TagSet>;
 /// site_network.add_edge(&"A".to_string(), &"B".to_string()).unwrap();
 ///
 /// let mut rng = ChaCha8Rng::seed_from_u64(42);
-/// let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::uniform(4));
+/// let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::uniform(4)).unwrap();
 ///
 /// assert_eq!(treetn.node_count(), 2);
 /// ```
@@ -101,7 +102,7 @@ pub fn random_treetn<T, R, V>(
     rng: &mut R,
     site_network: &SiteIndexNetwork<V, DefaultIndex>,
     link_space: LinkSpace<V>,
-) -> TreeTN<TensorDynLen, V>
+) -> Result<TreeTN<TensorDynLen, V>>
 where
     T: RandomScalar,
     R: Rng,
@@ -120,12 +121,12 @@ where
         };
         let key_clone = (key.0.clone(), key.1.clone());
 
-        link_indices.entry(key).or_insert_with(|| {
+        if let std::collections::hash_map::Entry::Vacant(entry) = link_indices.entry(key) {
             let dim = link_space
                 .get(&key_clone.0, &key_clone.1)
-                .expect("LinkSpace must provide dimension for all edges");
-            Index::new_dyn(dim)
-        });
+                .ok_or_else(|| anyhow!("LinkSpace has no dimension for edge {:?}", key_clone))?;
+            entry.insert(Index::new_dyn(dim));
+        }
     }
 
     // Step 2: For each node, collect all indices and create random tensor
@@ -157,14 +158,14 @@ where
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<T, R>(rng, all_indices);
+        let tensor = TensorDynLen::random::<T, R>(rng, all_indices)?;
 
         tensors.push(tensor);
         node_names.push(node_name);
     }
 
     // Step 3: Create TreeTN from tensors
-    TreeTN::from_tensors(tensors, node_names).expect("Failed to create TreeTN from random tensors")
+    TreeTN::from_tensors(tensors, node_names)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-treetn/src/random/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/random/tests/mod.rs
@@ -21,7 +21,8 @@ fn test_random_treetn_f64_two_nodes() {
         .unwrap();
 
     let mut rng = ChaCha8Rng::seed_from_u64(42);
-    let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::uniform(4));
+    let treetn =
+        random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::uniform(4)).unwrap();
 
     assert_eq!(treetn.node_count(), 2);
     assert_eq!(treetn.edge_count(), 1);
@@ -39,7 +40,8 @@ fn test_random_treetn_c64_chain() {
     site_network.add_edge(&1, &2).unwrap();
 
     let mut rng = ChaCha8Rng::seed_from_u64(123);
-    let treetn = random_treetn::<Complex64, _, _>(&mut rng, &site_network, LinkSpace::uniform(3));
+    let treetn =
+        random_treetn::<Complex64, _, _>(&mut rng, &site_network, LinkSpace::uniform(3)).unwrap();
 
     assert_eq!(treetn.node_count(), 3);
     assert_eq!(treetn.edge_count(), 2);
@@ -69,7 +71,8 @@ fn test_link_space_per_edge() {
     dims.insert(("B".to_string(), "C".to_string()), 10);
 
     let mut rng = ChaCha8Rng::seed_from_u64(42);
-    let treetn = random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::per_edge(dims));
+    let treetn =
+        random_treetn::<f64, _, _>(&mut rng, &site_network, LinkSpace::per_edge(dims)).unwrap();
 
     assert_eq!(treetn.node_count(), 3);
     assert_eq!(treetn.edge_count(), 2);

--- a/crates/tensor4all-treetn/src/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/src/simplett_bridge.rs
@@ -17,7 +17,7 @@ use crate::TreeTN;
 /// use tensor4all_treetn::tensor_train_to_treetn;
 ///
 /// let tt = TensorTrain::new(vec![
-///     tensor3_from_data(vec![1.0_f64, 2.0], 1, 2, 1),
+///     tensor3_from_data(vec![1.0_f64, 2.0], 1, 2, 1).unwrap(),
 /// ]).unwrap();
 ///
 /// let (treetn, site_indices) = tensor_train_to_treetn(&tt).unwrap();
@@ -49,7 +49,7 @@ where
 /// use tensor4all_treetn::tensor_train_to_treetn_with_names;
 ///
 /// let tt = TensorTrain::new(vec![
-///     tensor3_from_data(vec![1.0_f64, 2.0], 1, 2, 1),
+///     tensor3_from_data(vec![1.0_f64, 2.0], 1, 2, 1).unwrap(),
 /// ]).unwrap();
 ///
 /// let (treetn, site_indices) =
@@ -84,7 +84,7 @@ where
 /// use tensor4all_treetn::tensor_train_to_treetn_with_names_and_site_indices;
 ///
 /// let tt = TensorTrain::new(vec![
-///     tensor3_from_data(vec![1.0_f64, 2.0], 1, 2, 1),
+///     tensor3_from_data(vec![1.0_f64, 2.0], 1, 2, 1).unwrap(),
 /// ]).unwrap();
 /// let site = DynIndex::new_dyn(2);
 ///

--- a/crates/tensor4all-treetn/src/treetn/addition.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition.rs
@@ -315,7 +315,7 @@ where
     /// let sum = tn.add(&tn).unwrap();
     /// let dense = sum.to_dense().unwrap();
     /// let expected = TensorDynLen::from_dense(vec![s], vec![2.0, 4.0]).unwrap();
-    /// assert!((&dense - &expected).maxabs() < 1e-12);
+    /// assert!(dense.distance(&expected).unwrap() < 1e-12);
     /// ```
     pub fn add(&self, other: &Self) -> Result<Self>
     where
@@ -340,11 +340,19 @@ where
         let mut result_node_names: Vec<V> = Vec::new();
 
         for node_name in self.node_names() {
-            let self_idx = self.node_index(&node_name).unwrap();
-            let other_idx = other.node_index(&node_name).unwrap();
+            let self_idx = self
+                .node_index(&node_name)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in self", node_name))?;
+            let other_idx = other
+                .node_index(&node_name)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in other", node_name))?;
 
-            let tensor_a = self.tensor(self_idx).unwrap();
-            let tensor_b = other.tensor(other_idx).unwrap();
+            let tensor_a = self.tensor(self_idx).ok_or_else(|| {
+                anyhow::anyhow!("Tensor not found for node {:?} in self", node_name)
+            })?;
+            let tensor_b = other.tensor(other_idx).ok_or_else(|| {
+                anyhow::anyhow!("Tensor not found for node {:?} in other", node_name)
+            })?;
 
             // Find bond index pairs for this node and track neighbors
             let mut bond_pairs: Vec<(T::Index, T::Index)> = Vec::new();
@@ -352,12 +360,28 @@ where
 
             for neighbor in self.site_index_network().neighbors(&node_name) {
                 // Get bond index from self
-                let self_edge = self.edge_between(&node_name, &neighbor).unwrap();
-                let self_bond = self.bond_index(self_edge).unwrap();
+                let self_edge = self.edge_between(&node_name, &neighbor).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Edge not found in self between {:?} and {:?}",
+                        node_name,
+                        neighbor
+                    )
+                })?;
+                let self_bond = self
+                    .bond_index(self_edge)
+                    .ok_or_else(|| anyhow::anyhow!("Bond index not found in self"))?;
 
                 // Get bond index from other
-                let other_edge = other.edge_between(&node_name, &neighbor).unwrap();
-                let other_bond = other.bond_index(other_edge).unwrap();
+                let other_edge = other.edge_between(&node_name, &neighbor).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Edge not found in other between {:?} and {:?}",
+                        node_name,
+                        neighbor
+                    )
+                })?;
+                let other_bond = other
+                    .bond_index(other_edge)
+                    .ok_or_else(|| anyhow::anyhow!("Bond index not found in other"))?;
 
                 bond_pairs.push((self_bond.clone(), other_bond.clone()));
                 neighbors_for_edges.push(neighbor);

--- a/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex, TensorLike};
 
 use crate::treetn::TreeTN;
@@ -249,6 +250,83 @@ fn test_reindex_site_space_like_matches_template_ids() {
 
     let reindexed = tn_b.reindex_site_space_like(&tn_a).unwrap();
     assert!(reindexed.share_equivalent_site_index_network(&tn_a));
+}
+
+#[test]
+fn test_sorted_site_space_orders_deterministically() {
+    let a = DynIndex::new_dyn(3);
+    let b = DynIndex::new_dyn(2);
+    let c = b.prime();
+    let mut site_space = HashSet::new();
+    site_space.insert(c.clone());
+    site_space.insert(a.clone());
+    site_space.insert(b.clone());
+
+    let sorted = TreeTN::<TensorDynLen, usize>::sorted_site_space(&site_space);
+    assert_eq!(sorted, vec![b, c, a]);
+}
+
+#[test]
+fn test_reindex_site_space_like_rejects_incompatible_inputs() {
+    let (tn_a, _) = make_two_matching_treetns_different_site_ids();
+
+    let lone_site = DynIndex::new_dyn(2);
+    let lone_tensor = TensorDynLen::from_dense(vec![lone_site], vec![1.0, 2.0]).unwrap();
+    let single =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![lone_tensor], vec!["A".to_string()])
+            .unwrap();
+    let err = tn_a.reindex_site_space_like(&single).unwrap_err();
+    assert!(err.to_string().contains("incompatible topologies"));
+
+    let self_s0 = DynIndex::new_dyn(2);
+    let self_s1 = DynIndex::new_dyn(2);
+    let self_bond = DynIndex::new_dyn(1);
+    let self_t0 =
+        TensorDynLen::from_dense(vec![self_s0, self_bond.clone()], vec![1.0, 2.0]).unwrap();
+    let self_t1 = TensorDynLen::from_dense(vec![self_bond, self_s1], vec![1.0, 2.0]).unwrap();
+    let self_two_node = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![self_t0, self_t1],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+
+    let tmpl_s0 = DynIndex::new_dyn(2);
+    let tmpl_extra = DynIndex::new_dyn(2);
+    let tmpl_s1 = DynIndex::new_dyn(2);
+    let tmpl_bond = DynIndex::new_dyn(1);
+    let tmpl_t0 = TensorDynLen::from_dense(
+        vec![tmpl_s0, tmpl_extra, tmpl_bond.clone()],
+        vec![1.0, 2.0, 3.0, 4.0],
+    )
+    .unwrap();
+    let tmpl_t1 = TensorDynLen::from_dense(vec![tmpl_bond, tmpl_s1], vec![1.0, 2.0]).unwrap();
+    let template_extra_site = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![tmpl_t0, tmpl_t1],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+    let err = self_two_node
+        .reindex_site_space_like(&template_extra_site)
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("has 1 site indices in self but 2 in template"));
+
+    let tmpl_s0 = DynIndex::new_dyn(3);
+    let tmpl_s1 = DynIndex::new_dyn(2);
+    let tmpl_bond = DynIndex::new_dyn(1);
+    let tmpl_t0 =
+        TensorDynLen::from_dense(vec![tmpl_s0, tmpl_bond.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let tmpl_t1 = TensorDynLen::from_dense(vec![tmpl_bond, tmpl_s1], vec![1.0, 2.0]).unwrap();
+    let template_dim_mismatch = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![tmpl_t0, tmpl_t1],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+    let err = self_two_node
+        .reindex_site_space_like(&template_dim_mismatch)
+        .unwrap_err();
+    assert!(err.to_string().contains("site dimension mismatch"));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
@@ -191,7 +191,7 @@ fn test_add_verifies_with_contraction() {
     assert!(
         tensor_sum.isapprox(&expected, 1e-10, 0.0),
         "contract(result) != contract(tn_a) + contract(tn_b): maxabs diff = {}",
-        (&tensor_sum - &expected).maxabs()
+        tensor_sum.distance(&expected).unwrap()
     );
 }
 
@@ -239,7 +239,7 @@ fn test_add_single_site() {
     assert!(
         dense.isapprox(&expected, 1e-10, 0.0),
         "single-site add failed: maxabs diff = {}",
-        (&dense - &expected).maxabs()
+        dense.distance(&expected).unwrap()
     );
 }
 
@@ -274,7 +274,7 @@ fn test_add_aligned_accepts_equivalent_site_space_with_different_ids() {
     assert!(
         dense_sum.isapprox(&dense_expected, 1e-10, 0.0),
         "add_aligned failed: maxabs diff = {}",
-        (&dense_sum - &dense_expected).maxabs()
+        dense_sum.distance(&dense_expected).unwrap()
     );
 }
 
@@ -315,6 +315,6 @@ fn test_add_preserves_same_id_prime_pair_site_indices() {
     assert!(
         dense_result.isapprox(&dense_expected, 1e-10, 0.0),
         "same-id prime-pair MPO-like add failed: maxabs diff = {}",
-        (&dense_result - &dense_expected).maxabs()
+        dense_result.distance(&dense_expected).unwrap()
     );
 }

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -135,8 +135,15 @@ where
             for point in 0..n_points {
                 let key = entries
                     .iter()
-                    .map(|entry| *values.get(&[entry.input_position, point]).unwrap())
-                    .collect::<Vec<_>>();
+                    .map(|entry| {
+                        value_at(
+                            values,
+                            entry.input_position,
+                            point,
+                            "ComponentCostIndex::new",
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
                 validate_entry_values(entries, &key, "ComponentCostIndex::new")?;
                 keys.push(local_interner.intern(key));
             }
@@ -151,9 +158,10 @@ where
             let Some(parent_node) = parent.get(node).and_then(Clone::clone) else {
                 continue;
             };
-            let incoming = neighbors
-                .get(node)
-                .unwrap()
+            let node_neighbors = neighbors.get(node).ok_or_else(|| {
+                anyhow::anyhow!("ComponentCostIndex::new: missing neighbors for {:?}", node)
+            })?;
+            let incoming = node_neighbors
                 .iter()
                 .filter(|neighbor| *neighbor != &parent_node)
                 .map(|neighbor| {
@@ -167,8 +175,11 @@ where
                         })
                 })
                 .collect::<Result<Vec<_>>>()?;
+            let node_local_keys = local_keys.get(node).ok_or_else(|| {
+                anyhow::anyhow!("ComponentCostIndex::new: missing local keys for {:?}", node)
+            })?;
             let keys = intern_component_keys(
-                local_keys.get(node).unwrap(),
+                node_local_keys,
                 &incoming,
                 n_points,
                 &mut component_interner,
@@ -177,12 +188,13 @@ where
         }
 
         for node in &order {
-            for child in neighbors.get(node).unwrap().iter().filter(|neighbor| {
+            let node_neighbors = neighbors.get(node).ok_or_else(|| {
+                anyhow::anyhow!("ComponentCostIndex::new: missing neighbors for {:?}", node)
+            })?;
+            for child in node_neighbors.iter().filter(|neighbor| {
                 parent.get(*neighbor).and_then(Clone::clone) == Some(node.clone())
             }) {
-                let incoming = neighbors
-                    .get(node)
-                    .unwrap()
+                let incoming = node_neighbors
                     .iter()
                     .filter(|neighbor| *neighbor != child)
                     .map(|neighbor| {
@@ -196,8 +208,11 @@ where
                             })
                     })
                     .collect::<Result<Vec<_>>>()?;
+                let node_local_keys = local_keys.get(node).ok_or_else(|| {
+                    anyhow::anyhow!("ComponentCostIndex::new: missing local keys for {:?}", node)
+                })?;
                 let keys = intern_component_keys(
-                    local_keys.get(node).unwrap(),
+                    node_local_keys,
                     &incoming,
                     n_points,
                     &mut component_interner,
@@ -520,7 +535,13 @@ where
             }
 
             let mut candidates = Vec::new();
-            for neighbor in cost_index.neighbors.get(&center).unwrap() {
+            let neighbors = cost_index.neighbors.get(&center).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "GreedyCenterSearch::descend_from: center {:?} is not present in cost index",
+                    center
+                )
+            })?;
+            for neighbor in neighbors {
                 candidates.push((cost_index.center_cost(neighbor)?, neighbor.clone()));
             }
             candidates.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
@@ -558,7 +579,7 @@ where
 /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
 /// let values = [0usize, 1usize];
 /// let shape = [1usize, 2usize];
-/// let points = ColMajorArrayRef::new(&values, &shape);
+/// let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 ///
 /// let mut evaluator = TreeTNCachedEvaluator::new(
 ///     &tree,
@@ -663,7 +684,7 @@ where
     /// assert_eq!(evaluator.center(), None);
     /// let values = [0usize];
     /// let shape = [1usize, 1usize];
-    /// let _ = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+    /// let _ = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape).unwrap())?;
     /// assert_eq!(evaluator.center(), Some(&0));
     /// # Ok::<(), anyhow::Error>(())
     /// ```
@@ -698,7 +719,7 @@ where
     ///     &[s],
     ///     CachedEvaluatorOptions::<usize>::default(),
     /// )?;
-    /// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+    /// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape).unwrap())?;
     /// assert_eq!(result.len(), 2);
     /// assert_eq!(result[0].real(), 4.0);
     /// assert_eq!(result[1].real(), 6.0);
@@ -738,7 +759,9 @@ where
             let result = search.search(&cost_index, &self.options.initial_centers)?;
             self.center = Some(result.center);
         }
-        Ok(self.center.as_ref().unwrap())
+        self.center.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("TreeTNCachedEvaluator::ensure_center: no center selected")
+        })
     }
 
     fn build_environment_cache(
@@ -815,8 +838,15 @@ where
             for point in 0..n_points {
                 let key = entries
                     .iter()
-                    .map(|entry| *values.get(&[entry.input_position, point]).unwrap())
-                    .collect::<Vec<_>>();
+                    .map(|entry| {
+                        value_at(
+                            values,
+                            entry.input_position,
+                            point,
+                            "TreeTNCachedEvaluator::evaluate_batch",
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
                 validate_entry_values(entries, &key, "TreeTNCachedEvaluator::evaluate_batch")?;
                 keys.push(local_interner.intern(key));
             }
@@ -869,7 +899,7 @@ where
         let tensor = tensor_for_node(self.tree, node)?;
         let mut local_slices = Vec::with_capacity(assignment_batch.first_points.len());
         for point in assignment_batch.first_points.iter().copied() {
-            let index_vals = self.index_vals_for_point(node, values, point);
+            let index_vals = self.index_vals_for_point(node, values, point)?;
             local_slices.push(slice_tensor(tensor, &index_vals).with_context(|| {
                 format!(
                     "TreeTNCachedEvaluator::evaluate_batch: failed to slice message node {:?}",
@@ -966,10 +996,15 @@ where
             let center_index_vals = center_entries
                 .iter()
                 .map(|entry| {
-                    let value = *values.get(&[entry.input_position, point]).unwrap();
-                    (entry.index.clone(), value)
+                    let value = value_at(
+                        values,
+                        entry.input_position,
+                        point,
+                        "TreeTNCachedEvaluator::evaluate_batch",
+                    )?;
+                    Ok((entry.index.clone(), value))
                 })
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>>>()?;
             validate_index_vals(&center_index_vals, "TreeTNCachedEvaluator::evaluate_batch")?;
             center_slices.push(
                 slice_tensor(center_tensor, &center_index_vals).context(
@@ -1025,20 +1060,22 @@ where
         node: &V,
         values: ColMajorArrayRef<'_, usize>,
         point: usize,
-    ) -> Vec<(DynIndex, usize)> {
-        self.layout
-            .entries_by_node
-            .get(node)
-            .map(|entries| {
-                entries
-                    .iter()
-                    .map(|entry| {
-                        let value = *values.get(&[entry.input_position, point]).unwrap();
-                        (entry.index.clone(), value)
-                    })
-                    .collect()
+    ) -> Result<Vec<(DynIndex, usize)>> {
+        let Some(entries) = self.layout.entries_by_node.get(node) else {
+            return Ok(Vec::new());
+        };
+        entries
+            .iter()
+            .map(|entry| {
+                let value = value_at(
+                    values,
+                    entry.input_position,
+                    point,
+                    "TreeTNCachedEvaluator::evaluate_batch",
+                )?;
+                Ok((entry.index.clone(), value))
             })
-            .unwrap_or_default()
+            .collect()
     }
 
     #[cfg(test)]
@@ -1168,6 +1205,25 @@ fn validate_values_shape(
         n_indices
     );
     Ok(())
+}
+
+fn value_at(
+    values: ColMajorArrayRef<'_, usize>,
+    input_position: usize,
+    point: usize,
+    context: &str,
+) -> Result<usize> {
+    values
+        .get(&[input_position, point])
+        .copied()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{context}: missing coordinate at row {} point {} for shape {:?}",
+                input_position,
+                point,
+                values.shape()
+            )
+        })
 }
 
 fn validate_entry_values(entries: &[SiteEntry], values: &[usize], context: &str) -> Result<()> {
@@ -1508,7 +1564,7 @@ mod tests {
         let (tree, indices) = two_node_tree();
         let values = vec![0, 0, 1, 0, 0, 1, 1, 1];
         let shape = [2, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let expected = tree.evaluate(&indices, points).unwrap();
         let options = CachedEvaluatorOptions {
@@ -1527,7 +1583,7 @@ mod tests {
         let (tree, indices) = three_node_chain();
         let values = vec![0, 0, 0, 0, 1, 1, 1, 1, 1];
         let shape = [3, 3];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let cost_index = ComponentCostIndex::new(&tree, &indices, points).unwrap();
 
@@ -1545,7 +1601,7 @@ mod tests {
         let (tree, indices) = three_node_chain();
         let values = vec![0, 1, 1, 0];
         let shape = [2, 2];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let err = ComponentCostIndex::new(&tree, &indices, points)
             .err()
@@ -1594,7 +1650,7 @@ mod tests {
         let (tree, indices) = three_node_chain();
         let values = vec![0, 0, 0, 0, 1, 1, 1, 1, 1];
         let shape = [3, 3];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let expected = tree.evaluate(&indices, points).unwrap();
         let mut evaluator = TreeTNCachedEvaluator::new(
@@ -1635,7 +1691,7 @@ mod tests {
         let (tree, indices) = three_node_chain();
         let values = vec![0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1];
         let shape = [3, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let mut evaluator = TreeTNCachedEvaluator::new(
             &tree,
@@ -1663,7 +1719,7 @@ mod tests {
             1, 1, 1, 1, 1,
         ];
         let shape = [5, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let expected = tree.evaluate(&indices, points).unwrap();
         let mut evaluator = TreeTNCachedEvaluator::new(
@@ -1691,7 +1747,7 @@ mod tests {
             1, 1, 1, 1, 1,
         ];
         let shape = [5, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
 
         let expected = tree.evaluate(&indices, points).unwrap();
         let mut evaluator = TreeTNCachedEvaluator::new(
@@ -1715,7 +1771,7 @@ mod tests {
         let (tree, indices) = two_node_tree();
         let values = vec![0, 1, 1];
         let shape = [1, 3];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
         let mut evaluator =
             TreeTNCachedEvaluator::new(&tree, &indices, CachedEvaluatorOptions::default()).unwrap();
 
@@ -1728,7 +1784,7 @@ mod tests {
         let (tree, indices) = two_node_tree();
         let values = vec![0, 2];
         let shape = [2, 1];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
         let mut evaluator =
             TreeTNCachedEvaluator::new(&tree, &indices, CachedEvaluatorOptions::default()).unwrap();
 
@@ -1741,7 +1797,7 @@ mod tests {
         let (tree, indices) = two_node_tree();
         let values = vec![0, 0, 1, 1, 0, 0, 1, 1];
         let shape = [2, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
         let expected = tree.evaluate(&indices, points).unwrap();
         let mut evaluator =
             TreeTNCachedEvaluator::new(&tree, &indices, CachedEvaluatorOptions::default()).unwrap();
@@ -1763,7 +1819,7 @@ mod tests {
             1, 1, 1, 1,
         ];
         let shape = [4, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
         let expected = tree.evaluate(&indices, points).unwrap();
         let mut evaluator = TreeTNCachedEvaluator::new(
             &tree,
@@ -1790,7 +1846,7 @@ mod tests {
             1, 1, 1, 1,
         ];
         let shape = [4, 4];
-        let points = ColMajorArrayRef::new(&values, &shape);
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
         let expected = tree.evaluate(&indices, points).unwrap();
         let mut evaluator = TreeTNCachedEvaluator::new(
             &tree,

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -568,8 +568,18 @@ where
                 result.node_index(source_name),
                 result.node_index(destination_name),
             ) {
-                let tensor_a = result.tensor(node_a_idx).unwrap();
-                let tensor_b = result.tensor(node_b_idx).unwrap();
+                let tensor_a = result.tensor(node_a_idx).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "contract_zipup_tree_accumulated: result tensor not found for node {:?}",
+                        source_name
+                    )
+                })?;
+                let tensor_b = result.tensor(node_b_idx).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "contract_zipup_tree_accumulated: result tensor not found for node {:?}",
+                        destination_name
+                    )
+                })?;
 
                 // Find the common index (should be the bond index)
                 use tensor4all_core::index_ops::common_inds;

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -158,7 +158,7 @@ fn test_contract_to_tensor_two_nodes() {
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
-    let expected = t0.contract(&t1).to_vec::<f64>().unwrap();
+    let expected = t0.contract(&t1).unwrap().to_vec::<f64>().unwrap();
 
     let result_data = result.to_vec::<f64>().unwrap();
     assert_eq!(result_data.len(), expected.len());
@@ -336,7 +336,7 @@ fn test_naive_contraction_scalar_result() {
 
     assert_eq!(result.node_count(), 1);
     let dense = result.contract_to_tensor().unwrap();
-    let val = dense.sum().real();
+    let val = dense.sum().unwrap().real();
     assert!(
         (val - 6.0).abs() < 1e-10,
         "scalar contraction expected 6.0, got {}",

--- a/crates/tensor4all-treetn/src/treetn/decompose.rs
+++ b/crates/tensor4all-treetn/src/treetn/decompose.rs
@@ -161,7 +161,12 @@ where
 
     if topology.nodes.len() == 1 {
         // Single node - just wrap the tensor
-        let node_name = topology.nodes.keys().next().unwrap().clone();
+        let node_name = topology
+            .nodes
+            .keys()
+            .next()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Tree topology must have at least one node"))?;
         if &node_name != root {
             return Err(anyhow::anyhow!("Requested root node not found in topology"));
         }
@@ -208,8 +213,12 @@ where
         adj.insert(node.clone(), Vec::new());
     }
     for (a, b) in &topology.edges {
-        adj.get_mut(a).unwrap().push(b.clone());
-        adj.get_mut(b).unwrap().push(a.clone());
+        adj.get_mut(a)
+            .ok_or_else(|| anyhow::anyhow!("Edge refers to unknown node {:?}", a))?
+            .push(b.clone());
+        adj.get_mut(b)
+            .ok_or_else(|| anyhow::anyhow!("Edge refers to unknown node {:?}", b))?
+            .push(a.clone());
     }
     // Sort each adjacency list to ensure deterministic traversal order
     for neighbors in adj.values_mut() {
@@ -235,11 +244,22 @@ where
         visited.insert(node.clone());
         traversal_order.push((node.clone(), parent));
 
-        for neighbor in adj.get(&node).unwrap() {
+        let neighbors = adj
+            .get(&node)
+            .ok_or_else(|| anyhow::anyhow!("Traversal reached unknown node {:?}", node))?;
+        for neighbor in neighbors {
             if !visited.contains(neighbor) {
                 queue.push_back((neighbor.clone(), Some(node.clone())));
             }
         }
+    }
+    if visited.len() != topology.nodes.len() {
+        return Err(anyhow::anyhow!(
+            "Tree topology must be connected: reached {} of {} nodes from root {:?}",
+            visited.len(),
+            topology.nodes.len(),
+            root
+        ));
     }
 
     let mut children_by_parent: HashMap<V, Vec<V>> = HashMap::new();
@@ -273,11 +293,15 @@ where
     };
 
     // Process nodes in post-order (leaves first)
-    #[allow(clippy::needless_range_loop)]
-    for i in 0..traversal_order.len() - 1 {
-        let (node, _parent) = &traversal_order[i];
+    for (node, _parent) in traversal_order
+        .iter()
+        .take(traversal_order.len().saturating_sub(1))
+    {
         // Get the indices for this node.
-        let node_indices = topology.nodes.get(node).unwrap();
+        let node_indices = topology
+            .nodes
+            .get(node)
+            .ok_or_else(|| anyhow::anyhow!("Topology is missing node {:?}", node))?;
 
         // Keep this node's physical indices and the bonds to already-factorized
         // children on the left side. This preserves the requested tree topology
@@ -342,7 +366,9 @@ where
     }
 
     // The last node (root) gets the remaining tensor
-    let (root_node, _) = &traversal_order.last().unwrap();
+    let (root_node, _) = traversal_order
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("Tree traversal produced no nodes"))?;
     node_tensors.insert(root_node.clone(), current_tensor);
 
     // Build the TreeTN using from_tensors (auto-connection by contractable indices).
@@ -352,8 +378,13 @@ where
     node_names.sort();
     let tensors: Vec<T> = node_names
         .iter()
-        .map(|name| node_tensors.get(name).cloned().unwrap())
-        .collect();
+        .map(|name| {
+            node_tensors
+                .get(name)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Missing tensor for topology node {:?}", name))
+        })
+        .collect::<Result<_>>()?;
 
     let mut tn = TreeTN::from_tensors(tensors, node_names)?;
     tn.set_canonical_region([root.clone()])?;

--- a/crates/tensor4all-treetn/src/treetn/evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/evaluator.rs
@@ -46,7 +46,7 @@ where
 /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
 /// let values = [0usize, 2usize];
 /// let shape = [1usize, 2usize];
-/// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+/// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape).unwrap())?;
 ///
 /// assert_eq!(result.len(), 2);
 /// assert!((result[0].real() - 10.0).abs() < 1.0e-12);
@@ -250,7 +250,7 @@ where
     /// let values = [1usize];
     /// let shape = [1usize, 1usize];
     ///
-    /// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape))?;
+    /// let result = evaluator.evaluate_batch(ColMajorArrayRef::new(&values, &shape).unwrap())?;
     /// assert!((result[0].real() - 9.0).abs() < 1.0e-12);
     /// # Ok::<(), anyhow::Error>(())
     /// ```
@@ -294,10 +294,15 @@ where
                 .site_entries
                 .iter()
                 .map(|site| {
-                    let val = *values.get(&[site.input_position, point]).unwrap();
-                    (site.index.clone(), val)
+                    let value = value_at(
+                        values,
+                        site.input_position,
+                        point,
+                        "TreeTNEvaluator::evaluate_batch",
+                    )?;
+                    Ok((site.index.clone(), value))
                 })
-                .collect();
+                .collect::<Result<_>>()?;
 
             let onehot = T::onehot(&index_vals)
                 .context("TreeTNEvaluator::evaluate_batch: failed to create one-hot tensor")?;
@@ -324,4 +329,23 @@ where
             .inner_product(&result_tensor)
             .context("TreeTNEvaluator::evaluate_batch: failed to extract scalar value")
     }
+}
+
+fn value_at(
+    values: ColMajorArrayRef<'_, usize>,
+    input_position: usize,
+    point: usize,
+    context: &str,
+) -> Result<usize> {
+    values
+        .get(&[input_position, point])
+        .copied()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{context}: missing coordinate at row {} point {} for shape {:?}",
+                input_position,
+                point,
+                values.shape()
+            )
+        })
 }

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -109,6 +109,46 @@ fn take_fit_profile() -> Option<FitProfile> {
     FIT_PROFILE_STATE.with(|state| state.borrow_mut().take())
 }
 
+fn sorted_neighbors_by_node_index<T, V>(
+    tn: &TreeTN<T, V>,
+    node: &V,
+    excluded: Option<&V>,
+    context: &str,
+) -> Result<Vec<V>>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    let mut neighbors = Vec::new();
+    for neighbor in tn.site_index_network().neighbors(node) {
+        if excluded == Some(&neighbor) {
+            continue;
+        }
+        let node_idx = tn.node_index(&neighbor).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{context}: neighbor {:?} of node {:?} is missing from TreeTN node map",
+                neighbor,
+                node
+            )
+        })?;
+        neighbors.push((node_idx.index(), neighbor));
+    }
+    neighbors.sort_by_key(|(index, _node)| *index);
+    Ok(neighbors.into_iter().map(|(_index, node)| node).collect())
+}
+
+fn tensor_at_node<'a, T, V>(tn: &'a TreeTN<T, V>, node: &V, tree_name: &str) -> Result<&'a T>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    let node_idx = tn
+        .node_index(node)
+        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in {}", node, tree_name))?;
+    tn.tensor(node_idx)
+        .ok_or_else(|| anyhow::anyhow!("Tensor for node {:?} not found in {}", node, tree_name))
+}
+
 // ============================================================================
 // FitEnvironment: Environment tensor cache
 // ============================================================================
@@ -230,16 +270,8 @@ where
         });
 
         // Get neighbors of `from` excluding `to`
-        let mut child_neighbors: Vec<V> = tn_c
-            .site_index_network()
-            .neighbors(from)
-            .filter(|n| n != to)
-            .collect();
-        child_neighbors.sort_by_key(|node| {
-            tn_c.node_index(node)
-                .expect("neighbor must exist in site index network")
-                .index()
-        });
+        let child_neighbors =
+            sorted_neighbors_by_node_index(tn_c, from, Some(to), "FitEnvironment::get_or_compute")?;
 
         // Recursively get or compute child environments
         let child_envs: Vec<T> = child_neighbors
@@ -273,44 +305,49 @@ where
     where
         V: 'a + Send + Sync,
     {
+        let _ = self.try_invalidate(region, tn_c);
+    }
+
+    fn try_invalidate<'a>(
+        &mut self,
+        region: impl IntoIterator<Item = &'a V>,
+        tn_c: &TreeTN<T, V>,
+    ) -> Result<()>
+    where
+        V: 'a + Send + Sync,
+    {
         for t in region {
             // Get all neighbors of t
-            let mut neighbors: Vec<V> = tn_c.site_index_network().neighbors(t).collect();
-            neighbors.sort_by_key(|node| {
-                tn_c.node_index(node)
-                    .expect("neighbor must exist in site index network")
-                    .index()
-            });
+            let neighbors =
+                sorted_neighbors_by_node_index(tn_c, t, None, "FitEnvironment::invalidate")?;
 
             // Remove all env[(t, *)] and propagate recursively
             for neighbor in neighbors {
-                self.invalidate_recursive(t, &neighbor, tn_c);
+                self.invalidate_recursive(t, &neighbor, tn_c)?;
             }
         }
+        Ok(())
     }
 
     /// Recursively invalidate caches starting from env[(from, to)] towards leaves.
     ///
     /// If env[(from, to)] exists, remove it and propagate to env[(to, x)] for all x ≠ from.
-    fn invalidate_recursive(&mut self, from: &V, to: &V, tn_c: &TreeTN<T, V>) {
+    fn invalidate_recursive(&mut self, from: &V, to: &V, tn_c: &TreeTN<T, V>) -> Result<()> {
         // Remove env[(from, to)] if it exists
         if self.envs.remove(&(from.clone(), to.clone())).is_some() {
             // Propagate to next generation: env[(to, x)] for all neighbors x of to, x ≠ from
-            let mut neighbors: Vec<V> = tn_c
-                .site_index_network()
-                .neighbors(to)
-                .filter(|n| n != from)
-                .collect();
-            neighbors.sort_by_key(|node| {
-                tn_c.node_index(node)
-                    .expect("neighbor must exist in site index network")
-                    .index()
-            });
+            let neighbors = sorted_neighbors_by_node_index(
+                tn_c,
+                to,
+                Some(from),
+                "FitEnvironment::invalidate_recursive",
+            )?;
 
             for neighbor in neighbors {
-                self.invalidate_recursive(to, &neighbor, tn_c);
+                self.invalidate_recursive(to, &neighbor, tn_c)?;
             }
         }
+        Ok(())
     }
 
     /// Verify cache structural consistency.
@@ -329,16 +366,12 @@ where
     {
         for (from, to) in self.envs.keys() {
             // Get neighbors of `from` excluding `to`
-            let mut child_neighbors: Vec<V> = tn_c
-                .site_index_network()
-                .neighbors(from)
-                .filter(|n| n != to)
-                .collect();
-            child_neighbors.sort_by_key(|node| {
-                tn_c.node_index(node)
-                    .expect("neighbor must exist in site index network")
-                    .index()
-            });
+            let child_neighbors = sorted_neighbors_by_node_index(
+                tn_c,
+                from,
+                Some(to),
+                "FitEnvironment::verify_structural_consistency",
+            )?;
 
             // If `from` is not a leaf, all child environments must exist
             for child in &child_neighbors {
@@ -385,25 +418,9 @@ where
     let started = fit_profile_enabled().then(Instant::now);
 
     // Get tensors
-    let node_idx_a = tn_a
-        .node_index(node)
-        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in tn_a", node))?;
-    let node_idx_b = tn_b
-        .node_index(node)
-        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in tn_b", node))?;
-    let node_idx_c = tn_c
-        .node_index(node)
-        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in tn_c", node))?;
-
-    let tensor_a = tn_a
-        .tensor(node_idx_a)
-        .ok_or_else(|| anyhow::anyhow!("Tensor not found in tn_a"))?;
-    let tensor_b = tn_b
-        .tensor(node_idx_b)
-        .ok_or_else(|| anyhow::anyhow!("Tensor not found in tn_b"))?;
-    let tensor_c = tn_c
-        .tensor(node_idx_c)
-        .ok_or_else(|| anyhow::anyhow!("Tensor not found in tn_c"))?;
+    let tensor_a = tensor_at_node(tn_a, node, "tn_a")?;
+    let tensor_b = tensor_at_node(tn_b, node, "tn_b")?;
+    let tensor_c = tensor_at_node(tn_c, node, "tn_c")?;
 
     // Contract A × B × conj(C) with a single multi-tensor call.
     let c_conj = tensor_c.conj();
@@ -439,25 +456,9 @@ where
     let started = fit_profile_enabled().then(Instant::now);
 
     // Get local tensors
-    let node_idx_a = tn_a
-        .node_index(node)
-        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in tn_a", node))?;
-    let node_idx_b = tn_b
-        .node_index(node)
-        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in tn_b", node))?;
-    let node_idx_c = tn_c
-        .node_index(node)
-        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in tn_c", node))?;
-
-    let tensor_a = tn_a
-        .tensor(node_idx_a)
-        .ok_or_else(|| anyhow::anyhow!("Tensor not found in tn_a"))?;
-    let tensor_b = tn_b
-        .tensor(node_idx_b)
-        .ok_or_else(|| anyhow::anyhow!("Tensor not found in tn_b"))?;
-    let tensor_c = tn_c
-        .tensor(node_idx_c)
-        .ok_or_else(|| anyhow::anyhow!("Tensor not found in tn_c"))?;
+    let tensor_a = tensor_at_node(tn_a, node, "tn_a")?;
+    let tensor_b = tensor_at_node(tn_b, node, "tn_b")?;
+    let tensor_c = tensor_at_node(tn_c, node, "tn_c")?;
 
     if child_envs.is_empty() {
         // Leaf node: compute from tensors directly
@@ -594,55 +595,75 @@ where
             profile.step_count += 1;
         });
 
-        // Get node indices in various TreeTNs
-        let idx_u_a = self.tn_a.node_index(node_u).unwrap();
-        let idx_v_a = self.tn_a.node_index(node_v).unwrap();
-        let idx_u_b = self.tn_b.node_index(node_u).unwrap();
-        let idx_v_b = self.tn_b.node_index(node_v).unwrap();
-
         // Get tensors
-        let a_u = self.tn_a.tensor(idx_u_a).unwrap();
-        let a_v = self.tn_a.tensor(idx_v_a).unwrap();
-        let b_u = self.tn_b.tensor(idx_u_b).unwrap();
-        let b_v = self.tn_b.tensor(idx_v_b).unwrap();
+        let a_u = tensor_at_node(&self.tn_a, node_u, "tn_a")?;
+        let a_v = tensor_at_node(&self.tn_a, node_v, "tn_a")?;
+        let b_u = tensor_at_node(&self.tn_b, node_u, "tn_b")?;
+        let b_v = tensor_at_node(&self.tn_b, node_v, "tn_b")?;
+
+        if full_treetn.node_index(node_u).is_none() {
+            return Err(anyhow::anyhow!(
+                "Node {:?} not found in full TreeTN",
+                node_u
+            ));
+        }
+        if full_treetn.node_index(node_v).is_none() {
+            return Err(anyhow::anyhow!(
+                "Node {:?} not found in full TreeTN",
+                node_v
+            ));
+        }
+        if full_treetn.edge_between(node_u, node_v).is_none() {
+            return Err(anyhow::anyhow!(
+                "FitUpdater update step nodes {:?} and {:?} are not adjacent in full TreeTN",
+                node_u,
+                node_v
+            ));
+        }
 
         // Collect environments from neighbors (excluding the edge between u and v)
         // Uses lazy evaluation: computes and caches if not already present
         let mut env_tensors: Vec<T> = Vec::new();
 
         // Environments from u's neighbors (except v)
-        let mut u_neighbors: Vec<V> = full_treetn.site_index_network().neighbors(node_u).collect();
-        u_neighbors.sort_by_key(|node| {
-            full_treetn
-                .node_index(node)
-                .expect("neighbor must exist in site index network")
-                .index()
-        });
-        for neighbor in u_neighbors {
-            if neighbor == *node_v {
+        let u_neighbors =
+            sorted_neighbors_by_node_index(full_treetn, node_u, None, "FitUpdater::update")?;
+        let mut left_bond_indices = Vec::new();
+        for neighbor in &u_neighbors {
+            if neighbor == node_v {
                 continue;
             }
+            let edge = full_treetn.edge_between(node_u, neighbor).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "FitUpdater: missing edge between {:?} and {:?} in full TreeTN",
+                    node_u,
+                    neighbor
+                )
+            })?;
+            let bond = full_treetn.bond_index(edge).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "FitUpdater: missing bond index for edge between {:?} and {:?}",
+                    node_u,
+                    neighbor
+                )
+            })?;
+            left_bond_indices.push(bond.clone());
             let env =
                 self.envs
-                    .get_or_compute(&neighbor, node_u, &self.tn_a, &self.tn_b, full_treetn)?;
+                    .get_or_compute(neighbor, node_u, &self.tn_a, &self.tn_b, full_treetn)?;
             env_tensors.push(env);
         }
 
         // Environments from v's neighbors (except u)
-        let mut v_neighbors: Vec<V> = full_treetn.site_index_network().neighbors(node_v).collect();
-        v_neighbors.sort_by_key(|node| {
-            full_treetn
-                .node_index(node)
-                .expect("neighbor must exist in site index network")
-                .index()
-        });
-        for neighbor in v_neighbors {
-            if neighbor == *node_u {
+        let v_neighbors =
+            sorted_neighbors_by_node_index(full_treetn, node_v, None, "FitUpdater::update")?;
+        for neighbor in &v_neighbors {
+            if neighbor == node_u {
                 continue;
             }
             let env =
                 self.envs
-                    .get_or_compute(&neighbor, node_v, &self.tn_a, &self.tn_b, full_treetn)?;
+                    .get_or_compute(neighbor, node_v, &self.tn_a, &self.tn_b, full_treetn)?;
             env_tensors.push(env);
         }
 
@@ -664,24 +685,18 @@ where
 
         // Determine left indices (indices that will remain on u after factorization)
         let left_inds_started = fit_profile_enabled().then(Instant::now);
-        let site_c_u = full_treetn.site_space(node_u).cloned().unwrap_or_default();
+        let site_c_u = full_treetn.site_space(node_u).cloned().ok_or_else(|| {
+            anyhow::anyhow!(
+                "FitUpdater: site space for node {:?} not found in full TreeTN",
+                node_u
+            )
+        })?;
         let mut left_inds: Vec<_> = ab_uv
             .external_indices()
             .iter()
             .filter(|idx| {
                 // Keep site indices of u and link indices to u's other neighbors
-                site_c_u.contains(*idx)
-                    || full_treetn
-                        .site_index_network()
-                        .neighbors(node_u)
-                        .filter(|n| n != node_v)
-                        .any(|neighbor| {
-                            full_treetn
-                                .edge_between(node_u, &neighbor)
-                                .and_then(|e| full_treetn.bond_index(e))
-                                .map(|b| b == *idx)
-                                .unwrap_or(false)
-                        })
+                site_c_u.contains(*idx) || left_bond_indices.iter().any(|bond| bond == *idx)
             })
             .cloned()
             .collect();
@@ -747,16 +762,40 @@ where
         let new_bond = factorize_result.bond_index;
 
         // Get edge between u and v
-        let edge_uv = subtree.edge_between(node_u, node_v).unwrap();
+        let edge_uv = subtree.edge_between(node_u, node_v).ok_or_else(|| {
+            anyhow::anyhow!(
+                "FitUpdater: subtree is missing edge between {:?} and {:?}",
+                node_u,
+                node_v
+            )
+        })?;
 
         // Update subtree with new bond and tensors
-        let idx_u_sub = subtree.node_index(node_u).unwrap();
-        let idx_v_sub = subtree.node_index(node_v).unwrap();
+        let idx_u_sub = subtree.node_index(node_u).ok_or_else(|| {
+            anyhow::anyhow!("FitUpdater: node {:?} not found in update subtree", node_u)
+        })?;
+        let idx_v_sub = subtree.node_index(node_v).ok_or_else(|| {
+            anyhow::anyhow!("FitUpdater: node {:?} not found in update subtree", node_v)
+        })?;
 
         let replace_started = fit_profile_enabled().then(Instant::now);
         subtree.replace_edge_bond(edge_uv, new_bond.clone())?;
-        subtree.replace_tensor(idx_u_sub, new_tensor_u)?;
-        subtree.replace_tensor(idx_v_sub, new_tensor_v)?;
+        subtree
+            .replace_tensor(idx_u_sub, new_tensor_u)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "FitUpdater: node {:?} disappeared before tensor replacement",
+                    node_u
+                )
+            })?;
+        subtree
+            .replace_tensor(idx_v_sub, new_tensor_v)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "FitUpdater: node {:?} disappeared before tensor replacement",
+                    node_v
+                )
+            })?;
 
         // Set ortho_towards
         subtree.set_ortho_towards(&new_bond, Some(step.new_center.clone()));
@@ -777,7 +816,7 @@ where
     ) -> Result<()> {
         // Invalidate all caches affected by the updated region
         let started = fit_profile_enabled().then(Instant::now);
-        self.envs.invalidate(&step.nodes, full_treetn_after);
+        self.envs.try_invalidate(&step.nodes, full_treetn_after)?;
         if let Some(started) = started {
             with_fit_profile(|profile| {
                 profile.invalidate_time += started.elapsed();

--- a/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
@@ -173,7 +173,7 @@ fn test_fit_environment_get_or_compute_caches_leaf_environment() {
 
     let cached = env.get_or_compute(&from, &to, &tn_a, &tn_b, &tn_c).unwrap();
     assert_eq!(env.len(), 1);
-    assert!((&computed - &cached).maxabs() < 1e-12);
+    assert!(computed.distance(&cached).unwrap() < 1e-12);
 }
 
 #[test]
@@ -324,7 +324,7 @@ fn test_contract_fit_matches_naive_contraction_on_two_node_tree() {
 
     let fitted_dense = fitted.to_dense().unwrap();
     let expected_dense = tn_a.contract_naive(&tn_b).unwrap();
-    assert!((&fitted_dense - &expected_dense).maxabs() < 1e-10);
+    assert!(fitted_dense.distance(&expected_dense).unwrap() < 1e-10);
 }
 
 #[test]
@@ -355,5 +355,5 @@ fn test_contract_fit_positive_sweeps_do_not_skip_without_truncation_options() {
 
     let fitted_dense = fitted.to_dense().unwrap();
     let expected_dense = tn_a.contract_naive(&tn_b).unwrap();
-    assert!((&fitted_dense - &expected_dense).maxabs() < 1e-10);
+    assert!(fitted_dense.distance(&expected_dense).unwrap() < 1e-10);
 }

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -379,7 +379,9 @@ where
             ))
             .context("apply_local_update_sweep: canonical_region must be a single node");
         }
-        let center_node = canonical_region.iter().next().unwrap();
+        let center_node = canonical_region.iter().next().ok_or_else(|| {
+            anyhow::anyhow!("canonical_region reported one node but yielded none")
+        })?;
         let step_nodes_set: HashSet<V> = step.nodes.iter().cloned().collect();
         if !step_nodes_set.contains(center_node) {
             return Err(anyhow::anyhow!(
@@ -522,8 +524,12 @@ where
             .clone();
 
         // Contract A and B
-        let tensor_a = subtree.tensor(idx_a).unwrap();
-        let tensor_b = subtree.tensor(idx_b).unwrap();
+        let tensor_a = subtree
+            .tensor(idx_a)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?} in subtree", node_a))?;
+        let tensor_b = subtree
+            .tensor(idx_b)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?} in subtree", node_b))?;
         let tensor_ab = T::contract(&[tensor_a, tensor_b], AllowedPairs::All)
             .context("Failed to contract A and B")?;
 
@@ -636,7 +642,10 @@ where
 
         // Step 1: Add all nodes with their tensors
         for name in node_names {
-            let node_idx = self.graph.node_index(name).unwrap();
+            let node_idx = self
+                .graph
+                .node_index(name)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} does not exist", name))?;
             let tensor = self
                 .tensor(node_idx)
                 .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", name))?

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -343,10 +343,34 @@ where
 
     /// Add a tensor to the network using NodeIndex as the node name.
     ///
-    /// This method only works when `V = NodeIndex`.
+    /// This method only works when `V = NodeIndex`. The `tensor` argument
+    /// supplies the node data, and the generated node index is also used as
+    /// the public node name.
     ///
     /// Returns the NodeIndex for the newly added tensor.
-    pub fn add_tensor_auto_name(&mut self, tensor: T) -> NodeIndex
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the generated node name already exists or the
+    /// underlying graph rejects the tensor insertion.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(3);
+    /// let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0_f64; 6]).unwrap();
+    ///
+    /// let mut tn = TreeTN::<TensorDynLen>::new();
+    /// let node = tn.add_tensor_auto_name(tensor).unwrap();
+    ///
+    /// assert_eq!(node.index(), 0);
+    /// assert_eq!(tn.node_count(), 1);
+    /// ```
+    pub fn add_tensor_auto_name(&mut self, tensor: T) -> Result<NodeIndex>
     where
         V: From<NodeIndex> + Into<NodeIndex>,
     {
@@ -359,7 +383,6 @@ where
 
         // Re-add with the correct name
         self.add_tensor_internal(node_name, tensor)
-            .expect("add_tensor_internal failed for auto-named tensor")
     }
 
     /// Connect two tensors via a specified pair of indices.

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -298,7 +298,7 @@ where
         // For TreeTN (tree structure), each bond index should appear in exactly 2 tensors.
         for (shared_index, nodes_with_index) in index_map {
             match nodes_with_index.len() {
-                0 => unreachable!(),
+                0 => continue,
                 1 => {
                     // Index appears in only one tensor - this is a physical index, no connection needed
                     continue;
@@ -465,7 +465,7 @@ where
             .external_indices()
             .iter()
             .find(|idx| *idx == index_a)
-            .unwrap()
+            .ok_or_else(|| anyhow::anyhow!("Index not found in tensor_a"))?
             .clone();
 
         // Get node names for site_index_network (before mutable borrow)
@@ -1926,4 +1926,19 @@ pub(crate) fn common_inds<I: IndexLike>(inds_a: &[I], inds_b: &[I]) -> Vec<I> {
         .filter(|idx| inds_b.iter().any(|other| other == *idx))
         .cloned()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::TensorDynLen;
+
+    #[test]
+    fn from_tensors_empty_returns_empty_network() {
+        let tn = TreeTN::<TensorDynLen, usize>::from_tensors(Vec::new(), Vec::new()).unwrap();
+
+        assert_eq!(tn.node_count(), 0);
+        assert_eq!(tn.edge_count(), 0);
+        assert!(tn.node_names().is_empty());
+    }
 }

--- a/crates/tensor4all-treetn/src/treetn/ops.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops.rs
@@ -130,10 +130,21 @@ where
             if self.is_canonicalized() && self.canonical_form() == Some(CanonicalForm::Unitary) {
                 if self.canonical_region.len() == 1 {
                     // Already Unitary canonicalized to single site - use it
-                    self.canonical_region.iter().next().unwrap().clone()
+                    self.canonical_region
+                        .iter()
+                        .next()
+                        .cloned()
+                        .ok_or_else(|| anyhow::anyhow!("Canonical region is empty"))
+                        .context("log_norm: canonical region must contain one center")?
                 } else {
                     // Unitary canonicalized to multiple sites - canonicalize to min site
-                    let min_center = self.canonical_region.iter().min().unwrap().clone();
+                    let min_center = self
+                        .canonical_region
+                        .iter()
+                        .min()
+                        .cloned()
+                        .ok_or_else(|| anyhow::anyhow!("Canonical region is empty"))
+                        .context("log_norm: canonical region must contain centers")?;
                     self.canonicalize_mut(
                         std::iter::once(min_center.clone()),
                         CanonicalizationOptions::default(),
@@ -282,7 +293,7 @@ where
     ///     dense.external_indices(),
     ///     vec![2.0_f64, -4.0],
     /// ).unwrap();
-    /// assert!((&dense - &expected).maxabs() < 1e-12);
+    /// assert!(dense.distance(&expected).unwrap() < 1e-12);
     /// ```
     pub fn scale(&mut self, scalar: AnyScalar) -> Result<()> {
         let min_node = self
@@ -671,7 +682,7 @@ where
     /// // Evaluate at index value 2
     /// let data = [2usize];
     /// let shape = [indices.len(), 1];
-    /// let values = ColMajorArrayRef::new(&data, &shape);
+    /// let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     /// let result = tn.evaluate_at(&indices, values).unwrap();
     /// assert!((result[0].real() - 30.0).abs() < 1e-10);
     /// ```

--- a/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
@@ -83,7 +83,7 @@ fn test_evaluate_accepts_full_indices_for_same_id_prime_pair() {
     let values = [0usize, 0usize, 1usize, 1usize];
     let shape = [2usize, 2usize];
     let result = tn
-        .evaluate(&indices, ColMajorArrayRef::new(&values, &shape))
+        .evaluate(&indices, ColMajorArrayRef::new(&values, &shape).unwrap())
         .unwrap();
 
     assert_eq!(result.len(), 2);
@@ -97,7 +97,7 @@ fn evaluator_evaluate_batch_matches_evaluate_at_sugar() {
     let (indices, _) = tn.all_site_indices().unwrap();
     let values = [0usize, 0, 0, 1, 1, 1, 0, 1, 0];
     let shape = [indices.len(), 3usize];
-    let values_ref = ColMajorArrayRef::new(&values, &shape);
+    let values_ref = ColMajorArrayRef::new(&values, &shape).unwrap();
 
     let evaluator = TreeTNEvaluator::new(&tn, &indices).unwrap();
     let direct = evaluator.evaluate_batch(values_ref).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
@@ -1064,7 +1064,7 @@ where
     /// assert_eq!(result.node_count(), 1);
     /// let dense = result.contract_to_tensor()?;
     /// let expected = treetn.contract_to_tensor()?;
-    /// assert!((&dense - &expected).maxabs() < 1e-12);
+    /// assert!(dense.distance(&expected).unwrap() < 1e-12);
     /// # Ok::<(), anyhow::Error>(())
     /// # }
     /// ```
@@ -1202,7 +1202,7 @@ mod tests {
 
         assert_eq!(result.node_count(), 1);
         assert_eq!(result.site_index_network().node_count(), 1);
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-12);
 
         Ok(())
     }
@@ -1236,7 +1236,7 @@ mod tests {
         let dense_actual = result.contract_to_tensor()?;
 
         assert_eq!(result.node_count(), 2);
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-12);
 
         Ok(())
     }
@@ -1294,7 +1294,7 @@ mod tests {
                 .map(|name| name.as_str()),
             Some("Z")
         );
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-10);
 
         Ok(())
     }
@@ -1357,7 +1357,7 @@ mod tests {
                 .map(|name| name.as_str()),
             Some("Z")
         );
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-10);
 
         Ok(())
     }
@@ -1414,7 +1414,7 @@ mod tests {
                 .map(|name| name.as_str()),
             Some("Y")
         );
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-10);
 
         Ok(())
     }
@@ -1471,7 +1471,7 @@ mod tests {
                 .map(|name| name.as_str()),
             Some("Y")
         );
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-10);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-10);
 
         Ok(())
     }
@@ -1558,7 +1558,7 @@ mod tests {
         );
         let dense_expected = tn.contract_to_tensor()?;
         let dense_actual = result.contract_to_tensor()?;
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-12);
         Ok(())
     }
 
@@ -1637,7 +1637,7 @@ mod tests {
         );
         let dense_expected = tn.contract_to_tensor()?;
         let dense_actual = result.contract_to_tensor()?;
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-12);
         Ok(())
     }
 
@@ -1696,7 +1696,7 @@ mod tests {
         assert_eq!(result.node_count(), 2);
         let dense_expected = tn.contract_to_tensor()?;
         let dense_actual = result.contract_to_tensor()?;
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-12);
         Ok(())
     }
 }

--- a/crates/tensor4all-treetn/src/treetn/tensor_like.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like.rs
@@ -216,7 +216,7 @@ where
     ///
     /// let dense = unfused.contract_to_tensor().unwrap();
     /// let expected = TensorDynLen::from_dense(vec![left, right], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
-    /// assert!((&dense - &expected).maxabs() < 1.0e-12);
+    /// assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     /// ```
     pub fn replace_site_index_with_indices(
         &self,

--- a/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
@@ -193,7 +193,7 @@ fn test_replaceind_link_index_direct() {
     // The contracted result should be the same
     let orig_dense = tn.contract_to_tensor().unwrap();
     let new_dense = tn2.contract_to_tensor().unwrap();
-    assert!(orig_dense.distance(&new_dense) < 1e-12);
+    assert!(orig_dense.distance(&new_dense).unwrap() < 1e-12);
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -54,7 +54,9 @@ fn is_connected_subset_on_graph<T: TensorLike>(
     if nodes.is_empty() || nodes.len() == 1 {
         return true;
     }
-    let start = *nodes.iter().next().unwrap();
+    let Some(&start) = nodes.iter().next() else {
+        return true;
+    };
     let mut seen = HashSet::new();
     let mut stack = vec![start];
     seen.insert(start);
@@ -227,8 +229,12 @@ where
 
         let tensors: Vec<T> = target_names
             .iter()
-            .map(|name| result_tensors.remove(name).unwrap())
-            .collect();
+            .map(|name| {
+                result_tensors.remove(name).ok_or_else(|| {
+                    anyhow::anyhow!("fuse_to: missing contracted tensor for target {:?}", name)
+                })
+            })
+            .collect::<Result<_>>()?;
 
         let result = TreeTN::<T, TargetV>::from_tensors(tensors, target_names)
             .context("fuse_to: failed to build result TreeTN")?;
@@ -272,8 +278,14 @@ where
         }
 
         // Pick a root (smallest node name for determinism)
-        let root_name = nodes.iter().min().unwrap();
-        let root_idx = self.graph.node_index(root_name).unwrap();
+        let root_name = nodes
+            .iter()
+            .min()
+            .ok_or_else(|| anyhow::anyhow!("Cannot contract empty node group"))?;
+        let root_idx = self
+            .graph
+            .node_index(root_name)
+            .ok_or_else(|| anyhow::anyhow!("Root node {:?} not found in graph", root_name))?;
 
         // Get edges within the group, ordered from leaves to root.
         let mut dfs = petgraph::visit::DfsPostOrder::new(g, root_idx);
@@ -481,7 +493,9 @@ where
 
             if targets_for_node.len() == 1 {
                 // No split needed - just relabel
-                let target_name = targets_for_node.iter().next().unwrap().clone();
+                let target_name = targets_for_node.iter().next().cloned().ok_or_else(|| {
+                    anyhow::anyhow!("No target mapping for node {:?}", current_node_name)
+                })?;
                 result_tensors.push((target_name, tensor.clone()));
             } else {
                 // Need to split this node
@@ -713,8 +727,24 @@ where
         // the root (higher position in post-order) is the parent.
         let mut children_by_parent: HashMap<TargetV, Vec<TargetV>> = HashMap::new();
         for (ref parent_name, ref child_name) in fragment_target.edges() {
-            let pos_a = traversal.iter().position(|n| *n == *parent_name).unwrap();
-            let pos_b = traversal.iter().position(|n| *n == *child_name).unwrap();
+            let pos_a = traversal
+                .iter()
+                .position(|n| *n == *parent_name)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "split_to: fragment edge references node {:?} outside traversal",
+                        parent_name
+                    )
+                })?;
+            let pos_b = traversal
+                .iter()
+                .position(|n| *n == *child_name)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "split_to: fragment edge references node {:?} outside traversal",
+                        child_name
+                    )
+                })?;
             if pos_a > pos_b {
                 children_by_parent
                     .entry(parent_name.clone())
@@ -788,7 +818,9 @@ where
         }
 
         // Root gets the remaining tensor with all child bonds
-        let root_name = traversal.last().unwrap();
+        let root_name = traversal
+            .last()
+            .ok_or_else(|| anyhow::anyhow!("split_to: fragment traversal produced no nodes"))?;
         result.push((root_name.clone(), remaining_tensor));
 
         Ok(result)
@@ -812,7 +844,12 @@ where
         let mut result: Vec<(TargetV, T)> = Vec::new();
 
         for target_name in target_names.iter().take(target_names.len() - 1) {
-            let site_indices_for_target = partition.get(target_name).unwrap();
+            let site_indices_for_target = partition.get(target_name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "split_to: no partitioned indices found for target {:?}",
+                    target_name
+                )
+            })?;
 
             let left_inds: Vec<_> = remaining_tensor
                 .external_indices()
@@ -841,7 +878,9 @@ where
             remaining_tensor = factorize_result.right;
         }
 
-        let last_target = target_names.last().unwrap();
+        let last_target = target_names
+            .last()
+            .ok_or_else(|| anyhow::anyhow!("split_to: sequential split has no target nodes"))?;
         result.push((last_target.clone(), remaining_tensor));
 
         Ok(result)

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -39,7 +39,7 @@ fn test_fuse_to_two_nodes_into_one() {
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(
-        orig_full.distance(&fused_full) < 1e-12,
+        orig_full.distance(&fused_full).unwrap() < 1e-12,
         "fused tensor should match original contraction"
     );
 }
@@ -75,7 +75,7 @@ fn test_split_to_one_node_into_two() {
     let fused_full = fused.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
     assert!(
-        fused_full.distance(&split_full) < 1e-12,
+        fused_full.distance(&split_full).unwrap() < 1e-12,
         "split tensor should match fused tensor"
     );
 }
@@ -185,7 +185,7 @@ fn test_fuse_to_three_nodes_pairwise() {
 
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
-    assert!(orig_full.distance(&fused_full) < 1e-12);
+    assert!(orig_full.distance(&fused_full).unwrap() < 1e-12);
 }
 
 #[test]
@@ -205,7 +205,7 @@ fn test_fuse_to_three_nodes_into_one() {
 
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
-    assert!(orig_full.distance(&fused_full) < 1e-12);
+    assert!(orig_full.distance(&fused_full).unwrap() < 1e-12);
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn test_split_to_with_actual_splitting() {
 
     let fused_full = fused.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
-    assert!(fused_full.distance(&split_full) < 1e-12);
+    assert!(fused_full.distance(&split_full).unwrap() < 1e-12);
 }
 
 #[test]
@@ -350,6 +350,7 @@ fn test_split_to_allows_edgeless_intermediate_fragments() {
         tn.contract_to_tensor()
             .unwrap()
             .distance(&split.contract_to_tensor().unwrap())
+            .unwrap()
             < 1e-12
     );
 }
@@ -464,6 +465,7 @@ fn test_split_to_identity_preserves_explicit_edge() {
         tn.contract_to_tensor()
             .unwrap()
             .distance(&split.contract_to_tensor().unwrap())
+            .unwrap()
             < 1e-12
     );
 }
@@ -542,7 +544,7 @@ fn test_split_to_with_final_sweep() {
 
     let fused_full = fused.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
-    assert!(fused_full.distance(&split_full) < 1e-10);
+    assert!(fused_full.distance(&split_full).unwrap() < 1e-10);
 }
 
 #[test]
@@ -584,7 +586,7 @@ fn test_fuse_identity_mapping() {
 
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
-    assert!(orig_full.distance(&fused_full) < 1e-12);
+    assert!(orig_full.distance(&fused_full).unwrap() < 1e-12);
 }
 
 fn make_four_site_fused_node() -> (
@@ -640,7 +642,7 @@ fn test_split_to_y_shape() {
 
     let full = tn.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
-    assert!(full.distance(&split_full) < 1e-12);
+    assert!(full.distance(&split_full).unwrap() < 1e-12);
 }
 
 #[test]
@@ -675,7 +677,7 @@ fn test_split_to_nested_tree() {
 
     let full = tn.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
-    assert!(full.distance(&split_full) < 1e-12);
+    assert!(full.distance(&split_full).unwrap() < 1e-12);
 }
 
 #[test]
@@ -722,7 +724,7 @@ fn test_split_to_y_shape_across_original_bond() {
 
     let full = fused.contract_to_tensor().unwrap();
     let split_full = split.contract_to_tensor().unwrap();
-    assert!(full.distance(&split_full) < 1e-12);
+    assert!(full.distance(&split_full).unwrap() < 1e-12);
 }
 
 // ============================================================================
@@ -814,7 +816,7 @@ fn test_fuse_to_y_shape_fuse_subtree() {
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(
-        orig_full.distance(&fused_full) < 1e-12,
+        orig_full.distance(&fused_full).unwrap() < 1e-12,
         "fused Y-shape branch should match original contraction"
     );
 }
@@ -843,7 +845,7 @@ fn test_fuse_to_y_shape_all_into_one() {
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(
-        orig_full.distance(&fused_full) < 1e-12,
+        orig_full.distance(&fused_full).unwrap() < 1e-12,
         "fused entire Y-shape should match original contraction"
     );
 }
@@ -876,7 +878,7 @@ fn test_fuse_to_y_shape_identity() {
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(
-        orig_full.distance(&fused_full) < 1e-12,
+        orig_full.distance(&fused_full).unwrap() < 1e-12,
         "identity fuse on Y-shape should match original contraction"
     );
 }
@@ -947,7 +949,7 @@ fn test_fuse_to_y_shape_internal_center_node() {
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(
-        orig_full.distance(&fused_full) < 1e-12,
+        orig_full.distance(&fused_full).unwrap() < 1e-12,
         "fused Y-shape with internal center should match original contraction"
     );
 }

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -141,7 +141,12 @@ where
             .context(format!("{}: multi-node center not supported", context_name));
         }
 
-        let center_node = center_nodes.iter().next().unwrap().clone();
+        let center_node = center_nodes
+            .iter()
+            .next()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("truncate requires a center node"))
+            .context(format!("{}: missing center node", context_name))?;
 
         // Step 1: Canonicalize towards the center (required before truncation sweep)
         let canonicalize_options =

--- a/crates/tensor4all-treetn/tests/ad_treetn.rs
+++ b/crates/tensor4all-treetn/tests/ad_treetn.rs
@@ -36,6 +36,7 @@ fn backward_ad_to_dense_propagates_gradients() {
             TensorDynLen::from_dense(idx.clone(), d.clone())
                 .unwrap()
                 .enable_grad()
+                .unwrap()
         })
         .collect();
 
@@ -70,6 +71,7 @@ fn backward_ad_gradient_matches_finite_diff() {
             TensorDynLen::from_dense(idx.clone(), d.clone())
                 .unwrap()
                 .enable_grad()
+                .unwrap()
         })
         .collect();
 
@@ -110,7 +112,7 @@ fn backward_ad_gradient_matches_finite_diff() {
                 })
                 .collect();
             let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
-            ttn.to_dense().unwrap().sum().real()
+            ttn.to_dense().unwrap().sum().unwrap().real()
         };
 
         let fd = (make_perturbed_sum(eps) - make_perturbed_sum(-eps)) / (2.0 * eps);
@@ -134,6 +136,7 @@ fn backward_accumulates_until_clear_grad_across_treetn_nodes() {
             TensorDynLen::from_dense(idx.clone(), d.clone())
                 .unwrap()
                 .enable_grad()
+                .unwrap()
         })
         .collect();
 

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -36,11 +36,11 @@ fn create_two_node_treetn() -> (
 
     let tensor1 =
         TensorDynLen::from_dense(vec![phys1.clone(), bond.clone()], vec![1.0; 6]).unwrap();
-    let node1 = tn.add_tensor_auto_name(tensor1);
+    let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
         TensorDynLen::from_dense(vec![bond.clone(), phys2.clone()], vec![1.0; 12]).unwrap();
-    let node2 = tn.add_tensor_auto_name(tensor2);
+    let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let edge = tn.connect(node1, &bond, node2, &bond).unwrap();
 
@@ -67,15 +67,15 @@ fn create_three_node_chain() -> (
 
     let tensor1 =
         TensorDynLen::from_dense(vec![phys1.clone(), bond12.clone()], vec![1.0; 6]).unwrap();
-    let node1 = tn.add_tensor_auto_name(tensor1);
+    let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
         TensorDynLen::from_dense(vec![bond12.clone(), bond23.clone()], vec![1.0; 12]).unwrap();
-    let node2 = tn.add_tensor_auto_name(tensor2);
+    let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let tensor3 =
         TensorDynLen::from_dense(vec![bond23.clone(), phys3.clone()], vec![1.0; 20]).unwrap();
-    let node3 = tn.add_tensor_auto_name(tensor3);
+    let node3 = tn.add_tensor_auto_name(tensor3).unwrap();
 
     let edge12 = tn.connect(node1, &bond12, node2, &bond12).unwrap();
     let edge23 = tn.connect(node2, &bond23, node3, &bond23).unwrap();
@@ -95,12 +95,26 @@ fn test_treetn_add_tensor() {
     let j = DynIndex::new_dyn(3);
     let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
 
-    let node = tn.add_tensor_auto_name(tensor);
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
     assert_eq!(tn.node_count(), 1);
 
     let retrieved = tn.tensor(node);
     assert!(retrieved.is_some());
     assert_eq!(retrieved.unwrap().dims(), vec![2, 3]);
+}
+
+#[test]
+fn test_add_tensor_auto_name_returns_result() {
+    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+    let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
+
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
+
+    assert_eq!(node.index(), 0);
+    assert_eq!(tn.node_count(), 1);
 }
 
 #[test]
@@ -110,7 +124,7 @@ fn test_treetn_replace_tensor() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
     let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
-    let node = tn.add_tensor_auto_name(tensor);
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     // Replace with a tensor that has the same indices
     let new_tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
@@ -188,12 +202,12 @@ fn test_treetn_connect_id_mismatch() {
     let i1 = DynIndex::new_dyn(2);
     let j1 = DynIndex::new_dyn(3);
     let tensor1 = TensorDynLen::from_dense(vec![i1.clone(), j1.clone()], vec![0.0; 6]).unwrap();
-    let node1 = tn.add_tensor_auto_name(tensor1);
+    let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let i2 = DynIndex::new_dyn(3); // Different ID than j1
     let k2 = DynIndex::new_dyn(4);
     let tensor2 = TensorDynLen::from_dense(vec![i2.clone(), k2.clone()], vec![0.0; 12]).unwrap();
-    let node2 = tn.add_tensor_auto_name(tensor2);
+    let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Try to connect with different index IDs - should fail in Einsum mode
     let result = tn.connect(node1, &j1, node2, &i2);
@@ -215,7 +229,7 @@ fn test_treetn_connect_invalid_node() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
     let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
-    let node1 = tn.add_tensor_auto_name(tensor);
+    let node1 = tn.add_tensor_auto_name(tensor).unwrap();
 
     let invalid_node = NodeIndex::new(999);
     let result = tn.connect(node1, &j, invalid_node, &j);
@@ -229,12 +243,12 @@ fn test_treetn_connect_index_not_in_tensor() {
     let i1 = DynIndex::new_dyn(2);
     let j1 = DynIndex::new_dyn(3);
     let tensor1 = TensorDynLen::from_dense(vec![i1.clone(), j1.clone()], vec![0.0; 6]).unwrap();
-    let node1 = tn.add_tensor_auto_name(tensor1);
+    let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let bond = DynIndex::new_dyn(3);
     let k2 = DynIndex::new_dyn(4);
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k2.clone()], vec![0.0; 12]).unwrap();
-    let node2 = tn.add_tensor_auto_name(tensor2);
+    let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Try to connect with an index that doesn't exist in tensor1
     let fake_index = DynIndex::new_dyn(3);
@@ -310,7 +324,7 @@ fn test_treetn_set_edge_ortho_towards_invalid() {
     let i3 = DynIndex::new_dyn(5);
     let k3 = DynIndex::new_dyn(6);
     let tensor3 = TensorDynLen::from_dense(vec![i3, k3], vec![0.0; 30]).unwrap();
-    let node3 = tn.add_tensor_auto_name(tensor3);
+    let node3 = tn.add_tensor_auto_name(tensor3).unwrap();
 
     // Try to set ortho direction to a node that's not an endpoint
     let result = tn.set_edge_ortho_towards(edge, Some(node3));
@@ -344,15 +358,15 @@ fn test_treetn_validate_tree_cycle() {
 
     let tensor1 =
         TensorDynLen::from_dense(vec![bond12.clone(), bond31.clone()], vec![0.0; 15]).unwrap();
-    let node1 = tn.add_tensor_auto_name(tensor1);
+    let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
         TensorDynLen::from_dense(vec![bond12.clone(), bond23.clone()], vec![0.0; 12]).unwrap();
-    let node2 = tn.add_tensor_auto_name(tensor2);
+    let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let tensor3 =
         TensorDynLen::from_dense(vec![bond23.clone(), bond31.clone()], vec![0.0; 20]).unwrap();
-    let node3 = tn.add_tensor_auto_name(tensor3);
+    let node3 = tn.add_tensor_auto_name(tensor3).unwrap();
 
     tn.connect(node1, &bond12, node2, &bond12).unwrap();
     tn.connect(node2, &bond23, node3, &bond23).unwrap();
@@ -369,11 +383,11 @@ fn test_treetn_validate_tree_disconnected() {
     // Create two disconnected nodes
     let i1 = DynIndex::new_dyn(2);
     let tensor1 = TensorDynLen::from_dense(vec![i1], vec![0.0; 2]).unwrap();
-    let _node1 = tn.add_tensor_auto_name(tensor1);
+    let _node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let i2 = DynIndex::new_dyn(3);
     let tensor2 = TensorDynLen::from_dense(vec![i2], vec![0.0; 3]).unwrap();
-    let _node2 = tn.add_tensor_auto_name(tensor2);
+    let _node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Should fail: not connected
     assert!(tn.validate_tree().is_err());
@@ -402,7 +416,7 @@ fn test_set_canonical_region() {
 
     let i = DynIndex::new_dyn(2);
     let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
-    let node = tn.add_tensor_auto_name(tensor);
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     assert!(!tn.is_canonicalized());
 
@@ -427,7 +441,7 @@ fn test_clear_canonical_region() {
 
     let i = DynIndex::new_dyn(2);
     let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
-    let node = tn.add_tensor_auto_name(tensor);
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     tn.set_canonical_region(vec![node]).unwrap();
     assert!(tn.is_canonicalized());
@@ -447,7 +461,7 @@ fn test_add_to_canonical_region() {
 
     let i = DynIndex::new_dyn(2);
     let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
-    let node = tn.add_tensor_auto_name(tensor);
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     // Add valid node to canonical region
     tn.add_to_canonical_region(node).unwrap();
@@ -470,7 +484,7 @@ fn test_remove_from_canonical_region() {
 
     let i = DynIndex::new_dyn(2);
     let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
-    let node = tn.add_tensor_auto_name(tensor);
+    let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     tn.set_canonical_region(vec![node]).unwrap();
     assert!(tn.canonical_region().contains(&node));
@@ -527,11 +541,11 @@ fn test_validate_ortho_consistency_disconnected_centers() {
     // Create two disconnected nodes
     let i1 = DynIndex::new_dyn(2);
     let tensor1 = TensorDynLen::from_dense(vec![i1], vec![0.0; 2]).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let i2 = DynIndex::new_dyn(3);
     let tensor2 = TensorDynLen::from_dense(vec![i2], vec![0.0; 3]).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Two centers that are not connected should fail
     tn.set_canonical_region(vec![n1, n2]).unwrap();
@@ -578,11 +592,11 @@ fn test_canonicalize_simple() {
 
     let data1: Vec<f64> = vec![1.0; 6];
     let tensor1 = TensorDynLen::from_dense(vec![phys1.clone(), bond.clone()], data1).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = vec![1.0; 12];
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), phys2.clone()], data2).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
 
@@ -609,12 +623,12 @@ fn canonicalize_preserves_near_dependent_components() {
         vec![1.0, 0.0, 0.0, 1.0e-16],
     )
     .unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
         TensorDynLen::from_dense(vec![bond.clone(), right.clone()], vec![1.0, 0.0, 0.0, 1.0])
             .unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
     let expected = tn.contract_to_tensor().unwrap();
@@ -652,11 +666,11 @@ fn test_contract_two_nodes() {
 
     let data1: Vec<f64> = (0..6).map(|x| x as f64).collect();
     let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = (0..12).map(|x| x as f64).collect();
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
 
@@ -771,11 +785,11 @@ fn test_log_norm_simple() {
 
     let data1: Vec<f64> = vec![1.0; 6];
     let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = vec![1.0; 12];
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
 
@@ -803,7 +817,7 @@ fn test_truncate_simple() {
         data1[idx * 10 + 1] = 0.5;
     }
     let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     // tensor2[bond, k] similar structure
     let mut data2 = vec![0.0f64; 40];
@@ -812,7 +826,7 @@ fn test_truncate_simple() {
         data2[4 + k_idx] = 0.3;
     }
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let edge = tn.connect(n1, &bond, n2, &bond).unwrap();
 
@@ -842,11 +856,11 @@ fn test_truncate_mut_simple() {
 
     let data1: Vec<f64> = (0..16).map(|x| x as f64).collect();
     let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = (0..32).map(|x| x as f64).collect();
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let edge = tn.connect(n1, &bond, n2, &bond).unwrap();
 
@@ -905,14 +919,14 @@ fn test_truncate_with_svd_policy() {
     data1[0] = 1.0;
     data1[5] = 1.0;
     let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
-    let n1 = tn.add_tensor_auto_name(tensor1);
+    let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let mut data2 = vec![0.0f64; 15];
     data2[0] = 1.0;
     data2[1] = 1.0;
     data2[2] = 1.0;
     let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
-    let n2 = tn.add_tensor_auto_name(tensor2);
+    let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
 
@@ -954,22 +968,22 @@ fn test_truncate_y_shape() {
 
     let tensor_a =
         TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 12]).unwrap();
-    let n_a = tn.add_tensor_auto_name(tensor_a);
+    let n_a = tn.add_tensor_auto_name(tensor_a).unwrap();
 
     let tensor_b = TensorDynLen::from_dense(
         vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
         vec![1.0; 216],
     )
     .unwrap();
-    let n_b = tn.add_tensor_auto_name(tensor_b);
+    let n_b = tn.add_tensor_auto_name(tensor_b).unwrap();
 
     let tensor_c =
         TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 12]).unwrap();
-    let n_c = tn.add_tensor_auto_name(tensor_c);
+    let n_c = tn.add_tensor_auto_name(tensor_c).unwrap();
 
     let tensor_d =
         TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 12]).unwrap();
-    let n_d = tn.add_tensor_auto_name(tensor_d);
+    let n_d = tn.add_tensor_auto_name(tensor_d).unwrap();
 
     tn.connect(n_a, &bond_ab, n_b, &bond_ab).unwrap();
     tn.connect(n_b, &bond_bc, n_c, &bond_bc).unwrap();

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -644,7 +644,7 @@ fn canonicalize_preserves_near_dependent_components() {
             .contract_to_tensor()
             .unwrap();
 
-        let error = (&actual - &expected).maxabs();
+        let error = actual.distance(&expected).unwrap();
         assert!(
             error < 1.0e-18,
             "{form:?} canonicalization changed the represented tensor: maxabs diff = {error}"
@@ -1418,8 +1418,8 @@ fn compare_contract_vs_naive(
     // Create two random TreeTNs
     let mut rng1 = ChaCha8Rng::seed_from_u64(seed1);
     let mut rng2 = ChaCha8Rng::seed_from_u64(seed2);
-    let tn1 = random_treetn::<f64, _, _>(&mut rng1, site_network, link_space.clone());
-    let tn2 = random_treetn::<f64, _, _>(&mut rng2, site_network, link_space);
+    let tn1 = random_treetn::<f64, _, _>(&mut rng1, site_network, link_space.clone()).unwrap();
+    let tn2 = random_treetn::<f64, _, _>(&mut rng2, site_network, link_space).unwrap();
 
     // Contract using naive method (reference)
     let naive_result = tn1

--- a/crates/tensor4all-treetn/tests/bug_swap_values.rs
+++ b/crates/tensor4all-treetn/tests/bug_swap_values.rs
@@ -149,7 +149,7 @@ fn test_contract_factorize_roundtrip() {
     let t1 = treetn.tensor(n1).unwrap().clone();
     let t2 = treetn.tensor(n2).unwrap().clone();
 
-    let contracted = t1.contract(&t2);
+    let contracted = t1.contract(&t2).unwrap();
 
     // Find left_inds for factorization
     let t1_ids: std::collections::HashSet<_> = t1
@@ -180,8 +180,10 @@ fn test_contract_factorize_roundtrip() {
         .factorize(&left_inds, &factorize_options)
         .unwrap();
 
-    let reconstructed = result.left.contract(&result.right);
-    let recon_aligned = reconstructed.permute_indices(&contracted.external_indices());
+    let reconstructed = result.left.contract(&result.right).unwrap();
+    let recon_aligned = reconstructed
+        .permute_indices(&contracted.external_indices())
+        .unwrap();
     let neg = recon_aligned
         .scale(tensor4all_core::AnyScalar::new_real(-1.0))
         .unwrap();
@@ -203,15 +205,24 @@ fn test_manual_sweep_edge_steps() {
     let mut t = concatenate(&left, &right);
 
     // Reference: full contraction of original tensors
-    let full_ref = t[3].contract(&t[2]).contract(&t[1]).contract(&t[0]);
+    let full_ref = t[3]
+        .contract(&t[2])
+        .unwrap()
+        .contract(&t[1])
+        .unwrap()
+        .contract(&t[0])
+        .unwrap();
 
     // Helper: contract all 4 tensors and compare to reference
     let check_full = |_label: &str, tensors: &[TensorDynLen]| -> f64 {
         let full = tensors[3]
             .contract(&tensors[2])
+            .unwrap()
             .contract(&tensors[1])
-            .contract(&tensors[0]);
-        let aligned = full.permute_indices(&full_ref.external_indices());
+            .unwrap()
+            .contract(&tensors[0])
+            .unwrap();
+        let aligned = full.permute_indices(&full_ref.external_indices()).unwrap();
         let neg = full_ref
             .scale(tensor4all_core::AnyScalar::new_real(-1.0))
             .unwrap();
@@ -245,7 +256,7 @@ fn test_manual_sweep_edge_steps() {
         let fr = t[src]
             .factorize(&left_inds, &FactorizeOptions::qr())
             .unwrap();
-        let new_dst = t[dst].contract(&fr.right);
+        let new_dst = t[dst].contract(&fr.right).unwrap();
         t[src] = fr.left;
         t[dst] = new_dst;
     };
@@ -285,8 +296,8 @@ fn test_qr_roundtrip_tall_matrix() {
         .factorize(&[i2.clone(), i3.clone()], &FactorizeOptions::qr())
         .unwrap();
 
-    let recon = fr.left.contract(&fr.right);
-    let recon_aligned = recon.permute_indices(&t.external_indices());
+    let recon = fr.left.contract(&fr.right).unwrap();
+    let recon_aligned = recon.permute_indices(&t.external_indices()).unwrap();
     let neg = t.scale(tensor4all_core::AnyScalar::new_real(-1.0)).unwrap();
     let diff = recon_aligned.add(&neg).unwrap();
     let rel_err = diff.norm() / t.norm();

--- a/crates/tensor4all-treetn/tests/ops.rs
+++ b/crates/tensor4all-treetn/tests/ops.rs
@@ -255,7 +255,7 @@ fn test_to_dense_single_node() {
     assert!(
         dense.isapprox(&t0, 1e-10, 0.0),
         "to_dense mismatch: maxabs diff = {}",
-        (&dense - &t0).maxabs()
+        dense.distance(&t0).unwrap()
     );
 }
 
@@ -337,7 +337,7 @@ fn test_evaluate_single_node() {
     // Evaluate at index 0
     let data = [0usize];
     let shape = [indices.len(), 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let vals = tn.evaluate(&indices, values).unwrap();
     assert!(
         (vals[0].real() - 10.0).abs() < 1e-10,
@@ -347,7 +347,7 @@ fn test_evaluate_single_node() {
 
     // Evaluate at index 2
     let data = [2usize];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let vals = tn.evaluate(&indices, values).unwrap();
     assert!(
         (vals[0].real() - 30.0).abs() < 1e-10,
@@ -379,7 +379,7 @@ fn test_evaluate_two_nodes() {
             data[pos0] = i;
             data[pos1] = j;
             let shape = [indices.len(), 1];
-            let values = ColMajorArrayRef::new(&data, &shape);
+            let values = ColMajorArrayRef::new(&data, &shape).unwrap();
             let vals = tn.evaluate(&indices, values).unwrap();
 
             // Get the expected value from dense tensor
@@ -426,7 +426,7 @@ fn test_evaluate_two_nodes_complex() {
             data[pos0] = i;
             data[pos1] = j;
             let shape = [indices.len(), 1];
-            let values = ColMajorArrayRef::new(&data, &shape);
+            let values = ColMajorArrayRef::new(&data, &shape).unwrap();
             let vals = tn.evaluate(&indices, values).unwrap();
             let expected = *a_i * *b_j;
             let got = Complex64::new(vals[0].real(), vals[0].imag());
@@ -465,7 +465,7 @@ fn test_evaluate_three_nodes() {
         data[pos1] = j;
         data[pos2] = k;
         let shape = [indices.len(), 1];
-        let values = ColMajorArrayRef::new(&data, &shape);
+        let values = ColMajorArrayRef::new(&data, &shape).unwrap();
         let vals = tn.evaluate(&indices, values).unwrap();
 
         let flat_idx = i + dim0 * (j + dim1 * k);
@@ -498,11 +498,11 @@ fn test_evaluate_at_matches_evaluate() {
     let shape = [indices.len(), 3];
 
     let evaluate_data = build_col_major_data(&indices, &point_values);
-    let evaluate_values = ColMajorArrayRef::new(&evaluate_data, &shape);
+    let evaluate_values = ColMajorArrayRef::new(&evaluate_data, &shape).unwrap();
     let evaluate_result = tn.evaluate(&indices, evaluate_values).unwrap();
 
     let evaluate_at_data = build_col_major_data(&indices, &point_values);
-    let evaluate_at_values = ColMajorArrayRef::new(&evaluate_at_data, &shape);
+    let evaluate_at_values = ColMajorArrayRef::new(&evaluate_at_data, &shape).unwrap();
     let evaluate_at_result = tn.evaluate_at(&indices, evaluate_at_values).unwrap();
 
     assert_eq!(evaluate_at_result.len(), evaluate_result.len());
@@ -518,7 +518,7 @@ fn test_evaluate_empty() {
     let tn = TreeTN::<TensorDynLen, usize>::new();
     let data: [usize; 0] = [];
     let shape = [0, 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let result = tn.evaluate(&[], values);
     assert!(result.is_err());
 }
@@ -535,7 +535,7 @@ fn test_evaluate_rejects_duplicate_indices() {
     let dup_indices = vec![s0.clone(), s0.clone()];
     let data = [0usize, 0];
     let shape = [2, 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let result = tn.evaluate(&dup_indices, values);
     assert!(result.is_err(), "should reject duplicate indices");
     let msg = format!("{}", result.unwrap_err());
@@ -554,7 +554,7 @@ fn test_evaluate_rejects_unknown_indices() {
     let fake_indices = vec![s0.clone(), unknown];
     let data = [0usize, 0];
     let shape = [2, 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let result = tn.evaluate(&fake_indices, values);
     assert!(result.is_err(), "should reject unknown indices");
     let msg = format!("{}", result.unwrap_err());
@@ -572,7 +572,7 @@ fn test_evaluate_rejects_missing_indices() {
     let partial_indices = vec![s0.clone()];
     let data = [0usize];
     let shape = [1, 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let result = tn.evaluate(&partial_indices, values);
     assert!(result.is_err(), "should reject missing indices");
     let msg = format!("{}", result.unwrap_err());
@@ -650,7 +650,7 @@ fn test_evaluate_at_single_node() {
     // Evaluate at index 0
     let data = [0usize];
     let shape = [indices.len(), 1];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let vals = tn.evaluate_at(&indices, values).unwrap();
     assert!(
         (vals[0].real() - 10.0).abs() < 1e-10,
@@ -660,7 +660,7 @@ fn test_evaluate_at_single_node() {
 
     // Evaluate at index 2
     let data = [2usize];
-    let values = ColMajorArrayRef::new(&data, &shape);
+    let values = ColMajorArrayRef::new(&data, &shape).unwrap();
     let vals = tn.evaluate_at(&indices, values).unwrap();
     assert!(
         (vals[0].real() - 30.0).abs() < 1e-10,
@@ -692,7 +692,7 @@ fn test_evaluate_at_two_nodes() {
             data[pos0] = i;
             data[pos1] = j;
             let shape = [indices.len(), 1];
-            let values = ColMajorArrayRef::new(&data, &shape);
+            let values = ColMajorArrayRef::new(&data, &shape).unwrap();
             let vals = tn.evaluate_at(&indices, values).unwrap();
 
             let flat_idx = i + dim0 * j;
@@ -727,7 +727,7 @@ fn test_evaluate_at_consistent_with_evaluate() {
             data[pos0] = i;
             data[pos1] = j;
             let shape = [indices.len(), 1];
-            let values = ColMajorArrayRef::new(&data, &shape);
+            let values = ColMajorArrayRef::new(&data, &shape).unwrap();
 
             let vals_at = tn.evaluate_at(&indices, values).unwrap();
             let vals = tn.evaluate(&indices, values).unwrap();
@@ -765,7 +765,7 @@ fn test_evaluate_at_three_nodes() {
         data[pos1] = j;
         data[pos2] = k;
         let shape = [indices.len(), 1];
-        let values = ColMajorArrayRef::new(&data, &shape);
+        let values = ColMajorArrayRef::new(&data, &shape).unwrap();
         let vals = tn.evaluate_at(&indices, values).unwrap();
 
         let flat_idx = i + dim0 * (j + dim1 * k);
@@ -801,6 +801,6 @@ fn test_add_two_nodes() {
     assert!(
         sum_dense.isapprox(&expected, 1e-10, 0.0),
         "add mismatch: maxabs diff = {}",
-        (&sum_dense - &expected).maxabs()
+        sum_dense.distance(&expected).unwrap()
     );
 }

--- a/crates/tensor4all-treetn/tests/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/tests/simplett_bridge.rs
@@ -9,20 +9,22 @@ use tensor4all_treetn::{
 
 fn two_site_tensor_train_f64() -> TensorTrain<f64> {
     TensorTrain::new(vec![
-        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2),
-        tensor3_from_data(vec![1.0, 0.5, -1.0, 2.0], 2, 2, 1),
+        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(vec![1.0, 0.5, -1.0, 2.0], 2, 2, 1).unwrap(),
     ])
     .expect("valid two-site tensor train")
 }
 
 fn single_site_tensor_train_f64() -> TensorTrain<f64> {
-    TensorTrain::new(vec![tensor3_from_data(vec![1.0, -2.0, 3.5], 1, 3, 1)])
-        .expect("valid single-site tensor train")
+    TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, -2.0, 3.5], 1, 3, 1).unwrap()
+    ])
+    .expect("valid single-site tensor train")
 }
 
 fn three_site_tensor_train_f64() -> TensorTrain<f64> {
     TensorTrain::new(vec![
-        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2),
+        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
         tensor3_from_data(
             vec![
                 1.0, 0.5, -1.0, 2.0, //
@@ -31,8 +33,9 @@ fn three_site_tensor_train_f64() -> TensorTrain<f64> {
             2,
             2,
             2,
-        ),
-        tensor3_from_data(vec![0.5, 1.5, -2.0, 1.0], 2, 2, 1),
+        )
+        .unwrap(),
+        tensor3_from_data(vec![0.5, 1.5, -2.0, 1.0], 2, 2, 1).unwrap(),
     ])
     .expect("valid three-site tensor train")
 }
@@ -49,7 +52,8 @@ fn two_site_tensor_train_c64() -> TensorTrain<Complex64> {
             1,
             2,
             2,
-        ),
+        )
+        .unwrap(),
         tensor3_from_data(
             vec![
                 Complex64::new(1.0, -0.5),
@@ -60,7 +64,8 @@ fn two_site_tensor_train_c64() -> TensorTrain<Complex64> {
             2,
             2,
             1,
-        ),
+        )
+        .unwrap(),
     ])
     .expect("valid complex two-site tensor train")
 }

--- a/crates/tensor4all-treetn/tests/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/tests/simplett_bridge.rs
@@ -81,7 +81,7 @@ fn tensor_train_to_treetn_preserves_dense_values() -> Result<()> {
 
     assert_eq!(treetn.node_names(), vec![0, 1]);
     assert_eq!(site_indices.len(), tt.len());
-    assert!((&dense - &expected).maxabs() < 1.0e-12);
+    assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     Ok(())
 }
 
@@ -106,7 +106,7 @@ fn tensor_train_to_treetn_supports_complex_scalars() -> Result<()> {
     let (values, _shape) = tt.fulltensor();
     let expected = TensorDynLen::from_dense(site_indices, values)?;
 
-    assert!((&dense - &expected).maxabs() < 1.0e-12);
+    assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     Ok(())
 }
 
@@ -142,7 +142,7 @@ fn tensor_train_to_treetn_single_site_preserves_dense_values() -> Result<()> {
 
     assert_eq!(treetn.node_names(), vec![0]);
     assert_eq!(site_indices.len(), 1);
-    assert!((&dense - &expected).maxabs() < 1.0e-12);
+    assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     Ok(())
 }
 
@@ -156,7 +156,7 @@ fn tensor_train_to_treetn_three_site_preserves_dense_values() -> Result<()> {
     let expected = TensorDynLen::from_dense(site_indices, values)?;
 
     assert_eq!(treetn.node_names(), vec![0, 1, 2]);
-    assert!((&dense - &expected).maxabs() < 1.0e-12);
+    assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     Ok(())
 }
 

--- a/crates/tensor4all-treetn/tests/swap_test.rs
+++ b/crates/tensor4all-treetn/tests/swap_test.rs
@@ -342,11 +342,11 @@ fn test_swap_2r_interleave_generic<T: TensorElement + From<f64>>() {
     assert_eq!(net.find_node_by_index(&y1).map(|n| n.as_str()), Some("3"));
 
     let after = tn.contract_to_tensor().unwrap();
-    let diff = &before - &after;
+    let diff = before.distance(&after).unwrap();
     assert!(
-        diff.maxabs() < 1e-10,
+        diff < 1e-10,
         "contract_to_tensor must match before and after swap, diff={}",
-        diff.maxabs()
+        diff
     );
 }
 
@@ -378,11 +378,11 @@ fn test_swap_y_shape_contract_and_canonical_form_generic<T: TensorElement + From
         .unwrap();
 
     let after = tn.contract_to_tensor().unwrap();
-    let diff = &before - &after;
+    let diff = before.distance(&after).unwrap();
     assert!(
-        diff.maxabs() < 1e-10,
+        diff < 1e-10,
         "contract_to_tensor must match before and after Y-shape swap, diff={}",
-        diff.maxabs()
+        diff
     );
     assert!(tn.is_canonicalized());
 }
@@ -398,11 +398,11 @@ fn test_swap_correctness_contract_generic<T: TensorElement + From<f64>>() {
         .unwrap();
 
     let after = tn.contract_to_tensor().unwrap();
-    let diff = &before - &after;
+    let diff = before.distance(&after).unwrap();
     assert!(
-        diff.maxabs() < 1e-10,
+        diff < 1e-10,
         "contract_to_tensor must match before and after swap, diff={}",
-        diff.maxabs()
+        diff
     );
 }
 

--- a/crates/tensor4all-treetn/tests/unfuse.rs
+++ b/crates/tensor4all-treetn/tests/unfuse.rs
@@ -23,7 +23,7 @@ fn replace_site_index_with_indices_preserves_dense_tensor_values() {
     let expected =
         TensorDynLen::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0])
             .unwrap();
-    assert!((&dense - &expected).maxabs() < 1.0e-12);
+    assert!(dense.distance(&expected).unwrap() < 1.0e-12);
 
     let (site_indices, _) = unfused.all_site_indices().unwrap();
     let site_id_set: HashSet<_> = site_indices.iter().map(|idx| *idx.id()).collect();
@@ -62,7 +62,7 @@ fn split_to_preserves_sparse_tensor_with_zero_leading_qr_row() {
     let expected = tn.contract_to_tensor().unwrap();
 
     assert!(
-        dense.distance(&expected) < 1.0e-12,
+        dense.distance(&expected).unwrap() < 1.0e-12,
         "exact split_to must not drop rows when QR produces a zero leading row"
     );
 }

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -80,7 +80,8 @@ let zeros = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 let mut rng = ChaCha8Rng::seed_from_u64(42);
-let rand_t: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]);
+let rand_t: TensorDynLen =
+    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
 assert_eq!(rand_t.dims(), vec![2, 3]);
 ```
 
@@ -99,7 +100,7 @@ let out: Vec<f64> = t.to_vec().unwrap();
 assert_eq!(out, vec![10.0, 20.0]);
 
 // Sum all elements.
-let s = t.sum();
+let s = t.sum().unwrap();
 assert_eq!(s.real(), 30.0);
 ```
 
@@ -122,7 +123,7 @@ let k = Index::new_dyn(4);
 let a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 let b = TensorDynLen::zeros::<f64>(vec![j.clone(), k.clone()]).unwrap();
 
-let c = a.contract(&b);      // or equivalently: &a * &b
+let c = a.contract(&b).unwrap();      // or equivalently: &a * &b
 assert_eq!(c.dims(), vec![2, 4]);  // j is summed away
 ```
 
@@ -145,9 +146,12 @@ let mut rng = {
     use rand::SeedableRng;
     rand_chacha::ChaCha8Rng::seed_from_u64(0)
 };
-let a: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]);
-let b: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![j.clone(), k.clone()]);
-let c: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![k.clone(), l.clone()]);
+let a: TensorDynLen =
+    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
+let b: TensorDynLen =
+    TensorDynLen::random::<f64, _>(&mut rng, vec![j.clone(), k.clone()]).unwrap();
+let c: TensorDynLen =
+    TensorDynLen::random::<f64, _>(&mut rng, vec![k.clone(), l.clone()]).unwrap();
 
 // Contract A(i,j) * B(j,k) * C(k,l) -> result(i,l)
 let result = contract_multi(&[&a, &b, &c], AllowedPairs::All).unwrap();
@@ -184,7 +188,8 @@ let mut rng = {
     use rand::SeedableRng;
     rand_chacha::ChaCha8Rng::seed_from_u64(1)
 };
-let t: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]);
+let t: TensorDynLen =
+    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
 
 // SVD: split along i | j, discarding singular values below the chosen policy threshold.
 let opts = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1e-10));
@@ -215,7 +220,8 @@ let mut rng = {
     use rand::SeedableRng;
     rand_chacha::ChaCha8Rng::seed_from_u64(2)
 };
-let t: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]);
+let t: TensorDynLen =
+    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
 
 // QR: left factor is orthogonal (Q), right factor is upper-triangular (R).
 let opts = FactorizeOptions::qr();

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -250,7 +250,7 @@ let norm = tt.norm();
 assert!(norm.is_finite());
 
 // <tt|tt> = ||tt||^2
-let inner = tt.inner(&tt);
+let inner = tt.inner(&tt)?;
 assert!((inner.real() - norm * norm).abs() < 1e-10);
 # Ok(())
 # }
@@ -292,7 +292,7 @@ let norm = tt.norm();
 assert!(norm > 0.0);
 
 // For complex tensors, inner product uses complex conjugation on self
-let inner = tt.inner(&tt);
+let inner = tt.inner(&tt)?;
 assert!((inner.real() - norm * norm).abs() < 1e-10);
 # Ok(())
 # }

--- a/docs/book/src/guides/tree-tn.md
+++ b/docs/book/src/guides/tree-tn.md
@@ -182,7 +182,7 @@ let ttn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
 let sum = ttn.add(&ttn).unwrap();
 let dense = sum.to_dense().unwrap();
 let expected = TensorDynLen::from_dense(vec![s], vec![2.0, 4.0]).unwrap();
-assert!((&dense - &expected).maxabs() < 1e-12);
+assert!(dense.distance(&expected).unwrap() < 1e-12);
 ```
 
 After addition the bond dimensions grow, so it is common to follow up with `truncate` to keep them

--- a/docs/book/src/tutorials/computations-with-qtt/elementwise-product.md
+++ b/docs/book/src/tutorials/computations-with-qtt/elementwise-product.md
@@ -62,7 +62,7 @@ let product = partial_contract(
 )?;
 
 let shape = [site_indices_a.len(), 1];
-let site_values = ColMajorArrayRef::new(&[0usize, 1, 1], &shape);
+let site_values = ColMajorArrayRef::new(&[0usize, 1, 1], &shape)?;
 let value = product.evaluate_at(&site_indices_a, site_values)?;
 let x = (4.0 - 1.0) / npoints as f64;
 let expected = x.powi(2) * (10.0 * x).sin();

--- a/docs/plans/2026-04-22-issue-434-structured-tensor-plan.md
+++ b/docs/plans/2026-04-22-issue-434-structured-tensor-plan.md
@@ -712,7 +712,7 @@ fn structured_tensor_contract_materializes_to_correct_dense_result() {
     let result = diag.contract(&dense);
 
     let expected = TensorDynLen::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
-    assert!((&result - &expected).maxabs() < 1e-12);
+    assert!(result.distance(&expected).unwrap() < 1e-12);
 }
 ```
 

--- a/docs/plans/2026-04-25-compact-delta-copy-plan.md
+++ b/docs/plans/2026-04-25-compact-delta-copy-plan.md
@@ -176,7 +176,7 @@ fn naive_apply_noncontiguous_bonded_identity_uses_compact_bridge_delta() {
     let result = apply_linear_operator(&operator, &state, ApplyOptions::naive()).unwrap();
     let result_dense = result.to_dense().unwrap();
     let state_dense = state.to_dense().unwrap();
-    assert!((&result_dense - &state_dense).maxabs() < 1e-10);
+    assert!(result_dense.distance(&state_dense).unwrap() < 1e-10);
 }
 ```
 

--- a/docs/superpowers/plans/2026-04-25-fuse-to-internal-node-and-restructure-planner.md
+++ b/docs/superpowers/plans/2026-04-25-fuse-to-internal-node-and-restructure-planner.md
@@ -378,7 +378,7 @@ fn test_fuse_to_y_shape_internal_center_node() {
     let orig_full = tn.contract_to_tensor().unwrap();
     let fused_full = fused.contract_to_tensor().unwrap();
     assert!(
-        orig_full.distance(&fused_full) < 1e-12,
+        orig_full.distance(&fused_full).unwrap() < 1e-12,
         "fused Y-shape with internal center should match original contraction"
     );
 }
@@ -587,7 +587,7 @@ Add after the existing Y-shape tests:
         assert_eq!(result.node_count(), 2);
         let dense_expected = tn.contract_to_tensor()?;
         let dense_actual = result.contract_to_tensor()?;
-        assert!((&dense_actual - &dense_expected).maxabs() < 1e-12);
+        assert!(dense_actual.distance(&dense_expected).unwrap() < 1e-12);
         Ok(())
     }
 ```

--- a/docs/tutorial-code/src/qtt_affine_common.rs
+++ b/docs/tutorial-code/src/qtt_affine_common.rs
@@ -169,7 +169,7 @@ pub fn evaluate_tree_point(
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
     let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape);
+    let values = ColMajorArrayRef::new(site_values, &shape)?;
     let result = tn.evaluate_at(site_indices, values)?;
     let value = result
         .first()

--- a/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
+++ b/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
@@ -188,7 +188,7 @@ fn evaluate_tree_point(
     // Library call: evaluate the TreeTN at a specific set of site values.
     // We wrap it here so the sampling code stays simple.
     let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape);
+    let values = ColMajorArrayRef::new(site_values, &shape)?;
     let result = tn.evaluate_at(site_indices, values)?;
     let value = result
         .first()

--- a/docs/tutorial-code/src/qtt_fourier_common.rs
+++ b/docs/tutorial-code/src/qtt_fourier_common.rs
@@ -171,7 +171,7 @@ pub fn evaluate_tree_point(
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
     let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape);
+    let values = ColMajorArrayRef::new(site_values, &shape)?;
     let result = tn.evaluate_at(site_indices, values)?;
     let value = result
         .first()

--- a/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
+++ b/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
@@ -347,13 +347,13 @@ fn expand_operator_to_interleaved_state(
             let tensor = tensors_by_node
                 .get_mut(&start)
                 .ok_or_else(|| format!("missing tensor at expanded node {start}"))?;
-            *tensor = tensor.replaceind(bond, &left_bridge);
+            *tensor = tensor.replaceind(bond, &left_bridge)?;
         }
         {
             let tensor = tensors_by_node
                 .get_mut(&end)
                 .ok_or_else(|| format!("missing tensor at expanded node {end}"))?;
-            *tensor = tensor.replaceind(bond, &right_bridge);
+            *tensor = tensor.replaceind(bond, &right_bridge)?;
         }
         {
             let bridge = TensorDynLen::delta(&[left_bridge], &[right_bridge])?;
@@ -420,7 +420,7 @@ pub fn evaluate_tree_point(
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
     let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape);
+    let values = ColMajorArrayRef::new(site_values, &shape)?;
     let result = tn.evaluate_at(site_indices, values)?;
     let value = result
         .first()

--- a/scripts/audit-library-panics.py
+++ b/scripts/audit-library-panics.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Report panic-style calls in non-test library source files.
+
+This is an audit helper for issue #485. It intentionally reports only source
+lines that are likely to be runtime library code: rustdoc comments, line
+comments, files under src/**/tests, and cfg(test) modules are skipped.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+PATTERN = re.compile(r"\bpanic!\s*\(|\bunreachable!\s*\(|\.unwrap\(\)|\.expect\s*\(")
+
+
+def brace_delta(line: str) -> int:
+    """Best-effort brace balance for Rust blocks."""
+    return line.count("{") - line.count("}")
+
+
+def audit_file(path: Path) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+    pending_cfg_test = False
+    test_depth: int | None = None
+
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+
+        if test_depth is not None:
+            test_depth += brace_delta(line)
+            if test_depth <= 0:
+                test_depth = None
+            continue
+
+        if stripped.startswith("//"):
+            continue
+
+        if stripped.startswith("#[cfg(test)]"):
+            pending_cfg_test = True
+            continue
+
+        if pending_cfg_test:
+            if not stripped:
+                continue
+            if re.match(r"(pub\s+)?mod\s+\w+", stripped):
+                test_depth = max(brace_delta(line), 1)
+                pending_cfg_test = False
+                continue
+            pending_cfg_test = False
+
+        if PATTERN.search(line):
+            hits.append((lineno, stripped))
+
+    return hits
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    source_root = root / "crates"
+    hits: list[tuple[Path, int, str]] = []
+
+    for path in sorted(source_root.glob("*/src/**/*.rs")):
+        if "tests" in path.parts or path.name in {"tests.rs", "test_utils.rs"}:
+            continue
+        for lineno, line in audit_file(path):
+            hits.append((path.relative_to(root), lineno, line))
+
+    for path, lineno, line in hits:
+        print(f"{path}:{lineno}: {line}")
+
+    if hits:
+        print(f"\nFound {len(hits)} runtime panic-style hit(s).", file=sys.stderr)
+        return 1
+
+    print("No runtime panic-style hits found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #485.
Closes #498.

This PR converts remaining library-facing panic-style paths into explicit error returns across the tensor, tensorbackend, simplett, itensorlike, treetn, treetci, and related integration surfaces. It also updates downstream call sites, docs, examples, and tutorial snippets for the fallible APIs.

## Why

Library APIs should not abort user code on recoverable invalid input or backend failures. The previous implementation still had many `unwrap()`, `expect()`, and `panic!()` call sites in library code, which could turn shape, index, layout, or linear algebra failures into process panics.

## Notable Changes

- Replaced panic-style assumptions with `Result` propagation and typed/contextual errors.
- Added regression coverage for invalid indices, layout overflow, tensor construction, and itensorlike panic paths.
- Added `scripts/audit-library-panics.py` to audit runtime panic-style calls in library source.
- Fixed `TensorDynLen::conj()` so it preserves tracked AD payloads instead of dropping the graph.
- Updated rustdoc, mdBook, examples, benchmarks, and tests for fallible constructors and operations.

## Validation

- `python3 scripts/audit-library-panics.py`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --doc --release --workspace`
- `./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`
- `cargo nextest run --release --workspace` (`2122 passed`, `12 skipped`)
- `git diff --check`
