### PR TITLE
refactor(core): rename TensorDynLen to IdxTensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,9 +138,9 @@ cargo nextest run --release -p crate_name        # Single crate
 
 - Private functions: `#[cfg(test)]` module in source file
 - Integration tests: `tests/` directory
-- Dense whole-result comparisons: avoid per-element re-contraction loops in tests. Materialize once to a dense tensor/matrix, then compare via tensor subtraction and `maxabs()`. `TensorDynLen` subtraction aligns indices by index semantics, so explicit axis reordering is usually unnecessary.
+- Dense whole-result comparisons: avoid per-element re-contraction loops in tests. Materialize once to a dense tensor/matrix, then compare via tensor subtraction and `maxabs()`. `IdxTensor` subtraction aligns indices by index semantics, so explicit axis reordering is usually unnecessary.
 - **Test tolerance changes**: When relaxing test tolerances (unit tests, codecov targets, etc.), always seek explicit user approval before making changes.
-- **Dense whole-result comparisons**: When comparing full tensors/operators in tests, do not recompute contractions element-by-element. Materialize once to a dense tensor/matrix, then compare via tensor subtraction and `maxabs()`. `TensorDynLen` subtraction aligns indices by index semantics, so explicit axis reordering is usually unnecessary.
+- **Dense whole-result comparisons**: When comparing full tensors/operators in tests, do not recompute contractions element-by-element. Materialize once to a dense tensor/matrix, then compare via tensor subtraction and `maxabs()`. `IdxTensor` subtraction aligns indices by index semantics, so explicit axis reordering is usually unnecessary.
 
 ### Coverage and Path Exercise
 

--- a/benchmarks/rust/benchmark_contract.rs
+++ b/benchmarks/rust/benchmark_contract.rs
@@ -10,7 +10,7 @@
 use std::time::Instant;
 use rand::rng;
 
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, Result, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
@@ -53,7 +53,7 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices);
+        let tensor = IdxTensor::random::<f64, _>(&mut rng, indices);
         tensors.push(tensor);
     }
 

--- a/benchmarks/rust/benchmark_dmrg.rs
+++ b/benchmarks/rust/benchmark_dmrg.rs
@@ -11,7 +11,7 @@ use std::hint::black_box;
 use std::time::{Duration, Instant};
 
 use tensor4all_core::krylov::HermitianLanczosOptions;
-use tensor4all_core::{DynIndex, IndexLike, SvdTruncationPolicy, TensorDynLen};
+use tensor4all_core::{DynIndex, IndexLike, SvdTruncationPolicy, IdxTensor};
 use tensor4all_tensorbackend::{lowest_hermitian_eigenpair, Matrix};
 use tensor4all_treetn::{
     compose_exclusive_linear_operators, dmrg, DmrgOptions, IndexMapping, LinearOperator, TreeTN,
@@ -84,7 +84,7 @@ fn edges_for(topology: Topology, n_sites: usize) -> Vec<(usize, usize)> {
 fn make_initial_state(
     topology: Topology,
     n_sites: usize,
-) -> anyhow::Result<(TreeTN<TensorDynLen, String>, Vec<DynIndex>)> {
+) -> anyhow::Result<(TreeTN<IdxTensor, String>, Vec<DynIndex>)> {
     let edges = edges_for(topology, n_sites);
     let sites: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
     let bonds: Vec<_> = (0..edges.len()).map(|_| DynIndex::new_dyn(1)).collect();
@@ -94,7 +94,7 @@ fn make_initial_state(
         incident[b].push((a, bonds[edge_id].clone()));
     }
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let mut graph_nodes = Vec::with_capacity(n_sites);
     for i in 0..n_sites {
         let mut indices = Vec::with_capacity(1 + incident[i].len());
@@ -110,7 +110,7 @@ fn make_initial_state(
         let mut data = vec![0.0; indices.iter().map(DynIndex::dim).product()];
         data[0] = 1.0;
         data[1] = site_one_value;
-        let tensor = TensorDynLen::from_dense(indices, data)?;
+        let tensor = IdxTensor::from_dense(indices, data)?;
         graph_nodes.push(state.add_tensor(node_name(i), tensor)?);
     }
     for (edge_id, &(a, b)) in edges.iter().enumerate() {
@@ -124,7 +124,7 @@ fn local_heisenberg_tensor(
     in_left: DynIndex,
     out_right: DynIndex,
     in_right: DynIndex,
-) -> anyhow::Result<TensorDynLen> {
+) -> anyhow::Result<IdxTensor> {
     let dims = [2, 2, 2, 2];
     let mut data = vec![0.0; dims.iter().product()];
 
@@ -142,7 +142,7 @@ fn local_heisenberg_tensor(
         }
     }
 
-    TensorDynLen::from_dense(vec![out_left, in_left, out_right, in_right], data)
+    IdxTensor::from_dense(vec![out_left, in_left, out_right, in_right], data)
         .map_err(anyhow::Error::from)
 }
 
@@ -152,7 +152,7 @@ fn make_edge_heisenberg_operator(
     state_sites: &[DynIndex],
     op_inputs: &[DynIndex],
     op_outputs: &[DynIndex],
-) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+) -> anyhow::Result<LinearOperator<IdxTensor, String>> {
     let left_name = node_name(left);
     let right_name = node_name(right);
     let local = local_heisenberg_tensor(
@@ -213,9 +213,9 @@ fn make_edge_heisenberg_operator(
 
 fn make_heisenberg_operator(
     topology: Topology,
-    state: &TreeTN<TensorDynLen, String>,
+    state: &TreeTN<IdxTensor, String>,
     state_sites: &[DynIndex],
-) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+) -> anyhow::Result<LinearOperator<IdxTensor, String>> {
     let n_sites = state_sites.len();
     let edges = edges_for(topology, n_sites);
     let op_inputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();

--- a/benchmarks/rust/benchmark_local_linsolve.rs
+++ b/benchmarks/rust/benchmark_local_linsolve.rs
@@ -18,7 +18,7 @@ use tensor4all_core::{
     index::{DynId, Index},
     krylov::{gmres, GmresOptions},
     print_and_reset_contract_profile, reset_contract_profile,
-    AnyScalar, DynIndex, IndexLike, SvdTruncationPolicy, TensorContractionLike, TensorDynLen,
+    AnyScalar, DynIndex, IndexLike, SvdTruncationPolicy, TensorContractionLike, IdxTensor,
     TensorIndex,
 };
 use tensor4all_treetn::{
@@ -58,8 +58,8 @@ fn create_state_chain(
     spectator_sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut tree = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut tree = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, state_bond_dim, rng))
         .collect();
@@ -68,7 +68,7 @@ fn create_state_chain(
     for (i, spectator_site) in spectator_sites.iter().enumerate().take(n) {
         let mut indices = chain_node_indices(n, i, &bonds, acted_sites);
         indices.insert(0, spectator_site.clone());
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(rng, indices)?;
         let node = tree.add_tensor(make_node_name(i), tensor)?;
         nodes.push(node);
     }
@@ -89,11 +89,11 @@ fn create_operator_chain(
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
-    let mut tree = TreeTN::<TensorDynLen, String>::new();
+    let mut tree = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, operator_bond_dim, rng))
         .collect();
@@ -122,7 +122,7 @@ fn create_operator_chain(
                 bonds[i].clone(),
             ]
         };
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(rng, indices)?;
         let name = make_node_name(i);
         let node = tree.add_tensor(name.clone(), tensor)?;
         nodes.push(node);
@@ -163,7 +163,7 @@ fn same_index_set(a: &[DynIndex], b: &[DynIndex]) -> bool {
             .all(|ai| b.iter().any(|bi| ai == bi && ai.dim() == bi.dim()))
 }
 
-fn align_rhs_to_init(init: &TensorDynLen, rhs: TensorDynLen) -> anyhow::Result<TensorDynLen> {
+fn align_rhs_to_init(init: &IdxTensor, rhs: IdxTensor) -> anyhow::Result<IdxTensor> {
     let init_indices = init.external_indices();
     let rhs_indices = rhs.external_indices();
     if !same_index_set(&init_indices, &rhs_indices) {
@@ -180,7 +180,7 @@ fn align_rhs_to_init(init: &TensorDynLen, rhs: TensorDynLen) -> anyhow::Result<T
     }
 }
 
-fn max_bond_dim(tree: &TreeTN<TensorDynLen, String>) -> usize {
+fn max_bond_dim(tree: &TreeTN<IdxTensor, String>) -> usize {
     tree.site_index_network()
         .edges()
         .filter_map(|(a, b)| tree.edge_between(&a, &b))
@@ -301,7 +301,7 @@ fn main() -> anyhow::Result<()> {
 
     let gmres_start = Instant::now();
     let gmres_result = gmres(
-        |x: &TensorDynLen| {
+        |x: &IdxTensor| {
             apply_count_ref.set(apply_count_ref.get() + 1);
             let apply_start = Instant::now();
             let hx = projected_operator.borrow_mut().apply(

--- a/benchmarks/rust/benchmark_partitionedtt_patching.rs
+++ b/benchmarks/rust/benchmark_partitionedtt_patching.rs
@@ -15,7 +15,7 @@ use std::hint::black_box;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_partitionedtt::{
     add_with_patching, PartitionedTT, PatchSplitStrategy, PatchingOptions, SubDomainTT,
     TensorTrain,
@@ -268,8 +268,8 @@ fn make_anisotropic_gaussian_input(options: &Options) -> Result<BenchmarkInput> 
         }
     }
 
-    let t0 = TensorDynLen::from_dense(vec![x_index.clone(), component_index.clone()], left)?;
-    let t1 = TensorDynLen::from_dense(vec![component_index, y_index.clone()], right)?;
+    let t0 = IdxTensor::from_dense(vec![x_index.clone(), component_index.clone()], left)?;
+    let t1 = IdxTensor::from_dense(vec![component_index, y_index.clone()], right)?;
     let tt = TensorTrain::new(vec![t0, t1])?;
     let dense = tt.to_dense()?.to_vec::<f64>()?;
     let reference_norm = dense.iter().map(|value| value * value).sum::<f64>().sqrt();

--- a/benchmarks/rust/benchmark_projected_apply.rs
+++ b/benchmarks/rust/benchmark_projected_apply.rs
@@ -15,7 +15,7 @@ use rand::{Rng, SeedableRng};
 use tensor4all_core::{
     index::{DynId, Index},
     print_and_reset_contract_profile, reset_contract_profile,
-    DynIndex, TensorDynLen, TensorIndex,
+    DynIndex, IdxTensor, TensorIndex,
 };
 use tensor4all_treetn::{IndexMapping, LocalUpdateSweepPlan, ProjectedOperator, TreeTN};
 
@@ -51,8 +51,8 @@ fn create_state_chain(
     spectator_sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut tree = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut tree = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, state_bond_dim, rng))
         .collect();
@@ -61,7 +61,7 @@ fn create_state_chain(
     for (i, spectator_site) in spectator_sites.iter().enumerate().take(n) {
         let mut indices = chain_node_indices(n, i, &bonds, acted_sites);
         indices.insert(0, spectator_site.clone());
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(rng, indices)?;
         let node = tree.add_tensor(make_node_name(i), tensor)?;
         nodes.push(node);
     }
@@ -82,11 +82,11 @@ fn create_operator_chain(
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
-    let mut tree = TreeTN::<TensorDynLen, String>::new();
+    let mut tree = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, operator_bond_dim, rng))
         .collect();
@@ -117,7 +117,7 @@ fn create_operator_chain(
             ]
         };
         indices.shrink_to_fit();
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(rng, indices)?;
         let name = make_node_name(i);
         let node = tree.add_tensor(name.clone(), tensor)?;
         nodes.push(node);

--- a/benchmarks/rust/benchmark_tdvp.rs
+++ b/benchmarks/rust/benchmark_tdvp.rs
@@ -14,7 +14,7 @@ use num_complex::Complex64;
 use tensor4all_core::krylov::HermitianKrylovExpmOptions;
 use tensor4all_core::{
     DynIndex, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorContractionLike,
-    TensorDynLen,
+    IdxTensor,
 };
 use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
 use tensor4all_treetn::{
@@ -24,7 +24,7 @@ use tensor4all_treetn::{
 
 const ITENSOR_CUTOFF: f64 = 1.0e-12;
 
-type BenchmarkState = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<Complex64>);
+type BenchmarkState = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<Complex64>);
 
 fn itensor_cutoff_policy() -> SvdTruncationPolicy {
     SvdTruncationPolicy::new(ITENSOR_CUTOFF)
@@ -123,7 +123,7 @@ fn make_initial_state(
         incident[b].push((a, bonds[edge_id].clone()));
     }
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let mut graph_nodes = Vec::with_capacity(n_sites);
     for i in 0..n_sites {
         let mut indices = Vec::with_capacity(1 + incident[i].len());
@@ -133,7 +133,7 @@ fn make_initial_state(
         indices.push(sites[i].clone());
         let mut data = vec![Complex64::new(0.0, 0.0); indices.iter().map(DynIndex::dim).product()];
         data[initial_bit(i)] = Complex64::new(1.0, 0.0);
-        let tensor = TensorDynLen::from_dense(indices, data)?;
+        let tensor = IdxTensor::from_dense(indices, data)?;
         graph_nodes.push(state.add_tensor(node_name(i), tensor)?);
     }
     for (edge_id, &(a, b)) in edges.iter().enumerate() {
@@ -155,7 +155,7 @@ fn local_heisenberg_tensor(
     in_left: DynIndex,
     out_right: DynIndex,
     in_right: DynIndex,
-) -> anyhow::Result<TensorDynLen> {
+) -> anyhow::Result<IdxTensor> {
     let dims = [2, 2, 2, 2];
     let mut data = vec![0.0; dims.iter().product()];
 
@@ -173,7 +173,7 @@ fn local_heisenberg_tensor(
         }
     }
 
-    TensorDynLen::from_dense(vec![out_left, in_left, out_right, in_right], data)
+    IdxTensor::from_dense(vec![out_left, in_left, out_right, in_right], data)
         .map_err(anyhow::Error::from)
 }
 
@@ -183,7 +183,7 @@ fn make_edge_heisenberg_operator(
     state_sites: &[DynIndex],
     op_inputs: &[DynIndex],
     op_outputs: &[DynIndex],
-) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+) -> anyhow::Result<LinearOperator<IdxTensor, String>> {
     let left_name = node_name(left);
     let right_name = node_name(right);
     let local = local_heisenberg_tensor(
@@ -248,9 +248,9 @@ fn make_edge_heisenberg_operator(
 
 fn make_heisenberg_operator(
     topology: Topology,
-    state: &TreeTN<TensorDynLen, String>,
+    state: &TreeTN<IdxTensor, String>,
     state_sites: &[DynIndex],
-) -> anyhow::Result<LinearOperator<TensorDynLen, String>> {
+) -> anyhow::Result<LinearOperator<IdxTensor, String>> {
     let n_sites = state_sites.len();
     let edges = edges_for(topology, n_sites);
     let op_inputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
@@ -371,7 +371,7 @@ fn exact_evolve(
 }
 
 fn state_vector(
-    state: &TreeTN<TensorDynLen, String>,
+    state: &TreeTN<IdxTensor, String>,
     sites: &[DynIndex],
 ) -> anyhow::Result<Vec<Complex64>> {
     let tensor = state.contract_to_tensor()?;

--- a/benchmarks/rust/benchmark_tensor_ops.rs
+++ b/benchmarks/rust/benchmark_tensor_ops.rs
@@ -1,4 +1,4 @@
-// Benchmark non-AD TensorDynLen vector-space operations.
+// Benchmark non-AD IdxTensor vector-space operations.
 //
 // Run:
 //   RAYON_NUM_THREADS=1 cargo run -p tensor4all-core --example benchmark_tensor_ops --release
@@ -16,7 +16,7 @@ use anyhow::{bail, Result};
 use num_complex::Complex64;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, IdxTensor};
 
 fn parse_args() -> Result<(usize, Vec<usize>)> {
     let args = std::env::args().skip(1).collect::<Vec<_>>();
@@ -58,8 +58,8 @@ fn main() -> Result<()> {
     let element_count = dims.iter().product::<usize>();
     let indices = make_indices(&dims);
     let mut rng = StdRng::seed_from_u64(0x5EED_1234);
-    let a = TensorDynLen::random::<Complex64, _>(&mut rng, indices.clone())?;
-    let b = TensorDynLen::random::<Complex64, _>(&mut rng, indices)?;
+    let a = IdxTensor::random::<Complex64, _>(&mut rng, indices.clone())?;
+    let b = IdxTensor::random::<Complex64, _>(&mut rng, indices)?;
     let alpha = AnyScalar::new_complex(0.7, -0.2);
     let beta = AnyScalar::new_complex(-0.3, 0.4);
 
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
         black_box(a.conj().contract_pair(&b)?.sum()?);
     }
 
-    println!("=== TensorDynLen non-AD tensor ops benchmark ===");
+    println!("=== IdxTensor non-AD tensor ops benchmark ===");
     println!(
         "dims={dims:?} elements={element_count} repeats={repeats} dtype=Complex64"
     );

--- a/benchmarks/rust/benchmark_tt_ops.rs
+++ b/benchmarks/rust/benchmark_tt_ops.rs
@@ -22,7 +22,7 @@ use num_complex::Complex64;
 use tensor4all_core::{
     contract, contract_pair, print_and_reset_pairwise_contract_profile,
     reset_pairwise_contract_profile, AnyScalar, DynIndex, SvdTruncationPolicy,
-    TensorContractionLike, TensorDynLen,
+    TensorContractionLike, IdxTensor,
 };
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 use tenferro::{DotGeneralConfig, Tensor, TypedTensor};
@@ -151,12 +151,12 @@ fn deterministic_value(idx: usize, seed: usize) -> Complex64 {
     Complex64::new(real, imag)
 }
 
-fn deterministic_tensor(indices: Vec<DynIndex>, seed: usize) -> Result<TensorDynLen> {
+fn deterministic_tensor(indices: Vec<DynIndex>, seed: usize) -> Result<IdxTensor> {
     let len = indices.iter().map(|index| index.size()).product::<usize>();
     let data = (0..len)
         .map(|idx| deterministic_value(idx, seed))
         .collect::<Vec<_>>();
-    TensorDynLen::from_dense(indices, data).map_err(anyhow::Error::from)
+    IdxTensor::from_dense(indices, data).map_err(anyhow::Error::from)
 }
 
 fn deterministic_native_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
@@ -418,14 +418,14 @@ fn inner_sitewise_pair_no_sim(bra: &TensorTrain, ket: &TensorTrain) -> Result<An
     env.sum().map_err(anyhow::Error::from)
 }
 
-fn preconjugate_sites(bra: &TensorTrain) -> Result<Vec<TensorDynLen>> {
+fn preconjugate_sites(bra: &TensorTrain) -> Result<Vec<IdxTensor>> {
     (0..bra.len())
         .map(|site| Ok(bra.tensor(site)?.conj()))
         .collect()
 }
 
 fn inner_sitewise_pair_preconj_no_sim(
-    bra_conj: &[TensorDynLen],
+    bra_conj: &[IdxTensor],
     ket: &TensorTrain,
 ) -> Result<AnyScalar> {
     if bra_conj.len() != ket.len() {

--- a/benchmarks/rust/inspect_hdf5_mps_inputs.rs
+++ b/benchmarks/rust/inspect_hdf5_mps_inputs.rs
@@ -5,7 +5,7 @@
 
 use std::env;
 
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_hdf5::{load_itensor, load_mps};
 use tensor4all_itensorlike::TensorTrain;
 
@@ -34,7 +34,7 @@ fn summarize(name: &str, tt: &TensorTrain) {
 }
 
 fn summarize_raw_tensor(path: &str, name: &str) -> anyhow::Result<()> {
-    let tensor: TensorDynLen = load_itensor(path, name)?;
+    let tensor: IdxTensor = load_itensor(path, name)?;
     println!("{name}.raw_dims = {:?}", tensor.dims());
     println!("{name}.raw_indices = {:?}", tensor.indices());
     Ok(())

--- a/benchmarks/rust/issue566_perf_candidates.rs
+++ b/benchmarks/rust/issue566_perf_candidates.rs
@@ -144,12 +144,12 @@ fn main() {
         let i = tensor4all_core::DynIndex::new_dyn(4);
     let j = tensor4all_core::DynIndex::new_dyn(4);
     let k = tensor4all_core::DynIndex::new_dyn(4);
-    let a = tensor4all_core::TensorDynLen::from_dense(
+    let a = tensor4all_core::IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         (0..16).map(|x| x as f64).collect(),
     )
     .unwrap();
-    let b = tensor4all_core::TensorDynLen::from_dense(
+    let b = tensor4all_core::IdxTensor::from_dense(
         vec![j, k],
         (0..16).map(|x| (x as f64) * 0.5).collect(),
     )

--- a/crates/tensor4all-capi/src/quanticstransform.rs
+++ b/crates/tensor4all-capi/src/quanticstransform.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use num_complex::Complex64;
 use num_rational::Rational64;
-use tensor4all_core::{IndexLike, TensorDynLen};
+use tensor4all_core::{IdxTensor, IndexLike};
 use tensor4all_quanticstransform::{
     affine_operator, cumsum_operator, flip_operator, phase_rotation_operator,
     quantics_fourier_operator, shift_operator, AffineParams, BoundaryCondition, FourierOptions,
@@ -243,7 +243,7 @@ fn validate_single_var_materialization_layout(
 
 fn validate_affine_materialization_layout(layout: &InternalQttLayout) -> CapiResult<()> {
     checked_allocation_len::<SourceSite>(&[layout.nsites()], "affine site list")?;
-    checked_allocation_len::<TensorDynLen>(&[layout.nsites()], "affine tensor list")?;
+    checked_allocation_len::<IdxTensor>(&[layout.nsites()], "affine tensor list")?;
     checked_allocation_len::<InternalIndex>(
         &[layout.nsites().saturating_sub(1)],
         "affine bond index list",
@@ -273,7 +273,7 @@ fn build_chain_tensor<F>(
     in_index: InternalIndex,
     right_bond: Option<InternalIndex>,
     eval: F,
-) -> CapiResult<TensorDynLen>
+) -> CapiResult<IdxTensor>
 where
     F: Fn(usize, usize, usize, usize) -> Complex64,
 {
@@ -322,7 +322,7 @@ where
         }
     }
 
-    TensorDynLen::from_dense(indices, data).map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))
+    IdxTensor::from_dense(indices, data).map_err(|err| capi_error(T4A_INVALID_ARGUMENT, err))
 }
 
 fn build_identity_site(
@@ -330,7 +330,7 @@ fn build_identity_site(
     out_index: InternalIndex,
     in_index: InternalIndex,
     right_bond: Option<InternalIndex>,
-) -> CapiResult<TensorDynLen> {
+) -> CapiResult<IdxTensor> {
     let left_dim = left_bond.as_ref().map_or(1, |idx| idx.dim());
     let right_dim = right_bond.as_ref().map_or(1, |idx| idx.dim());
     if left_dim != right_dim {
@@ -357,7 +357,7 @@ fn build_identity_site(
     )
 }
 
-fn build_treetn_from_chain(tensors: Vec<TensorDynLen>) -> CapiResult<InternalTreeTN> {
+fn build_treetn_from_chain(tensors: Vec<IdxTensor>) -> CapiResult<InternalTreeTN> {
     let mut node_names = try_vec_with_capacity::<usize>("chain node-name list", tensors.len())?;
     node_names.extend(0..tensors.len());
     InternalTreeTN::from_tensors(tensors, node_names)
@@ -452,7 +452,7 @@ fn expand_chain_with_identities(
         bond_indices.push(InternalIndex::new_dyn(dim));
     }
 
-    let mut tensors = try_vec_with_capacity::<TensorDynLen>("expanded tensor list", nsites)?;
+    let mut tensors = try_vec_with_capacity::<IdxTensor>("expanded tensor list", nsites)?;
     let mut next_source = 0usize;
     for site in 0..nsites {
         let left_bond = (site > 0).then(|| bond_indices[site - 1].clone());
@@ -509,7 +509,7 @@ fn embed_single_var_fused(
         bond_indices.push(InternalIndex::new_dyn(site.right_dim));
     }
 
-    let mut tensors = try_vec_with_capacity::<TensorDynLen>("fused tensor list", nsites)?;
+    let mut tensors = try_vec_with_capacity::<IdxTensor>("fused tensor list", nsites)?;
     for (site_idx, src) in source_sites.iter().enumerate() {
         let left_bond = (site_idx > 0).then(|| bond_indices[site_idx - 1].clone());
         let right_bond = (site_idx + 1 < nsites).then(|| bond_indices[site_idx].clone());

--- a/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
+++ b/crates/tensor4all-capi/src/quanticstransform/tests/mod.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{t4a_index, t4a_treetn_release, T4A_INVALID_ARGUMENT, T4A_NULL_POINTER, T4A_SUCCESS};
 use num_complex::Complex64;
 use num_rational::Rational64;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_quanticstransform::{
     affine_operator, cumsum_operator, flip_operator, phase_rotation_operator,
     quantics_fourier_operator, shift_operator, AffineParams, BoundaryCondition, FourierOptions,
@@ -47,7 +47,7 @@ fn decode_mixed_radix(mut flat: usize, dims: &[usize]) -> Vec<usize> {
 }
 
 fn rust_operator_matrix(
-    op: &LinearOperator<TensorDynLen, usize>,
+    op: &LinearOperator<IdxTensor, usize>,
     out_dims: &[usize],
     in_dims: &[usize],
 ) -> Vec<Complex64> {

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -5,8 +5,8 @@ use std::ffi::c_void;
 #[cfg(test)]
 use tensor4all_core::TensorStorageError;
 use tensor4all_core::{
-    DynIndex, FactorizeAlg, SingularValueMeasure, SvdTruncationPolicy, TensorDynLen,
-    ThresholdScale, TruncationRule,
+    DynIndex, FactorizeAlg, IdxTensor, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale,
+    TruncationRule,
 };
 use tensor4all_quanticstransform::BoundaryCondition as QuanticsBoundaryCondition;
 use tensor4all_tensorbackend::StorageKind;
@@ -17,7 +17,7 @@ use tensor4all_treetn::{CanonicalForm as TreeCanonicalForm, DefaultTreeTN};
 pub(crate) type InternalIndex = DynIndex;
 
 /// Internal tensor type wrapped by `t4a_tensor`.
-pub(crate) type InternalTensor = TensorDynLen;
+pub(crate) type InternalTensor = IdxTensor;
 
 /// Internal tree tensor network type wrapped by `t4a_treetn`.
 pub(crate) type InternalTreeTN = DefaultTreeTN<usize>;
@@ -82,7 +82,7 @@ pub enum t4a_scalar_kind {
 
 impl t4a_scalar_kind {
     /// Classify a tensor by the scalar family exposed through the C API.
-    pub(crate) fn from_tensor(tensor: &TensorDynLen) -> Self {
+    pub(crate) fn from_tensor(tensor: &IdxTensor) -> Self {
         if tensor.is_complex() {
             Self::C64
         } else {

--- a/crates/tensor4all-core/README.md
+++ b/crates/tensor4all-core/README.md
@@ -5,7 +5,7 @@ Core tensor library: Index system, dynamic-rank Tensor, contraction, SVD/QR/LU f
 ## Key Types
 
 - `Index` — flexible index with tags and prime levels
-- `TensorDynLen` — dynamic-rank tensor with flexible index types
+- `IdxTensor` — dynamic-rank tensor with flexible index types
 - `Storage` — compact dense/diagonal/structured snapshots for `f64` and
   `Complex64`; `f32` and `Complex32` tensors retain eager authoritative payloads
 - `contract()` / `contract_with_options()` — connected tensor-network contraction
@@ -23,7 +23,7 @@ let j = DynIndex::new_dyn(4);
 
 // Create a dense tensor
 let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data)?;
+let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data)?;
 assert_eq!(tensor.dims(), vec![3, 4]);
 
 // SVD factorization

--- a/crates/tensor4all-core/src/any_scalar.rs
+++ b/crates/tensor4all-core/src/any_scalar.rs
@@ -11,7 +11,7 @@ use num_traits::{One, Zero};
 use tenferro::DType;
 use tensor4all_tensorbackend::AnyScalar as BackendScalar;
 
-use crate::defaults::tensordynlen::TensorDynLen;
+use crate::defaults::idx_tensor::IdxTensor;
 use crate::TensorElement;
 use tensor4all_tensorbackend::{Storage, SumFromStorage};
 
@@ -135,7 +135,7 @@ enum AnyScalarTensorError {
 
 fn initialize_tensor<T: ScalarTensorElement>(
     value: T,
-) -> std::result::Result<TensorDynLen, AnyScalarTensorError> {
+) -> std::result::Result<IdxTensor, AnyScalarTensorError> {
     #[cfg(test)]
     if FORCE_ANY_SCALAR_TENSOR_INITIALIZATION_FAILURE.with(Cell::get) {
         return Err(AnyScalarTensorError::Initialization {
@@ -145,7 +145,7 @@ fn initialize_tensor<T: ScalarTensorElement>(
         });
     }
 
-    TensorDynLen::scalar(value).map_err(|source| AnyScalarTensorError::Initialization {
+    IdxTensor::scalar(value).map_err(|source| AnyScalarTensorError::Initialization {
         source: Arc::from(anyhow::Error::new(source).into_boxed_dyn_error()),
     })
 }
@@ -203,7 +203,7 @@ fn operation_error_from_anyhow(op: &'static str, source: anyhow::Error) -> anyho
 }
 
 /// Dynamic scalar compatibility wrapper for tensor4all-core.
-/// This owns a rank-0 [`TensorDynLen`] so that scalar values can participate in
+/// This owns a rank-0 [`IdxTensor`] so that scalar values can participate in
 /// the same eager autodiff graph as tensors while preserving the existing
 /// dynamic scalar API shape. The infallible scalar constructors retain a
 /// tensor-initialization failure for later fallible tensor or AD operations.
@@ -211,13 +211,13 @@ fn operation_error_from_anyhow(op: &'static str, source: anyhow::Error) -> anyho
 /// tracked-state marker when an eager operation fails.
 #[derive(Clone)]
 pub struct AnyScalar {
-    tensor: std::result::Result<TensorDynLen, AnyScalarTensorError>,
+    tensor: std::result::Result<IdxTensor, AnyScalarTensorError>,
     value: ScalarValue,
     tracks_grad: bool,
 }
 
 impl AnyScalar {
-    fn wrap_tensor(tensor: TensorDynLen) -> Result<Self> {
+    fn wrap_tensor(tensor: IdxTensor) -> Result<Self> {
         let dims = tensor.dims();
         anyhow::ensure!(
             dims.is_empty(),
@@ -233,7 +233,7 @@ impl AnyScalar {
         })
     }
 
-    fn from_tensor_result(tensor: Result<TensorDynLen>, op: &'static str) -> Result<Self> {
+    fn from_tensor_result(tensor: Result<IdxTensor>, op: &'static str) -> Result<Self> {
         let tensor = tensor.map_err(|error| operation_error_from_anyhow(op, error))?;
         Self::wrap_tensor(tensor).map_err(|error| operation_error_from_anyhow(op, error))
     }
@@ -302,7 +302,7 @@ impl AnyScalar {
     {
         let result = f(lhs.as_tensor()?.as_inner()?, rhs.as_tensor()?.as_inner()?)
             .map_err(|error| operation_error(op, error))?;
-        Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
+        Self::from_tensor_result(IdxTensor::from_inner(vec![], result), op)
     }
 
     fn from_eager_unary<E>(
@@ -315,10 +315,10 @@ impl AnyScalar {
     {
         let result =
             f(input.as_tensor()?.as_inner()?).map_err(|error| operation_error(op, error))?;
-        Self::from_tensor_result(TensorDynLen::from_inner(vec![], result), op)
+        Self::from_tensor_result(IdxTensor::from_inner(vec![], result), op)
     }
 
-    fn scalar_value_from_tensor(tensor: &TensorDynLen) -> Result<ScalarValue> {
+    fn scalar_value_from_tensor(tensor: &IdxTensor) -> Result<ScalarValue> {
         let native = tensor.as_native()?;
         match native.dtype() {
             DType::F32 => native
@@ -358,11 +358,11 @@ impl AnyScalar {
         }
     }
 
-    pub(crate) fn from_tensor(tensor: TensorDynLen) -> Result<Self> {
+    pub(crate) fn from_tensor(tensor: IdxTensor) -> Result<Self> {
         Self::wrap_tensor(tensor)
     }
 
-    pub(crate) fn as_tensor(&self) -> Result<&TensorDynLen> {
+    pub(crate) fn as_tensor(&self) -> Result<&IdxTensor> {
         self.tensor
             .as_ref()
             .map_err(|error| anyhow::Error::new(error.clone()))
@@ -576,7 +576,7 @@ impl AnyScalar {
     /// assert!(!scalar.tracks_grad());
     /// ```
     pub fn tracks_grad(&self) -> bool {
-        self.tracks_grad || self.tensor.as_ref().is_ok_and(TensorDynLen::tracks_grad)
+        self.tracks_grad || self.tensor.as_ref().is_ok_and(IdxTensor::tracks_grad)
     }
 
     /// Returns the stored gradient, if any.
@@ -1528,11 +1528,11 @@ mod tests {
     fn compact_sum_preserves_f32_and_c32_dtype_with_and_without_ad() {
         let indices = || vec![crate::DynIndex::new_dyn(2), crate::DynIndex::new_dyn(2)];
         for tensor in [
-            TensorDynLen::from_diag(indices(), vec![1.0_f32, 2.0_f32])
+            IdxTensor::from_diag(indices(), vec![1.0_f32, 2.0_f32])
                 .unwrap()
                 .sum()
                 .unwrap(),
-            TensorDynLen::from_diag(indices(), vec![1.0_f32, 2.0_f32])
+            IdxTensor::from_diag(indices(), vec![1.0_f32, 2.0_f32])
                 .unwrap()
                 .enable_grad()
                 .unwrap()
@@ -1542,14 +1542,14 @@ mod tests {
             assert!(matches!(tensor.value(), ScalarValue::F32(3.0)));
         }
         for tensor in [
-            TensorDynLen::from_diag(
+            IdxTensor::from_diag(
                 indices(),
                 vec![Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)],
             )
             .unwrap()
             .sum()
             .unwrap(),
-            TensorDynLen::from_diag(
+            IdxTensor::from_diag(
                 indices(),
                 vec![Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)],
             )

--- a/crates/tensor4all-core/src/block_tensor.rs
+++ b/crates/tensor4all-core/src/block_tensor.rs
@@ -10,17 +10,17 @@
 //! ```
 //! use tensor4all_core::block_tensor::BlockTensor;
 //! use tensor4all_core::krylov::{gmres, GmresOptions};
-//! use tensor4all_core::{DynIndex, TensorDynLen};
+//! use tensor4all_core::{DynIndex, IdxTensor};
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! let i = DynIndex::new_dyn(2);
-//! let b_block = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0])?;
-//! let zero_block = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
+//! let b_block = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0])?;
+//! let zero_block = IdxTensor::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
 //!
 //! let b = BlockTensor::new(vec![b_block], (1, 1))?;
 //! let x0 = BlockTensor::new(vec![zero_block], (1, 1))?;
 //!
-//! let apply_a = |x: &BlockTensor<TensorDynLen>| Ok(x.clone());
+//! let apply_a = |x: &BlockTensor<IdxTensor>| Ok(x.clone());
 //! let result = gmres(apply_a, &b, &x0, &GmresOptions::default())?;
 //!
 //! assert!(result.converged);
@@ -73,17 +73,17 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t1 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    /// let t2 = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 4.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    /// let t2 = IdxTensor::from_dense(vec![i.clone()], vec![3.0, 4.0]).unwrap();
     ///
     /// let bt = BlockTensor::try_new(vec![t1, t2], (2, 1)).unwrap();
     /// assert_eq!(bt.shape(), (2, 1));
     ///
     /// // Wrong number of blocks returns an error
-    /// let t3 = TensorDynLen::from_dense(vec![i], vec![5.0, 6.0]).unwrap();
+    /// let t3 = IdxTensor::from_dense(vec![i], vec![5.0, 6.0]).unwrap();
     /// assert!(BlockTensor::try_new(vec![t3], (2, 1)).is_err());
     /// ```
     pub fn try_new(
@@ -119,10 +119,10 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
     /// let bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// assert_eq!(bt.shape(), (1, 1));
     /// ```
@@ -139,11 +139,11 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let blocks: Vec<TensorDynLen> = (0..6)
-    ///     .map(|_| TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap())
+    /// let blocks: Vec<IdxTensor> = (0..6)
+    ///     .map(|_| IdxTensor::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap())
     ///     .collect();
     /// let bt = BlockTensor::new(blocks, (2, 3)).unwrap();
     /// assert_eq!(bt.shape(), (2, 3));
@@ -163,11 +163,11 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t1 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    /// let t2 = TensorDynLen::from_dense(vec![i], vec![3.0, 4.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    /// let t2 = IdxTensor::from_dense(vec![i], vec![3.0, 4.0]).unwrap();
     /// let bt = BlockTensor::new(vec![t1, t2], (2, 1)).unwrap();
     /// assert_eq!(bt.get(0, 0).unwrap().dims(), vec![2]);
     /// assert_eq!(bt.get(1, 0).unwrap().dims(), vec![2]);
@@ -186,10 +186,10 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
     /// let mut bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// let block = bt.get_mut(0, 0).unwrap();
     /// assert_eq!(block.dims(), vec![2]);
@@ -208,11 +208,11 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t1 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    /// let t2 = TensorDynLen::from_dense(vec![i], vec![3.0, 4.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    /// let t2 = IdxTensor::from_dense(vec![i], vec![3.0, 4.0]).unwrap();
     /// let bt = BlockTensor::new(vec![t1, t2], (1, 2)).unwrap();
     /// assert_eq!(bt.blocks().len(), 2);
     /// ```
@@ -226,10 +226,10 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
     /// let mut bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// assert_eq!(bt.blocks_mut().len(), 1);
     /// ```
@@ -243,10 +243,10 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
     /// let bt = BlockTensor::new(vec![t], (1, 1)).unwrap();
     /// let blocks = bt.into_blocks();
     /// assert_eq!(blocks.len(), 1);
@@ -276,13 +276,13 @@ impl<T: TensorLike> BlockTensor<T> {
     ///
     /// ```
     /// use tensor4all_core::block_tensor::BlockTensor;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// // Column vector: always valid regardless of index sharing
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
-    /// let t1 = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
-    /// let t2 = TensorDynLen::from_dense(vec![j], vec![3.0, 4.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    /// let t2 = IdxTensor::from_dense(vec![j], vec![3.0, 4.0]).unwrap();
     /// let bt = BlockTensor::new(vec![t1, t2], (2, 1)).unwrap();
     /// assert!(bt.validate_indices().is_ok());
     /// ```

--- a/crates/tensor4all-core/src/block_tensor/tests/mod.rs
+++ b/crates/tensor4all-core/src/block_tensor/tests/mod.rs
@@ -1,13 +1,13 @@
 use super::*;
-use crate::defaults::tensordynlen::TensorDynLen;
+use crate::defaults::idx_tensor::IdxTensor;
 use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::krylov::{gmres, GmresOptions};
 use crate::tensor_like::TensorContractionLike;
 
 /// Helper to create a 1D tensor (vector) with given data and shared index.
-fn make_vector_with_index(data: Vec<f64>, idx: &DynIndex) -> TensorDynLen {
-    TensorDynLen::from_dense(vec![idx.clone()], data).unwrap()
+fn make_vector_with_index(data: Vec<f64>, idx: &DynIndex) -> IdxTensor {
+    IdxTensor::from_dense(vec![idx.clone()], data).unwrap()
 }
 
 // ========================================================================
@@ -76,13 +76,13 @@ fn test_fuse_indices_delegates_to_blocks_and_preserves_shape() {
     let j = DynIndex::new_dyn(2);
     let fused = DynIndex::new_dyn(4);
     let block_a =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     let block_b =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![5.0, 6.0, 7.0, 8.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![5.0, 6.0, 7.0, 8.0]).unwrap();
     let block = BlockTensor::new(vec![block_a, block_b], (1, 2)).unwrap();
 
     let fused_block =
-        <BlockTensor<TensorDynLen> as crate::tensor_like::TensorContractionLike>::fuse_indices(
+        <BlockTensor<IdxTensor> as crate::tensor_like::TensorContractionLike>::fuse_indices(
             &block,
             &[i, j],
             fused,
@@ -123,9 +123,8 @@ fn test_gmres_identity_block() {
     let x0 = BlockTensor::new(vec![zero1, zero2], (2, 1)).unwrap();
 
     // Identity operator: A x = x
-    let apply_a = |x: &BlockTensor<TensorDynLen>| -> anyhow::Result<BlockTensor<TensorDynLen>> {
-        Ok(x.clone())
-    };
+    let apply_a =
+        |x: &BlockTensor<IdxTensor>| -> anyhow::Result<BlockTensor<IdxTensor>> { Ok(x.clone()) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -178,31 +177,30 @@ fn test_gmres_diagonal_block() {
     let diag1 = [2.0, 3.0];
     let diag2 = [4.0, 5.0];
 
-    let apply_a =
-        move |x: &BlockTensor<TensorDynLen>| -> anyhow::Result<BlockTensor<TensorDynLen>> {
-            let x1 = x.get(0, 0).unwrap();
-            let x2 = x.get(1, 0).unwrap();
+    let apply_a = move |x: &BlockTensor<IdxTensor>| -> anyhow::Result<BlockTensor<IdxTensor>> {
+        let x1 = x.get(0, 0).unwrap();
+        let x2 = x.get(1, 0).unwrap();
 
-            // Apply D1 to x1
-            let x1_data = x1.to_vec::<f64>()?;
-            let y1_data: Vec<f64> = x1_data
-                .iter()
-                .zip(diag1.iter())
-                .map(|(&xi, &di)| xi * di)
-                .collect();
-            let y1 = TensorDynLen::from_dense(x1.indices.clone(), y1_data).unwrap();
+        // Apply D1 to x1
+        let x1_data = x1.to_vec::<f64>()?;
+        let y1_data: Vec<f64> = x1_data
+            .iter()
+            .zip(diag1.iter())
+            .map(|(&xi, &di)| xi * di)
+            .collect();
+        let y1 = IdxTensor::from_dense(x1.indices.clone(), y1_data).unwrap();
 
-            // Apply D2 to x2
-            let x2_data = x2.to_vec::<f64>()?;
-            let y2_data: Vec<f64> = x2_data
-                .iter()
-                .zip(diag2.iter())
-                .map(|(&xi, &di)| xi * di)
-                .collect();
-            let y2 = TensorDynLen::from_dense(x2.indices.clone(), y2_data).unwrap();
+        // Apply D2 to x2
+        let x2_data = x2.to_vec::<f64>()?;
+        let y2_data: Vec<f64> = x2_data
+            .iter()
+            .zip(diag2.iter())
+            .map(|(&xi, &di)| xi * di)
+            .collect();
+        let y2 = IdxTensor::from_dense(x2.indices.clone(), y2_data).unwrap();
 
-            BlockTensor::new(vec![y1, y2], (2, 1)).map_err(anyhow::Error::from)
-        };
+        BlockTensor::new(vec![y1, y2], (2, 1)).map_err(anyhow::Error::from)
+    };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -257,7 +255,7 @@ fn test_gmres_upper_triangular_block() {
     let expected = BlockTensor::new(vec![expected1, expected2], (2, 1)).unwrap();
 
     // Upper triangular block operator: A = [[I, I], [0, I]]
-    let apply_a = |x: &BlockTensor<TensorDynLen>| -> anyhow::Result<BlockTensor<TensorDynLen>> {
+    let apply_a = |x: &BlockTensor<IdxTensor>| -> anyhow::Result<BlockTensor<IdxTensor>> {
         let x1 = x.get(0, 0).unwrap();
         let x2 = x.get(1, 0).unwrap();
 
@@ -325,11 +323,11 @@ fn test_isapprox_uses_trait_default_with_error_propagation() {
     assert!(TensorVectorSpace::isapprox(&a, &b, 1.0e-12, 0.0).unwrap());
 
     // A NaN block makes the default norm fail; the trait default propagates it.
-    let nan = BlockTensor::new(vec![TensorDynLen::scalar(f64::NAN).unwrap()], (1, 1)).unwrap();
+    let nan = BlockTensor::new(vec![IdxTensor::scalar(f64::NAN).unwrap()], (1, 1)).unwrap();
     assert!(TensorVectorSpace::isapprox(&nan, &a, 1.0e-12, 1.0e-12).is_err());
 
     // A shape mismatch makes the default sub fail before any norm is taken.
-    let wide = BlockTensor::new(vec![TensorDynLen::scalar(1.0).unwrap(); 2], (2, 1)).unwrap();
+    let wide = BlockTensor::new(vec![IdxTensor::scalar(1.0).unwrap(); 2], (2, 1)).unwrap();
     assert!(TensorVectorSpace::isapprox(&a, &wide, 1.0e-12, 1.0e-12).is_err());
 }
 
@@ -424,16 +422,16 @@ fn test_validate_indices_matrix_shared() {
 
     // Block (0,0): [col0_idx, row0_idx]
     let b00 =
-        TensorDynLen::from_dense(vec![col0_idx.clone(), row0_idx.clone()], vec![0.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![col0_idx.clone(), row0_idx.clone()], vec![0.0; 6]).unwrap();
     // Block (0,1): [col1_idx, row0_idx] — same row → shares row0_idx
     let b01 =
-        TensorDynLen::from_dense(vec![col1_idx.clone(), row0_idx.clone()], vec![0.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![col1_idx.clone(), row0_idx.clone()], vec![0.0; 6]).unwrap();
     // Block (1,0): [col0_idx, row1_idx] — same column → shares col0_idx
     let b10 =
-        TensorDynLen::from_dense(vec![col0_idx.clone(), row1_idx.clone()], vec![0.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![col0_idx.clone(), row1_idx.clone()], vec![0.0; 6]).unwrap();
     // Block (1,1): [col1_idx, row1_idx]
     let b11 =
-        TensorDynLen::from_dense(vec![col1_idx.clone(), row1_idx.clone()], vec![0.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![col1_idx.clone(), row1_idx.clone()], vec![0.0; 6]).unwrap();
 
     let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2)).unwrap();
     assert!(block.validate_indices().is_ok());
@@ -442,10 +440,10 @@ fn test_validate_indices_matrix_shared() {
 #[test]
 fn test_validate_indices_matrix_no_row_sharing() {
     // 2x2 matrix: all indices independent → should fail (no common indices in same row)
-    let b00 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
-    let b01 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
-    let b10 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
-    let b11 = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
+    let b00 = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
+    let b01 = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
+    let b10 = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
+    let b11 = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![0.0; 2]).unwrap();
 
     let block = BlockTensor::new(vec![b00, b01, b10, b11], (2, 2)).unwrap();
     assert!(block.validate_indices().is_err());
@@ -455,8 +453,8 @@ fn test_validate_indices_matrix_no_row_sharing() {
 fn test_validate_indices_matrix_same_id_prime_is_not_shared_index() {
     let row = DynIndex::new_dyn(2);
     let row_prime = row.prime();
-    let b00 = TensorDynLen::from_dense(vec![row], vec![0.0; 2]).unwrap();
-    let b01 = TensorDynLen::from_dense(vec![row_prime], vec![0.0; 2]).unwrap();
+    let b00 = IdxTensor::from_dense(vec![row], vec![0.0; 2]).unwrap();
+    let b01 = IdxTensor::from_dense(vec![row_prime], vec![0.0; 2]).unwrap();
 
     let block = BlockTensor::new(vec![b00, b01], (1, 2)).unwrap();
 
@@ -581,8 +579,8 @@ fn test_replace_indices() {
     let new_idx1 = DynIndex::new_dyn(2);
     let new_idx2 = DynIndex::new_dyn(3);
 
-    let b1 = TensorDynLen::from_dense(vec![idx1.clone(), idx2.clone()], vec![0.0; 6]).unwrap();
-    let b2 = TensorDynLen::from_dense(vec![idx1.clone(), idx2.clone()], vec![1.0; 6]).unwrap();
+    let b1 = IdxTensor::from_dense(vec![idx1.clone(), idx2.clone()], vec![0.0; 6]).unwrap();
+    let b2 = IdxTensor::from_dense(vec![idx1.clone(), idx2.clone()], vec![1.0; 6]).unwrap();
     let block = BlockTensor::new(vec![b1, b2], (2, 1)).unwrap();
 
     let replaced = block
@@ -671,7 +669,7 @@ fn test_contract_unsupported() {
     let b1 = make_vector_with_index(vec![1.0, 2.0], &idx);
     let block = BlockTensor::new(vec![b1], (1, 1)).unwrap();
 
-    let result = BlockTensor::<TensorDynLen>::contract(&[&block]);
+    let result = BlockTensor::<IdxTensor>::contract(&[&block]);
     assert!(result.is_err());
 }
 
@@ -680,13 +678,13 @@ fn test_diagonal_unsupported() {
     let idx1 = DynIndex::new_dyn(2);
     let idx2 = DynIndex::new_dyn(2);
 
-    let result = BlockTensor::<TensorDynLen>::diagonal(&idx1, &idx2);
+    let result = BlockTensor::<IdxTensor>::diagonal(&idx1, &idx2);
     assert!(result.is_err());
 }
 
 #[test]
 fn test_scalar_one_unsupported() {
-    let result = BlockTensor::<TensorDynLen>::scalar_one();
+    let result = BlockTensor::<IdxTensor>::scalar_one();
     assert!(result.is_err());
 }
 
@@ -694,7 +692,7 @@ fn test_scalar_one_unsupported() {
 fn test_ones_unsupported() {
     let idx = DynIndex::new_dyn(2);
 
-    let result = BlockTensor::<TensorDynLen>::ones(&[idx]);
+    let result = BlockTensor::<IdxTensor>::ones(&[idx]);
     assert!(result.is_err());
 }
 
@@ -702,6 +700,6 @@ fn test_ones_unsupported() {
 fn test_onehot_unsupported() {
     let idx = DynIndex::new_dyn(2);
 
-    let result = BlockTensor::<TensorDynLen>::onehot(&[(idx, 0)]);
+    let result = BlockTensor::<IdxTensor>::onehot(&[(idx, 0)]);
     assert!(result.is_err());
 }

--- a/crates/tensor4all-core/src/defaults/contract.rs
+++ b/crates/tensor4all-core/src/defaults/contract.rs
@@ -4,7 +4,7 @@
 //! using einsum optimization via the tensorbackend
 //! (tenferro-backed implementation).
 //!
-//! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
+//! This module works with concrete types (`DynIndex`, `IdxTensor`) only.
 //!
 //! # Main Functions
 //!
@@ -33,8 +33,8 @@ use tensor4all_tensorbackend::{einsum_native_tensors, einsum_native_tensors_owne
 
 #[cfg(test)]
 use crate::defaults::DynId;
-use crate::defaults::TensorDynLenError;
-use crate::defaults::{DynIndex, TensorDynLen};
+use crate::defaults::IdxTensorError;
+use crate::defaults::{DynIndex, IdxTensor};
 
 use crate::index_like::IndexLike;
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -184,15 +184,15 @@ impl Default for ContractionOptions<'_> {
 /// use num_complex::Complex64;
 /// use tensor4all_core::{
 ///     contract_pair, contract_pair_with_operand_options, DynIndex,
-///     PairwiseContractionOptions, TensorDynLen,
+///     PairwiseContractionOptions, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(2);
-/// let lhs = TensorDynLen::from_dense(
+/// let lhs = IdxTensor::from_dense(
 ///     vec![i.clone()],
 ///     vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -1.0)],
 /// ).unwrap();
-/// let rhs = TensorDynLen::from_dense(
+/// let rhs = IdxTensor::from_dense(
 ///     vec![i],
 ///     vec![Complex64::new(2.0, 0.5), Complex64::new(-1.0, 4.0)],
 /// ).unwrap();
@@ -279,7 +279,7 @@ impl PairwiseContractionOptions {
 /// /// failure), when indices are incompatible (a shape or index mismatch), or
 /// /// when the contraction reports a failure (a backend failure).
 ///
-pub fn contract(tensors: &[&TensorDynLen]) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+pub fn contract(tensors: &[&IdxTensor]) -> std::result::Result<IdxTensor, IdxTensorError> {
     contract_with_options(tensors, ContractionOptions::new())
 }
 
@@ -291,10 +291,10 @@ pub fn contract(tensors: &[&TensorDynLen]) -> std::result::Result<TensorDynLen, 
 /// /// when the contraction reports a failure (a backend failure).
 ///
 pub fn contract_with_options(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     options: ContractionOptions<'_>,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
-    contract_with_options_impl(tensors, options).map_err(TensorDynLenError::from)
+) -> std::result::Result<IdxTensor, IdxTensorError> {
+    contract_with_options_impl(tensors, options).map_err(IdxTensorError::from)
 }
 
 /// Contract owned tensors with the default connected-network semantics.
@@ -304,9 +304,7 @@ pub fn contract_with_options(
 /// /// failure), when indices are incompatible (a shape or index mismatch), or
 /// /// when the contraction reports a failure (a backend failure).
 ///
-pub fn contract_owned(
-    tensors: Vec<TensorDynLen>,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+pub fn contract_owned(tensors: Vec<IdxTensor>) -> std::result::Result<IdxTensor, IdxTensorError> {
     contract_owned_with_options(tensors, ContractionOptions::new())
 }
 
@@ -318,24 +316,24 @@ pub fn contract_owned(
 /// /// when the contraction reports a failure (a backend failure).
 ///
 pub fn contract_owned_with_options(
-    tensors: Vec<TensorDynLen>,
+    tensors: Vec<IdxTensor>,
     options: ContractionOptions<'_>,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+) -> std::result::Result<IdxTensor, IdxTensorError> {
     let tensor_refs = tensors.iter().collect::<Vec<_>>();
     let components =
         find_tensor_connected_components_with_retained(&tensor_refs, options.retain_indices);
     if components.len() > 1 {
-        return Err(TensorDynLenError::from(anyhow::anyhow!(
+        return Err(IdxTensorError::from(anyhow::anyhow!(
             "Tensors form disconnected components; use explicit outer_product operations for an intentional disconnected product"
         )));
     }
     drop(tensor_refs);
-    contract_owned_with_options_impl(tensors, options).map_err(TensorDynLenError::from)
+    contract_owned_with_options_impl(tensors, options).map_err(IdxTensorError::from)
 }
 
 /// Contract two tensors with the default pairwise semantics.
 ///
-/// This is the concrete `TensorDynLen` entry point for binary contraction. It
+/// This is the concrete `IdxTensor` entry point for binary contraction. It
 /// contracts all common indices and preserves the pairwise structured fast
 /// paths used by [`TensorContractionLike::contract_pair`].
 /// # Errors
@@ -345,11 +343,11 @@ pub fn contract_owned_with_options(
 /// /// backend failure).
 ///
 pub fn contract_pair(
-    lhs: &TensorDynLen,
-    rhs: &TensorDynLen,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+    lhs: &IdxTensor,
+    rhs: &IdxTensor,
+) -> std::result::Result<IdxTensor, IdxTensorError> {
     lhs.try_contract_pairwise_default_with_options(rhs, PairwiseContractionOptions::new())
-        .map_err(TensorDynLenError::from)
+        .map_err(IdxTensorError::from)
 }
 
 /// Contract two tensors with operand-level conjugation options.
@@ -371,15 +369,15 @@ pub fn contract_pair(
 /// use num_complex::Complex64;
 /// use tensor4all_core::{
 ///     contract_pair, contract_pair_with_operand_options, DynIndex,
-///     PairwiseContractionOptions, TensorDynLen,
+///     PairwiseContractionOptions, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(2);
-/// let lhs = TensorDynLen::from_dense(
+/// let lhs = IdxTensor::from_dense(
 ///     vec![i.clone()],
 ///     vec![Complex64::new(1.0, 1.0), Complex64::new(0.0, 2.0)],
 /// ).unwrap();
-/// let rhs = TensorDynLen::from_dense(
+/// let rhs = IdxTensor::from_dense(
 ///     vec![i],
 ///     vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, -1.0)],
 /// ).unwrap();
@@ -394,12 +392,12 @@ pub fn contract_pair(
 /// assert!((flagged.sum().unwrap() - materialized.sum().unwrap()).abs() < 1e-12);
 /// ```
 pub fn contract_pair_with_operand_options(
-    lhs: &TensorDynLen,
-    rhs: &TensorDynLen,
+    lhs: &IdxTensor,
+    rhs: &IdxTensor,
     options: PairwiseContractionOptions,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+) -> std::result::Result<IdxTensor, IdxTensorError> {
     lhs.try_contract_pairwise_default_with_options(rhs, options)
-        .map_err(TensorDynLenError::from)
+        .map_err(IdxTensorError::from)
 }
 
 /// Contract two tensors with explicit contraction options.
@@ -410,10 +408,10 @@ pub fn contract_pair_with_operand_options(
 /// /// backend failure).
 ///
 pub fn contract_pair_with_options(
-    lhs: &TensorDynLen,
-    rhs: &TensorDynLen,
+    lhs: &IdxTensor,
+    rhs: &IdxTensor,
     options: ContractionOptions<'_>,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+) -> std::result::Result<IdxTensor, IdxTensorError> {
     contract_with_options(&[lhs, rhs], options)
 }
 
@@ -424,12 +422,12 @@ pub fn contract_pair_with_options(
 /// /// index mismatch) or the contraction reports a failure (a backend failure).
 ///
 pub fn tensordot(
-    lhs: &TensorDynLen,
-    rhs: &TensorDynLen,
+    lhs: &IdxTensor,
+    rhs: &IdxTensor,
     pairs: &[(DynIndex, DynIndex)],
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+) -> std::result::Result<IdxTensor, IdxTensorError> {
     lhs.try_tensordot_pairwise_explicit(rhs, pairs)
-        .map_err(TensorDynLenError::from)
+        .map_err(IdxTensorError::from)
 }
 
 /// Compute the outer product of two tensors.
@@ -443,11 +441,11 @@ pub fn tensordot(
 /// /// failure).
 ///
 pub fn outer_product(
-    lhs: &TensorDynLen,
-    rhs: &TensorDynLen,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
+    lhs: &IdxTensor,
+    rhs: &IdxTensor,
+) -> std::result::Result<IdxTensor, IdxTensorError> {
     lhs.try_outer_product_pairwise(rhs)
-        .map_err(TensorDynLenError::from)
+        .map_err(IdxTensorError::from)
 }
 
 /// Contract multiple owned tensors into a single tensor.
@@ -459,9 +457,9 @@ pub fn outer_product(
 /// path, this function falls back to the shared borrowed execution so semantics
 /// and reverse-mode AD remain intact.
 fn contract_owned_with_options_impl(
-    tensors: Vec<TensorDynLen>,
+    tensors: Vec<IdxTensor>,
     options: ContractionOptions<'_>,
-) -> Result<TensorDynLen> {
+) -> Result<IdxTensor> {
     match tensors.len() {
         0 => Err(anyhow::anyhow!("No tensors to contract")),
         _ => {
@@ -511,7 +509,7 @@ fn contract_owned_with_options_impl(
                 })
                 .collect::<Result<Vec<_>>>()?;
             let result_native = einsum_native_tensors_owned(native_operands, &plan.output_ids)?;
-            TensorDynLen::from_native_with_axis_classes(
+            IdxTensor::from_native_with_axis_classes(
                 plan.result_indices,
                 result_native,
                 plan.result_axis_classes,
@@ -520,7 +518,7 @@ fn contract_owned_with_options_impl(
     }
 }
 
-fn has_dense_axis_classes(tensor: &TensorDynLen) -> Result<bool> {
+fn has_dense_axis_classes(tensor: &IdxTensor) -> Result<bool> {
     Ok(tensor
         .axis_classes()
         .iter()
@@ -529,9 +527,9 @@ fn has_dense_axis_classes(tensor: &TensorDynLen) -> Result<bool> {
 }
 
 fn contract_with_options_impl(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     options: ContractionOptions<'_>,
-) -> Result<TensorDynLen> {
+) -> Result<IdxTensor> {
     match tensors.len() {
         0 => Err(anyhow::anyhow!("No tensors to contract")),
         _ => {
@@ -559,7 +557,7 @@ fn contract_with_options_impl(
             let has_grad = tensors.iter().any(|tensor| tensor.tracks_grad());
             if has_structured_storage || has_grad {
                 let plan = build_contraction_plan(tensors, options)?;
-                return TensorDynLen::contract_structured_payloads_nary(
+                return IdxTensor::contract_structured_payloads_nary(
                     tensors,
                     plan.result_indices,
                     plan.input_ids,
@@ -672,10 +670,7 @@ impl Default for AxisUnionFind {
 /// Returns a vector of remapped IDs for each tensor, suitable for passing
 /// to einsum. The original tensors are not modified.
 #[cfg(test)]
-pub(crate) fn remap_tensor_ids(
-    tensors: &[&TensorDynLen],
-    uf: &mut AxisUnionFind,
-) -> Vec<Vec<DynId>> {
+pub(crate) fn remap_tensor_ids(tensors: &[&IdxTensor], uf: &mut AxisUnionFind) -> Vec<Vec<DynId>> {
     tensors
         .iter()
         .map(|t| t.indices.iter().map(|idx| uf.find(*idx.id())).collect())
@@ -694,7 +689,7 @@ pub(crate) fn remap_output_ids(output: &[DynIndex], uf: &mut AxisUnionFind) -> V
 /// so we just take the first occurrence.
 #[cfg(test)]
 pub(crate) fn collect_sizes(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     uf: &mut AxisUnionFind,
 ) -> HashMap<DynId, usize> {
     let mut sizes = HashMap::new();
@@ -722,10 +717,7 @@ pub(crate) fn collect_sizes(
 ///
 /// The result keeps the common eager dtype across `f32`, `f64`, `c32`, and
 /// `c64` operands, using the backend's normal mixed-dtype promotion rules.
-fn contract_impl(
-    tensors: &[&TensorDynLen],
-    options: ContractionOptions<'_>,
-) -> Result<TensorDynLen> {
+fn contract_impl(tensors: &[&IdxTensor], options: ContractionOptions<'_>) -> Result<IdxTensor> {
     // 1. Build the contraction plan from internal labels.
     let plan = build_contraction_plan(tensors, options)?;
 
@@ -779,10 +771,10 @@ fn contract_impl(
 }
 
 fn execute_contraction_plan(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     plan: &ContractionPlan,
     has_retained_indices: bool,
-) -> Result<TensorDynLen> {
+) -> Result<IdxTensor> {
     let any_grad = tensors.iter().any(|tensor| tensor.tracks_grad());
     let first_dtype = tensors[0].as_native()?.dtype();
     let same_dtype = tensors
@@ -830,7 +822,7 @@ fn execute_contraction_plan(
             .collect::<Result<Vec<_>>>()?;
         let subscripts = build_einsum_subscripts_from_usize_ids(&plan.input_ids, &plan.output_ids)?;
         let result = eager_einsum_ad(&operands, &subscripts)?;
-        return TensorDynLen::from_inner_with_axis_classes(
+        return IdxTensor::from_inner_with_axis_classes(
             plan.result_indices.clone(),
             result,
             plan.result_axis_classes.clone(),
@@ -845,7 +837,7 @@ fn execute_contraction_plan(
         })
         .collect::<Result<Vec<_>>>()?;
     let result_native = einsum_native_tensors(&native_operands, &plan.output_ids)?;
-    TensorDynLen::from_native_with_axis_classes(
+    IdxTensor::from_native_with_axis_classes(
         plan.result_indices.clone(),
         result_native,
         plan.result_axis_classes.clone(),
@@ -887,7 +879,7 @@ struct ContractionPlan {
 }
 
 fn build_contraction_plan(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     options: ContractionOptions<'_>,
 ) -> Result<ContractionPlan> {
     let retained_indices: HashSet<DynIndex> = options.retain_indices.iter().cloned().collect();
@@ -945,7 +937,7 @@ fn build_contraction_plan(
 }
 
 fn validate_retained_indices_exist(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     retain_indices: &[DynIndex],
 ) -> Result<()> {
     for retain in retain_indices {
@@ -975,7 +967,7 @@ fn validate_unique_output_indices(indices: &[DynIndex]) -> Result<()> {
 }
 
 fn output_axis_classes(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     ixs: &[Vec<usize>],
     output: &[usize],
     internal_id_to_original: &HashMap<usize, (usize, usize)>,
@@ -1057,7 +1049,7 @@ fn output_axis_classes(
 /// Returns: (ixs, internal_id_to_original)
 #[allow(clippy::type_complexity)]
 fn build_internal_ids(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     retained_indices: &HashSet<DynIndex>,
 ) -> Result<(Vec<Vec<usize>>, HashMap<usize, (usize, usize)>)> {
     let mut next_id = 0usize;
@@ -1154,7 +1146,7 @@ fn build_internal_ids(
 // ============================================================================
 
 /// Check if two tensors have any contractable indices.
-fn has_contractable_indices(a: &TensorDynLen, b: &TensorDynLen) -> bool {
+fn has_contractable_indices(a: &IdxTensor, b: &IdxTensor) -> bool {
     a.indices
         .iter()
         .any(|idx_a| b.indices.iter().any(|idx_b| idx_a.is_contractable(idx_b)))
@@ -1164,12 +1156,12 @@ fn has_contractable_indices(a: &TensorDynLen, b: &TensorDynLen) -> bool {
 ///
 /// Uses petgraph for O(V+E) connected component detection.
 #[allow(dead_code)]
-fn find_tensor_connected_components(tensors: &[&TensorDynLen]) -> Vec<Vec<usize>> {
+fn find_tensor_connected_components(tensors: &[&IdxTensor]) -> Vec<Vec<usize>> {
     find_tensor_connected_components_with_retained(tensors, &[])
 }
 
 fn find_tensor_connected_components_with_retained(
-    tensors: &[&TensorDynLen],
+    tensors: &[&IdxTensor],
     retain_indices: &[DynIndex],
 ) -> Vec<Vec<usize>> {
     let n = tensors.len();
@@ -1234,7 +1226,7 @@ fn find_tensor_connected_components_with_retained(
     components
 }
 
-fn shares_retained_index(a: &TensorDynLen, b: &TensorDynLen, retain_indices: &[DynIndex]) -> bool {
+fn shares_retained_index(a: &IdxTensor, b: &IdxTensor, retain_indices: &[DynIndex]) -> bool {
     retain_indices.iter().any(|retain| {
         a.indices().iter().any(|idx_a| idx_a == retain)
             && b.indices().iter().any(|idx_b| idx_b == retain)

--- a/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/contract/tests/mod.rs
@@ -33,7 +33,7 @@ impl Drop for ScopedEnvVar {
     }
 }
 
-fn make_test_tensor(shape: &[usize], ids: &[u64]) -> TensorDynLen {
+fn make_test_tensor(shape: &[usize], ids: &[u64]) -> IdxTensor {
     let indices: Vec<DynIndex> = ids
         .iter()
         .zip(shape.iter())
@@ -43,17 +43,17 @@ fn make_test_tensor(shape: &[usize], ids: &[u64]) -> TensorDynLen {
     let data: Vec<Complex64> = (0..total_size)
         .map(|i| Complex64::new(i as f64, 0.0))
         .collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 fn make_test_tensor_from_data(
     shape: &[usize],
     indices: Vec<DynIndex>,
     data: Vec<f64>,
-) -> TensorDynLen {
+) -> IdxTensor {
     assert_eq!(shape.iter().product::<usize>(), data.len());
     assert_eq!(shape.len(), indices.len());
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 fn col_major_offset(coords: &[usize], dims: &[usize]) -> usize {
@@ -73,7 +73,7 @@ fn col_major_offset(coords: &[usize], dims: &[usize]) -> usize {
 
 #[test]
 fn test_contract_empty() {
-    let tensors: Vec<&TensorDynLen> = vec![];
+    let tensors: Vec<&IdxTensor> = vec![];
     let result = contract(&tensors);
     assert!(result.is_err());
 }
@@ -99,8 +99,8 @@ fn test_contract_default_entry_rejects_disconnected_inputs() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j], vec![3.0_f64, 4.0, 5.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![j], vec![3.0_f64, 4.0, 5.0]).unwrap();
 
     let err = contract(&[&a, &b]).unwrap_err();
     assert!(err.to_string().contains("Disconnected"));
@@ -112,8 +112,8 @@ fn test_contract_same_id_different_tags_is_disconnected() {
     let site = Index::new_with_tags(id, 2, TagSet::from_str("site").unwrap());
     let link = Index::new_with_tags(id, 2, TagSet::from_str("link").unwrap());
 
-    let a = TensorDynLen::from_dense(vec![site], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![link], vec![3.0_f64, 4.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![site], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![link], vec![3.0_f64, 4.0]).unwrap();
 
     let err = contract(&[&a, &b]).unwrap_err();
     assert!(err.to_string().contains("Disconnected"));
@@ -124,8 +124,8 @@ fn test_outer_product_is_explicit_disconnected_entry() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j.clone()], vec![3.0_f64, 4.0, 5.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![j.clone()], vec![3.0_f64, 4.0, 5.0]).unwrap();
 
     let result = outer_product(&a, &b).unwrap();
     assert_eq!(result.indices(), &[i, j]);
@@ -140,8 +140,8 @@ fn test_contract_owned_rejects_disconnected_inputs() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
 
-    let a = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j], vec![3.0_f64, 4.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![j], vec![3.0_f64, 4.0]).unwrap();
 
     let err = contract_owned(vec![a, b]).unwrap_err();
     assert!(err.to_string().contains("disconnected"));
@@ -153,8 +153,8 @@ fn test_contract_diag_diag_partial_preserves_diagonal_storage() {
     let j = Index::new(DynId(2), 3);
     let k = Index::new(DynId(3), 3);
 
-    let a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0]).unwrap();
-    let b = TensorDynLen::from_diag(vec![j, k.clone()], vec![4.0_f64, 5.0, 6.0]).unwrap();
+    let a = IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = IdxTensor::from_diag(vec![j, k.clone()], vec![4.0_f64, 5.0, 6.0]).unwrap();
 
     let result = contract(&[&a, &b]).unwrap();
 
@@ -165,7 +165,7 @@ fn test_contract_diag_diag_partial_preserves_diagonal_storage() {
         StorageKind::Diagonal
     );
 
-    let expected = TensorDynLen::from_diag(vec![i, k], vec![4.0_f64, 10.0, 18.0]).unwrap();
+    let expected = IdxTensor::from_diag(vec![i, k], vec![4.0_f64, 10.0, 18.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -504,8 +504,8 @@ fn test_contract_owned_with_options_falls_back_for_structured_storage() {
     let j = Index::new(DynId(77), 3);
     let k = Index::new(DynId(78), 3);
 
-    let a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0]).unwrap();
-    let b = TensorDynLen::from_diag(vec![j, k.clone()], vec![4.0_f64, 5.0, 6.0]).unwrap();
+    let a = IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = IdxTensor::from_diag(vec![j, k.clone()], vec![4.0_f64, 5.0, 6.0]).unwrap();
     let options = ContractionOptions::new();
 
     let owned = contract_owned_with_options(vec![a.clone(), b.clone()], options).unwrap();
@@ -517,7 +517,7 @@ fn test_contract_owned_with_options_falls_back_for_structured_storage() {
         StorageKind::Diagonal
     );
     assert!(owned.isapprox(&borrowed, 1e-12, 0.0).unwrap());
-    let expected = TensorDynLen::from_diag(vec![i, k], vec![4.0_f64, 10.0, 18.0]).unwrap();
+    let expected = IdxTensor::from_diag(vec![i, k], vec![4.0_f64, 10.0, 18.0]).unwrap();
     assert!(owned.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -586,7 +586,7 @@ fn test_contract_owned_with_options_falls_back_to_borrowed_for_grad_tensors() {
     let options = ContractionOptions::new().with_retain_indices(&retain_indices);
     let owned = contract_owned_with_options(vec![x.clone(), y], options).unwrap();
 
-    let ones = TensorDynLen::from_dense(owned.indices().to_vec(), vec![1.0; 8]).unwrap();
+    let ones = IdxTensor::from_dense(owned.indices().to_vec(), vec![1.0; 8]).unwrap();
     let loss = contract(&[&owned, &ones]).unwrap();
     loss.backward().unwrap();
 
@@ -597,7 +597,7 @@ fn test_contract_owned_with_options_falls_back_to_borrowed_for_grad_tensors() {
 
 #[test]
 fn test_find_tensor_connected_components_trivial_cases() {
-    let empty: Vec<&TensorDynLen> = Vec::new();
+    let empty: Vec<&IdxTensor> = Vec::new();
     assert!(find_tensor_connected_components(&empty).is_empty());
 
     let a = make_test_tensor(&[2, 3], &[1, 2]);
@@ -1015,7 +1015,7 @@ fn test_remap_preserves_order() {
 // dense contract tests
 // ========================================================================
 
-fn make_dense_tensor(shape: &[usize], ids: &[u64]) -> TensorDynLen {
+fn make_dense_tensor(shape: &[usize], ids: &[u64]) -> IdxTensor {
     let indices: Vec<DynIndex> = ids
         .iter()
         .zip(shape.iter())
@@ -1025,12 +1025,12 @@ fn make_dense_tensor(shape: &[usize], ids: &[u64]) -> TensorDynLen {
     let data: Vec<Complex64> = (0..total_size)
         .map(|i| Complex64::new((i + 1) as f64, 0.0))
         .collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 #[test]
 fn test_contract_empty_dense_entry() {
-    let tensors: Vec<&TensorDynLen> = vec![];
+    let tensors: Vec<&IdxTensor> = vec![];
     let result = contract(&tensors);
     assert!(result.is_err());
 }

--- a/crates/tensor4all-core/src/defaults/direct_sum.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum.rs
@@ -4,12 +4,12 @@
 //! along specified index pairs. The direct sum concatenates tensor data along
 //! the paired indices, creating new indices with combined dimensions.
 //!
-//! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
+//! This module works with concrete types (`DynIndex`, `IdxTensor`) only.
 
 use crate::defaults::DynIndex;
-use crate::defaults::TensorDynLenError;
+use crate::defaults::IdxTensorError;
 use crate::index_like::IndexLike;
-use crate::tensor::TensorDynLen;
+use crate::tensor::IdxTensor;
 use anyhow::Result;
 use num_traits::Zero;
 use tensor4all_tensorbackend::TensorElement;
@@ -42,14 +42,14 @@ use tensor4all_tensorbackend::TensorElement;
 /// # Example
 ///
 /// ```
-/// use tensor4all_core::{direct_sum, DynIndex, TensorDynLen};
+/// use tensor4all_core::{direct_sum, DynIndex, IdxTensor};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let j = DynIndex::new_dyn(2);
 /// let k = DynIndex::new_dyn(3);
 ///
-/// let a = TensorDynLen::from_dense(vec![j.clone()], vec![1.0, 2.0])?;
-/// let b = TensorDynLen::from_dense(vec![k.clone()], vec![3.0, 4.0, 5.0])?;
+/// let a = IdxTensor::from_dense(vec![j.clone()], vec![1.0, 2.0])?;
+/// let b = IdxTensor::from_dense(vec![k.clone()], vec![3.0, 4.0, 5.0])?;
 /// let (result, new_indices) = direct_sum(&a, &b, &[(j.clone(), k.clone())])?;
 ///
 /// assert_eq!(new_indices.len(), 1);
@@ -58,16 +58,16 @@ use tensor4all_tensorbackend::TensorElement;
 /// # }
 /// ```
 pub fn direct_sum(
-    a: &TensorDynLen,
-    b: &TensorDynLen,
+    a: &IdxTensor,
+    b: &IdxTensor,
     pairs: &[(DynIndex, DynIndex)],
-) -> std::result::Result<(TensorDynLen, Vec<DynIndex>), TensorDynLenError> {
+) -> std::result::Result<(IdxTensor, Vec<DynIndex>), IdxTensorError> {
     if a.is_f64() && b.is_f64() {
-        direct_sum_typed::<f64>(a, b, pairs).map_err(TensorDynLenError::from)
+        direct_sum_typed::<f64>(a, b, pairs).map_err(IdxTensorError::from)
     } else if a.is_complex() && b.is_complex() {
-        direct_sum_typed::<num_complex::Complex64>(a, b, pairs).map_err(TensorDynLenError::from)
+        direct_sum_typed::<num_complex::Complex64>(a, b, pairs).map_err(IdxTensorError::from)
     } else {
-        Err(TensorDynLenError::Operation {
+        Err(IdxTensorError::Operation {
             operation: "direct_sum",
             source: std::sync::Arc::new(std::io::Error::other(
                 "direct_sum requires both tensors to have the same dense scalar type (f64 or Complex64)",
@@ -96,8 +96,8 @@ struct DirectSumSetup {
 }
 
 fn setup_direct_sum(
-    a: &TensorDynLen,
-    b: &TensorDynLen,
+    a: &IdxTensor,
+    b: &IdxTensor,
     pairs: &[(DynIndex, DynIndex)],
 ) -> Result<DirectSumSetup> {
     use std::collections::HashMap;
@@ -259,10 +259,10 @@ fn multi_to_linear(multi: &[usize], strides: &[usize]) -> usize {
 }
 
 fn direct_sum_typed<T: TensorElement + Zero>(
-    a: &TensorDynLen,
-    b: &TensorDynLen,
+    a: &IdxTensor,
+    b: &IdxTensor,
     pairs: &[(DynIndex, DynIndex)],
-) -> Result<(TensorDynLen, Vec<DynIndex>)> {
+) -> Result<(IdxTensor, Vec<DynIndex>)> {
     let setup = setup_direct_sum(a, b, pairs)?;
     let a_data = a.to_vec::<T>()?;
     let b_data = b.to_vec::<T>()?;
@@ -310,7 +310,7 @@ fn direct_sum_typed<T: TensorElement + Zero>(
         // else: mixed case stays T::zero()
     }
 
-    let result = TensorDynLen::from_dense(setup.result_indices, result_data)?;
+    let result = IdxTensor::from_dense(setup.result_indices, result_data)?;
     Ok((result, setup.new_indices))
 }
 

--- a/crates/tensor4all-core/src/defaults/direct_sum/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/direct_sum/tests/mod.rs
@@ -9,7 +9,7 @@ fn test_direct_sum_simple() {
     let k = DynIndex::new_dyn(4);
 
     // A[i, j] - 2x3 tensor
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![
             1.0, 2.0, 3.0, // i=0
@@ -19,7 +19,7 @@ fn test_direct_sum_simple() {
     .unwrap();
 
     // B[i, k] - 2x4 tensor
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![i.clone(), k.clone()],
         vec![
             10.0, 20.0, 30.0, 40.0, // i=0
@@ -56,10 +56,10 @@ fn test_direct_sum_multiple_pairs() {
     let l = DynIndex::new_dyn(3);
 
     // A[i, j] - 2x2 tensor
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     // B[k, l] - 3x3 tensor (no common indices)
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![k.clone(), l.clone()],
         vec![10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0],
     )
@@ -84,12 +84,12 @@ fn test_direct_sum_preserves_same_id_prime_pair_common_indices() {
     let j_a = DynIndex::new_dyn(2);
     let j_b = DynIndex::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone(), i_prime.clone(), j_a.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
     )
     .unwrap();
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![i.clone(), i_prime.clone(), j_b.clone()],
         vec![
             10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0, 120.0,
@@ -120,7 +120,7 @@ fn test_direct_sum_c64() {
     let k = DynIndex::new_dyn(3);
 
     // A[i, j] - 2x2 complex tensor
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![
             Complex64::new(1.0, 0.5),
@@ -132,7 +132,7 @@ fn test_direct_sum_c64() {
     .unwrap();
 
     // B[i, k] - 2x3 complex tensor
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![i.clone(), k.clone()],
         vec![
             Complex64::new(10.0, 0.1),
@@ -172,8 +172,8 @@ fn test_direct_sum_mixed_types_error() {
     let j = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
-    let b = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
+    let b = IdxTensor::from_dense(
         vec![i.clone(), k.clone()],
         vec![Complex64::new(1.0, 0.0); 6],
     )
@@ -190,8 +190,8 @@ fn test_direct_sum_empty_pairs_error() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64; 6]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64; 6]).unwrap();
 
     let result = direct_sum(&a, &b, &[]);
     assert!(result.is_err());
@@ -206,8 +206,8 @@ fn test_direct_sum_index_not_in_first_tensor_error() {
     let k = DynIndex::new_dyn(3);
     let phantom = DynIndex::new_dyn(3); // not in either tensor
 
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone(), k.clone()], vec![2.0_f64; 6]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone(), k.clone()], vec![2.0_f64; 6]).unwrap();
 
     // phantom is not in tensor a
     let result = direct_sum(&a, &b, &[(phantom.clone(), k.clone())]);
@@ -223,8 +223,8 @@ fn test_direct_sum_index_not_in_second_tensor_error() {
     let k = DynIndex::new_dyn(3);
     let phantom = DynIndex::new_dyn(3); // not in either tensor
 
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone(), k.clone()], vec![2.0_f64; 6]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone(), k.clone()], vec![2.0_f64; 6]).unwrap();
 
     // phantom is not in tensor b
     let result = direct_sum(&a, &b, &[(j.clone(), phantom.clone())]);
@@ -248,8 +248,8 @@ fn test_direct_sum_common_index_dimension_mismatch_error() {
     // This requires indices that share the same ID but different dims,
     // which is not directly possible with DynIndex::new_dyn.
     // We'll just verify the happy path with matching common indices works.
-    let a = TensorDynLen::from_dense(vec![i_a.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i_b.clone(), k.clone()], vec![2.0_f64; 8]).unwrap();
+    let a = IdxTensor::from_dense(vec![i_a.clone(), j.clone()], vec![1.0_f64; 6]).unwrap();
+    let b = IdxTensor::from_dense(vec![i_b.clone(), k.clone()], vec![2.0_f64; 8]).unwrap();
 
     // No common indices (i_a and i_b have different ids), so no mismatch possible
     // Both indices are paired

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -5,18 +5,18 @@
 //!
 //! # Note
 //!
-//! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
+//! This module works with concrete types (`DynIndex`, `IdxTensor`) only.
 //! Generic tensor types are not supported.
 //!
 //! # Example
 //!
 //! ```
-//! use tensor4all_core::{factorize, Canonical, DynIndex, FactorizeOptions, TensorDynLen, TensorLike};
+//! use tensor4all_core::{factorize, Canonical, DynIndex, FactorizeOptions, IdxTensor, TensorLike};
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! let i = DynIndex::new_dyn(2);
 //! let j = DynIndex::new_dyn(2);
-//! let tensor = TensorDynLen::from_dense(
+//! let tensor = IdxTensor::from_dense(
 //!     vec![i.clone(), j.clone()],
 //!     vec![1.0, 0.0, 0.0, 1.0],
 //! )?;
@@ -32,9 +32,9 @@
 //! # }
 //! ```
 
-use crate::defaults::tensordynlen::unfold_split_inner;
+use crate::defaults::idx_tensor::unfold_split_inner;
 use crate::defaults::DynIndex;
-use crate::{contract_pair, unfold_split, TensorDynLen};
+use crate::{contract_pair, unfold_split, IdxTensor};
 use anyhow::Result as AnyhowResult;
 use num_complex::{Complex64, ComplexFloat};
 use tenferro_ad::EagerTensor;
@@ -78,10 +78,10 @@ pub use crate::tensor_like::{
 /// - QR is used with `Canonical::Right`
 /// - The underlying algorithm fails
 pub fn factorize(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     options.validate()?;
 
     if t.is_diag() {
@@ -126,12 +126,12 @@ pub fn factorize(
 ///
 /// ```
 /// use tensor4all_core::{
-///     factorize_full_rank, Canonical, DynIndex, FactorizeAlg, TensorContractionLike, TensorDynLen,
+///     factorize_full_rank, Canonical, DynIndex, FactorizeAlg, TensorContractionLike, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(2);
-/// let tensor = TensorDynLen::from_dense(
+/// let tensor = IdxTensor::from_dense(
 ///     vec![i.clone(), j.clone()],
 ///     vec![1.0_f64, 0.0, 0.0, 1.0e-16],
 /// )?;
@@ -147,11 +147,11 @@ pub fn factorize(
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn factorize_full_rank(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     alg: FactorizeAlg,
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     if t.is_diag() {
         return Err(FactorizeError::UnsupportedStorage(
             "Diagonal storage not supported for factorize",
@@ -170,10 +170,10 @@ pub fn factorize_full_rank(
 }
 
 fn factorize_impl_f64(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     match options.alg {
         FactorizeAlg::SVD => factorize_svd(t, left_inds, options),
         FactorizeAlg::QR => factorize_qr(t, left_inds, options),
@@ -183,11 +183,11 @@ fn factorize_impl_f64(
 }
 
 fn factorize_impl_f64_full_rank(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     alg: FactorizeAlg,
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     match alg {
         FactorizeAlg::SVD => factorize_svd_full_rank(t, left_inds, canonical),
         FactorizeAlg::QR => factorize_qr_full_rank(t, left_inds, canonical),
@@ -197,10 +197,10 @@ fn factorize_impl_f64_full_rank(
 }
 
 fn factorize_impl_c64(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     match options.alg {
         FactorizeAlg::SVD => factorize_svd(t, left_inds, options),
         FactorizeAlg::QR => factorize_qr(t, left_inds, options),
@@ -210,11 +210,11 @@ fn factorize_impl_c64(
 }
 
 fn factorize_impl_c64_full_rank(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     alg: FactorizeAlg,
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     match alg {
         FactorizeAlg::SVD => factorize_svd_full_rank(t, left_inds, canonical),
         FactorizeAlg::QR => factorize_qr_full_rank(t, left_inds, canonical),
@@ -225,10 +225,10 @@ fn factorize_impl_c64_full_rank(
 
 /// SVD factorization implementation.
 fn factorize_svd(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     let mut svd_options = SvdOptions::new();
     if let Some(policy) = options.svd_policy {
         svd_options = svd_options.with_policy(policy);
@@ -241,20 +241,20 @@ fn factorize_svd(
 }
 
 fn factorize_svd_full_rank(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     let svd_options = SvdOptions::full_rank();
     factorize_svd_with_options(t, left_inds, canonical, &svd_options)
 }
 
 fn factorize_svd_with_options(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
     svd_options: &SvdOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     let result = svd_for_factorize(t, left_inds, svd_options)?;
     let u = result.u;
     let s = result.s;
@@ -300,10 +300,10 @@ fn factorize_svd_with_options(
 
 /// QR factorization implementation.
 fn factorize_qr(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     if options.canonical == Canonical::Right {
         return Err(FactorizeError::UnsupportedCanonical(
             "QR only supports Canonical::Left (would need LQ for right)",
@@ -320,10 +320,10 @@ fn factorize_qr(
 }
 
 fn factorize_qr_full_rank(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     if canonical == Canonical::Right {
         return Err(FactorizeError::UnsupportedCanonical(
             "QR only supports Canonical::Left (would need LQ for right)",
@@ -334,10 +334,10 @@ fn factorize_qr_full_rank(
 }
 
 fn factorize_qr_with_options(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     qr_options: &QrOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError> {
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
     let (q, r) = qr_with::<f64>(t, left_inds, qr_options)?;
 
     // Get bond index from Q tensor (last index)
@@ -363,10 +363,10 @@ fn factorize_qr_with_options(
 
 /// LU factorization implementation.
 fn factorize_lu<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError>
 where
     T: TensorElement
         + ComplexFloat
@@ -387,10 +387,10 @@ where
 }
 
 fn factorize_lu_full_rank<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError>
 where
     T: TensorElement
         + ComplexFloat
@@ -405,12 +405,12 @@ where
 }
 
 fn factorize_lu_with_options<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
     max_bond_dim: usize,
     rel_tol: f64,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError>
 where
     T: TensorElement
         + ComplexFloat
@@ -453,14 +453,14 @@ where
     let l_vec = matrix_to_vec(&l_matrix);
     let mut l_indices = left_indices.clone();
     l_indices.push(bond_index.clone());
-    let left = TensorDynLen::from_dense(l_indices, l_vec)
+    let left = IdxTensor::from_dense(l_indices, l_vec)
         .map_err(|e| FactorizeError::ComputationError(anyhow::Error::new(e)))?;
 
     // Convert U matrix back to tensor
     let u_vec = matrix_to_vec(&u_matrix);
     let mut r_indices = vec![bond_index.clone()];
     r_indices.extend_from_slice(&right_indices);
-    let right = TensorDynLen::from_dense(r_indices, u_vec)
+    let right = IdxTensor::from_dense(r_indices, u_vec)
         .map_err(|e| FactorizeError::ComputationError(anyhow::Error::new(e)))?;
 
     Ok(FactorizeResult {
@@ -474,10 +474,10 @@ where
 
 /// CI (Cross Interpolation) factorization implementation.
 fn factorize_ci<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &FactorizeOptions,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError>
 where
     T: TensorElement
         + ComplexFloat
@@ -498,10 +498,10 @@ where
 }
 
 fn factorize_ci_full_rank<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError>
 where
     T: TensorElement
         + ComplexFloat
@@ -522,16 +522,16 @@ where
 // MatrixLuciScalar) below the algorithm layer. tensor4all-tcicore has no
 // dependency on tensor4all-core, so the direction core -> tcicore is
 // high-to-low and acyclic: the crate-boundary script rejects any reverse or
-// dev-dependency cycle. TensorDynLen data is unfolded into a column-major
+// dev-dependency cycle. IdxTensor data is unfolded into a column-major
 // eager matrix at this boundary, and fixed-pivot CI factors are rebuilt from
 // that primal value.
 fn factorize_ci_with_options<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     canonical: Canonical,
     max_bond_dim: usize,
     rel_tol: f64,
-) -> Result<FactorizeResult<TensorDynLen>, FactorizeError>
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError>
 where
     T: TensorElement
         + ComplexFloat
@@ -609,8 +609,8 @@ where
     let left_inner = left_inner.reshape(&l_dims).map_err(|e| {
         FactorizeError::ComputationError(anyhow::anyhow!("fixed-pivot CI left reshape failed: {e}"))
     })?;
-    let left = TensorDynLen::from_inner(l_indices, left_inner)
-        .map_err(FactorizeError::ComputationError)?;
+    let left =
+        IdxTensor::from_inner(l_indices, left_inner).map_err(FactorizeError::ComputationError)?;
 
     let mut r_indices = vec![bond_index.clone()];
     r_indices.extend_from_slice(&right_indices);
@@ -620,8 +620,8 @@ where
             "fixed-pivot CI right reshape failed: {e}"
         ))
     })?;
-    let right = TensorDynLen::from_inner(r_indices, right_inner)
-        .map_err(FactorizeError::ComputationError)?;
+    let right =
+        IdxTensor::from_inner(r_indices, right_inner).map_err(FactorizeError::ComputationError)?;
 
     Ok(FactorizeResult {
         left,

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -46,17 +46,17 @@ struct PairwiseContractProfileEntry {
     total_bytes: usize,
 }
 
-/// Hermitian eigendecomposition of a rank-2 [`TensorDynLen`].
+/// Hermitian eigendecomposition of a rank-2 [`IdxTensor`].
 /// Eigenvectors are returned as a rank-2 tensor whose first index is the input
 /// matrix row index and whose second index labels eigenvector columns. The
 /// eigenvalues are detached primal values intended for nonsmooth selection
 /// logic such as truncation cutoffs.
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// let row = DynIndex::new_dyn(2);
 /// let col = DynIndex::new_dyn(2);
-/// let matrix = TensorDynLen::from_dense(
+/// let matrix = IdxTensor::from_dense(
 ///     vec![row.clone(), col],
 ///     vec![1.0_f64, 0.0, 0.0, 2.0],
 /// ).unwrap();
@@ -72,7 +72,7 @@ pub struct TensorHermitianEigendecomposition {
     /// Real eigenvalues in backend Hermitian eigensolver order.
     pub eigenvalues: Vec<f64>,
     /// Eigenvector matrix with one eigenvector in each column.
-    pub eigenvectors: TensorDynLen,
+    pub eigenvectors: IdxTensor,
     /// Index labeling the eigenvector columns.
     pub eigenvector_index: DynIndex,
 }
@@ -120,12 +120,12 @@ fn profile_pairwise_contract_section<T>(section: &'static str, f: impl FnOnce() 
     result
 }
 
-/// Reset the aggregated pairwise `TensorDynLen` contraction profile.
+/// Reset the aggregated pairwise `IdxTensor` contraction profile.
 pub fn reset_pairwise_contract_profile() {
     PAIRWISE_CONTRACT_PROFILE_STATE.with(|state| state.borrow_mut().clear());
 }
 
-/// Print and clear the aggregated pairwise `TensorDynLen` contraction profile.
+/// Print and clear the aggregated pairwise `IdxTensor` contraction profile.
 pub fn print_and_reset_pairwise_contract_profile() {
     if !pairwise_contract_profile_enabled() {
         return;
@@ -139,7 +139,7 @@ pub fn print_and_reset_pairwise_contract_profile() {
         state.borrow_mut().clear();
         entries.sort_by_key(|(_, entry)| Reverse(entry.total_time));
 
-        eprintln!("=== TensorDynLen pairwise contract profile ===");
+        eprintln!("=== IdxTensor pairwise contract profile ===");
         for (section, entry) in entries {
             let per_call_us = if entry.calls == 0 {
                 0.0
@@ -172,7 +172,7 @@ fn native_tensor_profile_bytes(native: &NativeTensor) -> usize {
 
 /// Trait for scalar types that can generate random values from a standard
 /// normal distribution.
-/// This enables the generic [`TensorDynLen::random`] constructor.
+/// This enables the generic [`IdxTensor::random`] constructor.
 pub trait RandomScalar: TensorElement {
     /// Generate a random value from the standard normal distribution.
     fn random_value<R: Rng>(rng: &mut R) -> Self;
@@ -218,7 +218,7 @@ impl RandomScalar for Complex64 {
 pub fn compute_permutation_from_indices(
     original_indices: &[DynIndex],
     new_indices: &[DynIndex],
-) -> std::result::Result<Vec<usize>, TensorDynLenError> {
+) -> std::result::Result<Vec<usize>, IdxTensorError> {
     if !(new_indices.len() == original_indices.len()) {
         return Err(
             anyhow::anyhow!("new_indices length must match original_indices length").into(),
@@ -258,8 +258,8 @@ pub(crate) struct StructuredPayload {
     axis_classes: Vec<usize>,
 }
 
-/// Error returned when [`TensorDynLen::storage`] or
-/// [`TensorDynLen::to_storage`] cannot produce a compact `f64`/`Complex64`
+/// Error returned when [`IdxTensor::storage`] or
+/// [`IdxTensor::to_storage`] cannot produce a compact `f64`/`Complex64`
 /// storage snapshot from the authoritative payload.
 /// Backend diagnostics remain available through [`std::error::Error::source`]
 /// instead of being erased into a display string. The error is cloneable so a
@@ -279,7 +279,7 @@ pub(crate) struct StructuredPayload {
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum TensorStorageError {
     /// The eager or structured payload could not be converted to compact storage.
-    #[error("failed to materialize TensorDynLen storage: {source}")]
+    #[error("failed to materialize IdxTensor storage: {source}")]
     Materialization {
         /// Original diagnostic returned by the backend or storage conversion seam.
         #[source]
@@ -287,15 +287,15 @@ pub enum TensorStorageError {
     },
     /// An eager payload uses a scalar dtype that compact [`Storage`] cannot hold.
     #[error(
-        "compact TensorDynLen storage does not support dtype {dtype}; the eager payload remains authoritative"
+        "compact IdxTensor storage does not support dtype {dtype}; the eager payload remains authoritative"
     )]
     UnsupportedDtype {
         /// Native scalar dtype retained by the eager representation.
         dtype: &'static str,
     },
     /// An eager conjugation operation failed and was deferred by the infallible
-    /// [`TensorDynLen::conj`] API.
-    #[error("failed to conjugate TensorDynLen storage: {source}")]
+    /// [`IdxTensor::conj`] API.
+    #[error("failed to conjugate IdxTensor storage: {source}")]
     Conjugation {
         /// Original diagnostic returned by the eager AD backend.
         #[source]
@@ -304,7 +304,7 @@ pub enum TensorStorageError {
 }
 
 /// Errors returned by the fallible numerical and comparison methods on
-/// [`TensorDynLen`].
+/// [`IdxTensor`].
 /// The enum is intentionally owned by `tensor4all-core`: callers can match
 /// storage, shape, scalar, subtraction, and invalid-value failures without
 /// depending on the internal `anyhow` plumbing. Wrapped backend diagnostics
@@ -322,30 +322,30 @@ pub enum TensorStorageError {
 ///   re-run with the backend diagnostic visible (see `source`).
 /// # Examples
 /// ```
-/// use tensor4all_core::TensorDynLenError;
-/// let error = TensorDynLenError::NaNInput {
+/// use tensor4all_core::IdxTensorError;
+/// let error = IdxTensorError::NaNInput {
 ///     operation: "norm_squared",
 /// };
 /// assert!(error.to_string().contains("NaN"));
 /// ```
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum TensorDynLenError {
+pub enum IdxTensorError {
     /// Compact storage or deferred storage materialization failed.
-    #[error("TensorDynLen storage operation failed: {source}")]
+    #[error("IdxTensor storage operation failed: {source}")]
     Storage {
         /// Original storage diagnostic, including its backend source chain.
         #[source]
         source: TensorStorageError,
     },
     /// A native eager payload could not be materialized for a numerical operation.
-    #[error("TensorDynLen materialization failed: {source}")]
+    #[error("IdxTensor materialization failed: {source}")]
     Materialization {
         /// Original backend or eager-runtime diagnostic.
         #[source]
         source: Arc<dyn std::error::Error + Send + Sync + 'static>,
     },
     /// A rank-zero scalar could not be extracted from a reduction result.
-    #[error("TensorDynLen scalar extraction failed: {source}")]
+    #[error("IdxTensor scalar extraction failed: {source}")]
     ScalarExtraction {
         /// Original scalar-wrapper or backend diagnostic.
         #[source]
@@ -353,7 +353,7 @@ pub enum TensorDynLenError {
     },
     /// The reduction result has a scalar dtype that this real-valued operation
     /// cannot interpret.
-    #[error("TensorDynLen scalar type mismatch: expected {expected}, got {actual}")]
+    #[error("IdxTensor scalar type mismatch: expected {expected}, got {actual}")]
     ScalarTypeMismatch {
         /// Scalar dtype required by the operation.
         expected: &'static str,
@@ -363,7 +363,7 @@ pub enum TensorDynLenError {
     /// Tensor shapes, index spaces, or dimension metadata cannot be aligned
     /// for an operation (comparison, index replacement, or other shape-sensitive
     /// transformations).
-    #[error("TensorDynLen shape mismatch during {operation}: expected {expected}, got {actual}")]
+    #[error("IdxTensor shape mismatch during {operation}: expected {expected}, got {actual}")]
     ShapeMismatch {
         /// Operation that attempted the alignment.
         operation: &'static str,
@@ -373,7 +373,7 @@ pub enum TensorDynLenError {
         actual: String,
     },
     /// Tensor subtraction failed while evaluating a comparison.
-    #[error("TensorDynLen subtraction failed: {source}")]
+    #[error("IdxTensor subtraction failed: {source}")]
     Subtraction {
         /// Original arithmetic or backend diagnostic.
         #[source]
@@ -381,13 +381,13 @@ pub enum TensorDynLenError {
     },
     /// An input contained a NaN and the operation rejected it rather than
     /// silently converting it to zero.
-    #[error("TensorDynLen {operation} received NaN input")]
+    #[error("IdxTensor {operation} received NaN input")]
     NaNInput {
         /// Numerical operation that observed the NaN.
         operation: &'static str,
     },
     /// A comparison tolerance was NaN, infinite, or negative.
-    #[error("TensorDynLen tolerance {name} is invalid: {value}")]
+    #[error("IdxTensor tolerance {name} is invalid: {value}")]
     InvalidTolerance {
         /// Name of the invalid tolerance.
         name: &'static str,
@@ -395,7 +395,7 @@ pub enum TensorDynLenError {
         value: f64,
     },
     /// Another eager tensor operation failed while preparing a comparison.
-    #[error("TensorDynLen {operation} failed: {source}")]
+    #[error("IdxTensor {operation} failed: {source}")]
     Operation {
         /// Name of the eager operation that failed.
         operation: &'static str,
@@ -405,19 +405,19 @@ pub enum TensorDynLenError {
     },
 }
 
-impl From<anyhow::Error> for TensorDynLenError {
+impl From<anyhow::Error> for IdxTensorError {
     fn from(source: anyhow::Error) -> Self {
-        Self::operation("TensorDynLen", source)
+        Self::operation("IdxTensor", source)
     }
 }
 
-impl From<TensorStorageError> for TensorDynLenError {
+impl From<TensorStorageError> for IdxTensorError {
     fn from(source: TensorStorageError) -> Self {
         Self::Storage { source }
     }
 }
 
-impl From<tenferro_ad::Error> for TensorDynLenError {
+impl From<tenferro_ad::Error> for IdxTensorError {
     fn from(source: tenferro_ad::Error) -> Self {
         Self::Materialization {
             source: Arc::from(anyhow::Error::new(source).into_boxed_dyn_error()),
@@ -425,7 +425,7 @@ impl From<tenferro_ad::Error> for TensorDynLenError {
     }
 }
 
-impl From<tensor4all_tensorbackend::EagerContextError> for TensorDynLenError {
+impl From<tensor4all_tensorbackend::EagerContextError> for IdxTensorError {
     fn from(source: tensor4all_tensorbackend::EagerContextError) -> Self {
         Self::Materialization {
             source: Arc::from(anyhow::Error::new(source).into_boxed_dyn_error()),
@@ -433,7 +433,7 @@ impl From<tensor4all_tensorbackend::EagerContextError> for TensorDynLenError {
     }
 }
 
-impl From<tensor4all_tensorbackend::BridgeError> for TensorDynLenError {
+impl From<tensor4all_tensorbackend::BridgeError> for IdxTensorError {
     fn from(source: tensor4all_tensorbackend::BridgeError) -> Self {
         Self::Materialization {
             source: Arc::new(source),
@@ -441,7 +441,7 @@ impl From<tensor4all_tensorbackend::BridgeError> for TensorDynLenError {
     }
 }
 
-impl TensorDynLenError {
+impl IdxTensorError {
     fn boxed(error: anyhow::Error) -> Arc<dyn std::error::Error + Send + Sync + 'static> {
         Arc::from(error.into_boxed_dyn_error())
     }
@@ -467,7 +467,7 @@ impl TensorDynLenError {
 }
 
 #[derive(Clone)]
-pub(crate) enum TensorDynLenStorage {
+pub(crate) enum IdxTensorStorage {
     Materialized(Arc<Storage>),
     Eager {
         inner: Arc<EagerTensor>,
@@ -483,7 +483,7 @@ pub(crate) enum TensorDynLenStorage {
     },
 }
 
-impl TensorDynLenStorage {
+impl IdxTensorStorage {
     fn from_storage(storage: Arc<Storage>) -> Self {
         Self::Materialized(storage)
     }
@@ -491,7 +491,7 @@ impl TensorDynLenStorage {
     fn from_eager_dense(inner: EagerTensor, rank: usize) -> Self {
         Self::Eager {
             inner: Arc::new(inner),
-            axis_classes: TensorDynLen::dense_axis_classes(rank),
+            axis_classes: IdxTensor::dense_axis_classes(rank),
         }
     }
 
@@ -544,10 +544,10 @@ impl TensorDynLenStorage {
         match self {
             Self::Materialized(storage) => storage.payload_strides().to_vec(),
             Self::Eager { inner, .. } => {
-                TensorDynLen::col_major_strides(inner.data().shape()).unwrap_or_default()
+                IdxTensor::col_major_strides(inner.data().shape()).unwrap_or_default()
             }
             Self::Compact(payload) => {
-                TensorDynLen::col_major_strides(&payload.payload_dims).unwrap_or_default()
+                IdxTensor::col_major_strides(&payload.payload_dims).unwrap_or_default()
             }
             Self::Deferred { source, .. } => source.payload_strides_vec(),
         }
@@ -598,8 +598,8 @@ impl TensorDynLenStorage {
     fn is_diag(&self) -> bool {
         match self {
             Self::Materialized(storage) => storage.is_diag(),
-            Self::Eager { axis_classes, .. } => TensorDynLen::is_diag_axis_classes(axis_classes),
-            Self::Compact(payload) => TensorDynLen::is_diag_axis_classes(&payload.axis_classes),
+            Self::Eager { axis_classes, .. } => IdxTensor::is_diag_axis_classes(axis_classes),
+            Self::Compact(payload) => IdxTensor::is_diag_axis_classes(&payload.axis_classes),
             Self::Deferred { source, .. } => source.is_diag(),
         }
     }
@@ -610,7 +610,7 @@ impl TensorDynLenStorage {
             Self::Eager { axis_classes, .. } => {
                 if axis_classes.iter().copied().eq(0..axis_classes.len()) {
                     StorageKind::Dense
-                } else if TensorDynLen::is_diag_axis_classes(axis_classes) {
+                } else if IdxTensor::is_diag_axis_classes(axis_classes) {
                     StorageKind::Diagonal
                 } else {
                     StorageKind::Structured
@@ -624,7 +624,7 @@ impl TensorDynLenStorage {
                     .eq(0..payload.axis_classes.len())
                 {
                     StorageKind::Dense
-                } else if TensorDynLen::is_diag_axis_classes(&payload.axis_classes) {
+                } else if IdxTensor::is_diag_axis_classes(&payload.axis_classes) {
                     StorageKind::Diagonal
                 } else {
                     StorageKind::Structured
@@ -647,10 +647,10 @@ impl TensorDynLenStorage {
                 let dtype = inner.data().dtype();
                 if matches!(dtype, DType::F32 | DType::C32) {
                     return Err(TensorStorageError::UnsupportedDtype {
-                        dtype: TensorDynLen::dtype_name(dtype),
+                        dtype: IdxTensor::dtype_name(dtype),
                     });
                 }
-                TensorDynLen::storage_from_native_with_axis_classes(
+                IdxTensor::storage_from_native_with_axis_classes(
                     inner.data(),
                     axis_classes,
                     logical_rank,
@@ -664,10 +664,10 @@ impl TensorDynLenStorage {
                 let dtype = payload.payload.data().dtype();
                 if matches!(dtype, DType::F32 | DType::C32) {
                     return Err(TensorStorageError::UnsupportedDtype {
-                        dtype: TensorDynLen::dtype_name(dtype),
+                        dtype: IdxTensor::dtype_name(dtype),
                     });
                 }
-                TensorDynLen::storage_from_native_with_axis_classes(
+                IdxTensor::storage_from_native_with_axis_classes(
                     payload.payload.data(),
                     &payload.axis_classes,
                     logical_rank,
@@ -718,7 +718,7 @@ impl TensorDynLenStorage {
         };
         let scalar_inner = scalar.as_tensor()?.try_materialized_inner()?;
         let target_dtype =
-            TensorDynLen::scale_target_dtype(payload.data().dtype(), scalar_inner.data().dtype())?;
+            IdxTensor::scale_target_dtype(payload.data().dtype(), scalar_inner.data().dtype())?;
         let payload = if payload.data().dtype() == target_dtype {
             payload
         } else {
@@ -732,7 +732,7 @@ impl TensorDynLenStorage {
         let scaled = if payload.data().shape().is_empty() {
             payload.mul(&scalar_inner)?
         } else {
-            let subscripts = TensorDynLen::scale_subscripts(payload.data().shape().len())?;
+            let subscripts = IdxTensor::scale_subscripts(payload.data().shape().len())?;
             eager_einsum_ad(&[&payload, &scalar_inner], &subscripts)?
         };
         match self {
@@ -794,8 +794,8 @@ impl TensorDynLenStorage {
                     Ok(AnyScalar::new_complex(value.re, value.im))
                 }
             }
-            Self::Eager { inner, .. } => TensorDynLen::native_sum_scalar(inner.data()),
-            Self::Compact(payload) => TensorDynLen::native_sum_scalar(payload.payload.data()),
+            Self::Eager { inner, .. } => IdxTensor::native_sum_scalar(inner.data()),
+            Self::Compact(payload) => IdxTensor::native_sum_scalar(payload.payload.data()),
             Self::Deferred { error, .. } => Err(anyhow::Error::new((**error).clone())),
         }
     }
@@ -803,8 +803,8 @@ impl TensorDynLenStorage {
     fn nonfinite_flags(&self) -> Result<(bool, bool)> {
         match self {
             Self::Materialized(storage) => Ok(storage.payload_nonfinite_flags()),
-            Self::Eager { inner, .. } => TensorDynLen::native_nonfinite_flags(inner.data()),
-            Self::Compact(payload) => TensorDynLen::native_nonfinite_flags(payload.payload.data()),
+            Self::Eager { inner, .. } => IdxTensor::native_nonfinite_flags(inner.data()),
+            Self::Compact(payload) => IdxTensor::native_nonfinite_flags(payload.payload.data()),
             Self::Deferred { error, .. } => Err(anyhow::Error::new((**error).clone())),
         }
     }
@@ -816,12 +816,11 @@ impl TensorDynLenStorage {
                 .map(Complex64::from)
                 .map_err(anyhow::Error::new),
             Self::Eager { inner, .. } => {
-                TensorDynLen::native_complex_payload_value_at(inner.data(), payload_coords)
+                IdxTensor::native_complex_payload_value_at(inner.data(), payload_coords)
             }
-            Self::Compact(payload) => TensorDynLen::native_complex_payload_value_at(
-                payload.payload.data(),
-                payload_coords,
-            ),
+            Self::Compact(payload) => {
+                IdxTensor::native_complex_payload_value_at(payload.payload.data(), payload_coords)
+            }
             Self::Deferred { error, .. } => Err(anyhow::Error::new((**error).clone())),
         }
     }
@@ -863,11 +862,11 @@ impl TensorDynLenStorage {
 /// carry a bond through a fixed physical site without dense bond-squared storage.
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, StructuredSelectorError, TensorDynLen};
+/// use tensor4all_core::{DynIndex, StructuredSelectorError, IdxTensor};
 /// let left = DynIndex::new_dyn(2);
 /// let site = DynIndex::new_dyn(3);
 /// let right = DynIndex::new_dyn(4);
-/// let error = TensorDynLen::from_copy_selector(left, site, right, 1, 1.0_f64)
+/// let error = IdxTensor::from_copy_selector(left, site, right, 1, 1.0_f64)
 ///     .unwrap_err();
 /// assert!(matches!(error, StructuredSelectorError::BondDimensionMismatch { .. }));
 /// ```
@@ -925,7 +924,7 @@ pub enum StructuredSelectorError {
 
 /// Dynamic-rank tensor with structured payload storage -- the central data type
 /// of tensor4all.
-/// `TensorDynLen` stores a logical multi-dimensional tensor of supported scalar
+/// `IdxTensor` stores a logical multi-dimensional tensor of supported scalar
 /// values (`f32`, `f64`, `Complex32`, or `Complex64`) together with a list of
 /// [`DynIndex`] labels. `f64`/`Complex64` tensors may use compact [`Storage`]
 /// snapshots; `f32`/`Complex32` tensors retain an eager payload as the
@@ -951,12 +950,12 @@ pub enum StructuredSelectorError {
 /// and logical-axis classes.
 /// # Examples
 /// ```
-/// use tensor4all_core::{TensorDynLen, DynIndex};
+/// use tensor4all_core::{IdxTensor, DynIndex};
 /// // Create a 2x3 real tensor
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(3);
 /// let data = vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
-/// let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let t = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 /// assert_eq!(t.dims(), vec![2, 3]);
 /// assert!(t.is_f64());
 /// // Sum all elements: 1+2+3+4+5+6 = 21
@@ -967,18 +966,18 @@ pub enum StructuredSelectorError {
 /// assert_eq!(data_out, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 /// ```
 #[derive(Clone)]
-pub struct TensorDynLen {
+pub struct IdxTensor {
     /// Full index information (includes tags and other metadata).
     pub indices: Vec<DynIndex>,
     /// Authoritative payload representation. Compact storage is used when the
     /// dtype is supported by [`Storage`]; otherwise this retains an eager
     /// payload without promotion.
-    pub(crate) storage: TensorDynLenStorage,
+    pub(crate) storage: IdxTensorStorage,
     /// Lazily materialized logical-dense eager payload for native execution and AD.
     pub(crate) eager_cache: Arc<OnceLock<Arc<EagerTensor>>>,
 }
 
-impl TensorDynLen {
+impl IdxTensor {
     fn dense_axis_classes(rank: usize) -> Vec<usize> {
         (0..rank).collect()
     }
@@ -1005,7 +1004,7 @@ impl TensorDynLen {
             Ok(DType::C64)
         } else {
             Err(anyhow::anyhow!(
-                "unable to determine TensorDynLen scalar dtype"
+                "unable to determine IdxTensor scalar dtype"
             ))
         }
     }
@@ -1567,7 +1566,7 @@ impl TensorDynLen {
         });
         Ok(Self {
             indices,
-            storage: TensorDynLenStorage::Compact(structured_payload),
+            storage: IdxTensorStorage::Compact(structured_payload),
             eager_cache: Self::empty_eager_cache(),
         })
     }
@@ -1667,9 +1666,9 @@ impl TensorDynLen {
         let storage_owners = operands
             .iter()
             .map(|operand| match &operand.storage {
-                TensorDynLenStorage::Materialized(storage) => Some(Arc::clone(storage)),
-                TensorDynLenStorage::Deferred { source, .. } => match source.as_ref() {
-                    TensorDynLenStorage::Materialized(storage) => Some(Arc::clone(storage)),
+                IdxTensorStorage::Materialized(storage) => Some(Arc::clone(storage)),
+                IdxTensorStorage::Deferred { source, .. } => match source.as_ref() {
+                    IdxTensorStorage::Materialized(storage) => Some(Arc::clone(storage)),
                     _ => None,
                 },
                 _ => None,
@@ -1754,7 +1753,7 @@ impl TensorDynLen {
     ) -> Result<Storage> {
         if matches!(native.dtype(), DType::F32 | DType::C32) {
             return Err(anyhow::anyhow!(
-                "compact TensorDynLen storage does not support dtype {:?}; retain the eager payload",
+                "compact IdxTensor storage does not support dtype {:?}; retain the eager payload",
                 native.dtype()
             ));
         }
@@ -1769,7 +1768,7 @@ impl TensorDynLen {
                     logical_rank,
                 ),
                 DType::F32 | DType::C32 => Err(anyhow::anyhow!(
-                    "compact TensorDynLen storage does not support dtype {:?}",
+                    "compact IdxTensor storage does not support dtype {:?}",
                     native.dtype()
                 )),
             }
@@ -2169,7 +2168,7 @@ impl TensorDynLen {
                 .get()
                 .map(|inner| inner.as_ref())
                 .ok_or_else(|| {
-                    anyhow::anyhow!("TensorDynLen structured AD cache was not initialized")
+                    anyhow::anyhow!("IdxTensor structured AD cache was not initialized")
                 });
         }
         if let Some(inner) = self.storage.eager() {
@@ -2189,7 +2188,7 @@ impl TensorDynLen {
                 .get()
                 .map(|inner| inner.as_ref())
                 .ok_or_else(|| {
-                    anyhow::anyhow!("TensorDynLen structured eager cache was not initialized")
+                    anyhow::anyhow!("IdxTensor structured eager cache was not initialized")
                 });
         }
         if self.eager_cache.get().is_none() {
@@ -2197,7 +2196,7 @@ impl TensorDynLen {
                 let storage = self.storage.materialize(self.indices.len())?;
                 Self::seed_native_payload(storage.as_ref(), &logical_dims)
             })
-            .context("TensorDynLen materialization failed")?;
+            .context("IdxTensor materialization failed")?;
             record_pairwise_contract_profile_bytes(
                 "materialize_storage_to_native",
                 native_tensor_profile_bytes(&native),
@@ -2210,9 +2209,7 @@ impl TensorDynLen {
         self.eager_cache
             .get()
             .map(|inner| inner.as_ref())
-            .ok_or_else(|| {
-                anyhow::anyhow!("TensorDynLen materialization cache was not initialized")
-            })
+            .ok_or_else(|| anyhow::anyhow!("IdxTensor materialization cache was not initialized"))
     }
 
     pub(crate) fn as_inner(&self) -> Result<&EagerTensor> {
@@ -2232,12 +2229,12 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(3);
     /// let k = DynIndex::new_dyn(4);
-    /// let t = TensorDynLen::from_dense(
+    /// let t = IdxTensor::from_dense(
     ///     vec![i, j, k],
     ///     vec![0.0; 24],
     /// ).unwrap();
@@ -2278,12 +2275,12 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(3);
     /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    /// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
     ///
     /// let selected = tensor.select_indices(&[j], &[1]).unwrap();
     /// assert_eq!(selected.dims(), vec![2]);
@@ -2293,7 +2290,7 @@ impl TensorDynLen {
         &self,
         selected_indices: &[DynIndex],
         positions: &[usize],
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if selected_indices.len() != positions.len() {
             return Err(anyhow::anyhow!(
                 "selected_indices length {} does not match positions length {}",
@@ -2346,7 +2343,7 @@ impl TensorDynLen {
         if self.storage.storage_kind() == StorageKind::Diagonal {
             return self
                 .select_diag_indices(kept_indices, kept_dims, positions)
-                .map_err(TensorDynLenError::from);
+                .map_err(IdxTensorError::from);
         }
         if self.storage.storage_kind() == StorageKind::Structured {
             return self
@@ -2357,7 +2354,7 @@ impl TensorDynLen {
                     &selected_axes,
                     positions,
                 )
-                .map_err(TensorDynLenError::from);
+                .map_err(IdxTensorError::from);
         }
         if self.storage.storage_kind() != StorageKind::Dense {
             return Err(anyhow::anyhow!(
@@ -2383,7 +2380,7 @@ impl TensorDynLen {
         let sliced = self
             .try_materialized_inner()?
             .dynamic_slice(&starts_tensor, &slice_sizes)?;
-        Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?).map_err(TensorDynLenError::from)
+        Self::from_inner(kept_indices, sliced.reshape(&kept_dims)?).map_err(IdxTensorError::from)
     }
 
     /// Stack tensors along a newly inserted index.
@@ -2406,14 +2403,14 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let batch = DynIndex::new_dyn(2);
-    /// let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
-    /// let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+    /// let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    /// let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
     ///
-    /// let stacked = TensorDynLen::stack_along_new_index(&[&a, &b], batch.clone(), -1).unwrap();
+    /// let stacked = IdxTensor::stack_along_new_index(&[&a, &b], batch.clone(), -1).unwrap();
     ///
     /// assert_eq!(stacked.indices(), &[i, batch]);
     /// assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
@@ -2422,7 +2419,7 @@ impl TensorDynLen {
         tensors: &[&Self],
         new_index: DynIndex,
         axis: isize,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         let first = tensors
             .first()
             .copied()
@@ -2459,7 +2456,7 @@ impl TensorDynLen {
             .map(|tensor| tensor.try_materialized_inner())
             .collect::<Result<Vec<_>>>()?;
         let stacked = EagerTensor::stack(&inner_refs, axis)?;
-        Self::from_inner(result_indices, stacked).map_err(TensorDynLenError::from)
+        Self::from_inner(result_indices, stacked).map_err(IdxTensorError::from)
     }
 
     /// Select positions along one index and replace it with a new index.
@@ -2477,11 +2474,11 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let source = DynIndex::new_dyn(3);
     /// let target = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![source.clone()],
     ///     vec![10.0_f64, 20.0, 30.0],
     /// ).unwrap();
@@ -2496,7 +2493,7 @@ impl TensorDynLen {
         source_index: &DynIndex,
         target_index: DynIndex,
         positions: &[usize],
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if !(target_index.dim() == positions.len()) {
             return Err(anyhow::anyhow!(
                 "index_select: target index dim {} does not match position count {}",
@@ -2528,7 +2525,7 @@ impl TensorDynLen {
             .index_select(axis, positions)?;
         let mut result_indices = self.indices.clone();
         result_indices[axis as usize] = target_index;
-        Self::from_inner(result_indices, selected).map_err(TensorDynLenError::from)
+        Self::from_inner(result_indices, selected).map_err(IdxTensorError::from)
     }
 
     /// Create a new tensor with dynamic rank.
@@ -2540,19 +2537,19 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::Storage;
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(3);
     /// let storage = Arc::new(Storage::new_dense::<f64>(3).unwrap());
-    /// let t = TensorDynLen::new(vec![i], storage).unwrap();
+    /// let t = IdxTensor::new(vec![i], storage).unwrap();
     /// assert_eq!(t.dims(), vec![3]);
     /// ```
     pub fn new(
         indices: Vec<DynIndex>,
         storage: Arc<Storage>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         Self::from_storage(indices, storage)
     }
 
@@ -2567,19 +2564,19 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::Storage;
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(4);
     /// let storage = Arc::new(Storage::new_dense::<f64>(4).unwrap());
-    /// let t = TensorDynLen::from_indices(vec![i], storage).unwrap();
+    /// let t = IdxTensor::from_indices(vec![i], storage).unwrap();
     /// assert_eq!(t.dims(), vec![4]);
     /// ```
     pub fn from_indices(
         indices: Vec<DynIndex>,
         storage: Arc<Storage>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         Self::new(indices, storage)
     }
 
@@ -2592,32 +2589,32 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::Storage;
     /// use std::sync::Arc;
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
     /// let storage = Arc::new(Storage::new_diag(vec![1.0_f64, 2.0]).unwrap());
-    /// let t = TensorDynLen::from_storage(vec![i, j], storage).unwrap();
+    /// let t = IdxTensor::from_storage(vec![i, j], storage).unwrap();
     /// assert_eq!(t.dims(), vec![2, 2]);
     /// ```
     pub fn from_storage(
         indices: Vec<DynIndex>,
         storage: Arc<Storage>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         Self::validate_indices(&indices)?;
         Self::validate_storage_matches_indices(&indices, storage.as_ref())?;
         Ok(Self {
             indices,
-            storage: TensorDynLenStorage::from_storage(storage),
+            storage: IdxTensorStorage::from_storage(storage),
             eager_cache: Self::empty_eager_cache(),
         })
     }
 
     /// Create a tensor from explicit structured storage.
     ///
-    /// This is an alias for [`TensorDynLen::from_storage`] with a name that
+    /// This is an alias for [`IdxTensor::from_storage`] with a name that
     /// emphasizes that compact structured metadata is preserved.
     ///
     /// # Errors
@@ -2627,19 +2624,19 @@ impl TensorDynLen {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::{Storage, StorageKind};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
     /// let storage = Arc::new(Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap());
-    /// let tensor = TensorDynLen::from_structured_storage(vec![i, j], storage).unwrap();
+    /// let tensor = IdxTensor::from_structured_storage(vec![i, j], storage).unwrap();
     /// assert_eq!(tensor.storage().unwrap().storage_kind(), StorageKind::Diagonal);
     /// ```
     pub fn from_structured_storage(
         indices: Vec<DynIndex>,
         storage: Arc<Storage>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         Self::from_storage(indices, storage)
     }
 
@@ -2677,13 +2674,13 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::StorageKind;
     ///
     /// let left = DynIndex::new_dyn(2);
     /// let site = DynIndex::new_dyn(3);
     /// let right = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_copy_selector(
+    /// let tensor = IdxTensor::from_copy_selector(
     ///     left,
     ///     site,
     ///     right,
@@ -2808,7 +2805,7 @@ impl TensorDynLen {
     /// Compute the Hermitian eigendecomposition of a rank-2 tensor.
     ///
     /// The tensor must have two square matrix axes. The returned eigenvectors
-    /// stay in [`TensorDynLen`] form so downstream tensor algebra can preserve
+    /// stay in [`IdxTensor`] form so downstream tensor algebra can preserve
     /// AD metadata where the backend supports it. Eigenvalues are returned as
     /// detached real primal values because truncation and rank selection are
     /// nonsmooth control-flow decisions.
@@ -2824,11 +2821,11 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, IdxTensor};
     ///
     /// let row = DynIndex::new_dyn(2);
     /// let col = DynIndex::new_dyn(2);
-    /// let matrix = TensorDynLen::from_dense(
+    /// let matrix = IdxTensor::from_dense(
     ///     vec![row.clone(), col.clone()],
     ///     vec![3.0_f64, 0.0, 0.0, 5.0],
     /// ).unwrap();
@@ -2839,7 +2836,7 @@ impl TensorDynLen {
     ///     .select_indices(&[decomp.eigenvector_index.clone()], &[0])
     ///     .unwrap();
     /// let eigenvector_as_col = eigenvector.replaceind(&row, &col).unwrap();
-    /// let applied = TensorDynLen::contract(&[&matrix, &eigenvector_as_col]).unwrap();
+    /// let applied = IdxTensor::contract(&[&matrix, &eigenvector_as_col]).unwrap();
     /// let expected = eigenvector.scale(AnyScalar::new_real(decomp.eigenvalues[0])).unwrap();
     ///
     /// assert!(applied.isapprox(&expected, 1.0e-12, 0.0).unwrap());
@@ -2847,10 +2844,10 @@ impl TensorDynLen {
     pub fn hermitian_eigendecomposition(
         &self,
         hermitian_tol: f64,
-    ) -> std::result::Result<TensorHermitianEigendecomposition, TensorDynLenError> {
+    ) -> std::result::Result<TensorHermitianEigendecomposition, IdxTensorError> {
         if !(self.indices.len() == 2) {
             return Err(anyhow::anyhow!(
-                "TensorDynLen::hermitian_eigendecomposition requires a rank-2 tensor, got rank {}",
+                "IdxTensor::hermitian_eigendecomposition requires a rank-2 tensor, got rank {}",
                 self.indices.len()
             )
             .into());
@@ -2858,7 +2855,7 @@ impl TensorDynLen {
         let dims = self.dims();
         if !(dims[0] == dims[1]) {
             return Err(anyhow::anyhow!(
-                "TensorDynLen::hermitian_eigendecomposition requires a square matrix, got {}x{}",
+                "IdxTensor::hermitian_eigendecomposition requires a square matrix, got {}x{}",
                 dims[0],
                 dims[1]
             )
@@ -2866,12 +2863,15 @@ impl TensorDynLen {
         };
         if !(dims[0] > 0) {
             return Err(anyhow::anyhow!(
-                "TensorDynLen::hermitian_eigendecomposition requires a non-empty matrix"
+                "IdxTensor::hermitian_eigendecomposition requires a non-empty matrix"
             )
             .into());
         };
         if !(hermitian_tol.is_finite() && hermitian_tol >= 0.0) {
-            return Err(anyhow::anyhow!("TensorDynLen::hermitian_eigendecomposition requires a finite non-negative tolerance").into());
+            return Err(anyhow::anyhow!(
+                "IdxTensor::hermitian_eigendecomposition requires a finite non-negative tolerance"
+            )
+            .into());
         };
 
         let input = self.try_materialized_inner()?;
@@ -2883,7 +2883,7 @@ impl TensorDynLen {
         let eigenvalue_tensor = Self::from_inner(vec![eigenvalue_index], values)?;
         let eigenvalues = Self::read_real_eigenvalues(&eigenvalue_tensor, hermitian_tol)
             .with_context(|| {
-                "TensorDynLen::hermitian_eigendecomposition failed to read eigenvalues"
+                "IdxTensor::hermitian_eigendecomposition failed to read eigenvalues"
             })?;
         let eigenvectors = Self::from_inner(
             vec![self.indices[0].clone(), eigenvector_index.clone()],
@@ -2970,11 +2970,11 @@ impl TensorDynLen {
             })?;
         }
         let storage = if axis_classes == Self::dense_axis_classes(indices.len()) {
-            TensorDynLenStorage::from_eager_dense(inner, indices.len())
+            IdxTensorStorage::from_eager_dense(inner, indices.len())
         } else {
             let payload = Self::compact_inner_from_logical(&inner, &axis_classes)?;
             let payload_dims = payload.data().shape().to_vec();
-            TensorDynLenStorage::Compact(Arc::new(StructuredPayload {
+            IdxTensorStorage::Compact(Arc::new(StructuredPayload {
                 payload: Arc::new(payload),
                 payload_dims,
                 axis_classes,
@@ -3006,7 +3006,7 @@ impl TensorDynLen {
     /// Returns an error when the tensor is not a scalar (a rank mismatch) or the
     /// AD backend cannot track the tensor's dtype.
     ///
-    pub fn enable_grad(self) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn enable_grad(self) -> std::result::Result<Self, IdxTensorError> {
         self.ensure_storage_ready()?;
         // Keep the eager payload when available: compact Storage currently
         // stores only f64/C64 and must not promote f32/C32 leaves before AD.
@@ -3020,19 +3020,19 @@ impl TensorDynLen {
             None => {
                 let materialized = self.storage.materialize(self.indices.len())?;
                 storage_payload_native(materialized.as_ref())
-                    .context("TensorDynLen::enable_grad failed")?
+                    .context("IdxTensor::enable_grad failed")?
             }
         };
         let payload_dims = self.storage.payload_dims().to_vec();
         let axis_classes = self.storage.axis_classes().to_vec();
         let tracked = Arc::new(EagerTensor::requires_grad_in(payload, default_eager_ctx()?));
         let storage = if axis_classes == Self::dense_axis_classes(self.indices.len()) {
-            TensorDynLenStorage::Eager {
+            IdxTensorStorage::Eager {
                 inner: tracked,
                 axis_classes,
             }
         } else {
-            TensorDynLenStorage::Compact(Arc::new(StructuredPayload {
+            IdxTensorStorage::Compact(Arc::new(StructuredPayload {
                 payload: tracked,
                 payload_dims,
                 axis_classes,
@@ -3059,7 +3059,7 @@ impl TensorDynLen {
     /// Returns an error when the tensor is not a tracked leaf or the gradient is
     /// unavailable for the tensor's dtype (an unavailable-gradient failure).
     ///
-    pub fn grad(&self) -> std::result::Result<Option<Self>, TensorDynLenError> {
+    pub fn grad(&self) -> std::result::Result<Option<Self>, IdxTensorError> {
         if let Some(value) = self.tracked_compact_payload_value() {
             return value
                 .payload
@@ -3089,7 +3089,7 @@ impl TensorDynLen {
                     )
                 })
                 .transpose()
-                .map_err(TensorDynLenError::from);
+                .map_err(IdxTensorError::from);
         }
         self.try_materialized_inner()?
             .grad()
@@ -3101,7 +3101,7 @@ impl TensorDynLen {
                 )
             })
             .transpose()
-            .map_err(TensorDynLenError::from)
+            .map_err(IdxTensorError::from)
     }
 
     /// Clear the accumulated gradient stored for this tensor.
@@ -3109,7 +3109,7 @@ impl TensorDynLen {
     /// Returns an error when the tensor is not a tracked leaf (a missing-graph
     /// failure).
     ///
-    pub fn clear_grad(&self) -> std::result::Result<(), TensorDynLenError> {
+    pub fn clear_grad(&self) -> std::result::Result<(), IdxTensorError> {
         self.ensure_storage_ready()?;
         if let Some(value) = self.tracked_compact_payload_value() {
             value.payload.clear_grad();
@@ -3128,18 +3128,16 @@ impl TensorDynLen {
     /// Returns an error when the tensor is not a scalar (a rank mismatch) or the
     /// reverse pass fails (a graph failure).
     ///
-    pub fn backward(&self) -> std::result::Result<(), TensorDynLenError> {
+    pub fn backward(&self) -> std::result::Result<(), IdxTensorError> {
         if let Some(value) = self.tracked_compact_payload_value() {
             return value.payload.backward().map(|_| ()).map_err(|e| {
-                TensorDynLenError::from(anyhow::anyhow!("TensorDynLen::backward failed: {e}"))
+                IdxTensorError::from(anyhow::anyhow!("IdxTensor::backward failed: {e}"))
             });
         }
         self.try_materialized_inner()?
             .backward()
             .map(|_| ())
-            .map_err(|e| {
-                TensorDynLenError::from(anyhow::anyhow!("TensorDynLen::backward failed: {e}"))
-            })
+            .map_err(|e| IdxTensorError::from(anyhow::anyhow!("IdxTensor::backward failed: {e}")))
     }
 
     /// Detach this tensor from the reverse graph.
@@ -3147,13 +3145,13 @@ impl TensorDynLen {
     /// Returns an error when the tensor is not a tracked leaf (a missing-graph
     /// failure).
     ///
-    pub fn detach(&self) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn detach(&self) -> std::result::Result<Self, IdxTensorError> {
         Self::from_inner_with_axis_classes(
             self.indices.clone(),
             self.try_materialized_inner()?.detach(),
             self.storage.axis_classes().to_vec(),
         )
-        .map_err(TensorDynLenError::from)
+        .map_err(IdxTensorError::from)
     }
 
     /// Check if this tensor is already in canonical form.
@@ -3183,10 +3181,10 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::StorageKind;
     ///
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![DynIndex::new_dyn(2)],
     ///     vec![1.0_f64, 2.0],
     /// )
@@ -3205,10 +3203,10 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::StorageKind;
     ///
-    /// let tensor = TensorDynLen::from_diag(
+    /// let tensor = IdxTensor::from_diag(
     ///     vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)],
     ///     vec![1.0_f32, 2.0],
     /// )
@@ -3227,25 +3225,25 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(3);
-    /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
     /// let s = t.sum().unwrap();
     /// assert!((s.real() - 6.0).abs() < 1e-12);
     /// ```
-    pub fn sum(&self) -> std::result::Result<AnyScalar, TensorDynLenError> {
+    pub fn sum(&self) -> std::result::Result<AnyScalar, IdxTensorError> {
         self.ensure_storage_ready()?;
         if self.indices.is_empty() {
-            return AnyScalar::from_tensor(self.clone()).map_err(TensorDynLenError::from);
+            return AnyScalar::from_tensor(self.clone()).map_err(IdxTensorError::from);
         }
         if let Some(payload) = self.storage.eager().filter(|payload| payload.tracks_grad()) {
             let axes: Vec<usize> = (0..payload.data().shape().len()).collect();
             let reduced = payload.reduce_sum(&axes)?;
             return AnyScalar::from_tensor(Self::from_inner(Vec::new(), reduced)?)
-                .map_err(TensorDynLenError::from);
+                .map_err(IdxTensorError::from);
         }
-        self.storage.sum_scalar().map_err(TensorDynLenError::from)
+        self.storage.sum_scalar().map_err(IdxTensorError::from)
     }
 
     /// Extract the scalar value from a 0-dimensional tensor (or 1-element tensor).
@@ -3262,16 +3260,16 @@ impl TensorDynLen {
     /// # Example
     ///
     /// ```
-    /// use tensor4all_core::{TensorDynLen, AnyScalar};
+    /// use tensor4all_core::{IdxTensor, AnyScalar};
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// // Create a scalar tensor (0 dimensions, 1 element)
     /// let indices: Vec<Index<DynId>> = vec![];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![42.0]).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(indices, vec![42.0]).unwrap();
     ///
     /// assert_eq!(tensor.only().unwrap().real(), 42.0);
     /// ```
-    pub fn only(&self) -> std::result::Result<AnyScalar, TensorDynLenError> {
+    pub fn only(&self) -> std::result::Result<AnyScalar, IdxTensorError> {
         let dims = self.dims();
         let total_size = checked_product(&dims)?;
         if !(total_size == 1 || dims.is_empty()) {
@@ -3306,14 +3304,14 @@ impl TensorDynLen {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// // Create a 2×3 tensor
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
     /// let indices = vec![i.clone(), j.clone()];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Permute to 3×2: swap the two dimensions by providing new indices order
     /// let permuted = tensor.permute_indices(&[j, i]).unwrap();
@@ -3322,7 +3320,7 @@ impl TensorDynLen {
     pub fn permute_indices(
         &self,
         new_indices: &[DynIndex],
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         // Compute permutation by matching IDs
         let perm = compute_permutation_from_indices(&self.indices, new_indices)?;
         if perm.iter().copied().eq(0..perm.len()) {
@@ -3336,7 +3334,7 @@ impl TensorDynLen {
         let permuted = self.try_materialized_inner()?.transpose(&perm)?;
         let axis_classes = self.permute_axis_classes(&perm);
         Self::from_inner_with_axis_classes(new_indices.to_vec(), permuted, axis_classes)
-            .map_err(TensorDynLenError::from)
+            .map_err(IdxTensorError::from)
     }
 
     /// Permute the tensor dimensions, returning a new tensor.
@@ -3356,7 +3354,7 @@ impl TensorDynLen {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// // Create a 2×3 tensor
@@ -3364,13 +3362,13 @@ impl TensorDynLen {
     ///     Index::new_dyn(2),
     ///     Index::new_dyn(3),
     /// ];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Permute to 3×2: swap the two dimensions
     /// let permuted = tensor.permute(&[1, 0]).unwrap();
     /// assert_eq!(permuted.dims(), vec![3, 2]);
     /// ```
-    pub fn permute(&self, perm: &[usize]) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn permute(&self, perm: &[usize]) -> std::result::Result<Self, IdxTensorError> {
         if !(perm.len() == self.indices.len()) {
             return Err(anyhow::anyhow!("permutation length must match tensor rank").into());
         };
@@ -3392,7 +3390,7 @@ impl TensorDynLen {
         let permuted = self.try_materialized_inner()?.transpose(perm)?;
         let axis_classes = self.permute_axis_classes(perm);
         Self::from_inner_with_axis_classes(new_indices, permuted, axis_classes)
-            .map_err(TensorDynLenError::from)
+            .map_err(IdxTensorError::from)
     }
 
     pub(crate) fn try_contract_pairwise_default(&self, other: &Self) -> Result<Self> {
@@ -3702,7 +3700,7 @@ impl TensorDynLen {
 // Random tensor generation
 // ============================================================================
 
-impl TensorDynLen {
+impl IdxTensor {
     /// Create a random tensor with values from standard normal distribution (generic over scalar type).
     ///
     /// For `f64`, each element is drawn from the standard normal distribution.
@@ -3721,7 +3719,7 @@ impl TensorDynLen {
     /// or the backend cannot generate the requested scalar type.
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     /// use rand::SeedableRng;
     /// use rand_chacha::ChaCha8Rng;
@@ -3729,13 +3727,13 @@ impl TensorDynLen {
     /// let mut rng = ChaCha8Rng::seed_from_u64(42);
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
-    /// let tensor: TensorDynLen = TensorDynLen::random::<f64, _>(&mut rng, vec![i, j]).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::random::<f64, _>(&mut rng, vec![i, j]).unwrap();
     /// assert_eq!(tensor.dims(), vec![2, 3]);
     /// ```
     pub fn random<T: RandomScalar, R: Rng>(
         rng: &mut R,
         indices: Vec<DynIndex>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
         let size = checked_product(&dims)?;
         let data: Vec<T> = (0..size).map(|_| T::random_value(rng)).collect();
@@ -3743,7 +3741,7 @@ impl TensorDynLen {
     }
 }
 
-impl TensorDynLen {
+impl IdxTensor {
     /// Add two tensors element-wise.
     ///
     /// The tensors must have the same index set (matched by ID). If the indices
@@ -3763,7 +3761,7 @@ impl TensorDynLen {
     /// index-set mismatch) or the arithmetic reports a failure.
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
@@ -3771,16 +3769,16 @@ impl TensorDynLen {
     ///
     /// let indices_a = vec![i.clone(), j.clone()];
     /// let data_a = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    /// let tensor_a: TensorDynLen = TensorDynLen::from_dense(indices_a, data_a).unwrap();
+    /// let tensor_a: IdxTensor = IdxTensor::from_dense(indices_a, data_a).unwrap();
     ///
     /// let indices_b = vec![i.clone(), j.clone()];
     /// let data_b = vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
-    /// let tensor_b: TensorDynLen = TensorDynLen::from_dense(indices_b, data_b).unwrap();
+    /// let tensor_b: IdxTensor = IdxTensor::from_dense(indices_b, data_b).unwrap();
     ///
     /// let sum = tensor_a.add(&tensor_b).unwrap();
     /// // sum = [[2, 3, 4], [5, 6, 7]]
     /// ```
-    pub fn add(&self, other: &Self) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn add(&self, other: &Self) -> std::result::Result<Self, IdxTensorError> {
         // Validate that both tensors have the same number of indices
         if self.indices.len() != other.indices.len() {
             return Err(anyhow::anyhow!(
@@ -3849,11 +3847,11 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    /// let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 4.0]).unwrap();
+    /// let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    /// let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0, 4.0]).unwrap();
     ///
     /// // 2*a + 3*b = [2+9, 4+12] = [11, 16]
     /// let result = a.axpby(AnyScalar::new_real(2.0), &b, AnyScalar::new_real(3.0)).unwrap();
@@ -3866,7 +3864,7 @@ impl TensorDynLen {
         a: AnyScalar,
         other: &Self,
         b: AnyScalar,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         // Validate that both tensors have the same number of indices.
         if self.indices.len() != other.indices.len() {
             return Err(anyhow::anyhow!(
@@ -3912,8 +3910,8 @@ impl TensorDynLen {
             && self.storage.payload_strides_vec() == other_aligned.storage.payload_strides_vec()
             && self.storage.axis_classes() == other_aligned.storage.axis_classes();
         if same_compact_layout
-            && matches!(&self.storage, TensorDynLenStorage::Materialized(_))
-            && matches!(&other_aligned.storage, TensorDynLenStorage::Materialized(_))
+            && matches!(&self.storage, IdxTensorStorage::Materialized(_))
+            && matches!(&other_aligned.storage, IdxTensorStorage::Materialized(_))
             && !self.tracks_grad()
             && !other_aligned.tracks_grad()
             && !a.tracks_grad()
@@ -3949,7 +3947,7 @@ impl TensorDynLen {
                 combined,
                 axis_classes,
             )
-            .map_err(TensorDynLenError::from);
+            .map_err(IdxTensorError::from);
         }
 
         let a_native = a.as_tensor()?.as_native()?;
@@ -3969,7 +3967,7 @@ impl TensorDynLen {
                 combined,
                 axis_classes,
             )
-            .map_err(TensorDynLenError::from);
+            .map_err(IdxTensorError::from);
         }
 
         let lhs = self.scale(a)?;
@@ -3979,7 +3977,7 @@ impl TensorDynLen {
             .add(rhs.try_materialized_inner()?)
             .map_err(|e| anyhow::anyhow!("tensor addition failed: {e}"))?;
         Self::from_inner_with_axis_classes(self.indices.clone(), combined, axis_classes)
-            .map_err(TensorDynLenError::from)
+            .map_err(IdxTensorError::from)
     }
 
     /// Scalar multiplication.
@@ -3993,19 +3991,19 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(3);
-    /// let t = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
     /// let scaled = t.scale(AnyScalar::new_real(2.0)).unwrap();
     /// assert_eq!(scaled.to_vec::<f64>().unwrap(), vec![2.0, 4.0, 6.0]);
     /// ```
-    pub fn scale(&self, scalar: AnyScalar) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn scale(&self, scalar: AnyScalar) -> std::result::Result<Self, IdxTensorError> {
         if matches!(
             &self.storage,
-            TensorDynLenStorage::Eager { .. }
-                | TensorDynLenStorage::Compact(_)
-                | TensorDynLenStorage::Materialized(_)
+            IdxTensorStorage::Eager { .. }
+                | IdxTensorStorage::Compact(_)
+                | IdxTensorStorage::Materialized(_)
         ) {
             // Scale via the compact payload only. Materialized structured
             // storage is converted payload-coordinate by payload-coordinate
@@ -4052,7 +4050,7 @@ impl TensorDynLen {
                 scaled,
                 self.storage.axis_classes().to_vec(),
             )
-            .map_err(TensorDynLenError::from);
+            .map_err(IdxTensorError::from);
         }
         if self_native.dtype() != scalar_native.dtype() {
             let scaled = scale_native_tensor(self_native, &scalar.to_backend_scalar())?;
@@ -4061,7 +4059,7 @@ impl TensorDynLen {
                 scaled,
                 self.storage.axis_classes().to_vec(),
             )
-            .map_err(TensorDynLenError::from);
+            .map_err(IdxTensorError::from);
         }
 
         let scaled = if self.indices.is_empty() {
@@ -4084,7 +4082,7 @@ impl TensorDynLen {
             scaled,
             self.storage.axis_classes().to_vec(),
         )
-        .map_err(TensorDynLenError::from)
+        .map_err(IdxTensorError::from)
     }
 
     /// Inner product (dot product) of two tensors.
@@ -4097,17 +4095,17 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(3);
-    /// let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    /// let b = TensorDynLen::from_dense(vec![i.clone()], vec![4.0, 5.0, 6.0]).unwrap();
+    /// let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    /// let b = IdxTensor::from_dense(vec![i.clone()], vec![4.0, 5.0, 6.0]).unwrap();
     ///
     /// // <a, b> = 1*4 + 2*5 + 3*6 = 32
     /// let ip = a.inner_product(&b).unwrap();
     /// assert!((ip.real() - 32.0).abs() < 1e-12);
     /// ```
-    pub fn inner_product(&self, other: &Self) -> std::result::Result<AnyScalar, TensorDynLenError> {
+    pub fn inner_product(&self, other: &Self) -> std::result::Result<AnyScalar, IdxTensorError> {
         if self.indices.len() == other.indices.len() {
             let self_set: HashSet<_> = self.indices.iter().collect();
             let other_set: HashSet<_> = other.indices.iter().collect();
@@ -4137,7 +4135,7 @@ impl TensorDynLen {
 // Index Replacement Methods
 // ============================================================================
 
-impl TensorDynLen {
+impl IdxTensor {
     /// Replace an index in the tensor with a new index.
     ///
     /// This replaces every index equal to `old_index` (full index equality,
@@ -4157,7 +4155,7 @@ impl TensorDynLen {
     /// (a shape mismatch: the replacement dimension must equal the original).
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
@@ -4165,7 +4163,7 @@ impl TensorDynLen {
     /// let new_i = Index::new_dyn(2);  // Same dimension, different ID
     ///
     /// let indices = vec![i.clone(), j.clone()];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Replace index i with new_i
     /// let replaced = tensor.replaceind(&i, &new_i).unwrap();
@@ -4176,10 +4174,10 @@ impl TensorDynLen {
         &self,
         old_index: &DynIndex,
         new_index: &DynIndex,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         // Validate dimension match
         if old_index.dim() != new_index.dim() {
-            return Err(TensorDynLenError::ShapeMismatch {
+            return Err(IdxTensorError::ShapeMismatch {
                 operation: "replaceind",
                 expected: format!("dimension {}", old_index.dim()),
                 actual: format!("dimension {}", new_index.dim()),
@@ -4226,7 +4224,7 @@ impl TensorDynLen {
     /// original).
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
@@ -4235,7 +4233,7 @@ impl TensorDynLen {
     /// let new_j = Index::new_dyn(3);
     ///
     /// let indices = vec![i.clone(), j.clone()];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(indices, vec![0.0; 6]).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(indices, vec![0.0; 6]).unwrap();
     ///
     /// // Replace both indices
     /// let replaced = tensor
@@ -4248,9 +4246,9 @@ impl TensorDynLen {
         &self,
         old_indices: &[DynIndex],
         new_indices: &[DynIndex],
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if old_indices.len() != new_indices.len() {
-            return Err(TensorDynLenError::ShapeMismatch {
+            return Err(IdxTensorError::ShapeMismatch {
                 operation: "replace_indices",
                 expected: format!("{} indices", old_indices.len()),
                 actual: format!("{} indices", new_indices.len()),
@@ -4260,7 +4258,7 @@ impl TensorDynLen {
         // Validate dimension matches for all replacements
         for (old, new) in old_indices.iter().zip(new_indices.iter()) {
             if old.dim() != new.dim() {
-                return Err(TensorDynLenError::ShapeMismatch {
+                return Err(IdxTensorError::ShapeMismatch {
                     operation: "replace_indices",
                     expected: format!("dimension {}", old.dim()),
                     actual: format!("dimension {}", new.dim()),
@@ -4296,7 +4294,7 @@ impl TensorDynLen {
 // Complex Conjugation
 // ============================================================================
 
-impl TensorDynLen {
+impl IdxTensor {
     /// Complex conjugate of all tensor elements.
     ///
     /// For real (`f32`/`f64`) tensors, returns a copy (conjugate of real is
@@ -4311,13 +4309,13 @@ impl TensorDynLen {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     /// use num_complex::Complex64;
     ///
     /// let i = Index::new_dyn(2);
     /// let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(vec![i], data).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(vec![i], data).unwrap();
     ///
     /// let conj_tensor = tensor.conj();
     /// assert_eq!(
@@ -4478,7 +4476,7 @@ impl Lassq {
 // Norm Computation
 // ============================================================================
 
-impl TensorDynLen {
+impl IdxTensor {
     /// Compute the squared Frobenius norm of the tensor: ||T||² = Σ|T_ijk...|²
     ///
     /// For real tensors: sum of squares of all elements.
@@ -4487,38 +4485,38 @@ impl TensorDynLen {
     /// accumulator, so it does not form a source-dtype `self * conj(self)`.
     ///
     /// # Errors
-    /// Returns [`TensorDynLenError`] when storage/materialization or scalar
+    /// Returns [`IdxTensorError`] when storage/materialization or scalar
     /// extraction fails, or when the input produces NaN. The result is
     /// accumulated from squared magnitudes, so it is never negative;
     /// positive infinity is preserved.
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
     /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];  // 1² + 2² + ... + 6² = 91
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(vec![i, j], data).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(vec![i, j], data).unwrap();
     ///
     /// assert!((tensor.norm_squared().unwrap() - 91.0).abs() < 1e-10);
     /// ```
-    pub fn norm_squared(&self) -> std::result::Result<f64, TensorDynLenError> {
+    pub fn norm_squared(&self) -> std::result::Result<f64, IdxTensorError> {
         let dtype = self
             .scalar_dtype()
-            .map_err(TensorDynLenError::scalar_extraction)?;
+            .map_err(IdxTensorError::scalar_extraction)?;
         if !matches!(dtype, DType::F32 | DType::F64 | DType::C32 | DType::C64) {
-            return Err(TensorDynLenError::ScalarTypeMismatch {
+            return Err(IdxTensorError::ScalarTypeMismatch {
                 expected: "f32, f64, c32, or c64",
                 actual: Self::dtype_name(dtype).to_string(),
             });
         }
         let (has_nan, _) = self
             .compact_nonfinite_flags()
-            .map_err(TensorDynLenError::materialization)?;
+            .map_err(IdxTensorError::materialization)?;
         if has_nan {
-            return Err(TensorDynLenError::NaNInput {
+            return Err(IdxTensorError::NaNInput {
                 operation: "norm_squared",
             });
         }
@@ -4526,10 +4524,10 @@ impl TensorDynLen {
         let mut norm = Lassq::default();
         self.storage
             .for_each_payload_value(|value| norm.add_complex(value))
-            .map_err(TensorDynLenError::materialization)?;
+            .map_err(IdxTensorError::materialization)?;
         let value = norm.norm_squared();
         if value.is_nan() {
-            return Err(TensorDynLenError::NaNInput {
+            return Err(IdxTensorError::NaNInput {
                 operation: "norm_squared",
             });
         }
@@ -4539,63 +4537,63 @@ impl TensorDynLen {
     /// Compute the Frobenius norm of the tensor: ||T|| = sqrt(Σ|T_ijk...|²)
     ///
     /// # Errors
-    /// Returns [`TensorDynLenError`] when norm evaluation fails or when the
+    /// Returns [`IdxTensorError`] when norm evaluation fails or when the
     /// input contains NaN. Positive infinity is preserved.
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let data = vec![3.0, 4.0];  // sqrt(9 + 16) = 5
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(vec![i], data).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(vec![i], data).unwrap();
     ///
     /// assert!((tensor.norm().unwrap() - 5.0).abs() < 1e-10);
     /// ```
-    pub fn norm(&self) -> std::result::Result<f64, TensorDynLenError> {
+    pub fn norm(&self) -> std::result::Result<f64, IdxTensorError> {
         Ok(self.norm_squared()?.sqrt())
     }
 
     /// Maximum absolute value of all elements (L-infinity norm).
     ///
     /// # Errors
-    /// Returns [`TensorDynLenError`] when authoritative storage or eager
+    /// Returns [`IdxTensorError`] when authoritative storage or eager
     /// materialization cannot be read, or when the input contains NaN.
     ///
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(4);
-    /// let t = TensorDynLen::from_dense(vec![i], vec![-5.0, 1.0, 3.0, -2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![i], vec![-5.0, 1.0, 3.0, -2.0]).unwrap();
     /// assert!((t.maxabs().unwrap() - 5.0).abs() < 1e-12);
     /// ```
-    pub fn maxabs(&self) -> std::result::Result<f64, TensorDynLenError> {
+    pub fn maxabs(&self) -> std::result::Result<f64, IdxTensorError> {
         if let Some(error) = self.storage.deferred_error() {
-            return Err(TensorDynLenError::Storage {
+            return Err(IdxTensorError::Storage {
                 source: error.clone(),
             });
         }
         let dtype = self
             .storage
             .dtype()
-            .ok_or_else(|| TensorDynLenError::ScalarTypeMismatch {
+            .ok_or_else(|| IdxTensorError::ScalarTypeMismatch {
                 expected: "f32, f64, c32, or c64",
                 actual: "unknown".to_string(),
             })?;
         if !matches!(dtype, DType::F32 | DType::F64 | DType::C32 | DType::C64) {
-            return Err(TensorDynLenError::ScalarTypeMismatch {
+            return Err(IdxTensorError::ScalarTypeMismatch {
                 expected: "f32, f64, c32, or c64",
                 actual: Self::dtype_name(dtype).to_string(),
             });
         }
         let (has_nan, _) = self
             .compact_nonfinite_flags()
-            .map_err(TensorDynLenError::materialization)?;
+            .map_err(IdxTensorError::materialization)?;
         if has_nan {
-            return Err(TensorDynLenError::NaNInput {
+            return Err(IdxTensorError::NaNInput {
                 operation: "maxabs",
             });
         }
@@ -4605,7 +4603,7 @@ impl TensorDynLen {
                 let magnitude = scalar.re.hypot(scalar.im);
                 value = value.max(magnitude);
             })
-            .map_err(TensorDynLenError::materialization)?;
+            .map_err(IdxTensorError::materialization)?;
         Ok(value)
     }
 
@@ -4743,7 +4741,7 @@ impl TensorDynLen {
     /// Returns an error when the tensors have different index sets (an index-set
     /// mismatch) or the arithmetic reports a failure.
     ///
-    pub fn sub(&self, other: &Self) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn sub(&self, other: &Self) -> std::result::Result<Self, IdxTensorError> {
         self.axpby(AnyScalar::new_real(1.0), other, AnyScalar::new_real(-1.0))
     }
 
@@ -4753,7 +4751,7 @@ impl TensorDynLen {
     /// Returns an error when scalar multiplication fails for the tensor storage
     /// (a dtype mismatch) or the backend reports a failure.
     ///
-    pub fn neg(&self) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn neg(&self) -> std::result::Result<Self, IdxTensorError> {
         self.scale(AnyScalar::new_real(-1.0))
     }
 
@@ -4765,7 +4763,7 @@ impl TensorDynLen {
     /// avoiding logical-dense traversal and avoidable underflow/overflow.
     ///
     /// # Errors
-    /// Returns [`TensorDynLenError`] when tolerances are invalid, the index
+    /// Returns [`IdxTensorError`] when tolerances are invalid, the index
     /// spaces cannot be aligned, storage cannot be read, or either input
     /// contains NaN.
     pub fn isapprox(
@@ -4773,14 +4771,14 @@ impl TensorDynLen {
         other: &Self,
         atol: f64,
         rtol: f64,
-    ) -> std::result::Result<bool, TensorDynLenError> {
+    ) -> std::result::Result<bool, IdxTensorError> {
         for (name, value) in [("atol", atol), ("rtol", rtol)] {
             if !value.is_finite() || value < 0.0 {
-                return Err(TensorDynLenError::InvalidTolerance { name, value });
+                return Err(IdxTensorError::InvalidTolerance { name, value });
             }
         }
         if self.indices.len() != other.indices.len() {
-            return Err(TensorDynLenError::ShapeMismatch {
+            return Err(IdxTensorError::ShapeMismatch {
                 operation: "isapprox",
                 expected: format!("indices {:?}", self.indices),
                 actual: format!("indices {:?}", other.indices),
@@ -4799,7 +4797,7 @@ impl TensorDynLen {
             .iter()
             .map(|index| {
                 other_axis_by_index.get(index).copied().ok_or_else(|| {
-                    TensorDynLenError::ShapeMismatch {
+                    IdxTensorError::ShapeMismatch {
                         operation: "isapprox",
                         expected: format!("indices {:?}", self.indices),
                         actual: format!("indices {:?}", other.indices),
@@ -4811,7 +4809,7 @@ impl TensorDynLen {
         let other_dims = other.dims();
         for (axis, &other_axis) in other_positions.iter().enumerate() {
             if self_dims[axis] != other_dims[other_axis] {
-                return Err(TensorDynLenError::ShapeMismatch {
+                return Err(IdxTensorError::ShapeMismatch {
                     operation: "isapprox",
                     expected: format!("dims {:?}", self_dims),
                     actual: format!("dims {:?}", other_dims),
@@ -4821,10 +4819,10 @@ impl TensorDynLen {
         for tensor in [self, other] {
             if tensor
                 .compact_nonfinite_flags()
-                .map_err(TensorDynLenError::materialization)?
+                .map_err(IdxTensorError::materialization)?
                 .0
             {
-                return Err(TensorDynLenError::NaNInput {
+                return Err(IdxTensorError::NaNInput {
                     operation: "isapprox",
                 });
             }
@@ -4834,9 +4832,9 @@ impl TensorDynLen {
         let lhs_payload_dims = self.storage.payload_dims().to_vec();
         let rhs_payload_dims = other.storage.payload_dims().to_vec();
         let lhs_payload_len =
-            checked_product(&lhs_payload_dims).map_err(TensorDynLenError::materialization)?;
+            checked_product(&lhs_payload_dims).map_err(IdxTensorError::materialization)?;
         let rhs_payload_len =
-            checked_product(&rhs_payload_dims).map_err(TensorDynLenError::materialization)?;
+            checked_product(&rhs_payload_dims).map_err(IdxTensorError::materialization)?;
         let lhs_axis_classes = self.storage.axis_classes();
         let rhs_axis_classes = other.storage.axis_classes();
         let self_to_other = other_positions.clone();
@@ -4873,7 +4871,7 @@ impl TensorDynLen {
             let lhs = self
                 .storage
                 .payload_value_at(&lhs_coords)
-                .map_err(TensorDynLenError::materialization)?;
+                .map_err(IdxTensorError::materialization)?;
             if map_payload_support_coordinate(
                 lhs_axis_classes,
                 rhs_axis_classes,
@@ -4885,7 +4883,7 @@ impl TensorDynLen {
                 let rhs = other
                     .storage
                     .payload_value_at(&rhs_from_lhs)
-                    .map_err(TensorDynLenError::materialization)?;
+                    .map_err(IdxTensorError::materialization)?;
                 if !compare(lhs, rhs) {
                     return Ok(false);
                 }
@@ -4906,7 +4904,7 @@ impl TensorDynLen {
             let rhs = other
                 .storage
                 .payload_value_at(&rhs_coords)
-                .map_err(TensorDynLenError::materialization)?;
+                .map_err(IdxTensorError::materialization)?;
             if !map_payload_support_coordinate(
                 rhs_axis_classes,
                 lhs_axis_classes,
@@ -4953,7 +4951,7 @@ impl TensorDynLen {
     pub fn diagonal(
         input_index: &DynIndex,
         output_index: &DynIndex,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         <Self as TensorConstructionLike>::diagonal(input_index, output_index)
     }
 
@@ -4965,7 +4963,7 @@ impl TensorDynLen {
     pub fn delta(
         input_indices: &[DynIndex],
         output_indices: &[DynIndex],
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         <Self as TensorConstructionLike>::delta(input_indices, output_indices)
     }
 
@@ -4975,7 +4973,7 @@ impl TensorDynLen {
     /// Returns an error when dense scalar construction fails for the element type
     /// (an invalid scalar dtype or a construction failure).
     ///
-    pub fn scalar_one() -> std::result::Result<Self, TensorDynLenError> {
+    pub fn scalar_one() -> std::result::Result<Self, IdxTensorError> {
         <Self as TensorConstructionLike>::scalar_one()
     }
 
@@ -4985,7 +4983,7 @@ impl TensorDynLen {
     /// Returns an error when the tensor size overflows (an overflow failure) or
     /// dense construction fails.
     ///
-    pub fn ones(indices: &[DynIndex]) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn ones(indices: &[DynIndex]) -> std::result::Result<Self, IdxTensorError> {
         <Self as TensorConstructionLike>::ones(indices)
     }
 
@@ -4995,9 +4993,7 @@ impl TensorDynLen {
     /// Returns an error when any coordinate is outside its index dimension (an
     /// out of bounds failure).
     ///
-    pub fn onehot(
-        index_vals: &[(DynIndex, usize)],
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn onehot(index_vals: &[(DynIndex, usize)]) -> std::result::Result<Self, IdxTensorError> {
         <Self as TensorConstructionLike>::onehot(index_vals)
     }
 
@@ -5023,15 +5019,15 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
     /// let masked = tensor.mask_index(&i, 1).unwrap();
     ///
     /// assert_eq!(masked.indices(), &[i]);
     /// assert_eq!(masked.to_vec::<f64>().unwrap(), vec![0.0, 4.0]);
-    /// assert!(TensorDynLen::from_dense(
+    /// assert!(IdxTensor::from_dense(
     ///     vec![DynIndex::new_dyn(2)],
     ///     vec![1.0_f64, 2.0],
     /// )
@@ -5043,7 +5039,7 @@ impl TensorDynLen {
         &self,
         index: &DynIndex,
         position: usize,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if !(self.indices.iter().any(|candidate| candidate == index)) {
             return Err(anyhow::anyhow!("mask_index: index is not present in tensor").into());
         };
@@ -5119,7 +5115,7 @@ impl TensorDynLen {
     /// * `other` - The other tensor to compare with
     ///
     /// # Errors
-    /// Returns [`TensorDynLenError`] when either norm contains NaN, or when
+    /// Returns [`IdxTensorError`] when either norm contains NaN, or when
     /// scaling and subtracting the tensors fails.
     ///
     /// # Returns
@@ -5131,18 +5127,18 @@ impl TensorDynLen {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let data_a = vec![1.0, 0.0];
     /// let data_b = vec![1.0, 0.0];  // Same tensor
-    /// let tensor_a: TensorDynLen = TensorDynLen::from_dense(vec![i.clone()], data_a).unwrap();
-    /// let tensor_b: TensorDynLen = TensorDynLen::from_dense(vec![i.clone()], data_b).unwrap();
+    /// let tensor_a: IdxTensor = IdxTensor::from_dense(vec![i.clone()], data_a).unwrap();
+    /// let tensor_b: IdxTensor = IdxTensor::from_dense(vec![i.clone()], data_b).unwrap();
     ///
     /// assert!(tensor_a.distance(&tensor_b).unwrap() < 1e-10);  // Zero distance
     /// ```
-    pub fn distance(&self, other: &Self) -> std::result::Result<f64, TensorDynLenError> {
+    pub fn distance(&self, other: &Self) -> std::result::Result<f64, IdxTensorError> {
         let norm_self = self.norm()?;
 
         // Compute A - B = A + (-1) * B
@@ -5158,9 +5154,9 @@ impl TensorDynLen {
     }
 }
 
-impl std::fmt::Debug for TensorDynLen {
+impl std::fmt::Debug for IdxTensor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TensorDynLen")
+        f.debug_struct("IdxTensor")
             .field("indices", &self.indices)
             .field("dims", &self.dims())
             .field("is_diag", &self.is_diag())
@@ -5174,7 +5170,7 @@ impl std::fmt::Debug for TensorDynLen {
 /// * `diag_data` - The diagonal elements (length must equal the dimension of indices)
 ///
 /// The returned tensor preserves compact diagonal payload metadata; use
-/// [`TensorDynLen::is_diag`] or [`TensorDynLen::storage`] to inspect that
+/// [`IdxTensor::is_diag`] or [`IdxTensor::storage`] to inspect that
 /// representation.
 ///
 /// # Errors
@@ -5184,18 +5180,18 @@ impl std::fmt::Debug for TensorDynLen {
 /// Panics if indices have different dimensions, or if diag_data length doesn't match.
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, diag_tensor_dyn_len};
+/// use tensor4all_core::{DynIndex, diag_idx_tensor};
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
-/// let t = diag_tensor_dyn_len(vec![i, j], vec![1.0, 2.0, 3.0]).unwrap();
+/// let t = diag_idx_tensor(vec![i, j], vec![1.0, 2.0, 3.0]).unwrap();
 /// assert_eq!(t.dims(), vec![3, 3]);
 /// assert!(t.is_diag());
 /// ```
-pub fn diag_tensor_dyn_len(
+pub fn diag_idx_tensor(
     indices: Vec<DynIndex>,
     diag_data: Vec<f64>,
-) -> std::result::Result<TensorDynLen, TensorDynLenError> {
-    TensorDynLen::from_diag(indices, diag_data)
+) -> std::result::Result<IdxTensor, IdxTensorError> {
+    IdxTensor::from_diag(indices, diag_data)
 }
 
 #[allow(clippy::type_complexity)]
@@ -5231,11 +5227,11 @@ pub(crate) type UnfoldSplitInnerResult = (
 /// failure).
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, unfold_split};
+/// use tensor4all_core::{DynIndex, IdxTensor, unfold_split};
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(3);
 /// // 2x3 dense tensor with data [1..6]
-/// let t = TensorDynLen::from_dense(
+/// let t = IdxTensor::from_dense(
 ///     vec![i.clone(), j.clone()],
 ///     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
 /// ).unwrap();
@@ -5249,7 +5245,7 @@ pub(crate) type UnfoldSplitInnerResult = (
 /// ```
 #[allow(clippy::type_complexity)]
 pub fn unfold_split(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
 ) -> std::result::Result<
     (
@@ -5260,7 +5256,7 @@ pub fn unfold_split(
         Vec<DynIndex>,
         Vec<DynIndex>,
     ),
-    TensorDynLenError,
+    IdxTensorError,
 > {
     let (matrix_inner, left_len, m, n, left_indices, right_indices) =
         unfold_split_inner(t, left_inds)?;
@@ -5276,7 +5272,7 @@ pub fn unfold_split(
 }
 
 pub(crate) fn unfold_split_inner(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
 ) -> Result<UnfoldSplitInnerResult> {
     let rank = t.indices.len();
@@ -5345,17 +5341,17 @@ pub(crate) fn unfold_split_inner(
 }
 
 // ============================================================================
-// TensorIndex implementation for TensorDynLen
+// TensorIndex implementation for IdxTensor
 // ============================================================================
 
 use crate::tensor_index::TensorIndex;
 
-impl TensorIndex for TensorDynLen {
+impl TensorIndex for IdxTensor {
     type Index = DynIndex;
-    type Error = TensorDynLenError;
+    type Error = IdxTensorError;
 
     fn external_indices(&self) -> Vec<DynIndex> {
-        // For TensorDynLen, all indices are external.
+        // For IdxTensor, all indices are external.
         self.indices.clone()
     }
 
@@ -5369,7 +5365,7 @@ impl TensorIndex for TensorDynLen {
         new_index: &DynIndex,
     ) -> std::result::Result<Self, Self::Error> {
         // Delegate to the inherent method.
-        TensorDynLen::replaceind(self, old_index, new_index)
+        IdxTensor::replaceind(self, old_index, new_index)
     }
 
     fn replace_indices(
@@ -5378,12 +5374,12 @@ impl TensorIndex for TensorDynLen {
         new_indices: &[DynIndex],
     ) -> std::result::Result<Self, Self::Error> {
         // Delegate to the inherent method.
-        TensorDynLen::replace_indices(self, old_indices, new_indices)
+        IdxTensor::replace_indices(self, old_indices, new_indices)
     }
 }
 
 // ============================================================================
-// TensorLike implementation for TensorDynLen
+// TensorLike implementation for IdxTensor
 // ============================================================================
 
 use crate::tensor_like::{
@@ -5391,13 +5387,13 @@ use crate::tensor_like::{
     TensorContractionLike, TensorFactorizationLike, TensorVectorSpace,
 };
 
-impl TensorVectorSpace for TensorDynLen {
+impl TensorVectorSpace for IdxTensor {
     fn norm_squared(&self) -> std::result::Result<f64, Self::Error> {
-        TensorDynLen::norm_squared(self)
+        IdxTensor::norm_squared(self)
     }
 
     fn maxabs(&self) -> std::result::Result<f64, Self::Error> {
-        TensorDynLen::maxabs(self)
+        IdxTensor::maxabs(self)
     }
 
     fn isapprox(
@@ -5406,7 +5402,7 @@ impl TensorVectorSpace for TensorDynLen {
         atol: f64,
         rtol: f64,
     ) -> std::result::Result<bool, Self::Error> {
-        TensorDynLen::isapprox(self, other, atol, rtol)
+        IdxTensor::isapprox(self, other, atol, rtol)
     }
 
     fn axpby(
@@ -5415,19 +5411,19 @@ impl TensorVectorSpace for TensorDynLen {
         other: &Self,
         b: crate::AnyScalar,
     ) -> std::result::Result<Self, Self::Error> {
-        TensorDynLen::axpby(self, a, other, b)
+        IdxTensor::axpby(self, a, other, b)
     }
 
     fn scale(&self, scalar: crate::AnyScalar) -> std::result::Result<Self, Self::Error> {
-        TensorDynLen::scale(self, scalar)
+        IdxTensor::scale(self, scalar)
     }
 
     fn inner_product(&self, other: &Self) -> std::result::Result<crate::AnyScalar, Self::Error> {
-        TensorDynLen::inner_product(self, other)
+        IdxTensor::inner_product(self, other)
     }
 }
 
-impl TensorFactorizationLike for TensorDynLen {
+impl TensorFactorizationLike for IdxTensor {
     fn factorize(
         &self,
         left_inds: &[DynIndex],
@@ -5446,10 +5442,10 @@ impl TensorFactorizationLike for TensorDynLen {
     }
 }
 
-impl TensorContractionLike for TensorDynLen {
+impl TensorContractionLike for IdxTensor {
     fn conj(&self) -> Self {
         // Delegate to the inherent method (complex conjugate for dense tensors)
-        TensorDynLen::conj(self)
+        IdxTensor::conj(self)
     }
 
     fn direct_sum(
@@ -5470,7 +5466,7 @@ impl TensorContractionLike for TensorDynLen {
 
     fn permuteinds(&self, new_order: &[DynIndex]) -> std::result::Result<Self, Self::Error> {
         // Delegate to the inherent method
-        TensorDynLen::permute_indices(self, new_order)
+        IdxTensor::permute_indices(self, new_order)
     }
 
     fn fuse_indices(
@@ -5479,7 +5475,7 @@ impl TensorContractionLike for TensorDynLen {
         new_index: DynIndex,
         order: LinearizationOrder,
     ) -> std::result::Result<Self, Self::Error> {
-        TensorDynLen::fuse_indices(self, old_indices, new_index, order)
+        IdxTensor::fuse_indices(self, old_indices, new_index, order)
     }
 
     fn contract(tensors: &[&Self]) -> std::result::Result<Self, Self::Error> {
@@ -5491,13 +5487,13 @@ impl TensorContractionLike for TensorDynLen {
     }
 }
 
-impl TensorConstructionLike for TensorDynLen {
+impl TensorConstructionLike for IdxTensor {
     fn select_indices(
         &self,
         selected_indices: &[DynIndex],
         positions: &[usize],
     ) -> std::result::Result<Self, Self::Error> {
-        TensorDynLen::select_indices(self, selected_indices, positions)
+        IdxTensor::select_indices(self, selected_indices, positions)
     }
 
     fn diagonal(
@@ -5514,14 +5510,14 @@ impl TensorConstructionLike for TensorDynLen {
             .into());
         }
 
-        TensorDynLen::from_diag(
+        IdxTensor::from_diag(
             vec![input_index.clone(), output_index.clone()],
             vec![1.0_f64; dim],
         )
     }
 
     fn scalar_one() -> std::result::Result<Self, Self::Error> {
-        TensorDynLen::from_dense(vec![], vec![1.0_f64])
+        IdxTensor::from_dense(vec![], vec![1.0_f64])
     }
 
     fn ones(indices: &[DynIndex]) -> std::result::Result<Self, Self::Error> {
@@ -5530,7 +5526,7 @@ impl TensorConstructionLike for TensorDynLen {
         }
         let dims: Vec<usize> = indices.iter().map(|idx| idx.size()).collect();
         let total_size = checked_total_size(&dims)?;
-        TensorDynLen::from_dense(indices.to_vec(), vec![1.0_f64; total_size])
+        IdxTensor::from_dense(indices.to_vec(), vec![1.0_f64; total_size])
     }
 
     fn onehot(index_vals: &[(DynIndex, usize)]) -> std::result::Result<Self, Self::Error> {
@@ -5614,7 +5610,7 @@ fn column_major_offset(dims: &[usize], vals: &[usize]) -> Result<usize> {
 // High-level API for tensor construction (avoids direct Storage access)
 // ============================================================================
 
-impl TensorDynLen {
+impl IdxTensor {
     fn any_scalar_payload_to_complex(data: Vec<AnyScalar>) -> Vec<Complex64> {
         data.into_iter()
             .map(|value| {
@@ -5676,24 +5672,24 @@ impl TensorDynLen {
     /// product (a shape mismatch).
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
     /// let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    /// let tensor: TensorDynLen = TensorDynLen::from_dense(vec![i, j], data).unwrap();
+    /// let tensor: IdxTensor = IdxTensor::from_dense(vec![i, j], data).unwrap();
     /// assert_eq!(tensor.dims(), vec![2, 3]);
     /// ```
     pub fn from_dense<T: TensorElement>(
         indices: Vec<DynIndex>,
         data: Vec<T>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         let dims = Self::expected_dims_from_indices(&indices);
         Self::validate_indices(&indices)?;
         Self::validate_dense_payload_len(data.len(), &dims)?;
         let native = dense_native_tensor_from_col_major(&data, &dims)?;
-        Self::from_native(indices, native).map_err(TensorDynLenError::from)
+        Self::from_native(indices, native).map_err(IdxTensorError::from)
     }
 
     /// Create a tensor from dense payload data provided as [`AnyScalar`] values.
@@ -5706,12 +5702,12 @@ impl TensorDynLen {
     /// product (a shape mismatch) or a scalar conversion fails.
     /// # Examples
     /// ```
-    /// use tensor4all_core::{AnyScalar, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, IdxTensor};
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense_any(
+    /// let tensor = IdxTensor::from_dense_any(
     ///     vec![i, j],
     ///     vec![
     ///         AnyScalar::new_real(1.0),
@@ -5727,7 +5723,7 @@ impl TensorDynLen {
     pub fn from_dense_any(
         indices: Vec<DynIndex>,
         data: Vec<AnyScalar>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if data.iter().any(AnyScalar::is_complex) {
             Self::from_dense(indices, Self::any_scalar_payload_to_complex(data))
         } else {
@@ -5742,7 +5738,7 @@ impl TensorDynLen {
     /// the multi-index diagonal (`T[i,i,...,i] = data[i]`).
     ///
     /// The returned tensor preserves diagonal metadata; use
-    /// [`TensorDynLen::is_diag`] or [`TensorDynLen::storage_kind`] to inspect
+    /// [`IdxTensor::is_diag`] or [`IdxTensor::storage_kind`] to inspect
     /// that representation. `f32` and `Complex32` values remain eager and are
     /// never promoted into compact `f64`/`Complex64` storage.
     ///
@@ -5752,11 +5748,11 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(3);
     /// let j = DynIndex::new_dyn(3);
-    /// let diag = TensorDynLen::from_diag(vec![i, j], vec![1.0, 2.0, 3.0]).unwrap();
+    /// let diag = IdxTensor::from_diag(vec![i, j], vec![1.0, 2.0, 3.0]).unwrap();
     /// assert!(diag.is_diag());
     ///
     /// let data = diag.to_vec::<f64>().unwrap();
@@ -5769,13 +5765,13 @@ impl TensorDynLen {
     pub fn from_diag<T: TensorElement>(
         indices: Vec<DynIndex>,
         data: Vec<T>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         let dims = Self::expected_dims_from_indices(&indices);
         Self::validate_indices(&indices)?;
         Self::validate_diag_payload_len(data.len(), &dims)?;
         let native = diag_native_tensor_from_col_major(&data, dims.len())?;
         Self::from_native_with_axis_classes(indices, native, Self::diag_axis_classes(dims.len()))
-            .map_err(TensorDynLenError::from)
+            .map_err(IdxTensorError::from)
     }
 
     /// Create a diagonal tensor from diagonal payload data provided as
@@ -5790,12 +5786,12 @@ impl TensorDynLen {
     /// fails.
     /// # Examples
     /// ```
-    /// use tensor4all_core::{AnyScalar, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, IdxTensor};
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(2);
-    /// let tensor = TensorDynLen::from_diag_any(
+    /// let tensor = IdxTensor::from_diag_any(
     ///     vec![i, j],
     ///     vec![AnyScalar::new_real(1.0), AnyScalar::new_complex(2.0, -1.0)],
     /// ).unwrap();
@@ -5806,7 +5802,7 @@ impl TensorDynLen {
     pub fn from_diag_any(
         indices: Vec<DynIndex>,
         data: Vec<AnyScalar>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if data.iter().any(AnyScalar::is_complex) {
             Self::from_diag(indices, Self::any_scalar_payload_to_complex(data))
         } else {
@@ -5824,13 +5820,13 @@ impl TensorDynLen {
     /// mismatch) or the construction fails.
     /// # Examples
     /// ```
-    /// use tensor4all_core::{AnyScalar, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, IdxTensor};
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(2);
     /// let k = Index::new_dyn(2);
-    /// let tensor = TensorDynLen::copy_tensor(
+    /// let tensor = IdxTensor::copy_tensor(
     ///     vec![i, j, k],
     ///     AnyScalar::new_real(1.0),
     /// ).unwrap();
@@ -5840,7 +5836,7 @@ impl TensorDynLen {
     pub fn copy_tensor(
         indices: Vec<DynIndex>,
         value: AnyScalar,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if indices.is_empty() {
             return Self::from_dense_any(vec![], vec![value]);
         }
@@ -5885,12 +5881,12 @@ impl TensorDynLen {
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
     /// let fused = DynIndex::new_link(4).unwrap();
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![i.clone(), j.clone()],
     ///     vec![1.0, 2.0, 3.0, 4.0],
     /// ).unwrap();
@@ -5910,7 +5906,7 @@ impl TensorDynLen {
         old_indices: &[DynIndex],
         new_index: DynIndex,
         order: LinearizationOrder,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if !(!old_indices.is_empty()) {
             return Err(anyhow::anyhow!("fuse_indices requires at least one index to fuse").into());
         };
@@ -5997,7 +5993,7 @@ impl TensorDynLen {
 
         let packed = self.permute(&perm)?;
         let reshaped = packed.try_materialized_inner()?.reshape(&new_dims)?;
-        Self::from_inner(result_indices, reshaped).map_err(TensorDynLenError::from)
+        Self::from_inner(result_indices, reshaped).map_err(IdxTensorError::from)
     }
 
     /// Replace one fused index with multiple indices using an exact reshape.
@@ -6010,18 +6006,18 @@ impl TensorDynLen {
     /// the new index dimensions (a shape mismatch).
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, IdxTensor};
     ///
     /// let fused = DynIndex::new_dyn(4);
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     ///
     /// let unfused = tensor
     ///     .unfuse_index(&fused, &[i.clone(), j.clone()], LinearizationOrder::ColumnMajor)
     ///     .unwrap();
     ///
-    /// let expected = TensorDynLen::from_dense(vec![i, j], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    /// let expected = IdxTensor::from_dense(vec![i, j], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     /// assert!(unfused.isapprox(&expected, 1e-12, 0.0).unwrap());
     /// ```
     pub fn unfuse_index(
@@ -6029,7 +6025,7 @@ impl TensorDynLen {
         old_index: &DynIndex,
         new_indices: &[DynIndex],
         order: LinearizationOrder,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         if !(!new_indices.is_empty()) {
             return Err(
                 anyhow::anyhow!("unfuse_index requires at least one replacement index").into(),
@@ -6099,13 +6095,13 @@ impl TensorDynLen {
     /// unsupported-dtype failure).
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     ///
-    /// let scalar = TensorDynLen::scalar(42.0).unwrap();
+    /// let scalar = IdxTensor::scalar(42.0).unwrap();
     /// assert_eq!(scalar.dims(), Vec::<usize>::new());
     /// assert_eq!(scalar.only().unwrap().real(), 42.0);
     /// ```
-    pub fn scalar<T: TensorElement>(value: T) -> std::result::Result<Self, TensorDynLenError> {
+    pub fn scalar<T: TensorElement>(value: T) -> std::result::Result<Self, IdxTensorError> {
         Self::from_dense(vec![], vec![value])
     }
 
@@ -6116,17 +6112,17 @@ impl TensorDynLen {
     /// or the element type is unsupported.
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
     /// let j = Index::new_dyn(3);
-    /// let tensor = TensorDynLen::zeros::<f64>(vec![i, j]).unwrap();
+    /// let tensor = IdxTensor::zeros::<f64>(vec![i, j]).unwrap();
     /// assert_eq!(tensor.dims(), vec![2, 3]);
     /// ```
     pub fn zeros<T: TensorElement + Zero + Clone>(
         indices: Vec<DynIndex>,
-    ) -> std::result::Result<Self, TensorDynLenError> {
+    ) -> std::result::Result<Self, IdxTensorError> {
         let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
         let size: usize = dims.iter().product();
         Self::from_dense(indices, vec![T::zero(); size])
@@ -6137,7 +6133,7 @@ impl TensorDynLen {
 // High-level API for data extraction (avoids direct .storage() access)
 // ============================================================================
 
-impl TensorDynLen {
+impl IdxTensor {
     /// Extract tensor data as a column-major `Vec<T>`.
     ///
     /// # Type Parameters
@@ -6153,16 +6149,16 @@ impl TensorDynLen {
     /// type (a scalar-kind mismatch) or materialization fails.
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
     /// let data = tensor.to_vec::<f64>().unwrap();
     /// assert_eq!(data, &[1.0, 2.0]);
     /// ```
-    pub fn to_vec<T: TensorElement>(&self) -> std::result::Result<Vec<T>, TensorDynLenError> {
-        native_tensor_primal_to_dense_col_major(self.as_native()?).map_err(TensorDynLenError::from)
+    pub fn to_vec<T: TensorElement>(&self) -> std::result::Result<Vec<T>, IdxTensorError> {
+        native_tensor_primal_to_dense_col_major(self.as_native()?).map_err(IdxTensorError::from)
     }
 
     /// Consume the tensor and return its indices with dense column-major values.
@@ -6185,11 +6181,11 @@ impl TensorDynLen {
     /// type (a scalar-kind mismatch) or materialization fails.
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![i.clone(), j.clone()],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0],
     /// ).unwrap();
@@ -6201,9 +6197,9 @@ impl TensorDynLen {
     /// ```
     pub fn into_dense_col_major_parts<T: TensorElement>(
         self,
-    ) -> std::result::Result<(Vec<DynIndex>, Vec<T>), TensorDynLenError> {
+    ) -> std::result::Result<(Vec<DynIndex>, Vec<T>), IdxTensorError> {
         if !(!self.tracks_grad()) {
-            return Err(anyhow::anyhow!("TensorDynLen::into_dense_col_major_parts cannot consume tensors with tracked autodiff state").into());
+            return Err(anyhow::anyhow!("IdxTensor::into_dense_col_major_parts cannot consume tensors with tracked autodiff state").into());
         };
         let data = self.to_vec::<T>()?;
         Ok((self.indices, data))
@@ -6213,11 +6209,11 @@ impl TensorDynLen {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::TensorDynLen;
+    /// use tensor4all_core::IdxTensor;
     /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
     ///
     /// let i = Index::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
     /// assert!(tensor.is_f64());
     /// assert!(!tensor.is_complex());
     /// ```
@@ -6230,9 +6226,9 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![DynIndex::new_dyn(2)],
     ///     vec![1.0_f32, 2.0],
     /// )
@@ -6249,9 +6245,9 @@ impl TensorDynLen {
     ///
     /// ```
     /// use num_complex::Complex32;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![DynIndex::new_dyn(2)],
     ///     vec![Complex32::new(1.0, 0.0), Complex32::new(0.0, 1.0)],
     /// )
@@ -6267,10 +6263,10 @@ impl TensorDynLen {
     /// # Example
     /// ```
     /// use num_complex::Complex64;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![i],
     ///     vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)],
     /// )
@@ -6286,19 +6282,19 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_tensorbackend::Storage;
     ///
     /// // Tensors from `from_dense` use dense storage
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(2);
-    /// let dense = TensorDynLen::from_dense(vec![i, j], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    /// let dense = IdxTensor::from_dense(vec![i, j], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
     /// assert!(!dense.is_diag());
     ///
     /// // Diagonal metadata is preserved when constructing from diagonal storage.
     /// let k = DynIndex::new_dyn(2);
     /// let l = DynIndex::new_dyn(2);
-    /// let diag = TensorDynLen::from_storage(
+    /// let diag = IdxTensor::from_storage(
     ///     vec![k, l],
     ///     Storage::from_diag_col_major(vec![1.0, 2.0], 2)
     ///         .map(std::sync::Arc::new)
@@ -6316,14 +6312,14 @@ impl TensorDynLen {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use num_complex::Complex64;
     ///
     /// let i = DynIndex::new_dyn(2);
-    /// let real_t = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    /// let real_t = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
     /// assert!(!real_t.is_complex());
     ///
-    /// let complex_t = TensorDynLen::from_dense(
+    /// let complex_t = IdxTensor::from_dense(
     ///     vec![i],
     ///     vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)],
     /// ).unwrap();
@@ -6454,11 +6450,11 @@ mod tests {
         let right = DynIndex::new_dyn(n);
         let far = DynIndex::new_dyn(n);
         let end = DynIndex::new_dyn(n);
-        let a = TensorDynLen::from_copy_selector(left, site.clone(), right.clone(), 1, 1.0_f64)
-            .unwrap();
+        let a =
+            IdxTensor::from_copy_selector(left, site.clone(), right.clone(), 1, 1.0_f64).unwrap();
         let b =
-            TensorDynLen::from_copy_selector(right, site.clone(), far.clone(), 1, 2.0_f64).unwrap();
-        let c = TensorDynLen::from_copy_selector(far, site.clone(), end, 1, 3.0_f64).unwrap();
+            IdxTensor::from_copy_selector(right, site.clone(), far.clone(), 1, 2.0_f64).unwrap();
+        let c = IdxTensor::from_copy_selector(far, site.clone(), end, 1, 3.0_f64).unwrap();
         let result = crate::defaults::contract::contract_with_options(
             &[&a, &b, &c],
             crate::defaults::contract::ContractionOptions::new()
@@ -6473,8 +6469,8 @@ mod tests {
 
     #[test]
     fn structured_metrics_use_authoritative_compact_payload_for_all_dtypes() {
-        fn check(tensor: TensorDynLen, expected_sum: f64, expected_norm_squared: f64) {
-            assert!(matches!(tensor.storage, TensorDynLenStorage::Compact(_)));
+        fn check(tensor: IdxTensor, expected_sum: f64, expected_norm_squared: f64) {
+            assert!(matches!(tensor.storage, IdxTensorStorage::Compact(_)));
             assert!(tensor.eager_cache.get().is_none());
             assert!((tensor.sum().unwrap().real() - expected_sum).abs() < 1.0e-6);
             assert!((tensor.norm_squared().unwrap() - expected_norm_squared).abs() < 1.0e-6);
@@ -6485,17 +6481,17 @@ mod tests {
 
         let indices = || vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
         check(
-            TensorDynLen::from_diag(indices(), vec![1.0_f32, 2.0]).unwrap(),
+            IdxTensor::from_diag(indices(), vec![1.0_f32, 2.0]).unwrap(),
             3.0,
             5.0,
         );
         check(
-            TensorDynLen::from_diag(indices(), vec![1.0_f64, 2.0]).unwrap(),
+            IdxTensor::from_diag(indices(), vec![1.0_f64, 2.0]).unwrap(),
             3.0,
             5.0,
         );
         check(
-            TensorDynLen::from_diag(
+            IdxTensor::from_diag(
                 indices(),
                 vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)],
             )
@@ -6504,7 +6500,7 @@ mod tests {
             5.0,
         );
         check(
-            TensorDynLen::from_diag(
+            IdxTensor::from_diag(
                 indices(),
                 vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
             )
@@ -6525,7 +6521,7 @@ mod tests {
     fn materialization_error_retains_backend_source() {
         let native = NativeTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
         let inner = EagerTensor::from_tensor_in(native, default_eager_ctx().unwrap());
-        let storage = TensorDynLenStorage::Eager {
+        let storage = IdxTensorStorage::Eager {
             inner: Arc::new(inner),
             axis_classes: vec![0, 0],
         };
@@ -6536,10 +6532,10 @@ mod tests {
     }
 
     fn conjugate_with_injected_failure(
-        tensor: &TensorDynLen,
+        tensor: &IdxTensor,
         target: *const EagerTensor,
         message: &'static str,
-    ) -> TensorDynLen {
+    ) -> IdxTensor {
         let calls = Cell::new(0usize);
         let conjugated = tensor.conj_with(&|inner| {
             calls.set(calls.get() + 1);
@@ -6554,10 +6550,10 @@ mod tests {
     }
 
     fn assert_unwrapped_conjugation_error(
-        tensor: TensorDynLen,
+        tensor: IdxTensor,
         target: *const EagerTensor,
         message: &'static str,
-    ) -> TensorDynLen {
+    ) -> IdxTensor {
         let conjugated = conjugate_with_injected_failure(&tensor, target, message);
         let error = conjugated.to_storage().unwrap_err();
         assert!(matches!(error, TensorStorageError::Conjugation { .. }));
@@ -6575,11 +6571,11 @@ mod tests {
         let i = DynIndex::new_dyn(2);
         let native = NativeTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
         let inner = EagerTensor::requires_grad_in(native, default_eager_ctx().unwrap());
-        let tensor = TensorDynLen::from_inner(vec![i], inner).unwrap();
+        let tensor = IdxTensor::from_inner(vec![i], inner).unwrap();
         let source = match &tensor.storage {
-            TensorDynLenStorage::Eager { inner, .. } => Arc::clone(inner),
-            TensorDynLenStorage::Compact(payload) => Arc::clone(&payload.payload),
-            TensorDynLenStorage::Materialized(_) | TensorDynLenStorage::Deferred { .. } => {
+            IdxTensorStorage::Eager { inner, .. } => Arc::clone(inner),
+            IdxTensorStorage::Compact(payload) => Arc::clone(&payload.payload),
+            IdxTensorStorage::Materialized(_) | IdxTensorStorage::Deferred { .. } => {
                 panic!("tracked eager source expected")
             }
         };
@@ -6608,7 +6604,7 @@ mod tests {
     fn structured_payload_conjugation_failure_retains_graph_and_blocks_detached_primal() {
         let i = DynIndex::new_dyn(2);
         let j = DynIndex::new_dyn(2);
-        let tensor = TensorDynLen::from_diag(
+        let tensor = IdxTensor::from_diag(
             vec![i, j],
             vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)],
         )
@@ -6649,7 +6645,7 @@ mod tests {
     fn eager_cache_conjugation_failure_is_deferred_with_original_diagnostic() {
         let i = DynIndex::new_dyn(2);
         let j = DynIndex::new_dyn(2);
-        let tensor = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0]).unwrap();
+        let tensor = IdxTensor::from_diag(vec![i, j], vec![1.0_f64, 2.0]).unwrap();
         tensor.as_inner().unwrap();
         let target = Arc::as_ptr(tensor.eager_cache.get().unwrap());
 

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -6,7 +6,7 @@
 //! - [`TagSet`]: Tag set for metadata (Arc-wrapped for cheap cloning)
 //! - [`Index`]: Generic index type (`Index<Id, Tags>`)
 //! - [`DynIndex`]: Default index type (`Index<DynId, TagSet>`)
-//! - [`TensorDynLen`]: Dense tensor with dynamic rank
+//! - [`IdxTensor`]: Dense tensor with dynamic rank
 //!
 //! Linear algebra operations:
 //! - [`svd::svd`]: Singular Value Decomposition
@@ -17,9 +17,9 @@
 //! These types are suitable for most tensor network applications and provide
 //! a good balance of flexibility and performance.
 
-pub mod index;
 /// Dynamic-length tensor implementation.
-pub mod tensordynlen;
+pub mod idx_tensor;
+pub mod index;
 
 // Contraction
 pub mod contract;
@@ -36,12 +36,11 @@ pub use contract::{
     contract_pair_with_options, contract_with_options, outer_product,
     print_and_reset_contract_profile, reset_contract_profile, tensordot, ContractionOptions,
 };
-pub use index::{DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet};
-pub use tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len,
-    print_and_reset_pairwise_contract_profile, reset_pairwise_contract_profile, unfold_split,
-    TensorDynLen, TensorDynLenError, TensorStorageError,
+pub use idx_tensor::{
+    compute_permutation_from_indices, diag_idx_tensor, print_and_reset_pairwise_contract_profile,
+    reset_pairwise_contract_profile, unfold_split, IdxTensor, IdxTensorError, TensorStorageError,
 };
+pub use index::{DefaultIndex, DefaultTagSet, DynId, DynIndex, Index, TagSet};
 
 // Re-export linear algebra functions and types
 pub use direct_sum::direct_sum;

--- a/crates/tensor4all-core/src/defaults/qr.rs
+++ b/crates/tensor4all-core/src/defaults/qr.rs
@@ -1,11 +1,11 @@
 //! QR decomposition for tensors.
 //!
-//! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
+//! This module works with concrete types (`DynIndex`, `IdxTensor`) only.
 
-use crate::defaults::tensordynlen::unfold_split_inner;
+use crate::defaults::idx_tensor::unfold_split_inner;
 use crate::defaults::DynIndex;
 use crate::global_default::GlobalDefault;
-use crate::TensorDynLen;
+use crate::IdxTensor;
 use num_complex::{Complex64, ComplexFloat};
 use tenferro::DType;
 use tenferro_linalg::eager_tensor::qr as eager_qr;
@@ -29,12 +29,12 @@ pub enum QrError {
 ///
 /// ```
 /// use tensor4all_core::qr::{QrOptions, qr_with};
-/// use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen};
+/// use tensor4all_core::{DynIndex, TensorContractionLike, IdxTensor};
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
 /// let data: Vec<f64> = (0..9).map(|x| x as f64).collect();
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// let opts = QrOptions::new().with_rtol(1e-10);
 /// let (q, r) = qr_with::<f64>(&tensor, &[i], &opts).unwrap();
@@ -189,14 +189,14 @@ where
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{TensorDynLen, DynIndex, qr};
+/// use tensor4all_core::{IdxTensor, DynIndex, qr};
 ///
 /// // Create a 4x3 matrix
 /// let i = DynIndex::new_dyn(4);
 /// let j = DynIndex::new_dyn(3);
 /// // Identity-like data (4x3 column-major)
 /// let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-/// let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let t = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// let (q, r) = qr::<f64>(&t, &[i.clone()]).unwrap();
 ///
@@ -204,10 +204,7 @@ where
 /// assert_eq!(q.dims()[0], 4);
 /// assert_eq!(r.dims()[r.dims().len() - 1], 3);
 /// ```
-pub fn qr<T>(
-    t: &TensorDynLen,
-    left_inds: &[DynIndex],
-) -> Result<(TensorDynLen, TensorDynLen), QrError> {
+pub fn qr<T>(t: &IdxTensor, left_inds: &[DynIndex]) -> Result<(IdxTensor, IdxTensor), QrError> {
     qr_with::<T>(t, left_inds, &QrOptions::default())
 }
 
@@ -250,10 +247,10 @@ pub fn qr<T>(
 /// - The QR computation fails
 /// - `options.rtol` is invalid (not finite or negative)
 pub fn qr_with<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &QrOptions,
-) -> Result<(TensorDynLen, TensorDynLen), QrError> {
+) -> Result<(IdxTensor, IdxTensor), QrError> {
     // Unfold tensor into an eager rank-2 tensor so linalg AD nodes stay connected.
     let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
         .map_err(|e| anyhow::anyhow!("Failed to unfold tensor: {}", e))
@@ -309,7 +306,7 @@ pub fn qr_with<T>(
     let q_reshaped = q_inner.reshape(&q_dims).map_err(|e| {
         QrError::ComputationError(anyhow::anyhow!("eager QR Q reshape failed: {e}"))
     })?;
-    let q = TensorDynLen::from_inner(q_indices, q_reshaped).map_err(QrError::ComputationError)?;
+    let q = IdxTensor::from_inner(q_indices, q_reshaped).map_err(QrError::ComputationError)?;
 
     let mut r_indices = vec![bond_index.clone()];
     r_indices.extend_from_slice(&right_indices);
@@ -317,7 +314,7 @@ pub fn qr_with<T>(
     let r_reshaped = r_inner.reshape(&r_dims).map_err(|e| {
         QrError::ComputationError(anyhow::anyhow!("eager QR R reshape failed: {e}"))
     })?;
-    let r = TensorDynLen::from_inner(r_indices, r_reshaped).map_err(QrError::ComputationError)?;
+    let r = IdxTensor::from_inner(r_indices, r_reshaped).map_err(QrError::ComputationError)?;
 
     Ok((q, r))
 }

--- a/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/qr/tests/mod.rs
@@ -44,7 +44,7 @@ fn unfold_split_preserves_column_major_linearization_with_unit_dims() {
     let i1 = Index::new_dyn(1);
     let i2 = Index::new_dyn(2);
     let i3 = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i1.clone(), i2.clone(), i3.clone()],
         vec![1.0, 2.0, 3.0, 4.0],
     )
@@ -82,7 +82,7 @@ fn qr_options_report_rtol_and_default_roundtrips() {
 fn qr_with_invalid_rtol_is_rejected_before_linalg() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 4]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![0.0; 4]).unwrap();
 
     let nan = qr_with::<f64>(
         &tensor,
@@ -106,7 +106,7 @@ fn qr_with_native_truncation_reduces_bond_dimension() {
     let mut data = vec![0.0; 4];
     data[0] = 1.0;
     data[3] = 1.0e-14;
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 
     let (q, r) = qr_with::<f64>(
         &tensor,
@@ -125,7 +125,7 @@ fn qr_with_complex_fallback_truncation_reduces_bond_dimension() {
     let mut data = vec![Complex64::new(0.0, 0.0); 4];
     data[0] = Complex64::new(1.0, 0.0);
     data[3] = Complex64::new(1.0e-14, 0.0);
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 
     let (q, r) = qr_with::<Complex64>(
         &tensor,

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -1,20 +1,20 @@
 //! SVD decomposition for tensors.
 //!
 //! Provides [`svd`] and [`svd_with`] for computing truncated SVD of
-//! [`TensorDynLen`] values. The tensor is unfolded into a matrix by
+//! [`IdxTensor`] values. The tensor is unfolded into a matrix by
 //! splitting its indices into left and right groups, then the standard
 //! matrix SVD is computed and truncated according to [`SvdOptions`].
 //!
-//! This module works with concrete types (`DynIndex`, `TensorDynLen`) only.
+//! This module works with concrete types (`DynIndex`, `IdxTensor`) only.
 
-use crate::defaults::tensordynlen::unfold_split_inner;
+use crate::defaults::idx_tensor::unfold_split_inner;
 use crate::defaults::DynIndex;
 use crate::index_like::IndexLike;
 use crate::truncation::{
     validate_svd_truncation_policy, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale,
     TruncationRule,
 };
-use crate::TensorDynLen;
+use crate::IdxTensor;
 use num_complex::Complex64;
 use std::sync::Mutex;
 use tenferro::DType;
@@ -40,12 +40,12 @@ pub enum SvdError {
 ///
 /// ```
 /// use tensor4all_core::svd::{SvdOptions, svd_with};
-/// use tensor4all_core::{DynIndex, SvdTruncationPolicy, TensorDynLen};
+/// use tensor4all_core::{DynIndex, SvdTruncationPolicy, IdxTensor};
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
 /// let data: Vec<f64> = (0..9).map(|x| x as f64).collect();
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// let opts = SvdOptions::new().with_policy(SvdTruncationPolicy::new(1e-10));
 /// let (u, s, v) = svd_with::<f64>(&tensor, &[i.clone()], &opts).unwrap();
@@ -229,7 +229,7 @@ type SvdTruncatedEagerResult = (
 );
 
 fn svd_truncated_inner(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<SvdTruncatedEagerResult, SvdError> {
@@ -293,13 +293,13 @@ fn svd_truncated_inner(
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{TensorDynLen, DynIndex, svd};
+/// use tensor4all_core::{IdxTensor, DynIndex, svd};
 ///
 /// // Create a 2x3 matrix (rank-1 outer product: all-ones)
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(3);
 /// let data = vec![1.0_f64; 6]; // all-ones 2x3 matrix
-/// let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let t = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// let (u, s, v) = svd::<f64>(&t, &[i.clone()]).unwrap();
 ///
@@ -311,9 +311,9 @@ fn svd_truncated_inner(
 /// assert_eq!(s.dims().len(), 2);
 /// ```
 pub fn svd<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
-) -> Result<(TensorDynLen, TensorDynLen, TensorDynLen), SvdError> {
+) -> Result<(IdxTensor, IdxTensor, IdxTensor), SvdError> {
     svd_with::<T>(t, left_inds, &SvdOptions::default())
 }
 
@@ -330,7 +330,7 @@ pub fn svd<T>(
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_core::svd::{SvdOptions, svd_with};
 ///
 /// let i = DynIndex::new_dyn(4);
@@ -338,7 +338,7 @@ pub fn svd<T>(
 /// // Rank-1 matrix
 /// let mut data = vec![0.0_f64; 16];
 /// data[0] = 1.0;
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// use tensor4all_core::SvdTruncationPolicy;
 ///
@@ -353,10 +353,10 @@ pub fn svd<T>(
 /// assert!(s.dims()[0] <= 2);
 /// ```
 pub fn svd_with<T>(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &SvdOptions,
-) -> Result<(TensorDynLen, TensorDynLen, TensorDynLen), SvdError> {
+) -> Result<(IdxTensor, IdxTensor, IdxTensor), SvdError> {
     let (u_inner, s_inner, vt_inner, _singular_values, bond_index, left_indices, right_indices) =
         svd_truncated_inner(t, left_inds, options)?;
 
@@ -366,11 +366,10 @@ pub fn svd_with<T>(
     let u_reshaped = u_inner.reshape(&u_dims).map_err(|e| {
         SvdError::ComputationError(anyhow::anyhow!("eager SVD U reshape failed: {e}"))
     })?;
-    let u = TensorDynLen::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
+    let u = IdxTensor::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
 
     let s_indices = vec![bond_index.clone(), bond_index.sim()];
-    let s =
-        TensorDynLen::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
+    let s = IdxTensor::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
 
     let mut vh_indices = vec![bond_index.clone()];
     vh_indices.extend(right_indices);
@@ -378,8 +377,7 @@ pub fn svd_with<T>(
     let vt_reshaped = vt_inner.reshape(&vh_dims).map_err(|e| {
         SvdError::ComputationError(anyhow::anyhow!("eager SVD V^T reshape failed: {e}"))
     })?;
-    let vh =
-        TensorDynLen::from_inner(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
+    let vh = IdxTensor::from_inner(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
     let perm: Vec<usize> = (1..vh.indices.len()).chain(std::iter::once(0)).collect();
     let v = vh
         .conj()
@@ -391,9 +389,9 @@ pub fn svd_with<T>(
 
 /// SVD result for factorization, returning `V^H` directly.
 pub(crate) struct SvdFactorizeResult {
-    pub u: TensorDynLen,
-    pub s: TensorDynLen,
-    pub vh: TensorDynLen,
+    pub u: IdxTensor,
+    pub s: IdxTensor,
+    pub vh: IdxTensor,
     pub bond_index: DynIndex,
     pub singular_values: Vec<f64>,
     pub rank: usize,
@@ -401,7 +399,7 @@ pub(crate) struct SvdFactorizeResult {
 
 /// Compute truncated SVD for factorization, returning `V^H` instead of `V`.
 pub(crate) fn svd_for_factorize(
-    t: &TensorDynLen,
+    t: &IdxTensor,
     left_inds: &[DynIndex],
     options: &SvdOptions,
 ) -> Result<SvdFactorizeResult, SvdError> {
@@ -415,11 +413,10 @@ pub(crate) fn svd_for_factorize(
     let u_reshaped = u_inner.reshape(&u_dims).map_err(|e| {
         SvdError::ComputationError(anyhow::anyhow!("eager SVD U reshape failed: {e}"))
     })?;
-    let u = TensorDynLen::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
+    let u = IdxTensor::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
 
     let s_indices = vec![bond_index.clone(), bond_index.sim()];
-    let s =
-        TensorDynLen::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
+    let s = IdxTensor::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
 
     let mut vh_indices = vec![bond_index.clone()];
     vh_indices.extend(right_indices);
@@ -427,8 +424,7 @@ pub(crate) fn svd_for_factorize(
     let vt_reshaped = vt_inner.reshape(&vh_dims).map_err(|e| {
         SvdError::ComputationError(anyhow::anyhow!("eager SVD V^T reshape failed: {e}"))
     })?;
-    let vh =
-        TensorDynLen::from_inner(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
+    let vh = IdxTensor::from_inner(vh_indices, vt_reshaped).map_err(SvdError::ComputationError)?;
 
     Ok(SvdFactorizeResult {
         u,

--- a/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
+++ b/crates/tensor4all-core/src/defaults/svd/tests/mod.rs
@@ -101,7 +101,7 @@ fn svd_with_max_bond_dim_truncates_native_outputs() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![3.0, 0.0, 0.0, 1.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![3.0, 0.0, 0.0, 1.0]).unwrap();
 
     let (u, s, v) = svd_with::<f64>(
         &tensor,
@@ -120,7 +120,7 @@ fn svd_with_max_bond_dim_truncates_native_outputs() {
 fn svd_with_invalid_rtol_is_rejected_before_linalg() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 4]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![0.0; 4]).unwrap();
 
     let nan = svd_with::<f64>(
         &tensor,

--- a/crates/tensor4all-core/src/krylov.rs
+++ b/crates/tensor4all-core/src/krylov.rs
@@ -18,15 +18,15 @@
 //! ```
 //! use tensor4all_core::{
 //!     krylov::{gmres, GmresOptions},
-//!     DynIndex, TensorDynLen, TensorVectorSpace,
+//!     DynIndex, IdxTensor, TensorVectorSpace,
 //! };
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! let i = DynIndex::new_dyn(2);
-//! let rhs = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -1.0])?;
-//! let initial_guess = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
+//! let rhs = IdxTensor::from_dense(vec![i.clone()], vec![1.0, -1.0])?;
+//! let initial_guess = IdxTensor::from_dense(vec![i.clone()], vec![0.0, 0.0])?;
 //!
-//! let apply_operator = |x: &TensorDynLen| Ok(x.clone());
+//! let apply_operator = |x: &IdxTensor| Ok(x.clone());
 //! let result = gmres(apply_operator, &rhs, &initial_guess, &GmresOptions::default())?;
 //!
 //! assert!(result.converged);
@@ -268,12 +268,12 @@ impl GmresTolerance {
 /// convergence status.
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace};
 /// use tensor4all_core::krylov::{gmres, GmresOptions};
 /// let i = DynIndex::new_dyn(2);
-/// let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 7.0]).unwrap();
-/// let x0 = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap();
-/// let result = gmres(|x: &TensorDynLen| Ok(x.clone()), &b, &x0, &GmresOptions::default()).unwrap();
+/// let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0, 7.0]).unwrap();
+/// let x0 = IdxTensor::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap();
+/// let result = gmres(|x: &IdxTensor| Ok(x.clone()), &b, &x0, &GmresOptions::default()).unwrap();
 /// assert!(result.converged);
 /// assert!(result.residual_norm < 1e-10);
 /// ```
@@ -502,12 +502,12 @@ struct HermitianRitzState {
 /// [`HermitianLanczosResult::converged`] and does not produce an error.
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace};
 /// use tensor4all_core::krylov::{hermitian_lanczos_lowest_eigenpair, HermitianLanczosOptions};
 /// let i = DynIndex::new_dyn(2);
-/// let initial = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 1.0]).unwrap();
+/// let initial = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 1.0]).unwrap();
 /// let result = hermitian_lanczos_lowest_eigenpair(
-///     |x: &TensorDynLen| Ok(x.clone()),
+///     |x: &IdxTensor| Ok(x.clone()),
 ///     &initial,
 ///     &HermitianLanczosOptions::default(),
 /// ).unwrap();
@@ -658,10 +658,10 @@ where
 /// use tensor4all_core::krylov::{
 ///     hermitian_krylov_expm_multiply, HermitianKrylovExpmOptions,
 /// };
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// # fn main() -> anyhow::Result<()> {
 /// let index = DynIndex::new_dyn(2);
-/// let initial = TensorDynLen::from_dense(
+/// let initial = IdxTensor::from_dense(
 ///     vec![index.clone()],
 ///     vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
 /// )?;
@@ -671,9 +671,9 @@ where
 ///     ..Default::default()
 /// };
 /// let result = hermitian_krylov_expm_multiply(
-///     |x: &TensorDynLen| {
+///     |x: &IdxTensor| {
 ///         let data = x.to_vec::<Complex64>()?;
-///         TensorDynLen::from_dense(
+///         IdxTensor::from_dense(
 ///             vec![index.clone()],
 ///             vec![data[0], Complex64::new(2.0, 0.0) * data[1]],
 ///         )
@@ -1793,21 +1793,21 @@ where
 /// # Examples
 /// Solve `2x = b` with a no-op truncation function:
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace, AnyScalar};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace, AnyScalar};
 /// use tensor4all_core::krylov::{gmres_with_truncation, GmresOptions};
 /// let i = DynIndex::new_dyn(2);
-/// let b = TensorDynLen::from_dense(vec![i.clone()], vec![4.0, 6.0]).unwrap();
-/// let x0 = TensorDynLen::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap();
+/// let b = IdxTensor::from_dense(vec![i.clone()], vec![4.0, 6.0]).unwrap();
+/// let x0 = IdxTensor::from_dense(vec![i.clone()], vec![0.0, 0.0]).unwrap();
 /// // Operator A = 2*I (scales input by 2)
-/// let apply_a = |x: &TensorDynLen| {
+/// let apply_a = |x: &IdxTensor| {
 ///     x.scale(AnyScalar::new_real(2.0)).map_err(anyhow::Error::from)
 /// };
 /// // No-op truncation
-/// let truncate = |_x: &mut TensorDynLen| Ok(());
+/// let truncate = |_x: &mut IdxTensor| Ok(());
 /// let result = gmres_with_truncation(apply_a, &b, &x0, &GmresOptions::default(), truncate).unwrap();
 /// assert!(result.converged);
 /// // Solution should be [2.0, 3.0]
-/// let expected = TensorDynLen::from_dense(vec![i], vec![2.0, 3.0]).unwrap();
+/// let expected = IdxTensor::from_dense(vec![i], vec![2.0, 3.0]).unwrap();
 /// assert!(result.solution.sub(&expected).unwrap().maxabs().unwrap() < 1e-8);
 /// ```
 pub fn gmres_with_truncation<T, F, Tr>(
@@ -2222,14 +2222,14 @@ impl RestartGmresOptions {
 /// Result of restarted GMRES solver.
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, AnyScalar};
+/// use tensor4all_core::{DynIndex, IdxTensor, AnyScalar};
 /// use tensor4all_core::krylov::{restart_gmres_with_truncation, RestartGmresOptions};
 /// let i = DynIndex::new_dyn(2);
-/// let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 5.0]).unwrap();
-/// let apply_a = |x: &TensorDynLen| {
+/// let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0, 5.0]).unwrap();
+/// let apply_a = |x: &IdxTensor| {
 ///     x.scale(AnyScalar::new_real(3.0)).map_err(anyhow::Error::from)
 /// };
-/// let truncate = |_x: &mut TensorDynLen| Ok(());
+/// let truncate = |_x: &mut IdxTensor| Ok(());
 /// let result = restart_gmres_with_truncation(
 ///     apply_a, &b, None, &RestartGmresOptions::default(), truncate,
 /// ).unwrap();
@@ -2291,19 +2291,19 @@ pub struct RestartGmresResult<T> {
 /// # Examples
 /// Solve `5x = b` with no truncation:
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace, AnyScalar};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace, AnyScalar};
 /// use tensor4all_core::krylov::{restart_gmres_with_truncation, RestartGmresOptions};
 /// let i = DynIndex::new_dyn(3);
-/// let b = TensorDynLen::from_dense(vec![i.clone()], vec![5.0, 10.0, 15.0]).unwrap();
-/// let apply_a = |x: &TensorDynLen| {
+/// let b = IdxTensor::from_dense(vec![i.clone()], vec![5.0, 10.0, 15.0]).unwrap();
+/// let apply_a = |x: &IdxTensor| {
 ///     x.scale(AnyScalar::new_real(5.0)).map_err(anyhow::Error::from)
 /// };
-/// let truncate = |_x: &mut TensorDynLen| Ok(());
+/// let truncate = |_x: &mut IdxTensor| Ok(());
 /// let result = restart_gmres_with_truncation(
 ///     apply_a, &b, None, &RestartGmresOptions::default(), truncate,
 /// ).unwrap();
 /// assert!(result.converged);
-/// let expected = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
+/// let expected = IdxTensor::from_dense(vec![i], vec![1.0, 2.0, 3.0]).unwrap();
 /// assert!(result.solution.sub(&expected).unwrap().maxabs().unwrap() < 1e-8);
 /// ```
 pub fn restart_gmres_with_truncation<T, F, Tr>(

--- a/crates/tensor4all-core/src/krylov/tests/mod.rs
+++ b/crates/tensor4all-core/src/krylov/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::defaults::tensordynlen::TensorDynLen;
+use crate::defaults::idx_tensor::IdxTensor;
 use crate::defaults::DynIndex;
 use crate::tensor_index::TensorIndex;
 use crate::{TensorVectorSpace, TensorVectorSpaceError};
@@ -206,7 +206,7 @@ fn hermitian_lanczos_lowest_eigenpair_complex_pauli_y() {
     ];
 
     let result = hermitian_lanczos_lowest_eigenpair(
-        |x: &TensorDynLen| apply_matrix2_c64(x, &pauli_y),
+        |x: &IdxTensor| apply_matrix2_c64(x, &pauli_y),
         &initial,
         &HermitianLanczosOptions {
             max_iter: 4,
@@ -228,7 +228,7 @@ fn hermitian_lanczos_lowest_eigenpair_rejects_non_hermitian_projection() {
     let non_hermitian = [0.0, 1.0, 0.0, 0.0];
 
     let err = hermitian_lanczos_lowest_eigenpair(
-        |x: &TensorDynLen| apply_matrix2_f64(x, &non_hermitian),
+        |x: &IdxTensor| apply_matrix2_f64(x, &non_hermitian),
         &initial,
         &HermitianLanczosOptions {
             max_iter: 2,
@@ -250,7 +250,7 @@ fn hermitian_krylov_expm_multiply_diagonal_real_time_matches_exact() {
     );
 
     let result = hermitian_krylov_expm_multiply(
-        |x: &TensorDynLen| scale_vector_c64(x, &[1.0, 3.0]),
+        |x: &IdxTensor| scale_vector_c64(x, &[1.0, 3.0]),
         Complex64::new(0.0, -0.25),
         &initial,
         &HermitianKrylovExpmOptions {
@@ -278,7 +278,7 @@ fn hermitian_krylov_expm_multiply_first_step_breakdown_reports_finite_error() {
     );
 
     let result = hermitian_krylov_expm_multiply(
-        |x: &TensorDynLen| scale_vector_c64(x, &[2.0, 2.0]),
+        |x: &IdxTensor| scale_vector_c64(x, &[2.0, 2.0]),
         Complex64::new(0.0, -0.25),
         &initial,
         &HermitianKrylovExpmOptions::default(),
@@ -304,7 +304,7 @@ fn hermitian_krylov_expm_multiply_zero_exponent_returns_input() {
     );
 
     let result = hermitian_krylov_expm_multiply(
-        |_x: &TensorDynLen| panic!("zero exponent must not request a matvec"),
+        |_x: &IdxTensor| panic!("zero exponent must not request a matvec"),
         Complex64::new(0.0, 0.0),
         &initial,
         &HermitianKrylovExpmOptions::default(),
@@ -325,7 +325,7 @@ fn hermitian_krylov_expm_multiply_zero_initial_returns_zero_without_matvecs() {
     let initial = make_vector_c64(vec![Complex64::new(0.0, 0.0); 2], &idx);
 
     let result = hermitian_krylov_expm_multiply(
-        |_x: &TensorDynLen| panic!("zero input must not request a matvec"),
+        |_x: &IdxTensor| panic!("zero input must not request a matvec"),
         Complex64::new(0.0, -0.25),
         &initial,
         &HermitianKrylovExpmOptions::default(),
@@ -346,7 +346,7 @@ fn hermitian_krylov_expm_multiply_real_tensor_promotes_complex_evolution() {
     let initial = make_vector_with_index(vec![1.0, 0.0], &idx);
 
     let result = hermitian_krylov_expm_multiply(
-        |x: &TensorDynLen| apply_matrix2_f64(x, &[0.0, 1.0, 1.0, 0.0]),
+        |x: &IdxTensor| apply_matrix2_f64(x, &[0.0, 1.0, 1.0, 0.0]),
         Complex64::new(0.0, -0.5),
         &initial,
         &HermitianKrylovExpmOptions::default(),
@@ -371,7 +371,7 @@ fn hermitian_krylov_expm_multiply_errors_when_unconverged() {
     );
 
     let err = hermitian_krylov_expm_multiply(
-        |x: &TensorDynLen| scale_vector_c64(x, &[1.0, 2.0, 3.0]),
+        |x: &IdxTensor| scale_vector_c64(x, &[1.0, 2.0, 3.0]),
         Complex64::new(0.0, -1.0),
         &initial,
         &HermitianKrylovExpmOptions {
@@ -411,7 +411,7 @@ fn gmres_absolute_tolerance_and_total_iteration_limit_paths() {
     let idx = DynIndex::new_dyn(2);
     let b = make_vector_with_index(vec![4.0, 9.0], &idx);
     let x0 = make_vector_with_index(vec![0.0, 0.0], &idx);
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { scale_vector_f64(x, &[2.0, 3.0]) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { scale_vector_f64(x, &[2.0, 3.0]) };
     let options = GmresOptions {
         max_iter: 4,
         rtol: 1e-12,
@@ -426,7 +426,7 @@ fn gmres_absolute_tolerance_and_total_iteration_limit_paths() {
     assert!(result.solution.sub(&expected).unwrap().maxabs().unwrap() < 1e-10);
 
     let limited = gmres_with_total_iteration_limit(
-        |x: &TensorDynLen| scale_vector_f64(x, &[2.0, 3.0]),
+        |x: &IdxTensor| scale_vector_f64(x, &[2.0, 3.0]),
         &b,
         &x0,
         &options,
@@ -451,7 +451,7 @@ fn gmres_affine_matches_shifted_system_and_scalar_shortcuts() {
     };
 
     let result = gmres_affine_with_absolute_tolerance(
-        |x: &TensorDynLen| scale_vector_f64(x, &[2.0, 5.0]),
+        |x: &IdxTensor| scale_vector_f64(x, &[2.0, 5.0]),
         &b,
         &x0,
         AnyScalar::new_real(1.0),
@@ -465,7 +465,7 @@ fn gmres_affine_matches_shifted_system_and_scalar_shortcuts() {
     assert!(result.solution.sub(&expected).unwrap().maxabs().unwrap() < 1e-10);
 
     let scaled = gmres_affine(
-        |x: &TensorDynLen| scale_vector_f64(x, &[100.0, 100.0]),
+        |x: &IdxTensor| scale_vector_f64(x, &[100.0, 100.0]),
         &b,
         &x0,
         AnyScalar::new_real(2.0),
@@ -486,7 +486,7 @@ fn gmres_affine_matches_shifted_system_and_scalar_shortcuts() {
     );
 
     let err = gmres_affine(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         &x0,
         AnyScalar::new_real(0.0),
@@ -512,7 +512,7 @@ fn gmres_affine_profile_and_zero_rhs_paths() {
 
     let result = with_gmres_profile_env(|| {
         gmres_affine(
-            |x: &TensorDynLen| Ok(x.clone()),
+            |x: &IdxTensor| Ok(x.clone()),
             &b,
             &x0,
             AnyScalar::new_real(1.0),
@@ -562,7 +562,7 @@ fn gmres_affine_profile_covers_nonconverged_restart_and_final_paths() {
 
     let result = with_gmres_profile_env(|| {
         gmres_affine(
-            |x: &TensorDynLen| scale_vector_f64(x, &[2.0, 5.0]),
+            |x: &IdxTensor| scale_vector_f64(x, &[2.0, 5.0]),
             &b,
             &x0,
             AnyScalar::new_real(0.5),
@@ -586,7 +586,7 @@ fn gmres_affine_profile_covers_scalar_shortcut() {
 
     let result = with_gmres_profile_env(|| {
         gmres_affine(
-            |x: &TensorDynLen| Ok(x.clone()),
+            |x: &IdxTensor| Ok(x.clone()),
             &b,
             &x0,
             AnyScalar::new_real(2.0),
@@ -614,13 +614,13 @@ fn gmres_lucky_breakdown_paths_are_reachable_with_zero_tolerance() {
         check_true_residual: false,
     };
 
-    let result = gmres(|x: &TensorDynLen| Ok(x.clone()), &b, &x0, &options).unwrap();
+    let result = gmres(|x: &IdxTensor| Ok(x.clone()), &b, &x0, &options).unwrap();
     assert!(!result.converged);
     assert_eq!(result.iterations, 1);
     assert!(result.solution.sub(&b).unwrap().maxabs().unwrap() < 1e-12);
 
     let affine = gmres_affine(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         &x0,
         AnyScalar::new_real(0.0),
@@ -633,11 +633,11 @@ fn gmres_lucky_breakdown_paths_are_reachable_with_zero_tolerance() {
     assert!(affine.solution.sub(&b).unwrap().maxabs().unwrap() < 1e-12);
 
     let truncated = gmres_with_truncation(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         &x0,
         &options,
-        |_: &mut TensorDynLen| Ok(()),
+        |_: &mut IdxTensor| Ok(()),
     )
     .unwrap();
     assert!(!truncated.converged);
@@ -658,16 +658,16 @@ fn gmres_convergence_branches_cover_true_residual_and_affine_fast_finish() {
         check_true_residual: true,
     };
 
-    let checked = gmres(|x: &TensorDynLen| Ok(x.clone()), &b, &x0, &options).unwrap();
+    let checked = gmres(|x: &IdxTensor| Ok(x.clone()), &b, &x0, &options).unwrap();
     assert!(checked.converged);
     assert!(checked.solution.sub(&b).unwrap().maxabs().unwrap() < 1e-12);
 
     let truncated = gmres_with_truncation(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         &x0,
         &options,
-        |_: &mut TensorDynLen| Ok(()),
+        |_: &mut IdxTensor| Ok(()),
     )
     .unwrap();
     assert!(truncated.converged);
@@ -678,7 +678,7 @@ fn gmres_convergence_branches_cover_true_residual_and_affine_fast_finish() {
         ..options
     };
     let affine = gmres_affine(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         &x0,
         AnyScalar::new_real(0.0),
@@ -708,7 +708,7 @@ fn gmres_affine_profile_covers_true_residual_rejection_and_lucky_breakdown() {
     let calls = Cell::new(0usize);
     let checked = with_gmres_profile_env(|| {
         gmres_affine(
-            |x: &TensorDynLen| {
+            |x: &IdxTensor| {
                 let call = calls.get();
                 calls.set(call + 1);
                 if call == 2 {
@@ -736,7 +736,7 @@ fn gmres_affine_profile_covers_true_residual_rejection_and_lucky_breakdown() {
     };
     let lucky = with_gmres_profile_env(|| {
         gmres_affine(
-            |x: &TensorDynLen| Ok(x.clone()),
+            |x: &IdxTensor| Ok(x.clone()),
             &b,
             &x0,
             AnyScalar::new_real(0.0),
@@ -764,7 +764,7 @@ fn gmres_zero_cycle_and_restart_nonzero_update_paths() {
     };
 
     let zero_cycle = gmres_with_total_iteration_limit(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         &x0,
         &zero_cycle_options,
@@ -784,11 +784,11 @@ fn gmres_zero_cycle_and_restart_nonzero_update_paths() {
         verbose: true,
     };
     let restarted = restart_gmres_with_truncation(
-        |x: &TensorDynLen| Ok(x.clone()),
+        |x: &IdxTensor| Ok(x.clone()),
         &b,
         None,
         &restart_options,
-        |_: &mut TensorDynLen| Ok(()),
+        |_: &mut IdxTensor| Ok(()),
     )
     .unwrap();
     assert!(!restarted.converged);
@@ -823,50 +823,50 @@ fn gmres_private_helpers_cover_edge_paths() {
 }
 
 /// Helper to create a 1D tensor (vector) with given data and shared index.
-fn make_vector_with_index(data: Vec<f64>, idx: &DynIndex) -> TensorDynLen {
-    TensorDynLen::from_dense(vec![idx.clone()], data).unwrap()
+fn make_vector_with_index(data: Vec<f64>, idx: &DynIndex) -> IdxTensor {
+    IdxTensor::from_dense(vec![idx.clone()], data).unwrap()
 }
 
-fn scale_vector_f64(x: &TensorDynLen, diag: &[f64]) -> Result<TensorDynLen> {
+fn scale_vector_f64(x: &IdxTensor, diag: &[f64]) -> Result<IdxTensor> {
     let x_data = x.to_vec::<f64>()?;
     let result_data: Vec<f64> = x_data
         .iter()
         .zip(diag.iter())
         .map(|(&xi, &di)| xi * di)
         .collect();
-    Ok(TensorDynLen::from_dense(x.indices.clone(), result_data).unwrap())
+    Ok(IdxTensor::from_dense(x.indices.clone(), result_data).unwrap())
 }
 
-fn scale_vector_c64(x: &TensorDynLen, diag: &[f64]) -> Result<TensorDynLen> {
+fn scale_vector_c64(x: &IdxTensor, diag: &[f64]) -> Result<IdxTensor> {
     let x_data = x.to_vec::<Complex64>()?;
     let result_data: Vec<_> = x_data
         .iter()
         .zip(diag.iter())
         .map(|(&xi, &di)| xi * di)
         .collect();
-    Ok(TensorDynLen::from_dense(x.indices.clone(), result_data).unwrap())
+    Ok(IdxTensor::from_dense(x.indices.clone(), result_data).unwrap())
 }
 
-fn apply_matrix2_f64(x: &TensorDynLen, a_data: &[f64; 4]) -> Result<TensorDynLen> {
+fn apply_matrix2_f64(x: &IdxTensor, a_data: &[f64; 4]) -> Result<IdxTensor> {
     let x_data = x.to_vec::<f64>()?;
     let result_data = vec![
         a_data[0] * x_data[0] + a_data[1] * x_data[1],
         a_data[2] * x_data[0] + a_data[3] * x_data[1],
     ];
-    Ok(TensorDynLen::from_dense(x.indices.clone(), result_data).unwrap())
+    Ok(IdxTensor::from_dense(x.indices.clone(), result_data).unwrap())
 }
 
-fn make_vector_c64(data: Vec<Complex64>, idx: &DynIndex) -> TensorDynLen {
-    TensorDynLen::from_dense(vec![idx.clone()], data).unwrap()
+fn make_vector_c64(data: Vec<Complex64>, idx: &DynIndex) -> IdxTensor {
+    IdxTensor::from_dense(vec![idx.clone()], data).unwrap()
 }
 
-fn apply_matrix2_c64(x: &TensorDynLen, a_data: &[Complex64; 4]) -> Result<TensorDynLen> {
+fn apply_matrix2_c64(x: &IdxTensor, a_data: &[Complex64; 4]) -> Result<IdxTensor> {
     let x_data = x.to_vec::<Complex64>()?;
     let result_data = vec![
         a_data[0] * x_data[0] + a_data[1] * x_data[1],
         a_data[2] * x_data[0] + a_data[3] * x_data[1],
     ];
-    Ok(TensorDynLen::from_dense(x.indices.clone(), result_data).unwrap())
+    Ok(IdxTensor::from_dense(x.indices.clone(), result_data).unwrap())
 }
 
 #[test]
@@ -963,7 +963,7 @@ fn test_gmres_identity_operator() {
     let x0 = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
 
     // Identity operator: A x = x
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1001,7 +1001,7 @@ fn test_gmres_diagonal_matrix() {
 
     // Diagonal scaling operator
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1051,7 +1051,7 @@ fn test_gmres_complex_nonsymmetric_matrix() {
         Complex64::new(1.5, 1.0),
     ];
     let b = apply_matrix2_c64(&expected_x, &a_data).unwrap();
-    let apply_a = move |x: &TensorDynLen| apply_matrix2_c64(x, &a_data);
+    let apply_a = move |x: &IdxTensor| apply_matrix2_c64(x, &a_data);
     let options = GmresOptions {
         max_iter: 2,
         rtol: 1e-12,
@@ -1084,7 +1084,7 @@ fn test_gmres_with_total_iteration_limit_shortens_final_restart() {
     let x0 = make_vector_with_index(vec![0.0; 6], &idx);
 
     let diag = [1.0, 1.7, 2.3, 3.1, 4.2, 5.6];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
     let options = GmresOptions {
         max_iter: 3,
         rtol: 0.0,
@@ -1105,7 +1105,7 @@ fn test_gmres_with_total_iteration_limit_allows_zero_iterations() {
     let b = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
     let x0 = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
     let options = GmresOptions {
         max_iter: 3,
         rtol: 1e-10,
@@ -1135,7 +1135,7 @@ fn test_gmres_nonsymmetric_matrix() {
     // Matrix A = [[2, 1], [0, 3]]
     let a_data = [2.0, 1.0, 0.0, 3.0];
 
-    let apply_a = move |x: &TensorDynLen| apply_matrix2_f64(x, &a_data);
+    let apply_a = move |x: &IdxTensor| apply_matrix2_f64(x, &a_data);
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1172,7 +1172,7 @@ fn test_gmres_with_good_initial_guess() {
     let b = make_vector_with_index(vec![2.0, 4.0, 6.0], &idx);
     let x0 = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx); // Already the solution for A=diag(2,2,2)
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> {
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> {
         // A = 2*I
         x.scale(AnyScalar::new_real(2.0))
             .map_err(anyhow::Error::from)
@@ -1193,8 +1193,8 @@ fn test_gmres_with_good_initial_guess() {
 }
 
 /// Helper to create a 1D complex tensor (vector) with given data and shared index.
-fn make_vector_c64_with_index(data: Vec<num_complex::Complex64>, idx: &DynIndex) -> TensorDynLen {
-    TensorDynLen::from_dense(vec![idx.clone()], data).unwrap()
+fn make_vector_c64_with_index(data: Vec<num_complex::Complex64>, idx: &DynIndex) -> IdxTensor {
+    IdxTensor::from_dense(vec![idx.clone()], data).unwrap()
 }
 
 #[test]
@@ -1216,7 +1216,7 @@ fn test_gmres_identity_operator_c64() {
     let x0 = make_vector_c64_with_index(vec![Complex64::new(0.0, 0.0); 4], &idx);
 
     // Identity operator: A x = x
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
 
     let options = GmresOptions {
         max_iter: 20,
@@ -1268,14 +1268,14 @@ fn test_gmres_diagonal_c64() {
     let x0 = make_vector_c64_with_index(vec![Complex64::new(0.0, 0.0); 4], &idx);
     let expected = make_vector_c64_with_index(x_true.to_vec(), &idx);
 
-    let apply_a = move |x: &TensorDynLen| -> Result<TensorDynLen> {
+    let apply_a = move |x: &IdxTensor| -> Result<IdxTensor> {
         let x_data = x.to_vec::<Complex64>()?;
         let result_data: Vec<Complex64> = x_data
             .iter()
             .zip(diag.iter())
             .map(|(&xi, &di)| di * xi)
             .collect();
-        Ok(TensorDynLen::from_dense(x.indices.clone(), result_data).unwrap())
+        Ok(IdxTensor::from_dense(x.indices.clone(), result_data).unwrap())
     };
 
     let options = GmresOptions {
@@ -1309,7 +1309,7 @@ fn test_gmres_zero_rhs() {
     let b = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
     let x0 = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
 
     let options = GmresOptions::default();
 
@@ -1329,10 +1329,10 @@ fn test_restart_gmres_identity_operator() {
     let idx = DynIndex::new_dyn(3);
     let b = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
 
     // No-op truncation
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = RestartGmresOptions::default();
 
@@ -1365,10 +1365,10 @@ fn test_restart_gmres_diagonal_matrix() {
     let expected_x = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
     // No-op truncation
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = RestartGmresOptions {
         max_outer_iters: 10,
@@ -1414,9 +1414,9 @@ fn test_restart_gmres_with_initial_guess() {
     let expected_x = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = RestartGmresOptions::default();
 
@@ -1446,9 +1446,9 @@ fn test_restart_gmres_outer_iterations_tracked() {
     let b = make_vector_with_index(vec![2.0, 6.0, 12.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     // Use small inner_max_iter to encourage multiple outer iterations
     let options = RestartGmresOptions {
@@ -1482,8 +1482,8 @@ fn test_restart_gmres_zero_rhs() {
     let idx = DynIndex::new_dyn(3);
     let b = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = RestartGmresOptions::default();
 
@@ -1524,10 +1524,10 @@ fn test_gmres_with_truncation_check_true_residual_safe() {
     let x0 = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
     // No-op truncation: convergence should work normally with check enabled
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1568,10 +1568,10 @@ fn test_gmres_with_truncation_check_true_residual_consistency() {
 
     // A = diag(1, 2, 3, 4)
     let diag = [1.0, 2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
     // No-op truncation: the solver should converge normally
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     // Without check: converged with Hessenberg residual
     let options_no_check = GmresOptions {
@@ -1626,7 +1626,7 @@ fn test_gmres_verbose_output() {
     let x0 = make_vector_with_index(vec![0.0, 0.0], &idx);
 
     let a_data = [2.0, 1.0, 0.0, 3.0];
-    let apply_a = move |x: &TensorDynLen| apply_matrix2_f64(x, &a_data);
+    let apply_a = move |x: &IdxTensor| apply_matrix2_f64(x, &a_data);
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1649,7 +1649,7 @@ fn test_gmres_no_convergence_exhausts_restarts() {
     let x0 = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
     // Very few iterations and restarts, tight tolerance
     let options = GmresOptions {
@@ -1676,7 +1676,7 @@ fn test_gmres_lucky_breakdown() {
     let b = make_vector_with_index(vec![10.0], &idx);
     let x0 = make_vector_with_index(vec![0.0], &idx);
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { scale_vector_f64(x, &[5.0]) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { scale_vector_f64(x, &[5.0]) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1708,8 +1708,8 @@ fn test_gmres_with_truncation_zero_rhs() {
     let b = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
     let x0 = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
 
-    let apply_a = |x: &TensorDynLen| -> Result<TensorDynLen> { Ok(x.clone()) };
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = |x: &IdxTensor| -> Result<IdxTensor> { Ok(x.clone()) };
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1732,8 +1732,8 @@ fn test_gmres_with_truncation_already_converged() {
     let x0 = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx); // Exact solution for diag(2,3,4)
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1757,8 +1757,8 @@ fn test_gmres_with_truncation_verbose() {
     let x0 = make_vector_with_index(vec![0.0, 0.0, 0.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = GmresOptions {
         max_iter: 10,
@@ -1783,14 +1783,14 @@ fn test_restart_gmres_stagnation_detection() {
     let b = make_vector_with_index(vec![1.0, 1.0, 1.0], &idx);
 
     let diag = [3.0, 7.0, 11.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
     // Truncation that rounds to 1 decimal place - the exact solution [1/3, 1/7, 1/11]
     // gets rounded to [0.3, 0.1, 0.1], preventing convergence below the rounding error.
-    let truncate = |x: &mut TensorDynLen| -> Result<()> {
+    let truncate = |x: &mut IdxTensor| -> Result<()> {
         let data = x.to_vec::<f64>()?;
         let new_data: Vec<f64> = data.iter().map(|&v| (v * 10.0).round() / 10.0).collect();
-        *x = TensorDynLen::from_dense(x.indices.clone(), new_data).unwrap();
+        *x = IdxTensor::from_dense(x.indices.clone(), new_data).unwrap();
         Ok(())
     };
 
@@ -1816,8 +1816,8 @@ fn test_restart_gmres_exhausts_outer_iters() {
     let b = make_vector_with_index(vec![2.0, 6.0, 12.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     // Very few iterations and extremely tight tolerance to prevent convergence
     let options = RestartGmresOptions {
@@ -1842,8 +1842,8 @@ fn test_restart_gmres_verbose() {
     let b = make_vector_with_index(vec![2.0, 6.0, 12.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = RestartGmresOptions {
         max_outer_iters: 10,
@@ -1867,8 +1867,8 @@ fn test_restart_gmres_zero_rhs_with_x0() {
     let x0 = make_vector_with_index(vec![1.0, 2.0, 3.0], &idx);
 
     let diag = [2.0, 3.0, 4.0];
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
-    let truncate = |_x: &mut TensorDynLen| -> Result<()> { Ok(()) };
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
+    let truncate = |_x: &mut IdxTensor| -> Result<()> { Ok(()) };
 
     let options = RestartGmresOptions {
         max_outer_iters: 5,
@@ -1898,12 +1898,12 @@ fn test_restart_gmres_stagnation_verbose() {
     let diag: Vec<f64> = (0..n)
         .map(|i| 10.0_f64.powf(i as f64 * 3.0 / (n as f64 - 1.0)))
         .collect();
-    let apply_a = move |x: &TensorDynLen| scale_vector_f64(x, &diag);
+    let apply_a = move |x: &IdxTensor| scale_vector_f64(x, &diag);
 
-    let truncate = |x: &mut TensorDynLen| -> Result<()> {
+    let truncate = |x: &mut IdxTensor| -> Result<()> {
         let data = x.to_vec::<f64>()?;
         let new_data: Vec<f64> = data.iter().map(|&v| (v * 100.0).round() / 100.0).collect();
-        *x = TensorDynLen::from_dense(x.indices.clone(), new_data).unwrap();
+        *x = IdxTensor::from_dense(x.indices.clone(), new_data).unwrap();
         Ok(())
     };
 

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -5,13 +5,13 @@
 //!
 //! - **Index types**: [`DynIndex`], [`Index`], [`DynId`] for tensor indices
 //! - **Tag sets**: [`TagSet`], [`TagSetLike`] for metadata tagging
-//! - **Tensors**: [`TensorDynLen`] for dynamic-rank dense tensors
+//! - **Tensors**: [`IdxTensor`] for dynamic-rank dense tensors
 //! - **Operations**: Contraction, SVD, QR decomposition, factorization
 //!
 //! # Example
 //!
 //! ```
-//! use tensor4all_core::{Index, DynIndex, TensorDynLen};
+//! use tensor4all_core::{Index, DynIndex, IdxTensor};
 //!
 //! // Create indices with dynamic identity
 //! let i = Index::new_dyn(2);
@@ -19,7 +19,7 @@
 //!
 //! // Create a tensor
 //! let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-//! let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+//! let t = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 //! ```
 
 #[cfg(doctest)]
@@ -32,7 +32,7 @@ pub mod col_major_array;
 pub use col_major_array::{ColMajorArray, ColMajorArrayMut, ColMajorArrayRef};
 
 // Common (tags, utilities, scalar)
-/// Dynamic scalar compatibility wrapper built on rank-0 `TensorDynLen`.
+/// Dynamic scalar compatibility wrapper built on rank-0 `IdxTensor`.
 pub mod any_scalar;
 pub mod global_default;
 pub mod index_like;
@@ -77,13 +77,13 @@ pub mod krylov;
 // Block tensor for block matrix GMRES
 pub mod block_tensor;
 
-// Backwards compatibility: re-export defaults::tensordynlen as tensor
-pub use defaults::tensordynlen as tensor;
+// Backwards compatibility: re-export defaults::idx_tensor as tensor
+pub use defaults::idx_tensor as tensor;
 
 pub use any_scalar::{AnyScalar, AnyScalarError};
-pub use defaults::tensordynlen::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, unfold_split, StructuredSelectorError,
-    TensorDynLen, TensorDynLenError, TensorStorageError,
+pub use defaults::idx_tensor::{
+    compute_permutation_from_indices, diag_idx_tensor, unfold_split, IdxTensor, IdxTensorError,
+    StructuredSelectorError, TensorStorageError,
 };
 pub use tensor4all_tensorbackend::TensorElement;
 pub use tensor4all_tensorbackend::{
@@ -101,7 +101,7 @@ pub use defaults::contract::{
     outer_product, print_and_reset_contract_profile, reset_contract_profile, tensordot,
     ContractionOptions, PairwiseContractionOptions,
 };
-pub use defaults::tensordynlen::{
+pub use defaults::idx_tensor::{
     print_and_reset_pairwise_contract_profile, reset_pairwise_contract_profile,
 };
 

--- a/crates/tensor4all-core/src/prelude.rs
+++ b/crates/tensor4all-core/src/prelude.rs
@@ -7,7 +7,7 @@
 //! let i = DynIndex::new_dyn(3);
 //! let j = DynIndex::new_dyn(4);
 //! let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-//! let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+//! let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 //! let result = factorize(&tensor, &[i], &FactorizeOptions::svd()).unwrap();
 //! let recovered = result.left.contract_pair(&result.right).unwrap();
 //! assert!(tensor.distance(&recovered).unwrap() < 1e-12);
@@ -16,9 +16,9 @@
 pub use crate::{
     contract, contract_pair, direct_sum, factorize, outer_product, qr, svd, tensordot, Canonical,
     CommonScalar, ContractionOptions, DecompositionAlg, DirectSumResult, DynId, DynIndex,
-    FactorizeAlg, FactorizeOptions, FactorizeResult, Index, IndexLike, LinearizationOrder,
-    PairwiseContractionOptions, SingularValueMeasure, SvdOptions, SvdTruncationPolicy, Tag, TagSet,
-    TagSetLike, TensorConstructionLike, TensorContractionLike, TensorDynLen, TensorElement,
-    TensorFactorizationLike, TensorIndex, TensorLike, TensorVectorSpace, ThresholdScale,
-    TruncationRule,
+    FactorizeAlg, FactorizeOptions, FactorizeResult, IdxTensor, Index, IndexLike,
+    LinearizationOrder, PairwiseContractionOptions, SingularValueMeasure, SvdOptions,
+    SvdTruncationPolicy, Tag, TagSet, TagSetLike, TensorConstructionLike, TensorContractionLike,
+    TensorElement, TensorFactorizationLike, TensorIndex, TensorLike, TensorVectorSpace,
+    ThresholdScale, TruncationRule,
 };

--- a/crates/tensor4all-core/src/tensor_index.rs
+++ b/crates/tensor4all-core/src/tensor_index.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 /// Trait for objects that have external indices and support index operations.
 ///
 /// This is a minimal trait that can be implemented by:
-/// - Dense tensors (`TensorDynLen`)
+/// - Dense tensors (`IdxTensor`)
 /// - Tensor networks (`TreeTN`)
 /// - Any other structure that organizes tensors with indices
 ///

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -32,13 +32,13 @@ use thiserror::Error;
 ///
 /// ```
 /// use tensor4all_core::{
-///     factorize, Canonical, DynIndex, FactorizeOptions, TensorContractionLike, TensorDynLen,
+///     factorize, Canonical, DynIndex, FactorizeOptions, TensorContractionLike, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
 /// let data: Vec<f64> = (0..9).map(|x| x as f64).collect();
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// // QR with Canonical::Right is not supported
 /// let result = factorize(
@@ -138,13 +138,13 @@ pub enum FactorizeAlg {
 ///
 /// ```
 /// use tensor4all_core::{
-///     factorize, Canonical, DynIndex, FactorizeOptions, TensorContractionLike, TensorDynLen,
+///     factorize, Canonical, DynIndex, FactorizeOptions, TensorContractionLike, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(3);
 /// let data: Vec<f64> = (0..9).map(|x| x as f64).collect();
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// // Left canonical: left factor has orthonormal columns
 /// let left_result = factorize(
@@ -203,14 +203,14 @@ pub enum Canonical {
 ///
 /// ```
 /// use tensor4all_core::{
-///     factorize, Canonical, DynIndex, FactorizeOptions, TensorDynLen,
+///     factorize, Canonical, DynIndex, FactorizeOptions, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(4);
 /// let j = DynIndex::new_dyn(4);
 /// let mut data = vec![0.0_f64; 16];
 /// data[0] = 1.0;  // rank-1 matrix
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// // SVD with an explicit policy
 /// let opts = FactorizeOptions::svd()
@@ -431,13 +431,13 @@ impl FactorizeOptions {
 ///
 /// ```
 /// use tensor4all_core::{
-///     factorize, DynIndex, FactorizeOptions, TensorContractionLike, TensorDynLen,
+///     factorize, DynIndex, FactorizeOptions, TensorContractionLike, IdxTensor,
 /// };
 ///
 /// let i = DynIndex::new_dyn(3);
 /// let j = DynIndex::new_dyn(4);
 /// let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-/// let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+/// let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 ///
 /// let result = factorize(&tensor, &[i.clone()], &FactorizeOptions::svd()).unwrap();
 ///
@@ -554,10 +554,10 @@ pub trait TensorVectorSpace: TensorIndex {
     /// # Examples
     /// ```
     /// # fn main() -> anyhow::Result<()> {
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace};
     ///
     /// let index = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![index], vec![3.0_f64, 4.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![index], vec![3.0_f64, 4.0])?;
     /// assert!((TensorVectorSpace::norm_squared(&tensor)? - 25.0).abs() < 1e-12);
     /// # Ok(())
     /// # }
@@ -608,10 +608,10 @@ pub trait TensorVectorSpace: TensorIndex {
     /// # Examples
     /// ```
     /// # fn main() -> anyhow::Result<()> {
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace};
     ///
     /// let index = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![index], vec![3.0_f64, 4.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![index], vec![3.0_f64, 4.0])?;
     /// assert!((TensorVectorSpace::norm(&tensor)? - 5.0).abs() < 1e-12);
     /// # Ok(())
     /// # }
@@ -630,10 +630,10 @@ pub trait TensorVectorSpace: TensorIndex {
     /// # Examples
     /// ```
     /// # fn main() -> anyhow::Result<()> {
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorVectorSpace};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorVectorSpace};
     ///
     /// let index = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![index], vec![-3.0_f64, 2.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![index], vec![-3.0_f64, 2.0])?;
     /// assert!((TensorVectorSpace::maxabs(&tensor)? - 3.0).abs() < 1e-12);
     /// # Ok(())
     /// # }
@@ -960,20 +960,20 @@ pub trait TensorConstructionLike: TensorContractionLike {
 /// # Example
 ///
 /// ```
-/// use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen};
+/// use tensor4all_core::{DynIndex, TensorContractionLike, IdxTensor};
 ///
-/// fn contract_pair(a: &TensorDynLen, b: &TensorDynLen) -> anyhow::Result<TensorDynLen> {
-///     Ok(<TensorDynLen as TensorContractionLike>::contract(&[a, b])?)
+/// fn contract_pair(a: &IdxTensor, b: &IdxTensor) -> anyhow::Result<IdxTensor> {
+///     Ok(<IdxTensor as TensorContractionLike>::contract(&[a, b])?)
 /// }
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(2);
-/// let a = TensorDynLen::from_dense(
+/// let a = IdxTensor::from_dense(
 ///     vec![i.clone(), j.clone()],
 ///     vec![1.0, 0.0, 0.0, 1.0],
 /// )?;
-/// let b = TensorDynLen::from_dense(vec![j.clone()], vec![2.0, 3.0])?;
+/// let b = IdxTensor::from_dense(vec![j.clone()], vec![2.0, 3.0])?;
 ///
 /// let result = contract_pair(&a, &b)?;
 /// assert_eq!(result.to_vec::<f64>()?, vec![2.0, 3.0]);
@@ -986,15 +986,15 @@ pub trait TensorConstructionLike: TensorContractionLike {
 /// For mixing different tensor types, define an enum:
 ///
 /// ```
-/// use tensor4all_core::{block_tensor::BlockTensor, DynIndex, TensorDynLen};
+/// use tensor4all_core::{block_tensor::BlockTensor, DynIndex, IdxTensor};
 ///
 /// let i = DynIndex::new_dyn(2);
-/// let dense = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+/// let dense = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
 /// let block = BlockTensor::new(vec![dense.clone()], (1, 1)).unwrap();
 ///
 /// enum TensorNetwork {
-///     Dense(TensorDynLen),
-///     Block(BlockTensor<TensorDynLen>),
+///     Dense(IdxTensor),
+///     Block(BlockTensor<IdxTensor>),
 /// }
 ///
 /// let network = TensorNetwork::Block(block);
@@ -1027,13 +1027,13 @@ impl<T> TensorLike for T where
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{DynIndex, IndexLike, TensorContractionLike, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IndexLike, TensorContractionLike, IdxTensor};
 ///
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(3);
 ///
-/// let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-/// let b = TensorDynLen::from_dense(vec![j.clone()], vec![3.0, 4.0, 5.0]).unwrap();
+/// let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+/// let b = IdxTensor::from_dense(vec![j.clone()], vec![3.0, 4.0, 5.0]).unwrap();
 ///
 /// let result = a.direct_sum(&b, &[(i.clone(), j.clone())]).unwrap();
 ///

--- a/crates/tensor4all-core/src/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-core/src/tensor_like/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{DynIndex, TensorDynLen};
+use crate::{DynIndex, IdxTensor};
 
 // Compile-time check that TensorLike requires Sized (no dyn TensorLike)
 fn _assert_sized<T: TensorLike>() {
@@ -80,14 +80,14 @@ fn tensor_like_default_neg_and_delta_helpers_work() {
     let k = DynIndex::new_dyn(2);
     let l = DynIndex::new_dyn(3);
 
-    let tensor = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, -3.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone()], vec![2.0, -3.0]).unwrap();
     let negated = tensor.neg().unwrap();
     assert_eq!(negated.to_vec::<f64>().unwrap(), vec![-2.0, 3.0]);
 
-    let delta = TensorDynLen::delta(&[i.clone(), j.clone()], &[k, l]).unwrap();
+    let delta = IdxTensor::delta(&[i.clone(), j.clone()], &[k, l]).unwrap();
     assert_eq!(delta.dims(), vec![2, 2, 3, 3]);
     assert!((delta.sum().unwrap().real() - 6.0).abs() < 1.0e-12);
 
-    let err = TensorDynLen::delta(&[i], &[]).unwrap_err();
+    let err = IdxTensor::delta(&[i], &[]).unwrap_err();
     assert!(err.to_string().contains("Number of input indices"));
 }

--- a/crates/tensor4all-core/tests/ad_integration.rs
+++ b/crates/tensor4all-core/tests/ad_integration.rs
@@ -1,5 +1,5 @@
 use tensor4all_core::{
-    factorize_full_rank, svd, Canonical, FactorizeAlg, Index, TensorContractionLike, TensorDynLen,
+    factorize_full_rank, svd, Canonical, FactorizeAlg, IdxTensor, Index, TensorContractionLike,
 };
 
 fn assert_f64_slice_close(actual: &[f64], expected: &[f64], tol: f64) {
@@ -18,7 +18,7 @@ fn finite_diff_svd_singular_value_sum(data: &[f64], index: usize) -> f64 {
     fn eval(data: &[f64]) -> f64 {
         let i = Index::new_dyn(2);
         let j = Index::new_dyn(2);
-        let tensor = TensorDynLen::from_dense(vec![i.clone(), j], data.to_vec()).unwrap();
+        let tensor = IdxTensor::from_dense(vec![i.clone(), j], data.to_vec()).unwrap();
         let (_u, s, _v) = svd::<f64>(&tensor, &[i]).unwrap();
         s.sum().unwrap().real()
     }
@@ -33,7 +33,7 @@ fn finite_diff_svd_singular_value_sum(data: &[f64], index: usize) -> f64 {
 #[test]
 fn tensor_sum_returns_rank_zero_anyscalar_with_backward() {
     let i = Index::new_dyn(3);
-    let x = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0, 3.0])
+    let x = IdxTensor::from_dense(vec![i], vec![1.0, 2.0, 3.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -49,7 +49,7 @@ fn tensor_sum_returns_rank_zero_anyscalar_with_backward() {
 
 #[test]
 fn tensor_only_preserves_tracking_for_scalar_tensor() {
-    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad().unwrap();
+    let x = IdxTensor::scalar(2.0).unwrap().enable_grad().unwrap();
 
     let scalar = x.only().unwrap();
     let loss = &scalar * &scalar;
@@ -63,7 +63,7 @@ fn tensor_only_preserves_tracking_for_scalar_tensor() {
 fn factorize_qr_reconstruction_preserves_gradient_to_input() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let x = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64, 0.5, 1.0, 3.0])
+    let x = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64, 0.5, 1.0, 3.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -87,7 +87,7 @@ fn factorize_qr_reconstruction_preserves_gradient_to_input() {
 fn assert_ci_reconstruction_gradient(canonical: Canonical) {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let x = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64, 0.5, 1.0, 3.0])
+    let x = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![2.0_f64, 0.5, 1.0, 3.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -118,7 +118,7 @@ fn svd_singular_value_loss_preserves_gradient_to_input() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
     let data = vec![2.0_f64, 0.5, 1.0, 3.0];
-    let x = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone())
+    let x = IdxTensor::from_dense(vec![i.clone(), j.clone()], data.clone())
         .unwrap()
         .enable_grad()
         .unwrap();

--- a/crates/tensor4all-core/tests/bench_contract_fit_patterns.rs
+++ b/crates/tensor4all-core/tests/bench_contract_fit_patterns.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 use std::time::{Duration, Instant};
 
-use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, TensorContractionLike};
 use tensor4all_tensorbackend::{dense_native_tensor_from_col_major, einsum_native_tensors};
 
 fn make_data(dims: &[usize], offset: usize) -> Vec<f64> {
@@ -45,7 +45,7 @@ fn bench_contract_fit_patterns_vs_native() {
     let env3_b_data = make_data(&env3_b_dims, 11);
     let env3_c_data = make_data(&env3_c_dims, 12);
 
-    let env3_a = TensorDynLen::from_dense(
+    let env3_a = IdxTensor::from_dense(
         vec![
             env3_labels[3].clone(),
             env3_labels[0].clone(),
@@ -54,7 +54,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env3_a_data.clone(),
     )
     .unwrap();
-    let env3_b = TensorDynLen::from_dense(
+    let env3_b = IdxTensor::from_dense(
         vec![
             env3_labels[0].clone(),
             env3_labels[4].clone(),
@@ -64,7 +64,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env3_b_data.clone(),
     )
     .unwrap();
-    let env3_c = TensorDynLen::from_dense(
+    let env3_c = IdxTensor::from_dense(
         vec![
             env3_labels[1].clone(),
             env3_labels[2].clone(),
@@ -90,7 +90,7 @@ fn bench_contract_fit_patterns_vs_native() {
 
     let env4_labels = make_dyn_indices(&[2, 2, 8, 2, 8, 16, 8, 8, 16]);
 
-    let env4_a = TensorDynLen::from_dense(
+    let env4_a = IdxTensor::from_dense(
         vec![
             env4_labels[6].clone(),
             env4_labels[1].clone(),
@@ -100,7 +100,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env4_a_data.clone(),
     )
     .unwrap();
-    let env4_b = TensorDynLen::from_dense(
+    let env4_b = IdxTensor::from_dense(
         vec![
             env4_labels[7].clone(),
             env4_labels[0].clone(),
@@ -110,7 +110,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env4_b_data.clone(),
     )
     .unwrap();
-    let env4_c = TensorDynLen::from_dense(
+    let env4_c = IdxTensor::from_dense(
         vec![
             env4_labels[1].clone(),
             env4_labels[3].clone(),
@@ -120,7 +120,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env4_c_data.clone(),
     )
     .unwrap();
-    let env4_d = TensorDynLen::from_dense(
+    let env4_d = IdxTensor::from_dense(
         vec![
             env4_labels[2].clone(),
             env4_labels[4].clone(),
@@ -149,7 +149,7 @@ fn bench_contract_fit_patterns_vs_native() {
     let env6_e_data = make_data(&env6_e_dims, 34);
     let env6_f_data = make_data(&env6_f_dims, 35);
 
-    let env6_a = TensorDynLen::from_dense(
+    let env6_a = IdxTensor::from_dense(
         vec![
             env6_labels[2].clone(),
             env6_labels[8].clone(),
@@ -159,7 +159,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env6_a_data.clone(),
     )
     .unwrap();
-    let env6_b = TensorDynLen::from_dense(
+    let env6_b = IdxTensor::from_dense(
         vec![
             env6_labels[4].clone(),
             env6_labels[0].clone(),
@@ -169,7 +169,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env6_b_data.clone(),
     )
     .unwrap();
-    let env6_c = TensorDynLen::from_dense(
+    let env6_c = IdxTensor::from_dense(
         vec![
             env6_labels[1].clone(),
             env6_labels[10].clone(),
@@ -179,7 +179,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env6_c_data.clone(),
     )
     .unwrap();
-    let env6_d = TensorDynLen::from_dense(
+    let env6_d = IdxTensor::from_dense(
         vec![
             env6_labels[3].clone(),
             env6_labels[5].clone(),
@@ -189,7 +189,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env6_d_data.clone(),
     )
     .unwrap();
-    let env6_e = TensorDynLen::from_dense(
+    let env6_e = IdxTensor::from_dense(
         vec![
             env6_labels[2].clone(),
             env6_labels[4].clone(),
@@ -198,7 +198,7 @@ fn bench_contract_fit_patterns_vs_native() {
         env6_e_data.clone(),
     )
     .unwrap();
-    let env6_f = TensorDynLen::from_dense(
+    let env6_f = IdxTensor::from_dense(
         vec![
             env6_labels[6].clone(),
             env6_labels[7].clone(),
@@ -215,9 +215,9 @@ fn bench_contract_fit_patterns_vs_native() {
     let env6_e_native = dense_native_tensor_from_col_major(&env6_e_data, &env6_e_dims).unwrap();
     let env6_f_native = dense_native_tensor_from_col_major(&env6_f_data, &env6_f_dims).unwrap();
 
-    eprintln!("\n=== TensorDynLen contract vs native einsum ===");
-    let env3_contract = time_best_of("env3 TensorDynLen::contract", 2_000, || {
-        <TensorDynLen as TensorContractionLike>::contract(&[&env3_a, &env3_b, &env3_c]).unwrap()
+    eprintln!("\n=== IdxTensor contract vs native einsum ===");
+    let env3_contract = time_best_of("env3 IdxTensor::contract", 2_000, || {
+        <IdxTensor as TensorContractionLike>::contract(&[&env3_a, &env3_b, &env3_c]).unwrap()
     });
     let env3_native = time_best_of("env3 native einsum", 2_000, || {
         einsum_native_tensors(
@@ -231,8 +231,8 @@ fn bench_contract_fit_patterns_vs_native() {
         .unwrap()
     });
 
-    let env4_contract = time_best_of("env4 TensorDynLen::contract", 600, || {
-        <TensorDynLen as TensorContractionLike>::contract(&[&env4_a, &env4_b, &env4_c, &env4_d])
+    let env4_contract = time_best_of("env4 IdxTensor::contract", 600, || {
+        <IdxTensor as TensorContractionLike>::contract(&[&env4_a, &env4_b, &env4_c, &env4_d])
             .unwrap()
     });
     let env4_native = time_best_of("env4 native einsum", 600, || {
@@ -247,8 +247,8 @@ fn bench_contract_fit_patterns_vs_native() {
         )
         .unwrap()
     });
-    let env6_contract = time_best_of("env6 TensorDynLen::contract", 400, || {
-        <TensorDynLen as TensorContractionLike>::contract(&[
+    let env6_contract = time_best_of("env6 IdxTensor::contract", 400, || {
+        <IdxTensor as TensorContractionLike>::contract(&[
             &env6_a, &env6_b, &env6_c, &env6_d, &env6_e, &env6_f,
         ])
         .unwrap()
@@ -269,15 +269,15 @@ fn bench_contract_fit_patterns_vs_native() {
     });
 
     eprintln!(
-        "  ratio env3 TensorDynLen/native       = {:.2}x",
+        "  ratio env3 IdxTensor/native       = {:.2}x",
         env3_contract.as_secs_f64() / env3_native.as_secs_f64()
     );
     eprintln!(
-        "  ratio env4 TensorDynLen/native       = {:.2}x",
+        "  ratio env4 IdxTensor/native       = {:.2}x",
         env4_contract.as_secs_f64() / env4_native.as_secs_f64()
     );
     eprintln!(
-        "  ratio env6 TensorDynLen/native       = {:.2}x",
+        "  ratio env6 IdxTensor/native       = {:.2}x",
         env6_contract.as_secs_f64() / env6_native.as_secs_f64()
     );
 }

--- a/crates/tensor4all-core/tests/bug_qr_after_permute.rs
+++ b/crates/tensor4all-core/tests/bug_qr_after_permute.rs
@@ -8,11 +8,11 @@
 
 use num_complex::Complex64;
 use tensor4all_core::{
-    factorize, svd, DynIndex, FactorizeOptions, TensorContractionLike, TensorDynLen,
+    factorize, svd, DynIndex, FactorizeOptions, IdxTensor, TensorContractionLike,
 };
 
 /// Create a [5,2,2,5] tensor with data that triggers the QR bug.
-fn make_buggy_tensor() -> TensorDynLen {
+fn make_buggy_tensor() -> IdxTensor {
     let idx_a = DynIndex::new_dyn_with_tag(5, "a").unwrap();
     let idx_b = DynIndex::new_dyn_with_tag(2, "b").unwrap();
     let idx_c = DynIndex::new_dyn_with_tag(2, "c").unwrap();
@@ -123,10 +123,10 @@ fn make_buggy_tensor() -> TensorDynLen {
         Complex64::new(-1.01688110680129151e0, 8.34913283284349772e-2),
     ];
 
-    TensorDynLen::from_dense(vec![idx_a, idx_b, idx_c, idx_d], data).unwrap()
+    IdxTensor::from_dense(vec![idx_a, idx_b, idx_c, idx_d], data).unwrap()
 }
 
-fn reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex], opts: &FactorizeOptions) -> f64 {
+fn reconstruction_error(t: &IdxTensor, left_inds: &[DynIndex], opts: &FactorizeOptions) -> f64 {
     let result = factorize(t, left_inds, opts).unwrap();
     let recon = result.left.contract_pair(&result.right).unwrap();
     let neg = recon
@@ -136,7 +136,7 @@ fn reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex], opts: &Factori
     diff.norm().unwrap()
 }
 
-fn svd_reconstruction_error(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
+fn svd_reconstruction_error(t: &IdxTensor, left_inds: &[DynIndex]) -> f64 {
     let (u, s, v) = svd::<Complex64>(t, left_inds).unwrap();
     let mut perm = vec![v.indices.len() - 1];
     perm.extend(0..v.indices.len() - 1);
@@ -164,7 +164,7 @@ fn test_qr_reconstruction_regression() {
 
     let matrix_i = DynIndex::new_dyn_with_tag(10, "row").unwrap();
     let matrix_j = DynIndex::new_dyn_with_tag(10, "col").unwrap();
-    let matrix = TensorDynLen::from_dense(
+    let matrix = IdxTensor::from_dense(
         vec![matrix_i.clone(), matrix_j],
         t.to_vec::<Complex64>().unwrap(),
     )

--- a/crates/tensor4all-core/tests/error_paths.rs
+++ b/crates/tensor4all-core/tests/error_paths.rs
@@ -4,8 +4,7 @@ use tensor4all_core::block_tensor::BlockTensor;
 use tensor4all_core::col_major_array::{ColMajorArrayError, ColMajorArrayRef};
 use tensor4all_core::index_like::IndexLike;
 use tensor4all_core::{
-    compute_permutation_from_indices, diag_tensor_dyn_len, DynIndex, TensorContractionLike,
-    TensorDynLen,
+    compute_permutation_from_indices, diag_idx_tensor, DynIndex, IdxTensor, TensorContractionLike,
 };
 use tensor4all_tensorbackend::Storage;
 
@@ -25,7 +24,7 @@ fn tensor_new_rejects_duplicate_indices() {
     let i = DynIndex::new_dyn(2);
     let storage = Arc::new(Storage::from_dense_col_major(vec![1.0_f64, 2.0], &[2]).unwrap());
 
-    let err = TensorDynLen::new(vec![i.clone(), i], storage).unwrap_err();
+    let err = IdxTensor::new(vec![i.clone(), i], storage).unwrap_err();
 
     assert!(err.to_string().contains("unique"));
 }
@@ -34,7 +33,7 @@ fn tensor_new_rejects_duplicate_indices() {
 fn tensor_permute_rejects_invalid_axis_order() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
@@ -49,8 +48,8 @@ fn tensor_permute_rejects_invalid_axis_order() {
 fn tensor_contract_rejects_mismatched_common_dimension() {
     let shared_left = DynIndex::new_dyn(2);
     let shared_right = DynIndex::new_with_tags(*shared_left.id(), 3, shared_left.tags().clone());
-    let a = TensorDynLen::from_dense(vec![shared_left], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![shared_right], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![shared_left], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![shared_right], vec![1.0_f64, 2.0, 3.0]).unwrap();
 
     let err = a.contract_pair(&b).unwrap_err();
 
@@ -67,7 +66,7 @@ fn random_rejects_duplicate_indices() {
     let i = DynIndex::new_dyn(2);
     let mut rng = rand::rng();
 
-    let err = TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), i]).unwrap_err();
+    let err = IdxTensor::random::<f64, _>(&mut rng, vec![i.clone(), i]).unwrap_err();
 
     assert!(err.to_string().contains("unique"));
 }
@@ -75,7 +74,7 @@ fn random_rejects_duplicate_indices() {
 #[test]
 fn block_tensor_new_rejects_shape_mismatch() {
     let i = DynIndex::new_dyn(2);
-    let block = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
+    let block = IdxTensor::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap();
 
     let err = BlockTensor::new(vec![block], (2, 1)).unwrap_err();
 
@@ -100,7 +99,7 @@ fn diag_tensor_helper_rejects_dimension_mismatch() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
 
-    let err = diag_tensor_dyn_len(vec![i, j], vec![1.0, 2.0]).unwrap_err();
+    let err = diag_idx_tensor(vec![i, j], vec![1.0, 2.0]).unwrap_err();
 
     assert!(err.to_string().contains("same dimension"));
 }

--- a/crates/tensor4all-core/tests/linalg_eigh.rs
+++ b/crates/tensor4all-core/tests/linalg_eigh.rs
@@ -1,11 +1,11 @@
 use num_complex::Complex64;
-use tensor4all_core::{AnyScalar, DynIndex, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, TensorContractionLike};
 
 #[test]
 fn hermitian_eigendecomposition_solves_complex_residuals() {
     let row = DynIndex::new_dyn(2);
     let col = DynIndex::new_dyn(2);
-    let matrix = TensorDynLen::from_dense(
+    let matrix = IdxTensor::from_dense(
         vec![row.clone(), col.clone()],
         vec![
             Complex64::new(2.0, 0.0),
@@ -32,7 +32,7 @@ fn hermitian_eigendecomposition_solves_complex_residuals() {
             .select_indices(std::slice::from_ref(&decomp.eigenvector_index), &[position])
             .unwrap();
         let vector_as_col = vector.replaceind(&row, &col).unwrap();
-        let applied = TensorDynLen::contract(&[&matrix, &vector_as_col]).unwrap();
+        let applied = IdxTensor::contract(&[&matrix, &vector_as_col]).unwrap();
         let expected = vector.scale(AnyScalar::new_real(lambda)).unwrap();
 
         assert!(
@@ -47,7 +47,7 @@ fn hermitian_eigendecomposition_solves_complex_residuals() {
 fn hermitian_eigendecomposition_keeps_eigenvectors_tracked() {
     let row = DynIndex::new_dyn(2);
     let col = DynIndex::new_dyn(2);
-    let matrix = TensorDynLen::from_dense(vec![row, col], vec![2.0_f64, 0.25, 0.25, 3.0])
+    let matrix = IdxTensor::from_dense(vec![row, col], vec![2.0_f64, 0.25, 0.25, 3.0])
         .unwrap()
         .enable_grad()
         .unwrap();

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -5,41 +5,41 @@ use tensor4all_core::{
     factorize, factorize_full_rank, Canonical, DynIndex, FactorizeAlg, FactorizeError,
     FactorizeOptions, TensorContractionLike,
 };
-use tensor4all_core::{SvdTruncationPolicy, TensorDynLen};
+use tensor4all_core::{IdxTensor, SvdTruncationPolicy};
 
 // ============================================================================
 // Test Data Helpers
 // ============================================================================
 
 /// Helper to create a simple 2x3 matrix tensor for testing.
-fn create_test_matrix() -> TensorDynLen {
+fn create_test_matrix() -> IdxTensor {
     let i: DynIndex = Index::new_dyn(2);
     let j: DynIndex = Index::new_dyn(3);
 
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    TensorDynLen::from_dense(vec![i, j], data).unwrap()
+    IdxTensor::from_dense(vec![i, j], data).unwrap()
 }
 
 /// Helper to create a rank-3 tensor for testing.
-fn create_rank3_tensor() -> TensorDynLen {
+fn create_rank3_tensor() -> IdxTensor {
     let i: DynIndex = Index::new_dyn(2);
     let j: DynIndex = Index::new_dyn(3);
     let k: DynIndex = Index::new_dyn(2);
 
     let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    TensorDynLen::from_dense(vec![i, j, k], data).unwrap()
+    IdxTensor::from_dense(vec![i, j, k], data).unwrap()
 }
 
-fn create_unit_dim_rank3_tensor() -> TensorDynLen {
+fn create_unit_dim_rank3_tensor() -> IdxTensor {
     let i: DynIndex = Index::new_dyn(1);
     let j: DynIndex = Index::new_dyn(2);
     let k: DynIndex = Index::new_dyn(2);
 
     let data = vec![1.0, 2.0, 3.0, 4.0];
-    TensorDynLen::from_dense(vec![i, j, k], data).unwrap()
+    IdxTensor::from_dense(vec![i, j, k], data).unwrap()
 }
 
-fn create_non_symmetric_col_major_matrix() -> TensorDynLen {
+fn create_non_symmetric_col_major_matrix() -> IdxTensor {
     let i: DynIndex = Index::new_dyn(2);
     let j: DynIndex = Index::new_dyn(3);
 
@@ -47,7 +47,7 @@ fn create_non_symmetric_col_major_matrix() -> TensorDynLen {
     // [[1, 2, 4],
     //  [3, 5, 6]]
     let data = vec![1.0, 3.0, 2.0, 5.0, 4.0, 6.0];
-    TensorDynLen::from_dense(vec![i, j], data).unwrap()
+    IdxTensor::from_dense(vec![i, j], data).unwrap()
 }
 
 // ============================================================================
@@ -282,7 +282,7 @@ fn test_factorize_full_rank_preserves_near_dependent_components() {
     let i: DynIndex = Index::new_dyn(2);
     let j: DynIndex = Index::new_dyn(2);
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 0.0, 0.0, 1.0e-16]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 0.0, 0.0, 1.0e-16]).unwrap();
 
     for alg in [FactorizeAlg::SVD, FactorizeAlg::QR, FactorizeAlg::LU] {
         let result =
@@ -339,7 +339,7 @@ fn test_diag_dense_contraction_svd_internals() {
     let j: DynIndex = Index::new_dyn(3);
 
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 
     let (u, s, v) = svd::<f64>(&tensor, std::slice::from_ref(&i)).expect("SVD should succeed");
 
@@ -368,7 +368,7 @@ fn test_diag_dense_contraction_svd_internals() {
 // Helper Functions
 // ============================================================================
 
-fn assert_tensors_approx_equal(a: &TensorDynLen, b: &TensorDynLen, tol: f64) {
+fn assert_tensors_approx_equal(a: &IdxTensor, b: &IdxTensor, tol: f64) {
     assert!(
         a.isapprox(b, tol, 0.0).unwrap(),
         "Tensors differ: maxabs diff = {}",

--- a/crates/tensor4all-core/tests/linalg_qr.rs
+++ b/crates/tensor4all-core/tests/linalg_qr.rs
@@ -1,14 +1,14 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::{qr, DynIndex};
-use tensor4all_core::{TensorContractionLike, TensorDynLen};
+use tensor4all_core::{IdxTensor, TensorContractionLike};
 
-fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 #[test]
@@ -99,7 +99,7 @@ fn test_qr_invalid_rank() {
     // Test that QR fails for rank-1 tensors
     let i = Index::new_dyn(2);
 
-    let tensor = TensorDynLen::zeros::<f64>(vec![i.clone()]).unwrap();
+    let tensor = IdxTensor::zeros::<f64>(vec![i.clone()]).unwrap();
 
     let result = qr::<f64>(&tensor, std::slice::from_ref(&i));
     assert!(result.is_err());
@@ -115,7 +115,7 @@ fn test_qr_invalid_split() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
 
-    let tensor = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
     // Empty left_inds should fail
     let result = qr::<f64>(&tensor, &[]);
@@ -216,7 +216,7 @@ fn test_qr_complex_reconstruction() {
 }
 
 /// Helper: compute ||Q*R - T|| via tensor contraction for any tensor shape.
-fn qr_reconstruction_error_f64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
+fn qr_reconstruction_error_f64(t: &IdxTensor, left_inds: &[DynIndex]) -> f64 {
     let (q, r) = qr::<f64>(t, left_inds).expect("QR should succeed");
     let recon = q.contract_pair(&r).unwrap();
     let neg = recon
@@ -226,7 +226,7 @@ fn qr_reconstruction_error_f64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 
     diff.norm().unwrap()
 }
 
-fn qr_reconstruction_error_c64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
+fn qr_reconstruction_error_c64(t: &IdxTensor, left_inds: &[DynIndex]) -> f64 {
     let (q, r) = qr::<Complex64>(t, left_inds).expect("QR should succeed");
     let recon = q.contract_pair(&r).unwrap();
     let neg = recon

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -4,17 +4,17 @@ use tensor4all_core::{
     default_svd_truncation_policy, set_default_svd_truncation_policy, svd, svd_with, SvdOptions,
     SvdTruncationPolicy,
 };
-use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, TensorContractionLike};
 
-fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn vh_from_v(v: &TensorDynLen) -> TensorDynLen {
+fn vh_from_v(v: &IdxTensor) -> IdxTensor {
     assert!(
         !v.indices.is_empty(),
         "V tensor must have at least one (bond) index"
@@ -26,7 +26,7 @@ fn vh_from_v(v: &TensorDynLen) -> TensorDynLen {
     v_conj.permute(&perm).unwrap()
 }
 
-fn reconstruct_from_svd(u: &TensorDynLen, s: &TensorDynLen, v: &TensorDynLen) -> TensorDynLen {
+fn reconstruct_from_svd(u: &IdxTensor, s: &IdxTensor, v: &IdxTensor) -> IdxTensor {
     let vh = vh_from_v(v);
     let svh = s.contract_pair(&vh).unwrap();
     let sim_bond = s.indices[1].clone();
@@ -130,7 +130,7 @@ fn test_svd_invalid_rank() {
     // Test that SVD fails for rank-1 tensors
     let i = Index::new_dyn(2);
 
-    let tensor = TensorDynLen::zeros::<f64>(vec![i.clone()]).unwrap();
+    let tensor = IdxTensor::zeros::<f64>(vec![i.clone()]).unwrap();
 
     let result = svd::<f64>(&tensor, std::slice::from_ref(&i));
     assert!(result.is_err());
@@ -146,7 +146,7 @@ fn test_svd_invalid_split() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
 
-    let tensor = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
     // Empty left_inds should fail
     let result = svd::<f64>(&tensor, &[]);
@@ -426,7 +426,7 @@ fn test_svd_uses_global_default() {
 }
 
 /// Helper: compute SVD reconstruction error for a given tensor and split.
-fn svd_reconstruction_error_f64(t: &TensorDynLen, left_inds: &[DynIndex]) -> f64 {
+fn svd_reconstruction_error_f64(t: &IdxTensor, left_inds: &[DynIndex]) -> f64 {
     let (u, s, v) = svd::<f64>(t, left_inds).expect("SVD should succeed");
     let recon = reconstruct_from_svd(&u, &s, &v);
     let neg = recon

--- a/crates/tensor4all-core/tests/send_sync.rs
+++ b/crates/tensor4all-core/tests/send_sync.rs
@@ -1,9 +1,9 @@
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 
 fn assert_send_sync<T: Send + Sync>() {}
 
 #[test]
-fn eager_tensor_and_tensordynlen_are_send_sync() {
+fn eager_tensor_and_idx_tensor_are_send_sync() {
     assert_send_sync::<tenferro_ad::EagerTensor>();
-    assert_send_sync::<TensorDynLen>();
+    assert_send_sync::<IdxTensor>();
 }

--- a/crates/tensor4all-core/tests/tensor_api_correction.rs
+++ b/crates/tensor4all-core/tests/tensor_api_correction.rs
@@ -1,13 +1,13 @@
 use num_complex::{Complex32, Complex64};
 use std::error::Error;
 use std::sync::Arc;
-use tensor4all_core::{DynIndex, TensorDynLen, TensorDynLenError, TensorStorageError};
+use tensor4all_core::{DynIndex, IdxTensor, IdxTensorError, TensorStorageError};
 use tensor4all_tensorbackend::{Storage, StorageKind};
 
 #[test]
-fn tensor_dyn_len_norm_and_comparison_operations_are_fallible() {
+fn idx_tensor_norm_and_comparison_operations_are_fallible() {
     let index = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![index.clone()], vec![3.0_f64, 4.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![index.clone()], vec![3.0_f64, 4.0]).unwrap();
 
     assert!((tensor.norm_squared().unwrap() - 25.0).abs() < 1.0e-12);
     assert!((tensor.norm().unwrap() - 5.0).abs() < 1.0e-12);
@@ -15,15 +15,15 @@ fn tensor_dyn_len_norm_and_comparison_operations_are_fallible() {
     assert!(tensor.isapprox(&tensor, 0.0, 0.0).unwrap());
 
     let other_index = DynIndex::new_dyn(2);
-    let incompatible = TensorDynLen::from_dense(vec![other_index], vec![3.0_f64, 4.0]).unwrap();
+    let incompatible = IdxTensor::from_dense(vec![other_index], vec![3.0_f64, 4.0]).unwrap();
     let error = tensor.isapprox(&incompatible, 1.0e-12, 0.0).unwrap_err();
     assert!(error.to_string().contains("Index"));
 }
 
 #[test]
-fn tensor_dyn_len_norm_and_maxabs_preserve_complex_values() {
+fn idx_tensor_norm_and_maxabs_preserve_complex_values() {
     let index = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![index],
         vec![Complex64::new(3.0, 4.0), Complex64::new(0.0, -2.0)],
     )
@@ -35,13 +35,13 @@ fn tensor_dyn_len_norm_and_maxabs_preserve_complex_values() {
 }
 
 #[test]
-fn tensor_dyn_len_operations_cover_f32_and_c32() {
+fn idx_tensor_operations_cover_f32_and_c32() {
     let index = DynIndex::new_dyn(2);
-    let f32_tensor = TensorDynLen::from_dense(vec![index.clone()], vec![3.0_f32, 4.0]).unwrap();
+    let f32_tensor = IdxTensor::from_dense(vec![index.clone()], vec![3.0_f32, 4.0]).unwrap();
     assert!((f32_tensor.norm_squared().unwrap() - 25.0).abs() < 1.0e-6);
     assert_eq!(f32_tensor.to_vec::<f32>().unwrap(), vec![3.0_f32, 4.0]);
 
-    let c32_tensor = TensorDynLen::from_dense(
+    let c32_tensor = IdxTensor::from_dense(
         vec![index],
         vec![Complex32::new(3.0, 4.0), Complex32::new(0.0, -2.0)],
     )
@@ -56,7 +56,7 @@ fn tensor_dyn_len_operations_cover_f32_and_c32() {
 #[test]
 fn arithmetic_does_not_promote_32_bit_tensors() {
     let index = DynIndex::new_dyn(2);
-    let f32_tensor = TensorDynLen::from_dense(vec![index.clone()], vec![1.0_f32, 2.0]).unwrap();
+    let f32_tensor = IdxTensor::from_dense(vec![index.clone()], vec![1.0_f32, 2.0]).unwrap();
     let scaled_f32 = f32_tensor
         .scale(tensor4all_core::AnyScalar::new_real(2.0))
         .unwrap();
@@ -82,7 +82,7 @@ fn arithmetic_does_not_promote_32_bit_tensors() {
     assert_eq!(combined_f32.to_vec::<f32>().unwrap(), vec![5.0, 10.0]);
     assert!(combined_f32.to_vec::<f64>().is_err());
 
-    let c32_tensor = TensorDynLen::from_dense(
+    let c32_tensor = IdxTensor::from_dense(
         vec![index],
         vec![Complex32::new(1.0, 0.5), Complex32::new(2.0, -0.25)],
     )
@@ -111,17 +111,17 @@ fn arithmetic_does_not_promote_32_bit_tensors() {
 }
 
 #[test]
-fn tensor_dyn_len_norm_api_has_crate_local_error_and_source_chain() {
+fn idx_tensor_norm_api_has_crate_local_error_and_source_chain() {
     fn assert_typed_result<T, E: Error + Send + Sync + 'static>(_: Result<T, E>) {}
 
     let index = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![index], vec![3.0_f64, 4.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![index], vec![3.0_f64, 4.0]).unwrap();
     assert_typed_result(tensor.norm_squared());
     assert_typed_result(tensor.norm());
     assert_typed_result(tensor.maxabs());
     assert_typed_result(tensor.isapprox(&tensor, 0.0, 0.0));
 
-    let error = TensorDynLenError::Storage {
+    let error = IdxTensorError::Storage {
         source: TensorStorageError::Materialization {
             source: Arc::new(std::io::Error::other("backend unavailable")),
         },
@@ -131,33 +131,33 @@ fn tensor_dyn_len_norm_api_has_crate_local_error_and_source_chain() {
 }
 
 #[test]
-fn tensor_dyn_len_norm_rejects_nan_and_preserves_infinity() {
+fn idx_tensor_norm_rejects_nan_and_preserves_infinity() {
     for tensor in [
-        TensorDynLen::scalar(f64::NAN).unwrap(),
-        TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0, f64::NAN]).unwrap(),
+        IdxTensor::scalar(f64::NAN).unwrap(),
+        IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0, f64::NAN]).unwrap(),
     ] {
         assert!(matches!(
             tensor.norm_squared(),
-            Err(TensorDynLenError::NaNInput { .. })
+            Err(IdxTensorError::NaNInput { .. })
         ));
         assert!(matches!(
             tensor.norm(),
-            Err(TensorDynLenError::NaNInput { .. })
+            Err(IdxTensorError::NaNInput { .. })
         ));
         assert!(matches!(
             tensor.maxabs(),
-            Err(TensorDynLenError::NaNInput { .. })
+            Err(IdxTensorError::NaNInput { .. })
         ));
     }
 
-    let tensor = TensorDynLen::scalar(f64::INFINITY).unwrap();
+    let tensor = IdxTensor::scalar(f64::INFINITY).unwrap();
     assert!(tensor.norm_squared().unwrap().is_infinite());
     assert!(tensor.norm().unwrap().is_infinite());
     assert!(tensor.maxabs().unwrap().is_infinite());
 
     for tensor in [
-        TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0_f32, f32::NAN]).unwrap(),
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0_f32, f32::NAN]).unwrap(),
+        IdxTensor::from_dense(
             vec![DynIndex::new_dyn(2)],
             vec![Complex32::new(1.0, 0.0), Complex32::new(f32::NAN, 0.0)],
         )
@@ -165,18 +165,18 @@ fn tensor_dyn_len_norm_rejects_nan_and_preserves_infinity() {
     ] {
         assert!(matches!(
             tensor.norm_squared(),
-            Err(TensorDynLenError::NaNInput { .. })
+            Err(IdxTensorError::NaNInput { .. })
         ));
         assert!(matches!(
             tensor.maxabs(),
-            Err(TensorDynLenError::NaNInput { .. })
+            Err(IdxTensorError::NaNInput { .. })
         ));
     }
 }
 
 #[test]
 fn compact_norms_promote_f32_extremes_to_stable_f64_metrics() {
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![DynIndex::new_dyn(2)],
         vec![f32::MAX, f32::MIN_POSITIVE],
     )
@@ -201,7 +201,7 @@ fn tracked_scale_from_public_structured_storage_stays_compact() {
         vec![0, 1, 0],
     )
     .unwrap();
-    let tensor = TensorDynLen::from_storage(vec![left, site, right], Arc::new(storage)).unwrap();
+    let tensor = IdxTensor::from_storage(vec![left, site, right], Arc::new(storage)).unwrap();
     let scalar = tensor4all_core::AnyScalar::new_real(3.0)
         .enable_grad()
         .unwrap();
@@ -236,7 +236,7 @@ fn untracked_scale_of_gapped_structured_storage_stays_compact() {
         vec![0, 1],
     )
     .unwrap();
-    let tensor = TensorDynLen::from_storage(vec![left, right], Arc::new(storage)).unwrap();
+    let tensor = IdxTensor::from_storage(vec![left, right], Arc::new(storage)).unwrap();
     assert!(!tensor.tracks_grad());
     let scaled = tensor
         .scale(tensor4all_core::AnyScalar::new_real(2.0))
@@ -262,16 +262,16 @@ fn mixed_complex_nonfinite_components_are_typed_nan_inputs() {
         Complex64::new(f64::INFINITY, f64::NAN),
         Complex64::new(f64::NAN, f64::INFINITY),
     ] {
-        let tensor = TensorDynLen::scalar(value).unwrap();
+        let tensor = IdxTensor::scalar(value).unwrap();
         assert!(matches!(
             tensor.norm_squared(),
-            Err(TensorDynLenError::NaNInput {
+            Err(IdxTensorError::NaNInput {
                 operation: "norm_squared"
             })
         ));
         assert!(matches!(
             tensor.maxabs(),
-            Err(TensorDynLenError::NaNInput {
+            Err(IdxTensorError::NaNInput {
                 operation: "maxabs"
             })
         ));
@@ -280,23 +280,23 @@ fn mixed_complex_nonfinite_components_are_typed_nan_inputs() {
         Complex32::new(f32::INFINITY, f32::NAN),
         Complex32::new(f32::NAN, f32::INFINITY),
     ] {
-        let tensor = TensorDynLen::scalar(value).unwrap();
+        let tensor = IdxTensor::scalar(value).unwrap();
         assert!(matches!(
             tensor.norm_squared(),
-            Err(TensorDynLenError::NaNInput {
+            Err(IdxTensorError::NaNInput {
                 operation: "norm_squared"
             })
         ));
         assert!(matches!(
             tensor.maxabs(),
-            Err(TensorDynLenError::NaNInput {
+            Err(IdxTensorError::NaNInput {
                 operation: "maxabs"
             })
         ));
     }
 
     let index = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![index],
         vec![
             Complex64::new(f64::INFINITY, f64::NAN),
@@ -306,7 +306,7 @@ fn mixed_complex_nonfinite_components_are_typed_nan_inputs() {
     .unwrap();
     assert!(matches!(
         tensor.maxabs(),
-        Err(TensorDynLenError::NaNInput {
+        Err(IdxTensorError::NaNInput {
             operation: "maxabs"
         })
     ));
@@ -314,9 +314,9 @@ fn mixed_complex_nonfinite_components_are_typed_nan_inputs() {
 
 #[test]
 fn isapprox_handles_nonfinite_values_like_julia() {
-    let scalar_inf = TensorDynLen::scalar(f64::INFINITY).unwrap();
-    let scalar_inf_same = TensorDynLen::scalar(f64::INFINITY).unwrap();
-    let scalar_finite = TensorDynLen::scalar(1.0_f64).unwrap();
+    let scalar_inf = IdxTensor::scalar(f64::INFINITY).unwrap();
+    let scalar_inf_same = IdxTensor::scalar(f64::INFINITY).unwrap();
+    let scalar_finite = IdxTensor::scalar(1.0_f64).unwrap();
     assert!(scalar_inf
         .isapprox(&scalar_inf_same, 1.0e-12, 1.0e-12)
         .unwrap());
@@ -326,11 +326,11 @@ fn isapprox_handles_nonfinite_values_like_julia() {
 
     let real_index = DynIndex::new_dyn(2);
     let real_tensor =
-        TensorDynLen::from_dense(vec![real_index.clone()], vec![f64::INFINITY, 2.0]).unwrap();
+        IdxTensor::from_dense(vec![real_index.clone()], vec![f64::INFINITY, 2.0]).unwrap();
     let real_tensor_same =
-        TensorDynLen::from_dense(vec![real_index.clone()], vec![f64::INFINITY, 2.0]).unwrap();
+        IdxTensor::from_dense(vec![real_index.clone()], vec![f64::INFINITY, 2.0]).unwrap();
     let real_tensor_different =
-        TensorDynLen::from_dense(vec![real_index], vec![f64::NEG_INFINITY, 2.0]).unwrap();
+        IdxTensor::from_dense(vec![real_index], vec![f64::NEG_INFINITY, 2.0]).unwrap();
     assert!(real_tensor
         .isapprox(&real_tensor_same, 1.0e-12, 1.0e-12)
         .unwrap());
@@ -338,10 +338,9 @@ fn isapprox_handles_nonfinite_values_like_julia() {
         .isapprox(&real_tensor_different, 1.0e-12, 1.0e-12)
         .unwrap());
 
-    let complex_scalar = TensorDynLen::scalar(Complex64::new(0.0, f64::INFINITY)).unwrap();
-    let complex_scalar_same = TensorDynLen::scalar(Complex64::new(0.0, f64::INFINITY)).unwrap();
-    let complex_scalar_different =
-        TensorDynLen::scalar(Complex64::new(f64::INFINITY, 0.0)).unwrap();
+    let complex_scalar = IdxTensor::scalar(Complex64::new(0.0, f64::INFINITY)).unwrap();
+    let complex_scalar_same = IdxTensor::scalar(Complex64::new(0.0, f64::INFINITY)).unwrap();
+    let complex_scalar_different = IdxTensor::scalar(Complex64::new(f64::INFINITY, 0.0)).unwrap();
     assert!(complex_scalar
         .isapprox(&complex_scalar_same, 1.0e-12, 1.0e-12)
         .unwrap());
@@ -350,17 +349,17 @@ fn isapprox_handles_nonfinite_values_like_julia() {
         .unwrap());
 
     let index = DynIndex::new_dyn(2);
-    let complex_inf = TensorDynLen::from_dense(
+    let complex_inf = IdxTensor::from_dense(
         vec![index.clone()],
         vec![Complex64::new(f64::INFINITY, 0.0), Complex64::new(2.0, 0.0)],
     )
     .unwrap();
-    let complex_inf_same = TensorDynLen::from_dense(
+    let complex_inf_same = IdxTensor::from_dense(
         vec![index.clone()],
         vec![Complex64::new(f64::INFINITY, 0.0), Complex64::new(2.0, 0.0)],
     )
     .unwrap();
-    let complex_inf_different = TensorDynLen::from_dense(
+    let complex_inf_different = IdxTensor::from_dense(
         vec![index],
         vec![Complex64::new(0.0, f64::INFINITY), Complex64::new(2.0, 0.0)],
     )
@@ -374,12 +373,12 @@ fn isapprox_handles_nonfinite_values_like_julia() {
 }
 
 #[test]
-fn tensor_dyn_len_distance_uses_typed_metric_error() {
-    let tensor = TensorDynLen::scalar(f64::NAN).unwrap();
-    let result: Result<f64, TensorDynLenError> = tensor.distance(&tensor);
+fn idx_tensor_distance_uses_typed_metric_error() {
+    let tensor = IdxTensor::scalar(f64::NAN).unwrap();
+    let result: Result<f64, IdxTensorError> = tensor.distance(&tensor);
     assert!(matches!(
         result,
-        Err(TensorDynLenError::NaNInput {
+        Err(IdxTensorError::NaNInput {
             operation: "norm_squared"
         })
     ));
@@ -389,15 +388,14 @@ fn tensor_dyn_len_distance_uses_typed_metric_error() {
 fn structured_32_bit_selection_preserves_dtype() {
     let f32_i = DynIndex::new_dyn(2);
     let f32_j = DynIndex::new_dyn(2);
-    let f32_tensor =
-        TensorDynLen::from_diag(vec![f32_i.clone(), f32_j], vec![1.0_f32, 2.0]).unwrap();
+    let f32_tensor = IdxTensor::from_diag(vec![f32_i.clone(), f32_j], vec![1.0_f32, 2.0]).unwrap();
     let selected_f32 = f32_tensor.select_indices(&[f32_i], &[1]).unwrap();
     assert_eq!(selected_f32.to_vec::<f32>().unwrap(), vec![0.0, 2.0]);
     assert!(selected_f32.to_vec::<f64>().is_err());
 
     let c32_i = DynIndex::new_dyn(2);
     let c32_j = DynIndex::new_dyn(2);
-    let c32_tensor = TensorDynLen::from_diag(
+    let c32_tensor = IdxTensor::from_diag(
         vec![c32_i.clone(), c32_j],
         vec![Complex32::new(1.0, 0.5), Complex32::new(2.0, -0.25)],
     )
@@ -409,7 +407,7 @@ fn structured_32_bit_selection_preserves_dtype() {
     );
     assert!(selected_c32.to_vec::<Complex64>().is_err());
 
-    let selector_f32 = TensorDynLen::from_copy_selector(
+    let selector_f32 = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(2),
         DynIndex::new_dyn(3),
         DynIndex::new_dyn(2),
@@ -426,7 +424,7 @@ fn structured_32_bit_selection_preserves_dtype() {
     );
     assert!(selected_selector_f32.to_vec::<f64>().is_err());
 
-    let selector_c32 = TensorDynLen::from_copy_selector(
+    let selector_c32 = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(2),
         DynIndex::new_dyn(3),
         DynIndex::new_dyn(2),
@@ -451,7 +449,7 @@ fn structured_32_bit_selection_preserves_dtype() {
 
 #[test]
 fn detach_preserves_32_bit_dtype_after_enabling_grad() {
-    let f32_tensor = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0_f32, 2.0])
+    let f32_tensor = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0_f32, 2.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -459,7 +457,7 @@ fn detach_preserves_32_bit_dtype_after_enabling_grad() {
     assert_eq!(detached_f32.to_vec::<f32>().unwrap(), vec![1.0, 2.0]);
     assert!(detached_f32.to_vec::<f64>().is_err());
 
-    let c32_tensor = TensorDynLen::from_dense(
+    let c32_tensor = IdxTensor::from_dense(
         vec![DynIndex::new_dyn(2)],
         vec![Complex32::new(1.0, 0.5), Complex32::new(2.0, -0.25)],
     )
@@ -473,7 +471,7 @@ fn detach_preserves_32_bit_dtype_after_enabling_grad() {
     );
     assert!(detached_c32.to_vec::<Complex64>().is_err());
 
-    let structured_f32 = TensorDynLen::from_diag(
+    let structured_f32 = IdxTensor::from_diag(
         vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)],
         vec![1.0_f32, 2.0],
     )
@@ -493,12 +491,12 @@ fn structured_constructors_preserve_f32_and_c32_dtype() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let f32_diag =
-        TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f32, 2.0_f32]).unwrap();
+        IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![1.0_f32, 2.0_f32]).unwrap();
     assert!(f32_diag.is_diag());
     assert_eq!(f32_diag.to_vec::<f32>().unwrap(), vec![1.0, 0.0, 0.0, 2.0]);
     assert!(f32_diag.to_vec::<f64>().is_err());
 
-    let c32_diag = TensorDynLen::from_diag(
+    let c32_diag = IdxTensor::from_diag(
         vec![i, j],
         vec![Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)],
     )
@@ -518,7 +516,7 @@ fn structured_constructors_preserve_f32_and_c32_dtype() {
     let left = DynIndex::new_dyn(2);
     let site = DynIndex::new_dyn(3);
     let right = DynIndex::new_dyn(2);
-    let selector = TensorDynLen::from_copy_selector(left, site, right, 1, 2.5_f32).unwrap();
+    let selector = IdxTensor::from_copy_selector(left, site, right, 1, 2.5_f32).unwrap();
     assert_eq!(
         selector
             .to_vec::<f32>()

--- a/crates/tensor4all-core/tests/tensor_basic.rs
+++ b/crates/tensor4all-core/tests/tensor_basic.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::sync::Arc;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index::DynIndex;
-use tensor4all_core::{AnyScalar, TensorDynLen, TensorElement, TensorStorageError};
+use tensor4all_core::{AnyScalar, IdxTensor, TensorElement, TensorStorageError};
 use tensor4all_tensorbackend::{Storage, StorageKind};
 
 /// Helper to create DenseF64 storage with shape information
@@ -16,12 +16,12 @@ fn make_dense_c64(data: Vec<Complex64>, dims: &[usize]) -> Storage {
     Storage::from_dense_col_major(data, dims).unwrap()
 }
 
-fn make_tensor_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn make_tensor_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn make_tensor_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn make_tensor_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 fn assert_from_diag_dense_constructor_contract<T>(data: Vec<T>)
@@ -30,7 +30,7 @@ where
 {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = TensorDynLen::from_diag(vec![i, j], data).unwrap();
+    let tensor = IdxTensor::from_diag(vec![i, j], data).unwrap();
     assert_eq!(tensor.dims(), vec![3, 3]);
     assert!(tensor.is_diag());
     assert_eq!(tensor.storage_kind(), StorageKind::Diagonal);
@@ -173,11 +173,11 @@ fn test_cow_storage() {
 }
 
 #[test]
-fn test_tensor_dyn_len_creation() {
+fn test_idx_tensor_creation() {
     let indices = vec![Index::new_dyn(2), Index::new_dyn(3)];
     let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap());
 
-    let tensor: TensorDynLen = TensorDynLen::new(indices, storage).unwrap();
+    let tensor: IdxTensor = IdxTensor::new(indices, storage).unwrap();
     assert_eq!(tensor.indices.len(), 2);
     let dims = tensor.dims();
     assert_eq!(dims.len(), 2);
@@ -200,7 +200,7 @@ fn tensor_from_structured_storage_preserves_compact_payload() {
         .unwrap(),
     );
 
-    let tensor = TensorDynLen::from_storage(vec![i, j, k], Arc::clone(&storage)).unwrap();
+    let tensor = IdxTensor::from_storage(vec![i, j, k], Arc::clone(&storage)).unwrap();
     let snapshot = tensor.storage().unwrap();
 
     assert_eq!(snapshot.storage_kind(), StorageKind::Structured);
@@ -220,7 +220,7 @@ fn copy_selector_is_compact_and_numerically_correct() {
     let site = Index::new_dyn(3);
     let right = Index::new_dyn(2);
 
-    let tensor = TensorDynLen::from_copy_selector(left, site, right, 1, 2.5_f64).unwrap();
+    let tensor = IdxTensor::from_copy_selector(left, site, right, 1, 2.5_f64).unwrap();
 
     assert_eq!(
         tensor.storage().unwrap().storage_kind(),
@@ -236,7 +236,7 @@ fn copy_selector_is_compact_and_numerically_correct() {
 
 #[test]
 fn copy_selector_rejects_payload_and_stride_overflow_before_allocation() {
-    let payload_error = TensorDynLen::from_copy_selector(
+    let payload_error = IdxTensor::from_copy_selector(
         Index::new_dyn(usize::MAX),
         Index::new_dyn(2),
         Index::new_dyn(usize::MAX),
@@ -250,7 +250,7 @@ fn copy_selector_rejects_payload_and_stride_overflow_before_allocation() {
     ));
 
     let oversized_stride = (isize::MAX as usize) + 1;
-    let stride_error = TensorDynLen::from_copy_selector(
+    let stride_error = IdxTensor::from_copy_selector(
         Index::new_dyn(oversized_stride),
         Index::new_dyn(1),
         Index::new_dyn(oversized_stride),
@@ -278,7 +278,7 @@ fn tensor_from_structured_storage_rejects_index_dim_mismatch() {
         .unwrap(),
     );
 
-    let err = TensorDynLen::from_storage(vec![i, j], storage).unwrap_err();
+    let err = IdxTensor::from_storage(vec![i, j], storage).unwrap_err();
     assert!(err.to_string().contains("storage logical dims"));
 }
 
@@ -287,7 +287,7 @@ fn structured_select_indices_preserves_copy_structure_when_possible() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_storage(
+    let tensor = IdxTensor::from_storage(
         vec![i.clone(), j.clone(), k.clone()],
         Arc::new(
             Storage::new_structured(
@@ -326,7 +326,7 @@ fn structured_select_indices_handles_fixed_copy_class() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_storage(
+    let tensor = IdxTensor::from_storage(
         vec![i.clone(), j.clone(), k.clone()],
         Arc::new(
             Storage::new_structured(
@@ -370,7 +370,7 @@ fn same_layout_axpby_preserves_structured_metadata() {
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(2);
     let make = |offset| {
-        TensorDynLen::from_storage(
+        IdxTensor::from_storage(
             vec![i.clone(), j.clone(), k.clone()],
             Arc::new(
                 Storage::new_structured(
@@ -464,7 +464,7 @@ fn test_tensor_duplicate_indices_new() {
     let indices = vec![i.clone(), j.clone(), i.clone()]; // duplicate i
     let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
 
-    let err = TensorDynLen::new(indices, storage).unwrap_err();
+    let err = IdxTensor::new(indices, storage).unwrap_err();
     assert!(err.to_string().contains("unique"));
 }
 
@@ -475,7 +475,7 @@ fn test_tensor_duplicate_indices_from_indices() {
     let indices = vec![i.clone(), j.clone(), i.clone()]; // duplicate i
     let storage = Arc::new(Storage::from_dense_col_major(vec![0.0; 12], &[2, 3, 2]).unwrap());
 
-    let err = TensorDynLen::from_indices(indices, storage).unwrap_err();
+    let err = IdxTensor::from_indices(indices, storage).unwrap_err();
     assert!(err.to_string().contains("unique"));
 }
 
@@ -641,7 +641,7 @@ fn test_replace_indices_does_not_reorder_data() {
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone()];
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(indices, data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(indices, data.clone()).unwrap();
 
     // Create new indices with same dimensions but different IDs
     let new_i = Index::new_dyn(2);
@@ -676,7 +676,7 @@ fn test_replace_indices_with_different_order_does_not_reorder_data() {
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone()];
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(indices, data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(indices, data.clone()).unwrap();
 
     // Create new indices with same dimensions
     let new_i = Index::new_dyn(2);
@@ -716,7 +716,7 @@ fn test_permuteinds_reorders_data() {
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone()];
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(indices, data).unwrap();
+    let tensor = IdxTensor::from_dense(indices, data).unwrap();
 
     // Use permuteinds to swap indices: [j, i] instead of [i, j]
     // This should reorder both indices AND data
@@ -750,7 +750,7 @@ fn test_replace_indices_vs_permuteinds_comparison() {
     let j = Index::new_dyn(3);
     let indices = vec![i.clone(), j.clone()];
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(indices, data).unwrap();
+    let tensor = IdxTensor::from_dense(indices, data).unwrap();
 
     // Create new indices with same dimensions
     let new_i = Index::new_dyn(2);
@@ -868,7 +868,7 @@ fn test_tensor_conj_c64() {
         Complex64::new(-1.0, 1.0),
         Complex64::new(5.0, 5.0),
     ];
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 
     let conj_tensor = tensor.conj();
 
@@ -890,7 +890,7 @@ fn test_tensor_conj_c64() {
 }
 
 // ============================================================================
-// High-level API tests for TensorDynLen
+// High-level API tests for IdxTensor
 // ============================================================================
 
 #[test]
@@ -898,7 +898,7 @@ fn test_from_dense_f64() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(vec![i, j], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i, j], data.clone()).unwrap();
 
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(tensor.is_f64());
@@ -914,7 +914,7 @@ fn test_from_dense_c64() {
     let data: Vec<Complex64> = (1..=6)
         .map(|x| Complex64::new(x as f64, x as f64))
         .collect();
-    let tensor = TensorDynLen::from_dense(vec![i, j], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i, j], data.clone()).unwrap();
 
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(!tensor.is_f64());
@@ -928,7 +928,7 @@ fn test_into_dense_col_major_parts_returns_indices_and_values() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
 
     let (indices, values) = tensor.into_dense_col_major_parts::<f64>().unwrap();
 
@@ -940,7 +940,7 @@ fn test_into_dense_col_major_parts_returns_indices_and_values() {
 fn test_into_dense_col_major_parts_materializes_diag_storage() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let tensor = IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0]).unwrap();
 
     let (indices, values) = tensor.into_dense_col_major_parts::<f64>().unwrap();
 
@@ -951,7 +951,7 @@ fn test_into_dense_col_major_parts_materializes_diag_storage() {
 #[test]
 fn test_into_dense_col_major_parts_rejects_ad_tracked_tensor() {
     let i = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0])
+    let tensor = IdxTensor::from_dense(vec![i], vec![1.0_f64, 2.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -964,11 +964,11 @@ fn test_into_dense_col_major_parts_rejects_ad_tracked_tensor() {
 fn assert_dense_constructor_dims<T>(data: Vec<T>)
 where
     T: TensorElement,
-    TensorDynLen: std::fmt::Debug,
+    IdxTensor: std::fmt::Debug,
 {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i, j], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i, j], data).unwrap();
     assert_eq!(tensor.dims(), vec![2, 2]);
 }
 
@@ -994,7 +994,7 @@ fn test_from_dense_generic_supports_all_supported_element_types() {
 fn test_from_dense_generic_preserves_column_major_input_order() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
@@ -1011,7 +1011,7 @@ fn test_from_dense_generic_preserves_column_major_input_order() {
 fn test_from_dense_generic_rejects_length_mismatch() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let err = TensorDynLen::from_dense(vec![i, j], vec![1.0_f64, 2.0, 3.0]).unwrap_err();
+    let err = IdxTensor::from_dense(vec![i, j], vec![1.0_f64, 2.0, 3.0]).unwrap_err();
     assert!(
         err.to_string().contains("length"),
         "unexpected error: {err}"
@@ -1038,7 +1038,7 @@ fn test_from_diag_generic_supports_all_supported_element_types() {
 fn test_from_diag_generic_rejects_mismatched_index_dims() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let err = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0]).unwrap_err();
+    let err = IdxTensor::from_diag(vec![i, j], vec![1.0_f64, 2.0]).unwrap_err();
     assert!(
         err.to_string().contains("same dimension"),
         "unexpected error: {err}"
@@ -1049,7 +1049,7 @@ fn test_from_diag_generic_rejects_mismatched_index_dims() {
 fn test_from_diag_generic_rejects_payload_length_mismatch() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let err = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0]).unwrap_err();
+    let err = IdxTensor::from_diag(vec![i, j], vec![1.0_f64, 2.0]).unwrap_err();
     assert!(
         err.to_string().contains("length"),
         "unexpected error: {err}"
@@ -1058,7 +1058,7 @@ fn test_from_diag_generic_rejects_payload_length_mismatch() {
 
 #[test]
 fn test_scalar_f64() {
-    let scalar = TensorDynLen::scalar(42.0).unwrap();
+    let scalar = IdxTensor::scalar(42.0).unwrap();
     assert_eq!(scalar.dims(), Vec::<usize>::new());
     assert!(scalar.is_f64());
     assert_eq!(scalar.to_vec::<f64>().unwrap(), &[42.0]);
@@ -1067,7 +1067,7 @@ fn test_scalar_f64() {
 #[test]
 fn test_scalar_c64() {
     let z = Complex64::new(1.0, 2.0);
-    let scalar = TensorDynLen::scalar(z).unwrap();
+    let scalar = IdxTensor::scalar(z).unwrap();
     assert_eq!(scalar.dims(), Vec::<usize>::new());
     assert!(scalar.is_complex());
     assert_eq!(scalar.to_vec::<Complex64>().unwrap(), &[z]);
@@ -1077,7 +1077,7 @@ fn test_scalar_c64() {
 fn test_zeros_f64() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let tensor = TensorDynLen::zeros::<f64>(vec![i, j]).unwrap();
+    let tensor = IdxTensor::zeros::<f64>(vec![i, j]).unwrap();
 
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(tensor.is_f64());
@@ -1089,7 +1089,7 @@ fn test_zeros_f64() {
 fn test_zeros_c64() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let tensor = TensorDynLen::zeros::<num_complex::Complex64>(vec![i, j]).unwrap();
+    let tensor = IdxTensor::zeros::<num_complex::Complex64>(vec![i, j]).unwrap();
 
     assert_eq!(tensor.dims(), vec![2, 3]);
     assert!(tensor.is_complex());
@@ -1101,12 +1101,12 @@ fn test_zeros_c64() {
 fn test_as_slice_error_on_wrong_type() {
     let i = Index::new_dyn(2);
     // Create f64 tensor but try to get c64 slice
-    let tensor_f64 = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    let tensor_f64 = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
     assert!(tensor_f64.to_vec::<Complex64>().is_err());
     assert!(tensor_f64.to_vec::<Complex64>().is_err());
 
     // Create c64 tensor but try to get f64 slice
-    let tensor_c64 = TensorDynLen::from_dense(
+    let tensor_c64 = IdxTensor::from_dense(
         vec![i],
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
     )

--- a/crates/tensor4all-core/tests/tensor_comparison.rs
+++ b/crates/tensor4all-core/tests/tensor_comparison.rs
@@ -1,12 +1,12 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::{diag_tensor_dyn_len, TensorDynLen};
+use tensor4all_core::{diag_idx_tensor, IdxTensor};
 
 #[test]
 fn test_sub_identical_tensors_is_zero() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
@@ -20,8 +20,8 @@ fn test_sub_identical_tensors_is_zero() {
 #[test]
 fn test_sub_different_tensors() {
     let i = Index::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 5.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![3.0, 5.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
 
     let diff = a.sub(&b).unwrap();
     let data = diff.to_vec::<f64>().unwrap();
@@ -34,12 +34,12 @@ fn test_sub_permuted_indices() {
     // a[i,j] - b[j,i] should auto-permute
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
     .unwrap();
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![j.clone(), i.clone()],
         vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0], // transposed in column-major order
     )
@@ -52,7 +52,7 @@ fn test_sub_permuted_indices() {
 #[test]
 fn test_neg() {
     let i = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0]).unwrap();
 
     let neg_a = a.neg().unwrap();
     let data = neg_a.to_vec::<f64>().unwrap();
@@ -64,13 +64,13 @@ fn test_neg() {
 #[test]
 fn test_maxabs() {
     let i = Index::new_dyn(4);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -5.0, 3.0, -2.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, -5.0, 3.0, -2.0]).unwrap();
     assert!((a.maxabs().unwrap() - 5.0).abs() < 1e-14);
 }
 
 #[test]
 fn test_maxabs_scalar() {
-    let s = TensorDynLen::scalar(-7.0).unwrap();
+    let s = IdxTensor::scalar(-7.0).unwrap();
     assert!((s.maxabs().unwrap() - 7.0).abs() < 1e-14);
 }
 
@@ -78,7 +78,7 @@ fn test_maxabs_scalar() {
 fn test_maxabs_diag_f64() {
     let i = Index::new_dyn(4);
     let j = Index::new_dyn(4);
-    let d = diag_tensor_dyn_len(vec![i, j], vec![1.0, -5.0, 3.0, -2.0]).unwrap();
+    let d = diag_idx_tensor(vec![i, j], vec![1.0, -5.0, 3.0, -2.0]).unwrap();
     assert!((d.maxabs().unwrap() - 5.0).abs() < 1e-14);
 }
 
@@ -86,7 +86,7 @@ fn test_maxabs_diag_f64() {
 fn test_maxabs_diag_c64() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let d = TensorDynLen::from_diag(
+    let d = IdxTensor::from_diag(
         vec![i, j],
         vec![
             Complex64::new(3.0, 4.0),  // |z| = 5
@@ -101,15 +101,15 @@ fn test_maxabs_diag_c64() {
 #[test]
 fn test_isapprox_identical() {
     let i = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
     assert!(a.isapprox(&a, 0.0, 0.0).unwrap());
 }
 
 #[test]
 fn test_isapprox_atol() {
     let i = Index::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.01]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.01]).unwrap();
 
     // ||a - b|| = 0.01
     assert!(a.isapprox(&b, 0.1, 0.0).unwrap()); // atol=0.1 > 0.01
@@ -119,8 +119,8 @@ fn test_isapprox_atol() {
 #[test]
 fn test_isapprox_rtol() {
     let i = Index::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![100.0, 200.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![100.0, 201.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![100.0, 200.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![100.0, 201.0]).unwrap();
 
     // ||a - b|| = 1.0, max(||a||, ||b||) ≈ 224
     // rtol * max_norm ≈ 0.01 * 224 ≈ 2.24 > 1.0
@@ -133,8 +133,8 @@ fn test_isapprox_rtol() {
 fn test_isapprox_index_mismatch_returns_error() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![j.clone()], vec![1.0, 2.0, 3.0]).unwrap();
 
     // Different indices → sub fails → isapprox returns an error.
     assert!(a.isapprox(&b, 1e10, 1e10).is_err());
@@ -144,25 +144,24 @@ fn test_isapprox_index_mismatch_returns_error() {
 fn test_isapprox_aligns_permuted_axes_without_reordering_payloads() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let lhs =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
-    let rhs = TensorDynLen::from_dense(vec![j, i], vec![1.0, 3.0, 2.0, 4.0]).unwrap();
+    let lhs = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let rhs = IdxTensor::from_dense(vec![j, i], vec![1.0, 3.0, 2.0, 4.0]).unwrap();
 
     assert!(lhs.isapprox(&rhs, 0.0, 0.0).unwrap());
 }
 
 #[test]
 fn test_isapprox_exact_comparison_does_not_underflow() {
-    let lhs = TensorDynLen::scalar(1.0e-300).unwrap();
-    let rhs = TensorDynLen::scalar(2.0e-300).unwrap();
+    let lhs = IdxTensor::scalar(1.0e-300).unwrap();
+    let rhs = IdxTensor::scalar(2.0e-300).unwrap();
 
     assert!(!lhs.isapprox(&rhs, 0.0, 0.0).unwrap());
 }
 
 #[test]
 fn test_isapprox_relative_tolerance_does_not_underflow() {
-    let lhs = TensorDynLen::scalar(1.0e-300).unwrap();
-    let rhs = TensorDynLen::scalar(2.0e-300).unwrap();
+    let lhs = IdxTensor::scalar(1.0e-300).unwrap();
+    let rhs = IdxTensor::scalar(2.0e-300).unwrap();
 
     assert!(!lhs.isapprox(&rhs, 0.0, 0.1).unwrap());
     assert!(lhs.isapprox(&rhs, 0.0, 0.6).unwrap());
@@ -170,8 +169,8 @@ fn test_isapprox_relative_tolerance_does_not_underflow() {
 
 #[test]
 fn test_isapprox_relative_tolerance_does_not_overflow() {
-    let lhs = TensorDynLen::scalar(f64::MAX).unwrap();
-    let rhs = TensorDynLen::scalar(-f64::MAX).unwrap();
+    let lhs = IdxTensor::scalar(f64::MAX).unwrap();
+    let rhs = IdxTensor::scalar(-f64::MAX).unwrap();
 
     assert!(!lhs.isapprox(&rhs, 0.0, 1.0).unwrap());
     assert!(lhs.isapprox(&rhs, 0.0, 2.0).unwrap());
@@ -183,12 +182,12 @@ fn test_isapprox_structured_support_matches_permuted_and_dense_layouts() {
     let site = Index::new_dyn(3);
     let right = Index::new_dyn(2);
     let structured =
-        TensorDynLen::from_copy_selector(left.clone(), site.clone(), right.clone(), 1, 2.0_f64)
+        IdxTensor::from_copy_selector(left.clone(), site.clone(), right.clone(), 1, 2.0_f64)
             .unwrap();
     let permuted = structured
         .permute_indices(&[site.clone(), right.clone(), left.clone()])
         .unwrap();
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         structured.indices().to_vec(),
         structured.to_vec::<f64>().unwrap(),
     )
@@ -205,27 +204,26 @@ fn test_isapprox_structured_support_matches_permuted_and_dense_layouts() {
 fn test_isapprox_diagonal_vs_dense_collapsed_support() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let diag = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, 2.0]).unwrap();
+    let diag = diag_idx_tensor(vec![i.clone(), j.clone()], vec![1.0, 2.0]).unwrap();
     // Dense expansion keeps the diagonal support; off-diagonal structural
     // zeros are still part of the logical tensor and must be compared.
-    let same =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
-    let different = TensorDynLen::from_dense(vec![i.clone(), j], vec![1.0, 0.0, 0.0, 3.0]).unwrap();
+    let same = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
+    let different = IdxTensor::from_dense(vec![i.clone(), j], vec![1.0, 0.0, 0.0, 3.0]).unwrap();
     assert!(diag.isapprox(&same, 1.0e-12, 1.0e-12).unwrap());
     assert!(!diag.isapprox(&different, 0.0, 0.1).unwrap());
 }
 
 #[test]
 fn test_isapprox_rejects_nan_input() {
-    let lhs = TensorDynLen::scalar(f64::NAN).unwrap();
-    let rhs = TensorDynLen::scalar(1.0).unwrap();
+    let lhs = IdxTensor::scalar(f64::NAN).unwrap();
+    let rhs = IdxTensor::scalar(1.0).unwrap();
     assert!(lhs.isapprox(&rhs, 1.0e-12, 1.0e-12).is_err());
     // The NaN preflight must also apply in exact comparison mode.
     assert!(lhs.isapprox(&rhs, 0.0, 0.0).is_err());
 
     let index = Index::new_dyn(2);
-    let nan_tensor = TensorDynLen::from_dense(vec![index.clone()], vec![1.0, f64::NAN]).unwrap();
-    let finite = TensorDynLen::from_dense(vec![index], vec![1.0, 1.0]).unwrap();
+    let nan_tensor = IdxTensor::from_dense(vec![index.clone()], vec![1.0, f64::NAN]).unwrap();
+    let finite = IdxTensor::from_dense(vec![index], vec![1.0, 1.0]).unwrap();
     assert!(nan_tensor.isapprox(&finite, 1.0e-12, 1.0e-12).is_err());
 }
 
@@ -233,8 +231,8 @@ fn test_isapprox_rejects_nan_input() {
 fn test_isapprox_rejects_nan_in_structured_payload() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let nan_diag = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, f64::NAN]).unwrap();
-    let dense = TensorDynLen::from_dense(vec![i.clone(), j], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
+    let nan_diag = diag_idx_tensor(vec![i.clone(), j.clone()], vec![1.0, f64::NAN]).unwrap();
+    let dense = IdxTensor::from_dense(vec![i.clone(), j], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
     assert!(nan_diag.isapprox(&dense, 1.0e-12, 1.0e-12).is_err());
 }
 
@@ -242,19 +240,19 @@ fn test_isapprox_rejects_nan_in_structured_payload() {
 fn test_isapprox_unmatched_support_is_compared_in_both_orders() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let diag = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, 2.0]).unwrap();
+    let diag = diag_idx_tensor(vec![i.clone(), j.clone()], vec![1.0, 2.0]).unwrap();
     // The off-diagonal entry (1,0) lies outside the diagonal compact support;
     // it must be compared against the structural zero in both operand orders.
     let off_diag =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 10.0, 0.0, 2.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 10.0, 0.0, 2.0]).unwrap();
     assert!(!diag.isapprox(&off_diag, 0.0, 0.5).unwrap());
     assert!(!off_diag.isapprox(&diag, 0.0, 0.5).unwrap());
 }
 
 #[test]
 fn test_isapprox_zero_vs_nonzero_tolerant() {
-    let zero = TensorDynLen::scalar(0.0).unwrap();
-    let small = TensorDynLen::scalar(1.0e-8).unwrap();
+    let zero = IdxTensor::scalar(0.0).unwrap();
+    let small = IdxTensor::scalar(1.0e-8).unwrap();
     // One side has a zero reference norm; the unit ratio must only pass at
     // rtol >= 1 and never in exact mode.
     assert!(!zero.isapprox(&small, 0.0, 0.5).unwrap());
@@ -265,7 +263,7 @@ fn test_isapprox_zero_vs_nonzero_tolerant() {
 fn test_isapprox_large_structured_support_does_not_visit_logical_domain() {
     let bond_dim = 100_000;
     let site = Index::new_dyn(3);
-    let tensor = TensorDynLen::from_copy_selector(
+    let tensor = IdxTensor::from_copy_selector(
         Index::new_dyn(bond_dim),
         site,
         Index::new_dyn(bond_dim),
@@ -282,8 +280,8 @@ fn test_isapprox_large_structured_support_does_not_visit_logical_domain() {
 #[test]
 fn test_isapprox_matching_infinities_are_not_reference_norms() {
     let index = Index::new_dyn(2);
-    let lhs = TensorDynLen::from_dense(vec![index.clone()], vec![f64::INFINITY, 0.0]).unwrap();
-    let rhs = TensorDynLen::from_dense(vec![index], vec![f64::INFINITY, 1.0]).unwrap();
+    let lhs = IdxTensor::from_dense(vec![index.clone()], vec![f64::INFINITY, 0.0]).unwrap();
+    let rhs = IdxTensor::from_dense(vec![index], vec![f64::INFINITY, 1.0]).unwrap();
 
     assert!(!lhs.isapprox(&rhs, 0.0, 0.5).unwrap());
     assert!(lhs.isapprox(&rhs, 0.0, 1.0).unwrap());
@@ -292,8 +290,8 @@ fn test_isapprox_matching_infinities_are_not_reference_norms() {
 #[test]
 fn test_sub_operator_owned() {
     let i = Index::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![5.0, 10.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 3.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![5.0, 10.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 3.0]).unwrap();
 
     // owned - owned
     let diff = a.sub(&b).unwrap();

--- a/crates/tensor4all-core/tests/tensor_contract_nary_pair_equivalence.rs
+++ b/crates/tensor4all-core/tests/tensor_contract_nary_pair_equivalence.rs
@@ -1,13 +1,13 @@
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::{
-    factorize, outer_product, svd, Canonical, DynIndex, FactorizeOptions, TensorContractionLike,
-    TensorDynLen,
+    factorize, outer_product, svd, Canonical, DynIndex, FactorizeOptions, IdxTensor,
+    TensorContractionLike,
 };
 
-fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>, dims: &[usize]) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>, dims: &[usize]) -> IdxTensor {
     let expected_len: usize = dims.iter().product();
     assert_eq!(data.len(), expected_len);
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 fn col_major_multi_index(mut offset: usize, dims: &[usize]) -> Vec<usize> {
@@ -65,7 +65,7 @@ fn test_contract_nary_pair_matches_binary_contract() {
     );
 
     let binary = t1.contract_pair(&t2).unwrap();
-    let multi = <TensorDynLen as TensorContractionLike>::contract(&[&t1, &t2]).expect("contract");
+    let multi = <IdxTensor as TensorContractionLike>::contract(&[&t1, &t2]).expect("contract");
 
     assert!(
         multi.isapprox(&binary, 1e-12, 0.0).unwrap(),
@@ -99,8 +99,7 @@ fn test_contract_nary_three_matches_sequential_binary_contract() {
     );
 
     let sequential = t0.contract_pair(&t1).unwrap().contract_pair(&t2).unwrap();
-    let multi =
-        <TensorDynLen as TensorContractionLike>::contract(&[&t0, &t1, &t2]).expect("contract");
+    let multi = <IdxTensor as TensorContractionLike>::contract(&[&t0, &t1, &t2]).expect("contract");
 
     assert!(
         multi.isapprox(&sequential, 1e-12, 0.0).unwrap(),
@@ -123,7 +122,7 @@ fn test_contract_nary_pair_matches_binary_contract_for_zero_masked_inputs() {
     let t1 = make_tensor(vec![l01, s1], (1..=6).map(|x| x as f64).collect(), &[3, 2]);
 
     let binary = t0.contract_pair(&t1).unwrap();
-    let multi = <TensorDynLen as TensorContractionLike>::contract(&[&t0, &t1]).expect("contract");
+    let multi = <IdxTensor as TensorContractionLike>::contract(&[&t0, &t1]).expect("contract");
 
     assert!(
         multi.isapprox(&binary, 1e-12, 0.0).unwrap(),
@@ -165,7 +164,7 @@ fn test_zipup_zero_masked_root_nary_matches_sequential_binary_contract() {
     let permuted_leaf = leaf
         .permute_indices(&[s0.clone(), s1.clone(), l01.clone(), l12.clone()])
         .unwrap();
-    let expected_permuted = TensorDynLen::from_dense(
+    let expected_permuted = IdxTensor::from_dense(
         vec![s0.clone(), s1.clone(), l01.clone(), l12.clone()],
         permute_col_major(&leaf.to_vec::<f64>().unwrap(), &leaf.dims(), &[0, 2, 1, 3]),
     )
@@ -212,7 +211,7 @@ fn test_zipup_zero_masked_root_nary_matches_sequential_binary_contract() {
         .unwrap()
         .contract_pair(&b1)
         .unwrap();
-    let multi = <TensorDynLen as TensorContractionLike>::contract(&[&factorized.right, &a1, &b1])
+    let multi = <IdxTensor as TensorContractionLike>::contract(&[&factorized.right, &a1, &b1])
         .expect("root contract");
 
     assert!(

--- a/crates/tensor4all-core/tests/tensor_contraction.rs
+++ b/crates/tensor4all-core/tests/tensor_contraction.rs
@@ -2,20 +2,20 @@ use num_complex::{Complex32, Complex64};
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index_ops::common_inds;
 use tensor4all_core::{
-    contract, contract_pair, contract_pair_with_operand_options, tensordot, DynIndex,
-    PairwiseContractionOptions, TensorContractionLike, TensorDynLen,
+    contract, contract_pair, contract_pair_with_operand_options, tensordot, DynIndex, IdxTensor,
+    PairwiseContractionOptions, TensorContractionLike,
 };
 use tensor4all_tensorbackend::{Storage, StorageKind};
 
-fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn assert_all_f64(tensor: &TensorDynLen, expected_len: usize, expected_value: f64) {
+fn assert_all_f64(tensor: &IdxTensor, expected_len: usize, expected_value: f64) {
     let data = tensor.to_vec::<f64>().unwrap();
     assert_eq!(data.len(), expected_len);
     for value in data {
@@ -109,9 +109,9 @@ fn test_contract_no_common_indices_gives_outer_product() {
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(4);
 
-    let tensor_a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor_a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
-    let tensor_b = TensorDynLen::zeros::<f64>(vec![k.clone()]).unwrap();
+    let tensor_b = IdxTensor::zeros::<f64>(vec![k.clone()]).unwrap();
 
     // No common indices → outer product
     let result = tensor_a.contract_pair(&tensor_b).unwrap();
@@ -124,13 +124,13 @@ fn test_contract_no_common_indices_preserves_left_then_right_index_order_and_val
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
 
-    let tensor_a = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, -1.0]).unwrap();
-    let tensor_b = TensorDynLen::from_dense(vec![j.clone()], vec![3.0, 4.0, -2.0]).unwrap();
+    let tensor_a = IdxTensor::from_dense(vec![i.clone()], vec![2.0, -1.0]).unwrap();
+    let tensor_b = IdxTensor::from_dense(vec![j.clone()], vec![3.0, 4.0, -2.0]).unwrap();
 
     let result = tensor_a.contract_pair(&tensor_b).unwrap();
 
     assert_eq!(result.indices, vec![i, j]);
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         result.indices.clone(),
         vec![
             6.0, -3.0, 8.0, //
@@ -146,13 +146,13 @@ fn structured_tensor_contract_materializes_to_correct_dense_result() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
     let k = Index::new_dyn(2);
-    let diag = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![2.0_f64, 3.0]).unwrap();
+    let diag = IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![2.0_f64, 3.0]).unwrap();
     assert!(diag.is_diag());
-    let dense = TensorDynLen::from_dense(vec![j, k.clone()], vec![5.0, 7.0, 11.0, 13.0]).unwrap();
+    let dense = IdxTensor::from_dense(vec![j, k.clone()], vec![5.0, 7.0, 11.0, 13.0]).unwrap();
 
     let result = diag.contract_pair(&dense).unwrap();
 
-    let expected = TensorDynLen::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
+    let expected = IdxTensor::from_dense(vec![i, k], vec![10.0, 21.0, 22.0, 39.0]).unwrap();
     assert!(result.sub(&expected).unwrap().maxabs().unwrap() < 1e-12);
 }
 
@@ -162,7 +162,7 @@ fn general_structured_contract_preserves_output_axis_classes() {
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(2);
     let l = Index::new_dyn(2);
-    let structured = TensorDynLen::from_storage(
+    let structured = IdxTensor::from_storage(
         vec![i.clone(), j.clone(), k.clone()],
         Storage::new_structured(
             vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -174,7 +174,7 @@ fn general_structured_contract_preserves_output_axis_classes() {
         .unwrap(),
     )
     .unwrap();
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         vec![j, l.clone()],
         vec![10.0, 20.0, 30.0, 100.0, 200.0, 300.0],
     )
@@ -233,13 +233,13 @@ fn structured_mixed_dtype_nary_contract_preserves_compact_result() {
     let j = Index::new_dyn(2);
     let k = Index::new_dyn(2);
     let l = Index::new_dyn(2);
-    let a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f32, 2.0]).unwrap();
-    let b = TensorDynLen::from_diag(
+    let a = IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![1.0_f32, 2.0]).unwrap();
+    let b = IdxTensor::from_diag(
         vec![j.clone(), k.clone()],
         vec![Complex32::new(3.0, 1.0), Complex32::new(4.0, -2.0)],
     )
     .unwrap();
-    let c = TensorDynLen::from_diag(vec![k, l.clone()], vec![2.0_f64, 3.0]).unwrap();
+    let c = IdxTensor::from_diag(vec![k, l.clone()], vec![2.0_f64, 3.0]).unwrap();
 
     let result = contract(&[&a, &b, &c]).unwrap();
     assert_eq!(result.storage_kind(), StorageKind::Diagonal);
@@ -259,11 +259,11 @@ fn structured_mixed_dtype_nary_contract_preserves_compact_result() {
 fn structured_mixed_dtype_ad_contract_preserves_gradient() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
-    let a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0])
+    let a = IdxTensor::from_diag(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0])
         .unwrap()
         .enable_grad()
         .unwrap();
-    let b = TensorDynLen::from_diag(
+    let b = IdxTensor::from_diag(
         vec![j, Index::new_dyn(2)],
         vec![Complex64::new(3.0, 0.0), Complex64::new(4.0, 0.0)],
     )
@@ -281,11 +281,11 @@ fn structured_mixed_dtype_ad_contract_preserves_gradient() {
 #[test]
 fn dense_mixed_dtype_ad_contract_preserves_gradient() {
     let i = Index::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0])
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0])
         .unwrap()
         .enable_grad()
         .unwrap();
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![i],
         vec![Complex64::new(3.0, 0.0), Complex64::new(4.0, 0.0)],
     )
@@ -493,9 +493,9 @@ fn test_tensordot_dimension_mismatch() {
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(5); // Different dimension from j
 
-    let tensor_a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor_a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
-    let tensor_b = TensorDynLen::zeros::<f64>(vec![k.clone()]).unwrap();
+    let tensor_b = IdxTensor::zeros::<f64>(vec![k.clone()]).unwrap();
 
     let result = tensordot(&tensor_a, &tensor_b, &[(j.clone(), k.clone())]);
     assert!(result.is_err());
@@ -517,9 +517,9 @@ fn test_tensordot_index_not_found() {
     let k = Index::new_dyn(3);
     let nonexistent = Index::new_dyn(3);
 
-    let tensor_a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor_a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
-    let tensor_b = TensorDynLen::zeros::<f64>(vec![k.clone()]).unwrap();
+    let tensor_b = IdxTensor::zeros::<f64>(vec![k.clone()]).unwrap();
 
     // Try to contract with a non-existent index from tensor_a
     let result = tensordot(&tensor_a, &tensor_b, &[(nonexistent.clone(), k.clone())]);
@@ -542,9 +542,9 @@ fn test_tensordot_duplicate_axis() {
     let k = Index::new_dyn(3);
     let l = Index::new_dyn(4);
 
-    let tensor_a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor_a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
-    let tensor_b = TensorDynLen::zeros::<f64>(vec![k.clone(), l.clone()]).unwrap();
+    let tensor_b = IdxTensor::zeros::<f64>(vec![k.clone(), l.clone()]).unwrap();
 
     // Try to contract j twice (duplicate axis in self)
     let result = tensordot(
@@ -565,9 +565,9 @@ fn test_tensordot_empty_pairs() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
 
-    let tensor_a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+    let tensor_a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
-    let tensor_b = TensorDynLen::zeros::<f64>(vec![j.clone()]).unwrap();
+    let tensor_b = IdxTensor::zeros::<f64>(vec![j.clone()]).unwrap();
 
     let result = tensordot(&tensor_a, &tensor_b, &[]);
     assert!(result.is_err());
@@ -594,10 +594,10 @@ fn test_tensordot_common_index_not_in_pairs() {
     let l = Index::new_dyn(5);
 
     // Create tensor A[i, j, k]
-    let tensor_a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone(), k.clone()]).unwrap();
+    let tensor_a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone(), k.clone()]).unwrap();
 
     // Create tensor B[j, l] where j is a common index with A
-    let tensor_b = TensorDynLen::zeros::<f64>(vec![j.clone(), l.clone()]).unwrap();
+    let tensor_b = IdxTensor::zeros::<f64>(vec![j.clone(), l.clone()]).unwrap();
 
     // Try to contract only k with l, leaving j as a "batch" dimension
     // This should fail because batch contraction is not yet implemented
@@ -640,11 +640,11 @@ fn test_tensordot_common_index_in_pairs_ok() {
 #[test]
 fn test_scalar_times_tensor() {
     // scalar_one() * tensor = tensor
-    let scalar = TensorDynLen::scalar_one().unwrap();
+    let scalar = IdxTensor::scalar_one().unwrap();
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
 
     let result = scalar.contract_pair(&tensor).unwrap();
     assert_eq!(result.dims(), vec![2, 3]);
@@ -654,10 +654,10 @@ fn test_scalar_times_tensor() {
 #[test]
 fn test_tensor_times_scalar() {
     // tensor * scalar_one() = tensor
-    let scalar = TensorDynLen::scalar_one().unwrap();
+    let scalar = IdxTensor::scalar_one().unwrap();
     let i = Index::new_dyn(2);
     let data = vec![10.0, 20.0];
-    let tensor = TensorDynLen::from_dense(vec![i.clone()], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone()], data.clone()).unwrap();
 
     let result = tensor.contract_pair(&scalar).unwrap();
     assert_eq!(result.dims(), vec![2]);
@@ -666,8 +666,8 @@ fn test_tensor_times_scalar() {
 
 #[test]
 fn test_scalar_times_scalar() {
-    let s1 = TensorDynLen::scalar(3.0).unwrap();
-    let s2 = TensorDynLen::scalar(5.0).unwrap();
+    let s1 = IdxTensor::scalar(3.0).unwrap();
+    let s2 = IdxTensor::scalar(5.0).unwrap();
 
     let result = s1.contract_pair(&s2).unwrap();
     assert_eq!(result.dims().len(), 0);
@@ -679,10 +679,10 @@ fn test_scalar_times_scalar() {
 #[test]
 fn test_mul_operator_scalar_times_tensor() {
     // &scalar * &tensor via Mul trait
-    let scalar = TensorDynLen::scalar_one().unwrap();
+    let scalar = IdxTensor::scalar_one().unwrap();
     let i = Index::new_dyn(3);
     let data = vec![1.0, 2.0, 3.0];
-    let tensor = TensorDynLen::from_dense(vec![i.clone()], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone()], data.clone()).unwrap();
 
     let result = scalar.contract_pair(&tensor).unwrap();
     assert_eq!(result.dims(), vec![3]);
@@ -694,10 +694,10 @@ fn test_foldl_sequential_contraction() {
     // Simulate foldl-style: acc = scalar_one; acc = acc * a; acc = acc * b;
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0; 6]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j.clone(), i.clone()], vec![2.0; 6]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0; 6]).unwrap();
+    let b = IdxTensor::from_dense(vec![j.clone(), i.clone()], vec![2.0; 6]).unwrap();
 
-    let mut acc = TensorDynLen::scalar_one().unwrap();
+    let mut acc = IdxTensor::scalar_one().unwrap();
     acc = acc.contract_pair(&a).unwrap(); // acc = a (outer product with scalar)
     acc = acc.contract_pair(&b).unwrap(); // acc = contract(a, b) over i and j
 

--- a/crates/tensor4all-core/tests/tensor_diag.rs
+++ b/crates/tensor4all-core/tests/tensor_diag.rs
@@ -1,8 +1,8 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::{
-    diag_tensor_dyn_len, outer_product, tensordot, AnyScalar, TensorConstructionLike,
-    TensorContractionLike, TensorDynLen,
+    diag_idx_tensor, outer_product, tensordot, AnyScalar, IdxTensor, TensorConstructionLike,
+    TensorContractionLike,
 };
 use tensor4all_tensorbackend::StorageKind;
 
@@ -12,7 +12,7 @@ fn test_diag_tensor_creation() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![3, 3]);
     assert!(tensor.is_diag());
     assert_eq!(
@@ -35,7 +35,7 @@ fn test_diag_tensor_validation_different_dims() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0];
 
-    let err = diag_tensor_dyn_len(vec![i, j], diag_data).unwrap_err();
+    let err = diag_idx_tensor(vec![i, j], diag_data).unwrap_err();
     assert!(err.to_string().contains("same dimension"));
 }
 
@@ -45,7 +45,7 @@ fn test_diag_tensor_sum() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone()], diag_data).unwrap();
     let sum: AnyScalar = tensor.sum().unwrap();
     assert!(!sum.is_complex());
     assert!((sum.real() - 6.0).abs() < 1e-10);
@@ -55,7 +55,7 @@ fn test_diag_tensor_sum() {
 fn test_diag_tensor_scale_preserves_diagonal_values() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, -2.0, 4.0]).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone()], vec![1.0, -2.0, 4.0]).unwrap();
 
     let scaled = tensor.scale(AnyScalar::new_real(-0.5)).unwrap();
 
@@ -64,7 +64,7 @@ fn test_diag_tensor_scale_preserves_diagonal_values() {
         scaled.storage().unwrap().storage_kind(),
         StorageKind::Diagonal
     );
-    let expected = diag_tensor_dyn_len(vec![i, j], vec![-0.5, 1.0, -2.0]).unwrap();
+    let expected = diag_idx_tensor(vec![i, j], vec![-0.5, 1.0, -2.0]).unwrap();
     assert!(scaled.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -75,13 +75,12 @@ fn test_diag_tensor_permute() {
     let k = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor =
-        diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone()).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone(), k.clone()], diag_data.clone()).unwrap();
 
     // Permute: data should not change for DiagTensor
     let permuted = tensor.permute(&[2, 0, 1]).unwrap();
     assert_eq!(permuted.dims(), vec![3, 3, 3]);
-    let expected = diag_tensor_dyn_len(vec![k, i, j], diag_data).unwrap();
+    let expected = diag_idx_tensor(vec![k, i, j], diag_data).unwrap();
     assert!(permuted.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -89,7 +88,7 @@ fn test_diag_tensor_permute() {
 fn diag_tensor_select_index_returns_dense_slice_from_payload() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 5.0, 7.0]).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone()], vec![2.0, 5.0, 7.0]).unwrap();
 
     let selected = tensor.select_indices(&[j], &[1]).unwrap();
 
@@ -107,7 +106,7 @@ fn diag_tensor_select_multiple_indices_requires_matching_coordinates() {
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(3);
     let tensor =
-        diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], vec![2.0, 5.0, 7.0]).unwrap();
+        diag_idx_tensor(vec![i.clone(), j.clone(), k.clone()], vec![2.0, 5.0, 7.0]).unwrap();
 
     let matching = tensor
         .select_indices(&[i.clone(), k.clone()], &[2, 2])
@@ -128,8 +127,8 @@ fn test_diag_tensor_contract_diag_diag_all_contracted() {
     let diag_a = vec![1.0, 2.0];
     let diag_b = vec![3.0, 4.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a).unwrap();
-    let tensor_b = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_b).unwrap();
+    let tensor_a = diag_idx_tensor(vec![i.clone(), j.clone()], diag_a).unwrap();
+    let tensor_b = diag_idx_tensor(vec![i.clone(), j.clone()], diag_b).unwrap();
 
     // Contract all indices: result should be scalar (inner product)
     let result = tensor_a.contract_pair(&tensor_b).unwrap();
@@ -148,8 +147,8 @@ fn test_diag_tensor_contract_diag_diag_partial() {
     let diag_a = vec![1.0, 2.0, 3.0];
     let diag_b = vec![4.0, 5.0, 6.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a).unwrap();
-    let tensor_b = diag_tensor_dyn_len(vec![j.clone(), k.clone()], diag_b).unwrap();
+    let tensor_a = diag_idx_tensor(vec![i.clone(), j.clone()], diag_a).unwrap();
+    let tensor_b = diag_idx_tensor(vec![j.clone(), k.clone()], diag_b).unwrap();
 
     // Contract along j: result should be DiagTensor[i, k]
     let result = tensor_a.contract_pair(&tensor_b).unwrap();
@@ -162,7 +161,7 @@ fn test_diag_tensor_contract_diag_diag_partial() {
     );
 
     // Result diagonal should be element-wise product: [1*4, 2*5, 3*6] = [4, 10, 18]
-    let expected = diag_tensor_dyn_len(vec![i, k], vec![4.0, 10.0, 18.0]).unwrap();
+    let expected = diag_idx_tensor(vec![i, k], vec![4.0, 10.0, 18.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -171,16 +170,16 @@ fn tracked_diag_partial_contraction_preserves_diag_result_and_grad() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(3);
-    let a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![2.0, 3.0, 5.0])
+    let a = diag_idx_tensor(vec![i.clone(), j.clone()], vec![2.0, 3.0, 5.0])
         .unwrap()
         .enable_grad()
         .unwrap();
-    let b = diag_tensor_dyn_len(vec![j, k.clone()], vec![7.0, 11.0, 13.0]).unwrap();
+    let b = diag_idx_tensor(vec![j, k.clone()], vec![7.0, 11.0, 13.0]).unwrap();
 
     let c = a.contract_pair(&b).unwrap();
     assert_eq!(c.storage().unwrap().storage_kind(), StorageKind::Diagonal);
 
-    let ones = diag_tensor_dyn_len(vec![i, k], vec![1.0, 1.0, 1.0]).unwrap();
+    let ones = diag_idx_tensor(vec![i, k], vec![1.0, 1.0, 1.0]).unwrap();
     let loss = c.contract_pair(&ones).unwrap();
     loss.backward().unwrap();
 
@@ -202,8 +201,8 @@ fn test_diag_tensor_tensordot_diag_diag_partial_preserves_diagonal_storage() {
     let k = Index::new_dyn(3);
     let l = Index::new_dyn(3);
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], vec![4.0, 5.0, 6.0]).unwrap();
+    let tensor_a = diag_idx_tensor(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let tensor_b = diag_idx_tensor(vec![k.clone(), l.clone()], vec![4.0, 5.0, 6.0]).unwrap();
 
     let result =
         tensordot(&tensor_a, &tensor_b, &[(j, k)]).expect("diag-diag tensordot should succeed");
@@ -215,7 +214,7 @@ fn test_diag_tensor_tensordot_diag_diag_partial_preserves_diagonal_storage() {
         StorageKind::Diagonal
     );
 
-    let expected = diag_tensor_dyn_len(vec![i, l], vec![4.0, 10.0, 18.0]).unwrap();
+    let expected = diag_idx_tensor(vec![i, l], vec![4.0, 10.0, 18.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -227,16 +226,16 @@ fn test_diag_tensor_contract_diag_dense() {
     let k = Index::new_dyn(2);
     let diag_a = vec![1.0, 2.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_a).unwrap();
+    let tensor_a = diag_idx_tensor(vec![i.clone(), j.clone()], diag_a).unwrap();
 
     // Create DenseTensor B[j, k] with all ones
-    let tensor_b = TensorDynLen::from_dense(vec![j.clone(), k.clone()], vec![1.0; 4]).unwrap();
+    let tensor_b = IdxTensor::from_dense(vec![j.clone(), k.clone()], vec![1.0; 4]).unwrap();
 
     // Contract along j: result should be DenseTensor[i, k]
     let result = tensor_a.contract_pair(&tensor_b).unwrap();
 
     assert_eq!(result.dims(), vec![2, 2]);
-    let expected = TensorDynLen::from_dense(vec![i, k], vec![1.0, 2.0, 1.0, 2.0]).unwrap();
+    let expected = IdxTensor::from_dense(vec![i, k], vec![1.0, 2.0, 1.0, 2.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -246,11 +245,10 @@ fn test_diag_tensor_convert_to_dense() {
     let j = Index::new_dyn(3);
     let diag_data = vec![1.0, 2.0, 3.0];
 
-    let tensor = diag_tensor_dyn_len(vec![i.clone(), j.clone()], diag_data).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone()], diag_data).unwrap();
     let dense_tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], tensor.to_vec::<f64>().unwrap())
-            .unwrap();
-    let expected = TensorDynLen::from_dense(
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], tensor.to_vec::<f64>().unwrap()).unwrap();
+    let expected = IdxTensor::from_dense(
         vec![i, j],
         vec![
             1.0, 0.0, 0.0, //
@@ -266,7 +264,7 @@ fn test_diag_tensor_convert_to_dense() {
 fn from_diag_storage_roundtrip_uses_payload_not_dense_logical_values() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let tensor = IdxTensor::from_diag(vec![i, j], vec![1.0_f64, 2.0, 3.0]).unwrap();
     let storage = tensor.storage().unwrap();
 
     assert_eq!(storage.storage_kind(), StorageKind::Diagonal);
@@ -287,7 +285,7 @@ fn tensorlike_diagonal_uses_compact_diagonal_storage() {
     let i = Index::new_dyn(4);
     let o = Index::new_dyn(4);
 
-    let delta = <TensorDynLen as TensorConstructionLike>::diagonal(&i, &o).unwrap();
+    let delta = <IdxTensor as TensorConstructionLike>::diagonal(&i, &o).unwrap();
 
     assert!(delta.is_diag());
     assert_eq!(
@@ -313,7 +311,7 @@ fn tensorlike_delta_two_pairs_preserves_independent_copy_structure() {
     let i2 = Index::new_dyn(3);
     let o2 = Index::new_dyn(3);
 
-    let delta = <TensorDynLen as TensorConstructionLike>::delta(
+    let delta = <IdxTensor as TensorConstructionLike>::delta(
         &[i1.clone(), i2.clone()],
         &[o1.clone(), o2.clone()],
     )
@@ -328,8 +326,8 @@ fn tensorlike_delta_two_pairs_preserves_independent_copy_structure() {
     assert_eq!(delta.storage().unwrap().axis_classes(), &[0, 0, 1, 1]);
 
     let expected = outer_product(
-        &TensorDynLen::from_diag(vec![i1, o1], vec![1.0_f64, 1.0]).unwrap(),
-        &TensorDynLen::from_diag(vec![i2, o2], vec![1.0_f64, 1.0, 1.0]).unwrap(),
+        &IdxTensor::from_diag(vec![i1, o1], vec![1.0_f64, 1.0]).unwrap(),
+        &IdxTensor::from_diag(vec![i2, o2], vec![1.0_f64, 1.0, 1.0]).unwrap(),
     )
     .unwrap();
     assert!(delta.isapprox(&expected, 1e-12, 0.0).unwrap());
@@ -340,7 +338,7 @@ fn diag_permute_scale_conj_and_replaceind_preserve_payload_metadata() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(3);
-    let tensor = TensorDynLen::from_diag(
+    let tensor = IdxTensor::from_diag(
         vec![i.clone(), j.clone(), k.clone()],
         vec![1.0_f64, -2.0, 4.0],
     )
@@ -400,8 +398,7 @@ fn test_diag_tensor_rank3() {
     let k = Index::new_dyn(2);
     let diag_data = vec![1.0, 2.0];
 
-    let tensor =
-        diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_data.clone()).unwrap();
+    let tensor = diag_idx_tensor(vec![i.clone(), j.clone(), k.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![2, 2, 2]);
     assert!(tensor.is_diag());
     assert_eq!(
@@ -421,13 +418,13 @@ fn test_copy_tensor_rank3() {
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(3);
 
-    let tensor = TensorDynLen::copy_tensor(
+    let tensor = IdxTensor::copy_tensor(
         vec![i.clone(), j.clone(), k.clone()],
         AnyScalar::new_real(1.0),
     )
     .unwrap();
 
-    let expected = TensorDynLen::from_diag(vec![i, j, k], vec![1.0, 1.0, 1.0]).unwrap();
+    let expected = IdxTensor::from_diag(vec![i, j, k], vec![1.0, 1.0, 1.0]).unwrap();
     assert!(tensor.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -436,7 +433,7 @@ fn test_copy_tensor_rejects_mismatched_dimensions() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
 
-    let err = TensorDynLen::copy_tensor(vec![i, j], AnyScalar::new_real(1.0)).unwrap_err();
+    let err = IdxTensor::copy_tensor(vec![i, j], AnyScalar::new_real(1.0)).unwrap_err();
     assert!(err
         .to_string()
         .contains("DiagTensor requires all indices to have the same dimension"));
@@ -447,13 +444,13 @@ fn test_from_diag_any_real() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
 
-    let tensor = TensorDynLen::from_diag_any(
+    let tensor = IdxTensor::from_diag_any(
         vec![i.clone(), j.clone()],
         vec![AnyScalar::new_real(1.0), AnyScalar::new_real(2.0)],
     )
     .unwrap();
 
-    let expected = TensorDynLen::from_diag(vec![i, j], vec![1.0, 2.0]).unwrap();
+    let expected = IdxTensor::from_diag(vec![i, j], vec![1.0, 2.0]).unwrap();
     assert!(tensor.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -462,13 +459,13 @@ fn test_from_diag_any_complex_promotes_payload() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(2);
 
-    let tensor = TensorDynLen::from_diag_any(
+    let tensor = IdxTensor::from_diag_any(
         vec![i.clone(), j.clone()],
         vec![AnyScalar::new_real(1.0), AnyScalar::new_complex(2.0, -0.5)],
     )
     .unwrap();
 
-    let expected = TensorDynLen::from_diag(
+    let expected = IdxTensor::from_diag(
         vec![i, j],
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, -0.5)],
     )
@@ -482,7 +479,7 @@ fn test_diag_tensor_complex() {
     let j = Index::new_dyn(2);
     let diag_data = vec![Complex64::new(1.0, 0.5), Complex64::new(2.0, 1.0)];
 
-    let tensor = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
+    let tensor = IdxTensor::from_diag(vec![i.clone(), j.clone()], diag_data.clone()).unwrap();
     assert_eq!(tensor.dims(), vec![2, 2]);
     assert!(tensor.is_diag());
     assert_eq!(
@@ -514,8 +511,8 @@ fn test_diag_tensor_complex_axpby_preserves_diagonal_values() {
     let diag_a = vec![Complex64::new(1.0, 0.5), Complex64::new(-2.0, 1.0)];
     let diag_b = vec![Complex64::new(0.5, -1.0), Complex64::new(3.0, 0.25)];
 
-    let tensor_a = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_a.clone()).unwrap();
-    let tensor_b = TensorDynLen::from_diag(vec![i.clone(), j.clone()], diag_b.clone()).unwrap();
+    let tensor_a = IdxTensor::from_diag(vec![i.clone(), j.clone()], diag_a.clone()).unwrap();
+    let tensor_b = IdxTensor::from_diag(vec![i.clone(), j.clone()], diag_b.clone()).unwrap();
 
     let a = AnyScalar::new_real(2.0);
     let b = AnyScalar::new_complex(-0.5, 1.0);
@@ -532,7 +529,7 @@ fn test_diag_tensor_complex_axpby_preserves_diagonal_values() {
         .zip(diag_b.iter())
         .map(|(&x, &y)| Complex64::new(2.0, 0.0) * x + b_c * y)
         .collect();
-    let expected = TensorDynLen::from_diag(vec![i, j], expected_diag).unwrap();
+    let expected = IdxTensor::from_diag(vec![i, j], expected_diag).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -546,8 +543,8 @@ fn test_diag_tensor_contract_rank3() {
     let diag_a = vec![1.0, 2.0];
     let diag_b = vec![3.0, 4.0];
 
-    let tensor_a = diag_tensor_dyn_len(vec![i.clone(), j.clone(), k.clone()], diag_a).unwrap();
-    let tensor_b = diag_tensor_dyn_len(vec![k.clone(), l.clone()], diag_b).unwrap();
+    let tensor_a = diag_idx_tensor(vec![i.clone(), j.clone(), k.clone()], diag_a).unwrap();
+    let tensor_b = diag_idx_tensor(vec![k.clone(), l.clone()], diag_b).unwrap();
 
     // Contract along k: result should be DiagTensor[i, j, l]
     let result = tensor_a.contract_pair(&tensor_b).unwrap();
@@ -560,6 +557,6 @@ fn test_diag_tensor_contract_rank3() {
     );
 
     // Result diagonal should be element-wise product: [1*3, 2*4] = [3, 8]
-    let expected = diag_tensor_dyn_len(vec![i, j, l], vec![3.0, 8.0]).unwrap();
+    let expected = diag_idx_tensor(vec![i, j, l], vec![3.0, 8.0]).unwrap();
     assert!(result.isapprox(&expected, 1e-12, 0.0).unwrap());
 }

--- a/crates/tensor4all-core/tests/tensor_mask.rs
+++ b/crates/tensor4all-core/tests/tensor_mask.rs
@@ -1,5 +1,5 @@
 use num_traits::Zero;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 
 fn compact_expected<T: Copy + Zero>(value: T) -> Vec<T> {
     let mut expected = vec![T::zero(); 12];
@@ -12,7 +12,7 @@ fn compact_expected<T: Copy + Zero>(value: T) -> Vec<T> {
 fn mask_index_preserves_values_indices_and_reverse_mode_graph() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
-    let source = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0, 4.0])
+    let source = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64, 2.0, 3.0, 4.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -33,7 +33,7 @@ fn mask_index_preserves_values_indices_and_reverse_mode_graph() {
 #[test]
 fn mask_index_rejects_missing_or_out_of_range_indices() {
     let index = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![index.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![index.clone()], vec![1.0_f64, 2.0]).unwrap();
 
     assert!(tensor.mask_index(&DynIndex::new_dyn(2), 0).is_err());
     assert!(tensor.mask_index(&index, 2).is_err());
@@ -43,7 +43,7 @@ fn mask_index_rejects_missing_or_out_of_range_indices() {
 fn mask_index_preserves_compact_diagonal_storage() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
-    let source = TensorDynLen::from_diag(vec![i.clone(), j], vec![3.0_f64, 4.0]).unwrap();
+    let source = IdxTensor::from_diag(vec![i.clone(), j], vec![3.0_f64, 4.0]).unwrap();
 
     let masked = source.mask_index(&i, 1).unwrap();
     let storage = masked.storage().unwrap();
@@ -58,7 +58,7 @@ macro_rules! assert_mask_index_dtype_and_grad {
         #[test]
         fn $name() {
             let index = DynIndex::new_dyn(2);
-            let source = TensorDynLen::from_dense(vec![index.clone()], $values)
+            let source = IdxTensor::from_dense(vec![index.clone()], $values)
                 .unwrap()
                 .enable_grad()
                 .unwrap();
@@ -140,7 +140,7 @@ macro_rules! assert_structured_mask_index_dtype_and_grad {
         fn $name() {
             let i = DynIndex::new_dyn(2);
             let j = DynIndex::new_dyn(2);
-            let source = TensorDynLen::from_diag(vec![i.clone(), j], $values)
+            let source = IdxTensor::from_diag(vec![i.clone(), j], $values)
                 .unwrap()
                 .enable_grad()
                 .unwrap();
@@ -218,7 +218,7 @@ macro_rules! assert_compact_mask_index_dtype_and_grad {
             let site = DynIndex::new_dyn(3);
             let right = DynIndex::new_dyn(2);
             let source =
-                TensorDynLen::from_copy_selector(left.clone(), site.clone(), right, 1, $scale)
+                IdxTensor::from_copy_selector(left.clone(), site.clone(), right, 1, $scale)
                     .unwrap()
                     .enable_grad()
                     .unwrap();
@@ -270,14 +270,14 @@ fn untracked_structured_32_bit_tensors_can_be_consumed_as_dense_parts() {
     let site = DynIndex::new_dyn(3);
     let right = DynIndex::new_dyn(2);
     let f32_tensor =
-        TensorDynLen::from_copy_selector(left.clone(), site.clone(), right.clone(), 1, 2.0_f32)
+        IdxTensor::from_copy_selector(left.clone(), site.clone(), right.clone(), 1, 2.0_f32)
             .unwrap();
     assert!(!f32_tensor.tracks_grad());
     let (indices, values) = f32_tensor.into_dense_col_major_parts::<f32>().unwrap();
     assert_eq!(indices, vec![left, site, right]);
     assert_eq!(values, compact_expected(2.0_f32));
 
-    let c32_tensor = TensorDynLen::from_copy_selector(
+    let c32_tensor = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(2),
         DynIndex::new_dyn(3),
         DynIndex::new_dyn(2),
@@ -300,7 +300,7 @@ fn compact_scale_preserves_large_selector_layout_for_all_supported_dtypes() {
     let bond_dim = 100_000;
     let site = DynIndex::new_dyn(3);
 
-    let f64_tensor = TensorDynLen::from_copy_selector(
+    let f64_tensor = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(bond_dim),
         site.clone(),
         DynIndex::new_dyn(bond_dim),
@@ -317,7 +317,7 @@ fn compact_scale_preserves_large_selector_layout_for_all_supported_dtypes() {
     assert_eq!(f64_storage.payload_len(), bond_dim * 3);
     assert_eq!(f64_storage.scalar_at(&[0, 1]).unwrap().real(), 6.0);
 
-    let tracked = TensorDynLen::from_copy_selector(
+    let tracked = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(32),
         site.clone(),
         DynIndex::new_dyn(32),
@@ -345,7 +345,7 @@ fn compact_scale_preserves_large_selector_layout_for_all_supported_dtypes() {
         32 * 3
     );
 
-    let f32_tensor = TensorDynLen::from_copy_selector(
+    let f32_tensor = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(2),
         site.clone(),
         DynIndex::new_dyn(2),
@@ -359,7 +359,7 @@ fn compact_scale_preserves_large_selector_layout_for_all_supported_dtypes() {
     assert_eq!(f32_scaled.to_vec::<f32>().unwrap()[2], 6.0);
     assert!(f32_scaled.to_vec::<f64>().is_err());
 
-    let diag = TensorDynLen::from_diag(
+    let diag = IdxTensor::from_diag(
         vec![DynIndex::new_dyn(3), DynIndex::new_dyn(3)],
         vec![1.0_f64, 2.0, 3.0],
     )
@@ -381,7 +381,7 @@ fn structured_mask_retains_compact_payload_for_large_copy_selector() {
     let left = DynIndex::new_dyn(bond_dim);
     let site = DynIndex::new_dyn(3);
     let right = DynIndex::new_dyn(bond_dim);
-    let source = TensorDynLen::from_copy_selector(left, site.clone(), right, 1, 2.0_f64).unwrap();
+    let source = IdxTensor::from_copy_selector(left, site.clone(), right, 1, 2.0_f64).unwrap();
 
     let masked = source.mask_index(&site, 1).unwrap();
     let storage = masked.storage().unwrap();
@@ -389,7 +389,7 @@ fn structured_mask_retains_compact_payload_for_large_copy_selector() {
     assert_eq!(storage.payload_dims(), &[bond_dim, 3]);
     assert_eq!(storage.payload_len(), bond_dim * 3);
 
-    let tracked = TensorDynLen::from_copy_selector(
+    let tracked = IdxTensor::from_copy_selector(
         DynIndex::new_dyn(bond_dim),
         site.clone(),
         DynIndex::new_dyn(bond_dim),

--- a/crates/tensor4all-core/tests/tensor_native_ad.rs
+++ b/crates/tensor4all-core/tests/tensor_native_ad.rs
@@ -1,13 +1,13 @@
 use num_complex::Complex64;
 use tensor4all_core::{
-    contract, contract_with_options, ContractionOptions, Index, TensorContractionLike, TensorDynLen,
+    contract, contract_with_options, ContractionOptions, IdxTensor, Index, TensorContractionLike,
 };
 use tensor4all_tensorbackend::{Storage, StorageKind};
 
 #[test]
 fn plain_dense_storage_auto_seeds_native_payload() {
     let i = Index::new_dyn(2);
-    let tensor = TensorDynLen::from_storage(
+    let tensor = IdxTensor::from_storage(
         vec![i],
         Storage::from_dense_col_major(vec![1.0, 2.0], &[2])
             .map(std::sync::Arc::new)
@@ -22,7 +22,7 @@ fn plain_dense_storage_auto_seeds_native_payload() {
 fn plain_diag_storage_preserves_diag_metadata() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(3);
-    let tensor = TensorDynLen::from_storage(
+    let tensor = IdxTensor::from_storage(
         vec![i, j],
         Storage::from_diag_col_major(vec![1.0, 2.0, 3.0], 2)
             .map(std::sync::Arc::new)
@@ -44,8 +44,8 @@ fn plain_diag_storage_preserves_diag_metadata() {
 #[test]
 fn contraction_without_grad_returns_rank_zero_scalar() {
     let i = Index::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let ones = IdxTensor::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
 
     let result = contract(&[&a, &ones]).unwrap();
 
@@ -56,7 +56,7 @@ fn contraction_without_grad_returns_rank_zero_scalar() {
 #[test]
 fn tracked_complex_conjugation_preserves_values_and_gradient_path() {
     let i = Index::new_dyn(2);
-    let x = TensorDynLen::from_dense(
+    let x = IdxTensor::from_dense(
         vec![i.clone()],
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)],
     )
@@ -80,11 +80,11 @@ fn tracked_complex_conjugation_preserves_values_and_gradient_path() {
 #[test]
 fn backward_accumulates_until_clear_grad() {
     let i = Index::new_dyn(3);
-    let x = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0])
+    let x = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0, 3.0])
         .unwrap()
         .enable_grad()
         .unwrap();
-    let ones = TensorDynLen::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
+    let ones = IdxTensor::from_dense(vec![i], vec![1.0, 1.0, 1.0]).unwrap();
 
     let loss = contract(&[&x, &ones]).unwrap();
     loss.backward().unwrap();
@@ -115,11 +115,11 @@ fn general_structured_grad_preserves_input_axis_classes() {
     )
     .map(std::sync::Arc::new)
     .unwrap();
-    let x = TensorDynLen::from_storage(vec![i.clone(), j.clone(), k.clone()], storage)
+    let x = IdxTensor::from_storage(vec![i.clone(), j.clone(), k.clone()], storage)
         .unwrap()
         .enable_grad()
         .unwrap();
-    let ones = TensorDynLen::from_dense(vec![i, j, k], vec![1.0; 12]).unwrap();
+    let ones = IdxTensor::from_dense(vec![i, j, k], vec![1.0; 12]).unwrap();
 
     let loss = contract(&[&x, &ones]).unwrap();
     loss.backward().unwrap();
@@ -138,7 +138,7 @@ fn general_structured_grad_preserves_input_axis_classes() {
 
 #[test]
 fn tracks_grad_and_detach_report_leaf_state() {
-    let scalar = TensorDynLen::scalar(2.0).unwrap();
+    let scalar = IdxTensor::scalar(2.0).unwrap();
     assert!(!scalar.tracks_grad());
 
     let tracked = scalar.enable_grad();
@@ -152,7 +152,7 @@ fn tracks_grad_and_detach_report_leaf_state() {
 
 #[test]
 fn clone_shares_tracked_leaf_gradient_slot() {
-    let x = TensorDynLen::scalar(2.0).unwrap().enable_grad().unwrap();
+    let x = IdxTensor::scalar(2.0).unwrap().enable_grad().unwrap();
     let alias = x.clone();
 
     let loss = x.contract_pair(&alias).unwrap();
@@ -171,7 +171,7 @@ fn retained_multi_contraction_preserves_grad_path() {
     let k = Index::new_dyn(3);
     let j = Index::new_dyn(2);
 
-    let x = TensorDynLen::from_dense(
+    let x = IdxTensor::from_dense(
         vec![batch.clone(), i.clone(), k.clone()],
         (1..=12).map(|value| value as f64).collect(),
     )
@@ -179,7 +179,7 @@ fn retained_multi_contraction_preserves_grad_path() {
     .enable_grad()
     .unwrap();
     let y =
-        TensorDynLen::from_dense(vec![batch.clone(), k.clone(), j.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![batch.clone(), k.clone(), j.clone()], vec![1.0; 12]).unwrap();
     let retain_indices = [batch.clone()];
     let options = ContractionOptions::new().with_retain_indices(&retain_indices);
 
@@ -190,7 +190,7 @@ fn retained_multi_contraction_preserves_grad_path() {
         vec![15.0, 18.0, 21.0, 24.0, 15.0, 18.0, 21.0, 24.0]
     );
 
-    let ones = TensorDynLen::from_dense(result.indices().to_vec(), vec![1.0; 8]).unwrap();
+    let ones = IdxTensor::from_dense(result.indices().to_vec(), vec![1.0; 8]).unwrap();
     let loss = contract(&[&result, &ones]).unwrap();
     loss.backward().unwrap();
 
@@ -203,7 +203,7 @@ fn retained_multi_contraction_preserves_grad_path() {
 fn mixed_nary_copy_selector_contraction_stays_compact() {
     let bond = 128;
     let site = Index::new_dyn(3);
-    let a = TensorDynLen::from_copy_selector(
+    let a = IdxTensor::from_copy_selector(
         Index::new_dyn(bond),
         site.clone(),
         Index::new_dyn(bond),
@@ -211,7 +211,7 @@ fn mixed_nary_copy_selector_contraction_stays_compact() {
         2.0_f32,
     )
     .unwrap();
-    let b = TensorDynLen::from_copy_selector(
+    let b = IdxTensor::from_copy_selector(
         a.indices()[2].clone(),
         site.clone(),
         Index::new_dyn(bond),
@@ -219,7 +219,7 @@ fn mixed_nary_copy_selector_contraction_stays_compact() {
         3.0_f64,
     )
     .unwrap();
-    let c = TensorDynLen::from_copy_selector(
+    let c = IdxTensor::from_copy_selector(
         b.indices()[2].clone(),
         site,
         Index::new_dyn(bond),
@@ -248,7 +248,7 @@ fn mixed_nary_copy_selector_contraction_stays_compact() {
 fn tracked_nary_copy_selector_contraction_preserves_compact_gradient() {
     let bond = 4;
     let site = Index::new_dyn(3);
-    let a = TensorDynLen::from_copy_selector(
+    let a = IdxTensor::from_copy_selector(
         Index::new_dyn(bond),
         site.clone(),
         Index::new_dyn(bond),
@@ -258,7 +258,7 @@ fn tracked_nary_copy_selector_contraction_preserves_compact_gradient() {
     .unwrap()
     .enable_grad()
     .unwrap();
-    let b = TensorDynLen::from_copy_selector(
+    let b = IdxTensor::from_copy_selector(
         a.indices()[2].clone(),
         site.clone(),
         Index::new_dyn(bond),
@@ -266,7 +266,7 @@ fn tracked_nary_copy_selector_contraction_preserves_compact_gradient() {
         3.0_f64,
     )
     .unwrap();
-    let c = TensorDynLen::from_copy_selector(
+    let c = IdxTensor::from_copy_selector(
         b.indices()[2].clone(),
         site.clone(),
         Index::new_dyn(bond),
@@ -280,8 +280,8 @@ fn tracked_nary_copy_selector_contraction_preserves_compact_gradient() {
         ContractionOptions::new().with_retain_indices(&[a.indices()[1].clone()]),
     )
     .unwrap();
-    let ones = TensorDynLen::from_dense(result.indices().to_vec(), vec![1.0_f64; bond * 3 * bond])
-        .unwrap();
+    let ones =
+        IdxTensor::from_dense(result.indices().to_vec(), vec![1.0_f64; bond * 3 * bond]).unwrap();
     contract(&[&result, &ones]).unwrap().backward().unwrap();
 
     let grad = a.grad().unwrap().unwrap();
@@ -306,12 +306,11 @@ fn structured_retained_multi_contraction_preserves_grad_path() {
     )
     .map(std::sync::Arc::new)
     .unwrap();
-    let x = TensorDynLen::from_storage(vec![batch.clone(), i.clone(), k.clone()], storage)
+    let x = IdxTensor::from_storage(vec![batch.clone(), i.clone(), k.clone()], storage)
         .unwrap()
         .enable_grad()
         .unwrap();
-    let y =
-        TensorDynLen::from_dense(vec![batch.clone(), k.clone(), j.clone()], vec![1.0; 8]).unwrap();
+    let y = IdxTensor::from_dense(vec![batch.clone(), k.clone(), j.clone()], vec![1.0; 8]).unwrap();
     let retain_indices = [batch.clone()];
     let options = ContractionOptions::new().with_retain_indices(&retain_indices);
 
@@ -322,7 +321,7 @@ fn structured_retained_multi_contraction_preserves_grad_path() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     );
 
-    let ones = TensorDynLen::from_dense(result.indices().to_vec(), vec![1.0; 12]).unwrap();
+    let ones = IdxTensor::from_dense(result.indices().to_vec(), vec![1.0; 12]).unwrap();
     let loss = contract(&[&result, &ones]).unwrap();
     loss.backward().unwrap();
     assert_eq!(

--- a/crates/tensor4all-core/tests/tensor_permute.rs
+++ b/crates/tensor4all-core/tests/tensor_permute.rs
@@ -1,13 +1,13 @@
 use num_complex::Complex64;
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::{compute_permutation_from_indices, DynIndex, TensorDynLen};
+use tensor4all_core::{compute_permutation_from_indices, DynIndex, IdxTensor};
 
-fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_f64(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn dense_c64(indices: Vec<DynIndex>, data: Vec<Complex64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 fn col_major_multi_index(mut flat: usize, dims: &[usize]) -> Vec<usize> {

--- a/crates/tensor4all-core/tests/tensor_shape_packing.rs
+++ b/crates/tensor4all-core/tests/tensor_shape_packing.rs
@@ -1,13 +1,13 @@
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 
 #[test]
 fn stack_along_new_index_uses_trailing_column_major_batch_axis() {
     let batch = DynIndex::new_dyn(2);
     let i = DynIndex::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
 
-    let stacked = TensorDynLen::stack_along_new_index(&[&a, &b], batch.clone(), -1).unwrap();
+    let stacked = IdxTensor::stack_along_new_index(&[&a, &b], batch.clone(), -1).unwrap();
 
     assert_eq!(stacked.indices(), &[i, batch]);
     assert_eq!(stacked.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
@@ -18,7 +18,7 @@ fn index_select_replaces_trailing_index_and_allows_repeated_positions() {
     let source_batch = DynIndex::new_dyn(3);
     let target_batch = DynIndex::new_dyn(4);
     let i = DynIndex::new_dyn(2);
-    let source = TensorDynLen::from_dense(
+    let source = IdxTensor::from_dense(
         vec![i.clone(), source_batch.clone()],
         vec![10.0_f64, 11.0, 20.0, 21.0, 30.0, 31.0],
     )
@@ -39,12 +39,11 @@ fn index_select_replaces_trailing_index_and_allows_repeated_positions() {
 fn index_select_backward_scatter_adds_repeated_positions() {
     let source = DynIndex::new_dyn(3);
     let target = DynIndex::new_dyn(3);
-    let x = TensorDynLen::from_dense(vec![source.clone()], vec![1.0_f64, 2.0, 3.0])
+    let x = IdxTensor::from_dense(vec![source.clone()], vec![1.0_f64, 2.0, 3.0])
         .unwrap()
         .enable_grad()
         .unwrap();
-    let weights =
-        TensorDynLen::from_dense(vec![target.clone()], vec![10.0_f64, 20.0, 30.0]).unwrap();
+    let weights = IdxTensor::from_dense(vec![target.clone()], vec![10.0_f64, 20.0, 30.0]).unwrap();
 
     let y = x.index_select(&source, target, &[1, 1, 2]).unwrap();
     let loss = y.inner_product(&weights).unwrap();
@@ -58,11 +57,11 @@ fn index_select_backward_scatter_adds_repeated_positions() {
 #[test]
 fn stack_along_new_index_backward_splits_cotangent_to_inputs() {
     let batch = DynIndex::new_dyn(2);
-    let x0 = TensorDynLen::scalar(2.0).unwrap().enable_grad().unwrap();
-    let x1 = TensorDynLen::scalar(3.0).unwrap().enable_grad().unwrap();
-    let weights = TensorDynLen::from_dense(vec![batch.clone()], vec![10.0_f64, 20.0]).unwrap();
+    let x0 = IdxTensor::scalar(2.0).unwrap().enable_grad().unwrap();
+    let x1 = IdxTensor::scalar(3.0).unwrap().enable_grad().unwrap();
+    let weights = IdxTensor::from_dense(vec![batch.clone()], vec![10.0_f64, 20.0]).unwrap();
 
-    let stacked = TensorDynLen::stack_along_new_index(&[&x0, &x1], batch, -1).unwrap();
+    let stacked = IdxTensor::stack_along_new_index(&[&x0, &x1], batch, -1).unwrap();
     let loss = stacked.inner_product(&weights).unwrap();
     loss.backward().unwrap();
 
@@ -77,12 +76,12 @@ fn stack_along_new_index_rejects_tracked_compact_storage() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let batch = DynIndex::new_dyn(1);
-    let diag = TensorDynLen::from_diag(vec![i, j], vec![1.0_f64, 2.0])
+    let diag = IdxTensor::from_diag(vec![i, j], vec![1.0_f64, 2.0])
         .unwrap()
         .enable_grad()
         .unwrap();
 
-    let err = TensorDynLen::stack_along_new_index(&[&diag], batch, -1).unwrap_err();
+    let err = IdxTensor::stack_along_new_index(&[&diag], batch, -1).unwrap_err();
 
     assert!(err.to_string().contains("structured AD"));
 }
@@ -92,7 +91,7 @@ fn index_select_rejects_tracked_compact_storage() {
     let source = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let target = DynIndex::new_dyn(1);
-    let diag = TensorDynLen::from_diag(vec![source.clone(), j], vec![1.0_f64, 2.0])
+    let diag = IdxTensor::from_diag(vec![source.clone(), j], vec![1.0_f64, 2.0])
         .unwrap()
         .enable_grad()
         .unwrap();

--- a/crates/tensor4all-core/tests/tensor_tensor_like.rs
+++ b/crates/tensor4all-core/tests/tensor_tensor_like.rs
@@ -3,16 +3,16 @@
 use tensor4all_core::index::{DynId, Index};
 use tensor4all_core::DynIndex;
 use tensor4all_core::{
-    outer_product, TensorConstructionLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    outer_product, IdxTensor, TensorConstructionLike, TensorContractionLike, TensorIndex,
     TensorVectorSpace,
 };
 
 /// Helper to create a simple tensor with given dimensions
-fn make_tensor(dims: &[usize]) -> TensorDynLen {
+fn make_tensor(dims: &[usize]) -> IdxTensor {
     let indices: Vec<DynIndex> = dims.iter().map(|&d| Index::new_dyn(d)).collect();
     let total_size: usize = dims.iter().product();
     let data: Vec<f64> = (0..total_size).map(|i| i as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 #[test]
@@ -47,16 +47,16 @@ fn test_tensor_like_contract_basic() {
 
     // Tensor A: 2x3 matrix
     let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
 
     // Tensor B: 3x4 matrix (use a copy of j with same id)
     let j_copy = Index::new(j.id, j.dim);
     let b_data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let b = TensorDynLen::from_dense(vec![j_copy.clone(), k.clone()], b_data).unwrap();
+    let b = IdxTensor::from_dense(vec![j_copy.clone(), k.clone()], b_data).unwrap();
 
     // Use TensorContractionLike::contract - auto-detects contractable pairs via is_contractable
-    let c = <TensorDynLen as TensorContractionLike>::contract(&[&a, &b])
-        .expect("contract should succeed");
+    let c =
+        <IdxTensor as TensorContractionLike>::contract(&[&a, &b]).expect("contract should succeed");
 
     // Result should be 2x4
     assert_eq!(c.dims(), vec![2, 4]);
@@ -65,15 +65,15 @@ fn test_tensor_like_contract_basic() {
 #[test]
 fn tensor_vector_space_default_methods_cover_common_paths() {
     let i = Index::<DynId>::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0 + 1.0e-13]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![1.0, -2.0, 3.0 + 1.0e-13]).unwrap();
 
     let neg = TensorVectorSpace::neg(&a).unwrap();
     assert_eq!(neg.to_vec::<f64>().unwrap(), vec![-1.0, 2.0, -3.0]);
     assert!(a.isapprox(&b, 1.0e-12, 0.0).unwrap());
 
     let j = Index::<DynId>::new_dyn(2);
-    let incompatible = TensorDynLen::from_dense(vec![j], vec![1.0, 2.0]).unwrap();
+    let incompatible = IdxTensor::from_dense(vec![j], vec![1.0, 2.0]).unwrap();
     assert!(a.isapprox(&incompatible, 1.0e-12, 0.0).is_err());
 }
 
@@ -81,8 +81,8 @@ fn tensor_vector_space_default_methods_cover_common_paths() {
 fn tensor_contraction_and_construction_default_methods_cover_paths() {
     let i = Index::<DynId>::new_dyn(2);
     let j = Index::<DynId>::new_dyn(3);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, 5.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0; 6]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![2.0, 5.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0; 6]).unwrap();
 
     let contracted = a.contract_pair(&b).unwrap();
     assert_eq!(contracted.indices, vec![j.clone()]);
@@ -106,8 +106,8 @@ fn tensor_contraction_and_construction_default_methods_cover_paths() {
 fn tensor_vector_space_fallible_metrics_propagate_nan_inputs() {
     // NaN payloads make norm_squared/norm/maxabs fail closed through the
     // trait's fallible surface; the errors must propagate, not wrap.
-    let nan = TensorDynLen::scalar(f64::NAN).unwrap();
-    let finite = TensorDynLen::scalar(1.0).unwrap();
+    let nan = IdxTensor::scalar(f64::NAN).unwrap();
+    let finite = IdxTensor::scalar(1.0).unwrap();
     assert!(TensorVectorSpace::norm_squared(&nan).is_err());
     assert!(TensorVectorSpace::norm(&nan).is_err());
     assert!(TensorVectorSpace::maxabs(&nan).is_err());
@@ -130,19 +130,19 @@ fn test_contract_three_tensor_chain() {
 
     // Tensor A: 2x3 matrix (i, j)
     let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
 
     // Tensor B: 3x4 matrix (j, k) - j has same id as A's j
     let j_copy = Index::new(j.id, j.dim);
     let b_data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let b = TensorDynLen::from_dense(vec![j_copy.clone(), k.clone()], b_data).unwrap();
+    let b = IdxTensor::from_dense(vec![j_copy.clone(), k.clone()], b_data).unwrap();
 
     // Tensor C: 4x5 matrix (k, l) - k has same id as B's k
     let k_copy = Index::new(k.id, k.dim);
     let c_data: Vec<f64> = (0..20).map(|x| x as f64).collect();
-    let c = TensorDynLen::from_dense(vec![k_copy.clone(), l.clone()], c_data).unwrap();
+    let c = IdxTensor::from_dense(vec![k_copy.clone(), l.clone()], c_data).unwrap();
 
-    let result = <TensorDynLen as TensorContractionLike>::contract(&[&a, &b, &c])
+    let result = <IdxTensor as TensorContractionLike>::contract(&[&a, &b, &c])
         .expect("contract should succeed");
 
     // Result should have: i (from A, dim=2), l (from C, dim=5)
@@ -160,13 +160,13 @@ fn test_outer_product_with_common_indices_errors() {
 
     // Tensor A: 2x3 matrix
     let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
 
     // Tensor B: 2x3 matrix (use copies of i and j with same ids)
     let i_copy = Index::new(i.id, i.dim);
     let j_copy = Index::new(j.id, j.dim);
     let b_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
-    let b = TensorDynLen::from_dense(vec![i_copy.clone(), j_copy.clone()], b_data).unwrap();
+    let b = IdxTensor::from_dense(vec![i_copy.clone(), j_copy.clone()], b_data).unwrap();
 
     let result = outer_product(&a, &b);
 
@@ -185,11 +185,11 @@ fn test_outer_product_disconnected_tensors() {
 
     // Tensor A: 2x3 matrix with indices (i, j)
     let a_data: Vec<f64> = (0..6).map(|x| x as f64).collect();
-    let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], a_data).unwrap();
 
     // Tensor B: 4x5 matrix with indices (k, l) - different from a
     let b_data: Vec<f64> = (0..20).map(|x| x as f64).collect();
-    let b = TensorDynLen::from_dense(vec![k.clone(), l.clone()], b_data).unwrap();
+    let b = IdxTensor::from_dense(vec![k.clone(), l.clone()], b_data).unwrap();
 
     let result = outer_product(&a, &b).unwrap();
 
@@ -205,13 +205,13 @@ fn test_outer_product_preserves_input_component_order() {
     let i = Index::<DynId>::new_dyn(2);
     let j = Index::<DynId>::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![2.0, -1.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j.clone()], vec![3.0, 4.0, -2.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![2.0, -1.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![j.clone()], vec![3.0, 4.0, -2.0]).unwrap();
 
     let result = outer_product(&a, &b).unwrap();
 
     assert_eq!(result.indices, vec![i, j]);
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         result.indices.clone(),
         vec![
             6.0, -3.0, 8.0, //
@@ -227,15 +227,15 @@ fn test_contract_components_then_outer_product() {
     let i = Index::<DynId>::new_dyn(2);
     let j = Index::<DynId>::new_dyn(3);
 
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
     let i_copy = Index::new(i.id, i.dim);
-    let b = TensorDynLen::from_dense(vec![i_copy.clone()], vec![3.0, 4.0]).unwrap();
-    let c = TensorDynLen::from_dense(vec![j.clone()], vec![5.0, 6.0, 7.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i_copy.clone()], vec![3.0, 4.0]).unwrap();
+    let c = IdxTensor::from_dense(vec![j.clone()], vec![5.0, 6.0, 7.0]).unwrap();
     let j_copy = Index::new(j.id, j.dim);
-    let d = TensorDynLen::from_dense(vec![j_copy.clone()], vec![8.0, 9.0, 10.0]).unwrap();
+    let d = IdxTensor::from_dense(vec![j_copy.clone()], vec![8.0, 9.0, 10.0]).unwrap();
 
-    let left = <TensorDynLen as TensorContractionLike>::contract(&[&a, &b]).unwrap();
-    let right = <TensorDynLen as TensorContractionLike>::contract(&[&c, &d]).unwrap();
+    let left = <IdxTensor as TensorContractionLike>::contract(&[&a, &b]).unwrap();
+    let right = <IdxTensor as TensorContractionLike>::contract(&[&c, &d]).unwrap();
     let result = outer_product(&left, &right).unwrap();
 
     // A(i) * B(i) contracts to scalar (dim 0)
@@ -251,7 +251,7 @@ fn test_contract_components_then_outer_product() {
 #[test]
 fn test_onehot_1d() {
     let i = Index::new_dyn(3);
-    let t = TensorDynLen::onehot(&[(i.clone(), 0)]).unwrap();
+    let t = IdxTensor::onehot(&[(i.clone(), 0)]).unwrap();
     assert_eq!(t.dims(), vec![3]);
     let data = t.to_vec::<f64>().unwrap();
     assert_eq!(data, vec![1.0, 0.0, 0.0]);
@@ -261,7 +261,7 @@ fn test_onehot_1d() {
 fn test_onehot_2d() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(4);
-    let t = TensorDynLen::onehot(&[(i.clone(), 1), (j.clone(), 2)]).unwrap();
+    let t = IdxTensor::onehot(&[(i.clone(), 1), (j.clone(), 2)]).unwrap();
     assert_eq!(t.dims(), vec![3, 4]);
     let data = t.to_vec::<f64>().unwrap();
     // Column-major: position (1,2) in 3×4 = 1 + 3*2 = 7
@@ -275,7 +275,7 @@ fn test_onehot_boundary() {
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(4);
     // Last position in the first dimension, nontrivial column in the second.
-    let t = TensorDynLen::onehot(&[(i.clone(), 2), (j.clone(), 1)]).unwrap();
+    let t = IdxTensor::onehot(&[(i.clone(), 2), (j.clone(), 1)]).unwrap();
     let data = t.to_vec::<f64>().unwrap();
     // Column-major: position (2,1) in 3×4 = 2 + 3*1 = 5
     let mut expected = vec![0.0; 12];
@@ -286,7 +286,7 @@ fn test_onehot_boundary() {
 #[test]
 fn test_onehot_error_out_of_bounds() {
     let i = Index::new_dyn(3);
-    let result = TensorDynLen::onehot(&[(i.clone(), 3)]);
+    let result = IdxTensor::onehot(&[(i.clone(), 3)]);
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("onehot"));
@@ -295,7 +295,7 @@ fn test_onehot_error_out_of_bounds() {
 #[test]
 fn test_onehot_empty() {
     // Empty input should return scalar 1.0
-    let t = TensorDynLen::onehot(&[]).unwrap();
+    let t = IdxTensor::onehot(&[]).unwrap();
     assert_eq!(t.dims().len(), 0);
 }
 
@@ -304,17 +304,17 @@ fn test_onehot_contraction() {
     // Create a tensor A(i,j) and a onehot V(i)
     let i = Index::new_dyn(3);
     let j = Index::new_dyn(4);
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         (0..12).map(|x| x as f64).collect(),
     )
     .unwrap();
 
     // onehot selecting i=1
-    let v = TensorDynLen::onehot(&[(i.clone(), 1)]).unwrap();
+    let v = IdxTensor::onehot(&[(i.clone(), 1)]).unwrap();
 
     // Contract: V(i) * A(i,j) = A[1,:]
-    let result = <TensorDynLen as TensorContractionLike>::contract(&[&v, &a]).unwrap();
+    let result = <IdxTensor as TensorContractionLike>::contract(&[&v, &a]).unwrap();
     assert_eq!(result.dims(), vec![4]);
     let data = result.to_vec::<f64>().unwrap();
     // Row i=1 of the column-major 3×4 matrix: [1, 4, 7, 10]

--- a/crates/tensor4all-core/tests/tensor_unfuse.rs
+++ b/crates/tensor4all-core/tests/tensor_unfuse.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex64;
 use tensor4all_core::{
-    DynIndex, IndexLike, LinearizationOrder, TensorContractionLike, TensorDynLen, TensorIndex,
+    DynIndex, IdxTensor, IndexLike, LinearizationOrder, TensorContractionLike, TensorIndex,
 };
 
 #[test]
@@ -8,7 +8,7 @@ fn unfuse_index_column_major_preserves_column_major_layout() {
     let fused = DynIndex::new_dyn(4);
     let left = DynIndex::new_dyn(2);
     let right = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     let unfused = tensor
         .unfuse_index(
@@ -18,7 +18,7 @@ fn unfuse_index_column_major_preserves_column_major_layout() {
         )
         .unwrap();
 
-    let expected = TensorDynLen::from_dense(vec![left, right], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let expected = IdxTensor::from_dense(vec![left, right], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     assert!(unfused.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -27,7 +27,7 @@ fn unfuse_index_row_major_reorders_fused_axis_meaning() {
     let fused = DynIndex::new_dyn(4);
     let left = DynIndex::new_dyn(2);
     let right = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     let unfused = tensor
         .unfuse_index(
@@ -37,14 +37,14 @@ fn unfuse_index_row_major_reorders_fused_axis_meaning() {
         )
         .unwrap();
 
-    let expected = TensorDynLen::from_dense(vec![left, right], vec![1.0, 3.0, 2.0, 4.0]).unwrap();
+    let expected = IdxTensor::from_dense(vec![left, right], vec![1.0, 3.0, 2.0, 4.0]).unwrap();
     assert!(unfused.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
 #[test]
 fn unfuse_index_rejects_dimension_mismatch() {
     let fused = DynIndex::new_dyn(4);
-    let tensor = TensorDynLen::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     let err = tensor
         .unfuse_index(
@@ -66,7 +66,7 @@ fn fuse_indices_column_major_roundtrips_unfuse_index() {
     let k = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(6).unwrap();
     let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
 
     let fused_tensor = tensor
         .fuse_indices(
@@ -89,7 +89,7 @@ fn fuse_indices_backward_preserves_source_gradient() {
     let j = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(6).unwrap();
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i.clone(), j.clone(), k.clone()],
         (0..12).map(|x| x as f64).collect(),
     )
@@ -106,7 +106,7 @@ fn fuse_indices_backward_preserves_source_gradient() {
         .unwrap();
     assert!(fused_tensor.tracks_grad());
 
-    let weights = TensorDynLen::from_dense(
+    let weights = IdxTensor::from_dense(
         vec![fused.clone(), k.clone()],
         (1..=12).map(|x| x as f64).collect(),
     )
@@ -116,20 +116,20 @@ fn fuse_indices_backward_preserves_source_gradient() {
 
     let grad = tensor.grad().unwrap().unwrap();
     let expected =
-        TensorDynLen::from_dense(vec![i, j, k], (1..=12).map(|x| x as f64).collect()).unwrap();
+        IdxTensor::from_dense(vec![i, j, k], (1..=12).map(|x| x as f64).collect()).unwrap();
     assert!(grad.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
 #[test]
-fn fuse_indices_trait_dispatch_on_tensordynlen_uses_old_index_order() {
+fn fuse_indices_trait_dispatch_on_idx_tensor_uses_old_index_order() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(6).unwrap();
     let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
 
-    let fused_tensor = <TensorDynLen as TensorContractionLike>::fuse_indices(
+    let fused_tensor = <IdxTensor as TensorContractionLike>::fuse_indices(
         &tensor,
         &[j.clone(), i.clone()],
         fused.clone(),
@@ -154,7 +154,7 @@ fn unfuse_index_backward_preserves_source_gradient() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![fused.clone(), k.clone()],
         (0..12).map(|x| x as f64).collect(),
     )
@@ -172,14 +172,13 @@ fn unfuse_index_backward_preserves_source_gradient() {
     assert!(unfused.tracks_grad());
 
     let weights =
-        TensorDynLen::from_dense(vec![i, j, k.clone()], (1..=12).map(|x| x as f64).collect())
-            .unwrap();
+        IdxTensor::from_dense(vec![i, j, k.clone()], (1..=12).map(|x| x as f64).collect()).unwrap();
     let loss = unfused.inner_product(&weights).unwrap();
     loss.backward().unwrap();
 
     let grad = tensor.grad().unwrap().unwrap();
     let expected =
-        TensorDynLen::from_dense(vec![fused, k], (1..=12).map(|x| x as f64).collect()).unwrap();
+        IdxTensor::from_dense(vec![fused, k], (1..=12).map(|x| x as f64).collect()).unwrap();
     assert!(grad.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -190,7 +189,7 @@ fn fuse_indices_row_major_roundtrips_unfuse_index() {
     let k = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(6).unwrap();
     let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
 
     let fused_tensor = tensor
         .fuse_indices(
@@ -215,7 +214,7 @@ fn fuse_indices_preserves_complex_payload_roundtrip() {
     let data: Vec<Complex64> = (0..6)
         .map(|x| Complex64::new(x as f64, -(x as f64)))
         .collect();
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], data.clone()).unwrap();
 
     let roundtrip = tensor
         .fuse_indices(
@@ -238,7 +237,7 @@ fn fuse_indices_supports_non_adjacent_axes() {
     let k = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(4).unwrap();
     let data: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone(), k.clone()], data).unwrap();
 
     let fused_tensor = tensor
         .fuse_indices(
@@ -261,7 +260,7 @@ fn fuse_indices_supports_non_adjacent_axes() {
 fn fuse_indices_rejects_empty_old_indices() {
     let i = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(2).unwrap();
-    let tensor = TensorDynLen::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i], vec![1.0, 2.0]).unwrap();
 
     let err = tensor
         .fuse_indices(&[], fused, LinearizationOrder::ColumnMajor)
@@ -278,7 +277,7 @@ fn fuse_indices_rejects_duplicate_old_indices() {
     let j = DynIndex::new_dyn(3);
     let fused = DynIndex::new_link(4).unwrap();
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let err = tensor
         .fuse_indices(&[i.clone(), i], fused, LinearizationOrder::ColumnMajor)
@@ -294,7 +293,7 @@ fn fuse_indices_rejects_missing_index() {
     let missing = DynIndex::new_dyn(2);
     let fused = DynIndex::new_link(6).unwrap();
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let err = tensor
         .fuse_indices(&[i, missing], fused, LinearizationOrder::ColumnMajor)
@@ -308,7 +307,7 @@ fn fuse_indices_rejects_dimension_mismatch() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
     let fused = DynIndex::new_link(5).unwrap();
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
@@ -329,7 +328,7 @@ fn fuse_indices_rejects_same_id_with_wrong_dimension() {
     let j = DynIndex::new_dyn(3);
     let same_id_wrong_dim = DynIndex::new(*i.id(), 3);
     let fused = DynIndex::new_link(9).unwrap();
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
@@ -353,7 +352,7 @@ fn fuse_indices_rejects_duplicate_result_index() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     let err = tensor
         .fuse_indices(&[i], j, LinearizationOrder::ColumnMajor)
@@ -369,7 +368,7 @@ fn fuse_indices_allows_same_id_prime_pair_in_result() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     let result = tensor
         .fuse_indices(&[i], j.prime(), LinearizationOrder::ColumnMajor)
@@ -385,7 +384,7 @@ fn unfuse_index_selects_exact_same_id_prime_index() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
     let data: Vec<f64> = (0..16).map(|value| value as f64).collect();
-    let tensor = TensorDynLen::from_dense(vec![fused.clone(), fused_prime.clone()], data).unwrap();
+    let tensor = IdxTensor::from_dense(vec![fused.clone(), fused_prime.clone()], data).unwrap();
 
     let result = tensor
         .unfuse_index(

--- a/crates/tensor4all-hdf5/README.md
+++ b/crates/tensor4all-hdf5/README.md
@@ -4,10 +4,10 @@ HDF5 serialization for tensor4all-rs, compatible with ITensors.jl / ITensorMPS.j
 
 ## Key Types
 
-- `save_itensor()` / `load_itensor()` — read/write `TensorDynLen` as ITensors.jl `ITensor`
+- `save_itensor()` / `load_itensor()` — read/write `IdxTensor` as ITensors.jl `ITensor`
 - `save_mps()` / `load_mps()` — read/write `TensorTrain` as ITensorMPS.jl `MPS`
 - `save_treetn()` / `append_treetn()` / `load_treetn()` — read/write a general
-  `TreeTN<TensorDynLen, V>` (`String` or `usize` node names) using the
+  `TreeTN<IdxTensor, V>` (`String` or `usize` node names) using the
   tensor4all-rs `TreeTN` v1 schema: one `node_i/` ITensor subgroup per node
   with a `node_name` attribute; topology is recovered on load from shared
   index identity via `TreeTN::from_tensors`

--- a/crates/tensor4all-hdf5/src/itensor.rs
+++ b/crates/tensor4all-hdf5/src/itensor.rs
@@ -1,14 +1,14 @@
-//! Layer 1: ITensor (TensorDynLen) HDF5 read/write (ITensors.jl compatible).
+//! Layer 1: ITensor (IdxTensor) HDF5 read/write (ITensors.jl compatible).
 
 use crate::backend::Group;
 use anyhow::{bail, Context, Result};
 use num_complex::Complex64;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 
 use crate::index;
 use crate::schema;
 
-/// Write a [`TensorDynLen`] as an ITensors.jl `ITensor` to an HDF5 group.
+/// Write a [`IdxTensor`] as an ITensors.jl `ITensor` to an HDF5 group.
 ///
 /// The tensor data is stored in column-major order (matching ITensors.jl convention).
 /// Both `f64` and `Complex64` storage types are supported.
@@ -25,7 +25,7 @@ use crate::schema;
 ///     @version = 1
 ///     data: [N]    (flat column-major array)
 /// ```
-pub(crate) fn write_itensor(group: &Group, tensor: &TensorDynLen) -> Result<()> {
+pub(crate) fn write_itensor(group: &Group, tensor: &IdxTensor) -> Result<()> {
     schema::write_type_version(group, "ITensor", 1)?;
 
     // Write indices
@@ -66,7 +66,7 @@ pub(crate) fn write_itensor(group: &Group, tensor: &TensorDynLen) -> Result<()> 
     Ok(())
 }
 
-/// Read a [`TensorDynLen`] from an ITensors.jl `ITensor` in an HDF5 group.
+/// Read a [`IdxTensor`] from an ITensors.jl `ITensor` in an HDF5 group.
 ///
 /// Validates the `@type` and `@version` attributes before reading. Supports
 /// both `Dense{Float64}` and `Dense{ComplexF64}` storage types.
@@ -74,7 +74,7 @@ pub(crate) fn write_itensor(group: &Group, tensor: &TensorDynLen) -> Result<()> 
 /// String attributes are read using [`crate::compat`] helpers, which handle
 /// both variable-length Unicode (our format) and fixed-length Unicode
 /// (ITensors.jl format).
-pub(crate) fn read_itensor(group: &Group) -> Result<TensorDynLen> {
+pub(crate) fn read_itensor(group: &Group) -> Result<IdxTensor> {
     schema::require_type_version(group, "ITensor", 1)?;
 
     // Read indices
@@ -91,8 +91,8 @@ pub(crate) fn read_itensor(group: &Group) -> Result<TensorDynLen> {
             .read_1d()
             .context("Failed to read f64 data")?
             .to_vec();
-        TensorDynLen::from_dense(indices, col_major_data)
-            .context("Failed to build f64 TensorDynLen from HDF5 data")
+        IdxTensor::from_dense(indices, col_major_data)
+            .context("Failed to build f64 IdxTensor from HDF5 data")
     } else if storage_type_str.contains("Dense{ComplexF64}") {
         let data_ds = storage_group.dataset("data")?;
         // Read as native HDF5 compound type (Complex64)
@@ -101,8 +101,8 @@ pub(crate) fn read_itensor(group: &Group) -> Result<TensorDynLen> {
             .read_1d()
             .context("Failed to read complex data")?
             .to_vec();
-        TensorDynLen::from_dense(indices, col_major_data)
-            .context("Failed to build complex TensorDynLen from HDF5 data")
+        IdxTensor::from_dense(indices, col_major_data)
+            .context("Failed to build complex IdxTensor from HDF5 data")
     } else {
         bail!(
             "Unsupported storage type: {}. Only Dense{{Float64}} and Dense{{ComplexF64}} are supported.",

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! | Rust type | HDF5 schema | Julia equivalent |
 //! |-----------|-------------|------------------|
-//! | [`TensorDynLen`] | `ITensor` | `ITensors.ITensor` |
+//! | [`IdxTensor`] | `ITensor` | `ITensors.ITensor` |
 //! | [`TensorTrain`] | `MPS` | `ITensorMPS.MPS` |
 //! | [`TreeTN`](tensor4all_treetn::TreeTN) | `TreeTN` (tensor4all-rs schema) | — (no ITensorNetworks.jl equivalent) |
 //!
@@ -29,14 +29,14 @@
 //!
 //! ```
 //! use tensor4all_hdf5::{save_itensor, load_itensor, save_mps, load_mps};
-//! use tensor4all_core::{Index, TensorDynLen};
+//! use tensor4all_core::{Index, IdxTensor};
 //! use tensor4all_itensorlike::TensorTrain;
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! // Save and load a single tensor
 //! let i = Index::new_dyn(2);
 //! let j = Index::new_dyn(3);
-//! let tensor = TensorDynLen::from_dense(
+//! let tensor = IdxTensor::from_dense(
 //!     vec![i, j],
 //!     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
 //! )?;
@@ -54,8 +54,8 @@
 //! let s0 = Index::new_dyn(2);
 //! let bond = Index::new_dyn(1);
 //! let s1 = Index::new_dyn(2);
-//! let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
-//! let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
+//! let t0 = IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
+//! let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
 //! let tt = TensorTrain::new(vec![t0, t1])?;
 //!
 //! let mps_path = dir.path().join("mps.h5");
@@ -127,7 +127,7 @@ use backend::File;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::str::FromStr;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_itensorlike::TensorTrain;
 use tensor4all_treetn::TreeTN;
 
@@ -137,7 +137,7 @@ pub use hdf5_rt::sys::{
     init as hdf5_init, is_initialized as hdf5_is_initialized, library_path as hdf5_library_path,
 };
 
-/// Save a [`TensorDynLen`] as an ITensors.jl-compatible `ITensor` in an HDF5 file.
+/// Save a [`IdxTensor`] as an ITensors.jl-compatible `ITensor` in an HDF5 file.
 ///
 /// Creates the file if it does not exist, or overwrites an existing file.
 /// The tensor is stored under a group named `name` within the file.
@@ -156,12 +156,12 @@ pub use hdf5_rt::sys::{
 ///
 /// ```
 /// use tensor4all_hdf5::{save_itensor, load_itensor};
-/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_core::{Index, IdxTensor};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let i = Index::new_dyn(2);
 /// let j = Index::new_dyn(3);
-/// let tensor = TensorDynLen::from_dense(
+/// let tensor = IdxTensor::from_dense(
 ///     vec![i.clone(), j.clone()],
 ///     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
 /// )?;
@@ -182,13 +182,13 @@ pub use hdf5_rt::sys::{
 ///
 /// ```
 /// use tensor4all_hdf5::{save_itensor, load_itensor};
-/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_core::{Index, IdxTensor};
 /// use num_complex::Complex64;
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let i = Index::new_dyn(2);
 /// let data = vec![Complex64::new(1.0, 0.5), Complex64::new(2.0, -0.5)];
-/// let tensor = TensorDynLen::from_dense(vec![i], data.clone())?;
+/// let tensor = IdxTensor::from_dense(vec![i], data.clone())?;
 ///
 /// let dir = tempfile::tempdir()?;
 /// let path = dir.path().join("save_itensor_c64.h5");
@@ -203,14 +203,14 @@ pub use hdf5_rt::sys::{
 pub fn save_itensor(
     filepath: &str,
     name: &str,
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
 ) -> std::result::Result<(), Hdf5Error> {
     let file = File::create(filepath)?;
     let group = file.create_group(name)?;
     itensor::write_itensor(&group, tensor).map_err(Hdf5Error::from)
 }
 
-/// Append a [`TensorDynLen`] as an ITensors.jl-compatible `ITensor` to an HDF5 file.
+/// Append a [`IdxTensor`] as an ITensors.jl-compatible `ITensor` to an HDF5 file.
 ///
 /// Opens `filepath` read/write if it exists, or creates it otherwise, then
 /// writes the tensor under `name`. This is useful for files containing multiple
@@ -224,15 +224,15 @@ pub fn save_itensor(
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_hdf5::{append_itensor, load_itensor};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let dir = tempfile::tempdir()?;
 /// let path = dir.path().join("append_itensor.h5");
 /// let path = path.to_str().unwrap();
-/// let a = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0, 2.0])?;
-/// let b = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![3.0, 4.0])?;
+/// let a = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0, 2.0])?;
+/// let b = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![3.0, 4.0])?;
 ///
 /// append_itensor(path, "a", &a)?;
 /// append_itensor(path, "b", &b)?;
@@ -244,14 +244,14 @@ pub fn save_itensor(
 pub fn append_itensor(
     filepath: &str,
     name: &str,
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
 ) -> std::result::Result<(), Hdf5Error> {
     let file = File::append(filepath)?;
     let group = file.create_group(name)?;
     itensor::write_itensor(&group, tensor).map_err(Hdf5Error::from)
 }
 
-/// Load a [`TensorDynLen`] from an ITensors.jl-compatible `ITensor` in an HDF5 file.
+/// Load a [`IdxTensor`] from an ITensors.jl-compatible `ITensor` in an HDF5 file.
 ///
 /// Opens the file in read-only mode and reads the tensor from the group named
 /// `name`. Index metadata (id, dimension, prime level, tags) is restored from
@@ -273,12 +273,12 @@ pub fn append_itensor(
 ///
 /// ```
 /// use tensor4all_hdf5::{save_itensor, load_itensor};
-/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_core::{Index, IdxTensor};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let i = Index::new_dyn(2);
 /// let j = Index::new_dyn(3);
-/// let tensor = TensorDynLen::from_dense(
+/// let tensor = IdxTensor::from_dense(
 ///     vec![i.clone(), j.clone()],
 ///     vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
 /// )?;
@@ -301,7 +301,7 @@ pub fn append_itensor(
 /// # Ok(())
 /// # }
 /// ```
-pub fn load_itensor(filepath: &str, name: &str) -> std::result::Result<TensorDynLen, Hdf5Error> {
+pub fn load_itensor(filepath: &str, name: &str) -> std::result::Result<IdxTensor, Hdf5Error> {
     let file = File::open(filepath)?;
     let group = file.group(name)?;
     itensor::read_itensor(&group).map_err(Hdf5Error::from)
@@ -330,15 +330,15 @@ pub fn load_itensor(filepath: &str, name: &str) -> std::result::Result<TensorDyn
 ///
 /// ```
 /// use tensor4all_hdf5::{save_mps, load_mps};
-/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_core::{Index, IdxTensor};
 /// use tensor4all_itensorlike::TensorTrain;
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let s0 = Index::new_dyn(2);
 /// let bond = Index::new_dyn(1);
 /// let s1 = Index::new_dyn(2);
-/// let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
-/// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
+/// let t0 = IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
+/// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
 /// let tt = TensorTrain::new(vec![t0, t1])?;
 ///
 /// let dir = tempfile::tempdir()?;
@@ -381,7 +381,7 @@ pub fn save_mps(
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_hdf5::{append_mps, load_mps};
 /// use tensor4all_itensorlike::TensorTrain;
 ///
@@ -391,8 +391,8 @@ pub fn save_mps(
 /// let path = path.to_str().unwrap();
 /// let s0 = DynIndex::new_dyn(2);
 /// let s1 = DynIndex::new_dyn(2);
-/// let a = TensorTrain::new(vec![TensorDynLen::from_dense(vec![s0], vec![1.0, 2.0])?])?;
-/// let b = TensorTrain::new(vec![TensorDynLen::from_dense(vec![s1], vec![3.0, 4.0])?])?;
+/// let a = TensorTrain::new(vec![IdxTensor::from_dense(vec![s0], vec![1.0, 2.0])?])?;
+/// let b = TensorTrain::new(vec![IdxTensor::from_dense(vec![s1], vec![3.0, 4.0])?])?;
 ///
 /// append_mps(path, "a", &a)?;
 /// append_mps(path, "b", &b)?;
@@ -432,15 +432,15 @@ pub fn append_mps(
 ///
 /// ```
 /// use tensor4all_hdf5::{save_mps, load_mps};
-/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_core::{Index, IdxTensor};
 /// use tensor4all_itensorlike::TensorTrain;
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let s0 = Index::new_dyn(2);
 /// let bond = Index::new_dyn(1);
 /// let s1 = Index::new_dyn(2);
-/// let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
-/// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
+/// let t0 = IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
+/// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
 /// let tt = TensorTrain::new(vec![t0, t1])?;
 ///
 /// let dir = tempfile::tempdir()?;
@@ -492,16 +492,16 @@ pub fn load_mps(filepath: &str, name: &str) -> std::result::Result<TensorTrain, 
 ///
 /// ```
 /// use tensor4all_hdf5::{load_treetn, save_treetn};
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::TreeTN;
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let s0 = DynIndex::new_dyn(2);
 /// let s1 = DynIndex::new_dyn(2);
 /// let b01 = DynIndex::new_dyn(4);
-/// let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
-/// let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0; 8])?;
-/// let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+/// let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
+/// let t1 = IdxTensor::from_dense(vec![b01, s1], vec![1.0; 8])?;
+/// let tn = TreeTN::<IdxTensor, String>::from_tensors(
 ///     vec![t0, t1],
 ///     vec!["left".to_string(), "right".to_string()],
 /// )?;
@@ -522,7 +522,7 @@ pub fn load_mps(filepath: &str, name: &str) -> std::result::Result<TensorTrain, 
 pub fn save_treetn<V>(
     filepath: &str,
     name: &str,
-    tn: &TreeTN<TensorDynLen, V>,
+    tn: &TreeTN<IdxTensor, V>,
 ) -> std::result::Result<(), Hdf5Error>
 where
     V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
@@ -546,7 +546,7 @@ where
 pub fn append_treetn<V>(
     filepath: &str,
     name: &str,
-    tn: &TreeTN<TensorDynLen, V>,
+    tn: &TreeTN<IdxTensor, V>,
 ) -> std::result::Result<(), Hdf5Error>
 where
     V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
@@ -574,7 +574,7 @@ where
 pub fn load_treetn<V>(
     filepath: &str,
     name: &str,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, Hdf5Error>
+) -> std::result::Result<TreeTN<IdxTensor, V>, Hdf5Error>
 where
     V: FromStr + Ord + Clone + Hash + Eq + Send + Sync + Debug,
     V::Err: std::fmt::Display,

--- a/crates/tensor4all-hdf5/src/treetn.rs
+++ b/crates/tensor4all-hdf5/src/treetn.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::str::FromStr;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_treetn::TreeTN;
 
 use crate::index;
@@ -47,7 +47,7 @@ const NODE_NAME_ATTR: &str = "node_name";
 ///   node_2/
 ///     ...
 /// ```
-pub(crate) fn write_treetn<V>(group: &Group, tn: &TreeTN<TensorDynLen, V>) -> Result<()>
+pub(crate) fn write_treetn<V>(group: &Group, tn: &TreeTN<IdxTensor, V>) -> Result<()>
 where
     V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
 {
@@ -95,7 +95,7 @@ where
 /// reconstructed with [`TreeTN::from_tensors`], which reconnects bond indices
 /// by shared [`Index`](tensor4all_core::Index) identity and validates that
 /// the result is a consistent tree.
-pub(crate) fn read_treetn<V>(group: &Group) -> Result<TreeTN<TensorDynLen, V>>
+pub(crate) fn read_treetn<V>(group: &Group) -> Result<TreeTN<IdxTensor, V>>
 where
     V: FromStr + Ord + Clone + Hash + Eq + Send + Sync + Debug,
     V::Err: Display,

--- a/crates/tensor4all-hdf5/tests/test_hdf5.rs
+++ b/crates/tensor4all-hdf5/tests/test_hdf5.rs
@@ -4,7 +4,7 @@ use hdf5_metno::File;
 use num_complex::Complex64;
 use std::str::FromStr;
 use tensor4all_core::index::{DynId, DynIndex, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_hdf5::{
     append_itensor, append_mps, append_treetn, load_itensor, load_mps, load_treetn, save_itensor,
     save_mps, save_treetn,
@@ -63,15 +63,15 @@ fn mps_error(name: &str, mutate: impl FnOnce(&hdf5_metno::Group)) -> String {
 }
 
 /// Create a simple 2x3 f64 tensor with known data.
-fn make_test_tensor_f64() -> TensorDynLen {
+fn make_test_tensor_f64() -> IdxTensor {
     let i1 = Index::new_dyn_with_tags(2, TagSet::from_str("Site,n=1").unwrap()).set_plev(1);
     let i2 = Index::new_dyn_with_tags(3, TagSet::from_str("Link,l=1").unwrap()).set_plev(2);
     let data: Vec<f64> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
-    TensorDynLen::from_dense(vec![i1, i2], data).unwrap()
+    IdxTensor::from_dense(vec![i1, i2], data).unwrap()
 }
 
 /// Create a simple 2x3 complex tensor with known data.
-fn make_test_tensor_c64() -> TensorDynLen {
+fn make_test_tensor_c64() -> IdxTensor {
     let i1 = Index::new_dyn_with_tags(2, TagSet::from_str("Site,n=1").unwrap()).set_plev(1);
     let i2 = Index::new_dyn_with_tags(3, TagSet::from_str("Link,l=1").unwrap()).set_plev(2);
     let data: Vec<Complex64> = vec![
@@ -82,7 +82,7 @@ fn make_test_tensor_c64() -> TensorDynLen {
         Complex64::new(5.0, 0.5),
         Complex64::new(6.0, 0.6),
     ];
-    TensorDynLen::from_dense(vec![i1, i2], data).unwrap()
+    IdxTensor::from_dense(vec![i1, i2], data).unwrap()
 }
 
 #[test]
@@ -165,8 +165,8 @@ fn test_itensor_c64_roundtrip() {
 fn test_append_itensor_keeps_multiple_named_objects() {
     let path = temp_path("append_itensor_multiple");
     std::fs::remove_file(&path).ok();
-    let first = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0, 2.0]).unwrap();
-    let second = TensorDynLen::from_dense(vec![DynIndex::new_dyn(2)], vec![3.0, 4.0]).unwrap();
+    let first = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![1.0, 2.0]).unwrap();
+    let second = IdxTensor::from_dense(vec![DynIndex::new_dyn(2)], vec![3.0, 4.0]).unwrap();
 
     append_itensor(&path, "first", &first).unwrap();
     append_itensor(&path, "second", &second).unwrap();
@@ -219,7 +219,7 @@ fn test_itensor_3d_roundtrip() {
     let i3 = Index::new_dyn_with_tags(4, TagSet::from_str("Link,l=1").unwrap());
     let n = 2 * 3 * 4;
     let data: Vec<f64> = (0..n).map(|i| i as f64).collect();
-    let tensor = TensorDynLen::from_dense(vec![i1, i2, i3], data.clone()).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i1, i2, i3], data.clone()).unwrap();
 
     save_itensor(&path, "tensor3d", &tensor).unwrap();
     let loaded = load_itensor(&path, "tensor3d").unwrap();
@@ -445,15 +445,15 @@ fn make_test_mps() -> TensorTrain {
 
     // Tensor 0: shape (1, 2, 3) = 6 elements
     let data0: Vec<f64> = (0..6).map(|i| i as f64 * 0.1).collect();
-    let t0 = TensorDynLen::from_dense(vec![left_dummy, site0, link01_left], data0).unwrap();
+    let t0 = IdxTensor::from_dense(vec![left_dummy, site0, link01_left], data0).unwrap();
 
     // Tensor 1: shape (3, 2, 4) = 24 elements
     let data1: Vec<f64> = (0..24).map(|i| i as f64 * 0.01).collect();
-    let t1 = TensorDynLen::from_dense(vec![link01_right, site1, link12_left], data1).unwrap();
+    let t1 = IdxTensor::from_dense(vec![link01_right, site1, link12_left], data1).unwrap();
 
     // Tensor 2: shape (4, 2, 1) = 8 elements
     let data2: Vec<f64> = (0..8).map(|i| i as f64 * 0.05).collect();
-    let t2 = TensorDynLen::from_dense(vec![link12_right, site2, right_dummy], data2).unwrap();
+    let t2 = IdxTensor::from_dense(vec![link12_right, site2, right_dummy], data2).unwrap();
 
     TensorTrain::new(vec![t0, t1, t2]).unwrap()
 }
@@ -747,12 +747,12 @@ fn test_mps_load_preserves_site_tensor_index_order() {
     let site0 = Index::new_with_size(DynId(10), 2);
     let link = Index::new_with_size(DynId(11), 3);
     let site1 = Index::new_with_size(DynId(12), 2);
-    let left = TensorDynLen::from_dense(
+    let left = IdxTensor::from_dense(
         vec![link.clone(), site0.clone()],
         vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
     )
     .unwrap();
-    let right = TensorDynLen::from_dense(
+    let right = IdxTensor::from_dense(
         vec![site1.clone(), link.clone()],
         vec![6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
     )
@@ -772,13 +772,13 @@ fn test_mps_load_preserves_site_tensor_index_order() {
 fn test_append_mps_keeps_multiple_named_objects() {
     let path = temp_path("append_mps_multiple");
     std::fs::remove_file(&path).ok();
-    let first = TensorTrain::new(vec![TensorDynLen::from_dense(
+    let first = TensorTrain::new(vec![IdxTensor::from_dense(
         vec![DynIndex::new_dyn(2)],
         vec![1.0, 2.0],
     )
     .unwrap()])
     .unwrap();
-    let second = TensorTrain::new(vec![TensorDynLen::from_dense(
+    let second = TensorTrain::new(vec![IdxTensor::from_dense(
         vec![DynIndex::new_dyn(2)],
         vec![3.0, 4.0],
     )
@@ -905,7 +905,7 @@ fn mps_attribute_lookup_does_not_enumerate_attribute_names() {
 
 #[test]
 fn test_roundtrip_preserves_same_id_distinct_metadata_indices() -> anyhow::Result<()> {
-    use tensor4all_core::{DynId, Index, TagSet, TensorDynLen};
+    use tensor4all_core::{DynId, IdxTensor, Index, TagSet};
     use tensor4all_hdf5::{load_itensor, save_itensor};
 
     let tags_a = TagSet::from_str("Site,A")?;
@@ -914,7 +914,7 @@ fn test_roundtrip_preserves_same_id_distinct_metadata_indices() -> anyhow::Resul
     let j = Index::new_with_tags(DynId(7), 3, tags_b).set_plev(1);
     assert_ne!(i, j);
 
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![i.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )?;
@@ -952,17 +952,16 @@ fn test_type_mismatch_error() {
 use tensor4all_treetn::TreeTN;
 
 /// A 3-node tree (root connected to two leaves) with known data.
-fn make_test_treetn() -> TreeTN<TensorDynLen, String> {
+fn make_test_treetn() -> TreeTN<IdxTensor, String> {
     let s_left = DynIndex::new_dyn(2);
     let s_root = DynIndex::new_dyn(3);
     let s_right = DynIndex::new_dyn(2);
     let b_left = DynIndex::new_dyn(4);
     let b_right = DynIndex::new_dyn(5);
 
-    let left = TensorDynLen::from_dense(vec![s_left, b_left.clone()], vec![1.0; 8]).unwrap();
-    let root =
-        TensorDynLen::from_dense(vec![b_left, s_root, b_right.clone()], vec![2.0; 60]).unwrap();
-    let right = TensorDynLen::from_dense(vec![b_right, s_right], vec![3.0; 10]).unwrap();
+    let left = IdxTensor::from_dense(vec![s_left, b_left.clone()], vec![1.0; 8]).unwrap();
+    let root = IdxTensor::from_dense(vec![b_left, s_root, b_right.clone()], vec![2.0; 60]).unwrap();
+    let right = IdxTensor::from_dense(vec![b_right, s_right], vec![3.0; 10]).unwrap();
 
     TreeTN::from_tensors(
         vec![left, root, right],
@@ -971,7 +970,7 @@ fn make_test_treetn() -> TreeTN<TensorDynLen, String> {
     .unwrap()
 }
 
-fn treetn_node_tensors(tn: &TreeTN<TensorDynLen, String>) -> Vec<TensorDynLen> {
+fn treetn_node_tensors(tn: &TreeTN<IdxTensor, String>) -> Vec<IdxTensor> {
     tn.node_indices()
         .iter()
         .map(|idx| tn.tensor(*idx).unwrap().clone())
@@ -1023,9 +1022,9 @@ fn test_treetn_usize_node_names_roundtrip() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let b01 = DynIndex::new_dyn(4);
-    let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0; 8]).unwrap();
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0; 8]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01, s1], vec![1.0; 8]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
 
     save_treetn(path.as_str(), "tn", &tn).unwrap();
     let loaded = load_treetn::<usize>(path.as_str(), "tn").unwrap();

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -12,7 +12,7 @@ ITensors.jl-inspired TensorTrain API with orthogonality tracking and multiple ca
 
 ## Conventions
 
-- Dense data passed to `TensorDynLen::from_dense` is **column-major**: the
+- Dense data passed to `IdxTensor::from_dense` is **column-major**: the
   first listed index varies fastest.
 - Complex tensors use `num_complex::Complex64`; `inner()` conjugates the left
   operand, so `tt.inner(&tt)` equals the square of `tt.norm()?` for real and
@@ -41,9 +41,9 @@ let s2 = DynIndex::new_dyn(2);
 let b01 = DynIndex::new_bond(2)?;
 let b12 = DynIndex::new_bond(2)?;
 
-let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
-let t1 = TensorDynLen::from_dense(vec![b01, s1.clone(), b12.clone()], vec![1.0; 8])?;
-let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![1.0, 0.0, 0.0, 1.0])?;
+let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+let t1 = IdxTensor::from_dense(vec![b01, s1.clone(), b12.clone()], vec![1.0; 8])?;
+let t2 = IdxTensor::from_dense(vec![b12, s2], vec![1.0, 0.0, 0.0, 1.0])?;
 
 let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 tt.orthogonalize(1)?;
@@ -71,7 +71,7 @@ use num_complex::Complex64;
 use tensor4all_itensorlike::prelude::*;
 
 let site = DynIndex::new_dyn(2);
-let tensor = TensorDynLen::from_dense(
+let tensor = IdxTensor::from_dense(
     vec![site],
     vec![Complex64::new(1.0, 2.0), Complex64::new(0.0, -1.0)],
 )?;

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract.rs
@@ -11,7 +11,7 @@ use rand::rng;
 use std::time::Instant;
 
 use anyhow::Result;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
@@ -51,7 +51,7 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_detailed.rs
@@ -4,7 +4,7 @@ use rand::rng;
 use std::time::Instant;
 
 use anyhow::Result;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
@@ -30,7 +30,7 @@ fn create_random_mpo(
             indices.push(link_indices[i].clone());
         }
 
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit.rs
@@ -11,7 +11,7 @@ use rand::rng;
 use std::time::Instant;
 
 use anyhow::Result;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
@@ -51,7 +51,7 @@ fn create_random_mpo(
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_one_shot.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_one_shot.rs
@@ -2,7 +2,7 @@ use rand::rng;
 use std::time::Instant;
 
 use anyhow::Result;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{CanonicalForm, ContractOptions, TensorTrain};
 
 fn create_random_mpo(
@@ -24,7 +24,7 @@ fn create_random_mpo(
         if i + 1 < length {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_profiled.rs
@@ -4,7 +4,7 @@ use rand::rng;
 use std::time::Instant;
 
 use anyhow::Result;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain};
 
 /// Create a random MPO (Matrix Product Operator).
@@ -30,7 +30,7 @@ fn create_random_mpo(
             indices.push(link_indices[i].clone());
         }
 
-        let tensor = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
+        let tensor = IdxTensor::random::<f64, _>(&mut rng, indices)?;
         tensors.push(tensor);
     }
 

--- a/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
+++ b/crates/tensor4all-itensorlike/examples/test_fit_vs_zipup.rs
@@ -7,7 +7,7 @@
 //!   cargo run -p tensor4all-itensorlike --example test_fit_vs_zipup --release
 
 use tensor4all_core::krylov::{gmres, gmres_with_truncation, GmresOptions};
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Shared indices for MPO operations.
@@ -1381,22 +1381,21 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -1421,25 +1420,24 @@ fn create_pauli_x_operator(indices: &SharedIndices) -> anyhow::Result<TensorTrai
         let op_out_idx = indices.operator_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx], pauli_x.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], pauli_x.to_vec())
+                IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], pauli_x.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], pauli_x.to_vec())
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], pauli_x.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
+            let tensor = IdxTensor::from_dense(
                 vec![left_bond, in_idx, op_out_idx, right_bond],
                 pauli_x.to_vec(),
             )

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mpo.rs
@@ -18,7 +18,7 @@ use tensor4all_core::krylov::{
     gmres_with_truncation, restart_gmres_with_truncation, GmresOptions, RestartGmresOptions,
 };
 use tensor4all_core::TensorVectorSpace;
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 // ============================================================================
@@ -131,22 +131,21 @@ fn create_ones_mpo_for_block(
         let data = vec![1.0_f64; in_dim * out_dim];
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[block_idx][i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let right_bond = indices.bonds[block_idx][i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -185,22 +184,21 @@ fn create_const_mpo_for_block(
         let data = vec![fill_value; in_dim * out_dim];
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[block_idx][i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let right_bond = indices.bonds[block_idx][i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -237,23 +235,21 @@ fn create_identity_operator_for_block(
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
                     .unwrap();
             tensors.push(tensor);
         }
@@ -283,24 +279,24 @@ fn create_diagonal_operator_for_block(
 
         if i == 0 && n == 1 {
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx], diag_data.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![in_idx, op_out_idx], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], diag_data.to_vec())
+                IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], diag_data.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], diag_data.to_vec())
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], diag_data.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
+            let tensor = IdxTensor::from_dense(
                 vec![left_bond, in_idx, op_out_idx, right_bond],
                 diag_data.to_vec(),
             )
@@ -338,23 +334,21 @@ fn create_cross_block_identity_operator(
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
                     .unwrap();
             tensors.push(tensor);
         }
@@ -391,23 +385,21 @@ fn create_i_pauli_x_cross_block_operator(
         let data = vec![zero, factor, factor, zero];
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
                     .unwrap();
             tensors.push(tensor);
         }
@@ -437,22 +429,21 @@ fn create_complex_const_mpo_for_block(
         let data = vec![fill; in_dim * out_dim];
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[block_idx][i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let right_bond = indices.bonds[block_idx][i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }

--- a/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_block_mps.rs
@@ -15,7 +15,7 @@ use tensor4all_core::krylov::{
     gmres_with_truncation, restart_gmres_with_truncation, GmresOptions, RestartGmresOptions,
 };
 use tensor4all_core::TensorVectorSpace;
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 // ============================================================================
@@ -98,24 +98,24 @@ fn create_ones_mps_for_block(
 
         if i == 0 && n == 1 {
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[block_idx][i].clone();
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![left_bond, site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, site_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let right_bond = indices.bonds[block_idx][i].clone();
             let data = vec![1.0; site_dim];
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -150,24 +150,24 @@ fn create_const_mps_for_block(
 
         if i == 0 && n == 1 {
             let data = vec![fill_value; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[block_idx][i].clone();
             let data = vec![fill_value; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let data = vec![fill_value; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![left_bond, site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, site_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let right_bond = indices.bonds[block_idx][i].clone();
             let data = vec![fill_value; site_dim];
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -204,21 +204,21 @@ fn create_identity_mpo_for_block(
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -246,27 +246,24 @@ fn create_diagonal_mpo_for_block(
         let s_out = indices.mpo_outputs[block_idx][i].clone();
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], diag_data.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![s_in, s_out, right_bond], diag_data.to_vec())
-                    .unwrap();
+                IdxTensor::from_dense(vec![s_in, s_out, right_bond], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out], diag_data.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
-                vec![left_bond, s_in, s_out, right_bond],
-                diag_data.to_vec(),
-            )
-            .unwrap();
+            let tensor =
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], diag_data.to_vec())
+                    .unwrap();
             tensors.push(tensor);
         }
     }
@@ -294,24 +291,24 @@ fn create_complex_ones_mps_for_block(
 
         if i == 0 && n == 1 {
             let data = vec![fill; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[block_idx][i].clone();
             let data = vec![fill; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let data = vec![fill; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![left_bond, site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, site_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[block_idx][i - 1].clone();
             let right_bond = indices.bonds[block_idx][i].clone();
             let data = vec![fill; site_dim];
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -346,21 +343,21 @@ fn create_i_pauli_x_cross_block_mpo(
         let data = vec![zero, factor, factor, zero];
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -395,21 +392,21 @@ fn create_cross_block_identity_mpo(
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }

--- a/crates/tensor4all-itensorlike/examples/test_gmres_identity_high_bonddim.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_identity_high_bonddim.rs
@@ -15,7 +15,7 @@
 
 use anyhow::Result;
 use tensor4all_core::krylov::{restart_gmres_with_truncation, RestartGmresOptions};
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
 use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
 
 /// Create a product-state MPS (bond dim 1) with given per-site values.
@@ -39,7 +39,7 @@ fn create_product_mps(
             indices.push(bond_indices[i].clone());
         }
         let data = site_values[i].to_vec();
-        tensors.push(TensorDynLen::from_dense(indices, data).unwrap());
+        tensors.push(IdxTensor::from_dense(indices, data).unwrap());
     }
     TensorTrain::new(tensors).map_err(|e| anyhow::anyhow!("{e}"))
 }

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mpo.rs
@@ -12,7 +12,7 @@
 use num_complex::Complex64;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use tensor4all_core::krylov::{gmres_with_truncation, GmresOptions};
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Shared indices for all MPO operations.
@@ -569,22 +569,21 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -616,22 +615,21 @@ fn create_imaginary_identity_mpo(indices: &SharedIndices) -> anyhow::Result<Tens
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -658,25 +656,24 @@ fn create_pauli_x_operator_mpo(indices: &SharedIndices) -> anyhow::Result<Tensor
         let op_out_idx = indices.operator_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx], pauli_x.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], pauli_x.to_vec())
+                IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], pauli_x.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], pauli_x.to_vec())
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], pauli_x.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
+            let tensor = IdxTensor::from_dense(
                 vec![left_bond, in_idx, op_out_idx, right_bond],
                 pauli_x.to_vec(),
             )
@@ -717,23 +714,21 @@ fn create_random_operator_mpo(indices: &SharedIndices, seed: u64) -> anyhow::Res
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
-            let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx, right_bond], data)
                     .unwrap();
             tensors.push(tensor);
         }

--- a/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_gmres_mps.rs
@@ -12,7 +12,7 @@
 use num_complex::Complex64;
 use rand::{rngs::StdRng, SeedableRng};
 use tensor4all_core::krylov::{gmres_with_truncation, GmresOptions};
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Shared indices for all MPS/MPO operations.
@@ -308,7 +308,7 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
             for j in 0..site_dim {
                 data[j * site_dim + j] = 1.0;
             }
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             // First site: [s_in, s_out, right]
@@ -317,7 +317,7 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
             for j in 0..site_dim {
                 data[j * site_dim + j] = 1.0;
             }
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             // Last site: [left, s_in, s_out]
@@ -326,7 +326,7 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
             for j in 0..site_dim {
                 data[j * site_dim + j] = 1.0;
             }
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             // Middle site: [left, s_in, s_out, right]
@@ -337,7 +337,7 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
                 data[j * site_dim + j] = 1.0;
             }
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -356,24 +356,24 @@ fn create_ones_mps(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
 
         if i == 0 && n == 1 {
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
             let data = vec![1.0; site_dim * 1];
-            let tensor = TensorDynLen::from_dense(vec![site_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
             let data = vec![1.0; 1 * site_dim];
-            let tensor = TensorDynLen::from_dense(vec![left_bond, site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, site_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let data = vec![1.0; 1 * site_dim * 1];
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -428,26 +428,24 @@ fn create_pauli_x_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         let s_out = indices.mpo_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], pauli_x.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![s_in, s_out, right_bond], pauli_x.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![s_in, s_out, right_bond], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out], pauli_x.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
-                vec![left_bond, s_in, s_out, right_bond],
-                pauli_x.to_vec(),
-            )
-            .unwrap();
+            let tensor =
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], pauli_x.to_vec())
+                    .unwrap();
             tensors.push(tensor);
         }
     }
@@ -595,7 +593,7 @@ fn create_imaginary_identity_mpo(indices: &SharedIndices) -> anyhow::Result<Tens
             for j in 0..site_dim {
                 data[j * site_dim + j] = factor;
             }
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             // First site: [s_in, s_out, right]
@@ -604,7 +602,7 @@ fn create_imaginary_identity_mpo(indices: &SharedIndices) -> anyhow::Result<Tens
             for j in 0..site_dim {
                 data[j * site_dim + j] = factor;
             }
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             // Last site: [left, s_in, s_out]
@@ -613,7 +611,7 @@ fn create_imaginary_identity_mpo(indices: &SharedIndices) -> anyhow::Result<Tens
             for j in 0..site_dim {
                 data[j * site_dim + j] = factor;
             }
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             // Middle site: [left, s_in, s_out, right]
@@ -624,7 +622,7 @@ fn create_imaginary_identity_mpo(indices: &SharedIndices) -> anyhow::Result<Tens
                 data[j * site_dim + j] = factor;
             }
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -649,24 +647,24 @@ fn create_imaginary_ones_mps(indices: &SharedIndices) -> anyhow::Result<TensorTr
 
         if i == 0 && n == 1 {
             let data = vec![factor; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
             let data = vec![factor; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
             let data = vec![factor; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![left_bond, site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, site_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let data = vec![factor; site_dim];
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -696,26 +694,24 @@ fn create_diagonal_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         let s_out = indices.mpo_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], diag_mat.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], diag_mat.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![s_in, s_out, right_bond], diag_mat.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![s_in, s_out, right_bond], diag_mat.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out], diag_mat.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out], diag_mat.to_vec()).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
-                vec![left_bond, s_in, s_out, right_bond],
-                diag_mat.to_vec(),
-            )
-            .unwrap();
+            let tensor =
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], diag_mat.to_vec())
+                    .unwrap();
             tensors.push(tensor);
         }
     }
@@ -865,21 +861,21 @@ fn create_random_mpo(indices: &SharedIndices, seed: u64) -> anyhow::Result<Tenso
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }

--- a/crates/tensor4all-itensorlike/examples/test_restart_gmres_mpo.rs
+++ b/crates/tensor4all-itensorlike/examples/test_restart_gmres_mpo.rs
@@ -11,7 +11,7 @@
 //!   cargo run -p tensor4all-itensorlike --example test_restart_gmres_mpo --release
 
 use tensor4all_core::krylov::{restart_gmres_with_truncation, RestartGmresOptions};
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Shared indices for all MPO operations.
@@ -383,22 +383,21 @@ fn create_ones_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         let data = vec![1.0_f64; in_dim * out_dim];
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, in_idx, out_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data)
-                    .unwrap();
+                IdxTensor::from_dense(vec![left_bond, in_idx, out_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -424,25 +423,24 @@ fn create_pauli_x_operator_mpo(indices: &SharedIndices) -> anyhow::Result<Tensor
         let op_out_idx = indices.operator_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx], pauli_x.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![in_idx, op_out_idx], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], pauli_x.to_vec())
+                IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], pauli_x.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], pauli_x.to_vec())
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], pauli_x.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
+            let tensor = IdxTensor::from_dense(
                 vec![left_bond, in_idx, op_out_idx, right_bond],
                 pauli_x.to_vec(),
             )
@@ -473,24 +471,24 @@ fn create_diagonal_operator_mpo(indices: &SharedIndices) -> anyhow::Result<Tenso
 
         if i == 0 && n == 1 {
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx], diag_data.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![in_idx, op_out_idx], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = op_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![in_idx, op_out_idx, right_bond], diag_data.to_vec())
+                IdxTensor::from_dense(vec![in_idx, op_out_idx, right_bond], diag_data.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = op_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, in_idx, op_out_idx], diag_data.to_vec())
+                IdxTensor::from_dense(vec![left_bond, in_idx, op_out_idx], diag_data.to_vec())
                     .unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = op_bonds[i - 1].clone();
             let right_bond = op_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
+            let tensor = IdxTensor::from_dense(
                 vec![left_bond, in_idx, op_out_idx, right_bond],
                 diag_data.to_vec(),
             )

--- a/crates/tensor4all-itensorlike/examples/test_restart_gmres_mps.rs
+++ b/crates/tensor4all-itensorlike/examples/test_restart_gmres_mps.rs
@@ -9,7 +9,7 @@
 //!   cargo run -p tensor4all-itensorlike --example test_restart_gmres_mps --release
 
 use tensor4all_core::krylov::{restart_gmres_with_truncation, RestartGmresOptions};
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Shared indices for all MPS/MPO operations.
@@ -210,21 +210,21 @@ fn create_identity_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         }
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
-            let tensor = TensorDynLen::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, s_in, s_out], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }
@@ -424,27 +424,24 @@ fn create_diagonal_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         let s_out = indices.mpo_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], diag_data.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![s_in, s_out, right_bond], diag_data.to_vec())
-                    .unwrap();
+                IdxTensor::from_dense(vec![s_in, s_out, right_bond], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out], diag_data.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out], diag_data.to_vec()).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
-                vec![left_bond, s_in, s_out, right_bond],
-                diag_data.to_vec(),
-            )
-            .unwrap();
+            let tensor =
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], diag_data.to_vec())
+                    .unwrap();
             tensors.push(tensor);
         }
     }
@@ -471,26 +468,24 @@ fn create_pauli_x_mpo(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
         let s_out = indices.mpo_outputs[i].clone();
 
         if i == 0 && n == 1 {
-            let tensor = TensorDynLen::from_dense(vec![s_in, s_out], pauli_x.to_vec()).unwrap();
+            let tensor = IdxTensor::from_dense(vec![s_in, s_out], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = mpo_bonds[i].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![s_in, s_out, right_bond], pauli_x.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![s_in, s_out, right_bond], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = mpo_bonds[i - 1].clone();
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, s_in, s_out], pauli_x.to_vec()).unwrap();
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out], pauli_x.to_vec()).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = mpo_bonds[i - 1].clone();
             let right_bond = mpo_bonds[i].clone();
-            let tensor = TensorDynLen::from_dense(
-                vec![left_bond, s_in, s_out, right_bond],
-                pauli_x.to_vec(),
-            )
-            .unwrap();
+            let tensor =
+                IdxTensor::from_dense(vec![left_bond, s_in, s_out, right_bond], pauli_x.to_vec())
+                    .unwrap();
             tensors.push(tensor);
         }
     }
@@ -509,24 +504,24 @@ fn create_ones_mps(indices: &SharedIndices) -> anyhow::Result<TensorTrain> {
 
         if i == 0 && n == 1 {
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx], data).unwrap();
             tensors.push(tensor);
         } else if i == 0 {
             let right_bond = indices.bonds[i].clone();
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![site_idx, right_bond], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         } else if i == n - 1 {
             let left_bond = indices.bonds[i - 1].clone();
             let data = vec![1.0; site_dim];
-            let tensor = TensorDynLen::from_dense(vec![left_bond, site_idx], data).unwrap();
+            let tensor = IdxTensor::from_dense(vec![left_bond, site_idx], data).unwrap();
             tensors.push(tensor);
         } else {
             let left_bond = indices.bonds[i - 1].clone();
             let right_bond = indices.bonds[i].clone();
             let data = vec![1.0; site_dim];
             let tensor =
-                TensorDynLen::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
+                IdxTensor::from_dense(vec![left_bond, site_idx, right_bond], data).unwrap();
             tensors.push(tensor);
         }
     }

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -1,13 +1,13 @@
 use super::*;
 use crate::TensorTrainError;
-use tensor4all_core::{DynId, DynIndex, Index, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{DynId, DynIndex, IdxTensor, Index, TensorContractionLike};
 
 /// Helper to create a simple tensor for testing
-fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.size()).collect();
     let size: usize = dims.iter().product();
     let data: Vec<f64> = (0..size).map(|i| (i + 1) as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Helper to create a DynIndex
@@ -171,7 +171,7 @@ fn test_contract_zipup_matches_naive_for_zero_masked_inputs() {
     let l12 = idx(1038, 3);
 
     let tt1 = TensorTrain::new(vec![
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![s0.clone(), l01.clone()],
             vec![0.0, 0.0, 0.0, 4.0, 5.0, 6.0],
         )
@@ -182,7 +182,7 @@ fn test_contract_zipup_matches_naive_for_zero_masked_inputs() {
 
     let tt2 = TensorTrain::new(vec![
         make_tensor(vec![s0.clone(), l12.clone()]),
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![l12.clone(), s2.clone()],
             vec![1.0, 0.0, 3.0, 0.0, 5.0, 0.0],
         )
@@ -204,7 +204,7 @@ fn test_treetn_zipup_matches_naive_for_zero_masked_inputs() {
     let l12 = idx(1043, 3);
 
     let tt1 = TensorTrain::new(vec![
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![s0.clone(), l01.clone()],
             vec![0.0, 0.0, 0.0, 4.0, 5.0, 6.0],
         )
@@ -215,7 +215,7 @@ fn test_treetn_zipup_matches_naive_for_zero_masked_inputs() {
 
     let tt2 = TensorTrain::new(vec![
         make_tensor(vec![s0.clone(), l12.clone()]),
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![l12.clone(), s2.clone()],
             vec![1.0, 0.0, 3.0, 0.0, 5.0, 0.0],
         )

--- a/crates/tensor4all-itensorlike/src/error.rs
+++ b/crates/tensor4all-itensorlike/src/error.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// Result type for TensorTrain operations.
 pub type Result<T> = std::result::Result<T, TensorTrainError>;
 
-use tensor4all_core::TensorDynLenError;
+use tensor4all_core::IdxTensorError;
 
 /// Errors that can occur in `TensorTrain` operations.
 ///
@@ -64,12 +64,12 @@ pub enum TensorTrainError {
     #[error("Factorization error: {0}")]
     Factorize(#[from] tensor4all_core::FactorizeError),
 
-    /// A typed TensorDynLen metric or materialization error.
-    #[error("TensorDynLen operation error: {source}")]
-    TensorDynLen {
+    /// A typed IdxTensor metric or materialization error.
+    #[error("IdxTensor operation error: {source}")]
+    IdxTensor {
         /// The typed tensor diagnostic.
         #[source]
-        source: tensor4all_core::TensorDynLenError,
+        source: tensor4all_core::IdxTensorError,
     },
 
     /// General operation error.
@@ -96,9 +96,9 @@ impl From<anyhow::Error> for TensorTrainError {
     }
 }
 
-impl From<TensorDynLenError> for TensorTrainError {
-    fn from(source: TensorDynLenError) -> Self {
-        Self::TensorDynLen { source }
+impl From<IdxTensorError> for TensorTrainError {
+    fn from(source: IdxTensorError) -> Self {
+        Self::IdxTensor { source }
     }
 }
 

--- a/crates/tensor4all-itensorlike/src/linsolve.rs
+++ b/crates/tensor4all-itensorlike/src/linsolve.rs
@@ -277,10 +277,10 @@ impl TensorTrain {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tensor4all_core::{DynIndex, TensorDynLen};
+    use tensor4all_core::{DynIndex, IdxTensor};
 
-    fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-        TensorDynLen::from_dense(indices, data).unwrap()
+    fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+        IdxTensor::from_dense(indices, data).unwrap()
     }
 
     #[test]

--- a/crates/tensor4all-itensorlike/src/prelude.rs
+++ b/crates/tensor4all-itensorlike/src/prelude.rs
@@ -8,8 +8,8 @@
 //! let s0 = DynIndex::new_dyn(2);
 //! let s1 = DynIndex::new_dyn(2);
 //! let b01 = DynIndex::new_bond(2)?;
-//! let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
-//! let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0, 0.0, 0.0, 1.0])?;
+//! let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+//! let t1 = IdxTensor::from_dense(vec![b01, s1], vec![1.0, 0.0, 0.0, 1.0])?;
 //! let mut tt = TensorTrain::new(vec![t0, t1])?;
 //! tt.orthogonalize(0)?;
 //! tt.truncate(&TruncateOptions::svd()
@@ -23,4 +23,4 @@
 pub use crate::{
     CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TensorTrain, TruncateOptions,
 };
-pub use tensor4all_core::{DynIndex, IndexLike, SvdTruncationPolicy, TensorDynLen};
+pub use tensor4all_core::{DynIndex, IdxTensor, IndexLike, SvdTruncationPolicy};

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -4,7 +4,7 @@
 //! (also known as MPS) with orthogonality tracking, inspired by ITensorMPS.jl.
 //!
 //! Internally, TensorTrain is implemented as a thin wrapper around
-//! `TreeTN<TensorDynLen, usize>` where node names are site indices (0, 1, 2, ...).
+//! `TreeTN<IdxTensor, usize>` where node names are site indices (0, 1, 2, ...).
 
 use num_complex::Complex64;
 use std::any::TypeId;
@@ -18,8 +18,8 @@ use tensor4all_core::{
 };
 use tensor4all_core::{
     AnyScalar, Canonical, CommonScalar, DirectSumResult, FactorizeAlg, FactorizeError,
-    FactorizeOptions, FactorizeResult, LinearizationOrder, TensorConstructionLike,
-    TensorContractionLike, TensorDynLen, TensorDynLenError, TensorElement, TensorFactorizationLike,
+    FactorizeOptions, FactorizeResult, IdxTensor, IdxTensorError, LinearizationOrder,
+    TensorConstructionLike, TensorContractionLike, TensorElement, TensorFactorizationLike,
     TensorIndex, TensorVectorSpace,
 };
 use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
@@ -85,23 +85,23 @@ fn print_tt_inner_profile(profile: &TensorTrainInnerProfile, length: usize) {
 /// - When `ortho_region` is empty, no orthogonality is assumed
 /// - When `ortho_region` contains a single site, that site is the orthogonality center
 /// # Implementation
-/// Internally wraps `TreeTN<TensorDynLen, usize>` where node names are site indices.
+/// Internally wraps `TreeTN<IdxTensor, usize>` where node names are site indices.
 /// This allows reuse of TreeTN's canonicalization and contraction algorithms.
 /// # Examples
 /// Build a 2-site tensor train and query its properties:
 /// ```
 /// use tensor4all_itensorlike::TensorTrain;
-/// use tensor4all_core::{DynIndex, TensorDynLen, Index};
+/// use tensor4all_core::{DynIndex, IdxTensor, Index};
 /// use tensor4all_core::DynId;
 /// // Site indices and link index
 /// let s0 = Index::new_with_size(DynId(0), 2);
 /// let link = Index::new_with_size(DynId(1), 3);
 /// let s1 = Index::new_with_size(DynId(2), 2);
-/// let t0 = TensorDynLen::from_dense(
+/// let t0 = IdxTensor::from_dense(
 ///     vec![s0.clone(), link.clone()],
 ///     (0..6).map(|i| i as f64).collect(),
 /// ).unwrap();
-/// let t1 = TensorDynLen::from_dense(
+/// let t1 = IdxTensor::from_dense(
 ///     vec![link.clone(), s1.clone()],
 ///     (0..6).map(|i| i as f64).collect(),
 /// ).unwrap();
@@ -114,7 +114,7 @@ fn print_tt_inner_profile(profile: &TensorTrainInnerProfile, length: usize) {
 pub struct TensorTrain {
     /// The underlying TreeTN with linear chain topology.
     /// Node names are usize (0, 1, 2, ...) representing site indices.
-    pub(crate) treetn: TreeTN<TensorDynLen, usize>,
+    pub(crate) treetn: TreeTN<IdxTensor, usize>,
     /// The canonical form used (if known).
     canonical_form: Option<CanonicalForm>,
 }
@@ -173,10 +173,10 @@ impl TensorTrain {
     /// /// its neighbors (a shape mismatch) or the chain is structurally
     /// /// inconsistent (an invalid-state failure).
     ///
-    pub fn new(tensors: Vec<TensorDynLen>) -> Result<Self> {
+    pub fn new(tensors: Vec<IdxTensor>) -> Result<Self> {
         if tensors.is_empty() {
             // Create an empty TreeTN
-            let treetn = TreeTN::<TensorDynLen, usize>::new();
+            let treetn = TreeTN::<IdxTensor, usize>::new();
             return Ok(Self {
                 treetn,
                 canonical_form: None,
@@ -215,7 +215,7 @@ impl TensorTrain {
 
         // Create TreeTN with from_tensors (auto-connects by shared index IDs)
         let treetn =
-            TreeTN::<TensorDynLen, usize>::from_tensors(tensors, node_names).map_err(|e| {
+            TreeTN::<IdxTensor, usize>::from_tensors(tensors, node_names).map_err(|e| {
                 TensorTrainError::InvalidStructure {
                     message: format!("Failed to create TreeTN: {}", e),
                 }
@@ -244,7 +244,7 @@ impl TensorTrain {
     /// /// out of bounds failure) or orthogonalization fails.
     ///
     pub fn with_ortho(
-        tensors: Vec<TensorDynLen>,
+        tensors: Vec<IdxTensor>,
         llim: i32,
         rlim: i32,
         canonical_form: Option<CanonicalForm>,
@@ -270,7 +270,7 @@ impl TensorTrain {
     ///
     /// This is a crate-internal constructor used by `contract` and `linsolve`.
     pub(crate) fn from_inner(
-        treetn: TreeTN<TensorDynLen, usize>,
+        treetn: TreeTN<IdxTensor, usize>,
         canonical_form: Option<CanonicalForm>,
     ) -> Result<Self> {
         let mut node_names = treetn.node_names();
@@ -305,7 +305,7 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     /// use tensor4all_treetn::TreeTN;
     ///
@@ -313,8 +313,8 @@ impl TensorTrain {
     /// let site0 = DynIndex::new_dyn(2);
     /// let link = DynIndex::new_bond(1)?;
     /// let site1 = DynIndex::new_dyn(2);
-    /// let t0 = TensorDynLen::from_dense(vec![site0, link.clone()], vec![1.0, 0.0])?;
-    /// let t1 = TensorDynLen::from_dense(vec![link, site1], vec![2.0, 0.0])?;
+    /// let t0 = IdxTensor::from_dense(vec![site0, link.clone()], vec![1.0, 0.0])?;
+    /// let t1 = IdxTensor::from_dense(vec![link, site1], vec![2.0, 0.0])?;
     /// let tree = TreeTN::from_tensors(vec![t0, t1], vec![0usize, 1usize])?;
     ///
     /// let tt = TensorTrain::from_treetn(tree)?;
@@ -329,7 +329,7 @@ impl TensorTrain {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_treetn(treetn: TreeTN<TensorDynLen, usize>) -> Result<Self> {
+    pub fn from_treetn(treetn: TreeTN<IdxTensor, usize>) -> Result<Self> {
         Self::from_inner(treetn, None)
     }
 
@@ -342,12 +342,12 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let site = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![site], vec![1.0, 2.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![site], vec![1.0, 2.0])?;
     /// let tt = TensorTrain::new(vec![tensor])?;
     ///
     /// let tree = tt.into_treetn();
@@ -355,14 +355,14 @@ impl TensorTrain {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn into_treetn(self) -> TreeTN<TensorDynLen, usize> {
+    pub fn into_treetn(self) -> TreeTN<IdxTensor, usize> {
         self.treetn
     }
 
     /// Get a reference to the underlying TreeTN.
     ///
     /// This is a crate-internal accessor used by `contract` and `linsolve`.
-    pub(crate) fn as_treetn(&self) -> &TreeTN<TensorDynLen, usize> {
+    pub(crate) fn as_treetn(&self) -> &TreeTN<IdxTensor, usize> {
         &self.treetn
     }
 
@@ -484,7 +484,7 @@ impl TensorTrain {
     ///
     /// Returns an error when `site` is out of range (an out of bounds failure).
     ///
-    pub fn tensor(&self, site: usize) -> Result<&TensorDynLen> {
+    pub fn tensor(&self, site: usize) -> Result<&IdxTensor> {
         self.tensor_checked(site)
     }
 
@@ -494,7 +494,7 @@ impl TensorTrain {
     ///
     /// Returns an error when `site` is out of range (an out of bounds failure).
     ///
-    pub fn tensor_checked(&self, site: usize) -> Result<&TensorDynLen> {
+    pub fn tensor_checked(&self, site: usize) -> Result<&IdxTensor> {
         if site >= self.len() {
             return Err(TensorTrainError::SiteOutOfBounds {
                 site,
@@ -523,7 +523,7 @@ impl TensorTrain {
     ///
     /// Returns an error when `site` is out of range (an out of bounds failure).
     ///
-    pub fn tensor_mut(&mut self, site: usize) -> Result<&mut TensorDynLen> {
+    pub fn tensor_mut(&mut self, site: usize) -> Result<&mut IdxTensor> {
         self.tensor_mut_checked(site)
     }
 
@@ -536,20 +536,20 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_core::{DynId, Index, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// let s0 = Index::new_with_size(DynId(0), 2);
     /// let link = Index::new_with_size(DynId(1), 3);
     /// let s1 = Index::new_with_size(DynId(2), 2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![link, s1], vec![2.0; 6]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![link, s1], vec![2.0; 6]).unwrap();
     /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
     /// assert_eq!(tt.tensor_mut_checked(0).unwrap().indices()[0], s0);
     /// assert!(tt.tensor_mut_checked(2).is_err());
     /// ```
-    pub fn tensor_mut_checked(&mut self, site: usize) -> Result<&mut TensorDynLen> {
+    pub fn tensor_mut_checked(&mut self, site: usize) -> Result<&mut IdxTensor> {
         if site >= self.len() {
             return Err(TensorTrainError::SiteOutOfBounds {
                 site,
@@ -570,7 +570,7 @@ impl TensorTrain {
 
     /// Get a reference to all tensors.
     #[inline]
-    pub fn tensors(&self) -> Vec<&TensorDynLen> {
+    pub fn tensors(&self) -> Vec<&IdxTensor> {
         (0..self.len())
             .filter_map(|site| {
                 let node_idx = self.treetn.node_index(&site)?;
@@ -591,7 +591,7 @@ impl TensorTrain {
     /// Returns an error when the operation fails (a shape or index mismatch, or
     /// /// a backend failure).
     ///
-    pub fn tensors_mut(&mut self) -> Result<Vec<&mut TensorDynLen>> {
+    pub fn tensors_mut(&mut self) -> Result<Vec<&mut IdxTensor>> {
         self.tensors_mut_checked()
     }
 
@@ -605,14 +605,14 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_core::{DynId, Index, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// let s0 = Index::new_with_size(DynId(0), 2);
     /// let link = Index::new_with_size(DynId(1), 3);
     /// let s1 = Index::new_with_size(DynId(2), 2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0, link.clone()], vec![1.0; 6]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![link, s1], vec![2.0; 6]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0, link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![link, s1], vec![2.0; 6]).unwrap();
     /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
     /// let tensors = tt.tensors_mut_checked().unwrap();
@@ -620,7 +620,7 @@ impl TensorTrain {
     /// assert_eq!(tensors[0].indices().len(), 2);
     /// assert_eq!(tensors[1].indices().len(), 2);
     /// ```
-    pub fn tensors_mut_checked(&mut self) -> Result<Vec<&mut TensorDynLen>> {
+    pub fn tensors_mut_checked(&mut self) -> Result<Vec<&mut IdxTensor>> {
         let length = self.len();
         let node_indices: Vec<_> = (0..length)
             .map(|site| {
@@ -636,7 +636,7 @@ impl TensorTrain {
                     message: format!("missing tensor storage for site {site}"),
                 }
             })?;
-            tensor_ptrs.push(tensor as *mut TensorDynLen);
+            tensor_ptrs.push(tensor as *mut IdxTensor);
         }
 
         // SAFETY: TensorTrain site names are unique, so each site resolves to a
@@ -801,14 +801,15 @@ impl TensorTrain {
             }
 
             let link = DynIndex::new_dyn(1);
-            let left_link =
-                <TensorDynLen as TensorConstructionLike>::ones(std::slice::from_ref(&link))
-                    .map_err(|e| {
-                        TensorTrainError::operation_source(
-                            "failed to build implicit unit link tensor",
-                            anyhow::Error::new(e),
-                        )
-                    })?;
+            let left_link = <IdxTensor as TensorConstructionLike>::ones(std::slice::from_ref(
+                &link,
+            ))
+            .map_err(|e| {
+                TensorTrainError::operation_source(
+                    "failed to build implicit unit link tensor",
+                    anyhow::Error::new(e),
+                )
+            })?;
             tensors[site] = tensors[site].outer_product(&left_link).map_err(|e| {
                 TensorTrainError::operation_source(
                     "failed to attach implicit unit link",
@@ -816,13 +817,12 @@ impl TensorTrain {
                 )
             })?;
 
-            let right_link =
-                <TensorDynLen as TensorConstructionLike>::ones(&[link]).map_err(|e| {
-                    TensorTrainError::operation_source(
-                        "failed to build implicit unit link tensor",
-                        anyhow::Error::new(e),
-                    )
-                })?;
+            let right_link = <IdxTensor as TensorConstructionLike>::ones(&[link]).map_err(|e| {
+                TensorTrainError::operation_source(
+                    "failed to build implicit unit link tensor",
+                    anyhow::Error::new(e),
+                )
+            })?;
             tensors[site + 1] = tensors[site + 1].outer_product(&right_link).map_err(|e| {
                 TensorTrainError::operation_source(
                     "failed to attach implicit unit link",
@@ -961,7 +961,7 @@ impl TensorTrain {
     /// Replace the tensor at the given site.
     ///
     /// This invalidates orthogonality tracking.
-    fn set_tensor_raw(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
+    fn set_tensor_raw(&mut self, site: usize, tensor: IdxTensor) -> Result<()> {
         let node_idx =
             self.treetn
                 .node_index(&site)
@@ -989,21 +989,21 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_core::{DynId, Index, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// let s0 = Index::new_with_size(DynId(0), 2);
     /// let link = Index::new_with_size(DynId(1), 3);
     /// let s1 = Index::new_with_size(DynId(2), 2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![link.clone(), s1], vec![2.0; 6]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![link.clone(), s1], vec![2.0; 6]).unwrap();
     /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
-    /// let replacement = TensorDynLen::from_dense(vec![s0, link], vec![3.0; 6]).unwrap();
+    /// let replacement = IdxTensor::from_dense(vec![s0, link], vec![3.0; 6]).unwrap();
     /// tt.set_tensor(0, replacement).unwrap();
     /// assert_eq!(tt.tensor(0).unwrap().to_vec::<f64>().unwrap(), vec![3.0; 6]);
     /// ```
-    pub fn set_tensor(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
+    pub fn set_tensor(&mut self, site: usize, tensor: IdxTensor) -> Result<()> {
         self.set_tensor_checked(site, tensor)
     }
 
@@ -1019,21 +1019,21 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_core::{DynId, Index, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// let s0 = Index::new_with_size(DynId(0), 2);
     /// let link = Index::new_with_size(DynId(1), 3);
     /// let s1 = Index::new_with_size(DynId(2), 2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![link.clone(), s1], vec![2.0; 6]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), link.clone()], vec![1.0; 6]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![link.clone(), s1], vec![2.0; 6]).unwrap();
     /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
-    /// let replacement = TensorDynLen::from_dense(vec![s0, link], vec![4.0; 6]).unwrap();
+    /// let replacement = IdxTensor::from_dense(vec![s0, link], vec![4.0; 6]).unwrap();
     /// tt.set_tensor_checked(0, replacement).unwrap();
     /// assert!(tt.set_tensor_checked(2, tt.tensor(0).unwrap().clone()).is_err());
     /// ```
-    pub fn set_tensor_checked(&mut self, site: usize, tensor: TensorDynLen) -> Result<()> {
+    pub fn set_tensor_checked(&mut self, site: usize, tensor: IdxTensor) -> Result<()> {
         self.set_tensor_raw(site, tensor)?;
         // Invalidate orthogonality
         self.treetn
@@ -1061,17 +1061,17 @@ impl TensorTrain {
     ///
     /// ```
     /// use tensor4all_itensorlike::TensorTrain;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, Index, DynId};
+    /// use tensor4all_core::{DynIndex, IdxTensor, Index, DynId};
     ///
     /// let s0 = Index::new_with_size(DynId(0), 2);
     /// let link = Index::new_with_size(DynId(1), 3);
     /// let s1 = Index::new_with_size(DynId(2), 2);
     ///
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), link.clone()],
     ///     (0..6).map(|i| i as f64).collect(),
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![link.clone(), s1.clone()],
     ///     (0..6).map(|i| i as f64).collect(),
     /// ).unwrap();
@@ -1143,7 +1143,7 @@ impl TensorTrain {
     ///
     /// ```
     /// use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
-    /// use tensor4all_core::{DynIndex, TensorDynLen, Index, DynId};
+    /// use tensor4all_core::{DynIndex, IdxTensor, Index, DynId};
     ///
     /// // Build a 3-site tensor train with bond dimension 4
     /// let s0 = Index::new_with_size(DynId(0), 2);
@@ -1152,15 +1152,15 @@ impl TensorTrain {
     /// let l12 = Index::new_with_size(DynId(3), 4);
     /// let s2 = Index::new_with_size(DynId(4), 2);
     ///
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), l01.clone()],
     ///     (0..8).map(|i| i as f64).collect(),
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![l01.clone(), s1.clone(), l12.clone()],
     ///     (0..32).map(|i| i as f64).collect(),
     /// ).unwrap();
-    /// let t2 = TensorDynLen::from_dense(
+    /// let t2 = IdxTensor::from_dense(
     ///     vec![l12.clone(), s2.clone()],
     ///     (0..8).map(|i| i as f64).collect(),
     /// ).unwrap();
@@ -1220,11 +1220,11 @@ impl TensorTrain {
     ///
     /// ```
     /// use tensor4all_itensorlike::TensorTrain;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, Index, DynId, AnyScalar};
+    /// use tensor4all_core::{DynIndex, IdxTensor, Index, DynId, AnyScalar};
     ///
     /// // Single-site tensor train with values [1.0, 0.0]
     /// let s0 = Index::new_with_size(DynId(0), 2);
-    /// let t = TensorDynLen::from_dense(
+    /// let t = IdxTensor::from_dense(
     ///     vec![s0.clone()],
     ///     vec![1.0_f64, 0.0],
     /// ).unwrap();
@@ -1259,7 +1259,7 @@ impl TensorTrain {
                 other.treetn.sim_internal_inds()
             });
 
-        let node_idx = |ttn: &TreeTN<TensorDynLen, usize>, site: usize| {
+        let node_idx = |ttn: &TreeTN<IdxTensor, usize>, site: usize| {
             ttn.node_index(&site)
                 .ok_or_else(|| TensorTrainError::InvalidStructure {
                     message: format!("missing node for site {site}"),
@@ -1277,7 +1277,7 @@ impl TensorTrain {
                 })?;
             let b0 =
                 profile_tt_inner_section(profile_enabled, &mut profile.right_tensor_clone, || {
-                    Ok::<TensorDynLen, TensorTrainError>(
+                    Ok::<IdxTensor, TensorTrainError>(
                         other_sim
                             .tensor(b0_node)
                             .ok_or_else(|| TensorTrainError::InvalidStructure {
@@ -1385,11 +1385,11 @@ impl TensorTrain {
     /// # Examples
     /// ```
     /// # fn main() -> anyhow::Result<()> {
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// let site = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![site], vec![3.0_f64, 4.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![site], vec![3.0_f64, 4.0])?;
     /// let tt = TensorTrain::new(vec![tensor])?;
     /// assert!((tt.norm_squared()? - 25.0).abs() < 1e-12);
     /// # Ok(())
@@ -1403,8 +1403,8 @@ impl TensorTrain {
     /// so the returned value is clamped to be non-negative.
     pub fn norm_squared(&self) -> Result<f64> {
         match self.norm_squared_fast_path()? {
-            Some(value) if value.is_nan() => Err(TensorTrainError::TensorDynLen {
-                source: TensorDynLenError::NaNInput {
+            Some(value) if value.is_nan() => Err(TensorTrainError::IdxTensor {
+                source: IdxTensorError::NaNInput {
                     operation: "norm_squared",
                 },
             }),
@@ -1412,8 +1412,8 @@ impl TensorTrain {
             None => self.inner(self).and_then(|value| {
                 let value = value.real();
                 if value.is_nan() {
-                    Err(TensorTrainError::TensorDynLen {
-                        source: TensorDynLenError::NaNInput {
+                    Err(TensorTrainError::IdxTensor {
+                        source: IdxTensorError::NaNInput {
                             operation: "norm_squared",
                         },
                     })
@@ -1435,11 +1435,11 @@ impl TensorTrain {
     /// # Examples
     /// ```
     /// # fn main() -> anyhow::Result<()> {
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// let site = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![site], vec![3.0_f64, 4.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![site], vec![3.0_f64, 4.0])?;
     /// let tt = TensorTrain::new(vec![tensor])?;
     /// assert!((tt.norm()? - 5.0).abs() < 1e-12);
     /// # Ok(())
@@ -1596,15 +1596,15 @@ impl TensorTrain {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let s0 = DynIndex::new_dyn(2);
     /// let link = DynIndex::new_dyn(1);
     /// let s1 = DynIndex::new_dyn(2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), link.clone()], vec![1.0, 2.0])?;
-    /// let t1 = TensorDynLen::from_dense(vec![link.clone(), s1.clone()], vec![3.0, 4.0])?;
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), link.clone()], vec![1.0, 2.0])?;
+    /// let t1 = IdxTensor::from_dense(vec![link.clone(), s1.clone()], vec![3.0, 4.0])?;
     ///
     /// let tt = TensorTrain::new(vec![t0, t1])?;
     /// let dense = tt.to_dense()?;
@@ -1614,7 +1614,7 @@ impl TensorTrain {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn to_dense(&self) -> Result<TensorDynLen> {
+    pub fn to_dense(&self) -> Result<IdxTensor> {
         if self.is_empty() {
             return Err(TensorTrainError::InvalidStructure {
                 message: "Cannot convert empty tensor train to dense".to_string(),
@@ -1649,12 +1649,12 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let site = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![site], vec![-2.0, 3.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![site], vec![-2.0, 3.0])?;
     /// let tt = TensorTrain::new(vec![tensor])?;
     /// assert_eq!(tt.dense_maxabs()?, 3.0);
     /// # Ok(())
@@ -1663,7 +1663,7 @@ impl TensorTrain {
     pub fn dense_maxabs(&self) -> Result<f64> {
         self.to_dense()?
             .maxabs()
-            .map_err(|source| TensorTrainError::TensorDynLen { source })
+            .map_err(|source| TensorTrainError::IdxTensor { source })
     }
 
     /// Add two tensor trains using direct-sum construction.
@@ -1743,12 +1743,12 @@ impl TensorTrain {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynId, Index, TensorDynLen};
+    /// use tensor4all_core::{DynId, Index, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// fn one_site(id: u64, values: Vec<f64>) -> TensorTrain {
     ///     let site = Index::new_with_size(DynId(id), 2);
-    ///     let tensor = TensorDynLen::from_dense(vec![site], values).unwrap();
+    ///     let tensor = IdxTensor::from_dense(vec![site], values).unwrap();
     ///     TensorTrain::new(vec![tensor]).unwrap()
     /// }
     ///
@@ -1815,12 +1815,12 @@ impl TensorTrain {
     ///
     /// # Example
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
     /// use tensor4all_itensorlike::TensorTrain;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let s0 = DynIndex::new_dyn(2);
-    /// let tt = TensorTrain::new(vec![TensorDynLen::from_dense(
+    /// let tt = TensorTrain::new(vec![IdxTensor::from_dense(
     ///     vec![s0.clone()],
     ///     vec![1.0, 2.0],
     /// )?])?;
@@ -2058,7 +2058,7 @@ impl TensorConstructionLike for TensorTrain {
         output: &Self::Index,
     ) -> std::result::Result<Self, Self::Error> {
         // Create a single-site TensorTrain with an identity tensor
-        let delta = TensorDynLen::diagonal(input, output)?;
+        let delta = IdxTensor::diagonal(input, output)?;
         Self::new(vec![delta])
     }
 
@@ -2068,12 +2068,12 @@ impl TensorConstructionLike for TensorTrain {
     }
 
     fn ones(indices: &[Self::Index]) -> std::result::Result<Self, Self::Error> {
-        let t = TensorDynLen::ones(indices)?;
+        let t = IdxTensor::ones(indices)?;
         Self::new(vec![t])
     }
 
     fn onehot(index_vals: &[(Self::Index, usize)]) -> std::result::Result<Self, Self::Error> {
-        let t = TensorDynLen::onehot(index_vals)?;
+        let t = IdxTensor::onehot(index_vals)?;
         Self::new(vec![t])
     }
 }

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 use tensor4all_core::{DynId, Index, LinearizationOrder, TensorContractionLike, TensorVectorSpace};
 
 /// Helper to create a simple tensor for testing
-fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.size()).collect();
     let size: usize = dims.iter().product();
     let data: Vec<f64> = (0..size).map(|i| i as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Helper to create a DynIndex
@@ -75,14 +75,14 @@ fn add_reindexed_like_self_aligns_site_indices_before_addition() {
     let rhs_link = idx(12, 2);
 
     let lhs = TensorTrain::new(vec![
-        TensorDynLen::from_dense(vec![i0.clone(), link.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
-        TensorDynLen::from_dense(vec![link.clone(), i1.clone()], vec![5.0, 6.0, 7.0, 8.0]).unwrap(),
+        IdxTensor::from_dense(vec![i0.clone(), link.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
+        IdxTensor::from_dense(vec![link.clone(), i1.clone()], vec![5.0, 6.0, 7.0, 8.0]).unwrap(),
     ])
     .unwrap();
     let rhs = TensorTrain::new(vec![
-        TensorDynLen::from_dense(vec![j0.clone(), rhs_link.clone()], vec![2.0, 3.0, 4.0, 5.0])
+        IdxTensor::from_dense(vec![j0.clone(), rhs_link.clone()], vec![2.0, 3.0, 4.0, 5.0])
             .unwrap(),
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![rhs_link.clone(), j1.clone()],
             vec![7.0, 11.0, 13.0, 17.0],
         )
@@ -890,7 +890,7 @@ fn test_tensors_mut_returns_all_sites_in_order() {
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
 
     let replacement =
-        TensorDynLen::from_dense(vec![s0, l01], vec![42.0; 6]).expect("valid replacement");
+        IdxTensor::from_dense(vec![s0, l01], vec![42.0; 6]).expect("valid replacement");
 
     {
         let mut tensors = tt.tensors_mut().unwrap();
@@ -915,7 +915,7 @@ fn test_tensors_mut_checked_returns_all_sites_in_order() {
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
 
     let replacement =
-        TensorDynLen::from_dense(vec![s0, l01], vec![42.0; 6]).expect("valid replacement");
+        IdxTensor::from_dense(vec![s0, l01], vec![42.0; 6]).expect("valid replacement");
 
     {
         let mut tensors = tt.tensors_mut_checked().unwrap();
@@ -1497,8 +1497,8 @@ fn tt_inner_profile_enabled_path_runs() {
         std::env::set_var("T4A_PROFILE_TT_INNER", "1");
     }
     let i = DynIndex::new_dyn(2);
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0, 4.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0, 4.0]).unwrap();
     let _ = super::contract_pair(&a, &b).unwrap();
     unsafe {
         std::env::remove_var("T4A_PROFILE_TT_INNER");

--- a/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
+++ b/crates/tensor4all-itensorlike/tests/bench_basic_ops.rs
@@ -2,7 +2,7 @@
 //! Run: cargo test --release -p tensor4all-itensorlike --test bench_basic_ops -- --nocapture
 
 use std::time::Instant;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 fn make_random_mps(n_sites: usize, d: usize, bond_dim: usize, seed: u64) -> TensorTrain {
@@ -27,7 +27,7 @@ fn make_random_mps(n_sites: usize, d: usize, bond_dim: usize, seed: u64) -> Tens
         };
         let size: usize = indices.iter().map(|idx| idx.dim()).product();
         let data: Vec<f64> = (0..size).map(|_| rng.random::<f64>() - 0.5).collect();
-        tensors.push(TensorDynLen::from_dense(indices, data).unwrap());
+        tensors.push(IdxTensor::from_dense(indices, data).unwrap());
         prev_bond = next_bond;
     }
     TensorTrain::new(tensors).unwrap()
@@ -66,7 +66,7 @@ fn make_random_mpo_pair(n_sites: usize, d: usize, bond_dim: usize) -> (TensorTra
                 };
                 let size: usize = indices.iter().map(|idx| idx.dim()).product();
                 let data: Vec<f64> = (0..size).map(|_| rng.random::<f64>() - 0.5).collect();
-                tensors.push(TensorDynLen::from_dense(indices, data).unwrap());
+                tensors.push(IdxTensor::from_dense(indices, data).unwrap());
                 prev_bond = next_bond;
             }
             TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-itensorlike/tests/bug_complex_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_complex_inner.rs
@@ -9,7 +9,7 @@
 //! ITensors.jl, which doesn't enforce a particular in-memory index ordering.
 
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::TensorTrain;
 
 fn c(re: f64, im: f64) -> Complex64 {
@@ -29,15 +29,15 @@ fn test_inner_wrong_with_nonstandard_index_order() {
 
     // Standard ordering: site 0 = [s0, b], site 1 = [b, s1] → PASSES
     let tt_std = TensorTrain::new(vec![
-        TensorDynLen::from_dense(vec![s0.clone(), b.clone()], data0.clone()).unwrap(),
-        TensorDynLen::from_dense(vec![b.clone(), s1.clone()], data1.clone()).unwrap(),
+        IdxTensor::from_dense(vec![s0.clone(), b.clone()], data0.clone()).unwrap(),
+        IdxTensor::from_dense(vec![b.clone(), s1.clone()], data1.clone()).unwrap(),
     ])
     .unwrap();
 
     // Non-standard ordering: site 1 = [s1, b] (site index first)
     let tt_ns = TensorTrain::new(vec![
-        TensorDynLen::from_dense(vec![s0.clone(), b.clone()], data0).unwrap(),
-        TensorDynLen::from_dense(vec![s1.clone(), b.clone()], data1).unwrap(),
+        IdxTensor::from_dense(vec![s0.clone(), b.clone()], data0).unwrap(),
+        IdxTensor::from_dense(vec![s1.clone(), b.clone()], data1).unwrap(),
     ])
     .unwrap();
 
@@ -124,9 +124,9 @@ fn test_inner_wrong_3site_nonstandard() {
 
     // Non-standard: [s0, b0], [s1, b0, b1], [s2, b1]
     let tt = TensorTrain::new(vec![
-        TensorDynLen::from_dense(vec![s0.clone(), b0.clone()], data0).unwrap(),
-        TensorDynLen::from_dense(vec![s1.clone(), b0.clone(), b1.clone()], data1).unwrap(),
-        TensorDynLen::from_dense(vec![s2.clone(), b1.clone()], data2).unwrap(),
+        IdxTensor::from_dense(vec![s0.clone(), b0.clone()], data0).unwrap(),
+        IdxTensor::from_dense(vec![s1.clone(), b0.clone(), b1.clone()], data1).unwrap(),
+        IdxTensor::from_dense(vec![s2.clone(), b1.clone()], data2).unwrap(),
     ])
     .unwrap();
 
@@ -192,8 +192,8 @@ fn test_inner_wrong_with_two_site_indices_per_site_nonstandard_order() {
     ];
 
     let tt = TensorTrain::new(vec![
-        TensorDynLen::from_dense(vec![s0_in, s0_out, b.clone()], data0).unwrap(),
-        TensorDynLen::from_dense(vec![s1_in, s1_out, b], data1).unwrap(),
+        IdxTensor::from_dense(vec![s0_in, s0_out, b.clone()], data0).unwrap(),
+        IdxTensor::from_dense(vec![s1_in, s1_out, b], data1).unwrap(),
     ])
     .unwrap();
 

--- a/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_bond_growth.rs
@@ -15,7 +15,7 @@
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain};
 
 /// Create a random MPO with specified bond dimension.
@@ -35,7 +35,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices).unwrap();
+        let tensor = IdxTensor::random::<f64, _>(rng, indices).unwrap();
         tensors.push(tensor);
     }
     TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -6,7 +6,7 @@
 //!
 //! This blocks using fit() for bubble computations in quanticsnegf-rs.
 
-use tensor4all_core::{factorize, DynIndex, FactorizeOptions, IndexLike, TensorDynLen};
+use tensor4all_core::{factorize, DynIndex, FactorizeOptions, IdxTensor, IndexLike};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Convert a column-major matrix buffer to quantics interleaved bit ordering.
@@ -55,7 +55,7 @@ fn create_function_2d_tt(
         all_sites.push(col_sites[i].clone());
     }
 
-    let big = TensorDynLen::from_dense(all_sites.clone(), quantics_data).unwrap();
+    let big = IdxTensor::from_dense(all_sites.clone(), quantics_data).unwrap();
     let opts = FactorizeOptions::qr().with_qr_rtol(0.0);
     let n_sites = all_sites.len();
     let mut remaining = big;
@@ -86,11 +86,11 @@ fn create_function_2d_tt(
 
 /// Diagonalize: replace index `s` with [s_new1, s_new2], non-zero when s_new1==s_new2.
 fn as_diagonal(
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
     s: &DynIndex,
     s_new1: &DynIndex,
     s_new2: &DynIndex,
-) -> TensorDynLen {
+) -> IdxTensor {
     let indices = tensor.indices();
     let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
     let dim = s.dim();
@@ -121,11 +121,11 @@ fn as_diagonal(
         }
         new_data[nf] = val;
     }
-    TensorDynLen::from_dense(new_indices, new_data).unwrap()
+    IdxTensor::from_dense(new_indices, new_data).unwrap()
 }
 
 /// Extract diagonal: keep only s==s_result, remove s_result index.
-fn extract_diagonal(tensor: &TensorDynLen, s: &DynIndex, s_result: &DynIndex) -> TensorDynLen {
+fn extract_diagonal(tensor: &IdxTensor, s: &DynIndex, s_result: &DynIndex) -> IdxTensor {
     let indices = tensor.indices();
     let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
     let s_pos = indices.iter().position(|idx| idx.id() == s.id()).unwrap();
@@ -166,7 +166,7 @@ fn extract_diagonal(tensor: &TensorDynLen, s: &DynIndex, s_result: &DynIndex) ->
         }
         new_data[nf] = val;
     }
-    TensorDynLen::from_dense(new_indices, new_data).unwrap()
+    IdxTensor::from_dense(new_indices, new_data).unwrap()
 }
 
 /// Element-wise product via diagonal embedding + TT contraction.

--- a/crates/tensor4all-itensorlike/tests/bug_norm_oom_large_tt.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_norm_oom_large_tt.rs
@@ -4,7 +4,7 @@
 //! `maxabs()` comparisons. They use local transfer-matrix references, structural
 //! assertions, and norm-based residuals instead.
 
-use tensor4all_core::defaults::tensordynlen::TensorDynLen;
+use tensor4all_core::defaults::idx_tensor::IdxTensor;
 use tensor4all_core::{AnyScalar, DynIndex, IndexLike};
 use tensor4all_itensorlike::TensorTrain;
 
@@ -17,17 +17,17 @@ fn make_tt(n_sites: usize) -> TensorTrain {
         if k == 0 {
             let bond_r = DynIndex::new_dyn(2);
             let t =
-                TensorDynLen::from_dense(vec![site_idx, bond_r], vec![1.0, 0.5, 0.3, 1.0]).unwrap();
+                IdxTensor::from_dense(vec![site_idx, bond_r], vec![1.0, 0.5, 0.3, 1.0]).unwrap();
             tensors.push(t);
         } else if k == n_sites - 1 {
             let bond_l = tensors[k - 1].indices().last().unwrap().clone();
             let t =
-                TensorDynLen::from_dense(vec![bond_l, site_idx], vec![1.0, 0.2, 0.7, 1.0]).unwrap();
+                IdxTensor::from_dense(vec![bond_l, site_idx], vec![1.0, 0.2, 0.7, 1.0]).unwrap();
             tensors.push(t);
         } else {
             let bond_l = tensors[k - 1].indices().last().unwrap().clone();
             let bond_r = DynIndex::new_dyn(2);
-            let t = TensorDynLen::from_dense(
+            let t = IdxTensor::from_dense(
                 vec![bond_l, site_idx, bond_r],
                 vec![1.0, 0.0, 0.5, 0.3, 0.0, 1.0, 0.2, 0.8],
             )

--- a/crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_zipup_inflated_bonds.rs
@@ -14,7 +14,7 @@
 //! requires bonddim=2 to represent exactly. truncate(rtol=1e-15) drops to
 //! bonddim=1, losing 15% of the function.
 
-use tensor4all_core::{AnyScalar, DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IndexLike};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// Create identity MPO with bond dim 1.
@@ -39,7 +39,7 @@ fn create_identity_mpo(row_indices: &[DynIndex], col_indices: &[DynIndex]) -> Te
         if i < nsites - 1 {
             indices.push(bonds[i].clone());
         }
-        tensors.push(TensorDynLen::from_dense(indices, data).unwrap());
+        tensors.push(IdxTensor::from_dense(indices, data).unwrap());
     }
     TensorTrain::new(tensors).unwrap()
 }
@@ -62,7 +62,7 @@ fn create_ones_mpo(row_indices: &[DynIndex], col_indices: &[DynIndex]) -> Tensor
             indices.push(bonds[i].clone());
         }
         let data = vec![1.0_f64; row_indices[i].dim() * col_indices[i].dim()];
-        tensors.push(TensorDynLen::from_dense(indices, data).unwrap());
+        tensors.push(IdxTensor::from_dense(indices, data).unwrap());
     }
     TensorTrain::new(tensors).unwrap()
 }

--- a/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
@@ -9,7 +9,7 @@
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain};
 
 const TEST_LENGTH: usize = 4;
@@ -33,7 +33,7 @@ fn create_random_mpo(
         if i < length - 1 {
             indices.push(link_indices[i].clone());
         }
-        let tensor = TensorDynLen::random::<f64, _>(rng, indices).unwrap();
+        let tensor = IdxTensor::random::<f64, _>(rng, indices).unwrap();
         tensors.push(tensor);
     }
     TensorTrain::new(tensors).unwrap()

--- a/crates/tensor4all-itensorlike/tests/linsolve_mpo.rs
+++ b/crates/tensor4all-itensorlike/tests/linsolve_mpo.rs
@@ -5,7 +5,7 @@
 //! it did not pass IndexMapping to the treetn solver.
 
 use num_complex::Complex64;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
 use tensor4all_itensorlike::{LinsolveOptions, TensorTrain};
 
 /// Build a 2-site identity MPO where input indices are the SAME objects
@@ -34,12 +34,11 @@ fn test_linsolve_identity_mpo_distinct_output_indices() {
     for i in 0..phys_dim {
         data0[i * phys_dim + i] = 1.0;
     }
-    let t0_mps = TensorDynLen::from_dense(vec![s0.clone(), b_mps.clone()], data0).unwrap();
+    let t0_mps = IdxTensor::from_dense(vec![s0.clone(), b_mps.clone()], data0).unwrap();
 
     // Site 1: [b_mps, s1] = values
     let t1_mps =
-        TensorDynLen::from_dense(vec![b_mps.clone(), s1.clone()], vec![1.0, 2.0, 3.0, 4.0])
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mps.clone(), s1.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     let rhs = TensorTrain::new(vec![t0_mps.clone(), t1_mps.clone()]).unwrap();
     let init = TensorTrain::new(vec![t0_mps, t1_mps]).unwrap();
@@ -52,7 +51,7 @@ fn test_linsolve_identity_mpo_distinct_output_indices() {
     for i in 0..phys_dim {
         id_data[i * phys_dim + i] = 1.0;
     }
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0.clone(), b_mpo.clone()],
         id_data.clone(),
     )
@@ -60,7 +59,7 @@ fn test_linsolve_identity_mpo_distinct_output_indices() {
 
     // Site 1: [b_mpo, s1_out, s1] - identity
     let t1_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1.clone()], id_data).unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1.clone()], id_data).unwrap();
 
     let operator = TensorTrain::new(vec![t0_mpo, t1_mpo]).unwrap();
 
@@ -91,7 +90,7 @@ fn test_linsolve_identity_mpo_accepts_complex_coefficients() {
     for i in 0..phys_dim {
         data0[i * phys_dim + i] = Complex64::new(1.0, 0.0);
     }
-    let t0_mps = TensorDynLen::from_dense(vec![s0.clone(), b_mps.clone()], data0).unwrap();
+    let t0_mps = IdxTensor::from_dense(vec![s0.clone(), b_mps.clone()], data0).unwrap();
 
     let rhs_values = vec![
         Complex64::new(1.0, 0.5),
@@ -100,11 +99,11 @@ fn test_linsolve_identity_mpo_accepts_complex_coefficients() {
         Complex64::new(0.5, 1.5),
     ];
     let t1_mps =
-        TensorDynLen::from_dense(vec![b_mps.clone(), s1.clone()], rhs_values.clone()).unwrap();
+        IdxTensor::from_dense(vec![b_mps.clone(), s1.clone()], rhs_values.clone()).unwrap();
     let rhs = TensorTrain::new(vec![t0_mps.clone(), t1_mps]).unwrap();
 
     let zero0 = t0_mps.scale(AnyScalar::new_real(0.0)).unwrap();
-    let zero1 = TensorDynLen::from_dense(
+    let zero1 = IdxTensor::from_dense(
         vec![b_mps.clone(), s1.clone()],
         vec![Complex64::new(0.0, 0.0); phys_dim * phys_dim],
     )
@@ -115,12 +114,12 @@ fn test_linsolve_identity_mpo_accepts_complex_coefficients() {
     for i in 0..phys_dim {
         id_data[i * phys_dim + i] = Complex64::new(1.0, 0.0);
     }
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
-    let t1_mpo = TensorDynLen::from_dense(vec![b_mpo, s1_out, s1.clone()], id_data).unwrap();
+    let t1_mpo = IdxTensor::from_dense(vec![b_mpo, s1_out, s1.clone()], id_data).unwrap();
     let operator = TensorTrain::new(vec![t0_mpo, t1_mpo]).unwrap();
 
     let options = LinsolveOptions::new(3)

--- a/crates/tensor4all-itensorlike/tests/panic_paths.rs
+++ b/crates/tensor4all-itensorlike/tests/panic_paths.rs
@@ -1,11 +1,11 @@
 use std::error::Error;
-use tensor4all_core::{DynIndex, TensorDynLen, TensorDynLenError};
+use tensor4all_core::{DynIndex, IdxTensor, IdxTensorError};
 use tensor4all_itensorlike::{TensorTrain, TensorTrainError};
 use tensor4all_treetn::TreeTN;
 
-fn site_tensor(size: usize, data: Vec<f64>) -> TensorDynLen {
+fn site_tensor(size: usize, data: Vec<f64>) -> IdxTensor {
     let site = DynIndex::new_dyn(size);
-    TensorDynLen::from_dense(vec![site], data).unwrap()
+    IdxTensor::from_dense(vec![site], data).unwrap()
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn inner_reports_length_mismatch() {
 
 #[test]
 fn to_dense_preserves_contraction_error_source() {
-    let mut tree = TreeTN::<TensorDynLen, usize>::new();
+    let mut tree = TreeTN::<IdxTensor, usize>::new();
     tree.add_tensor(0, site_tensor(2, vec![1.0, 2.0])).unwrap();
     tree.add_tensor(1, site_tensor(2, vec![3.0, 4.0])).unwrap();
     let tt = TensorTrain::from_treetn(tree).unwrap();
@@ -51,13 +51,13 @@ fn to_dense_preserves_contraction_error_source() {
 
 #[test]
 fn dense_maxabs_preserves_typed_tensor_error_source() {
-    let tt = TensorTrain::new(vec![TensorDynLen::scalar(f64::NAN).unwrap()]).unwrap();
+    let tt = TensorTrain::new(vec![IdxTensor::scalar(f64::NAN).unwrap()]).unwrap();
     let error = tt.dense_maxabs().unwrap_err();
 
     assert!(matches!(
         error,
-        TensorTrainError::TensorDynLen {
-            source: TensorDynLenError::NaNInput {
+        TensorTrainError::IdxTensor {
+            source: IdxTensorError::NaNInput {
                 operation: "maxabs"
             }
         }

--- a/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
@@ -1,7 +1,7 @@
 //! Tests for TensorTrain inner product operations
 
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_itensorlike::TensorTrain;
 
 /// Test inner product of empty tensor trains
@@ -22,14 +22,14 @@ fn test_inner_single_site() {
     let link_right = Index::new_dyn(1);
 
     // Create [1, 0] as tensor with shape [1, 2, 1]
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![link_left.clone(), site.clone(), link_right.clone()],
         vec![1.0, 0.0],
     )
     .unwrap();
 
     // Create [0, 1] as tensor with shape [1, 2, 1]
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![link_left.clone(), site.clone(), link_right.clone()],
         vec![0.0, 1.0],
     )

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
@@ -9,7 +9,7 @@ use std::collections::{HashSet, VecDeque};
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use tensor4all_core::{DynIndex, TensorDynLen, TensorElement};
+use tensor4all_core::{DynIndex, IdxTensor, TensorElement};
 use tensor4all_itensorlike::TensorTrain;
 use tensor4all_simplett::{tensor3_from_data, SimpleTensorTrain, TTScalar};
 use tensor4all_tcicore::{MatrixLuciScalar, MultiIndex, Scalar};
@@ -561,7 +561,7 @@ where
 }
 
 fn embed_active_tt<T>(
-    active_tree: TreeTN<TensorDynLen, usize>,
+    active_tree: TreeTN<IdxTensor, usize>,
     site_indices: &[DynIndex],
     active_positions: &[usize],
     projector: &Projector,
@@ -625,7 +625,7 @@ where
                 indices.push(index.clone());
             }
             tensors.push(
-                TensorDynLen::from_dense(indices, core.clone()).map_err(|error| {
+                IdxTensor::from_dense(indices, core.clone()).map_err(|error| {
                     PartitionedTTError::tensor_train_operation(error.to_string())
                 })?,
             );
@@ -655,19 +655,15 @@ fn projected_site_tensor<T>(
     right: Option<&DynIndex>,
     value: usize,
     scale: T,
-) -> Result<TensorDynLen>
+) -> Result<IdxTensor>
 where
     T: Scalar + TensorElement + StorageScalar + Default + Copy,
 {
     match (left, right) {
-        (Some(left), Some(right)) => TensorDynLen::from_copy_selector(
-            left.clone(),
-            site.clone(),
-            right.clone(),
-            value,
-            scale,
-        )
-        .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string())),
+        (Some(left), Some(right)) => {
+            IdxTensor::from_copy_selector(left.clone(), site.clone(), right.clone(), value, scale)
+                .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))
+        }
         (None, Some(right)) => {
             if right.dim != 1 {
                 return Err(PartitionedTTError::tensor_train_operation(format!(
@@ -677,7 +673,7 @@ where
             }
             let mut data = vec![T::zero(); site.dim];
             data[value] = scale;
-            TensorDynLen::from_dense(vec![site.clone(), right.clone()], data)
+            IdxTensor::from_dense(vec![site.clone(), right.clone()], data)
                 .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))
         }
         (Some(left), None) => {
@@ -689,13 +685,13 @@ where
             }
             let mut data = vec![T::zero(); site.dim];
             data[value] = scale;
-            TensorDynLen::from_dense(vec![left.clone(), site.clone()], data)
+            IdxTensor::from_dense(vec![left.clone(), site.clone()], data)
                 .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))
         }
         (None, None) => {
             let mut data = vec![T::zero(); site.dim];
             data[value] = scale;
-            TensorDynLen::from_dense(vec![site.clone()], data)
+            IdxTensor::from_dense(vec![site.clone()], data)
                 .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))
         }
     }
@@ -735,9 +731,9 @@ where
                 indices.push(index.clone());
             }
             tensors.push(
-                TensorDynLen::from_dense(indices, vec![local_scale; site.dim]).map_err(
-                    |error| PartitionedTTError::tensor_train_operation(error.to_string()),
-                )?,
+                IdxTensor::from_dense(indices, vec![local_scale; site.dim]).map_err(|error| {
+                    PartitionedTTError::tensor_train_operation(error.to_string())
+                })?,
             );
         }
     }

--- a/crates/tensor4all-partitionedtt/src/contract.rs
+++ b/crates/tensor4all-partitionedtt/src/contract.rs
@@ -24,16 +24,16 @@ use tensor4all_itensorlike::ContractOptions;
 /// # Examples
 ///
 /// ```
-/// use tensor4all_partitionedtt::{contract, DynIndex, SubDomainTT, TensorDynLen, TensorTrain};
+/// use tensor4all_partitionedtt::{contract, DynIndex, SubDomainTT, IdxTensor, TensorTrain};
 /// use tensor4all_itensorlike::ContractOptions;
 ///
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(2);
 /// let left = SubDomainTT::from_tt(TensorTrain::new(vec![
-///     TensorDynLen::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap(),
+///     IdxTensor::from_dense(vec![i], vec![1.0_f64, 2.0]).unwrap(),
 /// ]).unwrap());
 /// let right = SubDomainTT::from_tt(TensorTrain::new(vec![
-///     TensorDynLen::from_dense(vec![j], vec![3.0_f64, 4.0]).unwrap(),
+///     IdxTensor::from_dense(vec![j], vec![3.0_f64, 4.0]).unwrap(),
 /// ]).unwrap());
 ///
 /// assert!(contract(&left, &right, &ContractOptions::default()).unwrap().is_some());
@@ -59,15 +59,15 @@ pub fn contract(
 /// # Examples
 ///
 /// ```
-/// use tensor4all_partitionedtt::{proj_contract, DynIndex, Projector, SubDomainTT, TensorDynLen, TensorTrain};
+/// use tensor4all_partitionedtt::{proj_contract, DynIndex, Projector, SubDomainTT, IdxTensor, TensorTrain};
 /// use tensor4all_itensorlike::ContractOptions;
 ///
 /// let i = DynIndex::new_dyn(2);
 /// let left = SubDomainTT::from_tt(TensorTrain::new(vec![
-///     TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap(),
+///     IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap(),
 /// ]).unwrap());
 /// let right = SubDomainTT::from_tt(TensorTrain::new(vec![
-///     TensorDynLen::from_dense(vec![i], vec![3.0_f64, 4.0]).unwrap(),
+///     IdxTensor::from_dense(vec![i], vec![3.0_f64, 4.0]).unwrap(),
 /// ]).unwrap());
 /// let projector = Projector::from_pairs([(left.all_indices()[0].clone(), 0)]);
 ///

--- a/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use num_complex::Complex64;
 use tensor4all_core::index::Index;
-use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen, TensorElement};
+use tensor4all_core::{DynIndex, IdxTensor, TensorContractionLike, TensorElement};
 use tensor4all_itensorlike::TensorTrain;
 
 /// Trait for scalar types used in tests.
@@ -14,7 +14,7 @@ trait TestScalar: TensorElement + From<f64> + std::ops::Sub<Output = Self> + std
     fn zero_val() -> Self;
 
     /// Extract dense data from tensor.
-    fn extract_slice(tensor: &TensorDynLen) -> Vec<Self>;
+    fn extract_slice(tensor: &IdxTensor) -> Vec<Self>;
 }
 
 impl TestScalar for f64 {
@@ -26,7 +26,7 @@ impl TestScalar for f64 {
         0.0
     }
 
-    fn extract_slice(tensor: &TensorDynLen) -> Vec<Self> {
+    fn extract_slice(tensor: &IdxTensor) -> Vec<Self> {
         tensor.to_vec::<f64>().unwrap()
     }
 }
@@ -40,7 +40,7 @@ impl TestScalar for Complex64 {
         Complex64::new(0.0, 0.0)
     }
 
-    fn extract_slice(tensor: &TensorDynLen) -> Vec<Self> {
+    fn extract_slice(tensor: &IdxTensor) -> Vec<Self> {
         tensor.to_vec::<Complex64>().unwrap()
     }
 }
@@ -50,11 +50,11 @@ fn make_index(size: usize) -> DynIndex {
 }
 
 /// Create a tensor with generic scalar type
-fn make_tensor_generic<T: TestScalar>(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor_generic<T: TestScalar>(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.dim).collect();
     let size: usize = dims.iter().product();
     let data: Vec<T> = (0..size).map(|i| T::from((i + 1) as f64)).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Create indices for testing TT contraction
@@ -86,10 +86,10 @@ fn naive_reference_options() -> ContractOptions {
 }
 
 fn project_dense_tensor_at_index<T: TestScalar>(
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
     index: &DynIndex,
     projected_value: usize,
-) -> TensorDynLen {
+) -> IdxTensor {
     let indices = tensor.indices().to_vec();
     let axis = indices
         .iter()
@@ -108,7 +108,7 @@ fn project_dense_tensor_at_index<T: TestScalar>(
         }
     }
 
-    TensorDynLen::from_dense(indices, projected_data).unwrap()
+    IdxTensor::from_dense(indices, projected_data).unwrap()
 }
 
 #[test]

--- a/crates/tensor4all-partitionedtt/src/lib.rs
+++ b/crates/tensor4all-partitionedtt/src/lib.rs
@@ -31,7 +31,7 @@ pub use projector::Projector;
 pub use subdomain_tt::SubDomainTT;
 
 // Re-export commonly used types from dependencies
-pub use tensor4all_core::{DynIndex, TensorDynLen};
+pub use tensor4all_core::{DynIndex, IdxTensor};
 pub use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 pub use tensor4all_tcicore::MultiIndex;
 pub use tensor4all_tensorci::TCI2Options;

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -21,12 +21,12 @@ use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 ///
 /// ```
 /// use tensor4all_partitionedtt::{PartitionedTT, Projector, SubDomainTT, TensorTrain};
-/// use tensor4all_partitionedtt::{DynIndex, TensorDynLen};
+/// use tensor4all_partitionedtt::{DynIndex, IdxTensor};
 /// use tensor4all_core::index::Index;
 ///
 /// fn make_tt(s0: &DynIndex, bond: &DynIndex, s1: &DynIndex) -> TensorTrain {
-///     let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
-///     let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![3.0, 4.0]).unwrap();
+///     let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
+///     let t1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![3.0, 4.0]).unwrap();
 ///     TensorTrain::new(vec![t0, t1]).unwrap()
 /// }
 ///
@@ -80,14 +80,14 @@ impl PartitionedTT {
     ///
     /// ```
     /// use tensor4all_partitionedtt::{PartitionedTT, Projector, SubDomainTT, TensorTrain};
-    /// use tensor4all_partitionedtt::{DynIndex, TensorDynLen};
+    /// use tensor4all_partitionedtt::{DynIndex, IdxTensor};
     /// use tensor4all_core::index::Index;
     ///
     /// let s0 = Index::new_dyn(2);
     /// let bond = Index::new_dyn(1);
     /// let s1 = Index::new_dyn(2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![3.0, 4.0]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![3.0, 4.0]).unwrap();
     /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
     /// // Two disjoint patches: s0=0 and s0=1
@@ -152,14 +152,14 @@ impl PartitionedTT {
     ///
     /// ```
     /// use tensor4all_partitionedtt::{PartitionedTT, Projector, SubDomainTT, TensorTrain};
-    /// use tensor4all_partitionedtt::{DynIndex, TensorDynLen};
+    /// use tensor4all_partitionedtt::{DynIndex, IdxTensor};
     /// use tensor4all_core::index::Index;
     ///
     /// let s0 = Index::new_dyn(2);
     /// let bond = Index::new_dyn(1);
     /// let s1 = Index::new_dyn(2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![3.0, 4.0]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![3.0, 4.0]).unwrap();
     /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
     /// let proj = Projector::from_pairs([(s0.clone(), 0)]);
@@ -240,14 +240,14 @@ impl PartitionedTT {
     ///
     /// ```
     /// use tensor4all_partitionedtt::{PartitionedTT, Projector, SubDomainTT, TensorTrain};
-    /// use tensor4all_partitionedtt::{DynIndex, TensorDynLen};
+    /// use tensor4all_partitionedtt::{DynIndex, IdxTensor};
     /// use tensor4all_core::index::Index;
     ///
     /// let s0 = Index::new_dyn(2);
     /// let bond = Index::new_dyn(1);
     /// let s1 = Index::new_dyn(2);
-    /// let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 0.0]).unwrap();
-    /// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0]).unwrap();
+    /// let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0, 0.0]).unwrap();
+    /// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0]).unwrap();
     /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
     /// let proj = Projector::from_pairs([(s0, 0)]);

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
@@ -1,17 +1,17 @@
 use super::*;
 use tensor4all_core::index::Index;
-use tensor4all_core::{TensorContractionLike, TensorDynLen};
+use tensor4all_core::{IdxTensor, TensorContractionLike};
 use tensor4all_itensorlike::TensorTrainError;
 
 fn make_index(size: usize) -> DynIndex {
     Index::new_dyn(size)
 }
 
-fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.dim).collect();
     let size: usize = dims.iter().product();
     let data: Vec<f64> = (0..size).map(|i| (i + 1) as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Create shared indices for testing
@@ -175,10 +175,10 @@ fn make_tt2(s1: &DynIndex, l12: &DynIndex, s2: &DynIndex) -> TensorTrain {
 }
 
 fn project_dense_tensor_at_index(
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
     index: &DynIndex,
     projected_value: usize,
-) -> TensorDynLen {
+) -> IdxTensor {
     let indices = tensor.indices().to_vec();
     let axis = indices
         .iter()
@@ -197,7 +197,7 @@ fn project_dense_tensor_at_index(
         }
     }
 
-    TensorDynLen::from_dense(indices, projected_data).unwrap()
+    IdxTensor::from_dense(indices, projected_data).unwrap()
 }
 
 #[test]

--- a/crates/tensor4all-partitionedtt/src/patching.rs
+++ b/crates/tensor4all-partitionedtt/src/patching.rs
@@ -118,18 +118,18 @@ impl Default for PatchingOptions {
 /// ```
 /// use tensor4all_core::index::Index;
 /// use tensor4all_partitionedtt::{
-///     add_with_patching, PatchingOptions, SubDomainTT, TensorDynLen, TensorTrain,
+///     add_with_patching, PatchingOptions, SubDomainTT, IdxTensor, TensorTrain,
 /// };
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let s0 = Index::new_dyn(2);
 /// let bond = Index::new_dyn(3);
 /// let s1 = Index::new_dyn(2);
-/// let t0 = TensorDynLen::from_dense(
+/// let t0 = IdxTensor::from_dense(
 ///     vec![s0.clone(), bond.clone()],
 ///     (1..=6).map(f64::from).collect(),
 /// )?;
-/// let t1 = TensorDynLen::from_dense(vec![bond, s1], (1..=6).map(f64::from).collect())?;
+/// let t1 = IdxTensor::from_dense(vec![bond, s1], (1..=6).map(f64::from).collect())?;
 /// let tt = TensorTrain::new(vec![t0, t1])?;
 /// let options = PatchingOptions {
 ///     rtol: 1e-12,
@@ -227,7 +227,7 @@ pub fn add_with_patching(
 /// use tensor4all_core::index::Index;
 /// use tensor4all_partitionedtt::{
 ///     contract_adaptive, ContractOptions, PartitionedTT, PatchSplitStrategy, PatchingOptions,
-///     SubDomainTT, TensorDynLen, TensorTrain,
+///     SubDomainTT, IdxTensor, TensorTrain,
 /// };
 ///
 /// # fn three_site_tt(
@@ -237,12 +237,12 @@ pub fn add_with_patching(
 /// #     l12: &tensor4all_partitionedtt::DynIndex,
 /// #     s2: &tensor4all_partitionedtt::DynIndex,
 /// # ) -> Result<TensorTrain, Box<dyn std::error::Error>> {
-/// #     let t0 = TensorDynLen::from_dense(vec![s0.clone(), l01.clone()], vec![1.0; 6])?;
-/// #     let t1 = TensorDynLen::from_dense(
+/// #     let t0 = IdxTensor::from_dense(vec![s0.clone(), l01.clone()], vec![1.0; 6])?;
+/// #     let t1 = IdxTensor::from_dense(
 /// #         vec![l01.clone(), s1.clone(), l12.clone()],
 /// #         vec![1.0; 18],
 /// #     )?;
-/// #     let t2 = TensorDynLen::from_dense(vec![l12.clone(), s2.clone()], vec![1.0; 6])?;
+/// #     let t2 = IdxTensor::from_dense(vec![l12.clone(), s2.clone()], vec![1.0; 6])?;
 /// #     Ok(TensorTrain::new(vec![t0, t1, t2])?)
 /// # }
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -317,7 +317,7 @@ pub fn contract_adaptive(
 /// ```
 /// use tensor4all_core::index::Index;
 /// use tensor4all_partitionedtt::{
-///     truncate_adaptive, PartitionedTT, Projector, SubDomainTT, TensorDynLen, TensorTrain,
+///     truncate_adaptive, PartitionedTT, Projector, SubDomainTT, IdxTensor, TensorTrain,
 /// };
 ///
 /// # fn rank_one_tt(
@@ -326,8 +326,8 @@ pub fn contract_adaptive(
 /// #     scale: f64,
 /// # ) -> Result<TensorTrain, Box<dyn std::error::Error>> {
 /// #     let bond = Index::new_dyn(1);
-/// #     let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![scale; s0.dim])?;
-/// #     let t1 = TensorDynLen::from_dense(vec![bond, s1.clone()], vec![1.0; s1.dim])?;
+/// #     let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![scale; s0.dim])?;
+/// #     let t1 = IdxTensor::from_dense(vec![bond, s1.clone()], vec![1.0; s1.dim])?;
 /// #     Ok(TensorTrain::new(vec![t0, t1])?)
 /// # }
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
@@ -2,18 +2,18 @@ use super::*;
 use crate::projector::Projector;
 use approx::assert_abs_diff_eq;
 use tensor4all_core::index::Index;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_itensorlike::{ContractOptions, TensorTrain};
 
 fn make_index(size: usize) -> DynIndex {
     Index::new_dyn(size)
 }
 
-fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.dim).collect();
     let size: usize = dims.iter().product();
     let data: Vec<f64> = (0..size).map(|i| (i + 1) as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Create shared indices for testing
@@ -33,12 +33,12 @@ fn make_tt_with_indices(site_inds: &[DynIndex], link_ind: &DynIndex) -> TensorTr
 
 fn make_scaled_rank_one_tt(site_inds: &[DynIndex], scale: f64) -> TensorTrain {
     let link = make_index(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![site_inds[0].clone(), link.clone()],
         vec![scale; site_inds[0].dim],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![link, site_inds[1].clone()],
         vec![1.0; site_inds[1].dim],
     )
@@ -53,14 +53,14 @@ fn make_selector_middle_site_tt() -> (TensorTrain, Vec<DynIndex>) {
     let l01 = make_index(2);
     let l12 = make_index(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), l01.clone()], vec![1.0; 8]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), l01.clone()], vec![1.0; 8]).unwrap();
     let mut center_data = vec![0.0; 8];
     for channel in 0..2 {
         let flat = channel + 2 * channel + 4 * channel;
         center_data[flat] = 1.0;
     }
-    let t1 = TensorDynLen::from_dense(vec![l01, s1.clone(), l12.clone()], center_data).unwrap();
-    let t2 = TensorDynLen::from_dense(vec![l12, s2.clone()], vec![1.0; 4]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![l01, s1.clone(), l12.clone()], center_data).unwrap();
+    let t2 = IdxTensor::from_dense(vec![l12, s2.clone()], vec![1.0; 4]).unwrap();
 
     (
         TensorTrain::new(vec![t0, t1, t2]).unwrap(),
@@ -77,8 +77,8 @@ fn make_overcomplete_rank_one_tt(site_inds: &[DynIndex], link_ind: &DynIndex) ->
     for (y, chunk) in right.chunks_exact_mut(link_ind.dim).enumerate() {
         chunk[0] = (y + 1) as f64;
     }
-    let t0 = TensorDynLen::from_dense(vec![site_inds[0].clone(), link_ind.clone()], left).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![link_ind.clone(), site_inds[1].clone()], right).unwrap();
+    let t0 = IdxTensor::from_dense(vec![site_inds[0].clone(), link_ind.clone()], left).unwrap();
+    let t1 = IdxTensor::from_dense(vec![link_ind.clone(), site_inds[1].clone()], right).unwrap();
     TensorTrain::new(vec![t0, t1]).unwrap()
 }
 

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 
 use crate::error::{PartitionedTTError, Result};
 use crate::projector::Projector;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen, TensorDynLenError};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, IdxTensorError};
 use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 
 /// A tensor train with an associated projector defining its subdomain.
@@ -18,14 +18,14 @@ use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 /// # Examples
 ///
 /// ```
-/// use tensor4all_partitionedtt::{DynIndex, Projector, SubDomainTT, TensorDynLen, TensorTrain};
+/// use tensor4all_partitionedtt::{DynIndex, Projector, SubDomainTT, IdxTensor, TensorTrain};
 ///
 /// let site0 = DynIndex::new_dyn(2);
 /// let bond = DynIndex::new_dyn(1);
 /// let site1 = DynIndex::new_dyn(2);
 ///
-/// let t0 = TensorDynLen::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
-/// let t1 = TensorDynLen::from_dense(vec![bond.clone(), site1.clone()], vec![3.0, 4.0]).unwrap();
+/// let t0 = IdxTensor::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 2.0]).unwrap();
+/// let t1 = IdxTensor::from_dense(vec![bond.clone(), site1.clone()], vec![3.0, 4.0]).unwrap();
 /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
 ///
 /// let projector = Projector::from_pairs([(site0.clone(), 1)]);
@@ -153,10 +153,10 @@ impl SubDomainTT {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_partitionedtt::{DynIndex, Projector, SubDomainTT, TensorDynLen, TensorTrain};
+    /// use tensor4all_partitionedtt::{DynIndex, Projector, SubDomainTT, IdxTensor, TensorTrain};
     ///
     /// let site = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![site.clone()], vec![3.0_f64, 4.0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0]).unwrap();
     /// let subdomain = SubDomainTT::from_tt(TensorTrain::new(vec![tensor]).unwrap());
     /// let projected = subdomain
     ///     .project(&Projector::from_pairs([(site.clone(), 1)]))
@@ -229,9 +229,9 @@ impl SubDomainTT {
         TensorTrain::new(new_tensors).map_err(|source| PartitionedTTError::TensorTrain { source })
     }
 
-    fn tensor_operation_error(error: TensorDynLenError) -> PartitionedTTError {
+    fn tensor_operation_error(error: IdxTensorError) -> PartitionedTTError {
         match error {
-            TensorDynLenError::Storage { source } => PartitionedTTError::TensorStorage { source },
+            IdxTensorError::Storage { source } => PartitionedTTError::TensorStorage { source },
             other => PartitionedTTError::TensorConstruction {
                 source: anyhow::Error::new(other),
             },
@@ -240,10 +240,10 @@ impl SubDomainTT {
 
     /// Project a single tensor by applying a backend-level one-hot mask.
     fn project_tensor_at_index(
-        tensor: &TensorDynLen,
+        tensor: &IdxTensor,
         index: &DynIndex,
         projected_value: usize,
-    ) -> Result<TensorDynLen> {
+    ) -> Result<IdxTensor> {
         if !tensor.indices().iter().any(|candidate| candidate == index) {
             return Err(PartitionedTTError::ProjectorIndexNotFound {
                 index: index.clone(),
@@ -316,16 +316,16 @@ impl SubDomainTT {
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_partitionedtt::{DynIndex, SubDomainTT, TensorDynLen, TensorTrain};
+    /// use tensor4all_partitionedtt::{DynIndex, SubDomainTT, IdxTensor, TensorTrain};
     /// use tensor4all_itensorlike::ContractOptions;
     ///
     /// let left_index = DynIndex::new_dyn(2);
     /// let right_index = DynIndex::new_dyn(2);
     /// let left = SubDomainTT::from_tt(TensorTrain::new(vec![
-    ///     TensorDynLen::from_dense(vec![left_index], vec![1.0_f64, 2.0]).unwrap(),
+    ///     IdxTensor::from_dense(vec![left_index], vec![1.0_f64, 2.0]).unwrap(),
     /// ]).unwrap());
     /// let right = SubDomainTT::from_tt(TensorTrain::new(vec![
-    ///     TensorDynLen::from_dense(vec![right_index], vec![3.0_f64, 4.0]).unwrap(),
+    ///     IdxTensor::from_dense(vec![right_index], vec![3.0_f64, 4.0]).unwrap(),
     /// ]).unwrap());
     ///
     /// let result = left.contract(&right, &ContractOptions::default()).unwrap();

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt/tests/mod.rs
@@ -1,17 +1,17 @@
 use super::*;
 use std::sync::Arc;
 use tensor4all_core::index::Index;
-use tensor4all_core::{TensorDynLenError, TensorStorageError};
+use tensor4all_core::{IdxTensorError, TensorStorageError};
 use tensor4all_itensorlike::TensorTrainError;
 fn make_index(size: usize) -> DynIndex {
     Index::new_dyn(size)
 }
 
-fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.dim).collect();
     let size: usize = dims.iter().product();
     let data: Vec<f64> = (0..size).map(|i| (i + 1) as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 fn make_simple_tt() -> (TensorTrain, Vec<DynIndex>, Vec<DynIndex>) {
@@ -160,7 +160,7 @@ fn project_rejects_index_absent_from_tensor_train() {
 #[test]
 fn project_preserves_autodiff_metadata_and_backward_values() {
     let site = make_index(2);
-    let source = TensorDynLen::from_dense(vec![site.clone()], vec![3.0_f64, 4.0])
+    let source = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0])
         .unwrap()
         .enable_grad()
         .unwrap();
@@ -192,7 +192,7 @@ fn project_error_mapping_retains_typed_storage_source() {
     let storage_source = TensorStorageError::Materialization {
         source: Arc::new(std::io::Error::other("forced projection storage failure")),
     };
-    let error = SubDomainTT::tensor_operation_error(TensorDynLenError::Storage {
+    let error = SubDomainTT::tensor_operation_error(IdxTensorError::Storage {
         source: storage_source,
     });
 

--- a/crates/tensor4all-partitionedtt/src/test_utils.rs
+++ b/crates/tensor4all-partitionedtt/src/test_utils.rs
@@ -7,7 +7,7 @@
 
 use num_complex::Complex64;
 use tensor4all_core::index::Index;
-use tensor4all_core::{DynIndex, TensorDynLen, TensorElement};
+use tensor4all_core::{DynIndex, IdxTensor, TensorElement};
 use tensor4all_itensorlike::TensorTrain;
 
 /// Trait for types that can be used as test scalars (f64 or Complex64).
@@ -36,16 +36,16 @@ pub fn make_index(size: usize) -> DynIndex {
 }
 
 /// Create a tensor with incrementing f64 values for the given indices.
-pub fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+pub fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     make_tensor_generic::<f64>(indices)
 }
 
 /// Create a tensor with test data for the given scalar type.
-pub fn make_tensor_generic<T: TestScalar>(indices: Vec<DynIndex>) -> TensorDynLen {
+pub fn make_tensor_generic<T: TestScalar>(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|i| i.dim).collect();
     let size: usize = dims.iter().product();
     let data = T::make_test_data(size);
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Create shared indices for a 2-site tensor train.

--- a/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/affine/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 
-fn tensor_axis_lookup(template: &TensorDynLen) -> std::collections::HashMap<DynIndex, usize> {
+fn tensor_axis_lookup(template: &IdxTensor) -> std::collections::HashMap<DynIndex, usize> {
     template
         .indices()
         .iter()
@@ -25,7 +25,7 @@ fn tensor_axis_position(
 fn tensor_axis_lookup_uses_full_index_identity() {
     let base = DynIndex::new_dyn(2);
     let primed = base.prime();
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![base.clone(), primed.clone()],
         vec![Complex64::new(0.0, 0.0); 4],
     )
@@ -637,8 +637,8 @@ fn affine_matrix_to_dense_tensor(
     r: usize,
     m: usize,
     n: usize,
-    template: &TensorDynLen,
-) -> TensorDynLen {
+    template: &IdxTensor,
+) -> IdxTensor {
     let indices = template.indices().to_vec();
     let dims = template.dims();
     let axis_lookup = tensor_axis_lookup(template);
@@ -677,7 +677,7 @@ fn affine_matrix_to_dense_tensor(
         }
     }
 
-    TensorDynLen::from_dense(indices, data).expect("failed to build affine reference tensor")
+    IdxTensor::from_dense(indices, data).expect("failed to build affine reference tensor")
 }
 
 fn affine_interleaved_matrix_to_dense_tensor(
@@ -686,8 +686,8 @@ fn affine_interleaved_matrix_to_dense_tensor(
     r: usize,
     m: usize,
     n: usize,
-    template: &TensorDynLen,
-) -> TensorDynLen {
+    template: &IdxTensor,
+) -> IdxTensor {
     let indices = template.indices().to_vec();
     let dims = template.dims();
     let axis_lookup = tensor_axis_lookup(template);
@@ -733,7 +733,7 @@ fn affine_interleaved_matrix_to_dense_tensor(
         }
     }
 
-    TensorDynLen::from_dense(indices, data)
+    IdxTensor::from_dense(indices, data)
         .expect("failed to build interleaved affine reference tensor")
 }
 
@@ -751,10 +751,10 @@ fn affine_dense_reference_element_count(r: usize, m: usize, n: usize) -> Option<
 
 fn affine_operator_expected_dense_tensor(
     op: &QuanticsOperator,
-    template: &TensorDynLen,
+    template: &IdxTensor,
     r: usize,
     mut expected: impl FnMut(usize, usize) -> Complex64,
-) -> TensorDynLen {
+) -> IdxTensor {
     let indices = template.indices().to_vec();
     let dims = template.dims();
     let axis_lookup = tensor_axis_lookup(template);
@@ -793,7 +793,7 @@ fn affine_operator_expected_dense_tensor(
         }
     }
 
-    TensorDynLen::from_dense(indices, data).expect("failed to build expected affine tensor")
+    IdxTensor::from_dense(indices, data).expect("failed to build expected affine tensor")
 }
 
 #[allow(clippy::needless_range_loop)]

--- a/crates/tensor4all-quanticstransform/src/common.rs
+++ b/crates/tensor4all-quanticstransform/src/common.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use num_complex::Complex64;
 use num_traits::One;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_simplett::{
     tensor3_from_data, types::tensor3_zeros, AbstractTensorTrain, SimpleTensorTrain, Tensor3Ops,
 };
@@ -75,7 +75,7 @@ pub enum CarryDirection {
 }
 
 /// Type alias for the standard LinearOperator used in this crate.
-/// Uses TensorDynLen as the tensor type and usize as the node name type.
+/// Uses IdxTensor as the tensor type and usize as the node name type.
 /// # Examples
 /// ```
 /// use tensor4all_quanticstransform::{
@@ -85,7 +85,7 @@ pub enum CarryDirection {
 /// let operator: QuanticsOperator = tensortrain_to_linear_operator(&mpo, &[2]).unwrap();
 /// assert_eq!(operator.mpo().node_count(), 1);
 /// ```
-pub type QuanticsOperator = LinearOperator<TensorDynLen, usize>;
+pub type QuanticsOperator = LinearOperator<IdxTensor, usize>;
 
 /// Convert a SimpleTensorTrain (MPO form) to a LinearOperator.
 /// The SimpleTensorTrain is assumed to be an MPO with site dimension 4 (2x2 for input/output).
@@ -128,7 +128,7 @@ pub fn tensortrain_to_linear_operator(
         .ok_or_else(|| anyhow::anyhow!("tensor-train bond count overflows usize"))?;
     checked_allocation_len::<DynIndex>(&[n], "operator site indices")?;
     checked_allocation_len::<DynIndex>(&[bond_capacity], "operator bond indices")?;
-    checked_allocation_len::<TensorDynLen>(&[n], "operator tensor list")?;
+    checked_allocation_len::<IdxTensor>(&[n], "operator tensor list")?;
     checked_allocation_len::<usize>(&[n], "operator node-name list")?;
     for (site, &dim) in site_dims.iter().enumerate() {
         checked_allocation_len::<Complex64>(&[dim, dim], &format!("site {site}"))?;
@@ -166,7 +166,7 @@ pub fn tensortrain_to_linear_operator(
     }
 
     // Build tensors for TreeTN
-    let mut tensors = try_vec_with_capacity::<TensorDynLen>("operator tensor list", n)?;
+    let mut tensors = try_vec_with_capacity::<IdxTensor>("operator tensor list", n)?;
     let mut node_names = try_vec_with_capacity::<usize>("operator node-name list", n)?;
 
     for i in 0..n {
@@ -265,7 +265,7 @@ pub fn tensortrain_to_linear_operator(
             }
         }
 
-        let tensor_dyn = TensorDynLen::from_dense(indices, data)?;
+        let tensor_dyn = IdxTensor::from_dense(indices, data)?;
         tensors.push(tensor_dyn);
         node_names.push(i);
     }
@@ -339,7 +339,7 @@ pub fn tensortrain_to_linear_operator_asymmetric(
         .ok_or_else(|| anyhow::anyhow!("tensor-train bond count overflows usize"))?;
     checked_allocation_len::<DynIndex>(&[n], "operator site indices")?;
     checked_allocation_len::<DynIndex>(&[bond_capacity], "operator bond indices")?;
-    checked_allocation_len::<TensorDynLen>(&[n], "operator tensor list")?;
+    checked_allocation_len::<IdxTensor>(&[n], "operator tensor list")?;
     checked_allocation_len::<usize>(&[n], "operator node-name list")?;
     for i in 0..n {
         checked_allocation_len::<Complex64>(
@@ -380,7 +380,7 @@ pub fn tensortrain_to_linear_operator_asymmetric(
     }
 
     // Build tensors for TreeTN
-    let mut tensors = try_vec_with_capacity::<TensorDynLen>("operator tensor list", n)?;
+    let mut tensors = try_vec_with_capacity::<IdxTensor>("operator tensor list", n)?;
     let mut node_names = try_vec_with_capacity::<usize>("operator node-name list", n)?;
 
     for i in 0..n {
@@ -478,7 +478,7 @@ pub fn tensortrain_to_linear_operator_asymmetric(
             }
         }
 
-        let tensor_dyn = TensorDynLen::from_dense(indices, data)?;
+        let tensor_dyn = IdxTensor::from_dense(indices, data)?;
         tensors.push(tensor_dyn);
         node_names.push(i);
     }

--- a/crates/tensor4all-quanticstransform/src/error.rs
+++ b/crates/tensor4all-quanticstransform/src/error.rs
@@ -38,8 +38,8 @@ impl From<anyhow::Error> for QuanticsTransformError {
     }
 }
 
-impl From<tensor4all_core::TensorDynLenError> for QuanticsTransformError {
-    fn from(source: tensor4all_core::TensorDynLenError) -> Self {
+impl From<tensor4all_core::IdxTensorError> for QuanticsTransformError {
+    fn from(source: tensor4all_core::IdxTensorError) -> Self {
         Self::Operation {
             source: anyhow::Error::new(source),
         }
@@ -81,7 +81,7 @@ mod tests {
             "root cause"
         );
 
-        let dyn_err = QuanticsTransformError::from(tensor4all_core::TensorDynLenError::NaNInput {
+        let dyn_err = QuanticsTransformError::from(tensor4all_core::IdxTensorError::NaNInput {
             operation: "test",
         });
         assert!(dyn_err

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -15,7 +15,7 @@ use num_complex::Complex64;
 use num_traits::{One, Zero};
 
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{IdxTensor, IndexLike, TensorIndex};
 use tensor4all_simplett::{
     types::tensor3_zeros, AbstractTensorTrain, SimpleTensorTrain, Tensor3Ops,
 };
@@ -37,7 +37,7 @@ type DynIndex = Index<DynId, TagSet>;
 
 fn tensortrain_to_treetn(
     tt: &SimpleTensorTrain<Complex64>,
-) -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
     tensor4all_treetn::tensor_train_to_treetn(tt).expect("MPS to TreeTN conversion failed")
 }
 
@@ -83,7 +83,7 @@ fn create_two_bit_value_qtt(values: [f64; 4]) -> SimpleTensorTrain<Complex64> {
 ///
 /// Returns a vector of length 2^R representing f[x] for x = 0, 1, ..., 2^R - 1.
 fn contract_treetn_to_vector(
-    treetn: &TreeTN<TensorDynLen, usize>,
+    treetn: &TreeTN<IdxTensor, usize>,
     site_indices: &[DynIndex],
 ) -> Vec<Complex64> {
     let r = site_indices.len();
@@ -174,7 +174,7 @@ fn evaluate_mps_all(mps: &SimpleTensorTrain<Complex64>) -> Vec<Complex64> {
 /// * `n_in` - Number of input sites (must equal n_out)
 /// * `n_out` - Number of output sites (must equal n_in)
 fn apply_operator_to_dense_matrix(
-    op: &LinearOperator<TensorDynLen, usize>,
+    op: &LinearOperator<IdxTensor, usize>,
     n_in: usize,
     n_out: usize,
 ) -> Vec<Vec<Complex64>> {
@@ -247,7 +247,7 @@ fn test_difference_kernel_mpo_rejects_open_boundary() {
 /// # Returns
 /// A dim × dim matrix where dim = site_dim^n_sites
 fn contract_operator_to_dense_matrix(
-    op: &LinearOperator<TensorDynLen, usize>,
+    op: &LinearOperator<IdxTensor, usize>,
     n_sites: usize,
     site_dim: usize,
 ) -> Vec<Vec<Complex64>> {
@@ -2438,7 +2438,7 @@ fn test_operator_linearity() {
 /// Contracts the MPO directly to obtain the dense matrix representation.
 /// The operator has `r` sites, each with input/output dimension 2^nvariables.
 fn apply_multivar_operator_to_dense_matrix(
-    op: &LinearOperator<TensorDynLen, usize>,
+    op: &LinearOperator<IdxTensor, usize>,
     r: usize,
     nvariables: usize,
 ) -> Vec<Vec<Complex64>> {

--- a/crates/tensor4all-treetci/src/api.rs
+++ b/crates/tensor4all-treetci/src/api.rs
@@ -15,7 +15,7 @@ use tensor4all_treetn::TreeTN;
 /// - `ranks_per_iter`: Maximum bond dimension at each iteration.
 /// - `normalized_errors_per_iter`: Normalized bond error at each iteration.
 pub type TreeTciRunResult = (
-    TreeTN<tensor4all_core::TensorDynLen, usize>,
+    TreeTN<tensor4all_core::IdxTensor, usize>,
     Vec<usize>,
     Vec<f64>,
 );

--- a/crates/tensor4all-treetci/src/error.rs
+++ b/crates/tensor4all-treetci/src/error.rs
@@ -45,8 +45,8 @@ impl From<anyhow::Error> for TreeTciError {
     }
 }
 
-impl From<tensor4all_core::TensorDynLenError> for TreeTciError {
-    fn from(source: tensor4all_core::TensorDynLenError) -> Self {
+impl From<tensor4all_core::IdxTensorError> for TreeTciError {
+    fn from(source: tensor4all_core::IdxTensorError) -> Self {
         Self::Operation {
             source: anyhow::Error::new(source),
         }
@@ -96,7 +96,7 @@ mod tests {
         );
 
         let dyn_err =
-            TreeTciError::from(tensor4all_core::TensorDynLenError::NaNInput { operation: "test" });
+            TreeTciError::from(tensor4all_core::IdxTensorError::NaNInput { operation: "test" });
         assert!(dyn_err.to_string().contains("tree-TCI operation failed"));
     }
 }

--- a/crates/tensor4all-treetci/src/globalpivot/tests.rs
+++ b/crates/tensor4all-treetci/src/globalpivot/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use anyhow::Result;
 use num_complex::Complex64;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_treetn::TreeTN;
 
 /// Batch evaluator for a two-peak function on a 10-site chain.
@@ -76,7 +76,7 @@ fn seeded_state() -> TreeTCI2<f64> {
 }
 
 /// Evaluate the materialized tree at a full-site index.
-fn tree_value(tree: &TreeTN<TensorDynLen, usize>, index: &[usize]) -> f64 {
+fn tree_value(tree: &TreeTN<IdxTensor, usize>, index: &[usize]) -> f64 {
     let mut site_indices = Vec::with_capacity(index.len());
     for site in 0..index.len() {
         let node = tree.node_index(&site).unwrap();

--- a/crates/tensor4all-treetci/src/materialize.rs
+++ b/crates/tensor4all-treetci/src/materialize.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::Result;
 
 use std::collections::HashMap;
-use tensor4all_core::{ColMajorArray, DynIndex, TensorDynLen};
+use tensor4all_core::{ColMajorArray, DynIndex, IdxTensor};
 use tensor4all_tcicore::MatrixLuciScalar as Scalar;
 use tensor4all_tensorbackend::FullPivLuScalar;
 use tensor4all_treetn::TreeTN;
@@ -31,7 +31,7 @@ pub fn to_treetn<T, F>(
     state: &TreeTCI2<T>,
     evaluate: F,
     center_site: Option<usize>,
-) -> TreeTciResult<TreeTN<TensorDynLen, usize>>
+) -> TreeTciResult<TreeTN<IdxTensor, usize>>
 where
     T: FullPivLuScalar + tensor4all_tcicore::MatrixLuciScalar + tensor4all_core::TensorElement,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
@@ -108,7 +108,7 @@ where
             );
         }
 
-        tensors.push(TensorDynLen::from_dense(indices, data)?);
+        tensors.push(IdxTensor::from_dense(indices, data)?);
         node_names.push(site);
     }
 

--- a/crates/tensor4all-treetci/tests/advanced_quantics.rs
+++ b/crates/tensor4all-treetci/tests/advanced_quantics.rs
@@ -24,7 +24,7 @@ fn branching_tree(n_sites: usize) -> TreeTciGraph {
 }
 
 fn evaluate_treetn(
-    tn: &tensor4all_treetn::TreeTN<tensor4all_core::TensorDynLen, usize>,
+    tn: &tensor4all_treetn::TreeTN<tensor4all_core::IdxTensor, usize>,
     point: &[usize],
 ) -> f64 {
     let (indices, _vertices) = tn.all_site_indices().unwrap();

--- a/crates/tensor4all-treetn/README.md
+++ b/crates/tensor4all-treetn/README.md
@@ -24,11 +24,11 @@ let s2 = DynIndex::new_dyn(2);
 let b01 = DynIndex::new_dyn(4);
 let b12 = DynIndex::new_dyn(4);
 
-let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
-let t1 = TensorDynLen::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 32])?;
-let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![1.0; 8])?;
+let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
+let t1 = IdxTensor::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 32])?;
+let t2 = IdxTensor::from_dense(vec![b12, s2], vec![1.0; 8])?;
 
-let ttn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2])?;
+let ttn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2])?;
 assert_eq!(ttn.node_count(), 3);
 assert_eq!(ttn.edge_count(), 2);
 

--- a/crates/tensor4all-treetn/examples/bench_swap_interleave_r45.rs
+++ b/crates/tensor4all-treetn/examples/bench_swap_interleave_r45.rs
@@ -1,16 +1,13 @@
 use std::collections::HashMap;
 
 use rand_chacha::rand_core::{RngCore, SeedableRng};
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 use tensor4all_treetn::{SwapOptions, TreeTN};
 
-fn build_tn(
-    r: usize,
-    bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, HashMap<DynIndex, String>) {
+fn build_tn(r: usize, bond_dim: usize) -> (TreeTN<IdxTensor, String>, HashMap<DynIndex, String>) {
     let n = 2 * r;
     let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let x_inds: Vec<DynIndex> = (0..r).map(|_| DynIndex::new_dyn(2)).collect();
     let y_inds: Vec<DynIndex> = (0..r).map(|_| DynIndex::new_dyn(2)).collect();
     let bonds: Vec<DynIndex> = (0..n - 1).map(|_| DynIndex::new_dyn(bond_dim)).collect();
@@ -32,7 +29,7 @@ fn build_tn(
         let data: Vec<f64> = (0..size)
             .map(|_| (rng.next_u64() as f64) / (u64::MAX as f64))
             .collect();
-        let t = TensorDynLen::from_dense(indices, data).unwrap();
+        let t = IdxTensor::from_dense(indices, data).unwrap();
         tn.add_tensor(i.to_string(), t).unwrap();
     }
     for (i, bond) in bonds.iter().enumerate() {
@@ -50,7 +47,7 @@ fn build_tn(
 
 /// Frobenius relative error: ||after - before|| / ||before||
 /// Uses sub() to align indices correctly before subtracting.
-fn rel_error(before: &TensorDynLen, after: &TensorDynLen) -> f64 {
+fn rel_error(before: &IdxTensor, after: &IdxTensor) -> f64 {
     let norm_before = before.norm().unwrap();
     if norm_before == 0.0 {
         return 0.0;

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use tensor4all_core::{
-    index::DynId, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    index::DynId, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, random_treetn, ApplyOptions, CanonicalForm,
@@ -29,10 +29,10 @@ fn create_n_site_ones_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags (for readable debug output)
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -59,7 +59,7 @@ fn create_n_site_ones_mps(
         };
 
         let nelem: usize = indices.iter().map(|idx| idx.dim).product();
-        let tensor = TensorDynLen::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
+        let tensor = IdxTensor::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
         mps.add_tensor(name, tensor).unwrap();
     }
 
@@ -81,7 +81,7 @@ fn create_random_chain_mpo_with_internal_indices(
     phys_dim: usize,
     mpo_bond_dim: usize,
     seed: u64,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -240,7 +240,7 @@ fn main() -> anyhow::Result<()> {
         .with_gmres_restart_dim(gmres_restart_dim)
         .with_coefficients(a0, a1);
 
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
         let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
 
@@ -250,7 +250,7 @@ fn main() -> anyhow::Result<()> {
 
         // Align tensor indices to b's order before converting to vectors
         let ref_order = b_full.external_indices();
-        let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+        let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
             let inds = tensor.external_indices();
             let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
             let mut out = Vec::with_capacity(ref_order.len());
@@ -324,7 +324,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Measured runs...");
     let mut times = Vec::with_capacity(n_runs);
-    let mut x_last: Option<TreeTN<TensorDynLen, String>> = None;
+    let mut x_last: Option<TreeTN<IdxTensor, String>> = None;
 
     for run in 1..=n_runs {
         let start = Instant::now();

--- a/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
+++ b/crates/tensor4all-treetn/examples/benchmark_linsolve_mpo.rs
@@ -19,7 +19,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tensor4all_core::{
     index::{DynId, Index},
-    DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalForm,
@@ -82,10 +82,10 @@ fn create_identity_mpo_state(
     true_site_indices: &[DynIndex], // external indices (contracted with operator)
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -115,7 +115,7 @@ fn create_identity_mpo_state(
                 base_data[idx] = 1.0;
             }
         }
-        let base = TensorDynLen::from_dense(
+        let base = IdxTensor::from_dense(
             vec![
                 true_site_indices[i].clone(), // external (contracted with operator)
                 s_out_tmp[i].clone(),
@@ -140,8 +140,8 @@ fn create_identity_mpo_state(
                 base
             } else {
                 let bond_size: usize = bond_inds.iter().map(|b| b.dim()).product();
-                let ones = TensorDynLen::from_dense(bond_inds, vec![1.0_f64; bond_size]).unwrap();
-                TensorDynLen::outer_product(&base, &ones)?
+                let ones = IdxTensor::from_dense(bond_inds, vec![1.0_f64; bond_size]).unwrap();
+                IdxTensor::outer_product(&base, &ones)?
             }
         };
 
@@ -169,13 +169,13 @@ fn create_random_mpo_operator(
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds (deterministic IDs from rng)
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -198,7 +198,7 @@ fn create_random_mpo_operator(
         let node_name = make_node_name(i);
 
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
-        let t = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let t = IdxTensor::random::<f64, _>(rng, indices)?;
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);
@@ -348,7 +348,7 @@ fn main() -> anyhow::Result<()> {
         .with_gmres_restart_dim(gmres_restart_dim)
         .with_coefficients(a0, a1);
 
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(
             operator_a.clone(),
             a_input_mapping.clone(),
@@ -363,7 +363,7 @@ fn main() -> anyhow::Result<()> {
         // Align indices using b_full as reference (like test_linsolve_mpo_identity.rs)
         let ref_order: Vec<DynIndex> = b_full.external_indices();
 
-        let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+        let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
             let inds: Vec<DynIndex> = tensor.external_indices();
             let by_id: HashMap<DynId, DynIndex> =
                 inds.into_iter().map(|i: DynIndex| (*i.id(), i)).collect();
@@ -440,7 +440,7 @@ fn main() -> anyhow::Result<()> {
 
     println!("Measured runs...");
     let mut times = Vec::with_capacity(n_runs);
-    let mut x_last: Option<TreeTN<TensorDynLen, String>> = None;
+    let mut x_last: Option<TreeTN<IdxTensor, String>> = None;
 
     for run in 1..=n_runs {
         let start = Instant::now();

--- a/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
+++ b/crates/tensor4all-treetn/examples/compare_mps_mpo_pauli.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use tensor4all_core::{
-    index::DynId, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    index::DynId, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalForm,
@@ -20,7 +20,7 @@ use tensor4all_treetn::{
     SquareLinsolveUpdater, TreeTN, TruncationOptions,
 };
 
-type TnWithInternalIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>);
+type TnWithInternalIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>);
 
 fn make_node_name(i: usize) -> String {
     format!("site{i}")
@@ -45,7 +45,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
     anyhow::ensure!(n_sites >= 1, "Need at least 1 site");
     anyhow::ensure!(phys_dim == 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     let s_in_tmp: Vec<DynIndex> = (0..n_sites)
         .map(|_| unique_dyn_index(used_ids, phys_dim))
@@ -67,15 +67,15 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         let data = pauli_x.to_vec();
 
         let tensor = if n_sites == 1 {
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
         } else if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![s_out_tmp[i].clone(), s_in_tmp[i].clone(), bonds[i].clone()],
                 data,
             )
             .unwrap()
         } else if i + 1 == n_sites {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bonds[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -85,7 +85,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bonds[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -151,10 +151,10 @@ fn create_all_ones_mps(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -173,7 +173,7 @@ fn create_all_ones_mps(
 
         let nelem: usize = indices.iter().map(|idx| idx.dim()).product();
         let data = vec![1.0_f64; nelem];
-        let t = TensorDynLen::from_dense(indices, data).unwrap();
+        let t = IdxTensor::from_dense(indices, data).unwrap();
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -196,7 +196,7 @@ fn create_all_ones_mpo_state(
     true_site_indices: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
@@ -205,7 +205,7 @@ fn create_all_ones_mpo_state(
         "true_site_indices.len() must equal n"
     );
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -264,7 +264,7 @@ fn create_all_ones_mpo_state(
 
         let nelem: usize = indices.iter().map(|idx| idx.dim()).product();
         let data = vec![1.0_f64; nelem];
-        let t = TensorDynLen::from_dense(indices, data).unwrap();
+        let t = IdxTensor::from_dense(indices, data).unwrap();
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);
@@ -294,13 +294,13 @@ fn create_all_ones_mpo_state(
 }
 
 fn compute_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
     a0: f64,
     a1: f64,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<f64> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
@@ -309,7 +309,7 @@ fn compute_residual(
     let b_full = rhs.contract_to_tensor()?;
     let ref_order = b_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
         let mut out = Vec::with_capacity(ref_order.len());

--- a/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
+++ b/crates/tensor4all-treetn/examples/minimal_linsolve_identity_cases.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
-use tensor4all_core::{index::DynId, DynIndex, IndexLike, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{index::DynId, DynIndex, IdxTensor, IndexLike, TensorContractionLike};
 use tensor4all_treetn::{
     apply_local_update_sweep, CanonicalizationOptions, IndexMapping, LinsolveOptions,
     LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater, SquareLinsolveUpdater, TreeTN,
@@ -39,10 +39,10 @@ fn create_mps_chain_with_sites_all_ones(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -64,7 +64,7 @@ fn create_mps_chain_with_sites_all_ones(
         };
 
         let nelem: usize = indices.iter().map(|idx| idx.dim()).product();
-        let t = TensorDynLen::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
+        let t = IdxTensor::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -83,10 +83,10 @@ fn create_random_mps_chain_with_sites(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -102,7 +102,7 @@ fn create_random_mps_chain_with_sites(
         } else {
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
-        let t = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let t = IdxTensor::random::<f64, _>(rng, indices)?;
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -117,7 +117,7 @@ fn create_random_mps_chain_with_sites(
 
 /// Create an N-site identity MPO with internal indices (bond dim = 1).
 type IdentityMpoWithMappings = (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 );
@@ -130,7 +130,7 @@ fn create_identity_mpo_chain_with_internal_indices(
 ) -> anyhow::Result<IdentityMpoWithMappings> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -180,8 +180,8 @@ fn create_identity_mpo_chain_with_internal_indices(
         for k in 0..phys_dim {
             data[k * phys_dim + k] = 1.0;
         }
-        let base = TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data)
-            .unwrap();
+        let base =
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap();
         let t = if indices.len() == 2 {
             base
         } else {
@@ -190,8 +190,8 @@ fn create_identity_mpo_chain_with_internal_indices(
                 .filter(|idx| idx.dim() == 1)
                 .cloned()
                 .collect();
-            let ones = TensorDynLen::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+            let ones = IdxTensor::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();

--- a/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_random_mpo.rs
@@ -15,7 +15,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tensor4all_core::{
     index::{DynId, Index},
-    DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
@@ -78,13 +78,13 @@ fn create_identity_operator(
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1 for identity
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -112,15 +112,15 @@ fn create_identity_operator(
             base_data[k * phys_dim + k] = 1.0;
         }
         let base =
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], base_data)
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], base_data)
                 .unwrap();
 
         let t = if indices.len() == 2 {
             base
         } else {
             let bond_inds = bond_indices(&indices);
-            let ones = TensorDynLen::from_dense(bond_inds, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+            let ones = IdxTensor::from_dense(bond_inds, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -160,13 +160,13 @@ fn create_random_operator(
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim, rng))
@@ -186,7 +186,7 @@ fn create_random_operator(
     for i in 0..n {
         let node_name = make_node_name(i);
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
-        let t = TensorDynLen::random::<f64, _>(rng, indices)?;
+        let t = IdxTensor::random::<f64, _>(rng, indices)?;
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
         nodes.push(node);
@@ -233,10 +233,10 @@ fn create_identity_mpo_state(
     true_site_indices: &[DynIndex], // external indices (contracted with operator)
     used_ids: &mut HashSet<DynId>,
     rng: &mut StdRng,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds (dim 1 for identity-like structure)
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -266,7 +266,7 @@ fn create_identity_mpo_state(
                 base_data[idx] = 1.0;
             }
         }
-        let base = TensorDynLen::from_dense(
+        let base = IdxTensor::from_dense(
             vec![
                 true_site_indices[i].clone(), // external (contracted with operator)
                 s_out_tmp[i].clone(),
@@ -291,8 +291,8 @@ fn create_identity_mpo_state(
                 base
             } else {
                 let bond_size: usize = bond_inds.iter().map(|b| b.dim()).product();
-                let ones = TensorDynLen::from_dense(bond_inds, vec![1.0_f64; bond_size]).unwrap();
-                TensorDynLen::outer_product(&base, &ones)?
+                let ones = IdxTensor::from_dense(bond_inds, vec![1.0_f64; bond_size]).unwrap();
+                IdxTensor::outer_product(&base, &ones)?
             }
         };
 
@@ -309,13 +309,13 @@ fn create_identity_mpo_state(
 }
 
 fn compute_rel_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
     a0: f64,
     a1: f64,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<f64> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
@@ -327,7 +327,7 @@ fn compute_rel_residual(
     // Align indices using b_full as reference (like test_linsolve_mpo_identity.rs)
     let ref_order: Vec<DynIndex> = b_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds: Vec<DynIndex> = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> =
             inds.into_iter().map(|i: DynIndex| (*i.id(), i)).collect();
@@ -373,10 +373,10 @@ fn compute_rel_residual(
 #[allow(clippy::too_many_arguments)]
 fn run_linsolve_test(
     test_name: &str,
-    operator: &TreeTN<TensorDynLen, String>,
+    operator: &TreeTN<IdxTensor, String>,
     input_mapping: &HashMap<String, IndexMapping<DynIndex>>,
     output_mapping: &HashMap<String, IndexMapping<DynIndex>>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    rhs: &TreeTN<IdxTensor, String>,
     a0: f64,
     a1: f64,
     n_sweeps: usize,

--- a/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
+++ b/crates/tensor4all-treetn/examples/repro_linsolve_single_run.rs
@@ -28,7 +28,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Context;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, random_treetn, ApplyOptions, CanonicalForm,
     CanonicalizationOptions, IndexMapping, LinearOperator, LinkSpace, LinsolveOptions,
@@ -39,10 +39,10 @@ fn create_n_site_ones_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     let site_indices: Vec<DynIndex> = (0..n_sites)
         .map(|i| DynIndex::new_dyn_with_tag(phys_dim, &format!("site{i}")).unwrap())
@@ -67,7 +67,7 @@ fn create_n_site_ones_mps(
         };
 
         let nelem: usize = indices.iter().map(|idx| idx.dim).product();
-        let tensor = TensorDynLen::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
+        let tensor = IdxTensor::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
         mps.add_tensor(name, tensor).unwrap();
     }
 
@@ -85,10 +85,10 @@ fn create_n_site_ones_mps(
 fn create_identity_chain_mpo_with_internal_indices(
     n_sites: usize,
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
     let s_out_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -103,7 +103,7 @@ fn create_identity_chain_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -113,7 +113,7 @@ fn create_identity_chain_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -123,7 +123,7 @@ fn create_identity_chain_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -153,7 +153,7 @@ fn create_random_chain_mpo_with_internal_indices(
     phys_dim: usize,
     mpo_bond_dim: usize,
     seed: u64,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -218,9 +218,9 @@ fn create_n_site_index_mappings(
 }
 
 fn compute_rel_residual(
-    x: &TreeTN<TensorDynLen, String>,
-    linop: &LinearOperator<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    linop: &LinearOperator<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
     a0: f64,
     a1: f64,
 ) -> anyhow::Result<f64> {

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n10.rs
@@ -43,7 +43,7 @@ use std::collections::HashMap;
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
     IndexMapping, LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater,
@@ -56,10 +56,10 @@ fn create_n_site_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags (for readable debug output)
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -80,7 +80,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * bond_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}] - identity-like
@@ -88,7 +88,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * phys_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -100,7 +100,7 @@ fn create_n_site_mps(
                 let idx = j * phys_dim * bond_dim + j * bond_dim + j;
                 data[idx] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -130,7 +130,7 @@ fn create_random_mps_with_same_sites(
     site_indices: &[DynIndex],
     init_bond_dim: usize,
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(site_indices.len() == n_sites, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -138,22 +138,22 @@ fn create_random_mps_with_same_sites(
         .map(|i| DynIndex::new_dyn_with_tag(init_bond_dim, &format!("init_bond{i}")).unwrap())
         .collect();
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -178,10 +178,10 @@ fn create_random_mps_with_same_sites(
 
 /// Scale a TreeTN by a scalar factor.
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: f64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
 
     // Scale all tensors
@@ -221,11 +221,11 @@ fn scale_treetn(
 fn create_n_site_pauli_x_mpo_with_internal_indices(
     n_sites: usize,
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
     assert_eq!(phys_dim, 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -248,7 +248,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -258,7 +258,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -268,7 +268,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -295,7 +295,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
 }
 
 /// Print bond dimensions of a TreeTN MPS.
-fn print_bond_dims(mps: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(mps: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = mps.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -407,7 +407,7 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
     );
 
     // Helper: compute relative residual ||(a0*I + a1*A) x - b|| / ||b|| in full space.
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
         let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_general_coefficients_n3.rs
@@ -40,7 +40,7 @@ use std::collections::HashMap;
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
     IndexMapping, LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater,
@@ -53,10 +53,10 @@ fn create_n_site_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags (for readable debug output)
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -77,7 +77,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * bond_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}] - identity-like
@@ -85,7 +85,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * phys_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -97,7 +97,7 @@ fn create_n_site_mps(
                 let idx = j * phys_dim * bond_dim + j * bond_dim + j;
                 data[idx] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -132,11 +132,11 @@ fn create_complex_n_site_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
     assert!(bond_dim >= 2, "bond_dim must be at least 2");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -168,7 +168,7 @@ fn create_complex_n_site_mps(
                     data[idx] = 1.0 / (bond_dim as f64).sqrt();
                 }
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}]
@@ -180,7 +180,7 @@ fn create_complex_n_site_mps(
                     data[idx] = 1.0 / (bond_dim as f64).sqrt();
                 }
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -204,7 +204,7 @@ fn create_complex_n_site_mps(
                     }
                 }
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -234,7 +234,7 @@ fn create_random_mps_with_same_sites(
     site_indices: &[DynIndex],
     init_bond_dim: usize,
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(site_indices.len() == n_sites, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -242,22 +242,22 @@ fn create_random_mps_with_same_sites(
         .map(|i| DynIndex::new_dyn_with_tag(init_bond_dim, &format!("init_bond{i}")).unwrap())
         .collect();
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -282,10 +282,10 @@ fn create_random_mps_with_same_sites(
 
 /// Scale a TreeTN by a scalar factor.
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: f64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
 
     // Scale all tensors
@@ -325,11 +325,11 @@ fn scale_treetn(
 fn create_n_site_pauli_x_mpo_with_internal_indices(
     n_sites: usize,
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
     assert_eq!(phys_dim, 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -352,7 +352,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -362,7 +362,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -372,7 +372,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -399,7 +399,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
 }
 
 /// Print bond dimensions of a TreeTN MPS.
-fn print_bond_dims(mps: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(mps: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = mps.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -518,7 +518,7 @@ fn run_test_case(
     );
 
     // Helper: compute relative residual ||(a0*I + a1*A) x - b|| / ||b|| in full space.
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
         let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_operator_issue.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
     IndexMapping, LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater,
@@ -39,11 +39,11 @@ fn create_all_ones_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
     assert!(bond_dim >= 1, "bond_dim must be at least 1");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -72,7 +72,7 @@ fn create_all_ones_mps(
                     data[idx] = 1.0 / (phys_dim as f64).sqrt();
                 }
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}]
@@ -84,7 +84,7 @@ fn create_all_ones_mps(
                     data[idx] = 1.0 / (phys_dim as f64).sqrt();
                 }
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -103,7 +103,7 @@ fn create_all_ones_mps(
                     }
                 }
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -135,14 +135,14 @@ fn create_all_ones_mps(
 fn create_simple_two_state_mps(
     n_sites: usize,
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
     assert!(phys_dim >= 2, "phys_dim must be at least 2");
 
     // This state requires bond_dim=2: one bond index for |000...0⟩, one for |111...1⟩
     let bond_dim = 2usize;
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -164,7 +164,7 @@ fn create_simple_two_state_mps(
             let mut data = vec![0.0; phys_dim * bond_dim];
             data[0] = 1.0 / 2.0_f64.sqrt(); // |0⟩ -> bond 0
             data[bond_dim + 1] = 1.0 / 2.0_f64.sqrt(); // |1⟩ -> bond 1
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}]
@@ -172,7 +172,7 @@ fn create_simple_two_state_mps(
             let mut data = vec![0.0; bond_dim * phys_dim];
             data[0] = 1.0 / 2.0_f64.sqrt(); // bond 0 -> |0⟩
             data[phys_dim + 1] = 1.0 / 2.0_f64.sqrt(); // bond 1 -> |1⟩
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -183,7 +183,7 @@ fn create_simple_two_state_mps(
             let mut data = vec![0.0; bond_dim * phys_dim * bond_dim];
             data[0] = 1.0 / 2.0_f64.sqrt(); // bond 0 -> |0⟩ -> bond 0
             data[phys_dim * bond_dim + bond_dim + 1] = 1.0 / 2.0_f64.sqrt(); // bond 1 -> |1⟩ -> bond 1
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -213,7 +213,7 @@ fn create_random_mps_with_same_sites(
     site_indices: &[DynIndex],
     init_bond_dim: usize,
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(site_indices.len() == n_sites, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -221,22 +221,22 @@ fn create_random_mps_with_same_sites(
         .map(|i| DynIndex::new_dyn_with_tag(init_bond_dim, &format!("init_bond{i}")).unwrap())
         .collect();
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -262,10 +262,10 @@ fn create_random_mps_with_same_sites(
 /// Scale a TreeTN by a scalar factor.
 /// For MPS, we only scale one tensor (the last one) to avoid scaling by scalar^n_sites.
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: f64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
 
     // For MPS, scale only the last tensor to scale the entire vector by scalar
@@ -313,11 +313,11 @@ fn scale_treetn(
 fn create_n_site_pauli_x_mpo_with_internal_indices(
     n_sites: usize,
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
     assert_eq!(phys_dim, 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -340,7 +340,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -350,7 +350,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -360,7 +360,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -387,7 +387,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
 }
 
 /// Print bond dimensions of a TreeTN MPS.
-fn print_bond_dims(mps: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(mps: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = mps.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -622,7 +622,7 @@ fn run_test_case(
     );
 
     // Helper: compute relative residual ||(a0*I + a1*A) x - b|| / ||b|| in full space.
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
         let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
 
@@ -651,7 +651,7 @@ fn run_test_case(
     };
 
     // Helper: compute error relative to exact solution ||x - x_exact|| / ||x_exact||
-    let compute_exact_error = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_exact_error = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let x_full = x.contract_to_tensor()?;
         let x_exact_full = x_exact.contract_to_tensor()?;
         let x_vec = x_full.to_vec::<f64>()?;

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
     IndexMapping, LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater,
@@ -32,10 +32,10 @@ fn create_n_site_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags (for readable debug output)
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -56,7 +56,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * bond_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}] - identity-like
@@ -64,7 +64,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * phys_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -76,7 +76,7 @@ fn create_n_site_mps(
                 let idx = j * phys_dim * bond_dim + j * bond_dim + j;
                 data[idx] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -106,7 +106,7 @@ fn create_random_mps_with_same_sites(
     bond_dim: usize,
     site_indices: &[DynIndex],
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(site_indices.len() == n_sites, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -114,22 +114,22 @@ fn create_random_mps_with_same_sites(
         .map(|_| DynIndex::new_dyn(bond_dim))
         .collect();
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -157,11 +157,11 @@ fn create_random_mps_with_same_sites(
 fn create_n_site_mpo_with_internal_indices(
     diag_values: &[f64],
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     let n_sites = diag_values.len();
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -178,7 +178,7 @@ fn create_n_site_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -188,7 +188,7 @@ fn create_n_site_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -198,7 +198,7 @@ fn create_n_site_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -302,7 +302,7 @@ fn run_test_case(init_mode: &str, bond_dim: usize) -> anyhow::Result<()> {
     );
 
     // Helper: compute relative residual ||(a0*I + a1*A) x - b|| / ||b|| in full space.
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
         let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_identity_residual_n3_variants.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
     IndexMapping, LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater,
@@ -32,10 +32,10 @@ fn create_n_site_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices with tags (for readable debug output)
     let site_indices: Vec<DynIndex> = (0..n_sites)
@@ -56,7 +56,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * bond_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}] - identity-like
@@ -64,7 +64,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * phys_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -76,7 +76,7 @@ fn create_n_site_mps(
                 let idx = j * phys_dim * bond_dim + j * bond_dim + j;
                 data[idx] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -106,7 +106,7 @@ fn create_random_mps_with_same_sites(
     site_indices: &[DynIndex],
     init_bond_dim: usize,
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(site_indices.len() == n_sites, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -114,22 +114,22 @@ fn create_random_mps_with_same_sites(
         .map(|i| DynIndex::new_dyn_with_tag(init_bond_dim, &format!("init_bond{i}")).unwrap())
         .collect();
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     for i in 0..n_sites {
         let name = format!("site{i}");
         let tensor = if i == 0 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![site_indices[i].clone(), bond_indices[i].clone()],
             )
         } else if i == n_sites - 1 {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
             )
         } else {
-            TensorDynLen::random::<f64, _>(
+            IdxTensor::random::<f64, _>(
                 &mut rng,
                 vec![
                     bond_indices[i - 1].clone(),
@@ -154,10 +154,10 @@ fn create_random_mps_with_same_sites(
 
 /// Scale a TreeTN by a scalar factor.
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: f64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
 
     // Scale all tensors
@@ -185,11 +185,11 @@ fn scale_treetn(
 fn create_n_site_mpo_with_internal_indices(
     diag_values: &[f64],
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     let n_sites = diag_values.len();
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -206,7 +206,7 @@ fn create_n_site_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -216,7 +216,7 @@ fn create_n_site_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -226,7 +226,7 @@ fn create_n_site_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -253,7 +253,7 @@ fn create_n_site_mpo_with_internal_indices(
 }
 
 /// Print bond dimensions of a TreeTN MPS.
-fn print_bond_dims(mps: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(mps: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = mps.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -362,7 +362,7 @@ fn run_test_case(a0: f64, a1: f64, init_mode: &str, bond_dim: usize) -> anyhow::
     );
 
     // Helper: compute relative residual ||(a0*I + a1*A) x - b|| / ||b|| in full space.
-    let compute_rel_residual = |x: &TreeTN<TensorDynLen, String>| -> anyhow::Result<f64> {
+    let compute_rel_residual = |x: &TreeTN<IdxTensor, String>| -> anyhow::Result<f64> {
         let linop = LinearOperator::new(mpo.clone(), input_mapping.clone(), output_mapping.clone());
         let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
 

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_identity.rs
@@ -16,7 +16,7 @@ use num_complex::Complex64;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tensor4all_core::{
-    index::DynId, AnyScalar, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    index::DynId, AnyScalar, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
@@ -77,13 +77,13 @@ fn create_identity_mpo_with_mappings(
     true_site_indices: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -126,7 +126,7 @@ fn create_identity_mpo_with_mappings(
                 base_data[idx] = 1.0;
             }
         }
-        let base = TensorDynLen::from_dense(
+        let base = IdxTensor::from_dense(
             vec![
                 true_site_indices[i].clone(), // external index (appears in site_space)
                 s_out_tmp[i].clone(),
@@ -142,8 +142,8 @@ fn create_identity_mpo_with_mappings(
         } else {
             // Add bond indices via outer product
             let bond_indices = bond_indices(&indices);
-            let ones = TensorDynLen::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+            let ones = IdxTensor::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -176,16 +176,16 @@ fn create_identity_mpo_with_mappings(
 /// Create a random MPO with the same structure (same index IDs) as `template`.
 /// Replaces each node's tensor with random **real** data. Used for init != rhs (real case).
 fn create_random_mpo_matching_structure(
-    template: &TreeTN<TensorDynLen, String>,
+    template: &TreeTN<IdxTensor, String>,
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let mut mpo = template.clone();
     for node_name in template.node_names() {
         let node_idx = mpo.node_index(&node_name).unwrap();
         let t = mpo.tensor(node_idx).unwrap();
         let indices = t.external_indices();
-        let new_t = TensorDynLen::random::<f64, _>(&mut rng, indices)?;
+        let new_t = IdxTensor::random::<f64, _>(&mut rng, indices)?;
         mpo.replace_tensor(node_idx, new_t)?;
     }
     Ok(mpo)
@@ -194,16 +194,16 @@ fn create_random_mpo_matching_structure(
 /// Like `create_random_mpo_matching_structure` but uses **complex** random tensors.
 /// Use for init=random when RHS is complex (e.g. b = i*I) so storage matches DenseC64.
 fn create_random_mpo_matching_structure_c64(
-    template: &TreeTN<TensorDynLen, String>,
+    template: &TreeTN<IdxTensor, String>,
     seed: u64,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let mut mpo = template.clone();
     for node_name in template.node_names() {
         let node_idx = mpo.node_index(&node_name).unwrap();
         let t = mpo.tensor(node_idx).unwrap();
         let indices = t.external_indices();
-        let new_t = TensorDynLen::random::<Complex64, _>(&mut rng, indices)?;
+        let new_t = IdxTensor::random::<Complex64, _>(&mut rng, indices)?;
         mpo.replace_tensor(node_idx, new_t)?;
     }
     Ok(mpo)
@@ -220,13 +220,13 @@ fn create_identity_mpo_operator_only(
     true_site_indices: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, 1))
         .collect();
@@ -250,15 +250,15 @@ fn create_identity_mpo_operator_only(
             base_data[k * phys_dim + k] = 1.0;
         }
         let base =
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], base_data)
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], base_data)
                 .unwrap();
 
         let t = if indices.len() == 2 {
             base
         } else {
             let bond_indices = bond_indices(&indices);
-            let ones = TensorDynLen::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+            let ones = IdxTensor::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -287,7 +287,7 @@ fn create_identity_mpo_operator_only(
     Ok((mpo, input_mapping, output_mapping))
 }
 
-fn print_bond_dims(treetn: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(treetn: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = treetn.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -306,10 +306,10 @@ fn print_bond_dims(treetn: &TreeTN<TensorDynLen, String>, label: &str) {
 
 /// Scale a TreeTN by a scalar factor (scale only one tensor to avoid scalar^n scaling).
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: AnyScalar,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
     let last_idx = node_names.len().saturating_sub(1);
 
@@ -336,13 +336,13 @@ fn scale_treetn(
 }
 
 fn compute_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
     a0: f64,
     a1: f64,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
@@ -351,7 +351,7 @@ fn compute_residual(
     let b_full = rhs.contract_to_tensor()?;
     let ref_order = b_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
         let mut out = Vec::with_capacity(ref_order.len());

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_imaginary.rs
@@ -18,7 +18,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tensor4all_core::index::DynId;
 use tensor4all_core::{
-    AnyScalar, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    AnyScalar, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
@@ -26,7 +26,7 @@ use tensor4all_treetn::{
     TreeTN,
 };
 
-type TnWithInternalIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>);
+type TnWithInternalIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>);
 
 fn make_node_name(i: usize) -> String {
     format!("site{i}")
@@ -83,7 +83,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
     anyhow::ensure!(n_sites >= 1, "Need at least 1 site");
     anyhow::ensure!(phys_dim == 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites)
@@ -113,9 +113,9 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         }
 
         let tensor = if n_sites == 1 {
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
         } else if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -125,7 +125,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -135,7 +135,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -207,14 +207,14 @@ fn create_random_mpo_state_c64(
     used_ids: &mut HashSet<DynId>,
     seed: u64,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -238,7 +238,7 @@ fn create_random_mpo_state_c64(
         let indices = mpo_node_indices(n, i, &bonds, &s_out_tmp, &s_in_tmp);
 
         // Create random complex tensor with shape [external, s_out, s_in]
-        let random_tensor = TensorDynLen::random::<Complex64, _>(
+        let random_tensor = IdxTensor::random::<Complex64, _>(
             &mut rng,
             vec![
                 true_site_indices[i].clone(), // external index
@@ -253,8 +253,8 @@ fn create_random_mpo_state_c64(
         } else {
             // Add bond indices via outer product
             let bond_indices = bond_indices(&indices);
-            let ones = TensorDynLen::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&random_tensor, &ones)?
+            let ones = IdxTensor::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&random_tensor, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -295,13 +295,13 @@ fn create_identity_mpo_state_c64(
     true_site_indices: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -334,7 +334,7 @@ fn create_identity_mpo_state_c64(
                 base_data[idx] = Complex64::new(1.0, 0.0);
             }
         }
-        let base = TensorDynLen::from_dense(
+        let base = IdxTensor::from_dense(
             vec![
                 true_site_indices[i].clone(), // external index
                 s_out_tmp[i].clone(),
@@ -351,8 +351,8 @@ fn create_identity_mpo_state_c64(
             // Add bond indices via outer product
             let bond_indices = bond_indices(&indices);
             let ones =
-                TensorDynLen::from_dense(bond_indices, vec![Complex64::new(1.0, 0.0); 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+                IdxTensor::from_dense(bond_indices, vec![Complex64::new(1.0, 0.0); 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -395,13 +395,13 @@ fn create_all_ones_mpo_state_c64(
     true_site_indices: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -426,7 +426,7 @@ fn create_all_ones_mpo_state_c64(
 
         // All-ones on (external, s_out, s_in)
         let base_data = vec![Complex64::new(1.0, 0.0); phys_dim * phys_dim * phys_dim];
-        let base = TensorDynLen::from_dense(
+        let base = IdxTensor::from_dense(
             vec![
                 true_site_indices[i].clone(),
                 s_out_tmp[i].clone(),
@@ -441,8 +441,8 @@ fn create_all_ones_mpo_state_c64(
         } else {
             let bond_indices = bond_indices(&indices);
             let ones =
-                TensorDynLen::from_dense(bond_indices, vec![Complex64::new(1.0, 0.0); 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+                IdxTensor::from_dense(bond_indices, vec![Complex64::new(1.0, 0.0); 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -472,7 +472,7 @@ fn create_all_ones_mpo_state_c64(
     Ok((mpo, input_mapping, output_mapping))
 }
 
-fn print_bond_dims(treetn: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(treetn: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = treetn.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -491,10 +491,10 @@ fn print_bond_dims(treetn: &TreeTN<TensorDynLen, String>, label: &str) {
 
 /// Scale a TreeTN by a scalar factor (scale only one tensor to avoid scalar^n scaling).
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: AnyScalar,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
     let last_idx = node_names.len().saturating_sub(1);
 
@@ -521,7 +521,7 @@ fn scale_treetn(
 }
 
 fn print_operator_dense_matrix(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     s_out: &[DynIndex],
     s_in: &[DynIndex],
     label: &str,
@@ -595,13 +595,13 @@ fn print_operator_dense_matrix(
 }
 
 fn compute_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
     a0: f64,
     a1: f64,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
@@ -610,7 +610,7 @@ fn compute_residual(
     let b_full = rhs.contract_to_tensor()?;
     let ref_order = b_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
         let mut out = Vec::with_capacity(ref_order.len());
@@ -671,14 +671,14 @@ fn compute_residual(
 /// Compute the difference between x and x_true.
 /// Returns (absolute error, relative error) where relative error is |x - x_true| / |x_true|.
 fn compute_state_error(
-    x: &TreeTN<TensorDynLen, String>,
-    x_true: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    x_true: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let x_full = x.contract_to_tensor()?;
     let x_true_full = x_true.contract_to_tensor()?;
     let ref_order = x_true_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
         let mut out = Vec::with_capacity(ref_order.len());

--- a/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mpo_pauli_operator.rs
@@ -13,7 +13,7 @@ use num_complex::Complex64;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use tensor4all_core::{
-    index::DynId, AnyScalar, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    index::DynId, AnyScalar, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
@@ -21,7 +21,7 @@ use tensor4all_treetn::{
     TreeTN,
 };
 
-type TnWithInternalIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>);
+type TnWithInternalIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>);
 
 fn make_node_name(i: usize) -> String {
     format!("site{i}")
@@ -78,7 +78,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
     anyhow::ensure!(n_sites >= 1, "Need at least 1 site");
     anyhow::ensure!(phys_dim == 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites)
@@ -108,9 +108,9 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         }
 
         let tensor = if n_sites == 1 {
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
         } else if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -120,7 +120,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -130,7 +130,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -200,13 +200,13 @@ fn create_identity_mpo_operator(
     true_site_indices: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, 1))
         .collect();
@@ -230,15 +230,15 @@ fn create_identity_mpo_operator(
             base_data[k * phys_dim + k] = 1.0;
         }
         let base =
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], base_data)
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], base_data)
                 .unwrap();
 
         let t = if indices.len() == 2 {
             base
         } else {
             let bond_indices = bond_indices(&indices);
-            let ones = TensorDynLen::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+            let ones = IdxTensor::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -278,14 +278,14 @@ fn create_random_mpo_state(
     used_ids: &mut HashSet<DynId>,
     seed: u64,
 ) -> anyhow::Result<(
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 )> {
     anyhow::ensure!(true_site_indices.len() == n, "site index count mismatch");
 
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // MPO bonds: dim 1
     let bonds: Vec<_> = (0..n.saturating_sub(1))
@@ -314,7 +314,7 @@ fn create_random_mpo_state(
         // where external = true_site_indices[i] is the index that remains open.
         //
         // Create random tensor with shape [external, s_out, s_in]
-        let random_tensor = TensorDynLen::random::<f64, _>(
+        let random_tensor = IdxTensor::random::<f64, _>(
             &mut rng,
             vec![
                 true_site_indices[i].clone(), // external index
@@ -329,8 +329,8 @@ fn create_random_mpo_state(
         } else {
             // Add bond indices via outer product
             let bond_indices = bond_indices(&indices);
-            let ones = TensorDynLen::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&random_tensor, &ones)?
+            let ones = IdxTensor::from_dense(bond_indices, vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&random_tensor, &ones)?
         };
 
         let node = mpo.add_tensor(node_name.clone(), t).unwrap();
@@ -360,7 +360,7 @@ fn create_random_mpo_state(
     Ok((mpo, input_mapping, output_mapping))
 }
 
-fn print_bond_dims(treetn: &TreeTN<TensorDynLen, String>, label: &str) {
+fn print_bond_dims(treetn: &TreeTN<IdxTensor, String>, label: &str) {
     let edges: Vec<_> = treetn.site_index_network().edges().collect();
     if edges.is_empty() {
         println!("{label}: no bonds");
@@ -379,10 +379,10 @@ fn print_bond_dims(treetn: &TreeTN<TensorDynLen, String>, label: &str) {
 
 /// Scale a TreeTN by a scalar factor (scale only one tensor to avoid scalar^n scaling).
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: AnyScalar,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
     let last_idx = node_names.len().saturating_sub(1);
 
@@ -409,13 +409,13 @@ fn scale_treetn(
 }
 
 fn compute_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
     a0: f64,
     a1: f64,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
@@ -424,7 +424,7 @@ fn compute_residual(
     let b_full = rhs.contract_to_tensor()?;
     let ref_order = b_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
         let mut out = Vec::with_capacity(ref_order.len());
@@ -485,14 +485,14 @@ fn compute_residual(
 /// Compute the difference between x and x_true.
 /// Returns (absolute error, relative error) where relative error is |x - x_true| / |x_true|.
 fn compute_state_error(
-    x: &TreeTN<TensorDynLen, String>,
-    x_true: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    x_true: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let x_full = x.contract_to_tensor()?;
     let x_true_full = x_true.contract_to_tensor()?;
     let ref_order = x_true_full.external_indices();
 
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds.into_iter().map(|i| (*i.id(), i)).collect();
         let mut out = Vec::with_capacity(ref_order.len());

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_identity_n2.rs
@@ -9,14 +9,14 @@ use num_complex::Complex64;
 use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use tensor4all_core::{index::DynId, DynIndex, IndexLike, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{index::DynId, DynIndex, IdxTensor, IndexLike, TensorContractionLike};
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
     IndexMapping, LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater,
     TreeTN,
 };
 
-type MpoWithInternalIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>);
+type MpoWithInternalIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>);
 
 fn make_node_name(i: usize) -> String {
     format!("site{i}")
@@ -37,10 +37,10 @@ fn create_random_mps_chain_with_sites_c64(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -57,7 +57,7 @@ fn create_random_mps_chain_with_sites_c64(
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
 
-        let t = TensorDynLen::random::<Complex64, _>(rng, indices)?;
+        let t = IdxTensor::random::<Complex64, _>(rng, indices)?;
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -75,10 +75,10 @@ fn create_random_mps_chain_with_sites_real_c64(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -101,7 +101,7 @@ fn create_random_mps_chain_with_sites_real_c64(
             let r: f64 = rng.random();
             data.push(num_complex::Complex64::new(r, 0.0));
         }
-        let t = TensorDynLen::from_dense(indices, data).unwrap();
+        let t = IdxTensor::from_dense(indices, data).unwrap();
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -119,10 +119,10 @@ fn create_random_mps_chain_with_sites_imag_c64(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -145,7 +145,7 @@ fn create_random_mps_chain_with_sites_imag_c64(
             let im: f64 = rng.random();
             data.push(num_complex::Complex64::new(0.0, im));
         }
-        let t = TensorDynLen::from_dense(indices, data).unwrap();
+        let t = IdxTensor::from_dense(indices, data).unwrap();
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -163,7 +163,7 @@ fn create_identity_mpo_with_internal_indices(
     used_ids: &mut HashSet<DynId>,
 ) -> anyhow::Result<MpoWithInternalIndices> {
     anyhow::ensure!(n >= 1, "need at least 1 site");
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     let s_in_tmp: Vec<_> = (0..n)
         .map(|_| unique_dyn_index(used_ids, phys_dim))
@@ -182,25 +182,24 @@ fn create_identity_mpo_with_internal_indices(
         for k in 0..phys_dim {
             data[k * phys_dim + k] = 1.0;
         }
-        let base = TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data)
-            .unwrap();
+        let base =
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap();
 
         let tensor = if n == 1 {
             base
         } else if i == 0 {
-            let ones = TensorDynLen::from_dense(vec![bonds[i].clone()], vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&base, &ones)?
+            let ones = IdxTensor::from_dense(vec![bonds[i].clone()], vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&base, &ones)?
         } else if i + 1 == n {
-            let ones =
-                TensorDynLen::from_dense(vec![bonds[i - 1].clone()], vec![1.0_f64; 1]).unwrap();
-            TensorDynLen::outer_product(&ones, &base)?
+            let ones = IdxTensor::from_dense(vec![bonds[i - 1].clone()], vec![1.0_f64; 1]).unwrap();
+            IdxTensor::outer_product(&ones, &base)?
         } else {
             let ones_left =
-                TensorDynLen::from_dense(vec![bonds[i - 1].clone()], vec![1.0_f64; 1]).unwrap();
+                IdxTensor::from_dense(vec![bonds[i - 1].clone()], vec![1.0_f64; 1]).unwrap();
             let ones_right =
-                TensorDynLen::from_dense(vec![bonds[i].clone()], vec![1.0_f64; 1]).unwrap();
-            let t = TensorDynLen::outer_product(&ones_left, &base)?;
-            TensorDynLen::outer_product(&t, &ones_right)?
+                IdxTensor::from_dense(vec![bonds[i].clone()], vec![1.0_f64; 1]).unwrap();
+            let t = IdxTensor::outer_product(&ones_left, &base)?;
+            IdxTensor::outer_product(&t, &ones_right)?
         };
 
         mpo.add_tensor(name, tensor)?;
@@ -216,11 +215,11 @@ fn create_identity_mpo_with_internal_indices(
 }
 
 fn compute_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;

--- a/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
+++ b/crates/tensor4all-treetn/examples/test_linsolve_mps_pauli_imaginary.rs
@@ -16,7 +16,7 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
 use tensor4all_core::{
-    index::DynId, AnyScalar, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    index::DynId, AnyScalar, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     apply_linear_operator, apply_local_update_sweep, ApplyOptions, CanonicalizationOptions,
@@ -24,7 +24,7 @@ use tensor4all_treetn::{
     TreeTN,
 };
 
-type TnWithInternalIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>);
+type TnWithInternalIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>);
 
 fn make_node_name(i: usize) -> String {
     format!("site{i}")
@@ -49,7 +49,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
     anyhow::ensure!(n_sites >= 1, "Need at least 1 site");
     anyhow::ensure!(phys_dim == 2, "Pauli-X requires phys_dim=2");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     let s_in_tmp: Vec<DynIndex> = (0..n_sites)
         .map(|_| unique_dyn_index(used_ids, phys_dim))
@@ -71,15 +71,15 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
         let data = pauli_x.to_vec();
 
         let tensor = if n_sites == 1 {
-            TensorDynLen::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
+            IdxTensor::from_dense(vec![s_out_tmp[i].clone(), s_in_tmp[i].clone()], data).unwrap()
         } else if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![s_out_tmp[i].clone(), s_in_tmp[i].clone(), bonds[i].clone()],
                 data,
             )
             .unwrap()
         } else if i + 1 == n_sites {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bonds[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -89,7 +89,7 @@ fn create_n_site_pauli_x_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bonds[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -150,10 +150,10 @@ fn create_index_mappings(
 
 /// Scale a TreeTN by a scalar factor (scale only one tensor to avoid scalar^n scaling).
 fn scale_treetn(
-    treetn: &TreeTN<TensorDynLen, String>,
+    treetn: &TreeTN<IdxTensor, String>,
     scalar: AnyScalar,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
-    let mut scaled = TreeTN::<TensorDynLen, String>::new();
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
+    let mut scaled = TreeTN::<IdxTensor, String>::new();
     let node_names: Vec<String> = treetn.node_names().into_iter().collect();
     let last_idx = node_names.len().saturating_sub(1);
 
@@ -185,10 +185,10 @@ fn create_random_mps_chain_with_sites_c64(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -209,7 +209,7 @@ fn create_random_mps_chain_with_sites_c64(
             vec![bonds[i - 1].clone(), sites[i].clone(), bonds[i].clone()]
         };
 
-        let t = TensorDynLen::random::<Complex64, _>(rng, indices)?;
+        let t = IdxTensor::random::<Complex64, _>(rng, indices)?;
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -227,10 +227,10 @@ fn create_mps_chain_with_sites_all_ones_c64(
     bond_dim: usize,
     sites: &[DynIndex],
     used_ids: &mut HashSet<DynId>,
-) -> anyhow::Result<TreeTN<TensorDynLen, String>> {
+) -> anyhow::Result<TreeTN<IdxTensor, String>> {
     anyhow::ensure!(sites.len() == n, "sites.len() must equal n");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let bonds: Vec<_> = (0..n.saturating_sub(1))
         .map(|_| unique_dyn_index(used_ids, bond_dim))
         .collect();
@@ -249,7 +249,7 @@ fn create_mps_chain_with_sites_all_ones_c64(
 
         let nelem: usize = indices.iter().map(|idx| idx.dim()).product();
         let data = vec![Complex64::new(1.0, 0.0); nelem];
-        let t = TensorDynLen::from_dense(indices, data).unwrap();
+        let t = IdxTensor::from_dense(indices, data).unwrap();
         let node = mps.add_tensor(make_node_name(i), t).unwrap();
         nodes.push(node);
     }
@@ -263,11 +263,11 @@ fn create_mps_chain_with_sites_all_ones_c64(
 }
 
 fn compute_residual(
-    op: &TreeTN<TensorDynLen, String>,
+    op: &TreeTN<IdxTensor, String>,
     im: &HashMap<String, IndexMapping<DynIndex>>,
     om: &HashMap<String, IndexMapping<DynIndex>>,
-    x: &TreeTN<TensorDynLen, String>,
-    rhs: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    rhs: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let linop = LinearOperator::new(op.clone(), im.clone(), om.clone());
     let ax = apply_linear_operator(&linop, x, ApplyOptions::default())?;
@@ -277,7 +277,7 @@ fn compute_residual(
 
     // Align ax to b's external index ordering.
     let ref_order: Vec<DynIndex> = b_full.external_indices();
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds: Vec<DynIndex> = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds
             .into_iter()
@@ -317,14 +317,14 @@ fn compute_residual(
 }
 
 fn compute_state_error(
-    x: &TreeTN<TensorDynLen, String>,
-    x_true: &TreeTN<TensorDynLen, String>,
+    x: &TreeTN<IdxTensor, String>,
+    x_true: &TreeTN<IdxTensor, String>,
 ) -> anyhow::Result<(f64, f64)> {
     let x_full = x.contract_to_tensor()?;
     let x_true_full = x_true.contract_to_tensor()?;
 
     let ref_order: Vec<DynIndex> = x_true_full.external_indices();
-    let order_for = |tensor: &TensorDynLen| -> anyhow::Result<Vec<DynIndex>> {
+    let order_for = |tensor: &IdxTensor| -> anyhow::Result<Vec<DynIndex>> {
         let inds: Vec<DynIndex> = tensor.external_indices();
         let by_id: HashMap<DynId, DynIndex> = inds
             .into_iter()

--- a/crates/tensor4all-treetn/src/dmrg/mod.rs
+++ b/crates/tensor4all-treetn/src/dmrg/mod.rs
@@ -584,16 +584,16 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashMap;
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{dmrg, DmrgOptions, IndexMapping, LinearOperator, TreeTN};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let site0 = DynIndex::new_dyn(2);
 /// let site1 = DynIndex::new_dyn(2);
 /// let bond = DynIndex::new_dyn(1);
-/// let left = TensorDynLen::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 1.0])?;
-/// let right = TensorDynLen::from_dense(vec![bond.clone(), site1.clone()], vec![1.0, 1.0])?;
-/// let mut state = TreeTN::<TensorDynLen, usize>::new();
+/// let left = IdxTensor::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 1.0])?;
+/// let right = IdxTensor::from_dense(vec![bond.clone(), site1.clone()], vec![1.0, 1.0])?;
+/// let mut state = TreeTN::<IdxTensor, usize>::new();
 /// let n0 = state.add_tensor(0, left)?;
 /// let n1 = state.add_tensor(1, right)?;
 /// state.connect(n0, &bond, n1, &bond)?;
@@ -606,9 +606,9 @@ where
 /// let mut id = vec![0.0; 4];
 /// id[0] = 1.0;
 /// id[3] = 1.0;
-/// let op0 = TensorDynLen::from_dense(vec![out0.clone(), in0.clone(), op_bond.clone()], id.clone())?;
-/// let op1 = TensorDynLen::from_dense(vec![op_bond.clone(), out1.clone(), in1.clone()], id)?;
-/// let mut mpo = TreeTN::<TensorDynLen, usize>::new();
+/// let op0 = IdxTensor::from_dense(vec![out0.clone(), in0.clone(), op_bond.clone()], id.clone())?;
+/// let op1 = IdxTensor::from_dense(vec![op_bond.clone(), out1.clone(), in1.clone()], id)?;
+/// let mut mpo = TreeTN::<IdxTensor, usize>::new();
 /// let m0 = mpo.add_tensor(0, op0)?;
 /// let m1 = mpo.add_tensor(1, op1)?;
 /// mpo.connect(m0, &op_bond, m1, &op_bond)?;
@@ -737,21 +737,21 @@ where
 ///
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{dmrg_with_treetn_operator, DmrgOptions, TreeTN};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let site = DynIndex::new_dyn(2);
-/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+/// let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0])?;
 ///
 /// let op_in = DynIndex::new_dyn(2);
 /// let op_out = DynIndex::new_dyn(2);
-/// let op_tensor = TensorDynLen::from_dense(
+/// let op_tensor = IdxTensor::from_dense(
 ///     vec![op_out, op_in],
 ///     vec![1.0, 0.0, 0.0, 2.0],
 /// )?;
-/// let operator = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+/// let operator = TreeTN::<IdxTensor, usize>::from_tensors(vec![op_tensor], vec![0])?;
 ///
 /// let err = dmrg_with_treetn_operator(&operator, state, &0, DmrgOptions::default()).unwrap_err();
 /// assert!(matches!(err, tensor4all_treetn::DmrgError::EmptyTwoSiteSweep));

--- a/crates/tensor4all-treetn/src/error.rs
+++ b/crates/tensor4all-treetn/src/error.rs
@@ -423,8 +423,8 @@ impl From<anyhow::Error> for TreeTNOperationError {
     }
 }
 
-impl From<tensor4all_core::TensorDynLenError> for TreeTNOperationError {
-    fn from(source: tensor4all_core::TensorDynLenError) -> Self {
+impl From<tensor4all_core::IdxTensorError> for TreeTNOperationError {
+    fn from(source: tensor4all_core::IdxTensorError) -> Self {
         Self {
             source: anyhow::Error::new(source),
         }

--- a/crates/tensor4all-treetn/src/gse.rs
+++ b/crates/tensor4all-treetn/src/gse.rs
@@ -2,14 +2,14 @@
 //!
 //! This module implements the v1 TreeTN form of the MPS global subspace
 //! expansion documented in `docs/design/gse-chain-mps-algorithm.md`.
-//! The implementation is intentionally narrow: it supports `TensorDynLen`
+//! The implementation is intentionally narrow: it supports `IdxTensor`
 //! states with exactly one state site index per node and mapped TreeTN
 //! operators with one input and one output index per node.
 //!
 //! During expansion, old bonds are reconstructed from full-rank local SVDs. This
 //! preserves the represented state, but can remove exactly redundant bond
 //! directions while adding missing reference directions. Local projected-density
-//! contractions and basis reconstruction stay in `TensorDynLen` form; only the
+//! contractions and basis reconstruction stay in `IdxTensor` form; only the
 //! eigenvalue cutoff itself reads detached primal eigenvalues for rank
 //! selection.
 
@@ -18,9 +18,9 @@ use std::hash::Hash;
 
 use anyhow::Result;
 use tensor4all_core::{
-    contract_pair_with_operand_options, AnyScalar, Canonical, DynIndex, FactorizeAlg, IndexLike,
-    LinearizationOrder, PairwiseContractionOptions, SvdTruncationPolicy, TensorContractionLike,
-    TensorDynLen, TensorFactorizationLike, TensorIndex,
+    contract_pair_with_operand_options, AnyScalar, Canonical, DynIndex, FactorizeAlg, IdxTensor,
+    IndexLike, LinearizationOrder, PairwiseContractionOptions, SvdTruncationPolicy,
+    TensorContractionLike, TensorFactorizationLike, TensorIndex,
 };
 use thiserror::Error;
 
@@ -122,7 +122,7 @@ where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
     /// Expanded TreeTN state.
-    pub state: TreeTN<TensorDynLen, V>,
+    pub state: TreeTN<IdxTensor, V>,
     /// Number of reference states supplied or generated.
     pub references_built: usize,
     /// Number of directed edges visited by the expansion sweep.
@@ -149,7 +149,7 @@ where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
     /// Final evolved state.
-    pub state: TreeTN<TensorDynLen, V>,
+    pub state: TreeTN<IdxTensor, V>,
     /// Number of one-sweep TDVP calls completed.
     pub sweeps_completed: usize,
     /// Total number of projected local TDVP updates.
@@ -270,8 +270,8 @@ struct EdgeExpansionStats {
 /// /// mismatch, a non-convergence failure, or a backend failure).
 ///
 pub fn global_subspace_expand<V>(
-    operator: &LinearOperator<TensorDynLen, V>,
-    init: TreeTN<TensorDynLen, V>,
+    operator: &LinearOperator<IdxTensor, V>,
+    init: TreeTN<IdxTensor, V>,
     center: &V,
     options: GseOptions,
 ) -> std::result::Result<GseResult<V>, GseError>
@@ -304,8 +304,8 @@ where
 /// /// mismatch, a non-convergence failure, or a backend failure).
 ///
 pub fn global_subspace_expand_with_references<V>(
-    init: TreeTN<TensorDynLen, V>,
-    references: Vec<TreeTN<TensorDynLen, V>>,
+    init: TreeTN<IdxTensor, V>,
+    references: Vec<TreeTN<IdxTensor, V>>,
     center: &V,
     options: GseOptions,
 ) -> std::result::Result<GseResult<V>, GseError>
@@ -372,8 +372,8 @@ where
 /// /// mismatch, a non-convergence failure, or a backend failure).
 ///
 pub fn gse_tdvp<V>(
-    operator: &LinearOperator<TensorDynLen, V>,
-    init: TreeTN<TensorDynLen, V>,
+    operator: &LinearOperator<IdxTensor, V>,
+    init: TreeTN<IdxTensor, V>,
     center: &V,
     options: GseTdvpOptions,
 ) -> std::result::Result<GseTdvpResult<V>, GseError>
@@ -448,11 +448,11 @@ fn validate_options(options: &GseOptions) -> Result<(), GseError> {
 }
 
 fn build_references<V>(
-    operator: &LinearOperator<TensorDynLen, V>,
-    init: &TreeTN<TensorDynLen, V>,
+    operator: &LinearOperator<IdxTensor, V>,
+    init: &TreeTN<IdxTensor, V>,
     center: &V,
     options: &GseOptions,
-) -> Result<Vec<TreeTN<TensorDynLen, V>>, GseError>
+) -> Result<Vec<TreeTN<IdxTensor, V>>, GseError>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug + 'static,
 {
@@ -505,7 +505,7 @@ where
     Ok(references)
 }
 
-fn validate_single_site_state<V>(state: &TreeTN<TensorDynLen, V>) -> Result<(), GseError>
+fn validate_single_site_state<V>(state: &TreeTN<IdxTensor, V>) -> Result<(), GseError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
@@ -522,8 +522,8 @@ where
 }
 
 fn validate_reference<V>(
-    target: &TreeTN<TensorDynLen, V>,
-    reference: &TreeTN<TensorDynLen, V>,
+    target: &TreeTN<IdxTensor, V>,
+    reference: &TreeTN<IdxTensor, V>,
 ) -> Result<(), GseError>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
@@ -546,8 +546,8 @@ where
 }
 
 fn expand_edges<V>(
-    state: &mut TreeTN<TensorDynLen, V>,
-    references: &mut [TreeTN<TensorDynLen, V>],
+    state: &mut TreeTN<IdxTensor, V>,
+    references: &mut [TreeTN<IdxTensor, V>],
     center: &V,
     options: &GseOptions,
 ) -> Result<EdgeExpansionStats, GseError>
@@ -599,8 +599,8 @@ where
 }
 
 fn expand_one_edge<V>(
-    state: &mut TreeTN<TensorDynLen, V>,
-    references: &mut [TreeTN<TensorDynLen, V>],
+    state: &mut TreeTN<IdxTensor, V>,
+    references: &mut [TreeTN<IdxTensor, V>],
     parent: &V,
     child: &V,
     options: &GseOptions,
@@ -681,7 +681,7 @@ where
         state, references, parent, child, &q_indices, &q_left, &q_right,
     )?;
     let trace_identity = identity_on_index_pairs(&q_left, &q_right)?;
-    let trace_tensor = TensorDynLen::contract(&[&density, &trace_identity]).map_err(|source| {
+    let trace_tensor = IdxTensor::contract(&[&density, &trace_identity]).map_err(|source| {
         GseError::Algorithm {
             context: "GSE failed to compute local reference-density trace",
             source: anyhow::Error::new(source),
@@ -755,7 +755,7 @@ where
     let target_child = stack_basis_rows(&basis_rows, new_bond.clone())?;
     let coeff_tensor = coefficient_tensor(&child_tensor, &target_child)?;
     let target_parent =
-        TensorDynLen::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
+        IdxTensor::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
             GseError::Algorithm {
                 context: "GSE failed to absorb expanded coefficients into target parent",
                 source: anyhow::Error::new(source),
@@ -810,12 +810,12 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn update_reference_edge<V>(
-    reference: &mut TreeTN<TensorDynLen, V>,
-    target: &TreeTN<TensorDynLen, V>,
+    reference: &mut TreeTN<IdxTensor, V>,
+    target: &TreeTN<IdxTensor, V>,
     parent: &V,
     child: &V,
     target_q_indices: &[DynIndex],
-    expanded_basis: &TensorDynLen,
+    expanded_basis: &IdxTensor,
     target_new_bond: &DynIndex,
 ) -> Result<(), GseError>
 where
@@ -889,7 +889,7 @@ where
             other => other,
         })?;
     let parent_replacement =
-        TensorDynLen::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
+        IdxTensor::contract(&[&parent_tensor, &coeff_tensor]).map_err(|source| {
             GseError::Algorithm {
                 context: "GSE failed to absorb expanded coefficients into reference parent",
                 source: anyhow::Error::new(source),
@@ -930,18 +930,18 @@ where
 }
 
 fn build_reference_density<V>(
-    target: &TreeTN<TensorDynLen, V>,
-    references: &[TreeTN<TensorDynLen, V>],
+    target: &TreeTN<IdxTensor, V>,
+    references: &[TreeTN<IdxTensor, V>],
     parent: &V,
     child: &V,
     target_q_indices: &[DynIndex],
     q_left: &[DynIndex],
     q_right: &[DynIndex],
-) -> Result<TensorDynLen, GseError>
+) -> Result<IdxTensor, GseError>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
-    let mut density: Option<TensorDynLen> = None;
+    let mut density: Option<IdxTensor> = None;
     for reference in references {
         let ref_edge =
             reference
@@ -1020,10 +1020,10 @@ where
 }
 
 fn old_basis_rows(
-    basis: &TensorDynLen,
+    basis: &IdxTensor,
     basis_bond: &DynIndex,
     basis_rank: usize,
-) -> Result<Vec<TensorDynLen>, GseError> {
+) -> Result<Vec<IdxTensor>, GseError> {
     (0..basis_rank)
         .map(|row| {
             basis
@@ -1037,13 +1037,13 @@ fn old_basis_rows(
 }
 
 fn eigenvector_basis_row(
-    eigenvectors: &TensorDynLen,
+    eigenvectors: &IdxTensor,
     flat_left: &DynIndex,
     eigenvector_index: &DynIndex,
     col: usize,
     q_left: &[DynIndex],
     q_indices: &[DynIndex],
-) -> Result<TensorDynLen, GseError> {
+) -> Result<IdxTensor, GseError> {
     let vector = eigenvectors
         .select_indices(std::slice::from_ref(eigenvector_index), &[col])
         .map_err(|source| GseError::Algorithm {
@@ -1060,18 +1060,18 @@ fn eigenvector_basis_row(
     Ok(row)
 }
 
-fn stack_basis_rows(rows: &[TensorDynLen], new_bond: DynIndex) -> Result<TensorDynLen, GseError> {
+fn stack_basis_rows(rows: &[IdxTensor], new_bond: DynIndex) -> Result<IdxTensor, GseError> {
     let refs = rows.iter().collect::<Vec<_>>();
-    TensorDynLen::stack_along_new_index(&refs, new_bond, 0).map_err(|source| GseError::Algorithm {
+    IdxTensor::stack_along_new_index(&refs, new_bond, 0).map_err(|source| GseError::Algorithm {
         context: "GSE failed to stack expanded basis rows",
         source: anyhow::Error::new(source),
     })
 }
 
 fn coefficient_tensor(
-    child_tensor: &TensorDynLen,
-    expanded_basis: &TensorDynLen,
-) -> Result<TensorDynLen, GseError> {
+    child_tensor: &IdxTensor,
+    expanded_basis: &IdxTensor,
+) -> Result<IdxTensor, GseError> {
     contract_pair_with_operand_options(
         child_tensor,
         expanded_basis,
@@ -1084,13 +1084,13 @@ fn coefficient_tensor(
 }
 
 fn projected_missing_density_tensor(
-    density: &TensorDynLen,
-    basis: &TensorDynLen,
+    density: &IdxTensor,
+    basis: &IdxTensor,
     basis_bond: &DynIndex,
     q_indices: &[DynIndex],
     q_left: &[DynIndex],
     q_right: &[DynIndex],
-) -> Result<TensorDynLen, GseError> {
+) -> Result<IdxTensor, GseError> {
     let identity = identity_on_index_pairs(q_left, q_right)?;
     let basis_left =
         basis
@@ -1147,7 +1147,7 @@ fn projected_missing_density_tensor(
             context: "GSE failed to relabel right projected-density projector",
             source: anyhow::Error::new(source),
         })?;
-    TensorDynLen::contract(&[&p_left_mid, &density_mid, &p_mid_right]).map_err(|source| {
+    IdxTensor::contract(&[&p_left_mid, &density_mid, &p_mid_right]).map_err(|source| {
         GseError::Algorithm {
             context: "GSE failed to contract projected missing reference density",
             source: anyhow::Error::new(source),
@@ -1155,10 +1155,7 @@ fn projected_missing_density_tensor(
     })
 }
 
-fn identity_on_index_pairs(
-    left: &[DynIndex],
-    right: &[DynIndex],
-) -> Result<TensorDynLen, GseError> {
+fn identity_on_index_pairs(left: &[DynIndex], right: &[DynIndex]) -> Result<IdxTensor, GseError> {
     if left.len() != right.len() {
         return Err(GseError::Algorithm {
             context: "GSE failed to build identity on q-space",
@@ -1169,9 +1166,9 @@ fn identity_on_index_pairs(
             ),
         });
     }
-    let mut identity: Option<TensorDynLen> = None;
+    let mut identity: Option<IdxTensor> = None;
     for (left_index, right_index) in left.iter().zip(right.iter()) {
-        let pair = TensorDynLen::copy_tensor(
+        let pair = IdxTensor::copy_tensor(
             vec![left_index.clone(), right_index.clone()],
             AnyScalar::new_real(1.0),
         )
@@ -1193,7 +1190,7 @@ fn identity_on_index_pairs(
     }
     match identity {
         Some(tensor) => Ok(tensor),
-        None => TensorDynLen::scalar(1.0_f64).map_err(|source| GseError::Algorithm {
+        None => IdxTensor::scalar(1.0_f64).map_err(|source| GseError::Algorithm {
             context: "GSE failed to build scalar q-space identity",
             source: anyhow::Error::new(source),
         }),
@@ -1201,10 +1198,10 @@ fn identity_on_index_pairs(
 }
 
 fn hermitianize_by_index_groups(
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
     left: &[DynIndex],
     right: &[DynIndex],
-) -> Result<TensorDynLen, GseError> {
+) -> Result<IdxTensor, GseError> {
     let adjoint = adjoint_by_index_groups(tensor, left, right)?;
     tensor
         .axpby(AnyScalar::new_real(0.5), &adjoint, AnyScalar::new_real(0.5))
@@ -1215,10 +1212,10 @@ fn hermitianize_by_index_groups(
 }
 
 fn adjoint_by_index_groups(
-    tensor: &TensorDynLen,
+    tensor: &IdxTensor,
     left: &[DynIndex],
     right: &[DynIndex],
-) -> Result<TensorDynLen, GseError> {
+) -> Result<IdxTensor, GseError> {
     if left.len() != right.len() {
         return Err(GseError::Algorithm {
             context: "GSE failed to adjoint grouped tensor",
@@ -1249,8 +1246,8 @@ fn fresh_indices_like(indices: &[DynIndex]) -> Vec<DynIndex> {
 }
 
 fn map_q_indices<V>(
-    target: &TreeTN<TensorDynLen, V>,
-    reference: &TreeTN<TensorDynLen, V>,
+    target: &TreeTN<IdxTensor, V>,
+    reference: &TreeTN<IdxTensor, V>,
     child: &V,
     parent: &V,
     target_q_indices: &[DynIndex],
@@ -1316,7 +1313,7 @@ where
 }
 
 fn neighbor_for_bond<V>(
-    state: &TreeTN<TensorDynLen, V>,
+    state: &TreeTN<IdxTensor, V>,
     node: &V,
     bond: &DynIndex,
 ) -> Result<Option<V>, GseError>
@@ -1334,7 +1331,7 @@ where
     Ok(None)
 }
 
-fn single_site_index<V>(state: &TreeTN<TensorDynLen, V>, node: &V) -> Result<DynIndex, GseError>
+fn single_site_index<V>(state: &TreeTN<IdxTensor, V>, node: &V) -> Result<DynIndex, GseError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
@@ -1364,17 +1361,14 @@ fn product_dim(indices: &[DynIndex]) -> usize {
     indices.iter().map(DynIndex::dim).product()
 }
 
-fn max_link_dim<V>(state: &TreeTN<TensorDynLen, V>) -> usize
+fn max_link_dim<V>(state: &TreeTN<IdxTensor, V>) -> usize
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
     state.link_dims().into_iter().max().unwrap_or(1)
 }
 
-fn move_center_to_region_full_rank<V>(
-    state: &mut TreeTN<TensorDynLen, V>,
-    region: &[V],
-) -> Result<()>
+fn move_center_to_region_full_rank<V>(state: &mut TreeTN<IdxTensor, V>, region: &[V]) -> Result<()>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
@@ -1450,40 +1444,36 @@ mod tests {
         values
     }
 
-    fn product_chain_state(
-        left_dim: usize,
-        right_dim: usize,
-    ) -> TreeTN<TensorDynLen, &'static str> {
+    fn product_chain_state(left_dim: usize, right_dim: usize) -> TreeTN<IdxTensor, &'static str> {
         let left = DynIndex::new_dyn(left_dim);
         let right = DynIndex::new_dyn(right_dim);
         let bond = DynIndex::new_dyn(1);
         let left_tensor =
-            TensorDynLen::from_dense(vec![left, bond.clone()], basis_vector(left_dim, 0)).unwrap();
+            IdxTensor::from_dense(vec![left, bond.clone()], basis_vector(left_dim, 0)).unwrap();
         let right_tensor =
-            TensorDynLen::from_dense(vec![bond.clone(), right], basis_vector(right_dim, 0))
-                .unwrap();
-        let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+            IdxTensor::from_dense(vec![bond.clone(), right], basis_vector(right_dim, 0)).unwrap();
+        let mut state = TreeTN::<IdxTensor, &'static str>::new();
         let left_node = state.add_tensor("site0", left_tensor).unwrap();
         let right_node = state.add_tensor("site1", right_tensor).unwrap();
         state.connect(left_node, &bond, right_node, &bond).unwrap();
         state
     }
 
-    fn product_chain3_state(tail_bond_dim: usize) -> TreeTN<TensorDynLen, &'static str> {
+    fn product_chain3_state(tail_bond_dim: usize) -> TreeTN<IdxTensor, &'static str> {
         let s0 = DynIndex::new_dyn(2);
         let s1 = DynIndex::new_dyn(2);
         let s2 = DynIndex::new_dyn(2);
         let b01 = DynIndex::new_dyn(1);
         let b12 = DynIndex::new_dyn(tail_bond_dim);
-        let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0]).unwrap();
+        let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0]).unwrap();
         let mut t1_data = vec![0.0; 2 * tail_bond_dim];
         t1_data[0] = 1.0;
-        let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1, b12.clone()], t1_data).unwrap();
+        let t1 = IdxTensor::from_dense(vec![b01.clone(), s1, b12.clone()], t1_data).unwrap();
         let mut t2_data = vec![0.0; tail_bond_dim * 2];
         t2_data[0] = 1.0;
-        let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2], t2_data).unwrap();
+        let t2 = IdxTensor::from_dense(vec![b12.clone(), s2], t2_data).unwrap();
 
-        let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+        let mut state = TreeTN::<IdxTensor, &'static str>::new();
         let n0 = state.add_tensor("site0", t0).unwrap();
         let n1 = state.add_tensor("site1", t1).unwrap();
         let n2 = state.add_tensor("site2", t2).unwrap();
@@ -1582,7 +1572,7 @@ mod tests {
         let left = DynIndex::new_dyn(2);
         let right = DynIndex::new_dyn(2);
         let tensor =
-            TensorDynLen::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0])
+            IdxTensor::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0])
                 .unwrap();
 
         let adjoint = adjoint_by_index_groups(

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -8,7 +8,7 @@
 //! # Key Types
 //!
 //! - [`TreeTN`]: The main tree tensor network type, parameterized by tensor and node name types.
-//! - [`DefaultTreeTN`]: A convenient alias for `TreeTN<TensorDynLen, NodeIndex>`.
+//! - [`DefaultTreeTN`]: A convenient alias for `TreeTN<IdxTensor, NodeIndex>`.
 //! - [`NamedGraph`]: A graph wrapper that maps node names to internal graph indices.
 //!
 //! # Features
@@ -56,7 +56,7 @@ pub use gse::{
 };
 pub use treetn::contraction;
 
-// dyn_treetn exports removed - use TreeTN<TensorDynLen, V> directly
+// dyn_treetn exports removed - use TreeTN<IdxTensor, V> directly
 pub use link_index_network::LinkIndexNetwork;
 pub use named_graph::NamedGraph;
 pub use node_name_network::{CanonicalizeEdges, NodeNameNetwork};
@@ -116,9 +116,9 @@ pub use linsolve::{
 };
 
 use petgraph::graph::NodeIndex;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 
-/// Default TreeTN type using TensorDynLen as the tensor type.
+/// Default TreeTN type using IdxTensor as the tensor type.
 ///
 /// This is the most common configuration for TreeTN, equivalent to:
 /// ```
@@ -129,4 +129,4 @@ use tensor4all_core::TensorDynLen;
 /// ```
 ///
 /// Use this when you don't need custom tensor types.
-pub type DefaultTreeTN<V = NodeIndex> = TreeTN<TensorDynLen, V>;
+pub type DefaultTreeTN<V = NodeIndex> = TreeTN<IdxTensor, V>;

--- a/crates/tensor4all-treetn/src/linsolve/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/mod.rs
@@ -16,7 +16,7 @@
 //! use tensor4all_treetn::{square_linsolve, LinsolveOptions};
 //!
 //! let options = LinsolveOptions::default().with_nfullsweeps(2);
-//! let _solver = square_linsolve::<tensor4all_core::TensorDynLen, usize>;
+//! let _solver = square_linsolve::<tensor4all_core::IdxTensor, usize>;
 //!
 //! assert_eq!(options.nfullsweeps, 2);
 //! ```

--- a/crates/tensor4all-treetn/src/linsolve/square/local_linop/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/local_linop/tests/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use tensor4all_core::index::DynId;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 
 use crate::operator::IndexMapping;
 use crate::treetn::TreeTN;
@@ -17,7 +17,7 @@ fn unique_dyn_index(used: &mut HashSet<DynId>, dim: usize) -> DynIndex {
     }
 }
 
-fn tensor_indices(state: &TreeTN<TensorDynLen, String>, node: &str) -> Vec<DynIndex> {
+fn tensor_indices(state: &TreeTN<IdxTensor, String>, node: &str) -> Vec<DynIndex> {
     state
         .tensor(state.node_index(&node.to_string()).unwrap())
         .unwrap()
@@ -28,9 +28,9 @@ fn tensor_indices(state: &TreeTN<TensorDynLen, String>, node: &str) -> Vec<DynIn
 fn test_local_linop_new() {
     use crate::linsolve::common::ProjectedOperator;
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = DynIndex::new_dyn(2);
-    let t0 = TensorDynLen::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
     state.add_tensor("site0".to_string(), t0).unwrap();
 
     let reference_state = state.clone();
@@ -53,9 +53,9 @@ fn test_local_linop_new() {
 fn test_local_linop_apply_projected_rejects_mismatch() {
     use crate::linsolve::common::ProjectedOperator;
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = DynIndex::new_dyn(2);
-    let t0 = TensorDynLen::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
     state.add_tensor("site0".to_string(), t0).unwrap();
 
     let reference_state = state.clone();
@@ -84,9 +84,9 @@ fn test_local_linop_apply_projected_rejects_mismatch() {
 fn test_local_linop_apply_index_mismatch() {
     use crate::linsolve::common::ProjectedOperator;
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = DynIndex::new_dyn(2);
-    let t0 = TensorDynLen::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
     state.add_tensor("site0".to_string(), t0).unwrap();
 
     let reference_state = state.clone();
@@ -102,7 +102,7 @@ fn test_local_linop_apply_index_mismatch() {
     );
 
     let other = DynIndex::new_dyn(2);
-    let x = TensorDynLen::from_dense(vec![other], vec![1.0, 0.0]).unwrap();
+    let x = IdxTensor::from_dense(vec![other], vec![1.0, 0.0]).unwrap();
     let err = linop.apply_projected(&x).unwrap_err();
     assert!(err.to_string().contains("index structure mismatch"));
 }
@@ -118,9 +118,9 @@ fn test_local_linop_apply_success_mappings() {
     let contracted = unique_dyn_index(&mut used, phys_dim);
     let external = unique_dyn_index(&mut used, ext_dim);
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let nelem = ext_dim * phys_dim;
-    let t = TensorDynLen::from_dense(vec![external.clone(), contracted.clone()], vec![1.0; nelem])
+    let t = IdxTensor::from_dense(vec![external.clone(), contracted.clone()], vec![1.0; nelem])
         .unwrap();
     state.add_tensor("site0".to_string(), t).unwrap();
 
@@ -130,8 +130,8 @@ fn test_local_linop_apply_success_mappings() {
     for k in 0..phys_dim {
         id_data[k * phys_dim + k] = 1.0;
     }
-    let op_t = TensorDynLen::from_dense(vec![s_out.clone(), s_in.clone()], id_data).unwrap();
-    let mut op_tn = TreeTN::<TensorDynLen, String>::new();
+    let op_t = IdxTensor::from_dense(vec![s_out.clone(), s_in.clone()], id_data).unwrap();
+    let mut op_tn = TreeTN::<IdxTensor, String>::new();
     op_tn.add_tensor("site0".to_string(), op_t).unwrap();
 
     let mut im = HashMap::new();

--- a/crates/tensor4all-treetn/src/linsolve/square/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/mod.rs
@@ -133,7 +133,7 @@ where
 ///
 /// ```
 /// use std::collections::HashMap;
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{square_linsolve, IndexMapping, LinsolveOptions, TreeTN};
 ///
 /// # fn main() -> anyhow::Result<()> {
@@ -143,12 +143,12 @@ where
 /// let b01 = DynIndex::new_dyn(phys_dim);
 ///
 /// // Right-hand side |b>: a two-site state with bond dimension two.
-/// let mut rhs = TreeTN::<TensorDynLen, usize>::new();
-/// let a = TensorDynLen::from_dense(
+/// let mut rhs = TreeTN::<IdxTensor, usize>::new();
+/// let a = IdxTensor::from_dense(
 ///     vec![s0.clone(), b01.clone()],
 ///     vec![1.0_f64, 0.0, 0.0, 2.0],
 /// )?;
-/// let b = TensorDynLen::from_dense(
+/// let b = IdxTensor::from_dense(
 ///     vec![b01.clone(), s1.clone()],
 ///     vec![3.0_f64, 0.0, 0.0, 4.0],
 /// )?;
@@ -166,12 +166,12 @@ where
 /// for i in 0..phys_dim {
 ///     id[i * phys_dim + i] = 1.0;
 /// }
-/// let mut operator = TreeTN::<TensorDynLen, usize>::new();
-/// let t0 = TensorDynLen::from_dense(
+/// let mut operator = TreeTN::<IdxTensor, usize>::new();
+/// let t0 = IdxTensor::from_dense(
 ///     vec![s0_out.clone(), s0_in.clone(), m_bond.clone()],
 ///     id.clone(),
 /// )?;
-/// let t1 = TensorDynLen::from_dense(
+/// let t1 = IdxTensor::from_dense(
 ///     vec![m_bond.clone(), s1_out.clone(), s1_in.clone()],
 ///     id.clone(),
 /// )?;
@@ -187,12 +187,12 @@ where
 ///
 /// // Zero initial guess: not the solution, so the assertions below prove the
 /// // solver actually solves the system.
-/// let mut init = TreeTN::<TensorDynLen, usize>::new();
-/// let iz0 = TensorDynLen::from_dense(
+/// let mut init = TreeTN::<IdxTensor, usize>::new();
+/// let iz0 = IdxTensor::from_dense(
 ///     vec![s0.clone(), b01.clone()],
 ///     vec![0.0_f64, 0.0, 0.0, 0.0],
 /// )?;
-/// let iz1 = TensorDynLen::from_dense(
+/// let iz1 = IdxTensor::from_dense(
 ///     vec![b01.clone(), s1.clone()],
 ///     vec![0.0_f64, 0.0, 0.0, 0.0],
 /// )?;
@@ -457,7 +457,7 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashMap;
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{
 ///     relative_linear_system_residual, ApplyOptions, IndexMapping, LinearOperator, TreeTN,
 /// };
@@ -465,13 +465,13 @@ where
 /// let site = DynIndex::new_dyn(2);
 /// let s_in = DynIndex::new_dyn(2);
 /// let s_out = DynIndex::new_dyn(2);
-/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![3.0_f64, 5.0]).unwrap();
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
-/// let mpo_tensor = TensorDynLen::from_dense(
+/// let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 5.0]).unwrap();
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
+/// let mpo_tensor = IdxTensor::from_dense(
 ///     vec![s_out.clone(), s_in.clone()],
 ///     vec![1.0_f64, 0.0, 0.0, 1.0],
 /// ).unwrap();
-/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+/// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
 /// let mut input_mapping = HashMap::new();
 /// input_mapping.insert(0usize, IndexMapping { true_index: site.clone(), internal_index: s_in });
 /// let mut output_mapping = HashMap::new();

--- a/crates/tensor4all-treetn/src/linsolve/square/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/tests/mod.rs
@@ -1,14 +1,14 @@
 use super::*;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 
-fn create_simple_2site_mps() -> TreeTN<TensorDynLen, String> {
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+fn create_simple_2site_mps() -> TreeTN<IdxTensor, String> {
+    let mut mps = TreeTN::<IdxTensor, String>::new();
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let b01 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 4]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 4]).unwrap();
 
     let n0 = mps.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = mps.add_tensor("site1".to_string(), t1).unwrap();
@@ -17,8 +17,8 @@ fn create_simple_2site_mps() -> TreeTN<TensorDynLen, String> {
     mps
 }
 
-fn create_simple_2site_mpo() -> TreeTN<TensorDynLen, String> {
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+fn create_simple_2site_mpo() -> TreeTN<IdxTensor, String> {
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let s0_in = DynIndex::new_dyn(2);
     let s0_out = DynIndex::new_dyn(2);
     let s1_in = DynIndex::new_dyn(2);
@@ -26,14 +26,13 @@ fn create_simple_2site_mpo() -> TreeTN<TensorDynLen, String> {
     let b_mpo = DynIndex::new_dyn(1);
 
     let id_data = vec![1.0, 0.0, 0.0, 1.0]; // Identity matrix
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
     let t1_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data)
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data).unwrap();
 
     let n0_mpo = mpo.add_tensor("site0".to_string(), t0_mpo).unwrap();
     let n1_mpo = mpo.add_tensor("site1".to_string(), t1_mpo).unwrap();
@@ -59,13 +58,13 @@ fn test_validate_linsolve_inputs_incompatible_dimensions() {
     let rhs = create_simple_2site_mps();
 
     // Create init with different dimensions
-    let mut init = TreeTN::<TensorDynLen, String>::new();
+    let mut init = TreeTN::<IdxTensor, String>::new();
     let s0 = DynIndex::new_dyn(3); // Different dimension
     let s1 = DynIndex::new_dyn(3);
     let b01 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 6]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 6]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 6]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 6]).unwrap();
 
     let n0 = init.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = init.add_tensor("site1".to_string(), t1).unwrap();
@@ -127,13 +126,13 @@ fn test_square_linsolve_validation_error_bubbles_up() {
     let operator = create_simple_2site_mpo();
     let rhs = create_simple_2site_mps();
 
-    let mut init = TreeTN::<TensorDynLen, String>::new();
+    let mut init = TreeTN::<IdxTensor, String>::new();
     let s0 = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(3);
     let b01 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 6]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 6]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 6]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 6]).unwrap();
 
     let n0 = init.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = init.add_tensor("site1".to_string(), t1).unwrap();

--- a/crates/tensor4all-treetn/src/linsolve/square/updater.rs
+++ b/crates/tensor4all-treetn/src/linsolve/square/updater.rs
@@ -455,7 +455,7 @@ where
             gmres_options.verbose = true;
         }
 
-        // Solve using GMRES (works directly with TensorDynLen)
+        // Solve using GMRES (works directly with IdxTensor)
         let result = match self.options.gmres_tolerance_mode {
             GmresToleranceMode::Relative => gmres_affine(
                 apply_a,
@@ -864,19 +864,19 @@ fn local_gmres_options(options: &LinsolveOptions) -> Result<GmresOptions> {
 
 #[cfg(test)]
 mod tests {
-    use tensor4all_core::{DynId, DynIndex, TagSet, TensorDynLen};
+    use tensor4all_core::{DynId, DynIndex, IdxTensor, TagSet};
 
     use super::*;
 
-    fn one_node_state(node: usize, indices: Vec<DynIndex>) -> TreeTN<TensorDynLen, usize> {
+    fn one_node_state(node: usize, indices: Vec<DynIndex>) -> TreeTN<IdxTensor, usize> {
         let len = indices.iter().map(|idx| idx.dim()).product();
-        let tensor = TensorDynLen::from_dense(indices, vec![1.0_f64; len]).unwrap();
-        TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![node]).unwrap()
+        let tensor = IdxTensor::from_dense(indices, vec![1.0_f64; len]).unwrap();
+        TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![node]).unwrap()
     }
 
     #[test]
     fn index_sets_match_distinguishes_same_id_prime_pair() {
-        let updater = SquareLinsolveUpdater::<TensorDynLen, usize>::new(
+        let updater = SquareLinsolveUpdater::<IdxTensor, usize>::new(
             TreeTN::new(),
             TreeTN::new(),
             LinsolveOptions::default(),
@@ -897,7 +897,7 @@ mod tests {
         let rhs = one_node_state(0, vec![state_site]);
         let operator = one_node_state(0, vec![op_site]);
 
-        let updater = SquareLinsolveUpdater::<TensorDynLen, usize>::new(
+        let updater = SquareLinsolveUpdater::<IdxTensor, usize>::new(
             operator,
             rhs,
             LinsolveOptions::default(),
@@ -936,7 +936,7 @@ mod tests {
             },
         );
 
-        let mut updater = SquareLinsolveUpdater::<TensorDynLen, usize>::with_index_mappings(
+        let mut updater = SquareLinsolveUpdater::<IdxTensor, usize>::with_index_mappings(
             operator,
             input_mapping,
             output_mapping,

--- a/crates/tensor4all-treetn/src/operator/apply.rs
+++ b/crates/tensor4all-treetn/src/operator/apply.rs
@@ -18,21 +18,21 @@
 //! ```
 //! use std::collections::HashMap;
 //!
-//! use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+//! use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 //! use tensor4all_treetn::{apply_linear_operator, ApplyOptions, IndexMapping, LinearOperator, TreeTN};
 //!
 //! # fn main() -> anyhow::Result<()> {
 //! let site = DynIndex::new_dyn(2);
-//! let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 2.0])?;
-//! let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+//! let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 2.0])?;
+//! let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0])?;
 //!
 //! let input_internal = DynIndex::new_dyn(2);
 //! let output_internal = DynIndex::new_dyn(2);
-//! let mpo_tensor = TensorDynLen::from_dense(
+//! let mpo_tensor = IdxTensor::from_dense(
 //!     vec![input_internal.clone(), output_internal.clone()],
 //!     vec![1.0, 0.0, 0.0, 1.0],
 //! )?;
-//! let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0])?;
+//! let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0])?;
 //!
 //! let mut input_mapping = HashMap::new();
 //! input_mapping.insert(
@@ -70,7 +70,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 
 use tensor4all_core::{
-    DynIndex, IndexLike, LinearizationOrder, SvdTruncationPolicy, TensorDynLen, TensorIndex,
+    DynIndex, IdxTensor, IndexLike, LinearizationOrder, SvdTruncationPolicy, TensorIndex,
     TensorLike,
 };
 
@@ -249,21 +249,21 @@ impl ApplyOptions {
 /// ```
 /// use std::collections::HashMap;
 ///
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 /// use tensor4all_treetn::{apply_linear_operator, ApplyOptions, IndexMapping, LinearOperator, TreeTN};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let site = DynIndex::new_dyn(2);
-/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 2.0])?;
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+/// let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 2.0])?;
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0])?;
 ///
 /// let input_internal = DynIndex::new_dyn(2);
 /// let output_internal = DynIndex::new_dyn(2);
-/// let mpo_tensor = TensorDynLen::from_dense(
+/// let mpo_tensor = IdxTensor::from_dense(
 ///     vec![input_internal.clone(), output_internal.clone()],
 ///     vec![1.0, 0.0, 0.0, 1.0],
 /// )?;
-/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0])?;
+/// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0])?;
 ///
 /// let mut input_mapping = HashMap::new();
 /// input_mapping.insert(
@@ -399,7 +399,7 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashMap;
-/// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
 /// use tensor4all_treetn::{
 ///     bind_linear_operator_indices, IndexMapping, LinearOperator, TreeTN,
 /// };
@@ -408,11 +408,11 @@ where
 /// let op_output = DynIndex::new_dyn(2);
 /// let input_internal = DynIndex::new_dyn(2);
 /// let output_internal = DynIndex::new_dyn(2);
-/// let mpo_tensor = TensorDynLen::from_dense(
+/// let mpo_tensor = IdxTensor::from_dense(
 ///     vec![input_internal.clone(), output_internal.clone()],
 ///     vec![1.0, 0.0, 0.0, 1.0],
 /// ).unwrap();
-/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+/// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
 ///
 /// let mut input_mapping = HashMap::new();
 /// input_mapping.insert(0usize, IndexMapping { true_index: op_input.clone(), internal_index: input_internal });
@@ -471,24 +471,24 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashMap;
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{
 ///     apply_linear_operator_to_indices, ApplyOptions, IndexMapping, LinearOperator, TreeTN,
 /// };
 ///
 /// let state_index = DynIndex::new_dyn(2);
-/// let state_tensor = TensorDynLen::from_dense(vec![state_index.clone()], vec![3.0, 5.0]).unwrap();
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
+/// let state_tensor = IdxTensor::from_dense(vec![state_index.clone()], vec![3.0, 5.0]).unwrap();
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
 ///
 /// let op_input = DynIndex::new_dyn(2);
 /// let op_output = DynIndex::new_dyn(2);
 /// let input_internal = DynIndex::new_dyn(2);
 /// let output_internal = DynIndex::new_dyn(2);
-/// let mpo_tensor = TensorDynLen::from_dense(
+/// let mpo_tensor = IdxTensor::from_dense(
 ///     vec![input_internal.clone(), output_internal.clone()],
 ///     vec![1.0, 0.0, 0.0, 1.0],
 /// ).unwrap();
-/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+/// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
 ///
 /// let mut input_mapping = HashMap::new();
 /// input_mapping.insert(0usize, IndexMapping { true_index: op_input.clone(), internal_index: input_internal });
@@ -559,15 +559,15 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashMap;
-/// use tensor4all_core::{DynIndex, TagSet, TensorDynLen, TensorLike};
+/// use tensor4all_core::{DynIndex, TagSet, IdxTensor, TensorLike};
 /// use tensor4all_treetn::{
 ///     apply_linear_operator_to_numbered_tags, ApplyOptions, IndexMapping,
 ///     LinearOperator, TreeTN,
 /// };
 ///
 /// let k1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![k1.clone()], vec![1.0, 2.0]).unwrap()],
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![k1.clone()], vec![1.0, 2.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
 ///
@@ -575,11 +575,11 @@ where
 /// let true_output = DynIndex::new_dyn(2);
 /// let internal_input = DynIndex::new_dyn(2);
 /// let internal_output = DynIndex::new_dyn(2);
-/// let mpo_tensor = TensorDynLen::from_dense(
+/// let mpo_tensor = IdxTensor::from_dense(
 ///     vec![internal_output.clone(), internal_input.clone()],
 ///     vec![1.0, 0.0, 0.0, 1.0],
 /// ).unwrap();
-/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+/// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
 /// let mut input_mapping = HashMap::new();
 /// input_mapping.insert(0, IndexMapping {
 ///     true_index: true_input,
@@ -602,12 +602,12 @@ where
 /// assert!(result.to_dense().unwrap().distance(&state.to_dense().unwrap()).unwrap() < 1.0e-12);
 /// ```
 pub fn apply_linear_operator_to_numbered_tags<V>(
-    operator: &LinearOperator<TensorDynLen, V>,
-    state: &TreeTN<TensorDynLen, V>,
+    operator: &LinearOperator<IdxTensor, V>,
+    state: &TreeTN<IdxTensor, V>,
     tag_prefix: &str,
     start_index: usize,
     options: ApplyOptions,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, LinearOperatorTaggedApplyError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, LinearOperatorTaggedApplyError>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
 {
@@ -644,7 +644,7 @@ where
 }
 
 fn true_indices_in_operator_node_order<V>(
-    operator: &LinearOperator<TensorDynLen, V>,
+    operator: &LinearOperator<IdxTensor, V>,
     mappings_by_node: &HashMap<V, Vec<IndexMapping<DynIndex>>>,
 ) -> Vec<DynIndex>
 where

--- a/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/apply/tests/mod.rs
@@ -6,13 +6,13 @@ use crate::{
 };
 use std::collections::{HashMap, HashSet};
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::{ColMajorArrayRef, SvdTruncationPolicy, TensorDynLen};
+use tensor4all_core::{ColMajorArrayRef, IdxTensor, SvdTruncationPolicy};
 use tensor4all_tensorbackend::StorageKind;
 
 type DynIndex = Index<DynId, TagSet>;
 type ChainStateAndIdentity = (
-    TreeTN<TensorDynLen, String>,
-    LinearOperator<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
+    LinearOperator<IdxTensor, String>,
     Vec<(String, DynIndex)>,
 );
 
@@ -20,7 +20,7 @@ fn make_index(dim: usize) -> DynIndex {
     Index::new_dyn(dim)
 }
 
-fn build_identity_operator(sites: &[(String, DynIndex)]) -> LinearOperator<TensorDynLen, String> {
+fn build_identity_operator(sites: &[(String, DynIndex)]) -> LinearOperator<IdxTensor, String> {
     let mut mpo = TreeTN::new();
     let mut input_mapping = HashMap::new();
     let mut output_mapping = HashMap::new();
@@ -28,7 +28,7 @@ fn build_identity_operator(sites: &[(String, DynIndex)]) -> LinearOperator<Tenso
     for (name, true_index) in sites {
         let internal_input = make_index(true_index.dim());
         let internal_output = make_index(true_index.dim());
-        let tensor = TensorDynLen::from_dense(
+        let tensor = IdxTensor::from_dense(
             vec![internal_output.clone(), internal_input.clone()],
             vec![1.0, 0.0, 0.0, 1.0],
         )
@@ -56,7 +56,7 @@ fn build_identity_operator(sites: &[(String, DynIndex)]) -> LinearOperator<Tenso
 
 fn build_bonded_identity_operator(
     sites: &[(String, DynIndex)],
-) -> LinearOperator<TensorDynLen, String> {
+) -> LinearOperator<IdxTensor, String> {
     assert_eq!(sites.len(), 2);
 
     let mut mpo = TreeTN::new();
@@ -68,7 +68,7 @@ fn build_bonded_identity_operator(
         let internal_input = make_index(true_index.dim());
         let internal_output = make_index(true_index.dim());
         let tensor = if name == &sites[0].0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     internal_output.clone(),
                     internal_input.clone(),
@@ -78,7 +78,7 @@ fn build_bonded_identity_operator(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond.clone(),
                     internal_output.clone(),
@@ -116,7 +116,7 @@ fn build_bonded_identity_operator(
 fn build_redundant_bonded_identity_operator(
     sites: &[(String, DynIndex)],
     mpo_bond_dim: usize,
-) -> LinearOperator<TensorDynLen, String> {
+) -> LinearOperator<IdxTensor, String> {
     assert_eq!(sites.len(), 2);
 
     let mut mpo = TreeTN::new();
@@ -135,7 +135,7 @@ fn build_redundant_bonded_identity_operator(
                     data[site_value + dim * (site_value + dim * bond_value)] = 1.0;
                 }
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     internal_output.clone(),
                     internal_input.clone(),
@@ -152,7 +152,7 @@ fn build_redundant_bonded_identity_operator(
                         1.0 / mpo_bond_dim as f64;
                 }
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond.clone(),
                     internal_output.clone(),
@@ -187,7 +187,7 @@ fn build_redundant_bonded_identity_operator(
     LinearOperator::new(mpo, input_mapping, output_mapping)
 }
 
-fn build_chain_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>) {
+fn build_chain_state() -> (TreeTN<IdxTensor, String>, Vec<(String, DynIndex)>) {
     let s0 = make_index(2);
     let s1 = make_index(2);
     let s2 = make_index(2);
@@ -196,12 +196,12 @@ fn build_chain_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>
     let b12 = make_index(2);
     let b23 = make_index(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
     let t1 =
-        TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
     let t2 =
-        TensorDynLen::from_dense(vec![b12.clone(), s2.clone(), b23.clone()], vec![1.0; 8]).unwrap();
-    let t3 = TensorDynLen::from_dense(vec![b23.clone(), s3.clone()], vec![1.0; 4]).unwrap();
+        IdxTensor::from_dense(vec![b12.clone(), s2.clone(), b23.clone()], vec![1.0; 8]).unwrap();
+    let t3 = IdxTensor::from_dense(vec![b23.clone(), s3.clone()], vec![1.0; 4]).unwrap();
 
     let state = TreeTN::from_tensors(
         vec![t0, t1, t2, t3],
@@ -230,9 +230,9 @@ fn apply_linear_operator_supports_multiple_index_mappings_per_node() {
     let x = make_index(2);
     let y = make_index(2);
     let state_tensor =
-        TensorDynLen::from_dense(vec![x.clone(), y.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        IdxTensor::from_dense(vec![x.clone(), y.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["site".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["site".to_string()])
             .unwrap();
 
     let x_in = make_index(2);
@@ -247,14 +247,13 @@ fn apply_linear_operator_supports_multiple_index_mappings_per_node() {
             data[xo + 2 * (yo + 2 * (xi + 2 * yi))] = 1.0;
         }
     }
-    let mpo_tensor = TensorDynLen::from_dense(
+    let mpo_tensor = IdxTensor::from_dense(
         vec![x_out.clone(), y_out.clone(), x_in.clone(), y_in.clone()],
         data,
     )
     .unwrap();
-    let mpo =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["site".to_string()])
-            .unwrap();
+    let mpo = TreeTN::<IdxTensor, String>::from_tensors(vec![mpo_tensor], vec!["site".to_string()])
+        .unwrap();
 
     let mut input_mapping = HashMap::new();
     input_mapping.insert(
@@ -301,23 +300,22 @@ fn apply_linear_operator_supports_multiple_index_mappings_per_node() {
 #[test]
 fn apply_linear_operator_to_indices_binds_explicit_external_indices() {
     let state_index = make_index(2);
-    let state_tensor = TensorDynLen::from_dense(vec![state_index.clone()], vec![2.0, 5.0]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![state_index.clone()], vec![2.0, 5.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["site".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["site".to_string()])
             .unwrap();
 
     let op_true_input = make_index(2);
     let op_true_output = make_index(2);
     let internal_input = make_index(2);
     let internal_output = make_index(2);
-    let mpo_tensor = TensorDynLen::from_dense(
+    let mpo_tensor = IdxTensor::from_dense(
         vec![internal_output.clone(), internal_input.clone()],
         vec![1.0, 0.0, 0.0, 1.0],
     )
     .unwrap();
-    let mpo =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["site".to_string()])
-            .unwrap();
+    let mpo = TreeTN::<IdxTensor, String>::from_tensors(vec![mpo_tensor], vec!["site".to_string()])
+        .unwrap();
 
     let mut input_mapping = HashMap::new();
     input_mapping.insert(
@@ -401,10 +399,10 @@ fn apply_linear_operator_to_numbered_tags_binds_state_indices_in_tag_order() {
     let k1 = Index::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
     let k2 = Index::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
     let bond = make_index(1);
-    let state = TreeTN::<TensorDynLen, String>::from_tensors(
+    let state = TreeTN::<IdxTensor, String>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![k1.clone(), bond.clone()], vec![1.0, 2.0]).unwrap(),
-            TensorDynLen::from_dense(vec![bond, k2.clone()], vec![3.0, 5.0]).unwrap(),
+            IdxTensor::from_dense(vec![k1.clone(), bond.clone()], vec![1.0, 2.0]).unwrap(),
+            IdxTensor::from_dense(vec![bond, k2.clone()], vec![3.0, 5.0]).unwrap(),
         ],
         vec!["site0".to_string(), "site1".to_string()],
     )
@@ -431,8 +429,8 @@ fn apply_linear_operator_to_numbered_tags_binds_state_indices_in_tag_order() {
 #[test]
 fn apply_linear_operator_to_numbered_tags_reports_missing_tag() {
     let k1 = Index::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
-    let state = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![k1], vec![1.0, 2.0]).unwrap()],
+    let state = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(vec![k1], vec![1.0, 2.0]).unwrap()],
         vec!["site0".to_string()],
     )
     .unwrap();
@@ -453,7 +451,7 @@ fn apply_linear_operator_to_numbered_tags_reports_missing_tag() {
     ));
 }
 
-fn build_tree_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>) {
+fn build_tree_state() -> (TreeTN<IdxTensor, String>, Vec<(String, DynIndex)>) {
     let s_a = make_index(2);
     let s_b = make_index(2);
     let s_c = make_index(2);
@@ -464,16 +462,16 @@ fn build_tree_state() -> (TreeTN<TensorDynLen, String>, Vec<(String, DynIndex)>)
     let b_bd = make_index(2);
     let b_be = make_index(2);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone(), b_ab.clone()], vec![1.0; 4]).unwrap();
-    let t_b = TensorDynLen::from_dense(
+    let t_a = IdxTensor::from_dense(vec![s_a.clone(), b_ab.clone()], vec![1.0; 4]).unwrap();
+    let t_b = IdxTensor::from_dense(
         vec![b_ab.clone(), s_b.clone(), b_bc.clone(), b_bd.clone()],
         vec![1.0; 16],
     )
     .unwrap();
-    let t_c = TensorDynLen::from_dense(vec![b_bc.clone(), s_c.clone()], vec![1.0; 4]).unwrap();
-    let t_d = TensorDynLen::from_dense(vec![b_bd.clone(), s_d.clone(), b_be.clone()], vec![1.0; 8])
-        .unwrap();
-    let t_e = TensorDynLen::from_dense(vec![b_be.clone(), s_e.clone()], vec![1.0; 4]).unwrap();
+    let t_c = IdxTensor::from_dense(vec![b_bc.clone(), s_c.clone()], vec![1.0; 4]).unwrap();
+    let t_d =
+        IdxTensor::from_dense(vec![b_bd.clone(), s_d.clone(), b_be.clone()], vec![1.0; 8]).unwrap();
+    let t_e = IdxTensor::from_dense(vec![b_be.clone(), s_e.clone()], vec![1.0; 4]).unwrap();
 
     let state = TreeTN::from_tensors(
         vec![t_a, t_b, t_c, t_d, t_e],
@@ -531,7 +529,7 @@ fn build_uniform_chain_state_and_identity_operator(
             state_indices.push(state_bonds[site].clone());
         }
         let state_len = state_indices.iter().map(|idx| idx.dim()).product();
-        state_tensors.push(TensorDynLen::from_dense(state_indices, vec![1.0; state_len]).unwrap());
+        state_tensors.push(IdxTensor::from_dense(state_indices, vec![1.0; state_len]).unwrap());
 
         let internal_input = make_index(2);
         let internal_output = make_index(2);
@@ -567,7 +565,7 @@ fn build_uniform_chain_state_and_identity_operator(
                 }
             }
         }
-        mpo_tensors.push(TensorDynLen::from_dense(mpo_indices, mpo_data).unwrap());
+        mpo_tensors.push(IdxTensor::from_dense(mpo_indices, mpo_data).unwrap());
 
         input_mapping.insert(
             name.clone(),
@@ -601,8 +599,8 @@ fn build_uniform_chain_state_and_identity_operator(
 }
 
 fn assert_identity_application(
-    state: &TreeTN<TensorDynLen, String>,
-    operator: &LinearOperator<TensorDynLen, String>,
+    state: &TreeTN<IdxTensor, String>,
+    operator: &LinearOperator<IdxTensor, String>,
 ) {
     use crate::operator::apply_linear_operator;
 
@@ -748,20 +746,20 @@ fn test_apply_linear_operator_full_coverage() {
     use crate::operator::ApplyOptions;
 
     // Create a 2-site state
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = make_index(2);
     let s1 = make_index(2);
     let b01 = make_index(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 4]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 4]).unwrap();
 
     let n0 = state.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = state.add_tensor("site1".to_string(), t1).unwrap();
     state.connect(n0, &b01, n1, &b01).unwrap();
 
     // Create identity operator covering both sites
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let s0_in = make_index(2);
     let s0_out = make_index(2);
     let s1_in = make_index(2);
@@ -769,14 +767,13 @@ fn test_apply_linear_operator_full_coverage() {
     let b_mpo = make_index(1);
 
     let id_data = vec![1.0, 0.0, 0.0, 1.0]; // Identity matrix
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
     let t1_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data)
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data).unwrap();
 
     let n0_mpo = mpo.add_tensor("site0".to_string(), t0_mpo).unwrap();
     let n1_mpo = mpo.add_tensor("site1".to_string(), t1_mpo).unwrap();
@@ -835,12 +832,12 @@ fn naive_apply_preserves_product_link_space_for_redundant_mpo_bond() {
     let state_bond = make_index(2);
     let state = TreeTN::from_tensors(
         vec![
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![s0.clone(), state_bond.clone()],
                 vec![1.0, 3.0, 2.0, 5.0],
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![state_bond.clone(), s1.clone()],
                 vec![7.0, 11.0, 13.0, 17.0],
             )
@@ -962,17 +959,17 @@ fn test_apply_linear_operator_partial() {
     use crate::operator::ApplyOptions;
 
     // Create a 3-site state
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = make_index(2);
     let s1 = make_index(2);
     let s2 = make_index(2);
     let b01 = make_index(2);
     let b12 = make_index(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
     let t1 =
-        TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
-    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], vec![1.0; 4]).unwrap();
+        IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone(), s2.clone()], vec![1.0; 4]).unwrap();
 
     let n0 = state.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = state.add_tensor("site1".to_string(), t1).unwrap();
@@ -981,7 +978,7 @@ fn test_apply_linear_operator_partial() {
     state.connect(n1, &b12, n2, &b12).unwrap();
 
     // Create operator covering only site0 and site1 (partial)
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let s0_in = make_index(2);
     let s0_out = make_index(2);
     let s1_in = make_index(2);
@@ -989,14 +986,13 @@ fn test_apply_linear_operator_partial() {
     let b_mpo = make_index(1);
 
     let id_data = vec![1.0, 0.0, 0.0, 1.0];
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
     let t1_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data)
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data).unwrap();
 
     let n0_mpo = mpo.add_tensor("site0".to_string(), t0_mpo).unwrap();
     let n1_mpo = mpo.add_tensor("site1".to_string(), t1_mpo).unwrap();
@@ -1046,17 +1042,17 @@ fn test_apply_linear_operator_partial_preserves_site_index_set() {
     use crate::operator::apply_linear_operator;
     use crate::operator::ApplyOptions;
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = make_index(2);
     let s1 = make_index(2);
     let s2 = make_index(2);
     let b01 = make_index(2);
     let b12 = make_index(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
     let t1 =
-        TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
-    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], vec![1.0; 4]).unwrap();
+        IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 8]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone(), s2.clone()], vec![1.0; 4]).unwrap();
 
     let n0 = state.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = state.add_tensor("site1".to_string(), t1).unwrap();
@@ -1064,7 +1060,7 @@ fn test_apply_linear_operator_partial_preserves_site_index_set() {
     state.connect(n0, &b01, n1, &b01).unwrap();
     state.connect(n1, &b12, n2, &b12).unwrap();
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let s0_in = make_index(2);
     let s0_out = make_index(2);
     let s1_in = make_index(2);
@@ -1072,14 +1068,13 @@ fn test_apply_linear_operator_partial_preserves_site_index_set() {
     let b_mpo = make_index(1);
 
     let id_data = vec![1.0, 0.0, 0.0, 1.0];
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
     let t1_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data)
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data).unwrap();
 
     let n0_mpo = mpo.add_tensor("site0".to_string(), t0_mpo).unwrap();
     let n1_mpo = mpo.add_tensor("site1".to_string(), t1_mpo).unwrap();
@@ -1132,7 +1127,7 @@ fn test_apply_linear_operator_partial_shift_factorized_rooted_state_intermediate
     let s0 = make_index(2);
     let s1 = make_index(2);
     let spectator = make_index(2);
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         vec![s0.clone(), s1.clone(), spectator.clone()],
         vec![10.0, 30.0, 20.0, 40.0, 11.0, 31.0, 21.0, 41.0],
     )
@@ -1148,7 +1143,7 @@ fn test_apply_linear_operator_partial_shift_factorized_rooted_state_intermediate
     state_edges.sort();
     assert_eq!(state_edges, vec![(0usize, 1usize), (1usize, 2usize)]);
 
-    let mut mpo = TreeTN::<TensorDynLen, usize>::new();
+    let mut mpo = TreeTN::<IdxTensor, usize>::new();
     let s0_in = make_index(2);
     let s0_out = make_index(2);
     let s1_in = make_index(2);
@@ -1156,14 +1151,13 @@ fn test_apply_linear_operator_partial_shift_factorized_rooted_state_intermediate
     let b_mpo = make_index(1);
 
     let id_data = vec![1.0, 0.0, 0.0, 1.0];
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
     let t1_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data)
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s1_out.clone(), s1_in.clone()], id_data).unwrap();
 
     let n0_mpo = mpo.add_tensor(0usize, t0_mpo).unwrap();
     let n1_mpo = mpo.add_tensor(1usize, t1_mpo).unwrap();
@@ -1325,20 +1319,20 @@ fn test_apply_linear_operator_error_cases() {
     use crate::operator::ApplyOptions;
 
     // Create a 2-site state
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = make_index(2);
     let s1 = make_index(2);
     let b01 = make_index(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 4]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone()], vec![1.0; 4]).unwrap();
 
     let n0 = state.add_tensor("site0".to_string(), t0).unwrap();
     let n1 = state.add_tensor("site1".to_string(), t1).unwrap();
     state.connect(n0, &b01, n1, &b01).unwrap();
 
     // Create operator with extra node not in state (should error)
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     let s0_in = make_index(2);
     let s0_out = make_index(2);
     let s2_in = make_index(2); // site2 doesn't exist in state
@@ -1346,14 +1340,13 @@ fn test_apply_linear_operator_error_cases() {
     let b_mpo = make_index(1);
 
     let id_data = vec![1.0, 0.0, 0.0, 1.0];
-    let t0_mpo = TensorDynLen::from_dense(
+    let t0_mpo = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), b_mpo.clone()],
         id_data.clone(),
     )
     .unwrap();
     let t2_mpo =
-        TensorDynLen::from_dense(vec![b_mpo.clone(), s2_out.clone(), s2_in.clone()], id_data)
-            .unwrap();
+        IdxTensor::from_dense(vec![b_mpo.clone(), s2_out.clone(), s2_in.clone()], id_data).unwrap();
 
     let n0_mpo = mpo.add_tensor("site0".to_string(), t0_mpo).unwrap();
     let n2_mpo = mpo.add_tensor("site2".to_string(), t2_mpo).unwrap();
@@ -1492,12 +1485,12 @@ fn test_compose_operator_along_state_paths_missing_state_node() {
     let g_out = make_index(2);
     let bond = make_index(1);
 
-    let t_a = TensorDynLen::from_dense(
+    let t_a = IdxTensor::from_dense(
         vec![a_out.clone(), a_in.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 1.0],
     )
     .unwrap();
-    let t_g = TensorDynLen::from_dense(
+    let t_g = IdxTensor::from_dense(
         vec![bond.clone(), g_out.clone(), g_in.clone()],
         vec![1.0, 0.0, 0.0, 1.0],
     )

--- a/crates/tensor4all-treetn/src/operator/compose/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/compose/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::random::{random_treetn, LinkSpace};
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 
 type DynIndex = Index<DynId, TagSet>;
 
@@ -26,10 +26,10 @@ fn create_chain_site_network(n: usize) -> SiteIndexNetwork<String, DynIndex> {
 
 /// Create a simple LinearOperator from a TreeTN with explicit index mappings.
 fn create_linear_operator_from_treetn(
-    mpo: TreeTN<TensorDynLen, String>,
+    mpo: TreeTN<IdxTensor, String>,
     input_indices: &[(String, DynIndex, DynIndex)], // (node, true_input, internal_input)
     output_indices: &[(String, DynIndex, DynIndex)], // (node, true_output, internal_output)
-) -> LinearOperator<TensorDynLen, String> {
+) -> LinearOperator<IdxTensor, String> {
     let mut input_mapping = HashMap::new();
     let mut output_mapping = HashMap::new();
 
@@ -83,7 +83,7 @@ fn test_are_exclusive_disjoint() {
     let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
     // Test exclusivity
-    let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
+    let result = are_exclusive_operators::<IdxTensor, _, _>(&target, &[&op1, &op2]);
     assert!(result, "Disjoint operators should be exclusive");
 }
 
@@ -112,7 +112,7 @@ fn test_are_exclusive_overlapping() {
     let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
     let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
-    let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
+    let result = are_exclusive_operators::<IdxTensor, _, _>(&target, &[&op1, &op2]);
     assert!(!result, "Overlapping operators should not be exclusive");
 }
 
@@ -133,7 +133,7 @@ fn test_are_exclusive_single_node_operators() {
     let op1 = random_treetn::<f64, _, _>(&mut rng, &op1_net, link_space.clone()).unwrap();
     let op2 = random_treetn::<f64, _, _>(&mut rng, &op2_net, link_space.clone()).unwrap();
 
-    let result = are_exclusive_operators::<TensorDynLen, _, _>(&target, &[&op1, &op2]);
+    let result = are_exclusive_operators::<IdxTensor, _, _>(&target, &[&op1, &op2]);
     assert!(result, "Single-node disjoint operators should be exclusive");
 }
 

--- a/crates/tensor4all-treetn/src/operator/identity.rs
+++ b/crates/tensor4all-treetn/src/operator/identity.rs
@@ -7,7 +7,7 @@
 
 use crate::error::TreeTNOperationError;
 
-use tensor4all_core::{DynIndex, TensorConstructionLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, TensorConstructionLike};
 
 /// Build an identity operator tensor for a gap node.
 ///
@@ -41,8 +41,8 @@ use tensor4all_core::{DynIndex, TensorConstructionLike, TensorDynLen};
 pub fn build_identity_operator_tensor(
     site_indices: &[DynIndex],
     output_site_indices: &[DynIndex],
-) -> std::result::Result<TensorDynLen, TreeTNOperationError> {
-    <TensorDynLen as TensorConstructionLike>::delta(site_indices, output_site_indices)
+) -> std::result::Result<IdxTensor, TreeTNOperationError> {
+    <IdxTensor as TensorConstructionLike>::delta(site_indices, output_site_indices)
         .map_err(TreeTNOperationError::from)
 }
 

--- a/crates/tensor4all-treetn/src/operator/identity/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/identity/tests/mod.rs
@@ -5,7 +5,7 @@ fn make_index(dim: usize) -> DynIndex {
     Index::new_dyn(dim)
 }
 
-fn get_f64_data(tensor: &TensorDynLen) -> Vec<f64> {
+fn get_f64_data(tensor: &IdxTensor) -> Vec<f64> {
     tensor.to_vec::<f64>().expect("Expected DenseF64 storage")
 }
 

--- a/crates/tensor4all-treetn/src/operator/linear_operator.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator.rs
@@ -27,9 +27,9 @@ use std::hash::Hash;
 use anyhow::Result;
 
 use tensor4all_core::DynIndex;
+use tensor4all_core::IdxTensor;
 use tensor4all_core::IndexLike;
 use tensor4all_core::LinearizationOrder;
-use tensor4all_core::TensorDynLen;
 use tensor4all_core::TensorLike;
 
 use super::index_mapping::IndexMapping;
@@ -52,14 +52,14 @@ use crate::treetn::TreeTN;
 ///
 /// ```
 /// use tensor4all_treetn::LinearOperator;
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 /// use tensor4all_treetn::TreeTN;
 /// use std::collections::HashMap;
 ///
 /// // Build a trivial single-node LinearOperator wrapping a 2x2 identity
 /// let s_in = DynIndex::new_dyn(2);
 /// let s_out = DynIndex::new_dyn(2);
-/// let t = TensorDynLen::from_dense(
+/// let t = IdxTensor::from_dense(
 ///     vec![s_in.clone(), s_out.clone()],
 ///     vec![1.0_f64, 0.0, 0.0, 1.0],
 /// ).unwrap();
@@ -100,14 +100,14 @@ where
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// // Build a 2x2 identity operator (single node)
     /// let site = DynIndex::new_dyn(2);
     /// let s_in = DynIndex::new_dyn(2);
     /// let s_out = DynIndex::new_dyn(2);
-    /// let mpo_tensor = TensorDynLen::from_dense(
+    /// let mpo_tensor = IdxTensor::from_dense(
     ///     vec![s_in.clone(), s_out.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// ).unwrap();
@@ -159,7 +159,7 @@ where
     /// # Examples
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let x = DynIndex::new_dyn(2);
@@ -168,7 +168,7 @@ where
     /// let y_in = DynIndex::new_dyn(3);
     /// let x_out = DynIndex::new_dyn(2);
     /// let y_out = DynIndex::new_dyn(3);
-    /// let mpo_tensor = TensorDynLen::delta(
+    /// let mpo_tensor = IdxTensor::delta(
     ///     &[x_in.clone(), y_in.clone()],
     ///     &[x_out.clone(), y_out.clone()],
     /// ).unwrap();
@@ -402,17 +402,17 @@ where
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let true_site = DynIndex::new_dyn(2);
     /// let input_internal = DynIndex::new_dyn(2);
     /// let output_internal = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![input_internal.clone(), output_internal.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// )?;
-    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     ///
     /// let mut input_mapping = HashMap::new();
     /// input_mapping.insert(0, IndexMapping {
@@ -461,17 +461,17 @@ where
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let true_site = DynIndex::new_dyn(2);
     /// let input_internal = DynIndex::new_dyn(2);
     /// let output_internal = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![input_internal.clone(), output_internal.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// )?;
-    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     ///
     /// let mut input_mapping = HashMap::new();
     /// input_mapping.insert(0, IndexMapping {
@@ -742,20 +742,20 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let state_index = DynIndex::new_dyn(2);
-    /// let state_tensor = TensorDynLen::from_dense(vec![state_index.clone()], vec![1.0, 2.0]).unwrap();
-    /// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
+    /// let state_tensor = IdxTensor::from_dense(vec![state_index.clone()], vec![1.0, 2.0]).unwrap();
+    /// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0]).unwrap();
     ///
     /// let input_internal = DynIndex::new_dyn(2);
     /// let output_internal = DynIndex::new_dyn(2);
-    /// let mpo_tensor = TensorDynLen::from_dense(
+    /// let mpo_tensor = IdxTensor::from_dense(
     ///     vec![input_internal.clone(), output_internal.clone()],
     ///     vec![1.0, 0.0, 0.0, 1.0],
     /// ).unwrap();
-    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
+    /// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![mpo_tensor], vec![0]).unwrap();
     ///
     /// let mut input_mapping = HashMap::new();
     /// input_mapping.insert(
@@ -804,7 +804,7 @@ where
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let site_in = DynIndex::new_dyn(2);
@@ -812,7 +812,7 @@ where
     /// let s_in_tmp = DynIndex::new_dyn(2);
     /// let s_out_tmp = DynIndex::new_dyn(3);
     ///
-    /// let mpo_tensor = TensorDynLen::from_dense(
+    /// let mpo_tensor = IdxTensor::from_dense(
     ///     vec![s_in_tmp.clone(), s_out_tmp.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 0.0, 1.0, 0.0],
     /// ).unwrap();
@@ -876,7 +876,7 @@ where
     /// ```
     /// use std::collections::{HashMap, HashSet};
     ///
-    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     /// use tensor4all_treetn::{
     ///     IndexMapping, LinearOperator, RestructureOptions, SiteIndexNetwork, TreeTN,
     /// };
@@ -890,15 +890,15 @@ where
     /// let y_out = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(1);
     ///
-    /// let left = TensorDynLen::from_dense(
+    /// let left = IdxTensor::from_dense(
     ///     vec![x_out.clone(), x_in.clone(), bond.clone()],
     ///     vec![1.0, 0.0, 0.0, 1.0],
     /// )?;
-    /// let right = TensorDynLen::from_dense(
+    /// let right = IdxTensor::from_dense(
     ///     vec![bond, y_out.clone(), y_in.clone()],
     ///     vec![1.0, 0.0, 0.0, 1.0],
     /// )?;
-    /// let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    /// let mut mpo = TreeTN::<IdxTensor, String>::new();
     /// mpo.add_tensor("x".to_string(), left)?;
     /// mpo.add_tensor("y".to_string(), right)?;
     /// let x_node = mpo.node_index(&"x".to_string()).unwrap();
@@ -980,14 +980,14 @@ where
     }
 }
 
-impl<V> LinearOperator<TensorDynLen, V>
+impl<V> LinearOperator<IdxTensor, V>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
 {
     /// Replace one fused input mapping with several ordered input mappings.
     ///
     /// The operator's internal input index is exactly unfused inside the MPO
-    /// tensor using [`TensorDynLen::unfuse_index`], then the corresponding
+    /// tensor using [`IdxTensor::unfuse_index`], then the corresponding
     /// [`IndexMapping`] entry is replaced by one entry per `new_true_indices`.
     /// New internal indices are generated automatically with matching
     /// dimensions and the same order as `new_true_indices`.
@@ -1021,7 +1021,7 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// # fn main() -> anyhow::Result<()> {
@@ -1029,14 +1029,14 @@ where
     /// let y = DynIndex::new_dyn(4);
     /// let x_internal = DynIndex::new_dyn(4);
     /// let y_internal = DynIndex::new_dyn(4);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![y_internal.clone(), x_internal.clone()],
     ///     vec![1.0, 0.0, 0.0, 0.0,
     ///          0.0, 1.0, 0.0, 0.0,
     ///          0.0, 0.0, 1.0, 0.0,
     ///          0.0, 0.0, 0.0, 1.0],
     /// )?;
-    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     /// let mut input = HashMap::new();
     /// input.insert(0, IndexMapping { true_index: x.clone(), internal_index: x_internal });
     /// let mut output = HashMap::new();
@@ -1096,7 +1096,7 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// # fn main() -> anyhow::Result<()> {
@@ -1104,14 +1104,14 @@ where
     /// let y = DynIndex::new_dyn(4);
     /// let x_internal = DynIndex::new_dyn(4);
     /// let y_internal = DynIndex::new_dyn(4);
-    /// let tensor = TensorDynLen::from_dense(
+    /// let tensor = IdxTensor::from_dense(
     ///     vec![y_internal.clone(), x_internal.clone()],
     ///     vec![1.0, 0.0, 0.0, 0.0,
     ///          0.0, 1.0, 0.0, 0.0,
     ///          0.0, 0.0, 1.0, 0.0,
     ///          0.0, 0.0, 0.0, 1.0],
     /// )?;
-    /// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     /// let mut input = HashMap::new();
     /// input.insert(0, IndexMapping { true_index: x, internal_index: x_internal });
     /// let mut output = HashMap::new();

--- a/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/linear_operator/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::collections::{HashMap, HashSet};
-use tensor4all_core::{DynIndex, LinearizationOrder, TensorConstructionLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, LinearizationOrder, TensorConstructionLike};
 
 use crate::operator::index_mapping::IndexMapping;
 use crate::operator::Operator;
@@ -11,8 +11,8 @@ use crate::{RestructureOptions, SiteIndexNetwork};
 /// Structure: single node "A" with indices (s_in_tmp, s_out_tmp)
 /// Also returns a "state" TreeTN with a single site index s.
 fn make_simple_mpo_and_state() -> (
-    TreeTN<TensorDynLen, String>,
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex, // s (true site index)
     DynIndex, // s_in_tmp
     DynIndex, // s_out_tmp
@@ -25,15 +25,15 @@ fn make_simple_mpo_and_state() -> (
     // s_in_tmp x s_out_tmp with identity values
     let mpo_data = vec![1.0, 0.0, 0.0, 1.0]; // identity matrix
     let mpo_tensor =
-        TensorDynLen::from_dense(vec![s_in_tmp.clone(), s_out_tmp.clone()], mpo_data).unwrap();
-    let mpo = TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()])
-        .unwrap();
+        IdxTensor::from_dense(vec![s_in_tmp.clone(), s_out_tmp.clone()], mpo_data).unwrap();
+    let mpo =
+        TreeTN::<IdxTensor, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()]).unwrap();
 
     // State tensor
     let state_data = vec![1.0, 0.0]; // |0> state
-    let state_tensor = TensorDynLen::from_dense(vec![s.clone()], state_data).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![s.clone()], state_data).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
             .unwrap();
 
     (mpo, state, s, s_in_tmp, s_out_tmp)
@@ -42,7 +42,7 @@ fn make_simple_mpo_and_state() -> (
 /// Create a simple LinearOperator for testing.
 /// Returns (operator, s, s_in_tmp, s_out_tmp)
 fn make_linear_operator() -> (
-    LinearOperator<TensorDynLen, String>,
+    LinearOperator<IdxTensor, String>,
     DynIndex, // s (true site index)
     DynIndex, // s_in_tmp
     DynIndex, // s_out_tmp
@@ -71,7 +71,7 @@ fn make_linear_operator() -> (
     (op, s, s_in_tmp, s_out_tmp)
 }
 
-fn make_three_node_linear_operator() -> LinearOperator<TensorDynLen, usize> {
+fn make_three_node_linear_operator() -> LinearOperator<IdxTensor, usize> {
     let site0 = DynIndex::new_dyn(2);
     let site1 = DynIndex::new_dyn(2);
     let site2 = DynIndex::new_dyn(2);
@@ -84,17 +84,17 @@ fn make_three_node_linear_operator() -> LinearOperator<TensorDynLen, usize> {
     let bond01 = DynIndex::new_dyn(2);
     let bond12 = DynIndex::new_dyn(3);
 
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![in0.clone(), out0.clone(), bond01.clone()],
         vec![1.0_f64; 2 * 2 * 2],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond01.clone(), in1.clone(), out1.clone(), bond12.clone()],
         vec![1.0_f64; 2 * 2 * 2 * 3],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![bond12.clone(), in2.clone(), out2.clone()],
         vec![1.0_f64; 3 * 2 * 2],
     )
@@ -151,7 +151,7 @@ fn make_three_node_linear_operator() -> LinearOperator<TensorDynLen, usize> {
 }
 
 fn make_fused_identity_operator() -> (
-    LinearOperator<TensorDynLen, String>,
+    LinearOperator<IdxTensor, String>,
     DynIndex,
     DynIndex,
     DynIndex,
@@ -167,10 +167,9 @@ fn make_fused_identity_operator() -> (
         data[value + 4 * value] = 1.0;
     }
     let tensor =
-        TensorDynLen::from_dense(vec![output_internal.clone(), input_internal.clone()], data)
-            .unwrap();
+        IdxTensor::from_dense(vec![output_internal.clone(), input_internal.clone()], data).unwrap();
     let mpo =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     let mut input_mapping = HashMap::new();
     input_mapping.insert(
@@ -299,7 +298,7 @@ fn test_linear_operator_apply_local_identity() {
     let (op, s, _s_in_tmp, _s_out_tmp) = make_linear_operator();
 
     // Create a local tensor to apply operator to: |0> = [1, 0]
-    let local_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
+    let local_tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
 
     let result = op.apply_local(&local_tensor, &["A".to_string()]).unwrap();
 
@@ -339,17 +338,17 @@ fn test_from_mpo_and_state_mismatched_site_count() {
     let s_out_tmp = DynIndex::new_dyn(2);
     let s_extra = DynIndex::new_dyn(2);
 
-    let mpo_tensor = TensorDynLen::from_dense(
+    let mpo_tensor = IdxTensor::from_dense(
         vec![s_in_tmp.clone(), s_out_tmp.clone(), s_extra.clone()],
         vec![0.0; 8],
     )
     .unwrap();
-    let mpo = TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()])
-        .unwrap();
+    let mpo =
+        TreeTN::<IdxTensor, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()]).unwrap();
 
-    let state_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
             .unwrap();
 
     let result = LinearOperator::from_mpo_and_state(mpo, &state);
@@ -366,9 +365,9 @@ fn test_from_mpo_and_state_no_site_indices() {
     let s_out = DynIndex::new_dyn(2);
 
     // State: A has site index, B has no site index (only bond)
-    let t_a = TensorDynLen::from_dense(vec![s.clone(), bond.clone()], vec![1.0; 4]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![bond.clone()], vec![1.0; 2]).unwrap();
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let t_a = IdxTensor::from_dense(vec![s.clone(), bond.clone()], vec![1.0; 4]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![bond.clone()], vec![1.0; 2]).unwrap();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     state.add_tensor("A".to_string(), t_a).unwrap();
     state.add_tensor("B".to_string(), t_b).unwrap();
     let a = state.node_index(&"A".to_string()).unwrap();
@@ -377,13 +376,13 @@ fn test_from_mpo_and_state_no_site_indices() {
 
     // MPO: A has two site indices, B has no site index (only bond)
     let bond2 = DynIndex::new_dyn(2);
-    let t_a_mpo = TensorDynLen::from_dense(
+    let t_a_mpo = IdxTensor::from_dense(
         vec![s_in.clone(), s_out.clone(), bond2.clone()],
         vec![0.0; 8],
     )
     .unwrap();
-    let t_b_mpo = TensorDynLen::from_dense(vec![bond2.clone()], vec![0.0; 2]).unwrap();
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let t_b_mpo = IdxTensor::from_dense(vec![bond2.clone()], vec![0.0; 2]).unwrap();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     mpo.add_tensor("A".to_string(), t_a_mpo).unwrap();
     mpo.add_tensor("B".to_string(), t_b_mpo).unwrap();
     let a2 = mpo.node_index(&"A".to_string()).unwrap();
@@ -400,16 +399,16 @@ fn test_from_mpo_and_state_mismatched_presence() {
     // State has site indices at A, but MPO has none at A -> (Some, None) branch
     let s = DynIndex::new_dyn(2);
 
-    let state_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
             .unwrap();
 
     // MPO with no site indices
     let mpo_idx = DynIndex::new_dyn(1);
-    let mpo_tensor = TensorDynLen::from_dense(vec![mpo_idx.clone()], vec![1.0]).unwrap();
-    let mpo = TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()])
-        .unwrap();
+    let mpo_tensor = IdxTensor::from_dense(vec![mpo_idx.clone()], vec![1.0]).unwrap();
+    let mpo =
+        TreeTN::<IdxTensor, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()]).unwrap();
 
     // The state has site indices but the mpo's site indices are different,
     // so this should trigger a mismatch error
@@ -426,13 +425,13 @@ fn test_from_mpo_and_state_not_enough_matching_dims() {
     let s_out_tmp = DynIndex::new_dyn(3);
 
     let mpo_tensor =
-        TensorDynLen::from_dense(vec![s_in_tmp.clone(), s_out_tmp.clone()], vec![0.0; 9]).unwrap();
-    let mpo = TreeTN::<TensorDynLen, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()])
-        .unwrap();
+        IdxTensor::from_dense(vec![s_in_tmp.clone(), s_out_tmp.clone()], vec![0.0; 9]).unwrap();
+    let mpo =
+        TreeTN::<IdxTensor, String>::from_tensors(vec![mpo_tensor], vec!["A".to_string()]).unwrap();
 
-    let state_tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
             .unwrap();
 
     let result = LinearOperator::from_mpo_and_state(mpo, &state);
@@ -441,7 +440,7 @@ fn test_from_mpo_and_state_not_enough_matching_dims() {
 
 /// Create a 2-node MPO and state for multi-node apply_local test.
 fn make_two_node_mpo_and_operator() -> (
-    LinearOperator<TensorDynLen, String>,
+    LinearOperator<IdxTensor, String>,
     DynIndex, // s0 (true site index for A)
     DynIndex, // s1 (true site index for B)
 ) {
@@ -455,19 +454,19 @@ fn make_two_node_mpo_and_operator() -> (
 
     // Identity MPO: two nodes with bond dim 1
     // A tensor: s0_in x s0_out x bond
-    let t_a = TensorDynLen::from_dense(
+    let t_a = IdxTensor::from_dense(
         vec![s0_in.clone(), s0_out.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 1.0], // identity for each bond=0 slice
     )
     .unwrap();
     // B tensor: bond x s1_in x s1_out
-    let t_b = TensorDynLen::from_dense(
+    let t_b = IdxTensor::from_dense(
         vec![bond.clone(), s1_in.clone(), s1_out.clone()],
         vec![1.0, 0.0, 0.0, 1.0],
     )
     .unwrap();
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     mpo.add_tensor("A".to_string(), t_a).unwrap();
     mpo.add_tensor("B".to_string(), t_b).unwrap();
     let a = mpo.node_index(&"A".to_string()).unwrap();
@@ -516,7 +515,7 @@ fn test_apply_local_multi_node_region() {
 
     // Create a local tensor spanning both nodes: |00> = [1, 0, 0, 0]
     let local_tensor =
-        TensorDynLen::from_dense(vec![s0.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 0.0]).unwrap();
+        IdxTensor::from_dense(vec![s0.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 0.0]).unwrap();
 
     let result = op
         .apply_local(&local_tensor, &["A".to_string(), "B".to_string()])
@@ -540,9 +539,9 @@ fn test_align_to_state_single_node() {
     let new_s = DynIndex::new_dyn(2);
     assert_ne!(original_s, new_s);
 
-    let state_tensor = TensorDynLen::from_dense(vec![new_s.clone()], vec![0.5, 0.5]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![new_s.clone()], vec![0.5, 0.5]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
             .unwrap();
 
     // Align operator to the new state
@@ -556,7 +555,7 @@ fn test_align_to_state_single_node() {
     assert_eq!(output_mapping.true_index, new_s);
 
     // Verify: operator should still work correctly after alignment
-    let local_tensor = TensorDynLen::from_dense(vec![new_s.clone()], vec![1.0, 0.0]).unwrap();
+    let local_tensor = IdxTensor::from_dense(vec![new_s.clone()], vec![1.0, 0.0]).unwrap();
     let result = op.apply_local(&local_tensor, &["A".to_string()]).unwrap();
     let result_data = result.to_vec::<f64>().unwrap();
     assert_eq!(result_data.len(), 2);
@@ -576,9 +575,9 @@ fn test_align_to_state_two_nodes() {
     assert_ne!(original_s0, new_s0);
     assert_ne!(original_s1, new_s1);
 
-    let t_a = TensorDynLen::from_dense(vec![new_s0.clone(), bond.clone()], vec![1.0; 2]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![bond.clone(), new_s1.clone()], vec![1.0; 2]).unwrap();
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let t_a = IdxTensor::from_dense(vec![new_s0.clone(), bond.clone()], vec![1.0; 2]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![bond.clone(), new_s1.clone()], vec![1.0; 2]).unwrap();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     state.add_tensor("A".to_string(), t_a).unwrap();
     state.add_tensor("B".to_string(), t_b).unwrap();
     let a = state.node_index(&"A".to_string()).unwrap();
@@ -602,7 +601,7 @@ fn test_align_to_state_two_nodes() {
     assert_eq!(output_b.true_index, new_s1);
 
     // Verify: operator still works after alignment
-    let local_tensor = TensorDynLen::from_dense(
+    let local_tensor = IdxTensor::from_dense(
         vec![new_s0.clone(), new_s1.clone()],
         vec![1.0, 0.0, 0.0, 0.0],
     )
@@ -624,9 +623,9 @@ fn test_align_to_state_dimension_mismatch() {
 
     // Create a state with a different dimension
     let new_s = DynIndex::new_dyn(3); // dim 3 != dim 2
-    let state_tensor = TensorDynLen::from_dense(vec![new_s.clone()], vec![1.0, 0.0, 0.0]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![new_s.clone()], vec![1.0, 0.0, 0.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["A".to_string()])
             .unwrap();
 
     // Should fail due to shape mismatch
@@ -640,9 +639,9 @@ fn test_align_to_state_missing_node() {
 
     // Create a state that doesn't have node "A"
     let new_s = DynIndex::new_dyn(2);
-    let state_tensor = TensorDynLen::from_dense(vec![new_s.clone()], vec![1.0, 0.0]).unwrap();
+    let state_tensor = IdxTensor::from_dense(vec![new_s.clone()], vec![1.0, 0.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![state_tensor], vec!["B".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![state_tensor], vec!["B".to_string()])
             .unwrap();
 
     // Should fail because node "A" is not in the state
@@ -760,7 +759,7 @@ fn test_unfuse_input_and_output_indices_splits_internal_mpo_axes() {
         .map(|mapping| mapping.internal_index.clone())
         .collect::<Vec<_>>();
     let expected =
-        <TensorDynLen as TensorConstructionLike>::delta(&output_internal, &input_internal).unwrap();
+        <IdxTensor as TensorConstructionLike>::delta(&output_internal, &input_internal).unwrap();
     let actual = op.mpo().contract_to_tensor().unwrap();
 
     assert!(actual.distance(&expected).unwrap() < 1.0e-12);

--- a/crates/tensor4all-treetn/src/operator/mod.rs
+++ b/crates/tensor4all-treetn/src/operator/mod.rs
@@ -22,8 +22,8 @@
 //! };
 //!
 //! assert_eq!(mapping.true_index.dim(), mapping.internal_index.dim());
-//! let _apply = apply_linear_operator::<tensor4all_core::TensorDynLen, usize>;
-//! let _compose = compose_exclusive_linear_operators::<tensor4all_core::TensorDynLen, usize>;
+//! let _apply = apply_linear_operator::<tensor4all_core::IdxTensor, usize>;
+//! let _compose = compose_exclusive_linear_operators::<tensor4all_core::IdxTensor, usize>;
 //! ```
 
 mod apply;

--- a/crates/tensor4all-treetn/src/prelude.rs
+++ b/crates/tensor4all-treetn/src/prelude.rs
@@ -2,15 +2,15 @@
 //! canonicalization, truncation, and application.
 //!
 //! ```rust
-//! use tensor4all_core::{DynIndex, TensorDynLen};
+//! use tensor4all_core::{DynIndex, IdxTensor};
 //! use tensor4all_treetn::prelude::*;
 //!
 //! let s0 = DynIndex::new_dyn(2);
 //! let s1 = DynIndex::new_dyn(2);
 //! let b01 = DynIndex::new_dyn(4);
-//! let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8]).unwrap();
-//! let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0; 8]).unwrap();
-//! let ttn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+//! let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0; 8]).unwrap();
+//! let t1 = IdxTensor::from_dense(vec![b01, s1], vec![1.0; 8]).unwrap();
+//! let ttn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
 //! assert_eq!(ttn.node_count(), 2);
 //! assert_eq!(ttn.edge_count(), 1);
 //! ```

--- a/crates/tensor4all-treetn/src/random.rs
+++ b/crates/tensor4all-treetn/src/random.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use tensor4all_core::index::{DynId, Index, TagSet};
 use tensor4all_core::tensor::RandomScalar;
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 
 /// Specification for link (bond) dimensions.
 ///
@@ -108,7 +108,7 @@ pub fn random_treetn<T, R, V>(
     rng: &mut R,
     site_network: &SiteIndexNetwork<V, DefaultIndex>,
     link_space: LinkSpace<V>,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, TreeTNOperationError>
 where
     T: RandomScalar,
     R: Rng,
@@ -164,7 +164,7 @@ where
         }
 
         // Create random tensor
-        let tensor = TensorDynLen::random::<T, R>(rng, all_indices)?;
+        let tensor = IdxTensor::random::<T, R>(rng, all_indices)?;
 
         tensors.push(tensor);
         node_names.push(node_name);

--- a/crates/tensor4all-treetn/src/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/src/simplett_bridge.rs
@@ -1,7 +1,7 @@
 use crate::error::TreeTNOperationError;
 use anyhow::Result;
 
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorElement};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorElement};
 use tensor4all_simplett::{
     tensor3_from_data, tensor3_zeros, AbstractTensorTrain, SimpleTensorTrain, TTScalar, Tensor3Ops,
 };
@@ -39,7 +39,7 @@ use crate::TreeTN;
 /// ```
 pub fn tensor_train_to_treetn<T>(
     tt: &SimpleTensorTrain<T>,
-) -> std::result::Result<(TreeTN<TensorDynLen, usize>, Vec<DynIndex>), TreeTNOperationError>
+) -> std::result::Result<(TreeTN<IdxTensor, usize>, Vec<DynIndex>), TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone,
 {
@@ -75,7 +75,7 @@ where
 pub fn tensor_train_to_treetn_with_names<T, V>(
     tt: &SimpleTensorTrain<T>,
     node_names: Vec<V>,
-) -> std::result::Result<(TreeTN<TensorDynLen, V>, Vec<DynIndex>), TreeTNOperationError>
+) -> std::result::Result<(TreeTN<IdxTensor, V>, Vec<DynIndex>), TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone,
     V: Clone + std::hash::Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -119,7 +119,7 @@ pub fn tensor_train_to_treetn_with_names_and_site_indices<T, V>(
     tt: &SimpleTensorTrain<T>,
     node_names: Vec<V>,
     site_indices: Vec<DynIndex>,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone,
     V: Clone + std::hash::Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -128,7 +128,7 @@ where
     Ok(treetn)
 }
 
-/// Convert a linear-chain `TreeTN<TensorDynLen, usize>` back into a simple tensor train.
+/// Convert a linear-chain `TreeTN<IdxTensor, usize>` back into a simple tensor train.
 ///
 /// The TreeTN must use node names `0..n-1`, contain exactly one site index per
 /// node, and have edges only between adjacent node names. This is the inverse of
@@ -170,7 +170,7 @@ where
 /// assert_eq!(roundtrip.full_tensor(), tt.full_tensor());
 /// ```
 pub fn treetn_to_tensor_train<T>(
-    mut treetn: TreeTN<TensorDynLen, usize>,
+    mut treetn: TreeTN<IdxTensor, usize>,
 ) -> std::result::Result<SimpleTensorTrain<T>, TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone,
@@ -276,7 +276,7 @@ where
     SimpleTensorTrain::new(tensors).map_err(|e| TreeTNOperationError::from(anyhow::Error::new(e)))
 }
 
-/// Insert a one-hot site into a linear-chain `TreeTN<TensorDynLen, usize>`.
+/// Insert a one-hot site into a linear-chain `TreeTN<IdxTensor, usize>`.
 ///
 /// The input and output chains use node names `0..n-1` / `0..n`. `position`
 /// chooses the insertion point:
@@ -334,11 +334,11 @@ where
 /// # }
 /// ```
 pub fn insert_onehot_site_in_treetn_chain<T>(
-    treetn: TreeTN<TensorDynLen, usize>,
+    treetn: TreeTN<IdxTensor, usize>,
     position: usize,
     site_index: DynIndex,
     value: usize,
-) -> std::result::Result<TreeTN<TensorDynLen, usize>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, usize>, TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone + Default,
 {
@@ -388,7 +388,7 @@ where
     tensor_train_to_treetn_with_names_and_site_indices(&tt, (0..tt.len()).collect(), site_indices)
 }
 
-/// Fix a site in a linear-chain `TreeTN<TensorDynLen, usize>` and remove it.
+/// Fix a site in a linear-chain `TreeTN<IdxTensor, usize>` and remove it.
 ///
 /// `position` selects the chain site to remove, and `value` selects the local
 /// coordinate kept at that site. The returned chain has one fewer site, node
@@ -439,10 +439,10 @@ where
 /// # }
 /// ```
 pub fn fix_and_remove_site_from_treetn_chain<T>(
-    treetn: TreeTN<TensorDynLen, usize>,
+    treetn: TreeTN<IdxTensor, usize>,
     position: usize,
     value: usize,
-) -> std::result::Result<TreeTN<TensorDynLen, usize>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, usize>, TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone + Default,
 {
@@ -474,7 +474,7 @@ where
         .map_err(TreeTNOperationError::from)
 }
 
-/// Contract a site of a linear-chain `TreeTN<TensorDynLen, usize>` with weights and remove it.
+/// Contract a site of a linear-chain `TreeTN<IdxTensor, usize>` with weights and remove it.
 ///
 /// The removed site is summed as `sum_s weights[s] * tensor[..., s, ...]`.
 /// Pass already scaled weights, such as `1/d` averaging weights, when a
@@ -525,10 +525,10 @@ where
 /// # }
 /// ```
 pub fn weighted_remove_site_from_treetn_chain<T>(
-    treetn: TreeTN<TensorDynLen, usize>,
+    treetn: TreeTN<IdxTensor, usize>,
     position: usize,
     weights: &[T],
-) -> std::result::Result<TreeTN<TensorDynLen, usize>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, usize>, TreeTNOperationError>
 where
     T: TTScalar + TensorElement + Clone + Default,
 {
@@ -557,10 +557,7 @@ where
         .map_err(TreeTNOperationError::from)
 }
 
-fn chain_site_indices(
-    treetn: &TreeTN<TensorDynLen, usize>,
-    context: &str,
-) -> Result<Vec<DynIndex>> {
+fn chain_site_indices(treetn: &TreeTN<IdxTensor, usize>, context: &str) -> Result<Vec<DynIndex>> {
     let nsites = treetn.node_count();
     let mut node_names = treetn.node_names();
     node_names.sort_unstable();
@@ -620,7 +617,7 @@ fn remove_site_with_reduced_matrix<T>(
     mut site_indices: Vec<DynIndex>,
     position: usize,
     reduced_site: &[T],
-) -> Result<TreeTN<TensorDynLen, usize>>
+) -> Result<TreeTN<IdxTensor, usize>>
 where
     T: TTScalar + TensorElement + Clone + Default,
 {
@@ -710,7 +707,7 @@ fn tensor_train_to_treetn_impl<T, V>(
     tt: &SimpleTensorTrain<T>,
     node_names: Vec<V>,
     site_indices: Option<Vec<DynIndex>>,
-) -> Result<(TreeTN<TensorDynLen, V>, Vec<DynIndex>)>
+) -> Result<(TreeTN<IdxTensor, V>, Vec<DynIndex>)>
 where
     T: TTScalar + TensorElement + Clone,
     V: Clone + std::hash::Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
@@ -765,22 +762,22 @@ where
         let site_tensor = tt.site_tensor(site);
         let tensor = if nsites == 1 {
             let data = single_site_data(site_tensor);
-            TensorDynLen::from_dense(vec![site_indices[site].clone()], data)?
+            IdxTensor::from_dense(vec![site_indices[site].clone()], data)?
         } else if site == 0 {
             let data = left_boundary_data(site_tensor);
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![site_indices[site].clone(), bond_indices[site].clone()],
                 data,
             )?
         } else if site + 1 == nsites {
             let data = right_boundary_data(site_tensor);
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[site - 1].clone(), site_indices[site].clone()],
                 data,
             )?
         } else {
             let data = middle_site_data(site_tensor);
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[site - 1].clone(),
                     site_indices[site].clone(),
@@ -808,7 +805,7 @@ where
 }
 
 fn treetn_site_to_tensor3<T>(
-    tensor: TensorDynLen,
+    tensor: IdxTensor,
     metadata: ChainSiteMetadata,
     site: usize,
 ) -> Result<tensor4all_simplett::Tensor3<T>>

--- a/crates/tensor4all-treetn/src/tdvp/mod.rs
+++ b/crates/tensor4all-treetn/src/tdvp/mod.rs
@@ -1071,21 +1071,21 @@ where
 /// ```
 /// use std::collections::HashMap;
 /// use num_complex::Complex64;
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{tdvp, IndexMapping, LinearOperator, TdvpOptions, TreeTN};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let site = DynIndex::new_dyn(2);
-/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+/// let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0])?;
 ///
 /// let input = DynIndex::new_dyn(2);
 /// let output = DynIndex::new_dyn(2);
-/// let op_tensor = TensorDynLen::from_dense(
+/// let op_tensor = IdxTensor::from_dense(
 ///     vec![output.clone(), input.clone()],
 ///     vec![1.0, 0.0, 0.0, 1.0],
 /// )?;
-/// let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+/// let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![op_tensor], vec![0])?;
 /// let operator = LinearOperator::new(
 ///     mpo,
 ///     HashMap::from([(0, IndexMapping { true_index: site.clone(), internal_index: input })]),
@@ -1228,17 +1228,17 @@ where
 ///
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{tdvp_with_treetn_operator, TdvpOptions, TreeTN};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let site = DynIndex::new_dyn(2);
-/// let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+/// let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0])?;
 /// let input = DynIndex::new_dyn(2);
 /// let output = DynIndex::new_dyn(2);
-/// let op_tensor = TensorDynLen::from_dense(vec![output, input], vec![1.0, 0.0, 0.0, 1.0])?;
-/// let operator = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+/// let op_tensor = IdxTensor::from_dense(vec![output, input], vec![1.0, 0.0, 0.0, 1.0])?;
+/// let operator = TreeTN::<IdxTensor, usize>::from_tensors(vec![op_tensor], vec![0])?;
 ///
 /// let result = tdvp_with_treetn_operator(&operator, state, &0, TdvpOptions::default().with_nsite(1))?;
 /// assert_eq!(result.sweeps_completed, 1);

--- a/crates/tensor4all-treetn/src/treetn/addition.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition.rs
@@ -67,14 +67,14 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
-    /// # fn make_chain(site0: DynIndex, site1: DynIndex) -> TreeTN<TensorDynLen, usize> {
+    /// # fn make_chain(site0: DynIndex, site1: DynIndex) -> TreeTN<IdxTensor, usize> {
     /// #     let bond = DynIndex::new_dyn(1);
-    /// #     let t0 = TensorDynLen::from_dense(vec![site0, bond.clone()], vec![1.0, 0.0]).unwrap();
-    /// #     let t1 = TensorDynLen::from_dense(vec![bond, site1], vec![1.0, 0.0]).unwrap();
-    /// #     TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap()
+    /// #     let t0 = IdxTensor::from_dense(vec![site0, bond.clone()], vec![1.0, 0.0]).unwrap();
+    /// #     let t1 = IdxTensor::from_dense(vec![bond, site1], vec![1.0, 0.0]).unwrap();
+    /// #     TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap()
     /// # }
     /// let state_a = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
     /// let state_b = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
@@ -160,14 +160,14 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
-    /// # fn make_chain(site0: DynIndex, site1: DynIndex) -> TreeTN<TensorDynLen, usize> {
+    /// # fn make_chain(site0: DynIndex, site1: DynIndex) -> TreeTN<IdxTensor, usize> {
     /// #     let bond = DynIndex::new_dyn(1);
-    /// #     let t0 = TensorDynLen::from_dense(vec![site0, bond.clone()], vec![1.0, 0.0]).unwrap();
-    /// #     let t1 = TensorDynLen::from_dense(vec![bond, site1], vec![1.0, 0.0]).unwrap();
-    /// #     TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap()
+    /// #     let t0 = IdxTensor::from_dense(vec![site0, bond.clone()], vec![1.0, 0.0]).unwrap();
+    /// #     let t1 = IdxTensor::from_dense(vec![bond, site1], vec![1.0, 0.0]).unwrap();
+    /// #     TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap()
     /// # }
     /// let state_a = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
     /// let state_b = make_chain(DynIndex::new_dyn(2), DynIndex::new_dyn(2));
@@ -326,17 +326,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();
     /// let tn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
     ///
     /// // Adding a single-node network to itself doubles the values
     /// let sum = tn.add(&tn).unwrap();
     /// let dense = sum.to_dense().unwrap();
-    /// let expected = TensorDynLen::from_dense(vec![s], vec![2.0, 4.0]).unwrap();
+    /// let expected = IdxTensor::from_dense(vec![s], vec![2.0, 4.0]).unwrap();
     /// assert!(dense.distance(&expected).unwrap() < 1e-12);
     /// ```
     pub fn add(&self, other: &Self) -> std::result::Result<Self, TreeTNOperationError>
@@ -479,12 +479,12 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{AnyScalar, DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let site = DynIndex::new_dyn(2);
-    /// let a = TensorDynLen::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap();
-    /// let b = TensorDynLen::from_dense(vec![site.clone()], vec![3.0_f64, 4.0]).unwrap();
+    /// let a = IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap();
+    /// let b = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0]).unwrap();
     /// let tn_a = TreeTN::<_, usize>::from_tensors(vec![a], vec![0]).unwrap();
     /// let tn_b = TreeTN::<_, usize>::from_tensors(vec![b], vec![0]).unwrap();
     ///
@@ -492,7 +492,7 @@ where
     ///     .axpby(AnyScalar::new_real(2.0), &tn_b, AnyScalar::new_real(-1.0))
     ///     .unwrap();
     /// let dense = result.contract_to_tensor().unwrap();
-    /// let expected = TensorDynLen::from_dense(vec![site], vec![-1.0, 0.0]).unwrap();
+    /// let expected = IdxTensor::from_dense(vec![site], vec![-1.0, 0.0]).unwrap();
     /// assert!(dense.isapprox(&expected, 1.0e-12, 0.0).unwrap());
     /// ```
     pub fn axpby<A, B>(

--- a/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/addition/tests/mod.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 
 use crate::treetn::TreeTN;
 
 /// Create two TreeTNs with the same topology for testing addition.
 /// Both are 2-node chains: A -- bond -- B
 fn make_two_matching_treetns() -> (
-    TreeTN<TensorDynLen, String>,
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex, // s0
     DynIndex, // s1
 ) {
@@ -15,18 +15,18 @@ fn make_two_matching_treetns() -> (
     let bond_a = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(2);
 
-    let t0_a = TensorDynLen::from_dense(
+    let t0_a = IdxTensor::from_dense(
         vec![s0.clone(), bond_a.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1_a = TensorDynLen::from_dense(
+    let t1_a = IdxTensor::from_dense(
         vec![bond_a.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
 
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0_a, t1_a],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -34,12 +34,12 @@ fn make_two_matching_treetns() -> (
 
     let bond_b = DynIndex::new_dyn(2);
 
-    let t0_b = TensorDynLen::from_dense(vec![s0.clone(), bond_b.clone()], vec![0.0, 1.0, 1.0, 0.0])
-        .unwrap();
-    let t1_b = TensorDynLen::from_dense(vec![bond_b.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 1.0])
-        .unwrap();
+    let t0_b =
+        IdxTensor::from_dense(vec![s0.clone(), bond_b.clone()], vec![0.0, 1.0, 1.0, 0.0]).unwrap();
+    let t1_b =
+        IdxTensor::from_dense(vec![bond_b.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0_b, t1_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -49,22 +49,22 @@ fn make_two_matching_treetns() -> (
 }
 
 fn make_two_matching_treetns_different_site_ids(
-) -> (TreeTN<TensorDynLen, String>, TreeTN<TensorDynLen, String>) {
+) -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
     let s0_a = DynIndex::new_dyn(2);
     let bond_a = DynIndex::new_dyn(3);
     let s1_a = DynIndex::new_dyn(2);
 
-    let t0_a = TensorDynLen::from_dense(
+    let t0_a = IdxTensor::from_dense(
         vec![s0_a.clone(), bond_a.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1_a = TensorDynLen::from_dense(
+    let t1_a = IdxTensor::from_dense(
         vec![bond_a.clone(), s1_a.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0_a, t1_a],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -74,13 +74,11 @@ fn make_two_matching_treetns_different_site_ids(
     let bond_b = DynIndex::new_dyn(2);
     let s1_b = DynIndex::new_dyn(2);
 
-    let t0_b =
-        TensorDynLen::from_dense(vec![s0_b.clone(), bond_b.clone()], vec![0.0, 1.0, 1.0, 0.0])
-            .unwrap();
-    let t1_b =
-        TensorDynLen::from_dense(vec![bond_b.clone(), s1_b.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t0_b = IdxTensor::from_dense(vec![s0_b.clone(), bond_b.clone()], vec![0.0, 1.0, 1.0, 0.0])
+        .unwrap();
+    let t1_b = IdxTensor::from_dense(vec![bond_b.clone(), s1_b.clone()], vec![1.0, 0.0, 0.0, 1.0])
+        .unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0_b, t1_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -108,14 +106,14 @@ fn make_same_id_prime_pair_mpo_like_treetn(
     inputs: &[DynIndex],
     outputs: &[DynIndex],
     links: &[DynIndex],
-) -> TreeTN<TensorDynLen, usize> {
+) -> TreeTN<IdxTensor, usize> {
     let tensors = vec![
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![inputs[0].clone(), outputs[0].clone(), links[0].clone()],
             scaled_sequence(scale, 18),
         )
         .unwrap(),
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![
                 links[0].clone(),
                 inputs[1].clone(),
@@ -125,13 +123,13 @@ fn make_same_id_prime_pair_mpo_like_treetn(
             scaled_sequence(scale, 36),
         )
         .unwrap(),
-        TensorDynLen::from_dense(
+        IdxTensor::from_dense(
             vec![links[1].clone(), inputs[2].clone(), outputs[2].clone()],
             scaled_sequence(scale, 18),
         )
         .unwrap(),
     ];
-    TreeTN::<TensorDynLen, usize>::from_tensors(tensors, vec![0, 1, 2]).unwrap()
+    TreeTN::<IdxTensor, usize>::from_tensors(tensors, vec![0, 1, 2]).unwrap()
 }
 
 #[test]
@@ -202,18 +200,18 @@ fn test_add_topology_mismatch() {
     let bond = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 6]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 6]).unwrap();
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 6]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 6]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1],
         vec!["A".to_string(), "B".to_string()],
     )
     .unwrap();
 
     // Single-node TN (different topology)
-    let t_single = TensorDynLen::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(vec![t_single], vec!["X".to_string()])
-        .unwrap();
+    let t_single = IdxTensor::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
+    let tn_b =
+        TreeTN::<IdxTensor, String>::from_tensors(vec![t_single], vec!["X".to_string()]).unwrap();
 
     let result = tn_a.add(&tn_b);
     assert!(result.is_err());
@@ -224,19 +222,17 @@ fn test_add_topology_mismatch() {
 fn test_add_single_site() {
     let s = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let result = tn_a.add(&tn_b).unwrap();
     assert_eq!(result.node_count(), 1);
 
     let dense = result.contract_to_tensor().unwrap();
-    let expected = TensorDynLen::from_dense(vec![s.clone()], vec![11.0, 22.0, 33.0]).unwrap();
+    let expected = IdxTensor::from_dense(vec![s.clone()], vec![11.0, 22.0, 33.0]).unwrap();
     assert!(
         dense.isapprox(&expected, 1e-10, 0.0).unwrap(),
         "single-site add failed: maxabs diff = {}",
@@ -262,7 +258,7 @@ fn test_sorted_site_space_orders_deterministically() {
     site_space.insert(a.clone());
     site_space.insert(b.clone());
 
-    let sorted = TreeTN::<TensorDynLen, usize>::sorted_site_space(&site_space);
+    let sorted = TreeTN::<IdxTensor, usize>::sorted_site_space(&site_space);
     assert_eq!(sorted, vec![b, c, a]);
 }
 
@@ -271,9 +267,9 @@ fn test_reindex_site_space_like_rejects_incompatible_inputs() {
     let (tn_a, _) = make_two_matching_treetns_different_site_ids();
 
     let lone_site = DynIndex::new_dyn(2);
-    let lone_tensor = TensorDynLen::from_dense(vec![lone_site], vec![1.0, 2.0]).unwrap();
+    let lone_tensor = IdxTensor::from_dense(vec![lone_site], vec![1.0, 2.0]).unwrap();
     let single =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![lone_tensor], vec!["A".to_string()])
+        TreeTN::<IdxTensor, String>::from_tensors(vec![lone_tensor], vec!["A".to_string()])
             .unwrap();
     let err = tn_a.reindex_site_space_like(&single).unwrap_err();
     assert!(err.to_string().contains("incompatible topologies"));
@@ -281,10 +277,9 @@ fn test_reindex_site_space_like_rejects_incompatible_inputs() {
     let self_s0 = DynIndex::new_dyn(2);
     let self_s1 = DynIndex::new_dyn(2);
     let self_bond = DynIndex::new_dyn(1);
-    let self_t0 =
-        TensorDynLen::from_dense(vec![self_s0, self_bond.clone()], vec![1.0, 2.0]).unwrap();
-    let self_t1 = TensorDynLen::from_dense(vec![self_bond, self_s1], vec![1.0, 2.0]).unwrap();
-    let self_two_node = TreeTN::<TensorDynLen, String>::from_tensors(
+    let self_t0 = IdxTensor::from_dense(vec![self_s0, self_bond.clone()], vec![1.0, 2.0]).unwrap();
+    let self_t1 = IdxTensor::from_dense(vec![self_bond, self_s1], vec![1.0, 2.0]).unwrap();
+    let self_two_node = TreeTN::<IdxTensor, String>::from_tensors(
         vec![self_t0, self_t1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -294,13 +289,13 @@ fn test_reindex_site_space_like_rejects_incompatible_inputs() {
     let tmpl_extra = DynIndex::new_dyn(2);
     let tmpl_s1 = DynIndex::new_dyn(2);
     let tmpl_bond = DynIndex::new_dyn(1);
-    let tmpl_t0 = TensorDynLen::from_dense(
+    let tmpl_t0 = IdxTensor::from_dense(
         vec![tmpl_s0, tmpl_extra, tmpl_bond.clone()],
         vec![1.0, 2.0, 3.0, 4.0],
     )
     .unwrap();
-    let tmpl_t1 = TensorDynLen::from_dense(vec![tmpl_bond, tmpl_s1], vec![1.0, 2.0]).unwrap();
-    let template_extra_site = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tmpl_t1 = IdxTensor::from_dense(vec![tmpl_bond, tmpl_s1], vec![1.0, 2.0]).unwrap();
+    let template_extra_site = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tmpl_t0, tmpl_t1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -316,9 +311,9 @@ fn test_reindex_site_space_like_rejects_incompatible_inputs() {
     let tmpl_s1 = DynIndex::new_dyn(2);
     let tmpl_bond = DynIndex::new_dyn(1);
     let tmpl_t0 =
-        TensorDynLen::from_dense(vec![tmpl_s0, tmpl_bond.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let tmpl_t1 = TensorDynLen::from_dense(vec![tmpl_bond, tmpl_s1], vec![1.0, 2.0]).unwrap();
-    let template_dim_mismatch = TreeTN::<TensorDynLen, String>::from_tensors(
+        IdxTensor::from_dense(vec![tmpl_s0, tmpl_bond.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let tmpl_t1 = IdxTensor::from_dense(vec![tmpl_bond, tmpl_s1], vec![1.0, 2.0]).unwrap();
+    let template_dim_mismatch = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tmpl_t0, tmpl_t1],
         vec!["A".to_string(), "B".to_string()],
     )

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -8,8 +8,8 @@ use std::hash::Hash;
 use anyhow::{bail, Context, Result};
 use num_complex::Complex64;
 use tensor4all_core::{
-    contract_with_options, AnyScalar, ColMajorArrayRef, ContractionOptions, DynIndex, IndexLike,
-    TensorContractionLike, TensorDynLen, TensorIndex, TensorLike,
+    contract_with_options, AnyScalar, ColMajorArrayRef, ContractionOptions, DynIndex, IdxTensor,
+    IndexLike, TensorContractionLike, TensorIndex, TensorLike,
 };
 
 use super::TreeTN;
@@ -65,7 +65,7 @@ struct ComponentBatch<V> {
 #[derive(Clone, Debug)]
 struct StackedMessage {
     assignment_index: DynIndex,
-    tensor: TensorDynLen,
+    tensor: IdxTensor,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -99,7 +99,7 @@ where
     /// /// index mismatch, or a backend failure).
     ///
     fn new(
-        tree: &TreeTN<TensorDynLen, V>,
+        tree: &TreeTN<IdxTensor, V>,
         indices: &[DynIndex],
         values: ColMajorArrayRef<'_, usize>,
     ) -> Result<Self> {
@@ -108,7 +108,7 @@ where
     }
 
     fn from_layout(
-        tree: &TreeTN<TensorDynLen, V>,
+        tree: &TreeTN<IdxTensor, V>,
         layout: &EvaluatorLayout<V>,
         values: ColMajorArrayRef<'_, usize>,
     ) -> Result<Self> {
@@ -318,7 +318,7 @@ where
     /// Returns an error when the construction or conversion fails (a shape or
     /// /// index mismatch, or a backend failure).
     ///
-    fn new(tree: &TreeTN<TensorDynLen, V>, center: &V) -> Result<Self> {
+    fn new(tree: &TreeTN<IdxTensor, V>, center: &V) -> Result<Self> {
         let neighbors = sorted_neighbors(tree);
         let (parent, order) = rooted_tree(&neighbors, center)?;
 
@@ -582,11 +582,11 @@ where
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+/// use tensor4all_core::{ColMajorArrayRef, DynIndex, IdxTensor};
 /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
 ///
 /// let s = DynIndex::new_dyn(2);
-/// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![4.0_f64, 6.0])?;
+/// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![4.0_f64, 6.0])?;
 /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
 /// let values = [0usize, 1usize];
 /// let shape = [1usize, 2usize];
@@ -608,7 +608,7 @@ pub struct TreeTNCachedEvaluator<'a, V>
 where
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
-    tree: &'a TreeTN<TensorDynLen, V>,
+    tree: &'a TreeTN<IdxTensor, V>,
     layout: EvaluatorLayout<V>,
     options: CachedEvaluatorOptions<V>,
     center: Option<V>,
@@ -633,11 +633,11 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0_f64, 2.0])?;
     /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![5])?;
     /// let evaluator = TreeTNCachedEvaluator::new(
     ///     &tree,
@@ -648,7 +648,7 @@ where
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn new(
-        tree: &'a TreeTN<TensorDynLen, V>,
+        tree: &'a TreeTN<IdxTensor, V>,
         indices: &[DynIndex],
         options: CachedEvaluatorOptions<V>,
     ) -> std::result::Result<Self, TreeTNOperationError> {
@@ -681,11 +681,11 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, IdxTensor};
     /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0_f64, 2.0])?;
     /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
     /// let mut evaluator = TreeTNCachedEvaluator::new(
     ///     &tree,
@@ -716,11 +716,11 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, IdxTensor};
     /// use tensor4all_treetn::{CachedEvaluatorOptions, TreeTN, TreeTNCachedEvaluator};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![4.0_f64, 6.0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![4.0_f64, 6.0])?;
     /// let tree = TreeTN::<_, usize>::from_tensors(vec![tensor], vec![0])?;
     /// let values = [0usize, 1usize];
     /// let shape = [1usize, 2usize];
@@ -1099,10 +1099,7 @@ where
     }
 }
 
-fn build_layout<V>(
-    tree: &TreeTN<TensorDynLen, V>,
-    indices: &[DynIndex],
-) -> Result<EvaluatorLayout<V>>
+fn build_layout<V>(tree: &TreeTN<IdxTensor, V>, indices: &[DynIndex]) -> Result<EvaluatorLayout<V>>
 where
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
 {
@@ -1266,7 +1263,7 @@ where
     Ok(())
 }
 
-fn ensure_node_exists<V>(tree: &TreeTN<TensorDynLen, V>, node: &V, context: &str) -> Result<()>
+fn ensure_node_exists<V>(tree: &TreeTN<IdxTensor, V>, node: &V, context: &str) -> Result<()>
 where
     V: Clone + Eq + Hash + Debug + Send + Sync,
 {
@@ -1276,7 +1273,7 @@ where
     Ok(())
 }
 
-fn tensor_for_node<'a, V>(tree: &'a TreeTN<TensorDynLen, V>, node: &V) -> Result<&'a TensorDynLen>
+fn tensor_for_node<'a, V>(tree: &'a TreeTN<IdxTensor, V>, node: &V) -> Result<&'a IdxTensor>
 where
     V: Clone + Eq + Hash + Debug + Send + Sync,
 {
@@ -1287,7 +1284,7 @@ where
         .ok_or_else(|| anyhow::anyhow!("tensor for node {:?} is not present", node))
 }
 
-fn slice_tensor(tensor: &TensorDynLen, index_vals: &[(DynIndex, usize)]) -> Result<TensorDynLen> {
+fn slice_tensor(tensor: &IdxTensor, index_vals: &[(DynIndex, usize)]) -> Result<IdxTensor> {
     if index_vals.is_empty() {
         return Ok(tensor.clone());
     }
@@ -1305,7 +1302,7 @@ fn slice_tensor(tensor: &TensorDynLen, index_vals: &[(DynIndex, usize)]) -> Resu
         .map_err(anyhow::Error::from)
 }
 
-fn tensor_values_any(tensor: &TensorDynLen) -> Result<Vec<AnyScalar>> {
+fn tensor_values_any(tensor: &IdxTensor) -> Result<Vec<AnyScalar>> {
     if tensor.is_complex() {
         tensor
             .to_vec::<Complex64>()
@@ -1326,8 +1323,8 @@ fn tensor_values_any(tensor: &TensorDynLen) -> Result<Vec<AnyScalar>> {
 
 fn stack_tensors_with_assignment_index(
     assignment_index: &DynIndex,
-    tensors: &[TensorDynLen],
-) -> Result<TensorDynLen> {
+    tensors: &[IdxTensor],
+) -> Result<IdxTensor> {
     anyhow::ensure!(
         !tensors.is_empty(),
         "stack_tensors_with_assignment_index requires at least one tensor"
@@ -1340,16 +1337,16 @@ fn stack_tensors_with_assignment_index(
     );
 
     let tensor_refs = tensors.iter().collect::<Vec<_>>();
-    TensorDynLen::stack_along_new_index(&tensor_refs, assignment_index.clone(), -1)
+    IdxTensor::stack_along_new_index(&tensor_refs, assignment_index.clone(), -1)
         .map_err(anyhow::Error::from)
 }
 
 fn gather_stacked_tensor(
-    stacked: &TensorDynLen,
+    stacked: &IdxTensor,
     source_assignment_index: &DynIndex,
     target_assignment_index: &DynIndex,
     selected_assignments: &[usize],
-) -> Result<TensorDynLen> {
+) -> Result<IdxTensor> {
     anyhow::ensure!(
         stacked.indices().last() == Some(source_assignment_index),
         "source assignment index must be the last stacked axis"
@@ -1371,9 +1368,9 @@ fn gather_stacked_tensor(
 }
 
 fn ensure_assignment_axis_last(
-    tensor: TensorDynLen,
+    tensor: IdxTensor,
     assignment_index: &DynIndex,
-) -> Result<TensorDynLen> {
+) -> Result<IdxTensor> {
     if tensor.indices().last() == Some(assignment_index) {
         return Ok(tensor);
     }
@@ -1448,7 +1445,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    use tensor4all_core::{ColMajorArrayRef, DynIndex, IdxTensor};
 
     fn assert_scalars_close(actual: &[AnyScalar], expected: &[AnyScalar]) {
         assert_eq!(actual.len(), expected.len());
@@ -1466,8 +1463,8 @@ mod tests {
     fn stack_tensors_adds_trailing_assignment_axis_in_column_major_order() {
         let batch = DynIndex::new_dyn(2);
         let i = DynIndex::new_dyn(2);
-        let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
-        let b = TensorDynLen::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
+        let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+        let b = IdxTensor::from_dense(vec![i.clone()], vec![3.0_f64, 4.0]).unwrap();
 
         let stacked = stack_tensors_with_assignment_index(&batch, &[a, b]).unwrap();
 
@@ -1480,7 +1477,7 @@ mod tests {
         let source_batch = DynIndex::new_dyn(3);
         let target_batch = DynIndex::new_dyn(4);
         let i = DynIndex::new_dyn(2);
-        let stacked = TensorDynLen::from_dense(
+        let stacked = IdxTensor::from_dense(
             vec![i.clone(), source_batch.clone()],
             vec![10.0_f64, 11.0, 20.0, 21.0, 30.0, 31.0],
         )
@@ -1496,68 +1493,66 @@ mod tests {
         );
     }
 
-    fn two_node_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+    fn two_node_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
         let s0 = DynIndex::new_dyn(2);
         let bond = DynIndex::new_dyn(2);
         let s1 = DynIndex::new_dyn(2);
 
         let t0 =
-            TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0_f64, 2.0, 3.0, 4.0])
+            IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0_f64, 2.0, 3.0, 4.0])
                 .unwrap();
         let t1 =
-            TensorDynLen::from_dense(vec![bond, s1.clone()], vec![0.5_f64, 1.5, 2.5, 3.5]).unwrap();
+            IdxTensor::from_dense(vec![bond, s1.clone()], vec![0.5_f64, 1.5, 2.5, 3.5]).unwrap();
 
         let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
         (tree, vec![s0, s1])
     }
 
-    fn three_node_chain() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+    fn three_node_chain() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
         let s0 = DynIndex::new_dyn(2);
         let b01 = DynIndex::new_dyn(2);
         let s1 = DynIndex::new_dyn(2);
         let b12 = DynIndex::new_dyn(2);
         let s2 = DynIndex::new_dyn(2);
 
-        let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0_f64; 4]).unwrap();
+        let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0_f64; 4]).unwrap();
         let t1 =
-            TensorDynLen::from_dense(vec![b01, s1.clone(), b12.clone()], vec![1.0_f64; 8]).unwrap();
-        let t2 = TensorDynLen::from_dense(vec![b12, s2.clone()], vec![1.0_f64; 4]).unwrap();
+            IdxTensor::from_dense(vec![b01, s1.clone(), b12.clone()], vec![1.0_f64; 8]).unwrap();
+        let t2 = IdxTensor::from_dense(vec![b12, s2.clone()], vec![1.0_f64; 4]).unwrap();
         let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap();
         (tree, vec![s0, s1, s2])
     }
 
-    fn five_node_chain() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+    fn five_node_chain() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
         let sites: Vec<DynIndex> = (0..5).map(|_| DynIndex::new_dyn(2)).collect();
         let bonds: Vec<DynIndex> = (0..4).map(|_| DynIndex::new_dyn(2)).collect();
 
-        let t0 =
-            TensorDynLen::from_dense(vec![sites[0].clone(), bonds[0].clone()], vec![1.0_f64; 4])
-                .unwrap();
-        let t1 = TensorDynLen::from_dense(
+        let t0 = IdxTensor::from_dense(vec![sites[0].clone(), bonds[0].clone()], vec![1.0_f64; 4])
+            .unwrap();
+        let t1 = IdxTensor::from_dense(
             vec![bonds[0].clone(), sites[1].clone(), bonds[1].clone()],
             vec![1.0_f64; 8],
         )
         .unwrap();
-        let t2 = TensorDynLen::from_dense(
+        let t2 = IdxTensor::from_dense(
             vec![bonds[1].clone(), sites[2].clone(), bonds[2].clone()],
             vec![1.0_f64; 8],
         )
         .unwrap();
-        let t3 = TensorDynLen::from_dense(
+        let t3 = IdxTensor::from_dense(
             vec![bonds[2].clone(), sites[3].clone(), bonds[3].clone()],
             vec![1.0_f64; 8],
         )
         .unwrap();
-        let t4 =
-            TensorDynLen::from_dense(vec![bonds[3].clone(), sites[4].clone()], vec![1.0_f64; 4])
-                .unwrap();
+        let t4 = IdxTensor::from_dense(vec![bonds[3].clone(), sites[4].clone()], vec![1.0_f64; 4])
+            .unwrap();
 
         let tree = TreeTN::<_, usize>::from_tensors(vec![t0, t1, t2, t3, t4], vec![0, 1, 2, 3, 4])
             .unwrap();
         (tree, sites)
     }
 
-    fn star_tree() -> (TreeTN<TensorDynLen, usize>, Vec<DynIndex>) {
+    fn star_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
         let sc = DynIndex::new_dyn(2);
         let s0 = DynIndex::new_dyn(2);
         let s1 = DynIndex::new_dyn(2);
@@ -1566,17 +1561,17 @@ mod tests {
         let b1 = DynIndex::new_dyn(2);
         let b2 = DynIndex::new_dyn(2);
         let center_data: Vec<f64> = (0..16).map(|value| value as f64 + 1.0).collect();
-        let center = TensorDynLen::from_dense(
+        let center = IdxTensor::from_dense(
             vec![sc.clone(), b0.clone(), b1.clone(), b2.clone()],
             center_data,
         )
         .unwrap();
         let leaf0 =
-            TensorDynLen::from_dense(vec![b0, s0.clone()], vec![1.0_f64, 0.5, 1.5, 2.0]).unwrap();
+            IdxTensor::from_dense(vec![b0, s0.clone()], vec![1.0_f64, 0.5, 1.5, 2.0]).unwrap();
         let leaf1 =
-            TensorDynLen::from_dense(vec![b1, s1.clone()], vec![0.25_f64, 1.0, 1.25, 2.0]).unwrap();
+            IdxTensor::from_dense(vec![b1, s1.clone()], vec![0.25_f64, 1.0, 1.25, 2.0]).unwrap();
         let leaf2 =
-            TensorDynLen::from_dense(vec![b2, s2.clone()], vec![2.0_f64, 1.0, 0.75, 1.5]).unwrap();
+            IdxTensor::from_dense(vec![b2, s2.clone()], vec![2.0_f64, 1.0, 0.75, 1.5]).unwrap();
         let tree =
             TreeTN::<_, usize>::from_tensors(vec![center, leaf0, leaf1, leaf2], vec![0, 1, 2, 3])
                 .unwrap();

--- a/crates/tensor4all-treetn/src/treetn/canonicalize.rs
+++ b/crates/tensor4all-treetn/src/treetn/canonicalize.rs
@@ -43,17 +43,17 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::{TreeTN, CanonicalizationOptions};
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// let s0 = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(3);
     /// let s1 = DynIndex::new_dyn(2);
     ///
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), bond.clone()],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![bond.clone(), s1.clone()],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
     /// ).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -114,17 +114,17 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorIndex, TensorLike};
     ///
     /// let s0 = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(2);
     /// let s1 = DynIndex::new_dyn(2);
     ///
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), bond.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![bond, s1.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// ).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -1,26 +1,26 @@
 use super::*;
 use tensor4all_core::{
-    DynIndex, IndexLike, SvdTruncationPolicy, TensorContractionLike, TensorDynLen, TensorIndex,
+    DynIndex, IdxTensor, IndexLike, SvdTruncationPolicy, TensorContractionLike, TensorIndex,
 };
 
 /// Helper to create a simple 2-node TreeTN: A -- bond -- B
-fn make_two_node_treetn() -> (TreeTN<TensorDynLen, String>, DynIndex, DynIndex, DynIndex) {
+fn make_two_node_treetn() -> (TreeTN<IdxTensor, String>, DynIndex, DynIndex, DynIndex) {
     let s0 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -103,7 +103,7 @@ fn test_contraction_options_qr_builder() {
 
 #[test]
 fn test_contract_to_tensor_empty_error() {
-    let tn = TreeTN::<TensorDynLen, String>::new();
+    let tn = TreeTN::<IdxTensor, String>::new();
     let result = tn.contract_to_tensor();
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("empty"));
@@ -113,12 +113,12 @@ fn test_contract_to_tensor_empty_error() {
 fn test_contract_to_tensor_single_node() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(3);
-    let t = TensorDynLen::from_dense(
+    let t = IdxTensor::from_dense(
         vec![s0.clone(), s1.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
     .unwrap();
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
 
     let result = tn.contract_to_tensor().unwrap();
     assert_eq!(result.external_indices().len(), 2);
@@ -150,12 +150,12 @@ fn test_contract_to_tensor_two_nodes() {
     assert!(ext_ids.contains(s1.id()));
 
     // Verify values against the equivalent high-level tensor contraction.
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), _bond.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![_bond.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
@@ -224,8 +224,8 @@ fn test_contract_naive_topology_mismatch() {
 
     // Create a single-node TN (different topology)
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
-    let tn2 = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["X".to_string()]).unwrap();
+    let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
+    let tn2 = TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["X".to_string()]).unwrap();
 
     let result = tn1.contract_naive(&tn2);
     assert!(result.is_err());
@@ -236,8 +236,8 @@ fn test_contract_zipup_topology_mismatch() {
     let (tn1, _s0, _bond, _s1) = make_two_node_treetn();
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
-    let tn2 = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["X".to_string()]).unwrap();
+    let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 0.0]).unwrap();
+    let tn2 = TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["X".to_string()]).unwrap();
 
     let result = tn1.contract_zipup(&tn2, &"A".to_string(), None, None);
     assert!(result.is_err());
@@ -264,12 +264,10 @@ fn zipup_parent_bond_filter_keeps_same_id_primed_nonbond_index() {
 #[test]
 fn test_contract_naive_requires_dense_reference_limit() {
     let s = DynIndex::new_dyn(3);
-    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s], vec![1.0, 1.0, 1.0]).unwrap();
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s], vec![1.0, 1.0, 1.0]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let err = contract(
         &tn_a,
@@ -284,12 +282,10 @@ fn test_contract_naive_requires_dense_reference_limit() {
 #[test]
 fn test_contract_naive_dense_reference_limit_bounds_materialization() {
     let s = DynIndex::new_dyn(3);
-    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s], vec![1.0, 1.0, 1.0]).unwrap();
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s], vec![1.0, 1.0, 1.0]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let err = contract(
         &tn_a,
@@ -316,8 +312,8 @@ fn test_find_common_indices() {
     let bond = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(4);
 
-    let t_a = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 6]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 12]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 6]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 12]).unwrap();
 
     let common = find_common_indices(&t_a, &t_b);
     assert_eq!(common.len(), 1);
@@ -329,8 +325,8 @@ fn test_find_common_indices_no_common() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s1.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s0.clone()], vec![1.0, 2.0]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s1.clone()], vec![1.0, 2.0, 3.0]).unwrap();
 
     let common = find_common_indices(&t_a, &t_b);
     assert_eq!(common.len(), 0);
@@ -342,13 +338,11 @@ fn test_naive_contraction_scalar_result() {
     // Two single-site TreeTNs that share an index → contraction produces a scalar
     let s = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 1.0, 1.0]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0, 3.0]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 1.0, 1.0]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     // Naive contraction: inner product = 1+2+3 = 6
     let result =

--- a/crates/tensor4all-treetn/src/treetn/decompose/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/decompose/tests/mod.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::collections::HashMap;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 
 #[test]
 fn test_tree_topology_validate() {
@@ -46,7 +46,7 @@ fn test_factorize_tensor_to_treetn_rejects_duplicate_index_assignment() {
     let i0 = DynIndex::new_dyn(2);
     let i1 = DynIndex::new_dyn(2);
     let tensor =
-        TensorDynLen::from_dense(vec![i0.clone(), i1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+        IdxTensor::from_dense(vec![i0.clone(), i1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
     let mut nodes: HashMap<String, Vec<DynIndex>> = HashMap::new();
     nodes.insert("node0".to_string(), vec![i0.clone()]);
@@ -68,7 +68,7 @@ fn test_factorize_tensor_to_treetn_preserves_requested_chain_topology_for_nonroo
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![s0.clone(), s1.clone(), s2.clone()],
         vec![10.0, 30.0, 20.0, 40.0, 11.0, 31.0, 21.0, 41.0],
     )
@@ -92,8 +92,7 @@ fn test_factorize_tensor_to_treetn_accepts_full_index_topology_for_same_id_prime
     let i = DynIndex::new_dyn(2);
     let i_prime = i.prime();
     let tensor =
-        TensorDynLen::from_dense(vec![i.clone(), i_prime.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
+        IdxTensor::from_dense(vec![i.clone(), i_prime.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
     let mut nodes: HashMap<String, Vec<DynIndex>> = HashMap::new();
     nodes.insert("input".to_string(), vec![i.clone()]);

--- a/crates/tensor4all-treetn/src/treetn/evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/evaluator.rs
@@ -37,12 +37,12 @@ where
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+/// use tensor4all_core::{ColMajorArrayRef, DynIndex, IdxTensor};
 /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
 ///
 /// let s = DynIndex::new_dyn(3);
-/// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0])?;
-/// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+/// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0])?;
+/// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
 ///
 /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
 /// let values = [0usize, 2usize];
@@ -97,12 +97,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
-    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+    /// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     ///
     /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
     /// assert_eq!(evaluator.input_count(), 1);
@@ -210,12 +210,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
-    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+    /// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
     ///
     /// assert_eq!(evaluator.input_count(), 1);
@@ -249,12 +249,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, TensorDynLen};
+    /// use tensor4all_core::{ColMajorArrayRef, DynIndex, IdxTensor};
     /// use tensor4all_treetn::{TreeTN, TreeTNEvaluator};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![4.0, 9.0])?;
-    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![4.0, 9.0])?;
+    /// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     /// let evaluator = TreeTNEvaluator::new(&tree, &[s])?;
     /// let values = [1usize];
     /// let shape = [1usize, 1usize];

--- a/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
@@ -1,37 +1,33 @@
 use super::*;
 use crate::treetn::localupdate::{LocalUpdateStep, LocalUpdater};
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 
 /// Create a simple 2-node TreeTN: A -- bond -- B
-fn make_two_node_treetn() -> TreeTN<TensorDynLen, String> {
+fn make_two_node_treetn() -> TreeTN<IdxTensor, String> {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     make_two_node_treetn_with_sites(&s0, &s1)
 }
 
-fn make_two_node_treetn_with_sites(s0: &DynIndex, s1: &DynIndex) -> TreeTN<TensorDynLen, String> {
+fn make_two_node_treetn_with_sites(s0: &DynIndex, s1: &DynIndex) -> TreeTN<IdxTensor, String> {
     let bond = DynIndex::new_dyn(3);
 
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
 
-    TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![t0, t1],
-        vec!["A".to_string(), "B".to_string()],
-    )
-    .unwrap()
+    TreeTN::<IdxTensor, String>::from_tensors(vec![t0, t1], vec!["A".to_string(), "B".to_string()])
+        .unwrap()
 }
 
-fn make_contractible_two_node_pair() -> (TreeTN<TensorDynLen, String>, TreeTN<TensorDynLen, String>)
-{
+fn make_contractible_two_node_pair() -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     (
@@ -41,7 +37,7 @@ fn make_contractible_two_node_pair() -> (TreeTN<TensorDynLen, String>, TreeTN<Te
 }
 
 fn make_contractible_two_node_pair_with_surviving_sites(
-) -> (TreeTN<TensorDynLen, String>, TreeTN<TensorDynLen, String>) {
+) -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let a0 = DynIndex::new_dyn(2);
@@ -51,14 +47,14 @@ fn make_contractible_two_node_pair_with_surviving_sites(
     let bond_a = DynIndex::new_dyn(2);
     let bond_b = DynIndex::new_dyn(2);
 
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![s0.clone(), a0, bond_a.clone()],
                 (1..=8).map(|value| value as f64 / 8.0).collect(),
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_a, s1.clone(), a1],
                 (1..=8).map(|value| value as f64 / 10.0).collect(),
             )
@@ -67,14 +63,14 @@ fn make_contractible_two_node_pair_with_surviving_sites(
         vec!["A".to_string(), "B".to_string()],
     )
     .unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![s0, b0, bond_b.clone()],
                 (1..=8).map(|value| (value as f64 - 2.0) / 9.0).collect(),
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_b, s1, b1],
                 (1..=8).map(|value| (value as f64 + 1.0) / 11.0).collect(),
             )
@@ -87,10 +83,10 @@ fn make_contractible_two_node_pair_with_surviving_sites(
 }
 
 fn make_fit_initial_c(
-    tn_a: &TreeTN<TensorDynLen, String>,
-    tn_b: &TreeTN<TensorDynLen, String>,
+    tn_a: &TreeTN<IdxTensor, String>,
+    tn_b: &TreeTN<IdxTensor, String>,
     center: &str,
-) -> TreeTN<TensorDynLen, String> {
+) -> TreeTN<IdxTensor, String> {
     tn_a.contract_zipup_preserving_topology_with(
         tn_b,
         &center.to_string(),
@@ -101,25 +97,25 @@ fn make_fit_initial_c(
     .unwrap()
 }
 
-fn make_single_node_treetn() -> TreeTN<TensorDynLen, String> {
+fn make_single_node_treetn() -> TreeTN<IdxTensor, String> {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(3);
-    let t = TensorDynLen::from_dense(vec![s0, s1], vec![1.0; 6]).unwrap();
-    TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap()
+    let t = IdxTensor::from_dense(vec![s0, s1], vec![1.0; 6]).unwrap();
+    TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap()
 }
 
-fn make_three_node_treetn() -> TreeTN<TensorDynLen, String> {
+fn make_three_node_treetn() -> TreeTN<IdxTensor, String> {
     let s0 = DynIndex::new_dyn(2);
     let bond01 = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(2);
     let bond12 = DynIndex::new_dyn(3);
     let s2 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0, bond01.clone()], vec![1.0; 6]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond01, s1, bond12.clone()], vec![1.0; 18]).unwrap();
-    let t2 = TensorDynLen::from_dense(vec![bond12, s2], vec![1.0; 6]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0, bond01.clone()], vec![1.0; 6]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![bond01, s1, bond12.clone()], vec![1.0; 18]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![bond12, s2], vec![1.0; 6]).unwrap();
 
-    TreeTN::<TensorDynLen, String>::from_tensors(
+    TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1, t2],
         vec!["A".to_string(), "B".to_string(), "C".to_string()],
     )
@@ -132,24 +128,24 @@ fn make_three_node_treetn() -> TreeTN<TensorDynLen, String> {
 
 #[test]
 fn test_fit_environment_new() {
-    let env = FitEnvironment::<TensorDynLen, String>::new();
+    let env = FitEnvironment::<IdxTensor, String>::new();
     assert!(env.is_empty());
     assert_eq!(env.len(), 0);
 }
 
 #[test]
 fn test_fit_environment_default() {
-    let env = FitEnvironment::<TensorDynLen, String>::default();
+    let env = FitEnvironment::<IdxTensor, String>::default();
     assert!(env.is_empty());
     assert_eq!(env.len(), 0);
 }
 
 #[test]
 fn test_fit_environment_insert_and_get() {
-    let mut env = FitEnvironment::<TensorDynLen, String>::new();
+    let mut env = FitEnvironment::<IdxTensor, String>::new();
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
+    let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
 
     env.insert("A".to_string(), "B".to_string(), t.clone());
 
@@ -164,16 +160,16 @@ fn test_fit_environment_insert_and_get() {
 
 #[test]
 fn test_fit_environment_get_nonexistent() {
-    let env = FitEnvironment::<TensorDynLen, String>::new();
+    let env = FitEnvironment::<IdxTensor, String>::new();
     assert!(env.get(&"A".to_string(), &"B".to_string()).is_none());
 }
 
 #[test]
 fn test_fit_environment_clear() {
-    let mut env = FitEnvironment::<TensorDynLen, String>::new();
+    let mut env = FitEnvironment::<IdxTensor, String>::new();
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
+    let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
 
     env.insert("A".to_string(), "B".to_string(), t.clone());
     env.insert("B".to_string(), "A".to_string(), t.clone());
@@ -187,11 +183,11 @@ fn test_fit_environment_clear() {
 
 #[test]
 fn test_fit_environment_invalidate() {
-    let mut env = FitEnvironment::<TensorDynLen, String>::new();
+    let mut env = FitEnvironment::<IdxTensor, String>::new();
     let tn = make_two_node_treetn();
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
+    let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
 
     // Insert environments for both directions
     env.insert("A".to_string(), "B".to_string(), t.clone());
@@ -215,18 +211,18 @@ fn test_fit_environment_invalidate() {
 
 #[test]
 fn test_fit_environment_verify_structural_consistency_empty() {
-    let env = FitEnvironment::<TensorDynLen, String>::new();
+    let env = FitEnvironment::<IdxTensor, String>::new();
     let tn = make_two_node_treetn();
     assert!(env.verify_structural_consistency(&tn).is_ok());
 }
 
 #[test]
 fn test_fit_environment_verify_structural_consistency_valid() {
-    let mut env = FitEnvironment::<TensorDynLen, String>::new();
+    let mut env = FitEnvironment::<IdxTensor, String>::new();
     let tn = make_two_node_treetn();
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
+    let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0]).unwrap();
 
     // A is a leaf with only neighbor B. env[(A, B)] is valid alone.
     env.insert("A".to_string(), "B".to_string(), t.clone());
@@ -237,7 +233,7 @@ fn test_fit_environment_verify_structural_consistency_valid() {
 fn test_fit_environment_get_or_compute_caches_leaf_environment() {
     let (tn_a, tn_b) = make_contractible_two_node_pair_with_surviving_sites();
     let tn_c = make_fit_initial_c(&tn_a, &tn_b, "A");
-    let mut env = FitEnvironment::<TensorDynLen, String>::new();
+    let mut env = FitEnvironment::<IdxTensor, String>::new();
 
     let from = "A".to_string();
     let to = "B".to_string();
@@ -252,11 +248,11 @@ fn test_fit_environment_get_or_compute_caches_leaf_environment() {
 
 #[test]
 fn test_fit_environment_verify_structural_consistency_detects_missing_child_env() {
-    let mut env = FitEnvironment::<TensorDynLen, String>::new();
+    let mut env = FitEnvironment::<IdxTensor, String>::new();
     let tn = make_three_node_treetn();
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s], vec![1.0, 2.0]).unwrap();
+    let t = IdxTensor::from_dense(vec![s], vec![1.0, 2.0]).unwrap();
 
     // B is non-leaf toward A, so env[(C, B)] must also exist.
     env.insert("B".to_string(), "A".to_string(), t);
@@ -354,7 +350,7 @@ fn test_fit_updater_after_step_invalidates_cached_region() {
     let mut updater = FitUpdater::new(tn_a, tn_b, None, None);
 
     let s = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(vec![s], vec![1.0, 2.0]).unwrap();
+    let t = IdxTensor::from_dense(vec![s], vec![1.0, 2.0]).unwrap();
     updater
         .envs
         .insert("A".to_string(), "B".to_string(), t.clone());
@@ -384,47 +380,47 @@ fn test_fit_updater_update_pins_same_id_prime_pair_leg_order() {
     // The primed index appears first in the first contracted tensor, so the
     // unsorted left_inds insertion order is [s', s] (the buggy stable sort
     // preserves it; the full-index sort must pin [s, s']).
-    let a_u = TensorDynLen::from_dense(
+    let a_u = IdxTensor::from_dense(
         vec![s_prime.clone(), bond.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
     .unwrap();
-    let b_u = TensorDynLen::from_dense(
+    let b_u = IdxTensor::from_dense(
         vec![s.clone(), bond.clone()],
         vec![6.0, 5.0, 4.0, 3.0, 2.0, 1.0],
     )
     .unwrap();
-    let a_v = TensorDynLen::from_dense(
+    let a_v = IdxTensor::from_dense(
         vec![bond.clone(), t_a.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
-    let b_v = TensorDynLen::from_dense(
+    let b_v = IdxTensor::from_dense(
         vec![bond.clone(), t_b.clone()],
         vec![0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
     )
     .unwrap();
 
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![a_u, a_v],
         vec!["A".to_string(), "B".to_string()],
     )
     .unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![b_u, b_v],
         vec!["A".to_string(), "B".to_string()],
     )
     .unwrap();
 
     // Full network C: node A's site space holds the same-ID primed pair.
-    let c_a = TensorDynLen::from_dense(
+    let c_a = IdxTensor::from_dense(
         vec![s_prime.clone(), s.clone(), bond.clone()],
         vec![1.0; 12],
     )
     .unwrap();
-    let c_b = TensorDynLen::from_dense(vec![bond.clone(), t_a.clone(), t_b.clone()], vec![1.0; 12])
-        .unwrap();
-    let full_treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let c_b =
+        IdxTensor::from_dense(vec![bond.clone(), t_a.clone(), t_b.clone()], vec![1.0; 12]).unwrap();
+    let full_treetn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![c_a, c_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -527,19 +523,19 @@ fn test_contract_fit_handles_leaf_site_space_that_contracts_away() {
     let b_ab = DynIndex::new_dyn(2);
     let b_bc = DynIndex::new_dyn(2);
 
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![left.clone(), shared_left.clone(), a_ab.clone()],
                 (1..=8).map(|value| value as f64 / 8.0).collect(),
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![a_ab.clone(), shared_mid.clone(), a_bc.clone()],
                 (1..=8).map(|value| value as f64 / 10.0).collect(),
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![a_bc.clone(), shared_leaf.clone()],
                 vec![0.5, 1.5, -0.5, 2.0],
             )
@@ -549,14 +545,14 @@ fn test_contract_fit_handles_leaf_site_space_that_contracts_away() {
     )
     .unwrap();
 
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![b_ab.clone(), shared_left.clone()],
                 vec![1.0, -0.5, 0.25, 0.75],
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     b_ab.clone(),
                     shared_mid.clone(),
@@ -566,7 +562,7 @@ fn test_contract_fit_handles_leaf_site_space_that_contracts_away() {
                 (1..=16).map(|value| (value as f64 - 3.0) / 7.0).collect(),
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![b_bc.clone(), shared_leaf.clone()],
                 vec![2.0, -1.0, 0.25, 0.75],
             )

--- a/crates/tensor4all-treetn/src/treetn/localupdate.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate.rs
@@ -464,16 +464,16 @@ use tensor4all_core::{Canonical, FactorizeOptions, SvdTruncationPolicy};
 ///
 /// # Usage
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{apply_local_update_sweep, LocalUpdateSweepPlan, TreeTN, TruncateUpdater};
 ///
 /// # fn main() -> anyhow::Result<()> {
 /// let s0 = DynIndex::new_dyn(2);
 /// let bond = DynIndex::new_dyn(1);
 /// let s1 = DynIndex::new_dyn(2);
-/// let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
-/// let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
-/// let mut treetn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
+/// let t0 = IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0])?;
+/// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0])?;
+/// let mut treetn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1])?;
 /// treetn.canonicalize_mut(std::iter::once(0usize), Default::default())?;
 ///
 /// let plan = LocalUpdateSweepPlan::from_treetn(&treetn, &0usize, 2).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/localupdate/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/localupdate/tests/mod.rs
@@ -1,5 +1,5 @@
 use super::*;
-use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, TensorIndex};
 
 /// Create a 4-node Y-shape TreeTN:
 ///     A
@@ -8,13 +8,13 @@ use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
 ///    / \
 ///   C   D
 fn create_y_shape_treetn() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex,
     DynIndex,
     DynIndex,
     DynIndex,
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let site_c = DynIndex::new_dyn(2);
@@ -25,11 +25,11 @@ fn create_y_shape_treetn() -> (
 
     // Tensor A: [site_a, bond_ab]
     let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // Tensor B: [bond_ab, bond_bc, bond_bd]
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
         vec![1.0; 27],
     )
@@ -38,12 +38,12 @@ fn create_y_shape_treetn() -> (
 
     // Tensor C: [bond_bc, site_c]
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     // Tensor D: [bond_bd, site_d]
     let tensor_d =
-        TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("D".to_string(), tensor_d).unwrap();
 
     // Connect
@@ -66,16 +66,15 @@ fn truncate_updater_keeps_same_id_primed_nonbond_index() {
     let bond = DynIndex::new_dyn(1);
     let bond_prime = bond.prime();
 
-    let tensor_0 = TensorDynLen::from_dense(
+    let tensor_0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone(), bond_prime.clone()],
         vec![1.0, 0.0],
     )
     .unwrap();
-    let tensor_1 =
-        TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0, 0.0]).unwrap();
+    let tensor_1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![1.0, 0.0]).unwrap();
 
     let tn =
-        TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor_0, tensor_1], vec![0usize, 1usize])
+        TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor_0, tensor_1], vec![0usize, 1usize])
             .unwrap();
 
     let step = LocalUpdateStep {
@@ -98,16 +97,16 @@ fn canonicalize_keeps_same_id_primed_nonbond_index_on_source() {
     let bond = DynIndex::new_dyn(2);
     let bond_prime = bond.prime();
 
-    let tensor_0 = TensorDynLen::from_dense(
+    let tensor_0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone(), bond_prime.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, 0.25],
     )
     .unwrap();
     let tensor_1 =
-        TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+        IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
     let mut tn =
-        TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor_0, tensor_1], vec![0usize, 1usize])
+        TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor_0, tensor_1], vec![0usize, 1usize])
             .unwrap();
 
     tn.canonicalize_mut([1usize], Default::default()).unwrap();
@@ -402,8 +401,8 @@ fn test_sweep_plan_nonexistent_root() {
 
 /// Create a chain TreeTN: A - B - C
 /// Each node has a site index of dim 2, bonds of dim 4
-fn create_chain_treetn() -> TreeTN<TensorDynLen, String> {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+fn create_chain_treetn() -> TreeTN<IdxTensor, String> {
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let site_b = DynIndex::new_dyn(2);
@@ -413,11 +412,11 @@ fn create_chain_treetn() -> TreeTN<TensorDynLen, String> {
 
     // Tensor A: [site_a, bond_ab] dim 2x4
     let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 8]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // Tensor B: [bond_ab, site_b, bond_bc] dim 4x2x4
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![bond_ab.clone(), site_b.clone(), bond_bc.clone()],
         vec![1.0; 32],
     )
@@ -426,7 +425,7 @@ fn create_chain_treetn() -> TreeTN<TensorDynLen, String> {
 
     // Tensor C: [bond_bc, site_c] dim 4x2
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 8]).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     // Connect

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -72,7 +72,7 @@ pub use swap::{ScheduledSwapStep, SwapOptions, SwapSchedule};
 /// - **Topology**: Graph structure (which nodes connect to which)
 /// - **Site Space**: Physical indices organized by node
 /// # Type Parameters
-/// - `T`: Tensor type implementing `TensorLike` (default: `TensorDynLen`)
+/// - `T`: Tensor type implementing `TensorLike` (default: `IdxTensor`)
 /// - `V`: Node name type for named nodes (default: NodeIndex for backward compatibility)
 /// # Construction
 /// - `TreeTN::new()`: Create an empty network, then use `add_tensor()` and `connect()` to build.
@@ -81,17 +81,17 @@ pub use swap::{ScheduledSwapStep, SwapOptions, SwapSchedule};
 /// Build a 2-node chain manually and verify node count:
 /// ```
 /// use tensor4all_treetn::TreeTN;
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 /// // Create site and bond indices
 /// let s0 = DynIndex::new_dyn(2);
 /// let bond = DynIndex::new_dyn(3);
 /// let s1 = DynIndex::new_dyn(2);
 /// // Build tensors
-/// let t0 = TensorDynLen::from_dense(
+/// let t0 = IdxTensor::from_dense(
 ///     vec![s0.clone(), bond.clone()],
 ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 /// ).unwrap();
-/// let t1 = TensorDynLen::from_dense(
+/// let t1 = IdxTensor::from_dense(
 ///     vec![bond.clone(), s1.clone()],
 ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 /// ).unwrap();
@@ -103,7 +103,7 @@ pub use swap::{ScheduledSwapStep, SwapOptions, SwapSchedule};
 /// assert_eq!(tn.node_count(), 2);
 /// assert_eq!(tn.edge_count(), 1);
 /// ```
-pub struct TreeTN<T = tensor4all_core::TensorDynLen, V = NodeIndex>
+pub struct TreeTN<T = tensor4all_core::IdxTensor, V = NodeIndex>
 where
     T: TensorLike,
     V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
@@ -193,17 +193,17 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// let s0 = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(3);
     /// let s1 = DynIndex::new_dyn(2);
     ///
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), bond.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0, 0.0, 0.0],
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![bond.clone(), s1.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0, 0.0, 0.0],
     /// ).unwrap();
@@ -350,14 +350,14 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let i = DynIndex::new_dyn(2);
     /// let j = DynIndex::new_dyn(3);
-    /// let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0_f64; 6]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![i, j], vec![0.0_f64; 6]).unwrap();
     ///
-    /// let mut tn = TreeTN::<TensorDynLen>::new();
+    /// let mut tn = TreeTN::<IdxTensor>::new();
     /// let node = tn.add_tensor_auto_name(tensor).unwrap();
     ///
     /// assert_eq!(node.index(), 0);
@@ -1749,7 +1749,7 @@ where
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     /// use tensor4all_treetn::{SwapOptions, TreeTN};
     ///
     /// # fn main() -> anyhow::Result<()> {
@@ -1758,9 +1758,9 @@ where
     /// let idx_a = DynIndex::new_dyn(2);
     /// let idx_b = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(1);
-    /// let t0 = TensorDynLen::from_dense(vec![idx_a.clone(), bond.clone()], vec![1.0, 0.0])?;
-    /// let t1 = TensorDynLen::from_dense(vec![bond, idx_b.clone()], vec![1.0, 0.0])?;
-    /// let mut treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+    /// let t0 = IdxTensor::from_dense(vec![idx_a.clone(), bond.clone()], vec![1.0, 0.0])?;
+    /// let t1 = IdxTensor::from_dense(vec![bond, idx_b.clone()], vec![1.0, 0.0])?;
+    /// let mut treetn = TreeTN::<IdxTensor, String>::from_tensors(
     ///     vec![t0, t1],
     ///     vec![node_name_a.clone(), node_name_b.clone()],
     /// )?;
@@ -2013,11 +2013,11 @@ pub(crate) fn common_inds<I: IndexLike>(inds_a: &[I], inds_b: &[I]) -> Vec<I> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tensor4all_core::TensorDynLen;
+    use tensor4all_core::IdxTensor;
 
     #[test]
     fn from_tensors_empty_returns_empty_network() {
-        let tn = TreeTN::<TensorDynLen, usize>::from_tensors(Vec::new(), Vec::new()).unwrap();
+        let tn = TreeTN::<IdxTensor, usize>::from_tensors(Vec::new(), Vec::new()).unwrap();
 
         assert_eq!(tn.node_count(), 0);
         assert_eq!(tn.edge_count(), 0);

--- a/crates/tensor4all-treetn/src/treetn/operator_impl/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/operator_impl/tests/mod.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 
 use crate::operator::Operator;
 use crate::treetn::TreeTN;
 
 /// Helper to create a simple 2-node TreeTN: A -- bond -- B
 fn make_two_node_treetn() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex, // s0
     DynIndex, // bond
     DynIndex, // s1
@@ -16,10 +16,10 @@ fn make_two_node_treetn() -> (
     let bond = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(4);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 6]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 12]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 6]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 12]).unwrap();
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -65,8 +65,8 @@ fn test_node_names() {
 fn test_site_indices_single_node() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(3);
-    let t = TensorDynLen::from_dense(vec![s0.clone(), s1.clone()], vec![0.0; 6]).unwrap();
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
+    let t = IdxTensor::from_dense(vec![s0.clone(), s1.clone()], vec![0.0; 6]).unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
 
     let site_indices = tn.site_indices();
     assert_eq!(site_indices.len(), 2);
@@ -84,15 +84,15 @@ fn test_site_indices_three_node_chain() {
     let bond12 = DynIndex::new_dyn(3);
     let s2 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond01.clone()], vec![1.0; 6]).unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond01.clone()], vec![1.0; 6]).unwrap();
+    let t1 = IdxTensor::from_dense(
         vec![bond01.clone(), s1.clone(), bond12.clone()],
         vec![1.0; 18],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(vec![bond12.clone(), s2.clone()], vec![1.0; 6]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![bond12.clone(), s2.clone()], vec![1.0; 6]).unwrap();
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1, t2],
         vec!["A".to_string(), "B".to_string(), "C".to_string()],
     )

--- a/crates/tensor4all-treetn/src/treetn/ops.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops.rs
@@ -107,10 +107,10 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
     /// let mut tn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
     ///
     /// // log(||[3, 4]||) = log(5)
@@ -202,12 +202,12 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// // Single-node TreeTN with tensor [1, 0, 0, 1] (identity 2x2)
     /// let s0 = DynIndex::new_dyn(2);
     /// let s1 = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(
+    /// let t = IdxTensor::from_dense(
     ///     vec![s0.clone(), s1.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// ).unwrap();
@@ -242,10 +242,10 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
     /// let mut tn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
     ///
     /// // ||[3, 4]||^2 = 9 + 16 = 25
@@ -281,17 +281,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen, TensorIndex, TensorLike};
+    /// use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, TensorIndex, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![s], vec![1.0_f64, -2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![s], vec![1.0_f64, -2.0]).unwrap();
     /// let mut tn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
     ///
     /// tn.scale_mut(AnyScalar::new_real(2.0)).unwrap();
     ///
     /// let dense = tn.to_dense().unwrap();
-    /// let expected = TensorDynLen::from_dense(
+    /// let expected = IdxTensor::from_dense(
     ///     dense.external_indices(),
     ///     vec![2.0_f64, -4.0],
     /// ).unwrap();
@@ -346,17 +346,17 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{AnyScalar, DynIndex, TensorDynLen, TensorIndex, TensorLike};
+    /// use tensor4all_core::{AnyScalar, DynIndex, IdxTensor, TensorIndex, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![s], vec![1.0_f64, -2.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![s], vec![1.0_f64, -2.0]).unwrap();
     /// let tn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
     ///
     /// let scaled = tn.scale(AnyScalar::new_real(2.0)).unwrap();
     ///
     /// let dense = scaled.to_dense().unwrap();
-    /// let expected = TensorDynLen::from_dense(
+    /// let expected = IdxTensor::from_dense(
     ///     dense.external_indices(),
     ///     vec![2.0_f64, -4.0],
     /// ).unwrap();
@@ -390,10 +390,10 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let t = TensorDynLen::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
+    /// let t = IdxTensor::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
     /// let tn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
     ///
     /// // <v|v> = 3^2 + 4^2 = 25
@@ -531,7 +531,7 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::TreeTN;
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorIndex, TensorLike};
     ///
     /// // Build a 2-node chain
     /// let s0 = DynIndex::new_dyn(2);
@@ -539,11 +539,11 @@ where
     /// let s1 = DynIndex::new_dyn(2);
     ///
     /// // Identity matrices
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), bond.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![bond.clone(), s1.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0],
     /// ).unwrap();
@@ -586,12 +586,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s = DynIndex::new_dyn(2);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
-    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![1.0, 2.0])?;
+    /// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     ///
     /// let evaluator = tree.evaluator(&[s])?;
     /// assert_eq!(evaluator.input_count(), 1);
@@ -670,12 +670,12 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s = DynIndex::new_dyn(3);
-    /// let tensor = TensorDynLen::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0])?;
-    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0])?;
+    /// let tensor = IdxTensor::from_dense(vec![s.clone()], vec![10.0, 20.0, 30.0])?;
+    /// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0])?;
     ///
     /// let value = tree.evaluate_point(&[s], &[2])?;
     /// assert!((value.real() - 30.0).abs() < 1e-12);
@@ -723,21 +723,21 @@ where
     /// # Examples
     ///
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s0 = DynIndex::new_dyn(2);
     /// let s1 = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(3);
-    /// let left = TensorDynLen::from_dense(
+    /// let left = IdxTensor::from_dense(
     ///     vec![s0, bond.clone()],
     ///     vec![1.0_f64; 2 * 3],
     /// )?;
-    /// let right = TensorDynLen::from_dense(
+    /// let right = IdxTensor::from_dense(
     ///     vec![bond, s1],
     ///     vec![1.0_f64; 3 * 2],
     /// )?;
-    /// let tree = TreeTN::<TensorDynLen, usize>::from_tensors(vec![left, right], vec![0, 1])?;
+    /// let tree = TreeTN::<IdxTensor, usize>::from_tensors(vec![left, right], vec![0, 1])?;
     ///
     /// assert_eq!(tree.link_dims(), vec![3]);
     /// # Ok::<(), anyhow::Error>(())
@@ -773,19 +773,19 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let s0 = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(3);
     /// let s1 = DynIndex::new_dyn(2);
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), bond.clone()], vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![bond.clone(), s1.clone()], vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     /// ).unwrap();
-    /// let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+    /// let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
     ///
     /// let (indices, vertices) = tn.all_site_indices().unwrap();
     /// assert_eq!(indices.len(), 2);

--- a/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/ops/tests/mod.rs
@@ -1,23 +1,22 @@
 use num_complex::Complex64;
-use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, TensorDynLen};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, IdxTensor};
 
 use crate::{TreeTN, TreeTNEvaluator};
 
-fn make_three_node_chain() -> TreeTN<TensorDynLen, usize> {
+fn make_three_node_chain() -> TreeTN<IdxTensor, usize> {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
     let bond01 = DynIndex::new_dyn(2);
     let bond12 = DynIndex::new_dyn(2);
 
-    let t0 =
-        TensorDynLen::from_dense(vec![s0, bond01.clone()], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(vec![s0, bond01.clone()], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let t1 = IdxTensor::from_dense(
         vec![bond01, s1, bond12.clone()],
         vec![1.0_f64, -1.0, 0.5, 2.0, 1.5, 0.25, -0.75, 3.0],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(vec![bond12, s2], vec![2.0_f64, 0.0, 1.0, 3.0]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![bond12, s2], vec![2.0_f64, 0.0, 1.0, 3.0]).unwrap();
 
     TreeTN::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap()
 }
@@ -48,12 +47,12 @@ fn test_scale_doubles_norm() {
 #[test]
 fn test_inner_preserves_complex_phase() {
     let site = DynIndex::new_dyn(2);
-    let left = TensorDynLen::from_dense(
+    let left = IdxTensor::from_dense(
         vec![site.clone()],
         vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
     )
     .unwrap();
-    let right = TensorDynLen::from_dense(
+    let right = IdxTensor::from_dense(
         vec![site],
         vec![Complex64::new(3.0, -2.0), Complex64::new(-1.0, 4.0)],
     )
@@ -72,7 +71,7 @@ fn test_inner_preserves_complex_phase() {
 fn test_evaluate_accepts_full_indices_for_same_id_prime_pair() {
     let input = DynIndex::new_dyn(2);
     let output = input.prime();
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![input.clone(), output.clone()],
         vec![10.0, 20.0, 30.0, 40.0],
     )
@@ -146,10 +145,10 @@ fn link_dims_reports_bond_dimensions_in_node_order() {
     let bond01 = DynIndex::new_dyn(2);
     let bond12 = DynIndex::new_dyn(3);
 
-    let t0 = TensorDynLen::from_dense(vec![s0, bond01.clone()], vec![1.0_f64; 2 * 2]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond01, s1, bond12.clone()], vec![1.0_f64; 2 * 2 * 3])
-        .unwrap();
-    let t2 = TensorDynLen::from_dense(vec![bond12, s2], vec![1.0_f64; 3 * 2]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0, bond01.clone()], vec![1.0_f64; 2 * 2]).unwrap();
+    let t1 =
+        IdxTensor::from_dense(vec![bond01, s1, bond12.clone()], vec![1.0_f64; 2 * 2 * 3]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![bond12, s2], vec![1.0_f64; 3 * 2]).unwrap();
     let tn = TreeTN::from_tensors(vec![t0, t1, t2], vec![0usize, 1, 2]).unwrap();
 
     assert_eq!(tn.link_dims(), vec![2, 3]);

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction.rs
@@ -19,13 +19,13 @@ use crate::error::{format_anyhow_error, SelectedIndexContractionError};
 use crate::options::RestructureOptions;
 use crate::site_index_network::SiteIndexNetwork;
 use tensor4all_core::{
-    tensordot, AnyScalar, DynIndex, FactorizeAlg, FactorizeOptions, IndexLike,
-    TensorConstructionLike, TensorContractionLike, TensorDynLen, TensorIndex, TensorLike,
+    tensordot, AnyScalar, DynIndex, FactorizeAlg, FactorizeOptions, IdxTensor, IndexLike,
+    TensorConstructionLike, TensorContractionLike, TensorIndex, TensorLike,
 };
 
 type DiagonalPairApplication<V> = (
-    TreeTN<TensorDynLen, V>,
-    TreeTN<TensorDynLen, V>,
+    TreeTN<IdxTensor, V>,
+    TreeTN<IdxTensor, V>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 );
@@ -153,7 +153,7 @@ where
     }
 }
 
-fn sorted_edge_set<V>(tn: &TreeTN<TensorDynLen, V>) -> Vec<(V, V)>
+fn sorted_edge_set<V>(tn: &TreeTN<IdxTensor, V>) -> Vec<(V, V)>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
 {
@@ -167,10 +167,7 @@ where
     edges
 }
 
-fn compatible_union_node_names<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
-) -> Vec<V>
+fn compatible_union_node_names<V>(a: &TreeTN<IdxTensor, V>, b: &TreeTN<IdxTensor, V>) -> Vec<V>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
 {
@@ -252,9 +249,9 @@ fn factorize_options_from_contraction_options(
 }
 
 fn union_result_topology<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
-    contracted_tensor: &TensorDynLen,
+    a: &TreeTN<IdxTensor, V>,
+    b: &TreeTN<IdxTensor, V>,
+    contracted_tensor: &IdxTensor,
 ) -> Result<TreeTopology<V, DynIndex>>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
@@ -296,10 +293,10 @@ where
 }
 
 fn align_to_union_topology<V>(
-    tn: &TreeTN<TensorDynLen, V>,
+    tn: &TreeTN<IdxTensor, V>,
     node_names: &[V],
     union_edges: &[(V, V)],
-) -> Result<TreeTN<TensorDynLen, V>>
+) -> Result<TreeTN<IdxTensor, V>>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -340,7 +337,7 @@ where
                 )
             })?;
             if !links.is_empty() {
-                let link_tensor = <TensorDynLen as TensorConstructionLike>::ones(&links)
+                let link_tensor = <IdxTensor as TensorConstructionLike>::ones(&links)
                     .context("partial_contract: failed to build dimension-1 structural links")?;
                 tensor = tensor
                     .outer_product(&link_tensor)
@@ -348,7 +345,7 @@ where
             }
             tensor
         } else {
-            <TensorDynLen as TensorConstructionLike>::ones(&links)
+            <IdxTensor as TensorConstructionLike>::ones(&links)
                 .context("partial_contract: failed to build missing-node scalar tensor")?
         };
 
@@ -404,8 +401,8 @@ fn ensure_dense_reference_limit(
 }
 
 fn validate_mismatched_dense_reference_fallback<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
+    a: &TreeTN<IdxTensor, V>,
+    b: &TreeTN<IdxTensor, V>,
     options: &ContractionOptions,
 ) -> Result<()>
 where
@@ -427,11 +424,11 @@ where
 }
 
 fn contract_mismatched_topologies<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
+    a: &TreeTN<IdxTensor, V>,
+    b: &TreeTN<IdxTensor, V>,
     center: &V,
     options: ContractionOptions,
-) -> Result<TreeTN<TensorDynLen, V>>
+) -> Result<TreeTN<IdxTensor, V>>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -474,7 +471,7 @@ where
         .context("partial_contract: failed dense contraction for mismatched topologies")?;
 
     if contracted_tensor.external_indices().is_empty() {
-        let mut result = TreeTN::<TensorDynLen, V>::new();
+        let mut result = TreeTN::<IdxTensor, V>::new();
         result
             .add_tensor(center.clone(), contracted_tensor)
             .context("partial_contract: failed to wrap scalar mismatched-topology result")?;
@@ -587,7 +584,7 @@ where
     Ok(reordered)
 }
 
-fn diagonal_copy_value(tensor: &TensorDynLen) -> AnyScalar {
+fn diagonal_copy_value(tensor: &IdxTensor) -> AnyScalar {
     if tensor.is_complex() {
         AnyScalar::new_complex(1.0, 0.0)
     } else {
@@ -596,8 +593,8 @@ fn diagonal_copy_value(tensor: &TensorDynLen) -> AnyScalar {
 }
 
 fn apply_diagonal_pairs<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
+    a: &TreeTN<IdxTensor, V>,
+    b: &TreeTN<IdxTensor, V>,
     diagonal_pairs: &[(DynIndex, DynIndex)],
 ) -> Result<DiagonalPairApplication<V>>
 where
@@ -637,7 +634,7 @@ where
 
         let aux_index = idx_a.sim();
         let kept_index = idx_a.sim();
-        let copy_tensor = TensorDynLen::copy_tensor(
+        let copy_tensor = IdxTensor::copy_tensor(
             vec![idx_a.clone(), aux_index.clone(), kept_index.clone()],
             diagonal_copy_value(&local_tensor),
         )
@@ -693,8 +690,8 @@ where
 }
 
 fn align_contract_pair_site_nodes<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &mut TreeTN<TensorDynLen, V>,
+    a: &TreeTN<IdxTensor, V>,
+    b: &mut TreeTN<IdxTensor, V>,
     contract_pairs: &[(DynIndex, DynIndex)],
 ) -> Result<()>
 where
@@ -744,8 +741,8 @@ fn has_contractable_index_pair(left: &[DynIndex], right: &[DynIndex]) -> bool {
 }
 
 fn connect_nodewise_outer_product_spectators<V>(
-    a: &mut TreeTN<TensorDynLen, V>,
-    b: &mut TreeTN<TensorDynLen, V>,
+    a: &mut TreeTN<IdxTensor, V>,
+    b: &mut TreeTN<IdxTensor, V>,
 ) -> Result<()>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
@@ -777,10 +774,10 @@ where
 
         let (dummy_a, dummy_b) = DynIndex::create_dummy_link_pair();
         let dummy_tensor_a =
-            <TensorDynLen as TensorConstructionLike>::ones(std::slice::from_ref(&dummy_a))
+            <IdxTensor as TensorConstructionLike>::ones(std::slice::from_ref(&dummy_a))
                 .context("partial_contract: failed to build dummy contraction link")?;
         let dummy_tensor_b =
-            <TensorDynLen as TensorConstructionLike>::ones(std::slice::from_ref(&dummy_b))
+            <IdxTensor as TensorConstructionLike>::ones(std::slice::from_ref(&dummy_b))
                 .context("partial_contract: failed to build matching dummy contraction link")?;
         let expanded_a = tensor_a
             .outer_product(&dummy_tensor_a)
@@ -837,7 +834,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen};
+/// use tensor4all_core::{DynIndex, IdxTensor};
 /// use tensor4all_treetn::{
 ///     contraction::ContractionOptions,
 ///     partial_contract,
@@ -847,12 +844,12 @@ where
 ///
 /// let idx_a = DynIndex::new_dyn(2);
 /// let idx_b = DynIndex::new_dyn(2);
-/// let a = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![idx_a.clone()], vec![1.0, 2.0]).unwrap()],
+/// let a = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![idx_a.clone()], vec![1.0, 2.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
-/// let b = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![idx_b.clone()], vec![3.0, 4.0]).unwrap()],
+/// let b = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![idx_b.clone()], vec![3.0, 4.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
 ///
@@ -867,12 +864,12 @@ where
 /// assert!((scalar - 11.0).abs() < 1.0e-12);
 /// ```
 pub fn partial_contract<V>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
+    a: &TreeTN<IdxTensor, V>,
+    b: &TreeTN<IdxTensor, V>,
     spec: &PartialContractionSpec<DynIndex>,
     center: &V,
     options: ContractionOptions,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, TreeTNOperationError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -951,7 +948,7 @@ where
 /// ```
 /// use std::collections::HashSet;
 ///
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorIndex};
 /// use tensor4all_treetn::{
 ///     contraction::ContractionOptions,
 ///     partial_contract_to_site_network,
@@ -966,15 +963,15 @@ where
 /// let k_right = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(2);
 ///
-/// let a = TreeTN::<TensorDynLen, &str>::from_tensors(
-///     vec![TensorDynLen::from_dense(
+/// let a = TreeTN::<IdxTensor, &str>::from_tensors(
+///     vec![IdxTensor::from_dense(
 ///         vec![i.clone(), k_left.clone()],
 ///         vec![1.0, 2.0, 3.0, 4.0],
 ///     ).unwrap()],
 ///     vec!["center"],
 /// ).unwrap();
-/// let b = TreeTN::<TensorDynLen, &str>::from_tensors(
-///     vec![TensorDynLen::from_dense(
+/// let b = TreeTN::<IdxTensor, &str>::from_tensors(
+///     vec![IdxTensor::from_dense(
 ///         vec![k_right.clone(), j.clone()],
 ///         vec![5.0, 6.0, 7.0, 8.0],
 ///     ).unwrap()],
@@ -1012,14 +1009,14 @@ where
 /// assert_eq!(result.site_index_network().find_node_by_index(&j), Some(&"1_col"));
 /// ```
 pub fn partial_contract_to_site_network<V, TargetV>(
-    a: &TreeTN<TensorDynLen, V>,
-    b: &TreeTN<TensorDynLen, V>,
+    a: &TreeTN<IdxTensor, V>,
+    b: &TreeTN<IdxTensor, V>,
     spec: &PartialContractionSpec<DynIndex>,
     center: &V,
     target: &SiteIndexNetwork<TargetV, DynIndex>,
     options: ContractionOptions,
     restructure_options: &RestructureOptions,
-) -> std::result::Result<TreeTN<TensorDynLen, TargetV>, TreeTNOperationError>
+) -> std::result::Result<TreeTN<IdxTensor, TargetV>, TreeTNOperationError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     TargetV: Clone + Hash + Eq + Send + Sync + Debug + Ord,
@@ -1063,17 +1060,17 @@ where
 ///
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorIndex};
 /// use tensor4all_treetn::{contraction::ContractionOptions, hadamard, TreeTN};
 ///
 /// let i = DynIndex::new_dyn(2);
 /// let j = DynIndex::new_dyn(2);
-/// let left = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![i.clone()], vec![2.0, 3.0]).unwrap()],
+/// let left = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![i.clone()], vec![2.0, 3.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
-/// let right = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![j.clone()], vec![5.0, 7.0]).unwrap()],
+/// let right = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![j.clone()], vec![5.0, 7.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
 ///
@@ -1083,12 +1080,12 @@ where
 /// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![10.0, 21.0]);
 /// ```
 pub fn hadamard<V>(
-    left: &TreeTN<TensorDynLen, V>,
-    right: &TreeTN<TensorDynLen, V>,
+    left: &TreeTN<IdxTensor, V>,
+    right: &TreeTN<IdxTensor, V>,
     index_pairs: &[(DynIndex, DynIndex)],
     center: &V,
     options: ContractionOptions,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, SelectedIndexContractionError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, SelectedIndexContractionError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -1127,7 +1124,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorIndex};
 /// use tensor4all_treetn::{
 ///     contraction::ContractionOptions,
 ///     weighted_sum_over_index_pairs,
@@ -1137,12 +1134,12 @@ where
 /// let x = DynIndex::new_dyn(2);
 /// let z = DynIndex::new_dyn(2);
 /// let wz = DynIndex::new_dyn(2);
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![x.clone(), z.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap()],
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![x.clone(), z.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
-/// let weights = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![wz.clone()], vec![10.0, 100.0]).unwrap()],
+/// let weights = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![wz.clone()], vec![10.0, 100.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
 ///
@@ -1158,12 +1155,12 @@ where
 /// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![310.0, 420.0]);
 /// ```
 pub fn weighted_sum_over_index_pairs<V>(
-    state: &TreeTN<TensorDynLen, V>,
-    weights: &TreeTN<TensorDynLen, V>,
+    state: &TreeTN<IdxTensor, V>,
+    weights: &TreeTN<IdxTensor, V>,
     index_pairs: &[(DynIndex, DynIndex)],
     center: &V,
     options: ContractionOptions,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, SelectedIndexContractionError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, SelectedIndexContractionError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -1204,13 +1201,13 @@ where
 ///
 /// # Examples
 /// ```
-/// use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex};
+/// use tensor4all_core::{DynIndex, IdxTensor, TensorIndex};
 /// use tensor4all_treetn::{contraction::ContractionOptions, sum_over_indices, TreeTN};
 ///
 /// let x = DynIndex::new_dyn(2);
 /// let z = DynIndex::new_dyn(2);
-/// let state = TreeTN::<TensorDynLen, usize>::from_tensors(
-///     vec![TensorDynLen::from_dense(vec![x.clone(), z.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap()],
+/// let state = TreeTN::<IdxTensor, usize>::from_tensors(
+///     vec![IdxTensor::from_dense(vec![x.clone(), z.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap()],
 ///     vec![0],
 /// ).unwrap();
 ///
@@ -1220,11 +1217,11 @@ where
 /// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![4.0, 6.0]);
 /// ```
 pub fn sum_over_indices<V>(
-    state: &TreeTN<TensorDynLen, V>,
+    state: &TreeTN<IdxTensor, V>,
     sum_indices: &[DynIndex],
     center: &V,
     options: ContractionOptions,
-) -> std::result::Result<TreeTN<TensorDynLen, V>, SelectedIndexContractionError>
+) -> std::result::Result<TreeTN<IdxTensor, V>, SelectedIndexContractionError>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug + Ord,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + Debug + Send + Sync,
@@ -1298,7 +1295,7 @@ where
             indices.append(&mut links);
         }
         tensors.push(
-            <TensorDynLen as TensorConstructionLike>::ones(&indices).map_err(|error| {
+            <IdxTensor as TensorConstructionLike>::ones(&indices).map_err(|error| {
                 SelectedIndexContractionError::BuildOnesTensor {
                     node: format!("{node:?}"),
                     message: format_anyhow_error(anyhow::Error::new(error)),

--- a/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs
@@ -6,12 +6,12 @@ use crate::{
 };
 use num_complex::Complex64;
 use tensor4all_core::{
-    DynIndex, FactorizeAlg, SvdTruncationPolicy, TensorContractionLike, TensorDynLen, TensorIndex,
+    DynIndex, FactorizeAlg, IdxTensor, SvdTruncationPolicy, TensorContractionLike, TensorIndex,
 };
 
 struct PartialContractionInputs {
-    tn_a: TreeTN<TensorDynLen, String>,
-    tn_b: TreeTN<TensorDynLen, String>,
+    tn_a: TreeTN<IdxTensor, String>,
+    tn_b: TreeTN<IdxTensor, String>,
     s_contract_a: DynIndex,
     s_contract_b: DynIndex,
     s_multiply_a: DynIndex,
@@ -31,28 +31,26 @@ fn make_partial_contraction_inputs() -> PartialContractionInputs {
     let s_b_only = DynIndex::new_dyn(4);
     let bond_b = DynIndex::new_dyn(2);
 
-    let t_a0 = TensorDynLen::from_dense(
+    let t_a0 = IdxTensor::from_dense(
         vec![s_contract_a.clone(), s_multiply_a.clone(), bond_a.clone()],
         vec![1.0; 8],
     )
     .unwrap();
-    let t_a1 =
-        TensorDynLen::from_dense(vec![bond_a.clone(), s_a_only.clone()], vec![1.0; 6]).unwrap();
+    let t_a1 = IdxTensor::from_dense(vec![bond_a.clone(), s_a_only.clone()], vec![1.0; 6]).unwrap();
 
-    let t_b0 = TensorDynLen::from_dense(
+    let t_b0 = IdxTensor::from_dense(
         vec![s_contract_b.clone(), s_multiply_b.clone(), bond_b.clone()],
         vec![2.0; 8],
     )
     .unwrap();
-    let t_b1 =
-        TensorDynLen::from_dense(vec![bond_b.clone(), s_b_only.clone()], vec![2.0; 8]).unwrap();
+    let t_b1 = IdxTensor::from_dense(vec![bond_b.clone(), s_b_only.clone()], vec![2.0; 8]).unwrap();
 
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_a0, t_a1],
         vec!["A".to_string(), "B".to_string()],
     )
     .unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_b0, t_b1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -159,13 +157,13 @@ fn helper_factorize_options_and_union_topology_paths_are_exercised() {
 fn hadamard_multiplies_paired_external_indices() {
     let left_index = DynIndex::new_dyn(2);
     let right_index = DynIndex::new_dyn(2);
-    let lhs = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![left_index.clone()], vec![2.0, 3.0]).unwrap()],
+    let lhs = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(vec![left_index.clone()], vec![2.0, 3.0]).unwrap()],
         vec!["A".to_string()],
     )
     .unwrap();
-    let rhs = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![right_index.clone()], vec![5.0, 7.0]).unwrap()],
+    let rhs = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(vec![right_index.clone()], vec![5.0, 7.0]).unwrap()],
         vec!["A".to_string()],
     )
     .unwrap();
@@ -189,8 +187,8 @@ fn weighted_sum_over_index_pairs_contracts_only_selected_axes() {
     let x = DynIndex::new_dyn(2);
     let z = DynIndex::new_dyn(3);
     let wz = DynIndex::new_dyn(3);
-    let state = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(
+    let state = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(
             vec![x.clone(), z.clone()],
             vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0],
         )
@@ -198,8 +196,8 @@ fn weighted_sum_over_index_pairs_contracts_only_selected_axes() {
         vec!["A".to_string()],
     )
     .unwrap();
-    let weights = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![wz.clone()], vec![2.0, 3.0, 5.0]).unwrap()],
+    let weights = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(vec![wz.clone()], vec![2.0, 3.0, 5.0]).unwrap()],
         vec!["A".to_string()],
     )
     .unwrap();
@@ -222,8 +220,8 @@ fn weighted_sum_over_index_pairs_contracts_only_selected_axes() {
 fn sum_over_indices_uses_factorized_ones_weights() {
     let x = DynIndex::new_dyn(2);
     let z = DynIndex::new_dyn(3);
-    let state = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(
+    let state = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(
             vec![x.clone(), z.clone()],
             vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0],
         )
@@ -248,8 +246,8 @@ fn sum_over_indices_uses_factorized_ones_weights() {
 #[test]
 fn sum_over_indices_reports_typed_selection_errors() {
     let x = DynIndex::new_dyn(2);
-    let state = TreeTN::<TensorDynLen, String>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![x.clone()], vec![1.0, 2.0]).unwrap()],
+    let state = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![IdxTensor::from_dense(vec![x.clone()], vec![1.0, 2.0]).unwrap()],
         vec!["A".to_string()],
     )
     .unwrap();
@@ -459,13 +457,11 @@ fn test_partial_contract_contract_only() {
     let extra_a = DynIndex::new_dyn(2);
     let extra_b = DynIndex::new_dyn(2);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone(), extra_a.clone()], vec![1.0; 6]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s_b.clone(), extra_b.clone()], vec![2.0; 6]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s_a.clone(), extra_a.clone()], vec![1.0; 6]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s_b.clone(), extra_b.clone()], vec![2.0; 6]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let spec = PartialContractionSpec {
         contract_pairs: vec![(s_a, s_b)],
@@ -494,29 +490,29 @@ fn partial_contract_fit_inserts_dummy_links_for_nodewise_outer_product_spectator
     let bond_left = DynIndex::new_dyn(2);
     let bond_right = DynIndex::new_dyn(2);
 
-    let a0 = TensorDynLen::from_dense(
+    let a0 = IdxTensor::from_dense(
         vec![k_left.clone(), bond_left.clone()],
         vec![1.0, 2.0, 3.0, 4.0],
     )
     .unwrap();
-    let a1 = TensorDynLen::from_dense(vec![bond_left.clone(), i.clone()], vec![5.0, 6.0, 7.0, 8.0])
+    let a1 = IdxTensor::from_dense(vec![bond_left.clone(), i.clone()], vec![5.0, 6.0, 7.0, 8.0])
         .unwrap();
-    let b0 = TensorDynLen::from_dense(
+    let b0 = IdxTensor::from_dense(
         vec![k_right.clone(), bond_right.clone()],
         vec![0.5, 1.5, 2.5, 3.5],
     )
     .unwrap();
-    let b1 = TensorDynLen::from_dense(
+    let b1 = IdxTensor::from_dense(
         vec![bond_right.clone(), j.clone()],
         vec![1.0, -1.0, 2.0, -2.0],
     )
     .unwrap();
-    let lhs = TreeTN::<TensorDynLen, String>::from_tensors(
+    let lhs = TreeTN::<IdxTensor, String>::from_tensors(
         vec![a0, a1],
         vec!["left".to_string(), "right".to_string()],
     )
     .unwrap();
-    let rhs = TreeTN::<TensorDynLen, String>::from_tensors(
+    let rhs = TreeTN::<IdxTensor, String>::from_tensors(
         vec![b0, b1],
         vec!["left".to_string(), "right".to_string()],
     )
@@ -554,13 +550,11 @@ fn test_partial_contract_empty_spec() {
     let s_a = DynIndex::new_dyn(2);
     let s_b = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s_b.clone()], vec![2.0; 3]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s_b.clone()], vec![2.0; 3]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let spec: PartialContractionSpec<DynIndex> = PartialContractionSpec {
         contract_pairs: vec![],
@@ -585,13 +579,11 @@ fn test_partial_contract_rejects_bad_output_order_length() {
     let s_a = DynIndex::new_dyn(2);
     let s_b = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s_b], vec![2.0; 3]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s_b], vec![2.0; 3]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let spec = PartialContractionSpec {
         contract_pairs: vec![],
@@ -618,13 +610,11 @@ fn test_partial_contract_rejects_unknown_output_order_index() {
     let s_b = DynIndex::new_dyn(3);
     let unknown = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
-    let t_b = TensorDynLen::from_dense(vec![s_b], vec![2.0; 3]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
+    let t_b = IdxTensor::from_dense(vec![s_b], vec![2.0; 3]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![t_b], vec!["A".to_string()]).unwrap();
 
     let spec = PartialContractionSpec {
         contract_pairs: vec![],
@@ -653,9 +643,9 @@ fn test_partial_contract_allows_same_node_in_second_network() {
     let bond_a = DynIndex::new_dyn(2);
 
     // tn_a: node "A" has s_a1 only, node "B" has s_a2 only
-    let t_a0 = TensorDynLen::from_dense(vec![s_a1.clone(), bond_a.clone()], vec![1.0; 4]).unwrap();
-    let t_a1 = TensorDynLen::from_dense(vec![bond_a.clone(), s_a2.clone()], vec![1.0; 4]).unwrap();
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t_a0 = IdxTensor::from_dense(vec![s_a1.clone(), bond_a.clone()], vec![1.0; 4]).unwrap();
+    let t_a1 = IdxTensor::from_dense(vec![bond_a.clone(), s_a2.clone()], vec![1.0; 4]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_a0, t_a1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -667,14 +657,13 @@ fn test_partial_contract_allows_same_node_in_second_network() {
     let bond_b = DynIndex::new_dyn(2);
     let s_b_only = DynIndex::new_dyn(3);
 
-    let t_b0 = TensorDynLen::from_dense(
+    let t_b0 = IdxTensor::from_dense(
         vec![s_b_contract.clone(), s_b_multiply.clone(), bond_b.clone()],
         vec![2.0; 8],
     )
     .unwrap();
-    let t_b1 =
-        TensorDynLen::from_dense(vec![bond_b.clone(), s_b_only.clone()], vec![2.0; 6]).unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t_b1 = IdxTensor::from_dense(vec![bond_b.clone(), s_b_only.clone()], vec![2.0; 6]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_b0, t_b1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -716,32 +705,32 @@ fn test_partial_contract_moves_misaligned_same_topology_contract_pair() {
     let b_b23 = DynIndex::new_dyn(1);
     let b_b34 = DynIndex::new_dyn(1);
 
-    let tn_a = TreeTN::<TensorDynLen, usize>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, usize>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![a_row0.clone(), a_b01.clone()], vec![1.0; 2]).unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(vec![a_row0.clone(), a_b01.clone()], vec![1.0; 2]).unwrap(),
+            IdxTensor::from_dense(
                 vec![a_b01.clone(), a_contract.clone(), a_b12.clone()],
                 vec![1.0; 2],
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![a_b12.clone(), a_row1.clone(), a_b23.clone()],
                 vec![1.0; 2],
             )
             .unwrap(),
-            TensorDynLen::from_dense(vec![a_b23.clone(), a_b34.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(vec![a_b34.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![a_b23.clone(), a_b34.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![a_b34.clone()], vec![1.0]).unwrap(),
         ],
         vec![0, 1, 2, 3, 4],
     )
     .unwrap();
 
-    let tn_b = TreeTN::<TensorDynLen, usize>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, usize>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![b_b01.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(vec![b_b01.clone(), b_b12.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(vec![b_b12.clone(), b_b23.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(vec![b_b01.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![b_b01.clone(), b_b12.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![b_b12.clone(), b_b23.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(
                 vec![
                     b_b23.clone(),
                     b_contract.clone(),
@@ -751,7 +740,7 @@ fn test_partial_contract_moves_misaligned_same_topology_contract_pair() {
                 vec![1.0; 4],
             )
             .unwrap(),
-            TensorDynLen::from_dense(vec![b_b34.clone(), b_col1.clone()], vec![1.0; 2]).unwrap(),
+            IdxTensor::from_dense(vec![b_b34.clone(), b_col1.clone()], vec![1.0; 2]).unwrap(),
         ],
         vec![0, 1, 2, 3, 4],
     )
@@ -787,13 +776,12 @@ fn test_partial_contract_allows_compatible_topology_mismatch_with_gap_leaf() {
     let bond_b = DynIndex::new_dyn(2);
     let s_b2 = DynIndex::new_dyn(3);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s_a.clone()], vec![1.0; 2]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
 
-    let t_b0 = TensorDynLen::from_dense(vec![s_b.clone(), bond_b.clone()], vec![2.0; 4]).unwrap();
-    let t_b1 = TensorDynLen::from_dense(vec![bond_b.clone(), s_b2.clone()], vec![2.0; 6]).unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t_b0 = IdxTensor::from_dense(vec![s_b.clone(), bond_b.clone()], vec![2.0; 4]).unwrap();
+    let t_b1 = IdxTensor::from_dense(vec![bond_b.clone(), s_b2.clone()], vec![2.0; 6]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_b0, t_b1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -823,7 +811,7 @@ fn test_partial_contract_allows_compatible_topology_mismatch_with_gap_leaf() {
 
 #[test]
 fn test_partial_contract_aligns_long_mismatched_chain_without_dense_limit() {
-    fn binary_chain(node_count: usize) -> TreeTN<TensorDynLen, usize> {
+    fn binary_chain(node_count: usize) -> TreeTN<IdxTensor, usize> {
         let mut tensors = Vec::with_capacity(node_count);
         let mut names = Vec::with_capacity(node_count);
         let mut left_bond: Option<DynIndex> = None;
@@ -841,12 +829,12 @@ fn test_partial_contract_aligns_long_mismatched_chain_without_dense_limit() {
             }
 
             let element_count = indices.iter().map(IndexLike::dim).product();
-            tensors.push(TensorDynLen::from_dense(indices, vec![1.0; element_count]).unwrap());
+            tensors.push(IdxTensor::from_dense(indices, vec![1.0; element_count]).unwrap());
             names.push(site);
             left_bond = right_bond;
         }
 
-        TreeTN::<TensorDynLen, usize>::from_tensors(tensors, names).unwrap()
+        TreeTN::<IdxTensor, usize>::from_tensors(tensors, names).unwrap()
     }
 
     let tn_a = binary_chain(24);
@@ -877,21 +865,21 @@ fn test_partial_contract_rejects_incompatible_topology_union() {
     let ab2 = DynIndex::new_dyn(2);
     let ac2 = DynIndex::new_dyn(2);
 
-    let ta0 = TensorDynLen::from_dense(vec![sa.clone(), ab.clone()], vec![1.0; 4]).unwrap();
+    let ta0 = IdxTensor::from_dense(vec![sa.clone(), ab.clone()], vec![1.0; 4]).unwrap();
     let ta1 =
-        TensorDynLen::from_dense(vec![ab.clone(), sb.clone(), bc.clone()], vec![1.0; 8]).unwrap();
-    let ta2 = TensorDynLen::from_dense(vec![bc.clone(), sc.clone()], vec![1.0; 4]).unwrap();
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+        IdxTensor::from_dense(vec![ab.clone(), sb.clone(), bc.clone()], vec![1.0; 8]).unwrap();
+    let ta2 = IdxTensor::from_dense(vec![bc.clone(), sc.clone()], vec![1.0; 4]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![ta0, ta1, ta2],
         vec!["A".to_string(), "B".to_string(), "C".to_string()],
     )
     .unwrap();
 
     let tb0 =
-        TensorDynLen::from_dense(vec![sa.sim(), ab2.clone(), ac2.clone()], vec![2.0; 8]).unwrap();
-    let tb1 = TensorDynLen::from_dense(vec![ab2.clone(), sb.sim()], vec![2.0; 4]).unwrap();
-    let tb2 = TensorDynLen::from_dense(vec![ac2.clone(), sc.sim()], vec![2.0; 4]).unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+        IdxTensor::from_dense(vec![sa.sim(), ab2.clone(), ac2.clone()], vec![2.0; 8]).unwrap();
+    let tb1 = IdxTensor::from_dense(vec![ab2.clone(), sb.sim()], vec![2.0; 4]).unwrap();
+    let tb2 = IdxTensor::from_dense(vec![ac2.clone(), sc.sim()], vec![2.0; 4]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tb0, tb1, tb2],
         vec!["A".to_string(), "B".to_string(), "C".to_string()],
     )
@@ -920,13 +908,12 @@ fn test_partial_contract_mismatched_topology_scalar_result() {
     let s_b = DynIndex::new_dyn(2);
     let bond_b = DynIndex::new_dyn(1);
 
-    let t_a = TensorDynLen::from_dense(vec![s_a.clone()], vec![1.0, 2.0]).unwrap();
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
+    let t_a = IdxTensor::from_dense(vec![s_a.clone()], vec![1.0, 2.0]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![t_a], vec!["A".to_string()]).unwrap();
 
-    let t_b0 = TensorDynLen::from_dense(vec![s_b.clone(), bond_b.clone()], vec![3.0, 4.0]).unwrap();
-    let t_b1 = TensorDynLen::from_dense(vec![bond_b], vec![1.0]).unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t_b0 = IdxTensor::from_dense(vec![s_b.clone(), bond_b.clone()], vec![3.0, 4.0]).unwrap();
+    let t_b1 = IdxTensor::from_dense(vec![bond_b], vec![1.0]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_b0, t_b1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -960,17 +947,15 @@ fn test_partial_contract_honors_output_order() {
     let bond_a1 = DynIndex::new_dyn(2);
 
     let t_a0 =
-        TensorDynLen::from_dense(vec![a0.clone(), bond_a0.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
-    let t_a1 = TensorDynLen::from_dense(
+        IdxTensor::from_dense(vec![a0.clone(), bond_a0.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let t_a1 = IdxTensor::from_dense(
         vec![bond_a0.clone(), a1.clone(), bond_a1.clone()],
         vec![1.0; 8],
     )
     .unwrap();
     let t_a2 =
-        TensorDynLen::from_dense(vec![bond_a1.clone(), a2.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
-    let tn_a = TreeTN::<TensorDynLen, String>::from_tensors(
+        IdxTensor::from_dense(vec![bond_a1.clone(), a2.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_a0, t_a1, t_a2],
         vec!["A".to_string(), "B".to_string(), "C".to_string()],
     )
@@ -983,17 +968,15 @@ fn test_partial_contract_honors_output_order() {
     let bond_b1 = DynIndex::new_dyn(2);
 
     let t_b0 =
-        TensorDynLen::from_dense(vec![b0.clone(), bond_b0.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
-    let t_b1 = TensorDynLen::from_dense(
+        IdxTensor::from_dense(vec![b0.clone(), bond_b0.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let t_b1 = IdxTensor::from_dense(
         vec![bond_b0.clone(), b1.clone(), bond_b1.clone()],
         vec![1.0; 8],
     )
     .unwrap();
     let t_b2 =
-        TensorDynLen::from_dense(vec![bond_b1.clone(), b2.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
-    let tn_b = TreeTN::<TensorDynLen, String>::from_tensors(
+        IdxTensor::from_dense(vec![bond_b1.clone(), b2.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t_b0, t_b1, t_b2],
         vec!["A".to_string(), "B".to_string(), "C".to_string()],
     )
@@ -1038,35 +1021,35 @@ fn test_partial_contract_output_order_rejects_multiple_survivors_on_one_node() {
     let b_b23 = DynIndex::new_dyn(1);
     let b_b34 = DynIndex::new_dyn(1);
 
-    let tn_a = TreeTN::<TensorDynLen, usize>::from_tensors(
+    let tn_a = TreeTN::<IdxTensor, usize>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![a_row0.clone(), a_b01.clone()], vec![1.0; 2]).unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(vec![a_row0.clone(), a_b01.clone()], vec![1.0; 2]).unwrap(),
+            IdxTensor::from_dense(
                 vec![a_b01.clone(), a_contract.clone(), a_b12.clone()],
                 vec![1.0; 2],
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![a_b12.clone(), a_row1.clone(), a_b23.clone()],
                 vec![1.0; 2],
             )
             .unwrap(),
-            TensorDynLen::from_dense(vec![a_b23.clone(), a_b34.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(vec![a_b34.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![a_b23.clone(), a_b34.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![a_b34.clone()], vec![1.0]).unwrap(),
         ],
         vec![0, 1, 2, 3, 4],
     )
     .unwrap();
-    let tn_b = TreeTN::<TensorDynLen, usize>::from_tensors(
+    let tn_b = TreeTN::<IdxTensor, usize>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![b_b01.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(vec![b_b01.clone(), b_b12.clone()], vec![1.0]).unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(vec![b_b01.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![b_b01.clone(), b_b12.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(
                 vec![b_b12.clone(), b_col1.clone(), b_b23.clone()],
                 vec![1.0; 2],
             )
             .unwrap(),
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     b_b23.clone(),
                     b_contract.clone(),
@@ -1076,7 +1059,7 @@ fn test_partial_contract_output_order_rejects_multiple_survivors_on_one_node() {
                 vec![1.0; 4],
             )
             .unwrap(),
-            TensorDynLen::from_dense(vec![b_b34.clone()], vec![1.0]).unwrap(),
+            IdxTensor::from_dense(vec![b_b34.clone()], vec![1.0]).unwrap(),
         ],
         vec![0, 1, 2, 3, 4],
     )
@@ -1110,17 +1093,17 @@ fn test_partial_contract_to_site_network_splits_onto_explicit_target() {
     let k_right = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
 
-    let a = TreeTN::<TensorDynLen, &str>::from_tensors(
+    let a = TreeTN::<IdxTensor, &str>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![i.clone(), k_left.clone()], vec![1.0, 2.0, 3.0, 4.0])
+            IdxTensor::from_dense(vec![i.clone(), k_left.clone()], vec![1.0, 2.0, 3.0, 4.0])
                 .unwrap(),
         ],
         vec!["center"],
     )
     .unwrap();
-    let b = TreeTN::<TensorDynLen, &str>::from_tensors(
+    let b = TreeTN::<IdxTensor, &str>::from_tensors(
         vec![
-            TensorDynLen::from_dense(vec![k_right.clone(), j.clone()], vec![5.0, 6.0, 7.0, 8.0])
+            IdxTensor::from_dense(vec![k_right.clone(), j.clone()], vec![5.0, 6.0, 7.0, 8.0])
                 .unwrap(),
         ],
         vec!["center"],
@@ -1176,13 +1159,13 @@ fn test_partial_contract_to_site_network_splits_onto_explicit_target() {
 fn test_partial_contract_to_site_network_rejects_output_order() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
-    let a = TreeTN::<TensorDynLen, &str>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap()],
+    let a = TreeTN::<IdxTensor, &str>::from_tensors(
+        vec![IdxTensor::from_dense(vec![i.clone()], vec![1.0, 2.0]).unwrap()],
         vec!["center"],
     )
     .unwrap();
-    let b = TreeTN::<TensorDynLen, &str>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![j], vec![3.0, 4.0]).unwrap()],
+    let b = TreeTN::<IdxTensor, &str>::from_tensors(
+        vec![IdxTensor::from_dense(vec![j], vec![3.0, 4.0]).unwrap()],
         vec!["center"],
     )
     .unwrap();
@@ -1215,21 +1198,19 @@ fn test_partial_contract_complex_diagonal_pair_keeps_left_leg() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
 
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![i.clone()],
         vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
     )
     .unwrap();
-    let b = TensorDynLen::from_dense(
+    let b = IdxTensor::from_dense(
         vec![j.clone()],
         vec![Complex64::new(3.0, 0.5), Complex64::new(-1.0, 4.0)],
     )
     .unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![b], vec!["A".to_string()]).unwrap();
 
     let spec = PartialContractionSpec {
         contract_pairs: vec![],
@@ -1246,7 +1227,7 @@ fn test_partial_contract_complex_diagonal_pair_keeps_left_leg() {
     .unwrap();
 
     let dense = result.contract_to_tensor().unwrap();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![i],
         vec![Complex64::new(2.5, 3.5), Complex64::new(2.0, 9.0)],
     )
@@ -1259,13 +1240,11 @@ fn test_partial_contract_diagonal_pair_keeps_left_leg() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(2);
 
-    let a = TensorDynLen::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
-    let b = TensorDynLen::from_dense(vec![j.clone()], vec![10.0_f64, 20.0]).unwrap();
+    let a = IdxTensor::from_dense(vec![i.clone()], vec![1.0_f64, 2.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![j.clone()], vec![10.0_f64, 20.0]).unwrap();
 
-    let tn_a =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![a], vec!["A".to_string()]).unwrap();
-    let tn_b =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![b], vec!["A".to_string()]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, String>::from_tensors(vec![a], vec!["A".to_string()]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, String>::from_tensors(vec![b], vec!["A".to_string()]).unwrap();
 
     let spec = PartialContractionSpec {
         contract_pairs: vec![],
@@ -1283,7 +1262,7 @@ fn test_partial_contract_diagonal_pair_keeps_left_leg() {
     .unwrap();
 
     let dense = result.contract_to_tensor().unwrap();
-    let expected = TensorDynLen::from_dense(vec![i], vec![10.0_f64, 40.0]).unwrap();
+    let expected = IdxTensor::from_dense(vec![i], vec![10.0_f64, 40.0]).unwrap();
     assert!(dense.isapprox(&expected, 1e-12, 0.0).unwrap());
 }
 
@@ -1298,7 +1277,7 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
     let i_b = DynIndex::new_dyn(2);
     let j_b = DynIndex::new_dyn(3);
 
-    let dense_a = TensorDynLen::from_dense(vec![x_a.clone(), w_a.clone(), i_a.clone()], {
+    let dense_a = IdxTensor::from_dense(vec![x_a.clone(), w_a.clone(), i_a.clone()], {
         let mut values = Vec::new();
         for i in 0..i_a.dim() {
             for w in 0..w_a.dim() {
@@ -1310,7 +1289,7 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
         values
     })
     .unwrap();
-    let dense_b = TensorDynLen::from_dense(
+    let dense_b = IdxTensor::from_dense(
         vec![
             x_b.clone(),
             w_b.clone(),
@@ -1390,7 +1369,7 @@ fn test_partial_contract_matches_dense_reference_for_cross_topology_chain() {
     .unwrap();
     let result_dense = result.to_dense().unwrap();
 
-    let expected = TensorDynLen::from_dense(vec![x_a, z_b, j_b], {
+    let expected = IdxTensor::from_dense(vec![x_a, z_b, j_b], {
         let mut values = Vec::new();
         for j in 0..3 {
             for z in 0..2 {

--- a/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/restructure/mod.rs
@@ -1288,16 +1288,16 @@ where
     /// ```
     /// use std::collections::HashSet;
     ///
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     /// use tensor4all_treetn::{RestructureOptions, SiteIndexNetwork, TreeTN};
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let left = DynIndex::new_dyn(2);
     /// let right = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(1);
-    /// let t0 = TensorDynLen::from_dense(vec![left.clone(), bond.clone()], vec![1.0, 0.0])?;
-    /// let t1 = TensorDynLen::from_dense(vec![bond, right.clone()], vec![1.0, 0.0])?;
-    /// let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+    /// let t0 = IdxTensor::from_dense(vec![left.clone(), bond.clone()], vec![1.0, 0.0])?;
+    /// let t1 = IdxTensor::from_dense(vec![bond, right.clone()], vec![1.0, 0.0])?;
+    /// let treetn = TreeTN::<IdxTensor, String>::from_tensors(
     ///     vec![t0, t1],
     ///     vec!["A".to_string(), "B".to_string()],
     /// )?;
@@ -1338,25 +1338,25 @@ where
 mod tests {
     use std::collections::HashSet;
 
-    use tensor4all_core::{DynIndex, TensorDynLen};
+    use tensor4all_core::{DynIndex, IdxTensor};
 
     use super::*;
 
     type FourSiteChainCase = (
-        TreeTN<TensorDynLen, String>,
+        TreeTN<IdxTensor, String>,
         DynIndex,
         DynIndex,
         DynIndex,
         DynIndex,
     );
 
-    fn two_node_chain() -> anyhow::Result<(TreeTN<TensorDynLen, String>, DynIndex, DynIndex)> {
+    fn two_node_chain() -> anyhow::Result<(TreeTN<IdxTensor, String>, DynIndex, DynIndex)> {
         let left = DynIndex::new_dyn(2);
         let right = DynIndex::new_dyn(2);
         let bond = DynIndex::new_dyn(1);
-        let t0 = TensorDynLen::from_dense(vec![left.clone(), bond.clone()], vec![1.0, 0.0])?;
-        let t1 = TensorDynLen::from_dense(vec![bond, right.clone()], vec![1.0, 0.0])?;
-        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+        let t0 = IdxTensor::from_dense(vec![left.clone(), bond.clone()], vec![1.0, 0.0])?;
+        let t1 = IdxTensor::from_dense(vec![bond, right.clone()], vec![1.0, 0.0])?;
+        let treetn = TreeTN::<IdxTensor, String>::from_tensors(
             vec![t0, t1],
             vec!["A".to_string(), "B".to_string()],
         )?;
@@ -1369,15 +1369,15 @@ mod tests {
         let y0 = DynIndex::new_dyn(2);
         let y1 = DynIndex::new_dyn(2);
         let bond = DynIndex::new_dyn(2);
-        let left_tensor = TensorDynLen::from_dense(
+        let left_tensor = IdxTensor::from_dense(
             vec![x0.clone(), x1.clone(), bond.clone()],
             vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
         )?;
-        let right_tensor = TensorDynLen::from_dense(
+        let right_tensor = IdxTensor::from_dense(
             vec![bond, y0.clone(), y1.clone()],
             vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
         )?;
-        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+        let treetn = TreeTN::<IdxTensor, String>::from_tensors(
             vec![left_tensor, right_tensor],
             vec!["Left".to_string(), "Right".to_string()],
         )?;
@@ -1391,16 +1391,16 @@ mod tests {
         let s3 = DynIndex::new_dyn(2);
         let b01 = DynIndex::new_dyn(2);
         let b12 = DynIndex::new_dyn(2);
-        let t0 = TensorDynLen::from_dense(
+        let t0 = IdxTensor::from_dense(
             vec![s0.clone(), s1.clone(), b01.clone()],
             vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0],
         )?;
-        let t1 = TensorDynLen::from_dense(
+        let t1 = IdxTensor::from_dense(
             vec![b01.clone(), s2.clone(), b12.clone()],
             vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
         )?;
-        let t2 = TensorDynLen::from_dense(vec![b12, s3.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
-        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+        let t2 = IdxTensor::from_dense(vec![b12, s3.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
+        let treetn = TreeTN::<IdxTensor, String>::from_tensors(
             vec![t0, t1, t2],
             vec!["A".to_string(), "B".to_string(), "C".to_string()],
         )?;
@@ -1415,17 +1415,17 @@ mod tests {
         let b01 = DynIndex::new_dyn(2);
         let b12 = DynIndex::new_dyn(2);
         let b23 = DynIndex::new_dyn(2);
-        let t0 = TensorDynLen::from_dense(vec![x0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
-        let t1 = TensorDynLen::from_dense(
+        let t0 = IdxTensor::from_dense(vec![x0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+        let t1 = IdxTensor::from_dense(
             vec![b01.clone(), x1.clone(), b12.clone()],
             vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
         )?;
-        let t2 = TensorDynLen::from_dense(
+        let t2 = IdxTensor::from_dense(
             vec![b12.clone(), y0.clone(), b23.clone()],
             vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
         )?;
-        let t3 = TensorDynLen::from_dense(vec![b23, y1.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
-        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+        let t3 = IdxTensor::from_dense(vec![b23, y1.clone()], vec![1.0, 0.0, 0.0, 1.0])?;
+        let treetn = TreeTN::<IdxTensor, String>::from_tensors(
             vec![t0, t1, t2, t3],
             vec![
                 "0".to_string(),
@@ -1464,14 +1464,13 @@ mod tests {
         let b01 = DynIndex::new_dyn(2);
         let b12 = DynIndex::new_dyn(2);
 
-        let t0 =
-            TensorDynLen::from_dense(vec![left.clone(), b01.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
-        let t1 = TensorDynLen::from_dense(
+        let t0 = IdxTensor::from_dense(vec![left.clone(), b01.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
+        let t1 = IdxTensor::from_dense(
             vec![b01.clone(), right.clone(), b12.clone()],
             (1..=8).map(|value| value as f64 / 3.0).collect(),
         )?;
-        let t2 = TensorDynLen::from_dense(vec![b12], vec![0.5, -1.25])?;
-        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+        let t2 = IdxTensor::from_dense(vec![b12], vec![0.5, -1.25])?;
+        let treetn = TreeTN::<IdxTensor, String>::from_tensors(
             vec![t0, t1, t2],
             vec!["A".to_string(), "B".to_string(), "C".to_string()],
         )?;
@@ -1501,12 +1500,11 @@ mod tests {
         let b01 = DynIndex::new_dyn(2);
         let b12 = DynIndex::new_dyn(2);
 
-        let t0 =
-            TensorDynLen::from_dense(vec![left.clone(), b01.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
+        let t0 = IdxTensor::from_dense(vec![left.clone(), b01.clone()], vec![1.0, 2.0, 3.0, 4.0])?;
         let t1 =
-            TensorDynLen::from_dense(vec![b01.clone(), b12.clone()], vec![0.5, -1.0, 1.25, 0.75])?;
-        let t2 = TensorDynLen::from_dense(vec![b12, right.clone()], vec![2.0, -0.5, 1.5, 3.0])?;
-        let treetn = TreeTN::<TensorDynLen, String>::from_tensors(
+            IdxTensor::from_dense(vec![b01.clone(), b12.clone()], vec![0.5, -1.0, 1.25, 0.75])?;
+        let t2 = IdxTensor::from_dense(vec![b12, right.clone()], vec![2.0, -0.5, 1.5, 3.0])?;
+        let treetn = TreeTN::<IdxTensor, String>::from_tensors(
             vec![t0, t1, t2],
             vec!["A".to_string(), "M".to_string(), "B".to_string()],
         )?;
@@ -1850,13 +1848,13 @@ mod tests {
     /// (site_c) (site_d)
     #[allow(clippy::type_complexity)]
     fn y_shape_treetn() -> anyhow::Result<(
-        TreeTN<TensorDynLen, String>,
+        TreeTN<IdxTensor, String>,
         DynIndex,
         DynIndex,
         DynIndex,
         DynIndex,
     )> {
-        let mut tn = TreeTN::<TensorDynLen, String>::new();
+        let mut tn = TreeTN::<IdxTensor, String>::new();
         let site_a = DynIndex::new_dyn(2);
         let site_b = DynIndex::new_dyn(2);
         let site_c = DynIndex::new_dyn(2);
@@ -1864,10 +1862,9 @@ mod tests {
         let bond_ab = DynIndex::new_dyn(3);
         let bond_bc = DynIndex::new_dyn(3);
         let bond_bd = DynIndex::new_dyn(3);
-        let tensor_a =
-            TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
+        let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
         tn.add_tensor("A".to_string(), tensor_a).unwrap();
-        let tensor_b = TensorDynLen::from_dense(
+        let tensor_b = IdxTensor::from_dense(
             vec![
                 bond_ab.clone(),
                 bond_bc.clone(),
@@ -1877,11 +1874,9 @@ mod tests {
             vec![1.0; 54],
         )?;
         tn.add_tensor("B".to_string(), tensor_b).unwrap();
-        let tensor_c =
-            TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
+        let tensor_c = IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
         tn.add_tensor("C".to_string(), tensor_c).unwrap();
-        let tensor_d =
-            TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
+        let tensor_d = IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
         tn.add_tensor("D".to_string(), tensor_d).unwrap();
         let n_a = tn.node_index(&"A".to_string()).unwrap();
         let n_b = tn.node_index(&"B".to_string()).unwrap();
@@ -1926,7 +1921,7 @@ mod tests {
     #[test]
     fn test_restructure_to_y_shape_swap_only() -> anyhow::Result<()> {
         // Build a Y-shape with all bonds visible
-        let mut tn = TreeTN::<TensorDynLen, String>::new();
+        let mut tn = TreeTN::<IdxTensor, String>::new();
         let site_a = DynIndex::new_dyn(2);
         let site_b = DynIndex::new_dyn(2);
         let site_c = DynIndex::new_dyn(2);
@@ -1935,10 +1930,9 @@ mod tests {
         let bond_bc = DynIndex::new_dyn(3);
         let bond_bd = DynIndex::new_dyn(3);
 
-        let tensor_a =
-            TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
+        let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
         tn.add_tensor("A".to_string(), tensor_a)?;
-        let tensor_b = TensorDynLen::from_dense(
+        let tensor_b = IdxTensor::from_dense(
             vec![
                 bond_ab.clone(),
                 bond_bc.clone(),
@@ -1948,11 +1942,9 @@ mod tests {
             vec![1.0; 54],
         )?;
         tn.add_tensor("B".to_string(), tensor_b)?;
-        let tensor_c =
-            TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
+        let tensor_c = IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
         tn.add_tensor("C".to_string(), tensor_c)?;
-        let tensor_d =
-            TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
+        let tensor_d = IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
         tn.add_tensor("D".to_string(), tensor_d)?;
 
         let n_a = tn.node_index(&"A".to_string()).unwrap();
@@ -2010,7 +2002,7 @@ mod tests {
         //     B(no site)
         //      / \
         // C(site_c) D(site_d)
-        let mut tn = TreeTN::<TensorDynLen, String>::new();
+        let mut tn = TreeTN::<IdxTensor, String>::new();
         let site_a = DynIndex::new_dyn(2);
         let site_c = DynIndex::new_dyn(2);
         let site_d = DynIndex::new_dyn(2);
@@ -2018,19 +2010,16 @@ mod tests {
         let bond_bc = DynIndex::new_dyn(3);
         let bond_bd = DynIndex::new_dyn(3);
 
-        let tensor_a =
-            TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
+        let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
         tn.add_tensor("A".to_string(), tensor_a)?;
-        let tensor_b = TensorDynLen::from_dense(
+        let tensor_b = IdxTensor::from_dense(
             vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
             vec![1.0; 27],
         )?;
         tn.add_tensor("B".to_string(), tensor_b)?;
-        let tensor_c =
-            TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
+        let tensor_c = IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
         tn.add_tensor("C".to_string(), tensor_c)?;
-        let tensor_d =
-            TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
+        let tensor_d = IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
         tn.add_tensor("D".to_string(), tensor_d)?;
 
         let n_a = tn.node_index(&"A".to_string()).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/tensor_like.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like.rs
@@ -25,7 +25,7 @@
 use std::hash::Hash;
 
 use tensor4all_core::{
-    DynIndex, IndexLike, LinearizationOrder, TensorDynLen, TensorIndex, TensorLike,
+    DynIndex, IdxTensor, IndexLike, LinearizationOrder, TensorIndex, TensorLike,
 };
 
 use crate::error::{NumberedTagSelectionError, TreeTNOperationError};
@@ -193,7 +193,7 @@ where
     }
 }
 
-impl<V> TreeTN<TensorDynLen, V>
+impl<V> TreeTN<IdxTensor, V>
 where
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
     <DynIndex as IndexLike>::Id: Clone + Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
@@ -213,13 +213,13 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, TagSet, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, TagSet, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let x = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,x").unwrap());
     /// let y = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,y").unwrap());
-    /// let tensor = TensorDynLen::from_dense(vec![x.clone(), y], vec![0.0; 4]).unwrap();
-    /// let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![x.clone(), y], vec![0.0; 4]).unwrap();
+    /// let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
     ///
     /// assert_eq!(tn.external_indices_with_tag("x"), vec![x]);
     /// assert!(tn.external_indices_with_tag("missing").is_empty());
@@ -259,13 +259,13 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, TagSet, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, TagSet, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let k1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
     /// let k2 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
-    /// let tensor = TensorDynLen::from_dense(vec![k2.clone(), k1.clone()], vec![0.0; 4]).unwrap();
-    /// let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![k2.clone(), k1.clone()], vec![0.0; 4]).unwrap();
+    /// let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
     ///
     /// let indices = tn.external_indices_with_numbered_tag("k", 1, 2).unwrap();
     /// assert_eq!(indices, vec![k1, k2]);
@@ -314,7 +314,7 @@ where
 
     /// Replace one site index with multiple site indices using an exact reshape.
     ///
-    /// This is a TreeTN-level wrapper around [`TensorDynLen::unfuse_index`].
+    /// This is a TreeTN-level wrapper around [`IdxTensor::unfuse_index`].
     /// It updates the owning node tensor and the site-index metadata, without
     /// introducing any approximation.
     ///
@@ -325,12 +325,12 @@ where
     ///
     /// # Examples
     /// ```
-    /// use tensor4all_core::{DynIndex, LinearizationOrder, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, LinearizationOrder, IdxTensor};
     /// use tensor4all_treetn::TreeTN;
     ///
     /// let fused = DynIndex::new_dyn(4);
-    /// let tensor = TensorDynLen::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
-    /// let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    /// let tensor = IdxTensor::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    /// let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
     /// let left = DynIndex::new_dyn(2);
     /// let right = DynIndex::new_dyn(2);
     ///
@@ -343,7 +343,7 @@ where
     ///     .unwrap();
     ///
     /// let dense = unfused.contract_to_tensor().unwrap();
-    /// let expected = TensorDynLen::from_dense(vec![left, right], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    /// let expected = IdxTensor::from_dense(vec![left, right], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     /// assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     /// ```
     pub fn replace_site_index_with_indices(

--- a/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/tensor_like/tests/mod.rs
@@ -1,11 +1,11 @@
-use tensor4all_core::{DynIndex, IndexLike, TagSet, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TagSet, TensorIndex};
 
 use crate::treetn::TreeTN;
 use crate::NumberedTagSelectionError;
 
 /// Helper to create a simple 2-node TreeTN: A -- bond -- B
 fn make_two_node_treetn() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex, // s0
     DynIndex, // bond
     DynIndex, // s1
@@ -14,18 +14,18 @@ fn make_two_node_treetn() -> (
     let bond = DynIndex::new_dyn(3);
     let s1 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     )
     .unwrap();
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -58,8 +58,8 @@ fn test_num_external_indices_single_node() {
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(4);
-    let t = TensorDynLen::from_dense(vec![i.clone(), j.clone(), k.clone()], vec![0.0; 24]).unwrap();
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
+    let t = IdxTensor::from_dense(vec![i.clone(), j.clone(), k.clone()], vec![0.0; 24]).unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
     assert_eq!(tn.num_external_indices(), 3);
 }
 
@@ -68,14 +68,14 @@ fn test_external_indices_with_tag_filters_site_indices() {
     let x = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,x").unwrap());
     let y = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,y").unwrap());
     let bond = DynIndex::new_dyn(3);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![x.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond, y.clone()], vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-        .unwrap();
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let t1 =
+        IdxTensor::from_dense(vec![bond, y.clone()], vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![t0, t1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -93,9 +93,9 @@ fn test_external_indices_with_numbered_tag_uses_explicit_range() {
     let k2 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
     let k3 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=3").unwrap());
     let x1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,x=1").unwrap());
-    let tensor = TensorDynLen::from_dense(vec![x1, k3.clone(), k2.clone()], vec![0.0; 8]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![x1, k3.clone(), k2.clone()], vec![0.0; 8]).unwrap();
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     let indices = tn.external_indices_with_numbered_tag("k", 2, 2).unwrap();
 
@@ -107,9 +107,9 @@ fn test_external_indices_with_numbered_tag_keeps_same_id_tags_distinct() {
     let base = DynIndex::new_dyn(2);
     let k1 = DynIndex::new_with_tags(*base.id(), 2, TagSet::from_str("Qubit,k=1").unwrap());
     let other = DynIndex::new_with_tags(*base.id(), 2, TagSet::from_str("Qubit,other").unwrap());
-    let tensor = TensorDynLen::from_dense(vec![other, k1.clone()], vec![0.0; 4]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![other, k1.clone()], vec![0.0; 4]).unwrap();
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     assert_eq!(tn.external_indices_with_tag("k=1"), vec![k1.clone()]);
     assert_eq!(
@@ -122,9 +122,9 @@ fn test_external_indices_with_numbered_tag_keeps_same_id_tags_distinct() {
 fn test_external_indices_with_numbered_tag_rejects_missing_number() {
     let k2 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=2").unwrap());
     let k4 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=4").unwrap());
-    let tensor = TensorDynLen::from_dense(vec![k2, k4], vec![0.0; 4]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![k2, k4], vec![0.0; 4]).unwrap();
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     let err = tn
         .external_indices_with_numbered_tag("k", 2, 3)
@@ -140,9 +140,9 @@ fn test_external_indices_with_numbered_tag_rejects_missing_number() {
 fn test_external_indices_with_numbered_tag_rejects_duplicate_number() {
     let k1_left = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
     let k1_right = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
-    let tensor = TensorDynLen::from_dense(vec![k1_left, k1_right], vec![0.0; 4]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![k1_left, k1_right], vec![0.0; 4]).unwrap();
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     let err = tn
         .external_indices_with_numbered_tag("k", 1, 1)
@@ -157,9 +157,9 @@ fn test_external_indices_with_numbered_tag_rejects_duplicate_number() {
 #[test]
 fn test_external_indices_with_numbered_tag_rejects_prefix_with_equals() {
     let k1 = DynIndex::new_dyn_with_tags(2, TagSet::from_str("Qubit,k=1").unwrap());
-    let tensor = TensorDynLen::from_dense(vec![k1], vec![0.0; 2]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![k1], vec![0.0; 2]).unwrap();
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     let err = tn
         .external_indices_with_numbered_tag("k=1", 1, 1)
@@ -189,9 +189,9 @@ fn test_replaceind_matches_same_id_prime_pair_site_index_exactly() {
     let i = DynIndex::new_dyn(2);
     let i_prime = i.prime();
     let replacement = i_prime.sim();
-    let t = TensorDynLen::from_dense(vec![i.clone(), i_prime.clone()], vec![1.0, 2.0, 3.0, 4.0])
-        .unwrap();
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
+    let t =
+        IdxTensor::from_dense(vec![i.clone(), i_prime.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(vec![t], vec!["A".to_string()]).unwrap();
 
     let replaced = tn.replaceind(&i_prime, &replacement).unwrap();
     let site_space = replaced.site_space(&"A".to_string()).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/transform/tests/mod.rs
@@ -1,18 +1,18 @@
 use super::*;
 use crate::site_index_network::SiteIndexNetwork;
 use std::collections::HashSet;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 
-fn make_two_node_chain() -> (TreeTN<TensorDynLen, String>, DynIndex, DynIndex) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+fn make_two_node_chain() -> (TreeTN<IdxTensor, String>, DynIndex, DynIndex) {
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(3);
     let bond = DynIndex::new_dyn(4);
 
     // Make a simple chain A --bond-- B
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 2 * 4]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 4 * 3]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0; 2 * 4]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], vec![1.0; 4 * 3]).unwrap();
 
     tn.add_tensor("A".to_string(), t0).unwrap();
     tn.add_tensor("B".to_string(), t1).unwrap();
@@ -94,12 +94,12 @@ fn test_fuse_to_errors_for_unknown_site_index() {
 
 /// Create a 3-node chain: A -- B -- C
 fn make_three_node_chain() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex, // s0
     DynIndex, // s1
     DynIndex, // s2
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
@@ -107,13 +107,13 @@ fn make_three_node_chain() -> (
     let bond_ab = DynIndex::new_dyn(2);
     let bond_bc = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond_ab.clone()], vec![1.0; 2 * 2]).unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond_ab.clone()], vec![1.0; 2 * 2]).unwrap();
+    let t1 = IdxTensor::from_dense(
         vec![bond_ab.clone(), s1.clone(), bond_bc.clone()],
         vec![1.0; 2 * 2 * 2],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(vec![bond_bc.clone(), s2.clone()], vec![1.0; 2 * 3]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![bond_bc.clone(), s2.clone()], vec![1.0; 2 * 3]).unwrap();
 
     tn.add_tensor("A".to_string(), t0).unwrap();
     tn.add_tensor("B".to_string(), t1).unwrap();
@@ -129,7 +129,7 @@ fn make_three_node_chain() -> (
 }
 
 fn make_two_node_groups_of_two() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex,
     DynIndex,
     DynIndex,
@@ -141,15 +141,14 @@ fn make_two_node_groups_of_two() -> (
     let y1 = DynIndex::new_dyn(2);
     let old_bond = DynIndex::new_dyn(2);
 
-    let left = TensorDynLen::from_dense(
+    let left = IdxTensor::from_dense(
         vec![x0.clone(), x1.clone(), old_bond.clone()],
         vec![1.0; 2 * 2 * 2],
     )
     .unwrap();
-    let right =
-        TensorDynLen::from_dense(vec![old_bond, y0.clone(), y1.clone()], vec![1.0; 2 * 2 * 2])
-            .unwrap();
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let right = IdxTensor::from_dense(vec![old_bond, y0.clone(), y1.clone()], vec![1.0; 2 * 2 * 2])
+        .unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![left, right],
         vec!["left".to_string(), "right".to_string()],
     )
@@ -593,7 +592,7 @@ fn test_fuse_identity_mapping() {
 }
 
 fn make_four_site_fused_node() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex,
     DynIndex,
     DynIndex,
@@ -603,12 +602,12 @@ fn make_four_site_fused_node() -> (
     let s_b = DynIndex::new_dyn(2);
     let s_c = DynIndex::new_dyn(2);
     let s_d = DynIndex::new_dyn(2);
-    let t = TensorDynLen::from_dense(
+    let t = IdxTensor::from_dense(
         vec![s_a.clone(), s_b.clone(), s_c.clone(), s_d.clone()],
         vec![1.0; 16],
     )
     .unwrap();
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     tn.add_tensor("fused".to_string(), t).unwrap();
     (tn, s_a, s_b, s_c, s_d)
 }
@@ -742,13 +741,13 @@ fn test_split_to_y_shape_across_original_bond() {
 ///   C   D
 /// (site_c) (site_d)
 fn make_y_shape_treetn() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex, // site_a
     DynIndex, // site_b
     DynIndex, // site_c
     DynIndex, // site_d
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let site_b = DynIndex::new_dyn(2);
@@ -759,10 +758,10 @@ fn make_y_shape_treetn() -> (
     let bond_bd = DynIndex::new_dyn(3);
 
     let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![
             bond_ab.clone(),
             bond_bc.clone(),
@@ -775,11 +774,11 @@ fn make_y_shape_treetn() -> (
     tn.add_tensor("B".to_string(), tensor_b).unwrap();
 
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     let tensor_d =
-        TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("D".to_string(), tensor_d).unwrap();
 
     let n_a = tn.node_index(&"A".to_string()).unwrap();
@@ -894,7 +893,7 @@ fn test_fuse_to_y_shape_internal_center_node() {
     //     B(no site)   <-- internal node, only bonds
     //      / \
     // C(site_c) D(site_d)
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let site_c = DynIndex::new_dyn(2);
@@ -904,11 +903,11 @@ fn test_fuse_to_y_shape_internal_center_node() {
     let bond_bd = DynIndex::new_dyn(3);
 
     let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // B has NO site index -- only bond indices
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
         vec![1.0; 27],
     )
@@ -916,11 +915,11 @@ fn test_fuse_to_y_shape_internal_center_node() {
     tn.add_tensor("B".to_string(), tensor_b).unwrap();
 
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     let tensor_d =
-        TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("D".to_string(), tensor_d).unwrap();
 
     let n_a = tn.node_index(&"A".to_string()).unwrap();

--- a/crates/tensor4all-treetn/src/treetn/truncate.rs
+++ b/crates/tensor4all-treetn/src/treetn/truncate.rs
@@ -49,18 +49,18 @@ where
     ///
     /// ```
     /// use tensor4all_treetn::{TreeTN, TruncationOptions};
-    /// use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+    /// use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
     ///
     /// // Build a 2-node chain
     /// let s0 = DynIndex::new_dyn(2);
     /// let bond = DynIndex::new_dyn(3);
     /// let s1 = DynIndex::new_dyn(2);
     ///
-    /// let t0 = TensorDynLen::from_dense(
+    /// let t0 = IdxTensor::from_dense(
     ///     vec![s0.clone(), bond.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0, 0.0, 0.0],
     /// ).unwrap();
-    /// let t1 = TensorDynLen::from_dense(
+    /// let t1 = IdxTensor::from_dense(
     ///     vec![bond.clone(), s1.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 1.0, 0.0, 0.0],
     /// ).unwrap();

--- a/crates/tensor4all-treetn/tests/ad_treetn.rs
+++ b/crates/tensor4all-treetn/tests/ad_treetn.rs
@@ -1,6 +1,6 @@
 //! Tests for reverse-mode automatic differentiation through TreeTN operations.
 
-use tensor4all_core::{contract, DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{contract, DynIndex, IdxTensor, IndexLike};
 use tensor4all_treetn::TreeTN;
 
 fn make_three_site_mps_data() -> (Vec<Vec<DynIndex>>, Vec<Vec<f64>>) {
@@ -29,11 +29,11 @@ fn make_three_site_mps_data() -> (Vec<Vec<DynIndex>>, Vec<Vec<f64>>) {
 fn backward_ad_to_dense_propagates_gradients() {
     let (index_sets, data) = make_three_site_mps_data();
 
-    let tensors: Vec<TensorDynLen> = index_sets
+    let tensors: Vec<IdxTensor> = index_sets
         .iter()
         .zip(&data)
         .map(|(idx, d)| {
-            TensorDynLen::from_dense(idx.clone(), d.clone())
+            IdxTensor::from_dense(idx.clone(), d.clone())
                 .unwrap()
                 .enable_grad()
                 .unwrap()
@@ -44,7 +44,7 @@ fn backward_ad_to_dense_propagates_gradients() {
     let dense = ttn.to_dense().unwrap();
 
     // Contract dense with ones to get scalar = sum(dense)
-    let ones = TensorDynLen::from_dense(
+    let ones = IdxTensor::from_dense(
         dense.indices().to_vec(),
         vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
     )
@@ -64,11 +64,11 @@ fn backward_ad_gradient_matches_finite_diff() {
     let (index_sets, data) = make_three_site_mps_data();
     let eps = 1e-6;
 
-    let tensors: Vec<TensorDynLen> = index_sets
+    let tensors: Vec<IdxTensor> = index_sets
         .iter()
         .zip(&data)
         .map(|(idx, d)| {
-            TensorDynLen::from_dense(idx.clone(), d.clone())
+            IdxTensor::from_dense(idx.clone(), d.clone())
                 .unwrap()
                 .enable_grad()
                 .unwrap()
@@ -78,7 +78,7 @@ fn backward_ad_gradient_matches_finite_diff() {
     let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
     let dense = ttn.to_dense().unwrap();
 
-    let ones = TensorDynLen::from_dense(
+    let ones = IdxTensor::from_dense(
         dense.indices().to_vec(),
         vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
     )
@@ -99,7 +99,7 @@ fn backward_ad_gradient_matches_finite_diff() {
 
     for elem_idx in 0..data[0].len() {
         let make_perturbed_sum = |delta: f64| -> f64 {
-            let tensors: Vec<TensorDynLen> = index_sets
+            let tensors: Vec<IdxTensor> = index_sets
                 .iter()
                 .zip(&data)
                 .enumerate()
@@ -108,7 +108,7 @@ fn backward_ad_gradient_matches_finite_diff() {
                     if i == 0 {
                         d[elem_idx] += delta;
                     }
-                    TensorDynLen::from_dense(idx.clone(), d).unwrap()
+                    IdxTensor::from_dense(idx.clone(), d).unwrap()
                 })
                 .collect();
             let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
@@ -129,11 +129,11 @@ fn backward_ad_gradient_matches_finite_diff() {
 fn backward_accumulates_until_clear_grad_across_treetn_nodes() {
     let (index_sets, data) = make_three_site_mps_data();
 
-    let tensors: Vec<TensorDynLen> = index_sets
+    let tensors: Vec<IdxTensor> = index_sets
         .iter()
         .zip(&data)
         .map(|(idx, d)| {
-            TensorDynLen::from_dense(idx.clone(), d.clone())
+            IdxTensor::from_dense(idx.clone(), d.clone())
                 .unwrap()
                 .enable_grad()
                 .unwrap()
@@ -142,7 +142,7 @@ fn backward_accumulates_until_clear_grad_across_treetn_nodes() {
 
     let ttn = TreeTN::from_tensors(tensors, vec![0, 1, 2]).unwrap();
     let dense = ttn.to_dense().unwrap();
-    let ones = TensorDynLen::from_dense(
+    let ones = IdxTensor::from_dense(
         dense.indices().to_vec(),
         vec![1.0; dense.indices().iter().map(|i| i.dim()).product::<usize>()],
     )

--- a/crates/tensor4all-treetn/tests/basic.rs
+++ b/crates/tensor4all-treetn/tests/basic.rs
@@ -9,7 +9,7 @@
 //! - Tests using random_treetn_f64/LinkSpace are commented out (random module disabled)
 
 use petgraph::graph::NodeIndex;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_treetn::CanonicalForm;
 use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
 
@@ -20,7 +20,7 @@ use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
 /// Create a simple 2-node TreeTN with shared bond index.
 /// Returns (tn, node1, node2, edge, physical1, bond, physical2)
 fn create_two_node_treetn() -> (
-    TreeTN<TensorDynLen, NodeIndex>,
+    TreeTN<IdxTensor, NodeIndex>,
     NodeIndex,
     NodeIndex,
     petgraph::graph::EdgeIndex,
@@ -28,18 +28,16 @@ fn create_two_node_treetn() -> (
     DynIndex,
     DynIndex,
 ) {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let phys1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(3);
     let phys2 = DynIndex::new_dyn(4);
 
-    let tensor1 =
-        TensorDynLen::from_dense(vec![phys1.clone(), bond.clone()], vec![1.0; 6]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![phys1.clone(), bond.clone()], vec![1.0; 6]).unwrap();
     let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
-    let tensor2 =
-        TensorDynLen::from_dense(vec![bond.clone(), phys2.clone()], vec![1.0; 12]).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), phys2.clone()], vec![1.0; 12]).unwrap();
     let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let edge = tn.connect(node1, &bond, node2, &bond).unwrap();
@@ -49,7 +47,7 @@ fn create_two_node_treetn() -> (
 
 /// Create a 3-node chain: n1 -- n2 -- n3
 fn create_three_node_chain() -> (
-    TreeTN<TensorDynLen, NodeIndex>,
+    TreeTN<IdxTensor, NodeIndex>,
     NodeIndex,
     NodeIndex,
     NodeIndex,
@@ -58,23 +56,22 @@ fn create_three_node_chain() -> (
     DynIndex, // bond12
     DynIndex, // bond23
 ) {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let phys1 = DynIndex::new_dyn(2);
     let bond12 = DynIndex::new_dyn(3);
     let bond23 = DynIndex::new_dyn(4);
     let phys3 = DynIndex::new_dyn(5);
 
-    let tensor1 =
-        TensorDynLen::from_dense(vec![phys1.clone(), bond12.clone()], vec![1.0; 6]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![phys1.clone(), bond12.clone()], vec![1.0; 6]).unwrap();
     let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
-        TensorDynLen::from_dense(vec![bond12.clone(), bond23.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond12.clone(), bond23.clone()], vec![1.0; 12]).unwrap();
     let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let tensor3 =
-        TensorDynLen::from_dense(vec![bond23.clone(), phys3.clone()], vec![1.0; 20]).unwrap();
+        IdxTensor::from_dense(vec![bond23.clone(), phys3.clone()], vec![1.0; 20]).unwrap();
     let node3 = tn.add_tensor_auto_name(tensor3).unwrap();
 
     let edge12 = tn.connect(node1, &bond12, node2, &bond12).unwrap();
@@ -89,11 +86,11 @@ fn create_three_node_chain() -> (
 
 #[test]
 fn test_treetn_add_tensor() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
 
     let node = tn.add_tensor_auto_name(tensor).unwrap();
     assert_eq!(tn.node_count(), 1);
@@ -105,11 +102,11 @@ fn test_treetn_add_tensor() {
 
 #[test]
 fn test_add_tensor_auto_name_returns_result() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
 
     let node = tn.add_tensor_auto_name(tensor).unwrap();
 
@@ -119,15 +116,15 @@ fn test_add_tensor_auto_name_returns_result() {
 
 #[test]
 fn test_treetn_replace_tensor() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
     let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     // Replace with a tensor that has the same indices
-    let new_tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
+    let new_tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
     let result = tn.replace_tensor(node, new_tensor);
     assert!(result.is_ok());
     assert!(result.unwrap().is_some());
@@ -135,11 +132,11 @@ fn test_treetn_replace_tensor() {
 
 #[test]
 fn test_treetn_replace_tensor_nonexistent() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i, j], vec![0.0; 6]).unwrap();
 
     let invalid_node = NodeIndex::new(999);
     let result = tn.replace_tensor(invalid_node, tensor);
@@ -154,7 +151,7 @@ fn test_treetn_replace_tensor_missing_bond_index() {
     // Try to replace node1 with a tensor that doesn't have the bond index
     let new_i = DynIndex::new_dyn(5);
     let new_j = DynIndex::new_dyn(6);
-    let new_tensor = TensorDynLen::from_dense(
+    let new_tensor = IdxTensor::from_dense(
         vec![new_i, new_j], // bond is missing!
         vec![0.0; 30],
     )
@@ -174,7 +171,7 @@ fn test_treetn_replace_tensor_with_bond() {
 
     // Replace node1 with a tensor that has the same bond index
     let new_i = DynIndex::new_dyn(5);
-    let new_tensor = TensorDynLen::from_dense(vec![new_i, bond.clone()], vec![0.0; 15]).unwrap();
+    let new_tensor = IdxTensor::from_dense(vec![new_i, bond.clone()], vec![0.0; 15]).unwrap();
 
     let result = tn.replace_tensor(node1, new_tensor);
     assert!(result.is_ok());
@@ -197,16 +194,16 @@ fn test_treetn_connect() {
 
 #[test]
 fn test_treetn_connect_id_mismatch() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i1 = DynIndex::new_dyn(2);
     let j1 = DynIndex::new_dyn(3);
-    let tensor1 = TensorDynLen::from_dense(vec![i1.clone(), j1.clone()], vec![0.0; 6]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i1.clone(), j1.clone()], vec![0.0; 6]).unwrap();
     let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let i2 = DynIndex::new_dyn(3); // Different ID than j1
     let k2 = DynIndex::new_dyn(4);
-    let tensor2 = TensorDynLen::from_dense(vec![i2.clone(), k2.clone()], vec![0.0; 12]).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![i2.clone(), k2.clone()], vec![0.0; 12]).unwrap();
     let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Try to connect with different index IDs - should fail in Einsum mode
@@ -224,11 +221,11 @@ fn test_treetn_connect_id_mismatch() {
 
 #[test]
 fn test_treetn_connect_invalid_node() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let j = DynIndex::new_dyn(3);
-    let tensor = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![0.0; 6]).unwrap();
     let node1 = tn.add_tensor_auto_name(tensor).unwrap();
 
     let invalid_node = NodeIndex::new(999);
@@ -238,16 +235,16 @@ fn test_treetn_connect_invalid_node() {
 
 #[test]
 fn test_treetn_connect_index_not_in_tensor() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i1 = DynIndex::new_dyn(2);
     let j1 = DynIndex::new_dyn(3);
-    let tensor1 = TensorDynLen::from_dense(vec![i1.clone(), j1.clone()], vec![0.0; 6]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i1.clone(), j1.clone()], vec![0.0; 6]).unwrap();
     let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let bond = DynIndex::new_dyn(3);
     let k2 = DynIndex::new_dyn(4);
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k2.clone()], vec![0.0; 12]).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), k2.clone()], vec![0.0; 12]).unwrap();
     let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Try to connect with an index that doesn't exist in tensor1
@@ -323,7 +320,7 @@ fn test_treetn_set_edge_ortho_towards_invalid() {
     // Create a third node that is not connected to this edge
     let i3 = DynIndex::new_dyn(5);
     let k3 = DynIndex::new_dyn(6);
-    let tensor3 = TensorDynLen::from_dense(vec![i3, k3], vec![0.0; 30]).unwrap();
+    let tensor3 = IdxTensor::from_dense(vec![i3, k3], vec![0.0; 30]).unwrap();
     let node3 = tn.add_tensor_auto_name(tensor3).unwrap();
 
     // Try to set ortho direction to a node that's not an endpoint
@@ -349,7 +346,7 @@ fn test_treetn_validate_tree_three_nodes() {
 
 #[test]
 fn test_treetn_validate_tree_cycle() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     // Create a cycle: n1 -- n2 -- n3 -- n1
     let bond12 = DynIndex::new_dyn(3);
@@ -357,15 +354,15 @@ fn test_treetn_validate_tree_cycle() {
     let bond31 = DynIndex::new_dyn(5);
 
     let tensor1 =
-        TensorDynLen::from_dense(vec![bond12.clone(), bond31.clone()], vec![0.0; 15]).unwrap();
+        IdxTensor::from_dense(vec![bond12.clone(), bond31.clone()], vec![0.0; 15]).unwrap();
     let node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
-        TensorDynLen::from_dense(vec![bond12.clone(), bond23.clone()], vec![0.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond12.clone(), bond23.clone()], vec![0.0; 12]).unwrap();
     let node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let tensor3 =
-        TensorDynLen::from_dense(vec![bond23.clone(), bond31.clone()], vec![0.0; 20]).unwrap();
+        IdxTensor::from_dense(vec![bond23.clone(), bond31.clone()], vec![0.0; 20]).unwrap();
     let node3 = tn.add_tensor_auto_name(tensor3).unwrap();
 
     tn.connect(node1, &bond12, node2, &bond12).unwrap();
@@ -378,15 +375,15 @@ fn test_treetn_validate_tree_cycle() {
 
 #[test]
 fn test_treetn_validate_tree_disconnected() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     // Create two disconnected nodes
     let i1 = DynIndex::new_dyn(2);
-    let tensor1 = TensorDynLen::from_dense(vec![i1], vec![0.0; 2]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i1], vec![0.0; 2]).unwrap();
     let _node1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let i2 = DynIndex::new_dyn(3);
-    let tensor2 = TensorDynLen::from_dense(vec![i2], vec![0.0; 3]).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![i2], vec![0.0; 3]).unwrap();
     let _node2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Should fail: not connected
@@ -395,7 +392,7 @@ fn test_treetn_validate_tree_disconnected() {
 
 #[test]
 fn test_treetn_validate_tree_empty() {
-    let tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let tn = TreeTN::<IdxTensor, NodeIndex>::new();
     assert!(tn.validate_tree().is_ok());
 }
 
@@ -405,17 +402,17 @@ fn test_treetn_validate_tree_empty() {
 
 #[test]
 fn test_canonical_region_empty() {
-    let tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let tn = TreeTN::<IdxTensor, NodeIndex>::new();
     assert!(!tn.is_canonicalized());
     assert!(tn.canonical_region().is_empty());
 }
 
 #[test]
 fn test_set_canonical_region() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i], vec![0.0; 2]).unwrap();
     let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     assert!(!tn.is_canonicalized());
@@ -428,7 +425,7 @@ fn test_set_canonical_region() {
 
 #[test]
 fn test_set_canonical_region_invalid_node() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let invalid_node = NodeIndex::new(999);
     let result = tn.set_canonical_region(vec![invalid_node]);
@@ -437,10 +434,10 @@ fn test_set_canonical_region_invalid_node() {
 
 #[test]
 fn test_clear_canonical_region() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i], vec![0.0; 2]).unwrap();
     let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     tn.set_canonical_region(vec![node]).unwrap();
@@ -457,10 +454,10 @@ fn test_clear_canonical_region() {
 
 #[test]
 fn test_add_to_canonical_region() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i], vec![0.0; 2]).unwrap();
     let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     // Add valid node to canonical region
@@ -471,7 +468,7 @@ fn test_add_to_canonical_region() {
 
 #[test]
 fn test_add_to_canonical_region_invalid_node() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let invalid_node = NodeIndex::new(999);
     let result = tn.add_to_canonical_region(invalid_node);
@@ -480,10 +477,10 @@ fn test_add_to_canonical_region_invalid_node() {
 
 #[test]
 fn test_remove_from_canonical_region() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![i], vec![0.0; 2]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![i], vec![0.0; 2]).unwrap();
     let node = tn.add_tensor_auto_name(tensor).unwrap();
 
     tn.set_canonical_region(vec![node]).unwrap();
@@ -536,15 +533,15 @@ fn test_log_norm_already_canonicalized_single_site() {
 
 #[test]
 fn test_validate_ortho_consistency_disconnected_centers() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     // Create two disconnected nodes
     let i1 = DynIndex::new_dyn(2);
-    let tensor1 = TensorDynLen::from_dense(vec![i1], vec![0.0; 2]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i1], vec![0.0; 2]).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let i2 = DynIndex::new_dyn(3);
-    let tensor2 = TensorDynLen::from_dense(vec![i2], vec![0.0; 3]).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![i2], vec![0.0; 3]).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     // Two centers that are not connected should fail
@@ -584,18 +581,18 @@ fn test_validate_ortho_consistency_chain_pointing_towards_center() {
 
 #[test]
 fn test_canonicalize_simple() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let phys1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(3);
     let phys2 = DynIndex::new_dyn(4);
 
     let data1: Vec<f64> = vec![1.0; 6];
-    let tensor1 = TensorDynLen::from_dense(vec![phys1.clone(), bond.clone()], data1).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![phys1.clone(), bond.clone()], data1).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = vec![1.0; 12];
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), phys2.clone()], data2).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), phys2.clone()], data2).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -612,13 +609,13 @@ fn test_canonicalize_simple() {
 
 #[test]
 fn canonicalize_preserves_near_dependent_components() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let left = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(2);
     let right = DynIndex::new_dyn(2);
 
-    let tensor1 = TensorDynLen::from_dense(
+    let tensor1 = IdxTensor::from_dense(
         vec![left.clone(), bond.clone()],
         vec![1.0, 0.0, 0.0, 1.0e-16],
     )
@@ -626,8 +623,7 @@ fn canonicalize_preserves_near_dependent_components() {
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let tensor2 =
-        TensorDynLen::from_dense(vec![bond.clone(), right.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
+        IdxTensor::from_dense(vec![bond.clone(), right.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -658,18 +654,18 @@ fn canonicalize_preserves_near_dependent_components() {
 
 #[test]
 fn test_contract_two_nodes() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(4);
 
     let data1: Vec<f64> = (0..6).map(|x| x as f64).collect();
-    let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = (0..12).map(|x| x as f64).collect();
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -696,7 +692,7 @@ fn test_contract_chain() {
 #[test]
 fn test_contract_to_tensor_index_ordering() {
     // Create a TreeTN with string node names for predictable ordering
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     // Create site indices with known IDs
     // Site index for node "A" (first in alphabetical order)
@@ -708,11 +704,10 @@ fn test_contract_to_tensor_index_ordering() {
 
     // Create tensors - note: add "B" first to test that result is reordered correctly
     let tensor_b =
-        TensorDynLen::from_dense(vec![bond.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
     tn.add_tensor("B".to_string(), tensor_b).unwrap();
 
-    let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond.clone()], vec![1.0; 8]).unwrap();
+    let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond.clone()], vec![1.0; 8]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // Connect A and B
@@ -736,7 +731,7 @@ fn test_contract_to_tensor_index_ordering() {
 /// Test contract_to_tensor index ordering with reverse alphabetical node names.
 #[test]
 fn test_contract_to_tensor_index_ordering_reverse() {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     // Site indices
     let site_z = DynIndex::new_dyn(4); // Node "Z"
@@ -745,12 +740,12 @@ fn test_contract_to_tensor_index_ordering_reverse() {
 
     // Add "Z" first
     let tensor_z =
-        TensorDynLen::from_dense(vec![site_z.clone(), bond.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![site_z.clone(), bond.clone()], vec![1.0; 12]).unwrap();
     tn.add_tensor("Z".to_string(), tensor_z).unwrap();
 
     // Add "A" second
     let tensor_a =
-        TensorDynLen::from_dense(vec![bond.clone(), site_a.clone()], vec![1.0; 15]).unwrap();
+        IdxTensor::from_dense(vec![bond.clone(), site_a.clone()], vec![1.0; 15]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // Connect
@@ -777,18 +772,18 @@ fn test_contract_to_tensor_index_ordering_reverse() {
 
 #[test]
 fn test_log_norm_simple() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(3);
     let k = DynIndex::new_dyn(4);
 
     let data1: Vec<f64> = vec![1.0; 6];
-    let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = vec![1.0; 12];
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -803,7 +798,7 @@ fn test_log_norm_simple() {
 
 #[test]
 fn test_truncate_simple() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(10); // Large bond
@@ -816,7 +811,7 @@ fn test_truncate_simple() {
         data1[idx * 10] = 1.0;
         data1[idx * 10 + 1] = 0.5;
     }
-    let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     // tensor2[bond, k] similar structure
@@ -825,7 +820,7 @@ fn test_truncate_simple() {
         data2[k_idx] = 1.0;
         data2[4 + k_idx] = 0.3;
     }
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let edge = tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -848,18 +843,18 @@ fn test_truncate_simple() {
 
 #[test]
 fn test_truncate_mut_simple() {
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(8);
     let k = DynIndex::new_dyn(4);
 
     let data1: Vec<f64> = (0..16).map(|x| x as f64).collect();
-    let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let data2: Vec<f64> = (0..32).map(|x| x as f64).collect();
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     let edge = tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -908,7 +903,7 @@ fn test_truncate_three_node_chain() {
 fn test_truncate_with_svd_policy() {
     use tensor4all_core::SvdTruncationPolicy;
 
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let i = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(5);
@@ -918,14 +913,14 @@ fn test_truncate_with_svd_policy() {
     let mut data1 = vec![0.0f64; 10];
     data1[0] = 1.0;
     data1[5] = 1.0;
-    let tensor1 = TensorDynLen::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![i.clone(), bond.clone()], data1).unwrap();
     let n1 = tn.add_tensor_auto_name(tensor1).unwrap();
 
     let mut data2 = vec![0.0f64; 15];
     data2[0] = 1.0;
     data2[1] = 1.0;
     data2[2] = 1.0;
-    let tensor2 = TensorDynLen::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), k.clone()], data2).unwrap();
     let n2 = tn.add_tensor_auto_name(tensor2).unwrap();
 
     tn.connect(n1, &bond, n2, &bond).unwrap();
@@ -957,7 +952,7 @@ fn test_truncate_y_shape() {
     //     B     (bond_bc, bond_bd)
     //    / \
     //   C   D
-    let mut tn = TreeTN::<TensorDynLen, NodeIndex>::new();
+    let mut tn = TreeTN::<IdxTensor, NodeIndex>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let bond_ab = DynIndex::new_dyn(6);
@@ -967,10 +962,10 @@ fn test_truncate_y_shape() {
     let site_d = DynIndex::new_dyn(2);
 
     let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 12]).unwrap();
     let n_a = tn.add_tensor_auto_name(tensor_a).unwrap();
 
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
         vec![1.0; 216],
     )
@@ -978,11 +973,11 @@ fn test_truncate_y_shape() {
     let n_b = tn.add_tensor_auto_name(tensor_b).unwrap();
 
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 12]).unwrap();
     let n_c = tn.add_tensor_auto_name(tensor_c).unwrap();
 
     let tensor_d =
-        TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 12]).unwrap();
     let n_d = tn.add_tensor_auto_name(tensor_d).unwrap();
 
     tn.connect(n_a, &bond_ab, n_b, &bond_ab).unwrap();
@@ -1241,14 +1236,14 @@ fn test_contract_zipup_shared_site_indices() {
 
     // Create tensor for node A in network 1: A1[site_a, bond1]
     let tensor_a1 =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond1.clone()], vec![1.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond1.clone()], vec![1.0; 8]).unwrap();
 
     // Create tensor for node B in network 1: B1[bond1, site_b]
     let tensor_b1 =
-        TensorDynLen::from_dense(vec![bond1.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond1.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
 
     // Create TreeTN 1
-    let tn1: TreeTN<TensorDynLen, String> = TreeTN::from_tensors(
+    let tn1: TreeTN<IdxTensor, String> = TreeTN::from_tensors(
         vec![tensor_a1, tensor_b1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -1257,15 +1252,15 @@ fn test_contract_zipup_shared_site_indices() {
     // Create tensor for node A in network 2: A2[site_a, bond2]
     // Uses the SAME site_a index
     let tensor_a2 =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond2.clone()], vec![2.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond2.clone()], vec![2.0; 8]).unwrap();
 
     // Create tensor for node B in network 2: B2[bond2, site_b]
     // Uses the SAME site_b index
     let tensor_b2 =
-        TensorDynLen::from_dense(vec![bond2.clone(), site_b.clone()], vec![2.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond2.clone(), site_b.clone()], vec![2.0; 12]).unwrap();
 
     // Create TreeTN 2
-    let tn2: TreeTN<TensorDynLen, String> = TreeTN::from_tensors(
+    let tn2: TreeTN<IdxTensor, String> = TreeTN::from_tensors(
         vec![tensor_a2, tensor_b2],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -1314,12 +1309,12 @@ fn test_contract_zipup_partial_contraction() {
     // Network 1 (like bra <ψ|):
     // A1[site_a, bond1] -- B1[bond1, site_b]
     let tensor_a1 =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond1.clone()], vec![1.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond1.clone()], vec![1.0; 8]).unwrap();
 
     let tensor_b1 =
-        TensorDynLen::from_dense(vec![bond1.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond1.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
 
-    let tn1: TreeTN<TensorDynLen, String> = TreeTN::from_tensors(
+    let tn1: TreeTN<IdxTensor, String> = TreeTN::from_tensors(
         vec![tensor_a1, tensor_b1],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -1328,19 +1323,19 @@ fn test_contract_zipup_partial_contraction() {
     // Network 2 (like O|φ> with MPO indices):
     // A2[site_a, site_external_a, bond2] -- B2[bond2, site_b, site_external_b]
     // Has both shared and external site indices at each node
-    let tensor_a2 = TensorDynLen::from_dense(
+    let tensor_a2 = IdxTensor::from_dense(
         vec![site_a.clone(), site_external_a.clone(), bond2.clone()],
         vec![2.0; 16],
     )
     .unwrap();
 
-    let tensor_b2 = TensorDynLen::from_dense(
+    let tensor_b2 = IdxTensor::from_dense(
         vec![bond2.clone(), site_b.clone(), site_external_b.clone()],
         vec![2.0; 36],
     )
     .unwrap();
 
-    let tn2: TreeTN<TensorDynLen, String> = TreeTN::from_tensors(
+    let tn2: TreeTN<IdxTensor, String> = TreeTN::from_tensors(
         vec![tensor_a2, tensor_b2],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -1699,17 +1694,16 @@ fn test_verify_internal_consistency_after_canonicalization() {
 #[test]
 fn test_verify_internal_consistency_with_string_node_names() {
     // Create TreeTN with string node names
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let site_b = DynIndex::new_dyn(3);
     let bond = DynIndex::new_dyn(4);
 
-    let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond.clone()], vec![1.0; 8]).unwrap();
+    let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond.clone()], vec![1.0; 8]).unwrap();
 
     let tensor_b =
-        TensorDynLen::from_dense(vec![bond.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond.clone(), site_b.clone()], vec![1.0; 12]).unwrap();
 
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
     tn.add_tensor("B".to_string(), tensor_b).unwrap();
@@ -1823,8 +1817,8 @@ use tensor4all_treetn::FitContractionOptions;
 /// Create a simple MPS-like chain for fit testing: A - B - C
 /// Each node has physical index (site) and bond indices.
 #[allow(dead_code)]
-fn create_mps_chain_for_fit() -> TreeTN<TensorDynLen, String> {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+fn create_mps_chain_for_fit() -> TreeTN<IdxTensor, String> {
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices
     let site_a = DynIndex::new_dyn(2);
@@ -1837,17 +1831,17 @@ fn create_mps_chain_for_fit() -> TreeTN<TensorDynLen, String> {
 
     // Tensor A: [site_a, bond_ab]
     let data_a: Vec<f64> = (0..6).map(|x| (x as f64 + 1.0) / 10.0).collect();
-    let tensor_a = TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], data_a).unwrap();
+    let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], data_a).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // Tensor B: [bond_ab, site_b, bond_bc]
     let data_b: Vec<f64> = (0..18).map(|x| (x as f64 + 1.0) / 20.0).collect();
-    let tensor_b = TensorDynLen::from_dense(vec![bond_ab.clone(), site_b.clone(), bond_bc.clone()], data_b).unwrap();
+    let tensor_b = IdxTensor::from_dense(vec![bond_ab.clone(), site_b.clone(), bond_bc.clone()], data_b).unwrap();
     tn.add_tensor("B".to_string(), tensor_b).unwrap();
 
     // Tensor C: [bond_bc, site_c]
     let data_c: Vec<f64> = (0..6).map(|x| (x as f64 + 1.0) / 10.0).collect();
-    let tensor_c = TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], data_c).unwrap();
+    let tensor_c = IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], data_c).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     // Connect
@@ -1874,8 +1868,8 @@ fn create_mps_chain_for_fit() -> TreeTN<TensorDynLen, String> {
 
 /// Create an MPO-like chain (same topology as MPS but with two physical indices per site)
 #[allow(dead_code)]
-fn create_mpo_chain_for_fit() -> TreeTN<TensorDynLen, String> {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+fn create_mpo_chain_for_fit() -> TreeTN<IdxTensor, String> {
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices (input and output for each site)
     let site_a_in = DynIndex::new_dyn(2);
@@ -1891,12 +1885,12 @@ fn create_mpo_chain_for_fit() -> TreeTN<TensorDynLen, String> {
 
     // Tensor A: [site_a_in, site_a_out, bond_ab]
     let data_a: Vec<f64> = (0..8).map(|x| (x as f64 + 1.0) / 10.0).collect();
-    let tensor_a = TensorDynLen::from_dense(vec![site_a_in.clone(), site_a_out.clone(), bond_ab.clone()], data_a).unwrap();
+    let tensor_a = IdxTensor::from_dense(vec![site_a_in.clone(), site_a_out.clone(), bond_ab.clone()], data_a).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // Tensor B: [bond_ab, site_b_in, site_b_out, bond_bc]
     let data_b: Vec<f64> = (0..16).map(|x| (x as f64 + 1.0) / 20.0).collect();
-    let tensor_b = TensorDynLen::from_dense(vec![
+    let tensor_b = IdxTensor::from_dense(vec![
             bond_ab.clone(),
             site_b_in.clone(),
             site_b_out.clone(),
@@ -1906,7 +1900,7 @@ fn create_mpo_chain_for_fit() -> TreeTN<TensorDynLen, String> {
 
     // Tensor C: [bond_bc, site_c_in, site_c_out]
     let data_c: Vec<f64> = (0..8).map(|x| (x as f64 + 1.0) / 10.0).collect();
-    let tensor_c = TensorDynLen::from_dense(vec![bond_bc.clone(), site_c_in.clone(), site_c_out.clone()], data_c).unwrap();
+    let tensor_c = IdxTensor::from_dense(vec![bond_bc.clone(), site_c_in.clone(), site_c_out.clone()], data_c).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     // Connect
@@ -2127,19 +2121,17 @@ fn test_fit_vs_naive_5node_chain() {
 // ============================================================================
 
 /// Helper: Create a simple 2-node TreeTN with String node names for testing
-fn create_two_node_treetn_string() -> TreeTN<TensorDynLen, String> {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+fn create_two_node_treetn_string() -> TreeTN<IdxTensor, String> {
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let phys1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(3);
     let phys2 = DynIndex::new_dyn(4);
 
-    let tensor1 =
-        TensorDynLen::from_dense(vec![phys1.clone(), bond.clone()], vec![1.0; 6]).unwrap();
+    let tensor1 = IdxTensor::from_dense(vec![phys1.clone(), bond.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("A".to_string(), tensor1).unwrap();
 
-    let tensor2 =
-        TensorDynLen::from_dense(vec![bond.clone(), phys2.clone()], vec![1.0; 12]).unwrap();
+    let tensor2 = IdxTensor::from_dense(vec![bond.clone(), phys2.clone()], vec![1.0; 12]).unwrap();
     tn.add_tensor("B".to_string(), tensor2).unwrap();
 
     let n_a = tn.node_index(&"A".to_string()).unwrap();
@@ -2152,15 +2144,15 @@ fn create_two_node_treetn_string() -> TreeTN<TensorDynLen, String> {
 /// Test single node contraction
 #[test]
 fn test_zipup_with_single_node() {
-    let mut tn_a = TreeTN::<TensorDynLen, String>::new();
-    let mut tn_b = TreeTN::<TensorDynLen, String>::new();
+    let mut tn_a = TreeTN::<IdxTensor, String>::new();
+    let mut tn_b = TreeTN::<IdxTensor, String>::new();
 
     // Use the same site index so this is a real contraction, not an implicit
     // outer product of unrelated inputs.
     let phys_a = DynIndex::new_dyn(2);
     let phys_b = phys_a.clone();
-    let tensor_a = TensorDynLen::from_dense(vec![phys_a.clone()], vec![1.0, 2.0]).unwrap();
-    let tensor_b = TensorDynLen::from_dense(vec![phys_b.clone()], vec![3.0, 4.0]).unwrap();
+    let tensor_a = IdxTensor::from_dense(vec![phys_a.clone()], vec![1.0, 2.0]).unwrap();
+    let tensor_b = IdxTensor::from_dense(vec![phys_b.clone()], vec![3.0, 4.0]).unwrap();
 
     tn_a.add_tensor("X".to_string(), tensor_a).unwrap();
     tn_b.add_tensor("X".to_string(), tensor_b).unwrap();
@@ -2197,8 +2189,8 @@ fn test_zipup_with_two_node_chain() {
 /// Test 3-node chain contraction
 #[test]
 fn test_zipup_with_three_node_chain() {
-    let mut tn_a = TreeTN::<TensorDynLen, String>::new();
-    let mut tn_b = TreeTN::<TensorDynLen, String>::new();
+    let mut tn_a = TreeTN::<IdxTensor, String>::new();
+    let mut tn_b = TreeTN::<IdxTensor, String>::new();
 
     let phys1_a = DynIndex::new_dyn(2);
     let bond12_a = DynIndex::new_dyn(3);
@@ -2212,28 +2204,28 @@ fn test_zipup_with_three_node_chain() {
 
     // Create chain: A -- B -- C (tn_a)
     let tensor_a =
-        TensorDynLen::from_dense(vec![phys1_a.clone(), bond12_a.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys1_a.clone(), bond12_a.clone()], vec![1.0; 6]).unwrap();
     tn_a.add_tensor("A".to_string(), tensor_a).unwrap();
 
     let tensor_b =
-        TensorDynLen::from_dense(vec![bond12_a.clone(), bond23_a.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond12_a.clone(), bond23_a.clone()], vec![1.0; 12]).unwrap();
     tn_a.add_tensor("B".to_string(), tensor_b).unwrap();
 
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond23_a.clone(), phys3_a.clone()], vec![1.0; 20]).unwrap();
+        IdxTensor::from_dense(vec![bond23_a.clone(), phys3_a.clone()], vec![1.0; 20]).unwrap();
     tn_a.add_tensor("C".to_string(), tensor_c).unwrap();
 
     // Create chain: A -- B -- C (tn_b) with distinct site indices
     let tensor_a_b =
-        TensorDynLen::from_dense(vec![phys1_b.clone(), bond12_b.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys1_b.clone(), bond12_b.clone()], vec![1.0; 6]).unwrap();
     tn_b.add_tensor("A".to_string(), tensor_a_b).unwrap();
 
     let tensor_b_b =
-        TensorDynLen::from_dense(vec![bond12_b.clone(), bond23_b.clone()], vec![1.0; 12]).unwrap();
+        IdxTensor::from_dense(vec![bond12_b.clone(), bond23_b.clone()], vec![1.0; 12]).unwrap();
     tn_b.add_tensor("B".to_string(), tensor_b_b).unwrap();
 
     let tensor_c_b =
-        TensorDynLen::from_dense(vec![bond23_b.clone(), phys3_b.clone()], vec![1.0; 20]).unwrap();
+        IdxTensor::from_dense(vec![bond23_b.clone(), phys3_b.clone()], vec![1.0; 20]).unwrap();
     tn_b.add_tensor("C".to_string(), tensor_c_b).unwrap();
 
     // Connect nodes
@@ -2260,8 +2252,8 @@ fn test_zipup_with_three_node_chain() {
 /// Test star topology (multiple leaves connected to root)
 #[test]
 fn test_zipup_with_star_topology() {
-    let mut tn_a = TreeTN::<TensorDynLen, String>::new();
-    let mut tn_b = TreeTN::<TensorDynLen, String>::new();
+    let mut tn_a = TreeTN::<IdxTensor, String>::new();
+    let mut tn_b = TreeTN::<IdxTensor, String>::new();
 
     // Create star: A, B, C all connected to center D
     let phys_a = DynIndex::new_dyn(2);
@@ -2283,30 +2275,30 @@ fn test_zipup_with_star_topology() {
 
     // Node A
     let tensor_a =
-        TensorDynLen::from_dense(vec![phys_a.clone(), bond_ad.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys_a.clone(), bond_ad.clone()], vec![1.0; 6]).unwrap();
     tn_a.add_tensor("A".to_string(), tensor_a.clone()).unwrap();
     let tensor_a_b =
-        TensorDynLen::from_dense(vec![phys_a_b.clone(), bond_ad_b.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys_a_b.clone(), bond_ad_b.clone()], vec![1.0; 6]).unwrap();
     tn_b.add_tensor("A".to_string(), tensor_a_b).unwrap();
 
     // Node B
     let tensor_b =
-        TensorDynLen::from_dense(vec![phys_b.clone(), bond_bd.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys_b.clone(), bond_bd.clone()], vec![1.0; 6]).unwrap();
     tn_a.add_tensor("B".to_string(), tensor_b.clone()).unwrap();
     let tensor_b_b =
-        TensorDynLen::from_dense(vec![phys_b_b.clone(), bond_bd_b.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys_b_b.clone(), bond_bd_b.clone()], vec![1.0; 6]).unwrap();
     tn_b.add_tensor("B".to_string(), tensor_b_b).unwrap();
 
     // Node C
     let tensor_c =
-        TensorDynLen::from_dense(vec![phys_c.clone(), bond_cd.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys_c.clone(), bond_cd.clone()], vec![1.0; 6]).unwrap();
     tn_a.add_tensor("C".to_string(), tensor_c.clone()).unwrap();
     let tensor_c_b =
-        TensorDynLen::from_dense(vec![phys_c_b.clone(), bond_cd_b.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![phys_c_b.clone(), bond_cd_b.clone()], vec![1.0; 6]).unwrap();
     tn_b.add_tensor("C".to_string(), tensor_c_b).unwrap();
 
     // Node D (center)
-    let tensor_d = TensorDynLen::from_dense(
+    let tensor_d = IdxTensor::from_dense(
         vec![
             bond_ad.clone(),
             bond_bd.clone(),
@@ -2317,7 +2309,7 @@ fn test_zipup_with_star_topology() {
     )
     .unwrap();
     tn_a.add_tensor("D".to_string(), tensor_d.clone()).unwrap();
-    let tensor_d_b = TensorDynLen::from_dense(
+    let tensor_d_b = IdxTensor::from_dense(
         vec![
             bond_ad_b.clone(),
             bond_bd_b.clone(),

--- a/crates/tensor4all-treetn/tests/bug_swap_values.rs
+++ b/crates/tensor4all-treetn/tests/bug_swap_values.rs
@@ -7,14 +7,14 @@
 
 use std::collections::HashMap;
 use tensor4all_core::{
-    common_inds, DynIndex, FactorizeOptions, IndexLike, TensorContractionLike, TensorDynLen,
+    common_inds, DynIndex, FactorizeOptions, IdxTensor, IndexLike, TensorContractionLike,
     TensorFactorizationLike, TensorIndex,
 };
 use tensor4all_treetn::{SwapOptions, TreeTN};
 
 /// Build a 2-site MPS from dense data via QR factorization.
-fn make_2site_mps(s1: &DynIndex, s2: &DynIndex, data: &[f64]) -> Vec<TensorDynLen> {
-    let dense = TensorDynLen::from_dense(vec![s1.clone(), s2.clone()], data.to_vec()).unwrap();
+fn make_2site_mps(s1: &DynIndex, s2: &DynIndex, data: &[f64]) -> Vec<IdxTensor> {
+    let dense = IdxTensor::from_dense(vec![s1.clone(), s2.clone()], data.to_vec()).unwrap();
     let fr = dense
         .factorize(std::slice::from_ref(s1), &FactorizeOptions::qr())
         .unwrap();
@@ -22,9 +22,9 @@ fn make_2site_mps(s1: &DynIndex, s2: &DynIndex, data: &[f64]) -> Vec<TensorDynLe
 }
 
 /// Concatenate two MPS by adding a dim-1 bond between them.
-fn concatenate(left: &[TensorDynLen], right: &[TensorDynLen]) -> Vec<TensorDynLen> {
+fn concatenate(left: &[IdxTensor], right: &[IdxTensor]) -> Vec<IdxTensor> {
     let bond = DynIndex::new_dyn(1);
-    let ones = TensorDynLen::ones(std::slice::from_ref(&bond)).unwrap();
+    let ones = IdxTensor::ones(std::slice::from_ref(&bond)).unwrap();
     let n_left = left.len();
     let mut tensors = Vec::with_capacity(n_left + right.len());
     for (i, t) in left.iter().enumerate() {
@@ -59,14 +59,13 @@ fn test_swap_preserves_values_nontrivial_data() {
     let tensors = concatenate(&left, &right);
     let node_names: Vec<usize> = (0..tensors.len()).collect();
 
-    let treetn_before: TreeTN<TensorDynLen, usize> =
+    let treetn_before: TreeTN<IdxTensor, usize> =
         TreeTN::from_tensors(tensors.clone(), node_names.clone()).unwrap();
     let dense_before = treetn_before.contract_to_tensor().unwrap();
     let norm_before = dense_before.norm().unwrap();
 
     // Swap sites 1 and 2: [z1=1, z1=2, z2=1, z2=2] → [z1=1, z2=1, z1=2, z2=2]
-    let mut treetn: TreeTN<TensorDynLen, usize> =
-        TreeTN::from_tensors(tensors, node_names).unwrap();
+    let mut treetn: TreeTN<IdxTensor, usize> = TreeTN::from_tensors(tensors, node_names).unwrap();
     let mut target = HashMap::new();
     target.insert(z1_1.clone(), 0usize);
     target.insert(z2_1.clone(), 1usize);
@@ -102,11 +101,11 @@ fn test_canonicalize_preserves_contract_to_tensor() {
     let tensors = concatenate(&left, &right);
     let node_names: Vec<usize> = (0..tensors.len()).collect();
 
-    let treetn_before: TreeTN<TensorDynLen, usize> =
+    let treetn_before: TreeTN<IdxTensor, usize> =
         TreeTN::from_tensors(tensors.clone(), node_names.clone()).unwrap();
     let dense_before = treetn_before.contract_to_tensor().unwrap();
 
-    let mut treetn_after: TreeTN<TensorDynLen, usize> =
+    let mut treetn_after: TreeTN<IdxTensor, usize> =
         TreeTN::from_tensors(tensors, node_names).unwrap();
     use tensor4all_treetn::CanonicalizationOptions;
     treetn_after
@@ -138,8 +137,7 @@ fn test_contract_factorize_roundtrip() {
     let tensors = concatenate(&left, &right);
     let node_names: Vec<usize> = (0..tensors.len()).collect();
 
-    let mut treetn: TreeTN<TensorDynLen, usize> =
-        TreeTN::from_tensors(tensors, node_names).unwrap();
+    let mut treetn: TreeTN<IdxTensor, usize> = TreeTN::from_tensors(tensors, node_names).unwrap();
     use tensor4all_treetn::CanonicalizationOptions;
     treetn
         .canonicalize_mut(std::iter::once(0usize), CanonicalizationOptions::default())
@@ -215,7 +213,7 @@ fn test_manual_sweep_edge_steps() {
         .unwrap();
 
     // Helper: contract all 4 tensors and compare to reference
-    let check_full = |_label: &str, tensors: &[TensorDynLen]| -> f64 {
+    let check_full = |_label: &str, tensors: &[IdxTensor]| -> f64 {
         let full = tensors[3]
             .contract_pair(&tensors[2])
             .unwrap()
@@ -232,7 +230,7 @@ fn test_manual_sweep_edge_steps() {
     };
 
     // Helper: find shared index between two tensors
-    let find_bond = |a: &TensorDynLen, b: &TensorDynLen| -> DynIndex {
+    let find_bond = |a: &IdxTensor, b: &IdxTensor| -> DynIndex {
         let ids: std::collections::HashSet<_> = a
             .external_indices()
             .iter()
@@ -246,7 +244,7 @@ fn test_manual_sweep_edge_steps() {
     };
 
     // Helper: sweep_edge from src to dst
-    let sweep_edge = |t: &mut [TensorDynLen], src: usize, dst: usize| {
+    let sweep_edge = |t: &mut [IdxTensor], src: usize, dst: usize| {
         let bond = find_bond(&t[dst], &t[src]);
         let left_inds: Vec<DynIndex> = t[src]
             .external_indices()
@@ -291,7 +289,7 @@ fn test_qr_roundtrip_tall_matrix() {
     let i3 = DynIndex::new_dyn_with_tag(2, "site_b").unwrap();
 
     let data = vec![1.0, 2.0, 3.0, 4.0];
-    let t = TensorDynLen::from_dense(vec![i1.clone(), i2.clone(), i3.clone()], data).unwrap();
+    let t = IdxTensor::from_dense(vec![i1.clone(), i2.clone(), i3.clone()], data).unwrap();
 
     let fr = t
         .factorize(&[i2.clone(), i3.clone()], &FactorizeOptions::qr())
@@ -315,9 +313,9 @@ fn test_swap_preserves_values_plain_mps() {
 
     let data: Vec<f64> = (1..=16).map(|i| i as f64).collect();
     let indices = vec![s0.clone(), s1.clone(), s2.clone(), s3.clone()];
-    let dense = TensorDynLen::from_dense(indices.clone(), data).unwrap();
+    let dense = IdxTensor::from_dense(indices.clone(), data).unwrap();
 
-    let mut tensors: Vec<TensorDynLen> = Vec::new();
+    let mut tensors: Vec<IdxTensor> = Vec::new();
     let mut remaining = dense;
     for k in 0..3 {
         let mut left_inds = Vec::new();
@@ -336,12 +334,11 @@ fn test_swap_preserves_values_plain_mps() {
 
     let node_names: Vec<usize> = (0..tensors.len()).collect();
 
-    let treetn_before: TreeTN<TensorDynLen, usize> =
+    let treetn_before: TreeTN<IdxTensor, usize> =
         TreeTN::from_tensors(tensors.clone(), node_names.clone()).unwrap();
     let dense_before = treetn_before.contract_to_tensor().unwrap();
 
-    let mut treetn: TreeTN<TensorDynLen, usize> =
-        TreeTN::from_tensors(tensors, node_names).unwrap();
+    let mut treetn: TreeTN<IdxTensor, usize> = TreeTN::from_tensors(tensors, node_names).unwrap();
     let mut target = HashMap::new();
     target.insert(s0.clone(), 0usize);
     target.insert(s2.clone(), 1usize);

--- a/crates/tensor4all-treetn/tests/dmrg.rs
+++ b/crates/tensor4all-treetn/tests/dmrg.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, FactorizeOptions, TensorDynLen};
+use tensor4all_core::{DynIndex, FactorizeOptions, IdxTensor};
 use tensor4all_treetn::{
     dmrg, dmrg_with_treetn_operator, DmrgError, DmrgOptions, IndexMapping, LinearOperator, TreeTN,
     TreeTopology,
@@ -17,7 +17,7 @@ fn col_major_offset(coords: &[usize], dims: &[usize]) -> usize {
     offset
 }
 
-fn two_site_state(values: &[f64]) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+fn two_site_state(values: &[f64]) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 2]) {
     assert_eq!(values.len(), 4);
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
@@ -27,9 +27,9 @@ fn two_site_state(values: &[f64]) -> (TreeTN<TensorDynLen, &'static str>, [DynIn
     left[col_major_offset(&[0, 0], &[2, 2])] = 1.0;
     left[col_major_offset(&[1, 1], &[2, 2])] = 1.0;
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], left).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], values.to_vec()).unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], left).unwrap();
+    let t1 = IdxTensor::from_dense(vec![bond.clone(), s1.clone()], values.to_vec()).unwrap();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();
@@ -39,7 +39,7 @@ fn two_site_state(values: &[f64]) -> (TreeTN<TensorDynLen, &'static str>, [DynIn
 fn diagonal_two_site_operator(
     state_sites: &[DynIndex; 2],
     energies: [f64; 4],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let s0_out = DynIndex::new_dyn(2);
     let s0_in = DynIndex::new_dyn(2);
     let s1_out = DynIndex::new_dyn(2);
@@ -54,7 +54,7 @@ fn diagonal_two_site_operator(
         }
     }
 
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), s1_out.clone(), s1_in.clone()],
         data,
     )
@@ -111,24 +111,20 @@ fn diagonal_two_site_operator(
     LinearOperator::new(mpo, input_mapping, output_mapping)
 }
 
-fn single_site_state() -> (TreeTN<TensorDynLen, &'static str>, DynIndex) {
+fn single_site_state() -> (TreeTN<IdxTensor, &'static str>, DynIndex) {
     let site = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
     (state, site)
 }
 
-fn single_site_identity_operator(
-    state_site: &DynIndex,
-) -> LinearOperator<TensorDynLen, &'static str> {
+fn single_site_identity_operator(state_site: &DynIndex) -> LinearOperator<IdxTensor, &'static str> {
     let out = DynIndex::new_dyn(2);
     let input = DynIndex::new_dyn(2);
     let tensor =
-        TensorDynLen::from_dense(vec![out.clone(), input.clone()], vec![1.0, 0.0, 0.0, 1.0])
-            .unwrap();
-    let mpo =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
+        IdxTensor::from_dense(vec![out.clone(), input.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let mpo = TreeTN::<IdxTensor, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
     LinearOperator::new(
         mpo,
         HashMap::from([(
@@ -151,7 +147,7 @@ fn single_site_identity_operator(
 fn complex_two_site_operator(
     state_sites: &[DynIndex; 2],
     entries: &[(usize, usize, usize, usize, Complex64)],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let s0_out = DynIndex::new_dyn(2);
     let s0_in = DynIndex::new_dyn(2);
     let s1_out = DynIndex::new_dyn(2);
@@ -163,7 +159,7 @@ fn complex_two_site_operator(
         data[col_major_offset(&[out0, in0, out1, in1], &dims)] = value;
     }
 
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         vec![s0_out.clone(), s0_in.clone(), s1_out.clone(), s1_in.clone()],
         data,
     )
@@ -224,7 +220,7 @@ fn heisenberg_dense_operator(
     state_sites: &[DynIndex],
     edges: &[(usize, usize)],
     topology_edges: &[(&'static str, &'static str)],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let n_sites = state_sites.len();
     let outputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
     let inputs: Vec<_> = (0..n_sites).map(|_| DynIndex::new_dyn(2)).collect();
@@ -266,7 +262,7 @@ fn heisenberg_dense_operator(
         }
     }
 
-    let dense = TensorDynLen::from_dense(indices, data).unwrap();
+    let dense = IdxTensor::from_dense(indices, data).unwrap();
     let topology = TreeTopology::new(
         (0..n_sites)
             .map(|i| (site_name(i), vec![outputs[i].clone(), inputs[i].clone()]))
@@ -317,12 +313,12 @@ fn site_name(i: usize) -> &'static str {
     }
 }
 
-fn three_site_star_plus_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+fn three_site_star_plus_state() -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 3]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
     let dense =
-        TensorDynLen::from_dense(vec![s0.clone(), s1.clone(), s2.clone()], vec![1.0; 8]).unwrap();
+        IdxTensor::from_dense(vec![s0.clone(), s1.clone(), s2.clone()], vec![1.0; 8]).unwrap();
     let topology = TreeTopology::new(
         HashMap::from([
             ("site0", vec![s0.clone()]),
@@ -341,12 +337,12 @@ fn three_site_star_plus_state() -> (TreeTN<TensorDynLen, &'static str>, [DynInde
     (state, [s0, s1, s2])
 }
 
-fn four_site_star_asymmetric_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 4]) {
+fn four_site_star_asymmetric_state() -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 4]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
     let s3 = DynIndex::new_dyn(2);
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         vec![s0.clone(), s1.clone(), s2.clone(), s3.clone()],
         vec![
             0.7, -0.3, 1.1, 0.2, -0.8, 0.5, 0.9, -1.2, 0.4, 1.3, -0.6, 0.1, 1.0, -0.9, 0.3, 0.8,
@@ -372,7 +368,7 @@ fn four_site_star_asymmetric_state() -> (TreeTN<TensorDynLen, &'static str>, [Dy
     (state, [s0, s1, s2, s3])
 }
 
-fn star_sum_z_operator(state_sites: &[DynIndex; 3]) -> LinearOperator<TensorDynLen, &'static str> {
+fn star_sum_z_operator(state_sites: &[DynIndex; 3]) -> LinearOperator<IdxTensor, &'static str> {
     let out0 = DynIndex::new_dyn(2);
     let in0 = DynIndex::new_dyn(2);
     let out1 = DynIndex::new_dyn(2);
@@ -392,7 +388,7 @@ fn star_sum_z_operator(state_sites: &[DynIndex; 3]) -> LinearOperator<TensorDynL
             }
         }
     }
-    let dense = TensorDynLen::from_dense(
+    let dense = IdxTensor::from_dense(
         vec![
             out0.clone(),
             in0.clone(),

--- a/crates/tensor4all-treetn/tests/gse.rs
+++ b/crates/tensor4all-treetn/tests/gse.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, IndexLike, TensorContractionLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorContractionLike};
 use tensor4all_treetn::{
     global_subspace_expand, global_subspace_expand_with_references, gse_tdvp, GseError, GseOptions,
     GseTdvpOptions, IndexMapping, LinearOperator, TdvpOptions, TreeTN,
@@ -9,21 +9,21 @@ use tensor4all_treetn::{
 
 fn product_chain_state(
     amplitudes: [[Complex64; 2]; 2],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 2]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![amplitudes[0][0], amplitudes[0][1]],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![amplitudes[1][0], amplitudes[1][1]],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();
@@ -32,21 +32,21 @@ fn product_chain_state(
 
 fn product_chain_state_f64(
     amplitudes: [[f64; 2]; 2],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 2]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![amplitudes[0][0], amplitudes[0][1]],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![amplitudes[1][0], amplitudes[1][1]],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();
@@ -56,15 +56,15 @@ fn product_chain_state_f64(
 fn product_chain_state_from_vectors(
     left_amplitudes: &[Complex64],
     right_amplitudes: &[Complex64],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 2]) {
     let s0 = DynIndex::new_dyn(left_amplitudes.len());
     let s1 = DynIndex::new_dyn(right_amplitudes.len());
     let bond = DynIndex::new_dyn(1);
     let t0 =
-        TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], left_amplitudes.to_vec()).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![bond.clone(), s1.clone()], right_amplitudes.to_vec())
-        .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+        IdxTensor::from_dense(vec![s0.clone(), bond.clone()], left_amplitudes.to_vec()).unwrap();
+    let t1 =
+        IdxTensor::from_dense(vec![bond.clone(), s1.clone()], right_amplitudes.to_vec()).unwrap();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();
@@ -73,28 +73,28 @@ fn product_chain_state_from_vectors(
 
 fn product_chain3_state(
     amplitudes: [[Complex64; 2]; 3],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 3]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
     let b01 = DynIndex::new_dyn(1);
     let b12 = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone()],
         vec![amplitudes[0][0], amplitudes[0][1]],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone(), b12.clone()],
         vec![amplitudes[1][0], amplitudes[1][1]],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b12.clone(), s2.clone()],
         vec![amplitudes[2][0], amplitudes[2][1]],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     let n2 = state.add_tensor("site2", t2).unwrap();
@@ -105,28 +105,28 @@ fn product_chain3_state(
 
 fn product_star_state(
     amplitudes: [[Complex64; 2]; 3],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 3]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
     let b01 = DynIndex::new_dyn(1);
     let b02 = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone(), b02.clone()],
         vec![amplitudes[0][0], amplitudes[0][1]],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone()],
         vec![amplitudes[1][0], amplitudes[1][1]],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b02.clone(), s2.clone()],
         vec![amplitudes[2][0], amplitudes[2][1]],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     let n2 = state.add_tensor("site2", t2).unwrap();
@@ -137,7 +137,7 @@ fn product_star_state(
 
 fn product_internal_branch_state(
     amplitudes: [[Complex64; 2]; 4],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 4]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 4]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
@@ -145,27 +145,27 @@ fn product_internal_branch_state(
     let b01 = DynIndex::new_dyn(1);
     let b12 = DynIndex::new_dyn(1);
     let b13 = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone()],
         vec![amplitudes[0][0], amplitudes[0][1]],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone(), b12.clone(), b13.clone()],
         vec![amplitudes[1][0], amplitudes[1][1]],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b12.clone(), s2.clone()],
         vec![amplitudes[2][0], amplitudes[2][1]],
     )
     .unwrap();
-    let t3 = TensorDynLen::from_dense(
+    let t3 = IdxTensor::from_dense(
         vec![b13.clone(), s3.clone()],
         vec![amplitudes[3][0], amplitudes[3][1]],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     let n2 = state.add_tensor("site2", t2).unwrap();
@@ -178,7 +178,7 @@ fn product_internal_branch_state(
 
 fn entangled_chain3_state(
     leaf_matrix: [[Complex64; 2]; 2],
-) -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+) -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 3]) {
     let zero = Complex64::new(0.0, 0.0);
     let one = Complex64::new(1.0, 0.0);
     let s0 = DynIndex::new_dyn(2);
@@ -187,13 +187,13 @@ fn entangled_chain3_state(
     let b01 = DynIndex::new_dyn(1);
     let b12 = DynIndex::new_dyn(2);
 
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![one, zero]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![one, zero]).unwrap();
 
     let mut t1_data = vec![zero; 4];
     for b in 0..2 {
         t1_data[b + 2 * b] = one;
     }
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], t1_data).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], t1_data).unwrap();
 
     let mut t2_data = vec![zero; 4];
     for b in 0..2 {
@@ -201,9 +201,9 @@ fn entangled_chain3_state(
             t2_data[b + 2 * s] = leaf_matrix[b][s];
         }
     }
-    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], t2_data).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone(), s2.clone()], t2_data).unwrap();
 
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     let n2 = state.add_tensor("site2", t2).unwrap();
@@ -217,7 +217,7 @@ fn identity_or_x_operator(
     node_names: &[&'static str],
     edges: &[(&'static str, &'static str)],
     x_nodes: &[&'static str],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let mut node_indices = HashMap::new();
     let mut input_mapping = HashMap::new();
     let mut output_mapping = HashMap::new();
@@ -227,7 +227,7 @@ fn identity_or_x_operator(
         op_bonds.insert((a, b), DynIndex::new_dyn(1));
     }
 
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
     for (i, &name) in node_names.iter().enumerate() {
         let input = DynIndex::new_dyn(2);
         let output = DynIndex::new_dyn(2);
@@ -270,7 +270,7 @@ fn identity_or_x_operator(
             data[col_major_offset(&coord, &dims)] = Complex64::new(1.0, 0.0);
         }
         let node = mpo
-            .add_tensor(name, TensorDynLen::from_dense(inds, data).unwrap())
+            .add_tensor(name, IdxTensor::from_dense(inds, data).unwrap())
             .unwrap();
         node_indices.insert(name, node);
     }
@@ -300,8 +300,8 @@ fn col_major_offset(coord: &[usize], dims: &[usize]) -> usize {
 }
 
 fn dense_distance(
-    lhs: &TreeTN<TensorDynLen, &'static str>,
-    rhs: &TreeTN<TensorDynLen, &'static str>,
+    lhs: &TreeTN<IdxTensor, &'static str>,
+    rhs: &TreeTN<IdxTensor, &'static str>,
 ) -> f64 {
     lhs.contract_to_tensor()
         .unwrap()
@@ -309,14 +309,12 @@ fn dense_distance(
         .unwrap()
 }
 
-fn edge_dim(state: &TreeTN<TensorDynLen, &'static str>, a: &str, b: &str) -> usize {
+fn edge_dim(state: &TreeTN<IdxTensor, &'static str>, a: &str, b: &str) -> usize {
     let edge = state.edge_between(&a, &b).unwrap();
     state.bond_index(edge).unwrap().dim()
 }
 
-fn enable_grad_all(
-    mut state: TreeTN<TensorDynLen, &'static str>,
-) -> TreeTN<TensorDynLen, &'static str> {
+fn enable_grad_all(mut state: TreeTN<IdxTensor, &'static str>) -> TreeTN<IdxTensor, &'static str> {
     let nodes = state.node_indices().to_vec();
     for node in nodes {
         let tensor = state.tensor(node).unwrap().clone().enable_grad().unwrap();
@@ -326,7 +324,7 @@ fn enable_grad_all(
 }
 
 fn local_basis_matrix(
-    state: &TreeTN<TensorDynLen, &'static str>,
+    state: &TreeTN<IdxTensor, &'static str>,
     parent: &str,
     child: &str,
     q_indices: &[DynIndex],
@@ -876,9 +874,9 @@ fn gse_rejects_invalid_options_and_missing_center() {
 fn gse_rejects_multiple_state_sites_per_node() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![s0, s1], vec![Complex64::new(0.0, 0.0); 4]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![s0, s1], vec![Complex64::new(0.0, 0.0); 4]).unwrap();
     let state =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![tensor], vec!["site0"]).unwrap();
 
     let err =
         global_subspace_expand_with_references(state, Vec::new(), &"site0", GseOptions::default())
@@ -933,13 +931,13 @@ fn global_subspace_expand_accepts_mixed_scalar_storage_inside_target_tree() {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), bond.clone()], vec![1.0_f64, 0.0]).unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), bond.clone()], vec![1.0_f64, 0.0]).unwrap();
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();

--- a/crates/tensor4all-treetn/tests/issue192_regression.rs
+++ b/crates/tensor4all-treetn/tests/issue192_regression.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
 
 use anyhow::Context;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_treetn::{
     apply_local_update_sweep, ApplyOptions, CanonicalForm, CanonicalizationOptions, IndexMapping,
     LinearOperator, LinsolveOptions, LocalUpdateSweepPlan, SquareLinsolveUpdater, TreeTN,
     TruncationOptions,
 };
 
-type MpsWithSiteIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>);
-type MpoWithInternalIndices = (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>);
+type MpsWithSiteIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>);
+type MpoWithInternalIndices = (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>);
 
 fn create_n_site_ones_mps(
     n_sites: usize,
@@ -18,7 +18,7 @@ fn create_n_site_ones_mps(
 ) -> anyhow::Result<MpsWithSiteIndices> {
     anyhow::ensure!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     let site_indices: Vec<DynIndex> = (0..n_sites)
         .map(|i| {
@@ -49,7 +49,7 @@ fn create_n_site_ones_mps(
         };
 
         let nelem: usize = indices.iter().map(|idx| idx.dim).product();
-        let tensor = TensorDynLen::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
+        let tensor = IdxTensor::from_dense(indices, vec![1.0_f64; nelem]).unwrap();
         mps.add_tensor(name, tensor)?;
     }
 
@@ -70,7 +70,7 @@ fn create_identity_chain_mpo_with_internal_indices(
 ) -> anyhow::Result<MpoWithInternalIndices> {
     anyhow::ensure!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
     let s_out_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -85,7 +85,7 @@ fn create_identity_chain_mpo_with_internal_indices(
         }
 
         let tensor = if i == 0 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -95,7 +95,7 @@ fn create_identity_chain_mpo_with_internal_indices(
             )
             .unwrap()
         } else if i == n_sites - 1 {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -105,7 +105,7 @@ fn create_identity_chain_mpo_with_internal_indices(
             )
             .unwrap()
         } else {
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),

--- a/crates/tensor4all-treetn/tests/linsolve.rs
+++ b/crates/tensor4all-treetn/tests/linsolve.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use tensor4all_core::{
-    AnyScalar, DynIndex, IndexLike, TensorContractionLike, TensorDynLen, TensorIndex,
+    AnyScalar, DynIndex, IdxTensor, IndexLike, TensorContractionLike, TensorIndex,
 };
 use tensor4all_treetn::{
     relative_linear_system_residual, ApplyOptions, EnvironmentCache, IndexMapping, LinearOperator,
@@ -65,11 +65,11 @@ fn create_fixed_site_index_mappings<const N: usize>(
 /// Create a simple 3-site MPS chain for testing.
 /// Returns (mps, site indices, bond indices)
 fn create_simple_mps_chain() -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
-    let mut mps = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mps = TreeTN::<IdxTensor, &'static str>::new();
 
     // Physical indices (dimension 2 for each site)
     let s0 = DynIndex::new_dyn(2);
@@ -82,14 +82,14 @@ fn create_simple_mps_chain() -> (
 
     // Create tensors with random data
     // Site 0: [s0, b01] shape (2, 4)
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 8]).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 8]).unwrap();
 
     // Site 1: [b01, s1, b12] shape (4, 2, 4)
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 32])
-        .unwrap();
+    let t1 =
+        IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], vec![1.0; 32]).unwrap();
 
     // Site 2: [b12, s2] shape (4, 2)
-    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], vec![1.0; 8]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone(), s2.clone()], vec![1.0; 8]).unwrap();
 
     // Add nodes with string names (add_tensor returns Result)
     let n0 = mps.add_tensor("site0", t0).unwrap();
@@ -114,18 +114,18 @@ fn create_simple_mps_chain() -> (
 
 #[test]
 fn test_environment_cache_basic() {
-    let cache: EnvironmentCache<TensorDynLen, &str> = EnvironmentCache::new();
+    let cache: EnvironmentCache<IdxTensor, &str> = EnvironmentCache::new();
     assert!(cache.is_empty());
     assert_eq!(cache.len(), 0);
 }
 
 #[test]
 fn test_environment_cache_insert_get() {
-    let mut cache: EnvironmentCache<TensorDynLen, &str> = EnvironmentCache::new();
+    let mut cache: EnvironmentCache<IdxTensor, &str> = EnvironmentCache::new();
 
     // Create a simple tensor to cache
     let idx = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![idx], vec![1.0, 2.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![idx], vec![1.0, 2.0]).unwrap();
 
     cache.insert("a", "b", tensor.clone());
 
@@ -140,10 +140,10 @@ fn test_environment_cache_insert_get() {
 
 #[test]
 fn test_environment_cache_clear() {
-    let mut cache: EnvironmentCache<TensorDynLen, &str> = EnvironmentCache::new();
+    let mut cache: EnvironmentCache<IdxTensor, &str> = EnvironmentCache::new();
 
     let idx = DynIndex::new_dyn(2);
-    let tensor = TensorDynLen::from_dense(vec![idx], vec![1.0, 2.0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![idx], vec![1.0, 2.0]).unwrap();
 
     cache.insert("a", "b", tensor);
     assert_eq!(cache.len(), 1);
@@ -278,21 +278,21 @@ fn test_projected_operator_apply_distinguishes_same_id_prime_level() {
 
     let site = DynIndex::new_dyn(2);
     let site_prime = site.prime();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     state
         .add_tensor(
             "site0",
-            TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap(),
+            IdxTensor::from_dense(vec![site.clone()], vec![1.0, 0.0]).unwrap(),
         )
         .unwrap();
 
     let op_in = DynIndex::new_dyn(2);
     let op_out = DynIndex::new_dyn(2);
-    let mut operator = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut operator = TreeTN::<IdxTensor, &'static str>::new();
     operator
         .add_tensor(
             "site0",
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![op_out.clone(), op_in.clone()],
                 vec![1.0, 0.0, 0.0, 1.0],
             )
@@ -319,7 +319,7 @@ fn test_projected_operator_apply_distinguishes_same_id_prime_level() {
     );
 
     for data in [vec![1.0, 2.0, 3.0, 4.0], vec![4.0, 3.0, 2.0, 1.0]] {
-        let input = TensorDynLen::from_dense(vec![site.clone(), site_prime.clone()], data).unwrap();
+        let input = IdxTensor::from_dense(vec![site.clone(), site_prime.clone()], data).unwrap();
         let output = projected_op
             .apply(&input, &["site0"], &state, &state, &SingleNode)
             .unwrap();
@@ -339,11 +339,11 @@ fn test_projected_operator_apply_distinguishes_same_id_prime_level() {
 /// Create a simple 2-site MPS chain for testing.
 /// Returns (mps, site indices, bond indices)
 fn create_two_site_mps() -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
-    let mut mps = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mps = TreeTN::<IdxTensor, &'static str>::new();
 
     // Physical indices (dimension 2 for each site)
     let s0 = DynIndex::new_dyn(2);
@@ -354,7 +354,7 @@ fn create_two_site_mps() -> (
 
     // Create tensors with normalized data
     // Site 0: [s0, b01] shape (2, 2)
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone()],
         vec![
             1.0, 0.0, // s0=0: b01=0, b01=1
@@ -364,7 +364,7 @@ fn create_two_site_mps() -> (
     .unwrap();
 
     // Site 1: [b01, s1] shape (2, 2)
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone()],
         vec![
             1.0, 0.0, // b01=0: s1=0, s1=1
@@ -399,7 +399,7 @@ fn create_two_site_mps() -> (
 fn create_diagonal_mpo(
     site_indices: &[DynIndex],
     diag_values: &[f64],
-) -> (TreeTN<TensorDynLen, &'static str>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, &'static str>, Vec<DynIndex>) {
     assert_eq!(
         site_indices.len(),
         diag_values.len(),
@@ -407,7 +407,7 @@ fn create_diagonal_mpo(
     );
     assert_eq!(site_indices.len(), 2, "Currently only supports 2-site MPO");
 
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     // Physical dimension
     let phys_dim = site_indices[0].dim();
@@ -431,7 +431,7 @@ fn create_diagonal_mpo(
         data0[i * phys_dim + i] = diag_values[0];
     }
     let t0 =
-        TensorDynLen::from_dense(vec![s0_out.clone(), s0_in.clone(), b01.clone()], data0).unwrap();
+        IdxTensor::from_dense(vec![s0_out.clone(), s0_in.clone(), b01.clone()], data0).unwrap();
 
     // Diagonal tensor at site 1: [b01, s1_out, s1_in] shape (1, 2, 2)
     let mut data1 = vec![0.0; phys_dim * phys_dim];
@@ -439,7 +439,7 @@ fn create_diagonal_mpo(
         data1[i * phys_dim + i] = diag_values[1];
     }
     let t1 =
-        TensorDynLen::from_dense(vec![b01.clone(), s1_out.clone(), s1_in.clone()], data1).unwrap();
+        IdxTensor::from_dense(vec![b01.clone(), s1_out.clone(), s1_in.clone()], data1).unwrap();
 
     // Add nodes
     let n0 = mpo.add_tensor("site0", t0).unwrap();
@@ -455,7 +455,7 @@ fn create_diagonal_mpo(
 /// Returns (MPO, output_indices) where output_indices are the new output site indices.
 fn create_identity_mpo(
     site_indices: &[DynIndex],
-) -> (TreeTN<TensorDynLen, &'static str>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, &'static str>, Vec<DynIndex>) {
     let diag_values = vec![1.0; site_indices.len()];
     create_diagonal_mpo(site_indices, &diag_values)
 }
@@ -467,7 +467,7 @@ fn create_mps_from_values(
     values: &[f64],
     phys_dim: usize,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
@@ -477,7 +477,7 @@ fn create_mps_from_values(
         "values length must be phys_dim^2"
     );
 
-    let mut mps = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mps = TreeTN::<IdxTensor, &'static str>::new();
 
     // Physical indices
     let s0 = DynIndex::new_dyn(phys_dim);
@@ -505,10 +505,10 @@ fn create_mps_from_values(
     for i in 0..phys_dim.min(bond_dim) {
         data0[i * bond_dim + i] = 1.0;
     }
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], data0).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], data0).unwrap();
 
     // Site 1 tensor: [b01, s1] - contains the values
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone()], values.to_vec()).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone()], values.to_vec()).unwrap();
 
     let n0 = mps.add_tensor("site0", t0).unwrap();
     let n1 = mps.add_tensor("site1", t1).unwrap();
@@ -659,14 +659,14 @@ fn test_linsolve_nonuniform_diagonal() {
 fn create_three_site_mps(
     values: Option<&[f64]>,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
     let phys_dim = 2;
     let bond_dim = 2;
 
-    let mut mps = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mps = TreeTN::<IdxTensor, &'static str>::new();
 
     // Physical indices
     let s0 = DynIndex::new_dyn(phys_dim);
@@ -692,7 +692,7 @@ fn create_three_site_mps(
     for i in 0..phys_dim.min(bond_dim) {
         data0[i * bond_dim + i] = 1.0;
     }
-    let t0 = TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], data0).unwrap();
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], data0).unwrap();
 
     // Site 1: [b01, s1, b12] shape (2, 2, 2) - identity-like
     // B[b, s, b'] = delta(b, s) * delta(s, b')
@@ -702,7 +702,7 @@ fn create_three_site_mps(
         let idx = i * phys_dim * bond_dim + i * bond_dim + i;
         data1[idx] = 1.0;
     }
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], data1).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], data1).unwrap();
 
     // Site 2: [b12, s2] shape (2, 2) - contains values or identity
     let data2 = if let Some(vals) = values {
@@ -721,7 +721,7 @@ fn create_three_site_mps(
         }
         d
     };
-    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone()], data2).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone(), s2.clone()], data2).unwrap();
 
     let n0 = mps.add_tensor("site0", t0).unwrap();
     let n1 = mps.add_tensor("site1", t1).unwrap();
@@ -747,10 +747,10 @@ fn create_three_site_mps(
 /// - s_in should SHARE the ID with the state's site index (for input/ket side)
 fn create_three_site_identity_mpo(
     site_indices: &[DynIndex],
-) -> (TreeTN<TensorDynLen, &'static str>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, &'static str>, Vec<DynIndex>) {
     assert_eq!(site_indices.len(), 3);
 
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     let phys_dim = 2;
 
@@ -774,14 +774,14 @@ fn create_three_site_identity_mpo(
         data0[i * phys_dim + i] = 1.0;
     }
     let t0 =
-        TensorDynLen::from_dense(vec![s0_out.clone(), s0_in.clone(), b01.clone()], data0).unwrap();
+        IdxTensor::from_dense(vec![s0_out.clone(), s0_in.clone(), b01.clone()], data0).unwrap();
 
     // Site 1: [b01, s1_out, s1_in, b12] - identity on physical indices
     let mut data1 = vec![0.0; phys_dim * phys_dim];
     for i in 0..phys_dim {
         data1[i * phys_dim + i] = 1.0;
     }
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1_out.clone(), s1_in.clone(), b12.clone()],
         data1,
     )
@@ -793,7 +793,7 @@ fn create_three_site_identity_mpo(
         data2[i * phys_dim + i] = 1.0;
     }
     let t2 =
-        TensorDynLen::from_dense(vec![b12.clone(), s2_out.clone(), s2_in.clone()], data2).unwrap();
+        IdxTensor::from_dense(vec![b12.clone(), s2_out.clone(), s2_in.clone()], data2).unwrap();
 
     let n0 = mpo.add_tensor("site0", t0).unwrap();
     let n1 = mpo.add_tensor("site1", t1).unwrap();
@@ -919,13 +919,13 @@ fn create_mpo_with_internal_indices(
     diag_values: &[f64],
     phys_dim: usize,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>, // s_in_tmp (internal input indices)
     Vec<DynIndex>, // s_out_tmp (internal output indices)
 ) {
     assert_eq!(diag_values.len(), 2);
 
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     // Internal input indices (new IDs)
     let s0_in_tmp = DynIndex::new_dyn(phys_dim);
@@ -943,7 +943,7 @@ fn create_mpo_with_internal_indices(
     for i in 0..phys_dim {
         data0[i * phys_dim + i] = diag_values[0];
     }
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0_out_tmp.clone(), s0_in_tmp.clone(), b01.clone()],
         data0,
     )
@@ -954,7 +954,7 @@ fn create_mpo_with_internal_indices(
     for i in 0..phys_dim {
         data1[i * phys_dim + i] = diag_values[1];
     }
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1_out_tmp.clone(), s1_in_tmp.clone()],
         data1,
     )
@@ -976,11 +976,11 @@ fn create_mpo_with_internal_indices(
 fn create_mapped_identity_mpo_with_spectator_node(
     phys_dim: usize,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     let s0_in_tmp = DynIndex::new_dyn(phys_dim);
     let s1_in_tmp = DynIndex::new_dyn(phys_dim);
@@ -994,12 +994,12 @@ fn create_mapped_identity_mpo_with_spectator_node(
         id_data[i * phys_dim + i] = 1.0;
     }
 
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0_out_tmp.clone(), s0_in_tmp.clone(), b01.clone()],
         id_data.clone(),
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![
             b01.clone(),
             s1_out_tmp.clone(),
@@ -1009,7 +1009,7 @@ fn create_mapped_identity_mpo_with_spectator_node(
         id_data,
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(vec![b12.clone()], vec![1.0]).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone()], vec![1.0]).unwrap();
 
     let n0 = mpo.add_tensor("site0", t0).unwrap();
     let n1 = mpo.add_tensor("site1", t1).unwrap();
@@ -1123,7 +1123,7 @@ fn test_linear_operator_apply_local() {
 
     // Create a local tensor for site0 only
     // v = [1.0, 0.0] representing |0⟩ at site0
-    let local_v = TensorDynLen::from_dense(vec![site_indices[0].clone()], vec![1.0, 0.0]).unwrap();
+    let local_v = IdxTensor::from_dense(vec![site_indices[0].clone()], vec![1.0, 0.0]).unwrap();
 
     // Apply operator locally at site0
     let result = linear_op.apply_local(&local_v, &["site0"]);
@@ -1210,7 +1210,7 @@ fn test_linear_operator_apply_local_two_sites() {
 
     // Create a local tensor for both sites (merged region)
     // v = |00⟩ = [1, 0, 0, 0] in (s0, s1) basis
-    let local_v = TensorDynLen::from_dense(
+    let local_v = IdxTensor::from_dense(
         vec![site_indices[0].clone(), site_indices[1].clone()],
         vec![
             1.0, 0.0, // s0=0: s1=0, s1=1
@@ -1434,7 +1434,7 @@ fn create_three_site_mpo_with_internal_indices(
     diag_values: &[f64],
     phys_dim: usize,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>, // s_in_tmp for each site
     Vec<DynIndex>, // s_out_tmp for each site
 ) {
@@ -1444,7 +1444,7 @@ fn create_three_site_mpo_with_internal_indices(
         "Need 3 diagonal values for 3-site MPO"
     );
 
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     // Internal indices (independent IDs)
     let s0_in_tmp = DynIndex::new_dyn(phys_dim);
@@ -1463,7 +1463,7 @@ fn create_three_site_mpo_with_internal_indices(
     for i in 0..phys_dim {
         data0[i * phys_dim + i] = diag_values[0];
     }
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0_out_tmp.clone(), s0_in_tmp.clone(), b01.clone()],
         data0,
     )
@@ -1474,7 +1474,7 @@ fn create_three_site_mpo_with_internal_indices(
     for i in 0..phys_dim {
         data1[i * phys_dim + i] = diag_values[1];
     }
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![
             b01.clone(),
             s1_out_tmp.clone(),
@@ -1490,7 +1490,7 @@ fn create_three_site_mpo_with_internal_indices(
     for i in 0..phys_dim {
         data2[i * phys_dim + i] = diag_values[2];
     }
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b12.clone(), s2_out_tmp.clone(), s2_in_tmp.clone()],
         data2,
     )
@@ -1640,11 +1640,11 @@ fn test_linsolve_with_index_mappings_three_site_diagonal() {
 fn create_pauli_x_mpo(
     phys_dim: usize,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     // MPO internal indices
     let s0_in_tmp = DynIndex::new_dyn(phys_dim);
@@ -1666,7 +1666,7 @@ fn create_pauli_x_mpo(
             data0[out_idx * phys_dim + in_idx] = pauli_x[out_idx * phys_dim + in_idx];
         }
     }
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0_out_tmp.clone(), s0_in_tmp.clone(), bond.clone()],
         data0,
     )
@@ -1681,7 +1681,7 @@ fn create_pauli_x_mpo(
             data1[out_idx * phys_dim + in_idx] = pauli_x[out_idx * phys_dim + in_idx];
         }
     }
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1_out_tmp.clone(), s1_in_tmp.clone()],
         data1,
     )
@@ -1800,11 +1800,11 @@ fn create_general_2x2_mpo(
     mat: &[f64; 4], // [a, b, c, d] encoding [[a, b], [c, d]]
     phys_dim: usize,
 ) -> (
-    TreeTN<TensorDynLen, &'static str>,
+    TreeTN<IdxTensor, &'static str>,
     Vec<DynIndex>,
     Vec<DynIndex>,
 ) {
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
 
     // MPO internal indices
     let s0_in_tmp = DynIndex::new_dyn(phys_dim);
@@ -1821,7 +1821,7 @@ fn create_general_2x2_mpo(
             data0[out_idx + phys_dim * in_idx] = mat[out_idx * phys_dim + in_idx];
         }
     }
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0_out_tmp.clone(), s0_in_tmp.clone(), bond.clone()],
         data0,
     )
@@ -1835,7 +1835,7 @@ fn create_general_2x2_mpo(
             data1[out_idx + phys_dim * in_idx] = mat[out_idx * phys_dim + in_idx];
         }
     }
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1_out_tmp.clone(), s1_in_tmp.clone()],
         data1,
     )
@@ -2049,10 +2049,10 @@ fn create_n_site_mps(
     n_sites: usize,
     phys_dim: usize,
     bond_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mps = TreeTN::<TensorDynLen, String>::new();
+    let mut mps = TreeTN::<IdxTensor, String>::new();
 
     // Physical indices
     let site_indices: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -2071,7 +2071,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * bond_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
+            IdxTensor::from_dense(vec![site_indices[i].clone(), bond_indices[i].clone()], data)
                 .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_{n-1}] - identity-like
@@ -2079,7 +2079,7 @@ fn create_n_site_mps(
             for j in 0..phys_dim.min(bond_dim) {
                 data[j * phys_dim + j] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![bond_indices[i - 1].clone(), site_indices[i].clone()],
                 data,
             )
@@ -2091,7 +2091,7 @@ fn create_n_site_mps(
                 let idx = j * phys_dim * bond_dim + j * bond_dim + j;
                 data[idx] = 1.0;
             }
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     site_indices[i].clone(),
@@ -2121,11 +2121,11 @@ fn create_n_site_mps(
 fn create_n_site_mpo_with_internal_indices(
     diag_values: &[f64],
     phys_dim: usize,
-) -> (TreeTN<TensorDynLen, String>, Vec<DynIndex>, Vec<DynIndex>) {
+) -> (TreeTN<IdxTensor, String>, Vec<DynIndex>, Vec<DynIndex>) {
     let n_sites = diag_values.len();
     assert!(n_sites >= 2, "Need at least 2 sites");
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
 
     // Internal indices (independent IDs)
     let s_in_tmp: Vec<DynIndex> = (0..n_sites).map(|_| DynIndex::new_dyn(phys_dim)).collect();
@@ -2144,7 +2144,7 @@ fn create_n_site_mpo_with_internal_indices(
 
         let tensor = if i == 0 {
             // First site: [s_out, s_in, b01]
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     s_out_tmp[i].clone(),
                     s_in_tmp[i].clone(),
@@ -2155,7 +2155,7 @@ fn create_n_site_mpo_with_internal_indices(
             .unwrap()
         } else if i == n_sites - 1 {
             // Last site: [b_{n-2,n-1}, s_out, s_in]
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -2166,7 +2166,7 @@ fn create_n_site_mpo_with_internal_indices(
             .unwrap()
         } else {
             // Middle sites: [b_{i-1,i}, s_out, s_in, b_{i,i+1}]
-            TensorDynLen::from_dense(
+            IdxTensor::from_dense(
                 vec![
                     bond_indices[i - 1].clone(),
                     s_out_tmp[i].clone(),
@@ -2196,12 +2196,12 @@ fn create_n_site_mpo_with_internal_indices(
 /// Returns (mpo, input_mapping, output_mapping)
 #[allow(clippy::type_complexity)]
 fn create_n_site_index_mappings(
-    mpo: TreeTN<TensorDynLen, String>,
+    mpo: TreeTN<IdxTensor, String>,
     state_site_indices: &[DynIndex],
     s_in_tmp: &[DynIndex],
     s_out_tmp: &[DynIndex],
 ) -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 ) {
@@ -2471,8 +2471,8 @@ fn test_square_linsolve_rejects_one_site_systems() {
     let site = DynIndex::new_dyn(2);
     let s_in = DynIndex::new_dyn(2);
     let s_out = DynIndex::new_dyn(2);
-    let operator = TreeTN::<TensorDynLen, usize>::from_tensors(
-        vec![TensorDynLen::from_dense(
+    let operator = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(
             vec![s_out.clone(), s_in.clone()],
             vec![1.0_f64, 0.0, 0.0, 1.0],
         )
@@ -2480,8 +2480,8 @@ fn test_square_linsolve_rejects_one_site_systems() {
         vec![0],
     )
     .unwrap();
-    let rhs = TreeTN::<TensorDynLen, usize>::from_tensors(
-        vec![TensorDynLen::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap()],
+    let rhs = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap()],
         vec![0],
     )
     .unwrap();

--- a/crates/tensor4all-treetn/tests/linsolve_mpo_xb.rs
+++ b/crates/tensor4all-treetn/tests/linsolve_mpo_xb.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use tensor4all_core::{index::DynId, DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{index::DynId, DynIndex, IdxTensor, IndexLike};
 use tensor4all_treetn::{
     CanonicalizationOptions, IndexMapping, LinsolveOptions, LocalUpdateStep, LocalUpdater,
     SquareLinsolveUpdater, TreeTN,
@@ -33,13 +33,10 @@ fn unique_dyn_index(used: &mut HashSet<DynId>, dim: usize) -> DynIndex {
 }
 
 /// Create a 1-node "MPO-like" state tensor with two site indices (external, contracted).
-fn one_node_mpo_like_state(
-    external: DynIndex,
-    contracted: DynIndex,
-) -> TreeTN<TensorDynLen, String> {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+fn one_node_mpo_like_state(external: DynIndex, contracted: DynIndex) -> TreeTN<IdxTensor, String> {
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let nelem = external.dim() * contracted.dim();
-    let t = TensorDynLen::from_dense(vec![external, contracted], vec![1.0; nelem]).unwrap();
+    let t = IdxTensor::from_dense(vec![external, contracted], vec![1.0; nelem]).unwrap();
     tn.add_tensor("site0".to_string(), t).unwrap();
     tn
 }
@@ -51,7 +48,7 @@ fn one_node_identity_operator_with_mappings(
     true_contracted: DynIndex,
     used: &mut HashSet<DynId>,
 ) -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     HashMap<String, IndexMapping<DynIndex>>,
     HashMap<String, IndexMapping<DynIndex>>,
 ) {
@@ -64,9 +61,9 @@ fn one_node_identity_operator_with_mappings(
     for k in 0..phys_dim {
         data[k * phys_dim + k] = 1.0;
     }
-    let t = TensorDynLen::from_dense(vec![s_out_tmp.clone(), s_in_tmp.clone()], data).unwrap();
+    let t = IdxTensor::from_dense(vec![s_out_tmp.clone(), s_in_tmp.clone()], data).unwrap();
 
-    let mut mpo = TreeTN::<TensorDynLen, String>::new();
+    let mut mpo = TreeTN::<IdxTensor, String>::new();
     mpo.add_tensor("site0".to_string(), t).unwrap();
 
     let mut input_mapping = HashMap::new();

--- a/crates/tensor4all-treetn/tests/ops.rs
+++ b/crates/tensor4all-treetn/tests/ops.rs
@@ -1,9 +1,7 @@
 //! Tests for TreeTN operations: norm, norm_squared, inner, to_dense, evaluate.
 
 use num_complex::Complex64;
-use tensor4all_core::{
-    AnyScalar, ColMajorArrayRef, DynIndex, IndexLike, TensorDynLen, TensorIndex,
-};
+use tensor4all_core::{AnyScalar, ColMajorArrayRef, DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_treetn::TreeTN;
 
 // ============================================================================
@@ -15,19 +13,19 @@ fn idx(size: usize) -> DynIndex {
     DynIndex::new_dyn(size)
 }
 
-/// Create a TensorDynLen from indices and f64 data.
-fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+/// Create a IdxTensor from indices and f64 data.
+fn make_tensor(indices: Vec<DynIndex>, data: Vec<f64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
-fn make_complex_tensor(indices: Vec<DynIndex>, data: Vec<Complex64>) -> TensorDynLen {
-    TensorDynLen::from_dense(indices, data).unwrap()
+fn make_complex_tensor(indices: Vec<DynIndex>, data: Vec<Complex64>) -> IdxTensor {
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Create a simple 2-node linear TreeTN with named nodes (usize).
 /// Structure: node 0 (phys s0) -- bond -- node 1 (phys s1)
 fn create_two_node_named() -> (
-    TreeTN<TensorDynLen, usize>,
+    TreeTN<IdxTensor, usize>,
     DynIndex, // s0 (physical index at node 0)
     DynIndex, // bond
     DynIndex, // s1 (physical index at node 1)
@@ -46,7 +44,7 @@ fn create_two_node_named() -> (
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     );
 
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
 
     (tn, s0, bond, s1)
 }
@@ -54,7 +52,7 @@ fn create_two_node_named() -> (
 /// Create a 3-node chain TreeTN with named nodes.
 /// Structure: node 0 -- bond01 -- node 1 -- bond12 -- node 2
 fn create_three_node_named() -> (
-    TreeTN<TensorDynLen, usize>,
+    TreeTN<IdxTensor, usize>,
     DynIndex, // s0
     DynIndex, // s1
     DynIndex, // s2
@@ -83,7 +81,7 @@ fn create_three_node_named() -> (
         (0..dims2).map(|i| (i + 1) as f64).collect(),
     );
 
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1, t2], vec![0, 1, 2]).unwrap();
 
     (tn, s0, s1, s2)
 }
@@ -96,7 +94,7 @@ fn create_three_node_named() -> (
 fn test_norm_single_node() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![1.0, 2.0, 3.0]);
-    let mut tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
+    let mut tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
     let norm = tn.norm().unwrap();
     let expected = (1.0f64 + 4.0 + 9.0).sqrt();
@@ -178,7 +176,7 @@ fn test_inner_different_networks() {
         vec![bond.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0],
     );
-    let tn_a = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0a, t1a], vec![0, 1]).unwrap();
+    let tn_a = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0a, t1a], vec![0, 1]).unwrap();
 
     let t0b = make_tensor(
         vec![s0.clone(), bond.clone()],
@@ -188,7 +186,7 @@ fn test_inner_different_networks() {
         vec![bond.clone(), s1.clone()],
         vec![0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
     );
-    let tn_b = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0b, t1b], vec![0, 1]).unwrap();
+    let tn_b = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0b, t1b], vec![0, 1]).unwrap();
 
     // Compute inner product via TreeTN method
     let inner_val = tn_a.inner(&tn_b).unwrap();
@@ -231,7 +229,7 @@ fn test_inner_three_nodes() {
 fn test_to_dense_single_node() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![1.0, 2.0, 3.0]);
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0.clone()], vec![0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0.clone()], vec![0]).unwrap();
 
     let dense = tn.to_dense().unwrap();
     assert!(
@@ -252,7 +250,7 @@ fn test_to_dense_two_nodes() {
 
 #[test]
 fn test_to_dense_empty() {
-    let tn = TreeTN::<TensorDynLen, usize>::new();
+    let tn = TreeTN::<IdxTensor, usize>::new();
     let result = tn.to_dense();
     assert!(result.is_err());
 }
@@ -265,7 +263,7 @@ fn test_to_dense_empty() {
 fn test_all_site_indices_single_node_returns_indices() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![1.0, 2.0, 3.0]);
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
     let (indices, vertices) = tn.all_site_indices().unwrap();
     assert_eq!(indices.len(), 1);
@@ -312,7 +310,7 @@ fn test_all_site_indices_three_nodes_returns_indices() {
 fn test_evaluate_single_node_with_dense() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![10.0, 20.0, 30.0]);
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
     let (indices, _vertices) = tn.all_site_indices().unwrap();
 
@@ -390,7 +388,7 @@ fn test_evaluate_two_nodes_complex() {
 
     let t0 = make_complex_tensor(vec![s0.clone(), bond.clone()], vec![a[0], a[1]]);
     let t1 = make_complex_tensor(vec![bond.clone(), s1.clone()], vec![b[0], b[1]]);
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0, t1], vec![0, 1]).unwrap();
 
     let (indices, _vertices) = tn.all_site_indices().unwrap();
     let pos0 = indices.iter().position(|index| index == &s0).unwrap();
@@ -467,7 +465,7 @@ fn test_evaluate_three_nodes_sugar() {
 
 #[test]
 fn test_evaluate_empty() {
-    let tn = TreeTN::<TensorDynLen, usize>::new();
+    let tn = TreeTN::<IdxTensor, usize>::new();
     let data: [usize; 0] = [];
     let shape = [0, 1];
     let values = ColMajorArrayRef::new(&data, &shape).unwrap();
@@ -542,7 +540,7 @@ fn test_evaluate_rejects_missing_indices() {
 fn test_all_site_indices_single_node() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![1.0, 2.0, 3.0]);
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
     let (indices, vertices) = tn.all_site_indices().unwrap();
     assert_eq!(indices.len(), 1);
@@ -595,7 +593,7 @@ fn test_all_site_indices_has_matching_vertices() {
 fn test_evaluate_single_node_sugar() {
     let s0 = idx(3);
     let t0 = make_tensor(vec![s0.clone()], vec![10.0, 20.0, 30.0]);
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![t0], vec![0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![t0], vec![0]).unwrap();
 
     let (indices, _vertices) = tn.all_site_indices().unwrap();
 

--- a/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
+++ b/crates/tensor4all-treetn/tests/repro_swap_truncation.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashMap;
 
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_treetn::{SwapOptions, TreeTN};
 
 /// Orthogonal 4x4 Hadamard/2, column-major flat.
@@ -38,7 +38,7 @@ fn hadamard4() -> Vec<f64> {
 /// 4-site chain "0"-"1"-"2"-"3" whose middle cut 01|23 has singular values
 /// (1, 1e-13, 1e-13, 1e-13).
 fn chain_with_tiny_singular_values() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     DynIndex,
     DynIndex,
     DynIndex,
@@ -64,13 +64,13 @@ fn chain_with_tiny_singular_values() -> (
     let b23 = DynIndex::new_dyn(2);
 
     let t0 =
-        TensorDynLen::from_dense(vec![s0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
-    let t1 = TensorDynLen::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], u).unwrap();
-    let t2 = TensorDynLen::from_dense(vec![b12.clone(), s2.clone(), b23.clone()], m).unwrap();
+        IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![b01.clone(), s1.clone(), b12.clone()], u).unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12.clone(), s2.clone(), b23.clone()], m).unwrap();
     let t3 =
-        TensorDynLen::from_dense(vec![b23.clone(), s3.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+        IdxTensor::from_dense(vec![b23.clone(), s3.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     tn.add_tensor("0".to_string(), t0).unwrap();
     tn.add_tensor("1".to_string(), t1).unwrap();
     tn.add_tensor("2".to_string(), t2).unwrap();
@@ -86,7 +86,7 @@ fn chain_with_tiny_singular_values() -> (
 }
 
 /// Largest non-site bond dimension adjacent to `node`.
-fn bond_dim_at(tn: &TreeTN<TensorDynLen, String>, node: &str, sites: &[&DynIndex]) -> usize {
+fn bond_dim_at(tn: &TreeTN<IdxTensor, String>, node: &str, sites: &[&DynIndex]) -> usize {
     let n = tn.node_index(&node.to_string()).unwrap();
     tn.tensor(n)
         .unwrap()
@@ -157,11 +157,11 @@ fn swap_without_transport_must_not_truncate() {
     let sa = DynIndex::new_dyn(2);
     let sb = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(2);
-    let ta = TensorDynLen::from_dense(vec![sa.clone(), bond.clone()], m).unwrap();
+    let ta = IdxTensor::from_dense(vec![sa.clone(), bond.clone()], m).unwrap();
     let tb =
-        TensorDynLen::from_dense(vec![bond.clone(), sb.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+        IdxTensor::from_dense(vec![bond.clone(), sb.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
 
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     tn.add_tensor("A".to_string(), ta).unwrap();
     tn.add_tensor("B".to_string(), tb).unwrap();
     let na = tn.node_index(&"A".to_string()).unwrap();

--- a/crates/tensor4all-treetn/tests/simplett_bridge.rs
+++ b/crates/tensor4all-treetn/tests/simplett_bridge.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, SimpleTensorTrain};
 use tensor4all_treetn::{
     fix_and_remove_site_from_treetn_chain, insert_onehot_site_in_treetn_chain,
@@ -159,7 +159,7 @@ fn tensor_train_to_treetn_preserves_dense_values() -> Result<()> {
     let (treetn, site_indices) = tensor_train_to_treetn(&tt)?;
     let dense = treetn.contract_to_tensor()?;
     let (values, _shape) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(site_indices.clone(), values)?;
+    let expected = IdxTensor::from_dense(site_indices.clone(), values)?;
 
     assert_eq!(treetn.node_names(), vec![0, 1]);
     assert_eq!(site_indices.len(), tt.len());
@@ -186,7 +186,7 @@ fn tensor_train_to_treetn_supports_complex_scalars() -> Result<()> {
     let (treetn, site_indices) = tensor_train_to_treetn(&tt)?;
     let dense = treetn.contract_to_tensor()?;
     let (values, _shape) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(site_indices, values)?;
+    let expected = IdxTensor::from_dense(site_indices, values)?;
 
     assert!(dense.distance(&expected).unwrap() < 1.0e-12);
     Ok(())
@@ -220,7 +220,7 @@ fn tensor_train_to_treetn_single_site_preserves_dense_values() -> Result<()> {
     let (treetn, site_indices) = tensor_train_to_treetn(&tt)?;
     let dense = treetn.contract_to_tensor()?;
     let (values, _shape) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(site_indices.clone(), values)?;
+    let expected = IdxTensor::from_dense(site_indices.clone(), values)?;
 
     assert_eq!(treetn.node_names(), vec![0]);
     assert_eq!(site_indices.len(), 1);
@@ -235,7 +235,7 @@ fn tensor_train_to_treetn_three_site_preserves_dense_values() -> Result<()> {
     let (treetn, site_indices) = tensor_train_to_treetn(&tt)?;
     let dense = treetn.contract_to_tensor()?;
     let (values, _shape) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(site_indices, values)?;
+    let expected = IdxTensor::from_dense(site_indices, values)?;
 
     assert_eq!(treetn.node_names(), vec![0, 1, 2]);
     assert!(dense.distance(&expected).unwrap() < 1.0e-12);
@@ -282,8 +282,8 @@ fn treetn_to_tensor_train_handles_local_axis_permutations() -> Result<()> {
     let site0 = DynIndex::new_dyn(2);
     let site1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_bond(2)?;
-    let t0 = TensorDynLen::from_dense(vec![bond.clone(), site0], vec![1.0_f64, 3.0, 2.0, 4.0])?;
-    let t1 = TensorDynLen::from_dense(vec![site1, bond], vec![1.0_f64, -1.0, 0.5, 2.0])?;
+    let t0 = IdxTensor::from_dense(vec![bond.clone(), site0], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    let t1 = IdxTensor::from_dense(vec![site1, bond], vec![1.0_f64, -1.0, 0.5, 2.0])?;
     let treetn = TreeTN::from_tensors(vec![t0, t1], vec![0, 1])?;
 
     let roundtrip = treetn_to_tensor_train::<f64>(treetn)?;
@@ -317,7 +317,7 @@ fn insert_onehot_site_in_treetn_chain_prepends_fixed_site() -> Result<()> {
     let result = insert_onehot_site_in_treetn_chain::<f64>(treetn, 0, inserted_site.clone(), 0)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, _) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![inserted_site, old_sites[0].clone(), old_sites[1].clone()],
         vec![
             old_values[0],
@@ -345,7 +345,7 @@ fn insert_onehot_site_in_treetn_chain_preserves_edge_bond_flow() -> Result<()> {
     let result = insert_onehot_site_in_treetn_chain::<f64>(treetn, 1, inserted_site.clone(), 1)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, _) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![old_sites[0].clone(), inserted_site, old_sites[1].clone()],
         vec![
             0.0,
@@ -377,7 +377,7 @@ fn insert_onehot_site_in_treetn_chain_appends_fixed_site() -> Result<()> {
     let result = insert_onehot_site_in_treetn_chain::<f64>(treetn, 2, inserted_site.clone(), 1)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, _) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![old_sites[0].clone(), old_sites[1].clone(), inserted_site],
         vec![
             0.0,
@@ -430,7 +430,7 @@ fn fix_and_remove_site_from_treetn_chain_removes_first_site() -> Result<()> {
     let result = fix_and_remove_site_from_treetn_chain::<f64>(treetn, 0, 1)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, old_dims) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![site_indices[1].clone(), site_indices[2].clone()],
         fixed_removed_dense(&old_values, &old_dims, 0, 1),
     )?;
@@ -452,7 +452,7 @@ fn fix_and_remove_site_from_treetn_chain_removes_middle_site() -> Result<()> {
     let result = fix_and_remove_site_from_treetn_chain::<f64>(treetn, 1, 0)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, old_dims) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![site_indices[0].clone(), site_indices[2].clone()],
         fixed_removed_dense(&old_values, &old_dims, 1, 0),
     )?;
@@ -474,7 +474,7 @@ fn fix_and_remove_site_from_treetn_chain_removes_last_site() -> Result<()> {
     let result = fix_and_remove_site_from_treetn_chain::<f64>(treetn, 2, 1)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, old_dims) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![site_indices[0].clone(), site_indices[1].clone()],
         fixed_removed_dense(&old_values, &old_dims, 2, 1),
     )?;
@@ -497,7 +497,7 @@ fn weighted_remove_site_from_treetn_chain_removes_middle_site() -> Result<()> {
     let result = weighted_remove_site_from_treetn_chain::<f64>(treetn, 1, &weights)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, old_dims) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![site_indices[0].clone(), site_indices[2].clone()],
         weighted_removed_dense(&old_values, &old_dims, 1, &weights),
     )?;
@@ -520,7 +520,7 @@ fn weighted_remove_site_from_treetn_chain_removes_boundary_site() -> Result<()> 
     let result = weighted_remove_site_from_treetn_chain::<f64>(treetn, 2, &weights)?;
     let dense = result.contract_to_tensor()?;
     let (old_values, old_dims) = tt.full_tensor();
-    let expected = TensorDynLen::from_dense(
+    let expected = IdxTensor::from_dense(
         vec![site_indices[0].clone(), site_indices[1].clone()],
         weighted_removed_dense(&old_values, &old_dims, 2, &weights),
     )?;

--- a/crates/tensor4all-treetn/tests/swap_test.rs
+++ b/crates/tensor4all-treetn/tests/swap_test.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use num_complex::Complex64;
-use tensor4all_core::{TensorDynLen, TensorElement};
+use tensor4all_core::{IdxTensor, TensorElement};
 use tensor4all_treetn::{SwapOptions, TreeTN};
 
 // ============================================================================
@@ -12,15 +12,15 @@ use tensor4all_treetn::{SwapOptions, TreeTN};
 
 /// 2-node chain: A -- B with one site index each. Returns (tn, site_at_A, site_at_B).
 fn two_node_chain<T: TensorElement + From<f64>>() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let s0 = tensor4all_core::DynIndex::new_dyn(2);
     let s1 = tensor4all_core::DynIndex::new_dyn(2);
     let bond = tensor4all_core::DynIndex::new_dyn(3);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
             .into_iter()
@@ -28,7 +28,7 @@ fn two_node_chain<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
             .into_iter()
@@ -46,18 +46,18 @@ fn two_node_chain<T: TensorElement + From<f64>>() -> (
 
 /// 3-node chain: "0" -- "1" -- "2" with one site index each.
 fn three_node_chain<T: TensorElement + From<f64>>() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let s0 = tensor4all_core::DynIndex::new_dyn(2);
     let s1 = tensor4all_core::DynIndex::new_dyn(2);
     let s2 = tensor4all_core::DynIndex::new_dyn(2);
     let b01 = tensor4all_core::DynIndex::new_dyn(3);
     let b12 = tensor4all_core::DynIndex::new_dyn(3);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
             .into_iter()
@@ -65,7 +65,7 @@ fn three_node_chain<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone(), b12.clone()],
         vec![
             1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
@@ -76,7 +76,7 @@ fn three_node_chain<T: TensorElement + From<f64>>() -> (
         .collect(),
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b12.clone(), s2.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
             .into_iter()
@@ -97,13 +97,13 @@ fn three_node_chain<T: TensorElement + From<f64>>() -> (
 
 /// 4-node chain: "0" -- "1" -- "2" -- "3" with one site index each.
 fn four_node_chain<T: TensorElement + From<f64>>() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let s0 = tensor4all_core::DynIndex::new_dyn(2);
     let s1 = tensor4all_core::DynIndex::new_dyn(2);
     let s2 = tensor4all_core::DynIndex::new_dyn(2);
@@ -111,12 +111,12 @@ fn four_node_chain<T: TensorElement + From<f64>>() -> (
     let b01 = tensor4all_core::DynIndex::new_dyn(2);
     let b12 = tensor4all_core::DynIndex::new_dyn(2);
     let b23 = tensor4all_core::DynIndex::new_dyn(2);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone()],
         vec![1.0, 2.0, 3.0, 4.0].into_iter().map(T::from).collect(),
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone(), b12.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
             .into_iter()
@@ -124,7 +124,7 @@ fn four_node_chain<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b12.clone(), s2.clone(), b23.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
             .into_iter()
@@ -132,7 +132,7 @@ fn four_node_chain<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t3 = TensorDynLen::from_dense(
+    let t3 = IdxTensor::from_dense(
         vec![b23.clone(), s3.clone()],
         vec![1.0, 2.0, 3.0, 4.0].into_iter().map(T::from).collect(),
     )
@@ -153,13 +153,13 @@ fn four_node_chain<T: TensorElement + From<f64>>() -> (
 
 /// 4-node chain with sites x0,x1 at nodes "0","1" and y0,y1 at nodes "2","3". R=2.
 fn chain_2r_interleave<T: TensorElement + From<f64>>() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     tensor4all_core::DynIndex, // x0
     tensor4all_core::DynIndex, // x1
     tensor4all_core::DynIndex, // y0
     tensor4all_core::DynIndex, // y1
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let x0 = tensor4all_core::DynIndex::new_dyn(2);
     let x1 = tensor4all_core::DynIndex::new_dyn(2);
     let y0 = tensor4all_core::DynIndex::new_dyn(2);
@@ -167,12 +167,12 @@ fn chain_2r_interleave<T: TensorElement + From<f64>>() -> (
     let b01 = tensor4all_core::DynIndex::new_dyn(2);
     let b12 = tensor4all_core::DynIndex::new_dyn(2);
     let b23 = tensor4all_core::DynIndex::new_dyn(2);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![x0.clone(), b01.clone()],
         vec![1.0, 0.0, 0.0, 1.0].into_iter().map(T::from).collect(),
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), x1.clone(), b12.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
             .into_iter()
@@ -180,7 +180,7 @@ fn chain_2r_interleave<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b12.clone(), y0.clone(), b23.clone()],
         vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]
             .into_iter()
@@ -188,7 +188,7 @@ fn chain_2r_interleave<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t3 = TensorDynLen::from_dense(
+    let t3 = IdxTensor::from_dense(
         vec![b23.clone(), y1.clone()],
         vec![1.0, 0.0, 0.0, 1.0].into_iter().map(T::from).collect(),
     )
@@ -209,19 +209,19 @@ fn chain_2r_interleave<T: TensorElement + From<f64>>() -> (
 
 /// Y-shape: center "C", leaves "L0", "L1", "L2". Each leaf has one site index.
 fn y_shape_tree<T: TensorElement + From<f64>>() -> (
-    TreeTN<TensorDynLen, String>,
+    TreeTN<IdxTensor, String>,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
     tensor4all_core::DynIndex,
 ) {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let s0 = tensor4all_core::DynIndex::new_dyn(2);
     let s1 = tensor4all_core::DynIndex::new_dyn(2);
     let s2 = tensor4all_core::DynIndex::new_dyn(2);
     let bc0 = tensor4all_core::DynIndex::new_dyn(2);
     let bc1 = tensor4all_core::DynIndex::new_dyn(2);
     let bc2 = tensor4all_core::DynIndex::new_dyn(2);
-    let t_center = TensorDynLen::from_dense(
+    let t_center = IdxTensor::from_dense(
         vec![bc0.clone(), bc1.clone(), bc2.clone()],
         vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
             .into_iter()
@@ -229,17 +229,17 @@ fn y_shape_tree<T: TensorElement + From<f64>>() -> (
             .collect(),
     )
     .unwrap();
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![bc0.clone(), s0.clone()],
         vec![1.0, 0.0, 0.0, 1.0].into_iter().map(T::from).collect(),
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bc1.clone(), s1.clone()],
         vec![1.0, 0.0, 0.0, 1.0].into_iter().map(T::from).collect(),
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![bc2.clone(), s2.clone()],
         vec![1.0, 0.0, 0.0, 1.0].into_iter().map(T::from).collect(),
     )
@@ -434,17 +434,17 @@ fn test_swap_by_index_alias_matches_swap_site_indices_generic<T: TensorElement +
 
 #[test]
 fn test_swap_by_index_distinguishes_same_id_prime_pair() {
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
     let s = tensor4all_core::DynIndex::new_dyn(2);
     let s_prime = s.prime();
     let t = tensor4all_core::DynIndex::new_dyn(2);
     let bond = tensor4all_core::DynIndex::new_dyn(1);
-    let a = TensorDynLen::from_dense(
+    let a = IdxTensor::from_dense(
         vec![s.clone(), s_prime.clone(), bond.clone()],
         vec![1.0, 2.0, 3.0, 4.0],
     )
     .unwrap();
-    let b = TensorDynLen::from_dense(vec![bond.clone(), t.clone()], vec![1.0, 1.0]).unwrap();
+    let b = IdxTensor::from_dense(vec![bond.clone(), t.clone()], vec![1.0, 1.0]).unwrap();
     tn.add_tensor("A".to_string(), a).unwrap();
     tn.add_tensor("B".to_string(), b).unwrap();
     let na = tn.node_index(&"A".to_string()).unwrap();

--- a/crates/tensor4all-treetn/tests/tdvp.rs
+++ b/crates/tensor4all-treetn/tests/tdvp.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use num_complex::Complex64;
 use tensor4all_core::krylov::HermitianKrylovExpmOptions;
 use tensor4all_core::{
-    DynIndex, FactorizeOptions, IndexLike, SvdTruncationPolicy, TensorContractionLike,
-    TensorDynLen, TensorIndex,
+    DynIndex, FactorizeOptions, IdxTensor, IndexLike, SvdTruncationPolicy, TensorContractionLike,
+    TensorIndex,
 };
 use tensor4all_tensorbackend::{hermitian_eigendecomposition, Matrix};
 use tensor4all_treetn::{
@@ -12,49 +12,49 @@ use tensor4all_treetn::{
     TdvpError, TdvpOptions, TreeTN, TreeTopology,
 };
 
-fn chain_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 2]) {
+fn chain_state() -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 2]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let bond = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), bond.clone()],
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![bond.clone(), s1.clone()],
         vec![Complex64::new(0.5, 0.0), Complex64::new(-1.0, 0.0)],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     state.connect(n0, &bond, n1, &bond).unwrap();
     (state, [s0, s1])
 }
 
-fn star_state() -> (TreeTN<TensorDynLen, &'static str>, [DynIndex; 3]) {
+fn star_state() -> (TreeTN<IdxTensor, &'static str>, [DynIndex; 3]) {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
     let s2 = DynIndex::new_dyn(2);
     let b01 = DynIndex::new_dyn(1);
     let b02 = DynIndex::new_dyn(1);
-    let t0 = TensorDynLen::from_dense(
+    let t0 = IdxTensor::from_dense(
         vec![s0.clone(), b01.clone(), b02.clone()],
         vec![Complex64::new(1.0, 0.0), Complex64::new(-0.25, 0.0)],
     )
     .unwrap();
-    let t1 = TensorDynLen::from_dense(
+    let t1 = IdxTensor::from_dense(
         vec![b01.clone(), s1.clone()],
         vec![Complex64::new(0.5, 0.0), Complex64::new(1.5, 0.0)],
     )
     .unwrap();
-    let t2 = TensorDynLen::from_dense(
+    let t2 = IdxTensor::from_dense(
         vec![b02.clone(), s2.clone()],
         vec![Complex64::new(-2.0, 0.0), Complex64::new(0.75, 0.0)],
     )
     .unwrap();
-    let mut state = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut state = TreeTN::<IdxTensor, &'static str>::new();
     let n0 = state.add_tensor("site0", t0).unwrap();
     let n1 = state.add_tensor("site1", t1).unwrap();
     let n2 = state.add_tensor("site2", t2).unwrap();
@@ -67,7 +67,7 @@ fn identity_operator(
     state_sites: &[DynIndex],
     node_names: &[&'static str],
     edges: &[(&'static str, &'static str)],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let mut tensors = HashMap::new();
     let mut node_indices = HashMap::new();
     let mut input_mapping = HashMap::new();
@@ -98,7 +98,7 @@ fn identity_operator(
         op_bonds.insert((a, b), DynIndex::new_dyn(1));
     }
 
-    let mut mpo = TreeTN::<TensorDynLen, &'static str>::new();
+    let mut mpo = TreeTN::<IdxTensor, &'static str>::new();
     for &name in node_names {
         let (input, output) = tensors.get(name).unwrap();
         let mut inds = Vec::new();
@@ -120,7 +120,7 @@ fn identity_operator(
             data[col_major_offset(&coord, &dims)] = Complex64::new(1.0, 0.0);
         }
         let node = mpo
-            .add_tensor(name, TensorDynLen::from_dense(inds, data).unwrap())
+            .add_tensor(name, IdxTensor::from_dense(inds, data).unwrap())
             .unwrap();
         node_indices.insert(name, node);
     }
@@ -143,7 +143,7 @@ fn diagonal_sum_z_operator(
     node_names: &[&'static str],
     edges: &[(&'static str, &'static str)],
     coeffs: &[f64],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let mut dense_indices = Vec::new();
     let mut topology_nodes = HashMap::new();
     let mut input_mapping = HashMap::new();
@@ -185,7 +185,7 @@ fn diagonal_sum_z_operator(
         data[col_major_offset(&coord, &dims)] = Complex64::new(energy, 0.0);
     }
 
-    let dense = TensorDynLen::from_dense(dense_indices, data).unwrap();
+    let dense = IdxTensor::from_dense(dense_indices, data).unwrap();
     let topology = TreeTopology::new(topology_nodes, edges.to_vec());
     let mpo = factorize_tensor_to_treetn_with(
         &dense,
@@ -202,7 +202,7 @@ fn heisenberg_operator(
     state_sites: &[DynIndex],
     node_names: &[&'static str],
     edges: &[(&'static str, &'static str)],
-) -> LinearOperator<TensorDynLen, &'static str> {
+) -> LinearOperator<IdxTensor, &'static str> {
     let mut dense_indices = Vec::new();
     let mut topology_nodes = HashMap::new();
     let mut input_mapping = HashMap::new();
@@ -269,7 +269,7 @@ fn heisenberg_operator(
         }
     }
 
-    let dense = TensorDynLen::from_dense(dense_indices, data).unwrap();
+    let dense = IdxTensor::from_dense(dense_indices, data).unwrap();
     let topology = TreeTopology::new(topology_nodes, edges.to_vec());
     let mpo = factorize_tensor_to_treetn_with(
         &dense,
@@ -344,7 +344,7 @@ fn exact_evolve(
     result
 }
 
-fn state_vector(state: &TreeTN<TensorDynLen, &'static str>, sites: &[DynIndex]) -> Vec<Complex64> {
+fn state_vector(state: &TreeTN<IdxTensor, &'static str>, sites: &[DynIndex]) -> Vec<Complex64> {
     state
         .contract_to_tensor()
         .unwrap()
@@ -374,8 +374,8 @@ fn col_major_offset(coord: &[usize], dims: &[usize]) -> usize {
 }
 
 fn assert_phase_evolution(
-    before: &TensorDynLen,
-    after: &TensorDynLen,
+    before: &IdxTensor,
+    after: &IdxTensor,
     exponent: Complex64,
     tolerance: f64,
 ) {
@@ -395,8 +395,8 @@ fn assert_phase_evolution(
 }
 
 fn assert_diagonal_sum_z_evolution(
-    before: &TensorDynLen,
-    after: &TensorDynLen,
+    before: &IdxTensor,
+    after: &IdxTensor,
     exponent: Complex64,
     coeffs: &[f64],
     tolerance: f64,
@@ -537,14 +537,13 @@ fn two_site_tdvp_sum_z_star_matches_exact_dense_phase() {
 #[test]
 fn one_site_tdvp_identity_single_node_matches_global_phase() {
     let site = DynIndex::new_dyn(2);
-    let state_tensor = TensorDynLen::from_dense(
+    let state_tensor = IdxTensor::from_dense(
         vec![site.clone()],
         vec![Complex64::new(0.75, 0.0), Complex64::new(-1.25, 0.0)],
     )
     .unwrap();
     let state =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
-            .unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![state_tensor], vec!["site0"]).unwrap();
     let before = state.contract_to_tensor().unwrap();
     let operator = identity_operator(&[site], &["site0"], &[]);
     let exponent = Complex64::new(0.0, -0.3);
@@ -857,14 +856,13 @@ fn tdvp_rejects_missing_center_and_topology_mismatch() {
 #[test]
 fn two_site_tdvp_rejects_single_node_empty_sweep() {
     let site = DynIndex::new_dyn(2);
-    let state_tensor = TensorDynLen::from_dense(
+    let state_tensor = IdxTensor::from_dense(
         vec![site.clone()],
         vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0)],
     )
     .unwrap();
     let state =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
-            .unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![state_tensor], vec!["site0"]).unwrap();
     let operator = identity_operator(&[site], &["site0"], &[]);
 
     let err = tdvp(
@@ -900,18 +898,17 @@ fn two_site_tdvp_accepts_truncation_options() {
 #[test]
 fn tdvp_with_treetn_operator_single_node_identity_runs() {
     let site = DynIndex::new_dyn(2);
-    let state_tensor = TensorDynLen::from_dense(
+    let state_tensor = IdxTensor::from_dense(
         vec![site.clone()],
         vec![Complex64::new(0.6, 0.0), Complex64::new(-0.8, 0.0)],
     )
     .unwrap();
     let state =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
-            .unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![state_tensor], vec!["site0"]).unwrap();
 
     let input = DynIndex::new_dyn(2);
     let output = DynIndex::new_dyn(2);
-    let op_tensor = TensorDynLen::from_dense(
+    let op_tensor = IdxTensor::from_dense(
         vec![output, input],
         vec![
             Complex64::new(1.0, 0.0),
@@ -922,7 +919,7 @@ fn tdvp_with_treetn_operator_single_node_identity_runs() {
     )
     .unwrap();
     let operator =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![op_tensor], vec!["site0"]).unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![op_tensor], vec!["site0"]).unwrap();
 
     let result = tdvp_with_treetn_operator(
         &operator,

--- a/crates/tensor4all-treetn/tests/tdvp_profile.rs
+++ b/crates/tensor4all-treetn/tests/tdvp_profile.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, TensorContractionLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, TensorContractionLike, TensorIndex};
 use tensor4all_treetn::{tdvp, IndexMapping, LinearOperator, TdvpOptions, TreeTN};
 
 #[test]
@@ -9,19 +9,18 @@ fn profiling_env_preserves_single_site_identity_evolution() {
     std::env::set_var("T4A_PROFILE_TDVP", "1");
 
     let site = DynIndex::new_dyn(2);
-    let state_tensor = TensorDynLen::from_dense(
+    let state_tensor = IdxTensor::from_dense(
         vec![site.clone()],
         vec![Complex64::new(0.75, 0.5), Complex64::new(-1.25, 0.25)],
     )
     .unwrap();
     let state =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![state_tensor], vec!["site0"])
-            .unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![state_tensor], vec!["site0"]).unwrap();
     let before = state.contract_to_tensor().unwrap();
 
     let input = DynIndex::new_dyn(2);
     let output = DynIndex::new_dyn(2);
-    let op_tensor = TensorDynLen::from_dense(
+    let op_tensor = IdxTensor::from_dense(
         vec![output.clone(), input.clone()],
         vec![
             Complex64::new(1.0, 0.0),
@@ -32,7 +31,7 @@ fn profiling_env_preserves_single_site_identity_evolution() {
     )
     .unwrap();
     let mpo =
-        TreeTN::<TensorDynLen, &'static str>::from_tensors(vec![op_tensor], vec!["site0"]).unwrap();
+        TreeTN::<IdxTensor, &'static str>::from_tensors(vec![op_tensor], vec!["site0"]).unwrap();
     let operator = LinearOperator::new(
         mpo,
         HashMap::from([(

--- a/crates/tensor4all-treetn/tests/tensor_like.rs
+++ b/crates/tensor4all-treetn/tests/tensor_like.rs
@@ -6,25 +6,25 @@
 //! - `contract_to_tensor()` instead of `to_tensor()`
 //!
 //! Migrated from tensor4all-rs main branch with type adjustments:
-//! - TreeTN<DynId, NoSymmSpace, String> -> TreeTN<TensorDynLen, String>
+//! - TreeTN<DynId, NoSymmSpace, String> -> TreeTN<IdxTensor, String>
 //! - Index<DynId> -> DynIndex
-//! - TensorDynLen<DynId, NoSymmSpace> -> TensorDynLen
+//! - IdxTensor<DynId, NoSymmSpace> -> IdxTensor
 //! - idx.id -> idx.id() (IndexLike trait method)
 
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen, TensorIndex};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorIndex};
 use tensor4all_treetn::TreeTN;
 
 /// Helper to create a simple tensor with given indices
-fn make_tensor(indices: Vec<DynIndex>) -> TensorDynLen {
+fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
     let dims: Vec<usize> = indices.iter().map(|idx| idx.dim()).collect();
     let total_size: usize = dims.iter().product();
     let data: Vec<f64> = (0..total_size).map(|i| i as f64).collect();
-    TensorDynLen::from_dense(indices, data).unwrap()
+    IdxTensor::from_dense(indices, data).unwrap()
 }
 
 /// Helper to collect all site (physical) indices from a TreeTN.
 /// This corresponds to `external_indices()` in the original TensorLike trait.
-fn collect_site_indices(tn: &TreeTN<TensorDynLen, String>) -> Vec<DynIndex> {
+fn collect_site_indices(tn: &TreeTN<IdxTensor, String>) -> Vec<DynIndex> {
     let mut indices = Vec::new();
     for node_name in tn.node_names() {
         if let Some(site_space) = tn.site_space(&node_name) {
@@ -43,7 +43,7 @@ fn test_treetn_site_indices_single_node() {
 
     // Use from_tensors to create the network
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     // Site indices should be all indices (since no connections)
     let site_indices = collect_site_indices(&tn);
@@ -70,7 +70,7 @@ fn test_treetn_site_indices_connected_nodes() {
     let tensor_b = make_tensor(vec![bond_ab.clone(), j.clone()]);
 
     // from_tensors automatically connects tensors that share common indices
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tensor_a, tensor_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -96,7 +96,7 @@ fn test_treetn_num_site_indices() {
     let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
     let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tensor_a, tensor_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -115,16 +115,16 @@ fn test_treetn_contract_to_tensor() {
 
     // Tensor A: 2x2 with values
     let tensor_a =
-        TensorDynLen::from_dense(vec![i.clone(), bond.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap(); // identity-like
+        IdxTensor::from_dense(vec![i.clone(), bond.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap(); // identity-like
 
     // Tensor B: 2x3 with values
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![bond.clone(), j.clone()],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     )
     .unwrap();
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tensor_a, tensor_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -160,7 +160,7 @@ fn test_treetn_site_indices_deterministic_ordering() {
     // C has site index idx_c and bond to A
     // A has site index idx_a and bonds to C and B
     // B has site index idx_b and bond to A
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![
             make_tensor(vec![idx_c.clone(), bond_ca.clone()]),
             make_tensor(vec![bond_ca.clone(), idx_a.clone(), bond_ab.clone()]),
@@ -212,7 +212,7 @@ fn test_treetn_external_indices_via_trait() {
     let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
     let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tensor_a, tensor_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -239,7 +239,7 @@ fn test_treetn_replaceind_site_index() {
     let tensor_a = make_tensor(vec![i.clone(), bond.clone()]);
     let tensor_b = make_tensor(vec![bond.clone(), j.clone()]);
 
-    let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
         vec![tensor_a, tensor_b],
         vec!["A".to_string(), "B".to_string()],
     )
@@ -320,7 +320,7 @@ fn test_treetn_replaceind_not_found() {
 
     let tensor = make_tensor(vec![i.clone(), j.clone()]);
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     // Try to replace an index that doesn't exist
     let unknown = DynIndex::new_dyn(5);
@@ -338,7 +338,7 @@ fn test_treetn_replaceind_dimension_mismatch() {
 
     let tensor = make_tensor(vec![i.clone(), j.clone()]);
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     // Try to replace with index of different dimension
     let wrong_size = DynIndex::new_dyn(5);
@@ -366,7 +366,7 @@ fn test_treetn_replace_indices_multiple() {
 
     let tensor = make_tensor(vec![i.clone(), j.clone(), k.clone()]);
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     // Replace i and j with new indices
     let i_new = DynIndex::new_dyn(2);
@@ -393,7 +393,7 @@ fn test_treetn_external_indices_single_node_multiple_indices() {
 
     let tensor = make_tensor(indices.clone());
     let tn =
-        TreeTN::<TensorDynLen, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+        TreeTN::<IdxTensor, String>::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
 
     let ext = tn.external_indices();
     assert_eq!(ext.len(), 5);

--- a/crates/tensor4all-treetn/tests/unfuse.rs
+++ b/crates/tensor4all-treetn/tests/unfuse.rs
@@ -1,13 +1,13 @@
 use std::collections::HashSet;
 
-use tensor4all_core::{DynIndex, IndexLike, LinearizationOrder, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, LinearizationOrder};
 use tensor4all_treetn::{SiteIndexNetwork, TreeTN};
 
 #[test]
 fn replace_site_index_with_indices_preserves_dense_tensor_values() {
     let fused = DynIndex::new_dyn(4);
-    let tensor = TensorDynLen::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    let tensor = IdxTensor::from_dense(vec![fused.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
     let left = DynIndex::new_dyn(2);
     let right = DynIndex::new_dyn(2);
 
@@ -21,8 +21,7 @@ fn replace_site_index_with_indices_preserves_dense_tensor_values() {
 
     let dense = unfused.contract_to_tensor().unwrap();
     let expected =
-        TensorDynLen::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0])
-            .unwrap();
+        IdxTensor::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     assert!(dense.distance(&expected).unwrap() < 1.0e-12);
 
     let (site_indices, _) = unfused.all_site_indices().unwrap();
@@ -41,12 +40,12 @@ fn split_to_preserves_sparse_tensor_with_zero_leading_qr_row() {
 
     let mut data = vec![0.0; 16];
     data[6] = 1.0;
-    let tensor = TensorDynLen::from_dense(
+    let tensor = IdxTensor::from_dense(
         vec![out0.clone(), out1.clone(), in0.clone(), in1.clone()],
         data,
     )
     .unwrap();
-    let tn = TreeTN::<TensorDynLen, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
+    let tn = TreeTN::<IdxTensor, usize>::from_tensors(vec![tensor], vec![0]).unwrap();
 
     let mut target = SiteIndexNetwork::<usize, DynIndex>::new();
     target

--- a/docs/book/src/architecture.md
+++ b/docs/book/src/architecture.md
@@ -80,7 +80,7 @@ operation names are unified across crates:
   `tensor4all-simplett`.)
 - **Densification**: `full_tensor` materializes a tensor train/MPO into a flat
   column-major buffer plus shape; `to_dense` materializes a single tensor into
-  a dense `TensorDynLen`. The distinction is intentional (whole-TT vs
+  a dense `IdxTensor`. The distinction is intentional (whole-TT vs
   one-tensor).
 - **Canonicalization**: `treetn` uses `canonicalize` / `canonicalize_mut`;
   `itensorlike` uses `orthogonalize` (ITensors.jl-compatible vocabulary) for
@@ -99,7 +99,7 @@ naming trap that PR 3 resolves:
 | Type | Crate | Representation | Use when |
 |------|-------|----------------|----------|
 | `SimpleTensorTrain<T>` | `tensor4all-simplett` | positional cores (`Tensor3<T>`), no named indices | lightweight create/evaluate/compress |
-| `TensorTrain` | `tensor4all-itensorlike` | `TreeTN<TensorDynLen, usize>` wrapper with orthogonality tracking | ITensors.jl-style interface |
+| `TensorTrain` | `tensor4all-itensorlike` | `TreeTN<IdxTensor, usize>` wrapper with orthogonality tracking | ITensors.jl-style interface |
 
 Rules:
 

--- a/docs/book/src/conventions.md
+++ b/docs/book/src/conventions.md
@@ -54,14 +54,14 @@ context).
 | ITensors.jl | tensor4all-rs |
 |-------------|---------------|
 | `Index{Int}` | `Index<Id, NoSymmSpace>` |
-| `ITensor` | `TensorDynLen` |
+| `ITensor` | `IdxTensor` |
 | `Dense` | eager dense payload; `Storage` snapshot for `f64`/`Complex64` |
 | `Diag` | compact `Storage` for `f64`/`Complex64`, eager diagonal payload for `f32`/`Complex32` |
 | `A * B` | `a.contract(&b)` |
 
 ## Scalar Types
 
-`TensorDynLen` supports four scalar types:
+`IdxTensor` supports four scalar types:
 
 - `f32` — single-precision real
 - `f64` — double-precision real

--- a/docs/book/src/guides/hdf5-serialization.md
+++ b/docs/book/src/guides/hdf5-serialization.md
@@ -5,7 +5,7 @@ HDF5 files. Three storage schemas are supported:
 
 | Type | Schema | Notes |
 |------|--------|-------|
-| [`TensorDynLen`](rustdoc/tensor4all_core/struct.TensorDynLen.html) | `ITensor` | ITensors.jl compatible |
+| [`IdxTensor`](rustdoc/tensor4all_core/struct.IdxTensor.html) | `ITensor` | ITensors.jl compatible |
 | [`TensorTrain`](rustdoc/tensor4all_itensorlike/struct.TensorTrain.html) | `MPS` | ITensorMPS.jl compatible |
 | [`TreeTN`](rustdoc/tensor4all_treetn/struct.TreeTN.html) | `TreeTN` (v1) | tensor4all-rs schema; no ITensorNetworks.jl equivalent exists |
 
@@ -41,7 +41,7 @@ Two design decisions keep the schema minimal:
 
 ```rust
 # fn main() -> anyhow::Result<()> {
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_hdf5::{load_treetn, save_treetn};
 use tensor4all_treetn::TreeTN;
 
@@ -52,11 +52,11 @@ let s2 = DynIndex::new_dyn(2);
 let b01 = DynIndex::new_dyn(4);
 let b12 = DynIndex::new_dyn(4);
 
-let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
-let t1 = TensorDynLen::from_dense(vec![b01, s1, b12.clone()], vec![2.0; 32])?;
-let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![3.0; 8])?;
+let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0; 8])?;
+let t1 = IdxTensor::from_dense(vec![b01, s1, b12.clone()], vec![2.0; 32])?;
+let t2 = IdxTensor::from_dense(vec![b12, s2], vec![3.0; 8])?;
 
-let tn = TreeTN::<TensorDynLen, String>::from_tensors(
+let tn = TreeTN::<IdxTensor, String>::from_tensors(
     vec![t0, t1, t2],
     vec!["left".to_string(), "center".to_string(), "right".to_string()],
 )?;

--- a/docs/book/src/guides/tensor-basics.md
+++ b/docs/book/src/guides/tensor-basics.md
@@ -52,9 +52,9 @@ assert_eq!(site.plev(), 0);
 assert_eq!(bra.plev(), 1);
 ```
 
-## Tensor (TensorDynLen)
+## Tensor (IdxTensor)
 
-`TensorDynLen` is a dynamic-rank tensor parameterized by a list of `Index`
+`IdxTensor` is a dynamic-rank tensor parameterized by a list of `Index`
 values and backed by compact storage that may be dense, diagonal, or explicitly
 structured. Each index uniquely identifies an axis; there is no fixed axis
 ordering in the abstract sense — operations match axes by index identity.
@@ -62,7 +62,7 @@ ordering in the abstract sense — operations match axes by index identity.
 ### Creating tensors
 
 ```rust
-use tensor4all_core::{TensorDynLen, Index};
+use tensor4all_core::{IdxTensor, Index};
 use tensor4all_core::index::DynId;
 
 let i = Index::new_dyn(2);
@@ -70,30 +70,30 @@ let j = Index::new_dyn(3);
 
 // From explicit column-major data (2×3 tensor, 6 elements).
 let data = vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
-let t = TensorDynLen::from_dense(vec![i.clone(), j.clone()], data).unwrap();
+let t = IdxTensor::from_dense(vec![i.clone(), j.clone()], data).unwrap();
 assert_eq!(t.dims(), vec![2, 3]);
 
 // All-zeros tensor.
-let zeros = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+let zeros = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
 
 // Random tensor (standard normal).
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 let mut rng = ChaCha8Rng::seed_from_u64(42);
-let rand_t: TensorDynLen =
-    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
+let rand_t: IdxTensor =
+    IdxTensor::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
 assert_eq!(rand_t.dims(), vec![2, 3]);
 ```
 
 ### Extracting data
 
 ```rust
-use tensor4all_core::{TensorDynLen, Index};
+use tensor4all_core::{IdxTensor, Index};
 use tensor4all_core::index::DynId;
 
 let i = Index::new_dyn(2);
 let data = vec![10.0_f64, 20.0];
-let t = TensorDynLen::from_dense(vec![i], data).unwrap();
+let t = IdxTensor::from_dense(vec![i], data).unwrap();
 
 // Extract all elements in column-major order.
 let out: Vec<f64> = t.to_vec().unwrap();
@@ -112,7 +112,7 @@ Think of it as a generalization of matrix multiplication.
 ### Pairwise contraction
 
 ```rust
-use tensor4all_core::{TensorDynLen, Index, contract};
+use tensor4all_core::{IdxTensor, Index, contract};
 use tensor4all_core::index::DynId;
 
 // A[i,j] and B[j,k] — contracting over j gives C[i,k].
@@ -120,8 +120,8 @@ let i = Index::new_dyn(2);
 let j = Index::new_dyn(3);
 let k = Index::new_dyn(4);
 
-let a = TensorDynLen::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
-let b = TensorDynLen::zeros::<f64>(vec![j.clone(), k.clone()]).unwrap();
+let a = IdxTensor::zeros::<f64>(vec![i.clone(), j.clone()]).unwrap();
+let b = IdxTensor::zeros::<f64>(vec![j.clone(), k.clone()]).unwrap();
 
 let c = contract(&[&a, &b]).unwrap();
 assert_eq!(c.dims(), vec![2, 4]);  // j is summed away
@@ -135,7 +135,7 @@ pieces is intended.
 
 ```rust
 use tensor4all_core::{
-    TensorDynLen, Index, contract, outer_product,
+    IdxTensor, Index, contract, outer_product,
 };
 use tensor4all_core::index::DynId;
 
@@ -148,12 +148,12 @@ let mut rng = {
     use rand::SeedableRng;
     rand_chacha::ChaCha8Rng::seed_from_u64(0)
 };
-let a: TensorDynLen =
-    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
-let b: TensorDynLen =
-    TensorDynLen::random::<f64, _>(&mut rng, vec![j.clone(), k.clone()]).unwrap();
-let c: TensorDynLen =
-    TensorDynLen::random::<f64, _>(&mut rng, vec![k.clone(), l.clone()]).unwrap();
+let a: IdxTensor =
+    IdxTensor::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
+let b: IdxTensor =
+    IdxTensor::random::<f64, _>(&mut rng, vec![j.clone(), k.clone()]).unwrap();
+let c: IdxTensor =
+    IdxTensor::random::<f64, _>(&mut rng, vec![k.clone(), l.clone()]).unwrap();
 
 // Contract A(i,j) * B(j,k) * C(k,l) -> result(i,l)
 let result = contract(&[&a, &b, &c]).unwrap();
@@ -173,7 +173,7 @@ factor connected by a new bond index.
 ### SVD with truncation
 
 ```rust
-use tensor4all_core::{TensorDynLen, Index, factorize, FactorizeOptions, SvdTruncationPolicy};
+use tensor4all_core::{IdxTensor, Index, factorize, FactorizeOptions, SvdTruncationPolicy};
 use tensor4all_core::index::DynId;
 
 let i = Index::new_dyn(4);
@@ -183,8 +183,8 @@ let mut rng = {
     use rand::SeedableRng;
     rand_chacha::ChaCha8Rng::seed_from_u64(1)
 };
-let t: TensorDynLen =
-    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
+let t: IdxTensor =
+    IdxTensor::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
 
 // SVD: split along i | j, discarding singular values below the chosen policy threshold.
 let opts = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1e-10));
@@ -205,7 +205,7 @@ assert!(result_capped.rank <= 2);
 ### QR decomposition
 
 ```rust
-use tensor4all_core::{TensorDynLen, Index, factorize, FactorizeOptions};
+use tensor4all_core::{IdxTensor, Index, factorize, FactorizeOptions};
 use tensor4all_core::index::DynId;
 
 let i = Index::new_dyn(4);
@@ -215,8 +215,8 @@ let mut rng = {
     use rand::SeedableRng;
     rand_chacha::ChaCha8Rng::seed_from_u64(2)
 };
-let t: TensorDynLen =
-    TensorDynLen::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
+let t: IdxTensor =
+    IdxTensor::random::<f64, _>(&mut rng, vec![i.clone(), j.clone()]).unwrap();
 
 // QR: left factor is orthogonal (Q), right factor is upper-triangular (R).
 let opts = FactorizeOptions::qr();

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -142,7 +142,7 @@ ordering.
 
 > **Key conventions**
 > - Sites are **0-indexed** (Julia uses 1-indexed).
-> - `TensorDynLen::from_dense` expects data in **column-major** (Fortran) order.
+> - `IdxTensor::from_dense` expects data in **column-major** (Fortran) order.
 > - `inner()` computes `<self|other>` with complex conjugation on `self`.
 
 ### Creating and orthogonalizing
@@ -159,15 +159,15 @@ let b01 = DynIndex::new_bond(2)?;
 let b12 = DynIndex::new_bond(2)?;
 
 // Build site tensors (column-major data)
-let t0 = TensorDynLen::from_dense(
+let t0 = IdxTensor::from_dense(
     vec![s0.clone(), b01.clone()],
     vec![1.0_f64, 0.0, 0.0, 1.0],
 )?;
-let t1 = TensorDynLen::from_dense(
+let t1 = IdxTensor::from_dense(
     vec![b01.clone(), s1.clone(), b12.clone()],
     vec![1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0],
 )?;
-let t2 = TensorDynLen::from_dense(
+let t2 = IdxTensor::from_dense(
     vec![b12.clone(), s2.clone()],
     vec![1.0, 0.0, 0.0, 1.0],
 )?;
@@ -198,15 +198,15 @@ After orthogonalization you can truncate bond dimensions by SVD:
 # let s2 = DynIndex::new_dyn(2);
 # let b01 = DynIndex::new_bond(4)?;
 # let b12 = DynIndex::new_bond(4)?;
-# let t0 = TensorDynLen::from_dense(
+# let t0 = IdxTensor::from_dense(
 #     vec![s0, b01.clone()],
 #     (0..8).map(|i| i as f64).collect(),
 # )?;
-# let t1 = TensorDynLen::from_dense(
+# let t1 = IdxTensor::from_dense(
 #     vec![b01, s1, b12.clone()],
 #     (0..32).map(|i| i as f64).collect(),
 # )?;
-# let t2 = TensorDynLen::from_dense(
+# let t2 = IdxTensor::from_dense(
 #     vec![b12, s2],
 #     (0..8).map(|i| i as f64).collect(),
 # )?;
@@ -234,11 +234,11 @@ To emulate ITensor-style discarded-weight cutoffs, use
 # let s0 = DynIndex::new_dyn(2);
 # let s1 = DynIndex::new_dyn(2);
 # let b = DynIndex::new_bond(2)?;
-# let t0 = TensorDynLen::from_dense(
+# let t0 = IdxTensor::from_dense(
 #     vec![s0, b.clone()],
 #     vec![1.0_f64, 0.0, 0.0, 1.0],
 # )?;
-# let t1 = TensorDynLen::from_dense(
+# let t1 = IdxTensor::from_dense(
 #     vec![b, s1],
 #     vec![1.0, 0.0, 0.0, 1.0],
 # )?;
@@ -266,14 +266,14 @@ let s0 = DynIndex::new_dyn(2);
 let s1 = DynIndex::new_dyn(2);
 let b  = DynIndex::new_bond(2)?;
 
-let t0 = TensorDynLen::from_dense(
+let t0 = IdxTensor::from_dense(
     vec![s0, b.clone()],
     vec![
         Complex64::new(1.0,  0.0), Complex64::new(0.0,  1.0),
         Complex64::new(0.0, -1.0), Complex64::new(1.0,  0.0),
     ],
 )?;
-let t1 = TensorDynLen::from_dense(
+let t1 = IdxTensor::from_dense(
     vec![b, s1],
     vec![
         Complex64::new(1.0, 0.0), Complex64::new(0.0, 0.0),

--- a/docs/book/src/guides/tree-tn.md
+++ b/docs/book/src/guides/tree-tn.md
@@ -13,7 +13,7 @@ that appears in both tensors). Physical (site) indices appear in exactly one ten
 The example below builds a 3-site MPS chain `t0 -- t1 -- t2`:
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 use tensor4all_treetn::TreeTN;
 
 // Site indices (appear in one tensor each)
@@ -25,11 +25,11 @@ let s2 = DynIndex::new_dyn(2);
 let b01 = DynIndex::new_dyn(3);
 let b12 = DynIndex::new_dyn(3);
 
-let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0; 6]).unwrap();
-let t1 = TensorDynLen::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 18]).unwrap();
-let t2 = TensorDynLen::from_dense(vec![b12, s2], vec![1.0; 6]).unwrap();
+let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0; 6]).unwrap();
+let t1 = IdxTensor::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 18]).unwrap();
+let t2 = IdxTensor::from_dense(vec![b12, s2], vec![1.0; 6]).unwrap();
 
-let ttn = TreeTN::<TensorDynLen, usize>::from_tensors(
+let ttn = TreeTN::<IdxTensor, usize>::from_tensors(
     vec![t0, t1, t2],
     vec![0, 1, 2],   // vertex labels
 ).unwrap();
@@ -47,7 +47,7 @@ and arbitrary branching topologies. Below is a **Y-shaped** tree with a central 
 to three leaves:
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 use tensor4all_treetn::TreeTN;
 
 // Site indices for the four nodes
@@ -62,15 +62,15 @@ let b_hb = DynIndex::new_dyn(3);
 let b_hc = DynIndex::new_dyn(3);
 
 // Hub tensor has 1 site index + 3 bond indices (2 * 3 * 3 * 3 = 54 elements)
-let t_hub = TensorDynLen::from_dense(
+let t_hub = IdxTensor::from_dense(
     vec![s_hub, b_ha.clone(), b_hb.clone(), b_hc.clone()],
     vec![1.0_f64; 54],
 ).unwrap();
 
 // Leaf tensors each have 1 site index + 1 bond index
-let t_a = TensorDynLen::from_dense(vec![b_ha, s_a], vec![1.0; 6]).unwrap();
-let t_b = TensorDynLen::from_dense(vec![b_hb, s_b], vec![1.0; 6]).unwrap();
-let t_c = TensorDynLen::from_dense(vec![b_hc, s_c], vec![1.0; 6]).unwrap();
+let t_a = IdxTensor::from_dense(vec![b_ha, s_a], vec![1.0; 6]).unwrap();
+let t_b = IdxTensor::from_dense(vec![b_hb, s_b], vec![1.0; 6]).unwrap();
+let t_c = IdxTensor::from_dense(vec![b_hc, s_c], vec![1.0; 6]).unwrap();
 
 let ttn = TreeTN::<_, String>::from_tensors(
     vec![t_hub, t_a, t_b, t_c],
@@ -89,17 +89,17 @@ except the root into isometries. This puts the full norm information into the ro
 prerequisite for efficient norm computation and truncation.
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen, TensorLike};
+use tensor4all_core::{DynIndex, IdxTensor, TensorLike};
 use tensor4all_treetn::{TreeTN, CanonicalizationOptions, TruncationOptions};
 
 let s0 = DynIndex::new_dyn(2);
 let bond = DynIndex::new_dyn(3);
 let s1 = DynIndex::new_dyn(2);
 
-let t0 = TensorDynLen::from_dense(
+let t0 = IdxTensor::from_dense(
     vec![s0, bond.clone()], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 ).unwrap();
-let t1 = TensorDynLen::from_dense(
+let t1 = IdxTensor::from_dense(
     vec![bond, s1], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
 ).unwrap();
 
@@ -130,7 +130,7 @@ use tensor4all_core::prelude::*;
 use tensor4all_treetn::prelude::*;
 
 let s = DynIndex::new_dyn(2);
-let t = TensorDynLen::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
+let t = IdxTensor::from_dense(vec![s], vec![3.0_f64, 4.0]).unwrap();
 let mut ttn = TreeTN::<_, i32>::from_tensors(vec![t], vec![0]).unwrap();
 
 let norm = ttn.norm().unwrap();
@@ -140,22 +140,22 @@ assert!((norm - 5.0).abs() < 1e-10);
 
 ### Dense Conversion
 
-`to_dense()` contracts all bond indices and returns a single `TensorDynLen` whose indices are the
+`to_dense()` contracts all bond indices and returns a single `IdxTensor` whose indices are the
 physical (site) indices of the network. For large networks this can be expensive — use it mainly
 for testing or small examples.
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen, TensorIndex, TensorLike};
+use tensor4all_core::{DynIndex, IdxTensor, TensorIndex, TensorLike};
 use tensor4all_treetn::TreeTN;
 
 let s0 = DynIndex::new_dyn(2);
 let bond = DynIndex::new_dyn(2);
 let s1 = DynIndex::new_dyn(2);
 
-let t0 = TensorDynLen::from_dense(
+let t0 = IdxTensor::from_dense(
     vec![s0, bond.clone()], vec![1.0_f64, 0.0, 0.0, 1.0],
 ).unwrap();
-let t1 = TensorDynLen::from_dense(
+let t1 = IdxTensor::from_dense(
     vec![bond, s1], vec![1.0_f64, 0.0, 0.0, 1.0],
 ).unwrap();
 
@@ -175,13 +175,13 @@ use tensor4all_core::prelude::*;
 use tensor4all_treetn::prelude::*;
 
 let s = DynIndex::new_dyn(2);
-let t = TensorDynLen::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();
+let t = IdxTensor::from_dense(vec![s.clone()], vec![1.0_f64, 2.0]).unwrap();
 let ttn = TreeTN::<_, usize>::from_tensors(vec![t], vec![0]).unwrap();
 
 // sum represents ttn + ttn
 let sum = ttn.add(&ttn).unwrap();
 let dense = sum.to_dense().unwrap();
-let expected = TensorDynLen::from_dense(vec![s], vec![2.0, 4.0]).unwrap();
+let expected = IdxTensor::from_dense(vec![s], vec![2.0, 4.0]).unwrap();
 assert!(dense.distance(&expected).unwrap() < 1e-12);
 ```
 

--- a/docs/superpowers/handoffs/2026-08-09-issue-566-task-8-checkpoint.md
+++ b/docs/superpowers/handoffs/2026-08-09-issue-566-task-8-checkpoint.md
@@ -18,7 +18,7 @@ The seven source/test files below were dirty at `e1b0dfc`; the scanner changes a
 
 The interrupted checkpoint implements compact-support, allocation-safe tensor metrics and scaling:
 
-- `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- `crates/tensor4all-core/src/defaults/idx_tensor.rs`
   - Streams `isapprox` over compact payload support rather than the logical tensor domain, including aligned/permuted index layouts and unmatched support points.
   - Keeps exact comparisons exact and handles finite values, matching/mismatched infinities, and NaN errors during tolerant comparison.
   - Computes `norm`, `norm_squared`, and `maxabs` from compact payload values with an `f64` LASSQ accumulator rather than source-dtype `self * conj(self)` materialization.

--- a/docs/superpowers/handoffs/2026-08-10-issue-566-pr3-foundation-checkpoint.md
+++ b/docs/superpowers/handoffs/2026-08-10-issue-566-pr3-foundation-checkpoint.md
@@ -28,7 +28,7 @@
   fuse_indices / contract / contract_pair / validate）と
   `TensorConstructionLike`（diagonal / delta / scalar_one / ones /
   select_indices / onehot）を typed 化。
-- 実装者: TensorDynLen → TensorDynLenError、BlockTensor →
+- 実装者: IdxTensor → IdxTensorError、BlockTensor →
   TensorVectorSpaceError、TensorTrain（itensorlike）→ TensorTrainError、
   TreeTN / LinearOperator（treetn）→ 新設 TreeTNOperationError。
 - 下流呼び出し元（gse / tdvp / linsolve / contraction / cached_evaluator /
@@ -58,13 +58,13 @@
 ## 注意
 - スライス単位のコミットはブランチに蓄積済み（未 push）。1 つの PR として
   全スライス完了後に push する想定（設計の「crate 単位コミット・1 PR」方針）。
-- tensordynlen.rs の # Errors バックログ 46 件が core の最大クラスタ。
+- idx_tensor.rs の # Errors バックログ 46 件が core の最大クラスタ。
 
 ## 追記（2026-08-10 続行分）
 
 - ブランチ: `chore/issue-566-pr3-errors`（origin/main から 22 コミット、未 push）。
 - **バックログ燃焼**: # Errors ドキュメントバックログを 545 → 321 まで削減。
-  対象: tensordynlen(46) / tenferro_bridge(26) / itensorlike tensortrain /
+  対象: idx_tensor(46) / tenferro_bridge(26) / itensorlike tensortrain /
   treetn mod・ops・named_graph / storage / interpolation / affine / graph /
   contract / krylov / backend / site_index_network ほか。
 - **教訓（繰り返す場合）**: ① doc 挿入は行番号シフトを避けるため降順処理。
@@ -132,23 +132,23 @@
 - 教訓: blanket `From<E: std::error::Error>` は E0119 自己衝突 → 使わない。trait メソッド（anyhow 返し）と tenferro エラーは map_err が異なる（前者 From 直、後者 anyhow::Error::new wrap）
 
 ### core contraction API 完了（レビュー済み・コミット済み）
-- `f62c4af` defaults/contract.rs 9 fn + direct_sum.rs 1 fn → Result<_, TensorDynLenError>
-- defaults/mod.rs で TensorDynLenError 再エクスポート追加
-- trait impl（TensorContractionLike for TensorDynLen）の identity map_err 削除
+- `f62c4af` defaults/contract.rs 9 fn + direct_sum.rs 1 fn → Result<_, IdxTensorError>
+- defaults/mod.rs で IdxTensorError 再エクスポート追加
+- trait impl（TensorContractionLike for IdxTensor）の identity map_err 削除
 - 呼び出し側: factorize.rs（anyhow::Error::new wrap）、treetn gse.rs 6 サイト（GseError::Algorithm source を anyhow::Error::new）、itensorlike tensortrain.rs 3 サイト（operation_source に anyhow::Error::new）
-- 教訓: `TensorDynLenError::Operation.source` は `Arc<dyn Error + Send + Sync>`（anyhow ではない）→ std::io::Error::other で構築
+- 教訓: `IdxTensorError::Operation.source` は `Arc<dyn Error + Send + Sync>`（anyhow ではない）→ std::io::Error::other で構築
 - reviewer-gpt: finding 0（clean）
 
 ### 次のスライス候補
 - defaults/index.rs + index_ops.rs（index 生成/置換系）
 - any_scalar.rs（13 fn、内部に AnyScalarTensorError 下地あり）
 - krylov.rs（9 fn、エラー enum 新設が必要）
-- 残り ~100 fn の tensordynlen inherent メソッド
+- 残り ~100 fn の idx_tensor inherent メソッド
 
 ## Session 2026-08-12 後半（typed-error step 2 継続）
 
 ### core index 置換 API 完了（レビュー済み・コミット済み）
-- `2c4720a` TensorDynLen::replaceind/replace_indices（inherent）→ Result<_, TensorDynLenError>（ShapeMismatch 構造化バリアント使用）、DynIndex::new_bond → TagSetError
+- `2c4720a` IdxTensor::replaceind/replace_indices（inherent）→ Result<_, IdxTensorError>（ShapeMismatch 構造化バリアント使用）、DynIndex::new_bond → TagSetError
 - 呼び出し側: factorize（anyhow::Error::new wrap）、treetn gse 多数サイト、simplett_bridge collect 修正、itensorlike tensortrain
 - tensor_basic.rs の 3 テストを構造化メッセージ（operation + "shape mismatch"）に更新
 - `bfc4236` reviewer 指摘の rustdoc 修正: replaceind(s) の全等価マッチ記述・new_bond の TagSetError 記述・ShapeMismatch バリアント説明拡張
@@ -162,21 +162,21 @@
 ### 現状
 - ブランチ chore/issue-566-pr3-errors、origin/main より 47 コミット
 - セッション内レビュー: 4 スライス（bridge/contraction/index/any_scalar）全て reviewer-gpt で finding 解消済み
-- core 残り anyhow 公開 fn: 92 → ~80（tensordynlen inherent が大半）
+- core 残り anyhow 公開 fn: 92 → ~80（idx_tensor inherent が大半）
 
 ### 次のスライス候補
-- tensordynlen inherent メソッド群（sum/scale/add/axpby/inner_product/sub/neg/permute/select_indices/from_dense/from_diag/to_vec/scalar/zeros/fuse_indices/unfuse_index/stack_along_new_index/index_select/mask_index/from_native/as_native 等 ~80 fn）— 最大ブロック
+- idx_tensor inherent メソッド群（sum/scale/add/axpby/inner_product/sub/neg/permute/select_indices/from_dense/from_diag/to_vec/scalar/zeros/fuse_indices/unfuse_index/stack_along_new_index/index_select/mask_index/from_native/as_native 等 ~80 fn）— 最大ブロック
 - block_tensor.rs / col_major_array.rs / krylov.rs
 - レイヤリング項目 c..i
 
-## Session 2026-08-12 後半2（TensorDynLen 一括型付け）
+## Session 2026-08-12 後半2（IdxTensor 一括型付け）
 
-### 完了: TensorDynLen inherent 43 fn 型付け（レビュー済み・コミット済み）
-- `cd61911`: select_indices/stack_along_new_index/index_select/from_dense(_any)/from_diag(_any)/from_indices/from_storage/from_structured_storage/enable_grad/grad/clear_grad/backward/detach/sum/only/inner_product/add/axpby/scale/sub/neg/permute_indices/permute/fuse_indices/unfuse_index/mask_index/diagonal/delta/scalar_one/ones/onehot/to_vec/scalar/zeros/copy_tensor/into_dense_col_major_parts/as_slice_f64/c64/compute_permutation_from_indices/hermitian_eigendecomposition/diag_tensor_dyn_len/unfold_split/norm/norm_squared/maxabs/isapprox/distance → Result<_, TensorDynLenError>
+### 完了: IdxTensor inherent 43 fn 型付け（レビュー済み・コミット済み）
+- `cd61911`: select_indices/stack_along_new_index/index_select/from_dense(_any)/from_diag(_any)/from_indices/from_storage/from_structured_storage/enable_grad/grad/clear_grad/backward/detach/sum/only/inner_product/add/axpby/scale/sub/neg/permute_indices/permute/fuse_indices/unfuse_index/mask_index/diagonal/delta/scalar_one/ones/onehot/to_vec/scalar/zeros/copy_tensor/into_dense_col_major_parts/as_slice_f64/c64/compute_permutation_from_indices/hermitian_eigendecomposition/diag_idx_tensor/unfold_split/norm/norm_squared/maxabs/isapprox/distance → Result<_, IdxTensorError>
 - 新設 From impl: TensorStorageError→Storage / tenferro_ad::Error・EagerContextError・BridgeError→Materialization
 - trait impl の identity map_err(Self::Error::from) 除去
-- 呼び出し側: itensorlike（From<TensorDynLenError> 追加）、treetn gse/cached_evaluator、partitionedtt、benchmarks 3 本、krylov doc examples
-- `862dcaa`: reviewer major 3 件修正 — (1) partitionedtt tensor_operation_error を TensorDynLenError::Storage 直接マッチ化、テスト実パス化、(2) From<BridgeError> は Arc::new(source) でフレーム保存、(3) tensortrain の二重ラップ削除（TensorTrainError::from 直）
+- 呼び出し側: itensorlike（From<IdxTensorError> 追加）、treetn gse/cached_evaluator、partitionedtt、benchmarks 3 本、krylov doc examples
+- `862dcaa`: reviewer major 3 件修正 — (1) partitionedtt tensor_operation_error を IdxTensorError::Storage 直接マッチ化、テスト実パス化、(2) From<BridgeError> は Arc::new(source) でフレーム保存、(3) tensortrain の二重ラップ削除（TensorTrainError::from 直）
 
 ### 教訓（ハンドオフ追記）
 - 一括変換は行範囲認識なしのブロック regex で破損が起きた（ファイルを bfc4236 に戻して再適用）。安全手順: (a) シグネチャ subn → (b) Err(anyhow) の .into() 付与 → (c) ensure! の paren-aware 変換 → (d) コンパイラ駆動で tail 修正 → (e) clippy の useless_conversion を報告行ベースで除去（ブロック regex は typed fn の .into() も消すため禁止）
@@ -212,7 +212,7 @@
 - reviewer minor: sum() を infallible と文書化、# Errors を variant 基準に、stray '///' 除去
 
 ### treetci（`5b7f133` + `44b9caf`）
-- 新規 TreeTciError（InvalidGraph/IndexOutOfBounds/Operation + From<anyhow>/From<TensorDynLenError>）+ TreeTciResult alias
+- 新規 TreeTciError（InvalidGraph/IndexOutOfBounds/Operation + From<anyhow>/From<IdxTensorError>）+ TreeTciResult alias
 - 21 公開 fn 型付け（api/assemble/batch/graph/materialize/optimize/state）
 - reviewer must-fix 3 件修正: (1) NaN セマンティクス復元（partial_cmp matches!）、(2) 専用 variant 到達可能化（graph 検証→InvalidGraph、site/edge bounds→IndexOutOfBounds、ConvergenceFailure 削除）、(3) 公開 trait メソッド（FullPivLuScalar::solve_right_full_piv_lu、PivotCandidateProposer::candidates）も TreeTciResult 化
 - 教訓: ensure! 変換の `anyhow!` は macro 未 import ファイルで E0433 → `anyhow::anyhow!` に正規化
@@ -271,7 +271,7 @@
 ## Session 2026-08-13 深夜2（step 5 完了）
 
 ### quanticstransform（`0c94b68`）
-- 新規 QuanticsTransformError（InvalidConfiguration/Operation + From<anyhow>/TensorDynLenError/TreeTNOperationError）
+- 新規 QuanticsTransformError（InvalidConfiguration/Operation + From<anyhow>/IdxTensorError/TreeTNOperationError）
 - 29 公開 fn 型付け（affine/cumsum/difference_kernel/flip/fourier/phase_rotation/shift/common MPO・LinearOperator 変換）
 - bail!/ensure!/Err 変換、TensorTrain::new・trait-op の wrap
 

--- a/docs/superpowers/plans/2026-04-08-documentation-improvement.md
+++ b/docs/superpowers/plans/2026-04-08-documentation-improvement.md
@@ -359,7 +359,7 @@ Source material: `crates/tensor4all-core/README.md`
 
 Content:
 - **Index**: Creating indices with `Index::new(dim)`, tags, prime levels
-- **Tensor**: Creating tensors with `TensorDynLen`, random tensors
+- **Tensor**: Creating tensors with `IdxTensor`, random tensors
 - **Contraction**: `contract()`, `contract_multi()`, `AllowedPairs`
 - **Factorization**: SVD with truncation, QR
 - Code examples from current core README, adapted with assertions
@@ -440,7 +440,7 @@ Content migrated from current README sections:
 | ITensors.jl | tensor4all-rs |
 |-------------|---------------|
 | `Index{Int}` | `Index<Id, NoSymmSpace>` |
-| `ITensor` | `TensorDynLen` |
+| `ITensor` | `IdxTensor` |
 | `Dense` | `Storage::StructuredF64/C64` |
 | `Diag` | `Storage::StructuredF64/C64` (diagonal) |
 | `A * B` | `a.contract(&b)` |
@@ -631,7 +631,7 @@ For each crate, replace the existing README with the unified template format:
 Read each existing README, extract the key types and one short example with assertions. Discard detailed explanations (now in Book). Keep the example minimal (~10-15 lines of code).
 
 Key types per crate:
-- **core**: `Index`, `TensorDynLen`, `Storage`, `contract()`, `svd()`
+- **core**: `Index`, `IdxTensor`, `Storage`, `contract()`, `svd()`
 - **treetn**: `TreeTN`, `from_tensors()`, `canonicalize()`, `truncate()`
 - **itensorlike**: `TensorTrain`, `orthogonalize()`, `truncate()`, `inner()`
 - **simplett**: `TensorTrain`, `evaluate()`, `sum()`, `compressed()`
@@ -723,7 +723,7 @@ HDF5 serialization for tensor4all-rs, compatible with ITensors.jl / ITensorMPS.j
 
 ## Key Types
 
-- `save_itensor()` / `load_itensor()` — read/write `TensorDynLen` as ITensors.jl `ITensor`
+- `save_itensor()` / `load_itensor()` — read/write `IdxTensor` as ITensors.jl `ITensor`
 - `save_mps()` / `load_mps()` — read/write `TensorTrain` as ITensorMPS.jl `MPS`
 
 ## Feature Flags
@@ -807,14 +807,14 @@ For each crate, identify public types/traits/functions that lack `/// # Examples
 
 - [ ] **Step 1: Add doc examples to tensor4all-core**
 
-Key items: `Index::new()`, `TensorDynLen` creation, `contract()`, `svd()`, `qr()`
+Key items: `Index::new()`, `IdxTensor` creation, `contract()`, `svd()`, `qr()`
 
 Pattern for each:
 ```rust
 /// # Examples
 ///
 /// ```
-/// use tensor4all_core::{Index, TensorDynLen};
+/// use tensor4all_core::{Index, IdxTensor};
 ///
 /// let i = Index::new(3);
 /// assert_eq!(i.dim(), 3);

--- a/docs/superpowers/plans/2026-04-08-issues-404-405-plan.md
+++ b/docs/superpowers/plans/2026-04-08-issues-404-405-plan.md
@@ -264,8 +264,8 @@ use tensor4all_treetn::operator::ApplyOptions;
 fn build_state_from_fn(
     grid: &DiscretizedGrid,
     f: impl Fn(&[f64]) -> Complex64,
-) -> tensor4all_treetn::TreeTN<tensor4all_core::TensorDynLen, usize> {
-    use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+) -> tensor4all_treetn::TreeTN<tensor4all_core::IdxTensor, usize> {
+    use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     use tensor4all_treetn::{factorize_tensor_to_treetn, TreeTopology};
 
     let local_dims = grid.local_dimensions();
@@ -300,7 +300,7 @@ fn build_state_from_fn(
     // Build tensor
     let shape: Vec<usize> = local_dims.clone();
     let indices: Vec<DynIndex> = site_indices.clone();
-    let tensor = TensorDynLen::from_col_major_data(
+    let tensor = IdxTensor::from_col_major_data(
         indices,
         &data.iter().map(|c| tensor4all_core::AnyScalar::from(*c)).collect::<Vec<_>>(),
     ).unwrap();
@@ -618,7 +618,7 @@ fn shift_on_grouped_grid(
     bc: &[BoundaryCondition],
 ) -> Result<QuanticsOperator> {
     use crate::common::tensortrain_to_linear_operator;
-    use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     use tensor4all_treetn::{TreeTN, operator::LinearOperator};
 
     let rs = grid.rs();
@@ -700,7 +700,7 @@ fn shift_on_interleaved_grid(
 fn compose_sequential_operators(
     ops: &[QuanticsOperator],
 ) -> Result<QuanticsOperator> {
-    use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     use tensor4all_treetn::{TreeTN, operator::{LinearOperator, IndexMapping}};
     use std::collections::HashMap;
 
@@ -982,7 +982,7 @@ Add test in appropriate test module within linear_operator.rs or a tests file:
 ```rust
 #[test]
 fn test_align_to_state() {
-    use tensor4all_core::{DynIndex, TensorDynLen};
+    use tensor4all_core::{DynIndex, IdxTensor};
 
     // Create a simple operator with generic site indices
     // Create a state with specific site indices
@@ -1045,7 +1045,7 @@ Part of #405"
 ```rust
 #[test]
 fn test_evaluate_with_indices() {
-    use tensor4all_core::{DynIndex, TensorDynLen, AnyScalar};
+    use tensor4all_core::{DynIndex, IdxTensor, AnyScalar};
 
     // Build a simple 2-site TreeTN
     let idx_a = DynIndex::new_dyn(2);
@@ -1147,7 +1147,7 @@ In `crates/tensor4all-treetn/src/treetn/partial_contraction/tests/mod.rs`:
 
 ```rust
 use super::*;
-use tensor4all_core::{DynIndex, TensorDynLen, AnyScalar};
+use tensor4all_core::{DynIndex, IdxTensor, AnyScalar};
 
 #[test]
 fn test_partial_contraction_spec_creation() {

--- a/docs/superpowers/plans/2026-04-08-pluto-examples-migration.md
+++ b/docs/superpowers/plans/2026-04-08-pluto-examples-migration.md
@@ -382,7 +382,7 @@ The worker must:
 2. Read `apply_linear_operator` (file: `crates/tensor4all-treetn/src/operator/apply.rs:139`)
 3. Read how to convert `QuanticsTensorCI2` → `TreeTN`:
    - `qtci.tci()` returns `&TreeTCI2<V>`
-   - `tensor4all_treetci::materialize::to_treetn(tci, batch_eval, center)` returns `TreeTN<TensorDynLen, usize>`
+   - `tensor4all_treetci::materialize::to_treetn(tci, batch_eval, center)` returns `TreeTN<IdxTensor, usize>`
 4. Read `FourierOptions` (file: `crates/tensor4all-quanticstransform/src/fourier.rs:22`)
 
 Write an example that:

--- a/docs/superpowers/plans/2026-04-08-steiner-tree-partial-apply.md
+++ b/docs/superpowers/plans/2026-04-08-steiner-tree-partial-apply.md
@@ -233,7 +233,7 @@ fn test_apply_linear_operator_non_contiguous() {
     // This should work by inserting identity at site1 (Steiner tree)
     // and identity at site3 (outer gap)
 
-    let mut state = TreeTN::<TensorDynLen, String>::new();
+    let mut state = TreeTN::<IdxTensor, String>::new();
     let s0 = make_index(2);
     let s1 = make_index(2);
     let s2 = make_index(2);
@@ -242,10 +242,10 @@ fn test_apply_linear_operator_non_contiguous() {
     let b12 = make_index(3);
     let b23 = make_index(3);
 
-    let t0 = TensorDynLen::random_f64(&mut rng(), vec![s0.clone(), b01.clone()]);
-    let t1 = TensorDynLen::random_f64(&mut rng(), vec![b01.clone(), s1.clone(), b12.clone()]);
-    let t2 = TensorDynLen::random_f64(&mut rng(), vec![b12.clone(), s2.clone(), b23.clone()]);
-    let t3 = TensorDynLen::random_f64(&mut rng(), vec![b23.clone(), s3.clone()]);
+    let t0 = IdxTensor::random_f64(&mut rng(), vec![s0.clone(), b01.clone()]);
+    let t1 = IdxTensor::random_f64(&mut rng(), vec![b01.clone(), s1.clone(), b12.clone()]);
+    let t2 = IdxTensor::random_f64(&mut rng(), vec![b12.clone(), s2.clone(), b23.clone()]);
+    let t3 = IdxTensor::random_f64(&mut rng(), vec![b23.clone(), s3.clone()]);
 
     state.add_tensor("site0".into(), t0).unwrap();
     state.add_tensor("site1".into(), t1).unwrap();

--- a/docs/superpowers/plans/2026-04-13-eagertensor-migration.md
+++ b/docs/superpowers/plans/2026-04-13-eagertensor-migration.md
@@ -2,9 +2,9 @@
 
 > **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Migrate tensor4all-rs from the legacy tenferro API to the new split API (`Tensor`, `TypedTensor<T>`, `EagerTensor`) while removing deprecated AD shims, adopting explicit accumulation/reset semantics for eager gradients, and restoring `tensor4all_core::AnyScalar` as a core-owned rank-0 `TensorDynLen` wrapper.
+**Goal:** Migrate tensor4all-rs from the legacy tenferro API to the new split API (`Tensor`, `TypedTensor<T>`, `EagerTensor`) while removing deprecated AD shims, adopting explicit accumulation/reset semantics for eager gradients, and restoring `tensor4all_core::AnyScalar` as a core-owned rank-0 `IdxTensor` wrapper.
 
-**Architecture:** Execute strictly bottom-up by actual crate dependencies: update the workspace pin and tensorbackend first, then migrate tcicore, then migrate tensor4all-core primal operations and public SVD/QR entry points, then reintroduce the renamed AD surface on `TensorDynLen` plus a core-owned `AnyScalar` compatibility wrapper, then migrate simplett's typed-tensor paths and memory-layout handling, and finally sweep higher crates, tests, benches, and FFI invariants.
+**Architecture:** Execute strictly bottom-up by actual crate dependencies: update the workspace pin and tensorbackend first, then migrate tcicore, then migrate tensor4all-core primal operations and public SVD/QR entry points, then reintroduce the renamed AD surface on `IdxTensor` plus a core-owned `AnyScalar` compatibility wrapper, then migrate simplett's typed-tensor paths and memory-layout handling, and finally sweep higher crates, tests, benches, and FFI invariants.
 
 **Tech Stack:** Rust, tenferro, tenferro-tensor, tenferro-einsum, tenferro-algebra, cargo-nextest, mdBook
 
@@ -13,7 +13,7 @@
 - `docs/design/review-eagertensor-migration-v2.md`
 
 **Non-goals:**
-- Preserve deprecated AD method names on `AnyScalar` or `TensorDynLen`.
+- Preserve deprecated AD method names on `AnyScalar` or `IdxTensor`.
 - Keep removed tenferro re-exports such as `print_and_reset_contract_profile` alive via compatibility shims.
 - Perform blind `from_slice -> from_vec` renames without auditing memory order at each call site.
 - Reintroduce seeded backward or implicit gradient clearing semantics that are absent from the target tenferro API.
@@ -63,7 +63,7 @@ Make the following changes in one coherent pass:
 - Verify whether the pinned tenferro API can make `TypedTensor` ops and `EagerTensor` ops share the exact same `CpuBackend` instance.
 - If exact single-instance sharing is supported, implement it and document that invariant.
 - If exact single-instance sharing is not supported, implement paired thread-local execution objects (`with_default_backend`, `default_eager_ctx`) and update the doc comments to avoid claiming a single shared backend instance.
-- Remove AD behavior from backend `AnyScalar` entirely. Delete deprecated methods such as `requires_grad`, `set_requires_grad`, `zero_grad`, `backward_with_seed`, `grad`, and `detach`. The public `tensor4all_core::AnyScalar` compatibility layer is reintroduced later in Task 4 as a core-owned rank-0 `TensorDynLen` wrapper.
+- Remove AD behavior from backend `AnyScalar` entirely. Delete deprecated methods such as `requires_grad`, `set_requires_grad`, `zero_grad`, `backward_with_seed`, `grad`, and `detach`. The public `tensor4all_core::AnyScalar` compatibility layer is reintroduced later in Task 4 as a core-owned rank-0 `IdxTensor` wrapper.
 - Update `tensor_element.rs` for `DType`, `shape()`, `as_slice()`, and explicit column-major `TypedTensor::from_vec(...)` construction.
 - Update `backend.rs` to use `TensorScalar` plus `TypedTensor::{svd, qr}` through `with_default_backend(...)`.
 - Simplify `tenferro_bridge.rs` to the conversion and profiling helpers still needed by downstream crates, and update it to `Tensor::new(...)`, `dtype()`, and `shape()`.
@@ -144,7 +144,7 @@ git commit -m "refactor: migrate tcicore einsum to new tenferro API"
 ## Task 3: Migrate tensor4all-core primal tensor operations and public factorization entry points
 
 **Files:**
-- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Modify: `crates/tensor4all-core/src/defaults/idx_tensor.rs`
 - Modify: `crates/tensor4all-core/src/defaults/contract.rs`
 - Modify: `crates/tensor4all-core/src/defaults/factorize.rs`
 - Modify: `crates/tensor4all-core/src/defaults/svd.rs`
@@ -159,11 +159,11 @@ Run:
 cargo check -p tensor4all-core --all-targets
 ```
 
-Expected: FAIL around old `ScalarType` dispatch, old `TensorDynLen` internals (`Arc<NativeTensor>`), and the removed pre-migration AD methods.
+Expected: FAIL around old `ScalarType` dispatch, old `IdxTensor` internals (`Arc<NativeTensor>`), and the removed pre-migration AD methods.
 
-- [ ] **Step 2: Change `TensorDynLen` to the new storage model**
+- [ ] **Step 2: Change `IdxTensor` to the new storage model**
 
-In `tensordynlen.rs`:
+In `idx_tensor.rs`:
 
 - Replace `native: Arc<NativeTensor>` with `inner: EagerTensor<CpuBackend>`.
 - Add `axis_classes: Vec<usize>` and initialize it in every constructor and result-building path.
@@ -210,10 +210,10 @@ git commit -m "refactor: migrate core primal tensor ops to EagerTensor"
 
 ---
 
-## Task 4: Add the new TensorDynLen AD surface and restore core AnyScalar compatibility
+## Task 4: Add the new IdxTensor AD surface and restore core AnyScalar compatibility
 
 **Files:**
-- Modify: `crates/tensor4all-core/src/defaults/tensordynlen.rs`
+- Modify: `crates/tensor4all-core/src/defaults/idx_tensor.rs`
 - Create: `crates/tensor4all-core/src/any_scalar.rs`
 - Modify: `crates/tensor4all-core/src/lib.rs`
 - Modify: `crates/tensor4all-core/tests/tensor_native_ad.rs`
@@ -239,7 +239,7 @@ Replace old AD test expectations with the new surface:
 
 - `enable_grad(self) -> Self`
 - `tracks_grad(&self) -> bool`
-- `grad(&self) -> Result<Option<TensorDynLen>>`
+- `grad(&self) -> Result<Option<IdxTensor>>`
 - `clear_grad(&self) -> Result<()>`
 - `backward(&self) -> Result<()>`
 - `detach(&self) -> Self`
@@ -249,7 +249,7 @@ Also add explicit failing tests for:
 - repeated `backward()` accumulation
 - `clear_grad()` resetting the accumulated gradient
 - `tracks_grad()` on tracked vs detached tensors
-- core `AnyScalar` rank-0 conversion and forwarding to `TensorDynLen`
+- core `AnyScalar` rank-0 conversion and forwarding to `IdxTensor`
 - borrow-based named-value arithmetic such as `&x * &y + &x`
 - function APIs that take `&AnyScalar`
 - shared-handle `Clone` behavior for tracked scalars
@@ -266,14 +266,14 @@ Expected: FAIL before implementation.
 
 - [ ] **Step 3: Implement the new AD surface and core-owned AnyScalar without reviving removed APIs**
 
-In `tensordynlen.rs` and the new `any_scalar.rs`:
+In `idx_tensor.rs` and the new `any_scalar.rs`:
 
 - Implement `enable_grad`, `tracks_grad`, `grad`, `clear_grad`, `backward`, and `detach`.
 - Do not reintroduce `zero_grad` or `backward_with_seed`.
 - Preserve `axis_classes` and index metadata across gradient and detach paths.
 - Ensure scalar-loss backward is the only supported public entry point.
 - Preserve tenferro's accumulation semantics instead of clearing gradients implicitly inside the wrapper.
-- Replace the `tensor4all-core` re-export of backend `AnyScalar` with a core-owned wrapper around rank-0 `TensorDynLen`.
+- Replace the `tensor4all-core` re-export of backend `AnyScalar` with a core-owned wrapper around rank-0 `IdxTensor`.
 - Preserve the public type name `tensor4all_core::AnyScalar` plus primal helpers such as `new_real`, `new_complex`, `from_value`, `real`, `imag`, `abs`, `is_real`, `is_complex`, `is_zero`, and arithmetic.
 - Implement the documented borrow-based operator contract for named values. Function APIs should take `&AnyScalar`; the plan does not require owned-variable `x * y + x`.
 - Make `Clone` a shared-handle clone of the same tracked scalar. Do not add a value-returning `close()` API.
@@ -297,7 +297,7 @@ Expected: PASS.
 
 ```bash
 git add crates/tensor4all-core/
-git commit -m "feat: add EagerTensor AD surface for TensorDynLen and AnyScalar"
+git commit -m "feat: add EagerTensor AD surface for IdxTensor and AnyScalar"
 ```
 
 ---
@@ -407,7 +407,7 @@ If the grep reveals additional production files outside the earlier tasks, migra
 Create `crates/tensor4all-core/tests/send_sync.rs` with static assertions for:
 
 - `tenferro::EagerTensor<tenferro::CpuBackend>`
-- `tensor4all_core::defaults::TensorDynLen`
+- `tensor4all_core::defaults::IdxTensor`
 
 If the FFI handle types in `tensor4all-capi` expose a similarly testable public type, add an assertion there too.
 

--- a/docs/superpowers/plans/2026-04-19-issue-431-linearoperator-transpose.md
+++ b/docs/superpowers/plans/2026-04-19-issue-431-linearoperator-transpose.md
@@ -120,7 +120,7 @@ that impl, around line 440):
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+    /// use tensor4all_core::{DynIndex, IndexLike, IdxTensor};
     /// use tensor4all_treetn::{IndexMapping, LinearOperator, TreeTN};
     ///
     /// let site_in = DynIndex::new_dyn(2);
@@ -128,7 +128,7 @@ that impl, around line 440):
     /// let s_in_tmp = DynIndex::new_dyn(2);
     /// let s_out_tmp = DynIndex::new_dyn(3);
     ///
-    /// let mpo_tensor = TensorDynLen::from_dense(
+    /// let mpo_tensor = IdxTensor::from_dense(
     ///     vec![s_in_tmp.clone(), s_out_tmp.clone()],
     ///     vec![1.0_f64, 0.0, 0.0, 0.0, 1.0, 0.0],
     /// ).unwrap();

--- a/docs/superpowers/plans/2026-04-25-fuse-to-internal-node-and-restructure-planner.md
+++ b/docs/superpowers/plans/2026-04-25-fuse-to-internal-node-and-restructure-planner.md
@@ -319,7 +319,7 @@ fn test_fuse_to_y_shape_internal_center_node() {
     //     B(no site)   <-- internal node, only bonds
     //      / \
     // C(site_c) D(site_d)
-    let mut tn = TreeTN::<TensorDynLen, String>::new();
+    let mut tn = TreeTN::<IdxTensor, String>::new();
 
     let site_a = DynIndex::new_dyn(2);
     let site_c = DynIndex::new_dyn(2);
@@ -329,11 +329,11 @@ fn test_fuse_to_y_shape_internal_center_node() {
     let bond_bd = DynIndex::new_dyn(3);
 
     let tensor_a =
-        TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("A".to_string(), tensor_a).unwrap();
 
     // B has NO site index — only bond indices
-    let tensor_b = TensorDynLen::from_dense(
+    let tensor_b = IdxTensor::from_dense(
         vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
         vec![1.0; 27],
     )
@@ -341,11 +341,11 @@ fn test_fuse_to_y_shape_internal_center_node() {
     tn.add_tensor("B".to_string(), tensor_b).unwrap();
 
     let tensor_c =
-        TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("C".to_string(), tensor_c).unwrap();
 
     let tensor_d =
-        TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
+        IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6]).unwrap();
     tn.add_tensor("D".to_string(), tensor_d).unwrap();
 
     let n_a = tn.node_index(&"A".to_string()).unwrap();
@@ -548,7 +548,7 @@ Add after the existing Y-shape tests:
         //     B(no site)
         //      / \
         // C(site_c) D(site_d)
-        let mut tn = TreeTN::<TensorDynLen, String>::new();
+        let mut tn = TreeTN::<IdxTensor, String>::new();
         let site_a = DynIndex::new_dyn(2);
         let site_c = DynIndex::new_dyn(2);
         let site_d = DynIndex::new_dyn(2);
@@ -556,17 +556,17 @@ Add after the existing Y-shape tests:
         let bond_bc = DynIndex::new_dyn(3);
         let bond_bd = DynIndex::new_dyn(3);
 
-        let tensor_a = TensorDynLen::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
+        let tensor_a = IdxTensor::from_dense(vec![site_a.clone(), bond_ab.clone()], vec![1.0; 6])?;
         tn.add_tensor("A".to_string(), tensor_a)?;
         // B has no site index
-        let tensor_b = TensorDynLen::from_dense(
+        let tensor_b = IdxTensor::from_dense(
             vec![bond_ab.clone(), bond_bc.clone(), bond_bd.clone()],
             vec![1.0; 27],
         )?;
         tn.add_tensor("B".to_string(), tensor_b)?;
-        let tensor_c = TensorDynLen::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
+        let tensor_c = IdxTensor::from_dense(vec![bond_bc.clone(), site_c.clone()], vec![1.0; 6])?;
         tn.add_tensor("C".to_string(), tensor_c)?;
-        let tensor_d = TensorDynLen::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
+        let tensor_d = IdxTensor::from_dense(vec![bond_bd.clone(), site_d.clone()], vec![1.0; 6])?;
         tn.add_tensor("D".to_string(), tensor_d)?;
 
         let n_a = tn.node_index(&"A".to_string()).unwrap();

--- a/docs/superpowers/plans/2026-08-08-issue-566-pr1-soundness-ci.md
+++ b/docs/superpowers/plans/2026-08-08-issue-566-pr1-soundness-ci.md
@@ -702,7 +702,7 @@ Expected: FAIL because source-aware assertion handling and baseline semantics do
 Classify and remove/fix:
 
 ```text
-crates/tensor4all-core/src/defaults/tensordynlen.rs:2354
+crates/tensor4all-core/src/defaults/idx_tensor.rs:2354
 crates/tensor4all-simplett/src/mpo/test_support.rs:40
 crates/tensor4all-tensorbackend/src/context.rs:115
 crates/tensor4all-tensorbackend/src/matrix.rs:901
@@ -841,22 +841,22 @@ Replace the `square_linsolve` example's invalid one-index operator with a one-si
 
 ```rust
 use std::collections::HashMap;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_treetn::{square_linsolve, IndexMapping, LinsolveOptions, TreeTN};
 
 # fn main() -> anyhow::Result<()> {
 let site = DynIndex::new_dyn(2);
 let s_in = DynIndex::new_dyn(2);
 let s_out = DynIndex::new_dyn(2);
-let operator_tensor = TensorDynLen::from_dense(
+let operator_tensor = IdxTensor::from_dense(
     vec![s_out.clone(), s_in.clone()],
     vec![1.0_f64, 0.0, 0.0, 1.0],
 )?;
-let rhs_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0_f64, 2.0])?;
-let init_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![0.0_f64, 0.0])?;
-let operator = TreeTN::<TensorDynLen, usize>::from_tensors(vec![operator_tensor], vec![0])?;
-let rhs = TreeTN::<TensorDynLen, usize>::from_tensors(vec![rhs_tensor], vec![0])?;
-let init = TreeTN::<TensorDynLen, usize>::from_tensors(vec![init_tensor], vec![0])?;
+let rhs_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0])?;
+let init_tensor = IdxTensor::from_dense(vec![site.clone()], vec![0.0_f64, 0.0])?;
+let operator = TreeTN::<IdxTensor, usize>::from_tensors(vec![operator_tensor], vec![0])?;
+let rhs = TreeTN::<IdxTensor, usize>::from_tensors(vec![rhs_tensor], vec![0])?;
+let init = TreeTN::<IdxTensor, usize>::from_tensors(vec![init_tensor], vec![0])?;
 let mut input_mapping = HashMap::new();
 input_mapping.insert(0usize, IndexMapping { true_index: site.clone(), internal_index: s_in });
 let mut output_mapping = HashMap::new();

--- a/docs/superpowers/specs/2026-04-08-documentation-improvement-design.md
+++ b/docs/superpowers/specs/2026-04-08-documentation-improvement-design.md
@@ -178,7 +178,7 @@ Add assertion-bearing examples to major public API items. Priority:
 
 | Priority | Crate | Key items |
 |----------|-------|-----------|
-| High | tensor4all-core | `Index`, `TensorDynLen`, `contract`, `svd`, `qr` |
+| High | tensor4all-core | `Index`, `IdxTensor`, `contract`, `svd`, `qr` |
 | High | tensor4all-simplett | `TensorTrain`, `evaluate`, `sum`, `compressed` |
 | High | tensor4all-tensorci | `crossinterpolate2`, `TCI2Options` |
 | High | tensor4all-quanticstci | `QuanticsTensorCI2`, `DiscretizedGrid` |

--- a/docs/tutorial-code/docs/tutorials/qtt_elementwise_product_tutorial.md
+++ b/docs/tutorial-code/docs/tutorials/qtt_elementwise_product_tutorial.md
@@ -230,7 +230,7 @@ Inputs:
 
 Outputs:
 
-- a `TreeTN<TensorDynLen, usize>`
+- a `TreeTN<IdxTensor, usize>`
 - the corresponding site indices, which are reused later for pairing and
   evaluation
 

--- a/docs/tutorial-code/src/qtt_affine_common.rs
+++ b/docs/tutorial-code/src/qtt_affine_common.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use num_complex::Complex64;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_quanticstci::{
     quanticscrossinterpolate_discrete, InherentDiscreteGrid, QtciOptions, QuanticsTensorCI2,
     UnfoldingScheme,
@@ -80,7 +80,7 @@ pub type AffineBondDimRow = (
 pub type AffineOperatorBondDimRow = (usize, Option<usize>, Option<usize>, Option<usize>);
 
 /// Result of applying the affine operator to a source QTT.
-pub type AffineTransformOutput = (TreeTN<TensorDynLen, usize>, Vec<SiteIndex>);
+pub type AffineTransformOutput = (TreeTN<IdxTensor, usize>, Vec<SiteIndex>);
 /// Result of building the source QTT.
 pub type AffineQttOutput = (QuanticsTensorCI2<f64>, Vec<usize>, Vec<f64>);
 
@@ -183,7 +183,7 @@ fn boundary_conditions(mode: AffineBoundaryMode) -> Vec<BoundaryCondition> {
 pub fn build_affine_operator(
     config: &AffineTutorialConfig,
     mode: AffineBoundaryMode,
-) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
+) -> Result<LinearOperator<IdxTensor, usize>, Box<dyn Error>> {
     let params = affine_params()?;
     Ok(affine_operator(config.bits, &params, &boundary_conditions(mode))?.transpose())
 }
@@ -195,7 +195,7 @@ pub fn build_affine_operator(
 /// /// mismatch or backend failure).
 ///
 pub fn evaluate_tree_point(
-    tn: &TreeTN<TensorDynLen, usize>,
+    tn: &TreeTN<IdxTensor, usize>,
     site_indices: &[SiteIndex],
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
@@ -211,7 +211,7 @@ pub fn evaluate_tree_point(
 ///
 pub fn apply_affine_operator(
     source: &QuanticsTensorCI2<f64>,
-    operator: &LinearOperator<TensorDynLen, usize>,
+    operator: &LinearOperator<IdxTensor, usize>,
 ) -> Result<AffineTransformOutput, Box<dyn Error>> {
     let tt = source.tensor_train();
     let (state, _site_indices) = tensor_train_to_treetn(&tt)?;
@@ -233,11 +233,11 @@ pub fn apply_affine_operator(
 /// /// backend failure).
 ///
 pub fn collect_samples(
-    periodic: &TreeTN<TensorDynLen, usize>,
+    periodic: &TreeTN<IdxTensor, usize>,
     periodic_site_indices: &[SiteIndex],
-    antiperiodic: &TreeTN<TensorDynLen, usize>,
+    antiperiodic: &TreeTN<IdxTensor, usize>,
     antiperiodic_site_indices: &[SiteIndex],
-    open: &TreeTN<TensorDynLen, usize>,
+    open: &TreeTN<IdxTensor, usize>,
     open_site_indices: &[SiteIndex],
     evaluation_grid: &InherentDiscreteGrid,
     config: &AffineTutorialConfig,
@@ -438,9 +438,9 @@ pub fn write_operator_bond_dims_csv(
 /// Print a compact summary to the terminal used by the binary.
 pub fn print_summary(
     source: &QuanticsTensorCI2<f64>,
-    periodic: &TreeTN<TensorDynLen, usize>,
-    antiperiodic: &TreeTN<TensorDynLen, usize>,
-    open: &TreeTN<TensorDynLen, usize>,
+    periodic: &TreeTN<IdxTensor, usize>,
+    antiperiodic: &TreeTN<IdxTensor, usize>,
+    open: &TreeTN<IdxTensor, usize>,
     samples: &[AffineSamplePoint],
     config: &AffineTutorialConfig,
 ) {

--- a/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
+++ b/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use tensor4all_core::{DynIndex, IndexLike, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 use tensor4all_quanticstci::QuanticsTensorCI2;
 use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain, Tensor3Ops};
 use tensor4all_treetn::TreeTN;
@@ -146,7 +146,7 @@ fn preview_f64(values: &[f64], n: usize) -> String {
 ///
 pub fn print_treetn_summary(
     label: &str,
-    tn: &TreeTN<TensorDynLen, usize>,
+    tn: &TreeTN<IdxTensor, usize>,
 ) -> Result<(), Box<dyn Error>> {
     println!("{label}");
     println!("node_count = {}", tn.node_count());
@@ -162,7 +162,7 @@ pub fn print_treetn_summary(
 }
 
 fn evaluate_tree_point(
-    tn: &TreeTN<TensorDynLen, usize>,
+    tn: &TreeTN<IdxTensor, usize>,
     site_indices: &[DynIndex],
     site_values: &[usize],
 ) -> Result<f64, Box<dyn Error>> {
@@ -186,8 +186,8 @@ fn evaluate_tree_point(
 pub fn collect_samples<F, G>(
     cosh_qtci: &QuanticsTensorCI2<f64>,
     factor_b_qtci: &QuanticsTensorCI2<f64>,
-    product_raw_tn: &TreeTN<TensorDynLen, usize>,
-    product_compressed_tn: &TreeTN<TensorDynLen, usize>,
+    product_raw_tn: &TreeTN<IdxTensor, usize>,
+    product_compressed_tn: &TreeTN<IdxTensor, usize>,
     product_site_indices: &[DynIndex],
     bits: usize,
     npoints: usize,
@@ -245,8 +245,8 @@ where
 pub fn collect_bond_profile(
     cosh_tt: &SimpleTensorTrain<f64>,
     factor_b_tt: &SimpleTensorTrain<f64>,
-    product_raw_tn: &TreeTN<TensorDynLen, usize>,
-    product_compressed_tn: &TreeTN<TensorDynLen, usize>,
+    product_raw_tn: &TreeTN<IdxTensor, usize>,
+    product_compressed_tn: &TreeTN<IdxTensor, usize>,
 ) -> Result<Vec<BondProfileRow>, Box<dyn Error>> {
     let cosh_bonds = cosh_tt.link_dims();
     let factor_b_bonds = factor_b_tt.link_dims();

--- a/docs/tutorial-code/src/qtt_fourier_common.rs
+++ b/docs/tutorial-code/src/qtt_fourier_common.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use num_complex::Complex64;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_quanticstci::{
     quanticscrossinterpolate, DiscretizedGrid, QtciOptions, QuanticsTensorCI2, UnfoldingScheme,
 };
@@ -47,7 +47,7 @@ pub const DEFAULT_FOURIER_CONFIG: FourierTutorialConfig = FourierTutorialConfig 
 /// QTT construction result returned by the Fourier helper.
 pub type FourierQttOutput = (QuanticsTensorCI2<f64>, Vec<usize>, Vec<f64>);
 /// Transformed Fourier state and the site indices needed for evaluation.
-pub type FourierTransformOutput = (TreeTN<TensorDynLen, usize>, Vec<SiteIndex>);
+pub type FourierTransformOutput = (TreeTN<IdxTensor, usize>, Vec<SiteIndex>);
 
 /// One row in the Fourier sample table.
 #[derive(Debug, Clone)]
@@ -138,7 +138,7 @@ pub fn build_gaussian_qtt(
 ///
 pub fn build_fourier_operator(
     config: &FourierTutorialConfig,
-) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
+) -> Result<LinearOperator<IdxTensor, usize>, Box<dyn Error>> {
     let options = FourierOptions {
         max_bond_dim: Some(config.max_bond_dim),
         tolerance: config.tolerance,
@@ -166,7 +166,7 @@ pub fn global_index_to_quantics_sites(index_1based: usize, bits: usize) -> Vec<u
 ///
 pub fn transform_gaussian(
     qtci: &QuanticsTensorCI2<f64>,
-    operator: &LinearOperator<TensorDynLen, usize>,
+    operator: &LinearOperator<IdxTensor, usize>,
     _config: &FourierTutorialConfig,
 ) -> Result<FourierTransformOutput, Box<dyn Error>> {
     let tt = qtci.tensor_train();
@@ -185,7 +185,7 @@ pub fn transform_gaussian(
 /// /// mismatch or backend failure).
 ///
 pub fn evaluate_tree_point(
-    tn: &TreeTN<TensorDynLen, usize>,
+    tn: &TreeTN<IdxTensor, usize>,
     site_indices: &[SiteIndex],
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
@@ -200,7 +200,7 @@ pub fn evaluate_tree_point(
 /// /// backend failure).
 ///
 pub fn collect_samples(
-    transformed: &TreeTN<TensorDynLen, usize>,
+    transformed: &TreeTN<IdxTensor, usize>,
     site_indices: &[SiteIndex],
     input_grid: &DiscretizedGrid,
     frequency_grid: &DiscretizedGrid,
@@ -255,7 +255,7 @@ pub fn collect_bond_dims_from_profiles(
 /// Print a compact summary for the Gaussian Fourier tutorial.
 pub fn print_summary(
     input_qtci: &QuanticsTensorCI2<f64>,
-    transformed: &TreeTN<TensorDynLen, usize>,
+    transformed: &TreeTN<IdxTensor, usize>,
     ranks: &[usize],
     errors: &[f64],
     samples: &[SamplePoint],

--- a/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
+++ b/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 use num_complex::Complex64;
 use tensor4all_core::index::{DynId, Index, TagSet};
-use tensor4all_core::TensorDynLen;
+use tensor4all_core::IdxTensor;
 use tensor4all_quanticstci::{
     quanticscrossinterpolate, DiscretizedGrid, QtciOptions, QuanticsTensorCI2, UnfoldingScheme,
 };
@@ -23,7 +23,7 @@ use tensor4all_treetn::{
 
 pub type SiteIndex = Index<DynId, TagSet>;
 pub type PartialFourier2dQttOutput = (QuanticsTensorCI2<f64>, Vec<usize>, Vec<f64>);
-pub type PartialFourier2dTransformOutput = (TreeTN<TensorDynLen, usize>, Vec<SiteIndex>);
+pub type PartialFourier2dTransformOutput = (TreeTN<IdxTensor, usize>, Vec<SiteIndex>);
 
 #[derive(Debug, Clone, Copy)]
 pub struct PartialFourier2dConfig {
@@ -220,7 +220,7 @@ pub fn build_source_qtt(
 ///
 pub fn build_partial_fourier_operator(
     config: &PartialFourier2dConfig,
-) -> Result<LinearOperator<TensorDynLen, usize>, Box<dyn Error>> {
+) -> Result<LinearOperator<IdxTensor, usize>, Box<dyn Error>> {
     let options = FourierOptions {
         max_bond_dim: Some(config.max_bond_dim),
         tolerance: config.tolerance,
@@ -231,7 +231,7 @@ pub fn build_partial_fourier_operator(
 }
 
 fn single_site_index_from_state(
-    state: &TreeTN<TensorDynLen, usize>,
+    state: &TreeTN<IdxTensor, usize>,
     node: usize,
 ) -> Result<SiteIndex, Box<dyn Error>> {
     let site_space = state
@@ -258,7 +258,7 @@ fn single_site_index_from_state(
 ///
 pub fn transform_x_dimension(
     qtci: &QuanticsTensorCI2<f64>,
-    operator: &LinearOperator<TensorDynLen, usize>,
+    operator: &LinearOperator<IdxTensor, usize>,
 ) -> Result<PartialFourier2dTransformOutput, Box<dyn Error>> {
     let tt = qtci.tensor_train();
     let (state, _state_site_indices) = tensor_train_to_treetn(&tt)?;
@@ -278,7 +278,7 @@ pub fn transform_x_dimension(
 /// /// mismatch or backend failure).
 ///
 pub fn evaluate_tree_point(
-    tn: &TreeTN<TensorDynLen, usize>,
+    tn: &TreeTN<IdxTensor, usize>,
     site_indices: &[SiteIndex],
     site_values: &[usize],
 ) -> Result<Complex64, Box<dyn Error>> {
@@ -291,7 +291,7 @@ pub fn evaluate_tree_point(
 /// /// backend failure).
 ///
 pub fn collect_samples(
-    transformed: &TreeTN<TensorDynLen, usize>,
+    transformed: &TreeTN<IdxTensor, usize>,
     site_indices: &[SiteIndex],
     frequency_grid: &DiscretizedGrid,
     config: &PartialFourier2dConfig,
@@ -448,7 +448,7 @@ pub fn write_operator_bond_dims_csv(
 
 pub fn print_summary(
     input_qtci: &QuanticsTensorCI2<f64>,
-    transformed: &TreeTN<TensorDynLen, usize>,
+    transformed: &TreeTN<IdxTensor, usize>,
     ranks: &[usize],
     errors: &[f64],
     samples: &[PartialFourier2dSamplePoint],

--- a/docs/worklogs/2026-08-09-issue-566-panic-audit.md
+++ b/docs/worklogs/2026-08-09-issue-566-panic-audit.md
@@ -77,8 +77,8 @@ the nested rules' transcribers contribute findings.
 
 The panic-audit tool itself adds no Rust library or C API surface. Task 8 also
 carries an API checkpoint (committed as `6add467` and its successors) that
-makes `TensorDynLen` compact-support metrics, scaling, and comparison
-allocation-safe (`tensordynlen.rs`, tensorbackend `storage.rs`); it was
+makes `IdxTensor` compact-support metrics, scaling, and comparison
+allocation-safe (`idx_tensor.rs`, tensorbackend `storage.rs`); it was
 validated by workspace nextest, doctests, mdBook, API dump, workspace clippy,
 and the scanner self-test/audit.
 
@@ -93,7 +93,7 @@ findings, all fixed and re-confirmed:
    entries via the whole-backing `Storage::scale` fast path. Fixed by routing
    all `Eager`/`Compact`/`Materialized` scaling through `scale_eager_payload`,
    which converts only the compact payload and returns compact storage
-   (commit `53897d3`); the now-unused `TensorDynLenStorage::scale` method and
+   (commit `53897d3`); the now-unused `IdxTensorStorage::scale` method and
    `BackendScalar` import were removed.
 2. Dense logical materialization silently returned an empty buffer when the
    logical-dim product overflowed. `StructuredStorage::logical_dense_col_major_vec`

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/tensordynlen.rs:5996:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:5992:debug_assert_eq",
   "crates/tensor4all-tcicore/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-tcicore/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-tcicore/src/matrixluci/source.rs:108:assert_eq",

--- a/scripts/refactor_treetn.py
+++ b/scripts/refactor_treetn.py
@@ -4,7 +4,7 @@ Refactor treetn modules from TreeTN<I, V> to TreeTN<T, V> pattern.
 
 Pattern changes:
 - impl<I, V> TreeTN<I, V> where I: IndexLike -> impl<T, V> TreeTN<T, V> where T: TensorLike
-- TensorDynLen<I::Id, I::Symm> -> T
+- IdxTensor<I::Id, I::Symm> -> T
 - I (as index type in TreeTN context) -> T::Index
 - I::Id -> <T::Index as IndexLike>::Id
 - I::Symm -> (remove entirely)
@@ -97,19 +97,19 @@ class RustRefactorer:
         return content
 
     def fix_tensor_dynlen(self, content: str) -> str:
-        """Replace TensorDynLen<I::Id, I::Symm> with T."""
-        # TensorDynLen<I::Id, I::Symm> -> T
-        pattern = r'TensorDynLen<I::Id,\s*I::Symm>'
+        """Replace IdxTensor<I::Id, I::Symm> with T."""
+        # IdxTensor<I::Id, I::Symm> -> T
+        pattern = r'IdxTensor<I::Id,\s*I::Symm>'
         replacement = r'T'
         content = re.sub(pattern, replacement, content)
 
-        # Vec<TensorDynLen<I::Id, I::Symm>> -> Vec<T>
-        pattern = r'Vec<TensorDynLen<I::Id,\s*I::Symm>>'
+        # Vec<IdxTensor<I::Id, I::Symm>> -> Vec<T>
+        pattern = r'Vec<IdxTensor<I::Id,\s*I::Symm>>'
         replacement = r'Vec<T>'
         content = re.sub(pattern, replacement, content)
 
-        # HashMap<..., TensorDynLen<I::Id, I::Symm>> -> HashMap<..., T>
-        pattern = r'HashMap<([^,]+),\s*TensorDynLen<I::Id,\s*I::Symm>>'
+        # HashMap<..., IdxTensor<I::Id, I::Symm>> -> HashMap<..., T>
+        pattern = r'HashMap<([^,]+),\s*IdxTensor<I::Id,\s*I::Symm>>'
         replacement = r'HashMap<\1, T>'
         content = re.sub(pattern, replacement, content)
 

--- a/skills/use-tensor4all-rs/SKILL.md
+++ b/skills/use-tensor4all-rs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-tensor4all-rs
-description: Use the tensor4all-rs Rust tensor-network library (TCI, quantics tensor trains, tree tensor networks, DMRG/TDVP/GSE time evolution, adaptive patch interpolation). Use when working with `tensor4all-*` crates (core/simplett/tensorci/quanticstci/treetn/partitionedtt/...), their `TensorDynLen`/`SimpleTensorTrain`/`TreeTN`/`QuanticsTensorCI2`/`PartitionedTT` APIs, or the `dmrg`/`tdvp`/`gse_tdvp`/`adaptiveinterpolate` entry points. Also when porting ITensors.jl, QuanticsTCI.jl, or TCI patterns to Rust, or debugging column-major, `rtol`, or 0-vs-1 indexing mismatches in tensor4all-rs code.
+description: Use the tensor4all-rs Rust tensor-network library (TCI, quantics tensor trains, tree tensor networks, DMRG/TDVP/GSE time evolution, adaptive patch interpolation). Use when working with `tensor4all-*` crates (core/simplett/tensorci/quanticstci/treetn/partitionedtt/...), their `IdxTensor`/`SimpleTensorTrain`/`TreeTN`/`QuanticsTensorCI2`/`PartitionedTT` APIs, or the `dmrg`/`tdvp`/`gse_tdvp`/`adaptiveinterpolate` entry points. Also when porting ITensors.jl, QuanticsTCI.jl, or TCI patterns to Rust, or debugging column-major, `rtol`, or 0-vs-1 indexing mismatches in tensor4all-rs code.
 license: MIT
 ---
 
@@ -31,7 +31,7 @@ This skill tracks `main`; a release tag may not contain every API described belo
 
 - **Backend defaults to pure-Rust `faer` — no system BLAS.** Compute crates enable `tenferro-cpu-faer` by default, so a plain dependency compiles standalone. To link a system BLAS (OpenBLAS / MKL / Apple Accelerate) instead, set `default-features = false` and enable `tenferro-system-blas` on each directly imported crate where it is exposed.
 - **Build with `--release`.** Tensor linalg in debug is orders of magnitude slower; TCI and DMRG are unusable without optimization. For benchmarks set `opt-level = 3` (and `lto`, `codegen-units = 1`).
-- **TensorDynLen scalars** are `f32`, `f64`, `Complex32`, and `Complex64` (`num-complex` 0.4). Compact `Storage` snapshots support only `f64`/`Complex64`; 32-bit tensors retain eager authoritative payloads without promotion. Recipes that build random tensors assume you add `rand` + `rand_chacha` (matching the library's `0.9`) as dev-dependencies.
+- **IdxTensor scalars** are `f32`, `f64`, `Complex32`, and `Complex64` (`num-complex` 0.4). Compact `Storage` snapshots support only `f64`/`Complex64`; 32-bit tensors retain eager authoritative payloads without promotion. Recipes that build random tensors assume you add `rand` + `rand_chacha` (matching the library's `0.9`) as dev-dependencies.
 - **`tensor4all-tensorbackend` is internal** — never depend on it or instantiate `CpuBackend` directly; get scalars, storage, and linalg through the public crates. `tensor4all-tcicore` is the home of `CachedFunction` and `MultiIndex`: depend on it for `CachedFunction`, or take `MultiIndex` re-exported from `tensor4all-partitionedtt`.
 
 Done when `cargo build --release` succeeds and a constant TT evaluates:
@@ -79,7 +79,7 @@ Only read source when the API doc is insufficient. For concrete task patterns (b
 
 These apply across crates and fail silently when ignored. Check them against every data-handling path.
 
-**Dense layout is column-major (Fortran order).** `TensorDynLen::from_dense(indices, data)` and all flat buffers, `reshape`, the C API, and HDF5 use column-major: the **first listed index varies fastest**. Matches Julia / ITensors.jl. When feeding NumPy data, use `order="F"`.
+**Dense layout is column-major (Fortran order).** `IdxTensor::from_dense(indices, data)` and all flat buffers, `reshape`, the C API, and HDF5 use column-major: the **first listed index varies fastest**. Matches Julia / ITensors.jl. When feeding NumPy data, use `order="F"`.
 
 **Indexing base depends on the crate.** Rust sites are **0-indexed**, unlike ITensors.jl (1-indexed). One exception: `tensor4all-quanticstci` grid indices are **1-indexed** (`1..=grid_size`), matching QuanticsTCI.jl. The low-level `tensor4all-tensorci::crossinterpolate2` is **0-indexed** (`0..local_dim`). `tensor4all-partitionedtt::adaptiveinterpolate` pivots are full-domain **0-indexed** too (it wraps `tensorci`). Mixing 0- and 1-indexed territory is the commonest off-by-one.
 

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -15,9 +15,9 @@ Indices, dynamic-rank tensors, contraction, factorization. Most other crates re-
   - `.prime()` / `.noprime()` — raise / clear prime level (ket vs bra).
   - `.dim()`, `.plev()` via the `IndexLike` trait (in `tensor4all_core::prelude`).
   - Two independently created indices are always distinct even with equal dim.
-- `TensorDynLen` — dynamic-rank tensor supporting `f32`, `f64`, `Complex32`, and `Complex64`; `f64`/`Complex64` may use compact dense/diagonal/structured snapshots while 32-bit tensors retain eager authoritative payloads. Axes are matched by index identity, with no fixed ordering.
-  - `TensorDynLen::from_dense(indices, data)` — column-major `data`; first index varies fastest.
-  - `TensorDynLen::zeros::<f64>(indices)`, `::random::<f64, _>(&mut rng, indices)`.
+- `IdxTensor` — dynamic-rank tensor supporting `f32`, `f64`, `Complex32`, and `Complex64`; `f64`/`Complex64` may use compact dense/diagonal/structured snapshots while 32-bit tensors retain eager authoritative payloads. Axes are matched by index identity, with no fixed ordering.
+  - `IdxTensor::from_dense(indices, data)` — column-major `data`; first index varies fastest.
+  - `IdxTensor::zeros::<f64>(indices)`, `::random::<f64, _>(&mut rng, indices)`.
   - `.to_vec::<f32>()` / `.to_vec::<f64>()` / `.to_vec::<Complex32>()` / `.to_vec::<Complex64>()`, `.sum()`, `.dims()`.
 - `contract(&[&a, &b, ...])` — sum over all shared indices; inputs must be connected (else error). `outer_product(&a, &b)` for disconnected products.
 - `factorize(&t, &[left_indices], &opts) -> FactorizeResult { left, right, rank, singular_values }`.
@@ -41,7 +41,7 @@ Plain generic tensor train (`f32`, `f64`, `Complex32`, or `Complex64` where the 
 
 Named `DynIndex` objects; orthogonality-center tracking; multiple canonical forms. Use when you need named indices or ITensors.jl compatibility.
 
-- `SimpleTensorTrain::new(vec![t0, t1, ...])` from `TensorDynLen` cores.
+- `SimpleTensorTrain::new(vec![t0, t1, ...])` from `IdxTensor` cores.
 - `.orthogonalize(site)`, `.orthogonalize_with(site, CanonicalForm::...)` (LU / CI forms).
 - `.truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol)).with_max_bond_dim(n))`.
 - `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, `.isortho()`, `.orthocenter()`, `.max_bond_dim()`.
@@ -103,7 +103,7 @@ Every constructor returns a `LinearOperator` (from `tensor4all-treetn`). All use
 
 Generic `TreeTN` over arbitrary tree topology (TT/MPS is the path-graph special case).
 
-- `TreeTN::<TensorDynLen, V>::from_tensors(tensors, labels) -> Result` — topology inferred from shared bond indices; site indices appear once, bond indices appear twice. `V: Eq + Hash` labels vertices.
+- `TreeTN::<IdxTensor, V>::from_tensors(tensors, labels) -> Result` — topology inferred from shared bond indices; site indices appear once, bond indices appear twice. `V: Eq + Hash` labels vertices.
 - `.node_count()`, `.edge_count()`, `ttn[v]` access, `.norm()`, `.to_dense()` (test/small only), `.add(&b)` (same topology + matching site indices; bonds grow as direct sum), `.replaceind(&old, &new)`.
 - `.canonicalize([root], CanonicalizationOptions)`, `.truncate([root], TruncationOptions::default().with_max_bond_dim(n).with_rtol(t))`.
 - `apply_linear_operator(&op, &state, ApplyOptions)`:
@@ -115,7 +115,7 @@ Generic `TreeTN` over arbitrary tree topology (TT/MPS is the path-graph special 
 - Optimization sweeps (ground state + time evolution). All take a `LinearOperator` (or a bare MPO `TreeTN` via the `*_with_treetn_operator` wrappers), an initial `TreeTN` state, and a `center: &V` root node; the state is canonicalized at `center` first. v1: one input and one output site mapping per node. Build the mapping with `LinearOperator::from_mpo_and_state(mpo, &state)` when site indices are unambiguous, else hand-build `IndexMapping { true_index, internal_index }` input/output maps.
   - `dmrg(operator, init, center, DmrgOptions) -> Result<DmrgResult>` — two-site ground-state DMRG (Lanczos local solve; Rayleigh-quotient energy, no dense materialization). `DmrgOptions::default()` = `nsite 2, nsweeps 5, max_bond_dim None, svd_policy None, energy_tol None`. Builders: `with_nsweeps`, `with_max_bond_dim`, `with_svd_policy`, `with_energy_tol`, `with_lanczos_options`. `DmrgResult { state, energy, sweeps_completed, local_updates, converged, max_residual_norm }`. `nsite` must be 2.
   - `tdvp(operator, init, center, TdvpOptions) -> Result<TdvpResult>` — time-dependent variational principle via Krylov `exp(exponent_step·H)`. `exponent_step` is the Hamiltonian coefficient: real time `dt` → `Complex64::new(0.0, -dt)`; imaginary time `tau` → `-tau` (real negative). `TdvpOptions::default()` = `nsite 2, nsweeps 1, order 2, exponent_step -0.1i, max_bond_dim None, svd_policy None`. `order` ∈ {1,2,4} (Suzuki–Trotter/applyexp, ITensorNetworks.jl parity). `nsite 1` = fixed-rank one-site (rejects truncation options); `nsite 2` allows bond changes. For ITensors `cutoff` parity use `SvdTruncationPolicy::new(cutoff).with_squared_values().with_discarded_tail_sum()`. `TdvpResult { state, sweeps_completed, local_updates, max_error_estimate, max_krylov_iterations }`.
-  - `gse_tdvp(operator, init, center, GseTdvpOptions) -> Result<GseTdvpResult>` — Global Subspace Expansion: build Krylov references `H·ψ, H²·ψ, …` and expand bond bases between TDVP sweeps to grow rank where needed. `GseTdvpOptions { gse: GseOptions, tdvp: TdvpOptions }`; `GseOptions::default()` = `krylov_dim 0, density_weight_cutoff 1e-12, hermitian_tol 1e-12, normalize_references true, expand_before_first_sweep true`. Also `global_subspace_expand(operator, init, center, GseOptions)` and `global_subspace_expand_with_references(init, references, center, GseOptions)` for standalone expansion. v1: `TensorDynLen` states, one state site index per node.
+  - `gse_tdvp(operator, init, center, GseTdvpOptions) -> Result<GseTdvpResult>` — Global Subspace Expansion: build Krylov references `H·ψ, H²·ψ, …` and expand bond bases between TDVP sweeps to grow rank where needed. `GseTdvpOptions { gse: GseOptions, tdvp: TdvpOptions }`; `GseOptions::default()` = `krylov_dim 0, density_weight_cutoff 1e-12, hermitian_tol 1e-12, normalize_references true, expand_before_first_sweep true`. Also `global_subspace_expand(operator, init, center, GseOptions)` and `global_subspace_expand_with_references(init, references, center, GseOptions)` for standalone expansion. v1: `IdxTensor` states, one state site index per node.
 
 ## tensor4all-aci — elementwise TT operations
 
@@ -140,7 +140,7 @@ Ports InterpolativeQTT.jl; returns `SimpleTensorTrain<f64>`.
 
 ## tensor4all-partitionedtt — subdomain patches + adaptive TCI
 
-Split a function's domain into non-overlapping projected patches, each its own TT. Use when a function is low-rank only after fixing some site indices. Re-exports `DynIndex`, `TensorDynLen`, `MultiIndex`, `SimpleTensorTrain`, `ContractOptions`/`TruncateOptions`, `TCI2Options` — get them here rather than depending on `tensor4all-tcicore`.
+Split a function's domain into non-overlapping projected patches, each its own TT. Use when a function is low-rank only after fixing some site indices. Re-exports `DynIndex`, `IdxTensor`, `MultiIndex`, `SimpleTensorTrain`, `ContractOptions`/`TruncateOptions`, `TCI2Options` — get them here rather than depending on `tensor4all-tcicore`.
 
 - `Projector` — maps site `DynIndex` → fixed coordinate, defining a subdomain.
   - `Projector::new()`, `Projector::from_pairs([(idx, value), ...])`.
@@ -171,7 +171,7 @@ Split a function's domain into non-overlapping projected patches, each its own T
 
 ## tensor4all-hdf5 — ITensors.jl-compatible I/O
 
-- `save_itensor()` / `load_itensor()` — `TensorDynLen` as ITensors.jl `ITensor`.
+- `save_itensor()` / `load_itensor()` — `IdxTensor` as ITensors.jl `ITensor`.
 - `save_mps()` / `load_mps()` — `SimpleTensorTrain` as ITensorMPS.jl `MPS`.
 - Features: `link` (default, compile-time HDF5), `runtime-loading` (dlopen for FFI).
 

--- a/skills/use-tensor4all-rs/references/recipes.md
+++ b/skills/use-tensor4all-rs/references/recipes.md
@@ -34,19 +34,19 @@ assert!((c.evaluate(&[0, 1, 2])? - 3.0).abs() < 1e-10);
 
 ```rust
 use rand::SeedableRng;
-use tensor4all_core::{Index, IndexLike, TensorDynLen, contract, factorize, FactorizeOptions, SvdTruncationPolicy};
+use tensor4all_core::{Index, IndexLike, IdxTensor, contract, factorize, FactorizeOptions, SvdTruncationPolicy};
 
 let i = Index::new_dyn(2);
 let j = Index::new_dyn(3);
 let k = Index::new_dyn(4);
 
-let a = TensorDynLen::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6])?;
-let b = TensorDynLen::from_dense(vec![j, k.clone()], vec![1.0_f64; 12])?;
+let a = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![1.0_f64; 6])?;
+let b = IdxTensor::from_dense(vec![j, k.clone()], vec![1.0_f64; 12])?;
 let c = contract(&[&a, &b])?;          // j summed away -> [i, k]
 assert_eq!(c.dims(), vec![2, 4]);
 
 // SVD split along i | k, truncating below rtol.
-let t = TensorDynLen::random::<f64, _>(&mut rand_chacha::ChaCha8Rng::seed_from_u64(1), vec![i.clone(), k.clone()])?;
+let t = IdxTensor::random::<f64, _>(&mut rand_chacha::ChaCha8Rng::seed_from_u64(1), vec![i.clone(), k.clone()])?;
 let opts = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1e-10));
 let r = factorize(&t, &[i], &opts)?;   // r.left=[i,bond], r.right=[bond,k]
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -160,14 +160,14 @@ identity tensors at the skipped sites automatically.
 ## Tree TN: build, canonicalize, truncate
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_treetn::{TreeTN, TruncationOptions};
 
 let s0 = DynIndex::new_dyn(2);
 let s1 = DynIndex::new_dyn(2);
 let bond = DynIndex::new_dyn(3);
-let t0 = TensorDynLen::from_dense(vec![s0, bond.clone()], vec![1.0_f64; 6])?;
-let t1 = TensorDynLen::from_dense(vec![bond, s1], vec![1.0_f64; 6])?;
+let t0 = IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0_f64; 6])?;
+let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0_f64; 6])?;
 let mut ttn = TreeTN::<_, i32>::from_tensors(vec![t0, t1], vec![0, 1])?;
 assert_eq!(ttn.edge_count(), 1);
 
@@ -190,18 +190,18 @@ and one output site mapping per node.
 
 ```rust
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_treetn::{tdvp_with_treetn_operator, TdvpOptions, TreeTN};
 
 // One-site TDVP under a 2x2 identity MPO: |0> evolves under exp(-0.1i * I).
 let site = DynIndex::new_dyn(2);
-let state_tensor = TensorDynLen::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
-let state = TreeTN::<TensorDynLen, usize>::from_tensors(vec![state_tensor], vec![0])?;
+let state_tensor = IdxTensor::from_dense(vec![site.clone()], vec![1.0, 0.0])?;
+let state = TreeTN::<IdxTensor, usize>::from_tensors(vec![state_tensor], vec![0])?;
 
 let op_in = DynIndex::new_dyn(2);
 let op_out = DynIndex::new_dyn(2);
-let op_tensor = TensorDynLen::from_dense(vec![op_out, op_in], vec![1.0, 0.0, 0.0, 1.0])?;
-let mpo = TreeTN::<TensorDynLen, usize>::from_tensors(vec![op_tensor], vec![0])?;
+let op_tensor = IdxTensor::from_dense(vec![op_out, op_in], vec![1.0, 0.0, 0.0, 1.0])?;
+let mpo = TreeTN::<IdxTensor, usize>::from_tensors(vec![op_tensor], vec![0])?;
 
 let result = tdvp_with_treetn_operator(
     &mpo, state, &0,
@@ -220,14 +220,14 @@ assert_eq!(result.sweeps_completed, 1);
 ## ITensorLike TT: orthogonalize, truncate, inner
 
 ```rust
-use tensor4all_core::{DynIndex, TensorDynLen};
+use tensor4all_core::{DynIndex, IdxTensor};
 use tensor4all_itensorlike::{TensorTrain, TruncateOptions};
 
 let s0 = DynIndex::new_dyn(2);
 let s1 = DynIndex::new_dyn(2);
 let b01 = DynIndex::new_bond(2)?;
-let t0 = TensorDynLen::from_dense(vec![s0, b01.clone()], vec![1.0_f64, 0.0, 0.0, 1.0])?;
-let t1 = TensorDynLen::from_dense(vec![b01, s1], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0_f64, 0.0, 0.0, 1.0])?;
+let t1 = IdxTensor::from_dense(vec![b01, s1], vec![1.0_f64, 0.0, 0.0, 1.0])?;
 let mut tt = SimpleTensorTrain::new(vec![t0, t1])?;
 
 let norm_before = tt.norm();

--- a/slides/tensor4all202601.typ
+++ b/slides/tensor4all202601.typ
@@ -187,7 +187,7 @@
     stroke: 0.5pt,
     [*ITensors.jl*], [*tensor4all-rs*],
     [`Index{Int}`], [`Index<Id, NoSymmSpace>`],
-    [`ITensor`], [`TensorDynLen<Id, Symm>`],
+    [`ITensor`], [`IdxTensor<Id, Symm>`],
     [`Dense` / `Diag`], [`Storage::DenseF64` / `DiagF64`],
     [`A * B`], [`a.contract(&b)` or `T::contract(&[a, b])`],
     [`cutoff`], [`rtol` (= √cutoff)],
@@ -305,14 +305,14 @@
     ```rust
     // Contractable index pairs are automatically found and contracted
     let c = T::contract(&[a, b, c])?;
-    // Or using * operator for TensorDynLen
+    // Or using * operator for IdxTensor
     let c = &a * &b;
     ```
   ]
 
   #v(0.5em)
 
-  *Explicit contraction* — on concrete type (TensorDynLen):
+  *Explicit contraction* — on concrete type (IdxTensor):
   #code-block[
     ```rust
     // Contract specific indices i from A with j from B
@@ -329,7 +329,7 @@
 #slide("Type Hierarchy Overview")[
   #text(size: 20pt)[
   ```
-  TensorDynLen (implements TensorLike)
+  IdxTensor (implements TensorLike)
       │
       ├── indices: Vec<DynIndex>     ← Index information
       │
@@ -342,7 +342,7 @@
 
   #v(0.8em)
 
-  - *TensorDynLen*: User-facing tensor type (implements `TensorLike`)
+  - *IdxTensor*: User-facing tensor type (implements `TensorLike`)
   - *TensorData*: Lazy outer product of tensor components
   - *Storage*: Low-level data storage (`mdarray` backend)
   ]


### PR DESCRIPTION
Closes #374.

## What

One-shot rename of the core tensor type `TensorDynLen` → `IdxTensor`
(no compatibility alias, per the decision recorded on #374): the old name
described an implementation detail (dynamic-length indices) rather than
what the type conceptually represents, and the project is in early
development.

## Scope

- `pub struct TensorDynLen` → `IdxTensor` (now `crates/tensor4all-core/src/defaults/idx_tensor.rs`)
- `TensorDynLenError` → `IdxTensorError`, `diag_tensor_dyn_len` → `diag_idx_tensor`
- Module/file `tensordynlen` → `idx_tensor`; the `tensor4all_core::tensor`
  module re-export is preserved
- 218 files: all Rust code (library, tests, benchmarks, C API internals),
  READMEs, live mdBook guides, conventions/architecture docs, the
  downstream-usage skill, slides, and the library-panics audit baseline
  (line numbers shifted under `cargo fmt`)
- Historical records left as-is: `benchmarks/results/`, `docs/design/`,
  `docs/plans/`, and the generated `coverage.json`

The C API has no symbols named after the type (FFI types are separate),
and Tensor4all.jl does not reference the name, so no cross-repo
coordination is needed.

## Verification

- `cargo nextest run --release --workspace`: 2787 passed
- doc tests, mdBook, clippy (`-D warnings`), fmt all pass
- `audit-library-panics.py` passes with the updated baseline
- `check-public-error-docs.py` passes