### PR TITLE
Fix ID-only index matching

### DIFF
--- a/crates/tensor4all-core/src/block_tensor/tests/mod.rs
+++ b/crates/tensor4all-core/src/block_tensor/tests/mod.rs
@@ -450,7 +450,7 @@ fn test_external_indices_deduplication() {
     let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
     let ext = block.external_indices();
     assert_eq!(ext.len(), 1, "Shared index should appear once");
-    assert!(ext[0].same_id(&idx));
+    assert_eq!(ext[0], idx);
 }
 
 #[test]
@@ -544,7 +544,7 @@ fn test_replaceind() {
     // All blocks should now use new_idx
     for blk in replaced.blocks() {
         let ext = blk.external_indices();
-        assert!(ext[0].same_id(&new_idx));
+        assert_eq!(ext[0], new_idx);
     }
     // Data should be preserved
     let data = replaced.get(0, 0).unwrap().to_vec::<f64>().unwrap();

--- a/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::defaults::Index;
+use crate::defaults::{Index, TagSet};
 use num_complex::Complex64;
 use std::ffi::OsString;
 use std::time::Duration;
@@ -101,6 +101,19 @@ fn test_contract_default_entry_rejects_disconnected_inputs() {
 
     let a = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
     let b = TensorDynLen::from_dense(vec![j], vec![3.0_f64, 4.0, 5.0]).unwrap();
+
+    let err = contract(&[&a, &b]).unwrap_err();
+    assert!(err.to_string().contains("Disconnected"));
+}
+
+#[test]
+fn test_contract_same_id_different_tags_is_disconnected() {
+    let id = DynId(90);
+    let site = Index::new_with_tags(id, 2, TagSet::from_str("site").unwrap());
+    let link = Index::new_with_tags(id, 2, TagSet::from_str("link").unwrap());
+
+    let a = TensorDynLen::from_dense(vec![site], vec![1.0_f64, 2.0]).unwrap();
+    let b = TensorDynLen::from_dense(vec![link], vec![3.0_f64, 4.0]).unwrap();
 
     let err = contract(&[&a, &b]).unwrap_err();
     assert!(err.to_string().contains("Disconnected"));

--- a/crates/tensor4all-core/src/index_like.rs
+++ b/crates/tensor4all-core/src/index_like.rs
@@ -36,7 +36,7 @@ pub enum ConjState {
     /// Directionless index (ITensors.jl-like default).
     ///
     /// Undirected indices can contract with other undirected indices
-    /// if they have the same ID and dimension.
+    /// only when their full index identity matches and their dimensions match.
     Undirected,
     /// Ket (ingoing) index.
     ///
@@ -78,10 +78,10 @@ pub enum ConjState {
 /// - `Bra`: Outgoing index (QSpace: trailing `*` in itag)
 ///
 /// Two indices are contractable if:
-/// - They have the same `id()` and `dim()`
-/// - Their conjugate states are compatible:
-///   - `(Ket, Bra)` or `(Bra, Ket)` → contractable
-///   - `(Undirected, Undirected)` → contractable
+/// - Their dimensions match
+/// - Their full index identity is compatible:
+///   - `(Undirected, Undirected)` → equal indices
+///   - `(Ket, Bra)` or `(Bra, Ket)` → one index is the other's conjugate
 ///   - Mixed `(Undirected, Ket/Bra)` → **not contractable** (mixing forbidden)
 ///
 /// # Example
@@ -102,24 +102,26 @@ pub enum ConjState {
 pub trait IndexLike: Clone + Eq + Hash + Debug + Send + Sync + 'static {
     /// Lightweight identifier type (conjugate-independent).
     ///
-    /// **Rule**: Contractable indices must have the same ID.
+    /// **Rule**: Contractable indices must have compatible full index identity.
     ///
-    /// The ID serves as a "pairing key" to identify which legs are intended to contract.
+    /// The ID serves as a lightweight component of full index identity.
     /// In large tensor networks, IDs enable efficient graph-based lookups (O(1) with HashSet/HashMap)
     /// to find matching legs across many tensors.
     ///
-    /// This is separate from dimension/direction checks:
-    /// - **ID**: "intent to pair" (which specific legs should connect)
-    /// - **dim/ConjState**: "mathematical compatibility" (can they actually contract)
+    /// This is separate from the full `Eq`/`Hash` identity:
+    /// - **ID**: raw logical identifier, useful for serialization and diagnostics
+    /// - **Eq/Hash**: concrete tensor leg identity used by maps, sets, and contraction
+    /// - **dim/ConjState**: mathematical compatibility checks
     type Id: Clone + Eq + Hash + Debug + Send + Sync;
 
     /// Get the identifier of this index.
     ///
-    /// The ID is used as the pairing key during contraction.
-    /// **Contractable indices must have the same ID** — this is enforced by `is_contractable()`.
+    /// The ID is a lightweight raw identifier.
+    /// **Do not use ID-only equality as concrete tensor leg identity**; use full index
+    /// equality, or `is_contractable()` when deciding contraction compatibility.
     ///
-    /// Two indices with the same ID represent the same logical leg (though they may differ
-    /// in conjugate state for directed indices).
+    /// Two indices with the same ID may still be distinct concrete legs, for example when
+    /// they differ by prime level, tags, or direction.
     fn id(&self) -> &Self::Id;
 
     /// Get the total dimension (state-space dimension) of the index.
@@ -149,26 +151,28 @@ pub trait IndexLike: Clone + Eq + Hash + Debug + Send + Sync + 'static {
     /// Check if this index can be contracted with another index.
     ///
     /// Two indices are contractable if:
-    /// - They have the same `id()` and `dim()`
-    /// - Their conjugate states are compatible:
-    ///   - `(Ket, Bra)` or `(Bra, Ket)` → contractable
-    ///   - `(Undirected, Undirected)` → contractable
+    /// - They have the same dimension
+    /// - Their full identity is compatible:
+    ///   - `(Undirected, Undirected)` → equal indices
+    ///   - `(Ket, Bra)` or `(Bra, Ket)` → one index is the other's conjugate
     ///   - Mixed `(Undirected, Ket/Bra)` → **not contractable** (mixing forbidden)
     ///
     /// # Default Implementation
     ///
     /// The default implementation checks:
-    /// 1. Same ID: `self.id() == other.id()`
-    /// 2. Same dimension: `self.dim() == other.dim()`
-    /// 3. Same prime level: `self.plev() == other.plev()`
-    /// 4. Compatible conjugate states (see rules above)
+    /// 1. Same dimension: `self.dim() == other.dim()`
+    /// 2. Compatible conjugate states (see rules above)
+    /// 3. Full index equality for undirected indices, or conjugate full equality for
+    ///    directed pairs.
     fn is_contractable(&self, other: &Self) -> bool {
-        if self.id() != other.id() || self.dim() != other.dim() || self.plev() != other.plev() {
+        if self.dim() != other.dim() {
             return false;
         }
         match (self.conj_state(), other.conj_state()) {
-            (ConjState::Ket, ConjState::Bra) | (ConjState::Bra, ConjState::Ket) => true,
-            (ConjState::Undirected, ConjState::Undirected) => true,
+            (ConjState::Ket, ConjState::Bra) | (ConjState::Bra, ConjState::Ket) => {
+                self.conj() == other.clone()
+            }
+            (ConjState::Undirected, ConjState::Undirected) => self == other,
             _ => false, // Mixed directed/undirected is forbidden
         }
     }

--- a/crates/tensor4all-core/tests/common_index_ops.rs
+++ b/crates/tensor4all-core/tests/common_index_ops.rs
@@ -1,9 +1,9 @@
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index_ops::{
-    common_inds, hascommoninds, hasind, hasinds, noncommon_inds, replaceinds, replaceinds_in_place,
-    union_inds, unique_inds, ReplaceIndsError,
+    common_ind_positions, common_inds, hascommoninds, hasind, hasinds, noncommon_inds, replaceinds,
+    replaceinds_in_place, union_inds, unique_inds, ReplaceIndsError,
 };
-use tensor4all_core::IndexLike;
+use tensor4all_core::{DynId, IndexLike, TagSet};
 
 #[test]
 fn test_sim_preserves_symm_and_tags() {
@@ -219,6 +219,18 @@ fn test_index_ops_distinguish_same_id_prime_pair() {
 
     let replaced = replaceinds(indices, &[(i_prime.clone(), replacement.clone())]).unwrap();
     assert_eq!(replaced, vec![i, replacement]);
+}
+
+#[test]
+fn test_common_ind_positions_distinguish_same_id_tag_pair() {
+    let id = DynId(42);
+    let site = Index::new_with_tags(id, 2, TagSet::from_str("site").unwrap());
+    let link = Index::new_with_tags(id, 2, TagSet::from_str("link").unwrap());
+
+    assert!(site.same_id(&link));
+    assert_ne!(site, link);
+    assert!(!site.is_contractable(&link));
+    assert!(common_ind_positions(&[site], &[link]).is_empty());
 }
 
 #[test]

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use tensor4all_core::{DynIndex, IndexLike};
+use tensor4all_core::DynIndex;
 use tensor4all_treetn::{square_linsolve, IndexMapping, TruncationOptions};
 
 use crate::error::{Result, TensorTrainError};
@@ -146,9 +146,9 @@ type SiteMappings = (
 /// Infer index mappings from the MPO/MPS structure.
 ///
 /// For each site where the operator has exactly 2 site indices and init has 1,
-/// finds the operator index sharing an ID with init's index (input) and the
-/// remaining one (output). Returns `(None, None)` when no mappings are needed
-/// (operator and init share all site indices).
+/// finds the operator index exactly matching init's index (input) and the
+/// remaining full index (output). Returns `(None, None)` when no mappings are
+/// needed (operator and init share all site indices).
 fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<SiteMappings> {
     let op_treetn = operator.as_treetn();
     let init_treetn = init.as_treetn();
@@ -163,7 +163,7 @@ fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<Si
 
         if let (Some(op_indices), Some(init_indices)) = (op_site, init_site) {
             if op_indices.len() == 2 && init_indices.len() == 1 {
-                // MPO-like site: check if we need mappings
+                // MPO-like site: exact input match plus one distinct output leg.
                 let init_idx =
                     init_indices
                         .iter()
@@ -171,31 +171,27 @@ fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<Si
                         .ok_or_else(|| TensorTrainError::OperationError {
                             message: format!("Site {site}: init site space is empty"),
                         })?;
-                let has_shared = op_indices.iter().any(|idx| idx.same_id(init_idx));
-                if has_shared {
-                    // The shared index exists but may differ by plev → need mapping
-                    let input_idx = op_indices.iter().find(|idx| idx.same_id(init_idx));
-                    if let Some(input_idx) = input_idx {
-                        if input_idx != init_idx {
-                            needs_mapping = true;
-                        }
-                    }
-                    // Check if output index differs from init
-                    let output_idx = op_indices.iter().find(|idx| !idx.same_id(init_idx));
-                    if output_idx.is_some() {
-                        needs_mapping = true;
-                    }
-                } else {
-                    return Err(TensorTrainError::OperationError {
+                let op_input = op_indices
+                    .iter()
+                    .find(|idx| *idx == init_idx)
+                    .ok_or_else(|| TensorTrainError::OperationError {
                         message: format!(
-                            "Site {}: operator has 2 site indices but none share an ID with init's \
+                            "Site {}: operator has 2 site indices but none exactly match init's \
                              site index {:?}. Cannot auto-infer index mappings. \
                              Use the treetn-level API with explicit IndexMapping.",
-                            site,
-                            init_idx.id()
+                            site, init_idx
                         ),
-                    });
-                }
+                    })?;
+                op_indices
+                    .iter()
+                    .find(|idx| *idx != op_input)
+                    .ok_or_else(|| TensorTrainError::OperationError {
+                        message: format!(
+                            "Site {site}: operator has no output index distinct from init index {:?}",
+                            init_idx
+                        ),
+                    })?;
+                needs_mapping = true;
             }
         }
     }
@@ -224,20 +220,20 @@ fn infer_index_mappings(operator: &TensorTrain, init: &TensorTrain) -> Result<Si
 
                 let op_input = op_indices
                     .iter()
-                    .find(|idx| idx.same_id(init_idx))
+                    .find(|idx| *idx == init_idx)
                     .ok_or_else(|| TensorTrainError::OperationError {
                         message: format!(
-                            "Site {site}: operator has no input index sharing an ID with init index {:?}",
-                            init_idx.id()
+                            "Site {site}: operator has no input index exactly matching init index {:?}",
+                            init_idx
                         ),
                     })?;
                 let op_output = op_indices
                     .iter()
-                    .find(|idx| !idx.same_id(init_idx))
+                    .find(|idx| *idx != op_input)
                     .ok_or_else(|| TensorTrainError::OperationError {
                         message: format!(
                             "Site {site}: operator has no output index distinct from init index {:?}",
-                            init_idx.id()
+                            init_idx
                         ),
                     })?;
 
@@ -300,5 +296,28 @@ mod tests {
 
         assert!(matches!(err, TensorTrainError::OperationError { .. }));
         assert!(err.to_string().contains("Cannot auto-infer index mappings"));
+    }
+
+    #[test]
+    fn infer_index_mappings_handles_same_id_primed_output() {
+        let init_site = DynIndex::new_dyn(2);
+        let output_site = init_site.prime();
+
+        let operator = TensorTrain::new(vec![make_tensor(
+            vec![output_site.clone(), init_site.clone()],
+            vec![1.0, 0.0, 0.0, 1.0],
+        )])
+        .unwrap();
+        let init =
+            TensorTrain::new(vec![make_tensor(vec![init_site.clone()], vec![1.0, 2.0])]).unwrap();
+
+        let (input_mapping, output_mapping) = infer_index_mappings(&operator, &init).unwrap();
+        let input_mapping = input_mapping.unwrap();
+        let output_mapping = output_mapping.unwrap();
+
+        assert_eq!(input_mapping[&0].true_index, init_site);
+        assert_eq!(input_mapping[&0].internal_index, init_site);
+        assert_eq!(output_mapping[&0].true_index, init_site);
+        assert_eq!(output_mapping[&0].internal_index, output_site);
     }
 }

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -1446,8 +1446,8 @@ fn test_replaceind() {
 
     // The new TT should have the new index
     let ext_inds = tt2.external_indices();
-    assert!(ext_inds.iter().any(|i| i.id() == new_s0.id()));
-    assert!(!ext_inds.iter().any(|i| i.id() == s0.id()));
+    assert!(ext_inds.contains(&new_s0));
+    assert!(!ext_inds.contains(&s0));
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -276,24 +276,18 @@ where
             if let Some(state_idx) = state.node_index(node) {
                 if let Some(state_tensor) = state.tensor(state_idx) {
                     let state_indices_vec = state_tensor.external_indices();
-                    let state_indices: Vec<_> = state_indices_vec
-                        .iter()
-                        .map(|idx| (idx.id().clone(), idx.dim()))
-                        .collect();
 
                     // Get operator tensor indices
                     if let Some(op_idx) = operator.node_index(node) {
                         if let Some(op_tensor) = operator.tensor(op_idx) {
                             let op_indices_vec = op_tensor.external_indices();
-                            let op_indices: Vec<_> = op_indices_vec
-                                .iter()
-                                .map(|idx| (idx.id().clone(), idx.dim()))
-                                .collect();
 
-                            // Check for common indices (should have at least bond indices)
-                            let common_count = state_indices
+                            // Check for common full indices (should have at least bond indices)
+                            let common_count = state_indices_vec
                                 .iter()
-                                .filter(|(id, _)| op_indices.iter().any(|(oid, _)| oid == id))
+                                .filter(|state_idx| {
+                                    op_indices_vec.iter().any(|op_idx| op_idx == *state_idx)
+                                })
                                 .count();
 
                             report.node_details.push(NodeVerifyDetail {
@@ -304,13 +298,13 @@ where
                                 op_site_indices: op_site
                                     .map(|s| s.iter().map(|i| format!("{:?}", i.id())).collect())
                                     .unwrap_or_default(),
-                                state_tensor_indices: state_indices
+                                state_tensor_indices: state_indices_vec
                                     .iter()
-                                    .map(|(id, dim)| format!("{:?}(dim={})", id, dim))
+                                    .map(|idx| format!("{:?}(dim={})", idx, idx.dim()))
                                     .collect(),
-                                op_tensor_indices: op_indices
+                                op_tensor_indices: op_indices_vec
                                     .iter()
-                                    .map(|(id, dim)| format!("{:?}(dim={})", id, dim))
+                                    .map(|idx| format!("{:?}(dim={})", idx, idx.dim()))
                                     .collect(),
                                 common_index_count: common_count,
                             });
@@ -320,10 +314,10 @@ where
                             // that match state's site indices
                             if common_count == 0 {
                                 report.warnings.push(format!(
-                                    "Node {:?}: No common indices between state and operator tensors. \
+                                        "Node {:?}: No common indices between state and operator tensors. \
                                      State has {:?}, operator has {:?}",
-                                    node, state_indices, op_indices
-                                ));
+                                        node, state_indices_vec, op_indices_vec
+                                    ));
                             }
                         }
                     }
@@ -804,12 +798,12 @@ where
 
             let x_external: Vec<_> = x_sites
                 .iter()
-                .filter(|idx| !idx.same_id(&x_contracted))
+                .filter(|idx| *idx != &x_contracted)
                 .cloned()
                 .collect();
             let b_external: Vec<_> = b_sites
                 .iter()
-                .filter(|idx| !idx.same_id(&b_contracted))
+                .filter(|idx| *idx != &b_contracted)
                 .cloned()
                 .collect();
 
@@ -826,13 +820,13 @@ where
 
             let x_ext = &x_external[0];
             let b_ext = &b_external[0];
-            if !x_ext.same_id(b_ext) || x_ext.dim() != b_ext.dim() {
+            if x_ext != b_ext {
                 return Err(anyhow::anyhow!(
                     "MPO validation: external index mismatch at node {:?}: x has {:?}:{}, b has {:?}:{}",
                     node,
-                    x_ext.id(),
+                    x_ext,
                     x_ext.dim(),
-                    b_ext.id(),
+                    b_ext,
                     b_ext.dim(),
                 ));
             }
@@ -861,9 +855,15 @@ fn local_gmres_options(options: &LinsolveOptions) -> Result<GmresOptions> {
 
 #[cfg(test)]
 mod tests {
-    use tensor4all_core::{DynIndex, TensorDynLen};
+    use tensor4all_core::{DynId, DynIndex, TagSet, TensorDynLen};
 
     use super::*;
+
+    fn one_node_state(node: usize, indices: Vec<DynIndex>) -> TreeTN<TensorDynLen, usize> {
+        let len = indices.iter().map(|idx| idx.dim()).product();
+        let tensor = TensorDynLen::from_dense(indices, vec![1.0_f64; len]).unwrap();
+        TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![node]).unwrap()
+    }
 
     #[test]
     fn index_sets_match_distinguishes_same_id_prime_pair() {
@@ -877,6 +877,65 @@ mod tests {
 
         assert!(updater.index_sets_match(std::slice::from_ref(&i), std::slice::from_ref(&i)));
         assert!(!updater.index_sets_match(&[i], &[i_prime]));
+    }
+
+    #[test]
+    fn verify_counts_only_full_index_overlap() {
+        let id = DynId(700);
+        let state_site = DynIndex::new_with_tags(id, 2, TagSet::from_str("state").unwrap());
+        let op_site = DynIndex::new_with_tags(id, 2, TagSet::from_str("operator").unwrap());
+        let state = one_node_state(0, vec![state_site.clone()]);
+        let rhs = one_node_state(0, vec![state_site]);
+        let operator = one_node_state(0, vec![op_site]);
+
+        let updater = SquareLinsolveUpdater::<TensorDynLen, usize>::new(
+            operator,
+            rhs,
+            LinsolveOptions::default(),
+        );
+        let report = updater.verify(&state).unwrap();
+
+        assert_eq!(report.node_details[0].common_index_count, 0);
+        assert_eq!(report.warnings.len(), 1);
+    }
+
+    #[test]
+    fn validate_mpo_external_indices_keeps_same_id_primed_external_leg() {
+        let contracted = DynIndex::new_dyn(2);
+        let external = contracted.prime();
+        let state = one_node_state(0, vec![external.clone(), contracted.clone()]);
+        let rhs = one_node_state(0, vec![external.clone(), contracted.clone()]);
+
+        let op_in = DynIndex::new_dyn(2);
+        let op_out = DynIndex::new_dyn(2);
+        let operator = one_node_state(0, vec![op_out.clone(), op_in.clone()]);
+
+        let mut input_mapping = HashMap::new();
+        input_mapping.insert(
+            0,
+            IndexMapping {
+                true_index: contracted.clone(),
+                internal_index: op_in,
+            },
+        );
+        let mut output_mapping = HashMap::new();
+        output_mapping.insert(
+            0,
+            IndexMapping {
+                true_index: contracted,
+                internal_index: op_out,
+            },
+        );
+
+        let mut updater = SquareLinsolveUpdater::<TensorDynLen, usize>::with_index_mappings(
+            operator,
+            input_mapping,
+            output_mapping,
+            rhs,
+            LinsolveOptions::default(),
+        );
+
+        updater.validate_mpo_external_indices(&state).unwrap();
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -419,8 +419,8 @@ where
 ///     &[(op_input, state_index.clone())],
 ///     &[(op_output, state_index.clone())],
 /// ).unwrap();
-/// assert!(rebound.get_input_mapping(&0).unwrap().true_index.same_id(&state_index));
-/// assert!(rebound.get_output_mapping(&0).unwrap().true_index.same_id(&state_index));
+/// assert_eq!(rebound.get_input_mapping(&0).unwrap().true_index, state_index);
+/// assert_eq!(rebound.get_output_mapping(&0).unwrap().true_index, state_index);
 /// ```
 pub fn bind_linear_operator_indices<T, V>(
     operator: &LinearOperator<T, V>,

--- a/crates/tensor4all-treetn/src/operator/linear_operator.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator.rs
@@ -721,8 +721,8 @@ where
     /// let mut op = LinearOperator::new(mpo, input_mapping, output_mapping);
     /// op.align_to_state(&state).unwrap();
     ///
-    /// assert!(op.get_input_mapping(&0).unwrap().true_index.same_id(&state_index));
-    /// assert!(op.get_output_mapping(&0).unwrap().true_index.same_id(&state_index));
+    /// assert_eq!(op.get_input_mapping(&0).unwrap().true_index, state_index);
+    /// assert_eq!(op.get_output_mapping(&0).unwrap().true_index, state_index);
     /// ```
     pub fn align_to_state(&mut self, state: &TreeTN<T, V>) -> Result<()> {
         self.set_input_space_from_state(state)?;
@@ -745,7 +745,7 @@ where
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let site_in = DynIndex::new_dyn(2);
@@ -774,8 +774,8 @@ where
     /// let t = op.transpose();
     ///
     /// // Input/output mappings are swapped.
-    /// assert!(t.get_input_mapping(&0).unwrap().true_index.same_id(&site_out));
-    /// assert!(t.get_output_mapping(&0).unwrap().true_index.same_id(&site_in));
+    /// assert_eq!(t.get_input_mapping(&0).unwrap().true_index, site_out);
+    /// assert_eq!(t.get_output_mapping(&0).unwrap().true_index, site_in);
     /// ```
     pub fn transpose(self) -> Self {
         Self {
@@ -960,7 +960,7 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::{DynIndex, IndexLike, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// # fn main() -> anyhow::Result<()> {
@@ -988,8 +988,8 @@ where
     ///
     /// let mappings = unfused.get_input_mappings(&0).unwrap();
     /// assert_eq!(mappings.len(), 2);
-    /// assert!(mappings[0].true_index.same_id(&x0));
-    /// assert!(mappings[1].true_index.same_id(&x1));
+    /// assert_eq!(mappings[0].true_index, x0);
+    /// assert_eq!(mappings[1].true_index, x1);
     /// # Ok(())
     /// # }
     /// ```
@@ -1032,7 +1032,7 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::{DynIndex, IndexLike, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// # fn main() -> anyhow::Result<()> {
@@ -1060,8 +1060,8 @@ where
     ///
     /// let mappings = unfused.get_output_mappings(&0).unwrap();
     /// assert_eq!(mappings.len(), 2);
-    /// assert!(mappings[0].true_index.same_id(&y0));
-    /// assert!(mappings[1].true_index.same_id(&y1));
+    /// assert_eq!(mappings[0].true_index, y0);
+    /// assert_eq!(mappings[1].true_index, y1);
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
@@ -1,8 +1,6 @@
 use super::*;
 use std::collections::{HashMap, HashSet};
-use tensor4all_core::{
-    DynIndex, IndexLike, LinearizationOrder, TensorConstructionLike, TensorDynLen,
-};
+use tensor4all_core::{DynIndex, LinearizationOrder, TensorConstructionLike, TensorDynLen};
 
 use crate::operator::index_mapping::IndexMapping;
 use crate::operator::Operator;
@@ -233,11 +231,11 @@ fn test_linear_operator_input_output_site_indices() {
 
     let input_indices = op.input_site_indices();
     assert_eq!(input_indices.len(), 1);
-    assert!(input_indices.iter().any(|i| i.id() == s.id()));
+    assert!(input_indices.contains(&s));
 
     let output_indices = op.output_site_indices();
     assert_eq!(output_indices.len(), 1);
-    assert!(output_indices.iter().any(|i| i.id() == s.id()));
+    assert!(output_indices.contains(&s));
 }
 
 #[test]
@@ -540,7 +538,7 @@ fn test_align_to_state_single_node() {
 
     // Create a new state with a *different* site index (same dimension)
     let new_s = DynIndex::new_dyn(2);
-    assert_ne!(original_s.id(), new_s.id());
+    assert_ne!(original_s, new_s);
 
     let state_tensor = TensorDynLen::from_dense(vec![new_s.clone()], vec![0.5, 0.5]).unwrap();
     let state =
@@ -552,10 +550,10 @@ fn test_align_to_state_single_node() {
 
     // Verify: true indices should now match the state's site index
     let input_mapping = op.get_input_mapping(&"A".to_string()).unwrap();
-    assert_eq!(input_mapping.true_index.id(), new_s.id());
+    assert_eq!(input_mapping.true_index, new_s);
 
     let output_mapping = op.get_output_mapping(&"A".to_string()).unwrap();
-    assert_eq!(output_mapping.true_index.id(), new_s.id());
+    assert_eq!(output_mapping.true_index, new_s);
 
     // Verify: operator should still work correctly after alignment
     let local_tensor = TensorDynLen::from_dense(vec![new_s.clone()], vec![1.0, 0.0]).unwrap();
@@ -575,8 +573,8 @@ fn test_align_to_state_two_nodes() {
     let new_s0 = DynIndex::new_dyn(2);
     let new_s1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(1);
-    assert_ne!(original_s0.id(), new_s0.id());
-    assert_ne!(original_s1.id(), new_s1.id());
+    assert_ne!(original_s0, new_s0);
+    assert_ne!(original_s1, new_s1);
 
     let t_a = TensorDynLen::from_dense(vec![new_s0.clone(), bond.clone()], vec![1.0; 2]).unwrap();
     let t_b = TensorDynLen::from_dense(vec![bond.clone(), new_s1.clone()], vec![1.0; 2]).unwrap();
@@ -592,16 +590,16 @@ fn test_align_to_state_two_nodes() {
 
     // Verify: true indices should match the state's site indices
     let input_a = op.get_input_mapping(&"A".to_string()).unwrap();
-    assert_eq!(input_a.true_index.id(), new_s0.id());
+    assert_eq!(input_a.true_index, new_s0);
 
     let input_b = op.get_input_mapping(&"B".to_string()).unwrap();
-    assert_eq!(input_b.true_index.id(), new_s1.id());
+    assert_eq!(input_b.true_index, new_s1);
 
     let output_a = op.get_output_mapping(&"A".to_string()).unwrap();
-    assert_eq!(output_a.true_index.id(), new_s0.id());
+    assert_eq!(output_a.true_index, new_s0);
 
     let output_b = op.get_output_mapping(&"B".to_string()).unwrap();
-    assert_eq!(output_b.true_index.id(), new_s1.id());
+    assert_eq!(output_b.true_index, new_s1);
 
     // Verify: operator still works after alignment
     let local_tensor = TensorDynLen::from_dense(
@@ -676,10 +674,10 @@ fn test_linear_operator_transpose_swaps_mappings() {
         .get("A")
         .and_then(|mappings| mappings.first())
         .unwrap();
-    assert!(tin.true_index.same_id(&expected_in.true_index));
-    assert!(tin.internal_index.same_id(&expected_in.internal_index));
-    assert!(tout.true_index.same_id(&expected_out.true_index));
-    assert!(tout.internal_index.same_id(&expected_out.internal_index));
+    assert_eq!(tin.true_index, expected_in.true_index);
+    assert_eq!(tin.internal_index, expected_in.internal_index);
+    assert_eq!(tout.true_index, expected_out.true_index);
+    assert_eq!(tout.internal_index, expected_out.internal_index);
 }
 
 #[test]
@@ -704,10 +702,10 @@ fn test_linear_operator_transpose_is_involutive() {
         .get("A")
         .and_then(|mappings| mappings.first())
         .unwrap();
-    assert!(rin.true_index.same_id(&ein.true_index));
-    assert!(rin.internal_index.same_id(&ein.internal_index));
-    assert!(rout.true_index.same_id(&eout.true_index));
-    assert!(rout.internal_index.same_id(&eout.internal_index));
+    assert_eq!(rin.true_index, ein.true_index);
+    assert_eq!(rin.internal_index, ein.internal_index);
+    assert_eq!(rout.true_index, eout.true_index);
+    assert_eq!(rout.internal_index, eout.internal_index);
 }
 
 #[test]
@@ -745,13 +743,13 @@ fn test_unfuse_input_and_output_indices_splits_internal_mpo_axes() {
 
     let input_mappings = op.get_input_mappings(&"A".to_string()).unwrap();
     assert_eq!(input_mappings.len(), 2);
-    assert!(input_mappings[0].true_index.same_id(&input0));
-    assert!(input_mappings[1].true_index.same_id(&input1));
+    assert_eq!(input_mappings[0].true_index, input0);
+    assert_eq!(input_mappings[1].true_index, input1);
 
     let output_mappings = op.get_output_mappings(&"A".to_string()).unwrap();
     assert_eq!(output_mappings.len(), 2);
-    assert!(output_mappings[0].true_index.same_id(&output0));
-    assert!(output_mappings[1].true_index.same_id(&output1));
+    assert_eq!(output_mappings[0].true_index, output0);
+    assert_eq!(output_mappings[1].true_index, output1);
 
     let output_internal = output_mappings
         .iter()
@@ -812,14 +810,18 @@ fn test_linear_operator_restructure_to_moves_mapping_nodes() {
     let actual = moved.mpo().contract_to_tensor().unwrap();
 
     assert!(actual.distance(&expected).unwrap() < 1.0e-12);
-    assert!(moved
-        .get_input_mapping(&"left".to_string())
-        .unwrap()
-        .true_index
-        .same_id(&s1));
-    assert!(moved
-        .get_input_mapping(&"right".to_string())
-        .unwrap()
-        .true_index
-        .same_id(&s0));
+    assert_eq!(
+        moved
+            .get_input_mapping(&"left".to_string())
+            .unwrap()
+            .true_index,
+        s1
+    );
+    assert_eq!(
+        moved
+            .get_input_mapping(&"right".to_string())
+            .unwrap()
+            .true_index,
+        s0
+    );
 }

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -819,9 +819,9 @@ fn test_partial_contract_allows_compatible_topology_mismatch_with_gap_leaf() {
     let result = result.unwrap();
     let external = result.external_indices();
     assert_eq!(external.len(), 3);
-    assert!(external.iter().any(|idx| idx.id() == s_a.id()));
-    assert!(external.iter().any(|idx| idx.id() == s_b.id()));
-    assert!(external.iter().any(|idx| idx.id() == s_b2.id()));
+    assert!(external.contains(&s_a));
+    assert!(external.contains(&s_b));
+    assert!(external.contains(&s_b2));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Tighten default `IndexLike::is_contractable` to require full index equality for undirected indices and conjugate full equality for directed pairs.
- Fix TensorTrain linsolve MPO/MPS mapping inference and TreeTN square linsolve validation to avoid ID-only leg matching.
- Add regressions for same-ID/different-tag and same-ID/primed cases, and update tests/docs that were asserting concrete identity via ID only.

## Audit note
After the source-wide scan, remaining `same_id`/ID-only comparisons in the touched crates are limited to the raw helper implementation, its dedicated tests, and the `same_id` documentation example.

## Verification
- `cargo test --release -q -p tensor4all-core`
- `cargo test --release -q -p tensor4all-itensorlike`
- `cargo test --release -q -p tensor4all-treetn`
- `cargo clippy --release -q -p tensor4all-core --all-targets -- -D warnings`
- `cargo clippy --release -q -p tensor4all-itensorlike --all-targets -- -D warnings`
- `cargo clippy --release -q -p tensor4all-treetn --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #534