### PR TITLE
Add tagged-index operator application

### DIFF
--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -58,8 +58,24 @@ fn rust_operator_matrix(
 
     let mut indices = Vec::with_capacity(2 * nsites);
     for site in 0..nsites {
-        indices.push(op.output_mapping.get(&site).unwrap().internal_index.clone());
-        indices.push(op.input_mapping.get(&site).unwrap().internal_index.clone());
+        indices.push(
+            op.output_mapping
+                .get(&site)
+                .unwrap()
+                .first()
+                .unwrap()
+                .internal_index
+                .clone(),
+        );
+        indices.push(
+            op.input_mapping
+                .get(&site)
+                .unwrap()
+                .first()
+                .unwrap()
+                .internal_index
+                .clone(),
+        );
     }
 
     let mut matrix = vec![Complex64::new(0.0, 0.0); nrows * ncols];

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -27,6 +27,7 @@ num-complex.workspace = true
 dyn-clone.workspace = true
 rand.workspace = true
 kryst.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }

--- a/crates/tensor4all-treetn/src/error.rs
+++ b/crates/tensor4all-treetn/src/error.rs
@@ -1,0 +1,224 @@
+//! Public error types for tensor4all-treetn APIs.
+
+use thiserror::Error;
+
+/// Error returned when selecting external indices by numbered tags fails.
+///
+/// Use this for APIs that resolve tags such as `"k=1"`, `"k=2"`, ... into a
+/// concrete ordered index list.
+///
+/// # Examples
+/// ```
+/// use tensor4all_treetn::NumberedTagSelectionError;
+///
+/// let err = NumberedTagSelectionError::MissingTag {
+///     tag: "k=3".to_string(),
+/// };
+/// assert_eq!(err.to_string(), "no external index with tag k=3");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum NumberedTagSelectionError {
+    /// The tag prefix is malformed for numbered-tag lookup.
+    #[error("invalid numbered tag prefix {tag_prefix}: prefix must not contain '='")]
+    InvalidPrefix {
+        /// Prefix provided by the caller.
+        tag_prefix: String,
+    },
+    /// The requested numeric range overflows `usize`.
+    #[error("numbered tag range overflows usize at offset {offset} from start {start_index}")]
+    RangeOverflow {
+        /// First requested numeric suffix.
+        start_index: usize,
+        /// Offset from `start_index` that overflowed.
+        offset: usize,
+    },
+    /// A required numbered tag was not present on any external index.
+    #[error("no external index with tag {tag}")]
+    MissingTag {
+        /// Missing tag, including the numeric suffix.
+        tag: String,
+    },
+    /// A required numbered tag matched more than one external index.
+    #[error("found more than one external index with tag {tag}")]
+    AmbiguousTag {
+        /// Ambiguous tag, including the numeric suffix.
+        tag: String,
+    },
+}
+
+/// Error returned when rebinding a [`LinearOperator`](crate::LinearOperator)'s
+/// true input or output indices fails.
+///
+/// The error reports whether the failed binding belonged to the input or output
+/// map through the `role` field.
+///
+/// # Examples
+/// ```
+/// use tensor4all_treetn::LinearOperatorIndexBindingError;
+///
+/// let err = LinearOperatorIndexBindingError::DimensionMismatch {
+///     role: "input",
+///     old_dim: 2,
+///     new_dim: 3,
+/// };
+/// assert!(err.to_string().contains("input index dimension mismatch"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum LinearOperatorIndexBindingError {
+    /// A replacement would change an index dimension.
+    #[error("{role} index dimension mismatch: old dimension {old_dim} vs new dimension {new_dim}")]
+    DimensionMismatch {
+        /// Binding role, currently `"input"` or `"output"`.
+        role: &'static str,
+        /// Dimension of the source true index.
+        old_dim: usize,
+        /// Dimension of the requested replacement index.
+        new_dim: usize,
+    },
+    /// The same source index was named more than once.
+    #[error("duplicate {role} index binding for {index}")]
+    DuplicateSourceIndex {
+        /// Binding role, currently `"input"` or `"output"`.
+        role: &'static str,
+        /// Debug representation of the duplicate source index.
+        index: String,
+    },
+    /// The source index does not appear in the corresponding mapping.
+    #[error("{role} index {index} not found in operator mappings")]
+    MissingSourceIndex {
+        /// Binding role, currently `"input"` or `"output"`.
+        role: &'static str,
+        /// Debug representation of the missing source index.
+        index: String,
+    },
+}
+
+/// Error returned when applying a linear operator after explicit index binding
+/// fails.
+///
+/// This separates binding failures from failures in the underlying apply
+/// algorithm.
+///
+/// # Examples
+/// ```
+/// use tensor4all_treetn::{
+///     LinearOperatorIndexApplyError,
+///     LinearOperatorIndexBindingError,
+/// };
+///
+/// let err = LinearOperatorIndexApplyError::BindIndices(
+///     LinearOperatorIndexBindingError::MissingSourceIndex {
+///         role: "input",
+///         index: "i".to_string(),
+///     },
+/// );
+/// assert!(err.to_string().contains("failed to bind operator indices"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum LinearOperatorIndexApplyError {
+    /// Explicit true-index rebinding failed before application.
+    #[error("failed to bind operator indices: {0}")]
+    BindIndices(#[from] LinearOperatorIndexBindingError),
+    /// The underlying operator application failed.
+    #[error("failed to apply rebound linear operator: {message}")]
+    ApplyFailed {
+        /// Error message from the underlying apply path, including context.
+        message: String,
+    },
+}
+
+/// Error returned when applying a linear operator to state indices selected by
+/// numbered tags.
+///
+/// This is used by [`apply_linear_operator_to_numbered_tags`](crate::apply_linear_operator_to_numbered_tags),
+/// which resolves state indices tagged as `"k=1"`, `"k=2"`, ... and then uses
+/// explicit index binding before applying the operator.
+///
+/// # Examples
+/// ```
+/// use tensor4all_treetn::LinearOperatorTaggedApplyError;
+///
+/// let err = LinearOperatorTaggedApplyError::MappingCountMismatch {
+///     input_count: 2,
+///     output_count: 3,
+/// };
+/// assert!(err.to_string().contains("input mappings"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum LinearOperatorTaggedApplyError {
+    /// State index selection from numbered tags failed.
+    #[error("failed to select state indices by numbered tag: {0}")]
+    SelectTaggedIndices(#[from] NumberedTagSelectionError),
+    /// The operator does not have matching input and output mapping counts.
+    #[error("operator has {input_count} input mappings but {output_count} output mappings")]
+    MappingCountMismatch {
+        /// Number of true input mappings found in operator node order.
+        input_count: usize,
+        /// Number of true output mappings found in operator node order.
+        output_count: usize,
+    },
+    /// Explicit binding or application failed after tag selection.
+    #[error("failed to apply operator to tagged indices: {0}")]
+    ApplyToIndices(#[from] LinearOperatorIndexApplyError),
+}
+
+/// Error returned by selected-index TreeTN contraction helper APIs.
+///
+/// This covers helpers such as [`hadamard`](crate::hadamard),
+/// [`weighted_sum_over_index_pairs`](crate::weighted_sum_over_index_pairs), and
+/// [`sum_over_indices`](crate::sum_over_indices).
+///
+/// # Examples
+/// ```
+/// use tensor4all_treetn::SelectedIndexContractionError;
+///
+/// let err = SelectedIndexContractionError::DuplicateIndex {
+///     index: "i".to_string(),
+/// };
+/// assert!(err.to_string().contains("duplicate index"));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SelectedIndexContractionError {
+    /// The same selected index was provided more than once.
+    #[error("sum_over_indices: duplicate index {index}")]
+    DuplicateIndex {
+        /// Debug representation of the duplicated index.
+        index: String,
+    },
+    /// A selected index appeared in more than one site space.
+    #[error("sum_over_indices: index {index} appears in more than one site space")]
+    IndexInMultipleSiteSpaces {
+        /// Debug representation of the repeated index.
+        index: String,
+    },
+    /// A selected index was not external to the input TreeTN.
+    #[error("sum_over_indices: index {index} not found in external indices")]
+    IndexNotFound {
+        /// Debug representation of the missing index.
+        index: String,
+    },
+    /// Construction of a local unit-weight tensor failed.
+    #[error("sum_over_indices: failed to build ones tensor at node {node}: {message}")]
+    BuildOnesTensor {
+        /// Debug representation of the node.
+        node: String,
+        /// Error message from the tensor constructor.
+        message: String,
+    },
+    /// Construction of the weight TreeTN failed.
+    #[error("sum_over_indices: failed to build ones TreeTN: {message}")]
+    BuildWeightsTree {
+        /// Error message from the TreeTN constructor.
+        message: String,
+    },
+    /// The underlying partial contraction failed.
+    #[error("selected-index contraction failed: {message}")]
+    PartialContractFailed {
+        /// Error message from the partial contraction path, including context.
+        message: String,
+    },
+}
+
+pub(crate) fn format_anyhow_error(error: anyhow::Error) -> String {
+    format!("{error:#}")
+}

--- a/crates/tensor4all-treetn/src/error.rs
+++ b/crates/tensor4all-treetn/src/error.rs
@@ -222,3 +222,178 @@ pub enum SelectedIndexContractionError {
 pub(crate) fn format_anyhow_error(error: anyhow::Error) -> String {
     format!("{error:#}")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn numbered_tag_selection_error_messages_are_stable() {
+        assert_eq!(
+            NumberedTagSelectionError::InvalidPrefix {
+                tag_prefix: "k=1".to_string(),
+            }
+            .to_string(),
+            "invalid numbered tag prefix k=1: prefix must not contain '='"
+        );
+        assert_eq!(
+            NumberedTagSelectionError::RangeOverflow {
+                start_index: usize::MAX,
+                offset: 1,
+            }
+            .to_string(),
+            format!(
+                "numbered tag range overflows usize at offset 1 from start {}",
+                usize::MAX
+            )
+        );
+        assert_eq!(
+            NumberedTagSelectionError::MissingTag {
+                tag: "k=3".to_string(),
+            }
+            .to_string(),
+            "no external index with tag k=3"
+        );
+        assert_eq!(
+            NumberedTagSelectionError::AmbiguousTag {
+                tag: "k=1".to_string(),
+            }
+            .to_string(),
+            "found more than one external index with tag k=1"
+        );
+    }
+
+    #[test]
+    fn linear_operator_binding_error_messages_are_stable() {
+        assert_eq!(
+            LinearOperatorIndexBindingError::DimensionMismatch {
+                role: "input",
+                old_dim: 2,
+                new_dim: 3,
+            }
+            .to_string(),
+            "input index dimension mismatch: old dimension 2 vs new dimension 3"
+        );
+        assert_eq!(
+            LinearOperatorIndexBindingError::DuplicateSourceIndex {
+                role: "output",
+                index: "i".to_string(),
+            }
+            .to_string(),
+            "duplicate output index binding for i"
+        );
+        assert_eq!(
+            LinearOperatorIndexBindingError::MissingSourceIndex {
+                role: "input",
+                index: "j".to_string(),
+            }
+            .to_string(),
+            "input index j not found in operator mappings"
+        );
+    }
+
+    #[test]
+    fn linear_operator_apply_error_messages_are_stable() {
+        assert_eq!(
+            LinearOperatorIndexApplyError::BindIndices(
+                LinearOperatorIndexBindingError::MissingSourceIndex {
+                    role: "input",
+                    index: "i".to_string(),
+                }
+            )
+            .to_string(),
+            "failed to bind operator indices: input index i not found in operator mappings"
+        );
+        assert_eq!(
+            LinearOperatorIndexApplyError::ApplyFailed {
+                message: "contraction failed".to_string(),
+            }
+            .to_string(),
+            "failed to apply rebound linear operator: contraction failed"
+        );
+    }
+
+    #[test]
+    fn tagged_apply_error_messages_are_stable() {
+        assert_eq!(
+            LinearOperatorTaggedApplyError::SelectTaggedIndices(
+                NumberedTagSelectionError::MissingTag {
+                    tag: "x=2".to_string(),
+                }
+            )
+            .to_string(),
+            "failed to select state indices by numbered tag: no external index with tag x=2"
+        );
+        assert_eq!(
+            LinearOperatorTaggedApplyError::MappingCountMismatch {
+                input_count: 2,
+                output_count: 3,
+            }
+            .to_string(),
+            "operator has 2 input mappings but 3 output mappings"
+        );
+        assert_eq!(
+            LinearOperatorTaggedApplyError::ApplyToIndices(
+                LinearOperatorIndexApplyError::ApplyFailed {
+                    message: "apply failed".to_string(),
+                }
+            )
+            .to_string(),
+            "failed to apply operator to tagged indices: failed to apply rebound linear operator: apply failed"
+        );
+    }
+
+    #[test]
+    fn selected_index_contraction_error_messages_are_stable() {
+        assert_eq!(
+            SelectedIndexContractionError::DuplicateIndex {
+                index: "i".to_string(),
+            }
+            .to_string(),
+            "sum_over_indices: duplicate index i"
+        );
+        assert_eq!(
+            SelectedIndexContractionError::IndexInMultipleSiteSpaces {
+                index: "i".to_string(),
+            }
+            .to_string(),
+            "sum_over_indices: index i appears in more than one site space"
+        );
+        assert_eq!(
+            SelectedIndexContractionError::IndexNotFound {
+                index: "j".to_string(),
+            }
+            .to_string(),
+            "sum_over_indices: index j not found in external indices"
+        );
+        assert_eq!(
+            SelectedIndexContractionError::BuildOnesTensor {
+                node: "v0".to_string(),
+                message: "shape mismatch".to_string(),
+            }
+            .to_string(),
+            "sum_over_indices: failed to build ones tensor at node v0: shape mismatch"
+        );
+        assert_eq!(
+            SelectedIndexContractionError::BuildWeightsTree {
+                message: "invalid tree".to_string(),
+            }
+            .to_string(),
+            "sum_over_indices: failed to build ones TreeTN: invalid tree"
+        );
+        assert_eq!(
+            SelectedIndexContractionError::PartialContractFailed {
+                message: "zipup failed".to_string(),
+            }
+            .to_string(),
+            "selected-index contraction failed: zipup failed"
+        );
+    }
+
+    #[test]
+    fn format_anyhow_error_preserves_context_chain() {
+        let error = anyhow::anyhow!("root").context("outer context");
+
+        assert_eq!(format_anyhow_error(error), "outer context: root");
+    }
+}

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod algorithm;
 // dyn_treetn.rs has been removed.
 // TreeTN uses the `T: TensorLike` pattern, making a separate dyn wrapper unnecessary.
+pub mod error;
 pub mod link_index_network;
 pub mod linsolve;
 pub mod named_graph;
@@ -34,6 +35,10 @@ pub mod site_index_network;
 pub mod treetn;
 
 pub use algorithm::{CanonicalForm, CompressionAlgorithm, ContractionAlgorithm};
+pub use error::{
+    LinearOperatorIndexApplyError, LinearOperatorIndexBindingError, LinearOperatorTaggedApplyError,
+    NumberedTagSelectionError, SelectedIndexContractionError,
+};
 pub use treetn::contraction;
 
 // dyn_treetn exports removed - use TreeTN<TensorDynLen, V> directly
@@ -41,9 +46,10 @@ pub use link_index_network::LinkIndexNetwork;
 pub use named_graph::NamedGraph;
 pub use node_name_network::{CanonicalizeEdges, NodeNameNetwork};
 pub use operator::{
-    apply_linear_operator, are_exclusive_operators, build_identity_operator_tensor,
-    compose_exclusive_linear_operators, ApplyOptions, ArcLinearOperator, IndexMapping,
-    LinearOperator, Operator,
+    apply_linear_operator, apply_linear_operator_to_indices,
+    apply_linear_operator_to_numbered_tags, are_exclusive_operators, bind_linear_operator_indices,
+    build_identity_operator_tensor, compose_exclusive_linear_operators, ApplyOptions,
+    ArcLinearOperator, IndexMapping, LinearOperator, Operator,
 };
 pub use options::{CanonicalizationOptions, RestructureOptions, SplitOptions, TruncationOptions};
 pub use random::{random_treetn, LinkSpace};
@@ -59,7 +65,10 @@ pub use treetn::{
     factorize_tensor_to_treetn,
     factorize_tensor_to_treetn_with,
     get_boundary_edges,
+    hadamard,
     partial_contract,
+    sum_over_indices,
+    weighted_sum_over_index_pairs,
     BoundaryEdge,
     CachedEvaluatorOptions,
     CenterSearchResult,

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -70,12 +70,17 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 
 use tensor4all_core::{
-    AllowedPairs, IndexLike, LinearizationOrder, SvdTruncationPolicy, TensorIndex, TensorLike,
+    AllowedPairs, DynIndex, IndexLike, LinearizationOrder, SvdTruncationPolicy, TensorDynLen,
+    TensorIndex, TensorLike,
 };
 
 use super::index_mapping::IndexMapping;
 use super::linear_operator::LinearOperator;
 use super::Operator;
+use crate::error::{
+    format_anyhow_error, LinearOperatorIndexApplyError, LinearOperatorIndexBindingError,
+    LinearOperatorTaggedApplyError,
+};
 use crate::operator::compose::{
     compose_exclusive_linear_operators, compose_exclusive_linear_operators_unchecked,
 };
@@ -365,6 +370,342 @@ where
     Ok(result)
 }
 
+/// Return a copy of `operator` with selected true indices rebound explicitly.
+///
+/// This rewrites only the external true-index side of the operator mappings.
+/// The internal MPO tensors and their internal indices are left unchanged.
+/// Each pair is `(current_operator_true_index, desired_true_index)`.
+///
+/// # Arguments
+/// * `operator` - Operator whose true input/output mappings should be rebound.
+/// * `input_pairs` - Explicit replacements for input true indices.
+/// * `output_pairs` - Explicit replacements for output true indices.
+///
+/// # Returns
+/// A new operator with the requested true-index bindings.
+///
+/// # Errors
+/// Returns an error if a replacement changes dimension, names an index not
+/// present in the corresponding mapping, or names the same source index more
+/// than once.
+///
+/// # Examples
+/// ```
+/// use std::collections::HashMap;
+/// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+/// use tensor4all_treetn::{
+///     bind_linear_operator_indices, IndexMapping, LinearOperator, TreeTN,
+/// };
+///
+/// let op_input = DynIndex::new_dyn(2);
+/// let op_output = DynIndex::new_dyn(2);
+/// let input_internal = DynIndex::new_dyn(2);
+/// let output_internal = DynIndex::new_dyn(2);
+/// let mpo_tensor = TensorDynLen::from_dense(
+///     vec![input_internal.clone(), output_internal.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// ).unwrap();
+/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+///
+/// let mut input_mapping = HashMap::new();
+/// input_mapping.insert(0usize, IndexMapping { true_index: op_input.clone(), internal_index: input_internal });
+/// let mut output_mapping = HashMap::new();
+/// output_mapping.insert(0usize, IndexMapping { true_index: op_output.clone(), internal_index: output_internal });
+/// let operator = LinearOperator::new(mpo, input_mapping, output_mapping);
+///
+/// let state_index = DynIndex::new_dyn(2);
+/// let rebound = bind_linear_operator_indices(
+///     &operator,
+///     &[(op_input, state_index.clone())],
+///     &[(op_output, state_index.clone())],
+/// ).unwrap();
+/// assert!(rebound.get_input_mapping(&0).unwrap().true_index.same_id(&state_index));
+/// assert!(rebound.get_output_mapping(&0).unwrap().true_index.same_id(&state_index));
+/// ```
+pub fn bind_linear_operator_indices<T, V>(
+    operator: &LinearOperator<T, V>,
+    input_pairs: &[(T::Index, T::Index)],
+    output_pairs: &[(T::Index, T::Index)],
+) -> std::result::Result<LinearOperator<T, V>, LinearOperatorIndexBindingError>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut rebound = operator.clone();
+    replace_mapping_true_indices(&mut rebound.input_mapping, input_pairs, "input")?;
+    replace_mapping_true_indices(&mut rebound.output_mapping, output_pairs, "output")?;
+    Ok(rebound)
+}
+
+/// Apply a linear operator after explicitly binding selected external indices.
+///
+/// This is a convenience wrapper around [`bind_linear_operator_indices`] followed
+/// by [`apply_linear_operator`]. It is useful when an operator was constructed
+/// with its own input/output index IDs but should act on selected indices of a
+/// target state.
+///
+/// # Arguments
+/// * `operator` - Operator to apply.
+/// * `state` - State to which the rebound operator is applied.
+/// * `input_pairs` - `(operator_true_input, state_input)` replacements.
+/// * `output_pairs` - `(operator_true_output, desired_output)` replacements.
+/// * `options` - Apply algorithm and truncation options.
+///
+/// # Returns
+/// The result of applying the explicitly rebound operator to `state`.
+///
+/// # Errors
+/// Returns an error if binding fails or if [`apply_linear_operator`] fails.
+///
+/// # Examples
+/// ```
+/// use std::collections::HashMap;
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{
+///     apply_linear_operator_to_indices, ApplyOptions, IndexMapping, LinearOperator, TreeTN,
+/// };
+///
+/// let state_index = DynIndex::new_dyn(2);
+/// let state_tensor = TensorDynLen::from_dense(vec![state_index.clone()], vec![3.0, 5.0]).unwrap();
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
+///
+/// let op_input = DynIndex::new_dyn(2);
+/// let op_output = DynIndex::new_dyn(2);
+/// let input_internal = DynIndex::new_dyn(2);
+/// let output_internal = DynIndex::new_dyn(2);
+/// let mpo_tensor = TensorDynLen::from_dense(
+///     vec![input_internal.clone(), output_internal.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// ).unwrap();
+/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+///
+/// let mut input_mapping = HashMap::new();
+/// input_mapping.insert(0usize, IndexMapping { true_index: op_input.clone(), internal_index: input_internal });
+/// let mut output_mapping = HashMap::new();
+/// output_mapping.insert(0usize, IndexMapping { true_index: op_output.clone(), internal_index: output_internal });
+/// let operator = LinearOperator::new(mpo, input_mapping, output_mapping);
+///
+/// let result = apply_linear_operator_to_indices(
+///     &operator,
+///     &state,
+///     &[(op_input, state_index.clone())],
+///     &[(op_output, state_index.clone())],
+///     ApplyOptions::naive(),
+/// ).unwrap();
+/// assert!(result.to_dense().unwrap().distance(&state.to_dense().unwrap()).unwrap() < 1.0e-12);
+/// ```
+pub fn apply_linear_operator_to_indices<T, V>(
+    operator: &LinearOperator<T, V>,
+    state: &TreeTN<T, V>,
+    input_pairs: &[(T::Index, T::Index)],
+    output_pairs: &[(T::Index, T::Index)],
+    options: ApplyOptions,
+) -> std::result::Result<TreeTN<T, V>, LinearOperatorIndexApplyError>
+where
+    T: TensorLike,
+    T::Index: IndexLike + Clone + Hash + Eq + std::fmt::Debug,
+    <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let rebound = bind_linear_operator_indices(operator, input_pairs, output_pairs)?;
+    apply_linear_operator(&rebound, state, options).map_err(|error| {
+        LinearOperatorIndexApplyError::ApplyFailed {
+            message: format_anyhow_error(error),
+        }
+    })
+}
+
+/// Apply a linear operator to state indices selected by numbered tags.
+///
+/// The selected state indices are resolved with
+/// [`TreeTN::external_indices_with_numbered_tag`]. For example,
+/// `tag_prefix = "k"` and `start_index = 1` selects `"k=1"`, `"k=2"`, ...
+/// in operator node order. The number of selected tags is inferred from the
+/// operator's true input mappings, so this helper works for any operator whose
+/// input and output mapping counts match.
+///
+/// The result keeps the selected state indices as the operator output indices.
+/// If a transform should write to different output indices, use
+/// [`apply_linear_operator_to_indices`] and pass explicit output bindings.
+///
+/// # Arguments
+/// * `operator` - Operator to apply. Its node order defines the bit order.
+/// * `state` - State containing numbered-tagged external indices.
+/// * `tag_prefix` - Prefix before the equals sign, such as `"k"` or `"x"`.
+/// * `start_index` - First numbered tag to select. Use `1` for Quantics.jl-style
+///   tags such as `"k=1"`, `"k=2"`, ...
+/// * `options` - Apply algorithm and truncation options.
+///
+/// # Returns
+/// The result of applying `operator` to the selected state indices.
+///
+/// # Errors
+/// Returns an error if numbered-tag selection fails, if the operator has
+/// unequal input/output mapping counts, if binding selected indices fails, or
+/// if the underlying apply algorithm fails.
+///
+/// # Examples
+/// ```
+/// use std::collections::HashMap;
+/// use tensor4all_core::{DynIndex, TagSet, TensorDynLen, TensorLike};
+/// use tensor4all_treetn::{
+///     apply_linear_operator_to_numbered_tags, ApplyOptions, IndexMapping,
+///     LinearOperator, TreeTN,
+/// };
+///
+/// let k1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![k1.clone()], vec![1.0, 2.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+///
+/// let true_input = DynIndex::new_dyn(2);
+/// let true_output = DynIndex::new_dyn(2);
+/// let internal_input = DynIndex::new_dyn(2);
+/// let internal_output = DynIndex::new_dyn(2);
+/// let mpo_tensor = TensorDynLen::from_dense(
+///     vec![internal_output.clone(), internal_input.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// ).unwrap();
+/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+/// let mut input_mapping = HashMap::new();
+/// input_mapping.insert(0, IndexMapping {
+///     true_index: true_input,
+///     internal_index: internal_input,
+/// });
+/// let mut output_mapping = HashMap::new();
+/// output_mapping.insert(0, IndexMapping {
+///     true_index: true_output,
+///     internal_index: internal_output,
+/// });
+/// let operator = LinearOperator::new(mpo, input_mapping, output_mapping);
+///
+/// let result = apply_linear_operator_to_numbered_tags(
+///     &operator,
+///     &state,
+///     "k",
+///     1,
+///     ApplyOptions::naive(),
+/// ).unwrap();
+/// assert!(result.to_dense().unwrap().distance(&state.to_dense().unwrap()).unwrap() < 1.0e-12);
+/// ```
+pub fn apply_linear_operator_to_numbered_tags<V>(
+    operator: &LinearOperator<TensorDynLen, V>,
+    state: &TreeTN<TensorDynLen, V>,
+    tag_prefix: &str,
+    start_index: usize,
+    options: ApplyOptions,
+) -> std::result::Result<TreeTN<TensorDynLen, V>, LinearOperatorTaggedApplyError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let input_true_indices = true_indices_in_operator_node_order(operator, &operator.input_mapping);
+    let output_true_indices =
+        true_indices_in_operator_node_order(operator, &operator.output_mapping);
+
+    if input_true_indices.len() != output_true_indices.len() {
+        return Err(LinearOperatorTaggedApplyError::MappingCountMismatch {
+            input_count: input_true_indices.len(),
+            output_count: output_true_indices.len(),
+        });
+    }
+
+    let state_indices = state.external_indices_with_numbered_tag(
+        tag_prefix,
+        start_index,
+        input_true_indices.len(),
+    )?;
+    let input_pairs: Vec<(DynIndex, DynIndex)> = input_true_indices
+        .into_iter()
+        .zip(state_indices.iter().cloned())
+        .collect();
+    let output_pairs: Vec<(DynIndex, DynIndex)> =
+        output_true_indices.into_iter().zip(state_indices).collect();
+
+    Ok(apply_linear_operator_to_indices(
+        operator,
+        state,
+        &input_pairs,
+        &output_pairs,
+        options,
+    )?)
+}
+
+fn true_indices_in_operator_node_order<V>(
+    operator: &LinearOperator<TensorDynLen, V>,
+    mappings_by_node: &HashMap<V, Vec<IndexMapping<DynIndex>>>,
+) -> Vec<DynIndex>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut nodes = operator.mpo().node_names();
+    nodes.sort();
+    let mut indices = Vec::new();
+    for node in nodes {
+        if let Some(mappings) = mappings_by_node.get(&node) {
+            indices.extend(mappings.iter().map(|mapping| mapping.true_index.clone()));
+        }
+    }
+    indices
+}
+
+fn replace_mapping_true_indices<I, V>(
+    mappings_by_node: &mut HashMap<V, Vec<IndexMapping<I>>>,
+    pairs: &[(I, I)],
+    role: &'static str,
+) -> std::result::Result<(), LinearOperatorIndexBindingError>
+where
+    I: IndexLike + Clone + Hash + Eq + std::fmt::Debug,
+    <I as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut seen = HashSet::new();
+    for (old_index, new_index) in pairs {
+        if old_index.dim() != new_index.dim() {
+            return Err(LinearOperatorIndexBindingError::DimensionMismatch {
+                role,
+                old_dim: old_index.dim(),
+                new_dim: new_index.dim(),
+            });
+        }
+        if !seen.insert(old_index.clone()) {
+            return Err(LinearOperatorIndexBindingError::DuplicateSourceIndex {
+                role,
+                index: format!("{old_index:?}"),
+            });
+        }
+
+        let mut hits = 0usize;
+        for mappings in mappings_by_node.values_mut() {
+            for mapping in mappings {
+                if mapping.true_index == *old_index {
+                    mapping.true_index = new_index.clone();
+                    hits += 1;
+                }
+            }
+        }
+
+        match hits {
+            0 => {
+                return Err(LinearOperatorIndexBindingError::MissingSourceIndex {
+                    role,
+                    index: format!("{old_index:?}"),
+                });
+            }
+            1 => {}
+            _ => {
+                return Err(LinearOperatorIndexBindingError::DuplicateSourceIndex {
+                    role,
+                    index: format!("{old_index:?}"),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Embed a full-coverage operator MPO on the state's topology for local exact apply.
 ///
 /// The local naive apply fuses one state bond and one MPO bond per state edge, so
@@ -591,9 +932,9 @@ where
 
     // Also track true<->internal mappings for gap nodes
     #[allow(clippy::type_complexity)]
-    let mut gap_input_mappings: HashMap<V, IndexMapping<T::Index>> = HashMap::new();
+    let mut gap_input_mappings: HashMap<V, Vec<IndexMapping<T::Index>>> = HashMap::new();
     #[allow(clippy::type_complexity)]
-    let mut gap_output_mappings: HashMap<V, IndexMapping<T::Index>> = HashMap::new();
+    let mut gap_output_mappings: HashMap<V, Vec<IndexMapping<T::Index>>> = HashMap::new();
 
     for gap_name in &gap_nodes {
         let site_space = state
@@ -605,28 +946,25 @@ where
         // - Internal indices = new simulated indices for the MPO tensor
         let mut pairs: Vec<(T::Index, T::Index)> = Vec::new();
 
-        for (i, true_idx) in site_space.iter().enumerate() {
+        for true_idx in site_space {
             let input_internal = true_idx.sim();
             let output_internal = true_idx.sim();
             pairs.push((input_internal.clone(), output_internal.clone()));
 
-            // Store mapping for the first site index of each gap node
-            if i == 0 {
-                gap_input_mappings.insert(
-                    gap_name.clone(),
-                    IndexMapping {
-                        true_index: true_idx.clone(),
-                        internal_index: input_internal,
-                    },
-                );
-                gap_output_mappings.insert(
-                    gap_name.clone(),
-                    IndexMapping {
-                        true_index: true_idx.clone(),
-                        internal_index: output_internal,
-                    },
-                );
-            }
+            gap_input_mappings
+                .entry(gap_name.clone())
+                .or_insert_with(Vec::new)
+                .push(IndexMapping {
+                    true_index: true_idx.clone(),
+                    internal_index: input_internal,
+                });
+            gap_output_mappings
+                .entry(gap_name.clone())
+                .or_insert_with(Vec::new)
+                .push(IndexMapping {
+                    true_index: true_idx.clone(),
+                    internal_index: output_internal,
+                });
         }
 
         gap_site_indices.insert(gap_name.clone(), pairs);
@@ -670,8 +1008,8 @@ fn compose_operator_along_state_paths<T, V>(
     operator: &LinearOperator<T, V>,
     state_network: &crate::site_index_network::SiteIndexNetwork<V, T::Index>,
     gap_site_indices: &HashMap<V, Vec<(T::Index, T::Index)>>,
-    input_mappings: HashMap<V, IndexMapping<T::Index>>,
-    output_mappings: HashMap<V, IndexMapping<T::Index>>,
+    input_mappings: HashMap<V, Vec<IndexMapping<T::Index>>>,
+    output_mappings: HashMap<V, Vec<IndexMapping<T::Index>>>,
 ) -> Result<LinearOperator<T, V>>
 where
     T: TensorLike,
@@ -929,7 +1267,11 @@ where
     let mpo = TreeTN::from_tensors(tensors, state_node_names.clone())
         .context("compose_operator_along_state_paths: failed to create TreeTN")?;
 
-    Ok(LinearOperator::new(mpo, input_mappings, output_mappings))
+    Ok(LinearOperator::new_multi(
+        mpo,
+        input_mappings,
+        output_mappings,
+    ))
 }
 
 /// Transform state's site indices to operator's input indices.
@@ -945,11 +1287,13 @@ where
 {
     let mut result = state.clone();
 
-    for (node, mapping) in operator.input_mappings() {
-        // Replace true_index with internal_index in the state
-        result = result
-            .replaceind(&mapping.true_index, &mapping.internal_index)
-            .with_context(|| format!("Failed to transform input index at node {:?}", node))?;
+    for (node, mappings) in operator.input_mappings() {
+        for mapping in mappings {
+            // Replace true_index with internal_index in the state
+            result = result
+                .replaceind(&mapping.true_index, &mapping.internal_index)
+                .with_context(|| format!("Failed to transform input index at node {:?}", node))?;
+        }
     }
 
     Ok(result)
@@ -966,11 +1310,13 @@ where
     <T::Index as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
 {
-    for (node, mapping) in operator.output_mappings() {
-        // Replace internal_index with true_index in the result
-        result = result
-            .replaceind(&mapping.internal_index, &mapping.true_index)
-            .with_context(|| format!("Failed to transform output index at node {:?}", node))?;
+    for (node, mappings) in operator.output_mappings() {
+        for mapping in mappings {
+            // Replace internal_index with true_index in the result
+            result = result
+                .replaceind(&mapping.internal_index, &mapping.true_index)
+                .with_context(|| format!("Failed to transform output index at node {:?}", node))?;
+        }
     }
 
     Ok(result)
@@ -994,14 +1340,19 @@ where
         let mut result: Vec<Self::Index> = self
             .input_mapping
             .values()
-            .map(|m| m.true_index.clone())
+            .flat_map(|mappings| mappings.iter().map(|m| m.true_index.clone()))
             .collect();
-        result.extend(self.output_mapping.values().map(|m| m.true_index.clone()));
+        result.extend(
+            self.output_mapping
+                .values()
+                .flat_map(|mappings| mappings.iter().map(|m| m.true_index.clone())),
+        );
         result
     }
 
     fn num_external_indices(&self) -> usize {
-        self.input_mapping.len() + self.output_mapping.len()
+        self.input_mapping.values().map(Vec::len).sum::<usize>()
+            + self.output_mapping.values().map(Vec::len).sum::<usize>()
     }
 
     /// Replace an external index (true index) in this operator.
@@ -1018,33 +1369,30 @@ where
         }
 
         let mut result = self.clone();
+        let mut found = false;
 
         // Check input mappings
-        for (node, mapping) in &self.input_mapping {
-            if mapping.true_index == *old_index && mapping.true_index.dim() == old_index.dim() {
-                result.input_mapping.insert(
-                    node.clone(),
-                    IndexMapping {
-                        true_index: new_index.clone(),
-                        internal_index: mapping.internal_index.clone(),
-                    },
-                );
-                return Ok(result);
+        for mappings in result.input_mapping.values_mut() {
+            for mapping in mappings {
+                if mapping.true_index == *old_index && mapping.true_index.dim() == old_index.dim() {
+                    mapping.true_index = new_index.clone();
+                    found = true;
+                }
             }
         }
 
         // Check output mappings
-        for (node, mapping) in &self.output_mapping {
-            if mapping.true_index == *old_index && mapping.true_index.dim() == old_index.dim() {
-                result.output_mapping.insert(
-                    node.clone(),
-                    IndexMapping {
-                        true_index: new_index.clone(),
-                        internal_index: mapping.internal_index.clone(),
-                    },
-                );
-                return Ok(result);
+        for mappings in result.output_mapping.values_mut() {
+            for mapping in mappings {
+                if mapping.true_index == *old_index && mapping.true_index.dim() == old_index.dim() {
+                    mapping.true_index = new_index.clone();
+                    found = true;
+                }
             }
+        }
+
+        if found {
+            return Ok(result);
         }
 
         Err(anyhow::anyhow!(
@@ -1065,6 +1413,15 @@ where
                 old_indices.len(),
                 new_indices.len()
             ));
+        }
+        let mut seen = HashSet::new();
+        for old in old_indices {
+            if !seen.insert(old.clone()) {
+                return Err(anyhow::anyhow!(
+                    "Duplicate old index {:?} in LinearOperator::replaceinds",
+                    old.id()
+                ));
+            }
         }
 
         let mut result = self.clone();
@@ -1092,10 +1449,10 @@ where
 {
     /// The MPO with internal index IDs (wrapped in Arc for CoW)
     pub mpo: Arc<TreeTN<T, V>>,
-    /// Input index mapping: node -> (true s_in, internal s_in_tmp)
-    pub input_mapping: HashMap<V, IndexMapping<T::Index>>,
-    /// Output index mapping: node -> (true s_out, internal s_out_tmp)
-    pub output_mapping: HashMap<V, IndexMapping<T::Index>>,
+    /// Input index mappings: node -> [(true s_in, internal s_in_tmp)].
+    pub input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
+    /// Output index mappings: node -> [(true s_out, internal s_out_tmp)].
+    pub output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
 }
 
 impl<T, V> ArcLinearOperator<T, V>
@@ -1119,6 +1476,27 @@ where
         mpo: TreeTN<T, V>,
         input_mapping: HashMap<V, IndexMapping<T::Index>>,
         output_mapping: HashMap<V, IndexMapping<T::Index>>,
+    ) -> Self {
+        let input_mapping = input_mapping
+            .into_iter()
+            .map(|(node, mapping)| (node, vec![mapping]))
+            .collect();
+        let output_mapping = output_mapping
+            .into_iter()
+            .map(|(node, mapping)| (node, vec![mapping]))
+            .collect();
+        Self {
+            mpo: Arc::new(mpo),
+            input_mapping,
+            output_mapping,
+        }
+    }
+
+    /// Create a new ArcLinearOperator with possibly multiple mappings per node.
+    pub fn new_multi(
+        mpo: TreeTN<T, V>,
+        input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
+        output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
     ) -> Self {
         Self {
             mpo: Arc::new(mpo),
@@ -1151,21 +1529,35 @@ where
 
     /// Get input mapping for a node.
     pub fn get_input_mapping(&self, node: &V) -> Option<&IndexMapping<T::Index>> {
-        self.input_mapping.get(node)
+        self.input_mapping
+            .get(node)
+            .and_then(|mappings| mappings.first())
     }
 
     /// Get output mapping for a node.
     pub fn get_output_mapping(&self, node: &V) -> Option<&IndexMapping<T::Index>> {
-        self.output_mapping.get(node)
+        self.output_mapping
+            .get(node)
+            .and_then(|mappings| mappings.first())
+    }
+
+    /// Get all input mappings for a node.
+    pub fn get_input_mappings(&self, node: &V) -> Option<&[IndexMapping<T::Index>]> {
+        self.input_mapping.get(node).map(Vec::as_slice)
+    }
+
+    /// Get all output mappings for a node.
+    pub fn get_output_mappings(&self, node: &V) -> Option<&[IndexMapping<T::Index>]> {
+        self.output_mapping.get(node).map(Vec::as_slice)
     }
 
     /// Get all input mappings.
-    pub fn input_mappings(&self) -> &HashMap<V, IndexMapping<T::Index>> {
+    pub fn input_mappings(&self) -> &HashMap<V, Vec<IndexMapping<T::Index>>> {
         &self.input_mapping
     }
 
     /// Get all output mappings.
-    pub fn output_mappings(&self) -> &HashMap<V, IndexMapping<T::Index>> {
+    pub fn output_mappings(&self) -> &HashMap<V, Vec<IndexMapping<T::Index>>> {
         &self.output_mapping
     }
 

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::random::{random_treetn, LinkSpace};
-use crate::SiteIndexNetwork;
+use crate::{
+    LinearOperatorIndexBindingError, LinearOperatorTaggedApplyError, NumberedTagSelectionError,
+    SiteIndexNetwork,
+};
 use std::collections::{HashMap, HashSet};
 use tensor4all_core::index::{DynId, Index, TagSet};
 use tensor4all_core::{ColMajorArrayRef, SvdTruncationPolicy, TensorDynLen};
@@ -220,6 +223,234 @@ fn build_chain_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>
             ("site3".to_string(), s3),
         ],
     )
+}
+
+#[test]
+fn apply_linear_operator_supports_multiple_index_mappings_per_node() {
+    let x = make_index(2);
+    let y = make_index(2);
+    let state_tensor =
+        TensorDynLen::from_dense(vec![x.clone(), y.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let state =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["site".to_string()])
+            .unwrap();
+
+    let x_in = make_index(2);
+    let y_in = make_index(2);
+    let x_out = make_index(2);
+    let y_out = make_index(2);
+    let mut data = vec![0.0; 16];
+    for xi in 0..2 {
+        for yi in 0..2 {
+            let xo = xi;
+            let yo = yi;
+            data[xo + 2 * (yo + 2 * (xi + 2 * yi))] = 1.0;
+        }
+    }
+    let mpo_tensor = TensorDynLen::from_dense(
+        vec![x_out.clone(), y_out.clone(), x_in.clone(), y_in.clone()],
+        data,
+    )
+    .unwrap();
+    let mpo =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["site".to_string()])
+            .unwrap();
+
+    let mut input_mapping = HashMap::new();
+    input_mapping.insert(
+        "site".to_string(),
+        vec![
+            IndexMapping {
+                true_index: x.clone(),
+                internal_index: x_in,
+            },
+            IndexMapping {
+                true_index: y.clone(),
+                internal_index: y_in,
+            },
+        ],
+    );
+    let mut output_mapping = HashMap::new();
+    output_mapping.insert(
+        "site".to_string(),
+        vec![
+            IndexMapping {
+                true_index: x.clone(),
+                internal_index: x_out,
+            },
+            IndexMapping {
+                true_index: y.clone(),
+                internal_index: y_out,
+            },
+        ],
+    );
+
+    let operator = LinearOperator::new_multi(mpo, input_mapping, output_mapping);
+    let result = apply_linear_operator(&operator, &state, ApplyOptions::naive()).unwrap();
+
+    assert!(
+        result
+            .to_dense()
+            .unwrap()
+            .distance(&state.to_dense().unwrap())
+            .unwrap()
+            < 1e-12
+    );
+}
+
+#[test]
+fn apply_linear_operator_to_indices_binds_explicit_external_indices() {
+    let state_index = make_index(2);
+    let state_tensor = TensorDynLen::from_dense(vec![state_index.clone()], vec![2.0, 5.0]).unwrap();
+    let state =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["site".to_string()])
+            .unwrap();
+
+    let op_true_input = make_index(2);
+    let op_true_output = make_index(2);
+    let internal_input = make_index(2);
+    let internal_output = make_index(2);
+    let mpo_tensor = TensorDynLen::from_dense(
+        vec![internal_output.clone(), internal_input.clone()],
+        vec![1.0, 0.0, 0.0, 1.0],
+    )
+    .unwrap();
+    let mpo =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["site".to_string()])
+            .unwrap();
+
+    let mut input_mapping = HashMap::new();
+    input_mapping.insert(
+        "site".to_string(),
+        IndexMapping {
+            true_index: op_true_input.clone(),
+            internal_index: internal_input,
+        },
+    );
+    let mut output_mapping = HashMap::new();
+    output_mapping.insert(
+        "site".to_string(),
+        IndexMapping {
+            true_index: op_true_output.clone(),
+            internal_index: internal_output,
+        },
+    );
+    let operator = LinearOperator::new(mpo, input_mapping, output_mapping);
+
+    let result = apply_linear_operator_to_indices(
+        &operator,
+        &state,
+        &[(op_true_input, state_index.clone())],
+        &[(op_true_output, state_index.clone())],
+        ApplyOptions::naive(),
+    )
+    .unwrap();
+
+    assert!(
+        result
+            .to_dense()
+            .unwrap()
+            .distance(&state.to_dense().unwrap())
+            .unwrap()
+            < 1e-12
+    );
+}
+
+#[test]
+fn bind_linear_operator_indices_reports_typed_error_paths() {
+    let op_true_input = make_index(2);
+    let operator = build_identity_operator(&[("site".to_string(), op_true_input.clone())]);
+    let same_id_prime = op_true_input.prime();
+
+    let missing = bind_linear_operator_indices(&operator, &[(same_id_prime, make_index(2))], &[])
+        .unwrap_err();
+    assert!(matches!(
+        missing,
+        LinearOperatorIndexBindingError::MissingSourceIndex { role: "input", .. }
+    ));
+
+    let mismatch =
+        bind_linear_operator_indices(&operator, &[(op_true_input.clone(), make_index(3))], &[])
+            .unwrap_err();
+    assert!(matches!(
+        mismatch,
+        LinearOperatorIndexBindingError::DimensionMismatch {
+            role: "input",
+            old_dim: 2,
+            new_dim: 3,
+        }
+    ));
+
+    let duplicate = bind_linear_operator_indices(
+        &operator,
+        &[
+            (op_true_input.clone(), make_index(2)),
+            (op_true_input, make_index(2)),
+        ],
+        &[],
+    )
+    .unwrap_err();
+    assert!(matches!(
+        duplicate,
+        LinearOperatorIndexBindingError::DuplicateSourceIndex { role: "input", .. }
+    ));
+}
+
+#[test]
+fn apply_linear_operator_to_numbered_tags_binds_state_indices_in_tag_order() {
+    let k1 = Index::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+    let k2 = Index::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
+    let bond = make_index(1);
+    let state = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![
+            TensorDynLen::from_dense(vec![k1.clone(), bond.clone()], vec![1.0, 2.0]).unwrap(),
+            TensorDynLen::from_dense(vec![bond, k2.clone()], vec![3.0, 5.0]).unwrap(),
+        ],
+        vec!["site0".to_string(), "site1".to_string()],
+    )
+    .unwrap();
+    let operator = build_bonded_identity_operator(&[
+        ("site0".to_string(), make_index(2)),
+        ("site1".to_string(), make_index(2)),
+    ]);
+
+    let result =
+        apply_linear_operator_to_numbered_tags(&operator, &state, "k", 1, ApplyOptions::naive())
+            .unwrap();
+
+    assert!(
+        result
+            .to_dense()
+            .unwrap()
+            .distance(&state.to_dense().unwrap())
+            .unwrap()
+            < 1.0e-12
+    );
+}
+
+#[test]
+fn apply_linear_operator_to_numbered_tags_reports_missing_tag() {
+    let k1 = Index::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+    let state = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(vec![k1], vec![1.0, 2.0]).unwrap()],
+        vec!["site0".to_string()],
+    )
+    .unwrap();
+    let operator = build_identity_operator(&[
+        ("site0".to_string(), make_index(2)),
+        ("site1".to_string(), make_index(2)),
+    ]);
+
+    let err =
+        apply_linear_operator_to_numbered_tags(&operator, &state, "k", 1, ApplyOptions::naive())
+            .unwrap_err();
+
+    assert!(matches!(
+        err,
+        LinearOperatorTaggedApplyError::SelectTaggedIndices(
+            NumberedTagSelectionError::MissingTag { ref tag }
+        ) if tag == "k=2"
+    ));
 }
 
 fn build_tree_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>) {
@@ -1401,14 +1632,30 @@ fn test_linear_operator_replaceinds() {
             std::slice::from_ref(&new_idx1),
         )
         .unwrap();
-    assert!(replaced.get_input_mapping(&"N0".to_string()).is_some());
+    assert_eq!(
+        replaced
+            .get_input_mapping(&"N0".to_string())
+            .unwrap()
+            .true_index,
+        new_idx1
+    );
+    assert_eq!(
+        replaced
+            .get_output_mapping(&"N0".to_string())
+            .unwrap()
+            .true_index,
+        new_idx1
+    );
 
-    // Test replaceinds with multiple indices
+    // Replacing the same old index twice is ambiguous now that replaceind
+    // updates all matching input/output mappings.
     let new_idx3 = make_index(2);
-    let replaced2 = lin_op
-        .replaceinds(&[true_s0.clone(), true_s0.clone()], &[new_idx2, new_idx3])
-        .unwrap();
-    assert!(replaced2.get_input_mapping(&"N0".to_string()).is_some());
+    let duplicate = lin_op.replaceinds(&[true_s0.clone(), true_s0.clone()], &[new_idx2, new_idx3]);
+    assert!(duplicate.is_err());
+    assert!(duplicate
+        .unwrap_err()
+        .to_string()
+        .contains("Duplicate old index"));
 
     // Test replaceinds error case (length mismatch)
     let result = lin_op.replaceinds(

--- a/crates/tensor4all-treetn/src/operator/compose.rs
+++ b/crates/tensor4all-treetn/src/operator/compose.rs
@@ -262,8 +262,8 @@ where
     // 5. Build tensors and mappings
     let mut tensors: Vec<T> = Vec::new();
     let mut result_node_names: Vec<V> = Vec::new();
-    let mut combined_input_mapping: HashMap<V, IndexMapping<T::Index>> = HashMap::new();
-    let mut combined_output_mapping: HashMap<V, IndexMapping<T::Index>> = HashMap::new();
+    let mut combined_input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>> = HashMap::new();
+    let mut combined_output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>> = HashMap::new();
 
     // 5a. Add tensors from operators (with dummy links added via outer product)
     for op in operators {
@@ -294,11 +294,11 @@ where
             result_node_names.push(name.clone());
 
             // Copy mappings
-            if let Some(input_map) = op.get_input_mapping(&name) {
-                combined_input_mapping.insert(name.clone(), input_map.clone());
+            if let Some(input_maps) = op.get_input_mappings(&name) {
+                combined_input_mapping.insert(name.clone(), input_maps.to_vec());
             }
-            if let Some(output_map) = op.get_output_mapping(&name) {
-                combined_output_mapping.insert(name.clone(), output_map.clone());
+            if let Some(output_maps) = op.get_output_mappings(&name) {
+                combined_output_mapping.insert(name.clone(), output_maps.to_vec());
             }
         }
     }
@@ -313,26 +313,21 @@ where
         let input_indices: Vec<T::Index> = index_pairs.iter().map(|(i, _)| i.clone()).collect();
         let output_indices: Vec<T::Index> = index_pairs.iter().map(|(_, o)| o.clone()).collect();
 
-        // Store mappings for the first site pair (if any)
-        if let Some((true_input, true_output)) = index_pairs.first() {
-            if !combined_input_mapping.contains_key(&gap_name) {
-                combined_input_mapping.insert(
-                    gap_name.clone(),
-                    IndexMapping {
-                        true_index: true_input.clone(),
-                        internal_index: input_indices[0].clone(),
-                    },
-                );
-            }
-            if !combined_output_mapping.contains_key(&gap_name) {
-                combined_output_mapping.insert(
-                    gap_name.clone(),
-                    IndexMapping {
-                        true_index: true_output.clone(),
-                        internal_index: output_indices[0].clone(),
-                    },
-                );
-            }
+        if !index_pairs.is_empty() {
+            combined_input_mapping
+                .entry(gap_name.clone())
+                .or_insert_with(Vec::new)
+                .extend(input_indices.iter().map(|index| IndexMapping {
+                    true_index: index.clone(),
+                    internal_index: index.clone(),
+                }));
+            combined_output_mapping
+                .entry(gap_name.clone())
+                .or_insert_with(Vec::new)
+                .extend(output_indices.iter().map(|index| IndexMapping {
+                    true_index: index.clone(),
+                    internal_index: index.clone(),
+                }));
         }
 
         // Create delta tensor for site indices
@@ -367,7 +362,7 @@ where
     let mpo = TreeTN::from_tensors(tensors, result_node_names)
         .context("compose_exclusive_linear_operators: failed to create TreeTN")?;
 
-    Ok(LinearOperator::new(
+    Ok(LinearOperator::new_multi(
         mpo,
         combined_input_mapping,
         combined_output_mapping,

--- a/crates/tensor4all-treetn/src/operator/linear_operator.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator.rs
@@ -69,10 +69,10 @@ where
 {
     /// The MPO with internal index IDs
     pub mpo: TreeTN<T, V>,
-    /// Input index mapping: node -> (true s_in, internal s_in_tmp)
-    pub input_mapping: HashMap<V, IndexMapping<T::Index>>,
-    /// Output index mapping: node -> (true s_out, internal s_out_tmp)
-    pub output_mapping: HashMap<V, IndexMapping<T::Index>>,
+    /// Input index mappings: node -> [(true s_in, internal s_in_tmp)].
+    pub input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
+    /// Output index mappings: node -> [(true s_out, internal s_out_tmp)].
+    pub output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
 }
 
 impl<T, V> LinearOperator<T, V>
@@ -119,6 +119,71 @@ where
         mpo: TreeTN<T, V>,
         input_mapping: HashMap<V, IndexMapping<T::Index>>,
         output_mapping: HashMap<V, IndexMapping<T::Index>>,
+    ) -> Self {
+        let input_mapping = input_mapping
+            .into_iter()
+            .map(|(node, mapping)| (node, vec![mapping]))
+            .collect();
+        let output_mapping = output_mapping
+            .into_iter()
+            .map(|(node, mapping)| (node, vec![mapping]))
+            .collect();
+        Self {
+            mpo,
+            input_mapping,
+            output_mapping,
+        }
+    }
+
+    /// Create a new LinearOperator from an MPO and possibly multiple index mappings per node.
+    ///
+    /// Use this when one tree node owns more than one external input/output
+    /// index, such as tensorized or multi-axis quantics nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `mpo` - The MPO with internal index IDs.
+    /// * `input_mapping` - Mapping from node names to all true/internal input
+    ///   index pairs for that node.
+    /// * `output_mapping` - Mapping from node names to all true/internal output
+    ///   index pairs for that node.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::collections::HashMap;
+    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
+    ///
+    /// let x = DynIndex::new_dyn(2);
+    /// let y = DynIndex::new_dyn(3);
+    /// let x_in = DynIndex::new_dyn(2);
+    /// let y_in = DynIndex::new_dyn(3);
+    /// let x_out = DynIndex::new_dyn(2);
+    /// let y_out = DynIndex::new_dyn(3);
+    /// let mpo_tensor = TensorDynLen::delta(
+    ///     &[x_in.clone(), y_in.clone()],
+    ///     &[x_out.clone(), y_out.clone()],
+    /// ).unwrap();
+    /// let mpo = TreeTN::<_, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+    ///
+    /// let mut input_mapping = HashMap::new();
+    /// input_mapping.insert(0usize, vec![
+    ///     IndexMapping { true_index: x.clone(), internal_index: x_in },
+    ///     IndexMapping { true_index: y.clone(), internal_index: y_in },
+    /// ]);
+    /// let mut output_mapping = HashMap::new();
+    /// output_mapping.insert(0usize, vec![
+    ///     IndexMapping { true_index: x, internal_index: x_out },
+    ///     IndexMapping { true_index: y, internal_index: y_out },
+    /// ]);
+    ///
+    /// let op = LinearOperator::new_multi(mpo, input_mapping, output_mapping);
+    /// assert_eq!(op.get_input_mappings(&0).unwrap().len(), 2);
+    /// ```
+    pub fn new_multi(
+        mpo: TreeTN<T, V>,
+        input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
+        output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
     ) -> Self {
         Self {
             mpo,
@@ -187,22 +252,22 @@ where
 
                         // Convention: first matching is s_in_tmp, second is s_out_tmp
                         // (This depends on how the MPO was constructed)
-                        input_mapping.insert(
-                            node.clone(),
-                            IndexMapping {
+                        input_mapping
+                            .entry(node.clone())
+                            .or_insert_with(Vec::new)
+                            .push(IndexMapping {
                                 true_index: state_idx.clone(),
                                 internal_index: matching_mpo[0].clone(),
-                            },
-                        );
+                            });
 
                         // For output, use the same true index (space(x) = space(b))
-                        output_mapping.insert(
-                            node.clone(),
-                            IndexMapping {
+                        output_mapping
+                            .entry(node.clone())
+                            .or_insert_with(Vec::new)
+                            .push(IndexMapping {
                                 true_index: state_idx.clone(),
                                 internal_index: matching_mpo[1].clone(),
-                            },
-                        );
+                            });
                     }
                 }
                 (None, None) => {
@@ -240,9 +305,11 @@ where
         // Step 1: Replace input indices in local_tensor with internal indices
         let mut transformed = local_tensor.clone();
         for node in region {
-            if let Some(mapping) = self.input_mapping.get(node) {
-                transformed =
-                    transformed.replaceind(&mapping.true_index, &mapping.internal_index)?;
+            if let Some(mappings) = self.input_mapping.get(node) {
+                for mapping in mappings {
+                    transformed =
+                        transformed.replaceind(&mapping.true_index, &mapping.internal_index)?;
+                }
             }
         }
 
@@ -273,8 +340,10 @@ where
         // Step 3: Replace output indices back to true indices
         let mut result = contracted;
         for node in region {
-            if let Some(mapping) = self.output_mapping.get(node) {
-                result = result.replaceind(&mapping.internal_index, &mapping.true_index)?;
+            if let Some(mappings) = self.output_mapping.get(node) {
+                for mapping in mappings {
+                    result = result.replaceind(&mapping.internal_index, &mapping.true_index)?;
+                }
             }
         }
 
@@ -288,12 +357,26 @@ where
 
     /// Get input mapping for a node.
     pub fn get_input_mapping(&self, node: &V) -> Option<&IndexMapping<T::Index>> {
-        self.input_mapping.get(node)
+        self.input_mapping
+            .get(node)
+            .and_then(|mappings| mappings.first())
     }
 
     /// Get output mapping for a node.
     pub fn get_output_mapping(&self, node: &V) -> Option<&IndexMapping<T::Index>> {
-        self.output_mapping.get(node)
+        self.output_mapping
+            .get(node)
+            .and_then(|mappings| mappings.first())
+    }
+
+    /// Get all input mappings for a node.
+    pub fn get_input_mappings(&self, node: &V) -> Option<&[IndexMapping<T::Index>]> {
+        self.input_mapping.get(node).map(Vec::as_slice)
+    }
+
+    /// Get all output mappings for a node.
+    pub fn get_output_mappings(&self, node: &V) -> Option<&[IndexMapping<T::Index>]> {
+        self.output_mapping.get(node).map(Vec::as_slice)
     }
 
     fn single_site_index_from_state(state: &TreeTN<T, V>, node: &V) -> Result<T::Index> {
@@ -323,9 +406,18 @@ where
         let nodes: Vec<V> = self.input_mapping.keys().cloned().collect();
         for node in nodes {
             let new_true_index = Self::single_site_index_from_state(state, &node)?;
-            let mapping = self
+            let mappings = self
                 .input_mapping
                 .get_mut(&node)
+                .ok_or_else(|| anyhow::anyhow!("Input mapping missing for node {:?}", node))?;
+            if mappings.len() != 1 {
+                return Err(anyhow::anyhow!(
+                    "Node {:?}: set_input_space_from_state only supports one input mapping per node; use explicit index binding for multi-index nodes",
+                    node
+                ));
+            }
+            let mapping = mappings
+                .first_mut()
                 .ok_or_else(|| anyhow::anyhow!("Input mapping missing for node {:?}", node))?;
             if mapping.internal_index.dim() != new_true_index.dim() {
                 return Err(anyhow::anyhow!(
@@ -347,9 +439,18 @@ where
         let nodes: Vec<V> = self.output_mapping.keys().cloned().collect();
         for node in nodes {
             let new_true_index = Self::single_site_index_from_state(state, &node)?;
-            let mapping = self
+            let mappings = self
                 .output_mapping
                 .get_mut(&node)
+                .ok_or_else(|| anyhow::anyhow!("Output mapping missing for node {:?}", node))?;
+            if mappings.len() != 1 {
+                return Err(anyhow::anyhow!(
+                    "Node {:?}: set_output_space_from_state only supports one output mapping per node; use explicit index binding for multi-index nodes",
+                    node
+                ));
+            }
+            let mapping = mappings
+                .first_mut()
                 .ok_or_else(|| anyhow::anyhow!("Output mapping missing for node {:?}", node))?;
             if mapping.internal_index.dim() != new_true_index.dim() {
                 return Err(anyhow::anyhow!(
@@ -429,8 +530,8 @@ where
     /// let mut op = LinearOperator::new(mpo, input_mapping, output_mapping);
     /// op.align_to_state(&state).unwrap();
     ///
-    /// assert!(op.input_mappings()[&0].true_index.same_id(&state_index));
-    /// assert!(op.output_mappings()[&0].true_index.same_id(&state_index));
+    /// assert!(op.get_input_mapping(&0).unwrap().true_index.same_id(&state_index));
+    /// assert!(op.get_output_mapping(&0).unwrap().true_index.same_id(&state_index));
     /// ```
     pub fn align_to_state(&mut self, state: &TreeTN<T, V>) -> Result<()> {
         self.set_input_space_from_state(state)?;
@@ -482,8 +583,8 @@ where
     /// let t = op.transpose();
     ///
     /// // Input/output mappings are swapped.
-    /// assert!(t.input_mapping[&0].true_index.same_id(&site_out));
-    /// assert!(t.output_mapping[&0].true_index.same_id(&site_in));
+    /// assert!(t.get_input_mapping(&0).unwrap().true_index.same_id(&site_out));
+    /// assert!(t.get_output_mapping(&0).unwrap().true_index.same_id(&site_in));
     /// ```
     pub fn transpose(self) -> Self {
         Self {
@@ -515,9 +616,13 @@ where
         let mut result: HashSet<T::Index> = self
             .input_mapping
             .values()
-            .map(|m| m.true_index.clone())
+            .flat_map(|mappings| mappings.iter().map(|m| m.true_index.clone()))
             .collect();
-        result.extend(self.output_mapping.values().map(|m| m.true_index.clone()));
+        result.extend(
+            self.output_mapping
+                .values()
+                .flat_map(|mappings| mappings.iter().map(|m| m.true_index.clone())),
+        );
         result
     }
 
@@ -545,7 +650,7 @@ where
     pub fn input_site_indices(&self) -> HashSet<T::Index> {
         self.input_mapping
             .values()
-            .map(|m| m.true_index.clone())
+            .flat_map(|mappings| mappings.iter().map(|m| m.true_index.clone()))
             .collect()
     }
 
@@ -553,17 +658,17 @@ where
     pub fn output_site_indices(&self) -> HashSet<T::Index> {
         self.output_mapping
             .values()
-            .map(|m| m.true_index.clone())
+            .flat_map(|mappings| mappings.iter().map(|m| m.true_index.clone()))
             .collect()
     }
 
     /// Get all input mappings.
-    pub fn input_mappings(&self) -> &HashMap<V, IndexMapping<T::Index>> {
+    pub fn input_mappings(&self) -> &HashMap<V, Vec<IndexMapping<T::Index>>> {
         &self.input_mapping
     }
 
     /// Get all output mappings.
-    pub fn output_mappings(&self) -> &HashMap<V, IndexMapping<T::Index>> {
+    pub fn output_mappings(&self) -> &HashMap<V, Vec<IndexMapping<T::Index>>> {
         &self.output_mapping
     }
 }

--- a/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
@@ -498,16 +498,16 @@ fn test_linear_operator_transpose_swaps_mappings() {
     // and vice versa.
     assert_eq!(transposed.input_mapping.len(), original_output.len());
     assert_eq!(transposed.output_mapping.len(), original_input.len());
-    let tin = transposed
-        .input_mapping
+    let tin = transposed.get_input_mapping(&"A".to_string()).unwrap();
+    let tout = transposed.get_output_mapping(&"A".to_string()).unwrap();
+    let expected_in = original_output
         .get("A")
-        .expect("transposed input mapping for A");
-    let tout = transposed
-        .output_mapping
+        .and_then(|mappings| mappings.first())
+        .unwrap();
+    let expected_out = original_input
         .get("A")
-        .expect("transposed output mapping for A");
-    let expected_in = original_output.get("A").unwrap();
-    let expected_out = original_input.get("A").unwrap();
+        .and_then(|mappings| mappings.first())
+        .unwrap();
     assert!(tin.true_index.same_id(&expected_in.true_index));
     assert!(tin.internal_index.same_id(&expected_in.internal_index));
     assert!(tout.true_index.same_id(&expected_out.true_index));
@@ -526,10 +526,16 @@ fn test_linear_operator_transpose_is_involutive() {
     // Double transpose == identity on mappings.
     assert_eq!(round_trip.input_mapping.len(), original_input.len());
     assert_eq!(round_trip.output_mapping.len(), original_output.len());
-    let rin = round_trip.input_mapping.get("A").unwrap();
-    let rout = round_trip.output_mapping.get("A").unwrap();
-    let ein = original_input.get("A").unwrap();
-    let eout = original_output.get("A").unwrap();
+    let rin = round_trip.get_input_mapping(&"A".to_string()).unwrap();
+    let rout = round_trip.get_output_mapping(&"A".to_string()).unwrap();
+    let ein = original_input
+        .get("A")
+        .and_then(|mappings| mappings.first())
+        .unwrap();
+    let eout = original_output
+        .get("A")
+        .and_then(|mappings| mappings.first())
+        .unwrap();
     assert!(rin.true_index.same_id(&ein.true_index));
     assert!(rin.internal_index.same_id(&ein.internal_index));
     assert!(rout.true_index.same_id(&eout.true_index));

--- a/crates/tensor4all-treetn/src/operator/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/mod.rs
@@ -32,7 +32,11 @@ mod identity;
 mod index_mapping;
 mod linear_operator;
 
-pub use apply::{apply_linear_operator, ApplyOptions, ArcLinearOperator};
+pub use apply::{
+    apply_linear_operator, apply_linear_operator_to_indices,
+    apply_linear_operator_to_numbered_tags, bind_linear_operator_indices, ApplyOptions,
+    ArcLinearOperator,
+};
 pub use compose::{are_exclusive_operators, compose_exclusive_linear_operators};
 pub use identity::build_identity_operator_tensor;
 pub use index_mapping::IndexMapping;

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -57,7 +57,10 @@ pub use localupdate::{
 };
 
 // Re-export partial contraction types
-pub use partial_contraction::{partial_contract, PartialContractionSpec};
+pub use partial_contraction::{
+    hadamard, partial_contract, sum_over_indices, weighted_sum_over_index_pairs,
+    PartialContractionSpec,
+};
 
 // Re-export swap types
 pub use swap::{ScheduledSwapStep, SwapOptions, SwapSchedule};

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -13,6 +13,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use super::contraction::{contract, ContractionOptions};
 use super::decompose::{factorize_tensor_to_treetn_with, TreeTopology};
 use super::TreeTN;
+use crate::error::{format_anyhow_error, SelectedIndexContractionError};
 use tensor4all_core::{
     AllowedPairs, AnyScalar, DynIndex, FactorizeAlg, FactorizeOptions, IndexLike, TensorDynLen,
     TensorIndex, TensorLike,
@@ -705,6 +706,275 @@ where
     } else {
         Ok(result)
     }
+}
+
+/// Multiply two TreeTNs elementwise along selected external index pairs.
+///
+/// This is a convenience wrapper around [`partial_contract`] using diagonal
+/// pairs. For each `(left_index, right_index)` pair, only matching coordinates
+/// contribute and the left index remains in the result.
+///
+/// # Arguments
+/// * `left` - Left operand. Paired left indices are preserved in the output.
+/// * `right` - Right operand. Paired right indices are matched diagonally.
+/// * `index_pairs` - External index pairs with equal dimensions.
+/// * `center` - Canonical center node for the result.
+/// * `options` - Contraction algorithm options.
+///
+/// # Returns
+/// A TreeTN representing the selected-index Hadamard product.
+///
+/// # Errors
+/// Returns an error if a pair has mismatched dimensions, references a
+/// non-external index, or the underlying contraction fails.
+///
+/// # Examples
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_treetn::{contraction::ContractionOptions, hadamard, TreeTN};
+///
+/// let i = DynIndex::new_dyn(2);
+/// let j = DynIndex::new_dyn(2);
+/// let left = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![i.clone()], vec![2.0, 3.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+/// let right = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![j.clone()], vec![5.0, 7.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+///
+/// let result = hadamard(&left, &right, &[(i.clone(), j)], &0, ContractionOptions::default()).unwrap();
+/// let dense = result.to_dense().unwrap();
+/// assert_eq!(dense.external_indices(), vec![i]);
+/// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![10.0, 21.0]);
+/// ```
+pub fn hadamard<V>(
+    left: &TreeTN<TensorDynLen, V>,
+    right: &TreeTN<TensorDynLen, V>,
+    index_pairs: &[(DynIndex, DynIndex)],
+    center: &V,
+    options: ContractionOptions,
+) -> std::result::Result<TreeTN<TensorDynLen, V>, SelectedIndexContractionError>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
+    <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
+{
+    let spec = PartialContractionSpec {
+        contract_pairs: Vec::new(),
+        diagonal_pairs: index_pairs.to_vec(),
+        output_order: None,
+    };
+    partial_contract(left, right, &spec, center, options).map_err(|error| {
+        SelectedIndexContractionError::PartialContractFailed {
+            message: format_anyhow_error(error),
+        }
+    })
+}
+
+/// Sum over selected external index pairs with a weight TreeTN.
+///
+/// This contracts each `(state_index, weight_index)` pair and leaves all
+/// unpaired state and weight indices external.
+///
+/// # Arguments
+/// * `state` - Left operand whose selected indices are summed over.
+/// * `weights` - Right operand providing weights for the selected coordinates.
+/// * `index_pairs` - External index pairs to contract.
+/// * `center` - Canonical center node for the result.
+/// * `options` - Contraction algorithm options.
+///
+/// # Returns
+/// A TreeTN after summing over all selected pairs.
+///
+/// # Errors
+/// Returns an error if a pair has mismatched dimensions, references a
+/// non-external index, or the underlying contraction fails.
+///
+/// # Examples
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_treetn::{
+///     contraction::ContractionOptions,
+///     weighted_sum_over_index_pairs,
+///     TreeTN,
+/// };
+///
+/// let x = DynIndex::new_dyn(2);
+/// let z = DynIndex::new_dyn(2);
+/// let wz = DynIndex::new_dyn(2);
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![x.clone(), z.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+/// let weights = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![wz.clone()], vec![10.0, 100.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+///
+/// let result = weighted_sum_over_index_pairs(
+///     &state,
+///     &weights,
+///     &[(z, wz)],
+///     &0,
+///     ContractionOptions::default(),
+/// ).unwrap();
+/// let dense = result.to_dense().unwrap();
+/// assert_eq!(dense.external_indices(), vec![x]);
+/// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![310.0, 420.0]);
+/// ```
+pub fn weighted_sum_over_index_pairs<V>(
+    state: &TreeTN<TensorDynLen, V>,
+    weights: &TreeTN<TensorDynLen, V>,
+    index_pairs: &[(DynIndex, DynIndex)],
+    center: &V,
+    options: ContractionOptions,
+) -> std::result::Result<TreeTN<TensorDynLen, V>, SelectedIndexContractionError>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
+    <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
+{
+    let spec = PartialContractionSpec {
+        contract_pairs: index_pairs.to_vec(),
+        diagonal_pairs: Vec::new(),
+        output_order: None,
+    };
+    partial_contract(state, weights, &spec, center, options).map_err(|error| {
+        SelectedIndexContractionError::PartialContractFailed {
+            message: format_anyhow_error(error),
+        }
+    })
+}
+
+/// Sum a TreeTN over selected external indices using factorized unit weights.
+///
+/// This constructs an all-ones weight TreeTN on the same topology as `state`
+/// and delegates to [`weighted_sum_over_index_pairs`].
+///
+/// # Arguments
+/// * `state` - Input TreeTN.
+/// * `sum_indices` - External indices of `state` to sum over. Each index must
+///   be present exactly once in the list.
+/// * `center` - Canonical center node for the result.
+/// * `options` - Contraction algorithm options.
+///
+/// # Returns
+/// A TreeTN with `sum_indices` contracted away. If `sum_indices` is empty, this
+/// returns `state.clone()`.
+///
+/// # Errors
+/// Returns an error if an index is duplicated, is not external to `state`, or
+/// the underlying contraction fails.
+///
+/// # Examples
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_treetn::{contraction::ContractionOptions, sum_over_indices, TreeTN};
+///
+/// let x = DynIndex::new_dyn(2);
+/// let z = DynIndex::new_dyn(2);
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(
+///     vec![TensorDynLen::from_dense(vec![x.clone(), z.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap()],
+///     vec![0],
+/// ).unwrap();
+///
+/// let result = sum_over_indices(&state, &[z], &0, ContractionOptions::default()).unwrap();
+/// let dense = result.to_dense().unwrap();
+/// assert_eq!(dense.external_indices(), vec![x]);
+/// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![4.0, 6.0]);
+/// ```
+pub fn sum_over_indices<V>(
+    state: &TreeTN<TensorDynLen, V>,
+    sum_indices: &[DynIndex],
+    center: &V,
+    options: ContractionOptions,
+) -> std::result::Result<TreeTN<TensorDynLen, V>, SelectedIndexContractionError>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
+    <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
+{
+    if sum_indices.is_empty() {
+        return Ok(state.clone());
+    }
+
+    let mut seen = HashSet::new();
+    for index in sum_indices {
+        if !seen.insert(index.clone()) {
+            return Err(SelectedIndexContractionError::DuplicateIndex {
+                index: format!("{index:?}"),
+            });
+        }
+    }
+
+    let mut node_names = state.node_names();
+    node_names.sort();
+
+    let mut state_index_to_node: HashMap<DynIndex, V> = HashMap::new();
+    for node in &node_names {
+        let Some(site_space) = state.site_space(node) else {
+            continue;
+        };
+        for index in site_space {
+            if seen.contains(index)
+                && state_index_to_node
+                    .insert(index.clone(), node.clone())
+                    .is_some()
+            {
+                return Err(SelectedIndexContractionError::IndexInMultipleSiteSpaces {
+                    index: format!("{index:?}"),
+                });
+            }
+        }
+    }
+
+    let mut weight_indices_by_node: HashMap<V, Vec<DynIndex>> = HashMap::new();
+    let mut index_pairs = Vec::with_capacity(sum_indices.len());
+    for index in sum_indices {
+        let node = state_index_to_node.get(index).ok_or_else(|| {
+            SelectedIndexContractionError::IndexNotFound {
+                index: format!("{index:?}"),
+            }
+        })?;
+        let weight_index = index.sim();
+        weight_indices_by_node
+            .entry(node.clone())
+            .or_default()
+            .push(weight_index.clone());
+        index_pairs.push((index.clone(), weight_index));
+    }
+
+    let mut link_indices_by_node: HashMap<V, Vec<DynIndex>> = HashMap::new();
+    let mut edges: Vec<_> = state.site_index_network().edges().collect();
+    edges.sort();
+    for (left, right) in edges {
+        let link = DynIndex::new_dyn(1);
+        link_indices_by_node
+            .entry(left.clone())
+            .or_default()
+            .push(link.clone());
+        link_indices_by_node.entry(right).or_default().push(link);
+    }
+
+    let mut tensors = Vec::with_capacity(node_names.len());
+    for node in &node_names {
+        let mut indices = weight_indices_by_node.remove(node).unwrap_or_default();
+        if let Some(mut links) = link_indices_by_node.remove(node) {
+            indices.append(&mut links);
+        }
+        tensors.push(TensorDynLen::ones(&indices).map_err(|error| {
+            SelectedIndexContractionError::BuildOnesTensor {
+                node: format!("{node:?}"),
+                message: format_anyhow_error(error),
+            }
+        })?);
+    }
+
+    let weights = TreeTN::from_tensors(tensors, node_names).map_err(|error| {
+        SelectedIndexContractionError::BuildWeightsTree {
+            message: format_anyhow_error(error),
+        }
+    })?;
+    weighted_sum_over_index_pairs(state, &weights, &index_pairs, center, options)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::treetn::contraction::{ContractionMethod, ContractionOptions};
-use crate::{factorize_tensor_to_treetn, TreeTopology};
+use crate::{factorize_tensor_to_treetn, SelectedIndexContractionError, TreeTopology};
 use num_complex::Complex64;
 use tensor4all_core::{DynIndex, TensorDynLen};
 
@@ -76,6 +76,130 @@ fn test_partial_contraction_spec_creation() {
     };
     assert_eq!(spec.contract_pairs.len(), 1);
     assert!(spec.diagonal_pairs.is_empty());
+}
+
+#[test]
+fn hadamard_multiplies_paired_external_indices() {
+    let left_index = DynIndex::new_dyn(2);
+    let right_index = DynIndex::new_dyn(2);
+    let lhs = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(vec![left_index.clone()], vec![2.0, 3.0]).unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+    let rhs = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(vec![right_index.clone()], vec![5.0, 7.0]).unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+
+    let result = hadamard(
+        &lhs,
+        &rhs,
+        &[(left_index.clone(), right_index)],
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap();
+
+    let dense = result.to_dense().unwrap();
+    assert_eq!(dense.external_indices(), vec![left_index]);
+    assert_eq!(dense.to_vec::<f64>().unwrap(), vec![10.0, 21.0]);
+}
+
+#[test]
+fn weighted_sum_over_index_pairs_contracts_only_selected_axes() {
+    let x = DynIndex::new_dyn(2);
+    let z = DynIndex::new_dyn(3);
+    let wz = DynIndex::new_dyn(3);
+    let state = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(
+            vec![x.clone(), z.clone()],
+            vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0],
+        )
+        .unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+    let weights = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(vec![wz.clone()], vec![2.0, 3.0, 5.0]).unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+
+    let result = weighted_sum_over_index_pairs(
+        &state,
+        &weights,
+        &[(z, wz)],
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap();
+
+    let dense = result.to_dense().unwrap();
+    assert_eq!(dense.external_indices(), vec![x]);
+    assert_eq!(dense.to_vec::<f64>().unwrap(), vec![130.0, 140.0]);
+}
+
+#[test]
+fn sum_over_indices_uses_factorized_ones_weights() {
+    let x = DynIndex::new_dyn(2);
+    let z = DynIndex::new_dyn(3);
+    let state = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(
+            vec![x.clone(), z.clone()],
+            vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0],
+        )
+        .unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+
+    let result = sum_over_indices(
+        &state,
+        std::slice::from_ref(&z),
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap();
+
+    let dense = result.to_dense().unwrap();
+    assert_eq!(dense.external_indices(), vec![x]);
+    assert_eq!(dense.to_vec::<f64>().unwrap(), vec![30.0, 33.0]);
+}
+
+#[test]
+fn sum_over_indices_reports_typed_selection_errors() {
+    let x = DynIndex::new_dyn(2);
+    let state = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![TensorDynLen::from_dense(vec![x.clone()], vec![1.0, 2.0]).unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+
+    let duplicate = sum_over_indices(
+        &state,
+        &[x.clone(), x],
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        duplicate,
+        SelectedIndexContractionError::DuplicateIndex { .. }
+    ));
+
+    let missing = sum_over_indices(
+        &state,
+        &[DynIndex::new_dyn(2)],
+        &"A".to_string(),
+        ContractionOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        missing,
+        SelectedIndexContractionError::IndexNotFound { .. }
+    ));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/tensor_like.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like.rs
@@ -29,6 +29,8 @@ use tensor4all_core::{
     DynIndex, IndexLike, LinearizationOrder, TensorDynLen, TensorIndex, TensorLike,
 };
 
+use crate::error::NumberedTagSelectionError;
+
 use super::TreeTN;
 
 // ============================================================================
@@ -189,6 +191,117 @@ where
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
 {
+    /// Return external indices whose tag set contains `tag`.
+    ///
+    /// This filters only site/external indices; internal link indices are not
+    /// considered. The tag is matched exactly against one tag entry, so
+    /// `"k"` and `"k=1"` are different tags.
+    ///
+    /// # Arguments
+    /// * `tag` - Exact tag to match, such as `"x"` or `"k=1"`.
+    ///
+    /// # Returns
+    /// A vector of matching external indices. Multiple matches are allowed and
+    /// an empty vector means no external index has the requested tag.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::{DynIndex, TagSet, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let x = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,x").unwrap());
+    /// let y = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,y").unwrap());
+    /// let tensor = TensorDynLen::from_dense(vec![x.clone(), y], vec![0.0; 4]).unwrap();
+    /// let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    ///
+    /// assert_eq!(tn.external_indices_with_tag("x"), vec![x]);
+    /// assert!(tn.external_indices_with_tag("missing").is_empty());
+    /// ```
+    pub fn external_indices_with_tag(&self, tag: &str) -> Vec<DynIndex> {
+        self.external_indices()
+            .into_iter()
+            .filter(|index| index.tags().has_tag(tag))
+            .collect()
+    }
+
+    /// Return external indices matching numbered tags in an explicit range.
+    ///
+    /// For `tag_prefix = "k"`, `start_index = 1`, and `count = 3`, this
+    /// looks for exactly one external index with each of the tags `"k=1"`,
+    /// `"k=2"`, and `"k=3"`, and returns them in that numeric order.
+    ///
+    /// # Arguments
+    /// * `tag_prefix` - Prefix before the equals sign, such as `"k"` or `"x"`.
+    ///   It must not contain `=`.
+    /// * `start_index` - First numeric suffix to request. Use `1` for the
+    ///   usual quantics convention, or `0` for zero-based tags.
+    /// * `count` - Number of consecutive tags to request. `0` returns an
+    ///   empty vector.
+    ///
+    /// # Returns
+    /// The matching external indices ordered as `tag_prefix=start_index`,
+    /// `tag_prefix=start_index+1`, and so on.
+    ///
+    /// # Errors
+    /// Returns an error if `tag_prefix` contains `=`, if any requested numbered
+    /// tag is absent, if a requested numbered tag matches more than one
+    /// external index, or if `start_index + count` overflows `usize`.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::{DynIndex, TagSet, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let k1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+    /// let k2 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
+    /// let tensor = TensorDynLen::from_dense(vec![k2.clone(), k1.clone()], vec![0.0; 4]).unwrap();
+    /// let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    ///
+    /// let indices = tn.external_indices_with_numbered_tag("k", 1, 2).unwrap();
+    /// assert_eq!(indices, vec![k1, k2]);
+    /// ```
+    pub fn external_indices_with_numbered_tag(
+        &self,
+        tag_prefix: &str,
+        start_index: usize,
+        count: usize,
+    ) -> std::result::Result<Vec<DynIndex>, NumberedTagSelectionError> {
+        if tag_prefix.contains('=') {
+            return Err(NumberedTagSelectionError::InvalidPrefix {
+                tag_prefix: tag_prefix.to_string(),
+            });
+        }
+
+        let external_indices = self.external_indices();
+        let mut result = Vec::with_capacity(count);
+        for offset in 0..count {
+            let tag_number = start_index.checked_add(offset).ok_or(
+                NumberedTagSelectionError::RangeOverflow {
+                    start_index,
+                    offset,
+                },
+            )?;
+            let numbered_tag = format!("{tag_prefix}={tag_number}");
+            let mut matches = external_indices
+                .iter()
+                .filter(|index| index.tags().has_tag(&numbered_tag))
+                .cloned();
+            let first = matches.next();
+            let second = matches.next();
+
+            match (first, second) {
+                (None, _) => {
+                    return Err(NumberedTagSelectionError::MissingTag { tag: numbered_tag });
+                }
+                (Some(index), None) => result.push(index),
+                (Some(_), Some(_)) => {
+                    return Err(NumberedTagSelectionError::AmbiguousTag { tag: numbered_tag });
+                }
+            }
+        }
+        Ok(result)
+    }
+
     /// Replace one site index with multiple site indices using an exact reshape.
     ///
     /// This is a TreeTN-level wrapper around [`TensorDynLen::unfuse_index`].

--- a/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
@@ -1,6 +1,7 @@
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IndexLike, TagSet, TensorDynLen, TensorIndex};
 
 use crate::treetn::TreeTN;
+use crate::NumberedTagSelectionError;
 
 /// Helper to create a simple 2-node TreeTN: A -- bond -- B
 fn make_two_node_treetn() -> (
@@ -60,6 +61,114 @@ fn test_num_external_indices_single_node() {
     let t = TensorDynLen::from_dense(vec![i.clone(), j.clone(), k.clone()], vec![0.0; 24]).unwrap();
     let tn = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
     assert_eq!(tn.num_external_indices(), 3);
+}
+
+#[test]
+fn test_external_indices_with_tag_filters_site_indices() {
+    let x = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,x").unwrap());
+    let y = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,y").unwrap());
+    let bond = DynIndex::new_dyn(3);
+    let t0 = TensorDynLen::from_dense(
+        vec![x.clone(), bond.clone()],
+        vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(vec![bond, y.clone()], vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        .unwrap();
+    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![t0, t1],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+
+    assert_eq!(tn.external_indices_with_tag("x"), vec![x]);
+    assert_eq!(
+        tn.external_indices_with_tag("missing"),
+        Vec::<DynIndex>::new()
+    );
+}
+
+#[test]
+fn test_external_indices_with_numbered_tag_uses_explicit_range() {
+    let k2 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
+    let k3 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=3").unwrap());
+    let x1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,x=1").unwrap());
+    let tensor = TensorDynLen::from_dense(vec![x1, k3.clone(), k2.clone()], vec![0.0; 8]).unwrap();
+    let tn =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+
+    let indices = tn.external_indices_with_numbered_tag("k", 2, 2).unwrap();
+
+    assert_eq!(indices, vec![k2, k3]);
+}
+
+#[test]
+fn test_external_indices_with_numbered_tag_keeps_same_id_tags_distinct() {
+    let base = DynIndex::new_dyn(2);
+    let k1 = DynIndex::new_with_tags(*base.id(), 2, TagSet::from_str("Qubit,k=1").unwrap());
+    let other = DynIndex::new_with_tags(*base.id(), 2, TagSet::from_str("Qubit,other").unwrap());
+    let tensor = TensorDynLen::from_dense(vec![other, k1.clone()], vec![0.0; 4]).unwrap();
+    let tn =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+
+    assert_eq!(tn.external_indices_with_tag("k=1"), vec![k1.clone()]);
+    assert_eq!(
+        tn.external_indices_with_numbered_tag("k", 1, 1).unwrap(),
+        vec![k1]
+    );
+}
+
+#[test]
+fn test_external_indices_with_numbered_tag_rejects_missing_number() {
+    let k2 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
+    let k4 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=4").unwrap());
+    let tensor = TensorDynLen::from_dense(vec![k2, k4], vec![0.0; 4]).unwrap();
+    let tn =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+
+    let err = tn
+        .external_indices_with_numbered_tag("k", 2, 3)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        NumberedTagSelectionError::MissingTag { ref tag } if tag == "k=3"
+    ));
+}
+
+#[test]
+fn test_external_indices_with_numbered_tag_rejects_duplicate_number() {
+    let k1_left = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+    let k1_right = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+    let tensor = TensorDynLen::from_dense(vec![k1_left, k1_right], vec![0.0; 4]).unwrap();
+    let tn =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+
+    let err = tn
+        .external_indices_with_numbered_tag("k", 1, 1)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        NumberedTagSelectionError::AmbiguousTag { ref tag } if tag == "k=1"
+    ));
+}
+
+#[test]
+fn test_external_indices_with_numbered_tag_rejects_prefix_with_equals() {
+    let k1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
+    let tensor = TensorDynLen::from_dense(vec![k1], vec![0.0; 2]).unwrap();
+    let tn =
+        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+
+    let err = tn
+        .external_indices_with_numbered_tag("k=1", 1, 1)
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        NumberedTagSelectionError::InvalidPrefix { ref tag_prefix } if tag_prefix == "k=1"
+    ));
 }
 
 #[test]

--- a/docs/book/src/guides/quantics.md
+++ b/docs/book/src/guides/quantics.md
@@ -115,8 +115,11 @@ assert_eq!(affine_op.mpo.node_count(), r);
 ### Index Mapping Flow
 
 Operators define abstract *input* and *output* indices labeled `0, 1, ..., r-1`.
-To apply an operator, replace the tensor network's site indices with the
-operator's input indices using `replaceind`, then call `apply_linear_operator`.
+To apply an operator, bind those abstract indices to the concrete site indices
+of the target state, then call `apply_linear_operator`. When the target
+TreeTN's quantics sites are tagged as `x=1`, `x=2`, ..., use
+`apply_linear_operator_to_numbered_tags`; otherwise use explicit index binding
+with `apply_linear_operator_to_indices`.
 
 ```text
 Original TreeTN          Operator            Result TreeTN

--- a/docs/book/src/tutorials/computations-with-qtt/partial-fourier2d.md
+++ b/docs/book/src/tutorials/computations-with-qtt/partial-fourier2d.md
@@ -61,6 +61,7 @@ operator to the state, and applies it. Passing `None` for `initial_pivots` is
 the best starting point for tutorial code because it keeps QTCI on its default
 initialization path. Explicit pivot lists are a later tuning tool for cases
 where you already know important grid points.
+Use `apply_linear_operator_to_numbered_tags` if and only if numbered tags such as `x=1`, `x=2`, ... are the intended operator binding.
 
 ## What It Computes
 

--- a/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
+++ b/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
@@ -313,17 +313,17 @@ fn expand_operator_to_interleaved_state(
 
         input_mapping.insert(
             t_node,
-            IndexMapping {
+            vec![IndexMapping {
                 true_index: true_site.clone(),
                 internal_index: input_internal,
-            },
+            }],
         );
         output_mapping.insert(
             t_node,
-            IndexMapping {
+            vec![IndexMapping {
                 true_index: true_site,
                 internal_index: output_internal,
-            },
+            }],
         );
         tensors_by_node.insert(t_node, identity);
     }
@@ -395,7 +395,11 @@ fn expand_operator_to_interleaved_state(
         .collect::<Result<Vec<_>, _>>()?;
     let mpo = TreeTN::from_tensors(tensors, node_names)?;
 
-    Ok(LinearOperator::new(mpo, input_mapping, output_mapping))
+    Ok(LinearOperator::new_multi(
+        mpo,
+        input_mapping,
+        output_mapping,
+    ))
 }
 
 pub fn transform_x_dimension(


### PR DESCRIPTION
## Summary
- Add generic TreeTN helpers for resolving external indices by exact tags and numbered tags.
- Add shared operator binding/application APIs for explicit indices and numbered tags, avoiding per-operation `*_on_indices` wrappers.
- Extend `LinearOperator` mappings to support multi-index operator nodes and update docs/tutorial wording for the tag-binding flow.

## Tests
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --release -p tensor4all-treetn numbered_tags -- --nocapture`
- `cargo test --release -p tensor4all-quanticstransform operator_creation -- --nocapture`
- `cargo test --release -p tensor4all-treetn test_linear_operator_replaceinds -- --nocapture`
- `cargo test --doc --release -p tensor4all-treetn -p tensor4all-quanticstransform`
- `cargo nextest run --release --workspace`
- `cargo doc --workspace --no-deps`
- `./scripts/test-mdbook.sh`