### PR TITLE
[codex] Optimize TreeTN TDVP overhead

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -64,6 +64,9 @@ reports runtime plus L2 error against a small dense exact evolution reference:
 RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02
 ```
 
+Append `all`, `chain`, or `star` to the Rust command to run both topologies or
+only one topology in a fresh process.
+
 Non-AD local tensor operations:
 
 ```bash

--- a/benchmarks/results/2026-06-28-treetn-tdvp-overhead.md
+++ b/benchmarks/results/2026-06-28-treetn-tdvp-overhead.md
@@ -1,0 +1,77 @@
+# TreeTN TDVP Overhead Profile and ITensorNetworks.jl Comparison
+
+Date: 2026-06-28
+
+Purpose: measure the TreeTN TDVP overhead reductions against `origin/main` and
+record the parity comparison with a local ITensorNetworks.jl checkout. The Rust
+algorithm keeps the state as a TreeTN throughout TDVP; dense materialization is
+used only by the small benchmark exact-reference validator.
+
+Both runners evolve an alternating product state under the Pauli Heisenberg
+Hamiltonian `sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j` for total time
+`t = 0.08` using 4 two-site TDVP time steps of `dt = 0.02`. Both use
+`order = 2`, `maxdim = 32`, an ITensors-compatible relative discarded squared
+singular-value tail cutoff of `1e-12`, and Hermitian Krylov exponentials with
+`krylovdim = 30` and `tol = 1e-12`.
+
+## Commands
+
+Rust optimized branch:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 \
+cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02
+```
+
+Rust `origin/main` baseline was measured from a temporary detached worktree:
+
+```bash
+git worktree add --detach /tmp/t4a-origin-main-bench origin/main
+(
+  cd /tmp/t4a-origin-main-bench
+  CARGO_TARGET_DIR=/tmp/t4a-origin-main-target \
+  RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 \
+  cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02
+)
+git worktree remove --force /tmp/t4a-origin-main-bench
+rm -rf /tmp/t4a-origin-main-target
+```
+
+Julia:
+
+```bash
+export T4A_ITENSORNETWORKS_PATH=/home/shinaoka/tensor4all/ITensor/ITensorNetworks.jl
+export T4A_ITN_BENCH_PROJECT=/tmp/t4a-itensornetworks-bench-tdvp-overhead
+julia --project=$T4A_ITN_BENCH_PROJECT -e 'using Pkg; Pkg.develop(path=ENV["T4A_ITENSORNETWORKS_PATH"]); Pkg.add(["Graphs", "ITensors", "TensorOperations", "KrylovKit"]); Pkg.instantiate()'
+BLAS_NUM_THREADS=1 julia --project=$T4A_ITN_BENCH_PROJECT \
+  benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02
+```
+
+The Julia runner performs one untimed warmup per topology and reuses the
+already-built initial state and operator in the timed loop, so reported timings
+exclude Julia compilation, ITensorNetworks.jl first-call setup, KrylovKit
+initialization, operator construction, and dense exact reference construction.
+
+## Results
+
+| Implementation | Topology | N | Time steps | Repeats | Norm | L2 error | Relative L2 error | Mean ms | Min ms | Max ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Rust TreeTN TDVP (`origin/main`) | chain | 8 | 4 | 3 | 0.999999999998 | 1.375e-5 | 1.375e-5 | 213.602 | 209.228 | 219.574 |
+| Rust TreeTN TDVP (optimized) | chain | 8 | 4 | 3 | 0.999999999998 | 1.375e-5 | 1.375e-5 | 194.335 | 192.744 | 195.922 |
+| ITensorNetworks.jl | chain | 8 | 4 | 3 | 0.999999999998 | 1.3750765420845311e-5 | 1.3750765420845311e-5 | 169.096 | 152.953 | 197.118 |
+| Rust TreeTN TDVP (`origin/main`) | star | 8 | 4 | 3 | 1.000000000000 | 3.999e-4 | 3.999e-4 | 1769.085 | 1748.214 | 1780.838 |
+| Rust TreeTN TDVP (optimized) | star | 8 | 4 | 3 | 1.000000000000 | 3.999e-4 | 3.999e-4 | 1521.991 | 1489.183 | 1575.377 |
+| ITensorNetworks.jl | star | 8 | 4 | 3 | 1.0 | 0.00039988891002920937 | 0.0003998889100292092 | 8665.628 | 8366.429 | 8871.538 |
+
+## Notes
+
+- Optimized Rust vs `origin/main`: chain improves from 213.602 ms to
+  194.335 ms, and star improves from 1769.085 ms to 1521.991 ms.
+- Optimized Rust matches the dense-reference L2 errors reported by
+  ITensorNetworks.jl for both chain and star.
+- The optimized Rust benchmark reports `sweeps_completed=4` and
+  `local_updates=104` for both topologies. Maximum Krylov residual estimates
+  were `8.898e-13` for chain and `2.883e-22` for star.
+- The chain case remains a small-problem overhead control where
+  ITensorNetworks.jl is faster in mean time on this run. The non-chain star case
+  is faster in Rust by about 5.7x while matching the dense exact error.

--- a/benchmarks/rust/benchmark_tdvp.rs
+++ b/benchmarks/rust/benchmark_tdvp.rs
@@ -4,7 +4,7 @@
 //   RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_tdvp --release
 //
 // Optional args:
-//   cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- <n_sites> <time_steps> <repeats> <dt>
+//   cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- <n_sites> <time_steps> <repeats> <dt> [all|chain|star]
 
 use std::collections::HashMap;
 use std::hint::black_box;
@@ -44,6 +44,21 @@ impl Topology {
             Self::Chain => "chain",
             Self::Star => "star",
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TopologySelection {
+    All,
+    One(Topology),
+}
+
+fn parse_topology_selection(value: Option<&str>) -> anyhow::Result<TopologySelection> {
+    match value.unwrap_or("all") {
+        "all" => Ok(TopologySelection::All),
+        "chain" => Ok(TopologySelection::One(Topology::Chain)),
+        "star" => Ok(TopologySelection::One(Topology::Star)),
+        other => anyhow::bail!("unknown topology selection {other:?}; use all, chain, or star"),
     }
 }
 
@@ -458,13 +473,21 @@ fn main() -> anyhow::Result<()> {
     let time_steps = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(4);
     let repeats = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(3);
     let dt: f64 = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(0.02);
+    let topology_selection = parse_topology_selection(args.get(5).map(String::as_str))?;
     anyhow::ensure!(n_sites >= 2, "n_sites must be at least 2");
     anyhow::ensure!(time_steps >= 1, "time_steps must be at least 1");
     anyhow::ensure!(repeats >= 1, "repeats must be at least 1");
     anyhow::ensure!(dt.is_finite() && dt > 0.0, "dt must be finite and positive");
 
-    run_case(Topology::Chain, n_sites, time_steps, repeats, dt)?;
-    run_case(Topology::Star, n_sites, time_steps, repeats, dt)?;
+    match topology_selection {
+        TopologySelection::All => {
+            run_case(Topology::Chain, n_sites, time_steps, repeats, dt)?;
+            run_case(Topology::Star, n_sites, time_steps, repeats, dt)?;
+        }
+        TopologySelection::One(topology) => {
+            run_case(topology, n_sites, time_steps, repeats, dt)?;
+        }
+    }
     Ok(())
 }
 
@@ -486,6 +509,23 @@ mod tests {
     fn star_benchmark_uses_itensornetworks_leaf_root() {
         assert_eq!(tdvp_root_name(Topology::Chain), node_name(0));
         assert_eq!(tdvp_root_name(Topology::Star), node_name(1));
+    }
+
+    #[test]
+    fn topology_selection_parses_all_chain_and_star() {
+        assert!(matches!(
+            parse_topology_selection(None).unwrap(),
+            TopologySelection::All
+        ));
+        assert!(matches!(
+            parse_topology_selection(Some("chain")).unwrap(),
+            TopologySelection::One(Topology::Chain)
+        ));
+        assert!(matches!(
+            parse_topology_selection(Some("star")).unwrap(),
+            TopologySelection::One(Topology::Star)
+        ));
+        assert!(parse_topology_selection(Some("line")).is_err());
     }
 
     #[test]

--- a/crates/tensor4all-core/src/krylov.rs
+++ b/crates/tensor4all-core/src/krylov.rs
@@ -377,7 +377,7 @@ pub struct HermitianKrylovExpmOptions {
     pub max_iter: usize,
     /// Maximum number of equal time splits attempted after non-convergence.
     pub max_time_splits: usize,
-    /// Relative convergence tolerance for successive Krylov approximants.
+    /// Relative convergence tolerance for the Krylov residual estimate.
     pub tol: f64,
     /// Breakdown threshold for zero vectors and invariant Krylov subspaces.
     pub breakdown_tol: f64,
@@ -426,7 +426,7 @@ pub struct HermitianKrylovExpmResult<T> {
     pub iterations: usize,
     /// Total matrix-vector products over all accepted substeps.
     pub matvecs: usize,
-    /// Maximum successive-approximation error estimate.
+    /// Maximum Krylov residual estimate over accepted substeps.
     pub error_estimate: f64,
     /// Whether the requested tolerance was met.
     pub converged: bool,
@@ -638,14 +638,14 @@ where
 /// # }
 /// ```
 pub fn hermitian_krylov_expm_multiply<T, F>(
-    apply_a: F,
+    mut apply_a: F,
     exponent: Complex64,
     initial: &T,
     options: &HermitianKrylovExpmOptions,
 ) -> Result<HermitianKrylovExpmResult<T>>
 where
     T: TensorVectorSpace,
-    F: Fn(&T) -> Result<T>,
+    F: FnMut(&T) -> Result<T>,
 {
     validate_hermitian_krylov_expm_options(options)?;
     initial.validate()?;
@@ -682,7 +682,7 @@ where
 
         for _ in 0..splits {
             let result =
-                hermitian_krylov_expm_multiply_once(&apply_a, step_exponent, &output, options)?;
+                hermitian_krylov_expm_multiply_once(&mut apply_a, step_exponent, &output, options)?;
             iterations += result.iterations;
             matvecs += result.matvecs;
             max_error = max_error.max(result.error_estimate);
@@ -721,14 +721,14 @@ where
 }
 
 fn hermitian_krylov_expm_multiply_once<T, F>(
-    apply_a: &F,
+    apply_a: &mut F,
     exponent: Complex64,
     initial: &T,
     options: &HermitianKrylovExpmOptions,
 ) -> Result<HermitianKrylovExpmResult<T>>
 where
     T: TensorVectorSpace,
-    F: Fn(&T) -> Result<T>,
+    F: FnMut(&T) -> Result<T>,
 {
     let initial_norm = initial.norm();
     if initial_norm <= options.breakdown_tol {
@@ -745,8 +745,9 @@ where
     let mut basis = Vec::with_capacity(options.max_iter + 1);
     basis.push(initial.scale(AnyScalar::new_real(1.0 / initial_norm))?);
     let mut h_cols: Vec<Vec<Complex64>> = Vec::with_capacity(options.max_iter);
-    let mut previous: Option<T> = None;
-    let mut last: Option<HermitianKrylovExpmResult<T>> = None;
+    let mut last_coefficients: Option<Vec<Complex64>> = None;
+    let mut last_error_estimate = f64::INFINITY;
+    let mut last_subspace_dim = 0usize;
     let threshold = options.tol * initial_norm.max(1.0);
 
     for j in 0..options.max_iter {
@@ -780,57 +781,77 @@ where
         let coefficients =
             hermitian_exponential_first_column(&projected, exponent, options.hermitian_tol)
                 .map_err(|err| anyhow::anyhow!("projected operator is not Hermitian: {err}"))?;
-        let unit_output = combine_basis_with_complex_coefficients(
-            &basis[..subspace_dim],
-            &coefficients,
-            options.hermitian_tol,
-            "hermitian_krylov_expm_multiply",
-        )?;
-        let output = unit_output.scale(AnyScalar::new_real(initial_norm))?;
-        let mut error_estimate = match &previous {
-            Some(previous) => output
-                .axpby(
-                    AnyScalar::new_real(1.0),
-                    previous,
-                    AnyScalar::new_real(-1.0),
-                )?
-                .norm(),
-            None => f64::INFINITY,
+        let error_estimate = if beta_next <= options.breakdown_tol {
+            0.0
+        } else {
+            initial_norm * beta_next * coefficients[subspace_dim - 1].norm()
         };
         let converged = beta_next <= options.breakdown_tol || error_estimate <= threshold;
-        if converged && beta_next <= options.breakdown_tol && previous.is_none() {
-            error_estimate = 0.0;
-        }
 
         if options.verbose {
             eprintln!(
-                "Hermitian Krylov expm iter {}: error_estimate={:.6e} threshold={:.6e}",
+                "Hermitian Krylov expm iter {}: residual_estimate={:.6e} threshold={:.6e}",
                 subspace_dim, error_estimate, threshold
             );
         }
 
-        let result = HermitianKrylovExpmResult {
-            output: output.clone(),
-            iterations: subspace_dim,
-            matvecs: subspace_dim,
-            error_estimate,
-            converged,
-            time_splits: 1,
-        };
         if converged {
-            return Ok(result);
+            let output = finalize_hermitian_krylov_expm_output(
+                &basis[..subspace_dim],
+                &coefficients,
+                initial_norm,
+                options.hermitian_tol,
+            )?;
+            return Ok(HermitianKrylovExpmResult {
+                output,
+                iterations: subspace_dim,
+                matvecs: subspace_dim,
+                error_estimate,
+                converged: true,
+                time_splits: 1,
+            });
         }
-        if beta_next <= options.breakdown_tol {
-            return Ok(result);
-        }
-        previous = Some(output);
-        last = Some(result);
+        last_coefficients = Some(coefficients);
+        last_error_estimate = error_estimate;
+        last_subspace_dim = subspace_dim;
         basis.push(w_orth.scale(AnyScalar::new_real(1.0 / beta_next))?);
     }
 
-    last.ok_or_else(|| {
+    let coefficients = last_coefficients.ok_or_else(|| {
         anyhow::anyhow!("hermitian_krylov_expm_multiply: max_iter must be greater than zero")
+    })?;
+    let output = finalize_hermitian_krylov_expm_output(
+        &basis[..last_subspace_dim],
+        &coefficients,
+        initial_norm,
+        options.hermitian_tol,
+    )?;
+    Ok(HermitianKrylovExpmResult {
+        output,
+        iterations: last_subspace_dim,
+        matvecs: last_subspace_dim,
+        error_estimate: last_error_estimate,
+        converged: false,
+        time_splits: 1,
     })
+}
+
+fn finalize_hermitian_krylov_expm_output<T>(
+    basis: &[T],
+    coefficients: &[Complex64],
+    initial_norm: f64,
+    hermitian_tol: f64,
+) -> Result<T>
+where
+    T: TensorVectorSpace,
+{
+    let unit_output = combine_basis_with_complex_coefficients(
+        basis,
+        coefficients,
+        hermitian_tol,
+        "hermitian_krylov_expm_multiply",
+    )?;
+    unit_output.scale(AnyScalar::new_real(initial_norm))
 }
 
 /// Solve `A x = b` using GMRES (Generalized Minimal Residual Method).

--- a/crates/tensor4all-treetn/src/dmrg/mod.rs
+++ b/crates/tensor4all-treetn/src/dmrg/mod.rs
@@ -398,11 +398,12 @@ where
         init: &T,
         state: &TreeTN<T, V>,
     ) -> Result<T, DmrgError> {
-        let linop = LocalLinOp::new(
+        let linop = LocalLinOp::with_expected_input_indices(
             Arc::clone(&self.projected_operator),
             region.to_vec(),
             state,
             &self.reference_state,
+            init.external_indices(),
         );
 
         let result = hermitian_lanczos_lowest_eigenpair(
@@ -431,11 +432,12 @@ where
             context: "DMRG failed to contract final Rayleigh region",
             source,
         })?;
-        let linop = LocalLinOp::new(
+        let linop = LocalLinOp::with_expected_input_indices(
             Arc::clone(&self.projected_operator),
             region.to_vec(),
             state,
             &self.reference_state,
+            local.external_indices(),
         );
         let h_local = linop
             .apply_projected(&local)

--- a/crates/tensor4all-treetn/src/linsolve/common/environment.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/environment.rs
@@ -24,6 +24,56 @@ pub trait NetworkTopology<V> {
     fn neighbors(&self, node: &V) -> Self::Neighbors<'_>;
 }
 
+/// Cached neighbor lists for algorithms whose topology is fixed during a sweep.
+#[derive(Debug, Clone)]
+pub(crate) struct CachedTopology<V>
+where
+    V: Clone + Hash + Eq,
+{
+    neighbors: HashMap<V, Vec<V>>,
+    empty: Vec<V>,
+}
+
+impl<V> CachedTopology<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    pub(crate) fn from_site_index_network<I>(network: &SiteIndexNetwork<V, I>) -> Self
+    where
+        I: IndexLike,
+    {
+        let neighbors = network
+            .topology()
+            .node_names()
+            .into_iter()
+            .map(|node| (node.clone(), network.neighbors(node).collect::<Vec<_>>()))
+            .collect();
+        Self {
+            neighbors,
+            empty: Vec::new(),
+        }
+    }
+}
+
+impl<V> NetworkTopology<V> for CachedTopology<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    type Neighbors<'a>
+        = std::iter::Cloned<std::slice::Iter<'a, V>>
+    where
+        Self: 'a,
+        V: 'a;
+
+    fn neighbors(&self, node: &V) -> Self::Neighbors<'_> {
+        self.neighbors
+            .get(node)
+            .unwrap_or(&self.empty)
+            .iter()
+            .cloned()
+    }
+}
+
 /// Simple environment cache for tensor network computations.
 ///
 /// This struct handles:
@@ -37,8 +87,8 @@ where
     T: TensorLike,
     V: Clone + Hash + Eq,
 {
-    /// Cached environment tensors: (from, to) -> tensor
-    envs: HashMap<(V, V), T>,
+    /// Cached environment tensors: from -> to -> tensor.
+    envs: HashMap<V, HashMap<V, T>>,
 }
 
 impl<T, V> EnvironmentCache<T, V>
@@ -55,22 +105,22 @@ where
 
     /// Get a cached environment tensor if it exists.
     pub fn get(&self, from: &V, to: &V) -> Option<&T> {
-        self.envs.get(&(from.clone(), to.clone()))
+        self.envs.get(from).and_then(|from_envs| from_envs.get(to))
     }
 
     /// Insert an environment tensor.
     pub fn insert(&mut self, from: V, to: V, env: T) {
-        self.envs.insert((from, to), env);
+        self.envs.entry(from).or_default().insert(to, env);
     }
 
     /// Check if environment exists for edge (from, to).
     pub fn contains(&self, from: &V, to: &V) -> bool {
-        self.envs.contains_key(&(from.clone(), to.clone()))
+        self.get(from, to).is_some()
     }
 
     /// Get the number of cached environments.
     pub fn len(&self) -> usize {
-        self.envs.len()
+        self.envs.values().map(HashMap::len).sum()
     }
 
     /// Check if the cache is empty.
@@ -109,7 +159,15 @@ where
     /// Recursively invalidate caches starting from env[(from, to)] towards leaves.
     fn invalidate_recursive<NT: NetworkTopology<V>>(&mut self, from: &V, to: &V, topology: &NT) {
         // Remove env[(from, to)] if it exists
-        if self.envs.remove(&(from.clone(), to.clone())).is_some() {
+        let removed = if let Some(from_envs) = self.envs.get_mut(from) {
+            from_envs.remove(to).is_some()
+        } else {
+            false
+        };
+        if self.envs.get(from).is_some_and(HashMap::is_empty) {
+            self.envs.remove(from);
+        }
+        if removed {
             // Propagate to next generation: env[(to, x)] for all neighbors x of to, x ≠ from
             let neighbors: Vec<V> = topology.neighbors(to).filter(|n| n != from).collect();
 

--- a/crates/tensor4all-treetn/src/linsolve/common/environment/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/environment/tests/mod.rs
@@ -1,4 +1,37 @@
+use std::collections::HashSet;
+
+use tensor4all_core::DynIndex;
+
+use super::*;
+
 #[test]
 fn test_environment_cache_creation() {
     // Compile-time test
+}
+
+#[test]
+fn cached_topology_returns_neighbors_without_graph_lookup() {
+    let mut network = SiteIndexNetwork::<String, DynIndex>::new();
+    network
+        .add_node("a".to_string(), HashSet::from([DynIndex::new_dyn(2)]))
+        .unwrap();
+    network
+        .add_node("b".to_string(), HashSet::from([DynIndex::new_dyn(2)]))
+        .unwrap();
+    network
+        .add_node("c".to_string(), HashSet::from([DynIndex::new_dyn(2)]))
+        .unwrap();
+    network
+        .add_edge(&"a".to_string(), &"b".to_string())
+        .unwrap();
+    network
+        .add_edge(&"a".to_string(), &"c".to_string())
+        .unwrap();
+
+    let topology = CachedTopology::from_site_index_network(&network);
+    let mut neighbors = topology.neighbors(&"a".to_string()).collect::<Vec<_>>();
+    neighbors.sort();
+
+    assert_eq!(neighbors, vec!["b".to_string(), "c".to_string()]);
+    assert!(topology.neighbors(&"missing".to_string()).next().is_none());
 }

--- a/crates/tensor4all-treetn/src/linsolve/common/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/mod.rs
@@ -7,6 +7,7 @@ mod environment;
 mod options;
 mod projected_operator;
 
+pub(crate) use environment::CachedTopology;
 pub use environment::{EnvironmentCache, NetworkTopology};
 pub use options::{GmresToleranceMode, LinsolveOptions};
 pub use projected_operator::ProjectedOperator;

--- a/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/projected_operator.rs
@@ -46,16 +46,23 @@ where
     V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
 {
     /// The operator H
-    pub operator: TreeTN<T, V>,
+    operator: TreeTN<T, V>,
     /// Environment cache
-    pub envs: EnvironmentCache<T, V>,
+    envs: EnvironmentCache<T, V>,
     /// Input index mapping (true site index -> MPO's internal input index)
     /// Used when MPO has internal indices different from state's site indices.
-    pub input_mapping: Option<HashMap<V, IndexMapping<T::Index>>>,
+    input_mapping: Option<HashMap<V, IndexMapping<T::Index>>>,
     /// Output index mapping (true site index -> MPO's internal output index)
-    pub output_mapping: Option<HashMap<V, IndexMapping<T::Index>>>,
+    output_mapping: Option<HashMap<V, IndexMapping<T::Index>>>,
+    /// Stable temporary local mappings used to avoid regenerating temp indices
+    /// on every projected operator application.
+    temp_mapping: Option<HashMap<V, LocalIndexMapping<T::Index>>>,
+    /// Operator tensors with internal site indices already replaced by stable
+    /// temporary input/output indices.
+    temp_operator_tensors: HashMap<V, T>,
 }
 
+#[derive(Clone)]
 struct LocalIndexMapping<I> {
     true_in: I,
     internal_in: I,
@@ -63,6 +70,33 @@ struct LocalIndexMapping<I> {
     true_out: I,
     internal_out: I,
     temp_out: I,
+}
+
+fn build_temp_mappings<V, I>(
+    input_mapping: &HashMap<V, IndexMapping<I>>,
+    output_mapping: &HashMap<V, IndexMapping<I>>,
+) -> HashMap<V, LocalIndexMapping<I>>
+where
+    V: Clone + Hash + Eq,
+    I: IndexLike,
+{
+    let mut mappings = HashMap::with_capacity(input_mapping.len().min(output_mapping.len()));
+    for (node, input) in input_mapping {
+        if let Some(output) = output_mapping.get(node) {
+            mappings.insert(
+                node.clone(),
+                LocalIndexMapping {
+                    true_in: input.true_index.clone(),
+                    internal_in: input.internal_index.clone(),
+                    temp_in: input.internal_index.sim(),
+                    true_out: output.true_index.clone(),
+                    internal_out: output.internal_index.clone(),
+                    temp_out: output.internal_index.sim(),
+                },
+            );
+        }
+    }
+    mappings
 }
 
 enum ContractOperand<'a, T> {
@@ -79,6 +113,15 @@ impl<'a, T> ContractOperand<'a, T> {
     }
 }
 
+fn same_index_set<I: IndexLike>(left: &[I], right: &[I]) -> bool {
+    left.len() == right.len()
+        && left.iter().all(|left_idx| {
+            right
+                .iter()
+                .any(|right_idx| left_idx == right_idx && left_idx.dim() == right_idx.dim())
+        })
+}
+
 impl<T, V> ProjectedOperator<T, V>
 where
     T: TensorLike,
@@ -93,6 +136,8 @@ where
             envs: EnvironmentCache::new(),
             input_mapping: None,
             output_mapping: None,
+            temp_mapping: None,
+            temp_operator_tensors: HashMap::new(),
         }
     }
 
@@ -106,12 +151,53 @@ where
         input_mapping: HashMap<V, IndexMapping<T::Index>>,
         output_mapping: HashMap<V, IndexMapping<T::Index>>,
     ) -> Self {
+        let temp_mapping = build_temp_mappings(&input_mapping, &output_mapping);
         Self {
             operator,
             envs: EnvironmentCache::new(),
             input_mapping: Some(input_mapping),
             output_mapping: Some(output_mapping),
+            temp_mapping: Some(temp_mapping),
+            temp_operator_tensors: HashMap::new(),
         }
+    }
+
+    fn ensure_temp_operator_tensor(&mut self, node: &V) -> Result<()> {
+        if self.temp_operator_tensors.contains_key(node) {
+            return Ok(());
+        }
+        let Some(mapping) = self
+            .temp_mapping
+            .as_ref()
+            .and_then(|mappings| mappings.get(node))
+        else {
+            return Ok(());
+        };
+        let node_idx = self
+            .operator
+            .node_index(node)
+            .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in operator", node))?;
+        let tensor = self
+            .operator
+            .tensor(node_idx)
+            .ok_or_else(|| anyhow::anyhow!("Tensor not found in operator"))?;
+        let tensor = tensor
+            .replaceind(&mapping.internal_in, &mapping.temp_in)?
+            .replaceind(&mapping.internal_out, &mapping.temp_out)?;
+        self.temp_operator_tensors.insert(node.clone(), tensor);
+        Ok(())
+    }
+
+    pub(crate) fn operator(&self) -> &TreeTN<T, V> {
+        &self.operator
+    }
+
+    pub(crate) fn input_mapping(&self) -> Option<&HashMap<V, IndexMapping<T::Index>>> {
+        self.input_mapping.as_ref()
+    }
+
+    pub(crate) fn output_mapping(&self) -> Option<&HashMap<V, IndexMapping<T::Index>>> {
+        self.output_mapping.as_ref()
     }
 
     /// Apply the operator to a local tensor: compute `H|v⟩` at the current position.
@@ -142,11 +228,10 @@ where
         bra_state: &TreeTN<T, V>,
         topology: &NT,
     ) -> Result<T> {
-        // Ensure environments are computed
         self.ensure_environments(region, ket_state, bra_state, topology)?;
 
-        let mut all_tensors = Vec::new();
-        let mut temp_out_to_true: Vec<(T::Index, T::Index)> = Vec::new();
+        let mut all_tensors = Vec::with_capacity(1 + region.len() + region.len().saturating_mul(2));
+        let mut temp_out_to_true: Vec<(T::Index, T::Index)> = Vec::with_capacity(region.len());
 
         if let (Some(ref input_mapping), Some(ref output_mapping)) =
             (&self.input_mapping, &self.output_mapping)
@@ -154,20 +239,23 @@ where
             // MPO-with-mappings path: use unique temp indices to avoid duplicate IDs.
             // Replace true_index -> temp_in on v (never use internal_index on v).
             // Use same temp_in/temp_out on op tensors so they contract with v.
-            let mut per_node: Vec<Option<LocalIndexMapping<T::Index>>> = Vec::new();
+            let mut per_node: Vec<Option<LocalIndexMapping<T::Index>>> =
+                Vec::with_capacity(region.len());
             for node in region {
                 match (input_mapping.get(node), output_mapping.get(node)) {
-                    (Some(im), Some(om)) => {
-                        let temp_in = im.internal_index.sim();
-                        let temp_out = om.internal_index.sim();
-                        per_node.push(Some(LocalIndexMapping {
-                            true_in: im.true_index.clone(),
-                            internal_in: im.internal_index.clone(),
-                            temp_in,
-                            true_out: om.true_index.clone(),
-                            internal_out: om.internal_index.clone(),
-                            temp_out,
-                        }));
+                    (Some(_), Some(_)) => {
+                        let mapping = self
+                            .temp_mapping
+                            .as_ref()
+                            .and_then(|mappings| mappings.get(node))
+                            .cloned()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "Missing temporary index mapping for operator node {:?}",
+                                    node
+                                )
+                            })?;
+                        per_node.push(Some(mapping));
                     }
                     (None, None) => {
                         if self
@@ -194,6 +282,12 @@ where
                 }
             }
 
+            for (node, mapping) in region.iter().zip(per_node.iter()) {
+                if mapping.is_some() {
+                    self.ensure_temp_operator_tensor(node)?;
+                }
+            }
+
             if per_node.iter().any(Option::is_some) {
                 let mut transformed_v = v.clone();
                 for mapping in per_node.iter().flatten() {
@@ -205,21 +299,22 @@ where
             }
 
             for (node, mapping) in region.iter().zip(per_node.iter()) {
-                let node_idx = self
-                    .operator
-                    .node_index(node)
-                    .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in operator", node))?;
-                let tensor = self
-                    .operator
-                    .tensor(node_idx)
-                    .ok_or_else(|| anyhow::anyhow!("Tensor not found in operator"))?;
                 if let Some(mapping) = mapping {
-                    let mut t = tensor.clone();
-                    t = t.replaceind(&mapping.internal_in, &mapping.temp_in)?;
-                    t = t.replaceind(&mapping.internal_out, &mapping.temp_out)?;
+                    let t = self
+                        .temp_operator_tensors
+                        .get(node)
+                        .ok_or_else(|| anyhow::anyhow!("missing cached operator tensor"))?;
                     temp_out_to_true.push((mapping.temp_out.clone(), mapping.true_out.clone()));
-                    all_tensors.push(ContractOperand::Owned(t));
+                    all_tensors.push(ContractOperand::Borrowed(t));
                 } else {
+                    let node_idx = self
+                        .operator
+                        .node_index(node)
+                        .ok_or_else(|| anyhow::anyhow!("Node {:?} not found in operator", node))?;
+                    let tensor = self
+                        .operator
+                        .tensor(node_idx)
+                        .ok_or_else(|| anyhow::anyhow!("Tensor not found in operator"))?;
                     all_tensors.push(ContractOperand::Borrowed(tensor));
                 }
             }
@@ -290,11 +385,7 @@ where
         // Align result to v's index order
         let v_inds = v.external_indices();
         let res_inds = contracted.external_indices();
-        let v_index_keys: std::collections::HashSet<_> =
-            v_inds.iter().map(|i| (i.clone(), i.dim())).collect();
-        let res_index_keys: std::collections::HashSet<_> =
-            res_inds.iter().map(|i| (i.clone(), i.dim())).collect();
-        if v_index_keys == res_index_keys && v_inds.len() == res_inds.len() {
+        if same_index_set(&v_inds, &res_inds) {
             contracted = contracted.permuteinds(&v_inds)?;
         }
 
@@ -349,11 +440,7 @@ where
 
         let center_inds = center.external_indices();
         let res_inds = contracted.external_indices();
-        let center_index_keys: std::collections::HashSet<_> =
-            center_inds.iter().map(|i| (i.clone(), i.dim())).collect();
-        let res_index_keys: std::collections::HashSet<_> =
-            res_inds.iter().map(|i| (i.clone(), i.dim())).collect();
-        if center_index_keys == res_index_keys && center_inds.len() == res_inds.len() {
+        if same_index_set(&center_inds, &res_inds) {
             contracted = contracted.permuteinds(&center_inds)?;
         }
 

--- a/crates/tensor4all-treetn/src/linsolve/square/local_linop.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/local_linop.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::{Context, Result};
 use tensor4all_core::{IndexLike, TensorLike};
 
-use crate::linsolve::common::ProjectedOperator;
+use crate::linsolve::common::{NetworkTopology, ProjectedOperator};
 use crate::treetn::TreeTN;
 
 /// LocalLinOp: Wraps the projected operator for local GMRES solving.
@@ -36,6 +36,8 @@ where
     /// Reference state for bra in environment computation
     /// Uses separate bond indices to prevent unintended contractions
     pub reference_state: &'a TreeTN<T, V>,
+    /// Expected local vector-space indices for inputs to this projected operator.
+    expected_input_indices: Vec<T::Index>,
 }
 
 impl<'a, T, V> LocalLinOp<'a, T, V>
@@ -50,99 +52,49 @@ where
     ///
     /// The reference_state should have separate bond indices from state
     /// to prevent unintended bra↔ket contractions in environment computation.
-    pub fn new(
+    pub(crate) fn with_expected_input_indices(
         projected_operator: Arc<RwLock<ProjectedOperator<T, V>>>,
         region: Vec<V>,
         state: &'a TreeTN<T, V>,
         reference_state: &'a TreeTN<T, V>,
+        expected_input_indices: Vec<T::Index>,
     ) -> Self {
         Self {
             projected_operator,
             region,
             state,
             reference_state,
+            expected_input_indices,
         }
-    }
-
-    fn local_input_indices(&self) -> Result<Vec<T::Index>> {
-        let Some((first_node, rest_nodes)) = self.region.split_first() else {
-            return Err(anyhow::anyhow!(
-                "LocalLinOp::apply_projected: region must not be empty"
-            ));
-        };
-        let first_idx = self.state.node_index(first_node).ok_or_else(|| {
-            anyhow::anyhow!(
-                "LocalLinOp::apply_projected: node {:?} not found in state",
-                first_node
-            )
-        })?;
-        let mut local = self
-            .state
-            .tensor(first_idx)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "LocalLinOp::apply_projected: tensor for node {:?} not found in state",
-                    first_node
-                )
-            })?
-            .clone();
-
-        for node in rest_nodes {
-            let node_idx = self.state.node_index(node).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "LocalLinOp::apply_projected: node {:?} not found in state",
-                    node
-                )
-            })?;
-            let tensor = self.state.tensor(node_idx).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "LocalLinOp::apply_projected: tensor for node {:?} not found in state",
-                    node
-                )
-            })?;
-            local = local.contract_pair(tensor)?;
-        }
-
-        Ok(local.external_indices())
     }
 
     fn same_index_set(left: &[T::Index], right: &[T::Index]) -> bool {
-        let left_keys: std::collections::HashSet<_> =
-            left.iter().map(|idx| (idx.clone(), idx.dim())).collect();
-        let right_keys: std::collections::HashSet<_> =
-            right.iter().map(|idx| (idx.clone(), idx.dim())).collect();
-        left.len() == right.len() && left_keys == right_keys
+        left.len() == right.len()
+            && left.iter().all(|left_idx| {
+                right
+                    .iter()
+                    .any(|right_idx| left_idx == right_idx && left_idx.dim() == right_idx.dim())
+            })
     }
 
-    /// Apply the projected local operator: `y = H * x`.
-    pub fn apply_projected(&self, x: &T) -> Result<T> {
+    pub(crate) fn apply_projected_with_operator<NT: NetworkTopology<V>>(
+        &self,
+        x: &T,
+        proj_op: &mut ProjectedOperator<T, V>,
+        topology: &NT,
+    ) -> Result<T> {
         let x_indices = x.external_indices();
-        let expected_input_indices = self.local_input_indices()?;
-        if !Self::same_index_set(&x_indices, &expected_input_indices) {
+        if !Self::same_index_set(&x_indices, &self.expected_input_indices) {
             return Err(anyhow::anyhow!(
                 "LocalLinOp::apply_projected: index structure mismatch between input (x) and the local state vector space:\n  x has {} indices: {:?}\n  expected {} indices: {:?}",
                 x_indices.len(),
                 x_indices.iter().map(|i| format!("{:?}:{}", i.id(), i.dim())).collect::<Vec<_>>(),
-                expected_input_indices.len(),
-                expected_input_indices.iter().map(|i| format!("{:?}:{}", i.id(), i.dim())).collect::<Vec<_>>(),
+                self.expected_input_indices.len(),
+                self.expected_input_indices.iter().map(|i| format!("{:?}:{}", i.id(), i.dim())).collect::<Vec<_>>(),
             ));
         }
 
-        let mut proj_op = self
-            .projected_operator
-            .write()
-            .map_err(|e| {
-                anyhow::anyhow!("Failed to acquire write lock on projected_operator: {}", e)
-            })
-            .context("LocalLinOp::apply: lock poisoned")?;
-
-        let hx = proj_op.apply(
-            x,
-            &self.region,
-            self.state,
-            self.reference_state,
-            self.state.site_index_network(),
-        )?;
+        let hx = proj_op.apply(x, &self.region, self.state, self.reference_state, topology)?;
 
         let hx_indices = hx.external_indices();
         let indices_match = x_indices.len() == hx_indices.len()
@@ -161,6 +113,19 @@ where
         }
 
         Ok(hx)
+    }
+
+    /// Apply the projected local operator: `y = H * x`.
+    pub fn apply_projected(&self, x: &T) -> Result<T> {
+        let mut proj_op = self
+            .projected_operator
+            .write()
+            .map_err(|e| {
+                anyhow::anyhow!("Failed to acquire write lock on projected_operator: {}", e)
+            })
+            .context("LocalLinOp::apply: lock poisoned")?;
+
+        self.apply_projected_with_operator(x, &mut proj_op, self.state.site_index_network())
     }
 }
 

--- a/crates/tensor4all-treetn/src/linsolve/square/local_linop/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/local_linop/tests/mod.rs
@@ -17,6 +17,13 @@ fn unique_dyn_index(used: &mut HashSet<DynId>, dim: usize) -> DynIndex {
     }
 }
 
+fn tensor_indices(state: &TreeTN<TensorDynLen, String>, node: &str) -> Vec<DynIndex> {
+    state
+        .tensor(state.node_index(&node.to_string()).unwrap())
+        .unwrap()
+        .external_indices()
+}
+
 #[test]
 fn test_local_linop_new() {
     use crate::linsolve::common::ProjectedOperator;
@@ -29,11 +36,13 @@ fn test_local_linop_new() {
     let reference_state = state.clone();
     let projected_op = Arc::new(RwLock::new(ProjectedOperator::new(state.clone())));
 
-    let linop = LocalLinOp::new(
+    let expected = tensor_indices(&state, "site0");
+    let linop = LocalLinOp::with_expected_input_indices(
         projected_op,
         vec!["site0".to_string()],
         &state,
         &reference_state,
+        expected,
     );
 
     assert_eq!(linop.region.len(), 1);
@@ -52,11 +61,13 @@ fn test_local_linop_apply_projected_rejects_mismatch() {
     let reference_state = state.clone();
     let projected_op = Arc::new(RwLock::new(ProjectedOperator::new(state.clone())));
 
-    let linop = LocalLinOp::new(
+    let expected = tensor_indices(&state, "site0");
+    let linop = LocalLinOp::with_expected_input_indices(
         projected_op,
         vec!["site0".to_string()],
         &state,
         &reference_state,
+        expected,
     );
 
     let site0 = "site0".to_string();
@@ -81,11 +92,13 @@ fn test_local_linop_apply_index_mismatch() {
     let reference_state = state.clone();
     let projected_op = Arc::new(RwLock::new(ProjectedOperator::new(state.clone())));
 
-    let linop = LocalLinOp::new(
+    let expected = tensor_indices(&state, "site0");
+    let linop = LocalLinOp::with_expected_input_indices(
         projected_op,
         vec!["site0".to_string()],
         &state,
         &reference_state,
+        expected,
     );
 
     let other = DynIndex::new_dyn(2);
@@ -143,11 +156,13 @@ fn test_local_linop_apply_success_mappings() {
     )));
     let reference_state = state.clone();
 
-    let linop = LocalLinOp::new(
+    let expected = tensor_indices(&state, "site0");
+    let linop = LocalLinOp::with_expected_input_indices(
         projected_op,
         vec!["site0".to_string()],
         &state,
         &reference_state,
+        expected,
     );
 
     let site0 = "site0".to_string();

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -236,7 +236,7 @@ where
                 anyhow::anyhow!("Failed to acquire read lock on projected_operator: {}", e)
             })
             .context("verify: lock poisoned")?;
-        let operator = &proj_op.operator;
+        let operator = proj_op.operator();
         let rhs = &self.projected_state.rhs;
 
         // Check node consistency
@@ -425,11 +425,12 @@ where
 
         // Create local linear operator with separate reference_state
         // This prevents unintended bra↔ket link contractions in environment computation
-        let linop = LocalLinOp::new(
+        let linop = LocalLinOp::with_expected_input_indices(
             Arc::clone(&self.projected_operator),
             region.to_vec(),
             state,
             &self.reference_state,
+            init_indices,
         );
 
         // KrylovKit builds Arnoldi from the unshifted local operator H.
@@ -764,10 +765,10 @@ where
             let proj_op = self.projected_operator.read().map_err(|e| {
                 anyhow::anyhow!("validate_mpo_external_indices: lock poisoned: {e}")
             })?;
-            let Some(input) = proj_op.input_mapping.as_ref() else {
+            let Some(input) = proj_op.input_mapping() else {
                 return Ok(());
             };
-            let Some(output) = proj_op.output_mapping.as_ref() else {
+            let Some(output) = proj_op.output_mapping() else {
                 return Ok(());
             };
             (input.clone(), output.clone())

--- a/crates/tensor4all-treetn/src/tdvp/mod.rs
+++ b/crates/tensor4all-treetn/src/tdvp/mod.rs
@@ -7,20 +7,24 @@
 
 mod plan;
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::{Duration, Instant};
 
 use num_complex::Complex64;
-use tensor4all_core::krylov::{hermitian_krylov_expm_multiply, HermitianKrylovExpmOptions};
 use tensor4all_core::{
-    Canonical, FactorizeAlg, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorLike,
+    krylov::{hermitian_krylov_expm_multiply, HermitianKrylovExpmOptions},
+    print_and_reset_contract_profile, print_and_reset_pairwise_contract_profile,
+    reset_contract_profile, reset_pairwise_contract_profile, Canonical, FactorizeAlg,
+    FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorLike,
 };
 use thiserror::Error;
 
 use self::plan::{TdvpRegionKind, TdvpRegionPlan, TdvpRegionStep};
-use crate::linsolve::common::ProjectedOperator;
+use crate::linsolve::common::{CachedTopology, NetworkTopology, ProjectedOperator};
 use crate::linsolve::square::local_linop::LocalLinOp;
 use crate::local_update_support::{
     build_subtree_topology, contract_region, copy_decomposed_to_subtree,
@@ -140,6 +144,108 @@ impl From<SquareSiteMappingError> for TdvpError {
             }
         }
     }
+}
+
+#[derive(Debug, Default, Clone)]
+struct TdvpProfile {
+    total: Duration,
+    initial_mapping: Duration,
+    initial_canonicalize: Duration,
+    plan: Duration,
+    move_center: Duration,
+    reference_init: Duration,
+    reference_move: Duration,
+    two_site_total: Duration,
+    one_site_total: Duration,
+    extract_region: Duration,
+    contract_region: Duration,
+    evolve_local: Duration,
+    projected_apply: Duration,
+    build_topology: Duration,
+    factorize: Duration,
+    copy_decomposed: Duration,
+    subtree_center: Duration,
+    subtree_ortho: Duration,
+    replace_subtree: Duration,
+    state_center: Duration,
+    sync_reference: Duration,
+    invalidate: Duration,
+    steps: usize,
+    two_site_steps: usize,
+    one_site_steps: usize,
+    projected_apply_calls: usize,
+}
+
+thread_local! {
+    static TDVP_PROFILE: RefCell<Option<TdvpProfile>> = const { RefCell::new(None) };
+}
+
+fn tdvp_profile_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("T4A_PROFILE_TDVP").is_some())
+}
+
+fn tdvp_profile_reset() {
+    if tdvp_profile_enabled() {
+        TDVP_PROFILE.with(|profile| *profile.borrow_mut() = Some(TdvpProfile::default()));
+    }
+}
+
+fn with_tdvp_profile(f: impl FnOnce(&mut TdvpProfile)) {
+    if tdvp_profile_enabled() {
+        TDVP_PROFILE.with(|profile| {
+            if let Some(profile) = profile.borrow_mut().as_mut() {
+                f(profile);
+            }
+        });
+    }
+}
+
+fn take_tdvp_profile() -> Option<TdvpProfile> {
+    if !tdvp_profile_enabled() {
+        return None;
+    }
+    TDVP_PROFILE.with(|profile| profile.borrow_mut().take())
+}
+
+fn record_tdvp_profile(elapsed: Option<Instant>, f: impl FnOnce(&mut TdvpProfile, Duration)) {
+    if let Some(started) = elapsed {
+        let elapsed = started.elapsed();
+        with_tdvp_profile(|profile| f(profile, elapsed));
+    }
+}
+
+fn print_tdvp_profile(profile: &TdvpProfile) {
+    eprintln!("=== TreeTN TDVP profile ===");
+    eprintln!("total:              {:?}", profile.total);
+    eprintln!(
+        "steps:              {} two_site={} one_site/site_correction={} projected_apply_calls={}",
+        profile.steps,
+        profile.two_site_steps,
+        profile.one_site_steps,
+        profile.projected_apply_calls
+    );
+    eprintln!("initial mapping:    {:?}", profile.initial_mapping);
+    eprintln!("initial canon:      {:?}", profile.initial_canonicalize);
+    eprintln!("plan:               {:?}", profile.plan);
+    eprintln!("move center:        {:?}", profile.move_center);
+    eprintln!("reference init:     {:?}", profile.reference_init);
+    eprintln!("reference move:     {:?}", profile.reference_move);
+    eprintln!("two-site total:     {:?}", profile.two_site_total);
+    eprintln!("one-site total:     {:?}", profile.one_site_total);
+    eprintln!("extract region:     {:?}", profile.extract_region);
+    eprintln!("contract region:    {:?}", profile.contract_region);
+    eprintln!("evolve local:       {:?}", profile.evolve_local);
+    eprintln!("projected apply:    {:?}", profile.projected_apply);
+    eprintln!("build topology:     {:?}", profile.build_topology);
+    eprintln!("factorize:          {:?}", profile.factorize);
+    eprintln!("copy decomposed:    {:?}", profile.copy_decomposed);
+    eprintln!("subtree center:     {:?}", profile.subtree_center);
+    eprintln!("subtree ortho:      {:?}", profile.subtree_ortho);
+    eprintln!("replace subtree:    {:?}", profile.replace_subtree);
+    eprintln!("state center:       {:?}", profile.state_center);
+    eprintln!("sync reference:     {:?}", profile.sync_reference);
+    eprintln!("invalidate:         {:?}", profile.invalidate);
 }
 
 /// Options for TreeTN TDVP.
@@ -336,7 +442,7 @@ where
     pub sweeps_completed: usize,
     /// Number of projected local exponential updates performed.
     pub local_updates: usize,
-    /// Largest Krylov error estimate reported by local updates.
+    /// Largest Krylov residual estimate reported by local updates.
     pub max_error_estimate: f64,
     /// Largest number of Krylov iterations used by a local update.
     pub max_krylov_iterations: usize,
@@ -348,6 +454,7 @@ where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
     projected_operator: Arc<RwLock<ProjectedOperator<T, V>>>,
+    topology: CachedTopology<V>,
     options: TdvpOptions,
     reference_state: TreeTN<T, V>,
     local_updates: usize,
@@ -366,6 +473,7 @@ where
         operator: TreeTN<T, V>,
         input_mapping: HashMap<V, IndexMapping<T::Index>>,
         output_mapping: HashMap<V, IndexMapping<T::Index>>,
+        topology: CachedTopology<V>,
         options: TdvpOptions,
     ) -> Self {
         Self {
@@ -374,6 +482,7 @@ where
                 input_mapping,
                 output_mapping,
             ))),
+            topology,
             options,
             reference_state: TreeTN::new(),
             local_updates: 0,
@@ -390,20 +499,41 @@ where
         exponent_step: Complex64,
         context: &'static str,
     ) -> Result<T, TdvpError> {
-        let linop = LocalLinOp::new(
+        let linop = LocalLinOp::with_expected_input_indices(
             Arc::clone(&self.projected_operator),
             region.to_vec(),
             state,
             &self.reference_state,
+            init.external_indices(),
         );
 
+        let mut projected_operator =
+            self.projected_operator
+                .write()
+                .map_err(|err| TdvpError::Algorithm {
+                    context: "TDVP failed to lock projected operator",
+                    source: anyhow::anyhow!("{err}"),
+                })?;
+        let evolve_started = tdvp_profile_enabled().then(Instant::now);
         let result = hermitian_krylov_expm_multiply(
-            |x: &T| linop.apply_projected(x),
+            |x: &T| {
+                let apply_started = tdvp_profile_enabled().then(Instant::now);
+                let result =
+                    linop.apply_projected_with_operator(x, &mut projected_operator, &self.topology);
+                record_tdvp_profile(apply_started, |profile, elapsed| {
+                    profile.projected_apply += elapsed;
+                    profile.projected_apply_calls += 1;
+                });
+                result
+            },
             exponent_step,
             init,
             &self.options.krylov,
         )
         .map_err(|source| TdvpError::Algorithm { context, source })?;
+        record_tdvp_profile(evolve_started, |profile, elapsed| {
+            profile.evolve_local += elapsed;
+        });
 
         self.max_error_estimate = self.max_error_estimate.max(result.error_estimate);
         self.max_krylov_iterations = self.max_krylov_iterations.max(result.iterations);
@@ -417,19 +547,37 @@ where
         step: &TdvpRegionStep<V>,
         next_step: Option<&TdvpRegionStep<V>>,
     ) -> Result<(), TdvpError> {
+        with_tdvp_profile(|profile| {
+            profile.steps += 1;
+            match step.kind {
+                TdvpRegionKind::TwoSite => profile.two_site_steps += 1,
+                TdvpRegionKind::OneSite | TdvpRegionKind::SiteCorrection => {
+                    profile.one_site_steps += 1;
+                }
+            }
+        });
+        let reference_init_started = tdvp_profile_enabled().then(Instant::now);
         initialize_reference_state_if_empty(&mut self.reference_state, state).map_err(
             |source| TdvpError::Algorithm {
                 context: "TDVP failed to initialize reference state",
                 source,
             },
         )?;
+        record_tdvp_profile(reference_init_started, |profile, elapsed| {
+            profile.reference_init += elapsed;
+        });
+        let reference_move_started = tdvp_profile_enabled().then(Instant::now);
         move_center_to_region_full_rank(&mut self.reference_state, &step.nodes).map_err(
             |source| TdvpError::Algorithm {
                 context: "TDVP failed to move reference center to local region",
                 source,
             },
         )?;
+        record_tdvp_profile(reference_move_started, |profile, elapsed| {
+            profile.reference_move += elapsed;
+        });
 
+        let update_started = tdvp_profile_enabled().then(Instant::now);
         match step.kind {
             TdvpRegionKind::TwoSite => self.update_two_site(state, step),
             TdvpRegionKind::SiteCorrection => self.update_one_site_tensor(
@@ -445,7 +593,14 @@ where
                 "TDVP one-site Krylov exponential failed",
             ),
         }?;
+        record_tdvp_profile(update_started, |profile, elapsed| match step.kind {
+            TdvpRegionKind::TwoSite => profile.two_site_total += elapsed,
+            TdvpRegionKind::OneSite | TdvpRegionKind::SiteCorrection => {
+                profile.one_site_total += elapsed;
+            }
+        });
 
+        let sync_started = tdvp_profile_enabled().then(Instant::now);
         sync_reference_state_region(
             &mut self.reference_state,
             None,
@@ -459,8 +614,11 @@ where
             context: "TDVP failed to sync reference state",
             source,
         })?;
+        record_tdvp_profile(sync_started, |profile, elapsed| {
+            profile.sync_reference += elapsed;
+        });
 
-        let topology = state.site_index_network();
+        let invalidate_started = tdvp_profile_enabled().then(Instant::now);
         let mut projected_operator =
             self.projected_operator
                 .write()
@@ -468,7 +626,10 @@ where
                     context: "TDVP projected operator lock poisoned",
                     source: anyhow::anyhow!("{err}"),
                 })?;
-        projected_operator.invalidate(&step.nodes, topology);
+        projected_operator.invalidate(&step.nodes, &self.topology);
+        record_tdvp_profile(invalidate_started, |profile, elapsed| {
+            profile.invalidate += elapsed;
+        });
         Ok(())
     }
 
@@ -479,6 +640,7 @@ where
         next_step: Option<&TdvpRegionStep<V>>,
         context: &'static str,
     ) -> Result<(), TdvpError> {
+        let extract_started = tdvp_profile_enabled().then(Instant::now);
         let subtree =
             state
                 .extract_subtree(&step.nodes)
@@ -486,11 +648,18 @@ where
                     context: "TDVP failed to extract one-site region",
                     source,
                 })?;
+        record_tdvp_profile(extract_started, |profile, elapsed| {
+            profile.extract_region += elapsed;
+        });
+        let contract_started = tdvp_profile_enabled().then(Instant::now);
         let init_local =
             contract_region(&subtree, &step.nodes).map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to contract one-site region",
                 source,
             })?;
+        record_tdvp_profile(contract_started, |profile, elapsed| {
+            profile.contract_region += elapsed;
+        });
         let evolved =
             self.evolve_local(&step.nodes, &init_local, state, step.exponent_step, context)?;
         let evolved = if step.kind == TdvpRegionKind::OneSite {
@@ -504,18 +673,26 @@ where
                 .ok_or_else(|| TdvpError::MissingCenter {
                     center: format!("{:?}", step.nodes[0]),
                 })?;
+        let replace_started = tdvp_profile_enabled().then(Instant::now);
         state
             .replace_tensor(node_idx, evolved)
             .map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to replace one-site tensor",
                 source,
             })?;
+        record_tdvp_profile(replace_started, |profile, elapsed| {
+            profile.replace_subtree += elapsed;
+        });
+        let center_started = tdvp_profile_enabled().then(Instant::now);
         state
             .set_canonical_region([step.new_center.clone()])
             .map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to set one-site canonical center",
                 source,
             })?;
+        record_tdvp_profile(center_started, |profile, elapsed| {
+            profile.state_center += elapsed;
+        });
         Ok(())
     }
 
@@ -592,7 +769,7 @@ where
                 source,
             })?;
 
-        for neighbor in state.site_index_network().neighbors(current) {
+        for neighbor in self.topology.neighbors(current) {
             let Some(ket_edge) = state.edge_between(current, &neighbor) else {
                 continue;
             };
@@ -691,19 +868,30 @@ where
         init: &T,
         exponent_step: Complex64,
     ) -> Result<T, TdvpError> {
+        let mut proj_op = self
+            .projected_operator
+            .write()
+            .map_err(|err| TdvpError::Algorithm {
+                context: "TDVP failed to lock projected operator",
+                source: anyhow::anyhow!("{err}"),
+            })?;
+        let evolve_started = tdvp_profile_enabled().then(Instant::now);
         let result = hermitian_krylov_expm_multiply(
             |x: &T| {
-                let mut proj_op = self.projected_operator.write().map_err(|err| {
-                    anyhow::anyhow!("TDVP projected operator lock poisoned: {err}")
-                })?;
-                proj_op.apply_edge_center(
+                let apply_started = tdvp_profile_enabled().then(Instant::now);
+                let result = proj_op.apply_edge_center(
                     x,
                     (left, right),
                     (left_ket_tensor, left_bra_tensor),
                     bra_to_ket_indices,
                     (state, &self.reference_state),
-                    state.site_index_network(),
-                )
+                    &self.topology,
+                );
+                record_tdvp_profile(apply_started, |profile, elapsed| {
+                    profile.projected_apply += elapsed;
+                    profile.projected_apply_calls += 1;
+                });
+                result
             },
             exponent_step,
             init,
@@ -713,6 +901,9 @@ where
             context: "TDVP one-site bond-center Krylov exponential failed",
             source,
         })?;
+        record_tdvp_profile(evolve_started, |profile, elapsed| {
+            profile.evolve_local += elapsed;
+        });
         self.max_error_estimate = self.max_error_estimate.max(result.error_estimate);
         self.max_krylov_iterations = self.max_krylov_iterations.max(result.iterations);
         self.local_updates += 1;
@@ -729,6 +920,7 @@ where
                 requested: step.nodes.len(),
             });
         }
+        let extract_started = tdvp_profile_enabled().then(Instant::now);
         let mut subtree =
             state
                 .extract_subtree(&step.nodes)
@@ -736,11 +928,18 @@ where
                     context: "TDVP failed to extract two-site region",
                     source,
                 })?;
+        record_tdvp_profile(extract_started, |profile, elapsed| {
+            profile.extract_region += elapsed;
+        });
+        let contract_started = tdvp_profile_enabled().then(Instant::now);
         let init_local =
             contract_region(&subtree, &step.nodes).map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to contract two-site region",
                 source,
             })?;
+        record_tdvp_profile(contract_started, |profile, elapsed| {
+            profile.contract_region += elapsed;
+        });
         let evolved = self.evolve_local(
             &step.nodes,
             &init_local,
@@ -749,12 +948,16 @@ where
             "TDVP two-site Krylov exponential failed",
         )?;
 
+        let topology_started = tdvp_profile_enabled().then(Instant::now);
         let topology = build_subtree_topology(&evolved, &step.nodes, state).map_err(|source| {
             TdvpError::Algorithm {
                 context: "TDVP failed to build two-site subtree topology",
                 source,
             }
         })?;
+        record_tdvp_profile(topology_started, |profile, elapsed| {
+            profile.build_topology += elapsed;
+        });
         let mut factorize_options = FactorizeOptions::svd();
         if let Some(max_rank) = self.options.max_bond_dim {
             factorize_options = factorize_options.with_max_rank(max_rank);
@@ -762,6 +965,7 @@ where
         if let Some(policy) = self.options.svd_policy {
             factorize_options = factorize_options.with_svd_policy(policy);
         }
+        let factorize_started = tdvp_profile_enabled().then(Instant::now);
         let decomposed = factorize_tensor_to_treetn_with(
             &evolved,
             &topology,
@@ -772,18 +976,30 @@ where
             context: "TDVP failed to split evolved two-site tensor",
             source,
         })?;
+        record_tdvp_profile(factorize_started, |profile, elapsed| {
+            profile.factorize += elapsed;
+        });
+        let copy_started = tdvp_profile_enabled().then(Instant::now);
         copy_decomposed_to_subtree(&mut subtree, &decomposed, &step.nodes, state).map_err(
             |source| TdvpError::Algorithm {
                 context: "TDVP failed to copy split two-site tensors",
                 source,
             },
         )?;
+        record_tdvp_profile(copy_started, |profile, elapsed| {
+            profile.copy_decomposed += elapsed;
+        });
+        let subtree_center_started = tdvp_profile_enabled().then(Instant::now);
         subtree
             .set_canonical_region([step.new_center.clone()])
             .map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to set two-site subtree center",
                 source,
             })?;
+        record_tdvp_profile(subtree_center_started, |profile, elapsed| {
+            profile.subtree_center += elapsed;
+        });
+        let subtree_ortho_started = tdvp_profile_enabled().then(Instant::now);
         if let Some(edges) = subtree.edges_to_canonicalize_by_names(&step.new_center) {
             for (from, to) in edges {
                 if let Some(edge) = subtree.edge_between(&from, &to) {
@@ -796,18 +1012,29 @@ where
                 }
             }
         }
+        record_tdvp_profile(subtree_ortho_started, |profile, elapsed| {
+            profile.subtree_ortho += elapsed;
+        });
+        let replace_started = tdvp_profile_enabled().then(Instant::now);
         state
             .replace_subtree(&step.nodes, &subtree)
             .map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to replace two-site subtree",
                 source,
             })?;
+        record_tdvp_profile(replace_started, |profile, elapsed| {
+            profile.replace_subtree += elapsed;
+        });
+        let state_center_started = tdvp_profile_enabled().then(Instant::now);
         state
             .set_canonical_region([step.new_center.clone()])
             .map_err(|source| TdvpError::Algorithm {
                 context: "TDVP failed to set two-site canonical center",
                 source,
             })?;
+        record_tdvp_profile(state_center_started, |profile, elapsed| {
+            profile.state_center += elapsed;
+        });
         Ok(())
     }
 }
@@ -883,6 +1110,13 @@ where
     <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + Debug + Send + Sync + 'static,
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
 {
+    let profile_enabled = tdvp_profile_enabled();
+    if profile_enabled {
+        tdvp_profile_reset();
+        reset_contract_profile();
+        reset_pairwise_contract_profile();
+    }
+    let total_started = profile_enabled.then(Instant::now);
     validate_options(&options)?;
     if init.node_index(center).is_none() {
         return Err(TdvpError::MissingCenter {
@@ -893,14 +1127,23 @@ where
         return Err(TdvpError::TopologyMismatch);
     }
 
+    let mapping_started = profile_enabled.then(Instant::now);
     let (input_mapping, output_mapping) =
         single_site_square_mappings(operator, &init).map_err(TdvpError::from)?;
+    record_tdvp_profile(mapping_started, |profile, elapsed| {
+        profile.initial_mapping += elapsed;
+    });
+    let canonicalize_started = profile_enabled.then(Instant::now);
     let mut state = init
         .canonicalize([center.clone()], CanonicalizationOptions::default())
         .map_err(|source| TdvpError::Algorithm {
             context: "TDVP failed to canonicalize initial state",
             source,
         })?;
+    record_tdvp_profile(canonicalize_started, |profile, elapsed| {
+        profile.initial_canonicalize += elapsed;
+    });
+    let plan_started = profile_enabled.then(Instant::now);
     let plan = TdvpRegionPlan::new(
         state.site_index_network().topology(),
         center,
@@ -911,25 +1154,34 @@ where
     .ok_or_else(|| TdvpError::MissingCenter {
         center: format!("{center:?}"),
     })?;
+    record_tdvp_profile(plan_started, |profile, elapsed| {
+        profile.plan += elapsed;
+    });
     if options.nsite == 2 && plan.steps.is_empty() {
         return Err(TdvpError::EmptyTwoSiteSweep);
     }
 
+    let topology = CachedTopology::from_site_index_network(state.site_index_network());
     let mut updater = TdvpUpdater::new(
         operator.mpo().clone(),
         input_mapping,
         output_mapping,
+        topology,
         options.clone(),
     );
     let mut sweeps_completed = 0usize;
     for sweep in 0..options.nsweeps {
         for (step_index, step) in plan.steps.iter().enumerate() {
+            let move_started = profile_enabled.then(Instant::now);
             move_center_to_region_full_rank(&mut state, &step.nodes).map_err(|source| {
                 TdvpError::Algorithm {
                     context: "TDVP failed to move canonical center to local region",
                     source,
                 }
             })?;
+            record_tdvp_profile(move_started, |profile, elapsed| {
+                profile.move_center += elapsed;
+            });
             updater.update_step(&mut state, step, plan.steps.get(step_index + 1))?;
         }
         sweeps_completed = sweep + 1;
@@ -941,6 +1193,14 @@ where
         }
     }
 
+    record_tdvp_profile(total_started, |profile, elapsed| {
+        profile.total += elapsed;
+    });
+    if let Some(profile) = take_tdvp_profile() {
+        print_tdvp_profile(&profile);
+        print_and_reset_contract_profile();
+        print_and_reset_pairwise_contract_profile();
+    }
     Ok(TdvpResult {
         state,
         sweeps_completed,
@@ -1144,4 +1404,53 @@ where
         .ok_or_else(|| anyhow::anyhow!("path neighbor {:?} has no node name", next_idx))?
         .clone();
     Ok(Some(next))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn square_site_mapping_errors_convert_to_tdvp_errors() {
+        let err = TdvpError::from(SquareSiteMappingError::UnsupportedStateSiteCount {
+            node: "site0".to_string(),
+            count: 2,
+        });
+        assert!(matches!(
+            err,
+            TdvpError::UnsupportedStateSiteCount { node, count }
+                if node == "site0" && count == 2
+        ));
+
+        let err = TdvpError::from(SquareSiteMappingError::UnsupportedMultipleSiteMappings {
+            node: "site1".to_string(),
+            role: "input",
+            count: 3,
+        });
+        assert!(matches!(
+            err,
+            TdvpError::UnsupportedMultipleSiteMappings { node, role, count }
+                if node == "site1" && role == "input" && count == 3
+        ));
+
+        let err = TdvpError::from(SquareSiteMappingError::MissingMapping {
+            node: "site2".to_string(),
+            role: "output",
+        });
+        assert!(matches!(
+            err,
+            TdvpError::MissingMapping { node, role }
+                if node == "site2" && role == "output"
+        ));
+
+        let err = TdvpError::from(SquareSiteMappingError::InvalidMapping {
+            node: "site3".to_string(),
+            reason: "dimension mismatch".to_string(),
+        });
+        assert!(matches!(
+            err,
+            TdvpError::InvalidMapping { node, reason }
+                if node == "site3" && reason == "dimension mismatch"
+        ));
+    }
 }

--- a/crates/tensor4all-treetn/tests/linsolve.rs
+++ b/crates/tensor4all-treetn/tests/linsolve.rs
@@ -238,8 +238,7 @@ fn test_projected_operator_creation() {
     let (mps, _, _) = create_simple_mps_chain();
     let projected_op = ProjectedOperator::new(mps);
 
-    // Verify initial state
-    assert!(projected_op.envs.is_empty());
+    assert_eq!(projected_op.local_dimension(&["site0"]), 2);
 }
 
 #[test]
@@ -261,6 +260,76 @@ fn test_projected_operator_local_dimension() {
     let dim = projected_op.local_dimension(&["site0", "site1"]);
     // 2 * 2 = 4
     assert_eq!(dim, 4);
+}
+
+#[test]
+fn test_projected_operator_apply_distinguishes_same_id_prime_level() {
+    struct SingleNode;
+    impl NetworkTopology<&'static str> for SingleNode {
+        type Neighbors<'a>
+            = std::vec::IntoIter<&'static str>
+        where
+            Self: 'a;
+
+        fn neighbors(&self, _node: &&'static str) -> Self::Neighbors<'_> {
+            Vec::new().into_iter()
+        }
+    }
+
+    let site = DynIndex::new_dyn(2);
+    let site_prime = site.prime();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    state
+        .add_tensor(
+            "site0",
+            TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap(),
+        )
+        .unwrap();
+
+    let op_in = DynIndex::new_dyn(2);
+    let op_out = DynIndex::new_dyn(2);
+    let mut operator = TreeTN::<TensorDynLen, &'static str>::new();
+    operator
+        .add_tensor(
+            "site0",
+            TensorDynLen::from_dense(
+                vec![op_out.clone(), op_in.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+    let mut projected_op = ProjectedOperator::with_index_mappings(
+        operator,
+        HashMap::from([(
+            "site0",
+            IndexMapping {
+                true_index: site.clone(),
+                internal_index: op_in,
+            },
+        )]),
+        HashMap::from([(
+            "site0",
+            IndexMapping {
+                true_index: site.clone(),
+                internal_index: op_out,
+            },
+        )]),
+    );
+
+    for data in [vec![1.0, 2.0, 3.0, 4.0], vec![4.0, 3.0, 2.0, 1.0]] {
+        let input = TensorDynLen::from_dense(vec![site.clone(), site_prime.clone()], data).unwrap();
+        let output = projected_op
+            .apply(&input, &["site0"], &state, &state, &SingleNode)
+            .unwrap();
+
+        assert_eq!(
+            output.external_indices(),
+            vec![site.clone(), site_prime.clone()]
+        );
+        assert!(output.sub(&input).unwrap().maxabs() < 1e-12);
+    }
 }
 
 // ============================================================================

--- a/crates/tensor4all-treetn/tests/tdvp_profile.rs
+++ b/crates/tensor4all-treetn/tests/tdvp_profile.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen, TensorIndex};
+use tensor4all_treetn::{tdvp, IndexMapping, LinearOperator, TdvpOptions, TreeTN};
+
+#[test]
+fn profiling_env_preserves_single_site_identity_evolution() {
+    std::env::set_var("T4A_PROFILE_TDVP", "1");
+
+    let site = DynIndex::new_dyn(2);
+    let state_tensor = TensorDynLen::from_dense(
+        vec![site.clone()],
+        vec![Complex64::new(0.75, 0.5), Complex64::new(-1.25, 0.25)],
+    )
+    .unwrap();
+    let state =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
+            .unwrap();
+    let before = state.contract_to_tensor().unwrap();
+
+    let input = DynIndex::new_dyn(2);
+    let output = DynIndex::new_dyn(2);
+    let op_tensor = TensorDynLen::from_dense(
+        vec![output.clone(), input.clone()],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(1.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let mpo =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![op_tensor], vec!["site0"]).unwrap();
+    let operator = LinearOperator::new(
+        mpo,
+        HashMap::from([(
+            "site0",
+            IndexMapping {
+                true_index: site.clone(),
+                internal_index: input,
+            },
+        )]),
+        HashMap::from([(
+            "site0",
+            IndexMapping {
+                true_index: site,
+                internal_index: output,
+            },
+        )]),
+    );
+
+    let exponent = Complex64::new(0.0, -0.125);
+    let result = tdvp(
+        &operator,
+        state,
+        &"site0",
+        TdvpOptions::default()
+            .with_nsite(1)
+            .with_order(1)
+            .with_exponent_step(exponent),
+    )
+    .unwrap();
+
+    assert_eq!(result.sweeps_completed, 1);
+    assert_eq!(result.local_updates, 1);
+
+    let after = result
+        .state
+        .contract_to_tensor()
+        .unwrap()
+        .permuteinds(&before.external_indices())
+        .unwrap();
+    let before_data = before.to_vec::<Complex64>().unwrap();
+    let after_data = after.to_vec::<Complex64>().unwrap();
+    let phase = exponent.exp();
+    let max_error = before_data
+        .iter()
+        .zip(after_data)
+        .map(|(before_value, after_value)| (after_value - phase * *before_value).norm())
+        .fold(0.0, f64::max);
+    assert!(
+        max_error < 1.0e-10,
+        "profiling changed TDVP identity evolution: max_error={max_error:.3e}"
+    );
+}


### PR DESCRIPTION
## Summary
- reduce TreeTN TDVP overhead by reusing projected-operator state across local Krylov applications, avoiding repeated local-region index discovery, caching fixed topology, and delaying Hermitian Krylov output tensor assembly until convergence/finalization
- keep TDVP on TreeTN representation; no production full-TN materialization; local contractions still use n-ary `T::contract`
- add TDVP profiling hooks, chain/star benchmark selection, same-id/different-prime ProjectedOperator regression coverage, and saved Rust/ITensorNetworks.jl benchmark numbers

## Benchmarks
Commands and full output are recorded in `benchmarks/results/2026-06-28-treetn-tdvp-overhead.md`.

| Implementation | Topology | Mean ms | L2 error |
| --- | --- | ---: | ---: |
| Rust `origin/main` | chain | 213.602 | 1.375e-5 |
| Rust optimized | chain | 194.335 | 1.375e-5 |
| ITensorNetworks.jl | chain | 169.096 | 1.3750765420845311e-5 |
| Rust `origin/main` | star | 1769.085 | 3.999e-4 |
| Rust optimized | star | 1521.991 | 3.999e-4 |
| ITensorNetworks.jl | star | 8665.628 | 0.00039988891002920937 |

Julia timings exclude compilation through the script's warmup run.

## Validation
- `cargo fmt --all && cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p tensor4all-core --release`
- `cargo test -p tensor4all-treetn --release`
- `cargo nextest run --release --workspace`
- `cargo doc --workspace --no-deps` (passes; existing rustdoc warnings remain in unrelated docs)
- `RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02`
- `BLAS_NUM_THREADS=1 julia --project=/tmp/t4a-itensornetworks-bench-tdvp-overhead benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02`