### PR TITLE
Fix unrequested truncation in TreeTN::swap_site_indices

### DIFF
--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -63,14 +63,6 @@ pub use partial_contraction::{
 // Re-export swap types
 pub use swap::{ScheduledSwapStep, SwapOptions, SwapSchedule};
 
-enum SweepFactorization<'a> {
-    Options(&'a FactorizeOptions),
-    FullRank {
-        alg: FactorizeAlg,
-        canonical: Canonical,
-    },
-}
-
 /// Tree Tensor Network structure (inspired by ITensorNetworks.jl's TreeTensorNetwork).
 ///
 /// Maintains a graph of tensors connected by bonds (edges).
@@ -590,60 +582,29 @@ where
         Ok(Some(SweepContext { edges }))
     }
 
-    /// Process one edge during a sweep operation.
+    /// Process one edge during an exact sweep operation.
     ///
-    /// Factorizes the tensor at `src` node, absorbs the right factor into `dst` (parent),
-    /// and updates the edge bond and ortho_towards.
+    /// Factorizes the tensor at `src` node with the requested decomposition
+    /// algorithm, absorbs the right factor into `dst` (parent), and updates the
+    /// edge bond and ortho_towards. No truncation controls are passed and the
+    /// global rank-dropping defaults are not consulted, so the represented
+    /// tensor is preserved exactly.
     ///
     /// # Arguments
     /// * `src` - The source node to factorize (further from center)
     /// * `dst` - The destination/parent node (closer to center)
-    /// * `factorize_options` - Options for factorization (algorithm, rtol, max_rank)
+    /// * `alg` - Decomposition algorithm to use
+    /// * `canonical` - Which factor carries the canonical form
     /// * `context_name` - Name for error context
     ///
     /// # Returns
     /// `Ok(())` if successful, or an error if any step fails.
-    pub(crate) fn sweep_edge(
-        &mut self,
-        src: NodeIndex,
-        dst: NodeIndex,
-        factorize_options: &FactorizeOptions,
-        context_name: &str,
-    ) -> Result<()> {
-        self.sweep_edge_impl(
-            src,
-            dst,
-            SweepFactorization::Options(factorize_options),
-            context_name,
-        )
-    }
-
-    /// Process one edge during an exact sweep operation.
-    ///
-    /// This is the canonicalization variant of [`Self::sweep_edge`]. It uses
-    /// the requested decomposition algorithm without passing truncation controls
-    /// or consulting global rank-dropping defaults.
     pub(crate) fn sweep_edge_full_rank(
         &mut self,
         src: NodeIndex,
         dst: NodeIndex,
         alg: FactorizeAlg,
         canonical: Canonical,
-        context_name: &str,
-    ) -> Result<()> {
-        self.sweep_edge_impl(
-            src,
-            dst,
-            SweepFactorization::FullRank { alg, canonical },
-            context_name,
-        )
-    }
-
-    fn sweep_edge_impl(
-        &mut self,
-        src: NodeIndex,
-        dst: NodeIndex,
-        factorization: SweepFactorization<'_>,
         context_name: &str,
     ) -> Result<()> {
         // Find edge between src and dst
@@ -731,14 +692,10 @@ where
         }
 
         // Perform factorization
-        let factorize_result = match factorization {
-            SweepFactorization::Options(options) => tensor_src.factorize(&left_inds, options),
-            SweepFactorization::FullRank { alg, canonical } => {
-                tensor_src.factorize_full_rank(&left_inds, alg, canonical)
-            }
-        }
-        .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
-        .with_context(|| format!("{}: factorization failed", context_name))?;
+        let factorize_result = tensor_src
+            .factorize_full_rank(&left_inds, alg, canonical)
+            .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))
+            .with_context(|| format!("{}: factorization failed", context_name))?;
 
         let left_tensor = factorize_result.left;
         let right_tensor = factorize_result.right;
@@ -1651,15 +1608,17 @@ where
         )
         .context("swap_site_indices: canonicalize")?;
 
-        let mut swap_factorize_options = FactorizeOptions::svd().with_canonical(Canonical::Left);
+        // `rtol: None` must mean "no truncation", so always set an explicit
+        // policy: falling back to the process-global SVD default would silently
+        // drop singular values the caller never asked to drop.
+        let mut swap_factorize_options = FactorizeOptions::svd()
+            .with_canonical(Canonical::Left)
+            .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(
+                options.rtol.unwrap_or(0.0),
+            ));
         if let Some(mr) = options.max_rank {
             swap_factorize_options = swap_factorize_options.with_max_rank(mr);
         }
-        if let Some(rtol) = options.rtol {
-            swap_factorize_options = swap_factorize_options
-                .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
-        }
-        let transport_factorize_options = FactorizeOptions::svd().with_canonical(Canonical::Left);
 
         for step in &schedule.steps {
             for edge in step.transport_path.windows(2) {
@@ -1671,10 +1630,14 @@ where
                 let dst_idx = self.node_index(dst_name).ok_or_else(|| {
                     anyhow::anyhow!("swap_site_indices: transport node {:?} not found", dst_name)
                 })?;
-                self.sweep_edge(
+                // Transporting the orthogonality center is an exact rewrite, so
+                // use the full-rank sweep that canonicalization uses instead of
+                // a truncating factorization.
+                self.sweep_edge_full_rank(
                     src_idx,
                     dst_idx,
-                    &transport_factorize_options,
+                    FactorizeAlg::QR,
+                    Canonical::Left,
                     "swap_transport",
                 )
                 .context("swap_site_indices: transport")?;

--- a/crates/tensor4all-treetn/src/treetn/swap.rs
+++ b/crates/tensor4all-treetn/src/treetn/swap.rs
@@ -104,12 +104,14 @@ where
 ///
 /// When `max_rank` or `rtol` are set, the swap may introduce approximation error
 /// by truncating bond dimension. Default (both `None`) allows rank growth to preserve
-/// the tensor exactly.
+/// the tensor exactly: `None` is an explicit "no truncation" request and does
+/// *not* fall back to the process-global SVD truncation policy.
 #[derive(Debug, Clone, Default)]
 pub struct SwapOptions {
     /// Maximum bond dimension after each SVD (None = no limit).
     pub max_rank: Option<usize>,
-    /// Relative tolerance for singular value truncation (None = no truncation).
+    /// Relative tolerance for singular value truncation (None = no truncation,
+    /// equivalent to `Some(0.0)`).
     pub rtol: Option<f64>,
 }
 

--- a/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
+++ b/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
@@ -1,0 +1,191 @@
+//! Reproduction for `TreeTN::swap_site_indices` dropping singular values that the
+//! caller never asked to drop.
+//!
+//! `SwapOptions` documents `rtol: None` as "no truncation" and `swap_site_indices`
+//! documents its default as "no truncation, exact", but two independent paths fall
+//! back to the process-global `DEFAULT_SVD_TRUNCATION_POLICY` (per-value rtol 1e-12):
+//!
+//! 1. `rtol: None` sets no SVD policy on the swap factorization, so the global
+//!    default applies instead of an exact decomposition.
+//! 2. The canonical-center transport sweep never receives `SwapOptions` at all, so
+//!    even `rtol: Some(0.0)` cannot make the operation exact.
+//!
+//! Both tests below assert the *intended* (exact) behaviour and therefore fail on
+//! the current implementation. They are `#[ignore]`d so CI stays green until the
+//! fix lands.
+//!
+//! The singular value 1e-13 is chosen to sit well below the global default 1e-12
+//! and well above f64 roundoff 1e-16.
+
+use std::collections::HashMap;
+
+use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_treetn::{SwapOptions, TreeTN};
+
+/// Orthogonal 4x4 Hadamard/2, column-major flat.
+fn hadamard4() -> Vec<f64> {
+    let rows = [
+        [1.0, 1.0, 1.0, 1.0],
+        [1.0, -1.0, 1.0, -1.0],
+        [1.0, 1.0, -1.0, -1.0],
+        [1.0, -1.0, -1.0, 1.0],
+    ];
+    let mut out = vec![0.0; 16];
+    for (r, row) in rows.iter().enumerate() {
+        for (c, v) in row.iter().enumerate() {
+            out[r + 4 * c] = v / 2.0;
+        }
+    }
+    out
+}
+
+/// 4-site chain "0"-"1"-"2"-"3" whose middle cut 01|23 has singular values
+/// (1, 1e-13, 1e-13, 1e-13).
+fn chain_with_tiny_singular_values() -> (
+    TreeTN<TensorDynLen, String>,
+    DynIndex,
+    DynIndex,
+    DynIndex,
+    DynIndex,
+) {
+    let s = [1.0_f64, 1e-13, 1e-13, 1e-13];
+    let u = hadamard4();
+
+    // A = U * diag(s) * U^T, split as left = U, right = diag(s) * U^T.
+    let mut m = vec![0.0; 16];
+    for row in 0..4 {
+        for col in 0..4 {
+            m[row + 4 * col] = s[row] * u[col + 4 * row];
+        }
+    }
+
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let s3 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(2);
+    let b12 = DynIndex::new_dyn(4);
+    let b23 = DynIndex::new_dyn(2);
+
+    let t0 =
+        TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], u).unwrap();
+    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone(), b23.clone()], m).unwrap();
+    let t3 =
+        TensorDynLen::from_dense(vec![b23.clone(), s3.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+
+    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    tn.add_tensor("0".to_string(), t0).unwrap();
+    tn.add_tensor("1".to_string(), t1).unwrap();
+    tn.add_tensor("2".to_string(), t2).unwrap();
+    tn.add_tensor("3".to_string(), t3).unwrap();
+    let n0 = tn.node_index(&"0".to_string()).unwrap();
+    let n1 = tn.node_index(&"1".to_string()).unwrap();
+    let n2 = tn.node_index(&"2".to_string()).unwrap();
+    let n3 = tn.node_index(&"3".to_string()).unwrap();
+    tn.connect(n0, &b01, n1, &b01).unwrap();
+    tn.connect(n1, &b12, n2, &b12).unwrap();
+    tn.connect(n2, &b23, n3, &b23).unwrap();
+    (tn, s0, s1, s2, s3)
+}
+
+/// Largest non-site bond dimension adjacent to `node`.
+fn bond_dim_at(tn: &TreeTN<TensorDynLen, String>, node: &str, sites: &[&DynIndex]) -> usize {
+    let n = tn.node_index(&node.to_string()).unwrap();
+    tn.tensor(n)
+        .unwrap()
+        .external_indices()
+        .iter()
+        .filter(|idx| !sites.iter().any(|s| **s == **idx))
+        .map(|idx| idx.dim())
+        .max()
+        .unwrap_or(0)
+}
+
+/// A swap step that needs a transport sweep must not truncate, even with
+/// `rtol: Some(0.0)`, because `SwapOptions` is never passed to the transport.
+#[test]
+#[ignore = "reproduces the swap_site_indices truncation bug; unignore with the fix"]
+fn swap_with_transport_must_not_truncate() {
+    let (tn, s0, s1, s2, s3) = chain_with_tiny_singular_values();
+    let before = tn.contract_to_tensor().unwrap();
+    assert_eq!(
+        bond_dim_at(&tn, "1", &[&s1]),
+        4,
+        "input must have full middle rank"
+    );
+
+    // Swap s2 <-> s3 at nodes "2"/"3". Root is "0" (min node name), so the
+    // canonical center is transported 0 -> 1 -> 2 across the middle bond first.
+    let mut target: HashMap<DynIndex, String> = HashMap::new();
+    target.insert(s0, "0".to_string());
+    target.insert(s1.clone(), "1".to_string());
+    target.insert(s2, "3".to_string());
+    target.insert(s3, "2".to_string());
+
+    for (label, opts) in [
+        ("rtol: None", SwapOptions::default()),
+        (
+            "rtol: Some(0.0)",
+            SwapOptions {
+                max_rank: None,
+                rtol: Some(0.0),
+            },
+        ),
+    ] {
+        let mut tn = tn.clone();
+        tn.swap_site_indices(&target, &opts).unwrap();
+        let after = tn.contract_to_tensor().unwrap();
+        let err = before.sub(&after).unwrap().maxabs();
+        let dim = bond_dim_at(&tn, "1", &[&s1]);
+        assert_eq!(dim, 4, "{label}: middle bond rank must be preserved");
+        assert!(err < 1e-15, "{label}: swap must be exact, err={err:e}");
+    }
+}
+
+/// A swap step with no transport at all still truncates when `rtol: None`,
+/// which isolates the "`None` means global default, not exact" cause.
+#[test]
+#[ignore = "reproduces the swap_site_indices truncation bug; unignore with the fix"]
+fn swap_without_transport_must_not_truncate() {
+    // 2-node network A--B with M = H2 * diag(1, 1e-13) * H2^T on the single bond.
+    // Root is "A" (min node name), so the swap step has an empty transport path.
+    let h = 1.0 / 2.0_f64.sqrt();
+    let sig = [1.0_f64, 1e-13];
+    let hm = [[h, h], [h, -h]];
+    let mut m = vec![0.0; 4];
+    for a in 0..2 {
+        for b in 0..2 {
+            m[a + 2 * b] = (0..2).map(|k| hm[a][k] * sig[k] * hm[b][k]).sum();
+        }
+    }
+
+    let sa = DynIndex::new_dyn(2);
+    let sb = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let ta = TensorDynLen::from_dense(vec![sa.clone(), bond.clone()], m).unwrap();
+    let tb =
+        TensorDynLen::from_dense(vec![bond.clone(), sb.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+
+    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    tn.add_tensor("A".to_string(), ta).unwrap();
+    tn.add_tensor("B".to_string(), tb).unwrap();
+    let na = tn.node_index(&"A".to_string()).unwrap();
+    let nb = tn.node_index(&"B".to_string()).unwrap();
+    tn.connect(na, &bond, nb, &bond).unwrap();
+    let before = tn.contract_to_tensor().unwrap();
+    assert_eq!(bond_dim_at(&tn, "A", &[&sa]), 2);
+
+    let mut target: HashMap<DynIndex, String> = HashMap::new();
+    target.insert(sa, "B".to_string());
+    target.insert(sb.clone(), "A".to_string());
+
+    let mut tn = tn.clone();
+    tn.swap_site_indices(&target, &SwapOptions::default())
+        .unwrap();
+    let after = tn.contract_to_tensor().unwrap();
+    let err = before.sub(&after).unwrap().maxabs();
+    let dim = bond_dim_at(&tn, "A", &[&sb]);
+    assert_eq!(dim, 2, "rtol: None must not drop the 1e-13 singular value");
+    assert!(err < 1e-15, "rtol: None must be exact, err={err:e}");
+}

--- a/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
+++ b/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
@@ -1,21 +1,17 @@
-//! Reproduction for `TreeTN::swap_site_indices` dropping singular values that the
-//! caller never asked to drop.
+//! Regression tests for `TreeTN::swap_site_indices` dropping singular values
+//! that the caller never asked to drop (issue #564).
 //!
-//! `SwapOptions` documents `rtol: None` as "no truncation" and `swap_site_indices`
-//! documents its default as "no truncation, exact", but two independent paths fall
-//! back to the process-global `DEFAULT_SVD_TRUNCATION_POLICY` (per-value rtol 1e-12):
+//! Two independent paths used to fall back to the process-global
+//! `DEFAULT_SVD_TRUNCATION_POLICY` (per-value rtol 1e-12):
 //!
-//! 1. `rtol: None` sets no SVD policy on the swap factorization, so the global
-//!    default applies instead of an exact decomposition.
-//! 2. The canonical-center transport sweep never receives `SwapOptions` at all, so
-//!    even `rtol: Some(0.0)` cannot make the operation exact.
-//!
-//! Both tests below assert the *intended* (exact) behaviour and therefore fail on
-//! the current implementation. They are `#[ignore]`d so CI stays green until the
-//! fix lands.
+//! 1. `rtol: None` set no SVD policy on the swap factorization, so the global
+//!    default applied instead of an exact decomposition.
+//! 2. The canonical-center transport sweep never received `SwapOptions` at all,
+//!    so even `rtol: Some(0.0)` could not make the operation exact.
 //!
 //! The singular value 1e-13 is chosen to sit well below the global default 1e-12
-//! and well above f64 roundoff 1e-16.
+//! and well above f64 roundoff 1e-16, so any fallback to the global policy
+//! truncates it and fails these tests.
 
 use std::collections::HashMap;
 
@@ -102,10 +98,9 @@ fn bond_dim_at(tn: &TreeTN<TensorDynLen, String>, node: &str, sites: &[&DynIndex
         .unwrap_or(0)
 }
 
-/// A swap step that needs a transport sweep must not truncate, even with
-/// `rtol: Some(0.0)`, because `SwapOptions` is never passed to the transport.
+/// A swap step that needs a transport sweep must not truncate: the transport
+/// used to run a truncating factorization that ignored `SwapOptions` entirely.
 #[test]
-#[ignore = "reproduces the swap_site_indices truncation bug; unignore with the fix"]
 fn swap_with_transport_must_not_truncate() {
     let (tn, s0, s1, s2, s3) = chain_with_tiny_singular_values();
     let before = tn.contract_to_tensor().unwrap();
@@ -143,10 +138,9 @@ fn swap_with_transport_must_not_truncate() {
     }
 }
 
-/// A swap step with no transport at all still truncates when `rtol: None`,
-/// which isolates the "`None` means global default, not exact" cause.
+/// A swap step with no transport at all must not truncate with `rtol: None`:
+/// this isolates the "`None` used to mean global default, not exact" cause.
 #[test]
-#[ignore = "reproduces the swap_site_indices truncation bug; unignore with the fix"]
 fn swap_without_transport_must_not_truncate() {
     // 2-node network A--B with M = H2 * diag(1, 1e-13) * H2^T on the single bond.
     // Root is "A" (min node name), so the swap step has an empty transport path.


### PR DESCRIPTION
## Summary

Fixes #564: `TreeTN::swap_site_indices` documented `SwapOptions::default()` as
exact ("no truncation") but silently applied the process-global SVD truncation
policy (per-value rtol 1e-12) through two independent paths.

- **`rtol: None` meant "unspecified", not "exact"** — no SVD policy was set on
  the swap factorization, so the global `DEFAULT_SVD_TRUNCATION_POLICY` applied.
  Now an explicit `SvdTruncationPolicy::new(options.rtol.unwrap_or(0.0))` is
  always set.
- **`SwapOptions` never reached the transport sweep** — the canonical-center
  transport used a truncating `sweep_edge` with default options. Transporting
  the orthogonality center is an exact rewrite, so it now uses the same
  full-rank QR sweep as canonicalization (`sweep_edge_full_rank`).

The truncating `sweep_edge` and the `SweepFactorization` enum were left without
callers and are removed; `sweep_edge_full_rank` takes `alg`/`canonical`
directly.

Side effects of the fix (no extra code changes needed):
- `partial_contract`'s internal index alignment no longer applies an implicit
  1e-12 rank floor.
- The C API's `rtol = 0.0` (mapped to `rtol: None`) now requests an exact swap.

## Test plan

- New regression tests `crates/tensor4all-treetn/tests/repro_swap_truncation.rs`
  (added `#[ignore]`d in the first commit, un-ignored with the fix):
  - `swap_with_transport_must_not_truncate` — 4-site chain with middle-cut
    singular values `(1, 1e-13, 1e-13, 1e-13)`; asserts bond dim 4 and
    reconstruction error < 1e-15 for both `rtol: None` and `rtol: Some(0.0)`.
  - `swap_without_transport_must_not_truncate` — 2-node root-edge swap with
    bond spectrum `(1, 1e-13)`; isolates the `rtol: None` cause.
  - The 1e-13 value sits below the global default 1e-12 and above f64 roundoff,
    so any fallback to the global policy fails the tests.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo nextest run --release --workspace`: 2512 passed.
- `cargo test --doc --release -p tensor4all-treetn`: 117 passed.
- `cargo llvm-cov` coverage check: 201/201 files pass thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
