### PR TITLE
perf(treetci): remove quadratic candidate de-dup and per-point batch allocations (gw-rs#8)

### DIFF
--- a/crates/tensor4all-treetci/src/proposer.rs
+++ b/crates/tensor4all-treetci/src/proposer.rs
@@ -5,7 +5,7 @@ use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use tensor4all_core::ColMajorArray;
 
@@ -248,21 +248,31 @@ fn subtree_position(key: &SubtreeKey, site: usize) -> Result<usize> {
         .ok_or_else(|| anyhow::anyhow!("site {} not found in subtree key {:?}", site, key))
 }
 
+/// Concatenate `values` with the previous iteration's pivots for `key`,
+/// dropping duplicates and preserving first-occurrence order.
+///
+/// Membership is tested through a `HashSet`, mirroring `TreeTCI.jl`'s
+/// hash-based `union`. A linear `Vec::contains` scan here would be
+/// O(n^2), which is ruinous at a branching vertex: the candidate count is
+/// the *product* of the other incident bonds' dimensions (`d * chi_1 * chi_2`)
+/// rather than `d * chi` as on a chain, so n reaches O(10^5) and the
+/// quadratic term dominates the whole optimization.
 fn union_with_history(
     values: Vec<MultiIndex>,
     history: Option<&HashMap<SubtreeKey, ColMajorArray<usize>>>,
     key: &SubtreeKey,
 ) -> Result<Vec<MultiIndex>> {
     let mut unique = Vec::with_capacity(values.len());
+    let mut seen: HashSet<MultiIndex> = HashSet::with_capacity(values.len());
     for candidate in values {
-        if !unique.contains(&candidate) {
+        if seen.insert(candidate.clone()) {
             unique.push(candidate);
         }
     }
     if let Some(arr) = history.and_then(|history| history.get(key)) {
         for j in 0..ncols_2d(arr)? {
             let col = column_2d(arr, j)?.to_vec();
-            if !unique.contains(&col) {
+            if seen.insert(col.clone()) {
                 unique.push(col);
             }
         }

--- a/crates/tensor4all-treetci/src/proposer/tests.rs
+++ b/crates/tensor4all-treetci/src/proposer/tests.rs
@@ -1,4 +1,7 @@
-use super::{DefaultProposer, PivotCandidateProposer, SimpleProposer, TruncatedDefaultProposer};
+use super::{
+    union_with_history, DefaultProposer, PivotCandidateProposer, SimpleProposer,
+    TruncatedDefaultProposer,
+};
 use crate::{AllEdges, EdgeVisitor, SubtreeKey, TreeTCI2, TreeTciEdge, TreeTciGraph};
 use std::collections::HashMap;
 use tensor4all_core::ColMajorArray;
@@ -84,6 +87,27 @@ fn default_proposer_unions_history_candidates() {
         .unwrap();
 
     assert!(iset.contains(&vec![1, 1, 1, 1]));
+}
+
+#[test]
+fn union_with_history_dedups_in_first_occurrence_order() {
+    let key = SubtreeKey::new(vec![0, 1, 2]);
+    let history = HashMap::from([(
+        key.clone(),
+        ColMajorArray::new(vec![1, 1, 1, 0, 1, 2], vec![3, 2]).unwrap(), // [1,1,1], [0,1,2]
+    )]);
+
+    // `values` contains duplicates (the cartesian pivot expansion can produce
+    // them); history adds two columns, one of which is already present.
+    let values = vec![vec![0, 0, 0], vec![0, 0, 0], vec![1, 1, 1], vec![2, 2, 2]];
+    let out = union_with_history(values, Some(&history), &key).unwrap();
+
+    // First occurrence wins, both within `values` and across history: the
+    // already-seen [1,1,1] is not appended again, [0,1,2] is new and appended.
+    assert_eq!(
+        out,
+        vec![vec![0, 0, 0], vec![1, 1, 1], vec![2, 2, 2], vec![0, 1, 2]]
+    );
 }
 
 #[test]

--- a/crates/tensor4all-treetci/src/update.rs
+++ b/crates/tensor4all-treetci/src/update.rs
@@ -1,8 +1,5 @@
 use crate::{
-    assemble::{assemble_points_column_major, MultiIndex},
-    assemble_global_point,
-    batch::GlobalIndexBatch,
-    PivotCandidateProposer, TreeTCI2, TreeTciEdge,
+    assemble::MultiIndex, batch::GlobalIndexBatch, PivotCandidateProposer, TreeTCI2, TreeTciEdge,
 };
 use anyhow::{ensure, Result};
 use tensor4all_core::{ColMajorArray, CommonScalar};
@@ -47,6 +44,7 @@ where
         &left_candidates,
         &right_key,
         &right_candidates,
+        &state.local_dims,
         evaluate,
     )?;
 
@@ -54,12 +52,9 @@ where
         state.max_sample_value = state.max_sample_value.max(CommonScalar::abs_val(*value));
     }
 
-    let mut matrix = Matrix::zeros(left_candidates.len(), right_candidates.len());
-    for col in 0..right_candidates.len() {
-        for row in 0..left_candidates.len() {
-            matrix[[row, col]] = values[row + left_candidates.len() * col];
-        }
-    }
+    // `evaluate_candidate_matrix` already returns column-major data with
+    // `left_candidates.len()` rows, so this hands over the buffer as-is.
+    let matrix = Matrix::from_col_major_vec(left_candidates.len(), right_candidates.len(), values);
     let selection = matrix_luci_factors_from_matrix(&matrix, Some(options.clone()))?;
 
     // The LU can select zero pivots when the sampled submatrix is numerically
@@ -121,35 +116,113 @@ where
     update_edge(state, edge, evaluate, options, &DefaultProposer)
 }
 
+/// Evaluate the function on the full `I x J` candidate matrix for one edge.
+///
+/// Returns the values in column-major order with `left_candidates.len()` rows.
+///
+/// The global points are written straight into one contiguous batch buffer.
+/// Assembling them as individual `Vec<usize>` points instead (via
+/// `assemble_global_point` + `assemble_points_column_major`) costs one heap
+/// allocation and one extra full copy per matrix *entry*, and re-validates the
+/// bipartition `n_left * n_right` times over -- at a branching vertex that is
+/// O(10^7) allocations for a single edge update. The bipartition is a property
+/// of the two subtree keys, so it is checked once up front instead.
 fn evaluate_candidate_matrix<T, F>(
     n_sites: usize,
     left_key: &crate::SubtreeKey,
     left_candidates: &[MultiIndex],
     right_key: &crate::SubtreeKey,
     right_candidates: &[MultiIndex],
+    local_dims: &[usize],
     evaluate: F,
 ) -> Result<Vec<T>>
 where
     T: Scalar + CommonScalar,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
-    let mut points = Vec::with_capacity(left_candidates.len() * right_candidates.len());
-    for right in right_candidates {
-        for left in left_candidates {
-            points.push(assemble_global_point(
-                n_sites,
-                &[(left_key, left), (right_key, right)],
-                &[],
-            )?);
+    let left_sites = left_key.as_slice();
+    let right_sites = right_key.as_slice();
+
+    let mut assigned = vec![false; n_sites];
+    for &site in left_sites.iter().chain(right_sites.iter()) {
+        ensure!(
+            site < n_sites,
+            "site {} is out of bounds for {} sites",
+            site,
+            n_sites
+        );
+        ensure!(!assigned[site], "site {} was assigned more than once", site);
+        assigned[site] = true;
+    }
+    ensure!(
+        assigned.iter().all(|&seen| seen),
+        "global point assembly left some sites unassigned"
+    );
+
+    // Every candidate must match its own side's subtree key length, and every
+    // coordinate must lie within the site's local dimension. The two sides are
+    // validated separately (rather than inferring the side from the candidate
+    // length): a malformed candidate whose length coincides with the *other*
+    // side's key would otherwise pass validation and then silently leave part
+    // of its point at zero in the fill loop below. Coordinates are validated
+    // at this public boundary so a caller-supplied proposer cannot submit
+    // out-of-domain indices.
+    for (side, (candidates, sites)) in [
+        ("left", (left_candidates, left_sites)),
+        ("right", (right_candidates, right_sites)),
+    ] {
+        for candidate in candidates {
+            ensure!(
+                candidate.len() == sites.len(),
+                "subtree key of length {} cannot be filled from {side} multi-index of length {}",
+                sites.len(),
+                candidate.len()
+            );
+            for (&site, &value) in sites.iter().zip(candidate.iter()) {
+                ensure!(
+                    value < local_dims[site],
+                    "{side} candidate value {value} out of range for site {site} with local dimension {}",
+                    local_dims[site]
+                );
+            }
         }
     }
-    let batch = assemble_points_column_major(&points)?;
-    let values = evaluate(batch.as_view())?;
+
+    let n_left = left_candidates.len();
+    let n_right = right_candidates.len();
+    let n_points = n_left.checked_mul(n_right).ok_or_else(|| {
+        anyhow::anyhow!("candidate matrix shape {n_left} x {n_right} overflows usize")
+    })?;
     ensure!(
-        values.len() == left_candidates.len() * right_candidates.len(),
+        n_sites > 0 && n_points > 0,
+        "at least one point with one site is required"
+    );
+    let data_len = n_sites
+        .checked_mul(n_points)
+        .ok_or_else(|| anyhow::anyhow!("batch size {n_sites} x {n_points} overflows usize"))?;
+
+    // Column-major (n_sites, n_points): point p occupies data[p * n_sites ..].
+    let mut data = vec![0usize; data_len];
+    let mut offset = 0;
+    for right in right_candidates {
+        for left in left_candidates {
+            let point = &mut data[offset..offset + n_sites];
+            for (&site, &value) in left_sites.iter().zip(left.iter()) {
+                point[site] = value;
+            }
+            for (&site, &value) in right_sites.iter().zip(right.iter()) {
+                point[site] = value;
+            }
+            offset += n_sites;
+        }
+    }
+
+    let values = evaluate(GlobalIndexBatch::new(&data, n_sites, n_points)?)?;
+    ensure!(
+        values.len() == n_points,
         "batch evaluator returned {} values for {} candidate-matrix entries",
         values.len(),
-        left_candidates.len() * right_candidates.len()
+        n_points
     );
     Ok(values)
 }

--- a/crates/tensor4all-treetci/src/update/tests.rs
+++ b/crates/tensor4all-treetci/src/update/tests.rs
@@ -1,6 +1,6 @@
-use super::update_edge_default;
+use super::{evaluate_candidate_matrix, update_edge_default};
 use crate::test_support::assert_scalar_close;
-use crate::{GlobalIndexBatch, TreeTCI2, TreeTciEdge, TreeTciGraph};
+use crate::{GlobalIndexBatch, SubtreeKey, TreeTCI2, TreeTciEdge, TreeTciGraph};
 use anyhow::Result;
 use tensor4all_core::ColMajorArray;
 use tensor4all_tcicore::RrLUOptions;
@@ -75,5 +75,111 @@ fn update_edge_rejects_bad_batch_length() {
         &no_truncation_options(),
     );
 
+    assert!(result.is_err());
+}
+
+#[test]
+fn evaluate_candidate_matrix_writes_points_in_column_major_order() {
+    // Unequal candidate counts, so a transposed or mis-ordered assembly shows up.
+    let n_sites = 4;
+    // Local dims large enough for the probe values (2/3 on sites 2/3).
+    let local_dims = vec![4, 4, 4, 4];
+    let left_key = SubtreeKey::new(vec![0, 1]);
+    let left_candidates = vec![vec![0, 0], vec![1, 1], vec![0, 1]];
+    let right_key = SubtreeKey::new(vec![2, 3]);
+    let right_candidates = vec![vec![2, 3], vec![1, 0]];
+
+    // Encode each point's site values into a scalar so order and values are
+    // both asserted in one shot: right candidates vary slowest (column-major).
+    let evaluate = |batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> {
+        let mut out = Vec::with_capacity(batch.n_points());
+        for p in 0..batch.n_points() {
+            let code = (0..n_sites)
+                .map(|s| batch.get(s, p).unwrap())
+                .fold(0f64, |acc, v| acc * 10.0 + v as f64);
+            out.push(code);
+        }
+        Ok(out)
+    };
+
+    let values = evaluate_candidate_matrix(
+        n_sites,
+        &left_key,
+        &left_candidates,
+        &right_key,
+        &right_candidates,
+        &local_dims,
+        evaluate,
+    )
+    .unwrap();
+
+    // right=[2,3] x left=[0,0],[1,1],[0,1], then right=[1,0] x same lefts.
+    assert_eq!(values, vec![23.0, 1123.0, 123.0, 10.0, 1110.0, 110.0]);
+}
+
+#[test]
+fn evaluate_candidate_matrix_rejects_malformed_candidate_length() {
+    // Unequal partitions: left subtree has 2 sites, right has 3. A left
+    // candidate whose length coincides with the *right* key's length is the
+    // case the previous length-based side inference got wrong: it passed
+    // validation and silently dropped the excess entry, leaving part of its
+    // point at zero.
+    let n_sites = 5;
+    let local_dims = vec![2, 2, 2, 2, 2];
+    let left_key = SubtreeKey::new(vec![0, 1]);
+    let right_key = SubtreeKey::new(vec![2, 3, 4]);
+    let right_candidates = vec![vec![1, 0, 1]];
+
+    let malformed_left = vec![vec![0, 0, 1]]; // len 3 == right key len
+    let evaluate = |_batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> { Ok(vec![1.0]) };
+    let result = evaluate_candidate_matrix(
+        n_sites,
+        &left_key,
+        &malformed_left,
+        &right_key,
+        &right_candidates,
+        &local_dims,
+        evaluate,
+    );
+    assert!(result.is_err());
+
+    // A well-formed candidate still assembles correctly.
+    let ok_left = vec![vec![0, 1]];
+    let result = evaluate_candidate_matrix(
+        n_sites,
+        &left_key,
+        &ok_left,
+        &right_key,
+        &right_candidates,
+        &local_dims,
+        |batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> {
+            Ok(vec![
+                (batch.get(0, 0).unwrap() + batch.get(4, 0).unwrap()) as f64,
+            ])
+        },
+    );
+    assert_eq!(result.unwrap(), vec![1.0]);
+}
+
+#[test]
+fn evaluate_candidate_matrix_rejects_out_of_range_coordinates() {
+    let n_sites = 4;
+    let local_dims = vec![2, 2, 2, 2];
+    let left_key = SubtreeKey::new(vec![0, 1]);
+    let right_key = SubtreeKey::new(vec![2, 3]);
+    let right_candidates = vec![vec![0, 1]];
+    let evaluate = |_batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> { Ok(vec![1.0]) };
+
+    // Value 2 is out of range for a 2-state site.
+    let bad_left = vec![vec![0, 2]];
+    let result = evaluate_candidate_matrix(
+        n_sites,
+        &left_key,
+        &bad_left,
+        &right_key,
+        &right_candidates,
+        &local_dims,
+        evaluate,
+    );
     assert!(result.is_err());
 }

--- a/docs/worklogs/2026-08-12-treetci-branching-candidate-dedup.md
+++ b/docs/worklogs/2026-08-12-treetci-branching-candidate-dedup.md
@@ -1,0 +1,104 @@
+# Work Log — 2026-08-12 treetci branching-node candidate handling (gw-rs#8)
+
+Session summary: root-caused the branching-topology slowdown reported in
+[lingrui96/gw-rs#8](https://github.com/lingrui96/gw-rs/issues/8) (Rust
+`tensor4all-treetci` up to 11x slower than the TreeTCI.jl reference at R=10
+for comb/CTTN topologies with a 3-way junction, while chain topologies stay
+faster than Julia), landed the fix in treetci, and verified it against the
+g0 benchmark.
+
+Code and documents read:
+
+- `crates/tensor4all-treetci/src/proposer.rs` (candidate de-dup)
+- `crates/tensor4all-treetci/src/update.rs` (candidate-matrix evaluation)
+- `crates/tensor4all-tcicore/src/matrixlu.rs` (rrLU pivot kernel)
+- `TreeTCI.jl/src/pivotcandidateproposer.jl`, `simpletci_tensors.jl`,
+  `simpletci_optimize.jl` (Julia reference; same cartesian candidate
+  generation, hash-based `union`, buffer-reusing `_call`)
+- `TensorCrossInterpolation.jl/src/matrixlu.jl` (Julia rrLU; same
+  complete-pivoting algorithm)
+- `gw-rs/g0/examples/cttn_profile.rs` (instrumented benchmark harness)
+
+Reference implementations considered: TreeTCI.jl / TCI.jl (behavioral
+reference), TCI.jl's `:rook` pivoting (rejected: changes pivot selection and
+Julia's own default path uses full pivoting).
+
+Decisions made:
+
+1. `union_with_history` de-duplicates through a `HashSet` instead of a linear
+   `Vec::contains` scan, preserving first-occurrence order (mirrors
+   TreeTCI.jl's `Base.union`). At a branching vertex the candidate count is
+   the *product* of two incident bond dimensions (`d * chi_1 * chi_2`, up to
+   2.9e5 at R=10) rather than `d * chi` (~1.2e3) on a chain, so the quadratic
+   term dominated the whole optimization.
+2. `update_edge` hands `evaluate_candidate_matrix`'s column-major buffer
+   directly to `Matrix::from_col_major_vec` (no `Matrix::zeros` +
+   per-element `matrix[[r, c]] = v` fill).
+3. `evaluate_candidate_matrix` writes global points straight into one
+   contiguous `(n_sites, n_points)` buffer (one allocation per edge update)
+   instead of `assemble_global_point` (one `Vec` per matrix entry) +
+   `assemble_points_column_major` (one pack copy per entry), mirroring
+   TreeTCI.jl's `_call` buffer reuse. Bipartition and candidate-length
+   validation happens once up front; the two sides are validated separately
+   (a length-based side inference could let a malformed candidate pass and
+   silently leave part of its point at zero).
+
+Alternatives rejected or deferred:
+
+- rrLU SIMD rewrite: rejected after measurement. The hot loops
+  (`submatrix_argmax_col_major`, `update_trailing_submatrix`) are
+  memory-bandwidth-bound (~36 GB/s effective, single-core bandwidth) and
+  already autovectorized by LLVM (release binary contains ~1.8e5 vector
+  instructions). A manual re/im rewrite cannot beat memory bandwidth;
+  expect ~1.0–1.3x. The real lever would be parallelizing the scan/update
+  (rayon), which is a separate decision (dependency + determinism care).
+- Changing candidate *order* to Julia's `Iterators.product` order (first key
+  fastest vs Rust's last key fastest): rejected. Order only affects
+  tie-breaking in the argmax, not the candidate *set*; changing it risks
+  shifting convergence behavior without a performance benefit. PR claim is
+  set/size equivalence with Julia, not trajectory equivalence.
+- `materialize.rs` (same per-point pattern in `fill_tensor_values`): deferred.
+  One-time per run, measured ~1% of runtime.
+
+Verification performed:
+
+- `cargo test --release -p tensor4all-tcicore -p tensor4all-treetci`: 108 +
+  41 + integration tests pass, including new tests for exact batch point
+  order with unequal candidate counts, rejection of malformed candidate
+  lengths (unequal partitions, so the length-coincides-with-other-side case
+  is exercised), rejection of out-of-range candidate coordinates, and
+  first-occurrence de-dup order with duplicates in both `values` and history.
+- g0 benchmark (gw-rs, cttn/tt at R=8/9/10, T=0.01, mu=0.5, maxbonddim 2000,
+  maxiter 50, tol 1e-4), release build, default faer backend, single thread:
+  - cttn R=10 converges identically to the reported reference (max bond 412,
+    final error 9.8e-5) — same results as before the change.
+  - Wall time: cttn R=10 191.5 s here vs 2697 s in the issue (pre-fix code,
+    O(n^2) de-dup); R=9 40.6 s vs 131.5 s in the issue; R=8 A/B on the old
+    base: 6.4 s (fixed) vs 14.2 s (O(n^2) de-dup restored). Chain `tt` R=10
+    control: 61.7 s, unchanged by the fix.
+  - Breakdown at R=10 (fixed): proposer 1.0 s (0.5%), f-eval 40 s (21%),
+    rrLU + assembly + materialize 151 s (79%). The residual is dominated by
+    the bandwidth-bound rrLU on the product-sized junction candidate matrices
+    and by per-point f-eval overhead in the g0 closure itself
+    (`site_to_physical` allocations — gw-rs side, not treetci).
+  - Re-run after the review-fix validation hardening (local-dims bounds
+    check): R=8 unchanged at 6.6 s; built-in proposer output is always
+    in-range so the added checks are no-ops on the real path.
+- Note: pre/post measurements ran on different bases (pre-fix runs on
+  `ae655a9` + uncommitted worktree; post-fix runs on `origin/main` rebased +
+  this change). The R=8 A/B isolates the de-dup effect on one base.
+
+Pre-PR checks (AGENTS.md CI-equivalent list): `cargo fmt --all -- --check`
+clean; `cargo clippy --workspace --all-targets -- -D warnings` clean;
+`cargo nextest run --release --workspace` green; `cargo doc --workspace
+--no-deps` builds.
+
+Remaining risks:
+
+- The residual junction overhead (rrLU bandwidth + f-eval per-point work in
+  downstream closures) is structural and still present; matching Julia's
+  1.47x junction overhead would need parallel rrLU and/or allocation-free
+  downstream evaluators (gw-rs side).
+- Candidate order differs from Julia's product order; tie-break-driven pivot
+  trajectories may differ between the two implementations even though
+  candidate sets and final accuracy match.


### PR DESCRIPTION
## Summary

Fixes the branching-topology slowdown reported in [lingrui96/gw-rs#8](https://github.com/lingrui96/gw-rs/issues/8): Rust `tensor4all-treetci` ran up to 11x slower than the TreeTCI.jl reference for comb/CTTN topologies (3-way junction), while chain topologies were consistently faster than Julia.

Root cause (measured, not guessed): at a branching vertex the pivot-candidate count is the **product** of two incident bond dimensions (`d·χ₁·χ₂`, up to ~2.9e5 at R=10 for the g0 CTTN benchmark) rather than `d·χ` (~1.2e3) on a chain. Two implementation details made that blow up, while Julia's identical algorithm did not:

1. **O(n²) candidate de-dup** — `union_with_history` used a linear `Vec::contains` scan; TreeTCI.jl uses hash-based `Base.union`. A/B test at R=8: restoring the linear scan costs +7.2 s of 14.2 s total.
2. **Per-point allocations** — `evaluate_candidate_matrix` built one `Vec` per matrix entry plus one pack copy; TreeTCI.jl's `_call` reuses one buffer. 254M points at R=10.

## Changes

- `proposer.rs`: hash-based de-dup preserving first-occurrence order (mirrors TreeTCI.jl's `Base.union`).
- `update.rs`: hand the column-major `values` buffer directly to `Matrix::from_col_major_vec` (no `Matrix::zeros` + per-element fill); write global points straight into one contiguous `(n_sites, n_points)` buffer (one allocation per edge update); validate bipartition, per-side candidate lengths, candidate coordinate bounds, and overflow once up front.
- New tests: exact batch point order (unequal candidate counts), malformed-length rejection (unequal partitions — exercises the case a length-based side inference got wrong), out-of-range coordinate rejection, first-occurrence de-dup order.
- `docs/worklogs/2026-08-12-treetci-branching-candidate-dedup.md`.

## Benchmark (gw-rs g0, T=0.01, mu=0.5, maxbonddim 2000, maxiter 50, tol 1e-4)

| case | issue (pre-fix) | this PR |
|---|---|---|
| cttn R=10 wall time | 2697 s | **~200 s** (191–202 s across runs) |
| cttn R=9 | 131.5 s | 40.6 s |
| cttn R=8 (A/B on one base) | 14.2 s | 6.6 s |
| tt R=10 (chain control) | 83 s | 61.7 s |

Convergence is **unchanged**: cttn R=10 max bond 412, final error 9.8e-5, identical Pi-entry counts (bit-identical work).

## What was investigated and rejected

- **rrLU SIMD rewrite**: the hot loops (`submatrix_argmax_col_major`, `update_trailing_submatrix`) are memory-bandwidth-bound (~36 GB/s effective, single-core bandwidth) and already autovectorized by LLVM. A manual rewrite cannot beat memory bandwidth. The residual junction overhead is structural (product-sized candidate matrices); parallelizing the scan/update would be the real lever and is a separate decision.
- **Candidate-order change to Julia's `Iterators.product` order**: order only affects argmax tie-breaking, not the candidate *set*; changing it risks shifting convergence without a performance benefit.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo nextest run --release --workspace` 2787 passed; `cargo doc --workspace --no-deps` builds.