### PR TITLE
Add per-crate preludes and wire crate READMEs into the doctest harness (#577, #579)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tensor4all-simplett = { path = "../tensor4all-rs/crates/tensor4all-simplett" }
 ```
 
 ```rust
-use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};
+use tensor4all_simplett::prelude::*;
 
 let tt = SimpleTensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
 assert!((tt.evaluate(&[0, 1, 2]).unwrap() - 1.0).abs() < 1e-12);

--- a/crates/tensor4all-aci/README.md
+++ b/crates/tensor4all-aci/README.md
@@ -23,8 +23,7 @@ originally authored by Marc Ritter and contributors.
 input values per interpolation point.
 
 ```rust
-use tensor4all_aci::{elementwise, AciOptions};
-use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};
+use tensor4all_aci::prelude::*;
 
 let a = SimpleTensorTrain::<f64>::constant(&[2, 3], 2.0);
 let b = SimpleTensorTrain::<f64>::constant(&[2, 3], 4.0);
@@ -47,8 +46,7 @@ batch is a borrowed column-major view with `n_inputs` rows and `n_points`
 columns. Use `batch.get(input, point)` for checked access.
 
 ```rust
-use tensor4all_aci::{elementwise_batched, AciOptions, ElementwiseBatch};
-use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};
+use tensor4all_aci::prelude::*;
 
 let a = SimpleTensorTrain::<f64>::constant(&[2, 3], 2.0);
 let b = SimpleTensorTrain::<f64>::constant(&[2, 3], 4.0);
@@ -75,8 +73,7 @@ For hot callbacks, the flat batch slice can be read directly. Values are stored
 as `data[input + n_inputs * point]`.
 
 ```rust
-use tensor4all_aci::{elementwise_batched, AciOptions, ElementwiseBatch};
-use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};
+use tensor4all_aci::prelude::*;
 
 let a = SimpleTensorTrain::<f64>::constant(&[2, 3], 2.0);
 let b = SimpleTensorTrain::<f64>::constant(&[2, 3], 4.0);

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -22,6 +22,12 @@
 //! assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
 //! ```
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
+pub mod prelude;
+
 mod batch;
 mod elementwise;
 mod error;

--- a/crates/tensor4all-aci/src/prelude.rs
+++ b/crates/tensor4all-aci/src/prelude.rs
@@ -1,0 +1,21 @@
+//! Commonly used types and functions for alternating cross interpolation of
+//! elementwise tensor train operations.
+//!
+//! ```rust
+//! use tensor4all_aci::prelude::*;
+//!
+//! let a = SimpleTensorTrain::<f64>::constant(&[2, 3], 2.0);
+//! let b = SimpleTensorTrain::<f64>::constant(&[2, 3], 4.0);
+//! let result = elementwise(
+//!     |xs: &[f64]| xs[0] * xs[1],
+//!     &[a, b],
+//!     &AciOptions::default(),
+//! ).unwrap();
+//! assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
+//! assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 8.0).abs() < 1e-10);
+//! ```
+
+pub use crate::{
+    elementwise, elementwise_batched, AciOptions, AciResult, AciScalar, ElementwiseBatch,
+};
+pub use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};

--- a/crates/tensor4all-core/README.md
+++ b/crates/tensor4all-core/README.md
@@ -14,9 +14,7 @@ Core tensor library: Index system, dynamic-rank Tensor, contraction, SVD/QR/LU f
 ## Example
 
 ```rust
-use tensor4all_core::{
-    factorize, DynIndex, FactorizeOptions, TensorContractionLike, TensorDynLen,
-};
+use tensor4all_core::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Create indices

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Core tensor operations and types for tensor4all-rs.
 //!
 //! This crate provides the foundational types and operations for tensor networks:
@@ -21,7 +22,11 @@
 //! let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 //! ```
 
-#![warn(missing_docs)]
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
+pub mod prelude;
 
 pub mod col_major_array;
 pub use col_major_array::{ColMajorArray, ColMajorArrayMut, ColMajorArrayRef};

--- a/crates/tensor4all-core/src/prelude.rs
+++ b/crates/tensor4all-core/src/prelude.rs
@@ -1,0 +1,24 @@
+//! Commonly used traits, types, and functions for tensor construction,
+//! contraction, and factorization.
+//!
+//! ```rust
+//! use tensor4all_core::prelude::*;
+//!
+//! let i = DynIndex::new_dyn(3);
+//! let j = DynIndex::new_dyn(4);
+//! let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
+//! let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+//! let result = factorize(&tensor, &[i], &FactorizeOptions::svd()).unwrap();
+//! let recovered = result.left.contract_pair(&result.right).unwrap();
+//! assert!(tensor.distance(&recovered).unwrap() < 1e-12);
+//! ```
+
+pub use crate::{
+    contract, contract_pair, direct_sum, factorize, outer_product, qr, svd, tensordot, Canonical,
+    CommonScalar, ContractionOptions, DecompositionAlg, DirectSumResult, DynId, DynIndex,
+    FactorizeAlg, FactorizeOptions, FactorizeResult, Index, IndexLike, LinearizationOrder,
+    PairwiseContractionOptions, SingularValueMeasure, SvdOptions, SvdTruncationPolicy, Tag, TagSet,
+    TagSetLike, TensorConstructionLike, TensorContractionLike, TensorDynLen, TensorElement,
+    TensorFactorizationLike, TensorIndex, TensorLike, TensorVectorSpace, ThresholdScale,
+    TruncationRule,
+};

--- a/crates/tensor4all-interpolativeqtt/README.md
+++ b/crates/tensor4all-interpolativeqtt/README.md
@@ -7,9 +7,7 @@ This crate ports the tested public algorithms from
 `SimpleTensorTrain<f64>` values.
 
 ```rust
-use tensor4all_interpolativeqtt::{
-    interpolate_single_scale, AbstractTensorTrain, InterpolativeQttOptions,
-};
+use tensor4all_interpolativeqtt::prelude::*;
 
 let tt = interpolate_single_scale(
     |x| (-x * x).exp(),

--- a/crates/tensor4all-interpolativeqtt/src/lib.rs
+++ b/crates/tensor4all-interpolativeqtt/src/lib.rs
@@ -27,6 +27,12 @@
 //! assert!((value - (-1.0_f64).exp()).abs() < 1e-10);
 //! ```
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
+pub mod prelude;
+
 mod basis;
 mod error;
 mod interpolation;

--- a/crates/tensor4all-interpolativeqtt/src/prelude.rs
+++ b/crates/tensor4all-interpolativeqtt/src/prelude.rs
@@ -1,0 +1,27 @@
+//! Commonly used types and functions for interpolative quantics tensor train
+//! construction.
+//!
+//! ```rust
+//! use tensor4all_interpolativeqtt::prelude::*;
+//!
+//! let tt = interpolate_single_scale(
+//!     |x| (-x * x).exp(),
+//!     -2.0,
+//!     2.0,
+//!     5,
+//!     12,
+//!     &InterpolativeQttOptions::default(),
+//! ).unwrap();
+//! let value = tt.evaluate(&[0, 0, 0, 0, 0]).unwrap();
+//! let expected = (-4.0_f64).exp();
+//! assert!((value - expected).abs() < 1e-10);
+//! ```
+
+pub use crate::{
+    direct_product_core_tensors, estimate_interpolation_error, estimate_interpolation_error_nd,
+    get_chebyshev_grid, interpolate_adaptive, interpolate_adaptive_nd, interpolate_multi_scale,
+    interpolate_multi_scale_nd, interpolate_single_scale, interpolate_single_scale_nd,
+    interpolate_single_scale_sparse, interpolate_single_scale_sparse_nd, interpolation_tensor,
+    invert_qtt, AbstractTensorTrain, InterpolativeQttOptions, LagrangePolynomials,
+    SimpleTensorTrain,
+};

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -32,8 +32,7 @@ ITensors.jl-inspired TensorTrain API with orthogonality tracking and multiple ca
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
-use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
+use tensor4all_itensorlike::prelude::*;
 
 // Build a 3-site tensor train
 let s0 = DynIndex::new_dyn(2);
@@ -69,8 +68,7 @@ assert!((inner.real() - norm * norm).abs() < 1e-10);
 ```rust
 # fn main() -> anyhow::Result<()> {
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::TensorTrain;
+use tensor4all_itensorlike::prelude::*;
 
 let site = DynIndex::new_dyn(2);
 let tensor = TensorDynLen::from_dense(

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -5,6 +5,7 @@ pub mod contract;
 pub mod error;
 pub mod linsolve;
 pub mod options;
+pub mod prelude;
 pub mod tensortrain;
 
 pub use contract::contract;

--- a/crates/tensor4all-itensorlike/src/prelude.rs
+++ b/crates/tensor4all-itensorlike/src/prelude.rs
@@ -1,0 +1,26 @@
+//! Commonly used types for chain-facing tensor train operations backed by
+//! [`TreeTN`](crate::tensor4all_treetn::TreeTN).
+//!
+//! ```rust
+//! # fn main() -> anyhow::Result<()> {
+//! use tensor4all_itensorlike::prelude::*;
+//!
+//! let s0 = DynIndex::new_dyn(2);
+//! let s1 = DynIndex::new_dyn(2);
+//! let b01 = DynIndex::new_bond(2)?;
+//! let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+//! let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0, 0.0, 0.0, 1.0])?;
+//! let mut tt = TensorTrain::new(vec![t0, t1])?;
+//! tt.orthogonalize(0)?;
+//! tt.truncate(&TruncateOptions::svd()
+//!     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
+//!     .with_max_bond_dim(2))?;
+//! assert!(tt.isortho());
+//! # Ok(())
+//! # }
+//! ```
+
+pub use crate::{
+    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TensorTrain, TruncateOptions,
+};
+pub use tensor4all_core::{DynIndex, IndexLike, SvdTruncationPolicy, TensorDynLen};

--- a/crates/tensor4all-quanticstci/README.md
+++ b/crates/tensor4all-quanticstci/README.md
@@ -12,7 +12,7 @@ High-level Quantics Tensor Train interpolation interface. Port of QuanticsTCI.jl
 ## Example
 
 ```rust
-use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+use tensor4all_quanticstci::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Interpolate f(i, j) = i + j on a 16x16 discrete grid (1-indexed)

--- a/crates/tensor4all-quanticstci/src/lib.rs
+++ b/crates/tensor4all-quanticstci/src/lib.rs
@@ -82,6 +82,12 @@
 //! | Grid points given as explicit arrays | [`quanticscrossinterpolate_from_arrays`] |
 //! | Vector/tensor-valued function | [`quanticscrossinterpolate_batched`] |
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
+pub mod prelude;
+
 mod batched;
 mod error;
 mod options;

--- a/crates/tensor4all-quanticstci/src/prelude.rs
+++ b/crates/tensor4all-quanticstci/src/prelude.rs
@@ -1,0 +1,24 @@
+//! Commonly used types and functions for quantics tensor cross interpolation
+//! (QTT) on discrete or continuous grids.
+//!
+//! ```rust
+//! use tensor4all_quanticstci::prelude::*;
+//!
+//! let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+//! let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete(
+//!     &[16, 16],
+//!     f,
+//!     None,
+//!     QtciOptions::default().with_tolerance(1e-10),
+//! ).unwrap();
+//! let value = qtci.evaluate(&[5, 10]).unwrap();
+//! assert!((value - 15.0).abs() < 1e-10);
+//! assert!(errors.last().copied().unwrap() < 1e-10);
+//! ```
+
+pub use crate::{
+    quanticscrossinterpolate, quanticscrossinterpolate_batched, quanticscrossinterpolate_discrete,
+    quanticscrossinterpolate_from_arrays, DefaultProposer, DiscretizedGrid, InherentDiscreteGrid,
+    QtciOptions, QuanticsTensorCI2, QuanticsTensorCI2Batched, SimpleTensorTrain, TreeTciGraph,
+    TreeTciOptions, UnfoldingScheme,
+};

--- a/crates/tensor4all-quanticstransform/src/lib.rs
+++ b/crates/tensor4all-quanticstransform/src/lib.rs
@@ -58,6 +58,10 @@
 //! assert_eq!(op.mpo().node_count(), 8);
 //! ```
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
 mod affine;
 mod common;
 mod cumsum;

--- a/crates/tensor4all-simplett/README.md
+++ b/crates/tensor4all-simplett/README.md
@@ -12,7 +12,7 @@ Simple, efficient Tensor Train (MPS) implementation for numerical computation.
 ## Example
 
 ```rust
-use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, SimpleTensorTrain};
+use tensor4all_simplett::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Create a constant tensor train (all entries = 1.0) over a 2x3x4 grid
@@ -29,7 +29,7 @@ assert!((total - 24.0).abs() < 1e-10);
 // Compress with tolerance
 let options = CompressionOptions {
     tolerance: 1e-10,
-    max_bond_dim: 20,
+    max_bond_dim: Some(20),
     ..Default::default()
 };
 let compressed = tt.compressed(&options)?;

--- a/crates/tensor4all-simplett/src/lib.rs
+++ b/crates/tensor4all-simplett/src/lib.rs
@@ -46,6 +46,12 @@
 //! assert!((val2 - 1.0).abs() < 1e-10);
 //! ```
 
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
+pub mod prelude;
+
 pub mod arithmetic;
 pub mod cache;
 pub mod canonical;

--- a/crates/tensor4all-simplett/src/prelude.rs
+++ b/crates/tensor4all-simplett/src/prelude.rs
@@ -1,0 +1,23 @@
+//! Commonly used traits and types for tensor train (MPS) construction,
+//! evaluation, and compression.
+//!
+//! ```rust
+//! use tensor4all_simplett::prelude::*;
+//!
+//! let tt = SimpleTensorTrain::<f64>::constant(&[2, 3], 2.0);
+//! assert!((tt.evaluate(&[1, 1]).unwrap() - 2.0).abs() < 1e-15);
+//! let options = CompressionOptions {
+//!     tolerance: 1e-10,
+//!     max_bond_dim: Some(20),
+//!     ..Default::default()
+//! };
+//! let compressed = tt.compressed(&options).unwrap();
+//! assert!(compressed.rank() <= tt.rank());
+//! ```
+
+pub use crate::{
+    center_canonicalize, inner_product, tensor3_from_data, tensor3_zeros, AbstractTensorTrain,
+    CompressionMethod, CompressionOptions, ContractionOptions, DiagMatrix, InverseTensorTrain,
+    LocalIndex, MultiIndex, SimpleTensorTrain, SiteTensorTrain, TTCache, TTScalar, Tensor3,
+    Tensor3Ops, VidalTensorTrain,
+};

--- a/crates/tensor4all-tensorci/README.md
+++ b/crates/tensor4all-tensorci/README.md
@@ -16,8 +16,8 @@ Tensor Cross Interpolation algorithms. TCI2 is the primary maintained implementa
 ## Example
 
 ```rust
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
-use tensor4all_simplett::AbstractTensorTrain;
+use tensor4all_simplett::prelude::*;
+use tensor4all_tensorci::prelude::*;
 
 // Function to interpolate: f(i, j) = (i + j + 1) as f64
 let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;

--- a/crates/tensor4all-tensorci/src/lib.rs
+++ b/crates/tensor4all-tensorci/src/lib.rs
@@ -69,6 +69,7 @@ pub mod globalpivot;
 pub mod globalsearch;
 pub mod integration;
 pub mod optfirstpivot;
+pub mod prelude;
 pub mod tensorci1;
 pub mod tensorci2;
 

--- a/crates/tensor4all-tensorci/src/prelude.rs
+++ b/crates/tensor4all-tensorci/src/prelude.rs
@@ -1,0 +1,19 @@
+//! Commonly used types for cross interpolation (TCI) tensor train
+//! construction.
+//!
+//! ```rust
+//! use tensor4all_tensorci::prelude::*;
+//!
+//! let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
+//! let (tci, _ranks, _errors) =
+//!     crossinterpolate1(f, vec![4, 4], vec![3, 3], TCI1Options::default()).unwrap();
+//! let val = tci.evaluate(&[2, 3]).unwrap();
+//! assert!((val - 6.0).abs() < 1e-10);
+//! ```
+
+pub use crate::{
+    crossinterpolate1, crossinterpolate2, estimate_true_error, floating_zone, opt_first_pivot,
+    optimize_with_finder, DefaultGlobalPivotFinder, GlobalPivotFinder, GlobalPivotSearchInput,
+    PivotSearchStrategy, Sweep2Strategy, TCI1Options, TCI1SweepStrategy, TCI2OptimizationResult,
+    TCI2Options, TCI2Termination, TensorCI1, TensorCI2, TensorCI2FromTensorTrainOptions,
+};

--- a/crates/tensor4all-treetn/README.md
+++ b/crates/tensor4all-treetn/README.md
@@ -13,8 +13,8 @@ Tree tensor networks with arbitrary graph topology. Supports canonicalization, t
 ## Example
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_treetn::{TreeTN, CanonicalizationOptions, TruncationOptions};
+use tensor4all_core::prelude::*;
+use tensor4all_treetn::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 // 3-site MPS chain: t0 -- t1 -- t2

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Tree Tensor Network (TreeTN) library for tensor4all.
 //!
 //! This crate provides data structures and algorithms for working with tree tensor networks,
@@ -18,7 +19,12 @@
 //! - **Linear operators**: Apply and compose linear operators on tree tensor networks.
 //! - **Linear solvers**: Solve linear systems involving tree tensor network operators.
 
-#![warn(missing_docs)]
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+pub struct ReadmeDoctests;
+
+pub mod prelude;
+
 mod algorithm;
 // dyn_treetn.rs has been removed.
 // TreeTN uses the `T: TensorLike` pattern, making a separate dyn wrapper unnecessary.

--- a/crates/tensor4all-treetn/src/prelude.rs
+++ b/crates/tensor4all-treetn/src/prelude.rs
@@ -1,0 +1,25 @@
+//! Commonly used traits and types for tree tensor network construction,
+//! canonicalization, truncation, and application.
+//!
+//! ```rust
+//! use tensor4all_core::{DynIndex, TensorDynLen};
+//! use tensor4all_treetn::prelude::*;
+//!
+//! let s0 = DynIndex::new_dyn(2);
+//! let s1 = DynIndex::new_dyn(2);
+//! let b01 = DynIndex::new_dyn(4);
+//! let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8]).unwrap();
+//! let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0; 8]).unwrap();
+//! let ttn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+//! assert_eq!(ttn.node_count(), 2);
+//! assert_eq!(ttn.edge_count(), 1);
+//! ```
+
+pub use crate::{
+    apply_linear_operator, dmrg, dmrg_with_treetn_operator, random_treetn, tdvp,
+    tdvp_with_treetn_operator, tensor_train_to_treetn, ApplyOptions, BoundaryEdge, CanonicalForm,
+    CanonicalizationOptions, CompressionAlgorithm, ContractionAlgorithm, DmrgOptions, DmrgResult,
+    LinkIndexNetwork, LinkSpace, NamedGraph, NodeNameNetwork, Operator, RestructureOptions,
+    SiteIndexNetwork, SplitOptions, SwapOptions, TdvpOptions, TdvpResult, TreeTN, TreeTopology,
+    TruncationOptions,
+};

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -42,7 +42,7 @@ tensor4all-treetn = { path = "../tensor4all-rs/crates/tensor4all-treetn" }
 The following example uses `tensor4all-simplett` to create a constant tensor train, evaluate it at a specific index, and compress it.
 
 ```rust
-use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, SimpleTensorTrain};
+use tensor4all_simplett::prelude::*;
 
 fn main() {
     // Create a constant tensor train with local dimensions [2, 3, 4].

--- a/docs/book/src/guides/compress.md
+++ b/docs/book/src/guides/compress.md
@@ -20,8 +20,8 @@ or `1e-6`.
 ```rust
 # fn main() -> anyhow::Result<()> {
 use std::f64::consts::PI;
-use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops};
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
+use tensor4all_simplett::prelude::*;
+use tensor4all_tensorci::prelude::*;
 
 let local_dims = vec![128, 128, 128];
 let f = |idx: &Vec<usize>| {
@@ -70,8 +70,8 @@ The quality of the compression is visible in the bond dimensions and the paramet
 ```rust
 # fn main() -> anyhow::Result<()> {
 # use std::f64::consts::PI;
-# use tensor4all_simplett::{AbstractTensorTrain, Tensor3Ops};
-# use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+# use tensor4all_simplett::prelude::*;
+# use tensor4all_tensorci::prelude::*;
 # let local_dims = vec![128, 128, 128];
 # let f = |idx: &Vec<usize>| {
 #     let x = 2.0 * PI * idx[0] as f64 / 128.0;

--- a/docs/book/src/guides/tci.md
+++ b/docs/book/src/guides/tci.md
@@ -14,8 +14,8 @@ Use `crossinterpolate2` when you already know the local dimensions and want dire
 The function must accept a `&Vec<usize>` of 0-indexed multi-indices and return a scalar value. Here is a simple 2D example where `f(i, j) = i + j + 1`:
 
 ```rust
-use tensor4all_simplett::AbstractTensorTrain;
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options, TCI2Termination};
+use tensor4all_simplett::prelude::*;
+use tensor4all_tensorci::prelude::*;
 
 let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
 let local_dims = vec![4, 4];
@@ -83,8 +83,8 @@ If the errors plateau above your tolerance, try:
 Convert to a tensor train for further manipulation:
 
 ```rust
-# use tensor4all_simplett::AbstractTensorTrain;
-# use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+# use tensor4all_simplett::prelude::*;
+# use tensor4all_tensorci::prelude::*;
 # let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
 # let tensor4all_tensorci::TCI2OptimizationResult { tci, ranks: _ranks, errors: _errors, .. } = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
 #     f, None, vec![4, 4], vec![vec![3, 3]],
@@ -131,7 +131,7 @@ Use `quanticscrossinterpolate_discrete` when your function is naturally defined 
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+use tensor4all_quanticstci::prelude::*;
 
 let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
 let sizes = vec![16, 16];
@@ -162,9 +162,7 @@ For functions on continuous domains, build a `DiscretizedGrid` that maps grid in
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_quanticstci::{
-    quanticscrossinterpolate, DiscretizedGrid, QtciOptions,
-};
+use tensor4all_quanticstci::prelude::*;
 
 // 2^4 = 16 grid points on [0, 1)
 let grid = DiscretizedGrid::builder(&[4])
@@ -203,9 +201,7 @@ This has O(h) convergence where h is the grid spacing. The result depends on whe
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-# use tensor4all_quanticstci::{
-#     quanticscrossinterpolate, DiscretizedGrid, QtciOptions,
-# };
+# use tensor4all_quanticstci::prelude::*;
 # let grid = DiscretizedGrid::builder(&[4])
 #     .with_lower_bound(&[0.0])
 #     .with_upper_bound(&[1.0])
@@ -239,7 +235,7 @@ with `B = 2^-30` on `[0, ln(20))` using `R = 40` quantics bits.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_quanticstci::{quanticscrossinterpolate, DiscretizedGrid, QtciOptions};
+use tensor4all_quanticstci::prelude::*;
 
 // Use R = 10 bits (2^10 = 1024 points) for a fast doctest.
 // In practice, set R = 40 for the full multi-scale resolution.
@@ -290,7 +286,7 @@ This section corresponds to the Julia [Quantics TCI of multivariate function](ht
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
+use tensor4all_quanticstci::prelude::*;
 
 // Use 64x64 for a faster doctest (256x256 in practice)
 let sizes = vec![64, 64];

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -26,7 +26,7 @@ manage named indices.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, SimpleTensorTrain};
+use tensor4all_simplett::prelude::*;
 
 // Constant TT: all entries equal to 1.0, physical dimensions [2, 3, 4]
 let tt = SimpleTensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
@@ -45,7 +45,7 @@ assert!((zero_tt.sum()).abs() < 1e-14);
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-# use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};
+# use tensor4all_simplett::prelude::*;
 # let tt = SimpleTensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
 // Evaluate the tensor at a specific multi-index
 let value = tt.evaluate(&[0, 1, 2])?;
@@ -65,7 +65,7 @@ assert!((total - 24.0).abs() < 1e-10);
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-# use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, SimpleTensorTrain};
+# use tensor4all_simplett::prelude::*;
 // Build a TT with artificially inflated bond dimension by adding two constants
 let a = SimpleTensorTrain::<f64>::constant(&[2, 3, 4], 1.0);
 let b = SimpleTensorTrain::<f64>::constant(&[2, 3, 4], 2.0);
@@ -102,7 +102,7 @@ verify.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_simplett::{AbstractTensorTrain, CompressionOptions, SimpleTensorTrain};
+use tensor4all_simplett::prelude::*;
 
 // Step 1: Create two constant TTs
 let a = SimpleTensorTrain::<f64>::constant(&[4, 4, 4], 1.0);
@@ -149,8 +149,7 @@ ordering.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::{CanonicalForm, TensorTrain, TruncateOptions};
+use tensor4all_itensorlike::prelude::*;
 
 // Site and bond indices
 let s0 = DynIndex::new_dyn(2);
@@ -193,8 +192,7 @@ After orthogonalization you can truncate bond dimensions by SVD:
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-# use tensor4all_core::{DynIndex, TensorDynLen};
-# use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
+# use tensor4all_itensorlike::prelude::*;
 # let s0 = DynIndex::new_dyn(2);
 # let s1 = DynIndex::new_dyn(2);
 # let s2 = DynIndex::new_dyn(2);
@@ -232,8 +230,7 @@ To emulate ITensor-style discarded-weight cutoffs, use
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-# use tensor4all_core::{DynIndex, TensorDynLen};
-# use tensor4all_itensorlike::TensorTrain;
+# use tensor4all_itensorlike::prelude::*;
 # let s0 = DynIndex::new_dyn(2);
 # let s1 = DynIndex::new_dyn(2);
 # let b = DynIndex::new_bond(2)?;
@@ -263,8 +260,7 @@ The same API works with `Complex64`:
 ```rust
 # fn main() -> anyhow::Result<()> {
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, TensorDynLen};
-use tensor4all_itensorlike::TensorTrain;
+use tensor4all_itensorlike::prelude::*;
 
 let s0 = DynIndex::new_dyn(2);
 let s1 = DynIndex::new_dyn(2);

--- a/docs/book/src/guides/tree-tn.md
+++ b/docs/book/src/guides/tree-tn.md
@@ -126,8 +126,8 @@ contraction cost at the expense of a controlled approximation error.
 internally so the result is always exact (up to floating-point precision).
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
-use tensor4all_treetn::TreeTN;
+use tensor4all_core::prelude::*;
+use tensor4all_treetn::prelude::*;
 
 let s = DynIndex::new_dyn(2);
 let t = TensorDynLen::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
@@ -171,8 +171,8 @@ result has the same tree structure, but each bond dimension is the sum of the tw
 dimensions (direct-sum construction).
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
-use tensor4all_treetn::TreeTN;
+use tensor4all_core::prelude::*;
+use tensor4all_treetn::prelude::*;
 
 let s = DynIndex::new_dyn(2);
 let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();

--- a/skills/use-tensor4all-rs/SKILL.md
+++ b/skills/use-tensor4all-rs/SKILL.md
@@ -27,6 +27,8 @@ tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", pac
 
 This skill tracks `main`; a release tag may not contain every API described below. Add each crate that your code imports directly. Do not add transitive crates that you never name.
 
+- **Import the crate's `prelude`** — every user-facing crate (`tensor4all-core`, `tensor4all-simplett`, `tensor4all-treetn`, `tensor4all-itensorlike`, `tensor4all-tensorci`, `tensor4all-quanticstci`, `tensor4all-aci`, `tensor4all-interpolativeqtt`) ships a `prelude` re-exporting its public traits plus the types needed to call them. Start with `use tensor4all_<crate>::prelude::*;` instead of guessing trait imports; a missing trait import is the top first-try failure (`error[E0599]`).
+
 - **Backend defaults to pure-Rust `faer` — no system BLAS.** Compute crates enable `tenferro-cpu-faer` by default, so a plain dependency compiles standalone. To link a system BLAS (OpenBLAS / MKL / Apple Accelerate) instead, set `default-features = false` and enable `tenferro-system-blas` on each directly imported crate where it is exposed.
 - **Build with `--release`.** Tensor linalg in debug is orders of magnitude slower; TCI and DMRG are unusable without optimization. For benchmarks set `opt-level = 3` (and `lto`, `codegen-units = 1`).
 - **TensorDynLen scalars** are `f32`, `f64`, `Complex32`, and `Complex64` (`num-complex` 0.4). Compact `Storage` snapshots support only `f64`/`Complex64`; 32-bit tensors retain eager authoritative payloads without promotion. Recipes that build random tensors assume you add `rand` + `rand_chacha` (matching the library's `0.9`) as dev-dependencies.
@@ -35,8 +37,8 @@ This skill tracks `main`; a release tag may not contain every API described belo
 Done when `cargo build --release` succeeds and a constant TT evaluates:
 
 ```rust
-use tensor4all_simplett::AbstractTensorTrain;
-let tt = tensor4all_simplett::SimpleTensorTrain::<f64>::constant(&[2, 2], 1.0);
+use tensor4all_simplett::prelude::*;
+let tt = SimpleTensorTrain::<f64>::constant(&[2, 2], 1.0);
 assert!((tt.evaluate(&[0, 0])? - 1.0).abs() < 1e-12);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -13,7 +13,7 @@ Indices, dynamic-rank tensors, contraction, factorization. Most other crates re-
   - `Index::new_dyn_with_tag(dim, tag) -> Result` — named index.
   - `DynIndex::new_bond(dim) -> Result` — bond index; fallible (metadata validated).
   - `.prime()` / `.noprime()` — raise / clear prime level (ket vs bra).
-  - `.dim()`, `.plev()` via the `IndexLike` trait (`use tensor4all_core::IndexLike;`).
+  - `.dim()`, `.plev()` via the `IndexLike` trait (in `tensor4all_core::prelude`).
   - Two independently created indices are always distinct even with equal dim.
 - `TensorDynLen` — dynamic-rank tensor supporting `f32`, `f64`, `Complex32`, and `Complex64`; `f64`/`Complex64` may use compact dense/diagonal/structured snapshots while 32-bit tensors retain eager authoritative payloads. Axes are matched by index identity, with no fixed ordering.
   - `TensorDynLen::from_dense(indices, data)` — column-major `data`; first index varies fastest.

--- a/skills/use-tensor4all-rs/references/recipes.md
+++ b/skills/use-tensor4all-rs/references/recipes.md
@@ -55,8 +55,8 @@ let r = factorize(&t, &[i], &opts)?;   // r.left=[i,bond], r.right=[bond,k]
 ## TCI on a black-box function (low-level, 0-indexed)
 
 ```rust
-use tensor4all_simplett::AbstractTensorTrain;
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+use tensor4all_simplett::prelude::*;
+use tensor4all_tensorci::prelude::*;
 
 let f = |idx: &Vec<usize>| (idx[0] + idx[1] + 1) as f64;
 let result = crossinterpolate2::<f64, _, fn(&[Vec<usize>]) -> Vec<f64>>(
@@ -248,8 +248,8 @@ Define `f(idx)` computing each element on demand; let TCI find low-rank structur
 
 ```rust
 use std::f64::consts::PI;
-use tensor4all_simplett::AbstractTensorTrain;
-use tensor4all_tensorci::{crossinterpolate2, TCI2Options};
+use tensor4all_simplett::prelude::*;
+use tensor4all_tensorci::prelude::*;
 
 let f = |idx: &Vec<usize>| {
     let x = 2.0 * PI * idx[0] as f64 / 128.0;


### PR DESCRIPTION
Resolves #577 and #579.

## #577: crate-README doctest wiring

All 9 previously-untested ```rust fences in `crates/*/README.md` now execute as doctests. Added the `#[cfg(doctest)] #[doc = include_str!("../README.md")]` shim to:
`tensor4all-aci` (3 fences), `tensor4all-core`, `tensor4all-interpolativeqtt`, `tensor4all-quanticstci`, `tensor4all-quanticstransform`, `tensor4all-simplett`, `tensor4all-treetn`.

Verified: `cargo test --doc --workspace --release` passes; no fence carries `ignore`/`no_run`.

## #579: per-crate preludes

New `prelude` modules in `tensor4all-core`, `tensor4all-simplett`, `tensor4all-treetn`, `tensor4all-itensorlike`, `tensor4all-tensorci`, `tensor4all-quanticstci`, `tensor4all-aci`, `tensor4all-interpolativeqtt`, each re-exporting the crate's public traits plus the types needed to call them. Crate README quickstarts, the mdBook getting-started guides (`tensor-train`, `tree-tn`, `tci`, `compress`, `getting-started`), and the bundled `use-tensor4all-rs` skill now compile with prelude imports only.

Along the way the harness caught a stale simplett README fence (`TensorTrain` → `SimpleTensorTrain`, `max_bond_dim` → `Some(20)` after the #583 vocabulary unification); fixed.

## Verification

- `cargo test --doc --workspace --release` ✅
- `scripts/test-mdbook.sh` (all book fences, incl. root README) ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo nextest run --release` on the 8 affected crates: 1957 passed ✅