### PR TITLE
Add TreeTN TDVP sweeps and benchmarks

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -188,6 +188,25 @@
   dense/full-tensor exports return column-major flat data. Call sites that
   treat these buffers as matrices must use column-major indexing.
 
+## Differentiability And AD Preservation
+
+- Production tensor, tensor-network, linear algebra, and solver paths should
+  preserve automatic differentiation metadata whenever the underlying backend
+  and operation can do so.
+- Do not unnecessarily detach tensors, convert differentiable values through
+  plain Rust scalars, force `.real()`/real-only projections, or round-trip
+  through dense/reference paths in a way that discards AD metadata.
+- When an operation must cross a non-differentiable boundary, such as a scalar
+  control-flow decision, diagnostic conversion, FFI boundary, or unsupported
+  backend routine, keep that boundary explicit in the code and documentation.
+- Prefer backend-provided differentiable primitives for contraction, einsum,
+  SVD, QR, eigensolvers, exponentials, and scalar operations. If a required
+  primitive is missing, add or refine the appropriate backend/core API instead
+  of silently implementing a detached local workaround.
+- Tests that claim AD support must include oracle or finite-difference
+  coverage. Tests for algorithms that are not yet AD-supported should still
+  avoid unnecessary AD metadata loss along intermediate tensor paths.
+
 ## Index Identity Semantics
 
 - Do not use `index.id()` alone to decide whether two indices are the same

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,6 +51,19 @@ sweeps, without sweep-to-sweep energy early stopping:
 RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_dmrg --release -- 8 4 3
 ```
 
+Two-site TreeTN TDVP against the same Pauli Heisenberg Hamiltonian on chain and
+star topologies. The benchmark evolves an alternating product state, uses
+`order = 2`, `maxdim = 32`, ITensors-compatible relative discarded squared
+singular-value tail cutoff `1e-12`, and a Hermitian Krylov exponential with
+`krylovdim = 30` and `tol = 1e-12`. Both runners use the numeric cap `100`,
+though Julia's KrylovKit `maxiter` and Rust's `max_time_splits` are different
+control mechanisms. It performs one untimed TDVP warm-up per topology and
+reports runtime plus L2 error against a small dense exact evolution reference:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02
+```
+
 Non-AD local tensor operations:
 
 ```bash
@@ -181,6 +194,24 @@ contraction sequences. The Julia runner performs one untimed DMRG warm-up per
 topology before recording timings, so reported times exclude Julia compilation
 and ITensorNetworks.jl first-call setup. Both runners use `cutoff = 1e-12` as a
 relative discarded squared singular-value tail cutoff.
+
+ITensorNetworks.jl two-site TDVP parity benchmark on matching chain and star
+Pauli Heisenberg Hamiltonians:
+
+```bash
+export T4A_ITENSORNETWORKS_PATH=/home/shinaoka/tensor4all/ITensor/ITensorNetworks.jl
+export T4A_ITN_BENCH_PROJECT=/tmp/t4a-itensornetworks-bench
+julia --project=$T4A_ITN_BENCH_PROJECT -e 'using Pkg; Pkg.develop(path=ENV["T4A_ITENSORNETWORKS_PATH"]); Pkg.add(["Graphs", "ITensors", "TensorOperations", "KrylovKit"]); Pkg.instantiate()'
+BLAS_NUM_THREADS=1 julia --project=$T4A_ITN_BENCH_PROJECT \
+  benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02
+```
+
+The Julia TDVP runner performs one untimed warm-up per topology, so reported
+times exclude Julia compilation, ITensorNetworks.jl first-call setup, and
+KrylovKit initialization. It uses `exponentiate_solver` with `ishermitian =
+true`, `krylovdim = 30`, `tol = 1e-12`, and `maxiter = 100`. The Julia runner
+asserts that the benchmark's selected leaf root matches ITensorNetworks.jl's
+default TDVP sweep root for the chain and star graphs.
 
 Non-AD local tensor operations:
 

--- a/benchmarks/julia/benchmark_tdvp_itensornetworks.jl
+++ b/benchmarks/julia/benchmark_tdvp_itensornetworks.jl
@@ -1,0 +1,197 @@
+# Two-site TDVP benchmark for ITensorNetworks.jl.
+#
+# Prefer running against a local ITensorNetworks.jl checkout in a temporary
+# benchmark project so the upstream checkout remains clean:
+#   export T4A_ITENSORNETWORKS_PATH=/home/shinaoka/tensor4all/ITensor/ITensorNetworks.jl
+#   export T4A_ITN_BENCH_PROJECT=/tmp/t4a-itensornetworks-bench
+#   julia --project=$T4A_ITN_BENCH_PROJECT -e 'using Pkg; Pkg.develop(path=ENV["T4A_ITENSORNETWORKS_PATH"]); Pkg.add(["Graphs", "ITensors", "TensorOperations", "KrylovKit"]); Pkg.instantiate()'
+#   BLAS_NUM_THREADS=1 julia --project=$T4A_ITN_BENCH_PROJECT \
+#     benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02
+#
+# Optional args:
+#   julia benchmark_tdvp_itensornetworks.jl <n_sites> <time_steps> <repeats> <dt>
+
+using Graphs: SimpleGraph, add_edge!, edges, src, dst
+import ITensorNetworks
+using ITensorNetworks:
+  OpSum, contract, exponentiate_solver, maxlinkdim, siteinds, time_evolve, ttn
+using ITensors: disable_warn_order
+using LinearAlgebra: Hermitian, eigen, norm
+using Statistics: mean
+using TensorOperations
+
+disable_warn_order()
+
+function make_graph(kind::Symbol, n_sites::Int)
+  g = SimpleGraph(n_sites)
+  if kind == :chain
+    for i in 1:(n_sites - 1)
+      add_edge!(g, i, i + 1)
+    end
+  elseif kind == :star
+    for i in 2:n_sites
+      add_edge!(g, 1, i)
+    end
+  else
+    error("unknown topology kind $kind")
+  end
+  return g
+end
+
+function heisenberg_opsum(g::SimpleGraph)
+  os = OpSum()
+  for edge in edges(g)
+    i = src(edge)
+    j = dst(edge)
+    os += 1.0, "X", i, "X", j
+    os += 1.0, "Y", i, "Y", j
+    os += 1.0, "Z", i, "Z", j
+  end
+  return os
+end
+
+root_vertex(kind::Symbol) = kind == :star ? 2 : 1
+
+initial_bit(site::Int) = isodd(site) ? 0 : 1
+
+function make_initial_state(sites, n_sites::Int)
+  state = Dict{Int, String}()
+  for site in 1:n_sites
+    state[site] = initial_bit(site) == 0 ? "Up" : "Dn"
+  end
+  return ttn(state, sites)
+end
+
+function initial_vector(n_sites::Int)
+  dim = 1 << n_sites
+  vector = zeros(ComplexF64, dim)
+  basis = 0
+  for site in 1:n_sites
+    basis |= initial_bit(site) << (site - 1)
+  end
+  vector[basis + 1] = 1.0 + 0.0im
+  return vector
+end
+
+function dense_heisenberg_matrix(g::SimpleGraph, n_sites::Int)
+  n_sites <= 10 || error("dense exact benchmark reference is capped at n_sites <= 10")
+  dim = 1 << n_sites
+  h = zeros(ComplexF64, dim, dim)
+  for input_state in 0:(dim - 1)
+    bits = [((input_state >> site) & 1) for site in 0:(n_sites - 1)]
+    for edge in edges(g)
+      left = src(edge) - 1
+      right = dst(edge) - 1
+      z_left = bits[left + 1] == 0 ? 1.0 : -1.0
+      z_right = bits[right + 1] == 0 ? 1.0 : -1.0
+      h[input_state + 1, input_state + 1] += z_left * z_right
+
+      flipped = xor(input_state, (1 << left), (1 << right))
+      yy_coeff = bits[left + 1] == bits[right + 1] ? -1.0 : 1.0
+      h[flipped + 1, input_state + 1] += 1.0 + yy_coeff
+    end
+  end
+  return h
+end
+
+function exact_evolve(h, initial, total_time::Float64)
+  decomp = eigen(Hermitian(h))
+  phases = exp.((-1.0im * total_time) .* decomp.values)
+  return decomp.vectors * (phases .* (decomp.vectors' * initial))
+end
+
+function state_vector(psi, n_sites::Int)
+  dense = contract(psi)
+  ordered_sites = [only(siteinds(psi, site)) for site in 1:n_sites]
+  return vec(Array(dense, ordered_sites...))
+end
+
+function summarize(times_ns)
+  seconds = times_ns ./ 1.0e9
+  return mean(seconds), minimum(seconds), maximum(seconds)
+end
+
+function run_tdvp_once(H, psi0, root::Int, time_steps::Int, dt::Float64)
+  time_points = collect(range(0.0, step = dt, length = time_steps + 1))
+  return time_evolve(
+    H,
+    time_points,
+    psi0;
+    order = 2,
+    nsites = 2,
+    root_vertex = root,
+    factorize_kwargs = (; cutoff = 1.0e-12, maxdim = 32),
+    update!_kwargs = (; nsites = 2, solver = exponentiate_solver),
+    exponentiate_solver_kwargs = (;
+      ishermitian = true,
+      issymmetric = true,
+      krylovdim = 30,
+      tol = 1.0e-12,
+      maxiter = 100,
+    ),
+  )
+end
+
+function run_case(kind::Symbol, n_sites::Int, time_steps::Int, repeats::Int, dt::Float64)
+  g = make_graph(kind, n_sites)
+  sites = siteinds("S=1/2", g)
+  root = root_vertex(kind)
+  # ITensorNetworks.jl's TDVP sweep planner uses the graph's default DFS root.
+  # Keep these benchmark topologies pinned to the same leaf root used below.
+  default_root = ITensorNetworks.GraphsExtensions.default_root_vertex(g)
+  default_root == root ||
+    error("benchmark root $(root) does not match ITensorNetworks default sweep root $(default_root)")
+  H = ttn(heisenberg_opsum(g), sites; root_vertex = root, cutoff = 1.0e-12)
+  psi0 = make_initial_state(sites, n_sites)
+  exact = exact_evolve(dense_heisenberg_matrix(g, n_sites), initial_vector(n_sites), dt * time_steps)
+  exact_norm = norm(exact)
+
+  # Exclude Julia compilation, ITensorNetworks.jl first-call setup, and KrylovKit
+  # initialization from the timed region. The timed loop below measures TDVP only.
+  run_tdvp_once(H, psi0, root, time_steps, dt)
+  GC.gc()
+
+  times = UInt64[]
+  state_norm = NaN
+  error = NaN
+  max_link_dim = 0
+  for _ in 1:repeats
+    start = time_ns()
+    psi_t = run_tdvp_once(H, psi0, root, time_steps, dt)
+    push!(times, time_ns() - start)
+    actual = state_vector(psi_t, n_sites)
+    state_norm = norm(actual)
+    error = norm(actual - exact)
+    max_link_dim = maxlinkdim(psi_t)
+  end
+
+  mean_s, min_s, max_s = summarize(times)
+  println(
+    "case=$(kind) n=$(n_sites) time_steps=$(time_steps) dt=$(round(dt, digits = 12)) " *
+    "time=$(round(dt * time_steps, digits = 12)) maxlinkdim=$(max_link_dim) " *
+    "warmups=1 repeats=$(repeats) norm=$(round(state_norm, digits = 12)) " *
+    "exact_norm=$(round(exact_norm, digits = 12)) l2_error=$(error) " *
+    "rel_l2_error=$(error / max(exact_norm, floatmin(Float64))) " *
+    "mean_ms=$(round(mean_s * 1000, digits = 3)) " *
+    "min_ms=$(round(min_s * 1000, digits = 3)) " *
+    "max_ms=$(round(max_s * 1000, digits = 3))"
+  )
+  return nothing
+end
+
+function main()
+  n_sites = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 8
+  time_steps = length(ARGS) >= 2 ? parse(Int, ARGS[2]) : 4
+  repeats = length(ARGS) >= 3 ? parse(Int, ARGS[3]) : 3
+  dt = length(ARGS) >= 4 ? parse(Float64, ARGS[4]) : 0.02
+  n_sites >= 2 || error("n_sites must be at least 2")
+  time_steps >= 1 || error("time_steps must be at least 1")
+  repeats >= 1 || error("repeats must be at least 1")
+  isfinite(dt) && dt > 0 || error("dt must be finite and positive")
+
+  run_case(:chain, n_sites, time_steps, repeats, dt)
+  run_case(:star, n_sites, time_steps, repeats, dt)
+  return nothing
+end
+
+main()

--- a/benchmarks/results/2026-06-27-treetn-tdvp-itensornetworks.md
+++ b/benchmarks/results/2026-06-27-treetn-tdvp-itensornetworks.md
@@ -1,0 +1,75 @@
+# TreeTN TDVP vs ITensorNetworks.jl Benchmark
+
+Date: 2026-06-27
+
+Purpose: compare the initial TreeTN TDVP implementation against a local
+ITensorNetworks.jl checkout on matching chain and non-chain tree topologies.
+
+Both runners evolve an alternating product state under the Pauli Heisenberg
+Hamiltonian `sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j` for total time
+`t = 0.08` using 4 two-site TDVP time steps of `dt = 0.02`. Both use
+`order = 2`, `maxdim = 32`, an ITensors-compatible relative discarded squared
+singular-value tail cutoff of `1e-12`, and Hermitian Krylov exponentials with
+`krylovdim = 30` and `tol = 1e-12`. The iteration caps are set to the same
+numeric value, `100`, but they are not identical semantics: Julia's
+KrylovKit `maxiter` controls adaptive Krylov restarts inside one exponential,
+while Rust's `max_time_splits` caps a step-halving retry schedule.
+
+Accuracy is the dense-vector L2 error against an exact dense Hermitian
+eigendecomposition reference. Dense materialization is used only by these
+small benchmark validators, not by the TDVP production algorithm.
+
+For the star topology, both runners use a leaf as the TDVP root. This matches
+ITensorNetworks.jl's `ttn(OpSum, ...)` requirement that the tree root be a leaf
+vertex. The Julia runner asserts that this leaf also matches
+ITensorNetworks.jl's default TDVP sweep root for the benchmark graph.
+
+## Commands
+
+Rust:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 \
+cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02
+```
+
+Julia:
+
+```bash
+export T4A_ITENSORNETWORKS_PATH=/home/shinaoka/tensor4all/ITensor/ITensorNetworks.jl
+export T4A_ITN_BENCH_PROJECT=/tmp/t4a-itensornetworks-bench-issue531
+julia --project=$T4A_ITN_BENCH_PROJECT -e 'using Pkg; Pkg.develop(path=ENV["T4A_ITENSORNETWORKS_PATH"]); Pkg.add(["Graphs", "ITensors", "TensorOperations", "KrylovKit"]); Pkg.instantiate()'
+BLAS_NUM_THREADS=1 julia --project=$T4A_ITN_BENCH_PROJECT \
+  benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02
+```
+
+The Julia runner performs one untimed warmup per topology and reuses the
+already-built initial state and operator in the timed loop, so reported timings
+exclude Julia compilation, ITensorNetworks.jl first-call setup, KrylovKit
+initialization, operator construction, and dense exact reference construction.
+
+## Representative Results
+
+| Implementation | Topology | N | Time steps | Total time | Repeats | Norm | L2 error | Relative L2 error | Mean ms | Min ms | Max ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Rust TreeTN TDVP | chain | 8 | 4 | 0.08 | 3 | 0.999999999998 | 1.375e-5 | 1.375e-5 | 205.519 | 203.475 | 209.107 |
+| ITensorNetworks.jl | chain | 8 | 4 | 0.08 | 3 | 0.999999999998 | 1.375e-5 | 1.375e-5 | 148.246 | 138.167 | 156.985 |
+| Rust TreeTN TDVP | star | 8 | 4 | 0.08 | 3 | 1.000000000000 | 3.999e-4 | 3.999e-4 | 1510.157 | 1507.512 | 1514.993 |
+| ITensorNetworks.jl | star | 8 | 4 | 0.08 | 3 | 1.000000000000 | 3.999e-4 | 3.999e-4 | 7988.115 | 7689.838 | 8563.478 |
+
+## Notes
+
+- The Rust benchmark source is `benchmarks/rust/benchmark_tdvp.rs`, included by
+  `crates/tensor4all-treetn/examples/benchmark_tdvp.rs`.
+- The Julia benchmark source is
+  `benchmarks/julia/benchmark_tdvp_itensornetworks.jl`.
+- The Rust benchmark reported `sweeps_completed=4` and `local_updates=104` for
+  both chain and star, confirming that all requested TDVP steps ran.
+- The Rust benchmark reported max Krylov diagnostic error `2.000e-2` and max
+  Krylov iterations `8` for both chain and star. The diagnostic error is a
+  successive-approximation quantity and can be nonzero when convergence is
+  certified by Lanczos breakdown in an invariant subspace; dense exact L2 error
+  above is the benchmark accuracy metric.
+- The chain case is a control for harness overhead and is faster in
+  ITensorNetworks.jl for this small run. The non-chain star case is faster in
+  Rust while matching ITensorNetworks.jl's dense exact error.

--- a/benchmarks/rust/benchmark_tdvp.rs
+++ b/benchmarks/rust/benchmark_tdvp.rs
@@ -1,0 +1,502 @@
+// Two-site TreeTN TDVP benchmark.
+//
+// Run:
+//   RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_tdvp --release
+//
+// Optional args:
+//   cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- <n_sites> <time_steps> <repeats> <dt>
+
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use num_complex::Complex64;
+use tensor4all_core::krylov::HermitianKrylovExpmOptions;
+use tensor4all_core::{
+    DynIndex, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorContractionLike,
+    TensorDynLen,
+};
+use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
+use tensor4all_treetn::{
+    compose_exclusive_linear_operators, tdvp, IndexMapping, LinearOperator, TdvpOptions, TreeTN,
+    TreeTopology, TruncationOptions,
+};
+
+const ITENSOR_CUTOFF: f64 = 1.0e-12;
+
+type BenchmarkState = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<Complex64>);
+
+fn itensor_cutoff_policy() -> SvdTruncationPolicy {
+    SvdTruncationPolicy::new(ITENSOR_CUTOFF)
+        .with_squared_values()
+        .with_discarded_tail_sum()
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Topology {
+    Chain,
+    Star,
+}
+
+impl Topology {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Chain => "chain",
+            Self::Star => "star",
+        }
+    }
+}
+
+fn node_name(i: usize) -> String {
+    format!("site{i}")
+}
+
+fn tdvp_root_name(topology: Topology) -> String {
+    match topology {
+        Topology::Chain => node_name(0),
+        Topology::Star => node_name(1),
+    }
+}
+
+fn benchmark_tdvp_options(time_steps: usize, dt: f64) -> TdvpOptions {
+    TdvpOptions::default()
+        .with_nsite(2)
+        .with_order(2)
+        .with_nsweeps(time_steps)
+        .with_exponent_step(Complex64::new(0.0, -dt))
+        .with_max_bond_dim(32)
+        .with_svd_policy(itensor_cutoff_policy())
+        .with_krylov_options(HermitianKrylovExpmOptions {
+            max_iter: 30,
+            max_time_splits: 100,
+            tol: 1.0e-12,
+            ..HermitianKrylovExpmOptions::default()
+        })
+}
+
+fn col_major_offset(coords: &[usize], dims: &[usize]) -> usize {
+    let mut stride = 1usize;
+    let mut offset = 0usize;
+    for (&coord, &dim) in coords.iter().zip(dims.iter()) {
+        offset += coord * stride;
+        stride *= dim;
+    }
+    offset
+}
+
+fn edges_for(topology: Topology, n_sites: usize) -> Vec<(usize, usize)> {
+    match topology {
+        Topology::Chain => (0..n_sites.saturating_sub(1)).map(|i| (i, i + 1)).collect(),
+        Topology::Star => (1..n_sites).map(|i| (0, i)).collect(),
+    }
+}
+
+fn initial_bit(site: usize) -> usize {
+    site % 2
+}
+
+fn make_initial_state(
+    topology: Topology,
+    n_sites: usize,
+) -> anyhow::Result<BenchmarkState> {
+    let edges = edges_for(topology, n_sites);
+    let sites: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+    let bonds: Vec<_> = (0..edges.len()).map(|_| DynIndex::new_dyn(1)).collect();
+    let mut incident: Vec<Vec<(usize, DynIndex)>> = vec![Vec::new(); n_sites];
+    for (edge_id, &(a, b)) in edges.iter().enumerate() {
+        incident[a].push((b, bonds[edge_id].clone()));
+        incident[b].push((a, bonds[edge_id].clone()));
+    }
+
+    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut graph_nodes = Vec::with_capacity(n_sites);
+    for i in 0..n_sites {
+        let mut indices = Vec::with_capacity(1 + incident[i].len());
+        for (_, bond) in &incident[i] {
+            indices.push(bond.clone());
+        }
+        indices.push(sites[i].clone());
+        let mut data = vec![Complex64::new(0.0, 0.0); indices.iter().map(DynIndex::dim).product()];
+        data[initial_bit(i)] = Complex64::new(1.0, 0.0);
+        let tensor = TensorDynLen::from_dense(indices, data)?;
+        graph_nodes.push(state.add_tensor(node_name(i), tensor)?);
+    }
+    for (edge_id, &(a, b)) in edges.iter().enumerate() {
+        state.connect(graph_nodes[a], &bonds[edge_id], graph_nodes[b], &bonds[edge_id])?;
+    }
+
+    let dim = 1usize << n_sites;
+    let mut vector = vec![Complex64::new(0.0, 0.0); dim];
+    let mut basis = 0usize;
+    for i in 0..n_sites {
+        basis |= initial_bit(i) << i;
+    }
+    vector[basis] = Complex64::new(1.0, 0.0);
+    Ok((state, sites, vector))
+}
+
+fn local_heisenberg_tensor(
+    out_left: DynIndex,
+    in_left: DynIndex,
+    out_right: DynIndex,
+    in_right: DynIndex,
+) -> anyhow::Result<TensorDynLen> {
+    let dims = [2, 2, 2, 2];
+    let mut data = vec![0.0; dims.iter().product()];
+
+    for left in 0..2 {
+        for right in 0..2 {
+            let z_left = if left == 0 { 1.0 } else { -1.0 };
+            let z_right = if right == 0 { 1.0 } else { -1.0 };
+            data[col_major_offset(&[left, left, right, right], &dims)] += z_left * z_right;
+
+            let yy_coeff = if left == right { -1.0 } else { 1.0 };
+            let flip_coeff = 1.0 + yy_coeff;
+            if flip_coeff != 0.0 {
+                data[col_major_offset(&[left ^ 1, left, right ^ 1, right], &dims)] += flip_coeff;
+            }
+        }
+    }
+
+    TensorDynLen::from_dense(vec![out_left, in_left, out_right, in_right], data)
+}
+
+fn make_edge_heisenberg_operator(
+    left: usize,
+    right: usize,
+    state_sites: &[DynIndex],
+    op_inputs: &[DynIndex],
+    op_outputs: &[DynIndex],
+) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+    let left_name = node_name(left);
+    let right_name = node_name(right);
+    let local = local_heisenberg_tensor(
+        op_outputs[left].clone(),
+        op_inputs[left].clone(),
+        op_outputs[right].clone(),
+        op_inputs[right].clone(),
+    )?;
+    let topology = TreeTopology::new(
+        HashMap::from([
+            (
+                left_name.clone(),
+                vec![op_outputs[left].clone(), op_inputs[left].clone()],
+            ),
+            (
+                right_name.clone(),
+                vec![op_outputs[right].clone(), op_inputs[right].clone()],
+            ),
+        ]),
+        vec![(left_name.clone(), right_name.clone())],
+    );
+    let mpo = tensor4all_treetn::factorize_tensor_to_treetn_with(
+        &local,
+        &topology,
+        FactorizeOptions::svd(),
+        &left_name,
+    )?;
+    let input_mapping = HashMap::from([
+        (
+            left_name.clone(),
+            IndexMapping {
+                true_index: state_sites[left].clone(),
+                internal_index: op_inputs[left].clone(),
+            },
+        ),
+        (
+            right_name.clone(),
+            IndexMapping {
+                true_index: state_sites[right].clone(),
+                internal_index: op_inputs[right].clone(),
+            },
+        ),
+    ]);
+    let output_mapping = HashMap::from([
+        (
+            left_name,
+            IndexMapping {
+                true_index: state_sites[left].clone(),
+                internal_index: op_outputs[left].clone(),
+            },
+        ),
+        (
+            right_name,
+            IndexMapping {
+                true_index: state_sites[right].clone(),
+                internal_index: op_outputs[right].clone(),
+            },
+        ),
+    ]);
+    Ok(LinearOperator::new(mpo, input_mapping, output_mapping))
+}
+
+fn make_heisenberg_operator(
+    topology: Topology,
+    state: &TreeTN<TensorDynLen, String>,
+    state_sites: &[DynIndex],
+) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+    let n_sites = state_sites.len();
+    let edges = edges_for(topology, n_sites);
+    let op_inputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+    let op_outputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
+
+    let gap_site_indices: HashMap<_, _> = (0..n_sites)
+        .map(|i| (node_name(i), vec![(op_inputs[i].clone(), op_outputs[i].clone())]))
+        .collect();
+    let mut term_mpos = Vec::with_capacity(edges.len());
+    for &(left, right) in &edges {
+        let edge_op =
+            make_edge_heisenberg_operator(left, right, state_sites, &op_inputs, &op_outputs)?;
+        let composed = compose_exclusive_linear_operators(
+            state.site_index_network(),
+            &[&edge_op],
+            &gap_site_indices,
+        )?;
+        term_mpos.push(composed.into_mpo());
+    }
+
+    let mpo = term_mpos
+        .into_iter()
+        .reduce(|acc, term| {
+            acc.add(&term)
+                .expect("matching Heisenberg MPO term topology")
+        })
+        .ok_or_else(|| anyhow::anyhow!("Heisenberg operator requires at least one edge"))?;
+    let mpo = mpo.truncate(
+        [node_name(0)],
+        TruncationOptions::default().with_svd_policy(itensor_cutoff_policy()),
+    )?;
+
+    let input_mapping: HashMap<_, _> = (0..n_sites)
+        .map(|i| {
+            (
+                node_name(i),
+                IndexMapping {
+                    true_index: state_sites[i].clone(),
+                    internal_index: op_inputs[i].clone(),
+                },
+            )
+        })
+        .collect();
+    let output_mapping: HashMap<_, _> = (0..n_sites)
+        .map(|i| {
+            (
+                node_name(i),
+                IndexMapping {
+                    true_index: state_sites[i].clone(),
+                    internal_index: op_outputs[i].clone(),
+                },
+            )
+        })
+        .collect();
+    mpo.verify_internal_consistency()?;
+
+    Ok(LinearOperator::new(mpo, input_mapping, output_mapping))
+}
+
+fn dense_heisenberg_matrix(topology: Topology, n_sites: usize) -> anyhow::Result<Matrix<Complex64>> {
+    anyhow::ensure!(
+        n_sites <= 10,
+        "dense exact benchmark reference is capped at n_sites <= 10"
+    );
+    let edges = edges_for(topology, n_sites);
+    let dim = 1usize << n_sites;
+    let mut data = vec![Complex64::new(0.0, 0.0); dim * dim];
+    for input_state in 0..dim {
+        let bits: Vec<_> = (0..n_sites)
+            .map(|site| (input_state >> site) & 1)
+            .collect();
+        for &(left, right) in &edges {
+            let z_left = if bits[left] == 0 { 1.0 } else { -1.0 };
+            let z_right = if bits[right] == 0 { 1.0 } else { -1.0 };
+            data[input_state + dim * input_state] += Complex64::new(z_left * z_right, 0.0);
+
+            let flipped = input_state ^ (1usize << left) ^ (1usize << right);
+            let yy_coeff = if bits[left] == bits[right] {
+                -1.0
+            } else {
+                1.0
+            };
+            data[flipped + dim * input_state] += Complex64::new(1.0 + yy_coeff, 0.0);
+        }
+    }
+    Ok(Matrix::from_col_major_vec(dim, dim, data))
+}
+
+fn exact_evolve(
+    hamiltonian: &Matrix<Complex64>,
+    initial: &[Complex64],
+    total_time: f64,
+) -> anyhow::Result<Vec<Complex64>> {
+    let n = hamiltonian.nrows();
+    anyhow::ensure!(hamiltonian.ncols() == n, "Hamiltonian must be square");
+    anyhow::ensure!(initial.len() == n, "initial vector length mismatch");
+
+    let decomp = hermitian_eigendecomposition(hamiltonian, 1.0e-10)?;
+    let vectors = decomp.eigenvectors.as_col_major_slice();
+    let mut coefficients = vec![Complex64::new(0.0, 0.0); n];
+    for col in 0..n {
+        let mut coeff = Complex64::new(0.0, 0.0);
+        for row in 0..n {
+            coeff += vectors[row + col * n].conj() * initial[row];
+        }
+        coefficients[col] = coeff;
+    }
+
+    let mut result = vec![Complex64::new(0.0, 0.0); n];
+    for col in 0..n {
+        let phase = (Complex64::new(0.0, -total_time) * decomp.eigenvalues[col]).exp();
+        let coeff = phase * coefficients[col];
+        for row in 0..n {
+            result[row] += vectors[row + col * n] * coeff;
+        }
+    }
+    Ok(result)
+}
+
+fn state_vector(
+    state: &TreeTN<TensorDynLen, String>,
+    sites: &[DynIndex],
+) -> anyhow::Result<Vec<Complex64>> {
+    let tensor = state.contract_to_tensor()?;
+    let aligned = tensor.permuteinds(sites)?;
+    aligned.to_vec::<Complex64>()
+}
+
+fn vector_norm(vector: &[Complex64]) -> f64 {
+    vector.iter().map(|z| z.norm_sqr()).sum::<f64>().sqrt()
+}
+
+fn l2_error(actual: &[Complex64], expected: &[Complex64]) -> f64 {
+    actual
+        .iter()
+        .zip(expected)
+        .map(|(a, e)| (*a - *e).norm_sqr())
+        .sum::<f64>()
+        .sqrt()
+}
+
+fn summarize(times: &[Duration]) -> (f64, f64, f64) {
+    let seconds: Vec<_> = times.iter().map(Duration::as_secs_f64).collect();
+    let mean = seconds.iter().sum::<f64>() / seconds.len() as f64;
+    let min = seconds.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = seconds.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    (mean, min, max)
+}
+
+fn run_case(
+    topology: Topology,
+    n_sites: usize,
+    time_steps: usize,
+    repeats: usize,
+    dt: f64,
+) -> anyhow::Result<()> {
+    let (state, sites, initial_vector) = make_initial_state(topology, n_sites)?;
+    let operator = make_heisenberg_operator(topology, &state, &sites)?;
+    let total_time = dt * time_steps as f64;
+    let exact = exact_evolve(
+        &dense_heisenberg_matrix(topology, n_sites)?,
+        &initial_vector,
+        total_time,
+    )?;
+    let exact_norm = vector_norm(&exact);
+    let root = tdvp_root_name(topology);
+    let options = benchmark_tdvp_options(time_steps, dt);
+
+    let warmup = tdvp(&operator, black_box(state.clone()), &root, options.clone())?;
+    black_box(&warmup.state);
+
+    let mut times = Vec::with_capacity(repeats);
+    let mut norm = f64::NAN;
+    let mut error = f64::NAN;
+    let mut sweeps_completed = 0usize;
+    let mut local_updates = 0usize;
+    let mut max_krylov_error = f64::NAN;
+    let mut max_krylov_iterations = 0usize;
+    for _ in 0..repeats {
+        let init = black_box(state.clone());
+        let start = Instant::now();
+        let result = tdvp(&operator, init, &root, options.clone())?;
+        times.push(start.elapsed());
+        let actual = state_vector(&result.state, &sites)?;
+        norm = vector_norm(&actual);
+        error = l2_error(&actual, &exact);
+        sweeps_completed = result.sweeps_completed;
+        local_updates = result.local_updates;
+        max_krylov_error = result.max_error_estimate;
+        max_krylov_iterations = result.max_krylov_iterations;
+        black_box(&result.state);
+    }
+
+    let (mean, min, max) = summarize(&times);
+    println!(
+        "case={} n={} time_steps={} dt={:.12} time={:.12} sweeps_completed={} local_updates={} warmups=1 repeats={} norm={:.12} exact_norm={:.12} l2_error={:.3e} rel_l2_error={:.3e} max_krylov_error={:.3e} max_krylov_iterations={} mean_ms={:.3} min_ms={:.3} max_ms={:.3}",
+        topology.label(),
+        n_sites,
+        time_steps,
+        dt,
+        total_time,
+        sweeps_completed,
+        local_updates,
+        repeats,
+        norm,
+        exact_norm,
+        error,
+        error / exact_norm.max(f64::MIN_POSITIVE),
+        max_krylov_error,
+        max_krylov_iterations,
+        mean * 1000.0,
+        min * 1000.0,
+        max * 1000.0,
+    );
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let n_sites = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let time_steps = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(4);
+    let repeats = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
+    let dt: f64 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(0.02);
+    anyhow::ensure!(n_sites >= 2, "n_sites must be at least 2");
+    anyhow::ensure!(time_steps >= 1, "time_steps must be at least 1");
+    anyhow::ensure!(repeats >= 1, "repeats must be at least 1");
+    anyhow::ensure!(dt.is_finite() && dt > 0.0, "dt must be finite and positive");
+
+    run_case(Topology::Chain, n_sites, time_steps, repeats, dt)?;
+    run_case(Topology::Star, n_sites, time_steps, repeats, dt)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::{SingularValueMeasure, ThresholdScale, TruncationRule};
+
+    #[test]
+    fn tdvp_benchmark_uses_itensors_cutoff_strategy() {
+        let policy = itensor_cutoff_policy();
+        assert_eq!(policy.threshold, ITENSOR_CUTOFF);
+        assert_eq!(policy.scale, ThresholdScale::Relative);
+        assert_eq!(policy.measure, SingularValueMeasure::SquaredValue);
+        assert_eq!(policy.rule, TruncationRule::DiscardedTailSum);
+    }
+
+    #[test]
+    fn star_benchmark_uses_itensornetworks_leaf_root() {
+        assert_eq!(tdvp_root_name(Topology::Chain), node_name(0));
+        assert_eq!(tdvp_root_name(Topology::Star), node_name(1));
+    }
+
+    #[test]
+    fn tdvp_benchmark_options_set_requested_solver_caps() {
+        let options = benchmark_tdvp_options(4, 0.02);
+        assert_eq!(options.nsite, 2);
+        assert_eq!(options.order, 2);
+        assert_eq!(options.nsweeps, 4);
+        assert_eq!(options.max_bond_dim, Some(32));
+        assert_eq!(options.krylov.max_iter, 30);
+        assert_eq!(options.krylov.max_time_splits, 100);
+        assert_eq!(options.krylov.tol, 1.0e-12);
+    }
+}

--- a/crates/tensor4all-core/src/krylov.rs
+++ b/crates/tensor4all-core/src/krylov.rs
@@ -41,7 +41,9 @@ use anyhow::Result;
 use num_complex::Complex64;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use tensor4all_tensorbackend::{lowest_hermitian_eigenpair, Matrix};
+use tensor4all_tensorbackend::{
+    hermitian_exponential_first_column, lowest_hermitian_eigenpair, Matrix,
+};
 
 static GMRES_OP_PROFILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -347,6 +349,91 @@ pub struct HermitianLanczosResult<T> {
     pub converged: bool,
 }
 
+/// Options for [`hermitian_krylov_expm_multiply`].
+///
+/// The routine builds a Hermitian Lanczos basis for a matrix-free operator,
+/// exponentiates the small projected Hermitian matrix, and combines the basis
+/// vectors without materializing the full operator. Scalar convergence checks
+/// and projected eigendecompositions are explicit non-differentiable
+/// boundaries; vector-space tensor operations preserve backend metadata when
+/// the underlying tensor implementation supports it.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::krylov::HermitianKrylovExpmOptions;
+///
+/// let options = HermitianKrylovExpmOptions {
+///     max_iter: 32,
+///     tol: 1.0e-10,
+///     ..HermitianKrylovExpmOptions::default()
+/// };
+/// assert_eq!(options.max_iter, 32);
+/// assert_eq!(options.tol, 1.0e-10);
+/// ```
+#[derive(Debug, Clone)]
+pub struct HermitianKrylovExpmOptions {
+    /// Maximum Krylov subspace dimension for one exponential application.
+    pub max_iter: usize,
+    /// Maximum number of equal time splits attempted after non-convergence.
+    pub max_time_splits: usize,
+    /// Relative convergence tolerance for successive Krylov approximants.
+    pub tol: f64,
+    /// Breakdown threshold for zero vectors and invariant Krylov subspaces.
+    pub breakdown_tol: f64,
+    /// Hermitian validation tolerance for projected matrices.
+    pub hermitian_tol: f64,
+    /// Whether to print per-attempt diagnostics.
+    pub verbose: bool,
+}
+
+impl Default for HermitianKrylovExpmOptions {
+    fn default() -> Self {
+        Self {
+            max_iter: 30,
+            max_time_splits: 100,
+            tol: 1.0e-12,
+            breakdown_tol: 1.0e-14,
+            hermitian_tol: 1.0e-10,
+            verbose: false,
+        }
+    }
+}
+
+/// Result of [`hermitian_krylov_expm_multiply`].
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::krylov::HermitianKrylovExpmResult;
+///
+/// let result = HermitianKrylovExpmResult {
+///     output: vec![1.0_f64, 0.0],
+///     iterations: 1,
+///     matvecs: 1,
+///     error_estimate: 0.0,
+///     converged: true,
+///     time_splits: 1,
+/// };
+/// assert!(result.converged);
+/// assert_eq!(result.output[0], 1.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct HermitianKrylovExpmResult<T> {
+    /// Approximation to `exp(exponent * A) * initial`.
+    pub output: T,
+    /// Total Krylov iterations over all accepted substeps.
+    pub iterations: usize,
+    /// Total matrix-vector products over all accepted substeps.
+    pub matvecs: usize,
+    /// Maximum successive-approximation error estimate.
+    pub error_estimate: f64,
+    /// Whether the requested tolerance was met.
+    pub converged: bool,
+    /// Number of equal time splits used.
+    pub time_splits: usize,
+}
+
 #[derive(Debug, Clone)]
 struct HermitianRitzState {
     eigenvalue: f64,
@@ -489,6 +576,261 @@ where
         &ritz_state,
         options,
     )
+}
+
+/// Apply `exp(exponent * A)` to a vector using a matrix-free Hermitian Krylov method.
+///
+/// This routine only materializes small projected Krylov matrices. It never
+/// forms the full matrix for `A`, so it can be used by tensor-network local
+/// solvers whose operator application is available as a closure.
+///
+/// # Arguments
+/// * `apply_a` - Matrix-free Hermitian operator application.
+/// * `exponent` - Scalar exponent, for example `-im * dt` for real-time TDVP.
+/// * `initial` - Initial vector.
+/// * `options` - Krylov dimension, tolerance, and Hermitian validation options.
+///
+/// # Returns
+/// A [`HermitianKrylovExpmResult`] containing the evolved vector and diagnostics.
+///
+/// # Errors
+/// Returns an error if an option is invalid, a vector-space operation fails,
+/// the projected matrix is not Hermitian, or the requested tolerance is not met
+/// after the configured time splits.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tensor4all_core::krylov::{
+///     hermitian_krylov_expm_multiply, HermitianKrylovExpmOptions,
+/// };
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let index = DynIndex::new_dyn(2);
+/// let initial = TensorDynLen::from_dense(
+///     vec![index.clone()],
+///     vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+/// )?;
+/// let options = HermitianKrylovExpmOptions {
+///     max_iter: 4,
+///     tol: 1.0e-12,
+///     ..Default::default()
+/// };
+/// let result = hermitian_krylov_expm_multiply(
+///     |x: &TensorDynLen| {
+///         let data = x.to_vec::<Complex64>()?;
+///         TensorDynLen::from_dense(
+///             vec![index.clone()],
+///             vec![data[0], Complex64::new(2.0, 0.0) * data[1]],
+///         )
+///     },
+///     Complex64::new(0.0, -0.25),
+///     &initial,
+///     &options,
+/// )?;
+/// let evolved = result.output.to_vec::<Complex64>()?;
+/// let expected = Complex64::new(0.25_f64.cos(), -0.25_f64.sin());
+/// assert!((evolved[0] - expected).norm() < 1.0e-10);
+/// assert!(evolved[1].norm() < 1.0e-12);
+/// # Ok(())
+/// # }
+/// ```
+pub fn hermitian_krylov_expm_multiply<T, F>(
+    apply_a: F,
+    exponent: Complex64,
+    initial: &T,
+    options: &HermitianKrylovExpmOptions,
+) -> Result<HermitianKrylovExpmResult<T>>
+where
+    T: TensorVectorSpace,
+    F: Fn(&T) -> Result<T>,
+{
+    validate_hermitian_krylov_expm_options(options)?;
+    initial.validate()?;
+
+    if exponent == Complex64::new(0.0, 0.0) {
+        return Ok(HermitianKrylovExpmResult {
+            output: initial.clone(),
+            iterations: 0,
+            matvecs: 0,
+            error_estimate: 0.0,
+            converged: true,
+            time_splits: 1,
+        });
+    }
+    if initial.norm() <= options.breakdown_tol {
+        return Ok(HermitianKrylovExpmResult {
+            output: initial.clone(),
+            iterations: 0,
+            matvecs: 0,
+            error_estimate: 0.0,
+            converged: true,
+            time_splits: 1,
+        });
+    }
+
+    let mut splits = 1usize;
+    loop {
+        let step_exponent = exponent / splits as f64;
+        let mut output = initial.clone();
+        let mut iterations = 0usize;
+        let mut matvecs = 0usize;
+        let mut max_error = 0.0_f64;
+        let mut converged = true;
+
+        for _ in 0..splits {
+            let result =
+                hermitian_krylov_expm_multiply_once(&apply_a, step_exponent, &output, options)?;
+            iterations += result.iterations;
+            matvecs += result.matvecs;
+            max_error = max_error.max(result.error_estimate);
+            output = result.output;
+            if !result.converged {
+                converged = false;
+                break;
+            }
+        }
+
+        if converged {
+            return Ok(HermitianKrylovExpmResult {
+                output,
+                iterations,
+                matvecs,
+                error_estimate: max_error,
+                converged: true,
+                time_splits: splits,
+            });
+        }
+
+        if options.verbose {
+            eprintln!(
+                "Hermitian Krylov expm did not converge with {splits} time split(s); retrying"
+            );
+        }
+        if splits >= options.max_time_splits {
+            return Err(anyhow::anyhow!(
+                "hermitian_krylov_expm_multiply did not converge within max_time_splits={} and max_iter={}",
+                options.max_time_splits,
+                options.max_iter
+            ));
+        }
+        splits = splits.saturating_mul(2).min(options.max_time_splits);
+    }
+}
+
+fn hermitian_krylov_expm_multiply_once<T, F>(
+    apply_a: &F,
+    exponent: Complex64,
+    initial: &T,
+    options: &HermitianKrylovExpmOptions,
+) -> Result<HermitianKrylovExpmResult<T>>
+where
+    T: TensorVectorSpace,
+    F: Fn(&T) -> Result<T>,
+{
+    let initial_norm = initial.norm();
+    if initial_norm <= options.breakdown_tol {
+        return Ok(HermitianKrylovExpmResult {
+            output: initial.clone(),
+            iterations: 0,
+            matvecs: 0,
+            error_estimate: 0.0,
+            converged: true,
+            time_splits: 1,
+        });
+    }
+
+    let mut basis = Vec::with_capacity(options.max_iter + 1);
+    basis.push(initial.scale(AnyScalar::new_real(1.0 / initial_norm))?);
+    let mut h_cols: Vec<Vec<Complex64>> = Vec::with_capacity(options.max_iter);
+    let mut previous: Option<T> = None;
+    let mut last: Option<HermitianKrylovExpmResult<T>> = None;
+    let threshold = options.tol * initial_norm.max(1.0);
+
+    for j in 0..options.max_iter {
+        let w = apply_a(&basis[j])?;
+        if j == 0 {
+            w.validate()?;
+        }
+        let mut w_orth = w;
+        let mut h_col = Vec::with_capacity(j + 2);
+
+        for v_i in basis.iter().take(j + 1) {
+            let h_ij = v_i.inner_product(&w_orth)?;
+            h_col.push(any_scalar_to_complex(&h_ij));
+            let neg_h_ij = AnyScalar::new_real(0.0) - h_ij;
+            w_orth = w_orth.axpby(AnyScalar::new_real(1.0), v_i, neg_h_ij)?;
+        }
+
+        for (i, v_i) in basis.iter().take(j + 1).enumerate() {
+            let correction = v_i.inner_product(&w_orth)?;
+            h_col[i] += any_scalar_to_complex(&correction);
+            let neg_correction = AnyScalar::new_real(0.0) - correction;
+            w_orth = w_orth.axpby(AnyScalar::new_real(1.0), v_i, neg_correction)?;
+        }
+
+        let beta_next = w_orth.norm();
+        h_col.push(Complex64::new(beta_next, 0.0));
+        h_cols.push(h_col);
+
+        let subspace_dim = j + 1;
+        let projected = projected_matrix_from_columns(&h_cols, subspace_dim);
+        let coefficients =
+            hermitian_exponential_first_column(&projected, exponent, options.hermitian_tol)
+                .map_err(|err| anyhow::anyhow!("projected operator is not Hermitian: {err}"))?;
+        let unit_output = combine_basis_with_complex_coefficients(
+            &basis[..subspace_dim],
+            &coefficients,
+            options.hermitian_tol,
+            "hermitian_krylov_expm_multiply",
+        )?;
+        let output = unit_output.scale(AnyScalar::new_real(initial_norm))?;
+        let mut error_estimate = match &previous {
+            Some(previous) => output
+                .axpby(
+                    AnyScalar::new_real(1.0),
+                    previous,
+                    AnyScalar::new_real(-1.0),
+                )?
+                .norm(),
+            None => f64::INFINITY,
+        };
+        let converged = beta_next <= options.breakdown_tol || error_estimate <= threshold;
+        if converged && beta_next <= options.breakdown_tol && previous.is_none() {
+            error_estimate = 0.0;
+        }
+
+        if options.verbose {
+            eprintln!(
+                "Hermitian Krylov expm iter {}: error_estimate={:.6e} threshold={:.6e}",
+                subspace_dim, error_estimate, threshold
+            );
+        }
+
+        let result = HermitianKrylovExpmResult {
+            output: output.clone(),
+            iterations: subspace_dim,
+            matvecs: subspace_dim,
+            error_estimate,
+            converged,
+            time_splits: 1,
+        };
+        if converged {
+            return Ok(result);
+        }
+        if beta_next <= options.breakdown_tol {
+            return Ok(result);
+        }
+        previous = Some(output);
+        last = Some(result);
+        basis.push(w_orth.scale(AnyScalar::new_real(1.0 / beta_next))?);
+    }
+
+    last.ok_or_else(|| {
+        anyhow::anyhow!("hermitian_krylov_expm_multiply: max_iter must be greater than zero")
+    })
 }
 
 /// Solve `A x = b` using GMRES (Generalized Minimal Residual Method).
@@ -2024,6 +2366,30 @@ fn validate_hermitian_lanczos_options(options: &HermitianLanczosOptions) -> Resu
     Ok(())
 }
 
+fn validate_hermitian_krylov_expm_options(options: &HermitianKrylovExpmOptions) -> Result<()> {
+    anyhow::ensure!(
+        options.max_iter > 0,
+        "hermitian_krylov_expm_multiply: max_iter must be greater than zero"
+    );
+    anyhow::ensure!(
+        options.max_time_splits > 0,
+        "hermitian_krylov_expm_multiply: max_time_splits must be greater than zero"
+    );
+    anyhow::ensure!(
+        options.tol.is_finite() && options.tol >= 0.0,
+        "hermitian_krylov_expm_multiply: tol must be finite and non-negative"
+    );
+    anyhow::ensure!(
+        options.breakdown_tol.is_finite() && options.breakdown_tol >= 0.0,
+        "hermitian_krylov_expm_multiply: breakdown_tol must be finite and non-negative"
+    );
+    anyhow::ensure!(
+        options.hermitian_tol.is_finite() && options.hermitian_tol >= 0.0,
+        "hermitian_krylov_expm_multiply: hermitian_tol must be finite and non-negative"
+    );
+    Ok(())
+}
+
 fn projected_matrix_from_columns(h_cols: &[Vec<Complex64>], dim: usize) -> Matrix<Complex64> {
     let mut data = vec![Complex64::new(0.0, 0.0); dim * dim];
     for col in 0..dim {
@@ -2128,6 +2494,34 @@ where
             AnyScalar::new_real(1.0),
             basis_vector,
             any_scalar_from_complex(*coefficient, options.hermitian_tol)?,
+        )?;
+    }
+    Ok(result)
+}
+
+fn combine_basis_with_complex_coefficients<T>(
+    basis: &[T],
+    coefficients: &[Complex64],
+    hermitian_tol: f64,
+    context: &'static str,
+) -> Result<T>
+where
+    T: TensorVectorSpace,
+{
+    anyhow::ensure!(!basis.is_empty(), "{context}: empty Krylov basis");
+    anyhow::ensure!(
+        basis.len() == coefficients.len(),
+        "{context}: coefficient length {} does not match basis length {}",
+        coefficients.len(),
+        basis.len()
+    );
+
+    let mut result = basis[0].scale(any_scalar_from_complex(coefficients[0], hermitian_tol)?)?;
+    for (basis_vector, coefficient) in basis.iter().zip(coefficients.iter()).skip(1) {
+        result = result.axpby(
+            AnyScalar::new_real(1.0),
+            basis_vector,
+            any_scalar_from_complex(*coefficient, hermitian_tol)?,
         )?;
     }
     Ok(result)

--- a/crates/tensor4all-core/src/krylov/tests/mod.rs
+++ b/crates/tensor4all-core/src/krylov/tests/mod.rs
@@ -228,6 +228,151 @@ fn hermitian_lanczos_lowest_eigenpair_rejects_non_hermitian_projection() {
 }
 
 #[test]
+fn hermitian_krylov_expm_multiply_diagonal_real_time_matches_exact() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_c64(
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+        &idx,
+    );
+
+    let result = hermitian_krylov_expm_multiply(
+        |x: &TensorDynLen| scale_vector_c64(x, &[1.0, 3.0]),
+        Complex64::new(0.0, -0.25),
+        &initial,
+        &HermitianKrylovExpmOptions {
+            max_iter: 8,
+            tol: 1.0e-12,
+            ..HermitianKrylovExpmOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert!(result.converged, "error={:.3e}", result.error_estimate);
+    let actual = result.output.to_vec::<Complex64>().unwrap();
+    let expected0 = Complex64::new(0.25_f64.cos(), -0.25_f64.sin());
+    let expected1 = Complex64::new(2.0 * 0.75_f64.cos(), -2.0 * 0.75_f64.sin());
+    assert!((actual[0] - expected0).norm() < 1.0e-10);
+    assert!((actual[1] - expected1).norm() < 1.0e-10);
+}
+
+#[test]
+fn hermitian_krylov_expm_multiply_first_step_breakdown_reports_finite_error() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_c64(
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+        &idx,
+    );
+
+    let result = hermitian_krylov_expm_multiply(
+        |x: &TensorDynLen| scale_vector_c64(x, &[2.0, 2.0]),
+        Complex64::new(0.0, -0.25),
+        &initial,
+        &HermitianKrylovExpmOptions::default(),
+    )
+    .unwrap();
+
+    assert!(result.converged);
+    assert_eq!(result.iterations, 1);
+    assert!(result.error_estimate.is_finite());
+    assert!(result.error_estimate <= 1.0e-15);
+    let actual = result.output.to_vec::<Complex64>().unwrap();
+    let phase = Complex64::new(0.5_f64.cos(), -0.5_f64.sin());
+    assert!((actual[0] - phase).norm() < 1.0e-10);
+    assert!((actual[1] - Complex64::new(2.0, 0.0) * phase).norm() < 1.0e-10);
+}
+
+#[test]
+fn hermitian_krylov_expm_multiply_zero_exponent_returns_input() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_c64(
+        vec![Complex64::new(2.0, 1.0), Complex64::new(-3.0, 0.5)],
+        &idx,
+    );
+
+    let result = hermitian_krylov_expm_multiply(
+        |_x: &TensorDynLen| panic!("zero exponent must not request a matvec"),
+        Complex64::new(0.0, 0.0),
+        &initial,
+        &HermitianKrylovExpmOptions::default(),
+    )
+    .unwrap();
+
+    assert!(result.converged);
+    assert_eq!(result.matvecs, 0);
+    assert_eq!(
+        result.output.to_vec::<Complex64>().unwrap(),
+        initial.to_vec::<Complex64>().unwrap()
+    );
+}
+
+#[test]
+fn hermitian_krylov_expm_multiply_zero_initial_returns_zero_without_matvecs() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_c64(vec![Complex64::new(0.0, 0.0); 2], &idx);
+
+    let result = hermitian_krylov_expm_multiply(
+        |_x: &TensorDynLen| panic!("zero input must not request a matvec"),
+        Complex64::new(0.0, -0.25),
+        &initial,
+        &HermitianKrylovExpmOptions::default(),
+    )
+    .unwrap();
+
+    assert!(result.converged);
+    assert_eq!(result.matvecs, 0);
+    assert_eq!(
+        result.output.to_vec::<Complex64>().unwrap(),
+        initial.to_vec::<Complex64>().unwrap()
+    );
+}
+
+#[test]
+fn hermitian_krylov_expm_multiply_real_tensor_promotes_complex_evolution() {
+    let idx = DynIndex::new_dyn(2);
+    let initial = make_vector_with_index(vec![1.0, 0.0], &idx);
+
+    let result = hermitian_krylov_expm_multiply(
+        |x: &TensorDynLen| apply_matrix2_f64(x, &[0.0, 1.0, 1.0, 0.0]),
+        Complex64::new(0.0, -0.5),
+        &initial,
+        &HermitianKrylovExpmOptions::default(),
+    )
+    .unwrap();
+
+    let actual = result.output.to_vec::<Complex64>().unwrap();
+    assert!((actual[0] - Complex64::new(0.5_f64.cos(), 0.0)).norm() < 1.0e-10);
+    assert!((actual[1] - Complex64::new(0.0, -0.5_f64.sin())).norm() < 1.0e-10);
+}
+
+#[test]
+fn hermitian_krylov_expm_multiply_errors_when_unconverged() {
+    let idx = DynIndex::new_dyn(3);
+    let initial = make_vector_c64(
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ],
+        &idx,
+    );
+
+    let err = hermitian_krylov_expm_multiply(
+        |x: &TensorDynLen| scale_vector_c64(x, &[1.0, 2.0, 3.0]),
+        Complex64::new(0.0, -1.0),
+        &initial,
+        &HermitianKrylovExpmOptions {
+            max_iter: 1,
+            max_time_splits: 1,
+            tol: 1.0e-14,
+            ..HermitianKrylovExpmOptions::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("did not converge"));
+}
+
+#[test]
 fn gmres_accepts_vector_space_without_tensorlike() {
     let b = PlainVector {
         data: vec![1.0, -2.0],
@@ -669,6 +814,16 @@ fn make_vector_with_index(data: Vec<f64>, idx: &DynIndex) -> TensorDynLen {
 fn scale_vector_f64(x: &TensorDynLen, diag: &[f64]) -> Result<TensorDynLen> {
     let x_data = x.to_vec::<f64>()?;
     let result_data: Vec<f64> = x_data
+        .iter()
+        .zip(diag.iter())
+        .map(|(&xi, &di)| xi * di)
+        .collect();
+    Ok(TensorDynLen::from_dense(x.indices.clone(), result_data).unwrap())
+}
+
+fn scale_vector_c64(x: &TensorDynLen, diag: &[f64]) -> Result<TensorDynLen> {
+    let x_data = x.to_vec::<Complex64>()?;
+    let result_data: Vec<_> = x_data
         .iter()
         .zip(diag.iter())
         .map(|(&xi, &di)| xi * di)

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -37,9 +37,11 @@ pub use backend::{
 pub use context::{default_eager_ctx, with_default_backend};
 pub use matrix::{
     batched_mat_mul_same_shape, batched_mat_mul_same_shape_owned, from_vec2d,
-    lowest_hermitian_eigenpair, mat_mul, mat_mul_owned, submatrix, submatrix_argmax, swap_cols,
-    swap_rows, transpose, try_from_vec2d, BlasMul, HermitianEigenError, HermitianEigenScalar,
-    HermitianEigenpair, Matrix, MatrixScalar, MatrixShapeError, MatrixTensorConversionError,
+    hermitian_eigendecomposition, hermitian_exponential_first_column, lowest_hermitian_eigenpair,
+    mat_mul, mat_mul_owned, submatrix, submatrix_argmax, swap_cols, swap_rows, transpose,
+    try_from_vec2d, BlasMul, HermitianEigenError, HermitianEigenScalar,
+    HermitianEigendecomposition, HermitianEigenpair, Matrix, MatrixScalar, MatrixShapeError,
+    MatrixTensorConversionError,
 };
 pub use memory::{release_process_allocator_cached_memory, AllocatorPressureRelief};
 pub use storage::{

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -122,8 +122,9 @@ pub enum MatrixShapeError {
 ///
 /// The eigensolver is intended for small Rayleigh-Ritz projected matrices. It
 /// validates shape and Hermitian structure before calling the backend Hermitian
-/// eigendecomposition, so non-Hermitian effective operators are rejected
-/// explicitly instead of silently taking a real part.
+/// eigendecomposition, symmetrizing only roundoff that is within the requested
+/// tolerance. Non-Hermitian effective operators are rejected explicitly instead
+/// of silently taking a real part.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum HermitianEigenError {
     /// The matrix has zero rows and columns, so it has no eigenpair.
@@ -154,7 +155,7 @@ pub enum HermitianEigenError {
         col: usize,
         /// Absolute Hermitian residual for the offending pair.
         difference: f64,
-        /// Tolerance used for validation.
+        /// Effective tolerance used for this entry pair.
         tolerance: f64,
     },
     /// The backend returned an output with an unexpected dtype.
@@ -210,6 +211,31 @@ pub struct HermitianEigenpair<T> {
     pub eigenvector: Vec<T>,
 }
 
+/// Full eigendecomposition of a small Hermitian projected matrix.
+///
+/// `eigenvectors` stores one normalized eigenvector per column in column-major
+/// [`Matrix`] layout. Eigenvalues are returned in the backend's ascending
+/// Hermitian eigensolver order.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
+///
+/// let matrix = Matrix::from_col_major_vec(2, 2, vec![1.0, 0.0, 0.0, 2.0]);
+/// let decomp = hermitian_eigendecomposition(&matrix, 1.0e-12).unwrap();
+/// assert_eq!(decomp.eigenvalues, vec![1.0, 2.0]);
+/// assert_eq!(decomp.eigenvectors.nrows(), 2);
+/// assert_eq!(decomp.eigenvectors.ncols(), 2);
+/// ```
+#[derive(Debug, Clone)]
+pub struct HermitianEigendecomposition<T> {
+    /// Real eigenvalues of the Hermitian matrix.
+    pub eigenvalues: Vec<f64>,
+    /// Eigenvector matrix with one eigenvector in each column.
+    pub eigenvectors: Matrix<T>,
+}
+
 /// Scalar types supported by [`lowest_hermitian_eigenpair`].
 ///
 /// The current backend path is used for `f64` and `Complex64`, which are the
@@ -219,15 +245,33 @@ pub trait HermitianEigenScalar: TensorScalar + MatrixScalar {
     fn hermitian_difference(a_ij: Self, a_ji: Self) -> f64;
 
     #[doc(hidden)]
+    fn hermitian_scale(a_ij: Self, a_ji: Self) -> f64;
+
+    #[doc(hidden)]
+    fn symmetrized_hermitian_pair(a_ij: Self, a_ji: Self) -> (Self, Self);
+
+    #[doc(hidden)]
     fn eigenvalues_from_tensor(
         tensor: Tensor,
         tolerance: f64,
     ) -> std::result::Result<(Vec<usize>, Vec<f64>), HermitianEigenError>;
+
+    #[doc(hidden)]
+    fn to_complex64(value: Self) -> Complex64;
 }
 
 impl HermitianEigenScalar for f64 {
     fn hermitian_difference(a_ij: Self, a_ji: Self) -> f64 {
         (a_ij - a_ji).abs()
+    }
+
+    fn hermitian_scale(a_ij: Self, a_ji: Self) -> f64 {
+        a_ij.abs().max(a_ji.abs()).max(1.0)
+    }
+
+    fn symmetrized_hermitian_pair(a_ij: Self, a_ji: Self) -> (Self, Self) {
+        let value = 0.5 * (a_ij + a_ji);
+        (value, value)
     }
 
     fn eigenvalues_from_tensor(
@@ -237,11 +281,24 @@ impl HermitianEigenScalar for f64 {
         let values = typed_eigh_output::<f64>("eigenvalues", tensor)?;
         Ok((values.shape().to_vec(), values.as_slice().to_vec()))
     }
+
+    fn to_complex64(value: Self) -> Complex64 {
+        Complex64::new(value, 0.0)
+    }
 }
 
 impl HermitianEigenScalar for Complex64 {
     fn hermitian_difference(a_ij: Self, a_ji: Self) -> f64 {
         (a_ij - a_ji.conj()).norm()
+    }
+
+    fn hermitian_scale(a_ij: Self, a_ji: Self) -> f64 {
+        a_ij.norm().max(a_ji.norm()).max(1.0)
+    }
+
+    fn symmetrized_hermitian_pair(a_ij: Self, a_ji: Self) -> (Self, Self) {
+        let value = 0.5 * (a_ij + a_ji.conj());
+        (value, value.conj())
     }
 
     fn eigenvalues_from_tensor(
@@ -252,16 +309,21 @@ impl HermitianEigenScalar for Complex64 {
         let mut real_values = Vec::with_capacity(values.as_slice().len());
         for (index, value) in values.as_slice().iter().copied().enumerate() {
             let imaginary = value.im.abs();
-            if imaginary > tolerance {
+            let allowed = tolerance * value.norm().max(1.0);
+            if imaginary > allowed {
                 return Err(HermitianEigenError::NonRealEigenvalue {
                     index,
                     imaginary,
-                    tolerance,
+                    tolerance: allowed,
                 });
             }
             real_values.push(value.re);
         }
         Ok((values.shape().to_vec(), real_values))
+    }
+
+    fn to_complex64(value: Self) -> Complex64 {
+        value
     }
 }
 
@@ -443,14 +505,16 @@ impl<T> Matrix<T> {
 /// Compute the smallest eigenpair of a small Hermitian projected matrix.
 ///
 /// This function validates that `matrix` is square, non-empty, and Hermitian
-/// within `hermitian_tol`, then calls tenferro's Hermitian eigendecomposition.
-/// It is intended for Rayleigh-Ritz projected Krylov matrices, whose dimension
-/// is bounded by the Krylov subspace size. It must not be used to materialize a
-/// full tensor-network effective Hamiltonian.
+/// within `hermitian_tol`, symmetrizes accepted roundoff as `(A + A†) / 2`,
+/// then calls tenferro's Hermitian eigendecomposition. It is intended for
+/// Rayleigh-Ritz projected Krylov matrices, whose dimension is bounded by the
+/// Krylov subspace size. It must not be used to materialize a full
+/// tensor-network effective Hamiltonian.
 ///
 /// # Arguments
 /// * `matrix` - Small dense Hermitian matrix in column-major [`Matrix`] layout.
-/// * `hermitian_tol` - Absolute tolerance for `A[i, j] = conj(A[j, i])`.
+/// * `hermitian_tol` - Relative tolerance for `A[i, j] = conj(A[j, i])`,
+///   applied as `hermitian_tol * max(1, |A[i,j]|, |A[j,i]|)`.
 ///   Typical values are `1e-12` for `f64`/`Complex64` projected matrices.
 ///
 /// # Returns
@@ -480,7 +544,66 @@ pub fn lowest_hermitian_eigenpair<T>(
 where
     T: HermitianEigenScalar,
 {
-    validate_hermitian_matrix(matrix, hermitian_tol)?;
+    let decomp = hermitian_eigendecomposition(matrix, hermitian_tol)?;
+
+    let (min_col, eigenvalue) = decomp
+        .eigenvalues
+        .iter()
+        .copied()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.total_cmp(b))
+        .ok_or(HermitianEigenError::Empty)?;
+
+    let n = decomp.eigenvalues.len();
+    let vector_data = decomp.eigenvectors.as_col_major_slice();
+    let start = n * min_col;
+    let eigenvector = vector_data[start..start + n].to_vec();
+
+    Ok(HermitianEigenpair {
+        eigenvalue,
+        eigenvector,
+    })
+}
+
+/// Compute all eigenpairs of a small Hermitian projected matrix.
+///
+/// This validates Hermitian structure and symmetrizes accepted roundoff before
+/// calling the backend. It is meant for bounded Krylov/Rayleigh-Ritz matrices,
+/// not full tensor-network materialization.
+///
+/// # Arguments
+///
+/// * `matrix` - Square Hermitian matrix in column-major [`Matrix`] layout.
+/// * `hermitian_tol` - Relative tolerance for checking `A = A†`, applied per
+///   entry pair with scale `max(1, |A[i,j]|, |A[j,i]|)`.
+///
+/// # Returns
+///
+/// All real eigenvalues and all eigenvectors of `matrix`.
+///
+/// # Errors
+///
+/// Returns [`HermitianEigenError`] if `matrix` is not square, is not Hermitian
+/// within `hermitian_tol`, or the backend eigensolver fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
+///
+/// let matrix = Matrix::from_col_major_vec(2, 2, vec![3.0, 0.0, 0.0, 5.0]);
+/// let decomp = hermitian_eigendecomposition(&matrix, 1.0e-12).unwrap();
+/// assert_eq!(decomp.eigenvalues, vec![3.0, 5.0]);
+/// assert_eq!(decomp.eigenvectors.as_col_major_slice().len(), 4);
+/// ```
+pub fn hermitian_eigendecomposition<T>(
+    matrix: &Matrix<T>,
+    hermitian_tol: f64,
+) -> std::result::Result<HermitianEigendecomposition<T>, HermitianEigenError>
+where
+    T: HermitianEigenScalar,
+{
+    let matrix = validate_and_symmetrize_hermitian_matrix(matrix, hermitian_tol)?;
 
     let n = matrix.nrows();
     let input_tensor = T::into_tensor(vec![n, n], matrix.as_col_major_slice().to_vec());
@@ -491,32 +614,85 @@ where
         }
     })?;
 
-    let (values_shape, values) = T::eigenvalues_from_tensor(values.data().clone(), hermitian_tol)?;
+    let (values_shape, eigenvalues) =
+        T::eigenvalues_from_tensor(values.data().clone(), hermitian_tol)?;
     ensure_eigh_shape("eigenvalues", &values_shape, &[n])?;
     let vectors = typed_eigh_output::<T>("eigenvectors", vectors.data().clone())?;
     ensure_eigh_shape("eigenvectors", vectors.shape(), &[n, n])?;
 
-    let (min_col, eigenvalue) = values
-        .iter()
-        .copied()
-        .enumerate()
-        .min_by(|(_, a), (_, b)| a.total_cmp(b))
-        .ok_or(HermitianEigenError::Empty)?;
-
-    let vector_data = vectors.as_slice();
-    let start = n * min_col;
-    let eigenvector = vector_data[start..start + n].to_vec();
-
-    Ok(HermitianEigenpair {
-        eigenvalue,
-        eigenvector,
+    Ok(HermitianEigendecomposition {
+        eigenvalues,
+        eigenvectors: Matrix::from_col_major_vec(n, n, vectors.as_slice().to_vec()),
     })
 }
 
-fn validate_hermitian_matrix<T>(
+/// Compute the first column of `exp(exponent * A)` for a small Hermitian matrix.
+///
+/// Krylov exponential routines use this for the projected matrix action on the
+/// first basis vector. The returned coefficients are complex even when `A` is
+/// real because real-time evolution has complex phases.
+///
+/// # Arguments
+///
+/// * `matrix` - Square Hermitian matrix in column-major [`Matrix`] layout.
+/// * `exponent` - Scalar multiplier in `exp(exponent * A)`.
+/// * `hermitian_tol` - Relative tolerance for checking `A = A†`; accepted
+///   roundoff is symmetrized before eigensolving.
+///
+/// # Returns
+///
+/// The first column of the matrix exponential.
+///
+/// # Errors
+///
+/// Returns [`HermitianEigenError`] if Hermitian validation or eigensolving
+/// fails.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tensor4all_tensorbackend::{hermitian_exponential_first_column, Matrix};
+///
+/// let matrix = Matrix::from_col_major_vec(2, 2, vec![1.0, 0.0, 0.0, 2.0]);
+/// let column = hermitian_exponential_first_column(
+///     &matrix,
+///     Complex64::new(0.0, -0.5),
+///     1.0e-12,
+/// ).unwrap();
+/// let expected = Complex64::new(0.5_f64.cos(), -0.5_f64.sin());
+/// assert!((column[0] - expected).norm() < 1.0e-12);
+/// assert!(column[1].norm() < 1.0e-12);
+/// ```
+pub fn hermitian_exponential_first_column<T>(
+    matrix: &Matrix<T>,
+    exponent: Complex64,
+    hermitian_tol: f64,
+) -> std::result::Result<Vec<Complex64>, HermitianEigenError>
+where
+    T: HermitianEigenScalar,
+{
+    let decomp = hermitian_eigendecomposition(matrix, hermitian_tol)?;
+    let n = decomp.eigenvalues.len();
+    let vectors = decomp.eigenvectors.as_col_major_slice();
+    let mut result = vec![Complex64::new(0.0, 0.0); n];
+
+    for col in 0..n {
+        let lambda = decomp.eigenvalues[col];
+        let phase = (exponent * lambda).exp();
+        let first_component = T::to_complex64(vectors[col * n]).conj();
+        for row in 0..n {
+            result[row] += T::to_complex64(vectors[row + col * n]) * phase * first_component;
+        }
+    }
+
+    Ok(result)
+}
+
+fn validate_and_symmetrize_hermitian_matrix<T>(
     matrix: &Matrix<T>,
     hermitian_tol: f64,
-) -> std::result::Result<(), HermitianEigenError>
+) -> std::result::Result<Matrix<T>, HermitianEigenError>
 where
     T: HermitianEigenScalar,
 {
@@ -535,20 +711,28 @@ where
         return Err(HermitianEigenError::Empty);
     }
 
+    let n = matrix.nrows();
+    let mut data = matrix.as_col_major_slice().to_vec();
     for col in 0..matrix.ncols() {
         for row in 0..=col {
-            let difference = T::hermitian_difference(matrix[[row, col]], matrix[[col, row]]);
-            if difference > hermitian_tol {
+            let row_col = matrix[[row, col]];
+            let col_row = matrix[[col, row]];
+            let difference = T::hermitian_difference(row_col, col_row);
+            let tolerance = hermitian_tol * T::hermitian_scale(row_col, col_row);
+            if difference > tolerance {
                 return Err(HermitianEigenError::NonHermitian {
                     row,
                     col,
                     difference,
-                    tolerance: hermitian_tol,
+                    tolerance,
                 });
             }
+            let (row_col, col_row) = T::symmetrized_hermitian_pair(row_col, col_row);
+            data[row + n * col] = row_col;
+            data[col + n * row] = col_row;
         }
     }
-    Ok(())
+    Ok(Matrix::from_col_major_vec(n, n, data))
 }
 
 fn typed_eigh_output<T>(

--- a/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix/tests/mod.rs
@@ -52,6 +52,23 @@ fn projected_hermitian_lowest_eigenpair_works_for_real_symmetric_matrix() {
 }
 
 #[test]
+fn hermitian_eigendecomposition_returns_all_real_symmetric_pairs() {
+    let matrix = Matrix::from_col_major_vec(2, 2, vec![2.0_f64, 1.0, 1.0, 2.0]);
+
+    let decomp = hermitian_eigendecomposition(&matrix, 1.0e-12).unwrap();
+
+    assert_eq!(decomp.eigenvalues.len(), 2);
+    assert_eq!(decomp.eigenvectors.nrows(), 2);
+    assert_eq!(decomp.eigenvectors.ncols(), 2);
+    assert!((decomp.eigenvalues[0] - 1.0).abs() < 1.0e-12);
+    assert!((decomp.eigenvalues[1] - 3.0).abs() < 1.0e-12);
+    for col in 0..2 {
+        let vector = [decomp.eigenvectors[[0, col]], decomp.eigenvectors[[1, col]]];
+        assert!(real_eigen_residual_norm(&matrix, decomp.eigenvalues[col], &vector) < 1.0e-10);
+    }
+}
+
+#[test]
 fn projected_hermitian_lowest_eigenpair_works_for_complex_hermitian_matrix() {
     let i = Complex64::new(0.0, 1.0);
     let matrix = Matrix::from_col_major_vec(
@@ -64,6 +81,37 @@ fn projected_hermitian_lowest_eigenpair_works_for_complex_hermitian_matrix() {
 
     assert!((pair.eigenvalue + 1.0).abs() < 1.0e-12);
     assert!(complex_eigen_residual_norm(&matrix, pair.eigenvalue, &pair.eigenvector) < 1.0e-10);
+}
+
+#[test]
+fn hermitian_eigendecomposition_returns_all_complex_pairs() {
+    let i = Complex64::new(0.0, 1.0);
+    let matrix = Matrix::from_col_major_vec(
+        2,
+        2,
+        vec![Complex64::new(0.0, 0.0), i, -i, Complex64::new(0.0, 0.0)],
+    );
+
+    let decomp = hermitian_eigendecomposition(&matrix, 1.0e-12).unwrap();
+
+    assert!((decomp.eigenvalues[0] + 1.0).abs() < 1.0e-12);
+    assert!((decomp.eigenvalues[1] - 1.0).abs() < 1.0e-12);
+    for col in 0..2 {
+        let vector = [decomp.eigenvectors[[0, col]], decomp.eigenvectors[[1, col]]];
+        assert!(complex_eigen_residual_norm(&matrix, decomp.eigenvalues[col], &vector) < 1.0e-10);
+    }
+}
+
+#[test]
+fn hermitian_exponential_first_column_matches_diagonal_action() {
+    let matrix = Matrix::from_col_major_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 3.0]);
+
+    let coeffs =
+        hermitian_exponential_first_column(&matrix, Complex64::new(0.0, -0.5), 1.0e-12).unwrap();
+
+    assert_eq!(coeffs.len(), 2);
+    assert!((coeffs[0] - Complex64::new(0.5_f64.cos(), -0.5_f64.sin())).norm() < 1.0e-12);
+    assert!(coeffs[1].norm() < 1.0e-12);
 }
 
 #[test]
@@ -84,6 +132,33 @@ fn projected_hermitian_lowest_eigenpair_rejects_non_hermitian_diagonal() {
 
     assert!(matches!(err, HermitianEigenError::NonHermitian { .. }));
     assert!(err.to_string().contains("not Hermitian"));
+}
+
+#[test]
+fn hermitian_eigendecomposition_accepts_relative_roundoff_and_symmetrizes() {
+    let matrix = Matrix::from_col_major_vec(2, 2, vec![1.0e8_f64, 2.0e8, 2.0e8 + 1.0e-5, 3.0e8]);
+
+    let decomp = hermitian_eigendecomposition(&matrix, 1.0e-12).unwrap();
+
+    let symmetrized =
+        Matrix::from_col_major_vec(2, 2, vec![1.0e8, 2.0e8 + 0.5e-5, 2.0e8 + 0.5e-5, 3.0e8]);
+    for col in 0..2 {
+        let vector = [decomp.eigenvectors[[0, col]], decomp.eigenvectors[[1, col]]];
+        let residual = real_eigen_residual_norm(&symmetrized, decomp.eigenvalues[col], &vector);
+        assert!(
+            residual < 1.0e-6,
+            "residual {residual:.3e} exceeds tolerance"
+        );
+    }
+}
+
+#[test]
+fn hermitian_eigendecomposition_rejects_relative_asymmetry_above_tolerance() {
+    let matrix = Matrix::from_col_major_vec(2, 2, vec![1.0e8_f64, 2.0e8, 2.0e8 + 1.0e-2, 3.0e8]);
+
+    let err = hermitian_eigendecomposition(&matrix, 1.0e-12).unwrap_err();
+
+    assert!(matches!(err, HermitianEigenError::NonHermitian { .. }));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/examples/benchmark_tdvp.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_tdvp.rs
@@ -1,0 +1,1 @@
+include!("../../../benchmarks/rust/benchmark_tdvp.rs");

--- a/crates/tensor4all-treetn/src/dmrg/mod.rs
+++ b/crates/tensor4all-treetn/src/dmrg/mod.rs
@@ -17,15 +17,14 @@ use crate::linsolve::common::ProjectedOperator;
 use crate::linsolve::square::local_linop::LocalLinOp;
 use crate::local_update_support::{
     build_subtree_topology, contract_region, copy_decomposed_to_subtree,
-    initialize_reference_state_if_empty, sync_reference_state_region,
+    initialize_reference_state_if_empty, single_site_square_mappings, sync_reference_state_region,
+    SquareSiteMappingError,
 };
 use crate::operator::{IndexMapping, LinearOperator};
 use crate::{
     apply_local_update_sweep, factorize_tensor_to_treetn_with, CanonicalizationOptions,
     LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater, TreeTN,
 };
-
-type SiteMappings<V, I> = (HashMap<V, IndexMapping<I>>, HashMap<V, IndexMapping<I>>);
 
 /// Errors reported by TreeTN DMRG.
 ///
@@ -130,6 +129,25 @@ pub enum DmrgError {
         #[source]
         source: anyhow::Error,
     },
+}
+
+impl From<SquareSiteMappingError> for DmrgError {
+    fn from(error: SquareSiteMappingError) -> Self {
+        match error {
+            SquareSiteMappingError::UnsupportedStateSiteCount { node, count } => {
+                Self::UnsupportedStateSiteCount { node, count }
+            }
+            SquareSiteMappingError::UnsupportedMultipleSiteMappings { node, role, count } => {
+                Self::UnsupportedMultipleSiteMappings { node, role, count }
+            }
+            SquareSiteMappingError::MissingMapping { node, role } => {
+                Self::MissingMapping { node, role }
+            }
+            SquareSiteMappingError::InvalidMapping { node, reason } => {
+                Self::InvalidMapping { node, reason }
+            }
+        }
+    }
 }
 
 /// Options for two-site TreeTN DMRG.
@@ -626,7 +644,8 @@ where
         return Err(DmrgError::TopologyMismatch);
     }
 
-    let (input_mapping, output_mapping) = single_site_mappings(operator, &init)?;
+    let (input_mapping, output_mapping) =
+        single_site_square_mappings(operator, &init).map_err(DmrgError::from)?;
     let mut state = init
         .canonicalize([center.clone()], CanonicalizationOptions::default())
         .map_err(|source| DmrgError::Algorithm {
@@ -803,107 +822,6 @@ fn checked_real_scalar(
         });
     }
     Ok(value.real())
-}
-
-fn single_site_mappings<T, V>(
-    operator: &LinearOperator<T, V>,
-    state: &TreeTN<T, V>,
-) -> Result<SiteMappings<V, T::Index>, DmrgError>
-where
-    T: TensorLike,
-    T::Index: IndexLike,
-    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
-    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
-{
-    let mut input = HashMap::new();
-    let mut output = HashMap::new();
-
-    for node in state.node_names() {
-        let node_name = format!("{node:?}");
-        let state_sites =
-            state
-                .site_space(&node)
-                .ok_or_else(|| DmrgError::UnsupportedStateSiteCount {
-                    node: node_name.clone(),
-                    count: 0,
-                })?;
-        if state_sites.len() != 1 {
-            return Err(DmrgError::UnsupportedStateSiteCount {
-                node: node_name,
-                count: state_sites.len(),
-            });
-        }
-        let state_site =
-            state_sites
-                .iter()
-                .next()
-                .ok_or_else(|| DmrgError::UnsupportedStateSiteCount {
-                    node: node_name.clone(),
-                    count: 0,
-                })?;
-
-        let in_mapping = single_mapping(
-            operator.input_mappings().get(&node).map(Vec::as_slice),
-            &node,
-            "input",
-        )?;
-        let out_mapping = single_mapping(
-            operator.output_mappings().get(&node).map(Vec::as_slice),
-            &node,
-            "output",
-        )?;
-
-        if &in_mapping.true_index != state_site {
-            return Err(DmrgError::InvalidMapping {
-                node: format!("{node:?}"),
-                reason: "input true index does not match the state site index".to_string(),
-            });
-        }
-        if &out_mapping.true_index != state_site {
-            return Err(DmrgError::InvalidMapping {
-                node: format!("{node:?}"),
-                reason: "output true index must equal the state site index for square DMRG"
-                    .to_string(),
-            });
-        }
-        if in_mapping.internal_index.dim() != state_site.dim()
-            || out_mapping.internal_index.dim() != state_site.dim()
-        {
-            return Err(DmrgError::InvalidMapping {
-                node: format!("{node:?}"),
-                reason: "operator internal mapping dimensions must match the state site dimension"
-                    .to_string(),
-            });
-        }
-
-        input.insert(node.clone(), in_mapping.clone());
-        output.insert(node, out_mapping.clone());
-    }
-
-    Ok((input, output))
-}
-
-fn single_mapping<'a, I, V>(
-    mappings: Option<&'a [IndexMapping<I>]>,
-    node: &V,
-    role: &'static str,
-) -> Result<&'a IndexMapping<I>, DmrgError>
-where
-    I: IndexLike,
-    V: std::fmt::Debug,
-{
-    let mappings = mappings.ok_or_else(|| DmrgError::MissingMapping {
-        node: format!("{node:?}"),
-        role,
-    })?;
-    if mappings.len() != 1 {
-        return Err(DmrgError::UnsupportedMultipleSiteMappings {
-            node: format!("{node:?}"),
-            role,
-            count: mappings.len(),
-        });
-    }
-    Ok(&mappings[0])
 }
 
 fn rayleigh_region<T, V>(state: &TreeTN<T, V>, center: &V) -> Result<Vec<V>, DmrgError>

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -34,6 +34,7 @@ pub mod options;
 pub mod random;
 mod simplett_bridge;
 pub mod site_index_network;
+pub mod tdvp;
 pub mod treetn;
 
 pub use algorithm::{CanonicalForm, CompressionAlgorithm, ContractionAlgorithm};
@@ -63,6 +64,7 @@ pub use simplett_bridge::{
     weighted_remove_site_from_treetn_chain,
 };
 pub use site_index_network::SiteIndexNetwork;
+pub use tdvp::{tdvp, tdvp_with_treetn_operator, TdvpError, TdvpOptions, TdvpResult};
 pub use treetn::{
     // Local update
     apply_local_update_sweep,

--- a/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
@@ -301,6 +301,65 @@ where
         Ok(contracted)
     }
 
+    /// Apply the operator projected to a bond-center tensor.
+    ///
+    /// This is used by one-site TDVP after factoring a site tensor as `Q * R`:
+    /// the left endpoint environment is computed with the temporary `Q` tensor,
+    /// the right endpoint environment is taken from the current state/reference
+    /// environments, and the result is mapped back to the input bond-center
+    /// index space.
+    pub(crate) fn apply_edge_center<NT: NetworkTopology<V>>(
+        &mut self,
+        center: &T,
+        edge: (&V, &V),
+        left_tensors: (&T, &T),
+        bra_to_ket_indices: &[(T::Index, T::Index)],
+        states: (&TreeTN<T, V>, &TreeTN<T, V>),
+        topology: &NT,
+    ) -> Result<T> {
+        let (left, right) = edge;
+        let (left_ket_tensor, left_bra_tensor) = left_tensors;
+        let (ket_state, bra_state) = states;
+        if !self.envs.contains(right, left) {
+            let env = self.compute_environment(right, left, ket_state, bra_state, topology)?;
+            self.envs.insert(right.clone(), left.clone(), env);
+        }
+
+        let left_env = self.compute_environment_from_node_tensors(
+            (left, right),
+            (left_ket_tensor, left_bra_tensor),
+            (ket_state, bra_state),
+            topology,
+        )?;
+        let right_env = self
+            .envs
+            .get(right, left)
+            .ok_or_else(|| anyhow::anyhow!("missing right environment for edge center"))?;
+
+        let mut contracted = T::contract(&[center, &left_env, right_env])?;
+        for (bra_idx, ket_idx) in bra_to_ket_indices {
+            if contracted
+                .external_indices()
+                .iter()
+                .any(|idx| idx == bra_idx)
+            {
+                contracted = contracted.replaceind(bra_idx, ket_idx)?;
+            }
+        }
+
+        let center_inds = center.external_indices();
+        let res_inds = contracted.external_indices();
+        let center_index_keys: std::collections::HashSet<_> =
+            center_inds.iter().map(|i| (i.clone(), i.dim())).collect();
+        let res_index_keys: std::collections::HashSet<_> =
+            res_inds.iter().map(|i| (i.clone(), i.dim())).collect();
+        if center_index_keys == res_index_keys && center_inds.len() == res_inds.len() {
+            contracted = contracted.permuteinds(&center_inds)?;
+        }
+
+        Ok(contracted)
+    }
+
     /// Ensure environments are computed for neighbors of the region.
     fn ensure_environments<NT: NetworkTopology<V>>(
         &mut self,
@@ -337,7 +396,39 @@ where
         bra_state: &TreeTN<T, V>,
         topology: &NT,
     ) -> Result<T> {
-        // First, ensure child environments are computed
+        // Get tensors from bra (V_out), operator, and ket (V_in) at this node
+        let node_idx_bra = bra_state
+            .node_index(from)
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in bra_state", from))?;
+        let node_idx_ket = ket_state
+            .node_index(from)
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in ket_state", from))?;
+
+        let tensor_bra = bra_state
+            .tensor(node_idx_bra)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found in bra_state"))?;
+        let tensor_ket = ket_state
+            .tensor(node_idx_ket)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found in ket_state"))?;
+
+        self.compute_environment_from_node_tensors(
+            (from, to),
+            (tensor_ket, tensor_bra),
+            (ket_state, bra_state),
+            topology,
+        )
+    }
+
+    fn compute_environment_from_node_tensors<NT: NetworkTopology<V>>(
+        &mut self,
+        edge: (&V, &V),
+        tensors: (&T, &T),
+        states: (&TreeTN<T, V>, &TreeTN<T, V>),
+        topology: &NT,
+    ) -> Result<T> {
+        let (from, to) = edge;
+        let (tensor_ket, tensor_bra) = tensors;
+        let (ket_state, bra_state) = states;
         let child_neighbors: Vec<V> = topology.neighbors(from).filter(|n| n != to).collect();
 
         for child in &child_neighbors {
@@ -348,34 +439,19 @@ where
             }
         }
 
-        // Collect child environments
         let child_envs: Vec<&T> = child_neighbors
             .iter()
             .filter_map(|child| self.envs.get(child, from))
             .collect();
 
-        // Get tensors from bra (V_out), operator, and ket (V_in) at this node
-        let node_idx_bra = bra_state
-            .node_index(from)
-            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in bra_state", from))?;
         let node_idx_op = self
             .operator
             .node_index(from)
             .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in operator", from))?;
-        let node_idx_ket = ket_state
-            .node_index(from)
-            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in ket_state", from))?;
-
-        let tensor_bra = bra_state
-            .tensor(node_idx_bra)
-            .ok_or_else(|| anyhow::anyhow!("Tensor not found in bra_state"))?;
         let tensor_op = self
             .operator
             .tensor(node_idx_op)
             .ok_or_else(|| anyhow::anyhow!("Tensor not found in operator"))?;
-        let tensor_ket = ket_state
-            .tensor(node_idx_ket)
-            .ok_or_else(|| anyhow::anyhow!("Tensor not found in ket_state"))?;
 
         // Environment contraction for 3-chain: <bra| H |ket>
         //

--- a/crates/tensor4all-treetn/src/local_update_support.rs
+++ b/crates/tensor4all-treetn/src/local_update_support.rs
@@ -11,8 +11,131 @@ use std::hash::Hash;
 
 use anyhow::Result;
 use tensor4all_core::{IndexLike, TensorLike};
+use thiserror::Error;
 
+use crate::operator::{IndexMapping, LinearOperator};
 use crate::treetn::{get_boundary_edges, LocalUpdateStep, TreeTN, TreeTopology};
+
+pub(crate) type SiteMappings<V, I> = (HashMap<V, IndexMapping<I>>, HashMap<V, IndexMapping<I>>);
+
+#[derive(Debug, Error)]
+pub(crate) enum SquareSiteMappingError {
+    #[error(
+        "square local update requires exactly one state site index at node {node}, found {count}"
+    )]
+    UnsupportedStateSiteCount { node: String, count: usize },
+    #[error(
+        "square local update requires exactly one {role} mapping at node {node}, found {count}"
+    )]
+    UnsupportedMultipleSiteMappings {
+        node: String,
+        role: &'static str,
+        count: usize,
+    },
+    #[error("square local update missing {role} mapping at node {node}")]
+    MissingMapping { node: String, role: &'static str },
+    #[error("invalid square local update mapping at node {node}: {reason}")]
+    InvalidMapping { node: String, reason: String },
+}
+
+pub(crate) fn single_site_square_mappings<T, V>(
+    operator: &LinearOperator<T, V>,
+    state: &TreeTN<T, V>,
+) -> Result<SiteMappings<V, T::Index>, SquareSiteMappingError>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut input = HashMap::new();
+    let mut output = HashMap::new();
+
+    for node in state.node_names() {
+        let node_name = format!("{node:?}");
+        let state_sites = state.site_space(&node).ok_or_else(|| {
+            SquareSiteMappingError::UnsupportedStateSiteCount {
+                node: node_name.clone(),
+                count: 0,
+            }
+        })?;
+        if state_sites.len() != 1 {
+            return Err(SquareSiteMappingError::UnsupportedStateSiteCount {
+                node: node_name,
+                count: state_sites.len(),
+            });
+        }
+        let state_site = state_sites.iter().next().ok_or_else(|| {
+            SquareSiteMappingError::UnsupportedStateSiteCount {
+                node: node_name.clone(),
+                count: 0,
+            }
+        })?;
+
+        let in_mapping = single_mapping(
+            operator.input_mappings().get(&node).map(Vec::as_slice),
+            &node,
+            "input",
+        )?;
+        let out_mapping = single_mapping(
+            operator.output_mappings().get(&node).map(Vec::as_slice),
+            &node,
+            "output",
+        )?;
+
+        if &in_mapping.true_index != state_site {
+            return Err(SquareSiteMappingError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason: "input true index does not match the state site index".to_string(),
+            });
+        }
+        if &out_mapping.true_index != state_site {
+            return Err(SquareSiteMappingError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason:
+                    "output true index must equal the state site index for square local updates"
+                        .to_string(),
+            });
+        }
+        if in_mapping.internal_index.dim() != state_site.dim()
+            || out_mapping.internal_index.dim() != state_site.dim()
+        {
+            return Err(SquareSiteMappingError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason: "operator internal mapping dimensions must match the state site dimension"
+                    .to_string(),
+            });
+        }
+
+        input.insert(node.clone(), in_mapping.clone());
+        output.insert(node, out_mapping.clone());
+    }
+
+    Ok((input, output))
+}
+
+fn single_mapping<'a, I, V>(
+    mappings: Option<&'a [IndexMapping<I>]>,
+    node: &V,
+    role: &'static str,
+) -> Result<&'a IndexMapping<I>, SquareSiteMappingError>
+where
+    I: IndexLike,
+    V: std::fmt::Debug,
+{
+    let mappings = mappings.ok_or_else(|| SquareSiteMappingError::MissingMapping {
+        node: format!("{node:?}"),
+        role,
+    })?;
+    if mappings.len() != 1 {
+        return Err(SquareSiteMappingError::UnsupportedMultipleSiteMappings {
+            node: format!("{node:?}"),
+            role,
+            count: mappings.len(),
+        });
+    }
+    Ok(&mappings[0])
+}
 
 /// Initialize a reference state by cloning the ket state and relabeling links.
 pub(crate) fn initialize_reference_state_if_empty<T, V>(

--- a/crates/tensor4all-treetn/src/tdvp/mod.rs
+++ b/crates/tensor4all-treetn/src/tdvp/mod.rs
@@ -1,0 +1,1147 @@
+//! Time-dependent variational principle sweeps for TreeTN states.
+//!
+//! This module implements TreeTN TDVP with ITensorNetworks-compatible
+//! `applyexp` region plans. Production updates use projected local operators
+//! and Krylov exponentials; dense full-network materialization is reserved for
+//! tests and external benchmark validation.
+
+mod plan;
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::sync::{Arc, RwLock};
+
+use num_complex::Complex64;
+use tensor4all_core::krylov::{hermitian_krylov_expm_multiply, HermitianKrylovExpmOptions};
+use tensor4all_core::{
+    Canonical, FactorizeAlg, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorLike,
+};
+use thiserror::Error;
+
+use self::plan::{TdvpRegionKind, TdvpRegionPlan, TdvpRegionStep};
+use crate::linsolve::common::ProjectedOperator;
+use crate::linsolve::square::local_linop::LocalLinOp;
+use crate::local_update_support::{
+    build_subtree_topology, contract_region, copy_decomposed_to_subtree,
+    initialize_reference_state_if_empty, single_site_square_mappings, sync_reference_state_region,
+    SquareSiteMappingError,
+};
+use crate::operator::{IndexMapping, LinearOperator};
+use crate::{factorize_tensor_to_treetn_with, CanonicalizationOptions, LocalUpdateStep, TreeTN};
+
+/// Errors reported by TreeTN TDVP.
+///
+/// This error type covers unsupported v1 API shapes, invalid options, topology
+/// mismatches, and numerical failures from local Hermitian Krylov exponentials.
+#[derive(Debug, Error)]
+pub enum TdvpError {
+    /// The requested local update size is not implemented.
+    #[error("TDVP supports nsite=1 or nsite=2 in this version, got nsite={requested}")]
+    UnsupportedNsite {
+        /// Requested number of sites per local update.
+        requested: usize,
+    },
+
+    /// The requested Suzuki-Trotter order is not implemented.
+    #[error("TDVP applyexp order {requested} is not supported; supported orders are 1, 2, and 4")]
+    UnsupportedOrder {
+        /// Requested applyexp order.
+        requested: usize,
+    },
+
+    /// A numeric or algorithm option is invalid.
+    #[error("invalid TDVP option {option}: {reason}")]
+    InvalidOption {
+        /// Option name.
+        option: &'static str,
+        /// Why the value is invalid.
+        reason: String,
+    },
+
+    /// The requested sweep center does not exist in the state.
+    #[error("TDVP center {center} is not a state node")]
+    MissingCenter {
+        /// Debug representation of the missing center.
+        center: String,
+    },
+
+    /// Two-site TDVP cannot run because there is no update edge.
+    #[error("two-site TDVP requires at least one state edge")]
+    EmptyTwoSiteSweep,
+
+    /// The operator and state do not share the same tree topology.
+    #[error("TDVP requires the operator and state to have the same tree topology")]
+    TopologyMismatch,
+
+    /// The initial v1 implementation supports one physical site index per node.
+    #[error("TDVP v1 requires exactly one state site index at node {node}, found {count}")]
+    UnsupportedStateSiteCount {
+        /// Debug representation of the node.
+        node: String,
+        /// Number of state site indices found.
+        count: usize,
+    },
+
+    /// The initial v1 implementation supports one input/output mapping per node.
+    #[error("TDVP v1 requires exactly one {role} mapping at node {node}, found {count}")]
+    UnsupportedMultipleSiteMappings {
+        /// Debug representation of the node.
+        node: String,
+        /// Mapping role, either input or output.
+        role: &'static str,
+        /// Number of mappings found.
+        count: usize,
+    },
+
+    /// A required input/output mapping is missing.
+    #[error("TDVP missing {role} mapping at node {node}")]
+    MissingMapping {
+        /// Debug representation of the node.
+        node: String,
+        /// Mapping role, either input or output.
+        role: &'static str,
+    },
+
+    /// A mapping does not describe the same state vector space.
+    #[error("invalid TDVP mapping at node {node}: {reason}")]
+    InvalidMapping {
+        /// Debug representation of the node.
+        node: String,
+        /// Why the mapping is invalid.
+        reason: String,
+    },
+
+    /// A lower-level TreeTN or Krylov operation failed.
+    #[error("{context}: {source}")]
+    Algorithm {
+        /// Context for the failing operation.
+        context: &'static str,
+        /// Source error.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl From<SquareSiteMappingError> for TdvpError {
+    fn from(error: SquareSiteMappingError) -> Self {
+        match error {
+            SquareSiteMappingError::UnsupportedStateSiteCount { node, count } => {
+                Self::UnsupportedStateSiteCount { node, count }
+            }
+            SquareSiteMappingError::UnsupportedMultipleSiteMappings { node, role, count } => {
+                Self::UnsupportedMultipleSiteMappings { node, role, count }
+            }
+            SquareSiteMappingError::MissingMapping { node, role } => {
+                Self::MissingMapping { node, role }
+            }
+            SquareSiteMappingError::InvalidMapping { node, reason } => {
+                Self::InvalidMapping { node, reason }
+            }
+        }
+    }
+}
+
+/// Options for TreeTN TDVP.
+///
+/// `TdvpOptions::default()` runs one second-order two-site TDVP sweep with a
+/// Krylov exponential. The `exponent_step` is the coefficient multiplying the
+/// Hamiltonian in `exp(exponent_step * H)`, so real-time evolution for a time
+/// step `dt` uses `Complex64::new(0.0, -dt)`.
+///
+/// # Examples
+/// ```
+/// use num_complex::Complex64;
+/// use tensor4all_treetn::TdvpOptions;
+///
+/// let options = TdvpOptions::default()
+///     .with_nsite(2)
+///     .with_order(4)
+///     .with_exponent_step(Complex64::new(0.0, -0.05));
+///
+/// assert_eq!(options.nsite, 2);
+/// assert_eq!(options.order, 4);
+/// assert_eq!(options.exponent_step, Complex64::new(0.0, -0.05));
+/// ```
+#[derive(Debug, Clone)]
+pub struct TdvpOptions {
+    /// Number of sites in each projected local update.
+    ///
+    /// Use `2` to allow bond-dimension changes through two-site factorization.
+    /// Use `1` for fixed-rank one-site TDVP.
+    pub nsite: usize,
+    /// Number of full applyexp sweeps.
+    ///
+    /// Each sweep applies `exponent_step` once, split according to `order`.
+    pub nsweeps: usize,
+    /// Suzuki-Trotter/applyexp composition order.
+    ///
+    /// Supported values match ITensorNetworks.jl: `1`, `2`, and `4`.
+    pub order: usize,
+    /// Coefficient multiplying the Hamiltonian in the exponential.
+    ///
+    /// For real time `dt`, use `-i dt`; for imaginary time `tau`, use `-tau`.
+    pub exponent_step: Complex64,
+    /// Optional maximum bond dimension after each two-site split.
+    ///
+    /// `None` keeps all singular vectors allowed by the SVD truncation policy.
+    /// This option is valid only for `nsite = 2`; one-site TDVP has fixed
+    /// ranks and rejects truncation options.
+    pub max_bond_dim: Option<usize>,
+    /// Optional SVD truncation policy for two-site splits.
+    ///
+    /// For ITensors cutoff parity, use `SvdTruncationPolicy::new(cutoff)` with
+    /// `.with_squared_values()` and `.with_discarded_tail_sum()`. This option
+    /// is valid only for `nsite = 2`; one-site TDVP has fixed ranks and
+    /// rejects truncation options.
+    pub svd_policy: Option<SvdTruncationPolicy>,
+    /// Local Hermitian Krylov exponential options.
+    pub krylov: HermitianKrylovExpmOptions,
+    /// Whether to print per-sweep progress to stderr.
+    pub verbose: bool,
+}
+
+impl Default for TdvpOptions {
+    fn default() -> Self {
+        Self {
+            nsite: 2,
+            nsweeps: 1,
+            order: 2,
+            exponent_step: Complex64::new(0.0, -0.1),
+            max_bond_dim: None,
+            svd_policy: None,
+            krylov: HermitianKrylovExpmOptions::default(),
+            verbose: false,
+        }
+    }
+}
+
+impl TdvpOptions {
+    /// Set the number of sites in each projected update.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let options = TdvpOptions::default().with_nsite(1);
+    /// assert_eq!(options.nsite, 1);
+    /// ```
+    pub fn with_nsite(mut self, nsite: usize) -> Self {
+        self.nsite = nsite;
+        self
+    }
+
+    /// Set the number of full TDVP sweeps.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let options = TdvpOptions::default().with_nsweeps(3);
+    /// assert_eq!(options.nsweeps, 3);
+    /// ```
+    pub fn with_nsweeps(mut self, nsweeps: usize) -> Self {
+        self.nsweeps = nsweeps;
+        self
+    }
+
+    /// Set the applyexp composition order.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let options = TdvpOptions::default().with_order(4);
+    /// assert_eq!(options.order, 4);
+    /// ```
+    pub fn with_order(mut self, order: usize) -> Self {
+        self.order = order;
+        self
+    }
+
+    /// Set the exponential step coefficient.
+    ///
+    /// # Examples
+    /// ```
+    /// use num_complex::Complex64;
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let options = TdvpOptions::default().with_exponent_step(Complex64::new(0.0, -0.25));
+    /// assert_eq!(options.exponent_step, Complex64::new(0.0, -0.25));
+    /// ```
+    pub fn with_exponent_step(mut self, exponent_step: Complex64) -> Self {
+        self.exponent_step = exponent_step;
+        self
+    }
+
+    /// Set the maximum retained bond dimension for two-site splits.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let options = TdvpOptions::default().with_max_bond_dim(16);
+    /// assert_eq!(options.max_bond_dim, Some(16));
+    /// ```
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
+        self
+    }
+
+    /// Set the SVD truncation policy for two-site splits.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::SvdTruncationPolicy;
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let options = TdvpOptions::default().with_svd_policy(SvdTruncationPolicy::new(1e-8));
+    /// assert!(options.svd_policy.is_some());
+    /// ```
+    pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
+        self.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set local Hermitian Krylov exponential options.
+    ///
+    /// # Examples
+    /// ```
+    /// use tensor4all_core::krylov::HermitianKrylovExpmOptions;
+    /// use tensor4all_treetn::TdvpOptions;
+    ///
+    /// let krylov = HermitianKrylovExpmOptions { max_iter: 10, ..Default::default() };
+    /// let options = TdvpOptions::default().with_krylov_options(krylov);
+    /// assert_eq!(options.krylov.max_iter, 10);
+    /// ```
+    pub fn with_krylov_options(mut self, krylov: HermitianKrylovExpmOptions) -> Self {
+        self.krylov = krylov;
+        self
+    }
+}
+
+/// Result returned by TreeTN TDVP.
+///
+/// The evolved state remains a TreeTN and is never produced by dense
+/// full-network materialization inside the production algorithm.
+#[derive(Debug, Clone)]
+pub struct TdvpResult<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Evolved TreeTN state.
+    pub state: TreeTN<T, V>,
+    /// Number of full sweeps completed.
+    pub sweeps_completed: usize,
+    /// Number of projected local exponential updates performed.
+    pub local_updates: usize,
+    /// Largest Krylov error estimate reported by local updates.
+    pub max_error_estimate: f64,
+    /// Largest number of Krylov iterations used by a local update.
+    pub max_krylov_iterations: usize,
+}
+
+struct TdvpUpdater<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    projected_operator: Arc<RwLock<ProjectedOperator<T, V>>>,
+    options: TdvpOptions,
+    reference_state: TreeTN<T, V>,
+    local_updates: usize,
+    max_error_estimate: f64,
+    max_krylov_iterations: usize,
+}
+
+impl<T, V> TdvpUpdater<T, V>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    fn new(
+        operator: TreeTN<T, V>,
+        input_mapping: HashMap<V, IndexMapping<T::Index>>,
+        output_mapping: HashMap<V, IndexMapping<T::Index>>,
+        options: TdvpOptions,
+    ) -> Self {
+        Self {
+            projected_operator: Arc::new(RwLock::new(ProjectedOperator::with_index_mappings(
+                operator,
+                input_mapping,
+                output_mapping,
+            ))),
+            options,
+            reference_state: TreeTN::new(),
+            local_updates: 0,
+            max_error_estimate: 0.0,
+            max_krylov_iterations: 0,
+        }
+    }
+
+    fn evolve_local(
+        &mut self,
+        region: &[V],
+        init: &T,
+        state: &TreeTN<T, V>,
+        exponent_step: Complex64,
+        context: &'static str,
+    ) -> Result<T, TdvpError> {
+        let linop = LocalLinOp::new(
+            Arc::clone(&self.projected_operator),
+            region.to_vec(),
+            state,
+            &self.reference_state,
+        );
+
+        let result = hermitian_krylov_expm_multiply(
+            |x: &T| linop.apply_projected(x),
+            exponent_step,
+            init,
+            &self.options.krylov,
+        )
+        .map_err(|source| TdvpError::Algorithm { context, source })?;
+
+        self.max_error_estimate = self.max_error_estimate.max(result.error_estimate);
+        self.max_krylov_iterations = self.max_krylov_iterations.max(result.iterations);
+        self.local_updates += 1;
+        Ok(result.output)
+    }
+
+    fn update_step(
+        &mut self,
+        state: &mut TreeTN<T, V>,
+        step: &TdvpRegionStep<V>,
+        next_step: Option<&TdvpRegionStep<V>>,
+    ) -> Result<(), TdvpError> {
+        initialize_reference_state_if_empty(&mut self.reference_state, state).map_err(
+            |source| TdvpError::Algorithm {
+                context: "TDVP failed to initialize reference state",
+                source,
+            },
+        )?;
+        move_center_to_region_full_rank(&mut self.reference_state, &step.nodes).map_err(
+            |source| TdvpError::Algorithm {
+                context: "TDVP failed to move reference center to local region",
+                source,
+            },
+        )?;
+
+        match step.kind {
+            TdvpRegionKind::TwoSite => self.update_two_site(state, step),
+            TdvpRegionKind::SiteCorrection => self.update_one_site_tensor(
+                state,
+                step,
+                None,
+                "TDVP single-site correction Krylov exponential failed",
+            ),
+            TdvpRegionKind::OneSite => self.update_one_site_tensor(
+                state,
+                step,
+                next_step,
+                "TDVP one-site Krylov exponential failed",
+            ),
+        }?;
+
+        sync_reference_state_region(
+            &mut self.reference_state,
+            None,
+            &LocalUpdateStep {
+                nodes: step.nodes.clone(),
+                new_center: step.new_center.clone(),
+            },
+            state,
+        )
+        .map_err(|source| TdvpError::Algorithm {
+            context: "TDVP failed to sync reference state",
+            source,
+        })?;
+
+        let topology = state.site_index_network();
+        let mut projected_operator =
+            self.projected_operator
+                .write()
+                .map_err(|err| TdvpError::Algorithm {
+                    context: "TDVP projected operator lock poisoned",
+                    source: anyhow::anyhow!("{err}"),
+                })?;
+        projected_operator.invalidate(&step.nodes, topology);
+        Ok(())
+    }
+
+    fn update_one_site_tensor(
+        &mut self,
+        state: &mut TreeTN<T, V>,
+        step: &TdvpRegionStep<V>,
+        next_step: Option<&TdvpRegionStep<V>>,
+        context: &'static str,
+    ) -> Result<(), TdvpError> {
+        let subtree =
+            state
+                .extract_subtree(&step.nodes)
+                .map_err(|source| TdvpError::Algorithm {
+                    context: "TDVP failed to extract one-site region",
+                    source,
+                })?;
+        let init_local =
+            contract_region(&subtree, &step.nodes).map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to contract one-site region",
+                source,
+            })?;
+        let evolved =
+            self.evolve_local(&step.nodes, &init_local, state, step.exponent_step, context)?;
+        let evolved = if step.kind == TdvpRegionKind::OneSite {
+            self.apply_one_site_bond_correction(state, step, next_step, evolved)?
+        } else {
+            evolved
+        };
+        let node_idx =
+            state
+                .node_index(&step.nodes[0])
+                .ok_or_else(|| TdvpError::MissingCenter {
+                    center: format!("{:?}", step.nodes[0]),
+                })?;
+        state
+            .replace_tensor(node_idx, evolved)
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to replace one-site tensor",
+                source,
+            })?;
+        state
+            .set_canonical_region([step.new_center.clone()])
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to set one-site canonical center",
+                source,
+            })?;
+        Ok(())
+    }
+
+    fn apply_one_site_bond_correction(
+        &mut self,
+        state: &TreeTN<T, V>,
+        step: &TdvpRegionStep<V>,
+        next_step: Option<&TdvpRegionStep<V>>,
+        evolved: T,
+    ) -> Result<T, TdvpError> {
+        let Some(next_step) = next_step else {
+            return Ok(evolved);
+        };
+        if next_step.kind != TdvpRegionKind::OneSite || next_step.nodes == step.nodes {
+            return Ok(evolved);
+        }
+        let current = step.nodes.first().ok_or(TdvpError::UnsupportedNsite {
+            requested: step.nodes.len(),
+        })?;
+        let target = next_step.nodes.first().ok_or(TdvpError::UnsupportedNsite {
+            requested: next_step.nodes.len(),
+        })?;
+        let Some(next_neighbor) =
+            first_path_neighbor(state, current, target).map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to find one-site correction edge",
+                source,
+            })?
+        else {
+            return Ok(evolved);
+        };
+
+        let edge =
+            state
+                .edge_between(current, &next_neighbor)
+                .ok_or_else(|| TdvpError::Algorithm {
+                    context: "TDVP one-site correction edge is missing",
+                    source: anyhow::anyhow!(
+                        "missing edge between {:?} and {:?}",
+                        current,
+                        next_neighbor
+                    ),
+                })?;
+        let ket_edge_bond =
+            state
+                .bond_index(edge)
+                .cloned()
+                .ok_or_else(|| TdvpError::Algorithm {
+                    context: "TDVP one-site correction edge has no bond",
+                    source: anyhow::anyhow!(
+                        "missing bond between {:?} and {:?}",
+                        current,
+                        next_neighbor
+                    ),
+                })?;
+        let left_inds = evolved
+            .external_indices()
+            .into_iter()
+            .filter(|idx| idx != &ket_edge_bond)
+            .collect::<Vec<_>>();
+        let factorized = evolved
+            .factorize_full_rank(&left_inds, FactorizeAlg::QR, Canonical::Left)
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP one-site QR factorization failed",
+                source: source.into(),
+            })?;
+        let q = factorized.left;
+        let r = factorized.right;
+        let ket_center_bond = factorized.bond_index;
+        let ref_center_bond = ket_center_bond.sim();
+        let mut q_ref = q
+            .replaceind(&ket_center_bond, &ref_center_bond)
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to relabel one-site Q reference bond",
+                source,
+            })?;
+
+        for neighbor in state.site_index_network().neighbors(current) {
+            let Some(ket_edge) = state.edge_between(current, &neighbor) else {
+                continue;
+            };
+            let Some(ket_bond) = state.bond_index(ket_edge) else {
+                continue;
+            };
+            if !q_ref.external_indices().iter().any(|idx| idx == ket_bond) {
+                continue;
+            }
+            let Some(ref_edge) = self.reference_state.edge_between(current, &neighbor) else {
+                continue;
+            };
+            let Some(ref_bond) = self.reference_state.bond_index(ref_edge) else {
+                continue;
+            };
+            q_ref =
+                q_ref
+                    .replaceind(ket_bond, ref_bond)
+                    .map_err(|source| TdvpError::Algorithm {
+                        context: "TDVP failed to relabel one-site Q boundary bond",
+                        source,
+                    })?;
+        }
+
+        let ref_edge = self
+            .reference_state
+            .edge_between(current, &next_neighbor)
+            .ok_or_else(|| TdvpError::Algorithm {
+                context: "TDVP reference state is missing one-site correction edge",
+                source: anyhow::anyhow!(
+                    "missing reference edge between {:?} and {:?}",
+                    current,
+                    next_neighbor
+                ),
+            })?;
+        let ref_edge_bond = self
+            .reference_state
+            .bond_index(ref_edge)
+            .cloned()
+            .ok_or_else(|| TdvpError::Algorithm {
+                context: "TDVP reference one-site correction edge has no bond",
+                source: anyhow::anyhow!(
+                    "missing reference bond between {:?} and {:?}",
+                    current,
+                    next_neighbor
+                ),
+            })?;
+        let bra_to_ket = vec![
+            (ref_center_bond, ket_center_bond),
+            (ref_edge_bond, ket_edge_bond),
+        ];
+        let r_evolved = self.evolve_edge_center(
+            state,
+            current,
+            &next_neighbor,
+            &q,
+            &q_ref,
+            &bra_to_ket,
+            &r,
+            -step.exponent_step,
+        )?;
+        let mut local = T::contract(&[&q, &r_evolved]).map_err(|source| TdvpError::Algorithm {
+            context: "TDVP failed to contract corrected one-site tensor",
+            source,
+        })?;
+        let target_inds = evolved.external_indices();
+        let local_inds = local.external_indices();
+        let target_keys: std::collections::HashSet<_> = target_inds
+            .iter()
+            .map(|idx| (idx.clone(), idx.dim()))
+            .collect();
+        let local_keys: std::collections::HashSet<_> = local_inds
+            .iter()
+            .map(|idx| (idx.clone(), idx.dim()))
+            .collect();
+        if target_keys == local_keys && target_inds.len() == local_inds.len() {
+            local = local
+                .permuteinds(&target_inds)
+                .map_err(|source| TdvpError::Algorithm {
+                    context: "TDVP failed to align corrected one-site tensor indices",
+                    source,
+                })?;
+        }
+        Ok(local)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn evolve_edge_center(
+        &mut self,
+        state: &TreeTN<T, V>,
+        left: &V,
+        right: &V,
+        left_ket_tensor: &T,
+        left_bra_tensor: &T,
+        bra_to_ket_indices: &[(T::Index, T::Index)],
+        init: &T,
+        exponent_step: Complex64,
+    ) -> Result<T, TdvpError> {
+        let result = hermitian_krylov_expm_multiply(
+            |x: &T| {
+                let mut proj_op = self.projected_operator.write().map_err(|err| {
+                    anyhow::anyhow!("TDVP projected operator lock poisoned: {err}")
+                })?;
+                proj_op.apply_edge_center(
+                    x,
+                    (left, right),
+                    (left_ket_tensor, left_bra_tensor),
+                    bra_to_ket_indices,
+                    (state, &self.reference_state),
+                    state.site_index_network(),
+                )
+            },
+            exponent_step,
+            init,
+            &self.options.krylov,
+        )
+        .map_err(|source| TdvpError::Algorithm {
+            context: "TDVP one-site bond-center Krylov exponential failed",
+            source,
+        })?;
+        self.max_error_estimate = self.max_error_estimate.max(result.error_estimate);
+        self.max_krylov_iterations = self.max_krylov_iterations.max(result.iterations);
+        self.local_updates += 1;
+        Ok(result.output)
+    }
+
+    fn update_two_site(
+        &mut self,
+        state: &mut TreeTN<T, V>,
+        step: &TdvpRegionStep<V>,
+    ) -> Result<(), TdvpError> {
+        if step.nodes.len() != 2 {
+            return Err(TdvpError::UnsupportedNsite {
+                requested: step.nodes.len(),
+            });
+        }
+        let mut subtree =
+            state
+                .extract_subtree(&step.nodes)
+                .map_err(|source| TdvpError::Algorithm {
+                    context: "TDVP failed to extract two-site region",
+                    source,
+                })?;
+        let init_local =
+            contract_region(&subtree, &step.nodes).map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to contract two-site region",
+                source,
+            })?;
+        let evolved = self.evolve_local(
+            &step.nodes,
+            &init_local,
+            state,
+            step.exponent_step,
+            "TDVP two-site Krylov exponential failed",
+        )?;
+
+        let topology = build_subtree_topology(&evolved, &step.nodes, state).map_err(|source| {
+            TdvpError::Algorithm {
+                context: "TDVP failed to build two-site subtree topology",
+                source,
+            }
+        })?;
+        let mut factorize_options = FactorizeOptions::svd();
+        if let Some(max_rank) = self.options.max_bond_dim {
+            factorize_options = factorize_options.with_max_rank(max_rank);
+        }
+        if let Some(policy) = self.options.svd_policy {
+            factorize_options = factorize_options.with_svd_policy(policy);
+        }
+        let decomposed = factorize_tensor_to_treetn_with(
+            &evolved,
+            &topology,
+            factorize_options,
+            &step.new_center,
+        )
+        .map_err(|source| TdvpError::Algorithm {
+            context: "TDVP failed to split evolved two-site tensor",
+            source,
+        })?;
+        copy_decomposed_to_subtree(&mut subtree, &decomposed, &step.nodes, state).map_err(
+            |source| TdvpError::Algorithm {
+                context: "TDVP failed to copy split two-site tensors",
+                source,
+            },
+        )?;
+        subtree
+            .set_canonical_region([step.new_center.clone()])
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to set two-site subtree center",
+                source,
+            })?;
+        if let Some(edges) = subtree.edges_to_canonicalize_by_names(&step.new_center) {
+            for (from, to) in edges {
+                if let Some(edge) = subtree.edge_between(&from, &to) {
+                    subtree
+                        .set_edge_ortho_towards(edge, Some(to))
+                        .map_err(|source| TdvpError::Algorithm {
+                            context: "TDVP failed to set subtree orthogonality direction",
+                            source,
+                        })?;
+                }
+            }
+        }
+        state
+            .replace_subtree(&step.nodes, &subtree)
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to replace two-site subtree",
+                source,
+            })?;
+        state
+            .set_canonical_region([step.new_center.clone()])
+            .map_err(|source| TdvpError::Algorithm {
+                context: "TDVP failed to set two-site canonical center",
+                source,
+            })?;
+        Ok(())
+    }
+}
+
+/// Run TreeTN TDVP for a mapped TreeTN linear operator.
+///
+/// # Arguments
+///
+/// * `operator` - Hamiltonian as a [`LinearOperator`]. The v1 implementation
+///   supports exactly one input and one output site mapping per node.
+/// * `init` - Initial TreeTN state. It is canonicalized at `center` before
+///   sweeping.
+/// * `center` - Initial sweep root used for ITensorNetworks-compatible
+///   post-order region plans.
+/// * `options` - Sweep, truncation, and Krylov exponential options.
+///
+/// # Returns
+///
+/// A [`TdvpResult`] containing the evolved state and local Krylov diagnostics.
+///
+/// # Errors
+///
+/// Returns [`TdvpError`] for unsupported options, incompatible mappings,
+/// missing centers, topology mismatches, and local projected exponential
+/// failures.
+///
+/// # Examples
+/// ```
+/// use std::collections::HashMap;
+/// use num_complex::Complex64;
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{tdvp, IndexMapping, LinearOperator, TdvpOptions, TreeTN};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let site = DynIndex::new_dyn(2);
+/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+///
+/// let input = DynIndex::new_dyn(2);
+/// let output = DynIndex::new_dyn(2);
+/// let op_tensor = TensorDynLen::from_dense(
+///     vec![output.clone(), input.clone()],
+///     vec![1.0, 0.0, 0.0, 1.0],
+/// )?;
+/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+/// let operator = LinearOperator::new(
+///     mpo,
+///     HashMap::from([(0, IndexMapping { true_index: site.clone(), internal_index: input })]),
+///     HashMap::from([(0, IndexMapping { true_index: site, internal_index: output })]),
+/// );
+///
+/// let result = tdvp(
+///     &operator,
+///     state,
+///     &0,
+///     TdvpOptions::default()
+///         .with_nsite(1)
+///         .with_exponent_step(Complex64::new(0.0, -0.1)),
+/// )?;
+/// assert_eq!(result.sweeps_completed, 1);
+/// # Ok(())
+/// # }
+/// ```
+pub fn tdvp<T, V>(
+    operator: &LinearOperator<T, V>,
+    init: TreeTN<T, V>,
+    center: &V,
+    options: TdvpOptions,
+) -> Result<TdvpResult<T, V>, TdvpError>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    validate_options(&options)?;
+    if init.node_index(center).is_none() {
+        return Err(TdvpError::MissingCenter {
+            center: format!("{center:?}"),
+        });
+    }
+    if !init.same_topology(operator.mpo()) {
+        return Err(TdvpError::TopologyMismatch);
+    }
+
+    let (input_mapping, output_mapping) =
+        single_site_square_mappings(operator, &init).map_err(TdvpError::from)?;
+    let mut state = init
+        .canonicalize([center.clone()], CanonicalizationOptions::default())
+        .map_err(|source| TdvpError::Algorithm {
+            context: "TDVP failed to canonicalize initial state",
+            source,
+        })?;
+    let plan = TdvpRegionPlan::new(
+        state.site_index_network().topology(),
+        center,
+        options.nsite,
+        options.order,
+        options.exponent_step,
+    )
+    .ok_or_else(|| TdvpError::MissingCenter {
+        center: format!("{center:?}"),
+    })?;
+    if options.nsite == 2 && plan.steps.is_empty() {
+        return Err(TdvpError::EmptyTwoSiteSweep);
+    }
+
+    let mut updater = TdvpUpdater::new(
+        operator.mpo().clone(),
+        input_mapping,
+        output_mapping,
+        options.clone(),
+    );
+    let mut sweeps_completed = 0usize;
+    for sweep in 0..options.nsweeps {
+        for (step_index, step) in plan.steps.iter().enumerate() {
+            move_center_to_region_full_rank(&mut state, &step.nodes).map_err(|source| {
+                TdvpError::Algorithm {
+                    context: "TDVP failed to move canonical center to local region",
+                    source,
+                }
+            })?;
+            updater.update_step(&mut state, step, plan.steps.get(step_index + 1))?;
+        }
+        sweeps_completed = sweep + 1;
+        if options.verbose {
+            eprintln!(
+                "TDVP sweep {}: updates={} max_krylov_error={:.6e}",
+                sweeps_completed, updater.local_updates, updater.max_error_estimate
+            );
+        }
+    }
+
+    Ok(TdvpResult {
+        state,
+        sweeps_completed,
+        local_updates: updater.local_updates,
+        max_error_estimate: updater.max_error_estimate,
+        max_krylov_iterations: updater.max_krylov_iterations,
+    })
+}
+
+/// Build a mapped operator from a TreeTN MPO and run TreeTN TDVP.
+///
+/// This is a convenience wrapper over [`LinearOperator::from_mpo_and_state`] and
+/// [`tdvp`].
+///
+/// # Examples
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::{tdvp_with_treetn_operator, TdvpOptions, TreeTN};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let site = DynIndex::new_dyn(2);
+/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+/// let input = DynIndex::new_dyn(2);
+/// let output = DynIndex::new_dyn(2);
+/// let op_tensor = TensorDynLen::from_dense(vec![output, input], vec![1.0, 0.0, 0.0, 1.0])?;
+/// let operator = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+///
+/// let result = tdvp_with_treetn_operator(&operator, state, &0, TdvpOptions::default().with_nsite(1))?;
+/// assert_eq!(result.sweeps_completed, 1);
+/// # Ok(())
+/// # }
+/// ```
+pub fn tdvp_with_treetn_operator<T, V>(
+    operator: &TreeTN<T, V>,
+    init: TreeTN<T, V>,
+    center: &V,
+    options: TdvpOptions,
+) -> Result<TdvpResult<T, V>, TdvpError>
+where
+    T: TensorLike + 'static,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    let linear_operator =
+        LinearOperator::from_mpo_and_state(operator.clone(), &init).map_err(|source| {
+            TdvpError::Algorithm {
+                context: "TDVP failed to build LinearOperator from TreeTN operator",
+                source,
+            }
+        })?;
+    tdvp(&linear_operator, init, center, options)
+}
+
+fn validate_options(options: &TdvpOptions) -> Result<(), TdvpError> {
+    if options.nsite != 1 && options.nsite != 2 {
+        return Err(TdvpError::UnsupportedNsite {
+            requested: options.nsite,
+        });
+    }
+    if options.nsweeps == 0 {
+        return Err(TdvpError::InvalidOption {
+            option: "nsweeps",
+            reason: "must be greater than zero".to_string(),
+        });
+    }
+    if !matches!(options.order, 1 | 2 | 4) {
+        return Err(TdvpError::UnsupportedOrder {
+            requested: options.order,
+        });
+    }
+    if !options.exponent_step.re.is_finite() || !options.exponent_step.im.is_finite() {
+        return Err(TdvpError::InvalidOption {
+            option: "exponent_step",
+            reason: "real and imaginary parts must be finite".to_string(),
+        });
+    }
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        if max_bond_dim == 0 {
+            return Err(TdvpError::InvalidOption {
+                option: "max_bond_dim",
+                reason: "must be greater than zero when set".to_string(),
+            });
+        }
+    }
+    if options.nsite == 1 {
+        if options.max_bond_dim.is_some() {
+            return Err(TdvpError::InvalidOption {
+                option: "max_bond_dim",
+                reason: "one-site TDVP has fixed ranks; use nsite=2 for truncation".to_string(),
+            });
+        }
+        if options.svd_policy.is_some() {
+            return Err(TdvpError::InvalidOption {
+                option: "svd_policy",
+                reason: "one-site TDVP has fixed ranks; use nsite=2 for truncation".to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn move_center_to_region_full_rank<T, V>(
+    state: &mut TreeTN<T, V>,
+    region: &[V],
+) -> anyhow::Result<()>
+where
+    T: TensorLike,
+    T::Index: IndexLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + Debug + Send + Sync + 'static,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if region.is_empty() {
+        return Err(anyhow::anyhow!(
+            "TDVP cannot move center to an empty region"
+        ));
+    }
+    let current = state.canonical_region();
+    if current.is_empty() {
+        return Err(anyhow::anyhow!("TDVP state is not canonicalized"));
+    }
+    if region.iter().any(|node| current.contains(node)) {
+        return Ok(());
+    }
+
+    let (path, target) = {
+        let topology = state.site_index_network().topology();
+        let mut best_path = None;
+        for src in current {
+            let Some(src_idx) = topology.node_index(src) else {
+                continue;
+            };
+            for dst in region {
+                let Some(dst_idx) = topology.node_index(dst) else {
+                    continue;
+                };
+                let Some(path) = topology.path_between(src_idx, dst_idx) else {
+                    continue;
+                };
+                if best_path
+                    .as_ref()
+                    .is_none_or(|best: &Vec<_>| path.len() < best.len())
+                {
+                    best_path = Some(path);
+                }
+            }
+        }
+        let path = best_path.ok_or_else(|| {
+            anyhow::anyhow!(
+                "TDVP could not find a path from canonical region {:?} to {:?}",
+                current,
+                region
+            )
+        })?;
+        let target = path
+            .last()
+            .and_then(|idx| topology.node_name(*idx))
+            .ok_or_else(|| anyhow::anyhow!("TDVP center path ended at an unknown node"))?
+            .clone();
+        (path, target)
+    };
+    for pair in path.windows(2) {
+        let src = pair[0];
+        let dst = pair[1];
+        state.sweep_edge_full_rank(
+            src,
+            dst,
+            FactorizeAlg::QR,
+            Canonical::Left,
+            "TDVP path-only center move",
+        )?;
+    }
+    state.set_canonical_region([target])?;
+    Ok(())
+}
+
+fn first_path_neighbor<T, V>(state: &TreeTN<T, V>, from: &V, to: &V) -> anyhow::Result<Option<V>>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if from == to {
+        return Ok(None);
+    }
+    let topology = state.site_index_network().topology();
+    let from_idx = topology
+        .node_index(from)
+        .ok_or_else(|| anyhow::anyhow!("source node {:?} is missing", from))?;
+    let to_idx = topology
+        .node_index(to)
+        .ok_or_else(|| anyhow::anyhow!("target node {:?} is missing", to))?;
+    let path = topology
+        .path_between(from_idx, to_idx)
+        .ok_or_else(|| anyhow::anyhow!("no path between {:?} and {:?}", from, to))?;
+    let Some(next_idx) = path.get(1) else {
+        return Ok(None);
+    };
+    let next = topology
+        .node_name(*next_idx)
+        .ok_or_else(|| anyhow::anyhow!("path neighbor {:?} has no node name", next_idx))?
+        .clone();
+    Ok(Some(next))
+}

--- a/crates/tensor4all-treetn/src/tdvp/plan.rs
+++ b/crates/tensor4all-treetn/src/tdvp/plan.rs
@@ -1,0 +1,279 @@
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use num_complex::Complex64;
+
+use crate::node_name_network::NodeNameNetwork;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TdvpRegionKind {
+    OneSite,
+    TwoSite,
+    SiteCorrection,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TdvpRegionStep<V> {
+    pub(crate) nodes: Vec<V>,
+    pub(crate) new_center: V,
+    pub(crate) exponent_step: Complex64,
+    pub(crate) kind: TdvpRegionKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct TdvpRegionPlan<V> {
+    pub(crate) steps: Vec<TdvpRegionStep<V>>,
+    pub(crate) nsite: usize,
+    pub(crate) order: usize,
+}
+
+impl<V> TdvpRegionPlan<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    pub(crate) fn new(
+        network: &NodeNameNetwork<V>,
+        root: &V,
+        nsite: usize,
+        order: usize,
+        exponent_step: Complex64,
+    ) -> Option<Self> {
+        if nsite != 1 && nsite != 2 {
+            return None;
+        }
+        let weights = applyexp_sub_steps(order)?;
+        let base_sweep = first_order_sweep(network, root, nsite, exponent_step)?;
+        let mut steps = Vec::new();
+        for (substep, weight) in weights.iter().enumerate() {
+            let mut region_plan = base_sweep
+                .iter()
+                .map(|step| {
+                    let mut step = step.clone();
+                    step.exponent_step *= *weight;
+                    step
+                })
+                .collect::<Vec<_>>();
+            if (substep + 1) % 2 == 0 {
+                region_plan = reverse_regions(&region_plan);
+            }
+            steps.extend(region_plan);
+        }
+        Some(Self {
+            steps,
+            nsite,
+            order,
+        })
+    }
+}
+
+pub(crate) fn applyexp_sub_steps(order: usize) -> Option<Vec<f64>> {
+    match order {
+        1 => Some(vec![1.0]),
+        2 => Some(vec![0.5, 0.5]),
+        4 => {
+            let s = (2.0 - 2.0_f64.powf(1.0 / 3.0)).recip();
+            Some(vec![s / 2.0, s / 2.0, 0.5 - s, 0.5 - s, s / 2.0, s / 2.0])
+        }
+        _ => None,
+    }
+}
+
+fn first_order_sweep<V>(
+    network: &NodeNameNetwork<V>,
+    root: &V,
+    nsite: usize,
+    exponent_step: Complex64,
+) -> Option<Vec<TdvpRegionStep<V>>>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    match nsite {
+        1 => {
+            let vertices = network.post_order_dfs(root)?;
+            Some(
+                vertices
+                    .into_iter()
+                    .map(|node| TdvpRegionStep {
+                        nodes: vec![node.clone()],
+                        new_center: node,
+                        exponent_step,
+                        kind: TdvpRegionKind::OneSite,
+                    })
+                    .collect(),
+            )
+        }
+        2 => {
+            let edges = post_order_dfs_edges_by_name(network, root)?;
+            let mut steps = Vec::new();
+            let last_edge = edges.len().saturating_sub(1);
+            for (j, (src, dst)) in edges.into_iter().enumerate() {
+                steps.push(TdvpRegionStep {
+                    nodes: vec![src, dst.clone()],
+                    new_center: dst.clone(),
+                    exponent_step,
+                    kind: TdvpRegionKind::TwoSite,
+                });
+                if j < last_edge {
+                    steps.push(TdvpRegionStep {
+                        nodes: vec![dst.clone()],
+                        new_center: dst,
+                        exponent_step: -exponent_step,
+                        kind: TdvpRegionKind::SiteCorrection,
+                    });
+                }
+            }
+            Some(steps)
+        }
+        _ => None,
+    }
+}
+
+fn reverse_regions<V>(steps: &[TdvpRegionStep<V>]) -> Vec<TdvpRegionStep<V>>
+where
+    V: Clone,
+{
+    steps
+        .iter()
+        .rev()
+        .map(|step| {
+            let mut nodes = step.nodes.clone();
+            nodes.reverse();
+            let new_center = nodes
+                .last()
+                .expect("TDVP region steps are never empty")
+                .clone();
+            TdvpRegionStep {
+                nodes,
+                new_center,
+                exponent_step: step.exponent_step,
+                kind: step.kind,
+            }
+        })
+        .collect()
+}
+
+fn post_order_dfs_edges_by_name<V>(network: &NodeNameNetwork<V>, root: &V) -> Option<Vec<(V, V)>>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    let root_idx = network.node_index(root)?;
+    let post_order = network.post_order_dfs_by_index(root_idx);
+    let mut edges = Vec::new();
+    for child in post_order {
+        if child == root_idx {
+            continue;
+        }
+        let path = network.path_between(child, root_idx)?;
+        let parent = *path.get(1)?;
+        let child_name = network.node_name(child)?.clone();
+        let parent_name = network.node_name(parent)?.clone();
+        edges.push((child_name, parent_name));
+    }
+    Some(edges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain_abc() -> NodeNameNetwork<&'static str> {
+        let mut network = NodeNameNetwork::new();
+        network.add_node("A").unwrap();
+        network.add_node("B").unwrap();
+        network.add_node("C").unwrap();
+        network.add_edge(&"A", &"B").unwrap();
+        network.add_edge(&"B", &"C").unwrap();
+        network
+    }
+
+    fn star_abcd() -> NodeNameNetwork<&'static str> {
+        let mut network = NodeNameNetwork::new();
+        for node in ["A", "B", "C", "D"] {
+            network.add_node(node).unwrap();
+        }
+        network.add_edge(&"A", &"B").unwrap();
+        network.add_edge(&"A", &"C").unwrap();
+        network.add_edge(&"A", &"D").unwrap();
+        network
+    }
+
+    #[test]
+    fn applyexp_sub_steps_match_itensornetworks_orders() {
+        assert_eq!(applyexp_sub_steps(1).unwrap(), vec![1.0]);
+        assert_eq!(applyexp_sub_steps(2).unwrap(), vec![0.5, 0.5]);
+
+        let fourth = applyexp_sub_steps(4).unwrap();
+        assert_eq!(fourth.len(), 6);
+        let total: f64 = fourth.iter().sum();
+        assert!((total - 1.0).abs() < 1.0e-14);
+        assert!(applyexp_sub_steps(3).is_none());
+    }
+
+    #[test]
+    fn two_site_plan_inserts_negative_single_site_corrections_except_last_edge() {
+        let network = chain_abc();
+        let exponent = Complex64::new(0.0, -0.2);
+        let plan = TdvpRegionPlan::new(&network, &"B", 2, 1, exponent).unwrap();
+
+        let regions: Vec<_> = plan
+            .steps
+            .iter()
+            .map(|step| (step.kind, step.nodes.clone(), step.exponent_step))
+            .collect();
+        assert_eq!(
+            regions,
+            vec![
+                (TdvpRegionKind::TwoSite, vec!["A", "B"], exponent),
+                (TdvpRegionKind::SiteCorrection, vec!["B"], -exponent),
+                (TdvpRegionKind::TwoSite, vec!["C", "B"], exponent),
+            ]
+        );
+    }
+
+    #[test]
+    fn second_order_plan_reverses_even_substep_regions() {
+        let network = chain_abc();
+        let exponent = Complex64::new(0.0, -0.2);
+        let plan = TdvpRegionPlan::new(&network, &"B", 2, 2, exponent).unwrap();
+
+        let regions: Vec<_> = plan
+            .steps
+            .iter()
+            .map(|step| (step.kind, step.nodes.clone(), step.exponent_step))
+            .collect();
+        let half = exponent * 0.5;
+        assert_eq!(
+            regions,
+            vec![
+                (TdvpRegionKind::TwoSite, vec!["A", "B"], half),
+                (TdvpRegionKind::SiteCorrection, vec!["B"], -half),
+                (TdvpRegionKind::TwoSite, vec!["C", "B"], half),
+                (TdvpRegionKind::TwoSite, vec!["B", "C"], half),
+                (TdvpRegionKind::SiteCorrection, vec!["B"], -half),
+                (TdvpRegionKind::TwoSite, vec!["B", "A"], half),
+            ]
+        );
+    }
+
+    #[test]
+    fn one_site_plan_uses_post_order_vertices() {
+        let network = star_abcd();
+        let exponent = Complex64::new(0.0, -0.2);
+        let plan = TdvpRegionPlan::new(&network, &"A", 1, 1, exponent).unwrap();
+
+        assert_eq!(plan.nsite, 1);
+        assert_eq!(plan.order, 1);
+        assert_eq!(
+            plan.steps
+                .iter()
+                .map(|step| (step.kind, step.nodes.clone()))
+                .collect::<Vec<_>>(),
+            vec![
+                (TdvpRegionKind::OneSite, vec!["B"]),
+                (TdvpRegionKind::OneSite, vec!["C"]),
+                (TdvpRegionKind::OneSite, vec!["D"]),
+                (TdvpRegionKind::OneSite, vec!["A"]),
+            ]
+        );
+    }
+}

--- a/crates/tensor4all-treetn/tests/tdvp.rs
+++ b/crates/tensor4all-treetn/tests/tdvp.rs
@@ -1,14 +1,15 @@
 use std::collections::HashMap;
 
 use num_complex::Complex64;
+use tensor4all_core::krylov::HermitianKrylovExpmOptions;
 use tensor4all_core::{
     DynIndex, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorContractionLike,
     TensorDynLen, TensorIndex,
 };
 use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
 use tensor4all_treetn::{
-    factorize_tensor_to_treetn_with, tdvp, IndexMapping, LinearOperator, TdvpError, TdvpOptions,
-    TreeTN, TreeTopology,
+    factorize_tensor_to_treetn_with, tdvp, tdvp_with_treetn_operator, IndexMapping, LinearOperator,
+    TdvpError, TdvpOptions, TreeTN, TreeTopology,
 };
 
 fn chain_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
@@ -739,4 +740,198 @@ fn one_site_tdvp_rejects_svd_truncation_policy() {
             ..
         }
     ));
+}
+
+#[test]
+fn tdvp_options_set_sweeps_and_krylov_options() {
+    let krylov = HermitianKrylovExpmOptions {
+        max_iter: 7,
+        tol: 1.0e-11,
+        ..Default::default()
+    };
+    let options = TdvpOptions::default()
+        .with_nsweeps(2)
+        .with_krylov_options(krylov);
+
+    assert_eq!(options.nsweeps, 2);
+    assert_eq!(options.krylov.max_iter, 7);
+    assert_eq!(options.krylov.tol, 1.0e-11);
+}
+
+#[test]
+fn tdvp_rejects_invalid_public_options() {
+    let (state, sites) = chain_state();
+    let operator = identity_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+
+    let err = tdvp(
+        &operator,
+        state.clone(),
+        &"site0",
+        TdvpOptions::default().with_nsite(3),
+    )
+    .unwrap_err();
+    assert!(matches!(err, TdvpError::UnsupportedNsite { requested: 3 }));
+
+    let err = tdvp(
+        &operator,
+        state.clone(),
+        &"site0",
+        TdvpOptions::default().with_nsweeps(0),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        TdvpError::InvalidOption {
+            option: "nsweeps",
+            ..
+        }
+    ));
+
+    let err = tdvp(
+        &operator,
+        state.clone(),
+        &"site0",
+        TdvpOptions::default().with_order(3),
+    )
+    .unwrap_err();
+    assert!(matches!(err, TdvpError::UnsupportedOrder { requested: 3 }));
+
+    let err = tdvp(
+        &operator,
+        state.clone(),
+        &"site0",
+        TdvpOptions::default().with_exponent_step(Complex64::new(f64::NAN, 0.0)),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        TdvpError::InvalidOption {
+            option: "exponent_step",
+            ..
+        }
+    ));
+
+    let err = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default().with_max_bond_dim(0),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        TdvpError::InvalidOption {
+            option: "max_bond_dim",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn tdvp_rejects_missing_center_and_topology_mismatch() {
+    let (chain, chain_sites) = chain_state();
+    let chain_operator =
+        identity_operator(&chain_sites, &["site0", "site1"], &[("site0", "site1")]);
+    let err = tdvp(
+        &chain_operator,
+        chain.clone(),
+        &"missing",
+        TdvpOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(err, TdvpError::MissingCenter { .. }));
+
+    let (star, star_sites) = star_state();
+    let star_operator = identity_operator(
+        &star_sites,
+        &["site0", "site1", "site2"],
+        &[("site0", "site1"), ("site0", "site2")],
+    );
+    let err = tdvp(&star_operator, chain, &"site0", TdvpOptions::default()).unwrap_err();
+    assert!(matches!(err, TdvpError::TopologyMismatch));
+
+    let result = tdvp(&star_operator, star, &"site0", TdvpOptions::default());
+    assert!(result.is_ok());
+}
+
+#[test]
+fn two_site_tdvp_rejects_single_node_empty_sweep() {
+    let site = DynIndex::new_dyn(2);
+    let state_tensor = TensorDynLen::from_dense(
+        vec![site.clone()],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    )
+    .unwrap();
+    let state =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
+            .unwrap();
+    let operator = identity_operator(&[site], &["site0"], &[]);
+
+    let err = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default().with_nsite(2),
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, TdvpError::EmptyTwoSiteSweep));
+}
+
+#[test]
+fn two_site_tdvp_accepts_truncation_options() {
+    let (state, sites) = chain_state();
+    let operator = identity_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_max_bond_dim(1)
+            .with_svd_policy(SvdTruncationPolicy::new(1.0e-12)),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 2);
+}
+
+#[test]
+fn tdvp_with_treetn_operator_single_node_identity_runs() {
+    let site = DynIndex::new_dyn(2);
+    let state_tensor = TensorDynLen::from_dense(
+        vec![site.clone()],
+        vec![Complex64::new(0.6, 0.0), Complex64::new(-0.8, 0.0)],
+    )
+    .unwrap();
+    let state =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
+            .unwrap();
+
+    let input = DynIndex::new_dyn(2);
+    let output = DynIndex::new_dyn(2);
+    let op_tensor = TensorDynLen::from_dense(
+        vec![output, input],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let operator =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![op_tensor], vec!["site0"]).unwrap();
+
+    let result = tdvp_with_treetn_operator(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default().with_nsite(1),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 2);
 }

--- a/crates/tensor4all-treetn/tests/tdvp.rs
+++ b/crates/tensor4all-treetn/tests/tdvp.rs
@@ -1,0 +1,742 @@
+use std::collections::HashMap;
+
+use num_complex::Complex64;
+use tensor4all_core::{
+    DynIndex, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorContractionLike,
+    TensorDynLen, TensorIndex,
+};
+use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
+use tensor4all_treetn::{
+    factorize_tensor_to_treetn_with, tdvp, IndexMapping, LinearOperator, TdvpError, TdvpOptions,
+    TreeTN, TreeTopology,
+};
+
+fn chain_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), bond.clone()],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![bond.clone(), s1.clone()],
+        vec![Complex64::new(0.5, 0.0), Complex64::new(-1.0, 0.0)],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    state.connect(n0, &bond, n1, &bond).unwrap();
+    (state, [s0, s1])
+}
+
+fn star_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(1);
+    let b02 = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), b01.clone(), b02.clone()],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(-0.25, 0.0)],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![b01.clone(), s1.clone()],
+        vec![Complex64::new(0.5, 0.0), Complex64::new(1.5, 0.0)],
+    )
+    .unwrap();
+    let t2 = TensorDynLen::from_dense(
+        vec![b02.clone(), s2.clone()],
+        vec![Complex64::new(-2.0, 0.0), Complex64::new(0.75, 0.0)],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    let n2 = state.add_tensor("site2", t2).unwrap();
+    state.connect(n0, &b01, n1, &b01).unwrap();
+    state.connect(n0, &b02, n2, &b02).unwrap();
+    (state, [s0, s1, s2])
+}
+
+fn identity_operator(
+    state_sites: &[DynIndex],
+    node_names: &[&'static str],
+    edges: &[(&'static str, &'static str)],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let mut tensors = HashMap::new();
+    let mut node_indices = HashMap::new();
+    let mut input_mapping = HashMap::new();
+    let mut output_mapping = HashMap::new();
+    let mut op_bonds = HashMap::new();
+
+    for (i, &name) in node_names.iter().enumerate() {
+        let input = DynIndex::new_dyn(2);
+        let output = DynIndex::new_dyn(2);
+        input_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: input.clone(),
+            },
+        );
+        output_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: output.clone(),
+            },
+        );
+        tensors.insert(name, (input, output));
+    }
+
+    for &(a, b) in edges {
+        op_bonds.insert((a, b), DynIndex::new_dyn(1));
+    }
+
+    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    for &name in node_names {
+        let (input, output) = tensors.get(name).unwrap();
+        let mut inds = Vec::new();
+        for &(a, b) in edges {
+            if a == name || b == name {
+                inds.push(op_bonds.get(&(a, b)).unwrap().clone());
+            }
+        }
+        inds.push(output.clone());
+        inds.push(input.clone());
+        let mut data = vec![Complex64::new(0.0, 0.0); inds.iter().map(DynIndex::dim).product()];
+        let output_pos = inds.len() - 2;
+        let input_pos = inds.len() - 1;
+        let dims: Vec<_> = inds.iter().map(DynIndex::dim).collect();
+        for s in 0..2 {
+            let mut coord = vec![0; inds.len()];
+            coord[output_pos] = s;
+            coord[input_pos] = s;
+            data[col_major_offset(&coord, &dims)] = Complex64::new(1.0, 0.0);
+        }
+        let node = mpo
+            .add_tensor(name, TensorDynLen::from_dense(inds, data).unwrap())
+            .unwrap();
+        node_indices.insert(name, node);
+    }
+    for &(a, b) in edges {
+        let bond = op_bonds.get(&(a, b)).unwrap();
+        mpo.connect(
+            *node_indices.get(a).unwrap(),
+            bond,
+            *node_indices.get(b).unwrap(),
+            bond,
+        )
+        .unwrap();
+    }
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn diagonal_sum_z_operator(
+    state_sites: &[DynIndex],
+    node_names: &[&'static str],
+    edges: &[(&'static str, &'static str)],
+    coeffs: &[f64],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let mut dense_indices = Vec::new();
+    let mut topology_nodes = HashMap::new();
+    let mut input_mapping = HashMap::new();
+    let mut output_mapping = HashMap::new();
+
+    for (i, &name) in node_names.iter().enumerate() {
+        let output = DynIndex::new_dyn(2);
+        let input = DynIndex::new_dyn(2);
+        dense_indices.push(output.clone());
+        dense_indices.push(input.clone());
+        topology_nodes.insert(name, vec![output.clone(), input.clone()]);
+        input_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: input,
+            },
+        );
+        output_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: output,
+            },
+        );
+    }
+
+    let dims = vec![2; dense_indices.len()];
+    let mut data = vec![Complex64::new(0.0, 0.0); dims.iter().product()];
+    for basis in 0..(1usize << node_names.len()) {
+        let mut coord = vec![0; dense_indices.len()];
+        let mut energy = 0.0;
+        for site in 0..node_names.len() {
+            let bit = (basis >> site) & 1;
+            coord[2 * site] = bit;
+            coord[2 * site + 1] = bit;
+            energy += coeffs[site] * if bit == 0 { 1.0 } else { -1.0 };
+        }
+        data[col_major_offset(&coord, &dims)] = Complex64::new(energy, 0.0);
+    }
+
+    let dense = TensorDynLen::from_dense(dense_indices, data).unwrap();
+    let topology = TreeTopology::new(topology_nodes, edges.to_vec());
+    let mpo = factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        node_names.first().unwrap(),
+    )
+    .unwrap();
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn heisenberg_operator(
+    state_sites: &[DynIndex],
+    node_names: &[&'static str],
+    edges: &[(&'static str, &'static str)],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let mut dense_indices = Vec::new();
+    let mut topology_nodes = HashMap::new();
+    let mut input_mapping = HashMap::new();
+    let mut output_mapping = HashMap::new();
+
+    for (i, &name) in node_names.iter().enumerate() {
+        let output = DynIndex::new_dyn(2);
+        let input = DynIndex::new_dyn(2);
+        dense_indices.push(output.clone());
+        dense_indices.push(input.clone());
+        topology_nodes.insert(name, vec![output.clone(), input.clone()]);
+        input_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: input,
+            },
+        );
+        output_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: output,
+            },
+        );
+    }
+
+    let name_to_site: HashMap<_, _> = node_names
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(i, name)| (name, i))
+        .collect();
+    let dims = vec![2; dense_indices.len()];
+    let mut data = vec![Complex64::new(0.0, 0.0); dims.iter().product()];
+    for input_basis in 0..(1usize << node_names.len()) {
+        for &(left_name, right_name) in edges {
+            let left = *name_to_site.get(left_name).unwrap();
+            let right = *name_to_site.get(right_name).unwrap();
+            let left_bit = (input_basis >> left) & 1;
+            let right_bit = (input_basis >> right) & 1;
+            let z_left = if left_bit == 0 { 1.0 } else { -1.0 };
+            let z_right = if right_bit == 0 { 1.0 } else { -1.0 };
+            add_dense_operator_entry(
+                &mut data,
+                &dims,
+                node_names.len(),
+                input_basis,
+                input_basis,
+                Complex64::new(z_left * z_right, 0.0),
+            );
+
+            if left_bit != right_bit {
+                let flipped = input_basis ^ (1usize << left) ^ (1usize << right);
+                add_dense_operator_entry(
+                    &mut data,
+                    &dims,
+                    node_names.len(),
+                    input_basis,
+                    flipped,
+                    Complex64::new(2.0, 0.0),
+                );
+            }
+        }
+    }
+
+    let dense = TensorDynLen::from_dense(dense_indices, data).unwrap();
+    let topology = TreeTopology::new(topology_nodes, edges.to_vec());
+    let mpo = factorize_tensor_to_treetn_with(
+        &dense,
+        &topology,
+        FactorizeOptions::svd(),
+        node_names.first().unwrap(),
+    )
+    .unwrap();
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn add_dense_operator_entry(
+    data: &mut [Complex64],
+    dims: &[usize],
+    n_sites: usize,
+    input_basis: usize,
+    output_basis: usize,
+    value: Complex64,
+) {
+    let mut coord = vec![0; 2 * n_sites];
+    for site in 0..n_sites {
+        coord[2 * site] = (output_basis >> site) & 1;
+        coord[2 * site + 1] = (input_basis >> site) & 1;
+    }
+    data[col_major_offset(&coord, dims)] += value;
+}
+
+fn dense_heisenberg_matrix(n_sites: usize, edges: &[(usize, usize)]) -> Matrix<Complex64> {
+    let dim = 1usize << n_sites;
+    let mut data = vec![Complex64::new(0.0, 0.0); dim * dim];
+    for input_basis in 0..dim {
+        for &(left, right) in edges {
+            let left_bit = (input_basis >> left) & 1;
+            let right_bit = (input_basis >> right) & 1;
+            let z_left = if left_bit == 0 { 1.0 } else { -1.0 };
+            let z_right = if right_bit == 0 { 1.0 } else { -1.0 };
+            data[input_basis + dim * input_basis] += Complex64::new(z_left * z_right, 0.0);
+
+            if left_bit != right_bit {
+                let flipped = input_basis ^ (1usize << left) ^ (1usize << right);
+                data[flipped + dim * input_basis] += Complex64::new(2.0, 0.0);
+            }
+        }
+    }
+    Matrix::from_col_major_vec(dim, dim, data)
+}
+
+fn exact_evolve(
+    hamiltonian: &Matrix<Complex64>,
+    initial: &[Complex64],
+    time: f64,
+) -> Vec<Complex64> {
+    let decomp = hermitian_eigendecomposition(hamiltonian, 1.0e-12).unwrap();
+    let n = hamiltonian.nrows();
+    let vectors = decomp.eigenvectors.as_col_major_slice();
+    let mut coefficients = vec![Complex64::new(0.0, 0.0); n];
+    for col in 0..n {
+        for row in 0..n {
+            coefficients[col] += vectors[row + col * n].conj() * initial[row];
+        }
+    }
+
+    let mut result = vec![Complex64::new(0.0, 0.0); n];
+    for col in 0..n {
+        let phase = (Complex64::new(0.0, -time) * decomp.eigenvalues[col]).exp();
+        let coeff = phase * coefficients[col];
+        for row in 0..n {
+            result[row] += vectors[row + col * n] * coeff;
+        }
+    }
+    result
+}
+
+fn state_vector(state: &TreeTN<TensorDynLen, &'static str>, sites: &[DynIndex]) -> Vec<Complex64> {
+    state
+        .contract_to_tensor()
+        .unwrap()
+        .permuteinds(sites)
+        .unwrap()
+        .to_vec::<Complex64>()
+        .unwrap()
+}
+
+fn l2_error(actual: &[Complex64], expected: &[Complex64]) -> f64 {
+    actual
+        .iter()
+        .zip(expected)
+        .map(|(a, e)| (*a - *e).norm_sqr())
+        .sum::<f64>()
+        .sqrt()
+}
+
+fn col_major_offset(coord: &[usize], dims: &[usize]) -> usize {
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (&value, &dim) in coord.iter().zip(dims) {
+        offset += value * stride;
+        stride *= dim;
+    }
+    offset
+}
+
+fn assert_phase_evolution(
+    before: &TensorDynLen,
+    after: &TensorDynLen,
+    exponent: Complex64,
+    tolerance: f64,
+) {
+    let after = after.permuteinds(&before.external_indices()).unwrap();
+    let before_data = before.to_vec::<Complex64>().unwrap();
+    let after_data = after.to_vec::<Complex64>().unwrap();
+    let phase = exponent.exp();
+    let max_error = before_data
+        .iter()
+        .zip(after_data.iter())
+        .map(|(x, y)| (*y - phase * *x).norm())
+        .fold(0.0, f64::max);
+    assert!(
+        max_error < tolerance,
+        "max phase evolution error {max_error:.3e} exceeds tolerance {tolerance:.3e}"
+    );
+}
+
+fn assert_diagonal_sum_z_evolution(
+    before: &TensorDynLen,
+    after: &TensorDynLen,
+    exponent: Complex64,
+    coeffs: &[f64],
+    tolerance: f64,
+) {
+    let after = after.permuteinds(&before.external_indices()).unwrap();
+    let before_data = before.to_vec::<Complex64>().unwrap();
+    let after_data = after.to_vec::<Complex64>().unwrap();
+    let dims = vec![2; coeffs.len()];
+    let max_error = before_data
+        .iter()
+        .zip(after_data.iter())
+        .enumerate()
+        .map(|(offset, (x, y))| {
+            let coord = decode_col_major_offset(offset, &dims);
+            let energy = coord
+                .iter()
+                .zip(coeffs.iter())
+                .map(|(&bit, &coeff)| coeff * if bit == 0 { 1.0 } else { -1.0 })
+                .sum::<f64>();
+            (*y - (exponent * energy).exp() * *x).norm()
+        })
+        .fold(0.0, f64::max);
+    assert!(
+        max_error < tolerance,
+        "max diagonal evolution error {max_error:.3e} exceeds tolerance {tolerance:.3e}"
+    );
+}
+
+fn decode_col_major_offset(mut offset: usize, dims: &[usize]) -> Vec<usize> {
+    let mut coord = Vec::with_capacity(dims.len());
+    for &dim in dims {
+        coord.push(offset % dim);
+        offset /= dim;
+    }
+    coord
+}
+
+#[test]
+fn two_site_tdvp_identity_chain_matches_global_phase() {
+    let (state, sites) = chain_state();
+    let before = state.contract_to_tensor().unwrap();
+    let operator = identity_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+    let exponent = Complex64::new(0.0, -0.2);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_order(2)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 2);
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_phase_evolution(&before, &after, exponent, 1.0e-10);
+}
+
+#[test]
+fn two_site_tdvp_identity_star_matches_global_phase() {
+    let (state, sites) = star_state();
+    let before = state.contract_to_tensor().unwrap();
+    let operator = identity_operator(
+        &sites,
+        &["site0", "site1", "site2"],
+        &[("site0", "site1"), ("site0", "site2")],
+    );
+    let exponent = Complex64::new(0.0, -0.15);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_order(2)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 6);
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_phase_evolution(&before, &after, exponent, 1.0e-10);
+}
+
+#[test]
+fn two_site_tdvp_sum_z_chain_matches_exact_dense_phase() {
+    let (state, sites) = chain_state();
+    let before = state.contract_to_tensor().unwrap();
+    let coeffs = [1.0, -0.35];
+    let operator =
+        diagonal_sum_z_operator(&sites, &["site0", "site1"], &[("site0", "site1")], &coeffs);
+    let exponent = Complex64::new(0.0, -0.07);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_order(4)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_diagonal_sum_z_evolution(&before, &after, exponent, &coeffs, 1.0e-10);
+}
+
+#[test]
+fn two_site_tdvp_sum_z_star_matches_exact_dense_phase() {
+    let (state, sites) = star_state();
+    let before = state.contract_to_tensor().unwrap();
+    let coeffs = [0.75, -0.5, 0.25];
+    let operator = diagonal_sum_z_operator(
+        &sites,
+        &["site0", "site1", "site2"],
+        &[("site0", "site1"), ("site0", "site2")],
+        &coeffs,
+    );
+    let exponent = Complex64::new(0.0, -0.04);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_order(2)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_diagonal_sum_z_evolution(&before, &after, exponent, &coeffs, 1.0e-10);
+}
+
+#[test]
+fn one_site_tdvp_identity_single_node_matches_global_phase() {
+    let site = DynIndex::new_dyn(2);
+    let state_tensor = TensorDynLen::from_dense(
+        vec![site.clone()],
+        vec![Complex64::new(0.75, 0.0), Complex64::new(-1.25, 0.0)],
+    )
+    .unwrap();
+    let state =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
+            .unwrap();
+    let before = state.contract_to_tensor().unwrap();
+    let operator = identity_operator(&[site], &["site0"], &[]);
+    let exponent = Complex64::new(0.0, -0.3);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(1)
+            .with_order(4)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 6);
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_phase_evolution(&before, &after, exponent, 1.0e-10);
+}
+
+#[test]
+fn one_site_tdvp_identity_chain_matches_global_phase() {
+    let (state, sites) = chain_state();
+    let before = state.contract_to_tensor().unwrap();
+    let operator = identity_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+    let exponent = Complex64::new(0.0, -0.12);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(1)
+            .with_order(2)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 6);
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_phase_evolution(&before, &after, exponent, 1.0e-10);
+}
+
+#[test]
+fn one_site_tdvp_identity_star_matches_global_phase() {
+    let (state, sites) = star_state();
+    let before = state.contract_to_tensor().unwrap();
+    let operator = identity_operator(
+        &sites,
+        &["site0", "site1", "site2"],
+        &[("site0", "site1"), ("site0", "site2")],
+    );
+    let exponent = Complex64::new(0.0, -0.08);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(1)
+            .with_order(2)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 10);
+    let after = result.state.contract_to_tensor().unwrap();
+    assert_phase_evolution(&before, &after, exponent, 1.0e-10);
+}
+
+#[test]
+fn one_site_tdvp_sum_z_chain_preserves_norm_and_matches_exact_phase() {
+    let (state, sites) = chain_state();
+    let before = state.contract_to_tensor().unwrap();
+    let before_norm = before.norm();
+    let coeffs = [0.4, -0.9];
+    let operator =
+        diagonal_sum_z_operator(&sites, &["site0", "site1"], &[("site0", "site1")], &coeffs);
+    let exponent = Complex64::new(0.0, -0.05);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(1)
+            .with_order(2)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    let after = result.state.contract_to_tensor().unwrap();
+    assert!((after.norm() - before_norm).abs() < 1.0e-10);
+    assert_diagonal_sum_z_evolution(&before, &after, exponent, &coeffs, 1.0e-10);
+}
+
+#[test]
+fn two_site_tdvp_heisenberg_chain_matches_dense_exact_evolution() {
+    let (state, sites) = chain_state();
+    let initial = state_vector(&state, &sites);
+    let operator = heisenberg_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+    let dt = 0.03;
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_order(2)
+            .with_exponent_step(Complex64::new(0.0, -dt)),
+    )
+    .unwrap();
+
+    let actual = state_vector(&result.state, &sites);
+    let expected = exact_evolve(&dense_heisenberg_matrix(2, &[(0, 1)]), &initial, dt);
+    let error = l2_error(&actual, &expected);
+    assert!(
+        error < 1.0e-9,
+        "chain Heisenberg TDVP error {error:.3e} exceeds tolerance"
+    );
+}
+
+#[test]
+fn two_site_tdvp_heisenberg_star_tracks_dense_exact_evolution() {
+    let (state, sites) = star_state();
+    let initial = state_vector(&state, &sites);
+    let operator = heisenberg_operator(
+        &sites,
+        &["site0", "site1", "site2"],
+        &[("site0", "site1"), ("site0", "site2")],
+    );
+    let dt = 0.01;
+    let result = tdvp(
+        &operator,
+        state,
+        &"site1",
+        TdvpOptions::default()
+            .with_nsite(2)
+            .with_order(2)
+            .with_exponent_step(Complex64::new(0.0, -dt)),
+    )
+    .unwrap();
+
+    let actual = state_vector(&result.state, &sites);
+    let expected = exact_evolve(&dense_heisenberg_matrix(3, &[(0, 1), (0, 2)]), &initial, dt);
+    let error = l2_error(&actual, &expected);
+    assert!(
+        error < 5.0e-6,
+        "star Heisenberg TDVP error {error:.3e} exceeds tolerance"
+    );
+}
+
+#[test]
+fn one_site_tdvp_rejects_max_bond_dim_truncation() {
+    let (state, sites) = chain_state();
+    let operator = identity_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+
+    let err = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default().with_nsite(1).with_max_bond_dim(2),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        TdvpError::InvalidOption {
+            option: "max_bond_dim",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn one_site_tdvp_rejects_svd_truncation_policy() {
+    let (state, sites) = chain_state();
+    let operator = identity_operator(&sites, &["site0", "site1"], &[("site0", "site1")]);
+
+    let err = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(1)
+            .with_svd_policy(SvdTruncationPolicy::new(1.0e-12)),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        TdvpError::InvalidOption {
+            option: "svd_policy",
+            ..
+        }
+    ));
+}


### PR DESCRIPTION
## Summary

- adds TreeTN TDVP with ITensorNetworks-compatible `applyexp` region plans for `nsite = 2` and fixed-rank `nsite = 1`
- adds Hermitian Krylov exponential support plus small Hermitian eigendecomposition/exponential helpers
- reuses shared local-update helpers for DMRG/TDVP and keeps production TDVP matrix-free except bounded Krylov projected matrices
- documents AD metadata preservation rules and adds Rust/Julia TDVP benchmarks against local ITensorNetworks.jl

## Benchmark

Model: Pauli Heisenberg `sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j`, alternating product state, `n = 8`, `time_steps = 4`, `dt = 0.02`, `order = 2`, `maxdim = 32`, ITensors-compatible relative discarded squared singular-value tail cutoff `1e-12`.

| Implementation | Topology | L2 error | Mean ms | Min ms | Max ms |
| --- | --- | ---: | ---: | ---: | ---: |
| Rust TreeTN TDVP | chain | 1.375e-5 | 205.519 | 203.475 | 209.107 |
| ITensorNetworks.jl | chain | 1.3750765420845311e-5 | 148.246 | 138.167 | 156.985 |
| Rust TreeTN TDVP | star | 3.999e-4 | 1510.157 | 1507.512 | 1514.993 |
| ITensorNetworks.jl | star | 0.00039988891002920937 | 7988.115 | 7689.838 | 8563.478 |

Julia timing excludes compilation/first-call setup through an untimed warmup. The Julia runner uses `exponentiate_solver` with `ishermitian=true`, `krylovdim=30`, `tol=1e-12`, and `maxiter=100`. Rust uses `max_iter=30`, `tol=1e-12`, and `max_time_splits=100`; the last cap is intentionally documented as not semantically identical to KrylovKit `maxiter`.

Full benchmark notes are in `benchmarks/results/2026-06-27-treetn-tdvp-itensornetworks.md`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps` (passes; existing unrelated rustdoc link warnings remain)
- `cargo test --doc --release --workspace`
- `CARGO_BUILD_JOBS=1 cargo nextest run --release --workspace` => `2440 passed, 14 skipped`
- `RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02`
- `BLAS_NUM_THREADS=1 julia --project=/tmp/t4a-itensornetworks-bench-issue531 benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02`

## Review Notes

Claude max review found three pre-merge issues: missing non-commuting TDVP CI coverage, one-site truncation options accepted silently, and absolute-only Hermitian validation. This PR addresses all three. A final post-fix Claude rerun was attempted with a 15-minute timeout but produced no output before timing out.
