### PR TITLE
Add an Agent Skill for tensor4all-rs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,8 @@ Every public type, trait, and function **must** have doc comments with the follo
 
 ### Public Surface Drift
 
-- `README.md`, rustdoc, and examples must not claim more than the current public surface actually provides.
+- `README.md`, rustdoc, examples, and `skills/use-tensor4all-rs/` must not
+  claim more than the current public surface actually provides.
 - When changing public APIs, documented capabilities, or user-facing examples, check for stale names, stale capability claims, and references to removed paths or workflows.
 - Keep documentation slightly behind reality if validation is incomplete; do not advertise partially landed surfaces as stable or fully supported.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ validated in CI. Longer runnable examples live in the
 - **[Design Documents](docs/design/index.md)** — architecture and design decisions
 - **[Provenance and Citation Policy](docs/PROVENANCE_AND_CITATION_POLICY.md)** — which components build on which external projects, algorithm origins, and how to cite
 
+## Agent Skill
+
+A portable [Agent Skill](skills/use-tensor4all-rs/SKILL.md) teaches compatible
+coding agents the crate map, common workflows, and tensor4all-rs conventions.
+Install and update it with:
+
+```bash
+npx skills add tensor4all/tensor4all-rs --skill use-tensor4all-rs -g
+npx skills update use-tensor4all-rs -g
+```
+
 ## Acknowledgments
 
 Inspired by [ITensors.jl](https://github.com/ITensor/ITensors.jl) and

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -2,8 +2,9 @@
 
 ## Public Surface Drift
 
-- `README.md`, rustdoc, mdBook guide snippets, and examples must not claim
-  capabilities beyond the current public surface.
+- `README.md`, rustdoc, mdBook guide snippets, examples, and
+  `skills/use-tensor4all-rs/` must not claim capabilities beyond the current
+  public surface.
 - When public APIs, documented capabilities, or user-facing examples change,
   check for stale names, stale capability claims, and references to removed
   paths or workflows before considering the work complete.

--- a/docs/worklogs/2026-08-04-agent-skill.md
+++ b/docs/worklogs/2026-08-04-agent-skill.md
@@ -1,0 +1,45 @@
+# Agent skill contribution
+
+## Summary
+
+Added a portable Agent Skills specification-compatible guide for using tensor4all-rs. The repository now owns the canonical copy under `skills/use-tensor4all-rs/`, and the README provides install and update commands.
+
+## Material reviewed
+
+- `README.md`, `AGENTS.md`, and `REPOSITORY_RULES.md`
+- Current crate manifests, rustdoc, mdBook guides, and relevant public API implementations
+- Agent Skills specification: <https://agentskills.io/specification>
+- `skills` CLI discovery and update behavior: <https://github.com/vercel-labs/skills>
+- The pre-existing local skill and two independent review passes
+
+## Decisions
+
+- Use the vendor-neutral `skills/<name>/SKILL.md` layout. It is discoverable by Agent Skills tooling and avoids maintaining client-specific copies under `.claude/`, `.pi/`, or similar directories.
+- Keep the skill with the library so API and convention changes can update it in the same PR. `AGENTS.md` and `REPOSITORY_RULES.md` now include it in public-surface drift checks.
+- Link it from the README and use `npx skills update` for installed-copy updates.
+- Do not add dedicated CI automation yet. The skill has no executable scripts, and existing documentation/API checks remain the source of truth; format/discovery and links are checked during this PR.
+
+## Review fixes
+
+The imported draft was corrected before publication:
+
+- fixed the column-major rule: the first listed index varies fastest;
+- removed a stale dependency-layer diagram;
+- replaced the stale fixed release example and incorrect “floating rev” wording;
+- clarified that Rust code needs direct dependencies for every imported crate;
+- distinguished SVD `rtol` from algorithm option fields named `tolerance`;
+- fixed the random-tensor import, TreeTN edge count, HDF5 argument order, and a broken skill-relative link in the recipes;
+- removed an unsupported ACI “pivot-search” option claim.
+
+## Verification
+
+- `npx skills add . --list` validated the local source and discovered exactly `use-tensor4all-rs`.
+- A local Markdown link check resolved every relative link in the README and skill.
+- Thirteen executable recipe blocks compiled and ran against the current workspace. The HDF5 recipe signature was checked against source; its local build is blocked by the installed Homebrew HDF5 2.2.0, which `hdf5-metno-sys` does not recognize.
+- `cargo fmt --all -- --check`, `git diff --check`, and the repository-rules dry run passed.
+- Clippy, release workspace tests, and rustdoc passed with `tensor4all-hdf5` excluded for the same local HDF5 issue. The full clippy command reached only that external build failure.
+- Two independent read-only reviewers found no blockers in the final API content or integration strategy.
+
+## Remaining risk
+
+The detailed crate reference and recipes intentionally track `main` and can drift as public APIs evolve. The repository rules now make that review obligation explicit; volatile signatures should continue to defer to rustdoc rather than gain more duplicated detail.

--- a/skills/use-tensor4all-rs/SKILL.md
+++ b/skills/use-tensor4all-rs/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: use-tensor4all-rs
+description: Use the tensor4all-rs Rust tensor-network library (TCI, quantics tensor trains, tree tensor networks, DMRG/TDVP/GSE time evolution, adaptive patch interpolation). Use when working with `tensor4all-*` crates (core/simplett/tensorci/quanticstci/treetn/partitionedtt/...), their `TensorDynLen`/`TensorTrain`/`TreeTN`/`QuanticsTensorCI2`/`PartitionedTT` APIs, or the `dmrg`/`tdvp`/`gse_tdvp`/`adaptiveinterpolate` entry points. Also when porting ITensors.jl, QuanticsTCI.jl, or TCI patterns to Rust, or debugging column-major, `rtol`, or 0-vs-1 indexing mismatches in tensor4all-rs code.
+license: MIT
+---
+
+# Use tensor4all-rs
+
+tensor4all-rs is a Rust workspace of tensor-network crates — TCI, quantics tensor trains (QTT), and tree tensor networks (TreeTN) — inspired by ITensors.jl / ITensorNetworks.jl. Two rules run through everything: **column-major** dense layout, and **conventions** that differ per crate (indexing base, tolerance name). Both bite silently — check them every time.
+
+The library is a **stack**: a layered set of crates where each layer builds on the one below. Land on the right layer before writing code, then honor the conventions that span every layer.
+
+## 1. Set up the project
+
+The library is **not on crates.io**; declare a git or path dependency, and build in release.
+
+```toml
+[dependencies]
+# Current main; Cargo.lock records the resolved commit:
+tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-simplett" }
+# Exact source revision or release:
+# tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", rev = "<sha>", package = "tensor4all-simplett" }
+# tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", tag = "<release-tag>", package = "tensor4all-simplett" }
+# Local checkout — path relative to your Cargo.toml:
+# tensor4all-simplett = { path = "../tensor4all-rs/crates/tensor4all-simplett" }
+```
+
+This skill tracks `main`; a release tag may not contain every API described below. Add each crate that your code imports directly. Do not add transitive crates that you never name.
+
+- **Backend defaults to pure-Rust `faer` — no system BLAS.** Compute crates enable `tenferro-cpu-faer` by default, so a plain dependency compiles standalone. To link a system BLAS (OpenBLAS / MKL / Apple Accelerate) instead, set `default-features = false` and enable `tenferro-system-blas` on each directly imported crate where it is exposed.
+- **Build with `--release`.** Tensor linalg in debug is orders of magnitude slower; TCI and DMRG are unusable without optimization. For benchmarks set `opt-level = 3` (and `lto`, `codegen-units = 1`).
+- **Scalars** are `f64` and `Complex64` (`num-complex` 0.4). Recipes that build random tensors assume you add `rand` + `rand_chacha` (matching the library's `0.9`) as dev-dependencies.
+- **`tensor4all-tensorbackend` is internal** — never depend on it or instantiate `CpuBackend` directly; get scalars, storage, and linalg through the public crates. `tensor4all-tcicore` is the home of `CachedFunction` and `MultiIndex`: depend on it for `CachedFunction`, or take `MultiIndex` re-exported from `tensor4all-partitionedtt`.
+
+Done when `cargo build --release` succeeds and a constant TT evaluates:
+
+```rust
+use tensor4all_simplett::AbstractTensorTrain;
+let tt = tensor4all_simplett::TensorTrain::<f64>::constant(&[2, 2], 1.0);
+assert!((tt.evaluate(&[0, 0])? - 1.0).abs() < 1e-12);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## 2. Land on the right crate
+
+Match the goal to the crate. This is the leading decision — the rest follows.
+
+| Goal | Crate |
+|------|-------|
+| TCI on a black-box function, high level | `tensor4all-quanticstci` |
+| TCI with fine-grained, low-level control | `tensor4all-tensorci` |
+| Tree-structured cross interpolation | `tensor4all-treetci` |
+| Elementwise ops on tensor trains (ACI) | `tensor4all-aci` |
+| Simple TT: create / evaluate / compress | `tensor4all-simplett` |
+| TT with ITensors.jl-style named indices, orthogonality center | `tensor4all-itensorlike` |
+| Tree tensor networks, arbitrary topology; DMRG/TDVP/GSE sweeps | `tensor4all-treetn` |
+| Quantics transform operators (shift, flip, Fourier, affine) | `tensor4all-quanticstransform` |
+| Interpolative QTT construction | `tensor4all-interpolativeqtt` |
+| Adaptive TCI over subdomain patches; patching add/contract/truncate | `tensor4all-partitionedtt` |
+| Core Index / Tensor / contraction / SVD-QR-LU | `tensor4all-core` |
+| HDF5 I/O compatible with ITensors.jl | `tensor4all-hdf5` |
+| C FFI for language bindings | `tensor4all-capi` |
+
+For each crate's key types and entry points, read [`references/crates.md`](references/crates.md).
+
+## 3. Read the authoritative API, not the source
+
+tensor4all-rs keeps source and rustdoc as the API source of truth, and generates a plain-text API dump you should read first:
+
+- **`docs/api/*.md` in a repository checkout** — generated by `cargo run -p api-dump --release -- . -o docs/api`. Read the relevant generated file when present; never hand-edit it.
+- **rustdoc** — `cargo doc -p <crate> --open`, or online at `https://tensor4all.org/tensor4all-rs/rustdoc/<crate>/`.
+- **mdBook user guide** — `docs/book/src/` (run `mdbook serve docs/book`). Online: `https://tensor4all.org/tensor4all-rs/`. The guide snippets are runnable and CI-checked.
+
+Only read source when the API doc is insufficient. For concrete task patterns (build a TT, run TCI, apply a quantics transform, contract a TreeTN), pull the recipe from [`references/recipes.md`](references/recipes.md) rather than reconstructing from memory.
+
+## 4. Honor the cross-cutting conventions
+
+These apply across crates and fail silently when ignored. Check them against every data-handling path.
+
+**Dense layout is column-major (Fortran order).** `TensorDynLen::from_dense(indices, data)` and all flat buffers, `reshape`, the C API, and HDF5 use column-major: the **first listed index varies fastest**. Matches Julia / ITensors.jl. When feeding NumPy data, use `order="F"`.
+
+**Indexing base depends on the crate.** Rust sites are **0-indexed**, unlike ITensors.jl (1-indexed). One exception: `tensor4all-quanticstci` grid indices are **1-indexed** (`1..=grid_size`), matching QuanticsTCI.jl. The low-level `tensor4all-tensorci::crossinterpolate2` is **0-indexed** (`0..local_dim`). `tensor4all-partitionedtt::adaptiveinterpolate` pivots are full-domain **0-indexed** too (it wraps `tensorci`). Mixing 0- and 1-indexed territory is the commonest off-by-one.
+
+**SVD truncation uses `rtol`, not `cutoff`.** ITensors.jl uses `cutoff`; convert with `rtol = sqrt(cutoff)` (so `cutoff=1e-10` → `rtol=1e-5`). Algorithm-specific option structs such as `CompressionOptions` and `TCI2Options` instead name their threshold `tolerance`; check the exact type. Singular values are indexed `s[[0, i]]`, not `s[[i, i]]`.
+
+**Sweep counts differ by API.** TreeTN `ApplyOptions` uses `nfullsweeps` (each edge visited twice, forward+back); TreeTN DMRG/TDVP options call the same unit `nsweeps`. `tensor4all-itensorlike` uses `nhalfsweeps`, with `nfullsweeps = nhalfsweeps / 2`; its `ContractOptions`/`LinsolveOptions` provide `with_nsweeps(n)` = `with_nhalfsweeps(2 * n)`.
+
+**Quantics bits are big-endian.** Site 0 = most-significant bit, site R-1 = least-significant. `quantics_fourier_operator` output is **bit-reversed** frequency order. `quanticscrossinterpolate_discrete` requires all grid dimensions equal and powers of 2.
+
+**Prefer generic APIs over scalar-specific names.** `f64` and `Complex64` flow through the same generic entry points. `*_f64` / `*_c64` names exist only at the C-API / FFI boundary.
+
+**No hidden dense materialization in production paths.** `to_dense()`, `contract_to_tensor()`, and full-network `evaluate`-every-element loops are for tests and small examples only — they scale as the product of index dimensions. For long TT / TreeTN comparisons use a direct-sum difference plus a tensor-network norm, or sampled `evaluate()` checks. `ApplyOptions::naive()` is local exact apply (bond dims may grow as products), not full dense.
+
+**Index identity is full-index equality, not `id()`.** Two indices with the same id but different prime level, tags, or direction are distinct. Key maps and sets by the full `Index` value. Select concrete legs/sites by passing the full `Index`, never an id. `AdaptiveInterpolateOptions::patch_order` and `PatchingOptions::patch_order` are validated as exact full-`Index` permutations of the site indices — matching by id alone is rejected.
+
+## 5. If you are inside the tensor4all-rs repo itself
+
+This skill is for *using* the library. If the working tree is the tensor4all-rs checkout (you see `AGENTS.md` and `REPOSITORY_RULES.md`), the repo's own rules take over — this skill does not override them:
+
+- Read `AGENTS.md` then `REPOSITORY_RULES.md` before non-trivial work (`AGENTS.md` first points to the shared `tensor4all-agent-rules` repo). Early development: no backward compatibility; remove deprecated code.
+- Follow the repo's Rust rules — `thiserror` typed errors in library APIs, `anyhow` only for internal plumbing/binaries/examples/tests, no `unwrap()`/`expect()` in library code. For general Rust idiom, lean on the `rust-skills` skill; this repo hard-enforces the error-handling and no-unwrap rules even where a generic style guide would leave it to judgement.
+- Run `cargo fmt --all` and `cargo clippy` before committing. Doc examples must run with real assertions (no `ignore`/`no_run`); verify with `cargo test --doc --release --workspace` and `./scripts/test-mdbook.sh`.
+- Dense linalg, SVD/QR/einsum go through `tensor4all-tensorbackend` wrappers (don't write hand-rolled matrix kernels, don't form explicit inverses — use solves). Graph traversals use `petgraph` (via `node_name_network` / `site_index_network`).
+
+## Sources of truth
+
+- Library APIs: source + rustdoc (online rustdoc at `https://tensor4all.org/tensor4all-rs/rustdoc/tensor4all_core/`).
+- Generated API dump: `docs/api/` (from `api-dump`; do not edit).
+- User guide: `docs/book/src/` (mdBook); online `https://tensor4all.org/tensor4all-rs/`.
+- In a repository checkout, the developer entry point is `AGENTS.md`; durable repo rules are in `REPOSITORY_RULES.md`; shared agent rules live in the `tensor4all-agent-rules` repo.
+- Julia bindings: https://github.com/tensor4all/Tensor4all.jl (wraps `tensor4all-capi`).
+- Repository paths: design docs `docs/design/index.md`; plans `docs/plans/`; C API design `docs/CAPI_DESIGN.md`; provenance/citation `docs/PROVENANCE_AND_CITATION_POLICY.md`.

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -1,0 +1,180 @@
+# tensor4all-rs crate reference
+
+Per-crate key types and entry points. Pull the crate you landed on in step 2 of `SKILL.md`.
+Signatures are abbreviated; confirm exact shapes in `docs/api/` or rustdoc before relying on them.
+All `tensor4all_*` crate names map to `tensor4all-<name>` packages.
+
+## tensor4all-core — foundation
+
+Indices, dynamic-rank tensors, contraction, factorization. Most other crates re-export from here.
+
+- `Index` (alias `DynIndex = Index<DynId, TagSet>`) — identifies a tensor axis by unique identity, optional tags, optional prime level.
+  - `Index::new_dyn(dim)` — site index, auto id, no tags.
+  - `Index::new_dyn_with_tag(dim, tag) -> Result` — named index.
+  - `DynIndex::new_bond(dim) -> Result` — bond index; fallible (metadata validated).
+  - `.prime()` / `.noprime()` — raise / clear prime level (ket vs bra).
+  - `.dim()`, `.plev()` via the `IndexLike` trait (`use tensor4all_core::IndexLike;`).
+  - Two independently created indices are always distinct even with equal dim.
+- `TensorDynLen` — dynamic-rank tensor backed by compact (dense / diagonal / structured) storage; axes matched by index identity, no fixed ordering.
+  - `TensorDynLen::from_dense(indices, data)` — column-major `data`; first index varies fastest.
+  - `TensorDynLen::zeros::<f64>(indices)`, `::random::<f64, _>(&mut rng, indices)`.
+  - `.to_vec::<f64>()`, `.sum()`, `.dims()`.
+- `contract(&[&a, &b, ...])` — sum over all shared indices; inputs must be connected (else error). `outer_product(&a, &b)` for disconnected products.
+- `factorize(&t, &[left_indices], &opts) -> FactorizeResult { left, right, rank, singular_values }`.
+  - `FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol))` / `.with_max_rank(n)`.
+  - `FactorizeOptions::qr().with_qr_rtol(tol)` / `.with_max_rank(n)`.
+
+## tensor4all-simplett — lightweight TT/MPS
+
+Plain `f64` / `Complex64` tensor train; no named indices needed. The go-to for numerics.
+
+- `TensorTrain::<f64>` / `::<Complex64>` — chain of 3-leg cores.
+  - `TensorTrain::constant(&[dims], val)`, `::zeros(&[dims])`.
+  - `TensorTrain::new(tensors: Vec<Tensor3>)`.
+  - `trait AbstractTensorTrain`: `.evaluate(&[idx]) -> Result`, `.sum()`, `.norm()`, `.rank()`, `.len()`, `.site_dims()`, `.link_dims()`, `.site_tensor(i)`, `.add(&b)`, `.compressed(&CompressionOptions)`.
+- `CompressionOptions { tolerance, max_bond_dim, .. }` — `tolerance` is the relative truncation threshold. Default ~1e-12 near-lossless; 1e-8..1e-6 for science.
+- `SiteTensorTrain` (center-canonical), `VidalTensorTrain` (Vidal form with singular values).
+- `Tensor3Ops` (`.left_dim()/.site_dim()/.right_dim()/.set3()`), `types::tensor3_zeros(l, s, r)`.
+- Bridge: `tensor_train_to_treetn(&mps) -> (TreeTN, site_indices)` (re-exported from `tensor4all-treetn`).
+
+## tensor4all-itensorlike — ITensors.jl-style TT
+
+Named `DynIndex` objects; orthogonality-center tracking; multiple canonical forms. Use when you need named indices or ITensors.jl compatibility.
+
+- `TensorTrain::new(vec![t0, t1, ...])` from `TensorDynLen` cores.
+- `.orthogonalize(site)`, `.orthogonalize_with(site, CanonicalForm::...)` (LU / CI forms).
+- `.truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol)).with_max_rank(n))`.
+- `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, `.isortho()`, `.orthocenter()`, `.maxbonddim()`.
+- `TruncateOptions`, `CanonicalForm`. `ContractOptions` / `LinsolveOptions` with `with_nsweeps(n)` (= `with_nhalfsweeps(2*n)`).
+- Build indices with `DynIndex::new_dyn(dim)` (site) and `DynIndex::new_bond(dim)?` (bond). `from_dense` data is column-major.
+
+## tensor4all-tensorci — low-level TCI
+
+Direct cross interpolation on integer indices. TCI2 is the primary algorithm; TCI1 is legacy.
+
+- `crossinterpolate2::<T, F, B>(f, batched_f: Option<B>, local_dims, initial_pivots, TCI2Options) -> Result<TCI2OptimizationResult<T>>`. The result is a **struct** — access `result.tci` (`TensorCI2<T>`), `result.ranks`, `result.errors`, `result.termination`. (Not a tuple.)
+  - `f: &MultiIndex -> T` — **0-indexed** multi-index (`MultiIndex = Vec<usize>`).
+  - `batched_f: Option<B>`, `B: Fn(&[MultiIndex]) -> Vec<T>` — same function, batched; pass `None` when batching is unavailable.
+  - `initial_pivots` — pick where `|f|` is large.
+- `TCI2Options { tolerance, max_bond_dim, max_iter, seed, normalize_error, .. }`.
+  - `tolerance` default 1e-8; 1e-6 explore, 1e-12 high accuracy.
+  - `max_bond_dim` cap to prevent runaway on expensive functions.
+  - `seed: Some(42)` for reproducibility.
+- `opt_first_pivot::<T, F>(&f, &local_dims, &start, n_iters) -> MultiIndex` — local search for a large-`|f|` pivot.
+- `TensorCI2::to_tensor_train() -> Result<TensorTrain>`. Convergence: check `result.termination == TCI2Termination::Converged` (bond-error, global-pivot history, and rank stability all met). `MaxBondDimension` / `MaxIterations` are stops, **not** convergence — treat them as "not done".
+
+## tensor4all-tcicore — caching + multi-index plumbing
+
+Home of `CachedFunction` and `MultiIndex`. Prefer the higher-level crates; reach for this one only for those two types. `MultiIndex` is re-exported from `tensor4all-partitionedtt`, so you need a direct dep only for `CachedFunction`.
+
+- `CachedFunction::new(f, &local_dims)` — memoize expensive evaluations across sweeps. `.eval(&idx)`, `.cache_size()`, `.num_cache_hits()`. Worth it only when `f` is expensive; cheap functions lose to overhead.
+- `MultiIndex` = `Vec<usize>`, the coordinate type threaded through `tensorci` and `partitionedtt` callbacks.
+
+Do **not** depend on `tensor4all-tensorbackend` — it is internal (storage + linalg wrappers); use the public crates and never instantiate `CpuBackend` directly.
+
+## tensor4all-quanticstci — high-level quantics TCI
+
+Quantics encoding (binary bits across sites) often yields far lower bond dims. Port of QuanticsTCI.jl.
+
+- Entry points (return `(QuanticsTensorCI2, ranks, errors)`):
+  - `quanticscrossinterpolate_discrete::<T, F>(&sizes, f, None, opts)` — integer grid; indices **1-indexed** (`1..=grid_size`). `sizes` must be equal powers of 2.
+  - `quanticscrossinterpolate(&grid, f, None, opts)` — continuous domain via `DiscretizedGrid`.
+  - `quanticscrossinterpolate_from_arrays` — explicit coordinate arrays.
+  - `quanticscrossinterpolate_batched` — vector/tensor-valued `f`.
+- `DiscretizedGrid::builder(&[r_bits]).with_lower_bound(&[x0]).with_upper_bound(&[x1]).include_endpoint(bool).build()`.
+- `QtciOptions::default().with_tolerance(t).with_maxbonddim(m).with_nrandominitpivot(k).with_unfoldingscheme(UnfoldingScheme::Interleaved)`.
+  - `nrandominitpivot` default 5; raise to 10–20 for multi-feature / high-dim.
+- `QuanticsTensorCI2`: `.evaluate(&[idx])`, `.sum()`, `.integral()` (left Riemann sum; O(h)), `.tci()`.
+- Interleaved multivariate encoding: site `n` encodes one bit per variable, local dim `2^num_vars`.
+
+## tensor4all-quanticstransform — quantics operators
+
+Every constructor returns a `LinearOperator` (from `tensor4all-treetn`). All use **big-endian** bits; `r` = bits per variable (`2^r` grid points).
+
+- `flip_operator(r, BoundaryCondition)`, `shift_operator(r, offset, BoundaryCondition)`, `phase_rotation_operator(r, theta)`, `cumsum_operator(r)`, `quantics_fourier_operator(r, FourierOptions)`, `affine_operator(r, &AffineParams, &bc)`.
+- `_multivar` variants use interleaved encoding (site local dim `2^num_vars`).
+- `BoundaryCondition::{Periodic, Open}`. `FourierOptions::{forward, inverse, default}` (`normalize` default true = isometry). QFT output is **bit-reversed**.
+- `AffineParams::new(a: Vec<Rational64>, b: Vec<Rational64>, n_out, n_in)`.
+- `LinearOperator`: `.mpo()`, `.node_count()`, `.rename_nodes(&[(from, to)])`, `.set_input_space_from_state(&state)`, `.set_output_space_from_state(&state)`, `.get_input_mapping(&i)`, `.get_output_mapping(&i)`.
+- Apply via `tensor4all_treetn::apply_linear_operator(&op, &state, ApplyOptions)`. Partial apply (subset of sites) builds a Steiner tree automatically — no manual identity tensors.
+- Error conditions: `r == 0`; `r == 1` for cumsum/triangle/fourier; `r >= 64` for shift (overflow); NaN/Inf `theta`.
+
+## tensor4all-treetn — tree tensor networks
+
+Generic `TreeTN` over arbitrary tree topology (TT/MPS is the path-graph special case).
+
+- `TreeTN::<TensorDynLen, V>::from_tensors(tensors, labels) -> Result` — topology inferred from shared bond indices; site indices appear once, bond indices appear twice. `V: Eq + Hash` labels vertices.
+- `.node_count()`, `.edge_count()`, `ttn[v]` access, `.norm()`, `.to_dense()` (test/small only), `.add(&b)` (same topology + matching site indices; bonds grow as direct sum), `.replaceind(&old, &new)`.
+- `.canonicalize([root], CanonicalizationOptions)`, `.truncate([root], TruncationOptions::default().with_max_rank(n).with_rtol(t))`.
+- `apply_linear_operator(&op, &state, ApplyOptions)`:
+  - `ApplyOptions::naive()` — local exact, no truncation; bond dims grow as products. Small/debug only.
+  - `ApplyOptions::zipup().with_max_rank(n).with_svd_policy(policy)` — default; single sweep, controllable.
+  - `ApplyOptions::fit().with_max_rank(n).with_nfullsweeps(k)` — iterative; best compression.
+- Sweep convention: `ApplyOptions::fit().with_nfullsweeps(k)` uses `nfullsweeps` (full = forward+back); `nfullsweeps = nhalfsweeps / 2`. The DMRG/TDVP option structs instead name the same full-sweep count `nsweeps` (no `full` prefix) — there is no `with_nfullsweeps` on `DmrgOptions`/`TdvpOptions`.
+- `tensor_train_to_treetn(&mps) -> (TreeTN, Vec<site_index>)` bridge from simplett.
+- Optimization sweeps (ground state + time evolution). All take a `LinearOperator` (or a bare MPO `TreeTN` via the `*_with_treetn_operator` wrappers), an initial `TreeTN` state, and a `center: &V` root node; the state is canonicalized at `center` first. v1: one input and one output site mapping per node. Build the mapping with `LinearOperator::from_mpo_and_state(mpo, &state)` when site indices are unambiguous, else hand-build `IndexMapping { true_index, internal_index }` input/output maps.
+  - `dmrg(operator, init, center, DmrgOptions) -> Result<DmrgResult>` — two-site ground-state DMRG (Lanczos local solve; Rayleigh-quotient energy, no dense materialization). `DmrgOptions::default()` = `nsite 2, nsweeps 5, max_bond_dim None, svd_policy None, energy_tol None`. Builders: `with_nsweeps`, `with_max_bond_dim`, `with_svd_policy`, `with_energy_tol`, `with_lanczos_options`. `DmrgResult { state, energy, sweeps_completed, local_updates, converged, max_residual_norm }`. `nsite` must be 2.
+  - `tdvp(operator, init, center, TdvpOptions) -> Result<TdvpResult>` — time-dependent variational principle via Krylov `exp(exponent_step·H)`. `exponent_step` is the Hamiltonian coefficient: real time `dt` → `Complex64::new(0.0, -dt)`; imaginary time `tau` → `-tau` (real negative). `TdvpOptions::default()` = `nsite 2, nsweeps 1, order 2, exponent_step -0.1i, max_bond_dim None, svd_policy None`. `order` ∈ {1,2,4} (Suzuki–Trotter/applyexp, ITensorNetworks.jl parity). `nsite 1` = fixed-rank one-site (rejects truncation options); `nsite 2` allows bond changes. For ITensors `cutoff` parity use `SvdTruncationPolicy::new(cutoff).with_squared_values().with_discarded_tail_sum()`. `TdvpResult { state, sweeps_completed, local_updates, max_error_estimate, max_krylov_iterations }`.
+  - `gse_tdvp(operator, init, center, GseTdvpOptions) -> Result<GseTdvpResult>` — Global Subspace Expansion: build Krylov references `H·ψ, H²·ψ, …` and expand bond bases between TDVP sweeps to grow rank where needed. `GseTdvpOptions { gse: GseOptions, tdvp: TdvpOptions }`; `GseOptions::default()` = `krylov_dim 0, density_weight_cutoff 1e-12, hermitian_tol 1e-12, normalize_references true, expand_before_first_sweep true`. Also `global_subspace_expand(operator, init, center, GseOptions)` and `global_subspace_expand_with_references(init, references, center, GseOptions)` for standalone expansion. v1: `TensorDynLen` states, one state site index per node.
+
+## tensor4all-aci — elementwise TT operations
+
+Ports AlternatingCrossInterpolation.jl. Approximates an elementwise op on input TTs.
+
+- `elementwise(|xs: &[f64]| ..., &[a, b, ...], &AciOptions::default()) -> AciResult`.
+- `elementwise_batched(|batch: ElementwiseBatch, out: &mut [f64]| ..., &[a, b], &AciOptions)` — amortized batched callback; `batch.get(input, point)`.
+- `AciOptions` controls tolerance, sweep limits, maximum bond dimension, scaling, initial guess, and random seed; `AciResult { tensor_train, ... }`.
+
+## tensor4all-treetci — tree TCI
+
+Ports TreeTCI.jl. Cross interpolation on tree-structured graphs → TreeTN.
+
+- `crossinterpolate2()` (tree entry), `TreeTCI2`, `TreeTciGraph`.
+- `tensor4all_treetci::materialize::to_treetn(tci_state, batch_eval, Some(root))` — materialize as TreeTN with a batched evaluator.
+
+## tensor4all-interpolativeqtt — interpolative QTT
+
+Ports InterpolativeQTT.jl; returns `TensorTrain<f64>`.
+
+- `interpolate_single_scale(f, x_min, x_max, R, oversampling, &InterpolativeQttOptions::default())`.
+
+## tensor4all-partitionedtt — subdomain patches + adaptive TCI
+
+Split a function's domain into non-overlapping projected patches, each its own TT. Use when a function is low-rank only after fixing some site indices. Re-exports `DynIndex`, `TensorDynLen`, `MultiIndex`, `TensorTrain`, `ContractOptions`/`TruncateOptions`, `TCI2Options` — get them here rather than depending on `tensor4all-tcicore`.
+
+- `Projector` — maps site `DynIndex` → fixed coordinate, defining a subdomain.
+  - `Projector::new()`, `Projector::from_pairs([(idx, value), ...])`.
+  - `.get(&idx) -> Option<usize>`, `.is_projected_at(&idx)`, `.insert(idx, value)`, `.projected_indices()`, `.len()`, `.is_empty()`.
+- `SubDomainTT` — an itensorlike `TensorTrain` plus its `Projector`.
+  - `SubDomainTT::new(tt, projector)`, `SubDomainTT::from_tt(tt)` (empty projector).
+  - `.data()`, `.data_mut()`, `.projector()`, `.max_bond_dim()`, `.into_data()`, `.all_indices()`.
+- `PartitionedTT` — collection of mutually disjoint `SubDomainTT`s (disjointness validated at construction).
+  - `PartitionedTT::from_subdomains(vec)?`, `::from_subdomain(one)`, `::new()`.
+  - `.len()`, `.is_empty()`, `.projectors()`, `.iter()`, `.values()`, `.values_mut()`, `.contains(&projector)`.
+  - `.to_tensor_train() -> Result<TensorTrain>` — recombine all patches into one TT (drops the partition structure).
+  - `.contract(&other, &ContractOptions)?` (also free `contract` / `proj_contract`).
+- Adaptive patching — bond-cap-driven splitting plus volume-proportional truncation:
+  - `add_with_patching(subdomains: Vec<SubDomainTT>, &PatchingOptions) -> Result<PartitionedTT>` — split over-cap patches along `patch_order`, then truncate.
+  - `contract_adaptive(&left, &right, &ContractOptions, &PatchingOptions) -> Result<PartitionedTT>`.
+  - `truncate_adaptive(&PartitionedTT, rtol, max_bond_dim) -> Result<PartitionedTT>` — total budget `rtol²·‖F‖²` shared by patch volume; patches at/below their budget are dropped.
+  - `PatchingOptions { rtol: 1e-12, max_bond_dim: 100, patch_order: Vec<DynIndex>, split_strategy: ExactParameterGain }`.
+  - `PatchSplitStrategy::{Sequential, ExactParameterGain (default)}` — `ExactParameterGain` forms + counts child cores to pick the smallest split; `Sequential` takes the first unprojected `patch_order` index.
+- Adaptive TCI interpolation — ports TCIAlgorithms.jl `adaptiveinterpolate` / `createpatch` / `_globalpivots`:
+  - `adaptiveinterpolate::<T, F, B>(f, batched_f: Option<B>, site_indices: Vec<DynIndex>, initial_pivots: Vec<MultiIndex>, AdaptiveInterpolateOptions) -> Result<PartitionedTT>`.
+    - `f: &MultiIndex -> T` receives one **full, 0-based** multi-index (tensorci territory, not quanticstci).
+    - `batched_f: Option<B>` with `B: Fn(&[MultiIndex]) -> Vec<T>` — same function, batched; pass `None` when batching is unavailable.
+    - `initial_pivots` — full-domain, 0-based; empty allowed.
+  - `AdaptiveInterpolateOptions { tci_options: TCI2Options, patch_order: Vec<DynIndex>, n_initial_pivots: 5, recycle_pivots: false }`. Empty `patch_order` ⇒ site order; nonempty must be an exact full-`Index` permutation of `site_indices`.
+  - Flow: run TCI2 per patch on the active (unprojected) sites; **accept** only when `TCI2Termination::Converged` **and** final error ≤ `tci_options.tolerance`; otherwise split at the next `patch_order` index into one child per coordinate. Patches with 0/1 active sites are evaluated exactly. Reaching `max_bond_dim`/`max_iter` is a stop, not convergence — such a patch is split.
+  - `recycle_pivots = true` seeds children with a rejected parent's diagonal TCI pivots (opt-in; incompatible pivots discarded; every child is still replenished to `n_initial_pivots`).
+  - Sampled-zero policy: if every candidate evaluates below `1e-30` the patch is stored as zero — supply known-nonzero pivots for sparse functions.
+
+## tensor4all-hdf5 — ITensors.jl-compatible I/O
+
+- `save_itensor()` / `load_itensor()` — `TensorDynLen` as ITensors.jl `ITensor`.
+- `save_mps()` / `load_mps()` — `TensorTrain` as ITensorMPS.jl `MPS`.
+- Features: `link` (default, compile-time HDF5), `runtime-loading` (dlopen for FFI).
+
+## tensor4all-capi — C FFI
+
+Status enum `t4a_status_code` with `T4A_` prefix (`T4A_SUCCESS`, `T4A_NULL_POINTER`, `T4A_INTERNAL_ERROR`). Header `crates/tensor4all-capi/include/tensor4all_capi.h` regenerated with `cbindgen`. See `docs/CAPI_DESIGN.md`. Wrapped by Tensor4all.jl. Not for direct Rust use.

--- a/skills/use-tensor4all-rs/references/recipes.md
+++ b/skills/use-tensor4all-rs/references/recipes.md
@@ -1,0 +1,331 @@
+# tensor4all-rs recipes
+
+Doctest-style task patterns distilled from the mdBook guides (`docs/book/src/`). Each is the
+minimal correct shape — confirm option defaults and scalar support against rustdoc before
+production use.
+
+## Dependency
+
+Declare every `tensor4all-*` crate imported by your code as a git/path dependency and build
+in release — see [`SKILL.md`](../SKILL.md) §1 for the authoritative setup (revision pinning,
+backend features, `--release`, dev-deps). Each recipe below assumes that is done.
+
+## Build, evaluate, compress a TT (simplett)
+
+```rust
+use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, TensorTrain};
+
+let tt = TensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
+assert!((tt.evaluate(&[0, 1, 2]).unwrap() - 1.0).abs() < 1e-12);
+assert!((tt.sum() - 24.0).abs() < 1e-12); // 2*3*4 entries
+
+// Adding two constants inflates bond dim; compression recovers rank 1.
+let big = TensorTrain::<f64>::constant(&[2, 3, 4], 1.0)
+    .add(&TensorTrain::<f64>::constant(&[2, 3, 4], 2.0))?;
+assert_eq!(big.rank(), 2);
+let opts = CompressionOptions { tolerance: 1e-10, max_bond_dim: 20, ..Default::default() };
+let c = big.compressed(&opts)?;
+assert_eq!(c.rank(), 1);
+assert!((c.evaluate(&[0, 1, 2])? - 3.0).abs() < 1e-10);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Core: indices, tensors, contraction, factorize
+
+```rust
+use rand::SeedableRng;
+use tensor4all_core::{Index, IndexLike, TensorDynLen, contract, factorize, FactorizeOptions, SvdTruncationPolicy};
+
+let i = Index::new_dyn(2);
+let j = Index::new_dyn(3);
+let k = Index::new_dyn(4);
+
+let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6])?;
+let b = TensorDynLen::from_dense(vec![j, k.clone()], vec![1.0_f64; 12])?;
+let c = contract(&[&a, &b])?;          // j summed away -> [i, k]
+assert_eq!(c.dims(), vec![2, 4]);
+
+// SVD split along i | k, truncating below rtol.
+let t = TensorDynLen::random::<f64, _>(&mut rand_chacha::ChaCha8Rng::seed_from_u64(1), vec![i.clone(), k.clone()])?;
+let opts = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1e-10));
+let r = factorize(&t, &[i], &opts)?;   // r.left=[i,bond], r.right=[bond,k]
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## TCI on a black-box function (low-level, 0-indexed)
+
+```rust
+use tensor4all_simplett::AbstractTensorTrain;
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+
+let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
+let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+    f, None, vec![4, 4], vec![vec![3, 3]],            // pivot where |f| is large
+    TCI2Options { tolerance: 1e-10, seed: Some(42), ..Default::default() },
+)?;
+assert_eq!(result.termination, tensor4all_tensorci::TCI2Termination::Converged);
+assert!(*result.errors.last().unwrap() < 1e-10);
+let tt = result.tci.to_tensor_train()?;
+assert!((tt.evaluate(&[2, 3])? - 6.0).abs() < 1e-10); // f(2,3)=6
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Quantics TCI on a discrete grid (1-indexed, equal powers of 2)
+
+```rust
+use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+
+let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;       // 1-indexed
+let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete::<f64, _>(
+    &vec![16, 16], f, None,
+    QtciOptions::default().with_tolerance(1e-10),
+)?;
+assert!(*errors.last().unwrap() < 1e-10);
+assert!((qtci.evaluate(&[5, 10])? - 15.0).abs() < 1e-8);
+// sum of (i+j) for i,j in 1..=16 = 2 * 16 * (16*17/2) = 4352
+assert!((qtci.sum()? - 4352.0).abs() < 1e-6);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Quantics TCI on a continuous interval + integral
+
+```rust
+use tensor4all_quanticstci::{quanticscrossinterpolate, DiscretizedGrid, QtciOptions};
+
+let grid = DiscretizedGrid::builder(&[4])              // 2^4 = 16 points
+    .with_lower_bound(&[0.0]).with_upper_bound(&[1.0]).build()?;
+let (qtci, _ranks, errors) = quanticscrossinterpolate::<f64, _>(
+    &grid, |x: &[f64]| x[0] * x[0], None, QtciOptions::default(),
+)?;
+assert!(*errors.last().unwrap() < 1e-8);
+assert!((qtci.evaluate(&[1])? - 0.0).abs() < 1e-10);   // grid point 1 -> x=0
+let integral = qtci.integral()?;                         // left Riemann sum, O(h)
+assert!((integral - 1.0 / 3.0).abs() < 5e-2);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+For a manual integral on a uniform half-open `[x_min, x_max)`:
+`integral = tt.sum() * (x_max - x_min) / 2^R`.
+
+## Cache expensive evaluations
+
+```rust
+use tensor4all_tcicore::CachedFunction;
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+
+let r = 8;
+let local_dims = vec![2; r];
+let step = 1.0 / (1usize << r) as f64;
+let cf = CachedFunction::new(
+    |idx: &[usize]| {
+        let q = idx.iter().fold(0usize, |acc, &b| (acc << 1) | b);
+        (-(3.0 * q as f64 * step)).exp()
+    },
+    &local_dims,
+)?;
+let cached_f = |idx: &Vec<usize>| cf.eval(idx);
+let _result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+    cached_f, None, local_dims, vec![vec![0; r]],
+    TCI2Options { tolerance: 1e-12, seed: Some(42), ..Default::default() },
+)?;
+assert!(cf.num_cache_hits() > 0);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Quantics transform: build + apply an operator
+
+```rust
+use tensor4all_core::SvdTruncationPolicy;
+use tensor4all_quanticstransform::{quantics_fourier_operator, FourierOptions, shift_operator, BoundaryCondition};
+use tensor4all_treetn::ApplyOptions;
+
+let r = 8;
+let shift = shift_operator(r, 10, BoundaryCondition::Periodic)?;     // each -> LinearOperator
+let qft = quantics_fourier_operator(r, FourierOptions::forward())?;
+assert_eq!(qft.mpo().node_count(), r);
+
+// Apply to a TreeTN state. zipUp is the default; naive grows bonds, fit compresses.
+let opts = ApplyOptions::zipup()
+    .with_max_rank(64)
+    .with_svd_policy(SvdTruncationPolicy::new(1e-10));
+// let result = apply_linear_operator(&qft, &state, opts)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Partial apply (subset of sites, e.g. Fourier only the x-variable of an interleaved 2D
+encoding): rename operator nodes to the x-sites, `set_input_space_from_state` /
+`set_output_space_from_state`, then `apply_linear_operator`. The Steiner tree inserts
+identity tensors at the skipped sites automatically.
+
+## Tree TN: build, canonicalize, truncate
+
+```rust
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_treetn::{TreeTN, TruncationOptions};
+
+let s0 = DynIndex::new_dyn(2);
+let s1 = DynIndex::new_dyn(2);
+let bond = DynIndex::new_dyn(3);
+let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0_f64; 6])?;
+let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0_f64; 6])?;
+let mut ttn = TreeTN::<_, i32>::from_tensors(vec![t0, t1], vec![0, 1])?;
+assert_eq!(ttn.edge_count(), 1);
+
+let norm_before = ttn.norm()?;
+let mut ttn = ttn.canonicalize([0], Default::default())?; // root 0 holds the norm
+assert!(ttn.is_canonicalized());
+let mut ttn = ttn.truncate([0], TruncationOptions::default().with_max_rank(2))?;
+assert_eq!(ttn.node_count(), 2);
+assert!((ttn.norm()? - norm_before).abs() / norm_before < 1e-10); // canonicalization preserves the value
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## TreeTN DMRG / TDVP (treetn optimization sweeps)
+
+DMRG (ground state) and TDVP (real/imaginary time evolution) sweep a `TreeTN`
+state against a `LinearOperator` MPO, canonicalized at a root `center` node.
+Build the mapping with `LinearOperator::from_mpo_and_state(mpo, &state)`, or
+pass a bare MPO `TreeTN` to the `*_with_treetn_operator` wrappers. v1: one input
+and one output site mapping per node.
+
+```rust
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_treetn::{tdvp_with_treetn_operator, TdvpOptions, TreeTN};
+
+// One-site TDVP under a 2x2 identity MPO: |0> evolves under exp(-0.1i * I).
+let site = DynIndex::new_dyn(2);
+let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+
+let op_in = DynIndex::new_dyn(2);
+let op_out = DynIndex::new_dyn(2);
+let op_tensor = TensorDynLen::from_dense(vec![op_out, op_in], vec![1.0, 0.0, 0.0, 1.0])?;
+let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+
+let result = tdvp_with_treetn_operator(
+    &mpo, state, &0,
+    TdvpOptions::default()
+        .with_nsite(1)                                  // fixed-rank one-site
+        .with_exponent_step(Complex64::new(0.0, -0.1)),  // exp(-0.1i * H)
+)?;
+assert_eq!(result.sweeps_completed, 1);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+- DMRG: swap to `dmrg_with_treetn_operator(&mpo, state, &0, DmrgOptions::default().with_nsweeps(4).with_max_bond_dim(32).with_energy_tol(1e-10))`; read `result.energy` (Rayleigh quotient), `result.converged`, `result.max_residual_norm`.
+- Real time step `dt` → `exponent_step = Complex64::new(0.0, -dt)`; imaginary time `tau` → `-tau`. `order` ∈ {1,2,4}. `nsite 2` grows bonds (set `max_bond_dim`/`svd_policy`); `nsite 1` is fixed-rank.
+- To grow rank on the fly use `gse_tdvp` with `GseTdvpOptions { gse: GseOptions::default().with_krylov_dim(3), tdvp: TdvpOptions::default() }`; it expands bond bases with `H·ψ, H²·ψ, …` between sweeps.
+
+## ITensorLike TT: orthogonalize, truncate, inner
+
+```rust
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
+
+let s0 = DynIndex::new_dyn(2);
+let s1 = DynIndex::new_dyn(2);
+let b01 = DynIndex::new_bond(2)?;
+let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+let mut tt = TensorTrain::new(vec![t0, t1])?;
+
+let norm_before = tt.norm();
+tt.orthogonalize(1)?;
+assert!(tt.isortho());
+tt.truncate(&TruncateOptions::svd()
+    .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
+    .with_max_rank(2))?;
+let inner = tt.inner(&tt)?;                  // <tt|tt> = norm^2
+assert!((inner.real() - norm_before * norm_before).abs() < 1e-10);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Compress existing data without materializing (TCI)
+
+Define `f(idx)` computing each element on demand; let TCI find low-rank structure.
+`local_dims = vec![128; 3]` for a 128³ grid — never allocate the full array.
+
+```rust
+use std::f64::consts::PI;
+use tensor4all_simplett::AbstractTensorTrain;
+use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+
+let f = |idx: &Vec<usize>| {
+    let x = 2.0 * PI * idx[0] as f64 / 128.0;
+    let y = 2.0 * PI * idx[1] as f64 / 128.0;
+    let z = 2.0 * PI * idx[2] as f64 / 128.0;
+    x.cos() + y.cos() + z.cos()           // exact TT rank 2
+};
+let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
+    f, None, vec![128, 128, 128], vec![vec![0, 0, 0]],
+    TCI2Options { tolerance: 1e-12, max_bond_dim: 64, ..Default::default() },
+)?;
+assert_eq!(result.termination, tensor4all_tensorci::TCI2Termination::Converged);
+assert!(*result.errors.last().unwrap() < 1e-10);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Adaptive TCI over subdomain patches (partitionedtt, 0-indexed)
+
+`adaptiveinterpolate` runs TCI2 per patch and subdivides patches that miss the
+tolerance. Pivots are full-domain and **0-indexed** (tensorci territory, not
+quanticstci). The result is a `PartitionedTT`; `to_tensor_train()` recombines it.
+
+```rust
+use tensor4all_core::contract;
+use tensor4all_partitionedtt::{
+    adaptiveinterpolate, AdaptiveInterpolateOptions, DynIndex, MultiIndex,
+};
+
+let sites = vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+// full-domain, 0-indexed evaluator
+let f = |idx: &MultiIndex| ((idx[0] + 1) * (idx[1] + 1)) as f64;
+let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+    f,
+    None,                                  // batched_f: None when batching unavailable
+    sites,
+    vec![vec![1, 1]],                      // initial pivots where |f| is large
+    AdaptiveInterpolateOptions::default(), // tci_options tol 1e-8, n_initial_pivots 5
+)?;
+assert_eq!(result.len(), 1);               // one patch covered the whole domain
+
+let tt = result.to_tensor_train()?;
+let dense = contract(&[tt.tensor(0)?, tt.tensor(1)?])?;
+assert_eq!(dense.to_vec::<f64>()?, vec![1.0, 2.0, 2.0, 4.0]); // column-major
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+For a function low-rank only after fixing an index, raise `n_initial_pivots`
+(10–20 for multi-feature/high-dim), set `recycle_pivots(true)` to seed children
+from a rejected parent, and supply known-nonzero pivots for sparse functions
+(patches whose candidates all sample below `1e-30` are stored as zero).
+
+## Elementwise op on TTs (ACI)
+
+```rust
+use tensor4all_aci::{elementwise, AciOptions};
+use tensor4all_simplett::AbstractTensorTrain;
+
+let a = tensor4all_simplett::TensorTrain::<f64>::constant(&[2, 3], 2.0);
+let b = tensor4all_simplett::TensorTrain::<f64>::constant(&[2, 3], 4.0);
+let result = elementwise(|xs: &[f64]| xs[0] * xs[1], &[a, b], &AciOptions::default())?;
+assert!((result.tensor_train.evaluate(&[1, 2])? - 8.0).abs() < 1e-10);
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## HDF5 I/O (ITensors.jl-compatible)
+
+```rust
+use tensor4all_hdf5::{load_mps, save_mps};
+// save_mps("state.h5", "MPS", &tt)?;      // or save_itensor for a single ITensor
+// let loaded = load_mps("state.h5", "MPS")?;
+```
+
+## Convergence debugging checklist
+
+- `errors.last()` plateaus above `tolerance`: raise `max_bond_dim` (needs higher rank), raise `max_iter` (more sweeps), or pick better initial pivots where `|f|` is large (`opt_first_pivot`).
+- Quantics discrete: all `sizes` equal and powers of 2; raise `nrandominitpivot` (10–20) for multi-feature / high-dim.
+- Off-by-one at a boundary: confirm whether you are in 0-indexed (`tensorci`, `partitionedtt::adaptiveinterpolate`) or 1-indexed (`quanticstci`) territory.
+- Tolerance mismatch with Julia: `rtol = sqrt(cutoff)`.
+- Running in a debug build (no `--release`): tensor linalg is orders of magnitude slower — always run TCI/DMRG in release.


### PR DESCRIPTION
## Summary

- add a portable Agent Skills-compatible `use-tensor4all-rs` skill under the vendor-neutral `skills/` directory
- link install/update commands from the README
- make skill drift part of the repository's public-surface review policy
- include crate selection, API navigation, cross-cutting conventions, focused references, and task recipes

## Strategy

The repository copy is canonical so public API and convention changes can update the skill in the same PR. Installed copies use `npx skills update`; client-specific duplicate directories are intentionally avoided. Dedicated CI was not added because the skill has no scripts and current API/rustdoc/mdBook checks remain authoritative.

## Review fixes made before publication

The original draft was audited against current `main`. This PR fixes the reversed column-major rule, stale release/dependency wording, a stale dependency diagram, direct-dependency guidance, `rtol` versus `tolerance` ambiguity, a missing random import, an incorrect TreeTN edge count, HDF5 argument order, a broken relative link, and an unsupported ACI option claim.

## Validation

- `npx skills add . --list`
- local link check for README and all skill Markdown
- generated harness compiled and ran 13 executable recipe blocks against the current workspace
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/repository-rules-review.py --base main --worktree --dry-run`
- `cargo clippy --workspace --exclude tensor4all-hdf5 --all-targets -- -D warnings`
- `cargo test --release --workspace --exclude tensor4all-hdf5`
- `cargo doc --workspace --exclude tensor4all-hdf5 --no-deps`
- two independent read-only final reviews: no blockers

The full clippy command was also attempted, but the local `hdf5-metno-sys` build rejects the installed Homebrew HDF5 2.2.0 version string. The HDF5 recipe signatures were verified directly against current source; hosted CI remains responsible for that platform-dependent crate.
