### PR TITLE
treetci: add missing convergence check to optimize's sweep loop

### DIFF
--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -119,8 +119,10 @@ impl Default for TreeTciOptions {
 /// let options = TreeTciOptions { tolerance: 1e-10, max_iter: 5, ..Default::default() };
 /// let (ranks, errors) = optimize_default(&mut state, evaluate, &options).unwrap();
 ///
-/// assert_eq!(ranks.len(), 5); // one entry per iteration
-/// assert_eq!(errors.len(), 5);
+/// // One entry per sweep actually run; the loop stops early once converged,
+/// // so this may be less than max_iter (5).
+/// assert!(!ranks.is_empty() && ranks.len() <= 5);
+/// assert_eq!(ranks.len(), errors.len());
 /// assert!(errors.last().copied().unwrap_or(1.0) < 1e-8);
 /// ```
 pub fn optimize_default<T, F>(
@@ -173,8 +175,10 @@ where
 ///     &mut state, evaluate, &options, &proposer,
 /// ).unwrap();
 ///
-/// assert_eq!(ranks.len(), 3);
-/// assert_eq!(errors.len(), 3);
+/// // One entry per sweep actually run; the loop stops early once converged,
+/// // so this may be less than max_iter (3).
+/// assert!(!ranks.is_empty() && ranks.len() <= 3);
+/// assert_eq!(ranks.len(), errors.len());
 /// ```
 pub fn optimize_with_proposer<T, F, P>(
     state: &mut TreeTCI2<T>,
@@ -200,6 +204,14 @@ where
     let mut errors = Vec::new();
     let visitor = AllEdges;
     const INNER_EDGE_PASSES: usize = 2;
+    // Matches `tensor4all-tensorci`'s `TensorCI2Options::ncheck_history` default
+    // (see `convergence_criterion` in tensorci2.rs, itself a port of Julia's
+    // `convergencecriterion`). A single below-tolerance sweep is not reliable:
+    // the bond-error estimate can dip before the pivot search has actually
+    // stabilized. TreeTCI2 has no per-sweep "new global pivots" count to check
+    // (unlike TensorCI2), so this only checks error-below-tolerance + rank
+    // stability over the trailing window, not the third TensorCI2 criterion.
+    const NCHECK_HISTORY: usize = 3;
 
     for _iter in 0..options.max_iter {
         for _pass in 0..INNER_EDGE_PASSES {
@@ -230,6 +242,31 @@ where
             state.max_bond_error()
         };
         errors.push(normalized_error);
+
+        // BUGFIX (local, not upstream): the sweep loop previously always ran
+        // to `max_iter` with no convergence check, wasting O(max_iter /
+        // actual_sweeps_needed) work on already-converged problems. See
+        // ~/tensor4all-rust/treetci-optimize-no-early-stop-bug.md.
+        //
+        // Mirrors `TreeTCI.jl`'s `convergencecriterion` (as locally patched
+        // for the scale-mismatch bug on branch `local-fix-convergence`,
+        // commit 06563dd): error-below-tolerance + rank-stable over the
+        // trailing window, OR the rank has saturated at `max_bond_dim` for
+        // the whole window (further sweeps cannot reduce the error once the
+        // bond dimension is capped, so waiting for it to also cross
+        // `tolerance` would just burn the remaining `max_iter` sweeps).
+        if errors.len() >= NCHECK_HISTORY {
+            let n = errors.len();
+            let last_errors = &errors[n - NCHECK_HISTORY..];
+            let last_ranks = &ranks[n - NCHECK_HISTORY..];
+            let errors_converged = last_errors.iter().all(|&e| e < options.tolerance);
+            let rank_stable = last_ranks.iter().min().copied().unwrap_or(0)
+                == last_ranks.last().copied().unwrap_or(0);
+            let bond_dim_saturated = last_ranks.iter().all(|&r| r >= options.max_bond_dim);
+            if (errors_converged && rank_stable) || bond_dim_saturated {
+                break;
+            }
+        }
     }
 
     Ok((ranks, errors))

--- a/crates/tensor4all-treetci/src/optimize/tests.rs
+++ b/crates/tensor4all-treetci/src/optimize/tests.rs
@@ -44,8 +44,18 @@ fn optimize_default_converges_on_two_site_identity() {
     assert_eq!(tci.max_rank(), 2);
 }
 
+// Previously named `optimize_default_runs_all_iterations_like_upstream_tree_tci`
+// and asserted `ranks.len() == 4` / `errors.len() == 4` (max_iter), pinning
+// parity with upstream TreeTCI.jl's sweep loop, which has no early-convergence
+// break at all. That upstream behavior is a known bug: see
+// ~/gw/CombTCI/COMPATIBILITY.md's `treetci-fix-convergence-criterion.patch`
+// (a *different*, scale-mismatch bug in the same convergence-check area,
+// found and locally patched by the same user, not yet upstreamed) and
+// ~/tensor4all-rust/treetci-optimize-no-early-stop-bug.md for this crate's
+// specific issue (no break at all, not just a wrong-scale comparison).
+// Renamed and flipped to assert the fixed (early-stopping) behavior instead.
 #[test]
-fn optimize_default_runs_all_iterations_like_upstream_tree_tci() {
+fn optimize_default_stops_early_once_converged() {
     let mut tci = TreeTCI2::<f64>::new(vec![2, 2], two_site_graph()).unwrap();
     tci.add_global_pivots(&[vec![0, 0]]).unwrap();
 
@@ -71,6 +81,50 @@ fn optimize_default_runs_all_iterations_like_upstream_tree_tci() {
     )
     .unwrap();
 
-    assert_eq!(ranks.len(), 4);
-    assert_eq!(errors.len(), 4);
+    // The 2x2 identity function is exactly rank 2 and converges on the first
+    // sweep; the loop must not keep going through the remaining max_iter-1
+    // sweeps once the error is already below tolerance.
+    assert!(ranks.len() < 4);
+    assert_eq!(ranks.len(), errors.len());
+    assert_eq!(ranks.last().copied(), Some(2));
+}
+
+// Mirrors `TreeTCI.jl`'s `convergencecriterion` third disjunct
+// (`all(lastranks .>= maxbonddim)`, branch `local-fix-convergence`, commit
+// 06563dd): once the rank has saturated at `max_bond_dim` for the trailing
+// window, further sweeps cannot lower the error, so the loop should stop
+// even though the error never crosses `tolerance`.
+#[test]
+fn optimize_default_stops_early_when_bond_dim_saturated() {
+    let mut tci = TreeTCI2::<f64>::new(vec![3, 3], two_site_graph()).unwrap();
+    tci.add_global_pivots(&[vec![0, 0]]).unwrap();
+
+    let batch_eval = |batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> {
+        let mut values = Vec::with_capacity(batch.n_points());
+        for point in 0..batch.n_points() {
+            let i = batch.get(0, point).unwrap();
+            let j = batch.get(1, point).unwrap();
+            values.push(if i == j { 1.0 } else { 0.0 });
+        }
+        Ok(values)
+    };
+
+    let (ranks, errors) = optimize_default(
+        &mut tci,
+        batch_eval,
+        &TreeTciOptions {
+            tolerance: 1e-12,
+            max_iter: 10,
+            max_bond_dim: 1,
+            normalize_error: true,
+        },
+    )
+    .unwrap();
+
+    // Rank-3 identity capped at max_bond_dim = 1 can never reach the 1e-12
+    // tolerance; without the bond-dim-saturation criterion this would run
+    // all 10 sweeps.
+    assert!(ranks.len() < 10);
+    assert!(ranks.iter().all(|&r| r <= 1));
+    assert!(errors.last().copied().unwrap_or(0.0) > 1e-12);
 }


### PR DESCRIPTION
## Summary

`optimize_with_proposer`'s sweep loop had no convergence check at all: it
always ran exactly `max_iter` sweeps regardless of whether the error had
already converged, wasting significant work on already-converged problems
(see the earlier discussion in this repo — a 15-site chain smoke test took
24.8s instead of ~2.2s because it always swept all 50 iterations even though
the error dropped below tolerance after a handful of sweeps). There was even
a test pinning this down as intentional
(`optimize_default_runs_all_iterations_like_upstream_tree_tci`, asserting
`ranks.len() == max_iter`).

This PR adds the missing check, mirroring `TreeTCI.jl`'s
`convergencecriterion` (local branch `local-fix-convergence`, commit
`06563dd`, itself patching a separate scale-mismatch bug in the same
function — not yet upstreamed):

```julia
return (
    all(last(errors, ncheckhistory) .< tolerance) &&
    minimum(lastranks) == lastranks[end]
) || all(lastranks .>= maxbonddim)
```

Ported as two disjuncts:
1. Error below `tolerance` **and** rank stable over a trailing window of
   `ncheck_history = 3` sweeps (matching `TensorCI2Options::ncheck_history`'s
   default). A single below-tolerance sweep isn't reliable on its own — the
   bond-error estimate can dip before the pivot search has actually
   stabilized.
2. Rank saturated at `max_bond_dim` for the whole trailing window — once the
   bond dimension is capped, further sweeps cannot reduce the error, so
   waiting for it to also cross `tolerance` would just burn the rest of
   `max_iter`.

The old test asserting the "always run all `max_iter` sweeps" behavior is
renamed/flipped to assert the fixed (early-stopping) behavior, and a new
test covers the `max_bond_dim`-saturation branch. Two doctests updated
accordingly (`ranks.len()` is no longer pinned to exactly `max_iter`).

## Test plan

- [x] `cargo nextest run --release -p tensor4all-treetci` — including new
      test `optimize_default_stops_early_when_bond_dim_saturated`: a rank-3
      identity capped at `max_bond_dim = 1` never reaches `tolerance`, and
      without criterion 2 above would run the full `max_iter = 10` sweeps;
      now stops once the rank has been saturated at 1 for `ncheck_history`
      sweeps
- [x] `cargo test --doc --release -p tensor4all-treetci`
- [x] `cargo clippy -p tensor4all-treetci --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check` (clean for the changed files)

**Not requesting auto-merge** — this changes core convergence semantics for
`TreeTCI2::optimize`, so flagging for a maintainer look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)