### PR TITLE
[codex] Clean up tutorial API usage

### DIFF
--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -557,7 +557,7 @@ pub extern "C" fn t4a_qtransform_shift_materialize(
         let r = layout_ref.resolution(target_var);
         let source = shift_operator(r, offset, bc.into())
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        let treetn = materialize_single_var_operator(layout_ref, target_var, source.mpo)?;
+        let treetn = materialize_single_var_operator(layout_ref, target_var, source.into_mpo())?;
         Ok(t4a_treetn::new(treetn))
     })
 }
@@ -582,7 +582,7 @@ pub extern "C" fn t4a_qtransform_flip_materialize(
         let r = layout_ref.resolution(target_var);
         let source =
             flip_operator(r, bc.into()).map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        let treetn = materialize_single_var_operator(layout_ref, target_var, source.mpo)?;
+        let treetn = materialize_single_var_operator(layout_ref, target_var, source.into_mpo())?;
         Ok(t4a_treetn::new(treetn))
     })
 }
@@ -607,7 +607,7 @@ pub extern "C" fn t4a_qtransform_phase_rotation_materialize(
         let r = layout_ref.resolution(target_var);
         let source = phase_rotation_operator(r, theta)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        let treetn = materialize_single_var_operator(layout_ref, target_var, source.mpo)?;
+        let treetn = materialize_single_var_operator(layout_ref, target_var, source.into_mpo())?;
         Ok(t4a_treetn::new(treetn))
     })
 }
@@ -630,7 +630,7 @@ pub extern "C" fn t4a_qtransform_cumsum_materialize(
         }
         let r = layout_ref.resolution(target_var);
         let source = cumsum_operator(r).map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        let treetn = materialize_single_var_operator(layout_ref, target_var, source.mpo)?;
+        let treetn = materialize_single_var_operator(layout_ref, target_var, source.into_mpo())?;
         Ok(t4a_treetn::new(treetn))
     })
 }
@@ -668,7 +668,7 @@ pub extern "C" fn t4a_qtransform_fourier_materialize(
         }
         let source = quantics_fourier_operator(r, options)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        let treetn = materialize_single_var_operator(layout_ref, target_var, source.mpo)?;
+        let treetn = materialize_single_var_operator(layout_ref, target_var, source.into_mpo())?;
         Ok(t4a_treetn::new(treetn))
     })
 }
@@ -728,7 +728,7 @@ pub extern "C" fn t4a_qtransform_affine_materialize(
             AffineParams::new(a, b, m, n).map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
         let source = affine_operator(layout_ref.nsites(), &params, &bc)
             .map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))?;
-        Ok(t4a_treetn::new(source.mpo))
+        Ok(t4a_treetn::new(source.into_mpo()))
     })
 }
 

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{t4a_index, t4a_treetn_release, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS};
 use num_complex::Complex64;
 use num_rational::Rational64;
-use tensor4all_core::{ColMajorArrayRef, TensorDynLen};
+use tensor4all_core::TensorDynLen;
 use tensor4all_quanticstransform::{
     affine_operator, cumsum_operator, flip_operator, phase_rotation_operator,
     quantics_fourier_operator, shift_operator, AffineParams, BoundaryCondition, FourierOptions,
@@ -59,8 +59,7 @@ fn rust_operator_matrix(
     let mut indices = Vec::with_capacity(2 * nsites);
     for site in 0..nsites {
         indices.push(
-            op.output_mapping
-                .get(&site)
+            op.get_output_mappings(&site)
                 .unwrap()
                 .first()
                 .unwrap()
@@ -68,8 +67,7 @@ fn rust_operator_matrix(
                 .clone(),
         );
         indices.push(
-            op.input_mapping
-                .get(&site)
+            op.get_input_mappings(&site)
                 .unwrap()
                 .first()
                 .unwrap()
@@ -88,12 +86,8 @@ fn rust_operator_matrix(
                 values.push(out_values[site]);
                 values.push(in_values[site]);
             }
-            let shape = [values.len(), 1];
-            let result = op
-                .mpo
-                .evaluate_at(&indices, ColMajorArrayRef::new(&values, &shape).unwrap())
-                .unwrap();
-            matrix[y + nrows * x] = result[0].clone().into();
+            let result = op.mpo().evaluate_point(&indices, &values).unwrap();
+            matrix[y + nrows * x] = result.into();
         }
     }
     matrix

--- a/crates/tensor4all-quanticstci/tests/qft_2d_test.rs
+++ b/crates/tensor4all-quanticstci/tests/qft_2d_test.rs
@@ -10,48 +10,7 @@ use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions, Unf
 use tensor4all_quanticstransform::{quantics_fourier_operator, FourierOptions};
 use tensor4all_treetci::materialize::to_treetn;
 use tensor4all_treetn::operator::{apply_linear_operator, ApplyOptions};
-use tensor4all_treetn::LinearOperator;
 use tensor4all_treetn::Operator;
-
-/// Rename LinearOperator nodes according to a mapping: old_name -> new_name.
-/// Uses a two-phase rename (old → temp → new) to avoid collisions.
-fn rename_operator_nodes(
-    mut op: LinearOperator<tensor4all_core::TensorDynLen, usize>,
-    mapping: &[(usize, usize)],
-) -> Result<LinearOperator<tensor4all_core::TensorDynLen, usize>> {
-    // Phase 1: rename old → temp (use large offsets to avoid collisions)
-    let offset = 1_000_000;
-    for &(old, _) in mapping {
-        op.mpo.rename_node(&old, old + offset)?;
-    }
-    // Phase 2: rename temp → new
-    for &(old, new) in mapping {
-        op.mpo.rename_node(&(old + offset), new)?;
-    }
-    // Rename in input_mapping
-    let mut new_input = std::collections::HashMap::new();
-    for (k, v) in op.input_mapping.drain() {
-        let new_k = mapping
-            .iter()
-            .find(|&&(o, _)| o == k)
-            .map(|&(_, n)| n)
-            .unwrap_or(k);
-        new_input.insert(new_k, v);
-    }
-    op.input_mapping = new_input;
-    // Rename in output_mapping
-    let mut new_output = std::collections::HashMap::new();
-    for (k, v) in op.output_mapping.drain() {
-        let new_k = mapping
-            .iter()
-            .find(|&&(o, _)| o == k)
-            .map(|&(_, n)| n)
-            .unwrap_or(k);
-        new_output.insert(new_k, v);
-    }
-    op.output_mapping = new_output;
-    Ok(op)
-}
 
 /// Test that 1D QFT applied to x-variable in a 2D interleaved QTT works.
 ///
@@ -123,7 +82,7 @@ fn test_2d_qft_x_only_interleaved() -> Result<()> {
 
     // Rename operator nodes: 0→0, 1→2, 2→4 (x-variable sites in interleaved layout)
     let node_mapping: Vec<(usize, usize)> = (0..r).map(|i| (i, 2 * i)).collect();
-    let mut renamed_op = rename_operator_nodes(fourier_op, &node_mapping)?;
+    let mut renamed_op = fourier_op.rename_nodes(&node_mapping)?;
 
     // Verify renamed operator nodes are {0, 2, 4}
     let op_nodes = renamed_op.node_names();

--- a/crates/tensor4all-quanticstransform/README.md
+++ b/crates/tensor4all-quanticstransform/README.md
@@ -36,8 +36,8 @@ let shift_op = shift_operator(r, 3, BoundaryCondition::Periodic)?;
 let flip_op = flip_operator(r, BoundaryCondition::Periodic)?;
 
 // Operators are LinearOperator (TreeTN form).
-assert_eq!(shift_op.mpo.node_count(), r);
-assert_eq!(flip_op.mpo.node_count(), r);
+assert_eq!(shift_op.mpo().node_count(), r);
+assert_eq!(flip_op.mpo().node_count(), r);
 # Ok(())
 # }
 ```

--- a/crates/tensor4all-quanticstransform/src/affine.rs
+++ b/crates/tensor4all-quanticstransform/src/affine.rs
@@ -439,7 +439,7 @@ fn remap_affine_site_indices(
 /// let params = AffineParams::new(a, b, 2, 2).unwrap();
 /// let bc = vec![BoundaryCondition::Periodic; 2];
 /// let op = affine_operator(4, &params, &bc).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 ///
 /// Using integer convenience constructor:
@@ -451,7 +451,7 @@ fn remap_affine_site_indices(
 /// let params = AffineParams::from_integers(vec![1], vec![0], 1, 1).unwrap();
 /// let bc = vec![BoundaryCondition::Periodic];
 /// let op = affine_operator(4, &params, &bc).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn affine_operator(
     r: usize,

--- a/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
@@ -624,7 +624,7 @@ fn assert_affine_mpo_matches_matrix(r: usize, params: &AffineParams, bc: &[Bound
 
     let matrix = affine_transform_matrix(r, params, bc).unwrap();
     let op = affine_operator(r, params, bc).unwrap();
-    let actual = op.mpo.contract_to_tensor().unwrap();
+    let actual = op.mpo().contract_to_tensor().unwrap();
     let expected = affine_matrix_to_dense_tensor(&matrix, &op, r, m, n, &actual);
     let maxabs = actual.distance(&expected).unwrap();
 
@@ -1093,7 +1093,7 @@ fn test_affine_operator_interleaved_matches_matrix() {
         }
     }
 
-    let actual = op.mpo.contract_to_tensor().unwrap();
+    let actual = op.mpo().contract_to_tensor().unwrap();
     let expected =
         affine_interleaved_matrix_to_dense_tensor(&matrix, &op, r, params.m, params.n, &actual);
     let maxabs = actual.distance(&expected).unwrap();

--- a/crates/tensor4all-quanticstransform/src/cumsum.rs
+++ b/crates/tensor4all-quanticstransform/src/cumsum.rs
@@ -25,11 +25,11 @@ use crate::common::{tensortrain_to_linear_operator, QuanticsOperator};
 ///
 /// // Prefix sum (lower triangle)
 /// let lower = triangle_operator(4, TriangleType::Lower).unwrap();
-/// assert_eq!(lower.mpo.node_count(), 4);
+/// assert_eq!(lower.mpo().node_count(), 4);
 ///
 /// // Suffix sum (upper triangle)
 /// let upper = triangle_operator(4, TriangleType::Upper).unwrap();
-/// assert_eq!(upper.mpo.node_count(), 4);
+/// assert_eq!(upper.mpo().node_count(), 4);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TriangleType {
@@ -63,7 +63,7 @@ pub enum TriangleType {
 /// use tensor4all_quanticstransform::cumsum_operator;
 ///
 /// let op = cumsum_operator(4).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 ///
 /// // Requires at least 2 sites
 /// assert!(cumsum_operator(1).is_err());
@@ -98,7 +98,7 @@ pub fn cumsum_operator(r: usize) -> Result<QuanticsOperator> {
 /// use tensor4all_quanticstransform::{triangle_operator, TriangleType};
 ///
 /// let op = triangle_operator(4, TriangleType::Lower).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 ///
 /// // Requires at least 2 sites
 /// assert!(triangle_operator(1, TriangleType::Lower).is_err());

--- a/crates/tensor4all-quanticstransform/src/flip.rs
+++ b/crates/tensor4all-quanticstransform/src/flip.rs
@@ -36,7 +36,7 @@ use crate::common::{
 /// let op = flip_operator(4, BoundaryCondition::Periodic).unwrap();
 ///
 /// // The operator has one MPO tensor per bit
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn flip_operator(r: usize, bc: BoundaryCondition) -> Result<QuanticsOperator> {
     if r == 0 {
@@ -76,7 +76,7 @@ pub fn flip_operator(r: usize, bc: BoundaryCondition) -> Result<QuanticsOperator
 ///
 /// // Flip only the x-variable of a 2-variable function f(x, y)
 /// let op = flip_operator_multivar(4, BoundaryCondition::Periodic, 2, 0).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn flip_operator_multivar(
     r: usize,

--- a/crates/tensor4all-quanticstransform/src/fourier.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier.rs
@@ -99,10 +99,10 @@ impl FourierOptions {
 /// assert_eq!(ft.r(), 4);
 ///
 /// let fwd_op = ft.forward().unwrap();
-/// assert_eq!(fwd_op.mpo.node_count(), 4);
+/// assert_eq!(fwd_op.mpo().node_count(), 4);
 ///
 /// let bwd_op = ft.backward().unwrap();
-/// assert_eq!(bwd_op.mpo.node_count(), 4);
+/// assert_eq!(bwd_op.mpo().node_count(), 4);
 /// ```
 #[derive(Clone)]
 pub struct FTCore {
@@ -197,7 +197,7 @@ impl FTCore {
 /// let op = quantics_fourier_operator(4, FourierOptions::forward()).unwrap();
 ///
 /// // The operator has one MPO tensor per bit
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn quantics_fourier_operator(r: usize, options: FourierOptions) -> Result<QuanticsOperator> {
     if r < 2 {

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -55,7 +55,7 @@
 //!
 //! // Create a flip operator for 8-bit quantics representation
 //! let op = flip_operator(8, BoundaryCondition::Periodic).unwrap();
-//! assert_eq!(op.mpo.node_count(), 8);
+//! assert_eq!(op.mpo().node_count(), 8);
 //! ```
 
 mod affine;

--- a/crates/tensor4all-quanticstransform/src/phase_rotation.rs
+++ b/crates/tensor4all-quanticstransform/src/phase_rotation.rs
@@ -44,7 +44,7 @@ use crate::common::{
 /// let op = phase_rotation_operator(4, PI / 4.0).unwrap();
 ///
 /// // The operator has one MPO tensor per bit
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 ///
 /// // Phase rotation is a diagonal operator (bond dimension 1)
 /// // Error on invalid input
@@ -90,7 +90,7 @@ pub fn phase_rotation_operator(r: usize, theta: f64) -> Result<QuanticsOperator>
 ///
 /// // Phase rotate only the x-variable of a 2-variable function f(x, y)
 /// let op = phase_rotation_operator_multivar(4, PI / 4.0, 2, 0).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn phase_rotation_operator_multivar(
     r: usize,

--- a/crates/tensor4all-quanticstransform/src/shift.rs
+++ b/crates/tensor4all-quanticstransform/src/shift.rs
@@ -40,7 +40,7 @@ use crate::common::{
 /// let op = shift_operator(4, 3, BoundaryCondition::Periodic).unwrap();
 ///
 /// // The operator has one MPO tensor per bit
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn shift_operator(r: usize, offset: i64, bc: BoundaryCondition) -> Result<QuanticsOperator> {
     if r == 0 {
@@ -76,7 +76,7 @@ pub fn shift_operator(r: usize, offset: i64, bc: BoundaryCondition) -> Result<Qu
 ///
 /// // Shift only the x-variable of a 2-variable function f(x, y) by 3
 /// let op = shift_operator_multivar(4, 3, BoundaryCondition::Periodic, 2, 0).unwrap();
-/// assert_eq!(op.mpo.node_count(), 4);
+/// assert_eq!(op.mpo().node_count(), 4);
 /// ```
 pub fn shift_operator_multivar(
     r: usize,

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -281,7 +281,10 @@ fn contract_operator_to_dense_matrix(
     let dim: usize = site_dim.pow(n_sites as u32);
 
     // Contract the MPO to a single dense tensor
-    let dense_tensor = op.mpo.contract_to_tensor().expect("Failed to contract MPO");
+    let dense_tensor = op
+        .mpo()
+        .contract_to_tensor()
+        .expect("Failed to contract MPO");
 
     let ext_indices = &dense_tensor.indices;
     let data = dense_tensor

--- a/crates/tensor4all-treetn/src/operator/linear_operator.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator.rs
@@ -46,7 +46,8 @@ use crate::treetn::TreeTN;
 /// # Examples
 ///
 /// A `LinearOperator` is typically obtained from a constructor function rather
-/// than built directly. The `mpo` field contains the underlying TreeTN:
+/// than built directly. The [`mpo()`](Self::mpo) method exposes the underlying
+/// TreeTN:
 ///
 /// ```
 /// use tensor4all_treetn::LinearOperator;
@@ -72,11 +73,11 @@ where
     V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
 {
     /// The MPO with internal index IDs
-    pub mpo: TreeTN<T, V>,
+    pub(crate) mpo: TreeTN<T, V>,
     /// Input index mappings: node -> [(true s_in, internal s_in_tmp)].
-    pub input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
+    pub(crate) input_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
     /// Output index mappings: node -> [(true s_out, internal s_out_tmp)].
-    pub output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
+    pub(crate) output_mapping: HashMap<V, Vec<IndexMapping<T::Index>>>,
 }
 
 impl<T, V> LinearOperator<T, V>
@@ -357,6 +358,192 @@ where
     /// Get the internal MPO.
     pub fn mpo(&self) -> &TreeTN<T, V> {
         &self.mpo
+    }
+
+    /// Consume the operator and return its internal MPO.
+    ///
+    /// Use this when the caller needs to take ownership of the TreeTN rather
+    /// than inspect it through [`Self::mpo`]. The input/output index mappings
+    /// are discarded.
+    ///
+    /// # Returns
+    ///
+    /// The underlying MPO TreeTN.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
+    ///
+    /// let true_site = DynIndex::new_dyn(2);
+    /// let input_internal = DynIndex::new_dyn(2);
+    /// let output_internal = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(
+    ///     vec![input_internal.clone(), output_internal.clone()],
+    ///     vec![1.0_f64, 0.0, 0.0, 1.0],
+    /// )?;
+    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    ///
+    /// let mut input_mapping = HashMap::new();
+    /// input_mapping.insert(0, IndexMapping {
+    ///     true_index: true_site.clone(),
+    ///     internal_index: input_internal,
+    /// });
+    /// let mut output_mapping = HashMap::new();
+    /// output_mapping.insert(0, IndexMapping {
+    ///     true_index: true_site,
+    ///     internal_index: output_internal,
+    /// });
+    ///
+    /// let op = LinearOperator::new(mpo, input_mapping, output_mapping);
+    /// let mpo = op.into_mpo();
+    /// assert_eq!(mpo.node_count(), 1);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn into_mpo(self) -> TreeTN<T, V> {
+        self.mpo
+    }
+
+    /// Rename operator nodes and update all mapping keys consistently.
+    ///
+    /// The method consumes the operator and returns a renamed operator. It
+    /// rebuilds the internal MPO from the same tensors, so mappings such as
+    /// `0 -> 1, 1 -> 2` work even though they would collide during a sequential
+    /// in-place rename.
+    ///
+    /// # Arguments
+    ///
+    /// * `mapping` - Pairs of `(old_node, new_node)`. Nodes not listed in the
+    ///   mapping keep their existing names.
+    ///
+    /// # Returns
+    ///
+    /// A `LinearOperator` with the same tensor data and index mappings attached
+    /// to the renamed nodes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an old node is unknown, if the mapping contains a
+    /// duplicate old node, if the resulting node names would contain
+    /// duplicates, or if rebuilding the MPO fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::HashMap;
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
+    ///
+    /// let true_site = DynIndex::new_dyn(2);
+    /// let input_internal = DynIndex::new_dyn(2);
+    /// let output_internal = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_dense(
+    ///     vec![input_internal.clone(), output_internal.clone()],
+    ///     vec![1.0_f64, 0.0, 0.0, 1.0],
+    /// )?;
+    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    ///
+    /// let mut input_mapping = HashMap::new();
+    /// input_mapping.insert(0, IndexMapping {
+    ///     true_index: true_site.clone(),
+    ///     internal_index: input_internal,
+    /// });
+    /// let mut output_mapping = HashMap::new();
+    /// output_mapping.insert(0, IndexMapping {
+    ///     true_index: true_site,
+    ///     internal_index: output_internal,
+    /// });
+    ///
+    /// let op = LinearOperator::new(mpo, input_mapping, output_mapping);
+    /// let renamed = op.rename_nodes(&[(0, 2)])?;
+    ///
+    /// assert!(renamed.mpo().node_index(&0).is_none());
+    /// assert!(renamed.mpo().node_index(&2).is_some());
+    /// assert!(renamed.get_input_mapping(&2).is_some());
+    /// assert!(renamed.get_output_mapping(&2).is_some());
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn rename_nodes(mut self, mapping: &[(V, V)]) -> Result<Self> {
+        let mut rename_map = HashMap::with_capacity(mapping.len());
+        for (old_node, new_node) in mapping {
+            let previous = rename_map.insert(old_node.clone(), new_node.clone());
+            anyhow::ensure!(
+                previous.is_none(),
+                "LinearOperator::rename_nodes: duplicate old node {:?}",
+                old_node
+            );
+        }
+
+        for old_node in rename_map.keys() {
+            anyhow::ensure!(
+                self.mpo.node_index(old_node).is_some(),
+                "LinearOperator::rename_nodes: unknown old node {:?}",
+                old_node
+            );
+        }
+
+        let old_names = self.mpo.node_names();
+        let mut new_names = Vec::with_capacity(old_names.len());
+        let mut seen_names = HashSet::with_capacity(old_names.len());
+        for old_name in &old_names {
+            let new_name = rename_map
+                .get(old_name)
+                .cloned()
+                .unwrap_or_else(|| old_name.clone());
+            anyhow::ensure!(
+                seen_names.insert(new_name.clone()),
+                "LinearOperator::rename_nodes: duplicate node name {:?} after renaming",
+                new_name
+            );
+            new_names.push(new_name);
+        }
+
+        let tensors = old_names
+            .iter()
+            .map(|old_name| {
+                let node = self.mpo.node_index(old_name).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "LinearOperator::rename_nodes: node {:?} disappeared during rename",
+                        old_name
+                    )
+                })?;
+                self.mpo.tensor(node).cloned().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "LinearOperator::rename_nodes: tensor for node {:?} not found",
+                        old_name
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.mpo = TreeTN::from_tensors(tensors, new_names)?;
+        self.input_mapping = Self::rename_mapping_keys(self.input_mapping, &rename_map, "input")?;
+        self.output_mapping =
+            Self::rename_mapping_keys(self.output_mapping, &rename_map, "output")?;
+
+        Ok(self)
+    }
+
+    fn rename_mapping_keys(
+        mappings_by_node: HashMap<V, Vec<IndexMapping<T::Index>>>,
+        rename_map: &HashMap<V, V>,
+        kind: &str,
+    ) -> Result<HashMap<V, Vec<IndexMapping<T::Index>>>> {
+        let mut renamed = HashMap::with_capacity(mappings_by_node.len());
+        for (old_node, mappings) in mappings_by_node {
+            let new_node = rename_map
+                .get(&old_node)
+                .cloned()
+                .unwrap_or_else(|| old_node.clone());
+            anyhow::ensure!(
+                renamed.insert(new_node.clone(), mappings).is_none(),
+                "LinearOperator::rename_nodes: duplicate {kind} mapping node {:?}",
+                new_node
+            );
+        }
+        Ok(renamed)
     }
 
     /// Get input mapping for a node.

--- a/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
@@ -73,6 +73,85 @@ fn make_linear_operator() -> (
     (op, s, s_in_tmp, s_out_tmp)
 }
 
+fn make_three_node_linear_operator() -> LinearOperator<TensorDynLen, usize> {
+    let site0 = DynIndex::new_dyn(2);
+    let site1 = DynIndex::new_dyn(2);
+    let site2 = DynIndex::new_dyn(2);
+    let in0 = DynIndex::new_dyn(2);
+    let in1 = DynIndex::new_dyn(2);
+    let in2 = DynIndex::new_dyn(2);
+    let out0 = DynIndex::new_dyn(2);
+    let out1 = DynIndex::new_dyn(2);
+    let out2 = DynIndex::new_dyn(2);
+    let bond01 = DynIndex::new_dyn(2);
+    let bond12 = DynIndex::new_dyn(3);
+
+    let t0 = TensorDynLen::from_dense(
+        vec![in0.clone(), out0.clone(), bond01.clone()],
+        vec![1.0_f64; 2 * 2 * 2],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![bond01.clone(), in1.clone(), out1.clone(), bond12.clone()],
+        vec![1.0_f64; 2 * 2 * 2 * 3],
+    )
+    .unwrap();
+    let t2 = TensorDynLen::from_dense(
+        vec![bond12.clone(), in2.clone(), out2.clone()],
+        vec![1.0_f64; 3 * 2 * 2],
+    )
+    .unwrap();
+    let mpo = TreeTN::from_tensors(vec![t0, t1, t2], vec![0usize, 1, 2]).unwrap();
+
+    let mut input_mapping = HashMap::new();
+    input_mapping.insert(
+        0,
+        IndexMapping {
+            true_index: site0.clone(),
+            internal_index: in0,
+        },
+    );
+    input_mapping.insert(
+        1,
+        IndexMapping {
+            true_index: site1.clone(),
+            internal_index: in1,
+        },
+    );
+    input_mapping.insert(
+        2,
+        IndexMapping {
+            true_index: site2.clone(),
+            internal_index: in2,
+        },
+    );
+
+    let mut output_mapping = HashMap::new();
+    output_mapping.insert(
+        0,
+        IndexMapping {
+            true_index: site0,
+            internal_index: out0,
+        },
+    );
+    output_mapping.insert(
+        1,
+        IndexMapping {
+            true_index: site1,
+            internal_index: out1,
+        },
+    );
+    output_mapping.insert(
+        2,
+        IndexMapping {
+            true_index: site2,
+            internal_index: out2,
+        },
+    );
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
 fn make_fused_identity_operator() -> (
     LinearOperator<TensorDynLen, String>,
     DynIndex,
@@ -140,6 +219,15 @@ fn test_linear_operator_mpo_accessor() {
 }
 
 #[test]
+fn test_linear_operator_into_mpo_consumes_operator() {
+    let (op, _s, _s_in_tmp, _s_out_tmp) = make_linear_operator();
+
+    let mpo = op.into_mpo();
+
+    assert_eq!(mpo.node_count(), 1);
+}
+
+#[test]
 fn test_linear_operator_input_output_site_indices() {
     let (op, s, _s_in_tmp, _s_out_tmp) = make_linear_operator();
 
@@ -150,6 +238,35 @@ fn test_linear_operator_input_output_site_indices() {
     let output_indices = op.output_site_indices();
     assert_eq!(output_indices.len(), 1);
     assert!(output_indices.iter().any(|i| i.id() == s.id()));
+}
+
+#[test]
+fn rename_nodes_rebuilds_mpo_and_mappings_for_colliding_targets() {
+    let op = make_three_node_linear_operator();
+
+    let renamed = op.rename_nodes(&[(0, 0), (1, 2), (2, 4)]).unwrap();
+
+    assert!(renamed.mpo().node_index(&0).is_some());
+    assert!(renamed.mpo().node_index(&1).is_none());
+    assert!(renamed.mpo().node_index(&2).is_some());
+    assert!(renamed.mpo().node_index(&4).is_some());
+    assert!(renamed.mpo().edge_between(&0, &2).is_some());
+    assert!(renamed.mpo().edge_between(&2, &4).is_some());
+    assert!(renamed.get_input_mapping(&0).is_some());
+    assert!(renamed.get_input_mapping(&2).is_some());
+    assert!(renamed.get_input_mapping(&4).is_some());
+    assert!(renamed.get_output_mapping(&0).is_some());
+    assert!(renamed.get_output_mapping(&2).is_some());
+    assert!(renamed.get_output_mapping(&4).is_some());
+}
+
+#[test]
+fn rename_nodes_rejects_duplicate_new_names() {
+    let op = make_three_node_linear_operator();
+
+    let err = op.rename_nodes(&[(0, 1)]).unwrap_err();
+
+    assert!(err.to_string().contains("duplicate node name"));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/ops.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops.rs
@@ -596,6 +596,114 @@ where
         TreeTNEvaluator::new(self, indices)?.evaluate_batch(values)
     }
 
+    /// Evaluate the TreeTN at one multi-index.
+    ///
+    /// This is a convenience wrapper around [`Self::evaluate`] for the common
+    /// single-point case.
+    ///
+    /// # Arguments
+    ///
+    /// * `indices` - Identifies each site index by full `Index` value. It must
+    ///   enumerate every site index exactly once.
+    /// * `values` - One site value for each entry in `indices`.
+    ///
+    /// # Returns
+    ///
+    /// The scalar value of this TreeTN at the requested multi-index.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `values.len() != indices.len()`, if the index list is
+    /// invalid, if any value is out of bounds, or if contraction fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let s = DynIndex::new_dyn(3);
+    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0])?;
+    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    ///
+    /// let value = tree.evaluate_point(&[s], &[2])?;
+    /// assert!((value.real() - 30.0).abs() < 1e-12);
+    /// assert!(value.imag().abs() < 1e-12);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn evaluate_point(&self, indices: &[T::Index], values: &[usize]) -> Result<AnyScalar>
+    where
+        T::Index: Clone + Hash + Eq,
+        <T::Index as IndexLike>::Id: Ord,
+    {
+        anyhow::ensure!(
+            values.len() == indices.len(),
+            "TreeTN::evaluate_point: values.len() ({}) != indices.len() ({})",
+            values.len(),
+            indices.len()
+        );
+
+        let shape = [indices.len(), 1usize];
+        let values = ColMajorArrayRef::new(values, &shape)
+            .context("TreeTN::evaluate_point: values must contain one point")?;
+        let result = self.evaluate(indices, values)?;
+
+        result
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("TreeTN::evaluate_point: evaluation returned no values"))
+    }
+
+    /// Return the dimensions of all internal bond links.
+    ///
+    /// The dimensions are ordered by sorted node-name edge pairs, giving a stable
+    /// profile for reports and examples. Site dimensions are not included.
+    ///
+    /// # Returns
+    ///
+    /// A vector containing one dimension for each TreeTN edge.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let s0 = DynIndex::new_dyn(2);
+    /// let s1 = DynIndex::new_dyn(2);
+    /// let bond = DynIndex::new_dyn(3);
+    /// let left = TensorDynLen::from_dense(
+    ///     vec![s0, bond.clone()],
+    ///     vec![1.0_f64; 2 * 3],
+    /// )?;
+    /// let right = TensorDynLen::from_dense(
+    ///     vec![bond, s1],
+    ///     vec![1.0_f64; 3 * 2],
+    /// )?;
+    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![left, right], vec![0, 1])?;
+    ///
+    /// assert_eq!(tree.link_dims(), vec![3]);
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn link_dims(&self) -> Vec<usize> {
+        let mut edges = self.site_index_network.edges().collect::<Vec<_>>();
+        for (left, right) in &mut edges {
+            if right < left {
+                std::mem::swap(left, right);
+            }
+        }
+        edges.sort();
+        edges.dedup();
+
+        edges
+            .into_iter()
+            .filter_map(|(left, right)| {
+                let edge = self.edge_between(&left, &right)?;
+                self.bond_index(edge).map(IndexLike::dim)
+            })
+            .collect()
+    }
+
     /// Returns all site indices and their owning vertex names.
     ///
     /// Returns `(indices, vertex_names)` where `indices[i]` belongs to

--- a/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
@@ -112,6 +112,50 @@ fn evaluator_evaluate_batch_matches_evaluate_at_sugar() {
 }
 
 #[test]
+fn evaluate_point_matches_single_column_batch() {
+    let tn = make_three_node_chain();
+    let (indices, _) = tn.all_site_indices().unwrap();
+    let values = [1usize, 0, 1];
+    let shape = [indices.len(), 1usize];
+
+    let point = tn.evaluate_point(&indices, &values).unwrap();
+    let batch = tn
+        .evaluate_at(&indices, ColMajorArrayRef::new(&values, &shape).unwrap())
+        .unwrap();
+
+    assert_eq!(batch.len(), 1);
+    assert!((point.real() - batch[0].real()).abs() < 1.0e-12);
+    assert!((point.imag() - batch[0].imag()).abs() < 1.0e-12);
+}
+
+#[test]
+fn evaluate_point_rejects_value_count_mismatch() {
+    let tn = make_three_node_chain();
+    let (indices, _) = tn.all_site_indices().unwrap();
+
+    let err = tn.evaluate_point(&indices, &[0usize, 1]).unwrap_err();
+
+    assert!(err.to_string().contains("values.len()"));
+}
+
+#[test]
+fn link_dims_reports_bond_dimensions_in_node_order() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let bond01 = DynIndex::new_dyn(2);
+    let bond12 = DynIndex::new_dyn(3);
+
+    let t0 = TensorDynLen::from_dense(vec![s0, bond01.clone()], vec![1.0_f64; 2 * 2]).unwrap();
+    let t1 = TensorDynLen::from_dense(vec![bond01, s1, bond12.clone()], vec![1.0_f64; 2 * 2 * 3])
+        .unwrap();
+    let t2 = TensorDynLen::from_dense(vec![bond12, s2], vec![1.0_f64; 3 * 2]).unwrap();
+    let tn = TreeTN::from_tensors(vec![t0, t1, t2], vec![0usize, 1, 2]).unwrap();
+
+    assert_eq!(tn.link_dims(), vec![2, 3]);
+}
+
+#[test]
 fn evaluator_rejects_incomplete_site_index_list() {
     let tn = make_three_node_chain();
     let (indices, _) = tn.all_site_indices().unwrap();

--- a/docs/book/src/guides/qft.md
+++ b/docs/book/src/guides/qft.md
@@ -33,8 +33,8 @@ let fwd = ft.forward().unwrap();
 let bwd = ft.backward().unwrap();
 
 // Each operator has r sites
-assert_eq!(fwd.mpo.node_count(), r);
-assert_eq!(bwd.mpo.node_count(), r);
+assert_eq!(fwd.mpo().node_count(), r);
+assert_eq!(bwd.mpo().node_count(), r);
 
 // Both operators have input and output mappings for all sites
 for i in 0..r {
@@ -196,30 +196,13 @@ let batch_eval = move |batch: tensor4all_treetci::GlobalIndexBatch<'_>|
 let state = to_treetn(tci_state, batch_eval, Some(0)).unwrap();
 
 // Build 1D Fourier operator (nodes 0,1,2)
-let mut fourier_op = quantics_fourier_operator(
+let fourier_op = quantics_fourier_operator(
     r, FourierOptions { normalize: true, ..Default::default() },
 ).unwrap();
 
 // Rename nodes to x-variable sites: 0->0, 1->2, 2->4
-// Use two-phase rename to avoid collisions
-let offset = 1_000_000;
-for i in 0..r {
-    fourier_op.mpo.rename_node(&i, i + offset).unwrap();
-}
-for i in 0..r {
-    fourier_op.mpo.rename_node(&(i + offset), 2 * i).unwrap();
-}
-// Update mappings
-let mut new_input = std::collections::HashMap::new();
-for (k, v) in fourier_op.input_mapping.drain() {
-    new_input.insert(2 * k, v);
-}
-fourier_op.input_mapping = new_input;
-let mut new_output = std::collections::HashMap::new();
-for (k, v) in fourier_op.output_mapping.drain() {
-    new_output.insert(2 * k, v);
-}
-fourier_op.output_mapping = new_output;
+let x_site_mapping: Vec<_> = (0..r).map(|i| (i, 2 * i)).collect();
+let mut fourier_op = fourier_op.rename_nodes(&x_site_mapping).unwrap();
 
 // Match operator's true indices to state's site indices
 fourier_op.set_input_space_from_state(&state).unwrap();

--- a/docs/book/src/guides/quantics.md
+++ b/docs/book/src/guides/quantics.md
@@ -67,23 +67,23 @@ let r = 8;
 
 // Flip: f(x) = g(2^R - x)
 let flip_op = flip_operator(r, BoundaryCondition::Periodic).unwrap();
-assert_eq!(flip_op.mpo.node_count(), r);
+assert_eq!(flip_op.mpo().node_count(), r);
 
 // Shift by 10: f(x) = g(x + 10) mod 2^R
 let shift_op = shift_operator(r, 10, BoundaryCondition::Periodic).unwrap();
-assert_eq!(shift_op.mpo.node_count(), r);
+assert_eq!(shift_op.mpo().node_count(), r);
 
 // Phase rotation: f(x) = exp(i*pi/4*x) * g(x)
 let phase_op = phase_rotation_operator(r, std::f64::consts::PI / 4.0).unwrap();
-assert_eq!(phase_op.mpo.node_count(), r);
+assert_eq!(phase_op.mpo().node_count(), r);
 
 // Cumulative sum
 let cumsum_op = cumsum_operator(r).unwrap();
-assert_eq!(cumsum_op.mpo.node_count(), r);
+assert_eq!(cumsum_op.mpo().node_count(), r);
 
 // Fourier transform (forward)
 let ft_op = quantics_fourier_operator(r, FourierOptions::forward()).unwrap();
-assert_eq!(ft_op.mpo.node_count(), r);
+assert_eq!(ft_op.mpo().node_count(), r);
 ```
 
 ### Affine Transform
@@ -105,7 +105,7 @@ let b = vec![Rational64::from_integer(0), Rational64::from_integer(0)];
 let params = AffineParams::new(a, b, 2, 2).unwrap();
 let bc = vec![BoundaryCondition::Periodic; 2];
 let affine_op = affine_operator(r, &params, &bc).unwrap();
-assert_eq!(affine_op.mpo.node_count(), r);
+assert_eq!(affine_op.mpo().node_count(), r);
 ```
 
 ---
@@ -241,11 +241,11 @@ use tensor4all_quanticstransform::{shift_operator, BoundaryCondition};
 
 // Periodic: shift(7, 2) in 3-bit (mod 8) wraps to 1
 let shift_periodic = shift_operator(3, 2, BoundaryCondition::Periodic).unwrap();
-assert_eq!(shift_periodic.mpo.node_count(), 3);
+assert_eq!(shift_periodic.mpo().node_count(), 3);
 
 // Open: shift(7, 2) in 3-bit goes to 9 >= 8, producing zero
 let shift_open = shift_operator(3, 2, BoundaryCondition::Open).unwrap();
-assert_eq!(shift_open.mpo.node_count(), 3);
+assert_eq!(shift_open.mpo().node_count(), 3);
 ```
 
 ---
@@ -264,11 +264,11 @@ let r = 4;
 
 // Forward QFT (bit-reversed output)
 let fwd = quantics_fourier_operator(r, FourierOptions::forward()).unwrap();
-assert_eq!(fwd.mpo.node_count(), r);
+assert_eq!(fwd.mpo().node_count(), r);
 
 // Inverse QFT
 let inv = quantics_fourier_operator(r, FourierOptions::inverse()).unwrap();
-assert_eq!(inv.mpo.node_count(), r);
+assert_eq!(inv.mpo().node_count(), r);
 ```
 
 ---

--- a/docs/book/src/tutorials/computations-with-qtt/elementwise-product.md
+++ b/docs/book/src/tutorials/computations-with-qtt/elementwise-product.md
@@ -16,7 +16,6 @@ pointwise product. The two target functions are `f(x) = x^2` and
 ```rust
 # fn main() -> anyhow::Result<()> {
 # use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
-# use tensor4all_core::ColMajorArrayRef;
 # use tensor4all_treetn::{
 #     contraction::ContractionOptions,
 #     partial_contract, tensor_train_to_treetn, PartialContractionSpec,
@@ -61,12 +60,10 @@ let product = partial_contract(
     &tn_a, &tn_b, &spec, &center, ContractionOptions::default(),
 )?;
 
-let shape = [site_indices_a.len(), 1];
-let site_values = ColMajorArrayRef::new(&[0usize, 1, 1], &shape)?;
-let value = product.evaluate_at(&site_indices_a, site_values)?;
+let value = product.evaluate_point(&site_indices_a, &[0usize, 1, 1])?;
 let x = (4.0 - 1.0) / npoints as f64;
 let expected = x.powi(2) * (10.0 * x).sin();
-assert!((value[0].real() - expected).abs() < 1e-8);
+assert!((value.real() - expected).abs() < 1e-8);
 assert_eq!(product.node_count(), 3);
 # Ok(())
 # }

--- a/docs/book/src/tutorials/computations-with-qtt/fourier-transform.md
+++ b/docs/book/src/tutorials/computations-with-qtt/fourier-transform.md
@@ -38,7 +38,7 @@ let options = QtciOptions::default()
 let (state, _, _) = quanticscrossinterpolate(&grid, gaussian, None, options)?;
 
 let mut operator = quantics_fourier_operator(bits, FourierOptions::forward())?;
-assert_eq!(operator.mpo.node_count(), bits);
+assert_eq!(operator.mpo().node_count(), bits);
 
 let tt = state.tensor_train();
 let (state_tn, _indices) = tensor_train_to_treetn(&tt)?;

--- a/docs/book/src/tutorials/computations-with-qtt/partial-fourier2d.md
+++ b/docs/book/src/tutorials/computations-with-qtt/partial-fourier2d.md
@@ -10,10 +10,10 @@ Runnable source: [`docs/tutorial-code/src/bin/qtt_partial_fourier2d.rs`](../../.
 
 For an interleaved two-variable QTT, the state nodes are ordered
 `x0, t0, x1, t1, ...`. A one-dimensional Fourier MPO has only `x` nodes, so the
-operator nodes must be renamed onto the even state nodes before the operator is
-expanded with identity tensors on the `t` nodes. The runnable source linked
-above performs that expansion in `transform_x_dimension`. The source function
-is `f(x, t) = exp(-x^2 / 2) * cos(2πt)`.
+operator nodes are renamed onto the even state nodes. `apply_linear_operator`
+then handles the partial operator and leaves the missing `t` nodes as identity
+gaps. The source function is
+`f(x, t) = exp(-x^2 / 2) * cos(2πt)`.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
@@ -43,24 +43,25 @@ let options = QtciOptions::default()
 let (state, _ranks, _errors) = quanticscrossinterpolate(&grid, f, None, options)?;
 
 let operator = quantics_fourier_operator(bits, FourierOptions::forward())?;
-assert_eq!(operator.mpo.node_count(), bits);
+assert_eq!(operator.mpo().node_count(), bits);
 
 let x_site_mapping: Vec<_> = (0..bits).map(|site| (site, 2 * site)).collect();
+let renamed_operator = operator.rename_nodes(&x_site_mapping)?;
 
 assert_eq!(state.tensor_train().len(), 2 * bits);
 assert_eq!(x_site_mapping.len(), bits);
 assert_eq!(x_site_mapping[0], (0, 0));
 assert_eq!(x_site_mapping[bits - 1], (bits - 1, 2 * (bits - 1)));
+assert_eq!(renamed_operator.mpo().node_count(), bits);
 # Ok(())
 # }
 ```
 
-The full source then renames the operator nodes with this mapping, expands the
-operator with identity tensors on the odd `t` nodes, aligns the resulting
-operator to the state, and applies it. Passing `None` for `initial_pivots` is
-the best starting point for tutorial code because it keeps QTCI on its default
-initialization path. Explicit pivot lists are a later tuning tool for cases
-where you already know important grid points.
+The full source then aligns the renamed partial operator to the state and
+applies it. Passing `None` for `initial_pivots` is the best starting point for
+tutorial code because it keeps QTCI on its default initialization path. Explicit
+pivot lists are a later tuning tool for cases where you already know important
+grid points.
 Use `apply_linear_operator_to_numbered_tags` if and only if numbered tags such as `x=1`, `x=2`, ... are the intended operator binding.
 
 ## What It Computes
@@ -73,7 +74,8 @@ partial transform.
 
 ![Partial Fourier error](qtt_partial_fourier2d_error.png)
 
-Only the x-sites receive the operator, so the implementation must map the
-one-dimensional operator nodes onto the even nodes of the interleaved state.
+Only the x-sites receive the operator, so the implementation maps the
+one-dimensional operator nodes onto the even nodes of the interleaved state and
+lets partial apply supply the identity behavior on the t-sites.
 
 ![Bond dimensions for the partial Fourier result](qtt_partial_fourier2d_bond_dims.png)

--- a/docs/tutorial-code/src/bin/qtt_affine.rs
+++ b/docs/tutorial-code/src/bin/qtt_affine.rs
@@ -12,8 +12,8 @@ use tensor4all_treetn::{apply_linear_operator, tensor_train_to_treetn, ApplyOpti
 use tensor4all_tutorial_code::output_paths;
 use tensor4all_tutorial_code::qtt_affine_common::{
     collect_bond_dims, collect_operator_bond_dims, collect_samples, point_count, print_summary,
-    source_function, tree_link_dims, write_bond_dims_csv, write_operator_bond_dims_csv,
-    write_samples_csv, DEFAULT_AFFINE_CONFIG,
+    source_function, write_bond_dims_csv, write_operator_bond_dims_csv, write_samples_csv,
+    DEFAULT_AFFINE_CONFIG,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -106,14 +106,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         &config,
     )?;
 
-    let bond_dims = collect_bond_dims(
-        &tree_link_dims(&state),
-        &tree_link_dims(&periodic),
-        &tree_link_dims(&open),
-    );
+    let bond_dims = collect_bond_dims(&state.link_dims(), &periodic.link_dims(), &open.link_dims());
     let operator_bond_dims = collect_operator_bond_dims(
-        &tree_link_dims(&periodic_operator.mpo),
-        &tree_link_dims(&open_operator.mpo),
+        &periodic_operator.mpo().link_dims(),
+        &open_operator.mpo().link_dims(),
     );
 
     print_summary(&source, &periodic, &open, &samples, &config);

--- a/docs/tutorial-code/src/bin/qtt_fourier.rs
+++ b/docs/tutorial-code/src/bin/qtt_fourier.rs
@@ -11,9 +11,8 @@ use tensor4all_quanticstci::DiscretizedGrid;
 use tensor4all_tutorial_code::output_paths;
 use tensor4all_tutorial_code::qtt_fourier_common::{
     build_fourier_operator, build_gaussian_qtt, collect_bond_dims_from_profiles, collect_samples,
-    physical_frequency_bounds, print_summary, transform_gaussian, tree_link_dims,
-    write_bond_dims_csv, write_fourier_operator_bond_dims_csv, write_samples_csv,
-    DEFAULT_FOURIER_CONFIG,
+    physical_frequency_bounds, print_summary, transform_gaussian, write_bond_dims_csv,
+    write_fourier_operator_bond_dims_csv, write_samples_csv, DEFAULT_FOURIER_CONFIG,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -59,10 +58,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let input_bond_dims = qtci.link_dims();
 
     // The transformed state is a TreeTN, so inspect its internal bonds separately.
-    let transformed_bond_dims = tree_link_dims(&transformed);
+    let transformed_bond_dims = transformed.link_dims();
 
     // The Fourier operator is represented as an MPO; its bonds are the operator ranks.
-    let operator_bond_dims = tree_link_dims(&operator.mpo);
+    let operator_bond_dims = operator.mpo().link_dims();
 
     let bond_dims = collect_bond_dims_from_profiles(&input_bond_dims, &transformed_bond_dims);
 

--- a/docs/tutorial-code/src/bin/qtt_partial_fourier2d.rs
+++ b/docs/tutorial-code/src/bin/qtt_partial_fourier2d.rs
@@ -7,9 +7,8 @@ use std::path::Path;
 use tensor4all_tutorial_code::output_paths;
 use tensor4all_tutorial_code::qtt_partial_fourier2d_common::{
     build_frequency_grid, build_input_grid, build_partial_fourier_operator, build_source_qtt,
-    collect_bond_dims, collect_samples, print_summary, transform_x_dimension, tree_link_dims,
-    write_bond_dims_csv, write_operator_bond_dims_csv, write_samples_csv,
-    DEFAULT_PARTIAL_FOURIER2D_CONFIG,
+    collect_bond_dims, collect_samples, print_summary, transform_x_dimension, write_bond_dims_csv,
+    write_operator_bond_dims_csv, write_samples_csv, DEFAULT_PARTIAL_FOURIER2D_CONFIG,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -26,8 +25,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let (transformed, site_indices) = transform_x_dimension(&qtci, &operator)?;
     let samples = collect_samples(&transformed, &site_indices, &frequency_grid, &config)?;
 
-    let bond_dims = collect_bond_dims(&qtci.link_dims(), &tree_link_dims(&transformed));
-    let operator_bond_dims = tree_link_dims(&operator.mpo);
+    let bond_dims = collect_bond_dims(&qtci.link_dims(), &transformed.link_dims());
+    let operator_bond_dims = operator.mpo().link_dims();
 
     print_summary(&qtci, &transformed, &ranks, &errors, &samples, &config);
 

--- a/docs/tutorial-code/src/qtt_affine_common.rs
+++ b/docs/tutorial-code/src/qtt_affine_common.rs
@@ -378,3 +378,97 @@ pub fn print_summary(
     println!("max periodic abs error = {:.3e}", max_periodic_error);
     println!("max open abs error = {:.3e}", max_open_error);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn scratch_csv(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time is after the Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{name}-{nonce}.csv"))
+    }
+
+    #[test]
+    fn transformed_reference_applies_boundary_modes() {
+        let bits = 3;
+        let n = point_count(bits);
+
+        let periodic = transformed_reference(n - 1, 2, bits, AffineBoundaryMode::Periodic);
+        assert!((periodic - source_function(1, 2, n)).abs() < 1e-12);
+
+        let open_outside = transformed_reference(n - 1, 2, bits, AffineBoundaryMode::Open);
+        assert_eq!(open_outside, 0.0);
+
+        let open_inside = transformed_reference(1, 2, bits, AffineBoundaryMode::Open);
+        assert!((open_inside - source_function(3, 2, n)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bond_dim_rows_pad_missing_profiles() {
+        assert_eq!(
+            collect_bond_dims(&[2, 3], &[5], &[7, 11, 13]),
+            vec![
+                (1, Some(2), Some(5), Some(7)),
+                (2, Some(3), None, Some(11)),
+                (3, None, None, Some(13)),
+            ]
+        );
+
+        assert_eq!(
+            collect_operator_bond_dims(&[2], &[3, 5]),
+            vec![(1, Some(2), Some(3)), (2, None, Some(5))]
+        );
+    }
+
+    #[test]
+    fn csv_writers_keep_headers_and_empty_optional_cells() -> Result<(), Box<dyn Error>> {
+        let samples_path = scratch_csv("affine-samples");
+        write_samples_csv(
+            &samples_path,
+            &[AffineSamplePoint {
+                x_index: 1,
+                y_index: 2,
+                x: 0,
+                y: 1,
+                source_u_periodic: 1,
+                source_v: 1,
+                source_exact: 0.5,
+                periodic_exact: 0.25,
+                periodic_qtt: 0.125,
+                periodic_abs_error: 0.125,
+                open_exact: 0.0,
+                open_qtt: 0.0,
+                open_abs_error: 0.0,
+            }],
+        )?;
+        let sample_csv = fs::read_to_string(&samples_path)?;
+        assert!(sample_csv.starts_with(
+            "x_index,y_index,x,y,source_u_periodic,source_v,source_exact,periodic_exact,periodic_qtt,periodic_abs_error,open_exact,open_qtt,open_abs_error\n"
+        ));
+        assert!(sample_csv.contains(",0.5000000000000000,0.2500000000000000,"));
+
+        let bond_dims_path = scratch_csv("affine-bonds");
+        write_bond_dims_csv(&bond_dims_path, &[(1, Some(2), None, Some(4))])?;
+        let bond_csv = fs::read_to_string(&bond_dims_path)?;
+        assert_eq!(
+            bond_csv,
+            "bond_index,input_bond_dim,periodic_transformed_bond_dim,open_transformed_bond_dim\n1,2,,4\n"
+        );
+
+        let operator_dims_path = scratch_csv("affine-operator-bonds");
+        write_operator_bond_dims_csv(&operator_dims_path, &[(1, None, Some(8))])?;
+        let operator_csv = fs::read_to_string(&operator_dims_path)?;
+        assert_eq!(
+            operator_csv,
+            "bond_index,periodic_operator_bond_dim,open_operator_bond_dim\n1,,8\n"
+        );
+
+        Ok(())
+    }
+}

--- a/docs/tutorial-code/src/qtt_affine_common.rs
+++ b/docs/tutorial-code/src/qtt_affine_common.rs
@@ -3,7 +3,6 @@
 //! This helper keeps affine-operator construction, fused quantics grid conversion,
 //! dense sampling, CSV writing, and summary printing out of the tutorial binary.
 
-use std::collections::HashSet;
 use std::error::Error;
 use std::f64::consts::PI;
 use std::fs::File;
@@ -12,7 +11,7 @@ use std::path::Path;
 
 use num_complex::Complex64;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{ColMajorArrayRef, IndexLike, TensorDynLen};
+use tensor4all_core::TensorDynLen;
 use tensor4all_quanticstci::{
     quanticscrossinterpolate_discrete, InherentDiscreteGrid, QtciOptions, QuanticsTensorCI2,
     UnfoldingScheme,
@@ -168,12 +167,7 @@ pub fn evaluate_tree_point(
     site_indices: &[SiteIndex],
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
-    let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape)?;
-    let result = tn.evaluate_at(site_indices, values)?;
-    let value = result
-        .first()
-        .ok_or_else(|| "TreeTN evaluation returned no values".to_string())?;
+    let value = tn.evaluate_point(site_indices, site_values)?;
     Ok(Complex64::new(value.real(), value.imag()))
 }
 
@@ -239,26 +233,6 @@ pub fn collect_samples(
     }
 
     Ok(samples)
-}
-
-/// Inspect a TreeTN once and read out its bond dimensions.
-pub fn tree_link_dims(tn: &TreeTN<TensorDynLen, usize>) -> Vec<usize> {
-    let mut dims = Vec::new();
-    let mut seen_edges = HashSet::new();
-
-    for node_name in tn.node_names() {
-        if let Some(node_idx) = tn.node_index(&node_name) {
-            for (edge, _neighbor) in tn.edges_for_node(node_idx) {
-                if seen_edges.insert(edge) {
-                    if let Some(bond) = tn.bond_index(edge) {
-                        dims.push(bond.dim());
-                    }
-                }
-            }
-        }
-    }
-
-    dims
 }
 
 /// Pair input and transformed bond dimensions for the tutorial CSV output.

--- a/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
+++ b/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
@@ -9,13 +9,12 @@
 //!
 //! All output formatting, CSV writing, and reusable bookkeeping lives here so
 //! the binary remains readable for beginners.
-use std::collections::HashSet;
 use std::error::Error;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use tensor4all_core::{ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
 use tensor4all_quanticstci::QuanticsTensorCI2;
 use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops, TensorTrain};
 use tensor4all_treetn::TreeTN;
@@ -147,7 +146,7 @@ pub fn print_treetn_summary(
     println!("{label}");
     println!("node_count = {}", tn.node_count());
     println!("edge_count = {}", tn.edge_count());
-    println!("link_dims = {:?}", tree_link_dims(tn));
+    println!("link_dims = {:?}", tn.link_dims());
     let (site_indices, owners) = tn.all_site_indices()?;
     println!("site indices = {}", site_indices.len());
     for (index, owner) in site_indices.iter().zip(owners.iter()) {
@@ -157,42 +156,12 @@ pub fn print_treetn_summary(
     Ok(())
 }
 
-/// Collect the bond dimensions from a TreeTN by walking its edges once.
-///
-/// This is a small inspection helper around the TreeTN API. It does not change
-/// the network; it only reads out the bond sizes.
-pub fn tree_link_dims(tn: &TreeTN<TensorDynLen, usize>) -> Vec<usize> {
-    let mut dims = Vec::new();
-    let mut seen_edges = HashSet::new();
-
-    for node_name in tn.node_names() {
-        if let Some(node_idx) = tn.node_index(&node_name) {
-            for (edge, _neighbor) in tn.edges_for_node(node_idx) {
-                if seen_edges.insert(edge) {
-                    if let Some(bond) = tn.bond_index(edge) {
-                        dims.push(bond.dim());
-                    }
-                }
-            }
-        }
-    }
-
-    dims
-}
-
 fn evaluate_tree_point(
     tn: &TreeTN<TensorDynLen, usize>,
     site_indices: &[DynIndex],
     site_values: &[usize],
 ) -> Result<f64, Box<dyn Error>> {
-    // Library call: evaluate the TreeTN at a specific set of site values.
-    // We wrap it here so the sampling code stays simple.
-    let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape)?;
-    let result = tn.evaluate_at(site_indices, values)?;
-    let value = result
-        .first()
-        .ok_or_else(|| "TreeTN evaluation returned no values".to_string())?;
+    let value = tn.evaluate_point(site_indices, site_values)?;
     Ok(value.real())
 }
 
@@ -201,7 +170,7 @@ fn evaluate_tree_point(
 ///
 /// This function is mostly bookkeeping:
 /// - the QTT library gives us `evaluate(...)` for the factor QTTs
-/// - the TreeTN library gives us `evaluate_at(...)` for the product networks
+/// - the TreeTN library gives us `evaluate_point(...)` for the product networks
 /// - we combine all values into one row per grid point
 #[allow(clippy::too_many_arguments)]
 pub fn collect_samples<F, G>(
@@ -257,7 +226,7 @@ where
 /// Collect the bond-dimension profile for the two factors and their product.
 ///
 /// The factor QTTs are simple tensor trains, so we use `link_dims()` there.
-/// The product lives as TreeTN, so we use `tree_link_dims()` for those rows.
+/// The product lives as TreeTN, so we use `TreeTN::link_dims()` for those rows.
 pub fn collect_bond_profile(
     cosh_tt: &TensorTrain<f64>,
     factor_b_tt: &TensorTrain<f64>,
@@ -266,8 +235,8 @@ pub fn collect_bond_profile(
 ) -> Result<Vec<BondProfileRow>, Box<dyn Error>> {
     let cosh_bonds = cosh_tt.link_dims();
     let factor_b_bonds = factor_b_tt.link_dims();
-    let raw_bonds = tree_link_dims(product_raw_tn);
-    let compressed_bonds = tree_link_dims(product_compressed_tn);
+    let raw_bonds = product_raw_tn.link_dims();
+    let compressed_bonds = product_compressed_tn.link_dims();
 
     let len = [
         cosh_bonds.len(),

--- a/docs/tutorial-code/src/qtt_fourier_common.rs
+++ b/docs/tutorial-code/src/qtt_fourier_common.rs
@@ -3,7 +3,6 @@
 //! These helpers keep the Gaussian Fourier example focused on the operator
 //! flow instead of file output and coordinate plumbing.
 
-use std::collections::HashSet;
 use std::error::Error;
 use std::f64::consts::PI;
 use std::fs::File;
@@ -12,7 +11,7 @@ use std::path::Path;
 
 use num_complex::Complex64;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{ColMajorArrayRef, IndexLike, TensorDynLen};
+use tensor4all_core::TensorDynLen;
 use tensor4all_quanticstci::{
     quanticscrossinterpolate, DiscretizedGrid, QtciOptions, QuanticsTensorCI2, UnfoldingScheme,
 };
@@ -170,12 +169,7 @@ pub fn evaluate_tree_point(
     site_indices: &[SiteIndex],
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
-    let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape)?;
-    let result = tn.evaluate_at(site_indices, values)?;
-    let value = result
-        .first()
-        .ok_or_else(|| "TreeTN evaluation returned no values".to_string())?;
+    let value = tn.evaluate_point(site_indices, site_values)?;
     Ok(Complex64::new(value.real(), value.imag()))
 }
 
@@ -231,26 +225,6 @@ pub fn collect_bond_dims_from_profiles(
         .enumerate()
         .map(|(i, (&input_dim, &transformed_dim))| (i + 1, input_dim, transformed_dim))
         .collect()
-}
-
-/// Inspect a TreeTN once and read out its bond dimensions.
-pub fn tree_link_dims(tn: &TreeTN<TensorDynLen, usize>) -> Vec<usize> {
-    let mut dims = Vec::new();
-    let mut seen_edges = HashSet::new();
-
-    for node_name in tn.node_names() {
-        if let Some(node_idx) = tn.node_index(&node_name) {
-            for (edge, _neighbor) in tn.edges_for_node(node_idx) {
-                if seen_edges.insert(edge) {
-                    if let Some(bond) = tn.bond_index(edge) {
-                        dims.push(bond.dim());
-                    }
-                }
-            }
-        }
-    }
-
-    dims
 }
 
 /// Print a compact summary for the Gaussian Fourier tutorial.

--- a/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
+++ b/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
@@ -4,7 +4,6 @@
 //! operator only to the x-sites, and compares the result with an analytic
 //! partial Fourier transform.
 
-use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::f64::consts::PI;
 use std::fs::File;
@@ -13,14 +12,13 @@ use std::path::Path;
 
 use num_complex::Complex64;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{outer_product, ColMajorArrayRef, IndexLike, TensorDynLen};
+use tensor4all_core::TensorDynLen;
 use tensor4all_quanticstci::{
     quanticscrossinterpolate, DiscretizedGrid, QtciOptions, QuanticsTensorCI2, UnfoldingScheme,
 };
 use tensor4all_quanticstransform::{quantics_fourier_operator, FourierOptions};
 use tensor4all_treetn::{
-    apply_linear_operator, tensor_train_to_treetn, ApplyOptions, IndexMapping, LinearOperator,
-    TreeTN,
+    apply_linear_operator, tensor_train_to_treetn, ApplyOptions, LinearOperator, TreeTN,
 };
 
 pub type SiteIndex = Index<DynId, TagSet>;
@@ -200,44 +198,6 @@ pub fn build_source_qtt(
         options,
     )?)
 }
-pub fn rename_operator_nodes(
-    mut operator: LinearOperator<TensorDynLen, usize>,
-    mapping: &[(usize, usize)],
-) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
-    let offset = 1_000_000usize;
-
-    for &(old, _) in mapping {
-        operator.mpo.rename_node(&old, old + offset)?;
-    }
-    for &(old, new) in mapping {
-        operator.mpo.rename_node(&(old + offset), new)?;
-    }
-
-    let mut new_input = std::collections::HashMap::new();
-    for (node, mapping_value) in operator.input_mapping.drain() {
-        let new_node = mapping
-            .iter()
-            .find(|&&(old, _)| old == node)
-            .map(|&(_, new)| new)
-            .unwrap_or(node);
-        new_input.insert(new_node, mapping_value);
-    }
-    operator.input_mapping = new_input;
-
-    let mut new_output = std::collections::HashMap::new();
-    for (node, mapping_value) in operator.output_mapping.drain() {
-        let new_node = mapping
-            .iter()
-            .find(|&&(old, _)| old == node)
-            .map(|&(_, new)| new)
-            .unwrap_or(node);
-        new_output.insert(new_node, mapping_value);
-    }
-    operator.output_mapping = new_output;
-
-    Ok(operator)
-}
-
 pub fn build_partial_fourier_operator(
     config: &PartialFourier2dConfig,
 ) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
@@ -247,7 +207,7 @@ pub fn build_partial_fourier_operator(
         ..FourierOptions::forward()
     };
     let operator = quantics_fourier_operator(config.bits, options)?;
-    rename_operator_nodes(operator, &x_site_node_mapping(config.bits))
+    Ok(operator.rename_nodes(&x_site_node_mapping(config.bits))?)
 }
 
 fn single_site_index_from_state(
@@ -271,144 +231,13 @@ fn single_site_index_from_state(
         .ok_or_else(|| format!("state node {node} has an empty site space").into())
 }
 
-fn expand_operator_to_interleaved_state(
-    operator: &LinearOperator<TensorDynLen, usize>,
-    state: &TreeTN<TensorDynLen, usize>,
-) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
-    let bits = operator.input_mappings().len();
-    let expected_state_nodes = 2 * bits;
-    if state.node_count() != expected_state_nodes {
-        return Err(format!(
-            "partial Fourier state should have {expected_state_nodes} nodes for {bits} x-sites, got {}",
-            state.node_count()
-        )
-        .into());
-    }
-
-    let mut tensors_by_node: HashMap<usize, TensorDynLen> = HashMap::new();
-    let mut input_mapping = operator.input_mapping.clone();
-    let mut output_mapping = operator.output_mapping.clone();
-
-    for x_node in (0..expected_state_nodes).step_by(2) {
-        let node_idx = operator
-            .mpo
-            .node_index(&x_node)
-            .ok_or_else(|| format!("partial Fourier MPO is missing x node {x_node}"))?;
-        let tensor = operator
-            .mpo
-            .tensor(node_idx)
-            .ok_or_else(|| format!("partial Fourier MPO has no tensor at x node {x_node}"))?
-            .clone();
-        tensors_by_node.insert(x_node, tensor);
-    }
-
-    for t_node in (1..expected_state_nodes).step_by(2) {
-        let true_site = single_site_index_from_state(state, t_node)?;
-        let input_internal = true_site.sim();
-        let output_internal = true_site.sim();
-        let identity = TensorDynLen::delta(
-            std::slice::from_ref(&input_internal),
-            std::slice::from_ref(&output_internal),
-        )?;
-
-        input_mapping.insert(
-            t_node,
-            vec![IndexMapping {
-                true_index: true_site.clone(),
-                internal_index: input_internal,
-            }],
-        );
-        output_mapping.insert(
-            t_node,
-            vec![IndexMapping {
-                true_index: true_site,
-                internal_index: output_internal,
-            }],
-        );
-        tensors_by_node.insert(t_node, identity);
-    }
-
-    for x_site in 0..bits.saturating_sub(1) {
-        let start = 2 * x_site;
-        let mid = start + 1;
-        let end = start + 2;
-        let edge = operator
-            .mpo
-            .edge_between(&start, &end)
-            .ok_or_else(|| format!("partial Fourier MPO is missing edge {start}-{end}"))?;
-        let bond = operator
-            .mpo
-            .bond_index(edge)
-            .ok_or_else(|| format!("partial Fourier MPO edge {start}-{end} has no bond"))?;
-        let left_bridge = bond.sim();
-        let right_bridge = left_bridge.sim();
-
-        {
-            let tensor = tensors_by_node
-                .get_mut(&start)
-                .ok_or_else(|| format!("missing tensor at expanded node {start}"))?;
-            *tensor = tensor.replaceind(bond, &left_bridge)?;
-        }
-        {
-            let tensor = tensors_by_node
-                .get_mut(&end)
-                .ok_or_else(|| format!("missing tensor at expanded node {end}"))?;
-            *tensor = tensor.replaceind(bond, &right_bridge)?;
-        }
-        {
-            let bridge = TensorDynLen::delta(&[left_bridge], &[right_bridge])?;
-            let tensor = tensors_by_node
-                .get_mut(&mid)
-                .ok_or_else(|| format!("missing tensor at expanded node {mid}"))?;
-            *tensor = outer_product(tensor, &bridge)?;
-        }
-    }
-
-    if expected_state_nodes > 1 {
-        let last_x = expected_state_nodes - 2;
-        let last_t = expected_state_nodes - 1;
-        let (left_link, right_link) = <SiteIndex as IndexLike>::create_dummy_link_pair();
-        let left_ones = TensorDynLen::ones(std::slice::from_ref(&left_link))?;
-        let right_ones = TensorDynLen::ones(std::slice::from_ref(&right_link))?;
-        {
-            let tensor = tensors_by_node
-                .get_mut(&last_x)
-                .ok_or_else(|| format!("missing tensor at final x node {last_x}"))?;
-            *tensor = outer_product(tensor, &left_ones)?;
-        }
-        {
-            let tensor = tensors_by_node
-                .get_mut(&last_t)
-                .ok_or_else(|| format!("missing tensor at final t node {last_t}"))?;
-            *tensor = outer_product(tensor, &right_ones)?;
-        }
-    }
-
-    let node_names: Vec<usize> = (0..expected_state_nodes).collect();
-    let tensors = node_names
-        .iter()
-        .map(|node| {
-            tensors_by_node
-                .remove(node)
-                .ok_or_else(|| format!("missing expanded operator tensor at node {node}"))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    let mpo = TreeTN::from_tensors(tensors, node_names)?;
-
-    Ok(LinearOperator::new_multi(
-        mpo,
-        input_mapping,
-        output_mapping,
-    ))
-}
-
 pub fn transform_x_dimension(
     qtci: &QuanticsTensorCI2<f64>,
     operator: &LinearOperator<TensorDynLen, usize>,
 ) -> Result<PartialFourier2dTransformOutput, Box<dyn Error>> {
     let tt = qtci.tensor_train();
     let (state, _state_site_indices) = tensor_train_to_treetn(&tt)?;
-    let mut aligned_operator = expand_operator_to_interleaved_state(operator, &state)?;
+    let mut aligned_operator = operator.clone();
     aligned_operator.align_to_state(&state)?;
 
     let transformed = apply_linear_operator(&aligned_operator, &state, ApplyOptions::naive())?;
@@ -423,12 +252,7 @@ pub fn evaluate_tree_point(
     site_indices: &[SiteIndex],
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
-    let shape = [site_indices.len(), 1];
-    let values = ColMajorArrayRef::new(site_values, &shape)?;
-    let result = tn.evaluate_at(site_indices, values)?;
-    let value = result
-        .first()
-        .ok_or_else(|| "TreeTN evaluation returned no values".to_string())?;
+    let value = tn.evaluate_point(site_indices, site_values)?;
     Ok(Complex64::new(value.real(), value.imag()))
 }
 pub fn collect_samples(
@@ -489,25 +313,6 @@ pub fn collect_samples(
     }
 
     Ok(rows)
-}
-
-pub fn tree_link_dims(tn: &TreeTN<TensorDynLen, usize>) -> Vec<usize> {
-    let mut dims = Vec::new();
-    let mut seen_edges = HashSet::new();
-
-    for node_name in tn.node_names() {
-        if let Some(node_idx) = tn.node_index(&node_name) {
-            for (edge, _neighbor) in tn.edges_for_node(node_idx) {
-                if seen_edges.insert(edge) {
-                    if let Some(bond) = tn.bond_index(edge) {
-                        dims.push(bond.dim());
-                    }
-                }
-            }
-        }
-    }
-
-    dims
 }
 
 pub fn collect_bond_dims(

--- a/docs/tutorial-code/tests/verification.rs
+++ b/docs/tutorial-code/tests/verification.rs
@@ -1,39 +1,12 @@
 use std::error::Error;
-use std::f64::consts::PI;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tensor4all_core::{IndexLike, SvdTruncationPolicy};
-use tensor4all_quanticstci::{
-    quanticscrossinterpolate_discrete, DiscretizedGrid, InherentDiscreteGrid, QtciOptions,
-    UnfoldingScheme,
-};
-use tensor4all_simplett::{AbstractTensorTrain, TensorTrain};
-use tensor4all_treetn::{
-    contraction::{ContractionMethod, ContractionOptions},
-    partial_contract, tensor_train_to_treetn, PartialContractionSpec, TruncationOptions,
-};
-
-use tensor4all_treetn::Operator;
-
 use tensor4all_tutorial_code::{
-    interpolative_qtt_common, output_paths, qtt_affine_common, qtt_elementwise_product_utils,
-    qtt_fourier_common, qtt_function_utils, qtt_integral_sweep_utils, qtt_interval_common,
-    qtt_interval_utils, qtt_multivariate_common, qtt_partial_fourier2d_common, qtt_r_sweep_utils,
+    output_paths, qtt_affine_common, qtt_elementwise_product_utils, qtt_fourier_common,
+    qtt_function_utils, qtt_integral_sweep_utils, qtt_partial_fourier2d_common, qtt_r_sweep_utils,
 };
-
-const FUNCTION_BITS: usize = 7;
-const FUNCTION_NPOINTS: usize = 1 << FUNCTION_BITS;
-const FUNCTION_TOLERANCE: f64 = 1e-12;
-const FUNCTION_MAX_BOND_DIM: usize = 32;
-const SINE_FREQUENCY: f64 = 10.0;
-
-type QttDemoOutput = (
-    tensor4all_quanticstci::QuanticsTensorCI2<f64>,
-    Vec<usize>,
-    Vec<f64>,
-);
 
 fn scratch_dir(name: &str) -> PathBuf {
     let nonce = SystemTime::now()
@@ -56,66 +29,10 @@ fn read_lines(path: &Path) -> Vec<String> {
         .collect()
 }
 
-fn fourier_input_grid(
-    config: &qtt_fourier_common::FourierTutorialConfig,
-) -> Result<DiscretizedGrid, Box<dyn Error>> {
-    Ok(DiscretizedGrid::builder(&[config.bits])
-        .with_variable_names(&["x"])
-        .with_bounds(config.x_lower_bound, config.x_upper_bound)
-        .include_endpoint(config.include_endpoint)
-        .build()?)
-}
-
-fn fourier_frequency_grid(
-    config: &qtt_fourier_common::FourierTutorialConfig,
-) -> Result<DiscretizedGrid, Box<dyn Error>> {
-    let (k_lower_bound, k_upper_bound) = qtt_fourier_common::physical_frequency_bounds(config);
-
-    Ok(DiscretizedGrid::builder(&[config.bits])
-        .with_variable_names(&["k"])
-        .with_bounds(k_lower_bound, k_upper_bound)
-        .include_endpoint(config.include_endpoint)
-        .build()?)
-}
-
-fn function_target(x: f64) -> f64 {
-    x.cosh()
-}
-
-fn multivariate_target(x: f64, y: f64) -> f64 {
-    (20.0 * PI * x * y).cos() / 1000.0
-}
-
-fn factor_b_target(x: f64) -> f64 {
-    (SINE_FREQUENCY * x).sin()
-}
-
-fn build_function_qtt(target_fn: fn(f64) -> f64) -> Result<QttDemoOutput, Box<dyn Error>> {
-    let sizes = [FUNCTION_NPOINTS];
-    let options = QtciOptions::default()
-        .with_tolerance(FUNCTION_TOLERANCE)
-        .with_maxbonddim(FUNCTION_MAX_BOND_DIM)
-        .with_nrandominitpivot(0)
-        .with_unfoldingscheme(UnfoldingScheme::Interleaved)
-        .with_verbosity(0);
-
-    let callback = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] as f64 - 1.0) / FUNCTION_NPOINTS as f64;
-        target_fn(x)
-    };
-
-    let initial_pivots = vec![
-        vec![1],
-        vec![(FUNCTION_NPOINTS / 2) as i64],
-        vec![FUNCTION_NPOINTS as i64],
-    ];
-
-    Ok(quanticscrossinterpolate_discrete(
-        &sizes,
-        callback,
-        Some(initial_pivots),
-        options,
-    )?)
+fn assert_header(path: &Path, expected: &str) {
+    let lines = read_lines(path);
+    assert_eq!(lines.first().map(String::as_str), Some(expected));
+    assert_eq!(lines.len(), 2);
 }
 
 #[test]
@@ -130,1065 +47,66 @@ fn output_paths_support_default_and_override() {
 }
 
 #[test]
-fn qtt_function_demo_stays_accurate_and_exports_stable_csv() -> Result<(), Box<dyn Error>> {
-    let (qtci, ranks, errors) = build_function_qtt(function_target)?;
-    let tt = qtci.tensor_train();
-    let samples = qtt_function_utils::collect_samples(&qtci, FUNCTION_NPOINTS, function_target)?;
-
-    assert_eq!(samples.len(), FUNCTION_NPOINTS);
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-    assert!(qtci.rank() > 0);
-    assert!(tt.len() > 0);
-
-    let max_abs_error = samples
-        .iter()
-        .map(|sample| sample.abs_error)
-        .fold(0.0_f64, f64::max);
+fn quantics_index_helpers_keep_expected_order() {
+    assert_eq!(
+        qtt_fourier_common::global_index_to_quantics_sites(5, 3),
+        vec![1, 0, 0]
+    );
+    assert_eq!(
+        qtt_partial_fourier2d_common::x_site_node_mapping(3),
+        vec![(0, 0), (1, 2), (2, 4)]
+    );
+    assert_eq!(
+        qtt_partial_fourier2d_common::interleaved_site_values(2, 1, 2),
+        vec![1, 0, 0, 1]
+    );
+    assert!((qtt_function_utils::discrete_index_to_unit_interval(4, 8) - 0.375).abs() < 1e-12);
     assert!(
-        max_abs_error < 1e-9,
-        "unexpectedly large function-demo error: {max_abs_error}"
-    );
-
-    let first = samples.first().expect("at least one sample");
-    assert!((first.x - 0.0).abs() < f64::EPSILON);
-    assert!((first.exact - 1.0).abs() < 1e-12);
-    assert!((first.qtt - first.exact).abs() < 1e-9);
-
-    let middle = &samples[FUNCTION_NPOINTS / 2];
-    assert!(middle.x > 0.0);
-    assert!(middle.exact.is_finite());
-    assert!((middle.exact - middle.qtt).abs() < 1e-9);
-
-    let scratch = scratch_dir("qtt-function");
-    let samples_path = scratch.join("samples.csv");
-    let bond_dims_path = scratch.join("bond_dims.csv");
-    qtt_function_utils::write_samples_csv(&samples_path, &samples)?;
-    qtt_function_utils::write_bond_dims_csv(&bond_dims_path, &qtci.link_dims())?;
-
-    let sample_lines = read_lines(&samples_path);
-    assert_eq!(
-        sample_lines.first().map(String::as_str),
-        Some("index,x,exact,qtt,abs_error")
-    );
-    assert_eq!(sample_lines.len(), samples.len() + 1);
-    assert!(sample_lines
-        .get(1)
-        .expect("first sample row")
-        .starts_with("1,0.0000000000000000,1.0000000000000000,"));
-
-    let bond_lines = read_lines(&bond_dims_path);
-    assert_eq!(
-        bond_lines.first().map(String::as_str),
-        Some("bond_index,bond_dim")
-    );
-    assert_eq!(bond_lines.len(), qtci.link_dims().len() + 1);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_interval_demo_tracks_the_interval_and_exports_stable_csv() -> Result<(), Box<dyn Error>> {
-    let config = qtt_interval_common::DEFAULT_INTERVAL_CONFIG;
-    let grid = qtt_interval_common::build_interval_grid(&config)?;
-    let (qtci, ranks, errors) = qtt_interval_common::build_interval_qtt(
-        &grid,
-        qtt_interval_common::interval_target,
-        &config,
-    )?;
-    let tt = qtci.tensor_train();
-    let samples =
-        qtt_interval_utils::collect_samples(&qtci, &grid, qtt_interval_common::interval_target)?;
-
-    let coords = grid.grid_origcoords(0)?;
-    assert_eq!(samples.len(), coords.len());
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-    assert!(qtci.rank() > 0);
-    assert!(tt.len() > 0);
-
-    let first_coord = coords
-        .first()
-        .copied()
-        .expect("interval grid starts with a coordinate");
-    let last_coord = coords
-        .last()
-        .copied()
-        .expect("interval grid ends with a coordinate");
-    assert!((first_coord - config.lower_bound).abs() < 1e-12);
-    assert!((last_coord - config.upper_bound).abs() < 1e-12);
-
-    let max_abs_error = samples
-        .iter()
-        .map(|sample| sample.abs_error)
-        .fold(0.0_f64, f64::max);
-    assert!(
-        max_abs_error < 1e-9,
-        "unexpectedly large interval-demo error: {max_abs_error}"
-    );
-
-    let first = samples.first().expect("at least one sample");
-    assert!((first.x - config.lower_bound).abs() < 1e-12);
-    assert!((first.exact - qtt_interval_common::interval_target(first.x)).abs() < 1e-12);
-    assert!((first.qtt - first.exact).abs() < 1e-9);
-
-    let last = samples.last().expect("at least one sample");
-    assert!((last.x - config.upper_bound).abs() < 1e-12);
-    assert!((last.exact - qtt_interval_common::interval_target(last.x)).abs() < 1e-12);
-    assert!((last.qtt - last.exact).abs() < 1e-9);
-
-    let scratch = scratch_dir("qtt-interval");
-    let samples_path = scratch.join("samples.csv");
-    let bond_dims_path = scratch.join("bond_dims.csv");
-    qtt_interval_utils::write_samples_csv(&samples_path, &samples)?;
-    qtt_interval_utils::write_bond_dims_csv(&bond_dims_path, &qtci.link_dims())?;
-
-    let sample_lines = read_lines(&samples_path);
-    assert_eq!(
-        sample_lines.first().map(String::as_str),
-        Some("index,x,exact,qtt,abs_error")
-    );
-    assert_eq!(sample_lines.len(), samples.len() + 1);
-    assert!(sample_lines
-        .get(1)
-        .expect("first interval sample row")
-        .starts_with("1,-1.0000000000000000,1.0000000000000000,"));
-
-    let bond_lines = read_lines(&bond_dims_path);
-    assert_eq!(
-        bond_lines.first().map(String::as_str),
-        Some("bond_index,bond_dim")
-    );
-    assert_eq!(bond_lines.len(), qtci.link_dims().len() + 1);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_interval_integral_matches_the_analytic_answer() -> Result<(), Box<dyn Error>> {
-    let config = qtt_interval_common::DEFAULT_INTERVAL_CONFIG;
-    let grid = qtt_interval_common::build_interval_grid(&config)?;
-    let (qtci, ranks, errors) = qtt_interval_common::build_interval_qtt(
-        &grid,
-        qtt_interval_common::interval_target,
-        &config,
-    )?;
-
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-
-    let integral = qtci.integral()?;
-    let expected = qtt_interval_common::exact_integral(&config);
-    let abs_error = (integral - expected).abs();
-
-    assert!(
-        abs_error < 8e-2,
-        "integral = {integral}, expected = {expected}, abs_error = {abs_error}"
-    );
-
-    Ok(())
-}
-
-#[test]
-fn qtt_interval_exact_integral_uses_the_configured_bounds() {
-    let config = qtt_interval_common::IntervalTutorialConfig {
-        bits: 7,
-        lower_bound: 0.0,
-        upper_bound: 3.0,
-        include_endpoint: true,
-    };
-
-    assert!((qtt_interval_common::exact_integral(&config) - 9.0).abs() < 1e-12);
-}
-
-#[test]
-fn qtt_fourier_gaussian_input_builds_stable_qtt() -> Result<(), Box<dyn Error>> {
-    let config = qtt_fourier_common::DEFAULT_FOURIER_CONFIG;
-    let input_grid = fourier_input_grid(&config)?;
-    let frequency_grid = fourier_frequency_grid(&config)?;
-    let (qtci, ranks, errors) = qtt_fourier_common::build_gaussian_qtt(&input_grid, &config)?;
-
-    let input_coords = input_grid.grid_origcoords(0)?;
-    let frequency_coords = frequency_grid.grid_origcoords(0)?;
-
-    assert_eq!(input_coords.len(), 1usize << config.bits);
-    assert_eq!(frequency_coords.len(), 1usize << config.bits);
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-
-    let first_x = input_coords
-        .first()
-        .copied()
-        .expect("input grid has points");
-    let first_value = qtci.evaluate(&[1])?;
-    let exact_first = qtt_fourier_common::gaussian_target(first_x);
-    assert!((first_value - exact_first).abs() < 1e-9);
-
-    let reference = qtt_fourier_common::gaussian_fourier_reference(0.0);
-    assert!((reference.re - (2.0 * std::f64::consts::PI).sqrt()).abs() < 1e-12);
-    assert!(reference.im.abs() < 1e-12);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_fourier_operator_matches_gaussian_transform() -> Result<(), Box<dyn Error>> {
-    let config = qtt_fourier_common::DEFAULT_FOURIER_CONFIG;
-    let input_grid = fourier_input_grid(&config)?;
-    let frequency_grid = fourier_frequency_grid(&config)?;
-    let (qtci, ranks, errors) = qtt_fourier_common::build_gaussian_qtt(&input_grid, &config)?;
-    let operator = qtt_fourier_common::build_fourier_operator(&config)?;
-    let (transformed, site_indices) =
-        qtt_fourier_common::transform_gaussian(&qtci, &operator, &config)?;
-    let samples = qtt_fourier_common::collect_samples(
-        &transformed,
-        &site_indices,
-        &input_grid,
-        &frequency_grid,
-        &config,
-    )?;
-    let input_bond_dims = qtci.link_dims();
-    let transformed_bond_dims = qtt_fourier_common::tree_link_dims(&transformed);
-    let bond_dims = qtt_fourier_common::collect_bond_dims_from_profiles(
-        &input_bond_dims,
-        &transformed_bond_dims,
-    );
-
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-    assert_eq!(samples.len(), 1usize << config.bits);
-    assert_eq!(bond_dims.len(), input_bond_dims.len());
-
-    let max_abs_error = samples
-        .iter()
-        .map(|sample| sample.abs_error)
-        .fold(0.0_f64, f64::max);
-    assert!(
-        max_abs_error < 1e-9,
-        "unexpectedly large Fourier error: {max_abs_error}"
-    );
-
-    let center = samples
-        .iter()
-        .find(|sample| sample.k.abs() < 1e-12)
-        .expect("frequency grid should include zero");
-    assert!((center.qtt_re - center.analytic_re).abs() < 1e-9);
-    assert!(center.qtt_im.abs() < 1e-9);
-
-    let scratch = scratch_dir("qtt-fourier");
-    let samples_path = scratch.join("samples.csv");
-    let bond_dims_path = scratch.join("bond_dims.csv");
-    qtt_fourier_common::write_samples_csv(&samples_path, &samples)?;
-    qtt_fourier_common::write_bond_dims_csv(&bond_dims_path, &bond_dims)?;
-
-    let sample_lines = read_lines(&samples_path);
-    assert_eq!(
-        sample_lines.first().map(String::as_str),
-        Some("index,x,k,analytic_re,analytic_im,qtt_re,qtt_im,abs_error")
-    );
-    assert_eq!(sample_lines.len(), samples.len() + 1);
-
-    let bond_lines = read_lines(&bond_dims_path);
-    assert_eq!(
-        bond_lines.first().map(String::as_str),
-        Some("bond_index,input_bond_dim,transformed_bond_dim")
-    );
-    assert_eq!(bond_lines.len(), bond_dims.len() + 1);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_fourier_transform_uses_aligned_state_indices() -> Result<(), Box<dyn Error>> {
-    let config = qtt_fourier_common::DEFAULT_FOURIER_CONFIG;
-    let input_grid = fourier_input_grid(&config)?;
-    let (qtci, _, _) = qtt_fourier_common::build_gaussian_qtt(&input_grid, &config)?;
-    let operator = qtt_fourier_common::build_fourier_operator(&config)?;
-
-    let (_transformed, output_site_indices) =
-        qtt_fourier_common::transform_gaussian(&qtci, &operator, &config)?;
-
-    assert_eq!(output_site_indices.len(), config.bits);
-    for (site, output_index) in output_site_indices.iter().enumerate() {
-        let operator_output_index = &operator
-            .get_output_mapping(&site)
-            .expect("Fourier output mapping should exist")
-            .true_index;
-        assert!(
-            !output_index.same_id(operator_output_index),
-            "transform_gaussian should not expose the operator's original output index IDs"
-        );
-    }
-
-    Ok(())
-}
-
-#[test]
-fn qtt_fourier_operator_bond_profile_is_exportable() -> Result<(), Box<dyn Error>> {
-    let config = qtt_fourier_common::DEFAULT_FOURIER_CONFIG;
-    let operator = qtt_fourier_common::build_fourier_operator(&config)?;
-    let bond_dims = qtt_fourier_common::tree_link_dims(&operator.mpo);
-
-    assert_eq!(bond_dims.len(), config.bits.saturating_sub(1));
-    assert!(bond_dims.iter().all(|&bond_dim| bond_dim >= 1));
-
-    let scratch = scratch_dir("qtt-fourier-operator-bonds");
-    let path = scratch.join("operator_bond_dims.csv");
-    qtt_fourier_common::write_fourier_operator_bond_dims_csv(&path, &bond_dims)?;
-
-    let lines = read_lines(&path);
-    assert_eq!(
-        lines.first().map(String::as_str),
-        Some("bond_index,bond_dim")
-    );
-    assert_eq!(lines.len(), bond_dims.len() + 1);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_integral_sweep_utils_export_stable_csv_rows() -> Result<(), Box<dyn Error>> {
-    use qtt_integral_sweep_utils::{write_sweep_csv, IntegralSweepRow};
-
-    let scratch = scratch_dir("qtt-integral-sweep");
-    let csv_path = scratch.join("integral_sweep.csv");
-    write_sweep_csv(
-        &csv_path,
-        &[IntegralSweepRow {
-            r: 7,
-            npoints: 128,
-            integral: 3.125,
-            exact_integral: 3.0,
-            abs_error: 0.125,
-            rank: 3,
-        }],
-    )?;
-
-    let lines = read_lines(&csv_path);
-    assert_eq!(
-        lines.first().map(String::as_str),
-        Some("r,npoints,integral,exact_integral,abs_error,rank")
-    );
-    assert_eq!(lines.len(), 2);
-    assert_eq!(
-        lines.get(1).map(String::as_str),
-        Some("7,128,3.1250000000000000,3.0000000000000000,0.1250000000000000,3")
-    );
-
-    Ok(())
-}
-
-#[test]
-fn qtt_r_sweep_helpers_cover_index_conversion_and_error_stats() -> Result<(), Box<dyn Error>> {
-    use qtt_r_sweep_utils::{max_abs_error, mean_abs_error, write_samples_csv, write_stats_csv};
-    use qtt_r_sweep_utils::{SweepSample, SweepStats};
-
-    let samples = vec![
-        SweepSample {
-            r: 3,
-            npoints: 8,
-            index: 1,
-            x: 0.0,
-            exact: 0.0,
-            qtt: 0.1,
-            abs_error: 0.1,
-        },
-        SweepSample {
-            r: 3,
-            npoints: 8,
-            index: 8,
-            x: 0.875,
-            exact: 0.5,
-            qtt: 0.25,
-            abs_error: 0.25,
-        },
-    ];
-
-    assert!((qtt_r_sweep_utils::discrete_index_to_unit_interval(1, 8) - 0.0).abs() < 1e-12);
-    assert!((qtt_r_sweep_utils::discrete_index_to_unit_interval(8, 8) - 0.875).abs() < 1e-12);
-    assert!((mean_abs_error(&samples) - 0.175).abs() < 1e-12);
-    assert!((max_abs_error(&samples) - 0.25).abs() < 1e-12);
-
-    let scratch = scratch_dir("qtt-r-sweep");
-    let samples_path = scratch.join("samples.csv");
-    let stats_path = scratch.join("stats.csv");
-    write_samples_csv(&samples_path, &samples)?;
-    write_stats_csv(
-        &stats_path,
-        &[SweepStats {
-            r: 3,
-            npoints: 8,
-            build_time_sec: 0.123,
-            mean_abs_error: 0.175,
-            max_abs_error: 0.25,
-            rank: 4,
-        }],
-    )?;
-
-    let sample_lines = read_lines(&samples_path);
-    assert_eq!(
-        sample_lines.first().map(String::as_str),
-        Some("r,npoints,index,x,exact,qtt,abs_error")
-    );
-    assert_eq!(sample_lines.len(), samples.len() + 1);
-    assert_eq!(
-        sample_lines.get(1).map(String::as_str),
-        Some("3,8,1,0.0000000000000000,0.0000000000000000,0.1000000000000000,0.1000000000000000")
-    );
-
-    let stats_lines = read_lines(&stats_path);
-    assert_eq!(
-        stats_lines.first().map(String::as_str),
-        Some("r,npoints,build_time_sec,mean_abs_error,max_abs_error,rank")
-    );
-    assert_eq!(stats_lines.len(), 2);
-    assert_eq!(
-        stats_lines.get(1).map(String::as_str),
-        Some("3,8,0.1230000000000000,0.1750000000000000,0.2500000000000000,4")
-    );
-
-    Ok(())
-}
-
-#[test]
-fn qtt_elementwise_product_helpers_shape_bond_profiles_and_csv_output() -> Result<(), Box<dyn Error>>
-{
-    use qtt_elementwise_product_utils::{
-        collect_bond_profile, discrete_index_to_unit_interval, global_index_to_quantics_sites,
-        write_bond_dims_csv, write_samples_csv, SamplePoint,
-    };
-
-    assert!((discrete_index_to_unit_interval(1, 8) - 0.0).abs() < 1e-12);
-    assert!((discrete_index_to_unit_interval(8, 8) - 0.875).abs() < 1e-12);
-    assert_eq!(global_index_to_quantics_sites(1, 4), vec![0, 0, 0, 0]);
-    assert_eq!(global_index_to_quantics_sites(6, 4), vec![0, 1, 0, 1]);
-    assert_eq!(global_index_to_quantics_sites(16, 4), vec![1, 1, 1, 1]);
-
-    let tt = TensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
-    let (treetn, _site_indices) = tensor_train_to_treetn(&tt)?;
-    let rows = collect_bond_profile(&tt, &tt, &treetn, &treetn)?;
-
-    assert!(!rows.is_empty());
-    assert_eq!(rows[0].bond_index, 1);
-    assert!(rows.iter().all(|row| row.cosh >= 1));
-    assert!(rows.iter().all(|row| row.factor_b >= 1));
-    assert!(rows.iter().all(|row| row.product_raw >= 1));
-    assert!(rows.iter().all(|row| row.product_compressed >= 1));
-
-    let scratch = scratch_dir("qtt-elementwise-product");
-    let samples_path = scratch.join("samples.csv");
-    let bond_dims_path = scratch.join("bond_dims.csv");
-
-    write_samples_csv(
-        &samples_path,
-        &[SamplePoint {
-            index: 1,
-            x: 0.0,
-            cosh_exact: 1.0,
-            cosh_qtt: 1.0,
-            factor_b_exact: 0.0,
-            factor_b_qtt: 0.0,
-            product_exact: 0.0,
-            product_raw: 0.0,
-            product_compressed: 0.0,
-            abs_error_raw: 0.0,
-            abs_error_compressed: 0.0,
-        }],
-    )?;
-    write_bond_dims_csv(&bond_dims_path, &rows)?;
-
-    let sample_lines = read_lines(&samples_path);
-    assert_eq!(
-        sample_lines.first().map(String::as_str),
-        Some("index,x,cosh_exact,cosh_qtt,factor_b_exact,factor_b_qtt,product_exact,product_raw,product_compressed,abs_error_raw,abs_error_compressed")
-    );
-    assert_eq!(sample_lines.len(), 2);
-
-    let bond_lines = read_lines(&bond_dims_path);
-    assert_eq!(
-        bond_lines.first().map(String::as_str),
-        Some("bond_index,cosh,factor_b,product_raw,product_compressed")
-    );
-    assert_eq!(bond_lines.len(), rows.len() + 1);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_partial_fourier2d_reference_is_gaussian_in_k_and_periodic_in_t() {
-    let config = qtt_partial_fourier2d_common::DEFAULT_PARTIAL_FOURIER2D_CONFIG;
-
-    assert!((qtt_partial_fourier2d_common::source_function(0.0, 0.0, &config) - 1.0).abs() < 1e-12);
-    assert!(
-        (qtt_partial_fourier2d_common::source_function(0.0, 0.5, &config)
-            - (-1.0f64).powi(config.t_frequency as i32))
-        .abs()
+        (qtt_elementwise_product_utils::discrete_index_to_unit_interval(4, 8) - 0.375).abs()
             < 1e-12
     );
-
-    let reference = qtt_partial_fourier2d_common::partial_fourier_reference(0.0, 0.0, &config);
-    assert!((reference.re - (2.0 * std::f64::consts::PI).sqrt()).abs() < 1e-12);
-    assert!(reference.im.abs() < 1e-12);
-
-    let left = qtt_partial_fourier2d_common::partial_fourier_reference(-0.25, 0.25, &config);
-    let right = qtt_partial_fourier2d_common::partial_fourier_reference(0.25, 0.25, &config);
-    assert!((left.re - right.re).abs() < 1e-12);
-    assert!(left.im.abs() < 1e-12);
-    assert!(right.im.abs() < 1e-12);
 }
 
 #[test]
-fn qtt_partial_fourier2d_interleaved_x_nodes_are_even_positions() {
-    assert_eq!(
-        qtt_partial_fourier2d_common::x_site_node_mapping(4),
-        vec![(0, 0), (1, 2), (2, 4), (3, 6)]
-    );
-    assert_eq!(
-        qtt_partial_fourier2d_common::interleaved_site_values(0b101, 0b011, 3),
-        vec![1, 0, 0, 1, 1, 1]
-    );
-}
+fn csv_writers_keep_stable_headers() -> Result<(), Box<dyn Error>> {
+    let scratch = scratch_dir("csv-contracts");
 
-#[test]
-fn qtt_elementwise_product_demo_tracks_the_pointwise_product() -> Result<(), Box<dyn Error>> {
-    let (cosh_qtci, cosh_ranks, cosh_errors) = build_function_qtt(function_target)?;
-    let (factor_b_qtci, factor_b_ranks, factor_b_errors) = build_function_qtt(factor_b_target)?;
-
-    let cosh_tt = cosh_qtci.tensor_train();
-    let factor_b_tt = factor_b_qtci.tensor_train();
-    let (cosh_treetn, cosh_site_indices) = tensor_train_to_treetn(&cosh_tt)?;
-    let (factor_b_treetn, factor_b_site_indices) = tensor_train_to_treetn(&factor_b_tt)?;
-
-    let diagonal_pairs = cosh_site_indices
-        .iter()
-        .cloned()
-        .zip(factor_b_site_indices.iter().cloned())
-        .collect();
-    let spec = PartialContractionSpec {
-        contract_pairs: vec![],
-        diagonal_pairs,
-        output_order: Some(cosh_site_indices.clone()),
-    };
-
-    let mut center_nodes = cosh_treetn.node_names();
-    center_nodes.sort();
-    let center = center_nodes[center_nodes.len() / 2];
-
-    let raw_product_options = ContractionOptions::new(ContractionMethod::Naive)
-        .with_dense_reference_limit(FUNCTION_NPOINTS * FUNCTION_NPOINTS);
-    let product_raw_tn = partial_contract(
-        &cosh_treetn,
-        &factor_b_treetn,
-        &spec,
-        &center,
-        raw_product_options,
+    let function_samples = scratch.join("function_samples.csv");
+    qtt_function_utils::write_samples_csv(
+        &function_samples,
+        &[qtt_function_utils::SamplePoint {
+            index: 1,
+            x: 0.0,
+            exact: 1.0,
+            qtt: 1.0,
+            abs_error: 0.0,
+        }],
     )?;
+    assert_header(&function_samples, "index,x,exact,qtt,abs_error");
 
-    let compression_options = TruncationOptions::default()
-        .with_svd_policy(SvdTruncationPolicy::new(1e-12))
-        .with_max_rank(64);
-    let product_compressed_tn = product_raw_tn
-        .clone()
-        .truncate([center], compression_options)?;
-
-    let samples = qtt_elementwise_product_utils::collect_samples(
-        &cosh_qtci,
-        &factor_b_qtci,
-        &product_raw_tn,
-        &product_compressed_tn,
-        &cosh_site_indices,
-        FUNCTION_BITS,
-        FUNCTION_NPOINTS,
-        function_target,
-        factor_b_target,
+    let fourier_samples = scratch.join("fourier_samples.csv");
+    qtt_fourier_common::write_samples_csv(
+        &fourier_samples,
+        &[qtt_fourier_common::SamplePoint {
+            index: 1,
+            x: 0.0,
+            k: 0.0,
+            analytic_re: 1.0,
+            analytic_im: 0.0,
+            qtt_re: 1.0,
+            qtt_im: 0.0,
+            abs_error: 0.0,
+        }],
     )?;
-
-    let max_raw_error = samples
-        .iter()
-        .map(|sample| sample.abs_error_raw)
-        .fold(0.0_f64, f64::max);
-    let max_compressed_error = samples
-        .iter()
-        .map(|sample| sample.abs_error_compressed)
-        .fold(0.0_f64, f64::max);
-    let max_raw_vs_factor_error = samples
-        .iter()
-        .map(|sample| (sample.cosh_qtt * sample.factor_b_qtt - sample.product_raw).abs())
-        .fold(0.0_f64, f64::max);
-
-    assert!(!cosh_ranks.is_empty());
-    assert!(!factor_b_ranks.is_empty());
-    assert!(!cosh_errors.is_empty());
-    assert!(!factor_b_errors.is_empty());
-    assert!(
-        max_raw_vs_factor_error < 1e-12,
-        "raw TreeTN product differs from QTT factor product: {max_raw_vs_factor_error}"
-    );
-    assert!(
-        max_raw_error < 1e-14,
-        "raw TreeTN product error was too large: {max_raw_error}"
-    );
-    assert!(
-        max_compressed_error < 2e-14,
-        "compressed TreeTN product error was too large: {max_compressed_error}"
+    assert_header(
+        &fourier_samples,
+        "index,x,k,analytic_re,analytic_im,qtt_re,qtt_im,abs_error",
     );
 
-    Ok(())
-}
-
-#[test]
-fn qtt_multivariate_demo_compares_layouts_and_exports_stable_csv() -> Result<(), Box<dyn Error>> {
-    let config = qtt_multivariate_common::MultivariateTutorialConfig {
-        bits: 3,
-        maxbonddim: 16,
-        maxiter: 12,
-        ..qtt_multivariate_common::DEFAULT_MULTIVARIATE_CONFIG
-    };
-    let interleaved_grid =
-        qtt_multivariate_common::build_multivariate_grid(&config, UnfoldingScheme::Interleaved)?;
-    let grouped_grid =
-        qtt_multivariate_common::build_multivariate_grid(&config, UnfoldingScheme::Grouped)?;
-    let (interleaved, interleaved_ranks, interleaved_errors) =
-        qtt_multivariate_common::build_multivariate_qtt(
-            &interleaved_grid,
-            multivariate_target,
-            &config,
-        )?;
-    let (grouped, grouped_ranks, grouped_errors) = qtt_multivariate_common::build_multivariate_qtt(
-        &grouped_grid,
-        multivariate_target,
-        &config,
-    )?;
-
-    let samples =
-        qtt_multivariate_common::collect_samples(&interleaved, &grouped, multivariate_target)?;
-    let bond_dims =
-        qtt_multivariate_common::collect_bond_dims(&interleaved.link_dims(), &grouped.link_dims());
-
-    assert_eq!(samples.len(), 64);
-    assert!(!interleaved_ranks.is_empty());
-    assert!(!grouped_ranks.is_empty());
-    assert!(!interleaved_errors.is_empty());
-    assert!(!grouped_errors.is_empty());
-    assert!(interleaved.rank() > 0);
-    assert!(grouped.rank() > 0);
-    assert!(!bond_dims.is_empty());
-
-    let max_interleaved_error = samples
-        .iter()
-        .map(|sample| sample.interleaved_abs_error)
-        .fold(0.0_f64, f64::max);
-    let max_grouped_error = samples
-        .iter()
-        .map(|sample| sample.grouped_abs_error)
-        .fold(0.0_f64, f64::max);
-
-    assert!(
-        max_interleaved_error < 1e-3,
-        "unexpectedly large interleaved error: {max_interleaved_error}"
-    );
-    assert!(
-        max_grouped_error < 1e-3,
-        "unexpectedly large grouped error: {max_grouped_error}"
-    );
-
-    let scratch = scratch_dir("qtt-multivariate");
-    let samples_path = scratch.join("samples.csv");
-    let bond_dims_path = scratch.join("bond_dims.csv");
-    qtt_multivariate_common::write_samples_csv(&samples_path, &samples)?;
-    qtt_multivariate_common::write_bond_dims_csv(&bond_dims_path, &bond_dims)?;
-
-    let sample_lines = read_lines(&samples_path);
-    assert_eq!(
-        sample_lines.first().map(String::as_str),
-        Some("x_index,y_index,x,y,exact,interleaved_qtt,grouped_qtt,interleaved_abs_error,grouped_abs_error")
-    );
-    assert_eq!(sample_lines.len(), samples.len() + 1);
-
-    let bond_lines = read_lines(&bond_dims_path);
-    assert_eq!(
-        bond_lines.first().map(String::as_str),
-        Some("bond_index,interleaved_bond_dim,grouped_bond_dim")
-    );
-    assert_eq!(bond_lines.len(), bond_dims.len() + 1);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_affine_fused_grid_uses_library_site_mapping() -> Result<(), Box<dyn Error>> {
-    let grid = InherentDiscreteGrid::builder(&[3, 3])
-        .with_variable_names(&["x", "y"])
-        .with_unfolding_scheme(UnfoldingScheme::Fused)
-        .build()?;
-
-    assert_eq!(grid.local_dimensions(), vec![4, 4, 4]);
-    assert_eq!(
-        grid.grididx_to_quantics(&[0b101 + 1, 0b011 + 1])?
-            .into_iter()
-            .map(|site| (site - 1) as usize)
-            .collect::<Vec<_>>(),
-        vec![1, 2, 3]
-    );
-
-    Ok(())
-}
-
-#[test]
-fn qtt_affine_references_distinguish_periodic_and_open_boundaries() {
-    let bits = 3;
-    let n = 1usize << bits;
-
-    let periodic = qtt_affine_common::transformed_reference(
-        n - 1,
-        2,
-        bits,
-        qtt_affine_common::AffineBoundaryMode::Periodic,
-    );
-    let wrapped = qtt_affine_common::source_function(1, 2, n);
-    assert!((periodic - wrapped).abs() < 1e-12);
-
-    let open = qtt_affine_common::transformed_reference(
-        n - 1,
-        2,
-        bits,
-        qtt_affine_common::AffineBoundaryMode::Open,
-    );
-    assert_eq!(open, 0.0);
-
-    let inside_open = qtt_affine_common::transformed_reference(
-        1,
-        2,
-        bits,
-        qtt_affine_common::AffineBoundaryMode::Open,
-    );
-    let inside_expected = qtt_affine_common::source_function(3, 2, n);
-    assert!((inside_open - inside_expected).abs() < 1e-12);
-}
-
-#[test]
-fn qtt_affine_source_qtt_matches_source_function() -> Result<(), Box<dyn Error>> {
-    let config = qtt_affine_common::AffineTutorialConfig {
-        bits: 4,
-        tolerance: 1e-12,
-        maxbonddim: 32,
-        maxiter: 20,
-    };
-    let (qtci, ranks, errors) = qtt_affine_common::build_source_qtt(&config)?;
-
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-    assert!(qtci.rank() > 0);
-
-    let evaluation_grid = qtci
-        .inherent_grid()
-        .expect("source QTT uses an inherent discrete grid");
-    let n = qtt_affine_common::point_count(config.bits);
-    let grid_fused_sites: Vec<usize> = evaluation_grid
-        .grididx_to_quantics(&[0b0101 + 1, 0b0011 + 1])?
-        .into_iter()
-        .map(|site| (site - 1) as usize)
-        .collect();
-    assert_eq!(grid_fused_sites, vec![0, 1, 2, 3]);
-
-    let mut max_abs_error = 0.0_f64;
-    for x in 0..n {
-        for y in 0..n {
-            let sites: Vec<usize> = evaluation_grid
-                .grididx_to_quantics(&[(x + 1) as i64, (y + 1) as i64])?
-                .into_iter()
-                .map(|site| (site - 1) as usize)
-                .collect();
-            let qtt_direct = qtci.evaluate(&[(x + 1) as i64, (y + 1) as i64])?;
-            let qtt_fused = qtci.tensor_train().evaluate(&sites)?;
-            let exact = qtt_affine_common::source_function(x, y, n);
-            max_abs_error = max_abs_error.max((qtt_direct - exact).abs());
-            max_abs_error = max_abs_error.max((qtt_fused - exact).abs());
-        }
-    }
-
-    assert!(
-        max_abs_error < 1e-9,
-        "unexpectedly large affine source error: {max_abs_error}"
-    );
-
-    Ok(())
-}
-
-#[test]
-fn qtt_affine_pullback_matches_periodic_and_open_ground_truth() -> Result<(), Box<dyn Error>> {
-    let config = qtt_affine_common::AffineTutorialConfig {
-        bits: 4,
-        tolerance: 1e-12,
-        maxbonddim: 32,
-        maxiter: 20,
-    };
-
-    let (source, _, _) = qtt_affine_common::build_source_qtt(&config)?;
-    let periodic_operator = qtt_affine_common::build_affine_operator(
-        &config,
-        qtt_affine_common::AffineBoundaryMode::Periodic,
-    )?;
-    let open_operator = qtt_affine_common::build_affine_operator(
-        &config,
-        qtt_affine_common::AffineBoundaryMode::Open,
-    )?;
-    let evaluation_grid = source
-        .inherent_grid()
-        .expect("source QTT uses an inherent discrete grid");
-
-    let (periodic, periodic_sites) =
-        qtt_affine_common::apply_affine_operator(&source, &periodic_operator)?;
-    let (open, open_sites) = qtt_affine_common::apply_affine_operator(&source, &open_operator)?;
-
-    let samples = qtt_affine_common::collect_samples(
-        &periodic,
-        &periodic_sites,
-        &open,
-        &open_sites,
-        evaluation_grid,
-        &config,
-    )?;
-
-    let max_periodic_error = samples
-        .iter()
-        .map(|sample| sample.periodic_abs_error)
-        .fold(0.0_f64, f64::max);
-    let max_open_error = samples
-        .iter()
-        .map(|sample| sample.open_abs_error)
-        .fold(0.0_f64, f64::max);
-
-    assert!(
-        max_periodic_error < 1e-8,
-        "unexpectedly large periodic affine error: {max_periodic_error}"
-    );
-    assert!(
-        max_open_error < 1e-8,
-        "unexpectedly large open affine error: {max_open_error}"
-    );
-
-    let boundary_sample = samples
-        .iter()
-        .find(|sample| sample.x + sample.y >= qtt_affine_common::point_count(config.bits))
-        .expect("open-boundary region exists");
-    assert_eq!(boundary_sample.open_exact, 0.0);
-    assert!(boundary_sample.open_qtt.abs() < 1e-8);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_affine_exports_stable_csv_headers() -> Result<(), Box<dyn Error>> {
-    let config = qtt_affine_common::AffineTutorialConfig {
-        bits: 3,
-        tolerance: 1e-12,
-        maxbonddim: 32,
-        maxiter: 20,
-    };
-
-    let (source, _, _) = qtt_affine_common::build_source_qtt(&config)?;
-    let periodic_operator = qtt_affine_common::build_affine_operator(
-        &config,
-        qtt_affine_common::AffineBoundaryMode::Periodic,
-    )?;
-    let open_operator = qtt_affine_common::build_affine_operator(
-        &config,
-        qtt_affine_common::AffineBoundaryMode::Open,
-    )?;
-    let evaluation_grid = source
-        .inherent_grid()
-        .expect("source QTT uses an inherent discrete grid");
-    let (periodic, periodic_sites) =
-        qtt_affine_common::apply_affine_operator(&source, &periodic_operator)?;
-    let (open, open_sites) = qtt_affine_common::apply_affine_operator(&source, &open_operator)?;
-
-    let samples = qtt_affine_common::collect_samples(
-        &periodic,
-        &periodic_sites,
-        &open,
-        &open_sites,
-        evaluation_grid,
-        &config,
-    )?;
-    let source_tt = source.tensor_train();
-    let (source_treetn, _) = tensor_train_to_treetn(&source_tt)?;
-    let bond_dims = qtt_affine_common::collect_bond_dims(
-        &qtt_affine_common::tree_link_dims(&source_treetn),
-        &qtt_affine_common::tree_link_dims(&periodic),
-        &qtt_affine_common::tree_link_dims(&open),
-    );
-    let operator_bond_dims = qtt_affine_common::collect_operator_bond_dims(
-        &qtt_affine_common::tree_link_dims(&periodic_operator.mpo),
-        &qtt_affine_common::tree_link_dims(&open_operator.mpo),
-    );
-
-    let scratch = scratch_dir("qtt-affine");
-    let samples_path = scratch.join("samples.csv");
-    let bonds_path = scratch.join("bond_dims.csv");
-    let operator_bonds_path = scratch.join("operator_bond_dims.csv");
-
-    qtt_affine_common::write_samples_csv(&samples_path, &samples)?;
-    qtt_affine_common::write_bond_dims_csv(&bonds_path, &bond_dims)?;
-    qtt_affine_common::write_operator_bond_dims_csv(&operator_bonds_path, &operator_bond_dims)?;
-
-    assert_eq!(
-        read_lines(&samples_path).first().map(String::as_str),
-        Some("x_index,y_index,x,y,source_u_periodic,source_v,source_exact,periodic_exact,periodic_qtt,periodic_abs_error,open_exact,open_qtt,open_abs_error")
-    );
-    let first_sample = samples.first().expect("affine samples are not empty");
-    assert!(
-        (first_sample.source_exact
-            - qtt_affine_common::source_function(
-                first_sample.x,
-                first_sample.y,
-                qtt_affine_common::point_count(config.bits),
-            ))
-        .abs()
-            < 1e-12
-    );
-    assert_eq!(
-        read_lines(&bonds_path).first().map(String::as_str),
-        Some("bond_index,input_bond_dim,periodic_transformed_bond_dim,open_transformed_bond_dim")
-    );
-    assert_eq!(
-        read_lines(&operator_bonds_path).first().map(String::as_str),
-        Some("bond_index,periodic_operator_bond_dim,open_operator_bond_dim")
-    );
-
-    Ok(())
-}
-#[test]
-fn qtt_partial_fourier2d_source_qtt_matches_input_function() -> Result<(), Box<dyn Error>> {
-    let config = qtt_partial_fourier2d_common::PartialFourier2dConfig {
-        bits: 5,
-        maxbonddim: 32,
-        maxiter: 12,
-        ..qtt_partial_fourier2d_common::DEFAULT_PARTIAL_FOURIER2D_CONFIG
-    };
-    let input_grid = qtt_partial_fourier2d_common::build_input_grid(&config)?;
-    let (qtci, ranks, errors) =
-        qtt_partial_fourier2d_common::build_source_qtt(&input_grid, &config)?;
-
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-    assert!(qtci.rank() > 0);
-
-    let x_coords = input_grid.grid_origcoords(0)?;
-    let t_coords = input_grid.grid_origcoords(1)?;
-    let x_index = x_coords.len() / 2;
-    let t_index = t_coords.len() / 3;
-    let qtt = qtci.evaluate(&[(x_index + 1) as i64, (t_index + 1) as i64])?;
-    let exact = qtt_partial_fourier2d_common::source_function(
-        x_coords[x_index],
-        t_coords[t_index],
-        &config,
-    );
-
-    assert!((qtt - exact).abs() < 1e-8);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_partial_fourier2d_operator_targets_only_x_nodes() -> Result<(), Box<dyn Error>> {
-    let config = qtt_partial_fourier2d_common::PartialFourier2dConfig {
-        bits: 4,
-        ..qtt_partial_fourier2d_common::DEFAULT_PARTIAL_FOURIER2D_CONFIG
-    };
-    let operator = qtt_partial_fourier2d_common::build_partial_fourier_operator(&config)?;
-    let nodes = operator.node_names();
-
-    assert_eq!(nodes.len(), config.bits);
-    for node in [0usize, 2, 4, 6] {
-        assert!(nodes.contains(&node));
-    }
-    for node in [1usize, 3, 5, 7] {
-        assert!(!nodes.contains(&node));
-    }
-
-    Ok(())
-}
-
-#[test]
-fn qtt_partial_fourier2d_operator_matches_analytic_transform() -> Result<(), Box<dyn Error>> {
-    let config = qtt_partial_fourier2d_common::PartialFourier2dConfig {
-        bits: 6,
-        maxbonddim: 64,
-        maxiter: 20,
-        ..qtt_partial_fourier2d_common::DEFAULT_PARTIAL_FOURIER2D_CONFIG
-    };
-    let input_grid = qtt_partial_fourier2d_common::build_input_grid(&config)?;
-    let frequency_grid = qtt_partial_fourier2d_common::build_frequency_grid(&config)?;
-    let (qtci, ranks, errors) =
-        qtt_partial_fourier2d_common::build_source_qtt(&input_grid, &config)?;
-    let operator = qtt_partial_fourier2d_common::build_partial_fourier_operator(&config)?;
-    let (transformed, site_indices) =
-        qtt_partial_fourier2d_common::transform_x_dimension(&qtci, &operator)?;
-    let samples = qtt_partial_fourier2d_common::collect_samples(
-        &transformed,
-        &site_indices,
-        &frequency_grid,
-        &config,
-    )?;
-
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
-    assert_eq!(site_indices.len(), 2 * config.bits);
-    assert_eq!(
-        samples.len(),
-        (1usize << config.bits) * (1usize << config.bits)
-    );
-
-    let max_abs_error = samples
-        .iter()
-        .map(|sample| sample.abs_error)
-        .fold(0.0_f64, f64::max);
-    assert!(
-        max_abs_error < 5e-8,
-        "unexpectedly large partial Fourier error: {max_abs_error}"
-    );
-
-    let center = samples
-        .iter()
-        .find(|sample| sample.k.abs() < 1e-12 && sample.t.abs() < 1e-12)
-        .expect("frequency/time grid should include k=0 and t=0");
-    assert!((center.qtt_re - center.analytic_re).abs() < 5e-8);
-    assert!(center.qtt_im.abs() < 5e-8);
-
-    Ok(())
-}
-
-#[test]
-fn qtt_partial_fourier2d_output_sites_are_interleaved_once() {
-    let mut k_sites = qtt_partial_fourier2d_common::global_index_to_quantics_sites(0b110 + 1, 3);
-    k_sites.reverse();
-    let t_sites = qtt_partial_fourier2d_common::global_index_to_quantics_sites(0b011 + 1, 3);
-    let values: Vec<usize> = k_sites
-        .into_iter()
-        .zip(t_sites)
-        .flat_map(|(k_site, t_site)| [k_site, t_site])
-        .collect();
-
-    assert_eq!(values, vec![0, 0, 1, 1, 1, 1]);
-    assert_eq!(values.len(), 6);
-}
-
-#[test]
-fn qtt_partial_fourier2d_exports_stable_csv_headers() -> Result<(), Box<dyn Error>> {
-    use qtt_partial_fourier2d_common::{
-        write_bond_dims_csv, write_operator_bond_dims_csv, write_samples_csv,
-        PartialFourier2dSamplePoint,
-    };
-
-    let scratch = scratch_dir("qtt-partial-fourier2d");
-    let samples_path = scratch.join("samples.csv");
-    let bond_dims_path = scratch.join("bond_dims.csv");
-    let operator_bond_dims_path = scratch.join("operator_bond_dims.csv");
-
-    write_samples_csv(
-        &samples_path,
-        &[PartialFourier2dSamplePoint {
+    let partial_samples = scratch.join("partial_fourier_samples.csv");
+    qtt_partial_fourier2d_common::write_samples_csv(
+        &partial_samples,
+        &[qtt_partial_fourier2d_common::PartialFourier2dSamplePoint {
             k_index: 1,
             t_index: 1,
             source_x_index: 1,
@@ -1201,133 +119,64 @@ fn qtt_partial_fourier2d_exports_stable_csv_headers() -> Result<(), Box<dyn Erro
             abs_error: 0.0,
         }],
     )?;
-    write_bond_dims_csv(&bond_dims_path, &[(1, Some(2), Some(3))])?;
-    write_operator_bond_dims_csv(&operator_bond_dims_path, &[4])?;
-
-    assert_eq!(
-        read_lines(&samples_path).first().map(String::as_str),
-        Some("k_index,t_index,source_x_index,k,t,analytic_re,analytic_im,qtt_re,qtt_im,abs_error")
-    );
-    assert_eq!(
-        read_lines(&bond_dims_path).first().map(String::as_str),
-        Some("bond_index,input_bond_dim,transformed_bond_dim")
-    );
-    assert_eq!(
-        read_lines(&operator_bond_dims_path)
-            .first()
-            .map(String::as_str),
-        Some("bond_index,bond_dim")
+    assert_header(
+        &partial_samples,
+        "k_index,t_index,source_x_index,k,t,analytic_re,analytic_im,qtt_re,qtt_im,abs_error",
     );
 
-    Ok(())
-}
-
-#[test]
-fn interpolative_qtt_demo_matches_known_values_and_exports_csv() -> Result<(), Box<dyn Error>> {
-    let config = interpolative_qtt_common::InterpolativeQttTutorialConfig {
-        bits_1d: 5,
-        bits_2d: 4,
-        single_scale_degree: 12,
-        multi_scale_degree_1d: 20,
-        multi_scale_degree_2d: 12,
-        ..interpolative_qtt_common::DEFAULT_INTERPOLATIVE_QTT_CONFIG
-    };
-
-    let single_scale = interpolative_qtt_common::build_single_scale_smooth_qtt(&config)?;
-    let multi_scale_1d =
-        interpolative_qtt_common::build_multi_scale_inverse_square_1d_qtt(&config)?;
-    let multi_scale_2d =
-        interpolative_qtt_common::build_multi_scale_inverse_square_2d_qtt(&config)?;
-
-    let smooth_samples = interpolative_qtt_common::collect_1d_samples(
-        "single_scale_1d",
-        &single_scale,
-        config.bits_1d,
-        config.lower_bound,
-        config.upper_bound,
-        interpolative_qtt_common::smooth_target,
+    let affine_samples = scratch.join("affine_samples.csv");
+    qtt_affine_common::write_samples_csv(
+        &affine_samples,
+        &[qtt_affine_common::AffineSamplePoint {
+            x_index: 1,
+            y_index: 1,
+            x: 0,
+            y: 0,
+            source_u_periodic: 0,
+            source_v: 0,
+            source_exact: 1.0,
+            periodic_exact: 1.0,
+            periodic_qtt: 1.0,
+            periodic_abs_error: 0.0,
+            open_exact: 1.0,
+            open_qtt: 1.0,
+            open_abs_error: 0.0,
+        }],
     )?;
-    let inverse_samples_1d = interpolative_qtt_common::collect_1d_samples(
-        "multi_scale_1d",
-        &multi_scale_1d,
-        config.bits_1d,
-        config.lower_bound,
-        config.upper_bound,
-        |x| interpolative_qtt_common::softened_inverse_square_1d(x, config.epsilon),
+    assert_header(
+        &affine_samples,
+        "x_index,y_index,x,y,source_u_periodic,source_v,source_exact,periodic_exact,periodic_qtt,periodic_abs_error,open_exact,open_qtt,open_abs_error",
+    );
+
+    let sweep = scratch.join("integral_sweep.csv");
+    qtt_integral_sweep_utils::write_sweep_csv(
+        &sweep,
+        &[qtt_integral_sweep_utils::IntegralSweepRow {
+            r: 3,
+            npoints: 8,
+            integral: 1.0,
+            exact_integral: 1.0,
+            abs_error: 0.0,
+            rank: 2,
+        }],
     )?;
-    let lower = [config.lower_bound, config.lower_bound];
-    let upper = [config.upper_bound, config.upper_bound];
-    let inverse_samples_2d = interpolative_qtt_common::collect_2d_samples(
-        &multi_scale_2d,
-        config.bits_2d,
-        &lower,
-        &upper,
-        |coords| interpolative_qtt_common::softened_inverse_square_2d(coords, config.epsilon),
+    assert_header(&sweep, "r,npoints,integral,exact_integral,abs_error,rank");
+
+    let r_sweep = scratch.join("r_sweep.csv");
+    qtt_r_sweep_utils::write_stats_csv(
+        &r_sweep,
+        &[qtt_r_sweep_utils::SweepStats {
+            r: 3,
+            npoints: 8,
+            build_time_sec: 0.25,
+            mean_abs_error: 0.0,
+            max_abs_error: 0.0,
+            rank: 2,
+        }],
     )?;
-
-    let smooth_error = interpolative_qtt_common::max_abs_error_1d(&smooth_samples);
-    let inverse_error_1d = interpolative_qtt_common::max_abs_error_1d(&inverse_samples_1d);
-    let inverse_error_2d = interpolative_qtt_common::max_abs_error_2d(&inverse_samples_2d);
-
-    assert!(
-        smooth_error < 1e-10,
-        "single-scale smooth interpolation error was {smooth_error}"
-    );
-    assert!(
-        inverse_error_1d < 1e-4,
-        "1D multiscale inverse-square interpolation error was {inverse_error_1d}"
-    );
-    assert!(
-        inverse_error_2d < 1e-2,
-        "2D multiscale inverse-square interpolation error was {inverse_error_2d}"
-    );
-
-    let first_smooth = smooth_samples
-        .first()
-        .expect("smooth sample table should be non-empty");
-    assert!((first_smooth.x - config.lower_bound).abs() < 1e-12);
-    assert!(
-        (first_smooth.exact - interpolative_qtt_common::smooth_target(config.lower_bound)).abs()
-            < 1e-12
-    );
-    assert!((first_smooth.qtt - first_smooth.exact).abs() < 1e-10);
-
-    let origin_peak = inverse_samples_1d
-        .iter()
-        .find(|sample| sample.x.abs() < 1e-12)
-        .expect("the 1D grid should contain the origin");
-    let expected_peak = interpolative_qtt_common::softened_inverse_square_1d(0.0, config.epsilon);
-    assert!((origin_peak.exact - expected_peak).abs() < 1e-12);
-    assert!((origin_peak.qtt - expected_peak).abs() < 1e-4);
-
-    let mut samples_1d = smooth_samples;
-    samples_1d.extend(inverse_samples_1d);
-    let bonds = interpolative_qtt_common::collect_bond_dims(
-        &single_scale.link_dims(),
-        &multi_scale_1d.link_dims(),
-        &multi_scale_2d.link_dims(),
-    );
-
-    let scratch = scratch_dir("interpolative-qtt");
-    let samples_1d_path = scratch.join("samples_1d.csv");
-    let samples_2d_path = scratch.join("samples_2d.csv");
-    let bonds_path = scratch.join("bond_dims.csv");
-
-    interpolative_qtt_common::write_1d_samples_csv(&samples_1d_path, &samples_1d)?;
-    interpolative_qtt_common::write_2d_samples_csv(&samples_2d_path, &inverse_samples_2d)?;
-    interpolative_qtt_common::write_bond_dims_csv(&bonds_path, &bonds)?;
-
-    assert_eq!(
-        read_lines(&samples_1d_path).first().map(String::as_str),
-        Some("case,index,x,exact,qtt,abs_error")
-    );
-    assert_eq!(
-        read_lines(&samples_2d_path).first().map(String::as_str),
-        Some("x_index,y_index,x,y,exact,qtt,abs_error")
-    );
-    assert_eq!(
-        read_lines(&bonds_path).first().map(String::as_str),
-        Some("bond_index,single_scale_1d,multi_scale_1d,multi_scale_2d")
+    assert_header(
+        &r_sweep,
+        "r,npoints,build_time_sec,mean_abs_error,max_abs_error,rank",
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

- add TreeTN convenience APIs for single-point evaluation and bond-dimension profiles
- add LinearOperator accessors for owned MPO extraction and collision-safe node renaming, then make internal fields crate-private
- simplify tutorial code to use tensor4all-rs APIs, including partial apply for the 2D partial Fourier operator
- reduce tutorial verification tests to lightweight output/path contracts while keeping binary smoke coverage

## Validation

- cargo fmt --all
- cargo test -p tensor4all-treetn --release
- cargo test -p tensor4all-treetn --doc --release
- cargo test -p tensor4all-tutorial-code --release
- cargo test -p tensor4all-quanticstransform --release
- cargo test -p tensor4all-quanticstci --release test_2d_qft_x_only_interleaved
- cargo test -p tensor4all-capi --release quanticstransform
- ./scripts/test-mdbook.sh
- git diff --check
