### PR TITLE
TDVP: root-edge-first sweep ordering (10-orders accuracy fix on branching trees)

### DIFF
--- a/benchmarks/results/2026-07-22-treetn-tdvp-itensornetworks-1t.md
+++ b/benchmarks/results/2026-07-22-treetn-tdvp-itensornetworks-1t.md
@@ -1,0 +1,200 @@
+# TreeTN TDVP vs ITensorNetworks.jl, strict single-thread rerun
+
+Date: 2026-07-22
+
+Purpose: rerun the 2026-06-27 TreeTN TDVP comparison
+(`2026-06-27-treetn-tdvp-itensornetworks.md`) under strictly verified
+single-thread conditions, and identify why the Rust implementation is faster
+on the star topology.
+
+Two corrections to the earlier setup motivated this rerun:
+
+1. The earlier Julia command set `BLAS_NUM_THREADS=1`, but Julia's OpenBLAS
+   reads `OPENBLAS_NUM_THREADS`. The earlier Julia timings may therefore have
+   run with multi-threaded BLAS. This rerun sets `JULIA_NUM_THREADS=1` and
+   `OPENBLAS_NUM_THREADS=1` and verifies `BLAS.get_num_threads() == 1` in the
+   benchmark process environment.
+2. The earlier run used a Linux machine. This rerun records the platform
+   explicitly (Apple M5 Max, macOS 25.5.0) so future comparisons are not mixed
+   across machines.
+
+The physical setup is unchanged: alternating product state evolved under the
+Pauli Heisenberg Hamiltonian `sum_(i,j in E) X_i X_j + Y_i Y_j + Z_i Z_j`
+for `t = 0.08` in 4 two-site TDVP steps of `dt = 0.02`, `order = 2`,
+`maxdim = 32`, ITensors-compatible relative discarded squared singular-value
+tail cutoff `1e-12`, Hermitian Krylov exponentials with `krylovdim = 30`,
+`tol = 1e-12`. Accuracy is the dense-vector L2 error against an exact dense
+Hermitian eigendecomposition reference.
+
+## Environment
+
+- Machine: Apple M5 Max, macOS (Darwin 25.5.0)
+- Rust: `benchmark_tdvp` release build, default faer-backed tensor backend.
+  The per-apply profile below shows GEMM time is negligible at these tensor
+  sizes, so the faer-vs-OpenBLAS backend choice does not affect this
+  comparison.
+- Julia: 1.12.5, ITensorNetworks.jl at commit `9a4c4a7` (v0.21.1,
+  2026-05-08). This is the newest upstream commit that still provides the
+  `ttn(OpSum, ...)` constructor used by the benchmark script; later commits
+  (#355/#356) remove that API.
+- Thread verification: `BLAS.get_num_threads() == 1`,
+  `Threads.nthreads() == 1` under the exact benchmark environment.
+
+## Commands
+
+Rust:
+
+```bash
+RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 \
+cargo run -p tensor4all-treetn --example benchmark_tdvp --release -- 8 4 3 0.02
+```
+
+Julia (bench project with `Pkg.develop` of the pinned ITensorNetworks.jl
+checkout, plus `Graphs`, `ITensors`, `TensorOperations`, `KrylovKit`):
+
+```bash
+JULIA_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+julia --project=$T4A_ITN_BENCH_PROJECT \
+  benchmarks/julia/benchmark_tdvp_itensornetworks.jl 8 4 3 0.02
+```
+
+## Results (1 thread)
+
+| Implementation | Topology | Norm | L2 error | Mean ms | Min ms | Max ms |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Rust TreeTN TDVP | chain | 0.999999999998 | 1.375e-5 | 104.585 | 99.150 | 107.514 |
+| ITensorNetworks.jl | chain | 0.999999999998 | 1.375e-5 | 101.034 | 90.188 | 117.843 |
+| Rust TreeTN TDVP | star | 1.000000000000 | 3.999e-4 | 1739.476 | 1736.142 | 1741.698 |
+| ITensorNetworks.jl | star | 1.000000000000 | 7.643e-14 | 5414.554 | 5373.677 | 5458.630 |
+
+Summary: on the chain control the two implementations are equal within noise.
+On the star topology Rust is 3.1x faster at strictly one thread. The earlier
+Linux run showed 5.3x; part of that gap was likely the unpinned Julia BLAS
+threading (multi-threaded BLAS hurts at these tiny tensor sizes) plus the
+different machine.
+
+## Why Rust wins on the star: profile evidence
+
+Both implementations spend essentially the whole star runtime applying the
+projected Hamiltonian inside the local Krylov exponentials, and both perform
+almost the same number of applies. The difference is the cost per apply.
+
+Rust (`T4A_PROFILE_TDVP=1`, 1 repeat, total 1.647 s):
+
+- `evolve local` (Krylov exponentials): 1.626 s = 98.7% of total
+- `projected apply` (H·v): 1.552 s = 94.2% of total, 752 calls
+- everything else (canonicalization moves, factorize, plan, environment
+  bookkeeping): < 2%
+- per apply: 1.552 s / 752 = 2.06 ms
+
+Julia (`Profile` flat samples, one run, 28 630 samples total):
+
+- `KrylovKit.exponentiate`: 99.7% of samples
+- `optimal_map` (projected H·v): 95.6% of samples
+- inside the apply, by exclusive share: `permutedims` 21.6%, allocation
+  (`similar`) 16.5%, contraction-sequence search 3.4%, remainder NDTensors
+  pairwise-contraction dispatch and kernel overhead; BLAS GEMM does not
+  register at these sizes
+- apply count (instrumented wrapper run): 802 calls
+- per apply: 0.956 x 5.415 s / 802 = 6.45 ms
+
+So the whole 3.1x gap reduces to a 3.1x per-apply cost ratio
+(6.45 ms vs 2.06 ms) at nearly identical apply counts (802 vs 752).
+
+The star's center vertex has degree 7, so a two-site projected apply at the
+center contracts on the order of 9 small tensors (6 leaf environments, 2
+operator tensors, the local state) pairwise. Every pairwise step carries
+per-contraction bookkeeping: index-set matching, output allocation, and a
+layout permutation. The numeric work is negligible (chi <= 32, d = 2), so
+per-contraction overhead dominates and the implementation with cheaper
+per-contraction machinery wins. The Rust side benefits from its multi-tensor
+`T::contract(&refs)` path and lighter per-contraction bookkeeping; the Julia
+side pays `permutedims` + allocation + dynamic dispatch per pairwise ITensor
+contraction. The chain control confirms this reading: with only 2
+environments per region (4-5 tensors per apply), the overhead share shrinks
+and the two implementations tie.
+
+Notably, the contraction-sequence search (`alg="optimal"`) is only ~3% of
+Julia's samples, ruling out the a-priori plausible hypothesis that repeated
+sequence optimization at the high-degree center explains the gap.
+
+## Caveat: accuracy divergence against the 2026-06-27 run
+
+At the same nominal parameters, ITensorNetworks.jl at `9a4c4a7` reaches
+L2 error 7.6e-14 with final `maxlinkdim = 2` on the star, while both Rust and
+the older ITensorNetworks checkout used on 2026-06-27 give 3.999e-4. Upstream
+therefore changed two-site TDVP behavior on non-chain trees somewhere before
+`9a4c4a7`, and the Rust implementation currently reproduces the older, less
+accurate behavior. This does not affect the timing conclusion above (the
+newer Julia code does less numerical work per bond, chi = 2, yet is still
+3.1x slower), but it means the "matching accuracy" parity claim from
+2026-06-27 no longer holds against current upstream.
+
+The changing commit was identified by targeted testing of the range
+`88f1b8c..9a4c4a7`: the transition happens exactly at `c6d7e64` ("Upgrade
+ITensorNetworks to use DataGraphs v0.4.0 and NamedGraphs v0.11.0", #317).
+Its parent `9ed5949` gives 3.999e-4; `c6d7e64` gives 7.64e-14. The
+improvement therefore comes from a change in graph traversal ordering in the
+NamedGraphs/DataGraphs dependencies (which determines the post-order DFS
+sweep order over the tree), not from any change in the TDVP solver code
+itself, which is unchanged over this range.
+
+The mechanism was isolated by instrumenting the local solver at `9ed5949`
+(NamedGraphs 0.8.2) and `c6d7e64` (NamedGraphs 0.11.5) and recording the
+region sequence of one time step. Everything else is bit-identical between
+the two versions: same root (vertex 2, a leaf), same Hamiltonian TTN (all
+link dimensions 5), same 26 solver calls, same final `maxlinkdim = 2`. Only
+the order changed:
+
+- Old: forward half-sweep `[1,3] [1,4] [1,5] [1,6] [1,7] [1,8] [1,2]` with
+  the root edge evolved last, then the reverse. The sweep starts at region
+  `[1,3]` while the orthogonality center sits at root vertex 2, so the
+  initial `orthogonalize` transports the gauge across the unevolved root
+  edge without a compensating backward step, at the start and at the turning
+  point of every half-sweep.
+- New: forward half-sweep `[1,2] [1,3] ... [1,8]`, starting at the edge
+  containing the orthogonality center and walking outward, then the exact
+  mirror. Every gauge move stays inside just-evolved regions with its
+  negative one-site correction. This is the exact symmetric
+  projector-splitting integrator.
+
+This also explains the size of the effect. For this benchmark the exact
+evolution happens to stay inside the bond-dimension-2 manifold, and when the
+exact solution lies in the variational manifold, correct projector-splitting
+TDVP is exact up to the local Krylov tolerance (1e-12), which matches the
+observed 7.6e-14. The uncompensated gauge transport at the sweep seam was
+therefore the only substantial error source, worth the full ten orders of
+magnitude here (3.999e-4).
+
+Implication for tensor4all-rs: `TdvpRegionPlan` used to emit the old,
+root-edge-last ordering. The fix is to start each half-sweep at the edge
+containing the sweep root / orthogonality center and walk outward
+(root-edge-first), matching NamedGraphs v0.11 behavior.
+
+## Addendum: fix applied (2026-07-22, issue #560)
+
+`TdvpRegionPlan` now generates root-edge-first pre-order half-sweeps. Rerun
+of the same benchmark on the same machine after the fix:
+
+| Implementation | Topology | Norm | L2 error | Mean ms |
+| --- | --- | ---: | ---: | ---: |
+| Rust TreeTN TDVP (fixed) | chain | 0.999999999998 | 1.375e-5 | 95.773 |
+| Rust TreeTN TDVP (fixed) | star | 1.000000000000 | 7.114e-13 | 1730.055 |
+
+The star error drops by nine orders of magnitude to the Krylov-tolerance
+level, matching ITensorNetworks.jl at NamedGraphs >= 0.11; the chain result
+is bit-identical to before the fix, as expected from the upstream
+observation; the runtime is unchanged.
+
+## Notes
+
+- Rust benchmark source: `benchmarks/rust/benchmark_tdvp.rs` via
+  `crates/tensor4all-treetn/examples/benchmark_tdvp.rs`.
+- Julia benchmark source: `benchmarks/julia/benchmark_tdvp_itensornetworks.jl`.
+- The Julia apply count was measured with a wrapper solver that counts
+  operator evaluations; the wrapper adds significant overhead, so its timing
+  is discarded and only the count (802) is used. The per-apply time is
+  computed from the uninstrumented run times the profile share.
+- Rust reported `sweeps_completed=4`, `local_updates=104`,
+  `max_krylov_iterations=8` on both topologies, matching the 2026-06-27 run,
+  and identical L2 errors to the 2026-06-27 run on both topologies.

--- a/crates/tensor4all-treetn/src/tdvp/plan.rs
+++ b/crates/tensor4all-treetn/src/tdvp/plan.rs
@@ -110,20 +110,46 @@ where
             )
         }
         2 => {
-            let edges = post_order_dfs_edges_by_name(network, root)?;
+            // Root-edge-first outward walk (pre-order DFS edges). Starting each
+            // half-sweep at the edge containing the sweep root keeps every gauge
+            // move inside already-evolved regions, which is required for the
+            // symmetric projector-splitting integrator; the old post-order
+            // (root-edge-last) ordering transported the gauge across unevolved
+            // edges at the start and turning point of each half-sweep. Matches
+            // ITensorNetworks.jl at NamedGraphs >= 0.11 (see benchmarks/results/
+            // 2026-07-22-treetn-tdvp-itensornetworks-1t.md).
+            let edges = pre_order_dfs_edges_by_name(network, root)?;
             let mut steps = Vec::new();
             let last_edge = edges.len().saturating_sub(1);
-            for (j, (src, dst)) in edges.into_iter().enumerate() {
+            for (j, (parent, child)) in edges.iter().enumerate() {
+                // The center after a two-site step sits on the vertex shared
+                // with the next region so the following site correction acts on
+                // the overlap; the final edge parks the center on its far side.
+                let center = match edges.get(j + 1) {
+                    Some((next_parent, next_child)) => {
+                        if parent == next_parent || parent == next_child {
+                            parent.clone()
+                        } else {
+                            child.clone()
+                        }
+                    }
+                    None => child.clone(),
+                };
+                let other = if center == *parent {
+                    child.clone()
+                } else {
+                    parent.clone()
+                };
                 steps.push(TdvpRegionStep {
-                    nodes: vec![src, dst.clone()],
-                    new_center: dst.clone(),
+                    nodes: vec![other, center.clone()],
+                    new_center: center.clone(),
                     exponent_step,
                     kind: TdvpRegionKind::TwoSite,
                 });
                 if j < last_edge {
                     steps.push(TdvpRegionStep {
-                        nodes: vec![dst.clone()],
-                        new_center: dst,
+                        nodes: vec![center.clone()],
+                        new_center: center,
                         exponent_step: -exponent_step,
                         kind: TdvpRegionKind::SiteCorrection,
                     });
@@ -159,14 +185,17 @@ where
         .collect()
 }
 
-fn post_order_dfs_edges_by_name<V>(network: &NodeNameNetwork<V>, root: &V) -> Option<Vec<(V, V)>>
+/// Tree edges as `(parent, child)` pairs in a parents-before-children order
+/// (reverse post-order), so the edge containing `root` comes first and each
+/// subsequent edge attaches to an already-visited vertex.
+fn pre_order_dfs_edges_by_name<V>(network: &NodeNameNetwork<V>, root: &V) -> Option<Vec<(V, V)>>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
     let root_idx = network.node_index(root)?;
     let post_order = network.post_order_dfs_by_index(root_idx);
     let mut edges = Vec::new();
-    for child in post_order {
+    for &child in post_order.iter().rev() {
         if child == root_idx {
             continue;
         }
@@ -174,7 +203,7 @@ where
         let parent = *path.get(1)?;
         let child_name = network.node_name(child)?.clone();
         let parent_name = network.node_name(parent)?.clone();
-        edges.push((child_name, parent_name));
+        edges.push((parent_name, child_name));
     }
     Some(edges)
 }
@@ -217,7 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn two_site_plan_inserts_negative_single_site_corrections_except_last_edge() {
+    fn two_site_plan_starts_at_root_edge_with_corrections_except_last_edge() {
         let network = chain_abc();
         let exponent = Complex64::new(0.0, -0.2);
         let plan = TdvpRegionPlan::new(&network, &"B", 2, 1, exponent).unwrap();
@@ -227,12 +256,13 @@ mod tests {
             .iter()
             .map(|step| (step.kind, step.nodes.clone(), step.exponent_step))
             .collect();
+        // The first region contains the sweep root B; the walk moves outward.
         assert_eq!(
             regions,
             vec![
-                (TdvpRegionKind::TwoSite, vec!["A", "B"], exponent),
-                (TdvpRegionKind::SiteCorrection, vec!["B"], -exponent),
                 (TdvpRegionKind::TwoSite, vec!["C", "B"], exponent),
+                (TdvpRegionKind::SiteCorrection, vec!["B"], -exponent),
+                (TdvpRegionKind::TwoSite, vec!["B", "A"], exponent),
             ]
         );
     }
@@ -252,14 +282,77 @@ mod tests {
         assert_eq!(
             regions,
             vec![
-                (TdvpRegionKind::TwoSite, vec!["A", "B"], half),
-                (TdvpRegionKind::SiteCorrection, vec!["B"], -half),
                 (TdvpRegionKind::TwoSite, vec!["C", "B"], half),
-                (TdvpRegionKind::TwoSite, vec!["B", "C"], half),
                 (TdvpRegionKind::SiteCorrection, vec!["B"], -half),
                 (TdvpRegionKind::TwoSite, vec!["B", "A"], half),
+                (TdvpRegionKind::TwoSite, vec!["A", "B"], half),
+                (TdvpRegionKind::SiteCorrection, vec!["B"], -half),
+                (TdvpRegionKind::TwoSite, vec!["B", "C"], half),
             ]
         );
+    }
+
+    #[test]
+    fn two_site_star_plan_walks_outward_from_root_leaf() {
+        // Regression test for the root-edge-first ordering (issue #560): on a
+        // branching tree the half-sweep must start at the edge containing the
+        // sweep root and keep every subsequent region attached to an
+        // already-visited vertex, with the site correction on the overlap.
+        let network = star_abcd();
+        let exponent = Complex64::new(0.0, -0.2);
+        let plan = TdvpRegionPlan::new(&network, &"B", 2, 1, exponent).unwrap();
+
+        let regions: Vec<_> = plan
+            .steps
+            .iter()
+            .map(|step| (step.kind, step.nodes.clone(), step.exponent_step))
+            .collect();
+        assert_eq!(
+            regions,
+            vec![
+                (TdvpRegionKind::TwoSite, vec!["B", "A"], exponent),
+                (TdvpRegionKind::SiteCorrection, vec!["A"], -exponent),
+                (TdvpRegionKind::TwoSite, vec!["D", "A"], exponent),
+                (TdvpRegionKind::SiteCorrection, vec!["A"], -exponent),
+                (TdvpRegionKind::TwoSite, vec!["A", "C"], exponent),
+            ]
+        );
+    }
+
+    #[test]
+    fn two_site_plan_keeps_every_region_attached_to_visited_vertices() {
+        // Two branches of depth 2 force a jump between subtrees; even then the
+        // walk must stay contiguous: the first region contains the sweep root
+        // and every later region shares a vertex with the already-visited set.
+        let mut network = NodeNameNetwork::new();
+        for node in ["A", "B", "C", "D", "E"] {
+            network.add_node(node).unwrap();
+        }
+        network.add_edge(&"A", &"B").unwrap();
+        network.add_edge(&"B", &"C").unwrap();
+        network.add_edge(&"A", &"D").unwrap();
+        network.add_edge(&"D", &"E").unwrap();
+
+        let exponent = Complex64::new(0.0, -0.2);
+        let plan = TdvpRegionPlan::new(&network, &"A", 2, 1, exponent).unwrap();
+
+        let two_site_regions: Vec<Vec<&str>> = plan
+            .steps
+            .iter()
+            .filter(|step| step.kind == TdvpRegionKind::TwoSite)
+            .map(|step| step.nodes.clone())
+            .collect();
+        assert_eq!(two_site_regions.len(), 4);
+        assert!(two_site_regions[0].contains(&"A"));
+        let mut visited: std::collections::HashSet<&str> =
+            two_site_regions[0].iter().copied().collect();
+        for region in &two_site_regions[1..] {
+            assert!(
+                region.iter().any(|node| visited.contains(node)),
+                "region {region:?} is detached from visited set {visited:?}"
+            );
+            visited.extend(region.iter().copied());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements #560. Two-site `TdvpRegionPlan` half-sweeps now start at the edge containing the sweep root and walk outward (pre-order DFS edges), with the center placed on the vertex shared with the next region and the negative one-site correction acting on that overlap. The previous post-order (root-edge-last) ordering transported the gauge across unevolved edges at the start and turning point of every half-sweep, which breaks the symmetric projector-splitting structure on branching trees. One-site plans are unchanged (out of scope).

## Evidence and validation

- Star benchmark (N=8, order 2, dt=0.02, 4 steps, maxdim 32, 1 thread): L2 error vs dense exact evolution drops **3.999e-4 to 7.114e-13**, matching ITensorNetworks.jl at NamedGraphs >= 0.11 (7.6e-14). The effect is this large because the exact evolution stays in the chi=2 manifold, where correct projector-splitting TDVP is exact up to the Krylov tolerance.
- Chain benchmark: **bit-identical** to before the fix (1.375e-5), matching the upstream observation that the ordering change does not affect chains.
- Runtime unchanged (star 1730 ms vs 1739 ms mean).
- Root cause of the upstream behavior change isolated to the NamedGraphs 0.11 traversal-order change (ITensor/ITensorNetworks.jl#317) by instrumenting the local solver at the adjacent upstream commits; everything else (root, Hamiltonian TTN link dimensions, 26 solver calls, final maxlinkdim) is identical. Full analysis in the included benchmark report `benchmarks/results/2026-07-22-treetn-tdvp-itensornetworks-1t.md`.

## Tests

- Updated the two plan-shape unit tests to pin the new ordering
- New regression test `two_site_star_plan_walks_outward_from_root_leaf` (references #560)
- New contiguity invariant test on a two-branch depth-2 tree (covers the subtree-jump path)
- `cargo nextest run --release --workspace`: 2493 passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean; `cargo fmt --all -- --check`: clean

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)