### PR TITLE
feat(quanticstci): adopt 0-indexed grid indices (quanticsgrids 0.2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ dyn-clone = "1.0"
 omeco = "0.2.1"
 hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
-quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "a76b8fb" }
+quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "8214b72" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
 tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }
 tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "f68b33d9e06cc0af8d2b9c40f7c52d8972cd1266", default-features = false }

--- a/crates/tensor4all-interpolativeqtt/src/tests.rs
+++ b/crates/tensor4all-interpolativeqtt/src/tests.rs
@@ -6,8 +6,8 @@ use crate::interval::NInterval;
 
 use super::*;
 
-fn quantics_to_indices(quantics: &[i64]) -> Vec<usize> {
-    quantics.iter().map(|&q| (q - 1) as usize).collect()
+fn quantics_to_indices(quantics: &[usize]) -> Vec<usize> {
+    quantics.to_vec()
 }
 
 fn grid_1d(r: usize, a: f64, b: f64) -> DiscretizedGrid {
@@ -28,19 +28,19 @@ fn grid_nd(r: usize, lower: &[f64], upper: &[f64]) -> DiscretizedGrid {
         .unwrap()
 }
 
-fn for_each_grid_index(ndims: usize, points_per_dim: usize, mut f: impl FnMut(&[i64])) {
-    let mut index = vec![1i64; ndims];
+fn for_each_grid_index(ndims: usize, points_per_dim: usize, mut f: impl FnMut(&[usize])) {
+    let mut index = vec![0usize; ndims];
     loop {
         f(&index);
 
         let mut advanced = false;
         for value in &mut index {
-            if *value < points_per_dim as i64 {
+            if *value + 1 < points_per_dim {
                 *value += 1;
                 advanced = true;
                 break;
             }
-            *value = 1;
+            *value = 0;
         }
         if !advanced {
             break;
@@ -55,8 +55,8 @@ fn assert_tt_matches_grid_1d(
     tol: f64,
 ) {
     let n = 1usize << grid.rs()[0];
-    for i in 1..=n {
-        let grid_idx = [i as i64];
+    for i in 0..n {
+        let grid_idx = [i];
         let quantics = grid.grididx_to_quantics(&grid_idx).unwrap();
         let coords = grid.grididx_to_origcoord(&grid_idx).unwrap();
         let value = tt.evaluate(&quantics_to_indices(&quantics)).unwrap();
@@ -393,8 +393,8 @@ fn multiscale_interpolation_one_over_x() {
     let n = 1usize << r;
     let mut diff_norm = 0.0;
     let mut ref_norm = 0.0;
-    for i in 1..=n {
-        let grid_idx = [i as i64];
+    for i in 0..n {
+        let grid_idx = [i];
         let quantics = grid.grididx_to_quantics(&grid_idx).unwrap();
         let x = grid.grididx_to_origcoord(&grid_idx).unwrap()[0];
         let value = tt.evaluate(&quantics_to_indices(&quantics)).unwrap();
@@ -513,8 +513,8 @@ fn invert_qtt_round_trip_uncompressed() {
 
     let mut max_err = 0.0_f64;
     for i in 0..(1usize << (r - 1)) {
-        let left_idx = [2 * i as i64 + 1];
-        let right_idx = [2 * i as i64 + 2];
+        let left_idx = [2 * i];
+        let right_idx = [2 * i + 1];
         let left_q = grid.grididx_to_quantics(&left_idx).unwrap();
         let right_q = grid.grididx_to_quantics(&right_idx).unwrap();
         let tt_left = tt.evaluate(&quantics_to_indices(&left_q)).unwrap();
@@ -549,8 +549,8 @@ fn invert_qtt_round_trip_compressed() {
 
     let mut max_err = 0.0_f64;
     for i in 0..(1usize << (r - 1)) {
-        let left_idx = [2 * i as i64 + 1];
-        let right_idx = [2 * i as i64 + 2];
+        let left_idx = [2 * i];
+        let right_idx = [2 * i + 1];
         let left_q = grid.grididx_to_quantics(&left_idx).unwrap();
         let right_q = grid.grididx_to_quantics(&right_idx).unwrap();
         let tt_left = tt.evaluate(&quantics_to_indices(&left_q)).unwrap();

--- a/crates/tensor4all-quanticstci/CHANGELOG.md
+++ b/crates/tensor4all-quanticstci/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## Unreleased — 0-indexed grid indices (breaking)
+
+Adopts the 0-indexed convention of `quanticsgrids` 0.2.0 (tensor4all/tensor4all-rs#584):
+the five `±1` conversions at the TCI boundary are gone and the public surface is
+0-indexed.
+
+**Porting note for QuanticsTCI.jl scripts: subtract 1 from grid indices at the
+call boundary.**
+
+- Interpolation callbacks (`quanticscrossinterpolate_discrete`) now receive
+  0-indexed grid indices as `&[usize]` instead of 1-indexed `&[i64]`.
+- `QuanticsTensorCI2::evaluate` takes 0-indexed grid indices (`&[usize]`).
+- `initial_pivots` are 0-indexed `Vec<Vec<usize>>`.
+- `cachedata()` keys are 0-indexed quantics indices (`Vec<usize>`).

--- a/crates/tensor4all-quanticstci/README.md
+++ b/crates/tensor4all-quanticstci/README.md
@@ -15,8 +15,8 @@ High-level Quantics Tensor Train interpolation interface. Port of QuanticsTCI.jl
 use tensor4all_quanticstci::prelude::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-// Interpolate f(i, j) = i + j on a 16x16 discrete grid (1-indexed)
-let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+// Interpolate f(i, j) = i + j on a 16x16 discrete grid (0-indexed)
+let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
 
 let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete(
     &[16, 16],   // grid sizes (must be equal powers of 2)
@@ -25,9 +25,9 @@ let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete(
     QtciOptions::default().with_tolerance(1e-10),
 )?;
 
-// Evaluate at a point (1-indexed)
-let value = qtci.evaluate(&[5, 10])?;
-assert!((value - 15.0).abs() < 1e-10);
+// Evaluate at a point (0-indexed)
+let value = qtci.evaluate(&[4, 9])?;
+assert!((value - 13.0).abs() < 1e-10);
 assert!(errors.last().copied().unwrap() < 1e-10);
 
 Ok(())

--- a/crates/tensor4all-quanticstci/src/batched/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/mod.rs
@@ -169,7 +169,7 @@ where
 /// * `output_dims` - Shape of the function output (e.g., `&[3]` for 3-vector,
 ///
 ///   `&[2, 2]` for 2x2 matrix)
-/// * `initial_pivots` - Initial pivot grid indices (optional)
+/// * `initial_pivots` - Initial pivot grid indices (0-indexed, optional)
 /// * `options` - TCI options
 ///
 /// # Returns
@@ -216,7 +216,7 @@ pub fn quanticscrossinterpolate_batched<V, F>(
     grid: &DiscretizedGrid,
     f: F,
     output_dims: &[usize],
-    initial_pivots: Option<Vec<Vec<i64>>>,
+    initial_pivots: Option<Vec<Vec<usize>>>,
     options: QtciOptions,
 ) -> QtciResult<(QuanticsTensorCI2Batched<V>, Vec<usize>, Vec<f64>)>
 where

--- a/crates/tensor4all-quanticstci/src/batched/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/batched/tests/mod.rs
@@ -37,15 +37,13 @@ fn test_batched_tci_2component_1d() {
     // Verify values at all grid points.
     let n_grid_points = 1usize << 6; // 2^6 = 64
     for i in 0..n_grid_points {
-        let grid_idx = vec![(i + 1) as i64]; // 1-indexed
+        let grid_idx = vec![i]; // 0-indexed
         let quantics = grid.grididx_to_quantics(&grid_idx).unwrap();
-        let quantics_usize: Vec<usize> = quantics.iter().map(|&q| (q - 1) as usize).collect();
-
         let coord = grid.quantics_to_origcoord(&quantics).unwrap();
         let x = coord[0];
 
         // Evaluate component 0 (sin + 1)
-        let mut indices0 = quantics_usize.clone();
+        let mut indices0 = quantics.clone();
         indices0.push(0);
         let val0 = result.tensor_train().evaluate(&indices0).unwrap();
         let expected0 = (2.0 * std::f64::consts::PI * x).sin() + 1.0;
@@ -58,7 +56,7 @@ fn test_batched_tci_2component_1d() {
         );
 
         // Evaluate component 1 (cos)
-        let mut indices1 = quantics_usize.clone();
+        let mut indices1 = quantics.clone();
         indices1.push(1);
         let val1 = result.tensor_train().evaluate(&indices1).unwrap();
         let expected1 = (2.0 * std::f64::consts::PI * x).cos();
@@ -108,13 +106,12 @@ fn test_batched_tci_scalar_equivalent() {
     // Both should produce the same values at grid points.
     let n_grid_points = 1usize << 4; // 16
     for i in 0..n_grid_points {
-        let grid_idx = vec![(i + 1) as i64];
+        let grid_idx = vec![i];
         let quantics = grid.grididx_to_quantics(&grid_idx).unwrap();
-        let quantics_usize: Vec<usize> = quantics.iter().map(|&q| (q - 1) as usize).collect();
 
         let scalar_val = scalar_result.evaluate(&grid_idx).unwrap();
 
-        let mut batched_indices = quantics_usize;
+        let mut batched_indices = quantics;
         batched_indices.push(0); // single component
         let batched_val = batched_result
             .tensor_train()
@@ -124,7 +121,7 @@ fn test_batched_tci_scalar_equivalent() {
         assert!(
             (scalar_val - batched_val).abs() < 1e-10,
             "mismatch at grid_idx={}: scalar={}, batched={}",
-            i + 1,
+            i,
             scalar_val,
             batched_val
         );
@@ -191,14 +188,13 @@ fn test_batched_tci_matrix_valued() {
     // Verify values at several grid points.
     let n_grid_points = 1usize << 4;
     for i in 0..n_grid_points {
-        let grid_idx = vec![(i + 1) as i64];
+        let grid_idx = vec![i];
         let quantics = grid.grididx_to_quantics(&grid_idx).unwrap();
-        let quantics_usize: Vec<usize> = quantics.iter().map(|&q| (q - 1) as usize).collect();
         let coord = grid.quantics_to_origcoord(&quantics).unwrap();
         let x = coord[0];
 
         for comp in 0..4 {
-            let mut indices = quantics_usize.clone();
+            let mut indices = quantics.clone();
             indices.push(comp);
             let val = result.tensor_train().evaluate(&indices).unwrap();
             let expected = (comp as f64 + 1.0) * (x + 1.0);

--- a/crates/tensor4all-quanticstci/src/lib.rs
+++ b/crates/tensor4all-quanticstci/src/lib.rs
@@ -10,8 +10,8 @@
 //!
 //! # Important Conventions
 //!
-//! - **1-indexed grid indices**: All grid indices are **1-indexed** (following the Julia
-//!   QuanticsTCI.jl convention). The first grid point is `[1, 1]`, not `[0, 0]`.
+//! - **0-indexed grid indices**: All grid indices are **0-indexed** (matching the rest of
+//!   the workspace). The first grid point is `[0, 0]`. QuanticsTCI.jl scripts must subtract 1.
 //! - **Equal dimensions**: [`quanticscrossinterpolate_discrete`] and
 //!   [`quanticscrossinterpolate_from_arrays`] require all dimensions to have the **same**
 //!   number of points (same power of 2). Use [`quanticscrossinterpolate`] with an explicit
@@ -31,8 +31,8 @@
 //! use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
 //!
 //! // Interpolate f(i, j) = i + j on a 16x16 grid
-//! // Discrete indices are 1-indexed and passed as `&[i64]`.
-//! let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+//! // Discrete indices are 0-indexed and passed as `&[usize]`.
+//! let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
 //! let sizes = vec![16, 16];
 //!
 //! let (qtci, _ranks, _errors) = quanticscrossinterpolate_discrete(
@@ -42,8 +42,8 @@
 //!     QtciOptions::default(),
 //! ).unwrap();
 //!
-//! let value = qtci.evaluate(&[5, 10]).unwrap();  // 1-indexed
-//! assert!((value - 15.0).abs() < 1e-10);
+//! let value = qtci.evaluate(&[4, 9]).unwrap();  // 0-indexed
+//! assert!((value - 13.0).abs() < 1e-10);
 //! ```
 //!
 //! # Example: Continuous Grid with `DiscretizedGrid`

--- a/crates/tensor4all-quanticstci/src/prelude.rs
+++ b/crates/tensor4all-quanticstci/src/prelude.rs
@@ -4,15 +4,15 @@
 //! ```rust
 //! use tensor4all_quanticstci::prelude::*;
 //!
-//! let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+//! let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
 //! let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete(
 //!     &[16, 16],
 //!     f,
 //!     None,
 //!     QtciOptions::default().with_tolerance(1e-10),
 //! ).unwrap();
-//! let value = qtci.evaluate(&[5, 10]).unwrap();
-//! assert!((value - 15.0).abs() < 1e-10);
+//! let value = qtci.evaluate(&[4, 9]).unwrap();
+//! assert!((value - 13.0).abs() < 1e-10);
 //! assert!(errors.last().copied().unwrap() < 1e-10);
 //! ```
 

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -33,8 +33,8 @@ fn point_from_batch(batch: GlobalIndexBatch<'_>, point: usize) -> Result<Vec<usi
 }
 
 fn evaluate_grid_point<V>(
-    quantics: &[i64],
-    to_coord: impl FnOnce(&[i64]) -> Result<Vec<f64>>,
+    quantics: &[usize],
+    to_coord: impl FnOnce(&[usize]) -> Result<Vec<f64>>,
     evaluate: impl FnOnce(&[f64]) -> V,
 ) -> Result<V> {
     let coords = to_coord(quantics)
@@ -58,20 +58,20 @@ fn evaluate_grid_point<V>(
 /// ```
 /// use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
 ///
-/// // Interpolate f(i) = i on a grid of size 8 (1-indexed)
-/// let f = |idx: &[i64]| idx[0] as f64;
+/// // Interpolate f(i) = i on a grid of size 8 (0-indexed)
+/// let f = |idx: &[usize]| idx[0] as f64;
 /// let (qtci, _ranks, _errors) =
 ///     quanticscrossinterpolate_discrete::<f64, _>(
 ///         &[8], f, None, QtciOptions::default(),
 ///     ).unwrap();
 ///
-/// // Evaluate at grid point 5
-/// let val = qtci.evaluate(&[5]).unwrap();
-/// assert!((val - 5.0).abs() < 1e-8);
+/// // Evaluate at grid point 4
+/// let val = qtci.evaluate(&[4]).unwrap();
+/// assert!((val - 4.0).abs() < 1e-8);
 ///
-/// // Sum over all grid points: 1 + 2 + ... + 8 = 36
+/// // Sum over all grid points: 0 + 1 + ... + 7 = 28
 /// let sum = qtci.sum().unwrap();
-/// assert!((sum - 36.0).abs() < 1e-6);
+/// assert!((sum - 28.0).abs() < 1e-6);
 ///
 /// // rank() gives the maximum bond dimension
 /// assert!(qtci.rank() >= 1);
@@ -90,7 +90,7 @@ pub struct QuanticsTensorCI2<V: TTScalar> {
     /// Grid for coordinate conversion (InherentDiscreteGrid)
     inherent_grid: Option<InherentDiscreteGrid>,
     /// Cached function values (quantics index -> value)
-    cache: HashMap<Vec<i64>, V>,
+    cache: HashMap<Vec<usize>, V>,
 }
 
 impl<V> QuanticsTensorCI2<V>
@@ -102,7 +102,7 @@ where
         tt: SimpleTensorTrain<V>,
         tci_state: TreeTCI2<V>,
         grid: DiscretizedGrid,
-        cache: HashMap<Vec<i64>, V>,
+        cache: HashMap<Vec<usize>, V>,
     ) -> Self {
         Self {
             tt,
@@ -118,7 +118,7 @@ where
         tt: SimpleTensorTrain<V>,
         tci_state: TreeTCI2<V>,
         grid: InherentDiscreteGrid,
-        cache: HashMap<Vec<i64>, V>,
+        cache: HashMap<Vec<usize>, V>,
     ) -> Self {
         Self {
             tt,
@@ -150,7 +150,7 @@ where
     }
 
     /// Convert grid indices to quantics indices.
-    fn grididx_to_quantics(&self, indices: &[i64]) -> Result<Vec<i64>> {
+    fn grididx_to_quantics(&self, indices: &[usize]) -> Result<Vec<usize>> {
         if let Some(grid) = &self.discretized_grid {
             grid.grididx_to_quantics(indices)
                 .map_err(|e| anyhow!("Grid index conversion error: {}", e))
@@ -165,9 +165,9 @@ where
     /// Evaluate at grid indices.
     ///
     /// # Arguments
-    /// * `indices` - Grid indices (1-indexed). For a grid of size N,
+    /// * `indices` - Grid indices (0-indexed). For a grid of size N,
     ///
-    ///   valid indices are `1..=N`.
+    ///   valid indices are `0..N`.
     ///
     /// # Returns
     /// The interpolated value at the specified grid point.
@@ -182,21 +182,19 @@ where
     /// ```
     /// use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
     ///
-    /// let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    /// let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
     /// let (qtci, _, _) = quanticscrossinterpolate_discrete::<f64, _>(
     ///     &[4, 4], f, None, QtciOptions::default(),
     /// ).unwrap();
     ///
-    /// // Indices are 1-indexed: f(2, 3) = 2 + 3 = 5
-    /// let val = qtci.evaluate(&[2, 3]).unwrap();
-    /// assert!((val - 5.0).abs() < 1e-8);
+    /// // Indices are 0-indexed: f(1, 2) = 1 + 2 = 3
+    /// let val = qtci.evaluate(&[1, 2]).unwrap();
+    /// assert!((val - 3.0).abs() < 1e-8);
     /// ```
-    pub fn evaluate(&self, indices: &[i64]) -> QtciResult<V> {
+    pub fn evaluate(&self, indices: &[usize]) -> QtciResult<V> {
         let quantics = self.grididx_to_quantics(indices)?;
-        // Convert 1-indexed i64 quantics to 0-indexed usize for tensor train evaluation
-        let quantics_usize: Vec<usize> = quantics.iter().map(|&x| (x - 1) as usize).collect();
         self.tt
-            .evaluate(&quantics_usize)
+            .evaluate(&quantics)
             .map_err(|e| anyhow!("Evaluation error: {e}"))
             .map_err(QuanticsTCIError::from)
     }
@@ -216,7 +214,7 @@ where
     /// use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
     ///
     /// // f(i) = 1 on a grid of size 8 => sum = 8
-    /// let f = |_idx: &[i64]| 1.0_f64;
+    /// let f = |_idx: &[usize]| 1.0_f64;
     /// let (qtci, _, _) = quanticscrossinterpolate_discrete::<f64, _>(
     ///     &[8], f, None, QtciOptions::default(),
     /// ).unwrap();
@@ -290,7 +288,7 @@ where
     ///     quanticscrossinterpolate_discrete, AbstractTensorTrain, QtciOptions,
     /// };
     ///
-    /// let f = |idx: &[i64]| idx[0] as f64;
+    /// let f = |idx: &[usize]| idx[0] as f64;
     /// let (qtci, _, _) = quanticscrossinterpolate_discrete::<f64, _>(
     ///     &[4], f, None, QtciOptions::default(),
     /// ).unwrap();
@@ -311,7 +309,7 @@ where
     /// Access cached evaluation points.
     ///
     /// Returns a map from quantics indices to function values.
-    pub fn cachedata(&self) -> &HashMap<Vec<i64>, V> {
+    pub fn cachedata(&self) -> &HashMap<Vec<usize>, V> {
         &self.cache
     }
 
@@ -390,7 +388,7 @@ where
 pub fn quanticscrossinterpolate<V, F>(
     grid: &DiscretizedGrid,
     f: F,
-    initial_pivots: Option<Vec<Vec<i64>>>,
+    initial_pivots: Option<Vec<Vec<usize>>>,
     options: QtciOptions,
 ) -> QtciResult<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
@@ -408,24 +406,21 @@ where
     let n_sites = local_dims.len();
 
     // Use RefCell to allow mutation from within the closure
-    let cache: Rc<RefCell<HashMap<Vec<i64>, V>>> = Rc::new(RefCell::new(HashMap::new()));
+    let cache: Rc<RefCell<HashMap<Vec<usize>, V>>> = Rc::new(RefCell::new(HashMap::new()));
     let cache_clone = cache.clone();
 
     // Wrap function to accept quantics indices (usize 0-indexed for TCI)
     let grid_clone = grid.clone();
     let qf = move |q: &Vec<usize>| -> Result<V> {
-        // Convert 0-indexed TCI values to 1-indexed for quanticsgrids
-        let q_i64: Vec<i64> = q.iter().map(|&x| (x + 1) as i64).collect();
-
         // Check cache first
-        if let Some(v) = cache_clone.borrow().get(&q_i64) {
+        if let Some(v) = cache_clone.borrow().get(q) {
             #[allow(clippy::clone_on_copy)]
             return Ok(v.clone());
         }
 
         // Compute and cache
         let value = evaluate_grid_point(
-            &q_i64,
+            q,
             |quantics| {
                 grid_clone
                     .quantics_to_origcoord(quantics)
@@ -434,7 +429,7 @@ where
             |coords| f(coords),
         )?;
         #[allow(clippy::clone_on_copy)]
-        cache_clone.borrow_mut().insert(q_i64, value.clone());
+        cache_clone.borrow_mut().insert(q.clone(), value.clone());
         Ok(value)
     };
 
@@ -456,8 +451,6 @@ where
             .map(|pivot| {
                 grid.grididx_to_quantics(pivot)
                     .map_err(|error| anyhow!("initial pivot {pivot:?} conversion failed: {error}"))
-                    // Convert 1-indexed quantics to 0-indexed for TCI
-                    .map(|q| q.iter().map(|&x| (x - 1) as usize).collect())
             })
             .collect::<Result<Vec<_>>>()?
     } else {
@@ -535,7 +528,7 @@ where
 ///
 ///   **same** number of points and each must be a power of 2.
 /// * `f` - Function to interpolate, takes original coordinates as `&[f64]`
-/// * `initial_pivots` - Initial pivot grid indices (1-indexed, optional)
+/// * `initial_pivots` - Initial pivot grid indices (0-indexed, optional)
 /// * `options` - TCI options
 ///
 /// # Returns
@@ -559,14 +552,14 @@ where
 ///     &xvals, f, None, QtciOptions::default(),
 /// ).unwrap();
 ///
-/// // Grid index 3 maps to x = 2.0, so f = 4.0
-/// let val = qtci.evaluate(&[3]).unwrap();
+/// // Grid index 2 maps to x = 2.0, so f = 4.0
+/// let val = qtci.evaluate(&[2]).unwrap();
 /// assert!((val - 4.0).abs() < 1e-8);
 /// ```
 pub fn quanticscrossinterpolate_from_arrays<V, F>(
     xvals: &[Vec<f64>],
     f: F,
-    initial_pivots: Option<Vec<Vec<i64>>>,
+    initial_pivots: Option<Vec<Vec<usize>>>,
     options: QtciOptions,
 ) -> QtciResult<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
@@ -644,8 +637,8 @@ where
 ///
 /// Use this when your function is naturally indexed by integers (e.g.,
 /// lattice models, combinatorial functions). Grid indices are
-/// **1-indexed**: the first grid point is `[1, 1, ...]`, and the last
-/// is `[size[0], size[1], ...]`.
+/// **0-indexed**: the first grid point is `[0, 0, ...]`, and the last
+/// is `[size[0] - 1, size[1] - 1, ...]`.
 ///
 /// For functions on continuous domains, use [`quanticscrossinterpolate`]
 /// with a [`DiscretizedGrid`] instead.
@@ -654,8 +647,8 @@ where
 /// * `size` - Grid size in each dimension. All dimensions must have the **same** number of
 ///
 ///   points and each must be a power of 2 (e.g., `&[16, 16]`).
-/// * `f` - Function to interpolate, taking **1-indexed** grid indices as `&[i64]`
-/// * `initial_pivots` - Initial pivot grid indices (1-indexed, optional)
+/// * `f` - Function to interpolate, taking **0-indexed** grid indices as `&[usize]`
+/// * `initial_pivots` - Initial pivot grid indices (0-indexed, optional)
 /// * `options` - TCI options
 ///
 /// # Returns
@@ -673,7 +666,7 @@ where
 /// use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
 ///
 /// // Interpolate f(i, j) = i * j on a 16x16 grid
-/// let f = |idx: &[i64]| (idx[0] * idx[1]) as f64;
+/// let f = |idx: &[usize]| (idx[0] * idx[1]) as f64;
 /// let (qtci, ranks, errors) = quanticscrossinterpolate_discrete::<f64, _>(
 ///     &[16, 16],
 ///     f,
@@ -684,14 +677,14 @@ where
 /// // Check convergence
 /// assert!(*errors.last().unwrap() < 1e-8);
 ///
-/// // Evaluate: f(3, 5) = 15
-/// let val = qtci.evaluate(&[3, 5]).unwrap();
-/// assert!((val - 15.0).abs() < 1e-8);
+/// // Evaluate: f(2, 4) = 8
+/// let val = qtci.evaluate(&[2, 4]).unwrap();
+/// assert!((val - 8.0).abs() < 1e-8);
 /// ```
 pub fn quanticscrossinterpolate_discrete<V, F>(
     size: &[usize],
     f: F,
-    initial_pivots: Option<Vec<Vec<i64>>>,
+    initial_pivots: Option<Vec<Vec<usize>>>,
     options: QtciOptions,
 ) -> QtciResult<(QuanticsTensorCI2<V>, Vec<usize>, Vec<f64>)>
 where
@@ -703,7 +696,7 @@ where
         + tensor4all_tcicore::MatrixLuciScalar
         + FullPivLuScalar
         + tensor4all_treetci::globalpivot::ScalarParts,
-    F: Fn(&[i64]) -> V + 'static,
+    F: Fn(&[usize]) -> V + 'static,
 {
     if size.is_empty() {
         return Err(QuanticsTCIError::InvalidConfiguration {
@@ -742,28 +735,25 @@ where
     let n_sites = local_dims.len();
 
     // Use RefCell to allow mutation from within the closure
-    let cache: Rc<RefCell<HashMap<Vec<i64>, V>>> = Rc::new(RefCell::new(HashMap::new()));
+    let cache: Rc<RefCell<HashMap<Vec<usize>, V>>> = Rc::new(RefCell::new(HashMap::new()));
     let cache_clone = cache.clone();
 
     // Wrap function to accept quantics indices (usize 0-indexed for TCI)
     let grid_clone = grid.clone();
     let qf = move |q: &[usize]| -> Result<V> {
-        // Convert 0-indexed TCI values to 1-indexed for quanticsgrids
-        let q_i64: Vec<i64> = q.iter().map(|&x| (x + 1) as i64).collect();
-
         // Check cache first
-        if let Some(v) = cache_clone.borrow().get(&q_i64) {
+        if let Some(v) = cache_clone.borrow().get(q) {
             #[allow(clippy::clone_on_copy)]
             return Ok(v.clone());
         }
 
         // Compute and cache
         let grididx = grid_clone
-            .quantics_to_grididx(&q_i64)
-            .map_err(|err| anyhow!("failed to convert quantics index {q_i64:?}: {err}"))?;
+            .quantics_to_grididx(q)
+            .map_err(|err| anyhow!("failed to convert quantics index {q:?}: {err}"))?;
         let value = f(&grididx);
         #[allow(clippy::clone_on_copy)]
-        cache_clone.borrow_mut().insert(q_i64, value.clone());
+        cache_clone.borrow_mut().insert(q.to_vec(), value.clone());
         Ok(value)
     };
 
@@ -785,8 +775,6 @@ where
             .map(|pivot| {
                 grid.grididx_to_quantics(pivot)
                     .map_err(|error| anyhow!("initial pivot {pivot:?} conversion failed: {error}"))
-                    // Convert 1-indexed quantics to 0-indexed for TCI
-                    .map(|q| q.iter().map(|&x| (x - 1) as usize).collect())
             })
             .collect::<Result<Vec<_>>>()?
     } else {

--- a/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
@@ -17,7 +17,7 @@ fn point_from_batch_rejects_out_of_bounds_point() {
 fn grid_evaluation_propagates_coordinate_conversion_failure() {
     let called = std::cell::Cell::new(false);
     let result = evaluate_grid_point(
-        &[3_i64],
+        &[3_usize],
         |_point| anyhow::bail!("synthetic coordinate failure"),
         |_coord| {
             called.set(true);
@@ -32,16 +32,15 @@ fn grid_evaluation_propagates_coordinate_conversion_failure() {
 
 #[test]
 fn grid_evaluation_passes_converted_coordinates_to_callback() {
-    let value =
-        evaluate_grid_point(&[1_i64], |_point| Ok(vec![0.25]), |coord| coord[0] * 4.0).unwrap();
+    let value = evaluate_grid_point(&[0], |_point| Ok(vec![0.25]), |coord| coord[0] * 4.0).unwrap();
     assert_eq!(value, 1.0);
 }
 
 #[test]
 fn test_discrete_simple_function() {
-    // f(i, j) = i + j (grididx are 1-indexed)
+    // f(i, j) = i + j (grididx are 0-indexed)
     // Use 4x4 grid which gives 2 sites with Fused scheme
-    let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
     let sizes = vec![4, 4];
 
     // Use Fused to get 2 sites (4x4 = 2 bits, so 2 sites for 2D)
@@ -55,12 +54,12 @@ fn test_discrete_simple_function() {
 
     let (qtci, _ranks, _errors) = result.unwrap();
 
-    // Verify some evaluations (grididx are 1-indexed)
-    let val = qtci.evaluate(&[3, 4]).unwrap();
-    assert_relative_eq!(val, 7.0, epsilon = 1e-8);
+    // Verify some evaluations (grididx are 0-indexed)
+    let val = qtci.evaluate(&[2, 3]).unwrap();
+    assert_relative_eq!(val, 5.0, epsilon = 1e-8);
 
-    let val = qtci.evaluate(&[1, 1]).unwrap();
-    assert_relative_eq!(val, 2.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[0, 0]).unwrap();
+    assert_relative_eq!(val, 0.0, epsilon = 1e-8);
 
     // Rank should be low for this simple function (i + j is rank 2)
     assert!(qtci.rank() <= 3);
@@ -70,7 +69,7 @@ fn test_discrete_simple_function() {
 fn test_discrete_tci_structure() {
     // Test that the QTCI structure (bonds, rank, cache, sum) works correctly.
     // f(i,j) = i + j on a 4x4 grid with Fused scheme.
-    let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
     let sizes = vec![4, 4];
 
     let opts = QtciOptions::default()
@@ -99,17 +98,17 @@ fn test_discrete_tci_structure() {
 
     // Verify evaluate() matches f at known-exact points (same block in
     // quantics representation).
-    let val = qtci.evaluate(&[1, 1]).unwrap();
-    assert_relative_eq!(val, 2.0, epsilon = 1e-8);
-    let val = qtci.evaluate(&[3, 4]).unwrap();
-    assert_relative_eq!(val, 7.0, epsilon = 1e-8);
-    let val = qtci.evaluate(&[4, 4]).unwrap();
-    assert_relative_eq!(val, 8.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[0, 0]).unwrap();
+    assert_relative_eq!(val, 0.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[2, 3]).unwrap();
+    assert_relative_eq!(val, 5.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[3, 3]).unwrap();
+    assert_relative_eq!(val, 6.0, epsilon = 1e-8);
 }
 
 #[test]
 fn test_size_validation() {
-    let f = |_idx: &[i64]| 1.0_f64;
+    let f = |_idx: &[usize]| 1.0_f64;
 
     // Non-power of 2 should fail
     let sizes = vec![5, 5];
@@ -127,7 +126,7 @@ fn test_from_arrays_empty_inputs() {
 
 #[test]
 fn discrete_interpolation_rejects_empty_size_without_panicking() {
-    let f = |_point: &[i64]| 1.0_f64;
+    let f = |_point: &[usize]| 1.0_f64;
     let result = quanticscrossinterpolate_discrete::<f64, _>(&[], f, None, QtciOptions::default());
     assert!(result.is_err());
     let error = result.err().unwrap().to_string();
@@ -162,7 +161,7 @@ fn test_options_builder() {
 fn test_discrete_inherent_grid_accessor() {
     // quanticscrossinterpolate_discrete uses from_inherent internally.
     // Verify that inherent_grid() returns Some and discretized_grid() returns None.
-    let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
     let sizes = vec![4, 4];
 
     let opts = QtciOptions::default()
@@ -186,17 +185,18 @@ fn test_discrete_inherent_grid_accessor() {
     }
 
     // Verify evaluate() at known-exact points
-    let val = qtci.evaluate(&[1, 1]).unwrap();
-    assert_relative_eq!(val, 2.0, epsilon = 1e-8);
-    let val = qtci.evaluate(&[4, 4]).unwrap();
-    assert_relative_eq!(val, 8.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[0, 0]).unwrap();
+    assert_relative_eq!(val, 0.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[3, 3]).unwrap();
+    assert_relative_eq!(val, 6.0, epsilon = 1e-8);
 }
 
 #[test]
 fn test_discrete_cachedata_origcoord_error() {
     // cachedata_origcoord() should return an error for inherent discrete grids
     // because there are no original continuous coordinates.
-    let f = |idx: &[i64]| idx[0] as f64;
+    // f is non-zero at the default initial pivot (grid index 0).
+    let f = |idx: &[usize]| idx[0] as f64 + 1.0;
     let sizes = vec![4];
 
     let opts = QtciOptions::default()
@@ -216,7 +216,7 @@ fn test_discrete_cachedata_origcoord_error() {
 fn test_discrete_integral_returns_sum() {
     // For inherent discrete grids, integral() should just return the sum.
     // f(i) = 1 for all i, on a grid of size 4 => sum = 4
-    let f = |_idx: &[i64]| 1.0_f64;
+    let f = |_idx: &[usize]| 1.0_f64;
     let sizes = vec![4];
 
     let opts = QtciOptions::default()
@@ -280,9 +280,9 @@ fn test_continuous_grid_interpolation() {
     }
 
     // Verify evaluate() produces finite values at grid endpoints
-    let val = qtci.evaluate(&[1]).unwrap();
+    let val = qtci.evaluate(&[0]).unwrap();
     assert!(val.is_finite());
-    let val = qtci.evaluate(&[8]).unwrap();
+    let val = qtci.evaluate(&[7]).unwrap();
     assert!(val.is_finite());
 }
 
@@ -313,7 +313,7 @@ fn test_continuous_grid_integral() {
 #[test]
 fn test_discrete_with_initial_pivots() {
     // Test that initial pivots are correctly converted and the TCI runs successfully.
-    let f = |idx: &[i64]| (idx[0] * idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] * idx[1]) as f64;
     let sizes = vec![4, 4];
 
     let opts = QtciOptions::default()
@@ -321,8 +321,8 @@ fn test_discrete_with_initial_pivots() {
         .with_nrandominitpivot(3)
         .with_unfoldingscheme(UnfoldingScheme::Fused);
 
-    // Provide explicit initial pivots (1-indexed grid indices)
-    let pivots = vec![vec![1, 1], vec![2, 3]];
+    // Provide explicit initial pivots (0-indexed grid indices)
+    let pivots = vec![vec![0, 0], vec![1, 2]];
     let result = quanticscrossinterpolate_discrete(&sizes, f, Some(pivots), opts);
     assert!(result.is_ok(), "Error: {:?}", result.err());
 
@@ -339,18 +339,18 @@ fn test_discrete_with_initial_pivots() {
     assert!(!qtci.cachedata().is_empty());
 
     // Verify evaluate() at known-exact points
-    let val = qtci.evaluate(&[1, 1]).unwrap();
-    assert_relative_eq!(val, 1.0, epsilon = 1e-8);
-    let val = qtci.evaluate(&[4, 4]).unwrap();
-    assert_relative_eq!(val, 16.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[0, 0]).unwrap();
+    assert_relative_eq!(val, 0.0, epsilon = 1e-8);
+    let val = qtci.evaluate(&[3, 3]).unwrap();
+    assert_relative_eq!(val, 9.0, epsilon = 1e-8);
 }
 
 #[test]
 fn test_discrete_rejects_invalid_initial_pivot() {
     let result = quanticscrossinterpolate_discrete(
         &[4],
-        |_idx: &[i64]| 1.0_f64,
-        Some(vec![vec![0_i64]]),
+        |_idx: &[usize]| 1.0_f64,
+        Some(vec![vec![4]]),
         QtciOptions::default().with_nrandominitpivot(0),
     );
     let message = match result {
@@ -359,10 +359,10 @@ fn test_discrete_rejects_invalid_initial_pivot() {
     };
 
     assert!(
-        message.contains("initial pivot [0] conversion failed"),
+        message.contains("initial pivot [4] conversion failed"),
         "{message}"
     );
-    assert!(message.contains("Grid index 0"), "{message}");
+    assert!(message.contains("Grid index 4"), "{message}");
 }
 
 #[test]
@@ -404,9 +404,9 @@ fn test_continuous_grid_with_initial_pivots() {
     }
 
     // Verify evaluate() produces finite values
-    let val = qtci.evaluate(&[1]).unwrap();
+    let val = qtci.evaluate(&[0]).unwrap();
     assert!(val.is_finite());
-    let val = qtci.evaluate(&[8]).unwrap();
+    let val = qtci.evaluate(&[7]).unwrap();
     assert!(val.is_finite());
 }
 
@@ -421,7 +421,7 @@ fn test_continuous_grid_rejects_invalid_initial_pivot() {
     let result = quanticscrossinterpolate(
         &grid,
         |_coords: &[f64]| 1.0_f64,
-        Some(vec![vec![0_i64]]),
+        Some(vec![vec![8]]),
         QtciOptions::default().with_nrandominitpivot(0),
     );
     let message = match result {
@@ -430,10 +430,10 @@ fn test_continuous_grid_rejects_invalid_initial_pivot() {
     };
 
     assert!(
-        message.contains("initial pivot [0] conversion failed"),
+        message.contains("initial pivot [8] conversion failed"),
         "{message}"
     );
-    assert!(message.contains("Grid index 0"), "{message}");
+    assert!(message.contains("Grid index 8"), "{message}");
 }
 
 #[test]
@@ -494,15 +494,15 @@ fn test_from_arrays_valid() {
 
     // Verify evaluate() at known-exact points
     // xvals = [0,1,2,3], so grid (1,1) -> (0,0), f=0 and (4,4) -> (3,3), f=6
-    let val = qtci.evaluate(&[1, 1]).unwrap();
+    let val = qtci.evaluate(&[0, 0]).unwrap();
     assert_relative_eq!(val, 0.0, epsilon = 1e-8);
-    let val = qtci.evaluate(&[4, 4]).unwrap();
+    let val = qtci.evaluate(&[3, 3]).unwrap();
     assert_relative_eq!(val, 6.0, epsilon = 1e-8);
 }
 
 #[test]
 fn test_discrete_unequal_dimensions_error() {
-    let f = |_idx: &[i64]| 1.0_f64;
+    let f = |_idx: &[usize]| 1.0_f64;
     // 4 vs 8 => unequal
     let sizes = vec![4, 8];
     let result = quanticscrossinterpolate_discrete(&sizes, f, None, QtciOptions::default());
@@ -534,7 +534,7 @@ fn test_from_arrays_1d() {
 
     // Verify at grid points
     for (i, &x) in xvals.iter().enumerate() {
-        let grid_idx = (i as i64) + 1; // 1-indexed
+        let grid_idx = i; // 0-indexed
         let expected = f_scalar(x);
         let actual = qtci.evaluate(&[grid_idx]).unwrap();
         assert!(

--- a/crates/tensor4all-quanticstci/tests/feature_test_physicist.rs
+++ b/crates/tensor4all-quanticstci/tests/feature_test_physicist.rs
@@ -28,7 +28,7 @@ const TOL: f64 = 1e-8;
 #[test]
 fn discrete_1d_polynomial() {
     let n: usize = 16; // 2^4
-    let f = |idx: &[i64]| {
+    let f = |idx: &[usize]| {
         let i = idx[0];
         (i * i) as f64
     };
@@ -48,8 +48,8 @@ fn discrete_1d_polynomial() {
         errors.last().unwrap()
     );
 
-    // Evaluate at every grid point (1-indexed)
-    for i in 1..=(n as i64) {
+    // Evaluate at every grid point (0-indexed)
+    for i in 0..n {
         let expected = (i * i) as f64;
         let actual = qtci.evaluate(&[i]).unwrap();
         assert!(
@@ -58,9 +58,8 @@ fn discrete_1d_polynomial() {
         );
     }
 
-    // Sum: sum_{i=1}^{N} i^2 = N*(N+1)*(2N+1)/6
-    let n_i64 = n as i64;
-    let expected_sum = (n_i64 * (n_i64 + 1) * (2 * n_i64 + 1)) as f64 / 6.0;
+    // Sum: sum_{i=0}^{N-1} i^2 = (N-1)*N*(2N-1)/6
+    let expected_sum = ((n - 1) * n * (2 * n - 1)) as f64 / 6.0;
     let actual_sum = qtci.sum().unwrap();
     assert!(
         (actual_sum - expected_sum).abs() < TOL,
@@ -73,7 +72,7 @@ fn discrete_1d_polynomial() {
 #[test]
 fn discrete_2d_product() {
     let n: usize = 16;
-    let f = |idx: &[i64]| (idx[0] * idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] * idx[1]) as f64;
     let sizes = vec![n, n];
 
     let opts = QtciOptions::default()
@@ -90,7 +89,7 @@ fn discrete_2d_product() {
     );
 
     // Spot-check evaluations
-    for &(i, j) in &[(1i64, 1i64), (1, 16), (8, 8), (16, 16)] {
+    for &(i, j) in &[(0usize, 0usize), (0, 15), (7, 7), (15, 15)] {
         let expected = (i * j) as f64;
         let actual = qtci.evaluate(&[i, j]).unwrap();
         assert!(
@@ -99,8 +98,8 @@ fn discrete_2d_product() {
         );
     }
 
-    // Sum: (sum_{i=1}^N i)^2 = [N(N+1)/2]^2
-    let s = (n as f64) * ((n as f64) + 1.0) / 2.0;
+    // Sum: (sum_{i=0}^{N-1} i)^2 = [N(N-1)/2]^2
+    let s = (n as f64) * ((n as f64) - 1.0) / 2.0;
     let expected_sum = s * s;
     let actual_sum = qtci.sum().unwrap();
     assert!(
@@ -115,7 +114,7 @@ fn discrete_2d_product() {
 fn discrete_1d_exponential() {
     let n: usize = 64; // 2^6
     let alpha = 0.1_f64;
-    let f = move |idx: &[i64]| (-alpha * idx[0] as f64).exp();
+    let f = move |idx: &[usize]| (-alpha * idx[0] as f64).exp();
     let sizes = vec![n];
 
     let opts = QtciOptions::default()
@@ -132,7 +131,7 @@ fn discrete_1d_exponential() {
     );
 
     // Evaluate at selected points
-    for i in [1i64, 10, 32, 64] {
+    for i in [0usize, 9, 31, 63] {
         let expected = (-alpha * i as f64).exp();
         let actual = qtci.evaluate(&[i]).unwrap();
         assert!(
@@ -141,9 +140,9 @@ fn discrete_1d_exponential() {
         );
     }
 
-    // Analytical sum: sum_{i=1}^{N} exp(-alpha*i) = exp(-alpha) * (1 - exp(-alpha*N)) / (1 - exp(-alpha))
+    // Analytical sum: sum_{i=0}^{N-1} exp(-alpha*i) = (1 - exp(-alpha*N)) / (1 - exp(-alpha))
     let r = (-alpha).exp();
-    let expected_sum = r * (1.0 - r.powi(n as i32)) / (1.0 - r);
+    let expected_sum = (1.0 - r.powi(n as i32)) / (1.0 - r);
     let actual_sum = qtci.sum().unwrap();
     assert!(
         (actual_sum - expected_sum).abs() < 1e-6,
@@ -156,7 +155,7 @@ fn discrete_1d_exponential() {
 #[test]
 fn discrete_constant_function() {
     let n: usize = 32; // 2^5
-    let f = |_idx: &[i64]| 42.0_f64;
+    let f = |_idx: &[usize]| 42.0_f64;
     let sizes = vec![n];
 
     let opts = QtciOptions::default()
@@ -181,15 +180,15 @@ fn discrete_constant_function() {
 #[test]
 fn discrete_with_explicit_pivots() {
     let n: usize = 16;
-    let f = |idx: &[i64]| (idx[0] + 2 * idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] + 2 * idx[1]) as f64;
     let sizes = vec![n, n];
 
     let opts = QtciOptions::default()
         .with_tolerance(1e-12)
         .with_nrandominitpivot(3);
 
-    // Provide 1-indexed grid pivots
-    let pivots = vec![vec![1, 1], vec![8, 8], vec![16, 16]];
+    // Provide 0-indexed grid pivots
+    let pivots = vec![vec![0, 0], vec![7, 7], vec![15, 15]];
     let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete(&sizes, f, Some(pivots), opts)
         .expect("explicit pivots should work");
 
@@ -199,14 +198,14 @@ fn discrete_with_explicit_pivots() {
         errors.last().unwrap()
     );
 
-    let val = qtci.evaluate(&[5, 10]).unwrap();
-    assert!((val - 25.0).abs() < TOL, "f(5,10) = {val}, expected 25.0");
+    let val = qtci.evaluate(&[4, 9]).unwrap();
+    assert!((val - 22.0).abs() < TOL, "f(4,9) = {val}, expected 22.0");
 }
 
 /// Verify that invalid grid sizes produce errors.
 #[test]
 fn discrete_non_power_of_two_error() {
-    let f = |_idx: &[i64]| 0.0_f64;
+    let f = |_idx: &[usize]| 0.0_f64;
     let result = quanticscrossinterpolate_discrete(&[10], f, None, QtciOptions::default());
     assert!(
         result.is_err(),
@@ -217,7 +216,7 @@ fn discrete_non_power_of_two_error() {
 /// Verify that unequal dimension sizes produce errors.
 #[test]
 fn discrete_unequal_sizes_error() {
-    let f = |_idx: &[i64]| 0.0_f64;
+    let f = |_idx: &[usize]| 0.0_f64;
     let result = quanticscrossinterpolate_discrete(&[8, 16], f, None, QtciOptions::default());
     assert!(
         result.is_err(),
@@ -303,7 +302,7 @@ fn continuous_2d_gaussian() {
     // Need to find the grid index closest to (0,0).
     // Grid goes from -2 to 2 with 64 points, no endpoint.
     // Grid step = 4/64 = 0.0625. Points: -2 + 0.03125, -2 + 0.09375, ...
-    // The midpoint nearest to 0 is around index 32 or 33 (1-indexed).
+    // The midpoint nearest to 0 is around index 31 or 32 (0-indexed).
     // Just check at a few points that the interpolation is reasonable.
     let val_corner = qtci.evaluate(&[1, 1]).unwrap();
     assert!(val_corner.is_finite());
@@ -406,9 +405,9 @@ fn from_arrays_1d_cubic() {
         errors.last().unwrap()
     );
 
-    // Evaluate at several grid points (1-indexed)
-    for i in [1_i64, 32, 64, 65, 128] {
-        let x = xvals[(i - 1) as usize];
+    // Evaluate at several grid points (0-indexed)
+    for i in [0_usize, 31, 63, 64, 127] {
+        let x = xvals[i];
         let expected = x.powi(3);
         let actual = qtci.evaluate(&[i]).unwrap();
         assert!(
@@ -429,9 +428,9 @@ fn from_arrays_2d_linear() {
         .with_tolerance(1e-12)
         .with_unfoldingscheme(UnfoldingScheme::Fused);
 
-    // Use explicit initial pivot at (2,2) where f(1,1)=2 ≠ 0, avoiding the
-    // flaky failure when random pivots all land on (1,1) where f(0,0)=0.
-    let initial_pivots = vec![vec![2_i64, 2]];
+    // Use explicit initial pivot at (1,1) where f(1,1)=2 ≠ 0, avoiding the
+    // flaky failure when random pivots all land on (0,0) where f(0,0)=0.
+    let initial_pivots = vec![vec![1usize, 1]];
 
     let (qtci, _ranks, _errors) = quanticscrossinterpolate_from_arrays(
         &[xvals.clone(), xvals.clone()],
@@ -442,10 +441,10 @@ fn from_arrays_2d_linear() {
     .expect("from_arrays 2D linear should work");
 
     // Evaluate at all 4x4 = 16 points
-    for i in 1..=4_i64 {
-        for j in 1..=4_i64 {
-            let x = xvals[(i - 1) as usize];
-            let y = xvals[(j - 1) as usize];
+    for i in 0..4 {
+        for j in 0..4 {
+            let x = xvals[i];
+            let y = xvals[j];
             let expected = x + y;
             let actual = qtci.evaluate(&[i, j]).unwrap();
             assert!(
@@ -552,7 +551,7 @@ fn options_builder_all_fields() {
 fn options_max_bond_dim_limits_rank() {
     // Use a function that would normally require higher rank
     let n: usize = 64;
-    let f = |idx: &[i64]| ((idx[0] as f64) * 0.1).sin() * ((idx[1] as f64) * 0.2).cos();
+    let f = |idx: &[usize]| ((idx[0] as f64) * 0.1).sin() * ((idx[1] as f64) * 0.2).cos();
     let sizes = vec![n, n];
 
     let opts = QtciOptions::default()
@@ -580,7 +579,7 @@ fn options_max_bond_dim_limits_rank() {
 #[test]
 fn tensor_train_consistency() {
     let n: usize = 16;
-    let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
     let sizes = vec![n, n];
 
     let opts = QtciOptions::default()
@@ -597,10 +596,10 @@ fn tensor_train_consistency() {
     assert!(!qtci_dims.is_empty());
     assert!(qtci.rank() > 0);
 
-    // Verify sum is correct analytically: sum_{i=1}^{N} sum_{j=1}^{N} (i + j)
-    // = N * sum_i + N * sum_j = 2 * N * N*(N+1)/2 = N^2 * (N+1)
+    // Verify sum is correct analytically: sum_{i=0}^{N-1} sum_{j=0}^{N-1} (i + j)
+    // = N * sum_i + N * sum_j = 2 * N * N*(N-1)/2 = N^2 * (N-1)
     let nf = n as f64;
-    let expected_sum = nf * nf * (nf + 1.0);
+    let expected_sum = nf * nf * (nf - 1.0);
     let qtci_sum = qtci.sum().unwrap();
     assert!(
         (qtci_sum - expected_sum).abs() < TOL,
@@ -613,7 +612,7 @@ fn tensor_train_consistency() {
 fn tensor_train_accessor() {
     use tensor4all_quanticstci::AbstractTensorTrain;
 
-    let f = |idx: &[i64]| idx[0] as f64;
+    let f = |idx: &[usize]| idx[0] as f64;
     let sizes = vec![8]; // 2^3
 
     let opts = QtciOptions::default()
@@ -637,7 +636,7 @@ fn tensor_train_accessor() {
 #[test]
 fn unfolding_scheme_comparison() {
     let n: usize = 16;
-    let f = |idx: &[i64]| (idx[0] * idx[0] + idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] * idx[0] + idx[1]) as f64;
     let sizes = vec![n, n];
 
     for scheme in [UnfoldingScheme::Interleaved, UnfoldingScheme::Fused] {
@@ -650,17 +649,17 @@ fn unfolding_scheme_comparison() {
             .unwrap_or_else(|e| panic!("scheme {scheme:?} failed: {e}"));
 
         // Check a few evaluations
-        let val = qtci.evaluate(&[3, 5]).unwrap();
-        let expected = (3i64 * 3 + 5) as f64;
+        let val = qtci.evaluate(&[2, 4]).unwrap();
+        let expected = (2usize * 2 + 4) as f64;
         assert!(
             (val - expected).abs() < TOL,
-            "scheme {scheme:?}: f(3,5) = {val}, expected {expected}"
+            "scheme {scheme:?}: f(2,4) = {val}, expected {expected}"
         );
 
         // Sum should be the same regardless of scheme
-        // sum_{i=1}^{N} sum_{j=1}^{N} (i^2 + j) = N * sum(i^2) + N * sum(j)
-        let sum_i2 = (n as f64) * ((n as f64) + 1.0) * (2.0 * (n as f64) + 1.0) / 6.0;
-        let sum_j = (n as f64) * ((n as f64) + 1.0) / 2.0;
+        // sum_{i=0}^{N-1} sum_{j=0}^{N-1} (i^2 + j) = N * sum(i^2) + N * sum(j)
+        let sum_i2 = ((n - 1) as f64) * (n as f64) * (2.0 * (n as f64) - 1.0) / 6.0;
+        let sum_j = (n as f64) * ((n as f64) - 1.0) / 2.0;
         let expected_sum = (n as f64) * sum_i2 + (n as f64) * sum_j;
         let actual_sum = qtci.sum().unwrap();
         assert!(

--- a/crates/tensor4all-quanticstci/tests/qft_2d_test.rs
+++ b/crates/tensor4all-quanticstci/tests/qft_2d_test.rs
@@ -22,9 +22,9 @@ fn test_2d_qft_x_only_interleaved() -> Result<()> {
     let r = 3;
     let n = 1usize << r; // 8
 
-    // f(x, y) = cos(2π (x-1) / N), 1-indexed
-    let f = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] - 1) as f64;
+    // f(x, y) = cos(2π x / N), 0-indexed
+    let f = move |idx: &[usize]| -> f64 {
+        let x = idx[0] as f64;
         (2.0 * PI * x / n as f64).cos()
     };
 
@@ -47,8 +47,8 @@ fn test_2d_qft_x_only_interleaved() -> Result<()> {
     // Convert to TreeTN
     let tci_state = qtci.tci();
     let r_copy = r;
-    let f_copy = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] - 1) as f64;
+    let f_copy = move |idx: &[usize]| -> f64 {
+        let x = idx[0] as f64;
         (2.0 * PI * x / (1usize << r_copy) as f64).cos()
     };
 
@@ -63,7 +63,7 @@ fn test_2d_qft_x_only_interleaved() -> Result<()> {
                 x_val |= x_bit << bit;
                 y_val |= y_bit << bit;
             }
-            values.push(f_copy(&[(x_val + 1) as i64, (y_val + 1) as i64]));
+            values.push(f_copy(&[x_val, y_val]));
         }
         Ok(values)
     };

--- a/crates/tensor4all-quanticstci/tests/readme_example.rs
+++ b/crates/tensor4all-quanticstci/tests/readme_example.rs
@@ -2,7 +2,7 @@ use tensor4all_quanticstci::{quanticscrossinterpolate_discrete, QtciOptions};
 
 #[test]
 fn readme_example_uses_public_callback_signature() {
-    let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+    let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
     let sizes = vec![16, 16];
 
     let (qtci, ranks, errors) = quanticscrossinterpolate_discrete(
@@ -14,9 +14,9 @@ fn readme_example_uses_public_callback_signature() {
     .expect("README example should compile and run");
 
     let value = qtci
-        .evaluate(&[5, 10])
+        .evaluate(&[4, 9])
         .expect("README example should evaluate");
-    assert!((value - 15.0).abs() < 1e-10);
+    assert!((value - 13.0).abs() < 1e-10);
     assert!(!ranks.is_empty());
     assert!(errors.last().copied().unwrap() < 1e-10);
 }

--- a/crates/tensor4all-treetci/tests/advanced_quantics.rs
+++ b/crates/tensor4all-treetci/tests/advanced_quantics.rs
@@ -75,11 +75,7 @@ fn quantics_grid_polynomial_matches_all_points_on_branching_tree() {
             + 5.0
     };
     let qf = |point: &[usize]| -> f64 {
-        let quantics = point
-            .iter()
-            .map(|&value| value as i64 + 1)
-            .collect::<Vec<_>>();
-        let coords = grid.quantics_to_origcoord(&quantics).unwrap();
+        let coords = grid.quantics_to_origcoord(point).unwrap();
         f(&coords)
     };
 
@@ -103,13 +99,10 @@ fn quantics_grid_polynomial_matches_all_points_on_branching_tree() {
     assert!(errors.last().copied().unwrap_or(f64::INFINITY) < 1e-10);
 
     let mut samples = Vec::new();
-    for i in 1..=4 {
-        for j in 1..=4 {
+    for i in 0..4 {
+        for j in 0..4 {
             let quantics = grid.grididx_to_quantics(&[i, j]).unwrap();
-            let point = quantics
-                .iter()
-                .map(|&value| (value - 1) as usize)
-                .collect::<Vec<_>>();
+            let point = quantics.to_vec();
             let got = evaluate_treetn(&tn, &point);
             samples.push((point, got));
         }
@@ -117,11 +110,7 @@ fn quantics_grid_polynomial_matches_all_points_on_branching_tree() {
     assert_real_samples_close(
         &samples,
         &|point| {
-            let quantics = point
-                .iter()
-                .map(|&value| value as i64 + 1)
-                .collect::<Vec<_>>();
-            let coords = grid.quantics_to_origcoord(&quantics).unwrap();
+            let coords = grid.quantics_to_origcoord(point).unwrap();
             f(&coords)
         },
         1e-8,
@@ -144,11 +133,7 @@ fn quantics_grid_batch_evaluator_matches_point_evaluator() {
             + 5.0
     };
     let qf = |point: &[usize]| -> f64 {
-        let quantics = point
-            .iter()
-            .map(|&value| value as i64 + 1)
-            .collect::<Vec<_>>();
-        let coords = grid.quantics_to_origcoord(&quantics).unwrap();
+        let coords = grid.quantics_to_origcoord(point).unwrap();
         f(&coords)
     };
 
@@ -177,9 +162,9 @@ fn quantics_grid_batch_evaluator_matches_point_evaluator() {
     let batch_eval = |batch: GlobalIndexBatch<'_>| -> Result<Vec<f64>> {
         let mut values = Vec::with_capacity(batch.n_points());
         for point_idx in 0..batch.n_points() {
-            let quantics = (0..batch.n_sites())
-                .map(|site| batch.get(site, point_idx).unwrap() as i64 + 1)
-                .collect::<Vec<_>>();
+            let quantics: Vec<usize> = (0..batch.n_sites())
+                .map(|site| batch.get(site, point_idx).unwrap())
+                .collect();
             let coords = grid_clone.quantics_to_origcoord(&quantics).unwrap();
             values.push(f(&coords));
         }
@@ -198,13 +183,10 @@ fn quantics_grid_batch_evaluator_matches_point_evaluator() {
     .unwrap();
 
     let mut samples = Vec::new();
-    for i in 1..=4 {
-        for j in 1..=4 {
+    for i in 0..4 {
+        for j in 0..4 {
             let quantics = grid.grididx_to_quantics(&[i, j]).unwrap();
-            let point = quantics
-                .iter()
-                .map(|&value| (value - 1) as usize)
-                .collect::<Vec<_>>();
+            let point = quantics.to_vec();
             let batch_only = evaluate_treetn(&tn_batch, &point);
             samples.push((point, batch_only));
         }

--- a/docs/book/src/conventions.md
+++ b/docs/book/src/conventions.md
@@ -13,9 +13,9 @@ This matches Julia, ITensors.jl, and tenferro-rs. When exchanging dense data wit
 
 ## Indexing
 
-- Sites are **0-indexed** in Rust (unlike ITensors.jl, which is 1-indexed).
-- **Exception**: `tensor4all-quanticstci` grid indices are **1-indexed**, following the Julia
-  convention for compatibility with QuanticsTCI.jl.
+- Sites and grid indices are **0-indexed** in Rust (unlike ITensors.jl, which is
+  1-indexed). QuanticsTCI.jl scripts must subtract 1 from grid indices at the
+  call boundary.
 
 ## Truncation Tolerance
 

--- a/docs/book/src/guides/qft.md
+++ b/docs/book/src/guides/qft.md
@@ -162,9 +162,9 @@ use tensor4all_treetn::Operator;
 let r = 3;
 let n = 1usize << r; // 8
 
-// f(x, y) = cos(2*pi*(x-1)/N), 1-indexed -- depends only on x
-let f = move |idx: &[i64]| -> f64 {
-    let x = (idx[0] - 1) as f64;
+// f(x, y) = cos(2*pi*x/N), 0-indexed -- depends only on x
+let f = move |idx: &[usize]| -> f64 {
+    let x = idx[0] as f64;
     (2.0 * PI * x / n as f64).cos()
 };
 

--- a/docs/book/src/guides/tci.md
+++ b/docs/book/src/guides/tci.md
@@ -110,7 +110,7 @@ The quantics representation encodes each grid index in binary and arranges the b
 
 - Indexing differs between the two APIs:
   - `crossinterpolate2` (low-level): indices and pivots are 0-indexed (`0..local_dim`)
-  - `quanticscrossinterpolate_discrete` (high-level): grid indices are 1-indexed (`1..=grid_size`), matching the Julia `QuanticsTCI.jl` convention
+  - `quanticscrossinterpolate_discrete` (high-level): grid indices are 0-indexed (`0..grid_size`)
 - Equal dimensions: `quanticscrossinterpolate_discrete` requires all dimensions to have the same number of points.
 - Power-of-2 grid sizes: all grid dimensions must be powers of 2 (4, 8, 16, 32, ...).
 
@@ -127,13 +127,13 @@ The quantics representation encodes each grid index in binary and arranges the b
 
 ### Discrete grid interpolation
 
-Use `quanticscrossinterpolate_discrete` when your function is naturally defined on an integer grid. Indices are passed as `&[i64]` and are 1-indexed.
+Use `quanticscrossinterpolate_discrete` when your function is naturally defined on an integer grid. Indices are passed as `&[usize]` and are 0-indexed.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
 use tensor4all_quanticstci::prelude::*;
 
-let f = |idx: &[i64]| (idx[0] + idx[1]) as f64;
+let f = |idx: &[usize]| (idx[0] + idx[1]) as f64;
 let sizes = vec![16, 16];
 
 let (qtci, ranks, errors) = quanticscrossinterpolate_discrete::<f64, _>(
@@ -149,9 +149,9 @@ assert!(!ranks.is_empty());
 let value = qtci.evaluate(&[5, 10])?;
 assert!((value - 15.0).abs() < 1e-8);
 
-// Sum of (i + j) for i, j in 1..=16 = 2 * 16 * (16 * 17 / 2) = 4352
+// Sum of (i + j) for i, j in 0..16 = 2 * 16 * (15 * 16 / 2) = 3840
 let total = qtci.sum()?;
-assert!((total - 4352.0).abs() < 1e-6);
+assert!((total - 3840.0).abs() < 1e-6);
 # Ok(())
 # }
 ```
@@ -182,8 +182,8 @@ let (qtci, _ranks, errors) = quanticscrossinterpolate::<f64, _>(
 
 assert!(*errors.last().unwrap() < 1e-8);
 
-// Verify the interpolation at grid point 1 (x = 0.0)
-let value = qtci.evaluate(&[1])?;
+// Verify the interpolation at grid point 0 (x = 0.0)
+let value = qtci.evaluate(&[0])?;
 assert!((value - 0.0).abs() < 1e-10);
 # Ok(())
 # }
@@ -268,7 +268,7 @@ let (qtci, _ranks, errors) = quanticscrossinterpolate::<f64, _>(
 assert!(*errors.last().unwrap() < tol);
 
 // Verify at several grid points across the domain
-for &grid_idx in &[1_i64, 100, 512, 1024] {
+for &grid_idx in &[0usize, 99, 511, 1023] {
     let got = qtci.evaluate(&[grid_idx])?;
     assert!(got.is_finite(), "value at grid index {} should be finite", grid_idx);
 }
@@ -290,7 +290,7 @@ use tensor4all_quanticstci::prelude::*;
 
 // Use 64x64 for a faster doctest (256x256 in practice)
 let sizes = vec![64, 64];
-let f = |idx: &[i64]| {
+let f = |idx: &[usize]| {
     let x = idx[0] as f64;
     let y = idx[1] as f64;
     (x / 24.0).cos() + (y / 17.0).cos() + 0.1 * ((x + y) / 13.0).sin()
@@ -308,7 +308,7 @@ let (qtci, _ranks, errors) = quanticscrossinterpolate_discrete::<f64, _>(
 
 assert!(*errors.last().unwrap() < 1e-8);
 
-for &(i, j) in &[(1_i64, 1_i64), (17, 33), (32, 50), (64, 64)] {
+for &(i, j) in &[(0usize, 0usize), (16, 32), (31, 49), (63, 63)] {
     let exact = (i as f64 / 24.0).cos()
         + (j as f64 / 17.0).cos()
         + 0.1 * (((i + j) as f64) / 13.0).sin();

--- a/docs/book/src/tutorials/computations-with-qtt/affine-transformation.md
+++ b/docs/book/src/tutorials/computations-with-qtt/affine-transformation.md
@@ -29,9 +29,9 @@ use std::f64::consts::PI;
 let bits = 7;
 let n = 1usize << bits;
 let source_grid = [n, n];
-let source_function = move |grid_1based: &[i64]| -> f64 {
-    let u = (grid_1based[0] - 1) as f64;
-    let v = (grid_1based[1] - 1) as f64;
+let source_function = move |grid_idx: &[usize]| -> f64 {
+    let u = grid_idx[0] as f64;
+    let v = grid_idx[1] as f64;
     let n = n as f64;
     (2.0 * PI * u / n).sin()
         + 0.5 * (2.0 * PI * v / n).cos()

--- a/docs/book/src/tutorials/computations-with-qtt/elementwise-product.md
+++ b/docs/book/src/tutorials/computations-with-qtt/elementwise-product.md
@@ -22,12 +22,12 @@ pointwise product. The two target functions are `f(x) = x^2` and
 # };
 let npoints = 8usize;
 let sizes = [npoints];
-let f = move |idx: &[i64]| -> f64 {
-    let x = (idx[0] as f64 - 1.0) / npoints as f64;
+let f = move |idx: &[usize]| -> f64 {
+    let x = idx[0] as f64 / npoints as f64;
     x.powi(2)
 };
-let g = move |idx: &[i64]| -> f64 {
-    let x = (idx[0] as f64 - 1.0) / npoints as f64;
+let g = move |idx: &[usize]| -> f64 {
+    let x = idx[0] as f64 / npoints as f64;
     (10.0 * x).sin()
 };
 let options = QtciOptions::default()

--- a/docs/book/src/tutorials/quantics-basics/multivariate-functions.md
+++ b/docs/book/src/tutorials/quantics-basics/multivariate-functions.md
@@ -34,7 +34,7 @@ let options = QtciOptions::default()
     .with_verbosity(0);
 let (qtt, _ranks, _errors) = quanticscrossinterpolate(&grid, f, None, options)?;
 
-assert!((qtt.evaluate(&[1, 1])? - f(&[-2.0, -2.0])).abs() < 1e-6);
+assert!((qtt.evaluate(&[0, 0])? - f(&[-2.0, -2.0])).abs() < 1e-6);
 # Ok(())
 # }
 ```

--- a/docs/book/src/tutorials/quantics-basics/qtt-physical-interval.md
+++ b/docs/book/src/tutorials/quantics-basics/qtt-physical-interval.md
@@ -31,12 +31,12 @@ let options = QtciOptions::default()
     .with_verbosity(0);
 let (qtt, _ranks, _errors) = quanticscrossinterpolate(&grid, f, None, options)?;
 
-assert!((qtt.evaluate(&[128])? - 4.0).abs() < 1e-8);
+assert!((qtt.evaluate(&[127])? - 4.0).abs() < 1e-8);
 # Ok(())
 # }
 ```
 
-Indices passed to `evaluate` are one-based grid indices. The grid converts them
+Indices passed to `evaluate` are zero-based grid indices. The grid converts them
 to the physical coordinate before the function is sampled. Passing `None` for
 the optional initial-pivot argument keeps the tutorial on the default QTCI
 initialization path.

--- a/docs/book/src/tutorials/quantics-basics/qtt-scalar-function.md
+++ b/docs/book/src/tutorials/quantics-basics/qtt-scalar-function.md
@@ -19,8 +19,8 @@ written in terms of grid indices.
 # };
 let npoints = 128usize;
 let sizes = [npoints];
-let f = move |idx: &[i64]| -> f64 {
-    let x = (idx[0] as f64 - 1.0) / npoints as f64;
+let f = move |idx: &[usize]| -> f64 {
+    let x = idx[0] as f64 / npoints as f64;
     x.cosh()
 };
 let options = QtciOptions::default()
@@ -31,7 +31,7 @@ let (qtt, ranks, _errors) =
     quanticscrossinterpolate_discrete::<f64, _>(&sizes, f, None, options)?;
 
 let x = 0.5_f64;
-assert!((qtt.evaluate(&[65])? - x.cosh()).abs() < 1e-8);
+assert!((qtt.evaluate(&[64])? - x.cosh()).abs() < 1e-8);
 assert!(!ranks.is_empty());
 # Ok(())
 # }

--- a/docs/book/src/tutorials/quantics-basics/sweep-bit-depth.md
+++ b/docs/book/src/tutorials/quantics-basics/sweep-bit-depth.md
@@ -10,7 +10,7 @@ Runnable source: [`docs/tutorial-code/src/bin/qtt_r_sweep.rs`](../../../../tutor
 
 The core loop changes only the grid size. The QTCI call stays the same.
 The target function is `f(x) = sin(10x)` on the unit interval, with the
-one-based discrete grid index mapped to `x in [0, 1)`.
+zero-based discrete grid index mapped to `x in [0, 1)`.
 
 ```rust
 # fn main() -> anyhow::Result<()> {
@@ -21,8 +21,8 @@ for bits in [7usize, 8] {
     let size = 1usize << bits;
     let sizes = [size];
     let target_function = |x: f64| -> f64 { (10.0 * x).sin() };
-    let f = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] as f64 - 1.0) / size as f64;
+    let f = move |idx: &[usize]| -> f64 {
+        let x = idx[0] as f64 / size as f64;
         target_function(x)
     };
     let options = QtciOptions::default()
@@ -30,8 +30,8 @@ for bits in [7usize, 8] {
     let (qtt, _ranks, _errors) =
         quanticscrossinterpolate_discrete::<f64, _>(&sizes, f, None, options)?;
 
-    let last_grid_index = size as i64;
-    let x_last = (last_grid_index as f64 - 1.0) / size as f64;
+    let last_grid_index = size - 1;
+    let x_last = last_grid_index as f64 / size as f64;
     assert!((qtt.evaluate(&[last_grid_index])? - target_function(x_last)).abs() < 1e-8);
     point_counts.push(size);
 }

--- a/docs/tutorial-code/src/bin/qtt_affine.rs
+++ b/docs/tutorial-code/src/bin/qtt_affine.rs
@@ -36,16 +36,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         .with_verbosity(0);
 
     // `quanticscrossinterpolate_discrete(...)` builds the fused quantics source QTT.
-    let source_callback = move |grid_1based: &[i64]| -> f64 {
-        let u = (grid_1based[0] - 1) as usize;
-        let v = (grid_1based[1] - 1) as usize;
-        source_function(u, v, n)
-    };
-    let initial_pivots = vec![
-        vec![1, 1],
-        vec![(n / 2) as i64, (n / 2) as i64],
-        vec![n as i64, n as i64],
-    ];
+    let source_callback =
+        move |grid_idx: &[usize]| -> f64 { source_function(grid_idx[0], grid_idx[1], n) };
+    // Grid indices are 0-based.
+    let initial_pivots = vec![vec![0, 0], vec![n / 2 - 1, n / 2 - 1], vec![n - 1, n - 1]];
     let (source, _ranks, _errors) = quanticscrossinterpolate_discrete(
         &source_grid,
         source_callback,

--- a/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
+++ b/docs/tutorial-code/src/bin/qtt_elementwise_product.rs
@@ -238,13 +238,13 @@ where
         .with_verbosity(0);
 
     // Library callback: the quantics interpolator asks for values on discrete
-    // grid points, so we convert the 1-based index into a floating-point x.
-    let callback = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] as f64 - 1.0) / NPOINTS as f64;
+    // grid points, so we convert the 0-based grid index into a floating-point x.
+    let callback = move |idx: &[usize]| -> f64 {
+        let x = idx[0] as f64 / NPOINTS as f64;
         target_fn(x)
     };
 
-    let initial_pivots = vec![vec![2], vec![(NPOINTS / 2) as i64], vec![NPOINTS as i64]];
+    let initial_pivots = vec![vec![1], vec![NPOINTS / 2 - 1], vec![NPOINTS - 1]];
 
     Ok(quanticscrossinterpolate_discrete(
         &sizes,

--- a/docs/tutorial-code/src/bin/qtt_function.rs
+++ b/docs/tutorial-code/src/bin/qtt_function.rs
@@ -105,13 +105,13 @@ where
         .with_verbosity(0);
 
     // The callback is the actual function we want to compress. The discrete API
-    // uses 1-based integer grid indices, so we convert them to x in [0, 1).
-    let f = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] as f64 - 1.0) / NPOINTS as f64;
+    // uses 0-based integer grid indices, so we convert them to x in [0, 1).
+    let f = move |idx: &[usize]| -> f64 {
+        let x = idx[0] as f64 / NPOINTS as f64;
         target_fn(x)
     };
 
-    let initial_pivots = vec![vec![2], vec![(NPOINTS / 2) as i64], vec![NPOINTS as i64]];
+    let initial_pivots = vec![vec![1], vec![NPOINTS / 2 - 1], vec![NPOINTS - 1]];
 
     Ok(quanticscrossinterpolate_discrete(
         &sizes,

--- a/docs/tutorial-code/src/bin/qtt_multivariate.rs
+++ b/docs/tutorial-code/src/bin/qtt_multivariate.rs
@@ -94,11 +94,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // `quanticscrossinterpolate` receives physical coordinates from the grid.
     let target = |coords: &[f64]| -> f64 { multivariate_target(coords[0], coords[1]) };
-    let npoints = 1_i64 << config.bits;
+    let npoints = 1usize << config.bits;
+    // Grid indices are 0-based.
     let initial_pivots = vec![
-        vec![1, 1],
-        vec![npoints / 2, npoints / 2],
-        vec![npoints, npoints],
+        vec![0, 0],
+        vec![npoints / 2 - 1, npoints / 2 - 1],
+        vec![npoints - 1, npoints - 1],
     ];
 
     // Build two QTT approximations of the same physical function using different layouts.

--- a/docs/tutorial-code/src/bin/qtt_r_sweep.rs
+++ b/docs/tutorial-code/src/bin/qtt_r_sweep.rs
@@ -144,13 +144,14 @@ where
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
-    // Library callback: the interpolator asks for discrete grid values.
-    let callback = move |idx: &[i64]| -> f64 {
-        let x = (idx[0] as f64 - 1.0) / npoints as f64;
+    // Library callback: the interpolator asks for discrete grid values
+    // (0-based indices).
+    let callback = move |idx: &[usize]| -> f64 {
+        let x = idx[0] as f64 / npoints as f64;
         target_fn(x)
     };
 
-    let initial_pivots = vec![vec![2], vec![(npoints / 2) as i64], vec![npoints as i64]];
+    let initial_pivots = vec![vec![1], vec![npoints / 2 - 1], vec![npoints - 1]];
 
     Ok(quanticscrossinterpolate_discrete(
         &sizes,

--- a/docs/tutorial-code/src/interpolative_qtt_common.rs
+++ b/docs/tutorial-code/src/interpolative_qtt_common.rs
@@ -183,17 +183,8 @@ fn grid_nd(bits: usize, lower: &[f64], upper: &[f64]) -> Result<DiscretizedGrid,
         .build()?)
 }
 
-fn quantics_to_tt_indices(quantics: &[i64]) -> Result<Vec<usize>, Box<dyn Error>> {
-    let mut indices = Vec::with_capacity(quantics.len());
-    for &value in quantics {
-        if value < 1 {
-            return Err(invalid_interpolative_input(format!(
-                "quantics digit must be one-based and positive, got {value}"
-            )));
-        }
-        indices.push((value - 1) as usize);
-    }
-    Ok(indices)
+fn quantics_to_tt_indices(quantics: &[usize]) -> Result<Vec<usize>, Box<dyn Error>> {
+    Ok(quantics.to_vec())
 }
 
 /// Collect full one-dimensional grid samples for plotting and verification.
@@ -217,8 +208,8 @@ where
     let npoints = 1usize << bits;
     let mut samples = Vec::with_capacity(npoints);
 
-    for index in 1..=npoints {
-        let grid_index = [index as i64];
+    for index in 0..npoints {
+        let grid_index = [index];
         let quantics = grid.grididx_to_quantics(&grid_index)?;
         let tt_indices = quantics_to_tt_indices(&quantics)?;
         let coords = grid.grididx_to_origcoord(&grid_index)?;
@@ -227,7 +218,8 @@ where
         let qtt = tt.evaluate(&tt_indices)?;
         samples.push(InterpolativeQtt1dSample {
             case_name,
-            index,
+            // 1-based display index; grid indices themselves are 0-based.
+            index: index + 1,
             x,
             exact,
             qtt,
@@ -264,17 +256,18 @@ where
     let npoints = 1usize << bits;
     let mut samples = Vec::with_capacity(npoints * npoints);
 
-    for x_index in 1..=npoints {
-        for y_index in 1..=npoints {
-            let grid_index = [x_index as i64, y_index as i64];
+    for x_index in 0..npoints {
+        for y_index in 0..npoints {
+            let grid_index = [x_index, y_index];
             let quantics = grid.grididx_to_quantics(&grid_index)?;
             let tt_indices = quantics_to_tt_indices(&quantics)?;
             let coords = grid.grididx_to_origcoord(&grid_index)?;
             let exact = exact_fn(&coords);
             let qtt = tt.evaluate(&tt_indices)?;
             samples.push(InterpolativeQtt2dSample {
-                x_index,
-                y_index,
+                // 1-based display indices; grid indices themselves are 0-based.
+                x_index: x_index + 1,
+                y_index: y_index + 1,
                 x: coords[0],
                 y: coords[1],
                 exact,

--- a/docs/tutorial-code/src/qtt_affine_common.rs
+++ b/docs/tutorial-code/src/qtt_affine_common.rs
@@ -135,17 +135,11 @@ pub fn build_source_qtt(config: &AffineTutorialConfig) -> Result<AffineQttOutput
         .with_unfoldingscheme(UnfoldingScheme::Fused)
         .with_verbosity(0);
 
-    let callback = move |grid_1based: &[i64]| -> f64 {
-        let u = (grid_1based[0] - 1) as usize;
-        let v = (grid_1based[1] - 1) as usize;
-        source_function(u, v, n)
-    };
+    let callback =
+        move |grid_idx: &[usize]| -> f64 { source_function(grid_idx[0], grid_idx[1], n) };
 
-    let initial_pivots = vec![
-        vec![1, 1],
-        vec![(n / 2) as i64, (n / 2) as i64],
-        vec![n as i64, n as i64],
-    ];
+    // Grid indices are 0-based.
+    let initial_pivots = vec![vec![0, 0], vec![n / 2 - 1, n / 2 - 1], vec![n - 1, n - 1]];
 
     Ok(quanticscrossinterpolate_discrete(
         &sizes,
@@ -247,11 +241,7 @@ pub fn collect_samples(
 
     for x in 0..n {
         for y in 0..n {
-            let sites: Vec<usize> = evaluation_grid
-                .grididx_to_quantics(&[(x + 1) as i64, (y + 1) as i64])?
-                .into_iter()
-                .map(|site| (site - 1) as usize)
-                .collect();
+            let sites = evaluation_grid.grididx_to_quantics(&[x, y])?;
             let periodic_qtt = evaluate_tree_point(periodic, periodic_site_indices, &sites)?.re;
             let antiperiodic_qtt =
                 evaluate_tree_point(antiperiodic, antiperiodic_site_indices, &sites)?.re;

--- a/docs/tutorial-code/src/qtt_difference_kernel_common.rs
+++ b/docs/tutorial-code/src/qtt_difference_kernel_common.rs
@@ -99,16 +99,14 @@ pub fn build_kernel_qtt(
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
-    let callback = move |idx: &[i64]| -> f64 {
-        let z = (idx[0] - 1) as usize;
-        kernel_value(z, n)
-    };
+    let callback = move |idx: &[usize]| -> f64 { kernel_value(idx[0], n) };
 
+    // Grid indices are 0-based.
     let initial_pivots = vec![
-        vec![1],
-        vec![(n / 4).max(1) as i64],
-        vec![(n / 2).max(1) as i64],
-        vec![n as i64],
+        vec![0],
+        vec![(n / 4).max(1) - 1],
+        vec![(n / 2).max(1) - 1],
+        vec![n - 1],
     ];
 
     Ok(quanticscrossinterpolate_discrete(
@@ -211,7 +209,7 @@ pub fn collect_samples(
         for xprime in 0..n {
             let difference = periodic_difference(x, xprime, n);
             let source_exact = kernel_value(difference, n);
-            let source_qtt = kernel.evaluate(&[(difference + 1) as i64])?;
+            let source_qtt = kernel.evaluate(&[difference])?;
             let kernel_exact = source_exact;
             let kernel_mpo = evaluate_difference_kernel_mpo(mpo, x, xprime, config.bits)?;
 

--- a/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
+++ b/docs/tutorial-code/src/qtt_elementwise_product_utils.rs
@@ -48,20 +48,20 @@ pub struct BondProfileRow {
     pub product_compressed: usize,
 }
 
-/// Convert the 1-based indexing used by the quantics callback into x in [0, 1).
-pub fn discrete_index_to_unit_interval(index_1based: i64, npoints: usize) -> f64 {
-    (index_1based as f64 - 1.0) / npoints as f64
+/// Convert a grid index into x in [0, 1).
+pub fn discrete_index_to_unit_interval(index: i64, npoints: usize) -> f64 {
+    index as f64 / npoints as f64
 }
 
-/// Convert a 1-based grid index into binary TT site indices.
+/// Convert a grid index into binary TT site indices.
 ///
 /// The returned indices follow the Quantics grid convention used here:
 /// the first TT site corresponds to the most significant bit.
-pub fn global_index_to_quantics_sites(index_1based: usize, bits: usize) -> Vec<usize> {
+pub fn global_index_to_quantics_sites(index: usize, bits: usize) -> Vec<usize> {
     let mut sites = Vec::with_capacity(bits);
 
     for bit in (0..bits).rev() {
-        sites.push(((index_1based - 1) >> bit) & 1);
+        sites.push((index >> bit) & 1);
     }
 
     sites
@@ -200,15 +200,15 @@ where
 {
     let mut samples = Vec::with_capacity(npoints);
 
-    for i in 1..=npoints {
+    for i in 0..npoints {
         let x = discrete_index_to_unit_interval(i as i64, npoints);
         let cosh_exact = cosh_fn(x);
         let factor_b_exact = factor_b_fn(x);
         let product_exact = cosh_exact * factor_b_exact;
 
-        // Library call: read one value back from each factor QTT.
-        let cosh_qtt = cosh_qtci.evaluate(&[i as i64])?;
-        let factor_b_qtt = factor_b_qtci.evaluate(&[i as i64])?;
+        // Library call: read one value back from each factor QTT (0-based index).
+        let cosh_qtt = cosh_qtci.evaluate(&[i])?;
+        let factor_b_qtt = factor_b_qtci.evaluate(&[i])?;
         let site_values = global_index_to_quantics_sites(i, bits);
         // Library call: read the pointwise product back from the TreeTN.
         let product_raw = evaluate_tree_point(product_raw_tn, product_site_indices, &site_values)?;
@@ -216,7 +216,7 @@ where
             evaluate_tree_point(product_compressed_tn, product_site_indices, &site_values)?;
 
         samples.push(SamplePoint {
-            index: i,
+            index: i + 1,
             x,
             cosh_exact,
             cosh_qtt,

--- a/docs/tutorial-code/src/qtt_fourier_common.rs
+++ b/docs/tutorial-code/src/qtt_fourier_common.rs
@@ -119,8 +119,9 @@ pub fn build_gaussian_qtt(
         .with_verbosity(0);
 
     let f = |coords: &[f64]| -> f64 { gaussian_target(coords[0]) };
-    let npoints = 1_i64 << config.bits;
-    let initial_pivots = vec![vec![1], vec![npoints / 2], vec![npoints]];
+    let npoints = 1usize << config.bits;
+    // Grid indices are 0-based.
+    let initial_pivots = vec![vec![0], vec![npoints / 2 - 1], vec![npoints - 1]];
 
     Ok(quanticscrossinterpolate(
         grid,
@@ -147,12 +148,12 @@ pub fn build_fourier_operator(
     Ok(quantics_fourier_operator(config.bits, options)?)
 }
 
-/// Convert a 1-based discrete index into the binary site values used by the quantics grid.
-pub fn global_index_to_quantics_sites(index_1based: usize, bits: usize) -> Vec<usize> {
+/// Convert a grid index into the binary site values used by the quantics grid.
+pub fn global_index_to_quantics_sites(index: usize, bits: usize) -> Vec<usize> {
     let mut sites = Vec::with_capacity(bits);
 
     for bit in (0..bits).rev() {
-        sites.push(((index_1based - 1) >> bit) & 1);
+        sites.push((index >> bit) & 1);
     }
 
     sites
@@ -215,7 +216,7 @@ pub fn collect_samples(
     for (row_index, &k) in k_coords.iter().enumerate() {
         let centered_bin = row_index as isize - (npoints as isize / 2);
         let coefficient_index = centered_bin.rem_euclid(npoints as isize) as usize;
-        let mut site_values = global_index_to_quantics_sites(coefficient_index + 1, config.bits);
+        let mut site_values = global_index_to_quantics_sites(coefficient_index, config.bits);
         site_values.reverse();
         // this is the actual extraction, the rest is just scaling and phase factors to match the continuous Fourier convention
         let raw_qtt = evaluate_tree_point(transformed, site_indices, &site_values)?;
@@ -378,8 +379,8 @@ mod tests {
 
     #[test]
     fn global_index_to_quantics_sites_uses_msb_first_order() {
-        assert_eq!(global_index_to_quantics_sites(1, 3), vec![0, 0, 0]);
-        assert_eq!(global_index_to_quantics_sites(5, 3), vec![1, 0, 0]);
-        assert_eq!(global_index_to_quantics_sites(8, 3), vec![1, 1, 1]);
+        assert_eq!(global_index_to_quantics_sites(0, 3), vec![0, 0, 0]);
+        assert_eq!(global_index_to_quantics_sites(4, 3), vec![1, 0, 0]);
+        assert_eq!(global_index_to_quantics_sites(7, 3), vec![1, 1, 1]);
     }
 }

--- a/docs/tutorial-code/src/qtt_function_utils.rs
+++ b/docs/tutorial-code/src/qtt_function_utils.rs
@@ -23,13 +23,12 @@ pub struct SamplePoint {
     pub abs_error: f64,
 }
 
-/// Convert a 1-based discrete index to a point in the unit interval.
+/// Convert a grid index to a point in the unit interval.
 ///
-/// The quantics interpolation API uses 1-based indexing for the callback.  That
-/// feels Julia-like, but it is different from Rust arrays, so we keep the mapping
-/// in a dedicated helper for clarity.
-pub fn discrete_index_to_unit_interval(index_1based: i64, npoints: usize) -> f64 {
-    (index_1based as f64 - 1.0) / npoints as f64
+/// The quantics interpolation API uses 0-based grid indices, matching Rust
+/// array indexing, so the mapping is the direct ratio `index / npoints`.
+pub fn discrete_index_to_unit_interval(index: i64, npoints: usize) -> f64 {
+    index as f64 / npoints as f64
 }
 
 /// Evaluate the QTT at every grid point and compare it with the analytic target.
@@ -48,13 +47,13 @@ where
 {
     let mut samples = Vec::with_capacity(npoints);
 
-    for i in 1..=npoints {
+    for i in 0..npoints {
         let x = discrete_index_to_unit_interval(i as i64, npoints);
         let exact = exact_fn(x);
-        let qtt = qtci.evaluate(&[i as i64])?;
+        let qtt = qtci.evaluate(&[i])?;
 
         samples.push(SamplePoint {
-            index: i,
+            index: i + 1,
             x,
             exact,
             qtt,

--- a/docs/tutorial-code/src/qtt_interval_common.rs
+++ b/docs/tutorial-code/src/qtt_interval_common.rs
@@ -86,8 +86,9 @@ where
         .with_verbosity(0);
 
     let f = move |coords: &[f64]| -> f64 { target_fn(coords[0]) };
-    let npoints = 1_i64 << config.bits;
-    let initial_pivots = vec![vec![1], vec![npoints / 2], vec![npoints]];
+    let npoints = 1usize << config.bits;
+    // Grid indices are 0-based.
+    let initial_pivots = vec![vec![0], vec![npoints / 2 - 1], vec![npoints - 1]];
 
     Ok(quanticscrossinterpolate(
         grid,

--- a/docs/tutorial-code/src/qtt_interval_utils.rs
+++ b/docs/tutorial-code/src/qtt_interval_utils.rs
@@ -37,8 +37,9 @@ pub fn collect_samples<F>(
 where
     F: Fn(f64) -> f64,
 {
-    // The grid gives us the physical coordinates.  We keep the 1-based grid
-    // index alongside each sample so the user can compare Rust and Julia output.
+    // The grid gives us the physical coordinates.  We keep a 1-based display
+    // index alongside each sample so the user can compare Rust and Julia output;
+    // the grid indices passed to the library are 0-based.
     //
     // `grid_origcoords(0)` is a `DiscretizedGrid` API call.  It returns the
     // physical coordinates for the first dimension, which is exactly what we
@@ -51,8 +52,8 @@ where
         let exact = exact_fn(x);
 
         // `evaluate(...)` is the QTT read-back step.  The input index is
-        // 1-based, matching the convention used throughout tensor4all-rs.
-        let qtt = qtci.evaluate(&[index as i64])?;
+        // 0-based, matching the convention used throughout tensor4all-rs.
+        let qtt = qtci.evaluate(&[i])?;
 
         samples.push(SamplePoint {
             index,

--- a/docs/tutorial-code/src/qtt_multivariate_common.rs
+++ b/docs/tutorial-code/src/qtt_multivariate_common.rs
@@ -85,11 +85,12 @@ where
         .with_verbosity(0);
 
     let f = move |coords: &[f64]| -> f64 { target_fn(coords[0], coords[1]) };
-    let npoints = point_count(config) as i64;
+    let npoints = point_count(config);
+    // Grid indices are 0-based.
     let initial_pivots = vec![
-        vec![1, 1],
-        vec![npoints / 2, npoints / 2],
-        vec![npoints, npoints],
+        vec![0, 0],
+        vec![npoints / 2 - 1, npoints / 2 - 1],
+        vec![npoints - 1, npoints - 1],
     ];
 
     Ok(quanticscrossinterpolate(
@@ -155,10 +156,10 @@ fn dense_quantics_batch(
     let mut indices = Vec::with_capacity(len);
 
     for flat_index in start..start + len {
-        let x_index = (flat_index / y_count) + 1;
-        let y_index = (flat_index % y_count) + 1;
-        let quantics = grid.grididx_to_quantics(&[x_index as i64, y_index as i64])?;
-        indices.push(quantics.iter().map(|&q| (q - 1) as usize).collect());
+        let x_index = flat_index / y_count;
+        let y_index = flat_index % y_count;
+        let quantics = grid.grididx_to_quantics(&[x_index, y_index])?;
+        indices.push(quantics);
     }
 
     Ok(indices)
@@ -450,8 +451,8 @@ mod tests {
             assert!(!ranks.is_empty());
             assert!(!errors.is_empty());
 
-            let value = qtci.evaluate(&[1, 1])?;
-            let exact = test_multivariate_target(0.0, 0.0);
+            let value = qtci.evaluate(&[0, 0])?;
+            let exact = test_multivariate_target(config.lower_bound, config.lower_bound);
             assert!((value - exact).abs() < 1e-9);
         }
 
@@ -497,9 +498,9 @@ mod tests {
 
         let dense_values = evaluate_dense_qtt(&qtt)?;
 
-        for (x_index, y_index) in [(1, 1), (2, 5), (8, 8)] {
-            let flat_index = (x_index - 1) * point_count(&config) + (y_index - 1);
-            let direct = qtt.evaluate(&[x_index as i64, y_index as i64])?;
+        for (x_index, y_index) in [(0, 0), (1, 4), (7, 7)] {
+            let flat_index = x_index * point_count(&config) + y_index;
+            let direct = qtt.evaluate(&[x_index, y_index])?;
             assert!((dense_values[flat_index] - direct).abs() < 1e-12);
         }
 

--- a/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
+++ b/docs/tutorial-code/src/qtt_partial_fourier2d_common.rs
@@ -104,10 +104,10 @@ pub fn x_site_node_mapping(bits: usize) -> Vec<(usize, usize)> {
     (0..bits).map(|site| (site, 2 * site)).collect()
 }
 
-pub fn global_index_to_quantics_sites(index_1based: usize, bits: usize) -> Vec<usize> {
+pub fn global_index_to_quantics_sites(index: usize, bits: usize) -> Vec<usize> {
     let mut sites = Vec::with_capacity(bits);
     for bit in (0..bits).rev() {
-        sites.push(((index_1based - 1) >> bit) & 1);
+        sites.push((index >> bit) & 1);
     }
     sites
 }
@@ -117,8 +117,8 @@ pub fn interleaved_site_values(
     t_zero_based: usize,
     bits: usize,
 ) -> Vec<usize> {
-    let x_sites = global_index_to_quantics_sites(x_zero_based + 1, bits);
-    let t_sites = global_index_to_quantics_sites(t_zero_based + 1, bits);
+    let x_sites = global_index_to_quantics_sites(x_zero_based, bits);
+    let t_sites = global_index_to_quantics_sites(t_zero_based, bits);
     x_sites
         .into_iter()
         .zip(t_sites)
@@ -186,19 +186,20 @@ pub fn build_source_qtt(
         .with_unfoldingscheme(UnfoldingScheme::Interleaved)
         .with_verbosity(0);
 
-    let npoints = point_count(config) as i64;
+    let npoints = point_count(config);
+    // 0-based grid indices; the first row spans x = 0.
     let x_indices = [
-        npoints / 8,
-        npoints / 4,
-        3 * npoints / 8,
+        npoints / 8 - 1,
+        npoints / 4 - 1,
+        3 * npoints / 8 - 1,
+        npoints / 2 - 2,
         npoints / 2 - 1,
         npoints / 2,
-        npoints / 2 + 1,
-        5 * npoints / 8,
-        3 * npoints / 4,
-        7 * npoints / 8,
+        5 * npoints / 8 - 1,
+        3 * npoints / 4 - 1,
+        7 * npoints / 8 - 1,
     ];
-    let t_indices: Vec<i64> = (1..=npoints).collect();
+    let t_indices: Vec<usize> = (0..npoints).collect();
     let initial_pivots = x_indices
         .iter()
         .flat_map(|&x_index| t_indices.iter().map(move |&t_index| vec![x_index, t_index]))
@@ -314,11 +315,11 @@ pub fn collect_samples(
     for (k_offset, &k) in k_coords.iter().enumerate() {
         let centered_bin = k_offset as isize - (npoints as isize / 2);
         let coefficient_index = centered_bin.rem_euclid(npoints as isize) as usize;
-        let mut k_sites = global_index_to_quantics_sites(coefficient_index + 1, config.bits);
+        let mut k_sites = global_index_to_quantics_sites(coefficient_index, config.bits);
         k_sites.reverse();
 
         for (t_offset, &t) in t_coords.iter().enumerate() {
-            let t_sites = global_index_to_quantics_sites(t_offset + 1, config.bits);
+            let t_sites = global_index_to_quantics_sites(t_offset, config.bits);
             let site_values: Vec<usize> = k_sites
                 .iter()
                 .copied()

--- a/docs/tutorial-code/src/qtt_r_sweep_utils.rs
+++ b/docs/tutorial-code/src/qtt_r_sweep_utils.rs
@@ -32,9 +32,9 @@ pub struct SweepStats {
     pub rank: usize,
 }
 
-/// Convert the 1-based discrete index used by the quantics callback into `x`.
-pub fn discrete_index_to_unit_interval(index_1based: i64, npoints: usize) -> f64 {
-    (index_1based as f64 - 1.0) / npoints as f64
+/// Convert a grid index into `x` in [0, 1).
+pub fn discrete_index_to_unit_interval(index: i64, npoints: usize) -> f64 {
+    index as f64 / npoints as f64
 }
 
 /// Re-evaluate one QTT on all grid points and collect the error against the
@@ -55,15 +55,16 @@ where
 {
     let mut rows = Vec::with_capacity(npoints);
 
-    for index in 1..=npoints {
+    for index in 0..npoints {
         let x = discrete_index_to_unit_interval(index as i64, npoints);
         let exact = target_fn(x);
-        // Library call: evaluate one grid point from the QTT approximation.
-        let qtt = qtci.evaluate(&[index as i64])?;
+        // Library call: evaluate one grid point from the QTT approximation
+        // (0-based index).
+        let qtt = qtci.evaluate(&[index])?;
         rows.push(SweepSample {
             r,
             npoints,
-            index,
+            index: index + 1,
             x,
             exact,
             qtt,

--- a/docs/tutorial-code/tests/verification.rs
+++ b/docs/tutorial-code/tests/verification.rs
@@ -51,7 +51,7 @@ fn output_paths_support_default_and_override() {
 #[test]
 fn quantics_index_helpers_keep_expected_order() {
     assert_eq!(
-        qtt_fourier_common::global_index_to_quantics_sites(5, 3),
+        qtt_fourier_common::global_index_to_quantics_sites(4, 3),
         vec![1, 0, 0]
     );
     assert_eq!(
@@ -62,9 +62,9 @@ fn quantics_index_helpers_keep_expected_order() {
         qtt_partial_fourier2d_common::interleaved_site_values(2, 1, 2),
         vec![1, 0, 0, 1]
     );
-    assert!((qtt_function_utils::discrete_index_to_unit_interval(4, 8) - 0.375).abs() < 1e-12);
+    assert!((qtt_function_utils::discrete_index_to_unit_interval(3, 8) - 0.375).abs() < 1e-12);
     assert!(
-        (qtt_elementwise_product_utils::discrete_index_to_unit_interval(4, 8) - 0.375).abs()
+        (qtt_elementwise_product_utils::discrete_index_to_unit_interval(3, 8) - 0.375).abs()
             < 1e-12
     );
 }


### PR DESCRIPTION
Closes tensor4all/tensor4all-rs#582.

## What

Follows the quanticsgrids-rs 0.2.0 migration (tensor4all/quanticsgrids-rs#2,
merged). The workspace now has exactly **one indexing convention
(0-indexed)** — the quanticstci exception is gone, and the five `±1`
conversions at the TCI boundary (`quantics_tci.rs` 178/478/523/774/811 at
the audited rev) are removed.

## Changes

- **Pin bump**: `quanticsgrids` rev `a76b8fb` → `8214b72` (0.2.0, 0-indexed).
- **`quanticscrossinterpolate_discrete`**: callbacks receive 0-indexed
  grid indices as `&[usize]` instead of 1-indexed `&[i64]`.
- **`QuanticsTensorCI2::evaluate(&[usize])`**: 0-indexed.
- **`initial_pivots`**: 0-indexed `Option<Vec<Vec<usize>>>`.
- **`cachedata()`**: keys are 0-indexed quantics indices (`Vec<usize>`).
- Removed the `(q ± 1)` conversions in the qf closures, initial-pivot
  handling, and the batched path — the treetci/TTCache boundary is now
  convention-free.
- **Docs**: `docs/book/src/conventions.md` drops the 1-indexed exception
  clause entirely; quanticstci module doc, README, and CHANGELOG
  porting note updated.

## Porting note

QuanticsTCI.jl scripts must subtract 1 from grid indices at the call
boundary.

## Verification

- `cargo nextest run --release --workspace`: 2791 passed
- doc tests + mdBook + clippy (`-D warnings`) + fmt all pass
- tutorial-code, interpolativeqtt, and treetci consumers updated to the
  0-indexed API
- Acceptance criterion: grep for "1-indexed" in `crates/` returns nothing
  except unrelated HDF5 subgroup naming; the five conversion sites are
  gone