### PR TITLE
Port tensor4all-aci elementwise API and benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/tensor4all-aci",
     "crates/tensor4all-tensorbackend",
     "crates/tensor4all-core",
     "crates/tensor4all-treetn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "6283c6f1a8a56f920a2600f6c27e9e6ade28beed", default-features = false }
-tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "6283c6f1a8a56f920a2600f6c27e9e6ade28beed" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "6283c6f1a8a56f920a2600f6c27e9e6ade28beed", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "6283c6f1a8a56f920a2600f6c27e9e6ade28beed", default-features = false }
+tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f07a3a08dd188ea5a726a43c6b53de5d417eb0a6", default-features = false }
+tenferro-device = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f07a3a08dd188ea5a726a43c6b53de5d417eb0a6" }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f07a3a08dd188ea5a726a43c6b53de5d417eb0a6", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f07a3a08dd188ea5a726a43c6b53de5d417eb0a6", default-features = false }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ validated in CI. Longer runnable examples live in the
 |-------|-------------|
 | [tensor4all-core](crates/tensor4all-core/) | Core types: Index, Tensor, contraction, SVD, QR |
 | [tensor4all-simplett](crates/tensor4all-simplett/) | Simple TT/MPS with compression |
+| [tensor4all-aci](crates/tensor4all-aci/) | Alternating Cross Interpolation for elementwise tensor train operations |
 | [tensor4all-itensorlike](crates/tensor4all-itensorlike/) | ITensors.jl-like TensorTrain API |
 | [tensor4all-treetn](crates/tensor4all-treetn/) | Tree tensor networks with arbitrary topology |
 | [tensor4all-tensorci](crates/tensor4all-tensorci/) | Tensor Cross Interpolation (TCI2) |

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -155,6 +155,11 @@
 - Dense flat-buffer APIs use column-major linearization. New public flat-buffer
   constructors, exports, examples, FFI contracts, and docs must state or
   preserve column-major semantics.
+- In hot dense loops over `Matrix`, validate shapes and ranges once, then
+  iterate over column-major slices such as `as_col_major_slice()` or
+  `as_col_major_mut_slice()`. If bounds-check removal needs `unsafe`, keep it
+  inside small helper functions with explicit safety comments rather than
+  scattering unchecked indexing through algorithm code.
 - Do not add row-major compatibility shims or hidden row-major round-trips in
   library code. When an external dependency or test fixture naturally provides
   row-shaped data, convert at that explicit boundary and keep the conversion

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -145,6 +145,10 @@
 - Use high-level APIs. If downstream code needs low-level access, add or refine
   the appropriate high-level API rather than exposing or reaching into internal
   details.
+- When the same scalar-specific implementation is needed for several Rust
+  scalar types, use a generic helper or a macro-generated implementation rather
+  than copy-pasting per-type code. This includes typed tensor conversion
+  wrappers such as `TypedTensor<T>` to dynamic tensor variants.
 
 ## Dense Layout And Linear Algebra
 
@@ -162,6 +166,15 @@
   `tensor4all-tensorbackend` route for SVD, QR, einsum, and dense tensor
   linear algebra. Do not reimplement these algorithms locally in feature
   crates.
+- Do not write hand-rolled dense matrix kernels in feature crates. In
+  particular, local GEMM, triangular solve, LU/QR/SVD, or pivot-block solve
+  loops must use `tensor4all-tensorbackend` wrappers instead of custom
+  arithmetic kernels.
+- Do not form explicit inverses of pivot blocks in MatrixLUCI, cross
+  interpolation, tensor-network compression, or related factor construction.
+  Pivot systems such as `A[:, J] * A[I, J]^{-1}` and
+  `A[I, J]^{-1} * A[I, :]` must be implemented with linear solves, triangular
+  solves, or equivalent numerically stable solve-based formulations.
 - Do not instantiate `CpuBackend` directly outside
   `tensor4all-tensorbackend`. Use `tensor4all-tensorbackend` wrappers or
   `with_default_backend` so tenferro CPU execution uses the repository's shared

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,9 +4,17 @@ This directory contains benchmark code for comparing Rust and Julia implementati
 
 ## Structure
 
-- `rust/`: Rust benchmark code using `tensor4all-rs`
-- `julia/`: Julia benchmark code using `ITensors.jl` and `ITensorMPS.jl`
-- `results/`: saved benchmark commands and representative local outputs
+- `rust/`: shared Rust benchmark bodies. Prefer putting reusable benchmark
+  source here, then include it from a thin crate example.
+- `julia/`: Julia benchmark code using `ITensors.jl`, `ITensorMPS.jl`, or
+  `AlternatingCrossInterpolation.jl`.
+- `results/`: saved benchmark commands and representative local outputs.
+- Crate-local `benches/`: Criterion microbenchmarks that are useful for Rust
+  regression tracking but not meant as the cross-language source of truth.
+
+Use ignored unit tests only when the benchmark needs crate-private state or
+instrumentation. Once the required hooks can be exposed cleanly, move the
+runner body into `benchmarks/rust/` and keep the crate-local entry point thin.
 
 ## Running Benchmarks
 
@@ -47,6 +55,42 @@ ACI elementwise TT chi scaling:
 RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- --sample-size 10
 ```
 
+For Julia parity runs on macOS/Homebrew, build Rust against the same system
+OpenBLAS backend instead of the default faer backend:
+
+```bash
+OPENBLAS_ROOT=${OPENBLAS_ROOT:-$(brew --prefix openblas)}
+env \
+RUSTFLAGS="-L native=${OPENBLAS_ROOT}/lib -l dylib=openblas" \
+DYLD_LIBRARY_PATH="${OPENBLAS_ROOT}/lib:${DYLD_LIBRARY_PATH:-}" \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+cargo bench -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas \
+  --bench elementwise_scaling -- --sample-size 10
+```
+
+ACI local-step bucket timing with system OpenBLAS:
+
+```bash
+OPENBLAS_ROOT=${OPENBLAS_ROOT:-$(brew --prefix openblas)}
+env \
+RUSTFLAGS="-L native=${OPENBLAS_ROOT}/lib -l dylib=openblas" \
+DYLD_LIBRARY_PATH="${OPENBLAS_ROOT}/lib:${DYLD_LIBRARY_PATH:-}" \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 T4A_STEP_TIMING_N_SITES=16 \
+T4A_STEP_TIMING_FIXED_SWEEPS=3 \
+T4A_STEP_TIMING_CHIS=16,32,64,128 \
+cargo test --release -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas \
+  local_update_step_timing -- --ignored --nocapture
+```
+
+When running Rust doctests with `tenferro-system-blas`, also set
+`RUSTDOCFLAGS="-L native=${OPENBLAS_ROOT}/lib"`. `RUSTFLAGS` is not enough for
+rustdoc's final link step.
+
 Optional long `chi = 32` case:
 
 ```bash
@@ -56,10 +100,30 @@ RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling --
 MatrixLUCI Hilbert step timing:
 
 ```bash
-RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+OPENBLAS_ROOT=${OPENBLAS_ROOT:-$(brew --prefix openblas)}
+env \
+RUSTFLAGS="-L native=${OPENBLAS_ROOT}/lib -l dylib=openblas" \
+DYLD_LIBRARY_PATH="${OPENBLAS_ROOT}/lib:${DYLD_LIBRARY_PATH:-}" \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
 T4A_MATRIX_LUCI_REPEATS=20 T4A_MATRIX_LUCI_SIZES=16,32,64 \
-cargo test --release -p tensor4all-tcicore matrix_luci_hilbert_timing -- --ignored --nocapture
+cargo test --release -p tensor4all-tcicore \
+  --no-default-features --features tenferro-system-blas \
+  matrix_luci_hilbert_timing -- --ignored --nocapture
 ```
+
+MatrixLU standalone Hilbert timing:
+
+```bash
+env \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LU_REPEATS=20 T4A_MATRIX_LU_SIZES=16,32,64,128 \
+cargo run --release -p tensor4all-tcicore --example benchmark_matrix_lu
+```
+
+MatrixLU itself does not call BLAS, so no system-BLAS feature is required for
+this standalone runner.
 
 Inspect Julia-dumped local linsolve inputs:
 
@@ -104,12 +168,28 @@ ACI elementwise TT chi scaling:
 BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_aci_elementwise.jl --chis 2,4,8,16
 ```
 
+ACI local-step bucket timing:
+
+```bash
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 \
+julia benchmarks/julia/benchmark_aci_local_steps.jl --sites 16 --fixed-sweeps 3 --chis 16,32,64,128
+```
+
 MatrixLUCI Hilbert step timing:
 
 ```bash
 JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
 T4A_MATRIX_LUCI_REPEATS=20 \
 julia benchmarks/julia/benchmark_matrix_luci.jl --sizes 16,32,64
+```
+
+MatrixLU standalone Hilbert timing:
+
+```bash
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LU_REPEATS=20 \
+julia benchmarks/julia/benchmark_matrix_lu.jl --sizes 16,32,64,128
 ```
 
 Dump local linsolve inputs as ITensorMPS-compatible HDF5:
@@ -162,11 +242,22 @@ the inputs and initial guess. The default smoke run covers `chi = 2, 4, 8, 16`.
 `aci_elementwise_chi_scaling_long` Criterion filter, and Julia can run the same
 long case with `--chis 2,4,8,16,32`.
 
+The ACI local-step benchmark isolates the local update buckets inside
+elementwise ACI. Use `T4A_STEP_TIMING_N_SITES=16` and fixed sweeps when checking
+`chi <= 128`; the old default `L = 12` has a central exact-rank bound of only
+`64` for `local_dim = 2`, so it clamps `chi = 128`.
+
 The MatrixLUCI Hilbert benchmarks isolate the matrix cross-interpolation step
 used inside ACI local updates. They print CSV-style timing buckets for rrLU
 pivot selection and factor construction on deterministic Hilbert matrices, with
 both left- and right-orthogonal variants. Keep these benchmarks out of normal
 test runs by using the ignored Rust test and the standalone Julia script.
+
+The MatrixLU standalone Hilbert benchmarks isolate `rrlu_inplace` and `rrlu`
+without MatrixLUCI factor wrappers. The Rust source of truth is
+`benchmarks/rust/benchmark_matrix_lu.rs`, included by
+`tensor4all-tcicore/examples/benchmark_matrix_lu.rs`; the Julia counterpart is
+`benchmarks/julia/benchmark_matrix_lu.jl`.
 
 `dump_local_linsolve_inputs.jl` writes the prepared local operator as
 `operator_as_mps`, plus `rhs` and `init`, in one HDF5 file. The operator is a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -41,6 +41,18 @@ TensorTrain-level operations against ITensorMPS:
 RAYON_NUM_THREADS=1 cargo run -p tensor4all-itensorlike --example benchmark_tt_ops --release -- --L 32 --zipup-L 10 --chis 4,8,16,32,64
 ```
 
+ACI elementwise TT chi scaling:
+
+```bash
+RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- --sample-size 10
+```
+
+Optional long `chi = 32` case:
+
+```bash
+RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- aci_elementwise_chi_scaling_long --sample-size 10
+```
+
 Inspect Julia-dumped local linsolve inputs:
 
 ```bash
@@ -76,6 +88,12 @@ TensorTrain-level operations against tensor4all:
 
 ```bash
 BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_tt_ops.jl --L 32 --zipup-L 10 --chis 4,8,16,32,64
+```
+
+ACI elementwise TT chi scaling:
+
+```bash
+BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_aci_elementwise.jl --chis 2,4,8,16
 ```
 
 Dump local linsolve inputs as ITensorMPS-compatible HDF5:
@@ -119,6 +137,14 @@ result max bond dimension, and a checksum. The Rust source of truth is
 `benchmarks/rust/benchmark_tt_ops.rs`, included by
 `tensor4all-itensorlike/examples/benchmark_tt_ops.rs`; the Julia counterpart is
 `benchmarks/julia/benchmark_tt_ops.jl`.
+
+The ACI elementwise benchmarks compare `tensor4all_aci::elementwise_batched`
+with upstream `AlternatingCrossInterpolation.jl` on deterministic two-input TT
+multiplication. The scaling axis is `chi`/`χ`, the maximum TT bond dimension of
+the inputs and initial guess. The default smoke run covers `chi = 2, 4, 8, 16`.
+`chi = 32` is a longer optional Rust case available through the
+`aci_elementwise_chi_scaling_long` Criterion filter, and Julia can run the same
+long case with `--chis 2,4,8,16,32`.
 
 `dump_local_linsolve_inputs.jl` writes the prepared local operator as
 `operator_as_mps`, plus `rhs` and `init`, in one HDF5 file. The operator is a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -53,6 +53,14 @@ Optional long `chi = 32` case:
 RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- aci_elementwise_chi_scaling_long --sample-size 10
 ```
 
+MatrixLUCI Hilbert step timing:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LUCI_REPEATS=20 T4A_MATRIX_LUCI_SIZES=16,32,64 \
+cargo test --release -p tensor4all-tcicore matrix_luci_hilbert_timing -- --ignored --nocapture
+```
+
 Inspect Julia-dumped local linsolve inputs:
 
 ```bash
@@ -94,6 +102,14 @@ ACI elementwise TT chi scaling:
 
 ```bash
 BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_aci_elementwise.jl --chis 2,4,8,16
+```
+
+MatrixLUCI Hilbert step timing:
+
+```bash
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LUCI_REPEATS=20 \
+julia benchmarks/julia/benchmark_matrix_luci.jl --sizes 16,32,64
 ```
 
 Dump local linsolve inputs as ITensorMPS-compatible HDF5:
@@ -145,6 +161,12 @@ the inputs and initial guess. The default smoke run covers `chi = 2, 4, 8, 16`.
 `chi = 32` is a longer optional Rust case available through the
 `aci_elementwise_chi_scaling_long` Criterion filter, and Julia can run the same
 long case with `--chis 2,4,8,16,32`.
+
+The MatrixLUCI Hilbert benchmarks isolate the matrix cross-interpolation step
+used inside ACI local updates. They print CSV-style timing buckets for rrLU
+pivot selection and factor construction on deterministic Hilbert matrices, with
+both left- and right-orthogonal variants. Keep these benchmarks out of normal
+test runs by using the ignored Rust test and the standalone Julia script.
 
 `dump_local_linsolve_inputs.jl` writes the prepared local operator as
 `operator_as_mps`, plus `rhs` and `init`, in one HDF5 file. The operator is a

--- a/benchmarks/julia/Project.toml
+++ b/benchmarks/julia/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 FastMPOContractions = "f6e391d2-8ffa-4d7a-98cd-7e70024481ca"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 ITensorMPS = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"

--- a/benchmarks/julia/benchmark_aci_elementwise.jl
+++ b/benchmarks/julia/benchmark_aci_elementwise.jl
@@ -1,0 +1,178 @@
+#!/usr/bin/env julia
+
+import Pkg
+
+Pkg.activate(; temp=true)
+Pkg.add(Pkg.PackageSpec(name="BenchmarkTools", uuid="6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"))
+if haskey(ENV, "ACI_JL_PATH")
+    Pkg.develop(path=ENV["ACI_JL_PATH"])
+else
+    Pkg.add(url="https://github.com/tensor4all/AlternatingCrossInterpolation.jl.git")
+end
+
+using BenchmarkTools
+using Statistics
+import AlternatingCrossInterpolation as ACI
+
+const TCI = ACI.TCI
+
+const N_SITES = 12
+const LOCAL_DIM = 2
+const N_INPUTS = 2
+const TOLERANCE = 1e-10
+const MAX_ITERS = 20
+const SAMPLE_POINTS = 64
+
+function parse_chis(args)
+    chis = [2, 4, 8, 16]
+    i = 1
+    while i <= length(args)
+        if args[i] == "--chis"
+            i == length(args) && error("--chis requires a comma-separated value list")
+            chis = parse.(Int, split(args[i + 1], ","))
+            i += 2
+        else
+            error("unknown argument: $(args[i])")
+        end
+    end
+    return chis
+end
+
+function link_dims(n_sites::Int, local_dim::Int, chi::Int)
+    return [
+        min(chi, local_dim ^ min(bond, n_sites - bond))
+        for bond in 1:(n_sites - 1)
+    ]
+end
+
+function core_value(input_index::Int, site::Int, physical::Int, left::Int, right::Int, left_dim::Int, right_dim::Int)
+    input = input_index + 1.0
+    site = site + 1.0
+    physical = physical + 1.0
+    left = left + 1.0
+    right = right + 1.0
+    left_coord = left / (left_dim + 1.0)
+    right_coord = right / (right_dim + 1.0)
+    phase = 0.173 * input * site +
+        0.193 * physical +
+        0.071 * left * right +
+        0.109 * input * left +
+        0.131 * site * right
+    bond_mix = 0.29 * sin(phase) +
+        0.23 * cos(0.157 * input * physical * right + 0.211 * site * left) +
+        0.17 * (left_coord - right_coord) * physical
+    site_value = 0.31 + bond_mix
+    scale = (left_dim * right_dim) ^ 0.25
+    return site_value / scale
+end
+
+function deterministic_tt(input_index::Int, n_sites::Int, local_dim::Int, chi::Int)
+    links = link_dims(n_sites, local_dim, chi)
+    tensors = Vector{Array{Float64,3}}(undef, n_sites)
+    for site in 1:n_sites
+        left_dim = site == 1 ? 1 : links[site - 1]
+        right_dim = site <= length(links) ? links[site] : 1
+        tensor = Array{Float64,3}(undef, left_dim, local_dim, right_dim)
+        for right in 1:right_dim, physical in 1:local_dim, left in 1:left_dim
+            tensor[left, physical, right] = core_value(
+                input_index,
+                site - 1,
+                physical - 1,
+                left - 1,
+                right - 1,
+                left_dim,
+                right_dim,
+            )
+        end
+        tensors[site] = tensor
+    end
+    return TCI.TensorTrain(tensors)
+end
+
+function deterministic_inputs(chi::Int)
+    return [deterministic_tt(input_index, N_SITES, LOCAL_DIM, chi) for input_index in 0:(N_INPUTS - 1)]
+end
+
+function deterministic_initial_guess(chi::Int)
+    return deterministic_tt(N_INPUTS, N_SITES, LOCAL_DIM, chi)
+end
+
+function sample_index(sample::Int, chi::Int)
+    state = UInt64(sample + 1) * UInt64(0x9E3779B97F4A7C15) ⊻
+        UInt64(chi + 17) * UInt64(0xBF58476D1CE4E5B9)
+    index = Vector{Int}(undef, N_SITES)
+    for site in 0:(N_SITES - 1)
+        state = state ⊻ (state >> 30)
+        state *= UInt64(0xBF58476D1CE4E5B9)
+        state = state ⊻ (state >> 27)
+        state *= UInt64(0x94D049BB133111EB)
+        index[site + 1] = Int((state ⊻ UInt64(site)) % UInt64(LOCAL_DIM)) + 1
+    end
+    return index
+end
+
+function sampled_max_abs_error(inputs, output, chi::Int)
+    max_error = 0.0
+    for sample in 0:(SAMPLE_POINTS - 1)
+        index = sample_index(sample, chi)
+        expected = prod(input(index) for input in inputs)
+        actual = output(index)
+        max_error = max(max_error, abs(actual - expected))
+    end
+    return max_error
+end
+
+function run_aci(inputs, initial_guess)
+    truncationparameters = ACI.TruncationParameters(typemax(Int), TOLERANCE, false)
+    return ACI.elementwise(
+        *,
+        inputs;
+        max_iters=MAX_ITERS,
+        min_iters=2,
+        truncationparameters=truncationparameters,
+        initial_guess=initial_guess,
+    )
+end
+
+function milliseconds(trial)
+    times = trial.times ./ 1e6
+    return (
+        median=median(times),
+        minimum=minimum(times),
+        mean=mean(times),
+        maximum=maximum(times),
+    )
+end
+
+function main()
+    chis = parse_chis(ARGS)
+    println("impl,n_sites,local_dim,chi,tolerance,median_ms,min_ms,mean_ms,max_ms,output_max_chi,n_sweeps,final_error,sampled_max_abs_error")
+    for chi in chis
+        inputs = deterministic_inputs(chi)
+        initial_guess = deterministic_initial_guess(chi)
+        output, ranks, errors = run_aci(inputs, initial_guess)
+        sampled_error = sampled_max_abs_error(inputs, output, chi)
+        sampled_error < 1e-8 || error("sampled max abs error for chi=$chi was $sampled_error")
+
+        trial = @benchmark run_aci($inputs, $initial_guess) samples = 10 seconds = 1 evals = 1
+        stats = milliseconds(trial)
+        final_error = isempty(errors) ? 0.0 : last(errors)
+        println(join([
+            "julia",
+            N_SITES,
+            LOCAL_DIM,
+            chi,
+            TOLERANCE,
+            stats.median,
+            stats.minimum,
+            stats.mean,
+            stats.maximum,
+            TCI.rank(output),
+            length(ranks),
+            final_error,
+            sampled_error,
+        ], ","))
+    end
+end
+
+main()

--- a/benchmarks/julia/benchmark_aci_local_steps.jl
+++ b/benchmarks/julia/benchmark_aci_local_steps.jl
@@ -14,7 +14,7 @@ import AlternatingCrossInterpolation as ACI
 
 const TCI = ACI.TCI
 
-const N_SITES = 12
+const DEFAULT_N_SITES = 12
 const LOCAL_DIM = 2
 const N_INPUTS = 2
 const TOLERANCE = 1e-10
@@ -40,19 +40,38 @@ end
 
 StepTiming() = StepTiming(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0)
 
-function parse_chis(args)
+function parse_args(args)
     chis = [2, 4, 8, 16]
+    n_sites = parse(Int, get(ENV, "T4A_STEP_TIMING_N_SITES", string(DEFAULT_N_SITES)))
+    min_iters = parse(Int, get(ENV, "T4A_STEP_TIMING_MIN_ITERS", string(MIN_ITERS)))
+    fixed_sweeps_env = get(ENV, "T4A_STEP_TIMING_FIXED_SWEEPS", "")
+    fixed_sweeps = isempty(fixed_sweeps_env) ? nothing : parse(Int, fixed_sweeps_env)
     i = 1
     while i <= length(args)
         if args[i] == "--chis"
             i == length(args) && error("--chis requires a comma-separated value list")
             chis = parse.(Int, split(args[i + 1], ","))
             i += 2
+        elseif args[i] == "--sites"
+            i == length(args) && error("--sites requires a site count")
+            n_sites = parse(Int, args[i + 1])
+            i += 2
+        elseif args[i] == "--min-iters"
+            i == length(args) && error("--min-iters requires an iteration count")
+            min_iters = parse(Int, args[i + 1])
+            i += 2
+        elseif args[i] == "--fixed-sweeps"
+            i == length(args) && error("--fixed-sweeps requires a sweep count")
+            fixed_sweeps = parse(Int, args[i + 1])
+            i += 2
         else
             error("unknown argument: $(args[i])")
         end
     end
-    return chis
+    n_sites < 2 && error("--sites must be at least 2")
+    min_iters < 1 && error("--min-iters must be at least 1")
+    fixed_sweeps !== nothing && fixed_sweeps < 1 && error("--fixed-sweeps must be at least 1")
+    return chis, n_sites, min_iters, fixed_sweeps
 end
 
 function link_dims(n_sites::Int, local_dim::Int, chi::Int)
@@ -83,10 +102,10 @@ function core_value(input_index::Int, site::Int, physical::Int, left::Int, right
     return site_value / scale
 end
 
-function deterministic_tt(input_index::Int, chi::Int)
-    links = link_dims(N_SITES, LOCAL_DIM, chi)
-    tensors = Vector{Array{Float64,3}}(undef, N_SITES)
-    for site in 1:N_SITES
+function deterministic_tt(input_index::Int, n_sites::Int, chi::Int)
+    links = link_dims(n_sites, LOCAL_DIM, chi)
+    tensors = Vector{Array{Float64,3}}(undef, n_sites)
+    for site in 1:n_sites
         left_dim = site == 1 ? 1 : links[site - 1]
         right_dim = site <= length(links) ? links[site] : 1
         tensor = Array{Float64,3}(undef, left_dim, LOCAL_DIM, right_dim)
@@ -106,8 +125,8 @@ function deterministic_tt(input_index::Int, chi::Int)
     return TCI.TensorTrain(tensors)
 end
 
-function deterministic_inputs(chi::Int)
-    return [deterministic_tt(input_index, chi) for input_index in 0:(N_INPUTS - 1)]
+function deterministic_inputs(n_sites::Int, chi::Int)
+    return [deterministic_tt(input_index, n_sites, chi) for input_index in 0:(N_INPUTS - 1)]
 end
 
 function timed_pitensor(problem, inputindex::Integer, bondindex::Integer, timing::StepTiming)
@@ -172,9 +191,9 @@ function timed_localupdate!(op, problem, bondindex::Integer; leftorthogonal::Boo
     nothing
 end
 
-function timed_run(chi::Int)
-    inputs = deterministic_inputs(chi)
-    initial_guess = deterministic_tt(N_INPUTS, chi)
+function timed_run(n_sites::Int, chi::Int, min_iters::Int, fixed_sweeps::Union{Nothing,Int})
+    inputs = deterministic_inputs(n_sites, chi)
+    initial_guess = deterministic_tt(N_INPUTS, n_sites, chi)
     truncationparameters = ACI.TruncationParameters(typemax(Int), TOLERANCE, false)
     problem = ACI.ElementwiseProblem(inputs, initial_guess)
     timing = StepTiming()
@@ -200,9 +219,13 @@ function timed_run(chi::Int)
         timing.final_rank = last(ranks)
         timing.final_error = last(errors)
 
-        if iteration >= MIN_ITERS &&
+        if fixed_sweeps !== nothing && timing.sweeps >= fixed_sweeps
+            break
+        end
+
+        if iteration >= min_iters &&
            errors[iteration] <= truncationparameters.tolerance &&
-           !any(last(ranks, MIN_ITERS) .> ranks[iteration-MIN_ITERS+1])
+           !any(last(ranks, min_iters) .> ranks[iteration-min_iters+1])
             break
         end
     end
@@ -217,10 +240,11 @@ setup_other_ns(run::StepTiming) = max(
 
 function main()
     repeats = parse(Int, get(ENV, "T4A_STEP_TIMING_REPEATS", "10"))
-    chis = parse_chis(ARGS)
-    println("impl,chi,repeats,n_sweeps,n_updates,setup_ms,setup_shape_ms,setup_dims_ms,setup_left_factor_ms,setup_right_factor_ms,setup_other_ms,input_values_ms,operator_ms,matrix_luci_ms,core_update_ms,frame_update_ms,total_ms,final_rank,final_error")
+    chis, n_sites, min_iters, fixed_sweeps = parse_args(ARGS)
+    fixed_sweeps_value = fixed_sweeps === nothing ? 0 : fixed_sweeps
+    println("impl,chi,n_sites,repeats,min_iters,fixed_sweeps,n_sweeps,n_updates,setup_ms,setup_shape_ms,setup_dims_ms,setup_left_factor_ms,setup_right_factor_ms,setup_other_ms,input_values_ms,operator_ms,matrix_luci_ms,core_update_ms,frame_update_ms,total_ms,final_rank,final_error")
     for chi in chis
-        runs = [timed_run(chi) for _ in 1:repeats]
+        runs = [timed_run(n_sites, chi, min_iters, fixed_sweeps) for _ in 1:repeats]
         total_ms = [
             ns_to_ms(run.setup_ns + run.input_values_ns + run.operator_ns + run.matrix_luci_ns + run.core_update_ns + run.frame_update_ns)
             for run in runs
@@ -229,7 +253,10 @@ function main()
         println(join([
             "julia",
             chi,
+            n_sites,
             repeats,
+            min_iters,
+            fixed_sweeps_value,
             first.sweeps,
             first.updates,
             median(ns_to_ms.(getfield.(runs, :setup_ns))),

--- a/benchmarks/julia/benchmark_aci_local_steps.jl
+++ b/benchmarks/julia/benchmark_aci_local_steps.jl
@@ -1,0 +1,253 @@
+#!/usr/bin/env julia
+
+import Pkg
+
+Pkg.activate(; temp=true)
+if haskey(ENV, "ACI_JL_PATH")
+    Pkg.develop(path=ENV["ACI_JL_PATH"])
+else
+    Pkg.add(url="https://github.com/tensor4all/AlternatingCrossInterpolation.jl.git")
+end
+
+using Statistics
+import AlternatingCrossInterpolation as ACI
+
+const TCI = ACI.TCI
+
+const N_SITES = 12
+const LOCAL_DIM = 2
+const N_INPUTS = 2
+const TOLERANCE = 1e-10
+const MAX_ITERS = 20
+const MIN_ITERS = 2
+
+mutable struct StepTiming
+    setup_ns::Int
+    setup_shape_ns::Int
+    setup_dims_ns::Int
+    setup_left_factor_ns::Int
+    setup_right_factor_ns::Int
+    input_values_ns::Int
+    operator_ns::Int
+    matrix_luci_ns::Int
+    core_update_ns::Int
+    frame_update_ns::Int
+    updates::Int
+    sweeps::Int
+    final_rank::Int
+    final_error::Float64
+end
+
+StepTiming() = StepTiming(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0)
+
+function parse_chis(args)
+    chis = [2, 4, 8, 16]
+    i = 1
+    while i <= length(args)
+        if args[i] == "--chis"
+            i == length(args) && error("--chis requires a comma-separated value list")
+            chis = parse.(Int, split(args[i + 1], ","))
+            i += 2
+        else
+            error("unknown argument: $(args[i])")
+        end
+    end
+    return chis
+end
+
+function link_dims(n_sites::Int, local_dim::Int, chi::Int)
+    return [
+        min(chi, local_dim ^ min(bond, n_sites - bond))
+        for bond in 1:(n_sites - 1)
+    ]
+end
+
+function core_value(input_index::Int, site::Int, physical::Int, left::Int, right::Int, left_dim::Int, right_dim::Int)
+    input = input_index + 1.0
+    site = site + 1.0
+    physical = physical + 1.0
+    left = left + 1.0
+    right = right + 1.0
+    left_coord = left / (left_dim + 1.0)
+    right_coord = right / (right_dim + 1.0)
+    phase = 0.173 * input * site +
+        0.193 * physical +
+        0.071 * left * right +
+        0.109 * input * left +
+        0.131 * site * right
+    bond_mix = 0.29 * sin(phase) +
+        0.23 * cos(0.157 * input * physical * right + 0.211 * site * left) +
+        0.17 * (left_coord - right_coord) * physical
+    site_value = 0.31 + bond_mix
+    scale = (left_dim * right_dim) ^ 0.25
+    return site_value / scale
+end
+
+function deterministic_tt(input_index::Int, chi::Int)
+    links = link_dims(N_SITES, LOCAL_DIM, chi)
+    tensors = Vector{Array{Float64,3}}(undef, N_SITES)
+    for site in 1:N_SITES
+        left_dim = site == 1 ? 1 : links[site - 1]
+        right_dim = site <= length(links) ? links[site] : 1
+        tensor = Array{Float64,3}(undef, left_dim, LOCAL_DIM, right_dim)
+        for right in 1:right_dim, physical in 1:LOCAL_DIM, left in 1:left_dim
+            tensor[left, physical, right] = core_value(
+                input_index,
+                site - 1,
+                physical - 1,
+                left - 1,
+                right - 1,
+                left_dim,
+                right_dim,
+            )
+        end
+        tensors[site] = tensor
+    end
+    return TCI.TensorTrain(tensors)
+end
+
+function deterministic_inputs(chi::Int)
+    return [deterministic_tt(input_index, chi) for input_index in 0:(N_INPUTS - 1)]
+end
+
+function timed_pitensor(problem, inputindex::Integer, bondindex::Integer, timing::StepTiming)
+    left = problem.leftframes[inputindex, bondindex-1]
+    Tleft = problem.inputs[inputindex][bondindex]
+    Tright = problem.inputs[inputindex][bondindex+1]
+    right = problem.rightframes[inputindex, bondindex+2]
+
+    t = time_ns()
+    L = ACI.contract(left, [2], Tleft, [1])
+    elapsed = time_ns() - t
+    timing.setup_left_factor_ns += elapsed
+    timing.setup_ns += elapsed
+
+    t = time_ns()
+    R = ACI.contract(Tright, [3], right, [1])
+    elapsed = time_ns() - t
+    timing.setup_right_factor_ns += elapsed
+    timing.setup_ns += elapsed
+
+    t = time_ns()
+    Π = ACI.contract(L, [3], R, [1])
+    timing.input_values_ns += time_ns() - t
+    return Π
+end
+
+function timed_localupdate!(op, problem, bondindex::Integer; leftorthogonal::Bool, truncationparameters, timing::StepTiming)
+    Πs = [timed_pitensor(problem, k, bondindex, timing) for k in ACI.eachinputindex(problem)]
+
+    t = time_ns()
+    Π = op.(Πs...)
+    timing.operator_ns += time_ns() - t
+
+    t = time_ns()
+    luci = TCI.MatrixLUCI(
+        reshape(Π, prod(size(Π)[1:2]), prod(size(Π)[3:4]));
+        leftorthogonal=leftorthogonal,
+        maxrank=truncationparameters.maxbonddimension,
+        abstol=truncationparameters.tolerance
+    )
+    timing.matrix_luci_ns += time_ns() - t
+
+    t = time_ns()
+    leftfactor = TCI.left(luci)
+    rightfactor = TCI.right(luci)
+    timing.matrix_luci_ns += time_ns() - t
+
+    t = time_ns()
+    problem.solution.sitetensors[bondindex] = reshape(leftfactor, size(Π, 1), size(Π, 2), :)
+    problem.solution.sitetensors[bondindex+1] = reshape(rightfactor, :, size(Π, 3), size(Π, 4))
+    timing.core_update_ns += time_ns() - t
+
+    t = time_ns()
+    if leftorthogonal
+        ACI.updateleftframes!(problem, bondindex, TCI.rowindices(luci))
+    else
+        ACI.updaterightframes!(problem, bondindex + 1, TCI.colindices(luci))
+    end
+    problem.pivoterrors[bondindex] = TCI.lastpivoterror(luci)
+    timing.frame_update_ns += time_ns() - t
+    timing.updates += 1
+    nothing
+end
+
+function timed_run(chi::Int)
+    inputs = deterministic_inputs(chi)
+    initial_guess = deterministic_tt(N_INPUTS, chi)
+    truncationparameters = ACI.TruncationParameters(typemax(Int), TOLERANCE, false)
+    problem = ACI.ElementwiseProblem(inputs, initial_guess)
+    timing = StepTiming()
+    ranks = Int[]
+    errors = Float64[]
+
+    for iteration in 1:MAX_ITERS
+        forward = isodd(iteration)
+        for bondindex in ACI.sweep(collect(ACI.eachbondindex(problem)); forward)
+            timed_localupdate!(
+                *,
+                problem,
+                bondindex;
+                leftorthogonal=forward,
+                truncationparameters,
+                timing,
+            )
+        end
+
+        push!(ranks, TCI.rank(problem.solution))
+        push!(errors, maximum(problem.pivoterrors))
+        timing.sweeps += 1
+        timing.final_rank = last(ranks)
+        timing.final_error = last(errors)
+
+        if iteration >= MIN_ITERS &&
+           errors[iteration] <= truncationparameters.tolerance &&
+           !any(last(ranks, MIN_ITERS) .> ranks[iteration-MIN_ITERS+1])
+            break
+        end
+    end
+    return timing
+end
+
+ns_to_ms(ns::Int) = ns / 1e6
+setup_other_ns(run::StepTiming) = max(
+    0,
+    run.setup_ns - run.setup_shape_ns - run.setup_dims_ns - run.setup_left_factor_ns - run.setup_right_factor_ns,
+)
+
+function main()
+    repeats = parse(Int, get(ENV, "T4A_STEP_TIMING_REPEATS", "10"))
+    chis = parse_chis(ARGS)
+    println("impl,chi,repeats,n_sweeps,n_updates,setup_ms,setup_shape_ms,setup_dims_ms,setup_left_factor_ms,setup_right_factor_ms,setup_other_ms,input_values_ms,operator_ms,matrix_luci_ms,core_update_ms,frame_update_ms,total_ms,final_rank,final_error")
+    for chi in chis
+        runs = [timed_run(chi) for _ in 1:repeats]
+        total_ms = [
+            ns_to_ms(run.setup_ns + run.input_values_ns + run.operator_ns + run.matrix_luci_ns + run.core_update_ns + run.frame_update_ns)
+            for run in runs
+        ]
+        first = runs[1]
+        println(join([
+            "julia",
+            chi,
+            repeats,
+            first.sweeps,
+            first.updates,
+            median(ns_to_ms.(getfield.(runs, :setup_ns))),
+            median(ns_to_ms.(getfield.(runs, :setup_shape_ns))),
+            median(ns_to_ms.(getfield.(runs, :setup_dims_ns))),
+            median(ns_to_ms.(getfield.(runs, :setup_left_factor_ns))),
+            median(ns_to_ms.(getfield.(runs, :setup_right_factor_ns))),
+            median(ns_to_ms.(setup_other_ns.(runs))),
+            median(ns_to_ms.(getfield.(runs, :input_values_ns))),
+            median(ns_to_ms.(getfield.(runs, :operator_ns))),
+            median(ns_to_ms.(getfield.(runs, :matrix_luci_ns))),
+            median(ns_to_ms.(getfield.(runs, :core_update_ns))),
+            median(ns_to_ms.(getfield.(runs, :frame_update_ns))),
+            median(total_ms),
+            first.final_rank,
+            first.final_error,
+        ], ","))
+    end
+end
+
+main()

--- a/benchmarks/julia/benchmark_matrix_lu.jl
+++ b/benchmarks/julia/benchmark_matrix_lu.jl
@@ -1,0 +1,112 @@
+#!/usr/bin/env julia
+
+import Pkg
+
+Pkg.activate(; temp=true)
+if haskey(ENV, "ACI_JL_PATH")
+    Pkg.develop(path=ENV["ACI_JL_PATH"])
+else
+    Pkg.add(url="https://github.com/tensor4all/AlternatingCrossInterpolation.jl.git")
+end
+
+using Statistics
+import AlternatingCrossInterpolation as ACI
+
+const TCI = ACI.TCI
+
+struct MatrixLuTiming
+    inplace_ns::Int
+    borrowed_ns::Int
+    rank::Int
+    last_error::Float64
+    checksum::Float64
+end
+
+function parse_sizes(args)
+    sizes = [16, 32, 64, 128]
+    i = 1
+    while i <= length(args)
+        if args[i] == "--sizes"
+            i == length(args) && error("--sizes requires a comma-separated value list")
+            sizes = parse.(Int, split(args[i + 1], ","))
+            i += 2
+        else
+            error("unknown argument: $(args[i])")
+        end
+    end
+    return sizes
+end
+
+function hilbert_matrix(size::Int)
+    A = Matrix{Float64}(undef, size, size)
+    for col in 1:size, row in 1:size
+        A[row, col] = 1.0 / (row + col - 1)
+    end
+    return A
+end
+
+function timed_once(size::Int, leftorthogonal::Bool)
+    A = hilbert_matrix(size)
+
+    A_copy = copy(A)
+    t = time_ns()
+    lu_inplace = TCI.rrlu!(
+        A_copy;
+        leftorthogonal=leftorthogonal,
+        maxrank=typemax(Int),
+        reltol=0.0,
+        abstol=1.0e-10,
+    )
+    inplace_ns = time_ns() - t
+
+    t = time_ns()
+    lu_borrowed = TCI.rrlu(
+        A;
+        leftorthogonal=leftorthogonal,
+        maxrank=typemax(Int),
+        reltol=0.0,
+        abstol=1.0e-10,
+    )
+    borrowed_ns = time_ns() - t
+
+    left = TCI.left(lu_inplace; permute=false)
+    right = TCI.right(lu_inplace; permute=false)
+    checksum = (isempty(left) ? 0.0 : abs(left[1, 1])) +
+        (isempty(right) ? 0.0 : abs(right[1, 1]))
+
+    return MatrixLuTiming(
+        inplace_ns,
+        borrowed_ns,
+        TCI.npivots(lu_borrowed),
+        TCI.lastpivoterror(lu_borrowed),
+        checksum,
+    )
+end
+
+ns_to_ms(ns::Int) = ns / 1e6
+
+function main()
+    repeats = parse(Int, get(ENV, "T4A_MATRIX_LU_REPEATS", "20"))
+    sizes = parse_sizes(ARGS)
+    println("impl,matrix,size,repeats,left_orthogonal,inplace_ms,borrowed_ms,rank,last_error,checksum")
+    for size in sizes
+        for leftorthogonal in (true, false)
+            runs = [timed_once(size, leftorthogonal) for _ in 1:repeats]
+            first = runs[1]
+            println(join([
+                "julia",
+                "hilbert",
+                size,
+                repeats,
+                leftorthogonal,
+                median(ns_to_ms.(getfield.(runs, :inplace_ns))),
+                median(ns_to_ms.(getfield.(runs, :borrowed_ns))),
+                first.rank,
+                first.last_error,
+                first.checksum,
+            ], ","))
+        end
+    end
+end
+
+main()

--- a/benchmarks/julia/benchmark_matrix_luci.jl
+++ b/benchmarks/julia/benchmark_matrix_luci.jl
@@ -1,0 +1,115 @@
+#!/usr/bin/env julia
+
+import Pkg
+
+Pkg.activate(; temp=true)
+if haskey(ENV, "ACI_JL_PATH")
+    Pkg.develop(path=ENV["ACI_JL_PATH"])
+else
+    Pkg.add(url="https://github.com/tensor4all/AlternatingCrossInterpolation.jl.git")
+end
+
+using Statistics
+import AlternatingCrossInterpolation as ACI
+
+const TCI = ACI.TCI
+
+struct MatrixLuciTiming
+    selection_ns::Int
+    gather_ns::Int
+    left_factor_ns::Int
+    right_factor_ns::Int
+    rank::Int
+    last_error::Float64
+    checksum::Float64
+end
+
+function parse_sizes(args)
+    sizes = [4, 8, 16, 32, 64]
+    i = 1
+    while i <= length(args)
+        if args[i] == "--sizes"
+            i == length(args) && error("--sizes requires a comma-separated value list")
+            sizes = parse.(Int, split(args[i + 1], ","))
+            i += 2
+        else
+            error("unknown argument: $(args[i])")
+        end
+    end
+    return sizes
+end
+
+function hilbert_matrix(size::Int)
+    A = Matrix{Float64}(undef, size, size)
+    for col in 1:size, row in 1:size
+        A[row, col] = 1.0 / (row + col - 1)
+    end
+    return A
+end
+
+function timed_once(size::Int, leftorthogonal::Bool)
+    A = hilbert_matrix(size)
+
+    t = time_ns()
+    luci = TCI.MatrixLUCI(
+        A;
+        leftorthogonal=leftorthogonal,
+        maxrank=typemax(Int),
+        reltol=0.0,
+        abstol=1.0e-10,
+    )
+    selection_ns = time_ns() - t
+
+    t = time_ns()
+    left = TCI.left(luci)
+    left_factor_ns = time_ns() - t
+
+    t = time_ns()
+    right = TCI.right(luci)
+    right_factor_ns = time_ns() - t
+
+    checksum = (isempty(left) ? 0.0 : abs(left[1, 1])) +
+        (isempty(right) ? 0.0 : abs(right[1, 1]))
+    return MatrixLuciTiming(
+        selection_ns,
+        0,
+        left_factor_ns,
+        right_factor_ns,
+        TCI.npivots(luci),
+        TCI.lastpivoterror(luci),
+        checksum,
+    )
+end
+
+ns_to_ms(ns::Int) = ns / 1e6
+total_ns(run::MatrixLuciTiming) =
+    run.selection_ns + run.gather_ns + run.left_factor_ns + run.right_factor_ns
+
+function main()
+    repeats = parse(Int, get(ENV, "T4A_MATRIX_LUCI_REPEATS", "20"))
+    sizes = parse_sizes(ARGS)
+    println("impl,matrix,size,repeats,left_orthogonal,selection_ms,gather_ms,left_factor_ms,right_factor_ms,total_ms,rank,last_error,checksum")
+    for size in sizes
+        for leftorthogonal in (true, false)
+            runs = [timed_once(size, leftorthogonal) for _ in 1:repeats]
+            first = runs[1]
+            println(join([
+                "julia",
+                "hilbert",
+                size,
+                repeats,
+                leftorthogonal,
+                median(ns_to_ms.(getfield.(runs, :selection_ns))),
+                median(ns_to_ms.(getfield.(runs, :gather_ns))),
+                median(ns_to_ms.(getfield.(runs, :left_factor_ns))),
+                median(ns_to_ms.(getfield.(runs, :right_factor_ns))),
+                median(ns_to_ms.(total_ns.(runs))),
+                first.rank,
+                first.last_error,
+                first.checksum,
+            ], ","))
+        end
+    end
+end
+
+main()

--- a/benchmarks/results/2026-05-21-aci-elementwise.md
+++ b/benchmarks/results/2026-05-21-aci-elementwise.md
@@ -1,0 +1,74 @@
+# ACI Elementwise Chi Scaling
+
+Date: 2026-05-21
+
+## Host and Thread Settings
+
+- Host CPU: AMD EPYC 7713P 64-Core Processor
+- Rust threads: `RAYON_NUM_THREADS=1`
+- Julia BLAS threads: `BLAS_NUM_THREADS=1`
+- Julia version: 1.12.5
+- Rust toolchain: `rustc 1.94.1 (e408947bf 2026-03-25)`, LLVM 21.1.8
+- Rust source state during the run: `469d612-dirty`
+- Julia package source: `ACI_JL_PATH=/tmp/AlternatingCrossInterpolation.jl`
+- Julia upstream SHA: `3a33e2b738c9502f7e312b79ebe45a578611d2ff`
+- Relevant Julia packages resolved in a temporary project:
+  `AlternatingCrossInterpolation v0.1.0`,
+  `TensorCrossInterpolation v0.9.19`, and `BenchmarkTools v1.8.0`
+
+## Commands
+
+```bash
+cargo bench --no-run -p tensor4all-aci --bench elementwise_scaling
+RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+ACI_JL_PATH=/tmp/AlternatingCrossInterpolation.jl BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_aci_elementwise.jl --chis 2,4,8,16
+```
+
+The benchmark scripts use the same deterministic closed-form TT core formula.
+The formula depends on physical and left/right bond coordinates so the fixture
+does not merely inflate structural bond dimensions. The Rust script asserts
+sampled max absolute error below `1e-8` and asserts non-rank-one output for
+`chi > 2`.
+
+The requested BenchmarkTools UUID
+`6e4b80f9-dda5-5e3a-8b7e-868b0140f7fe` is not registered. The benchmark project
+uses the registered UUID `6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf`.
+
+## Rust Results
+
+Rust metadata rows printed by the benchmark:
+
+| chi | Criterion estimate ms | output max chi | sweeps | final error | sampled max abs error |
+|---:|---:|---:|---:|---:|---:|
+| 2 | 3.4510 | 1 | 2 | 8.310106e-11 | 2.990242e-11 |
+| 4 | 25.551 | 7 | 4 | 9.776016e-11 | 4.295409e-11 |
+| 8 | 84.297 | 14 | 2 | 9.902878e-11 | 8.034786e-11 |
+| 16 | 4216.9 | 23 | 4 | 9.759426e-11 | 7.172652e-11 |
+
+## Julia Results
+
+CSV output:
+
+| impl | n_sites | local_dim | chi | tolerance | median_ms | min_ms | mean_ms | max_ms | output_max_chi | n_sweeps | final_error | sampled_max_abs_error |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| julia | 12 | 2 | 2 | 1.0e-10 | 2.019424 | 2.012608 | 2.0394163 | 2.205166 | 1 | 2 | 8.310105747818132e-11 | 2.9902424477977914e-11 |
+| julia | 12 | 2 | 4 | 1.0e-10 | 3.1609285 | 3.137227 | 3.1978732 | 3.520995 | 7 | 3 | 9.776015850916343e-11 | 4.2954087123189454e-11 |
+| julia | 12 | 2 | 8 | 1.0e-10 | 2.4988745 | 2.375364 | 2.6774354 | 3.340246 | 14 | 2 | 9.573733291247284e-11 | 4.0545975613723955e-11 |
+| julia | 12 | 2 | 16 | 1.0e-10 | 6.193907 | 5.741522 | 7.2255916 | 13.064673 | 25 | 3 | 8.80572239324038e-11 | 5.599156990105606e-11 |
+
+## Interpretation
+
+The revised fixture now exercises nontrivial output-rank growth: output max chi
+increases from 1 at `chi = 2` to the low-to-mid twenties at `chi = 16`. Runtime
+therefore reflects both larger input cores and larger local two-site blocks.
+
+In this short local run, Rust scales much more steeply at `chi = 16` than Julia.
+The jump is consistent with the Rust public API path spending most of the high
+chi case in local block construction, cache lookups, and MatrixLUCI updates over
+larger intermediate blocks. This is a smoke benchmark with only ten samples, so
+the exact timing ratios should be treated as directional.
+
+Numerical parity is within the required sampled threshold. All sampled max
+absolute errors are below `1e-8`. Rust and Julia agree on output max chi through
+`chi = 8`; for `chi = 16`, Rust returned output max chi 23 and Julia returned
+25, with both final error metrics near `1e-10`.

--- a/benchmarks/results/2026-05-22-aci-local-step-l16-openblas.md
+++ b/benchmarks/results/2026-05-22-aci-local-step-l16-openblas.md
@@ -1,0 +1,88 @@
+# ACI Local Step Timing, L=16, System OpenBLAS
+
+Date: 2026-05-22
+
+## Host and Thread Settings
+
+- Host CPU: Apple M5 Max
+- OS: Darwin 25.3.0 arm64
+- Rust toolchain: `rustc 1.94.0 (4a4ef493e 2026-03-02)`, LLVM 21.1.8
+- Julia version: 1.12.5
+- Rust backend feature: `tenferro-system-blas`
+- Rust BLAS provider: Homebrew OpenBLAS at `/opt/homebrew/opt/openblas`
+- Julia BLAS provider: `OpenBLAS_jll v0.3.29+0` through
+  `libblastrampoline_jll v5.15.0+0`
+- Thread settings:
+  `RAYON_NUM_THREADS=1`, `JULIA_NUM_THREADS=1`,
+  `BLAS_NUM_THREADS=1`, `OMP_NUM_THREADS=1`,
+  `OPENBLAS_NUM_THREADS=1`, `MKL_NUM_THREADS=1`
+
+This run uses 16 sites and local dimension 2. The central exact-rank bound is
+`2^8 = 256`, so `chi = 128` is not clamped by the fixture. Fixed sweeps are
+used to compare the same number of local updates across Rust and Julia.
+
+The native Rust convergence rule now mirrors Julia's `convergencecriterion`
+shape: run at least `min_iters = 2`, check `errors[iteration] <= tolerance`,
+and reject if any rank in `last(ranks, min_iters)` is greater than
+`ranks[iteration - min_iters + 1]`. Rust also has a relative `scale_tolerance`
+mode, but it is disabled here. Fixed sweeps are used because small
+numerical/path differences can still make Rust and Julia stop after different
+numbers of sweeps.
+
+## Commands
+
+Rust:
+
+```bash
+OPENBLAS_ROOT=${OPENBLAS_ROOT:-$(brew --prefix openblas)}
+env \
+RUSTFLAGS="-L native=${OPENBLAS_ROOT}/lib -l dylib=openblas" \
+DYLD_LIBRARY_PATH="${OPENBLAS_ROOT}/lib:${DYLD_LIBRARY_PATH:-}" \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=20 T4A_STEP_TIMING_N_SITES=16 \
+T4A_STEP_TIMING_FIXED_SWEEPS=3 T4A_STEP_TIMING_CHIS=16,32,64,128 \
+cargo test --release -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas \
+  local_update_step_timing -- --ignored --nocapture
+```
+
+Julia:
+
+```bash
+env \
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=20 \
+julia benchmarks/julia/benchmark_aci_local_steps.jl \
+  --sites 16 --fixed-sweeps 3 --chis 16,32,64,128
+```
+
+## Results
+
+All timings are medians in milliseconds over 20 repeats.
+
+| impl | chi | sites | sweeps | updates | setup | input | operator | MatrixLUCI | core | frame | total | rank | error |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| rust | 16 | 16 | 3 | 45 | 0.198875 | 0.194607 | 0.071831 | 1.259810 | 0.006457 | 0.111080 | 1.841535 | 33 | 9.525310e-11 |
+| julia | 16 | 16 | 3 | 45 | 0.344733 | 0.242043 | 0.030210 | 1.233481 | 0.016289 | 0.224732 | 2.115942 | 33 | 9.525310e-11 |
+| rust | 32 | 16 | 3 | 45 | 0.404332 | 0.374188 | 0.105338 | 2.209271 | 0.006583 | 0.228935 | 3.330730 | 46 | 9.720931e-11 |
+| julia | 32 | 16 | 3 | 45 | 0.523897 | 0.387251 | 0.026439 | 2.414964 | 0.016959 | 0.316272 | 4.085233 | 46 | 9.720948e-11 |
+| rust | 64 | 16 | 3 | 45 | 1.438957 | 0.930770 | 0.168311 | 4.708000 | 0.012729 | 0.714835 | 7.975667 | 63 | 9.320186e-11 |
+| julia | 64 | 16 | 3 | 45 | 1.735355 | 1.156627 | 0.045643 | 5.213416 | 0.018834 | 0.914043 | 9.584417 | 63 | 9.930868e-11 |
+| rust | 128 | 16 | 3 | 45 | 3.861642 | 1.956604 | 0.245189 | 7.987332 | 0.016482 | 1.808458 | 15.889415 | 76 | 8.523082e-11 |
+| julia | 128 | 16 | 3 | 45 | 4.560911 | 1.923917 | 0.054647 | 8.276169 | 0.023434 | 2.028794 | 17.230575 | 76 | 8.961109e-11 |
+
+## Summary
+
+| chi | Rust total / Julia total | Rust MatrixLUCI / Julia MatrixLUCI |
+|---:|---:|---:|
+| 16 | 0.870 | 1.021 |
+| 32 | 0.815 | 0.915 |
+| 64 | 0.832 | 0.903 |
+| 128 | 0.922 | 0.965 |
+
+The MatrixLUCI bucket is close across the whole range. Rust is slightly slower
+at `chi = 16`, faster for `chi = 32, 64`, and very close at `chi = 128`. Rust's
+operator bucket remains slower because this benchmark exercises the public
+batched callback path, while Julia uses broadcasted scalar multiplication.

--- a/benchmarks/results/2026-05-22-aci-local-step-openblas.md
+++ b/benchmarks/results/2026-05-22-aci-local-step-openblas.md
@@ -1,0 +1,102 @@
+# ACI Local Step Timing, System OpenBLAS
+
+Date: 2026-05-22
+
+## Host and Thread Settings
+
+- Host CPU: Apple M5 Max
+- OS: Darwin 25.3.0 arm64
+- Rust toolchain: `rustc 1.94.0 (4a4ef493e 2026-03-02)`, LLVM 21.1.8
+- Julia version: 1.12.5
+- Rust source state during the run: `cbd16e4-dirty`
+- Rust backend feature: `tenferro-system-blas`
+- Rust BLAS provider: Homebrew OpenBLAS at `/opt/homebrew/opt/openblas`
+- Rust binary link check:
+  `/opt/homebrew/opt/openblas/lib/libopenblas.0.dylib`
+- Thread settings:
+  `RAYON_NUM_THREADS=1`, `JULIA_NUM_THREADS=1`,
+  `BLAS_NUM_THREADS=1`, `OMP_NUM_THREADS=1`,
+  `OPENBLAS_NUM_THREADS=1`, `MKL_NUM_THREADS=1`
+
+The deterministic fixture has 12 sites and local dimension 2. Therefore
+`chi=128` is effectively clamped by the exact central rank bound `2^6 = 64`,
+which is why `chi=64` and `chi=128` are expected to be nearly identical.
+
+## Commands
+
+Rust:
+
+```bash
+env \
+RUSTFLAGS='-L native=/opt/homebrew/opt/openblas/lib -l dylib=openblas' \
+DYLD_LIBRARY_PATH=/opt/homebrew/opt/openblas/lib \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 T4A_STEP_TIMING_CHIS=16,32 \
+cargo test --release -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas \
+  local_update_step_timing -- --ignored --nocapture
+```
+
+```bash
+env \
+RUSTFLAGS='-L native=/opt/homebrew/opt/openblas/lib -l dylib=openblas' \
+DYLD_LIBRARY_PATH=/opt/homebrew/opt/openblas/lib \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 T4A_STEP_TIMING_CHIS=64,128 \
+cargo test --release -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas \
+  local_update_step_timing -- --ignored --nocapture
+```
+
+Julia:
+
+```bash
+env \
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 \
+julia benchmarks/julia/benchmark_aci_local_steps.jl --chis 16,32
+```
+
+```bash
+env \
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 \
+julia benchmarks/julia/benchmark_aci_local_steps.jl --chis 64,128
+```
+
+## Rust Results
+
+| chi | setup ms | input ms | operator ms | MatrixLUCI ms | core ms | frame ms | total ms | final rank | final error |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 16 | 0.117666 | 0.080397 | 0.027372 | 0.323687 | 0.004709 | 0.063438 | 0.614538 | 25 | 8.805722e-11 |
+| 32 | 0.211792 | 0.094503 | 0.025479 | 0.323209 | 0.003999 | 0.100208 | 0.759833 | 26 | 6.172906e-11 |
+| 64 | 0.309105 | 0.121538 | 0.026063 | 0.362123 | 0.004002 | 0.140831 | 0.962290 | 26 | 8.018094e-11 |
+| 128 | 0.305374 | 0.120855 | 0.025335 | 0.359270 | 0.004044 | 0.137960 | 0.955769 | 26 | 8.018094e-11 |
+
+## Julia Results
+
+| chi | setup ms | input ms | operator ms | MatrixLUCI ms | core ms | frame ms | total ms | final rank | final error |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 16 | 0.1879575 | 0.111789 | 0.0087505 | 0.3064995 | 0.0111035 | 0.1248325 | 0.755751 | 25 | 8.805721625343378e-11 |
+| 32 | 0.2998115 | 0.138312 | 0.0093775 | 0.3468935 | 0.0110005 | 0.1685645 | 0.9774875 | 26 | 6.172906150931444e-11 |
+| 64 | 0.4103360 | 0.1671675 | 0.010646 | 0.3941450 | 0.0114610 | 0.2140220 | 1.225249 | 26 | 8.018093743486929e-11 |
+| 128 | 0.3965050 | 0.1657890 | 0.010666 | 0.4011880 | 0.0120445 | 0.2153550 | 1.227997 | 26 | 8.018093743486929e-11 |
+
+## Notes
+
+- Rust is faster in total for all recorded chi values under this system
+  OpenBLAS comparison.
+- The MatrixLUCI bucket is now close: Rust is slightly slower at `chi=16`,
+  faster at `chi=32`, and faster at `chi=64/128`.
+- The operator bucket differs because the Rust benchmark uses the batched
+  public callback path while the Julia benchmark uses broadcasted scalar
+  multiplication.
+- The Rust bucket-timing code currently lives in the ignored unit test
+  `local_update_step_timing` because it needs crate-private ACI state and
+  timing hooks. If this benchmark becomes a regular artifact, extract the
+  shared body into a feature-gated `bench_support` module and expose a thin
+  wrapper from `benchmarks/rust/benchmark_aci_local_steps.rs`.

--- a/benchmarks/results/2026-05-22-matrix-lu-hilbert.md
+++ b/benchmarks/results/2026-05-22-matrix-lu-hilbert.md
@@ -1,0 +1,62 @@
+# MatrixLU Hilbert Timing
+
+Date: 2026-05-22
+
+## Scope
+
+This benchmark isolates rank-revealing LU (`rrlu_inplace` and non-destructive
+`rrlu`) on deterministic Hilbert matrices. It does not call BLAS, so the Rust
+standalone runner uses the default feature set; system OpenBLAS is irrelevant
+for this particular microbenchmark.
+
+Thread settings:
+`RAYON_NUM_THREADS=1`, `JULIA_NUM_THREADS=1`, `BLAS_NUM_THREADS=1`,
+`OMP_NUM_THREADS=1`, `OPENBLAS_NUM_THREADS=1`, `MKL_NUM_THREADS=1`.
+
+## Commands
+
+Rust:
+
+```bash
+env \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LU_REPEATS=20 T4A_MATRIX_LU_SIZES=16,32,64,128 \
+cargo run --release -p tensor4all-tcicore --example benchmark_matrix_lu
+```
+
+Julia:
+
+```bash
+env \
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LU_REPEATS=20 \
+julia benchmarks/julia/benchmark_matrix_lu.jl --sizes 16,32,64,128
+```
+
+## Results
+
+All timings are medians in milliseconds over 20 repeats.
+
+| size | left orthogonal | Rust inplace | Julia inplace | Rust borrowed | Julia borrowed | rank | last error |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 16 | true | 0.004042 | 0.002438 | 0.004125 | 0.002562 | 10 | 2.198484e-12 |
+| 16 | false | 0.004041 | 0.002708 | 0.004084 | 0.002959 | 10 | 2.198484e-12 |
+| 32 | true | 0.016188 | 0.011709 | 0.013104 | 0.011979 | 11 | 4.197675e-11 |
+| 32 | false | 0.011917 | 0.013187 | 0.012021 | 0.013333 | 11 | 4.197675e-11 |
+| 64 | true | 0.091688 | 0.062083 | 0.092771 | 0.063167 | 13 | 9.601802e-12 |
+| 64 | false | 0.092000 | 0.062208 | 0.093105 | 0.064792 | 13 | 9.601802e-12 |
+| 128 | true | 0.349042 | 0.288854 | 0.347458 | 0.315896 | 14 | 3.690140e-11 |
+| 128 | false | 0.309084 | 0.287292 | 0.315875 | 0.287583 | 14 | 3.690140e-11 |
+
+## Notes
+
+Rust and Julia agree on rank and pivot error. On this Hilbert microbenchmark,
+Julia's standalone rrLU is usually faster, especially at smaller sizes. This is
+not identical to the ACI local MatrixLUCI bucket because the local matrices and
+factor-wrapper work differ; use this benchmark to track rrLU-specific changes.
+
+TODO: make the `tensor4all-tcicore` dev-dependency backend features easier to
+select so examples can also be built with `--no-default-features --features
+tenferro-system-blas` without pulling in `tensor4all-tensorci/tenferro-cpu-faer`.

--- a/benchmarks/rust/benchmark_matrix_lu.rs
+++ b/benchmarks/rust/benchmark_matrix_lu.rs
@@ -1,0 +1,120 @@
+use std::time::{Duration, Instant};
+
+use tensor4all_tcicore::{rrlu, rrlu_inplace, RrLUOptions};
+use tensor4all_tensorbackend::Matrix;
+
+#[derive(Clone, Copy, Default)]
+struct MatrixLuTiming {
+    inplace: Duration,
+    borrowed: Duration,
+    rank: usize,
+    last_error: f64,
+    checksum: f64,
+}
+
+fn hilbert_matrix(size: usize) -> Matrix<f64> {
+    let mut data = vec![0.0; size * size];
+    for col in 0..size {
+        for row in 0..size {
+            data[row + size * col] = 1.0 / ((row + col + 1) as f64);
+        }
+    }
+    Matrix::from_col_major_vec(size, size, data)
+}
+
+fn parse_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn parse_env_usize_list(name: &str, default: Vec<usize>) -> Vec<usize> {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|item| item.parse::<usize>().unwrap())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or(default)
+}
+
+fn timing_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn timing_median(mut values: Vec<f64>) -> f64 {
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mid = values.len() / 2;
+    if values.len() % 2 == 0 {
+        0.5 * (values[mid - 1] + values[mid])
+    } else {
+        values[mid]
+    }
+}
+
+fn timed_hilbert_matrix_lu_once(size: usize, left_orthogonal: bool) -> MatrixLuTiming {
+    let matrix = hilbert_matrix(size);
+    let options = RrLUOptions {
+        max_rank: usize::MAX,
+        rel_tol: 0.0,
+        abs_tol: 1.0e-10,
+        left_orthogonal,
+    };
+
+    let mut matrix_for_inplace = matrix.clone();
+    let start = Instant::now();
+    let lu_inplace = rrlu_inplace(&mut matrix_for_inplace, Some(options.clone())).unwrap();
+    let inplace = start.elapsed();
+
+    let start = Instant::now();
+    let lu_borrowed = rrlu(&matrix, Some(options)).unwrap();
+    let borrowed = start.elapsed();
+
+    let left = lu_inplace.left(false);
+    let right = lu_inplace.right(false);
+    let checksum = if left.nrows() > 0 && left.ncols() > 0 {
+        left[[0, 0]].abs()
+    } else {
+        0.0
+    } + if right.nrows() > 0 && right.ncols() > 0 {
+        right[[0, 0]].abs()
+    } else {
+        0.0
+    };
+
+    MatrixLuTiming {
+        inplace,
+        borrowed,
+        rank: lu_borrowed.npivots(),
+        last_error: lu_borrowed.last_pivot_error(),
+        checksum,
+    }
+}
+
+fn main() {
+    let repeats = parse_env_usize("T4A_MATRIX_LU_REPEATS", 20);
+    let sizes = parse_env_usize_list("T4A_MATRIX_LU_SIZES", vec![16, 32, 64, 128]);
+
+    println!(
+        "impl,matrix,size,repeats,left_orthogonal,inplace_ms,borrowed_ms,rank,last_error,checksum"
+    );
+    for size in sizes {
+        for left_orthogonal in [true, false] {
+            let runs = (0..repeats)
+                .map(|_| timed_hilbert_matrix_lu_once(size, left_orthogonal))
+                .collect::<Vec<_>>();
+            let first = runs[0];
+            println!(
+                "rust,hilbert,{size},{repeats},{left_orthogonal},{:.6},{:.6},{},{:.6e},{:.6e}",
+                timing_median(runs.iter().map(|run| timing_ms(run.inplace)).collect()),
+                timing_median(runs.iter().map(|run| timing_ms(run.borrowed)).collect()),
+                first.rank,
+                first.last_error,
+                first.checksum,
+            );
+        }
+    }
+}

--- a/benchmarks/rust/benchmark_matrix_lu.rs
+++ b/benchmarks/rust/benchmark_matrix_lu.rs
@@ -48,7 +48,7 @@ fn timing_ms(duration: Duration) -> f64 {
 fn timing_median(mut values: Vec<f64>) -> f64 {
     values.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let mid = values.len() / 2;
-    if values.len() % 2 == 0 {
+    if values.len().is_multiple_of(2) {
         0.5 * (values[mid - 1] + values[mid])
     } else {
         values[mid]

--- a/benchmarks/rust/benchmark_tt_ops.rs
+++ b/benchmarks/rust/benchmark_tt_ops.rs
@@ -215,9 +215,9 @@ fn make_native_mps_t4a_shapes(
 }
 
 fn eager_mps_tensors(
-    ctx: &Arc<EagerContext<CpuBackend>>,
+    ctx: &Arc<EagerContext>,
     tensors: Vec<Tensor>,
-) -> Vec<EagerTensor<CpuBackend>> {
+) -> Vec<EagerTensor> {
     tensors
         .into_iter()
         .map(|tensor| EagerTensor::from_tensor_in(tensor, Arc::clone(ctx)))
@@ -256,15 +256,15 @@ impl RawEagerInnerConfigs {
     }
 }
 
-fn maybe_snapshot_output(tensor: &EagerTensor<CpuBackend>, snapshot_outputs: bool) {
+fn maybe_snapshot_output(tensor: &EagerTensor, snapshot_outputs: bool) {
     if snapshot_outputs {
         black_box(tensor.data().clone());
     }
 }
 
 fn raw_eager_inner_t4a_shapes(
-    bra: &[EagerTensor<CpuBackend>],
-    ket: &[EagerTensor<CpuBackend>],
+    bra: &[EagerTensor],
+    ket: &[EagerTensor],
     configs: &RawEagerInnerConfigs,
     snapshot_outputs: bool,
 ) -> Result<Complex64> {
@@ -666,7 +666,7 @@ fn main() -> Result<()> {
         let bra = make_mps(&sites, chi, 0)?;
         let ket = make_mps(&sites, chi, opts.length)?;
         let bra_conj = preconjugate_sites(&bra)?;
-        let raw_ctx = EagerContext::with_backend(CpuBackend::with_threads(1));
+        let raw_ctx = EagerContext::with_cpu_backend(CpuBackend::with_threads(1));
         let raw_bra = eager_mps_tensors(
             &raw_ctx,
             make_native_mps_t4a_shapes(opts.length, opts.phys_dim, chi, 0),

--- a/crates/tensor4all-aci/Cargo.toml
+++ b/crates/tensor4all-aci/Cargo.toml
@@ -36,3 +36,8 @@ tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-featu
 
 [dev-dependencies]
 approx.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "elementwise_scaling"
+harness = false

--- a/crates/tensor4all-aci/Cargo.toml
+++ b/crates/tensor4all-aci/Cargo.toml
@@ -18,6 +18,11 @@ tenferro-cpu-faer = [
     "tensor4all-tcicore/tenferro-cpu-faer",
     "tensor4all-tensorbackend/tenferro-cpu-faer",
 ]
+tenferro-system-blas = [
+    "tensor4all-simplett/tenferro-system-blas",
+    "tensor4all-tcicore/tenferro-system-blas",
+    "tensor4all-tensorbackend/tenferro-system-blas",
+]
 tenferro-provider-inject = [
     "tensor4all-simplett/tenferro-provider-inject",
     "tensor4all-tcicore/tenferro-provider-inject",

--- a/crates/tensor4all-aci/Cargo.toml
+++ b/crates/tensor4all-aci/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "tensor4all-aci"
+description = "Alternating Cross Interpolation elementwise operations for tensor4all tensor trains"
+version.workspace = true
+edition.workspace = true
+authors = [
+    "Marc Ritter <mritter@flatironinstitute.org>",
+    "Hiroshi Shinaoka <h.shinaoka@gmail.com>",
+    "tensor4all contributors",
+]
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-simplett/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-simplett/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+]
+
+[dependencies]
+num-complex.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+rand_distr.workspace = true
+thiserror.workspace = true
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+
+[dev-dependencies]
+approx.workspace = true

--- a/crates/tensor4all-aci/NOTICE
+++ b/crates/tensor4all-aci/NOTICE
@@ -1,0 +1,6 @@
+This crate ports AlternatingCrossInterpolation.jl, originally authored by
+Marc Ritter <mritter@flatironinstitute.org> and contributors.
+
+Upstream copyright:
+
+Copyright (c) 2026 Marc Ritter <mritter@flatironinstitute.org> and contributors

--- a/crates/tensor4all-aci/README.md
+++ b/crates/tensor4all-aci/README.md
@@ -14,7 +14,13 @@ originally authored by Marc Ritter and contributors.
 - `AciOptions` - tolerance, sweep, rank, and pivot-search controls
 - `AciResult` - output tensor train and convergence diagnostics
 
-## Example
+## Examples
+
+### Julia-style elementwise multiplication
+
+`elementwise()` is the Rust counterpart of Julia
+`AlternatingCrossInterpolation.elementwise`. The operator receives one slice of
+input values per interpolation point.
 
 ```rust
 use tensor4all_aci::{elementwise, AciOptions};
@@ -33,6 +39,71 @@ let result = elementwise(
 assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
 assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 8.0).abs() < 1e-10);
 ```
+
+### Batched operator callback
+
+`elementwise_batched()` is a Rust extension for amortizing operator calls. The
+batch is a borrowed column-major view with `n_inputs` rows and `n_points`
+columns. Use `batch.get(input, point)` for checked access.
+
+```rust
+use tensor4all_aci::{elementwise_batched, AciOptions, ElementwiseBatch};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+
+let a = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+let b = TensorTrain::<f64>::constant(&[2, 3], 4.0);
+
+let result = elementwise_batched(
+    |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        for point in 0..batch.n_points() {
+            let a = batch.get(0, point)?;
+            let b = batch.get(1, point)?;
+            output[point] = a * b + 1.0;
+        }
+        Ok(())
+    },
+    &[a, b],
+    &AciOptions::default(),
+)
+.unwrap();
+
+assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 9.0).abs() < 1e-10);
+```
+
+For hot callbacks, the flat batch slice can be read directly. Values are stored
+as `data[input + n_inputs * point]`.
+
+```rust
+use tensor4all_aci::{elementwise_batched, AciOptions, ElementwiseBatch};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+
+let a = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+let b = TensorTrain::<f64>::constant(&[2, 3], 4.0);
+
+let result = elementwise_batched(
+    |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        let data = batch.as_col_major_slice();
+        let n_inputs = batch.n_inputs();
+
+        for point in 0..batch.n_points() {
+            let base = n_inputs * point;
+            output[point] = data[base] * data[base + 1];
+        }
+        Ok(())
+    },
+    &[a, b],
+    &AciOptions::default(),
+)
+.unwrap();
+
+assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+assert!((result.tensor_train.evaluate(&[0, 1]).unwrap() - 8.0).abs() < 1e-10);
+```
+
+`ElementwiseBatch` is not `tensor4all_simplett::TTCache`. ACI maintains
+left/right frames internally and uses `ElementwiseBatch` only to pass local
+matrix entries to the user operator efficiently.
 
 ## Citation
 

--- a/crates/tensor4all-aci/README.md
+++ b/crates/tensor4all-aci/README.md
@@ -1,0 +1,46 @@
+# tensor4all-aci
+
+Alternating Cross Interpolation (ACI) elementwise operations for tensor trains.
+
+This crate ports the public Rust API for
+[AlternatingCrossInterpolation.jl](https://github.com/tensor4all/AlternatingCrossInterpolation.jl),
+originally authored by Marc Ritter and contributors.
+
+## Key Types
+
+- `elementwise()` - approximate an elementwise operation on tensor trains
+- `elementwise_batched()` - batch-evaluation entry point for amortized function calls
+- `ElementwiseBatch` - column-major batch of tensor-train input values
+- `AciOptions` - tolerance, sweep, rank, and pivot-search controls
+- `AciResult` - output tensor train and convergence diagnostics
+
+## Example
+
+```rust
+use tensor4all_aci::{elementwise, AciOptions};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+
+let a = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+let b = TensorTrain::<f64>::constant(&[2, 3], 4.0);
+
+let result = elementwise(
+    |xs: &[f64]| xs[0] * xs[1],
+    &[a, b],
+    &AciOptions::default(),
+)
+.unwrap();
+
+assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 8.0).abs() < 1e-10);
+```
+
+## Citation
+
+If you use ACI in research, please cite the original ACI paper:
+
+> M. K. Ritter, "Fast elementwise operations on tensor trains with alternating
+> cross interpolation", arXiv:2604.00037 (2026).
+
+## Documentation
+
+- [API Reference](https://tensor4all.org/tensor4all-rs/rustdoc/tensor4all_aci/)

--- a/crates/tensor4all-aci/benches/elementwise_scaling.rs
+++ b/crates/tensor4all-aci/benches/elementwise_scaling.rs
@@ -1,0 +1,256 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tensor4all_aci::{elementwise_batched, AciOptions, AciResult, ElementwiseBatch};
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
+
+const N_SITES: usize = 12;
+const LOCAL_DIM: usize = 2;
+const N_INPUTS: usize = 2;
+const TOLERANCE: f64 = 1e-10;
+const MAX_ITERS: usize = 20;
+const SAMPLE_POINTS: usize = 64;
+const DEFAULT_CHI_VALUES: [usize; 4] = [2, 4, 8, 16];
+const OPTIONAL_CHI: usize = 32;
+
+fn link_dims(n_sites: usize, local_dim: usize, chi: usize) -> Vec<usize> {
+    (0..n_sites.saturating_sub(1))
+        .map(|bond| {
+            let left_sites = bond + 1;
+            let right_sites = n_sites - left_sites;
+            let max_exact_rank = local_dim.pow(left_sites.min(right_sites) as u32);
+            chi.min(max_exact_rank).max(1)
+        })
+        .collect()
+}
+
+fn core_value(
+    input_index: usize,
+    site: usize,
+    physical: usize,
+    left: usize,
+    right: usize,
+    left_dim: usize,
+    right_dim: usize,
+) -> f64 {
+    let input = input_index as f64 + 1.0;
+    let site = site as f64 + 1.0;
+    let physical = physical as f64 + 1.0;
+    let left = left as f64 + 1.0;
+    let right = right as f64 + 1.0;
+    let left_coord = left / (left_dim as f64 + 1.0);
+    let right_coord = right / (right_dim as f64 + 1.0);
+    let phase = 0.173 * input * site
+        + 0.193 * physical
+        + 0.071 * left * right
+        + 0.109 * input * left
+        + 0.131 * site * right;
+    let bond_mix = 0.29 * phase.sin()
+        + 0.23 * (0.157 * input * physical * right + 0.211 * site * left).cos()
+        + 0.17 * (left_coord - right_coord) * physical;
+    let site_value = 0.31 + bond_mix;
+    let scale = ((left_dim * right_dim) as f64).powf(0.25);
+    site_value / scale
+}
+
+fn col_major_index3(
+    left: usize,
+    physical: usize,
+    right: usize,
+    left_dim: usize,
+    site_dim: usize,
+) -> usize {
+    left + left_dim * (physical + site_dim * right)
+}
+
+fn deterministic_tt(
+    input_index: usize,
+    n_sites: usize,
+    local_dim: usize,
+    chi: usize,
+) -> TensorTrain<f64> {
+    let links = link_dims(n_sites, local_dim, chi);
+    let cores = (0..n_sites)
+        .map(|site| {
+            let left_dim = if site == 0 { 1 } else { links[site - 1] };
+            let right_dim = links.get(site).copied().unwrap_or(1);
+            let mut data = vec![0.0; left_dim * local_dim * right_dim];
+            for right in 0..right_dim {
+                for physical in 0..local_dim {
+                    for left in 0..left_dim {
+                        data[col_major_index3(left, physical, right, left_dim, local_dim)] =
+                            core_value(
+                                input_index,
+                                site,
+                                physical,
+                                left,
+                                right,
+                                left_dim,
+                                right_dim,
+                            );
+                    }
+                }
+            }
+            tensor3_from_data(data, left_dim, local_dim, right_dim)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .expect("deterministic benchmark cores should have valid dimensions");
+    TensorTrain::new(cores).expect("deterministic benchmark tensor train should be valid")
+}
+
+fn deterministic_inputs(chi: usize) -> Vec<TensorTrain<f64>> {
+    (0..N_INPUTS)
+        .map(|input_index| deterministic_tt(input_index, N_SITES, LOCAL_DIM, chi))
+        .collect()
+}
+
+fn deterministic_initial_guess(chi: usize) -> TensorTrain<f64> {
+    deterministic_tt(N_INPUTS, N_SITES, LOCAL_DIM, chi)
+}
+
+fn multiply_batch(
+    batch: ElementwiseBatch<'_, f64>,
+    output: &mut [f64],
+) -> tensor4all_aci::Result<()> {
+    for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+        let mut product = 1.0;
+        for input in 0..batch.n_inputs() {
+            product *= batch.get(input, point)?;
+        }
+        *value = product;
+    }
+    Ok(())
+}
+
+fn sample_index(sample: usize, chi: usize) -> Vec<usize> {
+    let mut state = (sample as u64 + 1).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        ^ (chi as u64 + 17).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    (0..N_SITES)
+        .map(|site| {
+            state ^= state >> 30;
+            state = state.wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            state ^= state >> 27;
+            state = state.wrapping_mul(0x94D0_49BB_1331_11EB);
+            ((state ^ (site as u64)) as usize) % LOCAL_DIM
+        })
+        .collect()
+}
+
+fn sampled_max_abs_error(
+    inputs: &[TensorTrain<f64>],
+    output: &TensorTrain<f64>,
+    chi: usize,
+) -> f64 {
+    (0..SAMPLE_POINTS)
+        .map(|sample| {
+            let index = sample_index(sample, chi);
+            let expected = inputs
+                .iter()
+                .map(|input| input.evaluate(&index).expect("sample input evaluation"))
+                .product::<f64>();
+            let actual = output
+                .evaluate(&index)
+                .expect("sample output evaluation should succeed");
+            (actual - expected).abs()
+        })
+        .fold(0.0, f64::max)
+}
+
+fn run_aci(inputs: &[TensorTrain<f64>], initial_guess: &TensorTrain<f64>) -> AciResult<f64> {
+    let options = AciOptions {
+        max_iters: MAX_ITERS,
+        tolerance: TOLERANCE,
+        initial_guess: Some(initial_guess.clone()),
+        ..AciOptions::default()
+    };
+    elementwise_batched(multiply_batch, inputs, &options)
+        .expect("ACI elementwise multiplication benchmark should converge")
+}
+
+fn assert_nontrivial_output_rank(chi: usize, output_max_chi: usize) {
+    if chi <= 2 {
+        return;
+    }
+
+    assert!(
+        output_max_chi > 1,
+        "deterministic chi-scaling fixture collapsed to rank one for chi={chi}"
+    );
+}
+
+fn bench_aci_elementwise_chi_scaling(c: &mut Criterion) {
+    let mut group = c.benchmark_group("aci_elementwise_chi_scaling");
+    for chi in DEFAULT_CHI_VALUES {
+        let inputs = deterministic_inputs(chi);
+        let initial_guess = deterministic_initial_guess(chi);
+        let checked = run_aci(&inputs, &initial_guess);
+        let sampled_error = sampled_max_abs_error(&inputs, &checked.tensor_train, chi);
+        assert!(
+            sampled_error < 1e-8,
+            "sampled max abs error for chi={chi} was {sampled_error:e}"
+        );
+
+        let output_max_chi = checked.tensor_train.rank();
+        assert_nontrivial_output_rank(chi, output_max_chi);
+        let n_sweeps = checked.ranks.len();
+        let final_error = checked.errors.last().copied().unwrap_or(0.0);
+        println!(
+            "aci_elementwise_metadata,impl=rust,n_sites={N_SITES},local_dim={LOCAL_DIM},\
+             n_inputs={N_INPUTS},chi={chi},tolerance={TOLERANCE:.1e},\
+             output_max_chi={output_max_chi},n_sweeps={n_sweeps},\
+             final_error={final_error:.6e},sampled_max_abs_error={sampled_error:.6e}"
+        );
+
+        group.bench_with_input(BenchmarkId::from_parameter(chi), &chi, |b, _| {
+            b.iter(|| {
+                black_box(run_aci(black_box(&inputs), black_box(&initial_guess)));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn command_line_requests_long_case() -> bool {
+    std::env::args()
+        .any(|arg| arg.contains("aci_elementwise_chi_scaling_long") || arg.contains("chi32"))
+}
+
+fn bench_aci_elementwise_chi_scaling_long(c: &mut Criterion) {
+    if !command_line_requests_long_case() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("aci_elementwise_chi_scaling_long");
+    let chi = OPTIONAL_CHI;
+    let inputs = deterministic_inputs(chi);
+    let initial_guess = deterministic_initial_guess(chi);
+    let checked = run_aci(&inputs, &initial_guess);
+    let sampled_error = sampled_max_abs_error(&inputs, &checked.tensor_train, chi);
+    assert!(
+        sampled_error < 1e-8,
+        "sampled max abs error for chi={chi} was {sampled_error:e}"
+    );
+
+    let output_max_chi = checked.tensor_train.rank();
+    assert_nontrivial_output_rank(chi, output_max_chi);
+    let n_sweeps = checked.ranks.len();
+    let final_error = checked.errors.last().copied().unwrap_or(0.0);
+    println!(
+        "aci_elementwise_metadata,impl=rust,n_sites={N_SITES},local_dim={LOCAL_DIM},\
+         n_inputs={N_INPUTS},chi={chi},tolerance={TOLERANCE:.1e},\
+         output_max_chi={output_max_chi},n_sweeps={n_sweeps},\
+         final_error={final_error:.6e},sampled_max_abs_error={sampled_error:.6e}"
+    );
+
+    group.bench_with_input(BenchmarkId::from_parameter(chi), &chi, |b, _| {
+        b.iter(|| {
+            black_box(run_aci(black_box(&inputs), black_box(&initial_guess)));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    aci_elementwise_chi_scaling,
+    bench_aci_elementwise_chi_scaling,
+    bench_aci_elementwise_chi_scaling_long
+);
+criterion_main!(aci_elementwise_chi_scaling);

--- a/crates/tensor4all-aci/src/batch.rs
+++ b/crates/tensor4all-aci/src/batch.rs
@@ -1,0 +1,203 @@
+//! Batched input views for elementwise ACI operators.
+
+use crate::{AciError, Result};
+
+/// Borrowed column-major input batch for an elementwise operator.
+///
+/// `ElementwiseBatch` views a flat slice as a matrix with `n_inputs` rows and
+/// `n_points` columns. Values use column-major layout: the value for input
+/// `input` at interpolation point `point` is stored at
+/// `input + n_inputs * point`.
+///
+/// Related types: [`AciOptions`](crate::AciOptions) configures ACI runs that
+/// evaluate operators over batches, while [`AciError`] reports shape and access
+/// errors for invalid batches.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::ElementwiseBatch;
+///
+/// let values = [10.0, 20.0, 11.0, 21.0, 12.0, 22.0];
+/// let batch = ElementwiseBatch::new(&values, 2, 3).unwrap();
+///
+/// assert_eq!(batch.n_inputs(), 2);
+/// assert_eq!(batch.n_points(), 3);
+/// assert_eq!(batch.get(0, 0).unwrap(), 10.0);
+/// assert_eq!(batch.get(1, 0).unwrap(), 20.0);
+/// assert_eq!(batch.get(0, 2).unwrap(), 12.0);
+/// assert_eq!(batch.get(1, 2).unwrap(), 22.0);
+/// assert_eq!(batch.as_col_major_slice(), values.as_slice());
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ElementwiseBatch<'a, T> {
+    values: &'a [T],
+    n_inputs: usize,
+    n_points: usize,
+}
+
+impl<'a, T> ElementwiseBatch<'a, T> {
+    /// Creates a borrowed column-major batch view.
+    ///
+    /// `values` must contain exactly `n_inputs * n_points` entries in
+    /// column-major order. Both `n_inputs` and `n_points` must be nonzero.
+    ///
+    /// # Arguments
+    ///
+    /// * `values` - Flat column-major values with inputs varying fastest.
+    /// * `n_inputs` - Number of operator inputs per interpolation point.
+    /// * `n_points` - Number of interpolation points in the batch.
+    ///
+    /// # Returns
+    ///
+    /// Returns an [`ElementwiseBatch`] borrowing `values` when the length and
+    /// dimensions are valid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AciError::EmptyInputs`] when `n_inputs` or `n_points` is zero,
+    /// [`AciError::InvalidOptions`] if the product overflows `usize`, and
+    /// [`AciError::LengthMismatch`] if `values.len()` does not equal
+    /// `n_inputs * n_points`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_aci::ElementwiseBatch;
+    ///
+    /// let values = [1, 2, 3, 4];
+    /// let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+    /// assert_eq!(batch.n_inputs(), 2);
+    /// assert_eq!(batch.n_points(), 2);
+    /// assert_eq!(batch.get(1, 1).unwrap(), 4);
+    /// ```
+    ///
+    /// ```
+    /// use tensor4all_aci::{AciError, ElementwiseBatch};
+    ///
+    /// let err = ElementwiseBatch::<f64>::new(&[1.0, 2.0, 3.0], 2, 2).unwrap_err();
+    /// assert!(matches!(err, AciError::LengthMismatch { expected: 4, got: 3 }));
+    /// assert!(err.to_string().contains("length"));
+    /// ```
+    pub fn new(values: &'a [T], n_inputs: usize, n_points: usize) -> Result<Self> {
+        if n_inputs == 0 || n_points == 0 {
+            return Err(AciError::EmptyInputs);
+        }
+
+        let expected = n_inputs
+            .checked_mul(n_points)
+            .ok_or_else(|| AciError::InvalidOptions {
+                message: format!(
+                    "batch shape overflows usize: n_inputs={n_inputs}, n_points={n_points}"
+                ),
+            })?;
+
+        if values.len() != expected {
+            return Err(AciError::LengthMismatch {
+                expected,
+                got: values.len(),
+            });
+        }
+
+        Ok(Self {
+            values,
+            n_inputs,
+            n_points,
+        })
+    }
+
+    /// Returns the number of operator inputs per interpolation point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_aci::ElementwiseBatch;
+    ///
+    /// let values = [0.0, 1.0, 2.0, 3.0];
+    /// let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+    /// assert_eq!(batch.n_inputs(), 2);
+    /// ```
+    pub fn n_inputs(&self) -> usize {
+        self.n_inputs
+    }
+
+    /// Returns the number of interpolation points in the batch.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_aci::ElementwiseBatch;
+    ///
+    /// let values = [0.0, 1.0, 2.0, 3.0];
+    /// let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+    /// assert_eq!(batch.n_points(), 2);
+    /// ```
+    pub fn n_points(&self) -> usize {
+        self.n_points
+    }
+
+    /// Returns one value using column-major indexing.
+    ///
+    /// The returned value is `values[input + n_inputs * point]`, so `input`
+    /// varies fastest in the flat buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - Zero-based input index, less than [`n_inputs`](Self::n_inputs).
+    /// * `point` - Zero-based interpolation point, less than [`n_points`](Self::n_points).
+    ///
+    /// # Returns
+    ///
+    /// Returns a copy of the requested value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AciError::SiteDimMismatch`] if `input` is out of range and
+    /// [`AciError::LengthMismatch`] if `point` is out of range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_aci::ElementwiseBatch;
+    ///
+    /// let values = [10, 20, 11, 21];
+    /// let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+    /// assert_eq!(batch.get(0, 1).unwrap(), 11);
+    /// assert_eq!(batch.get(1, 1).unwrap(), 21);
+    /// ```
+    pub fn get(&self, input: usize, point: usize) -> Result<T>
+    where
+        T: Copy,
+    {
+        if input >= self.n_inputs {
+            return Err(AciError::SiteDimMismatch {
+                site: point,
+                expected: self.n_inputs,
+                got: input.saturating_add(1),
+            });
+        }
+        if point >= self.n_points {
+            return Err(AciError::LengthMismatch {
+                expected: self.n_points,
+                got: point.saturating_add(1),
+            });
+        }
+
+        Ok(self.values[input + self.n_inputs * point])
+    }
+
+    /// Returns the borrowed flat slice in column-major input/point layout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_aci::ElementwiseBatch;
+    ///
+    /// let values = [10.0, 20.0, 11.0, 21.0];
+    /// let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+    /// assert_eq!(batch.as_col_major_slice(), values.as_slice());
+    /// ```
+    pub fn as_col_major_slice(&self) -> &'a [T] {
+        self.values
+    }
+}

--- a/crates/tensor4all-aci/src/batch.rs
+++ b/crates/tensor4all-aci/src/batch.rs
@@ -152,8 +152,8 @@ impl<'a, T> ElementwiseBatch<'a, T> {
     ///
     /// # Errors
     ///
-    /// Returns [`AciError::SiteDimMismatch`] if `input` is out of range and
-    /// [`AciError::LengthMismatch`] if `point` is out of range.
+    /// Returns [`AciError::BatchIndexOutOfBounds`] if `input` or `point` is
+    /// outside the corresponding batch axis.
     ///
     /// # Examples
     ///
@@ -165,21 +165,38 @@ impl<'a, T> ElementwiseBatch<'a, T> {
     /// assert_eq!(batch.get(0, 1).unwrap(), 11);
     /// assert_eq!(batch.get(1, 1).unwrap(), 21);
     /// ```
+    ///
+    /// ```
+    /// use tensor4all_aci::{AciError, ElementwiseBatch};
+    ///
+    /// let values = [10, 20, 11, 21];
+    /// let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+    /// let err = batch.get(2, 0).unwrap_err();
+    /// assert!(matches!(
+    ///     err,
+    ///     AciError::BatchIndexOutOfBounds {
+    ///         axis: "input",
+    ///         index: 2,
+    ///         len: 2
+    ///     }
+    /// ));
+    /// ```
     pub fn get(&self, input: usize, point: usize) -> Result<T>
     where
         T: Copy,
     {
         if input >= self.n_inputs {
-            return Err(AciError::SiteDimMismatch {
-                site: point,
-                expected: self.n_inputs,
-                got: input.saturating_add(1),
+            return Err(AciError::BatchIndexOutOfBounds {
+                axis: "input",
+                index: input,
+                len: self.n_inputs,
             });
         }
         if point >= self.n_points {
-            return Err(AciError::LengthMismatch {
-                expected: self.n_points,
-                got: point.saturating_add(1),
+            return Err(AciError::BatchIndexOutOfBounds {
+                axis: "point",
+                index: point,
+                len: self.n_points,
             });
         }
 

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -1,0 +1,222 @@
+//! Public elementwise Alternating Cross Interpolation sweep APIs.
+
+use crate::scalar::AciScalar;
+use crate::validation::{validate_inputs, validate_options};
+use crate::{AciOptions, AciResult, ElementwiseBatch, ElementwiseProblem, Result};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+
+/// Runs batched elementwise ACI over tensor-train inputs.
+///
+/// This function approximates the pointwise application of `op` to `inputs`.
+/// The callback receives batches in column-major input/point layout through
+/// [`ElementwiseBatch`] and writes one output value per interpolation point.
+/// Forward and backward sweeps alternate until the configured iteration limit
+/// is reached or the conservative convergence rule accepts the current ranks
+/// and maximum pivot error.
+///
+/// For single-site tensor trains there are no bonds to sweep, so the returned
+/// [`AciResult`] contains the initialized tensor train and empty `ranks` and
+/// `errors` histories.
+///
+/// # Arguments
+///
+/// * `op` - Batched callback. For each point, write the elementwise output to
+///   the corresponding entry of the output slice. Return
+///   [`AciError::Operator`](crate::AciError::Operator) or another ACI error to
+///   stop the sweep.
+/// * `inputs` - Non-empty tensor trains with the same length and site
+///   dimensions. Core dimensions must be positive.
+/// * `options` - Sweep limits, tolerance, maximum bond dimension, random seed,
+///   and optional initial guess. When in doubt, start with
+///   [`AciOptions::default`].
+///
+/// # Returns
+///
+/// Returns an [`AciResult`] containing the approximating tensor train plus one
+/// rank and error sample after each completed sweep.
+///
+/// # Errors
+///
+/// Returns [`AciError`](crate::AciError) when options or inputs are invalid,
+/// initial guess construction fails, the operator callback fails, or a local
+/// matrix-CI update fails.
+///
+/// # Panics
+///
+/// This function does not intentionally panic. A panic from the caller-provided
+/// `op` callback is not caught.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::{elementwise_batched, AciOptions, ElementwiseBatch};
+/// use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+///
+/// let a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+/// let b = TensorTrain::<f64>::constant(&[2, 2], 3.0);
+/// let result = elementwise_batched(
+///     |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+///         for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+///             *value = batch.get(0, point)? * batch.get(1, point)?;
+///         }
+///         Ok(())
+///     },
+///     &[a, b],
+///     &AciOptions::default(),
+/// )
+/// .unwrap();
+///
+/// assert!((result.tensor_train.evaluate(&[0, 0]).unwrap() - 6.0).abs() < 1e-12);
+/// assert!((result.tensor_train.evaluate(&[1, 1]).unwrap() - 6.0).abs() < 1e-12);
+/// assert_eq!(result.ranks.len(), result.errors.len());
+/// ```
+pub fn elementwise_batched<T, F>(
+    mut op: F,
+    inputs: &[TensorTrain<T>],
+    options: &AciOptions<T>,
+) -> Result<AciResult<T>>
+where
+    T: AciScalar,
+    F: for<'batch> FnMut(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
+{
+    validate_options(options)?;
+    validate_inputs(inputs)?;
+
+    let mut problem = ElementwiseProblem::new(inputs.to_vec(), options.clone())?;
+    if problem.len() == 1 {
+        return Ok(AciResult {
+            tensor_train: problem.solution,
+            ranks: Vec::new(),
+            errors: Vec::new(),
+        });
+    }
+
+    let mut ranks = Vec::new();
+    let mut errors = Vec::new();
+
+    for iteration in 0..options.max_iters {
+        let forward = iteration % 2 == 0;
+        if forward {
+            for bond in 0..problem.len() - 1 {
+                problem.local_update(bond, true, options, &mut op)?;
+            }
+        } else {
+            for bond in (0..problem.len() - 1).rev() {
+                problem.local_update(bond, false, options, &mut op)?;
+            }
+        }
+
+        let max_error = problem.pivot_errors.iter().copied().fold(0.0_f64, f64::max);
+        ranks.push(problem.solution.rank());
+        errors.push(max_error);
+
+        if iteration + 1 >= options.min_iters
+            && max_error <= options.tolerance
+            && ranks_are_stable(&ranks, options.min_iters)
+        {
+            break;
+        }
+    }
+
+    Ok(AciResult {
+        tensor_train: problem.solution,
+        ranks,
+        errors,
+    })
+}
+
+/// Runs scalar elementwise ACI over tensor-train inputs.
+///
+/// This convenience wrapper evaluates `op` once per interpolation point. The
+/// callback receives one value from each input tensor train in input order and
+/// returns the corresponding output value. Use [`elementwise_batched`] when the
+/// operator can evaluate many points more efficiently at once or can fail.
+///
+/// # Arguments
+///
+/// * `op` - Scalar callback applied to one interpolation point. The input slice
+///   has length `inputs.len()`.
+/// * `inputs` - Non-empty tensor trains with the same length and site
+///   dimensions. Core dimensions must be positive.
+/// * `options` - Sweep limits, tolerance, maximum bond dimension, random seed,
+///   and optional initial guess.
+///
+/// # Returns
+///
+/// Returns an [`AciResult`] containing the approximating tensor train plus
+/// sweep-by-sweep rank and error histories.
+///
+/// # Errors
+///
+/// Returns [`AciError`](crate::AciError) when options or inputs are invalid,
+/// batch extraction fails, initial guess construction fails, or a local
+/// matrix-CI update fails.
+///
+/// # Panics
+///
+/// This function does not intentionally panic. A panic from the caller-provided
+/// `op` callback is not caught.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::{elementwise, AciOptions};
+/// use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+///
+/// let a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+/// let b = TensorTrain::<f64>::constant(&[2, 2], 5.0);
+/// let result = elementwise(
+///     |values| values[0] + values[1],
+///     &[a, b],
+///     &AciOptions::default(),
+/// )
+/// .unwrap();
+///
+/// assert!((result.tensor_train.evaluate(&[0, 0]).unwrap() - 7.0).abs() < 1e-12);
+/// assert!((result.tensor_train.evaluate(&[1, 1]).unwrap() - 7.0).abs() < 1e-12);
+/// assert_eq!(result.ranks.len(), result.errors.len());
+/// ```
+pub fn elementwise<T, F>(
+    mut op: F,
+    inputs: &[TensorTrain<T>],
+    options: &AciOptions<T>,
+) -> Result<AciResult<T>>
+where
+    T: AciScalar,
+    F: FnMut(&[T]) -> T,
+{
+    let mut scratch = Vec::new();
+    elementwise_batched(
+        |batch, output| {
+            scratch.clear();
+            scratch.reserve(batch.n_inputs());
+            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+                scratch.clear();
+                for input in 0..batch.n_inputs() {
+                    scratch.push(batch.get(input, point)?);
+                }
+                *value = op(&scratch);
+            }
+            Ok(())
+        },
+        inputs,
+        options,
+    )
+}
+
+fn ranks_are_stable(ranks: &[usize], min_iters: usize) -> bool {
+    if ranks.is_empty() || min_iters == 0 {
+        return min_iters == 0;
+    }
+
+    if ranks.len() > min_iters {
+        let baseline_index = ranks.len() - min_iters - 1;
+        let baseline = ranks[baseline_index];
+        ranks[baseline_index + 1..]
+            .iter()
+            .all(|&rank| rank <= baseline)
+    } else {
+        let baseline = ranks[0];
+        ranks.iter().all(|&rank| rank <= baseline)
+    }
+}

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -13,8 +13,9 @@ use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
 /// Forward and backward sweeps alternate until the configured iteration limit
 /// is reached or the conservative convergence rule accepts the current ranks
 /// and maximum error metric. When [`AciOptions::scale_tolerance`] is enabled,
-/// the metric is the maximum pivot error divided by the largest sampled
-/// operator-output magnitude from the completed sweep.
+/// each bond's pivot error is divided by that bond's largest sampled
+/// operator-output magnitude from the completed sweep, and the largest
+/// normalized value is used.
 ///
 /// For single-site tensor trains there are no bonds to sweep. In that case the
 /// operator is evaluated once over all site points, and the returned

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -234,21 +234,14 @@ where
     )
 }
 
-fn ranks_are_stable(ranks: &[usize], min_iters: usize) -> bool {
+pub(crate) fn ranks_are_stable(ranks: &[usize], min_iters: usize) -> bool {
     if ranks.is_empty() || min_iters == 0 {
         return min_iters == 0;
     }
 
-    if ranks.len() > min_iters {
-        let baseline_index = ranks.len() - min_iters - 1;
-        let baseline = ranks[baseline_index];
-        ranks[baseline_index + 1..]
-            .iter()
-            .all(|&rank| rank <= baseline)
-    } else {
-        let baseline = ranks[0];
-        ranks.iter().all(|&rank| rank <= baseline)
-    }
+    let baseline_index = ranks.len().saturating_sub(min_iters);
+    let baseline = ranks[baseline_index];
+    ranks[baseline_index..].iter().all(|&rank| rank <= baseline)
 }
 
 pub(crate) fn error_metric(

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -105,10 +105,11 @@ where
             }
         }
 
-        let max_pivot_error = problem.pivot_errors.iter().copied().fold(0.0_f64, f64::max);
-        let max_sampled_scale = problem.pivot_scales.iter().copied().fold(0.0_f64, f64::max);
-        let max_error_metric =
-            error_metric(max_pivot_error, max_sampled_scale, options.scale_tolerance);
+        let max_error_metric = max_error_metric(
+            &problem.pivot_errors,
+            &problem.pivot_scales,
+            options.scale_tolerance,
+        );
         ranks.push(problem.solution.rank());
         errors.push(max_error_metric);
 
@@ -259,4 +260,19 @@ pub(crate) fn error_metric(
     } else {
         max_pivot_error
     }
+}
+
+pub(crate) fn max_error_metric(
+    pivot_errors: &[f64],
+    pivot_scales: &[f64],
+    scale_tolerance: bool,
+) -> f64 {
+    pivot_errors
+        .iter()
+        .enumerate()
+        .map(|(bond, &error)| {
+            let scale = pivot_scales.get(bond).copied().unwrap_or(0.0);
+            error_metric(error, scale, scale_tolerance)
+        })
+        .fold(0.0_f64, f64::max)
 }

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -114,10 +114,13 @@ where
         ranks.push(problem.solution.rank());
         errors.push(max_error_metric);
 
-        if iteration + 1 >= options.min_iters
-            && max_error_metric <= options.tolerance
-            && ranks_are_stable(&ranks, options.min_iters)
-        {
+        if convergence_criterion_like_julia(
+            iteration + 1,
+            &ranks,
+            &errors,
+            options.min_iters,
+            options.tolerance,
+        ) {
             break;
         }
     }
@@ -234,6 +237,7 @@ where
     )
 }
 
+#[cfg(test)]
 pub(crate) fn ranks_are_stable(ranks: &[usize], min_iters: usize) -> bool {
     if ranks.is_empty() || min_iters == 0 {
         return min_iters == 0;
@@ -242,6 +246,33 @@ pub(crate) fn ranks_are_stable(ranks: &[usize], min_iters: usize) -> bool {
     let baseline_index = ranks.len().saturating_sub(min_iters);
     let baseline = ranks[baseline_index];
     ranks[baseline_index..].iter().all(|&rank| rank <= baseline)
+}
+
+pub(crate) fn convergence_criterion_like_julia(
+    iteration: usize,
+    ranks: &[usize],
+    errors: &[f64],
+    min_iters: usize,
+    tolerance: f64,
+) -> bool {
+    debug_assert!(iteration > 0);
+    debug_assert_eq!(ranks.len(), iteration);
+    debug_assert_eq!(errors.len(), iteration);
+
+    if iteration == 0 || min_iters == 0 {
+        return false;
+    }
+    if iteration < min_iters {
+        return false;
+    }
+    if errors[iteration - 1] > tolerance {
+        return false;
+    }
+
+    let baseline = ranks[iteration - min_iters];
+    !ranks[(iteration - min_iters)..iteration]
+        .iter()
+        .any(|&rank| rank > baseline)
 }
 
 pub(crate) fn error_metric(

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -3,7 +3,7 @@
 use crate::scalar::AciScalar;
 use crate::validation::{validate_inputs, validate_options};
 use crate::{AciOptions, AciResult, ElementwiseBatch, ElementwiseProblem, Result};
-use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
 
 /// Runs batched elementwise ACI over tensor-train inputs.
 ///
@@ -12,11 +12,13 @@ use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
 /// [`ElementwiseBatch`] and writes one output value per interpolation point.
 /// Forward and backward sweeps alternate until the configured iteration limit
 /// is reached or the conservative convergence rule accepts the current ranks
-/// and maximum pivot error.
+/// and maximum error metric. When [`AciOptions::scale_tolerance`] is enabled,
+/// the metric is the maximum pivot error divided by the largest sampled
+/// operator-output magnitude from the completed sweep.
 ///
-/// For single-site tensor trains there are no bonds to sweep, so the returned
-/// [`AciResult`] contains the initialized tensor train and empty `ranks` and
-/// `errors` histories.
+/// For single-site tensor trains there are no bonds to sweep. In that case the
+/// operator is evaluated once over all site points, and the returned
+/// [`AciResult`] contains empty `ranks` and `errors` histories.
 ///
 /// # Arguments
 ///
@@ -82,14 +84,11 @@ where
     validate_options(options)?;
     validate_inputs(inputs)?;
 
-    let mut problem = ElementwiseProblem::new(inputs.to_vec(), options.clone())?;
-    if problem.len() == 1 {
-        return Ok(AciResult {
-            tensor_train: problem.solution,
-            ranks: Vec::new(),
-            errors: Vec::new(),
-        });
+    if inputs[0].len() == 1 {
+        return elementwise_batched_one_site(op, inputs);
     }
+
+    let mut problem = ElementwiseProblem::new(inputs.to_vec(), options.clone())?;
 
     let mut ranks = Vec::new();
     let mut errors = Vec::new();
@@ -106,12 +105,15 @@ where
             }
         }
 
-        let max_error = problem.pivot_errors.iter().copied().fold(0.0_f64, f64::max);
+        let max_pivot_error = problem.pivot_errors.iter().copied().fold(0.0_f64, f64::max);
+        let max_sampled_scale = problem.pivot_scales.iter().copied().fold(0.0_f64, f64::max);
+        let max_error_metric =
+            error_metric(max_pivot_error, max_sampled_scale, options.scale_tolerance);
         ranks.push(problem.solution.rank());
-        errors.push(max_error);
+        errors.push(max_error_metric);
 
         if iteration + 1 >= options.min_iters
-            && max_error <= options.tolerance
+            && max_error_metric <= options.tolerance
             && ranks_are_stable(&ranks, options.min_iters)
         {
             break;
@@ -122,6 +124,32 @@ where
         tensor_train: problem.solution,
         ranks,
         errors,
+    })
+}
+
+fn elementwise_batched_one_site<T, F>(mut op: F, inputs: &[TensorTrain<T>]) -> Result<AciResult<T>>
+where
+    T: AciScalar,
+    F: for<'batch> FnMut(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
+{
+    let n_inputs = inputs.len();
+    let n_points = inputs[0].site_dim(0);
+    let mut input_values = vec![T::zero(); n_inputs * n_points];
+    for point in 0..n_points {
+        for input in 0..n_inputs {
+            input_values[input + n_inputs * point] = inputs[input].evaluate(&[point])?;
+        }
+    }
+
+    let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
+    let mut output = vec![T::zero(); n_points];
+    op(batch, &mut output)?;
+
+    let core = tensor3_from_data(output, 1, n_points, 1)?;
+    Ok(AciResult {
+        tensor_train: TensorTrain::new(vec![core])?,
+        ranks: Vec::new(),
+        errors: Vec::new(),
     })
 }
 
@@ -218,5 +246,17 @@ fn ranks_are_stable(ranks: &[usize], min_iters: usize) -> bool {
     } else {
         let baseline = ranks[0];
         ranks.iter().all(|&rank| rank <= baseline)
+    }
+}
+
+pub(crate) fn error_metric(
+    max_pivot_error: f64,
+    max_sampled_scale: f64,
+    scale_tolerance: bool,
+) -> f64 {
+    if scale_tolerance && max_sampled_scale > 0.0 {
+        max_pivot_error / max_sampled_scale
+    } else {
+        max_pivot_error
     }
 }

--- a/crates/tensor4all-aci/src/error.rs
+++ b/crates/tensor4all-aci/src/error.rs
@@ -26,6 +26,13 @@ pub type Result<T> = std::result::Result<T, AciError>;
 ///     message: "operator failed at point 3".to_string(),
 /// };
 /// assert!(err.to_string().contains("operator failed"));
+///
+/// let err = AciError::BatchIndexOutOfBounds {
+///     axis: "input",
+///     index: 4,
+///     len: 3,
+/// };
+/// assert!(err.to_string().contains("input index out of bounds"));
 /// ```
 #[derive(Debug, Error)]
 pub enum AciError {
@@ -51,6 +58,17 @@ pub enum AciError {
         expected: usize,
         /// Actual site dimension.
         got: usize,
+    },
+
+    /// A batch input or point index was outside the corresponding axis length.
+    #[error("ACI batch {axis} index out of bounds: index {index}, len {len}")]
+    BatchIndexOutOfBounds {
+        /// Batch axis name, such as `"input"` or `"point"`.
+        axis: &'static str,
+        /// Zero-based index requested by the caller.
+        index: usize,
+        /// Number of valid entries along the axis.
+        len: usize,
     },
 
     /// A configuration value or combination of values is invalid.

--- a/crates/tensor4all-aci/src/error.rs
+++ b/crates/tensor4all-aci/src/error.rs
@@ -1,0 +1,93 @@
+//! Error types for Alternating Cross Interpolation.
+
+use thiserror::Error;
+
+/// Result type for Alternating Cross Interpolation operations.
+pub type Result<T> = std::result::Result<T, AciError>;
+
+/// Errors that can occur while constructing or running ACI operations.
+///
+/// Use this error type when validating ACI inputs, options, initial tensor-train
+/// guesses, and operator callbacks. Errors from the lower-level matrix-CI and
+/// tensor-train crates are preserved through the corresponding variants.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::AciError;
+///
+/// let err = AciError::LengthMismatch {
+///     expected: 6,
+///     got: 5,
+/// };
+/// assert!(err.to_string().contains("length"));
+///
+/// let err = AciError::Operator {
+///     message: "operator failed at point 3".to_string(),
+/// };
+/// assert!(err.to_string().contains("operator failed"));
+/// ```
+#[derive(Debug, Error)]
+pub enum AciError {
+    /// No input tensors or input points were provided.
+    #[error("ACI requires at least one input and one interpolation point")]
+    EmptyInputs,
+
+    /// A flat buffer length did not match the shape implied by the caller.
+    #[error("ACI length mismatch: expected {expected} values, got {got}")]
+    LengthMismatch {
+        /// Number of values implied by the requested shape.
+        expected: usize,
+        /// Number of values supplied by the caller.
+        got: usize,
+    },
+
+    /// A tensor-train site dimension did not match the expected value.
+    #[error("ACI site dimension mismatch at site {site}: expected {expected}, got {got}")]
+    SiteDimMismatch {
+        /// Zero-based site where the mismatch occurred.
+        site: usize,
+        /// Expected site dimension.
+        expected: usize,
+        /// Actual site dimension.
+        got: usize,
+    },
+
+    /// A configuration value or combination of values is invalid.
+    #[error("Invalid ACI options: {message}")]
+    InvalidOptions {
+        /// Description of the invalid option value or relationship.
+        message: String,
+    },
+
+    /// The supplied initial tensor-train guess is incompatible with the ACI problem.
+    #[error("Invalid ACI initial guess: {message}")]
+    InvalidInitialGuess {
+        /// Description of the incompatible initial guess.
+        message: String,
+    },
+
+    /// An elementwise operator returned a buffer with the wrong length.
+    #[error("ACI operator output length mismatch: expected {expected}, got {got}")]
+    OperatorOutputLength {
+        /// Expected number of output values.
+        expected: usize,
+        /// Number of output values returned by the operator.
+        got: usize,
+    },
+
+    /// An elementwise operator reported an error.
+    #[error("ACI operator error: {message}")]
+    Operator {
+        /// Operator-provided error message.
+        message: String,
+    },
+
+    /// Error propagated from matrix cross interpolation.
+    #[error("Matrix CI error: {0}")]
+    MatrixCI(#[from] tensor4all_tcicore::MatrixCIError),
+
+    /// Error propagated from tensor-train construction or manipulation.
+    #[error("Tensor train error: {0}")]
+    TensorTrain(#[from] tensor4all_simplett::TensorTrainError),
+}

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -8,11 +8,19 @@
 mod batch;
 mod error;
 mod options;
+#[allow(dead_code)]
+mod random_tt;
 mod result;
+#[allow(dead_code)]
+mod scalar;
+#[allow(dead_code)]
+pub(crate) mod validation;
 
 pub use batch::ElementwiseBatch;
 pub use error::{AciError, Result};
 pub use options::AciOptions;
+#[allow(unused_imports)]
+pub(crate) use random_tt::initial_guess;
 pub use result::AciResult;
 
 #[cfg(test)]

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -14,6 +14,8 @@ mod result;
 #[allow(dead_code)]
 mod scalar;
 #[allow(dead_code)]
+mod state;
+#[allow(dead_code)]
 pub(crate) mod validation;
 
 pub use batch::ElementwiseBatch;
@@ -22,6 +24,8 @@ pub use options::AciOptions;
 #[allow(unused_imports)]
 pub(crate) use random_tt::initial_guess;
 pub use result::AciResult;
+#[allow(unused_imports)]
+pub(crate) use state::ElementwiseProblem;
 
 #[cfg(test)]
 mod tests;

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -5,7 +5,15 @@
 //! `AlternatingCrossInterpolation.jl`, originally authored by
 //! Marc Ritter <mritter@flatironinstitute.org> and contributors.
 
-/// Placeholder item until the public API is implemented.
-pub fn crate_ready() -> bool {
-    true
-}
+mod batch;
+mod error;
+mod options;
+mod result;
+
+pub use batch::ElementwiseBatch;
+pub use error::{AciError, Result};
+pub use options::AciOptions;
+pub use result::AciResult;
+
+#[cfg(test)]
+mod tests;

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -1,0 +1,11 @@
+#![warn(missing_docs)]
+//! Alternating Cross Interpolation for elementwise tensor-train operations.
+//!
+//! This crate ports the Rust public API for
+//! `AlternatingCrossInterpolation.jl`, originally authored by
+//! Marc Ritter <mritter@flatironinstitute.org> and contributors.
+
+/// Placeholder item until the public API is implemented.
+pub fn crate_ready() -> bool {
+    true
+}

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -4,6 +4,23 @@
 //! This crate ports the Rust public API for
 //! `AlternatingCrossInterpolation.jl`, originally authored by
 //! Marc Ritter <mritter@flatironinstitute.org> and contributors.
+//!
+//! ```
+//! use tensor4all_aci::{elementwise, AciOptions};
+//! use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+//!
+//! let a = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+//! let b = TensorTrain::<f64>::constant(&[2, 3], 4.0);
+//! let result = elementwise(
+//!     |xs: &[f64]| xs[0] * xs[1],
+//!     &[a, b],
+//!     &AciOptions::default(),
+//! )
+//! .unwrap();
+//!
+//! assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 8.0).abs() < 1e-10);
+//! assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+//! ```
 
 mod batch;
 mod elementwise;

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -7,6 +7,8 @@
 
 mod batch;
 mod error;
+#[allow(dead_code)]
+mod local;
 mod options;
 #[allow(dead_code)]
 mod random_tt;
@@ -20,6 +22,8 @@ pub(crate) mod validation;
 
 pub use batch::ElementwiseBatch;
 pub use error::{AciError, Result};
+#[allow(unused_imports)]
+pub(crate) use local::LocalBlockEvaluator;
 pub use options::AciOptions;
 #[allow(unused_imports)]
 pub(crate) use random_tt::initial_guess;

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -6,6 +6,7 @@
 //! Marc Ritter <mritter@flatironinstitute.org> and contributors.
 
 mod batch;
+mod elementwise;
 mod error;
 #[allow(dead_code)]
 mod local;
@@ -21,6 +22,7 @@ mod state;
 pub(crate) mod validation;
 
 pub use batch::ElementwiseBatch;
+pub use elementwise::{elementwise, elementwise_batched};
 pub use error::{AciError, Result};
 #[allow(unused_imports)]
 pub(crate) use local::LocalBlockEvaluator;
@@ -28,6 +30,7 @@ pub use options::AciOptions;
 #[allow(unused_imports)]
 pub(crate) use random_tt::initial_guess;
 pub use result::AciResult;
+pub use scalar::AciScalar;
 #[allow(unused_imports)]
 pub(crate) use state::ElementwiseProblem;
 

--- a/crates/tensor4all-aci/src/local.rs
+++ b/crates/tensor4all-aci/src/local.rs
@@ -4,16 +4,28 @@ use std::collections::HashMap;
 use crate::scalar::AciScalar;
 use crate::{AciError, ElementwiseBatch, ElementwiseProblem, Result};
 
+type LocalOperator<'a, T> =
+    dyn for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()> + 'a;
+
 pub(crate) struct LocalBlockEvaluator<'a, T: AciScalar> {
     problem: &'a ElementwiseProblem<T>,
+    operator: &'a LocalOperator<'a, T>,
     bond: usize,
     nrows: usize,
     ncols: usize,
     cache: RefCell<HashMap<usize, T>>,
+    first_error: RefCell<Option<AciError>>,
 }
 
 impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
-    pub(crate) fn new(problem: &'a ElementwiseProblem<T>, bond: usize) -> Result<Self> {
+    pub(crate) fn new<F>(
+        problem: &'a ElementwiseProblem<T>,
+        bond: usize,
+        operator: &'a F,
+    ) -> Result<Self>
+    where
+        F: for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()> + 'a,
+    {
         if problem.n_inputs() == 0 {
             return Err(AciError::EmptyInputs);
         }
@@ -33,10 +45,12 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
 
         Ok(Self {
             problem,
+            operator,
             bond,
             nrows,
             ncols,
             cache: RefCell::new(HashMap::new()),
+            first_error: RefCell::new(None),
         })
     }
 
@@ -48,16 +62,12 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
         self.ncols
     }
 
-    pub(crate) fn fill_local_block<F>(
+    pub(crate) fn fill_local_block(
         &self,
         rows: &[usize],
         cols: &[usize],
         out: &mut [T],
-        operator: F,
-    ) -> Result<()>
-    where
-        F: for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
-    {
+    ) -> Result<()> {
         let n_points = checked_local_mul(rows.len(), cols.len(), "local block point count")?;
         if out.len() != n_points {
             return Err(AciError::LengthMismatch {
@@ -114,7 +124,7 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
 
         let batch = ElementwiseBatch::new(&input_values, n_inputs, n_missing)?;
         let mut missing_output = vec![T::zero(); n_missing];
-        operator(batch, &mut missing_output)?;
+        (self.operator)(batch, &mut missing_output)?;
 
         {
             let mut cache = self.cache.borrow_mut();
@@ -131,8 +141,26 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
         Ok(())
     }
 
+    pub(crate) fn fill_local_block_or_zero(&self, rows: &[usize], cols: &[usize], out: &mut [T]) {
+        if let Err(err) = self.fill_local_block(rows, cols, out) {
+            self.record_error(err);
+            out.fill(T::zero());
+        }
+    }
+
+    pub(crate) fn take_error(&self) -> Option<AciError> {
+        self.first_error.borrow_mut().take()
+    }
+
     pub(crate) fn clear_cache(&self) {
         self.cache.borrow_mut().clear();
+    }
+
+    fn record_error(&self, err: AciError) {
+        let mut first_error = self.first_error.borrow_mut();
+        if first_error.is_none() {
+            *first_error = Some(err);
+        }
     }
 
     fn entry_key(&self, row: usize, col: usize) -> Result<usize> {

--- a/crates/tensor4all-aci/src/local.rs
+++ b/crates/tensor4all-aci/src/local.rs
@@ -330,7 +330,7 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
     pub(crate) fn apply_operator_to_input_values(&self, input_values: &[T]) -> Result<Matrix<T>> {
         let n_points = checked_local_mul(self.nrows, self.ncols, "local matrix entry count")?;
         let n_inputs = self.problem.n_inputs();
-        let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
+        let batch = ElementwiseBatch::new(input_values, n_inputs, n_points)?;
         let mut output = vec![T::zero(); n_points];
         (self.operator)(batch, &mut output)?;
         self.record_output_scale(&output);
@@ -611,8 +611,8 @@ fn build_left_factor<T: AciScalar>(
 ) -> Result<Vec<T>> {
     let frame = local_left_frame(problem, input, bond)?;
     let core_matrix = problem.input_core_left_matrix(input, bond);
-    let product = mat_mul(frame, &core_matrix)
-        .map_err(|err| local_factor_error("left factor matmul", err))?;
+    let product =
+        mat_mul(frame, core_matrix).map_err(|err| local_factor_error("left factor matmul", err))?;
     Ok(product.as_col_major_slice().to_vec())
 }
 
@@ -623,7 +623,7 @@ fn build_right_factor<T: AciScalar>(
 ) -> Result<Vec<T>> {
     let frame = local_right_frame(problem, input, bond)?;
     let core_matrix = problem.input_core_right_matrix(input, bond + 1);
-    let product = mat_mul(&core_matrix, frame)
+    let product = mat_mul(core_matrix, frame)
         .map_err(|err| local_factor_error("right factor matmul", err))?;
     Ok(product.as_col_major_slice().to_vec())
 }
@@ -647,11 +647,11 @@ fn validate_local_shapes<T: AciScalar>(
     Ok((nrows, ncols))
 }
 
-fn local_left_frame<'a, T: AciScalar>(
-    problem: &'a ElementwiseProblem<T>,
+fn local_left_frame<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
     input: usize,
     bond: usize,
-) -> Result<&'a tensor4all_tensorbackend::Matrix<T>> {
+) -> Result<&tensor4all_tensorbackend::Matrix<T>> {
     problem
         .left_frames
         .get(input)
@@ -662,11 +662,11 @@ fn local_left_frame<'a, T: AciScalar>(
         })
 }
 
-fn local_right_frame<'a, T: AciScalar>(
-    problem: &'a ElementwiseProblem<T>,
+fn local_right_frame<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
     input: usize,
     bond: usize,
-) -> Result<&'a tensor4all_tensorbackend::Matrix<T>> {
+) -> Result<&tensor4all_tensorbackend::Matrix<T>> {
     let site = bond + 2;
     problem
         .right_frames

--- a/crates/tensor4all-aci/src/local.rs
+++ b/crates/tensor4all-aci/src/local.rs
@@ -15,6 +15,7 @@ pub(crate) struct LocalBlockEvaluator<'a, T: AciScalar> {
     ncols: usize,
     cache: RefCell<HashMap<usize, T>>,
     first_error: RefCell<Option<AciError>>,
+    max_output_abs: RefCell<f64>,
 }
 
 impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
@@ -51,6 +52,7 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
             ncols,
             cache: RefCell::new(HashMap::new()),
             first_error: RefCell::new(None),
+            max_output_abs: RefCell::new(0.0),
         })
     }
 
@@ -125,6 +127,7 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
         let batch = ElementwiseBatch::new(&input_values, n_inputs, n_missing)?;
         let mut missing_output = vec![T::zero(); n_missing];
         (self.operator)(batch, &mut missing_output)?;
+        self.record_output_scale(&missing_output);
 
         {
             let mut cache = self.cache.borrow_mut();
@@ -156,6 +159,10 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
         self.cache.borrow_mut().clear();
     }
 
+    pub(crate) fn max_output_abs(&self) -> f64 {
+        *self.max_output_abs.borrow()
+    }
+
     fn record_error(&self, err: AciError) {
         let mut first_error = self.first_error.borrow_mut();
         if first_error.is_none() {
@@ -170,6 +177,14 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
             .ok_or_else(|| AciError::InvalidInitialGuess {
                 message: "local block cache key overflows usize".to_string(),
             })
+    }
+
+    fn record_output_scale(&self, values: &[T]) {
+        let mut max_output_abs = self.max_output_abs.borrow_mut();
+        for &value in values {
+            *max_output_abs =
+                max_output_abs.max(tensor4all_tcicore::MatrixLuciScalar::abs_val(value));
+        }
     }
 }
 

--- a/crates/tensor4all-aci/src/local.rs
+++ b/crates/tensor4all-aci/src/local.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use crate::scalar::AciScalar;
 use crate::{AciError, ElementwiseBatch, ElementwiseProblem, Result};
 use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops};
-use tensor4all_tensorbackend::{batched_mat_mul_same_shape, mat_mul, Matrix};
+use tensor4all_tensorbackend::{batched_mat_mul_same_shape_owned, mat_mul, mat_mul_owned, Matrix};
 
 type LocalOperator<'a, T> =
     dyn for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()> + 'a;
@@ -102,9 +102,9 @@ impl<T: AciScalar> LocalInputFactors<T> {
             Matrix::from_col_major_vec(self.nrows, self.middle_dim, self.left_values.clone());
         let right =
             Matrix::from_col_major_vec(self.middle_dim, self.ncols, self.right_values.clone());
-        let product = mat_mul(&left, &right)
+        let product = mat_mul_owned(left, right)
             .map_err(|err| local_factor_error("local input materialization matmul", err))?;
-        Ok(product.as_col_major_slice().to_vec())
+        Ok(product.into_col_major_vec())
     }
 
     fn left_offset(&self, left_pivot: usize, site_left: usize, middle: usize) -> usize {
@@ -286,13 +286,13 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
                     left_batch.extend_from_slice(&factors.left_values);
                     right_batch.extend_from_slice(&factors.right_values);
                 }
-                let values = batched_mat_mul_same_shape(
+                let values = batched_mat_mul_same_shape_owned(
                     n_inputs,
                     self.nrows,
                     middle_dim,
                     self.ncols,
-                    &left_batch,
-                    &right_batch,
+                    left_batch,
+                    right_batch,
                 )
                 .map_err(|err| local_factor_error("batched local input materialization", err))?;
                 for input in 0..n_inputs {
@@ -540,13 +540,13 @@ fn build_left_factors<T: AciScalar>(
                         .as_col_major_slice(),
                 );
             }
-            let values = batched_mat_mul_same_shape(
+            let values = batched_mat_mul_same_shape_owned(
                 n_inputs,
                 shared.left_rows,
                 shared.input_left_dim,
                 left_cols,
-                &frame_batch,
-                &core_batch,
+                frame_batch,
+                core_batch,
             )
             .map_err(|err| local_factor_error("batched left factor matmul", err))?;
             let item_len = shared.left_rows * left_cols;
@@ -583,13 +583,13 @@ fn build_right_factors<T: AciScalar>(
                     local_right_frame(problem, input, bond)?.as_col_major_slice(),
                 );
             }
-            let values = batched_mat_mul_same_shape(
+            let values = batched_mat_mul_same_shape_owned(
                 n_inputs,
                 right_rows,
                 shared.input_right_dim,
                 shared.right_cols,
-                &core_batch,
-                &frame_batch,
+                core_batch,
+                frame_batch,
             )
             .map_err(|err| local_factor_error("batched right factor matmul", err))?;
             let item_len = right_rows * shared.right_cols;

--- a/crates/tensor4all-aci/src/local.rs
+++ b/crates/tensor4all-aci/src/local.rs
@@ -1,0 +1,164 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::scalar::AciScalar;
+use crate::{AciError, ElementwiseBatch, ElementwiseProblem, Result};
+
+pub(crate) struct LocalBlockEvaluator<'a, T: AciScalar> {
+    problem: &'a ElementwiseProblem<T>,
+    bond: usize,
+    nrows: usize,
+    ncols: usize,
+    cache: RefCell<HashMap<usize, T>>,
+}
+
+impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
+    pub(crate) fn new(problem: &'a ElementwiseProblem<T>, bond: usize) -> Result<Self> {
+        if problem.n_inputs() == 0 {
+            return Err(AciError::EmptyInputs);
+        }
+
+        let (nrows, ncols) = problem.local_input_shape(0, bond)?;
+        for input in 1..problem.n_inputs() {
+            let (input_nrows, input_ncols) = problem.local_input_shape(input, bond)?;
+            if input_nrows != nrows || input_ncols != ncols {
+                return Err(AciError::InvalidInitialGuess {
+                    message: format!(
+                        "local block shape mismatch at input {input}, bond {bond}: \
+                         expected ({nrows}, {ncols}), got ({input_nrows}, {input_ncols})"
+                    ),
+                });
+            }
+        }
+
+        Ok(Self {
+            problem,
+            bond,
+            nrows,
+            ncols,
+            cache: RefCell::new(HashMap::new()),
+        })
+    }
+
+    pub(crate) fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    pub(crate) fn ncols(&self) -> usize {
+        self.ncols
+    }
+
+    pub(crate) fn fill_local_block<F>(
+        &self,
+        rows: &[usize],
+        cols: &[usize],
+        out: &mut [T],
+        operator: F,
+    ) -> Result<()>
+    where
+        F: for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
+    {
+        let n_points = checked_local_mul(rows.len(), cols.len(), "local block point count")?;
+        if out.len() != n_points {
+            return Err(AciError::LengthMismatch {
+                expected: n_points,
+                got: out.len(),
+            });
+        }
+        validate_indices("row", rows, self.nrows)?;
+        validate_indices("column", cols, self.ncols)?;
+        if n_points == 0 {
+            return Ok(());
+        }
+
+        let mut point_keys = Vec::with_capacity(n_points);
+        let mut missing_by_key = HashMap::new();
+        let mut missing_rows = Vec::new();
+        let mut missing_cols = Vec::new();
+
+        {
+            let cache = self.cache.borrow();
+            for (col_position, &col) in cols.iter().enumerate() {
+                for (row_position, &row) in rows.iter().enumerate() {
+                    let point = row_position + rows.len() * col_position;
+                    let key = self.entry_key(row, col)?;
+                    point_keys.push(key);
+                    if let Some(&value) = cache.get(&key) {
+                        out[point] = value;
+                    } else if let std::collections::hash_map::Entry::Vacant(entry) =
+                        missing_by_key.entry(key)
+                    {
+                        entry.insert(missing_rows.len());
+                        missing_rows.push(row);
+                        missing_cols.push(col);
+                    }
+                }
+            }
+        }
+
+        if missing_rows.is_empty() {
+            return Ok(());
+        }
+
+        let n_inputs = self.problem.n_inputs();
+        let n_missing = missing_rows.len();
+        let input_value_count =
+            checked_local_mul(n_inputs, n_missing, "local batch input value count")?;
+        let mut input_values = vec![T::zero(); input_value_count];
+        for (point, (&row, &col)) in missing_rows.iter().zip(&missing_cols).enumerate() {
+            for input in 0..n_inputs {
+                input_values[input + n_inputs * point] =
+                    self.problem.local_input_value(input, self.bond, row, col)?;
+            }
+        }
+
+        let batch = ElementwiseBatch::new(&input_values, n_inputs, n_missing)?;
+        let mut missing_output = vec![T::zero(); n_missing];
+        operator(batch, &mut missing_output)?;
+
+        {
+            let mut cache = self.cache.borrow_mut();
+            for (&key, &missing_index) in &missing_by_key {
+                cache.insert(key, missing_output[missing_index]);
+            }
+        }
+
+        for (point, &key) in point_keys.iter().enumerate() {
+            if let Some(&missing_index) = missing_by_key.get(&key) {
+                out[point] = missing_output[missing_index];
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clear_cache(&self) {
+        self.cache.borrow_mut().clear();
+    }
+
+    fn entry_key(&self, row: usize, col: usize) -> Result<usize> {
+        let col_offset = checked_local_mul(self.nrows, col, "local block cache key")?;
+        col_offset
+            .checked_add(row)
+            .ok_or_else(|| AciError::InvalidInitialGuess {
+                message: "local block cache key overflows usize".to_string(),
+            })
+    }
+}
+
+fn validate_indices(kind: &'static str, indices: &[usize], len: usize) -> Result<()> {
+    for &index in indices {
+        if index >= len {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!("local {kind} index {index} out of bounds for length {len}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn checked_local_mul(lhs: usize, rhs: usize, description: &str) -> Result<usize> {
+    lhs.checked_mul(rhs)
+        .ok_or_else(|| AciError::InvalidInitialGuess {
+            message: format!("{description} overflows usize"),
+        })
+}

--- a/crates/tensor4all-aci/src/local.rs
+++ b/crates/tensor4all-aci/src/local.rs
@@ -1,11 +1,35 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+#[cfg(test)]
+use std::time::{Duration, Instant};
 
 use crate::scalar::AciScalar;
 use crate::{AciError, ElementwiseBatch, ElementwiseProblem, Result};
+use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops};
+use tensor4all_tensorbackend::{batched_mat_mul_same_shape, mat_mul, Matrix};
 
 type LocalOperator<'a, T> =
     dyn for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()> + 'a;
+
+#[cfg(test)]
+fn local_setup_batching_enabled() -> bool {
+    std::env::var("T4A_ACI_DISABLE_BATCHED_LOCAL_SETUP").as_deref() != Ok("1")
+}
+
+#[cfg(not(test))]
+fn local_setup_batching_enabled() -> bool {
+    true
+}
+
+#[cfg(test)]
+fn local_materialize_batching_enabled() -> bool {
+    std::env::var("T4A_ACI_DISABLE_BATCHED_MATERIALIZE").as_deref() != Ok("1")
+}
+
+#[cfg(not(test))]
+fn local_materialize_batching_enabled() -> bool {
+    true
+}
 
 pub(crate) struct LocalBlockEvaluator<'a, T: AciScalar> {
     problem: &'a ElementwiseProblem<T>,
@@ -13,9 +37,83 @@ pub(crate) struct LocalBlockEvaluator<'a, T: AciScalar> {
     bond: usize,
     nrows: usize,
     ncols: usize,
+    input_factors: Vec<LocalInputFactors<T>>,
     cache: RefCell<HashMap<usize, T>>,
     first_error: RefCell<Option<AciError>>,
     max_output_abs: RefCell<f64>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Default)]
+pub(crate) struct LocalInputSetupTiming {
+    pub(crate) shape_validation: Duration,
+    pub(crate) dims: Duration,
+    pub(crate) left_factor: Duration,
+    pub(crate) right_factor: Duration,
+}
+
+#[derive(Clone)]
+pub(crate) struct LocalInputFactors<T: AciScalar> {
+    nrows: usize,
+    ncols: usize,
+    left_rows: usize,
+    site_dim_left: usize,
+    middle_dim: usize,
+    site_dim_right: usize,
+    right_cols: usize,
+    left_values: Vec<T>,
+    right_values: Vec<T>,
+}
+
+impl<T: AciScalar> LocalInputFactors<T> {
+    pub(crate) fn value(&self, row: usize, col: usize) -> Result<T> {
+        if row >= self.nrows {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "local row index {row} out of bounds for length {}",
+                    self.nrows
+                ),
+            });
+        }
+        if col >= self.ncols {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "local column index {col} out of bounds for length {}",
+                    self.ncols
+                ),
+            });
+        }
+
+        let left_pivot = row % self.left_rows;
+        let site_left = row / self.left_rows;
+        let site_right = col % self.site_dim_right;
+        let right_pivot = col / self.site_dim_right;
+        let mut value = T::zero();
+        for middle in 0..self.middle_dim {
+            value = value
+                + self.left_values[self.left_offset(left_pivot, site_left, middle)]
+                    * self.right_values[self.right_offset(middle, site_right, right_pivot)];
+        }
+        Ok(value)
+    }
+
+    fn materialize_values(&self) -> Result<Vec<T>> {
+        let left =
+            Matrix::from_col_major_vec(self.nrows, self.middle_dim, self.left_values.clone());
+        let right =
+            Matrix::from_col_major_vec(self.middle_dim, self.ncols, self.right_values.clone());
+        let product = mat_mul(&left, &right)
+            .map_err(|err| local_factor_error("local input materialization matmul", err))?;
+        Ok(product.as_col_major_slice().to_vec())
+    }
+
+    fn left_offset(&self, left_pivot: usize, site_left: usize, middle: usize) -> usize {
+        left_pivot + self.left_rows * (site_left + self.site_dim_left * middle)
+    }
+
+    fn right_offset(&self, middle: usize, site_right: usize, right_pivot: usize) -> usize {
+        middle + self.middle_dim * (site_right + self.site_dim_right * right_pivot)
+    }
 }
 
 impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
@@ -31,18 +129,8 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
             return Err(AciError::EmptyInputs);
         }
 
-        let (nrows, ncols) = problem.local_input_shape(0, bond)?;
-        for input in 1..problem.n_inputs() {
-            let (input_nrows, input_ncols) = problem.local_input_shape(input, bond)?;
-            if input_nrows != nrows || input_ncols != ncols {
-                return Err(AciError::InvalidInitialGuess {
-                    message: format!(
-                        "local block shape mismatch at input {input}, bond {bond}: \
-                         expected ({nrows}, {ncols}), got ({input_nrows}, {input_ncols})"
-                    ),
-                });
-            }
-        }
+        let (nrows, ncols) = validate_local_shapes(problem, bond)?;
+        let input_factors = local_input_factors_for_problem(problem, bond)?;
 
         Ok(Self {
             problem,
@@ -50,6 +138,40 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
             bond,
             nrows,
             ncols,
+            input_factors,
+            cache: RefCell::new(HashMap::new()),
+            first_error: RefCell::new(None),
+            max_output_abs: RefCell::new(0.0),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_setup_timing<F>(
+        problem: &'a ElementwiseProblem<T>,
+        bond: usize,
+        operator: &'a F,
+        timing: &mut LocalInputSetupTiming,
+    ) -> Result<Self>
+    where
+        F: for<'batch> Fn(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()> + 'a,
+    {
+        if problem.n_inputs() == 0 {
+            return Err(AciError::EmptyInputs);
+        }
+
+        let start = Instant::now();
+        let (nrows, ncols) = validate_local_shapes(problem, bond)?;
+        timing.shape_validation += start.elapsed();
+
+        let input_factors = local_input_factors_for_problem_with_timing(problem, bond, timing)?;
+
+        Ok(Self {
+            problem,
+            operator,
+            bond,
+            nrows,
+            ncols,
+            input_factors,
             cache: RefCell::new(HashMap::new()),
             first_error: RefCell::new(None),
             max_output_abs: RefCell::new(0.0),
@@ -120,7 +242,7 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
         for (point, (&row, &col)) in missing_rows.iter().zip(&missing_cols).enumerate() {
             for input in 0..n_inputs {
                 input_values[input + n_inputs * point] =
-                    self.problem.local_input_value(input, self.bond, row, col)?;
+                    self.input_factors[input].value(row, col)?;
             }
         }
 
@@ -142,6 +264,77 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn materialize_local_matrix(&self) -> Result<Matrix<T>> {
+        let input_values = self.materialize_input_values()?;
+        self.apply_operator_to_input_values(&input_values)
+    }
+
+    pub(crate) fn materialize_input_values(&self) -> Result<Vec<T>> {
+        let n_points = checked_local_mul(self.nrows, self.ncols, "local matrix entry count")?;
+        let n_inputs = self.problem.n_inputs();
+        let input_value_count =
+            checked_local_mul(n_inputs, n_points, "local matrix input value count")?;
+        let mut input_values = vec![T::zero(); input_value_count];
+
+        if local_materialize_batching_enabled() {
+            if let Some(middle_dim) = self.shared_middle_dim() {
+                let mut left_batch = Vec::with_capacity(n_inputs * self.nrows * middle_dim);
+                let mut right_batch = Vec::with_capacity(n_inputs * middle_dim * self.ncols);
+                for factors in &self.input_factors {
+                    left_batch.extend_from_slice(&factors.left_values);
+                    right_batch.extend_from_slice(&factors.right_values);
+                }
+                let values = batched_mat_mul_same_shape(
+                    n_inputs,
+                    self.nrows,
+                    middle_dim,
+                    self.ncols,
+                    &left_batch,
+                    &right_batch,
+                )
+                .map_err(|err| local_factor_error("batched local input materialization", err))?;
+                for input in 0..n_inputs {
+                    let offset = input * n_points;
+                    for point in 0..n_points {
+                        input_values[input + n_inputs * point] = values[offset + point];
+                    }
+                }
+                return Ok(input_values);
+            }
+        }
+
+        for input in 0..n_inputs {
+            let values = self.input_factors[input].materialize_values()?;
+            for point in 0..n_points {
+                input_values[input + n_inputs * point] = values[point];
+            }
+        }
+        Ok(input_values)
+    }
+
+    fn shared_middle_dim(&self) -> Option<usize> {
+        let first = self.input_factors.first()?;
+        if self.input_factors.iter().all(|factors| {
+            factors.nrows == self.nrows
+                && factors.ncols == self.ncols
+                && factors.middle_dim == first.middle_dim
+        }) {
+            Some(first.middle_dim)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn apply_operator_to_input_values(&self, input_values: &[T]) -> Result<Matrix<T>> {
+        let n_points = checked_local_mul(self.nrows, self.ncols, "local matrix entry count")?;
+        let n_inputs = self.problem.n_inputs();
+        let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
+        let mut output = vec![T::zero(); n_points];
+        (self.operator)(batch, &mut output)?;
+        self.record_output_scale(&output);
+        Ok(Matrix::from_col_major_vec(self.nrows, self.ncols, output))
     }
 
     pub(crate) fn fill_local_block_or_zero(&self, rows: &[usize], cols: &[usize], out: &mut [T]) {
@@ -185,6 +378,309 @@ impl<'a, T: AciScalar> LocalBlockEvaluator<'a, T> {
             *max_output_abs =
                 max_output_abs.max(tensor4all_tcicore::MatrixLuciScalar::abs_val(value));
         }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct LocalInputFactorDims {
+    left_rows: usize,
+    input_left_dim: usize,
+    site_dim_left: usize,
+    middle_dim: usize,
+    site_dim_right: usize,
+    input_right_dim: usize,
+    right_cols: usize,
+}
+
+pub(crate) fn local_input_factors_for_problem<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+) -> Result<Vec<LocalInputFactors<T>>> {
+    let dims = local_input_factor_dims_for_problem(problem, bond)?;
+    build_local_input_factors_from_dims(problem, bond, &dims)
+}
+
+#[cfg(test)]
+pub(crate) fn local_input_factors_for_problem_with_timing<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+    timing: &mut LocalInputSetupTiming,
+) -> Result<Vec<LocalInputFactors<T>>> {
+    let start = Instant::now();
+    let dims = local_input_factor_dims_for_problem(problem, bond)?;
+    timing.dims += start.elapsed();
+    build_local_input_factors_from_dims_with_timing(problem, bond, &dims, timing)
+}
+
+fn local_input_factor_dims_for_problem<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+) -> Result<Vec<LocalInputFactorDims>> {
+    (0..problem.n_inputs())
+        .map(|input| local_input_factor_dims(problem, input, bond))
+        .collect()
+}
+
+fn local_input_factor_dims<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    input: usize,
+    bond: usize,
+) -> Result<LocalInputFactorDims> {
+    let _ = problem.local_input_shape(input, bond)?;
+    let left_frame = local_left_frame(problem, input, bond)?;
+    let right_frame = local_right_frame(problem, input, bond)?;
+    let left_core = problem.inputs[input].site_tensor(bond);
+    let right_core = problem.inputs[input].site_tensor(bond + 1);
+
+    Ok(LocalInputFactorDims {
+        left_rows: left_frame.nrows(),
+        input_left_dim: left_core.left_dim(),
+        site_dim_left: left_core.site_dim(),
+        middle_dim: left_core.right_dim(),
+        site_dim_right: right_core.site_dim(),
+        input_right_dim: right_core.right_dim(),
+        right_cols: right_frame.ncols(),
+    })
+}
+
+#[cfg(test)]
+fn build_local_input_factors_from_dims_with_timing<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+    dims: &[LocalInputFactorDims],
+    timing: &mut LocalInputSetupTiming,
+) -> Result<Vec<LocalInputFactors<T>>> {
+    let start = Instant::now();
+    let left_values = build_left_factors(problem, bond, dims)?;
+    timing.left_factor += start.elapsed();
+
+    let start = Instant::now();
+    let right_values = build_right_factors(problem, bond, dims)?;
+    timing.right_factor += start.elapsed();
+
+    assemble_local_input_factors(dims, left_values, right_values)
+}
+
+fn build_local_input_factors_from_dims<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+    dims: &[LocalInputFactorDims],
+) -> Result<Vec<LocalInputFactors<T>>> {
+    let left_values = build_left_factors(problem, bond, dims)?;
+    let right_values = build_right_factors(problem, bond, dims)?;
+    assemble_local_input_factors(dims, left_values, right_values)
+}
+
+fn assemble_local_input_factors<T: AciScalar>(
+    dims: &[LocalInputFactorDims],
+    left_values: Vec<Vec<T>>,
+    right_values: Vec<Vec<T>>,
+) -> Result<Vec<LocalInputFactors<T>>> {
+    dims.iter()
+        .zip(left_values)
+        .zip(right_values)
+        .map(|((dims, left_values), right_values)| {
+            local_input_factors_from_values(*dims, left_values, right_values)
+        })
+        .collect()
+}
+
+fn local_input_factors_from_values<T: AciScalar>(
+    dims: LocalInputFactorDims,
+    left_values: Vec<T>,
+    right_values: Vec<T>,
+) -> Result<LocalInputFactors<T>> {
+    let nrows = checked_local_mul(dims.left_rows, dims.site_dim_left, "local block row count")?;
+    let ncols = checked_local_mul(
+        dims.site_dim_right,
+        dims.right_cols,
+        "local block column count",
+    )?;
+    Ok(LocalInputFactors {
+        nrows,
+        ncols,
+        left_rows: dims.left_rows,
+        site_dim_left: dims.site_dim_left,
+        middle_dim: dims.middle_dim,
+        site_dim_right: dims.site_dim_right,
+        right_cols: dims.right_cols,
+        left_values,
+        right_values,
+    })
+}
+
+fn shared_input_factor_dims(dims: &[LocalInputFactorDims]) -> Option<LocalInputFactorDims> {
+    let first = *dims.first()?;
+    if dims.iter().all(|dims| *dims == first) {
+        Some(first)
+    } else {
+        None
+    }
+}
+
+fn build_left_factors<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+    dims: &[LocalInputFactorDims],
+) -> Result<Vec<Vec<T>>> {
+    if local_setup_batching_enabled() {
+        if let Some(shared) = shared_input_factor_dims(dims) {
+            let n_inputs = dims.len();
+            let left_cols = shared.site_dim_left * shared.middle_dim;
+            let mut frame_batch =
+                Vec::with_capacity(n_inputs * shared.left_rows * shared.input_left_dim);
+            let mut core_batch = Vec::with_capacity(n_inputs * shared.input_left_dim * left_cols);
+            for input in 0..n_inputs {
+                frame_batch.extend_from_slice(
+                    local_left_frame(problem, input, bond)?.as_col_major_slice(),
+                );
+                core_batch.extend_from_slice(
+                    problem
+                        .input_core_left_matrix(input, bond)
+                        .as_col_major_slice(),
+                );
+            }
+            let values = batched_mat_mul_same_shape(
+                n_inputs,
+                shared.left_rows,
+                shared.input_left_dim,
+                left_cols,
+                &frame_batch,
+                &core_batch,
+            )
+            .map_err(|err| local_factor_error("batched left factor matmul", err))?;
+            let item_len = shared.left_rows * left_cols;
+            return Ok((0..n_inputs)
+                .map(|input| values[input * item_len..(input + 1) * item_len].to_vec())
+                .collect());
+        }
+    }
+
+    (0..dims.len())
+        .map(|input| build_left_factor(problem, input, bond))
+        .collect()
+}
+
+fn build_right_factors<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+    dims: &[LocalInputFactorDims],
+) -> Result<Vec<Vec<T>>> {
+    if local_setup_batching_enabled() {
+        if let Some(shared) = shared_input_factor_dims(dims) {
+            let n_inputs = dims.len();
+            let right_rows = shared.middle_dim * shared.site_dim_right;
+            let mut core_batch = Vec::with_capacity(n_inputs * right_rows * shared.input_right_dim);
+            let mut frame_batch =
+                Vec::with_capacity(n_inputs * shared.input_right_dim * shared.right_cols);
+            for input in 0..n_inputs {
+                core_batch.extend_from_slice(
+                    problem
+                        .input_core_right_matrix(input, bond + 1)
+                        .as_col_major_slice(),
+                );
+                frame_batch.extend_from_slice(
+                    local_right_frame(problem, input, bond)?.as_col_major_slice(),
+                );
+            }
+            let values = batched_mat_mul_same_shape(
+                n_inputs,
+                right_rows,
+                shared.input_right_dim,
+                shared.right_cols,
+                &core_batch,
+                &frame_batch,
+            )
+            .map_err(|err| local_factor_error("batched right factor matmul", err))?;
+            let item_len = right_rows * shared.right_cols;
+            return Ok((0..n_inputs)
+                .map(|input| values[input * item_len..(input + 1) * item_len].to_vec())
+                .collect());
+        }
+    }
+
+    (0..dims.len())
+        .map(|input| build_right_factor(problem, input, bond))
+        .collect()
+}
+
+fn build_left_factor<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    input: usize,
+    bond: usize,
+) -> Result<Vec<T>> {
+    let frame = local_left_frame(problem, input, bond)?;
+    let core_matrix = problem.input_core_left_matrix(input, bond);
+    let product = mat_mul(frame, &core_matrix)
+        .map_err(|err| local_factor_error("left factor matmul", err))?;
+    Ok(product.as_col_major_slice().to_vec())
+}
+
+fn build_right_factor<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    input: usize,
+    bond: usize,
+) -> Result<Vec<T>> {
+    let frame = local_right_frame(problem, input, bond)?;
+    let core_matrix = problem.input_core_right_matrix(input, bond + 1);
+    let product = mat_mul(&core_matrix, frame)
+        .map_err(|err| local_factor_error("right factor matmul", err))?;
+    Ok(product.as_col_major_slice().to_vec())
+}
+
+fn validate_local_shapes<T: AciScalar>(
+    problem: &ElementwiseProblem<T>,
+    bond: usize,
+) -> Result<(usize, usize)> {
+    let (nrows, ncols) = problem.local_input_shape(0, bond)?;
+    for input in 1..problem.n_inputs() {
+        let (input_nrows, input_ncols) = problem.local_input_shape(input, bond)?;
+        if input_nrows != nrows || input_ncols != ncols {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "local block shape mismatch at input {input}, bond {bond}: \
+                     expected ({nrows}, {ncols}), got ({input_nrows}, {input_ncols})"
+                ),
+            });
+        }
+    }
+    Ok((nrows, ncols))
+}
+
+fn local_left_frame<'a, T: AciScalar>(
+    problem: &'a ElementwiseProblem<T>,
+    input: usize,
+    bond: usize,
+) -> Result<&'a tensor4all_tensorbackend::Matrix<T>> {
+    problem
+        .left_frames
+        .get(input)
+        .and_then(|frames| frames.get(bond))
+        .and_then(|frame| frame.as_ref())
+        .ok_or_else(|| AciError::InvalidInitialGuess {
+            message: format!("missing left frame at input {input}, site {bond}"),
+        })
+}
+
+fn local_right_frame<'a, T: AciScalar>(
+    problem: &'a ElementwiseProblem<T>,
+    input: usize,
+    bond: usize,
+) -> Result<&'a tensor4all_tensorbackend::Matrix<T>> {
+    let site = bond + 2;
+    problem
+        .right_frames
+        .get(input)
+        .and_then(|frames| frames.get(site))
+        .and_then(|frame| frame.as_ref())
+        .ok_or_else(|| AciError::InvalidInitialGuess {
+            message: format!("missing right frame at input {input}, site {site}"),
+        })
+}
+
+fn local_factor_error(context: &str, err: impl std::fmt::Display) -> AciError {
+    AciError::InvalidInitialGuess {
+        message: format!("{context} failed: {err}"),
     }
 }
 

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -40,8 +40,8 @@ pub struct AciOptions<T: TTScalar> {
     /// Minimum number of ACI sweeps to run before convergence checks may stop.
     ///
     /// The default is `2`, which gives the interpolation pivots at least one
-    /// forward and backward refinement opportunity. Keep this below or equal to
-    /// [`max_iters`](Self::max_iters).
+    /// forward and backward refinement opportunity. Keep this at least `1` and
+    /// below or equal to [`max_iters`](Self::max_iters).
     pub min_iters: usize,
 
     /// Maximum allowed tensor-train bond dimension.

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -1,0 +1,96 @@
+//! Configuration for Alternating Cross Interpolation.
+
+use tensor4all_simplett::{TTScalar, TensorTrain};
+
+/// Options controlling an Alternating Cross Interpolation run.
+///
+/// Use this type to choose iteration limits, truncation pressure, stopping
+/// tolerance, and an optional initial tensor-train guess. The default values are
+/// conservative: they run at least two sweeps, allow up to twenty sweeps, do not
+/// cap bond dimensions, and use an absolute tolerance of `1e-12`.
+///
+/// Related types: [`AciResult`](crate::AciResult) stores the tensor train and
+/// convergence history produced by an ACI run, while [`ElementwiseBatch`](crate::ElementwiseBatch)
+/// describes batched column-major operator inputs.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::AciOptions;
+///
+/// let options = AciOptions::<f64>::default();
+/// assert_eq!(options.max_iters, 20);
+/// assert_eq!(options.min_iters, 2);
+/// assert_eq!(options.max_bond_dim, usize::MAX);
+/// assert!((options.tolerance - 1e-12).abs() < 1e-15);
+/// assert!(!options.scale_tolerance);
+/// assert!(options.initial_guess.is_none());
+/// assert_eq!(options.rng_seed, 0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct AciOptions<T: TTScalar> {
+    /// Maximum number of ACI sweeps to run.
+    ///
+    /// The default is `20`, which is usually enough for small and medium
+    /// problems while still preventing runaway iteration. Increase this when
+    /// convergence is steady but the requested [`tolerance`](Self::tolerance)
+    /// has not been reached.
+    pub max_iters: usize,
+
+    /// Minimum number of ACI sweeps to run before convergence checks may stop.
+    ///
+    /// The default is `2`, which gives the interpolation pivots at least one
+    /// forward and backward refinement opportunity. Keep this below or equal to
+    /// [`max_iters`](Self::max_iters).
+    pub min_iters: usize,
+
+    /// Maximum allowed tensor-train bond dimension.
+    ///
+    /// The default is [`usize::MAX`], meaning no explicit cap. Lower values
+    /// reduce memory and runtime but may prevent the approximation from
+    /// reaching the requested [`tolerance`](Self::tolerance).
+    pub max_bond_dim: usize,
+
+    /// Requested stopping tolerance for the ACI residual estimate.
+    ///
+    /// The default is `1e-12`. When [`scale_tolerance`](Self::scale_tolerance)
+    /// is `false`, this is interpreted as an absolute tolerance. When
+    /// `scale_tolerance` is `true`, implementations may scale it by an estimate
+    /// of the operator output magnitude.
+    pub tolerance: f64,
+
+    /// Whether to scale [`tolerance`](Self::tolerance) by the output magnitude.
+    ///
+    /// The default is `false`, giving absolute tolerance behavior. Set this to
+    /// `true` when outputs have problem-dependent scales and relative stopping
+    /// behavior is more appropriate.
+    pub scale_tolerance: bool,
+
+    /// Optional tensor train used to initialize interpolation pivots and ranks.
+    ///
+    /// The default is `None`, so ACI chooses its own starting state. Provide a
+    /// guess when a nearby solution is available; it must have site dimensions
+    /// compatible with the ACI problem.
+    pub initial_guess: Option<TensorTrain<T>>,
+
+    /// Seed for randomized choices made by ACI.
+    ///
+    /// The default is `0`, giving deterministic behavior for repeated runs with
+    /// the same inputs and options. Change this to sample a different initial
+    /// pivot path when convergence depends on random choices.
+    pub rng_seed: u64,
+}
+
+impl<T: TTScalar> Default for AciOptions<T> {
+    fn default() -> Self {
+        Self {
+            max_iters: 20,
+            min_iters: 2,
+            max_bond_dim: usize::MAX,
+            tolerance: 1e-12,
+            scale_tolerance: false,
+            initial_guess: None,
+            rng_seed: 0,
+        }
+    }
+}

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -55,15 +55,17 @@ pub struct AciOptions<T: TTScalar> {
     ///
     /// The default is `1e-12`. When [`scale_tolerance`](Self::scale_tolerance)
     /// is `false`, this is interpreted as an absolute tolerance. When
-    /// `scale_tolerance` is `true`, implementations may scale it by an estimate
-    /// of the operator output magnitude.
+    /// `scale_tolerance` is `true`, the public sweep APIs compare this value to
+    /// a relative error metric obtained by dividing the pivot error by the
+    /// largest sampled operator-output magnitude from the completed sweep.
     pub tolerance: f64,
 
     /// Whether to scale [`tolerance`](Self::tolerance) by the output magnitude.
     ///
     /// The default is `false`, giving absolute tolerance behavior. Set this to
     /// `true` when outputs have problem-dependent scales and relative stopping
-    /// behavior is more appropriate.
+    /// behavior is more appropriate. When in doubt, keep the default `false`
+    /// for absolute tolerance behavior.
     pub scale_tolerance: bool,
 
     /// Optional tensor train used to initialize interpolation pivots and ranks.

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -56,8 +56,9 @@ pub struct AciOptions<T: TTScalar> {
     /// The default is `1e-12`. When [`scale_tolerance`](Self::scale_tolerance)
     /// is `false`, this is interpreted as an absolute tolerance. When
     /// `scale_tolerance` is `true`, the public sweep APIs compare this value to
-    /// a relative error metric obtained by dividing the pivot error by the
-    /// largest sampled operator-output magnitude from the completed sweep.
+    /// the largest per-bond relative metric, obtained by dividing each bond's
+    /// pivot error by that bond's largest sampled operator-output magnitude
+    /// from the completed sweep.
     pub tolerance: f64,
 
     /// Whether to scale [`tolerance`](Self::tolerance) by the output magnitude.

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -3,7 +3,9 @@ use crate::validation::{validate_inputs, validate_options};
 use crate::{AciError, AciOptions, Result};
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, Tensor3, TensorTrain};
+use tensor4all_simplett::{
+    tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
+};
 
 pub(crate) const MAX_INITIAL_GUESS_CORE_ENTRIES: usize = 10_000_000;
 pub(crate) const MAX_INITIAL_GUESS_TOTAL_ENTRIES: usize = 10_000_000;
@@ -25,6 +27,7 @@ pub(crate) fn initial_guess<T: AciScalar>(
                 ),
             });
         }
+        initial_guess_existing_entry_count(guess)?;
         return Ok(guess.clone());
     }
 
@@ -135,6 +138,26 @@ pub(crate) fn initial_guess_total_entry_count(
     let mut total = 0usize;
     for &(left_dim, site_dim, right_dim) in core_dims {
         let len = initial_guess_core_entry_count(left_dim, site_dim, right_dim)?;
+        total = checked_add(total, len, "initial guess total size")?;
+        if total > MAX_INITIAL_GUESS_TOTAL_ENTRIES {
+            return Err(AciError::InvalidOptions {
+                message: format!(
+                    "initial guess total size {total} exceeds internal limit of \
+                     {MAX_INITIAL_GUESS_TOTAL_ENTRIES} entries"
+                ),
+            });
+        }
+    }
+    Ok(total)
+}
+
+pub(crate) fn initial_guess_existing_entry_count<T: AciScalar>(
+    guess: &TensorTrain<T>,
+) -> Result<usize> {
+    let mut total = 0usize;
+    for core in guess.site_tensors() {
+        let len =
+            initial_guess_core_entry_count(core.left_dim(), core.site_dim(), core.right_dim())?;
         total = checked_add(total, len, "initial guess total size")?;
         if total > MAX_INITIAL_GUESS_TOTAL_ENTRIES {
             return Err(AciError::InvalidOptions {

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -5,6 +5,8 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, Tensor3, TensorTrain};
 
+pub(crate) const MAX_INITIAL_GUESS_CORE_ENTRIES: usize = 10_000_000;
+
 pub(crate) fn initial_guess<T: AciScalar>(
     inputs: &[TensorTrain<T>],
     options: &AciOptions<T>,
@@ -85,15 +87,32 @@ fn random_core<T: AciScalar>(
     right_dim: usize,
     rng: &mut ChaCha8Rng,
 ) -> Result<Tensor3<T>> {
+    let len = initial_guess_core_entry_count(left_dim, site_dim, right_dim)?;
+    let data = (0..len)
+        .map(|_| T::sample_standard_normal(rng))
+        .collect::<Vec<_>>();
+    Ok(tensor3_from_data(data, left_dim, site_dim, right_dim)?)
+}
+
+pub(crate) fn initial_guess_core_entry_count(
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+) -> Result<usize> {
     let len = checked_mul(
         checked_mul(left_dim, site_dim, "initial guess core size")?,
         right_dim,
         "initial guess core size",
     )?;
-    let data = (0..len)
-        .map(|_| T::sample_standard_normal(rng))
-        .collect::<Vec<_>>();
-    Ok(tensor3_from_data(data, left_dim, site_dim, right_dim)?)
+    if len > MAX_INITIAL_GUESS_CORE_ENTRIES {
+        return Err(AciError::InvalidOptions {
+            message: format!(
+                "initial guess core size {len} exceeds internal limit of \
+                 {MAX_INITIAL_GUESS_CORE_ENTRIES} entries"
+            ),
+        });
+    }
+    Ok(len)
 }
 
 fn checked_mul(lhs: usize, rhs: usize, description: &str) -> Result<usize> {

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -1,0 +1,104 @@
+use crate::scalar::AciScalar;
+use crate::validation::{validate_inputs, validate_options};
+use crate::{AciError, AciOptions, Result};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, Tensor3, TensorTrain};
+
+pub(crate) fn initial_guess<T: AciScalar>(
+    inputs: &[TensorTrain<T>],
+    options: &AciOptions<T>,
+) -> Result<TensorTrain<T>> {
+    let site_dims = validate_inputs(inputs)?;
+    validate_options(options)?;
+
+    if let Some(guess) = &options.initial_guess {
+        let guess_site_dims = guess.site_dims();
+        if guess_site_dims != site_dims {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "site dimensions must match inputs: expected {:?}, got {:?}",
+                    site_dims, guess_site_dims
+                ),
+            });
+        }
+        return Ok(guess.clone());
+    }
+
+    let link_dims = default_link_dims(inputs, &site_dims, options.max_bond_dim)?;
+    let mut rng = ChaCha8Rng::seed_from_u64(options.rng_seed);
+    let mut cores = Vec::with_capacity(site_dims.len());
+
+    for (site, &site_dim) in site_dims.iter().enumerate() {
+        let left_dim = if site == 0 { 1 } else { link_dims[site - 1] };
+        let right_dim = link_dims.get(site).copied().unwrap_or(1);
+        cores.push(random_core(left_dim, site_dim, right_dim, &mut rng)?);
+    }
+
+    Ok(TensorTrain::new(cores)?)
+}
+
+fn default_link_dims<T: AciScalar>(
+    inputs: &[TensorTrain<T>],
+    site_dims: &[usize],
+    max_bond_dim: usize,
+) -> Result<Vec<usize>> {
+    if site_dims.len() <= 1 {
+        return Ok(Vec::new());
+    }
+
+    let mut left_products = Vec::with_capacity(site_dims.len() - 1);
+    let mut left_product = 1usize;
+    for &site_dim in &site_dims[..site_dims.len() - 1] {
+        left_product = checked_mul(left_product, site_dim, "site dimension product")?;
+        left_products.push(left_product);
+    }
+
+    let mut right_products = vec![1usize; site_dims.len() - 1];
+    let mut right_product = 1usize;
+    for bond in (0..site_dims.len() - 1).rev() {
+        right_product = checked_mul(right_product, site_dims[bond + 1], "site dimension product")?;
+        right_products[bond] = right_product;
+    }
+
+    let mut link_dims = Vec::with_capacity(site_dims.len() - 1);
+    for bond in 0..site_dims.len() - 1 {
+        let min_input_link_dim = inputs
+            .iter()
+            .map(|input| input.link_dim(bond))
+            .min()
+            .unwrap_or(usize::MAX);
+        let link_dim = left_products[bond]
+            .min(right_products[bond])
+            .min(min_input_link_dim)
+            .min(max_bond_dim)
+            .max(1);
+        link_dims.push(link_dim);
+    }
+
+    Ok(link_dims)
+}
+
+fn random_core<T: AciScalar>(
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+    rng: &mut ChaCha8Rng,
+) -> Result<Tensor3<T>> {
+    let len = checked_mul(
+        checked_mul(left_dim, site_dim, "initial guess core size")?,
+        right_dim,
+        "initial guess core size",
+    )?;
+    let data = (0..len)
+        .map(|_| T::sample_standard_normal(rng))
+        .collect::<Vec<_>>();
+    Ok(tensor3_from_data(data, left_dim, site_dim, right_dim)?)
+}
+
+fn checked_mul(lhs: usize, rhs: usize, description: &str) -> Result<usize> {
+    lhs.checked_mul(rhs)
+        .ok_or_else(|| AciError::InvalidOptions {
+            message: format!("{description} overflows usize"),
+        })
+}

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -1,4 +1,4 @@
-use crate::scalar::AciScalar;
+use crate::scalar::{sample_standard_normal, AciScalar};
 use crate::validation::{validate_inputs, validate_options};
 use crate::{AciError, AciOptions, Result};
 use rand::SeedableRng;
@@ -143,7 +143,7 @@ fn random_core<T: AciScalar>(
 ) -> Result<Tensor3<T>> {
     let len = initial_guess_core_entry_count(left_dim, site_dim, right_dim)?;
     let data = (0..len)
-        .map(|_| T::sample_standard_normal(rng))
+        .map(|_| sample_standard_normal(rng))
         .collect::<Vec<_>>();
     Ok(tensor3_from_data(data, left_dim, site_dim, right_dim)?)
 }

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -6,6 +6,7 @@ use rand_chacha::ChaCha8Rng;
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, Tensor3, TensorTrain};
 
 pub(crate) const MAX_INITIAL_GUESS_CORE_ENTRIES: usize = 10_000_000;
+pub(crate) const MAX_INITIAL_GUESS_TOTAL_ENTRIES: usize = 10_000_000;
 
 pub(crate) fn initial_guess<T: AciScalar>(
     inputs: &[TensorTrain<T>],
@@ -28,16 +29,29 @@ pub(crate) fn initial_guess<T: AciScalar>(
     }
 
     let link_dims = default_link_dims(inputs, &site_dims, options.max_bond_dim)?;
-    let mut rng = ChaCha8Rng::seed_from_u64(options.rng_seed);
-    let mut cores = Vec::with_capacity(site_dims.len());
+    let core_dims = initial_guess_core_dims(&site_dims, &link_dims);
+    initial_guess_total_entry_count(&core_dims)?;
 
-    for (site, &site_dim) in site_dims.iter().enumerate() {
-        let left_dim = if site == 0 { 1 } else { link_dims[site - 1] };
-        let right_dim = link_dims.get(site).copied().unwrap_or(1);
+    let mut rng = ChaCha8Rng::seed_from_u64(options.rng_seed);
+    let mut cores = Vec::with_capacity(core_dims.len());
+
+    for (left_dim, site_dim, right_dim) in core_dims {
         cores.push(random_core(left_dim, site_dim, right_dim, &mut rng)?);
     }
 
     Ok(TensorTrain::new(cores)?)
+}
+
+fn initial_guess_core_dims(site_dims: &[usize], link_dims: &[usize]) -> Vec<(usize, usize, usize)> {
+    site_dims
+        .iter()
+        .enumerate()
+        .map(|(site, &site_dim)| {
+            let left_dim = if site == 0 { 1 } else { link_dims[site - 1] };
+            let right_dim = link_dims.get(site).copied().unwrap_or(1);
+            (left_dim, site_dim, right_dim)
+        })
+        .collect()
 }
 
 fn default_link_dims<T: AciScalar>(
@@ -113,6 +127,32 @@ pub(crate) fn initial_guess_core_entry_count(
         });
     }
     Ok(len)
+}
+
+pub(crate) fn initial_guess_total_entry_count(
+    core_dims: &[(usize, usize, usize)],
+) -> Result<usize> {
+    let mut total = 0usize;
+    for &(left_dim, site_dim, right_dim) in core_dims {
+        let len = initial_guess_core_entry_count(left_dim, site_dim, right_dim)?;
+        total = checked_add(total, len, "initial guess total size")?;
+        if total > MAX_INITIAL_GUESS_TOTAL_ENTRIES {
+            return Err(AciError::InvalidOptions {
+                message: format!(
+                    "initial guess total size {total} exceeds internal limit of \
+                     {MAX_INITIAL_GUESS_TOTAL_ENTRIES} entries"
+                ),
+            });
+        }
+    }
+    Ok(total)
+}
+
+fn checked_add(lhs: usize, rhs: usize, description: &str) -> Result<usize> {
+    lhs.checked_add(rhs)
+        .ok_or_else(|| AciError::InvalidOptions {
+            message: format!("{description} overflows usize"),
+        })
 }
 
 fn checked_mul(lhs: usize, rhs: usize, description: &str) -> Result<usize> {

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -7,6 +7,8 @@ use tensor4all_simplett::{
     tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
 };
 
+// Protective internal allocation guard for generated or supplied guesses; this
+// is not a public tuning knob.
 pub(crate) const MAX_INITIAL_GUESS_CORE_ENTRIES: usize = 10_000_000;
 pub(crate) const MAX_INITIAL_GUESS_TOTAL_ENTRIES: usize = 10_000_000;
 
@@ -18,16 +20,7 @@ pub(crate) fn initial_guess<T: AciScalar>(
     validate_options(options)?;
 
     if let Some(guess) = &options.initial_guess {
-        let guess_site_dims = guess.site_dims();
-        if guess_site_dims != site_dims {
-            return Err(AciError::InvalidInitialGuess {
-                message: format!(
-                    "site dimensions must match inputs: expected {:?}, got {:?}",
-                    site_dims, guess_site_dims
-                ),
-            });
-        }
-        initial_guess_existing_entry_count(guess)?;
+        validate_existing_initial_guess(guess, &site_dims, options.max_bond_dim)?;
         return Ok(guess.clone());
     }
 
@@ -43,6 +36,50 @@ pub(crate) fn initial_guess<T: AciScalar>(
     }
 
     Ok(TensorTrain::new(cores)?)
+}
+
+fn validate_existing_initial_guess<T: AciScalar>(
+    guess: &TensorTrain<T>,
+    site_dims: &[usize],
+    max_bond_dim: usize,
+) -> Result<()> {
+    let guess_site_dims = guess.site_dims();
+    if guess_site_dims != site_dims {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "site dimensions must match inputs: expected {:?}, got {:?}",
+                site_dims, guess_site_dims
+            ),
+        });
+    }
+
+    for (site, core) in guess.site_tensors().iter().enumerate() {
+        if core.left_dim() == 0 || core.site_dim() == 0 || core.right_dim() == 0 {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "initial guess core {site} dimensions must be positive: got \
+                     ({}, {}, {})",
+                    core.left_dim(),
+                    core.site_dim(),
+                    core.right_dim()
+                ),
+            });
+        }
+    }
+
+    for (bond, link_dim) in guess.link_dims().into_iter().enumerate() {
+        if link_dim > max_bond_dim {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "initial guess bond dimension at bond {bond} exceeds max_bond_dim: \
+                     got {link_dim}, max {max_bond_dim}"
+                ),
+            });
+        }
+    }
+
+    initial_guess_existing_entry_count(guess)?;
+    Ok(())
 }
 
 fn initial_guess_core_dims(site_dims: &[usize], link_dims: &[usize]) -> Vec<(usize, usize, usize)> {

--- a/crates/tensor4all-aci/src/result.rs
+++ b/crates/tensor4all-aci/src/result.rs
@@ -1,0 +1,49 @@
+//! Result types returned by Alternating Cross Interpolation.
+
+use tensor4all_simplett::{TTScalar, TensorTrain};
+
+/// Output of an Alternating Cross Interpolation run.
+///
+/// The result contains the approximating tensor train plus convergence metadata
+/// collected during the run. Use [`tensor_train`](Self::tensor_train) for
+/// subsequent tensor-train operations, and inspect [`ranks`](Self::ranks) and
+/// [`errors`](Self::errors) to diagnose truncation or convergence behavior.
+///
+/// Related types: [`AciOptions`](crate::AciOptions) configures the run that
+/// produces this value; [`TensorTrain`] stores the approximating tensor.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::AciResult;
+/// use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+///
+/// let tensor_train = TensorTrain::<f64>::constant(&[2, 3], 4.0);
+/// let result = AciResult {
+///     tensor_train,
+///     ranks: vec![1],
+///     errors: vec![0.0],
+/// };
+///
+/// assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+/// assert_eq!(result.ranks, vec![1]);
+/// assert_eq!(result.errors, vec![0.0]);
+/// assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 4.0).abs() < 1e-12);
+/// ```
+#[derive(Debug, Clone)]
+pub struct AciResult<T: TTScalar> {
+    /// Tensor-train approximation produced by ACI.
+    pub tensor_train: TensorTrain<T>,
+
+    /// Maximum or sweep-level bond dimensions recorded during the run.
+    ///
+    /// Implementations should store these in iteration order so callers can
+    /// compare rank growth against [`AciOptions::max_bond_dim`](crate::AciOptions::max_bond_dim).
+    pub ranks: Vec<usize>,
+
+    /// Residual or convergence estimates recorded during the run.
+    ///
+    /// Values are stored in iteration order and use the same scaling convention
+    /// as [`AciOptions::tolerance`](crate::AciOptions::tolerance).
+    pub errors: Vec<f64>,
+}

--- a/crates/tensor4all-aci/src/result.rs
+++ b/crates/tensor4all-aci/src/result.rs
@@ -7,7 +7,7 @@ use tensor4all_simplett::{TTScalar, TensorTrain};
 /// The result contains the approximating tensor train plus convergence metadata
 /// collected during the run. Use [`tensor_train`](Self::tensor_train) for
 /// subsequent tensor-train operations, and inspect [`ranks`](Self::ranks) and
-/// [`errors`](Self::errors) to diagnose truncation or convergence behavior.
+/// [`errors`](Self::errors) to diagnose sweep-by-sweep convergence behavior.
 ///
 /// Related types: [`AciOptions`](crate::AciOptions) configures the run that
 /// produces this value; [`TensorTrain`] stores the approximating tensor.
@@ -21,13 +21,13 @@ use tensor4all_simplett::{TTScalar, TensorTrain};
 /// let tensor_train = TensorTrain::<f64>::constant(&[2, 3], 4.0);
 /// let result = AciResult {
 ///     tensor_train,
-///     ranks: vec![1],
-///     errors: vec![0.0],
+///     ranks: vec![1, 2],
+///     errors: vec![1e-3, 0.0],
 /// };
 ///
 /// assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
-/// assert_eq!(result.ranks, vec![1]);
-/// assert_eq!(result.errors, vec![0.0]);
+/// assert_eq!(result.ranks, vec![1, 2]);
+/// assert_eq!(result.errors, vec![1e-3, 0.0]);
 /// assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 4.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone)]
@@ -35,15 +35,15 @@ pub struct AciResult<T: TTScalar> {
     /// Tensor-train approximation produced by ACI.
     pub tensor_train: TensorTrain<T>,
 
-    /// Maximum or sweep-level bond dimensions recorded during the run.
+    /// Maximum bond dimension after each completed sweep.
     ///
-    /// Implementations should store these in iteration order so callers can
-    /// compare rank growth against [`AciOptions::max_bond_dim`](crate::AciOptions::max_bond_dim).
+    /// Entries are stored in completed-sweep order so callers can compare rank
+    /// growth against [`AciOptions::max_bond_dim`](crate::AciOptions::max_bond_dim).
     pub ranks: Vec<usize>,
 
-    /// Residual or convergence estimates recorded during the run.
+    /// Maximum pivot error after each completed sweep.
     ///
-    /// Values are stored in iteration order and use the same scaling convention
-    /// as [`AciOptions::tolerance`](crate::AciOptions::tolerance).
+    /// Entries are stored in completed-sweep order and use the same scaling
+    /// convention as [`AciOptions::tolerance`](crate::AciOptions::tolerance).
     pub errors: Vec<f64>,
 }

--- a/crates/tensor4all-aci/src/scalar.rs
+++ b/crates/tensor4all-aci/src/scalar.rs
@@ -1,0 +1,33 @@
+use num_complex::Complex64;
+use rand_distr::{Distribution, StandardNormal};
+
+pub(crate) trait AciRandomScalar: tensor4all_simplett::TTScalar {
+    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self;
+}
+
+pub(crate) trait AciScalar:
+    tensor4all_simplett::TTScalar + tensor4all_tcicore::MatrixLuciScalar + AciRandomScalar + Copy
+{
+}
+
+impl<T> AciScalar for T where
+    T: tensor4all_simplett::TTScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + AciRandomScalar
+        + Copy
+{
+}
+
+impl AciRandomScalar for f64 {
+    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
+        StandardNormal.sample(rng)
+    }
+}
+
+impl AciRandomScalar for Complex64 {
+    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
+        let re = StandardNormal.sample(rng);
+        let im = StandardNormal.sample(rng);
+        Complex64::new(re, im)
+    }
+}

--- a/crates/tensor4all-aci/src/scalar.rs
+++ b/crates/tensor4all-aci/src/scalar.rs
@@ -1,30 +1,42 @@
 use num_complex::Complex64;
 use rand_distr::{Distribution, StandardNormal};
 
-pub(crate) trait AciRandomScalar: tensor4all_simplett::TTScalar {
+/// Scalar types supported by Alternating Cross Interpolation.
+///
+/// Use this trait bound when writing generic helpers around ACI elementwise
+/// operations. It combines the tensor-train scalar requirements, matrix-CI
+/// scalar requirements, and deterministic random initialization support needed
+/// by the sweep algorithm.
+///
+/// Related types: [`AciOptions`](crate::AciOptions) configures ACI runs for an
+/// `AciScalar`, and [`AciResult`](crate::AciResult) returns a tensor train with
+/// the same scalar type.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_aci::AciScalar;
+///
+/// fn accepts_aci_scalar<T: AciScalar>(value: T) -> T {
+///     value
+/// }
+///
+/// assert_eq!(accepts_aci_scalar(3.0_f64), 3.0);
+/// ```
+pub trait AciScalar:
+    tensor4all_simplett::TTScalar + tensor4all_tcicore::MatrixLuciScalar + Copy
+{
+    #[doc(hidden)]
     fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self;
 }
 
-pub(crate) trait AciScalar:
-    tensor4all_simplett::TTScalar + tensor4all_tcicore::MatrixLuciScalar + AciRandomScalar + Copy
-{
-}
-
-impl<T> AciScalar for T where
-    T: tensor4all_simplett::TTScalar
-        + tensor4all_tcicore::MatrixLuciScalar
-        + AciRandomScalar
-        + Copy
-{
-}
-
-impl AciRandomScalar for f64 {
+impl AciScalar for f64 {
     fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
         StandardNormal.sample(rng)
     }
 }
 
-impl AciRandomScalar for Complex64 {
+impl AciScalar for Complex64 {
     fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
         let re = StandardNormal.sample(rng);
         let im = StandardNormal.sample(rng);

--- a/crates/tensor4all-aci/src/scalar.rs
+++ b/crates/tensor4all-aci/src/scalar.rs
@@ -1,12 +1,34 @@
 use num_complex::Complex64;
 use rand_distr::{Distribution, StandardNormal};
 
+mod private {
+    use super::*;
+
+    pub(super) trait Sealed {
+        fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self;
+    }
+
+    impl Sealed for f64 {
+        fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
+            StandardNormal.sample(rng)
+        }
+    }
+
+    impl Sealed for Complex64 {
+        fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
+            let re = StandardNormal.sample(rng);
+            let im = StandardNormal.sample(rng);
+            Complex64::new(re, im)
+        }
+    }
+}
+
 /// Scalar types supported by Alternating Cross Interpolation.
 ///
 /// Use this trait bound when writing generic helpers around ACI elementwise
-/// operations. It combines the tensor-train scalar requirements, matrix-CI
-/// scalar requirements, and deterministic random initialization support needed
-/// by the sweep algorithm.
+/// operations. It combines the tensor-train and matrix-CI scalar requirements
+/// needed by the sweep algorithm. The trait is sealed; use `f64` or
+/// [`num_complex::Complex64`].
 ///
 /// Related types: [`AciOptions`](crate::AciOptions) configures ACI runs for an
 /// `AciScalar`, and [`AciResult`](crate::AciResult) returns a tensor train with
@@ -23,23 +45,20 @@ use rand_distr::{Distribution, StandardNormal};
 ///
 /// assert_eq!(accepts_aci_scalar(3.0_f64), 3.0);
 /// ```
+#[allow(private_bounds)]
 pub trait AciScalar:
-    tensor4all_simplett::TTScalar + tensor4all_tcicore::MatrixLuciScalar + Copy
+    tensor4all_simplett::TTScalar + tensor4all_tcicore::MatrixLuciScalar + Copy + private::Sealed
 {
-    #[doc(hidden)]
-    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self;
 }
 
-impl AciScalar for f64 {
-    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
-        StandardNormal.sample(rng)
-    }
+impl<T> AciScalar for T where
+    T: tensor4all_simplett::TTScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + Copy
+        + private::Sealed
+{
 }
 
-impl AciScalar for Complex64 {
-    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self {
-        let re = StandardNormal.sample(rng);
-        let im = StandardNormal.sample(rng);
-        Complex64::new(re, im)
-    }
+pub(crate) fn sample_standard_normal<T: AciScalar>(rng: &mut rand_chacha::ChaCha8Rng) -> T {
+    <T as private::Sealed>::sample_standard_normal(rng)
 }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -62,6 +62,26 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             .map(|frame| (frame.nrows(), frame.ncols()))
     }
 
+    pub(crate) fn left_frame_value(
+        &self,
+        input: usize,
+        site: usize,
+        row: usize,
+        col: usize,
+    ) -> Option<T> {
+        frame_value(&self.left_frames, input, site, row, col)
+    }
+
+    pub(crate) fn right_frame_value(
+        &self,
+        input: usize,
+        site: usize,
+        row: usize,
+        col: usize,
+    ) -> Option<T> {
+        frame_value(&self.right_frames, input, site, row, col)
+    }
+
     pub(crate) fn update_left_frame(
         &mut self,
         input: usize,
@@ -238,6 +258,20 @@ impl<T: AciScalar> ElementwiseProblem<T> {
 
 fn unit_frame<T: AciScalar>() -> Matrix<T> {
     Matrix::from_col_major_vec(1, 1, vec![T::one()])
+}
+
+fn frame_value<T: AciScalar>(
+    frames: &[Vec<Option<Matrix<T>>>],
+    input: usize,
+    site: usize,
+    row: usize,
+    col: usize,
+) -> Option<T> {
+    let frame = frames.get(input)?.get(site)?.as_ref()?;
+    if row >= frame.nrows() || col >= frame.ncols() {
+        return None;
+    }
+    Some(frame[[row, col]])
 }
 
 fn validate_input_site(input: usize, site: usize, n_inputs: usize, n_sites: usize) -> Result<()> {

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -1,9 +1,13 @@
+use std::cell::RefCell;
+
 use crate::scalar::AciScalar;
-use crate::{initial_guess, AciError, AciOptions, Result};
+use crate::{initial_guess, AciError, AciOptions, ElementwiseBatch, LocalBlockEvaluator, Result};
 use tensor4all_simplett::{
     tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
 };
-use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
+use tensor4all_tcicore::{
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, RrLUOptions,
+};
 use tensor4all_tensorbackend::{mat_mul, Matrix};
 
 pub(crate) struct ElementwiseProblem<T: AciScalar> {
@@ -237,6 +241,121 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         for input in 0..self.n_inputs() {
             self.update_right_frame(input, site, col_indices)?;
         }
+        Ok(())
+    }
+
+    pub(crate) fn local_update<F>(
+        &mut self,
+        bond: usize,
+        left_orthogonal: bool,
+        options: &AciOptions<T>,
+        op: &mut F,
+    ) -> Result<()>
+    where
+        F: for<'batch> FnMut(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
+    {
+        let n = self.len();
+        if bond >= n.saturating_sub(1) {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!("bond index {bond} out of bounds for tensor train length {n}"),
+            });
+        }
+
+        let left_core = self.solution.site_tensor(bond);
+        let right_core = self.solution.site_tensor(bond + 1);
+        if left_core.right_dim() != right_core.left_dim() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "adjacent solution core bond mismatch at bond {bond}: \
+                     left core right bond is {}, right core left bond is {}",
+                    left_core.right_dim(),
+                    right_core.left_dim()
+                ),
+            });
+        }
+
+        let left_solution_rank = left_core.left_dim();
+        let site_dim_left = left_core.site_dim();
+        let site_dim_right = right_core.site_dim();
+        let right_solution_rank = right_core.right_dim();
+        let nrows = checked_frame_mul(
+            left_solution_rank,
+            site_dim_left,
+            "solution local block row count",
+        )?;
+        let ncols = checked_frame_mul(
+            site_dim_right,
+            right_solution_rank,
+            "solution local block column count",
+        )?;
+
+        let factors = {
+            let op_cell = RefCell::new(op);
+            let operator = |batch: ElementwiseBatch<'_, T>, output: &mut [T]| {
+                let mut op_ref = op_cell.borrow_mut();
+                (*op_ref)(batch, output)
+            };
+            let evaluator = LocalBlockEvaluator::new(self, bond, &operator)?;
+            if evaluator.nrows() != nrows || evaluator.ncols() != ncols {
+                return Err(AciError::InvalidInitialGuess {
+                    message: format!(
+                        "local block shape mismatch at bond {bond}: solution implies \
+                         ({nrows}, {ncols}), evaluator has ({}, {})",
+                        evaluator.nrows(),
+                        evaluator.ncols()
+                    ),
+                });
+            }
+
+            let factors_result = matrix_luci_factors_from_blocks(
+                nrows,
+                ncols,
+                |rows, cols, out: &mut [T]| {
+                    evaluator.fill_local_block_or_zero(rows, cols, out);
+                },
+                RrLUOptions {
+                    max_rank: options.max_bond_dim,
+                    rel_tol: if options.scale_tolerance {
+                        options.tolerance
+                    } else {
+                        0.0
+                    },
+                    abs_tol: if options.scale_tolerance {
+                        0.0
+                    } else {
+                        options.tolerance
+                    },
+                    left_orthogonal,
+                },
+            );
+            if let Some(err) = evaluator.take_error() {
+                return Err(err);
+            }
+            factors_result?
+        };
+
+        let mut solution_cores = self.solution.site_tensors().to_vec();
+        solution_cores[bond] = matrix_to_tensor3(
+            &factors.left,
+            left_solution_rank,
+            site_dim_left,
+            factors.rank,
+        )?;
+        solution_cores[bond + 1] = right_factor_to_tensor3(
+            &factors.right,
+            factors.rank,
+            site_dim_right,
+            right_solution_rank,
+        )?;
+        self.solution = TensorTrain::new(solution_cores)?;
+
+        if left_orthogonal {
+            self.update_left_frames(bond, &factors.row_indices)?;
+        } else {
+            self.update_right_frames(bond + 1, &factors.col_indices)?;
+        }
+        self.pivot_errors[bond] = factors.pivot_errors.last().copied().unwrap_or(0.0);
+
         Ok(())
     }
 

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -223,7 +223,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         validate_selection("row", row_indices, full_rows)?;
 
         let core_matrix = self.input_core_left_matrix(input, site);
-        let full_frame = frame_matmul_checked(&source, &core_matrix, "left", input, site)?;
+        let full_frame = frame_matmul_checked(&source, core_matrix, "left", input, site)?;
         let full_data = full_frame.as_col_major_slice();
         let mut selected = Matrix::zeros(row_indices.len(), core.right_dim());
         for (selected_row, &full_row) in row_indices.iter().enumerate() {
@@ -267,7 +267,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         validate_selection("column", col_indices, full_cols)?;
 
         let core_matrix = self.input_core_right_matrix(input, site);
-        let full_frame = frame_matmul_checked(&core_matrix, &source, "right", input, site)?;
+        let full_frame = frame_matmul_checked(core_matrix, &source, "right", input, site)?;
         let full_data = full_frame.as_col_major_slice();
         let mut selected = Matrix::zeros(core.left_dim(), col_indices.len());
         for (selected_col, &full_col) in col_indices.iter().enumerate() {

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -4,7 +4,7 @@ use tensor4all_simplett::{
     tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
 };
 use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
-use tensor4all_tensorbackend::Matrix;
+use tensor4all_tensorbackend::{mat_mul, Matrix};
 
 pub(crate) struct ElementwiseProblem<T: AciScalar> {
     pub(crate) inputs: Vec<TensorTrain<T>>,
@@ -226,31 +226,6 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             self.update_right_frames(site, &factors.col_indices)?;
         }
 
-        if n > 0 {
-            let current = &solution_cores[0];
-            let site_dim = current.site_dim();
-            let right_dim = current.right_dim();
-            let matrix = right_matrix_julia_order(current);
-            let factors = matrix_luci_factors_from_matrix(
-                &matrix,
-                Some(RrLUOptions {
-                    left_orthogonal: false,
-                    rel_tol: 0.0,
-                    abs_tol: 0.0,
-                    max_rank: usize::MAX,
-                }),
-            )?;
-
-            validate_selection(
-                "column",
-                &factors.col_indices,
-                checked_frame_mul(site_dim, right_dim, "solution right matrix column count")?,
-            )?;
-            let product = matmul_checked(&factors.left, &factors.right, 0)?;
-            solution_cores[0] = right_factor_to_tensor3(&product, 1, site_dim, right_dim)?;
-            self.update_right_frames(0, &factors.col_indices)?;
-        }
-
         self.solution = TensorTrain::new(solution_cores)?;
         Ok(())
     }
@@ -408,15 +383,7 @@ fn matmul_checked<T: AciScalar>(
         });
     }
 
-    let mut product = Matrix::zeros(left.nrows(), right.ncols());
-    for row in 0..left.nrows() {
-        for col in 0..right.ncols() {
-            let mut sum = T::zero();
-            for k in 0..left.ncols() {
-                sum = sum + left[[row, k]] * right[[k, col]];
-            }
-            product[[row, col]] = sum;
-        }
-    }
-    Ok(product)
+    mat_mul(left, right).map_err(|err| AciError::InvalidInitialGuess {
+        message: format!("solution core update at site {site} failed: {err}"),
+    })
 }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -16,6 +16,7 @@ pub(crate) struct ElementwiseProblem<T: AciScalar> {
     pub(crate) left_frames: Vec<Vec<Option<Matrix<T>>>>,
     pub(crate) right_frames: Vec<Vec<Option<Matrix<T>>>>,
     pub(crate) pivot_errors: Vec<f64>,
+    pub(crate) pivot_scales: Vec<f64>,
 }
 
 impl<T: AciScalar> ElementwiseProblem<T> {
@@ -37,6 +38,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             left_frames,
             right_frames,
             pivot_errors: vec![0.0; n.saturating_sub(1)],
+            pivot_scales: vec![0.0; n.saturating_sub(1)],
         };
         problem.initialize_right_frames()?;
         Ok(problem)
@@ -289,7 +291,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             "solution local block column count",
         )?;
 
-        let factors = {
+        let (factors, sampled_scale) = {
             let op_cell = RefCell::new(op);
             let operator = |batch: ElementwiseBatch<'_, T>, output: &mut [T]| {
                 let mut op_ref = op_cell.borrow_mut();
@@ -331,7 +333,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             if let Some(err) = evaluator.take_error() {
                 return Err(err);
             }
-            factors_result?
+            (factors_result?, evaluator.max_output_abs())
         };
 
         let pivot_error = match factors.pivot_errors.last() {
@@ -377,6 +379,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             self.update_right_frames(bond + 1, &col_indices)?;
         }
         self.pivot_errors[bond] = pivot_error;
+        self.pivot_scales[bond] = sampled_scale;
 
         Ok(())
     }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -5,18 +5,51 @@ use crate::{initial_guess, AciError, AciOptions, ElementwiseBatch, LocalBlockEva
 use tensor4all_simplett::{
     tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
 };
-use tensor4all_tcicore::{
-    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, RrLUOptions,
-};
-use tensor4all_tensorbackend::{mat_mul, Matrix};
+use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
+use tensor4all_tensorbackend::{batched_mat_mul_same_shape, mat_mul, Matrix};
+
+#[cfg(test)]
+fn frame_batching_enabled() -> bool {
+    std::env::var("T4A_ACI_DISABLE_BATCHED_FRAME").as_deref() != Ok("1")
+}
+
+#[cfg(not(test))]
+fn frame_batching_enabled() -> bool {
+    true
+}
 
 pub(crate) struct ElementwiseProblem<T: AciScalar> {
     pub(crate) inputs: Vec<TensorTrain<T>>,
     pub(crate) solution: TensorTrain<T>,
+    input_core_matrices: Vec<Vec<InputCoreMatrices<T>>>,
     pub(crate) left_frames: Vec<Vec<Option<Matrix<T>>>>,
     pub(crate) right_frames: Vec<Vec<Option<Matrix<T>>>>,
     pub(crate) pivot_errors: Vec<f64>,
     pub(crate) pivot_scales: Vec<f64>,
+}
+
+#[derive(Clone)]
+struct InputCoreMatrices<T> {
+    left_grouped: Matrix<T>,
+    right_grouped: Matrix<T>,
+}
+
+impl<T: AciScalar> InputCoreMatrices<T> {
+    fn from_core(core: &Tensor3<T>) -> Self {
+        let data = core.to_col_major_vec();
+        Self {
+            left_grouped: Matrix::from_col_major_vec(
+                core.left_dim(),
+                core.site_dim() * core.right_dim(),
+                data.clone(),
+            ),
+            right_grouped: Matrix::from_col_major_vec(
+                core.left_dim() * core.site_dim(),
+                core.right_dim(),
+                data,
+            ),
+        }
+    }
 }
 
 impl<T: AciScalar> ElementwiseProblem<T> {
@@ -24,6 +57,16 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         let solution = initial_guess(&inputs, &options)?;
         let n = solution.len();
         let n_inputs = inputs.len();
+        let input_core_matrices = inputs
+            .iter()
+            .map(|input| {
+                input
+                    .site_tensors()
+                    .iter()
+                    .map(InputCoreMatrices::from_core)
+                    .collect()
+            })
+            .collect();
         let mut left_frames = vec![vec![None; n + 1]; n_inputs];
         let mut right_frames = vec![vec![None; n + 1]; n_inputs];
 
@@ -35,6 +78,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         let mut problem = Self {
             inputs,
             solution,
+            input_core_matrices,
             left_frames,
             right_frames,
             pivot_errors: vec![0.0; n.saturating_sub(1)],
@@ -50,6 +94,14 @@ impl<T: AciScalar> ElementwiseProblem<T> {
 
     pub(crate) fn n_inputs(&self) -> usize {
         self.inputs.len()
+    }
+
+    pub(crate) fn input_core_left_matrix(&self, input: usize, site: usize) -> &Matrix<T> {
+        &self.input_core_matrices[input][site].left_grouped
+    }
+
+    pub(crate) fn input_core_right_matrix(&self, input: usize, site: usize) -> &Matrix<T> {
+        &self.input_core_matrices[input][site].right_grouped
     }
 
     pub(crate) fn left_frame_shape(&self, input: usize, site: usize) -> Option<(usize, usize)> {
@@ -168,16 +220,13 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         let full_rows = checked_frame_mul(source.nrows(), core.site_dim(), "left frame row count")?;
         validate_selection("row", row_indices, full_rows)?;
 
+        let core_matrix = self.input_core_left_matrix(input, site);
+        let full_frame = frame_matmul_checked(&source, &core_matrix, "left", input, site)?;
+        let full_data = full_frame.as_col_major_slice();
         let mut selected = Matrix::zeros(row_indices.len(), core.right_dim());
         for (selected_row, &full_row) in row_indices.iter().enumerate() {
-            let source_row = full_row % source.nrows();
-            let physical = full_row / source.nrows();
             for right in 0..core.right_dim() {
-                let mut sum = T::zero();
-                for left in 0..core.left_dim() {
-                    sum = sum + source[[source_row, left]] * *core.get3(left, physical, right);
-                }
-                selected[[selected_row, right]] = sum;
+                selected[[selected_row, right]] = full_data[full_row + full_rows * right];
             }
         }
 
@@ -215,16 +264,13 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             checked_frame_mul(core.site_dim(), source.ncols(), "right frame column count")?;
         validate_selection("column", col_indices, full_cols)?;
 
+        let core_matrix = self.input_core_right_matrix(input, site);
+        let full_frame = frame_matmul_checked(&core_matrix, &source, "right", input, site)?;
+        let full_data = full_frame.as_col_major_slice();
         let mut selected = Matrix::zeros(core.left_dim(), col_indices.len());
-        for left in 0..core.left_dim() {
-            for (selected_col, &full_col) in col_indices.iter().enumerate() {
-                let physical = full_col % core.site_dim();
-                let source_col = full_col / core.site_dim();
-                let mut sum = T::zero();
-                for right in 0..core.right_dim() {
-                    sum = sum + *core.get3(left, physical, right) * source[[right, source_col]];
-                }
-                selected[[left, selected_col]] = sum;
+        for (selected_col, &full_col) in col_indices.iter().enumerate() {
+            for left in 0..core.left_dim() {
+                selected[[left, selected_col]] = full_data[left + core.left_dim() * full_col];
             }
         }
 
@@ -233,6 +279,15 @@ impl<T: AciScalar> ElementwiseProblem<T> {
     }
 
     pub(crate) fn update_left_frames(&mut self, site: usize, row_indices: &[usize]) -> Result<()> {
+        if frame_batching_enabled() {
+            if let Some(frames) = self.batched_left_frame_updates(site, row_indices)? {
+                for (input, frame) in frames.into_iter().enumerate() {
+                    self.left_frames[input][site + 1] = Some(frame);
+                }
+                return Ok(());
+            }
+        }
+
         for input in 0..self.n_inputs() {
             self.update_left_frame(input, site, row_indices)?;
         }
@@ -240,10 +295,200 @@ impl<T: AciScalar> ElementwiseProblem<T> {
     }
 
     pub(crate) fn update_right_frames(&mut self, site: usize, col_indices: &[usize]) -> Result<()> {
+        if frame_batching_enabled() {
+            if let Some(frames) = self.batched_right_frame_updates(site, col_indices)? {
+                for (input, frame) in frames.into_iter().enumerate() {
+                    self.right_frames[input][site] = Some(frame);
+                }
+                return Ok(());
+            }
+        }
+
         for input in 0..self.n_inputs() {
             self.update_right_frame(input, site, col_indices)?;
         }
         Ok(())
+    }
+
+    fn batched_left_frame_updates(
+        &self,
+        site: usize,
+        row_indices: &[usize],
+    ) -> Result<Option<Vec<Matrix<T>>>> {
+        let n = self.len();
+        let n_inputs = self.n_inputs();
+        if n_inputs <= 1 {
+            return Ok(None);
+        }
+
+        let mut shared: Option<(usize, usize, usize, usize, usize)> = None;
+        let mut frame_batch = Vec::new();
+        let mut core_batch = Vec::new();
+
+        for input in 0..n_inputs {
+            validate_input_site(input, site, n_inputs, n)?;
+            let source = self.left_frames[input][site]
+                .as_ref()
+                .ok_or_else(|| missing_frame("left", input, site))?;
+            let core = self.inputs[input].site_tensor(site);
+
+            if source.ncols() != core.left_dim() {
+                return Err(AciError::InvalidInitialGuess {
+                    message: format!(
+                        "left frame/input bond mismatch at input {input}, site {site}: \
+                         frame has {} columns, core left bond is {}",
+                        source.ncols(),
+                        core.left_dim()
+                    ),
+                });
+            }
+
+            let full_rows =
+                checked_frame_mul(source.nrows(), core.site_dim(), "left frame row count")?;
+            validate_selection("row", row_indices, full_rows)?;
+
+            let dims = (
+                source.nrows(),
+                source.ncols(),
+                core.site_dim(),
+                core.right_dim(),
+                full_rows,
+            );
+            if let Some(shared) = shared {
+                if shared != dims {
+                    return Ok(None);
+                }
+            } else {
+                shared = Some(dims);
+            }
+
+            frame_batch.extend_from_slice(source.as_col_major_slice());
+            core_batch.extend_from_slice(
+                self.input_core_left_matrix(input, site)
+                    .as_col_major_slice(),
+            );
+        }
+
+        let Some((source_rows, source_cols, site_dim, right_dim, full_rows)) = shared else {
+            return Ok(None);
+        };
+        let output_cols = site_dim * right_dim;
+        let values = batched_mat_mul_same_shape(
+            n_inputs,
+            source_rows,
+            source_cols,
+            output_cols,
+            &frame_batch,
+            &core_batch,
+        )
+        .map_err(|err| frame_matmul_error("batched left", err))?;
+        let item_len = source_rows * output_cols;
+
+        let frames = (0..n_inputs)
+            .map(|input| {
+                let offset = input * item_len;
+                let full_data = &values[offset..offset + item_len];
+                let mut selected = Matrix::zeros(row_indices.len(), right_dim);
+                for (selected_row, &full_row) in row_indices.iter().enumerate() {
+                    for right in 0..right_dim {
+                        selected[[selected_row, right]] = full_data[full_row + full_rows * right];
+                    }
+                }
+                selected
+            })
+            .collect();
+        Ok(Some(frames))
+    }
+
+    fn batched_right_frame_updates(
+        &self,
+        site: usize,
+        col_indices: &[usize],
+    ) -> Result<Option<Vec<Matrix<T>>>> {
+        let n = self.len();
+        let n_inputs = self.n_inputs();
+        if n_inputs <= 1 {
+            return Ok(None);
+        }
+
+        let mut shared: Option<(usize, usize, usize, usize, usize)> = None;
+        let mut core_batch = Vec::new();
+        let mut frame_batch = Vec::new();
+        let source_site = site + 1;
+
+        for input in 0..n_inputs {
+            validate_input_site(input, site, n_inputs, n)?;
+            let source = self.right_frames[input][source_site]
+                .as_ref()
+                .ok_or_else(|| missing_frame("right", input, source_site))?;
+            let core = self.inputs[input].site_tensor(site);
+
+            if core.right_dim() != source.nrows() {
+                return Err(AciError::InvalidInitialGuess {
+                    message: format!(
+                        "right frame/input bond mismatch at input {input}, site {site}: \
+                         core right bond is {}, frame has {} rows",
+                        core.right_dim(),
+                        source.nrows()
+                    ),
+                });
+            }
+
+            let full_cols =
+                checked_frame_mul(core.site_dim(), source.ncols(), "right frame column count")?;
+            validate_selection("column", col_indices, full_cols)?;
+
+            let dims = (
+                core.left_dim(),
+                core.site_dim(),
+                core.right_dim(),
+                source.ncols(),
+                full_cols,
+            );
+            if let Some(shared) = shared {
+                if shared != dims {
+                    return Ok(None);
+                }
+            } else {
+                shared = Some(dims);
+            }
+
+            core_batch.extend_from_slice(
+                self.input_core_right_matrix(input, site)
+                    .as_col_major_slice(),
+            );
+            frame_batch.extend_from_slice(source.as_col_major_slice());
+        }
+
+        let Some((left_dim, site_dim, right_dim, source_cols, _full_cols)) = shared else {
+            return Ok(None);
+        };
+        let core_rows = left_dim * site_dim;
+        let values = batched_mat_mul_same_shape(
+            n_inputs,
+            core_rows,
+            right_dim,
+            source_cols,
+            &core_batch,
+            &frame_batch,
+        )
+        .map_err(|err| frame_matmul_error("batched right", err))?;
+        let item_len = core_rows * source_cols;
+
+        let frames = (0..n_inputs)
+            .map(|input| {
+                let offset = input * item_len;
+                let full_data = &values[offset..offset + item_len];
+                let mut selected = Matrix::zeros(left_dim, col_indices.len());
+                for (selected_col, &full_col) in col_indices.iter().enumerate() {
+                    for left in 0..left_dim {
+                        selected[[left, selected_col]] = full_data[left + left_dim * full_col];
+                    }
+                }
+                selected
+            })
+            .collect();
+        Ok(Some(frames))
     }
 
     pub(crate) fn local_update<F>(
@@ -309,13 +554,10 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                 });
             }
 
-            let factors_result = matrix_luci_factors_from_blocks(
-                nrows,
-                ncols,
-                |rows, cols, out: &mut [T]| {
-                    evaluator.fill_local_block_or_zero(rows, cols, out);
-                },
-                RrLUOptions {
+            let local_matrix = evaluator.materialize_local_matrix()?;
+            let factors_result = matrix_luci_factors_from_matrix(
+                &local_matrix,
+                Some(RrLUOptions {
                     max_rank: options.max_bond_dim,
                     rel_tol: if options.scale_tolerance {
                         options.tolerance
@@ -328,11 +570,8 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                         options.tolerance
                     },
                     left_orthogonal,
-                },
+                }),
             );
-            if let Some(err) = evaluator.take_error() {
-                return Err(err);
-            }
             (factors_result?, evaluator.max_output_abs())
         };
 
@@ -638,7 +877,7 @@ fn left_matrix_julia_order<T: AciScalar>(core: &Tensor3<T>) -> Matrix<T> {
     Matrix::from_col_major_vec(left_dim * site_dim, right_dim, data)
 }
 
-fn matrix_to_tensor3<T: AciScalar>(
+pub(crate) fn matrix_to_tensor3<T: AciScalar>(
     matrix: &Matrix<T>,
     left_dim: usize,
     site_dim: usize,
@@ -662,7 +901,7 @@ fn matrix_to_tensor3<T: AciScalar>(
     )?)
 }
 
-fn right_factor_to_tensor3<T: AciScalar>(
+pub(crate) fn right_factor_to_tensor3<T: AciScalar>(
     matrix: &Matrix<T>,
     left_dim: usize,
     site_dim: usize,
@@ -707,4 +946,35 @@ fn matmul_checked<T: AciScalar>(
     mat_mul(left, right).map_err(|err| AciError::InvalidInitialGuess {
         message: format!("solution core update at site {site} failed: {err}"),
     })
+}
+
+fn frame_matmul_checked<T: AciScalar>(
+    left: &Matrix<T>,
+    right: &Matrix<T>,
+    direction: &'static str,
+    input: usize,
+    site: usize,
+) -> Result<Matrix<T>> {
+    if left.ncols() != right.nrows() {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "{direction} frame update at input {input}, site {site} has incompatible matrix \
+                 shapes: left ({}, {}), right ({}, {})",
+                left.nrows(),
+                left.ncols(),
+                right.nrows(),
+                right.ncols()
+            ),
+        });
+    }
+
+    mat_mul(left, right).map_err(|err| AciError::InvalidInitialGuess {
+        message: format!("{direction} frame update at input {input}, site {site} failed: {err}"),
+    })
+}
+
+fn frame_matmul_error(direction: &'static str, err: impl std::fmt::Display) -> AciError {
+    AciError::InvalidInitialGuess {
+        message: format!("{direction} frame update failed: {err}"),
+    }
 }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -5,8 +5,10 @@ use crate::{initial_guess, AciError, AciOptions, ElementwiseBatch, LocalBlockEva
 use tensor4all_simplett::{
     tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
 };
-use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
-use tensor4all_tensorbackend::{batched_mat_mul_same_shape, mat_mul, Matrix};
+use tensor4all_tcicore::{
+    matrix_luci_factors_from_matrix, matrix_luci_factors_from_matrix_owned, RrLUOptions,
+};
+use tensor4all_tensorbackend::{batched_mat_mul_same_shape_owned, mat_mul, mat_mul_owned, Matrix};
 
 #[cfg(test)]
 fn frame_batching_enabled() -> bool {
@@ -373,13 +375,13 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             return Ok(None);
         };
         let output_cols = site_dim * right_dim;
-        let values = batched_mat_mul_same_shape(
+        let values = batched_mat_mul_same_shape_owned(
             n_inputs,
             source_rows,
             source_cols,
             output_cols,
-            &frame_batch,
-            &core_batch,
+            frame_batch,
+            core_batch,
         )
         .map_err(|err| frame_matmul_error("batched left", err))?;
         let item_len = source_rows * output_cols;
@@ -464,13 +466,13 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             return Ok(None);
         };
         let core_rows = left_dim * site_dim;
-        let values = batched_mat_mul_same_shape(
+        let values = batched_mat_mul_same_shape_owned(
             n_inputs,
             core_rows,
             right_dim,
             source_cols,
-            &core_batch,
-            &frame_batch,
+            core_batch,
+            frame_batch,
         )
         .map_err(|err| frame_matmul_error("batched right", err))?;
         let item_len = core_rows * source_cols;
@@ -555,8 +557,8 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             }
 
             let local_matrix = evaluator.materialize_local_matrix()?;
-            let factors_result = matrix_luci_factors_from_matrix(
-                &local_matrix,
+            let factors_result = matrix_luci_factors_from_matrix_owned(
+                local_matrix,
                 Some(RrLUOptions {
                     max_rank: options.max_bond_dim,
                     rel_tol: if options.scale_tolerance {
@@ -605,12 +607,13 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             )
         };
 
-        let mut solution_cores = self.solution.site_tensors().to_vec();
-        solution_cores[bond] =
-            matrix_to_tensor3(&left_factor, left_solution_rank, site_dim_left, new_rank)?;
-        solution_cores[bond + 1] =
-            right_factor_to_tensor3(&right_factor, new_rank, site_dim_right, right_solution_rank)?;
-        self.solution = TensorTrain::new(solution_cores)?;
+        let new_left_core =
+            matrix_into_tensor3(left_factor, left_solution_rank, site_dim_left, new_rank)?;
+        let new_right_core =
+            right_factor_into_tensor3(right_factor, new_rank, site_dim_right, right_solution_rank)?;
+        let solution_cores = self.solution.site_tensors_mut();
+        solution_cores[bond] = new_left_core;
+        solution_cores[bond + 1] = new_right_core;
 
         if left_orthogonal {
             self.update_left_frames(bond, &row_indices)?;
@@ -671,15 +674,15 @@ impl<T: AciScalar> ElementwiseProblem<T> {
 
             validate_selection("column", &col_indices, ncols)?;
             solution_cores[site] =
-                right_factor_to_tensor3(&right_factor, new_rank, site_dim, right_dim)?;
+                right_factor_into_tensor3(right_factor, new_rank, site_dim, right_dim)?;
 
             let previous = &solution_cores[site - 1];
             let previous_left_dim = previous.left_dim();
             let previous_site_dim = previous.site_dim();
             let previous_matrix = left_matrix_julia_order(previous);
-            let product = matmul_checked(&previous_matrix, &left_factor, site - 1)?;
+            let product = matmul_checked_owned(previous_matrix, left_factor, site - 1)?;
             solution_cores[site - 1] =
-                matrix_to_tensor3(&product, previous_left_dim, previous_site_dim, new_rank)?;
+                matrix_into_tensor3(product, previous_left_dim, previous_site_dim, new_rank)?;
 
             self.update_right_frames(site, &col_indices)?;
         }
@@ -901,6 +904,30 @@ pub(crate) fn matrix_to_tensor3<T: AciScalar>(
     )?)
 }
 
+pub(crate) fn matrix_into_tensor3<T: AciScalar>(
+    matrix: Matrix<T>,
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+) -> Result<Tensor3<T>> {
+    if matrix.nrows() != left_dim * site_dim || matrix.ncols() != right_dim {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot reshape matrix of shape ({}, {}) to tensor core ({left_dim}, \
+                 {site_dim}, {right_dim})",
+                matrix.nrows(),
+                matrix.ncols()
+            ),
+        });
+    }
+    Ok(tensor3_from_data(
+        matrix.into_col_major_vec(),
+        left_dim,
+        site_dim,
+        right_dim,
+    )?)
+}
+
 pub(crate) fn right_factor_to_tensor3<T: AciScalar>(
     matrix: &Matrix<T>,
     left_dim: usize,
@@ -925,9 +952,33 @@ pub(crate) fn right_factor_to_tensor3<T: AciScalar>(
     )?)
 }
 
-fn matmul_checked<T: AciScalar>(
-    left: &Matrix<T>,
-    right: &Matrix<T>,
+pub(crate) fn right_factor_into_tensor3<T: AciScalar>(
+    matrix: Matrix<T>,
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+) -> Result<Tensor3<T>> {
+    if matrix.nrows() != left_dim || matrix.ncols() != site_dim * right_dim {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot reshape right factor of shape ({}, {}) to tensor core ({left_dim}, \
+                 {site_dim}, {right_dim})",
+                matrix.nrows(),
+                matrix.ncols()
+            ),
+        });
+    }
+    Ok(tensor3_from_data(
+        matrix.into_col_major_vec(),
+        left_dim,
+        site_dim,
+        right_dim,
+    )?)
+}
+
+fn matmul_checked_owned<T: AciScalar>(
+    left: Matrix<T>,
+    right: Matrix<T>,
     site: usize,
 ) -> Result<Matrix<T>> {
     if left.ncols() != right.nrows() {
@@ -943,7 +994,7 @@ fn matmul_checked<T: AciScalar>(
         });
     }
 
-    mat_mul(left, right).map_err(|err| AciError::InvalidInitialGuess {
+    mat_mul_owned(left, right).map_err(|err| AciError::InvalidInitialGuess {
         message: format!("solution core update at site {site} failed: {err}"),
     })
 }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -82,6 +82,58 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         frame_value(&self.right_frames, input, site, row, col)
     }
 
+    pub(crate) fn local_input_shape(&self, input: usize, bond: usize) -> Result<(usize, usize)> {
+        let context = self.local_input_context(input, bond)?;
+        Ok((context.nrows, context.ncols))
+    }
+
+    pub(crate) fn local_input_value(
+        &self,
+        input: usize,
+        bond: usize,
+        row: usize,
+        col: usize,
+    ) -> Result<T> {
+        let context = self.local_input_context(input, bond)?;
+        if row >= context.nrows {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "local row index {row} out of bounds for bond {bond} with {} rows",
+                    context.nrows
+                ),
+            });
+        }
+        if col >= context.ncols {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "local column index {col} out of bounds for bond {bond} with {} columns",
+                    context.ncols
+                ),
+            });
+        }
+
+        let r_left = context.left_frame.nrows();
+        let d_right = context.right_core.site_dim();
+        let left_pivot = row % r_left;
+        let site_left = row / r_left;
+        let site_right = col % d_right;
+        let right_pivot = col / d_right;
+
+        let mut sum = T::zero();
+        for a in 0..context.left_core.left_dim() {
+            for m in 0..context.left_core.right_dim() {
+                for b in 0..context.right_core.right_dim() {
+                    sum = sum
+                        + context.left_frame[[left_pivot, a]]
+                            * *context.left_core.get3(a, site_left, m)
+                            * *context.right_core.get3(m, site_right, b)
+                            * context.right_frame[[b, right_pivot]];
+                }
+            }
+        }
+        Ok(sum)
+    }
+
     pub(crate) fn update_left_frame(
         &mut self,
         input: usize,
@@ -229,6 +281,108 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         self.solution = TensorTrain::new(solution_cores)?;
         Ok(())
     }
+
+    fn local_input_context(&self, input: usize, bond: usize) -> Result<LocalInputContext<'_, T>> {
+        let n = self.len();
+        if input >= self.n_inputs() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "input index {input} out of bounds for {} inputs",
+                    self.n_inputs()
+                ),
+            });
+        }
+        if bond >= n.saturating_sub(1) {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!("bond index {bond} out of bounds for tensor train length {n}"),
+            });
+        }
+
+        let right_frame_site = bond + 2;
+        let left_frame = self
+            .left_frames
+            .get(input)
+            .and_then(|frames| frames.get(bond))
+            .and_then(|frame| frame.as_ref())
+            .ok_or_else(|| missing_frame("left", input, bond))?;
+        let right_frame = self
+            .right_frames
+            .get(input)
+            .and_then(|frames| frames.get(right_frame_site))
+            .and_then(|frame| frame.as_ref())
+            .ok_or_else(|| missing_frame("right", input, right_frame_site))?;
+        let left_core = self.inputs[input].site_tensor(bond);
+        let right_core = self.inputs[input].site_tensor(bond + 1);
+
+        if left_frame.nrows() == 0
+            || left_core.site_dim() == 0
+            || right_core.site_dim() == 0
+            || right_frame.ncols() == 0
+        {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!("local block at input {input}, bond {bond} has a zero dimension"),
+            });
+        }
+        if left_frame.ncols() != left_core.left_dim() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "left frame/input bond mismatch at input {input}, bond {bond}: \
+                     frame has {} columns, left core left bond is {}",
+                    left_frame.ncols(),
+                    left_core.left_dim()
+                ),
+            });
+        }
+        if left_core.right_dim() != right_core.left_dim() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "adjacent input core bond mismatch at input {input}, bond {bond}: \
+                     left core right bond is {}, right core left bond is {}",
+                    left_core.right_dim(),
+                    right_core.left_dim()
+                ),
+            });
+        }
+        if right_core.right_dim() != right_frame.nrows() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "right frame/input bond mismatch at input {input}, bond {bond}: \
+                     right core right bond is {}, frame has {} rows",
+                    right_core.right_dim(),
+                    right_frame.nrows()
+                ),
+            });
+        }
+
+        let nrows = checked_frame_mul(
+            left_frame.nrows(),
+            left_core.site_dim(),
+            "local block row count",
+        )?;
+        let ncols = checked_frame_mul(
+            right_core.site_dim(),
+            right_frame.ncols(),
+            "local block column count",
+        )?;
+
+        Ok(LocalInputContext {
+            left_frame,
+            right_frame,
+            left_core,
+            right_core,
+            nrows,
+            ncols,
+        })
+    }
+}
+
+struct LocalInputContext<'a, T: AciScalar> {
+    left_frame: &'a Matrix<T>,
+    right_frame: &'a Matrix<T>,
+    left_core: &'a Tensor3<T>,
+    right_core: &'a Tensor3<T>,
+    nrows: usize,
+    ncols: usize,
 }
 
 fn unit_frame<T: AciScalar>() -> Matrix<T> {

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -400,23 +400,46 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                 }),
             )?;
 
-            validate_selection(
-                "column",
-                &factors.col_indices,
-                checked_frame_mul(site_dim, right_dim, "solution right matrix column count")?,
-            )?;
+            let ncols =
+                checked_frame_mul(site_dim, right_dim, "solution right matrix column count")?;
+            let (new_rank, left_factor, right_factor, col_indices) = if factors.rank == 0 {
+                if matrix.nrows() == 0 || ncols == 0 {
+                    return Err(AciError::InvalidInitialGuess {
+                        message: format!(
+                            "zero-rank right-frame initialization at site {site} requires positive \
+                             matrix shape, got ({}, {ncols})",
+                            matrix.nrows()
+                        ),
+                    });
+                }
+                (
+                    1,
+                    Matrix::zeros(matrix.nrows(), 1),
+                    Matrix::zeros(1, ncols),
+                    vec![0],
+                )
+            } else {
+                (
+                    factors.rank,
+                    factors.left,
+                    factors.right,
+                    factors.col_indices,
+                )
+            };
+
+            validate_selection("column", &col_indices, ncols)?;
             solution_cores[site] =
-                right_factor_to_tensor3(&factors.right, factors.rank, site_dim, right_dim)?;
+                right_factor_to_tensor3(&right_factor, new_rank, site_dim, right_dim)?;
 
             let previous = &solution_cores[site - 1];
             let previous_left_dim = previous.left_dim();
             let previous_site_dim = previous.site_dim();
             let previous_matrix = left_matrix_julia_order(previous);
-            let product = matmul_checked(&previous_matrix, &factors.left, site - 1)?;
+            let product = matmul_checked(&previous_matrix, &left_factor, site - 1)?;
             solution_cores[site - 1] =
-                matrix_to_tensor3(&product, previous_left_dim, previous_site_dim, factors.rank)?;
+                matrix_to_tensor3(&product, previous_left_dim, previous_site_dim, new_rank)?;
 
-            self.update_right_frames(site, &factors.col_indices)?;
+            self.update_right_frames(site, &col_indices)?;
         }
 
         self.solution = TensorTrain::new(solution_cores)?;

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -334,27 +334,49 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             factors_result?
         };
 
+        let pivot_error = match factors.pivot_errors.last() {
+            Some(&error) => error,
+            None => 0.0,
+        };
+        let (new_rank, left_factor, right_factor, row_indices, col_indices) = if factors.rank == 0 {
+            if nrows == 0 || ncols == 0 {
+                return Err(AciError::InvalidInitialGuess {
+                    message: format!(
+                        "zero-rank local update at bond {bond} requires positive local block \
+                             shape, got ({nrows}, {ncols})"
+                    ),
+                });
+            }
+            (
+                1,
+                Matrix::zeros(nrows, 1),
+                Matrix::zeros(1, ncols),
+                vec![0],
+                vec![0],
+            )
+        } else {
+            (
+                factors.rank,
+                factors.left,
+                factors.right,
+                factors.row_indices,
+                factors.col_indices,
+            )
+        };
+
         let mut solution_cores = self.solution.site_tensors().to_vec();
-        solution_cores[bond] = matrix_to_tensor3(
-            &factors.left,
-            left_solution_rank,
-            site_dim_left,
-            factors.rank,
-        )?;
-        solution_cores[bond + 1] = right_factor_to_tensor3(
-            &factors.right,
-            factors.rank,
-            site_dim_right,
-            right_solution_rank,
-        )?;
+        solution_cores[bond] =
+            matrix_to_tensor3(&left_factor, left_solution_rank, site_dim_left, new_rank)?;
+        solution_cores[bond + 1] =
+            right_factor_to_tensor3(&right_factor, new_rank, site_dim_right, right_solution_rank)?;
         self.solution = TensorTrain::new(solution_cores)?;
 
         if left_orthogonal {
-            self.update_left_frames(bond, &factors.row_indices)?;
+            self.update_left_frames(bond, &row_indices)?;
         } else {
-            self.update_right_frames(bond + 1, &factors.col_indices)?;
+            self.update_right_frames(bond + 1, &col_indices)?;
         }
-        self.pivot_errors[bond] = factors.pivot_errors.last().copied().unwrap_or(0.0);
+        self.pivot_errors[bond] = pivot_error;
 
         Ok(())
     }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -1,0 +1,388 @@
+use crate::scalar::AciScalar;
+use crate::{initial_guess, AciError, AciOptions, Result};
+use tensor4all_simplett::{
+    tensor3_from_data, AbstractTensorTrain, Tensor3, Tensor3Ops, TensorTrain,
+};
+use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
+use tensor4all_tensorbackend::Matrix;
+
+pub(crate) struct ElementwiseProblem<T: AciScalar> {
+    pub(crate) inputs: Vec<TensorTrain<T>>,
+    pub(crate) solution: TensorTrain<T>,
+    pub(crate) left_frames: Vec<Vec<Option<Matrix<T>>>>,
+    pub(crate) right_frames: Vec<Vec<Option<Matrix<T>>>>,
+    pub(crate) pivot_errors: Vec<f64>,
+}
+
+impl<T: AciScalar> ElementwiseProblem<T> {
+    pub(crate) fn new(inputs: Vec<TensorTrain<T>>, options: AciOptions<T>) -> Result<Self> {
+        let solution = initial_guess(&inputs, &options)?;
+        let n = solution.len();
+        let n_inputs = inputs.len();
+        let mut left_frames = vec![vec![None; n + 1]; n_inputs];
+        let mut right_frames = vec![vec![None; n + 1]; n_inputs];
+
+        for input in 0..n_inputs {
+            left_frames[input][0] = Some(unit_frame());
+            right_frames[input][n] = Some(unit_frame());
+        }
+
+        let mut problem = Self {
+            inputs,
+            solution,
+            left_frames,
+            right_frames,
+            pivot_errors: vec![0.0; n.saturating_sub(1)],
+        };
+        problem.initialize_right_frames()?;
+        Ok(problem)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.solution.len()
+    }
+
+    pub(crate) fn n_inputs(&self) -> usize {
+        self.inputs.len()
+    }
+
+    pub(crate) fn left_frame_shape(&self, input: usize, site: usize) -> Option<(usize, usize)> {
+        self.left_frames
+            .get(input)
+            .and_then(|frames| frames.get(site))
+            .and_then(|frame| frame.as_ref())
+            .map(|frame| (frame.nrows(), frame.ncols()))
+    }
+
+    pub(crate) fn right_frame_shape(&self, input: usize, site: usize) -> Option<(usize, usize)> {
+        self.right_frames
+            .get(input)
+            .and_then(|frames| frames.get(site))
+            .and_then(|frame| frame.as_ref())
+            .map(|frame| (frame.nrows(), frame.ncols()))
+    }
+
+    pub(crate) fn update_left_frame(
+        &mut self,
+        input: usize,
+        site: usize,
+        row_indices: &[usize],
+    ) -> Result<()> {
+        let n = self.len();
+        validate_input_site(input, site, self.n_inputs(), n)?;
+        let source = self.left_frames[input][site]
+            .as_ref()
+            .ok_or_else(|| missing_frame("left", input, site))?
+            .clone();
+        let core = self.inputs[input].site_tensor(site);
+
+        if source.ncols() != core.left_dim() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "left frame/input bond mismatch at input {input}, site {site}: \
+                     frame has {} columns, core left bond is {}",
+                    source.ncols(),
+                    core.left_dim()
+                ),
+            });
+        }
+
+        let full_rows = checked_frame_mul(source.nrows(), core.site_dim(), "left frame row count")?;
+        validate_selection("row", row_indices, full_rows)?;
+
+        let mut selected = Matrix::zeros(row_indices.len(), core.right_dim());
+        for (selected_row, &full_row) in row_indices.iter().enumerate() {
+            let source_row = full_row % source.nrows();
+            let physical = full_row / source.nrows();
+            for right in 0..core.right_dim() {
+                let mut sum = T::zero();
+                for left in 0..core.left_dim() {
+                    sum = sum + source[[source_row, left]] * *core.get3(left, physical, right);
+                }
+                selected[[selected_row, right]] = sum;
+            }
+        }
+
+        self.left_frames[input][site + 1] = Some(selected);
+        Ok(())
+    }
+
+    pub(crate) fn update_right_frame(
+        &mut self,
+        input: usize,
+        site: usize,
+        col_indices: &[usize],
+    ) -> Result<()> {
+        let n = self.len();
+        validate_input_site(input, site, self.n_inputs(), n)?;
+        let source_site = site + 1;
+        let source = self.right_frames[input][source_site]
+            .as_ref()
+            .ok_or_else(|| missing_frame("right", input, source_site))?
+            .clone();
+        let core = self.inputs[input].site_tensor(site);
+
+        if core.right_dim() != source.nrows() {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "right frame/input bond mismatch at input {input}, site {site}: \
+                     core right bond is {}, frame has {} rows",
+                    core.right_dim(),
+                    source.nrows()
+                ),
+            });
+        }
+
+        let full_cols =
+            checked_frame_mul(core.site_dim(), source.ncols(), "right frame column count")?;
+        validate_selection("column", col_indices, full_cols)?;
+
+        let mut selected = Matrix::zeros(core.left_dim(), col_indices.len());
+        for left in 0..core.left_dim() {
+            for (selected_col, &full_col) in col_indices.iter().enumerate() {
+                let physical = full_col % core.site_dim();
+                let source_col = full_col / core.site_dim();
+                let mut sum = T::zero();
+                for right in 0..core.right_dim() {
+                    sum = sum + *core.get3(left, physical, right) * source[[right, source_col]];
+                }
+                selected[[left, selected_col]] = sum;
+            }
+        }
+
+        self.right_frames[input][site] = Some(selected);
+        Ok(())
+    }
+
+    pub(crate) fn update_left_frames(&mut self, site: usize, row_indices: &[usize]) -> Result<()> {
+        for input in 0..self.n_inputs() {
+            self.update_left_frame(input, site, row_indices)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn update_right_frames(&mut self, site: usize, col_indices: &[usize]) -> Result<()> {
+        for input in 0..self.n_inputs() {
+            self.update_right_frame(input, site, col_indices)?;
+        }
+        Ok(())
+    }
+
+    fn initialize_right_frames(&mut self) -> Result<()> {
+        let n = self.solution.len();
+        let mut solution_cores = self.solution.site_tensors().to_vec();
+
+        for site in (1..n).rev() {
+            let current = &solution_cores[site];
+            let site_dim = current.site_dim();
+            let right_dim = current.right_dim();
+            let matrix = right_matrix_julia_order(current);
+            let factors = matrix_luci_factors_from_matrix(
+                &matrix,
+                Some(RrLUOptions {
+                    left_orthogonal: false,
+                    rel_tol: 0.0,
+                    abs_tol: 0.0,
+                    max_rank: usize::MAX,
+                }),
+            )?;
+
+            validate_selection(
+                "column",
+                &factors.col_indices,
+                checked_frame_mul(site_dim, right_dim, "solution right matrix column count")?,
+            )?;
+            solution_cores[site] =
+                right_factor_to_tensor3(&factors.right, factors.rank, site_dim, right_dim)?;
+
+            let previous = &solution_cores[site - 1];
+            let previous_left_dim = previous.left_dim();
+            let previous_site_dim = previous.site_dim();
+            let previous_matrix = left_matrix_julia_order(previous);
+            let product = matmul_checked(&previous_matrix, &factors.left, site - 1)?;
+            solution_cores[site - 1] =
+                matrix_to_tensor3(&product, previous_left_dim, previous_site_dim, factors.rank)?;
+
+            self.update_right_frames(site, &factors.col_indices)?;
+        }
+
+        if n > 0 {
+            let current = &solution_cores[0];
+            let site_dim = current.site_dim();
+            let right_dim = current.right_dim();
+            let matrix = right_matrix_julia_order(current);
+            let factors = matrix_luci_factors_from_matrix(
+                &matrix,
+                Some(RrLUOptions {
+                    left_orthogonal: false,
+                    rel_tol: 0.0,
+                    abs_tol: 0.0,
+                    max_rank: usize::MAX,
+                }),
+            )?;
+
+            validate_selection(
+                "column",
+                &factors.col_indices,
+                checked_frame_mul(site_dim, right_dim, "solution right matrix column count")?,
+            )?;
+            let product = matmul_checked(&factors.left, &factors.right, 0)?;
+            solution_cores[0] = right_factor_to_tensor3(&product, 1, site_dim, right_dim)?;
+            self.update_right_frames(0, &factors.col_indices)?;
+        }
+
+        self.solution = TensorTrain::new(solution_cores)?;
+        Ok(())
+    }
+}
+
+fn unit_frame<T: AciScalar>() -> Matrix<T> {
+    Matrix::from_col_major_vec(1, 1, vec![T::one()])
+}
+
+fn validate_input_site(input: usize, site: usize, n_inputs: usize, n_sites: usize) -> Result<()> {
+    if input >= n_inputs {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!("input index {input} out of bounds for {n_inputs} inputs"),
+        });
+    }
+    if site >= n_sites {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!("site index {site} out of bounds for tensor train length {n_sites}"),
+        });
+    }
+    Ok(())
+}
+
+fn validate_selection(kind: &'static str, indices: &[usize], len: usize) -> Result<()> {
+    for &index in indices {
+        if index >= len {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!("{kind} index {index} out of bounds for length {len}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn checked_frame_mul(lhs: usize, rhs: usize, description: &str) -> Result<usize> {
+    lhs.checked_mul(rhs)
+        .ok_or_else(|| AciError::InvalidInitialGuess {
+            message: format!("{description} overflows usize"),
+        })
+}
+
+fn missing_frame(kind: &'static str, input: usize, site: usize) -> AciError {
+    AciError::InvalidInitialGuess {
+        message: format!("{kind} frame for input {input}, site {site} is not initialized"),
+    }
+}
+
+fn right_matrix_julia_order<T: AciScalar>(core: &Tensor3<T>) -> Matrix<T> {
+    let left_dim = core.left_dim();
+    let site_dim = core.site_dim();
+    let right_dim = core.right_dim();
+    let mut data = Vec::with_capacity(left_dim * site_dim * right_dim);
+    for right in 0..right_dim {
+        for site in 0..site_dim {
+            for left in 0..left_dim {
+                data.push(*core.get3(left, site, right));
+            }
+        }
+    }
+    Matrix::from_col_major_vec(left_dim, site_dim * right_dim, data)
+}
+
+fn left_matrix_julia_order<T: AciScalar>(core: &Tensor3<T>) -> Matrix<T> {
+    let left_dim = core.left_dim();
+    let site_dim = core.site_dim();
+    let right_dim = core.right_dim();
+    let mut data = Vec::with_capacity(left_dim * site_dim * right_dim);
+    for right in 0..right_dim {
+        for site in 0..site_dim {
+            for left in 0..left_dim {
+                data.push(*core.get3(left, site, right));
+            }
+        }
+    }
+    Matrix::from_col_major_vec(left_dim * site_dim, right_dim, data)
+}
+
+fn matrix_to_tensor3<T: AciScalar>(
+    matrix: &Matrix<T>,
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+) -> Result<Tensor3<T>> {
+    if matrix.nrows() != left_dim * site_dim || matrix.ncols() != right_dim {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot reshape matrix of shape ({}, {}) to tensor core ({left_dim}, \
+                 {site_dim}, {right_dim})",
+                matrix.nrows(),
+                matrix.ncols()
+            ),
+        });
+    }
+    Ok(tensor3_from_data(
+        matrix.as_col_major_slice().to_vec(),
+        left_dim,
+        site_dim,
+        right_dim,
+    )?)
+}
+
+fn right_factor_to_tensor3<T: AciScalar>(
+    matrix: &Matrix<T>,
+    left_dim: usize,
+    site_dim: usize,
+    right_dim: usize,
+) -> Result<Tensor3<T>> {
+    if matrix.nrows() != left_dim || matrix.ncols() != site_dim * right_dim {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot reshape right factor of shape ({}, {}) to tensor core ({left_dim}, \
+                 {site_dim}, {right_dim})",
+                matrix.nrows(),
+                matrix.ncols()
+            ),
+        });
+    }
+    Ok(tensor3_from_data(
+        matrix.as_col_major_slice().to_vec(),
+        left_dim,
+        site_dim,
+        right_dim,
+    )?)
+}
+
+fn matmul_checked<T: AciScalar>(
+    left: &Matrix<T>,
+    right: &Matrix<T>,
+    site: usize,
+) -> Result<Matrix<T>> {
+    if left.ncols() != right.nrows() {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "solution core update at site {site} has incompatible matrix shapes: \
+                 left ({}, {}), right ({}, {})",
+                left.nrows(),
+                left.ncols(),
+                right.nrows(),
+                right.ncols()
+            ),
+        });
+    }
+
+    let mut product = Matrix::zeros(left.nrows(), right.ncols());
+    for row in 0..left.nrows() {
+        for col in 0..right.ncols() {
+            let mut sum = T::zero();
+            for k in 0..left.ncols() {
+                sum = sum + left[[row, k]] * right[[k, col]];
+            }
+            product[[row, col]] = sum;
+        }
+    }
+    Ok(product)
+}

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{AciOptions, ElementwiseBatch};
+use crate::{AciError, AciOptions, ElementwiseBatch};
 
 #[test]
 fn default_options_are_conservative() {
@@ -28,4 +28,65 @@ fn elementwise_batch_uses_column_major_input_point_layout() {
 fn elementwise_batch_rejects_bad_length() {
     let err = ElementwiseBatch::<f64>::new(&[1.0, 2.0, 3.0], 2, 2).unwrap_err();
     assert!(err.to_string().contains("length"));
+}
+
+#[test]
+fn elementwise_batch_rejects_zero_inputs() {
+    let err = ElementwiseBatch::<f64>::new(&[], 0, 1).unwrap_err();
+    assert!(matches!(err, AciError::EmptyInputs));
+    assert!(err.to_string().contains("at least one input"));
+}
+
+#[test]
+fn elementwise_batch_rejects_zero_points() {
+    let err = ElementwiseBatch::<f64>::new(&[], 1, 0).unwrap_err();
+    assert!(matches!(err, AciError::EmptyInputs));
+    assert!(err.to_string().contains("interpolation point"));
+}
+
+#[test]
+fn elementwise_batch_rejects_shape_overflow() {
+    let err = ElementwiseBatch::<f64>::new(&[], usize::MAX, 2).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("overflows usize"));
+}
+
+#[test]
+fn elementwise_batch_rejects_out_of_range_input_index() {
+    let values = [10.0, 20.0, 11.0, 21.0];
+    let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+
+    let err = batch.get(2, 0).unwrap_err();
+    assert!(matches!(
+        err,
+        AciError::BatchIndexOutOfBounds {
+            axis: "input",
+            index: 2,
+            len: 2,
+        }
+    ));
+    let message = err.to_string();
+    assert!(message.contains("input index"));
+    assert!(message.contains("out of bounds"));
+    assert!(message.contains("len 2"));
+}
+
+#[test]
+fn elementwise_batch_rejects_out_of_range_point_index() {
+    let values = [10.0, 20.0, 11.0, 21.0];
+    let batch = ElementwiseBatch::new(&values, 2, 2).unwrap();
+
+    let err = batch.get(0, 2).unwrap_err();
+    assert!(matches!(
+        err,
+        AciError::BatchIndexOutOfBounds {
+            axis: "point",
+            index: 2,
+            len: 2,
+        }
+    ));
+    let message = err.to_string();
+    assert!(message.contains("point index"));
+    assert!(message.contains("out of bounds"));
+    assert!(message.contains("len 2"));
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -739,11 +739,11 @@ fn local_input_factors_match_explicit_two_site_contraction_for_all_inputs() {
     let factors = crate::local::local_input_factors_for_problem(&problem, 1).unwrap();
 
     assert_eq!(factors.len(), problem.n_inputs());
-    for input in 0..problem.n_inputs() {
+    for (input, factors) in factors.iter().enumerate().take(problem.n_inputs()) {
         let (nrows, ncols) = problem.local_input_shape(input, 1).unwrap();
         for row in 0..nrows {
             for col in 0..ncols {
-                let actual = factors[input].value(row, col).unwrap();
+                let actual = factors.value(row, col).unwrap();
                 let expected = explicit_local_value(&problem, input, 1, row, col);
                 assert_eq!(actual, expected);
             }
@@ -1681,7 +1681,7 @@ fn duration_ms(duration: Duration) -> f64 {
 fn median_ms(mut values: Vec<f64>) -> f64 {
     values.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let mid = values.len() / 2;
-    if values.len() % 2 == 0 {
+    if values.len().is_multiple_of(2) {
         0.5 * (values[mid - 1] + values[mid])
     } else {
         values[mid]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,10 +1,13 @@
 use crate::validation::{validate_inputs, validate_options};
 use crate::{
     initial_guess,
-    random_tt::{initial_guess_core_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES},
+    random_tt::{
+        initial_guess_core_entry_count, initial_guess_total_entry_count,
+        MAX_INITIAL_GUESS_CORE_ENTRIES,
+    },
     AciError, AciOptions, ElementwiseBatch,
 };
-use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops, TensorTrain};
 
 #[test]
 fn default_options_are_conservative() {
@@ -104,6 +107,14 @@ fn validate_inputs_rejects_empty_inputs() {
 }
 
 #[test]
+fn validate_inputs_rejects_zero_site_tensor_train() {
+    let input = TensorTrain::<f64>::new(vec![]).unwrap();
+    let err = validate_inputs(&[input]).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("at least one site"));
+}
+
+#[test]
 fn validate_inputs_rejects_length_mismatch() {
     let a = TensorTrain::<f64>::constant(&[2, 2], 1.0);
     let b = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
@@ -128,6 +139,17 @@ fn validate_options_rejects_zero_max_iters() {
     let err = validate_options(&options).unwrap_err();
     assert!(matches!(err, AciError::InvalidOptions { .. }));
     assert!(err.to_string().contains("max_iters"));
+}
+
+#[test]
+fn validate_options_rejects_zero_max_bond_dim() {
+    let options = AciOptions::<f64> {
+        max_bond_dim: 0,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("max_bond_dim"));
 }
 
 #[test]
@@ -184,8 +206,70 @@ fn default_initial_guess_matches_input_site_dims() {
 }
 
 #[test]
+fn initial_guess_is_deterministic_for_same_seed() {
+    let a = TensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 3, 2], 2.0);
+    let options = AciOptions::<f64> {
+        max_bond_dim: 2,
+        rng_seed: 1234,
+        ..AciOptions::default()
+    };
+
+    let guess_a = initial_guess(&[a.clone(), b.clone()], &options).unwrap();
+    let guess_b = initial_guess(&[a, b], &options).unwrap();
+
+    for indices in [[0, 0, 0], [1, 2, 1], [0, 1, 1]] {
+        assert_eq!(
+            guess_a.evaluate(&indices).unwrap(),
+            guess_b.evaluate(&indices).unwrap()
+        );
+    }
+}
+
+#[test]
+fn initial_guess_accepts_compatible_explicit_guess() {
+    let input = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+    let explicit = TensorTrain::<f64>::constant(&[2, 3], 7.0);
+    let options = AciOptions {
+        initial_guess: Some(explicit),
+        ..AciOptions::default()
+    };
+
+    let guess = initial_guess(&[input], &options).unwrap();
+
+    assert_eq!(guess.site_dims(), vec![2, 3]);
+    assert_eq!(guess.site_tensor(0).site_dim(), 2);
+    assert_eq!(guess.site_tensor(1).site_dim(), 3);
+    assert!((guess.evaluate(&[0, 0]).unwrap() - 7.0).abs() < 1e-12);
+    assert!((guess.evaluate(&[1, 2]).unwrap() - 7.0).abs() < 1e-12);
+}
+
+#[test]
+fn initial_guess_rejects_incompatible_explicit_guess_site_dims() {
+    let input = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+    let explicit = TensorTrain::<f64>::constant(&[2, 4], 7.0);
+    let options = AciOptions {
+        initial_guess: Some(explicit),
+        ..AciOptions::default()
+    };
+
+    let err = initial_guess(&[input], &options).unwrap_err();
+
+    assert!(matches!(err, AciError::InvalidInitialGuess { .. }));
+    assert!(err.to_string().contains("site dimensions"));
+}
+
+#[test]
 fn initial_guess_rejects_huge_non_overflowing_core_size() {
     let err = initial_guess_core_entry_count(MAX_INITIAL_GUESS_CORE_ENTRIES + 1, 1, 1).unwrap_err();
     assert!(matches!(err, AciError::InvalidOptions { .. }));
     assert!(err.to_string().contains("initial guess core size"));
+}
+
+#[test]
+fn initial_guess_rejects_oversized_total_entries() {
+    let err = initial_guess_total_entry_count(&[(MAX_INITIAL_GUESS_CORE_ENTRIES, 1, 1), (1, 1, 1)])
+        .unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("initial guess total size"));
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::validation::{validate_inputs, validate_options};
 use crate::{
-    initial_guess,
+    elementwise, elementwise_batched, initial_guess,
     random_tt::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
         initial_guess_total_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES,
@@ -141,6 +141,83 @@ fn assert_solution_is_zero_on_binary_three_site_grid(problem: &ElementwiseProble
     ] {
         assert_eq!(problem.solution.evaluate(&indices).unwrap(), 0.0);
     }
+}
+
+#[test]
+fn elementwise_multiplies_constant_tensor_trains() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 3, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 3, 2], 4.0);
+
+    let result = elementwise(
+        |values| values[0] * values[1],
+        &[input_a, input_b],
+        &AciOptions::default(),
+    )
+    .unwrap();
+
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..2 {
+                let value = result.tensor_train.evaluate(&[i, j, k]).unwrap();
+                assert!((value - 8.0).abs() < 1e-12);
+            }
+        }
+    }
+}
+
+#[test]
+fn scalar_and_batched_paths_match() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2], 5.0);
+    let inputs = [input_a, input_b];
+    let options = AciOptions::default();
+
+    let scalar_result = elementwise(|values| values[0] + values[1], &inputs, &options).unwrap();
+    let batched_result = elementwise_batched(
+        |batch, output| {
+            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+                *value = batch.get(0, point)? + batch.get(1, point)?;
+            }
+            Ok(())
+        },
+        &inputs,
+        &options,
+    )
+    .unwrap();
+
+    for i in 0..2 {
+        for j in 0..2 {
+            let scalar_value = scalar_result.tensor_train.evaluate(&[i, j]).unwrap();
+            let batched_value = batched_result.tensor_train.evaluate(&[i, j]).unwrap();
+            assert!((scalar_value - batched_value).abs() < 1e-12);
+            assert!((scalar_value - 7.0).abs() < 1e-12);
+        }
+    }
+}
+
+#[test]
+fn elementwise_batched_propagates_operator_error() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2], 4.0);
+    let options = AciOptions {
+        max_iters: 1,
+        min_iters: 1,
+        ..AciOptions::default()
+    };
+
+    let err = elementwise_batched(
+        |_batch, _output| {
+            Err(AciError::Operator {
+                message: "public operator failed".to_string(),
+            })
+        },
+        &[input_a, input_b],
+        &options,
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, AciError::Operator { .. }));
+    assert!(err.to_string().contains("public operator failed"));
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,0 +1,31 @@
+use crate::{AciOptions, ElementwiseBatch};
+
+#[test]
+fn default_options_are_conservative() {
+    let options = AciOptions::<f64>::default();
+    assert_eq!(options.max_iters, 20);
+    assert_eq!(options.min_iters, 2);
+    assert_eq!(options.max_bond_dim, usize::MAX);
+    assert!((options.tolerance - 1e-12).abs() < 1e-15);
+    assert!(!options.scale_tolerance);
+    assert!(options.initial_guess.is_none());
+}
+
+#[test]
+fn elementwise_batch_uses_column_major_input_point_layout() {
+    let values = vec![10.0, 20.0, 11.0, 21.0, 12.0, 22.0];
+    let batch = ElementwiseBatch::new(&values, 2, 3).unwrap();
+    assert_eq!(batch.n_inputs(), 2);
+    assert_eq!(batch.n_points(), 3);
+    assert_eq!(batch.get(0, 0).unwrap(), 10.0);
+    assert_eq!(batch.get(1, 0).unwrap(), 20.0);
+    assert_eq!(batch.get(0, 2).unwrap(), 12.0);
+    assert_eq!(batch.get(1, 2).unwrap(), 22.0);
+    assert_eq!(batch.as_col_major_slice(), values.as_slice());
+}
+
+#[test]
+fn elementwise_batch_rejects_bad_length() {
+    let err = ElementwiseBatch::<f64>::new(&[1.0, 2.0, 3.0], 2, 2).unwrap_err();
+    assert!(err.to_string().contains("length"));
+}

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::validation::{validate_inputs, validate_options};
 use crate::{
     elementwise,
-    elementwise::error_metric,
+    elementwise::{error_metric, max_error_metric},
     elementwise_batched, initial_guess,
     random_tt::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
@@ -304,6 +304,15 @@ fn relative_error_metric_normalizes_by_sampled_scale() {
     assert_eq!(error_metric(2.0, 100.0, true), 0.02);
     assert_eq!(error_metric(2.0, 100.0, false), 2.0);
     assert_eq!(error_metric(2.0, 0.0, true), 2.0);
+}
+
+#[test]
+fn relative_error_metric_pairs_each_bond_with_its_scale() {
+    let errors = [1.0, 10.0];
+    let scales = [1.0, 10_000.0];
+
+    assert_eq!(max_error_metric(&errors, &scales, true), 1.0);
+    assert_eq!(max_error_metric(&errors, &scales, false), 10.0);
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -5,12 +5,13 @@ use crate::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
         initial_guess_total_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES,
     },
-    AciError, AciOptions, ElementwiseBatch, ElementwiseProblem,
+    AciError, AciOptions, ElementwiseBatch, ElementwiseProblem, LocalBlockEvaluator,
 };
 use num_complex::Complex64;
 use tensor4all_simplett::{
     tensor3_from_data, tensor3_zeros, AbstractTensorTrain, Tensor3Ops, TensorTrain,
 };
+use tensor4all_tensorbackend::Matrix;
 
 fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> TensorTrain<f64> {
     assert_eq!(link_dims.len(), site_dims.len().saturating_sub(1));
@@ -24,6 +25,93 @@ fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> Tens
         })
         .collect();
     TensorTrain::new(cores).unwrap()
+}
+
+fn local_test_problem() -> ElementwiseProblem<f64> {
+    let input_a = TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, 2.0, 10.0, 20.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(
+            vec![
+                1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0, 100.0, 200.0, 300.0, 400.0,
+            ],
+            2,
+            2,
+            3,
+        )
+        .unwrap(),
+        tensor3_from_data(
+            vec![
+                5.0, 6.0, 7.0, 50.0, 60.0, 70.0, 500.0, 600.0, 700.0, 8.0, 9.0, 10.0,
+            ],
+            3,
+            2,
+            2,
+        )
+        .unwrap(),
+        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let input_b = TensorTrain::new(vec![
+        tensor3_from_data(vec![2.0, 3.0, 20.0, 30.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(
+            vec![
+                2.0, 3.0, 4.0, 5.0, 20.0, 30.0, 40.0, 50.0, 200.0, 300.0, 400.0, 500.0,
+            ],
+            2,
+            2,
+            3,
+        )
+        .unwrap(),
+        tensor3_from_data(
+            vec![
+                6.0, 7.0, 8.0, 60.0, 70.0, 80.0, 600.0, 700.0, 800.0, 9.0, 10.0, 11.0,
+            ],
+            3,
+            2,
+            2,
+        )
+        .unwrap(),
+        tensor3_from_data(vec![2.0, 3.0, 4.0, 5.0], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let mut problem =
+        ElementwiseProblem::new(vec![input_a, input_b], AciOptions::default()).unwrap();
+    for input in 0..problem.n_inputs() {
+        problem.left_frames[input][1] =
+            Some(Matrix::from_col_major_vec(2, 2, vec![1.0, 2.0, 10.0, 20.0]));
+        problem.right_frames[input][3] =
+            Some(Matrix::from_col_major_vec(2, 2, vec![3.0, 4.0, 30.0, 40.0]));
+    }
+    problem
+}
+
+fn explicit_local_value(
+    problem: &ElementwiseProblem<f64>,
+    input: usize,
+    bond: usize,
+    row: usize,
+    col: usize,
+) -> f64 {
+    let left_frame = problem.left_frames[input][bond].as_ref().unwrap();
+    let right_frame = problem.right_frames[input][bond + 2].as_ref().unwrap();
+    let left_core = problem.inputs[input].site_tensor(bond);
+    let right_core = problem.inputs[input].site_tensor(bond + 1);
+    let left_pivot = row % left_frame.nrows();
+    let site_left = row / left_frame.nrows();
+    let site_right = col % right_core.site_dim();
+    let right_pivot = col / right_core.site_dim();
+    let mut sum = 0.0;
+    for a in 0..left_core.left_dim() {
+        for m in 0..left_core.right_dim() {
+            for b in 0..right_core.right_dim() {
+                sum += left_frame[[left_pivot, a]]
+                    * *left_core.get3(a, site_left, m)
+                    * *right_core.get3(m, site_right, b)
+                    * right_frame[[b, right_pivot]];
+            }
+        }
+    }
+    sum
 }
 
 #[test]
@@ -268,6 +356,150 @@ fn elementwise_problem_rejects_invalid_frame_selection_indices() {
     let right_err = problem.update_right_frame(0, 2, &[2]).unwrap_err();
     assert!(matches!(right_err, AciError::InvalidInitialGuess { .. }));
     assert!(right_err.to_string().contains("column index"));
+}
+
+#[test]
+fn local_input_value_matches_explicit_two_site_contraction() {
+    let problem = local_test_problem();
+
+    let value = problem.local_input_value(0, 1, 3, 2).unwrap();
+    let expected = explicit_local_value(&problem, 0, 1, 3, 2);
+
+    assert_eq!(value, expected);
+    assert_eq!(value, 265_133_700.0);
+}
+
+#[test]
+fn local_block_evaluator_uses_matrix_luci_point_order_and_batch_layout() {
+    let problem = local_test_problem();
+    let evaluator = LocalBlockEvaluator::new(&problem, 1).unwrap();
+    let rows = [0, 3];
+    let cols = [1, 2];
+    let mut out = vec![0.0; rows.len() * cols.len()];
+    let observed_batches = std::cell::RefCell::new(Vec::new());
+
+    evaluator
+        .fill_local_block(&rows, &cols, &mut out, |batch, output| {
+            assert_eq!(batch.n_inputs(), problem.n_inputs());
+            assert_eq!(batch.n_points(), rows.len() * cols.len());
+            observed_batches
+                .borrow_mut()
+                .push(batch.as_col_major_slice().to_vec());
+            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+                *value = batch.get(0, point).unwrap() + 10.0 * batch.get(1, point).unwrap();
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    let mut expected_values = Vec::new();
+    for &col in &cols {
+        for &row in &rows {
+            for input in 0..problem.n_inputs() {
+                expected_values.push(problem.local_input_value(input, 1, row, col).unwrap());
+            }
+        }
+    }
+    assert_eq!(observed_batches.into_inner(), vec![expected_values]);
+
+    let mut expected_out = Vec::new();
+    for &col in &cols {
+        for &row in &rows {
+            expected_out.push(
+                problem.local_input_value(0, 1, row, col).unwrap()
+                    + 10.0 * problem.local_input_value(1, 1, row, col).unwrap(),
+            );
+        }
+    }
+    assert_eq!(out, expected_out);
+}
+
+#[test]
+fn local_block_evaluator_serves_duplicate_entries_from_cache() {
+    let problem = local_test_problem();
+    let evaluator = LocalBlockEvaluator::new(&problem, 1).unwrap();
+    let rows = [0, 0, 1];
+    let cols = [0];
+    let mut first = vec![0.0; rows.len() * cols.len()];
+    let mut second = vec![0.0; rows.len() * cols.len()];
+    let observed_points = std::cell::RefCell::new(Vec::new());
+
+    let operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        observed_points.borrow_mut().push(batch.n_points());
+        for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+            *value = batch.get(0, point).unwrap() + batch.get(1, point).unwrap();
+        }
+        Ok(())
+    };
+
+    evaluator
+        .fill_local_block(&rows, &cols, &mut first, operator)
+        .unwrap();
+    evaluator
+        .fill_local_block(&rows, &cols, &mut second, operator)
+        .unwrap();
+
+    assert_eq!(observed_points.into_inner(), vec![2]);
+    assert_eq!(first[0], first[1]);
+    assert_eq!(first, second);
+}
+
+#[test]
+fn local_block_evaluator_cache_can_be_cleared() {
+    let problem = local_test_problem();
+    let evaluator = LocalBlockEvaluator::new(&problem, 1).unwrap();
+    let rows = [0];
+    let cols = [0];
+    let mut out = vec![0.0];
+    let observed_points = std::cell::RefCell::new(Vec::new());
+
+    let operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        observed_points.borrow_mut().push(batch.n_points());
+        output[0] = batch.get(0, 0).unwrap();
+        Ok(())
+    };
+
+    evaluator
+        .fill_local_block(&rows, &cols, &mut out, operator)
+        .unwrap();
+    evaluator.clear_cache();
+    evaluator
+        .fill_local_block(&rows, &cols, &mut out, operator)
+        .unwrap();
+
+    assert_eq!(observed_points.into_inner(), vec![1, 1]);
+}
+
+#[test]
+fn local_input_value_rejects_out_of_range_indices() {
+    let problem = local_test_problem();
+
+    let input_err = problem.local_input_value(2, 1, 0, 0).unwrap_err();
+    assert!(matches!(input_err, AciError::InvalidInitialGuess { .. }));
+    assert!(input_err.to_string().contains("input index"));
+
+    let bond_err = problem.local_input_value(0, 3, 0, 0).unwrap_err();
+    assert!(matches!(bond_err, AciError::InvalidInitialGuess { .. }));
+    assert!(bond_err.to_string().contains("bond index"));
+
+    let row_err = problem.local_input_value(0, 1, 4, 0).unwrap_err();
+    assert!(matches!(row_err, AciError::InvalidInitialGuess { .. }));
+    assert!(row_err.to_string().contains("row index"));
+
+    let col_err = problem.local_input_value(0, 1, 0, 4).unwrap_err();
+    assert!(matches!(col_err, AciError::InvalidInitialGuess { .. }));
+    assert!(col_err.to_string().contains("column index"));
+}
+
+#[test]
+fn local_input_value_rejects_missing_frames() {
+    let input = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+
+    let err = problem.local_input_value(0, 1, 0, 0).unwrap_err();
+
+    assert!(matches!(err, AciError::InvalidInitialGuess { .. }));
+    assert!(err.to_string().contains("left frame"));
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -752,6 +752,27 @@ fn validate_inputs_rejects_zero_physical_dim_in_later_input() {
 }
 
 #[test]
+fn validate_inputs_rejects_zero_internal_bond_dim_in_first_input() {
+    let input = tensor_train_with_link_dims(&[2, 3], &[0]);
+    let err = validate_inputs(&[input]).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    let message = err.to_string();
+    assert!(message.contains("bond dimension"));
+    assert!(message.contains("positive"));
+}
+
+#[test]
+fn validate_inputs_rejects_zero_internal_bond_dim_in_later_input() {
+    let first = tensor_train_with_link_dims(&[2, 3], &[1]);
+    let later = tensor_train_with_link_dims(&[2, 3], &[0]);
+    let err = validate_inputs(&[first, later]).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    let message = err.to_string();
+    assert!(message.contains("bond dimension"));
+    assert!(message.contains("positive"));
+}
+
+#[test]
 fn validate_inputs_rejects_length_mismatch() {
     let a = TensorTrain::<f64>::constant(&[2, 2], 1.0);
     let b = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,7 +1,8 @@
+use crate::local::LocalInputSetupTiming;
 use crate::validation::{validate_inputs, validate_options};
 use crate::{
     elementwise,
-    elementwise::{error_metric, max_error_metric},
+    elementwise::{error_metric, max_error_metric, ranks_are_stable},
     elementwise_batched, initial_guess,
     random_tt::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
@@ -10,9 +11,12 @@ use crate::{
     AciError, AciOptions, ElementwiseBatch, ElementwiseProblem, LocalBlockEvaluator,
 };
 use num_complex::Complex64;
+use std::cell::RefCell;
+use std::time::{Duration, Instant};
 use tensor4all_simplett::{
     tensor3_from_data, tensor3_zeros, AbstractTensorTrain, Tensor3Ops, TensorTrain,
 };
+use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
 use tensor4all_tensorbackend::Matrix;
 
 fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> TensorTrain<f64> {
@@ -314,6 +318,14 @@ fn relative_error_metric_pairs_each_bond_with_its_scale() {
     assert_eq!(max_error_metric(&errors, &scales, true), 1.0);
     assert_eq!(max_error_metric(&errors, &scales, false), 10.0);
     assert_eq!(max_error_metric(&errors, &[], true), 10.0);
+}
+
+#[test]
+fn rank_stability_matches_julia_min_iter_window() {
+    assert!(ranks_are_stable(&[10, 12, 12], 2));
+    assert!(!ranks_are_stable(&[10, 12, 13], 2));
+    assert!(!ranks_are_stable(&[10, 12], 2));
+    assert!(ranks_are_stable(&[10, 10], 2));
 }
 
 #[test]
@@ -687,6 +699,29 @@ fn local_input_value_matches_explicit_two_site_contraction() {
 }
 
 #[test]
+fn local_input_factors_match_explicit_two_site_contraction_for_all_inputs() {
+    let problem = local_test_problem();
+    let factors = crate::local::local_input_factors_for_problem(&problem, 1).unwrap();
+
+    assert_eq!(factors.len(), problem.n_inputs());
+    for input in 0..problem.n_inputs() {
+        let (nrows, ncols) = problem.local_input_shape(input, 1).unwrap();
+        for row in 0..nrows {
+            for col in 0..ncols {
+                let actual = factors[input].value(row, col).unwrap();
+                let expected = explicit_local_value(&problem, input, 1, row, col);
+                assert_eq!(actual, expected);
+            }
+        }
+    }
+
+    assert_ne!(
+        factors[0].value(3, 2).unwrap(),
+        factors[1].value(3, 2).unwrap()
+    );
+}
+
+#[test]
 fn local_block_evaluator_uses_matrix_luci_point_order_and_batch_layout() {
     let problem = local_test_problem();
     let rows = [0, 3];
@@ -729,6 +764,30 @@ fn local_block_evaluator_uses_matrix_luci_point_order_and_batch_layout() {
         }
     }
     assert_eq!(out, expected_out);
+}
+
+#[test]
+fn local_block_evaluator_materializes_full_matrix_in_column_major_order() {
+    let problem = local_test_problem();
+    let operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+            *value = batch.get(0, point).unwrap() + 10.0 * batch.get(1, point).unwrap();
+        }
+        Ok(())
+    };
+    let evaluator = LocalBlockEvaluator::new(&problem, 1, &operator).unwrap();
+    let matrix = evaluator.materialize_local_matrix().unwrap();
+    let rows = (0..evaluator.nrows()).collect::<Vec<_>>();
+    let cols = (0..evaluator.ncols()).collect::<Vec<_>>();
+    let mut expected = vec![0.0; rows.len() * cols.len()];
+
+    evaluator
+        .fill_local_block(&rows, &cols, &mut expected)
+        .unwrap();
+
+    assert_eq!(matrix.nrows(), evaluator.nrows());
+    assert_eq!(matrix.ncols(), evaluator.ncols());
+    assert_eq!(matrix.as_col_major_slice(), expected);
 }
 
 #[test]
@@ -1235,4 +1294,374 @@ fn initial_guess_rejects_oversized_total_entries() {
         .unwrap_err();
     assert!(matches!(err, AciError::InvalidOptions { .. }));
     assert!(err.to_string().contains("initial guess total size"));
+}
+
+const STEP_TIMING_N_SITES: usize = 12;
+const STEP_TIMING_LOCAL_DIM: usize = 2;
+const STEP_TIMING_N_INPUTS: usize = 2;
+const STEP_TIMING_TOLERANCE: f64 = 1e-10;
+
+#[derive(Clone, Copy, Default)]
+struct LocalStepTiming {
+    setup: Duration,
+    setup_shape_validation: Duration,
+    setup_dims: Duration,
+    setup_left_factor: Duration,
+    setup_right_factor: Duration,
+    input_values: Duration,
+    operator: Duration,
+    matrix_luci: Duration,
+    core_update: Duration,
+    frame_update: Duration,
+    updates: usize,
+    sweeps: usize,
+    final_rank: usize,
+    final_error: f64,
+}
+
+impl LocalStepTiming {
+    fn total(self) -> Duration {
+        self.setup
+            + self.input_values
+            + self.operator
+            + self.matrix_luci
+            + self.core_update
+            + self.frame_update
+    }
+
+    fn setup_other(self) -> Duration {
+        self.setup
+            .checked_sub(
+                self.setup_shape_validation
+                    + self.setup_dims
+                    + self.setup_left_factor
+                    + self.setup_right_factor,
+            )
+            .unwrap_or_default()
+    }
+}
+
+fn step_timing_link_dims(n_sites: usize, local_dim: usize, chi: usize) -> Vec<usize> {
+    (0..n_sites.saturating_sub(1))
+        .map(|bond| {
+            let left_sites = bond + 1;
+            let right_sites = n_sites - left_sites;
+            let max_exact_rank = local_dim.pow(left_sites.min(right_sites) as u32);
+            chi.min(max_exact_rank).max(1)
+        })
+        .collect()
+}
+
+fn step_timing_core_value(
+    input_index: usize,
+    site: usize,
+    physical: usize,
+    left: usize,
+    right: usize,
+    left_dim: usize,
+    right_dim: usize,
+) -> f64 {
+    let input = input_index as f64 + 1.0;
+    let site = site as f64 + 1.0;
+    let physical = physical as f64 + 1.0;
+    let left = left as f64 + 1.0;
+    let right = right as f64 + 1.0;
+    let left_coord = left / (left_dim as f64 + 1.0);
+    let right_coord = right / (right_dim as f64 + 1.0);
+    let phase = 0.173 * input * site
+        + 0.193 * physical
+        + 0.071 * left * right
+        + 0.109 * input * left
+        + 0.131 * site * right;
+    let bond_mix = 0.29 * phase.sin()
+        + 0.23 * (0.157 * input * physical * right + 0.211 * site * left).cos()
+        + 0.17 * (left_coord - right_coord) * physical;
+    let site_value = 0.31 + bond_mix;
+    let scale = ((left_dim * right_dim) as f64).powf(0.25);
+    site_value / scale
+}
+
+fn step_timing_deterministic_tt(input_index: usize, chi: usize) -> TensorTrain<f64> {
+    let links = step_timing_link_dims(STEP_TIMING_N_SITES, STEP_TIMING_LOCAL_DIM, chi);
+    let cores = (0..STEP_TIMING_N_SITES)
+        .map(|site| {
+            let left_dim = if site == 0 { 1 } else { links[site - 1] };
+            let right_dim = links.get(site).copied().unwrap_or(1);
+            let mut data = vec![0.0; left_dim * STEP_TIMING_LOCAL_DIM * right_dim];
+            for right in 0..right_dim {
+                for physical in 0..STEP_TIMING_LOCAL_DIM {
+                    for left in 0..left_dim {
+                        data[left + left_dim * (physical + STEP_TIMING_LOCAL_DIM * right)] =
+                            step_timing_core_value(
+                                input_index,
+                                site,
+                                physical,
+                                left,
+                                right,
+                                left_dim,
+                                right_dim,
+                            );
+                    }
+                }
+            }
+            tensor3_from_data(data, left_dim, STEP_TIMING_LOCAL_DIM, right_dim)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    TensorTrain::new(cores).unwrap()
+}
+
+fn step_timing_inputs(chi: usize) -> Vec<TensorTrain<f64>> {
+    (0..STEP_TIMING_N_INPUTS)
+        .map(|input| step_timing_deterministic_tt(input, chi))
+        .collect()
+}
+
+fn step_timing_multiply_batch(
+    batch: ElementwiseBatch<'_, f64>,
+    output: &mut [f64],
+) -> crate::Result<()> {
+    for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+        let mut product = 1.0;
+        for input in 0..batch.n_inputs() {
+            product *= batch.get(input, point)?;
+        }
+        *value = product;
+    }
+    Ok(())
+}
+
+fn timed_local_update<F>(
+    problem: &mut ElementwiseProblem<f64>,
+    bond: usize,
+    left_orthogonal: bool,
+    options: &AciOptions<f64>,
+    op: &mut F,
+    timing: &mut LocalStepTiming,
+) -> crate::Result<()>
+where
+    F: for<'batch> FnMut(ElementwiseBatch<'batch, f64>, &mut [f64]) -> crate::Result<()>,
+{
+    let left_core = problem.solution.site_tensor(bond);
+    let right_core = problem.solution.site_tensor(bond + 1);
+    let left_solution_rank = left_core.left_dim();
+    let site_dim_left = left_core.site_dim();
+    let site_dim_right = right_core.site_dim();
+    let right_solution_rank = right_core.right_dim();
+
+    let (factors, sampled_scale) = {
+        let op_cell = RefCell::new(op);
+        let operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+            let mut op_ref = op_cell.borrow_mut();
+            (*op_ref)(batch, output)
+        };
+
+        let start = Instant::now();
+        let mut setup_timing = LocalInputSetupTiming::default();
+        let evaluator = LocalBlockEvaluator::new_with_setup_timing(
+            problem,
+            bond,
+            &operator,
+            &mut setup_timing,
+        )?;
+        timing.setup += start.elapsed();
+        timing.setup_shape_validation += setup_timing.shape_validation;
+        timing.setup_dims += setup_timing.dims;
+        timing.setup_left_factor += setup_timing.left_factor;
+        timing.setup_right_factor += setup_timing.right_factor;
+
+        let start = Instant::now();
+        let input_values = evaluator.materialize_input_values()?;
+        timing.input_values += start.elapsed();
+
+        let start = Instant::now();
+        let local_matrix = evaluator.apply_operator_to_input_values(&input_values)?;
+        timing.operator += start.elapsed();
+        let sampled_scale = evaluator.max_output_abs();
+
+        let start = Instant::now();
+        let factors = matrix_luci_factors_from_matrix(
+            &local_matrix,
+            Some(RrLUOptions {
+                max_rank: options.max_bond_dim,
+                rel_tol: if options.scale_tolerance {
+                    options.tolerance
+                } else {
+                    0.0
+                },
+                abs_tol: if options.scale_tolerance {
+                    0.0
+                } else {
+                    options.tolerance
+                },
+                left_orthogonal,
+            }),
+        )?;
+        timing.matrix_luci += start.elapsed();
+        (factors, sampled_scale)
+    };
+
+    let pivot_error = factors.pivot_errors.last().copied().unwrap_or(0.0);
+    let new_rank = factors.rank.max(1);
+    let left_factor = if factors.rank == 0 {
+        Matrix::zeros(left_solution_rank * site_dim_left, 1)
+    } else {
+        factors.left
+    };
+    let right_factor = if factors.rank == 0 {
+        Matrix::zeros(1, site_dim_right * right_solution_rank)
+    } else {
+        factors.right
+    };
+    let row_indices = if factors.rank == 0 {
+        vec![0]
+    } else {
+        factors.row_indices
+    };
+    let col_indices = if factors.rank == 0 {
+        vec![0]
+    } else {
+        factors.col_indices
+    };
+
+    let start = Instant::now();
+    let mut solution_cores = problem.solution.site_tensors().to_vec();
+    solution_cores[bond] =
+        crate::state::matrix_to_tensor3(&left_factor, left_solution_rank, site_dim_left, new_rank)?;
+    solution_cores[bond + 1] = crate::state::right_factor_to_tensor3(
+        &right_factor,
+        new_rank,
+        site_dim_right,
+        right_solution_rank,
+    )?;
+    problem.solution = TensorTrain::new(solution_cores)?;
+    timing.core_update += start.elapsed();
+
+    let start = Instant::now();
+    if left_orthogonal {
+        problem.update_left_frames(bond, &row_indices)?;
+    } else {
+        problem.update_right_frames(bond + 1, &col_indices)?;
+    }
+    problem.pivot_errors[bond] = pivot_error;
+    problem.pivot_scales[bond] = sampled_scale;
+    timing.frame_update += start.elapsed();
+    timing.updates += 1;
+    Ok(())
+}
+
+fn timed_aci_run(chi: usize) -> LocalStepTiming {
+    let inputs = step_timing_inputs(chi);
+    let options = AciOptions {
+        max_iters: 20,
+        tolerance: STEP_TIMING_TOLERANCE,
+        initial_guess: Some(step_timing_deterministic_tt(STEP_TIMING_N_INPUTS, chi)),
+        ..AciOptions::default()
+    };
+    let mut problem = ElementwiseProblem::new(inputs, options.clone()).unwrap();
+    let mut timing = LocalStepTiming::default();
+    let mut op = step_timing_multiply_batch;
+    let mut ranks = Vec::new();
+
+    for iteration in 0..options.max_iters {
+        let forward = iteration % 2 == 0;
+        if forward {
+            for bond in 0..problem.len() - 1 {
+                timed_local_update(&mut problem, bond, true, &options, &mut op, &mut timing)
+                    .unwrap();
+            }
+        } else {
+            for bond in (0..problem.len() - 1).rev() {
+                timed_local_update(&mut problem, bond, false, &options, &mut op, &mut timing)
+                    .unwrap();
+            }
+        }
+
+        let max_error = max_error_metric(
+            &problem.pivot_errors,
+            &problem.pivot_scales,
+            options.scale_tolerance,
+        );
+        ranks.push(problem.solution.rank());
+        timing.sweeps += 1;
+        timing.final_rank = problem.solution.rank();
+        timing.final_error = max_error;
+
+        if iteration + 1 >= options.min_iters
+            && max_error <= options.tolerance
+            && ranks_are_stable(&ranks, options.min_iters)
+        {
+            break;
+        }
+    }
+    timing
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn median_ms(mut values: Vec<f64>) -> f64 {
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mid = values.len() / 2;
+    if values.len() % 2 == 0 {
+        0.5 * (values[mid - 1] + values[mid])
+    } else {
+        values[mid]
+    }
+}
+
+#[test]
+#[ignore]
+fn local_update_step_timing() {
+    let repeats = std::env::var("T4A_STEP_TIMING_REPEATS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10);
+    let chis = std::env::var("T4A_STEP_TIMING_CHIS")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|item| item.parse::<usize>().unwrap())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| vec![2, 4, 8, 16]);
+    println!(
+        "impl,chi,repeats,n_sweeps,n_updates,setup_ms,setup_shape_ms,setup_dims_ms,setup_left_factor_ms,setup_right_factor_ms,setup_other_ms,input_values_ms,operator_ms,matrix_luci_ms,core_update_ms,frame_update_ms,total_ms,final_rank,final_error"
+    );
+    for chi in chis {
+        let runs = (0..repeats).map(|_| timed_aci_run(chi)).collect::<Vec<_>>();
+        let sweeps = runs[0].sweeps;
+        let updates = runs[0].updates;
+        let final_rank = runs[0].final_rank;
+        let final_error = runs[0].final_error;
+        println!(
+            "rust,{chi},{repeats},{sweeps},{updates},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{final_rank},{final_error:.6e}",
+            median_ms(runs.iter().map(|run| duration_ms(run.setup)).collect()),
+            median_ms(
+                runs.iter()
+                    .map(|run| duration_ms(run.setup_shape_validation))
+                    .collect()
+            ),
+            median_ms(runs.iter().map(|run| duration_ms(run.setup_dims)).collect()),
+            median_ms(
+                runs.iter()
+                    .map(|run| duration_ms(run.setup_left_factor))
+                    .collect()
+            ),
+            median_ms(
+                runs.iter()
+                    .map(|run| duration_ms(run.setup_right_factor))
+                    .collect()
+            ),
+            median_ms(runs.iter().map(|run| duration_ms(run.setup_other())).collect()),
+            median_ms(runs.iter().map(|run| duration_ms(run.input_values)).collect()),
+            median_ms(runs.iter().map(|run| duration_ms(run.operator)).collect()),
+            median_ms(runs.iter().map(|run| duration_ms(run.matrix_luci)).collect()),
+            median_ms(runs.iter().map(|run| duration_ms(run.core_update)).collect()),
+            median_ms(runs.iter().map(|run| duration_ms(run.frame_update)).collect()),
+            median_ms(runs.iter().map(|run| duration_ms(run.total())).collect()),
+        );
+    }
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,6 +1,8 @@
 use crate::validation::{validate_inputs, validate_options};
 use crate::{
-    elementwise, elementwise_batched, initial_guess,
+    elementwise,
+    elementwise::error_metric,
+    elementwise_batched, initial_guess,
     random_tt::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
         initial_guess_total_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES,
@@ -218,6 +220,90 @@ fn elementwise_batched_propagates_operator_error() {
 
     assert!(matches!(err, AciError::Operator { .. }));
     assert!(err.to_string().contains("public operator failed"));
+}
+
+#[test]
+fn elementwise_single_site_scalar_evaluates_operator() {
+    let input_a = TensorTrain::<f64>::constant(&[3], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[3], 4.0);
+
+    let result = elementwise(
+        |values| values[0] * values[1] + 1.0,
+        &[input_a, input_b],
+        &AciOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(result.tensor_train.rank(), 1);
+    assert!(result.ranks.is_empty());
+    assert!(result.errors.is_empty());
+    for i in 0..3 {
+        let value = result.tensor_train.evaluate(&[i]).unwrap();
+        assert!((value - 9.0).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn elementwise_batched_single_site_uses_column_major_batch_layout() {
+    let input_a = TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, 2.0, 3.0], 1, 3, 1).unwrap()
+    ])
+    .unwrap();
+    let input_b = TensorTrain::new(vec![
+        tensor3_from_data(vec![10.0, 20.0, 30.0], 1, 3, 1).unwrap()
+    ])
+    .unwrap();
+    let observed_batches = std::cell::RefCell::new(Vec::new());
+
+    let result = elementwise_batched(
+        |batch, output| {
+            observed_batches
+                .borrow_mut()
+                .push(batch.as_col_major_slice().to_vec());
+            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+                *value = batch.get(0, point)? + batch.get(1, point)?;
+            }
+            Ok(())
+        },
+        &[input_a, input_b],
+        &AciOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        observed_batches.into_inner(),
+        vec![vec![1.0, 10.0, 2.0, 20.0, 3.0, 30.0]]
+    );
+    assert_eq!(result.tensor_train.evaluate(&[0]).unwrap(), 11.0);
+    assert_eq!(result.tensor_train.evaluate(&[1]).unwrap(), 22.0);
+    assert_eq!(result.tensor_train.evaluate(&[2]).unwrap(), 33.0);
+}
+
+#[test]
+fn elementwise_batched_single_site_propagates_operator_error() {
+    let input_a = TensorTrain::<f64>::constant(&[3], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[3], 4.0);
+
+    let err = elementwise_batched(
+        |_batch, _output| {
+            Err(AciError::Operator {
+                message: "single-site operator failed".to_string(),
+            })
+        },
+        &[input_a, input_b],
+        &AciOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, AciError::Operator { .. }));
+    assert!(err.to_string().contains("single-site operator failed"));
+}
+
+#[test]
+fn relative_error_metric_normalizes_by_sampled_scale() {
+    assert_eq!(error_metric(2.0, 100.0, true), 0.02);
+    assert_eq!(error_metric(2.0, 100.0, false), 2.0);
+    assert_eq!(error_metric(2.0, 0.0, true), 2.0);
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -136,9 +136,47 @@ fn elementwise_problem_initializes_all_rank_one_right_frames() {
     let problem = ElementwiseProblem::new(vec![a, b], AciOptions::default()).unwrap();
 
     for input in 0..problem.n_inputs() {
-        for site in 0..=problem.len() {
+        assert_eq!(
+            problem.right_frame_shape(input, problem.len()),
+            Some((1, 1))
+        );
+        for site in 1..problem.len() {
             assert_eq!(problem.right_frame_shape(input, site), Some((1, 1)));
         }
+        assert_eq!(problem.right_frame_shape(input, 0), None);
+    }
+}
+
+#[test]
+fn elementwise_problem_handles_one_site_input() {
+    let input = TensorTrain::<f64>::constant(&[2], 3.0);
+    let problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+    assert_eq!(problem.len(), 1);
+    assert_eq!(problem.left_frame_shape(0, 0), Some((1, 1)));
+    assert_eq!(problem.right_frame_shape(0, 1), Some((1, 1)));
+    assert_eq!(problem.right_frame_shape(0, 0), None);
+}
+
+#[test]
+fn elementwise_problem_preserves_initial_guess_values() {
+    let input = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+    let tt = TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(vec![5.0, 6.0, 7.0, 8.0], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let options = AciOptions {
+        initial_guess: Some(tt.clone()),
+        ..AciOptions::default()
+    };
+
+    let problem = ElementwiseProblem::new(vec![input], options).unwrap();
+
+    for indices in [[0, 0], [0, 1], [1, 0], [1, 1]] {
+        assert!(
+            (problem.solution.evaluate(&indices).unwrap() - tt.evaluate(&indices).unwrap()).abs()
+                < 1e-12
+        );
     }
 }
 

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -757,6 +757,82 @@ fn local_input_factors_match_explicit_two_site_contraction_for_all_inputs() {
 }
 
 #[test]
+fn local_input_factors_report_bounds_errors_and_record_timing() {
+    let problem = local_test_problem();
+    let factors = crate::local::local_input_factors_for_problem(&problem, 1).unwrap();
+    let (nrows, ncols) = problem.local_input_shape(0, 1).unwrap();
+
+    let row_err = match factors[0].value(nrows, 0) {
+        Ok(_) => panic!("expected row bounds error"),
+        Err(err) => err,
+    };
+    assert!(row_err.to_string().contains("local row index"));
+
+    let col_err = match factors[0].value(0, ncols) {
+        Ok(_) => panic!("expected column bounds error"),
+        Err(err) => err,
+    };
+    assert!(col_err.to_string().contains("local column index"));
+
+    let mut timing = LocalInputSetupTiming::default();
+    let timed = crate::local::local_input_factors_for_problem_with_timing(&problem, 1, &mut timing)
+        .unwrap();
+
+    assert_eq!(timed.len(), factors.len());
+}
+
+#[test]
+fn tensor3_reshape_helpers_accept_and_reject_shapes() {
+    let left_factor = Matrix::from_col_major_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]);
+
+    let core = crate::state::matrix_to_tensor3(&left_factor, 1, 2, 2).unwrap();
+    assert_eq!(core.left_dim(), 1);
+    assert_eq!(core.site_dim(), 2);
+    assert_eq!(core.right_dim(), 2);
+
+    let core = crate::state::matrix_into_tensor3(left_factor.clone(), 1, 2, 2).unwrap();
+    assert_eq!(core.left_dim(), 1);
+    assert_eq!(core.site_dim(), 2);
+    assert_eq!(core.right_dim(), 2);
+
+    let err = match crate::state::matrix_to_tensor3(&left_factor, 2, 2, 1) {
+        Ok(_) => panic!("expected left factor shape error"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("cannot reshape matrix"));
+
+    let err = match crate::state::matrix_into_tensor3(left_factor, 2, 2, 1) {
+        Ok(_) => panic!("expected owned left factor shape error"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("cannot reshape matrix"));
+
+    let right_factor =
+        Matrix::from_col_major_vec(2, 6, (0..12).map(|value| value as f64).collect());
+    let core = crate::state::right_factor_to_tensor3(&right_factor, 2, 3, 2).unwrap();
+    assert_eq!(core.left_dim(), 2);
+    assert_eq!(core.site_dim(), 3);
+    assert_eq!(core.right_dim(), 2);
+
+    let core = crate::state::right_factor_into_tensor3(right_factor.clone(), 2, 3, 2).unwrap();
+    assert_eq!(core.left_dim(), 2);
+    assert_eq!(core.site_dim(), 3);
+    assert_eq!(core.right_dim(), 2);
+
+    let err = match crate::state::right_factor_to_tensor3(&right_factor, 3, 2, 2) {
+        Ok(_) => panic!("expected right factor shape error"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("cannot reshape right factor"));
+
+    let err = match crate::state::right_factor_into_tensor3(right_factor, 3, 2, 2) {
+        Ok(_) => panic!("expected owned right factor shape error"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("cannot reshape right factor"));
+}
+
+#[test]
 fn local_block_evaluator_uses_matrix_luci_point_order_and_batch_layout() {
     let problem = local_test_problem();
     let rows = [0, 3];

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::{AciError, AciOptions, ElementwiseBatch};
+use crate::validation::{validate_inputs, validate_options};
+use crate::{initial_guess, AciError, AciOptions, ElementwiseBatch};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
 
 #[test]
 fn default_options_are_conservative() {
@@ -89,4 +91,90 @@ fn elementwise_batch_rejects_out_of_range_point_index() {
     assert!(message.contains("point index"));
     assert!(message.contains("out of bounds"));
     assert!(message.contains("len 2"));
+}
+
+#[test]
+fn validate_inputs_rejects_empty_inputs() {
+    let err = validate_inputs::<f64>(&[]).unwrap_err();
+    assert!(err.to_string().contains("at least one"));
+}
+
+#[test]
+fn validate_inputs_rejects_length_mismatch() {
+    let a = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let err = validate_inputs(&[a, b]).unwrap_err();
+    assert!(err.to_string().contains("length mismatch"));
+}
+
+#[test]
+fn validate_inputs_rejects_site_dim_mismatch() {
+    let a = TensorTrain::<f64>::constant(&[2, 3], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 4], 1.0);
+    let err = validate_inputs(&[a, b]).unwrap_err();
+    assert!(err.to_string().contains("site dimension mismatch"));
+}
+
+#[test]
+fn validate_options_rejects_zero_max_iters() {
+    let options = AciOptions::<f64> {
+        max_iters: 0,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("max_iters"));
+}
+
+#[test]
+fn validate_options_rejects_min_iters_above_max_iters() {
+    let options = AciOptions::<f64> {
+        min_iters: 3,
+        max_iters: 2,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("min_iters"));
+}
+
+#[test]
+fn validate_options_rejects_negative_tolerance() {
+    let options = AciOptions::<f64> {
+        tolerance: -1e-12,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("tolerance"));
+}
+
+#[test]
+fn validate_options_rejects_nan_tolerance() {
+    let options = AciOptions::<f64> {
+        tolerance: f64::NAN,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("tolerance"));
+}
+
+#[test]
+fn validate_options_rejects_infinite_tolerance() {
+    let options = AciOptions::<f64> {
+        tolerance: f64::INFINITY,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("tolerance"));
+}
+
+#[test]
+fn default_initial_guess_matches_input_site_dims() {
+    let a = TensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 3, 4], 2.0);
+    let guess = initial_guess(&[a, b], &AciOptions::default()).unwrap();
+    assert_eq!(guess.site_dims(), vec![2, 3, 4]);
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -2,7 +2,9 @@ use crate::local::LocalInputSetupTiming;
 use crate::validation::{validate_inputs, validate_options};
 use crate::{
     elementwise,
-    elementwise::{error_metric, max_error_metric, ranks_are_stable},
+    elementwise::{
+        convergence_criterion_like_julia, error_metric, max_error_metric, ranks_are_stable,
+    },
     elementwise_batched, initial_guess,
     random_tt::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
@@ -16,7 +18,7 @@ use std::time::{Duration, Instant};
 use tensor4all_simplett::{
     tensor3_from_data, tensor3_zeros, AbstractTensorTrain, Tensor3Ops, TensorTrain,
 };
-use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
+use tensor4all_tcicore::{matrix_luci_factors_from_matrix_owned, RrLUOptions};
 use tensor4all_tensorbackend::Matrix;
 
 fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> TensorTrain<f64> {
@@ -326,6 +328,39 @@ fn rank_stability_matches_julia_min_iter_window() {
     assert!(!ranks_are_stable(&[10, 12, 13], 2));
     assert!(!ranks_are_stable(&[10, 12], 2));
     assert!(ranks_are_stable(&[10, 10], 2));
+}
+
+#[test]
+fn convergence_criterion_matches_julia_algorithm() {
+    let ranks = [10, 12, 12];
+    let errors = [1.0e-8, 2.0e-11, 3.0e-11];
+
+    assert!(!convergence_criterion_like_julia(
+        1,
+        &ranks[..1],
+        &errors[..1],
+        2,
+        1.0e-10
+    ));
+    assert!(!convergence_criterion_like_julia(
+        2,
+        &ranks[..2],
+        &errors[..2],
+        2,
+        1.0e-10
+    ));
+    assert!(convergence_criterion_like_julia(
+        3, &ranks, &errors, 2, 1.0e-10
+    ));
+
+    let increasing_ranks = [10, 12, 13];
+    assert!(!convergence_criterion_like_julia(
+        3,
+        &increasing_ranks,
+        &errors,
+        2,
+        1.0e-10
+    ));
 }
 
 #[test]
@@ -1055,6 +1090,17 @@ fn validate_options_rejects_min_iters_above_max_iters() {
 }
 
 #[test]
+fn validate_options_rejects_zero_min_iters() {
+    let options = AciOptions::<f64> {
+        min_iters: 0,
+        ..AciOptions::default()
+    };
+    let err = validate_options(&options).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("min_iters"));
+}
+
+#[test]
 fn validate_options_rejects_negative_tolerance() {
     let options = AciOptions::<f64> {
         tolerance: -1e-12,
@@ -1296,7 +1342,7 @@ fn initial_guess_rejects_oversized_total_entries() {
     assert!(err.to_string().contains("initial guess total size"));
 }
 
-const STEP_TIMING_N_SITES: usize = 12;
+const STEP_TIMING_DEFAULT_N_SITES: usize = 12;
 const STEP_TIMING_LOCAL_DIM: usize = 2;
 const STEP_TIMING_N_INPUTS: usize = 2;
 const STEP_TIMING_TOLERANCE: f64 = 1e-10;
@@ -1381,9 +1427,13 @@ fn step_timing_core_value(
     site_value / scale
 }
 
-fn step_timing_deterministic_tt(input_index: usize, chi: usize) -> TensorTrain<f64> {
-    let links = step_timing_link_dims(STEP_TIMING_N_SITES, STEP_TIMING_LOCAL_DIM, chi);
-    let cores = (0..STEP_TIMING_N_SITES)
+fn step_timing_deterministic_tt(
+    input_index: usize,
+    n_sites: usize,
+    chi: usize,
+) -> TensorTrain<f64> {
+    let links = step_timing_link_dims(n_sites, STEP_TIMING_LOCAL_DIM, chi);
+    let cores = (0..n_sites)
         .map(|site| {
             let left_dim = if site == 0 { 1 } else { links[site - 1] };
             let right_dim = links.get(site).copied().unwrap_or(1);
@@ -1411,9 +1461,9 @@ fn step_timing_deterministic_tt(input_index: usize, chi: usize) -> TensorTrain<f
     TensorTrain::new(cores).unwrap()
 }
 
-fn step_timing_inputs(chi: usize) -> Vec<TensorTrain<f64>> {
+fn step_timing_inputs(n_sites: usize, chi: usize) -> Vec<TensorTrain<f64>> {
     (0..STEP_TIMING_N_INPUTS)
-        .map(|input| step_timing_deterministic_tt(input, chi))
+        .map(|input| step_timing_deterministic_tt(input, n_sites, chi))
         .collect()
 }
 
@@ -1480,8 +1530,8 @@ where
         let sampled_scale = evaluator.max_output_abs();
 
         let start = Instant::now();
-        let factors = matrix_luci_factors_from_matrix(
-            &local_matrix,
+        let factors = matrix_luci_factors_from_matrix_owned(
+            local_matrix,
             Some(RrLUOptions {
                 max_rank: options.max_bond_dim,
                 rel_tol: if options.scale_tolerance {
@@ -1525,16 +1575,21 @@ where
     };
 
     let start = Instant::now();
-    let mut solution_cores = problem.solution.site_tensors().to_vec();
-    solution_cores[bond] =
-        crate::state::matrix_to_tensor3(&left_factor, left_solution_rank, site_dim_left, new_rank)?;
-    solution_cores[bond + 1] = crate::state::right_factor_to_tensor3(
-        &right_factor,
+    let new_left_core = crate::state::matrix_into_tensor3(
+        left_factor,
+        left_solution_rank,
+        site_dim_left,
+        new_rank,
+    )?;
+    let new_right_core = crate::state::right_factor_into_tensor3(
+        right_factor,
         new_rank,
         site_dim_right,
         right_solution_rank,
     )?;
-    problem.solution = TensorTrain::new(solution_cores)?;
+    let solution_cores = problem.solution.site_tensors_mut();
+    solution_cores[bond] = new_left_core;
+    solution_cores[bond + 1] = new_right_core;
     timing.core_update += start.elapsed();
 
     let start = Instant::now();
@@ -1550,18 +1605,30 @@ where
     Ok(())
 }
 
-fn timed_aci_run(chi: usize) -> LocalStepTiming {
-    let inputs = step_timing_inputs(chi);
+fn timed_aci_run(
+    n_sites: usize,
+    chi: usize,
+    min_iters: usize,
+    fixed_sweeps: Option<usize>,
+) -> LocalStepTiming {
+    let inputs = step_timing_inputs(n_sites, chi);
+    let max_iters = fixed_sweeps.unwrap_or(20).max(20);
     let options = AciOptions {
-        max_iters: 20,
+        max_iters,
+        min_iters,
         tolerance: STEP_TIMING_TOLERANCE,
-        initial_guess: Some(step_timing_deterministic_tt(STEP_TIMING_N_INPUTS, chi)),
+        initial_guess: Some(step_timing_deterministic_tt(
+            STEP_TIMING_N_INPUTS,
+            n_sites,
+            chi,
+        )),
         ..AciOptions::default()
     };
     let mut problem = ElementwiseProblem::new(inputs, options.clone()).unwrap();
     let mut timing = LocalStepTiming::default();
     let mut op = step_timing_multiply_batch;
     let mut ranks = Vec::new();
+    let mut errors = Vec::new();
 
     for iteration in 0..options.max_iters {
         let forward = iteration % 2 == 0;
@@ -1583,13 +1650,23 @@ fn timed_aci_run(chi: usize) -> LocalStepTiming {
             options.scale_tolerance,
         );
         ranks.push(problem.solution.rank());
+        errors.push(max_error);
         timing.sweeps += 1;
         timing.final_rank = problem.solution.rank();
         timing.final_error = max_error;
 
-        if iteration + 1 >= options.min_iters
-            && max_error <= options.tolerance
-            && ranks_are_stable(&ranks, options.min_iters)
+        if fixed_sweeps.is_some_and(|target| timing.sweeps >= target) {
+            break;
+        }
+
+        if fixed_sweeps.is_none()
+            && convergence_criterion_like_julia(
+                iteration + 1,
+                &ranks,
+                &errors,
+                options.min_iters,
+                options.tolerance,
+            )
         {
             break;
         }
@@ -1618,6 +1695,22 @@ fn local_update_step_timing() {
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(10);
+    let n_sites = std::env::var("T4A_STEP_TIMING_N_SITES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(STEP_TIMING_DEFAULT_N_SITES);
+    assert!(n_sites >= 2, "T4A_STEP_TIMING_N_SITES must be at least 2");
+    let min_iters = std::env::var("T4A_STEP_TIMING_MIN_ITERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(AciOptions::<f64>::default().min_iters);
+    assert!(
+        min_iters >= 1,
+        "T4A_STEP_TIMING_MIN_ITERS must be at least 1"
+    );
+    let fixed_sweeps = std::env::var("T4A_STEP_TIMING_FIXED_SWEEPS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok());
     let chis = std::env::var("T4A_STEP_TIMING_CHIS")
         .ok()
         .map(|value| {
@@ -1628,16 +1721,19 @@ fn local_update_step_timing() {
         })
         .unwrap_or_else(|| vec![2, 4, 8, 16]);
     println!(
-        "impl,chi,repeats,n_sweeps,n_updates,setup_ms,setup_shape_ms,setup_dims_ms,setup_left_factor_ms,setup_right_factor_ms,setup_other_ms,input_values_ms,operator_ms,matrix_luci_ms,core_update_ms,frame_update_ms,total_ms,final_rank,final_error"
+        "impl,chi,n_sites,repeats,min_iters,fixed_sweeps,n_sweeps,n_updates,setup_ms,setup_shape_ms,setup_dims_ms,setup_left_factor_ms,setup_right_factor_ms,setup_other_ms,input_values_ms,operator_ms,matrix_luci_ms,core_update_ms,frame_update_ms,total_ms,final_rank,final_error"
     );
     for chi in chis {
-        let runs = (0..repeats).map(|_| timed_aci_run(chi)).collect::<Vec<_>>();
+        let runs = (0..repeats)
+            .map(|_| timed_aci_run(n_sites, chi, min_iters, fixed_sweeps))
+            .collect::<Vec<_>>();
         let sweeps = runs[0].sweeps;
         let updates = runs[0].updates;
         let final_rank = runs[0].final_rank;
         let final_error = runs[0].final_error;
+        let fixed_sweeps_value = fixed_sweeps.unwrap_or(0);
         println!(
-            "rust,{chi},{repeats},{sweeps},{updates},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{final_rank},{final_error:.6e}",
+            "rust,{chi},{n_sites},{repeats},{min_iters},{fixed_sweeps_value},{sweeps},{updates},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{:.6},{final_rank},{final_error:.6e}",
             median_ms(runs.iter().map(|run| duration_ms(run.setup)).collect()),
             median_ms(
                 runs.iter()

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -7,7 +7,10 @@ use crate::{
     },
     AciError, AciOptions, ElementwiseBatch,
 };
-use tensor4all_simplett::{tensor3_zeros, AbstractTensorTrain, Tensor3Ops, TensorTrain};
+use num_complex::Complex64;
+use tensor4all_simplett::{
+    tensor3_from_data, tensor3_zeros, AbstractTensorTrain, Tensor3Ops, TensorTrain,
+};
 
 fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> TensorTrain<f64> {
     assert_eq!(link_dims.len(), site_dims.len().saturating_sub(1));
@@ -325,6 +328,70 @@ fn initial_guess_rejects_incompatible_explicit_guess_site_dims() {
 
     assert!(matches!(err, AciError::InvalidInitialGuess { .. }));
     assert!(err.to_string().contains("site dimensions"));
+}
+
+#[test]
+fn explicit_initial_guess_rejects_rank_above_max_bond_dim() {
+    let input = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+    let explicit = TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0; 4], 1, 2, 2).unwrap(),
+        tensor3_from_data(vec![1.0; 4], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let options = AciOptions {
+        max_bond_dim: 1,
+        initial_guess: Some(explicit),
+        ..AciOptions::default()
+    };
+
+    let err = initial_guess(&[input], &options).unwrap_err();
+
+    assert!(matches!(err, AciError::InvalidInitialGuess { .. }));
+    let message = err.to_string();
+    assert!(message.contains("bond dimension"));
+    assert!(message.contains("max_bond_dim"));
+}
+
+#[test]
+fn explicit_initial_guess_rejects_zero_bond_dimension() {
+    let input = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+    let explicit = TensorTrain::new(vec![
+        tensor3_from_data(Vec::<f64>::new(), 1, 2, 0).unwrap(),
+        tensor3_from_data(Vec::<f64>::new(), 0, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let options = AciOptions {
+        initial_guess: Some(explicit),
+        ..AciOptions::default()
+    };
+
+    let err = initial_guess(&[input], &options).unwrap_err();
+
+    assert!(matches!(err, AciError::InvalidInitialGuess { .. }));
+    let message = err.to_string();
+    assert!(message.contains("dimension"));
+    assert!(message.contains("positive"));
+}
+
+#[test]
+fn complex_initial_guess_is_deterministic() {
+    let a = TensorTrain::<Complex64>::constant(&[2, 3, 2], Complex64::new(1.0, 0.0));
+    let b = TensorTrain::<Complex64>::constant(&[2, 3, 2], Complex64::new(2.0, 0.0));
+    let options = AciOptions::<Complex64> {
+        max_bond_dim: 2,
+        rng_seed: 4321,
+        ..AciOptions::default()
+    };
+
+    let guess_a = initial_guess(&[a.clone(), b.clone()], &options).unwrap();
+    let guess_b = initial_guess(&[a, b], &options).unwrap();
+
+    assert_eq!(guess_a.site_dims(), vec![2, 3, 2]);
+    assert_eq!(guess_b.site_dims(), vec![2, 3, 2]);
+    assert_eq!(
+        guess_a.evaluate(&[1, 2, 1]).unwrap(),
+        guess_b.evaluate(&[1, 2, 1]).unwrap()
+    );
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -153,6 +153,28 @@ fn elementwise_problem_updates_left_frame_for_selected_rows() {
 }
 
 #[test]
+fn elementwise_problem_updates_left_frame_values() {
+    let input = TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, 2.0, 10.0, 20.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(vec![3.0, 4.0, 5.0, 6.0], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let mut problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+
+    problem.update_left_frame(0, 0, &[0, 1]).unwrap();
+
+    assert_eq!(problem.left_frame_shape(0, 1), Some((2, 2)));
+    assert_eq!(problem.left_frame_value(0, 1, 0, 0), Some(1.0));
+    assert_eq!(problem.left_frame_value(0, 1, 1, 0), Some(2.0));
+    assert_eq!(problem.left_frame_value(0, 1, 0, 1), Some(10.0));
+    assert_eq!(problem.left_frame_value(0, 1, 1, 1), Some(20.0));
+    assert_eq!(problem.left_frame_value(1, 1, 0, 0), None);
+    assert_eq!(problem.left_frame_value(0, 2, 0, 0), None);
+    assert_eq!(problem.left_frame_value(0, 1, 2, 0), None);
+    assert_eq!(problem.left_frame_value(0, 1, 0, 2), None);
+}
+
+#[test]
 fn elementwise_problem_updates_all_left_frames_for_selected_rows() {
     let a = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
     let b = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
@@ -172,6 +194,28 @@ fn elementwise_problem_updates_right_frame_for_selected_columns() {
     problem.update_right_frame(0, 2, &[0, 1]).unwrap();
 
     assert_eq!(problem.right_frame_shape(0, 2), Some((1, 2)));
+}
+
+#[test]
+fn elementwise_problem_updates_right_frame_values() {
+    let input = TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, 2.0, 10.0, 20.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(vec![3.0, 30.0, 4.0, 40.0], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+    let mut problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+
+    problem.update_right_frame(0, 1, &[0, 1]).unwrap();
+
+    assert_eq!(problem.right_frame_shape(0, 1), Some((2, 2)));
+    assert_eq!(problem.right_frame_value(0, 1, 0, 0), Some(3.0));
+    assert_eq!(problem.right_frame_value(0, 1, 1, 0), Some(30.0));
+    assert_eq!(problem.right_frame_value(0, 1, 0, 1), Some(4.0));
+    assert_eq!(problem.right_frame_value(0, 1, 1, 1), Some(40.0));
+    assert_eq!(problem.right_frame_value(1, 1, 0, 0), None);
+    assert_eq!(problem.right_frame_value(0, 3, 0, 0), None);
+    assert_eq!(problem.right_frame_value(0, 1, 2, 0), None);
+    assert_eq!(problem.right_frame_value(0, 1, 0, 2), None);
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -756,7 +756,7 @@ fn local_block_evaluator_serves_duplicate_entries_from_cache() {
         .fill_local_block(&rows, &cols, &mut second)
         .unwrap();
 
-    assert!(calls.get() < first.len() + second.len());
+    assert_eq!(calls.get(), 2);
     assert_eq!(first[0], first[1]);
     assert_eq!(first, second);
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -2,12 +2,26 @@ use crate::validation::{validate_inputs, validate_options};
 use crate::{
     initial_guess,
     random_tt::{
-        initial_guess_core_entry_count, initial_guess_total_entry_count,
-        MAX_INITIAL_GUESS_CORE_ENTRIES,
+        initial_guess_core_entry_count, initial_guess_existing_entry_count,
+        initial_guess_total_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES,
     },
     AciError, AciOptions, ElementwiseBatch,
 };
-use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops, TensorTrain};
+use tensor4all_simplett::{tensor3_zeros, AbstractTensorTrain, Tensor3Ops, TensorTrain};
+
+fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> TensorTrain<f64> {
+    assert_eq!(link_dims.len(), site_dims.len().saturating_sub(1));
+    let cores = site_dims
+        .iter()
+        .enumerate()
+        .map(|(site, &site_dim)| {
+            let left_dim = if site == 0 { 1 } else { link_dims[site - 1] };
+            let right_dim = link_dims.get(site).copied().unwrap_or(1);
+            tensor3_zeros(left_dim, site_dim, right_dim)
+        })
+        .collect();
+    TensorTrain::new(cores).unwrap()
+}
 
 #[test]
 fn default_options_are_conservative() {
@@ -115,6 +129,27 @@ fn validate_inputs_rejects_zero_site_tensor_train() {
 }
 
 #[test]
+fn validate_inputs_rejects_zero_physical_dim_in_first_input() {
+    let input = tensor_train_with_link_dims(&[0, 3], &[1]);
+    let err = validate_inputs(&[input]).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    let message = err.to_string();
+    assert!(message.contains("site 0"));
+    assert!(message.contains("dimension must be positive"));
+}
+
+#[test]
+fn validate_inputs_rejects_zero_physical_dim_in_later_input() {
+    let first = tensor_train_with_link_dims(&[2, 3], &[1]);
+    let later = tensor_train_with_link_dims(&[2, 0], &[1]);
+    let err = validate_inputs(&[first, later]).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    let message = err.to_string();
+    assert!(message.contains("site 1"));
+    assert!(message.contains("dimension must be positive"));
+}
+
+#[test]
 fn validate_inputs_rejects_length_mismatch() {
     let a = TensorTrain::<f64>::constant(&[2, 2], 1.0);
     let b = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
@@ -206,6 +241,39 @@ fn default_initial_guess_matches_input_site_dims() {
 }
 
 #[test]
+fn initial_guess_link_dims_are_empty_for_one_site_input() {
+    let input = TensorTrain::<f64>::constant(&[5], 1.0);
+    let guess = initial_guess(&[input], &AciOptions::default()).unwrap();
+    assert_eq!(guess.link_dims(), Vec::<usize>::new());
+}
+
+#[test]
+fn initial_guess_link_dims_are_limited_by_max_bond_dim() {
+    let input = tensor_train_with_link_dims(&[8, 8, 8], &[8, 8]);
+    let options = AciOptions::<f64> {
+        max_bond_dim: 3,
+        ..AciOptions::default()
+    };
+    let guess = initial_guess(&[input], &options).unwrap();
+    assert_eq!(guess.link_dims(), vec![3, 3]);
+}
+
+#[test]
+fn initial_guess_link_dims_are_limited_by_physical_left_right_products() {
+    let input = tensor_train_with_link_dims(&[2, 3, 5, 7], &[20, 20, 20]);
+    let guess = initial_guess(&[input], &AciOptions::default()).unwrap();
+    assert_eq!(guess.link_dims(), vec![2, 6, 7]);
+}
+
+#[test]
+fn initial_guess_link_dims_are_limited_by_minimum_input_link_dim() {
+    let wide = tensor_train_with_link_dims(&[8, 8, 8], &[8, 8]);
+    let narrow = tensor_train_with_link_dims(&[8, 8, 8], &[5, 2]);
+    let guess = initial_guess(&[wide, narrow], &AciOptions::default()).unwrap();
+    assert_eq!(guess.link_dims(), vec![5, 2]);
+}
+
+#[test]
 fn initial_guess_is_deterministic_for_same_seed() {
     let a = TensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
     let b = TensorTrain::<f64>::constant(&[2, 3, 2], 2.0);
@@ -257,6 +325,13 @@ fn initial_guess_rejects_incompatible_explicit_guess_site_dims() {
 
     assert!(matches!(err, AciError::InvalidInitialGuess { .. }));
     assert!(err.to_string().contains("site dimensions"));
+}
+
+#[test]
+fn initial_guess_existing_entry_count_matches_explicit_guess_cores() {
+    let guess = tensor_train_with_link_dims(&[2, 3, 5], &[4, 6]);
+    let entry_count = initial_guess_existing_entry_count(&guess).unwrap();
+    assert_eq!(entry_count, 8 + 72 + 30);
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -738,12 +738,12 @@ fn local_block_evaluator_serves_duplicate_entries_from_cache() {
     let cols = [0];
     let mut first = vec![0.0; rows.len() * cols.len()];
     let mut second = vec![0.0; rows.len() * cols.len()];
-    let observed_points = std::cell::RefCell::new(Vec::new());
+    let calls = std::cell::Cell::new(0usize);
 
     let operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
-        observed_points.borrow_mut().push(batch.n_points());
+        calls.set(calls.get() + batch.n_points());
         for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
-            *value = batch.get(0, point).unwrap() + batch.get(1, point).unwrap();
+            *value = batch.get(0, point).unwrap() * batch.get(1, point).unwrap();
         }
         Ok(())
     };
@@ -756,7 +756,7 @@ fn local_block_evaluator_serves_duplicate_entries_from_cache() {
         .fill_local_block(&rows, &cols, &mut second)
         .unwrap();
 
-    assert_eq!(observed_points.into_inner(), vec![2]);
+    assert!(calls.get() < first.len() + second.len());
     assert_eq!(first[0], first[1]);
     assert_eq!(first, second);
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -114,6 +114,14 @@ fn explicit_local_value(
     sum
 }
 
+fn multiply_batch(batch: ElementwiseBatch<'_, f64>, output: &mut [f64]) -> crate::Result<()> {
+    assert_eq!(output.len(), batch.n_points());
+    for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+        *value = batch.get(0, point).unwrap() * batch.get(1, point).unwrap();
+    }
+    Ok(())
+}
+
 #[test]
 fn default_options_are_conservative() {
     let options = AciOptions::<f64>::default();
@@ -356,6 +364,71 @@ fn elementwise_problem_rejects_invalid_frame_selection_indices() {
     let right_err = problem.update_right_frame(0, 2, &[2]).unwrap_err();
     assert!(matches!(right_err, AciError::InvalidInitialGuess { .. }));
     assert!(right_err.to_string().contains("column index"));
+}
+
+#[test]
+fn elementwise_problem_one_bond_local_update_matches_dense_product_left_orthogonal() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2], 3.0);
+    let options = AciOptions::<f64>::default();
+    let mut problem = ElementwiseProblem::new(vec![input_a, input_b], options.clone()).unwrap();
+    let mut operator = multiply_batch;
+
+    problem
+        .local_update(0, true, &options, &mut operator)
+        .unwrap();
+
+    for indices in [[0, 0], [1, 0], [0, 1], [1, 1]] {
+        assert!((problem.solution.evaluate(&indices).unwrap() - 6.0).abs() < 1e-12);
+    }
+    assert_eq!(problem.left_frame_shape(0, 1), Some((1, 1)));
+    assert_eq!(problem.left_frame_shape(1, 1), Some((1, 1)));
+    assert_eq!(problem.pivot_errors.len(), 1);
+    assert!(problem.pivot_errors[0] <= 1e-12);
+}
+
+#[test]
+fn elementwise_problem_one_bond_local_update_matches_dense_product_right_orthogonal() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2], 3.0);
+    let options = AciOptions::<f64>::default();
+    let mut problem = ElementwiseProblem::new(vec![input_a, input_b], options.clone()).unwrap();
+    for input in 0..problem.n_inputs() {
+        problem.right_frames[input][1] = None;
+    }
+    let mut operator = multiply_batch;
+
+    problem
+        .local_update(0, false, &options, &mut operator)
+        .unwrap();
+
+    for indices in [[0, 0], [1, 0], [0, 1], [1, 1]] {
+        assert!((problem.solution.evaluate(&indices).unwrap() - 6.0).abs() < 1e-12);
+    }
+    assert_eq!(problem.right_frame_shape(0, 1), Some((1, 1)));
+    assert_eq!(problem.right_frame_shape(1, 1), Some((1, 1)));
+    assert_eq!(problem.pivot_errors.len(), 1);
+    assert!(problem.pivot_errors[0] <= 1e-12);
+}
+
+#[test]
+fn elementwise_problem_one_bond_local_update_returns_operator_error_side_channel() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2], 3.0);
+    let options = AciOptions::<f64>::default();
+    let mut problem = ElementwiseProblem::new(vec![input_a, input_b], options.clone()).unwrap();
+    let mut operator = |_batch: ElementwiseBatch<'_, f64>, _output: &mut [f64]| {
+        Err(AciError::Operator {
+            message: "side-channel operator failure".to_string(),
+        })
+    };
+
+    let err = problem
+        .local_update(0, true, &options, &mut operator)
+        .unwrap_err();
+
+    assert!(matches!(err, AciError::Operator { .. }));
+    assert!(err.to_string().contains("side-channel operator failure"));
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -1,5 +1,9 @@
 use crate::validation::{validate_inputs, validate_options};
-use crate::{initial_guess, AciError, AciOptions, ElementwiseBatch};
+use crate::{
+    initial_guess,
+    random_tt::{initial_guess_core_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES},
+    AciError, AciOptions, ElementwiseBatch,
+};
 use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
 
 #[test]
@@ -177,4 +181,11 @@ fn default_initial_guess_matches_input_site_dims() {
     let b = TensorTrain::<f64>::constant(&[2, 3, 4], 2.0);
     let guess = initial_guess(&[a, b], &AciOptions::default()).unwrap();
     assert_eq!(guess.site_dims(), vec![2, 3, 4]);
+}
+
+#[test]
+fn initial_guess_rejects_huge_non_overflowing_core_size() {
+    let err = initial_guess_core_entry_count(MAX_INITIAL_GUESS_CORE_ENTRIES + 1, 1, 1).unwrap_err();
+    assert!(matches!(err, AciError::InvalidOptions { .. }));
+    assert!(err.to_string().contains("initial guess core size"));
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -372,25 +372,25 @@ fn local_input_value_matches_explicit_two_site_contraction() {
 #[test]
 fn local_block_evaluator_uses_matrix_luci_point_order_and_batch_layout() {
     let problem = local_test_problem();
-    let evaluator = LocalBlockEvaluator::new(&problem, 1).unwrap();
     let rows = [0, 3];
     let cols = [1, 2];
     let mut out = vec![0.0; rows.len() * cols.len()];
     let observed_batches = std::cell::RefCell::new(Vec::new());
 
-    evaluator
-        .fill_local_block(&rows, &cols, &mut out, |batch, output| {
-            assert_eq!(batch.n_inputs(), problem.n_inputs());
-            assert_eq!(batch.n_points(), rows.len() * cols.len());
-            observed_batches
-                .borrow_mut()
-                .push(batch.as_col_major_slice().to_vec());
-            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
-                *value = batch.get(0, point).unwrap() + 10.0 * batch.get(1, point).unwrap();
-            }
-            Ok(())
-        })
-        .unwrap();
+    let operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        assert_eq!(batch.n_inputs(), problem.n_inputs());
+        assert_eq!(batch.n_points(), rows.len() * cols.len());
+        observed_batches
+            .borrow_mut()
+            .push(batch.as_col_major_slice().to_vec());
+        for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+            *value = batch.get(0, point).unwrap() + 10.0 * batch.get(1, point).unwrap();
+        }
+        Ok(())
+    };
+    let evaluator = LocalBlockEvaluator::new(&problem, 1, &operator).unwrap();
+
+    evaluator.fill_local_block(&rows, &cols, &mut out).unwrap();
 
     let mut expected_values = Vec::new();
     for &col in &cols {
@@ -417,7 +417,6 @@ fn local_block_evaluator_uses_matrix_luci_point_order_and_batch_layout() {
 #[test]
 fn local_block_evaluator_serves_duplicate_entries_from_cache() {
     let problem = local_test_problem();
-    let evaluator = LocalBlockEvaluator::new(&problem, 1).unwrap();
     let rows = [0, 0, 1];
     let cols = [0];
     let mut first = vec![0.0; rows.len() * cols.len()];
@@ -431,12 +430,13 @@ fn local_block_evaluator_serves_duplicate_entries_from_cache() {
         }
         Ok(())
     };
+    let evaluator = LocalBlockEvaluator::new(&problem, 1, &operator).unwrap();
 
     evaluator
-        .fill_local_block(&rows, &cols, &mut first, operator)
+        .fill_local_block(&rows, &cols, &mut first)
         .unwrap();
     evaluator
-        .fill_local_block(&rows, &cols, &mut second, operator)
+        .fill_local_block(&rows, &cols, &mut second)
         .unwrap();
 
     assert_eq!(observed_points.into_inner(), vec![2]);
@@ -447,7 +447,6 @@ fn local_block_evaluator_serves_duplicate_entries_from_cache() {
 #[test]
 fn local_block_evaluator_cache_can_be_cleared() {
     let problem = local_test_problem();
-    let evaluator = LocalBlockEvaluator::new(&problem, 1).unwrap();
     let rows = [0];
     let cols = [0];
     let mut out = vec![0.0];
@@ -458,16 +457,87 @@ fn local_block_evaluator_cache_can_be_cleared() {
         output[0] = batch.get(0, 0).unwrap();
         Ok(())
     };
+    let evaluator = LocalBlockEvaluator::new(&problem, 1, &operator).unwrap();
 
-    evaluator
-        .fill_local_block(&rows, &cols, &mut out, operator)
-        .unwrap();
+    evaluator.fill_local_block(&rows, &cols, &mut out).unwrap();
     evaluator.clear_cache();
-    evaluator
-        .fill_local_block(&rows, &cols, &mut out, operator)
-        .unwrap();
+    evaluator.fill_local_block(&rows, &cols, &mut out).unwrap();
 
     assert_eq!(observed_points.into_inner(), vec![1, 1]);
+}
+
+#[test]
+fn local_block_evaluators_with_different_operators_have_separate_caches() {
+    let problem = local_test_problem();
+    let rows = [0];
+    let cols = [0];
+    let mut first = vec![0.0];
+    let mut second = vec![0.0];
+
+    let first_operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        output[0] = batch.get(0, 0).unwrap();
+        Ok(())
+    };
+    let second_operator = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        output[0] = batch.get(0, 0).unwrap() + 1.0;
+        Ok(())
+    };
+
+    let first_evaluator = LocalBlockEvaluator::new(&problem, 1, &first_operator).unwrap();
+    let second_evaluator = LocalBlockEvaluator::new(&problem, 1, &second_operator).unwrap();
+
+    first_evaluator
+        .fill_local_block(&rows, &cols, &mut first)
+        .unwrap();
+    second_evaluator
+        .fill_local_block(&rows, &cols, &mut second)
+        .unwrap();
+
+    assert_eq!(second, vec![first[0] + 1.0]);
+}
+
+#[test]
+fn local_block_evaluator_or_zero_records_operator_error_once() {
+    let problem = local_test_problem();
+    let rows = [0];
+    let cols = [0];
+    let mut out = vec![123.0];
+    let calls = std::cell::Cell::new(0);
+    let operator = |_batch: ElementwiseBatch<'_, f64>, _output: &mut [f64]| {
+        calls.set(calls.get() + 1);
+        Err(AciError::Operator {
+            message: format!("operator failed on call {}", calls.get()),
+        })
+    };
+    let evaluator = LocalBlockEvaluator::new(&problem, 1, &operator).unwrap();
+
+    evaluator.fill_local_block_or_zero(&rows, &cols, &mut out);
+    assert_eq!(out, vec![0.0]);
+    evaluator.fill_local_block_or_zero(&rows, &cols, &mut out);
+    assert_eq!(out, vec![0.0]);
+
+    let err = evaluator.take_error().unwrap();
+    assert!(err.to_string().contains("call 1"));
+    assert!(evaluator.take_error().is_none());
+}
+
+#[test]
+fn local_block_evaluator_or_zero_records_local_error_once() {
+    let problem = local_test_problem();
+    let rows = [4];
+    let cols = [0];
+    let mut out = vec![123.0];
+    let operator = |_batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        output[0] = 1.0;
+        Ok(())
+    };
+    let evaluator = LocalBlockEvaluator::new(&problem, 1, &operator).unwrap();
+
+    evaluator.fill_local_block_or_zero(&rows, &cols, &mut out);
+
+    assert_eq!(out, vec![0.0]);
+    let err = evaluator.take_error().unwrap();
+    assert!(err.to_string().contains("row index"));
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
         initial_guess_core_entry_count, initial_guess_existing_entry_count,
         initial_guess_total_entry_count, MAX_INITIAL_GUESS_CORE_ENTRIES,
     },
-    AciError, AciOptions, ElementwiseBatch,
+    AciError, AciOptions, ElementwiseBatch, ElementwiseProblem,
 };
 use num_complex::Complex64;
 use tensor4all_simplett::{
@@ -115,6 +115,77 @@ fn elementwise_batch_rejects_out_of_range_point_index() {
     assert!(message.contains("point index"));
     assert!(message.contains("out of bounds"));
     assert!(message.contains("len 2"));
+}
+
+#[test]
+fn elementwise_problem_initializes_boundary_frames() {
+    let a = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let problem = ElementwiseProblem::new(vec![a, b], AciOptions::default()).unwrap();
+    assert_eq!(problem.len(), 3);
+    assert_eq!(problem.n_inputs(), 2);
+    assert_eq!(problem.left_frame_shape(0, 0), Some((1, 1)));
+    assert_eq!(problem.right_frame_shape(0, 3), Some((1, 1)));
+    assert_eq!(problem.pivot_errors, vec![0.0, 0.0]);
+}
+
+#[test]
+fn elementwise_problem_initializes_all_rank_one_right_frames() {
+    let a = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let problem = ElementwiseProblem::new(vec![a, b], AciOptions::default()).unwrap();
+
+    for input in 0..problem.n_inputs() {
+        for site in 0..=problem.len() {
+            assert_eq!(problem.right_frame_shape(input, site), Some((1, 1)));
+        }
+    }
+}
+
+#[test]
+fn elementwise_problem_updates_left_frame_for_selected_rows() {
+    let input = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let mut problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+
+    problem.update_left_frame(0, 0, &[0, 1]).unwrap();
+
+    assert_eq!(problem.left_frame_shape(0, 1), Some((2, 1)));
+}
+
+#[test]
+fn elementwise_problem_updates_all_left_frames_for_selected_rows() {
+    let a = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let mut problem = ElementwiseProblem::new(vec![a, b], AciOptions::default()).unwrap();
+
+    problem.update_left_frames(0, &[0, 1]).unwrap();
+
+    assert_eq!(problem.left_frame_shape(0, 1), Some((2, 1)));
+    assert_eq!(problem.left_frame_shape(1, 1), Some((2, 1)));
+}
+
+#[test]
+fn elementwise_problem_updates_right_frame_for_selected_columns() {
+    let input = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let mut problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+
+    problem.update_right_frame(0, 2, &[0, 1]).unwrap();
+
+    assert_eq!(problem.right_frame_shape(0, 2), Some((1, 2)));
+}
+
+#[test]
+fn elementwise_problem_rejects_invalid_frame_selection_indices() {
+    let input = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let mut problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+
+    let left_err = problem.update_left_frame(0, 0, &[2]).unwrap_err();
+    assert!(matches!(left_err, AciError::InvalidInitialGuess { .. }));
+    assert!(left_err.to_string().contains("row index"));
+
+    let right_err = problem.update_right_frame(0, 2, &[2]).unwrap_err();
+    assert!(matches!(right_err, AciError::InvalidInitialGuess { .. }));
+    assert!(right_err.to_string().contains("column index"));
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -313,6 +313,7 @@ fn relative_error_metric_pairs_each_bond_with_its_scale() {
 
     assert_eq!(max_error_metric(&errors, &scales, true), 1.0);
     assert_eq!(max_error_metric(&errors, &scales, false), 10.0);
+    assert_eq!(max_error_metric(&errors, &[], true), 10.0);
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -915,6 +915,34 @@ fn initial_guess_accepts_compatible_explicit_guess() {
 }
 
 #[test]
+fn initial_guess_zero_initializes_nonzero_dimensional_right_frames() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2, 2], 3.0);
+    let zero_guess = tensor_train_with_link_dims(&[2, 2, 2], &[1, 1]);
+    let options = AciOptions {
+        initial_guess: Some(zero_guess),
+        ..AciOptions::default()
+    };
+
+    let mut problem = ElementwiseProblem::new(vec![input_a, input_b], options.clone()).unwrap();
+
+    assert_solution_is_zero_on_binary_three_site_grid(&problem);
+    for input in 0..problem.n_inputs() {
+        assert_eq!(problem.right_frame_shape(input, 1), Some((1, 1)));
+        assert_eq!(problem.right_frame_shape(input, 2), Some((1, 1)));
+        assert_eq!(problem.right_frame_shape(input, 3), Some((1, 1)));
+    }
+    problem.update_left_frames(0, &[0]).unwrap();
+    assert!(problem.local_input_value(0, 1, 0, 0).is_ok());
+
+    let mut operator = zero_batch;
+    problem
+        .local_update(1, false, &options, &mut operator)
+        .unwrap();
+    assert_solution_is_zero_on_binary_three_site_grid(&problem);
+}
+
+#[test]
 fn initial_guess_rejects_incompatible_explicit_guess_site_dims() {
     let input = TensorTrain::<f64>::constant(&[2, 3], 2.0);
     let explicit = TensorTrain::<f64>::constant(&[2, 4], 7.0);

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -122,6 +122,27 @@ fn multiply_batch(batch: ElementwiseBatch<'_, f64>, output: &mut [f64]) -> crate
     Ok(())
 }
 
+fn zero_batch(batch: ElementwiseBatch<'_, f64>, output: &mut [f64]) -> crate::Result<()> {
+    assert_eq!(output.len(), batch.n_points());
+    output.fill(0.0);
+    Ok(())
+}
+
+fn assert_solution_is_zero_on_binary_three_site_grid(problem: &ElementwiseProblem<f64>) {
+    for indices in [
+        [0, 0, 0],
+        [1, 0, 0],
+        [0, 1, 0],
+        [1, 1, 0],
+        [0, 0, 1],
+        [1, 0, 1],
+        [0, 1, 1],
+        [1, 1, 1],
+    ] {
+        assert_eq!(problem.solution.evaluate(&indices).unwrap(), 0.0);
+    }
+}
+
 #[test]
 fn default_options_are_conservative() {
     let options = AciOptions::<f64>::default();
@@ -429,6 +450,56 @@ fn elementwise_problem_one_bond_local_update_returns_operator_error_side_channel
 
     assert!(matches!(err, AciError::Operator { .. }));
     assert!(err.to_string().contains("side-channel operator failure"));
+}
+
+#[test]
+fn elementwise_problem_one_bond_zero_update_keeps_left_frames_nonzero_dimensional() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2, 2], 3.0);
+    let options = AciOptions::<f64>::default();
+    let mut problem = ElementwiseProblem::new(vec![input_a, input_b], options.clone()).unwrap();
+    let mut operator = zero_batch;
+
+    problem
+        .local_update(0, true, &options, &mut operator)
+        .unwrap();
+
+    assert_solution_is_zero_on_binary_three_site_grid(&problem);
+    assert_eq!(problem.left_frame_shape(0, 1), Some((1, 1)));
+    assert_eq!(problem.left_frame_shape(1, 1), Some((1, 1)));
+    assert!(problem.local_input_value(0, 1, 0, 0).is_ok());
+
+    problem
+        .local_update(1, true, &options, &mut operator)
+        .unwrap();
+    assert_solution_is_zero_on_binary_three_site_grid(&problem);
+}
+
+#[test]
+fn elementwise_problem_one_bond_zero_update_keeps_right_frames_nonzero_dimensional() {
+    let input_a = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let input_b = TensorTrain::<f64>::constant(&[2, 2, 2], 3.0);
+    let options = AciOptions::<f64>::default();
+    let mut problem = ElementwiseProblem::new(vec![input_a, input_b], options.clone()).unwrap();
+    problem.update_left_frames(0, &[0]).unwrap();
+    for input in 0..problem.n_inputs() {
+        problem.right_frames[input][2] = None;
+    }
+    let mut operator = zero_batch;
+
+    problem
+        .local_update(1, false, &options, &mut operator)
+        .unwrap();
+
+    assert_solution_is_zero_on_binary_three_site_grid(&problem);
+    assert_eq!(problem.right_frame_shape(0, 2), Some((1, 1)));
+    assert_eq!(problem.right_frame_shape(1, 2), Some((1, 1)));
+    assert!(problem.local_input_value(0, 0, 0, 0).is_ok());
+
+    problem
+        .local_update(0, false, &options, &mut operator)
+        .unwrap();
+    assert_solution_is_zero_on_binary_three_site_grid(&problem);
 }
 
 #[test]

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -8,6 +8,12 @@ pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> R
         });
     }
 
+    if options.max_bond_dim == 0 {
+        return Err(AciError::InvalidOptions {
+            message: "max_bond_dim must be at least 1".to_string(),
+        });
+    }
+
     if options.min_iters > options.max_iters {
         return Err(AciError::InvalidOptions {
             message: format!(
@@ -33,6 +39,11 @@ pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<
 
     let site_dims = first.site_dims();
     let expected_len = site_dims.len();
+    if expected_len == 0 {
+        return Err(AciError::InvalidOptions {
+            message: "input tensor trains must have at least one site".to_string(),
+        });
+    }
 
     for input in &inputs[1..] {
         if input.len() != expected_len {

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -44,6 +44,7 @@ pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<
             message: "input tensor trains must have at least one site".to_string(),
         });
     }
+    validate_positive_site_dims(&site_dims)?;
 
     for input in &inputs[1..] {
         if input.len() != expected_len {
@@ -53,7 +54,10 @@ pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<
             });
         }
 
-        for (site, (expected, got)) in site_dims.iter().zip(input.site_dims()).enumerate() {
+        let input_site_dims = input.site_dims();
+        validate_positive_site_dims(&input_site_dims)?;
+
+        for (site, (expected, got)) in site_dims.iter().zip(input_site_dims).enumerate() {
             if *expected != got {
                 return Err(AciError::SiteDimMismatch {
                     site,
@@ -65,4 +69,15 @@ pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<
     }
 
     Ok(site_dims)
+}
+
+fn validate_positive_site_dims(site_dims: &[usize]) -> Result<()> {
+    for (site, &site_dim) in site_dims.iter().enumerate() {
+        if site_dim == 0 {
+            return Err(AciError::InvalidOptions {
+                message: format!("site {site} dimension must be positive, got 0"),
+            });
+        }
+    }
+    Ok(())
 }

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -1,0 +1,57 @@
+use crate::{AciError, Result};
+use tensor4all_simplett::{AbstractTensorTrain, TTScalar, TensorTrain};
+
+pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> Result<()> {
+    if options.max_iters == 0 {
+        return Err(AciError::InvalidOptions {
+            message: "max_iters must be at least 1".to_string(),
+        });
+    }
+
+    if options.min_iters > options.max_iters {
+        return Err(AciError::InvalidOptions {
+            message: format!(
+                "min_iters ({}) must be less than or equal to max_iters ({})",
+                options.min_iters, options.max_iters
+            ),
+        });
+    }
+
+    if !options.tolerance.is_finite() || options.tolerance < 0.0 {
+        return Err(AciError::InvalidOptions {
+            message: "tolerance must be finite and non-negative".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<Vec<usize>> {
+    let Some(first) = inputs.first() else {
+        return Err(AciError::EmptyInputs);
+    };
+
+    let site_dims = first.site_dims();
+    let expected_len = site_dims.len();
+
+    for input in &inputs[1..] {
+        if input.len() != expected_len {
+            return Err(AciError::LengthMismatch {
+                expected: expected_len,
+                got: input.len(),
+            });
+        }
+
+        for (site, (expected, got)) in site_dims.iter().zip(input.site_dims()).enumerate() {
+            if *expected != got {
+                return Err(AciError::SiteDimMismatch {
+                    site,
+                    expected: *expected,
+                    got,
+                });
+            }
+        }
+    }
+
+    Ok(site_dims)
+}

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -8,6 +8,12 @@ pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> R
         });
     }
 
+    if options.min_iters == 0 {
+        return Err(AciError::InvalidOptions {
+            message: "min_iters must be at least 1".to_string(),
+        });
+    }
+
     if options.max_bond_dim == 0 {
         return Err(AciError::InvalidOptions {
             message: "max_bond_dim must be at least 1".to_string(),

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -1,5 +1,5 @@
 use crate::{AciError, Result};
-use tensor4all_simplett::{AbstractTensorTrain, TTScalar, TensorTrain};
+use tensor4all_simplett::{AbstractTensorTrain, TTScalar, Tensor3Ops, TensorTrain};
 
 pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> Result<()> {
     if options.max_iters == 0 {
@@ -45,8 +45,10 @@ pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<
         });
     }
     validate_positive_site_dims(&site_dims)?;
+    validate_positive_core_dims(first, 0)?;
 
-    for input in &inputs[1..] {
+    for (input_index, input) in inputs[1..].iter().enumerate() {
+        let input_index = input_index + 1;
         if input.len() != expected_len {
             return Err(AciError::LengthMismatch {
                 expected: expected_len,
@@ -56,6 +58,7 @@ pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<
 
         let input_site_dims = input.site_dims();
         validate_positive_site_dims(&input_site_dims)?;
+        validate_positive_core_dims(input, input_index)?;
 
         for (site, (expected, got)) in site_dims.iter().zip(input_site_dims).enumerate() {
             if *expected != got {
@@ -76,6 +79,27 @@ fn validate_positive_site_dims(site_dims: &[usize]) -> Result<()> {
         if site_dim == 0 {
             return Err(AciError::InvalidOptions {
                 message: format!("site {site} dimension must be positive, got 0"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_positive_core_dims<T: TTScalar>(
+    input: &TensorTrain<T>,
+    input_index: usize,
+) -> Result<()> {
+    for site in 0..input.len() {
+        let core = input.site_tensor(site);
+        if core.left_dim() == 0 || core.site_dim() == 0 || core.right_dim() == 0 {
+            return Err(AciError::InvalidOptions {
+                message: format!(
+                    "input {input_index} site {site} core bond dimension must be positive, \
+                     got ({}, {}, {})",
+                    core.left_dim(),
+                    core.site_dim(),
+                    core.right_dim()
+                ),
             });
         }
     }

--- a/crates/tensor4all-aci/tests/elementwise.rs
+++ b/crates/tensor4all-aci/tests/elementwise.rs
@@ -1,0 +1,136 @@
+use approx::assert_abs_diff_eq;
+use tensor4all_aci::{elementwise, elementwise_batched, AciOptions, ElementwiseBatch};
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+fn exact_options() -> AciOptions<f64> {
+    AciOptions {
+        max_iters: 8,
+        min_iters: 2,
+        max_bond_dim: 8,
+        tolerance: 1e-12,
+        ..AciOptions::default()
+    }
+}
+
+fn assert_dense_close(actual: &TensorTrain<f64>, expected_shape: &[usize], expected: &[f64]) {
+    let (actual_data, actual_shape) = actual.fulltensor();
+    assert_eq!(actual_shape, expected_shape);
+    assert_eq!(actual_data.len(), expected.len());
+    for (actual_value, expected_value) in actual_data.iter().zip(expected) {
+        assert_abs_diff_eq!(actual_value, expected_value, epsilon = 1e-9);
+    }
+}
+
+fn dense_oracle2<F>(left: &TensorTrain<f64>, right: &TensorTrain<f64>, mut op: F) -> Vec<f64>
+where
+    F: FnMut(f64, f64) -> f64,
+{
+    let (left_data, left_shape) = left.fulltensor();
+    let (right_data, right_shape) = right.fulltensor();
+    assert_eq!(left_shape, right_shape);
+    left_data
+        .into_iter()
+        .zip(right_data)
+        .map(|(left_value, right_value)| op(left_value, right_value))
+        .collect()
+}
+
+fn col_major_index3(
+    left: usize,
+    site: usize,
+    right: usize,
+    left_dim: usize,
+    site_dim: usize,
+) -> usize {
+    left + left_dim * (site + site_dim * right)
+}
+
+fn two_site_tt_from_col_major(data: &[f64], shape: [usize; 2]) -> TestResult<TensorTrain<f64>> {
+    assert_eq!(data.len(), shape[0] * shape[1]);
+    let left_site_dim = shape[0];
+    let right_site_dim = shape[1];
+    let bond_dim = left_site_dim;
+
+    let mut left_core = vec![0.0; left_site_dim * bond_dim];
+    for site in 0..left_site_dim {
+        left_core[col_major_index3(0, site, site, 1, left_site_dim)] = 1.0;
+    }
+
+    let mut right_core = vec![0.0; bond_dim * right_site_dim];
+    for right_site in 0..right_site_dim {
+        for bond in 0..bond_dim {
+            let dense_index = bond + left_site_dim * right_site;
+            right_core[col_major_index3(bond, right_site, 0, bond_dim, right_site_dim)] =
+                data[dense_index];
+        }
+    }
+
+    Ok(TensorTrain::new(vec![
+        tensor3_from_data(left_core, 1, left_site_dim, bond_dim)?,
+        tensor3_from_data(right_core, bond_dim, right_site_dim, 1)?,
+    ])?)
+}
+
+#[test]
+fn dense_oracle_matches_rank_one_constant_multiplication() -> TestResult {
+    let left = TensorTrain::<f64>::constant(&[2, 3, 2], 2.5);
+    let right = TensorTrain::<f64>::constant(&[2, 3, 2], -4.0);
+    let expected = dense_oracle2(&left, &right, |left_value, right_value| {
+        left_value * right_value
+    });
+
+    let result = elementwise_batched(
+        |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+                *value = batch.get(0, point)? * batch.get(1, point)?;
+            }
+            Ok(())
+        },
+        &[left, right],
+        &exact_options(),
+    )?;
+
+    assert_eq!(result.tensor_train.site_dims(), vec![2, 3, 2]);
+    assert_dense_close(&result.tensor_train, &[2, 3, 2], &expected);
+    Ok(())
+}
+
+#[test]
+fn dense_oracle_matches_nonconstant_addition() -> TestResult {
+    let left = two_site_tt_from_col_major(&[1.0, -2.0, 3.0, 4.0, -5.0, 6.0], [2, 3])?;
+    let right = two_site_tt_from_col_major(&[0.5, 1.5, -3.0, 2.0, 8.0, -7.0], [2, 3])?;
+    let expected = dense_oracle2(&left, &right, |left_value, right_value| {
+        left_value + right_value
+    });
+
+    let result = elementwise(
+        |values| values[0] + values[1],
+        &[left, right],
+        &exact_options(),
+    )?;
+
+    assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+    assert_dense_close(&result.tensor_train, &[2, 3], &expected);
+    Ok(())
+}
+
+#[test]
+fn dense_oracle_matches_nonlinear_scalar_operation() -> TestResult {
+    let left = two_site_tt_from_col_major(&[0.0, 0.25, 0.5, 1.0, -0.75, 1.25], [2, 3])?;
+    let right = two_site_tt_from_col_major(&[2.0, -1.0, 0.5, -0.25, 1.5, -2.0], [2, 3])?;
+    let expected = dense_oracle2(&left, &right, |left_value, right_value| {
+        left_value.sin() + right_value * right_value
+    });
+
+    let result = elementwise(
+        |values| values[0].sin() + values[1] * values[1],
+        &[left, right],
+        &exact_options(),
+    )?;
+
+    assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+    assert_dense_close(&result.tensor_train, &[2, 3], &expected);
+    Ok(())
+}

--- a/crates/tensor4all-aci/tests/elementwise.rs
+++ b/crates/tensor4all-aci/tests/elementwise.rs
@@ -73,6 +73,56 @@ fn two_site_tt_from_col_major(data: &[f64], shape: [usize; 2]) -> TestResult<Ten
     ])?)
 }
 
+fn three_site_tt_from_col_major(data: &[f64], shape: [usize; 3]) -> TestResult<TensorTrain<f64>> {
+    assert_eq!(data.len(), shape.iter().product::<usize>());
+    let first_site_dim = shape[0];
+    let second_site_dim = shape[1];
+    let third_site_dim = shape[2];
+    let first_bond_dim = first_site_dim;
+    let second_bond_dim = first_site_dim * second_site_dim;
+
+    let mut first_core = vec![0.0; first_site_dim * first_bond_dim];
+    for first_site in 0..first_site_dim {
+        first_core[col_major_index3(0, first_site, first_site, 1, first_site_dim)] = 1.0;
+    }
+
+    let mut second_core = vec![0.0; first_bond_dim * second_site_dim * second_bond_dim];
+    for first_site in 0..first_site_dim {
+        for second_site in 0..second_site_dim {
+            let prefix = first_site + first_site_dim * second_site;
+            second_core[col_major_index3(
+                first_site,
+                second_site,
+                prefix,
+                first_bond_dim,
+                second_site_dim,
+            )] = 1.0;
+        }
+    }
+
+    let mut third_core = vec![0.0; second_bond_dim * third_site_dim];
+    for third_site in 0..third_site_dim {
+        for prefix in 0..second_bond_dim {
+            let dense_index = prefix + second_bond_dim * third_site;
+            third_core[col_major_index3(prefix, third_site, 0, second_bond_dim, third_site_dim)] =
+                data[dense_index];
+        }
+    }
+
+    let tensor_train = TensorTrain::new(vec![
+        tensor3_from_data(first_core, 1, first_site_dim, first_bond_dim)?,
+        tensor3_from_data(
+            second_core,
+            first_bond_dim,
+            second_site_dim,
+            second_bond_dim,
+        )?,
+        tensor3_from_data(third_core, second_bond_dim, third_site_dim, 1)?,
+    ])?;
+    assert_dense_close(&tensor_train, &shape, data);
+    Ok(tensor_train)
+}
+
 #[test]
 fn dense_oracle_matches_rank_one_constant_multiplication() -> TestResult {
     let left = TensorTrain::<f64>::constant(&[2, 3, 2], 2.5);
@@ -94,6 +144,34 @@ fn dense_oracle_matches_rank_one_constant_multiplication() -> TestResult {
 
     assert_eq!(result.tensor_train.site_dims(), vec![2, 3, 2]);
     assert_dense_close(&result.tensor_train, &[2, 3, 2], &expected);
+    Ok(())
+}
+
+#[test]
+fn dense_oracle_matches_nonconstant_three_site_batched_operation() -> TestResult {
+    let left =
+        three_site_tt_from_col_major(&[1.0, -2.0, 3.5, 4.25, -5.5, 6.75, 7.125, -8.25], [2, 2, 2])?;
+    let right =
+        three_site_tt_from_col_major(&[0.25, 1.5, -2.25, 3.0, 4.5, -5.75, 6.25, -7.5], [2, 2, 2])?;
+    let expected = dense_oracle2(&left, &right, |left_value, right_value| {
+        left_value * right_value + 0.5 * left_value - right_value
+    });
+
+    let result = elementwise_batched(
+        |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+            for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+                let left_value = batch.get(0, point)?;
+                let right_value = batch.get(1, point)?;
+                *value = left_value * right_value + 0.5 * left_value - right_value;
+            }
+            Ok(())
+        },
+        &[left, right],
+        &exact_options(),
+    )?;
+
+    assert_eq!(result.tensor_train.site_dims(), vec![2, 2, 2]);
+    assert_dense_close(&result.tensor_train, &[2, 2, 2], &expected);
     Ok(())
 }
 

--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -16,6 +16,12 @@ tenferro-cpu-faer = [
     "tenferro/cpu-faer",
     "tenferro-tensor/cpu-faer",
 ]
+tenferro-system-blas = [
+    "tensor4all-tensorbackend/tenferro-system-blas",
+    "tensor4all-tcicore/tenferro-system-blas",
+    "tenferro/cpu-blas",
+    "tenferro-tensor/cpu-blas",
+]
 tenferro-provider-inject = [
     "tensor4all-tensorbackend/tenferro-provider-inject",
     "tensor4all-tcicore/tenferro-provider-inject",

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -135,9 +135,9 @@ impl AnyScalar {
         rhs: &Self,
         op: &'static str,
         f: impl FnOnce(
-            &tenferro::EagerTensor<tenferro::CpuBackend>,
-            &tenferro::EagerTensor<tenferro::CpuBackend>,
-        ) -> std::result::Result<tenferro::EagerTensor<tenferro::CpuBackend>, E>,
+            &tenferro::EagerTensor,
+            &tenferro::EagerTensor,
+        ) -> std::result::Result<tenferro::EagerTensor, E>,
     ) -> Result<Self>
     where
         E: fmt::Display,
@@ -150,9 +150,7 @@ impl AnyScalar {
     fn from_eager_unary<E>(
         input: &Self,
         op: &'static str,
-        f: impl FnOnce(
-            &tenferro::EagerTensor<tenferro::CpuBackend>,
-        ) -> std::result::Result<tenferro::EagerTensor<tenferro::CpuBackend>, E>,
+        f: impl FnOnce(&tenferro::EagerTensor) -> std::result::Result<tenferro::EagerTensor, E>,
     ) -> Result<Self>
     where
         E: fmt::Display,

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -16,7 +16,7 @@ use crate::truncation::{
 };
 use crate::TensorDynLen;
 use std::sync::Mutex;
-use tenferro::{CpuBackend, DType, EagerTensor};
+use tenferro::{DType, EagerTensor};
 use tensor4all_tensorbackend::{
     native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,
 };
@@ -219,9 +219,9 @@ fn singular_values_from_native(tensor: &tenferro::Tensor) -> Result<Vec<f64>, Sv
 }
 
 type SvdTruncatedEagerResult = (
-    EagerTensor<CpuBackend>,
-    EagerTensor<CpuBackend>,
-    EagerTensor<CpuBackend>,
+    EagerTensor,
+    EagerTensor,
+    EagerTensor,
     Vec<f64>,
     DynIndex,
     Vec<DynIndex>,

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -15,9 +15,7 @@ use std::env;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tenferro::eager_tensor::einsum_subscripts as eager_einsum_ad;
-use tenferro::{
-    CpuBackend, DType, DotGeneralConfig, EagerTensor, EinsumSubscripts, Tensor as NativeTensor,
-};
+use tenferro::{DType, DotGeneralConfig, EagerTensor, EinsumSubscripts, Tensor as NativeTensor};
 use tensor4all_tensorbackend::{
     axpby_native_tensor, contract_native_tensor, default_eager_ctx,
     dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
@@ -216,7 +214,7 @@ pub fn compute_permutation_from_indices(
 
 #[derive(Clone)]
 pub(crate) struct StructuredAdValue {
-    payload: Arc<EagerTensor<CpuBackend>>,
+    payload: Arc<EagerTensor>,
     payload_dims: Vec<usize>,
     axis_classes: Vec<usize>,
 }
@@ -225,7 +223,7 @@ pub(crate) struct StructuredAdValue {
 pub(crate) enum TensorDynLenStorage {
     Materialized(Arc<Storage>),
     Eager {
-        inner: Arc<EagerTensor<CpuBackend>>,
+        inner: Arc<EagerTensor>,
         axis_classes: Vec<usize>,
     },
 }
@@ -235,14 +233,14 @@ impl TensorDynLenStorage {
         Self::Materialized(storage)
     }
 
-    fn from_eager_dense(inner: EagerTensor<CpuBackend>, rank: usize) -> Self {
+    fn from_eager_dense(inner: EagerTensor, rank: usize) -> Self {
         Self::Eager {
             inner: Arc::new(inner),
             axis_classes: TensorDynLen::dense_axis_classes(rank),
         }
     }
 
-    fn eager(&self) -> Option<&EagerTensor<CpuBackend>> {
+    fn eager(&self) -> Option<&EagerTensor> {
         match self {
             Self::Materialized(_) => None,
             Self::Eager { inner, .. } => Some(inner.as_ref()),
@@ -423,7 +421,7 @@ pub struct TensorDynLen {
     /// Optional tracked compact payload used to preserve structured AD layouts.
     pub(crate) structured_ad: Option<Arc<StructuredAdValue>>,
     /// Lazily materialized eager payload for native execution and AD.
-    pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>>,
+    pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor>>>,
 }
 
 impl TensorDynLen {
@@ -699,19 +697,17 @@ impl TensorDynLen {
         storage_to_native_tensor(storage, dims)
     }
 
-    fn empty_eager_cache() -> Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>> {
+    fn empty_eager_cache() -> Arc<OnceLock<Arc<EagerTensor>>> {
         Arc::new(OnceLock::new())
     }
 
-    fn eager_cache_with(
-        inner: EagerTensor<CpuBackend>,
-    ) -> Arc<OnceLock<Arc<EagerTensor<CpuBackend>>>> {
+    fn eager_cache_with(inner: EagerTensor) -> Arc<OnceLock<Arc<EagerTensor>>> {
         let cache = Arc::new(OnceLock::new());
         let _ = cache.set(Arc::new(inner));
         cache
     }
 
-    fn compact_payload_inner(&self) -> Result<EagerTensor<CpuBackend>> {
+    fn compact_payload_inner(&self) -> Result<EagerTensor> {
         Ok(EagerTensor::from_tensor_in(
             storage_payload_native(self.storage.materialize(self.indices.len())?.as_ref())?,
             default_eager_ctx(),
@@ -819,9 +815,9 @@ impl TensorDynLen {
     }
 
     fn normalize_eager_payload_for_roots(
-        payload: &EagerTensor<CpuBackend>,
+        payload: &EagerTensor,
         roots: &[usize],
-    ) -> Result<(Option<EagerTensor<CpuBackend>>, Vec<usize>)> {
+    ) -> Result<(Option<EagerTensor>, Vec<usize>)> {
         anyhow::ensure!(
             payload.data().shape().len() == roots.len(),
             "payload rank {} does not match root label count {}",
@@ -878,7 +874,7 @@ impl TensorDynLen {
 
     fn from_structured_payload_inner(
         indices: Vec<DynIndex>,
-        payload_inner: EagerTensor<CpuBackend>,
+        payload_inner: EagerTensor,
         payload_dims: Vec<usize>,
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
@@ -1352,7 +1348,7 @@ impl TensorDynLen {
         Ok(())
     }
 
-    fn try_materialized_inner(&self) -> Result<&EagerTensor<CpuBackend>> {
+    fn try_materialized_inner(&self) -> Result<&EagerTensor> {
         if let Some(value) = self.tracked_compact_payload_value() {
             if self.compact_payload_is_logical_dense(&value.payload_dims) {
                 return Ok(value.payload.as_ref());
@@ -1385,7 +1381,7 @@ impl TensorDynLen {
             })
     }
 
-    pub(crate) fn as_inner(&self) -> Result<&EagerTensor<CpuBackend>> {
+    pub(crate) fn as_inner(&self) -> Result<&EagerTensor> {
         self.try_materialized_inner()
     }
 
@@ -1807,17 +1803,14 @@ impl TensorDynLen {
         )
     }
 
-    pub(crate) fn from_inner(
-        indices: Vec<DynIndex>,
-        inner: EagerTensor<CpuBackend>,
-    ) -> Result<Self> {
+    pub(crate) fn from_inner(indices: Vec<DynIndex>, inner: EagerTensor) -> Result<Self> {
         let axis_classes = Self::dense_axis_classes(indices.len());
         Self::from_inner_with_axis_classes(indices, inner, axis_classes)
     }
 
     pub(crate) fn from_diag_inner(
         indices: Vec<DynIndex>,
-        payload_inner: EagerTensor<CpuBackend>,
+        payload_inner: EagerTensor,
     ) -> Result<Self> {
         let dims = Self::expected_dims_from_indices(&indices);
         Self::validate_indices(&indices)?;
@@ -1830,7 +1823,7 @@ impl TensorDynLen {
 
     pub(crate) fn from_inner_with_axis_classes(
         indices: Vec<DynIndex>,
-        inner: EagerTensor<CpuBackend>,
+        inner: EagerTensor,
         axis_classes: Vec<usize>,
     ) -> Result<Self> {
         let dims = profile_pairwise_contract_section("from_inner_expected_dims", || {
@@ -3250,7 +3243,7 @@ pub fn diag_tensor_dyn_len(indices: Vec<DynIndex>, diag_data: Vec<f64>) -> Resul
 
 #[allow(clippy::type_complexity)]
 pub(crate) type UnfoldSplitInnerResult = (
-    EagerTensor<CpuBackend>,
+    EagerTensor,
     usize,
     usize,
     usize,

--- a/crates/tensor4all-core/tests/send_sync.rs
+++ b/crates/tensor4all-core/tests/send_sync.rs
@@ -4,6 +4,6 @@ fn assert_send_sync<T: Send + Sync>() {}
 
 #[test]
 fn eager_tensor_and_tensordynlen_are_send_sync() {
-    assert_send_sync::<tenferro::EagerTensor<tenferro::CpuBackend>>();
+    assert_send_sync::<tenferro::EagerTensor>();
     assert_send_sync::<TensorDynLen>();
 }

--- a/crates/tensor4all-simplett/Cargo.toml
+++ b/crates/tensor4all-simplett/Cargo.toml
@@ -21,6 +21,13 @@ tenferro-cpu-faer = [
     "tenferro-einsum/cpu-faer",
     "tenferro-tensor/cpu-faer",
 ]
+tenferro-system-blas = [
+    "tensor4all-core/tenferro-system-blas",
+    "tensor4all-tcicore/tenferro-system-blas",
+    "tensor4all-tensorbackend/tenferro-system-blas",
+    "tenferro-einsum/cpu-blas",
+    "tenferro-tensor/cpu-blas",
+]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-tcicore/tenferro-provider-inject",

--- a/crates/tensor4all-tcicore/Cargo.toml
+++ b/crates/tensor4all-tcicore/Cargo.toml
@@ -14,6 +14,11 @@ tenferro-cpu-faer = [
     "tenferro-einsum/cpu-faer",
     "tenferro-tensor/cpu-faer",
 ]
+tenferro-system-blas = [
+    "tensor4all-tensorbackend/tenferro-system-blas",
+    "tenferro-einsum/cpu-blas",
+    "tenferro-tensor/cpu-blas",
+]
 tenferro-provider-inject = [
     "tensor4all-tensorbackend/tenferro-provider-inject",
     "tenferro-einsum/cpu-blas",

--- a/crates/tensor4all-tcicore/examples/benchmark_matrix_lu.rs
+++ b/crates/tensor4all-tcicore/examples/benchmark_matrix_lu.rs
@@ -1,0 +1,1 @@
+include!("../../../benchmarks/rust/benchmark_matrix_lu.rs");

--- a/crates/tensor4all-tcicore/src/lib.rs
+++ b/crates/tensor4all-tcicore/src/lib.rs
@@ -79,7 +79,8 @@ pub use cached_function::CachedFunction;
 pub use error::{MatrixCIError, Result};
 pub use indexset::{IndexSet, LocalIndex, MultiIndex};
 pub use matrix_luci::{
-    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix, MatrixLUCI, MatrixLuciFactors,
+    matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix,
+    matrix_luci_factors_from_matrix_owned, MatrixLUCI, MatrixLuciFactors,
 };
 pub use matrixaca::MatrixACA;
 pub use matrixlu::{rrlu, rrlu_inplace, RrLU, RrLUOptions};

--- a/crates/tensor4all-tcicore/src/matrix_luci.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci.rs
@@ -5,16 +5,15 @@
 //! via LU cross interpolation and implements [`AbstractMatrixCI`].
 
 use crate::error::{MatrixCIError, Result};
-use crate::matrixlu::RrLUOptions;
+use crate::matrixlu::{rrlu, RrLU, RrLUOptions};
 use crate::matrixluci::block_rook::LazyBlockRookKernel;
-use crate::matrixluci::dense::DenseLuKernel;
 use crate::matrixluci::factors::CrossFactors;
-use crate::matrixluci::source::{DenseMatrixSource, LazyMatrixSource};
+use crate::matrixluci::source::LazyMatrixSource;
 use crate::matrixluci::types::{PivotKernelOptions, PivotSelectionCore};
 use crate::matrixluci::PivotKernel;
 use crate::scalar::Scalar;
 use crate::traits::AbstractMatrixCI;
-use tensor4all_tensorbackend::Matrix;
+use tensor4all_tensorbackend::{mat_mul_owned, submatrix, triangular_solve_matrix_owned, Matrix};
 
 /// Matrix LU-based Cross Interpolation.
 ///
@@ -116,14 +115,14 @@ where
     T: Scalar + crate::MatrixLuciScalar,
 {
     let left = if left_orthogonal {
-        factors.cols_times_pivot_inv().map_err(map_backend_error)?
+        factors.cols_solve_pivot().map_err(map_backend_error)?
     } else {
         factors.pivot_cols.clone()
     };
     let right = if left_orthogonal {
         factors.pivot_rows.clone()
     } else {
-        factors.pivot_inv_times_rows().map_err(map_backend_error)?
+        factors.solve_pivot_rows().map_err(map_backend_error)?
     };
 
     Ok(MatrixLuciFactors {
@@ -136,27 +135,158 @@ where
     })
 }
 
+fn backend_linalg_error(message: impl Into<String>) -> MatrixCIError {
+    MatrixCIError::InvalidArgument {
+        message: message.into(),
+    }
+}
+
+fn index_range(start: usize, end: usize) -> Vec<usize> {
+    (start..end).collect()
+}
+
+fn identity_rect<T: Scalar>(nrows: usize, ncols: usize) -> Matrix<T> {
+    let mut result = Matrix::zeros(nrows, ncols);
+    for i in 0..nrows.min(ncols) {
+        result[[i, i]] = T::one();
+    }
+    result
+}
+
+fn apply_row_permutation<T: Scalar>(matrix: &Matrix<T>, permutation: &[usize]) -> Matrix<T> {
+    let mut result = Matrix::zeros(matrix.nrows(), matrix.ncols());
+    for col in 0..matrix.ncols() {
+        for (new_row, &old_row) in permutation.iter().enumerate().take(matrix.nrows()) {
+            result[[old_row, col]] = matrix[[new_row, col]];
+        }
+    }
+    result
+}
+
+fn apply_col_permutation<T: Scalar>(matrix: &Matrix<T>, permutation: &[usize]) -> Matrix<T> {
+    let mut result = Matrix::zeros(matrix.nrows(), matrix.ncols());
+    for (new_col, &old_col) in permutation.iter().enumerate().take(matrix.ncols()) {
+        for row in 0..matrix.nrows() {
+            result[[row, old_col]] = matrix[[row, new_col]];
+        }
+    }
+    result
+}
+
+pub(crate) fn rrlu_colmatrix<T>(lu: &RrLU<T>) -> Result<Matrix<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let rank = lu.npivots();
+    if rank == 0 {
+        return Ok(Matrix::zeros(lu.nrows(), 0));
+    }
+    let rows = index_range(0, rank);
+    let cols = index_range(0, rank);
+    let right_pivot_cols = submatrix(lu.right_unpermuted(), &rows, &cols);
+    mat_mul_owned(lu.left(true), right_pivot_cols)
+        .map_err(|err| backend_linalg_error(format!("MatrixLUCI colmatrix multiply failed: {err}")))
+}
+
+pub(crate) fn rrlu_rowmatrix<T>(lu: &RrLU<T>) -> Result<Matrix<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let rank = lu.npivots();
+    if rank == 0 {
+        return Ok(Matrix::zeros(0, lu.ncols()));
+    }
+    let rows = index_range(0, rank);
+    let cols = index_range(0, rank);
+    let left_pivot_rows = submatrix(lu.left_unpermuted(), &rows, &cols);
+    mat_mul_owned(left_pivot_rows, lu.right(true))
+        .map_err(|err| backend_linalg_error(format!("MatrixLUCI rowmatrix multiply failed: {err}")))
+}
+
+pub(crate) fn rrlu_cols_times_pivot_solve<T>(lu: &RrLU<T>) -> Result<Matrix<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let rank = lu.npivots();
+    let mut result = identity_rect(lu.nrows(), rank);
+    if rank > 0 && rank < lu.nrows() {
+        let pivot_rows = index_range(0, rank);
+        let pivot_cols = index_range(0, rank);
+        let rest_rows = index_range(rank, lu.nrows());
+        let pivot = submatrix(lu.left_unpermuted(), &pivot_rows, &pivot_cols);
+        let rest = submatrix(lu.left_unpermuted(), &rest_rows, &pivot_cols);
+        let solved = triangular_solve_matrix_owned(pivot, rest, false, true, false, false)
+            .map_err(|err| {
+                backend_linalg_error(format!("MatrixLUCI lower triangular solve failed: {err}"))
+            })?;
+        for row in 0..solved.nrows() {
+            for col in 0..solved.ncols() {
+                result[[rank + row, col]] = solved[[row, col]];
+            }
+        }
+    }
+    Ok(apply_row_permutation(&result, lu.row_permutation()))
+}
+
+pub(crate) fn rrlu_pivot_solve_times_rows<T>(lu: &RrLU<T>) -> Result<Matrix<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let rank = lu.npivots();
+    let mut result = identity_rect(rank, lu.ncols());
+    if rank > 0 && rank < lu.ncols() {
+        let pivot_rows = index_range(0, rank);
+        let pivot_cols = index_range(0, rank);
+        let rest_cols = index_range(rank, lu.ncols());
+        let pivot = submatrix(lu.right_unpermuted(), &pivot_rows, &pivot_cols);
+        let rest = submatrix(lu.right_unpermuted(), &pivot_rows, &rest_cols);
+        let solved = triangular_solve_matrix_owned(pivot, rest, true, false, false, false)
+            .map_err(|err| {
+                backend_linalg_error(format!("MatrixLUCI upper triangular solve failed: {err}"))
+            })?;
+        for row in 0..solved.nrows() {
+            for col in 0..solved.ncols() {
+                result[[row, rank + col]] = solved[[row, col]];
+            }
+        }
+    }
+    Ok(apply_col_permutation(&result, lu.col_permutation()))
+}
+
+fn factors_from_rrlu<T>(lu: &RrLU<T>) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let left = if lu.is_left_orthogonal() {
+        rrlu_cols_times_pivot_solve(lu)?
+    } else {
+        rrlu_colmatrix(lu)?
+    };
+    let right = if lu.is_left_orthogonal() {
+        rrlu_rowmatrix(lu)?
+    } else {
+        rrlu_pivot_solve_times_rows(lu)?
+    };
+
+    Ok(MatrixLuciFactors {
+        row_indices: lu.row_indices(),
+        col_indices: lu.col_indices(),
+        pivot_errors: lu.pivot_errors(),
+        rank: lu.npivots(),
+        left,
+        right,
+    })
+}
+
 pub(crate) fn dense_matrix_luci_factors_from_matrix<T>(
     a: &Matrix<T>,
     options: RrLUOptions,
 ) -> Result<MatrixLuciFactors<T>>
 where
     T: Scalar + crate::MatrixLuciScalar,
-    DenseLuKernel: PivotKernel<T>,
 {
-    let source = DenseMatrixSource::from_column_major(a.as_col_major_slice(), a.nrows(), a.ncols());
-    let kernel_options = PivotKernelOptions {
-        max_rank: options.max_rank,
-        rel_tol: options.rel_tol,
-        abs_tol: options.abs_tol,
-        left_orthogonal: options.left_orthogonal,
-    };
-
-    let selection = DenseLuKernel
-        .factorize(&source, &kernel_options)
-        .map_err(map_backend_error)?;
-    let factors = CrossFactors::from_source(&source, &selection).map_err(map_backend_error)?;
-    factors_to_public(selection, factors, options.left_orthogonal)
+    let lu = rrlu(a, Some(options))?;
+    factors_from_rrlu(&lu)
 }
 
 pub(crate) fn lazy_matrix_luci_factors_from_blocks<T, F>(

--- a/crates/tensor4all-tcicore/src/matrix_luci.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci.rs
@@ -5,7 +5,7 @@
 //! via LU cross interpolation and implements [`AbstractMatrixCI`].
 
 use crate::error::{MatrixCIError, Result};
-use crate::matrixlu::{rrlu, RrLU, RrLUOptions};
+use crate::matrixlu::{rrlu, rrlu_inplace, RrLU, RrLUOptions};
 use crate::matrixluci::block_rook::LazyBlockRookKernel;
 use crate::matrixluci::factors::CrossFactors;
 use crate::matrixluci::source::LazyMatrixSource;
@@ -289,6 +289,17 @@ where
     factors_from_rrlu(&lu)
 }
 
+pub(crate) fn dense_matrix_luci_factors_from_matrix_owned<T>(
+    mut a: Matrix<T>,
+    options: RrLUOptions,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    let lu = rrlu_inplace(&mut a, Some(options))?;
+    factors_from_rrlu(&lu)
+}
+
 pub(crate) fn lazy_matrix_luci_factors_from_blocks<T, F>(
     nrows: usize,
     ncols: usize,
@@ -359,6 +370,25 @@ where
     T: Scalar + crate::MatrixLuciScalar,
 {
     <T as crate::MatrixLuciScalar>::matrix_luci_factors_from_matrix(a, options.unwrap_or_default())
+}
+
+/// Factorize a dense matrix with MatrixLUCI while consuming the input matrix.
+///
+/// This is the owned-buffer counterpart of [`matrix_luci_factors_from_matrix`].
+/// It reuses the local matrix storage for the rrLU pivot selection step.
+///
+/// # Errors
+///
+/// Returns a [`MatrixCIError`] if the factorization fails, for example if the
+/// pivot block is singular or the backend rejects a factor solve.
+pub fn matrix_luci_factors_from_matrix_owned<T>(
+    a: Matrix<T>,
+    options: Option<RrLUOptions>,
+) -> Result<MatrixLuciFactors<T>>
+where
+    T: Scalar + crate::MatrixLuciScalar,
+{
+    dense_matrix_luci_factors_from_matrix_owned(a, options.unwrap_or_default())
 }
 
 /// Factorize a lazily supplied matrix with MatrixLUCI block-rook search.

--- a/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
@@ -226,7 +226,7 @@ fn timing_ms(duration: Duration) -> f64 {
 fn timing_median(mut values: Vec<f64>) -> f64 {
     values.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let mid = values.len() / 2;
-    if values.len() % 2 == 0 {
+    if values.len().is_multiple_of(2) {
         0.5 * (values[mid - 1] + values[mid])
     } else {
         values[mid]

--- a/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::rrlu;
+use std::time::{Duration, Instant};
 use tensor4all_tensorbackend::{from_vec2d, mat_mul};
 
 #[test]
@@ -117,4 +119,133 @@ fn test_matrixluci_rank_deficient() {
 
     let luci = MatrixLUCI::from_matrix(&m, None).unwrap();
     assert_eq!(luci.rank(), 1);
+}
+
+#[derive(Clone, Copy, Default)]
+struct MatrixLuciHilbertTiming {
+    selection: Duration,
+    gather: Duration,
+    left_factor: Duration,
+    right_factor: Duration,
+    rank: usize,
+    last_error: f64,
+    checksum: f64,
+}
+
+impl MatrixLuciHilbertTiming {
+    fn total(self) -> Duration {
+        self.selection + self.gather + self.left_factor + self.right_factor
+    }
+}
+
+fn hilbert_matrix(size: usize) -> Matrix<f64> {
+    let mut data = vec![0.0; size * size];
+    for col in 0..size {
+        for row in 0..size {
+            data[row + size * col] = 1.0 / ((row + col + 1) as f64);
+        }
+    }
+    Matrix::from_col_major_vec(size, size, data)
+}
+
+fn timed_hilbert_matrix_luci_once(size: usize, left_orthogonal: bool) -> MatrixLuciHilbertTiming {
+    let matrix = hilbert_matrix(size);
+    let options = RrLUOptions {
+        max_rank: usize::MAX,
+        rel_tol: 0.0,
+        abs_tol: 1.0e-10,
+        left_orthogonal,
+    };
+
+    let mut timing = MatrixLuciHilbertTiming::default();
+
+    let start = Instant::now();
+    let lu = rrlu(&matrix, Some(options)).unwrap();
+    timing.selection = start.elapsed();
+    timing.rank = lu.npivots();
+    timing.last_error = lu.pivot_errors().last().copied().unwrap_or(0.0);
+
+    let start = Instant::now();
+    let left = if left_orthogonal {
+        rrlu_cols_times_pivot_solve(&lu).unwrap()
+    } else {
+        rrlu_colmatrix(&lu).unwrap()
+    };
+    timing.left_factor = start.elapsed();
+
+    let start = Instant::now();
+    let right = if left_orthogonal {
+        rrlu_rowmatrix(&lu).unwrap()
+    } else {
+        rrlu_pivot_solve_times_rows(&lu).unwrap()
+    };
+    timing.right_factor = start.elapsed();
+
+    let left_checksum = if left.nrows() > 0 && left.ncols() > 0 {
+        left[[0, 0]].abs()
+    } else {
+        0.0
+    };
+    let right_checksum = if right.nrows() > 0 && right.ncols() > 0 {
+        right[[0, 0]].abs()
+    } else {
+        0.0
+    };
+    timing.checksum = left_checksum + right_checksum;
+    timing
+}
+
+fn timing_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+fn timing_median(mut values: Vec<f64>) -> f64 {
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mid = values.len() / 2;
+    if values.len() % 2 == 0 {
+        0.5 * (values[mid - 1] + values[mid])
+    } else {
+        values[mid]
+    }
+}
+
+#[test]
+#[ignore]
+fn matrix_luci_hilbert_timing() {
+    let repeats = std::env::var("T4A_MATRIX_LUCI_REPEATS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(20);
+    let sizes = std::env::var("T4A_MATRIX_LUCI_SIZES")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(|item| item.parse::<usize>().unwrap())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| vec![4, 8, 16, 32, 64]);
+
+    println!(
+        "impl,matrix,size,repeats,left_orthogonal,selection_ms,gather_ms,left_factor_ms,right_factor_ms,total_ms,rank,last_error,checksum"
+    );
+    for size in sizes {
+        for left_orthogonal in [true, false] {
+            let runs = (0..repeats)
+                .map(|_| timed_hilbert_matrix_luci_once(size, left_orthogonal))
+                .collect::<Vec<_>>();
+            let first = runs[0];
+            println!(
+                "rust,hilbert,{size},{repeats},{left_orthogonal},{:.6},{:.6},{:.6},{:.6},{:.6},{},{:.6e},{:.6e}",
+                timing_median(runs.iter().map(|run| timing_ms(run.selection)).collect()),
+                timing_median(runs.iter().map(|run| timing_ms(run.gather)).collect()),
+                timing_median(runs.iter().map(|run| timing_ms(run.left_factor)).collect()),
+                timing_median(runs.iter().map(|run| timing_ms(run.right_factor)).collect()),
+                timing_median(runs.iter().map(|run| timing_ms(run.total())).collect()),
+                first.rank,
+                first.last_error,
+                first.checksum,
+            );
+        }
+    }
 }

--- a/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
@@ -18,6 +18,30 @@ fn test_matrixluci_from_matrix() {
 }
 
 #[test]
+fn matrix_luci_factors_from_matrix_owned_matches_borrowed() {
+    let m = from_vec2d(vec![
+        vec![1.0, 2.0, 3.0],
+        vec![4.0, 5.0, 6.0],
+        vec![7.0, 8.0, 10.0],
+    ]);
+
+    let borrowed = matrix_luci_factors_from_matrix(&m, None).unwrap();
+    let owned = matrix_luci_factors_from_matrix_owned(m, None).unwrap();
+
+    assert_eq!(owned.rank, borrowed.rank);
+    assert_eq!(owned.row_indices, borrowed.row_indices);
+    assert_eq!(owned.col_indices, borrowed.col_indices);
+    assert_eq!(
+        owned.left.as_col_major_slice(),
+        borrowed.left.as_col_major_slice()
+    );
+    assert_eq!(
+        owned.right.as_col_major_slice(),
+        borrowed.right.as_col_major_slice()
+    );
+}
+
+#[test]
 fn test_matrixluci_reconstruct() {
     let m = from_vec2d(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
 

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -478,8 +478,8 @@ fn submatrix_argmax_col_major<T: Scalar>(
     let mut max_col = col_start;
 
     for col in col_start..col_end {
-        let mut offset = col_major_offset(nrows, row_start, col);
-        for row in row_start..row_end {
+        let col_start_offset = col_major_offset(nrows, row_start, col);
+        for (offset, row) in (col_start_offset..).zip(row_start..row_end) {
             // SAFETY: row and column loops stay within the prechecked region.
             let value = unsafe { *data.get_unchecked(offset) };
             let value_abs = value.abs_sq();
@@ -488,7 +488,6 @@ fn submatrix_argmax_col_major<T: Scalar>(
                 max_row = row;
                 max_col = col;
             }
-            offset += 1;
         }
     }
 

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -27,7 +27,7 @@
 
 use crate::error::{MatrixCIError, Result};
 use crate::scalar::Scalar;
-use tensor4all_tensorbackend::{submatrix_argmax, swap_cols, swap_rows, transpose, Matrix};
+use tensor4all_tensorbackend::{transpose, Matrix};
 
 /// Rank-Revealing LU decomposition.
 ///
@@ -432,6 +432,222 @@ impl<T: Scalar> RrLU<T> {
     }
 }
 
+#[inline]
+fn col_major_offset(nrows: usize, row: usize, col: usize) -> usize {
+    row + nrows * col
+}
+
+#[inline]
+fn col_major_get<T: Copy>(data: &[T], nrows: usize, row: usize, col: usize) -> T {
+    let offset = col_major_offset(nrows, row, col);
+    debug_assert!(row < nrows);
+    debug_assert!(offset < data.len());
+    // SAFETY: callers pass matrix-derived dimensions and prechecked ranges.
+    unsafe { *data.get_unchecked(offset) }
+}
+
+#[inline]
+fn col_major_set<T>(data: &mut [T], nrows: usize, row: usize, col: usize, value: T) {
+    let offset = col_major_offset(nrows, row, col);
+    debug_assert!(row < nrows);
+    debug_assert!(offset < data.len());
+    // SAFETY: callers pass matrix-derived dimensions and prechecked ranges.
+    unsafe {
+        *data.get_unchecked_mut(offset) = value;
+    }
+}
+
+fn submatrix_argmax_col_major<T: Scalar>(
+    data: &[T],
+    nrows: usize,
+    ncols: usize,
+    row_start: usize,
+    row_end: usize,
+    col_start: usize,
+    col_end: usize,
+) -> (usize, usize, T) {
+    debug_assert!(row_start < row_end);
+    debug_assert!(col_start < col_end);
+    debug_assert!(row_end <= nrows);
+    debug_assert!(col_end <= ncols);
+    debug_assert_eq!(data.len(), nrows * ncols);
+
+    let first = col_major_get(data, nrows, row_start, col_start);
+    let mut max_val = first.abs_sq();
+    let mut max_row = row_start;
+    let mut max_col = col_start;
+
+    for col in col_start..col_end {
+        let mut offset = col_major_offset(nrows, row_start, col);
+        for row in row_start..row_end {
+            // SAFETY: row and column loops stay within the prechecked region.
+            let value = unsafe { *data.get_unchecked(offset) };
+            let value_abs = value.abs_sq();
+            if value_abs > max_val {
+                max_val = value_abs;
+                max_row = row;
+                max_col = col;
+            }
+            offset += 1;
+        }
+    }
+
+    (
+        max_row,
+        max_col,
+        col_major_get(data, nrows, max_row, max_col),
+    )
+}
+
+fn swap_rows_col_major<T>(data: &mut [T], nrows: usize, ncols: usize, row_a: usize, row_b: usize) {
+    debug_assert!(row_a < nrows);
+    debug_assert!(row_b < nrows);
+    debug_assert_eq!(data.len(), nrows * ncols);
+    if row_a == row_b {
+        return;
+    }
+
+    let ptr = data.as_mut_ptr();
+    for col in 0..ncols {
+        let offset_a = col_major_offset(nrows, row_a, col);
+        let offset_b = col_major_offset(nrows, row_b, col);
+        // SAFETY: row_a/row_b are in range, and each column offset is within
+        // the matrix-sized backing slice.
+        unsafe {
+            std::ptr::swap(ptr.add(offset_a), ptr.add(offset_b));
+        }
+    }
+}
+
+fn swap_cols_col_major<T>(data: &mut [T], nrows: usize, ncols: usize, col_a: usize, col_b: usize) {
+    debug_assert!(col_a < ncols);
+    debug_assert!(col_b < ncols);
+    debug_assert_eq!(data.len(), nrows * ncols);
+    if col_a == col_b || nrows == 0 {
+        return;
+    }
+
+    let start_a = col_major_offset(nrows, 0, col_a);
+    let start_b = col_major_offset(nrows, 0, col_b);
+    // SAFETY: distinct columns are non-overlapping contiguous ranges of
+    // length nrows in column-major storage.
+    unsafe {
+        std::ptr::swap_nonoverlapping(
+            data.as_mut_ptr().add(start_a),
+            data.as_mut_ptr().add(start_b),
+            nrows,
+        );
+    }
+}
+
+fn scale_column_tail<T: Scalar>(
+    data: &mut [T],
+    nrows: usize,
+    col: usize,
+    row_start: usize,
+    pivot: T,
+) {
+    if row_start >= nrows {
+        return;
+    }
+    let start = col_major_offset(nrows, row_start, col);
+    let end = col_major_offset(nrows, nrows - 1, col) + 1;
+    for value in &mut data[start..end] {
+        *value = *value / pivot;
+    }
+}
+
+fn scale_row_tail<T: Scalar>(
+    data: &mut [T],
+    nrows: usize,
+    ncols: usize,
+    row: usize,
+    col_start: usize,
+    pivot: T,
+) {
+    for col in col_start..ncols {
+        let value = col_major_get(data, nrows, row, col) / pivot;
+        col_major_set(data, nrows, row, col, value);
+    }
+}
+
+fn update_trailing_submatrix<T: Scalar>(data: &mut [T], nrows: usize, ncols: usize, pivot: usize) {
+    let tail_row_start = pivot + 1;
+    let tail_col_start = pivot + 1;
+    if tail_row_start >= nrows || tail_col_start >= ncols {
+        return;
+    }
+
+    let tail_len = nrows - tail_row_start;
+    let pivot_col_tail_start = col_major_offset(nrows, tail_row_start, pivot);
+    for col in tail_col_start..ncols {
+        let y = col_major_get(data, nrows, pivot, col);
+        let target_start = col_major_offset(nrows, tail_row_start, col);
+        let (before_target, target_and_after) = data.split_at_mut(target_start);
+        let pivot_col_tail = &before_target[pivot_col_tail_start..pivot_col_tail_start + tail_len];
+        let target_tail = &mut target_and_after[..tail_len];
+        for (target, &x) in target_tail.iter_mut().zip(pivot_col_tail.iter()) {
+            *target = *target - x * y;
+        }
+    }
+}
+
+fn extract_lu_from_factorized<T: Scalar>(
+    data: &[T],
+    nrows: usize,
+    ncols: usize,
+    rank: usize,
+    left_orthogonal: bool,
+) -> Result<(Matrix<T>, Matrix<T>)> {
+    debug_assert!(rank <= nrows.min(ncols));
+    debug_assert_eq!(data.len(), nrows * ncols);
+
+    let mut l_data = vec![T::zero(); nrows * rank];
+    for col in 0..rank {
+        let src_start = col_major_offset(nrows, col, col);
+        let src_end = col_major_offset(nrows, nrows - 1, col) + 1;
+        let dst_start = col_major_offset(nrows, col, col);
+        l_data[dst_start..dst_start + (nrows - col)].copy_from_slice(&data[src_start..src_end]);
+    }
+
+    let mut u_data = vec![T::zero(); rank * ncols];
+    for col in 0..ncols {
+        let rows_to_copy = rank.min(col + 1);
+        if rows_to_copy > 0 {
+            let src_start = col_major_offset(nrows, 0, col);
+            let dst_start = col_major_offset(rank, 0, col);
+            u_data[dst_start..dst_start + rows_to_copy]
+                .copy_from_slice(&data[src_start..src_start + rows_to_copy]);
+        }
+    }
+
+    if left_orthogonal {
+        for i in 0..rank {
+            l_data[col_major_offset(nrows, i, i)] = T::one();
+        }
+    } else {
+        for i in 0..rank {
+            u_data[col_major_offset(rank, i, i)] = T::one();
+        }
+    }
+
+    if l_data.iter().any(|&value| value.is_nan()) {
+        return Err(MatrixCIError::NaNEncountered {
+            matrix: "L".to_string(),
+        });
+    }
+    if u_data.iter().any(|&value| value.is_nan()) {
+        return Err(MatrixCIError::NaNEncountered {
+            matrix: "U".to_string(),
+        });
+    }
+
+    Ok((
+        Matrix::from_col_major_vec(nrows, rank, l_data),
+        Matrix::from_col_major_vec(rank, ncols, u_data),
+    ))
+}
+
 /// Options for rank-revealing LU decomposition.
 ///
 /// # Examples
@@ -499,6 +715,8 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
     let opts = options.unwrap_or_default();
     let nr = a.nrows();
     let nc = a.ncols();
+    let data = a.as_col_major_mut_slice();
+    debug_assert_eq!(data.len(), nr * nc);
 
     let mut lu = RrLU::new(nr, nc, opts.left_orthogonal);
     let max_rank = opts.max_rank.min(nr).min(nc);
@@ -511,8 +729,8 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
             break;
         }
 
-        // Find pivot with maximum absolute value in submatrix
-        let (pivot_row, pivot_col, pivot_val) = submatrix_argmax(a, k..nr, k..nc);
+        let (pivot_row, pivot_col, pivot_val) =
+            submatrix_argmax_col_major(data, nr, nc, k, nr, k, nc);
 
         let pivot_abs = f64::sqrt(pivot_val.abs_sq());
         lu.error = pivot_abs;
@@ -542,93 +760,30 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
 
         // Swap rows and columns
         if pivot_row != k {
-            swap_rows(a, k, pivot_row);
+            swap_rows_col_major(data, nr, nc, k, pivot_row);
             lu.row_permutation.swap(k, pivot_row);
         }
         if pivot_col != k {
-            swap_cols(a, k, pivot_col);
+            swap_cols_col_major(data, nr, nc, k, pivot_col);
             lu.col_permutation.swap(k, pivot_col);
         }
 
-        let pivot = a[[k, k]];
+        let pivot = col_major_get(data, nr, k, k);
 
         // Eliminate
         if opts.left_orthogonal {
-            // Scale column below pivot
-            for i in (k + 1)..nr {
-                let val = a[[i, k]] / pivot;
-                a[[i, k]] = val;
-            }
+            scale_column_tail(data, nr, k, k + 1, pivot);
         } else {
-            // Scale row to the right of pivot
-            for j in (k + 1)..nc {
-                let val = a[[k, j]] / pivot;
-                a[[k, j]] = val;
-            }
+            scale_row_tail(data, nr, nc, k, k + 1, pivot);
         }
 
-        // Update submatrix: A[k+1:, k+1:] -= A[k+1:, k] * A[k, k+1:]
-        for j in (k + 1)..nc {
-            for i in (k + 1)..nr {
-                let x = a[[i, k]];
-                let y = a[[k, j]];
-                let old = a[[i, j]];
-                a[[i, j]] = old - x * y;
-            }
-        }
+        update_trailing_submatrix(data, nr, nc, k);
 
         lu.n_pivot += 1;
     }
 
-    // Extract L and U
     let n = lu.n_pivot;
-
-    // L is lower triangular part
-    let mut l = Matrix::zeros(nr, n);
-    for j in 0..n {
-        for i in j..nr {
-            l[[i, j]] = a[[i, j]];
-        }
-    }
-
-    // U is upper triangular part
-    let mut u = Matrix::zeros(n, nc);
-    for i in 0..n {
-        for j in i..nc {
-            u[[i, j]] = a[[i, j]];
-        }
-    }
-
-    // Set diagonal to 1 for the orthogonal factor
-    if opts.left_orthogonal {
-        for i in 0..n {
-            l[[i, i]] = T::one();
-        }
-    } else {
-        for i in 0..n {
-            u[[i, i]] = T::one();
-        }
-    }
-
-    // Check for NaNs (return error instead of panicking)
-    for i in 0..l.nrows() {
-        for j in 0..l.ncols() {
-            if l[[i, j]].is_nan() {
-                return Err(MatrixCIError::NaNEncountered {
-                    matrix: "L".to_string(),
-                });
-            }
-        }
-    }
-    for i in 0..u.nrows() {
-        for j in 0..u.ncols() {
-            if u[[i, j]].is_nan() {
-                return Err(MatrixCIError::NaNEncountered {
-                    matrix: "U".to_string(),
-                });
-            }
-        }
-    }
+    let (l, u) = extract_lu_from_factorized(data, nr, nc, n, opts.left_orthogonal)?;
 
     // Set error to 0 if full rank
     if n >= nr.min(nc) {

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -263,8 +263,8 @@ impl<T: Scalar> RrLU<T> {
     pub fn left(&self, permute: bool) -> Matrix<T> {
         if permute {
             let mut result = Matrix::zeros(self.l.nrows(), self.l.ncols());
-            for (new_i, &old_i) in self.row_permutation.iter().enumerate() {
-                for j in 0..self.l.ncols() {
+            for j in 0..self.l.ncols() {
+                for (new_i, &old_i) in self.row_permutation.iter().enumerate() {
                     result[[old_i, j]] = self.l[[new_i, j]];
                 }
             }
@@ -295,8 +295,8 @@ impl<T: Scalar> RrLU<T> {
     pub fn right(&self, permute: bool) -> Matrix<T> {
         if permute {
             let mut result = Matrix::zeros(self.u.nrows(), self.u.ncols());
-            for i in 0..self.u.nrows() {
-                for (new_j, &old_j) in self.col_permutation.iter().enumerate() {
+            for (new_j, &old_j) in self.col_permutation.iter().enumerate() {
+                for i in 0..self.u.nrows() {
                     result[[i, old_j]] = self.u[[i, new_j]];
                 }
             }
@@ -304,6 +304,14 @@ impl<T: Scalar> RrLU<T> {
         } else {
             self.u.clone()
         }
+    }
+
+    pub(crate) fn left_unpermuted(&self) -> &Matrix<T> {
+        &self.l
+    }
+
+    pub(crate) fn right_unpermuted(&self) -> &Matrix<T> {
+        &self.u
     }
 
     /// Get diagonal elements
@@ -560,8 +568,8 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
         }
 
         // Update submatrix: A[k+1:, k+1:] -= A[k+1:, k] * A[k, k+1:]
-        for i in (k + 1)..nr {
-            for j in (k + 1)..nc {
+        for j in (k + 1)..nc {
+            for i in (k + 1)..nr {
                 let x = a[[i, k]];
                 let y = a[[k, j]];
                 let old = a[[i, j]];
@@ -577,8 +585,8 @@ pub fn rrlu_inplace<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) 
 
     // L is lower triangular part
     let mut l = Matrix::zeros(nr, n);
-    for i in 0..nr {
-        for j in 0..n.min(i + 1) {
+    for j in 0..n {
+        for i in j..nr {
             l[[i, j]] = a[[i, j]];
         }
     }

--- a/crates/tensor4all-tcicore/src/matrixluci/block_rook.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/block_rook.rs
@@ -1,14 +1,14 @@
 //! Lazy pivot-kernel implementations.
 
 use crate::matrixluci::error::MatrixLuciError;
-use crate::matrixluci::factors::{invert_square, load_block, subtract_inplace};
+use crate::matrixluci::factors::{load_block, subtract_inplace};
 use crate::matrixluci::kernel::PivotKernel;
 use crate::matrixluci::scalar::Scalar;
 use crate::matrixluci::source::CandidateMatrixSource;
 use crate::matrixluci::types::{PivotKernelOptions, PivotSelectionCore};
 use crate::matrixluci::Result;
 use num_complex::{Complex32, Complex64};
-use tensor4all_tensorbackend::{mat_mul, Matrix};
+use tensor4all_tensorbackend::{mat_mul, solve_matrix, Matrix};
 
 /// Lazy pivot kernel based on residual row/column rook search.
 ///
@@ -24,23 +24,20 @@ fn residual_block<T: Scalar, S: CandidateMatrixSource<T>>(
     cols: &[usize],
     selected_rows: &[usize],
     selected_cols: &[usize],
-    pivot_inv: Option<&Matrix<T>>,
 ) -> Result<Matrix<T>> {
     let mut residual = load_block(source, rows, cols);
     if selected_rows.is_empty() {
         return Ok(residual);
     }
 
-    let pivot_inv = pivot_inv.ok_or_else(|| MatrixLuciError::InvalidArgument {
-        message: "pivot inverse is required after pivots have been selected".to_string(),
-    })?;
+    let pivot = load_block(source, selected_rows, selected_cols);
     let a_rj = load_block(source, rows, selected_cols);
     let a_ic = load_block(source, selected_rows, cols);
-    let temp = mat_mul(&a_rj, pivot_inv).map_err(|err| MatrixLuciError::InvalidArgument {
-        message: format!("residual left multiplication failed: {err}"),
+    let solved = solve_matrix(&pivot, &a_ic).map_err(|err| MatrixLuciError::InvalidArgument {
+        message: format!("residual pivot solve failed: {err}"),
     })?;
-    let approx = mat_mul(&temp, &a_ic).map_err(|err| MatrixLuciError::InvalidArgument {
-        message: format!("residual right multiplication failed: {err}"),
+    let approx = mat_mul(&a_rj, &solved).map_err(|err| MatrixLuciError::InvalidArgument {
+        message: format!("residual multiplication failed: {err}"),
     })?;
     subtract_inplace(&mut residual, &approx);
     Ok(residual)
@@ -77,7 +74,6 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
     remaining_cols: &[usize],
     selected_rows: &[usize],
     selected_cols: &[usize],
-    pivot_inv: Option<&Matrix<T>>,
 ) -> Result<(usize, usize, f64)> {
     let mut current_col = remaining_cols[0];
     let mut current_row = remaining_rows[0];
@@ -90,7 +86,6 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
             &[current_col],
             selected_rows,
             selected_cols,
-            pivot_inv,
         )?;
         let (best_row_pos, _, _) = argmax_abs(&col_residual);
         current_row = remaining_rows[best_row_pos];
@@ -101,7 +96,6 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
             remaining_cols,
             selected_rows,
             selected_cols,
-            pivot_inv,
         )?;
         let (_, best_col_pos, best_abs) = argmax_abs(&row_residual);
         let next_col = remaining_cols[best_col_pos];
@@ -118,7 +112,6 @@ fn rook_pivot<T: Scalar, S: CandidateMatrixSource<T>>(
         remaining_cols,
         selected_rows,
         selected_cols,
-        pivot_inv,
     )?;
     let (_, best_col_pos, best_abs) = argmax_abs(&row_residual);
     Ok((current_row, remaining_cols[best_col_pos], best_abs))
@@ -154,20 +147,12 @@ fn factorize_lazy<T: Scalar, S: CandidateMatrixSource<T>>(
             break;
         }
 
-        let pivot_inv = if selected_rows.is_empty() {
-            None
-        } else {
-            let pivot = load_block(source, &selected_rows, &selected_cols);
-            Some(invert_square(&pivot)?)
-        };
-
         let (pivot_row, pivot_col, pivot_abs) = rook_pivot(
             source,
             &remaining_rows,
             &remaining_cols,
             &selected_rows,
             &selected_cols,
-            pivot_inv.as_ref(),
         )?;
         last_error = pivot_abs;
 

--- a/crates/tensor4all-tcicore/src/matrixluci/dense/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/dense/tests.rs
@@ -1,4 +1,6 @@
-use crate::matrixluci::{DenseLuKernel, DenseMatrixSource, PivotKernel, PivotKernelOptions};
+use crate::matrixluci::{
+    DenseLuKernel, DenseMatrixSource, LazyMatrixSource, PivotKernel, PivotKernelOptions,
+};
 use crate::{rrlu, RrLUOptions};
 use approx::assert_abs_diff_eq;
 use tensor4all_tensorbackend::from_vec2d;
@@ -24,6 +26,71 @@ fn dense_kernel_reports_zero_rank_for_zero_matrix() {
         .factorize(&src, &PivotKernelOptions::no_truncation())
         .unwrap();
     assert_eq!(out.rank, 0);
+}
+
+#[test]
+fn pivot_errors_cover_empty_and_zero_pivot_stops() {
+    assert_eq!(
+        DenseLuKernel::compute_pivot_errors(&[], 0, 3, &PivotKernelOptions::default()),
+        vec![0.0]
+    );
+    assert_eq!(
+        DenseLuKernel::compute_pivot_errors(
+            &[2.0, 0.0],
+            2,
+            2,
+            &PivotKernelOptions::no_truncation()
+        ),
+        vec![2.0, 0.0]
+    );
+    assert_eq!(
+        DenseLuKernel::compute_pivot_errors(&[0.0], 1, 1, &PivotKernelOptions::default()),
+        vec![0.0]
+    );
+}
+
+#[test]
+fn dense_kernel_uses_rectangular_rrlu_fallback() {
+    let out = dense_factorize(
+        &[vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 7.0]],
+        PivotKernelOptions::no_truncation(),
+    );
+
+    assert_eq!(out.rank, 2);
+    assert_eq!(out.row_indices.len(), 2);
+    assert_eq!(out.col_indices.len(), 2);
+    assert_eq!(out.pivot_errors.last().copied(), Some(0.0));
+}
+
+#[test]
+fn dense_kernel_materializes_lazy_source() {
+    let data = col_major_from_rows(&[vec![1.0, 0.0], vec![0.0, 1.0]]);
+    let source = LazyMatrixSource::new(2, 2, |rows: &[usize], cols: &[usize], out: &mut [f64]| {
+        for (j, &col) in cols.iter().enumerate() {
+            for (i, &row) in rows.iter().enumerate() {
+                out[i + rows.len() * j] = data[row + 2 * col];
+            }
+        }
+    });
+
+    let out = DenseLuKernel
+        .factorize(&source, &PivotKernelOptions::no_truncation())
+        .unwrap();
+
+    assert_eq!(out.rank, 2);
+    assert_eq!(out.row_indices, vec![0, 1]);
+    assert_eq!(out.col_indices, vec![0, 1]);
+}
+
+#[test]
+fn permutation_indices_reject_invalid_permutation_rows() {
+    let multiple =
+        DenseLuKernel::permutation_indices_from_matrix(&[1.0, 0.0, 1.0, 1.0], 2, "P").unwrap_err();
+    assert!(multiple.to_string().contains("multiple entries"));
+
+    let missing =
+        DenseLuKernel::permutation_indices_from_matrix(&[0.0, 0.0, 0.0, 1.0], 2, "Q").unwrap_err();
+    assert!(missing.to_string().contains("no entry"));
 }
 
 fn col_major_from_rows(rows: &[Vec<f64>]) -> Vec<f64> {

--- a/crates/tensor4all-tcicore/src/matrixluci/factors.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/factors.rs
@@ -9,7 +9,7 @@ use crate::matrixluci::scalar::Scalar;
 use crate::matrixluci::source::CandidateMatrixSource;
 use crate::matrixluci::types::PivotSelectionCore;
 use crate::matrixluci::Result;
-use tensor4all_tensorbackend::{mat_mul, solve_matrix, Matrix};
+use tensor4all_tensorbackend::{solve_matrix, transpose, Matrix};
 
 /// Gather a dense column-major block from a source.
 pub(crate) fn load_block<T: Scalar, S: CandidateMatrixSource<T>>(
@@ -31,25 +31,6 @@ pub(crate) fn subtract_inplace<T: Scalar>(lhs: &mut Matrix<T>, rhs: &Matrix<T>) 
             lhs[[i, j]] = lhs[[i, j]] - rhs[[i, j]];
         }
     }
-}
-
-/// Invert a square dense matrix via the configured tensor backend.
-pub(crate) fn invert_square<T: Scalar>(matrix: &Matrix<T>) -> Result<Matrix<T>> {
-    if matrix.nrows() != matrix.ncols() {
-        return Err(MatrixLuciError::InvalidArgument {
-            message: "pivot block must be square".to_string(),
-        });
-    }
-
-    let n = matrix.nrows();
-    let mut identity = Matrix::zeros(n, n);
-    for i in 0..n {
-        identity[[i, i]] = T::one();
-    }
-
-    solve_matrix(matrix, &identity).map_err(|err| MatrixLuciError::InvalidArgument {
-        message: format!("pivot block solve failed: {err}"),
-    })
 }
 
 /// Dense factors derived from a pivot selection.
@@ -93,24 +74,24 @@ impl<T: Scalar> CrossFactors<T> {
         })
     }
 
-    /// Invert the pivot block.
-    pub fn pivot_inverse(&self) -> Result<Matrix<T>> {
-        invert_square(&self.pivot)
+    /// Solve for `A[:, J] * A[I, J]^{-1}` without forming an explicit inverse.
+    pub fn cols_solve_pivot(&self) -> Result<Matrix<T>> {
+        let pivot_t = transpose(&self.pivot);
+        let pivot_cols_t = transpose(&self.pivot_cols);
+        let solved_t = solve_matrix(&pivot_t, &pivot_cols_t).map_err(|err| {
+            MatrixLuciError::InvalidArgument {
+                message: format!("left factor solve failed: {err}"),
+            }
+        })?;
+        Ok(transpose(&solved_t))
     }
 
-    /// Form `A[:, J] * A[I, J]^{-1}`.
-    pub fn cols_times_pivot_inv(&self) -> Result<Matrix<T>> {
-        let pivot_inv = self.pivot_inverse()?;
-        mat_mul(&self.pivot_cols, &pivot_inv).map_err(|err| MatrixLuciError::InvalidArgument {
-            message: format!("left factor multiplication failed: {err}"),
-        })
-    }
-
-    /// Form `A[I, J]^{-1} * A[I, :]`.
-    pub fn pivot_inv_times_rows(&self) -> Result<Matrix<T>> {
-        let pivot_inv = self.pivot_inverse()?;
-        mat_mul(&pivot_inv, &self.pivot_rows).map_err(|err| MatrixLuciError::InvalidArgument {
-            message: format!("right factor multiplication failed: {err}"),
+    /// Solve for `A[I, J]^{-1} * A[I, :]` without forming an explicit inverse.
+    pub fn solve_pivot_rows(&self) -> Result<Matrix<T>> {
+        solve_matrix(&self.pivot, &self.pivot_rows).map_err(|err| {
+            MatrixLuciError::InvalidArgument {
+                message: format!("right factor solve failed: {err}"),
+            }
         })
     }
 }

--- a/crates/tensor4all-tcicore/src/matrixluci/factors/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/factors/tests.rs
@@ -61,8 +61,8 @@ fn reconstruct_cross_factors_can_form_inverse_scaled_factors() {
         .unwrap();
 
     let factors = CrossFactors::from_source(&src, &selection).unwrap();
-    let left = factors.cols_times_pivot_inv().unwrap();
-    let right = factors.pivot_inv_times_rows().unwrap();
+    let left = factors.cols_solve_pivot().unwrap();
+    let right = factors.solve_pivot_rows().unwrap();
 
     assert_eq!(left.nrows(), 4);
     assert_eq!(left.ncols(), selection.rank);

--- a/crates/tensor4all-tcicore/src/matrixluci/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/mod.rs
@@ -6,6 +6,7 @@
 //! the internal rrLU implementation for rectangular fallback coverage.
 
 pub(crate) mod block_rook;
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) mod dense;
 pub(crate) mod error;
 pub(crate) mod factors;

--- a/crates/tensor4all-tcicore/src/matrixluci/scalar.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/scalar.rs
@@ -6,7 +6,9 @@ use num_traits::{Float, One, Zero};
 use crate::error::Result;
 use crate::matrix_luci::MatrixLuciFactors;
 use crate::matrixlu::RrLUOptions;
-use tensor4all_tensorbackend::{BackendLinalgScalar, Matrix, MatrixScalar, MatrixSolveScalar};
+use tensor4all_tensorbackend::{
+    BackendLinalgScalar, Matrix, MatrixScalar, MatrixSolveScalar, MatrixTriangularSolveScalar,
+};
 
 /// Common scalar trait for matrix LUCI operations.
 pub trait Scalar:
@@ -25,6 +27,7 @@ pub trait Scalar:
     + BackendLinalgScalar
     + MatrixScalar
     + MatrixSolveScalar
+    + MatrixTriangularSolveScalar
     + 'static
 {
     /// Complex conjugate.

--- a/crates/tensor4all-tcicore/src/matrixluci/source.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/source.rs
@@ -23,6 +23,7 @@ pub(crate) trait CandidateMatrixSource<T: Scalar> {
     fn get_block(&self, rows: &[usize], cols: &[usize], out: &mut [T]);
 
     /// Borrow the whole matrix in column-major layout when available.
+    #[allow(dead_code)]
     fn dense_column_major_slice(&self) -> Option<&[T]> {
         None
     }
@@ -39,6 +40,7 @@ pub(crate) trait CandidateMatrixSource<T: Scalar> {
 /// Borrowed dense matrix source with column-major layout.
 ///
 /// Wraps a column-major data slice for use with pivot kernels.
+#[allow(dead_code)]
 pub(crate) struct DenseMatrixSource<'a, T: Scalar> {
     data: &'a [T],
     nrows: usize,
@@ -59,6 +61,7 @@ pub(crate) struct LazyMatrixSource<T: Scalar, F> {
 
 impl<'a, T: Scalar> DenseMatrixSource<'a, T> {
     /// Create a dense source from a column-major slice.
+    #[allow(dead_code)]
     pub fn from_column_major(data: &'a [T], nrows: usize, ncols: usize) -> Self {
         assert_eq!(data.len(), nrows * ncols);
         Self { data, nrows, ncols }
@@ -121,6 +124,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn materialize_source<T: Scalar, S: CandidateMatrixSource<T>>(source: &S) -> Matrix<T> {
     let nrows = source.nrows();
     let ncols = source.ncols();

--- a/crates/tensor4all-tcicore/src/matrixluci/types.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/types.rs
@@ -15,6 +15,7 @@ pub(crate) struct PivotKernelOptions {
     /// Maximum rank.
     pub max_rank: usize,
     /// Whether the left factor is unit-diagonal.
+    #[allow(dead_code)]
     pub left_orthogonal: bool,
 }
 

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["science", "mathematics"]
 default = ["backend-tenferro", "tenferro-cpu-faer"]
 backend-tenferro = []
 tenferro-cpu-faer = ["tenferro/cpu-faer"]
+tenferro-system-blas = ["tenferro/cpu-blas", "tenferro-tensor/cpu-blas"]
 tenferro-provider-inject = ["tenferro/cpu-blas", "tenferro-tensor/provider-inject"]
 einsum-dispatch-profile = []
 

--- a/crates/tensor4all-tensorbackend/src/backend.rs
+++ b/crates/tensor4all-tensorbackend/src/backend.rs
@@ -108,27 +108,192 @@ impl<T: TensorScalar> BackendLinalgScalar for T {}
 pub trait MatrixSolveScalar: BackendLinalgScalar + crate::matrix::MatrixScalar {
     #[doc(hidden)]
     fn solve_matrix_impl(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>>;
+
+    #[doc(hidden)]
+    fn solve_matrix_owned_impl(a: Matrix<Self>, b: Matrix<Self>) -> Result<Matrix<Self>> {
+        Self::solve_matrix_impl(&a, &b)
+    }
+}
+
+/// Scalar types supported by [`triangular_solve_matrix`].
+///
+/// `f64` and `Complex64` are solved directly. `f32` and `Complex32` are
+/// promoted to the corresponding 64-bit dtype for the backend solve and then
+/// converted back, because the current tenferro CPU triangular solve is double
+/// precision only.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{from_vec2d, triangular_solve_matrix};
+///
+/// let a = from_vec2d(vec![vec![2.0_f64, 0.0], vec![1.0, 3.0]]);
+/// let b = from_vec2d(vec![vec![2.0_f64], vec![7.0]]);
+/// let x = triangular_solve_matrix(&a, &b, true, true, false, false).unwrap();
+/// assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
+/// assert!((x[[1, 0]] - 2.0).abs() < 1.0e-12);
+/// ```
+pub trait MatrixTriangularSolveScalar: BackendLinalgScalar + crate::matrix::MatrixScalar {
+    #[doc(hidden)]
+    fn triangular_solve_matrix_impl(
+        a: &Matrix<Self>,
+        b: &Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>>;
+
+    #[doc(hidden)]
+    fn triangular_solve_matrix_owned_impl(
+        a: Matrix<Self>,
+        b: Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        Self::triangular_solve_matrix_impl(&a, &b, left_side, lower, transpose_a, unit_diagonal)
+    }
 }
 
 fn solve_matrix_direct<T>(a: &Matrix<T>, b: &Matrix<T>) -> Result<Matrix<T>>
 where
     T: BackendLinalgScalar + Copy,
+    Tensor: From<TypedTensor<T>>,
 {
-    let a_tensor = matrix_to_typed_tensor(a);
-    let b_tensor = matrix_to_typed_tensor(b);
-    let x = solve_backend(&a_tensor, &b_tensor)?;
+    solve_matrix_direct_owned(a.clone(), b.clone())
+}
+
+fn solve_matrix_direct_owned<T>(a: Matrix<T>, b: Matrix<T>) -> Result<Matrix<T>>
+where
+    T: BackendLinalgScalar + Copy,
+    Tensor: From<TypedTensor<T>>,
+{
+    let a_tensor: Tensor = a.into_typed_tensor().into();
+    let b_tensor: Tensor = b.into_typed_tensor().into();
+    let result = with_default_backend(|backend| a_tensor.solve(&b_tensor, backend))
+        .map_err(|e| anyhow!("linear solve failed via tenferro-tensor: {e}"))?;
+    let x = try_into_typed_result::<T>("solve", result)?;
     typed_tensor_to_matrix("solve", x)
+}
+
+fn triangular_solve_matrix_direct<T>(
+    a: &Matrix<T>,
+    b: &Matrix<T>,
+    left_side: bool,
+    lower: bool,
+    transpose_a: bool,
+    unit_diagonal: bool,
+) -> Result<Matrix<T>>
+where
+    T: BackendLinalgScalar + Copy,
+    Tensor: From<TypedTensor<T>>,
+{
+    triangular_solve_matrix_direct_owned(
+        a.clone(),
+        b.clone(),
+        left_side,
+        lower,
+        transpose_a,
+        unit_diagonal,
+    )
+}
+
+fn triangular_solve_matrix_direct_owned<T>(
+    a: Matrix<T>,
+    b: Matrix<T>,
+    left_side: bool,
+    lower: bool,
+    transpose_a: bool,
+    unit_diagonal: bool,
+) -> Result<Matrix<T>>
+where
+    T: BackendLinalgScalar + Copy,
+    Tensor: From<TypedTensor<T>>,
+{
+    let a_tensor: Tensor = a.into_typed_tensor().into();
+    let b_tensor: Tensor = b.into_typed_tensor().into();
+    let result = with_default_backend(|backend| {
+        a_tensor.triangular_solve(
+            &b_tensor,
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+            backend,
+        )
+    })
+    .map_err(|e| anyhow!("triangular solve failed via tenferro-tensor: {e}"))?;
+    let x = try_into_typed_result::<T>("triangular_solve", result)?;
+    typed_tensor_to_matrix("triangular_solve", x)
 }
 
 impl MatrixSolveScalar for f64 {
     fn solve_matrix_impl(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>> {
         solve_matrix_direct(a, b)
     }
+
+    fn solve_matrix_owned_impl(a: Matrix<Self>, b: Matrix<Self>) -> Result<Matrix<Self>> {
+        solve_matrix_direct_owned(a, b)
+    }
+}
+
+impl MatrixTriangularSolveScalar for f64 {
+    fn triangular_solve_matrix_impl(
+        a: &Matrix<Self>,
+        b: &Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        triangular_solve_matrix_direct(a, b, left_side, lower, transpose_a, unit_diagonal)
+    }
+
+    fn triangular_solve_matrix_owned_impl(
+        a: Matrix<Self>,
+        b: Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        triangular_solve_matrix_direct_owned(a, b, left_side, lower, transpose_a, unit_diagonal)
+    }
 }
 
 impl MatrixSolveScalar for Complex64 {
     fn solve_matrix_impl(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>> {
         solve_matrix_direct(a, b)
+    }
+
+    fn solve_matrix_owned_impl(a: Matrix<Self>, b: Matrix<Self>) -> Result<Matrix<Self>> {
+        solve_matrix_direct_owned(a, b)
+    }
+}
+
+impl MatrixTriangularSolveScalar for Complex64 {
+    fn triangular_solve_matrix_impl(
+        a: &Matrix<Self>,
+        b: &Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        triangular_solve_matrix_direct(a, b, left_side, lower, transpose_a, unit_diagonal)
+    }
+
+    fn triangular_solve_matrix_owned_impl(
+        a: Matrix<Self>,
+        b: Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        triangular_solve_matrix_direct_owned(a, b, left_side, lower, transpose_a, unit_diagonal)
     }
 }
 
@@ -162,6 +327,50 @@ impl MatrixSolveScalar for f32 {
     }
 }
 
+impl MatrixTriangularSolveScalar for f32 {
+    fn triangular_solve_matrix_impl(
+        a: &Matrix<Self>,
+        b: &Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        let a64 = Matrix::from_col_major_vec(
+            a.nrows(),
+            a.ncols(),
+            a.as_col_major_slice()
+                .iter()
+                .map(|&value| value as f64)
+                .collect(),
+        );
+        let b64 = Matrix::from_col_major_vec(
+            b.nrows(),
+            b.ncols(),
+            b.as_col_major_slice()
+                .iter()
+                .map(|&value| value as f64)
+                .collect(),
+        );
+        let x64 = triangular_solve_matrix_direct(
+            &a64,
+            &b64,
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+        )?;
+        Ok(Matrix::from_col_major_vec(
+            x64.nrows(),
+            x64.ncols(),
+            x64.as_col_major_slice()
+                .iter()
+                .map(|&value| value as f32)
+                .collect(),
+        ))
+    }
+}
+
 impl MatrixSolveScalar for Complex32 {
     fn solve_matrix_impl(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>> {
         let a64 = Matrix::from_col_major_vec(
@@ -181,6 +390,50 @@ impl MatrixSolveScalar for Complex32 {
                 .collect(),
         );
         let x64 = solve_matrix_direct(&a64, &b64)?;
+        Ok(Matrix::from_col_major_vec(
+            x64.nrows(),
+            x64.ncols(),
+            x64.as_col_major_slice()
+                .iter()
+                .map(|&value| Complex32::new(value.re as f32, value.im as f32))
+                .collect(),
+        ))
+    }
+}
+
+impl MatrixTriangularSolveScalar for Complex32 {
+    fn triangular_solve_matrix_impl(
+        a: &Matrix<Self>,
+        b: &Matrix<Self>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> Result<Matrix<Self>> {
+        let a64 = Matrix::from_col_major_vec(
+            a.nrows(),
+            a.ncols(),
+            a.as_col_major_slice()
+                .iter()
+                .map(|&value| Complex64::new(value.re as f64, value.im as f64))
+                .collect(),
+        );
+        let b64 = Matrix::from_col_major_vec(
+            b.nrows(),
+            b.ncols(),
+            b.as_col_major_slice()
+                .iter()
+                .map(|&value| Complex64::new(value.re as f64, value.im as f64))
+                .collect(),
+        );
+        let x64 = triangular_solve_matrix_direct(
+            &a64,
+            &b64,
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+        )?;
         Ok(Matrix::from_col_major_vec(
             x64.nrows(),
             x64.ncols(),
@@ -236,17 +489,7 @@ fn typed_tensor_to_matrix<T>(op: &'static str, tensor: TypedTensor<T>) -> Result
 where
     T: TensorScalar + Copy,
 {
-    if tensor.shape.len() != 2 {
-        return Err(anyhow!(
-            "{op}: expected a rank-2 tensor, got shape {:?}",
-            tensor.shape
-        ));
-    }
-    Ok(Matrix::from_col_major_vec(
-        tensor.shape[0],
-        tensor.shape[1],
-        tensor.as_slice().to_vec(),
-    ))
+    Matrix::try_from_typed_tensor(tensor).map_err(|err| anyhow!("{op}: {err}"))
 }
 
 /// Compute a thin/economy SVD on a typed tensor.
@@ -300,6 +543,43 @@ where
     try_into_typed_result::<T>("solve", result)
 }
 
+/// Solve a triangular system with the configured tenferro backend.
+///
+/// If `left_side` is true, this solves `op(A) X = B`; otherwise it solves
+/// `X op(A) = B`. `lower` selects the triangular half, `transpose_a` applies
+/// a transpose to `A`, and `unit_diagonal` treats the diagonal of `A` as ones.
+///
+/// # Errors
+///
+/// Returns an error if the backend rejects the input shapes, scalar dtype, or
+/// triangular solve flags.
+pub fn triangular_solve_backend<T>(
+    a: &TypedTensor<T>,
+    b: &TypedTensor<T>,
+    left_side: bool,
+    lower: bool,
+    transpose_a: bool,
+    unit_diagonal: bool,
+) -> Result<TypedTensor<T>>
+where
+    T: BackendLinalgScalar,
+{
+    let a_tensor = T::into_tensor(a.shape.clone(), a.host_data().to_vec());
+    let b_tensor = T::into_tensor(b.shape.clone(), b.host_data().to_vec());
+    let result = with_default_backend(|backend| {
+        a_tensor.triangular_solve(
+            &b_tensor,
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+            backend,
+        )
+    })
+    .map_err(|e| anyhow!("triangular solve failed via tenferro-tensor: {e}"))?;
+    try_into_typed_result::<T>("triangular_solve", result)
+}
+
 /// Solve `A X = B` for column-major [`Matrix`] values.
 ///
 /// This routes the operation through the configured tenferro backend and keeps
@@ -326,6 +606,107 @@ where
     T: MatrixSolveScalar,
 {
     T::solve_matrix_impl(a, b)
+}
+
+/// Solve `A X = B` while consuming column-major [`Matrix`] values.
+///
+/// This routes the operation through the configured tenferro backend and reuses
+/// the input buffers when constructing backend tensors for directly supported
+/// scalar types.
+///
+/// # Errors
+///
+/// Returns an error if the backend rejects the input shapes, scalar dtype, or
+/// coefficient matrix.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{from_vec2d, solve_matrix_owned};
+///
+/// let a = from_vec2d(vec![vec![2.0_f64, 1.0], vec![1.0, 2.0]]);
+/// let b = from_vec2d(vec![vec![1.0_f64], vec![0.0]]);
+/// let x = solve_matrix_owned(a, b).unwrap();
+/// assert!((x[[0, 0]] - 2.0 / 3.0).abs() < 1.0e-12);
+/// assert!((x[[1, 0]] + 1.0 / 3.0).abs() < 1.0e-12);
+/// ```
+pub fn solve_matrix_owned<T>(a: Matrix<T>, b: Matrix<T>) -> Result<Matrix<T>>
+where
+    T: MatrixSolveScalar,
+{
+    T::solve_matrix_owned_impl(a, b)
+}
+
+/// Solve a triangular system for column-major [`Matrix`] values.
+///
+/// If `left_side` is true, this solves `op(A) X = B`; otherwise it solves
+/// `X op(A) = B`. `lower` selects the triangular half, `transpose_a` applies
+/// a transpose to `A`, and `unit_diagonal` treats the diagonal of `A` as ones.
+///
+/// # Errors
+///
+/// Returns an error if the backend rejects the input shapes, scalar dtype,
+/// triangular solve flags, or coefficient matrix.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{from_vec2d, triangular_solve_matrix};
+///
+/// let a = from_vec2d(vec![vec![2.0_f64, 1.0], vec![0.0, 3.0]]);
+/// let b = from_vec2d(vec![vec![2.0_f64, 7.0]]);
+/// let x = triangular_solve_matrix(&a, &b, false, false, false, false).unwrap();
+/// assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
+/// assert!((x[[0, 1]] - 2.0).abs() < 1.0e-12);
+/// ```
+pub fn triangular_solve_matrix<T>(
+    a: &Matrix<T>,
+    b: &Matrix<T>,
+    left_side: bool,
+    lower: bool,
+    transpose_a: bool,
+    unit_diagonal: bool,
+) -> Result<Matrix<T>>
+where
+    T: MatrixTriangularSolveScalar,
+{
+    T::triangular_solve_matrix_impl(a, b, left_side, lower, transpose_a, unit_diagonal)
+}
+
+/// Solve a triangular system while consuming column-major [`Matrix`] values.
+///
+/// If `left_side` is true, this solves `op(A) X = B`; otherwise it solves
+/// `X op(A) = B`. `lower` selects the triangular half, `transpose_a` applies
+/// a transpose to `A`, and `unit_diagonal` treats the diagonal of `A` as ones.
+///
+/// # Errors
+///
+/// Returns an error if the backend rejects the input shapes, scalar dtype,
+/// triangular solve flags, or coefficient matrix.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{from_vec2d, triangular_solve_matrix_owned};
+///
+/// let a = from_vec2d(vec![vec![2.0_f64, 0.0], vec![1.0, 3.0]]);
+/// let b = from_vec2d(vec![vec![2.0_f64], vec![7.0]]);
+/// let x = triangular_solve_matrix_owned(a, b, true, true, false, false).unwrap();
+/// assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
+/// assert!((x[[1, 0]] - 2.0).abs() < 1.0e-12);
+/// ```
+pub fn triangular_solve_matrix_owned<T>(
+    a: Matrix<T>,
+    b: Matrix<T>,
+    left_side: bool,
+    lower: bool,
+    transpose_a: bool,
+    unit_diagonal: bool,
+) -> Result<Matrix<T>>
+where
+    T: MatrixTriangularSolveScalar,
+{
+    T::triangular_solve_matrix_owned_impl(a, b, left_side, lower, transpose_a, unit_diagonal)
 }
 
 /// Compute complete-pivoting LU with the configured tenferro backend.

--- a/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
@@ -131,6 +131,19 @@ fn solve_matrix_solves_real_system() {
 }
 
 #[test]
+fn solve_matrix_owned_solves_real_system() {
+    let a = crate::from_vec2d(vec![vec![2.0_f64, 1.0], vec![1.0, 2.0]]);
+    let b = crate::from_vec2d(vec![vec![1.0_f64], vec![0.0]]);
+
+    let x = solve_matrix_owned(a, b).unwrap();
+
+    assert_eq!(x.nrows(), 2);
+    assert_eq!(x.ncols(), 1);
+    assert!((x[[0, 0]] - 2.0 / 3.0).abs() < 1.0e-12);
+    assert!((x[[1, 0]] + 1.0 / 3.0).abs() < 1.0e-12);
+}
+
+#[test]
 fn solve_matrix_promotes_f32_system() {
     let a = crate::from_vec2d(vec![vec![2.0_f32, 1.0], vec![1.0, 2.0]]);
     let b = crate::from_vec2d(vec![vec![1.0_f32], vec![0.0]]);
@@ -158,6 +171,45 @@ fn solve_matrix_promotes_complex32_system() {
     assert!((x[[1, 0]].re + 1.0 / 3.0).abs() < 1.0e-6);
     assert!(x[[0, 0]].im.abs() < 1.0e-6);
     assert!(x[[1, 0]].im.abs() < 1.0e-6);
+}
+
+#[test]
+fn triangular_solve_matrix_solves_left_lower_system() {
+    let a = crate::from_vec2d(vec![vec![2.0_f64, 0.0], vec![1.0, 3.0]]);
+    let b = crate::from_vec2d(vec![vec![2.0_f64], vec![7.0]]);
+
+    let x = triangular_solve_matrix(&a, &b, true, true, false, false).unwrap();
+
+    assert_eq!(x.nrows(), 2);
+    assert_eq!(x.ncols(), 1);
+    assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
+    assert!((x[[1, 0]] - 2.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn triangular_solve_matrix_owned_solves_left_lower_system() {
+    let a = crate::from_vec2d(vec![vec![2.0_f64, 0.0], vec![1.0, 3.0]]);
+    let b = crate::from_vec2d(vec![vec![2.0_f64], vec![7.0]]);
+
+    let x = triangular_solve_matrix_owned(a, b, true, true, false, false).unwrap();
+
+    assert_eq!(x.nrows(), 2);
+    assert_eq!(x.ncols(), 1);
+    assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
+    assert!((x[[1, 0]] - 2.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn triangular_solve_matrix_solves_right_upper_system() {
+    let a = crate::from_vec2d(vec![vec![2.0_f64, 1.0], vec![0.0, 3.0]]);
+    let b = crate::from_vec2d(vec![vec![2.0_f64, 7.0]]);
+
+    let x = triangular_solve_matrix(&a, &b, false, false, false, false).unwrap();
+
+    assert_eq!(x.nrows(), 1);
+    assert_eq!(x.ncols(), 2);
+    assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
+    assert!((x[[0, 1]] - 2.0).abs() < 1.0e-12);
 }
 
 #[test]

--- a/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
@@ -144,6 +144,36 @@ fn solve_matrix_owned_solves_real_system() {
 }
 
 #[test]
+fn solve_matrix_owned_promotes_f32_system() {
+    let a = crate::from_vec2d(vec![vec![2.0_f32, 1.0], vec![1.0, 2.0]]);
+    let b = crate::from_vec2d(vec![vec![1.0_f32], vec![0.0]]);
+
+    let x = solve_matrix_owned(a, b).unwrap();
+
+    assert!((x[[0, 0]] - 2.0 / 3.0).abs() < 1.0e-6);
+    assert!((x[[1, 0]] + 1.0 / 3.0).abs() < 1.0e-6);
+}
+
+#[test]
+fn solve_matrix_owned_solves_complex64_system() {
+    let a = crate::from_vec2d(vec![
+        vec![Complex64::new(2.0, 0.0), Complex64::new(1.0, 0.0)],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    ]);
+    let b = crate::from_vec2d(vec![
+        vec![Complex64::new(1.0, 0.0)],
+        vec![Complex64::new(0.0, 0.0)],
+    ]);
+
+    let x = solve_matrix_owned(a, b).unwrap();
+
+    assert!((x[[0, 0]].re - 2.0 / 3.0).abs() < 1.0e-12);
+    assert!((x[[1, 0]].re + 1.0 / 3.0).abs() < 1.0e-12);
+    assert!(x[[0, 0]].im.abs() < 1.0e-12);
+    assert!(x[[1, 0]].im.abs() < 1.0e-12);
+}
+
+#[test]
 fn solve_matrix_promotes_f32_system() {
     let a = crate::from_vec2d(vec![vec![2.0_f32, 1.0], vec![1.0, 2.0]]);
     let b = crate::from_vec2d(vec![vec![1.0_f32], vec![0.0]]);
@@ -210,6 +240,76 @@ fn triangular_solve_matrix_solves_right_upper_system() {
     assert_eq!(x.ncols(), 2);
     assert!((x[[0, 0]] - 1.0).abs() < 1.0e-12);
     assert!((x[[0, 1]] - 2.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn triangular_solve_matrix_owned_promotes_f32_system() {
+    let a = crate::from_vec2d(vec![vec![2.0_f32, 0.0], vec![1.0, 3.0]]);
+    let b = crate::from_vec2d(vec![vec![2.0_f32], vec![7.0]]);
+
+    let x = triangular_solve_matrix_owned(a, b, true, true, false, false).unwrap();
+
+    assert!((x[[0, 0]] - 1.0).abs() < 1.0e-6);
+    assert!((x[[1, 0]] - 2.0).abs() < 1.0e-6);
+}
+
+#[test]
+fn triangular_solve_matrix_promotes_complex32_system() {
+    let a = crate::from_vec2d(vec![
+        vec![Complex32::new(2.0, 0.0), Complex32::new(0.0, 0.0)],
+        vec![Complex32::new(1.0, 0.0), Complex32::new(3.0, 0.0)],
+    ]);
+    let b = crate::from_vec2d(vec![
+        vec![Complex32::new(2.0, 0.0)],
+        vec![Complex32::new(7.0, 0.0)],
+    ]);
+
+    let x = triangular_solve_matrix(&a, &b, true, true, false, false).unwrap();
+
+    assert!((x[[0, 0]].re - 1.0).abs() < 1.0e-6);
+    assert!((x[[1, 0]].re - 2.0).abs() < 1.0e-6);
+    assert!(x[[0, 0]].im.abs() < 1.0e-6);
+    assert!(x[[1, 0]].im.abs() < 1.0e-6);
+}
+
+#[test]
+fn triangular_solve_matrix_owned_solves_complex64_system() {
+    let a = crate::from_vec2d(vec![
+        vec![Complex64::new(2.0, 0.0), Complex64::new(0.0, 0.0)],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(3.0, 0.0)],
+    ]);
+    let b = crate::from_vec2d(vec![
+        vec![Complex64::new(2.0, 0.0)],
+        vec![Complex64::new(7.0, 0.0)],
+    ]);
+
+    let x = triangular_solve_matrix_owned(a, b, true, true, false, false).unwrap();
+
+    assert!((x[[0, 0]].re - 1.0).abs() < 1.0e-12);
+    assert!((x[[1, 0]].re - 2.0).abs() < 1.0e-12);
+    assert!(x[[0, 0]].im.abs() < 1.0e-12);
+    assert!(x[[1, 0]].im.abs() < 1.0e-12);
+}
+
+#[test]
+fn triangular_solve_backend_solves_typed_tensor_system() {
+    let a = TypedTensor::from_vec(vec![2, 2], vec![2.0_f64, 1.0, 0.0, 3.0]);
+    let b = TypedTensor::from_vec(vec![2, 1], vec![2.0_f64, 7.0]);
+
+    let x = triangular_solve_backend(&a, &b, true, true, false, false).unwrap();
+
+    assert_eq!(x.shape, vec![2, 1]);
+    assert!((x.as_slice()[0] - 1.0).abs() < 1.0e-12);
+    assert!((x.as_slice()[1] - 2.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn try_into_typed_result_reports_dtype_mismatch() {
+    let tensor = Complex64::into_tensor(vec![1], vec![Complex64::new(1.0, 0.0)]);
+
+    let err = try_into_typed_result::<f64>("test_op", tensor).unwrap_err();
+
+    assert!(err.to_string().contains("test_op: dtype mismatch"));
 }
 
 #[test]

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -4,7 +4,7 @@
 //! `CpuContext`, matching tenferro's `cpu:0` default-global thread-pool model.
 //! Plain tensor operations, cached traced execution, and eager AD currently use
 //! separate `CpuBackend` values because tenferro does not yet expose a public
-//! API for borrowing the backend owned by an `EagerContext<CpuBackend>`. All
+//! API for borrowing the backend owned by an `EagerContext`. All
 //! backends are created from the same global CPU context, so thread-pool
 //! configuration is shared.
 
@@ -17,7 +17,7 @@ use tenferro_tensor::cpu::CpuContext;
 static DEFAULT_CPU_CONTEXT: OnceLock<Arc<CpuContext>> = OnceLock::new();
 static DEFAULT_BACKEND: OnceLock<Mutex<CpuBackend>> = OnceLock::new();
 static DEFAULT_ENGINE: OnceLock<Mutex<Engine<CpuBackend>>> = OnceLock::new();
-static DEFAULT_EAGER_CTX: OnceLock<Arc<EagerContext<CpuBackend>>> = OnceLock::new();
+static DEFAULT_EAGER_CTX: OnceLock<Arc<EagerContext>> = OnceLock::new();
 
 fn default_cpu_context() -> Arc<CpuContext> {
     DEFAULT_CPU_CONTEXT
@@ -87,9 +87,11 @@ pub(crate) fn reset_default_engine() {
 /// This context owns a separate `CpuBackend` from [`with_default_backend`] and
 /// the cached execution engine, but all backends share the same process-global
 /// tenferro CPU context.
-pub fn default_eager_ctx() -> Arc<EagerContext<CpuBackend>> {
+pub fn default_eager_ctx() -> Arc<EagerContext> {
     DEFAULT_EAGER_CTX
-        .get_or_init(|| EagerContext::with_backend(CpuBackend::from_context(default_cpu_context())))
+        .get_or_init(|| {
+            EagerContext::with_cpu_backend(CpuBackend::from_context(default_cpu_context()))
+        })
         .clone()
 }
 

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -36,8 +36,9 @@ pub use backend::{
 };
 pub use context::{default_eager_ctx, with_default_backend};
 pub use matrix::{
-    batched_mat_mul_same_shape, from_vec2d, mat_mul, mat_mul_owned, submatrix, submatrix_argmax,
-    swap_cols, swap_rows, transpose, BlasMul, Matrix, MatrixScalar, MatrixTensorConversionError,
+    batched_mat_mul_same_shape, batched_mat_mul_same_shape_owned, from_vec2d, mat_mul,
+    mat_mul_owned, submatrix, submatrix_argmax, swap_cols, swap_rows, transpose, BlasMul, Matrix,
+    MatrixScalar, MatrixTensorConversionError,
 };
 pub use memory::{release_process_allocator_cached_memory, AllocatorPressureRelief};
 pub use storage::{

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -29,13 +29,15 @@ mod tensor_element;
 
 pub use any_scalar::AnyScalar;
 pub use backend::{
-    full_piv_lu_backend, full_piv_lu_matrix, qr_backend, solve_backend, solve_matrix, svd_backend,
-    BackendLinalgScalar, FullPivLuMatrixResult, FullPivLuResult, MatrixSolveScalar, SvdResult,
+    full_piv_lu_backend, full_piv_lu_matrix, qr_backend, solve_backend, solve_matrix,
+    solve_matrix_owned, svd_backend, triangular_solve_backend, triangular_solve_matrix,
+    triangular_solve_matrix_owned, BackendLinalgScalar, FullPivLuMatrixResult, FullPivLuResult,
+    MatrixSolveScalar, MatrixTriangularSolveScalar, SvdResult,
 };
 pub use context::{default_eager_ctx, with_default_backend};
 pub use matrix::{
-    from_vec2d, mat_mul, submatrix, submatrix_argmax, swap_cols, swap_rows, transpose, BlasMul,
-    Matrix, MatrixScalar,
+    batched_mat_mul_same_shape, from_vec2d, mat_mul, mat_mul_owned, submatrix, submatrix_argmax,
+    swap_cols, swap_rows, transpose, BlasMul, Matrix, MatrixScalar, MatrixTensorConversionError,
 };
 pub use memory::{release_process_allocator_cached_memory, AllocatorPressureRelief};
 pub use storage::{

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -118,6 +118,24 @@ impl<T> Matrix<T> {
         &self.data
     }
 
+    /// View the underlying column-major data as a mutable contiguous slice.
+    ///
+    /// The slice uses `row + nrows * col` ordering. This is useful for kernels
+    /// that validate dimensions once and then operate over contiguous columns.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Matrix;
+    ///
+    /// let mut m = Matrix::from_col_major_vec(2, 2, vec![1, 3, 2, 4]);
+    /// m.as_col_major_mut_slice()[1] = 30;
+    /// assert_eq!(m[[1, 0]], 30);
+    /// ```
+    pub fn as_col_major_mut_slice(&mut self) -> &mut [T] {
+        &mut self.data
+    }
+
     /// Consume the matrix and return its owned column-major buffer.
     ///
     /// The returned buffer uses `row + nrows * col` ordering. Use this when
@@ -348,13 +366,27 @@ pub fn from_vec2d<T: Clone + Zero>(data: Vec<Vec<T>>) -> Matrix<T> {
 /// assert_eq!(sub[[1, 1]], 9.0); // m[2, 2]
 /// ```
 pub fn submatrix<T: Clone + Zero>(m: &Matrix<T>, rows: &[usize], cols: &[usize]) -> Matrix<T> {
-    let mut result = Matrix::zeros(rows.len(), cols.len());
-    for (ci, &c) in cols.iter().enumerate() {
-        for (ri, &r) in rows.iter().enumerate() {
-            result[[ri, ci]] = m[[r, c]].clone();
+    assert!(
+        rows.iter().all(|&row| row < m.nrows),
+        "submatrix row index out of bounds"
+    );
+    assert!(
+        cols.iter().all(|&col| col < m.ncols),
+        "submatrix column index out of bounds"
+    );
+
+    let mut data = Vec::with_capacity(rows.len() * cols.len());
+    let source = m.as_col_major_slice();
+    for &col in cols {
+        let col_start = col * m.nrows;
+        for &row in rows {
+            let offset = col_start + row;
+            // SAFETY: rows and cols are range-checked above, and Matrix stores
+            // exactly nrows * ncols values in column-major order.
+            data.push(unsafe { source.get_unchecked(offset).clone() });
         }
     }
-    result
+    Matrix::from_col_major_vec(rows.len(), cols.len(), data)
 }
 
 /// Swap two rows in a matrix in-place.
@@ -375,10 +407,13 @@ pub fn swap_rows<T>(m: &mut Matrix<T>, a: usize, b: usize) {
     if a == b {
         return;
     }
-    for j in 0..m.ncols {
-        let idx_a = m.offset(a, j);
-        let idx_b = m.offset(b, j);
-        m.data.swap(idx_a, idx_b);
+    assert!(a < m.nrows, "row index out of bounds");
+    assert!(b < m.nrows, "row index out of bounds");
+    let nrows = m.nrows;
+    let ncols = m.ncols;
+    let data = m.as_col_major_mut_slice();
+    for j in 0..ncols {
+        data.swap(a + nrows * j, b + nrows * j);
     }
 }
 
@@ -400,10 +435,18 @@ pub fn swap_cols<T>(m: &mut Matrix<T>, a: usize, b: usize) {
     if a == b {
         return;
     }
-    for i in 0..m.nrows {
-        let idx_a = m.offset(i, a);
-        let idx_b = m.offset(i, b);
-        m.data.swap(idx_a, idx_b);
+    assert!(a < m.ncols, "column index out of bounds");
+    assert!(b < m.ncols, "column index out of bounds");
+    let nrows = m.nrows;
+    let start_a = nrows * a;
+    let start_b = nrows * b;
+    let data = m.as_col_major_mut_slice();
+    if start_a < start_b {
+        let (left, right) = data.split_at_mut(start_b);
+        left[start_a..start_a + nrows].swap_with_slice(&mut right[..nrows]);
+    } else {
+        let (left, right) = data.split_at_mut(start_a);
+        right[..nrows].swap_with_slice(&mut left[start_b..start_b + nrows]);
     }
 }
 
@@ -462,8 +505,14 @@ pub fn submatrix_argmax<T: MatrixScalar>(
 ) -> (usize, usize, T) {
     assert!(!rows.is_empty(), "rows must not be empty");
     assert!(!cols.is_empty(), "cols must not be empty");
+    assert!(rows.end <= a.nrows, "row range out of bounds");
+    assert!(cols.end <= a.ncols, "column range out of bounds");
 
-    let mut max_val: f64 = a[[rows.start, cols.start]].matrix_abs_sq();
+    let data = a.as_col_major_slice();
+    let first_offset = rows.start + a.nrows * cols.start;
+    // SAFETY: the non-empty ranges are checked against the matrix shape above.
+    let first = unsafe { *data.get_unchecked(first_offset) };
+    let mut max_val: f64 = first.matrix_abs_sq();
     let mut max_row = rows.start;
     let mut max_col = cols.start;
     let row_start = rows.start;
@@ -472,17 +521,23 @@ pub fn submatrix_argmax<T: MatrixScalar>(
     let col_end = cols.end;
 
     for c in col_start..col_end {
+        let mut offset = row_start + a.nrows * c;
         for r in row_start..row_end {
-            let val: f64 = a[[r, c]].matrix_abs_sq();
+            // SAFETY: row and column loops stay within the checked ranges.
+            let value = unsafe { *data.get_unchecked(offset) };
+            let val: f64 = value.matrix_abs_sq();
             if val > max_val {
                 max_val = val;
                 max_row = r;
                 max_col = c;
             }
+            offset += 1;
         }
     }
 
-    (max_row, max_col, a[[max_row, max_col]])
+    let max_offset = max_row + a.nrows * max_col;
+    // SAFETY: max_row/max_col were selected from the checked ranges.
+    (max_row, max_col, unsafe { *data.get_unchecked(max_offset) })
 }
 
 /// BLAS-backed matrix multiplication dispatch.
@@ -717,32 +772,37 @@ pub fn batched_mat_mul_same_shape<T>(
 where
     T: tenferro::TensorScalar + Copy,
 {
+    batched_mat_mul_same_shape_owned(batch, m, k, n, a.to_vec(), b.to_vec())
+}
+
+/// Batched matrix multiplication while consuming column-major input buffers.
+///
+/// This is the owned-buffer counterpart of [`batched_mat_mul_same_shape`].
+/// It avoids cloning the two input batches when callers have just built the
+/// contiguous buffers for a backend call.
+///
+/// # Errors
+///
+/// Returns an error if the input buffer lengths do not match the declared
+/// shapes or if the backend rejects the batched GEMM.
+pub fn batched_mat_mul_same_shape_owned<T>(
+    batch: usize,
+    m: usize,
+    k: usize,
+    n: usize,
+    a: Vec<T>,
+    b: Vec<T>,
+) -> Result<Vec<T>>
+where
+    T: tenferro::TensorScalar + Copy,
+{
     use crate::with_default_backend;
     use tenferro::{DotGeneralConfig, TensorBackend};
 
-    let a_len = batch
-        .checked_mul(m)
-        .and_then(|value| value.checked_mul(k))
-        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication left shape overflows"))?;
-    let b_len = batch
-        .checked_mul(k)
-        .and_then(|value| value.checked_mul(n))
-        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication right shape overflows"))?;
-    ensure!(
-        a.len() == a_len,
-        "batched matrix multiplication left buffer has length {}, expected {}",
-        a.len(),
-        a_len
-    );
-    ensure!(
-        b.len() == b_len,
-        "batched matrix multiplication right buffer has length {}, expected {}",
-        b.len(),
-        b_len
-    );
+    validate_batched_mat_mul_inputs(batch, m, k, n, a.len(), b.len())?;
 
-    let a_tensor = T::into_tensor(vec![m, k, batch], a.to_vec());
-    let b_tensor = T::into_tensor(vec![k, n, batch], b.to_vec());
+    let a_tensor = T::into_tensor(vec![m, k, batch], a);
+    let b_tensor = T::into_tensor(vec![k, n, batch], b);
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -755,7 +815,7 @@ where
     .context("batched matrix multiplication failed")?;
     let c = T::try_into_typed(c)
         .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication returned wrong dtype"))?;
-    let data = c.as_slice().to_vec();
+    let (_shape, data) = c.try_into_vec()?;
     let expected_len = batch
         .checked_mul(m)
         .and_then(|value| value.checked_mul(n))
@@ -769,6 +829,37 @@ where
         batch
     );
     Ok(data)
+}
+
+fn validate_batched_mat_mul_inputs(
+    batch: usize,
+    m: usize,
+    k: usize,
+    n: usize,
+    a_len: usize,
+    b_len: usize,
+) -> Result<()> {
+    let expected_a_len = batch
+        .checked_mul(m)
+        .and_then(|value| value.checked_mul(k))
+        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication left shape overflows"))?;
+    let expected_b_len = batch
+        .checked_mul(k)
+        .and_then(|value| value.checked_mul(n))
+        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication right shape overflows"))?;
+    ensure!(
+        a_len == expected_a_len,
+        "batched matrix multiplication left buffer has length {}, expected {}",
+        a_len,
+        expected_a_len
+    );
+    ensure!(
+        b_len == expected_b_len,
+        "batched matrix multiplication right buffer has length {}, expected {}",
+        b_len,
+        expected_b_len
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -23,6 +23,7 @@ use anyhow::{ensure, Context, Result};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 use std::ops::{Index, IndexMut};
+use tenferro::{Tensor, TensorBackend, TensorScalar, TypedTensor};
 
 /// A dense 2D matrix in column-major layout.
 ///
@@ -46,6 +47,38 @@ pub struct Matrix<T> {
     data: Vec<T>,
     nrows: usize,
     ncols: usize,
+}
+
+/// Error returned when converting a [`TypedTensor`] into a [`Matrix`].
+///
+/// Use this when accepting dynamic tensor-shaped values at a dense-matrix
+/// boundary. It reports whether conversion failed because the tensor was not a
+/// rank-2 matrix or because its host buffer could not be consumed.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro::TypedTensor;
+/// use tensor4all_tensorbackend::Matrix;
+///
+/// let tensor = TypedTensor::from_vec(vec![2, 1, 1], vec![1.0_f64, 2.0]);
+/// let err = Matrix::try_from_typed_tensor(tensor).unwrap_err();
+/// assert!(err.to_string().contains("rank-2 tensor"));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum MatrixTensorConversionError {
+    /// The input tensor rank was not two.
+    #[error("expected a rank-2 tensor, got shape {shape:?}")]
+    Rank {
+        /// Tensor shape that failed the rank check.
+        shape: Vec<usize>,
+    },
+    /// The tensor did not contain an owned host buffer that can be consumed.
+    #[error("failed to consume typed tensor host buffer: {message}")]
+    HostBuffer {
+        /// Backend conversion error reported by tenferro.
+        message: String,
+    },
 }
 
 impl<T> Matrix<T> {
@@ -83,6 +116,112 @@ impl<T> Matrix<T> {
     /// ```
     pub fn as_col_major_slice(&self) -> &[T] {
         &self.data
+    }
+
+    /// Consume the matrix and return its owned column-major buffer.
+    ///
+    /// The returned buffer uses `row + nrows * col` ordering. Use this when
+    /// transferring matrix storage to another column-major dense container
+    /// without cloning.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Matrix;
+    ///
+    /// let m = Matrix::from_col_major_vec(2, 2, vec![1.0, 3.0, 2.0, 4.0]);
+    /// let data = m.into_col_major_vec();
+    /// assert_eq!(data, vec![1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn into_col_major_vec(self) -> Vec<T> {
+        self.data
+    }
+
+    /// Borrow this matrix as an owned tenferro [`TypedTensor`].
+    ///
+    /// This clones the matrix buffer and preserves column-major layout. Use
+    /// [`Matrix::into_typed_tensor`] when the matrix can be consumed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Matrix;
+    ///
+    /// let m = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 3.0, 2.0, 4.0]);
+    /// let tensor = m.to_typed_tensor();
+    /// assert_eq!(tensor.shape, vec![2, 2]);
+    /// assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    /// assert_eq!(m.as_col_major_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn to_typed_tensor(&self) -> TypedTensor<T>
+    where
+        T: TensorScalar,
+    {
+        TypedTensor::from_vec(vec![self.nrows, self.ncols], self.data.clone())
+    }
+
+    /// Consume this matrix as a tenferro [`TypedTensor`] without cloning.
+    ///
+    /// The tensor shape is `[nrows, ncols]`, and the owned data remains in
+    /// column-major layout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::Matrix;
+    ///
+    /// let m = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 3.0, 2.0, 4.0]);
+    /// let tensor = m.into_typed_tensor();
+    /// assert_eq!(tensor.shape, vec![2, 2]);
+    /// assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn into_typed_tensor(self) -> TypedTensor<T>
+    where
+        T: TensorScalar,
+    {
+        TypedTensor::from_vec(vec![self.nrows, self.ncols], self.data)
+    }
+
+    /// Consume a rank-2 tenferro [`TypedTensor`] as a [`Matrix`].
+    ///
+    /// The input tensor must have shape `[nrows, ncols]` and an owned host
+    /// buffer. The buffer is reused without cloning and interpreted as
+    /// column-major matrix storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixTensorConversionError::Rank`] if the tensor is not
+    /// rank-2, or [`MatrixTensorConversionError::HostBuffer`] if tenferro
+    /// cannot export the tensor as an owned host buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro::TypedTensor;
+    /// use tensor4all_tensorbackend::Matrix;
+    ///
+    /// let tensor = TypedTensor::from_vec(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
+    /// let m = Matrix::try_from_typed_tensor(tensor).unwrap();
+    /// assert_eq!(m.nrows(), 2);
+    /// assert_eq!(m.ncols(), 2);
+    /// assert_eq!(m[[0, 1]], 2.0);
+    /// ```
+    pub fn try_from_typed_tensor(
+        tensor: TypedTensor<T>,
+    ) -> std::result::Result<Self, MatrixTensorConversionError>
+    where
+        T: Clone,
+    {
+        let (shape, data) =
+            tensor
+                .try_into_vec()
+                .map_err(|source| MatrixTensorConversionError::HostBuffer {
+                    message: source.to_string(),
+                })?;
+        if shape.len() != 2 {
+            return Err(MatrixTensorConversionError::Rank { shape });
+        }
+        Ok(Self::from_col_major_vec(shape[0], shape[1], data))
     }
 
     fn offset(&self, row: usize, col: usize) -> usize {
@@ -210,8 +349,8 @@ pub fn from_vec2d<T: Clone + Zero>(data: Vec<Vec<T>>) -> Matrix<T> {
 /// ```
 pub fn submatrix<T: Clone + Zero>(m: &Matrix<T>, rows: &[usize], cols: &[usize]) -> Matrix<T> {
     let mut result = Matrix::zeros(rows.len(), cols.len());
-    for (ri, &r) in rows.iter().enumerate() {
-        for (ci, &c) in cols.iter().enumerate() {
+    for (ci, &c) in cols.iter().enumerate() {
+        for (ri, &r) in rows.iter().enumerate() {
             result[[ri, ci]] = m[[r, c]].clone();
         }
     }
@@ -284,8 +423,8 @@ pub fn swap_cols<T>(m: &mut Matrix<T>, a: usize, b: usize) {
 /// ```
 pub fn transpose<T: Clone + Zero>(m: &Matrix<T>) -> Matrix<T> {
     let mut result = Matrix::zeros(m.ncols, m.nrows);
-    for i in 0..m.nrows {
-        for j in 0..m.ncols {
+    for j in 0..m.ncols {
+        for i in 0..m.nrows {
             result[[j, i]] = m[[i, j]].clone();
         }
     }
@@ -327,9 +466,13 @@ pub fn submatrix_argmax<T: MatrixScalar>(
     let mut max_val: f64 = a[[rows.start, cols.start]].matrix_abs_sq();
     let mut max_row = rows.start;
     let mut max_col = cols.start;
+    let row_start = rows.start;
+    let row_end = rows.end;
+    let col_start = cols.start;
+    let col_end = cols.end;
 
-    for r in rows {
-        for c in cols.clone() {
+    for c in col_start..col_end {
+        for r in row_start..row_end {
             let val: f64 = a[[r, c]].matrix_abs_sq();
             if val > max_val {
                 max_val = val;
@@ -350,6 +493,52 @@ pub fn submatrix_argmax<T: MatrixScalar>(
 pub trait BlasMul: Sized {
     #[doc(hidden)]
     fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>>;
+
+    #[doc(hidden)]
+    fn blas_mat_mul_owned(a: Matrix<Self>, b: Matrix<Self>) -> Result<Matrix<Self>>;
+}
+
+fn dot_general_matrices<T>(
+    a_tensor: Tensor,
+    b_tensor: Tensor,
+    m: usize,
+    n: usize,
+) -> Result<Matrix<T>>
+where
+    T: TensorScalar,
+{
+    use crate::with_default_backend;
+    use tenferro::DotGeneralConfig;
+
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let c = with_default_backend(|backend| {
+        backend.with_exec_session(|exec| exec.dot_general(&a_tensor, &b_tensor, &config))
+    })
+    .context("matrix multiplication failed")?;
+    let c = T::try_into_typed(c)
+        .ok_or_else(|| anyhow::anyhow!("matrix multiplication returned wrong dtype"))?;
+    let result = Matrix::try_from_typed_tensor(c)?;
+    ensure!(
+        result.nrows() == m && result.ncols() == n,
+        "matrix multiplication returned shape {}x{} for expected shape {}x{}",
+        result.nrows(),
+        result.ncols(),
+        m,
+        n
+    );
+    ensure!(
+        result.as_col_major_slice().len() == m * n,
+        "matrix multiplication returned {} values for expected shape {}x{}",
+        result.as_col_major_slice().len(),
+        m,
+        n
+    );
+    Ok(result)
 }
 
 macro_rules! impl_blas_mul {
@@ -357,10 +546,6 @@ macro_rules! impl_blas_mul {
         $(
         impl BlasMul for $t {
             fn blas_mat_mul(a: &Matrix<Self>, b: &Matrix<Self>) -> Result<Matrix<Self>> {
-                use tenferro_einsum::typed_eager_einsum;
-                use tenferro_tensor::TypedTensor;
-                use crate::with_default_backend;
-
                 let m = a.nrows();
                 let k = a.ncols();
                 let n = b.ncols();
@@ -373,31 +558,27 @@ macro_rules! impl_blas_mul {
                     n
                 );
 
-                let a_tensor = TypedTensor::<$t>::from_vec(
-                    vec![m, k],
-                    a.as_col_major_slice().to_vec(),
-                );
-                let b_tensor = TypedTensor::<$t>::from_vec(
-                    vec![k, n],
-                    b.as_col_major_slice().to_vec(),
-                );
-                let c = with_default_backend(|backend| {
-                    typed_eager_einsum(backend, &[&a_tensor, &b_tensor], "ij,jk->ik")
-                })
-                .context("matrix multiplication einsum failed")?;
-                let data = c.as_slice().to_vec();
+                let a_tensor: Tensor = a.to_typed_tensor().into();
+                let b_tensor: Tensor = b.to_typed_tensor().into();
+                dot_general_matrices::<$t>(a_tensor, b_tensor, m, n)
+            }
+
+            fn blas_mat_mul_owned(a: Matrix<Self>, b: Matrix<Self>) -> Result<Matrix<Self>> {
+                let m = a.nrows();
+                let k = a.ncols();
+                let n = b.ncols();
                 ensure!(
-                    data.len() == m * n,
-                    "matrix multiplication returned {} values for expected shape {}x{}",
-                    data.len(),
+                    b.nrows() == k,
+                    "matrix dimensions must agree for multiplication: left is {}x{}, right is {}x{}",
                     m,
+                    k,
+                    b.nrows(),
                     n
                 );
-                Ok(Matrix {
-                    data,
-                    nrows: m,
-                    ncols: n,
-                })
+
+                let a_tensor: Tensor = a.into_typed_tensor().into();
+                let b_tensor: Tensor = b.into_typed_tensor().into();
+                dot_general_matrices::<$t>(a_tensor, b_tensor, m, n)
             }
         }
         )*
@@ -478,6 +659,116 @@ impl MatrixScalar for Complex32 {
 /// ```
 pub fn mat_mul<T: BlasMul>(a: &Matrix<T>, b: &Matrix<T>) -> Result<Matrix<T>> {
     T::blas_mat_mul(a, b)
+}
+
+/// Matrix multiplication: consume `A` and `B`, returning `A * B`.
+///
+/// Uses BLAS-backed einsum via tenferro. Compared with [`mat_mul`], this
+/// reuses the input matrix buffers when building tenferro tensors.
+///
+/// # Errors
+///
+/// Returns an error if `a.ncols() != b.nrows()` or the backend einsum fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{from_vec2d, mat_mul_owned};
+///
+/// let a = from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0]]);
+/// let b = from_vec2d(vec![vec![5.0, 6.0], vec![7.0, 8.0]]);
+/// let c = mat_mul_owned(a, b).unwrap();
+/// assert_eq!(c.as_col_major_slice(), &[19.0, 43.0, 22.0, 50.0]);
+/// ```
+pub fn mat_mul_owned<T: BlasMul>(a: Matrix<T>, b: Matrix<T>) -> Result<Matrix<T>> {
+    T::blas_mat_mul_owned(a, b)
+}
+
+/// Batched matrix multiplication for column-major matrices with one shared shape.
+///
+/// Computes `C[p] = A[p] * B[p]` for `batch` matrices. Each `A[p]` is an
+/// `m x k` column-major matrix and each `B[p]` is a `k x n` column-major
+/// matrix. The input buffers store complete matrices consecutively, and the
+/// returned buffer stores `batch` consecutive `m x n` column-major outputs.
+///
+/// # Errors
+///
+/// Returns an error if the input buffer lengths do not match the declared
+/// shapes or if the backend rejects the batched GEMM.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::batched_mat_mul_same_shape;
+///
+/// let a = vec![1.0_f64, 3.0, 2.0, 4.0];
+/// let b = vec![5.0_f64, 7.0, 6.0, 8.0];
+/// let out = batched_mat_mul_same_shape(1, 2, 2, 2, &a, &b).unwrap();
+/// assert_eq!(out, vec![19.0, 43.0, 22.0, 50.0]);
+/// ```
+pub fn batched_mat_mul_same_shape<T>(
+    batch: usize,
+    m: usize,
+    k: usize,
+    n: usize,
+    a: &[T],
+    b: &[T],
+) -> Result<Vec<T>>
+where
+    T: tenferro::TensorScalar + Copy,
+{
+    use crate::with_default_backend;
+    use tenferro::{DotGeneralConfig, TensorBackend};
+
+    let a_len = batch
+        .checked_mul(m)
+        .and_then(|value| value.checked_mul(k))
+        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication left shape overflows"))?;
+    let b_len = batch
+        .checked_mul(k)
+        .and_then(|value| value.checked_mul(n))
+        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication right shape overflows"))?;
+    ensure!(
+        a.len() == a_len,
+        "batched matrix multiplication left buffer has length {}, expected {}",
+        a.len(),
+        a_len
+    );
+    ensure!(
+        b.len() == b_len,
+        "batched matrix multiplication right buffer has length {}, expected {}",
+        b.len(),
+        b_len
+    );
+
+    let a_tensor = T::into_tensor(vec![m, k, batch], a.to_vec());
+    let b_tensor = T::into_tensor(vec![k, n, batch], b.to_vec());
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![2],
+        rhs_batch_dims: vec![2],
+    };
+    let c = with_default_backend(|backend| {
+        backend.with_exec_session(|exec| exec.dot_general(&a_tensor, &b_tensor, &config))
+    })
+    .context("batched matrix multiplication failed")?;
+    let c = T::try_into_typed(c)
+        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication returned wrong dtype"))?;
+    let data = c.as_slice().to_vec();
+    let expected_len = batch
+        .checked_mul(m)
+        .and_then(|value| value.checked_mul(n))
+        .ok_or_else(|| anyhow::anyhow!("batched matrix multiplication output shape overflows"))?;
+    ensure!(
+        data.len() == expected_len,
+        "batched matrix multiplication returned {} values for expected shape {}x{}x{}",
+        data.len(),
+        m,
+        n,
+        batch
+    );
+    Ok(data)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -521,8 +521,8 @@ pub fn submatrix_argmax<T: MatrixScalar>(
     let col_end = cols.end;
 
     for c in col_start..col_end {
-        let mut offset = row_start + a.nrows * c;
-        for r in row_start..row_end {
+        let col_start_offset = row_start + a.nrows * c;
+        for (offset, r) in (col_start_offset..).zip(row_start..row_end) {
             // SAFETY: row and column loops stay within the checked ranges.
             let value = unsafe { *data.get_unchecked(offset) };
             let val: f64 = value.matrix_abs_sq();
@@ -531,7 +531,6 @@ pub fn submatrix_argmax<T: MatrixScalar>(
                 max_row = r;
                 max_col = c;
             }
-            offset += 1;
         }
     }
 

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -157,6 +157,17 @@ fn batched_mat_mul_same_shape_preserves_column_major_batches() {
 }
 
 #[test]
+fn batched_mat_mul_same_shape_owned_matches_borrowed() {
+    let a = vec![1.0, 3.0, 2.0, 4.0, 2.0, 0.0, 0.0, 3.0];
+    let b = vec![5.0, 7.0, 6.0, 8.0, 1.0, 4.0, 2.0, 5.0];
+
+    let borrowed = batched_mat_mul_same_shape(2, 2, 2, 2, &a, &b).unwrap();
+    let owned = batched_mat_mul_same_shape_owned(2, 2, 2, 2, a, b).unwrap();
+
+    assert_eq!(owned, borrowed);
+}
+
+#[test]
 fn mat_mul_reports_dimension_mismatch() {
     let a = Matrix::from_col_major_vec(2, 3, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
     let b = Matrix::from_col_major_vec(2, 2, vec![1.0, 3.0, 2.0, 4.0]);

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tenferro::TypedTensor;
 
 #[test]
 fn test_matrix_basic() {
@@ -23,6 +24,57 @@ fn test_matrix_column_major_storage() {
     assert_eq!(m[[1, 1]], 5);
     assert_eq!(m[[1, 2]], 6);
     assert_eq!(m.as_col_major_slice(), &[1, 4, 2, 5, 3, 6]);
+}
+
+#[test]
+fn matrix_into_col_major_vec_consumes_storage() {
+    let m = Matrix::from_col_major_vec(2, 2, vec![1.0, 3.0, 2.0, 4.0]);
+
+    let data = m.into_col_major_vec();
+
+    assert_eq!(data, vec![1.0, 3.0, 2.0, 4.0]);
+}
+
+#[test]
+fn matrix_to_typed_tensor_preserves_column_major_layout() {
+    let m = Matrix::from_col_major_vec(2, 2, vec![1.0, 3.0, 2.0, 4.0]);
+
+    let tensor = m.to_typed_tensor();
+
+    assert_eq!(tensor.shape, vec![2, 2]);
+    assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    assert_eq!(m.as_col_major_slice(), &[1.0, 3.0, 2.0, 4.0]);
+}
+
+#[test]
+fn matrix_into_typed_tensor_consumes_column_major_layout() {
+    let m = Matrix::from_col_major_vec(2, 2, vec![1.0, 3.0, 2.0, 4.0]);
+
+    let tensor = m.into_typed_tensor();
+
+    assert_eq!(tensor.shape, vec![2, 2]);
+    assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
+}
+
+#[test]
+fn matrix_from_typed_tensor_consumes_column_major_layout() {
+    let tensor = TypedTensor::from_vec(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]);
+
+    let m = Matrix::try_from_typed_tensor(tensor).unwrap();
+
+    assert_eq!(m.nrows(), 2);
+    assert_eq!(m.ncols(), 2);
+    assert_eq!(m.as_col_major_slice(), &[1.0, 3.0, 2.0, 4.0]);
+    assert_eq!(m[[0, 1]], 2.0);
+}
+
+#[test]
+fn matrix_from_typed_tensor_rejects_non_matrix_rank() {
+    let tensor = TypedTensor::from_vec(vec![2, 1, 1], vec![1.0, 2.0]);
+
+    let err = Matrix::try_from_typed_tensor(tensor).unwrap_err();
+
+    assert!(err.to_string().contains("rank-2 tensor"));
 }
 
 #[test]
@@ -62,6 +114,16 @@ fn test_mat_mul() {
 }
 
 #[test]
+fn mat_mul_owned_matches_borrowed_multiplication() {
+    let a = from_vec2d(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
+    let b = from_vec2d(vec![vec![5.0, 6.0], vec![7.0, 8.0]]);
+
+    let c = mat_mul_owned(a, b).unwrap();
+
+    assert_eq!(c.as_col_major_slice(), &[19.0, 43.0, 22.0, 50.0]);
+}
+
+#[test]
 fn test_mat_mul_rectangular_preserves_column_major_layout() {
     let a = from_vec2d(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
     let b = from_vec2d(vec![vec![7.0, 8.0], vec![9.0, 10.0], vec![11.0, 12.0]]);
@@ -74,6 +136,24 @@ fn test_mat_mul_rectangular_preserves_column_major_layout() {
     assert_eq!(c[[1, 0]], 139.0);
     assert_eq!(c[[1, 1]], 154.0);
     assert_eq!(c.as_col_major_slice(), &[58.0, 139.0, 64.0, 154.0]);
+}
+
+#[test]
+fn batched_mat_mul_same_shape_preserves_column_major_batches() {
+    let a0 = vec![1.0, 3.0, 2.0, 4.0];
+    let a1 = vec![2.0, 0.0, 0.0, 3.0];
+    let b0 = vec![5.0, 7.0, 6.0, 8.0];
+    let b1 = vec![1.0, 4.0, 2.0, 5.0];
+    let mut a = a0;
+    a.extend(a1);
+    let mut b = b0;
+    b.extend(b1);
+
+    let out = batched_mat_mul_same_shape(2, 2, 2, 2, &a, &b).unwrap();
+
+    assert_eq!(out.len(), 8);
+    assert_eq!(&out[0..4], &[19.0, 43.0, 22.0, 50.0]);
+    assert_eq!(&out[4..8], &[2.0, 12.0, 4.0, 15.0]);
 }
 
 #[test]

--- a/docs/plans/2026-05-21-aci-rust-api-design.md
+++ b/docs/plans/2026-05-21-aci-rust-api-design.md
@@ -1,0 +1,212 @@
+# Alternating Cross Interpolation Rust API Design
+
+## Goal
+
+Port the Rust public API for
+[`AlternatingCrossInterpolation.jl`](https://github.com/tensor4all/AlternatingCrossInterpolation.jl)
+into `tensor4all-rs`. The first scope is Rust-only: no C API, Python API, or
+Tensor4all.jl binding surface is included in this design.
+
+ACI computes elementwise operations on existing tensor trains with an
+alternating two-site cross interpolation scheme. The implementation should use
+the existing `tensor4all-simplett::TensorTrain`, `tensor4all-tcicore`
+MatrixLUCI, and `tensor4all-tensorbackend::Matrix` abstractions.
+
+## Attribution
+
+Create a new crate with explicit upstream attribution:
+
+```toml
+authors = [
+    "Marc Ritter <mritter@flatironinstitute.org>",
+    "Hiroshi Shinaoka <h.shinaoka@gmail.com>",
+    "tensor4all contributors",
+]
+```
+
+The crate-level documentation or a `NOTICE` file should state:
+
+```text
+This crate ports AlternatingCrossInterpolation.jl, originally authored by
+Marc Ritter <mritter@flatironinstitute.org> and contributors.
+```
+
+The upstream MIT copyright notice must be preserved:
+
+```text
+Copyright (c) 2026 Marc Ritter <mritter@flatironinstitute.org> and contributors
+```
+
+## Crate Boundary
+
+Add a new crate:
+
+```text
+crates/tensor4all-aci
+```
+
+Primary dependencies:
+
+- `tensor4all-simplett`
+- `tensor4all-tcicore`
+- `tensor4all-tensorbackend`
+
+This keeps ACI separate from `tensor4all-simplett` core tensor-train
+containers and from `tensor4all-tensorci`, whose main role is interpolation of
+external functions into tensor trains.
+
+## Public API Shape
+
+Expose a small high-level API around simple tensor trains:
+
+```rust
+pub fn elementwise<T, F>(
+    op: F,
+    inputs: &[TensorTrain<T>],
+    options: &AciOptions<T>,
+) -> Result<AciResult<T>>
+where
+    F: FnMut(&[T]) -> T;
+
+pub fn elementwise_batched<T, F>(
+    op: F,
+    inputs: &[TensorTrain<T>],
+    options: &AciOptions<T>,
+) -> Result<AciResult<T>>
+where
+    F: FnMut(ElementwiseBatch<'_, T>, &mut [T]) -> Result<()>;
+```
+
+`elementwise` is a convenience wrapper over the batched path. The internal
+implementation should avoid maintaining two separate update algorithms.
+
+`AciResult<T>` should contain:
+
+- `tensor_train: TensorTrain<T>`
+- `ranks: Vec<usize>`
+- `errors: Vec<f64>`
+
+`AciOptions<T>` should contain:
+
+- `max_iters`
+- `min_iters`
+- `max_bond_dim`
+- `tolerance`
+- `scale_tolerance`
+- `initial_guess`
+- deterministic random initialization controls, such as `rng_seed`
+
+## Batch Evaluation Contract
+
+Batched elementwise callbacks receive a 2D column-major view with shape
+`(n_inputs, n_points)`. For point `p` and input tensor train `k`, the local
+value is stored at:
+
+```text
+values[k + n_inputs * p]
+```
+
+Represent this with an ACI-specific view wrapper:
+
+```rust
+pub struct ElementwiseBatch<'a, T> {
+    values: &'a [T],
+    n_inputs: usize,
+    n_points: usize,
+}
+```
+
+The wrapper should expose:
+
+```rust
+impl<'a, T> ElementwiseBatch<'a, T> {
+    pub fn n_inputs(&self) -> usize;
+    pub fn n_points(&self) -> usize;
+    pub fn get(&self, input: usize, point: usize) -> T;
+    pub fn as_col_major_slice(&self) -> &'a [T];
+}
+```
+
+The callback writes one output value per point into `out[p]`.
+
+This layout matches the repository-wide column-major dense boundary policy and
+avoids allocation-heavy `&[Vec<T>]` APIs.
+
+## Local Update Data Flow
+
+For each bond update:
+
+1. Maintain per-input left and right frame matrices.
+2. Expose the local two-site candidate matrix to MatrixLUCI as a lazy block
+   source through `matrix_luci_factors_from_blocks`.
+3. When LUCI requests `(rows, cols)`:
+   - decode each row into the left-frame row and site `b` value,
+   - decode each column into the site `b + 1` value and right-frame column,
+   - compute local values for every input tensor train,
+   - call the batched elementwise operator,
+   - fill the requested output block in column-major order.
+4. Reshape MatrixLUCI left/right factors back into the two updated site cores.
+5. Update the left or right frames depending on sweep direction.
+
+The implementation must not dense-materialize the full global tensor. Dense
+materialization is allowed only in small reference tests.
+
+## Cache Policy
+
+Use three cache levels with clear lifetimes:
+
+1. Frames are required algorithm state, not optional cache. They persist across
+   updates and are invalidated only by the sweep direction and local updates.
+2. Local entry cache is scoped to one bond update. It may map candidate matrix
+   entry positions to output values so repeated LUCI block requests do not
+   recompute the same elementwise result. It is dropped at the end of the bond
+   update.
+3. `TTCache` and `CachedFunction` are not part of the ACI core. They may be used
+   for tests, reference checks, or fallback diagnostics, but the production
+   local update path should use frames and lazy MatrixLUCI blocks.
+
+Do not expose detailed cache controls in the initial public API. If benchmarks
+show the need, add a later `CachePolicy` option such as:
+
+```rust
+pub enum CachePolicy {
+    None,
+    LocalEntries { max_entries: usize },
+}
+```
+
+## Error Handling
+
+Use a crate-local typed error enum, not `anyhow::Result`, for the public Rust
+API. Expected error categories include:
+
+- empty input list
+- tensor-train length mismatch
+- site dimension mismatch
+- invalid initial guess
+- invalid options
+- batched operator output length mismatch
+- MatrixLUCI factorization failure
+- tensor-train construction or mutation failure
+
+Callback failures should be preserved in a public error variant without
+discarding context.
+
+## Testing
+
+Add focused release-mode tests for:
+
+- validation paths: empty inputs, length mismatch, site dimension mismatch,
+  invalid options, invalid initial guess
+- algebraic cases: constant tensor trains, addition, multiplication, and a
+  small nonlinear elementwise function
+- dense oracle checks on small tensor trains by materializing each full result
+  once and comparing whole dense buffers
+- parity between `elementwise` and `elementwise_batched`
+- local cache behavior within one bond update and cache invalidation across
+  bond updates
+- small Julia-parity examples derived from the upstream Gaussian/product tests
+
+Doc examples must be runnable and include assertions. User-facing docs should
+state that only Rust public API is supported in the first phase; C API and
+language bindings are intentionally out of scope.

--- a/docs/plans/2026-05-21-aci-rust-api-implementation-plan.md
+++ b/docs/plans/2026-05-21-aci-rust-api-implementation-plan.md
@@ -1,0 +1,1139 @@
+# ACI Rust API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a Rust public API for alternating cross interpolation elementwise operations on `tensor4all-simplett::TensorTrain`.
+
+**Architecture:** Implement a new `tensor4all-aci` crate that depends on `tensor4all-simplett`, `tensor4all-tcicore`, and `tensor4all-tensorbackend`. The public API exposes scalar and batched elementwise entry points, while the internal algorithm uses persistent ACI frames, one-bond local entry caches, and lazy MatrixLUCI block requests.
+
+**Tech Stack:** Rust 2021, `thiserror`, `rand`, `rand_chacha`, `rand_distr`, `tensor4all-simplett`, `tensor4all-tcicore::matrix_luci_factors_from_blocks`, `tensor4all-tensorbackend::Matrix`.
+
+---
+
+## References
+
+- Design: `docs/plans/2026-05-21-aci-rust-api-design.md`
+- Upstream Julia package: `/tmp/AlternatingCrossInterpolation.jl` if still present, or clone `https://github.com/tensor4all/AlternatingCrossInterpolation.jl`
+- Existing APIs:
+  - `docs/api/tensor4all_simplett.md`
+  - `docs/api/tensor4all_tcicore.md`
+  - `docs/api/tensor4all_tensorbackend.md`
+- Source files likely needed for implementation:
+  - `crates/tensor4all-simplett/src/types.rs`
+  - `crates/tensor4all-simplett/src/tensortrain.rs`
+  - `crates/tensor4all-simplett/src/traits.rs`
+  - `crates/tensor4all-tcicore/src/matrix_luci.rs`
+  - `crates/tensor4all-tensorbackend/src/matrix.rs` or the current `Matrix` module path
+
+## Task 1: Scaffold `tensor4all-aci`
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `crates/tensor4all-aci/Cargo.toml`
+- Create: `crates/tensor4all-aci/src/lib.rs`
+- Create: `crates/tensor4all-aci/NOTICE`
+
+**Step 1: Write the minimal crate files**
+
+Add `crates/tensor4all-aci` to workspace members in root `Cargo.toml`.
+
+Create `crates/tensor4all-aci/Cargo.toml`:
+
+```toml
+[package]
+name = "tensor4all-aci"
+description = "Alternating Cross Interpolation elementwise operations for tensor4all tensor trains"
+version.workspace = true
+edition.workspace = true
+authors = [
+    "Marc Ritter <mritter@flatironinstitute.org>",
+    "Hiroshi Shinaoka <h.shinaoka@gmail.com>",
+    "tensor4all contributors",
+]
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-simplett/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-simplett/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+]
+
+[dependencies]
+num-complex.workspace = true
+rand.workspace = true
+rand_chacha.workspace = true
+rand_distr.workspace = true
+thiserror.workspace = true
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+
+[dev-dependencies]
+approx.workspace = true
+```
+
+Create `src/lib.rs`:
+
+```rust
+#![warn(missing_docs)]
+//! Alternating Cross Interpolation for elementwise tensor-train operations.
+//!
+//! This crate ports the Rust public API for
+//! `AlternatingCrossInterpolation.jl`, originally authored by
+//! Marc Ritter <mritter@flatironinstitute.org> and contributors.
+
+/// Placeholder item until the public API is implemented.
+pub fn crate_ready() -> bool {
+    true
+}
+```
+
+Create `NOTICE`:
+
+```text
+This crate ports AlternatingCrossInterpolation.jl, originally authored by
+Marc Ritter <mritter@flatironinstitute.org> and contributors.
+
+Upstream copyright:
+
+Copyright (c) 2026 Marc Ritter <mritter@flatironinstitute.org> and contributors
+```
+
+**Step 2: Run the crate check**
+
+Run:
+
+```bash
+cargo check -p tensor4all-aci
+```
+
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add Cargo.toml crates/tensor4all-aci
+git commit -m "Add tensor4all-aci crate scaffold"
+```
+
+## Task 2: Add Public Error, Options, Result, and Batch Types
+
+**Files:**
+- Modify: `crates/tensor4all-aci/src/lib.rs`
+- Create: `crates/tensor4all-aci/src/error.rs`
+- Create: `crates/tensor4all-aci/src/options.rs`
+- Create: `crates/tensor4all-aci/src/result.rs`
+- Create: `crates/tensor4all-aci/src/batch.rs`
+- Create: `crates/tensor4all-aci/src/tests.rs`
+
+**Step 1: Write tests for public type behavior**
+
+In `src/tests.rs`, add tests for default options and column-major batch access:
+
+```rust
+use crate::{AciOptions, ElementwiseBatch};
+
+#[test]
+fn default_options_are_conservative() {
+    let options = AciOptions::<f64>::default();
+    assert_eq!(options.max_iters, 20);
+    assert_eq!(options.min_iters, 2);
+    assert_eq!(options.max_bond_dim, usize::MAX);
+    assert!((options.tolerance - 1e-12).abs() < 1e-15);
+    assert!(!options.scale_tolerance);
+    assert!(options.initial_guess.is_none());
+}
+
+#[test]
+fn elementwise_batch_uses_column_major_input_point_layout() {
+    let values = vec![10.0, 20.0, 11.0, 21.0, 12.0, 22.0];
+    let batch = ElementwiseBatch::new(&values, 2, 3).unwrap();
+    assert_eq!(batch.n_inputs(), 2);
+    assert_eq!(batch.n_points(), 3);
+    assert_eq!(batch.get(0, 0).unwrap(), 10.0);
+    assert_eq!(batch.get(1, 0).unwrap(), 20.0);
+    assert_eq!(batch.get(0, 2).unwrap(), 12.0);
+    assert_eq!(batch.get(1, 2).unwrap(), 22.0);
+    assert_eq!(batch.as_col_major_slice(), values.as_slice());
+}
+
+#[test]
+fn elementwise_batch_rejects_bad_length() {
+    let err = ElementwiseBatch::<f64>::new(&[1.0, 2.0, 3.0], 2, 2).unwrap_err();
+    assert!(err.to_string().contains("length"));
+}
+```
+
+**Step 2: Verify tests fail**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci default_options_are_conservative
+cargo test --release -p tensor4all-aci elementwise_batch
+```
+
+Expected: FAIL because the types do not exist.
+
+**Step 3: Implement public types**
+
+`src/error.rs`:
+
+```rust
+use thiserror::Error;
+
+/// Result type for ACI operations.
+pub type Result<T> = std::result::Result<T, AciError>;
+
+/// Errors returned by the ACI Rust public API.
+#[derive(Debug, Error)]
+pub enum AciError {
+    /// No input tensor trains were provided.
+    #[error("at least one input tensor train is required")]
+    EmptyInputs,
+
+    /// Input tensor trains have different numbers of sites.
+    #[error("tensor train length mismatch: expected {expected}, got {got}")]
+    LengthMismatch {
+        /// Expected number of sites.
+        expected: usize,
+        /// Actual number of sites.
+        got: usize,
+    },
+
+    /// Input tensor trains have different physical dimensions at one site.
+    #[error("site dimension mismatch at site {site}: expected {expected}, got {got}")]
+    SiteDimMismatch {
+        /// Site where the mismatch was found.
+        site: usize,
+        /// Expected site dimension.
+        expected: usize,
+        /// Actual site dimension.
+        got: usize,
+    },
+
+    /// The caller supplied invalid options.
+    #[error("invalid ACI options: {message}")]
+    InvalidOptions {
+        /// Explanation.
+        message: String,
+    },
+
+    /// The initial guess is incompatible with the inputs.
+    #[error("invalid initial guess: {message}")]
+    InvalidInitialGuess {
+        /// Explanation.
+        message: String,
+    },
+
+    /// Batched operator returned or wrote an invalid number of values.
+    #[error("operator output length mismatch: expected {expected}, got {got}")]
+    OperatorOutputLength {
+        /// Expected output length.
+        expected: usize,
+        /// Actual output length.
+        got: usize,
+    },
+
+    /// User callback failed.
+    #[error("operator failed: {message}")]
+    Operator {
+        /// Error context.
+        message: String,
+    },
+
+    /// Matrix cross interpolation failed.
+    #[error("matrix CI error: {0}")]
+    MatrixCI(#[from] tensor4all_tcicore::MatrixCIError),
+
+    /// Tensor train operation failed.
+    #[error("tensor train error: {0}")]
+    TensorTrain(#[from] tensor4all_simplett::TensorTrainError),
+}
+```
+
+`src/options.rs`:
+
+```rust
+use tensor4all_simplett::{TTScalar, TensorTrain};
+
+/// Configuration for ACI elementwise operations.
+#[derive(Debug, Clone)]
+pub struct AciOptions<T: TTScalar> {
+    /// Maximum number of full sweeps.
+    pub max_iters: usize,
+    /// Minimum number of sweeps before convergence checks can stop the run.
+    pub min_iters: usize,
+    /// Maximum allowed output bond dimension.
+    pub max_bond_dim: usize,
+    /// Pivot-error tolerance.
+    pub tolerance: f64,
+    /// Whether to scale tolerance by an observed problem scale.
+    pub scale_tolerance: bool,
+    /// Optional initial guess for the output tensor train.
+    pub initial_guess: Option<TensorTrain<T>>,
+    /// Seed used when generating a default initial guess.
+    pub rng_seed: u64,
+}
+
+impl<T: TTScalar> Default for AciOptions<T> {
+    fn default() -> Self {
+        Self {
+            max_iters: 20,
+            min_iters: 2,
+            max_bond_dim: usize::MAX,
+            tolerance: 1e-12,
+            scale_tolerance: false,
+            initial_guess: None,
+            rng_seed: 0,
+        }
+    }
+}
+```
+
+`src/result.rs`:
+
+```rust
+use tensor4all_simplett::{TTScalar, TensorTrain};
+
+/// Output of an ACI elementwise run.
+#[derive(Debug, Clone)]
+pub struct AciResult<T: TTScalar> {
+    /// Resulting tensor train.
+    pub tensor_train: TensorTrain<T>,
+    /// Maximum bond dimension after each sweep.
+    pub ranks: Vec<usize>,
+    /// Maximum pivot error after each sweep.
+    pub errors: Vec<f64>,
+}
+```
+
+`src/batch.rs`:
+
+```rust
+use crate::{AciError, Result};
+
+/// Column-major 2D view passed to batched elementwise callbacks.
+#[derive(Debug, Clone, Copy)]
+pub struct ElementwiseBatch<'a, T> {
+    values: &'a [T],
+    n_inputs: usize,
+    n_points: usize,
+}
+
+impl<'a, T> ElementwiseBatch<'a, T> {
+    /// Create a view over `values` with shape `(n_inputs, n_points)`.
+    pub fn new(values: &'a [T], n_inputs: usize, n_points: usize) -> Result<Self> {
+        let expected = n_inputs.checked_mul(n_points).ok_or_else(|| AciError::InvalidOptions {
+            message: "batch shape overflows usize".to_string(),
+        })?;
+        if values.len() != expected {
+            return Err(AciError::OperatorOutputLength {
+                expected,
+                got: values.len(),
+            });
+        }
+        Ok(Self { values, n_inputs, n_points })
+    }
+
+    /// Number of input tensor trains.
+    pub fn n_inputs(&self) -> usize {
+        self.n_inputs
+    }
+
+    /// Number of points in the batch.
+    pub fn n_points(&self) -> usize {
+        self.n_points
+    }
+
+    /// Return the value for one input and point.
+    pub fn get(&self, input: usize, point: usize) -> Result<T>
+    where
+        T: Copy,
+    {
+        if input >= self.n_inputs || point >= self.n_points {
+            return Err(AciError::InvalidOptions {
+                message: format!("batch index out of bounds: input={input}, point={point}"),
+            });
+        }
+        Ok(self.values[input + self.n_inputs * point])
+    }
+
+    /// Borrow the raw column-major buffer.
+    pub fn as_col_major_slice(&self) -> &'a [T] {
+        self.values
+    }
+}
+```
+
+Update `src/lib.rs` to export the modules and remove `crate_ready`.
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI public API types"
+```
+
+## Task 3: Add Input Validation and Initial Guess Generation
+
+**Files:**
+- Create: `crates/tensor4all-aci/src/validation.rs`
+- Create: `crates/tensor4all-aci/src/random_tt.rs`
+- Create: `crates/tensor4all-aci/src/scalar.rs`
+- Modify: `crates/tensor4all-aci/src/lib.rs`
+- Modify: `crates/tensor4all-aci/src/tests.rs`
+
+**Step 1: Write failing validation tests**
+
+Add tests:
+
+```rust
+use crate::{initial_guess, AciOptions};
+use crate::validation::validate_inputs;
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+
+#[test]
+fn validate_inputs_rejects_empty_inputs() {
+    let err = validate_inputs::<f64>(&[]).unwrap_err();
+    assert!(err.to_string().contains("at least one"));
+}
+
+#[test]
+fn validate_inputs_rejects_length_mismatch() {
+    let a = TensorTrain::<f64>::constant(&[2, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let err = validate_inputs(&[a, b]).unwrap_err();
+    assert!(err.to_string().contains("length mismatch"));
+}
+
+#[test]
+fn validate_inputs_rejects_site_dim_mismatch() {
+    let a = TensorTrain::<f64>::constant(&[2, 3], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 4], 1.0);
+    let err = validate_inputs(&[a, b]).unwrap_err();
+    assert!(err.to_string().contains("site dimension mismatch"));
+}
+
+#[test]
+fn default_initial_guess_matches_input_site_dims() {
+    let a = TensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 3, 4], 2.0);
+    let guess = initial_guess(&[a, b], &AciOptions::default()).unwrap();
+    assert_eq!(guess.site_dims(), vec![2, 3, 4]);
+}
+```
+
+**Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci validate_inputs default_initial_guess
+```
+
+Expected: FAIL because validation helpers are missing.
+
+**Step 3: Implement validation**
+
+`validation.rs`:
+
+```rust
+use crate::{AciError, Result};
+use tensor4all_simplett::{AbstractTensorTrain, TTScalar, TensorTrain};
+
+pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> Result<()> {
+    if options.max_iters == 0 {
+        return Err(AciError::InvalidOptions { message: "max_iters must be positive".to_string() });
+    }
+    if options.min_iters > options.max_iters {
+        return Err(AciError::InvalidOptions {
+            message: "min_iters must be <= max_iters".to_string(),
+        });
+    }
+    if !(options.tolerance >= 0.0 && options.tolerance.is_finite()) {
+        return Err(AciError::InvalidOptions {
+            message: "tolerance must be finite and non-negative".to_string(),
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_inputs<T: TTScalar>(inputs: &[TensorTrain<T>]) -> Result<Vec<usize>> {
+    let first = inputs.first().ok_or(AciError::EmptyInputs)?;
+    let n = first.len();
+    let site_dims = first.site_dims();
+    for input in inputs.iter().skip(1) {
+        if input.len() != n {
+            return Err(AciError::LengthMismatch { expected: n, got: input.len() });
+        }
+        for site in 0..n {
+            let got = input.site_dim(site);
+            let expected = site_dims[site];
+            if got != expected {
+                return Err(AciError::SiteDimMismatch { site, expected, got });
+            }
+        }
+    }
+    Ok(site_dims)
+}
+```
+
+`random_tt.rs` should generate a deterministic random tensor train whose link
+dimensions are clamped by the product of left and right physical dimensions and
+by the minimum input link dimension where available.
+
+Define small internal scalar traits in `scalar.rs`:
+
+```rust
+pub(crate) trait AciRandomScalar: tensor4all_simplett::TTScalar {
+    fn sample_standard_normal(rng: &mut rand_chacha::ChaCha8Rng) -> Self;
+}
+
+pub(crate) trait AciScalar:
+    tensor4all_simplett::TTScalar
+    + tensor4all_tcicore::MatrixLuciScalar
+    + AciRandomScalar
+    + Copy
+{
+}
+
+impl<T> AciScalar for T
+where
+    T: tensor4all_simplett::TTScalar
+        + tensor4all_tcicore::MatrixLuciScalar
+        + AciRandomScalar
+        + Copy
+{
+}
+```
+
+Implement `AciRandomScalar` for `f64` and `num_complex::Complex64`.
+
+**Step 4: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci validate_inputs default_initial_guess
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI input validation and initial guess"
+```
+
+## Task 4: Implement Frame State Initialization
+
+**Files:**
+- Create: `crates/tensor4all-aci/src/state.rs`
+- Modify: `crates/tensor4all-aci/src/lib.rs`
+- Modify: `crates/tensor4all-aci/src/tests.rs`
+
+**Step 1: Write failing frame tests**
+
+Add tests for two three-site inputs:
+
+```rust
+use crate::{AciOptions, ElementwiseProblem};
+use tensor4all_simplett::TensorTrain;
+
+#[test]
+fn elementwise_problem_initializes_boundary_frames() {
+    let a = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2, 2], 2.0);
+    let problem = ElementwiseProblem::new(vec![a, b], AciOptions::default()).unwrap();
+    assert_eq!(problem.len(), 3);
+    assert_eq!(problem.n_inputs(), 2);
+    assert_eq!(problem.left_frame_shape(0, 0), Some((1, 1)));
+    assert_eq!(problem.right_frame_shape(0, 3), Some((1, 1)));
+}
+```
+
+Keep `ElementwiseProblem` crate-private if possible. Tests may live in the same
+crate so they can access `pub(crate)` helpers.
+
+**Step 2: Run and verify failure**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci elementwise_problem_initializes_boundary_frames
+```
+
+Expected: FAIL because `ElementwiseProblem` is missing.
+
+**Step 3: Implement frame state**
+
+Use:
+
+```rust
+struct ElementwiseProblem<T: AciScalar> {
+    inputs: Vec<TensorTrain<T>>,
+    solution: TensorTrain<T>,
+    left_frames: Vec<Vec<Option<Matrix<T>>>>,
+    right_frames: Vec<Vec<Option<Matrix<T>>>>,
+    pivot_errors: Vec<f64>,
+}
+```
+
+Indexing convention:
+
+- `left_frames[input][0] = 1 x 1`
+- `left_frames[input][site]` is available after site `site - 1`
+- `right_frames[input][n] = 1 x 1`
+- `right_frames[input][site]` is available before site `site`
+
+Implement:
+
+```rust
+fn update_left_frame(&mut self, input: usize, site: usize, row_indices: &[usize]) -> Result<()>;
+fn update_right_frame(&mut self, input: usize, site: usize, col_indices: &[usize]) -> Result<()>;
+fn update_left_frames(&mut self, site: usize, row_indices: &[usize]) -> Result<()>;
+fn update_right_frames(&mut self, site: usize, col_indices: &[usize]) -> Result<()>;
+```
+
+Manual loop formula for left update:
+
+```text
+new_full[(lf_row, s), right_bond] =
+    sum left_frame[lf_row, input_left] * site_tensor[input_left, s, right_bond]
+```
+
+Then select `row_indices`.
+
+Manual loop formula for right update:
+
+```text
+new_full[left_bond, (s, rf_col)] =
+    sum site_tensor[left_bond, s, input_right] * right_frame[input_right, rf_col]
+```
+
+Then select `col_indices`.
+
+**Step 4: Initialize solution CI-canonical form**
+
+Port the Julia right-to-left initialization:
+
+```text
+for site in (1..n).rev():
+    factorize solution[site].as_right_matrix() with left_orthogonal = false
+    replace solution[site] with right factor reshaped as (rank, site_dim, right_dim)
+    multiply previous core's right matrix by left factor
+    update right frames at `site` using selected column indices
+```
+
+Validate selected column indices before indexing input frame products. Return
+`AciError::InvalidInitialGuess` instead of panicking.
+
+**Step 5: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci elementwise_problem
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI frame state initialization"
+```
+
+## Task 5: Implement Lazy Local Block Evaluation
+
+**Files:**
+- Create: `crates/tensor4all-aci/src/local.rs`
+- Modify: `crates/tensor4all-aci/src/state.rs`
+- Modify: `crates/tensor4all-aci/src/lib.rs`
+- Modify: `crates/tensor4all-aci/src/tests.rs`
+
+**Step 1: Write failing tests for local value and batch layout**
+
+Create a test that compares the local block evaluator against an explicit
+small dense `pitensor` calculation for one input and one bond.
+
+The point ordering must match MatrixLUCI block layout:
+
+```text
+point = row_position + rows.len() * col_position
+out[point] = A[rows[row_position], cols[col_position]]
+```
+
+**Step 2: Implement local value evaluation**
+
+For one input tensor train and one candidate matrix entry:
+
+```rust
+fn local_input_value(
+    &self,
+    input: usize,
+    bond: usize,
+    row: usize,
+    col: usize,
+) -> Result<T>
+```
+
+Decode row and column:
+
+```text
+r_left = left_frame.nrows()
+d_left = input.site_dim(bond)
+d_right = input.site_dim(bond + 1)
+r_right = right_frame.ncols()
+
+left_pivot = row % r_left
+site_left = row / r_left
+site_right = col % d_right
+right_pivot = col / d_right
+```
+
+Then compute:
+
+```text
+sum_{a,m,b}
+    left_frame[left_pivot, a]
+  * core_left[a, site_left, m]
+  * core_right[m, site_right, b]
+  * right_frame[b, right_pivot]
+```
+
+Use `Tensor3Ops` and `Matrix` indexing. Return an error if any decoded index is
+out of range.
+
+**Step 3: Implement `fill_local_block`**
+
+Build an input values scratch buffer with shape `(n_inputs, n_points)` in
+column-major order:
+
+```text
+values[input + n_inputs * point]
+```
+
+Call `ElementwiseBatch::new(&values, n_inputs, n_points)` and then the user
+batched operator. Write output values back to the MatrixLUCI block output in
+the same point order.
+
+**Step 4: Add one-update local entry cache**
+
+Inside the local block evaluator, keep:
+
+```rust
+HashMap<usize, T>
+```
+
+with key:
+
+```rust
+row + nrows * col
+```
+
+Use checked multiplication/addition. Cache only output elementwise values, not
+per-input local values. Drop this cache at the end of each bond update.
+
+**Step 5: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci local
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI lazy local block evaluation"
+```
+
+## Task 6: Implement One Bond Update
+
+**Files:**
+- Modify: `crates/tensor4all-aci/src/local.rs`
+- Modify: `crates/tensor4all-aci/src/state.rs`
+- Modify: `crates/tensor4all-aci/src/tests.rs`
+
+**Step 1: Write failing one-bond update test**
+
+Use two two-site constant tensor trains. Run one local update at bond `0` with
+multiplication and assert the resulting two cores evaluate to the dense product
+on all four points.
+
+**Step 2: Implement local update**
+
+Add:
+
+```rust
+fn local_update<F>(
+    &mut self,
+    bond: usize,
+    left_orthogonal: bool,
+    options: &AciOptions<T>,
+    op: &mut F,
+) -> Result<()>
+where
+    F: FnMut(ElementwiseBatch<'_, T>, &mut [T]) -> Result<()>;
+```
+
+Inside:
+
+1. Determine candidate matrix dimensions:
+   - `nrows = left_solution_rank * site_dim[bond]`
+   - `ncols = site_dim[bond + 1] * right_solution_rank`
+2. Call `matrix_luci_factors_from_blocks`.
+3. Use `RrLUOptions`:
+   - `max_rank = options.max_bond_dim`
+   - `rel_tol = if options.scale_tolerance { options.tolerance } else { 0.0 }`
+   - `abs_tol = if options.scale_tolerance { 0.0 } else { options.tolerance }`
+   - `left_orthogonal = left_orthogonal`
+4. Reshape factors:
+   - left factor `(nrows, rank)` to `Tensor3(left_rank, site_dim_left, rank)`
+   - right factor `(rank, ncols)` to `Tensor3(rank, site_dim_right, right_rank)`
+5. Replace the two solution site tensors.
+6. Update left or right frames with selected LUCI row or column indices.
+7. Store `last_pivot_error` for that bond.
+
+**Step 3: Run one-bond tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci one_bond
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI local bond update"
+```
+
+## Task 7: Implement Public Sweep APIs
+
+**Files:**
+- Create: `crates/tensor4all-aci/src/elementwise.rs`
+- Modify: `crates/tensor4all-aci/src/lib.rs`
+- Modify: `crates/tensor4all-aci/src/tests.rs`
+
+**Step 1: Write failing public API tests**
+
+Add tests:
+
+```rust
+use crate::{elementwise, elementwise_batched, AciOptions};
+use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+
+#[test]
+fn elementwise_multiplies_constant_tensor_trains() {
+    let a = TensorTrain::<f64>::constant(&[2, 3, 2], 2.0);
+    let b = TensorTrain::<f64>::constant(&[2, 3, 2], 4.0);
+    let result = elementwise(|xs: &[f64]| xs[0] * xs[1], &[a, b], &AciOptions::default()).unwrap();
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..2 {
+                assert!((result.tensor_train.evaluate(&[i, j, k]).unwrap() - 8.0).abs() < 1e-10);
+            }
+        }
+    }
+}
+
+#[test]
+fn scalar_and_batched_paths_match() {
+    let a = TensorTrain::<f64>::constant(&[2, 2], 3.0);
+    let b = TensorTrain::<f64>::constant(&[2, 2], 5.0);
+    let options = AciOptions::default();
+    let scalar = elementwise(|xs: &[f64]| xs[0] + xs[1], &[a.clone(), b.clone()], &options).unwrap();
+    let batched = elementwise_batched(
+        |batch, out| {
+            for p in 0..batch.n_points() {
+                out[p] = batch.get(0, p)? + batch.get(1, p)?;
+            }
+            Ok(())
+        },
+        &[a, b],
+        &options,
+    ).unwrap();
+    for i in 0..2 {
+        for j in 0..2 {
+            let idx = [i, j];
+            assert!((scalar.tensor_train.evaluate(&idx).unwrap()
+                - batched.tensor_train.evaluate(&idx).unwrap()).abs() < 1e-12);
+        }
+    }
+}
+```
+
+**Step 2: Implement sweep**
+
+`elementwise_batched` flow:
+
+1. Validate options and inputs.
+2. Build or validate initial guess.
+3. Construct `ElementwiseProblem`.
+4. For `iteration in 0..max_iters`:
+   - forward if `iteration` is even, backward otherwise
+   - visit bonds in order or reverse order
+   - call `local_update`
+   - push `solution.rank()` and max pivot error
+   - stop after `min_iters` if error <= tolerance and rank history is stable
+5. Return `AciResult`.
+
+Use the Julia convergence rule as the first implementation:
+
+```text
+iteration >= min_iters
+max_error <= tolerance
+last min_iters ranks do not exceed the rank at the start of that window
+```
+
+**Step 3: Implement scalar wrapper**
+
+Wrap scalar callback into batched callback with a small scratch vector:
+
+```rust
+pub fn elementwise<T, F>(mut op: F, inputs: &[TensorTrain<T>], options: &AciOptions<T>) -> Result<AciResult<T>>
+where
+    T: AciScalar,
+    F: FnMut(&[T]) -> T,
+{
+    let mut scratch = Vec::new();
+    elementwise_batched(
+        |batch, out| {
+            scratch.resize(batch.n_inputs(), T::zero());
+            for p in 0..batch.n_points() {
+                for k in 0..batch.n_inputs() {
+                    scratch[k] = batch.get(k, p)?;
+                }
+                out[p] = op(&scratch);
+            }
+            Ok(())
+        },
+        inputs,
+        options,
+    )
+}
+```
+
+**Step 4: Run public API tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci elementwise
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI elementwise sweep API"
+```
+
+## Task 8: Add Dense Oracle and Cache Behavior Tests
+
+**Files:**
+- Create: `crates/tensor4all-aci/tests/elementwise.rs`
+- Modify: `crates/tensor4all-aci/src/local.rs`
+
+**Step 1: Add dense oracle helper**
+
+In the integration test, use `TensorTrain::to_dense()` for small tensors only.
+Materialize each input once and compare whole dense buffers.
+
+Test cases:
+
+- rank-1 constant multiplication
+- addition of two non-constant small hand-built tensor trains
+- nonlinear scalar operation such as `xs[0].sin() + xs[1] * xs[1]`
+
+**Step 2: Add cache behavior test**
+
+Use a counting batched callback:
+
+```rust
+let calls = std::cell::Cell::new(0usize);
+let op = |batch: ElementwiseBatch<'_, f64>, out: &mut [f64]| {
+    calls.set(calls.get() + batch.n_points());
+    for p in 0..batch.n_points() {
+        out[p] = batch.get(0, p)? * batch.get(1, p)?;
+    }
+    Ok(())
+};
+```
+
+Assert that repeated local block requests inside one local update do not call
+the callback for every duplicate entry. Do not assert a fragile exact count
+unless the test controls the local block requests directly.
+
+**Step 3: Run tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci --test elementwise
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add crates/tensor4all-aci
+git commit -m "Add ACI dense oracle tests"
+```
+
+## Task 9: Add Docs and API Dump
+
+**Files:**
+- Modify: `crates/tensor4all-aci/src/lib.rs`
+- Modify: `README.md`
+- Modify: `docs/api/*.md` through api-dump generation
+
+**Step 1: Add crate-level runnable example**
+
+In `src/lib.rs`, add a doc example:
+
+```rust
+//! ```
+//! use tensor4all_aci::{elementwise, AciOptions};
+//! use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
+//!
+//! let a = TensorTrain::<f64>::constant(&[2, 3], 2.0);
+//! let b = TensorTrain::<f64>::constant(&[2, 3], 4.0);
+//! let result = elementwise(
+//!     |xs: &[f64]| xs[0] * xs[1],
+//!     &[a, b],
+//!     &AciOptions::default(),
+//! ).unwrap();
+//!
+//! assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 8.0).abs() < 1e-10);
+//! assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+//! ```
+```
+
+**Step 2: Update README crate table**
+
+Add:
+
+```markdown
+| [tensor4all-aci](crates/tensor4all-aci/) | Alternating Cross Interpolation for elementwise tensor train operations |
+```
+
+Do not claim C API or language binding support.
+
+**Step 3: Generate API docs**
+
+Run:
+
+```bash
+cargo run -p api-dump --release -- . -o docs/api
+```
+
+Expected: PASS and a new or updated `docs/api/tensor4all_aci.md`.
+
+**Step 4: Run doc tests**
+
+Run:
+
+```bash
+cargo test --doc --release -p tensor4all-aci
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add crates/tensor4all-aci README.md docs/api
+git commit -m "Document ACI Rust API"
+```
+
+## Task 10: Final Verification
+
+**Files:**
+- No planned edits unless verification finds a bug.
+
+**Step 1: Format**
+
+Run:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+Expected: PASS.
+
+**Step 2: Lint**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: PASS. Fix warnings by improving code, not by suppressing warnings
+unless the suppression has a narrow justification.
+
+**Step 3: Targeted tests**
+
+Run:
+
+```bash
+cargo test --release -p tensor4all-aci
+cargo test --doc --release -p tensor4all-aci
+```
+
+Expected: PASS.
+
+**Step 4: Full tests**
+
+Run:
+
+```bash
+cargo nextest run --release --workspace
+```
+
+Expected: PASS.
+
+**Step 5: Commit any verification fixes**
+
+If formatting or test fixes were required:
+
+```bash
+git add <changed-files>
+git commit -m "Fix ACI verification issues"
+```
+
+If no fixes were required, do not create an empty commit.

--- a/docs/plans/2026-05-21-aci-rust-api-implementation-plan.md
+++ b/docs/plans/2026-05-21-aci-rust-api-implementation-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Implement a new `tensor4all-aci` crate that depends on `tensor4all-simplett`, `tensor4all-tcicore`, and `tensor4all-tensorbackend`. The public API exposes scalar and batched elementwise entry points, while the internal algorithm uses persistent ACI frames, one-bond local entry caches, and lazy MatrixLUCI block requests.
 
-**Tech Stack:** Rust 2021, `thiserror`, `rand`, `rand_chacha`, `rand_distr`, `tensor4all-simplett`, `tensor4all-tcicore::matrix_luci_factors_from_blocks`, `tensor4all-tensorbackend::Matrix`.
+**Tech Stack:** Rust 2021, `thiserror`, `rand`, `rand_chacha`, `rand_distr`, `criterion`, `tensor4all-simplett`, `tensor4all-tcicore::matrix_luci_factors_from_blocks`, `tensor4all-tensorbackend::Matrix`, Julia 1.10+, `BenchmarkTools.jl`, `AlternatingCrossInterpolation.jl`.
 
 ---
 
@@ -24,6 +24,10 @@
   - `crates/tensor4all-simplett/src/traits.rs`
   - `crates/tensor4all-tcicore/src/matrix_luci.rs`
   - `crates/tensor4all-tensorbackend/src/matrix.rs` or the current `Matrix` module path
+- Benchmark references:
+  - `benchmarks/README.md`
+  - `benchmarks/julia/Project.toml`
+  - Existing Rust/Julia paired benchmark scripts under `benchmarks/rust/` and `benchmarks/julia/`
 
 ## Task 1: Scaffold `tensor4all-aci`
 
@@ -1079,7 +1083,153 @@ git add crates/tensor4all-aci README.md docs/api
 git commit -m "Document ACI Rust API"
 ```
 
-## Task 10: Final Verification
+## Task 10: Add Julia Parity and Chi-Scaling Benchmarks
+
+**Files:**
+- Modify: `crates/tensor4all-aci/Cargo.toml`
+- Create: `crates/tensor4all-aci/benches/elementwise_scaling.rs`
+- Modify: `benchmarks/julia/Project.toml`
+- Create: `benchmarks/julia/benchmark_aci_elementwise.jl`
+- Modify: `benchmarks/README.md`
+- Create: `benchmarks/results/<date>-aci-elementwise.md`
+
+**Step 1: Add Criterion benchmark target**
+
+In the existing `crates/tensor4all-aci/Cargo.toml` `[dev-dependencies]`
+section, add `criterion.workspace = true`, preserving existing entries:
+
+```toml
+[dev-dependencies]
+approx.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "elementwise_scaling"
+harness = false
+```
+
+Do not create a second `[dev-dependencies]` section.
+
+**Step 2: Implement Rust chi-scaling benchmark**
+
+Create `crates/tensor4all-aci/benches/elementwise_scaling.rs`.
+
+Benchmark requirements:
+
+- Benchmark group name: `aci_elementwise_chi_scaling`.
+- Fixed parameters for the primary comparison:
+  - `n_sites = 12`
+  - `local_dim = 2`
+  - `n_inputs = 2`
+  - `tolerance = 1e-10`
+  - `max_iters = 20`
+  - `chi_values = [2, 4, 8, 16]`
+- Add `chi = 32` as an optional long case behind a command-line filter or a
+  separate benchmark group so the smoke run remains practical.
+- Build deterministic input tensor trains from the same closed-form core formula
+  used by the Julia script. Do not rely on Rust and Julia RNG streams matching.
+- Time the batched public API path as the primary benchmark. The scalar wrapper
+  can be included as a secondary callback-overhead benchmark, but the completion
+  criterion is the batched path.
+- Record enough observable metadata to compare with Julia:
+  - `chi`
+  - final maximum output bond dimension
+  - number of sweeps recorded in `AciResult::ranks`
+  - final maximum pivot error from `AciResult::errors`
+  - sampled max absolute error against direct dense point evaluation
+- Use `criterion::{criterion_group, criterion_main, BenchmarkId, Criterion}` and
+  `black_box`.
+
+The sampled correctness check should evaluate at least 64 deterministic points
+for each `chi` and assert the sampled max absolute error is less than `1e-8`.
+This check must run outside the timed closure so benchmark timing measures ACI,
+not validation.
+
+**Step 3: Implement Julia comparison benchmark**
+
+Add `BenchmarkTools` to `benchmarks/julia/Project.toml`:
+
+```toml
+BenchmarkTools = "6e4b80f9-dda5-5e3a-8b7e-868b0140f7fe"
+```
+
+Create `benchmarks/julia/benchmark_aci_elementwise.jl` that:
+
+- Loads upstream `AlternatingCrossInterpolation.jl` as `ACI`.
+  - If `ENV["ACI_JL_PATH"]` is set, use `Pkg.develop(path=ENV["ACI_JL_PATH"])`.
+  - Otherwise use `Pkg.add(url="https://github.com/tensor4all/AlternatingCrossInterpolation.jl.git")`.
+- Uses the same benchmark parameters and the same deterministic core formula as
+  the Rust benchmark.
+- Uses `ACI.TruncationParameters(typemax(Int), 1e-10, false)` unless the Rust
+  benchmark uses a smaller `max_bond_dim`; keep the two sides matched.
+- Runs `ACI.elementwise(*, inputs; truncationparameters=...)`.
+- Prints CSV rows with this schema:
+
+```text
+impl,n_sites,local_dim,chi,tolerance,median_ms,min_ms,mean_ms,max_ms,output_max_chi,n_sweeps,final_error,sampled_max_abs_error
+```
+
+Use `BenchmarkTools.@benchmark` or equivalent repeated timing. Do not include
+package installation time or input construction in the measured closure.
+
+**Step 4: Update benchmark README**
+
+In `benchmarks/README.md`, add commands:
+
+```bash
+RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- --sample-size 10
+BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_aci_elementwise.jl --chis 2,4,8,16
+```
+
+Document that `chi`/`χ` is the TT bond dimension scaling axis and that `chi=32`
+is a longer optional run.
+
+**Step 5: Run Rust benchmark smoke check**
+
+Run:
+
+```bash
+cargo bench --no-run -p tensor4all-aci --bench elementwise_scaling
+RAYON_NUM_THREADS=1 cargo bench -p tensor4all-aci --bench elementwise_scaling -- --sample-size 10 --measurement-time 1 --warm-up-time 1
+```
+
+Expected: benchmark compiles and prints timings for `chi = 2, 4, 8, 16`.
+
+**Step 6: Run Julia comparison**
+
+Run:
+
+```bash
+ACI_JL_PATH=/tmp/AlternatingCrossInterpolation.jl BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_aci_elementwise.jl --chis 2,4,8,16
+```
+
+Expected: Julia benchmark prints the same CSV schema and reports sampled errors
+below `1e-8`. If `/tmp/AlternatingCrossInterpolation.jl` is absent, clone the
+upstream repository or let the script install by URL.
+
+**Step 7: Record comparison results**
+
+Create `benchmarks/results/<date>-aci-elementwise.md` with:
+
+- Exact Rust and Julia commands.
+- Host CPU/thread settings if available.
+- A table comparing Rust and Julia for each `chi`.
+- A short interpretation of scaling versus `chi`, including whether runtime
+  growth appears consistent with the expected local two-site block cost.
+- Numerical parity notes: sampled max absolute errors for both implementations
+  and any rank/error trajectory differences.
+
+Do not claim Rust is faster or slower in docs unless the benchmark was actually
+run in the current branch and the raw commands/results are recorded.
+
+**Step 8: Commit**
+
+```bash
+git add crates/tensor4all-aci/Cargo.toml crates/tensor4all-aci/benches benchmarks/julia/Project.toml benchmarks/julia/benchmark_aci_elementwise.jl benchmarks/README.md benchmarks/results
+git commit -m "Benchmark ACI elementwise chi scaling"
+```
+
+## Task 11: Final Verification
 
 **Files:**
 - No planned edits unless verification finds a bug.
@@ -1127,7 +1277,28 @@ cargo nextest run --release --workspace
 
 Expected: PASS.
 
-**Step 5: Commit any verification fixes**
+**Step 5: Benchmark compile check**
+
+Run:
+
+```bash
+cargo bench --no-run -p tensor4all-aci --bench elementwise_scaling
+```
+
+Expected: PASS.
+
+**Step 6: Confirm Julia comparison was recorded**
+
+Check:
+
+```bash
+ls benchmarks/results/*aci-elementwise*.md
+```
+
+Expected: at least one result file from Task 10 containing the Rust/Julia
+comparison and chi-scaling table.
+
+**Step 7: Commit any verification fixes**
 
 If formatting or test fixes were required:
 

--- a/docs/plans/2026-05-22-aci-rust-api-handoff.md
+++ b/docs/plans/2026-05-22-aci-rust-api-handoff.md
@@ -155,27 +155,154 @@ MatrixLUCI selection is close under CPU pinning, but factor construction still
 differs by implementation route. The total is close enough that a quieter host
 is needed before further tuning.
 
+### ACI Local Step, System OpenBLAS Rerun
+
+On the macOS handoff host, Rust was rebuilt against Homebrew system OpenBLAS
+instead of the default faer backend. The test binary was verified with
+`otool -L` to link `/opt/homebrew/opt/openblas/lib/libopenblas.0.dylib`.
+
+Command:
+
+```bash
+OPENBLAS_ROOT=${OPENBLAS_ROOT:-$(brew --prefix openblas)}
+env \
+RUSTFLAGS="-L native=${OPENBLAS_ROOT}/lib -l dylib=openblas" \
+DYLD_LIBRARY_PATH="${OPENBLAS_ROOT}/lib:${DYLD_LIBRARY_PATH:-}" \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 T4A_STEP_TIMING_CHIS=16,32 \
+cargo test --release -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas \
+  local_update_step_timing -- --ignored --nocapture
+```
+
+Result after owned-conversion and rrLU flat-slice optimizations:
+
+```text
+rust,16,50,3,33,0.117666,0.000835,0.001292,0.055043,0.053250,0.006645,0.080397,0.027372,0.323687,0.004709,0.063438,0.614538,25,8.805722e-11
+rust,32,50,3,33,0.211792,0.000668,0.001084,0.073544,0.131126,0.005478,0.094503,0.025479,0.323209,0.003999,0.100208,0.759833,26,6.172906e-11
+```
+
+The corresponding Julia run from the same host earlier in the session was:
+
+```text
+julia,16,50,3,33,0.1879575,0.0,0.0,0.086867,0.0966605,0.0,0.111789,0.0087505,0.3064995,0.0111035,0.1248325,0.755751,25,8.805721625343378e-11
+julia,32,50,3,33,0.2998115,0.0,0.0,0.0964205,0.19694300000000003,0.0,0.138312,0.0093775,0.3468935,0.0110005,0.1685645,0.9774875,26,6.172906150931444e-11
+```
+
+This makes the Rust/Julia comparison use system OpenBLAS on both sides.
+
+For full Rust test runs that include doctests, add
+`RUSTDOCFLAGS="-L native=${OPENBLAS_ROOT}/lib"` as well. `RUSTFLAGS` handles
+normal test binaries, while rustdoc needs its own library search path.
+
+### ACI Local Step, L=16, chi <= 128
+
+The earlier `L = 12` fixture clamps `chi = 128` because the central exact-rank
+bound is `2^6 = 64`. A new `L = 16` run avoids that clamp (`2^8 = 256`) and
+uses `fixed_sweeps = 3` so Rust and Julia both perform 45 local updates.
+
+Saved result:
+`benchmarks/results/2026-05-22-aci-local-step-l16-openblas.md`.
+
+Summary:
+
+```text
+impl,chi,n_sites,repeats,min_iters,fixed_sweeps,n_sweeps,n_updates,total_ms,matrix_luci_ms,final_rank,final_error
+rust,16,16,20,2,3,3,45,1.841535,1.259810,33,9.525310e-11
+julia,16,16,20,2,3,3,45,2.115942,1.233481,33,9.525310e-11
+rust,32,16,20,2,3,3,45,3.330730,2.209271,46,9.720931e-11
+julia,32,16,20,2,3,3,45,4.085233,2.414964,46,9.720948e-11
+rust,64,16,20,2,3,3,45,7.975667,4.708000,63,9.320186e-11
+julia,64,16,20,2,3,3,45,9.584417,5.213416,63,9.930868e-11
+rust,128,16,20,2,3,3,45,15.889415,7.987332,76,8.523082e-11
+julia,128,16,20,2,3,3,45,17.230575,8.276169,76,8.961109e-11
+```
+
+The Rust implementation now uses a Julia-shaped convergence helper in
+`tensor4all-aci`: `iteration < min_iters` rejects, `errors[iteration] >
+tolerance` rejects, and `any(last(ranks, min_iters) .>
+ranks[iteration-min_iters+1])` rejects. Rust's optional `scale_tolerance` mode
+is disabled in this benchmark. Fixed sweeps are used because small
+numerical/path differences can still make the native stopping sweep differ.
+
+### MatrixLU Standalone Timing
+
+Added standalone MatrixLU Hilbert runners:
+
+- `benchmarks/rust/benchmark_matrix_lu.rs`
+- `crates/tensor4all-tcicore/examples/benchmark_matrix_lu.rs`
+- `benchmarks/julia/benchmark_matrix_lu.jl`
+
+Saved result:
+`benchmarks/results/2026-05-22-matrix-lu-hilbert.md`.
+
+MatrixLU itself does not call BLAS. The Rust runner currently uses the default
+feature set because the `tensor4all-tcicore` dev-dependency on
+`tensor4all-tensorci` still forces `tenferro-cpu-faer`, which conflicts with a
+system-BLAS example build.
+
+## TODO: Similar Clean Optimizations
+
+- Split MatrixLUCI timing into `rrlu_inplace`, LU extraction, triangular solve,
+  permutation, and public factor packaging. The current `matrix_luci_ms` bucket
+  is now close to Julia, but the sub-buckets will show whether more work belongs
+  in tcicore or tenferro.
+- Make `tensor4all-tcicore` benchmark/dev-dependency backend selection
+  feature-clean so standalone examples can be built with
+  `--no-default-features --features tenferro-system-blas` without pulling in a
+  conflicting `tensor4all-tensorci/tenferro-cpu-faer`.
+- Move ACI local-step timing out of the ignored unit test once a minimal
+  feature-gated `bench_support` API can expose the crate-private timing hooks.
+  Target layout: `benchmarks/rust/benchmark_aci_local_steps.rs` plus a thin
+  `crates/tensor4all-aci/examples/benchmark_aci_local_steps.rs` wrapper.
+- Add a MatrixLUCI-owned factorization path that constructs ACI-facing left and
+  right factors directly from the factorized column-major buffer. This can avoid
+  building intermediate full `RrLU` L/U matrices when callers only need
+  `MatrixLuciFactors`.
+- Audit remaining hot nested loops that use `Matrix[[row, col]]` after their
+  ranges are already known. Good candidates are `matrix_luci.rs`
+  `apply_row_permutation`, `apply_col_permutation`, `identity_rect`, and the
+  post-solve copy loops.
+- Keep unsafe indexing localized behind small column-major helpers, as in
+  `matrixlu.rs`; do not spread raw `get_unchecked` through algorithm code.
+- Check `matrixaca.rs`, `matrixluci/factors.rs`, and default
+  `AbstractMatrixCI` helper paths for the same pattern: validate once, then use
+  flat column-major slice iteration.
+- Consider borrowed/owned variants for repeated submatrix extraction and
+  permutation helpers so callers that just created a `Matrix` can avoid extra
+  clones while keeping the public API clear.
+
 ## Verification Run Before Commit
 
 The latest local verification before commit included:
 
 ```bash
 cargo fmt --all -- --check
-cargo test --release -p tensor4all-tensorbackend --lib -- --nocapture
-cargo test --release -p tensor4all-tcicore -- --nocapture
-cargo test --release -p tensor4all-aci -- --nocapture
+cargo test --release -p tensor4all-tensorbackend --lib
+cargo test --release -p tensor4all-tcicore
+cargo test --release -p tensor4all-aci
 cargo test --doc --release -p tensor4all-tensorbackend
+cargo test --doc --release -p tensor4all-aci
+OPENBLAS_ROOT=${OPENBLAS_ROOT:-$(brew --prefix openblas)}
+env \
+RUSTFLAGS="-L native=${OPENBLAS_ROOT}/lib -l dylib=openblas" \
+RUSTDOCFLAGS="-L native=${OPENBLAS_ROOT}/lib" \
+DYLD_LIBRARY_PATH="${OPENBLAS_ROOT}/lib:${DYLD_LIBRARY_PATH:-}" \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+cargo test --release -p tensor4all-aci \
+  --no-default-features --features tenferro-system-blas
 ```
 
 Observed results:
 
-- `tensor4all-tensorbackend`: 139 lib tests passed.
-- `tensor4all-tcicore`: 101 unit tests passed, 1 ignored; 97 doc tests passed.
-- `tensor4all-aci`: 72 unit tests passed, 1 ignored; 4 integration tests
+- `tensor4all-tensorbackend`: 140 lib tests passed; 123 doc tests passed.
+- `tensor4all-tcicore`: 102 unit tests passed, 1 ignored; 97 doc tests passed.
+- `tensor4all-aci`: 74 unit tests passed, 1 ignored; 4 integration tests
   passed; 15 doc tests passed.
-- `tensor4all-tensorbackend` doc tests: 122 passed.
-
-The branch should still be rechecked on the final benchmark host before a PR.
+- `tensor4all-aci` with `tenferro-system-blas`: 74 unit tests passed,
+  1 ignored; 4 integration tests passed; 15 doc tests passed.
 
 ## Recommended Next Steps
 

--- a/docs/plans/2026-05-22-aci-rust-api-handoff.md
+++ b/docs/plans/2026-05-22-aci-rust-api-handoff.md
@@ -1,0 +1,195 @@
+# ACI Rust API Handoff
+
+Date: 2026-05-22
+
+Branch: `codex/aci-rust-api`
+
+## Scope
+
+This branch ports the core public Rust API for Alternating Cross Interpolation
+workflows and aligns the local update path with the upstream Julia algorithm.
+The current work focuses on the elementwise two-input TensorTrain case,
+MatrixLUCI factor construction, batch evaluation, cache-aware local update
+setup, and benchmark instrumentation against
+`AlternatingCrossInterpolation.jl`.
+
+No PR has been created from this branch.
+
+## Main Changes
+
+- Added `crates/tensor4all-aci/README.md` with upstream attribution and the
+  Ritter paper citation.
+- Added repository rules that forbid explicit pivot inverses, local dense
+  linear algebra kernels, and copy-pasted scalar-specific implementations where
+  a generic helper or macro is appropriate.
+- Added system BLAS feature forwarding through relevant crates:
+  `tenferro-system-blas`.
+- Reworked ACI local update setup:
+  - precomputes local input factors per input instead of repeatedly evaluating
+    full local TT entries;
+  - batches local setup GEMMs when shapes match;
+  - batches full local input materialization with `batched_mat_mul_same_shape`;
+  - batches frame updates;
+  - keeps test-only benchmark gates:
+    `T4A_ACI_DISABLE_BATCHED_LOCAL_SETUP=1`,
+    `T4A_ACI_DISABLE_BATCHED_MATERIALIZE=1`, and
+    `T4A_ACI_DISABLE_BATCHED_FRAME=1`.
+- Added cached input-core matrix views in `ElementwiseProblem`, so repeated
+  local setup does not rebuild the same dense core matrix views.
+- Added `tensor4all-tensorbackend::Matrix` conversion APIs:
+  - `into_col_major_vec`;
+  - `to_typed_tensor`;
+  - `into_typed_tensor`;
+  - `try_from_typed_tensor`;
+  - `MatrixTensorConversionError`.
+- Added owned matrix linalg wrappers:
+  - `mat_mul_owned`;
+  - `solve_matrix_owned`;
+  - `triangular_solve_matrix_owned`.
+- Added backend triangular solve wrappers and tests.
+- Reworked MatrixLUCI dense factor construction to follow the Julia rrLU-based
+  solve formulation:
+  - no explicit pivot inverse;
+  - uses backend triangular solves;
+  - uses owned Matrix-to-TypedTensor conversion where input buffers can be
+    consumed.
+- Added MatrixLUCI Hilbert timing benchmark and Julia counterpart.
+- Added ACI local update step timing benchmark and Julia counterpart.
+
+## Tenferro Notes
+
+Do not assume tenferro changes are present. Another agent was working in a
+separate tenferro worktree. This branch currently uses the pinned tenferro API
+and its existing `From<TypedTensor<_>> for Tensor` conversions.
+
+A possible future tenferro cleanup is to add a macro-generated
+`TensorScalar::into_dynamic` / typed view helper inside tenferro itself, but
+that change is not required for this branch.
+
+## Benchmarks Run
+
+The machine was heavily loaded during the last benchmark pass:
+
+- load average was about `48`;
+- many unrelated `solve_bse_afm_hf_only_quench` processes were active;
+- `mpstat` showed a few mostly idle cores, but measurements still varied.
+
+Treat the following numbers as handoff context, not final performance claims.
+
+### ACI Local Step, `chi = 32`
+
+Command:
+
+```bash
+taskset -c 58 env \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 T4A_STEP_TIMING_CHIS=32 \
+cargo test --release -p tensor4all-aci local_update_step_timing -- --ignored --nocapture
+```
+
+Result:
+
+```text
+rust,32,50,3,33,2.022448,0.004660,0.005720,1.027935,0.986077,0.017761,1.147757,0.118297,3.225273,0.217013,1.325973,8.073430,26,6.172906e-11
+```
+
+Julia command:
+
+```bash
+taskset -c 58 env \
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_STEP_TIMING_REPEATS=50 \
+julia benchmarks/julia/benchmark_aci_local_steps.jl --chis 32
+```
+
+Result:
+
+```text
+julia,32,50,3,33,1.7984784999999999,0.0,0.0,0.896193,0.9031885,0.0,1.036934,0.085758,1.6588165,0.07977200000000001,1.076152,5.7409,26,6.172906150931444e-11
+```
+
+Earlier in the same session, without CPU pinning, Rust produced `4.457842 ms`
+total for `chi=32`, while Julia produced `6.0671765 ms`. Because the machine
+load changed during the session, rerun on a quieter host before drawing
+conclusions.
+
+### MatrixLUCI Hilbert, size 64
+
+Rust command:
+
+```bash
+taskset -c 58 env \
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LUCI_REPEATS=100 T4A_MATRIX_LUCI_SIZES=64 \
+cargo test --release -p tensor4all-tcicore matrix_luci_hilbert_timing -- --ignored --nocapture
+```
+
+Result:
+
+```text
+rust,hilbert,64,100,true,0.108844,0.000000,0.046796,0.045056,0.193050,13,9.601802e-12,2.000000e0
+rust,hilbert,64,100,false,0.104603,0.000000,0.045361,0.040711,0.187775,13,9.601802e-12,2.000000e0
+```
+
+Julia command:
+
+```bash
+taskset -c 58 env \
+JULIA_NUM_THREADS=1 BLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+T4A_MATRIX_LUCI_REPEATS=100 \
+julia benchmarks/julia/benchmark_matrix_luci.jl --sizes 64
+```
+
+Result:
+
+```text
+julia,hilbert,64,100,true,0.18505549999999998,0.0,0.015735,0.008965,0.212001,13,9.601801849524244e-12,2.0
+julia,hilbert,64,100,false,0.174785,0.0,0.008660000000000001,0.0145305,0.198306,13,9.601801849524244e-12,2.0
+```
+
+MatrixLUCI selection is close under CPU pinning, but factor construction still
+differs by implementation route. The total is close enough that a quieter host
+is needed before further tuning.
+
+## Verification Run Before Commit
+
+The latest local verification before commit included:
+
+```bash
+cargo fmt --all -- --check
+cargo test --release -p tensor4all-tensorbackend --lib -- --nocapture
+cargo test --release -p tensor4all-tcicore -- --nocapture
+cargo test --release -p tensor4all-aci -- --nocapture
+cargo test --doc --release -p tensor4all-tensorbackend
+```
+
+Observed results:
+
+- `tensor4all-tensorbackend`: 139 lib tests passed.
+- `tensor4all-tcicore`: 101 unit tests passed, 1 ignored; 97 doc tests passed.
+- `tensor4all-aci`: 72 unit tests passed, 1 ignored; 4 integration tests
+  passed; 15 doc tests passed.
+- `tensor4all-tensorbackend` doc tests: 122 passed.
+
+The branch should still be rechecked on the final benchmark host before a PR.
+
+## Recommended Next Steps
+
+1. Re-run the Rust and Julia benchmark commands above on a quieter host with
+   the same CPU affinity and one-thread settings.
+2. Compare `chi = 16, 32, 64` scaling for ACI local updates; `chi = 32` alone
+   is not enough to diagnose scaling.
+3. If Rust remains slower, inspect:
+   - MatrixLUCI selection timing;
+   - frame update timing;
+   - `core_update_ms`, where Rust was much slower in the noisy pinned run;
+   - whether tenferro-owned linalg wrappers can avoid more typed/dynamic
+     boundary overhead.
+4. Audit the repository for remaining hand-written dense linalg in feature
+   crates, as requested earlier.
+5. Decide whether the test-only ACI benchmark gates should remain in-tree or
+   move to a benchmark-specific configuration path.


### PR DESCRIPTION
## Summary
- Port `tensor4all-aci` as the Rust counterpart of `AlternatingCrossInterpolation.jl` elementwise ACI for tensor trains.
- Add the public ACI API surface: `elementwise`, `elementwise_batched`, `ElementwiseBatch`, `AciOptions`, `AciResult`, typed errors, README examples, and doctested usage.
- Wire ACI local updates through `tensor4all-simplett`, `tensor4all-tcicore`, and `tensor4all-tensorbackend`, including deterministic tests against dense oracles.
- Add Rust/Julia benchmark runners and saved benchmark results for elementwise ACI, local-step bucket timing, MatrixLUCI, and standalone MatrixLU.
- Align the Rust convergence check with Julia's `convergencecriterion` shape and reject `min_iters = 0` as an invalid option.

## Performance Work Included
- Reduce `Matrix` <-> tenferro `TypedTensor` conversion overhead with owned matrix and batched-GEMM paths.
- Add an owned MatrixLUCI factorization path for ACI local matrices.
- Optimize rrLU hot loops over prevalidated column-major slices, keeping unchecked indexing localized in small helpers.
- Store the durable dense-loop lesson in `REPOSITORY_RULES.md`: validate ranges once, then iterate over column-major slices in hot paths.

## Benchmark Snapshot
L=16 fixed-sweep local-step medians, Rust built with `tenferro-system-blas` against Homebrew OpenBLAS:

| chi | Rust total ms | Julia total ms | Rust MatrixLUCI ms | Julia MatrixLUCI ms | rank |
|---:|---:|---:|---:|---:|---:|
| 16 | 1.841535 | 2.115942 | 1.259810 | 1.233481 | 33 |
| 32 | 3.330730 | 4.085233 | 2.209271 | 2.414964 | 46 |
| 64 | 7.975667 | 9.584417 | 4.708000 | 5.213416 | 63 |
| 128 | 15.889415 | 17.230575 | 7.987332 | 8.276169 | 76 |

Saved details are in `benchmarks/results/2026-05-22-aci-local-step-l16-openblas.md` and `docs/plans/2026-05-22-aci-rust-api-handoff.md`.

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --release -p tensor4all-tensorbackend --lib`
- `cargo test --release -p tensor4all-tcicore`
- `cargo test --release -p tensor4all-aci`
- `cargo test --doc --release -p tensor4all-tensorbackend`
- `cargo test --doc --release -p tensor4all-aci`
- `cargo test --release -p tensor4all-aci --no-default-features --features tenferro-system-blas` with `RUSTFLAGS`, `RUSTDOCFLAGS`, and `DYLD_LIBRARY_PATH` pointed at Homebrew OpenBLAS

## Notes
- MatrixLU standalone still trails Julia on the saved Hilbert microbenchmark; this is tracked separately because the ACI local MatrixLUCI bucket is now close under the L=16 fixture.
- Upstream `AlternatingCrossInterpolation.jl` currently lists `Marc Ritter and contributors` in its Project.toml/LICENSE, while the paper citation is Marc Ritter.
