### PR TITLE
Add TreeTN HDF5 storage schema with save_treetn/load_treetn (#576)

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -153,6 +153,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # book-tests depends on tensor4all-hdf5, so --exclude tensor4all-hdf5
+      # still builds the HDF5 stack; the dev package is required for that.
+      - name: Install HDF5
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/crates/tensor4all-hdf5/Cargo.toml
+++ b/crates/tensor4all-hdf5/Cargo.toml
@@ -13,15 +13,18 @@ runtime-loading = ["dep:hdf5-rt"]
 tenferro-cpu-faer = [
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-itensorlike/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-itensorlike/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
 ]
 
 [dependencies]
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
 tensor4all-itensorlike = { path = "../tensor4all-itensorlike", default-features = false }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
 hdf5-metno = { workspace = true, default-features = false, features = ["complex"], optional = true }
 hdf5-metno-sys = { version = "0.12", default-features = false, optional = true }
 hdf5-rt = { workspace = true, default-features = false, features = ["complex"], optional = true }

--- a/crates/tensor4all-hdf5/README.md
+++ b/crates/tensor4all-hdf5/README.md
@@ -6,6 +6,26 @@ HDF5 serialization for tensor4all-rs, compatible with ITensors.jl / ITensorMPS.j
 
 - `save_itensor()` / `load_itensor()` — read/write `TensorDynLen` as ITensors.jl `ITensor`
 - `save_mps()` / `load_mps()` — read/write `TensorTrain` as ITensorMPS.jl `MPS`
+- `save_treetn()` / `append_treetn()` / `load_treetn()` — read/write a general
+  `TreeTN<TensorDynLen, V>` (`String` or `usize` node names) using the
+  tensor4all-rs `TreeTN` v1 schema: one `node_i/` ITensor subgroup per node
+  with a `node_name` attribute; topology is recovered on load from shared
+  index identity via `TreeTN::from_tensors`
+
+## TreeTN schema (v1)
+
+```text
+<group>/
+  @type = "TreeTN"
+  @version = 1
+  node_count: Int64
+  node_1/ ... node_N/
+    @node_name: VarLenUnicode
+    (ITensor — same per-node schema as save_itensor)
+```
+
+Edges are not stored explicitly: bond connections are recovered on load from
+shared `Index` identity, exactly as the tree was assembled originally.
 
 ## Feature Flags
 

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -541,7 +541,8 @@ where
 ///
 /// # Errors
 ///
-/// Returns an error if the file cannot be opened or the group already exists.
+/// Returns an error when the operation fails (a shape or index mismatch, or
+/// a backend failure).
 pub fn append_treetn<V>(
     filepath: &str,
     name: &str,

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -10,6 +10,7 @@
 //! |-----------|-------------|------------------|
 //! | [`TensorDynLen`] | `ITensor` | `ITensors.ITensor` |
 //! | [`TensorTrain`] | `MPS` | `ITensorMPS.MPS` |
+//! | [`TreeTN`](tensor4all_treetn::TreeTN) | `TreeTN` (tensor4all-rs schema) | — (no ITensorNetworks.jl equivalent) |
 //!
 //! Both `f64` and `Complex64` element types are supported for dense storage.
 //!
@@ -72,6 +73,7 @@ mod index;
 mod itensor;
 mod mps;
 mod schema;
+mod treetn;
 /// Error returned by tensor4all-hdf5 save/load operations.
 ///
 /// The full original diagnostic is preserved in [`Hdf5Error::source`].
@@ -122,8 +124,12 @@ impl From<anyhow::Error> for Hdf5Error {
 }
 
 use backend::File;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::str::FromStr;
 use tensor4all_core::TensorDynLen;
 use tensor4all_itensorlike::TensorTrain;
+use tensor4all_treetn::TreeTN;
 
 // Re-export the HDF5 initialization functions (runtime-loading mode only)
 #[cfg(feature = "runtime-loading")]
@@ -459,4 +465,120 @@ pub fn load_mps(filepath: &str, name: &str) -> std::result::Result<TensorTrain, 
     let file = File::open(filepath)?;
     let group = file.group(name)?;
     mps::read_mps(&group).map_err(Hdf5Error::from)
+}
+
+/// Save a [`TreeTN`] as a tensor4all-rs `TreeTN` in an HDF5 file.
+///
+/// Creates the file if it does not exist, or overwrites an existing file.
+/// The tree is stored under a group named `name`, with each node tensor
+/// written as a 1-indexed subgroup (`node_1/`, `node_2/`, ...) using the
+/// ITensor schema, plus a `node_name` attribute per node. Topology is not
+/// stored explicitly; on load it is recovered from shared index identity via
+/// [`TreeTN::from_tensors`].
+///
+/// The node name type `V` is serialized via [`ToString`] and restored via
+/// [`FromStr`]; any type supporting both round-trips exactly (e.g. `String`
+/// or `usize`) can be stored.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be created, if any node tensor uses
+/// an unsupported storage type (only `f64` and `Complex64` are supported),
+/// or if the tree is internally inconsistent.
+///
+/// # Examples
+///
+/// Round-trip a small tree with `String` node names:
+///
+/// ```
+/// use tensor4all_hdf5::{load_treetn, save_treetn};
+/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_treetn::TreeTN;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let s0 = DynIndex::new_dyn(2);
+/// let s1 = DynIndex::new_dyn(2);
+/// let b01 = DynIndex::new_dyn(4);
+/// let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
+/// let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0; 8])?;
+/// let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+///     vec![t0, t1],
+///     vec!["left".to_string(), "right".to_string()],
+/// )?;
+///
+/// let dir = tempfile::tempdir()?;
+/// let path = dir.path().join("treetn.h5");
+/// let path = path.to_str().unwrap();
+///
+/// save_treetn(path, "tn", &tn)?;
+/// let loaded = load_treetn::<String>(path, "tn")?;
+///
+/// assert_eq!(loaded.node_count(), 2);
+/// assert_eq!(loaded.edge_count(), 1);
+/// assert_eq!(loaded.node_names(), vec!["left".to_string(), "right".to_string()]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn save_treetn<V>(
+    filepath: &str,
+    name: &str,
+    tn: &TreeTN<TensorDynLen, V>,
+) -> std::result::Result<(), Hdf5Error>
+where
+    V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
+{
+    let file = File::create(filepath)?;
+    let group = file.create_group(name)?;
+    treetn::write_treetn(&group, tn).map_err(Hdf5Error::from)
+}
+
+/// Append a [`TreeTN`] to an HDF5 file.
+///
+/// Opens `filepath` read/write if it exists, or creates it otherwise, then
+/// writes the tree under `name`. This keeps the same `TreeTN` v1 schema as
+/// [`save_treetn`] while allowing multiple named trees in a single file.
+/// The target group must not already exist.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened or the group already exists.
+pub fn append_treetn<V>(
+    filepath: &str,
+    name: &str,
+    tn: &TreeTN<TensorDynLen, V>,
+) -> std::result::Result<(), Hdf5Error>
+where
+    V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
+{
+    let file = File::append(filepath)?;
+    let group = file.create_group(name)?;
+    treetn::write_treetn(&group, tn).map_err(Hdf5Error::from)
+}
+
+/// Load a [`TreeTN`] from a tensor4all-rs `TreeTN` in an HDF5 file.
+///
+/// Opens the file in read-only mode and reads the tree from the group named
+/// `name`. Node tensors, node names, and the tree topology (recovered from
+/// shared index identity) are all restored.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file does not exist or cannot be opened
+/// - The named group is missing or has an incompatible schema
+/// - The type/version metadata does not match `TreeTN` v1
+/// - A `node_name` attribute fails to parse as `V`
+/// - The stored tensors do not form a consistent tree (e.g. a bond index
+///   shared by more than two nodes)
+pub fn load_treetn<V>(
+    filepath: &str,
+    name: &str,
+) -> std::result::Result<TreeTN<TensorDynLen, V>, Hdf5Error>
+where
+    V: FromStr + Ord + Clone + Hash + Eq + Send + Sync + Debug,
+    V::Err: std::fmt::Display,
+{
+    let file = File::open(filepath)?;
+    let group = file.group(name)?;
+    treetn::read_treetn(&group).map_err(Hdf5Error::from)
 }

--- a/crates/tensor4all-hdf5/src/treetn.rs
+++ b/crates/tensor4all-hdf5/src/treetn.rs
@@ -1,0 +1,138 @@
+//! Layer 3: TreeTN HDF5 read/write (tensor4all-rs TreeTN schema v1).
+//!
+//! A [`TreeTN`] is stored as metadata (`node_count`) plus one ITensor
+//! subgroup per node (`node_1/` ... `node_N/`, 1-indexed like the MPS
+//! schema), each carrying the node name as a string attribute. Topology is
+//! not stored explicitly: bond connections are recovered on load from shared
+//! [`Index`](tensor4all_core::Index) identity via
+//! [`TreeTN::from_tensors`], exactly as the tree was assembled originally.
+//! This works because the per-node ITensor schema already preserves full
+//! index identity (id + prime level + tags), and every bond index appears in
+//! exactly the two nodes it connects.
+
+use crate::backend::types::VarLenUnicode;
+use crate::backend::Group;
+use anyhow::{Context, Result};
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::str::FromStr;
+use tensor4all_core::TensorDynLen;
+use tensor4all_treetn::TreeTN;
+
+use crate::index;
+use crate::itensor;
+use crate::schema;
+
+const NODE_NAME_ATTR: &str = "node_name";
+
+/// Write a [`TreeTN`] to an HDF5 group using the tensor4all-rs TreeTN schema
+/// v1.
+///
+/// Node tensors are stored as 1-indexed subgroups (`node_1/`, `node_2/`,
+/// ...), each written with [`crate::itensor::write_itensor`] and annotated
+/// with the node name as a `node_name` string attribute. The `node_count`
+/// dataset records the number of nodes.
+///
+/// # HDF5 Schema
+///
+/// ```text
+/// <group>/
+///   @type = "TreeTN"
+///   @version = 1
+///   node_count: Int64
+///   node_1/
+///     @node_name: VarLenUnicode
+///     (ITensor — see crate::itensor)
+///   node_2/
+///     ...
+/// ```
+pub(crate) fn write_treetn<V>(group: &Group, tn: &TreeTN<TensorDynLen, V>) -> Result<()>
+where
+    V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
+{
+    schema::write_type_version(group, "TreeTN", 1)?;
+
+    let node_count = tn.node_count() as i64;
+    let count_ds = group.new_dataset::<i64>().shape(()).create("node_count")?;
+    count_ds.as_writer().write_scalar(&node_count)?;
+
+    let names = tn.node_names();
+    let indices = tn.node_indices();
+    if names.len() != indices.len() {
+        anyhow::bail!(
+            "TreeTN has {} node names but {} node indices; refusing to save an inconsistent tree",
+            names.len(),
+            indices.len()
+        );
+    }
+
+    for (i, (idx, name)) in indices.iter().zip(&names).enumerate() {
+        let tensor = tn
+            .tensor(*idx)
+            .with_context(|| format!("TreeTN node {name:?} has no tensor"))?;
+        let node_group = group.create_group(&format!("node_{}", i + 1))?;
+
+        let name_attr = node_group
+            .new_attr::<VarLenUnicode>()
+            .shape(())
+            .create(NODE_NAME_ATTR)?;
+        name_attr
+            .as_writer()
+            .write_scalar(&VarLenUnicode::from_str(&name.to_string())?)?;
+
+        itensor::write_itensor(&node_group, tensor)?;
+    }
+
+    Ok(())
+}
+
+/// Read a [`TreeTN`] from an HDF5 group using the tensor4all-rs TreeTN schema
+/// v1.
+///
+/// Validates the `@type` and `@version` attributes, then reads each node's
+/// tensor and `node_name` attribute from 1-indexed subgroups. The tree is
+/// reconstructed with [`TreeTN::from_tensors`], which reconnects bond indices
+/// by shared [`Index`](tensor4all_core::Index) identity and validates that
+/// the result is a consistent tree.
+pub(crate) fn read_treetn<V>(group: &Group) -> Result<TreeTN<TensorDynLen, V>>
+where
+    V: FromStr + Ord + Clone + Hash + Eq + Send + Sync + Debug,
+    V::Err: Display,
+{
+    schema::require_type_version(group, "TreeTN", 1)?;
+
+    let node_count: i64 = group
+        .dataset("node_count")?
+        .as_reader()
+        .read_scalar()
+        .context("Failed to read TreeTN node_count")?;
+    let node_count = index::read_nonnegative_usize("node_count", node_count)?;
+
+    index::validate_expected_child_groups(
+        group,
+        node_count,
+        "TreeTN",
+        "node_",
+        None,
+        &["node_count"],
+    )?;
+
+    let mut names = Vec::with_capacity(node_count);
+    let mut tensors = Vec::with_capacity(node_count);
+    for ordinal in 1..=node_count {
+        let name = format!("node_{ordinal}");
+        let node_group = group
+            .group(&name)
+            .with_context(|| format!("Failed to open HDF5 TreeTN child group {name}"))?;
+
+        let name_str = crate::compat::read_string_attr_by_name(&node_group, NODE_NAME_ATTR)?;
+        let node_name = name_str
+            .parse::<V>()
+            .map_err(|e| anyhow::anyhow!("Failed to parse TreeTN node name {name_str:?}: {e}"))?;
+        names.push(node_name);
+        tensors.push(itensor::read_itensor(&node_group)?);
+    }
+
+    TreeTN::from_tensors(tensors, names).context("Failed to reconstruct TreeTN from HDF5 tensors")
+}

--- a/crates/tensor4all-hdf5/tests/test_hdf5.rs
+++ b/crates/tensor4all-hdf5/tests/test_hdf5.rs
@@ -5,7 +5,10 @@ use num_complex::Complex64;
 use std::str::FromStr;
 use tensor4all_core::index::{DynId, DynIndex, Index, TagSet};
 use tensor4all_core::TensorDynLen;
-use tensor4all_hdf5::{append_itensor, append_mps, load_itensor, load_mps, save_itensor, save_mps};
+use tensor4all_hdf5::{
+    append_itensor, append_mps, append_treetn, load_itensor, load_mps, load_treetn, save_itensor,
+    save_mps, save_treetn,
+};
 use tensor4all_itensorlike::{CanonicalForm, TensorTrain};
 
 fn temp_path(name: &str) -> String {
@@ -941,6 +944,128 @@ fn test_type_mismatch_error() {
         msg.contains("Expected HDF5 type 'MPS'"),
         "Expected type mismatch error, got: {}",
         msg
+    );
+
+    std::fs::remove_file(&path).ok();
+}
+
+use tensor4all_treetn::TreeTN;
+
+/// A 3-node tree (root connected to two leaves) with known data.
+fn make_test_treetn() -> TreeTN<TensorDynLen, String> {
+    let s_left = DynIndex::new_dyn(2);
+    let s_root = DynIndex::new_dyn(3);
+    let s_right = DynIndex::new_dyn(2);
+    let b_left = DynIndex::new_dyn(4);
+    let b_right = DynIndex::new_dyn(5);
+
+    let left = TensorDynLen::from_dense(vec![s_left, b_left.clone()], vec![1.0; 8]).unwrap();
+    let root =
+        TensorDynLen::from_dense(vec![b_left, s_root, b_right.clone()], vec![2.0; 60]).unwrap();
+    let right = TensorDynLen::from_dense(vec![b_right, s_right], vec![3.0; 10]).unwrap();
+
+    TreeTN::from_tensors(
+        vec![left, root, right],
+        vec!["left".to_string(), "root".to_string(), "right".to_string()],
+    )
+    .unwrap()
+}
+
+fn treetn_node_tensors(tn: &TreeTN<TensorDynLen, String>) -> Vec<TensorDynLen> {
+    tn.node_indices()
+        .iter()
+        .map(|idx| tn.tensor(*idx).unwrap().clone())
+        .collect()
+}
+
+#[test]
+fn test_treetn_roundtrip() {
+    let path = TempHdf5Path::new("treetn_roundtrip");
+    let tn = make_test_treetn();
+
+    save_treetn(path.as_str(), "tn", &tn).unwrap();
+    let loaded = load_treetn::<String>(path.as_str(), "tn").unwrap();
+
+    // Structural equality: same node count, same edges, same names in order.
+    assert_eq!(loaded.node_count(), tn.node_count());
+    assert_eq!(loaded.edge_count(), tn.edge_count());
+    assert_eq!(loaded.node_names(), tn.node_names());
+
+    // Numerical equality: each node tensor is identical (index identity and
+    // data), so the reconstructed topology matches the original exactly.
+    let orig = treetn_node_tensors(&tn);
+    let reloaded = treetn_node_tensors(&loaded);
+    assert_eq!(orig.len(), reloaded.len());
+    for (a, b) in orig.iter().zip(&reloaded) {
+        assert_eq!(a.indices(), b.indices());
+        assert!(a.distance(b).unwrap() < 1e-15);
+    }
+}
+
+#[test]
+fn test_treetn_append_multiple() {
+    let path = TempHdf5Path::new("treetn_append");
+    let tn = make_test_treetn();
+
+    save_treetn(path.as_str(), "a", &tn).unwrap();
+    append_treetn(path.as_str(), "b", &tn).unwrap();
+
+    let a = load_treetn::<String>(path.as_str(), "a").unwrap();
+    let b = load_treetn::<String>(path.as_str(), "b").unwrap();
+    assert_eq!(a.node_count(), 3);
+    assert_eq!(b.node_count(), 3);
+    assert_eq!(a.node_names(), b.node_names());
+}
+
+#[test]
+fn test_treetn_usize_node_names_roundtrip() {
+    let path = TempHdf5Path::new("treetn_usize");
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(4);
+    let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8]).unwrap();
+    let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0; 8]).unwrap();
+    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+
+    save_treetn(path.as_str(), "tn", &tn).unwrap();
+    let loaded = load_treetn::<usize>(path.as_str(), "tn").unwrap();
+    assert_eq!(loaded.node_names(), vec![0, 1]);
+    assert_eq!(loaded.edge_count(), 1);
+}
+
+#[test]
+fn test_treetn_bad_node_name_parse_error() {
+    // Save with String names, then request usize: parsing must fail loudly.
+    let path = TempHdf5Path::new("treetn_bad_name");
+    let tn = make_test_treetn();
+    save_treetn(path.as_str(), "tn", &tn).unwrap();
+
+    let err = load_treetn::<usize>(path.as_str(), "tn").unwrap_err();
+    assert!(
+        err.to_string().contains("Failed to parse TreeTN node name"),
+        "Expected node-name parse error, got: {}",
+        err
+    );
+}
+
+#[test]
+fn test_treetn_missing_child_group_error() {
+    // Corrupt the file: remove a node group, then loading must fail with a
+    // child-count mismatch rather than reading a partial tree.
+    let path = temp_path("treetn_missing_child");
+    save_treetn(&path, "tn", &make_test_treetn()).unwrap();
+
+    {
+        let file = File::open_rw(&path).unwrap();
+        let group = file.group("tn").unwrap();
+        group.unlink("node_3").unwrap();
+    }
+
+    let err = load_treetn::<String>(&path, "tn").unwrap_err();
+    assert!(
+        err.to_string().contains("declares 3 TreeTN children"),
+        "Expected child-count mismatch error, got: {}",
+        err
     );
 
     std::fs::remove_file(&path).ok();

--- a/docs/book-tests/Cargo.toml
+++ b/docs/book-tests/Cargo.toml
@@ -21,6 +21,7 @@ tensor4all-quanticstci = { path = "../../crates/tensor4all-quanticstci" }
 tensor4all-interpolativeqtt = { path = "../../crates/tensor4all-interpolativeqtt" }
 tensor4all-itensorlike = { path = "../../crates/tensor4all-itensorlike" }
 tensor4all-treetci = { path = "../../crates/tensor4all-treetci" }
+tensor4all-hdf5 = { path = "../../crates/tensor4all-hdf5" }
 anyhow = { workspace = true }
 num-complex = { workspace = true }
 num-rational = "0.4"
@@ -28,3 +29,4 @@ num-traits = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 approx = { workspace = true }
+tempfile = "3"

--- a/docs/book-tests/src/lib.rs
+++ b/docs/book-tests/src/lib.rs
@@ -38,6 +38,9 @@ mod tci_advanced {}
 #[doc = include_str!("../../book/src/guides/tree-tn.md")]
 mod tree_tn {}
 
+#[doc = include_str!("../../book/src/guides/hdf5-serialization.md")]
+mod hdf5_serialization {}
+
 #[doc = include_str!("../../book/src/guides/quantics.md")]
 mod quantics {}
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
   - [Quantics Transform](guides/quantics.md)
   - [Quantum Fourier Transform](guides/qft.md)
   - [Tree Tensor Networks](guides/tree-tn.md)
+  - [HDF5 Serialization](guides/hdf5-serialization.md)
 - [Tutorials]()
   - [Quantics Basics]()
     - [QTT of a Scalar Function](tutorials/quantics-basics/qtt-scalar-function.md)

--- a/docs/book/src/guides/hdf5-serialization.md
+++ b/docs/book/src/guides/hdf5-serialization.md
@@ -1,0 +1,85 @@
+# HDF5 Serialization
+
+The `tensor4all-hdf5` crate reads and writes tensor4all-rs data structures in
+HDF5 files. Three storage schemas are supported:
+
+| Type | Schema | Notes |
+|------|--------|-------|
+| [`TensorDynLen`](rustdoc/tensor4all_core/struct.TensorDynLen.html) | `ITensor` | ITensors.jl compatible |
+| [`TensorTrain`](rustdoc/tensor4all_itensorlike/struct.TensorTrain.html) | `MPS` | ITensorMPS.jl compatible |
+| [`TreeTN`](rustdoc/tensor4all_treetn/struct.TreeTN.html) | `TreeTN` (v1) | tensor4all-rs schema; no ITensorNetworks.jl equivalent exists |
+
+## TreeTN storage
+
+A general tree tensor network is stored as one ITensor subgroup per node,
+plus a `node_count` dataset:
+
+```text
+<name>/
+  @type = "TreeTN"
+  @version = 1
+  node_count: Int64
+  node_1/ ... node_N/
+    @node_name: VarLenUnicode
+    (ITensor — same per-node schema as save_itensor)
+```
+
+Two design decisions keep the schema minimal:
+
+- **Edges are not stored explicitly.** Bond connections are recovered on load
+  from shared `Index` identity via `TreeTN::from_tensors`, exactly as the
+  tree was assembled originally. The per-node ITensor schema already
+  preserves full index identity (id + prime level + tags), and every bond
+  index appears in exactly the two nodes it connects, so reconstruction is
+  exact.
+- **Node names travel with each node** as a `node_name` attribute. Unlike the
+  topology, node names (`TreeTN`'s `V` type) are *not* recoverable from the
+  tensors, so they are stored explicitly. Any node name type that round-trips
+  through strings works — `String` and `usize` are the common cases.
+
+## Example
+
+```rust
+# fn main() -> anyhow::Result<()> {
+use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_hdf5::{load_treetn, save_treetn};
+use tensor4all_treetn::TreeTN;
+
+// A 3-site chain: t0 -- t1 -- t2
+let s0 = DynIndex::new_dyn(2);
+let s1 = DynIndex::new_dyn(2);
+let s2 = DynIndex::new_dyn(2);
+let b01 = DynIndex::new_dyn(4);
+let b12 = DynIndex::new_dyn(4);
+
+let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
+let t1 = TensorDynLen::from_dense(vec![b01, s1, b12.clone()], vec![2.0; 32])?;
+let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![3.0; 8])?;
+
+let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    vec![t0, t1, t2],
+    vec!["left".to_string(), "center".to_string(), "right".to_string()],
+)?;
+
+let dir = tempfile::tempdir()?;
+let path = dir.path().join("treetn.h5");
+let path = path.to_str().unwrap();
+
+save_treetn(path, "tn", &tn)?;
+let loaded = load_treetn::<String>(path, "tn")?;
+
+// Structure and node names survive the round trip.
+assert_eq!(loaded.node_count(), 3);
+assert_eq!(loaded.edge_count(), 2);
+assert_eq!(loaded.node_names(), vec!["left".to_string(), "center".to_string(), "right".to_string()]);
+# Ok(())
+# }
+```
+
+## When to use which schema
+
+- **Chains (MPS/MPO)**: use `save_mps` / `load_mps` for ITensorMPS.jl
+  compatibility, or `save_treetn` when you want the orthogonality-center-free
+  TreeTN representation.
+- **General trees**: `save_treetn` / `load_treetn` is the only option — no
+  upstream ITensorNetworks.jl format exists.

--- a/scripts/test-mdbook.sh
+++ b/scripts/test-mdbook.sh
@@ -30,10 +30,26 @@ if [[ -z "$extern_args" ]]; then
 fi
 
 real_rustdoc="$(rustup which rustdoc)"
+# book-tests' dependency closure includes tensor4all-hdf5, whose doctests
+# link the native HDF5 library. The raw rustdoc invocation cannot see the
+# search path that hdf5-metno-sys emits as cargo build-script output, so
+# forward it explicitly when pkg-config resolves hdf5 (same resolution the
+# build script uses on Linux). Harmless no-op when hdf5 is absent.
+native_link_args=()
+if pkg-config --exists hdf5 2>/dev/null; then
+    # Same resolution hdf5-metno-sys uses on Linux; forward every native
+    # search dir (Debian/Ubuntu puts libhdf5 in .../hdf5/serial).
+    while IFS= read -r dir; do
+        [[ -n "$dir" ]] && native_link_args+=(-L "native=${dir}")
+    done < <(pkg-config --libs-only-L hdf5 | tr ' ' '\n' | sed 's/^ *-L//; s/ *$//' | grep -v '^$')
+fi
 {
     echo '#!/usr/bin/env bash'
     echo 'set -euo pipefail'
     printf 'exec %q ' "$real_rustdoc"
+    for ((i = 0; i < ${#native_link_args[@]}; i += 2)); do
+        printf '%q %q ' "${native_link_args[i]}" "${native_link_args[i + 1]}"
+    done
     while IFS= read -r extern_arg; do
         [[ -n "$extern_arg" ]] || continue
         crate_name="${extern_arg%%=*}"


### PR DESCRIPTION
Resolves #576.

## What

`tensor4all-hdf5` gains a documented, tested storage convention for general tree tensor networks (`TreeTN<TensorDynLen, V>`):

- `save_treetn` / `append_treetn` / `load_treetn`
- New `TreeTN` v1 schema:
  ```
  <group>/
    @type = "TreeTN"
    @version = 1
    node_count: Int64
    node_1/ ... node_N/
      @node_name: VarLenUnicode
      (ITensor — same per-node schema as save_itensor)
  ```
- Node name type `V` is generic over string round-tripping (`ToString`/`FromStr`); `String` and `usize` both work.

## Design decisions (vs. the issue's sketch)

- **No explicit `edges/` dataset.** Bond connections are recovered on load from shared `Index` identity via `TreeTN::from_tensors` — the per-node ITensor schema already preserves full index identity, and every bond index appears in exactly the two nodes it connects. The issue's "exactly-2-tensors-per-bond" failure mode cannot occur for a valid TreeTN, and `from_tensors` errors loudly on corrupt data anyway.
- **`node_names` stored as a per-node attribute** (not a separate dataset): names are the one thing a bare tensor list cannot recover, since `from_tensors` requires them.

## Verification

- End-to-end round-trip tests (save → reload → structural + numerical equality): `test_treetn_roundtrip`, `test_treetn_append_multiple`, `test_treetn_usize_node_names_roundtrip`
- Error-path tests: `test_treetn_bad_node_name_parse_error`, `test_treetn_missing_child_group_error`
- Runnable doctest on `save_treetn`/`load_treetn` in `lib.rs`
- New mdBook guide page `guides/hdf5-serialization.md` (added to SUMMARY + book-tests)
- `scripts/test-mdbook.sh` now forwards native HDF5 link search paths from pkg-config (raw rustdoc cannot see cargo build-script output); needed because book-tests' closure now includes tensor4all-hdf5
- `cargo test -p tensor4all-hdf5 --release`: 45 integration tests + 10 doctests pass
- `cargo test --doc -p book-tests --release`: 46 pass
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean