### PR TITLE
feat(aci): global pivot search guard against silently lost features

### DIFF
--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -1,9 +1,12 @@
 //! Public elementwise Alternating Cross Interpolation sweep APIs.
 
+use crate::global_guard::find_global_pivots;
 use crate::scalar::AciScalar;
 use crate::validation::{validate_inputs, validate_options};
 use crate::{AciOptions, AciResult, ElementwiseBatch, ElementwiseProblem, Result};
-use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, SimpleTensorTrain};
+use tensor4all_simplett::{
+    tensor3_from_data, AbstractTensorTrain, EinsumScalar, SimpleTensorTrain,
+};
 
 /// Runs batched elementwise ACI over tensor-train inputs.
 ///
@@ -16,6 +19,14 @@ use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, SimpleTensorTr
 /// each bond's pivot error is divided by that bond's largest sampled
 /// operator-output magnitude from the completed sweep, and the largest
 /// normalized value is used.
+///
+/// When [`AciOptions::enable_global_guard`] is enabled (the default), the
+/// local stopping rule is gated by a global pivot search: before accepting
+/// convergence, the current solution is sampled against the true operator at
+/// global points, and any significantly-wrong points are injected into the
+/// sweep's frames so the next sweep absorbs them. The search only runs at the
+/// moment the local criterion would otherwise stop, so it adds no operator
+/// evaluations during normal sweeps.
 ///
 /// Sweeping also stops once the solution rank has sat at
 /// [`AciOptions::max_bond_dim`] for [`AciOptions::min_iters`] consecutive
@@ -91,7 +102,7 @@ pub fn elementwise_batched<T, F>(
     options: &AciOptions<T>,
 ) -> Result<AciResult<T>>
 where
-    T: AciScalar,
+    T: AciScalar + EinsumScalar + PartialEq,
     F: for<'batch> FnMut(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
 {
     validate_options(options)?;
@@ -105,6 +116,7 @@ where
 
     let mut ranks = Vec::new();
     let mut errors = Vec::new();
+    let mut guard_runs = 0usize;
 
     for iteration in 0..options.max_iters {
         let forward = iteration % 2 == 0;
@@ -126,6 +138,12 @@ where
         ranks.push(problem.solution.rank());
         errors.push(max_error_metric);
 
+        // Global pivot search guard: the local criterion only sees
+        // bond-local samples, so a feature outside the sampled crosses can be
+        // silently lost while the run self-reports convergence. Before
+        // accepting, sample the current solution against the true operator at
+        // global points; if significantly-wrong points exist, inject them and
+        // keep sweeping instead of converging.
         if convergence_criterion_like_julia(
             iteration + 1,
             &ranks,
@@ -133,7 +151,25 @@ where
             options.min_iters,
             options.tolerance,
         ) {
-            break;
+            if !options.enable_global_guard
+                || options.nsearch_global_pivots == 0
+                || options.max_nglobal_pivot == 0
+            {
+                break;
+            }
+            guard_runs += 1;
+            let seed = options.rng_seed.wrapping_add(guard_runs as u64);
+            let pivots = find_global_pivots(&problem, &mut op, options, seed)?;
+            if pivots.is_empty() {
+                break;
+            }
+            let added = problem.add_global_pivots(&pivots)?;
+            if added == 0 {
+                // Every found pivot was already in the frames and the sweeps
+                // could not absorb it (e.g. the bond dimension is capped);
+                // further guard runs cannot help.
+                break;
+            }
         }
 
         if rank_is_saturated(&ranks, options.min_iters, options.max_bond_dim) {
@@ -237,7 +273,7 @@ pub fn elementwise<T, F>(
     options: &AciOptions<T>,
 ) -> Result<AciResult<T>>
 where
-    T: AciScalar,
+    T: AciScalar + EinsumScalar + PartialEq,
     F: FnMut(&[T]) -> T,
 {
     let mut scratch = Vec::new();

--- a/crates/tensor4all-aci/src/global_guard.rs
+++ b/crates/tensor4all-aci/src/global_guard.rs
@@ -1,0 +1,147 @@
+//! Global pivot search guard for elementwise ACI convergence.
+//!
+//! ACI's sweeps estimate error from bond-local 2-site LU blocks only, so a
+//! feature outside the sampled crosses (e.g. a near-degenerate second peak
+//! far from the initial pivots) is invisible to the stopping rule: the run
+//! self-reports convergence while the feature silently vanishes. This module
+//! implements the same guard as `tensor4all-treetci`'s global pivot search:
+//! before accepting convergence, the current solution is sampled against the
+//! true operator at global points, and any significantly-wrong points are
+//! returned for injection into the ACI frames.
+
+use crate::scalar::AciScalar;
+use crate::{AciOptions, ElementwiseBatch, ElementwiseProblem, Result};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use tensor4all_simplett::{AbstractTensorTrain, EinsumScalar, TTCache};
+use tensor4all_tcicore::MatrixLuciScalar;
+
+/// Search for global multi-indices where the current solution is wrong.
+///
+/// Algorithm (mirrors `tensor4all-treetci`'s `find_global_pivots`):
+///
+/// 1. Draw `nsearch` random starting points.
+/// 2. For each starting point, sweep every site coordinate over its full
+///    local dimension, keeping the point with the largest interpolation
+///    error `|op(inputs(idx)) - solution(idx)|`.
+/// 3. Keep points whose error exceeds `abs_tol * tol_margin`, where
+///    `abs_tol` is the configured tolerance (scaled by the maximum sampled
+///    operator magnitude when `scale_tolerance` is enabled).
+/// 4. Return at most `max_nglobal_pivot` distinct points.
+///
+/// Input values and the current solution are evaluated at all candidate
+/// points in one batch per tensor train via [`TTCache::evaluate_many`]
+/// (shared prefixes/suffixes are contracted once); the operator is called in
+/// a single [`ElementwiseBatch`].
+pub(crate) fn find_global_pivots<T, F>(
+    problem: &ElementwiseProblem<T>,
+    op: &mut F,
+    options: &AciOptions<T>,
+    seed: u64,
+) -> Result<Vec<Vec<usize>>>
+where
+    T: AciScalar + EinsumScalar,
+    F: for<'batch> FnMut(ElementwiseBatch<'batch, T>, &mut [T]) -> Result<()>,
+{
+    let n_sites = problem.len();
+    let n_inputs = problem.n_inputs();
+    let nsearch = options.nsearch_global_pivots;
+    let max_nglobal_pivot = options.max_nglobal_pivot;
+    if nsearch == 0 || max_nglobal_pivot == 0 || n_sites < 2 {
+        return Ok(Vec::new());
+    }
+
+    let site_dims: Vec<usize> = (0..n_sites)
+        .map(|site| problem.solution.site_dim(site))
+        .collect();
+
+    // Candidate points: for each random start, sweep each site coordinate
+    // over its full local dimension (same local search as the chain and tree
+    // TCI2 finders; candidates share prefixes/suffixes heavily, which
+    // `TTCache::evaluate_many` exploits).
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut points: Vec<Vec<usize>> = Vec::new();
+    for _ in 0..nsearch {
+        let start: Vec<usize> = site_dims.iter().map(|&d| rng.random_range(0..d)).collect();
+        for site in 0..n_sites {
+            for value in 0..site_dims[site] {
+                let mut point = start.clone();
+                point[site] = value;
+                points.push(point);
+            }
+        }
+    }
+    let n_points = points.len();
+
+    // Input values at all candidate points: one cached batch per input.
+    let mut input_values = vec![T::zero(); n_inputs * n_points];
+    for input in 0..n_inputs {
+        let mut cache = TTCache::new(&problem.inputs[input]);
+        let values = cache.evaluate_many(&points, None)?;
+        for (point, value) in values.into_iter().enumerate() {
+            input_values[input + n_inputs * point] = value;
+        }
+    }
+
+    // Operator output at all candidate points: one batch call.
+    let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
+    let mut op_values = vec![T::zero(); n_points];
+    op(batch, &mut op_values)?;
+
+    // Current solution at all candidate points: one cached batch.
+    let mut solution_cache = TTCache::new(&problem.solution);
+    let solution_values = solution_cache.evaluate_many(&points, None)?;
+
+    let max_op_abs = op_values
+        .iter()
+        .map(|&value| MatrixLuciScalar::abs_val(value))
+        .fold(0.0f64, f64::max);
+    let abs_tol = if options.scale_tolerance && max_op_abs > 0.0 {
+        options.tolerance * max_op_abs
+    } else {
+        options.tolerance
+    };
+    let threshold = abs_tol * options.tol_margin_global_search;
+
+    // Local search per starting point.
+    let mut best: Vec<(f64, Vec<usize>)> = Vec::new();
+    let mut point_index = 0usize;
+    for _ in 0..nsearch {
+        let mut start_best: Option<(f64, Vec<usize>)> = None;
+        for &site_dim in &site_dims {
+            for _value in 0..site_dim {
+                let error = MatrixLuciScalar::abs_val(
+                    op_values[point_index] - solution_values[point_index],
+                );
+                if start_best
+                    .as_ref()
+                    .is_none_or(|(best_error, _)| error > *best_error)
+                {
+                    start_best = Some((error, points[point_index].clone()));
+                }
+                point_index += 1;
+            }
+        }
+        if let Some((error, point)) = start_best {
+            if error > threshold {
+                best.push((error, point));
+            }
+        }
+    }
+
+    // Keep the strongest distinct points.
+    best.sort_by(|(a, _), (b, _)| b.total_cmp(a));
+    let mut pivots: Vec<Vec<usize>> = Vec::new();
+    for (_, point) in best {
+        if !pivots.contains(&point) {
+            pivots.push(point);
+            if pivots.len() >= max_nglobal_pivot {
+                break;
+            }
+        }
+    }
+    Ok(pivots)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tensor4all-aci/src/global_guard/tests.rs
+++ b/crates/tensor4all-aci/src/global_guard/tests.rs
@@ -1,0 +1,146 @@
+use super::find_global_pivots;
+use crate::{elementwise, AciOptions, ElementwiseProblem};
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, SimpleTensorTrain};
+
+const D: usize = 4;
+
+fn gauss(peak: usize, value: usize) -> f64 {
+    let d = value as f64 - peak as f64;
+    (-0.5 * d * d).exp()
+}
+
+/// f(idx) = 3*exp(-0.5*d2(idx, A)) + 2*exp(-0.5*d2(idx, B)) as a rank-2 TT
+/// with peaks A = (0, .., 0) and B = (3, .., 3) on an `n`-site chain.
+fn two_peak_tt(n: usize) -> SimpleTensorTrain<f64> {
+    let mut cores = Vec::new();
+    for site in 0..n {
+        let (l, r) = if site == 0 {
+            (1, 2)
+        } else if site == n - 1 {
+            (2, 1)
+        } else {
+            (2, 2)
+        };
+        let mut data = vec![0.0; l * D * r];
+        for r_idx in 0..r {
+            for i in 0..D {
+                for l_idx in 0..l {
+                    let value = match (site, l_idx, r_idx) {
+                        (0, 0, 0) => 3.0 * gauss(0, i),
+                        (0, 0, 1) => 2.0 * gauss(3, i),
+                        (s, 1, 0) if s == n - 1 => gauss(3, i),
+                        (_, 0, 0) => gauss(0, i),
+                        (_, 1, 1) => gauss(3, i),
+                        _ => 0.0,
+                    };
+                    data[l_idx + l * (i + D * r_idx)] = value;
+                }
+            }
+        }
+        cores.push(tensor3_from_data(data, l, D, r).unwrap());
+    }
+    SimpleTensorTrain::new(cores).unwrap()
+}
+
+fn run_case(seed: u64, guard: bool, nsearch: usize) -> SimpleTensorTrain<f64> {
+    let input = two_peak_tt(10);
+    let options = AciOptions {
+        rng_seed: seed,
+        enable_global_guard: guard,
+        nsearch_global_pivots: nsearch,
+        tolerance: 1e-4,
+        ..AciOptions::default()
+    };
+    elementwise(|xs: &[f64]| xs[0], &[input], &options)
+        .unwrap()
+        .tensor_train
+}
+
+#[test]
+fn global_guard_recovers_missed_near_degenerate_feature() {
+    // The two near-degenerate peaks are far apart, so the local sweeps can
+    // converge on the first basin only while the second peak silently
+    // vanishes: the guard-off run evaluates to ~0 at B (f(B) = 2). The
+    // global pivot search guard finds the missed point, injects it, and the
+    // guard-on run captures both peaks.
+    let fb = 2.0;
+    let off = run_case(0, false, 5);
+    let on = run_case(0, true, 30);
+
+    let err_off = (off.evaluate(&[3; 10]).unwrap() - fb).abs();
+    let err_on = (on.evaluate(&[3; 10]).unwrap() - fb).abs();
+    let err_on_a = (on.evaluate(&[0; 10]).unwrap() - 3.0).abs();
+
+    assert!(
+        err_off > 1.0,
+        "expected the guard-off run to miss the second peak, err at B = {err_off}"
+    );
+    assert!(
+        err_on < 1e-6,
+        "expected the guard to recover the second peak, err at B = {err_on}"
+    );
+    assert!(
+        err_on_a < 1e-6,
+        "the guard must not damage the first peak, err at A = {err_on_a}"
+    );
+}
+
+#[test]
+fn global_guard_disabled_by_zero_search_budget() {
+    // nsearch_global_pivots = 0 disables the search: the run behaves exactly
+    // like the guard-off run (second peak missed).
+    let fb = 2.0;
+    let input = two_peak_tt(10);
+    let options = AciOptions {
+        rng_seed: 0,
+        enable_global_guard: true,
+        nsearch_global_pivots: 0,
+        tolerance: 1e-4,
+        ..AciOptions::default()
+    };
+    let result = elementwise(|xs: &[f64]| xs[0], &[input], &options).unwrap();
+    let err = (result.tensor_train.evaluate(&[3; 10]).unwrap() - fb).abs();
+    assert!(
+        err > 1.0,
+        "zero search budget must behave like the guard is off"
+    );
+}
+
+#[test]
+fn find_global_pivots_noop_without_search_budget() {
+    // Direct finder check: a zero budget returns nothing without touching
+    // the problem.
+    let input = two_peak_tt(10);
+    let problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+    let options = AciOptions {
+        nsearch_global_pivots: 0,
+        max_nglobal_pivot: 0,
+        ..AciOptions::default()
+    };
+    let mut op = |_batch: crate::ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        output.fill(0.0);
+        Ok(())
+    };
+    let pivots = find_global_pivots(&problem, &mut op, &options, 0).unwrap();
+    assert!(pivots.is_empty());
+}
+
+#[test]
+fn global_guard_terminates_when_bond_dimension_capped() {
+    // With max_bond_dim = 1 the two-peak output cannot be represented, so the
+    // guard keeps finding the same missed point and must terminate cleanly
+    // (the pivot is already in the frames -> nothing new injected -> stop)
+    // instead of burning iterations or failing.
+    let input = two_peak_tt(10);
+    let options = AciOptions {
+        rng_seed: 0,
+        enable_global_guard: true,
+        nsearch_global_pivots: 30,
+        tolerance: 1e-4,
+        max_bond_dim: Some(1),
+        ..AciOptions::default()
+    };
+    let result = elementwise(|xs: &[f64]| xs[0], &[input], &options).unwrap();
+    assert!(result.tensor_train.rank() <= 1);
+    assert!(result.ranks.len() <= options.max_iters);
+}

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -31,6 +31,7 @@ pub mod prelude;
 mod batch;
 mod elementwise;
 mod error;
+mod global_guard;
 #[allow(dead_code)]
 mod local;
 mod options;

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -26,6 +26,10 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 /// assert!(!options.scale_tolerance);
 /// assert!(options.initial_guess.is_none());
 /// assert_eq!(options.rng_seed, 0);
+/// assert!(options.enable_global_guard);
+/// assert_eq!(options.nsearch_global_pivots, 5);
+/// assert_eq!(options.max_nglobal_pivot, 5);
+/// assert!((options.tol_margin_global_search - 10.0).abs() < 1e-15);
 /// ```
 #[derive(Debug, Clone)]
 pub struct AciOptions<T: TTScalar> {
@@ -82,6 +86,42 @@ pub struct AciOptions<T: TTScalar> {
     /// the same inputs and options. Change this to sample a different initial
     /// pivot path when convergence depends on random choices.
     pub rng_seed: u64,
+
+    /// Whether to run the global pivot search guard before accepting convergence.
+    ///
+    /// The local sweep estimates error from bond-local 2-site blocks only, so a
+    /// feature outside the sampled crosses (e.g. a near-degenerate second peak
+    /// far from the initial pivots) is invisible to the stopping rule. When
+    /// enabled, the optimizer samples the current solution against the true
+    /// operator at global points before accepting convergence and injects any
+    /// significantly-wrong points as pivots. The search runs only at the moment
+    /// the local criterion would otherwise stop, so the default-on guard adds no
+    /// operator evaluations during normal sweeps. Default: `true`.
+    pub enable_global_guard: bool,
+
+    /// Number of random starting points for the global pivot search guard.
+    ///
+    /// Each starting point is locally optimized over all site coordinates.
+    /// Larger values explore the index space more thoroughly at the cost of more
+    /// evaluations. Ignored when `enable_global_guard` is `false`; `0` disables
+    /// the search. Default: `5`.
+    pub nsearch_global_pivots: usize,
+
+    /// Maximum number of global pivots injected per guard run.
+    ///
+    /// Ignored when `enable_global_guard` is `false`; `0` disables the search.
+    /// Default: `5`.
+    pub max_nglobal_pivot: usize,
+
+    /// Tolerance margin for the global pivot search guard.
+    ///
+    /// A candidate point is injected when its interpolation error exceeds
+    /// `abs_tol * tol_margin_global_search`, where `abs_tol` is the configured
+    /// tolerance (scaled by the maximum sampled operator magnitude when
+    /// `scale_tolerance` is enabled). The value is always validated (finite and
+    /// nonnegative) but only consulted when `enable_global_guard` is `true`.
+    /// Default: `10.0`.
+    pub tol_margin_global_search: f64,
 }
 
 impl<T: TTScalar> Default for AciOptions<T> {
@@ -94,6 +134,10 @@ impl<T: TTScalar> Default for AciOptions<T> {
             scale_tolerance: false,
             initial_guess: None,
             rng_seed: 0,
+            enable_global_guard: true,
+            nsearch_global_pivots: 5,
+            max_nglobal_pivot: 5,
+            tol_margin_global_search: 10.0,
         }
     }
 }

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -493,6 +493,140 @@ impl<T: AciScalar> ElementwiseProblem<T> {
         Ok(Some(frames))
     }
 
+    /// Inject global pivots into the frame index sets and the solution rank.
+    ///
+    /// For each pivot `x` and each bond `b`, the left environment
+    /// `L_j(x[0..b])` is appended as a row to `left_frames[j][b]` and the
+    /// right environment `R_j(x[b+2..])` as a column to `right_frames[j][b+2]`
+    /// for every input `j`, so the next sweep's local block at bond `b`
+    /// samples the point `x`. Because ACI couples the frame sizes to the
+    /// solution rank (every `local_update` cross-checks them), the solution's
+    /// internal bond dimensions are zero-padded by the same amount and the
+    /// empty prefixes/suffixes (the bond-0 left frame and the site-`n` right
+    /// frame) are skipped. A pivot already fully represented in the frames is
+    /// skipped, and all inputs grow uniformly so `validate_local_shapes` keeps
+    /// holding.
+    ///
+    /// Returns the number of pivots actually injected (0 when every found
+    /// pivot was already represented in the frames).
+    pub(crate) fn add_global_pivots(&mut self, pivots: &[Vec<usize>]) -> Result<usize>
+    where
+        T: PartialEq,
+    {
+        let n = self.len();
+        let mut new_pivots = 0usize;
+        for pivot in pivots {
+            if pivot.len() != n {
+                return Err(AciError::InvalidInitialGuess {
+                    message: format!(
+                        "global pivot length {} must match the number of sites {n}",
+                        pivot.len()
+                    ),
+                });
+            }
+
+            let mut fully_represented = true;
+            for bond in 0..n.saturating_sub(1) {
+                for input in 0..self.n_inputs() {
+                    if bond >= 1 {
+                        let row = left_environment(&self.inputs[input], &pivot[..bond])?;
+                        if !frame_has_row(self.left_frames[input][bond].as_ref(), &row)? {
+                            fully_represented = false;
+                        }
+                    }
+                    if bond + 2 < n {
+                        let col = right_environment(&self.inputs[input], &pivot[bond + 2..])?;
+                        if !frame_has_col(self.right_frames[input][bond + 2].as_ref(), &col)? {
+                            fully_represented = false;
+                        }
+                    }
+                }
+            }
+            if fully_represented {
+                continue;
+            }
+
+            for bond in 0..n.saturating_sub(1) {
+                for input in 0..self.n_inputs() {
+                    if bond >= 1 {
+                        let row = left_environment(&self.inputs[input], &pivot[..bond])?;
+                        append_row(
+                            self.left_frames[input][bond].as_mut().ok_or_else(|| {
+                                AciError::InvalidInitialGuess {
+                                    message: format!(
+                                        "missing left frame at input {input}, bond {bond}"
+                                    ),
+                                }
+                            })?,
+                            &row,
+                        )?;
+                    }
+                    if bond + 2 < n {
+                        let col = right_environment(&self.inputs[input], &pivot[bond + 2..])?;
+                        append_col(
+                            self.right_frames[input][bond + 2].as_mut().ok_or_else(|| {
+                                AciError::InvalidInitialGuess {
+                                    message: format!(
+                                        "missing right frame at input {input}, bond {}",
+                                        bond + 2
+                                    ),
+                                }
+                            })?,
+                            &col,
+                        )?;
+                    }
+                }
+            }
+            new_pivots += 1;
+        }
+        if new_pivots > 0 {
+            self.pad_solution_internal_bonds(new_pivots)?;
+        }
+        Ok(new_pivots)
+    }
+
+    /// Grow every internal bond of the solution by `growth` with zero padding.
+    ///
+    /// ACI couples the solution rank to the frame sizes, so injecting pivots
+    /// into the frames requires growing the solution's internal bond
+    /// dimensions by the same amount to keep `local_update`'s shape checks
+    /// consistent. The zero-padded entries preserve the current solution
+    /// values; the following sweep's LU fills them from the new crosses.
+    fn pad_solution_internal_bonds(&mut self, growth: usize) -> Result<()> {
+        if growth == 0 {
+            return Ok(());
+        }
+        let n = self.len();
+        let cores = self.solution.site_tensors().to_vec();
+        let mut new_cores = Vec::with_capacity(n);
+        for (site, core) in cores.iter().enumerate() {
+            let site_dim = core.site_dim();
+            let left_dim = core.left_dim();
+            let right_dim = core.right_dim();
+            let new_left = if site == 0 {
+                left_dim
+            } else {
+                left_dim + growth
+            };
+            let new_right = if site == n - 1 {
+                right_dim
+            } else {
+                right_dim + growth
+            };
+            let mut data = vec![T::zero(); new_left * site_dim * new_right];
+            for r in 0..right_dim {
+                for s in 0..site_dim {
+                    for l in 0..left_dim {
+                        data[l + new_left * (s + site_dim * r)] = *core.get3(l, s, r);
+                    }
+                }
+            }
+            new_cores.push(tensor3_from_data(data, new_left, site_dim, new_right)?);
+        }
+        self.solution = SimpleTensorTrain::new(new_cores)?;
+        Ok(())
+    }
+
     pub(crate) fn local_update<F>(
         &mut self,
         bond: usize,
@@ -1028,4 +1162,121 @@ fn frame_matmul_error(direction: &'static str, err: impl std::fmt::Display) -> A
     AciError::InvalidInitialGuess {
         message: format!("{direction} frame update failed: {err}"),
     }
+}
+
+/// Left environment of `tt` at a prefix: the contraction of cores
+/// `0..prefix.len()` at the given index values, as a row vector of length
+/// `site_tensor(prefix.len()).left_dim()`.
+fn left_environment<T: AciScalar>(tt: &SimpleTensorTrain<T>, prefix: &[usize]) -> Result<Vec<T>> {
+    let mut env = Matrix::from_col_major_vec(1, 1, vec![T::one()]);
+    for (site, &index) in prefix.iter().enumerate() {
+        let core = tt.site_tensor(site);
+        let slice =
+            Matrix::from_col_major_vec(core.left_dim(), core.right_dim(), core.slice_site(index));
+        env = mat_mul(&env, &slice).map_err(|err| AciError::InvalidInitialGuess {
+            message: format!("left environment contraction failed: {err}"),
+        })?;
+    }
+    Ok(env.as_col_major_slice().to_vec())
+}
+
+/// Right environment of `tt` at a suffix: the contraction of the last
+/// `suffix.len()` cores at the given index values, as a column vector of
+/// length `site_tensor(n - suffix.len()).left_dim()`.
+fn right_environment<T: AciScalar>(tt: &SimpleTensorTrain<T>, suffix: &[usize]) -> Result<Vec<T>> {
+    let start = tt.len() - suffix.len();
+    let mut env = Matrix::from_col_major_vec(1, 1, vec![T::one()]);
+    for offset in (0..suffix.len()).rev() {
+        let site = start + offset;
+        let core = tt.site_tensor(site);
+        let slice = Matrix::from_col_major_vec(
+            core.left_dim(),
+            core.right_dim(),
+            core.slice_site(suffix[offset]),
+        );
+        env = mat_mul(&slice, &env).map_err(|err| AciError::InvalidInitialGuess {
+            message: format!("right environment contraction failed: {err}"),
+        })?;
+    }
+    Ok(env.as_col_major_slice().to_vec())
+}
+
+/// Whether `frame` contains a row equal to `row`.
+fn frame_has_row<T: AciScalar + PartialEq>(frame: Option<&Matrix<T>>, row: &[T]) -> Result<bool> {
+    let Some(frame) = frame else {
+        return Ok(false);
+    };
+    if frame.ncols() != row.len() {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot match a row of length {} against a frame with {} columns",
+                row.len(),
+                frame.ncols()
+            ),
+        });
+    }
+    for r in 0..frame.nrows() {
+        if (0..frame.ncols()).all(|c| frame[[r, c]] == row[c]) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Append `row` to `frame`. `row` must have length `frame.ncols()`.
+fn append_row<T: AciScalar>(frame: &mut Matrix<T>, row: &[T]) -> Result<()> {
+    if frame.ncols() != row.len() {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot append a row of length {} to a frame with {} columns",
+                row.len(),
+                frame.ncols()
+            ),
+        });
+    }
+    let mut data = frame.as_col_major_slice().to_vec();
+    data.extend_from_slice(row);
+    *frame = Matrix::from_col_major_vec(frame.nrows() + 1, frame.ncols(), data);
+    Ok(())
+}
+
+/// Whether `frame` contains a column equal to `col`.
+fn frame_has_col<T: AciScalar + PartialEq>(frame: Option<&Matrix<T>>, col: &[T]) -> Result<bool> {
+    let Some(frame) = frame else {
+        return Ok(false);
+    };
+    if frame.nrows() != col.len() {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot match a column of length {} against a frame with {} rows",
+                col.len(),
+                frame.nrows()
+            ),
+        });
+    }
+    for c in 0..frame.ncols() {
+        if (0..frame.nrows()).all(|r| frame[[r, c]] == col[r]) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Append `col` to `frame`. `col` must have length `frame.nrows()`.
+fn append_col<T: AciScalar>(frame: &mut Matrix<T>, col: &[T]) -> Result<()> {
+    if frame.nrows() != col.len() {
+        return Err(AciError::InvalidInitialGuess {
+            message: format!(
+                "cannot append a column of length {} to a frame with {} rows",
+                col.len(),
+                frame.nrows()
+            ),
+        });
+    }
+    let mut data = frame.as_col_major_slice().to_vec();
+    for value in col {
+        data.push(*value);
+    }
+    *frame = Matrix::from_col_major_vec(frame.nrows(), frame.ncols() + 1, data);
+    Ok(())
 }

--- a/crates/tensor4all-aci/src/validation.rs
+++ b/crates/tensor4all-aci/src/validation.rs
@@ -35,6 +35,12 @@ pub(crate) fn validate_options<T: TTScalar>(options: &crate::AciOptions<T>) -> R
         });
     }
 
+    if !options.tol_margin_global_search.is_finite() || options.tol_margin_global_search < 0.0 {
+        return Err(AciError::InvalidOptions {
+            message: "tol_margin_global_search must be finite and non-negative".to_string(),
+        });
+    }
+
     Ok(())
 }
 

--- a/crates/tensor4all-simplett/src/lib.rs
+++ b/crates/tensor4all-simplett/src/lib.rs
@@ -71,6 +71,7 @@ pub use cache::TTCache;
 pub use canonical::{center_canonicalize, SiteTensorTrain};
 pub use compression::{CompressionMethod, CompressionOptions};
 pub use contraction::{inner_product, ContractionOptions};
+pub use einsum_helper::EinsumScalar;
 pub use error::{Result, TensorTrainError};
 pub use tensortrain::SimpleTensorTrain;
 


### PR DESCRIPTION
Closes #608.

## Problem

`tensor4all-aci`'s elementwise sweeps accept convergence from **bond-local
pivot errors and rank stability alone**. A feature outside the sampled
crosses (e.g. a near-degenerate second peak far from the initial pivots)
is invisible to the stopping rule: the run self-reports convergence while
the feature silently vanishes — the same failure mode as gw-rs#9, already
fixed for the tree TCI2 loop in #594.

## Fix

Ports the global pivot search guard to ACI:

- **`global_guard::find_global_pivots`**: `nsearch` random starting points
  × full local-dim sweep per site, keeping points where
  `|op(inputs(idx)) − solution(idx)|` exceeds `abs_tol × tol_margin`.
  Inputs and the solution are evaluated in **one cached batch per tensor
  train** via `TTCache::evaluate_many` (shared prefixes/suffixes are
  contracted once); the operator is called in a single `ElementwiseBatch`.
- **`ElementwiseProblem::add_global_pivots`**: injects a point by appending
  the left environment `L_j(x[0..b])` as a row to `left_frames[j][b]` and
  the right environment `R_j(x[b+2..])` as a column to
  `right_frames[j][b+2]` for every bond and input, and zero-pads the
  solution's internal bond dimensions so `local_update`'s frame/rank shape
  checks stay consistent. Pivots already fully represented are skipped.
- **`AciOptions`** gains `enable_global_guard` (default `true` — the
  search only runs at the moment the local criterion would accept, so the
  default adds no operator evaluations during normal sweeps),
  `nsearch_global_pivots` (5), `max_nglobal_pivot` (5),
  `tol_margin_global_search` (10.0); `rng_seed` is reused for the search.
- `tensor4all-simplett` re-exports `EinsumScalar` so the guard can use
  `TTCache` from a generic context.

## Verification

- Regression test: a rank-2 two-peak input on a 10-site chain (peaks at
  opposite corners, `f(A)=3`, `f(B)=2`). The guard-off run converges at
  rank 1 with the second peak evaluating to ~0; with the guard on, both
  peaks are captured to 1e-6.
- The guard terminates cleanly when `max_bond_dim` caps the rank (found
  pivots already in the frames → nothing new injected → stop).
- Existing ACI tests unchanged with the guard on by default.
- Full workspace: 2787 tests pass; doc tests + mdbook pass; clippy clean;
  coverage thresholds met (global_guard.rs 94%, state.rs 79%).