### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["tensor4all collaboration"]
 license = "MIT"

--- a/docs/tutorial-code/Cargo.toml
+++ b/docs/tutorial-code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensor4all-tutorial-code"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- bump workspace crate version from 0.1.0 to 0.2.0
- bump the internal tutorial-code package version to 0.2.0

## Release scope
This is the next 0.x development release after v0.1.0. The release includes the accumulated main-branch work since v0.1.0, including ACI, tenferro migration work, C API expansion, TreeTN linsolve/DMRG/TDVP, tutorial updates, benchmarks, and documentation improvements.

The crates are still not published to crates.io; use git/path dependencies as documented.

## Local validation
- cargo metadata --no-deps --format-version 1
- cargo fmt --all -- --check