### PR TITLE
Add CITATION.cff and component-level How to Cite guidance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,65 @@
+cff-version: 1.2.0
+message: >-
+  If you use tensor4all-rs in research, please cite it using the metadata
+  below. Depending on which components your work relies on, please also cite
+  the references listed under "references" (see the "How to Cite" section of
+  the README for guidance). A software paper is planned; this file will be
+  updated with a preferred-citation entry when it is available.
+title: tensor4all-rs
+type: software
+authors:
+  - name: tensor4all collaboration
+repository-code: "https://github.com/tensor4all/tensor4all-rs"
+url: "https://tensor4all.org/tensor4all-rs/"
+license: MIT
+references:
+  - type: article
+    title: "Learning tensor networks with tensor cross interpolation: new algorithms and libraries"
+    authors:
+      - family-names: "Núñez Fernández"
+        given-names: Yuriel
+      - family-names: Ritter
+        given-names: Marc K.
+      - family-names: Jeannin
+        given-names: Matthieu
+      - family-names: Li
+        given-names: Jheng-Wei
+      - family-names: Kloss
+        given-names: Thomas
+      - family-names: Louvet
+        given-names: Thibaud
+      - family-names: Terasaki
+        given-names: Satoshi
+      - family-names: Parcollet
+        given-names: Olivier
+      - family-names: von Delft
+        given-names: Jan
+      - family-names: Shinaoka
+        given-names: Hiroshi
+      - family-names: Waintal
+        given-names: Xavier
+    journal: SciPost Physics
+    volume: 18
+    year: 2025
+    doi: 10.21468/SciPostPhys.18.3.104
+    notes: >-
+      Cite when your work relies on the tensor cross interpolation
+      components (tensor4all-tcicore, tensor4all-tensorci,
+      tensor4all-treetci, tensor4all-quanticstci).
+  - type: article
+    title: "The ITensor Software Library for Tensor Network Calculations"
+    authors:
+      - family-names: Fishman
+        given-names: Matthew
+      - family-names: White
+        given-names: Steven R.
+      - family-names: Stoudenmire
+        given-names: E. Miles
+    journal: SciPost Physics Codebases
+    volume: 4
+    year: 2022
+    doi: 10.21468/SciPostPhysCodeb.4
+    notes: >-
+      Cite when your work relies on the tree tensor network components
+      (tensor4all-treetn, tensor4all-itensorlike), whose designs build on
+      ITensors.jl and ITensorNetworks.jl.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ Inspired by [ITensors.jl](https://github.com/ITensor/ITensors.jl) and
 acknowledge fruitful discussions with M. Fishman and E. M. Stoudenmire at CCQ,
 Flatiron Institute.
 
+## How to Cite
+
+If you use tensor4all-rs in research, please cite this repository using the
+metadata in [CITATION.cff](CITATION.cff) (GitHub's "Cite this repository"
+button). A software paper is planned and will become the preferred citation
+once available.
+
+Depending on which components your work relies on, please also cite:
+
+- **Tensor cross interpolation** (`tensorci`, `treetci`, `quanticstci`,
+  `tcicore`): Y. Núñez Fernández et al., "Learning tensor networks with
+  tensor cross interpolation: new algorithms and libraries",
+  [SciPost Phys. 18, 104 (2025)](https://doi.org/10.21468/SciPostPhys.18.3.104)
+- **Tree tensor networks** (`treetn`, `itensorlike`): M. Fishman,
+  S. R. White, E. M. Stoudenmire, "The ITensor Software Library for Tensor
+  Network Calculations",
+  [SciPost Phys. Codebases 4 (2022)](https://doi.org/10.21468/SciPostPhysCodeb.4),
+  whose ITensors.jl / ITensorNetworks.jl designs these components build on
+
 ## License
 
 MIT License (see [LICENSE-MIT](LICENSE-MIT))


### PR DESCRIPTION
## Summary

Adds citation infrastructure ahead of production use (a first external preprint using tensor4all-rs is already out):

- `CITATION.cff` (software citation; enables GitHub's "Cite this repository" button) with two component-level references: the TCI paper (Núñez Fernández et al., SciPost Phys. 18, 104 (2025), DOI 10.21468/SciPostPhys.18.3.104) and the ITensor paper (Fishman, White, Stoudenmire, SciPost Phys. Codebases 4 (2022), DOI 10.21468/SciPostPhysCodeb.4). The file is structured so a future software paper becomes `preferred-citation` without restructuring.
- README "How to Cite" section mapping components to citations: TCI crates point to the TCI paper, `treetn`/`itensorlike` point to the ITensor paper whose ITensors.jl / ITensorNetworks.jl designs they build on.

Bibliographic metadata verified against arXiv:2407.02454 (journal reference) and the SciPost DOIs.

Prose/metadata only; no code changes. `cargo fmt --check` passes and the CFF file parses as YAML; full test suite left to CI since no Rust code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)