### PR TITLE
aci: stop the elementwise sweep once the rank saturates at max_bond_dim

### DIFF
--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -17,6 +17,15 @@ use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, TensorTrain};
 /// operator-output magnitude from the completed sweep, and the largest
 /// normalized value is used.
 ///
+/// Sweeping also stops once the solution rank has sat at
+/// [`AciOptions::max_bond_dim`] for [`AciOptions::min_iters`] consecutive
+/// sweeps. At the cap the sweep can no longer add pivots, so the tolerance can
+/// never be met and further sweeps only repeat full-rank work. A run that stops
+/// this way returns normally with a final entry of [`AciResult::errors`] above
+/// [`AciOptions::tolerance`]: under a binding `max_bond_dim` that outcome is by
+/// design, not a failure. Compare the last [`AciResult::ranks`] entry against
+/// `max_bond_dim` to tell a rank-limited run from a converged one.
+///
 /// For single-site tensor trains there are no bonds to sweep. In that case the
 /// operator is evaluated once over all site points, and the returned
 /// [`AciResult`] contains empty `ranks` and `errors` histories.
@@ -121,6 +130,10 @@ where
             options.min_iters,
             options.tolerance,
         ) {
+            break;
+        }
+
+        if rank_is_saturated(&ranks, options.min_iters, options.max_bond_dim) {
             break;
         }
     }
@@ -273,6 +286,34 @@ pub(crate) fn convergence_criterion_like_julia(
     !ranks[(iteration - min_iters)..iteration]
         .iter()
         .any(|&rank| rank > baseline)
+}
+
+/// Reports whether the solution rank has been pinned at `max_bond_dim` long
+/// enough that further sweeps cannot reduce the pivot error below tolerance.
+///
+/// Once the rank reaches the cap the tolerance branch of
+/// [`convergence_criterion_like_julia`] can never fire, because the sweep has no
+/// remaining freedom to add pivots. Without this exit a capped run burns every
+/// remaining sweep at full rank. The dwell of `min_iters` consecutive sweeps at
+/// the cap guards against stopping on the sweep where the cap is first reached,
+/// when pivot re-selection inside the fixed rank can still improve the error.
+///
+/// `min_iters == 0` disables the exit, matching
+/// [`convergence_criterion_like_julia`], and the default `max_bond_dim` of
+/// [`usize::MAX`] is unreachable, so unconstrained runs are unaffected.
+///
+/// This is the `all(lastranks .>= maxbonddim)` disjunct of the Julia
+/// `convergencecriterion` that [`convergence_criterion_like_julia`] otherwise
+/// ports, over the same trailing window. `tensor4all-treetci` gained the
+/// equivalent exit in its own sweep loop in #575.
+pub(crate) fn rank_is_saturated(ranks: &[usize], min_iters: usize, max_bond_dim: usize) -> bool {
+    if min_iters == 0 || ranks.len() < min_iters {
+        return false;
+    }
+
+    ranks[(ranks.len() - min_iters)..]
+        .iter()
+        .all(|&rank| rank >= max_bond_dim)
 }
 
 pub(crate) fn error_metric(

--- a/crates/tensor4all-aci/src/result.rs
+++ b/crates/tensor4all-aci/src/result.rs
@@ -45,5 +45,13 @@ pub struct AciResult<T: TTScalar> {
     ///
     /// Entries are stored in completed-sweep order and use the same scaling
     /// convention as [`AciOptions::tolerance`](crate::AciOptions::tolerance).
+    ///
+    /// The last entry is not guaranteed to be at or below the requested
+    /// tolerance. A run under a binding
+    /// [`AciOptions::max_bond_dim`](crate::AciOptions::max_bond_dim) stops once
+    /// the rank has sat at the cap, because the sweep can no longer add pivots
+    /// and the tolerance can never be met; such a run finishes above tolerance
+    /// by design. Compare the last [`ranks`](Self::ranks) entry against
+    /// `max_bond_dim` to tell a rank-limited run from a converged one.
     pub errors: Vec<f64>,
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -3,7 +3,8 @@ use crate::validation::{validate_inputs, validate_options};
 use crate::{
     elementwise,
     elementwise::{
-        convergence_criterion_like_julia, error_metric, max_error_metric, ranks_are_stable,
+        convergence_criterion_like_julia, error_metric, max_error_metric, rank_is_saturated,
+        ranks_are_stable,
     },
     elementwise_batched, initial_guess,
     random_tt::{
@@ -30,6 +31,40 @@ fn tensor_train_with_link_dims(site_dims: &[usize], link_dims: &[usize]) -> Tens
             let left_dim = if site == 0 { 1 } else { link_dims[site - 1] };
             let right_dim = link_dims.get(site).copied().unwrap_or(1);
             tensor3_zeros(left_dim, site_dim, right_dim)
+        })
+        .collect();
+    TensorTrain::new(cores).unwrap()
+}
+
+/// Builds a tensor train with the requested link dimensions and deterministic,
+/// value-dependent cores drawn from a small linear congruential generator.
+///
+/// Used where a genuinely high-rank pointwise product is needed;
+/// `tensor_train_with_link_dims` fills with zeros, whose product is degenerate.
+fn tensor_train_with_values(
+    site_dims: &[usize],
+    link_dims: &[usize],
+    seed: u64,
+) -> TensorTrain<f64> {
+    assert_eq!(link_dims.len(), site_dims.len().saturating_sub(1));
+    let mut state = seed | 1;
+    let mut next = move || {
+        state = state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1);
+        // Top bits carry the best-mixed randomness of an LCG.
+        (state >> 33) as f64 / (1u64 << 31) as f64 - 0.5
+    };
+    let cores = site_dims
+        .iter()
+        .enumerate()
+        .map(|(site, &site_dim)| {
+            let left_dim = if site == 0 { 1 } else { link_dims[site - 1] };
+            let right_dim = link_dims.get(site).copied().unwrap_or(1);
+            let data = (0..left_dim * site_dim * right_dim)
+                .map(|_| next())
+                .collect();
+            tensor3_from_data(data, left_dim, site_dim, right_dim).unwrap()
         })
         .collect();
     TensorTrain::new(cores).unwrap()
@@ -361,6 +396,69 @@ fn convergence_criterion_matches_julia_algorithm() {
         2,
         1.0e-10
     ));
+}
+
+#[test]
+fn rank_saturation_needs_a_full_dwell_at_the_cap() {
+    // Below the cap, or at the cap for fewer than min_iters sweeps, the exit
+    // must not fire.
+    assert!(!rank_is_saturated(&[4], 2, 4));
+    assert!(!rank_is_saturated(&[3, 4], 2, 4));
+    assert!(rank_is_saturated(&[3, 4, 4], 2, 4));
+    assert!(!rank_is_saturated(&[4, 4], 3, 4));
+    // The default cap is unreachable, so unconstrained runs never exit here.
+    assert!(!rank_is_saturated(&[4, 4], 2, usize::MAX));
+    // min_iters == 0 disables the exit, as it disables the tolerance criterion.
+    assert!(!rank_is_saturated(&[4, 4], 0, 4));
+}
+
+#[test]
+fn capped_elementwise_run_stops_once_rank_saturates() {
+    // Two value-dependent rank-4 trains whose pointwise product genuinely needs
+    // rank 16 in the interior, run against a cap of 4. The requested tolerance
+    // is therefore unreachable and the sweep must exit on rank saturation
+    // rather than burn all max_iters sweeps at the cap.
+    let site_dims = [2usize; 10];
+    let link_dims = [2usize, 4, 4, 4, 4, 4, 4, 4, 2];
+    let input_a = tensor_train_with_values(&site_dims, &link_dims, 12345);
+    let input_b = tensor_train_with_values(&site_dims, &link_dims, 98765);
+
+    let options = AciOptions::<f64> {
+        max_iters: 20,
+        min_iters: 2,
+        max_bond_dim: 4,
+        tolerance: 1e-10,
+        ..Default::default()
+    };
+
+    let result = elementwise_batched(multiply_batch, &[input_a, input_b], &options).unwrap();
+
+    // The cap is binding: the tolerance was never met, so without the
+    // rank-saturation exit this run would consume all 20 sweeps.
+    let last_error = *result.errors.last().unwrap();
+    assert!(
+        last_error > options.tolerance,
+        "cap is not binding, last error {last_error:e} already met the tolerance"
+    );
+    assert!(
+        result.ranks.len() <= options.min_iters + 2,
+        "expected an early exit, got {} sweeps with ranks {:?}",
+        result.ranks.len(),
+        result.ranks
+    );
+    assert!(result.ranks.len() < options.max_iters);
+    assert_eq!(
+        &result.ranks[(result.ranks.len() - options.min_iters)..],
+        &[options.max_bond_dim; 2],
+        "the exit must fire only after a full dwell at the cap, ranks {:?}",
+        result.ranks
+    );
+    assert_eq!(result.tensor_train.site_dims(), site_dims.to_vec());
+    assert!(result
+        .tensor_train
+        .link_dims()
+        .iter()
+        .all(|&dim| dim <= options.max_bond_dim));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`elementwise_batched` in `crates/tensor4all-aci/src/elementwise.rs` only exits its sweep loop through the tolerance branch of `convergence_criterion_like_julia`, which requires `errors.last() <= options.tolerance` before the rank-plateau check can apply. Once the solution rank reaches `options.max_bond_dim` the sweep has no remaining freedom to add pivots, so under a binding cap the tolerance can never be met. The loop then burns every remaining `max_iters` sweep at full rank doing nearly dead work.

Found while running tensor4all/tensor4all-benchmark case `elementwise_gauss2d_scaling`. At N=32 (`chi_in=116`, tolerance `1e-8`, `max_bond_dim=chi_in`) ACI reaches rank 116 on sweep 2 and then runs all 20 sweeps, per-sweep ranks `[112, 116, 116, ..., 116]`, with the pivot error metric flat near `2.1e-8`. Uncapped, the same problem converges in 3 sweeps. Same story at N=64.

## Fix

Break when the solution rank has stayed at `options.max_bond_dim` for `options.min_iters` consecutive sweeps, added as a separate `rank_is_saturated` check next to the existing criterion rather than folded into it, so the ported criterion keeps its shape.

Design notes:

- This is the `all(lastranks .>= maxbonddim)` disjunct of the Julia `convergencecriterion` that `convergence_criterion_like_julia` otherwise ports, evaluated over the same trailing window. `tensor4all-treetci` gained the equivalent exit in its own sweep loop in #575, so the two sweep loops now agree.
- The dwell of `min_iters` sweeps at the cap is deliberate. Breaking on the very sweep the cap is first hit would cut off pivot re-selection inside the now fixed rank, which can still lower the error; requiring the rank to sit at the cap for a full window keeps that opportunity.
- `min_iters == 0` disables the exit, matching how it disables the tolerance criterion.
- `max_bond_dim` defaults to `usize::MAX`, which is unreachable, so unconstrained runs take exactly the path they took before. Behavior for non-saturated runs is unchanged.

A capped run now returns normally with the last `AciResult::errors` entry above `tolerance`. Since that could be misread as a failure, both the `elementwise_batched` rustdoc and the `AciResult::errors` field doc now state that a binding `max_bond_dim` finishes above tolerance by design, and point callers at the last `ranks` entry to tell a rank-limited run from a converged one.

## Verification

End-to-end, benchmark `elementwise_gauss2d_scaling` with `BENCH_NS=8,16,32,64 BENCH_RUNS=1 BENCH_WARMUPS=0`, aci arm wall time:

| N | before | after | speedup |
|---|--------|-------|---------|
| 8 | 0.0434s | 0.0440s | 1.0x |
| 16 | 0.0781s | 0.0804s | 1.0x |
| 32 | 0.8066s | **0.0772s** | 10.4x |
| 64 | 1.7250s | **0.1522s** | 11.3x |

N=8 and N=16 do not hit the cap and are unchanged within run to run noise. Sampled relative errors stay at the same order (N=32: `1.04e-8` to `4.95e-9`; N=64: `2.04e-8` to `1.85e-8`), and the `zipup_treetn` and `fit_treetn` arms are unaffected. The `before` column was measured at the benchmark's current pin `7cfec22`, which is identical to `main` for `crates/tensor4all-aci` (`git log 7cfec22..main -- crates/tensor4all-aci` is empty).

Tests:

- New `capped_elementwise_run_stops_once_rank_saturates`: two value-dependent rank-4 trains whose pointwise product genuinely needs rank 16, run against `max_bond_dim: 4` with an unreachable `1e-10` tolerance. It asserts the cap is actually binding, that the run uses at most `min_iters + 2` sweeps, and that the trailing `ranks` entries equal the cap. On the unfixed loop it fails with `expected an early exit, got 20 sweeps with ranks [4, 4, ..., 4]`.
- New `rank_saturation_needs_a_full_dwell_at_the_cap` covers the dwell boundary, the unreachable default cap, and `min_iters == 0`.
- `cargo nextest run --release --workspace --exclude library-panic-audit`: 2718 passed. The excluded `library-panic-audit` tool tests fail on this machine independently of this branch, which touches nothing under `tools/`.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo doc -p tensor4all-aci --no-deps`, and `python3 scripts/repository-rules-review.py --base main --worktree --dry-run` (verdict: pass) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)