### PR TITLE
Resolve related issue #583/#578/#580/#573/#551/#588 acceptance criteria

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,7 @@ fn test_op_c64() { test_op_generic::<Complex64>(); }
 
 ## C API & Language Bindings
 
-See `docs/CAPI_DESIGN.md` for C API patterns. Bindings: [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl) (separate repo), `python/tensor4all/`.
+See `docs/CAPI_DESIGN.md` for C API patterns. Bindings: [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl) (separate repo). The C API is the binding boundary; see `docs/CAPI_DESIGN.md`.
 
 Truncation tolerance: support both `cutoff` (ITensors) and `rtol` (tensor4all-rs). Conversion: `rtol = √cutoff`.
 

--- a/benchmarks/rust/benchmark_contract.rs
+++ b/benchmarks/rust/benchmark_contract.rs
@@ -65,14 +65,14 @@ fn main() -> Result<()> {
     let length = 10;
     let phys_dim = 2;
     let bond_dim = 50;
-    let max_rank = 50;
+    let max_bond_dim = 50;
     let n_runs = 10;  // Number of runs for averaging
 
     println!("=== Random MPO Contraction Benchmark (Rust/tensor4all-rs) ===");
     println!("Length: {} sites", length);
     println!("Physical dimension: {}", phys_dim);
     println!("Bond dimension: {}", bond_dim);
-    println!("Max rank: {}", max_rank);
+    println!("Max rank: {}", max_bond_dim);
     println!("Number of runs: {} (excluding first compilation run)", n_runs);
     println!();
 
@@ -134,13 +134,13 @@ fn main() -> Result<()> {
     println!("MPO B created. Max bond dim: {}", mpo_b_original.max_bond_dim());
     println!();
 
-    // Contract options: zip-up with max_rank=50
+    // Contract options: zip-up with max_bond_dim=50
     let options = ContractOptions::zipup()
-        .with_max_rank(max_rank);
+        .with_max_bond_dim(max_bond_dim);
 
     println!("Contracting MPOs using zip-up method...");
-    println!("Options: method=Zipup, max_rank={}, rtol={:?}", 
-             max_rank, options.rtol);
+    println!("Options: method=Zipup, max_bond_dim={}, rtol={:?}", 
+             max_bond_dim, options.rtol);
     println!("Note: Each run copies MPOs and includes orthogonalization time");
     println!();
 

--- a/benchmarks/rust/benchmark_local_linsolve.rs
+++ b/benchmarks/rust/benchmark_local_linsolve.rs
@@ -361,7 +361,7 @@ fn main() -> anyhow::Result<()> {
         .with_gmres_tol(gmres_tol)
         .with_gmres_max_restarts(gmres_max_restarts)
         .with_gmres_restart_dim(gmres_restart_dim)
-        .with_max_rank(state_bond_dim)
+        .with_max_bond_dim(state_bond_dim)
         .with_svd_policy(SvdTruncationPolicy::new(0.0))
         .with_residual_check(false);
 

--- a/benchmarks/rust/benchmark_matrix_lu.rs
+++ b/benchmarks/rust/benchmark_matrix_lu.rs
@@ -58,7 +58,7 @@ fn timing_median(mut values: Vec<f64>) -> f64 {
 fn timed_hilbert_matrix_lu_once(size: usize, left_orthogonal: bool) -> MatrixLuTiming {
     let matrix = hilbert_matrix(size);
     let options = RrLUOptions {
-        max_rank: usize::MAX,
+        max_bond_dim: usize::MAX,
         rel_tol: 0.0,
         abs_tol: 1.0e-10,
         left_orthogonal,

--- a/benchmarks/rust/benchmark_partitionedtt_patching.rs
+++ b/benchmarks/rust/benchmark_partitionedtt_patching.rs
@@ -172,7 +172,7 @@ fn patching_options(
 ) -> PatchingOptions {
     PatchingOptions {
         rtol: options.rtol,
-        max_bond_dim: options.max_bond_dim,
+        max_bond_dim: Some(options.max_bond_dim),
         patch_order: patch_order.to_vec(),
         split_strategy,
     }

--- a/benchmarks/rust/benchmark_tt_ops.rs
+++ b/benchmarks/rust/benchmark_tt_ops.rs
@@ -878,7 +878,7 @@ fn main() -> Result<()> {
 
         let zipup_options = ContractOptions::zipup()
             .with_svd_policy(SvdTruncationPolicy::new(0.0))
-            .with_max_rank(chi);
+            .with_max_bond_dim(chi);
         let zipup_params = format!(
             "L_{}_chi_{}_d_{}_maxdim_{}",
             opts.zipup_length, chi, opts.phys_dim, chi

--- a/crates/tensor4all-aci/benches/elementwise_scaling.rs
+++ b/crates/tensor4all-aci/benches/elementwise_scaling.rs
@@ -154,18 +154,18 @@ fn sampled_max_abs_error(
         .fold(0.0, f64::max)
 }
 
-fn run_aci(
-    inputs: &[SimpleTensorTrain<f64>],
-    initial_guess: &SimpleTensorTrain<f64>,
-) -> AciResult<f64> {
-    let options = AciOptions {
+fn run_aci(inputs: &[SimpleTensorTrain<f64>], options: &AciOptions<f64>) -> AciResult<f64> {
+    elementwise_batched(multiply_batch, inputs, options)
+        .expect("ACI elementwise multiplication benchmark should converge")
+}
+
+fn aci_options(initial_guess: &SimpleTensorTrain<f64>) -> AciOptions<f64> {
+    AciOptions {
         max_iters: MAX_ITERS,
         tolerance: TOLERANCE,
         initial_guess: Some(initial_guess.clone()),
         ..AciOptions::default()
-    };
-    elementwise_batched(multiply_batch, inputs, &options)
-        .expect("ACI elementwise multiplication benchmark should converge")
+    }
 }
 
 fn assert_nontrivial_output_rank(chi: usize, output_max_chi: usize) {
@@ -184,7 +184,8 @@ fn bench_aci_elementwise_chi_scaling(c: &mut Criterion) {
     for chi in DEFAULT_CHI_VALUES {
         let inputs = deterministic_inputs(chi);
         let initial_guess = deterministic_initial_guess(chi);
-        let checked = run_aci(&inputs, &initial_guess);
+        let options = aci_options(&initial_guess);
+        let checked = run_aci(&inputs, &options);
         let sampled_error = sampled_max_abs_error(&inputs, &checked.tensor_train, chi);
         assert!(
             sampled_error < 1e-8,
@@ -202,9 +203,10 @@ fn bench_aci_elementwise_chi_scaling(c: &mut Criterion) {
              final_error={final_error:.6e},sampled_max_abs_error={sampled_error:.6e}"
         );
 
+        let options = aci_options(&initial_guess);
         group.bench_with_input(BenchmarkId::from_parameter(chi), &chi, |b, _| {
             b.iter(|| {
-                black_box(run_aci(black_box(&inputs), black_box(&initial_guess)));
+                black_box(run_aci(black_box(&inputs), black_box(&options)));
             });
         });
     }
@@ -225,7 +227,8 @@ fn bench_aci_elementwise_chi_scaling_long(c: &mut Criterion) {
     let chi = OPTIONAL_CHI;
     let inputs = deterministic_inputs(chi);
     let initial_guess = deterministic_initial_guess(chi);
-    let checked = run_aci(&inputs, &initial_guess);
+    let options = aci_options(&initial_guess);
+    let checked = run_aci(&inputs, &options);
     let sampled_error = sampled_max_abs_error(&inputs, &checked.tensor_train, chi);
     assert!(
         sampled_error < 1e-8,
@@ -245,7 +248,7 @@ fn bench_aci_elementwise_chi_scaling_long(c: &mut Criterion) {
 
     group.bench_with_input(BenchmarkId::from_parameter(chi), &chi, |b, _| {
         b.iter(|| {
-            black_box(run_aci(black_box(&inputs), black_box(&initial_guess)));
+            black_box(run_aci(black_box(&inputs), black_box(&options)));
         });
     });
     group.finish();

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -309,7 +309,7 @@ pub(crate) fn convergence_criterion_like_julia(
 ///
 /// `min_iters == 0` disables the exit, matching
 /// [`convergence_criterion_like_julia`], and the default `max_bond_dim` of
-/// [`usize::MAX`] is unreachable, so unconstrained runs are unaffected.
+/// `None` is unreachable, so unconstrained runs are unaffected.
 ///
 /// This is the `all(lastranks .>= max_bond_dim)` disjunct of the Julia
 /// `convergencecriterion` that [`convergence_criterion_like_julia`] otherwise

--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -315,14 +315,20 @@ pub(crate) fn convergence_criterion_like_julia(
 /// `convergencecriterion` that [`convergence_criterion_like_julia`] otherwise
 /// ports, over the same trailing window. `tensor4all-treetci` gained the
 /// equivalent exit in its own sweep loop in #575.
-pub(crate) fn rank_is_saturated(ranks: &[usize], min_iters: usize, max_bond_dim: usize) -> bool {
+pub(crate) fn rank_is_saturated(
+    ranks: &[usize],
+    min_iters: usize,
+    max_bond_dim: Option<usize>,
+) -> bool {
     if min_iters == 0 || ranks.len() < min_iters {
         return false;
     }
 
-    ranks[(ranks.len() - min_iters)..]
-        .iter()
-        .all(|&rank| rank >= max_bond_dim)
+    max_bond_dim.is_some_and(|cap| {
+        ranks[(ranks.len() - min_iters)..]
+            .iter()
+            .all(|&rank| rank >= cap)
+    })
 }
 
 pub(crate) fn error_metric(

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -46,7 +46,7 @@ pub struct AciOptions<T: TTScalar> {
 
     /// Maximum allowed tensor-train bond dimension.
     ///
-    /// The default is [`usize::MAX`], meaning no explicit cap. Lower values
+    /// The default is `None`, meaning no explicit cap. Lower values
     /// reduce memory and runtime but may prevent the approximation from
     /// reaching the requested [`tolerance`](Self::tolerance).
     pub max_bond_dim: Option<usize>,

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -21,7 +21,7 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 /// let options = AciOptions::<f64>::default();
 /// assert_eq!(options.max_iters, 20);
 /// assert_eq!(options.min_iters, 2);
-/// assert_eq!(options.max_bond_dim, usize::MAX);
+/// assert_eq!(options.max_bond_dim, None);
 /// assert!((options.tolerance - 1e-12).abs() < 1e-15);
 /// assert!(!options.scale_tolerance);
 /// assert!(options.initial_guess.is_none());
@@ -49,7 +49,7 @@ pub struct AciOptions<T: TTScalar> {
     /// The default is [`usize::MAX`], meaning no explicit cap. Lower values
     /// reduce memory and runtime but may prevent the approximation from
     /// reaching the requested [`tolerance`](Self::tolerance).
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
 
     /// Requested stopping tolerance for the ACI residual estimate.
     ///
@@ -89,7 +89,7 @@ impl<T: TTScalar> Default for AciOptions<T> {
         Self {
             max_iters: 20,
             min_iters: 2,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             tolerance: 1e-12,
             scale_tolerance: false,
             initial_guess: None,

--- a/crates/tensor4all-aci/src/random_tt.rs
+++ b/crates/tensor4all-aci/src/random_tt.rs
@@ -41,7 +41,7 @@ pub(crate) fn initial_guess<T: AciScalar>(
 fn validate_existing_initial_guess<T: AciScalar>(
     guess: &SimpleTensorTrain<T>,
     site_dims: &[usize],
-    max_bond_dim: usize,
+    max_bond_dim: Option<usize>,
 ) -> Result<()> {
     let guess_site_dims = guess.site_dims();
     if guess_site_dims != site_dims {
@@ -68,11 +68,11 @@ fn validate_existing_initial_guess<T: AciScalar>(
     }
 
     for (bond, link_dim) in guess.link_dims().into_iter().enumerate() {
-        if link_dim > max_bond_dim {
+        if max_bond_dim.is_some_and(|cap| link_dim > cap) {
             return Err(AciError::InvalidInitialGuess {
                 message: format!(
                     "initial guess bond dimension at bond {bond} exceeds max_bond_dim: \
-                     got {link_dim}, max {max_bond_dim}"
+                     got {link_dim}, max {max_bond_dim:?}"
                 ),
             });
         }
@@ -97,7 +97,7 @@ fn initial_guess_core_dims(site_dims: &[usize], link_dims: &[usize]) -> Vec<(usi
 fn default_link_dims<T: AciScalar>(
     inputs: &[SimpleTensorTrain<T>],
     site_dims: &[usize],
-    max_bond_dim: usize,
+    max_bond_dim: Option<usize>,
 ) -> Result<Vec<usize>> {
     if site_dims.len() <= 1 {
         return Ok(Vec::new());
@@ -124,10 +124,11 @@ fn default_link_dims<T: AciScalar>(
             .map(|input| input.link_dim(bond))
             .min()
             .unwrap_or(usize::MAX);
-        let link_dim = left_products[bond]
-            .min(right_products[bond])
+        let link_dim = max_bond_dim
+            .map_or(left_products[bond].min(right_products[bond]), |cap| {
+                left_products[bond].min(right_products[bond]).min(cap)
+            })
             .min(min_input_link_dim)
-            .min(max_bond_dim)
             .max(1);
         link_dims.push(link_dim);
     }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -560,7 +560,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             let factors_result = matrix_luci_factors_from_matrix_owned(
                 local_matrix,
                 Some(RrLUOptions {
-                    max_rank: options.max_bond_dim,
+                    max_bond_dim: options.max_bond_dim.unwrap_or(usize::MAX),
                     rel_tol: if options.scale_tolerance {
                         options.tolerance
                     } else {
@@ -641,7 +641,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                     left_orthogonal: false,
                     rel_tol: 0.0,
                     abs_tol: 0.0,
-                    max_rank: usize::MAX,
+                    max_bond_dim: usize::MAX,
                 }),
             )?;
 

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -402,14 +402,14 @@ fn convergence_criterion_matches_julia_algorithm() {
 fn rank_saturation_needs_a_full_dwell_at_the_cap() {
     // Below the cap, or at the cap for fewer than min_iters sweeps, the exit
     // must not fire.
-    assert!(!rank_is_saturated(&[4], 2, 4));
-    assert!(!rank_is_saturated(&[3, 4], 2, 4));
-    assert!(rank_is_saturated(&[3, 4, 4], 2, 4));
-    assert!(!rank_is_saturated(&[4, 4], 3, 4));
+    assert!(!rank_is_saturated(&[4], 2, Some(4)));
+    assert!(!rank_is_saturated(&[3, 4], 2, Some(4)));
+    assert!(rank_is_saturated(&[3, 4, 4], 2, Some(4)));
+    assert!(!rank_is_saturated(&[4, 4], 3, Some(4)));
     // The default cap is unreachable, so unconstrained runs never exit here.
-    assert!(!rank_is_saturated(&[4, 4], 2, usize::MAX));
+    assert!(!rank_is_saturated(&[4, 4], 2, None));
     // min_iters == 0 disables the exit, as it disables the tolerance criterion.
-    assert!(!rank_is_saturated(&[4, 4], 0, 4));
+    assert!(!rank_is_saturated(&[4, 4], 0, Some(4)));
 }
 
 #[test]
@@ -426,7 +426,7 @@ fn capped_elementwise_run_stops_once_rank_saturates() {
     let options = AciOptions::<f64> {
         max_iters: 20,
         min_iters: 2,
-        max_bond_dim: 4,
+        max_bond_dim: Some(4),
         tolerance: 1e-10,
         ..Default::default()
     };
@@ -449,7 +449,7 @@ fn capped_elementwise_run_stops_once_rank_saturates() {
     assert!(result.ranks.len() < options.max_iters);
     assert_eq!(
         &result.ranks[(result.ranks.len() - options.min_iters)..],
-        &[options.max_bond_dim; 2],
+        &[options.max_bond_dim.unwrap(); 2],
         "the exit must fire only after a full dwell at the cap, ranks {:?}",
         result.ranks
     );
@@ -458,7 +458,7 @@ fn capped_elementwise_run_stops_once_rank_saturates() {
         .tensor_train
         .link_dims()
         .iter()
-        .all(|&dim| dim <= options.max_bond_dim));
+        .all(|&dim| options.max_bond_dim.is_none_or(|cap| dim <= cap)));
 }
 
 #[test]
@@ -466,7 +466,7 @@ fn default_options_are_conservative() {
     let options = AciOptions::<f64>::default();
     assert_eq!(options.max_iters, 20);
     assert_eq!(options.min_iters, 2);
-    assert_eq!(options.max_bond_dim, usize::MAX);
+    assert_eq!(options.max_bond_dim, None);
     assert!((options.tolerance - 1e-12).abs() < 1e-15);
     assert!(!options.scale_tolerance);
     assert!(options.initial_guess.is_none());
@@ -1243,7 +1243,7 @@ fn validate_options_rejects_zero_max_iters() {
 #[test]
 fn validate_options_rejects_zero_max_bond_dim() {
     let options = AciOptions::<f64> {
-        max_bond_dim: 0,
+        max_bond_dim: Some(0),
         ..AciOptions::default()
     };
     let err = validate_options(&options).unwrap_err();
@@ -1326,7 +1326,7 @@ fn initial_guess_link_dims_are_empty_for_one_site_input() {
 fn initial_guess_link_dims_are_limited_by_max_bond_dim() {
     let input = tensor_train_with_link_dims(&[8, 8, 8], &[8, 8]);
     let options = AciOptions::<f64> {
-        max_bond_dim: 3,
+        max_bond_dim: Some(3),
         ..AciOptions::default()
     };
     let guess = initial_guess(&[input], &options).unwrap();
@@ -1353,7 +1353,7 @@ fn initial_guess_is_deterministic_for_same_seed() {
     let a = SimpleTensorTrain::<f64>::constant(&[2, 3, 2], 1.0);
     let b = SimpleTensorTrain::<f64>::constant(&[2, 3, 2], 2.0);
     let options = AciOptions::<f64> {
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         rng_seed: 1234,
         ..AciOptions::default()
     };
@@ -1439,7 +1439,7 @@ fn explicit_initial_guess_rejects_rank_above_max_bond_dim() {
     ])
     .unwrap();
     let options = AciOptions {
-        max_bond_dim: 1,
+        max_bond_dim: Some(1),
         initial_guess: Some(explicit),
         ..AciOptions::default()
     };
@@ -1478,7 +1478,7 @@ fn complex_initial_guess_is_deterministic() {
     let a = SimpleTensorTrain::<Complex64>::constant(&[2, 3, 2], Complex64::new(1.0, 0.0));
     let b = SimpleTensorTrain::<Complex64>::constant(&[2, 3, 2], Complex64::new(2.0, 0.0));
     let options = AciOptions::<Complex64> {
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         rng_seed: 4321,
         ..AciOptions::default()
     };
@@ -1707,7 +1707,7 @@ where
         let factors = matrix_luci_factors_from_matrix_owned(
             local_matrix,
             Some(RrLUOptions {
-                max_rank: options.max_bond_dim,
+                max_bond_dim: options.max_bond_dim.unwrap_or(usize::MAX),
                 rel_tol: if options.scale_tolerance {
                     options.tolerance
                 } else {

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -14,7 +14,7 @@ pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> R
         });
     }
 
-    if options.max_bond_dim == 0 {
+    if options.max_bond_dim == Some(0) {
         return Err(AciError::InvalidOptions {
             message: "max_bond_dim must be at least 1".to_string(),
         });

--- a/crates/tensor4all-aci/tests/elementwise.rs
+++ b/crates/tensor4all-aci/tests/elementwise.rs
@@ -8,7 +8,7 @@ fn exact_options() -> AciOptions<f64> {
     AciOptions {
         max_iters: 8,
         min_iters: 2,
-        max_bond_dim: 8,
+        max_bond_dim: Some(8),
         tolerance: 1e-12,
         ..AciOptions::default()
     }

--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -782,9 +782,7 @@ pub extern "C" fn t4a_qtransform_fourier_materialize(
         } else {
             FourierOptions::inverse()
         };
-        if max_bond_dim > 0 {
-            options.max_bond_dim = max_bond_dim;
-        }
+        options.max_bond_dim = (max_bond_dim > 0).then_some(max_bond_dim);
         if tolerance > 0.0 {
             options.tolerance = tolerance;
         }

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -265,7 +265,7 @@ fn test_fourier_materialization_matches_rust_reference() {
     );
     let actual = c_operator_matrix(op, &[2, 2], &[2, 2]);
     let mut options = FourierOptions::forward();
-    options.max_bond_dim = 8;
+    options.max_bond_dim = Some(8);
     options.tolerance = 1e-12;
     let expected = rust_operator_matrix(
         &quantics_fourier_operator(2, options).unwrap(),

--- a/crates/tensor4all-capi/src/tensor.rs
+++ b/crates/tensor4all-capi/src/tensor.rs
@@ -314,7 +314,7 @@ fn build_svd_options(policy: *const t4a_svd_truncation_policy, maxdim: usize) ->
         options = options.with_policy(SvdTruncationPolicy::from(policy));
     }
     if maxdim > 0 {
-        options = options.with_max_rank(maxdim);
+        options = options.with_max_bond_dim(maxdim);
     }
     options
 }

--- a/crates/tensor4all-capi/src/treetn.rs
+++ b/crates/tensor4all-capi/src/treetn.rs
@@ -427,7 +427,7 @@ fn build_split_options(
         .with_form(CanonicalForm::Unitary)
         .with_final_sweep(final_sweep != 0);
     if maxdim > 0 {
-        options = options.with_max_rank(maxdim);
+        options = options.with_max_bond_dim(maxdim);
     }
     if let Some(policy) = resolve_svd_policy(policy) {
         options = options.with_svd_policy(policy);
@@ -437,7 +437,7 @@ fn build_split_options(
 
 fn build_swap_options(maxdim: usize, rtol: f64) -> SwapOptions {
     SwapOptions {
-        max_rank: (maxdim > 0).then_some(maxdim),
+        max_bond_dim: (maxdim > 0).then_some(maxdim),
         rtol: (rtol > 0.0).then_some(rtol),
     }
 }
@@ -453,7 +453,7 @@ fn build_final_truncation(
 
     let mut options = TruncationOptions::new();
     if maxdim > 0 {
-        options = options.with_max_rank(maxdim);
+        options = options.with_max_bond_dim(maxdim);
     }
     if let Some(policy) = policy {
         options = options.with_svd_policy(policy);
@@ -1153,7 +1153,7 @@ pub extern "C" fn t4a_treetn_truncate(
             options = options.with_svd_policy(policy);
         }
         if maxdim > 0 {
-            options = options.with_max_rank(maxdim);
+            options = options.with_max_bond_dim(maxdim);
         }
 
         let center =
@@ -1544,10 +1544,10 @@ pub extern "C" fn t4a_treetn_add(
             options = options.with_svd_policy(policy);
         }
         if maxdim > 0 {
-            options = options.with_max_rank(maxdim);
+            options = options.with_max_bond_dim(maxdim);
         }
 
-        if options.svd_policy().is_some() || options.max_rank().is_some() {
+        if options.svd_policy().is_some() || options.max_bond_dim().is_some() {
             let center = result.node_names().into_iter().min().ok_or_else(|| {
                 capi_error(T4A_INVALID_ARGUMENT, "cannot truncate an empty TreeTN")
             })?;
@@ -1648,7 +1648,7 @@ pub extern "C" fn t4a_treetn_contract(
             }
         }
         if maxdim > 0 {
-            options = options.with_max_rank(maxdim);
+            options = options.with_max_bond_dim(maxdim);
         }
         if let Some(tol) = resolve_convergence_tol(convergence_tol) {
             options = options.with_convergence_tol(tol);
@@ -1770,7 +1770,7 @@ pub extern "C" fn t4a_treetn_partial_contract(
             }
         }
         if maxdim > 0 {
-            options = options.with_max_rank(maxdim);
+            options = options.with_max_bond_dim(maxdim);
         }
         if let Some(tol) = resolve_convergence_tol(convergence_tol) {
             options = options.with_convergence_tol(tol);
@@ -1876,7 +1876,7 @@ pub extern "C" fn t4a_treetn_apply_operator_chain(
             state.inner(),
             ApplyOptions {
                 method: method.into(),
-                max_rank: (maxdim > 0).then_some(maxdim),
+                max_bond_dim: (maxdim > 0).then_some(maxdim),
                 svd_policy: resolve_svd_policy(policy),
                 qr_rtol: None,
                 nfullsweeps: fit_nfullsweeps,
@@ -2005,7 +2005,7 @@ pub extern "C" fn t4a_treetn_linsolve(
             options = options.with_svd_policy(policy);
         }
         if maxdim > 0 {
-            options = options.with_max_rank(maxdim);
+            options = options.with_max_bond_dim(maxdim);
         }
         if let Some(tol) = resolve_convergence_tol(convergence_tol) {
             options = options.with_convergence_tol(tol);

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -233,8 +233,8 @@ fn factorize_svd(
     if let Some(policy) = options.svd_policy {
         svd_options = svd_options.with_policy(policy);
     }
-    if let Some(max_rank) = options.max_rank {
-        svd_options = svd_options.with_max_rank(max_rank);
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        svd_options = svd_options.with_max_bond_dim(max_bond_dim);
     }
 
     factorize_svd_with_options(t, left_inds, options.canonical, &svd_options)
@@ -381,7 +381,7 @@ where
         t,
         left_inds,
         options.canonical,
-        options.max_rank.unwrap_or(usize::MAX),
+        options.max_bond_dim.unwrap_or(usize::MAX),
         1e-14,
     )
 }
@@ -408,7 +408,7 @@ fn factorize_lu_with_options<T>(
     t: &TensorDynLen,
     left_inds: &[DynIndex],
     canonical: Canonical,
-    max_rank: usize,
+    max_bond_dim: usize,
     rel_tol: f64,
 ) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
 where
@@ -431,7 +431,7 @@ where
     // Set up LU options
     let left_orthogonal = canonical == Canonical::Left;
     let lu_options = RrLUOptions {
-        max_rank,
+        max_bond_dim,
         rel_tol,
         abs_tol: 0.0,
         left_orthogonal,
@@ -492,7 +492,7 @@ where
         t,
         left_inds,
         options.canonical,
-        options.max_rank.unwrap_or(usize::MAX),
+        options.max_bond_dim.unwrap_or(usize::MAX),
         1e-14,
     )
 }
@@ -529,7 +529,7 @@ fn factorize_ci_with_options<T>(
     t: &TensorDynLen,
     left_inds: &[DynIndex],
     canonical: Canonical,
-    max_rank: usize,
+    max_bond_dim: usize,
     rel_tol: f64,
 ) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
 where
@@ -553,7 +553,7 @@ where
     // Set up LU options for CI
     let left_orthogonal = canonical == Canonical::Left;
     let lu_options = RrLUOptions {
-        max_rank,
+        max_bond_dim,
         rel_tol,
         abs_tol: 0.0,
         left_orthogonal,

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -57,7 +57,7 @@ pub enum SvdError {
 #[derive(Debug, Clone, Copy)]
 pub struct SvdOptions {
     /// Maximum retained rank after policy-based truncation.
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Per-call SVD truncation policy.
     /// If `None`, the global default policy is used.
     pub policy: Option<SvdTruncationPolicy>,
@@ -75,7 +75,7 @@ impl SvdOptions {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            max_rank: None,
+            max_bond_dim: None,
             policy: None,
             truncate: true,
         }
@@ -83,8 +83,8 @@ impl SvdOptions {
 
     /// Set the maximum retained rank.
     #[must_use]
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -97,7 +97,7 @@ impl SvdOptions {
 
     pub(crate) fn full_rank() -> Self {
         Self {
-            max_rank: None,
+            max_bond_dim: None,
             policy: None,
             truncate: false,
         }
@@ -246,8 +246,8 @@ fn svd_truncated_inner(
         validate_svd_truncation_policy(policy).map_err(|e| SvdError::InvalidThreshold(e.0))?;
 
         let mut retained = compute_retained_rank(&s_full, &policy);
-        if let Some(max_rank) = options.max_rank {
-            retained = retained.min(max_rank);
+        if let Some(max_bond_dim) = options.max_bond_dim {
+            retained = retained.min(max_bond_dim);
         }
         retained.max(1)
     } else {
@@ -347,8 +347,8 @@ pub fn svd<T>(
 /// let (u, s, _v) = svd_with::<f64>(&tensor, &[i.clone()], &opts).unwrap();
 /// assert_eq!(s.dims()[0], 1);  // rank-1
 ///
-/// // Truncate with max_rank => capped
-/// let opts = SvdOptions::new().with_max_rank(2);
+/// // Truncate with max_bond_dim => capped
+/// let opts = SvdOptions::new().with_max_bond_dim(2);
 /// let (_u, s, _v) = svd_with::<f64>(&tensor, &[i.clone()], &opts).unwrap();
 /// assert!(s.dims()[0] <= 2);
 /// ```

--- a/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
@@ -80,11 +80,11 @@ fn svd_options_accessors_roundtrip() {
             rule: TruncationRule::DiscardedTailSum,
         })
     );
-    assert_eq!(by_policy.max_rank, None);
+    assert_eq!(by_policy.max_bond_dim, None);
 
-    let by_rank = SvdOptions::new().with_max_rank(7);
+    let by_rank = SvdOptions::new().with_max_bond_dim(7);
     assert_eq!(by_rank.policy, None);
-    assert_eq!(by_rank.max_rank, Some(7));
+    assert_eq!(by_rank.max_bond_dim, Some(7));
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn singular_values_from_native_rejects_unsupported_scalar_types() {
 }
 
 #[test]
-fn svd_with_max_rank_truncates_native_outputs() {
+fn svd_with_max_bond_dim_truncates_native_outputs() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
     let tensor =
@@ -106,7 +106,7 @@ fn svd_with_max_rank_truncates_native_outputs() {
     let (u, s, v) = svd_with::<f64>(
         &tensor,
         std::slice::from_ref(&i),
-        &SvdOptions::new().with_max_rank(1),
+        &SvdOptions::new().with_max_bond_dim(1),
     )
     .unwrap();
 

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -189,7 +189,7 @@ pub enum Canonical {
 ///
 /// - Algorithm: SVD
 /// - Canonical: Left (left factor is orthogonal)
-/// - max_rank: `None` (no rank limit)
+/// - max_bond_dim: `None` (no rank limit)
 /// - svd_policy: `None` (uses the SVD global default policy)
 /// - qr_rtol: `None` (uses the QR global default tolerance)
 ///
@@ -197,7 +197,7 @@ pub enum Canonical {
 ///
 /// - `svd_policy` is only valid for `FactorizeAlg::SVD`.
 /// - `qr_rtol` is only valid for `FactorizeAlg::QR`.
-/// - `max_rank` is independent of the algorithm-specific tolerance settings.
+/// - `max_bond_dim` is independent of the algorithm-specific tolerance settings.
 ///
 /// # Examples
 ///
@@ -219,7 +219,7 @@ pub enum Canonical {
 /// assert_eq!(result.rank, 1);
 ///
 /// // QR with max-rank truncation
-/// let opts = FactorizeOptions::qr().with_qr_rtol(1e-8).with_max_rank(2);
+/// let opts = FactorizeOptions::qr().with_qr_rtol(1e-8).with_max_bond_dim(2);
 /// let result = factorize(&tensor, &[i.clone()], &opts).unwrap();
 /// assert!(result.rank <= 2);
 /// ```
@@ -231,7 +231,7 @@ pub struct FactorizeOptions {
     pub canonical: Canonical,
     /// Maximum rank for truncation.
     /// If `None`, no rank limit is applied.
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// SVD truncation policy.
     /// If `None`, uses the SVD global default.
     pub svd_policy: Option<SvdTruncationPolicy>,
@@ -245,7 +245,7 @@ impl Default for FactorizeOptions {
         Self {
             alg: FactorizeAlg::SVD,
             canonical: Canonical::Left,
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             qr_rtol: None,
         }
@@ -373,11 +373,11 @@ impl FactorizeOptions {
     /// ```
     /// use tensor4all_core::FactorizeOptions;
     ///
-    /// let opts = FactorizeOptions::svd().with_max_rank(10);
-    /// assert_eq!(opts.max_rank, Some(10));
+    /// let opts = FactorizeOptions::svd().with_max_bond_dim(10);
+    /// assert_eq!(opts.max_bond_dim, Some(10));
     /// ```
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -11,17 +11,19 @@ fn factorize_options_builders_and_validation_accept_supported_fields() {
     let svd = FactorizeOptions::svd()
         .with_canonical(Canonical::Right)
         .with_svd_policy(SvdTruncationPolicy::new(1.0e-8))
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
     assert_eq!(svd.alg, FactorizeAlg::SVD);
     assert_eq!(svd.canonical, Canonical::Right);
-    assert_eq!(svd.max_rank, Some(4));
+    assert_eq!(svd.max_bond_dim, Some(4));
     assert_eq!(svd.svd_policy, Some(SvdTruncationPolicy::new(1.0e-8)));
     svd.validate().unwrap();
 
-    let qr = FactorizeOptions::qr().with_qr_rtol(0.0).with_max_rank(3);
+    let qr = FactorizeOptions::qr()
+        .with_qr_rtol(0.0)
+        .with_max_bond_dim(3);
     assert_eq!(qr.alg, FactorizeAlg::QR);
     assert_eq!(qr.qr_rtol, Some(0.0));
-    assert_eq!(qr.max_rank, Some(3));
+    assert_eq!(qr.max_bond_dim, Some(3));
     qr.validate().unwrap();
 
     let lu = FactorizeOptions::lu();

--- a/crates/tensor4all-core/src/truncation.rs
+++ b/crates/tensor4all-core/src/truncation.rs
@@ -112,7 +112,7 @@ pub enum TruncationRule {
 ///
 /// Use this type when you need to describe how singular values are measured,
 /// scaled, and turned into a retained rank. [`SvdOptions`](crate::SvdOptions)
-/// carries this policy plus an independent `max_rank` cap.
+/// carries this policy plus an independent `max_bond_dim` cap.
 ///
 /// # Examples
 ///

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -104,7 +104,7 @@ fn test_factorize_reconstruction_all_algorithms() {
             let options = FactorizeOptions {
                 alg,
                 canonical,
-                max_rank: None,
+                max_bond_dim: None,
                 svd_policy: None,
                 qr_rtol: None,
             };
@@ -127,7 +127,7 @@ fn test_factorize_shared_bond_index_all_algorithms() {
         let options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             qr_rtol: None,
         };
@@ -208,7 +208,7 @@ fn test_factorize_lu_ci_no_singular_values() {
             let options = FactorizeOptions {
                 alg,
                 canonical,
-                max_rank: None,
+                max_bond_dim: None,
                 svd_policy: None,
                 qr_rtol: None,
             };
@@ -228,7 +228,7 @@ fn test_factorize_lu_ci_reconstruction_with_unit_dim_axis() {
         let options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             qr_rtol: None,
         };
@@ -247,7 +247,7 @@ fn test_factorize_lu_ci_reconstruction_with_col_major_matrix_input() {
         let options = FactorizeOptions {
             alg,
             canonical: Canonical::Left,
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             qr_rtol: None,
         };
@@ -262,17 +262,17 @@ fn test_factorize_lu_ci_reconstruction_with_col_major_matrix_input() {
 // ============================================================================
 
 #[test]
-fn test_factorize_with_max_rank() {
+fn test_factorize_with_max_bond_dim() {
     let tensor = create_test_matrix();
     let left_inds = vec![tensor.indices[0].clone()];
 
-    // LU should respect max_rank
-    let options = FactorizeOptions::lu().with_max_rank(1);
+    // LU should respect max_bond_dim
+    let options = FactorizeOptions::lu().with_max_bond_dim(1);
     let result = factorize(&tensor, &left_inds, &options).unwrap();
     assert_eq!(result.rank, 1);
 
     // SVD API works (actual truncation behavior may vary)
-    let options = FactorizeOptions::svd().with_max_rank(1);
+    let options = FactorizeOptions::svd().with_max_bond_dim(1);
     let result = factorize(&tensor, &left_inds, &options).unwrap();
     assert!(result.rank >= 1);
 }

--- a/crates/tensor4all-interpolativeqtt/src/interpolation.rs
+++ b/crates/tensor4all-interpolativeqtt/src/interpolation.rs
@@ -663,7 +663,7 @@ fn validate_options(options: &InterpolativeQttOptions) -> Result<()> {
             "compression tolerance must be finite and non-negative",
         ));
     }
-    if options.max_bond_dim == 0 {
+    if options.max_bond_dim == Some(0) {
         return Err(invalid_argument("max_bond_dim must be at least 1"));
     }
     Ok(())
@@ -765,7 +765,7 @@ fn compress_train(
     options: &InterpolativeQttOptions,
 ) -> Result<SimpleTensorTrain<f64>> {
     let tt = SimpleTensorTrain::new(cores)?;
-    if options.tolerance == 0.0 && options.max_bond_dim == usize::MAX {
+    if options.tolerance == 0.0 && options.max_bond_dim.is_none() {
         return Ok(tt);
     }
 

--- a/crates/tensor4all-interpolativeqtt/src/options.rs
+++ b/crates/tensor4all-interpolativeqtt/src/options.rs
@@ -25,21 +25,21 @@
 ///     .with_max_bond_dim(64);
 ///
 /// assert!((opts.tolerance - 1e-10).abs() < 1e-15);
-/// assert_eq!(opts.max_bond_dim, 64);
+/// assert_eq!(opts.max_bond_dim, Some(64));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct InterpolativeQttOptions {
     /// Relative SVD truncation threshold.
     pub tolerance: f64,
     /// Maximum allowed TT bond dimension.
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
 }
 
 impl Default for InterpolativeQttOptions {
     fn default() -> Self {
         Self {
             tolerance: 1.0e-12,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
         }
     }
 }
@@ -75,10 +75,10 @@ impl InterpolativeQttOptions {
     /// use tensor4all_interpolativeqtt::InterpolativeQttOptions;
     ///
     /// let opts = InterpolativeQttOptions::default().with_max_bond_dim(8);
-    /// assert_eq!(opts.max_bond_dim, 8);
+    /// assert_eq!(opts.max_bond_dim, Some(8));
     /// ```
     pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
-        self.max_bond_dim = max_bond_dim;
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 }
@@ -92,7 +92,7 @@ mod tests {
         let opts = InterpolativeQttOptions::default();
 
         assert_eq!(opts.tolerance, 1.0e-12);
-        assert_eq!(opts.max_bond_dim, usize::MAX);
+        assert_eq!(opts.max_bond_dim, None);
     }
 
     #[test]
@@ -100,11 +100,11 @@ mod tests {
         let opts = InterpolativeQttOptions::default().with_tolerance(1.0e-8);
 
         assert_eq!(opts.tolerance, 1.0e-8);
-        assert_eq!(opts.max_bond_dim, usize::MAX);
+        assert_eq!(opts.max_bond_dim, None);
 
         let capped = opts.with_max_bond_dim(12);
 
         assert_eq!(capped.tolerance, 1.0e-8);
-        assert_eq!(capped.max_bond_dim, 12);
+        assert_eq!(capped.max_bond_dim, Some(12));
     }
 }

--- a/crates/tensor4all-interpolativeqtt/src/options.rs
+++ b/crates/tensor4all-interpolativeqtt/src/options.rs
@@ -11,7 +11,7 @@
 /// - `tolerance`: relative SVD truncation threshold. Smaller values preserve
 ///
 ///   more accuracy and usually produce larger bonds.
-/// - `max_bond_dim`: hard upper bound on every TT bond. Use `usize::MAX` for
+/// - `max_bond_dim`: hard upper bound on every TT bond. Use `None` for
 ///
 ///   no explicit cap.
 ///
@@ -66,7 +66,7 @@ impl InterpolativeQttOptions {
 
     /// Return a copy with a different maximum bond dimension.
     ///
-    /// Use `usize::MAX` for no explicit cap. Smaller caps force more
+    /// Use `None` for no explicit cap. Smaller caps force more
     /// aggressive compression and may increase approximation error.
     ///
     /// # Examples

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -50,7 +50,7 @@ let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 tt.orthogonalize(1)?;
 tt.truncate(&TruncateOptions::svd()
     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-    .with_max_rank(2))?;
+    .with_max_bond_dim(2))?;
 
 assert!(tt.isortho());
 assert_eq!(s1.dim(), 2);

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
@@ -63,14 +63,14 @@ fn main() -> Result<()> {
     let length = 10;
     let phys_dim = 2;
     let bond_dim = 50;
-    let max_rank = 50;
+    let max_bond_dim = 50;
     let n_runs = 10; // Number of runs for averaging
 
     println!("=== Random MPO Contraction Benchmark (Rust/tensor4all-rs) ===");
     println!("Length: {} sites", length);
     println!("Physical dimension: {}", phys_dim);
     println!("Bond dimension: {}", bond_dim);
-    println!("Max rank: {}", max_rank);
+    println!("Max rank: {}", max_bond_dim);
     println!(
         "Number of runs: {} (excluding first compilation run)",
         n_runs
@@ -135,13 +135,13 @@ fn main() -> Result<()> {
     );
     println!();
 
-    // Contract options: zip-up with max_rank=50
-    let options = ContractOptions::zipup().with_max_rank(max_rank);
+    // Contract options: zip-up with max_bond_dim=50
+    let options = ContractOptions::zipup().with_max_bond_dim(max_bond_dim);
 
     println!("Contracting MPOs using zip-up method...");
     println!(
-        "Options: method=Zipup, max_rank={}, rtol={:?}",
-        max_rank,
+        "Options: method=Zipup, max_bond_dim={}, rtol={:?}",
+        max_bond_dim,
         options.svd_policy().map(|policy| policy.threshold)
     );
     println!("Note: Each run copies MPOs and includes orthogonalization time");

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
@@ -41,13 +41,13 @@ fn main() -> Result<()> {
     let length = 10;
     let phys_dim = 2;
     let bond_dim = 50;
-    let max_rank = 50;
+    let max_bond_dim = 50;
     let n_runs = 5;
 
     println!("=== Detailed MPO Contraction Benchmark (Rust) ===");
     println!("Length: {} sites", length);
     println!("Bond dimension: {}", bond_dim);
-    println!("Max rank: {}", max_rank);
+    println!("Max rank: {}", max_bond_dim);
     println!();
 
     // Create fixed MPOs
@@ -89,7 +89,7 @@ fn main() -> Result<()> {
     // Enable profiling
     std::env::set_var("T4A_PROFILE_CONTRACTION", "1");
 
-    let options = ContractOptions::zipup().with_max_rank(max_rank);
+    let options = ContractOptions::zipup().with_max_bond_dim(max_bond_dim);
 
     println!("Running {} iterations...", n_runs);
     let mut times = Vec::new();

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
@@ -5,7 +5,7 @@
 //! - Physical dimension: 2 per site (input and output)
 //! - Bond dimension: 20
 //!
-//! Then contracts them using fit (variational) method with max_rank=20.
+//! Then contracts them using fit (variational) method with max_bond_dim=20.
 
 use rand::rng;
 use std::time::Instant;
@@ -63,7 +63,7 @@ fn main() -> Result<()> {
     let length = 10;
     let phys_dim = 2;
     let bond_dim = 60;
-    let max_rank = 60;
+    let max_bond_dim = 60;
     let n_half_sweeps = 10; // Number of half-sweeps for fit algorithm (must be multiple of 2)
     let n_runs = 10; // Number of runs for averaging
 
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
     println!("Length: {} sites", length);
     println!("Physical dimension: {}", phys_dim);
     println!("Bond dimension: {}", bond_dim);
-    println!("Max rank: {}", max_rank);
+    println!("Max rank: {}", max_bond_dim);
     println!(
         "Number of half-sweeps: {} ({} full sweeps)",
         n_half_sweeps,
@@ -142,15 +142,15 @@ fn main() -> Result<()> {
     );
     println!();
 
-    // Contract options: fit with max_rank=20 and n_half_sweeps=10
+    // Contract options: fit with max_bond_dim=20 and n_half_sweeps=10
     let options = ContractOptions::fit()
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_nhalfsweeps(n_half_sweeps);
 
     println!("Contracting MPOs using fit (variational) method...");
     println!(
-        "Options: method=Fit, max_rank={}, nhalfsweeps={}, rtol={:?}",
-        max_rank,
+        "Options: method=Fit, max_bond_dim={}, nhalfsweeps={}, rtol={:?}",
+        max_bond_dim,
         n_half_sweeps,
         options.svd_policy().map(|policy| policy.threshold)
     );

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_one_shot.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_one_shot.rs
@@ -33,7 +33,7 @@ fn create_random_mpo(
     Ok(TensorTrain::new(tensors)?)
 }
 
-fn run_zipup(length: usize, phys_dim: usize, bond_dim: usize, max_rank: usize) -> Result<()> {
+fn run_zipup(length: usize, phys_dim: usize, bond_dim: usize, max_bond_dim: usize) -> Result<()> {
     let input_indices_a: Vec<_> = (0..length).map(|_| DynIndex::new_dyn(phys_dim)).collect();
     let output_indices_shared: Vec<_> = (0..length).map(|_| DynIndex::new_dyn(phys_dim)).collect();
     let output_indices_b: Vec<_> = (0..length).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -61,7 +61,7 @@ fn run_zipup(length: usize, phys_dim: usize, bond_dim: usize, max_rank: usize) -
         &link_indices_b,
     )?;
 
-    let options = ContractOptions::zipup().with_max_rank(max_rank);
+    let options = ContractOptions::zipup().with_max_bond_dim(max_bond_dim);
 
     let start = Instant::now();
     let mut mpo_a = mpo_a;
@@ -83,7 +83,7 @@ fn run_fit(
     length: usize,
     phys_dim: usize,
     bond_dim: usize,
-    max_rank: usize,
+    max_bond_dim: usize,
     n_half_sweeps: usize,
 ) -> Result<()> {
     let input_indices_a: Vec<_> = (0..length).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -114,7 +114,7 @@ fn run_fit(
     )?;
 
     let options = ContractOptions::fit()
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_nhalfsweeps(n_half_sweeps);
 
     let start = Instant::now();
@@ -137,15 +137,15 @@ fn main() -> Result<()> {
     let length = 10;
     let phys_dim = 2;
     let bond_dim = 80;
-    let max_rank = 80;
+    let max_bond_dim = 80;
     let n_half_sweeps = 10;
 
     println!(
-        "one-shot benchmark: length={}, phys_dim={}, bond_dim={}, max_rank={}, n_half_sweeps={}",
-        length, phys_dim, bond_dim, max_rank, n_half_sweeps
+        "one-shot benchmark: length={}, phys_dim={}, bond_dim={}, max_bond_dim={}, n_half_sweeps={}",
+        length, phys_dim, bond_dim, max_bond_dim, n_half_sweeps
     );
 
-    run_zipup(length, phys_dim, bond_dim, max_rank)?;
-    run_fit(length, phys_dim, bond_dim, max_rank, n_half_sweeps)?;
+    run_zipup(length, phys_dim, bond_dim, max_bond_dim)?;
+    run_fit(length, phys_dim, bond_dim, max_bond_dim, n_half_sweeps)?;
     Ok(())
 }

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
@@ -86,13 +86,13 @@ fn main() -> Result<()> {
     println!();
 
     // Contract with profiling
-    let max_rank = 20;
-    let options = ContractOptions::zipup().with_max_rank(max_rank);
+    let max_bond_dim = 20;
+    let options = ContractOptions::zipup().with_max_bond_dim(max_bond_dim);
 
     println!("Contracting MPOs using zip-up method...");
     println!(
-        "Options: method=Zipup, max_rank={}, rtol={:?}",
-        max_rank,
+        "Options: method=Zipup, max_bond_dim={}, rtol={:?}",
+        max_bond_dim,
         options.svd_policy().map(|policy| policy.threshold)
     );
     println!();

--- a/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
+++ b/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
@@ -844,7 +844,7 @@ fn test_truncation_effect() -> anyhow::Result<()> {
     // Apply truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     r0.truncate(&truncate_opts)?;
 
     println!("\n=== After truncation ===");
@@ -1231,7 +1231,7 @@ fn test_gmres_with_both(
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -1459,7 +1459,7 @@ fn apply_with_zipup(
 ) -> anyhow::Result<TensorTrain> {
     let options = ContractOptions::zipup()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
 
     let result = op
         .contract(mpo, &options)
@@ -1478,7 +1478,7 @@ fn apply_with_fit(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
 
     let result = op
         .contract(mpo, &options)
@@ -1498,11 +1498,11 @@ fn debug_contract_result(
 
     let options_zipup = ContractOptions::zipup()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
     let options_fit = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
 
     let raw_zipup = op
         .contract(mpo, &options_zipup)
@@ -1634,7 +1634,7 @@ fn debug_contract_result(
 
     let trunc_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     result_zipup_trunc.truncate(&trunc_opts)?;
     result_fit_trunc.truncate(&trunc_opts)?;
 

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
@@ -475,7 +475,7 @@ fn apply_operator_for_block(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let result = op
         .contract(mpo, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -499,7 +499,7 @@ fn apply_cross_block_operator(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let result = op
         .contract(mpo, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -524,7 +524,7 @@ fn apply_cross_block_operator_full(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let result = op
         .contract(mpo, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -622,7 +622,7 @@ fn test_block_diagonal_identity() -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -719,7 +719,7 @@ fn test_block_diagonal_diagonal_operator() -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -860,7 +860,7 @@ fn test_block_upper_triangular() -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -949,7 +949,7 @@ fn test_restart_gmres_block_mpo() -> anyhow::Result<()> {
     // Truncation with aggressive settings
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-        .with_max_rank(10);
+        .with_max_bond_dim(10);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -967,12 +967,12 @@ fn test_restart_gmres_block_mpo() -> anyhow::Result<()> {
 
     println!("\nRunning Restart GMRES...");
     println!(
-        "Truncation: rtol={:.0e}, max_rank={}",
+        "Truncation: rtol={:.0e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
 
     let result = restart_gmres_with_truncation(&apply_a, &b, None, &options, &truncate_fn)?;
@@ -1113,7 +1113,7 @@ fn test_block_offdiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1271,7 +1271,7 @@ fn test_3x3_block_antidiagonal_complex_pauli_x_mpo() -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1395,7 +1395,7 @@ fn scaling_2x2_offdiagonal_mpo(n_sites: usize) -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1535,7 +1535,7 @@ fn scaling_3x3_antidiagonal_mpo(n_sites: usize) -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
@@ -431,7 +431,7 @@ fn apply_mpo_for_block(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let result = mpo
         .contract(mps, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -453,7 +453,7 @@ fn apply_cross_block_mpo(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let result = mpo
         .contract(mps, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -548,7 +548,7 @@ fn test_block_diagonal_identity() -> anyhow::Result<()> {
     // Truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -647,7 +647,7 @@ fn test_block_diagonal_diagonal_mpo() -> anyhow::Result<()> {
     // Truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -769,7 +769,7 @@ fn test_block_upper_triangular() -> anyhow::Result<()> {
     // Truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -858,7 +858,7 @@ fn test_restart_gmres_block_mps() -> anyhow::Result<()> {
     // Truncation with aggressive settings
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-        .with_max_rank(10);
+        .with_max_bond_dim(10);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -876,12 +876,12 @@ fn test_restart_gmres_block_mps() -> anyhow::Result<()> {
 
     println!("\nRunning Restart GMRES...");
     println!(
-        "Truncation: rtol={:.0e}, max_rank={}",
+        "Truncation: rtol={:.0e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
 
     let result = restart_gmres_with_truncation(&apply_a, &b, None, &options, &truncate_fn)?;
@@ -996,7 +996,7 @@ fn test_block_offdiagonal_complex_pauli_x() -> anyhow::Result<()> {
     // Truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1114,7 +1114,7 @@ fn test_3x3_block_antidiagonal_complex_pauli_x() -> anyhow::Result<()> {
     // Truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1214,7 +1214,7 @@ fn scaling_offdiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };
@@ -1315,7 +1315,7 @@ fn scaling_3x3_antidiagonal_complex_pauli_x(n_sites: usize) -> anyhow::Result<()
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut BlockTensor<TensorTrain>| -> anyhow::Result<()> {
         truncate_block_tensor(x, &truncate_opts)
     };

--- a/crates/tensor4all-itensorlike/examples/test_gmres_identity_high_bonddim.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_identity_high_bonddim.rs
@@ -75,7 +75,7 @@ fn run_identity_gmres(b: &TensorTrain, max_outer_iters: usize) -> Result<(bool, 
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(100);
+        .with_max_bond_dim(100);
     let truncate_fn = |x: &mut TensorTrain| -> Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
@@ -229,7 +229,7 @@ fn test_gmres_mpo_identity(n: usize) -> anyhow::Result<(f64, f64, usize)> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -327,7 +327,7 @@ fn test_gmres_mpo_pauli(n: usize) -> anyhow::Result<(f64, f64, usize)> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -415,7 +415,7 @@ fn test_gmres_mpo_imaginary(n: usize) -> anyhow::Result<(f64, f64, usize)> {
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -510,7 +510,7 @@ fn test_gmres_mpo_random(n: usize, max_iter: usize) -> anyhow::Result<(f64, f64,
 
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -754,7 +754,7 @@ fn apply_operator_to_mpo(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
 
     let result = op
         .contract(mpo, &options)

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
@@ -240,7 +240,7 @@ fn test_gmres_mps(n: usize, operator: &str) -> anyhow::Result<(f64, f64, usize)>
     // Truncation options: control bond dimension growth
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -252,12 +252,12 @@ fn test_gmres_mps(n: usize, operator: &str) -> anyhow::Result<(f64, f64, usize)>
     );
     println!("rtol = {:.2e}", options.rtol);
     println!(
-        "truncation: rtol={:.2e}, max_rank={}",
+        "truncation: rtol={:.2e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
     let result = gmres_with_truncation(&apply_a, &b, &x0, &options, truncate_fn)?;
 
@@ -391,11 +391,11 @@ fn apply_mpo(
     indices: &SharedIndices,
 ) -> anyhow::Result<TensorTrain> {
     // Contract MPO with MPS using fit method (more stable)
-    // Use consistent truncation: rtol=1e-10, max_rank=20
+    // Use consistent truncation: rtol=1e-10, max_bond_dim=20
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let result = mpo
         .contract(mps, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;
@@ -516,7 +516,7 @@ fn test_gmres_mps_imaginary(n: usize, max_iter: usize) -> anyhow::Result<(f64, f
     // Truncation options: control bond dimension growth
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(20);
+        .with_max_bond_dim(20);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -528,12 +528,12 @@ fn test_gmres_mps_imaginary(n: usize, max_iter: usize) -> anyhow::Result<(f64, f
     );
     println!("rtol = {:.2e}", options.rtol);
     println!(
-        "truncation: rtol={:.2e}, max_rank={}",
+        "truncation: rtol={:.2e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
     let result = gmres_with_truncation(&apply_a, &b, &x0, &options, truncate_fn)?;
 
@@ -784,7 +784,7 @@ fn test_gmres_mps_random(n: usize, max_iter: usize) -> anyhow::Result<(f64, f64,
     // Truncation options: control bond dimension growth
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-8))
-        .with_max_rank(50);
+        .with_max_bond_dim(50);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -796,12 +796,12 @@ fn test_gmres_mps_random(n: usize, max_iter: usize) -> anyhow::Result<(f64, f64,
     );
     println!("rtol = {:.2e}", options.rtol);
     println!(
-        "truncation: rtol={:.2e}, max_rank={}",
+        "truncation: rtol={:.2e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
     let result = gmres_with_truncation(&apply_a, &b, &x0, &options, truncate_fn)?;
 

--- a/crates/tensor4all-itensorlike/examples/test_restart_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_restart_gmres_mpo.rs
@@ -144,7 +144,7 @@ fn test_restart_gmres_mpo(n: usize, operator: &str) -> anyhow::Result<(bool, usi
     // Truncation options
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -214,19 +214,19 @@ fn test_restart_gmres_mpo_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
     // AGGRESSIVE truncation to make the problem harder
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-        .with_max_rank(5);
+        .with_max_bond_dim(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
     };
 
     println!(
-        "Truncation: rtol={:.0e}, max_rank={}",
+        "Truncation: rtol={:.0e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
 
     // Define apply_a closure
@@ -299,19 +299,19 @@ fn test_restart_gmres_mpo_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, 
     // Aggressive truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-        .with_max_rank(5);
+        .with_max_bond_dim(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
     };
 
     println!(
-        "Truncation: rtol={:.0e}, max_rank={}",
+        "Truncation: rtol={:.0e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
 
     // Define apply_a closure
@@ -513,7 +513,7 @@ fn apply_operator_to_mpo(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
 
     let result = op
         .contract(mpo, &options)

--- a/crates/tensor4all-itensorlike/examples/test_restart_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_restart_gmres_mps.rs
@@ -143,7 +143,7 @@ fn test_restart_gmres(n: usize, operator: &str) -> anyhow::Result<(bool, usize, 
     // Truncation options
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -261,7 +261,7 @@ fn test_restart_gmres_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
     // AGGRESSIVE truncation to make the problem harder
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-        .with_max_rank(5);
+        .with_max_bond_dim(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -272,12 +272,12 @@ fn test_restart_gmres_hard(n: usize) -> anyhow::Result<(bool, usize, f64)> {
     let initial_residual = 1.0;
     println!("Initial residual (x0=0): {:.6e}", initial_residual);
     println!(
-        "Truncation: rtol={:.0e}, max_rank={}",
+        "Truncation: rtol={:.0e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
 
     // Restart GMRES options - small inner iterations to force multiple outer iterations
@@ -345,7 +345,7 @@ fn test_restart_gmres_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, usiz
     // Aggressive truncation
     let truncate_opts = TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-        .with_max_rank(5);
+        .with_max_bond_dim(5);
     let truncate_fn = |x: &mut TensorTrain| -> anyhow::Result<()> {
         x.truncate(&truncate_opts)?;
         Ok(())
@@ -354,12 +354,12 @@ fn test_restart_gmres_imaginary_diagonal(n: usize) -> anyhow::Result<(bool, usiz
     let apply_a = |x: &TensorTrain| -> anyhow::Result<TensorTrain> { apply_mpo(&mpo, x, &indices) };
 
     println!(
-        "Truncation: rtol={:.0e}, max_rank={}",
+        "Truncation: rtol={:.0e}, max_bond_dim={}",
         truncate_opts
             .svd_policy()
             .map(|policy| policy.threshold)
             .unwrap_or(0.0),
-        truncate_opts.max_rank().unwrap_or(0)
+        truncate_opts.max_bond_dim().unwrap_or(0)
     );
 
     // Restart GMRES options - small inner iterations to force multiple outer iterations
@@ -543,7 +543,7 @@ fn apply_mpo(
     let options = ContractOptions::fit()
         .with_nhalfsweeps(4)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(30);
+        .with_max_bond_dim(30);
     let result = mpo
         .contract(mps, &options)
         .map_err(|e| anyhow::anyhow!("{}", e))?;

--- a/crates/tensor4all-itensorlike/src/contract.rs
+++ b/crates/tensor4all-itensorlike/src/contract.rs
@@ -20,7 +20,7 @@ use crate::tensortrain::TensorTrain;
 /// # Arguments
 /// * `a` - The first tensor train
 /// * `b` - The second tensor train
-/// * `options` - Contraction options (method, max_rank, rtol, nhalfsweeps)
+/// * `options` - Contraction options (method, max_bond_dim, rtol, nhalfsweeps)
 ///
 /// # Returns
 /// A new tensor train resulting from the contraction.
@@ -51,7 +51,7 @@ pub fn contract(
         });
     }
 
-    validate_svd_truncation_options(options.max_rank(), options.svd_policy())?;
+    validate_svd_truncation_options(options.max_bond_dim(), options.svd_policy())?;
 
     if matches!(options.method(), ContractMethod::Fit) && !options.nhalfsweeps().is_multiple_of(2) {
         return Err(TensorTrainError::OperationError {
@@ -73,8 +73,8 @@ pub fn contract(
     let nfullsweeps = options.nhalfsweeps() / 2;
     let treetn_options = TreeTNContractionOptions::new(treetn_method).with_nfullsweeps(nfullsweeps);
 
-    let treetn_options = if let Some(max_rank) = options.max_rank() {
-        treetn_options.with_max_rank(max_rank)
+    let treetn_options = if let Some(max_bond_dim) = options.max_bond_dim() {
+        treetn_options.with_max_bond_dim(max_bond_dim)
     } else {
         treetn_options
     };
@@ -100,7 +100,7 @@ pub fn contract(
                 &center,
                 CanonicalForm::Unitary,
                 options.svd_policy(),
-                options.max_rank(),
+                options.max_bond_dim(),
             )
             .map_err(|e| TensorTrainError::InvalidStructure {
                 message: format!("Zip-up contraction failed: {}", e),
@@ -124,7 +124,7 @@ impl TensorTrain {
     ///
     /// # Arguments
     /// * `other` - The other tensor train to contract with
-    /// * `options` - Contraction options (method, max_rank, rtol, nhalfsweeps)
+    /// * `options` - Contraction options (method, max_bond_dim, rtol, nhalfsweeps)
     ///
     /// # Returns
     /// A new tensor train resulting from the contraction.

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -90,13 +90,13 @@ fn test_contract_free_fn_invalid_rtol() {
 }
 
 #[test]
-fn test_contract_free_fn_invalid_max_rank_zero() {
+fn test_contract_free_fn_invalid_max_bond_dim_zero() {
     let s0 = idx(1006, 2);
     let t0 = make_tensor(vec![s0.clone()]);
     let tt1 = TensorTrain::new(vec![t0.clone()]).unwrap();
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
-    let options = ContractOptions::zipup().with_max_rank(0);
+    let options = ContractOptions::zipup().with_max_bond_dim(0);
     let err = contract(&tt1, &tt2, &options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }
@@ -133,7 +133,7 @@ fn test_contract_zipup_two_sites() {
     let t2_1 = make_tensor(vec![l01_b.clone(), s1.clone()]);
     let tt2 = TensorTrain::new(vec![t2_0, t2_1]).unwrap();
 
-    let options = ContractOptions::zipup().with_max_rank(10);
+    let options = ContractOptions::zipup().with_max_bond_dim(10);
     let result = contract(&tt1, &tt2, &options).unwrap();
     // Result should contract over shared site indices
     assert_eq!(result.len(), 1);
@@ -267,7 +267,9 @@ fn test_contract_fit_two_sites() {
     let t2_1 = make_tensor(vec![l01_b.clone(), s1.clone()]);
     let tt2 = TensorTrain::new(vec![t2_0, t2_1]).unwrap();
 
-    let options = ContractOptions::fit().with_max_rank(10).with_nhalfsweeps(4);
+    let options = ContractOptions::fit()
+        .with_max_bond_dim(10)
+        .with_nhalfsweeps(4);
     let result = contract(&tt1, &tt2, &options).unwrap();
     assert_matches_naive(&tt1, &tt2, &result);
 }
@@ -287,7 +289,9 @@ fn test_contract_fit_accepts_non_chain_ordered_site_tensors() {
     let t2_1 = make_tensor(vec![s1.clone(), l01_b.clone()]);
     let tt2 = TensorTrain::new(vec![t2_0, t2_1]).unwrap();
 
-    let options = ContractOptions::fit().with_max_rank(10).with_nhalfsweeps(4);
+    let options = ContractOptions::fit()
+        .with_max_bond_dim(10)
+        .with_nhalfsweeps(4);
     let result = contract(&tt1, &tt2, &options).unwrap();
     assert_matches_naive(&tt1, &tt2, &result);
 }
@@ -300,7 +304,9 @@ fn test_contract_fit_odd_nhalfsweeps() {
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
     // Odd nhalfsweeps should fail for Fit method
-    let options = ContractOptions::fit().with_nhalfsweeps(3).with_max_rank(10);
+    let options = ContractOptions::fit()
+        .with_nhalfsweeps(3)
+        .with_max_bond_dim(10);
     let err = contract(&tt1, &tt2, &options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }
@@ -313,7 +319,9 @@ fn test_contract_fit_nhalfsweeps_zero_ok() {
     let tt1 = TensorTrain::new(vec![t0.clone()]).unwrap();
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
-    let options = ContractOptions::fit().with_nhalfsweeps(0).with_max_rank(10);
+    let options = ContractOptions::fit()
+        .with_nhalfsweeps(0)
+        .with_max_bond_dim(10);
     let result = contract(&tt1, &tt2, &options).unwrap();
     assert_eq!(result.len(), 1);
     assert_matches_naive(&tt1, &tt2, &result);
@@ -357,7 +365,7 @@ fn test_contract_method_uses_tt_contract() {
 fn test_contract_zipup_with_truncation() {
     // 3-site TTs with shared site indices, bond dim 2
     // Contraction without truncation would produce bond dim up to 4.
-    // Truncate to max_rank=1 and verify:
+    // Truncate to max_bond_dim=1 and verify:
     //   (a) bond dims are actually truncated
     //   (b) result is approximately correct (not exact due to truncation)
     let s0 = idx(2000, 2);
@@ -382,13 +390,13 @@ fn test_contract_zipup_with_truncation() {
     ])
     .unwrap();
 
-    // Contract with truncation: max_rank=1
-    let options = ContractOptions::zipup().with_max_rank(1);
+    // Contract with truncation: max_bond_dim=1
+    let options = ContractOptions::zipup().with_max_bond_dim(1);
     let result = contract(&tt1, &tt2, &options).unwrap();
 
     // Verify truncation actually happened: all bond dims should be <= 1
     for bd in result.bond_dims() {
-        assert!(bd <= 1, "Bond dim {} exceeds max_rank=1", bd);
+        assert!(bd <= 1, "Bond dim {} exceeds max_bond_dim=1", bd);
     }
 
     // Compare with naive (exact) result — should be approximate, not exact

--- a/crates/tensor4all-itensorlike/src/error.rs
+++ b/crates/tensor4all-itensorlike/src/error.rs
@@ -12,10 +12,12 @@ use tensor4all_core::TensorDynLenError;
 /// Errors that can occur in `TensorTrain` operations.
 ///
 /// Note: `tensor4all-simplett` also defines a public type named
-/// [`TensorTrainError`](tensor4all_simplett::TensorTrainError) with different
-/// variants (its positional `SimpleTensorTrain`). When both crates are in
-/// scope, qualify the path (e.g. `tensor4all_itensorlike::TensorTrainError`
-/// vs `tensor4all_simplett::TensorTrainError`).
+/// `TensorTrainError` (see its
+/// [rustdoc](https://tensor4all.org/tensor4all-rs/rustdoc/tensor4all_simplett/error/enum.TensorTrainError.html))
+/// with different variants (its positional `SimpleTensorTrain`). When both
+/// crates are in scope, qualify the path (e.g.
+/// `tensor4all_itensorlike::TensorTrainError` vs
+/// `tensor4all_simplett::TensorTrainError`).
 #[derive(Debug, Error)]
 pub enum TensorTrainError {
     /// Tensor train is empty (has no tensors).

--- a/crates/tensor4all-itensorlike/src/error.rs
+++ b/crates/tensor4all-itensorlike/src/error.rs
@@ -9,7 +9,13 @@ pub type Result<T> = std::result::Result<T, TensorTrainError>;
 
 use tensor4all_core::TensorDynLenError;
 
-/// Errors that can occur in TensorTrain operations.
+/// Errors that can occur in `TensorTrain` operations.
+///
+/// Note: `tensor4all-simplett` also defines a public type named
+/// [`TensorTrainError`](tensor4all_simplett::TensorTrainError) with different
+/// variants (its positional `SimpleTensorTrain`). When both crates are in
+/// scope, qualify the path (e.g. `tensor4all_itensorlike::TensorTrainError`
+/// vs `tensor4all_simplett::TensorTrainError`).
 #[derive(Debug, Error)]
 pub enum TensorTrainError {
     /// Tensor train is empty (has no tensors).

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -52,7 +52,7 @@ pub fn linsolve(
         });
     }
 
-    validate_svd_truncation_options(options.max_rank(), options.svd_policy())?;
+    validate_svd_truncation_options(options.max_bond_dim(), options.svd_policy())?;
 
     if !options.gmres_tol().is_finite() || options.gmres_tol() <= 0.0 {
         return Err(TensorTrainError::OperationError {
@@ -100,8 +100,8 @@ pub fn linsolve(
         treetn_options
     };
 
-    let treetn_options = if let Some(max_rank) = options.max_rank() {
-        treetn_options.with_max_rank(max_rank)
+    let treetn_options = if let Some(max_bond_dim) = options.max_bond_dim() {
+        treetn_options.with_max_bond_dim(max_bond_dim)
     } else {
         treetn_options
     };

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -10,7 +10,7 @@ use crate::error::{Result, TensorTrainError};
 pub use tensor4all_treetn::CanonicalForm;
 
 pub(crate) fn validate_svd_truncation_options(
-    max_rank: Option<usize>,
+    max_bond_dim: Option<usize>,
     svd_policy: Option<SvdTruncationPolicy>,
 ) -> Result<()> {
     if let Some(policy) = svd_policy {
@@ -24,10 +24,10 @@ pub(crate) fn validate_svd_truncation_options(
         }
     }
 
-    if let Some(max_rank) = max_rank {
-        if max_rank == 0 {
+    if let Some(max_bond_dim) = max_bond_dim {
+        if max_bond_dim == 0 {
             return Err(TensorTrainError::OperationError {
-                message: "max_rank/maxdim must be >= 1".to_string(),
+                message: "max_bond_dim/maxdim must be >= 1".to_string(),
             });
         }
     }
@@ -48,16 +48,16 @@ pub(crate) fn validate_svd_truncation_options(
 ///
 /// let opts = TruncateOptions::svd()
 ///     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
-///     .with_max_rank(20)
+///     .with_max_bond_dim(20)
 ///     .with_site_range(0..4);
 ///
 /// assert_eq!(opts.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
-/// assert_eq!(opts.max_rank(), Some(20));
+/// assert_eq!(opts.max_bond_dim(), Some(20));
 /// assert_eq!(opts.site_range(), Some(0..4));
 /// ```
 #[derive(Debug, Clone, Default)]
 pub struct TruncateOptions {
-    max_rank: Option<usize>,
+    max_bond_dim: Option<usize>,
     svd_policy: Option<SvdTruncationPolicy>,
     site_range: Option<Range<usize>>,
 }
@@ -75,8 +75,8 @@ impl TruncateOptions {
     }
 
     /// Set the maximum retained bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -96,8 +96,8 @@ impl TruncateOptions {
 
     /// Get the maximum retained bond dimension.
     #[inline]
-    pub fn max_rank(&self) -> Option<usize> {
-        self.max_rank
+    pub fn max_bond_dim(&self) -> Option<usize> {
+        self.max_bond_dim
     }
 
     /// Get the site range for truncation.
@@ -131,17 +131,17 @@ pub enum ContractMethod {
 ///
 /// let opts = ContractOptions::fit()
 ///     .with_svd_policy(SvdTruncationPolicy::new(1e-8))
-///     .with_max_rank(50)
+///     .with_max_bond_dim(50)
 ///     .with_nsweeps(3);
 ///
-/// assert_eq!(opts.max_rank(), Some(50));
+/// assert_eq!(opts.max_bond_dim(), Some(50));
 /// assert_eq!(opts.svd_policy(), Some(SvdTruncationPolicy::new(1e-8)));
 /// assert_eq!(opts.nhalfsweeps(), 6);
 /// ```
 #[derive(Debug, Clone)]
 pub struct ContractOptions {
     method: ContractMethod,
-    max_rank: Option<usize>,
+    max_bond_dim: Option<usize>,
     svd_policy: Option<SvdTruncationPolicy>,
     nhalfsweeps: usize,
     dense_reference_limit: Option<usize>,
@@ -151,7 +151,7 @@ impl Default for ContractOptions {
     fn default() -> Self {
         Self {
             method: ContractMethod::default(),
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             nhalfsweeps: 2,
             dense_reference_limit: None,
@@ -203,8 +203,8 @@ impl ContractOptions {
     }
 
     /// Set the maximum retained bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -261,8 +261,8 @@ impl ContractOptions {
 
     /// Get the maximum retained bond dimension.
     #[inline]
-    pub fn max_rank(&self) -> Option<usize> {
-        self.max_rank
+    pub fn max_bond_dim(&self) -> Option<usize> {
+        self.max_bond_dim
     }
 
     /// Get the SVD truncation policy override.
@@ -310,18 +310,18 @@ impl ContractOptions {
 ///
 /// let opts = LinsolveOptions::new(5)
 ///     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
-///     .with_max_rank(64)
+///     .with_max_bond_dim(64)
 ///     .with_gmres_tol(1e-8)
 ///     .with_coefficients(1.0, -1.0);
 ///
-/// assert_eq!(opts.max_rank(), Some(64));
+/// assert_eq!(opts.max_bond_dim(), Some(64));
 /// assert_eq!(opts.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
 /// assert_eq!(opts.nhalfsweeps(), 10);
 /// ```
 #[derive(Debug, Clone)]
 pub struct LinsolveOptions {
     nhalfsweeps: usize,
-    max_rank: Option<usize>,
+    max_bond_dim: Option<usize>,
     svd_policy: Option<SvdTruncationPolicy>,
     gmres_tol: f64,
     gmres_max_restarts: usize,
@@ -336,7 +336,7 @@ impl Default for LinsolveOptions {
     fn default() -> Self {
         Self {
             nhalfsweeps: 10,
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             gmres_tol: 1e-10,
             gmres_max_restarts: 100,
@@ -365,8 +365,8 @@ impl LinsolveOptions {
     }
 
     /// Set the maximum retained bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -428,8 +428,8 @@ impl LinsolveOptions {
 
     /// Get the maximum retained bond dimension.
     #[inline]
-    pub fn max_rank(&self) -> Option<usize> {
-        self.max_rank
+    pub fn max_bond_dim(&self) -> Option<usize> {
+        self.max_bond_dim
     }
 
     /// Get the SVD truncation policy override.

--- a/crates/tensor4all-itensorlike/src/options/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/options/tests/mod.rs
@@ -23,10 +23,10 @@ fn test_validate_svd_truncation_options_rejects_non_finite_threshold() {
 }
 
 #[test]
-fn test_validate_svd_truncation_options_rejects_zero_max_rank() {
+fn test_validate_svd_truncation_options_rejects_zero_max_bond_dim() {
     let err =
         validate_svd_truncation_options(Some(0), Some(SvdTruncationPolicy::new(1e-8))).unwrap_err();
-    assert!(err.to_string().contains("max_rank/maxdim"));
+    assert!(err.to_string().contains("max_bond_dim/maxdim"));
 }
 
 #[test]
@@ -36,11 +36,11 @@ fn test_truncate_options_builder() {
         .with_discarded_tail_sum();
     let opts = TruncateOptions::svd()
         .with_svd_policy(policy)
-        .with_max_rank(50)
+        .with_max_bond_dim(50)
         .with_site_range(0..5);
 
     assert_eq!(opts.svd_policy(), Some(policy));
-    assert_eq!(opts.max_rank(), Some(50));
+    assert_eq!(opts.max_bond_dim(), Some(50));
     assert_eq!(opts.site_range(), Some(0..5));
 }
 
@@ -48,7 +48,7 @@ fn test_truncate_options_builder() {
 fn test_truncate_options_default() {
     let opts = TruncateOptions::default();
     assert_eq!(opts.svd_policy(), None);
-    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.max_bond_dim(), None);
     assert_eq!(opts.site_range(), None);
 }
 
@@ -56,13 +56,13 @@ fn test_truncate_options_default() {
 fn test_contract_options_builder() {
     let policy = SvdTruncationPolicy::new(1e-12);
     let opts = ContractOptions::zipup()
-        .with_max_rank(100)
+        .with_max_bond_dim(100)
         .with_svd_policy(policy)
         .with_nhalfsweeps(6)
         .with_dense_reference_limit(256);
 
     assert_eq!(opts.method(), ContractMethod::Zipup);
-    assert_eq!(opts.max_rank(), Some(100));
+    assert_eq!(opts.max_bond_dim(), Some(100));
     assert_eq!(opts.svd_policy(), Some(policy));
     assert_eq!(opts.nhalfsweeps(), 6);
     assert_eq!(opts.dense_reference_limit(), Some(256));
@@ -81,7 +81,7 @@ fn test_contract_options_default() {
     assert_eq!(opts.method(), ContractMethod::Zipup);
     assert_eq!(opts.nhalfsweeps(), 2);
     assert_eq!(opts.svd_policy(), None);
-    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.max_bond_dim(), None);
     assert_eq!(opts.dense_reference_limit(), None);
 }
 
@@ -117,7 +117,7 @@ fn test_linsolve_options_default() {
     assert_eq!(opts.convergence_tol(), None);
     assert!(opts.check_residual());
     assert_eq!(opts.svd_policy(), None);
-    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.max_bond_dim(), None);
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn test_linsolve_options_builder() {
     let opts = LinsolveOptions::default()
         .with_nsweeps(10)
         .with_svd_policy(policy)
-        .with_max_rank(100)
+        .with_max_bond_dim(100)
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(200)
         .with_gmres_restart_dim(50)
@@ -144,7 +144,7 @@ fn test_linsolve_options_builder() {
 
     assert_eq!(opts.nhalfsweeps(), 20);
     assert_eq!(opts.svd_policy(), Some(policy));
-    assert_eq!(opts.max_rank(), Some(100));
+    assert_eq!(opts.max_bond_dim(), Some(100));
     assert_eq!(opts.gmres_tol(), 1e-8);
     assert_eq!(opts.gmres_max_restarts(), 200);
     assert_eq!(opts.gmres_restart_dim(), 50);

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -1169,7 +1169,7 @@ impl TensorTrain {
     /// assert_eq!(tt.max_bond_dim(), 4);
     ///
     /// // Truncate bond dimension to at most 2
-    /// let opts = TruncateOptions::svd().with_max_rank(2);
+    /// let opts = TruncateOptions::svd().with_max_bond_dim(2);
     /// tt.truncate(&opts).unwrap();
     /// assert!(tt.max_bond_dim() <= 2);
     /// ```
@@ -1178,15 +1178,15 @@ impl TensorTrain {
             return Ok(());
         }
 
-        validate_svd_truncation_options(options.max_rank(), options.svd_policy())?;
+        validate_svd_truncation_options(options.max_bond_dim(), options.svd_policy())?;
 
         // Convert TruncateOptions to TruncationOptions
         let mut treetn_options = TruncationOptions::new();
         if let Some(policy) = options.svd_policy() {
             treetn_options = treetn_options.with_svd_policy(policy);
         }
-        if let Some(max_rank) = options.max_rank() {
-            treetn_options = treetn_options.with_max_rank(max_rank);
+        if let Some(max_bond_dim) = options.max_bond_dim() {
+            treetn_options = treetn_options.with_max_bond_dim(max_bond_dim);
         }
 
         // Truncate towards the last site (rightmost) as the canonical center

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -376,7 +376,7 @@ fn test_orthogonalize_with_ci() {
 }
 
 #[test]
-fn test_truncate_with_max_rank() {
+fn test_truncate_with_max_bond_dim() {
     // Create a 3-site tensor train with large bond dimension
     let s0 = idx(0, 4);
     let l01 = idx(1, 8);
@@ -392,7 +392,7 @@ fn test_truncate_with_max_rank() {
     assert_eq!(tt.max_bond_dim(), 8);
 
     // Truncate to max rank 4
-    let options = TruncateOptions::svd().with_max_rank(4);
+    let options = TruncateOptions::svd().with_max_bond_dim(4);
     tt.truncate(&options).unwrap();
 
     // Check that bond dimensions are reduced
@@ -419,7 +419,9 @@ fn test_contract_with_fit_method() {
     let tt2 = TensorTrain::new(vec![t2_0, t2_1]).unwrap();
 
     // Test contract with Fit method
-    let options = ContractOptions::fit().with_max_rank(10).with_nhalfsweeps(4); // 4 half-sweeps = 2 full sweeps
+    let options = ContractOptions::fit()
+        .with_max_bond_dim(10)
+        .with_nhalfsweeps(4); // 4 half-sweeps = 2 full sweeps
     let result = tt1.contract_pair(&tt2, &options);
     assert!(result.is_ok());
     let result_tt = result.unwrap();
@@ -485,7 +487,9 @@ fn test_contract_nhalfsweeps_conversion() {
 
     // Test that nhalfsweeps is correctly converted to nfullsweeps
     // nhalfsweeps=6 should become nfullsweeps=3
-    let options = ContractOptions::fit().with_nhalfsweeps(6).with_max_rank(10);
+    let options = ContractOptions::fit()
+        .with_nhalfsweeps(6)
+        .with_max_bond_dim(10);
     let result = tt1.contract_pair(&tt2, &options);
     assert!(result.is_ok());
     let result_tt = result.unwrap();
@@ -518,7 +522,9 @@ fn test_contract_fit_odd_nhalfsweeps_errors() {
     let t2_1 = make_tensor(vec![l01_b.clone(), s1.clone()]);
     let tt2 = TensorTrain::new(vec![t2_0, t2_1]).unwrap();
 
-    let options = ContractOptions::fit().with_nhalfsweeps(1).with_max_rank(10);
+    let options = ContractOptions::fit()
+        .with_nhalfsweeps(1)
+        .with_max_bond_dim(10);
     let err = tt1.contract_pair(&tt2, &options).unwrap_err();
     assert!(matches!(err, TensorTrainError::OperationError { .. }));
 }
@@ -1306,7 +1312,7 @@ fn test_truncate_single_site_noop() {
     let t0 = make_tensor(vec![s0]);
     let mut tt = TensorTrain::new(vec![t0]).unwrap();
 
-    let options = TruncateOptions::svd().with_max_rank(2);
+    let options = TruncateOptions::svd().with_max_bond_dim(2);
     tt.truncate(&options).unwrap();
     assert_eq!(tt.len(), 1);
 }

--- a/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
+++ b/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
@@ -119,7 +119,7 @@ fn bench_truncate() {
         let mut mps = make_random_mps(n, 2, 16, 123);
         let opts = TruncateOptions::svd()
             .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-            .with_max_rank(8);
+            .with_max_bond_dim(8);
         time_it(&format!("truncate({n} sites, bd=16→8)"), || {
             mps.truncate(&opts).unwrap();
         });
@@ -134,7 +134,7 @@ fn bench_contract_zipup() {
         let (a, b) = make_random_mpo_pair(n, 2, 8);
         let opts = ContractOptions::zipup()
             .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-            .with_max_rank(16);
+            .with_max_bond_dim(16);
         time_it(&format!("zipup({n} sites, bd=8)"), || {
             let _ = a.contract(&b, &opts).unwrap();
         });
@@ -149,7 +149,7 @@ fn bench_contract_fit() {
         let (a, b) = make_random_mpo_pair(n, 2, 8);
         let opts = ContractOptions::fit()
             .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-6))
-            .with_max_rank(16);
+            .with_max_bond_dim(16);
         time_it(&format!("fit({n} sites, bd=8)"), || {
             let _ = a.contract(&b, &opts).unwrap();
         });

--- a/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
@@ -1,11 +1,11 @@
-//! Bug: fit() does not allow bond dimension growth during sweeps when max_rank
+//! Bug: fit() does not allow bond dimension growth during sweeps when max_bond_dim
 //! is not specified and rtol truncates the initial zipup guess.
 //!
 //! Scenario:
-//!   1. User calls fit() with rtol but without max_rank
+//!   1. User calls fit() with rtol but without max_bond_dim
 //!   2. The zipup initialization uses this rtol, truncating to small bonds
 //!   3. During fit sweeps, bond dimensions are capped at the zipup value
-//!      (because max_rank is None, the code falls back to existing bond dim)
+//!      (because max_bond_dim is None, the code falls back to existing bond dim)
 //!   4. Fit cannot grow bonds beyond the zipup initialization → accuracy loss
 //!
 //! In Julia's ITensorMPS.jl, maxdim defaults to typemax(Int), so bonds grow
@@ -43,13 +43,13 @@ fn create_random_mpo(
 
 /// Demonstrates the bond capping bug with rtol-based truncation.
 ///
-/// When fit() is called with rtol (no max_rank):
+/// When fit() is called with rtol (no max_bond_dim):
 /// - Zipup initialization truncates bonds using rtol
-/// - Fit sweeps cap bonds at zipup's bond dims (because max_rank=None → fallback to existing)
+/// - Fit sweeps cap bonds at zipup's bond dims (because max_bond_dim=None → fallback to existing)
 /// - This prevents fit from improving accuracy by growing bonds
 ///
 /// Expected (Julia-like behavior): fit should be able to grow bonds during sweeps
-/// when max_rank is not specified, using only rtol for truncation control.
+/// when max_bond_dim is not specified, using only rtol for truncation control.
 #[test]
 fn test_fit_bond_growth_with_rtol() {
     let length = 4;
@@ -114,9 +114,9 @@ fn test_fit_bond_growth_with_rtol() {
         "Test setup: zipup should truncate (got {zipup_bd} >= exact {exact_bd})"
     );
 
-    // Fit with same rtol, NO max_rank:
+    // Fit with same rtol, NO max_bond_dim:
     // Bug: zipup init uses rtol → truncates to small bonds.
-    //       Fit sweeps cap at existing bonds (because max_rank=None).
+    //       Fit sweeps cap at existing bonds (because max_bond_dim=None).
     //       Bonds cannot grow → accuracy limited by zipup.
     // Expected: fit should be free to grow bonds during sweeps and achieve
     //           better accuracy than zipup alone (limited only by rtol).
@@ -154,7 +154,7 @@ fn test_fit_bond_growth_with_rtol() {
         / exact_norm;
     eprintln!("fit(rtol={rtol},4sw) max bond: {fit4_bd}, rel_err = {fit4_err:.6e}");
 
-    // Control: fit with small rtol (no truncation), no max_rank
+    // Control: fit with small rtol (no truncation), no max_bond_dim
     let result_fit_small_rtol = mpo_a
         .contract(
             &mpo_b,

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -78,7 +78,7 @@ fn create_function_2d_tt(
     tensors.push(remaining);
     let mut tt = TensorTrain::new(tensors).unwrap();
     if max_bond > 0 {
-        let trunc = TruncateOptions::svd().with_max_rank(max_bond);
+        let trunc = TruncateOptions::svd().with_max_bond_dim(max_bond);
         tt.truncate(&trunc).unwrap();
     }
     tt

--- a/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
@@ -1,8 +1,8 @@
 //! Tests for fit bond dimension capping behavior.
 //!
 //! Verifies the bond capping rules during fit sweeps:
-//! - max_rank specified: bonds capped at max_rank
-//! - rtol > 0 specified (no max_rank): bonds free to grow (rtol controls truncation)
+//! - max_bond_dim specified: bonds capped at max_bond_dim
+//! - rtol > 0 specified (no max_bond_dim): bonds free to grow (rtol controls truncation)
 //! - neither specified (or rtol=0): bonds capped at zipup initialization size
 //! - rtol=0 explicit and rtol unspecified should behave identically
 
@@ -131,37 +131,37 @@ fn test_fit_zero_threshold_matches_no_policy_bond_dims() {
     );
 }
 
-/// fit() with max_rank should cap bond dimensions at the given value.
+/// fit() with max_bond_dim should cap bond dimensions at the given value.
 #[test]
-fn test_fit_max_rank_caps_bonds() {
+fn test_fit_max_bond_dim_caps_bonds() {
     let t = setup_test_mpos(TEST_LENGTH, TEST_PHYS_DIM, TEST_BOND_DIM);
-    let max_rank = 5;
+    let max_bond_dim = 5;
 
     let result = t
         .mpo_a
         .contract(
             &t.mpo_b,
             &ContractOptions::fit()
-                .with_max_rank(max_rank)
+                .with_max_bond_dim(max_bond_dim)
                 .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-12)),
         )
         .unwrap();
     let result_bd = result.max_bond_dim();
 
-    eprintln!("fit(max_rank={max_rank}, rtol=1e-12): bd={result_bd}");
+    eprintln!("fit(max_bond_dim={max_bond_dim}, rtol=1e-12): bd={result_bd}");
 
     assert!(
-        result_bd <= max_rank,
-        "fit(max_rank={max_rank}) should cap bonds: got {result_bd}"
+        result_bd <= max_bond_dim,
+        "fit(max_bond_dim={max_bond_dim}) should cap bonds: got {result_bd}"
     );
 }
 
-/// fit() with max_rank should take precedence over rtol for bond capping,
+/// fit() with max_bond_dim should take precedence over rtol for bond capping,
 /// even when rtol would allow larger bonds.
 #[test]
-fn test_fit_max_rank_overrides_rtol() {
+fn test_fit_max_bond_dim_overrides_rtol() {
     let t = setup_test_mpos(TEST_LENGTH, TEST_PHYS_DIM, TEST_BOND_DIM);
-    let max_rank = 5;
+    let max_bond_dim = 5;
     let rtol = 1e-12; // very small → would allow large bonds
 
     let result = t
@@ -169,13 +169,13 @@ fn test_fit_max_rank_overrides_rtol() {
         .contract(
             &t.mpo_b,
             &ContractOptions::fit()
-                .with_max_rank(max_rank)
+                .with_max_bond_dim(max_bond_dim)
                 .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
         )
         .unwrap();
     let result_bd = result.max_bond_dim();
 
-    // Without max_rank, rtol=1e-12 produces large bonds
+    // Without max_bond_dim, rtol=1e-12 produces large bonds
     let result_no_cap = t
         .mpo_a
         .contract(
@@ -186,20 +186,20 @@ fn test_fit_max_rank_overrides_rtol() {
         .unwrap();
     let no_cap_bd = result_no_cap.max_bond_dim();
 
-    eprintln!("fit(max_rank={max_rank}, rtol={rtol}): bd={result_bd}");
+    eprintln!("fit(max_bond_dim={max_bond_dim}, rtol={rtol}): bd={result_bd}");
     eprintln!("fit(rtol={rtol}):                      bd={no_cap_bd}");
 
     assert!(
-        result_bd <= max_rank,
-        "max_rank should cap bonds even with small rtol: got {result_bd}"
+        result_bd <= max_bond_dim,
+        "max_bond_dim should cap bonds even with small rtol: got {result_bd}"
     );
     assert!(
-        no_cap_bd > max_rank,
-        "Test setup: fit without max_rank should have larger bonds: got {no_cap_bd}"
+        no_cap_bd > max_bond_dim,
+        "Test setup: fit without max_bond_dim should have larger bonds: got {no_cap_bd}"
     );
 }
 
-/// fit() with positive rtol (no max_rank) should allow bond growth beyond
+/// fit() with positive rtol (no max_bond_dim) should allow bond growth beyond
 /// the zipup initialization. Smaller rtol → larger bonds.
 #[test]
 fn test_fit_rtol_controls_bond_growth() {

--- a/crates/tensor4all-itensorlike/tests/linsolve_mpo.rs
+++ b/crates/tensor4all-itensorlike/tests/linsolve_mpo.rs
@@ -68,7 +68,7 @@ fn test_linsolve_identity_mpo_distinct_output_indices() {
     let options = LinsolveOptions::new(3)
         .with_gmres_tol(1e-10)
         .with_gmres_restart_dim(10)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let result = operator.linsolve(&rhs, init, &options).unwrap();
 
@@ -126,7 +126,7 @@ fn test_linsolve_identity_mpo_accepts_complex_coefficients() {
     let options = LinsolveOptions::new(3)
         .with_gmres_tol(1e-10)
         .with_gmres_restart_dim(10)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_coefficients(0.0, Complex64::new(0.0, 1.0));
 
     let result = operator.linsolve(&rhs, init, &options).unwrap();

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
@@ -363,7 +363,7 @@ fn validate_inputs(
             "TCI max_iter must be positive".to_string(),
         ));
     }
-    if options.tci_options.max_bond_dim == 0 {
+    if options.tci_options.max_bond_dim == Some(0) {
         return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
             "TCI max_bond_dim must be positive".to_string(),
         ));

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
@@ -100,7 +100,7 @@ fn rank_cap_forces_disjoint_exact_child_patches() {
     let options = AdaptiveInterpolateOptions {
         tci_options: TCI2Options {
             tolerance: 1.0e-14,
-            max_bond_dim: 1,
+            max_bond_dim: Some(1),
             max_iter: 4,
             ncheck_history: 1,
             nsearch: 0,
@@ -332,7 +332,7 @@ fn rejects_invalid_scalar_options_and_site_lists() {
             ..TCI2Options::default()
         },
         TCI2Options {
-            max_bond_dim: 0,
+            max_bond_dim: Some(0),
             ..TCI2Options::default()
         },
         TCI2Options {

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -297,8 +297,8 @@ impl PartitionedTT {
                     if let Some(policy) = options.svd_policy() {
                         truncate_opts = truncate_opts.with_svd_policy(policy);
                     }
-                    if let Some(max_rank) = options.max_rank() {
-                        truncate_opts = truncate_opts.with_max_rank(max_rank);
+                    if let Some(max_bond_dim) = options.max_bond_dim() {
+                        truncate_opts = truncate_opts.with_max_bond_dim(max_bond_dim);
                     }
                     summed_tt
                         .truncate(&truncate_opts)

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
@@ -582,8 +582,8 @@ fn test_partitioned_tt_contract_with_duplicate_projectors() {
 }
 
 #[test]
-fn test_partitioned_tt_contract_with_rtol_and_max_rank() {
-    // Exercise the contract() branches that pass rtol and max_rank to TruncateOptions
+fn test_partitioned_tt_contract_with_rtol_and_max_bond_dim() {
+    // Exercise the contract() branches that pass rtol and max_bond_dim to TruncateOptions
     let s0 = make_index(2);
     let l01 = make_index(3);
     let s1 = make_index(2);
@@ -605,7 +605,7 @@ fn test_partitioned_tt_contract_with_rtol_and_max_rank() {
 
     let options = ContractOptions::default()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-12))
-        .with_max_rank(10);
+        .with_max_bond_dim(10);
     let result = partitioned1.contract(&partitioned2, &options).unwrap();
 
     assert!(!result.is_empty());

--- a/crates/tensor4all-partitionedtt/src/patching.rs
+++ b/crates/tensor4all-partitionedtt/src/patching.rs
@@ -56,7 +56,7 @@ pub enum PatchSplitStrategy {
 ///
 /// let options = PatchingOptions::default();
 /// assert_eq!(options.rtol, 1e-12);
-/// assert_eq!(options.max_bond_dim, 100);
+/// assert_eq!(options.max_bond_dim, Some(100));
 /// assert!(options.patch_order.is_empty());
 /// assert_eq!(options.split_strategy, tensor4all_partitionedtt::PatchSplitStrategy::ExactParameterGain);
 /// ```
@@ -73,7 +73,7 @@ pub struct PatchingOptions {
     ///
     /// Values above this cap trigger splitting when `patch_order` contains an
     /// unprojected index for the patch. The value must be at least 1.
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
 
     /// Static fallback order for patch splitting.
     ///
@@ -94,7 +94,7 @@ impl Default for PatchingOptions {
     fn default() -> Self {
         Self {
             rtol: 1e-12,
-            max_bond_dim: 100,
+            max_bond_dim: Some(100),
             patch_order: Vec::new(),
             split_strategy: PatchSplitStrategy::default(),
         }
@@ -133,7 +133,7 @@ impl Default for PatchingOptions {
 /// let tt = TensorTrain::new(vec![t0, t1])?;
 /// let options = PatchingOptions {
 ///     rtol: 1e-12,
-///     max_bond_dim: 1,
+///     max_bond_dim: Some(1),
 ///     patch_order: vec![s0],
 ///     split_strategy: tensor4all_partitionedtt::PatchSplitStrategy::Sequential,
 /// };
@@ -157,9 +157,11 @@ pub fn add_with_patching(
     loop {
         working = assign_volume_budgets(working, options.rtol)?;
         working = budget_truncate_for_split_decision(working)?;
-        let over_budget = working
-            .iter()
-            .any(|subdomain| subdomain.max_bond_dim() > options.max_bond_dim);
+        let over_budget = working.iter().any(|subdomain| {
+            options
+                .max_bond_dim
+                .is_some_and(|cap| subdomain.max_bond_dim() > cap)
+        });
         if !over_budget {
             let partitioned = PartitionedTT::from_subdomains(working)?;
             return truncate_adaptive(&partitioned, options.rtol, options.max_bond_dim);
@@ -168,7 +170,10 @@ pub fn add_with_patching(
         let mut next = Vec::new();
         let mut split_any = false;
         for subdomain in working {
-            if subdomain.max_bond_dim() > options.max_bond_dim {
+            if options
+                .max_bond_dim
+                .is_some_and(|cap| subdomain.max_bond_dim() > cap)
+            {
                 if let Some(children) = split_subdomain_by_patch_order(&subdomain, options)? {
                     split_any = true;
                     next.extend(children);
@@ -256,7 +261,7 @@ pub fn add_with_patching(
 /// )?));
 /// let patching = PatchingOptions {
 ///     rtol: 0.0,
-///     max_bond_dim: 1,
+///     max_bond_dim: Some(1),
 ///     patch_order: vec![s0],
 ///     split_strategy: PatchSplitStrategy::Sequential,
 /// };
@@ -334,7 +339,7 @@ pub fn contract_adaptive(
 /// let low = SubDomainTT::new(rank_one_tt(&s0, &s1, 0.01)?, low_proj.clone());
 /// let partitioned = PartitionedTT::from_subdomains(vec![high, low])?;
 ///
-/// let truncated = truncate_adaptive(&partitioned, 0.01, 4)?;
+/// let truncated = truncate_adaptive(&partitioned, 0.01, Some(4))?;
 ///
 /// assert_eq!(truncated.len(), 1);
 /// assert!(truncated.contains(&high_proj));
@@ -345,7 +350,7 @@ pub fn contract_adaptive(
 pub fn truncate_adaptive(
     partitioned: &PartitionedTT,
     rtol: f64,
-    max_bond_dim: usize,
+    max_bond_dim: Option<usize>,
 ) -> Result<PartitionedTT> {
     validate_truncation_options(rtol, max_bond_dim)?;
 
@@ -460,13 +465,13 @@ fn budget_truncate_for_split_decision(subdomains: Vec<SubDomainTT>) -> Result<Ve
     Ok(retained)
 }
 
-fn validate_truncation_options(rtol: f64, max_bond_dim: usize) -> Result<()> {
+fn validate_truncation_options(rtol: f64, max_bond_dim: Option<usize>) -> Result<()> {
     if !rtol.is_finite() || rtol < 0.0 {
         return Err(PartitionedTTError::InvalidOptions(
             "rtol must be finite and non-negative".to_string(),
         ));
     }
-    if max_bond_dim == 0 {
+    if max_bond_dim == Some(0) {
         return Err(PartitionedTTError::InvalidOptions(
             "max_bond_dim must be at least 1".to_string(),
         ));
@@ -519,19 +524,19 @@ fn subdomain_volume(subdomain: &SubDomainTT) -> Result<usize> {
 fn truncate_subdomain_with_budget(
     subdomain: &mut SubDomainTT,
     budget_squared: f64,
-    max_bond_dim: usize,
+    max_bond_dim: Option<usize>,
 ) -> Result<f64> {
-    truncate_subdomain_with_optional_max_rank(subdomain, budget_squared, Some(max_bond_dim))
+    truncate_subdomain_with_optional_max_bond_dim(subdomain, budget_squared, max_bond_dim)
 }
 
 fn truncate_subdomain_with_budget_only(
     subdomain: &mut SubDomainTT,
     budget_squared: f64,
 ) -> Result<f64> {
-    truncate_subdomain_with_optional_max_rank(subdomain, budget_squared, None)
+    truncate_subdomain_with_optional_max_bond_dim(subdomain, budget_squared, None)
 }
 
-fn truncate_subdomain_with_optional_max_rank(
+fn truncate_subdomain_with_optional_max_bond_dim(
     subdomain: &mut SubDomainTT,
     budget_squared: f64,
     max_bond_dim: Option<usize>,
@@ -543,7 +548,7 @@ fn truncate_subdomain_with_optional_max_rank(
         .with_discarded_tail_sum();
     let mut options = TruncateOptions::svd().with_svd_policy(policy);
     if let Some(max_bond_dim) = max_bond_dim {
-        options = options.with_max_rank(max_bond_dim);
+        options = options.with_max_bond_dim(max_bond_dim);
     }
     subdomain.truncate(&options)?;
     let after = subdomain.norm_squared()?;

--- a/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
@@ -120,7 +120,7 @@ fn test_add_with_patching_splits_unprojected_patch_when_bond_hits_cap() {
 
     let options = PatchingOptions {
         rtol: 1e-12,
-        max_bond_dim: 1,
+        max_bond_dim: Some(1),
         patch_order: vec![site_inds[0].clone()],
         split_strategy: PatchSplitStrategy::Sequential,
     };
@@ -133,7 +133,9 @@ fn test_add_with_patching_splits_unprojected_patch_when_bond_hits_cap() {
     assert!(result.contains(&proj0));
     assert!(result.contains(&proj1));
     for subdomain in result.values() {
-        assert!(subdomain.max_bond_dim() <= options.max_bond_dim);
+        assert!(options
+            .max_bond_dim
+            .is_none_or(|cap| subdomain.max_bond_dim() <= cap));
         assert!(subdomain.budget_squared().is_some());
     }
 }
@@ -146,7 +148,7 @@ fn test_add_with_patching_truncates_before_deciding_to_split() {
 
     let options = PatchingOptions {
         rtol: 0.0,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         patch_order: vec![site_inds[0].clone()],
         split_strategy: PatchSplitStrategy::Sequential,
     };
@@ -169,7 +171,7 @@ fn test_truncate_adaptive_drops_patch_below_volume_budget() {
     let low = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 0.01), low_proj.clone());
     let partitioned = PartitionedTT::from_subdomains(vec![high, low]).unwrap();
 
-    let result = truncate_adaptive(&partitioned, 0.01, 4).unwrap();
+    let result = truncate_adaptive(&partitioned, 0.01, Some(4)).unwrap();
 
     assert_eq!(result.len(), 1);
     assert!(result.contains(&high_proj));
@@ -189,7 +191,7 @@ fn test_truncate_adaptive_assigns_volume_proportional_budgets() {
     );
     let partitioned = PartitionedTT::from_subdomains(vec![wide, narrow]).unwrap();
 
-    let result = truncate_adaptive(&partitioned, 1e-12, 4).unwrap();
+    let result = truncate_adaptive(&partitioned, 1e-12, Some(4)).unwrap();
     let wide_budget = result
         .get(&wide_proj)
         .and_then(SubDomainTT::budget_squared)
@@ -206,10 +208,10 @@ fn test_truncate_adaptive_assigns_volume_proportional_budgets() {
 fn test_truncate_adaptive_rejects_invalid_options() {
     let empty = PartitionedTT::new();
 
-    let bad_rtol = truncate_adaptive(&empty, f64::NAN, 1).unwrap_err();
+    let bad_rtol = truncate_adaptive(&empty, f64::NAN, Some(1)).unwrap_err();
     assert!(matches!(bad_rtol, PartitionedTTError::InvalidOptions(_)));
 
-    let bad_rank = truncate_adaptive(&empty, 1e-12, 0).unwrap_err();
+    let bad_rank = truncate_adaptive(&empty, 1e-12, Some(0)).unwrap_err();
     assert!(matches!(bad_rank, PartitionedTTError::InvalidOptions(_)));
 }
 
@@ -230,7 +232,7 @@ fn test_contract_adaptive_retruncates_output_with_corrected_norm() {
     )));
     let patching = PatchingOptions {
         rtol: 0.0,
-        max_bond_dim: 1,
+        max_bond_dim: Some(1),
         patch_order: vec![s0],
         split_strategy: PatchSplitStrategy::Sequential,
     };
@@ -238,9 +240,9 @@ fn test_contract_adaptive_retruncates_output_with_corrected_norm() {
     let result = contract_adaptive(&left, &right, &ContractOptions::default(), &patching).unwrap();
 
     assert_eq!(result.len(), 1);
-    assert!(result
-        .values()
-        .all(|subdomain| subdomain.max_bond_dim() <= patching.max_bond_dim));
+    assert!(result.values().all(|subdomain| patching
+        .max_bond_dim
+        .is_none_or(|cap| subdomain.max_bond_dim() <= cap)));
 }
 
 #[test]
@@ -250,7 +252,7 @@ fn test_exact_parameter_gain_strategy_can_override_sequential_order() {
 
     let sequential = PatchingOptions {
         rtol: 1e-12,
-        max_bond_dim: 1,
+        max_bond_dim: Some(1),
         patch_order: vec![site_inds[0].clone(), site_inds[1].clone()],
         split_strategy: PatchSplitStrategy::Sequential,
     };

--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -174,7 +174,7 @@ where
 ///
 /// # Returns
 ///
-/// Tuple of ([`QuanticsTensorCI2Batched`], max_ranks_across_components, max_errors_across_components)
+/// Tuple of ([`QuanticsTensorCI2Batched`], max_bond_dims_across_components, max_errors_across_components)
 ///
 /// # Errors
 ///
@@ -294,10 +294,10 @@ where
 
     // Compute aggregate ranks and errors (element-wise max across components).
     let max_len = all_ranks.iter().map(|r| r.len()).max().unwrap_or(0);
-    let mut max_ranks = vec![0usize; max_len];
+    let mut max_bond_dims = vec![0usize; max_len];
     for ranks in &all_ranks {
         for (i, &r) in ranks.iter().enumerate() {
-            max_ranks[i] = max_ranks[i].max(r);
+            max_bond_dims[i] = max_bond_dims[i].max(r);
         }
     }
 
@@ -315,7 +315,7 @@ where
         grid: grid.clone(),
     };
 
-    Ok((result, max_ranks, max_errors))
+    Ok((result, max_bond_dims, max_errors))
 }
 
 /// Combine per-component tensor trains into a single TT with a component

--- a/crates/tensor4all-quanticstci/src/options.rs
+++ b/crates/tensor4all-quanticstci/src/options.rs
@@ -277,14 +277,14 @@ impl QtciOptions {
     ///     .with_maxiter(100);
     /// let tree_opts = opts.to_treetci_options();
     /// assert!((tree_opts.tolerance - 1e-10).abs() < 1e-18);
-    /// assert_eq!(tree_opts.max_bond_dim, 64);
+    /// assert_eq!(tree_opts.max_bond_dim, Some(64));
     /// assert_eq!(tree_opts.max_iter, 100);
     /// ```
     pub fn to_treetci_options(&self) -> TreeTciOptions {
         TreeTciOptions {
             tolerance: self.tolerance,
             max_iter: self.maxiter,
-            max_bond_dim: self.max_bond_dim.unwrap_or(usize::MAX),
+            max_bond_dim: self.max_bond_dim,
             normalize_error: self.normalize_error,
         }
     }

--- a/crates/tensor4all-quanticstci/src/options/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/options/tests/mod.rs
@@ -36,7 +36,7 @@ fn test_to_treetci_options() {
 
     let tree_opts = opts.to_treetci_options();
     assert!((tree_opts.tolerance - 1e-6).abs() < 1e-15);
-    assert_eq!(tree_opts.max_bond_dim, 100);
+    assert_eq!(tree_opts.max_bond_dim, Some(100));
     assert_eq!(tree_opts.max_iter, 200);
     assert!(tree_opts.normalize_error);
 }

--- a/crates/tensor4all-quanticstci/tests/feature_test_physicist.rs
+++ b/crates/tensor4all-quanticstci/tests/feature_test_physicist.rs
@@ -543,7 +543,7 @@ fn options_builder_all_fields() {
     // Verify conversion to TreeTciOptions preserves key fields
     let tree_opts = opts.to_treetci_options();
     assert!((tree_opts.tolerance - 1e-6).abs() < 1e-15);
-    assert_eq!(tree_opts.max_bond_dim, 50);
+    assert_eq!(tree_opts.max_bond_dim, Some(50));
     assert_eq!(tree_opts.max_iter, 100);
 }
 

--- a/crates/tensor4all-quanticstransform/src/fourier.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier.rs
@@ -76,18 +76,18 @@ fn zero_tensor3(
 /// assert_eq!(inv.sign, 1.0);
 /// // Custom options
 /// let opts = FourierOptions {
-///     max_bond_dim: 20,
+///     max_bond_dim: Some(20),
 ///     tolerance: 1e-12,
 ///     ..FourierOptions::forward()
 /// };
-/// assert_eq!(opts.max_bond_dim, 20);
+/// assert_eq!(opts.max_bond_dim, Some(20));
 /// ```
 #[derive(Clone, Debug)]
 pub struct FourierOptions {
     /// Sign in the exponent: -1.0 (forward) or 1.0 (inverse)
     pub sign: f64,
     /// Maximum bond dimension after compression
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
     /// Tolerance for compression
     pub tolerance: f64,
     /// Number of Chebyshev basis functions (K+1 points); must be positive.
@@ -100,7 +100,7 @@ impl Default for FourierOptions {
     fn default() -> Self {
         Self {
             sign: -1.0,
-            max_bond_dim: 12,
+            max_bond_dim: Some(12),
             tolerance: 1e-14,
             k: 25,
             normalize: true,

--- a/crates/tensor4all-quanticstransform/src/fourier/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier/tests/mod.rs
@@ -49,7 +49,9 @@ fn test_fourier_mpo_structure() {
     // Bond dimensions should be compressed from K+1
     // After compression, they should be <= max_bond_dim
     for i in 0..3 {
-        assert!(mpo.site_tensor(i).right_dim() <= options.max_bond_dim);
+        assert!(options
+            .max_bond_dim
+            .is_none_or(|cap| mpo.site_tensor(i).right_dim() <= cap));
     }
 }
 

--- a/crates/tensor4all-simplett/src/canonical.rs
+++ b/crates/tensor4all-simplett/src/canonical.rs
@@ -17,7 +17,7 @@ use tensor4all_tensorbackend::{mat_mul, transpose, Matrix};
 /// Compute QR decomposition using rank-revealing LU with left-orthogonal output
 fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> Result<(Matrix<T>, Matrix<T>)> {
     let options = RrLUOptions {
-        max_rank: matrix.ncols().min(matrix.nrows()),
+        max_bond_dim: matrix.ncols().min(matrix.nrows()),
         rel_tol: 0.0, // No truncation
         abs_tol: 0.0,
         left_orthogonal: true,

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -53,7 +53,7 @@ pub enum CompressionMethod {
 /// |-------|---------|---------|
 /// | `method` | `LU` | Decomposition algorithm (see [`CompressionMethod`]) |
 /// | `tolerance` | `1e-12` | Relative truncation threshold per bond |
-/// | `max_bond_dim` | `usize::MAX` | Hard upper bound on any bond dimension |
+/// | `max_bond_dim` | `None` | Hard upper bound on any bond dimension |
 /// | `normalize_error` | `true` | Whether error is measured relative to the norm |
 ///
 /// # Choosing `tolerance`

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -73,13 +73,13 @@ pub enum CompressionMethod {
 /// let opts = CompressionOptions::default();
 /// assert_eq!(opts.method, CompressionMethod::LU);
 /// assert!((opts.tolerance - 1e-12).abs() < 1e-15);
-/// assert_eq!(opts.max_bond_dim, usize::MAX);
+/// assert_eq!(opts.max_bond_dim, None);
 ///
 /// // Custom: SVD with moderate tolerance and bond dim cap
 /// let opts = CompressionOptions {
 ///     method: CompressionMethod::SVD,
 ///     tolerance: 1e-6,
-///     max_bond_dim: 50,
+///     max_bond_dim: Some(50),
 ///     ..Default::default()
 /// };
 /// assert_eq!(opts.method, CompressionMethod::SVD);
@@ -97,8 +97,8 @@ pub struct CompressionOptions {
     /// Hard upper bound on any bond dimension.
     ///
     /// Even if the tolerance would allow a larger rank, the bond dimension
-    /// is capped at this value. Set to `usize::MAX` (default) for no limit.
-    pub max_bond_dim: usize,
+    /// is capped at this value. `None` (default) means no limit.
+    pub max_bond_dim: Option<usize>,
     /// Whether to normalize the truncation error by the tensor norm.
     pub normalize_error: bool,
 }
@@ -108,7 +108,7 @@ impl Default for CompressionOptions {
         Self {
             method: CompressionMethod::LU,
             tolerance: 1e-12,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             normalize_error: true,
         }
     }
@@ -157,7 +157,7 @@ fn factorize<T>(
     matrix: &Matrix<T>,
     method: CompressionMethod,
     tolerance: f64,
-    max_bond_dim: usize,
+    max_bond_dim: Option<usize>,
     left_orthogonal: bool,
 ) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
 where
@@ -174,7 +174,7 @@ where
     let abstol = 0.0;
 
     let options = RrLUOptions {
-        max_rank: max_bond_dim,
+        max_bond_dim: max_bond_dim.unwrap_or(usize::MAX),
         rel_tol: reltol,
         abs_tol: abstol,
         left_orthogonal,
@@ -203,7 +203,7 @@ where
 fn factorize_svd<T>(
     matrix: &Matrix<T>,
     tolerance: f64,
-    max_bond_dim: usize,
+    max_bond_dim: Option<usize>,
     left_orthogonal: bool,
 ) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
 where
@@ -251,7 +251,7 @@ where
 
     let mut rank = 0;
     for &singular_value in s_data.iter().take(min_dim) {
-        if rank >= max_bond_dim {
+        if max_bond_dim.is_some_and(|cap| rank >= cap) {
             break;
         }
         if singular_value < tolerance * s_max {
@@ -352,9 +352,9 @@ impl<T: TTScalar + Scalar + Default> SimpleTensorTrain<T> {
             let (left_factor, right_factor, new_bond_dim) = factorize(
                 &mat,
                 options.method,
-                0.0,        // No truncation in left sweep
-                usize::MAX, // No max bond dim in left sweep
-                true,       // left orthogonal
+                0.0,  // No truncation in left sweep
+                None, // No max bond dim in left sweep
+                true, // left orthogonal
             )?;
 
             // Update current tensor

--- a/crates/tensor4all-simplett/src/compression/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/compression/tests/mod.rs
@@ -89,7 +89,7 @@ where
     let original_norm = tt.norm();
 
     let options = CompressionOptions {
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         tolerance: 1e-12,
         ..Default::default()
     };
@@ -176,7 +176,7 @@ where
 
     let options = CompressionOptions {
         method: CompressionMethod::SVD,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         tolerance: 1e-12,
         ..Default::default()
     };

--- a/crates/tensor4all-simplett/src/contraction.rs
+++ b/crates/tensor4all-simplett/src/contraction.rs
@@ -29,14 +29,14 @@ fn contraction_helper_error(context: &str, err: impl std::fmt::Display) -> Tenso
 ///
 /// let opts = ContractionOptions::default();
 /// assert!((opts.tolerance - 1e-12).abs() < 1e-15);
-/// assert_eq!(opts.max_bond_dim, usize::MAX);
+/// assert_eq!(opts.max_bond_dim, None);
 /// ```
 #[derive(Debug, Clone)]
 pub struct ContractionOptions {
     /// Relative truncation tolerance during contraction.
     pub tolerance: f64,
-    /// Hard upper bound on bond dimension.
-    pub max_bond_dim: usize,
+    /// Hard upper bound on bond dimension. `None` (default) means no limit.
+    pub max_bond_dim: Option<usize>,
     /// Decomposition method for intermediate compression.
     pub method: CompressionMethod,
 }
@@ -45,7 +45,7 @@ impl Default for ContractionOptions {
     fn default() -> Self {
         Self {
             tolerance: 1e-12,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             method: CompressionMethod::LU,
         }
     }

--- a/crates/tensor4all-simplett/src/contraction/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/contraction/tests/mod.rs
@@ -154,7 +154,7 @@ fn test_dot_convenience_function() {
 fn test_contraction_options_default_values() {
     let opts = ContractionOptions::default();
     assert!((opts.tolerance - 1e-12).abs() < 1e-15);
-    assert_eq!(opts.max_bond_dim, usize::MAX);
+    assert_eq!(opts.max_bond_dim, None);
     assert!(matches!(opts.method, CompressionMethod::LU));
 }
 

--- a/crates/tensor4all-simplett/src/error.rs
+++ b/crates/tensor4all-simplett/src/error.rs
@@ -30,9 +30,10 @@ pub type Result<T> = std::result::Result<T, TensorTrainError>;
 /// Error type for `SimpleTensorTrain` operations.
 ///
 /// Note: `tensor4all-itensorlike` also defines a public type named
-/// [`TensorTrainError`](tensor4all_itensorlike::TensorTrainError) with
-/// different variants (its tree-based `TensorTrain`). When both crates are
-/// in scope, qualify the path (e.g. `tensor4all_simplett::TensorTrainError`
+/// `TensorTrainError` (see its
+/// [rustdoc](https://tensor4all.org/tensor4all-rs/rustdoc/tensor4all_itensorlike/error/enum.TensorTrainError.html))
+/// with different variants (its tree-based `TensorTrain`). When both crates
+/// are in scope, qualify the path (e.g. `tensor4all_simplett::TensorTrainError`
 /// vs `tensor4all_itensorlike::TensorTrainError`).
 #[derive(Error, Debug)]
 pub enum TensorTrainError {

--- a/crates/tensor4all-simplett/src/error.rs
+++ b/crates/tensor4all-simplett/src/error.rs
@@ -27,6 +27,13 @@ pub type Result<T> = std::result::Result<T, TensorTrainError>;
 /// };
 /// assert!(err.to_string().contains("test error"));
 /// ```
+/// Error type for `SimpleTensorTrain` operations.
+///
+/// Note: `tensor4all-itensorlike` also defines a public type named
+/// [`TensorTrainError`](tensor4all_itensorlike::TensorTrainError) with
+/// different variants (its tree-based `TensorTrain`). When both crates are
+/// in scope, qualify the path (e.g. `tensor4all_simplett::TensorTrainError`
+/// vs `tensor4all_itensorlike::TensorTrainError`).
 #[derive(Error, Debug)]
 pub enum TensorTrainError {
     /// Dimension mismatch between tensors

--- a/crates/tensor4all-simplett/src/mpo/contract_fit.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit.rs
@@ -22,8 +22,8 @@ pub struct FitOptions {
     /// bond's matrix. The threshold is invariant under a global rescaling of
     /// the operators being contracted.
     pub tolerance: f64,
-    /// Maximum bond dimension
-    pub max_bond_dim: usize,
+    /// Maximum bond dimension. `None` means no limit.
+    pub max_bond_dim: Option<usize>,
     /// Maximum number of sweeps
     pub max_sweeps: usize,
     /// Convergence tolerance (stop if change < this)
@@ -36,7 +36,7 @@ impl Default for FitOptions {
     fn default() -> Self {
         Self {
             tolerance: 1e-12,
-            max_bond_dim: 100,
+            max_bond_dim: Some(100),
             max_sweeps: 10,
             convergence_tol: 1e-10,
             factorize_method: FactorizeMethod::SVD,

--- a/crates/tensor4all-simplett/src/mpo/contract_fit/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit/tests/mod.rs
@@ -10,7 +10,7 @@ fn scalar_tensor4(value: f64) -> Tensor4<f64> {
 fn test_fit_options_default_values() {
     let options = FitOptions::default();
     assert_eq!(options.tolerance, 1e-12);
-    assert_eq!(options.max_bond_dim, 100);
+    assert_eq!(options.max_bond_dim, Some(100));
     assert_eq!(options.max_sweeps, 10);
     assert_eq!(options.convergence_tol, 1e-10);
     assert_eq!(options.factorize_method, FactorizeMethod::SVD);

--- a/crates/tensor4all-simplett/src/mpo/contract_naive.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive.rs
@@ -116,7 +116,7 @@ where
     let factorize_opts = FactorizeOptions {
         method: options.factorize_method,
         tolerance: options.tolerance,
-        max_rank: options.max_bond_dim,
+        max_bond_dim: options.max_bond_dim,
         left_orthogonal: true,
         ..Default::default()
     };

--- a/crates/tensor4all-simplett/src/mpo/contract_naive/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_naive/tests/mod.rs
@@ -52,7 +52,7 @@ fn test_contract_naive_with_compression() {
 
     let options = ContractionOptions {
         tolerance: 1e-10,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         factorize_method: FactorizeMethod::SVD,
     };
 
@@ -105,7 +105,7 @@ fn compression_at_a_binding_rank_cap_attains_the_optimal_truncation() {
 
     let options = ContractionOptions {
         tolerance: 0.0,
-        max_bond_dim: keep,
+        max_bond_dim: Some(keep),
         factorize_method: FactorizeMethod::SVD,
     };
     let truncated = contract_naive(&mpo_a, &mpo_b, Some(options)).unwrap();

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup.rs
@@ -86,7 +86,7 @@ where
     let factorize_opts = FactorizeOptions {
         method: options.factorize_method,
         tolerance: options.tolerance,
-        max_rank: options.max_bond_dim,
+        max_bond_dim: options.max_bond_dim,
         left_orthogonal: true,
         ..Default::default()
     };

--- a/crates/tensor4all-simplett/src/mpo/contract_zipup/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_zipup/tests/mod.rs
@@ -9,7 +9,7 @@ fn test_contract_zipup_identity() {
 
     let options = ContractionOptions {
         tolerance: 1e-12,
-        max_bond_dim: 10,
+        max_bond_dim: Some(10),
         factorize_method: FactorizeMethod::SVD,
     };
 
@@ -46,7 +46,7 @@ fn test_contract_zipup_compresses() {
 
     let options = ContractionOptions {
         tolerance: 1e-12,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         factorize_method: FactorizeMethod::SVD,
     };
 
@@ -69,7 +69,7 @@ fn test_contract_zipup_untruncated_matches_naive() {
 
     let options = ContractionOptions {
         tolerance: 0.0,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         factorize_method: FactorizeMethod::SVD,
     };
 

--- a/crates/tensor4all-simplett/src/mpo/contraction.rs
+++ b/crates/tensor4all-simplett/src/mpo/contraction.rs
@@ -23,8 +23,8 @@ pub struct ContractionOptions {
     /// bond's matrix. The threshold is invariant under a global rescaling of
     /// the operators being contracted.
     pub tolerance: f64,
-    /// Maximum bond dimension after contraction
-    pub max_bond_dim: usize,
+    /// Maximum bond dimension after contraction. `None` means no limit.
+    pub max_bond_dim: Option<usize>,
     /// Factorization method for compression
     pub factorize_method: super::factorize::FactorizeMethod,
 }
@@ -33,7 +33,7 @@ impl Default for ContractionOptions {
     fn default() -> Self {
         Self {
             tolerance: 1e-12,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             factorize_method: super::factorize::FactorizeMethod::SVD,
         }
     }

--- a/crates/tensor4all-simplett/src/mpo/factorize.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize.rs
@@ -41,7 +41,7 @@ pub struct FactorizeOptions {
     /// Smaller values preserve more accuracy but produce larger ranks.
     pub tolerance: f64,
     /// Maximum rank (bond dimension) after factorization
-    pub max_rank: usize,
+    pub max_bond_dim: Option<usize>,
     /// Whether to return the left factor as left-orthogonal
     pub left_orthogonal: bool,
     /// Number of random projections for RSVD (parameter q)
@@ -55,7 +55,7 @@ impl Default for FactorizeOptions {
         Self {
             method: FactorizeMethod::SVD,
             tolerance: 1e-12,
-            max_rank: usize::MAX,
+            max_bond_dim: None,
             left_orthogonal: true,
             rsvd_q: 2,
             rsvd_p: 10,
@@ -196,7 +196,7 @@ fn factorize_svd<T: SVDScalar>(
     let vt = typed_tensor_to_matrix2(&svd_result.vt, "svd.vt")?;
     let singular_values = typed_col_major_values(&svd_result.s, "svd.s")?;
 
-    // Determine rank based on tolerance and max_rank
+    // Determine rank based on tolerance and max_bond_dim
     let min_dim = m.min(n);
     let mut rank = 0;
     let mut total_weight: f64 = 0.0;
@@ -227,7 +227,7 @@ fn factorize_svd<T: SVDScalar>(
     if s_max > 0.0 {
         let cutoff = options.tolerance * s_max;
         for &singular_value in singular_values.iter().take(min_dim) {
-            if rank >= options.max_rank {
+            if options.max_bond_dim.is_some_and(|cap| rank >= cap) {
                 break;
             }
             let sv = T::linalg_real_to_f64(singular_value);
@@ -340,7 +340,7 @@ where
     }
 
     let lu_options = RrLUOptions {
-        max_rank: options.max_rank,
+        max_bond_dim: options.max_bond_dim.unwrap_or(usize::MAX),
         rel_tol: options.tolerance,
         abs_tol: 0.0,
         left_orthogonal: options.left_orthogonal,

--- a/crates/tensor4all-simplett/src/mpo/factorize/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/factorize/tests/mod.rs
@@ -12,7 +12,7 @@ fn test_factorize_svd() {
     let options = FactorizeOptions {
         method: FactorizeMethod::SVD,
         tolerance: 1e-12,
-        max_rank: 10,
+        max_bond_dim: Some(10),
         left_orthogonal: true,
         ..Default::default()
     };
@@ -55,7 +55,7 @@ fn test_factorize_lu() {
     let options = FactorizeOptions {
         method: FactorizeMethod::LU,
         tolerance: 1e-12,
-        max_rank: 10,
+        max_bond_dim: Some(10),
         left_orthogonal: true,
         ..Default::default()
     };
@@ -79,7 +79,7 @@ fn test_factorize_with_truncation() {
     let options = FactorizeOptions {
         method: FactorizeMethod::SVD,
         tolerance: 1e-10,
-        max_rank: 2,
+        max_bond_dim: Some(2),
         left_orthogonal: true,
         ..Default::default()
     };
@@ -122,7 +122,7 @@ fn test_factorize_svd_truncation_is_scale_invariant() {
     let options = FactorizeOptions {
         method: FactorizeMethod::SVD,
         tolerance: 1e-7,
-        max_rank: 10,
+        max_bond_dim: Some(10),
         left_orthogonal: true,
         ..Default::default()
     };
@@ -181,7 +181,7 @@ fn test_factorize_svd_complex64() {
     let options = FactorizeOptions {
         method: FactorizeMethod::SVD,
         tolerance: 1e-12,
-        max_rank: 10,
+        max_bond_dim: Some(10),
         left_orthogonal: true,
         ..Default::default()
     };

--- a/crates/tensor4all-simplett/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/tensortrain/tests/mod.rs
@@ -591,7 +591,7 @@ where
         .compress(&CompressionOptions {
             method: CompressionMethod::SVD,
             tolerance: 1e-10,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             normalize_error: true,
         })
         .unwrap();

--- a/crates/tensor4all-simplett/src/vidal.rs
+++ b/crates/tensor4all-simplett/src/vidal.rs
@@ -21,7 +21,7 @@ use tensor4all_tensorbackend::{mat_mul, svd_backend, BackendLinalgScalar, Matrix
 /// Compute QR decomposition
 fn qr_decomp<T: TTScalar + Scalar>(matrix: &Matrix<T>) -> Result<(Matrix<T>, Matrix<T>)> {
     let options = RrLUOptions {
-        max_rank: matrix.ncols().min(matrix.nrows()),
+        max_bond_dim: matrix.ncols().min(matrix.nrows()),
         rel_tol: 0.0,
         abs_tol: 0.0,
         left_orthogonal: true,

--- a/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
+++ b/crates/tensor4all-tcicore/benches/dense_vs_tenferro.rs
@@ -21,7 +21,7 @@ fn random_column_major(nrows: usize, ncols: usize, seed: u64) -> Vec<f64> {
 fn bench_dense_vs_tenferro(c: &mut Criterion) {
     let mut group = c.benchmark_group("dense_no_truncation_vs_tenferro");
     let options = RrLUOptions {
-        max_rank: usize::MAX,
+        max_bond_dim: usize::MAX,
         rel_tol: 0.0,
         abs_tol: 0.0,
         left_orthogonal: true,

--- a/crates/tensor4all-tcicore/benches/lazy_block_rook.rs
+++ b/crates/tensor4all-tcicore/benches/lazy_block_rook.rs
@@ -46,7 +46,7 @@ fn materialize_expensive(n: usize) -> Vec<f64> {
 
 fn bench_lazy_block_rook(c: &mut Criterion) {
     let options = RrLUOptions {
-        max_rank: 8,
+        max_bond_dim: 8,
         rel_tol: 0.0,
         abs_tol: 0.0,
         left_orthogonal: true,

--- a/crates/tensor4all-tcicore/benches/rrlu_bench.rs
+++ b/crates/tensor4all-tcicore/benches/rrlu_bench.rs
@@ -37,7 +37,7 @@ fn bench_rrlu(c: &mut Criterion) {
                 || random_matrix(n, n, 42),
                 |mut m| {
                     let opts = RrLUOptions {
-                        max_rank: n,
+                        max_bond_dim: n,
                         rel_tol: 0.0,
                         abs_tol: 0.0,
                         ..Default::default()

--- a/crates/tensor4all-tcicore/src/matrix_luci.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci.rs
@@ -313,7 +313,7 @@ where
 {
     let source = LazyMatrixSource::new(nrows, ncols, fill_block);
     let kernel_options = PivotKernelOptions {
-        max_rank: options.max_rank,
+        max_bond_dim: options.max_bond_dim,
         rel_tol: options.rel_tol,
         abs_tol: options.abs_tol,
         left_orthogonal: options.left_orthogonal,

--- a/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrix_luci/tests/mod.rs
@@ -175,7 +175,7 @@ fn hilbert_matrix(size: usize) -> Matrix<f64> {
 fn timed_hilbert_matrix_luci_once(size: usize, left_orthogonal: bool) -> MatrixLuciHilbertTiming {
     let matrix = hilbert_matrix(size);
     let options = RrLUOptions {
-        max_rank: usize::MAX,
+        max_bond_dim: usize::MAX,
         rel_tol: 0.0,
         abs_tol: 1.0e-10,
         left_orthogonal,

--- a/crates/tensor4all-tcicore/src/matrixlu.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu.rs
@@ -210,7 +210,7 @@ impl<T: Scalar> RrLU<T> {
     /// use tensor4all_tensorbackend::from_vec2d;
     ///
     /// let m = from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0]]);
-    /// let lu = rrlu(&m, Some(RrLUOptions { max_rank: 1, ..Default::default() })).unwrap();
+    /// let lu = rrlu(&m, Some(RrLUOptions { max_bond_dim: 1, ..Default::default() })).unwrap();
     /// let rows = lu.row_indices();
     /// assert_eq!(rows.len(), 1);
     /// assert!(rows[0] < 2);
@@ -228,7 +228,7 @@ impl<T: Scalar> RrLU<T> {
     /// use tensor4all_tensorbackend::from_vec2d;
     ///
     /// let m = from_vec2d(vec![vec![1.0_f64, 2.0], vec![3.0, 4.0]]);
-    /// let lu = rrlu(&m, Some(RrLUOptions { max_rank: 1, ..Default::default() })).unwrap();
+    /// let lu = rrlu(&m, Some(RrLUOptions { max_bond_dim: 1, ..Default::default() })).unwrap();
     /// let cols = lu.col_indices();
     /// assert_eq!(cols.len(), 1);
     /// assert!(cols[0] < 2);
@@ -681,13 +681,13 @@ fn extract_lu_from_factorized<T: Scalar>(
 /// assert!(opts.left_orthogonal);
 ///
 /// // Limit rank to 5
-/// let opts = RrLUOptions { max_rank: 5, ..Default::default() };
-/// assert_eq!(opts.max_rank, 5);
+/// let opts = RrLUOptions { max_bond_dim: 5, ..Default::default() };
+/// assert_eq!(opts.max_bond_dim, 5);
 /// ```
 #[derive(Debug, Clone)]
 pub struct RrLUOptions {
     /// Maximum rank
-    pub max_rank: usize,
+    pub max_bond_dim: usize,
     /// Relative tolerance
     pub rel_tol: f64,
     /// Absolute tolerance
@@ -699,7 +699,7 @@ pub struct RrLUOptions {
 impl Default for RrLUOptions {
     fn default() -> Self {
         Self {
-            max_rank: usize::MAX,
+            max_bond_dim: usize::MAX,
             rel_tol: 1e-14,
             abs_tol: 0.0,
             left_orthogonal: true,
@@ -729,7 +729,7 @@ impl Default for RrLUOptions {
 ///     vec![1.0_f64, 2.0],
 ///     vec![3.0, 4.0],
 /// ]);
-/// let lu = rrlu_mut(&mut m, Some(RrLUOptions { max_rank: 1, ..Default::default() })).unwrap();
+/// let lu = rrlu_mut(&mut m, Some(RrLUOptions { max_bond_dim: 1, ..Default::default() })).unwrap();
 /// assert_eq!(lu.npivots(), 1);
 /// ```
 pub fn rrlu_mut<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) -> Result<RrLU<T>> {
@@ -741,10 +741,10 @@ pub fn rrlu_mut<T: Scalar>(a: &mut Matrix<T>, options: Option<RrLUOptions>) -> R
     debug_assert_eq!(data.len(), nr * nc);
 
     let mut lu = RrLU::new(nr, nc, opts.left_orthogonal);
-    let max_rank = opts.max_rank.min(nr).min(nc);
+    let max_bond_dim = opts.max_bond_dim.min(nr).min(nc);
     let mut max_error = 0.0f64;
 
-    while lu.n_pivot < max_rank {
+    while lu.n_pivot < max_bond_dim {
         let k = lu.n_pivot;
 
         if k >= nr || k >= nc {

--- a/crates/tensor4all-tcicore/src/matrixlu/tests/mod.rs
+++ b/crates/tensor4all-tcicore/src/matrixlu/tests/mod.rs
@@ -183,9 +183,9 @@ fn test_rrlu_4x4_reconstruct() {
     }
 }
 
-/// Julia: "Truncated rank-revealing LU" (max_rank stopping)
+/// Julia: "Truncated rank-revealing LU" (max_bond_dim stopping)
 #[test]
-fn test_rrlu_max_rank() {
+fn test_rrlu_max_bond_dim() {
     let m = from_vec2d(vec![
         vec![0.684025, 0.784249, 0.826742, 0.054321, 0.0234695, 0.467096],
         vec![0.73928, 0.295516, 0.877126, 0.111711, 0.103509, 0.653785],
@@ -198,7 +198,7 @@ fn test_rrlu_max_rank() {
     ]);
 
     let opts = RrLUOptions {
-        max_rank: 4,
+        max_bond_dim: 4,
         ..Default::default()
     };
     let lu = rrlu(&m, Some(opts)).unwrap();
@@ -291,9 +291,9 @@ fn test_rrlu_pivot_errors_truncated() {
         vec![0.0676373, 0.450878, 0.672335, 0.77726, 0.540691],
     ]);
 
-    // max_rank=2
+    // max_bond_dim=2
     let opts = RrLUOptions {
-        max_rank: 2,
+        max_bond_dim: 2,
         ..Default::default()
     };
     let lu = rrlu(&m, Some(opts)).unwrap();

--- a/crates/tensor4all-tcicore/src/matrixluci/block_rook.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/block_rook.rs
@@ -133,14 +133,14 @@ fn factorize_lazy<T: Scalar, S: CandidateMatrixSource<T>>(
         });
     }
 
-    let max_rank = options.max_rank.min(full_rank);
-    let mut selected_rows = Vec::with_capacity(max_rank);
-    let mut selected_cols = Vec::with_capacity(max_rank);
-    let mut accepted = Vec::with_capacity(max_rank + 1);
+    let max_bond_dim = options.max_bond_dim.min(full_rank);
+    let mut selected_rows = Vec::with_capacity(max_bond_dim);
+    let mut selected_cols = Vec::with_capacity(max_bond_dim);
+    let mut accepted = Vec::with_capacity(max_bond_dim + 1);
     let mut max_error = 0.0f64;
     let mut last_error = f64::NAN;
 
-    while selected_rows.len() < max_rank {
+    while selected_rows.len() < max_bond_dim {
         let remaining_rows = remaining_indices(nrows, &selected_rows);
         let remaining_cols = remaining_indices(ncols, &selected_cols);
         if remaining_rows.is_empty() || remaining_cols.is_empty() {
@@ -178,7 +178,7 @@ fn factorize_lazy<T: Scalar, S: CandidateMatrixSource<T>>(
     let rank = selected_rows.len();
     if rank >= full_rank {
         last_error = 0.0;
-    } else if rank == max_rank && rank > 0 {
+    } else if rank == max_bond_dim && rank > 0 {
         last_error = accepted[rank - 1];
     }
     accepted.push(last_error);

--- a/crates/tensor4all-tcicore/src/matrixluci/dense.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/dense.rs
@@ -21,7 +21,7 @@ pub struct DenseLuKernel;
 
 impl DenseLuKernel {
     fn is_no_truncation(options: &PivotKernelOptions, full_rank: usize) -> bool {
-        options.max_rank >= full_rank && options.rel_tol == 0.0 && options.abs_tol == 0.0
+        options.max_bond_dim >= full_rank && options.rel_tol == 0.0 && options.abs_tol == 0.0
     }
 
     fn compute_pivot_errors(
@@ -52,13 +52,13 @@ impl DenseLuKernel {
             return pivot_errors;
         }
 
-        let max_rank = options.max_rank.min(full_rank);
+        let max_bond_dim = options.max_bond_dim.min(full_rank);
         let mut accepted = Vec::new();
         let mut max_error = 0.0f64;
         let mut last_error = f64::NAN;
         let mut rank = 0usize;
 
-        while rank < max_rank {
+        while rank < max_bond_dim {
             let pivot_abs = diag_abs.get(rank).copied().unwrap_or(0.0);
             last_error = pivot_abs;
 
@@ -81,8 +81,8 @@ impl DenseLuKernel {
 
         if rank >= full_rank {
             last_error = 0.0;
-        } else if rank == max_rank && rank > 0 {
-            // Preserve the legacy tcicore-compatible semantics for max_rank stopping.
+        } else if rank == max_bond_dim && rank > 0 {
+            // Preserve the legacy tcicore-compatible semantics for max_bond_dim stopping.
             last_error = accepted[rank - 1];
         }
 
@@ -97,7 +97,7 @@ impl DenseLuKernel {
         options: &PivotKernelOptions,
     ) -> Result<PivotSelectionCore> {
         let lu_options = RrLUOptions {
-            max_rank: options.max_rank,
+            max_bond_dim: options.max_bond_dim,
             rel_tol: options.rel_tol,
             abs_tol: options.abs_tol,
             left_orthogonal: options.left_orthogonal,

--- a/crates/tensor4all-tcicore/src/matrixluci/dense/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/dense/tests.rs
@@ -144,7 +144,7 @@ fn dense_kernel_matches_legacy_pivot_errors_for_full_rank() {
 }
 
 #[test]
-fn dense_kernel_matches_legacy_pivot_errors_for_max_rank_stop() {
+fn dense_kernel_matches_legacy_pivot_errors_for_max_bond_dim_stop() {
     let rows = vec![
         vec![0.433088, 0.956638, 0.0907974, 0.0447859, 0.0196053],
         vec![0.855517, 0.782503, 0.291197, 0.540828, 0.358579],
@@ -153,11 +153,11 @@ fn dense_kernel_matches_legacy_pivot_errors_for_max_rank_stop() {
         vec![0.0676373, 0.450878, 0.672335, 0.77726, 0.540691],
     ];
     let luci_options = PivotKernelOptions {
-        max_rank: 2,
+        max_bond_dim: 2,
         ..PivotKernelOptions::default()
     };
     let legacy_options = RrLUOptions {
-        max_rank: 2,
+        max_bond_dim: 2,
         ..RrLUOptions::default()
     };
     assert_pivot_parity(rows, luci_options, legacy_options);

--- a/crates/tensor4all-tcicore/src/matrixluci/kernel/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/kernel/tests.rs
@@ -17,6 +17,6 @@ fn pivot_kernel_options_no_truncation_uses_canonical_values() {
     let opts = PivotKernelOptions::no_truncation();
     assert_eq!(opts.rel_tol, 0.0);
     assert_eq!(opts.abs_tol, 0.0);
-    assert_eq!(opts.max_rank, usize::MAX);
+    assert_eq!(opts.max_bond_dim, usize::MAX);
     assert!(opts.left_orthogonal);
 }

--- a/crates/tensor4all-tcicore/src/matrixluci/scalar/tests.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/scalar/tests.rs
@@ -31,7 +31,7 @@ fn test_scalar_generic<T: Scalar>() {
 
 fn options() -> crate::matrixlu::RrLUOptions {
     crate::matrixlu::RrLUOptions {
-        max_rank: 2,
+        max_bond_dim: 2,
         rel_tol: 0.0,
         abs_tol: 0.0,
         left_orthogonal: true,

--- a/crates/tensor4all-tcicore/src/matrixluci/types.rs
+++ b/crates/tensor4all-tcicore/src/matrixluci/types.rs
@@ -13,7 +13,7 @@ pub(crate) struct PivotKernelOptions {
     /// Absolute tolerance.
     pub abs_tol: f64,
     /// Maximum rank.
-    pub max_rank: usize,
+    pub max_bond_dim: usize,
     /// Whether the left factor is unit-diagonal.
     #[allow(dead_code)]
     pub left_orthogonal: bool,
@@ -39,7 +39,7 @@ impl PivotKernelOptions {
         Self {
             rel_tol: 0.0,
             abs_tol: 0.0,
-            max_rank: usize::MAX,
+            max_bond_dim: usize::MAX,
             left_orthogonal: true,
         }
     }
@@ -50,7 +50,7 @@ impl Default for PivotKernelOptions {
         Self {
             rel_tol: 1e-14,
             abs_tol: 0.0,
-            max_rank: usize::MAX,
+            max_bond_dim: usize::MAX,
             left_orthogonal: true,
         }
     }

--- a/crates/tensor4all-tensorci/benches/end_to_end_chain_tci.rs
+++ b/crates/tensor4all-tensorci/benches/end_to_end_chain_tci.rs
@@ -29,7 +29,7 @@ fn bench_chain_tci(c: &mut Criterion) {
         let full_options = TCI2Options {
             tolerance: 1e-8,
             max_iter: 8,
-            max_bond_dim: 16,
+            max_bond_dim: Some(16),
             pivot_search: PivotSearchStrategy::Full,
             ..Default::default()
         };

--- a/crates/tensor4all-tensorci/src/conversion.rs
+++ b/crates/tensor4all-tensorci/src/conversion.rs
@@ -26,12 +26,12 @@ use tensor4all_tensorbackend::{mat_mul_owned, BlasMul, Matrix};
 ///
 /// let options = TensorCI2FromTensorTrainOptions {
 ///     tolerance: 1e-14,
-///     max_bond_dim: 8,
+///     max_bond_dim: Some(8),
 ///     max_iter: 4,
 /// };
 ///
 /// assert!((options.tolerance - 1e-14).abs() < 1e-20);
-/// assert_eq!(options.max_bond_dim, 8);
+/// assert_eq!(options.max_bond_dim, Some(8));
 /// assert_eq!(options.max_iter, 4);
 /// ```
 #[derive(Debug, Clone)]
@@ -45,7 +45,7 @@ pub struct TensorCI2FromTensorTrainOptions {
     ///
     /// The default is `usize::MAX`, meaning no explicit cap. Set this to the
     /// largest acceptable converted TCI rank for expensive downstream use.
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
     /// Maximum number of alternating one-site index extraction sweeps.
     ///
     /// The default is `3`, matching the legacy Julia conversion constructor.
@@ -57,7 +57,7 @@ impl Default for TensorCI2FromTensorTrainOptions {
     fn default() -> Self {
         Self {
             tolerance: 1e-12,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             max_iter: 3,
         }
     }
@@ -126,7 +126,7 @@ fn validate_options(options: &TensorCI2FromTensorTrainOptions) -> Result<()> {
             message: "TensorCI2 conversion tolerance must be finite and nonnegative".to_string(),
         });
     }
-    if options.max_bond_dim == 0 {
+    if options.max_bond_dim == Some(0) {
         return Err(TCIError::InvalidOperation {
             message: "TensorCI2 conversion max_bond_dim must be nonzero".to_string(),
         });
@@ -215,7 +215,7 @@ where
     let next_shape = tensor_shape(next);
     let current_matrix = group_indices(current, forward, false);
     let lu_options = RrLUOptions {
-        max_rank: options.max_bond_dim,
+        max_bond_dim: options.max_bond_dim.unwrap_or(usize::MAX),
         rel_tol: options.tolerance,
         abs_tol: 0.0,
         left_orthogonal: forward,

--- a/crates/tensor4all-tensorci/src/conversion.rs
+++ b/crates/tensor4all-tensorci/src/conversion.rs
@@ -43,7 +43,7 @@ pub struct TensorCI2FromTensorTrainOptions {
     pub tolerance: f64,
     /// Maximum bond dimension retained during index extraction.
     ///
-    /// The default is `usize::MAX`, meaning no explicit cap. Set this to the
+    /// The default is `None`, meaning no explicit cap. Set this to the
     /// largest acceptable converted TCI rank for expensive downstream use.
     pub max_bond_dim: Option<usize>,
     /// Maximum number of alternating one-site index extraction sweeps.

--- a/crates/tensor4all-tensorci/src/conversion/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/conversion/tests/mod.rs
@@ -16,7 +16,7 @@ fn test_tensorci2_from_tensor_train_preserves_values() {
 fn test_tensorci2_from_tensor_train_respects_max_bond_dim() {
     let tt = SimpleTensorTrain::<f64>::constant(&[2, 2, 2], 1.0);
     let options = TensorCI2FromTensorTrainOptions {
-        max_bond_dim: 1,
+        max_bond_dim: Some(1),
         ..TensorCI2FromTensorTrainOptions::default()
     };
     let tci = TensorCI2::from_tensor_train(tt, options).unwrap();
@@ -62,7 +62,7 @@ fn test_tensorci2_from_tensor_train_matches_complex_lorentz_full_grid() {
         TCI2Options {
             tolerance: 1e-12,
             max_iter: 20,
-            max_bond_dim: 5,
+            max_bond_dim: Some(5),
             ..TCI2Options::default()
         },
     )
@@ -73,7 +73,7 @@ fn test_tensorci2_from_tensor_train_matches_complex_lorentz_full_grid() {
         source_tt,
         TensorCI2FromTensorTrainOptions {
             tolerance: 1e-12,
-            max_bond_dim: 5,
+            max_bond_dim: Some(5),
             ..TensorCI2FromTensorTrainOptions::default()
         },
     )

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -82,7 +82,7 @@ pub struct TCI2Options {
     /// followed by a global pivot search. Increase if the function is
     /// difficult to converge.
     pub max_iter: usize,
-    /// Hard upper bound on bond dimension (default: `usize::MAX`, i.e. no limit).
+    /// Hard upper bound on bond dimension (default: `None`, i.e. no limit).
     ///
     /// The algorithm stops early once the rank reaches this value. For
     /// expensive functions, setting this to `50`--`500` avoids runaway

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -53,18 +53,18 @@ use tensor4all_tensorbackend::{solve_matrix, transpose, Matrix};
 /// let opts = TCI2Options::default();
 /// assert!((opts.tolerance - 1e-8).abs() < 1e-15);
 /// assert_eq!(opts.max_iter, 20);
-/// assert_eq!(opts.max_bond_dim, usize::MAX);
+/// assert_eq!(opts.max_bond_dim, None);
 /// assert_eq!(opts.verbosity, 0);
 ///
 /// // Custom options via struct update syntax
 /// let custom = TCI2Options {
 ///     tolerance: 1e-12,
-///     max_bond_dim: 100,
+///     max_bond_dim: Some(100),
 ///     seed: Some(42),
 ///     ..TCI2Options::default()
 /// };
 /// assert!((custom.tolerance - 1e-12).abs() < 1e-20);
-/// assert_eq!(custom.max_bond_dim, 100);
+/// assert_eq!(custom.max_bond_dim, Some(100));
 /// assert_eq!(custom.seed, Some(42));
 /// ```
 #[derive(Debug, Clone)]
@@ -87,7 +87,7 @@ pub struct TCI2Options {
     /// The algorithm stops early once the rank reaches this value. For
     /// expensive functions, setting this to `50`--`500` avoids runaway
     /// computation.
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
     /// Pivot search strategy (default: [`PivotSearchStrategy::Full`]).
     ///
     /// `Full` materializes the entire candidate matrix and finds the best
@@ -139,7 +139,7 @@ impl Default for TCI2Options {
         Self {
             tolerance: 1e-8,
             max_iter: 20,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             pivot_search: PivotSearchStrategy::Full,
             normalize_error: true,
             verbosity: 0,
@@ -907,7 +907,7 @@ where
 
         // LU-based cross interpolation
         let lu_options = RrLUOptions {
-            max_rank: config.max_bond_dim,
+            max_bond_dim: config.max_bond_dim,
             rel_tol: config.rel_tol,
             abs_tol: config.abs_tol,
             left_orthogonal: forward,
@@ -1651,7 +1651,7 @@ where
             &errors,
             &nglobal_pivots_history,
             options.tolerance,
-            options.max_bond_dim,
+            options.max_bond_dim.unwrap_or(usize::MAX),
             options.ncheck_history,
         ) {
             termination = reason;
@@ -1668,7 +1668,14 @@ where
         1.0
     };
     let abs_tol = options.tolerance * error_normalization;
-    tci.sweep1site(&f, true, 1e-14, abs_tol, options.max_bond_dim, true)?;
+    tci.sweep1site(
+        &f,
+        true,
+        1e-14,
+        abs_tol,
+        options.max_bond_dim.unwrap_or(usize::MAX),
+        true,
+    )?;
 
     Ok(TCI2OptimizationResult {
         tci,
@@ -1751,7 +1758,7 @@ where
         matrix_luci_factors_from_matrix(
             &pi,
             Some(RrLUOptions {
-                max_rank: context.options.max_bond_dim,
+                max_bond_dim: context.options.max_bond_dim.unwrap_or(usize::MAX),
                 rel_tol: context.options.tolerance,
                 abs_tol: 0.0,
                 left_orthogonal: context.left_orthogonal,
@@ -1772,7 +1779,7 @@ where
                 evaluator.fill_block(rows, cols, out);
             },
             RrLUOptions {
-                max_rank: context.options.max_bond_dim,
+                max_bond_dim: context.options.max_bond_dim.unwrap_or(usize::MAX),
                 rel_tol: context.options.tolerance,
                 abs_tol: 0.0,
                 left_orthogonal: context.left_orthogonal,

--- a/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
@@ -13,7 +13,7 @@ fn test_sweep1site_preserves_accuracy() {
     let options = TCI2Options {
         tolerance: 1e-12,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         ..Default::default()
     };
 
@@ -64,7 +64,7 @@ fn test_make_canonical() {
     let options = TCI2Options {
         tolerance: 1e-12,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         ..Default::default()
     };
 
@@ -111,7 +111,7 @@ fn test_fill_site_tensors() {
     let options = TCI2Options {
         tolerance: 1e-12,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         ..Default::default()
     };
 
@@ -189,7 +189,7 @@ fn test_crossinterpolate2_reports_convergence_and_rank_cap_separately() {
         None,
         vec![2, 2],
         vec![vec![0, 0]],
-        options(usize::MAX),
+        options(None),
     )
     .unwrap();
     assert_eq!(converged.termination, TCI2Termination::Converged);
@@ -199,7 +199,7 @@ fn test_crossinterpolate2_reports_convergence_and_rank_cap_separately() {
         None,
         vec![2, 2],
         vec![vec![0, 0]],
-        options(1),
+        options(Some(1)),
     )
     .unwrap();
     assert_eq!(capped.termination, TCI2Termination::MaxBondDimension);
@@ -366,7 +366,7 @@ fn test_crossinterpolate2_rook_search_uses_partial_batch_requests() {
     let first_pivot = vec![vec![0, 0]];
     let options = TCI2Options {
         max_iter: 1,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         pivot_search: PivotSearchStrategy::Rook,
         ..Default::default()
     };
@@ -398,7 +398,7 @@ fn test_crossinterpolate2_rook_search_rejects_bad_batch_length() {
     let first_pivot = vec![vec![0, 0]];
     let options = TCI2Options {
         max_iter: 1,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         pivot_search: PivotSearchStrategy::Rook,
         ..Default::default()
     };
@@ -415,7 +415,7 @@ fn test_crossinterpolate2_full_search_rejects_bad_batch_length() {
     let first_pivot = vec![vec![0, 0]];
     let options = TCI2Options {
         max_iter: 1,
-        max_bond_dim: 2,
+        max_bond_dim: Some(2),
         pivot_search: PivotSearchStrategy::Full,
         ..Default::default()
     };
@@ -582,7 +582,7 @@ fn test_crossinterpolate2_sin_quantics() {
     let first_pivot = vec![vec![0, 1, 0, 0, 0, 0]];
     let options = TCI2Options {
         tolerance: 1e-10,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         max_iter: 20,
         ..Default::default()
     };
@@ -612,7 +612,7 @@ fn test_crossinterpolate2_rank2_full_grid_reconstruction() {
     let options = TCI2Options {
         tolerance: 1e-12,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         ..Default::default()
     };
 
@@ -790,7 +790,7 @@ fn test_crossinterpolate2_lorentz_f64() {
     let options = TCI2Options {
         tolerance: 1e-8,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         ..Default::default()
     };
 
@@ -853,7 +853,7 @@ fn test_crossinterpolate2_lorentz_c64() {
     let options = TCI2Options {
         tolerance: 1e-8,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         ..Default::default()
     };
 
@@ -959,7 +959,7 @@ fn test_global_search_oscillatory() {
     let options = TCI2Options {
         tolerance: 1e-4,
         max_iter: 20,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         normalize_error: false,
         ..Default::default()
     };
@@ -1068,7 +1068,7 @@ fn test_custom_global_pivot_finder() {
     let options = TCI2Options {
         tolerance: 1e-4,
         max_iter: 10,
-        max_bond_dim: usize::MAX,
+        max_bond_dim: None,
         normalize_error: false,
         ..Default::default()
     };

--- a/crates/tensor4all-treetci/src/api.rs
+++ b/crates/tensor4all-treetci/src/api.rs
@@ -54,7 +54,7 @@ pub type TreeTciRunResult = (
 /// let options = TreeTciOptions {
 ///     tolerance: 1e-10,
 ///     max_iter: 10,
-///     max_bond_dim: 10,
+///     max_bond_dim: Some(10),
 ///     normalize_error: true,
 /// };
 ///

--- a/crates/tensor4all-treetci/src/materialize/tests.rs
+++ b/crates/tensor4all-treetci/src/materialize/tests.rs
@@ -34,7 +34,7 @@ fn to_treetn_preserves_two_site_identity_evaluations() {
         &TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 4,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             normalize_error: true,
         },
     )

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -17,7 +17,7 @@ use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
 /// |--------------------|---------------|-----------------------------------------------------|
 /// | `tolerance`        | `1e-8`        | Relative stopping tolerance on normalized bond error |
 /// | `max_iter`         | `20`          | Maximum number of edge-order iterations              |
-/// | `max_bond_dim`     | `usize::MAX`  | Maximum bond dimension (no cap by default)           |
+/// | `max_bond_dim`     | `None`        | Maximum bond dimension (no cap by default)           |
 /// | `normalize_error`  | `true`        | Normalize error by maximum sample magnitude          |
 ///
 /// # Examples
@@ -62,7 +62,7 @@ pub struct TreeTciOptions {
     /// Maximum bond dimension retained by the tcicore LUCI pivot substrate.
     ///
     /// Caps the number of pivots per edge bipartition. Use this to limit
-    /// memory and computation for large problems. Default: `usize::MAX` (no cap).
+    /// memory and computation for large problems. Default: `None` (no cap).
     pub max_bond_dim: Option<usize>,
 
     /// Whether to normalize the bond error by the maximum observed sample magnitude.

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -29,19 +29,19 @@ use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
 /// let opts = TreeTciOptions::default();
 /// assert!((opts.tolerance - 1e-8).abs() < 1e-15);
 /// assert_eq!(opts.max_iter, 20);
-/// assert_eq!(opts.max_bond_dim, usize::MAX);
+/// assert_eq!(opts.max_bond_dim, None);
 /// assert!(opts.normalize_error);
 ///
 /// // Custom options for high-precision work
 /// let opts = TreeTciOptions {
 ///     tolerance: 1e-12,
 ///     max_iter: 50,
-///     max_bond_dim: 100,
+///     max_bond_dim: Some(100),
 ///     normalize_error: true,
 /// };
 /// assert!((opts.tolerance - 1e-12).abs() < 1e-20);
 /// assert_eq!(opts.max_iter, 50);
-/// assert_eq!(opts.max_bond_dim, 100);
+/// assert_eq!(opts.max_bond_dim, Some(100));
 /// ```
 #[derive(Clone, Debug)]
 pub struct TreeTciOptions {
@@ -63,7 +63,7 @@ pub struct TreeTciOptions {
     ///
     /// Caps the number of pivots per edge bipartition. Use this to limit
     /// memory and computation for large problems. Default: `usize::MAX` (no cap).
-    pub max_bond_dim: usize,
+    pub max_bond_dim: Option<usize>,
 
     /// Whether to normalize the bond error by the maximum observed sample magnitude.
     ///
@@ -78,7 +78,7 @@ impl Default for TreeTciOptions {
         Self {
             tolerance: 1e-8,
             max_iter: 20,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             normalize_error: true,
         }
     }
@@ -205,7 +205,7 @@ where
     if !(options.max_iter > 0) {
         return Err(anyhow::anyhow!("TreeTCI optimization requires max_iter > 0").into());
     };
-    if !(options.max_bond_dim > 0) {
+    if options.max_bond_dim == Some(0) {
         return Err(anyhow::anyhow!("TreeTCI optimization requires max_bond_dim > 0").into());
     };
 
@@ -232,7 +232,7 @@ where
             let kernel_options = RrLUOptions {
                 rel_tol: 1e-14,
                 abs_tol: options.tolerance * error_scale,
-                max_rank: options.max_bond_dim,
+                max_bond_dim: options.max_bond_dim.unwrap_or(usize::MAX),
                 left_orthogonal: true,
             };
 
@@ -244,7 +244,7 @@ where
             }
         }
 
-        ranks.push(state.max_rank());
+        ranks.push(state.max_bond_dim());
         let normalized_error = if options.normalize_error && state.max_sample_value > 0.0 {
             state.max_bond_error() / state.max_sample_value
         } else {
@@ -271,7 +271,9 @@ where
             let errors_converged = last_errors.iter().all(|&e| e < options.tolerance);
             let rank_stable = last_ranks.iter().min().copied().unwrap_or(0)
                 == last_ranks.last().copied().unwrap_or(0);
-            let bond_dim_saturated = last_ranks.iter().all(|&r| r >= options.max_bond_dim);
+            let bond_dim_saturated = options
+                .max_bond_dim
+                .is_some_and(|cap| last_ranks.iter().all(|&r| r >= cap));
             if (errors_converged && rank_stable) || bond_dim_saturated {
                 break;
             }

--- a/crates/tensor4all-treetci/src/optimize/tests.rs
+++ b/crates/tensor4all-treetci/src/optimize/tests.rs
@@ -28,7 +28,7 @@ fn optimize_default_converges_on_two_site_identity() {
         &TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 4,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             normalize_error: true,
         },
     )
@@ -41,7 +41,7 @@ fn optimize_default_converges_on_two_site_identity() {
         tci.max_sample_value,
         1e-12,
     );
-    assert_eq!(tci.max_rank(), 2);
+    assert_eq!(tci.max_bond_dim(), 2);
 }
 
 // Previously named `optimize_default_runs_all_iterations_like_upstream_tree_tci`
@@ -75,7 +75,7 @@ fn optimize_default_stops_early_once_converged() {
         &TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 4,
-            max_bond_dim: usize::MAX,
+            max_bond_dim: None,
             normalize_error: true,
         },
     )
@@ -115,7 +115,7 @@ fn optimize_default_stops_early_when_bond_dim_saturated() {
         &TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 10,
-            max_bond_dim: 1,
+            max_bond_dim: Some(1),
             normalize_error: true,
         },
     )

--- a/crates/tensor4all-treetci/src/state.rs
+++ b/crates/tensor4all-treetci/src/state.rs
@@ -29,12 +29,12 @@ use tensor4all_core::ColMajorArray;
 /// ]).unwrap();
 ///
 /// let mut state = TreeTCI2::<f64>::new(vec![2, 3, 2], graph).unwrap();
-/// assert_eq!(state.max_rank(), 0);
+/// assert_eq!(state.max_bond_dim(), 0);
 /// assert!((state.max_bond_error() - 0.0).abs() < f64::EPSILON);
 ///
 /// // Seed with a global pivot
 /// state.add_global_pivots(&[vec![0, 0, 0]]).unwrap();
-/// assert!(state.max_rank() >= 1);
+/// assert!(state.max_bond_dim() >= 1);
 /// ```
 #[derive(Clone, Debug)]
 pub struct TreeTCI2<T> {
@@ -174,7 +174,7 @@ impl<T> TreeTCI2<T> {
     }
 
     /// Maximum current bond dimension across stored subtree pivot sets.
-    pub fn max_rank(&self) -> usize {
+    pub fn max_bond_dim(&self) -> usize {
         self.ijset
             .values()
             .filter_map(|arr| arr.ncols())

--- a/crates/tensor4all-treetci/src/update/tests.rs
+++ b/crates/tensor4all-treetci/src/update/tests.rs
@@ -7,7 +7,7 @@ use tensor4all_tcicore::RrLUOptions;
 
 fn no_truncation_options() -> RrLUOptions {
     RrLUOptions {
-        max_rank: usize::MAX,
+        max_bond_dim: usize::MAX,
         rel_tol: 0.0,
         abs_tol: 0.0,
         left_orthogonal: true,

--- a/crates/tensor4all-treetci/tests/advanced_quantics.rs
+++ b/crates/tensor4all-treetci/tests/advanced_quantics.rs
@@ -91,7 +91,7 @@ fn quantics_grid_polynomial_matches_all_points_on_branching_tree() {
         TreeTciOptions {
             tolerance: 1e-10,
             max_iter: 12,
-            max_bond_dim: 8,
+            max_bond_dim: Some(8),
             normalize_error: true,
         },
         Some(1),
@@ -154,7 +154,7 @@ fn quantics_grid_batch_evaluator_matches_point_evaluator() {
     let options = TreeTciOptions {
         tolerance: 1e-10,
         max_iter: 12,
-        max_bond_dim: 8,
+        max_bond_dim: Some(8),
         normalize_error: true,
     };
 

--- a/crates/tensor4all-treetci/tests/simple_parity.rs
+++ b/crates/tensor4all-treetci/tests/simple_parity.rs
@@ -55,7 +55,7 @@ fn simple_tree_parity_matches_reference_points() {
         TreeTciOptions {
             tolerance: 1e-8,
             max_iter: 10,
-            max_bond_dim: 5,
+            max_bond_dim: Some(5),
             normalize_error: true,
         },
         Some(0),
@@ -111,7 +111,7 @@ fn simple_tree_product_function_is_exact_on_branching_tree() {
         TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 8,
-            max_bond_dim: 2,
+            max_bond_dim: Some(2),
             normalize_error: true,
         },
         Some(0),
@@ -170,7 +170,7 @@ fn simple_tree_complex_product_function_is_exact_on_branching_tree() {
         TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 8,
-            max_bond_dim: 2,
+            max_bond_dim: Some(2),
             normalize_error: true,
         },
         Some(0),
@@ -237,7 +237,7 @@ fn simple_tree_complex_product_function_is_exact_on_two_site_tree() {
         TreeTciOptions {
             tolerance: 1e-12,
             max_iter: 8,
-            max_bond_dim: 2,
+            max_bond_dim: Some(2),
             normalize_error: true,
         },
         Some(0),

--- a/crates/tensor4all-treetn/README.md
+++ b/crates/tensor4all-treetn/README.md
@@ -34,7 +34,7 @@ assert_eq!(ttn.edge_count(), 2);
 
 // Canonicalize and truncate
 let ttn = ttn.canonicalize([0], CanonicalizationOptions::default())?;
-let mut ttn = ttn.truncate([0], TruncationOptions::default().with_max_rank(2))?;
+let mut ttn = ttn.truncate([0], TruncationOptions::default().with_max_bond_dim(2))?;
 
 // Compute norm
 let norm = ttn.norm()?;

--- a/crates/tensor4all-treetn/examples/bench_swap_interleave_r45.rs
+++ b/crates/tensor4all-treetn/examples/bench_swap_interleave_r45.rs
@@ -86,25 +86,25 @@ fn main() {
     for r in [5, 10, 15, 20, 25, 30] {
         run_timing(r, 5, &SwapOptions::default(), "");
     }
-    eprintln!("=== timing: bond_dim=5, max_rank=5 ===");
+    eprintln!("=== timing: bond_dim=5, max_bond_dim=5 ===");
     for r in [5, 10, 15, 20, 25, 30, 45] {
         run_timing(
             r,
             5,
             &SwapOptions {
-                max_rank: Some(5),
+                max_bond_dim: Some(5),
                 rtol: None,
             },
             "",
         );
     }
-    eprintln!("=== timing: bond_dim=5, max_rank=10 ===");
+    eprintln!("=== timing: bond_dim=5, max_bond_dim=10 ===");
     for r in [5, 10, 15, 20, 25, 30, 45] {
         run_timing(
             r,
             5,
             &SwapOptions {
-                max_rank: Some(10),
+                max_bond_dim: Some(10),
                 rtol: None,
             },
             "",
@@ -118,19 +118,19 @@ fn main() {
             r,
             5,
             &SwapOptions {
-                max_rank: Some(5),
+                max_bond_dim: Some(5),
                 rtol: None,
             },
-            "bond_dim=5 max_rank= 5",
+            "bond_dim=5 max_bond_dim= 5",
         );
         run_accuracy(
             r,
             5,
             &SwapOptions {
-                max_rank: Some(10),
+                max_bond_dim: Some(10),
                 rtol: None,
             },
-            "bond_dim=5 max_rank=10",
+            "bond_dim=5 max_bond_dim=10",
         );
     }
 }

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
@@ -176,7 +176,7 @@ fn main() -> anyhow::Result<()> {
     anyhow::ensure!(n_sites >= 2, "This benchmark currently requires N>=2");
 
     let phys_dim = 2usize;
-    let max_rank = bond_dim;
+    let max_bond_dim = bond_dim;
 
     let seed = 1234_u64;
 
@@ -200,7 +200,7 @@ fn main() -> anyhow::Result<()> {
     println!("phys_dim = {phys_dim}");
     println!("bond_dim = {bond_dim}");
     println!("n_sweeps = {n_sweeps}");
-    println!("max_rank = {max_rank}");
+    println!("max_bond_dim = {max_bond_dim}");
     println!("cutoff = {cutoff}");
     println!("rtol = sqrt(cutoff) = {rtol:.6}");
     println!("GMRES: tol={gmres_tol}, maxiter={gmres_max_restarts}, gmres_restart_dim={gmres_restart_dim}");
@@ -218,7 +218,7 @@ fn main() -> anyhow::Result<()> {
         create_n_site_index_mappings(&site_indices, &s_in_tmp, &s_out_tmp);
 
     let apply_opts = ApplyOptions::zipup()
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
     let linop_for_rhs =
         LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
@@ -230,7 +230,7 @@ fn main() -> anyhow::Result<()> {
     // algorithms more closely.
     let truncation = TruncationOptions::default()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
-        .with_max_rank(max_rank);
+        .with_max_bond_dim(max_bond_dim);
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(n_sweeps)

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
@@ -256,7 +256,7 @@ fn main() -> anyhow::Result<()> {
     let bond_dim: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(20);
 
     let phys_dim = 2usize;
-    let max_rank = bond_dim;
+    let max_bond_dim = bond_dim;
 
     let seed = 1234_u64;
 
@@ -281,7 +281,7 @@ fn main() -> anyhow::Result<()> {
     println!("N = {n_sites}");
     println!("phys_dim = {phys_dim}");
     println!("bond_dim = {bond_dim}");
-    println!("max_rank = {max_rank}");
+    println!("max_bond_dim = {max_bond_dim}");
     println!("n_sweeps = {n_sweeps}");
     println!("cutoff = {cutoff}");
     println!("rtol = sqrt(cutoff) = {rtol:.6}");
@@ -325,7 +325,7 @@ fn main() -> anyhow::Result<()> {
 
     // Compute b = A * x_true
     let apply_opts = ApplyOptions::zipup()
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
     let linop_for_rhs = LinearOperator::new(
         operator_a.clone(),
@@ -338,7 +338,7 @@ fn main() -> anyhow::Result<()> {
 
     let truncation = TruncationOptions::default()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
-        .with_max_rank(max_rank);
+        .with_max_bond_dim(max_bond_dim);
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(n_sweeps)

--- a/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
+++ b/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
@@ -354,7 +354,7 @@ fn main() -> anyhow::Result<()> {
     let n = 10usize;
     let phys_dim = 2usize;
     let bond_dim = 20usize;
-    let max_rank = 20usize;
+    let max_bond_dim = 20usize;
     let n_sweeps = 5usize;
     let cutoff = 1e-8_f64;
     let rtol = cutoff.sqrt();
@@ -368,7 +368,7 @@ fn main() -> anyhow::Result<()> {
     println!("N = {n}");
     println!("phys_dim = {phys_dim}");
     println!("bond_dim = {bond_dim}");
-    println!("max_rank = {max_rank}");
+    println!("max_bond_dim = {max_bond_dim}");
     println!("n_sweeps = {n_sweeps}");
     println!("cutoff = {cutoff}");
     println!("rtol = sqrt(cutoff) = {rtol}");
@@ -378,7 +378,7 @@ fn main() -> anyhow::Result<()> {
 
     let truncation = TruncationOptions::default()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
-        .with_max_rank(max_rank);
+        .with_max_bond_dim(max_bond_dim);
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(n_sweeps)

--- a/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
+++ b/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
@@ -244,7 +244,7 @@ fn case_ok_identity_single_1site_step() -> anyhow::Result<()> {
     // Keep coefficients simple (avoid the a0*x + ... path inside the linop).
     let options = LinsolveOptions::default()
         .with_nfullsweeps(1)
-        .with_max_rank(state_bond_dim)
+        .with_max_bond_dim(state_bond_dim)
         .with_gmres_tol(1e-6)
         .with_gmres_max_restarts(20)
         .with_gmres_restart_dim(30)
@@ -288,7 +288,7 @@ fn case_fail_identity_2site_sweep() -> anyhow::Result<()> {
     // Benchmark-like coefficients (this is where we reproduce the known failure)
     let options = LinsolveOptions::default()
         .with_nfullsweeps(1)
-        .with_max_rank(state_bond_dim)
+        .with_max_bond_dim(state_bond_dim)
         .with_gmres_tol(1e-6)
         .with_gmres_max_restarts(20)
         .with_gmres_restart_dim(30)

--- a/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
@@ -380,7 +380,7 @@ fn run_linsolve_test(
     a0: f64,
     a1: f64,
     n_sweeps: usize,
-    max_rank: usize,
+    max_bond_dim: usize,
 ) -> anyhow::Result<()> {
     println!("--- {test_name} ---");
 
@@ -389,7 +389,7 @@ fn run_linsolve_test(
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(n_sweeps)
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(50)
         .with_gmres_restart_dim(30)

--- a/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
@@ -278,7 +278,7 @@ fn main() -> anyhow::Result<()> {
 
     // Fixed parameters (keep constant except N and A).
     let phys_dim = 2usize;
-    let max_rank = bond_dim;
+    let max_bond_dim = bond_dim;
 
     let seed = 1234_u64;
 
@@ -297,7 +297,7 @@ fn main() -> anyhow::Result<()> {
     println!("A = {a_kind}");
     println!("rhs = {rhs_kind}");
     println!("n_sweeps = {n_sweeps}");
-    println!("max_rank = {max_rank}");
+    println!("max_bond_dim = {max_bond_dim}");
     println!("cutoff = {cutoff}");
     println!("rtol = sqrt(cutoff) = {rtol:.6}");
     println!("GMRES: tol={gmres_tol}, maxiter={gmres_max_restarts}, gmres_restart_dim={gmres_restart_dim}");
@@ -316,7 +316,7 @@ fn main() -> anyhow::Result<()> {
         create_n_site_index_mappings(&site_indices, &s_in_tmp, &s_out_tmp);
 
     let apply_opts = ApplyOptions::zipup()
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol));
     let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
 
@@ -337,7 +337,7 @@ fn main() -> anyhow::Result<()> {
 
     let truncation = TruncationOptions::default()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
-        .with_max_rank(max_rank);
+        .with_max_bond_dim(max_bond_dim);
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(n_sweeps)

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
@@ -391,11 +391,11 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
     let mut x = init.canonicalize(["site0".to_string()], CanonicalizationOptions::default())?;
 
     // Setup linsolve options and updater
-    // For N=10, we need higher max_rank to handle the larger system
+    // For N=10, we need higher max_bond_dim to handle the larger system
     let options = LinsolveOptions::default()
         .with_nfullsweeps(10)
         .with_gmres_tol(1e-10)
-        .with_max_rank(100)
+        .with_max_bond_dim(100)
         .with_coefficients(a0, a1);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
@@ -506,7 +506,7 @@ fn run_test_case(
     let options = LinsolveOptions::default()
         .with_nfullsweeps(10)
         .with_gmres_tol(1e-10)
-        .with_max_rank(50)
+        .with_max_bond_dim(50)
         .with_coefficients(a0, a1);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
@@ -447,7 +447,7 @@ fn run_test_case(
     a0: f64,
     a1: f64,
     use_simple_exact: bool,
-    max_rank: usize,
+    max_bond_dim: usize,
     init_mode: &str, // "random" or "rhs"
 ) -> anyhow::Result<(f64, f64, f64, f64)> {
     let phys_dim = 2usize;
@@ -549,7 +549,7 @@ fn run_test_case(
     };
 
     // Use the bond dimension from b for initial guess to avoid dimension mismatch
-    // Note: RHS bond dimension is fixed, but x's bond dimension can grow during linsolve (up to max_rank)
+    // Note: RHS bond dimension is fixed, but x's bond dimension can grow during linsolve (up to max_bond_dim)
     let init_bond_dim = if !rhs_bond_dims.is_empty() {
         rhs_bond_dims[0] // Use first bond dimension (they should all be the same)
     } else {
@@ -567,7 +567,9 @@ fn run_test_case(
             1 << n_sites
         );
         println!("Using init bond_dim={init_bond_dim} to match b (RHS) bond dimensions");
-        println!("Note: x's bond dimension can grow during linsolve (up to max_rank={max_rank})");
+        println!(
+            "Note: x's bond dimension can grow during linsolve (up to max_bond_dim={max_bond_dim})"
+        );
         println!();
         println!("Creating initial guess...");
         println!("  Using init_mode={init_mode}");
@@ -596,19 +598,19 @@ fn run_test_case(
     let mut x = init.canonicalize(["site0".to_string()], CanonicalizationOptions::default())?;
 
     // Setup linsolve options and updater
-    // max_rank is passed as parameter to allow bond dimension growth during sweeps
+    // max_bond_dim is passed as parameter to allow bond dimension growth during sweeps
     // Adjust GMRES parameters for better convergence
     let options = LinsolveOptions::default()
         .with_nfullsweeps(10)
         .with_gmres_tol(1e-8) // Slightly relaxed from 1e-10
         .with_gmres_max_restarts(200) // Increased from default 100
         .with_gmres_restart_dim(50) // Increased from default 30
-        .with_max_rank(max_rank)
+        .with_max_bond_dim(max_bond_dim)
         .with_coefficients(a0, a1)
         .with_convergence_tol(1e-6); // Early termination if residual < 1e-6
 
     if verbose {
-        println!("Linsolve options: max_rank={max_rank}, nfullsweeps=10, gmres_tol=1e-8, gmres_max_restarts=200, gmres_restart_dim=50, convergence_tol=1e-6");
+        println!("Linsolve options: max_bond_dim={max_bond_dim}, nfullsweeps=10, gmres_tol=1e-8, gmres_max_restarts=200, gmres_restart_dim=50, convergence_tol=1e-6");
     }
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
@@ -808,8 +810,8 @@ fn run_test_case(
 }
 
 fn main() -> anyhow::Result<()> {
-    // max_rank for linsolve (allows bond dimension to grow during sweeps)
-    let max_rank = 30usize;
+    // max_bond_dim for linsolve (allows bond dimension to grow during sweeps)
+    let max_bond_dim = 30usize;
 
     // Test N=6 and N=7 to compare convergence behavior
     let test_n_values = vec![6, 7];
@@ -821,7 +823,7 @@ fn main() -> anyhow::Result<()> {
     println!("  - Exact solution: x_exact = |000...0⟩ + |111...1⟩ (bond_dim=2)");
     println!("  - RHS: b = x_exact");
     println!("  - Initial guess: random or rhs (bond_dim matching RHS)");
-    println!("  - max_rank for linsolve: {max_rank}");
+    println!("  - max_bond_dim for linsolve: {max_bond_dim}");
     println!();
     println!("Metrics explanation:");
     println!("  - Residual: ||(a0*I + a1*A) x - b|| / ||b|| (how well the equation is satisfied)");
@@ -847,7 +849,7 @@ fn main() -> anyhow::Result<()> {
             for &init_mode in &init_modes {
                 println!("--- Test case: {case_desc}, init={init_mode} ---");
 
-                let result = run_test_case(n_sites, *a0, *a1, true, max_rank, init_mode);
+                let result = run_test_case(n_sites, *a0, *a1, true, max_bond_dim, init_mode);
 
                 match result {
                     Ok((initial_residual, initial_error, final_residual, final_error)) => {

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
@@ -290,7 +290,7 @@ fn run_test_case(init_mode: &str, bond_dim: usize) -> anyhow::Result<()> {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(20)
         .with_gmres_tol(1e-10)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_coefficients(a0, a1);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
@@ -350,7 +350,7 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
     let options = LinsolveOptions::default()
         .with_nfullsweeps(10)
         .with_gmres_tol(1e-10)
-        .with_max_rank(50)
+        .with_max_bond_dim(50)
         .with_coefficients(a0, a1);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
@@ -430,7 +430,7 @@ fn main() -> anyhow::Result<()> {
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(5)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(20)
         .with_gmres_restart_dim(30)
@@ -559,7 +559,7 @@ fn main() -> anyhow::Result<()> {
     let b_case3 = scale_treetn(&b_mpo, neg_one)?;
     let options_case3 = LinsolveOptions::default()
         .with_nfullsweeps(5)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(20)
         .with_gmres_restart_dim(30)

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
@@ -829,7 +829,7 @@ fn main() -> anyhow::Result<()> {
     // Set up linsolve options for a0=0, a1=1
     let options = LinsolveOptions::default()
         .with_nfullsweeps(10)
-        .with_max_rank(50)
+        .with_max_bond_dim(50)
         .with_gmres_tol(1e-10)
         .with_gmres_max_restarts(30)
         .with_gmres_restart_dim(30)

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
@@ -601,7 +601,7 @@ fn main() -> anyhow::Result<()> {
     // Set up linsolve options
     let options_1 = LinsolveOptions::default()
         .with_nfullsweeps(5)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(20)
         .with_gmres_restart_dim(30)
@@ -702,7 +702,7 @@ fn main() -> anyhow::Result<()> {
     // Set up linsolve options for a0=2, a1=1
     let options_2 = LinsolveOptions::default()
         .with_nfullsweeps(5)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(20)
         .with_gmres_restart_dim(30)

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
@@ -301,7 +301,7 @@ fn run_case(phys_dim: usize) -> anyhow::Result<()> {
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(5)
-        .with_max_rank(bond_dim)
+        .with_max_bond_dim(bond_dim)
         .with_gmres_tol(1e-8);
 
     let mut x = x_true.clone();

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
@@ -406,7 +406,7 @@ fn main() -> anyhow::Result<()> {
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(10)
-        .with_max_rank(bond_dim)
+        .with_max_bond_dim(bond_dim)
         .with_gmres_tol(1e-10)
         .with_gmres_max_restarts(30)
         .with_gmres_restart_dim(30)

--- a/crates/tensor4all-treetn/src/dmrg/mod.rs
+++ b/crates/tensor4all-treetn/src/dmrg/mod.rs
@@ -514,8 +514,8 @@ where
 
         let topology = build_subtree_topology(&solved_local, &step.nodes, full_treetn)?;
         let mut factorize_options = FactorizeOptions::svd();
-        if let Some(max_rank) = self.options.max_bond_dim {
-            factorize_options = factorize_options.with_max_rank(max_rank);
+        if let Some(max_bond_dim) = self.options.max_bond_dim {
+            factorize_options = factorize_options.with_max_bond_dim(max_bond_dim);
         }
         if let Some(policy) = self.options.svd_policy {
             factorize_options = factorize_options.with_svd_policy(policy);

--- a/crates/tensor4all-treetn/src/gse.rs
+++ b/crates/tensor4all-treetn/src/gse.rs
@@ -43,7 +43,7 @@ pub struct GseOptions {
     ///
     /// When this is `None`, generated references use `maxlinkdim(state) + 1`,
     /// matching the low-rank probe policy used by chain GSE implementations.
-    pub reference_max_rank: Option<usize>,
+    pub reference_max_bond_dim: Option<usize>,
     /// Optional SVD policy for generated reference states.
     pub reference_svd_policy: Option<SvdTruncationPolicy>,
     /// Density eigenvalue cutoff for retaining missing reference directions.
@@ -61,7 +61,7 @@ impl Default for GseOptions {
         Self {
             krylov_dim: 0,
             reference_apply: ApplyOptions::zipup(),
-            reference_max_rank: None,
+            reference_max_bond_dim: None,
             reference_svd_policy: None,
             density_weight_cutoff: 1.0e-12,
             hermitian_tol: 1.0e-12,
@@ -91,8 +91,8 @@ impl GseOptions {
     }
 
     /// Set the reference-state maximum rank used during operator application.
-    pub fn with_reference_max_rank(mut self, reference_max_rank: usize) -> Self {
-        self.reference_max_rank = Some(reference_max_rank);
+    pub fn with_reference_max_bond_dim(mut self, reference_max_bond_dim: usize) -> Self {
+        self.reference_max_bond_dim = Some(reference_max_bond_dim);
         self
     }
 
@@ -436,10 +436,10 @@ fn validate_options(options: &GseOptions) -> Result<(), GseError> {
             reason: "must be finite and non-negative".to_string(),
         });
     }
-    if let Some(max_rank) = options.reference_max_rank {
-        if max_rank == 0 {
+    if let Some(max_bond_dim) = options.reference_max_bond_dim {
+        if max_bond_dim == 0 {
             return Err(GseError::InvalidOption {
-                option: "reference_max_rank",
+                option: "reference_max_bond_dim",
                 reason: "must be greater than zero when set".to_string(),
             });
         }
@@ -458,14 +458,14 @@ where
 {
     let mut references = Vec::with_capacity(options.krylov_dim);
     let mut current = init.clone();
-    let generated_reference_max_rank = options
-        .reference_max_rank
+    let generated_reference_max_bond_dim = options
+        .reference_max_bond_dim
         .unwrap_or_else(|| max_link_dim(init).saturating_add(1));
     for _ in 0..options.krylov_dim {
         let mut apply_options = options
             .reference_apply
             .clone()
-            .with_max_rank(generated_reference_max_rank);
+            .with_max_bond_dim(generated_reference_max_bond_dim);
         if let Some(policy) = options.reference_svd_policy {
             apply_options = apply_options.with_svd_policy(policy);
         }
@@ -1496,12 +1496,12 @@ mod tests {
     fn gse_option_builders_set_reference_knobs() {
         let policy = SvdTruncationPolicy::new(1.0e-8);
         let options = GseOptions::default()
-            .with_reference_max_rank(7)
+            .with_reference_max_bond_dim(7)
             .with_reference_svd_policy(policy)
             .with_normalize_references(false)
             .with_expand_before_first_sweep(false);
 
-        assert_eq!(options.reference_max_rank, Some(7));
+        assert_eq!(options.reference_max_bond_dim, Some(7));
         assert_eq!(options.reference_svd_policy, Some(policy));
         assert!(!options.normalize_references);
         assert!(!options.expand_before_first_sweep);

--- a/crates/tensor4all-treetn/src/linsolve/common/options.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/options.rs
@@ -85,8 +85,8 @@ impl LinsolveOptions {
     }
 
     /// Set maximum bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.truncation = self.truncation.with_max_rank(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.truncation = self.truncation.with_max_bond_dim(max_bond_dim);
         self
     }
 

--- a/crates/tensor4all-treetn/src/linsolve/common/options/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/common/options/tests/mod.rs
@@ -19,7 +19,7 @@ fn test_builder_pattern() {
         .with_squared_values()
         .with_discarded_tail_sum();
     let opts = LinsolveOptions::new(5)
-        .with_max_rank(100)
+        .with_max_bond_dim(100)
         .with_svd_policy(policy)
         .with_gmres_tol(1e-8)
         .with_gmres_absolute_tolerance()
@@ -28,7 +28,7 @@ fn test_builder_pattern() {
         .with_residual_check(false);
 
     assert_eq!(opts.nfullsweeps, 5);
-    assert_eq!(opts.truncation.max_rank(), Some(100));
+    assert_eq!(opts.truncation.max_bond_dim(), Some(100));
     assert_eq!(opts.truncation.svd_policy(), Some(policy));
     assert_eq!(opts.gmres_tol, 1e-8);
     assert_eq!(opts.gmres_tolerance_mode, GmresToleranceMode::Absolute);

--- a/crates/tensor4all-treetn/src/linsolve/square/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/mod.rs
@@ -207,7 +207,7 @@ where
 ///     .with_gmres_tol(1.0e-10)
 ///     .with_gmres_restart_dim(10)
 ///     .with_gmres_max_restarts(30)
-///     .with_max_rank(4)
+///     .with_max_bond_dim(4)
 ///     .with_convergence_tol(1.0e-8);
 /// let result = square_linsolve(
 ///     &operator,

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -562,8 +562,8 @@ where
 
         // Decompose solved tensor back into TreeTN using factorize_tensor_to_treetn
         let mut factorize_options = FactorizeOptions::svd();
-        if let Some(max_rank) = self.options.truncation.max_rank() {
-            factorize_options = factorize_options.with_max_rank(max_rank);
+        if let Some(max_bond_dim) = self.options.truncation.max_bond_dim() {
+            factorize_options = factorize_options.with_max_bond_dim(max_bond_dim);
         }
         if let Some(policy) = self.options.truncation.svd_policy() {
             factorize_options = factorize_options.with_svd_policy(policy);

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -96,13 +96,13 @@ use crate::treetn::TreeTN;
 /// [`ApplyOptions::naive`] uses a dedicated local exact apply path: it contracts
 /// each state tensor with the corresponding operator tensor and fuses each
 /// state/operator link pair into one product link. It does not materialize the
-/// full state or operator tensor. Truncation fields such as `max_rank`,
+/// full state or operator tensor. Truncation fields such as `max_bond_dim`,
 /// `svd_policy`, and `qr_rtol` are ignored by the naive path.
 ///
 /// # Defaults
 ///
 /// - `method`: [`ContractionMethod::Zipup`] (single-sweep, no iteration)
-/// - `max_rank`: `None` (no rank limit)
+/// - `max_bond_dim`: `None` (no rank limit)
 /// - `svd_policy`: `None` (uses the SVD global default policy)
 /// - `qr_rtol`: `None` (uses the QR global default tolerance)
 /// - `nfullsweeps`: `1` (only used by Fit method)
@@ -116,29 +116,29 @@ use crate::treetn::TreeTN;
 ///
 /// // Default: Zipup with no truncation
 /// let opts = ApplyOptions::default();
-/// assert_eq!(opts.max_rank, None);
+/// assert_eq!(opts.max_bond_dim, None);
 ///
 /// // Zipup with rank and tolerance limits
 /// let opts = ApplyOptions::zipup()
-///     .with_max_rank(50)
+///     .with_max_bond_dim(50)
 ///     .with_svd_policy(SvdTruncationPolicy::new(1e-8));
-/// assert_eq!(opts.max_rank, Some(50));
+/// assert_eq!(opts.max_bond_dim, Some(50));
 /// assert_eq!(opts.svd_policy, Some(SvdTruncationPolicy::new(1e-8)));
 ///
 /// // Fit method with sweep control
-/// let opts = ApplyOptions::fit().with_nfullsweeps(3).with_max_rank(20);
+/// let opts = ApplyOptions::fit().with_nfullsweeps(3).with_max_bond_dim(20);
 /// assert_eq!(opts.nfullsweeps, 3);
 ///
 /// // Local exact naive apply: no truncation and no full dense tensor.
 /// let opts = ApplyOptions::naive();
-/// assert_eq!(opts.max_rank, None);
+/// assert_eq!(opts.max_bond_dim, None);
 /// ```
 #[derive(Debug, Clone)]
 pub struct ApplyOptions {
     /// Contraction method to use.
     pub method: ContractionMethod,
     /// Maximum bond dimension for truncation.
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Explicit SVD truncation policy.
     pub svd_policy: Option<SvdTruncationPolicy>,
     /// QR-specific relative tolerance.
@@ -155,7 +155,7 @@ impl Default for ApplyOptions {
     fn default() -> Self {
         Self {
             method: ContractionMethod::Zipup,
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             qr_rtol: None,
             nfullsweeps: 1,
@@ -193,8 +193,8 @@ impl ApplyOptions {
     }
 
     /// Set maximum bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -296,7 +296,7 @@ impl ApplyOptions {
 ///     &operator,
 ///     &state,
 ///     ApplyOptions::zipup()
-///         .with_max_rank(4)
+///         .with_max_bond_dim(4)
 ///         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10)),
 /// )?;
 /// assert_eq!(truncated.node_count(), 1);
@@ -350,7 +350,7 @@ where
 
     let contraction_options = ContractionOptions {
         method: options.method,
-        max_rank: options.max_rank,
+        max_bond_dim: options.max_bond_dim,
         svd_policy: options.svd_policy,
         qr_rtol: options.qr_rtol,
         nfullsweeps: options.nfullsweeps,

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -618,10 +618,10 @@ fn test_apply_options_builder() {
         .with_squared_values()
         .with_discarded_tail_sum();
     let opts = ApplyOptions::zipup()
-        .with_max_rank(50)
+        .with_max_bond_dim(50)
         .with_svd_policy(policy);
     assert_eq!(opts.method, ContractionMethod::Zipup);
-    assert_eq!(opts.max_rank, Some(50));
+    assert_eq!(opts.max_bond_dim, Some(50));
     assert_eq!(opts.svd_policy, Some(policy));
     assert_eq!(opts.qr_rtol, None);
 

--- a/crates/tensor4all-treetn/src/options.rs
+++ b/crates/tensor4all-treetn/src/options.rs
@@ -12,7 +12,7 @@ use tensor4all_core::SvdTruncationPolicy;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(crate) struct FactorizationToleranceOptions {
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     pub svd_policy: Option<SvdTruncationPolicy>,
     pub qr_rtol: Option<f64>,
 }
@@ -91,10 +91,10 @@ impl CanonicalizationOptions {
 /// use tensor4all_treetn::TruncationOptions;
 ///
 /// let options = TruncationOptions::default()
-///     .with_max_rank(50)
+///     .with_max_bond_dim(50)
 ///     .with_svd_policy(SvdTruncationPolicy::new(1e-10));
 ///
-/// assert_eq!(options.max_rank(), Some(50));
+/// assert_eq!(options.max_bond_dim(), Some(50));
 /// assert_eq!(options.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
 /// ```
 #[derive(Debug, Clone, Copy)]
@@ -120,8 +120,8 @@ impl TruncationOptions {
     }
 
     /// Create options with a maximum rank.
-    pub fn with_max_rank(mut self, rank: usize) -> Self {
-        self.truncation.max_rank = Some(rank);
+    pub fn with_max_bond_dim(mut self, rank: usize) -> Self {
+        self.truncation.max_bond_dim = Some(rank);
         self
     }
 
@@ -136,9 +136,9 @@ impl TruncationOptions {
         self.truncation.svd_policy
     }
 
-    /// Get max_rank.
-    pub fn max_rank(&self) -> Option<usize> {
-        self.truncation.max_rank
+    /// Get max_bond_dim.
+    pub fn max_bond_dim(&self) -> Option<usize> {
+        self.truncation.max_bond_dim
     }
 }
 
@@ -151,13 +151,13 @@ impl TruncationOptions {
 /// use tensor4all_treetn::{CanonicalForm, SplitOptions};
 ///
 /// let options = SplitOptions::default()
-///     .with_max_rank(50)
+///     .with_max_bond_dim(50)
 ///     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
 ///     .with_qr_rtol(1e-12)
 ///     .with_final_sweep(true);
 ///
 /// assert!(matches!(options.form, CanonicalForm::Unitary));
-/// assert_eq!(options.max_rank(), Some(50));
+/// assert_eq!(options.max_bond_dim(), Some(50));
 /// assert_eq!(options.svd_policy(), Some(SvdTruncationPolicy::new(1e-10)));
 /// assert_eq!(options.qr_rtol(), Some(1e-12));
 /// assert!(options.final_sweep);
@@ -189,8 +189,8 @@ impl SplitOptions {
     }
 
     /// Create options with a maximum rank.
-    pub fn with_max_rank(mut self, rank: usize) -> Self {
-        self.truncation.max_rank = Some(rank);
+    pub fn with_max_bond_dim(mut self, rank: usize) -> Self {
+        self.truncation.max_bond_dim = Some(rank);
         self
     }
 
@@ -228,9 +228,9 @@ impl SplitOptions {
         self.truncation.qr_rtol
     }
 
-    /// Get max_rank.
-    pub fn max_rank(&self) -> Option<usize> {
-        self.truncation.max_rank
+    /// Get max_bond_dim.
+    pub fn max_bond_dim(&self) -> Option<usize> {
+        self.truncation.max_bond_dim
     }
 }
 
@@ -261,18 +261,18 @@ impl SplitOptions {
 /// use tensor4all_core::SvdTruncationPolicy;
 ///
 /// let options = RestructureOptions::new()
-///     .with_split(SplitOptions::new().with_max_rank(32))
+///     .with_split(SplitOptions::new().with_max_bond_dim(32))
 ///     .with_swap(SwapOptions {
-///         max_rank: Some(16),
+///         max_bond_dim: Some(16),
 ///         rtol: Some(1e-10),
 ///     })
 ///     .with_final_truncation(
 ///         TruncationOptions::new().with_svd_policy(SvdTruncationPolicy::new(1e-12)),
 ///     );
 ///
-/// assert_eq!(options.split.max_rank(), Some(32));
+/// assert_eq!(options.split.max_bond_dim(), Some(32));
 /// assert!(!options.split.final_sweep);
-/// assert_eq!(options.swap.max_rank, Some(16));
+/// assert_eq!(options.swap.max_bond_dim, Some(16));
 /// assert_eq!(options.swap.rtol, Some(1e-10));
 /// assert_eq!(
 ///     options
@@ -287,7 +287,7 @@ pub struct RestructureOptions {
     /// Options for the split/refinement phase.
     ///
     /// These settings matter when a current node must be factored into multiple
-    /// fragments before any fragment movement can happen. Higher `max_rank`,
+    /// fragments before any fragment movement can happen. Higher `max_bond_dim`,
     /// stricter `svd_policy`, and smaller `qr_rtol` preserve more fidelity but
     /// can increase intermediate bond dimensions. `final_sweep` should usually
     /// remain `false` here unless a split-only workflow is being optimized in
@@ -296,7 +296,7 @@ pub struct RestructureOptions {
     /// Options for the site-transport / swap phase.
     ///
     /// This phase only moves already planned fragments across existing edges.
-    /// Leaving both fields unset keeps swaps exact. Setting `max_rank` or
+    /// Leaving both fields unset keeps swaps exact. Setting `max_bond_dim` or
     /// `rtol` can control intermediate rank growth, but may introduce
     /// approximation earlier than the optional final truncation sweep.
     pub swap: SwapOptions,
@@ -322,7 +322,7 @@ impl RestructureOptions {
     /// let options = RestructureOptions::new();
     ///
     /// assert!(!options.split.final_sweep);
-    /// assert_eq!(options.swap.max_rank, None);
+    /// assert_eq!(options.swap.max_bond_dim, None);
     /// assert_eq!(options.swap.rtol, None);
     /// assert!(options.final_truncation.is_none());
     /// ```
@@ -344,9 +344,9 @@ impl RestructureOptions {
     /// use tensor4all_treetn::{RestructureOptions, SplitOptions};
     ///
     /// let options = RestructureOptions::new()
-    ///     .with_split(SplitOptions::new().with_max_rank(24).with_final_sweep(true));
+    ///     .with_split(SplitOptions::new().with_max_bond_dim(24).with_final_sweep(true));
     ///
-    /// assert_eq!(options.split.max_rank(), Some(24));
+    /// assert_eq!(options.split.max_bond_dim(), Some(24));
     /// assert!(options.split.final_sweep);
     /// ```
     pub fn with_split(mut self, split: SplitOptions) -> Self {
@@ -368,11 +368,11 @@ impl RestructureOptions {
     /// use tensor4all_treetn::{RestructureOptions, SwapOptions};
     ///
     /// let options = RestructureOptions::new().with_swap(SwapOptions {
-    ///     max_rank: Some(12),
+    ///     max_bond_dim: Some(12),
     ///     rtol: Some(1e-8),
     /// });
     ///
-    /// assert_eq!(options.swap.max_rank, Some(12));
+    /// assert_eq!(options.swap.max_bond_dim, Some(12));
     /// assert_eq!(options.swap.rtol, Some(1e-8));
     /// ```
     pub fn with_swap(mut self, swap: SwapOptions) -> Self {
@@ -399,7 +399,7 @@ impl RestructureOptions {
     /// let options = RestructureOptions::new()
     ///     .with_final_truncation(
     ///         TruncationOptions::new()
-    ///             .with_max_rank(10)
+    ///             .with_max_bond_dim(10)
     ///             .with_svd_policy(SvdTruncationPolicy::new(1e-10)),
     ///     );
     ///
@@ -407,7 +407,7 @@ impl RestructureOptions {
     ///     options
     ///         .final_truncation
     ///         .as_ref()
-    ///         .and_then(TruncationOptions::max_rank),
+    ///         .and_then(TruncationOptions::max_bond_dim),
     ///     Some(10)
     /// );
     /// ```

--- a/crates/tensor4all-treetn/src/options/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/options/tests/mod.rs
@@ -37,21 +37,21 @@ fn test_canonicalization_options_builder() {
 #[test]
 fn test_truncation_options_default() {
     let opts = TruncationOptions::default();
-    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.max_bond_dim(), None);
     assert_eq!(opts.svd_policy(), None);
 }
 
 #[test]
 fn test_truncation_options_new() {
     let opts = TruncationOptions::new();
-    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.max_bond_dim(), None);
     assert_eq!(opts.svd_policy(), None);
 }
 
 #[test]
 fn test_truncation_options_do_not_expose_form() {
-    let opts = TruncationOptions::new().with_max_rank(8);
-    assert_eq!(opts.max_rank(), Some(8));
+    let opts = TruncationOptions::new().with_max_bond_dim(8);
+    assert_eq!(opts.max_bond_dim(), Some(8));
 }
 
 #[test]
@@ -66,9 +66,9 @@ fn test_truncation_options_builder() {
         .with_squared_values()
         .with_discarded_tail_sum();
     let opts = TruncationOptions::new()
-        .with_max_rank(50)
+        .with_max_bond_dim(50)
         .with_svd_policy(policy);
-    assert_eq!(opts.max_rank(), Some(50));
+    assert_eq!(opts.max_bond_dim(), Some(50));
     assert_eq!(opts.svd_policy(), Some(policy));
 }
 
@@ -77,7 +77,7 @@ fn test_split_options_default() {
     let opts = SplitOptions::default();
     assert_eq!(opts.form, CanonicalForm::Unitary);
     assert!(!opts.final_sweep);
-    assert_eq!(opts.max_rank(), None);
+    assert_eq!(opts.max_bond_dim(), None);
     assert_eq!(opts.svd_policy(), None);
     assert_eq!(opts.qr_rtol(), None);
 }
@@ -92,12 +92,12 @@ fn test_split_options_new() {
 fn test_split_options_builder() {
     let policy = SvdTruncationPolicy::new(1e-12).with_squared_values();
     let opts = SplitOptions::new()
-        .with_max_rank(100)
+        .with_max_bond_dim(100)
         .with_svd_policy(policy)
         .with_qr_rtol(1e-12)
         .with_form(CanonicalForm::Unitary)
         .with_final_sweep(true);
-    assert_eq!(opts.max_rank(), Some(100));
+    assert_eq!(opts.max_bond_dim(), Some(100));
     assert_eq!(opts.svd_policy(), Some(policy));
     assert_eq!(opts.qr_rtol(), Some(1e-12));
     assert_eq!(opts.form, CanonicalForm::Unitary);
@@ -121,21 +121,25 @@ fn test_restructure_options_default_and_builder() {
     let opts = RestructureOptions::default();
     assert_eq!(opts.split.form, CanonicalForm::Unitary);
     assert!(!opts.split.final_sweep);
-    assert_eq!(opts.swap.max_rank, None);
+    assert_eq!(opts.swap.max_bond_dim, None);
     assert_eq!(opts.swap.rtol, None);
     assert!(opts.final_truncation.is_none());
 
     let final_policy = SvdTruncationPolicy::new(1e-10).with_discarded_tail_sum();
     let opts = RestructureOptions::new()
-        .with_split(SplitOptions::new().with_max_rank(16).with_final_sweep(true))
+        .with_split(
+            SplitOptions::new()
+                .with_max_bond_dim(16)
+                .with_final_sweep(true),
+        )
         .with_swap(SwapOptions {
-            max_rank: Some(8),
+            max_bond_dim: Some(8),
             rtol: Some(1e-9),
         })
         .with_final_truncation(TruncationOptions::new().with_svd_policy(final_policy));
-    assert_eq!(opts.split.max_rank(), Some(16));
+    assert_eq!(opts.split.max_bond_dim(), Some(16));
     assert!(opts.split.final_sweep);
-    assert_eq!(opts.swap.max_rank, Some(8));
+    assert_eq!(opts.swap.max_bond_dim, Some(8));
     assert_eq!(opts.swap.rtol, Some(1e-9));
     assert_eq!(
         opts.final_truncation

--- a/crates/tensor4all-treetn/src/tdvp/mod.rs
+++ b/crates/tensor4all-treetn/src/tdvp/mod.rs
@@ -962,8 +962,8 @@ where
             profile.build_topology += elapsed;
         });
         let mut factorize_options = FactorizeOptions::svd();
-        if let Some(max_rank) = self.options.max_bond_dim {
-            factorize_options = factorize_options.with_max_rank(max_rank);
+        if let Some(max_bond_dim) = self.options.max_bond_dim {
+            factorize_options = factorize_options.with_max_bond_dim(max_bond_dim);
         }
         if let Some(policy) = self.options.svd_policy {
             factorize_options = factorize_options.with_svd_policy(policy);

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -264,7 +264,7 @@ where
     /// * `other` - The other TreeTN to contract with (must have same topology)
     /// * `center` - The center node name towards which to contract
     /// * `svd_policy` - Optional SVD truncation policy
-    /// * `max_rank` - Optional maximum bond dimension
+    /// * `max_bond_dim` - Optional maximum bond dimension
     ///
     /// # Returns
     /// The contracted TreeTN result, or an error if topologies don't match or contraction fails.
@@ -278,14 +278,20 @@ where
         other: &Self,
         center: &V,
         svd_policy: Option<SvdTruncationPolicy>,
-        max_rank: Option<usize>,
+        max_bond_dim: Option<usize>,
     ) -> std::result::Result<Self, TreeTNOperationError>
     where
         V: Ord,
         <T::Index as IndexLike>::Id:
             Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
     {
-        self.contract_zipup_with(other, center, CanonicalForm::Unitary, svd_policy, max_rank)
+        self.contract_zipup_with(
+            other,
+            center,
+            CanonicalForm::Unitary,
+            svd_policy,
+            max_bond_dim,
+        )
     }
 
     /// Contract two TreeTNs with the same topology using zip-up and a specified canonical form.
@@ -301,7 +307,7 @@ where
     /// * `center` - The center node name towards which to contract
     /// * `form` - Canonical form (Unitary/LU/CI)
     /// * `svd_policy` - Optional SVD truncation policy
-    /// * `max_rank` - Optional maximum bond dimension
+    /// * `max_bond_dim` - Optional maximum bond dimension
     ///
     /// # Returns
     /// The contracted TreeTN result, or an error if topologies don't match or contraction fails.
@@ -316,7 +322,7 @@ where
         center: &V,
         form: CanonicalForm,
         svd_policy: Option<SvdTruncationPolicy>,
-        max_rank: Option<usize>,
+        max_bond_dim: Option<usize>,
     ) -> std::result::Result<Self, TreeTNOperationError>
     where
         V: Ord,
@@ -328,7 +334,7 @@ where
             center,
             form,
             svd_policy,
-            max_rank,
+            max_bond_dim,
             ZipupTopologyMode::PruneScalarSubtrees,
         )
         .map_err(TreeTNOperationError::from)
@@ -340,7 +346,7 @@ where
         center: &V,
         form: CanonicalForm,
         svd_policy: Option<SvdTruncationPolicy>,
-        max_rank: Option<usize>,
+        max_bond_dim: Option<usize>,
     ) -> Result<Self>
     where
         V: Ord,
@@ -352,7 +358,7 @@ where
             center,
             form,
             svd_policy,
-            max_rank,
+            max_bond_dim,
             ZipupTopologyMode::PreserveInputTopology,
         )
     }
@@ -363,7 +369,7 @@ where
         center: &V,
         form: CanonicalForm,
         svd_policy: Option<SvdTruncationPolicy>,
-        max_rank: Option<usize>,
+        max_bond_dim: Option<usize>,
         topology_mode: ZipupTopologyMode,
     ) -> Result<Self>
     where
@@ -450,8 +456,8 @@ where
         }
         .with_canonical(Canonical::Left);
 
-        if let Some(max_rank) = max_rank {
-            factorize_options = factorize_options.with_max_rank(max_rank);
+        if let Some(max_bond_dim) = max_bond_dim {
+            factorize_options = factorize_options.with_max_bond_dim(max_bond_dim);
         }
         if let Some(policy) = svd_policy {
             factorize_options = factorize_options.with_svd_policy(policy);
@@ -909,7 +915,7 @@ pub struct ContractionOptions {
     /// Contraction method to use.
     pub method: ContractionMethod,
     /// Maximum bond dimension (optional).
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Explicit SVD truncation policy (optional).
     pub svd_policy: Option<SvdTruncationPolicy>,
     /// QR-specific relative tolerance (optional).
@@ -943,7 +949,7 @@ impl Default for ContractionOptions {
     fn default() -> Self {
         Self {
             method: ContractionMethod::default(),
-            max_rank: None,
+            max_bond_dim: None,
             svd_policy: None,
             qr_rtol: None,
             nfullsweeps: 1,
@@ -975,8 +981,8 @@ impl ContractionOptions {
     }
 
     /// Set maximum bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -1154,13 +1160,13 @@ where
 {
     match options.method {
         ContractionMethod::Zipup => {
-            tn_a.contract_zipup(tn_b, center, options.svd_policy, options.max_rank)
+            tn_a.contract_zipup(tn_b, center, options.svd_policy, options.max_bond_dim)
         }
         ContractionMethod::Fit => {
             let fit_options = FitContractionOptions::new(options.nfullsweeps)
                 .with_factorize_alg(options.factorize_alg);
-            let fit_options = if let Some(max_rank) = options.max_rank {
-                fit_options.with_max_rank(max_rank)
+            let fit_options = if let Some(max_bond_dim) = options.max_bond_dim {
+                fit_options.with_max_bond_dim(max_bond_dim)
             } else {
                 fit_options
             };
@@ -1187,7 +1193,7 @@ where
                 tn_a,
                 tn_b,
                 center,
-                options.max_rank,
+                options.max_bond_dim,
                 options.svd_policy,
                 options.qr_rtol,
             )
@@ -1213,7 +1219,7 @@ pub fn contract_naive_to_treetn<T, V>(
     tn_a: &TreeTN<T, V>,
     tn_b: &TreeTN<T, V>,
     center: &V,
-    _max_rank: Option<usize>,
+    _max_bond_dim: Option<usize>,
     _svd_policy: Option<SvdTruncationPolicy>,
     _qr_rtol: Option<f64>,
 ) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -39,7 +39,7 @@ fn test_contraction_method_default() {
 fn test_contraction_options_default() {
     let opts = ContractionOptions::default();
     assert_eq!(opts.method, ContractionMethod::Zipup);
-    assert!(opts.max_rank.is_none());
+    assert!(opts.max_bond_dim.is_none());
     assert!(opts.svd_policy.is_none());
     assert!(opts.qr_rtol.is_none());
     assert_eq!(opts.nfullsweeps, 1);
@@ -72,7 +72,7 @@ fn test_contraction_options_builders() {
         .with_squared_values()
         .with_discarded_tail_sum();
     let opts = ContractionOptions::zipup()
-        .with_max_rank(10)
+        .with_max_bond_dim(10)
         .with_svd_policy(policy)
         .with_nfullsweeps(3)
         .with_convergence_tol(1e-6)
@@ -80,7 +80,7 @@ fn test_contraction_options_builders() {
         .with_dense_reference_limit(128)
         .with_mismatched_topology_dense_limit(64);
 
-    assert_eq!(opts.max_rank, Some(10));
+    assert_eq!(opts.max_bond_dim, Some(10));
     assert_eq!(opts.svd_policy, Some(policy));
     assert_eq!(opts.qr_rtol, None);
     assert_eq!(opts.nfullsweeps, 3);

--- a/crates/tensor4all-treetn/src/treetn/decompose.rs
+++ b/crates/tensor4all-treetn/src/treetn/decompose.rs
@@ -127,7 +127,7 @@ where
 /// # Arguments
 /// * `tensor` - The dense tensor to decompose
 /// * `topology` - Tree topology specifying nodes, edges, and physical index assignments
-/// * `options` - Factorization options (algorithm, max_rank, rtol, etc.)
+/// * `options` - Factorization options (algorithm, max_bond_dim, rtol, etc.)
 ///
 /// # Returns
 /// A TreeTN representing the decomposed tensor.

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -608,7 +608,7 @@ where
     /// Environment cache
     pub envs: FitEnvironment<T, V>,
     /// Maximum bond dimension
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Legacy relative tolerance retained for same-crate tests and call chains.
     pub(crate) rtol: Option<f64>,
     /// Explicit SVD truncation policy
@@ -630,7 +630,7 @@ where
     /// # Arguments
     /// * `tn_a` - First input TreeTN
     /// * `tn_b` - Second input TreeTN
-    /// * `max_rank` - Maximum bond dimension for truncation
+    /// * `max_bond_dim` - Maximum bond dimension for truncation
     /// * `svd_policy` - Explicit SVD truncation policy
     /// * `qr_rtol` - QR-specific relative tolerance
     ///
@@ -640,14 +640,14 @@ where
     pub fn new(
         tn_a: TreeTN<T, V>,
         tn_b: TreeTN<T, V>,
-        max_rank: Option<usize>,
+        max_bond_dim: Option<usize>,
         rtol: Option<f64>,
     ) -> Self {
         Self {
             tn_a,
             tn_b,
             envs: FitEnvironment::new(),
-            max_rank,
+            max_bond_dim,
             rtol,
             svd_policy: rtol.map(SvdTruncationPolicy::new),
             qr_rtol: None,
@@ -828,13 +828,13 @@ where
             .map_err(|e| anyhow::anyhow!("invalid fit factorization options: {e}"))?;
 
         // Determine bond dimension cap for this factorization step.
-        // - If max_rank is explicitly specified, use it.
-        // - If an algorithm-specific tolerance is specified (but max_rank is not),
+        // - If max_bond_dim is explicitly specified, use it.
+        // - If an algorithm-specific tolerance is specified (but max_bond_dim is not),
         //   allow bonds to grow freely and let the factorization policy decide.
         // - Otherwise, cap at the existing bond dimension to preserve the zipup
         //   initialization size.
-        let bond_cap = if self.max_rank.is_some() {
-            self.max_rank
+        let bond_cap = if self.max_bond_dim.is_some() {
+            self.max_bond_dim
         } else if self.svd_policy.is_some() || self.qr_rtol.is_some() {
             None
         } else {
@@ -844,7 +844,7 @@ where
                 .map(|b| b.dim())
         };
         if let Some(cap) = bond_cap {
-            options = options.with_max_rank(cap);
+            options = options.with_max_bond_dim(cap);
         }
 
         // Factorize using TensorFactorizationLike::factorize
@@ -967,7 +967,7 @@ pub struct FitContractionOptions {
     /// A full sweep visits each edge twice (forward and backward) using an Euler tour.
     pub nfullsweeps: usize,
     /// Maximum bond dimension.
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Legacy relative tolerance retained for same-crate tests and call chains.
     pub(crate) rtol: Option<f64>,
     /// Explicit SVD truncation policy.
@@ -986,7 +986,7 @@ impl Default for FitContractionOptions {
     fn default() -> Self {
         Self {
             nfullsweeps: 1,
-            max_rank: None,
+            max_bond_dim: None,
             rtol: None,
             svd_policy: None,
             qr_rtol: None,
@@ -1006,8 +1006,8 @@ impl FitContractionOptions {
     }
 
     /// Set maximum bond dimension.
-    pub fn with_max_rank(mut self, max_rank: usize) -> Self {
-        self.max_rank = Some(max_rank);
+    pub fn with_max_bond_dim(mut self, max_bond_dim: usize) -> Self {
+        self.max_bond_dim = Some(max_bond_dim);
         self
     }
 
@@ -1100,7 +1100,7 @@ where
         center,
         CanonicalForm::Unitary,
         options.svd_policy,
-        options.max_rank,
+        options.max_bond_dim,
     )?;
     if let Some(zipup_started) = zipup_started {
         with_fit_profile(|profile| {
@@ -1118,7 +1118,7 @@ where
     }
 
     // Create FitUpdater (environments are computed lazily)
-    let mut updater = FitUpdater::new(tn_a.clone(), tn_b.clone(), options.max_rank, None)
+    let mut updater = FitUpdater::new(tn_a.clone(), tn_b.clone(), options.max_bond_dim, None)
         .with_svd_policy(options.svd_policy)
         .with_qr_rtol(options.qr_rtol)
         .with_factorize_alg(options.factorize_alg);

--- a/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
@@ -276,7 +276,7 @@ fn test_fit_environment_verify_structural_consistency_detects_missing_child_env(
 fn test_fit_contraction_options_default() {
     let opts = FitContractionOptions::default();
     assert_eq!(opts.nfullsweeps, 1);
-    assert!(opts.max_rank.is_none());
+    assert!(opts.max_bond_dim.is_none());
     assert!(opts.rtol.is_none());
     assert_eq!(opts.factorize_alg, FactorizeAlg::SVD);
     assert!(opts.convergence_tol.is_none());
@@ -291,13 +291,13 @@ fn test_fit_contraction_options_new() {
 #[test]
 fn test_fit_contraction_options_builders() {
     let opts = FitContractionOptions::new(2)
-        .with_max_rank(10)
+        .with_max_bond_dim(10)
         .with_rtol(1e-8)
         .with_factorize_alg(FactorizeAlg::LU)
         .with_convergence_tol(1e-6);
 
     assert_eq!(opts.nfullsweeps, 2);
-    assert_eq!(opts.max_rank, Some(10));
+    assert_eq!(opts.max_bond_dim, Some(10));
     assert_eq!(opts.rtol, Some(1e-8));
     assert_eq!(opts.factorize_alg, FactorizeAlg::LU);
     assert_eq!(opts.convergence_tol, Some(1e-6));
@@ -313,7 +313,7 @@ fn test_fit_updater_new() {
     let tn_b = make_two_node_treetn();
 
     let updater = FitUpdater::new(tn_a, tn_b, Some(5), Some(1e-8));
-    assert_eq!(updater.max_rank, Some(5));
+    assert_eq!(updater.max_bond_dim, Some(5));
     assert_eq!(updater.rtol, Some(1e-8));
     assert_eq!(updater.factorize_alg, FactorizeAlg::SVD);
     assert!(updater.envs.is_empty());

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -490,7 +490,7 @@ use tensor4all_core::{Canonical, FactorizeOptions, SvdTruncationPolicy};
 #[derive(Debug, Clone)]
 pub struct TruncateUpdater {
     /// Maximum bond dimension after truncation.
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Explicit SVD truncation policy.
     pub svd_policy: Option<SvdTruncationPolicy>,
 }
@@ -499,11 +499,11 @@ impl TruncateUpdater {
     /// Create a new truncation updater.
     ///
     /// # Arguments
-    /// * `max_rank` - Maximum bond dimension (None for no limit)
+    /// * `max_bond_dim` - Maximum bond dimension (None for no limit)
     /// * `svd_policy` - SVD truncation policy override (None uses the global default)
-    pub fn new(max_rank: Option<usize>, svd_policy: Option<SvdTruncationPolicy>) -> Self {
+    pub fn new(max_bond_dim: Option<usize>, svd_policy: Option<SvdTruncationPolicy>) -> Self {
         Self {
-            max_rank,
+            max_bond_dim,
             svd_policy,
         }
     }
@@ -576,8 +576,8 @@ where
         // Set up factorization options
         let mut options = FactorizeOptions::svd().with_canonical(Canonical::Left); // Left canonical: A is isometry, B has the norm
 
-        if let Some(max_rank) = self.max_rank {
-            options = options.with_max_rank(max_rank);
+        if let Some(max_bond_dim) = self.max_bond_dim {
+            options = options.with_max_bond_dim(max_bond_dim);
         }
         if let Some(policy) = self.svd_policy {
             options = options.with_svd_policy(policy);

--- a/crates/tensor4all-treetn/src/treetn/localupdate/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate/tests/mod.rs
@@ -456,7 +456,7 @@ fn test_truncate_updater_basic() {
     let plan = LocalUpdateSweepPlan::from_treetn(&tn, &"B".to_string(), 2).unwrap();
     assert_eq!(plan.len(), 4); // 2 edges × 2 directions
 
-    // Create truncate updater with max_rank=2
+    // Create truncate updater with max_bond_dim=2
     let mut updater = TruncateUpdater::new(Some(2), None);
 
     // Apply sweep
@@ -466,7 +466,7 @@ fn test_truncate_updater_basic() {
     tn.verify_internal_consistency().unwrap();
 
     // Check that bond dimensions are reduced
-    // After truncation with max_rank=2, all bonds should have dim <= 2
+    // After truncation with max_bond_dim=2, all bonds should have dim <= 2
     for node_name in tn.node_names() {
         let node_idx = tn.node_index(&node_name).unwrap();
         let tensor = tn.tensor(node_idx).unwrap();
@@ -494,7 +494,7 @@ fn test_apply_local_update_sweep_preserves_structure() {
     // Create sweep plan with nsite=2 from B
     let plan = LocalUpdateSweepPlan::from_treetn(&tn, &"B".to_string(), 2).unwrap();
 
-    // Apply with no truncation (max_rank=None)
+    // Apply with no truncation (max_bond_dim=None)
     let mut updater = TruncateUpdater::new(None, None);
     apply_local_update_sweep(&mut tn, &plan, &mut updater).unwrap();
 

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -1689,8 +1689,8 @@ where
             .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(
                 options.rtol.unwrap_or(0.0),
             ));
-        if let Some(mr) = options.max_rank {
-            swap_factorize_options = swap_factorize_options.with_max_rank(mr);
+        if let Some(mr) = options.max_bond_dim {
+            swap_factorize_options = swap_factorize_options.with_max_bond_dim(mr);
         }
 
         for step in &schedule.steps {

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -242,8 +242,8 @@ fn factorize_options_from_contraction_options(
     if let Some(rtol) = options.qr_rtol {
         factorize_options = factorize_options.with_qr_rtol(rtol);
     }
-    if let Some(max_rank) = options.max_rank {
-        factorize_options = factorize_options.with_max_rank(max_rank);
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        factorize_options = factorize_options.with_max_bond_dim(max_bond_dim);
     }
     factorize_options.validate().map_err(|err| {
         anyhow!("partial_contract: invalid contraction factorization options: {err}")

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -120,11 +120,11 @@ fn helper_factorize_options_and_union_topology_paths_are_exercised() {
     let policy = SvdTruncationPolicy::new(1.0e-8);
     let options = ContractionOptions::default()
         .with_factorize_alg(FactorizeAlg::SVD)
-        .with_max_rank(3)
+        .with_max_bond_dim(3)
         .with_svd_policy(policy);
     let factorize_options = factorize_options_from_contraction_options(&options).unwrap();
     assert_eq!(factorize_options.alg, FactorizeAlg::SVD);
-    assert_eq!(factorize_options.max_rank, Some(3));
+    assert_eq!(factorize_options.max_bond_dim, Some(3));
     assert_eq!(factorize_options.svd_policy, Some(policy));
 
     let qr_options = factorize_options_from_contraction_options(

--- a/crates/tensor4all-treetn/src/treetn/swap.rs
+++ b/crates/tensor4all-treetn/src/treetn/swap.rs
@@ -105,14 +105,14 @@ where
 
 /// Options for site index swap (truncation during SVD).
 ///
-/// When `max_rank` or `rtol` are set, the swap may introduce approximation error
+/// When `max_bond_dim` or `rtol` are set, the swap may introduce approximation error
 /// by truncating bond dimension. Default (both `None`) allows rank growth to preserve
 /// the tensor exactly: `None` is an explicit "no truncation" request and does
 /// *not* fall back to the process-global SVD truncation policy.
 #[derive(Debug, Clone, Default)]
 pub struct SwapOptions {
     /// Maximum bond dimension after each SVD (None = no limit).
-    pub max_rank: Option<usize>,
+    pub max_bond_dim: Option<usize>,
     /// Relative tolerance for singular value truncation (None = no truncation,
     /// equivalent to `Some(0.0)`).
     pub rtol: Option<f64>,

--- a/crates/tensor4all-treetn/src/treetn/transform.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform.rs
@@ -897,7 +897,7 @@ where
             let factorize_options = FactorizeOptions {
                 alg: FactorizeAlg::QR,
                 canonical: Canonical::Left,
-                max_rank: None,
+                max_bond_dim: None,
                 svd_policy: None,
                 qr_rtol: Some(0.0),
             };
@@ -971,7 +971,7 @@ where
             let factorize_options = FactorizeOptions {
                 alg: FactorizeAlg::QR,
                 canonical: Canonical::Left,
-                max_rank: None,
+                max_bond_dim: None,
                 svd_policy: None,
                 qr_rtol: Some(0.0),
             };

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -33,7 +33,7 @@ where
     ///
     /// This is the recommended unified API for truncation. It accepts:
     /// - Center nodes specified by their node names (V)
-    /// - [`TruncationOptions`] to control the SVD policy and max_rank
+    /// - [`TruncationOptions`] to control the SVD policy and max_bond_dim
     ///
     /// # Algorithm
     /// 1. Canonicalize the network towards the center (required for truncation)
@@ -73,7 +73,7 @@ where
     /// // Truncate with max rank 2 towards node "A"
     /// let tn = tn.truncate(
     ///     ["A".to_string()],
-    ///     TruncationOptions::default().with_max_rank(2),
+    ///     TruncationOptions::default().with_max_bond_dim(2),
     /// ).unwrap();
     ///
     /// // Bond dimension is now at most 2
@@ -91,7 +91,7 @@ where
         self.truncate_impl(
             canonical_region,
             options.svd_policy(),
-            options.truncation.max_rank,
+            options.truncation.max_bond_dim,
             "truncate",
         )?;
         Ok(self)
@@ -117,7 +117,7 @@ where
         self.truncate_impl(
             canonical_region,
             options.svd_policy(),
-            options.truncation.max_rank,
+            options.truncation.max_bond_dim,
             "truncate_mut",
         )
         .map_err(TreeTNOperationError::from)
@@ -130,7 +130,7 @@ where
         &mut self,
         canonical_region: impl IntoIterator<Item = V>,
         svd_policy: Option<SvdTruncationPolicy>,
-        max_rank: Option<usize>,
+        max_bond_dim: Option<usize>,
         context_name: &str,
     ) -> Result<()>
     where
@@ -182,7 +182,7 @@ where
         }
 
         // Step 3: Apply truncation sweep
-        let mut updater = TruncateUpdater::new(max_rank, svd_policy);
+        let mut updater = TruncateUpdater::new(max_bond_dim, svd_policy);
         apply_local_update_sweep(self, &plan, &mut updater)
             .context(format!("{}: truncation sweep failed", context_name))?;
 

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -833,11 +833,11 @@ fn test_truncate_simple() {
     // Original bond dimension is 10
     assert_eq!(tn.bond_index(edge).unwrap().size(), 10);
 
-    // Truncate with max_rank = 3
+    // Truncate with max_bond_dim = 3
     let truncated = tn
         .truncate(
             std::iter::once(n2),
-            TruncationOptions::default().with_max_rank(3),
+            TruncationOptions::default().with_max_bond_dim(3),
         )
         .unwrap();
 
@@ -867,10 +867,10 @@ fn test_truncate_mut_simple() {
     // Original bond dimension
     assert_eq!(tn.bond_index(edge).unwrap().size(), 8);
 
-    // Truncate in-place with max_rank = 4
+    // Truncate in-place with max_bond_dim = 4
     tn.truncate_mut(
         std::iter::once(n2),
-        TruncationOptions::default().with_max_rank(4),
+        TruncationOptions::default().with_max_bond_dim(4),
     )
     .unwrap();
 
@@ -887,11 +887,11 @@ fn test_truncate_three_node_chain() {
     assert_eq!(tn.bond_index(e12).unwrap().size(), 3);
     assert_eq!(tn.bond_index(e23).unwrap().size(), 4);
 
-    // Truncate towards center (n1) with max_rank = 2
+    // Truncate towards center (n1) with max_bond_dim = 2
     let truncated = tn
         .truncate(
             std::iter::once(n1),
-            TruncationOptions::default().with_max_rank(2),
+            TruncationOptions::default().with_max_bond_dim(2),
         )
         .unwrap();
 
@@ -997,11 +997,11 @@ fn test_truncate_y_shape() {
     assert_eq!(tn.bond_index(e_bc).unwrap().size(), 6);
     assert_eq!(tn.bond_index(e_bd).unwrap().size(), 6);
 
-    // Truncate towards center (n_b) with max_rank = 3
+    // Truncate towards center (n_b) with max_bond_dim = 3
     let truncated = tn
         .truncate(
             std::iter::once(n_b),
-            TruncationOptions::default().with_max_rank(3),
+            TruncationOptions::default().with_max_bond_dim(3),
         )
         .unwrap();
 
@@ -1942,11 +1942,11 @@ fn test_fit_contraction_options() {
         .with_squared_values()
         .with_discarded_tail_sum();
     let options = FitContractionOptions::new(5)
-        .with_max_rank(10)
+        .with_max_bond_dim(10)
         .with_svd_policy(policy);
 
     assert_eq!(options.nfullsweeps, 5);
-    assert_eq!(options.max_rank, Some(10));
+    assert_eq!(options.max_bond_dim, Some(10));
     assert_eq!(options.svd_policy, Some(policy));
     assert_eq!(options.qr_rtol, None);
 }

--- a/crates/tensor4all-treetn/tests/gse.rs
+++ b/crates/tensor4all-treetn/tests/gse.rs
@@ -841,7 +841,7 @@ fn gse_rejects_invalid_options_and_missing_center() {
     ));
 
     let invalid_rank_options = GseOptions {
-        reference_max_rank: Some(0),
+        reference_max_bond_dim: Some(0),
         ..Default::default()
     };
     let rank_err = global_subspace_expand_with_references(
@@ -854,7 +854,7 @@ fn gse_rejects_invalid_options_and_missing_center() {
     assert!(matches!(
         rank_err,
         GseError::InvalidOption {
-            option: "reference_max_rank",
+            option: "reference_max_bond_dim",
             ..
         }
     ));

--- a/crates/tensor4all-treetn/tests/issue192_regression.rs
+++ b/crates/tensor4all-treetn/tests/issue192_regression.rs
@@ -201,7 +201,7 @@ fn issue192_regression_no_svd_nan_n5_identity_ones() -> anyhow::Result<()> {
 
     let truncation = TruncationOptions::default()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol))
-        .with_max_rank(bond_dim);
+        .with_max_bond_dim(bond_dim);
 
     let options = LinsolveOptions::default()
         .with_nfullsweeps(n_sweeps)

--- a/crates/tensor4all-treetn/tests/linsolve.rs
+++ b/crates/tensor4all-treetn/tests/linsolve.rs
@@ -569,7 +569,7 @@ fn test_diagonal_linsolve_with_mappings(diag_values: &[f64], b_values: &[f64], t
         .with_gmres_tol(1e-10)
         .with_gmres_restart_dim(10)
         .with_gmres_max_restarts(30)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
     let nsweeps = options.nfullsweeps;
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
@@ -882,7 +882,7 @@ fn test_linsolve_3site_identity() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(2)
         .with_gmres_tol(1e-8)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1340,7 +1340,7 @@ fn test_linsolve_with_index_mappings_identity() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(1)
         .with_gmres_tol(1e-10)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1391,7 +1391,7 @@ fn test_linsolve_with_index_mappings_diagonal() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(3)
         .with_gmres_tol(1e-10)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1547,7 +1547,7 @@ fn test_linsolve_with_index_mappings_three_site_identity() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(1)
         .with_gmres_tol(1e-10)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1604,7 +1604,7 @@ fn test_linsolve_with_index_mappings_three_site_diagonal() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(5)
         .with_gmres_tol(1e-10)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1738,7 +1738,7 @@ fn test_linsolve_pauli_x() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(20)
         .with_gmres_tol(1e-12)
-        .with_max_rank(8);
+        .with_max_bond_dim(8);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1907,7 +1907,7 @@ fn test_linsolve_general_matrix() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(30)
         .with_gmres_tol(1e-12)
-        .with_max_rank(8);
+        .with_max_bond_dim(8);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -1995,7 +1995,7 @@ fn test_linsolve_general_matrix_nonsymmetric() {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(30)
         .with_gmres_tol(1e-12)
-        .with_max_rank(8);
+        .with_max_bond_dim(8);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -2266,7 +2266,7 @@ fn test_linsolve_n_site_identity_impl(n_sites: usize) {
     let options = LinsolveOptions::default()
         .with_nfullsweeps(1)
         .with_gmres_tol(1e-10)
-        .with_max_rank(4);
+        .with_max_bond_dim(4);
 
     let mut updater = SquareLinsolveUpdater::with_index_mappings(
         mpo,
@@ -2324,7 +2324,7 @@ fn test_square_linsolve_with_mappings_identity() {
         .with_gmres_tol(1e-10)
         .with_gmres_restart_dim(10)
         .with_gmres_max_restarts(30)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_convergence_tol(1e-8);
 
     // This previously failed with index mismatch when mappings were not supported
@@ -2415,7 +2415,7 @@ fn test_square_linsolve_with_mappings_allows_unmapped_spectator_nodes() {
         .with_gmres_tol(1e-10)
         .with_gmres_restart_dim(10)
         .with_gmres_max_restarts(30)
-        .with_max_rank(8);
+        .with_max_bond_dim(8);
     let result = square_linsolve(
         &mpo,
         &rhs,
@@ -2534,7 +2534,7 @@ fn test_square_linsolve_with_mappings_identity_term_only() {
         .with_gmres_tol(1e-12)
         .with_gmres_restart_dim(10)
         .with_gmres_max_restarts(30)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_convergence_tol(1e-8);
     let result = square_linsolve(
         &mpo,

--- a/crates/tensor4all-treetn/tests/linsolve_mpo_xb.rs
+++ b/crates/tensor4all-treetn/tests/linsolve_mpo_xb.rs
@@ -110,7 +110,7 @@ fn test_linsolve_allows_two_site_indices_per_node_for_rhs_alignment() -> anyhow:
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(10)
         .with_gmres_restart_dim(10)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_coefficients(0.0, 1.0);
 
     let mut x = init.canonicalize(["site0".to_string()], CanonicalizationOptions::default())?;
@@ -157,7 +157,7 @@ fn test_linsolve_precheck_fails_when_init_rhs_index_structure_mismatch() {
         .with_gmres_tol(1e-8)
         .with_gmres_max_restarts(10)
         .with_gmres_restart_dim(10)
-        .with_max_rank(4)
+        .with_max_bond_dim(4)
         .with_coefficients(0.0, 1.0);
 
     let x = init

--- a/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
+++ b/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
@@ -123,7 +123,7 @@ fn swap_with_transport_must_not_truncate() {
         (
             "rtol: Some(0.0)",
             SwapOptions {
-                max_rank: None,
+                max_bond_dim: None,
                 rtol: Some(0.0),
             },
         ),

--- a/docs/book/src/README.md
+++ b/docs/book/src/README.md
@@ -34,7 +34,7 @@ examples live in this guide and the guide examples are exercised in CI.
 - **Tensor Cross Interpolation (TCI)**: approximates high-dimensional tensors from a small number of evaluations using cross-approximation; TCI2 is the primary algorithm and TCI1 is available for legacy parity
 - **Quantics Tensor Train (QTT)**: represents smooth functions on exponentially fine grids; includes transformation operators (affine, shift, sum)
 - **Tree Tensor Networks**: arbitrary-topology TTN, not limited to chains (MPS/MPO); supports standard MPS/MPO as special cases with runtime topology checks
-- **C API** (`tensor4all-capi`): stable FFI surface for language bindings, currently used by [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl)
+- **C API** (`tensor4all-capi`): FFI surface for language bindings, currently used by [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl). This repository is early development with no backward-compatibility guarantee; the C ABI should not be treated as stable.
 
 ---
 

--- a/docs/book/src/architecture.md
+++ b/docs/book/src/architecture.md
@@ -143,6 +143,15 @@ Rules:
 | Crate | Description |
 |-------|-------------|
 | **quanticstransform** | Quantics transformation operators: shift, flip, Fourier, affine, and more. Consumes simplett-stack data; constructs TreeTN-based `LinearOperator`s (see the bridge exception above). |
+| **interpolativeqtt** | Interpolative QTT construction on a coarse grid (simplett stack). See the [interpolative-QTT tutorial](tutorials/quantics-basics/interpolative-qtt.md). |
+
+### Applications
+
+| Crate | Description |
+|-------|-------------|
+| **aci** | Alternating Cross Interpolation (ACI) for elementwise tensor-train operations. |
+
+### I/O & bindings
 
 ### I/O & bindings
 
@@ -164,6 +173,8 @@ Rules:
 | Subdomain decomposition via partitioned TT | `tensor4all-partitionedtt` |
 | Quantics transform operators | `tensor4all-quanticstransform` |
 | HDF5 I/O compatible with Julia | `tensor4all-hdf5` |
+| Interpolative QTT on a coarse grid | `tensor4all-interpolativeqtt` |
+| Elementwise TT ops via ACI | `tensor4all-aci` |
 
 ## Error remedies
 

--- a/docs/book/src/conventions.md
+++ b/docs/book/src/conventions.md
@@ -32,6 +32,23 @@ rtol = sqrt(cutoff)
 
 **Example**: ITensors.jl `cutoff=1e-10` corresponds to `rtol=1e-5` in tensor4all-rs.
 
+## Bond-Dimension Cap
+
+tensor4all-rs uses one spelling and one type for the bond-dimension cap across
+all crates: **`max_bond_dim: Option<usize>`** (`None` = unlimited). No
+`usize::MAX` sentinel is used.
+
+| Library | Parameter | tensor4all-rs |
+|---------|-----------|---------------|
+| tensor4all-rs | `max_bond_dim: Option<usize>` | — |
+| ITensors.jl | `maxdim` | `max_bond_dim: Some(d)` |
+| QuanticsTCI.jl / TCI | `maxbonddim` | `max_bond_dim: Some(d)` |
+| (historical) | `max_rank` | `max_bond_dim: Option<usize>` |
+
+`maxdim` is the closest ITensors.jl cousin of `max_bond_dim` (bond dimension
+is the unambiguous tensor-network term; "rank" is overloaded in TCI
+context).
+
 ## ITensors.jl Type Correspondence
 
 | ITensors.jl | tensor4all-rs |

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -60,7 +60,7 @@ fn main() {
     // Compress with a truncation tolerance.
     let options = CompressionOptions {
         tolerance: 1e-10,
-        max_bond_dim: 20,
+        max_bond_dim: Some(20),
         ..Default::default()
     };
     let compressed = tt.compressed(&options).unwrap();

--- a/docs/book/src/guides/compress.md
+++ b/docs/book/src/guides/compress.md
@@ -38,7 +38,7 @@ let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
     vec![vec![0, 0, 0]],
     TCI2Options {
         tolerance: 1e-12,
-        max_bond_dim: 64,
+        max_bond_dim: Some(64),
         ..Default::default()
     },
 )?;
@@ -81,7 +81,7 @@ The quality of the compression is visible in the bond dimensions and the paramet
 # };
 # let tensor4all_tensorci::TCI2OptimizationResult { tci, .. } = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
 #     f, None, local_dims.clone(), vec![vec![0, 0, 0]],
-#     TCI2Options { tolerance: 1e-12, max_bond_dim: 64, ..Default::default() },
+#     TCI2Options { tolerance: 1e-12, max_bond_dim: Some(64), ..Default::default() },
 # )?;
 # let tt = tci.to_tensor_train()?;
 let bond_dims = tt.link_dims();

--- a/docs/book/src/guides/quantics.md
+++ b/docs/book/src/guides/quantics.md
@@ -155,17 +155,17 @@ use tensor4all_treetn::ApplyOptions;
 // Use for small exact/debug cases; output bond dimensions can grow as
 // state/operator bond products.
 let opts = ApplyOptions::naive();
-assert_eq!(opts.max_rank, None);
+assert_eq!(opts.max_bond_dim, None);
 
 // ZipUp (default): single-pass, controllable truncation.
 let opts = ApplyOptions::zipup()
-    .with_max_rank(64)
+    .with_max_bond_dim(64)
     .with_svd_policy(SvdTruncationPolicy::new(1e-10));
-assert_eq!(opts.max_rank, Some(64));
+assert_eq!(opts.max_bond_dim, Some(64));
 
 // Fit: iterative sweeps for best compression.
 let opts = ApplyOptions::fit()
-    .with_max_rank(32)
+    .with_max_bond_dim(32)
     .with_nfullsweeps(3);
 assert_eq!(opts.nfullsweeps, 3);
 ```

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -197,7 +197,7 @@ let bond_dim = result.rank;
 println!("bond dimension after SVD: {bond_dim}");
 
 // Limit bond dimension explicitly.
-let opts_capped = FactorizeOptions::svd().with_max_rank(2);
+let opts_capped = FactorizeOptions::svd().with_max_bond_dim(2);
 let result_capped = factorize(&t, &[i], &opts_capped).unwrap();
 assert!(result_capped.rank <= 2);
 ```
@@ -227,6 +227,6 @@ let result = factorize(&t, &[i], &opts).unwrap();
 
 Both `FactorizeOptions::svd()` and `FactorizeOptions::qr()` return builder
 structs. Use `.with_svd_policy(policy)` for SVD and `.with_qr_rtol(tol)` for
-QR-specific rank control. `with_max_rank(n)` remains available as an
+QR-specific rank control. `with_max_bond_dim(n)` remains available as an
 algorithm-independent hard cap. For SVD, `result.singular_values` holds the
 retained singular values.

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -74,7 +74,7 @@ assert_eq!(big.rank(), 2);
 
 let options = CompressionOptions {
     tolerance: 1e-10,
-    max_bond_dim: 20,
+    max_bond_dim: Some(20),
     ..Default::default()
 };
 let compressed = big.compressed(&options)?;
@@ -217,7 +217,7 @@ After orthogonalization you can truncate bond dimensions by SVD:
 tt.truncate(
     &TruncateOptions::svd()
         .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-        .with_max_rank(2),
+        .with_max_bond_dim(2),
 )?;
 assert!(tt.max_bond_dim() <= 2);
 # Ok(())

--- a/docs/book/src/guides/tree-tn.md
+++ b/docs/book/src/guides/tree-tn.md
@@ -110,11 +110,11 @@ let ttn = ttn.canonicalize([0], CanonicalizationOptions::default()).unwrap();
 assert!(ttn.is_canonicalized());
 
 // Truncate bond dimensions after canonicalization
-let ttn = ttn.truncate([0], TruncationOptions::default().with_max_rank(2)).unwrap();
+let ttn = ttn.truncate([0], TruncationOptions::default().with_max_bond_dim(2)).unwrap();
 assert_eq!(ttn.node_count(), 2);
 ```
 
-`TruncationOptions` supports both a maximum rank (`with_max_rank`) and a relative tolerance
+`TruncationOptions` supports both a maximum rank (`with_max_bond_dim`) and a relative tolerance
 (`with_rtol`). Truncation discards small singular values on each bond, reducing memory and
 contraction cost at the expense of a controlled approximation error.
 

--- a/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
+++ b/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
@@ -144,7 +144,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // dimensions stay manageable for inspection and plotting.
     let compression_options = TruncationOptions::default()
         .with_svd_policy(SvdTruncationPolicy::new(1e-12))
-        .with_max_rank(64);
+        .with_max_bond_dim(64);
     let product_compressed_tn = product_raw_tn
         .clone()
         .truncate([center], compression_options)?;

--- a/docs/tutorial-code/src/main.rs
+++ b/docs/tutorial-code/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
     // Compress with a truncation tolerance.
     let options = CompressionOptions {
         tolerance: 1e-10,
-        max_bond_dim: 20,
+        max_bond_dim: Some(20),
         ..Default::default()
     };
     let compressed = tt.compressed(&options).unwrap();

--- a/docs/tutorial-code/src/qtt_fourier_common.rs
+++ b/docs/tutorial-code/src/qtt_fourier_common.rs
@@ -140,7 +140,7 @@ pub fn build_fourier_operator(
     config: &FourierTutorialConfig,
 ) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
     let options = FourierOptions {
-        max_bond_dim: config.max_bond_dim,
+        max_bond_dim: Some(config.max_bond_dim),
         tolerance: config.tolerance,
         ..FourierOptions::forward()
     };

--- a/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
+++ b/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
@@ -222,7 +222,7 @@ pub fn build_partial_fourier_operator(
     config: &PartialFourier2dConfig,
 ) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
     let options = FourierOptions {
-        max_bond_dim: config.max_bond_dim,
+        max_bond_dim: Some(config.max_bond_dim),
         tolerance: config.tolerance,
         ..FourierOptions::forward()
     };

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -16,7 +16,21 @@ def main():
     file_thresholds = config.get("files", {})
 
     if parser.coverage:
-        with open(parser.coverage) as f:
+        cov_path = Path(parser.coverage)
+        if not cov_path.is_file():
+            # Control 3 (build-artifact hygiene): an explicit local coverage
+            # attestation is required when the hosted-CI-owned measurement is
+            # being re-checked locally. Fail loudly instead of silently
+            # passing when the attestation file is absent.
+            print(
+                f"error: coverage attestation file '{parser.coverage}' not found. "
+                "Run `cargo llvm-cov --release --workspace --exclude "
+                "tensor4all-hdf5 --json --output-path coverage.json` first, or "
+                "pipe a coverage.json to stdin.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        with open(cov_path) as f:
             cov_data = json.load(f)
     else:
         cov_data = json.load(sys.stdin)

--- a/scripts/test-check-coverage.py
+++ b/scripts/test-check-coverage.py
@@ -85,6 +85,18 @@ class CoverageCheckTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1, result.stdout)
         self.assertIn("crates/unknown.rs: 74.9% < 75%", result.stdout)
 
+    def test_missing_attestation_file_fails_explicitly(self) -> None:
+        # Control 3: an explicit --coverage path that does not exist must fail
+        # loudly (explicit local attestation gate), not silently pass.
+        result = subprocess.run(
+            [PYTHON, str(SCRIPT), "definitely-missing-coverage.json"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("coverage attestation file", result.stderr)
+
     def test_comment_rationale_keys_are_ignored_for_enforcement(self) -> None:
         # Top-level _comment_* keys document rationale but never change numbers.
         thresholds = {

--- a/skills/use-tensor4all-rs/SKILL.md
+++ b/skills/use-tensor4all-rs/SKILL.md
@@ -93,6 +93,15 @@ These apply across crates and fail silently when ignored. Check them against eve
 
 **Index identity is full-index equality, not `id()`.** Two indices with the same id but different prime level, tags, or direction are distinct. Key maps and sets by the full `Index` value. Select concrete legs/sites by passing the full `Index`, never an id. `AdaptiveInterpolateOptions::patch_order` and `PatchingOptions::patch_order` are validated as exact full-`Index` permutations of the site indices — matching by id alone is rejected.
 
+## 4.5 Common pitfalls
+
+- **`TensorTrain` / `MPS` / `MPO` share one representation.** In `tensor4all-itensorlike`, `TensorTrain` (tree-based), `MPS`, and `MPO` are the same underlying type; MPS-like (1 site index per node) vs MPO-like (2 site indices per node) is a runtime property (`is_mps_like`/`is_mpo_like`), not a type. `tensor4all-simplett`'s positional chain type is a *different* type named `SimpleTensorTrain`. Do not mix the two `TensorTrainError` types (`tensor4all_simplett::TensorTrainError` vs `tensor4all_itensorlike::TensorTrainError`) — they have different variants; qualify the path.
+- **MPO-MPO contraction has two layers.** `tensor4all-simplett` (positional `SimpleTensorTrain`, `ContractionOptions`) and `tensor4all-treetn` (TreeTN, `apply_linear_operator`) both contract MPOs, but they are different API layers with different topology models. The TreeTN route is the canonical/general path used by the higher-level APIs; use it unless you specifically want the lightweight positional path.
+- **Contraction method changes cost and reliability.** MPO contraction supports different methods (naive / zip-up / fit, selected via `ContractionOptions::method` / `ApplyOptions`). The default is a deliberate tradeoff; benchmark the method for your sizes. `naive` means local exact tensor-network contraction (not full dense materialization) unless the docs explicitly say dense/reference.
+- **ACI tolerance scaling.** The option is named `scale_tolerance` (not `rescale_tolerance`). Enable it when the target function's scale varies across the domain: it makes the convergence tolerance scale-relative. It is not an accuracy certificate — hold out samples and check per-sweep diagnostics, and be aware of the early-convergence caveat tracked in tensor4all-rs issue #572.
+- **0- vs 1-indexing.** Sites are 0-indexed in Rust (unlike ITensors.jl's 1-indexing). Exception: `tensor4all-quanticstci` grid indices are 1-indexed for QuanticsTCI.jl compatibility.
+- **Bond cap / tolerance vocabulary.** The bond-dimension cap is `max_bond_dim: Option<usize>` (`None` = unlimited) everywhere — ITensors.jl `maxdim` maps to `max_bond_dim: Some(d)`, and `cutoff` maps to `rtol` with `rtol = sqrt(cutoff)`. See `docs/book/src/conventions.md`.
+
 ## 5. If you are inside the tensor4all-rs repo itself
 
 This skill is for *using* the library. If the working tree is the tensor4all-rs checkout (you see `AGENTS.md` and `REPOSITORY_RULES.md`), the repo's own rules take over — this skill does not override them:

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -21,8 +21,8 @@ Indices, dynamic-rank tensors, contraction, factorization. Most other crates re-
   - `.to_vec::<f32>()` / `.to_vec::<f64>()` / `.to_vec::<Complex32>()` / `.to_vec::<Complex64>()`, `.sum()`, `.dims()`.
 - `contract(&[&a, &b, ...])` — sum over all shared indices; inputs must be connected (else error). `outer_product(&a, &b)` for disconnected products.
 - `factorize(&t, &[left_indices], &opts) -> FactorizeResult { left, right, rank, singular_values }`.
-  - `FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol))` / `.with_max_rank(n)`.
-  - `FactorizeOptions::qr().with_qr_rtol(tol)` / `.with_max_rank(n)`.
+  - `FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol))` / `.with_max_bond_dim(n)`.
+  - `FactorizeOptions::qr().with_qr_rtol(tol)` / `.with_max_bond_dim(n)`.
 
 ## tensor4all-simplett — lightweight TT/MPS
 
@@ -43,7 +43,7 @@ Named `DynIndex` objects; orthogonality-center tracking; multiple canonical form
 
 - `SimpleTensorTrain::new(vec![t0, t1, ...])` from `TensorDynLen` cores.
 - `.orthogonalize(site)`, `.orthogonalize_with(site, CanonicalForm::...)` (LU / CI forms).
-- `.truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol)).with_max_rank(n))`.
+- `.truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol)).with_max_bond_dim(n))`.
 - `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, `.isortho()`, `.orthocenter()`, `.max_bond_dim()`.
 - `TruncateOptions`, `CanonicalForm`. `ContractOptions` / `LinsolveOptions` with `with_nsweeps(n)` (= `with_nhalfsweeps(2*n)`).
 - Build indices with `DynIndex::new_dyn(dim)` (site) and `DynIndex::new_bond(dim)?` (bond). `from_dense` data is column-major.
@@ -105,11 +105,11 @@ Generic `TreeTN` over arbitrary tree topology (TT/MPS is the path-graph special 
 
 - `TreeTN::<TensorDynLen, V>::from_tensors(tensors, labels) -> Result` — topology inferred from shared bond indices; site indices appear once, bond indices appear twice. `V: Eq + Hash` labels vertices.
 - `.node_count()`, `.edge_count()`, `ttn[v]` access, `.norm()`, `.to_dense()` (test/small only), `.add(&b)` (same topology + matching site indices; bonds grow as direct sum), `.replaceind(&old, &new)`.
-- `.canonicalize([root], CanonicalizationOptions)`, `.truncate([root], TruncationOptions::default().with_max_rank(n).with_rtol(t))`.
+- `.canonicalize([root], CanonicalizationOptions)`, `.truncate([root], TruncationOptions::default().with_max_bond_dim(n).with_rtol(t))`.
 - `apply_linear_operator(&op, &state, ApplyOptions)`:
   - `ApplyOptions::naive()` — local exact, no truncation; bond dims grow as products. Small/debug only.
-  - `ApplyOptions::zipup().with_max_rank(n).with_svd_policy(policy)` — default; single sweep, controllable.
-  - `ApplyOptions::fit().with_max_rank(n).with_nfullsweeps(k)` — iterative; best compression.
+  - `ApplyOptions::zipup().with_max_bond_dim(n).with_svd_policy(policy)` — default; single sweep, controllable.
+  - `ApplyOptions::fit().with_max_bond_dim(n).with_nfullsweeps(k)` — iterative; best compression.
 - Sweep convention: `ApplyOptions::fit().with_nfullsweeps(k)` uses `nfullsweeps` (full = forward+back); `nfullsweeps = nhalfsweeps / 2`. The DMRG/TDVP option structs instead name the same full-sweep count `nsweeps` (no `full` prefix) — there is no `with_nfullsweeps` on `DmrgOptions`/`TdvpOptions`.
 - `tensor_train_to_treetn(&mps) -> (TreeTN, Vec<site_index>)` bridge from simplett.
 - Optimization sweeps (ground state + time evolution). All take a `LinearOperator` (or a bare MPO `TreeTN` via the `*_with_treetn_operator` wrappers), an initial `TreeTN` state, and a `center: &V` root node; the state is canonicalized at `center` first. v1: one input and one output site mapping per node. Build the mapping with `LinearOperator::from_mpo_and_state(mpo, &state)` when site indices are unambiguous, else hand-build `IndexMapping { true_index, internal_index }` input/output maps.

--- a/skills/use-tensor4all-rs/references/recipes.md
+++ b/skills/use-tensor4all-rs/references/recipes.md
@@ -146,7 +146,7 @@ assert_eq!(qft.mpo().node_count(), r);
 
 // Apply to a TreeTN state. zipUp is the default; naive grows bonds, fit compresses.
 let opts = ApplyOptions::zipup()
-    .with_max_rank(64)
+    .with_max_bond_dim(64)
     .with_svd_policy(SvdTruncationPolicy::new(1e-10));
 // let result = apply_linear_operator(&qft, &state, opts)?;
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -174,7 +174,7 @@ assert_eq!(ttn.edge_count(), 1);
 let norm_before = ttn.norm()?;
 let mut ttn = ttn.canonicalize([0], Default::default())?; // root 0 holds the norm
 assert!(ttn.is_canonicalized());
-let mut ttn = ttn.truncate([0], TruncationOptions::default().with_max_rank(2))?;
+let mut ttn = ttn.truncate([0], TruncationOptions::default().with_max_bond_dim(2))?;
 assert_eq!(ttn.node_count(), 2);
 assert!((ttn.norm()? - norm_before).abs() / norm_before < 1e-10); // canonicalization preserves the value
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -235,7 +235,7 @@ tt.orthogonalize(1)?;
 assert!(tt.isortho());
 tt.truncate(&TruncateOptions::svd()
     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
-    .with_max_rank(2))?;
+    .with_max_bond_dim(2))?;
 let inner = tt.inner(&tt)?;                  // <tt|tt> = norm^2
 assert!((inner.real() - norm_before * norm_before).abs() < 1e-10);
 # Ok::<(), Box<dyn std::error::Error>>(())

--- a/tools/api-dump/Cargo.toml
+++ b/tools/api-dump/Cargo.toml
@@ -9,6 +9,7 @@ name = "api-dump"
 path = "src/main.rs"
 
 [dependencies]
+proc-macro2 = "1"
 syn = { version = "2", features = ["full", "parsing"] }
 quote = "1"
 walkdir = "2"

--- a/tools/api-dump/src/main.rs
+++ b/tools/api-dump/src/main.rs
@@ -223,10 +223,19 @@ fn is_public(vis: &Visibility) -> bool {
 /// (e.g. `#[cfg(test)] pub(crate)` helper types and their syntactically
 /// `pub` methods) are not part of the public API surface and are excluded.
 fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    use proc_macro2::TokenTree;
     attrs.iter().any(|attr| {
         attr.path().is_ident("cfg")
             && match &attr.meta {
-                syn::Meta::List(list) => list.tokens.to_string().replace(' ', "").contains("test"),
+                syn::Meta::List(list) => {
+                    // Exactly `cfg(test)`: a single top-level `test` ident.
+                    // `cfg(not(test))` must NOT match.
+                    let mut it = list.tokens.clone().into_iter();
+                    matches!(
+                        (it.next(), it.next()),
+                        (Some(TokenTree::Ident(ident)), None) if ident == "test"
+                    )
+                }
                 _ => false,
             }
     })
@@ -276,7 +285,7 @@ fn extract_impl_items(item_impl: &ItemImpl, funcs: &mut Vec<FuncInfo>) {
 
     for impl_item in &item_impl.items {
         if let ImplItem::Fn(method) = impl_item {
-            if !is_public(&method.vis) {
+            if !is_public(&method.vis) || has_cfg_test(&method.attrs) {
                 continue;
             }
             funcs.push(FuncInfo {
@@ -300,8 +309,8 @@ fn extract_trait_items(item_trait: &ItemTrait, funcs: &mut Vec<FuncInfo>) {
     for trait_item in &item_trait.items {
         if let TraitItem::Fn(method) = trait_item {
             // A trait method is public when its trait is public; non-public
-            // traits are excluded from the dump.
-            if !is_public(&item_trait.vis) {
+            // traits and test-only methods are excluded from the dump.
+            if !is_public(&item_trait.vis) || has_cfg_test(&method.attrs) {
                 continue;
             }
             let has_default = method.default.is_some();

--- a/tools/api-dump/src/main.rs
+++ b/tools/api-dump/src/main.rs
@@ -211,11 +211,21 @@ fn parse_file(path: &Path) -> Result<Vec<FuncInfo>, Box<dyn std::error::Error>> 
     Ok(funcs)
 }
 
+/// A public item is one a downstream user can call: `pub` visibility only.
+/// `pub(crate)`/`pub(super)`/`pub(self)` (Restricted) and private (Inherited)
+/// items are not part of the public API surface and are excluded from the
+/// dump.
+fn is_public(vis: &Visibility) -> bool {
+    matches!(vis, Visibility::Public(_))
+}
+
 fn extract_items(items: &[Item], funcs: &mut Vec<FuncInfo>) {
     for item in items {
         match item {
             Item::Fn(item_fn) => {
-                funcs.push(extract_fn_info(item_fn));
+                if is_public(&item_fn.vis) {
+                    funcs.push(extract_fn_info(item_fn));
+                }
             }
             Item::Impl(item_impl) => {
                 extract_impl_items(item_impl, funcs);
@@ -247,6 +257,9 @@ fn extract_impl_items(item_impl: &ItemImpl, funcs: &mut Vec<FuncInfo>) {
 
     for impl_item in &item_impl.items {
         if let ImplItem::Fn(method) = impl_item {
+            if !is_public(&method.vis) {
+                continue;
+            }
             funcs.push(FuncInfo {
                 visibility: vis_to_string(&method.vis),
                 signature: sig_to_string(&method.sig),
@@ -264,6 +277,11 @@ fn extract_trait_items(item_trait: &ItemTrait, funcs: &mut Vec<FuncInfo>) {
 
     for trait_item in &item_trait.items {
         if let TraitItem::Fn(method) = trait_item {
+            // A trait method is public when its trait is public; non-public
+            // traits are excluded from the dump.
+            if !is_public(&item_trait.vis) {
+                continue;
+            }
             let has_default = method.default.is_some();
             funcs.push(FuncInfo {
                 visibility: vis_to_string(&item_trait.vis),

--- a/tools/api-dump/src/main.rs
+++ b/tools/api-dump/src/main.rs
@@ -219,11 +219,24 @@ fn is_public(vis: &Visibility) -> bool {
     matches!(vis, Visibility::Public(_))
 }
 
+/// True when the item carries a `#[cfg(test)]` attribute. Test-only items
+/// (e.g. `#[cfg(test)] pub(crate)` helper types and their syntactically
+/// `pub` methods) are not part of the public API surface and are excluded.
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("cfg")
+            && match &attr.meta {
+                syn::Meta::List(list) => list.tokens.to_string().replace(' ', "").contains("test"),
+                _ => false,
+            }
+    })
+}
+
 fn extract_items(items: &[Item], funcs: &mut Vec<FuncInfo>) {
     for item in items {
         match item {
             Item::Fn(item_fn) => {
-                if is_public(&item_fn.vis) {
+                if is_public(&item_fn.vis) && !has_cfg_test(&item_fn.attrs) {
                     funcs.push(extract_fn_info(item_fn));
                 }
             }
@@ -234,6 +247,9 @@ fn extract_items(items: &[Item], funcs: &mut Vec<FuncInfo>) {
                 extract_trait_items(item_trait, funcs);
             }
             Item::Mod(item_mod) => {
+                if has_cfg_test(&item_mod.attrs) {
+                    continue;
+                }
                 if let Some((_, items)) = &item_mod.content {
                     extract_items(items, funcs);
                 }
@@ -253,6 +269,9 @@ fn extract_fn_info(item_fn: &ItemFn) -> FuncInfo {
 }
 
 fn extract_impl_items(item_impl: &ItemImpl, funcs: &mut Vec<FuncInfo>) {
+    if has_cfg_test(&item_impl.attrs) {
+        return;
+    }
     let impl_for = type_to_string(&item_impl.self_ty);
 
     for impl_item in &item_impl.items {
@@ -273,6 +292,9 @@ fn extract_impl_items(item_impl: &ItemImpl, funcs: &mut Vec<FuncInfo>) {
 }
 
 fn extract_trait_items(item_trait: &ItemTrait, funcs: &mut Vec<FuncInfo>) {
+    if has_cfg_test(&item_trait.attrs) {
+        return;
+    }
     let trait_name = item_trait.ident.to_string();
 
     for trait_item in &item_trait.items {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -86,8 +86,8 @@ fn cmd_ci() -> Result<()> {
     println!("📎 Running cargo clippy...");
     run_cargo(root, &["clippy", "--workspace", "--", "-D", "warnings"])?;
 
-    println!("🧪 Running cargo test...");
-    run_cargo(root, &["test", "--workspace"])?;
+    println!("🧪 Running release-mode cargo test...");
+    run_cargo(root, &["test", "--release", "--workspace"])?;
 
     println!("📚 Checking documentation...");
     run_cargo(root, &["doc", "--workspace", "--no-deps"])?;


### PR DESCRIPTION
Follow-up to the issue #566 remediation: closes the remaining open issues that #566 referenced or derived, whose acceptance criteria were not yet met.

## #583 — bond-cap vocabulary unified on `max_bond_dim: Option<usize>`
- `max_rank` -> `max_bond_dim` everywhere (core `SvdOptions`/`TruncateOptions`, treetn `TruncationOptions`, getters/builders; `maxbonddim` was already renamed in #595).
- `Option<usize>` replaces the `usize::MAX` sentinel in simplett (`CompressionOptions`/`ContractionOptions`/`FactorizeOptions`), tensorci (`TCI2Options`, conversion), treetci (`TreeTciOptions`), `AciOptions`, partitionedtt, interpolativeqtt, quanticstransform. `RrLUOptions` (tcicore, internal) stays `usize`.
- `grep max_rank|maxbonddim crates/` -> nothing outside CHANGELOG. CHANGELOG mapping table + conventions.md ITensors mapping (`maxdim` -> `max_bond_dim`, `cutoff` -> `rtol^2`).

## #578 — architecture.md + AGENTS.md
- architecture.md now covers `tensor4all-aci` and `tensor4all-interpolativeqtt` (layer tables + goal-to-crate table).
- AGENTS.md `python/` reference removed.

## #580 — TensorTrainError name collision
- Cross-references documented in both simplett and itensorlike rustdoc (hosted-rustdoc links; intra-doc links cannot resolve across crates).

## #573 — downstream skill pitfalls
- SKILL.md gains a "Common pitfalls" section: scale_tolerance, MPO two layers, contraction method, TensorTrain/MPS/MPO same representation, TensorTrainError collision, 0/1-indexing, bond-cap vocabulary.

## #551 — docs/tooling drift
- `xtask ci` runs release-mode tests; mdBook README no longer calls the C API "stable"; `api-dump` filters to effective public API (skips `#[cfg(test)]` items and non-public visibility, exact `cfg(test)` parse); ACI elementwise bench moves setup/clone out of the timed closure.

## #588 — coverage attestation gate (Control 3)
- `check-coverage.py` fails explicitly when the attestation coverage file is absent; regression test added.

Verification: fmt, clippy (both deny gates), nextest 2727 + 41 (hdf5), doctests 846, mdBook, all maintenance-script self-tests, coverage (CI-owned gate). Independent review: reviewer-gpt (3 passes, READY TO MERGE).