### PR TITLE
fix(aci): safe-side global pivot search guard — every-sweep search, floating-zone coordinate descent (#610)

### DIFF
--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -3,7 +3,7 @@
 use crate::global_guard::find_global_pivots;
 use crate::scalar::AciScalar;
 use crate::validation::{validate_inputs, validate_options};
-use crate::{AciOptions, AciResult, ElementwiseBatch, ElementwiseProblem, Result};
+use crate::{AciOptions, AciResult, AciTermination, ElementwiseBatch, ElementwiseProblem, Result};
 use tensor4all_simplett::{
     tensor3_from_data, AbstractTensorTrain, EinsumScalar, SimpleTensorTrain,
 };
@@ -21,21 +21,23 @@ use tensor4all_simplett::{
 /// normalized value is used.
 ///
 /// When [`AciOptions::enable_global_guard`] is enabled (the default), the
-/// local stopping rule is gated by a global pivot search: before accepting
-/// convergence, the current solution is sampled against the true operator at
-/// global points, and any significantly-wrong points are injected into the
-/// sweep's frames so the next sweep absorbs them. The search only runs at the
-/// moment the local criterion would otherwise stop, so it adds no operator
-/// evaluations during normal sweeps.
+/// local stopping rule is gated by a global pivot search: after every sweep
+/// the current solution is sampled against the true operator at global points
+/// via floating-zone walks, and any significantly-wrong points are injected
+/// into the sweep's frames so the next sweep absorbs them. Convergence is
+/// additionally gated on the search finding nothing for
+/// [`AciOptions::min_iters`] consecutive sweeps (mirroring the Julia
+/// `convergencecriterion`), so a feature the local sweeps cannot see blocks
+/// acceptance instead of being silently lost.
 ///
 /// Sweeping also stops once the solution rank has sat at
 /// [`AciOptions::max_bond_dim`] for [`AciOptions::min_iters`] consecutive
 /// sweeps. At the cap the sweep can no longer add pivots, so the tolerance can
 /// never be met and further sweeps only repeat full-rank work. A run that stops
 /// this way returns normally with a final entry of [`AciResult::errors`] above
-/// [`AciOptions::tolerance`]: under a binding `max_bond_dim` that outcome is by
-/// design, not a failure. Compare the last [`AciResult::ranks`] entry against
-/// `max_bond_dim` to tell a rank-limited run from a converged one.
+/// [`AciOptions::tolerance`] and [`AciResult::termination`] set to
+/// [`AciTermination::RankLimited`]: under a binding `max_bond_dim` that outcome
+/// is by design, not a failure.
 ///
 /// For single-site tensor trains there are no bonds to sweep. In that case the
 /// operator is evaluated once over all site points, and the returned
@@ -116,7 +118,9 @@ where
 
     let mut ranks = Vec::new();
     let mut errors = Vec::new();
+    let mut nglobal_pivots_history = Vec::new();
     let mut guard_runs = 0usize;
+    let mut termination = AciTermination::MaxIterations;
 
     for iteration in 0..options.max_iters {
         let forward = iteration % 2 == 0;
@@ -140,40 +144,60 @@ where
 
         // Global pivot search guard: the local criterion only sees
         // bond-local samples, so a feature outside the sampled crosses can be
-        // silently lost while the run self-reports convergence. Before
-        // accepting, sample the current solution against the true operator at
-        // global points; if significantly-wrong points exist, inject them and
-        // keep sweeping instead of converging.
+        // silently lost while the run self-reports convergence. After every
+        // sweep, walk random starting points toward large
+        // |op - solution| error and inject any significantly-wrong points;
+        // convergence is gated on the search finding nothing over the
+        // convergence window (see `convergence_criterion_like_julia`). The
+        // search is skipped while the rank already sits at `max_bond_dim`:
+        // the sweep has no headroom to absorb new pivots, so the guard could
+        // only pad the solution beyond the cap it will never be able to
+        // sweep back down.
+        let rank_capped = options
+            .max_bond_dim
+            .is_some_and(|cap| problem.solution.rank() >= cap);
+        if options.enable_global_guard
+            && options.nsearch_global_pivots > 0
+            && options.max_nglobal_pivot > 0
+            && !rank_capped
+        {
+            guard_runs += 1;
+            let seed = options.rng_seed.wrapping_add(guard_runs as u64);
+            let pivots = find_global_pivots(&problem, &mut op, options, seed)?;
+            let _added = problem.add_global_pivots(&pivots)?;
+            nglobal_pivots_history.push(pivots.len());
+        } else {
+            nglobal_pivots_history.push(0);
+        }
+
         if convergence_criterion_like_julia(
             iteration + 1,
             &ranks,
             &errors,
+            &nglobal_pivots_history,
             options.min_iters,
             options.tolerance,
         ) {
-            if !options.enable_global_guard
-                || options.nsearch_global_pivots == 0
-                || options.max_nglobal_pivot == 0
-            {
-                break;
-            }
-            guard_runs += 1;
-            let seed = options.rng_seed.wrapping_add(guard_runs as u64);
-            let pivots = find_global_pivots(&problem, &mut op, options, seed)?;
-            if pivots.is_empty() {
-                break;
-            }
-            let added = problem.add_global_pivots(&pivots)?;
-            if added == 0 {
-                // Every found pivot was already in the frames and the sweeps
-                // could not absorb it (e.g. the bond dimension is capped);
-                // further guard runs cannot help.
-                break;
-            }
+            termination = AciTermination::Converged;
+            break;
         }
 
         if rank_is_saturated(&ranks, options.min_iters, options.max_bond_dim) {
+            termination = AciTermination::RankLimited;
             break;
+        }
+    }
+
+    // A guard injection can leave the solution one injection above
+    // `max_bond_dim` when the loop exits right after (e.g. `max_iters`
+    // expired, or the rank capped below the sweep's headroom). Run one final
+    // forward sweep so the returned tensor train respects the cap; this
+    // mirrors the final cleanup sweep Julia performs after `addglobalpivots`.
+    if let Some(cap) = options.max_bond_dim {
+        if problem.solution.rank() > cap {
+            for bond in 0..problem.len() - 1 {
+                problem.local_update(bond, true, options, &mut op)?;
+            }
         }
     }
 
@@ -181,6 +205,8 @@ where
         tensor_train: problem.solution,
         ranks,
         errors,
+        nglobal_pivots: nglobal_pivots_history,
+        termination,
     })
 }
 
@@ -210,6 +236,8 @@ where
         tensor_train: SimpleTensorTrain::new(vec![core])?,
         ranks: Vec::new(),
         errors: Vec::new(),
+        nglobal_pivots: Vec::new(),
+        termination: AciTermination::Converged,
     })
 }
 
@@ -310,12 +338,14 @@ pub(crate) fn convergence_criterion_like_julia(
     iteration: usize,
     ranks: &[usize],
     errors: &[f64],
+    nglobal_pivots: &[usize],
     min_iters: usize,
     tolerance: f64,
 ) -> bool {
     debug_assert!(iteration > 0);
     debug_assert_eq!(ranks.len(), iteration);
     debug_assert_eq!(errors.len(), iteration);
+    debug_assert_eq!(nglobal_pivots.len(), iteration);
 
     if iteration == 0 || min_iters == 0 {
         return false;
@@ -328,9 +358,20 @@ pub(crate) fn convergence_criterion_like_julia(
     }
 
     let baseline = ranks[iteration - min_iters];
-    !ranks[(iteration - min_iters)..iteration]
+    if ranks[(iteration - min_iters)..iteration]
         .iter()
         .any(|&rank| rank > baseline)
+    {
+        return false;
+    }
+
+    // The global pivot search must have found nothing over the same window:
+    // an iteration that injected pivots has not yet swept them, so its error
+    // estimate is stale with respect to those pivots (Julia's
+    // `convergencecriterion` `nglobalpivots == 0` disjunct).
+    nglobal_pivots[(iteration - min_iters)..iteration]
+        .iter()
+        .all(|&n| n == 0)
 }
 
 /// Reports whether the solution rank has been pinned at `max_bond_dim` long

--- a/crates/tensor4all-aci/src/global_guard.rs
+++ b/crates/tensor4all-aci/src/global_guard.rs
@@ -4,35 +4,45 @@
 //! feature outside the sampled crosses (e.g. a near-degenerate second peak
 //! far from the initial pivots) is invisible to the stopping rule: the run
 //! self-reports convergence while the feature silently vanishes. This module
-//! implements the same guard as `tensor4all-treetci`'s global pivot search:
-//! before accepting convergence, the current solution is sampled against the
-//! true operator at global points, and any significantly-wrong points are
-//! returned for injection into the ACI frames.
+//! implements the global pivot search guard: before convergence is accepted
+//! the current solution is sampled against the true operator at global
+//! points, and any significantly-wrong points are returned for injection
+//! into the ACI frames.
+//!
+//! The search uses floating-zone walks ([`floating_zone_walk`]), the same
+//! greedy coordinate-descent search as `TensorCrossInterpolation.jl`'s
+//! `_floatingzone` and `tensor4all-tensorci`'s [`floating_zone`]
+//! (tensor4all_tensorci::floating_zone): each random start moves one site
+//! coordinate at a time toward the largest interpolation error. This is a
+//! strict generalization of the single-cross scan (one sweep with no
+//! repeats), so far features that a cross scan can never sample are reachable
+//! when the error landscape has a detectable gradient.
 
 use crate::scalar::AciScalar;
 use crate::{AciOptions, ElementwiseBatch, ElementwiseProblem, Result};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use tensor4all_simplett::{AbstractTensorTrain, EinsumScalar, TTCache};
-use tensor4all_tcicore::MatrixLuciScalar;
+use tensor4all_tcicore::{floating_zone_walk, MatrixLuciScalar};
 
 /// Search for global multi-indices where the current solution is wrong.
 ///
-/// Algorithm (mirrors `tensor4all-treetci`'s `find_global_pivots`):
+/// Algorithm:
 ///
 /// 1. Draw `nsearch` random starting points.
-/// 2. For each starting point, sweep every site coordinate over its full
-///    local dimension, keeping the point with the largest interpolation
-///    error `|op(inputs(idx)) - solution(idx)|`.
+/// 2. For each starting point, run a floating-zone walk: repeatedly sweep
+///    every site coordinate, moving each coordinate to the value with the
+///    largest interpolation error `|op(inputs(idx)) - solution(idx)|`, until
+///    the error stops improving or exceeds `abs_tol * tol_margin`.
 /// 3. Keep points whose error exceeds `abs_tol * tol_margin`, where
 ///    `abs_tol` is the configured tolerance (scaled by the maximum sampled
 ///    operator magnitude when `scale_tolerance` is enabled).
 /// 4. Return at most `max_nglobal_pivot` distinct points.
 ///
-/// Input values and the current solution are evaluated at all candidate
-/// points in one batch per tensor train via [`TTCache::evaluate_many`]
-/// (shared prefixes/suffixes are contracted once); the operator is called in
-/// a single [`ElementwiseBatch`].
+/// Input values and the current solution are evaluated per walk step in one
+/// cached batch per tensor train via [`TTCache::evaluate_many`] (shared
+/// prefixes/suffixes are contracted once); the operator is called in a single
+/// [`ElementwiseBatch`] per step.
 pub(crate) fn find_global_pivots<T, F>(
     problem: &ElementwiseProblem<T>,
     op: &mut F,
@@ -55,44 +65,27 @@ where
         .map(|site| problem.solution.site_dim(site))
         .collect();
 
-    // Candidate points: for each random start, sweep each site coordinate
-    // over its full local dimension (same local search as the chain and tree
-    // TCI2 finders; candidates share prefixes/suffixes heavily, which
-    // `TTCache::evaluate_many` exploits).
     let mut rng = StdRng::seed_from_u64(seed);
-    let mut points: Vec<Vec<usize>> = Vec::new();
-    for _ in 0..nsearch {
-        let start: Vec<usize> = site_dims.iter().map(|&d| rng.random_range(0..d)).collect();
-        for site in 0..n_sites {
-            for value in 0..site_dims[site] {
-                let mut point = start.clone();
-                point[site] = value;
-                points.push(point);
-            }
-        }
-    }
-    let n_points = points.len();
+    let starts: Vec<Vec<usize>> = (0..nsearch)
+        .map(|_| site_dims.iter().map(|&d| rng.random_range(0..d)).collect())
+        .collect();
 
-    // Input values at all candidate points: one cached batch per input.
-    let mut input_values = vec![T::zero(); n_inputs * n_points];
+    // Absolute threshold for "significantly wrong": abs_tol * tol_margin.
+    // With scale_tolerance the operator scale is estimated from the random
+    // starting points (the walk is not handed a precomputed candidate set).
+    let mut start_input_values = vec![T::zero(); n_inputs * nsearch];
     for input in 0..n_inputs {
         let mut cache = TTCache::new(&problem.inputs[input]);
-        let values = cache.evaluate_many(&points, None)?;
+        let values = cache.evaluate_many(&starts, None)?;
         for (point, value) in values.into_iter().enumerate() {
-            input_values[input + n_inputs * point] = value;
+            start_input_values[input + n_inputs * point] = value;
         }
     }
+    let start_batch = ElementwiseBatch::new(&start_input_values, n_inputs, nsearch)?;
+    let mut start_op_values = vec![T::zero(); nsearch];
+    op(start_batch, &mut start_op_values)?;
 
-    // Operator output at all candidate points: one batch call.
-    let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
-    let mut op_values = vec![T::zero(); n_points];
-    op(batch, &mut op_values)?;
-
-    // Current solution at all candidate points: one cached batch.
-    let mut solution_cache = TTCache::new(&problem.solution);
-    let solution_values = solution_cache.evaluate_many(&points, None)?;
-
-    let max_op_abs = op_values
+    let max_op_abs = start_op_values
         .iter()
         .map(|&value| MatrixLuciScalar::abs_val(value))
         .fold(0.0f64, f64::max);
@@ -103,29 +96,39 @@ where
     };
     let threshold = abs_tol * options.tol_margin_global_search;
 
-    // Local search per starting point.
+    // Floating-zone walk per starting point.
     let mut best: Vec<(f64, Vec<usize>)> = Vec::new();
-    let mut point_index = 0usize;
-    for _ in 0..nsearch {
-        let mut start_best: Option<(f64, Vec<usize>)> = None;
-        for &site_dim in &site_dims {
-            for _value in 0..site_dim {
-                let error = MatrixLuciScalar::abs_val(
-                    op_values[point_index] - solution_values[point_index],
-                );
-                if start_best
-                    .as_ref()
-                    .is_none_or(|(best_error, _)| error > *best_error)
-                {
-                    start_best = Some((error, points[point_index].clone()));
+    for start in &starts {
+        let (pivot, error) = floating_zone_walk(
+            &site_dims,
+            start,
+            options.nsweeps_global_search,
+            threshold,
+            |points: &[Vec<usize>]| -> crate::Result<Vec<f64>> {
+                let n_points = points.len();
+                let mut input_values = vec![T::zero(); n_inputs * n_points];
+                for input in 0..n_inputs {
+                    let mut cache = TTCache::new(&problem.inputs[input]);
+                    let values = cache.evaluate_many(points, None)?;
+                    for (point, value) in values.into_iter().enumerate() {
+                        input_values[input + n_inputs * point] = value;
+                    }
                 }
-                point_index += 1;
-            }
-        }
-        if let Some((error, point)) = start_best {
-            if error > threshold {
-                best.push((error, point));
-            }
+                let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
+                let mut op_values = vec![T::zero(); n_points];
+                op(batch, &mut op_values)?;
+                let mut solution_cache = TTCache::new(&problem.solution);
+                let solution_values = solution_cache.evaluate_many(points, None)?;
+                let errors = (0..n_points)
+                    .map(|point| {
+                        MatrixLuciScalar::abs_val(op_values[point] - solution_values[point])
+                    })
+                    .collect::<Vec<f64>>();
+                Ok(errors)
+            },
+        )?;
+        if error > threshold {
+            best.push((error, pivot));
         }
     }
 

--- a/crates/tensor4all-aci/src/lib.rs
+++ b/crates/tensor4all-aci/src/lib.rs
@@ -53,7 +53,7 @@ pub(crate) use local::LocalBlockEvaluator;
 pub use options::AciOptions;
 #[allow(unused_imports)]
 pub(crate) use random_tt::initial_guess;
-pub use result::AciResult;
+pub use result::{AciResult, AciTermination};
 pub use scalar::AciScalar;
 #[allow(unused_imports)]
 pub(crate) use state::ElementwiseProblem;

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -29,6 +29,7 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 /// assert!(options.enable_global_guard);
 /// assert_eq!(options.nsearch_global_pivots, 5);
 /// assert_eq!(options.max_nglobal_pivot, 5);
+/// assert_eq!(options.nsweeps_global_search, 100);
 /// assert!((options.tol_margin_global_search - 10.0).abs() < 1e-15);
 /// ```
 #[derive(Debug, Clone)]
@@ -92,19 +93,20 @@ pub struct AciOptions<T: TTScalar> {
     /// The local sweep estimates error from bond-local 2-site blocks only, so a
     /// feature outside the sampled crosses (e.g. a near-degenerate second peak
     /// far from the initial pivots) is invisible to the stopping rule. When
-    /// enabled, the optimizer samples the current solution against the true
-    /// operator at global points before accepting convergence and injects any
-    /// significantly-wrong points as pivots. The search runs only at the moment
-    /// the local criterion would otherwise stop, so the default-on guard adds no
-    /// operator evaluations during normal sweeps. Default: `true`.
+    /// enabled, the optimizer runs a global pivot search after every sweep,
+    /// injects any significantly-wrong points as pivots, and only accepts
+    /// convergence when the search has found nothing for [`min_iters`](Self::min_iters)
+    /// consecutive sweeps. Default: `true`.
     pub enable_global_guard: bool,
 
     /// Number of random starting points for the global pivot search guard.
     ///
-    /// Each starting point is locally optimized over all site coordinates.
-    /// Larger values explore the index space more thoroughly at the cost of more
-    /// evaluations. Ignored when `enable_global_guard` is `false`; `0` disables
-    /// the search. Default: `5`.
+    /// Each starting point launches a floating-zone walk (greedy
+    /// coordinate-descent; see [`floating_zone_walk`](tensor4all_tcicore::floating_zone_walk))
+    /// that moves one site coordinate at a time toward the largest
+    /// interpolation error. Larger values explore the index space more
+    /// thoroughly at the cost of more evaluations. Ignored when
+    /// `enable_global_guard` is `false`; `0` disables the search. Default: `5`.
     pub nsearch_global_pivots: usize,
 
     /// Maximum number of global pivots injected per guard run.
@@ -112,6 +114,14 @@ pub struct AciOptions<T: TTScalar> {
     /// Ignored when `enable_global_guard` is `false`; `0` disables the search.
     /// Default: `5`.
     pub max_nglobal_pivot: usize,
+
+    /// Upper bound on coordinate sweeps per floating-zone walk.
+    ///
+    /// A walk stops early once the maximum error stops improving or exceeds
+    /// `abs_tol * tol_margin_global_search`, so this bound rarely binds; it is
+    /// a safety cap for pathological error landscapes. Ignored when
+    /// `enable_global_guard` is `false`; `0` disables the search. Default: `100`.
+    pub nsweeps_global_search: usize,
 
     /// Tolerance margin for the global pivot search guard.
     ///
@@ -137,6 +147,7 @@ impl<T: TTScalar> Default for AciOptions<T> {
             enable_global_guard: true,
             nsearch_global_pivots: 5,
             max_nglobal_pivot: 5,
+            nsweeps_global_search: 100,
             tol_margin_global_search: 10.0,
         }
     }

--- a/crates/tensor4all-aci/src/result.rs
+++ b/crates/tensor4all-aci/src/result.rs
@@ -2,12 +2,32 @@
 
 use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 
+/// Reason an [`AciResult`] run stopped.
+///
+/// Related types: [`AciResult::termination`] reports which exit fired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AciTermination {
+    /// The sweep reached the requested tolerance with stable rank and the
+    /// global pivot search found nothing over the convergence window.
+    Converged,
+    /// The rank stayed at [`AciOptions::max_bond_dim`](crate::AciOptions::max_bond_dim)
+    /// for the whole convergence window, so the tolerance is not reachable
+    /// under the bond cap. This is by design, not a failure; the final
+    /// [`AciResult::errors`] entry is expected to remain above tolerance.
+    RankLimited,
+    /// The run consumed all [`AciOptions::max_iters`](crate::AciOptions::max_iters)
+    /// sweeps without satisfying either exit. Increase `max_iters` or loosen
+    /// the tolerance/bond cap if convergence is expected.
+    MaxIterations,
+}
+
 /// Output of an Alternating Cross Interpolation run.
 ///
 /// The result contains the approximating tensor train plus convergence metadata
 /// collected during the run. Use [`tensor_train`](Self::tensor_train) for
-/// subsequent tensor-train operations, and inspect [`ranks`](Self::ranks) and
-/// [`errors`](Self::errors) to diagnose sweep-by-sweep convergence behavior.
+/// subsequent tensor-train operations, and inspect [`ranks`](Self::ranks),
+/// [`errors`](Self::errors), and [`termination`](Self::termination) to diagnose
+/// how and why the run stopped.
 ///
 /// Related types: [`AciOptions`](crate::AciOptions) configures the run that
 /// produces this value; [`SimpleTensorTrain`] stores the approximating tensor.
@@ -15,7 +35,7 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 /// # Examples
 ///
 /// ```
-/// use tensor4all_aci::AciResult;
+/// use tensor4all_aci::{AciResult, AciTermination};
 /// use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain};
 ///
 /// let tensor_train = SimpleTensorTrain::<f64>::constant(&[2, 3], 4.0);
@@ -23,11 +43,15 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 ///     tensor_train,
 ///     ranks: vec![1, 2],
 ///     errors: vec![1e-3, 0.0],
+///     nglobal_pivots: vec![0, 0],
+///     termination: AciTermination::Converged,
 /// };
 ///
 /// assert_eq!(result.tensor_train.site_dims(), vec![2, 3]);
 /// assert_eq!(result.ranks, vec![1, 2]);
 /// assert_eq!(result.errors, vec![1e-3, 0.0]);
+/// assert_eq!(result.nglobal_pivots, vec![0, 0]);
+/// assert_eq!(result.termination, AciTermination::Converged);
 /// assert!((result.tensor_train.evaluate(&[1, 2]).unwrap() - 4.0).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone)]
@@ -47,11 +71,21 @@ pub struct AciResult<T: TTScalar> {
     /// convention as [`AciOptions::tolerance`](crate::AciOptions::tolerance).
     ///
     /// The last entry is not guaranteed to be at or below the requested
-    /// tolerance. A run under a binding
-    /// [`AciOptions::max_bond_dim`](crate::AciOptions::max_bond_dim) stops once
-    /// the rank has sat at the cap, because the sweep can no longer add pivots
-    /// and the tolerance can never be met; such a run finishes above tolerance
-    /// by design. Compare the last [`ranks`](Self::ranks) entry against
-    /// `max_bond_dim` to tell a rank-limited run from a converged one.
+    /// tolerance; see [`termination`](Self::termination) for the stopping
+    /// reason. A rank-limited run finishes above tolerance by design.
     pub errors: Vec<f64>,
+
+    /// Global pivot search findings after each completed sweep, one entry per
+    /// sweep in the same order as [`ranks`](Self::ranks) and [`errors`](Self::errors).
+    ///
+    /// Each entry is the number of global pivots the guard found in that
+    /// sweep (not the number injected — already-represented pivots are
+    /// skipped on injection). Convergence is only accepted once the trailing
+    /// [`AciOptions::min_iters`](crate::AciOptions::min_iters) entries are all
+    /// zero, so a nonzero trailing entry means the run stopped for another
+    /// reason.
+    pub nglobal_pivots: Vec<usize>,
+
+    /// Why the run stopped.
+    pub termination: AciTermination,
 }

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -369,11 +369,13 @@ fn rank_stability_matches_julia_min_iter_window() {
 fn convergence_criterion_matches_julia_algorithm() {
     let ranks = [10, 12, 12];
     let errors = [1.0e-8, 2.0e-11, 3.0e-11];
+    let no_pivots = [0, 0, 0];
 
     assert!(!convergence_criterion_like_julia(
         1,
         &ranks[..1],
         &errors[..1],
+        &no_pivots[..1],
         2,
         1.0e-10
     ));
@@ -381,11 +383,12 @@ fn convergence_criterion_matches_julia_algorithm() {
         2,
         &ranks[..2],
         &errors[..2],
+        &no_pivots[..2],
         2,
         1.0e-10
     ));
     assert!(convergence_criterion_like_julia(
-        3, &ranks, &errors, 2, 1.0e-10
+        3, &ranks, &errors, &no_pivots, 2, 1.0e-10
     ));
 
     let increasing_ranks = [10, 12, 13];
@@ -393,6 +396,39 @@ fn convergence_criterion_matches_julia_algorithm() {
         3,
         &increasing_ranks,
         &errors,
+        &no_pivots,
+        2,
+        1.0e-10
+    ));
+
+    // Julia's `convergencecriterion` also requires the global pivot search
+    // to have found nothing over the trailing window: a sweep that injected
+    // pivots has not yet absorbed them, so its error is stale with respect
+    // to them. A find outside the window no longer blocks convergence.
+    let found_pivots_early = [1, 0, 0];
+    assert!(convergence_criterion_like_julia(
+        3,
+        &ranks,
+        &errors,
+        &found_pivots_early,
+        2,
+        1.0e-10
+    ));
+    let found_pivots_in_window = [0, 1, 0];
+    assert!(!convergence_criterion_like_julia(
+        3,
+        &ranks,
+        &errors,
+        &found_pivots_in_window,
+        2,
+        1.0e-10
+    ));
+    let found_pivots_late = [0, 0, 1];
+    assert!(!convergence_criterion_like_julia(
+        3,
+        &ranks,
+        &errors,
+        &found_pivots_late,
         2,
         1.0e-10
     ));
@@ -1838,6 +1874,7 @@ fn timed_aci_run(
                 iteration + 1,
                 &ranks,
                 &errors,
+                &vec![0; ranks.len()],
                 options.min_iters,
                 options.tolerance,
             )

--- a/crates/tensor4all-tcicore/src/floating_zone.rs
+++ b/crates/tensor4all-tcicore/src/floating_zone.rs
@@ -38,6 +38,11 @@ use crate::MultiIndex;
 /// The final pivot and the maximum error encountered along the walk. The
 /// returned error may exceed `early_stop_tol`; the caller decides whether
 /// the point is significant.
+///
+/// # Errors
+///
+/// Propagates the error returned by `eval_batch` (e.g. an operator failure
+/// or a tensor-train evaluation failure).
 pub fn floating_zone_walk<E, Err>(
     local_dims: &[usize],
     init_p: &MultiIndex,
@@ -49,7 +54,6 @@ where
     E: FnMut(&[MultiIndex]) -> std::result::Result<Vec<f64>, Err>,
 {
     let n = local_dims.len();
-    debug_assert_eq!(init_p.len(), n);
 
     let mut pivot = init_p.clone();
 

--- a/crates/tensor4all-tcicore/src/floating_zone.rs
+++ b/crates/tensor4all-tcicore/src/floating_zone.rs
@@ -1,0 +1,91 @@
+//! Greedy coordinate-descent (floating-zone) search for high-error points.
+//!
+//! The floating-zone walk is the strongest global pivot search used in this
+//! codebase: from a starting point it repeatedly sweeps every site
+//! coordinate, moving each coordinate to the value with the largest
+//! interpolation error, until the error stops improving or exceeds a
+//! tolerance. It is a strict generalization of the single-cross search used
+//! elsewhere (one sweep with no repeats equals a cross scan).
+
+use crate::MultiIndex;
+
+/// Walk one floating-zone search trajectory.
+///
+/// Mirrors `TensorCrossInterpolation.jl`'s `_floatingzone`: starting from
+/// `init_p`, each sweep visits every site in order and moves that site's
+/// coordinate to the value with the largest error (as measured by
+/// `eval_batch`), keeping the running maximum error monotonically
+/// non-decreasing. The walk stops when a sweep does not increase the
+/// maximum error (the trajectory is stuck on a local maximum) or when the
+/// maximum error exceeds `early_stop_tol` (the point is already
+/// significant), or after `max_sweeps` sweeps as a safety bound.
+///
+/// # Arguments
+///
+/// * `local_dims` - Local dimension of each site.
+/// * `init_p` - Starting multi-index; must have length `local_dims.len()`.
+/// * `max_sweeps` - Upper bound on the number of coordinate sweeps. The
+///   no-improvement early stop almost always fires first.
+/// * `early_stop_tol` - Stop walking once the maximum error exceeds this
+///   value; the caller has found a significantly wrong point.
+/// * `eval_batch` - Evaluates the error magnitude `|f - tt|` at a batch of
+///   multi-indices. Called once per site per sweep with that site's
+///   `local_dims[site]` candidate points (the current pivot with the site
+///   coordinate varied), so callers can batch shared contractions.
+///
+/// # Returns
+///
+/// The final pivot and the maximum error encountered along the walk. The
+/// returned error may exceed `early_stop_tol`; the caller decides whether
+/// the point is significant.
+pub fn floating_zone_walk<E, Err>(
+    local_dims: &[usize],
+    init_p: &MultiIndex,
+    max_sweeps: usize,
+    early_stop_tol: f64,
+    mut eval_batch: E,
+) -> std::result::Result<(MultiIndex, f64), Err>
+where
+    E: FnMut(&[MultiIndex]) -> std::result::Result<Vec<f64>, Err>,
+{
+    let n = local_dims.len();
+    debug_assert_eq!(init_p.len(), n);
+
+    let mut pivot = init_p.clone();
+
+    // Initial error at the starting point.
+    let start_errors = eval_batch(&[pivot.clone()])?;
+    let mut max_error = start_errors.first().copied().unwrap_or(0.0);
+
+    for _ in 0..max_sweeps {
+        let prev_max_error = max_error;
+        for ipos in 0..n {
+            // Candidate points: every value at this site, the rest fixed at
+            // the current pivot (updated greedily within this sweep).
+            let mut points = Vec::with_capacity(local_dims[ipos]);
+            for value in 0..local_dims[ipos] {
+                let mut point = pivot.clone();
+                point[ipos] = value;
+                points.push(point);
+            }
+            let errors = eval_batch(&points)?;
+
+            let mut best_local_idx = pivot[ipos];
+            let mut best_local_error = 0.0f64;
+            for (value, &error) in errors.iter().enumerate() {
+                if error > best_local_error {
+                    best_local_error = error;
+                    best_local_idx = value;
+                }
+            }
+            pivot[ipos] = best_local_idx;
+            max_error = max_error.max(best_local_error);
+        }
+
+        if max_error == prev_max_error || max_error > early_stop_tol {
+            break;
+        }
+    }
+
+    Ok((pivot, max_error))
+}

--- a/crates/tensor4all-tcicore/src/floating_zone.rs
+++ b/crates/tensor4all-tcicore/src/floating_zone.rs
@@ -41,8 +41,8 @@ use crate::MultiIndex;
 ///
 /// # Errors
 ///
-/// Propagates the error returned by `eval_batch` (e.g. an operator failure
-/// or a tensor-train evaluation failure).
+/// Propagates the error returned by `eval_batch` unchanged — typically an
+/// operation failure or an index mismatch from the underlying evaluator.
 pub fn floating_zone_walk<E, Err>(
     local_dims: &[usize],
     init_p: &MultiIndex,

--- a/crates/tensor4all-tcicore/src/lib.rs
+++ b/crates/tensor4all-tcicore/src/lib.rs
@@ -63,6 +63,7 @@
 
 pub mod cached_function;
 pub mod error;
+pub mod floating_zone;
 pub mod indexset;
 mod matrix_luci;
 pub mod matrixaca;
@@ -77,6 +78,7 @@ pub use cached_function::error::CacheKeyError;
 pub use cached_function::index_int::IndexInt;
 pub use cached_function::CachedFunction;
 pub use error::{MatrixCIError, Result};
+pub use floating_zone::floating_zone_walk;
 pub use indexset::{IndexSet, LocalIndex, MultiIndex};
 pub use matrix_luci::{
     matrix_luci_factors_from_blocks, matrix_luci_factors_from_matrix,

--- a/crates/tensor4all-tensorci/src/globalsearch.rs
+++ b/crates/tensor4all-tensorci/src/globalsearch.rs
@@ -6,8 +6,10 @@
 //! [`floating_zone`] optimization.
 
 use rand::Rng;
-use tensor4all_simplett::{AbstractTensorTrain, SimpleTensorTrain, TTScalar, Tensor3Ops};
-use tensor4all_tcicore::{MultiIndex, Scalar};
+use tensor4all_simplett::{
+    AbstractTensorTrain, EinsumScalar, SimpleTensorTrain, TTCache, TTScalar, Tensor3Ops,
+};
+use tensor4all_tcicore::{floating_zone_walk, MultiIndex, Scalar};
 
 /// Estimate the true interpolation error by searching for worst-case indices.
 ///
@@ -66,7 +68,7 @@ pub fn estimate_true_error<T, F>(
     rng: &mut impl Rng,
 ) -> Vec<(MultiIndex, f64)>
 where
-    T: Scalar + TTScalar,
+    T: Scalar + TTScalar + EinsumScalar,
     F: Fn(&MultiIndex) -> T,
 {
     let site_dims: Vec<usize> = (0..tt.len())
@@ -133,7 +135,7 @@ where
 /// * `tt` -- the tensor train approximation
 /// * `f` -- the exact function
 /// * `local_dims` -- number of values each index can take
-/// * `init_p` -- starting point (`None` defaults to the all-zeros index)
+/// * `init_p` -- starting point (`None` draws a random starting point)
 /// * `early_stop_tol` -- stop early once the error exceeds this value
 ///
 ///   (use `f64::MAX` to search exhaustively)
@@ -149,54 +151,48 @@ pub fn floating_zone<T, F>(
     early_stop_tol: f64,
 ) -> (MultiIndex, f64)
 where
-    T: Scalar + TTScalar,
+    T: Scalar + TTScalar + EinsumScalar,
     F: Fn(&MultiIndex) -> T,
 {
-    let n = local_dims.len();
-
-    let mut pivot = if let Some(p) = init_p {
-        p.clone()
-    } else {
-        vec![0; n]
+    // Julia's `_floatingzone` draws a random starting point when none is
+    // given; match that instead of fixing the all-zeros index.
+    let init_p = match init_p {
+        Some(p) => p.clone(),
+        None => local_dims
+            .iter()
+            .map(|&d| rand::rng().random_range(0..d))
+            .collect(),
     };
 
-    let f_val = f(&pivot);
-    let tt_val = tt.evaluate(&pivot).unwrap_or(T::zero());
-    let diff = f_val - tt_val;
-    let mut max_error = f64::sqrt(Scalar::abs_sq(diff));
+    let max_sweeps = local_dims.len() * 10; // Reasonable upper bound
+    let mut tt_cache = TTCache::new(tt);
+    let (pivot, error) = floating_zone_walk(
+        local_dims,
+        &init_p,
+        max_sweeps,
+        early_stop_tol,
+        |points: &[MultiIndex]| {
+            // Batch-evaluate the tensor train once per site scan; `f` is
+            // evaluated pointwise (no batch API in this signature). A TT
+            // evaluation failure is treated as value zero, matching the
+            // previous point-by-point fallback.
+            let tt_values = tt_cache
+                .evaluate_many(points, None)
+                .unwrap_or_else(|_| vec![T::zero(); points.len()]);
+            let errors = points
+                .iter()
+                .zip(tt_values.iter())
+                .map(|(point, &tt_value)| {
+                    let diff = f(point) - tt_value;
+                    f64::sqrt(Scalar::abs_sq(diff))
+                })
+                .collect::<Vec<f64>>();
+            Ok::<Vec<f64>, std::convert::Infallible>(errors)
+        },
+    )
+    .unwrap_or_else(|never| match never {});
 
-    let max_sweeps = n * 10; // Reasonable upper bound
-    for _ in 0..max_sweeps {
-        let prev_max_error = max_error;
-
-        for ipos in 0..n {
-            // Evaluate all local indices at this position
-            let mut best_local_error = 0.0f64;
-            let mut best_local_idx = pivot[ipos];
-
-            for v in 0..local_dims[ipos] {
-                pivot[ipos] = v;
-                let f_val = f(&pivot);
-                let tt_val = tt.evaluate(&pivot).unwrap_or(T::zero());
-                let diff = f_val - tt_val;
-                let error = f64::sqrt(Scalar::abs_sq(diff));
-                if error > best_local_error {
-                    best_local_error = error;
-                    best_local_idx = v;
-                }
-            }
-
-            pivot[ipos] = best_local_idx;
-            // Keep max_error monotonically non-decreasing
-            max_error = max_error.max(best_local_error);
-        }
-
-        if max_error == prev_max_error || max_error > early_stop_tol {
-            break;
-        }
-    }
-
-    (pivot, max_error)
+    (pivot, error)
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-treetci/src/globalpivot.rs
+++ b/crates/tensor4all-treetci/src/globalpivot.rs
@@ -7,8 +7,8 @@
 //! large. Found pivots are injected via [`TreeTCI2::add_global_pivots`] so the
 //! next sweep samples regions the local pivot updates missed.
 //!
-//! The search is opt-in (`TreeTciOptions::enable_global_pivots`); the default
-//! optimization loop never materializes the tree.
+//! The search is enabled by default (`TreeTciOptions::enable_global_pivots`)
+//! and runs after every optimization sweep.
 
 use crate::error::Result as TreeTciResult;
 use crate::{materialize::to_treetn, GlobalIndexBatch, MultiIndex, TreeTCI2};

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -22,7 +22,7 @@ use tensor4all_tensorbackend::FullPivLuScalar;
 /// | `max_iter`                | `20`          | Maximum number of edge-order iterations              |
 /// | `max_bond_dim`            | `None`        | Maximum bond dimension (no cap by default)           |
 /// | `normalize_error`         | `true`        | Normalize error by maximum sample magnitude          |
-/// | `enable_global_pivots`    | `false`       | Run automatic global pivot search after each sweep   |
+/// | `enable_global_pivots`    | `true`        | Run automatic global pivot search after each sweep   |
 /// | `nsearch`                 | `5`           | Random starting points for the global pivot search   |
 /// | `max_nglobal_pivot`       | `5`           | Global pivots added per iteration                    |
 /// | `tol_margin_global_search`| `10.0`        | Global pivot acceptance margin over `abs_tol`        |
@@ -39,7 +39,7 @@ use tensor4all_tensorbackend::FullPivLuScalar;
 /// assert_eq!(opts.max_iter, 20);
 /// assert_eq!(opts.max_bond_dim, None);
 /// assert!(opts.normalize_error);
-/// assert!(!opts.enable_global_pivots);
+/// assert!(opts.enable_global_pivots);
 ///
 /// // Custom options for high-precision work
 /// let opts = TreeTciOptions {
@@ -95,8 +95,7 @@ pub struct TreeTciOptions {
     /// `|f(idx) - tt(idx)|` is large, injecting the best finds via
     /// [`TreeTCI2::add_global_pivots`](crate::TreeTCI2::add_global_pivots).
     /// This recovers separated features that local pivot updates miss when
-    /// the initial pivots sit in a single basin. Default: `false` (opt-in,
-    /// preserves existing behavior).
+    /// the initial pivots sit in a single basin. Default: `true`.
     pub enable_global_pivots: bool,
 
     /// Number of random starting points for the global pivot search.
@@ -136,7 +135,7 @@ impl Default for TreeTciOptions {
             max_iter: 20,
             max_bond_dim: None,
             normalize_error: true,
-            enable_global_pivots: false,
+            enable_global_pivots: true,
             nsearch: 5,
             max_nglobal_pivot: 5,
             tol_margin_global_search: 10.0,
@@ -323,10 +322,11 @@ where
         // Global pivot search: after each sweep, materialize the current
         // approximation and inject pivots where |f - tt| is large, so
         // separated features that the local pivot updates miss are sampled
-        // in the next sweep. Opt-in; see `TreeTciOptions::enable_global_pivots`.
-        // The search is skipped on the final iteration: a pivot injected after
-        // the last sweep would never be processed by a subsequent sweep, so the
-        // recorded error and termination reason would not reflect it.
+        // in the next sweep. Enabled by default; see
+        // `TreeTciOptions::enable_global_pivots`. The search is skipped on
+        // the final iteration: a pivot injected after the last sweep would
+        // never be processed by a subsequent sweep, so the recorded error
+        // and termination reason would not reflect it.
         if options.enable_global_pivots && _iter + 1 < options.max_iter {
             let error_scale = if options.normalize_error && state.max_sample_value > 0.0 {
                 state.max_sample_value


### PR DESCRIPTION
## What

Closes #610. The ACI global pivot search guard now follows the reference
(TensorCrossInterpolation.jl / tensorci / treetci) contract instead of the
weak "search once at acceptance, one empty search accepts" behavior that
failed to recover the gw-rs#9 20-pivot reproducer.

- **aci**: the guard search now runs **after every sweep** (not only at the
  would-be-acceptance moment), and convergence additionally requires the
  search to find **nothing for `min_iters` consecutive sweeps** — the
  `nglobalpivots == 0` disjunct of Julia's `convergencecriterion`. The
  search itself is upgraded from a single-cross scan to **floating-zone
  coordinate descent** (the cross scan is the `nsweeps = 1` special case).
  `AciResult` gains `termination` (`Converged` / `RankLimited` /
  `MaxIterations`) and per-sweep `nglobal_pivots` history so callers no
  longer have to infer the stop reason from the error metric. The guard is
  skipped while the rank sits at `max_bond_dim` (no headroom to absorb
  pivots) and a final cleanup sweep keeps the returned rank within the cap.
- **treetci**: `enable_global_pivots` defaults to **true** (was opt-in
  false). Its search was already batch-evaluated, so no caching change was
  needed there.
- **tensorci**: `floating_zone` now draws a **random starting point** when
  none is given (Julia parity) and batch-evaluates the tensor train via
  `TTCache` instead of point-by-point.
- **tcicore**: new shared `floating_zone_walk` helper (generic
  coordinate-descent walk) used by both tensorci and the ACI guard — no
  third copy of the walk.

## Verification

- Full workspace: 2791 tests pass (up from 2787), doc tests pass, clippy
  `-D warnings` clean, `cargo fmt --check` clean, repository-rules review
  passes (no findings).
- **gw-rs#9 reproducer (the #610 motivating case)**: re-ran
  `sgw/tests/pi_aci_false_convergence_regression.rs` (R=8, 24 binary sites,
  20 pivots, `1e-4` product tolerance) against this branch. Previously:
  `got = -2.5e-25` at the second peak (relative error 100%, peak silently
  vanished). Now:
  `at the second peak (rx=0,ry=255,tau=0): truth=-2.404469e3-1.035561e0i
   got=-2.404469e3-1.035561e0i  relative error=0.0%`
  Guard instrumentation on the same run: iterations 0–3 found the missing
  peak region (walk errors up to `1.8e2` vs `1e-3` threshold), injected
  4/5/3/4 pivots, rank grew 24 → 333; iterations 4–7 found nothing and
  convergence was accepted (final err `9.927e-5 < 1e-4`).
