### PR TITLE
Fix simplett MPO truncation semantics, zip-up cost, and compression optimality

### DIFF
--- a/crates/tensor4all-simplett/src/mpo/canonical.rs
+++ b/crates/tensor4all-simplett/src/mpo/canonical.rs
@@ -15,18 +15,13 @@
 
 use crate::einsum_helper::{einsum_tensors, typed_tensor_reshape, EinsumScalar};
 
-use super::error::{MPOError, Result};
+use super::environment::mpo_helper_error;
+use super::error::Result;
 use super::factorize::SVDScalar;
 use super::mpo::MPO;
 use super::types::{Tensor4, Tensor4Ops};
 use tenferro_tensor::TypedTensor;
 use tensor4all_tensorbackend::qr_backend;
-
-fn canonical_error(context: &str, err: impl std::fmt::Display) -> MPOError {
-    MPOError::InvalidOperation {
-        message: format!("{context}: {err}"),
-    }
-}
 
 /// Bring `mpo` into right-canonical form without changing the operator it
 /// represents.
@@ -56,35 +51,35 @@ where
         // Column-major data of `(left, s1, s2, right)` groups the trailing
         // three axes contiguously, so this reshape is a pure metadata change.
         let matrix = typed_tensor_reshape(tensor.as_inner(), &[left, rest])
-            .map_err(|err| canonical_error("Failed to reshape MPO site tensor", err))?;
+            .map_err(|err| mpo_helper_error("Failed to reshape MPO site tensor", err))?;
 
         // An LQ factorization `M = L * Q` with row-orthonormal `Q` is obtained
         // from the QR of the plain (unconjugated) transpose:
         // `M^T = Q_t R_t` gives `M = R_t^T Q_t^T`, and
         // `Q_t^T (Q_t^T)^H = conj(Q_t^H Q_t) = I`.
         let transposed = einsum_tensors("lx->xl", &[&matrix])
-            .map_err(|err| canonical_error("Failed to transpose MPO site matrix", err))?;
+            .map_err(|err| mpo_helper_error("Failed to transpose MPO site matrix", err))?;
         let (q, r) = qr_backend(&transposed)
-            .map_err(|err| canonical_error("QR failed during MPO canonicalization", err))?;
+            .map_err(|err| mpo_helper_error("QR failed during MPO canonicalization", err))?;
 
         let rank = q.shape()[1];
         let q_rows: TypedTensor<T> = einsum_tensors("xk->kx", &[&q])
-            .map_err(|err| canonical_error("Failed to transpose QR factor Q", err))?;
+            .map_err(|err| mpo_helper_error("Failed to transpose QR factor Q", err))?;
         let new_site = typed_tensor_reshape(&q_rows, &[rank, s1, s2, right])
-            .map_err(|err| canonical_error("Failed to reshape QR factor Q", err))?;
+            .map_err(|err| mpo_helper_error("Failed to reshape QR factor Q", err))?;
         let l_factor: TypedTensor<T> = einsum_tensors("kl->lk", &[&r])
-            .map_err(|err| canonical_error("Failed to transpose QR factor R", err))?;
+            .map_err(|err| mpo_helper_error("Failed to transpose QR factor R", err))?;
 
         // Absorb `L` into the left neighbour so the represented operator is
         // unchanged.
         let prev = mpo.site_tensor(i - 1);
         let new_prev = einsum_tensors("ausl,lk->ausk", &[prev.as_inner(), &l_factor])
-            .map_err(|err| canonical_error("Failed to absorb QR factor into MPO site", err))?;
+            .map_err(|err| mpo_helper_error("Failed to absorb QR factor into MPO site", err))?;
 
         *mpo.site_tensor_mut(i) = Tensor4::from_tenferro(new_site)
-            .map_err(|err| canonical_error("Canonicalized MPO site has invalid rank", err))?;
+            .map_err(|err| mpo_helper_error("Canonicalized MPO site has invalid rank", err))?;
         *mpo.site_tensor_mut(i - 1) = Tensor4::from_tenferro(new_prev)
-            .map_err(|err| canonical_error("Canonicalized MPO site has invalid rank", err))?;
+            .map_err(|err| mpo_helper_error("Canonicalized MPO site has invalid rank", err))?;
     }
 
     Ok(())

--- a/crates/tensor4all-simplett/src/mpo/canonical.rs
+++ b/crates/tensor4all-simplett/src/mpo/canonical.rs
@@ -1,0 +1,94 @@
+//! Canonical-form sweeps for MPOs.
+//!
+//! Local SVD truncation of a tensor train only minimizes the global error when
+//! the part of the train that is not being truncated is orthonormal. A
+//! truncating left-to-right sweep makes the sites to the left of the active
+//! bond left-orthogonal as it goes, but the sites to the right keep whatever
+//! gauge they were built with. Bringing the MPO into right-canonical form
+//! first, with rank-preserving QR factorizations, fixes that gauge so every
+//! subsequent local truncation is optimal against an orthonormal environment.
+//!
+//! The sweep here is rank preserving: it never discards a bond dimension for
+//! accuracy reasons, it only replaces each bond by the exact rank of the
+//! corresponding matricization. That makes it safe to run before any
+//! truncation policy is applied.
+
+use crate::einsum_helper::{einsum_tensors, typed_tensor_reshape, EinsumScalar};
+
+use super::error::{MPOError, Result};
+use super::factorize::SVDScalar;
+use super::mpo::MPO;
+use super::types::{Tensor4, Tensor4Ops};
+use tenferro_tensor::TypedTensor;
+use tensor4all_tensorbackend::qr_backend;
+
+fn canonical_error(context: &str, err: impl std::fmt::Display) -> MPOError {
+    MPOError::InvalidOperation {
+        message: format!("{context}: {err}"),
+    }
+}
+
+/// Bring `mpo` into right-canonical form without changing the operator it
+/// represents.
+///
+/// After the sweep every site tensor `B` with index `i >= 1` satisfies
+/// `sum_{s1, s2, r} B[l, s1, s2, r] * conj(B[l', s1, s2, r]) = delta_{l, l'}`,
+/// and the whole norm sits on site `0`.
+///
+/// Each bond is replaced by the exact rank of the matricization at that bond,
+/// so bond dimensions can shrink but no accuracy is lost.
+pub(crate) fn right_canonicalize<T>(mpo: &mut MPO<T>) -> Result<()>
+where
+    T: SVDScalar + EinsumScalar,
+{
+    if mpo.len() <= 1 {
+        return Ok(());
+    }
+
+    for i in (1..mpo.len()).rev() {
+        let tensor = mpo.site_tensor(i);
+        let left = tensor.left_dim();
+        let s1 = tensor.site_dim_1();
+        let s2 = tensor.site_dim_2();
+        let right = tensor.right_dim();
+        let rest = s1 * s2 * right;
+
+        // Column-major data of `(left, s1, s2, right)` groups the trailing
+        // three axes contiguously, so this reshape is a pure metadata change.
+        let matrix = typed_tensor_reshape(tensor.as_inner(), &[left, rest])
+            .map_err(|err| canonical_error("Failed to reshape MPO site tensor", err))?;
+
+        // An LQ factorization `M = L * Q` with row-orthonormal `Q` is obtained
+        // from the QR of the plain (unconjugated) transpose:
+        // `M^T = Q_t R_t` gives `M = R_t^T Q_t^T`, and
+        // `Q_t^T (Q_t^T)^H = conj(Q_t^H Q_t) = I`.
+        let transposed = einsum_tensors("lx->xl", &[&matrix])
+            .map_err(|err| canonical_error("Failed to transpose MPO site matrix", err))?;
+        let (q, r) = qr_backend(&transposed)
+            .map_err(|err| canonical_error("QR failed during MPO canonicalization", err))?;
+
+        let rank = q.shape()[1];
+        let q_rows: TypedTensor<T> = einsum_tensors("xk->kx", &[&q])
+            .map_err(|err| canonical_error("Failed to transpose QR factor Q", err))?;
+        let new_site = typed_tensor_reshape(&q_rows, &[rank, s1, s2, right])
+            .map_err(|err| canonical_error("Failed to reshape QR factor Q", err))?;
+        let l_factor: TypedTensor<T> = einsum_tensors("kl->lk", &[&r])
+            .map_err(|err| canonical_error("Failed to transpose QR factor R", err))?;
+
+        // Absorb `L` into the left neighbour so the represented operator is
+        // unchanged.
+        let prev = mpo.site_tensor(i - 1);
+        let new_prev = einsum_tensors("ausl,lk->ausk", &[prev.as_inner(), &l_factor])
+            .map_err(|err| canonical_error("Failed to absorb QR factor into MPO site", err))?;
+
+        *mpo.site_tensor_mut(i) = Tensor4::from_tenferro(new_site)
+            .map_err(|err| canonical_error("Canonicalized MPO site has invalid rank", err))?;
+        *mpo.site_tensor_mut(i - 1) = Tensor4::from_tenferro(new_prev)
+            .map_err(|err| canonical_error("Canonicalized MPO site has invalid rank", err))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tensor4all-simplett/src/mpo/canonical/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/canonical/tests/mod.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+use crate::mpo::test_support::random_mpo;
+use num_complex::{Complex64, ComplexFloat};
+
+const SEED: u64 = 0x2545_F491_4F6C_DD1D;
+
+fn assert_same_operator<T>(before: &MPO<T>, after: &MPO<T>, tol: f64)
+where
+    T: SVDScalar + EinsumScalar,
+    <T as ComplexFloat>::Real: Into<f64>,
+{
+    let (a, shape_a) = before.fulltensor();
+    let (b, shape_b) = after.fulltensor();
+    assert_eq!(shape_a, shape_b);
+    let max_diff = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| ComplexFloat::abs(*x - *y).into())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        max_diff < tol,
+        "canonicalization changed the operator: max abs difference {max_diff:e}"
+    );
+}
+
+/// Check `sum_{s1, s2, r} B[l, s1, s2, r] * conj(B[l', s1, s2, r]) = delta`.
+fn assert_right_orthogonal<T>(tensor: &Tensor4<T>, tol: f64)
+where
+    T: SVDScalar + EinsumScalar,
+    <T as ComplexFloat>::Real: Into<f64>,
+{
+    let left = tensor.left_dim();
+    for l in 0..left {
+        for lp in 0..left {
+            let mut sum = T::zero();
+            for s1 in 0..tensor.site_dim_1() {
+                for s2 in 0..tensor.site_dim_2() {
+                    for r in 0..tensor.right_dim() {
+                        sum = sum
+                            + *tensor.get4(l, s1, s2, r)
+                                * ComplexFloat::conj(*tensor.get4(lp, s1, s2, r));
+                    }
+                }
+            }
+            let expected = if l == lp { T::one() } else { T::zero() };
+            let diff: f64 = ComplexFloat::abs(sum - expected).into();
+            assert!(diff < tol, "gram entry ({l}, {lp}) is off by {diff:e}");
+        }
+    }
+}
+
+fn right_canonicalize_generic<T>(from_f64: impl Fn(f64) -> T)
+where
+    T: SVDScalar + EinsumScalar,
+    <T as ComplexFloat>::Real: Into<f64>,
+{
+    let bonds = [1, 3, 5, 4, 1];
+    let mpo = random_mpo(&bonds, 2, 2, SEED, from_f64);
+    let mut canonical = mpo.clone();
+    right_canonicalize(&mut canonical).unwrap();
+
+    assert_same_operator(&mpo, &canonical, 1e-10);
+    for i in 1..canonical.len() {
+        assert_right_orthogonal(canonical.site_tensor(i), 1e-10);
+    }
+}
+
+#[test]
+fn right_canonicalize_preserves_operator_and_orthogonalizes_f64() {
+    right_canonicalize_generic::<f64>(|x| x);
+}
+
+#[test]
+fn right_canonicalize_preserves_operator_and_orthogonalizes_c64() {
+    right_canonicalize_generic::<Complex64>(|x| Complex64::new(x, 0.5 - x));
+}
+
+#[test]
+fn right_canonicalize_reduces_oversized_bonds_to_the_exact_rank() {
+    // The last bond is declared as 7 but the site-2 matricization is only
+    // 7 x 4, so the exact rank at that bond is 4. A right-to-left sweep sees
+    // rank deficiency coming from the right, so this bond must shrink while
+    // the first bond, whose deficiency would only be visible from the left,
+    // is left alone.
+    let bonds = [1, 3, 7, 1];
+    let mpo = random_mpo(&bonds, 2, 2, SEED, |x: f64| x);
+    let mut canonical = mpo.clone();
+    right_canonicalize(&mut canonical).unwrap();
+
+    assert_same_operator(&mpo, &canonical, 1e-10);
+    assert_eq!(canonical.link_dims(), vec![3, 4]);
+}
+
+#[test]
+fn right_canonicalize_is_a_noop_for_short_mpos() {
+    let mut mpo = MPO::<f64>::constant(&[(2, 2)], 3.0);
+    let before = mpo.clone();
+    right_canonicalize(&mut mpo).unwrap();
+    assert_same_operator(&before, &mpo, 1e-12);
+}

--- a/crates/tensor4all-simplett/src/mpo/contract_fit.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit.rs
@@ -14,7 +14,13 @@ use crate::einsum_helper::EinsumScalar;
 /// Options for the variational fit algorithm
 #[derive(Debug, Clone)]
 pub struct FitOptions {
-    /// Tolerance for truncation at each step
+    /// Relative truncation tolerance at each step, forwarded to
+    /// [`FactorizeOptions::tolerance`](super::factorize::FactorizeOptions::tolerance).
+    ///
+    /// Singular values smaller than `tolerance * sigma_max` are discarded at
+    /// each bond, where `sigma_max` is the largest singular value of that
+    /// bond's matrix. The threshold is invariant under a global rescaling of
+    /// the operators being contracted.
     pub tolerance: f64,
     /// Maximum bond dimension
     pub max_bond_dim: usize,

--- a/crates/tensor4all-simplett/src/mpo/contract_naive.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive.rs
@@ -3,14 +3,15 @@
 //! Contracts two MPOs by directly multiplying site tensors,
 //! optionally followed by compression.
 
+use super::canonical::right_canonicalize;
 use super::contraction::ContractionOptions;
 use super::environment::contract_site_tensors;
 use super::error::{MPOError, Result};
 use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
-use super::types::{tensor4_zeros, Tensor4, Tensor4Ops};
-use super::{matrix2_zeros, Matrix2};
-use crate::einsum_helper::EinsumScalar;
+use super::types::{Tensor4, Tensor4Ops};
+use super::Matrix2;
+use crate::einsum_helper::{einsum_tensors, typed_tensor_reshape, EinsumScalar};
 
 /// Perform naive contraction of two MPOs
 ///
@@ -90,7 +91,15 @@ where
 }
 
 /// Compress an MPO using the specified options
-fn compress_mpo<T: SVDScalar>(mpo: &mut MPO<T>, options: &ContractionOptions) -> Result<()>
+///
+/// The MPO is first brought into right-canonical form with rank-preserving QR
+/// factorizations. Only then is the truncating left-to-right sweep run, so
+/// every local SVD truncation sees an orthonormal environment on both sides
+/// and discards the singular values that are actually smallest globally.
+fn compress_mpo<T: SVDScalar + EinsumScalar>(
+    mpo: &mut MPO<T>,
+    options: &ContractionOptions,
+) -> Result<()>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
 {
@@ -106,6 +115,8 @@ where
         ..Default::default()
     };
 
+    right_canonicalize(mpo)?;
+
     // Sweep left to right, factorizing each bond
     for i in 0..(mpo.len() - 1) {
         let tensor = mpo.site_tensor(i);
@@ -114,78 +125,45 @@ where
         let s2 = tensor.site_dim_2();
         let right_dim = tensor.right_dim();
 
-        // Reshape to matrix: (left * s1 * s2, right)
+        // Column-major data of `(left, s1, s2, right)` groups the leading
+        // three axes contiguously, so this reshape to `(left * s1 * s2, right)`
+        // is a pure metadata change.
         let rows = left_dim * s1 * s2;
-        let cols = right_dim;
-        let mut mat: Matrix2<T> = matrix2_zeros(rows, cols);
-        for l in 0..left_dim {
-            for i1 in 0..s1 {
-                for i2 in 0..s2 {
-                    let row = (l * s1 + i1) * s2 + i2;
-                    for col in 0..cols {
-                        mat[[row, col]] = *tensor.get4(l, i1, i2, col);
-                    }
-                }
-            }
-        }
+        let mat = typed_tensor_reshape(tensor.as_inner(), &[rows, right_dim])
+            .map_err(|err| naive_error("Failed to reshape MPO site tensor", err))?;
+        let mat: Matrix2<T> = Matrix2::from_tenferro_unchecked(mat);
 
-        // Factorize
         let fact_result = factorize(&mat, &factorize_opts)?;
         let new_rank = fact_result.rank;
 
-        // Update current tensor with left factor
-        let mut new_tensor = tensor4_zeros(left_dim, s1, s2, new_rank);
-        let left_rows = fact_result.left.dim(0);
-        let left_cols = fact_result.left.dim(1);
-        for l in 0..left_dim {
-            for i1 in 0..s1 {
-                for i2 in 0..s2 {
-                    let row = (l * s1 + i1) * s2 + i2;
-                    for r in 0..new_rank {
-                        if row < left_rows && r < left_cols {
-                            new_tensor.set4(l, i1, i2, r, fact_result.left[[row, r]]);
-                        }
-                    }
-                }
-            }
-        }
+        let new_tensor =
+            typed_tensor_reshape(fact_result.left.as_inner(), &[left_dim, s1, s2, new_rank])
+                .map_err(|err| naive_error("Failed to reshape compressed MPO site tensor", err))?;
+        let new_tensor = Tensor4::from_tenferro(new_tensor)
+            .map_err(|err| naive_error("Compressed MPO site has invalid rank", err))?;
 
-        // Get next tensor's dimensions
-        let next_tensor = mpo.site_tensor(i + 1);
-        let next_left = next_tensor.left_dim();
-        let next_s1 = next_tensor.site_dim_1();
-        let next_s2 = next_tensor.site_dim_2();
-        let next_right = next_tensor.right_dim();
-
-        // Multiply right factor into next tensor
+        // Multiply the right factor into the next tensor:
         // R[new_rank, right_dim] @ next[right_dim, s1, s2, next_right]
-        // = new_next[new_rank, s1, s2, next_right]
-        let right_rows = fact_result.right.dim(0);
-        let right_cols = fact_result.right.dim(1);
-        let mut new_next = tensor4_zeros(new_rank, next_s1, next_s2, next_right);
-        for l in 0..new_rank {
-            for i1 in 0..next_s1 {
-                for i2 in 0..next_s2 {
-                    for r in 0..next_right {
-                        let mut sum = T::zero();
-                        for k in 0..next_left.min(right_cols) {
-                            if l < right_rows {
-                                sum = sum
-                                    + fact_result.right[[l, k]] * *next_tensor.get4(k, i1, i2, r);
-                            }
-                        }
-                        new_next.set4(l, i1, i2, r, sum);
-                    }
-                }
-            }
-        }
+        let next_tensor = mpo.site_tensor(i + 1);
+        let new_next = einsum_tensors(
+            "lk,ksqr->lsqr",
+            &[fact_result.right.as_inner(), next_tensor.as_inner()],
+        )
+        .map_err(|err| naive_error("Failed to absorb right factor into MPO site", err))?;
+        let new_next = Tensor4::from_tenferro(new_next)
+            .map_err(|err| naive_error("Compressed MPO site has invalid rank", err))?;
 
-        // Update tensors in place
         *mpo.site_tensor_mut(i) = new_tensor;
         *mpo.site_tensor_mut(i + 1) = new_next;
     }
 
     Ok(())
+}
+
+fn naive_error(context: &str, err: impl std::fmt::Display) -> MPOError {
+    MPOError::InvalidOperation {
+        message: format!("{context}: {err}"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/contract_naive.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive.rs
@@ -6,6 +6,7 @@
 use super::canonical::right_canonicalize;
 use super::contraction::ContractionOptions;
 use super::environment::contract_site_tensors;
+use super::environment::mpo_helper_error;
 use super::error::{MPOError, Result};
 use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
@@ -130,7 +131,7 @@ where
         // is a pure metadata change.
         let rows = left_dim * s1 * s2;
         let mat = typed_tensor_reshape(tensor.as_inner(), &[rows, right_dim])
-            .map_err(|err| naive_error("Failed to reshape MPO site tensor", err))?;
+            .map_err(|err| mpo_helper_error("Failed to reshape MPO site tensor", err))?;
         let mat: Matrix2<T> = Matrix2::from_tenferro_unchecked(mat);
 
         let fact_result = factorize(&mat, &factorize_opts)?;
@@ -138,9 +139,11 @@ where
 
         let new_tensor =
             typed_tensor_reshape(fact_result.left.as_inner(), &[left_dim, s1, s2, new_rank])
-                .map_err(|err| naive_error("Failed to reshape compressed MPO site tensor", err))?;
+                .map_err(|err| {
+                    mpo_helper_error("Failed to reshape compressed MPO site tensor", err)
+                })?;
         let new_tensor = Tensor4::from_tenferro(new_tensor)
-            .map_err(|err| naive_error("Compressed MPO site has invalid rank", err))?;
+            .map_err(|err| mpo_helper_error("Compressed MPO site has invalid rank", err))?;
 
         // Multiply the right factor into the next tensor:
         // R[new_rank, right_dim] @ next[right_dim, s1, s2, next_right]
@@ -149,21 +152,15 @@ where
             "lk,ksqr->lsqr",
             &[fact_result.right.as_inner(), next_tensor.as_inner()],
         )
-        .map_err(|err| naive_error("Failed to absorb right factor into MPO site", err))?;
+        .map_err(|err| mpo_helper_error("Failed to absorb right factor into MPO site", err))?;
         let new_next = Tensor4::from_tenferro(new_next)
-            .map_err(|err| naive_error("Compressed MPO site has invalid rank", err))?;
+            .map_err(|err| mpo_helper_error("Compressed MPO site has invalid rank", err))?;
 
         *mpo.site_tensor_mut(i) = new_tensor;
         *mpo.site_tensor_mut(i + 1) = new_next;
     }
 
     Ok(())
-}
-
-fn naive_error(context: &str, err: impl std::fmt::Display) -> MPOError {
-    MPOError::InvalidOperation {
-        message: format!("{context}: {err}"),
-    }
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/contract_naive/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive/tests/mod.rs
@@ -1,5 +1,8 @@
 use super::*;
 use crate::mpo::factorize::FactorizeMethod;
+use crate::mpo::test_support::random_mpo;
+
+const SEED: u64 = 0x9E37_79B9_7F4A_7C15;
 
 #[test]
 fn test_contract_naive_identity() {
@@ -57,4 +60,62 @@ fn test_contract_naive_with_compression() {
 
     // Bond dimension should be compressed
     assert!(result.rank() <= 2);
+}
+
+fn frobenius_distance(a: &[f64], b: &[f64]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y) * (x - y))
+        .sum::<f64>()
+        .sqrt()
+}
+
+/// A truncating sweep is only optimal when the sites it has not reached yet
+/// are orthonormal. This pins that property: on a two-site product there is a
+/// single bond, so the best rank-`k` MPO is exactly the best rank-`k` matrix
+/// approximation of the dense matricization, and the compressed contraction
+/// must attain it.
+///
+/// Without the right-canonicalization pass in `compress_mpo` the sweep
+/// truncates against the raw gauge of site 1 and keeps the wrong subspace, so
+/// this assertion fails.
+#[test]
+fn compression_at_a_binding_rank_cap_attains_the_optimal_truncation() {
+    use tensor4all_tensorbackend::svd_backend;
+
+    let mpo_a = random_mpo(&[1, 3, 1], 2, 2, SEED, |x: f64| x);
+    let mpo_b = random_mpo(&[1, 3, 1], 2, 2, SEED ^ 0xFF, |x: f64| x);
+
+    let exact = contract_naive(&mpo_a, &mpo_b, None).unwrap();
+    let (exact_dense, shape) = exact.fulltensor();
+    assert_eq!(shape, vec![2, 2, 2, 2]);
+
+    // Column-major reshape to (site 0 pair) x (site 1 pair): the matricization
+    // at the only bond of the two-site train.
+    let matrix = tenferro_tensor::TypedTensor::from_vec_col_major(vec![4, 4], exact_dense.clone());
+    let svd = svd_backend(&matrix).unwrap();
+    let sigma = svd.s.host_data().to_vec();
+    let keep = 2;
+    let optimal_error = sigma[keep..].iter().map(|s| s * s).sum::<f64>().sqrt();
+    assert!(
+        optimal_error > 1e-3,
+        "the rank cap must actually bind for this test to mean anything, \
+         discarded weight was {optimal_error:e}"
+    );
+
+    let options = ContractionOptions {
+        tolerance: 0.0,
+        max_bond_dim: keep,
+        factorize_method: FactorizeMethod::SVD,
+    };
+    let truncated = contract_naive(&mpo_a, &mpo_b, Some(options)).unwrap();
+    assert_eq!(truncated.rank(), keep);
+
+    let (truncated_dense, _) = truncated.fulltensor();
+    let achieved_error = frobenius_distance(&exact_dense, &truncated_dense);
+    assert!(
+        achieved_error <= optimal_error * (1.0 + 1e-9),
+        "compression is not optimal at the rank cap: achieved {achieved_error:e}, \
+         best possible {optimal_error:e}"
+    );
 }

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
@@ -6,6 +6,7 @@
 use crate::einsum_helper::{einsum_tensors, typed_tensor_reshape, EinsumScalar};
 
 use super::contraction::ContractionOptions;
+use super::environment::mpo_helper_error;
 use super::error::{MPOError, Result};
 use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
@@ -106,17 +107,17 @@ where
         // which is two bond dimensions worse than the pairwise route and was
         // the dominant cost of this function.
         let ra = einsum_tensors("nab,askc->nbskc", &[&remainder, a.as_inner()])
-            .map_err(|err| zipup_error("Failed to contract remainder with MPO A", err))?;
+            .map_err(|err| mpo_helper_error("Failed to contract remainder with MPO A", err))?;
         let c = einsum_tensors("nbskc,bktd->nstcd", &[&ra, b.as_inner()])
-            .map_err(|err| zipup_error("Failed to contract remainder with MPO B", err))?;
+            .map_err(|err| mpo_helper_error("Failed to contract remainder with MPO B", err))?;
 
         if i == n - 1 {
             // Last site: the trailing bonds are both 1, so this is a reshape.
             let last = typed_tensor_reshape(&c, &[c_new_link, c_s1, c_s2, 1])
-                .map_err(|err| zipup_error("Failed to reshape final zip-up site", err))?;
+                .map_err(|err| mpo_helper_error("Failed to reshape final zip-up site", err))?;
             result_tensors.push(
                 Tensor4::from_tenferro(last)
-                    .map_err(|err| zipup_error("Final zip-up site has invalid rank", err))?,
+                    .map_err(|err| mpo_helper_error("Final zip-up site has invalid rank", err))?,
             );
             continue;
         }
@@ -127,7 +128,7 @@ where
         let rows = c_new_link * c_s1 * c_s2;
         let cols = c_right_a * c_right_b;
         let c_mat = typed_tensor_reshape(&c, &[rows, cols])
-            .map_err(|err| zipup_error("Failed to reshape zip-up site", err))?;
+            .map_err(|err| mpo_helper_error("Failed to reshape zip-up site", err))?;
         let c_mat: Matrix2<T> = Matrix2::from_tenferro_unchecked(c_mat);
 
         let fact_result = factorize(&c_mat, &factorize_opts)?;
@@ -137,26 +138,20 @@ where
             fact_result.left.as_inner(),
             &[c_new_link, c_s1, c_s2, new_bond_dim],
         )
-        .map_err(|err| zipup_error("Failed to reshape zip-up left factor", err))?;
+        .map_err(|err| mpo_helper_error("Failed to reshape zip-up left factor", err))?;
         result_tensors.push(
             Tensor4::from_tenferro(site)
-                .map_err(|err| zipup_error("Zip-up site has invalid rank", err))?,
+                .map_err(|err| mpo_helper_error("Zip-up site has invalid rank", err))?,
         );
 
         remainder = typed_tensor_reshape(
             fact_result.right.as_inner(),
             &[new_bond_dim, c_right_a, c_right_b],
         )
-        .map_err(|err| zipup_error("Failed to reshape zip-up right factor", err))?;
+        .map_err(|err| mpo_helper_error("Failed to reshape zip-up right factor", err))?;
     }
 
     Ok(MPO::from_tensors_unchecked(result_tensors))
-}
-
-fn zipup_error(context: &str, err: impl std::fmt::Display) -> MPOError {
-    MPOError::InvalidOperation {
-        message: format!("{context}: {err}"),
-    }
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
@@ -3,12 +3,15 @@
 //! Contracts two MPOs with on-the-fly compression at each step.
 //! This is more memory-efficient than naive contraction followed by compression.
 
+use crate::einsum_helper::{einsum_tensors, typed_tensor_reshape, EinsumScalar};
+
 use super::contraction::ContractionOptions;
 use super::error::{MPOError, Result};
 use super::factorize::{factorize, FactorizeOptions, SVDScalar};
 use super::mpo::MPO;
-use super::types::{tensor4_zeros, Tensor4, Tensor4Ops};
-use super::{matrix2_zeros, Matrix2};
+use super::types::{Tensor4, Tensor4Ops};
+use super::Matrix2;
+use tenferro_tensor::TypedTensor;
 
 /// Perform zip-up contraction of two MPOs
 ///
@@ -33,7 +36,7 @@ use super::{matrix2_zeros, Matrix2};
 ///
 /// # Returns
 /// The contracted and compressed MPO C
-pub fn contract_zipup<T: SVDScalar>(
+pub fn contract_zipup<T: SVDScalar + EinsumScalar>(
     mpo_a: &MPO<T>,
     mpo_b: &MPO<T>,
     options: &ContractionOptions,
@@ -67,12 +70,10 @@ where
         }
     }
 
-    // Remainder tensor: R[new_link, link_a, link_b]
-    // Start with 1x1x1 identity
-    let mut r_left_dim = 1usize;
-    let mut r_a_dim = 1usize;
-    let mut r_b_dim = 1usize;
-    let mut r_data: Vec<T> = vec![T::one()];
+    // Remainder tensor R[new_link, link_a, link_b], starting as the 1x1x1
+    // scalar one.
+    let mut remainder: TypedTensor<T> =
+        TypedTensor::from_vec_col_major(vec![1, 1, 1], vec![T::one()]);
 
     let mut result_tensors: Vec<Tensor4<T>> = Vec::with_capacity(n);
 
@@ -88,115 +89,74 @@ where
         let a = mpo_a.site_tensor(i);
         let b = mpo_b.site_tensor(i);
 
-        let s1_a = a.site_dim_1();
-        let s2_a = a.site_dim_2(); // shared with s1_b
-        let s2_b = b.site_dim_2();
-        let right_a = a.right_dim();
-        let right_b = b.right_dim();
+        let c_s1 = a.site_dim_1();
+        let c_s2 = b.site_dim_2();
+        let c_right_a = a.right_dim();
+        let c_right_b = b.right_dim();
+        let c_new_link = remainder.shape()[0];
 
-        // Contract R with A and B:
-        // C[new_link, s1_a, s2_b, right_a, right_b]
-        // = sum_{link_a, link_b, k} R[new_link, link_a, link_b]
-        //   * A[link_a, s1_a, k, right_a] * B[link_b, k, s2_b, right_b]
-
-        let c_new_link = r_left_dim;
-        let c_s1 = s1_a;
-        let c_s2 = s2_b;
-        let c_right_a = right_a;
-        let c_right_b = right_b;
-
-        // C as a 5D array, but we'll store it flat
-        // Shape: (c_new_link * c_s1 * c_s2) x (c_right_a * c_right_b)
-        let rows = c_new_link * c_s1 * c_s2;
-        let cols = c_right_a * c_right_b;
-        let mut c_mat: Matrix2<T> = matrix2_zeros(rows, cols);
-
-        for ln in 0..r_left_dim {
-            for la in 0..r_a_dim {
-                for lb in 0..r_b_dim {
-                    let r_idx = (ln * r_a_dim + la) * r_b_dim + lb;
-                    let r_val = r_data[r_idx];
-                    for s1 in 0..c_s1 {
-                        for s2 in 0..c_s2 {
-                            for k in 0..s2_a {
-                                for ra in 0..c_right_a {
-                                    for rb in 0..c_right_b {
-                                        let row = (ln * c_s1 + s1) * c_s2 + s2;
-                                        let col = ra * c_right_b + rb;
-                                        c_mat[[row, col]] = c_mat[[row, col]]
-                                            + r_val
-                                                * *a.get4(la, s1, k, ra)
-                                                * *b.get4(lb, k, s2, rb);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // Contract R with A and then with B:
+        //   C[new_link, s1, s2, right_a, right_b]
+        //   = sum_{link_a, link_b, k} R[new_link, link_a, link_b]
+        //     * A[link_a, s1, k, right_a] * B[link_b, k, s2, right_b]
+        //
+        // The two contractions are done pairwise on purpose. Evaluating the
+        // three-operand sum directly costs
+        // O(new_link * link_a * link_b * s1 * s2 * k * right_a * right_b),
+        // which is two bond dimensions worse than the pairwise route and was
+        // the dominant cost of this function.
+        let ra = einsum_tensors("nab,askc->nbskc", &[&remainder, a.as_inner()])
+            .map_err(|err| zipup_error("Failed to contract remainder with MPO A", err))?;
+        let c = einsum_tensors("nbskc,bktd->nstcd", &[&ra, b.as_inner()])
+            .map_err(|err| zipup_error("Failed to contract remainder with MPO B", err))?;
 
         if i == n - 1 {
-            // Last site: just reshape and store
-            // Result should have right_dim = 1
-            let mut result_tensor = tensor4_zeros(c_new_link, c_s1, c_s2, 1);
-            for ln in 0..c_new_link {
-                for s1 in 0..c_s1 {
-                    for s2 in 0..c_s2 {
-                        let row = (ln * c_s1 + s1) * c_s2 + s2;
-                        // Sum over all right indices (should be 1x1)
-                        let val = c_mat[[row, 0]];
-                        result_tensor.set4(ln, s1, s2, 0, val);
-                    }
-                }
-            }
-            result_tensors.push(result_tensor);
-        } else {
-            // Factorize C into left and right parts
-            let fact_result = factorize(&c_mat, &factorize_opts)?;
-            let new_bond_dim = fact_result.rank.max(1);
-            let left_rows = fact_result.left.dim(0);
-            let left_cols = fact_result.left.dim(1);
-            let right_rows = fact_result.right.dim(0);
-            let right_cols = fact_result.right.dim(1);
-
-            // Store left factor as site tensor: (c_new_link, c_s1, c_s2, new_bond_dim)
-            let mut result_tensor = tensor4_zeros(c_new_link, c_s1, c_s2, new_bond_dim);
-            for ln in 0..c_new_link {
-                for s1 in 0..c_s1 {
-                    for s2 in 0..c_s2 {
-                        for r in 0..new_bond_dim {
-                            let row = (ln * c_s1 + s1) * c_s2 + s2;
-                            if row < left_rows && r < left_cols {
-                                result_tensor.set4(ln, s1, s2, r, fact_result.left[[row, r]]);
-                            }
-                        }
-                    }
-                }
-            }
-            result_tensors.push(result_tensor);
-
-            // Update R tensor for next iteration: R[new_bond_dim, right_a, right_b]
-            r_left_dim = new_bond_dim;
-            r_a_dim = c_right_a;
-            r_b_dim = c_right_b;
-            r_data = vec![T::zero(); r_left_dim * r_a_dim * r_b_dim];
-
-            for l in 0..new_bond_dim {
-                for ra in 0..c_right_a {
-                    for rb in 0..c_right_b {
-                        let col = ra * c_right_b + rb;
-                        let r_idx = (l * r_a_dim + ra) * r_b_dim + rb;
-                        if l < right_rows && col < right_cols {
-                            r_data[r_idx] = fact_result.right[[l, col]];
-                        }
-                    }
-                }
-            }
+            // Last site: the trailing bonds are both 1, so this is a reshape.
+            let last = typed_tensor_reshape(&c, &[c_new_link, c_s1, c_s2, 1])
+                .map_err(|err| zipup_error("Failed to reshape final zip-up site", err))?;
+            result_tensors.push(
+                Tensor4::from_tenferro(last)
+                    .map_err(|err| zipup_error("Final zip-up site has invalid rank", err))?,
+            );
+            continue;
         }
+
+        // Column-major data of `(new_link, s1, s2, right_a, right_b)` groups
+        // the leading three and the trailing two axes contiguously, so both
+        // reshapes below are pure metadata changes.
+        let rows = c_new_link * c_s1 * c_s2;
+        let cols = c_right_a * c_right_b;
+        let c_mat = typed_tensor_reshape(&c, &[rows, cols])
+            .map_err(|err| zipup_error("Failed to reshape zip-up site", err))?;
+        let c_mat: Matrix2<T> = Matrix2::from_tenferro_unchecked(c_mat);
+
+        let fact_result = factorize(&c_mat, &factorize_opts)?;
+        let new_bond_dim = fact_result.rank;
+
+        let site = typed_tensor_reshape(
+            fact_result.left.as_inner(),
+            &[c_new_link, c_s1, c_s2, new_bond_dim],
+        )
+        .map_err(|err| zipup_error("Failed to reshape zip-up left factor", err))?;
+        result_tensors.push(
+            Tensor4::from_tenferro(site)
+                .map_err(|err| zipup_error("Zip-up site has invalid rank", err))?,
+        );
+
+        remainder = typed_tensor_reshape(
+            fact_result.right.as_inner(),
+            &[new_bond_dim, c_right_a, c_right_b],
+        )
+        .map_err(|err| zipup_error("Failed to reshape zip-up right factor", err))?;
     }
 
     Ok(MPO::from_tensors_unchecked(result_tensors))
+}
+
+fn zipup_error(context: &str, err: impl std::fmt::Display) -> MPOError {
+    MPOError::InvalidOperation {
+        message: format!("{context}: {err}"),
+    }
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup/tests/mod.rs
@@ -55,3 +55,41 @@ fn test_contract_zipup_compresses() {
     // Bond dimension should be limited
     assert!(result.rank() <= 2);
 }
+
+/// Without truncation the zip-up pass must reproduce the exact product, which
+/// pins the index conventions of the two pairwise contractions and of the
+/// reshapes around the local factorization.
+#[test]
+fn test_contract_zipup_untruncated_matches_naive() {
+    use crate::mpo::contract_naive;
+    use crate::mpo::test_support::random_mpo;
+
+    let mpo_a = random_mpo(&[1, 3, 4, 1], 2, 3, 0x1234_5678_9ABC_DEF0, |x: f64| x);
+    let mpo_b = random_mpo(&[1, 2, 5, 1], 3, 2, 0x0FED_CBA9_8765_4321, |x: f64| x);
+
+    let options = ContractionOptions {
+        tolerance: 0.0,
+        max_bond_dim: usize::MAX,
+        factorize_method: FactorizeMethod::SVD,
+    };
+
+    let zipped = contract_zipup(&mpo_a, &mpo_b, &options).unwrap();
+    let exact = contract_naive(&mpo_a, &mpo_b, None).unwrap();
+
+    let (zipped_dense, zipped_shape) = zipped.fulltensor();
+    let (exact_dense, exact_shape) = exact.fulltensor();
+    assert_eq!(zipped_shape, exact_shape);
+    assert_eq!(zipped_shape, vec![2, 2, 2, 2, 2, 2]);
+
+    let max_diff = zipped_dense
+        .iter()
+        .zip(exact_dense.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0_f64, f64::max);
+    let scale = exact_dense.iter().fold(0.0_f64, |m, x| m.max(x.abs()));
+    assert!(
+        max_diff < 1e-10 * scale,
+        "zip-up deviates from the exact product: max abs difference {max_diff:e} \
+         against scale {scale:e}"
+    );
+}

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup/tests/mod.rs
@@ -93,3 +93,51 @@ fn test_contract_zipup_untruncated_matches_naive() {
          against scale {scale:e}"
     );
 }
+
+#[test]
+fn test_contract_zipup_length_mismatch() {
+    let mpo_a = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+    let mpo_b = MPO::<f64>::constant(&[(2, 2)], 1.0);
+
+    let err = contract_zipup(&mpo_a, &mpo_b, &ContractionOptions::default()).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::mpo::MPOError::LengthMismatch {
+                expected: 2,
+                got: 1
+            }
+        ),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_contract_zipup_shared_dimension_mismatch() {
+    // A's second site index is 3 but B's first site index is 2, so the shared
+    // index does not line up at site 0.
+    let mpo_a = MPO::<f64>::constant(&[(2, 3)], 1.0);
+    let mpo_b = MPO::<f64>::constant(&[(2, 2)], 1.0);
+
+    let err = contract_zipup(&mpo_a, &mpo_b, &ContractionOptions::default()).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::mpo::MPOError::SharedDimensionMismatch {
+                site: 0,
+                dim_a: 3,
+                dim_b: 2
+            }
+        ),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn test_contract_zipup_empty() {
+    let mpo_a = MPO::<f64>::from_tensors_unchecked(Vec::new());
+    let mpo_b = MPO::<f64>::from_tensors_unchecked(Vec::new());
+
+    let result = contract_zipup(&mpo_a, &mpo_b, &ContractionOptions::default()).unwrap();
+    assert!(result.is_empty());
+}

--- a/crates/tensor4all-simplett/src/mpo/contraction.rs
+++ b/crates/tensor4all-simplett/src/mpo/contraction.rs
@@ -15,7 +15,13 @@ use super::Matrix2;
 /// Options for contraction operations
 #[derive(Debug, Clone)]
 pub struct ContractionOptions {
-    /// Tolerance for truncation
+    /// Relative truncation tolerance forwarded to
+    /// [`FactorizeOptions::tolerance`](super::factorize::FactorizeOptions::tolerance).
+    ///
+    /// Singular values smaller than `tolerance * sigma_max` are discarded at
+    /// each bond, where `sigma_max` is the largest singular value of that
+    /// bond's matrix. The threshold is invariant under a global rescaling of
+    /// the operators being contracted.
     pub tolerance: f64,
     /// Maximum bond dimension after contraction
     pub max_bond_dim: usize,

--- a/crates/tensor4all-simplett/src/mpo/environment.rs
+++ b/crates/tensor4all-simplett/src/mpo/environment.rs
@@ -11,7 +11,9 @@ use super::mpo::MPO;
 use super::types::{Tensor4, Tensor4Ops};
 use super::{matrix2_zeros, Matrix2};
 
-fn mpo_helper_error(context: &str, err: impl std::fmt::Display) -> MPOError {
+/// Wrap a helper-layer error (einsum, reshape, backend linear algebra) into an
+/// `MPOError` with the caller's context preserved for the C API and bindings.
+pub(crate) fn mpo_helper_error(context: &str, err: impl std::fmt::Display) -> MPOError {
     MPOError::InvalidOperation {
         message: format!("{context}: {err}"),
     }

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -29,7 +29,16 @@ pub enum FactorizeMethod {
 pub struct FactorizeOptions {
     /// Factorization method to use
     pub method: FactorizeMethod,
-    /// Tolerance for truncation
+    /// Relative truncation tolerance.
+    ///
+    /// Singular values (or pivots) smaller than `tolerance * sigma_max` are
+    /// discarded, where `sigma_max` is the largest singular value (or pivot)
+    /// of the matrix being factorized. The threshold is therefore invariant
+    /// under a global rescaling of the input, matching
+    /// [`crate::CompressionOptions::tolerance`] and
+    /// `tensor4all_core::SvdTruncationPolicy::new`.
+    ///
+    /// Smaller values preserve more accuracy but produce larger ranks.
     pub tolerance: f64,
     /// Maximum rank (bond dimension) after factorization
     pub max_rank: usize,
@@ -194,18 +203,35 @@ fn factorize_svd<T: SVDScalar>(
         total_weight += sv * sv;
     }
 
-    // Find rank by keeping singular values above tolerance
+    // Truncation is relative to the largest singular value, so the retained
+    // rank does not change when the input matrix is globally rescaled. An
+    // absolute cutoff would keep near-noise singular values for large-norm
+    // inputs and over-truncate small-norm ones.
+    // `svd_backend` returns singular values in non-increasing order, so the
+    // first entry is the largest; fall back to a scan to stay robust.
+    let s_max = singular_values
+        .iter()
+        .take(min_dim)
+        .map(|&sv| T::linalg_real_to_f64(sv))
+        .fold(0.0_f64, f64::max);
+
+    // Find rank by keeping singular values above the relative cutoff.
+    // A zero matrix (or an empty spectrum) has no meaningful reference scale;
+    // it falls through to the rank-1 floor below.
     let mut kept_weight: f64 = 0.0;
-    for &singular_value in singular_values.iter().take(min_dim) {
-        if rank >= options.max_rank {
-            break;
+    if s_max > 0.0 {
+        let cutoff = options.tolerance * s_max;
+        for &singular_value in singular_values.iter().take(min_dim) {
+            if rank >= options.max_rank {
+                break;
+            }
+            let sv = T::linalg_real_to_f64(singular_value);
+            if sv < cutoff {
+                break;
+            }
+            kept_weight += sv * sv;
+            rank += 1;
         }
-        let sv = T::linalg_real_to_f64(singular_value);
-        if sv < options.tolerance {
-            break;
-        }
-        kept_weight += sv * sv;
-        rank += 1;
     }
 
     // Ensure at least rank 1
@@ -278,6 +304,10 @@ fn factorize_rsvd<T: SVDScalar>(
 ///
 /// This function requires the tensor4all_tcicore::Scalar trait.
 /// Use this directly when you need LU-based factorization.
+///
+/// [`FactorizeOptions::tolerance`] is passed as `RrLUOptions::rel_tol` with
+/// `abs_tol` set to zero, so the cutoff is relative to the largest pivot,
+/// matching the SVD path.
 pub fn factorize_lu<T>(
     matrix: &Matrix2<T>,
     options: &FactorizeOptions,

--- a/crates/tensor4all-simplett/src/mpo/factorize/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize/tests/mod.rs
@@ -88,6 +88,82 @@ fn test_factorize_with_truncation() {
     assert!(result.rank <= 2);
 }
 
+/// Build a matrix with a geometrically decaying spectrum, scaled by `scale`.
+///
+/// Singular values are `scale * 1.0`, `scale * 1e-3`, `scale * 1e-6`,
+/// `scale * 1e-9`, `scale * 1e-12` up to orthogonal factors, so a relative
+/// tolerance of `1e-7` must keep exactly the first three.
+fn decaying_spectrum_matrix(scale: f64) -> Matrix2<f64> {
+    let n = 5;
+    let sigma = [1.0, 1e-3, 1e-6, 1e-9, 1e-12];
+
+    // Orthogonal factors from a discrete sine transform, so the constructed
+    // matrix is dense but its spectrum is exactly `scale * sigma`.
+    let basis = |i: usize, k: usize| -> f64 {
+        (2.0 / (n as f64 + 1.0)).sqrt()
+            * (std::f64::consts::PI * ((i + 1) * (k + 1)) as f64 / (n as f64 + 1.0)).sin()
+    };
+
+    let mut matrix: Matrix2<f64> = matrix2_zeros(n, n);
+    for i in 0..n {
+        for j in 0..n {
+            let mut value = 0.0;
+            for (k, &s) in sigma.iter().enumerate() {
+                value += basis(i, k) * scale * s * basis(k, j);
+            }
+            matrix[[i, j]] = value;
+        }
+    }
+    matrix
+}
+
+#[test]
+fn test_factorize_svd_truncation_is_scale_invariant() {
+    let options = FactorizeOptions {
+        method: FactorizeMethod::SVD,
+        tolerance: 1e-7,
+        max_rank: 10,
+        left_orthogonal: true,
+        ..Default::default()
+    };
+
+    let unscaled = factorize(&decaying_spectrum_matrix(1.0), &options).unwrap();
+    assert_eq!(
+        unscaled.rank, 3,
+        "relative tolerance 1e-7 should keep sigma >= 1e-7 * sigma_max"
+    );
+
+    // With an absolute cutoff the scaled matrix would keep extra near-noise
+    // singular values (1e6 * 1e-9 and 1e6 * 1e-12 both exceed 1e-7).
+    for scale in [1e6, 1e-6] {
+        let scaled = factorize(&decaying_spectrum_matrix(scale), &options).unwrap();
+        assert_eq!(
+            scaled.rank, unscaled.rank,
+            "rank must not depend on the overall scale {scale} of the matrix"
+        );
+    }
+}
+
+#[test]
+fn test_factorize_svd_zero_matrix_returns_rank_one() {
+    let matrix: Matrix2<f64> = matrix2_zeros(3, 4);
+    let options = FactorizeOptions {
+        method: FactorizeMethod::SVD,
+        tolerance: 1e-10,
+        ..Default::default()
+    };
+
+    let result = factorize(&matrix, &options).unwrap();
+    assert_eq!(result.rank, 1);
+    assert_eq!(result.discarded, 0.0);
+    for i in 0..3 {
+        for j in 0..4 {
+            let value = result.left[[i, 0]] * result.right[[0, j]];
+            assert!(value.abs() < 1e-15, "zero matrix reconstructed as {value}");
+        }
+    }
+}
+
 #[test]
 fn test_factorize_svd_complex64() {
     use num_complex::Complex64;

--- a/crates/tensor4all-simplett/src/mpo/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mod.rs
@@ -43,6 +43,7 @@ pub(crate) fn matrix2_zeros<T: crate::traits::TTScalar + Default>(
     crate::tensor::Tensor::from_elem([rows, cols], T::default())
 }
 
+pub(crate) mod canonical;
 pub mod contract_fit;
 pub mod contract_naive;
 pub mod contract_zipup;
@@ -55,6 +56,8 @@ pub mod inverse_mpo;
 #[allow(clippy::module_inception)]
 pub mod mpo;
 pub mod site_mpo;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod tt_contraction;
 pub mod types;
 pub mod vidal_mpo;

--- a/crates/tensor4all-simplett/src/mpo/test_support.rs
+++ b/crates/tensor4all-simplett/src/mpo/test_support.rs
@@ -1,0 +1,44 @@
+//! Shared fixtures for the MPO unit tests.
+
+use super::mpo::MPO;
+use super::types::tensor4_from_data;
+use crate::einsum_helper::EinsumScalar;
+use crate::mpo::factorize::SVDScalar;
+
+/// Deterministic pseudo-random MPO with the given bond dimensions.
+///
+/// `bonds` lists the bond dimensions including the two trivial boundaries, so
+/// `[1, 3, 1]` builds a two-site MPO. The site tensors are filled from a linear
+/// congruential sequence seeded by `seed`, which makes the MPO generic: no site
+/// tensor is orthogonal in either direction, which is exactly what the
+/// canonicalization and truncation tests need.
+pub(crate) fn random_mpo<T>(
+    bonds: &[usize],
+    s1: usize,
+    s2: usize,
+    seed: u64,
+    from_f64: impl Fn(f64) -> T,
+) -> MPO<T>
+where
+    T: SVDScalar + EinsumScalar,
+{
+    let mut state = seed;
+    let mut next = || {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        ((state >> 33) as f64) / ((1u64 << 31) as f64) - 0.5
+    };
+
+    let tensors = bonds
+        .windows(2)
+        .map(|w| {
+            let (left, right) = (w[0], w[1]);
+            let data: Vec<T> = (0..left * s1 * s2 * right)
+                .map(|_| from_f64(next()))
+                .collect();
+            tensor4_from_data(data, left, s1, s2, right).expect("valid site tensor shape")
+        })
+        .collect();
+    MPO::from_tensors_unchecked(tensors)
+}

--- a/docs/worklogs/2026-08-05-simplett-mpo-truncation-and-zipup.md
+++ b/docs/worklogs/2026-08-05-simplett-mpo-truncation-and-zipup.md
@@ -1,0 +1,135 @@
+# simplett MPO truncation semantics, zip-up cost, and compression optimality
+
+## Summary
+
+Three defects in `crates/tensor4all-simplett/src/mpo/` were found while
+building the public benchmark repository `tensor4all/tensor4all-benchmark`,
+on its 2D quantics Gaussian mixture MPO times MPO case. They are independent
+but they all show up on the same measurement, so they are fixed together.
+
+1. `factorize_svd` compared raw singular values against `options.tolerance`,
+   an unnormalized absolute cutoff, unlike every other truncation surface in
+   the repository.
+2. `contract_zipup` evaluated a three-operand tensor contraction as one
+   eight-deep scalar loop, which costs two extra bond-dimension factors.
+3. `compress_mpo` ran a truncating left-to-right sweep with no prior
+   canonicalization, so each local SVD truncated against a non-orthonormal
+   right environment and kept the wrong subspace.
+
+## Code and documents read
+
+- `REPOSITORY_RULES.md`, `AGENTS.md`, and the shared rules in
+  `tensor4all-agent-rules` (`common/repository.md`, `rust/numerical.md`).
+- `crates/tensor4all-simplett/src/mpo/`: `factorize.rs`, `contract_zipup.rs`,
+  `contract_naive.rs`, `contract_fit.rs`, `contraction.rs`, `environment.rs`,
+  `types.rs`, `mpo.rs`.
+- `crates/tensor4all-simplett/src/compression.rs` and
+  `crates/tensor4all-core/src/truncation.rs` plus
+  `crates/tensor4all-core/src/defaults/svd.rs`, as the two existing
+  definitions of what a truncation tolerance means here.
+- `crates/tensor4all-tensorbackend/src/backend.rs` for `svd_backend` and
+  `qr_backend`.
+
+## Decisions
+
+### Relative truncation is the house semantics
+
+`CompressionOptions::tolerance` documents "Singular values (or pivots) smaller
+than `tolerance * sigma_max` are discarded", and
+`SvdTruncationPolicy::new` defaults to `ThresholdScale::Relative`, which
+`compute_retained_rank` implements against the largest measured value.
+`factorize_svd` was the outlier, so it was changed rather than the other two.
+`factorize_lu` already forwards `tolerance` as `RrLUOptions::rel_tol` with
+`abs_tol` at zero, so it was already relative and is left alone; a doc comment
+now records that.
+
+The zero-matrix case is handled explicitly instead of falling out of the
+comparison: with `sigma_max == 0` a relative cutoff is zero, which would retain
+the full spectrum of zeros, so the sweep is skipped and the existing rank-one
+floor applies.
+
+### Pairwise contraction in zip-up, not a single scalar loop
+
+The zip-up step needs
+
+```
+C[n, s1, s2, ra, rb] = sum_{la, lb, k} R[n, la, lb] A[la, s1, k, ra] B[lb, k, s2, rb]
+```
+
+Evaluating that sum directly is `O(n * la * lb * s1 * s2 * k * ra * rb)`. Two
+pairwise `einsum` calls through `tensor4all-tensorbackend` cost
+`O(n * la * lb * s1 * k * ra)` plus `O(n * s1 * ra * lb * k * s2 * rb)`, which
+drops two bond-dimension factors and routes the arithmetic through GEMM instead
+of a bounds-checked scalar loop. On the benchmark instance at bond dimension
+77 that is a 900x wall-time reduction.
+
+The matrix reshapes around the local factorization are now plain column-major
+reshapes of the tenferro tensor rather than index-by-index copies. The row and
+column orderings differ from the previous hand-written ones by a permutation,
+which is immaterial because the same convention is used to pack and unpack.
+
+### Canonicalize before truncating
+
+Alternatives considered for `compress_mpo`:
+
+- Left-to-right QR pass, then a truncating right-to-left sweep. Rejected: on a
+  naive MPO product both boundaries carry un-reduced Kronecker bonds, and the
+  left-to-right QR then factorizes matrices of shape `(left * 4) x right` with
+  `left` at its largest, which was measured to be the expensive direction.
+- Right-to-left QR pass, then the existing truncating left-to-right sweep.
+  Chosen: the QR pass shrinks each bond to its exact rank as it moves left, so
+  every later factorization is smaller than the one before it.
+
+`right_canonicalize` is rank preserving. It only replaces a bond by the exact
+rank of its matricization, so it is safe to run ahead of any truncation policy
+and cannot itself lose accuracy.
+
+Canonicalizing the two inputs of `contract_zipup` was also prototyped, since
+that is the textbook prescription for zip-up. It was measured and reverted:
+the error moved from 2.5e-5 to 1.3e-5 on one instance and not at all on
+another, which is inside the instance-to-instance spread of the benchmark, and
+it costs two full MPO clones. Zip-up stays a heuristic whose accuracy matches
+the treetn engine's zip-up exactly, which is the right reference point.
+
+## Verification
+
+`cargo nextest run --release --workspace`: 2520 passed.
+`cargo test --doc --release --workspace`: passed.
+`cargo clippy --workspace --all-targets -- -D warnings`: clean.
+
+New tests, each verified to fail with its fix reverted:
+
+- `factorize::tests::test_factorize_svd_truncation_is_scale_invariant`
+- `contract_naive::tests::compression_at_a_binding_rank_cap_attains_the_optimal_truncation`
+- `contract_zipup::tests::test_contract_zipup_untruncated_matches_naive`
+  (guards the new index conventions rather than a fix)
+
+End-to-end, `tensor4all/tensor4all-benchmark`'s `mpo_mpo_quantics` at
+`BENCH_RS=6,8 BENCH_RUNS=1`, with the benchmark's tensor4all dependencies
+pointed at this branch. The `zipup_treetn` and `fit_treetn` arms run the treetn
+engine and are unaffected by this change; they are the control.
+
+| r | arm | before | after |
+|---|-----|--------|-------|
+| 6 | naive | 0.620 s, 1.05e-4, chi 53 | 0.027 s, 8.64e-9, chi 48 |
+| 6 | zipup_simplett | 2.528 s, 1.05e-4, chi 53 | 0.015 s, 1.05e-4, chi 53 |
+| 6 | zipup_treetn | 0.019 s, 1.05e-4, chi 53 | 0.020 s, 1.05e-4, chi 53 |
+| 6 | fit_treetn | 0.051 s, 8.64e-9, chi 48 | 0.039 s, 8.64e-9, chi 48 |
+| 8 | naive | 25.584 s, 2.01e-5, chi 76 | 0.590 s, 1.71e-8, chi 59 |
+| 8 | zipup_simplett | 103.075 s, 2.01e-5, chi 76 | 0.119 s, 2.28e-5, chi 77 |
+| 8 | zipup_treetn | 0.142 s, 2.01e-5, chi 76 | 0.138 s, 2.28e-5, chi 77 |
+| 8 | fit_treetn | 0.231 s, 1.71e-8, chi 59 | 0.226 s, 1.71e-8, chi 59 |
+
+The input rank of the generated instance is 76 or 77 depending on the run, so
+the r = 8 error figures move by a few percent between runs. Comparisons are
+only meaningful within a row against the treetn control in the same run.
+
+## Remaining risks
+
+- `contract_zipup` still truncates against a non-orthonormal environment, so
+  its accuracy remains that of a plain zip-up. It is now exactly on par with
+  the treetn zip-up arm, and the variational `contract_fit` path is the answer
+  for callers who need better. Improving zip-up itself is out of scope here.
+- Callers who relied on `FactorizeOptions::tolerance` being an absolute cutoff
+  on a large-norm operator will now see smaller ranks. That is the intended
+  correction, but it is a behavior change on a public field.


### PR DESCRIPTION
## Summary

Three independent defects in `crates/tensor4all-simplett/src/mpo/`, all found
while building the public benchmark repository
[`tensor4all/tensor4all-benchmark`](https://github.com/tensor4all/tensor4all-benchmark)
on its 2D quantics Gaussian mixture MPO times MPO case.

## 1. `factorize_svd` used an absolute truncation cutoff

Three definitions of "tolerance" coexisted in this repository:

- `crates/tensor4all-simplett/src/mpo/factorize.rs:204` (before this PR):
  `if sv < options.tolerance { break; }`, a raw singular value against the
  tolerance, so an unnormalized absolute cutoff.
- `crates/tensor4all-simplett/src/compression.rs:138`: "Singular values (or
  pivots) smaller than `tolerance * sigma_max` are discarded."
- `crates/tensor4all-core/src/truncation.rs:153`: `SvdTruncationPolicy::new`
  sets `scale: ThresholdScale::Relative`, which
  `crates/tensor4all-core/src/defaults/svd.rs:162` implements as
  `value / reference > policy.threshold` with `reference` the largest measured
  singular value.

`factorize_svd` was the outlier. Because singular values scale with the norm of
the operator, and a quantics grid carries a norm growing like `2^r`, a fixed
`1e-8` absolute cutoff kept near-noise directions on any large-norm input.
`fn factorize_svd` already computed `total_weight` and the discarded weight but
never used either for the cutoff.

The cutoff is now `sv >= tolerance * sigma_max`. `max_rank`, the kept and
discarded weight reporting, and the rank one floor are unchanged. A zero
spectrum is handled explicitly rather than falling out of the comparison: a
relative cutoff of zero would otherwise retain the full spectrum of zeros.

`factorize_lu` is **not** changed. It already passes `options.tolerance` as
`RrLUOptions::rel_tol` with `abs_tol: 0.0`, so it was relative all along; a doc
comment now records that so the next reader does not have to re-derive it.

## 2. `contract_zipup` evaluated a three-operand contraction as one scalar loop

The zip-up step needs

```
C[n, s1, s2, ra, rb] = sum_{la, lb, k} R[n, la, lb] A[la, s1, k, ra] B[lb, k, s2, rb]
```

`contract_zipup.rs:114` ran that as a single eight-deep scalar loop over
`n, la, lb, s1, s2, k, ra, rb`, costing two extra bond-dimension factors on top
of the pairwise route, with bounds-checked indexing rather than GEMM. At bond
dimension 77 that is roughly `2e10` scalar fused multiply-adds per site.

It is now two pairwise `einsum` calls through `tensor4all-tensorbackend`, and
the matrix reshapes around the local factorization are plain column-major
reshapes of the tenferro tensor instead of index-by-index copies.

## 3. `compress_mpo` truncated without canonicalizing first

`contract_naive.rs:110` swept left to right applying SVD truncation at each
bond, with nothing having established a gauge beforehand. The sites to the left
of the active bond become left-orthogonal as the sweep proceeds, but the sites
to the right keep whatever gauge the naive Kronecker product left them in. A
local SVD only minimizes the global error against an orthonormal environment,
so the sweep discarded the wrong subspace.

A new `crates/tensor4all-simplett/src/mpo/canonical.rs` adds a rank-preserving
right-to-left QR sweep, `right_canonicalize`, which `compress_mpo` now runs
before truncating. It never discards a bond for accuracy reasons: it only
replaces each bond by the exact rank of its matricization, so it is safe ahead
of any truncation policy and shrinks the later factorizations as it goes.

Canonicalizing the two **inputs** of `contract_zipup` was also prototyped, that
being the textbook prescription for zip-up, and reverted after measurement: the
error moved from 2.5e-5 to 1.3e-5 on one instance and not at all on another,
inside the instance-to-instance spread, for the price of two full MPO clones.
Zip-up remains a heuristic, and its accuracy already matches the treetn engine's
zip-up exactly.

## Measured evidence

`mpo_mpo_quantics` from tensor4all-benchmark, `BENCH_RS=6,8 BENCH_RUNS=1
BENCH_WARMUPS=0`, with the benchmark's tensor4all dependencies pointed at this
branch. Each cell is wall time, relative error against the analytic Gaussian
integral, and output bond dimension. The output budget is capped at the input
rank, identically for every arm. `zipup_treetn` and `fit_treetn` run the treetn
engine, are untouched by this PR, and serve as the control.

| r | arm | before | after |
|---|-----|--------|-------|
| 6 | naive | 0.620 s, 1.05e-4, chi 53 | **0.027 s, 8.64e-9, chi 48** |
| 6 | zipup_simplett | 2.528 s, 1.05e-4, chi 53 | **0.015 s, 1.05e-4, chi 53** |
| 6 | zipup_treetn (control) | 0.019 s, 1.05e-4, chi 53 | 0.020 s, 1.05e-4, chi 53 |
| 6 | fit_treetn (control) | 0.051 s, 8.64e-9, chi 48 | 0.039 s, 8.64e-9, chi 48 |
| 8 | naive | 25.584 s, 2.01e-5, chi 76 | **0.590 s, 1.71e-8, chi 59** |
| 8 | zipup_simplett | 103.075 s, 2.01e-5, chi 76 | **0.119 s, 2.28e-5, chi 77** |
| 8 | zipup_treetn (control) | 0.142 s, 2.01e-5, chi 76 | 0.138 s, 2.28e-5, chi 77 |
| 8 | fit_treetn (control) | 0.231 s, 1.71e-8, chi 59 | 0.226 s, 1.71e-8, chi 59 |

Reading the r = 8 row: zip-up goes from 103 s to 0.119 s, a factor of 870, and
from 4x slower than its own naive arm to 5x faster, at the accuracy of the
treetn zip-up control. Naive goes from 25.6 s to 0.59 s and its error drops by
three orders of magnitude to 1.71e-8 at chi 59, which is exactly what the
treetn variational fit arm reaches on the same instance, at 2.4x less wall time
than that arm. Before this PR both simplett arms sat at 2e-5 while an accurate
chi 59 approximation demonstrably existed.

The generated instance has input rank 76 or 77 depending on the run, so the
r = 8 error figures move by a few percent between runs. Only within-run
comparisons against the control are meaningful.

## Tests

Each new test was verified to fail with its corresponding fix reverted.

- `factorize::tests::test_factorize_svd_truncation_is_scale_invariant`: a
  matrix with a geometrically decaying spectrum truncates to the same rank at
  scale 1, 1e6, and 1e-6. Under the old absolute cutoff the 1e6 case kept two
  extra near-noise directions.
- `factorize::tests::test_factorize_svd_zero_matrix_returns_rank_one`: covers
  the new `sigma_max == 0` branch.
- `contract_naive::tests::compression_at_a_binding_rank_cap_attains_the_optimal_truncation`:
  on a two-site product there is a single bond, so the best rank-k MPO is
  exactly the best rank-k matrix approximation of the dense matricization. The
  test computes that optimum from the dense SVD and asserts the compressed
  contraction attains it. Before the canonicalization pass it achieved 2.27e-2
  against a best possible 1.94e-2.
- `contract_zipup::tests::test_contract_zipup_untruncated_matches_naive`: pins
  the index conventions of the two new pairwise contractions and the reshapes
  around the local factorization against the exact product.
- `canonical::tests`: four tests covering operator preservation and
  right-orthogonality for `f64` and `Complex64`, exact-rank bond reduction, and
  the short-MPO no-op path.

No existing test needed adapting. The existing `factorize` tests use tolerances
tight enough that the relative cutoff retains the same ranks, and they passed
unchanged.

Full verification: `cargo nextest run --release --workspace` 2520 passed,
`cargo test --doc --release --workspace` passed,
`cargo clippy --workspace --all-targets -- -D warnings` clean,
`scripts/repository-rules-review.py --worktree --dry-run` passes with no
findings.

## Behavior change for callers

`FactorizeOptions::tolerance`, and `ContractionOptions::tolerance` and
`FitOptions::tolerance` which forward to it, change meaning from an absolute to
a relative cutoff. Doc comments on all three now state the relative semantics.
Callers who were relying on the absolute cutoff will see smaller ranks on
large-norm operators and larger ranks on small-norm ones. That is the intended
correction and it brings these fields in line with `CompressionOptions` and
`SvdTruncationPolicy`, but it is a semantic change on public fields, so it is
called out here rather than buried.

A work log is included at
`docs/worklogs/2026-08-05-simplett-mpo-truncation-and-zipup.md` with the
alternatives considered for the canonicalization direction and the rejected
zip-up input canonicalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
