### PR TITLE
Reduce CI build artifact size

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -51,19 +51,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run rustdoc tests
-        run: cargo test --doc --release --workspace -j 8
+        run: cargo test --doc --profile ci --workspace -j 8
 
       - name: Run mdBook tests
-        run: ./scripts/test-mdbook.sh
+        run: TENSOR4ALL_CARGO_PROFILE=ci ./scripts/test-mdbook.sh
+
+      - name: Report Cargo artifact size
+        if: always()
+        run: |
+          if [[ -d target ]]; then
+            du -sh target
+          else
+            echo "target directory was not created"
+          fi
 
   # testジョブ全体を無効化
   # test:
   #   name: Test
   #   runs-on: ubuntu-22.04
-  #   env:
-  #     # CI release tests don't need DWARF debug info, and disabling it keeps
-  #     # target artifacts small enough to avoid runner disk exhaustion on cache misses.
-  #     CARGO_PROFILE_RELEASE_DEBUG: 0
   #   steps:
   #     - uses: actions/checkout@v4
 
@@ -80,10 +85,19 @@ jobs:
   #     # tensor4all-hdf5 is kept out of nextest because its dlopen-based tests
   #     # fail under nextest's per-process execution model.
   #     - name: Run tests (non-HDF5)
-  #       run: cargo nextest run --release --workspace --exclude tensor4all-hdf5
+  #       run: cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5
 
   #     - name: Run HDF5 tests
-  #       run: cargo test --release -p tensor4all-hdf5
+  #       run: cargo test --profile ci -p tensor4all-hdf5
+
+  #     - name: Report Cargo artifact size
+  #       if: always()
+  #       run: |
+  #         if [[ -d target ]]; then
+  #           du -sh target
+  #         else
+  #           echo "target directory was not created"
+  #         fi
 
   scripts:
     name: Maintenance scripts

--- a/.github/workflows/CI_rs_selfhost.yml
+++ b/.github/workflows/CI_rs_selfhost.yml
@@ -17,10 +17,6 @@ jobs:
     name: CI (fork PR / github-hosted)
     if: github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-22.04
-    env:
-      # CI release tests don't need DWARF debug info, and disabling it keeps
-      # target artifacts small enough to avoid runner disk exhaustion on cache misses.
-      CARGO_PROFILE_RELEASE_DEBUG: 0
     steps:
       - uses: actions/checkout@v6
 
@@ -37,10 +33,19 @@ jobs:
       # tensor4all-hdf5 is kept out of nextest because its dlopen-based tests
       # fail under nextest's per-process execution model.
       - name: Run tests (non-HDF5)
-        run: cargo nextest run --release --workspace --exclude tensor4all-hdf5
+        run: cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5
 
       - name: Run HDF5 tests
-        run: cargo test --release -p tensor4all-hdf5
+        run: cargo test --profile ci -p tensor4all-hdf5
+
+      - name: Report Cargo artifact size
+        if: always()
+        run: |
+          if [[ -d target ]]; then
+            du -sh target
+          else
+            echo "target directory was not created"
+          fi
 
   # PRs from the same repository: run heavy CI on self-hosted runner
   ci-maintainer:
@@ -50,7 +55,6 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/../target
-      CARGO_PROFILE_RELEASE_DEBUG: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,7 +69,16 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Run tests (non-HDF5)
-        run: cargo nextest run --release --workspace --exclude tensor4all-hdf5
+        run: cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5
 
       - name: Run HDF5 tests
-        run: cargo test --release -p tensor4all-hdf5
+        run: cargo test --profile ci -p tensor4all-hdf5
+
+      - name: Report Cargo artifact size
+        if: always()
+        run: |
+          if [[ -d "$CARGO_TARGET_DIR" ]]; then
+            du -sh "$CARGO_TARGET_DIR"
+          else
+            echo "target directory was not created"
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,13 @@ debug = 0
 inherits = "release"
 debug = true
 
+# Comprehensive CI keeps release-mode semantics while avoiding artifacts that
+# are not reused after the job and symbols that are not needed to run checks.
+[profile.ci]
+inherits = "release"
+incremental = false
+strip = "symbols"
+
 [workspace.dependencies]
 num-complex = "0.4"
 num-traits = "0.2"

--- a/docs/design/build-profiles.md
+++ b/docs/design/build-profiles.md
@@ -39,11 +39,35 @@ Set `RUST_BACKTRACE=1` or `full` when running the Tensor4all.jl/C API caller. Ke
 
 One-command dev/test debugger overrides remain available through `CARGO_PROFILE_DEV_DEBUG=2` and `CARGO_PROFILE_TEST_DEBUG=2`.
 
+Comprehensive CI uses release optimization without retaining incremental state
+or linker symbols:
+
+```toml
+[profile.ci]
+inherits = "release"
+incremental = false
+strip = "symbols"
+```
+
+Run release-equivalent CI tests locally with `cargo test --profile ci` or
+`cargo nextest run --cargo-profile ci`. Coverage remains on its
+instrumentation-owned profile and does not use `ci`.
+
 ## Rationale
 
 The repository normally runs tests, documentation examples, tutorials, and benchmarks in release mode. Full debuginfo or line tables are therefore multiplied across many independently linked test and example executables. A controlled full-workspace measurement found that changing ordinary release from line tables to `debug = 0` reduced allocated target output from 14,759,100,416 to 3,354,374,144 bytes (77.27%); see `docs/worklogs/2026-08-09-release-debug-info-reduction.md`.
 
 Most development does not debug Rust through Tensor4all.jl or the C API and does not benefit from this metadata. The named profile preserves the diagnostic capability without imposing its storage cost on every release build.
+
+## Artifact cleanup
+
+Profile changes prevent new oversized outputs but do not delete artifacts from
+older dependency revisions, feature sets, or profile settings. Inspect the
+workspace target with `du -sh target`. When stale output dominates and a cold
+rebuild is acceptable, remove only the relevant profile with, for example,
+`cargo clean --profile release`; use `cargo clean` when all historical variants
+should be discarded. Persistent self-hosted targets should be cleaned
+periodically based on available disk space rather than on every CI run.
 
 ## Compatibility and non-goals
 

--- a/docs/worklogs/2026-08-09-ci-artifact-reduction.md
+++ b/docs/worklogs/2026-08-09-ci-artifact-reduction.md
@@ -1,0 +1,68 @@
+# CI Build-Artifact Reduction
+
+## Session summary
+
+Extended the repository's debug-info reduction to CI. Comprehensive test and
+documentation jobs now use a release-based `ci` profile that disables
+incremental output and strips linker symbols. CI also reports target size so
+future dependency or target growth is visible.
+
+## Context reviewed
+
+- The build-artifact measurements and profile decision recorded in
+  `2026-08-09-release-debug-info-reduction.md`.
+- The supplied `strided-rs` build-artifact study.
+- Root Cargo profiles, hosted and self-hosted workflows, mdBook test plumbing,
+  and Cargo subprocess call sites.
+- Shared tensor4all repository, performance, Rust performance, and docs/test
+  rules.
+
+## Decisions
+
+- `profile.ci` inherits `release` because tensor4all-rs verification is required
+  to run with release semantics. It disables incremental compilation and strips
+  symbols, matching the lifecycle of comprehensive CI artifacts.
+- Coverage keeps its existing profile because instrumentation owns its artifact
+  requirements.
+- The mdBook helper accepts `TENSOR4ALL_CARGO_PROFILE`, allowing CI's probe and
+  rustdoc library search path to use the same profile without changing the
+  local release-mode default.
+- Persistent self-hosted targets are not cleaned on every run. Periodic
+  profile-specific or full cleanup is documented instead, preserving useful
+  dependency reuse.
+
+## Alternatives not selected
+
+- Inheriting `test` for `profile.ci` would lose the repository's required
+  release-mode test semantics.
+- Applying the CI profile to coverage could interfere with coverage-owned
+  compiler instrumentation.
+- Consolidating integration-test harnesses was not attempted: the supplied
+  study found a small gain relative to the loss of process isolation and
+  individually addressable test targets.
+- Nested Cargo environment defaults were not added because the repository has
+  no independent fixture workspace or trybuild-style Cargo invocation that
+  needs them today.
+- Adding an artifact-sweeping dependency was unnecessary for the initial
+  policy; explicit periodic Cargo cleanup has no new supply-chain or bootstrap
+  cost.
+
+## Verification
+
+Cargo metadata/profile parsing, workflow YAML, shell syntax, formatting, and the
+deterministic repository-rules review passed. The repository-rules review
+script's 89 self-tests also passed.
+
+A fresh-target comparison compiled the `xtask` test harness with four Cargo
+jobs, incremental compilation disabled, and no rustc wrapper. The ordinary
+release target occupied 64,752 KiB; `profile.ci` occupied 62,032 KiB, a 2,720
+KiB (4.20%) reduction. This small representative build validates that symbol
+stripping is active; it is not presented as a full-workspace estimate. Both
+temporary targets and the generated ignored lockfile were removed afterward.
+
+## Remaining risks
+
+Symbol stripping changes diagnostic richness for CI executables but not runtime
+semantics. The full-debug `release-debug` profile remains available for
+source-level debugging. Existing historical artifacts remain until explicitly
+cleaned.

--- a/scripts/test-mdbook.sh
+++ b/scripts/test-mdbook.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+cargo_profile="${TENSOR4ALL_CARGO_PROFILE:-release}"
+
 probe_log="$(mktemp)"
 rustdoc_wrapper_dir="$(mktemp -d)"
 trap 'rm -f "$probe_log"; rm -rf "$rustdoc_wrapper_dir"' EXIT
@@ -11,7 +13,7 @@ trap 'rm -f "$probe_log"; rm -rf "$rustdoc_wrapper_dir"' EXIT
 # Force a fresh book-tests rustc invocation so cargo prints the exact --extern
 # paths that its doctest harness resolves for the guide snippets.
 probe_metadata="mdbook_probe_$(date +%s%N)"
-cargo rustc -p book-tests --release --lib -vv -- -Cmetadata="$probe_metadata" >"$probe_log" 2>&1
+cargo rustc -p book-tests --profile "$cargo_profile" --lib -vv -- -Cmetadata="$probe_metadata" >"$probe_log" 2>&1
 
 rustc_line="$(grep -- '--crate-name book_tests' "$probe_log" | tail -n 1 || true)"
 if [[ -z "$rustc_line" ]]; then
@@ -48,4 +50,4 @@ real_rustdoc="$(rustup which rustdoc)"
 } > "$rustdoc_wrapper_dir/rustdoc"
 chmod +x "$rustdoc_wrapper_dir/rustdoc"
 
-PATH="$rustdoc_wrapper_dir:$PATH" mdbook test docs/book -L "$repo_root/target/release/deps" "$@"
+PATH="$rustdoc_wrapper_dir:$PATH" mdbook test docs/book -L "$repo_root/target/$cargo_profile/deps" "$@"


### PR DESCRIPTION
## Summary

- add a release-based `ci` Cargo profile with incremental compilation disabled and linker symbols stripped
- run comprehensive nextest, HDF5, rustdoc, and mdBook checks with the CI profile
- report Cargo target size in hosted and self-hosted CI
- document profile usage, cleanup guidance, measurements, and tradeoffs

## Why

The ordinary dev, test, and release profiles already omit debug information, which delivered the largest artifact reduction. CI still retained linker symbols and did not consistently use a dedicated profile, so this change removes additional CI-only output while preserving release-mode test semantics.

## Impact

Runtime behavior, optimization level, public APIs, ABI, feature selection, coverage instrumentation, and local release workflows are unchanged. CI backtraces contain less symbol detail; the existing `release-debug` profile remains available for source-level diagnostics.

## Validation

- `cargo fmt --all -- --check`
- Cargo metadata/profile parsing
- workflow YAML parsing
- `bash -n scripts/test-mdbook.sh`
- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run`
- `python3 scripts/test-repository-rules-review.py` (89 tests)
- fresh-target `xtask` compile comparison: 64,752 KiB release vs. 62,032 KiB CI (4.20% reduction)

The comparison targets and generated ignored lockfile were removed after measurement. A full workspace rebuild was intentionally not run locally because it would generate several GiB of artifacts; hosted CI owns the comprehensive run.