### PR TITLE
[codex] Reduce coverage CI link load

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -88,6 +88,9 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-22.04
+    env:
+      CARGO_BUILD_JOBS: 1
+      CARGO_PROFILE_DEV_DEBUG: 0
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Reduce the hosted-runner link load in the Coverage job after the tenferro-rs update.

The failing post-merge CI run did not fail on test assertions. `cargo llvm-cov --workspace --exclude tensor4all-hdf5 --json` crashed during test binary linking with `rust-lld` `Bus error` while building coverage-instrumented dev-profile test binaries.

This change limits coverage builds to one cargo job and disables dev-profile DWARF debug info for that job:

- `CARGO_BUILD_JOBS: 1` prevents multiple large coverage test binaries from linking in parallel.
- `CARGO_PROFILE_DEV_DEBUG: 0` removes full dev DWARF from coverage binaries while keeping LLVM coverage instrumentation enabled.

## Validation

- `git diff --check`
- Verified the workflow contains the expected Coverage job env settings.

The real validation is the GitHub Coverage job on this PR, because the failure is specific to hosted-runner coverage linking.