### PR TITLE
Implement TreeTN two-site DMRG

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,6 +37,20 @@ Prepared local linsolve:
 RAYON_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_local_linsolve --release -- 38 32 32 1 10 30 0
 ```
 
+Two-site TreeTN DMRG against a Pauli Heisenberg Hamiltonian
+`sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j` on chain and star topologies.
+The benchmark compresses the summed MPO before timing, uses the repository
+ITensors-compatible relative discarded squared singular-value tail cutoff
+`1e-12`, and performs one untimed DMRG warm-up per topology. It reports runtime
+and accuracy against a small dense exact reference. The star case uses a leaf
+DMRG root in both Rust and Julia because ITensorNetworks.jl requires a leaf root
+when converting an `OpSum` to a TTN. The Rust benchmark runs all requested
+sweeps, without sweep-to-sweep energy early stopping:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_dmrg --release -- 8 4 3
+```
+
 Non-AD local tensor operations:
 
 ```bash
@@ -149,6 +163,24 @@ Prepared local linsolve:
 ```bash
 BLAS_NUM_THREADS=1 julia --project=benchmarks/julia benchmarks/julia/benchmark_local_linsolve.jl 38 32 32 1 1 10
 ```
+
+ITensorNetworks.jl two-site DMRG parity benchmark on matching chain and star
+Pauli Heisenberg Hamiltonians:
+
+```bash
+export T4A_ITENSORNETWORKS_PATH=/home/shinaoka/tensor4all/ITensor/ITensorNetworks.jl
+export T4A_ITN_BENCH_PROJECT=/tmp/t4a-itensornetworks-bench
+julia --project=$T4A_ITN_BENCH_PROJECT -e 'using Pkg; Pkg.develop(path=ENV["T4A_ITENSORNETWORKS_PATH"]); Pkg.add(["Graphs", "ITensors", "TensorOperations"]); Pkg.instantiate()'
+BLAS_NUM_THREADS=1 julia --project=$T4A_ITN_BENCH_PROJECT \
+  benchmarks/julia/benchmark_dmrg_itensornetworks.jl 8 4 3
+```
+
+The temporary project keeps the local ITensorNetworks.jl checkout clean while
+loading `TensorOperations.jl` so ITensorNetworks.jl can choose optimized
+contraction sequences. The Julia runner performs one untimed DMRG warm-up per
+topology before recording timings, so reported times exclude Julia compilation
+and ITensorNetworks.jl first-call setup. Both runners use `cutoff = 1e-12` as a
+relative discarded squared singular-value tail cutoff.
 
 Non-AD local tensor operations:
 

--- a/benchmarks/julia/benchmark_dmrg_itensornetworks.jl
+++ b/benchmarks/julia/benchmark_dmrg_itensornetworks.jl
@@ -1,0 +1,142 @@
+# Two-site DMRG benchmark for ITensorNetworks.jl.
+#
+# Prefer running against a local ITensorNetworks.jl checkout in a temporary
+# benchmark project so the upstream checkout remains clean:
+#   export T4A_ITENSORNETWORKS_PATH=/home/shinaoka/tensor4all/ITensor/ITensorNetworks.jl
+#   export T4A_ITN_BENCH_PROJECT=/tmp/t4a-itensornetworks-bench
+#   julia --project=$T4A_ITN_BENCH_PROJECT -e 'using Pkg; Pkg.develop(path=ENV["T4A_ITENSORNETWORKS_PATH"]); Pkg.add(["Graphs", "ITensors", "TensorOperations"]); Pkg.instantiate()'
+#   BLAS_NUM_THREADS=1 julia --project=$T4A_ITN_BENCH_PROJECT \
+#     benchmarks/julia/benchmark_dmrg_itensornetworks.jl 8 4 3
+#
+# Optional args:
+#   julia benchmark_dmrg_itensornetworks.jl <n_sites> <nsweeps> <repeats>
+
+using Graphs: SimpleGraph, add_edge!, edges, src, dst
+using ITensorNetworks: OpSum, dmrg, random_tensornetwork, siteinds, ttn
+using ITensors: disable_warn_order
+using LinearAlgebra: Symmetric, eigvals
+using Random: MersenneTwister
+using Statistics: mean
+using TensorOperations
+
+disable_warn_order()
+
+function make_graph(kind::Symbol, n_sites::Int)
+  g = SimpleGraph(n_sites)
+  if kind == :chain
+    for i in 1:(n_sites - 1)
+      add_edge!(g, i, i + 1)
+    end
+  elseif kind == :star
+    for i in 2:n_sites
+      add_edge!(g, 1, i)
+    end
+  else
+    error("unknown topology kind $kind")
+  end
+  return g
+end
+
+function heisenberg_opsum(g::SimpleGraph)
+  os = OpSum()
+  for edge in edges(g)
+    i = src(edge)
+    j = dst(edge)
+    os += 1.0, "X", i, "X", j
+    os += 1.0, "Y", i, "Y", j
+    os += 1.0, "Z", i, "Z", j
+  end
+  return os
+end
+
+root_vertex(kind::Symbol) = kind == :star ? 2 : 1
+
+function dense_heisenberg_exact(g::SimpleGraph, n_sites::Int)
+  n_sites <= 10 || error("dense exact benchmark reference is capped at n_sites <= 10")
+  dim = 1 << n_sites
+  h = zeros(Float64, dim, dim)
+  for input_state in 0:(dim - 1)
+    bits = [((input_state >> site) & 1) for site in 0:(n_sites - 1)]
+    for edge in edges(g)
+      left = src(edge) - 1
+      right = dst(edge) - 1
+      z_left = bits[left + 1] == 0 ? 1.0 : -1.0
+      z_right = bits[right + 1] == 0 ? 1.0 : -1.0
+      h[input_state + 1, input_state + 1] += z_left * z_right
+
+      flipped = xor(input_state, (1 << left), (1 << right))
+      yy_coeff = bits[left + 1] == bits[right + 1] ? -1.0 : 1.0
+      h[flipped + 1, input_state + 1] += 1.0 + yy_coeff
+    end
+  end
+  return minimum(eigvals(Symmetric(h)))
+end
+
+function summarize(times_ns)
+  seconds = times_ns ./ 1.0e9
+  return mean(seconds), minimum(seconds), maximum(seconds)
+end
+
+function make_initial_state(sites, repeat_seed::Integer)
+  rng = MersenneTwister(repeat_seed)
+  return ttn(random_tensornetwork(rng, sites; link_space = 1))
+end
+
+function run_dmrg_once(H, psi0, root::Int, nsweeps::Int)
+  return dmrg(
+    H,
+    psi0;
+    nsweeps,
+    nsites = 2,
+    root_vertex = root,
+    factorize_kwargs = (; cutoff = 1.0e-12, maxdim = 32),
+    eigsolve_solver_kwargs = (; tol = 1.0e-12, krylovdim = 16, maxiter = 4),
+  )
+end
+
+function run_case(kind::Symbol, n_sites::Int, nsweeps::Int, repeats::Int)
+  g = make_graph(kind, n_sites)
+  sites = siteinds("S=1/2", g)
+  root = root_vertex(kind)
+  H = ttn(heisenberg_opsum(g), sites; root_vertex = root, cutoff = 1.0e-12)
+  exact_energy = dense_heisenberg_exact(g, n_sites)
+
+  # Exclude Julia compilation and ITensorNetworks.jl first-call setup from the
+  # timed region. The timed loop below measures DMRG execution only.
+  run_dmrg_once(H, make_initial_state(sites, 0x4a16), root, nsweeps)
+  GC.gc()
+
+  times = UInt64[]
+  energy = NaN
+  for repeat in 1:repeats
+    psi0 = make_initial_state(sites, 0x4a17 + repeat)
+    start = time_ns()
+    energy, _ = run_dmrg_once(H, psi0, root, nsweeps)
+    push!(times, time_ns() - start)
+  end
+
+  mean_s, min_s, max_s = summarize(times)
+  println(
+    "case=$(kind) n=$(n_sites) sweeps=$(nsweeps) warmups=1 repeats=$(repeats) " *
+    "energy=$(round(real(energy), digits = 12)) exact=$(round(exact_energy, digits = 12)) " *
+    "abs_error=$(abs(real(energy) - exact_energy)) " *
+    "mean_ms=$(round(mean_s * 1000, digits = 3)) " *
+    "min_ms=$(round(min_s * 1000, digits = 3)) " *
+    "max_ms=$(round(max_s * 1000, digits = 3))"
+  )
+  return nothing
+end
+
+function main()
+  n_sites = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 8
+  nsweeps = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 4
+  repeats = length(ARGS) >= 3 ? parse(Int, ARGS[3]) : 3
+  n_sites >= 2 || error("n_sites must be at least 2")
+  repeats >= 1 || error("repeats must be at least 1")
+
+  run_case(:chain, n_sites, nsweeps, repeats)
+  run_case(:star, n_sites, nsweeps, repeats)
+  return nothing
+end
+
+main()

--- a/benchmarks/results/2026-06-27-treetn-dmrg-itensornetworks.md
+++ b/benchmarks/results/2026-06-27-treetn-dmrg-itensornetworks.md
@@ -1,0 +1,67 @@
+# TreeTN DMRG vs ITensorNetworks.jl Benchmark
+
+Date: 2026-06-27
+
+Purpose: compare the initial two-site TreeTN DMRG implementation against a
+local ITensorNetworks.jl checkout on matching chain and non-chain tree
+topologies.
+
+Both runners use a Pauli Heisenberg Hamiltonian
+`sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j`, `maxdim = 32`, two-site updates,
+one untimed DMRG warmup per topology, and an ITensors-compatible relative
+discarded squared singular-value tail cutoff of `1e-12`.
+
+For the star topology, both runners use a leaf as the DMRG root. This matches
+ITensorNetworks.jl's `ttn(OpSum, ...)` requirement that the tree root be a leaf
+vertex. The Rust runner does not enable sweep-to-sweep energy early stopping
+for this benchmark and reports that all 4 requested sweeps completed.
+
+## Commands
+
+Rust:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 \
+cargo run -p tensor4all-treetn --example benchmark_dmrg --release -- 8 4 3
+```
+
+Julia:
+
+```bash
+BLAS_NUM_THREADS=1 \
+julia --project=/tmp/t4a-itensornetworks-bench-issue531 \
+  benchmarks/julia/benchmark_dmrg_itensornetworks.jl 8 4 3
+```
+
+The Julia runner performs one untimed warmup per topology and constructs the
+repeat initial state outside the timed region, so reported timings exclude Julia
+compilation, ITensorNetworks.jl first-call setup, and random initial-state
+construction.
+
+## Representative Results
+
+| Implementation | Topology | N | Sweeps | Repeats | Energy | Exact | Abs error | Mean ms | Min ms | Max ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Rust TreeTN DMRG | chain | 8 | 4 | 3 | -13.499730394752 | -13.499730394752 | 5.329e-15 | 135.364 | 132.498 | 137.314 |
+| ITensorNetworks.jl | chain | 8 | 4 | 3 | -13.499730394752 | -13.499730394752 | 5.151e-14 | 117.271 | 107.571 | 136.669 |
+| Rust TreeTN DMRG | star | 8 | 4 | 3 | -9.000000000000 | -9.000000000000 | 9.059e-14 | 242.797 | 239.229 | 245.971 |
+| ITensorNetworks.jl | star | 8 | 4 | 3 | -9.000000000000 | -9.000000000000 | 2.487e-14 | 1928.784 | 1716.034 | 2199.503 |
+
+## Notes
+
+- The Rust benchmark source is `benchmarks/rust/benchmark_dmrg.rs`, included by
+  `crates/tensor4all-treetn/examples/benchmark_dmrg.rs`.
+- The Julia benchmark source is `benchmarks/julia/benchmark_dmrg_itensornetworks.jl`.
+- The Rust benchmark also reports max residual norms. In this run they were
+  `2.784e-6` for the chain and `7.326e-3` for the star, while both energies
+  matched the dense exact reference to roundoff.
+- The Rust benchmark reported `sweeps_completed=4`, `local_updates=56`, and
+  `converged=false` for both chain and star, confirming that the timed runs did
+  not stop early.
+- Rust reuses one deterministic initial state for timed repeats, while Julia
+  uses deterministic per-repeat random initial states. Since both runners use a
+  fixed sweep count, this affects trajectories but not the amount of requested
+  sweep work.
+- The chain case is a control for harness overhead: Rust and ITensorNetworks.jl
+  are comparable on the chain, while the high-valence star is much slower in
+  ITensorNetworks.jl. The exact cause is not isolated by this benchmark alone.

--- a/benchmarks/rust/benchmark_dmrg.rs
+++ b/benchmarks/rust/benchmark_dmrg.rs
@@ -1,0 +1,401 @@
+// Two-site TreeTN DMRG benchmark.
+//
+// Run:
+//   RAYON_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_dmrg --release
+//
+// Optional args:
+//   cargo run -p tensor4all-treetn --example benchmark_dmrg --release -- <n_sites> <nsweeps> <repeats>
+
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use tensor4all_core::krylov::HermitianLanczosOptions;
+use tensor4all_core::{DynIndex, IndexLike, SvdTruncationPolicy, TensorDynLen};
+use tensor4all_tensorbackend::{lowest_hermitian_eigenpair, Matrix};
+use tensor4all_treetn::{
+    compose_exclusive_linear_operators, dmrg, DmrgOptions, IndexMapping, LinearOperator, TreeTN,
+    TreeTopology, TruncationOptions,
+};
+
+const ITENSOR_CUTOFF: f64 = 1.0e-12;
+
+fn itensor_cutoff_policy() -> SvdTruncationPolicy {
+    SvdTruncationPolicy::new(ITENSOR_CUTOFF)
+        .with_squared_values()
+        .with_discarded_tail_sum()
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Topology {
+    Chain,
+    Star,
+}
+
+impl Topology {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Chain => "chain",
+            Self::Star => "star",
+        }
+    }
+}
+
+fn node_name(i: usize) -> String {
+    format!("site{i}")
+}
+
+fn dmrg_root_name(topology: Topology) -> String {
+    match topology {
+        Topology::Chain => node_name(0),
+        Topology::Star => node_name(1),
+    }
+}
+
+fn benchmark_dmrg_options(nsweeps: usize) -> DmrgOptions {
+    DmrgOptions::default()
+        .with_nsweeps(nsweeps)
+        .with_max_bond_dim(32)
+        .with_svd_policy(itensor_cutoff_policy())
+        .with_lanczos_options(HermitianLanczosOptions {
+            max_iter: 16,
+            rtol: 1.0e-12,
+            ..HermitianLanczosOptions::default()
+        })
+}
+
+fn col_major_offset(coords: &[usize], dims: &[usize]) -> usize {
+    let mut stride = 1usize;
+    let mut offset = 0usize;
+    for (&coord, &dim) in coords.iter().zip(dims.iter()) {
+        offset += coord * stride;
+        stride *= dim;
+    }
+    offset
+}
+
+fn edges_for(topology: Topology, n_sites: usize) -> Vec<(usize, usize)> {
+    match topology {
+        Topology::Chain => (0..n_sites.saturating_sub(1)).map(|i| (i, i + 1)).collect(),
+        Topology::Star => (1..n_sites).map(|i| (0, i)).collect(),
+    }
+}
+
+fn make_initial_state(
+    topology: Topology,
+    n_sites: usize,
+) -> anyhow::Result<(TreeTN<TensorDynLen, String>, Vec<DynIndex>)> {
+    let edges = edges_for(topology, n_sites);
+    let sites: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+    let bonds: Vec<_> = (0..edges.len()).map(|_| DynIndex::new_dyn(1)).collect();
+    let mut incident: Vec<Vec<(usize, DynIndex)>> = vec![Vec::new(); n_sites];
+    for (edge_id, &(a, b)) in edges.iter().enumerate() {
+        incident[a].push((b, bonds[edge_id].clone()));
+        incident[b].push((a, bonds[edge_id].clone()));
+    }
+
+    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut graph_nodes = Vec::with_capacity(n_sites);
+    for i in 0..n_sites {
+        let mut indices = Vec::with_capacity(1 + incident[i].len());
+        for (_, bond) in &incident[i] {
+            indices.push(bond.clone());
+        }
+        indices.push(sites[i].clone());
+        let site_one_value = if i % 2 == 0 {
+            0.31 + 0.07 * i as f64
+        } else {
+            -0.43 + 0.05 * i as f64
+        };
+        let mut data = vec![0.0; indices.iter().map(DynIndex::dim).product()];
+        data[0] = 1.0;
+        data[1] = site_one_value;
+        let tensor = TensorDynLen::from_dense(indices, data)?;
+        graph_nodes.push(state.add_tensor(node_name(i), tensor)?);
+    }
+    for (edge_id, &(a, b)) in edges.iter().enumerate() {
+        state.connect(graph_nodes[a], &bonds[edge_id], graph_nodes[b], &bonds[edge_id])?;
+    }
+    Ok((state, sites))
+}
+
+fn local_heisenberg_tensor(
+    out_left: DynIndex,
+    in_left: DynIndex,
+    out_right: DynIndex,
+    in_right: DynIndex,
+) -> anyhow::Result<TensorDynLen> {
+    let dims = [2, 2, 2, 2];
+    let mut data = vec![0.0; dims.iter().product()];
+
+    for left in 0..2 {
+        for right in 0..2 {
+            let z_left = if left == 0 { 1.0 } else { -1.0 };
+            let z_right = if right == 0 { 1.0 } else { -1.0 };
+            data[col_major_offset(&[left, left, right, right], &dims)] += z_left * z_right;
+
+            let yy_coeff = if left == right { -1.0 } else { 1.0 };
+            let flip_coeff = 1.0 + yy_coeff;
+            if flip_coeff != 0.0 {
+                data[col_major_offset(&[left ^ 1, left, right ^ 1, right], &dims)] += flip_coeff;
+            }
+        }
+    }
+
+    TensorDynLen::from_dense(vec![out_left, in_left, out_right, in_right], data)
+}
+
+fn make_edge_heisenberg_operator(
+    left: usize,
+    right: usize,
+    state_sites: &[DynIndex],
+    op_inputs: &[DynIndex],
+    op_outputs: &[DynIndex],
+) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+    let left_name = node_name(left);
+    let right_name = node_name(right);
+    let local = local_heisenberg_tensor(
+        op_outputs[left].clone(),
+        op_inputs[left].clone(),
+        op_outputs[right].clone(),
+        op_inputs[right].clone(),
+    )?;
+    let topology = TreeTopology::new(
+        HashMap::from([
+            (
+                left_name.clone(),
+                vec![op_outputs[left].clone(), op_inputs[left].clone()],
+            ),
+            (
+                right_name.clone(),
+                vec![op_outputs[right].clone(), op_inputs[right].clone()],
+            ),
+        ]),
+        vec![(left_name.clone(), right_name.clone())],
+    );
+    let mpo =
+        tensor4all_treetn::factorize_tensor_to_treetn_with(&local, &topology, Default::default(), &left_name)?;
+    let input_mapping = HashMap::from([
+        (
+            left_name.clone(),
+            IndexMapping {
+                true_index: state_sites[left].clone(),
+                internal_index: op_inputs[left].clone(),
+            },
+        ),
+        (
+            right_name.clone(),
+            IndexMapping {
+                true_index: state_sites[right].clone(),
+                internal_index: op_inputs[right].clone(),
+            },
+        ),
+    ]);
+    let output_mapping = HashMap::from([
+        (
+            left_name,
+            IndexMapping {
+                true_index: state_sites[left].clone(),
+                internal_index: op_outputs[left].clone(),
+            },
+        ),
+        (
+            right_name,
+            IndexMapping {
+                true_index: state_sites[right].clone(),
+                internal_index: op_outputs[right].clone(),
+            },
+        ),
+    ]);
+    Ok(LinearOperator::new(mpo, input_mapping, output_mapping))
+}
+
+fn make_heisenberg_operator(
+    topology: Topology,
+    state: &TreeTN<TensorDynLen, String>,
+    state_sites: &[DynIndex],
+) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+    let n_sites = state_sites.len();
+    let edges = edges_for(topology, n_sites);
+    let op_inputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+    let op_outputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+
+    let gap_site_indices: HashMap<_, _> = (0..n_sites)
+        .map(|i| (node_name(i), vec![(op_inputs[i].clone(), op_outputs[i].clone())]))
+        .collect();
+    let mut term_mpos = Vec::with_capacity(edges.len());
+    for &(left, right) in &edges {
+        let edge_op =
+            make_edge_heisenberg_operator(left, right, state_sites, &op_inputs, &op_outputs)?;
+        let composed = compose_exclusive_linear_operators(
+            state.site_index_network(),
+            &[&edge_op],
+            &gap_site_indices,
+        )?;
+        term_mpos.push(composed.into_mpo());
+    }
+
+    let mpo = term_mpos
+        .into_iter()
+        .reduce(|acc, term| acc.add(&term).expect("matching Heisenberg MPO term topology"))
+        .ok_or_else(|| anyhow::anyhow!("Heisenberg operator requires at least one edge"))?;
+    let mpo = mpo.truncate(
+        [node_name(0)],
+        TruncationOptions::default().with_svd_policy(itensor_cutoff_policy()),
+    )?;
+
+    let input_mapping: HashMap<_, _> = (0..n_sites)
+        .map(|i| {
+            (
+                node_name(i),
+                IndexMapping {
+                    true_index: state_sites[i].clone(),
+                    internal_index: op_inputs[i].clone(),
+                },
+            )
+        })
+        .collect();
+    let output_mapping: HashMap<_, _> = (0..n_sites)
+        .map(|i| {
+            (
+                node_name(i),
+                IndexMapping {
+                    true_index: state_sites[i].clone(),
+                    internal_index: op_outputs[i].clone(),
+                },
+            )
+        })
+        .collect();
+    mpo.verify_internal_consistency()?;
+
+    Ok(LinearOperator::new(mpo, input_mapping, output_mapping))
+}
+
+fn dense_heisenberg_exact(topology: Topology, n_sites: usize) -> anyhow::Result<f64> {
+    anyhow::ensure!(
+        n_sites <= 10,
+        "dense exact benchmark reference is capped at n_sites <= 10"
+    );
+    let edges = edges_for(topology, n_sites);
+    let dim = 1usize << n_sites;
+    let mut data = vec![0.0; dim * dim];
+    for input_state in 0..dim {
+        let bits: Vec<_> = (0..n_sites)
+            .map(|site| (input_state >> site) & 1)
+            .collect();
+        for &(left, right) in &edges {
+            let z_left = if bits[left] == 0 { 1.0 } else { -1.0 };
+            let z_right = if bits[right] == 0 { 1.0 } else { -1.0 };
+            data[input_state + dim * input_state] += z_left * z_right;
+
+            let flipped = input_state ^ (1usize << left) ^ (1usize << right);
+            let yy_coeff = if bits[left] == bits[right] {
+                -1.0
+            } else {
+                1.0
+            };
+            data[flipped + dim * input_state] += 1.0 + yy_coeff;
+        }
+    }
+    let matrix = Matrix::from_col_major_vec(dim, dim, data);
+    Ok(lowest_hermitian_eigenpair(&matrix, 1.0e-10)?.eigenvalue)
+}
+
+fn summarize(times: &[Duration]) -> (f64, f64, f64) {
+    let seconds: Vec<_> = times.iter().map(Duration::as_secs_f64).collect();
+    let mean = seconds.iter().sum::<f64>() / seconds.len() as f64;
+    let min = seconds.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = seconds.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    (mean, min, max)
+}
+
+fn run_case(topology: Topology, n_sites: usize, nsweeps: usize, repeats: usize) -> anyhow::Result<()> {
+    let (state, sites) = make_initial_state(topology, n_sites)?;
+    let operator = make_heisenberg_operator(topology, &state, &sites)?;
+    let exact_energy = dense_heisenberg_exact(topology, n_sites)?;
+    let root = dmrg_root_name(topology);
+    let options = benchmark_dmrg_options(nsweeps);
+
+    let warmup = dmrg(&operator, black_box(state.clone()), &root, options.clone())?;
+    black_box(&warmup.state);
+
+    let mut times = Vec::with_capacity(repeats);
+    let mut energy = f64::NAN;
+    let mut residual = f64::NAN;
+    let mut sweeps_completed = 0usize;
+    let mut local_updates = 0usize;
+    let mut converged = false;
+    for _ in 0..repeats {
+        let init = black_box(state.clone());
+        let start = Instant::now();
+        let result = dmrg(&operator, init, &root, options.clone())?;
+        times.push(start.elapsed());
+        energy = result.energy;
+        residual = result.max_residual_norm;
+        sweeps_completed = result.sweeps_completed;
+        local_updates = result.local_updates;
+        converged = result.converged;
+        black_box(&result.state);
+    }
+
+    let (mean, min, max) = summarize(&times);
+    println!(
+        "case={} n={} sweeps={} sweeps_completed={} local_updates={} converged={} warmups=1 repeats={} energy={:.12} exact={:.12} abs_error={:.3e} max_residual={:.3e} mean_ms={:.3} min_ms={:.3} max_ms={:.3}",
+        topology.label(),
+        n_sites,
+        nsweeps,
+        sweeps_completed,
+        local_updates,
+        converged,
+        repeats,
+        energy,
+        exact_energy,
+        (energy - exact_energy).abs(),
+        residual,
+        mean * 1000.0,
+        min * 1000.0,
+        max * 1000.0,
+    );
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let n_sites = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let nsweeps = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(4);
+    let repeats = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
+    anyhow::ensure!(n_sites >= 2, "n_sites must be at least 2");
+    anyhow::ensure!(repeats >= 1, "repeats must be at least 1");
+
+    run_case(Topology::Chain, n_sites, nsweeps, repeats)?;
+    run_case(Topology::Star, n_sites, nsweeps, repeats)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::{SingularValueMeasure, ThresholdScale, TruncationRule};
+
+    #[test]
+    fn dmrg_benchmark_uses_itensors_cutoff_strategy() {
+        let policy = itensor_cutoff_policy();
+        assert_eq!(policy.threshold, ITENSOR_CUTOFF);
+        assert_eq!(policy.scale, ThresholdScale::Relative);
+        assert_eq!(policy.measure, SingularValueMeasure::SquaredValue);
+        assert_eq!(policy.rule, TruncationRule::DiscardedTailSum);
+    }
+
+    #[test]
+    fn star_benchmark_uses_itensornetworks_leaf_root() {
+        assert_eq!(dmrg_root_name(Topology::Chain), node_name(0));
+        assert_eq!(dmrg_root_name(Topology::Star), node_name(1));
+    }
+
+    #[test]
+    fn dmrg_benchmark_runs_all_requested_sweeps() {
+        let options = benchmark_dmrg_options(4);
+        assert_eq!(options.nsweeps, 4);
+        assert_eq!(options.energy_tol, None);
+    }
+}

--- a/crates/tensor4all-core/src/krylov.rs
+++ b/crates/tensor4all-core/src/krylov.rs
@@ -6,6 +6,7 @@
 //! # Solvers
 //!
 //! - [`gmres`]: Generalized Minimal Residual Method (GMRES) for non-symmetric systems
+//! - [`hermitian_lanczos_lowest_eigenpair`]: Matrix-free lowest eigenpair solver for Hermitian operators
 //!
 //! # Future Extensions
 //!
@@ -37,8 +38,10 @@
 use crate::any_scalar::AnyScalar;
 use crate::TensorVectorSpace;
 use anyhow::Result;
+use num_complex::Complex64;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
+use tensor4all_tensorbackend::{lowest_hermitian_eigenpair, Matrix};
 
 static GMRES_OP_PROFILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -234,6 +237,258 @@ pub struct GmresResult<T> {
 
     /// Whether the solver converged.
     pub converged: bool,
+}
+
+/// Options for [`hermitian_lanczos_lowest_eigenpair`].
+///
+/// These options control the maximum Krylov subspace dimension, convergence
+/// tolerance, and validation tolerance for the small projected Hermitian matrix.
+/// When in doubt, use [`Default::default`].
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::krylov::HermitianLanczosOptions;
+///
+/// let opts = HermitianLanczosOptions {
+///     max_iter: 32,
+///     rtol: 1.0e-9,
+///     ..HermitianLanczosOptions::default()
+/// };
+/// assert_eq!(opts.max_iter, 32);
+/// assert_eq!(opts.rtol, 1.0e-9);
+/// ```
+#[derive(Debug, Clone)]
+pub struct HermitianLanczosOptions {
+    /// Maximum Krylov subspace dimension.
+    ///
+    /// Larger values usually improve convergence but increase memory and the
+    /// cost of the small Rayleigh-Ritz eigensolve. Default: `64`.
+    pub max_iter: usize,
+
+    /// Relative residual tolerance.
+    ///
+    /// Convergence requires `||A v - lambda v|| <= max(atol, rtol *
+    /// max(1, |lambda|))`. Default: `1e-10`.
+    pub rtol: f64,
+
+    /// Absolute residual tolerance.
+    ///
+    /// This is useful when targeting eigenvalues near zero. Default: `0.0`.
+    pub atol: f64,
+
+    /// Breakdown threshold for the next Krylov vector norm.
+    ///
+    /// If the orthogonalized vector norm is at or below this value, the current
+    /// Krylov subspace is treated as invariant and iteration stops. Default:
+    /// `1e-14`.
+    pub breakdown_tol: f64,
+
+    /// Hermitian validation tolerance for the projected Rayleigh-Ritz matrix.
+    ///
+    /// The projected operator is rejected when `V^dagger A V` is not Hermitian
+    /// within this absolute tolerance. Default: `1e-10`.
+    pub hermitian_tol: f64,
+
+    /// Whether to print per-iteration residual information.
+    ///
+    /// Default: `false`.
+    pub verbose: bool,
+}
+
+impl Default for HermitianLanczosOptions {
+    fn default() -> Self {
+        Self {
+            max_iter: 64,
+            rtol: 1.0e-10,
+            atol: 0.0,
+            breakdown_tol: 1.0e-14,
+            hermitian_tol: 1.0e-10,
+            verbose: false,
+        }
+    }
+}
+
+/// Result of [`hermitian_lanczos_lowest_eigenpair`].
+///
+/// Contains the lowest Ritz eigenpair, the final true residual norm, iteration
+/// count, and convergence status.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::krylov::HermitianLanczosResult;
+///
+/// let result = HermitianLanczosResult {
+///     eigenvalue: 1.0,
+///     eigenvector: vec![1.0_f64],
+///     iterations: 1,
+///     residual_norm: 0.0,
+///     converged: true,
+/// };
+/// assert!(result.converged);
+/// assert_eq!(result.eigenvalue, 1.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct HermitianLanczosResult<T> {
+    /// Lowest Ritz eigenvalue.
+    pub eigenvalue: f64,
+
+    /// Corresponding Ritz eigenvector in the original vector space.
+    pub eigenvector: T,
+
+    /// Number of Krylov operator applications used to build the final subspace.
+    pub iterations: usize,
+
+    /// True residual norm `||A v - lambda v||`.
+    pub residual_norm: f64,
+
+    /// Whether the true residual satisfied the requested tolerance.
+    pub converged: bool,
+}
+
+#[derive(Debug, Clone)]
+struct HermitianRitzState {
+    eigenvalue: f64,
+    coefficients: Vec<Complex64>,
+    iterations: usize,
+    residual_estimate: f64,
+}
+
+/// Compute the lowest eigenpair of a Hermitian matrix-free operator.
+///
+/// The operator is supplied as `apply_a`, which maps a vector to `A * vector`.
+/// The algorithm builds an orthonormal Krylov basis using modified
+/// Gram-Schmidt with a second reorthogonalization pass, forms the small
+/// projected matrix `V^dagger A V`, and solves that small Hermitian problem via
+/// tensorbackend. The full operator matrix is never materialized.
+///
+/// # Arguments
+/// * `apply_a` - Matrix-free Hermitian operator application.
+/// * `initial` - Nonzero initial vector that defines the starting Krylov vector.
+/// * `options` - Krylov dimension, convergence tolerances, and Hermitian
+///   validation settings.
+///
+/// # Returns
+/// The lowest Ritz eigenpair and the true residual norm.
+///
+/// # Errors
+/// Returns an error if the initial vector is zero, a vector-space operation
+/// fails, `apply_a` fails, the projected operator is not Hermitian, or the small
+/// projected eigensolver fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace};
+/// use tensor4all_core::krylov::{hermitian_lanczos_lowest_eigenpair, HermitianLanczosOptions};
+///
+/// let i = DynIndex::new_dyn(2);
+/// let initial = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 1.0]).unwrap();
+/// let result = hermitian_lanczos_lowest_eigenpair(
+///     |x: &TensorDynLen| Ok(x.clone()),
+///     &initial,
+///     &HermitianLanczosOptions::default(),
+/// ).unwrap();
+///
+/// assert!(result.converged);
+/// assert!((result.eigenvalue - 1.0).abs() < 1.0e-12);
+/// ```
+pub fn hermitian_lanczos_lowest_eigenpair<T, F>(
+    apply_a: F,
+    initial: &T,
+    options: &HermitianLanczosOptions,
+) -> Result<HermitianLanczosResult<T>>
+where
+    T: TensorVectorSpace,
+    F: Fn(&T) -> Result<T>,
+{
+    validate_hermitian_lanczos_options(options)?;
+    initial.validate()?;
+
+    let initial_norm = initial.norm();
+    anyhow::ensure!(
+        initial_norm > options.breakdown_tol,
+        "hermitian_lanczos_lowest_eigenpair: zero initial vector"
+    );
+
+    let mut basis = Vec::with_capacity(options.max_iter + 1);
+    basis.push(initial.scale(AnyScalar::new_real(1.0 / initial_norm))?);
+    let mut h_cols: Vec<Vec<Complex64>> = Vec::with_capacity(options.max_iter);
+    let mut last_ritz: Option<HermitianRitzState> = None;
+
+    for j in 0..options.max_iter {
+        let w = apply_a(&basis[j])?;
+        if j == 0 {
+            w.validate()?;
+        }
+
+        let mut h_col = Vec::with_capacity(j + 2);
+        let mut w_orth = w;
+
+        for v_i in basis.iter().take(j + 1) {
+            let h_ij = v_i.inner_product(&w_orth)?;
+            h_col.push(any_scalar_to_complex(&h_ij));
+            let neg_h_ij = AnyScalar::new_real(0.0) - h_ij;
+            w_orth = w_orth.axpby(AnyScalar::new_real(1.0), v_i, neg_h_ij)?;
+        }
+
+        for (i, v_i) in basis.iter().take(j + 1).enumerate() {
+            let correction = v_i.inner_product(&w_orth)?;
+            h_col[i] += any_scalar_to_complex(&correction);
+            let neg_correction = AnyScalar::new_real(0.0) - correction;
+            w_orth = w_orth.axpby(AnyScalar::new_real(1.0), v_i, neg_correction)?;
+        }
+
+        let beta = w_orth.norm();
+        h_col.push(Complex64::new(beta, 0.0));
+        h_cols.push(h_col);
+
+        let subspace_dim = j + 1;
+        let projected = projected_matrix_from_columns(&h_cols, subspace_dim);
+        let ritz = lowest_hermitian_eigenpair(&projected, options.hermitian_tol)
+            .map_err(|err| anyhow::anyhow!("projected operator is not Hermitian: {err}"))?;
+        let residual_estimate = beta * ritz.eigenvector[subspace_dim - 1].norm();
+        let threshold = hermitian_lanczos_threshold(ritz.eigenvalue, options);
+        let estimate_converged = residual_estimate <= threshold;
+
+        if options.verbose {
+            eprintln!(
+                "Hermitian Lanczos iter {}: eigenvalue={:.16e} residual_estimate={:.6e} threshold={:.6e}",
+                subspace_dim, ritz.eigenvalue, residual_estimate, threshold
+            );
+        }
+
+        let ritz_state = HermitianRitzState {
+            eigenvalue: ritz.eigenvalue,
+            iterations: subspace_dim,
+            residual_estimate,
+            coefficients: ritz.eigenvector,
+        };
+        if estimate_converged || beta <= options.breakdown_tol {
+            let result = finalize_hermitian_lanczos_result(
+                &apply_a,
+                &basis[..subspace_dim],
+                &ritz_state,
+                options,
+            )?;
+            if result.converged || beta <= options.breakdown_tol {
+                return Ok(result);
+            }
+        }
+        last_ritz = Some(ritz_state);
+        basis.push(w_orth.scale(AnyScalar::new_real(1.0 / beta))?);
+    }
+
+    let ritz_state = last_ritz.ok_or_else(|| {
+        anyhow::anyhow!("hermitian_lanczos_lowest_eigenpair: max_iter must be greater than zero")
+    })?;
+    finalize_hermitian_lanczos_result(
+        &apply_a,
+        &basis[..ritz_state.iterations],
+        &ritz_state,
+        options,
+    )
 }
 
 /// Solve `A x = b` using GMRES (Generalized Minimal Residual Method).
@@ -1743,6 +1998,139 @@ where
         residual_norm: final_rel_res,
         converged: false,
     })
+}
+
+fn validate_hermitian_lanczos_options(options: &HermitianLanczosOptions) -> Result<()> {
+    anyhow::ensure!(
+        options.max_iter > 0,
+        "hermitian_lanczos_lowest_eigenpair: max_iter must be greater than zero"
+    );
+    anyhow::ensure!(
+        options.rtol.is_finite() && options.rtol >= 0.0,
+        "hermitian_lanczos_lowest_eigenpair: rtol must be finite and non-negative"
+    );
+    anyhow::ensure!(
+        options.atol.is_finite() && options.atol >= 0.0,
+        "hermitian_lanczos_lowest_eigenpair: atol must be finite and non-negative"
+    );
+    anyhow::ensure!(
+        options.breakdown_tol.is_finite() && options.breakdown_tol >= 0.0,
+        "hermitian_lanczos_lowest_eigenpair: breakdown_tol must be finite and non-negative"
+    );
+    anyhow::ensure!(
+        options.hermitian_tol.is_finite() && options.hermitian_tol >= 0.0,
+        "hermitian_lanczos_lowest_eigenpair: hermitian_tol must be finite and non-negative"
+    );
+    Ok(())
+}
+
+fn projected_matrix_from_columns(h_cols: &[Vec<Complex64>], dim: usize) -> Matrix<Complex64> {
+    let mut data = vec![Complex64::new(0.0, 0.0); dim * dim];
+    for col in 0..dim {
+        for row in 0..dim {
+            if let Some(value) = h_cols.get(col).and_then(|h_col| h_col.get(row)) {
+                data[row + dim * col] = *value;
+            }
+        }
+    }
+    Matrix::from_col_major_vec(dim, dim, data)
+}
+
+fn any_scalar_to_complex(value: &AnyScalar) -> Complex64 {
+    value
+        .as_c64()
+        .unwrap_or_else(|| Complex64::new(value.real(), 0.0))
+}
+
+fn any_scalar_from_complex(value: Complex64, tolerance: f64) -> Result<AnyScalar> {
+    if value.im.abs() <= tolerance {
+        Ok(AnyScalar::new_real(value.re))
+    } else {
+        Ok(AnyScalar::new_complex(value.re, value.im))
+    }
+}
+
+fn hermitian_lanczos_threshold(eigenvalue: f64, options: &HermitianLanczosOptions) -> f64 {
+    options.atol.max(options.rtol * eigenvalue.abs().max(1.0))
+}
+
+fn hermitian_true_residual_norm<T, F>(apply_a: &F, eigenvector: &T, eigenvalue: f64) -> Result<f64>
+where
+    T: TensorVectorSpace,
+    F: Fn(&T) -> Result<T>,
+{
+    let av = apply_a(eigenvector)?;
+    let lambda_v = eigenvector.scale(AnyScalar::new_real(eigenvalue))?;
+    let residual = av.axpby(
+        AnyScalar::new_real(1.0),
+        &lambda_v,
+        AnyScalar::new_real(-1.0),
+    )?;
+    Ok(residual.norm())
+}
+
+fn finalize_hermitian_lanczos_result<T, F>(
+    apply_a: &F,
+    basis: &[T],
+    ritz: &HermitianRitzState,
+    options: &HermitianLanczosOptions,
+) -> Result<HermitianLanczosResult<T>>
+where
+    T: TensorVectorSpace,
+    F: Fn(&T) -> Result<T>,
+{
+    let eigenvector = combine_basis_with_coefficients(basis, &ritz.coefficients, options)?;
+    let residual_norm = hermitian_true_residual_norm(apply_a, &eigenvector, ritz.eigenvalue)?;
+    let threshold = hermitian_lanczos_threshold(ritz.eigenvalue, options);
+    let converged = residual_norm <= threshold;
+
+    if options.verbose {
+        eprintln!(
+            "Hermitian Lanczos final check iter {}: residual_estimate={:.6e} true_residual={:.6e} threshold={:.6e}",
+            ritz.iterations, ritz.residual_estimate, residual_norm, threshold
+        );
+    }
+
+    Ok(HermitianLanczosResult {
+        eigenvalue: ritz.eigenvalue,
+        eigenvector,
+        iterations: ritz.iterations,
+        residual_norm,
+        converged,
+    })
+}
+
+fn combine_basis_with_coefficients<T>(
+    basis: &[T],
+    coefficients: &[Complex64],
+    options: &HermitianLanczosOptions,
+) -> Result<T>
+where
+    T: TensorVectorSpace,
+{
+    anyhow::ensure!(
+        !basis.is_empty(),
+        "hermitian_lanczos_lowest_eigenpair: empty Krylov basis"
+    );
+    anyhow::ensure!(
+        basis.len() == coefficients.len(),
+        "hermitian_lanczos_lowest_eigenpair: coefficient length {} does not match basis length {}",
+        coefficients.len(),
+        basis.len()
+    );
+
+    let mut result = basis[0].scale(any_scalar_from_complex(
+        coefficients[0],
+        options.hermitian_tol,
+    )?)?;
+    for (basis_vector, coefficient) in basis.iter().zip(coefficients.iter()).skip(1) {
+        result = result.axpby(
+            AnyScalar::new_real(1.0),
+            basis_vector,
+            any_scalar_from_complex(*coefficient, options.hermitian_tol)?,
+        )?;
+    }
+    Ok(result)
 }
 
 /// Compute Givens rotation coefficients to eliminate b in (a, b).

--- a/crates/tensor4all-core/src/krylov/tests/mod.rs
+++ b/crates/tensor4all-core/src/krylov/tests/mod.rs
@@ -4,6 +4,7 @@ use crate::defaults::DynIndex;
 use crate::tensor_index::TensorIndex;
 use crate::TensorVectorSpace;
 use num_complex::Complex64;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 static GMRES_PROFILE_ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -108,6 +109,122 @@ impl TensorVectorSpace for PlainVector {
     fn maxabs(&self) -> f64 {
         self.data.iter().map(|x| x.abs()).fold(0.0, f64::max)
     }
+}
+
+#[test]
+fn hermitian_lanczos_lowest_eigenpair_diagonal_plain_vector() {
+    let apply = |x: &PlainVector| -> Result<PlainVector> {
+        Ok(PlainVector {
+            data: vec![2.0 * x.data[0], -x.data[1], 4.0 * x.data[2]],
+        })
+    };
+    let initial = PlainVector {
+        data: vec![1.0, 1.0, 1.0],
+    };
+
+    let result =
+        hermitian_lanczos_lowest_eigenpair(apply, &initial, &HermitianLanczosOptions::default())
+            .unwrap();
+
+    assert!(result.converged, "residual={}", result.residual_norm);
+    assert!((result.eigenvalue + 1.0).abs() < 1.0e-10);
+    assert!(result.residual_norm < 1.0e-8);
+    assert!((result.eigenvector.data[1].abs() - 1.0).abs() < 1.0e-8);
+}
+
+#[test]
+fn hermitian_lanczos_avoids_true_residual_matvec_on_every_iteration() {
+    let apply_calls = AtomicUsize::new(0);
+    let apply = |x: &PlainVector| -> Result<PlainVector> {
+        apply_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(PlainVector {
+            data: vec![2.0 * x.data[0], -x.data[1], 4.0 * x.data[2]],
+        })
+    };
+    let initial = PlainVector {
+        data: vec![1.0, 1.0, 1.0],
+    };
+
+    let result = hermitian_lanczos_lowest_eigenpair(
+        apply,
+        &initial,
+        &HermitianLanczosOptions {
+            max_iter: 3,
+            rtol: 1.0e-12,
+            ..HermitianLanczosOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.converged, "residual={}", result.residual_norm);
+    assert_eq!(result.iterations, 3);
+    assert_eq!(apply_calls.load(Ordering::Relaxed), result.iterations + 1);
+}
+
+#[test]
+fn hermitian_lanczos_lowest_eigenpair_rejects_zero_initial_vector() {
+    let apply = |x: &PlainVector| -> Result<PlainVector> { Ok(x.clone()) };
+    let initial = PlainVector {
+        data: vec![0.0, 0.0],
+    };
+
+    let err =
+        hermitian_lanczos_lowest_eigenpair(apply, &initial, &HermitianLanczosOptions::default())
+            .unwrap_err();
+
+    assert!(err.to_string().contains("zero initial vector"));
+}
+
+#[test]
+fn hermitian_lanczos_lowest_eigenpair_complex_pauli_y() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_c64(
+        vec![Complex64::new(1.0, 0.0), Complex64::new(0.25, 0.5)],
+        &idx,
+    );
+    let minus_i = Complex64::new(0.0, -1.0);
+    let plus_i = Complex64::new(0.0, 1.0);
+    let pauli_y = [
+        Complex64::new(0.0, 0.0),
+        minus_i,
+        plus_i,
+        Complex64::new(0.0, 0.0),
+    ];
+
+    let result = hermitian_lanczos_lowest_eigenpair(
+        |x: &TensorDynLen| apply_matrix2_c64(x, &pauli_y),
+        &initial,
+        &HermitianLanczosOptions {
+            max_iter: 4,
+            rtol: 1.0e-12,
+            ..HermitianLanczosOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.converged, "residual={}", result.residual_norm);
+    assert!((result.eigenvalue + 1.0).abs() < 1.0e-10);
+    assert!(result.residual_norm < 1.0e-8);
+}
+
+#[test]
+fn hermitian_lanczos_lowest_eigenpair_rejects_non_hermitian_projection() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_with_index(vec![1.0, 1.0], &idx);
+    let non_hermitian = [0.0, 1.0, 0.0, 0.0];
+
+    let err = hermitian_lanczos_lowest_eigenpair(
+        |x: &TensorDynLen| apply_matrix2_f64(x, &non_hermitian),
+        &initial,
+        &HermitianLanczosOptions {
+            max_iter: 2,
+            rtol: 0.0,
+            ..HermitianLanczosOptions::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("not Hermitian"));
 }
 
 #[test]

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -36,9 +36,10 @@ pub use backend::{
 };
 pub use context::{default_eager_ctx, with_default_backend};
 pub use matrix::{
-    batched_mat_mul_same_shape, batched_mat_mul_same_shape_owned, from_vec2d, mat_mul,
-    mat_mul_owned, submatrix, submatrix_argmax, swap_cols, swap_rows, transpose, try_from_vec2d,
-    BlasMul, Matrix, MatrixScalar, MatrixShapeError, MatrixTensorConversionError,
+    batched_mat_mul_same_shape, batched_mat_mul_same_shape_owned, from_vec2d,
+    lowest_hermitian_eigenpair, mat_mul, mat_mul_owned, submatrix, submatrix_argmax, swap_cols,
+    swap_rows, transpose, try_from_vec2d, BlasMul, HermitianEigenError, HermitianEigenScalar,
+    HermitianEigenpair, Matrix, MatrixScalar, MatrixShapeError, MatrixTensorConversionError,
 };
 pub use memory::{release_process_allocator_cached_memory, AllocatorPressureRelief};
 pub use storage::{

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -24,6 +24,7 @@ use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 use std::ops::{Index, IndexMut};
 use tenferro::{Tensor, TensorScalar, TypedTensor};
+use tenferro_ad::EagerTensor;
 use tenferro_tensor::BackendSessionHost;
 
 /// A dense 2D matrix in column-major layout.
@@ -115,6 +116,153 @@ pub enum MatrixShapeError {
         /// Actual number of entries in `row`.
         actual: usize,
     },
+}
+
+/// Error returned by [`lowest_hermitian_eigenpair`].
+///
+/// The eigensolver is intended for small Rayleigh-Ritz projected matrices. It
+/// validates shape and Hermitian structure before calling the backend Hermitian
+/// eigendecomposition, so non-Hermitian effective operators are rejected
+/// explicitly instead of silently taking a real part.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum HermitianEigenError {
+    /// The matrix has zero rows and columns, so it has no eigenpair.
+    #[error("Hermitian eigenpair requires a non-empty matrix")]
+    Empty,
+    /// The input is not square.
+    #[error("Hermitian eigenpair requires a square matrix, got {nrows}x{ncols}")]
+    NonSquare {
+        /// Number of matrix rows.
+        nrows: usize,
+        /// Number of matrix columns.
+        ncols: usize,
+    },
+    /// The Hermitian validation tolerance was negative or not finite.
+    #[error("Hermitian tolerance must be finite and non-negative, got {tolerance}")]
+    InvalidTolerance {
+        /// Rejected tolerance value.
+        tolerance: f64,
+    },
+    /// A matrix entry violates `A[i, j] = conj(A[j, i])` within tolerance.
+    #[error(
+        "matrix is not Hermitian at ({row}, {col}): difference {difference} exceeds tolerance {tolerance}"
+    )]
+    NonHermitian {
+        /// Row of the first offending entry.
+        row: usize,
+        /// Column of the first offending entry.
+        col: usize,
+        /// Absolute Hermitian residual for the offending pair.
+        difference: f64,
+        /// Tolerance used for validation.
+        tolerance: f64,
+    },
+    /// The backend returned an output with an unexpected dtype.
+    #[error("{output} output dtype mismatch: expected {expected}, got {actual}")]
+    DType {
+        /// Output tensor name.
+        output: &'static str,
+        /// Expected dtype string.
+        expected: String,
+        /// Actual dtype string.
+        actual: String,
+    },
+    /// The backend returned an output with an unexpected shape.
+    #[error("{output} output shape mismatch: expected {expected:?}, got {actual:?}")]
+    Shape {
+        /// Output tensor name.
+        output: &'static str,
+        /// Expected shape.
+        expected: Vec<usize>,
+        /// Actual shape.
+        actual: Vec<usize>,
+    },
+    /// A Hermitian backend eigenvalue had a non-negligible imaginary part.
+    #[error(
+        "Hermitian eigenvalue {index} has imaginary part {imaginary}, exceeding tolerance {tolerance}"
+    )]
+    NonRealEigenvalue {
+        /// Eigenvalue position in the backend output.
+        index: usize,
+        /// Absolute imaginary part.
+        imaginary: f64,
+        /// Tolerance used for validation.
+        tolerance: f64,
+    },
+    /// The tenferro backend rejected or failed the eigendecomposition.
+    #[error("Hermitian eigendecomposition failed: {message}")]
+    Backend {
+        /// Backend error message.
+        message: String,
+    },
+}
+
+/// Small Hermitian eigenpair returned by [`lowest_hermitian_eigenpair`].
+///
+/// `eigenvector` stores the Ritz vector coefficients in ordinary vector order.
+/// It has length equal to the input matrix dimension and is normalized according
+/// to the backend eigendecomposition.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HermitianEigenpair<T> {
+    /// Smallest eigenvalue of the Hermitian matrix.
+    pub eigenvalue: f64,
+    /// Corresponding eigenvector coefficients.
+    pub eigenvector: Vec<T>,
+}
+
+/// Scalar types supported by [`lowest_hermitian_eigenpair`].
+///
+/// The current backend path is used for `f64` and `Complex64`, which are the
+/// scalar types needed by tensor4all's Hermitian Krylov and DMRG algorithms.
+pub trait HermitianEigenScalar: TensorScalar + MatrixScalar {
+    #[doc(hidden)]
+    fn hermitian_difference(a_ij: Self, a_ji: Self) -> f64;
+
+    #[doc(hidden)]
+    fn eigenvalues_from_tensor(
+        tensor: Tensor,
+        tolerance: f64,
+    ) -> std::result::Result<(Vec<usize>, Vec<f64>), HermitianEigenError>;
+}
+
+impl HermitianEigenScalar for f64 {
+    fn hermitian_difference(a_ij: Self, a_ji: Self) -> f64 {
+        (a_ij - a_ji).abs()
+    }
+
+    fn eigenvalues_from_tensor(
+        tensor: Tensor,
+        _tolerance: f64,
+    ) -> std::result::Result<(Vec<usize>, Vec<f64>), HermitianEigenError> {
+        let values = typed_eigh_output::<f64>("eigenvalues", tensor)?;
+        Ok((values.shape().to_vec(), values.as_slice().to_vec()))
+    }
+}
+
+impl HermitianEigenScalar for Complex64 {
+    fn hermitian_difference(a_ij: Self, a_ji: Self) -> f64 {
+        (a_ij - a_ji.conj()).norm()
+    }
+
+    fn eigenvalues_from_tensor(
+        tensor: Tensor,
+        tolerance: f64,
+    ) -> std::result::Result<(Vec<usize>, Vec<f64>), HermitianEigenError> {
+        let values = typed_eigh_output::<Complex64>("eigenvalues", tensor)?;
+        let mut real_values = Vec::with_capacity(values.as_slice().len());
+        for (index, value) in values.as_slice().iter().copied().enumerate() {
+            let imaginary = value.im.abs();
+            if imaginary > tolerance {
+                return Err(HermitianEigenError::NonRealEigenvalue {
+                    index,
+                    imaginary,
+                    tolerance,
+                });
+            }
+            real_values.push(value.re);
+        }
+        Ok((values.shape().to_vec(), real_values))
+    }
 }
 
 impl<T> Matrix<T> {
@@ -290,6 +438,147 @@ impl<T> Matrix<T> {
     pub fn ncols(&self) -> usize {
         self.ncols
     }
+}
+
+/// Compute the smallest eigenpair of a small Hermitian projected matrix.
+///
+/// This function validates that `matrix` is square, non-empty, and Hermitian
+/// within `hermitian_tol`, then calls tenferro's Hermitian eigendecomposition.
+/// It is intended for Rayleigh-Ritz projected Krylov matrices, whose dimension
+/// is bounded by the Krylov subspace size. It must not be used to materialize a
+/// full tensor-network effective Hamiltonian.
+///
+/// # Arguments
+/// * `matrix` - Small dense Hermitian matrix in column-major [`Matrix`] layout.
+/// * `hermitian_tol` - Absolute tolerance for `A[i, j] = conj(A[j, i])`.
+///   Typical values are `1e-12` for `f64`/`Complex64` projected matrices.
+///
+/// # Returns
+/// The smallest real eigenvalue and the corresponding normalized eigenvector
+/// coefficients.
+///
+/// # Errors
+/// Returns [`HermitianEigenError`] if the matrix is empty, non-square,
+/// non-Hermitian within `hermitian_tol`, or if the backend eigendecomposition
+/// fails or returns an unexpected dtype/shape.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{lowest_hermitian_eigenpair, Matrix};
+///
+/// let matrix = Matrix::from_col_major_vec(2, 2, vec![2.0_f64, 1.0, 1.0, 2.0]);
+/// let pair = lowest_hermitian_eigenpair(&matrix, 1.0e-12).unwrap();
+///
+/// assert!((pair.eigenvalue - 1.0).abs() < 1.0e-12);
+/// assert_eq!(pair.eigenvector.len(), 2);
+/// ```
+pub fn lowest_hermitian_eigenpair<T>(
+    matrix: &Matrix<T>,
+    hermitian_tol: f64,
+) -> std::result::Result<HermitianEigenpair<T>, HermitianEigenError>
+where
+    T: HermitianEigenScalar,
+{
+    validate_hermitian_matrix(matrix, hermitian_tol)?;
+
+    let n = matrix.nrows();
+    let input_tensor = T::into_tensor(vec![n, n], matrix.as_col_major_slice().to_vec());
+    let input = EagerTensor::from_tensor_in(input_tensor, crate::default_eager_ctx());
+    let (values, vectors) = tenferro_linalg::eager_tensor::eigh(&input).map_err(|source| {
+        HermitianEigenError::Backend {
+            message: source.to_string(),
+        }
+    })?;
+
+    let (values_shape, values) = T::eigenvalues_from_tensor(values.data().clone(), hermitian_tol)?;
+    ensure_eigh_shape("eigenvalues", &values_shape, &[n])?;
+    let vectors = typed_eigh_output::<T>("eigenvectors", vectors.data().clone())?;
+    ensure_eigh_shape("eigenvectors", vectors.shape(), &[n, n])?;
+
+    let (min_col, eigenvalue) = values
+        .iter()
+        .copied()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.total_cmp(b))
+        .ok_or(HermitianEigenError::Empty)?;
+
+    let vector_data = vectors.as_slice();
+    let start = n * min_col;
+    let eigenvector = vector_data[start..start + n].to_vec();
+
+    Ok(HermitianEigenpair {
+        eigenvalue,
+        eigenvector,
+    })
+}
+
+fn validate_hermitian_matrix<T>(
+    matrix: &Matrix<T>,
+    hermitian_tol: f64,
+) -> std::result::Result<(), HermitianEigenError>
+where
+    T: HermitianEigenScalar,
+{
+    if !hermitian_tol.is_finite() || hermitian_tol < 0.0 {
+        return Err(HermitianEigenError::InvalidTolerance {
+            tolerance: hermitian_tol,
+        });
+    }
+    if matrix.nrows() != matrix.ncols() {
+        return Err(HermitianEigenError::NonSquare {
+            nrows: matrix.nrows(),
+            ncols: matrix.ncols(),
+        });
+    }
+    if matrix.nrows() == 0 {
+        return Err(HermitianEigenError::Empty);
+    }
+
+    for col in 0..matrix.ncols() {
+        for row in 0..=col {
+            let difference = T::hermitian_difference(matrix[[row, col]], matrix[[col, row]]);
+            if difference > hermitian_tol {
+                return Err(HermitianEigenError::NonHermitian {
+                    row,
+                    col,
+                    difference,
+                    tolerance: hermitian_tol,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn typed_eigh_output<T>(
+    output: &'static str,
+    tensor: Tensor,
+) -> std::result::Result<TypedTensor<T>, HermitianEigenError>
+where
+    T: TensorScalar,
+{
+    let actual = tensor.dtype();
+    T::try_into_typed(tensor).ok_or_else(|| HermitianEigenError::DType {
+        output,
+        expected: format!("{:?}", T::dtype()),
+        actual: format!("{actual:?}"),
+    })
+}
+
+fn ensure_eigh_shape(
+    output: &'static str,
+    actual: &[usize],
+    expected: &[usize],
+) -> std::result::Result<(), HermitianEigenError> {
+    if actual != expected {
+        return Err(HermitianEigenError::Shape {
+            output,
+            expected: expected.to_vec(),
+            actual: actual.to_vec(),
+        });
+    }
+    Ok(())
 }
 
 impl<T: Clone> Matrix<T> {

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -1,5 +1,90 @@
 use super::*;
+use num_complex::Complex64;
 use tenferro::TypedTensor;
+
+fn real_eigen_residual_norm(matrix: &Matrix<f64>, eigenvalue: f64, vector: &[f64]) -> f64 {
+    let mut max_abs = 0.0_f64;
+    for row in 0..matrix.nrows() {
+        let mut av = 0.0;
+        for col in 0..matrix.ncols() {
+            av += matrix[[row, col]] * vector[col];
+        }
+        max_abs = max_abs.max((av - eigenvalue * vector[row]).abs());
+    }
+    max_abs
+}
+
+fn complex_eigen_residual_norm(
+    matrix: &Matrix<Complex64>,
+    eigenvalue: f64,
+    vector: &[Complex64],
+) -> f64 {
+    let mut max_abs = 0.0_f64;
+    for row in 0..matrix.nrows() {
+        let mut av = Complex64::new(0.0, 0.0);
+        for col in 0..matrix.ncols() {
+            av += matrix[[row, col]] * vector[col];
+        }
+        max_abs = max_abs.max((av - vector[row] * eigenvalue).norm());
+    }
+    max_abs
+}
+
+#[test]
+fn projected_hermitian_lowest_eigenpair_works_for_one_by_one() {
+    let matrix = Matrix::from_col_major_vec(1, 1, vec![3.5_f64]);
+
+    let pair = lowest_hermitian_eigenpair(&matrix, 1.0e-12).unwrap();
+
+    assert!((pair.eigenvalue - 3.5).abs() < 1.0e-12);
+    assert_eq!(pair.eigenvector.len(), 1);
+    assert!((pair.eigenvector[0].abs() - 1.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn projected_hermitian_lowest_eigenpair_works_for_real_symmetric_matrix() {
+    let matrix = Matrix::from_col_major_vec(2, 2, vec![2.0_f64, 1.0, 1.0, 2.0]);
+
+    let pair = lowest_hermitian_eigenpair(&matrix, 1.0e-12).unwrap();
+
+    assert!((pair.eigenvalue - 1.0).abs() < 1.0e-12);
+    assert!(real_eigen_residual_norm(&matrix, pair.eigenvalue, &pair.eigenvector) < 1.0e-10);
+}
+
+#[test]
+fn projected_hermitian_lowest_eigenpair_works_for_complex_hermitian_matrix() {
+    let i = Complex64::new(0.0, 1.0);
+    let matrix = Matrix::from_col_major_vec(
+        2,
+        2,
+        vec![Complex64::new(0.0, 0.0), i, -i, Complex64::new(0.0, 0.0)],
+    );
+
+    let pair = lowest_hermitian_eigenpair(&matrix, 1.0e-12).unwrap();
+
+    assert!((pair.eigenvalue + 1.0).abs() < 1.0e-12);
+    assert!(complex_eigen_residual_norm(&matrix, pair.eigenvalue, &pair.eigenvector) < 1.0e-10);
+}
+
+#[test]
+fn projected_hermitian_lowest_eigenpair_accepts_degenerate_smallest_eigenvalues() {
+    let matrix = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 1.0]);
+
+    let pair = lowest_hermitian_eigenpair(&matrix, 1.0e-12).unwrap();
+
+    assert!((pair.eigenvalue - 1.0).abs() < 1.0e-12);
+    assert!(real_eigen_residual_norm(&matrix, pair.eigenvalue, &pair.eigenvector) < 1.0e-10);
+}
+
+#[test]
+fn projected_hermitian_lowest_eigenpair_rejects_non_hermitian_diagonal() {
+    let matrix = Matrix::from_col_major_vec(1, 1, vec![Complex64::new(1.0, 1.0e-3)]);
+
+    let err = lowest_hermitian_eigenpair(&matrix, 1.0e-12).unwrap_err();
+
+    assert!(matches!(err, HermitianEigenError::NonHermitian { .. }));
+    assert!(err.to_string().contains("not Hermitian"));
+}
 
 #[test]
 fn test_matrix_basic() {

--- a/crates/tensor4all-treetn/examples/benchmark_dmrg.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_dmrg.rs
@@ -1,0 +1,1 @@
+include!("../../../benchmarks/rust/benchmark_dmrg.rs");

--- a/crates/tensor4all-treetn/src/dmrg/mod.rs
+++ b/crates/tensor4all-treetn/src/dmrg/mod.rs
@@ -1,0 +1,920 @@
+//! Two-site DMRG for TreeTN states.
+//!
+//! This module implements the first TreeTN DMRG path: two-site sweeps with a
+//! Hermitian projected local eigensolver. The production algorithm contracts
+//! only local regions and their environments; full TreeTN materialization is
+//! reserved for small tests and external benchmark validation.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::{Arc, RwLock};
+
+use tensor4all_core::krylov::{hermitian_lanczos_lowest_eigenpair, HermitianLanczosOptions};
+use tensor4all_core::{AnyScalar, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorLike};
+use thiserror::Error;
+
+use crate::linsolve::common::ProjectedOperator;
+use crate::linsolve::square::local_linop::LocalLinOp;
+use crate::local_update_support::{
+    build_subtree_topology, contract_region, copy_decomposed_to_subtree,
+    initialize_reference_state_if_empty, sync_reference_state_region,
+};
+use crate::operator::{IndexMapping, LinearOperator};
+use crate::{
+    apply_local_update_sweep, factorize_tensor_to_treetn_with, CanonicalizationOptions,
+    LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater, TreeTN,
+};
+
+type SiteMappings<V, I> = (HashMap<V, IndexMapping<I>>, HashMap<V, IndexMapping<I>>);
+
+/// Errors reported by TreeTN DMRG.
+///
+/// This error type covers unsupported v1 API shapes, invalid options, and
+/// numerical failures from local Hermitian eigensolves.
+#[derive(Debug, Error)]
+pub enum DmrgError {
+    /// The requested local update size is not implemented.
+    #[error("DMRG supports only nsite={supported} in this version, got nsite={requested}")]
+    UnsupportedNsite {
+        /// Requested number of sites per local update.
+        requested: usize,
+        /// Supported number of sites per local update.
+        supported: usize,
+    },
+
+    /// A numeric or algorithm option is invalid.
+    #[error("invalid DMRG option {option}: {reason}")]
+    InvalidOption {
+        /// Option name.
+        option: &'static str,
+        /// Why the value is invalid.
+        reason: String,
+    },
+
+    /// The requested sweep center does not exist in the state.
+    #[error("DMRG center {center} is not a state node")]
+    MissingCenter {
+        /// Debug representation of the missing center.
+        center: String,
+    },
+
+    /// Two-site DMRG cannot run because there is no update edge.
+    #[error("two-site DMRG requires at least one state edge")]
+    EmptyTwoSiteSweep,
+
+    /// The operator and state do not share the same tree topology.
+    #[error("DMRG requires the operator and state to have the same tree topology")]
+    TopologyMismatch,
+
+    /// The initial v1 implementation supports one physical site index per node.
+    #[error("DMRG v1 requires exactly one state site index at node {node}, found {count}")]
+    UnsupportedStateSiteCount {
+        /// Debug representation of the node.
+        node: String,
+        /// Number of state site indices found.
+        count: usize,
+    },
+
+    /// The initial v1 implementation supports one input/output mapping per node.
+    #[error("DMRG v1 requires exactly one {role} mapping at node {node}, found {count}")]
+    UnsupportedMultipleSiteMappings {
+        /// Debug representation of the node.
+        node: String,
+        /// Mapping role, either input or output.
+        role: &'static str,
+        /// Number of mappings found.
+        count: usize,
+    },
+
+    /// A required input/output mapping is missing.
+    #[error("DMRG missing {role} mapping at node {node}")]
+    MissingMapping {
+        /// Debug representation of the node.
+        node: String,
+        /// Mapping role, either input or output.
+        role: &'static str,
+    },
+
+    /// A mapping does not describe the same state vector space.
+    #[error("invalid DMRG mapping at node {node}: {reason}")]
+    InvalidMapping {
+        /// Debug representation of the node.
+        node: String,
+        /// Why the mapping is invalid.
+        reason: String,
+    },
+
+    /// A scalar expected to be real has a significant imaginary part.
+    #[error("{context} is not real within tolerance {tolerance}: real={real}, imag={imag}")]
+    NonRealScalar {
+        /// Computation that produced the scalar.
+        context: &'static str,
+        /// Real part.
+        real: f64,
+        /// Imaginary part.
+        imag: f64,
+        /// Absolute tolerance used for the check.
+        tolerance: f64,
+    },
+
+    /// A Rayleigh quotient denominator was numerically zero.
+    #[error("DMRG Rayleigh quotient denominator is zero")]
+    ZeroNormState,
+
+    /// A lower-level TreeTN or Krylov operation failed.
+    #[error("{context}: {source}")]
+    Algorithm {
+        /// Context for the failing operation.
+        context: &'static str,
+        /// Source error.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+/// Options for two-site TreeTN DMRG.
+///
+/// `DmrgOptions::default()` runs two-site sweeps with exact SVD splitting
+/// unless `max_bond_dim` or `svd_policy` are set. Use `with_nsweeps` to control
+/// the number of full sweeps and `with_lanczos_options` to tune the local
+/// Hermitian eigensolver.
+///
+/// # Examples
+/// ```
+/// use tensor4all_treetn::DmrgOptions;
+///
+/// let options = DmrgOptions::default()
+///     .with_nsweeps(4)
+///     .with_max_bond_dim(32)
+///     .with_energy_tol(1e-10);
+///
+/// assert_eq!(options.nsite, 2);
+/// assert_eq!(options.nsweeps, 4);
+/// assert_eq!(options.max_bond_dim, Some(32));
+/// ```
+#[derive(Debug, Clone)]
+pub struct DmrgOptions {
+    /// Number of sites optimized in each local update.
+    ///
+    /// The v1 implementation supports only `2`. `1` is rejected explicitly so
+    /// callers do not accidentally run a different algorithm.
+    pub nsite: usize,
+    /// Number of full sweeps over the tree.
+    ///
+    /// Typical small validation runs use `1` to `4`; larger Hamiltonians often
+    /// need more sweeps depending on the initial state.
+    pub nsweeps: usize,
+    /// Optional maximum bond dimension after each two-site split.
+    ///
+    /// `None` keeps all singular vectors allowed by the SVD truncation policy.
+    pub max_bond_dim: Option<usize>,
+    /// Optional SVD truncation policy applied after each local optimization.
+    ///
+    /// Use `SvdTruncationPolicy::new(rtol)` for relative singular-value
+    /// truncation. `None` uses exact splitting except for `max_bond_dim`.
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// Local Hermitian Lanczos eigensolver options.
+    ///
+    /// `hermitian_tol` controls projected Hermitian checks and the accepted
+    /// imaginary part of projected eigenvalues.
+    pub lanczos: HermitianLanczosOptions,
+    /// Optional convergence tolerance for sweep-to-sweep energy changes.
+    ///
+    /// When `None`, all requested sweeps are run.
+    pub energy_tol: Option<f64>,
+    /// Absolute tolerance for checking scalar quantities that should be real.
+    ///
+    /// This is used for Rayleigh quotient numerator and denominator checks.
+    pub real_scalar_tol: f64,
+    /// Whether to print per-sweep diagnostic lines to stderr.
+    pub verbose: bool,
+}
+
+impl Default for DmrgOptions {
+    fn default() -> Self {
+        Self {
+            nsite: 2,
+            nsweeps: 5,
+            max_bond_dim: None,
+            svd_policy: None,
+            lanczos: HermitianLanczosOptions::default(),
+            energy_tol: None,
+            real_scalar_tol: 1e-10,
+            verbose: false,
+        }
+    }
+}
+
+impl DmrgOptions {
+    /// Set the local update size.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let options = DmrgOptions::default().with_nsite(2);
+    /// assert_eq!(options.nsite, 2);
+    /// ```
+    pub fn with_nsite(mut self, nsite: usize) -> Self {
+        self.nsite = nsite;
+        self
+    }
+
+    /// Set the number of full sweeps.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let options = DmrgOptions::default().with_nsweeps(3);
+    /// assert_eq!(options.nsweeps, 3);
+    /// ```
+    pub fn with_nsweeps(mut self, nsweeps: usize) -> Self {
+        self.nsweeps = nsweeps;
+        self
+    }
+
+    /// Set the maximum bond dimension after local SVD splitting.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let options = DmrgOptions::default().with_max_bond_dim(16);
+    /// assert_eq!(options.max_bond_dim, Some(16));
+    /// ```
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
+        self
+    }
+
+    /// Set the SVD truncation policy after local optimization.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::SvdTruncationPolicy;
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let policy = SvdTruncationPolicy::new(1e-9);
+    /// let options = DmrgOptions::default().with_svd_policy(policy);
+    /// assert_eq!(options.svd_policy, Some(policy));
+    /// ```
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set local Hermitian Lanczos options.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::krylov::HermitianLanczosOptions;
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let lanczos = HermitianLanczosOptions { max_iter: 8, ..Default::default() };
+    /// let options = DmrgOptions::default().with_lanczos_options(lanczos.clone());
+    /// assert_eq!(options.lanczos.max_iter, 8);
+    /// ```
+    pub fn with_lanczos_options(mut self, lanczos: HermitianLanczosOptions) -> Self {
+        self.lanczos = lanczos;
+        self
+    }
+
+    /// Set the sweep energy convergence tolerance.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let options = DmrgOptions::default().with_energy_tol(1e-8);
+    /// assert_eq!(options.energy_tol, Some(1e-8));
+    /// ```
+    pub fn with_energy_tol(mut self, energy_tol: f64) -> Self {
+        self.energy_tol = Some(energy_tol);
+        self
+    }
+
+    /// Set the tolerance for real scalar checks.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::DmrgOptions;
+    ///
+    /// let options = DmrgOptions::default().with_real_scalar_tol(1e-12);
+    /// assert_eq!(options.real_scalar_tol, 1e-12);
+    /// ```
+    pub fn with_real_scalar_tol(mut self, tolerance: f64) -> Self {
+        self.real_scalar_tol = tolerance;
+        self
+    }
+}
+
+/// Result returned by two-site TreeTN DMRG.
+///
+/// The `energy` is evaluated from the final state by a local Rayleigh quotient
+/// through the projected operator, not by materializing the full tensor network.
+#[derive(Debug, Clone)]
+pub struct DmrgResult<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    /// Optimized TreeTN state.
+    pub state: TreeTN<T, V>,
+    /// Final Rayleigh quotient energy.
+    pub energy: f64,
+    /// Number of full sweeps completed.
+    pub sweeps_completed: usize,
+    /// Number of local two-site updates performed.
+    pub local_updates: usize,
+    /// Whether the sweep-to-sweep energy tolerance was reached.
+    pub converged: bool,
+    /// Maximum true local residual norm reported by the Hermitian eigensolver.
+    pub max_residual_norm: f64,
+}
+
+struct DmrgUpdater<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    projected_operator: Arc<RwLock<ProjectedOperator<T, V>>>,
+    options: DmrgOptions,
+    reference_state: TreeTN<T, V>,
+    local_updates: usize,
+    last_energy: Option<f64>,
+    max_residual_norm: f64,
+}
+
+impl<T, V> DmrgUpdater<T, V>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id:
+        Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug + 'static,
+{
+    fn new(
+        operator: TreeTN<T, V>,
+        input_mapping: HashMap<V, IndexMapping<T::Index>>,
+        output_mapping: HashMap<V, IndexMapping<T::Index>>,
+        options: DmrgOptions,
+    ) -> Self {
+        Self {
+            projected_operator: Arc::new(RwLock::new(ProjectedOperator::with_index_mappings(
+                operator,
+                input_mapping,
+                output_mapping,
+            ))),
+            options,
+            reference_state: TreeTN::new(),
+            local_updates: 0,
+            last_energy: None,
+            max_residual_norm: 0.0,
+        }
+    }
+
+    fn solve_local(
+        &mut self,
+        region: &[V],
+        init: &T,
+        state: &TreeTN<T, V>,
+    ) -> Result<T, DmrgError> {
+        let linop = LocalLinOp::new(
+            Arc::clone(&self.projected_operator),
+            region.to_vec(),
+            state,
+            &self.reference_state,
+        );
+
+        let result = hermitian_lanczos_lowest_eigenpair(
+            |x: &T| linop.apply_projected(x),
+            init,
+            &self.options.lanczos,
+        )
+        .map_err(|source| DmrgError::Algorithm {
+            context: "DMRG local Hermitian eigensolve failed",
+            source,
+        })?;
+
+        self.last_energy = Some(result.eigenvalue);
+        self.max_residual_norm = self.max_residual_norm.max(result.residual_norm);
+        Ok(result.eigenvector)
+    }
+
+    fn rayleigh_quotient(&self, state: &TreeTN<T, V>, region: &[V]) -> Result<f64, DmrgError> {
+        let subtree = state
+            .extract_subtree(region)
+            .map_err(|source| DmrgError::Algorithm {
+                context: "DMRG failed to extract final Rayleigh region",
+                source,
+            })?;
+        let local = contract_region(&subtree, region).map_err(|source| DmrgError::Algorithm {
+            context: "DMRG failed to contract final Rayleigh region",
+            source,
+        })?;
+        let linop = LocalLinOp::new(
+            Arc::clone(&self.projected_operator),
+            region.to_vec(),
+            state,
+            &self.reference_state,
+        );
+        let h_local = linop
+            .apply_projected(&local)
+            .map_err(|source| DmrgError::Algorithm {
+                context: "DMRG failed to apply final projected operator",
+                source,
+            })?;
+        let numerator = local
+            .inner_product(&h_local)
+            .map_err(|source| DmrgError::Algorithm {
+                context: "DMRG failed to compute Rayleigh numerator",
+                source,
+            })?;
+        let denominator = local
+            .inner_product(&local)
+            .map_err(|source| DmrgError::Algorithm {
+                context: "DMRG failed to compute Rayleigh denominator",
+                source,
+            })?;
+
+        let numerator = checked_real_scalar(
+            &numerator,
+            self.options.real_scalar_tol,
+            "Rayleigh numerator",
+        )?;
+        let denominator = checked_real_scalar(
+            &denominator,
+            self.options.real_scalar_tol,
+            "Rayleigh denominator",
+        )?;
+        if denominator.abs() <= self.options.real_scalar_tol {
+            return Err(DmrgError::ZeroNormState);
+        }
+        Ok(numerator / denominator)
+    }
+}
+
+impl<T, V> LocalUpdater<T, V> for DmrgUpdater<T, V>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id:
+        Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug + 'static,
+{
+    fn before_step(
+        &mut self,
+        step: &LocalUpdateStep<V>,
+        full_treetn_before: &TreeTN<T, V>,
+    ) -> anyhow::Result<()> {
+        if step.nodes.len() != 2 {
+            return Err(anyhow::Error::new(DmrgError::UnsupportedNsite {
+                requested: step.nodes.len(),
+                supported: 2,
+            }));
+        }
+        initialize_reference_state_if_empty(&mut self.reference_state, full_treetn_before)?;
+        Ok(())
+    }
+
+    fn update(
+        &mut self,
+        mut subtree: TreeTN<T, V>,
+        step: &LocalUpdateStep<V>,
+        full_treetn: &TreeTN<T, V>,
+    ) -> anyhow::Result<TreeTN<T, V>> {
+        let init_local = contract_region(&subtree, &step.nodes)?;
+        let solved_local = self
+            .solve_local(&step.nodes, &init_local, full_treetn)
+            .map_err(anyhow::Error::new)?;
+
+        let topology = build_subtree_topology(&solved_local, &step.nodes, full_treetn)?;
+        let mut factorize_options = FactorizeOptions::svd();
+        if let Some(max_rank) = self.options.max_bond_dim {
+            factorize_options = factorize_options.with_max_rank(max_rank);
+        }
+        if let Some(policy) = self.options.svd_policy {
+            factorize_options = factorize_options.with_svd_policy(policy);
+        }
+
+        let decomposed = factorize_tensor_to_treetn_with(
+            &solved_local,
+            &topology,
+            factorize_options,
+            &step.new_center,
+        )?;
+        copy_decomposed_to_subtree(&mut subtree, &decomposed, &step.nodes, full_treetn)?;
+
+        subtree.set_canonical_region([step.new_center.clone()])?;
+        if let Some(edges) = subtree.edges_to_canonicalize_by_names(&step.new_center) {
+            for (from, to) in edges {
+                if let Some(edge) = subtree.edge_between(&from, &to) {
+                    subtree.set_edge_ortho_towards(edge, Some(to))?;
+                }
+            }
+        }
+
+        self.local_updates += 1;
+        Ok(subtree)
+    }
+
+    fn after_step(
+        &mut self,
+        step: &LocalUpdateStep<V>,
+        full_treetn_after: &TreeTN<T, V>,
+    ) -> anyhow::Result<()> {
+        sync_reference_state_region(&mut self.reference_state, None, step, full_treetn_after)?;
+        let topology = full_treetn_after.site_index_network();
+        let mut projected_operator = self
+            .projected_operator
+            .write()
+            .map_err(|err| anyhow::anyhow!("DMRG projected operator lock poisoned: {err}"))?;
+        projected_operator.invalidate(&step.nodes, topology);
+        Ok(())
+    }
+}
+
+/// Run two-site DMRG for a TreeTN state and a mapped TreeTN linear operator.
+///
+/// # Arguments
+///
+/// * `operator` - Hamiltonian as a [`LinearOperator`]. The v1 implementation
+///   supports exactly one input and one output site mapping per node.
+/// * `init` - Initial TreeTN state. It is canonicalized at `center` before
+///   sweeping.
+/// * `center` - Initial sweep center node.
+/// * `options` - Sweep, truncation, and local eigensolver options.
+///
+/// # Returns
+///
+/// A [`DmrgResult`] containing the optimized state and final Rayleigh energy.
+///
+/// # Errors
+///
+/// Returns [`DmrgError`] for unsupported options, incompatible mappings, missing
+/// center nodes, non-real Rayleigh quotients, and local projected eigensolve
+/// failures.
+///
+/// # Examples
+/// ```
+/// use std::collections::HashMap;
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{dmrg, DmrgOptions, IndexMapping, LinearOperator, TreeTN};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let site0 = DynIndex::new_dyn(2);
+/// let site1 = DynIndex::new_dyn(2);
+/// let bond = DynIndex::new_dyn(1);
+/// let left = TensorDynLen::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 1.0])?;
+/// let right = TensorDynLen::from_dense(vec![bond.clone(), site1.clone()], vec![1.0, 1.0])?;
+/// let mut state = TreeTN::<TensorDynLen, usize>::new();
+/// let n0 = state.add_tensor(0, left)?;
+/// let n1 = state.add_tensor(1, right)?;
+/// state.connect(n0, &bond, n1, &bond)?;
+///
+/// let in0 = DynIndex::new_dyn(2);
+/// let out0 = DynIndex::new_dyn(2);
+/// let in1 = DynIndex::new_dyn(2);
+/// let out1 = DynIndex::new_dyn(2);
+/// let op_bond = DynIndex::new_dyn(1);
+/// let mut id = vec![0.0; 4];
+/// id[0] = 1.0;
+/// id[3] = 1.0;
+/// let op0 = TensorDynLen::from_dense(vec![out0.clone(), in0.clone(), op_bond.clone()], id.clone())?;
+/// let op1 = TensorDynLen::from_dense(vec![op_bond.clone(), out1.clone(), in1.clone()], id)?;
+/// let mut mpo = TreeTN::<TensorDynLen, usize>::new();
+/// let m0 = mpo.add_tensor(0, op0)?;
+/// let m1 = mpo.add_tensor(1, op1)?;
+/// mpo.connect(m0, &op_bond, m1, &op_bond)?;
+///
+/// let input = HashMap::from([
+///     (0, IndexMapping { true_index: site0.clone(), internal_index: in0 }),
+///     (1, IndexMapping { true_index: site1.clone(), internal_index: in1 }),
+/// ]);
+/// let output = HashMap::from([
+///     (0, IndexMapping { true_index: site0, internal_index: out0 }),
+///     (1, IndexMapping { true_index: site1, internal_index: out1 }),
+/// ]);
+/// let operator = LinearOperator::new(mpo, input, output);
+///
+/// let result = dmrg(&operator, state, &0, DmrgOptions::default().with_nsweeps(1))?;
+/// assert!((result.energy - 1.0).abs() < 1e-10);
+/// # Ok(())
+/// # }
+/// ```
+pub fn dmrg<T, V>(
+    operator: &LinearOperator<T, V>,
+    init: TreeTN<T, V>,
+    center: &V,
+    options: DmrgOptions,
+) -> Result<DmrgResult<T, V>, DmrgError>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id:
+        Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug + 'static,
+{
+    validate_options(&options)?;
+    if init.node_index(center).is_none() {
+        return Err(DmrgError::MissingCenter {
+            center: format!("{center:?}"),
+        });
+    }
+    if !init.same_topology(operator.mpo()) {
+        return Err(DmrgError::TopologyMismatch);
+    }
+
+    let (input_mapping, output_mapping) = single_site_mappings(operator, &init)?;
+    let mut state = init
+        .canonicalize([center.clone()], CanonicalizationOptions::default())
+        .map_err(|source| DmrgError::Algorithm {
+            context: "DMRG failed to canonicalize initial state",
+            source,
+        })?;
+
+    let plan =
+        LocalUpdateSweepPlan::from_treetn(&state, center, options.nsite).ok_or_else(|| {
+            DmrgError::MissingCenter {
+                center: format!("{center:?}"),
+            }
+        })?;
+    if plan.is_empty() {
+        return Err(DmrgError::EmptyTwoSiteSweep);
+    }
+
+    let mut updater = DmrgUpdater::new(
+        operator.mpo().clone(),
+        input_mapping,
+        output_mapping,
+        options.clone(),
+    );
+    let mut previous_energy: Option<f64> = None;
+    let mut converged = false;
+    let mut sweeps_completed = 0usize;
+
+    for sweep in 0..options.nsweeps {
+        apply_local_update_sweep(&mut state, &plan, &mut updater).map_err(|source| {
+            DmrgError::Algorithm {
+                context: "DMRG sweep failed",
+                source,
+            }
+        })?;
+        sweeps_completed = sweep + 1;
+
+        if let Some(energy_tol) = options.energy_tol {
+            let energy = updater.last_energy.ok_or_else(|| DmrgError::Algorithm {
+                context: "DMRG sweep produced no local energy",
+                source: anyhow::anyhow!("no local DMRG update was completed"),
+            })?;
+            if let Some(previous) = previous_energy {
+                if (energy - previous).abs() <= energy_tol {
+                    converged = true;
+                    break;
+                }
+            }
+            previous_energy = Some(energy);
+        }
+
+        if options.verbose {
+            eprintln!(
+                "DMRG sweep {}: local_energy={:?} max_residual={:.6e}",
+                sweeps_completed, updater.last_energy, updater.max_residual_norm
+            );
+        }
+    }
+
+    let final_region = rayleigh_region(&state, center)?;
+    let energy = updater.rayleigh_quotient(&state, &final_region)?;
+
+    Ok(DmrgResult {
+        state,
+        energy,
+        sweeps_completed,
+        local_updates: updater.local_updates,
+        converged,
+        max_residual_norm: updater.max_residual_norm,
+    })
+}
+
+/// Build a mapped operator from a TreeTN MPO and run two-site DMRG.
+///
+/// This is a convenience wrapper over [`LinearOperator::from_mpo_and_state`] and
+/// [`dmrg`]. Prefer explicit [`LinearOperator`] mappings when multiple same-dim
+/// operator site indices make input/output conventions ambiguous.
+///
+/// # Examples
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{dmrg_with_treetn_operator, DmrgOptions, TreeTN};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let site = DynIndex::new_dyn(2);
+/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+///
+/// let op_in = DynIndex::new_dyn(2);
+/// let op_out = DynIndex::new_dyn(2);
+/// let op_tensor = TensorDynLen::from_dense(
+///     vec![op_out, op_in],
+///     vec![1.0, 0.0, 0.0, 2.0],
+/// )?;
+/// let operator = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+///
+/// let err = dmrg_with_treetn_operator(&operator, state, &0, DmrgOptions::default()).unwrap_err();
+/// assert!(matches!(err, tensor4all_treetn::DmrgError::EmptyTwoSiteSweep));
+/// # Ok(())
+/// # }
+/// ```
+pub fn dmrg_with_treetn_operator<T, V>(
+    operator: &TreeTN<T, V>,
+    init: TreeTN<T, V>,
+    center: &V,
+    options: DmrgOptions,
+) -> Result<DmrgResult<T, V>, DmrgError>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id:
+        Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug + 'static,
+{
+    let linear_operator =
+        LinearOperator::from_mpo_and_state(operator.clone(), &init).map_err(|source| {
+            DmrgError::Algorithm {
+                context: "DMRG failed to build LinearOperator from TreeTN operator",
+                source,
+            }
+        })?;
+    dmrg(&linear_operator, init, center, options)
+}
+
+fn validate_options(options: &DmrgOptions) -> Result<(), DmrgError> {
+    if options.nsite != 2 {
+        return Err(DmrgError::UnsupportedNsite {
+            requested: options.nsite,
+            supported: 2,
+        });
+    }
+    if options.nsweeps == 0 {
+        return Err(DmrgError::InvalidOption {
+            option: "nsweeps",
+            reason: "must be greater than zero".to_string(),
+        });
+    }
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        if max_bond_dim == 0 {
+            return Err(DmrgError::InvalidOption {
+                option: "max_bond_dim",
+                reason: "must be greater than zero when set".to_string(),
+            });
+        }
+    }
+    if let Some(energy_tol) = options.energy_tol {
+        if !energy_tol.is_finite() || energy_tol < 0.0 {
+            return Err(DmrgError::InvalidOption {
+                option: "energy_tol",
+                reason: "must be finite and non-negative".to_string(),
+            });
+        }
+    }
+    if !options.real_scalar_tol.is_finite() || options.real_scalar_tol < 0.0 {
+        return Err(DmrgError::InvalidOption {
+            option: "real_scalar_tol",
+            reason: "must be finite and non-negative".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn checked_real_scalar(
+    value: &AnyScalar,
+    tolerance: f64,
+    context: &'static str,
+) -> Result<f64, DmrgError> {
+    let imag = value.imag();
+    if imag.abs() > tolerance {
+        return Err(DmrgError::NonRealScalar {
+            context,
+            real: value.real(),
+            imag,
+            tolerance,
+        });
+    }
+    Ok(value.real())
+}
+
+fn single_site_mappings<T, V>(
+    operator: &LinearOperator<T, V>,
+    state: &TreeTN<T, V>,
+) -> Result<SiteMappings<V, T::Index>, DmrgError>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut input = HashMap::new();
+    let mut output = HashMap::new();
+
+    for node in state.node_names() {
+        let node_name = format!("{node:?}");
+        let state_sites =
+            state
+                .site_space(&node)
+                .ok_or_else(|| DmrgError::UnsupportedStateSiteCount {
+                    node: node_name.clone(),
+                    count: 0,
+                })?;
+        if state_sites.len() != 1 {
+            return Err(DmrgError::UnsupportedStateSiteCount {
+                node: node_name,
+                count: state_sites.len(),
+            });
+        }
+        let state_site =
+            state_sites
+                .iter()
+                .next()
+                .ok_or_else(|| DmrgError::UnsupportedStateSiteCount {
+                    node: node_name.clone(),
+                    count: 0,
+                })?;
+
+        let in_mapping = single_mapping(
+            operator.input_mappings().get(&node).map(Vec::as_slice),
+            &node,
+            "input",
+        )?;
+        let out_mapping = single_mapping(
+            operator.output_mappings().get(&node).map(Vec::as_slice),
+            &node,
+            "output",
+        )?;
+
+        if &in_mapping.true_index != state_site {
+            return Err(DmrgError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason: "input true index does not match the state site index".to_string(),
+            });
+        }
+        if &out_mapping.true_index != state_site {
+            return Err(DmrgError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason: "output true index must equal the state site index for square DMRG"
+                    .to_string(),
+            });
+        }
+        if in_mapping.internal_index.dim() != state_site.dim()
+            || out_mapping.internal_index.dim() != state_site.dim()
+        {
+            return Err(DmrgError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason: "operator internal mapping dimensions must match the state site dimension"
+                    .to_string(),
+            });
+        }
+
+        input.insert(node.clone(), in_mapping.clone());
+        output.insert(node, out_mapping.clone());
+    }
+
+    Ok((input, output))
+}
+
+fn single_mapping<'a, I, V>(
+    mappings: Option<&'a [IndexMapping<I>]>,
+    node: &V,
+    role: &'static str,
+) -> Result<&'a IndexMapping<I>, DmrgError>
+where
+    I: IndexLike,
+    V: std::fmt::Debug,
+{
+    let mappings = mappings.ok_or_else(|| DmrgError::MissingMapping {
+        node: format!("{node:?}"),
+        role,
+    })?;
+    if mappings.len() != 1 {
+        return Err(DmrgError::UnsupportedMultipleSiteMappings {
+            node: format!("{node:?}"),
+            role,
+            count: mappings.len(),
+        });
+    }
+    Ok(&mappings[0])
+}
+
+fn rayleigh_region<T, V>(state: &TreeTN<T, V>, center: &V) -> Result<Vec<V>, DmrgError>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    let neighbor = state
+        .site_index_network()
+        .neighbors(center)
+        .next()
+        .ok_or(DmrgError::EmptyTwoSiteSweep)?;
+    Ok(vec![center.clone(), neighbor])
+}

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -22,9 +22,11 @@
 pub mod algorithm;
 // dyn_treetn.rs has been removed.
 // TreeTN uses the `T: TensorLike` pattern, making a separate dyn wrapper unnecessary.
+pub mod dmrg;
 pub mod error;
 pub mod link_index_network;
 pub mod linsolve;
+mod local_update_support;
 pub mod named_graph;
 pub mod node_name_network;
 pub mod operator;
@@ -35,6 +37,7 @@ pub mod site_index_network;
 pub mod treetn;
 
 pub use algorithm::{CanonicalForm, CompressionAlgorithm, ContractionAlgorithm};
+pub use dmrg::{dmrg, dmrg_with_treetn_operator, DmrgError, DmrgOptions, DmrgResult};
 pub use error::{
     LinearOperatorIndexApplyError, LinearOperatorIndexBindingError, LinearOperatorTaggedApplyError,
     NumberedTagSelectionError, SelectedIndexContractionError,

--- a/crates/tensor4all-treetn/src/linsolve/square/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! - Phys. Rev. B 72, 180403 (2005) - Noise term technique (not implemented in initial version)
 
-mod local_linop;
+pub(crate) mod local_linop;
 mod projected_state;
 mod updater;
 

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -19,11 +19,9 @@ use tensor4all_core::{FactorizeOptions, IndexLike, TensorLike};
 use super::local_linop::LocalLinOp;
 use super::projected_state::ProjectedState;
 use crate::linsolve::common::{GmresToleranceMode, LinsolveOptions, ProjectedOperator};
+use crate::local_update_support;
 use crate::operator::IndexMapping;
-use crate::{
-    factorize_tensor_to_treetn_with, get_boundary_edges, LocalUpdateStep, LocalUpdater, TreeTN,
-    TreeTopology,
-};
+use crate::{factorize_tensor_to_treetn_with, LocalUpdateStep, LocalUpdater, TreeTN, TreeTopology};
 
 static LOCAL_SOLVE_TRACE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -209,24 +207,14 @@ where
     ///
     /// This is called lazily on the first `before_step` to ensure we have the initial ket_state.
     fn ensure_reference_state_initialized(&mut self, ket_state: &TreeTN<T, V>) -> Result<()> {
-        // Check if reference_state is already initialized (has nodes)
-        if !self.reference_state.node_names().is_empty() {
-            return Ok(());
+        let initialized = self.reference_state.node_names().is_empty();
+        local_update_support::initialize_reference_state_if_empty(
+            &mut self.reference_state,
+            ket_state,
+        )?;
+        if initialized {
+            self.boundary_bond_map.clear();
         }
-
-        // Initialize reference_state by cloning ket_state and relabeling link indices
-        // For boundary bonds, we'll preserve the mapping for later reuse
-        let mut reference_state = ket_state.clone();
-
-        // Get all edges to determine which are boundary bonds
-        // Since we don't have a region yet, we'll relabel all links initially
-        // Boundary bonds will be stabilized in after_step when we know the region
-        reference_state.sim_linkinds_mut()?;
-
-        // Initialize boundary_bond_map as empty (will be populated per-region in after_step)
-        self.boundary_bond_map.clear();
-
-        self.reference_state = reference_state;
         Ok(())
     }
 
@@ -351,27 +339,7 @@ where
 
     /// Contract all tensors in the region into a single local tensor.
     fn contract_region(&self, subtree: &TreeTN<T, V>, region: &[V]) -> Result<T> {
-        if region.is_empty() {
-            return Err(anyhow::anyhow!("Region cannot be empty"));
-        }
-
-        // Collect all tensors in the region
-        let tensors: Vec<T> = region
-            .iter()
-            .map(|node| {
-                let idx = subtree
-                    .node_index(node)
-                    .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in subtree", node))?;
-                let tensor = subtree
-                    .tensor(idx)
-                    .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node))?;
-                Ok(tensor.clone())
-            })
-            .collect::<Result<_>>()?;
-
-        // Use TensorContractionLike::contract for contraction
-        let tensor_refs: Vec<&T> = tensors.iter().collect();
-        T::contract(&tensor_refs)
+        local_update_support::contract_region(subtree, region)
     }
 
     /// Build TreeTopology for the subtree region from the solved tensor.
@@ -383,54 +351,7 @@ where
         region: &[V],
         full_treetn: &TreeTN<T, V>,
     ) -> Result<TreeTopology<V, T::Index>> {
-        use std::collections::HashMap;
-
-        let mut nodes: HashMap<V, Vec<T::Index>> = HashMap::new();
-        let mut edges: Vec<(V, V)> = Vec::new();
-
-        let solved_indices = solved_tensor.external_indices();
-
-        // For each node in the region, find which indices belong to it.
-        for node in region {
-            let mut indices = Vec::new();
-
-            // Get site indices for this node
-            if let Some(site_indices) = full_treetn.site_space(node) {
-                for site_idx in site_indices {
-                    // Verify the index exists in solved_tensor and collect it.
-                    if solved_indices.iter().any(|idx| idx == site_idx) {
-                        indices.push(site_idx.clone());
-                    }
-                }
-            }
-
-            // Get bond indices to neighbors outside the region
-            for neighbor in full_treetn.site_index_network().neighbors(node) {
-                if !region.contains(&neighbor) {
-                    // This is an external neighbor - the bond belongs to this node
-                    if let Some(edge) = full_treetn.edge_between(node, &neighbor) {
-                        if let Some(bond) = full_treetn.bond_index(edge) {
-                            if solved_indices.iter().any(|idx| idx == bond) {
-                                indices.push(bond.clone());
-                            }
-                        }
-                    }
-                }
-            }
-
-            nodes.insert(node.clone(), indices);
-        }
-
-        // Build edges between nodes in the region
-        for (i, node_a) in region.iter().enumerate() {
-            for node_b in region.iter().skip(i + 1) {
-                if full_treetn.edge_between(node_a, node_b).is_some() {
-                    edges.push((node_a.clone(), node_b.clone()));
-                }
-            }
-        }
-
-        Ok(TreeTopology::new(nodes, edges))
+        local_update_support::build_subtree_topology(solved_tensor, region, full_treetn)
     }
 
     /// Copy decomposed tensors back to subtree, preserving original bond IDs.
@@ -441,64 +362,7 @@ where
         region: &[V],
         full_treetn: &TreeTN<T, V>,
     ) -> Result<()> {
-        use std::collections::HashMap;
-
-        // Phase 1: Build a mapping from decomposed bonds to new bond indices
-        // For internal bonds, we create a single new bond index that will be used
-        // for both nodes sharing that edge
-        let mut bond_mapping: HashMap<T::Index, T::Index> = HashMap::new();
-
-        for (i, node_a) in region.iter().enumerate() {
-            for node_b in region.iter().skip(i + 1) {
-                // Check if there's an edge between these nodes
-                if let Some(decomp_edge) = decomposed.edge_between(node_a, node_b) {
-                    if let Some(decomp_bond) = decomposed.bond_index(decomp_edge) {
-                        // Create a new bond index matching decomposed bond dimension.
-                        // Use sim() once for this edge to avoid ID collisions.
-                        if let Some(orig_edge) = subtree.edge_between(node_a, node_b) {
-                            let new_bond = decomp_bond.sim();
-                            bond_mapping.insert(decomp_bond.clone(), new_bond.clone());
-
-                            // Update the edge bond in subtree
-                            subtree.replace_edge_bond(orig_edge, new_bond)?;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Phase 2: For each node in the region, update its tensor using the bond mapping
-        for node in region {
-            let decomp_idx = decomposed
-                .node_index(node)
-                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in decomposed TreeTN", node))?;
-            let mut new_tensor = decomposed
-                .tensor(decomp_idx)
-                .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node))?
-                .clone();
-
-            // Replace bond indices using the pre-computed mapping
-            for neighbor in full_treetn.site_index_network().neighbors(node) {
-                if region.contains(&neighbor) {
-                    // Internal bond - use the mapped bond
-                    if let Some(decomp_edge) = decomposed.edge_between(node, &neighbor) {
-                        if let Some(decomp_bond) = decomposed.bond_index(decomp_edge) {
-                            if let Some(new_bond) = bond_mapping.get(decomp_bond) {
-                                new_tensor = new_tensor.replaceind(decomp_bond, new_bond)?;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Update the tensor in subtree
-            let subtree_idx = subtree
-                .node_index(node)
-                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in subtree", node))?;
-            subtree.replace_tensor(subtree_idx, new_tensor)?;
-        }
-
-        Ok(())
+        local_update_support::copy_decomposed_to_subtree(subtree, decomposed, region, full_treetn)
     }
 
     /// Solve the local linear problem using GMRES.
@@ -638,119 +502,12 @@ where
         step: &LocalUpdateStep<V>,
         ket_state: &TreeTN<T, V>,
     ) -> Result<()> {
-        // Extract updated region from ket_state
-        let ket_region = ket_state.extract_subtree(&step.nodes)?;
-
-        // Build mapping from ket bonds to reference bond indices for *all* bonds incident to the region.
-        //
-        // Important: reference_state bonds must remain stable across steps, even when an edge alternates
-        // between being a boundary edge and an internal edge in different steps (as happens in sweeps).
-        // Therefore, we always reuse the current reference_state bond indices, and never create fresh bonds here.
-        let mut ket_to_ref_bond_map: HashMap<T::Index, T::Index> = HashMap::new();
-
-        // Populate mapping for all edges incident to region nodes.
-        // - Boundary edges (region ↔ outside): use reference_state's existing bond IDs for cache stability
-        // - Internal edges (within region): use sim() to create new IDs distinct from ket
-        // This ensures reference_state bond IDs are always different from ket_state bond IDs.
-        let region_nodes: std::collections::HashSet<_> = step.nodes.iter().collect();
-        for node in &step.nodes {
-            for neighbor in ket_state.site_index_network().neighbors(node) {
-                let ket_edge = match ket_state.edge_between(node, &neighbor) {
-                    Some(e) => e,
-                    None => continue,
-                };
-                let ket_bond = match ket_state.bond_index(ket_edge) {
-                    Some(b) => b,
-                    None => continue,
-                };
-
-                let ref_bond = if region_nodes.contains(&neighbor) {
-                    // Internal edge: create new ID using sim()
-                    ket_bond.sim()
-                } else {
-                    // Boundary edge: use reference_state's existing bond ID
-                    let ref_edge = match self.reference_state.edge_between(node, &neighbor) {
-                        Some(e) => e,
-                        None => continue,
-                    };
-                    match self.reference_state.bond_index(ref_edge) {
-                        Some(b) => b.clone(),
-                        None => continue,
-                    }
-                };
-                ket_to_ref_bond_map.insert(ket_bond.clone(), ref_bond);
-            }
-        }
-
-        // Keep a small explicit cache for boundary edges (region ↔ outside) for inspection/debugging.
-        // This is not used to drive the mapping logic.
-        for boundary_edge in get_boundary_edges(ket_state, &step.nodes)? {
-            if let Some(edge) = self.reference_state.edge_between(
-                &boundary_edge.node_in_region,
-                &boundary_edge.neighbor_outside,
-            ) {
-                if let Some(ref_bond) = self.reference_state.bond_index(edge) {
-                    self.boundary_bond_map.insert(
-                        (
-                            boundary_edge.node_in_region.clone(),
-                            boundary_edge.neighbor_outside.clone(),
-                        ),
-                        ref_bond.clone(),
-                    );
-                }
-            }
-        }
-
-        // Create new ref_region by copying ket_region
-        let mut ref_region = ket_region.clone();
-
-        // First, update edge bonds in ref_region to reference-side IDs
-        // This must be done before replacing tensors to ensure consistency
-        let mut edges_to_update: Vec<(V, V, T::Index)> = Vec::new();
-        for node in &step.nodes {
-            let neighbors: Vec<V> = ref_region.site_index_network().neighbors(node).collect();
-            for neighbor in neighbors {
-                if let Some(edge) = ref_region.edge_between(node, &neighbor) {
-                    if let Some(bond) = ref_region.bond_index(edge) {
-                        if let Some(new_bond) = ket_to_ref_bond_map.get(bond) {
-                            edges_to_update.push((node.clone(), neighbor, new_bond.clone()));
-                        }
-                    }
-                }
-            }
-        }
-        // Update edges (ref_region is no longer borrowed)
-        for (node, neighbor, new_bond) in edges_to_update {
-            if let Some(edge) = ref_region.edge_between(&node, &neighbor) {
-                ref_region.replace_edge_bond(edge, new_bond)?;
-            }
-        }
-
-        // Now replace all bond indices (including boundary bonds) in ref_region tensors with reference-side IDs
-        for node in &step.nodes {
-            if let Some(node_idx) = ref_region.node_index(node) {
-                if let Some(tensor) = ref_region.tensor(node_idx) {
-                    let mut new_tensor = tensor.clone();
-                    let tensor_indices = tensor.external_indices();
-
-                    for ket_idx in &tensor_indices {
-                        // Replace if this index is one of the region's bond indices (internal or boundary)
-                        if let Some(ref_bond) = ket_to_ref_bond_map.get(ket_idx) {
-                            new_tensor = new_tensor.replaceind(ket_idx, ref_bond)?;
-                        }
-                        // Site indices are kept as-is.
-                    }
-
-                    ref_region.replace_tensor(node_idx, new_tensor)?;
-                }
-            }
-        }
-
-        // Replace the region back into reference_state
-        self.reference_state
-            .replace_subtree(&step.nodes, &ref_region)?;
-
-        Ok(())
+        local_update_support::sync_reference_state_region(
+            &mut self.reference_state,
+            Some(&mut self.boundary_bond_map),
+            step,
+            ket_state,
+        )
     }
 }
 

--- a/crates/tensor4all-treetn/src/local_update_support.rs
+++ b/crates/tensor4all-treetn/src/local_update_support.rs
@@ -1,0 +1,283 @@
+//! Shared support routines for local sweep algorithms.
+//!
+//! These helpers are intentionally crate-private. They encode the local-update
+//! conventions shared by linsolve, DMRG, and future TDVP-style algorithms:
+//! contract only the active region, pass multi-tensor contractions to
+//! `T::contract(&refs)`, and never materialize the full TreeTN in production
+//! update paths.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use anyhow::Result;
+use tensor4all_core::{IndexLike, TensorLike};
+
+use crate::treetn::{get_boundary_edges, LocalUpdateStep, TreeTN, TreeTopology};
+
+/// Initialize a reference state by cloning the ket state and relabeling links.
+pub(crate) fn initialize_reference_state_if_empty<T, V>(
+    reference_state: &mut TreeTN<T, V>,
+    ket_state: &TreeTN<T, V>,
+) -> Result<()>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    if !reference_state.node_names().is_empty() {
+        return Ok(());
+    }
+
+    let mut initialized = ket_state.clone();
+    initialized.sim_linkinds_mut()?;
+    *reference_state = initialized;
+    Ok(())
+}
+
+/// Contract all tensors in a local region into one tensor.
+pub(crate) fn contract_region<T, V>(subtree: &TreeTN<T, V>, region: &[V]) -> Result<T>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    if region.is_empty() {
+        return Err(anyhow::anyhow!("Region cannot be empty"));
+    }
+
+    let tensors: Vec<T> = region
+        .iter()
+        .map(|node| {
+            let idx = subtree
+                .node_index(node)
+                .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in subtree", node))?;
+            let tensor = subtree
+                .tensor(idx)
+                .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node))?;
+            Ok(tensor.clone())
+        })
+        .collect::<Result<_>>()?;
+
+    let tensor_refs: Vec<&T> = tensors.iter().collect();
+    T::contract(&tensor_refs)
+}
+
+/// Build a decomposition topology for a solved local tensor.
+pub(crate) fn build_subtree_topology<T, V>(
+    solved_tensor: &T,
+    region: &[V],
+    full_treetn: &TreeTN<T, V>,
+) -> Result<TreeTopology<V, T::Index>>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut nodes: HashMap<V, Vec<T::Index>> = HashMap::new();
+    let mut edges: Vec<(V, V)> = Vec::new();
+
+    let solved_indices = solved_tensor.external_indices();
+
+    for node in region {
+        let mut indices = Vec::new();
+
+        if let Some(site_indices) = full_treetn.site_space(node) {
+            for site_idx in site_indices {
+                if solved_indices.iter().any(|idx| idx == site_idx) {
+                    indices.push(site_idx.clone());
+                }
+            }
+        }
+
+        for neighbor in full_treetn.site_index_network().neighbors(node) {
+            if !region.contains(&neighbor) {
+                if let Some(edge) = full_treetn.edge_between(node, &neighbor) {
+                    if let Some(bond) = full_treetn.bond_index(edge) {
+                        if solved_indices.iter().any(|idx| idx == bond) {
+                            indices.push(bond.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        nodes.insert(node.clone(), indices);
+    }
+
+    for (i, node_a) in region.iter().enumerate() {
+        for node_b in region.iter().skip(i + 1) {
+            if full_treetn.edge_between(node_a, node_b).is_some() {
+                edges.push((node_a.clone(), node_b.clone()));
+            }
+        }
+    }
+
+    Ok(TreeTopology::new(nodes, edges))
+}
+
+/// Copy a decomposed local tensor network back into the extracted subtree.
+pub(crate) fn copy_decomposed_to_subtree<T, V>(
+    subtree: &mut TreeTN<T, V>,
+    decomposed: &TreeTN<T, V>,
+    region: &[V],
+    full_treetn: &TreeTN<T, V>,
+) -> Result<()>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut bond_mapping: HashMap<T::Index, T::Index> = HashMap::new();
+
+    for (i, node_a) in region.iter().enumerate() {
+        for node_b in region.iter().skip(i + 1) {
+            if let Some(decomp_edge) = decomposed.edge_between(node_a, node_b) {
+                if let Some(decomp_bond) = decomposed.bond_index(decomp_edge) {
+                    if let Some(orig_edge) = subtree.edge_between(node_a, node_b) {
+                        let new_bond = decomp_bond.sim();
+                        bond_mapping.insert(decomp_bond.clone(), new_bond.clone());
+                        subtree.replace_edge_bond(orig_edge, new_bond)?;
+                    }
+                }
+            }
+        }
+    }
+
+    for node in region {
+        let decomp_idx = decomposed
+            .node_index(node)
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in decomposed TreeTN", node))?;
+        let mut new_tensor = decomposed
+            .tensor(decomp_idx)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found for node {:?}", node))?
+            .clone();
+
+        for neighbor in full_treetn.site_index_network().neighbors(node) {
+            if region.contains(&neighbor) {
+                if let Some(decomp_edge) = decomposed.edge_between(node, &neighbor) {
+                    if let Some(decomp_bond) = decomposed.bond_index(decomp_edge) {
+                        if let Some(new_bond) = bond_mapping.get(decomp_bond) {
+                            new_tensor = new_tensor.replaceind(decomp_bond, new_bond)?;
+                        }
+                    }
+                }
+            }
+        }
+
+        let subtree_idx = subtree
+            .node_index(node)
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in subtree", node))?;
+        subtree.replace_tensor(subtree_idx, new_tensor)?;
+    }
+
+    Ok(())
+}
+
+/// Synchronize a separate reference state after a local update.
+pub(crate) fn sync_reference_state_region<T, V>(
+    reference_state: &mut TreeTN<T, V>,
+    boundary_bond_map: Option<&mut HashMap<(V, V), T::Index>>,
+    step: &LocalUpdateStep<V>,
+    ket_state: &TreeTN<T, V>,
+) -> Result<()>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let ket_region = ket_state.extract_subtree(&step.nodes)?;
+    let mut ket_to_ref_bond_map: HashMap<T::Index, T::Index> = HashMap::new();
+
+    let region_nodes: std::collections::HashSet<_> = step.nodes.iter().collect();
+    for node in &step.nodes {
+        for neighbor in ket_state.site_index_network().neighbors(node) {
+            let ket_edge = match ket_state.edge_between(node, &neighbor) {
+                Some(edge) => edge,
+                None => continue,
+            };
+            let ket_bond = match ket_state.bond_index(ket_edge) {
+                Some(bond) => bond,
+                None => continue,
+            };
+
+            let ref_bond = if region_nodes.contains(&neighbor) {
+                ket_bond.sim()
+            } else {
+                let ref_edge = match reference_state.edge_between(node, &neighbor) {
+                    Some(edge) => edge,
+                    None => continue,
+                };
+                match reference_state.bond_index(ref_edge) {
+                    Some(bond) => bond.clone(),
+                    None => continue,
+                }
+            };
+            ket_to_ref_bond_map.insert(ket_bond.clone(), ref_bond);
+        }
+    }
+
+    if let Some(boundary_bond_map) = boundary_bond_map {
+        for boundary_edge in get_boundary_edges(ket_state, &step.nodes)? {
+            if let Some(edge) = reference_state.edge_between(
+                &boundary_edge.node_in_region,
+                &boundary_edge.neighbor_outside,
+            ) {
+                if let Some(ref_bond) = reference_state.bond_index(edge) {
+                    boundary_bond_map.insert(
+                        (
+                            boundary_edge.node_in_region.clone(),
+                            boundary_edge.neighbor_outside.clone(),
+                        ),
+                        ref_bond.clone(),
+                    );
+                }
+            }
+        }
+    }
+
+    let mut ref_region = ket_region.clone();
+
+    let mut edges_to_update: Vec<(V, V, T::Index)> = Vec::new();
+    for node in &step.nodes {
+        let neighbors: Vec<V> = ref_region.site_index_network().neighbors(node).collect();
+        for neighbor in neighbors {
+            if let Some(edge) = ref_region.edge_between(node, &neighbor) {
+                if let Some(bond) = ref_region.bond_index(edge) {
+                    if let Some(new_bond) = ket_to_ref_bond_map.get(bond) {
+                        edges_to_update.push((node.clone(), neighbor, new_bond.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    for (node, neighbor, new_bond) in edges_to_update {
+        if let Some(edge) = ref_region.edge_between(&node, &neighbor) {
+            ref_region.replace_edge_bond(edge, new_bond)?;
+        }
+    }
+
+    for node in &step.nodes {
+        if let Some(node_idx) = ref_region.node_index(node) {
+            if let Some(tensor) = ref_region.tensor(node_idx) {
+                let mut new_tensor = tensor.clone();
+                let tensor_indices = tensor.external_indices();
+
+                for ket_idx in &tensor_indices {
+                    if let Some(ref_bond) = ket_to_ref_bond_map.get(ket_idx) {
+                        new_tensor = new_tensor.replaceind(ket_idx, ref_bond)?;
+                    }
+                }
+
+                ref_region.replace_tensor(node_idx, new_tensor)?;
+            }
+        }
+    }
+
+    reference_state.replace_subtree(&step.nodes, &ref_region)?;
+
+    Ok(())
+}

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -27,6 +27,10 @@ enum ZipupTopologyMode {
     PreserveInputTopology,
 }
 
+fn indices_except_exact<I: IndexLike>(indices: &[I], excluded: &[I]) -> Vec<I> {
+    tensor4all_core::index_ops::unique_inds(indices, excluded)
+}
+
 impl<T, V> TreeTN<T, V>
 where
     T: TensorLike,
@@ -496,13 +500,9 @@ where
                 .context("Failed to get bond index to destination in tn_b")?;
 
             // left_inds = all indices except the two parent bonds (keep site + child bonds)
-            let left_inds: Vec<_> = c_temp
-                .external_indices()
-                .into_iter()
-                .filter(|idx| {
-                    *idx.id() != *bond_to_dest_a.id() && *idx.id() != *bond_to_dest_b.id()
-                })
-                .collect();
+            let c_temp_indices = c_temp.external_indices();
+            let excluded_parent_bonds = [bond_to_dest_a, bond_to_dest_b];
+            let left_inds = indices_except_exact(&c_temp_indices, &excluded_parent_bonds);
 
             if left_inds.is_empty() {
                 match topology_mode {

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -244,6 +244,24 @@ fn test_contract_zipup_topology_mismatch() {
 }
 
 #[test]
+fn zipup_parent_bond_filter_keeps_same_id_primed_nonbond_index() {
+    let site = DynIndex::new_dyn(2);
+    let bond_a = DynIndex::new_dyn(2);
+    let bond_b = DynIndex::new_dyn(2);
+    let bond_a_prime = bond_a.prime();
+    let indices = vec![
+        site.clone(),
+        bond_a.clone(),
+        bond_a_prime.clone(),
+        bond_b.clone(),
+    ];
+
+    let kept = indices_except_exact(&indices, &[bond_a, bond_b]);
+
+    assert_eq!(kept, vec![site, bond_a_prime]);
+}
+
+#[test]
 fn test_contract_naive_requires_dense_reference_limit() {
     let s = DynIndex::new_dyn(3);
     let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -537,7 +537,7 @@ where
         let left_inds: Vec<_> = tensor_a
             .external_indices()
             .iter()
-            .filter(|idx| idx.id() != bond_ab.id())
+            .filter(|idx| *idx != &bond_ab)
             .cloned()
             .collect();
 

--- a/crates/tensor4all-treetn/src/treetn/localupdate/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate/tests/mod.rs
@@ -60,6 +60,71 @@ fn create_y_shape_treetn() -> (
 }
 
 #[test]
+fn truncate_updater_keeps_same_id_primed_nonbond_index() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(1);
+    let bond_prime = bond.prime();
+
+    let tensor_0 = TensorDynLen::from_dense(
+        vec![s0.clone(), bond.clone(), bond_prime.clone()],
+        vec![1.0, 0.0],
+    )
+    .unwrap();
+    let tensor_1 =
+        TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0, 0.0]).unwrap();
+
+    let tn =
+        TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor_0, tensor_1], vec![0usize, 1usize])
+            .unwrap();
+
+    let step = LocalUpdateStep {
+        nodes: vec![0usize, 1usize],
+        new_center: 1usize,
+    };
+    let mut updater = TruncateUpdater::new(Some(4), None);
+    let updated = updater.update(tn.clone(), &step, &tn).unwrap();
+
+    let node_0 = updated.node_index(&0usize).unwrap();
+    let tensor_0_indices = updated.tensor(node_0).unwrap().external_indices();
+    assert!(tensor_0_indices.iter().any(|idx| idx == &bond_prime));
+    assert!(!tensor_0_indices.iter().any(|idx| idx == &bond));
+}
+
+#[test]
+fn canonicalize_keeps_same_id_primed_nonbond_index_on_source() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let bond_prime = bond.prime();
+
+    let tensor_0 = TensorDynLen::from_dense(
+        vec![s0.clone(), bond.clone(), bond_prime.clone()],
+        vec![1.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, 0.25],
+    )
+    .unwrap();
+    let tensor_1 =
+        TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+
+    let mut tn =
+        TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor_0, tensor_1], vec![0usize, 1usize])
+            .unwrap();
+
+    tn.canonicalize_mut([1usize], Default::default()).unwrap();
+
+    let node_0 = tn.node_index(&0usize).unwrap();
+    let tensor_0_indices = tn.tensor(node_0).unwrap().external_indices();
+    assert!(
+        tensor_0_indices.iter().any(|idx| idx == &bond_prime),
+        "source tensor lost same-ID primed non-bond index: {tensor_0_indices:?}"
+    );
+    assert!(
+        !tensor_0_indices.iter().any(|idx| idx == &bond),
+        "source tensor should no longer carry the old edge bond: {tensor_0_indices:?}"
+    );
+}
+
+#[test]
 fn test_extract_subtree_single_node() {
     let (tn, _site_a, _, _, _) = create_y_shape_treetn();
 

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -675,7 +675,7 @@ where
         let left_inds: Vec<T::Index> = tensor_src
             .external_indices()
             .iter()
-            .filter(|idx| idx.id() != bond_on_src.id())
+            .filter(|idx| *idx != &bond_on_src)
             .cloned()
             .collect();
 

--- a/crates/tensor4all-treetn/tests/dmrg.rs
+++ b/crates/tensor4all-treetn/tests/dmrg.rs
@@ -1,0 +1,811 @@
+use std::collections::HashMap;
+
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, FactorizeOptions, TensorDynLen};
+use tensor4all_treetn::{
+    dmrg, DmrgError, DmrgOptions, IndexMapping, LinearOperator, TreeTN, TreeTopology,
+};
+
+fn col_major_offset(coords: &[usize], dims: &[usize]) -> usize {
+    let mut stride = 1usize;
+    let mut offset = 0usize;
+    for (&coord, &dim) in coords.iter().zip(dims.iter()) {
+        offset += coord * stride;
+        stride *= dim;
+    }
+    offset
+}
+
+fn two_site_state(values: &[f64]) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+    assert_eq!(values.len(), 4);
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+
+    let mut left = vec![0.0; 4];
+    left[col_major_offset(&[0, 0], &[2, 2])] = 1.0;
+    left[col_major_offset(&[1, 1], &[2, 2])] = 1.0;
+
+    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], left).unwrap();
+    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], values.to_vec()).unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    state.connect(n0, &bond, n1, &bond).unwrap();
+    (state, [s0, s1])
+}
+
+fn diagonal_two_site_operator(
+    state_sites: &[DynIndex; 2],
+    energies: [f64; 4],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let s0_out = DynIndex::new_dyn(2);
+    let s0_in = DynIndex::new_dyn(2);
+    let s1_out = DynIndex::new_dyn(2);
+    let s1_in = DynIndex::new_dyn(2);
+
+    let dims = [2, 2, 2, 2];
+    let mut data = vec![0.0; dims.iter().product()];
+    for s0 in 0..2 {
+        for s1 in 0..2 {
+            let energy = energies[s0 + 2 * s1];
+            data[col_major_offset(&[s0, s0, s1, s1], &dims)] = energy;
+        }
+    }
+
+    let dense = TensorDynLen::from_dense(
+        vec![s0_out.clone(), s0_in.clone(), s1_out.clone(), s1_in.clone()],
+        data,
+    )
+    .unwrap();
+
+    let topology = TreeTopology::new(
+        HashMap::from([
+            ("site0", vec![s0_out.clone(), s0_in.clone()]),
+            ("site1", vec![s1_out.clone(), s1_in.clone()]),
+        ]),
+        vec![("site0", "site1")],
+    );
+    let mpo = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        &"site0",
+    )
+    .unwrap();
+
+    let input_mapping = HashMap::from([
+        (
+            "site0",
+            IndexMapping {
+                true_index: state_sites[0].clone(),
+                internal_index: s0_in,
+            },
+        ),
+        (
+            "site1",
+            IndexMapping {
+                true_index: state_sites[1].clone(),
+                internal_index: s1_in,
+            },
+        ),
+    ]);
+    let output_mapping = HashMap::from([
+        (
+            "site0",
+            IndexMapping {
+                true_index: state_sites[0].clone(),
+                internal_index: s0_out,
+            },
+        ),
+        (
+            "site1",
+            IndexMapping {
+                true_index: state_sites[1].clone(),
+                internal_index: s1_out,
+            },
+        ),
+    ]);
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn single_site_state() -> (TreeTN<TensorDynLen, &'static str>, DynIndex) {
+    let site = DynIndex::new_dyn(2);
+    let tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap();
+    let state =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
+    (state, site)
+}
+
+fn single_site_identity_operator(
+    state_site: &DynIndex,
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let out = DynIndex::new_dyn(2);
+    let input = DynIndex::new_dyn(2);
+    let tensor =
+        TensorDynLen::from_dense(vec![out.clone(), input.clone()], vec![1.0, 0.0, 0.0, 1.0])
+            .unwrap();
+    let mpo =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
+    LinearOperator::new(
+        mpo,
+        HashMap::from([(
+            "site0",
+            IndexMapping {
+                true_index: state_site.clone(),
+                internal_index: input,
+            },
+        )]),
+        HashMap::from([(
+            "site0",
+            IndexMapping {
+                true_index: state_site.clone(),
+                internal_index: out,
+            },
+        )]),
+    )
+}
+
+fn complex_two_site_operator(
+    state_sites: &[DynIndex; 2],
+    entries: &[(usize, usize, usize, usize, Complex64)],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let s0_out = DynIndex::new_dyn(2);
+    let s0_in = DynIndex::new_dyn(2);
+    let s1_out = DynIndex::new_dyn(2);
+    let s1_in = DynIndex::new_dyn(2);
+
+    let dims = [2, 2, 2, 2];
+    let mut data = vec![Complex64::new(0.0, 0.0); dims.iter().product()];
+    for &(out0, in0, out1, in1, value) in entries {
+        data[col_major_offset(&[out0, in0, out1, in1], &dims)] = value;
+    }
+
+    let dense = TensorDynLen::from_dense(
+        vec![s0_out.clone(), s0_in.clone(), s1_out.clone(), s1_in.clone()],
+        data,
+    )
+    .unwrap();
+
+    let topology = TreeTopology::new(
+        HashMap::from([
+            ("site0", vec![s0_out.clone(), s0_in.clone()]),
+            ("site1", vec![s1_out.clone(), s1_in.clone()]),
+        ]),
+        vec![("site0", "site1")],
+    );
+    let mpo = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        &"site0",
+    )
+    .unwrap();
+
+    let input_mapping = HashMap::from([
+        (
+            "site0",
+            IndexMapping {
+                true_index: state_sites[0].clone(),
+                internal_index: s0_in,
+            },
+        ),
+        (
+            "site1",
+            IndexMapping {
+                true_index: state_sites[1].clone(),
+                internal_index: s1_in,
+            },
+        ),
+    ]);
+    let output_mapping = HashMap::from([
+        (
+            "site0",
+            IndexMapping {
+                true_index: state_sites[0].clone(),
+                internal_index: s0_out,
+            },
+        ),
+        (
+            "site1",
+            IndexMapping {
+                true_index: state_sites[1].clone(),
+                internal_index: s1_out,
+            },
+        ),
+    ]);
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn heisenberg_dense_operator(
+    state_sites: &[DynIndex],
+    edges: &[(usize, usize)],
+    topology_edges: &[(&'static str, &'static str)],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let n_sites = state_sites.len();
+    let outputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+    let inputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+    let mut indices = Vec::with_capacity(2 * n_sites);
+    for i in 0..n_sites {
+        indices.push(outputs[i].clone());
+        indices.push(inputs[i].clone());
+    }
+
+    let dims = vec![2; 2 * n_sites];
+    let basis_dim = 1usize << n_sites;
+    let mut data = vec![0.0; dims.iter().product()];
+    for input_state in 0..basis_dim {
+        let bits: Vec<_> = (0..n_sites).map(|site| (input_state >> site) & 1).collect();
+        for &(left, right) in edges {
+            let z_left = if bits[left] == 0 { 1.0 } else { -1.0 };
+            let z_right = if bits[right] == 0 { 1.0 } else { -1.0 };
+
+            let mut coords = Vec::with_capacity(2 * n_sites);
+            for &bit in &bits {
+                coords.push(bit);
+                coords.push(bit);
+            }
+            data[col_major_offset(&coords, &dims)] += z_left * z_right;
+
+            let mut out_bits = bits.clone();
+            out_bits[left] ^= 1;
+            out_bits[right] ^= 1;
+            let yy_coeff = if bits[left] == bits[right] { -1.0 } else { 1.0 };
+            let flip_coeff = 1.0 + yy_coeff;
+            if flip_coeff != 0.0 {
+                let mut coords = Vec::with_capacity(2 * n_sites);
+                for site in 0..n_sites {
+                    coords.push(out_bits[site]);
+                    coords.push(bits[site]);
+                }
+                data[col_major_offset(&coords, &dims)] += flip_coeff;
+            }
+        }
+    }
+
+    let dense = TensorDynLen::from_dense(indices, data).unwrap();
+    let topology = TreeTopology::new(
+        (0..n_sites)
+            .map(|i| (site_name(i), vec![outputs[i].clone(), inputs[i].clone()]))
+            .collect(),
+        topology_edges.to_vec(),
+    );
+    let mpo = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        &"site0",
+    )
+    .unwrap();
+
+    let input_mapping = (0..n_sites)
+        .map(|i| {
+            (
+                site_name(i),
+                IndexMapping {
+                    true_index: state_sites[i].clone(),
+                    internal_index: inputs[i].clone(),
+                },
+            )
+        })
+        .collect();
+    let output_mapping = (0..n_sites)
+        .map(|i| {
+            (
+                site_name(i),
+                IndexMapping {
+                    true_index: state_sites[i].clone(),
+                    internal_index: outputs[i].clone(),
+                },
+            )
+        })
+        .collect();
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn site_name(i: usize) -> &'static str {
+    match i {
+        0 => "site0",
+        1 => "site1",
+        2 => "site2",
+        3 => "site3",
+        _ => panic!("test helper supports at most four sites"),
+    }
+}
+
+fn three_site_star_plus_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let dense =
+        TensorDynLen::from_dense(vec![s0.clone(), s1.clone(), s2.clone()], vec![1.0; 8]).unwrap();
+    let topology = TreeTopology::new(
+        HashMap::from([
+            ("site0", vec![s0.clone()]),
+            ("site1", vec![s1.clone()]),
+            ("site2", vec![s2.clone()]),
+        ]),
+        vec![("site0", "site1"), ("site0", "site2")],
+    );
+    let state = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        &"site0",
+    )
+    .unwrap();
+    (state, [s0, s1, s2])
+}
+
+fn four_site_star_asymmetric_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 4]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let s3 = DynIndex::new_dyn(2);
+    let dense = TensorDynLen::from_dense(
+        vec![s0.clone(), s1.clone(), s2.clone(), s3.clone()],
+        vec![
+            0.7, -0.3, 1.1, 0.2, -0.8, 0.5, 0.9, -1.2, 0.4, 1.3, -0.6, 0.1, 1.0, -0.9, 0.3, 0.8,
+        ],
+    )
+    .unwrap();
+    let topology = TreeTopology::new(
+        HashMap::from([
+            ("site0", vec![s0.clone()]),
+            ("site1", vec![s1.clone()]),
+            ("site2", vec![s2.clone()]),
+            ("site3", vec![s3.clone()]),
+        ]),
+        vec![("site0", "site1"), ("site0", "site2"), ("site0", "site3")],
+    );
+    let state = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        &"site0",
+    )
+    .unwrap();
+    (state, [s0, s1, s2, s3])
+}
+
+fn star_sum_z_operator(state_sites: &[DynIndex; 3]) -> LinearOperator<TensorDynLen, &'static str> {
+    let out0 = DynIndex::new_dyn(2);
+    let in0 = DynIndex::new_dyn(2);
+    let out1 = DynIndex::new_dyn(2);
+    let in1 = DynIndex::new_dyn(2);
+    let out2 = DynIndex::new_dyn(2);
+    let in2 = DynIndex::new_dyn(2);
+
+    let dims = [2, 2, 2, 2, 2, 2];
+    let mut data = vec![0.0; dims.iter().product()];
+    for s0 in 0..2 {
+        for s1 in 0..2 {
+            for s2 in 0..2 {
+                let z0 = if s0 == 0 { 1.0 } else { -1.0 };
+                let z1 = if s1 == 0 { 1.0 } else { -1.0 };
+                let z2 = if s2 == 0 { 1.0 } else { -1.0 };
+                data[col_major_offset(&[s0, s0, s1, s1, s2, s2], &dims)] = z0 + z1 + z2;
+            }
+        }
+    }
+    let dense = TensorDynLen::from_dense(
+        vec![
+            out0.clone(),
+            in0.clone(),
+            out1.clone(),
+            in1.clone(),
+            out2.clone(),
+            in2.clone(),
+        ],
+        data,
+    )
+    .unwrap();
+    let topology = TreeTopology::new(
+        HashMap::from([
+            ("site0", vec![out0.clone(), in0.clone()]),
+            ("site1", vec![out1.clone(), in1.clone()]),
+            ("site2", vec![out2.clone(), in2.clone()]),
+        ]),
+        vec![("site0", "site1"), ("site0", "site2")],
+    );
+    let mpo = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        &"site0",
+    )
+    .unwrap();
+
+    let input_mapping = HashMap::from([
+        (
+            "site0",
+            IndexMapping {
+                true_index: state_sites[0].clone(),
+                internal_index: in0,
+            },
+        ),
+        (
+            "site1",
+            IndexMapping {
+                true_index: state_sites[1].clone(),
+                internal_index: in1,
+            },
+        ),
+        (
+            "site2",
+            IndexMapping {
+                true_index: state_sites[2].clone(),
+                internal_index: in2,
+            },
+        ),
+    ]);
+    let output_mapping = HashMap::from([
+        (
+            "site0",
+            IndexMapping {
+                true_index: state_sites[0].clone(),
+                internal_index: out0,
+            },
+        ),
+        (
+            "site1",
+            IndexMapping {
+                true_index: state_sites[1].clone(),
+                internal_index: out1,
+            },
+        ),
+        (
+            "site2",
+            IndexMapping {
+                true_index: state_sites[2].clone(),
+                internal_index: out2,
+            },
+        ),
+    ]);
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+#[test]
+fn dmrg_rejects_one_site_option() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+    let err = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default().with_nsite(1),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        DmrgError::UnsupportedNsite {
+            requested: 1,
+            supported: 2
+        }
+    ));
+}
+
+#[test]
+fn dmrg_rejects_invalid_options() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+
+    let zero_sweeps = DmrgOptions {
+        nsweeps: 0,
+        ..Default::default()
+    };
+    let err = dmrg(&operator, state.clone(), &"site0", zero_sweeps).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::InvalidOption {
+            option: "nsweeps",
+            ..
+        }
+    ));
+
+    let zero_max_bond_dim = DmrgOptions {
+        max_bond_dim: Some(0),
+        ..Default::default()
+    };
+    let err = dmrg(&operator, state.clone(), &"site0", zero_max_bond_dim).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::InvalidOption {
+            option: "max_bond_dim",
+            ..
+        }
+    ));
+
+    let negative_energy_tol = DmrgOptions {
+        energy_tol: Some(-1.0),
+        ..Default::default()
+    };
+    let err = dmrg(&operator, state.clone(), &"site0", negative_energy_tol).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::InvalidOption {
+            option: "energy_tol",
+            ..
+        }
+    ));
+
+    let negative_real_scalar_tol = DmrgOptions {
+        real_scalar_tol: -1.0,
+        ..Default::default()
+    };
+    let err = dmrg(&operator, state, &"site0", negative_real_scalar_tol).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::InvalidOption {
+            option: "real_scalar_tol",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn dmrg_rejects_missing_center() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+
+    let err = dmrg(&operator, state, &"missing", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::MissingCenter { center } if center == "\"missing\""
+    ));
+}
+
+#[test]
+fn dmrg_rejects_topology_mismatch() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = single_site_identity_operator(&sites[0]);
+
+    let err = dmrg(&operator, state, &"site0", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(err, DmrgError::TopologyMismatch));
+}
+
+#[test]
+fn dmrg_rejects_single_node_two_site_sweep() {
+    let (state, site) = single_site_state();
+    let operator = single_site_identity_operator(&site);
+
+    let err = dmrg(&operator, state, &"site0", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(err, DmrgError::EmptyTwoSiteSweep));
+}
+
+#[test]
+fn dmrg_rejects_missing_mapping() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+    let mut input_mapping = operator.input_mappings().clone();
+    input_mapping.remove("site1");
+    let operator = LinearOperator::new_multi(
+        operator.mpo().clone(),
+        input_mapping,
+        operator.output_mappings().clone(),
+    );
+
+    let err = dmrg(&operator, state, &"site0", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::MissingMapping {
+            node,
+            role: "input"
+        } if node == "\"site1\""
+    ));
+}
+
+#[test]
+fn dmrg_rejects_mapping_with_same_dimension_but_different_true_index() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+    let mut input_mapping = operator.input_mappings().clone();
+    input_mapping.get_mut("site0").unwrap()[0].true_index = DynIndex::new_dyn(2);
+    let operator = LinearOperator::new_multi(
+        operator.mpo().clone(),
+        input_mapping,
+        operator.output_mappings().clone(),
+    );
+
+    let err = dmrg(&operator, state, &"site0", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::InvalidMapping {
+            node,
+            reason
+        } if node == "\"site0\"" && reason.contains("input true index")
+    ));
+}
+
+#[test]
+fn dmrg_rejects_mapping_dimension_mismatch() {
+    let (state, sites) = two_site_state(&[0.3, 0.4, 0.5, 0.6]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+    let mut input_mapping = operator.input_mappings().clone();
+    input_mapping.get_mut("site0").unwrap()[0].internal_index = DynIndex::new_dyn(3);
+    let operator = LinearOperator::new_multi(
+        operator.mpo().clone(),
+        input_mapping,
+        operator.output_mappings().clone(),
+    );
+
+    let err = dmrg(&operator, state, &"site0", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::InvalidMapping {
+            node,
+            reason
+        } if node == "\"site0\"" && reason.contains("dimensions")
+    ));
+}
+
+#[test]
+fn dmrg_two_site_diagonal_hamiltonian_finds_lowest_energy() {
+    let (state, sites) = two_site_state(&[0.2, 0.3, 0.4, 0.5]);
+    let operator = diagonal_two_site_operator(&sites, [2.0, -1.5, 0.5, -3.0]);
+
+    let result = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default()
+            .with_nsweeps(2)
+            .with_energy_tol(1.0e-12),
+    )
+    .unwrap();
+
+    assert!(
+        (result.energy + 3.0).abs() < 1.0e-10,
+        "energy={}",
+        result.energy
+    );
+    assert!(result.local_updates >= 1);
+    assert!(result.max_residual_norm < 1.0e-8);
+}
+
+#[test]
+fn dmrg_two_site_heisenberg_singlet_builds_entangled_bond() {
+    let (state, sites) = two_site_state(&[0.7, -0.2, 0.5, 1.1]);
+    let operator = heisenberg_dense_operator(&sites, &[(0, 1)], &[("site0", "site1")]);
+
+    let result = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default()
+            .with_nsweeps(4)
+            .with_max_bond_dim(4)
+            .with_energy_tol(1.0e-12),
+    )
+    .unwrap();
+
+    assert!(
+        (result.energy + 3.0).abs() < 1.0e-10,
+        "energy={}",
+        result.energy
+    );
+    assert!(result.state.link_dims().iter().any(|&dim| dim >= 2));
+    assert!(result.max_residual_norm < 1.0e-8);
+}
+
+#[test]
+fn dmrg_rejects_multiple_site_mappings_per_node() {
+    let (state, sites) = two_site_state(&[0.2, 0.3, 0.4, 0.5]);
+    let operator = diagonal_two_site_operator(&sites, [1.0, 2.0, 3.0, 4.0]);
+
+    let extra_true = DynIndex::new_dyn(2);
+    let extra_internal = DynIndex::new_dyn(2);
+    let mut input_mapping = operator.input_mappings().clone();
+    input_mapping.get_mut("site0").unwrap().push(IndexMapping {
+        true_index: extra_true.clone(),
+        internal_index: extra_internal.clone(),
+    });
+    let output_mapping = operator.output_mappings().clone();
+    let operator = LinearOperator::new_multi(operator.mpo().clone(), input_mapping, output_mapping);
+
+    let err = dmrg(&operator, state, &"site0", DmrgOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        DmrgError::UnsupportedMultipleSiteMappings {
+            node,
+            role: "input",
+            count: 2
+        } if node == "\"site0\""
+    ));
+}
+
+#[test]
+fn dmrg_two_site_complex_hermitian_operator_keeps_real_energy() {
+    let (state, sites) = two_site_state(&[0.2, 0.3, 0.4, 0.5]);
+    let mut entries = Vec::new();
+    for s1 in 0..2 {
+        entries.push((0, 1, s1, s1, Complex64::new(0.0, -1.0)));
+        entries.push((1, 0, s1, s1, Complex64::new(0.0, 1.0)));
+    }
+    let operator = complex_two_site_operator(&sites, &entries);
+
+    let result = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default().with_nsweeps(2),
+    )
+    .unwrap();
+
+    assert!((result.energy + 1.0).abs() < 1.0e-10);
+}
+
+#[test]
+fn dmrg_non_chain_star_sum_z_finds_lowest_energy() {
+    let (state, sites) = three_site_star_plus_state();
+    let operator = star_sum_z_operator(&sites);
+
+    let result = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default()
+            .with_nsweeps(3)
+            .with_max_bond_dim(8)
+            .with_energy_tol(1.0e-12),
+    )
+    .unwrap();
+
+    assert!((result.energy + 3.0).abs() < 1.0e-10);
+}
+
+#[test]
+fn dmrg_branching_star_heisenberg_finds_entangled_ground_state() {
+    let (state, sites) = four_site_star_asymmetric_state();
+    let operator = heisenberg_dense_operator(
+        &sites,
+        &[(0, 1), (0, 2), (0, 3)],
+        &[("site0", "site1"), ("site0", "site2"), ("site0", "site3")],
+    );
+
+    let result = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default()
+            .with_nsweeps(5)
+            .with_max_bond_dim(8)
+            .with_energy_tol(1.0e-12),
+    )
+    .unwrap();
+
+    assert!(
+        (result.energy + 5.0).abs() < 1.0e-9,
+        "energy={}",
+        result.energy
+    );
+    assert!(result.state.link_dims().iter().any(|&dim| dim >= 2));
+}
+
+#[test]
+fn dmrg_rejects_non_hermitian_projected_operator() {
+    let (state, sites) = two_site_state(&[0.2, 0.3, 0.4, 0.5]);
+    let mut entries = Vec::new();
+    for s1 in 0..2 {
+        entries.push((0, 1, s1, s1, Complex64::new(1.0, 0.0)));
+    }
+    let operator = complex_two_site_operator(&sites, &entries);
+
+    let err = dmrg(
+        &operator,
+        state,
+        &"site0",
+        DmrgOptions::default().with_nsweeps(1),
+    )
+    .unwrap_err();
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("DMRG sweep failed") && err_text.contains("Hermitian"),
+        "{err_text}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #531.

Implements the first TreeTN DMRG path for `tensor4all-treetn`:

- Adds public two-site DMRG API: `dmrg`, `dmrg_with_treetn_operator`, `DmrgOptions`, `DmrgResult`, `DmrgError`.
- Adds a matrix-free Hermitian Lanczos lowest-eigenpair solver in `tensor4all-core`, backed by tensorbackend/tenferro `eigh` for the small Rayleigh-Ritz projected matrix.
- Uses projected residual estimates during Lanczos iterations and computes the true residual only at convergence/finalization, avoiding an extra local matvec per iteration.
- Reuses `ProjectedOperator` and shared local-update helpers so production DMRG contracts local regions/environments only; no full TreeTN materialization in the algorithm path.
- Rejects `nsite != 2` explicitly; one-site DMRG is intentionally not implemented in this PR.
- Hardens exact-index handling so same id with different prime/tag is not treated as the same index.
- Supports complex Hermitian operators without unchecked `.real()` and rejects non-Hermitian projected operators.
- Adds Rust and Julia/ITensorNetworks.jl parity benchmarks for chain and true non-chain star topologies, with benchmark results committed under `benchmarks/results/`.

## Truncation Strategy

The Rust DMRG benchmark now uses an ITensors-compatible SVD truncation policy for both summed-MPO compression and DMRG splitting:

```rust
SvdTruncationPolicy::new(1.0e-12)
    .with_squared_values()
    .with_discarded_tail_sum()
```

That matches ITensors' relative discarded squared singular-value tail `cutoff = 1e-12`, instead of the older `rtol = sqrt(cutoff)` approximation. The Julia ITensorNetworks runner uses `cutoff = 1e-12` for both TTN operator construction and two-site factorization.

## Benchmark Results

Local run on commit `6915331`, Pauli Heisenberg Hamiltonian
`sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j`, `n=8`, `sweeps=4`, `warmups=1`, `repeats=3`, `maxdim=32`.
Dense exact references are benchmark-only validation references.

Benchmark boundary details:

- Rust runs all requested sweeps: sweep-to-sweep energy early stopping is not enabled in the benchmark. Reported Rust rows had `sweeps_completed=4`, `local_updates=56`, `converged=false`.
- Julia performs one untimed warm-up per topology before timing, so reported Julia timings exclude compilation and ITensorNetworks.jl first-call setup.
- Julia repeat initial-state construction is outside the timed region, matching Rust's pre-timer state clone boundary.
- For the star topology, both runners use a leaf DMRG root. This matches ITensorNetworks.jl's `ttn(OpSum, ...)` requirement that the tree root be a leaf vertex; Rust is intentionally configured the same way for parity.

### Rust

Command:

```bash
RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_dmrg --release -- 8 4 3
```

| topology | energy | exact | abs error | max residual | mean ms | min ms | max ms |
|---|---:|---:|---:|---:|---:|---:|---:|
| chain | -13.499730394752 | -13.499730394752 | 5.329e-15 | 2.784e-6 | 135.364 | 132.498 | 137.314 |
| star | -9.000000000000 | -9.000000000000 | 9.059e-14 | 7.326e-3 | 242.797 | 239.229 | 245.971 |

### ITensorNetworks.jl

Command:

```bash
BLAS_NUM_THREADS=1 julia --project=/tmp/t4a-itensornetworks-bench-issue531 \
  benchmarks/julia/benchmark_dmrg_itensornetworks.jl 8 4 3
```

| topology | energy | exact | abs error | mean ms | min ms | max ms |
|---|---:|---:|---:|---:|---:|---:|
| chain | -13.499730394752 | -13.499730394752 | 5.1514348342607263e-14 | 117.271 | 107.571 | 136.669 |
| star | -9.0 | -9.0 | 2.4868995751603507e-14 | 1928.784 | 1716.034 | 2199.503 |

The chain case is a control for harness overhead: Rust and ITensorNetworks.jl are comparable on the chain, while the high-valence star is much slower in ITensorNetworks.jl. The exact cause is not isolated by this benchmark alone.

## Validation

```bash
cargo fmt --all -- --check
cargo test --release -p tensor4all-treetn --example benchmark_dmrg
cargo test --release -p tensor4all-treetn --test dmrg
cargo clippy --workspace --all-targets -- -D warnings
cargo llvm-cov --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json
python3 scripts/check-coverage.py coverage.json
RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_dmrg --release -- 8 4 3
BLAS_NUM_THREADS=1 julia --project=/tmp/t4a-itensornetworks-bench-issue531 benchmarks/julia/benchmark_dmrg_itensornetworks.jl 8 4 3
```

Coverage check result before the benchmark-only fairness amendment: `197/197 files passed`. After the fairness amendment: `cargo fmt --all -- --check`, `cargo test --release -p tensor4all-treetn --example benchmark_dmrg`, `cargo test --release -p tensor4all-treetn --test dmrg`, and `cargo clippy --workspace --all-targets -- -D warnings` passed.

## Independent Review

Claude (`opus`, max budget) reviewed the implementation plan and implementation multiple times.

- Earlier reviews flagged benchmark/quality issues around product-state-only validation, extra Lanczos matvecs, and uncompressed benchmark MPOs; those were addressed before the initial PR update.
- Final review on commit `51094c8` reported no Critical or Important findings remained.
- Follow-up review on commit `78a630f` specifically checked the ITensors-compatible truncation policy and benchmark-warning suppression. It reported no Critical or Important findings.
- Follow-up review after the Julia star timing question identified benchmark fairness issues: Rust early stopping, Julia initial-state construction inside timing, and missing Rust sweep/update reporting. This PR now does not enable Rust early stopping in the benchmark, hoists Julia initial-state construction out of the timed region, reports Rust `sweeps_completed/local_updates/converged`, and scopes the star conclusion to the measured high-valence star case.
- Final focused re-review after those fixes reported no Critical or Important findings. Minor notes remain only around Julia not printing completed sweep count, deterministic-vs-random initial states, and different local eigensolver parameterizations; the PR text now scopes the benchmark conclusion accordingly.
