### PR TITLE
[codex] Complete adaptive PartitionedTT patching

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -79,6 +79,16 @@ TensorTrain-level operations against ITensorMPS:
 RAYON_NUM_THREADS=1 cargo run -p tensor4all-itensorlike --example benchmark_tt_ops --release -- --L 32 --zipup-L 10 --chis 4,8,16,32,64
 ```
 
+PartitionedTT adaptive patching on a deterministic sum of randomly placed
+anisotropic Gaussians. The benchmark compares the static sequential split order
+against the exact child-parameter-gain ordering at the same global `rtol` and
+`max_bond_dim`, and reports patch count, total TT core parameters, max patch
+bond dimension, dense-reference relative error, and best elapsed time:
+
+```bash
+RAYON_NUM_THREADS=1 cargo run -p tensor4all-partitionedtt --example benchmark_patching --release -- --x 24 --y 16 --components 10 --max-bond-dim 3 --rtol 1e-8 --repeats 3
+```
+
 ACI elementwise TT chi scaling:
 
 ```bash

--- a/benchmarks/rust/benchmark_partitionedtt_patching.rs
+++ b/benchmarks/rust/benchmark_partitionedtt_patching.rs
@@ -1,0 +1,343 @@
+// Adaptive PartitionedTT patching benchmark.
+//
+// Run:
+//   RAYON_NUM_THREADS=1 cargo run -p tensor4all-partitionedtt --example benchmark_patching --release
+//
+// Optional args:
+//   --x N
+//   --y N
+//   --components N
+//   --max-bond-dim N
+//   --rtol FLOAT
+//   --repeats N
+
+use std::hint::black_box;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_partitionedtt::{
+    add_with_patching, PartitionedTT, PatchSplitStrategy, PatchingOptions, SubDomainTT,
+    TensorTrain,
+};
+
+#[derive(Debug, Clone)]
+struct Options {
+    x_dim: usize,
+    y_dim: usize,
+    components: usize,
+    max_bond_dim: usize,
+    rtol: f64,
+    repeats: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            x_dim: 24,
+            y_dim: 16,
+            components: 10,
+            max_bond_dim: 3,
+            rtol: 1.0e-8,
+            repeats: 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BenchmarkInput {
+    tt: TensorTrain,
+    x_index: DynIndex,
+    y_index: DynIndex,
+    reference: Vec<f64>,
+    reference_norm: f64,
+}
+
+#[derive(Debug, Clone)]
+struct BenchmarkResult {
+    strategy_name: &'static str,
+    elapsed: Duration,
+    patches: usize,
+    total_parameters: usize,
+    max_patch_bond_dim: usize,
+    relative_error: f64,
+}
+
+fn main() -> Result<()> {
+    let options = parse_args()?;
+    let input = make_anisotropic_gaussian_input(&options)?;
+
+    println!("tensor4all PartitionedTT adaptive patching benchmark");
+    println!(
+        "config,x_dim={},y_dim={},components={},max_bond_dim={},rtol={:.3e},repeats={}",
+        options.x_dim,
+        options.y_dim,
+        options.components,
+        options.max_bond_dim,
+        options.rtol,
+        options.repeats
+    );
+    println!("strategy,patches,total_parameters,max_patch_bond_dim,relative_error,time_ms");
+
+    let sequential_options = patching_options(
+        &options,
+        PatchSplitStrategy::Sequential,
+        &[input.x_index.clone(), input.y_index.clone()],
+    );
+    let exact_gain_options = patching_options(
+        &options,
+        PatchSplitStrategy::ExactParameterGain,
+        &[input.x_index.clone(), input.y_index.clone()],
+    );
+
+    run_case("sequential_xy", &input, &sequential_options, options.repeats)?;
+    run_case("exact_gain", &input, &exact_gain_options, options.repeats)?;
+
+    Ok(())
+}
+
+fn parse_args() -> Result<Options> {
+    let mut options = Options::default();
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--help" | "-h" => {
+                println!(
+                    "Usage: benchmark_patching [--x N] [--y N] [--components N] \
+                     [--max-bond-dim N] [--rtol FLOAT] [--repeats N]"
+                );
+                std::process::exit(0);
+            }
+            "--x" => {
+                i += 1;
+                options.x_dim = parse_arg(&args, i, "--x")?;
+            }
+            "--y" => {
+                i += 1;
+                options.y_dim = parse_arg(&args, i, "--y")?;
+            }
+            "--components" => {
+                i += 1;
+                options.components = parse_arg(&args, i, "--components")?;
+            }
+            "--max-bond-dim" => {
+                i += 1;
+                options.max_bond_dim = parse_arg(&args, i, "--max-bond-dim")?;
+            }
+            "--rtol" => {
+                i += 1;
+                options.rtol = parse_arg(&args, i, "--rtol")?;
+            }
+            "--repeats" => {
+                i += 1;
+                options.repeats = parse_arg(&args, i, "--repeats")?;
+            }
+            other => bail!("unknown argument: {other}"),
+        }
+        i += 1;
+    }
+
+    if options.x_dim == 0 || options.y_dim == 0 || options.components == 0 {
+        bail!("grid dimensions and component count must be positive");
+    }
+    if options.max_bond_dim == 0 {
+        bail!("max-bond-dim must be positive");
+    }
+    if !options.rtol.is_finite() || options.rtol < 0.0 {
+        bail!("rtol must be finite and non-negative");
+    }
+    if options.repeats == 0 {
+        bail!("repeats must be positive");
+    }
+
+    Ok(options)
+}
+
+fn parse_arg<T>(args: &[String], index: usize, name: &str) -> Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    args.get(index)
+        .with_context(|| format!("missing value for {name}"))?
+        .parse::<T>()
+        .with_context(|| format!("invalid value for {name}"))
+}
+
+fn patching_options(
+    options: &Options,
+    split_strategy: PatchSplitStrategy,
+    patch_order: &[DynIndex],
+) -> PatchingOptions {
+    PatchingOptions {
+        rtol: options.rtol,
+        max_bond_dim: options.max_bond_dim,
+        patch_order: patch_order.to_vec(),
+        split_strategy,
+    }
+}
+
+fn run_case(
+    strategy_name: &'static str,
+    input: &BenchmarkInput,
+    options: &PatchingOptions,
+    repeats: usize,
+) -> Result<()> {
+    let mut best: Option<BenchmarkResult> = None;
+    for _ in 0..repeats {
+        let started = Instant::now();
+        let patched =
+            add_with_patching(vec![SubDomainTT::from_tt(input.tt.clone())], options)?;
+        let elapsed = started.elapsed();
+        let result = summarize_result(strategy_name, input, black_box(&patched), elapsed)?;
+        if best
+            .as_ref()
+            .is_none_or(|current| result.elapsed < current.elapsed)
+        {
+            best = Some(result);
+        }
+    }
+
+    let result = best.expect("repeats is validated as positive");
+    println!(
+        "{},{},{},{},{:.6e},{:.6}",
+        result.strategy_name,
+        result.patches,
+        result.total_parameters,
+        result.max_patch_bond_dim,
+        result.relative_error,
+        result.elapsed.as_secs_f64() * 1.0e3
+    );
+
+    Ok(())
+}
+
+fn summarize_result(
+    strategy_name: &'static str,
+    input: &BenchmarkInput,
+    partitioned: &PartitionedTT,
+    elapsed: Duration,
+) -> Result<BenchmarkResult> {
+    let total_parameters = partitioned_parameter_count(partitioned)?;
+    let max_patch_bond_dim = partitioned
+        .values()
+        .map(|subdomain| subdomain.max_bond_dim())
+        .max()
+        .unwrap_or(0);
+    let relative_error = dense_relative_error(input, partitioned)?;
+    Ok(BenchmarkResult {
+        strategy_name,
+        elapsed,
+        patches: partitioned.len(),
+        total_parameters,
+        max_patch_bond_dim,
+        relative_error,
+    })
+}
+
+fn make_anisotropic_gaussian_input(options: &Options) -> Result<BenchmarkInput> {
+    let x_index = DynIndex::new_dyn(options.x_dim);
+    let component_index = DynIndex::new_dyn(options.components);
+    let y_index = DynIndex::new_dyn(options.y_dim);
+    let mut left = vec![0.0; options.x_dim * options.components];
+    let mut right = vec![0.0; options.components * options.y_dim];
+
+    for component in 0..options.components {
+        let center_x = deterministic_unit(component, 17) * (options.x_dim.saturating_sub(1) as f64);
+        let center_y = deterministic_unit(component, 29) * (options.y_dim.saturating_sub(1) as f64);
+        let narrow = 0.035 + 0.035 * deterministic_unit(component, 43);
+        let wide = 0.16 + 0.16 * deterministic_unit(component, 61);
+        let sigma_x = if component % 2 == 0 {
+            narrow * options.x_dim as f64
+        } else {
+            wide * options.x_dim as f64
+        };
+        let sigma_y = if component % 2 == 0 {
+            wide * options.y_dim as f64
+        } else {
+            narrow * options.y_dim as f64
+        };
+        let amplitude = 0.6 + deterministic_unit(component, 73);
+
+        for x in 0..options.x_dim {
+            left[x + options.x_dim * component] = amplitude * gaussian(x as f64, center_x, sigma_x);
+        }
+        for y in 0..options.y_dim {
+            right[component + options.components * y] = gaussian(y as f64, center_y, sigma_y);
+        }
+    }
+
+    let t0 = TensorDynLen::from_dense(vec![x_index.clone(), component_index.clone()], left)?;
+    let t1 = TensorDynLen::from_dense(vec![component_index, y_index.clone()], right)?;
+    let tt = TensorTrain::new(vec![t0, t1])?;
+    let dense = tt.to_dense()?.to_vec::<f64>()?;
+    let reference_norm = dense.iter().map(|value| value * value).sum::<f64>().sqrt();
+
+    Ok(BenchmarkInput {
+        tt,
+        x_index,
+        y_index,
+        reference: dense,
+        reference_norm,
+    })
+}
+
+fn deterministic_unit(component: usize, salt: usize) -> f64 {
+    let value = (component as u64)
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add((salt as u64).wrapping_mul(1_442_695_040_888_963_407));
+    ((value >> 11) as f64) / ((1u64 << 53) as f64)
+}
+
+fn gaussian(x: f64, center: f64, sigma: f64) -> f64 {
+    let sigma = sigma.max(1.0e-12);
+    let z = (x - center) / sigma;
+    (-0.5 * z * z).exp()
+}
+
+fn dense_relative_error(input: &BenchmarkInput, partitioned: &PartitionedTT) -> Result<f64> {
+    let dense = partitioned.to_tensor_train()?.to_dense()?.to_vec::<f64>()?;
+    if dense.len() != input.reference.len() {
+        bail!(
+            "dense result length mismatch: got {}, expected {}",
+            dense.len(),
+            input.reference.len()
+        );
+    }
+    let diff_norm = dense
+        .iter()
+        .zip(&input.reference)
+        .map(|(actual, expected)| {
+            let diff = actual - expected;
+            diff * diff
+        })
+        .sum::<f64>()
+        .sqrt();
+    if input.reference_norm == 0.0 {
+        Ok(diff_norm)
+    } else {
+        Ok(diff_norm / input.reference_norm)
+    }
+}
+
+fn partitioned_parameter_count(partitioned: &PartitionedTT) -> Result<usize> {
+    partitioned.values().try_fold(0usize, |total, subdomain| {
+        let patch_count = tensor_train_parameter_count(subdomain.data())?;
+        total
+            .checked_add(patch_count)
+            .context("partitioned parameter count overflowed usize")
+    })
+}
+
+fn tensor_train_parameter_count(tt: &TensorTrain) -> Result<usize> {
+    tt.tensors().into_iter().try_fold(0usize, |total, tensor| {
+        let tensor_count = tensor.dims().into_iter().try_fold(1usize, |acc, dim| {
+            acc.checked_mul(dim)
+                .context("tensor parameter count overflowed usize")
+        })?;
+        total
+            .checked_add(tensor_count)
+            .context("tensor train parameter count overflowed usize")
+    })
+}

--- a/crates/tensor4all-partitionedtt/examples/benchmark_patching.rs
+++ b/crates/tensor4all-partitionedtt/examples/benchmark_patching.rs
@@ -1,0 +1,1 @@
+include!("../../../benchmarks/rust/benchmark_partitionedtt_patching.rs");

--- a/crates/tensor4all-partitionedtt/src/error.rs
+++ b/crates/tensor4all-partitionedtt/src/error.rs
@@ -39,4 +39,8 @@ pub enum PartitionedTTError {
     /// Incompatible projector structure
     #[error("Incompatible projectors: {0}")]
     IncompatibleProjectors(String),
+
+    /// Invalid options for a partitioned tensor train operation
+    #[error("Invalid options: {0}")]
+    InvalidOptions(String),
 }

--- a/crates/tensor4all-partitionedtt/src/lib.rs
+++ b/crates/tensor4all-partitionedtt/src/lib.rs
@@ -22,7 +22,9 @@ mod test_utils;
 pub use contract::{contract, proj_contract};
 pub use error::{PartitionedTTError, Result};
 pub use partitioned_tt::PartitionedTT;
-pub use patching::{add_with_patching, truncate_adaptive, PatchingOptions};
+pub use patching::{
+    add_with_patching, contract_adaptive, truncate_adaptive, PatchSplitStrategy, PatchingOptions,
+};
 pub use projector::Projector;
 pub use subdomain_tt::SubDomainTT;
 

--- a/crates/tensor4all-partitionedtt/src/patching.rs
+++ b/crates/tensor4all-partitionedtt/src/patching.rs
@@ -9,18 +9,85 @@
 
 use crate::error::{PartitionedTTError, Result};
 use crate::partitioned_tt::PartitionedTT;
+use crate::projector::Projector;
 use crate::subdomain_tt::SubDomainTT;
-use tensor4all_core::DynIndex;
+use tensor4all_core::{DynIndex, SvdTruncationPolicy};
+use tensor4all_itensorlike::{ContractOptions, TruncateOptions};
 
-/// Options for patching operations.
+#[derive(Debug, Clone)]
+struct PatchStats {
+    subdomain: SubDomainTT,
+    volume: usize,
+    norm_squared: f64,
+}
+
+/// Strategy used to choose the next projected index for patch splitting.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtt::PatchSplitStrategy;
+///
+/// assert_eq!(
+///     PatchSplitStrategy::default(),
+///     PatchSplitStrategy::ExactParameterGain
+/// );
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PatchSplitStrategy {
+    /// Split the first available index from `PatchingOptions::patch_order`.
+    Sequential,
+    /// Choose the candidate with the smallest exact post-split TT parameter count.
+    #[default]
+    ExactParameterGain,
+}
+
+/// Options for adaptive patching and truncation.
+///
+/// Use this when constructing a [`PartitionedTT`] from subdomains whose
+/// internal bond dimensions may exceed the target cap. The global tolerance is
+/// converted into per-patch absolute squared-norm budgets proportional to each
+/// patch volume.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtt::PatchingOptions;
+///
+/// let options = PatchingOptions::default();
+/// assert_eq!(options.rtol, 1e-12);
+/// assert_eq!(options.max_bond_dim, 100);
+/// assert!(options.patch_order.is_empty());
+/// assert_eq!(options.split_strategy, tensor4all_partitionedtt::PatchSplitStrategy::ExactParameterGain);
+/// ```
 #[derive(Debug, Clone)]
 pub struct PatchingOptions {
-    /// Relative tolerance for truncation
+    /// Global relative tolerance used to compute the total squared-error budget.
+    ///
+    /// Each patch receives `rtol^2 * ||F||^2 * patch_volume / total_volume`.
+    /// Use smaller values for stricter truncation. The value must be finite and
+    /// non-negative.
     pub rtol: f64,
-    /// Maximum bond dimension before splitting
+
+    /// Maximum retained bond dimension after truncation.
+    ///
+    /// Values above this cap trigger splitting when `patch_order` contains an
+    /// unprojected index for the patch. The value must be at least 1.
     pub max_bond_dim: usize,
-    /// Order of indices for patching (indices to split first)
+
+    /// Static fallback order for patch splitting.
+    ///
+    /// The first unprojected index from this list that belongs to an over-cap
+    /// subdomain is considered for the next split. An empty order lets the
+    /// selected strategy consider all currently unprojected site indices.
     pub patch_order: Vec<DynIndex>,
+
+    /// Strategy used to choose from the available split candidates.
+    ///
+    /// `Sequential` preserves the explicit order in `patch_order`.
+    /// `ExactParameterGain` evaluates every candidate by actually forming,
+    /// budget-truncating, and counting the child TT cores.
+    pub split_strategy: PatchSplitStrategy,
 }
 
 impl Default for PatchingOptions {
@@ -29,74 +96,597 @@ impl Default for PatchingOptions {
             rtol: 1e-12,
             max_bond_dim: 100,
             patch_order: Vec::new(),
+            split_strategy: PatchSplitStrategy::default(),
         }
     }
 }
 
-/// Add SubDomainTTs with automatic patching.
+/// Add subdomains with automatic order-driven patching.
 ///
-/// Creates a PartitionedTT from the given subdomains. If subdomains have
-/// disjoint projectors, they are kept separate. If any subdomains share
-/// the same projector, they are summed using TT addition.
+/// Creates a [`PartitionedTT`] from the supplied subdomains. Subdomains whose
+/// budget-truncated bond dimension remains above `options.max_bond_dim` are
+/// split along an index chosen by `options.split_strategy`; the result is then
+/// truncated using volume-proportional absolute budgets.
 ///
 /// # Errors
 ///
 /// Returns an error if:
-/// - Subdomains have overlapping (but not identical) projectors
-/// - TT addition fails due to incompatible structures
+/// - `options.rtol` is negative, NaN, or infinite
+/// - `options.max_bond_dim` is zero
+/// - the input or split projectors overlap
+/// - tensor train projection or truncation fails
 ///
-/// # Note
+/// # Examples
 ///
-/// The `max_bond_dim` option in PatchingOptions is **not yet implemented**.
-/// If you need bond dimension control after summing, use
-/// `PartitionedTT::to_tensor_train()` followed by explicit truncation.
+/// ```
+/// use tensor4all_core::index::Index;
+/// use tensor4all_partitionedtt::{
+///     add_with_patching, PatchingOptions, SubDomainTT, TensorDynLen, TensorTrain,
+/// };
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let s0 = Index::new_dyn(2);
+/// let bond = Index::new_dyn(3);
+/// let s1 = Index::new_dyn(2);
+/// let t0 = TensorDynLen::from_dense(
+///     vec![s0.clone(), bond.clone()],
+///     (1..=6).map(f64::from).collect(),
+/// )?;
+/// let t1 = TensorDynLen::from_dense(vec![bond, s1], (1..=6).map(f64::from).collect())?;
+/// let tt = TensorTrain::new(vec![t0, t1])?;
+/// let options = PatchingOptions {
+///     rtol: 1e-12,
+///     max_bond_dim: 1,
+///     patch_order: vec![s0],
+///     split_strategy: tensor4all_partitionedtt::PatchSplitStrategy::Sequential,
+/// };
+///
+/// let patched = add_with_patching(vec![SubDomainTT::from_tt(tt)], &options)?;
+///
+/// assert_eq!(patched.len(), 2);
+/// assert!(patched.values().all(|patch| patch.max_bond_dim() <= 1));
+/// # Ok(())
+/// # }
+/// ```
+///
 pub fn add_with_patching(
     subdomains: Vec<SubDomainTT>,
     options: &PatchingOptions,
 ) -> Result<PartitionedTT> {
-    // Check if any subdomains would require actual patching
-    let max_bond = subdomains
-        .iter()
-        .map(|s| s.max_bond_dim())
-        .max()
-        .unwrap_or(0);
+    validate_patching_options(options)?;
 
-    if max_bond > options.max_bond_dim && !options.patch_order.is_empty() {
-        return Err(PartitionedTTError::NotImplemented(
-            "Adaptive patching with bond dimension splitting is not yet implemented. \
-             Use PartitionedTT::from_subdomains() for simple cases."
-                .to_string(),
-        ));
+    let mut working = subdomains;
+
+    loop {
+        working = assign_volume_budgets(working, options.rtol)?;
+        working = budget_truncate_for_split_decision(working)?;
+        let over_budget = working
+            .iter()
+            .any(|subdomain| subdomain.max_bond_dim() > options.max_bond_dim);
+        if !over_budget {
+            let partitioned = PartitionedTT::from_subdomains(working)?;
+            return truncate_adaptive(&partitioned, options.rtol, options.max_bond_dim);
+        }
+
+        let mut next = Vec::new();
+        let mut split_any = false;
+        for subdomain in working {
+            if subdomain.max_bond_dim() > options.max_bond_dim {
+                if let Some(children) = split_subdomain_by_patch_order(&subdomain, options)? {
+                    split_any = true;
+                    next.extend(children);
+                    continue;
+                }
+            }
+            next.push(subdomain);
+        }
+
+        if !split_any {
+            let partitioned = PartitionedTT::from_subdomains(next)?;
+            return truncate_adaptive(&partitioned, options.rtol, options.max_bond_dim);
+        }
+
+        working = next;
     }
-
-    PartitionedTT::from_subdomains(subdomains)
 }
 
-/// Truncate a PartitionedTT with adaptive weighting.
+/// Contract two partitioned tensor trains and adaptively truncate the output.
+///
+/// The contraction first uses the supplied [`ContractOptions`]. The resulting
+/// partitioned tensor is then re-truncated with [`truncate_adaptive`], so the
+/// final per-patch budgets are computed from the corrected output norm rather
+/// than from an input-side estimate.
+///
+/// # Arguments
+///
+/// * `left` - Left partitioned tensor train.
+/// * `right` - Right partitioned tensor train.
+/// * `contract_options` - Contraction method, sweep count, and provisional
+///   truncation settings used by the underlying TT contraction.
+/// * `patching_options` - Global output tolerance and output rank cap. Split
+///   fields are validated but not used by this post-contraction truncation
+///   pass.
+///
+/// # Returns
+///
+/// A partitioned tensor train containing the compatible pairwise contractions,
+/// with each output patch adaptively truncated against the final output norm.
 ///
 /// # Errors
 ///
-/// This function is **not yet implemented** and will return an error.
-/// For truncation, access individual SubDomainTTs via `iter()` or `values()`
-/// and truncate them directly.
+/// Returns an error if patching options are invalid, if the contraction fails,
+/// or if output truncation fails.
 ///
-/// # Future Implementation
+/// # Examples
 ///
-/// A full implementation would:
-/// 1. Compute norm of each subdomain
-/// 2. Adjust cutoff based on relative norms
-/// 3. Truncate each subdomain with adjusted cutoff
-/// 4. Optionally iterate to refine weights
-pub fn truncate_adaptive(
-    _partitioned: &PartitionedTT,
-    _rtol: f64,
-    _max_bond_dim: usize,
+/// ```
+/// use tensor4all_core::index::Index;
+/// use tensor4all_partitionedtt::{
+///     contract_adaptive, ContractOptions, PartitionedTT, PatchSplitStrategy, PatchingOptions,
+///     SubDomainTT, TensorDynLen, TensorTrain,
+/// };
+///
+/// # fn three_site_tt(
+/// #     s0: &tensor4all_partitionedtt::DynIndex,
+/// #     l01: &tensor4all_partitionedtt::DynIndex,
+/// #     s1: &tensor4all_partitionedtt::DynIndex,
+/// #     l12: &tensor4all_partitionedtt::DynIndex,
+/// #     s2: &tensor4all_partitionedtt::DynIndex,
+/// # ) -> Result<TensorTrain, Box<dyn std::error::Error>> {
+/// #     let t0 = TensorDynLen::from_dense(vec![s0.clone(), l01.clone()], vec![1.0; 6])?;
+/// #     let t1 = TensorDynLen::from_dense(
+/// #         vec![l01.clone(), s1.clone(), l12.clone()],
+/// #         vec![1.0; 18],
+/// #     )?;
+/// #     let t2 = TensorDynLen::from_dense(vec![l12.clone(), s2.clone()], vec![1.0; 6])?;
+/// #     Ok(TensorTrain::new(vec![t0, t1, t2])?)
+/// # }
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let s0 = Index::new_dyn(2);
+/// let s1 = Index::new_dyn(2);
+/// let s2 = Index::new_dyn(2);
+/// let left_l01 = Index::new_dyn(3);
+/// let left_l12 = Index::new_dyn(3);
+/// let right_l01 = Index::new_dyn(3);
+/// let right_l12 = Index::new_dyn(3);
+/// let left = PartitionedTT::from_subdomain(SubDomainTT::from_tt(three_site_tt(
+///     &s0, &left_l01, &s1, &left_l12, &s2,
+/// )?));
+/// let right = PartitionedTT::from_subdomain(SubDomainTT::from_tt(three_site_tt(
+///     &s0, &right_l01, &s1, &right_l12, &s2,
+/// )?));
+/// let patching = PatchingOptions {
+///     rtol: 0.0,
+///     max_bond_dim: 1,
+///     patch_order: vec![s0],
+///     split_strategy: PatchSplitStrategy::Sequential,
+/// };
+///
+/// let contracted =
+///     contract_adaptive(&left, &right, &ContractOptions::default(), &patching)?;
+///
+/// assert_eq!(contracted.len(), 1);
+/// assert!(contracted.values().all(|patch| patch.max_bond_dim() <= 1));
+/// # Ok(())
+/// # }
+/// ```
+pub fn contract_adaptive(
+    left: &PartitionedTT,
+    right: &PartitionedTT,
+    contract_options: &ContractOptions,
+    patching_options: &PatchingOptions,
 ) -> Result<PartitionedTT> {
-    Err(PartitionedTTError::NotImplemented(
-        "truncate_adaptive is not yet implemented. \
-         Access subdomains via iter() and truncate them individually."
-            .to_string(),
-    ))
+    validate_patching_options(patching_options)?;
+    let contracted = left.contract(right, contract_options)?;
+    truncate_adaptive(
+        &contracted,
+        patching_options.rtol,
+        patching_options.max_bond_dim,
+    )
+}
+
+/// Truncate a partitioned tensor train with volume-proportional absolute budgets.
+///
+/// The total squared-error budget is `rtol^2 * ||F||^2`, where `||F||^2` is the
+/// sum of projected patch norms. Each patch receives a share proportional to
+/// its unprojected grid volume. Patches whose projected squared norm is at or
+/// below their budget are dropped entirely.
+///
+/// # Arguments
+///
+/// * `partitioned` - Partitioned tensor train with mutually disjoint patches.
+/// * `rtol` - Global relative tolerance; must be finite and non-negative.
+/// * `max_bond_dim` - Maximum retained bond dimension; must be at least 1.
+///
+/// # Returns
+///
+/// A new [`PartitionedTT`] containing retained patches with projected data and
+/// bond dimensions capped by `max_bond_dim` where truncation succeeds.
+///
+/// # Errors
+///
+/// Returns an error if the tolerance or rank cap is invalid, if patch volume
+/// arithmetic overflows, or if tensor train truncation fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::index::Index;
+/// use tensor4all_partitionedtt::{
+///     truncate_adaptive, PartitionedTT, Projector, SubDomainTT, TensorDynLen, TensorTrain,
+/// };
+///
+/// # fn rank_one_tt(
+/// #     s0: &tensor4all_partitionedtt::DynIndex,
+/// #     s1: &tensor4all_partitionedtt::DynIndex,
+/// #     scale: f64,
+/// # ) -> Result<TensorTrain, Box<dyn std::error::Error>> {
+/// #     let bond = Index::new_dyn(1);
+/// #     let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![scale; s0.dim])?;
+/// #     let t1 = TensorDynLen::from_dense(vec![bond, s1.clone()], vec![1.0; s1.dim])?;
+/// #     Ok(TensorTrain::new(vec![t0, t1])?)
+/// # }
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let s0 = Index::new_dyn(2);
+/// let s1 = Index::new_dyn(2);
+/// let high_proj = Projector::from_pairs([(s0.clone(), 0)]);
+/// let low_proj = Projector::from_pairs([(s0.clone(), 1)]);
+/// let high = SubDomainTT::new(rank_one_tt(&s0, &s1, 10.0)?, high_proj.clone());
+/// let low = SubDomainTT::new(rank_one_tt(&s0, &s1, 0.01)?, low_proj.clone());
+/// let partitioned = PartitionedTT::from_subdomains(vec![high, low])?;
+///
+/// let truncated = truncate_adaptive(&partitioned, 0.01, 4)?;
+///
+/// assert_eq!(truncated.len(), 1);
+/// assert!(truncated.contains(&high_proj));
+/// assert!(!truncated.contains(&low_proj));
+/// # Ok(())
+/// # }
+/// ```
+pub fn truncate_adaptive(
+    partitioned: &PartitionedTT,
+    rtol: f64,
+    max_bond_dim: usize,
+) -> Result<PartitionedTT> {
+    validate_truncation_options(rtol, max_bond_dim)?;
+
+    if partitioned.is_empty() {
+        return Ok(PartitionedTT::new());
+    }
+
+    let stats = patch_stats(partitioned)?;
+    let total_volume = stats.iter().try_fold(0usize, |acc, stat| {
+        acc.checked_add(stat.volume).ok_or_else(|| {
+            PartitionedTTError::InvalidOptions("partition volume overflowed usize".to_string())
+        })
+    })?;
+    if total_volume == 0 {
+        return Ok(PartitionedTT::new());
+    }
+
+    let total_norm_squared: f64 = stats.iter().map(|stat| stat.norm_squared).sum();
+    if !total_norm_squared.is_finite() {
+        return Err(PartitionedTTError::TensorTrainError(
+            "partitioned norm is not finite".to_string(),
+        ));
+    }
+    let global_budget_squared = rtol * rtol * total_norm_squared;
+    if !global_budget_squared.is_finite() {
+        return Err(PartitionedTTError::InvalidOptions(
+            "rtol produced a non-finite truncation budget".to_string(),
+        ));
+    }
+
+    let mut retained = Vec::new();
+    for stat in stats {
+        let patch_budget_squared =
+            global_budget_squared * (stat.volume as f64 / total_volume as f64);
+        if stat.norm_squared <= patch_budget_squared {
+            continue;
+        }
+
+        let mut subdomain = stat.subdomain;
+        let _unused_budget_squared =
+            truncate_subdomain_with_budget(&mut subdomain, patch_budget_squared, max_bond_dim)?;
+        retained.push(subdomain.with_budget_squared(patch_budget_squared));
+    }
+
+    PartitionedTT::from_subdomains(retained)
+}
+
+fn validate_patching_options(options: &PatchingOptions) -> Result<()> {
+    validate_truncation_options(options.rtol, options.max_bond_dim)?;
+    for index in &options.patch_order {
+        if index.dim == 0 {
+            return Err(PartitionedTTError::InvalidOptions(
+                "patch_order cannot contain zero-dimensional indices".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn assign_volume_budgets(subdomains: Vec<SubDomainTT>, rtol: f64) -> Result<Vec<SubDomainTT>> {
+    if subdomains.is_empty() {
+        return Ok(subdomains);
+    }
+
+    let partitioned = PartitionedTT::from_subdomains(subdomains)?;
+    let stats = patch_stats(&partitioned)?;
+    let total_volume = stats.iter().try_fold(0usize, |acc, stat| {
+        acc.checked_add(stat.volume).ok_or_else(|| {
+            PartitionedTTError::InvalidOptions("partition volume overflowed usize".to_string())
+        })
+    })?;
+    if total_volume == 0 {
+        return Ok(Vec::new());
+    }
+    let total_norm_squared: f64 = stats.iter().map(|stat| stat.norm_squared).sum();
+    if !total_norm_squared.is_finite() {
+        return Err(PartitionedTTError::TensorTrainError(
+            "partitioned norm is not finite".to_string(),
+        ));
+    }
+    let global_budget_squared = rtol * rtol * total_norm_squared;
+    if !global_budget_squared.is_finite() {
+        return Err(PartitionedTTError::InvalidOptions(
+            "rtol produced a non-finite truncation budget".to_string(),
+        ));
+    }
+
+    stats
+        .into_iter()
+        .map(|stat| {
+            let patch_budget_squared =
+                global_budget_squared * (stat.volume as f64 / total_volume as f64);
+            Ok(stat.subdomain.with_budget_squared(patch_budget_squared))
+        })
+        .collect()
+}
+
+fn budget_truncate_for_split_decision(subdomains: Vec<SubDomainTT>) -> Result<Vec<SubDomainTT>> {
+    let mut retained = Vec::new();
+    for mut subdomain in subdomains {
+        let budget_squared = subdomain.budget_squared().ok_or_else(|| {
+            PartitionedTTError::InvalidOptions(
+                "subdomain was missing a split-decision budget".to_string(),
+            )
+        })?;
+        if subdomain.norm_squared() <= budget_squared {
+            continue;
+        }
+        truncate_subdomain_with_budget_only(&mut subdomain, budget_squared)?;
+        retained.push(subdomain);
+    }
+    Ok(retained)
+}
+
+fn validate_truncation_options(rtol: f64, max_bond_dim: usize) -> Result<()> {
+    if !rtol.is_finite() || rtol < 0.0 {
+        return Err(PartitionedTTError::InvalidOptions(
+            "rtol must be finite and non-negative".to_string(),
+        ));
+    }
+    if max_bond_dim == 0 {
+        return Err(PartitionedTTError::InvalidOptions(
+            "max_bond_dim must be at least 1".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn patch_stats(partitioned: &PartitionedTT) -> Result<Vec<PatchStats>> {
+    let mut stats = Vec::with_capacity(partitioned.len());
+    for subdomain in partitioned.values() {
+        let projected = projected_subdomain(subdomain)?;
+        let volume = subdomain_volume(&projected)?;
+        let norm_squared = projected.norm_squared();
+        stats.push(PatchStats {
+            subdomain: projected,
+            volume,
+            norm_squared,
+        });
+    }
+    Ok(stats)
+}
+
+fn projected_subdomain(subdomain: &SubDomainTT) -> Result<SubDomainTT> {
+    if subdomain.projector().is_empty() {
+        return Ok(subdomain.clone());
+    }
+    subdomain.project(subdomain.projector()).ok_or_else(|| {
+        PartitionedTTError::IncompatibleProjectors(
+            "subdomain projector was incompatible with itself".to_string(),
+        )
+    })
+}
+
+fn subdomain_volume(subdomain: &SubDomainTT) -> Result<usize> {
+    subdomain
+        .all_indices()
+        .into_iter()
+        .try_fold(1usize, |volume, index| {
+            let factor = if subdomain.projector().is_projected_at(&index) {
+                1
+            } else {
+                index.dim
+            };
+            volume.checked_mul(factor).ok_or_else(|| {
+                PartitionedTTError::InvalidOptions("subdomain volume overflowed usize".to_string())
+            })
+        })
+}
+
+fn truncate_subdomain_with_budget(
+    subdomain: &mut SubDomainTT,
+    budget_squared: f64,
+    max_bond_dim: usize,
+) -> Result<f64> {
+    truncate_subdomain_with_optional_max_rank(subdomain, budget_squared, Some(max_bond_dim))
+}
+
+fn truncate_subdomain_with_budget_only(
+    subdomain: &mut SubDomainTT,
+    budget_squared: f64,
+) -> Result<f64> {
+    truncate_subdomain_with_optional_max_rank(subdomain, budget_squared, None)
+}
+
+fn truncate_subdomain_with_optional_max_rank(
+    subdomain: &mut SubDomainTT,
+    budget_squared: f64,
+    max_bond_dim: Option<usize>,
+) -> Result<f64> {
+    let before = subdomain.norm_squared();
+    let policy = SvdTruncationPolicy::new(budget_squared)
+        .with_absolute()
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    let mut options = TruncateOptions::svd().with_svd_policy(policy);
+    if let Some(max_bond_dim) = max_bond_dim {
+        options = options.with_max_rank(max_bond_dim);
+    }
+    subdomain.truncate(&options)?;
+    let after = subdomain.norm_squared();
+    let used = (before - after).max(0.0);
+    Ok((budget_squared - used).max(0.0))
+}
+
+fn split_subdomain_by_patch_order(
+    subdomain: &SubDomainTT,
+    options: &PatchingOptions,
+) -> Result<Option<Vec<SubDomainTT>>> {
+    choose_split_index(subdomain, options)?
+        .map(|index| split_subdomain(subdomain, &index))
+        .transpose()
+}
+
+fn choose_split_index(
+    subdomain: &SubDomainTT,
+    options: &PatchingOptions,
+) -> Result<Option<DynIndex>> {
+    let candidates = split_candidates(subdomain, options);
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    match options.split_strategy {
+        PatchSplitStrategy::Sequential => Ok(candidates.into_iter().next()),
+        PatchSplitStrategy::ExactParameterGain => {
+            choose_exact_parameter_gain_split(subdomain, options, candidates)
+        }
+    }
+}
+
+fn split_candidates(subdomain: &SubDomainTT, options: &PatchingOptions) -> Vec<DynIndex> {
+    let all_indices = subdomain.all_indices();
+    let raw_candidates: Vec<DynIndex> = if options.patch_order.is_empty() {
+        all_indices.clone()
+    } else {
+        options.patch_order.clone()
+    };
+
+    let mut candidates = Vec::new();
+    for index in raw_candidates {
+        if subdomain.is_projected_at(&index) {
+            continue;
+        }
+        if !all_indices.iter().any(|candidate| candidate == &index) {
+            continue;
+        }
+        if candidates.iter().any(|candidate| candidate == &index) {
+            continue;
+        }
+        candidates.push(index);
+    }
+    candidates
+}
+
+fn choose_exact_parameter_gain_split(
+    subdomain: &SubDomainTT,
+    options: &PatchingOptions,
+    candidates: Vec<DynIndex>,
+) -> Result<Option<DynIndex>> {
+    let mut best: Option<(usize, DynIndex)> = None;
+    for candidate in candidates {
+        let candidate_count = split_child_parameter_count(subdomain, &candidate, options)?;
+        if best
+            .as_ref()
+            .is_none_or(|(best_count, _)| candidate_count < *best_count)
+        {
+            best = Some((candidate_count, candidate));
+        }
+    }
+    Ok(best.map(|(_, index)| index))
+}
+
+fn split_child_parameter_count(
+    subdomain: &SubDomainTT,
+    index: &DynIndex,
+    options: &PatchingOptions,
+) -> Result<usize> {
+    let children = split_subdomain(subdomain, index)?;
+    children.into_iter().try_fold(0usize, |total, mut child| {
+        let budget_squared = child.budget_squared().unwrap_or(0.0);
+        let projected = projected_subdomain(&child)?;
+        if projected.norm_squared() <= budget_squared {
+            return Ok(total);
+        }
+        truncate_subdomain_with_budget(&mut child, budget_squared, options.max_bond_dim)?;
+        let child_count = subdomain_parameter_count(&child)?;
+        total.checked_add(child_count).ok_or_else(|| {
+            PartitionedTTError::InvalidOptions(
+                "split child parameter count overflowed usize".to_string(),
+            )
+        })
+    })
+}
+
+fn subdomain_parameter_count(subdomain: &SubDomainTT) -> Result<usize> {
+    subdomain
+        .data()
+        .tensors()
+        .into_iter()
+        .try_fold(0usize, |total, tensor| {
+            let tensor_count = tensor.dims().into_iter().try_fold(1usize, |acc, dim| {
+                acc.checked_mul(dim).ok_or_else(|| {
+                    PartitionedTTError::InvalidOptions(
+                        "tensor parameter count overflowed usize".to_string(),
+                    )
+                })
+            })?;
+            total.checked_add(tensor_count).ok_or_else(|| {
+                PartitionedTTError::InvalidOptions(
+                    "subdomain parameter count overflowed usize".to_string(),
+                )
+            })
+        })
+}
+
+fn split_subdomain(subdomain: &SubDomainTT, index: &DynIndex) -> Result<Vec<SubDomainTT>> {
+    if index.dim == 0 {
+        return Err(PartitionedTTError::InvalidOptions(
+            "cannot split along a zero-dimensional index".to_string(),
+        ));
+    }
+
+    let child_budget_squared = subdomain
+        .budget_squared()
+        .map(|budget_squared| budget_squared / index.dim as f64);
+    let mut children = Vec::with_capacity(index.dim);
+    for value in 0..index.dim {
+        let projector = Projector::from_pairs([(index.clone(), value)]);
+        let child = subdomain.project(&projector).ok_or_else(|| {
+            PartitionedTTError::IncompatibleProjectors(
+                "split projector was incompatible with subdomain projector".to_string(),
+            )
+        })?;
+        children.push(match child_budget_squared {
+            Some(budget_squared) => child.with_budget_squared(budget_squared),
+            None => child,
+        });
+    }
+    Ok(children)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::projector::Projector;
+use approx::assert_abs_diff_eq;
 use tensor4all_core::index::Index;
 use tensor4all_core::TensorDynLen;
-use tensor4all_itensorlike::TensorTrain;
+use tensor4all_itensorlike::{ContractOptions, TensorTrain};
 
 fn make_index(size: usize) -> DynIndex {
     Index::new_dyn(size)
@@ -30,6 +31,70 @@ fn make_tt_with_indices(site_inds: &[DynIndex], link_ind: &DynIndex) -> TensorTr
     TensorTrain::new(vec![t0, t1]).unwrap()
 }
 
+fn make_scaled_rank_one_tt(site_inds: &[DynIndex], scale: f64) -> TensorTrain {
+    let link = make_index(1);
+    let t0 = TensorDynLen::from_dense(
+        vec![site_inds[0].clone(), link.clone()],
+        vec![scale; site_inds[0].dim],
+    )
+    .unwrap();
+    let t1 = TensorDynLen::from_dense(
+        vec![link, site_inds[1].clone()],
+        vec![1.0; site_inds[1].dim],
+    )
+    .unwrap();
+    TensorTrain::new(vec![t0, t1]).unwrap()
+}
+
+fn make_selector_middle_site_tt() -> (TensorTrain, Vec<DynIndex>) {
+    let s0 = make_index(4);
+    let s1 = make_index(2);
+    let s2 = make_index(2);
+    let l01 = make_index(2);
+    let l12 = make_index(2);
+
+    let t0 = TensorDynLen::from_dense(vec![s0.clone(), l01.clone()], vec![1.0; 8]).unwrap();
+    let mut center_data = vec![0.0; 8];
+    for channel in 0..2 {
+        let flat = channel + 2 * channel + 4 * channel;
+        center_data[flat] = 1.0;
+    }
+    let t1 = TensorDynLen::from_dense(vec![l01, s1.clone(), l12.clone()], center_data).unwrap();
+    let t2 = TensorDynLen::from_dense(vec![l12, s2.clone()], vec![1.0; 4]).unwrap();
+
+    (
+        TensorTrain::new(vec![t0, t1, t2]).unwrap(),
+        vec![s0, s1, s2],
+    )
+}
+
+fn make_overcomplete_rank_one_tt(site_inds: &[DynIndex], link_ind: &DynIndex) -> TensorTrain {
+    let mut left = vec![0.0; site_inds[0].dim * link_ind.dim];
+    for (x, value) in left.iter_mut().take(site_inds[0].dim).enumerate() {
+        *value = (x + 1) as f64;
+    }
+    let mut right = vec![0.0; link_ind.dim * site_inds[1].dim];
+    for (y, chunk) in right.chunks_exact_mut(link_ind.dim).enumerate() {
+        chunk[0] = (y + 1) as f64;
+    }
+    let t0 = TensorDynLen::from_dense(vec![site_inds[0].clone(), link_ind.clone()], left).unwrap();
+    let t1 = TensorDynLen::from_dense(vec![link_ind.clone(), site_inds[1].clone()], right).unwrap();
+    TensorTrain::new(vec![t0, t1]).unwrap()
+}
+
+fn make_contract_tt(
+    s0: &DynIndex,
+    l01: &DynIndex,
+    s1: &DynIndex,
+    l12: &DynIndex,
+    s2: &DynIndex,
+) -> TensorTrain {
+    let t0 = make_tensor(vec![s0.clone(), l01.clone()]);
+    let t1 = make_tensor(vec![l01.clone(), s1.clone(), l12.clone()]);
+    let t2 = make_tensor(vec![l12.clone(), s2.clone()]);
+    TensorTrain::new(vec![t0, t1, t2]).unwrap()
+}
+
 #[test]
 fn test_add_with_patching_simple() {
     let (site_inds, link_ind) = make_shared_indices();
@@ -47,40 +112,159 @@ fn test_add_with_patching_simple() {
 }
 
 #[test]
-fn test_add_with_patching_requires_splitting_fails() {
+fn test_add_with_patching_splits_unprojected_patch_when_bond_hits_cap() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = SubDomainTT::from_tt(tt1);
 
-    // Options that require splitting (max_bond_dim smaller than actual)
     let options = PatchingOptions {
         rtol: 1e-12,
-        max_bond_dim: 1,                         // Force splitting
-        patch_order: vec![site_inds[0].clone()], // Non-empty patch order triggers check
+        max_bond_dim: 1,
+        patch_order: vec![site_inds[0].clone()],
+        split_strategy: PatchSplitStrategy::Sequential,
     };
 
-    let result = add_with_patching(vec![subdomain1], &options);
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        PartitionedTTError::NotImplemented(_)
-    ));
+    let result = add_with_patching(vec![subdomain1], &options).unwrap();
+    let proj0 = Projector::from_pairs([(site_inds[0].clone(), 0)]);
+    let proj1 = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+
+    assert_eq!(result.len(), 2);
+    assert!(result.contains(&proj0));
+    assert!(result.contains(&proj1));
+    for subdomain in result.values() {
+        assert!(subdomain.max_bond_dim() <= options.max_bond_dim);
+        assert!(subdomain.budget_squared().is_some());
+    }
 }
 
 #[test]
-fn test_truncate_adaptive_not_implemented() {
+fn test_add_with_patching_truncates_before_deciding_to_split() {
     let (site_inds, link_ind) = make_shared_indices();
+    let tt = make_overcomplete_rank_one_tt(&site_inds, &link_ind);
+    assert_eq!(tt.maxbonddim(), 3);
 
-    let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let options = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: 2,
+        patch_order: vec![site_inds[0].clone()],
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
 
-    let partitioned = PartitionedTT::from_subdomains(vec![subdomain1]).unwrap();
+    let result = add_with_patching(vec![SubDomainTT::from_tt(tt)], &options).unwrap();
 
-    let result = truncate_adaptive(&partitioned, 1e-12, 100);
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        PartitionedTTError::NotImplemented(_)
-    ));
+    assert_eq!(result.len(), 1);
+    let only_patch = result.values().next().unwrap();
+    assert!(only_patch.projector().is_empty());
+    assert_eq!(only_patch.max_bond_dim(), 2);
+}
+
+#[test]
+fn test_truncate_adaptive_drops_patch_below_volume_budget() {
+    let site_inds = vec![make_index(2), make_index(2)];
+    let high_proj = Projector::from_pairs([(site_inds[0].clone(), 0)]);
+    let low_proj = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+
+    let high = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 10.0), high_proj.clone());
+    let low = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 0.01), low_proj.clone());
+    let partitioned = PartitionedTT::from_subdomains(vec![high, low]).unwrap();
+
+    let result = truncate_adaptive(&partitioned, 0.01, 4).unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result.contains(&high_proj));
+    assert!(!result.contains(&low_proj));
+}
+
+#[test]
+fn test_truncate_adaptive_assigns_volume_proportional_budgets() {
+    let site_inds = vec![make_index(2), make_index(2)];
+    let wide_proj = Projector::from_pairs([(site_inds[0].clone(), 0)]);
+    let narrow_proj = Projector::from_pairs([(site_inds[0].clone(), 1), (site_inds[1].clone(), 0)]);
+
+    let wide = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 10.0), wide_proj.clone());
+    let narrow = SubDomainTT::new(
+        make_scaled_rank_one_tt(&site_inds, 10.0),
+        narrow_proj.clone(),
+    );
+    let partitioned = PartitionedTT::from_subdomains(vec![wide, narrow]).unwrap();
+
+    let result = truncate_adaptive(&partitioned, 1e-12, 4).unwrap();
+    let wide_budget = result
+        .get(&wide_proj)
+        .and_then(SubDomainTT::budget_squared)
+        .unwrap();
+    let narrow_budget = result
+        .get(&narrow_proj)
+        .and_then(SubDomainTT::budget_squared)
+        .unwrap();
+
+    assert_abs_diff_eq!(wide_budget / narrow_budget, 2.0, epsilon = 1e-12);
+}
+
+#[test]
+fn test_truncate_adaptive_rejects_invalid_options() {
+    let empty = PartitionedTT::new();
+
+    let bad_rtol = truncate_adaptive(&empty, f64::NAN, 1).unwrap_err();
+    assert!(matches!(bad_rtol, PartitionedTTError::InvalidOptions(_)));
+
+    let bad_rank = truncate_adaptive(&empty, 1e-12, 0).unwrap_err();
+    assert!(matches!(bad_rank, PartitionedTTError::InvalidOptions(_)));
+}
+
+#[test]
+fn test_contract_adaptive_retruncates_output_with_corrected_norm() {
+    let s0 = make_index(2);
+    let s1 = make_index(2);
+    let s2 = make_index(2);
+    let l01 = make_index(3);
+    let l12 = make_index(3);
+    let r01 = make_index(3);
+    let r12 = make_index(3);
+    let left = PartitionedTT::from_subdomain(SubDomainTT::from_tt(make_contract_tt(
+        &s0, &l01, &s1, &l12, &s2,
+    )));
+    let right = PartitionedTT::from_subdomain(SubDomainTT::from_tt(make_contract_tt(
+        &s0, &r01, &s1, &r12, &s2,
+    )));
+    let patching = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: 1,
+        patch_order: vec![s0],
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
+
+    let result = contract_adaptive(&left, &right, &ContractOptions::default(), &patching).unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result
+        .values()
+        .all(|subdomain| subdomain.max_bond_dim() <= patching.max_bond_dim));
+}
+
+#[test]
+fn test_exact_parameter_gain_strategy_can_override_sequential_order() {
+    let (tt, site_inds) = make_selector_middle_site_tt();
+    let subdomain = SubDomainTT::from_tt(tt).with_budget_squared(1e-20);
+
+    let sequential = PatchingOptions {
+        rtol: 1e-12,
+        max_bond_dim: 1,
+        patch_order: vec![site_inds[0].clone(), site_inds[1].clone()],
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
+    let exact_gain = PatchingOptions {
+        split_strategy: PatchSplitStrategy::ExactParameterGain,
+        ..sequential.clone()
+    };
+
+    assert_eq!(
+        choose_split_index(&subdomain, &sequential).unwrap(),
+        Some(site_inds[0].clone())
+    );
+    assert_eq!(
+        choose_split_index(&subdomain, &exact_gain).unwrap(),
+        Some(site_inds[1].clone())
+    );
 }

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
@@ -41,6 +41,8 @@ pub struct SubDomainTT {
     data: TensorTrain,
     /// The projector defining the subdomain
     projector: Projector,
+    /// Absolute squared truncation budget assigned by adaptive patching.
+    budget_squared: Option<f64>,
 }
 
 impl SubDomainTT {
@@ -54,6 +56,7 @@ impl SubDomainTT {
         Self {
             data,
             projector: trimmed_projector,
+            budget_squared: None,
         }
     }
 
@@ -62,6 +65,7 @@ impl SubDomainTT {
         Self {
             data,
             projector: Projector::new(),
+            budget_squared: None,
         }
     }
 
@@ -88,6 +92,15 @@ impl SubDomainTT {
     /// Get a reference to the projector.
     pub fn projector(&self) -> &Projector {
         &self.projector
+    }
+
+    pub(crate) fn budget_squared(&self) -> Option<f64> {
+        self.budget_squared
+    }
+
+    pub(crate) fn with_budget_squared(mut self, budget_squared: f64) -> Self {
+        self.budget_squared = Some(budget_squared);
+        self
     }
 
     /// Convert to the underlying tensor train, consuming self.
@@ -140,6 +153,7 @@ impl SubDomainTT {
         Some(Self {
             data: projected_data,
             projector: merged_projector,
+            budget_squared: self.budget_squared,
         })
     }
 


### PR DESCRIPTION
## Summary

Completes the adaptive patching work for `tensor4all-partitionedtt` from issue #554.

- Adds volume-proportional absolute per-patch truncation budgets with below-budget patch elimination.
- Implements adaptive splitting in `add_with_patching` and removes the previous `NotImplemented` path.
- Adds `PatchSplitStrategy` with sequential and exact child-parameter-gain ordering.
- Adds `contract_adaptive` to contract first, then re-truncate output patches using the corrected output norm.
- Adds focused tests for budget allocation, patch dropping, splitting, oracle-visible ordering, and contract output re-truncation.
- Adds an anisotropic Gaussian benchmark comparing sequential order against exact-gain ordering at equal global error.

Fixes #554.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tensor4all-partitionedtt --release`
- `cargo clippy -p tensor4all-partitionedtt --all-targets -- -D warnings`
- `cargo doc -p tensor4all-partitionedtt --no-deps`
- `cargo run -p api-dump --release -- . -o docs/api`
- `cargo run -p tensor4all-partitionedtt --example benchmark_patching --release -- --x 8 --y 6 --components 4 --max-bond-dim 2 --rtol 1e-8 --repeats 1`

Benchmark smoke output showed `exact_gain` reducing patch count and core parameters versus `sequential_xy` at comparable dense-reference error.