### PR TITLE
fix: pin left-factor index order by full index identity in FitUpdater::update

### DIFF
--- a/crates/tensor4all-core/src/index_like.rs
+++ b/crates/tensor4all-core/src/index_like.rs
@@ -257,6 +257,63 @@ pub trait IndexLike: Clone + Eq + Hash + Debug + Send + Sync + 'static {
         Self: Sized;
 }
 
+/// Sort indices by a deterministic comparator over `dim`, `plev`, `id`, then
+/// `Debug` representation.
+///
+/// The `plev` and `Debug` terms keep distinct indices that share the same ID —
+/// for example a same-ID pair differing by prime level or tags — in a pinned,
+/// insertion-order-independent relative order instead of leaving them to the
+/// stable sort's input order.
+///
+/// The comparator is a pure function of the index values, so the result never
+/// depends on insertion order as long as `Debug` is deterministic and
+/// distinguishes all identity-relevant fields. The concrete
+/// [`DynIndex`](crate::defaults::DynIndex) satisfies the determinism part: its
+/// derived `Debug` covers `id`, `dim`, `plev`, and `tags`, so two `DynIndex`
+/// values compare `Equal` only when every field matches. Note that `dim`
+/// participates in the sort even though `DynIndex`'s `Eq` deliberately ignores
+/// it (ITensors semantics: equality = id + plev + tags). Implementors whose
+/// `Debug` omits identity-relevant fields may still see `Equal` comparisons
+/// between distinct indices, in which case the stable sort preserves the input
+/// order for those ties.
+///
+/// # Arguments
+/// * `indices` - The slice of indices to reorder in place.
+///
+/// # Returns
+/// Nothing; `indices` is reordered in place.
+///
+/// # Panics
+/// Never panics; the comparator relies only on `IndexLike` accessors and
+/// `Debug` implementations.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{sort_indices_deterministic, DynIndex, IndexLike};
+///
+/// let s = DynIndex::new_dyn(2);
+/// let s_prime = s.prime(); // same ID, plev 1
+/// assert!(s.same_id(&s_prime));
+///
+/// // Insertion order (primed first) must not survive the sort.
+/// let mut indices = vec![s_prime.clone(), s.clone()];
+/// sort_indices_deterministic(&mut indices);
+/// assert_eq!(indices, vec![s, s_prime]);
+/// ```
+pub fn sort_indices_deterministic<I: IndexLike>(indices: &mut [I])
+where
+    I::Id: Ord,
+{
+    indices.sort_by(|left, right| {
+        left.dim()
+            .cmp(&right.dim())
+            .then_with(|| left.plev().cmp(&right.plev()))
+            .then_with(|| left.id().cmp(right.id()))
+            .then_with(|| format!("{left:?}").cmp(&format!("{right:?}")))
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -413,5 +470,47 @@ mod tests {
         let a = test_index(42, 3);
         assert!(a.has_id(&42));
         assert!(!a.has_id(&99));
+    }
+
+    #[test]
+    fn test_sort_indices_deterministic_pins_same_id_prime_pair() {
+        use crate::defaults::DynIndex;
+
+        let s = DynIndex::new_dyn(2);
+        let s_prime = s.prime();
+        assert!(s.same_id(&s_prime));
+        assert_ne!(s, s_prime);
+
+        // Primed index first (worst-case insertion order): the sort must pin
+        // unprimed before primed by full-index order (plev 0 < plev 1), not
+        // preserve insertion order.
+        let mut indices = vec![s_prime.clone(), s.clone()];
+        sort_indices_deterministic(&mut indices);
+        assert_eq!(indices, vec![s.clone(), s_prime.clone()]);
+
+        // Same canonical order regardless of input permutation.
+        let mut indices = vec![s.clone(), s_prime.clone()];
+        sort_indices_deterministic(&mut indices);
+        assert_eq!(indices, vec![s, s_prime]);
+    }
+
+    #[test]
+    fn test_sort_indices_deterministic_distinguishes_same_id_tag_pair() {
+        use crate::defaults::{DynId, DynIndex, TagSet};
+
+        let site = DynIndex::new_with_tags(DynId(42), 2, TagSet::from_tags(&["Site"]).unwrap());
+        let link = DynIndex::new_with_tags(DynId(42), 2, TagSet::from_tags(&["Link"]).unwrap());
+        assert!(site.same_id(&link));
+        assert_ne!(site, link);
+
+        // The Debug tiebreak must give one deterministic order, not leave the
+        // pair to insertion order.
+        let mut a = vec![link.clone(), site.clone()];
+        let mut b = vec![site.clone(), link.clone()];
+        sort_indices_deterministic(&mut a);
+        sort_indices_deterministic(&mut b);
+        assert_eq!(a, b);
+        assert!(a.contains(&site));
+        assert!(a.contains(&link));
     }
 }

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -48,7 +48,7 @@ pub mod defaults;
 pub use defaults::index;
 
 pub use defaults::{DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet};
-pub use index_like::{ConjState, IndexLike};
+pub use index_like::{sort_indices_deterministic, ConjState, IndexLike};
 
 /// Index operations (replacement, set operations, contraction preparation).
 pub mod index_ops;

--- a/crates/tensor4all-treetn/src/treetn/addition.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 
 use anyhow::{bail, Result};
 
-use tensor4all_core::{AnyScalar, IndexLike, TensorIndex, TensorLike};
+use tensor4all_core::{sort_indices_deterministic, AnyScalar, IndexLike, TensorIndex, TensorLike};
 
 use super::TreeTN;
 
@@ -42,13 +42,7 @@ where
         <T::Index as IndexLike>::Id: Ord,
     {
         let mut indices: Vec<_> = site_space.iter().cloned().collect();
-        indices.sort_by(|left, right| {
-            left.dim()
-                .cmp(&right.dim())
-                .then_with(|| left.plev().cmp(&right.plev()))
-                .then_with(|| left.id().cmp(right.id()))
-                .then_with(|| format!("{left:?}").cmp(&format!("{right:?}")))
-        });
+        sort_indices_deterministic(&mut indices);
         indices
     }
 
@@ -56,7 +50,8 @@ where
     ///
     /// The topology must match, and each corresponding node must carry the same
     /// number of site indices with the same dimensions. Site indices are paired
-    /// node-by-node after sorting by `(dim, id)` for deterministic matching.
+    /// node-by-node after sorting by [`sort_indices_deterministic`]
+    /// (`dim` → `plev` → `id` → `Debug` tiebreak) for matching.
     ///
     /// # Arguments
     /// * `template` - Reference TreeTN whose site index IDs should be adopted

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -34,8 +34,8 @@ use anyhow::Result;
 
 use tensor4all_core::{
     print_and_reset_contract_profile, print_and_reset_native_einsum_profile,
-    reset_contract_profile, reset_native_einsum_profile, Canonical, FactorizeAlg, FactorizeOptions,
-    FactorizeResult, IndexLike, SvdTruncationPolicy, TensorLike,
+    reset_contract_profile, reset_native_einsum_profile, sort_indices_deterministic, Canonical,
+    FactorizeAlg, FactorizeOptions, FactorizeResult, IndexLike, SvdTruncationPolicy, TensorLike,
 };
 
 use super::localupdate::{LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater};
@@ -791,7 +791,7 @@ where
             })
             .cloned()
             .collect();
-        left_inds.sort_by(|a, b| a.id().cmp(b.id()));
+        sort_indices_deterministic(&mut left_inds);
         if let Some(left_inds_started) = left_inds_started {
             with_fit_profile(|profile| {
                 profile.left_inds_time += left_inds_started.elapsed();

--- a/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
@@ -369,6 +369,90 @@ fn test_fit_updater_after_step_invalidates_cached_region() {
 }
 
 #[test]
+fn test_fit_updater_update_pins_same_id_prime_pair_leg_order() {
+    // Node A carries a same-ID primed pair (s, s.prime()) in its site space.
+    // Both survive the 2-site contraction as external legs, so `left_inds`
+    // contains two indices that compare equal by `.id()` alone. The left
+    // factor's leg order must follow the canonical full-index sort (unprimed
+    // before primed), not the contraction output order.
+    let s = DynIndex::new_dyn(2);
+    let s_prime = s.prime();
+    let t_a = DynIndex::new_dyn(2);
+    let t_b = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(3);
+
+    // The primed index appears first in the first contracted tensor, so the
+    // unsorted left_inds insertion order is [s', s] (the buggy stable sort
+    // preserves it; the full-index sort must pin [s, s']).
+    let a_u = TensorDynLen::from_dense(
+        vec![s_prime.clone(), bond.clone()],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    )
+    .unwrap();
+    let b_u = TensorDynLen::from_dense(
+        vec![s.clone(), bond.clone()],
+        vec![6.0, 5.0, 4.0, 3.0, 2.0, 1.0],
+    )
+    .unwrap();
+    let a_v = TensorDynLen::from_dense(
+        vec![bond.clone(), t_a.clone()],
+        vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+    )
+    .unwrap();
+    let b_v = TensorDynLen::from_dense(
+        vec![bond.clone(), t_b.clone()],
+        vec![0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+    )
+    .unwrap();
+
+    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![a_u, a_v],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![b_u, b_v],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+
+    // Full network C: node A's site space holds the same-ID primed pair.
+    let c_a = TensorDynLen::from_dense(
+        vec![s_prime.clone(), s.clone(), bond.clone()],
+        vec![1.0; 12],
+    )
+    .unwrap();
+    let c_b = TensorDynLen::from_dense(vec![bond.clone(), t_a.clone(), t_b.clone()], vec![1.0; 12])
+        .unwrap();
+    let full_treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+        vec![c_a, c_b],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+    let site_c_u = full_treetn.site_space(&"A".to_string()).unwrap();
+    assert!(site_c_u.contains(&s));
+    assert!(site_c_u.contains(&s_prime));
+
+    let mut updater = FitUpdater::new(tn_a, tn_b, None, None);
+    let step = LocalUpdateStep {
+        nodes: vec!["A".to_string(), "B".to_string()],
+        new_center: "B".to_string(),
+    };
+    let updated = updater
+        .update(full_treetn.clone(), &step, &full_treetn)
+        .unwrap();
+
+    let a_idx = updated.node_index(&"A".to_string()).unwrap();
+    let new_a_inds = updated.tensor(a_idx).unwrap().indices();
+    let pos_s = new_a_inds.iter().position(|i| i == &s).unwrap();
+    let pos_s_prime = new_a_inds.iter().position(|i| i == &s_prime).unwrap();
+    assert!(
+        pos_s < pos_s_prime,
+        "left factor must order unprimed before primed; got indices {new_a_inds:?}"
+    );
+}
+
+#[test]
 fn test_contract_fit_rejects_topology_mismatch() {
     let tn_a = make_two_node_treetn();
     let tn_b = make_single_node_treetn();


### PR DESCRIPTION
Closes #567

## Problem

`FitUpdater::update` sorted the left-factor index list with
`left_inds.sort_by(|a, b| a.id().cmp(b.id()))` (fit.rs:794). When two
distinct indices share the same `.id()` but differ by prime level, tags, or
other metadata (e.g. a same-ID primed pair `s`, `s.prime()`), the
comparator returns `Ordering::Equal` and the stable sort preserves insertion
order — which is derived from the contraction output order, not from index
identity. The factorization's left-factor leg order is therefore unspecified,
violating REPOSITORY_RULES.md Index Identity Semantics (full index equality
required for identity decisions).

## Fix

- New public `tensor4all_core::sort_indices_deterministic` in
  `crates/tensor4all-core/src/index_like.rs`: deterministic comparator over
  `dim` → `plev` → `id` → `Debug` tiebreak (the full-index comparator
  pattern already used in `addition.rs`, now shared).
- `fit.rs`: replace the ID-only sort with the shared helper.
- `addition.rs`: `sorted_site_space` dedupes to the same helper; stale
  `(dim, id)` doc corrected.
- Root re-export in `tensor4all-core` lib.rs.

## Regression tests (REPOSITORY_RULES.md 358-360)

- Core unit tests: same-ID prime pair pinned to canonical order under both
  insertion permutations; same-ID tag pair sorted deterministically.
- Fit test: two-node fit update whose node A site space holds a same-ID
  primed pair; asserts the left factor orders unprimed before primed.
  Verified to FAIL with the old ID-only sort and PASS with the fix.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release -p tensor4all-core -p tensor4all-treetn` (1322 passed)
- `cargo test --doc -p tensor4all-core -p tensor4all-treetn` (doctests pass)

Reviewed by reviewer-gpt (design + 3 review rounds, no remaining findings).