### PR TITLE
[codex] Validate matrix row inputs

### DIFF
--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -37,8 +37,8 @@ pub use backend::{
 pub use context::{default_eager_ctx, with_default_backend};
 pub use matrix::{
     batched_mat_mul_same_shape, batched_mat_mul_same_shape_owned, from_vec2d, mat_mul,
-    mat_mul_owned, submatrix, submatrix_argmax, swap_cols, swap_rows, transpose, BlasMul, Matrix,
-    MatrixScalar, MatrixTensorConversionError,
+    mat_mul_owned, submatrix, submatrix_argmax, swap_cols, swap_rows, transpose, try_from_vec2d,
+    BlasMul, Matrix, MatrixScalar, MatrixShapeError, MatrixTensorConversionError,
 };
 pub use memory::{release_process_allocator_cached_memory, AllocatorPressureRelief};
 pub use storage::{

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -82,6 +82,41 @@ pub enum MatrixTensorConversionError {
     },
 }
 
+/// Error returned when row-shaped input cannot be converted into a [`Matrix`].
+///
+/// Use this when accepting user-provided row data. It reports the first row
+/// whose length differs from the first row, so callers can reject malformed
+/// input before any values are dropped or indexed out of bounds.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{try_from_vec2d, MatrixShapeError};
+///
+/// let err = try_from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0]]).unwrap_err();
+/// assert!(matches!(
+///     err,
+///     MatrixShapeError::RaggedRows {
+///         row: 1,
+///         expected: 2,
+///         actual: 1,
+///     }
+/// ));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MatrixShapeError {
+    /// A later row had a different length than the first row.
+    #[error("row {row} has length {actual}, expected {expected}")]
+    RaggedRows {
+        /// Zero-based row number with the mismatched length.
+        row: usize,
+        /// Column count established by the first row.
+        expected: usize,
+        /// Actual number of entries in `row`.
+        actual: usize,
+    },
+}
+
 impl<T> Matrix<T> {
     /// Create a matrix from raw column-major data.
     ///
@@ -316,10 +351,64 @@ impl<T> IndexMut<[usize; 2]> for Matrix<T> {
     }
 }
 
-/// Create a matrix from a 2D vector.
+/// Create a matrix from a 2D vector, returning an error for ragged rows.
 ///
 /// Each inner `Vec` is one row. The resulting matrix is stored internally in
 /// column-major order.
+///
+/// # Errors
+///
+/// Returns [`MatrixShapeError::RaggedRows`] when any row has a different length
+/// than the first row.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::try_from_vec2d;
+///
+/// let m = try_from_vec2d(vec![
+///     vec![1.0, 2.0],
+///     vec![3.0, 4.0],
+/// ])?;
+/// assert_eq!(m.nrows(), 2);
+/// assert_eq!(m.ncols(), 2);
+/// assert_eq!(m[[0, 1]], 2.0);
+/// assert_eq!(m[[1, 0]], 3.0);
+/// # Ok::<(), tensor4all_tensorbackend::MatrixShapeError>(())
+/// ```
+pub fn try_from_vec2d<T: Clone + Zero>(
+    data: Vec<Vec<T>>,
+) -> std::result::Result<Matrix<T>, MatrixShapeError> {
+    let nrows = data.len();
+    let ncols = data.first().map_or(0, Vec::len);
+    for (row, values) in data.iter().enumerate() {
+        let actual = values.len();
+        if actual != ncols {
+            return Err(MatrixShapeError::RaggedRows {
+                row,
+                expected: ncols,
+                actual,
+            });
+        }
+    }
+    let mut m = Matrix::zeros(nrows, ncols);
+    for i in 0..nrows {
+        for j in 0..ncols {
+            m[[i, j]] = data[i][j].clone();
+        }
+    }
+    Ok(m)
+}
+
+/// Create a matrix from a rectangular 2D vector.
+///
+/// Each inner `Vec` is one row. The resulting matrix is stored internally in
+/// column-major order.
+///
+/// # Panics
+///
+/// Panics if the row lengths are not all equal. Use [`try_from_vec2d`] when
+/// row-shaped input comes from users, files, or other fallible boundaries.
 ///
 /// # Examples
 ///
@@ -336,15 +425,7 @@ impl<T> IndexMut<[usize; 2]> for Matrix<T> {
 /// assert_eq!(m[[1, 0]], 3.0);
 /// ```
 pub fn from_vec2d<T: Clone + Zero>(data: Vec<Vec<T>>) -> Matrix<T> {
-    let nrows = data.len();
-    let ncols = if nrows > 0 { data[0].len() } else { 0 };
-    let mut m = Matrix::zeros(nrows, ncols);
-    for i in 0..nrows {
-        for j in 0..ncols {
-            m[[i, j]] = data[i][j].clone();
-        }
-    }
-    m
+    try_from_vec2d(data).unwrap_or_else(|err| panic!("{err}"))
 }
 
 /// Get a submatrix by selecting specific rows and columns.

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -78,6 +78,42 @@ fn matrix_from_typed_tensor_rejects_non_matrix_rank() {
 }
 
 #[test]
+fn try_from_vec2d_rejects_longer_rows() {
+    let err = try_from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0, 5.0]]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        MatrixShapeError::RaggedRows {
+            row: 1,
+            expected: 2,
+            actual: 3,
+        }
+    ));
+    assert_eq!(err.to_string(), "row 1 has length 3, expected 2");
+}
+
+#[test]
+fn try_from_vec2d_rejects_shorter_rows() {
+    let err = try_from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0]]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        MatrixShapeError::RaggedRows {
+            row: 1,
+            expected: 2,
+            actual: 1,
+        }
+    ));
+    assert_eq!(err.to_string(), "row 1 has length 1, expected 2");
+}
+
+#[test]
+#[should_panic(expected = "row 1 has length 3, expected 2")]
+fn from_vec2d_panics_with_shape_error_for_ragged_rows() {
+    let _ = from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0, 5.0]]);
+}
+
+#[test]
 fn test_matrix_transpose() {
     let m = from_vec2d(vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]]);
     let mt = transpose(&m);

--- a/crates/tensor4all-tensorci/src/tensorci1/matrix_ci.rs
+++ b/crates/tensor4all-tensorci/src/tensorci1/matrix_ci.rs
@@ -37,7 +37,7 @@ where
 
     #[cfg(test)]
     pub(super) fn rank(&self) -> usize {
-        self.row_indices.len().min(self.col_indices.len())
+        self.left.ncols()
     }
 
     #[cfg(test)]
@@ -130,6 +130,7 @@ where
 
     #[cfg(test)]
     fn left_matrix(&self) -> Result<Matrix<T>> {
+        self.ensure_square_rank_for_evaluation()?;
         right_solve(&self.left, &self.pivot_matrix())
     }
 
@@ -141,6 +142,20 @@ where
             value = value + left[[row, k]] * self.right[[k, col]];
         }
         Ok(value)
+    }
+
+    #[cfg(test)]
+    fn ensure_square_rank_for_evaluation(&self) -> Result<()> {
+        if self.left.ncols() != self.right.nrows() {
+            return Err(TCIError::DimensionMismatch {
+                message: format!(
+                    "MatrixCI evaluation requires matching left/right ranks, got {} and {}",
+                    self.left.ncols(),
+                    self.right.nrows()
+                ),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/tensor4all-tensorci/src/tensorci1/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/tensorci1/tests/mod.rs
@@ -39,6 +39,19 @@ fn test_matrix_ci_rejects_factor_rank_mismatch() {
 }
 
 #[test]
+fn test_matrix_ci_evaluate_rejects_left_right_rank_mismatch() {
+    let left = from_vec2d(vec![vec![1.0_f64, 2.0]]);
+    let right = from_vec2d(vec![vec![3.0_f64, 4.0]]);
+    let ci = matrix_ci::MatrixCI::new(vec![0], vec![0, 1], left, right).unwrap();
+    let err = ci.evaluate(0, 0).unwrap_err();
+
+    assert!(matches!(err, TCIError::DimensionMismatch { .. }));
+    assert!(err
+        .to_string()
+        .contains("requires matching left/right ranks"));
+}
+
+#[test]
 fn test_crossinterpolate1_rank2_function() {
     let f = |idx: &MultiIndex| (idx[0] + idx[1] + 1) as f64;
     let (tci, ranks, errors) = crossinterpolate1::<f64, _>(


### PR DESCRIPTION
## Summary

Addresses a focused subset of #522's input-validation findings.

- Add `MatrixShapeError` and `try_from_vec2d` so row-shaped matrix input rejects ragged rows with a typed error instead of silently truncating longer rows or panicking on shorter rows.
- Make existing `from_vec2d` reuse the same validation path and panic with the typed error message for literal/test convenience.
- Add MatrixCI regression coverage so left/right rank mismatches fail at the evaluation boundary without breaking TensorCI1's valid intermediate rectangular update states.

This does not close #522; the remaining index-identity, HDF5 metadata, quantics silent fallback, C API dense-materialization, and workflow-helper findings still need follow-up.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --release -p tensor4all-tensorbackend`
- `cargo test --release -p tensor4all-tensorci`
- `cargo clippy -p tensor4all-tensorbackend -p tensor4all-tensorci --all-targets -- -D warnings`
- `git diff --check`