### PR TITLE
[codex] Batch tensor conversion and AD fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb", default-features = false }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "9aed3a85544c50c7f2d2cddaa81ffd1569c466cb", default-features = false }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "925e2511bc6bd019432f66596de39389dfced754", default-features = false }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "925e2511bc6bd019432f66596de39389dfced754" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "925e2511bc6bd019432f66596de39389dfced754", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "925e2511bc6bd019432f66596de39389dfced754", default-features = false }

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -32,6 +32,7 @@
 //! # }
 //! ```
 
+use crate::defaults::tensordynlen::unfold_split_inner;
 use crate::defaults::DynIndex;
 use crate::{unfold_split, TensorDynLen};
 use num_complex::{Complex64, ComplexFloat};
@@ -522,12 +523,13 @@ where
         + 'static,
     <T as ComplexFloat>::Real: Into<f64> + 'static,
 {
-    // Unfold tensor into matrix
-    let (a_tensor, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
+    // Unfold tensor into an eager matrix. Pivot selection is primal-only, but
+    // fixed-pivot CI factors are rebuilt from this eager value below.
+    let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))?;
 
     // Convert to Matrix type for MatrixLUCI
-    let a_matrix = native_tensor_to_matrix::<T>(&a_tensor, m, n)?;
+    let a_matrix = native_tensor_to_matrix::<T>(matrix_inner.data(), m, n)?;
 
     // Set up LU options for CI
     let left_orthogonal = canonical == Canonical::Left;
@@ -542,27 +544,65 @@ where
     let ci = MatrixLUCI::from_matrix(&a_matrix, Some(lu_options))?;
     let rank = ci.rank();
 
-    // Get left and right matrices from CI
-    let l_matrix = ci.left();
-    let r_matrix = ci.right();
+    let row_indices = ci.row_indices().to_vec();
+    let col_indices = ci.col_indices().to_vec();
+    let cols_inner = matrix_inner.take_cols(&col_indices).map_err(|e| {
+        FactorizeError::ComputationError(anyhow::anyhow!(
+            "fixed-pivot CI column gather failed: {e}"
+        ))
+    })?;
+    let rows_inner = matrix_inner.take_rows(&row_indices).map_err(|e| {
+        FactorizeError::ComputationError(anyhow::anyhow!("fixed-pivot CI row gather failed: {e}"))
+    })?;
+    let pivot_inner = matrix_inner
+        .take_block(&row_indices, &col_indices)
+        .map_err(|e| {
+            FactorizeError::ComputationError(anyhow::anyhow!(
+                "fixed-pivot CI pivot block gather failed: {e}"
+            ))
+        })?;
+    let (left_inner, right_inner) = match canonical {
+        Canonical::Left => {
+            let left = pivot_inner.right_solve(&cols_inner).map_err(|e| {
+                FactorizeError::ComputationError(anyhow::anyhow!(
+                    "fixed-pivot CI right solve failed: {e}"
+                ))
+            })?;
+            (left, rows_inner)
+        }
+        Canonical::Right => {
+            let right = pivot_inner.solve(&rows_inner).map_err(|e| {
+                FactorizeError::ComputationError(anyhow::anyhow!(
+                    "fixed-pivot CI solve failed: {e}"
+                ))
+            })?;
+            (cols_inner, right)
+        }
+    };
 
     // Create bond index
     let bond_index = DynIndex::new_bond(rank)
         .map_err(|e| anyhow::anyhow!("Failed to create bond index: {:?}", e))?;
 
-    // Convert L matrix back to tensor
-    let l_vec = matrix_to_vec(&l_matrix);
     let mut l_indices = left_indices.clone();
     l_indices.push(bond_index.clone());
-    let left =
-        TensorDynLen::from_dense(l_indices, l_vec).map_err(FactorizeError::ComputationError)?;
+    let l_dims: Vec<usize> = l_indices.iter().map(|idx| idx.dim).collect();
+    let left_inner = left_inner.reshape(&l_dims).map_err(|e| {
+        FactorizeError::ComputationError(anyhow::anyhow!("fixed-pivot CI left reshape failed: {e}"))
+    })?;
+    let left = TensorDynLen::from_inner(l_indices, left_inner)
+        .map_err(FactorizeError::ComputationError)?;
 
-    // Convert R matrix back to tensor
-    let r_vec = matrix_to_vec(&r_matrix);
     let mut r_indices = vec![bond_index.clone()];
     r_indices.extend_from_slice(&right_indices);
-    let right =
-        TensorDynLen::from_dense(r_indices, r_vec).map_err(FactorizeError::ComputationError)?;
+    let r_dims: Vec<usize> = r_indices.iter().map(|idx| idx.dim).collect();
+    let right_inner = right_inner.reshape(&r_dims).map_err(|e| {
+        FactorizeError::ComputationError(anyhow::anyhow!(
+            "fixed-pivot CI right reshape failed: {e}"
+        ))
+    })?;
+    let right = TensorDynLen::from_inner(r_indices, right_inner)
+        .map_err(FactorizeError::ComputationError)?;
 
     Ok(FactorizeResult {
         left,

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -2,15 +2,14 @@
 //!
 //! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
 
+use crate::defaults::tensordynlen::unfold_split_inner;
 use crate::defaults::DynIndex;
 use crate::global_default::GlobalDefault;
-use crate::{unfold_split, TensorDynLen};
+use crate::TensorDynLen;
 use num_complex::ComplexFloat;
 use tenferro::DType;
 use tensor4all_tensorbackend::{
-    dense_native_tensor_from_col_major, native_tensor_primal_to_dense_c64_col_major,
-    native_tensor_primal_to_dense_f64_col_major, qr_native_tensor, reshape_col_major_native_tensor,
-    TensorElement,
+    native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
 };
 use thiserror::Error;
 
@@ -151,28 +150,6 @@ where
     Ok(r.max(1))
 }
 
-fn truncate_matrix_cols<T: TensorElement>(
-    data: &[T],
-    rows: usize,
-    keep_cols: usize,
-) -> anyhow::Result<tenferro::Tensor> {
-    dense_native_tensor_from_col_major(&data[..rows * keep_cols], &[rows, keep_cols])
-}
-
-fn truncate_matrix_rows<T: TensorElement>(
-    data: &[T],
-    rows: usize,
-    cols: usize,
-    keep_rows: usize,
-) -> anyhow::Result<tenferro::Tensor> {
-    let mut truncated = Vec::with_capacity(keep_rows * cols);
-    for col in 0..cols {
-        let start = col * rows;
-        truncated.extend_from_slice(&data[start..start + keep_rows]);
-    }
-    dense_native_tensor_from_col_major(&truncated, &[keep_rows, cols])
-}
-
 /// Compute QR decomposition of a tensor with arbitrary rank, returning (Q, R).
 ///
 /// This function uses the global default rtol for truncation.
@@ -276,13 +253,14 @@ pub fn qr_with<T>(
     left_inds: &[DynIndex],
     options: &QrOptions,
 ) -> Result<(TensorDynLen, TensorDynLen), QrError> {
-    // Unfold tensor into a native rank-2 tensor.
-    let (matrix_native, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
+    // Unfold tensor into an eager rank-2 tensor so linalg AD nodes stay connected.
+    let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(QrError::ComputationError)?;
     let k = m.min(n);
-    let (mut q_native, mut r_native) =
-        qr_native_tensor(&matrix_native).map_err(QrError::ComputationError)?;
+    let (mut q_inner, mut r_inner) = matrix_inner
+        .qr()
+        .map_err(|e| QrError::ComputationError(anyhow::anyhow!("{e}")))?;
 
     let r = if options.truncate {
         // Determine rtol to use
@@ -291,14 +269,14 @@ pub fn qr_with<T>(
             return Err(QrError::InvalidRtol(rtol));
         }
 
-        match r_native.dtype() {
+        match r_inner.data().dtype() {
             DType::F64 => {
-                let values = native_tensor_primal_to_dense_f64_col_major(&r_native)
+                let values = native_tensor_primal_to_dense_f64_col_major(r_inner.data())
                     .map_err(QrError::ComputationError)?;
                 compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
             }
             DType::C64 => {
-                let values = native_tensor_primal_to_dense_c64_col_major(&r_native)
+                let values = native_tensor_primal_to_dense_c64_col_major(r_inner.data())
                     .map_err(QrError::ComputationError)?;
                 compute_retained_rank_qr_from_dense(&values, k, n, rtol)?
             }
@@ -312,33 +290,13 @@ pub fn qr_with<T>(
         k
     };
     if r < k {
-        match q_native.dtype() {
-            DType::F64 => {
-                let q_values = native_tensor_primal_to_dense_f64_col_major(&q_native)
-                    .map_err(QrError::ComputationError)?;
-                let r_values = native_tensor_primal_to_dense_f64_col_major(&r_native)
-                    .map_err(QrError::ComputationError)?;
-                q_native =
-                    truncate_matrix_cols(&q_values, m, r).map_err(QrError::ComputationError)?;
-                r_native =
-                    truncate_matrix_rows(&r_values, k, n, r).map_err(QrError::ComputationError)?;
-            }
-            DType::C64 => {
-                let q_values = native_tensor_primal_to_dense_c64_col_major(&q_native)
-                    .map_err(QrError::ComputationError)?;
-                let r_values = native_tensor_primal_to_dense_c64_col_major(&r_native)
-                    .map_err(QrError::ComputationError)?;
-                q_native =
-                    truncate_matrix_cols(&q_values, m, r).map_err(QrError::ComputationError)?;
-                r_native =
-                    truncate_matrix_rows(&r_values, k, n, r).map_err(QrError::ComputationError)?;
-            }
-            other => {
-                return Err(QrError::ComputationError(anyhow::anyhow!(
-                    "native QR returned unsupported scalar type {other:?}"
-                )));
-            }
-        }
+        let keep: Vec<usize> = (0..r).collect();
+        q_inner = q_inner
+            .take_axis(1, &keep)
+            .map_err(|e| QrError::ComputationError(anyhow::anyhow!("{e}")))?;
+        r_inner = r_inner
+            .take_axis(0, &keep)
+            .map_err(|e| QrError::ComputationError(anyhow::anyhow!("{e}")))?;
     }
 
     let bond_index = DynIndex::new_bond(r)
@@ -348,18 +306,18 @@ pub fn qr_with<T>(
     let mut q_indices = left_indices.clone();
     q_indices.push(bond_index.clone());
     let q_dims: Vec<usize> = q_indices.iter().map(|idx| idx.dim).collect();
-    let q_reshaped = reshape_col_major_native_tensor(&q_native, &q_dims).map_err(|e| {
-        QrError::ComputationError(anyhow::anyhow!("native QR Q reshape failed: {e}"))
+    let q_reshaped = q_inner.reshape(&q_dims).map_err(|e| {
+        QrError::ComputationError(anyhow::anyhow!("eager QR Q reshape failed: {e}"))
     })?;
-    let q = TensorDynLen::from_native(q_indices, q_reshaped).map_err(QrError::ComputationError)?;
+    let q = TensorDynLen::from_inner(q_indices, q_reshaped).map_err(QrError::ComputationError)?;
 
     let mut r_indices = vec![bond_index.clone()];
     r_indices.extend_from_slice(&right_indices);
     let r_dims: Vec<usize> = r_indices.iter().map(|idx| idx.dim).collect();
-    let r_reshaped = reshape_col_major_native_tensor(&r_native, &r_dims).map_err(|e| {
-        QrError::ComputationError(anyhow::anyhow!("native QR R reshape failed: {e}"))
+    let r_reshaped = r_inner.reshape(&r_dims).map_err(|e| {
+        QrError::ComputationError(anyhow::anyhow!("eager QR R reshape failed: {e}"))
     })?;
-    let r = TensorDynLen::from_native(r_indices, r_reshaped).map_err(QrError::ComputationError)?;
+    let r = TensorDynLen::from_inner(r_indices, r_reshaped).map_err(QrError::ComputationError)?;
 
     Ok((q, r))
 }

--- a/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::index::DefaultIndex as Index;
+use crate::unfold_split;
 use num_complex::Complex64;
 use tensor4all_tensorbackend::native_tensor_primal_to_dense_f64_col_major;
 

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -7,19 +7,18 @@
 //!
 //! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
 
+use crate::defaults::tensordynlen::unfold_split_inner;
 use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::truncation::{
     validate_svd_truncation_policy, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale,
     TruncationRule,
 };
-use crate::{unfold_split, TensorDynLen};
+use crate::TensorDynLen;
 use std::sync::Mutex;
-use tenferro::DType;
+use tenferro::{CpuBackend, DType, EagerTensor};
 use tensor4all_tensorbackend::{
-    dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
     native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
-    reshape_col_major_native_tensor, svd_native_tensor, TensorElement,
 };
 use thiserror::Error;
 
@@ -219,51 +218,30 @@ fn singular_values_from_native(tensor: &tenferro::Tensor) -> Result<Vec<f64>, Sv
     }
 }
 
-fn truncate_matrix_cols<T: TensorElement>(
-    data: &[T],
-    rows: usize,
-    keep_cols: usize,
-) -> anyhow::Result<tenferro::Tensor> {
-    dense_native_tensor_from_col_major(&data[..rows * keep_cols], &[rows, keep_cols])
-}
-
-fn truncate_matrix_rows<T: TensorElement>(
-    data: &[T],
-    rows: usize,
-    cols: usize,
-    keep_rows: usize,
-) -> anyhow::Result<tenferro::Tensor> {
-    let mut truncated = Vec::with_capacity(keep_rows * cols);
-    for col in 0..cols {
-        let start = col * rows;
-        truncated.extend_from_slice(&data[start..start + keep_rows]);
-    }
-    dense_native_tensor_from_col_major(&truncated, &[keep_rows, cols])
-}
-
-type SvdTruncatedNativeResult = (
-    tenferro::Tensor,
-    tenferro::Tensor,
-    tenferro::Tensor,
+type SvdTruncatedEagerResult = (
+    EagerTensor<CpuBackend>,
+    EagerTensor<CpuBackend>,
+    EagerTensor<CpuBackend>,
     Vec<f64>,
     DynIndex,
     Vec<DynIndex>,
     Vec<DynIndex>,
 );
 
-fn svd_truncated_native(
+fn svd_truncated_inner(
     t: &TensorDynLen,
     left_inds: &[DynIndex],
     options: &SvdOptions,
-) -> Result<SvdTruncatedNativeResult, SvdError> {
-    let (matrix_native, _, m, n, left_indices, right_indices) = unfold_split(t, left_inds)
+) -> Result<SvdTruncatedEagerResult, SvdError> {
+    let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
         .map_err(SvdError::ComputationError)?;
     let k = m.min(n);
 
-    let (mut u_native, mut s_native, mut vt_native) =
-        svd_native_tensor(&matrix_native).map_err(SvdError::ComputationError)?;
-    let s_full = singular_values_from_native(&s_native)?;
+    let (mut u_inner, mut s_inner, mut vt_inner) = matrix_inner
+        .svd()
+        .map_err(|e| SvdError::ComputationError(anyhow::anyhow!("{e}")))?;
+    let s_full = singular_values_from_native(s_inner.data())?;
     let mut r = if options.truncate {
         let policy = options.policy.unwrap_or_else(default_svd_truncation_policy);
         validate_svd_truncation_policy(policy).map_err(|e| SvdError::InvalidThreshold(e.0))?;
@@ -278,35 +256,16 @@ fn svd_truncated_native(
     };
     r = r.min(s_full.len());
     if r < k {
-        match u_native.dtype() {
-            DType::F64 => {
-                let u_values = native_tensor_primal_to_dense_f64_col_major(&u_native)
-                    .map_err(SvdError::ComputationError)?;
-                let vt_values = native_tensor_primal_to_dense_f64_col_major(&vt_native)
-                    .map_err(SvdError::ComputationError)?;
-                u_native =
-                    truncate_matrix_cols(&u_values, m, r).map_err(SvdError::ComputationError)?;
-                vt_native = truncate_matrix_rows(&vt_values, k, n, r)
-                    .map_err(SvdError::ComputationError)?;
-            }
-            DType::C64 => {
-                let u_values = native_tensor_primal_to_dense_c64_col_major(&u_native)
-                    .map_err(SvdError::ComputationError)?;
-                let vt_values = native_tensor_primal_to_dense_c64_col_major(&vt_native)
-                    .map_err(SvdError::ComputationError)?;
-                u_native =
-                    truncate_matrix_cols(&u_values, m, r).map_err(SvdError::ComputationError)?;
-                vt_native = truncate_matrix_rows(&vt_values, k, n, r)
-                    .map_err(SvdError::ComputationError)?;
-            }
-            other => {
-                return Err(SvdError::ComputationError(anyhow::anyhow!(
-                    "native SVD returned unsupported singular-vector scalar type {other:?}"
-                )));
-            }
-        }
-        s_native = dense_native_tensor_from_col_major(&s_full[..r], &[r])
-            .map_err(SvdError::ComputationError)?;
+        let keep: Vec<usize> = (0..r).collect();
+        u_inner = u_inner
+            .take_axis(1, &keep)
+            .map_err(|e| SvdError::ComputationError(anyhow::anyhow!("{e}")))?;
+        s_inner = s_inner
+            .take_axis(0, &keep)
+            .map_err(|e| SvdError::ComputationError(anyhow::anyhow!("{e}")))?;
+        vt_inner = vt_inner
+            .take_axis(0, &keep)
+            .map_err(|e| SvdError::ComputationError(anyhow::anyhow!("{e}")))?;
     }
 
     let bond_index = DynIndex::new_bond(r)
@@ -315,9 +274,9 @@ fn svd_truncated_native(
     let singular_values = s_full[..r].to_vec();
 
     Ok((
-        u_native,
-        s_native,
-        vt_native,
+        u_inner,
+        s_inner,
+        vt_inner,
         singular_values,
         bond_index,
         left_indices,
@@ -389,30 +348,29 @@ pub fn svd_with<T>(
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<(TensorDynLen, TensorDynLen, TensorDynLen), SvdError> {
-    let (u_native, s_native, vt_native, _singular_values, bond_index, left_indices, right_indices) =
-        svd_truncated_native(t, left_inds, options)?;
+    let (u_inner, s_inner, vt_inner, _singular_values, bond_index, left_indices, right_indices) =
+        svd_truncated_inner(t, left_inds, options)?;
 
     let mut u_indices = left_indices;
     u_indices.push(bond_index.clone());
     let u_dims: Vec<usize> = u_indices.iter().map(|idx| idx.dim).collect();
-    let u_reshaped = reshape_col_major_native_tensor(&u_native, &u_dims).map_err(|e| {
-        SvdError::ComputationError(anyhow::anyhow!("native SVD U reshape failed: {e}"))
+    let u_reshaped = u_inner.reshape(&u_dims).map_err(|e| {
+        SvdError::ComputationError(anyhow::anyhow!("eager SVD U reshape failed: {e}"))
     })?;
-    let u = TensorDynLen::from_native(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
+    let u = TensorDynLen::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
 
     let s_indices = vec![bond_index.clone(), bond_index.sim()];
-    let s_diag = diag_native_tensor_from_col_major(&singular_values_from_native(&s_native)?, 2)
-        .map_err(SvdError::ComputationError)?;
-    let s = TensorDynLen::from_native(s_indices, s_diag).map_err(SvdError::ComputationError)?;
+    let s =
+        TensorDynLen::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
 
     let mut vh_indices = vec![bond_index.clone()];
     vh_indices.extend(right_indices);
     let vh_dims: Vec<usize> = vh_indices.iter().map(|idx| idx.dim).collect();
-    let vt_reshaped = reshape_col_major_native_tensor(&vt_native, &vh_dims).map_err(|e| {
-        SvdError::ComputationError(anyhow::anyhow!("native SVD V^T reshape failed: {e}"))
+    let vt_reshaped = vt_inner.reshape(&vh_dims).map_err(|e| {
+        SvdError::ComputationError(anyhow::anyhow!("eager SVD V^T reshape failed: {e}"))
     })?;
     let vh =
-        TensorDynLen::from_native(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
+        TensorDynLen::from_inner(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
     let perm: Vec<usize> = (1..vh.indices.len()).chain(std::iter::once(0)).collect();
     let v = vh
         .conj()
@@ -438,31 +396,30 @@ pub(crate) fn svd_for_factorize(
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<SvdFactorizeResult, SvdError> {
-    let (u_native, s_native, vt_native, singular_values, bond_index, left_indices, right_indices) =
-        svd_truncated_native(t, left_inds, options)?;
+    let (u_inner, s_inner, vt_inner, singular_values, bond_index, left_indices, right_indices) =
+        svd_truncated_inner(t, left_inds, options)?;
     let rank = singular_values.len();
 
     let mut u_indices = left_indices;
     u_indices.push(bond_index.clone());
     let u_dims: Vec<usize> = u_indices.iter().map(|idx| idx.dim).collect();
-    let u_reshaped = reshape_col_major_native_tensor(&u_native, &u_dims).map_err(|e| {
-        SvdError::ComputationError(anyhow::anyhow!("native SVD U reshape failed: {e}"))
+    let u_reshaped = u_inner.reshape(&u_dims).map_err(|e| {
+        SvdError::ComputationError(anyhow::anyhow!("eager SVD U reshape failed: {e}"))
     })?;
-    let u = TensorDynLen::from_native(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
+    let u = TensorDynLen::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
 
     let s_indices = vec![bond_index.clone(), bond_index.sim()];
-    let s_diag = diag_native_tensor_from_col_major(&singular_values_from_native(&s_native)?, 2)
-        .map_err(SvdError::ComputationError)?;
-    let s = TensorDynLen::from_native(s_indices, s_diag).map_err(SvdError::ComputationError)?;
+    let s =
+        TensorDynLen::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
 
     let mut vh_indices = vec![bond_index.clone()];
     vh_indices.extend(right_indices);
     let vh_dims: Vec<usize> = vh_indices.iter().map(|idx| idx.dim).collect();
-    let vt_reshaped = reshape_col_major_native_tensor(&vt_native, &vh_dims).map_err(|e| {
-        SvdError::ComputationError(anyhow::anyhow!("native SVD V^T reshape failed: {e}"))
+    let vt_reshaped = vt_inner.reshape(&vh_dims).map_err(|e| {
+        SvdError::ComputationError(anyhow::anyhow!("eager SVD V^T reshape failed: {e}"))
     })?;
     let vh =
-        TensorDynLen::from_native(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
+        TensorDynLen::from_inner(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
 
     Ok(SvdFactorizeResult {
         u,

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -16,9 +16,8 @@ use tensor4all_tensorbackend::{
     axpby_native_tensor, contract_native_tensor, default_eager_ctx,
     dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
     native_tensor_primal_to_dense_col_major, native_tensor_primal_to_diag_c64,
-    native_tensor_primal_to_diag_f64, native_tensor_primal_to_storage,
-    reshape_col_major_native_tensor, scale_native_tensor, storage_to_native_tensor, StorageScalar,
-    TensorElement,
+    native_tensor_primal_to_diag_f64, native_tensor_primal_to_storage, scale_native_tensor,
+    storage_to_native_tensor, StorageScalar, TensorElement,
 };
 use tensor4all_tensorbackend::{Storage, StorageKind};
 
@@ -1534,6 +1533,19 @@ impl TensorDynLen {
         Self::from_inner_with_axis_classes(indices, inner, axis_classes)
     }
 
+    pub(crate) fn from_diag_inner(
+        indices: Vec<DynIndex>,
+        payload_inner: EagerTensor<CpuBackend>,
+    ) -> Result<Self> {
+        let dims = Self::expected_dims_from_indices(&indices);
+        Self::validate_indices(&indices)?;
+        Self::validate_diag_dims(&dims)?;
+        Self::validate_diag_payload_len(payload_inner.data().shape().iter().product(), &dims)?;
+        let axis_classes = Self::diag_axis_classes(dims.len());
+        let diag_inner = payload_inner.embed_diag(0, 1)?;
+        Self::from_inner_with_axis_classes(indices, diag_inner, axis_classes)
+    }
+
     pub(crate) fn from_inner_with_axis_classes(
         indices: Vec<DynIndex>,
         inner: EagerTensor<CpuBackend>,
@@ -2897,6 +2909,16 @@ pub fn diag_tensor_dyn_len(indices: Vec<DynIndex>, diag_data: Vec<f64>) -> Resul
     TensorDynLen::from_diag(indices, diag_data)
 }
 
+#[allow(clippy::type_complexity)]
+pub(crate) type UnfoldSplitInnerResult = (
+    EagerTensor<CpuBackend>,
+    usize,
+    usize,
+    usize,
+    Vec<DynIndex>,
+    Vec<DynIndex>,
+);
+
 /// Unfold a tensor into a matrix by splitting indices into left and right groups.
 ///
 /// This function validates the split, permutes the tensor so that left indices
@@ -2955,6 +2977,23 @@ pub fn unfold_split(
     Vec<DynIndex>,
     Vec<DynIndex>,
 )> {
+    let (matrix_inner, left_len, m, n, left_indices, right_indices) =
+        unfold_split_inner(t, left_inds)?;
+
+    Ok((
+        matrix_inner.data().clone(),
+        left_len,
+        m,
+        n,
+        left_indices,
+        right_indices,
+    ))
+}
+
+pub(crate) fn unfold_split_inner(
+    t: &TensorDynLen,
+    left_inds: &[DynIndex],
+) -> Result<UnfoldSplitInnerResult> {
     let rank = t.indices.len();
 
     // Validate rank
@@ -3003,7 +3042,7 @@ pub fn unfold_split(
     let m: usize = unfolded_dims[..left_len].iter().product();
     let n: usize = unfolded_dims[left_len..].iter().product();
 
-    let matrix_tensor = reshape_col_major_native_tensor(unfolded.as_native()?, &[m, n])?;
+    let matrix_tensor = unfolded.try_materialized_inner()?.reshape(&[m, n])?;
 
     Ok((
         matrix_tensor,

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -131,7 +131,7 @@ pub(crate) struct StructuredAdValue {
 /// | Operation | Method |
 /// |-----------|--------|
 /// | Create from data | [`from_dense`](Self::from_dense), [`from_diag`](Self::from_diag), [`zeros`](Self::zeros) |
-/// | Extract data | [`to_vec`](Self::to_vec), [`sum`](Self::sum), [`only`](Self::only) |
+/// | Extract data | [`to_vec`](Self::to_vec), [`into_dense_col_major_parts`](Self::into_dense_col_major_parts), [`sum`](Self::sum), [`only`](Self::only) |
 /// | Contraction | [`contract`](Self::contract) |
 /// | Arithmetic | [`add`](Self::add), [`scale`](Self::scale), [`axpby`](Self::axpby) |
 /// | Factorization | via [`TensorLike::factorize`] |
@@ -3741,6 +3741,50 @@ impl TensorDynLen {
     /// ```
     pub fn to_vec<T: TensorElement>(&self) -> Result<Vec<T>> {
         native_tensor_primal_to_dense_col_major(self.as_native()?)
+    }
+
+    /// Consume the tensor and return its indices with dense column-major values.
+    ///
+    /// Use this when a caller needs to move index metadata and dense payload
+    /// values across an API boundary. The returned values are ordered with the
+    /// first tensor index varying fastest. Compact diagonal or structured
+    /// storage is materialized into dense logical values.
+    ///
+    /// # Type Parameters
+    /// * `T` - The scalar element type to extract. Use `f64` for real tensors
+    ///   and `Complex64` for complex tensors.
+    ///
+    /// # Returns
+    /// The tensor's original indices and dense column-major flat data.
+    ///
+    /// # Errors
+    /// Returns an error if the tensor has tracked autodiff state, if the
+    /// requested scalar type does not match the tensor payload, or if dense
+    /// materialization fails.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    ///
+    /// let i = DynIndex::new_dyn(2);
+    /// let j = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(
+    ///     vec![i.clone(), j.clone()],
+    ///     vec![1.0_f64, 2.0, 3.0, 4.0],
+    /// ).unwrap();
+    ///
+    /// let (indices, data) = tensor.into_dense_col_major_parts::<f64>().unwrap();
+    ///
+    /// assert_eq!(indices, vec![i, j]);
+    /// assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
+    /// ```
+    pub fn into_dense_col_major_parts<T: TensorElement>(self) -> Result<(Vec<DynIndex>, Vec<T>)> {
+        anyhow::ensure!(
+            self.structured_ad.is_none() && !self.tracks_grad(),
+            "TensorDynLen::into_dense_col_major_parts cannot consume tensors with tracked autodiff state"
+        );
+        let data = self.to_vec::<T>()?;
+        Ok((self.indices, data))
     }
 
     fn to_vec_any(&self) -> Result<Vec<AnyScalar>> {

--- a/crates/tensor4all-core/tests/ad_integration.rs
+++ b/crates/tensor4all-core/tests/ad_integration.rs
@@ -1,4 +1,32 @@
-use tensor4all_core::{Index, TensorDynLen};
+use tensor4all_core::{factorize_full_rank, svd, Canonical, FactorizeAlg, Index, TensorDynLen};
+
+fn assert_f64_slice_close(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= tol,
+            "entry {idx}: expected {expected}, got {actual}"
+        );
+    }
+}
+
+fn finite_diff_svd_singular_value_sum(data: &[f64], index: usize) -> f64 {
+    const STEP: f64 = 1.0e-6;
+
+    fn eval(data: &[f64]) -> f64 {
+        let i = Index::new_dyn(2);
+        let j = Index::new_dyn(2);
+        let tensor = TensorDynLen::from_dense(vec![i.clone(), j], data.to_vec()).unwrap();
+        let (_u, s, _v) = svd::<f64>(&tensor, &[i]).unwrap();
+        s.sum().unwrap().real()
+    }
+
+    let mut plus = data.to_vec();
+    let mut minus = data.to_vec();
+    plus[index] += STEP;
+    minus[index] -= STEP;
+    (eval(&plus) - eval(&minus)) / (2.0 * STEP)
+}
 
 #[test]
 fn tensor_sum_returns_rank_zero_anyscalar_with_backward() {
@@ -27,4 +55,80 @@ fn tensor_only_preserves_tracking_for_scalar_tensor() {
 
     let grad = x.grad().unwrap().unwrap();
     assert!((grad.only().unwrap().real() - 4.0).abs() < 1e-12);
+}
+
+#[test]
+fn factorize_qr_reconstruction_preserves_gradient_to_input() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let x = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64, 0.5, 1.0, 3.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+
+    let result = factorize_full_rank(
+        &x,
+        std::slice::from_ref(&i),
+        FactorizeAlg::QR,
+        Canonical::Left,
+    )
+    .unwrap();
+    let reconstructed = result.left.contract(&result.right).unwrap();
+    let loss = reconstructed.sum().unwrap();
+    assert!(loss.tracks_grad());
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert_f64_slice_close(&grad.to_vec::<f64>().unwrap(), &[1.0, 1.0, 1.0, 1.0], 1e-8);
+}
+
+fn assert_ci_reconstruction_gradient(canonical: Canonical) {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let x = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64, 0.5, 1.0, 3.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+
+    let result =
+        factorize_full_rank(&x, std::slice::from_ref(&i), FactorizeAlg::CI, canonical).unwrap();
+    let reconstructed = result.left.contract(&result.right).unwrap();
+    let loss = reconstructed.sum().unwrap();
+    assert!(loss.tracks_grad());
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    assert_f64_slice_close(&grad.to_vec::<f64>().unwrap(), &[1.0, 1.0, 1.0, 1.0], 1e-8);
+}
+
+#[test]
+fn factorize_ci_left_reconstruction_preserves_gradient_to_input() {
+    assert_ci_reconstruction_gradient(Canonical::Left);
+}
+
+#[test]
+fn factorize_ci_right_reconstruction_preserves_gradient_to_input() {
+    assert_ci_reconstruction_gradient(Canonical::Right);
+}
+
+#[test]
+fn svd_singular_value_loss_preserves_gradient_to_input() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let data = vec![2.0_f64, 0.5, 1.0, 3.0];
+    let x = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone())
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+
+    let (_u, s, _v) = svd::<f64>(&x, std::slice::from_ref(&i)).unwrap();
+    let loss = s.sum().unwrap();
+    assert!(loss.tracks_grad());
+    loss.backward().unwrap();
+
+    let grad = x.grad().unwrap().unwrap();
+    let expected: Vec<f64> = (0..data.len())
+        .map(|index| finite_diff_svd_singular_value_sum(&data, index))
+        .collect();
+    assert_f64_slice_close(&grad.to_vec::<f64>().unwrap(), &expected, 1e-5);
 }

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -343,8 +343,9 @@ fn test_diag_dense_contraction_svd_internals() {
 
     let (u, s, v) = svd::<f64>(&tensor, std::slice::from_ref(&i)).expect("SVD should succeed");
 
-    // The public bridge materializes diagonal payloads densely at the native layer.
-    assert!(!s.is_diag());
+    // SVD represents singular values as a compact diagonal tensor while keeping
+    // an eager diagonal embedding available for AD-preserving contractions.
+    assert!(s.is_diag());
     assert_eq!(s.dims().len(), 2);
     assert_eq!(s.dims()[0], s.dims()[1]);
 

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -792,6 +792,44 @@ fn test_from_dense_c64() {
     assert_eq!(tensor.to_vec::<Complex64>().unwrap(), data);
 }
 
+#[test]
+fn test_into_dense_col_major_parts_returns_indices_and_values() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(3);
+    let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
+
+    let (indices, values) = tensor.into_dense_col_major_parts::<f64>().unwrap();
+
+    assert_eq!(indices, vec![i, j]);
+    assert_eq!(values, data);
+}
+
+#[test]
+fn test_into_dense_col_major_parts_materializes_diag_storage() {
+    let i = Index::new_dyn(2);
+    let j = Index::new_dyn(2);
+    let tensor = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0]).unwrap();
+
+    let (indices, values) = tensor.into_dense_col_major_parts::<f64>().unwrap();
+
+    assert_eq!(indices, vec![i, j]);
+    assert_eq!(values, vec![1.0, 0.0, 0.0, 2.0]);
+}
+
+#[test]
+fn test_into_dense_col_major_parts_rejects_ad_tracked_tensor() {
+    let i = Index::new_dyn(2);
+    let tensor = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+
+    let err = tensor.into_dense_col_major_parts::<f64>().unwrap_err();
+
+    assert!(err.to_string().contains("tracked autodiff"));
+}
+
 fn assert_dense_constructor_dims<T>(data: Vec<T>)
 where
     T: TensorElement,

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, ensure, Result};
 use num_complex::{Complex32, Complex64};
-use tenferro::eager_einsum::eager_einsum_owned;
+use tenferro::eager_einsum::{eager_einsum, eager_einsum_owned};
 use tenferro::{DType, Tensor as NativeTensor, TensorBackend};
 
 use crate::any_scalar::promote_scalar_native;
@@ -24,7 +24,8 @@ use std::cell::Cell;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 enum NativeEinsumPath {
-    FrontendFallback,
+    Borrowed,
+    BorrowedWithConversions,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -709,20 +710,90 @@ pub fn einsum_native_tensors_owned(
     Ok(result)
 }
 
-/// Execute an eager einsum over native tensors.
+/// Execute an eager einsum over borrowed native tensors.
+///
+/// Inputs are promoted to a common dtype before contraction. Operands that
+/// already have the target dtype are passed to the backend by reference;
+/// operands with another dtype are converted into temporary native tensors and
+/// then borrowed for the contraction.
+///
+/// # Arguments
+/// * `operands` - Native tensors paired with numeric einsum labels for each axis.
+///   Each label slice must have the same length as the corresponding tensor rank.
+/// * `output_ids` - Numeric labels to keep in the result, in output axis order.
+///
+/// # Returns
+/// The contracted native tensor in the promoted common dtype.
+///
+/// # Errors
+/// Returns an error if the operand list is empty, any label list length does
+/// not match its tensor rank, label generation exceeds the supported range,
+/// dtype conversion fails, or the backend contraction fails.
+///
+/// # Examples
+/// ```
+/// use tensor4all_tensorbackend::einsum_native_tensors;
+/// use tenferro::Tensor as NativeTensor;
+///
+/// let lhs = NativeTensor::from_vec(vec![2, 3], vec![1.0_f64; 6]);
+/// let rhs = NativeTensor::from_vec(vec![3, 2], vec![1.0_f64; 6]);
+/// let result = einsum_native_tensors(&[(&lhs, &[0, 1]), (&rhs, &[1, 2])], &[0, 2]).unwrap();
+///
+/// assert_eq!(result.shape(), &[2, 2]);
+/// assert_eq!(result.as_slice::<f64>().unwrap(), &[3.0, 3.0, 3.0, 3.0]);
+/// ```
 pub fn einsum_native_tensors(
     operands: &[(&NativeTensor, &[usize])],
     output_ids: &[usize],
 ) -> Result<NativeTensor> {
-    let owned_operands = operands
-        .iter()
-        .map(|(tensor, ids)| ((*tensor).clone(), ids.to_vec()))
-        .collect::<Vec<_>>();
-    let output_ids_u32 = output_ids.iter().map(|&id| id as u32).collect::<Vec<_>>();
+    ensure!(
+        !operands.is_empty(),
+        "native einsum requires at least one operand"
+    );
+
+    let target = common_dtype(
+        &operands
+            .iter()
+            .map(|(tensor, _)| tensor.dtype())
+            .collect::<Vec<_>>(),
+    );
+    let mut converted = Vec::with_capacity(operands.len());
+    let mut input_ids = Vec::with_capacity(operands.len());
+    let mut has_conversions = false;
     let started = Instant::now();
-    let result = einsum_native_tensors_owned(owned_operands, output_ids)?;
+
+    for (tensor, ids) in operands {
+        ensure!(
+            tensor.shape().len() == ids.len(),
+            "einsum id list {:?} does not match tensor shape {:?}",
+            ids,
+            tensor.shape()
+        );
+        input_ids.push(ids.iter().map(|&id| id as u32).collect::<Vec<_>>());
+        if tensor.dtype() == target {
+            converted.push(None);
+        } else {
+            converted.push(Some(convert_tensor(tensor, target)?));
+            has_conversions = true;
+        }
+    }
+
+    let input_slices = input_ids.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let output_ids_u32 = output_ids.iter().map(|&id| id as u32).collect::<Vec<_>>();
+    let subscripts = build_einsum_subscripts(&input_slices, &output_ids_u32)?;
+    let input_refs = operands
+        .iter()
+        .zip(converted.iter())
+        .map(|((tensor, _), converted)| converted.as_ref().unwrap_or(*tensor))
+        .collect::<Vec<_>>();
+    let result = with_default_backend(|backend| eager_einsum(backend, &input_refs, &subscripts))
+        .map_err(|e| anyhow!("native einsum failed: {e}"))?;
     record_native_einsum_profile(
-        NativeEinsumPath::FrontendFallback,
+        if has_conversions {
+            NativeEinsumPath::BorrowedWithConversions
+        } else {
+            NativeEinsumPath::Borrowed
+        },
         operands,
         &output_ids_u32,
         started.elapsed(),

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -36,6 +36,23 @@ fn recorded_native_einsum_call_count(path: NativeEinsumPath) -> usize {
     })
 }
 
+struct ProfileGuard;
+
+impl ProfileGuard {
+    fn enable() -> Self {
+        reset_native_einsum_profile();
+        set_native_einsum_profile_enabled_for_tests(true);
+        Self
+    }
+}
+
+impl Drop for ProfileGuard {
+    fn drop(&mut self) {
+        set_native_einsum_profile_enabled_for_tests(false);
+        reset_native_einsum_profile();
+    }
+}
+
 #[test]
 fn storage_native_roundtrip_dense_f64() {
     let storage = Storage::from_dense_col_major(vec![1.0, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
@@ -265,7 +282,8 @@ fn einsum_native_tensors_supports_retained_shared_nary_label() {
 }
 
 #[test]
-fn einsum_native_tensors_owned_matches_borrowed_and_promotes_dtype() {
+fn einsum_native_tensors_mixed_dtype_records_borrowed_conversion_profile() {
+    let _guard = ProfileGuard::enable();
     let lhs = NativeTensor::from_vec(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]);
     let rhs = NativeTensor::from_vec(vec![2, 3], vec![5.0_f64, 6.0, 7.0, 8.0, 9.0, 10.0]);
 
@@ -282,33 +300,39 @@ fn einsum_native_tensors_owned_matches_borrowed_and_promotes_dtype() {
         native_tensor_primal_to_dense_f64_col_major(&owned).unwrap(),
         native_tensor_primal_to_dense_f64_col_major(&borrowed).unwrap()
     );
+    assert_eq!(
+        recorded_native_einsum_call_count(NativeEinsumPath::BorrowedWithConversions),
+        1
+    );
+    assert_eq!(
+        recorded_native_einsum_call_count(NativeEinsumPath::Borrowed),
+        0
+    );
 }
 
 #[test]
-fn einsum_native_tensors_dense_binary_records_frontend_fallback_profile() {
-    struct ProfileGuard;
-
-    impl Drop for ProfileGuard {
-        fn drop(&mut self) {
-            set_native_einsum_profile_enabled_for_tests(false);
-            reset_native_einsum_profile();
-        }
-    }
-
-    reset_native_einsum_profile();
-    set_native_einsum_profile_enabled_for_tests(true);
-    let _guard = ProfileGuard;
+fn einsum_native_tensors_dense_binary_records_borrowed_profile() {
+    let _guard = ProfileGuard::enable();
 
     let lhs = dense_native_tensor_from_col_major(&[1.0_f64, 3.0, 2.0, 4.0], &[2, 2]).unwrap();
     let rhs =
         dense_native_tensor_from_col_major(&[10.0_f64, 30.0, 50.0, 20.0, 40.0, 60.0], &[3, 2])
             .unwrap();
     let out = einsum_native_tensors(&[(&lhs, &[0, 1]), (&rhs, &[2, 1])], &[0, 2]).unwrap();
+    let snapshot = native_tensor_primal_to_storage(&out).unwrap();
+    let expected =
+        Storage::from_dense_col_major(vec![50.0, 110.0, 110.0, 250.0, 170.0, 390.0], &[2, 3])
+            .unwrap();
 
     assert_eq!(out.shape(), &[2, 3]);
+    assert_storage_eq(&snapshot, &expected);
     assert_eq!(
-        recorded_native_einsum_call_count(NativeEinsumPath::FrontendFallback),
+        recorded_native_einsum_call_count(NativeEinsumPath::Borrowed),
         1
+    );
+    assert_eq!(
+        recorded_native_einsum_call_count(NativeEinsumPath::BorrowedWithConversions),
+        0
     );
 }
 

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -49,7 +49,7 @@ pub use options::{CanonicalizationOptions, RestructureOptions, SplitOptions, Tru
 pub use random::{random_treetn, LinkSpace};
 pub use simplett_bridge::{
     tensor_train_to_treetn, tensor_train_to_treetn_with_names,
-    tensor_train_to_treetn_with_names_and_site_indices,
+    tensor_train_to_treetn_with_names_and_site_indices, treetn_to_tensor_train,
 };
 pub use site_index_network::SiteIndexNetwork;
 pub use treetn::{

--- a/crates/tensor4all-treetn/src/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/src/simplett_bridge.rs
@@ -1,6 +1,8 @@
 use anyhow::{ensure, Result};
 use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorElement};
-use tensor4all_simplett::{AbstractTensorTrain, TTScalar, Tensor3Ops, TensorTrain};
+use tensor4all_simplett::{
+    tensor3_from_data, AbstractTensorTrain, TTScalar, Tensor3Ops, TensorTrain,
+};
 
 use crate::TreeTN;
 
@@ -109,6 +111,150 @@ where
     Ok(treetn)
 }
 
+/// Convert a linear-chain `TreeTN<TensorDynLen, usize>` back into a simple tensor train.
+///
+/// The TreeTN must use node names `0..n-1`, contain exactly one site index per
+/// node, and have edges only between adjacent node names. This is the inverse of
+/// [`tensor_train_to_treetn`] for linear-chain TreeTNs.
+///
+/// # Arguments
+/// * `treetn` - A consumed linear-chain tree tensor network whose node names
+///   identify tensor-train site positions. Each node must contain one site
+///   index and zero, one, or two adjacent bond indices.
+///
+/// # Returns
+/// A simple [`TensorTrain`] with one core per TreeTN node. Site and bond index
+/// identities are used only to validate and order local axes; `TensorTrain`
+/// cores do not retain index metadata.
+///
+/// # Errors
+/// Returns an error if node names are not `0..n-1`, the topology is not a
+/// nearest-neighbor chain, a node has the wrong site/bond indices, a site
+/// tensor tracks autodiff state, scalar extraction fails, or a resulting core
+/// has invalid dimensions.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
+/// use tensor4all_treetn::{tensor_train_to_treetn, treetn_to_tensor_train};
+///
+/// let tt = TensorTrain::new(vec![
+///     tensor3_from_data(vec![1.0_f64, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
+///     tensor3_from_data(vec![0.5, 1.5, -1.0, 2.0], 2, 2, 1).unwrap(),
+/// ]).unwrap();
+///
+/// let (tree, _) = tensor_train_to_treetn(&tt).unwrap();
+/// let roundtrip = treetn_to_tensor_train::<f64>(tree).unwrap();
+///
+/// assert_eq!(roundtrip.site_dims(), tt.site_dims());
+/// assert_eq!(roundtrip.link_dims(), tt.link_dims());
+/// assert_eq!(roundtrip.fulltensor(), tt.fulltensor());
+/// ```
+pub fn treetn_to_tensor_train<T>(mut treetn: TreeTN<TensorDynLen, usize>) -> Result<TensorTrain<T>>
+where
+    T: TTScalar + TensorElement + Clone,
+{
+    let nsites = treetn.node_count();
+    if nsites == 0 {
+        return Ok(TensorTrain::new(Vec::new())?);
+    }
+
+    let mut node_names = treetn.node_names();
+    node_names.sort_unstable();
+    let expected_names: Vec<_> = (0..nsites).collect();
+    ensure!(
+        node_names == expected_names,
+        "treetn_to_tensor_train: expected node names 0..{}, got {:?}",
+        nsites,
+        node_names
+    );
+    ensure!(
+        treetn.edge_count() == nsites - 1,
+        "treetn_to_tensor_train: expected a chain with {} edges, got {}",
+        nsites - 1,
+        treetn.edge_count()
+    );
+
+    let mut site_metadata = Vec::with_capacity(nsites);
+    for site in 0..nsites {
+        let site_space = treetn.site_space(&site).ok_or_else(|| {
+            anyhow::anyhow!("treetn_to_tensor_train: missing site space at node {site}")
+        })?;
+        ensure!(
+            site_space.len() == 1,
+            "treetn_to_tensor_train: node {site} must have exactly one site index, got {}",
+            site_space.len()
+        );
+        let site_index = site_space.iter().next().ok_or_else(|| {
+            anyhow::anyhow!("treetn_to_tensor_train: node {site} has no site index")
+        })?;
+
+        let left_bond = if site == 0 {
+            None
+        } else {
+            let edge = treetn.edge_between(&(site - 1), &site).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "treetn_to_tensor_train: missing chain edge between nodes {} and {}",
+                    site - 1,
+                    site
+                )
+            })?;
+            Some(
+                treetn
+                    .bond_index(edge)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("treetn_to_tensor_train: missing left bond at node {site}")
+                    })?
+                    .clone(),
+            )
+        };
+
+        let right_bond = if site + 1 == nsites {
+            None
+        } else {
+            let edge = treetn.edge_between(&site, &(site + 1)).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "treetn_to_tensor_train: missing chain edge between nodes {} and {}",
+                    site,
+                    site + 1
+                )
+            })?;
+            Some(
+                treetn
+                    .bond_index(edge)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("treetn_to_tensor_train: missing right bond at node {site}")
+                    })?
+                    .clone(),
+            )
+        };
+
+        site_metadata.push(ChainSiteMetadata {
+            site_index: site_index.clone(),
+            left_bond,
+            right_bond,
+        });
+    }
+
+    let mut tensors = Vec::with_capacity(nsites);
+    for (site, metadata) in site_metadata.into_iter().enumerate() {
+        let tensor = treetn.remove_tensor_by_name(&site).ok_or_else(|| {
+            anyhow::anyhow!("treetn_to_tensor_train: missing tensor at node {site}")
+        })?;
+
+        tensors.push(treetn_site_to_tensor3::<T>(tensor, metadata, site)?);
+    }
+
+    Ok(TensorTrain::new(tensors)?)
+}
+
+struct ChainSiteMetadata {
+    site_index: DynIndex,
+    left_bond: Option<DynIndex>,
+    right_bond: Option<DynIndex>,
+}
+
 fn tensor_train_to_treetn_impl<T, V>(
     tt: &TensorTrain<T>,
     node_names: Vec<V>,
@@ -208,6 +354,102 @@ where
         data.push(*tensor.get3(0, s, 0));
     }
     data
+}
+
+fn treetn_site_to_tensor3<T>(
+    tensor: TensorDynLen,
+    metadata: ChainSiteMetadata,
+    site: usize,
+) -> Result<tensor4all_simplett::Tensor3<T>>
+where
+    T: TTScalar + TensorElement + Clone,
+{
+    let (tensor_indices, source) = tensor.into_dense_col_major_parts::<T>()?;
+    let expected_rank =
+        1 + usize::from(metadata.left_bond.is_some()) + usize::from(metadata.right_bond.is_some());
+    ensure!(
+        tensor_indices.len() == expected_rank,
+        "treetn_to_tensor_train: node {site} has rank {}, expected {expected_rank}",
+        tensor_indices.len()
+    );
+
+    let dims: Vec<_> = tensor_indices.iter().map(IndexLike::dim).collect();
+    let site_axis = index_axis(&tensor_indices, &metadata.site_index).ok_or_else(|| {
+        anyhow::anyhow!("treetn_to_tensor_train: node {site} tensor is missing its site index")
+    })?;
+    let left_axis = metadata
+        .left_bond
+        .as_ref()
+        .map(|index| {
+            index_axis(&tensor_indices, index).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "treetn_to_tensor_train: node {site} tensor is missing its left bond"
+                )
+            })
+        })
+        .transpose()?;
+    let right_axis = metadata
+        .right_bond
+        .as_ref()
+        .map(|index| {
+            index_axis(&tensor_indices, index).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "treetn_to_tensor_train: node {site} tensor is missing its right bond"
+                )
+            })
+        })
+        .transpose()?;
+
+    let left_dim = metadata.left_bond.as_ref().map(IndexLike::dim).unwrap_or(1);
+    let site_dim = metadata.site_index.dim();
+    let right_dim = metadata
+        .right_bond
+        .as_ref()
+        .map(IndexLike::dim)
+        .unwrap_or(1);
+
+    let expected_axes: Vec<_> = left_axis
+        .into_iter()
+        .chain(std::iter::once(site_axis))
+        .chain(right_axis)
+        .collect();
+    let data = if expected_axes == (0..tensor_indices.len()).collect::<Vec<_>>() {
+        source
+    } else {
+        let mut data = Vec::with_capacity(left_dim * site_dim * right_dim);
+        for r in 0..right_dim {
+            for s in 0..site_dim {
+                for l in 0..left_dim {
+                    let mut multi = vec![0usize; tensor_indices.len()];
+                    if let Some(axis) = left_axis {
+                        multi[axis] = l;
+                    }
+                    multi[site_axis] = s;
+                    if let Some(axis) = right_axis {
+                        multi[axis] = r;
+                    }
+                    data.push(source[col_major_offset(&multi, &dims)]);
+                }
+            }
+        }
+        data
+    };
+
+    Ok(tensor3_from_data(data, left_dim, site_dim, right_dim)?)
+}
+
+fn index_axis(indices: &[DynIndex], target: &DynIndex) -> Option<usize> {
+    indices.iter().position(|index| index == target)
+}
+
+fn col_major_offset(multi: &[usize], dims: &[usize]) -> usize {
+    let mut stride = 1usize;
+    let mut offset = 0usize;
+    for (&coord, &dim) in multi.iter().zip(dims) {
+        offset += coord * stride;
+        stride *= dim;
+    }
+    offset
 }
 
 fn left_boundary_data<T>(tensor: &tensor4all_simplett::Tensor3<T>) -> Vec<T>

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -793,6 +793,10 @@ where
         self.graph.graph_mut().node_weight_mut(node)
     }
 
+    pub(crate) fn remove_tensor_by_name(&mut self, node_name: &V) -> Option<T> {
+        self.graph.remove_node(node_name)
+    }
+
     /// Replace a tensor at the given node with a new tensor.
     ///
     /// Validates that the new tensor contains all indices used in connections

--- a/crates/tensor4all-treetn/tests/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/tests/simplett_bridge.rs
@@ -4,7 +4,7 @@ use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
 use tensor4all_treetn::{
     tensor_train_to_treetn, tensor_train_to_treetn_with_names,
-    tensor_train_to_treetn_with_names_and_site_indices,
+    tensor_train_to_treetn_with_names_and_site_indices, treetn_to_tensor_train, TreeTN,
 };
 
 fn two_site_tensor_train_f64() -> TensorTrain<f64> {
@@ -157,6 +157,72 @@ fn tensor_train_to_treetn_three_site_preserves_dense_values() -> Result<()> {
 
     assert_eq!(treetn.node_names(), vec![0, 1, 2]);
     assert!(dense.distance(&expected).unwrap() < 1.0e-12);
+    Ok(())
+}
+
+#[test]
+fn treetn_to_tensor_train_roundtrips_three_site_values() -> Result<()> {
+    let tt = three_site_tensor_train_f64();
+    let (treetn, _site_indices) = tensor_train_to_treetn(&tt)?;
+
+    let roundtrip = treetn_to_tensor_train::<f64>(treetn)?;
+
+    assert_eq!(roundtrip.site_dims(), tt.site_dims());
+    assert_eq!(roundtrip.link_dims(), tt.link_dims());
+
+    let (actual, actual_shape) = roundtrip.fulltensor();
+    let (expected, expected_shape) = tt.fulltensor();
+    assert_eq!(actual_shape, expected_shape);
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[test]
+fn treetn_to_tensor_train_roundtrips_complex_values() -> Result<()> {
+    let tt = two_site_tensor_train_c64();
+    let (treetn, _site_indices) = tensor_train_to_treetn(&tt)?;
+
+    let roundtrip = treetn_to_tensor_train::<Complex64>(treetn)?;
+
+    assert_eq!(roundtrip.site_dims(), tt.site_dims());
+    assert_eq!(roundtrip.link_dims(), tt.link_dims());
+
+    let (actual, actual_shape) = roundtrip.fulltensor();
+    let (expected, expected_shape) = tt.fulltensor();
+    assert_eq!(actual_shape, expected_shape);
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[test]
+fn treetn_to_tensor_train_handles_local_axis_permutations() -> Result<()> {
+    let tt = two_site_tensor_train_f64();
+    let site0 = DynIndex::new_dyn(2);
+    let site1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_bond(2)?;
+    let t0 = TensorDynLen::from_dense(vec![bond.clone(), site0], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    let t1 = TensorDynLen::from_dense(vec![site1, bond], vec![1.0_f64, -1.0, 0.5, 2.0])?;
+    let treetn = TreeTN::from_tensors(vec![t0, t1], vec![0, 1])?;
+
+    let roundtrip = treetn_to_tensor_train::<f64>(treetn)?;
+
+    assert_eq!(roundtrip.site_dims(), tt.site_dims());
+    assert_eq!(roundtrip.link_dims(), tt.link_dims());
+    assert_eq!(roundtrip.fulltensor(), tt.fulltensor());
+    Ok(())
+}
+
+#[test]
+fn treetn_to_tensor_train_rejects_ad_tracked_site_tensor() -> Result<()> {
+    let tt = single_site_tensor_train_f64();
+    let (mut treetn, _site_indices) = tensor_train_to_treetn(&tt)?;
+    let node = treetn.node_index(&0).unwrap();
+    let tracked_tensor = treetn.tensor(node).unwrap().clone().enable_grad()?;
+    treetn.replace_tensor(node, tracked_tensor)?;
+
+    let err = treetn_to_tensor_train::<f64>(treetn).unwrap_err();
+
+    assert!(err.to_string().contains("tracked autodiff"));
     Ok(())
 }
 

--- a/docs/plans/2026-05-16-native-einsum-borrowed-conversions-design.md
+++ b/docs/plans/2026-05-16-native-einsum-borrowed-conversions-design.md
@@ -1,0 +1,48 @@
+# Native Einsum Borrowed Conversions Design
+
+## Context
+
+Issue #441 identifies avoidable memory growth in dense native einsum paths. The
+public borrowed bridge `einsum_native_tensors` currently clones every native
+operand and forwards to the owned bridge. For CPU host buffers, `NativeTensor`
+cloning duplicates the underlying dense storage.
+
+The owned bridge already promotes only operands whose dtype differs from the
+common target dtype. The borrowed bridge should preserve that behavior without
+deep-cloning operands that can be reused by reference.
+
+## Design
+
+`einsum_native_tensors` will compute the common target dtype, validate each
+operand rank against its label list, and build einsum subscripts as before. It
+will then allocate converted temporary tensors only for operands whose dtype
+differs from the target dtype. Operands already at the target dtype will remain
+borrowed from the caller.
+
+The bridge will pass a `Vec<&NativeTensor>` to tenferro's borrowed
+`eager_einsum`. References will point either to the original caller-owned tensor
+or to the local converted temporary. The converted temporaries live until
+`eager_einsum` returns, so the borrowed input slice remains valid.
+
+## Alternatives Considered
+
+- Keep using the owned bridge for mixed dtype inputs. This keeps code simple but
+  deep-clones target-dtype operands unnecessarily, which is the memory issue.
+- Add a public mixed borrowed/owned tenferro API. This is more general but
+  expands the dependency surface before the tensor4all bridge needs it.
+- Convert only mismatched operands inside the tensor4all bridge. This solves the
+  immediate memory issue while keeping the public API unchanged.
+
+The third option is the chosen design.
+
+## Testing
+
+Tests should cover both native einsum execution paths:
+
+- same-dtype borrowed operands use the borrowed path with no conversions;
+- mixed-dtype borrowed operands use the borrowed-with-conversions path and still
+  promote to the common dtype;
+- existing validation and numerical results remain unchanged.
+
+The profile path enum is test-only observable within the module, so tests can
+assert which route was used without adding public API.

--- a/docs/plans/2026-05-16-native-einsum-borrowed-conversions-plan.md
+++ b/docs/plans/2026-05-16-native-einsum-borrowed-conversions-plan.md
@@ -1,0 +1,97 @@
+# Native Einsum Borrowed Conversions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Avoid deep-cloning native einsum operands when borrowed inputs can be reused directly or only mismatched dtype operands need conversion.
+
+**Architecture:** Keep the public tensorbackend API unchanged. Update `einsum_native_tensors` to build borrowed input references to either original operands or local converted temporaries, then call tenferro's borrowed `eager_einsum`.
+
+**Tech Stack:** Rust, tensor4all-tensorbackend, tenferro `eager_einsum`, `anyhow`, release-mode cargo tests.
+
+---
+
+### Task 1: Add Tests For Borrowed Native Einsum Paths
+
+**Files:**
+- Modify: `crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs`
+
+**Step 1: Write failing tests**
+
+Add or update tests so same-dtype borrowed einsum records a new borrowed path
+and mixed-dtype borrowed einsum records a borrowed-with-conversions path while
+returning the promoted dtype and expected values.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend tenferro_bridge::tests::einsum_native_tensors_dense_binary_records_borrowed_profile -- --exact
+cargo test --release -p tensor4all-tensorbackend tenferro_bridge::tests::einsum_native_tensors_mixed_dtype_records_borrowed_conversion_profile -- --exact
+```
+
+Expected: fail to compile or fail assertions because the profile variants and
+borrowed conversion path do not exist yet.
+
+### Task 2: Implement Borrowed And Borrowed-With-Conversions Paths
+
+**Files:**
+- Modify: `crates/tensor4all-tensorbackend/src/tenferro_bridge.rs`
+
+**Step 1: Import borrowed einsum**
+
+Import `eager_einsum` alongside `eager_einsum_owned`.
+
+**Step 2: Add profile variants**
+
+Extend `NativeEinsumPath` with `Borrowed` and `BorrowedWithConversions`.
+
+**Step 3: Implement minimal bridge change**
+
+In `einsum_native_tensors`:
+
+- reject empty operands;
+- compute target dtype with `common_dtype`;
+- validate rank and collect label ids;
+- convert only operands whose dtype differs from the target;
+- build references to converted temporaries or original operands;
+- call `eager_einsum` with the borrowed references;
+- record `Borrowed` when no conversions are needed, otherwise
+  `BorrowedWithConversions`.
+
+**Step 4: Run targeted tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-tensorbackend tenferro_bridge
+```
+
+Expected: all tensorbackend tenferro bridge tests pass.
+
+### Task 3: Verification And Commit
+
+**Files:**
+- Verify all modified files.
+
+**Step 1: Format and check**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+git diff --check
+cargo clippy -p tensor4all-tensorbackend --all-targets -- -D warnings
+```
+
+Expected: all commands pass.
+
+**Step 2: Commit**
+
+Run:
+
+```bash
+git add docs/plans/2026-05-16-native-einsum-borrowed-conversions-design.md docs/plans/2026-05-16-native-einsum-borrowed-conversions-plan.md crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+git commit -m "Avoid native einsum operand clones"
+```


### PR DESCRIPTION
## Summary

- Add TreeTN to TensorTrain conversion support.
- Document the native einsum borrowed-conversion plan and avoid cloning operands that already have the requested dtype.
- Update the tenferro pin and route SVD/QR factorization through eager linalg so AD graph information is preserved.
- Rebuild fixed-pivot CI factors with eager `take_*`, `solve`/`right_solve`, and `matmul`-compatible tensors after primal pivot selection.

## Validation

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy -p tensor4all-core --all-targets -- -D warnings`
- `cargo test --release -p tensor4all-core`
- `cargo test --release -p tensor4all-tensorbackend tenferro_bridge`
- `git diff --check`