### PR TITLE
build: drop full debug info from default profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,26 @@ authors = ["tensor4all collaboration"]
 license = "MIT"
 repository = "https://github.com/tensor4all/tensor4all-rs"
 
+# Keep default profiles free of full debug info (shared rule: build-artifact
+# hygiene). Line tables preserve readable RUST_BACKTRACE file:line output.
+# For full debugger info, build with --profile release-debug, or override one
+# command with CARGO_PROFILE_DEV_DEBUG=2 / CARGO_PROFILE_TEST_DEBUG=2.
+[profile.dev]
+debug = 0
+debug-assertions = true
+overflow-checks = true
+
+[profile.test]
+debug = 0
+debug-assertions = true
+overflow-checks = true
+
 [profile.release]
-debug = true  # Include debug info in release builds (enables detailed RUST_BACKTRACE)
+debug = "line-tables-only"
+
+[profile.release-debug]
+inherits = "release"
+debug = true
 
 [workspace.dependencies]
 num-complex = "0.4"


### PR DESCRIPTION
## Summary

Local `target/` measured 14 GB (release 12 GB, debug 2.7 GB) because `[profile.release] debug = true` combines with the repository policy of running normal verification in release mode, so every test binary and dependency rlib carries full debug info. Among the 12 GB were 7 orphaned feature/rev variants of `libtenferro_cpu` alone (596 MB).

Changes to the workspace `Cargo.toml`:

- `[profile.release] debug = "line-tables-only"`: keeps readable `RUST_BACKTRACE` file:line output (the stated reason for the previous `debug = true`) at a fraction of the size.
- New `[profile.release-debug]` inheriting release with `debug = true`, for sessions that attach a debugger: `cargo build --profile release-debug`.
- `[profile.dev]` / `[profile.test]` pin `debug = 0` while keeping `debug-assertions` and `overflow-checks`, matching tenferro-rs practice. One-command override: `CARGO_PROFILE_DEV_DEBUG=2`.

Follows the shared build-artifact hygiene rule proposed in tensor4all/tensor4all-agent-rules#9. Stale-artifact pruning and CI-profile work (strip, release overflow-checks) are tracked in #566 and not part of this change.

## Verification

- `cargo tree --workspace` and `cargo metadata` parse the new profiles (profile schema is validated at manifest load).
- Build-config only; no source changes. CI exercises the full matrix on the new settings.

Note: first build after merge is a full rebuild (profile flags change); reclaiming existing bloat needs a one-time `cargo clean --release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)