### PR TITLE
[codex] Add TreeTN GSE-TDVP v1

### DIFF
--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -41,6 +41,43 @@ struct PairwiseContractProfileEntry {
     total_bytes: usize,
 }
 
+/// Hermitian eigendecomposition of a rank-2 [`TensorDynLen`].
+///
+/// Eigenvectors are returned as a rank-2 tensor whose first index is the input
+/// matrix row index and whose second index labels eigenvector columns. The
+/// eigenvalues are detached primal values intended for nonsmooth selection
+/// logic such as truncation cutoffs.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+///
+/// let row = DynIndex::new_dyn(2);
+/// let col = DynIndex::new_dyn(2);
+/// let matrix = TensorDynLen::from_dense(
+///     vec![row.clone(), col],
+///     vec![1.0_f64, 0.0, 0.0, 2.0],
+/// ).unwrap();
+///
+/// let decomp = matrix.hermitian_eigendecomposition(1.0e-12).unwrap();
+///
+/// assert_eq!(decomp.eigenvalues, vec![1.0, 2.0]);
+/// assert_eq!(
+///     decomp.eigenvectors.indices(),
+///     &[row, decomp.eigenvector_index.clone()]
+/// );
+/// ```
+#[derive(Debug, Clone)]
+pub struct TensorHermitianEigendecomposition {
+    /// Real eigenvalues in backend Hermitian eigensolver order.
+    pub eigenvalues: Vec<f64>,
+    /// Eigenvector matrix with one eigenvector in each column.
+    pub eigenvectors: TensorDynLen,
+    /// Index labeling the eigenvector columns.
+    pub eigenvector_index: DynIndex,
+}
+
 thread_local! {
     static PAIRWISE_CONTRACT_PROFILE_STATE: RefCell<HashMap<&'static str, PairwiseContractProfileEntry>> =
         RefCell::new(HashMap::new());
@@ -1812,6 +1849,116 @@ impl TensorDynLen {
     pub(crate) fn from_inner(indices: Vec<DynIndex>, inner: EagerTensor) -> Result<Self> {
         let axis_classes = Self::dense_axis_classes(indices.len());
         Self::from_inner_with_axis_classes(indices, inner, axis_classes)
+    }
+
+    /// Compute the Hermitian eigendecomposition of a rank-2 tensor.
+    ///
+    /// The tensor must have two square matrix axes. The returned eigenvectors
+    /// stay in [`TensorDynLen`] form so downstream tensor algebra can preserve
+    /// AD metadata where the backend supports it. Eigenvalues are returned as
+    /// detached real primal values because truncation and rank selection are
+    /// nonsmooth control-flow decisions.
+    ///
+    /// `hermitian_tol` controls the allowed imaginary part of complex
+    /// eigenvalues after the backend solve; use a small non-negative value such
+    /// as `1e-12` for numerically Hermitian inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the tensor is not a non-empty square matrix, if the
+    /// backend eigensolver fails, or if complex eigenvalues have imaginary
+    /// parts larger than `hermitian_tol * max(|lambda|, 1)`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, TensorDynLen};
+    ///
+    /// let row = DynIndex::new_dyn(2);
+    /// let col = DynIndex::new_dyn(2);
+    /// let matrix = TensorDynLen::from_dense(
+    ///     vec![row.clone(), col.clone()],
+    ///     vec![3.0_f64, 0.0, 0.0, 5.0],
+    /// ).unwrap();
+    ///
+    /// let decomp = matrix.hermitian_eigendecomposition(1.0e-12).unwrap();
+    /// let eigenvector = decomp
+    ///     .eigenvectors
+    ///     .select_indices(&[decomp.eigenvector_index.clone()], &[0])
+    ///     .unwrap();
+    /// let eigenvector_as_col = eigenvector.replaceind(&row, &col).unwrap();
+    /// let applied = TensorDynLen::contract(&[&matrix, &eigenvector_as_col]).unwrap();
+    /// let expected = eigenvector.scale(AnyScalar::new_real(decomp.eigenvalues[0])).unwrap();
+    ///
+    /// assert!(applied.isapprox(&expected, 1.0e-12, 0.0));
+    /// ```
+    pub fn hermitian_eigendecomposition(
+        &self,
+        hermitian_tol: f64,
+    ) -> Result<TensorHermitianEigendecomposition> {
+        anyhow::ensure!(
+            self.indices.len() == 2,
+            "TensorDynLen::hermitian_eigendecomposition requires a rank-2 tensor, got rank {}",
+            self.indices.len()
+        );
+        let dims = self.dims();
+        anyhow::ensure!(
+            dims[0] == dims[1],
+            "TensorDynLen::hermitian_eigendecomposition requires a square matrix, got {}x{}",
+            dims[0],
+            dims[1]
+        );
+        anyhow::ensure!(
+            dims[0] > 0,
+            "TensorDynLen::hermitian_eigendecomposition requires a non-empty matrix"
+        );
+        anyhow::ensure!(
+            hermitian_tol.is_finite() && hermitian_tol >= 0.0,
+            "TensorDynLen::hermitian_eigendecomposition requires a finite non-negative tolerance"
+        );
+
+        let input = self.try_materialized_inner()?;
+        let (values, vectors) = tenferro_linalg::eager_tensor::eigh(input)
+            .map_err(|source| anyhow::anyhow!("Hermitian eigendecomposition failed: {source}"))?;
+
+        let eigenvalue_index = DynIndex::new_dyn(dims[0]);
+        let eigenvector_index = DynIndex::new_dyn(dims[0]);
+        let eigenvalue_tensor = Self::from_inner(vec![eigenvalue_index], values)?;
+        let eigenvalues = Self::read_real_eigenvalues(&eigenvalue_tensor, hermitian_tol)
+            .with_context(|| {
+                "TensorDynLen::hermitian_eigendecomposition failed to read eigenvalues"
+            })?;
+        let eigenvectors = Self::from_inner(
+            vec![self.indices[0].clone(), eigenvector_index.clone()],
+            vectors,
+        )?;
+
+        Ok(TensorHermitianEigendecomposition {
+            eigenvalues,
+            eigenvectors,
+            eigenvector_index,
+        })
+    }
+
+    fn read_real_eigenvalues(values: &Self, hermitian_tol: f64) -> Result<Vec<f64>> {
+        if values.is_complex() {
+            values
+                .to_vec::<Complex64>()?
+                .into_iter()
+                .enumerate()
+                .map(|(index, value)| {
+                    let imaginary = value.im.abs();
+                    let allowed = hermitian_tol * value.norm().max(1.0);
+                    anyhow::ensure!(
+                        imaginary <= allowed,
+                        "Hermitian eigenvalue {index} has imaginary part {imaginary}, exceeding tolerance {allowed}"
+                    );
+                    Ok(value.re)
+                })
+                .collect()
+        } else {
+            values.to_vec::<f64>()
+        }
     }
 
     pub(crate) fn from_diag_inner(
@@ -3958,27 +4105,23 @@ impl TensorDynLen {
             }
         }
 
-        let old_data = self.to_vec_any()?;
-        let mut new_data = vec![AnyScalar::new_real(0.0); old_data.len()];
-        for (old_linear, value) in old_data.into_iter().enumerate() {
-            let old_multi = decode_col_major_linear(old_linear, &old_dims)?;
-            let fused_multi: Vec<usize> = old_axes.iter().map(|&axis| old_multi[axis]).collect();
-            let fused_linear = encode_linear_with_order(&fused_multi, &fused_dims, order)?;
+        self.ensure_shape_packing_preserves_ad("fuse_indices")?;
 
-            let mut new_multi = Vec::with_capacity(new_dims.len());
-            for (axis, old_coord) in old_multi.iter().copied().enumerate() {
-                if axis == insertion_axis {
-                    new_multi.push(fused_linear);
-                }
-                if !old_axis_set.contains(&axis) {
-                    new_multi.push(old_coord);
-                }
-            }
-            let new_linear = encode_col_major_linear(&new_multi, &new_dims)?;
-            new_data[new_linear] = value;
+        let mut grouped_axes = old_axes.clone();
+        if matches!(order, LinearizationOrder::RowMajor) {
+            grouped_axes.reverse();
         }
+        let mut perm = Vec::with_capacity(self.indices.len());
+        perm.extend((0..insertion_axis).filter(|axis| !old_axis_set.contains(axis)));
+        perm.extend(grouped_axes);
+        perm.extend(
+            ((insertion_axis + 1)..self.indices.len()).filter(|axis| !old_axis_set.contains(axis)),
+        );
+        debug_assert_eq!(perm.len(), self.indices.len());
 
-        Self::from_dense_any(result_indices, new_data)
+        let packed = self.permute(&perm)?;
+        let reshaped = packed.try_materialized_inner()?.reshape(&new_dims)?;
+        Self::from_inner(result_indices, reshaped)
     }
 
     /// Replace one fused index with multiple indices using an exact reshape.
@@ -4039,20 +4182,32 @@ impl TensorDynLen {
         new_dims.extend_from_slice(&replacement_dims);
         new_dims.extend_from_slice(&old_dims[axis + 1..]);
 
-        let old_data = self.to_vec_any()?;
-        let mut new_data = vec![AnyScalar::new_real(0.0); old_data.len()];
-        for (old_linear, value) in old_data.into_iter().enumerate() {
-            let old_multi = decode_col_major_linear(old_linear, &old_dims)?;
-            let split_multi = decode_linear_with_order(old_multi[axis], &replacement_dims, order)?;
-            let mut new_multi = Vec::with_capacity(new_dims.len());
-            new_multi.extend_from_slice(&old_multi[..axis]);
-            new_multi.extend_from_slice(&split_multi);
-            new_multi.extend_from_slice(&old_multi[axis + 1..]);
-            let new_linear = encode_col_major_linear(&new_multi, &new_dims)?;
-            new_data[new_linear] = value;
-        }
+        self.ensure_shape_packing_preserves_ad("unfuse_index")?;
 
-        Self::from_dense_any(result_indices, new_data)
+        let mut grouped_indices = new_indices.to_vec();
+        let mut grouped_dims = replacement_dims.clone();
+        if matches!(order, LinearizationOrder::RowMajor) {
+            grouped_indices.reverse();
+            grouped_dims.reverse();
+        }
+        let mut packed_indices =
+            Vec::with_capacity(self.indices.len() - 1usize + grouped_indices.len());
+        packed_indices.extend_from_slice(&self.indices[..axis]);
+        packed_indices.extend(grouped_indices);
+        packed_indices.extend_from_slice(&self.indices[axis + 1..]);
+
+        let mut packed_dims = Vec::with_capacity(old_dims.len() - 1usize + grouped_dims.len());
+        packed_dims.extend_from_slice(&old_dims[..axis]);
+        packed_dims.extend_from_slice(&grouped_dims);
+        packed_dims.extend_from_slice(&old_dims[axis + 1..]);
+
+        let reshaped = self.try_materialized_inner()?.reshape(&packed_dims)?;
+        let packed = Self::from_inner(packed_indices, reshaped)?;
+        if matches!(order, LinearizationOrder::ColumnMajor) {
+            Ok(packed)
+        } else {
+            packed.permute_indices(&result_indices)
+        }
     }
 
     /// Create a scalar (0-dimensional) tensor from a supported element value.
@@ -4160,19 +4315,6 @@ impl TensorDynLen {
         );
         let data = self.to_vec::<T>()?;
         Ok((self.indices, data))
-    }
-
-    fn to_vec_any(&self) -> Result<Vec<AnyScalar>> {
-        if self.is_complex() {
-            self.to_vec::<Complex64>().map(|data| {
-                data.into_iter()
-                    .map(|value| AnyScalar::new_complex(value.re, value.im))
-                    .collect()
-            })
-        } else {
-            self.to_vec::<f64>()
-                .map(|data| data.into_iter().map(AnyScalar::new_real).collect())
-        }
     }
 
     /// Extract tensor data as a column-major `Vec<f64>`.
@@ -4306,69 +4448,4 @@ fn encode_col_major_linear(indices: &[usize], dims: &[usize]) -> Result<usize> {
             .ok_or_else(|| anyhow::anyhow!("stride overflow"))?;
     }
     Ok(linear)
-}
-
-fn decode_linear_with_order(
-    linear: usize,
-    dims: &[usize],
-    order: LinearizationOrder,
-) -> Result<Vec<usize>> {
-    let total = checked_product(dims)?;
-    anyhow::ensure!(
-        linear < total,
-        "linear offset {} out of bounds for dims {:?}",
-        linear,
-        dims
-    );
-
-    let mut remaining = linear;
-    let mut out = vec![0usize; dims.len()];
-    match order {
-        LinearizationOrder::ColumnMajor => {
-            for (slot, &dim) in out.iter_mut().zip(dims.iter()) {
-                *slot = remaining % dim;
-                remaining /= dim;
-            }
-        }
-        LinearizationOrder::RowMajor => {
-            for (slot, &dim) in out.iter_mut().rev().zip(dims.iter().rev()) {
-                *slot = remaining % dim;
-                remaining /= dim;
-            }
-        }
-    }
-    Ok(out)
-}
-
-fn encode_linear_with_order(
-    indices: &[usize],
-    dims: &[usize],
-    order: LinearizationOrder,
-) -> Result<usize> {
-    match order {
-        LinearizationOrder::ColumnMajor => encode_col_major_linear(indices, dims),
-        LinearizationOrder::RowMajor => {
-            anyhow::ensure!(
-                indices.len() == dims.len(),
-                "index rank {} does not match dims {:?}",
-                indices.len(),
-                dims
-            );
-            let mut linear = 0usize;
-            let mut stride = 1usize;
-            for (&index, &dim) in indices.iter().rev().zip(dims.iter().rev()) {
-                anyhow::ensure!(
-                    index < dim,
-                    "index {} out of bounds for dimension {}",
-                    index,
-                    dim
-                );
-                linear += index * stride;
-                stride = stride
-                    .checked_mul(dim)
-                    .ok_or_else(|| anyhow::anyhow!("stride overflow"))?;
-            }
-            Ok(linear)
-        }
-    }
 }

--- a/crates/tensor4all-core/tests/linalg_eigh.rs
+++ b/crates/tensor4all-core/tests/linalg_eigh.rs
@@ -1,0 +1,58 @@
+use num_complex::Complex64;
+use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, TensorDynLen};
+
+#[test]
+fn hermitian_eigendecomposition_solves_complex_residuals() {
+    let row = DynIndex::new_dyn(2);
+    let col = DynIndex::new_dyn(2);
+    let matrix = TensorDynLen::from_dense(
+        vec![row.clone(), col.clone()],
+        vec![
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, -1.0),
+            Complex64::new(0.0, 1.0),
+            Complex64::new(2.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let decomp = matrix.hermitian_eigendecomposition(1.0e-12).unwrap();
+
+    assert_eq!(decomp.eigenvalues.len(), 2);
+    assert!((decomp.eigenvalues[0] - 1.0).abs() < 1.0e-12);
+    assert!((decomp.eigenvalues[1] - 3.0).abs() < 1.0e-12);
+    assert_eq!(
+        decomp.eigenvectors.indices(),
+        &[row.clone(), decomp.eigenvector_index.clone()]
+    );
+
+    for (position, &lambda) in decomp.eigenvalues.iter().enumerate() {
+        let vector = decomp
+            .eigenvectors
+            .select_indices(std::slice::from_ref(&decomp.eigenvector_index), &[position])
+            .unwrap();
+        let vector_as_col = vector.replaceind(&row, &col).unwrap();
+        let applied = TensorDynLen::contract(&[&matrix, &vector_as_col]).unwrap();
+        let expected = vector.scale(AnyScalar::new_real(lambda)).unwrap();
+
+        assert!(
+            applied.isapprox(&expected, 1.0e-10, 0.0),
+            "eigenpair {position} residual maxabs={}",
+            applied.sub(&expected).unwrap().maxabs()
+        );
+    }
+}
+
+#[test]
+fn hermitian_eigendecomposition_keeps_eigenvectors_tracked() {
+    let row = DynIndex::new_dyn(2);
+    let col = DynIndex::new_dyn(2);
+    let matrix = TensorDynLen::from_dense(vec![row, col], vec![2.0_f64, 0.25, 0.25, 3.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+
+    let decomp = matrix.hermitian_eigendecomposition(1.0e-12).unwrap();
+
+    assert!(decomp.eigenvectors.tracks_grad());
+}

--- a/crates/tensor4all-core/tests/tensor_unfuse.rs
+++ b/crates/tensor4all-core/tests/tensor_unfuse.rs
@@ -84,6 +84,43 @@ fn fuse_indices_column_major_roundtrips_unfuse_index() {
 }
 
 #[test]
+fn fuse_indices_backward_preserves_source_gradient() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+    let k = DynIndex::new_dyn(2);
+    let fused = DynIndex::new_link(6).unwrap();
+    let tensor = TensorDynLen::from_dense(
+        vec![i.clone(), j.clone(), k.clone()],
+        (0..12).map(|x| x as f64).collect(),
+    )
+    .unwrap()
+    .enable_grad()
+    .unwrap();
+
+    let fused_tensor = tensor
+        .fuse_indices(
+            &[i.clone(), j.clone()],
+            fused.clone(),
+            LinearizationOrder::ColumnMajor,
+        )
+        .unwrap();
+    assert!(fused_tensor.tracks_grad());
+
+    let weights = TensorDynLen::from_dense(
+        vec![fused.clone(), k.clone()],
+        (1..=12).map(|x| x as f64).collect(),
+    )
+    .unwrap();
+    let loss = fused_tensor.inner_product(&weights).unwrap();
+    loss.backward().unwrap();
+
+    let grad = tensor.grad().unwrap().unwrap();
+    let expected =
+        TensorDynLen::from_dense(vec![i, j, k], (1..=12).map(|x| x as f64).collect()).unwrap();
+    assert!(grad.isapprox(&expected, 1e-12, 0.0));
+}
+
+#[test]
 fn fuse_indices_trait_dispatch_on_tensordynlen_uses_old_index_order() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
@@ -109,6 +146,41 @@ fn fuse_indices_trait_dispatch_on_tensordynlen_uses_old_index_order() {
         .permuteinds(tensor.indices())
         .unwrap();
     assert!(roundtrip.isapprox(&tensor, 1e-12, 0.0));
+}
+
+#[test]
+fn unfuse_index_backward_preserves_source_gradient() {
+    let fused = DynIndex::new_link(6).unwrap();
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+    let k = DynIndex::new_dyn(2);
+    let tensor = TensorDynLen::from_dense(
+        vec![fused.clone(), k.clone()],
+        (0..12).map(|x| x as f64).collect(),
+    )
+    .unwrap()
+    .enable_grad()
+    .unwrap();
+
+    let unfused = tensor
+        .unfuse_index(
+            &fused,
+            &[i.clone(), j.clone()],
+            LinearizationOrder::ColumnMajor,
+        )
+        .unwrap();
+    assert!(unfused.tracks_grad());
+
+    let weights =
+        TensorDynLen::from_dense(vec![i, j, k.clone()], (1..=12).map(|x| x as f64).collect())
+            .unwrap();
+    let loss = unfused.inner_product(&weights).unwrap();
+    loss.backward().unwrap();
+
+    let grad = tensor.grad().unwrap().unwrap();
+    let expected =
+        TensorDynLen::from_dense(vec![fused, k], (1..=12).map(|x| x as f64).collect()).unwrap();
+    assert!(grad.isapprox(&expected, 1e-12, 0.0));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -21,6 +21,7 @@ tenferro-provider-inject = [
 [dependencies]
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
 tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 petgraph.workspace = true
 anyhow.workspace = true
 num-complex.workspace = true

--- a/crates/tensor4all-treetn/src/gse.rs
+++ b/crates/tensor4all-treetn/src/gse.rs
@@ -6,24 +6,21 @@
 //! states with exactly one state site index per node and mapped TreeTN
 //! operators with one input and one output index per node.
 //!
-//! The v1 path performs local host-side linear algebra on primal dense values
-//! extracted from each local tensor. It does not preserve autodiff tracking.
-//! During expansion, old bonds are reconstructed from full-rank local SVDs; this
+//! During expansion, old bonds are reconstructed from full-rank local SVDs. This
 //! preserves the represented state, but can remove exactly redundant bond
-//! directions while adding missing reference directions.
+//! directions while adding missing reference directions. Local projected-density
+//! contractions and basis reconstruction stay in `TensorDynLen` form; only the
+//! eigenvalue cutoff itself reads detached primal eigenvalues for rank
+//! selection.
 
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use anyhow::Result;
-use num_complex::Complex64;
 use tensor4all_core::{
-    AnyScalar, Canonical, DynIndex, FactorizeAlg, IndexLike, SvdTruncationPolicy,
-    TensorContractionLike, TensorDynLen, TensorFactorizationLike, TensorIndex,
-};
-use tensor4all_tensorbackend::{
-    hermitian_eigendecomposition, HermitianEigenScalar, Matrix, TensorElement,
+    contract_pair_with_operand_options, AnyScalar, Canonical, DynIndex, FactorizeAlg, IndexLike,
+    LinearizationOrder, PairwiseContractionOptions, SvdTruncationPolicy, TensorContractionLike,
+    TensorDynLen, TensorFactorizationLike, TensorIndex,
 };
 use thiserror::Error;
 
@@ -276,61 +273,6 @@ impl From<SquareSiteMappingError> for GseError {
     }
 }
 
-trait GseScalar:
-    TensorElement
-    + HermitianEigenScalar
-    + Copy
-    + Default
-    + Add<Output = Self>
-    + AddAssign
-    + Sub<Output = Self>
-    + Mul<Output = Self>
-    + Div<f64, Output = Self>
-    + Debug
-    + 'static
-{
-    fn zero() -> Self;
-    fn one() -> Self;
-    fn conj(self) -> Self;
-    fn real(self) -> f64;
-}
-
-impl GseScalar for f64 {
-    fn zero() -> Self {
-        0.0
-    }
-
-    fn one() -> Self {
-        1.0
-    }
-
-    fn conj(self) -> Self {
-        self
-    }
-
-    fn real(self) -> f64 {
-        self
-    }
-}
-
-impl GseScalar for Complex64 {
-    fn zero() -> Self {
-        Complex64::new(0.0, 0.0)
-    }
-
-    fn one() -> Self {
-        Complex64::new(1.0, 0.0)
-    }
-
-    fn conj(self) -> Self {
-        Complex64::new(self.re, -self.im)
-    }
-
-    fn real(self) -> f64 {
-        self.re
-    }
-}
-
 #[derive(Debug, Clone)]
 struct EdgeExpansionStats {
     edges_processed: usize,
@@ -441,15 +383,8 @@ where
             bonds_expanded: 0,
             max_added_basis: 0,
         }
-    } else if target_scalar == ScalarKind::Complex {
-        expand_edges_with_scalar::<Complex64, V>(
-            &mut state,
-            &mut reference_buffers,
-            center,
-            &options,
-        )?
     } else {
-        expand_edges_with_scalar::<f64, V>(&mut state, &mut reference_buffers, center, &options)?
+        expand_edges(&mut state, &mut reference_buffers, center, &options)?
     };
 
     Ok(GseResult {
@@ -688,14 +623,13 @@ where
     })
 }
 
-fn expand_edges_with_scalar<S, V>(
+fn expand_edges<V>(
     state: &mut TreeTN<TensorDynLen, V>,
     references: &mut [TreeTN<TensorDynLen, V>],
     center: &V,
     options: &GseOptions,
 ) -> Result<EdgeExpansionStats, GseError>
 where
-    S: GseScalar,
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
 {
     let edge_order = state
@@ -726,7 +660,7 @@ where
                 },
             )?;
         }
-        let added = expand_one_edge::<S, V>(state, references, &parent, &child, options)?;
+        let added = expand_one_edge(state, references, &parent, &child, options)?;
         stats.edges_processed += 1;
         if added > 0 {
             stats.bonds_expanded += 1;
@@ -742,7 +676,7 @@ where
     Ok(stats)
 }
 
-fn expand_one_edge<S, V>(
+fn expand_one_edge<V>(
     state: &mut TreeTN<TensorDynLen, V>,
     references: &mut [TreeTN<TensorDynLen, V>],
     parent: &V,
@@ -750,7 +684,6 @@ fn expand_one_edge<S, V>(
     options: &GseOptions,
 ) -> Result<usize, GseError>
 where
-    S: GseScalar,
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
 {
     let edge = state
@@ -796,7 +729,6 @@ where
         .filter(|idx| idx != &old_bond)
         .collect::<Vec<_>>();
     let q_dim = product_dim(&q_indices);
-    let old_dim = old_bond.dim();
 
     let factorized = child_tensor
         .factorize_full_rank(
@@ -810,118 +742,96 @@ where
         })?;
     let basis_bond = factorized.bond_index;
     let basis_rank = basis_bond.dim();
-    let basis_data = tensor_matrix::<S>(&factorized.right, &basis_bond, &q_indices)?;
-    let target_matrix = tensor_matrix::<S>(&child_tensor, &old_bond, &q_indices)?;
-
-    let mut density = vec![<S as GseScalar>::zero(); q_dim * q_dim];
-    for reference in references.iter() {
-        let ref_edge =
-            reference
-                .edge_between(parent, child)
-                .ok_or_else(|| GseError::Algorithm {
-                    context: "GSE reference edge is missing",
-                    source: anyhow::anyhow!(
-                        "missing reference edge between {:?} and {:?}",
-                        parent,
-                        child
-                    ),
-                })?;
-        let ref_bond =
-            reference
-                .bond_index(ref_edge)
-                .cloned()
-                .ok_or_else(|| GseError::Algorithm {
-                    context: "GSE reference edge has no bond index",
-                    source: anyhow::anyhow!(
-                        "missing reference bond between {:?} and {:?}",
-                        parent,
-                        child
-                    ),
-                })?;
-        let ref_child_idx = reference
-            .node_index(child)
-            .ok_or_else(|| GseError::MissingCenter {
-                center: format!("{child:?}"),
-            })?;
-        let ref_child_tensor =
-            reference
-                .tensor(ref_child_idx)
-                .ok_or_else(|| GseError::Algorithm {
-                    context: "GSE reference child tensor is missing",
-                    source: anyhow::anyhow!("missing reference tensor at {:?}", child),
-                })?;
-        let ref_q_indices = map_q_indices(state, reference, child, parent, &q_indices)?;
-        let ref_matrix = tensor_matrix::<S>(ref_child_tensor, &ref_bond, &ref_q_indices)?;
-        accumulate_density::<S>(&mut density, &ref_matrix, ref_bond.dim(), q_dim);
-    }
-
-    let trace = density_trace::<S>(&density, q_dim);
-    let mut added = 0usize;
-    let mut expanded_basis = basis_data.clone();
-    if trace > 0.0 {
-        for value in &mut density {
-            *value = *value / trace;
-        }
-        let mut missing = projected_missing_density::<S>(&density, &basis_data, basis_rank, q_dim);
-        hermitianize_square::<S>(&mut missing, q_dim);
-        let decomp = hermitian_eigendecomposition(
-            &Matrix::from_col_major_vec(q_dim, q_dim, missing),
-            options.hermitian_tol,
-        )
+    let basis_order = std::iter::once(basis_bond.clone())
+        .chain(q_indices.iter().cloned())
+        .collect::<Vec<_>>();
+    let basis_tensor = factorized
+        .right
+        .permuteinds(&basis_order)
         .map_err(|source| GseError::Algorithm {
-            context: "GSE failed to diagonalize projected reference density",
-            source: source.into(),
+            context: "GSE failed to align old target row basis",
+            source,
         })?;
-        let kept = decomp
-            .eigenvalues
-            .iter()
-            .enumerate()
-            .filter_map(|(col, &lambda)| (lambda > options.density_weight_cutoff).then_some(col))
-            .collect::<Vec<_>>();
-        if !kept.is_empty() {
-            let new_rank = basis_rank + kept.len();
-            let mut data = vec![<S as GseScalar>::zero(); new_rank * q_dim];
-            for q in 0..q_dim {
-                for row in 0..basis_rank {
-                    data[row + new_rank * q] = basis_data[row + basis_rank * q];
-                }
+
+    let q_left = fresh_indices_like(&q_indices);
+    let q_right = fresh_indices_like(&q_indices);
+    let density = build_reference_density(
+        state, references, parent, child, &q_indices, &q_left, &q_right,
+    )?;
+    let trace_identity = identity_on_index_pairs(&q_left, &q_right)?;
+    let trace_tensor = TensorDynLen::contract(&[&density, &trace_identity]).map_err(|source| {
+        GseError::Algorithm {
+            context: "GSE failed to compute local reference-density trace",
+            source,
+        }
+    })?;
+    let trace = trace_tensor.sum().map_err(|source| GseError::Algorithm {
+        context: "GSE failed to read local reference-density trace",
+        source,
+    })?;
+
+    let mut basis_rows = old_basis_rows(&basis_tensor, &basis_bond, basis_rank)?;
+    if trace.real() > 0.0 {
+        let normalized_density =
+            density
+                .scale(AnyScalar::new_real(1.0) / trace)
+                .map_err(|source| GseError::Algorithm {
+                    context: "GSE failed to normalize local reference density",
+                    source,
+                })?;
+        let missing = projected_missing_density_tensor(
+            &normalized_density,
+            &basis_tensor,
+            &basis_bond,
+            &q_indices,
+            &q_left,
+            &q_right,
+        )?;
+        let missing = hermitianize_by_index_groups(&missing, &q_left, &q_right)?;
+        let flat_left = DynIndex::new_dyn(q_dim);
+        let flat_right = DynIndex::new_dyn(q_dim);
+        let missing_matrix = missing
+            .fuse_indices(&q_left, flat_left.clone(), LinearizationOrder::ColumnMajor)
+            .and_then(|tensor| {
+                tensor.fuse_indices(
+                    &q_right,
+                    flat_right.clone(),
+                    LinearizationOrder::ColumnMajor,
+                )
+            })
+            .and_then(|tensor| tensor.permuteinds(&[flat_left.clone(), flat_right]))
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to reshape projected reference density for eigensolve",
+                source,
+            })?;
+        let decomp = missing_matrix
+            .hermitian_eigendecomposition(options.hermitian_tol)
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to diagonalize projected reference density",
+                source,
+            })?;
+        for (col, &lambda) in decomp.eigenvalues.iter().enumerate() {
+            if lambda > options.density_weight_cutoff {
+                basis_rows.push(eigenvector_basis_row(
+                    &decomp.eigenvectors,
+                    &flat_left,
+                    &decomp.eigenvector_index,
+                    col,
+                    &q_left,
+                    &q_indices,
+                )?);
             }
-            let vectors = decomp.eigenvectors.as_col_major_slice();
-            for (offset, &col) in kept.iter().enumerate() {
-                let row = basis_rank + offset;
-                for q in 0..q_dim {
-                    data[row + new_rank * q] = vectors[q + q_dim * col].conj();
-                }
-            }
-            expanded_basis = data;
-            added = kept.len();
         }
     }
 
-    let new_dim = basis_rank + added;
+    let added = basis_rows.len() - basis_rank;
+    let new_dim = basis_rows.len();
     let new_bond = DynIndex::new_bond(new_dim).map_err(|source| GseError::Algorithm {
         context: "GSE failed to create expanded target bond index",
         source: anyhow::anyhow!("{source:?}"),
     })?;
-    let target_child = TensorDynLen::from_dense(
-        std::iter::once(new_bond.clone())
-            .chain(q_indices.iter().cloned())
-            .collect(),
-        expanded_basis.clone(),
-    )
-    .map_err(|source| GseError::Algorithm {
-        context: "GSE failed to build expanded target child tensor",
-        source,
-    })?;
-    let target_coeff =
-        coefficient_matrix::<S>(&target_matrix, old_dim, q_dim, &expanded_basis, new_dim);
-    let coeff_tensor =
-        TensorDynLen::from_dense(vec![old_bond.clone(), new_bond.clone()], target_coeff).map_err(
-            |source| GseError::Algorithm {
-                context: "GSE failed to build target coefficient tensor",
-                source,
-            },
-        )?;
+    let target_child = stack_basis_rows(&basis_rows, new_bond.clone())?;
+    let coeff_tensor = coefficient_tensor(&child_tensor, &target_child)?;
     let target_parent =
         TensorDynLen::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
             GseError::Algorithm {
@@ -937,7 +847,7 @@ where
             source,
         })?;
     state
-        .replace_tensor(child_idx, target_child)
+        .replace_tensor(child_idx, target_child.clone())
         .map_err(|source| GseError::Algorithm {
             context: "GSE failed to replace target child tensor",
             source,
@@ -962,14 +872,14 @@ where
         })?;
 
     for reference in references.iter_mut() {
-        update_reference_edge::<S, V>(
+        update_reference_edge(
             reference,
             state,
             parent,
             child,
             &q_indices,
-            &expanded_basis,
-            new_dim,
+            &target_child,
+            &new_bond,
         )?;
     }
 
@@ -977,17 +887,16 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn update_reference_edge<S, V>(
+fn update_reference_edge<V>(
     reference: &mut TreeTN<TensorDynLen, V>,
     target: &TreeTN<TensorDynLen, V>,
     parent: &V,
     child: &V,
     target_q_indices: &[DynIndex],
-    expanded_basis: &[S],
-    new_dim: usize,
+    expanded_basis: &TensorDynLen,
+    target_new_bond: &DynIndex,
 ) -> Result<(), GseError>
 where
-    S: GseScalar,
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
     let edge = reference
@@ -1000,7 +909,7 @@ where
                 child
             ),
         })?;
-    let old_bond = reference
+    let _old_bond = reference
         .bond_index(edge)
         .cloned()
         .ok_or_else(|| GseError::Algorithm {
@@ -1037,28 +946,25 @@ where
                 source: anyhow::anyhow!("missing reference tensor at {:?}", parent),
             })?;
     let ref_q_indices = map_q_indices(target, reference, child, parent, target_q_indices)?;
-    let q_dim = product_dim(&ref_q_indices);
-    let ref_matrix = tensor_matrix::<S>(&child_tensor, &old_bond, &ref_q_indices)?;
-    let coeff =
-        coefficient_matrix::<S>(&ref_matrix, old_bond.dim(), q_dim, expanded_basis, new_dim);
-    let new_bond = DynIndex::new_bond(new_dim).map_err(|source| GseError::Algorithm {
-        context: "GSE failed to create expanded reference bond index",
-        source: anyhow::anyhow!("{source:?}"),
-    })?;
-    let child_replacement = TensorDynLen::from_dense(
-        std::iter::once(new_bond.clone())
-            .chain(ref_q_indices.iter().cloned())
-            .collect(),
-        expanded_basis.to_vec(),
-    )
-    .map_err(|source| GseError::Algorithm {
-        context: "GSE failed to build expanded reference child tensor",
-        source,
-    })?;
-    let coeff_tensor = TensorDynLen::from_dense(vec![old_bond.clone(), new_bond.clone()], coeff)
+    let new_bond =
+        DynIndex::new_bond(target_new_bond.dim()).map_err(|source| GseError::Algorithm {
+            context: "GSE failed to create expanded reference bond index",
+            source: anyhow::anyhow!("{source:?}"),
+        })?;
+    let child_replacement = expanded_basis
+        .replaceind(target_new_bond, &new_bond)
+        .and_then(|tensor| tensor.replaceinds(target_q_indices, &ref_q_indices))
         .map_err(|source| GseError::Algorithm {
-            context: "GSE failed to build reference coefficient tensor",
+            context: "GSE failed to relabel expanded basis for reference child",
             source,
+        })?;
+    let coeff_tensor =
+        coefficient_tensor(&child_tensor, &child_replacement).map_err(|error| match error {
+            GseError::Algorithm { source, .. } => GseError::Algorithm {
+                context: "GSE failed to build reference coefficient tensor",
+                source,
+            },
+            other => other,
         })?;
     let parent_replacement =
         TensorDynLen::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
@@ -1101,134 +1007,324 @@ where
     Ok(())
 }
 
-fn tensor_matrix<S>(
-    tensor: &TensorDynLen,
-    row_index: &DynIndex,
-    column_indices: &[DynIndex],
-) -> Result<Vec<S>, GseError>
+fn build_reference_density<V>(
+    target: &TreeTN<TensorDynLen, V>,
+    references: &[TreeTN<TensorDynLen, V>],
+    parent: &V,
+    child: &V,
+    target_q_indices: &[DynIndex],
+    q_left: &[DynIndex],
+    q_right: &[DynIndex],
+) -> Result<TensorDynLen, GseError>
 where
-    S: GseScalar,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
-    let ordered = std::iter::once(row_index.clone())
-        .chain(column_indices.iter().cloned())
-        .collect::<Vec<_>>();
-    let permuted = tensor
-        .permuteinds(&ordered)
+    let mut density: Option<TensorDynLen> = None;
+    for reference in references {
+        let ref_edge =
+            reference
+                .edge_between(parent, child)
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference edge is missing",
+                    source: anyhow::anyhow!(
+                        "missing reference edge between {:?} and {:?}",
+                        parent,
+                        child
+                    ),
+                })?;
+        let ref_bond =
+            reference
+                .bond_index(ref_edge)
+                .cloned()
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference edge has no bond index",
+                    source: anyhow::anyhow!(
+                        "missing reference bond between {:?} and {:?}",
+                        parent,
+                        child
+                    ),
+                })?;
+        let ref_child_idx = reference
+            .node_index(child)
+            .ok_or_else(|| GseError::MissingCenter {
+                center: format!("{child:?}"),
+            })?;
+        let ref_child_tensor =
+            reference
+                .tensor(ref_child_idx)
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference child tensor is missing",
+                    source: anyhow::anyhow!("missing reference tensor at {:?}", child),
+                })?;
+        let ref_q_indices = map_q_indices(target, reference, child, parent, target_q_indices)?;
+        let bra = ref_child_tensor
+            .replaceinds(&ref_q_indices, q_left)
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to relabel reference density bra indices",
+                source,
+            })?;
+        let ket = ref_child_tensor
+            .replaceinds(&ref_q_indices, q_right)
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to relabel reference density ket indices",
+                source,
+            })?;
+        let contribution = contract_pair_with_operand_options(
+            &bra,
+            &ket,
+            PairwiseContractionOptions::new().with_lhs_conj(true),
+        )
         .map_err(|source| GseError::Algorithm {
-            context: "GSE failed to align local tensor matrix indices",
+            context: "GSE failed to contract reference density contribution",
             source,
         })?;
-    permuted
-        .to_vec::<S>()
+        debug_assert!(!contribution.external_indices().contains(&ref_bond));
+        density = Some(match density {
+            Some(accumulated) => {
+                accumulated
+                    .add(&contribution)
+                    .map_err(|source| GseError::Algorithm {
+                        context: "GSE failed to accumulate reference density",
+                        source,
+                    })?
+            }
+            None => contribution,
+        });
+    }
+    density.ok_or_else(|| GseError::Algorithm {
+        context: "GSE failed to build reference density",
+        source: anyhow::anyhow!("no references were supplied"),
+    })
+}
+
+fn old_basis_rows(
+    basis: &TensorDynLen,
+    basis_bond: &DynIndex,
+    basis_rank: usize,
+) -> Result<Vec<TensorDynLen>, GseError> {
+    (0..basis_rank)
+        .map(|row| {
+            basis
+                .select_indices(std::slice::from_ref(basis_bond), &[row])
+                .map_err(|source| GseError::Algorithm {
+                    context: "GSE failed to slice old target basis row",
+                    source,
+                })
+        })
+        .collect()
+}
+
+fn eigenvector_basis_row(
+    eigenvectors: &TensorDynLen,
+    flat_left: &DynIndex,
+    eigenvector_index: &DynIndex,
+    col: usize,
+    q_left: &[DynIndex],
+    q_indices: &[DynIndex],
+) -> Result<TensorDynLen, GseError> {
+    let vector = eigenvectors
+        .select_indices(std::slice::from_ref(eigenvector_index), &[col])
         .map_err(|source| GseError::Algorithm {
-            context: "GSE failed to read local tensor matrix values",
+            context: "GSE failed to select projected-density eigenvector",
+            source,
+        })?;
+    let row = vector
+        .unfuse_index(flat_left, q_left, LinearizationOrder::ColumnMajor)
+        .and_then(|tensor| tensor.conj().replaceinds(q_left, q_indices))
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to reshape projected-density eigenvector into a basis row",
+            source,
+        })?;
+    Ok(row)
+}
+
+fn stack_basis_rows(rows: &[TensorDynLen], new_bond: DynIndex) -> Result<TensorDynLen, GseError> {
+    let refs = rows.iter().collect::<Vec<_>>();
+    TensorDynLen::stack_along_new_index(&refs, new_bond, 0).map_err(|source| GseError::Algorithm {
+        context: "GSE failed to stack expanded basis rows",
+        source,
+    })
+}
+
+fn coefficient_tensor(
+    child_tensor: &TensorDynLen,
+    expanded_basis: &TensorDynLen,
+) -> Result<TensorDynLen, GseError> {
+    contract_pair_with_operand_options(
+        child_tensor,
+        expanded_basis,
+        PairwiseContractionOptions::new().with_rhs_conj(true),
+    )
+    .map_err(|source| GseError::Algorithm {
+        context: "GSE failed to build expansion coefficient tensor",
+        source,
+    })
+}
+
+fn projected_missing_density_tensor(
+    density: &TensorDynLen,
+    basis: &TensorDynLen,
+    basis_bond: &DynIndex,
+    q_indices: &[DynIndex],
+    q_left: &[DynIndex],
+    q_right: &[DynIndex],
+) -> Result<TensorDynLen, GseError> {
+    let identity = identity_on_index_pairs(q_left, q_right)?;
+    let basis_left =
+        basis
+            .replaceinds(q_indices, q_left)
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to relabel represented-basis bra indices",
+                source,
+            })?;
+    let basis_right =
+        basis
+            .replaceinds(q_indices, q_right)
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to relabel represented-basis ket indices",
+                source,
+            })?;
+    let represented = contract_pair_with_operand_options(
+        &basis_left,
+        &basis_right,
+        PairwiseContractionOptions::new().with_lhs_conj(true),
+    )
+    .map_err(|source| GseError::Algorithm {
+        context: "GSE failed to contract represented basis projector",
+        source,
+    })?;
+    debug_assert!(!represented.external_indices().contains(basis_bond));
+    let projector = identity
+        .axpby(
+            AnyScalar::new_real(1.0),
+            &represented,
+            AnyScalar::new_real(-1.0),
+        )
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to subtract represented basis projector",
+            source,
+        })?;
+
+    let q_mid_left = fresh_indices_like(q_left);
+    let q_mid_right = fresh_indices_like(q_right);
+    let p_left_mid = projector
+        .replaceinds(q_right, &q_mid_left)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to relabel left projected-density projector",
+            source,
+        })?;
+    let density_mid = density
+        .replaceinds(q_left, &q_mid_left)
+        .and_then(|tensor| tensor.replaceinds(q_right, &q_mid_right))
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to relabel middle projected-density tensor",
+            source,
+        })?;
+    let p_mid_right = projector
+        .replaceinds(q_left, &q_mid_right)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to relabel right projected-density projector",
+            source,
+        })?;
+    TensorDynLen::contract(&[&p_left_mid, &density_mid, &p_mid_right]).map_err(|source| {
+        GseError::Algorithm {
+            context: "GSE failed to contract projected missing reference density",
+            source,
+        }
+    })
+}
+
+fn identity_on_index_pairs(
+    left: &[DynIndex],
+    right: &[DynIndex],
+) -> Result<TensorDynLen, GseError> {
+    if left.len() != right.len() {
+        return Err(GseError::Algorithm {
+            context: "GSE failed to build identity on q-space",
+            source: anyhow::anyhow!(
+                "left/right q-index count mismatch: {} vs {}",
+                left.len(),
+                right.len()
+            ),
+        });
+    }
+    let mut identity: Option<TensorDynLen> = None;
+    for (left_index, right_index) in left.iter().zip(right.iter()) {
+        let pair = TensorDynLen::copy_tensor(
+            vec![left_index.clone(), right_index.clone()],
+            AnyScalar::new_real(1.0),
+        )
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to build one-index-pair identity",
+            source,
+        })?;
+        identity = Some(match identity {
+            Some(accumulated) => {
+                accumulated
+                    .outer_product(&pair)
+                    .map_err(|source| GseError::Algorithm {
+                        context: "GSE failed to combine q-space identity factors",
+                        source,
+                    })?
+            }
+            None => pair,
+        });
+    }
+    match identity {
+        Some(tensor) => Ok(tensor),
+        None => TensorDynLen::scalar(1.0_f64).map_err(|source| GseError::Algorithm {
+            context: "GSE failed to build scalar q-space identity",
+            source,
+        }),
+    }
+}
+
+fn hermitianize_by_index_groups(
+    tensor: &TensorDynLen,
+    left: &[DynIndex],
+    right: &[DynIndex],
+) -> Result<TensorDynLen, GseError> {
+    let adjoint = adjoint_by_index_groups(tensor, left, right)?;
+    tensor
+        .axpby(AnyScalar::new_real(0.5), &adjoint, AnyScalar::new_real(0.5))
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to Hermitianize projected reference density",
             source,
         })
 }
 
-fn accumulate_density<S>(density: &mut [S], matrix: &[S], row_dim: usize, q_dim: usize)
-where
-    S: GseScalar,
-{
-    for x in 0..q_dim {
-        for y in 0..q_dim {
-            let mut sum = <S as GseScalar>::zero();
-            for row in 0..row_dim {
-                sum += matrix[row + row_dim * x].conj() * matrix[row + row_dim * y];
-            }
-            density[x + q_dim * y] += sum;
-        }
+fn adjoint_by_index_groups(
+    tensor: &TensorDynLen,
+    left: &[DynIndex],
+    right: &[DynIndex],
+) -> Result<TensorDynLen, GseError> {
+    if left.len() != right.len() {
+        return Err(GseError::Algorithm {
+            context: "GSE failed to adjoint grouped tensor",
+            source: anyhow::anyhow!(
+                "left/right q-index count mismatch: {} vs {}",
+                left.len(),
+                right.len()
+            ),
+        });
     }
+    let temporary = fresh_indices_like(left);
+    tensor
+        .conj()
+        .replaceinds(left, &temporary)
+        .and_then(|tensor| tensor.replaceinds(right, left))
+        .and_then(|tensor| tensor.replaceinds(&temporary, right))
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to swap grouped tensor indices for adjoint",
+            source,
+        })
 }
 
-fn density_trace<S>(density: &[S], q_dim: usize) -> f64
-where
-    S: GseScalar,
-{
-    (0..q_dim)
-        .map(|i| density[i + q_dim * i].real())
-        .sum::<f64>()
-}
-
-fn projected_missing_density<S>(density: &[S], basis: &[S], rank: usize, q_dim: usize) -> Vec<S>
-where
-    S: GseScalar,
-{
-    let mut projector = vec![<S as GseScalar>::zero(); q_dim * q_dim];
-    for x in 0..q_dim {
-        for y in 0..q_dim {
-            let mut represented = <S as GseScalar>::zero();
-            for row in 0..rank {
-                represented += basis[row + rank * x].conj() * basis[row + rank * y];
-            }
-            projector[x + q_dim * y] = if x == y {
-                <S as GseScalar>::one() - represented
-            } else {
-                <S as GseScalar>::zero() - represented
-            };
-        }
-    }
-    let tmp = matmul_square::<S>(&projector, density, q_dim);
-    matmul_square::<S>(&tmp, &projector, q_dim)
-}
-
-fn matmul_square<S>(lhs: &[S], rhs: &[S], n: usize) -> Vec<S>
-where
-    S: GseScalar,
-{
-    let mut out = vec![<S as GseScalar>::zero(); n * n];
-    for col in 0..n {
-        for row in 0..n {
-            let mut sum = <S as GseScalar>::zero();
-            for k in 0..n {
-                sum += lhs[row + n * k] * rhs[k + n * col];
-            }
-            out[row + n * col] = sum;
-        }
-    }
-    out
-}
-
-fn hermitianize_square<S>(matrix: &mut [S], n: usize)
-where
-    S: GseScalar,
-{
-    for col in 0..n {
-        for row in 0..=col {
-            let ij = row + n * col;
-            let ji = col + n * row;
-            if row == col {
-                matrix[ij] = (matrix[ij] + matrix[ij].conj()) / 2.0;
-            } else {
-                let avg = (matrix[ij] + matrix[ji].conj()) / 2.0;
-                matrix[ij] = avg;
-                matrix[ji] = avg.conj();
-            }
-        }
-    }
-}
-
-fn coefficient_matrix<S>(
-    matrix: &[S],
-    row_dim: usize,
-    q_dim: usize,
-    basis: &[S],
-    basis_dim: usize,
-) -> Vec<S>
-where
-    S: GseScalar,
-{
-    let mut coeff = vec![<S as GseScalar>::zero(); row_dim * basis_dim];
-    for ell in 0..basis_dim {
-        for row in 0..row_dim {
-            let mut sum = <S as GseScalar>::zero();
-            for q in 0..q_dim {
-                sum += matrix[row + row_dim * q] * basis[ell + basis_dim * q].conj();
-            }
-            coeff[row + row_dim * ell] = sum;
-        }
-    }
-    coeff
+fn fresh_indices_like(indices: &[DynIndex]) -> Vec<DynIndex> {
+    indices
+        .iter()
+        .map(|index| DynIndex::new_dyn(index.dim()))
+        .collect()
 }
 
 fn map_q_indices<V>(

--- a/crates/tensor4all-treetn/src/gse.rs
+++ b/crates/tensor4all-treetn/src/gse.rs
@@ -1425,3 +1425,237 @@ where
     state.set_canonical_region([target])?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn basis_vector(dim: usize, selected: usize) -> Vec<f64> {
+        let mut values = vec![0.0; dim];
+        values[selected] = 1.0;
+        values
+    }
+
+    fn product_chain_state(
+        left_dim: usize,
+        right_dim: usize,
+    ) -> TreeTN<TensorDynLen, &'static str> {
+        let left = DynIndex::new_dyn(left_dim);
+        let right = DynIndex::new_dyn(right_dim);
+        let bond = DynIndex::new_dyn(1);
+        let left_tensor =
+            TensorDynLen::from_dense(vec![left, bond.clone()], basis_vector(left_dim, 0)).unwrap();
+        let right_tensor =
+            TensorDynLen::from_dense(vec![bond.clone(), right], basis_vector(right_dim, 0))
+                .unwrap();
+        let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+        let left_node = state.add_tensor("site0", left_tensor).unwrap();
+        let right_node = state.add_tensor("site1", right_tensor).unwrap();
+        state.connect(left_node, &bond, right_node, &bond).unwrap();
+        state
+    }
+
+    fn product_chain3_state(tail_bond_dim: usize) -> TreeTN<TensorDynLen, &'static str> {
+        let s0 = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+        let s2 = DynIndex::new_dyn(2);
+        let b01 = DynIndex::new_dyn(1);
+        let b12 = DynIndex::new_dyn(tail_bond_dim);
+        let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0]).unwrap();
+        let mut t1_data = vec![0.0; 2 * tail_bond_dim];
+        t1_data[0] = 1.0;
+        let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1, b12.clone()], t1_data).unwrap();
+        let mut t2_data = vec![0.0; tail_bond_dim * 2];
+        t2_data[0] = 1.0;
+        let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2], t2_data).unwrap();
+
+        let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+        let n0 = state.add_tensor("site0", t0).unwrap();
+        let n1 = state.add_tensor("site1", t1).unwrap();
+        let n2 = state.add_tensor("site2", t2).unwrap();
+        state.connect(n0, &b01, n1, &b01).unwrap();
+        state.connect(n1, &b12, n2, &b12).unwrap();
+        state
+    }
+
+    #[test]
+    fn gse_option_builders_set_reference_knobs() {
+        let policy = SvdTruncationPolicy::new(1.0e-8);
+        let options = GseOptions::default()
+            .with_reference_max_rank(7)
+            .with_reference_svd_policy(policy)
+            .with_normalize_references(false)
+            .with_expand_before_first_sweep(false);
+
+        assert_eq!(options.reference_max_rank, Some(7));
+        assert_eq!(options.reference_svd_policy, Some(policy));
+        assert!(!options.normalize_references);
+        assert!(!options.expand_before_first_sweep);
+    }
+
+    #[test]
+    fn square_site_mapping_errors_convert_to_gse_errors() {
+        let err = GseError::from(SquareSiteMappingError::UnsupportedStateSiteCount {
+            node: "site0".to_string(),
+            count: 2,
+        });
+        assert!(matches!(
+            err,
+            GseError::UnsupportedStateSiteCount { node, count }
+                if node == "site0" && count == 2
+        ));
+
+        let err = GseError::from(SquareSiteMappingError::UnsupportedMultipleSiteMappings {
+            node: "site1".to_string(),
+            role: "input",
+            count: 2,
+        });
+        assert!(matches!(
+            err,
+            GseError::UnsupportedMultipleSiteMappings { node, role, count }
+                if node == "site1" && role == "input" && count == 2
+        ));
+
+        let err = GseError::from(SquareSiteMappingError::MissingMapping {
+            node: "site2".to_string(),
+            role: "output",
+        });
+        assert!(matches!(
+            err,
+            GseError::MissingMapping { node, role }
+                if node == "site2" && role == "output"
+        ));
+
+        let err = GseError::from(SquareSiteMappingError::InvalidMapping {
+            node: "site3".to_string(),
+            reason: "bad dimension".to_string(),
+        });
+        assert!(matches!(
+            err,
+            GseError::InvalidMapping { node, reason }
+                if node == "site3" && reason == "bad dimension"
+        ));
+    }
+
+    #[test]
+    fn identity_on_index_pairs_handles_empty_products_and_mismatches() {
+        let scalar = identity_on_index_pairs(&[], &[]).unwrap();
+        assert!(scalar.indices().is_empty());
+        assert_eq!(scalar.to_vec::<f64>().unwrap(), vec![1.0]);
+
+        let left0 = DynIndex::new_dyn(2);
+        let left1 = DynIndex::new_dyn(3);
+        let right0 = DynIndex::new_dyn(2);
+        let right1 = DynIndex::new_dyn(3);
+        let identity = identity_on_index_pairs(
+            &[left0.clone(), left1.clone()],
+            &[right0.clone(), right1.clone()],
+        )
+        .unwrap();
+        assert_eq!(identity.indices(), &[left0.clone(), right0, left1, right1]);
+        assert_eq!(identity.sum().unwrap().real(), 6.0);
+
+        let err = identity_on_index_pairs(&[left0], &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            GseError::Algorithm { context, .. }
+                if context == "GSE failed to build identity on q-space"
+        ));
+    }
+
+    #[test]
+    fn adjoint_by_index_groups_swaps_groups_and_rejects_mismatched_lengths() {
+        let left = DynIndex::new_dyn(2);
+        let right = DynIndex::new_dyn(2);
+        let tensor =
+            TensorDynLen::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0])
+                .unwrap();
+
+        let adjoint = adjoint_by_index_groups(
+            &tensor,
+            std::slice::from_ref(&left),
+            std::slice::from_ref(&right),
+        )
+        .unwrap();
+        assert_eq!(adjoint.indices(), &[right.clone(), left.clone()]);
+        assert_eq!(adjoint.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+
+        let err = adjoint_by_index_groups(&tensor, &[left], &[]).unwrap_err();
+        assert!(matches!(
+            err,
+            GseError::Algorithm { context, .. }
+                if context == "GSE failed to adjoint grouped tensor"
+        ));
+    }
+
+    #[test]
+    fn validate_reference_rejects_site_dimension_mismatch() {
+        let target = product_chain_state(2, 2);
+        let reference = product_chain_state(3, 2);
+
+        let err = validate_reference(&target, &reference).unwrap_err();
+        assert!(matches!(
+            err,
+            GseError::InvalidMapping { reason, .. }
+                if reason == "reference site dimension does not match target"
+        ));
+    }
+
+    #[test]
+    fn map_q_indices_rejects_parent_bond_and_child_bond_dimension_mismatch() {
+        let target = product_chain3_state(2);
+        let reference = product_chain3_state(3);
+        let site1 = single_site_index(&target, &"site1").unwrap();
+        let parent_edge = target.edge_between(&"site0", &"site1").unwrap();
+        let parent_bond = target.bond_index(parent_edge).unwrap().clone();
+        let child_edge = target.edge_between(&"site1", &"site2").unwrap();
+        let child_bond = target.bond_index(child_edge).unwrap().clone();
+
+        let err = map_q_indices(
+            &target,
+            &reference,
+            &"site1",
+            &"site0",
+            &[site1.clone(), parent_bond],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            GseError::Algorithm { context, .. }
+                if context == "GSE parent bond cannot appear in q index map"
+        ));
+
+        let err = map_q_indices(
+            &target,
+            &reference,
+            &"site1",
+            &"site0",
+            &[site1, child_bond],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            GseError::InvalidMapping { reason, .. }
+                if reason == "reference child-side bond dimension does not match target"
+        ));
+    }
+
+    #[test]
+    fn move_center_to_region_full_rank_handles_errors_and_path_moves() {
+        let mut uncached = product_chain_state(2, 2);
+        let err = move_center_to_region_full_rank(&mut uncached, &[]).unwrap_err();
+        assert!(err.to_string().contains("empty region"));
+
+        let err = move_center_to_region_full_rank(&mut uncached, &["site0"]).unwrap_err();
+        assert!(err.to_string().contains("not canonicalized"));
+
+        let mut state = product_chain_state(2, 2)
+            .canonicalize(["site0"], CanonicalizationOptions::forced())
+            .unwrap();
+        move_center_to_region_full_rank(&mut state, &["site0"]).unwrap();
+        assert!(state.canonical_region().contains(&"site0"));
+
+        move_center_to_region_full_rank(&mut state, &["site1"]).unwrap();
+        assert!(state.canonical_region().contains(&"site1"));
+    }
+}

--- a/crates/tensor4all-treetn/src/gse.rs
+++ b/crates/tensor4all-treetn/src/gse.rs
@@ -1,0 +1,1424 @@
+//! Global subspace expansion for TreeTN TDVP.
+//!
+//! This module implements the v1 TreeTN form of the MPS global subspace
+//! expansion documented in `docs/design/gse-chain-mps-algorithm.md`.
+//! The implementation is intentionally narrow: it supports `TensorDynLen`
+//! states with exactly one state site index per node and mapped TreeTN
+//! operators with one input and one output index per node.
+//!
+//! The v1 path performs local host-side linear algebra on primal dense values
+//! extracted from each local tensor. It does not preserve autodiff tracking.
+//! During expansion, old bonds are reconstructed from full-rank local SVDs; this
+//! preserves the represented state, but can remove exactly redundant bond
+//! directions while adding missing reference directions.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
+
+use anyhow::Result;
+use num_complex::Complex64;
+use tensor4all_core::{
+    AnyScalar, Canonical, DynIndex, FactorizeAlg, IndexLike, SvdTruncationPolicy,
+    TensorContractionLike, TensorDynLen, TensorFactorizationLike, TensorIndex,
+};
+use tensor4all_tensorbackend::{
+    hermitian_eigendecomposition, HermitianEigenScalar, Matrix, TensorElement,
+};
+use thiserror::Error;
+
+use crate::local_update_support::{single_site_square_mappings, SquareSiteMappingError};
+use crate::operator::{apply_linear_operator, ApplyOptions, LinearOperator};
+use crate::{CanonicalizationOptions, TdvpError, TdvpOptions, TdvpResult, TreeTN};
+
+/// Options controlling TreeTN global subspace expansion.
+#[derive(Debug, Clone)]
+pub struct GseOptions {
+    /// Number of Krylov reference states to build as `H psi`, `H^2 psi`, ...
+    ///
+    /// This field is used by [`global_subspace_expand`] and [`gse_tdvp`]. It is
+    /// ignored by [`global_subspace_expand_with_references`], where references
+    /// are supplied directly.
+    pub krylov_dim: usize,
+    /// Options used when applying the operator to build each reference state.
+    pub reference_apply: ApplyOptions,
+    /// Optional maximum bond dimension for generated reference states.
+    ///
+    /// When this is `None`, generated references use `maxlinkdim(state) + 1`,
+    /// matching the low-rank probe policy used by chain GSE implementations.
+    pub reference_max_rank: Option<usize>,
+    /// Optional SVD policy for generated reference states.
+    pub reference_svd_policy: Option<SvdTruncationPolicy>,
+    /// Density eigenvalue cutoff for retaining missing reference directions.
+    pub density_weight_cutoff: f64,
+    /// Hermitian tolerance for local projected-density eigendecompositions.
+    pub hermitian_tol: f64,
+    /// Normalize each generated Krylov reference after operator application.
+    pub normalize_references: bool,
+    /// Whether [`gse_tdvp`] expands before the first TDVP sweep.
+    pub expand_before_first_sweep: bool,
+}
+
+impl Default for GseOptions {
+    fn default() -> Self {
+        Self {
+            krylov_dim: 0,
+            reference_apply: ApplyOptions::zipup(),
+            reference_max_rank: None,
+            reference_svd_policy: None,
+            density_weight_cutoff: 1.0e-12,
+            hermitian_tol: 1.0e-12,
+            normalize_references: true,
+            expand_before_first_sweep: true,
+        }
+    }
+}
+
+impl GseOptions {
+    /// Set the number of generated Krylov reference states.
+    pub fn with_krylov_dim(mut self, krylov_dim: usize) -> Self {
+        self.krylov_dim = krylov_dim;
+        self
+    }
+
+    /// Set the density eigenvalue cutoff.
+    pub fn with_density_weight_cutoff(mut self, density_weight_cutoff: f64) -> Self {
+        self.density_weight_cutoff = density_weight_cutoff;
+        self
+    }
+
+    /// Set the Hermitian tolerance for local density eigendecompositions.
+    pub fn with_hermitian_tol(mut self, hermitian_tol: f64) -> Self {
+        self.hermitian_tol = hermitian_tol;
+        self
+    }
+
+    /// Set the reference-state maximum rank used during operator application.
+    pub fn with_reference_max_rank(mut self, reference_max_rank: usize) -> Self {
+        self.reference_max_rank = Some(reference_max_rank);
+        self
+    }
+
+    /// Set the reference-state SVD policy used during operator application.
+    pub fn with_reference_svd_policy(mut self, reference_svd_policy: SvdTruncationPolicy) -> Self {
+        self.reference_svd_policy = Some(reference_svd_policy);
+        self
+    }
+
+    /// Set whether generated Krylov references are normalized.
+    pub fn with_normalize_references(mut self, normalize_references: bool) -> Self {
+        self.normalize_references = normalize_references;
+        self
+    }
+
+    /// Set whether GSE-TDVP expands before the first TDVP sweep.
+    pub fn with_expand_before_first_sweep(mut self, expand_before_first_sweep: bool) -> Self {
+        self.expand_before_first_sweep = expand_before_first_sweep;
+        self
+    }
+}
+
+/// Result returned by a TreeTN global subspace expansion.
+#[derive(Debug, Clone)]
+pub struct GseResult<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Expanded TreeTN state.
+    pub state: TreeTN<TensorDynLen, V>,
+    /// Number of reference states supplied or generated.
+    pub references_built: usize,
+    /// Number of directed edges visited by the expansion sweep.
+    pub edges_processed: usize,
+    /// Number of edges where at least one new basis vector was appended.
+    pub bonds_expanded: usize,
+    /// Largest number of basis vectors appended to one edge.
+    pub max_added_basis: usize,
+}
+
+/// Options for [`gse_tdvp`].
+#[derive(Debug, Clone, Default)]
+pub struct GseTdvpOptions {
+    /// Global subspace expansion options.
+    pub gse: GseOptions,
+    /// Existing TreeTN TDVP options.
+    pub tdvp: TdvpOptions,
+}
+
+/// Result returned by [`gse_tdvp`].
+#[derive(Debug, Clone)]
+pub struct GseTdvpResult<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Final evolved state.
+    pub state: TreeTN<TensorDynLen, V>,
+    /// Number of one-sweep TDVP calls completed.
+    pub sweeps_completed: usize,
+    /// Total number of projected local TDVP updates.
+    pub local_updates: usize,
+    /// Number of GSE expansions run before TDVP sweeps.
+    pub gse_expansions: usize,
+    /// Largest Krylov residual estimate reported by TDVP.
+    pub max_error_estimate: f64,
+    /// Largest number of Krylov iterations used by TDVP.
+    pub max_krylov_iterations: usize,
+}
+
+/// Errors returned by TreeTN GSE and GSE-TDVP.
+#[derive(Debug, Error)]
+pub enum GseError {
+    /// A numeric or algorithm option is invalid.
+    #[error("invalid GSE option {option}: {reason}")]
+    InvalidOption {
+        /// Option name.
+        option: &'static str,
+        /// Why the value is invalid.
+        reason: String,
+    },
+    /// The requested root does not exist.
+    #[error("GSE center {center} is not a state node")]
+    MissingCenter {
+        /// Debug representation of the missing center.
+        center: String,
+    },
+    /// State, reference, or operator topology is incompatible.
+    #[error(
+        "GSE requires target, references, and operator support to have the same tree topology"
+    )]
+    TopologyMismatch,
+    /// The v1 implementation supports one state site index per node.
+    #[error("GSE v1 requires exactly one state site index at node {node}, found {count}")]
+    UnsupportedStateSiteCount {
+        /// Debug representation of the node.
+        node: String,
+        /// Number of state site indices found.
+        count: usize,
+    },
+    /// The v1 implementation supports one input/output mapping per node.
+    #[error("GSE v1 requires exactly one {role} mapping at node {node}, found {count}")]
+    UnsupportedMultipleSiteMappings {
+        /// Debug representation of the node.
+        node: String,
+        /// Mapping role.
+        role: &'static str,
+        /// Number of mappings found.
+        count: usize,
+    },
+    /// A required operator mapping is missing.
+    #[error("GSE missing {role} mapping at node {node}")]
+    MissingMapping {
+        /// Debug representation of the node.
+        node: String,
+        /// Mapping role.
+        role: &'static str,
+    },
+    /// An operator mapping is invalid.
+    #[error("invalid GSE mapping at node {node}: {reason}")]
+    InvalidMapping {
+        /// Debug representation of the node.
+        node: String,
+        /// Why the mapping is invalid.
+        reason: String,
+    },
+    /// The v1 implementation supports uniform f64 or Complex64 storage.
+    #[error("GSE v1 unsupported scalar storage at node {node}: {reason}")]
+    UnsupportedScalarStorage {
+        /// Debug representation of the node.
+        node: String,
+        /// Why scalar storage is unsupported.
+        reason: String,
+    },
+    /// Target and reference states must use the same scalar storage.
+    #[error(
+        "GSE v1 requires target and reference tensors to have the same scalar storage; target is {target}, reference is {reference}"
+    )]
+    ScalarStorageMismatch {
+        /// Target scalar storage label.
+        target: &'static str,
+        /// Reference scalar storage label.
+        reference: &'static str,
+    },
+    /// Existing TDVP failed after GSE.
+    #[error("GSE-TDVP TDVP step failed: {source}")]
+    Tdvp {
+        /// TDVP source error.
+        #[source]
+        source: TdvpError,
+    },
+    /// A lower-level tensor-network or linalg operation failed.
+    #[error("{context}: {source}")]
+    Algorithm {
+        /// Context for the failing operation.
+        context: &'static str,
+        /// Source error.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl From<SquareSiteMappingError> for GseError {
+    fn from(error: SquareSiteMappingError) -> Self {
+        match error {
+            SquareSiteMappingError::UnsupportedStateSiteCount { node, count } => {
+                Self::UnsupportedStateSiteCount { node, count }
+            }
+            SquareSiteMappingError::UnsupportedMultipleSiteMappings { node, role, count } => {
+                Self::UnsupportedMultipleSiteMappings { node, role, count }
+            }
+            SquareSiteMappingError::MissingMapping { node, role } => {
+                Self::MissingMapping { node, role }
+            }
+            SquareSiteMappingError::InvalidMapping { node, reason } => {
+                Self::InvalidMapping { node, reason }
+            }
+        }
+    }
+}
+
+trait GseScalar:
+    TensorElement
+    + HermitianEigenScalar
+    + Copy
+    + Default
+    + Add<Output = Self>
+    + AddAssign
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<f64, Output = Self>
+    + Debug
+    + 'static
+{
+    fn zero() -> Self;
+    fn one() -> Self;
+    fn conj(self) -> Self;
+    fn real(self) -> f64;
+}
+
+impl GseScalar for f64 {
+    fn zero() -> Self {
+        0.0
+    }
+
+    fn one() -> Self {
+        1.0
+    }
+
+    fn conj(self) -> Self {
+        self
+    }
+
+    fn real(self) -> f64 {
+        self
+    }
+}
+
+impl GseScalar for Complex64 {
+    fn zero() -> Self {
+        Complex64::new(0.0, 0.0)
+    }
+
+    fn one() -> Self {
+        Complex64::new(1.0, 0.0)
+    }
+
+    fn conj(self) -> Self {
+        Complex64::new(self.re, -self.im)
+    }
+
+    fn real(self) -> f64 {
+        self.re
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EdgeExpansionStats {
+    edges_processed: usize,
+    bonds_expanded: usize,
+    max_added_basis: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScalarKind {
+    Real,
+    Complex,
+}
+
+impl ScalarKind {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Real => "f64",
+            Self::Complex => "Complex64",
+        }
+    }
+}
+
+/// Build Krylov references from `operator`, expand the TreeTN state, and return
+/// the expanded state.
+pub fn global_subspace_expand<V>(
+    operator: &LinearOperator<TensorDynLen, V>,
+    init: TreeTN<TensorDynLen, V>,
+    center: &V,
+    options: GseOptions,
+) -> Result<GseResult<V>, GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    validate_options(&options)?;
+    if init.node_index(center).is_none() {
+        return Err(GseError::MissingCenter {
+            center: format!("{center:?}"),
+        });
+    }
+    if !init.same_topology(operator.mpo()) {
+        return Err(GseError::TopologyMismatch);
+    }
+    single_site_square_mappings(operator, &init).map_err(GseError::from)?;
+
+    let references = build_references(operator, &init, center, &options)?;
+    global_subspace_expand_with_references(init, references, center, options)
+}
+
+/// Expand a TreeTN state using caller-supplied reference work buffers.
+///
+/// The supplied references are cloned into internal work buffers. Their link
+/// indices are relabeled before the sweep, so callers should not rely on the
+/// references being returned or mutated.
+pub fn global_subspace_expand_with_references<V>(
+    init: TreeTN<TensorDynLen, V>,
+    references: Vec<TreeTN<TensorDynLen, V>>,
+    center: &V,
+    options: GseOptions,
+) -> Result<GseResult<V>, GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    validate_options(&options)?;
+    if init.node_index(center).is_none() {
+        return Err(GseError::MissingCenter {
+            center: format!("{center:?}"),
+        });
+    }
+    validate_single_site_state(&init)?;
+    let target_scalar = tree_scalar_kind(&init)?;
+
+    let references_built = references.len();
+    let mut state = init
+        .canonicalize([center.clone()], CanonicalizationOptions::forced())
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to canonicalize target state",
+            source,
+        })?;
+
+    let mut reference_buffers = Vec::with_capacity(references.len());
+    for reference in references {
+        validate_reference(&state, &reference)?;
+        let reference_scalar = tree_scalar_kind(&reference)?;
+        if reference_scalar != target_scalar {
+            return Err(GseError::ScalarStorageMismatch {
+                target: target_scalar.label(),
+                reference: reference_scalar.label(),
+            });
+        }
+        let mut reference = reference
+            .canonicalize([center.clone()], CanonicalizationOptions::forced())
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to canonicalize reference state",
+                source,
+            })?;
+        reference
+            .sim_linkinds_mut()
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to relabel reference link indices",
+                source,
+            })?;
+        reference_buffers.push(reference);
+    }
+
+    let stats = if reference_buffers.is_empty() {
+        EdgeExpansionStats {
+            edges_processed: 0,
+            bonds_expanded: 0,
+            max_added_basis: 0,
+        }
+    } else if target_scalar == ScalarKind::Complex {
+        expand_edges_with_scalar::<Complex64, V>(
+            &mut state,
+            &mut reference_buffers,
+            center,
+            &options,
+        )?
+    } else {
+        expand_edges_with_scalar::<f64, V>(&mut state, &mut reference_buffers, center, &options)?
+    };
+
+    Ok(GseResult {
+        state,
+        references_built,
+        edges_processed: stats.edges_processed,
+        bonds_expanded: stats.bonds_expanded,
+        max_added_basis: stats.max_added_basis,
+    })
+}
+
+/// Run GSE before selected TDVP sweeps and delegate each sweep to existing TDVP.
+pub fn gse_tdvp<V>(
+    operator: &LinearOperator<TensorDynLen, V>,
+    init: TreeTN<TensorDynLen, V>,
+    center: &V,
+    options: GseTdvpOptions,
+) -> Result<GseTdvpResult<V>, GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    validate_options(&options.gse)?;
+    let mut state = init;
+    let sweeps = options.tdvp.nsweeps;
+    let mut sweeps_completed = 0usize;
+    let mut local_updates = 0usize;
+    let mut gse_expansions = 0usize;
+    let mut max_error_estimate = 0.0_f64;
+    let mut max_krylov_iterations = 0usize;
+
+    for sweep in 0..sweeps {
+        if options.gse.krylov_dim > 0 && (sweep > 0 || options.gse.expand_before_first_sweep) {
+            let expansion = global_subspace_expand(operator, state, center, options.gse.clone())?;
+            state = expansion.state;
+            gse_expansions += 1;
+        }
+
+        let mut tdvp_options = options.tdvp.clone();
+        tdvp_options.nsweeps = 1;
+        let TdvpResult {
+            state: evolved,
+            sweeps_completed: completed,
+            local_updates: updates,
+            max_error_estimate: error,
+            max_krylov_iterations: iterations,
+        } = crate::tdvp(operator, state, center, tdvp_options)
+            .map_err(|source| GseError::Tdvp { source })?;
+        state = evolved;
+        sweeps_completed += completed;
+        local_updates += updates;
+        max_error_estimate = max_error_estimate.max(error);
+        max_krylov_iterations = max_krylov_iterations.max(iterations);
+    }
+
+    Ok(GseTdvpResult {
+        state,
+        sweeps_completed,
+        local_updates,
+        gse_expansions,
+        max_error_estimate,
+        max_krylov_iterations,
+    })
+}
+
+fn validate_options(options: &GseOptions) -> Result<(), GseError> {
+    if !options.density_weight_cutoff.is_finite() || options.density_weight_cutoff < 0.0 {
+        return Err(GseError::InvalidOption {
+            option: "density_weight_cutoff",
+            reason: "must be finite and non-negative".to_string(),
+        });
+    }
+    if !options.hermitian_tol.is_finite() || options.hermitian_tol < 0.0 {
+        return Err(GseError::InvalidOption {
+            option: "hermitian_tol",
+            reason: "must be finite and non-negative".to_string(),
+        });
+    }
+    if let Some(max_rank) = options.reference_max_rank {
+        if max_rank == 0 {
+            return Err(GseError::InvalidOption {
+                option: "reference_max_rank",
+                reason: "must be greater than zero when set".to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn build_references<V>(
+    operator: &LinearOperator<TensorDynLen, V>,
+    init: &TreeTN<TensorDynLen, V>,
+    center: &V,
+    options: &GseOptions,
+) -> Result<Vec<TreeTN<TensorDynLen, V>>, GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    let mut references = Vec::with_capacity(options.krylov_dim);
+    let mut current = init.clone();
+    let generated_reference_max_rank = options
+        .reference_max_rank
+        .unwrap_or_else(|| max_link_dim(init).saturating_add(1));
+    for _ in 0..options.krylov_dim {
+        let mut apply_options = options
+            .reference_apply
+            .clone()
+            .with_max_rank(generated_reference_max_rank);
+        if let Some(policy) = options.reference_svd_policy {
+            apply_options = apply_options.with_svd_policy(policy);
+        }
+        let mut next =
+            apply_linear_operator(operator, &current, apply_options).map_err(|source| {
+                GseError::Algorithm {
+                    context: "GSE failed to apply operator while building references",
+                    source,
+                }
+            })?;
+        if !next.same_topology(init) {
+            return Err(GseError::TopologyMismatch);
+        }
+        validate_reference(init, &next)?;
+        if options.normalize_references {
+            let norm = next.norm().map_err(|source| GseError::Algorithm {
+                context: "GSE failed to compute reference norm",
+                source,
+            })?;
+            if norm > 0.0 {
+                next.scale(AnyScalar::new_real(norm.recip()))
+                    .map_err(|source| GseError::Algorithm {
+                        context: "GSE failed to normalize reference",
+                        source,
+                    })?;
+            }
+        }
+        next = next
+            .canonicalize([center.clone()], CanonicalizationOptions::forced())
+            .map_err(|source| GseError::Algorithm {
+                context: "GSE failed to canonicalize generated reference",
+                source,
+            })?;
+        current = next.clone();
+        references.push(next);
+    }
+    Ok(references)
+}
+
+fn validate_single_site_state<V>(state: &TreeTN<TensorDynLen, V>) -> Result<(), GseError>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    for node in state.node_names() {
+        let count = state.site_space(&node).map_or(0, |space| space.len());
+        if count != 1 {
+            return Err(GseError::UnsupportedStateSiteCount {
+                node: format!("{node:?}"),
+                count,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_reference<V>(
+    target: &TreeTN<TensorDynLen, V>,
+    reference: &TreeTN<TensorDynLen, V>,
+) -> Result<(), GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    validate_single_site_state(reference)?;
+    if !target.same_topology(reference) {
+        return Err(GseError::TopologyMismatch);
+    }
+    for node in target.node_names() {
+        let target_site = single_site_index(target, &node)?;
+        let reference_site = single_site_index(reference, &node)?;
+        if target_site.dim() != reference_site.dim() {
+            return Err(GseError::InvalidMapping {
+                node: format!("{node:?}"),
+                reason: "reference site dimension does not match target".to_string(),
+            });
+        }
+    }
+    let target_scalar = tree_scalar_kind(target)?;
+    let reference_scalar = tree_scalar_kind(reference)?;
+    if target_scalar != reference_scalar {
+        return Err(GseError::ScalarStorageMismatch {
+            target: target_scalar.label(),
+            reference: reference_scalar.label(),
+        });
+    }
+    Ok(())
+}
+
+fn tree_scalar_kind<V>(state: &TreeTN<TensorDynLen, V>) -> Result<ScalarKind, GseError>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    let mut kind: Option<ScalarKind> = None;
+    for node in state.node_names() {
+        let tensor = state
+            .node_index(&node)
+            .and_then(|idx| state.tensor(idx))
+            .ok_or_else(|| GseError::UnsupportedScalarStorage {
+                node: format!("{node:?}"),
+                reason: "missing tensor".to_string(),
+            })?;
+        let node_kind = if tensor.is_f64() {
+            ScalarKind::Real
+        } else if tensor.is_complex() {
+            ScalarKind::Complex
+        } else {
+            return Err(GseError::UnsupportedScalarStorage {
+                node: format!("{node:?}"),
+                reason: "expected f64 or Complex64 tensor storage".to_string(),
+            });
+        };
+        if let Some(previous) = kind {
+            if previous != node_kind {
+                return Err(GseError::UnsupportedScalarStorage {
+                    node: format!("{node:?}"),
+                    reason: format!(
+                        "mixed scalar storage in one TreeTN: expected {}, found {}",
+                        previous.label(),
+                        node_kind.label()
+                    ),
+                });
+            }
+        } else {
+            kind = Some(node_kind);
+        }
+    }
+    kind.ok_or_else(|| GseError::UnsupportedScalarStorage {
+        node: "<empty>".to_string(),
+        reason: "empty TreeTN has no scalar storage".to_string(),
+    })
+}
+
+fn expand_edges_with_scalar<S, V>(
+    state: &mut TreeTN<TensorDynLen, V>,
+    references: &mut [TreeTN<TensorDynLen, V>],
+    center: &V,
+    options: &GseOptions,
+) -> Result<EdgeExpansionStats, GseError>
+where
+    S: GseScalar,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    let edge_order = state
+        .site_index_network()
+        .topology()
+        .edges_to_canonicalize_by_names(center)
+        .ok_or_else(|| GseError::MissingCenter {
+            center: format!("{center:?}"),
+        })?;
+
+    let mut stats = EdgeExpansionStats {
+        edges_processed: 0,
+        bonds_expanded: 0,
+        max_added_basis: 0,
+    };
+    for (child, parent) in edge_order {
+        move_center_to_region_full_rank(state, std::slice::from_ref(&child)).map_err(|source| {
+            GseError::Algorithm {
+                context: "GSE failed to move target center to edge child",
+                source,
+            }
+        })?;
+        for reference in references.iter_mut() {
+            move_center_to_region_full_rank(reference, std::slice::from_ref(&child)).map_err(
+                |source| GseError::Algorithm {
+                    context: "GSE failed to move reference center to edge child",
+                    source,
+                },
+            )?;
+        }
+        let added = expand_one_edge::<S, V>(state, references, &parent, &child, options)?;
+        stats.edges_processed += 1;
+        if added > 0 {
+            stats.bonds_expanded += 1;
+            stats.max_added_basis = stats.max_added_basis.max(added);
+        }
+    }
+    state
+        .set_canonical_region([center.clone()])
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to set final canonical center",
+            source,
+        })?;
+    Ok(stats)
+}
+
+fn expand_one_edge<S, V>(
+    state: &mut TreeTN<TensorDynLen, V>,
+    references: &mut [TreeTN<TensorDynLen, V>],
+    parent: &V,
+    child: &V,
+    options: &GseOptions,
+) -> Result<usize, GseError>
+where
+    S: GseScalar,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
+{
+    let edge = state
+        .edge_between(parent, child)
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE target edge is missing",
+            source: anyhow::anyhow!("missing edge between {:?} and {:?}", parent, child),
+        })?;
+    let old_bond = state
+        .bond_index(edge)
+        .cloned()
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE target edge has no bond index",
+            source: anyhow::anyhow!("missing bond between {:?} and {:?}", parent, child),
+        })?;
+    let child_idx = state
+        .node_index(child)
+        .ok_or_else(|| GseError::MissingCenter {
+            center: format!("{child:?}"),
+        })?;
+    let parent_idx = state
+        .node_index(parent)
+        .ok_or_else(|| GseError::MissingCenter {
+            center: format!("{parent:?}"),
+        })?;
+    let child_tensor = state
+        .tensor(child_idx)
+        .cloned()
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE child tensor is missing",
+            source: anyhow::anyhow!("missing tensor at {:?}", child),
+        })?;
+    let parent_tensor = state
+        .tensor(parent_idx)
+        .cloned()
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE parent tensor is missing",
+            source: anyhow::anyhow!("missing tensor at {:?}", parent),
+        })?;
+    let q_indices = child_tensor
+        .external_indices()
+        .into_iter()
+        .filter(|idx| idx != &old_bond)
+        .collect::<Vec<_>>();
+    let q_dim = product_dim(&q_indices);
+    let old_dim = old_bond.dim();
+
+    let factorized = child_tensor
+        .factorize_full_rank(
+            std::slice::from_ref(&old_bond),
+            FactorizeAlg::SVD,
+            Canonical::Right,
+        )
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to extract old target row basis",
+            source: source.into(),
+        })?;
+    let basis_bond = factorized.bond_index;
+    let basis_rank = basis_bond.dim();
+    let basis_data = tensor_matrix::<S>(&factorized.right, &basis_bond, &q_indices)?;
+    let target_matrix = tensor_matrix::<S>(&child_tensor, &old_bond, &q_indices)?;
+
+    let mut density = vec![<S as GseScalar>::zero(); q_dim * q_dim];
+    for reference in references.iter() {
+        let ref_edge =
+            reference
+                .edge_between(parent, child)
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference edge is missing",
+                    source: anyhow::anyhow!(
+                        "missing reference edge between {:?} and {:?}",
+                        parent,
+                        child
+                    ),
+                })?;
+        let ref_bond =
+            reference
+                .bond_index(ref_edge)
+                .cloned()
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference edge has no bond index",
+                    source: anyhow::anyhow!(
+                        "missing reference bond between {:?} and {:?}",
+                        parent,
+                        child
+                    ),
+                })?;
+        let ref_child_idx = reference
+            .node_index(child)
+            .ok_or_else(|| GseError::MissingCenter {
+                center: format!("{child:?}"),
+            })?;
+        let ref_child_tensor =
+            reference
+                .tensor(ref_child_idx)
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference child tensor is missing",
+                    source: anyhow::anyhow!("missing reference tensor at {:?}", child),
+                })?;
+        let ref_q_indices = map_q_indices(state, reference, child, parent, &q_indices)?;
+        let ref_matrix = tensor_matrix::<S>(ref_child_tensor, &ref_bond, &ref_q_indices)?;
+        accumulate_density::<S>(&mut density, &ref_matrix, ref_bond.dim(), q_dim);
+    }
+
+    let trace = density_trace::<S>(&density, q_dim);
+    let mut added = 0usize;
+    let mut expanded_basis = basis_data.clone();
+    if trace > 0.0 {
+        for value in &mut density {
+            *value = *value / trace;
+        }
+        let mut missing = projected_missing_density::<S>(&density, &basis_data, basis_rank, q_dim);
+        hermitianize_square::<S>(&mut missing, q_dim);
+        let decomp = hermitian_eigendecomposition(
+            &Matrix::from_col_major_vec(q_dim, q_dim, missing),
+            options.hermitian_tol,
+        )
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to diagonalize projected reference density",
+            source: source.into(),
+        })?;
+        let kept = decomp
+            .eigenvalues
+            .iter()
+            .enumerate()
+            .filter_map(|(col, &lambda)| (lambda > options.density_weight_cutoff).then_some(col))
+            .collect::<Vec<_>>();
+        if !kept.is_empty() {
+            let new_rank = basis_rank + kept.len();
+            let mut data = vec![<S as GseScalar>::zero(); new_rank * q_dim];
+            for q in 0..q_dim {
+                for row in 0..basis_rank {
+                    data[row + new_rank * q] = basis_data[row + basis_rank * q];
+                }
+            }
+            let vectors = decomp.eigenvectors.as_col_major_slice();
+            for (offset, &col) in kept.iter().enumerate() {
+                let row = basis_rank + offset;
+                for q in 0..q_dim {
+                    data[row + new_rank * q] = vectors[q + q_dim * col].conj();
+                }
+            }
+            expanded_basis = data;
+            added = kept.len();
+        }
+    }
+
+    let new_dim = basis_rank + added;
+    let new_bond = DynIndex::new_bond(new_dim).map_err(|source| GseError::Algorithm {
+        context: "GSE failed to create expanded target bond index",
+        source: anyhow::anyhow!("{source:?}"),
+    })?;
+    let target_child = TensorDynLen::from_dense(
+        std::iter::once(new_bond.clone())
+            .chain(q_indices.iter().cloned())
+            .collect(),
+        expanded_basis.clone(),
+    )
+    .map_err(|source| GseError::Algorithm {
+        context: "GSE failed to build expanded target child tensor",
+        source,
+    })?;
+    let target_coeff =
+        coefficient_matrix::<S>(&target_matrix, old_dim, q_dim, &expanded_basis, new_dim);
+    let coeff_tensor =
+        TensorDynLen::from_dense(vec![old_bond.clone(), new_bond.clone()], target_coeff).map_err(
+            |source| GseError::Algorithm {
+                context: "GSE failed to build target coefficient tensor",
+                source,
+            },
+        )?;
+    let target_parent =
+        TensorDynLen::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
+            GseError::Algorithm {
+                context: "GSE failed to absorb expanded coefficients into target parent",
+                source,
+            }
+        })?;
+
+    state
+        .replace_edge_bond(edge, new_bond.clone())
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to replace target edge bond",
+            source,
+        })?;
+    state
+        .replace_tensor(child_idx, target_child)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to replace target child tensor",
+            source,
+        })?;
+    state
+        .replace_tensor(parent_idx, target_parent)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to replace target parent tensor",
+            source,
+        })?;
+    state
+        .set_edge_ortho_towards(edge, Some(parent.clone()))
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to set target edge orthogonality direction",
+            source,
+        })?;
+    state
+        .set_canonical_region([parent.clone()])
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to move target canonical metadata after expansion",
+            source,
+        })?;
+
+    for reference in references.iter_mut() {
+        update_reference_edge::<S, V>(
+            reference,
+            state,
+            parent,
+            child,
+            &q_indices,
+            &expanded_basis,
+            new_dim,
+        )?;
+    }
+
+    Ok(added)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update_reference_edge<S, V>(
+    reference: &mut TreeTN<TensorDynLen, V>,
+    target: &TreeTN<TensorDynLen, V>,
+    parent: &V,
+    child: &V,
+    target_q_indices: &[DynIndex],
+    expanded_basis: &[S],
+    new_dim: usize,
+) -> Result<(), GseError>
+where
+    S: GseScalar,
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let edge = reference
+        .edge_between(parent, child)
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE reference edge is missing during update",
+            source: anyhow::anyhow!(
+                "missing reference edge between {:?} and {:?}",
+                parent,
+                child
+            ),
+        })?;
+    let old_bond = reference
+        .bond_index(edge)
+        .cloned()
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE reference edge has no bond index during update",
+            source: anyhow::anyhow!(
+                "missing reference bond between {:?} and {:?}",
+                parent,
+                child
+            ),
+        })?;
+    let child_idx = reference
+        .node_index(child)
+        .ok_or_else(|| GseError::MissingCenter {
+            center: format!("{child:?}"),
+        })?;
+    let parent_idx = reference
+        .node_index(parent)
+        .ok_or_else(|| GseError::MissingCenter {
+            center: format!("{parent:?}"),
+        })?;
+    let child_tensor = reference
+        .tensor(child_idx)
+        .cloned()
+        .ok_or_else(|| GseError::Algorithm {
+            context: "GSE reference child tensor is missing during update",
+            source: anyhow::anyhow!("missing reference tensor at {:?}", child),
+        })?;
+    let parent_tensor =
+        reference
+            .tensor(parent_idx)
+            .cloned()
+            .ok_or_else(|| GseError::Algorithm {
+                context: "GSE reference parent tensor is missing during update",
+                source: anyhow::anyhow!("missing reference tensor at {:?}", parent),
+            })?;
+    let ref_q_indices = map_q_indices(target, reference, child, parent, target_q_indices)?;
+    let q_dim = product_dim(&ref_q_indices);
+    let ref_matrix = tensor_matrix::<S>(&child_tensor, &old_bond, &ref_q_indices)?;
+    let coeff =
+        coefficient_matrix::<S>(&ref_matrix, old_bond.dim(), q_dim, expanded_basis, new_dim);
+    let new_bond = DynIndex::new_bond(new_dim).map_err(|source| GseError::Algorithm {
+        context: "GSE failed to create expanded reference bond index",
+        source: anyhow::anyhow!("{source:?}"),
+    })?;
+    let child_replacement = TensorDynLen::from_dense(
+        std::iter::once(new_bond.clone())
+            .chain(ref_q_indices.iter().cloned())
+            .collect(),
+        expanded_basis.to_vec(),
+    )
+    .map_err(|source| GseError::Algorithm {
+        context: "GSE failed to build expanded reference child tensor",
+        source,
+    })?;
+    let coeff_tensor = TensorDynLen::from_dense(vec![old_bond.clone(), new_bond.clone()], coeff)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to build reference coefficient tensor",
+            source,
+        })?;
+    let parent_replacement =
+        TensorDynLen::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
+            GseError::Algorithm {
+                context: "GSE failed to absorb expanded coefficients into reference parent",
+                source,
+            }
+        })?;
+
+    reference
+        .replace_edge_bond(edge, new_bond)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to replace reference edge bond",
+            source,
+        })?;
+    reference
+        .replace_tensor(child_idx, child_replacement)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to replace reference child tensor",
+            source,
+        })?;
+    reference
+        .replace_tensor(parent_idx, parent_replacement)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to replace reference parent tensor",
+            source,
+        })?;
+    reference
+        .set_edge_ortho_towards(edge, Some(parent.clone()))
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to set reference edge orthogonality direction",
+            source,
+        })?;
+    reference
+        .set_canonical_region([parent.clone()])
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to move reference canonical metadata after expansion",
+            source,
+        })?;
+    Ok(())
+}
+
+fn tensor_matrix<S>(
+    tensor: &TensorDynLen,
+    row_index: &DynIndex,
+    column_indices: &[DynIndex],
+) -> Result<Vec<S>, GseError>
+where
+    S: GseScalar,
+{
+    let ordered = std::iter::once(row_index.clone())
+        .chain(column_indices.iter().cloned())
+        .collect::<Vec<_>>();
+    let permuted = tensor
+        .permuteinds(&ordered)
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to align local tensor matrix indices",
+            source,
+        })?;
+    permuted
+        .to_vec::<S>()
+        .map_err(|source| GseError::Algorithm {
+            context: "GSE failed to read local tensor matrix values",
+            source,
+        })
+}
+
+fn accumulate_density<S>(density: &mut [S], matrix: &[S], row_dim: usize, q_dim: usize)
+where
+    S: GseScalar,
+{
+    for x in 0..q_dim {
+        for y in 0..q_dim {
+            let mut sum = <S as GseScalar>::zero();
+            for row in 0..row_dim {
+                sum += matrix[row + row_dim * x].conj() * matrix[row + row_dim * y];
+            }
+            density[x + q_dim * y] += sum;
+        }
+    }
+}
+
+fn density_trace<S>(density: &[S], q_dim: usize) -> f64
+where
+    S: GseScalar,
+{
+    (0..q_dim)
+        .map(|i| density[i + q_dim * i].real())
+        .sum::<f64>()
+}
+
+fn projected_missing_density<S>(density: &[S], basis: &[S], rank: usize, q_dim: usize) -> Vec<S>
+where
+    S: GseScalar,
+{
+    let mut projector = vec![<S as GseScalar>::zero(); q_dim * q_dim];
+    for x in 0..q_dim {
+        for y in 0..q_dim {
+            let mut represented = <S as GseScalar>::zero();
+            for row in 0..rank {
+                represented += basis[row + rank * x].conj() * basis[row + rank * y];
+            }
+            projector[x + q_dim * y] = if x == y {
+                <S as GseScalar>::one() - represented
+            } else {
+                <S as GseScalar>::zero() - represented
+            };
+        }
+    }
+    let tmp = matmul_square::<S>(&projector, density, q_dim);
+    matmul_square::<S>(&tmp, &projector, q_dim)
+}
+
+fn matmul_square<S>(lhs: &[S], rhs: &[S], n: usize) -> Vec<S>
+where
+    S: GseScalar,
+{
+    let mut out = vec![<S as GseScalar>::zero(); n * n];
+    for col in 0..n {
+        for row in 0..n {
+            let mut sum = <S as GseScalar>::zero();
+            for k in 0..n {
+                sum += lhs[row + n * k] * rhs[k + n * col];
+            }
+            out[row + n * col] = sum;
+        }
+    }
+    out
+}
+
+fn hermitianize_square<S>(matrix: &mut [S], n: usize)
+where
+    S: GseScalar,
+{
+    for col in 0..n {
+        for row in 0..=col {
+            let ij = row + n * col;
+            let ji = col + n * row;
+            if row == col {
+                matrix[ij] = (matrix[ij] + matrix[ij].conj()) / 2.0;
+            } else {
+                let avg = (matrix[ij] + matrix[ji].conj()) / 2.0;
+                matrix[ij] = avg;
+                matrix[ji] = avg.conj();
+            }
+        }
+    }
+}
+
+fn coefficient_matrix<S>(
+    matrix: &[S],
+    row_dim: usize,
+    q_dim: usize,
+    basis: &[S],
+    basis_dim: usize,
+) -> Vec<S>
+where
+    S: GseScalar,
+{
+    let mut coeff = vec![<S as GseScalar>::zero(); row_dim * basis_dim];
+    for ell in 0..basis_dim {
+        for row in 0..row_dim {
+            let mut sum = <S as GseScalar>::zero();
+            for q in 0..q_dim {
+                sum += matrix[row + row_dim * q] * basis[ell + basis_dim * q].conj();
+            }
+            coeff[row + row_dim * ell] = sum;
+        }
+    }
+    coeff
+}
+
+fn map_q_indices<V>(
+    target: &TreeTN<TensorDynLen, V>,
+    reference: &TreeTN<TensorDynLen, V>,
+    child: &V,
+    parent: &V,
+    target_q_indices: &[DynIndex],
+) -> Result<Vec<DynIndex>, GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let target_site = single_site_index(target, child)?;
+    let reference_site = single_site_index(reference, child)?;
+    let mut mapped = Vec::with_capacity(target_q_indices.len());
+    for target_index in target_q_indices {
+        if target_index == &target_site {
+            mapped.push(reference_site.clone());
+            continue;
+        }
+        let neighbor =
+            neighbor_for_bond(target, child, target_index)?.ok_or_else(|| GseError::Algorithm {
+                context: "GSE failed to map target q bond to reference",
+                source: anyhow::anyhow!(
+                    "index {:?} at child {:?} is neither site nor bond",
+                    target_index,
+                    child
+                ),
+            })?;
+        if &neighbor == parent {
+            return Err(GseError::Algorithm {
+                context: "GSE parent bond cannot appear in q index map",
+                source: anyhow::anyhow!("parent bond was included in q for child {:?}", child),
+            });
+        }
+        let ref_edge =
+            reference
+                .edge_between(child, &neighbor)
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference topology is missing q edge",
+                    source: anyhow::anyhow!(
+                        "missing reference edge between {:?} and {:?}",
+                        child,
+                        neighbor
+                    ),
+                })?;
+        let ref_bond =
+            reference
+                .bond_index(ref_edge)
+                .cloned()
+                .ok_or_else(|| GseError::Algorithm {
+                    context: "GSE reference q edge has no bond",
+                    source: anyhow::anyhow!(
+                        "missing reference bond between {:?} and {:?}",
+                        child,
+                        neighbor
+                    ),
+                })?;
+        if ref_bond.dim() != target_index.dim() {
+            return Err(GseError::InvalidMapping {
+                node: format!("{child:?}"),
+                reason: "reference child-side bond dimension does not match target".to_string(),
+            });
+        }
+        mapped.push(ref_bond);
+    }
+    Ok(mapped)
+}
+
+fn neighbor_for_bond<V>(
+    state: &TreeTN<TensorDynLen, V>,
+    node: &V,
+    bond: &DynIndex,
+) -> Result<Option<V>, GseError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    for neighbor in state.site_index_network().neighbors(node) {
+        let Some(edge) = state.edge_between(node, &neighbor) else {
+            continue;
+        };
+        if state.bond_index(edge) == Some(bond) {
+            return Ok(Some(neighbor));
+        }
+    }
+    Ok(None)
+}
+
+fn single_site_index<V>(state: &TreeTN<TensorDynLen, V>, node: &V) -> Result<DynIndex, GseError>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    let site_space = state
+        .site_space(node)
+        .ok_or_else(|| GseError::UnsupportedStateSiteCount {
+            node: format!("{node:?}"),
+            count: 0,
+        })?;
+    if site_space.len() != 1 {
+        return Err(GseError::UnsupportedStateSiteCount {
+            node: format!("{node:?}"),
+            count: site_space.len(),
+        });
+    }
+    site_space
+        .iter()
+        .next()
+        .cloned()
+        .ok_or_else(|| GseError::UnsupportedStateSiteCount {
+            node: format!("{node:?}"),
+            count: 0,
+        })
+}
+
+fn product_dim(indices: &[DynIndex]) -> usize {
+    indices.iter().map(DynIndex::dim).product()
+}
+
+fn max_link_dim<V>(state: &TreeTN<TensorDynLen, V>) -> usize
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    state.link_dims().into_iter().max().unwrap_or(1)
+}
+
+fn move_center_to_region_full_rank<V>(
+    state: &mut TreeTN<TensorDynLen, V>,
+    region: &[V],
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if region.is_empty() {
+        return Err(anyhow::anyhow!("GSE cannot move center to an empty region"));
+    }
+    let current = state.canonical_region();
+    if current.is_empty() {
+        return Err(anyhow::anyhow!("GSE state is not canonicalized"));
+    }
+    if region.iter().any(|node| current.contains(node)) {
+        return Ok(());
+    }
+
+    let (path, target) = {
+        let topology = state.site_index_network().topology();
+        let mut best_path = None;
+        for src in current {
+            let Some(src_idx) = topology.node_index(src) else {
+                continue;
+            };
+            for dst in region {
+                let Some(dst_idx) = topology.node_index(dst) else {
+                    continue;
+                };
+                let Some(path) = topology.path_between(src_idx, dst_idx) else {
+                    continue;
+                };
+                if best_path
+                    .as_ref()
+                    .is_none_or(|best: &Vec<_>| path.len() < best.len())
+                {
+                    best_path = Some(path);
+                }
+            }
+        }
+        let path = best_path.ok_or_else(|| {
+            anyhow::anyhow!(
+                "GSE could not find a path from canonical region {:?} to {:?}",
+                current,
+                region
+            )
+        })?;
+        let target = path
+            .last()
+            .and_then(|idx| topology.node_name(*idx))
+            .ok_or_else(|| anyhow::anyhow!("GSE center path ended at an unknown node"))?
+            .clone();
+        (path, target)
+    };
+    for pair in path.windows(2) {
+        let src = pair[0];
+        let dst = pair[1];
+        state.sweep_edge_full_rank(
+            src,
+            dst,
+            FactorizeAlg::QR,
+            Canonical::Left,
+            "GSE path-only center move",
+        )?;
+    }
+    state.set_canonical_region([target])?;
+    Ok(())
+}

--- a/crates/tensor4all-treetn/src/gse.rs
+++ b/crates/tensor4all-treetn/src/gse.rs
@@ -218,24 +218,6 @@ pub enum GseError {
         /// Why the mapping is invalid.
         reason: String,
     },
-    /// The v1 implementation supports uniform f64 or Complex64 storage.
-    #[error("GSE v1 unsupported scalar storage at node {node}: {reason}")]
-    UnsupportedScalarStorage {
-        /// Debug representation of the node.
-        node: String,
-        /// Why scalar storage is unsupported.
-        reason: String,
-    },
-    /// Target and reference states must use the same scalar storage.
-    #[error(
-        "GSE v1 requires target and reference tensors to have the same scalar storage; target is {target}, reference is {reference}"
-    )]
-    ScalarStorageMismatch {
-        /// Target scalar storage label.
-        target: &'static str,
-        /// Reference scalar storage label.
-        reference: &'static str,
-    },
     /// Existing TDVP failed after GSE.
     #[error("GSE-TDVP TDVP step failed: {source}")]
     Tdvp {
@@ -278,21 +260,6 @@ struct EdgeExpansionStats {
     edges_processed: usize,
     bonds_expanded: usize,
     max_added_basis: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ScalarKind {
-    Real,
-    Complex,
-}
-
-impl ScalarKind {
-    fn label(self) -> &'static str {
-        match self {
-            Self::Real => "f64",
-            Self::Complex => "Complex64",
-        }
-    }
 }
 
 /// Build Krylov references from `operator`, expand the TreeTN state, and return
@@ -342,7 +309,6 @@ where
         });
     }
     validate_single_site_state(&init)?;
-    let target_scalar = tree_scalar_kind(&init)?;
 
     let references_built = references.len();
     let mut state = init
@@ -355,13 +321,6 @@ where
     let mut reference_buffers = Vec::with_capacity(references.len());
     for reference in references {
         validate_reference(&state, &reference)?;
-        let reference_scalar = tree_scalar_kind(&reference)?;
-        if reference_scalar != target_scalar {
-            return Err(GseError::ScalarStorageMismatch {
-                target: target_scalar.label(),
-                reference: reference_scalar.label(),
-            });
-        }
         let mut reference = reference
             .canonicalize([center.clone()], CanonicalizationOptions::forced())
             .map_err(|source| GseError::Algorithm {
@@ -568,59 +527,7 @@ where
             });
         }
     }
-    let target_scalar = tree_scalar_kind(target)?;
-    let reference_scalar = tree_scalar_kind(reference)?;
-    if target_scalar != reference_scalar {
-        return Err(GseError::ScalarStorageMismatch {
-            target: target_scalar.label(),
-            reference: reference_scalar.label(),
-        });
-    }
     Ok(())
-}
-
-fn tree_scalar_kind<V>(state: &TreeTN<TensorDynLen, V>) -> Result<ScalarKind, GseError>
-where
-    V: Clone + Hash + Eq + Send + Sync + Debug,
-{
-    let mut kind: Option<ScalarKind> = None;
-    for node in state.node_names() {
-        let tensor = state
-            .node_index(&node)
-            .and_then(|idx| state.tensor(idx))
-            .ok_or_else(|| GseError::UnsupportedScalarStorage {
-                node: format!("{node:?}"),
-                reason: "missing tensor".to_string(),
-            })?;
-        let node_kind = if tensor.is_f64() {
-            ScalarKind::Real
-        } else if tensor.is_complex() {
-            ScalarKind::Complex
-        } else {
-            return Err(GseError::UnsupportedScalarStorage {
-                node: format!("{node:?}"),
-                reason: "expected f64 or Complex64 tensor storage".to_string(),
-            });
-        };
-        if let Some(previous) = kind {
-            if previous != node_kind {
-                return Err(GseError::UnsupportedScalarStorage {
-                    node: format!("{node:?}"),
-                    reason: format!(
-                        "mixed scalar storage in one TreeTN: expected {}, found {}",
-                        previous.label(),
-                        node_kind.label()
-                    ),
-                });
-            }
-        } else {
-            kind = Some(node_kind);
-        }
-    }
-    kind.ok_or_else(|| GseError::UnsupportedScalarStorage {
-        node: "<empty>".to_string(),
-        reason: "empty TreeTN has no scalar storage".to_string(),
-    })
 }
 
 fn expand_edges<V>(

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -24,6 +24,7 @@ pub mod algorithm;
 // TreeTN uses the `T: TensorLike` pattern, making a separate dyn wrapper unnecessary.
 pub mod dmrg;
 pub mod error;
+pub mod gse;
 pub mod link_index_network;
 pub mod linsolve;
 mod local_update_support;
@@ -42,6 +43,10 @@ pub use dmrg::{dmrg, dmrg_with_treetn_operator, DmrgError, DmrgOptions, DmrgResu
 pub use error::{
     LinearOperatorIndexApplyError, LinearOperatorIndexBindingError, LinearOperatorTaggedApplyError,
     NumberedTagSelectionError, SelectedIndexContractionError,
+};
+pub use gse::{
+    global_subspace_expand, global_subspace_expand_with_references, gse_tdvp, GseError, GseOptions,
+    GseResult, GseTdvpOptions, GseTdvpResult,
 };
 pub use treetn::contraction;
 

--- a/crates/tensor4all-treetn/tests/gse.rs
+++ b/crates/tensor4all-treetn/tests/gse.rs
@@ -296,6 +296,17 @@ fn edge_dim(state: &TreeTN<TensorDynLen, &'static str>, a: &str, b: &str) -> usi
     state.bond_index(edge).unwrap().dim()
 }
 
+fn enable_grad_all(
+    mut state: TreeTN<TensorDynLen, &'static str>,
+) -> TreeTN<TensorDynLen, &'static str> {
+    let nodes = state.node_indices().to_vec();
+    for node in nodes {
+        let tensor = state.tensor(node).unwrap().clone().enable_grad().unwrap();
+        state.replace_tensor(node, tensor).unwrap();
+    }
+    state
+}
+
 fn local_basis_matrix(
     state: &TreeTN<TensorDynLen, &'static str>,
     parent: &str,
@@ -566,6 +577,37 @@ fn global_subspace_expand_preserves_complex_phase_state() {
     assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
     assert!(dense_distance(&result.state, &state) < 1.0e-10);
     assert!(result.state.canonical_region().contains(&"site1"));
+}
+
+#[test]
+fn global_subspace_expand_preserves_ad_tracking_through_local_density_path() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_chain_state([[one, zero], [one, zero]]);
+    let (reference, _) = product_chain_state([[one, zero], [zero, one]]);
+
+    let result = global_subspace_expand_with_references(
+        enable_grad_all(state),
+        vec![enable_grad_all(reference)],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert!(result.state.node_indices().iter().all(|&node| result
+        .state
+        .tensor(node)
+        .unwrap()
+        .tracks_grad()));
+
+    let loss = result.state.contract_to_tensor().unwrap().sum().unwrap();
+    loss.backward().unwrap();
+    for node in result.state.node_indices() {
+        assert!(
+            result.state.tensor(node).unwrap().grad().unwrap().is_some(),
+            "expanded node {node:?} lost gradient tracking"
+        );
+    }
 }
 
 #[test]

--- a/crates/tensor4all-treetn/tests/gse.rs
+++ b/crates/tensor4all-treetn/tests/gse.rs
@@ -1,0 +1,589 @@
+use std::collections::HashMap;
+
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, IndexLike, TensorContractionLike, TensorDynLen};
+use tensor4all_treetn::{
+    global_subspace_expand, global_subspace_expand_with_references, gse_tdvp, GseError, GseOptions,
+    GseTdvpOptions, IndexMapping, LinearOperator, TdvpOptions, TreeTN,
+};
+
+fn product_chain_state(
+    amplitudes: [[Complex64; 2]; 2],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), bond.clone()],
+        vec![amplitudes[0][0], amplitudes[0][1]],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![bond.clone(), s1.clone()],
+        vec![amplitudes[1][0], amplitudes[1][1]],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    state.connect(n0, &bond, n1, &bond).unwrap();
+    (state, [s0, s1])
+}
+
+fn product_chain_state_f64(
+    amplitudes: [[f64; 2]; 2],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), bond.clone()],
+        vec![amplitudes[0][0], amplitudes[0][1]],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![bond.clone(), s1.clone()],
+        vec![amplitudes[1][0], amplitudes[1][1]],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    state.connect(n0, &bond, n1, &bond).unwrap();
+    (state, [s0, s1])
+}
+
+fn product_chain3_state(
+    amplitudes: [[Complex64; 2]; 3],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(1);
+    let b12 = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), b01.clone()],
+        vec![amplitudes[0][0], amplitudes[0][1]],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![b01.clone(), s1.clone(), b12.clone()],
+        vec![amplitudes[1][0], amplitudes[1][1]],
+    )
+    .unwrap();
+    let t2 = TensorDynLen::from_dense(
+        vec![b12.clone(), s2.clone()],
+        vec![amplitudes[2][0], amplitudes[2][1]],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    let n2 = state.add_tensor("site2", t2).unwrap();
+    state.connect(n0, &b01, n1, &b01).unwrap();
+    state.connect(n1, &b12, n2, &b12).unwrap();
+    (state, [s0, s1, s2])
+}
+
+fn product_star_state(
+    amplitudes: [[Complex64; 2]; 3],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(1);
+    let b02 = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), b01.clone(), b02.clone()],
+        vec![amplitudes[0][0], amplitudes[0][1]],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![b01.clone(), s1.clone()],
+        vec![amplitudes[1][0], amplitudes[1][1]],
+    )
+    .unwrap();
+    let t2 = TensorDynLen::from_dense(
+        vec![b02.clone(), s2.clone()],
+        vec![amplitudes[2][0], amplitudes[2][1]],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    let n2 = state.add_tensor("site2", t2).unwrap();
+    state.connect(n0, &b01, n1, &b01).unwrap();
+    state.connect(n0, &b02, n2, &b02).unwrap();
+    (state, [s0, s1, s2])
+}
+
+fn product_internal_branch_state(
+    amplitudes: [[Complex64; 2]; 4],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 4]) {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let s3 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(1);
+    let b12 = DynIndex::new_dyn(1);
+    let b13 = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![s0.clone(), b01.clone()],
+        vec![amplitudes[0][0], amplitudes[0][1]],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![b01.clone(), s1.clone(), b12.clone(), b13.clone()],
+        vec![amplitudes[1][0], amplitudes[1][1]],
+    )
+    .unwrap();
+    let t2 = TensorDynLen::from_dense(
+        vec![b12.clone(), s2.clone()],
+        vec![amplitudes[2][0], amplitudes[2][1]],
+    )
+    .unwrap();
+    let t3 = TensorDynLen::from_dense(
+        vec![b13.clone(), s3.clone()],
+        vec![amplitudes[3][0], amplitudes[3][1]],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    let n2 = state.add_tensor("site2", t2).unwrap();
+    let n3 = state.add_tensor("site3", t3).unwrap();
+    state.connect(n0, &b01, n1, &b01).unwrap();
+    state.connect(n1, &b12, n2, &b12).unwrap();
+    state.connect(n1, &b13, n3, &b13).unwrap();
+    (state, [s0, s1, s2, s3])
+}
+
+fn identity_or_x_operator(
+    state_sites: &[DynIndex],
+    node_names: &[&'static str],
+    edges: &[(&'static str, &'static str)],
+    x_nodes: &[&'static str],
+) -> LinearOperator<TensorDynLen, &'static str> {
+    let mut node_indices = HashMap::new();
+    let mut input_mapping = HashMap::new();
+    let mut output_mapping = HashMap::new();
+    let mut op_bonds = HashMap::new();
+
+    for &(a, b) in edges {
+        op_bonds.insert((a, b), DynIndex::new_dyn(1));
+    }
+
+    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    for (i, &name) in node_names.iter().enumerate() {
+        let input = DynIndex::new_dyn(2);
+        let output = DynIndex::new_dyn(2);
+        input_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: input.clone(),
+            },
+        );
+        output_mapping.insert(
+            name,
+            IndexMapping {
+                true_index: state_sites[i].clone(),
+                internal_index: output.clone(),
+            },
+        );
+
+        let mut inds = Vec::new();
+        for &(a, b) in edges {
+            if a == name || b == name {
+                inds.push(op_bonds.get(&(a, b)).unwrap().clone());
+            }
+        }
+        inds.push(output.clone());
+        inds.push(input.clone());
+        let dims: Vec<_> = inds.iter().map(DynIndex::dim).collect();
+        let mut data = vec![Complex64::new(0.0, 0.0); dims.iter().product()];
+        let output_pos = inds.len() - 2;
+        let input_pos = inds.len() - 1;
+        for input_bit in 0..2 {
+            let output_bit = if x_nodes.contains(&name) {
+                1 - input_bit
+            } else {
+                input_bit
+            };
+            let mut coord = vec![0; inds.len()];
+            coord[output_pos] = output_bit;
+            coord[input_pos] = input_bit;
+            data[col_major_offset(&coord, &dims)] = Complex64::new(1.0, 0.0);
+        }
+        let node = mpo
+            .add_tensor(name, TensorDynLen::from_dense(inds, data).unwrap())
+            .unwrap();
+        node_indices.insert(name, node);
+    }
+
+    for &(a, b) in edges {
+        let bond = op_bonds.get(&(a, b)).unwrap();
+        mpo.connect(
+            *node_indices.get(a).unwrap(),
+            bond,
+            *node_indices.get(b).unwrap(),
+            bond,
+        )
+        .unwrap();
+    }
+
+    LinearOperator::new(mpo, input_mapping, output_mapping)
+}
+
+fn col_major_offset(coord: &[usize], dims: &[usize]) -> usize {
+    let mut offset = 0usize;
+    let mut stride = 1usize;
+    for (&value, &dim) in coord.iter().zip(dims) {
+        offset += value * stride;
+        stride *= dim;
+    }
+    offset
+}
+
+fn dense_distance(
+    lhs: &TreeTN<TensorDynLen, &'static str>,
+    rhs: &TreeTN<TensorDynLen, &'static str>,
+) -> f64 {
+    lhs.contract_to_tensor()
+        .unwrap()
+        .distance(&rhs.contract_to_tensor().unwrap())
+        .unwrap()
+}
+
+fn edge_dim(state: &TreeTN<TensorDynLen, &'static str>, a: &str, b: &str) -> usize {
+    let edge = state.edge_between(&a, &b).unwrap();
+    state.bond_index(edge).unwrap().dim()
+}
+
+#[test]
+fn global_subspace_expand_preserves_state_and_grows_chain_bond() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, sites) = product_chain_state([[one, zero], [one, zero]]);
+    let (reference, _) = product_chain_state([[one, zero], [zero, one]]);
+    let initial_bond_dim = edge_dim(&state, "site0", "site1");
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.references_built, 1);
+    assert_eq!(result.edges_processed, 1);
+    assert!(result.bonds_expanded >= 1);
+    assert_eq!(
+        edge_dim(&result.state, "site0", "site1"),
+        initial_bond_dim + 1
+    );
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+    assert!(result.state.canonical_region().contains(&"site0"));
+
+    let edge = result.state.edge_between(&"site0", &"site1").unwrap();
+    let bond = result.state.bond_index(edge).unwrap().clone();
+    let child = result
+        .state
+        .tensor(result.state.node_index(&"site1").unwrap())
+        .unwrap();
+    let child_basis = child.permuteinds(&[bond, sites[1].clone()]).unwrap();
+    let child_basis_data = child_basis.to_vec::<Complex64>().unwrap();
+    let missing_site_direction_norm =
+        child_basis_data[2].norm_sqr() + child_basis_data[3].norm_sqr();
+    assert!(missing_site_direction_norm > 1.0 - 1.0e-10);
+}
+
+#[test]
+fn global_subspace_expand_supports_real_tensors() {
+    let (state, _) = product_chain_state_f64([[1.0, 0.0], [1.0, 0.0]]);
+    let (reference, _) = product_chain_state_f64([[1.0, 0.0], [0.0, 1.0]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+}
+
+#[test]
+fn global_subspace_expand_maps_processed_child_bond_in_chain_q_space() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_chain3_state([[one, zero], [one, zero], [one, zero]]);
+    let (ref_tail, _) = product_chain3_state([[one, zero], [one, zero], [zero, one]]);
+    let (ref_middle_tail, _) = product_chain3_state([[one, zero], [zero, one], [zero, one]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![ref_tail, ref_middle_tail],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.edges_processed, 2);
+    assert!(result.bonds_expanded >= 2);
+    assert_eq!(edge_dim(&result.state, "site1", "site2"), 2);
+    assert!(edge_dim(&result.state, "site0", "site1") >= 2);
+    assert!(result.state.same_topology(&state));
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+    assert!(result.state.canonical_region().contains(&"site0"));
+}
+
+#[test]
+fn global_subspace_expand_handles_branching_tree() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_star_state([[one, zero], [one, zero], [one, zero]]);
+    let (ref_leaf1, _) = product_star_state([[one, zero], [zero, one], [one, zero]]);
+    let (ref_leaf2, _) = product_star_state([[one, zero], [one, zero], [zero, one]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![ref_leaf1, ref_leaf2],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.edges_processed, 2);
+    assert!(result.bonds_expanded >= 2);
+    assert!(result.state.same_topology(&state));
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert_eq!(edge_dim(&result.state, "site0", "site2"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+    assert!(result.state.canonical_region().contains(&"site0"));
+}
+
+#[test]
+fn global_subspace_expand_maps_two_processed_child_bonds_at_internal_node() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) =
+        product_internal_branch_state([[one, zero], [one, zero], [one, zero], [one, zero]]);
+    let (ref_leaf2, _) =
+        product_internal_branch_state([[one, zero], [one, zero], [zero, one], [one, zero]]);
+    let (ref_leaf3, _) =
+        product_internal_branch_state([[one, zero], [one, zero], [one, zero], [zero, one]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![ref_leaf2, ref_leaf3],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.edges_processed, 3);
+    assert!(result.bonds_expanded >= 3);
+    assert_eq!(edge_dim(&result.state, "site1", "site2"), 2);
+    assert_eq!(edge_dim(&result.state, "site1", "site3"), 2);
+    assert!(edge_dim(&result.state, "site0", "site1") >= 2);
+    assert!(result.state.same_topology(&state));
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+    assert!(result.state.canonical_region().contains(&"site0"));
+}
+
+#[test]
+fn global_subspace_expand_builds_operator_references() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, sites) = product_chain_state([[one, zero], [one, zero]]);
+    let operator = identity_or_x_operator(
+        &sites,
+        &["site0", "site1"],
+        &[("site0", "site1")],
+        &["site1"],
+    );
+
+    let result = global_subspace_expand(
+        &operator,
+        state.clone(),
+        &"site0",
+        GseOptions::default()
+            .with_krylov_dim(1)
+            .with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.references_built, 1);
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+}
+
+#[test]
+fn global_subspace_expand_preserves_complex_phase_state() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let inv_sqrt2 = 0.5_f64.sqrt();
+    let plus_i = Complex64::new(0.0, inv_sqrt2);
+    let minus_i = Complex64::new(0.0, -inv_sqrt2);
+    let (state, _) = product_chain_state([[Complex64::new(inv_sqrt2, 0.0), plus_i], [one, zero]]);
+    let (reference, _) =
+        product_chain_state([[Complex64::new(inv_sqrt2, 0.0), minus_i], [one, zero]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site1",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+    assert!(result.state.canonical_region().contains(&"site1"));
+}
+
+#[test]
+fn global_subspace_expand_respects_density_weight_cutoff_without_dropping_target() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_chain_state([[one, zero], [one, zero]]);
+    let (reference, _) = product_chain_state([[one, zero], [zero, one]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(2.0),
+    )
+    .unwrap();
+
+    assert_eq!(result.bonds_expanded, 0);
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 1);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+}
+
+#[test]
+fn global_subspace_expand_builds_multiple_krylov_references() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, sites) = product_chain_state([[one, zero], [one, zero]]);
+    let operator = identity_or_x_operator(
+        &sites,
+        &["site0", "site1"],
+        &[("site0", "site1")],
+        &["site1"],
+    );
+
+    let result = global_subspace_expand(
+        &operator,
+        state.clone(),
+        &"site0",
+        GseOptions::default()
+            .with_krylov_dim(2)
+            .with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.references_built, 2);
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+}
+
+#[test]
+fn gse_tdvp_runs_existing_tdvp_after_expansion() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, sites) = product_chain_state([[one, zero], [one, zero]]);
+    let operator = identity_or_x_operator(
+        &sites,
+        &["site0", "site1"],
+        &[("site0", "site1")],
+        &["site1"],
+    );
+
+    let result = gse_tdvp(
+        &operator,
+        state,
+        &"site0",
+        GseTdvpOptions {
+            gse: GseOptions::default()
+                .with_krylov_dim(1)
+                .with_density_weight_cutoff(1.0e-14),
+            tdvp: TdvpOptions::default()
+                .with_nsite(1)
+                .with_nsweeps(1)
+                .with_exponent_step(Complex64::new(0.0, -0.01)),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.gse_expansions, 1);
+    assert_eq!(result.sweeps_completed, 1);
+    assert!(result.local_updates > 0);
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+}
+
+#[test]
+fn gse_rejects_multiple_state_sites_per_node() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let tensor = TensorDynLen::from_dense(vec![s0, s1], vec![Complex64::new(0.0, 0.0); 4]).unwrap();
+    let state =
+        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
+
+    let err =
+        global_subspace_expand_with_references(state, Vec::new(), &"site0", GseOptions::default())
+            .unwrap_err();
+
+    assert!(matches!(
+        err,
+        GseError::UnsupportedStateSiteCount { node, count }
+            if node == "\"site0\"" && count == 2
+    ));
+}
+
+#[test]
+fn gse_rejects_reference_topology_mismatch() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_chain_state([[one, zero], [one, zero]]);
+    let (reference, _) = product_star_state([[one, zero], [one, zero], [one, zero]]);
+
+    let err = global_subspace_expand_with_references(
+        state,
+        vec![reference],
+        &"site0",
+        GseOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(err, GseError::TopologyMismatch));
+}
+
+#[test]
+fn gse_rejects_scalar_storage_mismatch() {
+    let (state, _) = product_chain_state_f64([[1.0, 0.0], [1.0, 0.0]]);
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (reference, _) = product_chain_state([[one, zero], [zero, one]]);
+
+    let err = global_subspace_expand_with_references(
+        state,
+        vec![reference],
+        &"site0",
+        GseOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        GseError::ScalarStorageMismatch {
+            target: "f64",
+            reference: "Complex64"
+        }
+    ));
+}

--- a/crates/tensor4all-treetn/tests/gse.rs
+++ b/crates/tensor4all-treetn/tests/gse.rs
@@ -53,6 +53,24 @@ fn product_chain_state_f64(
     (state, [s0, s1])
 }
 
+fn product_chain_state_from_vectors(
+    left_amplitudes: &[Complex64],
+    right_amplitudes: &[Complex64],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+    let s0 = DynIndex::new_dyn(left_amplitudes.len());
+    let s1 = DynIndex::new_dyn(right_amplitudes.len());
+    let bond = DynIndex::new_dyn(1);
+    let t0 =
+        TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], left_amplitudes.to_vec()).unwrap();
+    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], right_amplitudes.to_vec())
+        .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    state.connect(n0, &bond, n1, &bond).unwrap();
+    (state, [s0, s1])
+}
+
 fn product_chain3_state(
     amplitudes: [[Complex64; 2]; 3],
 ) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
@@ -580,6 +598,44 @@ fn global_subspace_expand_preserves_complex_phase_state() {
 }
 
 #[test]
+fn global_subspace_expand_preserves_complex_reference_direction_in_larger_q_space() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let inv_sqrt2 = 0.5_f64.sqrt();
+    let target_left = vec![one, zero, zero, zero];
+    let reference_left = vec![
+        zero,
+        Complex64::new(inv_sqrt2, 0.0),
+        Complex64::new(0.0, inv_sqrt2),
+        zero,
+    ];
+    let right = vec![one, zero];
+    let (state, sites) = product_chain_state_from_vectors(&target_left, &right);
+    let (reference, _) = product_chain_state_from_vectors(&reference_left, &right);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site1",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+
+    let (row_dim, q_dim, basis) =
+        local_basis_matrix(&result.state, "site1", "site0", &[sites[0].clone()]);
+    assert_eq!(row_dim, 2);
+    assert_eq!(q_dim, 4);
+    assert_rows_are_isometric(row_dim, q_dim, &basis);
+    assert!(
+        projected_weight(row_dim, q_dim, &basis, &reference_left) > 1.0 - 1.0e-10,
+        "expanded basis failed to preserve the complex reference direction"
+    );
+}
+
+#[test]
 fn global_subspace_expand_preserves_ad_tracking_through_local_density_path() {
     let zero = Complex64::new(0.0, 0.0);
     let one = Complex64::new(1.0, 0.0);
@@ -854,37 +910,32 @@ fn gse_rejects_reference_topology_mismatch() {
 }
 
 #[test]
-fn gse_rejects_scalar_storage_mismatch() {
+fn global_subspace_expand_accepts_complex_reference_for_real_target() {
     let (state, _) = product_chain_state_f64([[1.0, 0.0], [1.0, 0.0]]);
     let zero = Complex64::new(0.0, 0.0);
     let one = Complex64::new(1.0, 0.0);
     let (reference, _) = product_chain_state([[one, zero], [zero, one]]);
 
-    let err = global_subspace_expand_with_references(
-        state,
+    let result = global_subspace_expand_with_references(
+        state.clone(),
         vec![reference],
         &"site0",
-        GseOptions::default(),
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
     )
-    .unwrap_err();
+    .unwrap();
 
-    assert!(matches!(
-        err,
-        GseError::ScalarStorageMismatch {
-            target: "f64",
-            reference: "Complex64"
-        }
-    ));
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
 }
 
 #[test]
-fn gse_rejects_mixed_scalar_storage_inside_target_tree() {
+fn global_subspace_expand_accepts_mixed_scalar_storage_inside_target_tree() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0_f64, 0.0]).unwrap();
+    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0_f64, 0.0]).unwrap();
     let t1 = TensorDynLen::from_dense(
-        vec![bond.clone(), s1],
+        vec![bond.clone(), s1.clone()],
         vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
     )
     .unwrap();
@@ -892,14 +943,18 @@ fn gse_rejects_mixed_scalar_storage_inside_target_tree() {
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (reference, _) = product_chain_state([[one, zero], [zero, one]]);
 
-    let err =
-        global_subspace_expand_with_references(state, Vec::new(), &"site0", GseOptions::default())
-            .unwrap_err();
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
 
-    assert!(matches!(
-        err,
-        GseError::UnsupportedScalarStorage { reason, .. }
-            if reason.contains("mixed scalar storage")
-    ));
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
 }

--- a/crates/tensor4all-treetn/tests/gse.rs
+++ b/crates/tensor4all-treetn/tests/gse.rs
@@ -158,6 +158,42 @@ fn product_internal_branch_state(
     (state, [s0, s1, s2, s3])
 }
 
+fn entangled_chain3_state(
+    leaf_matrix: [[Complex64; 2]; 2],
+) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(1);
+    let b12 = DynIndex::new_dyn(2);
+
+    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![one, zero]).unwrap();
+
+    let mut t1_data = vec![zero; 4];
+    for b in 0..2 {
+        t1_data[b + 2 * b] = one;
+    }
+    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], t1_data).unwrap();
+
+    let mut t2_data = vec![zero; 4];
+    for b in 0..2 {
+        for s in 0..2 {
+            t2_data[b + 2 * s] = leaf_matrix[b][s];
+        }
+    }
+    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], t2_data).unwrap();
+
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    let n2 = state.add_tensor("site2", t2).unwrap();
+    state.connect(n0, &b01, n1, &b01).unwrap();
+    state.connect(n1, &b12, n2, &b12).unwrap();
+    (state, [s0, s1, s2])
+}
+
 fn identity_or_x_operator(
     state_sites: &[DynIndex],
     node_names: &[&'static str],
@@ -260,6 +296,56 @@ fn edge_dim(state: &TreeTN<TensorDynLen, &'static str>, a: &str, b: &str) -> usi
     state.bond_index(edge).unwrap().dim()
 }
 
+fn local_basis_matrix(
+    state: &TreeTN<TensorDynLen, &'static str>,
+    parent: &str,
+    child: &str,
+    q_indices: &[DynIndex],
+) -> (usize, usize, Vec<Complex64>) {
+    let edge = state.edge_between(&parent, &child).unwrap();
+    let bond = state.bond_index(edge).unwrap().clone();
+    let child_tensor = state.tensor(state.node_index(&child).unwrap()).unwrap();
+    let ordered = std::iter::once(bond.clone())
+        .chain(q_indices.iter().cloned())
+        .collect::<Vec<_>>();
+    let data = child_tensor
+        .permuteinds(&ordered)
+        .unwrap()
+        .to_vec::<Complex64>()
+        .unwrap();
+    let q_dim = q_indices.iter().map(DynIndex::dim).product();
+    (bond.dim(), q_dim, data)
+}
+
+fn assert_rows_are_isometric(row_dim: usize, q_dim: usize, data: &[Complex64]) {
+    for lhs in 0..row_dim {
+        for rhs in 0..row_dim {
+            let mut overlap = Complex64::new(0.0, 0.0);
+            for q in 0..q_dim {
+                overlap += data[lhs + row_dim * q] * data[rhs + row_dim * q].conj();
+            }
+            let expected = if lhs == rhs { 1.0 } else { 0.0 };
+            assert!(
+                (overlap - Complex64::new(expected, 0.0)).norm() < 1.0e-10,
+                "basis rows {lhs},{rhs} overlap {overlap:?}, expected {expected}"
+            );
+        }
+    }
+}
+
+fn projected_weight(row_dim: usize, q_dim: usize, data: &[Complex64], vector: &[Complex64]) -> f64 {
+    let norm: f64 = vector.iter().map(Complex64::norm_sqr).sum();
+    let mut projected = 0.0;
+    for row in 0..row_dim {
+        let mut coeff = Complex64::new(0.0, 0.0);
+        for q in 0..q_dim {
+            coeff += data[row + row_dim * q].conj() * vector[q];
+        }
+        projected += coeff.norm_sqr();
+    }
+    projected / norm
+}
+
 #[test]
 fn global_subspace_expand_preserves_state_and_grows_chain_bond() {
     let zero = Complex64::new(0.0, 0.0);
@@ -339,6 +425,42 @@ fn global_subspace_expand_maps_processed_child_bond_in_chain_q_space() {
     assert!(result.state.same_topology(&state));
     assert!(dense_distance(&result.state, &state) < 1.0e-10);
     assert!(result.state.canonical_region().contains(&"site0"));
+}
+
+#[test]
+fn global_subspace_expand_handles_nonproduct_processed_child_bond_basis() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let half = Complex64::new(0.5, 0.0);
+    let (state, sites) = entangled_chain3_state([[one, zero], [zero, half]]);
+    let (reference, _) = entangled_chain3_state([[zero, one], [half, zero]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        vec![reference],
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(1.0e-14),
+    )
+    .unwrap();
+
+    assert_eq!(result.edges_processed, 2);
+    assert!(result.bonds_expanded >= 1);
+    assert_eq!(edge_dim(&result.state, "site1", "site2"), 2);
+    assert!(edge_dim(&result.state, "site0", "site1") >= 2);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+
+    let child_edge = result.state.edge_between(&"site1", &"site2").unwrap();
+    let processed_child_bond = result.state.bond_index(child_edge).unwrap().clone();
+    let (row_dim, q_dim, basis) = local_basis_matrix(
+        &result.state,
+        "site0",
+        "site1",
+        &[sites[1].clone(), processed_child_bond],
+    );
+    assert_rows_are_isometric(row_dim, q_dim, &basis);
+
+    let reference_q_direction = vec![zero, half, one, zero];
+    assert!(projected_weight(row_dim, q_dim, &basis, &reference_q_direction) > 1.0 - 1.0e-10);
 }
 
 #[test]
@@ -467,6 +589,28 @@ fn global_subspace_expand_respects_density_weight_cutoff_without_dropping_target
 }
 
 #[test]
+fn global_subspace_expand_with_empty_references_is_noop() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_chain3_state([[one, zero], [one, zero], [one, zero]]);
+
+    let result = global_subspace_expand_with_references(
+        state.clone(),
+        Vec::new(),
+        &"site0",
+        GseOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(result.references_built, 0);
+    assert_eq!(result.edges_processed, 0);
+    assert_eq!(result.bonds_expanded, 0);
+    assert_eq!(result.max_added_basis, 0);
+    assert!(dense_distance(&result.state, &state) < 1.0e-10);
+    assert!(result.state.canonical_region().contains(&"site0"));
+}
+
+#[test]
 fn global_subspace_expand_builds_multiple_krylov_references() {
     let zero = Complex64::new(0.0, 0.0);
     let one = Complex64::new(1.0, 0.0);
@@ -528,6 +672,109 @@ fn gse_tdvp_runs_existing_tdvp_after_expansion() {
 }
 
 #[test]
+fn gse_tdvp_can_skip_first_expansion_and_expand_later_sweeps() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, sites) = product_chain_state([[one, zero], [one, zero]]);
+    let operator = identity_or_x_operator(
+        &sites,
+        &["site0", "site1"],
+        &[("site0", "site1")],
+        &["site1"],
+    );
+
+    let result = gse_tdvp(
+        &operator,
+        state,
+        &"site0",
+        GseTdvpOptions {
+            gse: GseOptions::default()
+                .with_krylov_dim(1)
+                .with_density_weight_cutoff(1.0e-14)
+                .with_expand_before_first_sweep(false),
+            tdvp: TdvpOptions::default()
+                .with_nsite(1)
+                .with_nsweeps(2)
+                .with_exponent_step(Complex64::new(0.0, -0.01)),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.gse_expansions, 1);
+    assert_eq!(result.sweeps_completed, 2);
+    assert!(result.local_updates > 0);
+    assert_eq!(edge_dim(&result.state, "site0", "site1"), 2);
+}
+
+#[test]
+fn gse_rejects_invalid_options_and_missing_center() {
+    let zero = Complex64::new(0.0, 0.0);
+    let one = Complex64::new(1.0, 0.0);
+    let (state, _) = product_chain_state([[one, zero], [one, zero]]);
+
+    let density_err = global_subspace_expand_with_references(
+        state.clone(),
+        Vec::new(),
+        &"site0",
+        GseOptions::default().with_density_weight_cutoff(-1.0),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        density_err,
+        GseError::InvalidOption {
+            option: "density_weight_cutoff",
+            ..
+        }
+    ));
+
+    let hermitian_err = global_subspace_expand_with_references(
+        state.clone(),
+        Vec::new(),
+        &"site0",
+        GseOptions::default().with_hermitian_tol(-1.0),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        hermitian_err,
+        GseError::InvalidOption {
+            option: "hermitian_tol",
+            ..
+        }
+    ));
+
+    let invalid_rank_options = GseOptions {
+        reference_max_rank: Some(0),
+        ..Default::default()
+    };
+    let rank_err = global_subspace_expand_with_references(
+        state.clone(),
+        Vec::new(),
+        &"site0",
+        invalid_rank_options,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        rank_err,
+        GseError::InvalidOption {
+            option: "reference_max_rank",
+            ..
+        }
+    ));
+
+    let missing_err = global_subspace_expand_with_references(
+        state,
+        Vec::new(),
+        &"missing",
+        GseOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        missing_err,
+        GseError::MissingCenter { center } if center == "\"missing\""
+    ));
+}
+
+#[test]
 fn gse_rejects_multiple_state_sites_per_node() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
@@ -585,5 +832,32 @@ fn gse_rejects_scalar_storage_mismatch() {
             target: "f64",
             reference: "Complex64"
         }
+    ));
+}
+
+#[test]
+fn gse_rejects_mixed_scalar_storage_inside_target_tree() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(1);
+    let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0_f64, 0.0]).unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![bond.clone(), s1],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
+    )
+    .unwrap();
+    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let n0 = state.add_tensor("site0", t0).unwrap();
+    let n1 = state.add_tensor("site1", t1).unwrap();
+    state.connect(n0, &bond, n1, &bond).unwrap();
+
+    let err =
+        global_subspace_expand_with_references(state, Vec::new(), &"site0", GseOptions::default())
+            .unwrap_err();
+
+    assert!(matches!(
+        err,
+        GseError::UnsupportedScalarStorage { reason, .. }
+            if reason.contains("mixed scalar storage")
     ));
 }

--- a/docs/design/assets/gse-bond-update.svg
+++ b/docs/design/assets/gse-bond-update.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="430" viewBox="0 0 1160 430" role="img" aria-labelledby="title desc">
+  <title id="title">Replace the right tensor by the expanded basis and absorb coefficients left</title>
+  <desc id="desc">Diagram showing the old two-site block A[j-1] A[j], the expanded basis E_j formed by stacking B_j and C_j, and the resulting tensors A_new[j-1] and E[j] connected by a larger bond.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#344054"/>
+    </marker>
+    <style>
+      .title { font: 18px sans-serif; font-weight: 700; fill: #111827; }
+      .label { font: 15px sans-serif; fill: #1f2937; }
+      .small { font: 12px sans-serif; fill: #475467; }
+      .math { font: 14px monospace; fill: #111827; }
+      .box { fill: #ffffff; stroke: #667085; stroke-width: 1.5; rx: 8; }
+      .tensor { fill: #dbeafe; stroke: #2563eb; stroke-width: 2; rx: 8; }
+      .basis { fill: #dcfce7; stroke: #16a34a; stroke-width: 2; rx: 6; }
+      .extra { fill: #fecaca; stroke: #dc2626; stroke-width: 1.5; }
+      .old { stroke: #667085; stroke-width: 2.2; fill: none; }
+      .new { stroke: #16a34a; stroke-width: 3; fill: none; }
+      .arrow { stroke: #344054; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <rect width="1160" height="430" fill="#ffffff"/>
+  <text x="30" y="36" class="title">Step 5: write the expanded basis back onto the bond</text>
+
+  <g transform="translate(55,94)">
+    <text x="0" y="0" class="label">Old two-site block</text>
+    <rect x="10" y="44" width="98" height="70" class="tensor"/>
+    <text x="30" y="84" class="math">A[j-1]</text>
+    <line x1="108" y1="79" x2="188" y2="79" class="old"/>
+    <text x="118" y="61" class="small">chi_old</text>
+    <rect x="188" y="44" width="86" height="70" class="tensor"/>
+    <text x="214" y="84" class="math">A[j]</text>
+    <text x="4" y="147" class="math">T = contract(A[j-1], A[j])</text>
+    <path d="M 48 178 L 48 242 L 238 242 L 238 178 Z" class="box"/>
+    <text x="110" y="217" class="math">T</text>
+    <text x="52" y="266" class="small">contains the same physical state across the cut</text>
+  </g>
+
+  <g transform="translate(415,92)">
+    <text x="0" y="0" class="label">Expanded row basis</text>
+    <rect x="12" y="40" width="170" height="146" class="basis"/>
+    <path d="M 12 40 L 182 40 L 182 106 L 12 106 Z" fill="#dcfce7" stroke="#16a34a" stroke-width="1.4"/>
+    <path d="M 12 106 L 182 106 L 182 186 L 12 186 Z" class="extra"/>
+    <text x="78" y="78" class="math">B_j</text>
+    <text x="78" y="150" class="math">C_j</text>
+    <text x="28" y="220" class="math">E_j = [B_j; C_j]</text>
+    <text x="10" y="246" class="small">reshape E_j to (chi_new, d_j, chi_right)</text>
+  </g>
+
+  <path d="M 330 255 C 375 255, 390 220, 420 178" class="arrow"/>
+  <text x="334" y="231" class="small">project T onto E_j</text>
+  <path d="M 514 286 C 555 330, 615 342, 660 310" class="arrow"/>
+  <text x="500" y="392" class="math">A_new[j-1] = &lt;E_j | T&gt;</text>
+
+  <g transform="translate(660,91)">
+    <text x="0" y="0" class="label">Expanded MPS tensors</text>
+    <rect x="10" y="54" width="118" height="78" class="tensor"/>
+    <text x="26" y="98" class="math">A_new[j-1]</text>
+    <line x1="128" y1="93" x2="236" y2="93" class="new"/>
+    <text x="144" y="74" class="small">chi_new = chi_old + chi_extra</text>
+    <rect x="236" y="54" width="92" height="78" class="basis"/>
+    <text x="270" y="98" class="math">E[j]</text>
+    <text x="10" y="166" class="small">old coefficients live in B_j rows</text>
+    <text x="10" y="184" class="small">new C_j rows start with zero target amplitude</text>
+    <text x="10" y="216" class="math">A[j-1]--A[j] = A_new[j-1]--E[j]</text>
+    <text x="10" y="240" class="small">up to the SVD/eigen tolerance used to choose bases</text>
+  </g>
+</svg>

--- a/docs/design/assets/gse-projection-density.svg
+++ b/docs/design/assets/gse-projection-density.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1060" height="430" viewBox="0 0 1060 430" role="img" aria-labelledby="title desc">
+  <title id="title">Project reference density into the complement of the current basis</title>
+  <desc id="desc">Diagram showing reference tensors forming rho_ref, projection by P onto the complement of the current basis B_j, and eigendecomposition to obtain missing basis vectors C_j.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#344054"/>
+    </marker>
+    <style>
+      .title { font: 18px sans-serif; font-weight: 700; fill: #111827; }
+      .label { font: 15px sans-serif; fill: #1f2937; }
+      .small { font: 12px sans-serif; fill: #475467; }
+      .math { font: 14px monospace; fill: #111827; }
+      .box { fill: #ffffff; stroke: #667085; stroke-width: 1.5; rx: 8; }
+      .ref { fill: #e0f2fe; stroke: #0284c7; stroke-width: 2; rx: 6; }
+      .rho { fill: #fef3c7; stroke: #d97706; stroke-width: 2; rx: 6; }
+      .basis { fill: #dcfce7; stroke: #16a34a; stroke-width: 2; rx: 6; }
+      .missing { fill: #fde2e2; stroke: #dc2626; stroke-width: 2; rx: 6; }
+      .arrow { stroke: #344054; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .dash { stroke: #667085; stroke-width: 1.6; stroke-dasharray: 6 5; fill: none; }
+    </style>
+  </defs>
+
+  <rect width="1060" height="430" fill="#ffffff"/>
+  <text x="30" y="36" class="title">Steps 2-4: reference density, complement projection, eigenvectors</text>
+
+  <g transform="translate(40,86)">
+    <text x="0" y="0" class="label">Reference MPS tensors at site j</text>
+    <rect x="10" y="30" width="150" height="78" class="ref"/>
+    <text x="54" y="73" class="math">R_1</text>
+    <rect x="28" y="122" width="150" height="78" class="ref"/>
+    <text x="72" y="165" class="math">R_2</text>
+    <rect x="46" y="214" width="150" height="78" class="ref"/>
+    <text x="86" y="257" class="math">R_k</text>
+    <text x="4" y="322" class="small">rows: reference left bond</text>
+    <text x="4" y="340" class="small">columns: (s_j, beta)</text>
+  </g>
+
+  <path d="M 245 235 C 305 235, 315 235, 365 235" class="arrow"/>
+  <text x="270" y="215" class="math">sum R_r^* R_r</text>
+
+  <g transform="translate(380,120)">
+    <rect x="0" y="0" width="190" height="190" class="rho"/>
+    <line x1="47" y1="0" x2="47" y2="190" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="94" y1="0" x2="94" y2="190" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="141" y1="0" x2="141" y2="190" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="0" y1="47" x2="190" y2="47" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="0" y1="94" x2="190" y2="94" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="0" y1="141" x2="190" y2="141" stroke="#d97706" stroke-width="1.2"/>
+    <text x="58" y="99" class="math">rho_j</text>
+    <text x="18" y="-16" class="label">reference density</text>
+    <text x="35" y="220" class="small">acts on (s_j, beta)</text>
+  </g>
+
+  <g transform="translate(398,138)">
+    <path d="M 18 18 L 150 18 L 150 64 L 18 64 Z" class="basis"/>
+    <text x="42" y="47" class="math">span(B_j)</text>
+    <path d="M 18 88 L 150 88 L 150 152 L 18 152 Z" class="missing"/>
+    <text x="38" y="124" class="math">missing</text>
+  </g>
+
+  <path d="M 590 235 C 640 235, 650 235, 700 235" class="arrow"/>
+  <text x="608" y="207" class="math">P = I - B^dag B</text>
+  <text x="628" y="226" class="math">P rho_j P</text>
+
+  <g transform="translate(715,120)">
+    <rect x="0" y="0" width="190" height="190" class="missing"/>
+    <path d="M 22 22 L 168 22 L 168 70 L 22 70 Z" fill="#ffffff" stroke="#dc2626" stroke-width="1.4"/>
+    <text x="42" y="53" class="math">projected out</text>
+    <path d="M 22 102 L 168 102 L 168 168 L 22 168 Z" fill="#fecaca" stroke="#dc2626" stroke-width="1.4"/>
+    <text x="50" y="140" class="math">rho_missing</text>
+    <text x="16" y="-16" class="label">complement block</text>
+  </g>
+
+  <path d="M 810 326 C 810 360, 740 360, 700 360" class="arrow"/>
+  <text x="730" y="383" class="math">eig(rho_missing)</text>
+
+  <g transform="translate(500,330)">
+    <rect x="0" y="0" width="150" height="58" class="basis"/>
+    <line x1="0" y1="28" x2="150" y2="28" stroke="#16a34a" stroke-width="1.4"/>
+    <text x="54" y="36" class="math">C_j</text>
+    <text x="8" y="82" class="small">new basis rows to append</text>
+  </g>
+
+  <path d="M 464 88 C 455 66, 455 62, 466 46" class="dash"/>
+  <text x="380" y="62" class="small">normalize by trace before projection</text>
+</svg>

--- a/docs/design/assets/gse-reshape-svd.svg
+++ b/docs/design/assets/gse-reshape-svd.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="430" viewBox="0 0 1180 430" role="img" aria-labelledby="title desc">
+  <title id="title">Reshape an MPS site tensor and extract the current right-block basis</title>
+  <desc id="desc">Diagram showing A[j] with left, physical, and right indices reshaped into a matrix M_j whose columns are the fused physical and right-block space, followed by an SVD that returns B_j as row basis vectors.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#344054"/>
+    </marker>
+    <style>
+      .label { font: 15px sans-serif; fill: #1f2937; }
+      .small { font: 12px sans-serif; fill: #475467; }
+      .math { font: 14px monospace; fill: #111827; }
+      .title { font: 18px sans-serif; font-weight: 700; fill: #111827; }
+      .box { fill: #ffffff; stroke: #667085; stroke-width: 1.5; rx: 8; }
+      .tensor { fill: #dbeafe; stroke: #2563eb; stroke-width: 2; rx: 8; }
+      .matrix { fill: #fef3c7; stroke: #d97706; stroke-width: 2; rx: 6; }
+      .basis { fill: #dcfce7; stroke: #16a34a; stroke-width: 2; rx: 6; }
+      .bond { stroke: #344054; stroke-width: 2.5; fill: none; }
+      .arrow { stroke: #344054; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .dim { stroke: #7c3aed; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+    </style>
+  </defs>
+
+  <rect width="1180" height="430" fill="#ffffff"/>
+  <text x="30" y="36" class="title">Step 1: reshape A[j] and take SVD</text>
+
+  <g transform="translate(40,78)">
+    <text x="0" y="0" class="label">Chain cut at bond (j-1, j)</text>
+    <line x1="22" y1="48" x2="116" y2="48" class="bond"/>
+    <rect x="116" y="24" width="76" height="48" class="box"/>
+    <text x="135" y="54" class="math">A[j-1]</text>
+    <line x1="192" y1="48" x2="260" y2="48" class="bond"/>
+    <text x="205" y="35" class="small">chi_left</text>
+    <rect x="260" y="18" width="68" height="60" class="tensor"/>
+    <text x="279" y="53" class="math">A[j]</text>
+    <line x1="328" y1="48" x2="430" y2="48" class="bond"/>
+    <text x="350" y="35" class="small">chi_right</text>
+    <text x="170" y="122" class="small">current center tensor</text>
+  </g>
+
+  <g transform="translate(70,215)">
+    <path d="M 30 20 L 135 20 L 165 52 L 60 52 Z" class="tensor"/>
+    <path d="M 135 20 L 165 52 L 165 132 L 135 100 Z" fill="#bfdbfe" stroke="#2563eb" stroke-width="2"/>
+    <path d="M 30 20 L 60 52 L 60 132 L 30 100 Z" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+    <path d="M 60 52 L 165 52 L 165 132 L 60 132 Z" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/>
+    <text x="80" y="83" class="math">A[j]</text>
+    <text x="-10" y="80" class="small">alpha</text>
+    <line x1="23" y1="73" x2="55" y2="73" class="dim"/>
+    <text x="72" y="154" class="small">s_j</text>
+    <line x1="86" y1="140" x2="86" y2="115" class="dim"/>
+    <text x="176" y="93" class="small">beta</text>
+    <line x1="174" y1="88" x2="148" y2="88" class="dim"/>
+    <text x="0" y="-8" class="label">rank-3 MPS tensor</text>
+  </g>
+
+  <path d="M 275 275 C 330 275, 340 275, 392 275" class="arrow"/>
+  <text x="302" y="258" class="small">reshape</text>
+
+  <g transform="translate(405,185)">
+    <rect x="0" y="0" width="170" height="170" class="matrix"/>
+    <line x1="45" y1="0" x2="45" y2="170" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="90" y1="0" x2="90" y2="170" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="135" y1="0" x2="135" y2="170" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="0" y1="43" x2="170" y2="43" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="0" y1="86" x2="170" y2="86" stroke="#d97706" stroke-width="1.2"/>
+    <line x1="0" y1="129" x2="170" y2="129" stroke="#d97706" stroke-width="1.2"/>
+    <text x="62" y="91" class="math">M_j</text>
+    <text x="24" y="-14" class="label">matrix view</text>
+    <text x="38" y="194" class="small">columns: (s_j, beta)</text>
+    <text x="-55" y="92" class="small" transform="rotate(-90 -55 92)">rows: alpha</text>
+  </g>
+
+  <path d="M 590 270 C 640 270, 650 270, 698 270" class="arrow"/>
+  <text x="615" y="252" class="math">M_j = U S B_j</text>
+
+  <g transform="translate(715,176)">
+    <rect x="0" y="0" width="92" height="188" class="box"/>
+    <text x="34" y="98" class="math">U</text>
+    <text x="25" y="211" class="small">coeffs</text>
+    <rect x="112" y="42" width="58" height="104" class="matrix"/>
+    <text x="136" y="99" class="math">S</text>
+    <rect x="190" y="20" width="196" height="148" class="basis"/>
+    <line x1="190" y1="57" x2="386" y2="57" stroke="#16a34a" stroke-width="1.4"/>
+    <line x1="190" y1="94" x2="386" y2="94" stroke="#16a34a" stroke-width="1.4"/>
+    <line x1="190" y1="131" x2="386" y2="131" stroke="#16a34a" stroke-width="1.4"/>
+    <text x="268" y="98" class="math">B_j</text>
+    <text x="206" y="192" class="small">row basis in (s_j, beta) space</text>
+  </g>
+</svg>

--- a/docs/design/gse-chain-mps-algorithm.md
+++ b/docs/design/gse-chain-mps-algorithm.md
@@ -126,6 +126,18 @@ important part of this particular implementation: the references are not meant
 to be unrestricted high-rank Krylov vectors. They are low-rank probes carrying
 directions just outside the current MPS manifold.
 
+Here `maxlinkdim(psi)` is a scalar maximum over the whole MPS, not a vector of
+bond-local dimensions. In the Julia source,
+
+$$
+\operatorname{maxlinkdim}(\psi)
+=
+\max_i \max(\dim \chi_{i-1}, \dim \chi_i),
+$$
+
+and the same scalar `maxdim` is passed to all SVD/eigen truncations inside
+`apply!(FullCompress(), ...)`.
+
 For a Rust translation that aims to match the original Julia strategy, this
 should be treated as the default reference-generation policy:
 
@@ -169,14 +181,75 @@ compatibility defaults should be:
 
 | Knob | Original-compatible default | Meaning |
 |---|---|---|
-| `reference_maxdim` | `maxlinkdim(psi) + 1` | Cap used while building each $H^m\psi$ reference. |
-| `reference_atol` | `1e-13` | SVD/compression tolerance for reference generation. |
-| `expand_atol` | `1e-13` | SVD rank and missing-density eigenvalue tolerance in `expand!`. |
+| `reference_maxdim` | `maxlinkdim(psi) + 1` | Global scalar cap used while building each $H^m\psi$ reference. |
+| `reference_atol` | `1e-13` | Absolute SVD/eigenvalue threshold used during reference generation. |
+| `expand_atol` | `sqrt(eps(real(T)))`, unless TDVP passes another `atol` | Absolute SVD rank and missing-density eigenvalue threshold in `expand!`. |
 | `max_added_per_bond` | none | No explicit cap in `expand.jl`; retained directions are selected by `expand_atol`. |
 
 If tensor4all-rs adds `max_added_per_bond = 1`, that is an extra policy, not the
 literal RydbergToolkit default. It may be useful for experiments, but it should
 not be the default when checking against the original Julia behavior.
+
+### Tolerance Semantics
+
+The Julia implementation uses the name `atol` literally. The helper
+`truncated_svd(M, atol, maxdim)` keeps singular values satisfying
+
+$$
+\sigma_i > \mathrm{atol},
+$$
+
+and `truncated_eigen(M, atol, maxdim)` keeps eigenvalues satisfying
+
+$$
+\lambda_i > \mathrm{atol}.
+$$
+
+There is no relative scaling by $\sigma_{\max}$, by matrix dimension, or by
+discarded weight in those helper functions. This is the behavior to reproduce
+in a strict compatibility mode.
+
+However, this does not mean the clean tensor4all-rs API should expose one
+absolute `atol` knob. TreeTN already routes SVD truncation through
+`SvdTruncationPolicy`, whose default is
+`SvdTruncationPolicy::new(1e-12)`: relative threshold, singular-value measure,
+and per-value truncation. In formulas, the default SVD rank rule is
+
+$$
+\frac{\sigma_i}{\sigma_{\max}} > 10^{-12}.
+$$
+
+That is the right default style for GSE SVDs as well. It is close to a numerical
+rank cutoff, matches the rest of TreeTN better than an absolute `atol`, and can
+be exposed in user-facing options as `singular_value_cutoff` or directly as an
+`SvdTruncationPolicy`.
+
+The preferred Rust design should therefore separate these roles:
+
+| Role | Julia-compatible behavior | TreeTN-aligned default |
+|---|---|---|
+| Reference compression after $H|\Phi_m\rangle$ | Absolute `reference_atol = 1e-13`, global `reference_maxdim = maxlinkdim(psi) + 1`. | Same global `reference_maxdim`, but use the TreeTN SVD policy default: relative per-value singular-value cutoff `1e-12`. |
+| Current-basis rank extraction from $M_j$ | Absolute `expand_atol`, defaulting to `sqrt(eps(real(T)))` in `expand!`. | Use a numerical-rank SVD policy, by default the same relative per-value singular-value cutoff `1e-12`. This step should only remove numerical zeros from the existing target basis. |
+| Missing-density eigenvector selection | Absolute $\lambda_i > \mathrm{expand\_atol}$ after trace-normalizing $\rho_j$. | Use a separate `density_weight_cutoff`, defaulting to the same numerical scale such as `1e-12`, because $\operatorname{Tr}\rho_j=1$. |
+
+The last row is not an SVD truncation policy. After trace normalization,
+
+$$
+\sum_i \lambda_i = 1,
+$$
+
+so the threshold on $\lambda_i$ is already relative to the total reference
+weight. It should be named as a density weight cutoff rather than folded into an
+SVD `singular_value_cutoff`.
+
+Therefore the recommended implementation shape is:
+
+1. provide a `JuliaCompat` tolerance mode that reproduces the absolute thresholds
+   above for regression tests against RydbergToolkit;
+2. make the default Rust-facing SVD knobs reuse the existing TreeTN
+   `SvdTruncationPolicy` default, exposed as `singular_value_cutoff = 1e-12`
+   when a simpler API is desired;
+3. keep the missing-density threshold separate as `density_weight_cutoff`.
 
 ## Per-Bond Expansion Step
 
@@ -224,9 +297,20 @@ The rows of $B_j$ form the current right-block basis for the bond $(j-1,j)$.
 With nonzero `atol`, numerically small old directions may be dropped before new
 directions are added. To match the Julia implementation, this `atol` should be
 the same `expand_atol` used for the missing-density eigenvalue test below,
-defaulting to $10^{-13}$. This is close to machine precision for double
-precision, but it is still an explicit algorithmic tolerance rather than an
-implicit backend epsilon.
+defaulting to $\sqrt{\epsilon_{\mathrm{mach}}}$ for the real scalar type in
+`expand!` and `tdvp`. This is not machine precision itself; it is a user-facing
+accuracy/adaptivity tolerance reused for several GSE decisions.
+
+For the TreeTN implementation, prefer the existing SVD policy instead:
+
+$$
+\frac{\sigma_i}{\sigma_{\max}} > \tau_{\mathrm{sv}},
+\qquad
+\tau_{\mathrm{sv}} = 10^{-12}
+$$
+
+by default. This is a numerical-rank decision for the current target basis, not
+the missing-density selection rule.
 
 ### 2. Build a Reference Density Matrix
 
@@ -660,8 +744,12 @@ The last point matters because eigenvalue thresholding and rank selection are
 piecewise-discrete operations:
 
 $$
-C_e = \{c_\ell : \lambda_\ell > \mathrm{atol}\}.
+C_e = \{c_\ell : \lambda_\ell > \tau_{\mathrm{density}}\}.
 $$
+
+In a Julia-compatible mode, $\tau_{\mathrm{density}}$ is the same `atol` passed
+to `expand!`. In the preferred Rust-facing API, it should be named as a density
+weight cutoff because the density matrix has already been trace-normalized.
 
 If the first implementation chooses to detach the selected expansion basis,
 that boundary should be named and documented, for example as "the expansion
@@ -672,9 +760,9 @@ unless the API explicitly requested a detached/reference path.
 
 The discrete selection itself is not part of the differentiable map. In other
 words, gradients should not be defined through the predicate
-$\lambda_\ell > \mathrm{atol}$, the number of retained eigenvectors, or bond
-dimension changes. The continuous tensor operations before and after that
-selection should still preserve AD metadata.
+$\lambda_\ell > \tau_{\mathrm{density}}$, the number of retained eigenvectors,
+or bond dimension changes. The continuous tensor operations before and after
+that selection should still preserve AD metadata.
 
 The nontrivial parts are:
 

--- a/docs/design/gse-chain-mps-algorithm.md
+++ b/docs/design/gse-chain-mps-algorithm.md
@@ -64,23 +64,44 @@ site `N`, then sweeps from `j = N` down to `j = 2`. At the step for site `j`,
 the bond between sites `j-1` and `j` is enlarged. Equivalently, the basis for
 the right block `j..N` seen across that cut is enlarged.
 
-Let
+Write the site tensor as $A^{[j]}_{\alpha s \beta}$, with shape
+$(\chi_L, d_j, \chi_R)$. At the $j$ step, combine the physical index $s$ and
+the right-block bond $\beta$ into a single column index
 
-`A[j]` have shape `(chi_left, d_j, chi_right)`.
+$$
+x = (s, \beta),
+\qquad
+M_j[\alpha, x] = A^{[j]}_{\alpha s \beta}.
+$$
 
-At the `j` step the tensor is reshaped to a matrix
+Thus $M_j$ is a matrix in
 
-```text
-M_j[alpha, (s_j, beta)] = A[j][alpha, s_j, beta]
+$$
+M_j \in \mathbb{C}^{\chi_L \times (d_j \chi_R)}.
+$$
 
-rows:    alpha in the left bond space of site j
-columns: local basis for site j times the already processed right block
-```
+The rows are labelled by the bond to the unprocessed left block. The columns
+are labelled by a local basis for site $j$ together with the already processed
+right block $j+1,\ldots,N$.
 
-The SVD of `M_j` gives the current row basis for the right block. In the
-RydbergToolkit helper, `truncated_svd` returns `Vt`, so the current basis is a
-matrix `B_j` whose rows are orthonormal basis vectors in the column space
-`C^(d_j * chi_right)`.
+The SVD of $M_j$ gives the current basis for that column space:
+
+$$
+M_j = U_j S_j B_j.
+$$
+
+RydbergToolkit's `truncated_svd` helper returns the $V^\dagger$ factor directly,
+so this note calls that row-basis matrix $B_j$. Its rows are orthonormal
+vectors in $\mathbb{C}^{d_j\chi_R}$:
+
+$$
+B_j B_j^\dagger = I,
+\qquad
+\Pi_j^{\mathrm{old}} = B_j^\dagger B_j.
+$$
+
+Here $\Pi_j^{\mathrm{old}}$ is the orthogonal projector onto the right-block
+subspace already represented by the current MPS across the cut $(j-1,j)$.
 
 ![Reshape A[j] and extract the current row basis](assets/gse-reshape-svd.svg)
 
@@ -105,61 +126,215 @@ important part of this particular implementation: the references are not meant
 to be unrestricted high-rank Krylov vectors. They are low-rank probes carrying
 directions just outside the current MPS manifold.
 
+For a Rust translation that aims to match the original Julia strategy, this
+should be treated as the default reference-generation policy:
+
+$$
+\chi_{\mathrm{ref,max}}
+= \max_j \chi_j(\psi) + 1,
+\qquad
+\epsilon_{\mathrm{ref}} = 10^{-13}.
+$$
+
+After each application,
+
+$$
+|\widetilde{\Phi}_{m+1}\rangle = H|\Phi_m\rangle,
+$$
+
+the temporary state is compressed as
+
+$$
+|\Phi_{m+1}\rangle
+=
+\operatorname{compress}
+\left(
+|\widetilde{\Phi}_{m+1}\rangle;
+\chi_{\mathrm{max}} = \chi_{\mathrm{ref,max}},
+\epsilon = \epsilon_{\mathrm{ref}}
+\right),
+$$
+
+then normalized. This means the reference states are approximate Krylov vectors,
+not exact $H^m|\psi\rangle$ vectors and not high-rank MPO-application results.
+
+This point is separate from the later bond expansion. The original algorithm
+does not say "add exactly one basis vector per bond." It says "build each
+reference with at most one more bond dimension than the current target's maximum
+link dimension," then let the projected reference density decide how many
+missing local directions pass the eigenvalue tolerance.
+
+Consequently, a compatible Rust API may expose extra safety knobs, but the
+compatibility defaults should be:
+
+| Knob | Original-compatible default | Meaning |
+|---|---|---|
+| `reference_maxdim` | `maxlinkdim(psi) + 1` | Cap used while building each $H^m\psi$ reference. |
+| `reference_atol` | `1e-13` | SVD/compression tolerance for reference generation. |
+| `expand_atol` | `1e-13` | SVD rank and missing-density eigenvalue tolerance in `expand!`. |
+| `max_added_per_bond` | none | No explicit cap in `expand.jl`; retained directions are selected by `expand_atol`. |
+
+If tensor4all-rs adds `max_added_per_bond = 1`, that is an extra policy, not the
+literal RydbergToolkit default. It may be useful for experiments, but it should
+not be the default when checking against the original Julia behavior.
+
 ## Per-Bond Expansion Step
 
 For a fixed site `j`, RydbergToolkit performs the following operations.
 
 ### 1. Extract the Current Basis
 
-Reshape the target tensor:
+Before processing site $j$, the target and all reference MPSs have their
+orthogonality center at site $j$. Therefore:
 
-`M_j = reshape(A[j], chi_left, d_j * chi_right)`.
+- each state's left block $1,\ldots,j-1$ gives an orthonormal basis for that
+  state, but the basis may differ between `psi` and the references;
+- the already processed right block $j+1,\ldots,N$ is represented in a common
+  orthonormal basis for `psi` and all references.
+
+The second point is a sweep invariant. At $j=N$, the right-block basis is the
+trivial boundary space, so it is automatically common. After processing site
+$j$, the algorithm writes the same expanded right tensor into `psi` and every
+reference work buffer, so the block $j,\ldots,N$ becomes the common right-block
+basis for the next step $j-1$.
+
+With that invariant, the target state near the cut can be written as
+
+$$
+|\psi\rangle
+= \sum_{\alpha,x}
+M_j[\alpha,x]\,
+|L^\psi_\alpha\rangle |x\rangle,
+\qquad
+x=(s_j,\beta).
+$$
+
+Here $|L^\psi_\alpha\rangle$ is an orthonormal left-block basis for the target
+state, and $|x\rangle$ is the common basis for "site $j$ plus the processed
+right block." Reshaping $A^{[j]}$ into $M_j$ is exactly the extraction of these
+coefficients.
 
 Compute a truncated SVD:
 
-`M_j = U S B_j`.
+$$
+M_j = U_j S_j B_j.
+$$
 
-Here `B_j` is the returned `Vt` block. Its rows form the current right-block
-basis for the bond `(j-1, j)`. With nonzero `atol`, numerically small old
-directions may be dropped before new directions are added.
+The rows of $B_j$ form the current right-block basis for the bond $(j-1,j)$.
+With nonzero `atol`, numerically small old directions may be dropped before new
+directions are added. To match the Julia implementation, this `atol` should be
+the same `expand_atol` used for the missing-density eigenvalue test below,
+defaulting to $10^{-13}$. This is close to machine precision for double
+precision, but it is still an explicit algorithmic tolerance rather than an
+implicit backend epsilon.
 
 ### 2. Build a Reference Density Matrix
 
-For each reference MPS `Phi_r`, reshape its current tensor at site `j` in the
+For each reference MPS $\Phi_r$, reshape its current tensor at site $j$ in the
 same way:
 
-`R_r = reshape(Phi_r[j], left_ref, d_j * chi_right)`.
+$$
+R_r[\gamma,x]
+= \Phi_r^{[j]}[\gamma,s_j,\beta],
+\qquad
+x=(s_j,\beta).
+$$
 
-Then accumulate
+The reference state has the cut expansion
 
-`rho_j = sum_r R_r^* R_r`.
+$$
+|\Phi_r\rangle
+=
+\sum_{\gamma,x}
+R_r[\gamma,x]\,
+|L^r_\gamma\rangle |x\rangle.
+$$
 
-This traces out the left/environment side of each reference and leaves a
-density matrix on the same local right-block space where `B_j` lives:
+The left basis $|L^r_\gamma\rangle$ can be different for every reference. It
+only needs to be orthonormal for that reference. The right basis $|x\rangle$ is
+the same one used for $B_j$, because the sweep has already put the processed
+right block into a common basis.
 
-```text
-left side traced out
-        |
-        v
-R_r^* R_r  acts on  (site j) x (right block basis)
-```
+Now trace out the left side of the reference state:
 
-RydbergToolkit normalizes `rho_j` by its trace before projection. That makes the
-absolute tolerance less sensitive to the norm and number of reference states.
+$$
+\rho_j^{(r)}
+=
+\operatorname{Tr}_{L_r}
+|\Phi_r\rangle\langle\Phi_r|.
+$$
+
+Using $\langle L^r_\delta | L^r_\gamma\rangle=\delta_{\delta\gamma}$, its
+matrix elements on the common right-block space are
+
+$$
+\rho_j^{(r)}[x,y]
+=
+\sum_\gamma
+\overline{R_r[\gamma,x]}\,R_r[\gamma,y].
+$$
+
+Equivalently,
+
+$$
+\rho_j^{(r)} = R_r^\dagger R_r.
+$$
+
+This is the reduced density matrix of the reference state on the local
+right-block space. It measures which directions in the $x=(s_j,\beta)$ space
+are important for that reference after ignoring the reference's left
+environment.
+
+For multiple references, RydbergToolkit accumulates
+
+$$
+\rho_j^{\mathrm{ref}}
+=
+\sum_r \rho_j^{(r)}
+=
+\sum_r R_r^\dagger R_r.
+$$
+
+RydbergToolkit then normalizes by the trace, when the trace is nonzero:
+
+$$
+\rho_j
+=
+\frac{\rho_j^{\mathrm{ref}}}
+{\operatorname{Tr}\rho_j^{\mathrm{ref}}}.
+$$
+
+That makes the absolute tolerance less sensitive to the norm and number of
+reference states.
 
 ### 3. Remove the Already Represented Directions
 
-The intended projector is the projector onto the complement of the row span of
-`B_j`:
+The density matrix $\rho_j$ includes both directions already represented by the
+current target MPS and directions missing from it. The represented subspace is
+the row span of $B_j$. With row-basis convention, its projector is
 
-`P_j = I - projector(rowspan(B_j))`.
+$$
+\Pi_j^{\mathrm{old}} = B_j^\dagger B_j.
+$$
+
+The intended complement projector is
+
+$$
+P_j = I - \Pi_j^{\mathrm{old}}.
+$$
 
 The projected density matrix is
 
-`rho_missing = P_j rho_j P_j`.
+$$
+\rho_j^{\mathrm{missing}}
+=
+P_j \rho_j P_j.
+$$
 
 This matrix contains only the reference-state weight that cannot already be
-represented by the current bond basis.
+represented by the current target bond basis. Since $\rho_j$ is positive
+semidefinite and $P_j$ is an orthogonal projector, $\rho_j^{\mathrm{missing}}$
+is also positive semidefinite up to numerical roundoff.
 
 Implementation detail: the Julia code stores basis vectors as rows from `Vt`
 and forms the projector with `transpose(B_j) * conj(B_j)`. Several nearby
@@ -171,32 +346,64 @@ copying the expression without checking the bra/ket orientation.
 
 ### 4. Diagonalize the Missing Density
 
-If `norm(rho_missing) > atol`, RydbergToolkit diagonalizes the Hermitian matrix
-`rho_missing` and keeps eigenvectors whose eigenvalues exceed `atol`:
+If $\|\rho_j^{\mathrm{missing}}\| > \mathrm{atol}$, RydbergToolkit diagonalizes
+the Hermitian matrix $\rho_j^{\mathrm{missing}}$:
 
-`C_j = significant eigenvectors of rho_missing`.
+$$
+\rho_j^{\mathrm{missing}} c_\ell = \lambda_\ell c_\ell.
+$$
 
-Since Julia's `eigen` returns eigenvectors as columns, the code transposes them
-before appending them to the row-basis matrix:
+It keeps eigenvectors whose eigenvalues exceed `atol`:
 
-`E_j = stack_rows(B_j, C_j)`.
+$$
+\lambda_\ell > \mathrm{atol}.
+$$
 
-If `rho_missing` is negligible, no new directions are added and `E_j = B_j`.
+These eigenvectors are directions in the same $x=(s_j,\beta)$ space. In the
+row-basis convention, collect the retained directions into a matrix $C_j$ whose
+rows are the retained missing basis vectors. Then append them to the old basis:
+
+$$
+E_j =
+\begin{bmatrix}
+B_j \\
+C_j
+\end{bmatrix}.
+$$
+
+Since Julia's `eigen` returns eigenvectors as columns, the RydbergToolkit code
+transposes them before appending them to the row-basis matrix. In a complex Rust
+translation, this is another place where the chosen row-vector convention and
+conjugation convention should be made explicit and tested.
+
+If $\rho_j^{\mathrm{missing}}$ is negligible, no new directions are added and
+$E_j = B_j$.
 
 The new bond dimension after this step is
 
-`rank(B_j) + number_of_kept_missing_directions`.
+$$
+\operatorname{rank}(B_j)
++
+\#\{\ell : \lambda_\ell > \mathrm{atol}\}.
+$$
 
 There is no explicit maximum expansion dimension in `expand.jl`; the only
 filter is the eigenvalue tolerance.
+
+Thus the "plus one" in the original implementation belongs to Krylov reference
+generation, not to this formula. A single bond often grows only slightly because
+the references themselves are low-rank, but if several independent missing
+density eigenvectors exceed `atol`, the expansion step can append several rows.
 
 ![Project the reference density into the complement basis](assets/gse-projection-density.svg)
 
 ### 5. Replace the Right Tensor and Absorb Coefficients Left
 
-Reshape the expanded basis matrix:
+Reshape the expanded basis matrix $E_j$:
 
-`E_j -> E_tensor[j]` with shape `(new_chi_left, d_j, chi_right)`.
+```text
+E_j -> E_tensor[j] with shape (new_chi_left, d_j, chi_right)
+```
 
 Then replace the two tensors around the cut by
 
@@ -227,21 +434,44 @@ The target state is not intentionally changed by GSE. Only its allowed bond
 space is enlarged.
 
 Before expansion, the right tensor `A[j]` lies completely in the row span of
-`B_j`:
+$B_j$. Equivalently, there is a coefficient matrix $F_j$ such that
 
-`A[j] = coefficients * B_j`.
+$$
+M_j = F_j B_j.
+$$
 
-After expansion, `E_j` contains all rows of `B_j` plus extra rows from the
-projected reference density. Therefore the old tensor can be represented in the
-larger basis exactly, up to SVD/eigensolver tolerance:
+After expansion, $E_j$ contains all rows of $B_j$ plus extra rows from the
+projected reference density:
 
-```text
-old right basis:       B_j
-expanded right basis:  [ B_j ]
-                       [ C_j ]
+$$
+E_j =
+\begin{bmatrix}
+B_j \\
+C_j
+\end{bmatrix}.
+$$
 
-old state coefficients in C_j directions: zero
-```
+Therefore the old tensor can be represented in the larger basis exactly, up to
+SVD/eigensolver tolerance. If $E_j$ is orthonormal by rows, the expanded
+coefficient matrix is
+
+$$
+F'_j = M_j E_j^\dagger.
+$$
+
+Reconstruction gives
+
+$$
+F'_j E_j
+=
+M_j E_j^\dagger E_j
+=
+M_j,
+$$
+
+because every row of $M_j$ already lies in the row span of $B_j$, and that span
+is a subspace of the row span of $E_j$. The new $C_j$ directions have zero
+target-state coefficient immediately after expansion.
 
 The left tensor `A_new[j-1]` receives those coefficients. The added basis
 vectors therefore create empty variational directions for `psi`; they do not
@@ -255,12 +485,22 @@ increases and the final orthogonality center is site `1`.
 ## What Happens to Reference States During the Sweep
 
 The reference states are mutable work buffers. At each cut, each reference is
-projected into the same expanded basis `E_j` so that the next cut to the left
+projected into the same expanded basis $E_j$ so that the next cut to the left
 can build a density matrix in a compatible gauge.
 
 For the next iteration, the important tensor is the updated
 `reference.data[j - 1]`: it contains the reference coefficients in the expanded
-right-block basis. The code also writes a tail tensor at `reference.data[j]`,
+right-block basis. In formulas, each reference is rewritten from
+
+$$
+|\Phi_r\rangle
+=
+\sum_{\gamma,x}
+R_r[\gamma,x]\,|L^r_\gamma\rangle |x\rangle
+$$
+
+to an equivalent representation using the common expanded basis labelled by the
+rows of $E_j$. The code also writes a tail tensor at `reference.data[j]`,
 but that line is marked with an index-order FIXME. Since the sweep never needs
 that already processed tensor again for density construction, a translation
 should treat the references as internal moving-center work buffers. If a Rust
@@ -326,16 +566,115 @@ parent side  ==  child tensor plus child-side subtrees
              expanded bond
 ```
 
-The child tensor should be reshaped as
+Let $a$ be the bond index from the child to the parent. Combine the physical
+indices at the child and all child-side outgoing bond indices into a single
+column multi-index $q$. The child tensor should be reshaped as
 
 ```text
-rows:    bond index toward the parent
-columns: physical indices at child plus all child-side bond indices
+rows:    a = bond index toward the parent
+columns: q = physical indices at child plus all child-side bond indices
 ```
 
-assuming the child-side subtrees have already been orthogonalized into
-isometric bases. Then the same density-projection-eigenvector logic can enlarge
-the parent-child bond.
+In formulas, the chain reshape
+
+$$
+M_j[\alpha,(s_j,\beta)]
+=
+A^{[j]}_{\alpha s_j \beta}
+$$
+
+becomes the directed-edge reshape
+
+$$
+M_e[a,q]
+=
+T^{[\mathrm{child}]}_{a,q}.
+$$
+
+The same reference-state expansion works if the sweep invariant is generalized:
+before processing edge $e=(\mathrm{parent},\mathrm{child})$, every already
+processed child-side subtree is in a common orthonormal basis for the target
+and all references. Then each reference has a cut expansion
+
+$$
+|\Phi_r\rangle
+=
+\sum_{\gamma,q}
+R_{r,e}[\gamma,q]\,
+|L^r_\gamma(e)\rangle |q;e\rangle,
+$$
+
+and the edge density matrix is
+
+$$
+\rho_e^{\mathrm{ref}}
+=
+\sum_r R_{r,e}^\dagger R_{r,e}.
+$$
+
+The old edge basis comes from the row-space SVD of $M_e$; projecting
+$\rho_e^{\mathrm{ref}}$ into the complement of that old row span and retaining
+dominant eigenvectors enlarges the parent-child bond exactly as in the chain.
+
+### AD Preservation
+
+TreeTN GSE should preserve AD metadata by default. The local matrices above are
+"small" relative to the full tensor network, but converting an AD-tracked tensor
+to host values is still a detach. A production implementation should not build
+$M_e$, $\rho_e^{\mathrm{ref}}$, or $E_e$ through value-extraction APIs such as
+`to_vec`, `into_dense_col_major_parts`, `native_tensor_primal_to_dense_*`, or a
+host `Matrix<T>` round trip when the input tensors track gradients.
+
+The preferred shape is:
+
+1. form local reshapes, contractions, projectors, and basis updates as
+   `TensorDynLen`/tenferro eager operations so the payload stays in the shared
+   AD context;
+2. use tenferro-backed `eigh` on the AD-carrying local density tensor, or add a
+   tensorbackend wrapper that returns tensor payloads rather than host
+   eigenvector buffers;
+3. make any intentionally non-differentiable boundary explicit.
+
+This argues for a small, clean `TensorDynLen` linear-algebra wrapper layer before
+implementing TreeTN GSE. The GSE implementation should not contain ad hoc
+matrix conversions for SVD, QR, or eigendecomposition. Instead, tensor4all-rs
+should provide AD-preserving tensor wrappers for the local dense linear algebra
+operations it needs:
+
+- SVD on a `TensorDynLen` unfolded by a chosen set of row indices, returning
+  `TensorDynLen` factors with the same index semantics as the existing
+  factorization path;
+- QR on the same tensor-unfolding convention, again returning tensor payloads
+  rather than host buffers;
+- Hermitian eigendecomposition on a rank-2 `TensorDynLen` density matrix,
+  returning eigenvalues and eigenvectors as tensor payloads.
+
+Those wrappers should call tenferro linalg operations on the underlying eager
+payload and should preserve tracked AD state whenever tenferro supports the
+corresponding AD rule. If a linalg operation or scalar type is not
+AD-supported, the wrapper should return an explicit error or document an
+explicit detach mode; it should not silently round-trip through primal host
+values.
+
+The last point matters because eigenvalue thresholding and rank selection are
+piecewise-discrete operations:
+
+$$
+C_e = \{c_\ell : \lambda_\ell > \mathrm{atol}\}.
+$$
+
+If the first implementation chooses to detach the selected expansion basis,
+that boundary should be named and documented, for example as "the expansion
+basis is selected from primal values." It should still keep the target and
+reference tensor contractions after basis selection AD-carrying. Tests should
+check that tracked target tensors still report gradient tracking after expansion
+unless the API explicitly requested a detached/reference path.
+
+The discrete selection itself is not part of the differentiable map. In other
+words, gradients should not be defined through the predicate
+$\lambda_\ell > \mathrm{atol}$, the number of retained eigenvectors, or bond
+dimension changes. The continuous tensor operations before and after that
+selection should still preserve AD metadata.
 
 The nontrivial parts are:
 
@@ -357,5 +696,7 @@ KrylovKit". It is an edge-oriented TreeTN basis-expansion primitive that:
 3. computes projected reference density matrices on local child-side spaces;
 4. expands shared bond indices while preserving the target state;
 5. updates reference work buffers consistently enough for the next edge; and
-6. hands the expanded state to the existing TreeTN TDVP with invalidated
+6. preserves AD metadata except at explicitly named nondifferentiable selection
+   boundaries; and
+7. hands the expanded state to the existing TreeTN TDVP with invalidated
    environments.

--- a/docs/design/gse-chain-mps-algorithm.md
+++ b/docs/design/gse-chain-mps-algorithm.md
@@ -82,6 +82,8 @@ RydbergToolkit helper, `truncated_svd` returns `Vt`, so the current basis is a
 matrix `B_j` whose rows are orthonormal basis vectors in the column space
 `C^(d_j * chi_right)`.
 
+![Reshape A[j] and extract the current row basis](assets/gse-reshape-svd.svg)
+
 ## Reference State Generation
 
 `global_krylov_subspace(psi, H; krylovdim)` builds reference states by repeated
@@ -188,6 +190,8 @@ The new bond dimension after this step is
 There is no explicit maximum expansion dimension in `expand.jl`; the only
 filter is the eigenvalue tolerance.
 
+![Project the reference density into the complement basis](assets/gse-projection-density.svg)
+
 ### 5. Replace the Right Tensor and Absorb Coefficients Left
 
 Reshape the expanded basis matrix:
@@ -214,6 +218,8 @@ A_new[j]             = E_j
 ```
 
 After this, the orthogonality center has moved from `j` to `j-1`.
+
+![Absorb the old two-site block into the expanded basis](assets/gse-bond-update.svg)
 
 ## Why the Target State Is Preserved
 

--- a/docs/design/gse-chain-mps-algorithm.md
+++ b/docs/design/gse-chain-mps-algorithm.md
@@ -1,0 +1,355 @@
+# Chain MPS Global Subspace Expansion
+
+This note explains the chain/MPS global subspace expansion (GSE) algorithm used
+by RydbergToolkit.jl before translating it to TreeTN GSE-TDVP.
+
+The goal is not to define the final tensor4all-rs API. The goal is to make the
+chain algorithm explicit enough that an MPS reader can see exactly what bond
+space is enlarged, why the original state is preserved, and which details are
+nontrivial when moving from a chain to a general tree.
+
+## Source Snapshot
+
+This analysis is based on CodingThrust/RydbergToolkit.jl at commit
+`9896452ce9f9164f67f761c88b64583aacd72ff9`.
+
+Related tensor4all-rs planning issue:
+[#539](https://github.com/tensor4all/tensor4all-rs/issues/539).
+
+Relevant files:
+
+| File | Role |
+|---|---|
+| [`src/gsetdvp/krylov.jl`](https://github.com/CodingThrust/RydbergToolkit.jl/blob/9896452ce9f9164f67f761c88b64583aacd72ff9/src/gsetdvp/krylov.jl) | Builds the global Krylov reference MPS list. |
+| [`src/gsetdvp/expand.jl`](https://github.com/CodingThrust/RydbergToolkit.jl/blob/9896452ce9f9164f67f761c88b64583aacd72ff9/src/gsetdvp/expand.jl) | Expands each MPS bond from the reference states. |
+| [`src/gsetdvp/tdvp.jl`](https://github.com/CodingThrust/RydbergToolkit.jl/blob/9896452ce9f9164f67f761c88b64583aacd72ff9/src/gsetdvp/tdvp.jl) | Runs TDVP and inserts GSE between TDVP steps when `krylov_dim > 0`. |
+| [`test/gsetdvp/krylov.jl`](https://github.com/CodingThrust/RydbergToolkit.jl/blob/9896452ce9f9164f67f761c88b64583aacd72ff9/test/gsetdvp/krylov.jl) | Compares GSE references and expansion with ITensorMPS. |
+| [`test/gsetdvp/expand.jl`](https://github.com/CodingThrust/RydbergToolkit.jl/blob/9896452ce9f9164f67f761c88b64583aacd72ff9/test/gsetdvp/expand.jl) | Checks state preservation, bond growth, and final orthogonality center. |
+
+The source comment in `expand.jl` cites Yang and White, "Time-dependent
+variational principle with ancillary Krylov subspace", Phys. Rev. B 102, 094315
+(2020).
+
+## Two Different Krylov Uses
+
+There are two Krylov-related pieces that should not be conflated.
+
+1. Local TDVP exponential: TDVP evolves a one-site or two-site local tensor by
+   applying `exp(dt H_eff)` in a small effective space. RydbergToolkit can use
+   KrylovKit or ExponentialUtilities for this local `expmv`. tensor4all-rs
+   already has Hermitian Krylov `expmv` machinery used by the existing TreeTN
+   TDVP.
+2. Global subspace expansion: GSE builds extra MPS reference states such as
+   `H psi`, `H^2 psi`, ... and uses them only to enlarge the variational bond
+   spaces before TDVP continues.
+
+This document is about the second item: how the bond basis is enlarged.
+
+## MPS Convention
+
+RydbergToolkit stores an MPS tensor as
+
+`A[j][left_bond, physical, right_bond]`.
+
+For a chain of `N` sites:
+
+```text
+A[1] -- A[2] -- ... -- A[j-1] == A[j] -- ... -- A[N]
+                         ^
+                         bond expanded by the j-th sweep step
+```
+
+The expansion sweep canonicalizes the target state and all reference states to
+site `N`, then sweeps from `j = N` down to `j = 2`. At the step for site `j`,
+the bond between sites `j-1` and `j` is enlarged. Equivalently, the basis for
+the right block `j..N` seen across that cut is enlarged.
+
+Let
+
+`A[j]` have shape `(chi_left, d_j, chi_right)`.
+
+At the `j` step the tensor is reshaped to a matrix
+
+```text
+M_j[alpha, (s_j, beta)] = A[j][alpha, s_j, beta]
+
+rows:    alpha in the left bond space of site j
+columns: local basis for site j times the already processed right block
+```
+
+The SVD of `M_j` gives the current row basis for the right block. In the
+RydbergToolkit helper, `truncated_svd` returns `Vt`, so the current basis is a
+matrix `B_j` whose rows are orthonormal basis vectors in the column space
+`C^(d_j * chi_right)`.
+
+## Reference State Generation
+
+`global_krylov_subspace(psi, H; krylovdim)` builds reference states by repeated
+MPO application:
+
+| Reference index | State represented by the code |
+|---|---|
+| `1` | normalized compressed `H psi` |
+| `2` | normalized compressed `H (H psi)` |
+| `k` | normalized compressed `H^k psi` |
+
+The implementation initializes `cur_reference = psi`, then repeatedly applies
+`H` to the current reference. The original `psi` itself is not inserted into
+the `references` vector.
+
+Each MPO application uses full compression with `maxdim = maxlinkdim(psi) + 1`
+and `atol = 1e-13` by default, then normalizes the result. The `+1` cap is an
+important part of this particular implementation: the references are not meant
+to be unrestricted high-rank Krylov vectors. They are low-rank probes carrying
+directions just outside the current MPS manifold.
+
+## Per-Bond Expansion Step
+
+For a fixed site `j`, RydbergToolkit performs the following operations.
+
+### 1. Extract the Current Basis
+
+Reshape the target tensor:
+
+`M_j = reshape(A[j], chi_left, d_j * chi_right)`.
+
+Compute a truncated SVD:
+
+`M_j = U S B_j`.
+
+Here `B_j` is the returned `Vt` block. Its rows form the current right-block
+basis for the bond `(j-1, j)`. With nonzero `atol`, numerically small old
+directions may be dropped before new directions are added.
+
+### 2. Build a Reference Density Matrix
+
+For each reference MPS `Phi_r`, reshape its current tensor at site `j` in the
+same way:
+
+`R_r = reshape(Phi_r[j], left_ref, d_j * chi_right)`.
+
+Then accumulate
+
+`rho_j = sum_r R_r^* R_r`.
+
+This traces out the left/environment side of each reference and leaves a
+density matrix on the same local right-block space where `B_j` lives:
+
+```text
+left side traced out
+        |
+        v
+R_r^* R_r  acts on  (site j) x (right block basis)
+```
+
+RydbergToolkit normalizes `rho_j` by its trace before projection. That makes the
+absolute tolerance less sensitive to the norm and number of reference states.
+
+### 3. Remove the Already Represented Directions
+
+The intended projector is the projector onto the complement of the row span of
+`B_j`:
+
+`P_j = I - projector(rowspan(B_j))`.
+
+The projected density matrix is
+
+`rho_missing = P_j rho_j P_j`.
+
+This matrix contains only the reference-state weight that cannot already be
+represented by the current bond basis.
+
+Implementation detail: the Julia code stores basis vectors as rows from `Vt`
+and forms the projector with `transpose(B_j) * conj(B_j)`. Several nearby
+comments in `expand.jl` mark conjugation and index order as items to verify.
+With a conventional column-vector bra/ket convention, the row-space projector
+would usually be written as `adjoint(B_j) * B_j`. A Rust translation should make
+the chosen convention explicit and test complex-valued MPS cases, rather than
+copying the expression without checking the bra/ket orientation.
+
+### 4. Diagonalize the Missing Density
+
+If `norm(rho_missing) > atol`, RydbergToolkit diagonalizes the Hermitian matrix
+`rho_missing` and keeps eigenvectors whose eigenvalues exceed `atol`:
+
+`C_j = significant eigenvectors of rho_missing`.
+
+Since Julia's `eigen` returns eigenvectors as columns, the code transposes them
+before appending them to the row-basis matrix:
+
+`E_j = stack_rows(B_j, C_j)`.
+
+If `rho_missing` is negligible, no new directions are added and `E_j = B_j`.
+
+The new bond dimension after this step is
+
+`rank(B_j) + number_of_kept_missing_directions`.
+
+There is no explicit maximum expansion dimension in `expand.jl`; the only
+filter is the eigenvalue tolerance.
+
+### 5. Replace the Right Tensor and Absorb Coefficients Left
+
+Reshape the expanded basis matrix:
+
+`E_j -> E_tensor[j]` with shape `(new_chi_left, d_j, chi_right)`.
+
+Then replace the two tensors around the cut by
+
+```text
+old:  A[j-1] -- A[j]
+new:  A_new[j-1] -- E_tensor[j]
+```
+
+where `A_new[j-1]` is obtained by contracting the old two-site block with the
+conjugate expanded basis on site `j` and the right bond.
+
+Conceptually:
+
+```text
+two-site block T = contract(A[j-1], A[j])
+
+A_new[j-1][..., ell] = <E_j[ell] | T>
+A_new[j]             = E_j
+```
+
+After this, the orthogonality center has moved from `j` to `j-1`.
+
+## Why the Target State Is Preserved
+
+The target state is not intentionally changed by GSE. Only its allowed bond
+space is enlarged.
+
+Before expansion, the right tensor `A[j]` lies completely in the row span of
+`B_j`:
+
+`A[j] = coefficients * B_j`.
+
+After expansion, `E_j` contains all rows of `B_j` plus extra rows from the
+projected reference density. Therefore the old tensor can be represented in the
+larger basis exactly, up to SVD/eigensolver tolerance:
+
+```text
+old right basis:       B_j
+expanded right basis:  [ B_j ]
+                       [ C_j ]
+
+old state coefficients in C_j directions: zero
+```
+
+The left tensor `A_new[j-1]` receives those coefficients. The added basis
+vectors therefore create empty variational directions for `psi`; they do not
+inject the reference states into `psi` immediately. Subsequent TDVP updates can
+then place amplitude in those new directions.
+
+This is why RydbergToolkit tests check that the overlap between the original
+and expanded target MPS is approximately one, while the maximum link dimension
+increases and the final orthogonality center is site `1`.
+
+## What Happens to Reference States During the Sweep
+
+The reference states are mutable work buffers. At each cut, each reference is
+projected into the same expanded basis `E_j` so that the next cut to the left
+can build a density matrix in a compatible gauge.
+
+For the next iteration, the important tensor is the updated
+`reference.data[j - 1]`: it contains the reference coefficients in the expanded
+right-block basis. The code also writes a tail tensor at `reference.data[j]`,
+but that line is marked with an index-order FIXME. Since the sweep never needs
+that already processed tensor again for density construction, a translation
+should treat the references as internal moving-center work buffers. If a Rust
+API returns expanded references, it should add separate validity tests for
+their tensor order and canonical form.
+
+## TDVP Integration in RydbergToolkit
+
+In `tdvp.jl`, GSE is enabled when `krylov_dim > 0`. The implementation:
+
+1. Performs an initial TDVP step.
+2. For each later time step, builds global Krylov references from the current
+   MPS.
+3. Calls `expand!` on the current MPS.
+4. Normalizes the expanded MPS if requested.
+5. Runs the next TDVP step, rebuilding environments instead of reusing the old
+   TDVP cache.
+
+The cache rebuild is essential: every expanded bond changes tensor shapes and
+invalidates projected-operator environments.
+
+## Mental Model
+
+GSE is a density-matrix basis-completion sweep.
+
+```text
+Current TDVP state psi:
+
+    ... -- A[j-1] == A[j] -- ...
+              chi_old
+
+Krylov references H psi, H^2 psi, ... show useful missing directions:
+
+    rho_ref on (site j) x (right block)
+       |
+       | remove directions already in psi basis
+       v
+    rho_missing
+       |
+       | keep dominant eigenvectors
+       v
+    extra basis rows C_j
+
+Expanded state:
+
+    ... -- A_new[j-1] == E[j] -- ...
+              chi_old + chi_extra
+```
+
+The state vector represented by `psi` is preserved, but TDVP now has a larger
+local tangent/variational space available on later updates.
+
+## Implications for a TreeTN Translation
+
+The chain algorithm has a single natural "right block" at each cut. A TreeTN
+translation must replace that with a directed-edge view.
+
+For an oriented edge `(parent, child)` in a rooted tree, the chain analogue is:
+
+```text
+parent side  ==  child tensor plus child-side subtrees
+             ^
+             expanded bond
+```
+
+The child tensor should be reshaped as
+
+```text
+rows:    bond index toward the parent
+columns: physical indices at child plus all child-side bond indices
+```
+
+assuming the child-side subtrees have already been orthogonalized into
+isometric bases. Then the same density-projection-eigenvector logic can enlarge
+the parent-child bond.
+
+The nontrivial parts are:
+
+| Chain assumption | TreeTN issue |
+|---|---|
+| There is one left and one right direction. | Every bond needs an explicit orientation relative to a root. |
+| Site `j` has columns `(physical, right_bond)`. | A tree node has `(physical indices, all child bonds except parent)`. |
+| A right-to-left sweep gives a natural order. | The sweep should follow a postorder over directed edges. |
+| Reference density uses one local tensor after the right block is canonical. | The reference work buffers must maintain compatible gauges on all already processed child subtrees. |
+| Bond update touches adjacent tensors `j-1` and `j`. | A TreeTN update touches the two endpoint tensors and must replace the shared bond index consistently. |
+| TDVP environments are chain arrays. | TreeTN projected-operator caches must invalidate all messages affected by expanded directed edges. |
+
+For issue-level planning, the key implementation target is therefore not "add
+KrylovKit". It is an edge-oriented TreeTN basis-expansion primitive that:
+
+1. builds low-rank reference states such as `H psi`, `H^2 psi`, ... without
+   hidden full materialization;
+2. sweeps directed edges in a canonical gauge;
+3. computes projected reference density matrices on local child-side spaces;
+4. expands shared bond indices while preserving the target state;
+5. updates reference work buffers consistently enough for the next edge; and
+6. hands the expanded state to the existing TreeTN TDVP with invalidated
+   environments.

--- a/docs/design/gse-chain-mps-algorithm.md
+++ b/docs/design/gse-chain-mps-algorithm.md
@@ -642,17 +642,21 @@ local tangent/variational space available on later updates.
 The chain algorithm has a single natural "right block" at each cut. A TreeTN
 translation must replace that with a directed-edge view.
 
-For an oriented edge `(parent, child)` in a rooted tree, the chain analogue is:
+Use a rooted tree with root `r`. For an edge `(p, c)`, let `p` be the endpoint
+closer to `r` and `c` the endpoint farther from `r`. The chain analogue is:
 
 ```text
-parent side  ==  child tensor plus child-side subtrees
-             ^
-             expanded bond
+root side / unprocessed complement -- bond a=(p,c) -- c-side subtree
 ```
 
-Let $a$ be the bond index from the child to the parent. Combine the physical
-indices at the child and all child-side outgoing bond indices into a single
-column multi-index $q$. The child tensor should be reshaped as
+This orientation matches the chain if the final root is the left end. The GSE
+sweep processes edges in postorder, from leaves toward `r`. At the moment edge
+`(p,c)` is processed, the whole `c`-side subtree has already been converted into
+a common basis for the target state and all reference work buffers.
+
+Let $a$ be the bond index on edge `(p,c)`. Combine the physical index at `c` and
+all already processed child-side bond indices incident to `c` into a column
+multi-index $q$:
 
 ```text
 rows:    a = bond index toward the parent
@@ -672,13 +676,14 @@ becomes the directed-edge reshape
 $$
 M_e[a,q]
 =
-T^{[\mathrm{child}]}_{a,q}.
+T^{[c]}_{a,q}.
 $$
 
 The same reference-state expansion works if the sweep invariant is generalized:
-before processing edge $e=(\mathrm{parent},\mathrm{child})$, every already
-processed child-side subtree is in a common orthonormal basis for the target
-and all references. Then each reference has a cut expansion
+before processing edge $e=(p,c)$, the target and every reference work buffer have
+their orthogonality center at `c`, and every already processed descendant
+subtree of `c` is represented in a common orthonormal basis. Then each reference
+has a cut expansion
 
 $$
 |\Phi_r\rangle
@@ -699,6 +704,220 @@ $$
 The old edge basis comes from the row-space SVD of $M_e$; projecting
 $\rho_e^{\mathrm{ref}}$ into the complement of that old row span and retaining
 dominant eigenvectors enlarges the parent-child bond exactly as in the chain.
+
+### TreeTN Sweep Invariant
+
+The hard part is not the local formula. The hard part is maintaining the common
+subtree basis while walking a branching topology.
+
+For a rooted postorder traversal, the invariant before processing edge `(p,c)`
+should be:
+
+1. every edge strictly below `c` has already been expanded;
+2. the target and all references use compatible bases for those processed
+   descendant bonds;
+3. the orthogonality center of each work buffer is at `c`;
+4. the bond `a=(p,c)` is the only open connection from the processed `c`-side
+   subtree to the unprocessed complement;
+5. the complement-side basis indexed by `a` is orthonormal for each work buffer,
+   so tracing the row index in $R_{r,e}^\dagger R_{r,e}$ is valid.
+
+For chains, this invariant is maintained automatically by the right-to-left
+sweep. For a branching TreeTN, a scheduler must move the center between sibling
+subtrees without changing already expanded descendant bases. The implementation
+should therefore not be a naive loop over unordered edges. It should build an
+explicit rooted postorder edge plan, and before each edge, move the target and
+all reference work buffers to the required child center `c`.
+
+This suggests an initial TreeTN GSE implementation should share the TDVP root
+planning convention but use a different update path:
+
+```text
+root r
+edge order: postorder directed edges (p, c), c far from r
+
+for (p, c) in edge_order:
+    move target and references to center c
+    expand bond (p, c) using the c-side density matrix
+    write the common expanded c-side basis into each work buffer
+    absorb each work buffer's coefficients into p
+    mark edge (p, c) orthogonal toward p
+```
+
+The final center after the full postorder expansion is the root `r`, matching
+the chain behavior where the original right-end-centered MPS finishes with
+orthocenter `1`.
+
+Be careful with tuple order. The existing TDVP planner stores postorder edges as
+`(child, parent)` because that is convenient for local TDVP updates. This note
+uses `(p, c)` for formulas, with `p` closer to the root. A TreeTN GSE
+implementation can reuse the same traversal, but it should explicitly rename
+planner tuples before applying the formulas.
+
+### Endpoint Update Formula
+
+After the projected-density step, let
+
+$$
+E_e[\ell,q]
+=
+\begin{bmatrix}
+B_e \\
+C_e
+\end{bmatrix}_{\ell,q}
+$$
+
+be the expanded row basis for the processed `c`-side space. If
+$M_e[a,q] = T^{[c]}_{a,q}$, compute the coefficient tensor
+
+$$
+G_e[a,\ell]
+=
+\sum_q M_e[a,q]\overline{E_e[\ell,q]}.
+$$
+
+Then update the two endpoint tensors by
+
+$$
+T'^{[c]}_{\ell,q} = E_e[\ell,q],
+$$
+
+and
+
+$$
+T'^{[p]}_{\ldots,\ell,\ldots}
+=
+\sum_a
+T^{[p]}_{\ldots,a,\ldots}\,
+G_e[a,\ell],
+$$
+
+where the slot `a` is the old bond index on edge `(p,c)`. The new shared bond
+index has dimension `dim(ell)`.
+
+Target preservation requires the old target row span to be retained. The SVD
+that extracts $B_e$ may discard numerical zeros, but it must not apply a
+reference-compression `maxdim`, a density cutoff, or any policy that truncates
+nonzero old target directions in the default state-preserving mode. Such a
+lossy mode would be a separate, explicitly named compression step.
+
+The reference work buffers use the same child-side basis but their own
+coefficients. For reference $r$, write its local matrix as $R_{r,e}[\gamma,q]$
+using the same logical $q$ ordering as above, then compute
+
+$$
+G^r_e[\gamma,\ell]
+=
+\sum_q R_{r,e}[\gamma,q]\overline{E_e[\ell,q]}.
+$$
+
+The reference child endpoint is replaced by the same numerical basis $E_e$
+renamed onto the reference-local site and child-side bond indices, while the
+reference parent endpoint absorbs $G^r_e$. This makes the processed `c`-side
+subtree a common basis for the next edge. The target state is preserved because
+its old row span is contained in $E_e$; references are only mutable work buffers
+and may be projected according to the chosen density cutoff.
+
+In tensor4all-rs this update must go through the TreeTN structural APIs:
+
+1. create a fresh bond index with the expanded dimension;
+2. call `TreeTN::replace_edge_bond(edge, new_bond)` before replacing endpoint
+   tensors, so `link_index_network`, `site_index_network`, and `ortho_towards`
+   stay consistent;
+3. replace the endpoint tensors with tensors carrying the new bond index;
+4. set `ortho_towards` on `(p,c)` to `p`, because the center has moved from `c`
+   toward the root side.
+
+Repeat the same structural update for every reference work buffer, but allocate
+buffer-local bond indices rather than reusing the target's `Index` object. The
+implementation should keep a logical mapping from target edge `(p,c)` to each
+work buffer's corresponding edge index.
+
+This mirrors the existing canonicalization implementation, which updates the
+edge bond before replacing tensors during a sweep edge.
+
+### Reference Work Buffers and Index Policy
+
+The references should be treated as internal work buffers, not as user-visible
+outputs of the expansion routine. The implementation needs an explicit index
+policy:
+
+- The target and reference work buffers should have the same tree topology.
+- Site index dimensions must match the target. For the first implementation,
+  keep the same v1 TDVP restriction: exactly one state site index per node.
+- Reference link IDs should not be assumed to be identical to target link IDs.
+  Existing TDVP support deliberately uses `sim_linkinds_mut()` for reference
+  states to avoid accidental bra/ket contractions.
+- For the local $q$ multi-index, the code should build an explicit
+  reference-to-target map covering both the state site index at `c` and every
+  processed child-side bond. Current TDVP reference initialization clones the
+  target state and then changes link indices, so site indices may be shared by
+  construction while link indices differ. The GSE code should still model this
+  as a logical-position-and-dimension map, not as raw index-ID equality.
+- When forming $R_{r,e}^\dagger R_{r,e}$, use temporary bra/ket copies of the
+  local row and column indices so the contraction traces only the row index and
+  leaves a density matrix on the target-compatible $q$ space.
+
+This is the same reason `ProjectedOperator` uses stable temporary mappings for
+local apply: relying on raw index equality across ket, bra, and operator tensors
+is too fragile once multiple TreeTNs participate in one contraction.
+
+### Reference Generation and Topology Compatibility
+
+The reference states $H\psi, H^2\psi,\ldots$ must be generated without hidden
+full materialization. They also need to be brought back to the target topology
+before GSE. Otherwise there is no well-defined edge `(p,c)` or local $q$ space
+shared by the target and the references.
+
+For an initial implementation, require:
+
+1. `apply_linear_operator` or a topology-preserving contraction path produces a
+   reference on the same node set and edge set as the target;
+2. each reference is compressed with the chosen reference SVD policy and maximum
+   bond dimension;
+3. each reference is reindexed/restructured to match the target's site-space
+   layout, while keeping link IDs collision-safe;
+4. after every operator application, explicitly verify site-space compatibility
+   with the target, including site index dimensions on each logical node;
+5. do not rely on shallow topology helpers that only clone or assume an
+   operator preserves site structure without checking the actual output;
+6. if topology preservation fails, return an explicit error rather than falling
+   back to full dense application.
+
+This keeps the implementation aligned with the repository rule that production
+paths must not silently materialize full dense tensors.
+
+### Initial Scope and Validation
+
+The first TreeTN GSE-TDVP implementation should be deliberately narrow:
+
+| Decision | Initial scope |
+|---|---|
+| State topology | Tree only, same topology for target, references, and operator support. |
+| Site space | One state site index per node, matching current TDVP v1. |
+| Sweep | Rooted postorder edge expansion ending at the requested TDVP root. |
+| Reference generation | Topology-preserving `H` application plus compression; no dense fallback. |
+| AD | Preserve tensor payloads where supported; any primal-only basis selection must be explicit. |
+| Cache | Fully clear/rebuild TDVP `ProjectedOperator` environments after GSE, or invalidate every node incident to a changed bond. Do not rely on invalidating only the final root. |
+
+Validation should include:
+
+1. chain TreeTN results matching the documented MPS algorithm on small complex
+   examples;
+2. branching trees where two sibling leaves and at least one high-degree
+   internal node are expanded before their parent edge, checking the
+   common-basis invariant;
+3. overlap/state-distance preservation for the target before and after
+   expansion, including a case where the reference cutoff is aggressive enough
+   to truncate reference directions but must not truncate the old target basis;
+4. link dimension growth only on selected edges, with `link_index_network`,
+   `site_index_network`, and `ortho_towards` consistency checks;
+5. cache behavior: a TDVP step after GSE must rebuild or invalidate projected
+   environments rather than using stale tensors, including reverse-direction
+   environment entries;
+6. explicit errors for a non-topology-preserving operator application;
+7. complex and, if relevant, non-Hermitian reference-generation cases that
+   exercise the conjugation convention in $G_e$ and $G^r_e$.
 
 ### AD Preservation
 
@@ -785,6 +1004,6 @@ KrylovKit". It is an edge-oriented TreeTN basis-expansion primitive that:
 4. expands shared bond indices while preserving the target state;
 5. updates reference work buffers consistently enough for the next edge; and
 6. preserves AD metadata except at explicitly named nondifferentiable selection
-   boundaries; and
+   boundaries;
 7. hands the expanded state to the existing TreeTN TDVP with invalidated
    environments.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -8,6 +8,12 @@
 | [torch_backend.md](./torch_backend.md) | PyTorch backend design exploration |
 | [tenferro_ad_scalar_operator_extension_note.md](./tenferro_ad_scalar_operator_extension_note.md) | Tenferro AD scalar operator extension notes |
 
+## Tensor Networks
+
+| Document | Description |
+|----------|-------------|
+| [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |
+
 ## Automatic Differentiation
 
 | Document | Description |


### PR DESCRIPTION
## Summary

- Document the chain-MPS GSE algorithm with reshape/projection SVG diagrams.
- Add TreeTN GSE and GSE-TDVP v1 for single-site-index TreeTN states and two-site-index TreeTN operators.
- Add AD-preserving TensorDynLen reshape/eigh support used by the GSE density projection path.
- Add GSE coverage for chains, branching trees, operator-built Krylov references, AD tracking, complex reference directions, and mixed real/complex scalar storage.

## Motivation

GSE should expand the local bond basis from reference/Krylov states without making scalar storage a mathematical constraint. The implementation now relies on TensorDynLen/backend promotion instead of pre-rejecting mixed f64/Complex64 cases.

## Validation

- `cargo test --release -p tensor4all-treetn --test gse`
- `cargo test --release -p tensor4all-treetn`
- `cargo test -p tensor4all-core`
- `cargo test -p tensor4all-treetn`
- `cargo clippy -p tensor4all-core --all-targets -- -D warnings`
- `cargo clippy -p tensor4all-treetn --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

This PR is draft while CI is being monitored.