### PR TITLE
[codex] Fix high-degree Chebyshev barycentric interpolation

### DIFF
--- a/crates/tensor4all-interpolativeqtt/src/basis.rs
+++ b/crates/tensor4all-interpolativeqtt/src/basis.rs
@@ -8,9 +8,9 @@ use crate::error::{invalid_argument, Result};
 
 /// Barycentric Lagrange basis on a one-dimensional interpolation grid.
 ///
-/// The basis stores interpolation nodes in `[0, 1]` and precomputed
-/// barycentric weights. It is used by the interpolative QTT constructors to
-/// transfer local polynomial information across binary refinement levels.
+/// The basis stores interpolation nodes in `[0, 1]` and scaled barycentric
+/// weights. It is used by the interpolative QTT constructors to transfer
+/// local polynomial information across binary refinement levels.
 ///
 /// # Related Types
 ///
@@ -64,9 +64,39 @@ impl LagrangePolynomials {
             return Err(invalid_argument("Lagrange grid values must be finite"));
         }
 
-        let mut barycentric_weights = Vec::with_capacity(grid.len());
+        let barycentric_weights = scaled_barycentric_weights(&grid)?;
+
+        Ok(Self {
+            grid,
+            barycentric_weights,
+        })
+    }
+
+    fn from_grid_and_weights(grid: Vec<f64>, barycentric_weights: Vec<f64>) -> Result<Self> {
+        if grid.len() < 2 {
+            return Err(invalid_argument(
+                "Lagrange grid must contain at least two points",
+            ));
+        }
+        if grid.len() != barycentric_weights.len() {
+            return Err(invalid_argument(format!(
+                "Lagrange grid/weight length mismatch: grid has {}, weights have {}",
+                grid.len(),
+                barycentric_weights.len()
+            )));
+        }
+        if grid.iter().any(|x| !x.is_finite()) {
+            return Err(invalid_argument("Lagrange grid values must be finite"));
+        }
+        if barycentric_weights
+            .iter()
+            .any(|weight| !weight.is_finite() || *weight == 0.0)
+        {
+            return Err(invalid_argument(
+                "barycentric weights must be finite and non-zero",
+            ));
+        }
         for j in 0..grid.len() {
-            let mut weight = 1.0;
             for m in 0..grid.len() {
                 if j == m {
                     continue;
@@ -75,9 +105,7 @@ impl LagrangePolynomials {
                 if diff.abs() < 1.0e-15 {
                     return Err(invalid_argument("Lagrange grid values must be distinct"));
                 }
-                weight *= 1.0 / diff;
             }
-            barycentric_weights.push(weight);
         }
 
         Ok(Self {
@@ -138,10 +166,10 @@ impl LagrangePolynomials {
         &self.grid
     }
 
-    /// Borrow the barycentric weights for the interpolation grid.
+    /// Borrow the scaled barycentric weights for the interpolation grid.
     ///
-    /// The weights are primarily useful for diagnostics and for reproducing
-    /// the Julia implementation exactly.
+    /// Only relative weights matter for barycentric interpolation; common
+    /// factors are intentionally omitted to avoid overflow at high degree.
     ///
     /// # Examples
     ///
@@ -193,8 +221,17 @@ impl LagrangePolynomials {
             return Ok(0.0);
         }
 
-        let product = self.grid.iter().fold(1.0, |acc, node| acc * (x - node));
-        Ok(product * self.barycentric_weights[alpha] / (x - self.grid[alpha]))
+        let mut denominator = 0.0;
+        for (node, weight) in self.grid.iter().zip(&self.barycentric_weights) {
+            denominator += weight / (x - node);
+        }
+        if denominator == 0.0 || !denominator.is_finite() {
+            return Err(invalid_argument(
+                "barycentric denominator must be finite and non-zero",
+            ));
+        }
+
+        Ok((self.barycentric_weights[alpha] / (x - self.grid[alpha])) / denominator)
     }
 }
 
@@ -225,7 +262,65 @@ pub fn get_chebyshev_grid(degree: usize) -> Result<LagrangePolynomials> {
     let grid = (0..=degree)
         .map(|j| 0.5 * (1.0 - ((j as f64) * PI / (degree as f64)).cos()))
         .collect();
-    LagrangePolynomials::new(grid)
+    let weights = chebyshev_lobatto_barycentric_weights(degree);
+    LagrangePolynomials::from_grid_and_weights(grid, weights)
+}
+
+fn scaled_barycentric_weights(grid: &[f64]) -> Result<Vec<f64>> {
+    let mut signs = Vec::with_capacity(grid.len());
+    let mut log_abs_weights = Vec::with_capacity(grid.len());
+
+    for j in 0..grid.len() {
+        let mut sign = 1.0;
+        let mut log_abs_weight = 0.0;
+        for m in 0..grid.len() {
+            if j == m {
+                continue;
+            }
+            let diff = grid[j] - grid[m];
+            if diff.abs() < 1.0e-15 {
+                return Err(invalid_argument("Lagrange grid values must be distinct"));
+            }
+            if diff.is_sign_negative() {
+                sign = -sign;
+            }
+            log_abs_weight -= diff.abs().ln();
+        }
+        signs.push(sign);
+        log_abs_weights.push(log_abs_weight);
+    }
+
+    let max_log_abs_weight = log_abs_weights
+        .iter()
+        .copied()
+        .fold(f64::NEG_INFINITY, f64::max);
+    let weights: Vec<_> = signs
+        .into_iter()
+        .zip(log_abs_weights)
+        .map(|(sign, log_abs_weight)| sign * (log_abs_weight - max_log_abs_weight).exp())
+        .collect();
+    if weights
+        .iter()
+        .any(|weight| !weight.is_finite() || *weight == 0.0)
+    {
+        return Err(invalid_argument(
+            "failed to compute finite non-zero barycentric weights",
+        ));
+    }
+    Ok(weights)
+}
+
+fn chebyshev_lobatto_barycentric_weights(degree: usize) -> Vec<f64> {
+    (0..=degree)
+        .map(|j| {
+            let magnitude = if j == 0 || j == degree { 0.5 } else { 1.0 };
+            if j % 2 == 0 {
+                magnitude
+            } else {
+                -magnitude
+            }
+        })
+        .collect()
 }
 
 /// Build the dense local interpolation core for a Lagrange basis.

--- a/crates/tensor4all-interpolativeqtt/src/tests.rs
+++ b/crates/tensor4all-interpolativeqtt/src/tests.rs
@@ -312,6 +312,41 @@ fn direct_product_core_tensors_three_tensors() {
 }
 
 #[test]
+fn lagrange_polynomials_new_handles_general_grid() {
+    let basis = LagrangePolynomials::new(vec![0.0, 0.2, 0.7, 1.0]).unwrap();
+    let x = 0.43_f64;
+
+    assert!(!basis.is_empty());
+    assert!(basis.barycentric_weights().iter().all(|w| w.is_finite()));
+    assert!(basis
+        .barycentric_weights()
+        .iter()
+        .any(|w| w.is_sign_negative()));
+
+    let mut partition_of_unity = 0.0;
+    let mut cubic_interpolant = 0.0;
+    for alpha in 0..basis.len() {
+        let value = basis.evaluate(alpha, x).unwrap();
+        partition_of_unity += value;
+        cubic_interpolant += value * basis.grid()[alpha].powi(3);
+    }
+
+    assert!((partition_of_unity - 1.0).abs() < 1.0e-12);
+    assert!((cubic_interpolant - x.powi(3)).abs() < 1.0e-12);
+}
+
+#[test]
+fn lagrange_polynomials_validation_errors() {
+    assert!(LagrangePolynomials::new(vec![0.0]).is_err());
+    assert!(LagrangePolynomials::new(vec![0.0, f64::NAN]).is_err());
+    assert!(LagrangePolynomials::new(vec![0.0, 0.0]).is_err());
+
+    let basis = LagrangePolynomials::new(vec![0.0, 0.5, 1.0]).unwrap();
+    assert!(basis.evaluate(basis.len(), 0.25).is_err());
+    assert!(basis.evaluate(0, f64::INFINITY).is_err());
+}
+
+#[test]
 fn high_degree_chebyshev_basis_stays_finite() {
     let degree = 600;
     let basis = get_chebyshev_grid(degree).unwrap();

--- a/crates/tensor4all-interpolativeqtt/src/tests.rs
+++ b/crates/tensor4all-interpolativeqtt/src/tests.rs
@@ -312,6 +312,37 @@ fn direct_product_core_tensors_three_tensors() {
 }
 
 #[test]
+fn high_degree_chebyshev_basis_stays_finite() {
+    let degree = 600;
+    let basis = get_chebyshev_grid(degree).unwrap();
+
+    assert_eq!(basis.len(), degree + 1);
+    assert!(basis.barycentric_weights().iter().all(|w| w.is_finite()));
+    assert!((basis.evaluate(0, basis.grid()[0]).unwrap() - 1.0).abs() < 1.0e-12);
+    assert!(basis.evaluate(1, basis.grid()[0]).unwrap().abs() < 1.0e-12);
+
+    let core = interpolation_tensor(&basis).unwrap();
+    for left in 0..core.left_dim() {
+        for site in 0..core.site_dim() {
+            for right in 0..core.right_dim() {
+                assert!(core.get3(left, site, right).is_finite());
+            }
+        }
+    }
+}
+
+#[test]
+fn high_degree_single_scale_compression_does_not_fail_svd() {
+    let f = |x: f64| (2.0 * std::f64::consts::PI * x).sin();
+    let opts = InterpolativeQttOptions::default();
+
+    let tt = interpolate_single_scale(f, 0.0, 1.0, 3, 600, &opts).unwrap();
+
+    assert_eq!(tt.len(), 3);
+    assert!(tt.link_dims().iter().all(|&dim| dim <= 601));
+}
+
+#[test]
 fn multiscale_interpolation_one_over_x() {
     let r = 12;
     let a = 0.0;


### PR DESCRIPTION
Fixes #529.

## Summary

This fixes high-degree Chebyshev-Lobatto interpolation in `tensor4all-interpolativeqtt` by avoiding the direct product formula for barycentric weights. The previous implementation formed weights as a product of `1 / (x_j - x_m)`, which overflows around degree 600 and injects non-finite values into the local interpolation core. That later reaches TT compression and fails in SVD.

The implementation now:

- uses closed-form scaled Chebyshev-Lobatto barycentric weights for `get_chebyshev_grid`
- computes generic-grid weights in log space and rescales them
- evaluates Lagrange basis functions with the second barycentric formula
- adds degree-600 regression tests for finite weights/core entries and successful compression

## Reproduction Data

Before the fix, the issue reproducer reaches non-finite barycentric weights/core entries at degree 600 and the compression path fails in SVD.

After the fix, the original-scale case succeeds:

```text
interpolate_single_scale(sin(2πx), 0.0, 1.0, K=20, degree=600)
OK len=20 links=[1, 2, 2, 2, 2, 2, 2, 3, 4, 5, 5, 5, 5, 4, 3, 2, 2, 2, 2]
```

I also evaluated the resulting TT on the full `2^20` grid against `sin(2πx)`:

```text
max_abs_err=9.538314582613339e-12 at grid index 585214
```

## Validation

```text
cargo fmt --all
cargo fmt --all -- --check
cargo test --release -p tensor4all-interpolativeqtt high_degree -- --nocapture
cargo test --release -p tensor4all-interpolativeqtt
cargo clippy --release -p tensor4all-interpolativeqtt --all-targets -- -D warnings
```

## References

- Berrut & Trefethen, “Barycentric Lagrange Interpolation”: https://people.maths.ox.ac.uk/trefethen/barycentric.pdf
- Webb, Trefethen & Gonnet, “Stability of Barycentric Interpolation Formulas”: https://personalpages.manchester.ac.uk/staff/marcus.webb/pdfs/webbbarycentric.pdf
- Chebfun Guide, Chebyshev approximation/interpolants: https://www.chebfun.org/docs/guide/guide04.html
