### PR TITLE
fix(aci): normalize the sweep tolerance by default, stop padding saturated bonds

### DIFF
--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -15,10 +15,15 @@ use tensor4all_simplett::{
 /// [`ElementwiseBatch`] and writes one output value per interpolation point.
 /// Forward and backward sweeps alternate until the configured iteration limit
 /// is reached or the conservative convergence rule accepts the current ranks
-/// and maximum error metric. When [`AciOptions::scale_tolerance`] is enabled,
-/// each bond's pivot error is divided by that bond's largest sampled
-/// operator-output magnitude from the completed sweep, and the largest
-/// normalized value is used.
+/// and maximum error metric. When [`AciOptions::scale_tolerance`] is enabled
+/// (the default), each bond's pivot error is divided by that bond's largest
+/// sampled operator-output magnitude from the completed sweep, and the largest
+/// normalized value is used; otherwise the pivot errors are compared to
+/// [`AciOptions::tolerance`] as an absolute budget. Prefer the normalized
+/// default: an absolute tolerance below the accuracy the inputs themselves
+/// carry makes the sweep interpolate their approximation error, and the pivot
+/// count then rises with the number of sites instead of saturating with the
+/// rank of the function.
 ///
 /// When [`AciOptions::enable_global_guard`] is enabled (the default), the
 /// local stopping rule is gated by a global pivot search: after every sweep

--- a/crates/tensor4all-aci/src/options.rs
+++ b/crates/tensor4all-aci/src/options.rs
@@ -7,7 +7,8 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 /// Use this type to choose iteration limits, truncation pressure, stopping
 /// tolerance, and an optional initial tensor-train guess. The default values are
 /// conservative: they run at least two sweeps, allow up to twenty sweeps, do not
-/// cap bond dimensions, and use an absolute tolerance of `1e-12`.
+/// cap bond dimensions, and use a tolerance of `1e-12` relative to the sampled
+/// operator-output magnitude (see [`scale_tolerance`](Self::scale_tolerance)).
 ///
 /// Related types: [`AciResult`](crate::AciResult) stores the tensor train and
 /// convergence history produced by an ACI run, while [`ElementwiseBatch`](crate::ElementwiseBatch)
@@ -23,7 +24,7 @@ use tensor4all_simplett::{SimpleTensorTrain, TTScalar};
 /// assert_eq!(options.min_iters, 2);
 /// assert_eq!(options.max_bond_dim, None);
 /// assert!((options.tolerance - 1e-12).abs() < 1e-15);
-/// assert!(!options.scale_tolerance);
+/// assert!(options.scale_tolerance);
 /// assert!(options.initial_guess.is_none());
 /// assert_eq!(options.rng_seed, 0);
 /// assert!(options.enable_global_guard);
@@ -59,19 +60,32 @@ pub struct AciOptions<T: TTScalar> {
     /// Requested stopping tolerance for the ACI residual estimate.
     ///
     /// The default is `1e-12`. When [`scale_tolerance`](Self::scale_tolerance)
-    /// is `false`, this is interpreted as an absolute tolerance. When
-    /// `scale_tolerance` is `true`, the public sweep APIs compare this value to
-    /// the largest per-bond relative metric, obtained by dividing each bond's
-    /// pivot error by that bond's largest sampled operator-output magnitude
-    /// from the completed sweep.
+    /// is `true` (the default), the public sweep APIs compare this value to the
+    /// largest per-bond relative metric, obtained by dividing each bond's pivot
+    /// error by that bond's largest sampled operator-output magnitude from the
+    /// completed sweep. When `scale_tolerance` is `false`, this is interpreted
+    /// as an absolute tolerance on the same pivot errors.
     pub tolerance: f64,
 
     /// Whether to scale [`tolerance`](Self::tolerance) by the output magnitude.
     ///
-    /// The default is `false`, giving absolute tolerance behavior. Set this to
-    /// `true` when outputs have problem-dependent scales and relative stopping
-    /// behavior is more appropriate. When in doubt, keep the default `false`
-    /// for absolute tolerance behavior.
+    /// The default is `true`, giving relative stopping behavior: each bond's
+    /// pivot error is compared against `tolerance` times the largest operator
+    /// output sampled at that bond. This matches the reference contract of
+    /// `TensorCrossInterpolation.jl` (`normalizeerror = true`), where the
+    /// tolerance is normalized by the largest sampled value.
+    ///
+    /// Set this to `false` only when an absolute error budget is genuinely
+    /// wanted, and keep in mind what an absolute budget asks for: a tolerance
+    /// far below the accuracy of the input tensor trains makes the sweep
+    /// interpolate their own approximation error, which is not low rank. The
+    /// pivot count then keeps rising with the number of sites at fixed
+    /// tolerance instead of saturating with the rank of the function (issue
+    /// #618). Scale-blind tolerances are also easy to misjudge: for an operator
+    /// output of magnitude `1e3`, an absolute `1e-12` is a relative `1e-15`,
+    /// close to double-precision rounding noise.
+    ///
+    /// When in doubt, keep the default `true`.
     pub scale_tolerance: bool,
 
     /// Optional tensor train used to initialize interpolation pivots and ranks.
@@ -141,7 +155,7 @@ impl<T: TTScalar> Default for AciOptions<T> {
             min_iters: 2,
             max_bond_dim: None,
             tolerance: 1e-12,
-            scale_tolerance: false,
+            scale_tolerance: true,
             initial_guess: None,
             rng_seed: 0,
             enable_global_guard: true,

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -495,26 +495,50 @@ impl<T: AciScalar> ElementwiseProblem<T> {
 
     /// Inject global pivots into the frame index sets and the solution rank.
     ///
-    /// For each pivot `x` and each bond `b`, the left environment
-    /// `L_j(x[0..b])` is appended as a row to `left_frames[j][b]` and the
-    /// right environment `R_j(x[b+2..])` as a column to `right_frames[j][b+2]`
-    /// for every input `j`, so the next sweep's local block at bond `b`
-    /// samples the point `x`. Because ACI couples the frame sizes to the
+    /// Internal bond `k` (between sites `k - 1` and `k`) is sampled through two
+    /// frames of equal size: `left_frames[j][k]`, whose rows are left
+    /// environments `L_j(x[..k])`, and `right_frames[j][k]`, whose columns are
+    /// right environments `R_j(x[k..])`. A point `x` becomes visible to the
+    /// next sweep's local block at bond `b` once `left_frames[j][b]` holds the
+    /// row for `x[..b]` and `right_frames[j][b + 2]` the column for
+    /// `x[b + 2..]`, so a pivot is injected by growing every internal bond by
+    /// one row and one column. Because ACI couples the frame sizes to the
     /// solution rank (every `local_update` cross-checks them), the solution's
-    /// internal bond dimensions are zero-padded by the same amount and the
-    /// empty prefixes/suffixes (the bond-0 left frame and the site-`n` right
-    /// frame) are skipped. A pivot already fully represented in the frames is
-    /// skipped, and all inputs grow uniformly so `validate_local_shapes` keeps
-    /// holding.
+    /// internal bond dimensions are zero-padded by the same per-bond amount.
     ///
-    /// Returns the number of pivots actually injected (0 when every found
-    /// pivot was already represented in the frames).
+    /// Growth is skipped for a bond that cannot absorb it, so no frame is ever
+    /// padded with a provably linearly dependent row or column:
+    ///
+    /// * **Duplicate.** Both the row and the column of this pivot are already
+    ///   present in every input's frames at that bond.
+    /// * **Index-space saturation.** The bond dimension already equals the
+    ///   number of distinct multi-indices on the shorter side of the cut
+    ///   (`prod(site_dims[..k])` or `prod(site_dims[k..])`). One of the two
+    ///   frames then already enumerates its whole index space, so an appended
+    ///   row (or column) can only repeat one that is there, and the local
+    ///   block at that bond already interpolates exactly.
+    ///
+    /// Without these guards a run can carry bond dimensions above the algebraic
+    /// maximum of the site space (issue #618 observed a transient rank of 1044
+    /// on an eleven-site dimension-four train, whose bound is 1024), which
+    /// costs full-rank sweep work for pivots that carry no information.
+    ///
+    /// Returns the number of pivots that grew at least one bond (0 when every
+    /// found pivot was already represented in the frames, or when no bond could
+    /// absorb it).
     pub(crate) fn add_global_pivots(&mut self, pivots: &[Vec<usize>]) -> Result<usize>
     where
         T: PartialEq,
     {
         let n = self.len();
         let mut new_pivots = 0usize;
+        let mut growth = vec![0usize; n + 1];
+        let bounds = self.algebraic_bond_bounds();
+        let mut dims = vec![0usize; n + 1];
+        for (bond, dim) in self.solution.link_dims().iter().enumerate() {
+            dims[bond + 1] = *dim;
+        }
+
         for pivot in pivots {
             if pivot.len() != n {
                 return Err(AciError::InvalidInitialGuess {
@@ -525,30 +549,37 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                 });
             }
 
-            let mut fully_represented = true;
-            for bond in 0..n.saturating_sub(1) {
+            let mut injected = false;
+            for bond in 1..n {
+                if dims[bond] >= bounds[bond] {
+                    continue;
+                }
+                // The row lives in `left_frames[j][bond]`, which exists for
+                // bonds up to `n - 2`; the column lives in
+                // `right_frames[j][bond]`, which exists from bond 2 on.
+                let needs_row = bond + 1 < n;
+                let needs_col = bond >= 2;
+                let mut duplicate = true;
                 for input in 0..self.n_inputs() {
-                    if bond >= 1 {
+                    if needs_row {
                         let row = left_environment(&self.inputs[input], &pivot[..bond])?;
                         if !frame_has_row(self.left_frames[input][bond].as_ref(), &row)? {
-                            fully_represented = false;
+                            duplicate = false;
                         }
                     }
-                    if bond + 2 < n {
-                        let col = right_environment(&self.inputs[input], &pivot[bond + 2..])?;
-                        if !frame_has_col(self.right_frames[input][bond + 2].as_ref(), &col)? {
-                            fully_represented = false;
+                    if needs_col {
+                        let col = right_environment(&self.inputs[input], &pivot[bond..])?;
+                        if !frame_has_col(self.right_frames[input][bond].as_ref(), &col)? {
+                            duplicate = false;
                         }
                     }
                 }
-            }
-            if fully_represented {
-                continue;
-            }
+                if duplicate {
+                    continue;
+                }
 
-            for bond in 0..n.saturating_sub(1) {
                 for input in 0..self.n_inputs() {
-                    if bond >= 1 {
+                    if needs_row {
                         let row = left_environment(&self.inputs[input], &pivot[..bond])?;
                         append_row(
                             self.left_frames[input][bond].as_mut().ok_or_else(|| {
@@ -561,14 +592,13 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                             &row,
                         )?;
                     }
-                    if bond + 2 < n {
-                        let col = right_environment(&self.inputs[input], &pivot[bond + 2..])?;
+                    if needs_col {
+                        let col = right_environment(&self.inputs[input], &pivot[bond..])?;
                         append_col(
-                            self.right_frames[input][bond + 2].as_mut().ok_or_else(|| {
+                            self.right_frames[input][bond].as_mut().ok_or_else(|| {
                                 AciError::InvalidInitialGuess {
                                     message: format!(
-                                        "missing right frame at input {input}, bond {}",
-                                        bond + 2
+                                        "missing right frame at input {input}, bond {bond}"
                                     ),
                                 }
                             })?,
@@ -576,27 +606,68 @@ impl<T: AciScalar> ElementwiseProblem<T> {
                         )?;
                     }
                 }
+                growth[bond] += 1;
+                dims[bond] += 1;
+                injected = true;
             }
-            new_pivots += 1;
+
+            if injected {
+                new_pivots += 1;
+            }
         }
         if new_pivots > 0 {
-            self.pad_solution_internal_bonds(new_pivots)?;
+            self.pad_solution_internal_bonds(&growth)?;
         }
         Ok(new_pivots)
     }
 
-    /// Grow every internal bond of the solution by `growth` with zero padding.
+    /// Number of distinct multi-indices on the shorter side of each bond cut.
+    ///
+    /// Entry `k` refers to the bond between sites `k - 1` and `k` and is the
+    /// largest number of linearly independent rows (or columns) its frames can
+    /// hold; entries `0` and `n` are the trivial boundary bonds and are `1`.
+    /// Products are computed with saturating arithmetic, so a site space too
+    /// large to count simply never reports saturation.
+    fn algebraic_bond_bounds(&self) -> Vec<usize> {
+        let n = self.len();
+        let dims: Vec<usize> = (0..n).map(|site| self.solution.site_dim(site)).collect();
+        let mut left_space = vec![1usize; n + 1];
+        for site in 0..n {
+            left_space[site + 1] = left_space[site].saturating_mul(dims[site]);
+        }
+        let mut right_space = vec![1usize; n + 1];
+        for site in (0..n).rev() {
+            right_space[site] = right_space[site + 1].saturating_mul(dims[site]);
+        }
+
+        (0..=n)
+            .map(|bond| left_space[bond].min(right_space[bond]))
+            .collect()
+    }
+
+    /// Grow internal bond `k` of the solution by `growth[k]` with zero padding.
     ///
     /// ACI couples the solution rank to the frame sizes, so injecting pivots
     /// into the frames requires growing the solution's internal bond
-    /// dimensions by the same amount to keep `local_update`'s shape checks
-    /// consistent. The zero-padded entries preserve the current solution
+    /// dimensions by the same per-bond amount to keep `local_update`'s shape
+    /// checks consistent. The zero-padded entries preserve the current solution
     /// values; the following sweep's LU fills them from the new crosses.
-    fn pad_solution_internal_bonds(&mut self, growth: usize) -> Result<()> {
-        if growth == 0 {
+    /// `growth` has `len() + 1` entries; the boundary entries `0` and `n` are
+    /// ignored because those bonds are trivial.
+    fn pad_solution_internal_bonds(&mut self, growth: &[usize]) -> Result<()> {
+        let n = self.len();
+        if growth.iter().all(|&g| g == 0) {
             return Ok(());
         }
-        let n = self.len();
+        if growth.len() != n + 1 {
+            return Err(AciError::InvalidInitialGuess {
+                message: format!(
+                    "bond growth has {} entries, expected {} for {n} sites",
+                    growth.len(),
+                    n + 1
+                ),
+            });
+        }
         let cores = self.solution.site_tensors().to_vec();
         let mut new_cores = Vec::with_capacity(n);
         for (site, core) in cores.iter().enumerate() {
@@ -606,12 +677,12 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             let new_left = if site == 0 {
                 left_dim
             } else {
-                left_dim + growth
+                left_dim + growth[site]
             };
             let new_right = if site == n - 1 {
                 right_dim
             } else {
-                right_dim + growth
+                right_dim + growth[site + 1]
             };
             let mut data = vec![T::zero(); new_left * site_dim * new_right];
             for r in 0..right_dim {

--- a/crates/tensor4all-aci/src/tests.rs
+++ b/crates/tensor4all-aci/src/tests.rs
@@ -504,7 +504,9 @@ fn default_options_are_conservative() {
     assert_eq!(options.min_iters, 2);
     assert_eq!(options.max_bond_dim, None);
     assert!((options.tolerance - 1e-12).abs() < 1e-15);
-    assert!(!options.scale_tolerance);
+    // The tolerance is normalized by the sampled operator magnitude by
+    // default, matching the reference `normalizeerror = true` contract.
+    assert!(options.scale_tolerance);
     assert!(options.initial_guess.is_none());
 }
 
@@ -598,6 +600,129 @@ fn elementwise_problem_initializes_boundary_frames() {
     assert_eq!(problem.left_frame_shape(0, 0), Some((1, 1)));
     assert_eq!(problem.right_frame_shape(0, 3), Some((1, 1)));
     assert_eq!(problem.pivot_errors, vec![0.0, 0.0]);
+}
+
+/// Rank-one train whose left and right environments differ for every prefix,
+/// so an injected pivot is genuinely new information rather than a repeat of a
+/// row the frames already hold: entry `site, index` is `1 + index + seed *
+/// site`.
+fn separable_tt(site_dims: &[usize], seed: f64) -> SimpleTensorTrain<f64> {
+    let cores = site_dims
+        .iter()
+        .enumerate()
+        .map(|(site, &dim)| {
+            let data: Vec<f64> = (0..dim)
+                .map(|index| 1.0 + index as f64 + seed * site as f64)
+                .collect();
+            tensor3_from_data(data, 1, dim, 1).unwrap()
+        })
+        .collect();
+    SimpleTensorTrain::new(cores).unwrap()
+}
+
+/// One forward sweep, after which every left frame exists: `add_global_pivots`
+/// is only ever called from that state.
+fn sweep_forward_once(problem: &mut ElementwiseProblem<f64>, options: &AciOptions<f64>) {
+    let mut op = |batch: ElementwiseBatch<'_, f64>, output: &mut [f64]| {
+        for (point, value) in output.iter_mut().enumerate().take(batch.n_points()) {
+            *value = batch.get(0, point)? * batch.get(1, point)?;
+        }
+        Ok(())
+    };
+    for bond in 0..problem.len() - 1 {
+        problem.local_update(bond, true, options, &mut op).unwrap();
+    }
+}
+
+/// Distinct-multi-index bound of every internal bond: bond `k` cannot carry
+/// more independent rows than there are index tuples on the shorter side of
+/// the cut.
+fn algebraic_bond_bounds(site_dims: &[usize]) -> Vec<usize> {
+    let n = site_dims.len();
+    (1..n)
+        .map(|bond| {
+            let left: usize = site_dims[..bond].iter().product();
+            let right: usize = site_dims[bond..].iter().product();
+            left.min(right)
+        })
+        .collect()
+}
+
+#[test]
+fn global_pivot_injection_stays_within_the_algebraic_bond_bounds() {
+    // Five sites of dimension two: the bounds are [2, 4, 4, 2], so a run that
+    // pads every bond per injected pivot leaves bond dimensions far above the
+    // number of multi-indices that exist there (the transient rank above the
+    // algebraic bound reported in issue #618).
+    let site_dims = [2usize, 2, 2, 2, 2];
+    let a = separable_tt(&site_dims, 0.25);
+    let b = separable_tt(&site_dims, 0.5);
+    let options = AciOptions::default();
+    let mut problem = ElementwiseProblem::new(vec![a, b], options.clone()).unwrap();
+    sweep_forward_once(&mut problem, &options);
+
+    let pivots: Vec<Vec<usize>> = (0..8)
+        .map(|k| (0..site_dims.len()).map(|site| (k >> site) & 1).collect())
+        .collect();
+    let dims_before = problem.solution.link_dims();
+    let shapes_before: Vec<Option<(usize, usize)>> = (1..site_dims.len())
+        .map(|bond| problem.right_frame_shape(0, bond))
+        .collect();
+    problem.add_global_pivots(&pivots).unwrap();
+
+    let bounds = algebraic_bond_bounds(&site_dims);
+    let link_dims = problem.solution.link_dims();
+    assert_eq!(link_dims.len(), bounds.len());
+    for (bond, (&dim, &bound)) in link_dims.iter().zip(&bounds).enumerate() {
+        assert!(
+            dim <= bound,
+            "bond {bond} has dimension {dim} above its algebraic bound {bound}"
+        );
+    }
+    // Some bond did grow: the guard prunes provably redundant growth, it does
+    // not reject every pivot.
+    assert!(link_dims.iter().zip(&dims_before).any(|(&a, &b)| a > b));
+
+    // Frames and solution bonds must grow by the same amount, or the next
+    // local update sees inconsistent shapes. The forward sweep leaves the left
+    // frames (those a local update reads, bonds up to `n - 2`) sized to the
+    // current bond dimensions; the right frames a local update reads (bond 2
+    // and up) are refreshed by the backward sweep, so only their growth is
+    // checked.
+    let n = site_dims.len();
+    for bond in 1..n {
+        let growth = link_dims[bond - 1] - dims_before[bond - 1];
+        if bond + 1 < n {
+            assert_eq!(
+                problem.left_frame_shape(0, bond).map(|(rows, _)| rows),
+                Some(link_dims[bond - 1])
+            );
+        }
+        if bond >= 2 {
+            let cols = problem.right_frame_shape(0, bond).map(|(_, cols)| cols);
+            let cols_before = shapes_before[bond - 1].map(|(_, cols)| cols);
+            assert_eq!(cols, cols_before.map(|before| before + growth));
+        }
+    }
+}
+
+#[test]
+fn global_pivot_injection_skips_pivots_already_represented() {
+    let site_dims = [2usize, 2, 2, 2, 2, 2];
+    let a = separable_tt(&site_dims, 0.25);
+    let b = separable_tt(&site_dims, 0.5);
+    let options = AciOptions::default();
+    let mut problem = ElementwiseProblem::new(vec![a, b], options.clone()).unwrap();
+    sweep_forward_once(&mut problem, &options);
+
+    let pivot = vec![vec![1usize, 0, 1, 0, 1, 0]];
+    assert_eq!(problem.add_global_pivots(&pivot).unwrap(), 1);
+    let after_first = problem.solution.link_dims();
+
+    // The same pivot a second time is a duplicate at every bond, so nothing
+    // grows and the injection count is zero.
+    assert_eq!(problem.add_global_pivots(&pivot).unwrap(), 0);
+    assert_eq!(problem.solution.link_dims(), after_first);
 }
 
 #[test]

--- a/crates/tensor4all-aci/tests/rank_scaling.rs
+++ b/crates/tensor4all-aci/tests/rank_scaling.rs
@@ -1,0 +1,186 @@
+//! Regression coverage for issue #618: the rank of an elementwise product must
+//! follow the rank of the function, not the number of sites.
+//!
+//! The target is a product of two trigonometric sums on a base-four quantics
+//! grid. Each factor `sum_j w_j cos(2 pi m_j x)` is a rank-`2K` tensor train for
+//! every site count `R`, and the product of a `K`-term and a `K'`-term sum is a
+//! `2 K K'`-term sum, so the exact rank of the product is bounded by `4 K K'`
+//! independently of `R`. A run whose output rank tracks the algebraic bound of
+//! the site space instead (`4^(R/2)`, the behavior reported in the issue) is
+//! therefore visible as rank growth between two site counts.
+//!
+//! The factors also carry a large amplitude, which is what makes the effect
+//! reproducible in a few seconds: with a scale-blind tolerance the requested
+//! `1e-12` becomes a relative `1e-18` against an output magnitude of `1e6`,
+//! below double-precision rounding, and the sweep then adds pivots for rounding
+//! noise until it runs out of index space.
+
+use std::f64::consts::TAU;
+use tensor4all_aci::{elementwise, AciOptions};
+use tensor4all_simplett::{tensor3_from_data, AbstractTensorTrain, SimpleTensorTrain};
+
+type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
+const SITE_DIM: usize = 4;
+
+/// Value of the grid coordinate `x` in `[0, 1)` for a base-four multi-index.
+fn coordinate(index: &[usize]) -> f64 {
+    index
+        .iter()
+        .enumerate()
+        .map(|(site, &digit)| digit as f64 * (SITE_DIM as f64).powi(-(site as i32 + 1)))
+        .sum()
+}
+
+/// `scale * sum_j weights[j] * cos(TAU * freqs[j] * x)` as an exact rank-`2K`
+/// tensor train over `r` base-four sites.
+///
+/// Site `n` advances the phase of term `j` by `TAU * freqs[j] * digit *
+/// 4^-(n+1)` through a two-by-two rotation, so the running state
+/// `[cos(phase), sin(phase)]` reaches `[cos(TAU f x), sin(TAU f x)]` at the last
+/// site, where it is contracted with the weight.
+fn cosine_sum_tt(freqs: &[f64], weights: &[f64], scale: f64, r: usize) -> SimpleTensorTrain<f64> {
+    assert_eq!(freqs.len(), weights.len());
+    let terms = freqs.len();
+    let rank = 2 * terms;
+    let rotation = |term: usize, site: usize, digit: usize| {
+        let phase = TAU * freqs[term] * digit as f64 * (SITE_DIM as f64).powi(-(site as i32 + 1));
+        let (sin, cos) = phase.sin_cos();
+        [[cos, sin], [-sin, cos]]
+    };
+
+    let mut cores = Vec::with_capacity(r);
+    #[allow(clippy::needless_range_loop)]
+    for site in 0..r {
+        let left = if site == 0 { 1 } else { rank };
+        let right = if site == r - 1 { 1 } else { rank };
+        let mut data = vec![0.0; left * SITE_DIM * right];
+        for digit in 0..SITE_DIM {
+            for term in 0..terms {
+                let rot = rotation(term, site, digit);
+                for (row, rot_row) in rot.iter().enumerate() {
+                    for (col, &value) in rot_row.iter().enumerate() {
+                        // Start from [cos(0), sin(0)] = [1, 0] at the first
+                        // site and project onto the weighted cosine component
+                        // at the last one.
+                        let (l, r_idx, entry) = match (site == 0, site == r - 1) {
+                            (true, true) => {
+                                if row != 0 || col != 0 {
+                                    continue;
+                                }
+                                (0, 0, scale * weights[term] * value)
+                            }
+                            (true, false) => {
+                                if row != 0 {
+                                    continue;
+                                }
+                                (0, 2 * term + col, value)
+                            }
+                            (false, true) => {
+                                if col != 0 {
+                                    continue;
+                                }
+                                (2 * term + row, 0, scale * weights[term] * value)
+                            }
+                            (false, false) => (2 * term + row, 2 * term + col, value),
+                        };
+                        data[l + left * (digit + SITE_DIM * r_idx)] += entry;
+                    }
+                }
+            }
+        }
+        cores.push(tensor3_from_data(data, left, SITE_DIM, right).unwrap());
+    }
+    SimpleTensorTrain::new(cores).unwrap()
+}
+
+fn cosine_sum_value(freqs: &[f64], weights: &[f64], scale: f64, x: f64) -> f64 {
+    scale
+        * freqs
+            .iter()
+            .zip(weights)
+            .map(|(&f, &w)| w * (TAU * f * x).cos())
+            .sum::<f64>()
+}
+
+/// Deterministic grid points spread over the index space.
+fn sample_indices(r: usize, count: usize) -> Vec<Vec<usize>> {
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    (0..count)
+        .map(|_| {
+            (0..r)
+                .map(|_| {
+                    state ^= state << 13;
+                    state ^= state >> 7;
+                    state ^= state << 17;
+                    (state % SITE_DIM as u64) as usize
+                })
+                .collect()
+        })
+        .collect()
+}
+
+struct ProductRun {
+    rank: usize,
+    max_rel_error: f64,
+}
+
+fn run_product(r: usize, options: &AciOptions<f64>) -> TestResult<ProductRun> {
+    let f_freqs = [1.0, 5.0, 11.0];
+    let f_weights = [1.0, 0.6, 0.3];
+    let g_freqs = [2.0, 7.0, 13.0];
+    let g_weights = [0.9, 0.5, 0.2];
+    let scale = 1.0e3;
+
+    let f = cosine_sum_tt(&f_freqs, &f_weights, scale, r);
+    let g = cosine_sum_tt(&g_freqs, &g_weights, scale, r);
+    let result = elementwise(|values| values[0] * values[1], &[f, g], options)?;
+
+    let mut max_abs = 0.0f64;
+    let mut max_ref = 0.0f64;
+    for index in sample_indices(r, 96) {
+        let x = coordinate(&index);
+        let want = cosine_sum_value(&f_freqs, &f_weights, scale, x)
+            * cosine_sum_value(&g_freqs, &g_weights, scale, x);
+        let got = result.tensor_train.evaluate(&index)?;
+        max_abs = max_abs.max((got - want).abs());
+        max_ref = max_ref.max(want.abs());
+    }
+
+    Ok(ProductRun {
+        rank: result.tensor_train.rank(),
+        max_rel_error: max_abs / max_ref,
+    })
+}
+
+#[test]
+fn product_rank_does_not_grow_with_the_site_count() -> TestResult {
+    // Three terms per factor: the product has at most 2 * 3 * 3 = 18 cosine
+    // terms, so its exact rank is at most 36 for every site count.
+    const EXACT_RANK_BOUND: usize = 36;
+
+    let options = AciOptions::<f64>::default();
+    let short = run_product(6, &options)?;
+    let long = run_product(8, &options)?;
+
+    for (r, run) in [(6, &short), (8, &long)] {
+        assert!(
+            run.max_rel_error < 1e-10,
+            "r = {r}: relative error {:.3e} is above 1e-10",
+            run.max_rel_error
+        );
+        assert!(
+            run.rank <= 6 * EXACT_RANK_BOUND / 5,
+            "r = {r}: rank {} exceeds 1.2 times the exact rank bound {EXACT_RANK_BOUND}",
+            run.rank
+        );
+    }
+
+    assert!(
+        long.rank * 5 <= short.rank * 6,
+        "rank grew with the site count: {} at r = 6, {} at r = 8",
+        short.rank,
+        long.rank
+    );
+    Ok(())
+}

--- a/crates/tensor4all-simplett/src/compression.rs
+++ b/crates/tensor4all-simplett/src/compression.rs
@@ -54,7 +54,7 @@ pub enum CompressionMethod {
 /// | `method` | `LU` | Decomposition algorithm (see [`CompressionMethod`]) |
 /// | `tolerance` | `1e-12` | Relative truncation threshold per bond |
 /// | `max_bond_dim` | `None` | Hard upper bound on any bond dimension |
-/// | `normalize_error` | `true` | Whether error is measured relative to the norm |
+/// | `normalize_error` | `true` | Whether `tolerance` is relative (`true`) or absolute (`false`) |
 ///
 /// # Choosing `tolerance`
 ///
@@ -88,18 +88,27 @@ pub enum CompressionMethod {
 pub struct CompressionOptions {
     /// Decomposition method (LU, CI, or SVD).
     pub method: CompressionMethod,
-    /// Relative truncation tolerance per bond.
+    /// Truncation tolerance per bond.
     ///
-    /// Singular values (or pivots) smaller than `tolerance * sigma_max` are
-    /// discarded. Smaller values preserve more accuracy but produce larger
-    /// bond dimensions.
+    /// With `normalize_error` (the default), singular values (or pivots)
+    /// smaller than `tolerance * sigma_max` of that bond are discarded, so the
+    /// threshold is relative. With `normalize_error` disabled the same
+    /// tolerance is applied as an absolute threshold. Smaller values preserve
+    /// more accuracy but produce larger bond dimensions.
     pub tolerance: f64,
     /// Hard upper bound on any bond dimension.
     ///
     /// Even if the tolerance would allow a larger rank, the bond dimension
     /// is capped at this value. `None` (default) means no limit.
     pub max_bond_dim: Option<usize>,
-    /// Whether to normalize the truncation error by the tensor norm.
+    /// Whether [`tolerance`](Self::tolerance) is relative to the bond scale.
+    ///
+    /// `true` (the default) discards singular values (or pivots) below
+    /// `tolerance * sigma_max` of that bond. `false` discards those below
+    /// `tolerance` itself, which is what a caller with an absolute error
+    /// budget wants: the bond-wise discarded weight then bounds the elementwise
+    /// error contribution of that bond directly, independent of the tensor
+    /// scale.
     pub normalize_error: bool,
 }
 
@@ -157,6 +166,7 @@ fn factorize<T>(
     matrix: &Matrix<T>,
     method: CompressionMethod,
     tolerance: f64,
+    normalize_error: bool,
     max_bond_dim: Option<usize>,
     left_orthogonal: bool,
 ) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
@@ -170,8 +180,18 @@ where
         + TensorScalar,
     f64: From<<T as TensorScalar>::Real>,
 {
-    let reltol = if tolerance > 0.0 { tolerance } else { 1e-14 };
-    let abstol = 0.0;
+    // `normalize_error` selects the meaning of `tolerance`: a threshold
+    // relative to the largest singular value / pivot of the bond, or an
+    // absolute threshold on the discarded weight. The non-truncating left
+    // sweep passes `tolerance == 0.0` and keeps the relative machine-precision
+    // floor in both modes.
+    let (reltol, abstol) = if tolerance > 0.0 && !normalize_error {
+        (0.0, tolerance)
+    } else if tolerance > 0.0 {
+        (tolerance, 0.0)
+    } else {
+        (1e-14, 0.0)
+    };
 
     let options = RrLUOptions {
         max_bond_dim: max_bond_dim.unwrap_or(usize::MAX),
@@ -195,7 +215,13 @@ where
             let npivots = luci.rank();
             Ok((left, right, npivots))
         }
-        CompressionMethod::SVD => factorize_svd(matrix, tolerance, max_bond_dim, left_orthogonal),
+        CompressionMethod::SVD => factorize_svd(
+            matrix,
+            tolerance,
+            normalize_error,
+            max_bond_dim,
+            left_orthogonal,
+        ),
     }
 }
 
@@ -203,6 +229,7 @@ where
 fn factorize_svd<T>(
     matrix: &Matrix<T>,
     tolerance: f64,
+    normalize_error: bool,
     max_bond_dim: Option<usize>,
     left_orthogonal: bool,
 ) -> crate::error::Result<(Matrix<T>, Matrix<T>, usize)>
@@ -249,12 +276,18 @@ where
     let min_dim = m.min(n);
     let s_max = if !s_data.is_empty() { s_data[0] } else { 0.0 };
 
+    let threshold = if normalize_error {
+        tolerance * s_max
+    } else {
+        tolerance
+    };
+
     let mut rank = 0;
     for &singular_value in s_data.iter().take(min_dim) {
         if max_bond_dim.is_some_and(|cap| rank >= cap) {
             break;
         }
-        if singular_value < tolerance * s_max {
+        if singular_value < threshold {
             break;
         }
         rank += 1;
@@ -353,6 +386,7 @@ impl<T: TTScalar + Scalar + Default> SimpleTensorTrain<T> {
                 &mat,
                 options.method,
                 0.0,  // No truncation in left sweep
+                true, // relative machine-precision floor only
                 None, // No max bond dim in left sweep
                 true, // left orthogonal
             )?;
@@ -410,6 +444,7 @@ impl<T: TTScalar + Scalar + Default> SimpleTensorTrain<T> {
                 &mat,
                 options.method,
                 options.tolerance,
+                options.normalize_error,
                 options.max_bond_dim,
                 false, // right orthogonal
             )?;

--- a/crates/tensor4all-simplett/src/compression/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/compression/tests/mod.rs
@@ -206,3 +206,86 @@ fn test_compress_svd_with_truncation_f64() {
 fn test_compress_svd_with_truncation_c64() {
     test_compress_svd_with_truncation_generic::<Complex64>();
 }
+
+/// Two-site train whose bond carries exactly the singular values `1e6` and
+/// `1e-3`, built from orthonormal site vectors so the Schmidt values are the
+/// coefficients themselves.
+fn two_scale_tt<T>() -> SimpleTensorTrain<T>
+where
+    T: TTScalar + Scalar + Default,
+{
+    let half = std::f64::consts::FRAC_1_SQRT_2;
+    let left_vectors = [[half, half], [half, -half]];
+    let right_vectors = [[half, half], [half, -half]];
+    let coefficients = [1.0e6, 1.0e-3];
+
+    let mut t0: Tensor3<T> = tensor3_zeros(1, 2, 2);
+    let mut t1: Tensor3<T> = tensor3_zeros(2, 2, 1);
+    for (component, &coefficient) in coefficients.iter().enumerate() {
+        for site in 0..2 {
+            t0.set3(
+                0,
+                site,
+                component,
+                <T as Scalar>::from_f64(coefficient * left_vectors[component][site]),
+            );
+            t1.set3(
+                component,
+                site,
+                0,
+                <T as Scalar>::from_f64(right_vectors[component][site]),
+            );
+        }
+    }
+    SimpleTensorTrain::new(vec![t0, t1]).unwrap()
+}
+
+fn test_normalize_error_selects_relative_or_absolute_threshold_generic<T>()
+where
+    T: TTScalar + Scalar + Default + tensor4all_tcicore::MatrixLuciScalar,
+    f64: From<<T as TensorScalar>::Real>,
+{
+    let tt = two_scale_tt::<T>();
+    assert_eq!(tt.rank(), 2);
+
+    // Relative: the threshold is 1e-6 * 1e6 = 1, so the 1e-3 component goes.
+    let relative = tt
+        .compressed(&CompressionOptions {
+            method: CompressionMethod::SVD,
+            tolerance: 1e-6,
+            max_bond_dim: None,
+            normalize_error: true,
+        })
+        .unwrap();
+    assert_eq!(relative.rank(), 1);
+
+    // Absolute: the threshold is 1e-6 itself, well below 1e-3, so both
+    // components are kept and the train is reproduced.
+    let absolute = tt
+        .compressed(&CompressionOptions {
+            method: CompressionMethod::SVD,
+            tolerance: 1e-6,
+            max_bond_dim: None,
+            normalize_error: false,
+        })
+        .unwrap();
+    assert_eq!(absolute.rank(), 2);
+    for left in 0..2 {
+        for right in 0..2 {
+            let want = tt.evaluate(&[left, right]).unwrap();
+            let got = absolute.evaluate(&[left, right]).unwrap();
+            let deviation = <T as Scalar>::abs_val(got - want);
+            assert!(deviation < 1e-6, "deviation {deviation:.3e} above 1e-6");
+        }
+    }
+}
+
+#[test]
+fn normalize_error_selects_relative_or_absolute_threshold_f64() {
+    test_normalize_error_selects_relative_or_absolute_threshold_generic::<f64>();
+}
+
+#[test]
+fn normalize_error_selects_relative_or_absolute_threshold_c64() {
+    test_normalize_error_selects_relative_or_absolute_threshold_generic::<Complex64>();
+}


### PR DESCRIPTION
Fixes #618.

## Root cause

The issue reported the returned rank of `tensor4all_aci::elementwise` growing
with the site count `R` at fixed tolerance, reaching several times the rank of
the function, while the run reported `Converged`. Two separate causes, and the
dominant one is not redundant pivots but the tolerance contract.

### 1. The tolerance was scale blind (the rank growth)

`AciOptions::scale_tolerance` defaulted to `false`, so `tolerance` was an
absolute budget on the local pivot errors
(`crates/tensor4all-aci/src/state.rs`, `local_update`, which passes
`abs_tol = tolerance, rel_tol = 0` into the local rrLU, and
`elementwise::max_error_metric`, which then compares raw pivot errors against
`tolerance`).

Instrumenting the issue's reproduction at R = 11 shows what that asks for. The
local blocks have entries up to about 40, the inputs are quantics trains built
at *relative* 1e-8, so they carry an absolute accuracy of about 4e-7. An
absolute 1e-8 on the product is therefore a relative 2e-10, three orders below
the accuracy the inputs have: the sweep is asked to interpolate the inputs' own
interpolation error, which is not low rank and gains structure with every added
site. The pivot count then follows the algebraic bound of the site space,
`4^(R/2)`, rather than the rank of the function, which is exactly the reported
pattern (bond dimensions `[4, 16, 64, 256, 689, ...]`, the left half sitting on
`4^k`).

The local rrLU is honest about this, which rules out the "redundant pivots"
hypotheses for the returned train:

- Forcing 17 sweeps instead of 4 leaves the rank at 675 to 690: it is a fixed
  point of the criterion, not premature stopping.
- Truncating the returned train bond-wise at an absolute spectral 1e-8 removes
  nothing: at R = 11 the middle bond genuinely holds 689 Schmidt values above
  1e-8. The 4x reduction quoted in the issue came from a *relative* SVD
  truncation, which for this train is a threshold about 1e4 times looser, and
  it does change the function by 1.7e-6, five times the error ACI delivers.

So no pruning or recompression of the output can help. The fix is to stop
asking for accuracy below the noise floor: `scale_tolerance` now defaults to
`true`, so each bond's pivot error is compared against `tolerance` times the
largest operator output sampled at that bond. This is the reference contract of
`TensorCrossInterpolation.jl` (`normalizeerror = true`), and it is what this
repository's own `tensor4all-tensorci` already does by default
(`TensorCi1Options::normalize_error` / `TensorCi2Options::normalize_error`, both
`true`, normalized by `max_sample_value`). ACI was the outlier.

### 2. The guard padded bonds that cannot absorb a pivot (the transient rank above the algebraic bound)

`ElementwiseProblem::add_global_pivots` computed a single `fully_represented`
flag over all bonds and inputs, and if a pivot was new anywhere it appended a
row and a column at *every* internal bond. A bond whose frames already
enumerate their whole index space then received rows that can only repeat rows
already present. That is the forensic fact from the issue: a transient rank of
1044 on an eleven-site dimension-four train, above its algebraic bound of 1024.
The bond dimensions `4, 16, 64` near the boundary were padded to `9, 21, 69`
on every guard run for the same reason, and the following sweep spent full-rank
work discarding them.

## Fix

- `crates/tensor4all-aci/src/options.rs`: `scale_tolerance` defaults to `true`.
  Its documentation now states both contracts and what an absolute budget below
  the inputs' accuracy costs. No new knob.
- `crates/tensor4all-aci/src/state.rs`: the pivot injection decision is per
  bond. A bond is skipped when the pivot's row and column are already present
  in every input's frames at that bond (duplicate), and when its dimension has
  reached the number of distinct multi-indices on the shorter side of its cut
  (index-space saturation, where any appended row or column is provably
  linearly dependent and the local block already interpolates exactly).
  `pad_solution_internal_bonds` takes per-bond growth so the frames and the
  solution bonds still grow by the same amount, which is what
  `local_update`'s shape checks require. The set of appends is otherwise
  unchanged, and the guard's convergence gating is untouched.
- `crates/tensor4all-simplett/src/compression.rs`: `normalize_error` was
  documented but ignored, both in the SVD path and in the LU/CI path, which
  always truncated relative to the bond's largest singular value or pivot. It
  now selects a relative or an absolute threshold as documented. The default
  (`true`) is unchanged, so no existing behavior moves; the absolute path is
  what a caller with an absolute error budget needs and is how the rank claims
  above were measured.

A final SVD recompression of the returned train was implemented and then
dropped: measured on this reproduction it removes nothing at ACI's own error
budget in either tolerance mode (682 to 682 absolute, 249 to 247 normalized),
while costing an extra orthogonalization plus truncation sweep.

## Before and after

Issue #618 reproduction: elementwise product of two fused-quantics trains of an
anisotropic Gaussian mixture (N = 512 spikes, seeds 1 and 2), `chi_in` about
185, tolerance 1e-8, `max_bond_dim` 4096, single threaded, same machine. `err`
is the sampled max relative error over 128 random grid points; `t_prod` is the
product wall time. Input construction varies slightly between runs, so
`chi_in` moves by a digit or two.

| R | main `chi_out` | this branch, default | main params | this branch params | main `t_prod` | this branch `t_prod` | main err | this branch err |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 9 | 256 | **233** | 3.1e5 | **2.0e5** | 1.2 s | **0.8 s** | 6.8e-9 | 7.4e-9 |
| 10 | 481 to 489 | **243** | 9.2e5 | **2.7e5** | 3.6 s | **2.2 s** | 5.8e-9 | 9.8e-9 |
| 11 | 661 to 694 | **249** | 1.7e6 | **3.4e5** | 8.7 s | **4.0 s** | 8.5e-9 | 1.4e-8 |

The rank is now flat in `R` (233, 243, 249 against 256, 485, 689), the
parameter count drops 5x at R = 11, and the run is 2.2x faster rather than
slower. The delivered accuracy is unchanged in character: 1.4e-8 sampled
relative error at R = 11 against 8.5e-9 before, and against 2e-8 to 7e-8 for
the variational fit route at rank 171. ACI now sits at 1.45x the fit rank with
a 3x smaller error, where it was at 4x the rank.

Second cause, isolated by running the same reproduction with
`scale_tolerance: false` (opting out of the new default) so only the injection
change is active:

| R | main transient max rank | this branch | main `t_prod` | this branch |
| --- | --- | --- | --- | --- |
| 9 | 268 | 256 | 1.2 s | 0.8 s |
| 10 | 1024 | 465 | 3.6 s | 2.1 s |
| 11 | 1044 (bound 1024) | 852 | 8.7 s | 8.0 s |

No sweep now carries a rank above the algebraic bound, and the final rank in
this mode is unchanged within run-to-run variation (256 / 465 / 689), as
expected: the padding was transient waste, not output rank.

## Tests

- `crates/tensor4all-aci/tests/rank_scaling.rs`, new:
  `product_rank_does_not_grow_with_the_site_count`. The target is a product of
  two three-term trigonometric sums on a base-four quantics grid, each an exact
  rank-6 train for every site count, so the product's exact rank is bounded by
  36 independently of `R`; the factors carry amplitude 1e3 so that a scale-blind
  1e-12 becomes a relative 1e-18 against an output of 1e6. The test asserts the
  rank stays within 1.2x of the exact bound at R = 6 and R = 8, that it does not
  grow between them, and that the sampled relative error stays below 1e-10. It
  runs in 0.2 s. Against the previous default it fails with rank 64 at R = 6 and
  256 at R = 8, both exactly `4^(R/2)`, versus 13 and 13 now.
- `crates/tensor4all-aci/src/tests.rs`, new:
  `global_pivot_injection_stays_within_the_algebraic_bond_bounds` (no bond
  exceeds the distinct-multi-index bound after injecting eight pivots, some bond
  still grows, and frames and solution bonds grow together) and
  `global_pivot_injection_skips_pivots_already_represented` (re-injecting the
  same pivot grows nothing and reports zero).
- `crates/tensor4all-simplett/src/compression/tests/mod.rs`, new:
  `normalize_error_selects_relative_or_absolute_threshold_{f64,c64}` on a train
  whose bond carries exactly the Schmidt values 1e6 and 1e-3, where a tolerance
  of 1e-6 gives rank 1 relative and rank 2 absolute.
- `default_options_are_conservative` updated for the new default.

## Verification

- `cargo test -p tensor4all-aci -p tensor4all-simplett --release`: 404 tests
  pass (85 + 4 + 1 + 249 + 19 + 47), 1 pre-existing ignored.
- `cargo test --doc -p tensor4all-aci -p tensor4all-simplett --release`: 66 doc
  tests pass.
- `cargo clippy` on both crates: no findings in the touched crates. The 45
  pre-existing `nonminimal_bool` warnings from `tensor4all-core` are unrelated
  to this branch and come from a newer local clippy than CI.
- `cargo fmt --all -- --check` clean.
- `python3 scripts/repository-rules-review.py --base main --worktree --dry-run`:
  pass, no findings.
- No in-repo caller of `tensor4all-aci` exists outside the crate, and no caller
  of `CompressionOptions::normalize_error` outside `tensor4all-simplett`, so the
  default change and the option fix reach external callers only.
