### PR TITLE
Add adaptive TCI interpolation for partitioned tensor trains

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ validated in CI. Longer runnable examples live in the
 | [tensor4all-interpolativeqtt](crates/tensor4all-interpolativeqtt/) | Interpolative QTT construction |
 | [tensor4all-quanticstransform](crates/tensor4all-quanticstransform/) | Quantics transformation operators |
 | [tensor4all-treetci](crates/tensor4all-treetci/) | Tree-structured cross interpolation |
-| [tensor4all-partitionedtt](crates/tensor4all-partitionedtt/) | Partitioned Tensor Train |
+| [tensor4all-partitionedtt](crates/tensor4all-partitionedtt/) | Partitioned tensor trains and adaptive TCI interpolation |
 | [tensor4all-hdf5](crates/tensor4all-hdf5/) | ITensors.jl-compatible HDF5 serialization |
 | [tensor4all-capi](crates/tensor4all-capi/) | C FFI for language bindings |
 

--- a/crates/tensor4all-core/src/defaults/tensordynlen.rs
+++ b/crates/tensor4all-core/src/defaults/tensordynlen.rs
@@ -402,6 +402,76 @@ impl TensorDynLenStorage {
     }
 }
 
+/// Errors returned when constructing a compact copy-selector tensor.
+///
+/// A copy-selector has logical values
+/// `scale * delta(left, right) * delta(site, selected_value)` and is used to
+/// carry a bond through a fixed physical site without dense bond-squared storage.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, StructuredSelectorError, TensorDynLen};
+///
+/// let left = DynIndex::new_dyn(2);
+/// let site = DynIndex::new_dyn(3);
+/// let right = DynIndex::new_dyn(4);
+/// let error = TensorDynLen::from_copy_selector(left, site, right, 1, 1.0_f64)
+///     .unwrap_err();
+/// assert!(matches!(error, StructuredSelectorError::BondDimensionMismatch { .. }));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum StructuredSelectorError {
+    /// The two logical copy axes have different dimensions.
+    #[error("copy-selector bond dimensions differ: left={left}, right={right}")]
+    BondDimensionMismatch {
+        /// Dimension of the left copy axis.
+        left: usize,
+        /// Dimension of the right copy axis.
+        right: usize,
+    },
+    /// One of the logical axes has dimension zero.
+    #[error("copy-selector {axis} dimension must be positive")]
+    ZeroDimension {
+        /// Name of the zero-dimensional axis.
+        axis: &'static str,
+    },
+    /// The selected physical coordinate is outside the site dimension.
+    #[error("selected site value {value} is outside 0..{site_dim}")]
+    SelectedValueOutOfBounds {
+        /// Requested zero-based physical coordinate.
+        value: usize,
+        /// Dimension of the physical site.
+        site_dim: usize,
+    },
+    /// The compact payload element count cannot be represented by `usize`.
+    #[error("copy-selector payload size overflows usize for dimensions {bond_dim} x {site_dim}")]
+    PayloadSizeOverflow {
+        /// Dimension shared by the copy axes.
+        bond_dim: usize,
+        /// Dimension of the physical site.
+        site_dim: usize,
+    },
+    /// A compact payload stride cannot be represented by `isize`.
+    #[error("copy-selector bond stride {bond_dim} exceeds isize::MAX")]
+    StrideOverflow {
+        /// Bond dimension that could not be converted to a stride.
+        bond_dim: usize,
+    },
+    /// Reserving the compact payload failed.
+    #[error("could not allocate copy-selector payload with {elements} elements")]
+    AllocationFailed {
+        /// Number of compact payload elements requested.
+        elements: usize,
+    },
+    /// Backend structured-storage validation failed.
+    #[error("invalid copy-selector storage: {message}")]
+    InvalidStorage {
+        /// Diagnostic returned by structured-storage validation.
+        message: String,
+    },
+}
+
 /// Dynamic-rank tensor with structured payload storage -- the central data type
 /// of tensor4all.
 ///
@@ -1826,6 +1896,131 @@ impl TensorDynLen {
     /// ```
     pub fn from_structured_storage(indices: Vec<DynIndex>, storage: Arc<Storage>) -> Result<Self> {
         Self::from_storage(indices, storage)
+    }
+
+    /// Construct a compact copy tensor that selects one physical-site value.
+    ///
+    /// The returned rank-3 tensor has logical indices `[left, site, right]` and
+    /// value `scale` exactly when `left == right` and `site == selected_value`;
+    /// every other entry is zero. Its payload has `left.dim * site.dim`
+    /// elements rather than `left.dim * site.dim * right.dim` dense elements.
+    ///
+    /// # Arguments
+    ///
+    /// - `left`: left copy axis; its dimension must be positive and equal to
+    ///   `right.dim`.
+    /// - `site`: physical axis whose selected coordinate remains active.
+    /// - `right`: right copy axis paired with `left`.
+    /// - `selected_value`: zero-based coordinate in `0..site.dim`.
+    /// - `scale`: value stored on the selected copy diagonal.
+    ///
+    /// # Returns
+    ///
+    /// A compact structured tensor with axis classes `[0, 1, 0]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StructuredSelectorError`] when dimensions are zero or
+    /// inconsistent, the selected value is out of bounds, checked size or
+    /// stride arithmetic overflows, allocation fails, or backend structured
+    /// storage validation rejects the metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_tensorbackend::StorageKind;
+    ///
+    /// let left = DynIndex::new_dyn(2);
+    /// let site = DynIndex::new_dyn(3);
+    /// let right = DynIndex::new_dyn(2);
+    /// let tensor = TensorDynLen::from_copy_selector(
+    ///     left,
+    ///     site,
+    ///     right,
+    ///     1,
+    ///     2.5_f64,
+    /// ).unwrap();
+    ///
+    /// assert_eq!(tensor.storage().storage_kind(), StorageKind::Structured);
+    /// assert_eq!(tensor.storage().payload_len(), 6);
+    /// assert_eq!(
+    ///     tensor.to_vec::<f64>().unwrap(),
+    ///     vec![0.0, 0.0, 2.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.5, 0.0, 0.0],
+    /// );
+    /// ```
+    pub fn from_copy_selector<T>(
+        left: DynIndex,
+        site: DynIndex,
+        right: DynIndex,
+        selected_value: usize,
+        scale: T,
+    ) -> std::result::Result<Self, StructuredSelectorError>
+    where
+        T: TensorElement + StorageScalar + Copy + Zero,
+    {
+        if left.dim == 0 {
+            return Err(StructuredSelectorError::ZeroDimension { axis: "left" });
+        }
+        if site.dim == 0 {
+            return Err(StructuredSelectorError::ZeroDimension { axis: "site" });
+        }
+        if right.dim == 0 {
+            return Err(StructuredSelectorError::ZeroDimension { axis: "right" });
+        }
+        if left.dim != right.dim {
+            return Err(StructuredSelectorError::BondDimensionMismatch {
+                left: left.dim,
+                right: right.dim,
+            });
+        }
+        if selected_value >= site.dim {
+            return Err(StructuredSelectorError::SelectedValueOutOfBounds {
+                value: selected_value,
+                site_dim: site.dim,
+            });
+        }
+
+        let payload_len =
+            left.dim
+                .checked_mul(site.dim)
+                .ok_or(StructuredSelectorError::PayloadSizeOverflow {
+                    bond_dim: left.dim,
+                    site_dim: site.dim,
+                })?;
+        let site_stride = isize::try_from(left.dim)
+            .map_err(|_| StructuredSelectorError::StrideOverflow { bond_dim: left.dim })?;
+        let selected_offset = left.dim.checked_mul(selected_value).ok_or(
+            StructuredSelectorError::PayloadSizeOverflow {
+                bond_dim: left.dim,
+                site_dim: site.dim,
+            },
+        )?;
+
+        let mut payload = Vec::new();
+        payload.try_reserve_exact(payload_len).map_err(|_| {
+            StructuredSelectorError::AllocationFailed {
+                elements: payload_len,
+            }
+        })?;
+        payload.resize(payload_len, T::zero());
+        for bond in 0..left.dim {
+            payload[selected_offset + bond] = scale;
+        }
+        let storage = Storage::new_structured(
+            payload,
+            vec![left.dim, site.dim],
+            vec![1, site_stride],
+            vec![0, 1, 0],
+        )
+        .map_err(|error| StructuredSelectorError::InvalidStorage {
+            message: error.to_string(),
+        })?;
+        Self::from_structured_storage(vec![left, site, right], Arc::new(storage)).map_err(|error| {
+            StructuredSelectorError::InvalidStorage {
+                message: error.to_string(),
+            }
+        })
     }
 
     /// Create a tensor from a native tenferro payload.

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -76,7 +76,8 @@ pub use defaults::tensordynlen as tensor;
 
 pub use any_scalar::AnyScalar;
 pub use defaults::tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, TensorDynLen,
+    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, StructuredSelectorError,
+    TensorDynLen,
 };
 pub use tensor4all_tensorbackend::TensorElement;
 pub use tensor4all_tensorbackend::{

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -147,6 +147,53 @@ fn tensor_from_structured_storage_preserves_compact_payload() {
 }
 
 #[test]
+fn copy_selector_is_compact_and_numerically_correct() {
+    let left = Index::new_dyn(2);
+    let site = Index::new_dyn(3);
+    let right = Index::new_dyn(2);
+
+    let tensor = TensorDynLen::from_copy_selector(left, site, right, 1, 2.5_f64).unwrap();
+
+    assert_eq!(tensor.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(tensor.storage().payload_len(), 6);
+    assert_eq!(tensor.storage().axis_classes(), &[0, 1, 0]);
+    assert_eq!(
+        tensor.to_vec::<f64>().unwrap(),
+        vec![0.0, 0.0, 2.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.5, 0.0, 0.0]
+    );
+}
+
+#[test]
+fn copy_selector_rejects_payload_and_stride_overflow_before_allocation() {
+    let payload_error = TensorDynLen::from_copy_selector(
+        Index::new_dyn(usize::MAX),
+        Index::new_dyn(2),
+        Index::new_dyn(usize::MAX),
+        0,
+        1.0_f64,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        payload_error,
+        tensor4all_core::StructuredSelectorError::PayloadSizeOverflow { .. }
+    ));
+
+    let oversized_stride = (isize::MAX as usize) + 1;
+    let stride_error = TensorDynLen::from_copy_selector(
+        Index::new_dyn(oversized_stride),
+        Index::new_dyn(1),
+        Index::new_dyn(oversized_stride),
+        0,
+        1.0_f64,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        stride_error,
+        tensor4all_core::StructuredSelectorError::StrideOverflow { .. }
+    ));
+}
+
+#[test]
 fn tensor_from_structured_storage_rejects_index_dim_mismatch() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(4);

--- a/crates/tensor4all-partitionedtt/Cargo.toml
+++ b/crates/tensor4all-partitionedtt/Cargo.toml
@@ -12,19 +12,32 @@ default = ["tenferro-cpu-faer"]
 tenferro-cpu-faer = [
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-itensorlike/tenferro-cpu-faer",
+    "tensor4all-simplett/tenferro-cpu-faer",
+    "tensor4all-tcicore/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+    "tensor4all-tensorci/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-itensorlike/tenferro-provider-inject",
+    "tensor4all-simplett/tenferro-provider-inject",
+    "tensor4all-tcicore/tenferro-provider-inject",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+    "tensor4all-tensorci/tenferro-provider-inject",
 ]
 
 [dependencies]
 num-complex.workspace = true
 num-traits.workspace = true
+rand.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
 tensor4all-itensorlike = { path = "../tensor4all-itensorlike", default-features = false }
+tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
+tensor4all-tcicore = { path = "../tensor4all-tcicore", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+tensor4all-tensorci = { path = "../tensor4all-tensorci", default-features = false }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-partitionedtt/LICENSE-TCIALGORITHMS-MIT
+++ b/crates/tensor4all-partitionedtt/LICENSE-TCIALGORITHMS-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ritter.Marc <Ritter.Marc@physik.uni-muenchen.de> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/tensor4all-partitionedtt/README.md
+++ b/crates/tensor4all-partitionedtt/README.md
@@ -8,6 +8,36 @@ with projectors.
 - `PartitionedTT` — collection of non-overlapping subdomain tensor trains
 - `SubDomainTT` — tensor train restricted to a specific subdomain
 - `Projector` — maps tensor indices to fixed values defining subdomains
+- `adaptiveinterpolate` — runs TCI2 per patch and subdivides patches that miss the requested tolerance
+- `AdaptiveInterpolateOptions` — controls TCI2, patch order, initial pivots, and opt-in pivot recycling
+
+## Adaptive interpolation
+
+```rust
+use tensor4all_partitionedtt::{
+    adaptiveinterpolate, AdaptiveInterpolateOptions, DynIndex, MultiIndex,
+};
+
+let sites = vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+let f = |index: &MultiIndex| ((index[0] + 1) * (index[1] + 1)) as f64;
+let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    f,
+    None,
+    sites,
+    vec![vec![1, 1]],
+    AdaptiveInterpolateOptions::default(),
+)
+.unwrap();
+
+assert_eq!(result.len(), 1);
+assert!(result.projectors().next().unwrap().is_empty());
+```
+
+Set `recycle_pivots` to reuse compatible parent TCI pivots in child patches.
+Children with no compatible recycled pivots are replenished with seeded random
+candidates rather than being treated as zero. A patch is classified as sampled
+zero only when all of its initial candidates evaluate below `1e-30`; provide
+known nonzero pivots for very sparse functions.
 
 ## Documentation
 

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
@@ -6,7 +6,6 @@
 //! (MIT license; Copyright 2023 Ritter.Marc and contributors).
 
 use std::collections::{HashSet, VecDeque};
-use std::sync::Arc;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -14,8 +13,10 @@ use tensor4all_core::{DynIndex, TensorDynLen, TensorElement};
 use tensor4all_itensorlike::TensorTrain;
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TTScalar};
 use tensor4all_tcicore::{MatrixLuciScalar, MultiIndex, Scalar};
-use tensor4all_tensorbackend::{Storage, StorageScalar};
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TensorCI2};
+use tensor4all_tensorbackend::StorageScalar;
+use tensor4all_tensorci::{
+    crossinterpolate2, TCI2OptimizationResult, TCI2Options, TCI2Termination, TensorCI2,
+};
 
 use crate::{PartitionedTT, PartitionedTTError, Projector, Result, SubDomainTT};
 
@@ -209,7 +210,7 @@ where
             &patch.recycled_pivots,
             options.n_initial_pivots,
             &mut rng,
-        );
+        )?;
         let candidate_values: Vec<T> = candidate_pivots
             .iter()
             .map(|pivot| {
@@ -254,7 +255,12 @@ where
                 batch(&full_pivots)
             }
         });
-        let (tci, _ranks, errors) = crossinterpolate2(
+        let TCI2OptimizationResult {
+            tci,
+            errors,
+            termination,
+            ..
+        } = crossinterpolate2(
             local_f,
             local_batch,
             local_dims,
@@ -271,7 +277,7 @@ where
             .copied()
             .unwrap_or_else(|| tci.max_bond_error() / normalization);
 
-        if final_error <= options.tci_options.tolerance {
+        if patch_is_accepted(termination, final_error, options.tci_options.tolerance) {
             let simple_tt = tci.to_tensor_train()?;
             let tt = embed_active_tt(
                 simple_tt,
@@ -397,6 +403,10 @@ fn validate_inputs(
     Ok(patch_order)
 }
 
+fn patch_is_accepted(termination: TCI2Termination, final_error: f64, tolerance: f64) -> bool {
+    termination == TCI2Termination::Converged && final_error <= tolerance
+}
+
 fn active_positions(site_indices: &[DynIndex], projector: &Projector) -> Vec<usize> {
     site_indices
         .iter()
@@ -413,7 +423,7 @@ fn patch_candidates(
     recycled_pivots: &[MultiIndex],
     target: usize,
     rng: &mut StdRng,
-) -> Vec<MultiIndex> {
+) -> Result<Vec<MultiIndex>> {
     let mut candidates = Vec::new();
     let mut seen = HashSet::new();
     for full_pivot in initial_pivots.iter().chain(recycled_pivots) {
@@ -432,12 +442,22 @@ fn patch_candidates(
         .iter()
         .map(|&position| site_indices[position].dim)
         .collect();
-    let point_count = local_dims
-        .iter()
-        .copied()
-        .fold(1usize, usize::saturating_mul);
+    let point_count = local_dims.iter().try_fold(1usize, |count, &dim| {
+        count.checked_mul(dim).ok_or_else(|| {
+            PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "active patch point count exceeds usize".to_string(),
+            )
+        })
+    })?;
     let desired = target.max(candidates.len()).min(point_count);
-    let random_attempts = desired.saturating_mul(20).saturating_add(100);
+    let random_attempts = desired
+        .checked_mul(20)
+        .and_then(|attempts| attempts.checked_add(100))
+        .ok_or_else(|| {
+            PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "initial-pivot search attempt count exceeds usize".to_string(),
+            )
+        })?;
     for _ in 0..random_attempts {
         if candidates.len() >= desired {
             break;
@@ -459,7 +479,7 @@ fn patch_candidates(
             candidates.push(pivot);
         }
     }
-    candidates
+    Ok(candidates)
 }
 
 fn is_compatible_pivot(
@@ -608,31 +628,14 @@ where
     T: Scalar + TensorElement + StorageScalar + Default + Copy,
 {
     match (left, right) {
-        (Some(left), Some(right)) => {
-            if left.dim != right.dim {
-                return Err(PartitionedTTError::TensorTrainError(format!(
-                    "projected site cannot carry unequal bond dimensions {} and {}",
-                    left.dim, right.dim
-                )));
-            }
-            let bond_dim = left.dim;
-            let mut payload = vec![T::zero(); bond_dim * site.dim];
-            for bond in 0..bond_dim {
-                payload[bond + bond_dim * value] = scale;
-            }
-            let storage = Storage::new_structured(
-                payload,
-                vec![bond_dim, site.dim],
-                vec![1, bond_dim as isize],
-                vec![0, 1, 0],
-            )
-            .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))?;
-            TensorDynLen::from_structured_storage(
-                vec![left.clone(), site.clone(), right.clone()],
-                Arc::new(storage),
-            )
-            .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
-        }
+        (Some(left), Some(right)) => TensorDynLen::from_copy_selector(
+            left.clone(),
+            site.clone(),
+            right.clone(),
+            value,
+            scale,
+        )
+        .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string())),
         (None, Some(right)) => {
             if right.dim != 1 {
                 return Err(PartitionedTTError::TensorTrainError(format!(

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
@@ -1,0 +1,713 @@
+//! Adaptive tensor cross interpolation over disjoint projected patches.
+//!
+//! The patch queue, convergence/splitting flow, and diagonal-pivot recycling are
+//! derived from `adaptiveinterpolate`, `createpatch`, and `_globalpivots` in
+//! TCIAlgorithms.jl at commit e501032278c9dd41b46c5851d8238169c8d178c5
+//! (MIT license; Copyright 2023 Ritter.Marc and contributors).
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tensor4all_core::{DynIndex, TensorDynLen, TensorElement};
+use tensor4all_itensorlike::TensorTrain;
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TTScalar};
+use tensor4all_tcicore::{MatrixLuciScalar, MultiIndex, Scalar};
+use tensor4all_tensorbackend::{Storage, StorageScalar};
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TensorCI2};
+
+use crate::{PartitionedTT, PartitionedTTError, Projector, Result, SubDomainTT};
+
+const ZERO_SAMPLE_THRESHOLD: f64 = 1.0e-30;
+
+/// Options controlling adaptive interpolation and patch subdivision.
+///
+/// `AdaptiveInterpolateOptions` augments [`TCI2Options`] with a deterministic
+/// patch order and initial-pivot policy. Use [`TCI2Options`] directly when no
+/// domain subdivision is needed.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtt::AdaptiveInterpolateOptions;
+///
+/// let options = AdaptiveInterpolateOptions::default();
+/// assert_eq!(options.n_initial_pivots, 5);
+/// assert!(!options.recycle_pivots);
+/// assert!(options.patch_order.is_empty());
+/// assert!((options.tci_options.tolerance - 1.0e-8).abs() < 1.0e-16);
+/// ```
+#[derive(Debug, Clone)]
+pub struct AdaptiveInterpolateOptions {
+    /// TCI2 sweep, tolerance, rank-cap, and random-search options.
+    ///
+    /// A patch is accepted when its final normalized or absolute bond error,
+    /// according to `normalize_error`, is at most `tolerance`. Otherwise it is
+    /// split. When in doubt, use [`TCI2Options::default`].
+    pub tci_options: TCI2Options,
+
+    /// Complete order in which site indices are fixed when patches split.
+    ///
+    /// An empty vector uses the order of `site_indices`. A nonempty vector must
+    /// be an exact permutation of `site_indices`, including index identity,
+    /// tags, prime level, and dimension.
+    pub patch_order: Vec<DynIndex>,
+
+    /// Target number of distinct initial pivot candidates per patch.
+    ///
+    /// Compatible user and recycled pivots are retained, then deterministic
+    /// random candidates are added until this target is reached (or the patch
+    /// contains fewer points). The recommended and default value is `5`.
+    pub n_initial_pivots: usize,
+
+    /// Whether a nonconverged parent TCI's diagonal pivots seed its child patches.
+    ///
+    /// Recycling is opt-in because it retains more pivot state. Incompatible
+    /// pivots are discarded, and every child is replenished to
+    /// `n_initial_pivots`; a child is never classified as zero merely because
+    /// no recycled pivot is compatible.
+    pub recycle_pivots: bool,
+}
+
+impl Default for AdaptiveInterpolateOptions {
+    fn default() -> Self {
+        Self {
+            tci_options: TCI2Options::default(),
+            patch_order: Vec::new(),
+            n_initial_pivots: 5,
+            recycle_pivots: false,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PendingPatch {
+    projector: Projector,
+    recycled_pivots: Vec<MultiIndex>,
+}
+
+/// Adaptively interpolate a discrete function as a partitioned tensor train.
+///
+/// Each attempted patch runs TCI2 on the sites not fixed by its projector. A
+/// converged patch is retained; a patch whose final error exceeds
+/// `options.tci_options.tolerance` is split at the next index in
+/// `options.patch_order`. Patches with zero or one active site are evaluated
+/// exactly because TCI2 requires at least two sites.
+///
+/// Initial pivots use zero-based coordinates and span the full `site_indices`
+/// domain. Compatible supplied and recycled pivots are supplemented with
+/// seeded random pivots. If every candidate evaluates below `1e-30`, the patch
+/// is represented as zero without further sampling; sparse functions should
+/// therefore provide pivots in known nonzero regions.
+///
+/// # Arguments
+///
+/// - `f`: scalar evaluator receiving one full, zero-based multi-index.
+/// - `batched_f`: optional batch evaluator receiving full multi-indices and
+///   returning values in the same order. Use `None` when batching is unavailable.
+/// - `site_indices`: one distinct [`DynIndex`] per TCI site, in evaluator order.
+/// - `initial_pivots`: full-domain, zero-based pivots. Empty input is allowed.
+/// - `options`: TCI2, patch-order, pivot-count, and recycling settings.
+///
+/// # Returns
+///
+/// A [`PartitionedTT`] whose mutually disjoint patches cover the full domain.
+/// Calling [`PartitionedTT::to_tensor_train`] combines the patches into one TT.
+///
+/// # Errors
+///
+/// Returns [`PartitionedTTError::InvalidAdaptiveInterpolationInput`] for empty,
+/// duplicate, zero-dimensional, or inconsistently ordered site indices; invalid
+/// pivots; a zero pivot target; or invalid TCI tolerances/rank limits. It also
+/// forwards TCI2 and tensor-train construction failures.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::contract;
+/// use tensor4all_partitionedtt::{
+///     adaptiveinterpolate, AdaptiveInterpolateOptions, DynIndex, MultiIndex,
+/// };
+///
+/// let sites = vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+/// let f = |idx: &MultiIndex| ((idx[0] + 1) * (idx[1] + 1)) as f64;
+/// let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+///     f,
+///     None,
+///     sites,
+///     vec![vec![1, 1]],
+///     AdaptiveInterpolateOptions::default(),
+/// )
+/// .unwrap();
+///
+/// let tt = result.to_tensor_train().unwrap();
+/// let dense = contract(&[tt.tensor(0).unwrap(), tt.tensor(1).unwrap()]).unwrap();
+/// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 2.0, 4.0]);
+/// ```
+pub fn adaptiveinterpolate<T, F, B>(
+    f: F,
+    batched_f: Option<B>,
+    site_indices: Vec<DynIndex>,
+    initial_pivots: Vec<MultiIndex>,
+    options: AdaptiveInterpolateOptions,
+) -> Result<PartitionedTT>
+where
+    T: Scalar + TTScalar + MatrixLuciScalar + TensorElement + StorageScalar + Default + Copy,
+    F: Fn(&MultiIndex) -> T,
+    B: Fn(&[MultiIndex]) -> Vec<T>,
+{
+    let patch_order = validate_inputs(&site_indices, &initial_pivots, &options)?;
+    let mut rng = StdRng::seed_from_u64(options.tci_options.seed.unwrap_or(0));
+    let mut pending = VecDeque::from([PendingPatch {
+        projector: Projector::new(),
+        recycled_pivots: Vec::new(),
+    }]);
+    let mut accepted = Vec::new();
+
+    while let Some(patch) = pending.pop_front() {
+        let active_positions = active_positions(&site_indices, &patch.projector);
+
+        if active_positions.is_empty() {
+            let value = f(&expand_pivot(
+                &Vec::new(),
+                &active_positions,
+                &patch.projector,
+                &site_indices,
+            ));
+            let tt = rank_one_full_tt(&site_indices, &patch.projector, value)?;
+            accepted.push(SubDomainTT::new(tt, patch.projector));
+            continue;
+        }
+
+        if active_positions.len() == 1 {
+            let dim = site_indices[active_positions[0]].dim;
+            let data = (0..dim)
+                .map(|value| {
+                    f(&expand_pivot(
+                        &vec![value],
+                        &active_positions,
+                        &patch.projector,
+                        &site_indices,
+                    ))
+                })
+                .collect();
+            let core = tensor3_from_data(data, 1, dim, 1)
+                .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))?;
+            let exact = tensor4all_simplett::TensorTrain::new(vec![core])
+                .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))?;
+            let tt = embed_active_tt(exact, &site_indices, &active_positions, &patch.projector)?;
+            accepted.push(SubDomainTT::new(tt, patch.projector));
+            continue;
+        }
+
+        let candidate_pivots = patch_candidates(
+            &site_indices,
+            &active_positions,
+            &patch.projector,
+            &initial_pivots,
+            &patch.recycled_pivots,
+            options.n_initial_pivots,
+            &mut rng,
+        );
+        let candidate_values: Vec<T> = candidate_pivots
+            .iter()
+            .map(|pivot| {
+                f(&expand_pivot(
+                    pivot,
+                    &active_positions,
+                    &patch.projector,
+                    &site_indices,
+                ))
+            })
+            .collect();
+
+        if candidate_values
+            .iter()
+            .all(|value| Scalar::abs_val(*value) < ZERO_SAMPLE_THRESHOLD)
+        {
+            let tt = rank_one_full_tt(&site_indices, &patch.projector, T::zero())?;
+            accepted.push(SubDomainTT::new(tt, patch.projector));
+            continue;
+        }
+
+        let local_dims = active_positions
+            .iter()
+            .map(|&position| site_indices[position].dim)
+            .collect();
+        let local_f = |pivot: &MultiIndex| {
+            f(&expand_pivot(
+                pivot,
+                &active_positions,
+                &patch.projector,
+                &site_indices,
+            ))
+        };
+        let local_batch = batched_f.as_ref().map(|batch| {
+            |pivots: &[MultiIndex]| {
+                let full_pivots: Vec<_> = pivots
+                    .iter()
+                    .map(|pivot| {
+                        expand_pivot(pivot, &active_positions, &patch.projector, &site_indices)
+                    })
+                    .collect();
+                batch(&full_pivots)
+            }
+        });
+        let (tci, _ranks, errors) = crossinterpolate2(
+            local_f,
+            local_batch,
+            local_dims,
+            candidate_pivots,
+            options.tci_options.clone(),
+        )?;
+        let normalization = if options.tci_options.normalize_error && tci.max_sample_value() > 0.0 {
+            tci.max_sample_value()
+        } else {
+            1.0
+        };
+        let final_error = errors
+            .last()
+            .copied()
+            .unwrap_or_else(|| tci.max_bond_error() / normalization);
+
+        if final_error <= options.tci_options.tolerance {
+            let simple_tt = tci.to_tensor_train()?;
+            let tt = embed_active_tt(
+                simple_tt,
+                &site_indices,
+                &active_positions,
+                &patch.projector,
+            )?;
+            accepted.push(SubDomainTT::new(tt, patch.projector));
+            continue;
+        }
+
+        let split_index = patch_order
+            .iter()
+            .find(|index| !patch.projector.is_projected_at(index))
+            .ok_or_else(|| {
+                PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                    "a nonconverged patch has no remaining split index".to_string(),
+                )
+            })?
+            .clone();
+        let recycled_pivots = if options.recycle_pivots {
+            global_diagonal_pivots(&tci, &active_positions, &patch.projector, &site_indices)
+        } else {
+            Vec::new()
+        };
+        for value in 0..split_index.dim {
+            let mut child_projector = patch.projector.clone();
+            child_projector.insert(split_index.clone(), value);
+            pending.push_back(PendingPatch {
+                projector: child_projector,
+                recycled_pivots: recycled_pivots.clone(),
+            });
+        }
+    }
+
+    PartitionedTT::from_subdomains(accepted)
+}
+
+fn validate_inputs(
+    site_indices: &[DynIndex],
+    initial_pivots: &[MultiIndex],
+    options: &AdaptiveInterpolateOptions,
+) -> Result<Vec<DynIndex>> {
+    if site_indices.is_empty() {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "site_indices must not be empty".to_string(),
+        ));
+    }
+    if site_indices.iter().any(|index| index.dim == 0) {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "site indices must have positive dimensions".to_string(),
+        ));
+    }
+    let unique_sites: HashSet<_> = site_indices.iter().cloned().collect();
+    if unique_sites.len() != site_indices.len() {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "site_indices contains duplicate indices".to_string(),
+        ));
+    }
+    if options.n_initial_pivots == 0 {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "n_initial_pivots must be positive".to_string(),
+        ));
+    }
+    if !options.tci_options.tolerance.is_finite() || options.tci_options.tolerance < 0.0 {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "TCI tolerance must be finite and nonnegative".to_string(),
+        ));
+    }
+    if options.tci_options.max_iter == 0 {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "TCI max_iter must be positive".to_string(),
+        ));
+    }
+    if options.tci_options.max_bond_dim == 0 {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "TCI max_bond_dim must be positive".to_string(),
+        ));
+    }
+    if options.tci_options.ncheck_history == 0 {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "TCI ncheck_history must be positive".to_string(),
+        ));
+    }
+    if !options.tci_options.tol_margin_global_search.is_finite()
+        || options.tci_options.tol_margin_global_search < 0.0
+    {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "TCI tol_margin_global_search must be finite and nonnegative".to_string(),
+        ));
+    }
+    for pivot in initial_pivots {
+        if pivot.len() != site_indices.len() {
+            return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "every initial pivot must have one coordinate per site".to_string(),
+            ));
+        }
+        if pivot
+            .iter()
+            .zip(site_indices)
+            .any(|(&value, index)| value >= index.dim)
+        {
+            return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "an initial pivot coordinate is outside its site dimension".to_string(),
+            ));
+        }
+    }
+
+    let patch_order = if options.patch_order.is_empty() {
+        site_indices.to_vec()
+    } else {
+        options.patch_order.clone()
+    };
+    let unique_order: HashSet<_> = patch_order.iter().cloned().collect();
+    if patch_order.len() != site_indices.len()
+        || unique_order.len() != patch_order.len()
+        || unique_order != unique_sites
+    {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "patch_order must be an exact permutation of site_indices".to_string(),
+        ));
+    }
+    Ok(patch_order)
+}
+
+fn active_positions(site_indices: &[DynIndex], projector: &Projector) -> Vec<usize> {
+    site_indices
+        .iter()
+        .enumerate()
+        .filter_map(|(position, index)| (!projector.is_projected_at(index)).then_some(position))
+        .collect()
+}
+
+fn patch_candidates(
+    site_indices: &[DynIndex],
+    active_positions: &[usize],
+    projector: &Projector,
+    initial_pivots: &[MultiIndex],
+    recycled_pivots: &[MultiIndex],
+    target: usize,
+    rng: &mut StdRng,
+) -> Vec<MultiIndex> {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+    for full_pivot in initial_pivots.iter().chain(recycled_pivots) {
+        if is_compatible_pivot(full_pivot, site_indices, projector) {
+            let local = active_positions
+                .iter()
+                .map(|&position| full_pivot[position])
+                .collect::<Vec<_>>();
+            if seen.insert(local.clone()) {
+                candidates.push(local);
+            }
+        }
+    }
+
+    let local_dims: Vec<_> = active_positions
+        .iter()
+        .map(|&position| site_indices[position].dim)
+        .collect();
+    let point_count = local_dims
+        .iter()
+        .copied()
+        .fold(1usize, usize::saturating_mul);
+    let desired = target.max(candidates.len()).min(point_count);
+    let random_attempts = desired.saturating_mul(20).saturating_add(100);
+    for _ in 0..random_attempts {
+        if candidates.len() >= desired {
+            break;
+        }
+        let pivot: Vec<_> = local_dims
+            .iter()
+            .map(|&dim| rng.random_range(0..dim))
+            .collect();
+        if seen.insert(pivot.clone()) {
+            candidates.push(pivot);
+        }
+    }
+    for flat in 0..point_count {
+        if candidates.len() >= desired {
+            break;
+        }
+        let pivot = decode_col_major(flat, &local_dims);
+        if seen.insert(pivot.clone()) {
+            candidates.push(pivot);
+        }
+    }
+    candidates
+}
+
+fn is_compatible_pivot(
+    pivot: &MultiIndex,
+    site_indices: &[DynIndex],
+    projector: &Projector,
+) -> bool {
+    pivot.len() == site_indices.len()
+        && site_indices.iter().enumerate().all(|(position, index)| {
+            projector
+                .get(index)
+                .is_none_or(|value| pivot[position] == value)
+        })
+}
+
+fn decode_col_major(mut flat: usize, dims: &[usize]) -> MultiIndex {
+    dims.iter()
+        .map(|&dim| {
+            let value = flat % dim;
+            flat /= dim;
+            value
+        })
+        .collect()
+}
+
+fn expand_pivot(
+    local_pivot: &MultiIndex,
+    active_positions: &[usize],
+    projector: &Projector,
+    site_indices: &[DynIndex],
+) -> MultiIndex {
+    let mut full = vec![0; site_indices.len()];
+    for (&position, &value) in active_positions.iter().zip(local_pivot) {
+        full[position] = value;
+    }
+    for (position, index) in site_indices.iter().enumerate() {
+        if let Some(value) = projector.get(index) {
+            full[position] = value;
+        }
+    }
+    full
+}
+
+fn global_diagonal_pivots<T>(
+    tci: &TensorCI2<T>,
+    active_positions: &[usize],
+    projector: &Projector,
+    site_indices: &[DynIndex],
+) -> Vec<MultiIndex>
+where
+    T: Scalar + TTScalar + MatrixLuciScalar + Default,
+{
+    let mut result = Vec::new();
+    let mut seen = HashSet::new();
+    for bond in 0..active_positions.len() - 1 {
+        for (left, right) in tci.i_set(bond + 1).iter().zip(tci.j_set(bond)) {
+            let mut local = left.clone();
+            local.extend(right);
+            if local.len() == active_positions.len() {
+                let full = expand_pivot(&local, active_positions, projector, site_indices);
+                if seen.insert(full.clone()) {
+                    result.push(full);
+                }
+            }
+        }
+    }
+    result
+}
+
+fn embed_active_tt<T>(
+    active_tt: tensor4all_simplett::TensorTrain<T>,
+    site_indices: &[DynIndex],
+    active_positions: &[usize],
+    projector: &Projector,
+) -> Result<TensorTrain>
+where
+    T: Scalar + TTScalar + TensorElement + StorageScalar + Default + Copy,
+{
+    let active_count = active_positions.len();
+    let link_dims = active_tt.link_dims();
+    let cores = active_tt.into_site_tensors();
+    let mut edge_dims = Vec::with_capacity(site_indices.len().saturating_sub(1));
+    for edge in 0..site_indices.len().saturating_sub(1) {
+        let active_left = active_positions
+            .iter()
+            .filter(|&&position| position <= edge)
+            .count();
+        edge_dims.push(if active_left == 0 || active_left == active_count {
+            1
+        } else {
+            link_dims[active_left - 1]
+        });
+    }
+    let edge_indices: Vec<_> = edge_dims
+        .iter()
+        .map(|&dimension| DynIndex::new_dyn(dimension))
+        .collect();
+
+    let mut tensors = Vec::with_capacity(site_indices.len());
+    let mut next_active = 0;
+    for (position, site_index) in site_indices.iter().enumerate() {
+        let left = position.checked_sub(1).map(|edge| &edge_indices[edge]);
+        let right = edge_indices.get(position);
+        if active_positions.get(next_active) == Some(&position) {
+            let core = &cores[next_active];
+            let mut indices = Vec::with_capacity(3);
+            if let Some(index) = left {
+                indices.push(index.clone());
+            }
+            indices.push(site_index.clone());
+            if let Some(index) = right {
+                indices.push(index.clone());
+            }
+            tensors.push(
+                TensorDynLen::from_dense(indices, core.to_col_major_vec())
+                    .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))?,
+            );
+            next_active += 1;
+        } else {
+            let value = projector.get(site_index).ok_or_else(|| {
+                PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                    "an embedded inactive site is missing from its projector".to_string(),
+                )
+            })?;
+            tensors.push(projected_site_tensor::<T>(
+                left,
+                site_index,
+                right,
+                value,
+                T::one(),
+            )?);
+        }
+    }
+    TensorTrain::new(tensors)
+        .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
+}
+
+fn projected_site_tensor<T>(
+    left: Option<&DynIndex>,
+    site: &DynIndex,
+    right: Option<&DynIndex>,
+    value: usize,
+    scale: T,
+) -> Result<TensorDynLen>
+where
+    T: Scalar + TensorElement + StorageScalar + Default + Copy,
+{
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            if left.dim != right.dim {
+                return Err(PartitionedTTError::TensorTrainError(format!(
+                    "projected site cannot carry unequal bond dimensions {} and {}",
+                    left.dim, right.dim
+                )));
+            }
+            let bond_dim = left.dim;
+            let mut payload = vec![T::zero(); bond_dim * site.dim];
+            for bond in 0..bond_dim {
+                payload[bond + bond_dim * value] = scale;
+            }
+            let storage = Storage::new_structured(
+                payload,
+                vec![bond_dim, site.dim],
+                vec![1, bond_dim as isize],
+                vec![0, 1, 0],
+            )
+            .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))?;
+            TensorDynLen::from_structured_storage(
+                vec![left.clone(), site.clone(), right.clone()],
+                Arc::new(storage),
+            )
+            .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
+        }
+        (None, Some(right)) => {
+            if right.dim != 1 {
+                return Err(PartitionedTTError::TensorTrainError(format!(
+                    "projected first site requires a unit right bond, got {}",
+                    right.dim
+                )));
+            }
+            let mut data = vec![T::zero(); site.dim];
+            data[value] = scale;
+            TensorDynLen::from_dense(vec![site.clone(), right.clone()], data)
+                .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
+        }
+        (Some(left), None) => {
+            if left.dim != 1 {
+                return Err(PartitionedTTError::TensorTrainError(format!(
+                    "projected last site requires a unit left bond, got {}",
+                    left.dim
+                )));
+            }
+            let mut data = vec![T::zero(); site.dim];
+            data[value] = scale;
+            TensorDynLen::from_dense(vec![left.clone(), site.clone()], data)
+                .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
+        }
+        (None, None) => {
+            let mut data = vec![T::zero(); site.dim];
+            data[value] = scale;
+            TensorDynLen::from_dense(vec![site.clone()], data)
+                .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
+        }
+    }
+}
+
+fn rank_one_full_tt<T>(
+    site_indices: &[DynIndex],
+    projector: &Projector,
+    scale: T,
+) -> Result<TensorTrain>
+where
+    T: Scalar + TensorElement + StorageScalar + Default + Copy,
+{
+    let edge_indices: Vec<_> = (0..site_indices.len().saturating_sub(1))
+        .map(|_| DynIndex::new_dyn(1))
+        .collect();
+    let mut tensors = Vec::with_capacity(site_indices.len());
+    for (position, site) in site_indices.iter().enumerate() {
+        let left = position.checked_sub(1).map(|edge| &edge_indices[edge]);
+        let right = edge_indices.get(position);
+        let local_scale = if position == 0 { scale } else { T::one() };
+        if let Some(value) = projector.get(site) {
+            tensors.push(projected_site_tensor(
+                left,
+                site,
+                right,
+                value,
+                local_scale,
+            )?);
+        } else {
+            let mut indices = Vec::with_capacity(3);
+            if let Some(index) = left {
+                indices.push(index.clone());
+            }
+            indices.push(site.clone());
+            if let Some(index) = right {
+                indices.push(index.clone());
+            }
+            tensors.push(
+                TensorDynLen::from_dense(indices, vec![local_scale; site.dim])
+                    .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))?,
+            );
+        }
+    }
+    TensorTrain::new(tensors)
+        .map_err(|error| PartitionedTTError::TensorTrainError(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
@@ -16,6 +16,30 @@ fn binary_sites(nsites: usize) -> Vec<DynIndex> {
 }
 
 #[test]
+fn accepts_only_full_tci_convergence() {
+    assert!(patch_is_accepted(
+        TCI2Termination::Converged,
+        1.0e-10,
+        1.0e-8
+    ));
+    assert!(!patch_is_accepted(
+        TCI2Termination::MaxIterations,
+        1.0e-10,
+        1.0e-8,
+    ));
+    assert!(!patch_is_accepted(
+        TCI2Termination::MaxBondDimension,
+        1.0e-10,
+        1.0e-8,
+    ));
+    assert!(!patch_is_accepted(
+        TCI2Termination::Converged,
+        1.0e-6,
+        1.0e-8,
+    ));
+}
+
+#[test]
 fn interpolates_low_rank_function_without_splitting() {
     let sites = binary_sites(3);
     let function =
@@ -182,17 +206,18 @@ fn sampled_zero_patch_is_represented_as_zero() {
 #[test]
 fn extracts_full_diagonal_pivots_for_recycling() {
     let function = |index: &MultiIndex| (index[0] + 2 * index[1] + 3 * index[2] + 1) as f64;
-    let (tci, _, _) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
-        function,
-        None,
-        vec![2, 2, 2],
-        vec![vec![0, 0, 0], vec![1, 1, 1]],
-        TCI2Options {
-            seed: Some(3),
-            ..TCI2Options::default()
-        },
-    )
-    .unwrap();
+    let tensor4all_tensorci::TCI2OptimizationResult { tci, .. } =
+        crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            function,
+            None,
+            vec![2, 2, 2],
+            vec![vec![0, 0, 0], vec![1, 1, 1]],
+            TCI2Options {
+                seed: Some(3),
+                ..TCI2Options::default()
+            },
+        )
+        .unwrap();
     let sites = binary_sites(3);
 
     let pivots = global_diagonal_pivots(&tci, &[0, 1, 2], &Projector::new(), &sites);
@@ -211,7 +236,8 @@ fn incompatible_recycled_pivots_are_replenished_for_nonzero_child() {
     let recycled = vec![vec![0, 0, 0], vec![0, 1, 1]];
     let mut rng = StdRng::seed_from_u64(7);
 
-    let candidates = patch_candidates(&sites, &active, &projector, &[], &recycled, 3, &mut rng);
+    let candidates =
+        patch_candidates(&sites, &active, &projector, &[], &recycled, 3, &mut rng).unwrap();
     let values: Vec<_> = candidates
         .iter()
         .map(|local| {
@@ -245,6 +271,27 @@ fn projected_middle_sites_use_compact_structured_storage() {
     assert_eq!(middle.storage().storage_kind(), StorageKind::Structured);
     assert_eq!(middle.storage().payload_len(), 4);
     assert_eq!(middle.storage().axis_classes(), &[0, 1, 0]);
+
+    let tensors: Vec<_> = (0..tt.len())
+        .map(|position| tt.tensor(position).unwrap())
+        .collect();
+    let dense = contract(&tensors).unwrap().to_vec::<f64>().unwrap();
+    assert_eq!(dense, vec![0.0, 0.0, 23.0, 34.0, 0.0, 0.0, 31.0, 46.0]);
+}
+
+#[test]
+fn patch_candidate_count_overflow_is_rejected() {
+    let sites = vec![DynIndex::new_dyn(usize::MAX), DynIndex::new_dyn(2)];
+    let mut rng = StdRng::seed_from_u64(1);
+
+    let error =
+        patch_candidates(&sites, &[0, 1], &Projector::new(), &[], &[], 1, &mut rng).unwrap_err();
+
+    assert!(matches!(
+        error,
+        PartitionedTTError::InvalidAdaptiveInterpolationInput(message)
+            if message.contains("point count")
+    ));
 }
 
 #[test]
@@ -255,7 +302,7 @@ fn projected_site_tensor_rejects_unequal_carried_bonds() {
 
     let error = projected_site_tensor::<f64>(Some(&left), &site, Some(&right), 0, 1.0).unwrap_err();
 
-    assert!(error.to_string().contains("unequal bond dimensions"));
+    assert!(error.to_string().contains("bond dimensions differ"));
 }
 
 #[test]

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
@@ -1,0 +1,377 @@
+use super::*;
+use num_complex::Complex64;
+use std::cell::Cell;
+use std::rc::Rc;
+use tensor4all_core::contract;
+use tensor4all_tensorbackend::StorageKind;
+
+fn dense_f64(result: &PartitionedTT) -> Vec<f64> {
+    let tt = result.to_tensor_train().unwrap();
+    let tensors: Vec<_> = (0..tt.len()).map(|site| tt.tensor(site).unwrap()).collect();
+    contract(&tensors).unwrap().to_vec::<f64>().unwrap()
+}
+
+fn binary_sites(nsites: usize) -> Vec<DynIndex> {
+    (0..nsites).map(|_| DynIndex::new_dyn(2)).collect()
+}
+
+#[test]
+fn interpolates_low_rank_function_without_splitting() {
+    let sites = binary_sites(3);
+    let function =
+        |index: &MultiIndex| (index[0] + 1) as f64 * (index[1] + 2) as f64 * (index[2] + 3) as f64;
+    let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        function,
+        None,
+        sites,
+        vec![vec![1, 1, 1]],
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        dense_f64(&result),
+        vec![6.0, 12.0, 9.0, 18.0, 8.0, 16.0, 12.0, 24.0]
+    );
+}
+
+#[test]
+fn evaluates_single_active_site_exactly() {
+    let site = DynIndex::new_dyn(4);
+    let function = |index: &MultiIndex| {
+        if index[0] == 3 {
+            10.0
+        } else {
+            (index[0] * index[0] + 1) as f64
+        }
+    };
+    let options = AdaptiveInterpolateOptions {
+        n_initial_pivots: 1,
+        ..AdaptiveInterpolateOptions::default()
+    };
+    let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        function,
+        None,
+        vec![site],
+        Vec::new(),
+        options,
+    )
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(dense_f64(&result), vec![1.0, 2.0, 5.0, 10.0]);
+}
+
+#[test]
+fn rank_cap_forces_disjoint_exact_child_patches() {
+    let sites = binary_sites(3);
+    let function = |index: &MultiIndex| {
+        if index.iter().all(|value| *value == index[0]) {
+            2.0
+        } else {
+            0.5
+        }
+    };
+    let options = AdaptiveInterpolateOptions {
+        tci_options: TCI2Options {
+            tolerance: 1.0e-14,
+            max_bond_dim: 1,
+            max_iter: 4,
+            ncheck_history: 1,
+            nsearch: 0,
+            max_nglobal_pivot: 0,
+            ..TCI2Options::default()
+        },
+        patch_order: sites.clone(),
+        recycle_pivots: true,
+        ..AdaptiveInterpolateOptions::default()
+    };
+
+    let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        function,
+        None,
+        sites,
+        vec![vec![0, 0, 0], vec![1, 1, 1]],
+        options,
+    )
+    .unwrap();
+
+    assert!(result.len() >= 2);
+    assert!(Projector::are_disjoint(
+        &result.projectors().cloned().collect::<Vec<_>>()
+    ));
+    assert_eq!(
+        dense_f64(&result),
+        vec![2.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 2.0]
+    );
+}
+
+#[test]
+fn uses_batched_callback_on_tci_patches() {
+    let sites = binary_sites(2);
+    let batch_calls = Rc::new(Cell::new(0));
+    let batch_calls_for_callback = Rc::clone(&batch_calls);
+    let function = |index: &MultiIndex| (index[0] + index[1] + 1) as f64;
+    let batched = move |indices: &[MultiIndex]| {
+        batch_calls_for_callback.set(batch_calls_for_callback.get() + 1);
+        indices
+            .iter()
+            .map(|index| (index[0] + index[1] + 1) as f64)
+            .collect()
+    };
+    let result = adaptiveinterpolate(
+        function,
+        Some(batched),
+        sites,
+        vec![vec![1, 1]],
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap();
+
+    assert!(batch_calls.get() > 0);
+    assert_eq!(dense_f64(&result), vec![1.0, 2.0, 2.0, 3.0]);
+}
+
+#[test]
+fn supports_complex_values() {
+    let sites = binary_sites(2);
+    let function = |index: &MultiIndex| {
+        Complex64::new((index[0] + 1) as f64, index[1] as f64)
+            * Complex64::new((index[1] + 2) as f64, 0.0)
+    };
+    let result = adaptiveinterpolate::<Complex64, _, fn(&[MultiIndex]) -> Vec<Complex64>>(
+        function,
+        None,
+        sites,
+        vec![vec![1, 1]],
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap();
+    let tt = result.to_tensor_train().unwrap();
+    let tensors: Vec<_> = (0..tt.len()).map(|site| tt.tensor(site).unwrap()).collect();
+    let dense = contract(&tensors).unwrap().to_vec::<Complex64>().unwrap();
+
+    assert_eq!(
+        dense,
+        vec![
+            Complex64::new(2.0, 0.0),
+            Complex64::new(4.0, 0.0),
+            Complex64::new(3.0, 3.0),
+            Complex64::new(6.0, 3.0),
+        ]
+    );
+}
+
+#[test]
+fn sampled_zero_patch_is_represented_as_zero() {
+    let sites = binary_sites(2);
+    let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        |_| 0.0,
+        None,
+        sites,
+        Vec::new(),
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(dense_f64(&result), vec![0.0; 4]);
+}
+
+#[test]
+fn extracts_full_diagonal_pivots_for_recycling() {
+    let function = |index: &MultiIndex| (index[0] + 2 * index[1] + 3 * index[2] + 1) as f64;
+    let (tci, _, _) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        function,
+        None,
+        vec![2, 2, 2],
+        vec![vec![0, 0, 0], vec![1, 1, 1]],
+        TCI2Options {
+            seed: Some(3),
+            ..TCI2Options::default()
+        },
+    )
+    .unwrap();
+    let sites = binary_sites(3);
+
+    let pivots = global_diagonal_pivots(&tci, &[0, 1, 2], &Projector::new(), &sites);
+
+    assert!(!pivots.is_empty());
+    assert!(pivots
+        .iter()
+        .all(|pivot| pivot.len() == 3 && pivot.iter().all(|value| *value < 2)));
+}
+
+#[test]
+fn incompatible_recycled_pivots_are_replenished_for_nonzero_child() {
+    let sites = binary_sites(3);
+    let projector = Projector::from_pairs([(sites[0].clone(), 1)]);
+    let active = active_positions(&sites, &projector);
+    let recycled = vec![vec![0, 0, 0], vec![0, 1, 1]];
+    let mut rng = StdRng::seed_from_u64(7);
+
+    let candidates = patch_candidates(&sites, &active, &projector, &[], &recycled, 3, &mut rng);
+    let values: Vec<_> = candidates
+        .iter()
+        .map(|local| {
+            let full = expand_pivot(local, &active, &projector, &sites);
+            if full[0] == 1 {
+                1.0
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    assert_eq!(candidates.len(), 3);
+    assert!(values.iter().any(|value| *value != 0.0));
+}
+
+#[test]
+fn projected_middle_sites_use_compact_structured_storage() {
+    let sites = binary_sites(3);
+    let active = vec![0, 2];
+    let projector = Projector::from_pairs([(sites[1].clone(), 1)]);
+    let active_tt = tensor4all_simplett::TensorTrain::new(vec![
+        tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
+        tensor3_from_data(vec![5.0, 6.0, 7.0, 8.0], 2, 2, 1).unwrap(),
+    ])
+    .unwrap();
+
+    let tt = embed_active_tt(active_tt, &sites, &active, &projector).unwrap();
+    let middle = tt.tensor(1).unwrap();
+
+    assert_eq!(middle.storage().storage_kind(), StorageKind::Structured);
+    assert_eq!(middle.storage().payload_len(), 4);
+    assert_eq!(middle.storage().axis_classes(), &[0, 1, 0]);
+}
+
+#[test]
+fn projected_site_tensor_rejects_unequal_carried_bonds() {
+    let left = DynIndex::new_dyn(2);
+    let site = DynIndex::new_dyn(2);
+    let right = DynIndex::new_dyn(3);
+
+    let error = projected_site_tensor::<f64>(Some(&left), &site, Some(&right), 0, 1.0).unwrap_err();
+
+    assert!(error.to_string().contains("unequal bond dimensions"));
+}
+
+#[test]
+fn rejects_invalid_scalar_options_and_site_lists() {
+    let make_sites = || binary_sites(2);
+    let valid_pivots = vec![vec![0, 0]];
+
+    let mut cases = Vec::new();
+    cases.push((
+        make_sites(),
+        AdaptiveInterpolateOptions {
+            n_initial_pivots: 0,
+            ..AdaptiveInterpolateOptions::default()
+        },
+    ));
+    for tci_options in [
+        TCI2Options {
+            tolerance: -1.0,
+            ..TCI2Options::default()
+        },
+        TCI2Options {
+            max_iter: 0,
+            ..TCI2Options::default()
+        },
+        TCI2Options {
+            max_bond_dim: 0,
+            ..TCI2Options::default()
+        },
+        TCI2Options {
+            ncheck_history: 0,
+            ..TCI2Options::default()
+        },
+        TCI2Options {
+            tol_margin_global_search: f64::NAN,
+            ..TCI2Options::default()
+        },
+    ] {
+        cases.push((
+            make_sites(),
+            AdaptiveInterpolateOptions {
+                tci_options,
+                ..AdaptiveInterpolateOptions::default()
+            },
+        ));
+    }
+
+    for (sites, options) in cases {
+        let error = validate_inputs(&sites, &valid_pivots, &options).unwrap_err();
+        assert!(matches!(
+            error,
+            PartitionedTTError::InvalidAdaptiveInterpolationInput(_)
+        ));
+    }
+
+    let zero_dim_error = validate_inputs(
+        &[DynIndex::new_dyn(0)],
+        &[],
+        &AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        zero_dim_error,
+        PartitionedTTError::InvalidAdaptiveInterpolationInput(_)
+    ));
+
+    let duplicate = DynIndex::new_dyn(2);
+    let duplicate_error = validate_inputs(
+        &[duplicate.clone(), duplicate],
+        &valid_pivots,
+        &AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        duplicate_error,
+        PartitionedTTError::InvalidAdaptiveInterpolationInput(_)
+    ));
+    let empty_error =
+        validate_inputs(&[], &[], &AdaptiveInterpolateOptions::default()).unwrap_err();
+    assert!(matches!(
+        empty_error,
+        PartitionedTTError::InvalidAdaptiveInterpolationInput(_)
+    ));
+}
+
+#[test]
+fn rejects_invalid_patch_order_and_pivots() {
+    let sites = binary_sites(2);
+    let options = AdaptiveInterpolateOptions {
+        patch_order: vec![sites[0].clone(), DynIndex::new_dyn(2)],
+        ..AdaptiveInterpolateOptions::default()
+    };
+    let order_error = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        |_| 1.0,
+        None,
+        sites.clone(),
+        vec![vec![0, 0]],
+        options,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        order_error,
+        PartitionedTTError::InvalidAdaptiveInterpolationInput(_)
+    ));
+
+    for pivots in [vec![vec![0]], vec![vec![0, 2]]] {
+        let pivot_error = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            |_| 1.0,
+            None,
+            sites.clone(),
+            pivots,
+            AdaptiveInterpolateOptions::default(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            pivot_error,
+            PartitionedTTError::InvalidAdaptiveInterpolationInput(_)
+        ));
+    }
+}

--- a/crates/tensor4all-partitionedtt/src/error.rs
+++ b/crates/tensor4all-partitionedtt/src/error.rs
@@ -32,6 +32,14 @@ pub enum PartitionedTTError {
     #[error("Tensor train error: {0}")]
     TensorTrainError(String),
 
+    /// Error from tensor cross interpolation
+    #[error("Tensor cross interpolation error: {0}")]
+    TensorCrossInterpolation(#[from] tensor4all_tensorci::TCIError),
+
+    /// Invalid site-index or pivot input for adaptive interpolation
+    #[error("Invalid adaptive interpolation input: {0}")]
+    InvalidAdaptiveInterpolationInput(String),
+
     /// Feature not yet implemented
     #[error("Not implemented: {0}")]
     NotImplemented(String),

--- a/crates/tensor4all-partitionedtt/src/lib.rs
+++ b/crates/tensor4all-partitionedtt/src/lib.rs
@@ -9,6 +9,7 @@
 //! - [`SubDomainTT`]: A tensor train restricted to a specific subdomain
 //! - [`PartitionedTT`]: A collection of non-overlapping SubDomainTTs
 
+mod adaptive_interpolation;
 mod contract;
 mod error;
 mod partitioned_tt;
@@ -19,6 +20,7 @@ mod subdomain_tt;
 #[cfg(test)]
 mod test_utils;
 
+pub use adaptive_interpolation::{adaptiveinterpolate, AdaptiveInterpolateOptions};
 pub use contract::{contract, proj_contract};
 pub use error::{PartitionedTTError, Result};
 pub use partitioned_tt::PartitionedTT;
@@ -31,3 +33,5 @@ pub use subdomain_tt::SubDomainTT;
 // Re-export commonly used types from dependencies
 pub use tensor4all_core::{DynIndex, TensorDynLen};
 pub use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
+pub use tensor4all_tcicore::MultiIndex;
+pub use tensor4all_tensorci::TCI2Options;

--- a/crates/tensor4all-tcicore/benches/end_to_end_chain_tci.rs
+++ b/crates/tensor4all-tcicore/benches/end_to_end_chain_tci.rs
@@ -35,15 +35,16 @@ fn bench_chain_tci(c: &mut Criterion) {
         };
         group.bench_with_input(BenchmarkId::new("full", n_sites), &n_sites, |b, _| {
             b.iter(|| {
-                let (tci, ranks, errors) =
-                    crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
-                        chain_value,
-                        Some(chain_values),
-                        local_dims.clone(),
-                        initial_pivots.clone(),
-                        full_options.clone(),
-                    )
-                    .unwrap();
+                let tensor4all_tensorci::TCI2OptimizationResult {
+                    tci, ranks, errors, ..
+                } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+                    chain_value,
+                    Some(chain_values),
+                    local_dims.clone(),
+                    initial_pivots.clone(),
+                    full_options.clone(),
+                )
+                .unwrap();
                 black_box((
                     tci.rank(),
                     ranks.len(),
@@ -58,15 +59,16 @@ fn bench_chain_tci(c: &mut Criterion) {
         };
         group.bench_with_input(BenchmarkId::new("rook", n_sites), &n_sites, |b, _| {
             b.iter(|| {
-                let (tci, ranks, errors) =
-                    crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
-                        chain_value,
-                        Some(chain_values),
-                        local_dims.clone(),
-                        initial_pivots.clone(),
-                        rook_options.clone(),
-                    )
-                    .unwrap();
+                let tensor4all_tensorci::TCI2OptimizationResult {
+                    tci, ranks, errors, ..
+                } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+                    chain_value,
+                    Some(chain_values),
+                    local_dims.clone(),
+                    initial_pivots.clone(),
+                    rook_options.clone(),
+                )
+                .unwrap();
                 black_box((
                     tci.rank(),
                     ranks.len(),

--- a/crates/tensor4all-tensorci/README.md
+++ b/crates/tensor4all-tensorci/README.md
@@ -6,6 +6,7 @@ Tensor Cross Interpolation algorithms. TCI2 is the primary maintained implementa
 
 - `crossinterpolate2()` — main entry point for two-site TCI
 - `TCI2Options` — tolerance, pivot strategy, and convergence settings
+- `TCI2OptimizationResult` and `TCI2Termination` — sweep histories and explicit stop reason
 - `TensorCI2` — two-site TCI state; convert it to `TensorTrain` for repeated evaluation
 - `TensorCI2::from_tensor_train()` and `TensorCI2::from_index_sets()` — non-dense conversion constructors
 - `crossinterpolate1()` — legacy one-site TCI entry point
@@ -15,14 +16,14 @@ Tensor Cross Interpolation algorithms. TCI2 is the primary maintained implementa
 ## Example
 
 ```rust
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
 use tensor4all_simplett::AbstractTensorTrain;
 
 // Function to interpolate: f(i, j) = (i + j + 1) as f64
 let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
 
 // Run TCI on a 4x4 grid
-let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
     f,
     None,
     vec![4, 4],         // local dimensions
@@ -33,11 +34,11 @@ let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec
     },
 ).unwrap();
 
-// Verify convergence
-assert!(*errors.last().unwrap() < 1e-10);
+// Verify full convergence, including stable ranks and no recent global pivots
+assert_eq!(result.termination, TCI2Termination::Converged);
 
 // Verify interpolation accuracy
-let tt = tci.to_tensor_train().unwrap();
+let tt = result.tci.to_tensor_train().unwrap();
 let val = tt.evaluate(&[2, 3]).unwrap();  // f(2, 3) = 2 + 3 + 1 = 6.0
 assert!((val - 6.0).abs() < 1e-10);
 ```

--- a/crates/tensor4all-tensorci/src/conversion/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/conversion/tests/mod.rs
@@ -49,20 +49,24 @@ fn test_tensorci2_from_tensor_train_matches_complex_lorentz_full_grid() {
             + 1.0;
         coeff / Complex64::new(denom, 0.0)
     };
-    let (source, _ranks, _errors) =
-        crossinterpolate2::<Complex64, _, fn(&[MultiIndex]) -> Vec<Complex64>>(
-            f,
-            None,
-            vec![4; 4],
-            vec![vec![0; 4]],
-            TCI2Options {
-                tolerance: 1e-12,
-                max_iter: 20,
-                max_bond_dim: 5,
-                ..TCI2Options::default()
-            },
-        )
-        .unwrap();
+    let crate::TCI2OptimizationResult {
+        tci: source,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<Complex64, _, fn(&[MultiIndex]) -> Vec<Complex64>>(
+        f,
+        None,
+        vec![4; 4],
+        vec![vec![0; 4]],
+        TCI2Options {
+            tolerance: 1e-12,
+            max_iter: 20,
+            max_bond_dim: 5,
+            ..TCI2Options::default()
+        },
+    )
+    .unwrap();
     let source_tt = source.to_tensor_train().unwrap();
     let (expected_data, expected_shape) = source_tt.fulltensor();
     let converted = TensorCI2::from_tensor_train(
@@ -91,7 +95,12 @@ fn test_tensorci2_from_tensor_train_preserves_nontrivial_tensor() {
         let z = (idx[2] + 3) as f64;
         x * y + z
     };
-    let (source, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci: source,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         vec![3, 3, 3],

--- a/crates/tensor4all-tensorci/src/integration.rs
+++ b/crates/tensor4all-tensorci/src/integration.rs
@@ -580,7 +580,12 @@ where
 
     let local_dims = vec![n_nodes; ndims];
 
-    let (tci, _ranks, _errors) = crossinterpolate2::<T, _, fn(&[MultiIndex]) -> Vec<T>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<T, _, fn(&[MultiIndex]) -> Vec<T>>(
         wrapper,
         None,
         local_dims,

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -32,21 +32,20 @@
 //! let local_dims = vec![4, 4];
 //! let first_pivot = vec![vec![1, 1]];
 //!
-//! let (tci, _ranks, errors) =
-//!     crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
-//!         f,
-//!         None,
-//!         local_dims,
-//!         first_pivot,
-//!         TCI2Options::default(),
-//!     )
-//!     .unwrap();
+//! let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+//!     f,
+//!     None,
+//!     local_dims,
+//!     first_pivot,
+//!     TCI2Options::default(),
+//! )
+//! .unwrap();
 //!
 //! // Check convergence
-//! assert!(*errors.last().unwrap() < 1e-6);
+//! assert_eq!(result.termination, tensor4all_tensorci::TCI2Termination::Converged);
 //!
 //! // Evaluate through the tensor train
-//! let tt = tci.to_tensor_train().unwrap();
+//! let tt = result.tci.to_tensor_train().unwrap();
 //! let val = tt.evaluate(&[2, 3]).unwrap();
 //! assert!((val - 6.0).abs() < 1e-10); // f(2,3) = 2+3+1 = 6
 //! ```
@@ -81,6 +80,6 @@ pub use globalsearch::{estimate_true_error, floating_zone};
 pub use optfirstpivot::opt_first_pivot;
 pub use tensorci1::{crossinterpolate1, TCI1Options, TCI1SweepStrategy, TensorCI1};
 pub use tensorci2::{
-    crossinterpolate2, optimize_with_finder, PivotSearchStrategy, Sweep2Strategy, TCI2Options,
-    TensorCI2,
+    crossinterpolate2, optimize_with_finder, PivotSearchStrategy, Sweep2Strategy,
+    TCI2OptimizationResult, TCI2Options, TCI2Termination, TensorCI2,
 };

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -1521,12 +1521,13 @@ where
             );
         }
 
-        // Check convergence
+        // `errors` is already divided by `error_normalization`, so compare it
+        // with the configured relative tolerance rather than `abs_tol`.
         if convergence_criterion(
             &ranks,
             &errors,
             &nglobal_pivots_history,
-            abs_tol,
+            options.tolerance,
             options.max_bond_dim,
             options.ncheck_history,
         ) {

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -154,6 +154,81 @@ impl Default for TCI2Options {
     }
 }
 
+/// Reason why a TCI2 optimization stopped.
+///
+/// Only [`Self::Converged`] means that the complete history-based convergence
+/// criterion was satisfied. Reaching a configured limit is reported separately
+/// so adaptive callers can choose whether to accept or refine the result.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
+///
+/// let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+///     |_| 1.0,
+///     None,
+///     vec![2, 2],
+///     vec![vec![0, 0]],
+///     TCI2Options {
+///         ncheck_history: 1,
+///         nsearch: 0,
+///         max_nglobal_pivot: 0,
+///         ..TCI2Options::default()
+///     },
+/// ).unwrap();
+/// assert_eq!(result.termination, TCI2Termination::Converged);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TCI2Termination {
+    /// Bond error, global-pivot history, and rank stability all converged.
+    Converged,
+    /// The recent rank history reached the configured maximum bond dimension.
+    MaxBondDimension,
+    /// The iteration limit was exhausted before another stopping condition held.
+    MaxIterations,
+}
+
+/// Result of a complete TCI2 optimization.
+///
+/// This groups the optimized state with its sweep histories and termination
+/// reason. Use [`TCI2Termination`] rather than the last error alone when deciding
+/// whether the optimization converged.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_simplett::AbstractTensorTrain;
+/// use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
+///
+/// let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+///     |idx| ((idx[0] + 1) * (idx[1] + 1)) as f64,
+///     None,
+///     vec![2, 2],
+///     vec![vec![1, 1]],
+///     TCI2Options {
+///         ncheck_history: 1,
+///         nsearch: 0,
+///         max_nglobal_pivot: 0,
+///         ..TCI2Options::default()
+///     },
+/// ).unwrap();
+/// assert_eq!(result.termination, TCI2Termination::Converged);
+/// let tt = result.tci.to_tensor_train().unwrap();
+/// assert!((tt.evaluate(&[1, 0]).unwrap() - 2.0).abs() < 1.0e-12);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TCI2OptimizationResult<T: Scalar + TTScalar> {
+    /// Optimized interpolation state after the final one-site cleanup sweep.
+    pub tci: TensorCI2<T>,
+    /// Bond dimension recorded after each half-sweep.
+    pub ranks: Vec<usize>,
+    /// Normalized or absolute error estimate recorded after each half-sweep.
+    pub errors: Vec<f64>,
+    /// Reason why optimization stopped.
+    pub termination: TCI2Termination,
+}
+
 #[derive(Clone, Copy)]
 struct Sweep1SiteBondConfig {
     rel_tol: f64,
@@ -1182,9 +1257,9 @@ fn convergence_criterion(
     tolerance: f64,
     max_bond_dim: usize,
     ncheck_history: usize,
-) -> bool {
+) -> Option<TCI2Termination> {
     if errors.len() < ncheck_history {
-        return false;
+        return None;
     }
 
     let n = errors.len();
@@ -1198,7 +1273,13 @@ fn convergence_criterion(
         last_ranks.iter().min().copied().unwrap_or(0) == last_ranks.last().copied().unwrap_or(0);
     let at_max_bond = last_ranks.iter().all(|&r| r >= max_bond_dim);
 
-    (errors_converged && no_global_pivots && rank_stable) || at_max_bond
+    if at_max_bond {
+        Some(TCI2Termination::MaxBondDimension)
+    } else if errors_converged && no_global_pivots && rank_stable {
+        Some(TCI2Termination::Converged)
+    } else {
+        None
+    }
 }
 
 /// Approximate a function as a tensor train using the TCI2 algorithm.
@@ -1224,14 +1305,10 @@ fn convergence_criterion(
 ///
 /// # Returns
 ///
-/// A tuple `(tci, ranks, errors)`:
-///
-/// * `tci: TensorCI2<T>` -- The interpolation state. Call
-///   [`to_tensor_train`](TensorCI2::to_tensor_train) to get a
-///   [`TensorTrain`].
-/// * `ranks: Vec<usize>` -- Bond dimension after each half-sweep.
-/// * `errors: Vec<f64>` -- Normalized error estimate after each half-sweep.
-///   The last value should be below `tolerance` if the algorithm converged.
+/// A [`TCI2OptimizationResult`] containing the interpolation state, sweep
+/// histories, and the reason optimization stopped. Check
+/// [`TCI2OptimizationResult::termination`] rather than inferring convergence
+/// from the final error alone.
 ///
 /// # Errors
 ///
@@ -1251,30 +1328,29 @@ fn convergence_criterion(
 /// let local_dims = vec![4, 4];
 /// let initial_pivots = vec![vec![3, 3]]; // pick where |f| is large
 ///
-/// let (tci, _ranks, errors) =
-///     crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
-///         f,
-///         None,
-///         local_dims,
-///         initial_pivots,
-///         TCI2Options {
-///             tolerance: 1e-10,
-///             seed: Some(42),
-///             ..TCI2Options::default()
-///         },
-///     )
-///     .unwrap();
+/// let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+///     f,
+///     None,
+///     local_dims,
+///     initial_pivots,
+///     TCI2Options {
+///         tolerance: 1e-10,
+///         seed: Some(42),
+///         ..TCI2Options::default()
+///     },
+/// )
+/// .unwrap();
 ///
 /// // Verify convergence
-/// assert!(*errors.last().unwrap() < 1e-10);
+/// assert_eq!(result.termination, tensor4all_tensorci::TCI2Termination::Converged);
 ///
 /// // Evaluate through the tensor train
-/// let tt = tci.to_tensor_train().unwrap();
+/// let tt = result.tci.to_tensor_train().unwrap();
 /// let val = tt.evaluate(&[2, 3]).unwrap();
 /// assert!((val - 6.0).abs() < 1e-10); // f(2,3) = 2+3+1 = 6
 ///
 /// // Bond dimensions are available
-/// assert!(!tci.link_dims().is_empty());
+/// assert!(!tt.link_dims().is_empty());
 /// ```
 pub fn crossinterpolate2<T, F, B>(
     f: F,
@@ -1282,7 +1358,7 @@ pub fn crossinterpolate2<T, F, B>(
     local_dims: Vec<usize>,
     initial_pivots: Vec<MultiIndex>,
     options: TCI2Options,
-) -> Result<(TensorCI2<T>, Vec<usize>, Vec<f64>)>
+) -> Result<TCI2OptimizationResult<T>>
 where
     T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&MultiIndex) -> T,
@@ -1345,8 +1421,8 @@ where
 ///
 /// # Returns
 ///
-/// Returns `(tci, ranks, errors)`, matching [`crossinterpolate2`]. `ranks` and
-/// `errors` contain one entry per half-sweep.
+/// Returns a [`TCI2OptimizationResult`], matching [`crossinterpolate2`]. Its
+/// rank and error histories contain one entry per half-sweep.
 ///
 /// # Errors
 ///
@@ -1367,23 +1443,22 @@ where
 /// tci.add_global_pivots(&[vec![3, 3]]).unwrap();
 ///
 /// let finder = DefaultGlobalPivotFinder::new(0, 0, 10.0);
-/// let (tci, ranks, errors) =
-///     optimize_with_finder::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>, _>(
-///         tci,
-///         f,
-///         None,
-///         TCI2Options {
-///             tolerance: 1e-10,
-///             max_iter: 5,
-///             ..TCI2Options::default()
-///         },
-///         finder,
-///     )
-///     .unwrap();
+/// let result = optimize_with_finder::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>, _>(
+///     tci,
+///     f,
+///     None,
+///     TCI2Options {
+///         tolerance: 1e-10,
+///         max_iter: 5,
+///         ..TCI2Options::default()
+///     },
+///     finder,
+/// )
+/// .unwrap();
 ///
-/// assert!(!ranks.is_empty());
-/// assert!(!errors.is_empty());
-/// let tt = tci.to_tensor_train().unwrap();
+/// assert!(!result.ranks.is_empty());
+/// assert!(!result.errors.is_empty());
+/// let tt = result.tci.to_tensor_train().unwrap();
 /// assert!((tt.evaluate(&[2, 3]).unwrap() - 6.0).abs() < 1e-10);
 /// ```
 pub fn optimize_with_finder<T, F, B, G>(
@@ -1392,7 +1467,7 @@ pub fn optimize_with_finder<T, F, B, G>(
     batched_f: Option<B>,
     options: TCI2Options,
     finder: G,
-) -> Result<(TensorCI2<T>, Vec<usize>, Vec<f64>)>
+) -> Result<TCI2OptimizationResult<T>>
 where
     T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&MultiIndex) -> T,
@@ -1410,6 +1485,7 @@ where
     let mut errors = Vec::new();
     let mut ranks = Vec::new();
     let mut nglobal_pivots_history: Vec<usize> = Vec::new();
+    let mut termination = TCI2Termination::MaxIterations;
 
     let mut rng = if let Some(seed) = options.seed {
         rand::rngs::StdRng::seed_from_u64(seed)
@@ -1523,7 +1599,7 @@ where
 
         // `errors` is already divided by `error_normalization`, so compare it
         // with the configured relative tolerance rather than `abs_tol`.
-        if convergence_criterion(
+        if let Some(reason) = convergence_criterion(
             &ranks,
             &errors,
             &nglobal_pivots_history,
@@ -1531,6 +1607,7 @@ where
             options.max_bond_dim,
             options.ncheck_history,
         ) {
+            termination = reason;
             break;
         }
     }
@@ -1546,7 +1623,12 @@ where
     let abs_tol = options.tolerance * error_normalization;
     tci.sweep1site(&f, true, 1e-14, abs_tol, options.max_bond_dim, true)?;
 
-    Ok((tci, ranks, errors))
+    Ok(TCI2OptimizationResult {
+        tci,
+        ranks,
+        errors,
+        termination,
+    })
 }
 
 /// Update pivots at bond b using LU-based cross interpolation

--- a/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
@@ -816,6 +816,17 @@ fn test_convergence_criterion() {
         3
     ));
 
+    // Normalized errors are compared with the configured relative tolerance,
+    // not with an absolute tolerance rescaled by a large function magnitude.
+    assert!(!super::convergence_criterion(
+        &[5, 5, 5],
+        &[1e-6, 1e-6, 1e-6],
+        &[0, 0, 0],
+        1e-8,
+        100,
+        3
+    ));
+
     // Not converged: global pivots still being added
     assert!(!super::convergence_criterion(
         &[5, 5, 5],

--- a/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
@@ -17,7 +17,12 @@ fn test_sweep1site_preserves_accuracy() {
         ..Default::default()
     };
 
-    let (mut tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        mut tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -63,12 +68,12 @@ fn test_make_canonical() {
         ..Default::default()
     };
 
-    let (mut tci, _, _) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
-        f,
-        None,
-        local_dims,
-        first_pivot,
-        options,
+    let crate::TCI2OptimizationResult { mut tci, .. } = crossinterpolate2::<
+        f64,
+        _,
+        fn(&[MultiIndex]) -> Vec<f64>,
+    >(
+        f, None, local_dims, first_pivot, options
     )
     .unwrap();
 
@@ -110,12 +115,12 @@ fn test_fill_site_tensors() {
         ..Default::default()
     };
 
-    let (mut tci, _, _) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
-        f,
-        None,
-        local_dims,
-        first_pivot,
-        options,
+    let crate::TCI2OptimizationResult { mut tci, .. } = crossinterpolate2::<
+        f64,
+        _,
+        fn(&[MultiIndex]) -> Vec<f64>,
+    >(
+        f, None, local_dims, first_pivot, options
     )
     .unwrap();
 
@@ -151,7 +156,12 @@ fn test_crossinterpolate2_constant() {
     let first_pivot = vec![vec![0, 0]];
     let options = TCI2Options::default();
 
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -162,6 +172,37 @@ fn test_crossinterpolate2_constant() {
 
     assert_eq!(tci.len(), 2);
     assert!(tci.rank() >= 1);
+}
+
+#[test]
+fn test_crossinterpolate2_reports_convergence_and_rank_cap_separately() {
+    let options = |max_bond_dim| TCI2Options {
+        max_bond_dim,
+        ncheck_history: 1,
+        nsearch: 0,
+        max_nglobal_pivot: 0,
+        ..TCI2Options::default()
+    };
+
+    let converged = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        |_| 1.0,
+        None,
+        vec![2, 2],
+        vec![vec![0, 0]],
+        options(usize::MAX),
+    )
+    .unwrap();
+    assert_eq!(converged.termination, TCI2Termination::Converged);
+
+    let capped = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        |_| 1.0,
+        None,
+        vec![2, 2],
+        vec![vec![0, 0]],
+        options(1),
+    )
+    .unwrap();
+    assert_eq!(capped.termination, TCI2Termination::MaxBondDimension);
 }
 
 #[test]
@@ -179,8 +220,12 @@ fn test_crossinterpolate2_with_batch_function() {
     let first_pivot = vec![vec![1, 1]];
     let options = TCI2Options::default();
 
-    let (tci, _ranks, _errors) =
-        crossinterpolate2(f, Some(batched_f), local_dims, first_pivot, options).unwrap();
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2(f, Some(batched_f), local_dims, first_pivot, options).unwrap();
 
     assert_eq!(tci.len(), 2);
 }
@@ -197,7 +242,12 @@ fn test_crossinterpolate2_rank2_function() {
         ..Default::default()
     };
 
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -237,7 +287,12 @@ fn test_crossinterpolate2_rank2_function_rook_search() {
         ..Default::default()
     };
 
-    let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -266,7 +321,12 @@ fn test_crossinterpolate2_pivot_errors_match_diagonal_values() {
             0.0
         }
     };
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         vec![3, 3],
@@ -311,8 +371,12 @@ fn test_crossinterpolate2_rook_search_uses_partial_batch_requests() {
         ..Default::default()
     };
 
-    let (_tci, _ranks, _errors) =
-        crossinterpolate2(f, Some(batched_f), local_dims, first_pivot, options).unwrap();
+    let crate::TCI2OptimizationResult {
+        tci: _tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2(f, Some(batched_f), local_dims, first_pivot, options).unwrap();
 
     assert!(
         max_batch.get() < 64,
@@ -381,7 +445,7 @@ fn test_crossinterpolate2_3sites_constant() {
         "crossinterpolate2 failed: {:?}",
         result.err()
     );
-    let (tci, _ranks, _errors) = result.unwrap();
+    let crate::TCI2OptimizationResult { tci, .. } = result.unwrap();
 
     assert_eq!(tci.len(), 3);
     assert!(tci.rank() >= 1);
@@ -432,7 +496,7 @@ fn test_crossinterpolate2_4sites_product() {
         "crossinterpolate2 failed: {:?}",
         result.err()
     );
-    let (tci, _ranks, _errors) = result.unwrap();
+    let crate::TCI2OptimizationResult { tci, .. } = result.unwrap();
 
     assert_eq!(tci.len(), 4);
 
@@ -476,7 +540,7 @@ fn test_crossinterpolate2_5sites_constant() {
         "crossinterpolate2 failed: {:?}",
         result.err()
     );
-    let (tci, _ranks, _errors) = result.unwrap();
+    let crate::TCI2OptimizationResult { tci, .. } = result.unwrap();
 
     assert_eq!(tci.len(), 5);
 
@@ -552,7 +616,12 @@ fn test_crossinterpolate2_rank2_full_grid_reconstruction() {
         ..Default::default()
     };
 
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -598,7 +667,12 @@ fn test_crossinterpolate2_non_strictly_nested() {
         pivot_search: PivotSearchStrategy::Full,
         ..Default::default()
     };
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims.clone(),
@@ -622,7 +696,12 @@ fn test_crossinterpolate2_non_strictly_nested() {
         pivot_search: PivotSearchStrategy::Full,
         ..Default::default()
     };
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims.clone(),
@@ -646,7 +725,12 @@ fn test_crossinterpolate2_non_strictly_nested() {
         pivot_search: PivotSearchStrategy::Rook,
         ..Default::default()
     };
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims.clone(),
@@ -670,7 +754,12 @@ fn test_crossinterpolate2_non_strictly_nested() {
         pivot_search: PivotSearchStrategy::Rook,
         ..Default::default()
     };
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -705,7 +794,12 @@ fn test_crossinterpolate2_lorentz_f64() {
         ..Default::default()
     };
 
-    let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims.clone(),
@@ -763,11 +857,18 @@ fn test_crossinterpolate2_lorentz_c64() {
         ..Default::default()
     };
 
-    let (tci, _ranks, errors) = crossinterpolate2::<
-        Complex64,
-        _,
-        fn(&[MultiIndex]) -> Vec<Complex64>,
-    >(f, None, local_dims, first_pivot, options)
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors,
+        ..
+    } = crossinterpolate2::<Complex64, _, fn(&[MultiIndex]) -> Vec<Complex64>>(
+        f,
+        None,
+        local_dims,
+        first_pivot,
+        options,
+    )
     .unwrap();
 
     let final_error = *errors.last().unwrap();
@@ -797,65 +898,41 @@ fn test_crossinterpolate2_lorentz_c64() {
 #[test]
 fn test_convergence_criterion() {
     // Not converged: too few history points
-    assert!(!super::convergence_criterion(
-        &[2],
-        &[1e-10],
-        &[0],
-        1e-8,
-        100,
-        3
-    ));
+    assert_eq!(
+        super::convergence_criterion(&[2], &[1e-10], &[0], 1e-8, 100, 3),
+        None
+    );
 
     // Converged: 3 iterations with low error, no global pivots, stable rank
-    assert!(super::convergence_criterion(
-        &[5, 5, 5],
-        &[1e-10, 1e-10, 1e-10],
-        &[0, 0, 0],
-        1e-8,
-        100,
-        3
-    ));
+    assert_eq!(
+        super::convergence_criterion(&[5, 5, 5], &[1e-10, 1e-10, 1e-10], &[0, 0, 0], 1e-8, 100, 3,),
+        Some(TCI2Termination::Converged)
+    );
 
     // Normalized errors are compared with the configured relative tolerance,
     // not with an absolute tolerance rescaled by a large function magnitude.
-    assert!(!super::convergence_criterion(
-        &[5, 5, 5],
-        &[1e-6, 1e-6, 1e-6],
-        &[0, 0, 0],
-        1e-8,
-        100,
-        3
-    ));
+    assert_eq!(
+        super::convergence_criterion(&[5, 5, 5], &[1e-6, 1e-6, 1e-6], &[0, 0, 0], 1e-8, 100, 3,),
+        None
+    );
 
     // Not converged: global pivots still being added
-    assert!(!super::convergence_criterion(
-        &[5, 5, 5],
-        &[1e-10, 1e-10, 1e-10],
-        &[0, 1, 0],
-        1e-8,
-        100,
-        3
-    ));
+    assert_eq!(
+        super::convergence_criterion(&[5, 5, 5], &[1e-10, 1e-10, 1e-10], &[0, 1, 0], 1e-8, 100, 3,),
+        None
+    );
 
-    // Converged: at max bond dim
-    assert!(super::convergence_criterion(
-        &[100, 100, 100],
-        &[0.1, 0.1, 0.1],
-        &[5, 5, 5],
-        1e-8,
-        100,
-        3
-    ));
+    // Reaching the rank cap is a limit, not convergence.
+    assert_eq!(
+        super::convergence_criterion(&[100, 100, 100], &[0.1, 0.1, 0.1], &[5, 5, 5], 1e-8, 100, 3,),
+        Some(TCI2Termination::MaxBondDimension)
+    );
 
     // Not converged: rank still growing
-    assert!(!super::convergence_criterion(
-        &[3, 4, 5],
-        &[1e-10, 1e-10, 1e-10],
-        &[0, 0, 0],
-        1e-8,
-        100,
-        3
-    ));
+    assert_eq!(
+        super::convergence_criterion(&[3, 4, 5], &[1e-10, 1e-10, 1e-10], &[0, 0, 0], 1e-8, 100, 3,),
+        None
+    );
 }
 
 /// Port of Julia test: global search with oscillatory function
@@ -887,7 +964,12 @@ fn test_global_search_oscillatory() {
         ..Default::default()
     };
 
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims,
@@ -991,7 +1073,12 @@ fn test_custom_global_pivot_finder() {
         ..Default::default()
     };
 
-    let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks: _ranks,
+        errors: _errors,
+        ..
+    } = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         f,
         None,
         local_dims.clone(),
@@ -1076,17 +1163,27 @@ fn test_optimize_with_finder_invokes_custom_finder() {
     let finder = CountingFinder {
         calls: Rc::clone(&calls),
     };
-    let (tci, ranks, errors) = optimize_with_finder::<f64, _, fn(&[MultiIndex]) -> Vec<f64>, _>(
+    let crate::TCI2OptimizationResult {
+        tci,
+        ranks,
+        errors,
+        termination,
+    } = optimize_with_finder::<f64, _, fn(&[MultiIndex]) -> Vec<f64>, _>(
         tci,
         f,
         None,
-        TCI2Options::default(),
+        TCI2Options {
+            max_iter: 3,
+            ncheck_history: 1,
+            ..TCI2Options::default()
+        },
         finder,
     )
     .unwrap();
 
-    assert!(!ranks.is_empty());
-    assert!(!errors.is_empty());
+    assert_eq!(ranks.len(), 3);
+    assert_eq!(errors.len(), 3);
     assert!(tci.rank() >= 1);
-    assert!(calls.get() > 0);
+    assert_eq!(calls.get(), 3);
+    assert_eq!(termination, TCI2Termination::MaxIterations);
 }

--- a/docs/PROVENANCE_AND_CITATION_POLICY.md
+++ b/docs/PROVENANCE_AND_CITATION_POLICY.md
@@ -71,6 +71,7 @@ relationship; the role is stated only on the first row.
 | `tensor4all-quanticstransform` | Quantics operators (shift, flip, QFT, affine) | [Quantics.jl](https://github.com/tensor4all/Quantics.jl) | Port (validated against v0.4.7) |
 | `tensor4all-aci` | Alternating cross interpolation elementwise ops | [AlternatingCrossInterpolation.jl](https://github.com/tensor4all/AlternatingCrossInterpolation.jl) | Port |
 | `tensor4all-partitionedtt` | Partitioned TT over subdomains | [PartitionedMPSs.jl](https://github.com/tensor4all/PartitionedMPSs.jl) | Port |
+| `tensor4all-partitionedtt` | | [TCIAlgorithms.jl](https://github.com/tensor4all/TCIAlgorithms.jl) | Derived (MIT): adaptive TCI interpolation |
 | `tensor4all-hdf5` | HDF5 serialization | [ITensors.jl](https://github.com/ITensor/ITensors.jl) / ITensorMPS.jl file formats | Compatible (round-trip validated) |
 | `tensor4all-capi` | C FFI surface for language bindings | — | Original (consumed by [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl)) |
 
@@ -96,4 +97,5 @@ list is best-effort; corrections and additions are welcome.
 | Partitioned tensor trains / adaptive patching | `partitionedtt` | G. Grosso, M. K. Ritter, S. Rohshap, S. Badr, A. Kauch, M. Wallerberger, J. von Delft, H. Shinaoka, "Adaptive Patching for Tensor Train Computations", [arXiv:2602.22372](https://arxiv.org/abs/2602.22372) |
 
 License-bearing derivations are declared in the affected crate
-(`tensor4all-treetn`: `LICENSE-APACHE`, SPDX `MIT AND Apache-2.0`).
+(`tensor4all-treetn`: `LICENSE-APACHE`, SPDX `MIT AND Apache-2.0`;
+`tensor4all-partitionedtt`: `LICENSE-TCIALGORITHMS-MIT`, crate remains MIT).

--- a/docs/book/src/guides/compress.md
+++ b/docs/book/src/guides/compress.md
@@ -21,7 +21,7 @@ or `1e-6`.
 # fn main() -> anyhow::Result<()> {
 use std::f64::consts::PI;
 use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops};
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
 
 let local_dims = vec![128, 128, 128];
 let f = |idx: &Vec<usize>| {
@@ -31,7 +31,7 @@ let f = |idx: &Vec<usize>| {
     x.cos() + y.cos() + z.cos()
 };
 
-let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
     f,
     None,
     local_dims.clone(),
@@ -43,9 +43,9 @@ let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec
     },
 )?;
 
-assert!(*errors.last().unwrap() < 1e-10);
+assert_eq!(result.termination, TCI2Termination::Converged);
 
-let tt = tci.to_tensor_train()?;
+let tt = result.tci.to_tensor_train()?;
 for point in [
     vec![0, 0, 0],
     vec![1, 2, 3],
@@ -79,7 +79,7 @@ The quality of the compression is visible in the bond dimensions and the paramet
 #     let z = 2.0 * PI * idx[2] as f64 / 128.0;
 #     x.cos() + y.cos() + z.cos()
 # };
-# let (tci, _, _) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+# let tensor4all_tensorci::TCI2OptimizationResult { tci, .. } = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
 #     f, None, local_dims.clone(), vec![vec![0, 0, 0]],
 #     TCI2Options { tolerance: 1e-12, max_bond_dim: 64, ..Default::default() },
 # )?;

--- a/docs/book/src/guides/tci-advanced.md
+++ b/docs/book/src/guides/tci-advanced.md
@@ -8,7 +8,7 @@ This path bypasses the high-level quantics wrapper and works directly with quant
 
 ```rust
 use tensor4all_simplett::AbstractTensorTrain;
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
 
 let r = 8;
 let local_dims = vec![2; r];
@@ -22,7 +22,7 @@ let f = move |idx: &Vec<usize>| {
 };
 
 let initial_pivots = vec![vec![0; r]];
-let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
     f,
     None,
     local_dims.clone(),
@@ -34,9 +34,9 @@ let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec
     },
 ).unwrap();
 
-assert!(*errors.last().unwrap() < 1e-10);
+assert_eq!(result.termination, TCI2Termination::Converged);
 
-let tt = tci.to_tensor_train().unwrap();
+let tt = result.tci.to_tensor_train().unwrap();
 for bits in [
     vec![0, 0, 0, 0, 0, 0, 0, 0],
     vec![1, 0, 0, 0, 0, 0, 0, 0],
@@ -119,7 +119,7 @@ let cf = CachedFunction::new(
 ).unwrap();
 
 let cached_f = |idx: &Vec<usize>| cf.eval(idx);
-let (tci_cached, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+let tensor4all_tensorci::TCI2OptimizationResult { tci: tci_cached, ranks: _ranks, errors: _errors, .. } = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
     cached_f,
     None,
     local_dims.clone(),
@@ -165,7 +165,7 @@ For a uniform half-open grid on `[x_min, x_max)`, the quantics tensor train sum 
 #     let x = q as f64 * step;
 #     (-3.0 * x).exp()
 # };
-# let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+# let tensor4all_tensorci::TCI2OptimizationResult { tci, ranks: _ranks, errors: _errors, .. } = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
 #     f, None, local_dims, vec![vec![0; r]],
 #     TCI2Options { tolerance: 1e-12, seed: Some(42), ..Default::default() },
 # ).unwrap();

--- a/docs/book/src/guides/tci.md
+++ b/docs/book/src/guides/tci.md
@@ -15,13 +15,13 @@ The function must accept a `&Vec<usize>` of 0-indexed multi-indices and return a
 
 ```rust
 use tensor4all_simplett::AbstractTensorTrain;
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
 
 let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
 let local_dims = vec![4, 4];
 let initial_pivots = vec![vec![3, 3]]; // pick where |f| is large
 
-let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
     f,
     None,
     local_dims,
@@ -33,9 +33,9 @@ let (tci, _ranks, errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec
     },
 ).unwrap();
 
-assert!(*errors.last().unwrap() < 1e-10);
+assert_eq!(result.termination, TCI2Termination::Converged);
 
-let tt = tci.to_tensor_train().unwrap();
+let tt = result.tci.to_tensor_train().unwrap();
 let value = tt.evaluate(&[2, 3]).unwrap();
 assert!((value - 6.0).abs() < 1e-10);
 assert!(tt.rank() >= 1);
@@ -55,13 +55,17 @@ The most important parameters:
 
 ### Interpreting the results
 
-`crossinterpolate2` returns a triple:
+`crossinterpolate2` returns a `TCI2OptimizationResult`:
 
-| Value | Type | Description |
+| Field | Type | Description |
 |-------|------|-------------|
 | `tci` | `TensorCI2<T>` | Completed TCI object; call `.to_tensor_train()` to get a `TensorTrain`. |
 | `ranks` | `Vec<usize>` | Bond dimensions after each sweep. |
-| `errors` | `Vec<f64>` | Error estimate after each sweep; convergence when the last value is below tolerance. |
+| `errors` | `Vec<f64>` | Error estimate after each sweep. |
+| `termination` | `TCI2Termination` | Whether the full criterion converged, the rank cap was reached, or iterations were exhausted. |
+
+Do not infer convergence from `errors.last()` alone. Full convergence also
+requires no recent global pivots and a stable rank history.
 
 ### Convergence diagnostics
 
@@ -82,7 +86,7 @@ Convert to a tensor train for further manipulation:
 # use tensor4all_simplett::AbstractTensorTrain;
 # use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
 # let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
-# let (tci, _ranks, _errors) = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+# let tensor4all_tensorci::TCI2OptimizationResult { tci, ranks: _ranks, errors: _errors, .. } = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
 #     f, None, vec![4, 4], vec![vec![3, 3]],
 #     TCI2Options { seed: Some(42), ..Default::default() },
 # ).unwrap();

--- a/docs/design/adaptive-tci-interpolation.md
+++ b/docs/design/adaptive-tci-interpolation.md
@@ -1,0 +1,94 @@
+# Adaptive TCI interpolation
+
+## Scope
+
+`tensor4all-partitionedtt::adaptiveinterpolate` approximates a discrete function
+with a collection of mutually disjoint tensor-train patches. It is intended for
+functions that are low-rank only after restricting selected site indices.
+
+The queue and split flow follow the `adaptiveinterpolate`, `createpatch`, and
+`_globalpivots` design in TCIAlgorithms.jl. The Rust implementation remains
+sequential so callback thread-safety is not part of the API contract.
+
+## Patch model
+
+A patch consists of a `Projector` and optional full-domain recycled pivots. The
+projector fixes zero-based coordinates at selected site indices. All other sites
+are active and are passed to TCI2 in their original order.
+
+The algorithm processes a FIFO queue:
+
+1. Evaluate patches with zero or one active site exactly.
+2. For larger patches, filter user and recycled pivots for compatibility,
+   deduplicate them, and replenish the candidate set with a seeded generator.
+3. Run TCI2 on the active sites.
+4. Accept only a patch for which TCI2 reports `TCI2Termination::Converged` and
+   whose accepted error satisfies the requested tolerance.
+5. Otherwise fix the next active index in `patch_order` and enqueue one child
+   for each coordinate of that index.
+
+Reaching `max_bond_dim` or exhausting `max_iter` is a stopping condition for
+TCI2, not proof that an adaptive patch converged. Such a patch is split.
+
+The patch order must be an exact permutation of the site indices. Index
+identity includes the ID, dimension, tags, and prime level; matching by ID alone
+is not sufficient.
+
+## Pivot policy
+
+Initial pivots and recycled pivots use full-domain coordinates. Each patch keeps
+only compatible pivots and converts them to active-site coordinates.
+
+Pivot recycling is opt-in. When enabled, diagonal TCI pivots from a rejected
+parent seed its children. A child that receives no compatible recycled pivot is
+not classified as zero: seeded candidates replenish it to
+`n_initial_pivots`, bounded by the number of points in the patch.
+
+The product of active dimensions and the random-attempt count use checked
+arithmetic. An unrepresentable count is rejected before enumeration or
+allocation.
+
+## Sampled-zero policy
+
+A patch may be represented as zero when every supplied and seeded candidate is
+sampled as zero. This is a finite-sampling policy, not a mathematical proof.
+Sparse functions should supply pivots in known nonzero regions. The numerical
+zero predicate must not silently discard nonzero functions merely because their
+scale is small.
+
+## Embedding active tensor trains
+
+An accepted active-site TT is embedded back into the full site order. Fixed
+boundary sites have unit carried bonds. A fixed middle site carries equal left
+and right bonds with a compact copy-selector tensor:
+
+```text
+scale * delta(left, right) * delta(site, selected_value)
+```
+
+The owning `tensor4all-core` constructor uses structured axis classes
+`[0, 1, 0]`. Its payload contains `bond_dim * site_dim` elements rather than a
+dense `bond_dim * site_dim * bond_dim` buffer. Bond products, payload sizes, and
+stride conversions are checked before allocation.
+
+Tests of this path must verify both compact representation and dense numerical
+behavior.
+
+## Callback contract
+
+The scalar callback receives one full zero-based multi-index. The optional batch
+callback receives full multi-indices and must return one value per input in the
+same order. Both callbacks describe the same deterministic function; batching
+may change evaluation strategy but not values.
+
+## Output and complexity
+
+Accepted projectors are mutually disjoint and cover the original domain because
+every rejected patch is replaced by all children of one complete coordinate
+split. `PartitionedTT::from_subdomains` validates disjointness at construction.
+
+Patch execution is sequential and deterministic for a fixed seed and
+deterministic callbacks. The number of patches can grow with the subdivision
+tree; callers should choose rank limits and patch order with that tradeoff in
+mind. A general improvement to the quadratic final disjointness validation is
+outside this design change and must preserve validation rather than bypass it.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -12,6 +12,7 @@
 
 | Document | Description |
 |----------|-------------|
+| [adaptive-tci-interpolation.md](./adaptive-tci-interpolation.md) | Adaptive TCI patching, convergence, pivot recycling, and structured embedding |
 | [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |
 
 ## Automatic Differentiation

--- a/docs/worklogs/2026-07-24-adaptive-interpolate.md
+++ b/docs/worklogs/2026-07-24-adaptive-interpolate.md
@@ -22,6 +22,9 @@
 
 ## Chosen design
 
+Durable algorithm and API decisions are recorded in
+[`docs/design/adaptive-tci-interpolation.md`](../design/adaptive-tci-interpolation.md).
+
 - `tensor4all-partitionedtt::adaptiveinterpolate` runs TCI2 on each patch's
   active sites and splits a nonconverged patch in an explicit complete order.
 - Zero- and one-active-site leaves use exact evaluation because TCI2 requires
@@ -35,6 +38,8 @@
   documented as risky for sparse functions without known nonzero pivots.
 - TCI2 convergence now compares its already-normalized error history with the
   configured tolerance rather than a magnitude-rescaled absolute tolerance.
+- TCI2 reports whether it converged, reached the bond cap, or exhausted its
+  iteration budget; adaptive interpolation accepts only full convergence.
 - The TCIAlgorithms.jl MIT notice is retained in the crate and in the
   repository provenance table.
 

--- a/docs/worklogs/2026-07-24-adaptive-interpolate.md
+++ b/docs/worklogs/2026-07-24-adaptive-interpolate.md
@@ -1,0 +1,57 @@
+# Adaptive interpolation for partitioned tensor trains
+
+## Context read
+
+- Repository and Rust contributor rules, including numerical, performance,
+  documentation, testing, and provenance requirements.
+- The public APIs of `tensor4all-partitionedtt`, `tensor4all-tensorci`,
+  `tensor4all-simplett`, `tensor4all-core`, and `tensor4all-tensorbackend`.
+- `adaptiveinterpolate`, `createpatch`, and `_globalpivots` from
+  TCIAlgorithms.jl commit `e501032278c9dd41b46c5851d8238169c8d178c5`.
+
+## Alternatives considered
+
+- Post-hoc splitting of one global TT was rejected because it does not retry
+  TCI independently on difficult subdomains.
+- Parallel patch execution was deferred to keep callback requirements minimal
+  and seeded behavior deterministic.
+- Dense identity cores at fixed middle sites were rejected because their
+  storage grows quadratically with the carried bond dimension.
+- Treating a child with no compatible recycled pivots as zero was rejected:
+  an empty sample set does not establish that a function vanishes.
+
+## Chosen design
+
+- `tensor4all-partitionedtt::adaptiveinterpolate` runs TCI2 on each patch's
+  active sites and splits a nonconverged patch in an explicit complete order.
+- Zero- and one-active-site leaves use exact evaluation because TCI2 requires
+  at least two sites.
+- Full-domain user pivots and opt-in recycled diagonal pivots are filtered for
+  each patch, deduplicated, and replenished to a configurable target with a
+  seeded generator.
+- Fixed middle sites carry bonds with compact structured storage using axis
+  classes `[0, 1, 0]`, avoiding dense rank-squared identity cores.
+- Sampled-zero detection remains an explicit finite-sampling policy and is
+  documented as risky for sparse functions without known nonzero pivots.
+- TCI2 convergence now compares its already-normalized error history with the
+  configured tolerance rather than a magnitude-rescaled absolute tolerance.
+- The TCIAlgorithms.jl MIT notice is retained in the crate and in the
+  repository provenance table.
+
+## Verification
+
+- Focused adaptive interpolation tests cover low-rank real and complex values,
+  batch callbacks, forced splitting, exact one-site fallback, sampled-zero
+  patches, compact fixed-site storage, invalid input, opt-in recycling, and
+  the no-compatible-recycled-pivot regression.
+- The TCI2 convergence criterion has a regression assertion for normalized
+  errors under large function scaling.
+- Full contributor checks are recorded in the pull request.
+
+## Remaining risks
+
+- Sampled-zero classification can miss isolated nonzero entries not represented
+  by supplied or seeded candidates; callers interpolating sparse functions
+  should provide pivots in known nonzero regions.
+- Patch execution is intentionally sequential; parallel scheduling can be
+  considered later with an explicit callback thread-safety API.

--- a/slides/tensor4all202601.typ
+++ b/slides/tensor4all202601.typ
@@ -490,7 +490,7 @@
     };
 
     let options = TCI2Options { tolerance: 1e-10, ..Default::default() };
-    let (tci, ranks, errors) = crossinterpolate2(
+    let tensor4all_tensorci::TCI2OptimizationResult { tci, ranks, errors, .. } = crossinterpolate2(
         f, None, vec![4, 4, 4], vec![vec![0, 0, 0]], options)?;
     ```
   ]


### PR DESCRIPTION
## Summary

- add `tensor4all_partitionedtt::adaptiveinterpolate` and `AdaptiveInterpolateOptions`
- run TCI2 independently per patch, splitting nonconverged patches in an explicit full-index order
- support exact 0/1-active-site leaves, scalar and optional batch callbacks, sampled-zero patches, and opt-in pivot recycling
- replenish children that receive no compatible recycled pivots instead of incorrectly treating them as zero
- embed fixed middle sites with compact structured copy/one-hot storage
- fix TCI2 convergence to compare normalized error history with the configured relative tolerance
- record TCIAlgorithms.jl MIT provenance and license notice

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --release --workspace`
- `cargo test --doc --release --workspace`
- `cargo doc --workspace --no-deps` (passes; pre-existing rustdoc warnings remain)
- `cargo run -p api-dump --release -- . -o docs/api`

`cargo nextest` and `mdbook` are not installed in the local environment, so `cargo nextest run --release --workspace` and `./scripts/test-mdbook.sh` could not run locally. The full release `cargo test --workspace` fallback passed.

## Provenance

The patch queue and pivot-recycling structure are derived from TCIAlgorithms.jl commit `e501032278c9dd41b46c5851d8238169c8d178c5` under MIT. The upstream notice is retained in `crates/tensor4all-partitionedtt/LICENSE-TCIALGORITHMS-MIT`.
