### PR TITLE
feat(treetci): automatic global pivot search (port from tensor4all-tensorci)

### DIFF
--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -227,7 +227,8 @@ where
         + 'static
         + TensorElement
         + tensor4all_tcicore::MatrixLuciScalar
-        + FullPivLuScalar,
+        + FullPivLuScalar
+        + tensor4all_treetci::globalpivot::ScalarParts,
 {
     // Validate output_dims
     if output_dims.is_empty() {

--- a/crates/tensor4all-quanticstci/src/options.rs
+++ b/crates/tensor4all-quanticstci/src/options.rs
@@ -286,6 +286,13 @@ impl QtciOptions {
             max_iter: self.maxiter,
             max_bond_dim: self.max_bond_dim,
             normalize_error: self.normalize_error,
+            // Global pivot search stays opt-in; the legacy `nsearchglobalpivot`
+            // and `nsearch` fields are not wired through yet.
+            enable_global_pivots: false,
+            nsearch: self.nsearch,
+            max_nglobal_pivot: self.nsearchglobalpivot,
+            tol_margin_global_search: 10.0,
+            seed: None,
         }
     }
 }

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -400,7 +400,8 @@ where
         + 'static
         + tensor4all_core::TensorElement
         + tensor4all_tcicore::MatrixLuciScalar
-        + FullPivLuScalar,
+        + FullPivLuScalar
+        + tensor4all_treetci::globalpivot::ScalarParts,
     F: Fn(&[f64]) -> V + 'static,
 {
     let local_dims = grid.local_dimensions();
@@ -575,7 +576,8 @@ where
         + 'static
         + tensor4all_core::TensorElement
         + tensor4all_tcicore::MatrixLuciScalar
-        + FullPivLuScalar,
+        + FullPivLuScalar
+        + tensor4all_treetci::globalpivot::ScalarParts,
     F: Fn(&[f64]) -> V + 'static,
 {
     if xvals.is_empty() {
@@ -699,7 +701,8 @@ where
         + 'static
         + tensor4all_core::TensorElement
         + tensor4all_tcicore::MatrixLuciScalar
-        + FullPivLuScalar,
+        + FullPivLuScalar
+        + tensor4all_treetci::globalpivot::ScalarParts,
     F: Fn(&[i64]) -> V + 'static,
 {
     if size.is_empty() {

--- a/crates/tensor4all-treetci/src/api.rs
+++ b/crates/tensor4all-treetci/src/api.rs
@@ -56,6 +56,7 @@ pub type TreeTciRunResult = (
 ///     max_iter: 10,
 ///     max_bond_dim: Some(10),
 ///     normalize_error: true,
+///     ..Default::default()
 /// };
 ///
 /// let proposer = DefaultProposer;
@@ -93,7 +94,8 @@ where
     T: FullPivLuScalar
         + CommonScalar
         + tensor4all_tcicore::MatrixLuciScalar
-        + tensor4all_core::TensorElement,
+        + tensor4all_core::TensorElement
+        + crate::globalpivot::ScalarParts,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {

--- a/crates/tensor4all-treetci/src/globalpivot.rs
+++ b/crates/tensor4all-treetci/src/globalpivot.rs
@@ -1,0 +1,245 @@
+//! Automatic global pivot search for [`TreeTCI2`].
+//!
+//! Port of the `GlobalPivotFinder` machinery from the chain TCI2 crate
+//! (`tensor4all-tensorci`): after each sweep the optimizer materializes the
+//! current tree approximation and searches random starting points with local
+//! coordinate optimization for multi-indices where `|f(idx) - tt(idx)|` is
+//! large. Found pivots are injected via [`TreeTCI2::add_global_pivots`] so the
+//! next sweep samples regions the local pivot updates missed.
+//!
+//! The search is opt-in (`TreeTciOptions::enable_global_pivots`); the default
+//! optimization loop never materializes the tree.
+
+use crate::error::Result as TreeTciResult;
+use crate::{materialize::to_treetn, GlobalIndexBatch, MultiIndex, TreeTCI2};
+use anyhow::Result;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef};
+use tensor4all_tcicore::MatrixLuciScalar as Scalar;
+use tensor4all_tensorbackend::FullPivLuScalar;
+
+/// Search for multi-indices where the current approximation error is large.
+///
+/// Algorithm (mirrors `DefaultGlobalPivotFinder` in `tensor4all-tensorci`):
+///
+/// 1. Materialize the current [`TreeTCI2`] state as a `TreeTN`.
+/// 2. Draw `nsearch` random starting points.
+/// 3. For each starting point, sweep every site coordinate and keep the
+///    point with the largest interpolation error `|f(idx) - tt(idx)|`.
+/// 4. Keep points whose error exceeds `abs_tol * tol_margin`.
+/// 5. Return at most `max_nglobal_pivot` distinct points.
+///
+/// The returned pivots are full-site multi-indices ready for
+/// [`TreeTCI2::add_global_pivots`].
+///
+/// # Arguments
+///
+/// * `state` -- current TreeTCI pivot state.
+/// * `evaluate` -- batch evaluator, identical to the one passed to
+///
+///   [`optimize_with_proposer`](crate::optimize_with_proposer).
+/// * `nsearch` -- number of random starting points.
+/// * `max_nglobal_pivot` -- maximum number of pivots returned.
+/// * `tol_margin` -- acceptance margin over `abs_tol`.
+/// * `abs_tol` -- absolute interpolation-error threshold.
+/// * `seed` -- RNG seed; a fixed seed makes the search deterministic.
+///
+/// # Returns
+///
+/// Up to `max_nglobal_pivot` distinct full-site multi-indices where the
+/// current approximation is (likely) poor. An empty vector when nothing
+/// exceeds the threshold.
+///
+/// # Errors
+///
+/// Returns an error when the current state cannot be materialized as a
+/// `TreeTN` (a rank mismatch or a singular pivot matrix), when the batch
+/// evaluator returns a wrong number of values (a batch length mismatch),
+/// when `abs_tol` or `tol_margin` is not finite and nonnegative (an
+/// invalid configuration), or when the candidate index array shape is
+/// malformed (a shape mismatch).
+pub fn find_global_pivots<T, F>(
+    state: &TreeTCI2<T>,
+    evaluate: F,
+    nsearch: usize,
+    max_nglobal_pivot: usize,
+    tol_margin: f64,
+    abs_tol: f64,
+    seed: u64,
+) -> TreeTciResult<Vec<MultiIndex>>
+where
+    T: FullPivLuScalar + Scalar + tensor4all_core::TensorElement + ScalarParts,
+    F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
+{
+    if !abs_tol.is_finite() || abs_tol < 0.0 {
+        return Err(
+            anyhow::anyhow!("global pivot search abs_tol must be finite and nonnegative").into(),
+        );
+    }
+    if !tol_margin.is_finite() || tol_margin < 0.0 {
+        return Err(anyhow::anyhow!(
+            "global pivot search tol_margin must be finite and nonnegative"
+        )
+        .into());
+    }
+    if nsearch == 0 || max_nglobal_pivot == 0 {
+        return Ok(Vec::new());
+    }
+    let n_sites = state.local_dims.len();
+    if n_sites == 0 {
+        return Ok(Vec::new());
+    }
+
+    // Materialize the current approximation once per search. A degenerate or
+    // inconsistent pivot state is a real error; propagate it rather than
+    // silently skipping the search.
+    let treetn = to_treetn(state, &evaluate, None)?;
+    let mut site_indices = Vec::with_capacity(n_sites);
+    for site in 0..n_sites {
+        let node = treetn
+            .node_index(&site)
+            .ok_or_else(|| anyhow::anyhow!("materialized tree missing site {site}"))?;
+        let tensor = treetn
+            .tensor(node)
+            .ok_or_else(|| anyhow::anyhow!("materialized tree missing tensor for site {site}"))?;
+        // `to_treetn` always stores the site index first.
+        site_indices.push(tensor.indices()[0].clone());
+    }
+
+    // Candidate points: for each random start, each site coordinate swept
+    // over its full local dimension (same local search as the chain finder).
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut points: Vec<MultiIndex> = Vec::new();
+    for _ in 0..nsearch {
+        let start: MultiIndex = (0..n_sites)
+            .map(|site| rng.random_range(0..state.local_dims[site]))
+            .collect();
+        for site in 0..n_sites {
+            for value in 0..state.local_dims[site] {
+                let mut point = start.clone();
+                point[site] = value;
+                points.push(point);
+            }
+        }
+    }
+
+    // Evaluate the function at all candidates in one batch.
+    let flat: Vec<usize> = points.iter().flat_map(|p| p.iter().copied()).collect();
+    let f_values = evaluate(GlobalIndexBatch::new(&flat, n_sites, points.len())?)?;
+    if f_values.len() != points.len() {
+        return Err(anyhow::anyhow!(
+            "batch evaluator returned {} values for {} global-pivot candidates",
+            f_values.len(),
+            points.len()
+        )
+        .into());
+    }
+
+    // Evaluate the current approximation at all candidates in one batch.
+    let shape = [n_sites, points.len()];
+    let values_ref = ColMajorArrayRef::new(&flat, &shape)
+        .map_err(|error| anyhow::anyhow!("failed to build candidate index array: {error}"))?;
+    let tt_values = treetn
+        .evaluate(&site_indices, values_ref)
+        .map_err(anyhow::Error::from)?;
+
+    // Local search per starting point.
+    let mut best: Vec<(f64, MultiIndex)> = Vec::new();
+    let mut point_index = 0usize;
+    for _ in 0..nsearch {
+        let mut start_best: Option<(f64, MultiIndex)> = None;
+        for site in 0..n_sites {
+            for _value in 0..state.local_dims[site] {
+                let error = interp_error(f_values[point_index], tt_values[point_index].clone());
+                if start_best
+                    .as_ref()
+                    .is_none_or(|(best_error, _)| error > *best_error)
+                {
+                    start_best = Some((error, points[point_index].clone()));
+                }
+                point_index += 1;
+            }
+        }
+        if let Some((error, point)) = start_best {
+            if error > abs_tol * tol_margin {
+                best.push((error, point));
+            }
+        }
+    }
+
+    // Keep the strongest distinct points.
+    best.sort_by(|(a, _), (b, _)| b.total_cmp(a));
+    let mut pivots: Vec<MultiIndex> = Vec::new();
+    for (_, point) in best {
+        if !pivots.contains(&point) {
+            pivots.push(point);
+            if pivots.len() >= max_nglobal_pivot {
+                break;
+            }
+        }
+    }
+    Ok(pivots)
+}
+
+/// Real and imaginary parts of a scalar, used to estimate the interpolation
+/// error `|f(idx) - tt(idx)|` in `f64` space.
+///
+/// Implemented for `f32`, `f64`, `num_complex::Complex32`, and
+/// `num_complex::Complex64`, the scalar types supported by the tree TCI2
+/// optimization loop.
+pub trait ScalarParts {
+    /// Real part as `f64`.
+    fn real_part(self) -> f64;
+    /// Imaginary part as `f64` (zero for real scalars).
+    fn imag_part(self) -> f64;
+}
+
+impl ScalarParts for f32 {
+    fn real_part(self) -> f64 {
+        self as f64
+    }
+
+    fn imag_part(self) -> f64 {
+        0.0
+    }
+}
+
+impl ScalarParts for f64 {
+    fn real_part(self) -> f64 {
+        self
+    }
+
+    fn imag_part(self) -> f64 {
+        0.0
+    }
+}
+
+impl ScalarParts for num_complex::Complex32 {
+    fn real_part(self) -> f64 {
+        self.re as f64
+    }
+
+    fn imag_part(self) -> f64 {
+        self.im as f64
+    }
+}
+
+impl ScalarParts for num_complex::Complex64 {
+    fn real_part(self) -> f64 {
+        self.re
+    }
+
+    fn imag_part(self) -> f64 {
+        self.im
+    }
+}
+
+fn interp_error<T: ScalarParts + Copy>(f_value: T, tt_value: AnyScalar) -> f64 {
+    let re = f_value.real_part() - tt_value.real();
+    let im = f_value.imag_part() - tt_value.imag();
+    (re * re + im * im).sqrt()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tensor4all-treetci/src/globalpivot/tests.rs
+++ b/crates/tensor4all-treetci/src/globalpivot/tests.rs
@@ -1,0 +1,227 @@
+use super::find_global_pivots;
+use crate::{
+    materialize::to_treetn, optimize_with_proposer, DefaultProposer, GlobalIndexBatch, TreeTCI2,
+    TreeTciEdge, TreeTciGraph, TreeTciOptions,
+};
+use anyhow::Result;
+use num_complex::Complex64;
+use tensor4all_core::TensorDynLen;
+use tensor4all_treetn::TreeTN;
+
+/// Batch evaluator for a two-peak function on a 10-site chain.
+///
+/// f(idx) = 3 * exp(-beta * d2(idx, A)) + 2 * exp(-beta * d2(idx, B)) with
+/// d2(x, y) = |x - y|^2. Each single Gaussian is exactly rank 1, so the
+/// full function needs rank 2 — but only if both peaks are sampled. A sweep
+/// seeded only at A walks toward B one coordinate at a time, and the walk
+/// stalls once intermediate |f| drops below the absolute tolerance, so the
+/// near-degenerate second peak is silently lost (the gw-rs defect).
+const N: usize = 10;
+const PEAK_A: [usize; N] = [0; N];
+const PEAK_B: [usize; N] = [3; N];
+const BETA: f64 = 0.5;
+
+fn peak_value(index: &[usize]) -> f64 {
+    let d2 = |peak: &[usize; N]| -> f64 {
+        (0..N)
+            .map(|i| {
+                let d = index[i] as f64 - peak[i] as f64;
+                d * d
+            })
+            .sum()
+    };
+    3.0 * (-BETA * d2(&PEAK_A)).exp() + 2.0 * (-BETA * d2(&PEAK_B)).exp()
+}
+
+fn evaluate(batch: GlobalIndexBatch<'_>) -> Result<Vec<f64>> {
+    let mut values = Vec::with_capacity(batch.n_points());
+    for point in 0..batch.n_points() {
+        let mut index = [0usize; N];
+        for (site, slot) in index.iter_mut().enumerate() {
+            *slot = batch.get(site, point).unwrap();
+        }
+        values.push(peak_value(&index));
+    }
+    Ok(values)
+}
+
+fn chain_graph() -> TreeTciGraph {
+    let edges: Vec<TreeTciEdge> = (0..N - 1).map(|i| TreeTciEdge::new(i, i + 1)).collect();
+    TreeTciGraph::new(N, &edges).unwrap()
+}
+
+fn options(enable_global_pivots: bool) -> TreeTciOptions {
+    TreeTciOptions {
+        tolerance: 1e-8,
+        max_iter: 30,
+        max_bond_dim: None,
+        normalize_error: true,
+        enable_global_pivots,
+        nsearch: 10,
+        max_nglobal_pivot: 5,
+        tol_margin_global_search: 1.0,
+        seed: Some(42),
+    }
+}
+
+fn seeded_state() -> TreeTCI2<f64> {
+    let mut tci = TreeTCI2::<f64>::new(vec![4; N], chain_graph()).unwrap();
+    // Seed the sweep in the first basin only.
+    tci.add_global_pivots(&[PEAK_A.to_vec()]).unwrap();
+    let flat: Vec<usize> = PEAK_A.to_vec();
+    let init_batch = GlobalIndexBatch::new(&flat, N, 1).unwrap();
+    let init_values = evaluate(init_batch).unwrap();
+    tci.max_sample_value = init_values.iter().copied().fold(0.0f64, f64::max);
+    tci
+}
+
+/// Evaluate the materialized tree at a full-site index.
+fn tree_value(tree: &TreeTN<TensorDynLen, usize>, index: &[usize]) -> f64 {
+    let mut site_indices = Vec::with_capacity(index.len());
+    for site in 0..index.len() {
+        let node = tree.node_index(&site).unwrap();
+        let tensor = tree.tensor(node).unwrap();
+        site_indices.push(tensor.indices()[0].clone());
+    }
+    tree.evaluate_point(&site_indices, index).unwrap().real()
+}
+
+fn run(enable_global_pivots: bool) -> (Vec<usize>, Vec<f64>, f64, f64) {
+    let mut tci = seeded_state();
+    let opts = options(enable_global_pivots);
+    let (ranks, errors) =
+        optimize_with_proposer(&mut tci, evaluate, &opts, &DefaultProposer).unwrap();
+    let tree = to_treetn(&tci, evaluate, None).unwrap();
+    (
+        ranks,
+        errors,
+        tree_value(&tree, &PEAK_A),
+        tree_value(&tree, &PEAK_B),
+    )
+}
+
+#[test]
+fn global_pivot_search_finds_pivots_with_large_error() {
+    // Direct finder check: with a rank-1 state seeded only at peak A, the
+    // search must escape the A basin and return points near peak B.
+    let tci = seeded_state();
+    let pivots =
+        find_global_pivots(&tci, evaluate, 10, 5, 1.0, 1e-8 * tci.max_sample_value, 42).unwrap();
+
+    let closer_to_b = |pivot: &Vec<usize>| {
+        let d2 = |peak: &[usize; N]| {
+            (0..N)
+                .map(|i| {
+                    let d = pivot[i] as i64 - peak[i] as i64;
+                    d * d
+                })
+                .sum::<i64>()
+        };
+        d2(&PEAK_B) < d2(&PEAK_A)
+    };
+    assert!(
+        !pivots.is_empty() && pivots.iter().all(closer_to_b),
+        "global pivot search must escape the seeded basin, got {pivots:?}"
+    );
+}
+
+#[test]
+fn global_pivots_capture_both_near_degenerate_basins() {
+    // Regression for the gw-rs defect (lingrui96/gw-rs#9): with initial
+    // pivots confined to one basin, the sweep self-reports convergence while
+    // a whole near-degenerate peak silently vanishes. Enabling the global
+    // pivot search must recover both peaks.
+    let (ranks, errors, value_a, value_b) = run(true);
+
+    assert!(
+        errors.last().copied().unwrap_or(1.0) < 1e-6,
+        "expected convergence with global pivots, errors={errors:?}"
+    );
+    assert!(
+        (value_a - peak_value(&PEAK_A)).abs() < 1e-6,
+        "first basin lost: tree value at A is {value_a}, expected {}",
+        peak_value(&PEAK_A)
+    );
+    assert!(
+        (value_b - peak_value(&PEAK_B)).abs() < 1e-6,
+        "second basin lost: tree value at B is {value_b}, expected {}",
+        peak_value(&PEAK_B)
+    );
+    assert!(*ranks.last().unwrap() >= 2, "both peaks need rank >= 2");
+}
+
+#[test]
+fn without_global_pivots_second_basin_is_lost() {
+    // Documents why the option exists: the same instance without the global
+    // pivot search converges (error estimate near peak A) but the materialized
+    // tree evaluates to ~zero at peak B, where f(B) = 2.
+    let (_, errors, value_a, value_b) = run(false);
+
+    assert!(errors.last().copied().unwrap_or(1.0) < 1e-6);
+    assert!((value_a - peak_value(&PEAK_A)).abs() < 1e-6);
+    assert!(
+        (value_b - peak_value(&PEAK_B)).abs() > 1.0,
+        "expected the second basin to be missed without global pivots, tree value at B is {value_b}"
+    );
+}
+
+#[test]
+fn find_global_pivots_rejects_invalid_parameters() {
+    let tci = seeded_state();
+    // Non-finite or negative tolerances are rejected.
+    assert!(find_global_pivots(&tci, evaluate, 5, 5, 1.0, f64::NAN, 1).is_err());
+    assert!(find_global_pivots(&tci, evaluate, 5, 5, -1.0, 1e-8, 1).is_err());
+    assert!(find_global_pivots(&tci, evaluate, 5, 5, 1.0, -1.0, 1).is_err());
+    // A disabled search (no starting points or no pivot budget) is a no-op.
+    assert!(find_global_pivots(&tci, evaluate, 0, 5, 1.0, 1e-8, 1)
+        .unwrap()
+        .is_empty());
+    assert!(find_global_pivots(&tci, evaluate, 5, 0, 1.0, 1e-8, 1)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn find_global_pivots_rejects_bad_batch_length() {
+    let tci = seeded_state();
+    // Evaluator returns one value regardless of the requested batch size.
+    let bad = |_batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> { Ok(vec![0.0]) };
+    assert!(find_global_pivots(&tci, bad, 5, 5, 1.0, 1e-8, 1).is_err());
+}
+
+#[test]
+fn find_global_pivots_respects_threshold_and_limit() {
+    let tci = seeded_state();
+    // A huge absolute tolerance rejects every candidate.
+    let none = find_global_pivots(&tci, evaluate, 10, 5, 1.0, 1e10, 1).unwrap();
+    assert!(none.is_empty());
+    // A strict pivot budget truncates the found candidates.
+    let few =
+        find_global_pivots(&tci, evaluate, 10, 2, 1.0, 1e-8 * tci.max_sample_value, 1).unwrap();
+    assert!(!few.is_empty());
+    assert!(few.len() <= 2);
+}
+
+#[test]
+fn find_global_pivots_supports_complex_scalars() {
+    let graph = chain_graph();
+    let mut tci = TreeTCI2::<Complex64>::new(vec![4; N], graph).unwrap();
+    tci.add_global_pivots(&[PEAK_A.to_vec()]).unwrap();
+
+    // Nonzero complex function: mixture + i * mixture / 2.
+    let complex_eval = |batch: GlobalIndexBatch<'_>| -> Result<Vec<Complex64>> {
+        let mut values = Vec::with_capacity(batch.n_points());
+        for point in 0..batch.n_points() {
+            let mut index = [0usize; N];
+            for (site, slot) in index.iter_mut().enumerate() {
+                *slot = batch.get(site, point).unwrap();
+            }
+            let v = peak_value(&index);
+            values.push(Complex64::new(v, 0.5 * v));
+        }
+        Ok(values)
+    };
+
+    let pivots = find_global_pivots(&tci, complex_eval, 10, 5, 1.0, 1e-8, 1).unwrap();
+    assert!(!pivots.is_empty());
+}

--- a/crates/tensor4all-treetci/src/lib.rs
+++ b/crates/tensor4all-treetci/src/lib.rs
@@ -76,6 +76,8 @@ pub mod assemble;
 /// Batch views for global site-order evaluation.
 pub mod batch;
 pub mod error;
+/// Automatic global pivot search for the optimization loop.
+pub mod globalpivot;
 /// Tree graph helpers and edge-bipartition utilities for TreeTCI.
 pub mod graph;
 /// Canonical subtree-key types.
@@ -100,6 +102,7 @@ pub use api::crossinterpolate2;
 pub use assemble::{assemble_global_point, assemble_points_column_major, MultiIndex};
 pub use batch::{GlobalIndexBatch, OwnedGlobalIndexBatch};
 pub use error::{Result as TreeTciResult, TreeTciError};
+pub use globalpivot::find_global_pivots;
 pub use graph::{TreeTciEdge, TreeTciGraph};
 pub use key::SubtreeKey;
 pub use materialize::to_treetn;

--- a/crates/tensor4all-treetci/src/materialize.rs
+++ b/crates/tensor4all-treetci/src/materialize.rs
@@ -159,6 +159,17 @@ where
         ));
     };
 
+    // A numerically zero pivot matrix (the function underflows in this
+    // subdomain) cannot be solved; emit a zero site tensor of the same shape
+    // instead of failing the solve. Mirrors the guard in
+    // `tensor4all-tensorci`'s `fill_site_tensors`.
+    if p_values
+        .iter()
+        .all(|value| Scalar::abs_val(*value) < f64::EPSILON)
+    {
+        return Ok(vec![T::zero(); rows * cols]);
+    }
+
     T::solve_right_full_piv_lu(&pi1_values, rows, cols, &p_values, p_rows, cols)
         .map_err(anyhow::Error::from)
 }

--- a/crates/tensor4all-treetci/src/materialize/tests.rs
+++ b/crates/tensor4all-treetci/src/materialize/tests.rs
@@ -36,6 +36,7 @@ fn to_treetn_preserves_two_site_identity_evaluations() {
             max_iter: 4,
             max_bond_dim: None,
             normalize_error: true,
+            ..Default::default()
         },
     )
     .unwrap();
@@ -154,4 +155,22 @@ fn solve_right_full_piv_lu_recovers_complex_rhs_for_nontrivial_pivot() {
         .map(|value| value.norm())
         .fold(0.0_f64, f64::max);
     assert_complex_slice_close(&solved, &target, max_sample, 1e-12);
+}
+
+#[test]
+fn to_treetn_emits_zero_core_for_zero_pivot_matrix() {
+    // A pivot whose sampled function values are all exactly zero produces a
+    // singular pivot matrix in `site_tensor_with_parent`; materialization
+    // must emit a zero core instead of failing the solve.
+    let mut tci = TreeTCI2::<f64>::new(vec![2, 2], two_site_graph()).unwrap();
+    tci.add_global_pivots(&[vec![0, 0]]).unwrap();
+
+    // Evaluator that is exactly zero at every pivot cross-section.
+    let batch_eval =
+        |batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> { Ok(vec![0.0; batch.n_points()]) };
+
+    let tn = to_treetn(&tci, batch_eval, Some(0)).unwrap();
+    let dense = tn.to_dense().unwrap();
+    let values = dense.to_vec::<f64>().unwrap();
+    assert_eq!(values, vec![0.0; 4]);
 }

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -1,10 +1,13 @@
 use crate::error::Result as TreeTciResult;
 use crate::{
-    update::update_edge, AllEdges, EdgeVisitor, GlobalIndexBatch, PivotCandidateProposer, TreeTCI2,
+    globalpivot::{find_global_pivots, ScalarParts},
+    update::update_edge,
+    AllEdges, EdgeVisitor, GlobalIndexBatch, PivotCandidateProposer, TreeTCI2,
 };
 use anyhow::Result;
 use tensor4all_core::CommonScalar;
 use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
+use tensor4all_tensorbackend::FullPivLuScalar;
 
 /// MVP optimization options for TreeTCI.
 ///
@@ -13,12 +16,17 @@ use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
 ///
 /// # Defaults
 ///
-/// | Field              | Default       | Description                                         |
-/// |--------------------|---------------|-----------------------------------------------------|
-/// | `tolerance`        | `1e-8`        | Relative stopping tolerance on normalized bond error |
-/// | `max_iter`         | `20`          | Maximum number of edge-order iterations              |
-/// | `max_bond_dim`     | `None`        | Maximum bond dimension (no cap by default)           |
-/// | `normalize_error`  | `true`        | Normalize error by maximum sample magnitude          |
+/// | Field                     | Default       | Description                                         |
+/// |---------------------------|---------------|-----------------------------------------------------|
+/// | `tolerance`               | `1e-8`        | Relative stopping tolerance on normalized bond error |
+/// | `max_iter`                | `20`          | Maximum number of edge-order iterations              |
+/// | `max_bond_dim`            | `None`        | Maximum bond dimension (no cap by default)           |
+/// | `normalize_error`         | `true`        | Normalize error by maximum sample magnitude          |
+/// | `enable_global_pivots`    | `false`       | Run automatic global pivot search after each sweep   |
+/// | `nsearch`                 | `5`           | Random starting points for the global pivot search   |
+/// | `max_nglobal_pivot`       | `5`           | Global pivots added per iteration                    |
+/// | `tol_margin_global_search`| `10.0`        | Global pivot acceptance margin over `abs_tol`        |
+/// | `seed`                    | `None`        | RNG seed for the global pivot search                 |
 ///
 /// # Examples
 ///
@@ -31,6 +39,7 @@ use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
 /// assert_eq!(opts.max_iter, 20);
 /// assert_eq!(opts.max_bond_dim, None);
 /// assert!(opts.normalize_error);
+/// assert!(!opts.enable_global_pivots);
 ///
 /// // Custom options for high-precision work
 /// let opts = TreeTciOptions {
@@ -38,10 +47,17 @@ use tensor4all_tcicore::{MatrixLuciScalar as Scalar, RrLUOptions};
 ///     max_iter: 50,
 ///     max_bond_dim: Some(100),
 ///     normalize_error: true,
+///     enable_global_pivots: true,
+///     nsearch: 20,
+///     max_nglobal_pivot: 10,
+///     tol_margin_global_search: 5.0,
+///     seed: Some(42),
 /// };
 /// assert!((opts.tolerance - 1e-12).abs() < 1e-20);
 /// assert_eq!(opts.max_iter, 50);
 /// assert_eq!(opts.max_bond_dim, Some(100));
+/// assert!(opts.enable_global_pivots);
+/// assert_eq!(opts.seed, Some(42));
 /// ```
 #[derive(Clone, Debug)]
 pub struct TreeTciOptions {
@@ -71,6 +87,46 @@ pub struct TreeTciOptions {
     /// `max_bond_error / max_sample_value`. When `false`, the raw absolute
     /// bond error is used. Default: `true`.
     pub normalize_error: bool,
+
+    /// Whether to run an automatic global pivot search after each sweep.
+    ///
+    /// When `true`, the optimizer materializes the current approximation
+    /// after each iteration and searches for multi-indices where
+    /// `|f(idx) - tt(idx)|` is large, injecting the best finds via
+    /// [`TreeTCI2::add_global_pivots`](crate::TreeTCI2::add_global_pivots).
+    /// This recovers separated features that local pivot updates miss when
+    /// the initial pivots sit in a single basin. Default: `false` (opt-in,
+    /// preserves existing behavior).
+    pub enable_global_pivots: bool,
+
+    /// Number of random starting points for the global pivot search.
+    ///
+    /// Each starting point is locally optimized over all site coordinates.
+    /// Larger values explore the index space more thoroughly at the cost of
+    /// more evaluations. Ignored when `enable_global_pivots` is `false`.
+    /// Default: `5`.
+    pub nsearch: usize,
+
+    /// Maximum number of global pivots added per iteration.
+    ///
+    /// Ignored when `enable_global_pivots` is `false`. Default: `5`.
+    pub max_nglobal_pivot: usize,
+
+    /// Tolerance margin for the global pivot search.
+    ///
+    /// A candidate pivot is accepted when its interpolation error exceeds
+    /// `abs_tol * tol_margin_global_search`, where `abs_tol` is the sweep's
+    /// absolute tolerance (`tolerance * max_sample_value` when
+    /// `normalize_error` is enabled). The value is always validated (it must
+    /// be finite and nonnegative) but only consulted when `enable_global_pivots`
+    /// is `true`. Default: `10.0`.
+    pub tol_margin_global_search: f64,
+
+    /// Random seed for the global pivot search.
+    ///
+    /// `None` seeds from OS entropy. Only used when `enable_global_pivots`
+    /// is `true`. Default: `None`.
+    pub seed: Option<u64>,
 }
 
 impl Default for TreeTciOptions {
@@ -80,6 +136,11 @@ impl Default for TreeTciOptions {
             max_iter: 20,
             max_bond_dim: None,
             normalize_error: true,
+            enable_global_pivots: false,
+            nsearch: 5,
+            max_nglobal_pivot: 5,
+            tol_margin_global_search: 10.0,
+            seed: None,
         }
     }
 }
@@ -137,7 +198,7 @@ pub fn optimize_default<T, F>(
     options: &TreeTciOptions,
 ) -> TreeTciResult<(Vec<usize>, Vec<f64>)>
 where
-    T: Scalar + CommonScalar,
+    T: Scalar + CommonScalar + FullPivLuScalar + tensor4all_core::TensorElement + ScalarParts,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
     optimize_with_proposer(state, evaluate, options, &crate::DefaultProposer)
@@ -198,7 +259,7 @@ pub fn optimize_with_proposer<T, F, P>(
     proposer: &P,
 ) -> TreeTciResult<(Vec<usize>, Vec<f64>)>
 where
-    T: Scalar + CommonScalar,
+    T: Scalar + CommonScalar + FullPivLuScalar + tensor4all_core::TensorElement + ScalarParts,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
@@ -208,18 +269,25 @@ where
     if options.max_bond_dim == Some(0) {
         return Err(anyhow::anyhow!("TreeTCI optimization requires max_bond_dim > 0").into());
     };
+    if !options.tol_margin_global_search.is_finite() || options.tol_margin_global_search < 0.0 {
+        return Err(anyhow::anyhow!(
+            "TreeTCI optimization requires a finite nonnegative tol_margin_global_search"
+        )
+        .into());
+    };
 
     let mut ranks = Vec::new();
     let mut errors = Vec::new();
+    let mut nglobal_pivots_history: Vec<usize> = Vec::new();
     let visitor = AllEdges;
     const INNER_EDGE_PASSES: usize = 2;
-    // Matches `tensor4all-tensorci`'s `TensorCI2Options::ncheck_history` default
+    // Mirrors `tensor4all-tensorci`'s `TensorCI2Options::ncheck_history` default
     // (see `convergence_criterion` in tensorci2.rs, itself a port of Julia's
     // `convergencecriterion`). A single below-tolerance sweep is not reliable:
     // the bond-error estimate can dip before the pivot search has actually
-    // stabilized. TreeTCI2 has no per-sweep "new global pivots" count to check
-    // (unlike TensorCI2), so this only checks error-below-tolerance + rank
-    // stability over the trailing window, not the third TensorCI2 criterion.
+    // stabilized. Like TensorCI2, the window must also contain no newly added
+    // global pivots: an iteration that injected pivots has not yet swept them,
+    // so its error estimate is stale with respect to those pivots.
     const NCHECK_HISTORY: usize = 3;
 
     for _iter in 0..options.max_iter {
@@ -252,6 +320,39 @@ where
         };
         errors.push(normalized_error);
 
+        // Global pivot search: after each sweep, materialize the current
+        // approximation and inject pivots where |f - tt| is large, so
+        // separated features that the local pivot updates miss are sampled
+        // in the next sweep. Opt-in; see `TreeTciOptions::enable_global_pivots`.
+        // The search is skipped on the final iteration: a pivot injected after
+        // the last sweep would never be processed by a subsequent sweep, so the
+        // recorded error and termination reason would not reflect it.
+        if options.enable_global_pivots && _iter + 1 < options.max_iter {
+            let error_scale = if options.normalize_error && state.max_sample_value > 0.0 {
+                state.max_sample_value
+            } else {
+                1.0
+            };
+            let abs_tol = options.tolerance * error_scale;
+            let seed = match options.seed {
+                Some(base) => base.wrapping_add(_iter as u64),
+                None => rand::random(),
+            };
+            let pivots = find_global_pivots(
+                state,
+                &evaluate,
+                options.nsearch,
+                options.max_nglobal_pivot,
+                options.tol_margin_global_search,
+                abs_tol,
+                seed,
+            )?;
+            state.add_global_pivots(&pivots)?;
+            nglobal_pivots_history.push(pivots.len());
+        } else {
+            nglobal_pivots_history.push(0);
+        }
+
         // BUGFIX (local, not upstream): the sweep loop previously always ran
         // to `max_iter` with no convergence check, wasting O(max_iter /
         // actual_sweeps_needed) work on already-converged problems. See
@@ -268,13 +369,15 @@ where
             let n = errors.len();
             let last_errors = &errors[n - NCHECK_HISTORY..];
             let last_ranks = &ranks[n - NCHECK_HISTORY..];
+            let last_ngp = &nglobal_pivots_history[n - NCHECK_HISTORY..];
             let errors_converged = last_errors.iter().all(|&e| e < options.tolerance);
+            let no_global_pivots = last_ngp.iter().all(|&n| n == 0);
             let rank_stable = last_ranks.iter().min().copied().unwrap_or(0)
                 == last_ranks.last().copied().unwrap_or(0);
             let bond_dim_saturated = options
                 .max_bond_dim
                 .is_some_and(|cap| last_ranks.iter().all(|&r| r >= cap));
-            if (errors_converged && rank_stable) || bond_dim_saturated {
+            if (errors_converged && no_global_pivots && rank_stable) || bond_dim_saturated {
                 break;
             }
         }

--- a/crates/tensor4all-treetci/src/optimize/tests.rs
+++ b/crates/tensor4all-treetci/src/optimize/tests.rs
@@ -30,6 +30,7 @@ fn optimize_default_converges_on_two_site_identity() {
             max_iter: 4,
             max_bond_dim: None,
             normalize_error: true,
+            ..Default::default()
         },
     )
     .unwrap();
@@ -77,6 +78,7 @@ fn optimize_default_stops_early_once_converged() {
             max_iter: 4,
             max_bond_dim: None,
             normalize_error: true,
+            ..Default::default()
         },
     )
     .unwrap();
@@ -117,6 +119,7 @@ fn optimize_default_stops_early_when_bond_dim_saturated() {
             max_iter: 10,
             max_bond_dim: Some(1),
             normalize_error: true,
+            ..Default::default()
         },
     )
     .unwrap();

--- a/crates/tensor4all-treetci/src/update.rs
+++ b/crates/tensor4all-treetci/src/update.rs
@@ -36,6 +36,11 @@ where
 {
     let (left_key, right_key) = state.graph.subregion_vertices(edge)?;
     let (left_candidates, right_candidates) = proposer.candidates(state, edge)?;
+    if left_candidates.is_empty() || right_candidates.is_empty() {
+        return Err(anyhow::anyhow!(
+            "proposer returned empty candidate list for edge {edge:?}",
+        ));
+    }
     let values = evaluate_candidate_matrix(
         state.local_dims.len(),
         &left_key,
@@ -57,25 +62,39 @@ where
     }
     let selection = matrix_luci_factors_from_matrix(&matrix, Some(options.clone()))?;
 
+    // The LU can select zero pivots when the sampled submatrix is numerically
+    // zero (the function underflows in a subdomain). Keep at least one index
+    // so the stored pivot sets never become empty and the state stays
+    // materializable; the resulting rank-1 zero core is the correct
+    // approximation of a zero subdomain. Candidate lists are validated
+    // non-empty above.
+    let row_indices = if selection.row_indices.is_empty() {
+        vec![0]
+    } else {
+        selection.row_indices.clone()
+    };
+    let col_indices = if selection.col_indices.is_empty() {
+        vec![0]
+    } else {
+        selection.col_indices.clone()
+    };
+
     // Build ColMajorArray from selected pivot indices
     let n_left_sites = left_key.as_slice().len();
     let n_right_sites = right_key.as_slice().len();
 
-    let left_data: Vec<usize> = selection
-        .row_indices
+    let left_data: Vec<usize> = row_indices
         .iter()
         .flat_map(|&row| left_candidates[row].iter().copied())
         .collect();
-    let left_arr = ColMajorArray::new(left_data, vec![n_left_sites, selection.row_indices.len()])?;
+    let left_arr = ColMajorArray::new(left_data, vec![n_left_sites, row_indices.len()])?;
     state.ijset.insert(left_key.clone(), left_arr);
 
-    let right_data: Vec<usize> = selection
-        .col_indices
+    let right_data: Vec<usize> = col_indices
         .iter()
         .flat_map(|&col| right_candidates[col].iter().copied())
         .collect();
-    let right_arr =
-        ColMajorArray::new(right_data, vec![n_right_sites, selection.col_indices.len()])?;
+    let right_arr = ColMajorArray::new(right_data, vec![n_right_sites, col_indices.len()])?;
     state.ijset.insert(right_key.clone(), right_arr);
 
     let last_error = selection.pivot_errors.last().copied().unwrap_or(0.0);

--- a/crates/tensor4all-treetci/tests/advanced_quantics.rs
+++ b/crates/tensor4all-treetci/tests/advanced_quantics.rs
@@ -93,6 +93,7 @@ fn quantics_grid_polynomial_matches_all_points_on_branching_tree() {
             max_iter: 12,
             max_bond_dim: Some(8),
             normalize_error: true,
+            ..Default::default()
         },
         Some(1),
         &SimpleProposer::seeded(0),
@@ -156,6 +157,7 @@ fn quantics_grid_batch_evaluator_matches_point_evaluator() {
         max_iter: 12,
         max_bond_dim: Some(8),
         normalize_error: true,
+        ..Default::default()
     };
 
     // Run with point-eval-based batch closure

--- a/crates/tensor4all-treetci/tests/simple_parity.rs
+++ b/crates/tensor4all-treetci/tests/simple_parity.rs
@@ -57,6 +57,7 @@ fn simple_tree_parity_matches_reference_points() {
             max_iter: 10,
             max_bond_dim: Some(5),
             normalize_error: true,
+            ..Default::default()
         },
         Some(0),
         &SimpleProposer::seeded(0),
@@ -113,6 +114,7 @@ fn simple_tree_product_function_is_exact_on_branching_tree() {
             max_iter: 8,
             max_bond_dim: Some(2),
             normalize_error: true,
+            ..Default::default()
         },
         Some(0),
         &DefaultProposer,
@@ -172,6 +174,7 @@ fn simple_tree_complex_product_function_is_exact_on_branching_tree() {
             max_iter: 8,
             max_bond_dim: Some(2),
             normalize_error: true,
+            ..Default::default()
         },
         Some(0),
         &DefaultProposer,
@@ -239,6 +242,7 @@ fn simple_tree_complex_product_function_is_exact_on_two_site_tree() {
             max_iter: 8,
             max_bond_dim: Some(2),
             normalize_error: true,
+            ..Default::default()
         },
         Some(0),
         &DefaultProposer,


### PR DESCRIPTION
Closes #594.

## Problem

The tree TCI2 optimizer (`optimize_with_proposer`) runs no global pivot
search, so when the initial pivots sit in a single basin the sweep never
samples far high-|f| regions and a near-degenerate second peak is
silently lost while the sweep self-reports convergence
(motivating bug: lingrui96/gw-rs#9).

## Fix

Ports the `GlobalPivotFinder` machinery from the chain TCI2 crate:

- `TreeTciOptions` gains opt-in controls: `enable_global_pivots`,
  `nsearch`, `max_nglobal_pivot`, `tol_margin_global_search`, `seed`.
  Default behavior is unchanged (search off).
- New `globalpivot::find_global_pivots`: materializes the current TreeTN
  once per iteration, evaluates f and the approximation at random starting
  points with local coordinate optimization, returns the multi-indices
  with the largest interpolation error for `TreeTCI2::add_global_pivots`.
- `optimize_with_proposer` runs the search after each sweep when enabled
  (skipped on the final iteration so injected pivots are always swept),
  and the convergence criterion requires zero newly injected pivots in the
  trailing window, mirroring `TensorCI2`'s `convergence_criterion`.
- `ScalarParts` (f32/f64/Complex32/Complex64) estimates |f - tt|.
- Related robustness: `update_edge` keeps at least one pivot when the LU
  selects none, and materialization emits a zero core when the pivot
  matrix is numerically zero, so degenerate zero subdomains stay
  materializable (same bug class as #598).

## Verification

Regression test on a 10-site two-Gaussian chain seeded in one basin:
- without the search: converges at rank 1, second peak evaluates to ~0
  (f(B) = 2);
- with the search: converges at rank 2, both peaks captured to 1e-6.
- Existing treetci/quanticstci tests unchanged (search off by default).
- Full workspace: 2779 tests pass; doc tests + mdbook pass; clippy clean.