### PR TITLE
[codex] Update to latest tenferro-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,9 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "95fb0724c81cfb2f7640b2cd9255d1700c100358", default-features = false }
-tenferro-device = { package = "tenferro-internal-device", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "95fb0724c81cfb2f7640b2cd9255d1700c100358" }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "95fb0724c81cfb2f7640b2cd9255d1700c100358", default-features = false }
-tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "95fb0724c81cfb2f7640b2cd9255d1700c100358", default-features = false }
-tenferro-tensor = { package = "tenferro-internal-tensor", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "95fb0724c81cfb2f7640b2cd9255d1700c100358", default-features = false }
+tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }
+tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }
+tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }
+tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }

--- a/benchmarks/rust/benchmark_tt_ops.rs
+++ b/benchmarks/rust/benchmark_tt_ops.rs
@@ -25,7 +25,9 @@ use tensor4all_core::{
     TensorContractionLike, TensorDynLen,
 };
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
-use tenferro::{CpuBackend, DotGeneralConfig, EagerRuntime, EagerTensor, Tensor, TypedTensor};
+use tenferro::{DotGeneralConfig, Tensor, TypedTensor};
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_cpu::CpuBackend;
 
 #[derive(Debug, Clone)]
 struct Options {

--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -13,35 +13,32 @@ backend-tenferro = ["tensor4all-tensorbackend/backend-tenferro"]
 tenferro-cpu-faer = [
     "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tensor4all-tcicore/tenferro-cpu-faer",
-    "tenferro/autodiff",
     "tenferro/cpu-faer",
+    "tenferro-ad/cpu-faer",
     "tenferro-einsum/autodiff",
     "tenferro-einsum/cpu-faer",
     "tenferro-linalg/autodiff",
     "tenferro-linalg/cpu-faer",
-    "tenferro-tensor/cpu-faer",
 ]
 tenferro-system-blas = [
     "tensor4all-tensorbackend/tenferro-system-blas",
     "tensor4all-tcicore/tenferro-system-blas",
-    "tenferro/autodiff",
     "tenferro/cpu-blas",
+    "tenferro-ad/cpu-blas",
     "tenferro-einsum/autodiff",
     "tenferro-einsum/cpu-blas",
     "tenferro-linalg/autodiff",
     "tenferro-linalg/cpu-blas",
-    "tenferro-tensor/cpu-blas",
 ]
 tenferro-provider-inject = [
     "tensor4all-tensorbackend/tenferro-provider-inject",
     "tensor4all-tcicore/tenferro-provider-inject",
-    "tenferro/autodiff",
     "tenferro/cpu-blas",
+    "tenferro-ad/cpu-blas",
     "tenferro-einsum/autodiff",
     "tenferro-einsum/cpu-blas",
     "tenferro-linalg/autodiff",
-    "tenferro-linalg/cpu-blas",
-    "tenferro-tensor/provider-inject",
+    "tenferro-linalg/provider-inject",
 ]
 
 [dependencies]
@@ -58,6 +55,7 @@ omeco.workspace = true
 petgraph.workspace = true
 smallvec.workspace = true
 tenferro.workspace = true
+tenferro-ad.workspace = true
 tenferro-einsum.workspace = true
 tenferro-linalg.workspace = true
 tenferro-tensor.workspace = true

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -135,9 +135,9 @@ impl AnyScalar {
         rhs: &Self,
         op: &'static str,
         f: impl FnOnce(
-            &tenferro::EagerTensor,
-            &tenferro::EagerTensor,
-        ) -> std::result::Result<tenferro::EagerTensor, E>,
+            &tenferro_ad::EagerTensor,
+            &tenferro_ad::EagerTensor,
+        ) -> std::result::Result<tenferro_ad::EagerTensor, E>,
     ) -> Result<Self>
     where
         E: fmt::Display,
@@ -150,7 +150,7 @@ impl AnyScalar {
     fn from_eager_unary<E>(
         input: &Self,
         op: &'static str,
-        f: impl FnOnce(&tenferro::EagerTensor) -> std::result::Result<tenferro::EagerTensor, E>,
+        f: impl FnOnce(&tenferro_ad::EagerTensor) -> std::result::Result<tenferro_ad::EagerTensor, E>,
     ) -> Result<Self>
     where
         E: fmt::Display,

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -37,7 +37,7 @@ use crate::defaults::DynIndex;
 use crate::{contract_pair, unfold_split, TensorDynLen};
 use anyhow::Result as AnyhowResult;
 use num_complex::{Complex64, ComplexFloat};
-use tenferro::EagerTensor;
+use tenferro_ad::EagerTensor;
 use tenferro_linalg::eager_tensor::full_piv_lu_solve as eager_full_piv_lu_solve;
 use tensor4all_tcicore::{rrlu, AbstractMatrixCI, MatrixLUCI, RrLUOptions, Scalar as MatrixScalar};
 use tensor4all_tensorbackend::{Matrix, TensorElement};

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -16,7 +16,8 @@ use crate::truncation::{
 };
 use crate::TensorDynLen;
 use std::sync::Mutex;
-use tenferro::{DType, EagerTensor};
+use tenferro::DType;
+use tenferro_ad::EagerTensor;
 use tenferro_linalg::eager_tensor::svd as eager_svd;
 use tensor4all_tensorbackend::{
     native_tensor_primal_to_dense_c64_col_major, native_tensor_primal_to_dense_f64_col_major,

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -14,7 +14,8 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
-use tenferro::{DType, DotGeneralConfig, EagerTensor, Tensor as NativeTensor};
+use tenferro::{DType, DotGeneralConfig, Tensor as NativeTensor};
+use tenferro_ad::EagerTensor;
 use tenferro_einsum::eager_tensor::einsum_subscripts as eager_einsum_ad;
 use tenferro_einsum::EinsumSubscripts;
 use tensor4all_tensorbackend::{

--- a/crates/tensor4all-core/tests/send_sync.rs
+++ b/crates/tensor4all-core/tests/send_sync.rs
@@ -4,6 +4,6 @@ fn assert_send_sync<T: Send + Sync>() {}
 
 #[test]
 fn eager_tensor_and_tensordynlen_are_send_sync() {
-    assert_send_sync::<tenferro::EagerTensor>();
+    assert_send_sync::<tenferro_ad::EagerTensor>();
     assert_send_sync::<TensorDynLen>();
 }

--- a/crates/tensor4all-itensorlike/Cargo.toml
+++ b/crates/tensor4all-itensorlike/Cargo.toml
@@ -33,4 +33,6 @@ anyhow.workspace = true
 [dev-dependencies]
 approx.workspace = true
 tenferro.workspace = true
+tenferro-ad.workspace = true
+tenferro-cpu.workspace = true
 tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false, features = ["tenferro-cpu-faer"] }

--- a/crates/tensor4all-simplett/Cargo.toml
+++ b/crates/tensor4all-simplett/Cargo.toml
@@ -19,21 +19,18 @@ tenferro-cpu-faer = [
     "tensor4all-tcicore/tenferro-cpu-faer",
     "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tenferro-einsum/cpu-faer",
-    "tenferro-tensor/cpu-faer",
 ]
 tenferro-system-blas = [
     "tensor4all-core/tenferro-system-blas",
     "tensor4all-tcicore/tenferro-system-blas",
     "tensor4all-tensorbackend/tenferro-system-blas",
     "tenferro-einsum/cpu-blas",
-    "tenferro-tensor/cpu-blas",
 ]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-tcicore/tenferro-provider-inject",
     "tensor4all-tensorbackend/tenferro-provider-inject",
     "tenferro-einsum/cpu-blas",
-    "tenferro-tensor/provider-inject",
 ]
 
 [dependencies]

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -231,8 +231,8 @@ where
     })?;
 
     let u = Matrix::from_col_major_vec(
-        svd_result.u.shape[0],
-        svd_result.u.shape[1],
+        svd_result.u.shape()[0],
+        svd_result.u.shape()[1],
         tensor_to_col_major_vec(&svd_result.u),
     );
     let s_data: Vec<f64> = tensor_to_col_major_vec(&svd_result.s)
@@ -240,8 +240,8 @@ where
         .map(f64::from)
         .collect();
     let vt = Matrix::from_col_major_vec(
-        svd_result.vt.shape[0],
-        svd_result.vt.shape[1],
+        svd_result.vt.shape()[0],
+        svd_result.vt.shape()[1],
         tensor_to_col_major_vec(&svd_result.vt),
     );
 

--- a/crates/tensor4all-simplett/src/einsum_helper.rs
+++ b/crates/tensor4all-simplett/src/einsum_helper.rs
@@ -97,7 +97,7 @@ pub(crate) fn einsum_tensors<T: EinsumScalar>(
     })?;
     let tensors: Vec<Tensor> = operands
         .iter()
-        .map(|tensor| T::into_tensor(tensor.shape.clone(), tensor.host_data().to_vec()))
+        .map(|tensor| T::into_tensor(tensor.shape().to_vec(), tensor.host_data().to_vec()))
         .collect();
     let input_ids = parsed
         .inputs
@@ -155,10 +155,10 @@ pub(crate) fn typed_tensor_reshape<T: TensorScalar>(
     shape: &[usize],
 ) -> Result<TypedTensor<T>> {
     let target_elements = shape_element_count(shape)?;
-    let source_elements = shape_element_count(&tensor.shape)?;
+    let source_elements = shape_element_count(tensor.shape())?;
     if target_elements != source_elements {
         return Err(EinsumHelperError::ReshapeElementCountMismatch {
-            source_shape: tensor.shape.clone(),
+            source_shape: tensor.shape().to_vec(),
             target_shape: shape.to_vec(),
             source_elements,
             target_elements,

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -138,11 +138,11 @@ fn typed_tensor_to_matrix2<T>(tensor: &TypedTensor<T>, op: &'static str) -> Resu
 where
     T: crate::traits::TTScalar + Default,
 {
-    if tensor.shape.len() != 2 {
+    if tensor.shape().len() != 2 {
         return Err(MPOError::FactorizationError {
             message: format!(
                 "{op} returned rank-{} tensor, expected matrix",
-                tensor.shape.len()
+                tensor.shape().len()
             ),
         });
     }

--- a/crates/tensor4all-simplett/src/tensor.rs
+++ b/crates/tensor4all-simplett/src/tensor.rs
@@ -133,13 +133,13 @@ impl<'a, T: TensorScalar, const N: usize> ExactSizeIterator for TensorIterMut<'a
 impl<T: TensorScalar, const N: usize> Tensor<T, N> {
     pub(crate) fn from_tenferro_unchecked(tensor: TfTensor<T>) -> Self {
         debug_assert_eq!(
-            tensor.shape.len(),
+            tensor.shape().len(),
             N,
             "tensor rank mismatch: expected rank {N}, got {}",
-            tensor.shape.len()
+            tensor.shape().len()
         );
         let mut dims = [0usize; N];
-        for (dim, value) in dims.iter_mut().zip(tensor.shape.iter().copied()) {
+        for (dim, value) in dims.iter_mut().zip(tensor.shape().iter().copied()) {
             *dim = value;
         }
         Self {
@@ -252,16 +252,16 @@ impl<T: TensorScalar, const N: usize> Tensor<T, N> {
     /// assert!(Tensor3::from_tenferro(rank_2).is_err());
     /// ```
     pub fn from_tenferro(tensor: TfTensor<T>) -> Result<Self> {
-        if tensor.shape.len() != N {
+        if tensor.shape().len() != N {
             return Err(TensorTrainError::InvalidOperation {
                 message: format!(
                     "tensor rank mismatch: expected rank {N}, got {}",
-                    tensor.shape.len()
+                    tensor.shape().len()
                 ),
             });
         }
         let mut dims = [0usize; N];
-        dims.copy_from_slice(&tensor.shape);
+        dims.copy_from_slice(tensor.shape());
         Ok(Self {
             inner: tensor,
             dims,
@@ -372,9 +372,9 @@ mod tests {
     }
 
     #[test]
-    fn dims_remain_available_after_inner_shape_mutation() {
+    fn dims_remain_available_after_inner_mutation() {
         let mut t: Tensor2<f64> = Tensor2::from_elem([2, 3], 1.0);
-        t.as_inner_mut().shape.push(4);
+        let _ = t.as_inner_mut();
 
         assert_eq!(t.dims(), &[2, 3]);
     }

--- a/crates/tensor4all-simplett/src/vidal.rs
+++ b/crates/tensor4all-simplett/src/vidal.rs
@@ -36,17 +36,17 @@ fn typed_tensor_to_matrix<T>(tensor: &TypedTensor<T>, op: &'static str) -> Resul
 where
     T: TTScalar + Scalar + Default,
 {
-    if tensor.shape.len() != 2 {
+    if tensor.shape().len() != 2 {
         return Err(TensorTrainError::InvalidOperation {
             message: format!(
                 "{op} returned rank-{} tensor, expected matrix",
-                tensor.shape.len()
+                tensor.shape().len()
             ),
         });
     }
 
-    let rows = tensor.shape[0];
-    let cols = tensor.shape[1];
+    let rows = tensor.shape()[0];
+    let cols = tensor.shape()[1];
     Ok(Matrix::from_col_major_vec(
         rows,
         cols,

--- a/crates/tensor4all-tcicore/Cargo.toml
+++ b/crates/tensor4all-tcicore/Cargo.toml
@@ -12,17 +12,14 @@ default = ["tenferro-cpu-faer"]
 tenferro-cpu-faer = [
     "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tenferro-einsum/cpu-faer",
-    "tenferro-tensor/cpu-faer",
 ]
 tenferro-system-blas = [
     "tensor4all-tensorbackend/tenferro-system-blas",
     "tenferro-einsum/cpu-blas",
-    "tenferro-tensor/cpu-blas",
 ]
 tenferro-provider-inject = [
     "tensor4all-tensorbackend/tenferro-provider-inject",
     "tenferro-einsum/cpu-blas",
-    "tenferro-tensor/provider-inject",
 ]
 
 [dependencies]
@@ -41,6 +38,7 @@ approx.workspace = true
 criterion.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
+tenferro-linalg.workspace = true
 tensor4all-tensorci = { path = "../tensor4all-tensorci", default-features = false, features = ["tenferro-cpu-faer"] }
 uint.workspace = true
 

--- a/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
+++ b/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
@@ -2,6 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::Tensor;
 use tensor4all_tcicore::{matrix_luci_factors_from_matrix, RrLUOptions};
 use tensor4all_tensorbackend::{with_default_backend, Matrix};
@@ -47,7 +48,7 @@ fn bench_dense_vs_tenferro(c: &mut Criterion) {
             |b, &n| {
                 b.iter(|| {
                     let mat = Tensor::from_vec_col_major(vec![n, n], data.clone());
-                    black_box(with_default_backend(|backend| mat.full_piv_lu(backend)).unwrap());
+                    black_box(with_default_backend(|backend| backend.full_piv_lu(&mat)).unwrap());
                 });
             },
         );

--- a/crates/tensor4all-tcicore/benches/rrlu_bench.rs
+++ b/crates/tensor4all-tcicore/benches/rrlu_bench.rs
@@ -2,6 +2,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
+use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::Tensor;
 use tensor4all_tcicore::{rrlu_inplace, RrLUOptions};
 use tensor4all_tensorbackend::{from_vec2d, with_default_backend, Matrix};
@@ -54,7 +55,7 @@ fn bench_rrlu(c: &mut Criterion) {
                 b.iter_batched(
                     || random_tenferro_matrix(n, n, 42),
                     |m| {
-                        with_default_backend(|backend| m.full_piv_lu(backend)).unwrap();
+                        with_default_backend(|backend| backend.full_piv_lu(&m)).unwrap();
                     },
                     criterion::BatchSize::SmallInput,
                 );

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -13,24 +13,31 @@ categories = ["science", "mathematics"]
 default = ["backend-tenferro", "tenferro-cpu-faer"]
 backend-tenferro = []
 tenferro-cpu-faer = [
-    "tenferro/autodiff",
     "tenferro/cpu-faer",
+    "tenferro-ad/cpu-faer",
+    "tenferro-cpu/cpu-faer",
     "tenferro-einsum/autodiff",
     "tenferro-einsum/cpu-faer",
+    "tenferro-linalg/autodiff",
+    "tenferro-linalg/cpu-faer",
 ]
 tenferro-system-blas = [
-    "tenferro/autodiff",
     "tenferro/cpu-blas",
+    "tenferro-ad/cpu-blas",
+    "tenferro-cpu/cpu-blas",
     "tenferro-einsum/autodiff",
     "tenferro-einsum/cpu-blas",
-    "tenferro-tensor/cpu-blas",
+    "tenferro-linalg/autodiff",
+    "tenferro-linalg/cpu-blas",
 ]
 tenferro-provider-inject = [
-    "tenferro/autodiff",
     "tenferro/cpu-blas",
+    "tenferro-ad/cpu-blas",
+    "tenferro-cpu/provider-inject",
     "tenferro-einsum/autodiff",
     "tenferro-einsum/cpu-blas",
-    "tenferro-tensor/provider-inject",
+    "tenferro-linalg/autodiff",
+    "tenferro-linalg/provider-inject",
 ]
 einsum-dispatch-profile = []
 
@@ -43,8 +50,10 @@ rand.workspace = true
 rand_distr.workspace = true
 omeco.workspace = true
 tenferro.workspace = true
-tenferro-device.workspace = true
+tenferro-ad.workspace = true
+tenferro-cpu.workspace = true
 tenferro-einsum.workspace = true
+tenferro-linalg.workspace = true
 tenferro-tensor.workspace = true
 
 [dev-dependencies]

--- a/crates/tensor4all-tensorbackend/src/backend.rs
+++ b/crates/tensor4all-tensorbackend/src/backend.rs
@@ -5,7 +5,9 @@
 
 use anyhow::{anyhow, Result};
 use num_complex::{Complex32, Complex64};
-use tenferro::{DType, Tensor, TensorBackend, TensorScalar, TypedTensor};
+use tenferro::{DType, Tensor, TensorScalar, TypedTensor};
+use tenferro_linalg::LinalgBackend;
+use tenferro_tensor::BackendSessionHost;
 
 use crate::context::with_default_backend;
 use crate::matrix::Matrix;
@@ -24,9 +26,9 @@ use crate::matrix::Matrix;
 /// let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]);
 /// let result = svd_backend(&a).unwrap();
 ///
-/// assert_eq!(result.u.shape, vec![2, 2]);
-/// assert_eq!(result.s.shape, vec![2]);
-/// assert_eq!(result.vt.shape, vec![2, 2]);
+/// assert_eq!(result.u.shape(), &[2, 2]);
+/// assert_eq!(result.s.shape(), &[2]);
+/// assert_eq!(result.vt.shape(), &[2, 2]);
 /// ```
 #[derive(Debug, Clone)]
 pub struct SvdResult<T: TensorScalar> {
@@ -172,7 +174,7 @@ where
 {
     let a_tensor: Tensor = a.into_typed_tensor().into();
     let b_tensor: Tensor = b.into_typed_tensor().into();
-    let result = with_default_backend(|backend| a_tensor.solve(&b_tensor, backend))
+    let result = with_default_backend(|backend| backend.solve(&a_tensor, &b_tensor))
         .map_err(|e| anyhow!("linear solve failed via tenferro-tensor: {e}"))?;
     let x = try_into_typed_result::<T>("solve", result)?;
     typed_tensor_to_matrix("solve", x)
@@ -215,13 +217,13 @@ where
     let a_tensor: Tensor = a.into_typed_tensor().into();
     let b_tensor: Tensor = b.into_typed_tensor().into();
     let result = with_default_backend(|backend| {
-        a_tensor.triangular_solve(
+        backend.triangular_solve(
+            &a_tensor,
             &b_tensor,
             left_side,
             lower,
             transpose_a,
             unit_diagonal,
-            backend,
         )
     })
     .map_err(|e| anyhow!("triangular solve failed via tenferro-tensor: {e}"))?;
@@ -468,7 +470,7 @@ fn convert_for_typed<T: TensorScalar>(op: &'static str, tensor: Tensor) -> Resul
         tensor
     } else {
         with_default_backend(|backend| {
-            backend.with_exec_session(|exec| exec.convert(&tensor, expected))
+            backend.with_backend_session(|exec| exec.convert(&tensor, expected))
         })
         .map_err(|e| anyhow!("{op}: dtype conversion to {expected:?} failed: {e}"))?
     };
@@ -502,9 +504,12 @@ pub fn svd_backend<T>(a: &TypedTensor<T>) -> Result<SvdResult<T>>
 where
     T: BackendLinalgScalar,
 {
-    let tensor = T::into_tensor(a.shape.clone(), a.host_data().to_vec());
-    let (u, s, vt) = with_default_backend(|backend| tensor.svd(backend))
+    let tensor = T::into_tensor(a.shape().to_vec(), a.host_data().to_vec());
+    let outputs = with_default_backend(|backend| backend.svd(&tensor))
         .map_err(|e| anyhow!("SVD computation failed via tenferro-tensor: {e}"))?;
+    let [u, s, vt]: [Tensor; 3] = outputs.try_into().map_err(|outputs: Vec<Tensor>| {
+        anyhow!("svd: expected 3 outputs, got {}", outputs.len())
+    })?;
     Ok(SvdResult {
         u: convert_for_typed::<T>("svd", u)?,
         s: convert_for_typed::<T::Real>("svd", s)?,
@@ -522,8 +527,16 @@ pub fn qr_backend<T>(a: &TypedTensor<T>) -> Result<(TypedTensor<T>, TypedTensor<
 where
     T: BackendLinalgScalar,
 {
-    with_default_backend(|backend| a.qr(backend))
-        .map_err(|e| anyhow!("QR computation failed via tenferro-tensor: {e}"))
+    let tensor = T::into_tensor(a.shape().to_vec(), a.host_data().to_vec());
+    let outputs = with_default_backend(|backend| backend.qr(&tensor))
+        .map_err(|e| anyhow!("QR computation failed via tenferro-tensor: {e}"))?;
+    let [q, r]: [Tensor; 2] = outputs
+        .try_into()
+        .map_err(|outputs: Vec<Tensor>| anyhow!("qr: expected 2 outputs, got {}", outputs.len()))?;
+    Ok((
+        convert_for_typed::<T>("qr", q)?,
+        convert_for_typed::<T>("qr", r)?,
+    ))
 }
 
 /// Solve `A X = B` with the configured tenferro backend.
@@ -536,9 +549,9 @@ pub fn solve_backend<T>(a: &TypedTensor<T>, b: &TypedTensor<T>) -> Result<TypedT
 where
     T: BackendLinalgScalar,
 {
-    let a_tensor = T::into_tensor(a.shape.clone(), a.host_data().to_vec());
-    let b_tensor = T::into_tensor(b.shape.clone(), b.host_data().to_vec());
-    let result = with_default_backend(|backend| a_tensor.solve(&b_tensor, backend))
+    let a_tensor = T::into_tensor(a.shape().to_vec(), a.host_data().to_vec());
+    let b_tensor = T::into_tensor(b.shape().to_vec(), b.host_data().to_vec());
+    let result = with_default_backend(|backend| backend.solve(&a_tensor, &b_tensor))
         .map_err(|e| anyhow!("linear solve failed via tenferro-tensor: {e}"))?;
     try_into_typed_result::<T>("solve", result)
 }
@@ -564,16 +577,16 @@ pub fn triangular_solve_backend<T>(
 where
     T: BackendLinalgScalar,
 {
-    let a_tensor = T::into_tensor(a.shape.clone(), a.host_data().to_vec());
-    let b_tensor = T::into_tensor(b.shape.clone(), b.host_data().to_vec());
+    let a_tensor = T::into_tensor(a.shape().to_vec(), a.host_data().to_vec());
+    let b_tensor = T::into_tensor(b.shape().to_vec(), b.host_data().to_vec());
     let result = with_default_backend(|backend| {
-        a_tensor.triangular_solve(
+        backend.triangular_solve(
+            &a_tensor,
             &b_tensor,
             left_side,
             lower,
             transpose_a,
             unit_diagonal,
-            backend,
         )
     })
     .map_err(|e| anyhow!("triangular solve failed via tenferro-tensor: {e}"))?;
@@ -719,9 +732,13 @@ pub fn full_piv_lu_backend<T>(a: &TypedTensor<T>) -> Result<FullPivLuResult<T>>
 where
     T: BackendLinalgScalar,
 {
-    let tensor = T::into_tensor(a.shape.clone(), a.host_data().to_vec());
-    let (p, l, u, q, _parity) = with_default_backend(|backend| tensor.full_piv_lu(backend))
+    let tensor = T::into_tensor(a.shape().to_vec(), a.host_data().to_vec());
+    let outputs = with_default_backend(|backend| backend.full_piv_lu(&tensor))
         .map_err(|e| anyhow!("complete-pivoting LU failed via tenferro-tensor: {e}"))?;
+    let [p, l, u, q, _parity]: [Tensor; 5] =
+        outputs.try_into().map_err(|outputs: Vec<Tensor>| {
+            anyhow!("full_piv_lu: expected 5 outputs, got {}", outputs.len())
+        })?;
     Ok(FullPivLuResult {
         p: convert_for_typed::<T>("full_piv_lu", p)?,
         l: convert_for_typed::<T>("full_piv_lu", l)?,

--- a/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/backend/tests/mod.rs
@@ -6,9 +6,9 @@ fn row_major_values<T>(tensor: &TypedTensor<T>) -> Vec<T>
 where
     T: Copy,
 {
-    assert_eq!(tensor.shape.len(), 2, "test helper expects a matrix");
-    let rows = tensor.shape[0];
-    let cols = tensor.shape[1];
+    assert_eq!(tensor.shape().len(), 2, "test helper expects a matrix");
+    let rows = tensor.shape()[0];
+    let cols = tensor.shape()[1];
     let values = tensor.as_slice();
     let mut out = Vec::with_capacity(values.len());
     for row in 0..rows {
@@ -57,8 +57,8 @@ fn qr_backend_reconstructs_real_matrix() {
     let input = TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
 
     let (q, r) = qr_backend(&input).unwrap();
-    assert_eq!(q.shape, vec![2, 2]);
-    assert_eq!(r.shape, vec![2, 2]);
+    assert_eq!(q.shape(), &[2, 2]);
+    assert_eq!(r.shape(), &[2, 2]);
 
     let q_values = row_major_values(&q);
     let r_values = row_major_values(&r);
@@ -86,9 +86,9 @@ fn svd_backend_reconstructs_complex_matrix() {
     );
 
     let decomp = svd_backend(&input).unwrap();
-    assert_eq!(decomp.u.shape, vec![2, 2]);
-    assert_eq!(decomp.s.shape, vec![2]);
-    assert_eq!(decomp.vt.shape, vec![2, 2]);
+    assert_eq!(decomp.u.shape(), &[2, 2]);
+    assert_eq!(decomp.s.shape(), &[2]);
+    assert_eq!(decomp.vt.shape(), &[2, 2]);
 
     let u = row_major_values(&decomp.u);
     let s = decomp.s.as_slice().to_vec();
@@ -112,7 +112,7 @@ fn solve_backend_solves_real_system() {
 
     let x = solve_backend(&a, &b).unwrap();
 
-    assert_eq!(x.shape, vec![2, 1]);
+    assert_eq!(x.shape(), &[2, 1]);
     assert!((x.as_slice()[0] - 2.0 / 3.0).abs() < 1.0e-12);
     assert!((x.as_slice()[1] + 1.0 / 3.0).abs() < 1.0e-12);
 }
@@ -298,7 +298,7 @@ fn triangular_solve_backend_solves_typed_tensor_system() {
 
     let x = triangular_solve_backend(&a, &b, true, true, false, false).unwrap();
 
-    assert_eq!(x.shape, vec![2, 1]);
+    assert_eq!(x.shape(), &[2, 1]);
     assert!((x.as_slice()[0] - 1.0).abs() < 1.0e-12);
     assert!((x.as_slice()[1] - 2.0).abs() < 1.0e-12);
 }
@@ -318,10 +318,10 @@ fn full_piv_lu_backend_returns_square_factors() {
 
     let decomp = full_piv_lu_backend(&input).unwrap();
 
-    assert_eq!(decomp.p.shape, vec![2, 2]);
-    assert_eq!(decomp.l.shape, vec![2, 2]);
-    assert_eq!(decomp.u.shape, vec![2, 2]);
-    assert_eq!(decomp.q.shape, vec![2, 2]);
+    assert_eq!(decomp.p.shape(), &[2, 2]);
+    assert_eq!(decomp.l.shape(), &[2, 2]);
+    assert_eq!(decomp.u.shape(), &[2, 2]);
+    assert_eq!(decomp.q.shape(), &[2, 2]);
 }
 
 #[test]

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -10,9 +10,9 @@
 
 use std::sync::{Arc, Mutex, OnceLock};
 
-use tenferro::{CpuBackend, EagerRuntime, GraphCompiler, GraphExecutor};
-use tenferro_tensor::buffer_pool::BufferPoolStats;
-use tenferro_tensor::cpu::CpuContext;
+use tenferro::{GraphCompiler, GraphExecutor};
+use tenferro_ad::EagerRuntime;
+use tenferro_cpu::{buffer_pool::BufferPoolStats, CpuBackend, CpuContext};
 
 static DEFAULT_CPU_CONTEXT: OnceLock<Arc<CpuContext>> = OnceLock::new();
 static DEFAULT_BACKEND: OnceLock<Mutex<CpuBackend>> = OnceLock::new();
@@ -82,12 +82,13 @@ pub(crate) fn with_default_graph_runtime<R>(
 
 /// Return retained-buffer statistics for the process-global graph executor.
 pub(crate) fn default_engine_buffer_pool_stats() -> BufferPoolStats {
-    lock_default_graph_executor().buffer_pool_stats()
+    lock_default_graph_executor().backend().buffer_pool_stats()
 }
 
 /// Reset retained buffers in the process-global graph executor.
 pub(crate) fn reset_default_engine_buffer_pool() {
-    lock_default_graph_executor().reset_buffer_pool();
+    let mut executor = lock_default_graph_executor();
+    *executor = GraphExecutor::new(CpuBackend::from_context(default_cpu_context()));
 }
 
 /// Drop and recreate the process-global graph compiler/executor.
@@ -110,6 +111,8 @@ pub(crate) fn reset_default_engine() {
 pub fn default_eager_ctx() -> Arc<EagerRuntime> {
     DEFAULT_EAGER_RUNTIME
         .get_or_init(|| {
+            tenferro_linalg::register_extension_rule()
+                .expect("tenferro linalg AD rule should register once");
             EagerRuntime::with_cpu_backend(CpuBackend::from_context(default_cpu_context()))
         })
         .clone()

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -23,7 +23,8 @@ use anyhow::{ensure, Context, Result};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 use std::ops::{Index, IndexMut};
-use tenferro::{Tensor, TensorBackend, TensorScalar, TypedTensor};
+use tenferro::{Tensor, TensorScalar, TypedTensor};
+use tenferro_tensor::BackendSessionHost;
 
 /// A dense 2D matrix in column-major layout.
 ///
@@ -167,7 +168,7 @@ impl<T> Matrix<T> {
     ///
     /// let m = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 3.0, 2.0, 4.0]);
     /// let tensor = m.to_typed_tensor();
-    /// assert_eq!(tensor.shape, vec![2, 2]);
+    /// assert_eq!(tensor.shape(), &[2, 2]);
     /// assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
     /// assert_eq!(m.as_col_major_slice(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
@@ -190,7 +191,7 @@ impl<T> Matrix<T> {
     ///
     /// let m = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 3.0, 2.0, 4.0]);
     /// let tensor = m.into_typed_tensor();
-    /// assert_eq!(tensor.shape, vec![2, 2]);
+    /// assert_eq!(tensor.shape(), &[2, 2]);
     /// assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
     pub fn into_typed_tensor(self) -> TypedTensor<T>
@@ -570,7 +571,7 @@ where
         rhs_batch_dims: vec![],
     };
     let c = with_default_backend(|backend| {
-        backend.with_exec_session(|exec| exec.dot_general(&a_tensor, &b_tensor, &config))
+        backend.with_backend_session(|exec| exec.dot_general(&a_tensor, &b_tensor, &config))
     })
     .context("matrix multiplication failed")?;
     let c = T::try_into_typed(c)
@@ -795,7 +796,7 @@ where
     T: tenferro::TensorScalar + Copy,
 {
     use crate::with_default_backend;
-    use tenferro::{DotGeneralConfig, TensorBackend};
+    use tenferro::DotGeneralConfig;
 
     validate_batched_mat_mul_inputs(batch, m, k, n, a.len(), b.len())?;
 
@@ -808,7 +809,7 @@ where
         rhs_batch_dims: vec![2],
     };
     let c = with_default_backend(|backend| {
-        backend.with_exec_session(|exec| exec.dot_general(&a_tensor, &b_tensor, &config))
+        backend.with_backend_session(|exec| exec.dot_general(&a_tensor, &b_tensor, &config))
     })
     .context("batched matrix multiplication failed")?;
     let c = T::try_into_typed(c)

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -41,7 +41,7 @@ fn matrix_to_typed_tensor_preserves_column_major_layout() {
 
     let tensor = m.to_typed_tensor();
 
-    assert_eq!(tensor.shape, vec![2, 2]);
+    assert_eq!(tensor.shape(), &[2, 2]);
     assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
     assert_eq!(m.as_col_major_slice(), &[1.0, 3.0, 2.0, 4.0]);
 }
@@ -52,7 +52,7 @@ fn matrix_into_typed_tensor_consumes_column_major_layout() {
 
     let tensor = m.into_typed_tensor();
 
-    assert_eq!(tensor.shape, vec![2, 2]);
+    assert_eq!(tensor.shape(), &[2, 2]);
     assert_eq!(tensor.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
 }
 

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge.rs
@@ -9,12 +9,12 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, ensure, Result};
 use num_complex::{Complex32, Complex64};
 use omeco::ScoreFunction;
-use tenferro::{
-    DType, Tensor as NativeTensor, TensorBackend, TensorRead, TensorView, TracedTensor,
-};
+use tenferro::{DType, Tensor as NativeTensor, TensorRead, TensorView, TracedTensor};
 use tenferro_einsum::{
     ContractionOptimizerOptions, ContractionTree, EinsumOptimize, EinsumSubscripts, Subscripts,
 };
+use tenferro_linalg::LinalgBackend;
+use tenferro_tensor::BackendSessionHost;
 
 use crate::any_scalar::promote_scalar_native;
 use crate::context::{
@@ -41,7 +41,7 @@ impl<'a> NativeTensorReadInput<'a> {
     /// Return this input as a read-only tenferro tensor input.
     pub fn as_read(&'a self) -> TensorRead<'a> {
         match self {
-            Self::Borrowed(read) => *read,
+            Self::Borrowed(read) => read.clone(),
             Self::Owned(tensor) => TensorRead::from_tensor(tensor),
         }
     }
@@ -522,7 +522,7 @@ fn convert_tensor(tensor: &NativeTensor, to: DType) -> Result<NativeTensor> {
     if tensor.dtype() == to {
         return Ok(tensor.clone());
     }
-    with_default_backend(|backend| backend.with_exec_session(|exec| exec.convert(tensor, to)))
+    with_default_backend(|backend| backend.with_backend_session(|exec| exec.convert(tensor, to)))
         .map_err(|e| anyhow!("tensor conversion to {to:?} failed: {e}"))
 }
 
@@ -986,21 +986,31 @@ pub fn reshape_col_major_native_tensor(
     tensor: &NativeTensor,
     logical_dims: &[usize],
 ) -> Result<NativeTensor> {
-    with_default_backend(|backend| tensor.reshape(logical_dims, backend))
+    with_default_backend(|backend| tenferro::tensor::reshape(tensor, logical_dims, backend))
         .map_err(|e| anyhow!("native reshape failed: {e}"))
 }
 
 /// Compute a QR decomposition on a native tensor.
 pub fn qr_native_tensor(tensor: &NativeTensor) -> Result<(NativeTensor, NativeTensor)> {
-    with_default_backend(|backend| tensor.qr(backend)).map_err(|e| anyhow!("native QR failed: {e}"))
+    let outputs = with_default_backend(|backend| backend.qr(tensor))
+        .map_err(|e| anyhow!("native QR failed: {e}"))?;
+    let [q, r]: [NativeTensor; 2] = outputs.try_into().map_err(|outputs: Vec<NativeTensor>| {
+        anyhow!("native QR expected 2 outputs, got {}", outputs.len())
+    })?;
+    Ok((q, r))
 }
 
 /// Compute an SVD on a native tensor.
 pub fn svd_native_tensor(
     tensor: &NativeTensor,
 ) -> Result<(NativeTensor, NativeTensor, NativeTensor)> {
-    with_default_backend(|backend| tensor.svd(backend))
-        .map_err(|e| anyhow!("native SVD failed: {e}"))
+    let outputs = with_default_backend(|backend| backend.svd(tensor))
+        .map_err(|e| anyhow!("native SVD failed: {e}"))?;
+    let [u, s, vt]: [NativeTensor; 3] =
+        outputs.try_into().map_err(|outputs: Vec<NativeTensor>| {
+            anyhow!("native SVD expected 3 outputs, got {}", outputs.len())
+        })?;
+    Ok((u, s, vt))
 }
 
 /// Sum all elements of a native tensor, returning a dynamic scalar.
@@ -1009,7 +1019,7 @@ pub fn sum_native_tensor(tensor: &NativeTensor) -> Result<AnyScalar> {
         tensor.clone()
     } else {
         let axes: Vec<usize> = (0..tensor.shape().len()).collect();
-        with_default_backend(|backend| tensor.reduce_sum(&axes, backend))
+        with_default_backend(|backend| tenferro::tensor::reduce_sum(tensor, &axes, backend))
             .map_err(|e| anyhow!("native sum failed: {e}"))?
     };
     AnyScalar::from_native(reduced)
@@ -1472,7 +1482,7 @@ pub fn einsum_native_tensor_reads(
 
 /// Permute axes of a native tensor.
 pub fn permute_native_tensor(tensor: &NativeTensor, perm: &[usize]) -> Result<NativeTensor> {
-    with_default_backend(|backend| tensor.transpose(perm, backend))
+    with_default_backend(|backend| tenferro::tensor::transpose(tensor, perm, backend))
         .map_err(|e| anyhow!("native permute failed: {e}"))
 }
 

--- a/crates/tensor4all-treetci/Cargo.toml
+++ b/crates/tensor4all-treetci/Cargo.toml
@@ -17,14 +17,12 @@ tenferro-cpu-faer = [
     "tensor4all-tcicore/tenferro-cpu-faer",
     "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tensor4all-treetn/tenferro-cpu-faer",
-    "tenferro-tensor/cpu-faer",
 ]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-tcicore/tenferro-provider-inject",
     "tensor4all-tensorbackend/tenferro-provider-inject",
     "tensor4all-treetn/tenferro-provider-inject",
-    "tenferro-tensor/provider-inject",
 ]
 
 [dependencies]
@@ -33,6 +31,7 @@ thiserror.workspace = true
 petgraph.workspace = true
 num-complex.workspace = true
 rand.workspace = true
+tenferro-linalg.workspace = true
 tenferro-tensor.workspace = true
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
 tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }

--- a/crates/tensor4all-treetci/src/materialize.rs
+++ b/crates/tensor4all-treetci/src/materialize.rs
@@ -6,6 +6,7 @@ use crate::{
 use anyhow::{ensure, Result};
 use num_complex::{Complex32, Complex64};
 use std::collections::HashMap;
+use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{Tensor, TensorScalar};
 use tensor4all_core::{ColMajorArray, DynIndex, TensorDynLen, TensorElement};
 use tensor4all_tcicore::MatrixLuciScalar as Scalar;
@@ -56,7 +57,7 @@ macro_rules! impl_full_piv_lu_scalar {
                     Tensor::from_vec_col_major(vec![pivot_cols, pivot_rows], pivot_t);
                 let lhs_tensor = Tensor::from_vec_col_major(vec![lhs_cols, lhs_rows], lhs_t);
                 let solved_t = with_default_backend(|backend| {
-                    pivot_tensor.full_piv_lu_solve(&lhs_tensor, backend)
+                    backend.full_piv_lu_solve(&pivot_tensor, &lhs_tensor, false)
                 })?;
 
                 let solved_t_values = solved_t.as_slice::<Self>().ok_or_else(|| {


### PR DESCRIPTION
## Summary

Updates tensor4all-rs to the latest tenferro-rs `main` commit `f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266`.

This migrates the dependency surface to the current tenferro crate split, including `tenferro-runtime`, `tenferro-ad`, `tenferro-cpu`, `tenferro-linalg`, `tenferro-tensor`, and `tenferro-einsum`. It also updates tensorbackend/core/simplett/tcicore/treetci call sites for the new linalg backend APIs, eager AD types, backend session APIs, and `TypedTensor::shape()` accessors.

## Root Cause / Compatibility Notes

The latest tenferro moved CPU/runtime/AD/linalg functionality into separate crates and changed linalg operations to be invoked through `LinalgBackend`. Eager linalg AD also now requires the linalg extension AD rule to be registered; the default eager context now registers that rule so QR/SVD/CI gradients continue to work while einsum keeps using its global extension rule registration.

## Validation

- `cargo fmt --all`
- `cargo check --workspace --all-targets --release`
- `cargo nextest run --release --workspace` (`2385 passed`, `14 skipped`)