### PR TITLE
perf(aci): reuse TTCache across sweeps and skip einsum recompile in guard walks (#620)

### DIFF
--- a/crates/tensor4all-aci/src/elementwise.rs
+++ b/crates/tensor4all-aci/src/elementwise.rs
@@ -168,7 +168,7 @@ where
         {
             guard_runs += 1;
             let seed = options.rng_seed.wrapping_add(guard_runs as u64);
-            let pivots = find_global_pivots(&problem, &mut op, options, seed)?;
+            let pivots = find_global_pivots(&mut problem, &mut op, options, seed)?;
             let _added = problem.add_global_pivots(&pivots)?;
             nglobal_pivots_history.push(pivots.len());
         } else {

--- a/crates/tensor4all-aci/src/global_guard.rs
+++ b/crates/tensor4all-aci/src/global_guard.rs
@@ -39,12 +39,15 @@ use tensor4all_tcicore::{floating_zone_walk, MatrixLuciScalar};
 ///    operator magnitude when `scale_tolerance` is enabled).
 /// 4. Return at most `max_nglobal_pivot` distinct points.
 ///
-/// Input values and the current solution are evaluated per walk step in one
-/// cached batch per tensor train via [`TTCache::evaluate_many`] (shared
-/// prefixes/suffixes are contracted once); the operator is called in a single
-/// [`ElementwiseBatch`] per step.
+/// Input values and the current solution are evaluated through [`TTCache`]s
+/// via [`TTCache::evaluate_many`] (shared prefixes/suffixes are contracted
+/// once). The input caches live in [`ElementwiseProblem`] and persist across
+/// sweeps and starting points — the inputs never change for the run — while
+/// the solution cache is created once per invocation (the solution is fixed
+/// for the whole search and only changes when pivots are injected after it
+/// returns). The operator is called in a single [`ElementwiseBatch`] per step.
 pub(crate) fn find_global_pivots<T, F>(
-    problem: &ElementwiseProblem<T>,
+    problem: &mut ElementwiseProblem<T>,
     op: &mut F,
     options: &AciOptions<T>,
     seed: u64,
@@ -75,8 +78,7 @@ where
     // starting points (the walk is not handed a precomputed candidate set).
     let mut start_input_values = vec![T::zero(); n_inputs * nsearch];
     for input in 0..n_inputs {
-        let mut cache = TTCache::new(&problem.inputs[input]);
-        let values = cache.evaluate_many(&starts, None)?;
+        let values = problem.input_caches[input].evaluate_many(&starts, None)?;
         for (point, value) in values.into_iter().enumerate() {
             start_input_values[input + n_inputs * point] = value;
         }
@@ -96,6 +98,12 @@ where
     };
     let threshold = abs_tol * options.tol_margin_global_search;
 
+    // The solution is fixed for the whole guard invocation (pivots are only
+    // injected by the caller after this returns), so one cache per invocation
+    // amortizes the left/right environment contractions across every walk
+    // step of every starting point.
+    let mut solution_cache = TTCache::new(&problem.solution);
+
     // Floating-zone walk per starting point.
     let mut best: Vec<(f64, Vec<usize>)> = Vec::new();
     for start in &starts {
@@ -106,10 +114,26 @@ where
             threshold,
             |points: &[Vec<usize>]| -> crate::Result<Vec<f64>> {
                 let n_points = points.len();
+                // The walk hands us the current pivot with one site varied,
+                // so every candidate shares all coordinates except that site.
+                // Splitting the evaluation at the varying site contracts the
+                // shared side once (and reuses the cached environments across
+                // scans) instead of re-deriving it per candidate; this is
+                // what keeps a walk at O(chi^2 * dim) per site scan rather
+                // than O(n_sites * chi^2) per point.
+                let split = if n_points < 2 {
+                    None
+                } else {
+                    (0..n_sites)
+                        .find(|&site| {
+                            let first = points[0][site];
+                            points[1..].iter().any(|point| point[site] != first)
+                        })
+                        .map(|site| site + 1)
+                };
                 let mut input_values = vec![T::zero(); n_inputs * n_points];
                 for input in 0..n_inputs {
-                    let mut cache = TTCache::new(&problem.inputs[input]);
-                    let values = cache.evaluate_many(points, None)?;
+                    let values = problem.input_caches[input].evaluate_many(points, split)?;
                     for (point, value) in values.into_iter().enumerate() {
                         input_values[input + n_inputs * point] = value;
                     }
@@ -117,8 +141,7 @@ where
                 let batch = ElementwiseBatch::new(&input_values, n_inputs, n_points)?;
                 let mut op_values = vec![T::zero(); n_points];
                 op(batch, &mut op_values)?;
-                let mut solution_cache = TTCache::new(&problem.solution);
-                let solution_values = solution_cache.evaluate_many(points, None)?;
+                let solution_values = solution_cache.evaluate_many(points, split)?;
                 let errors = (0..n_points)
                     .map(|point| {
                         MatrixLuciScalar::abs_val(op_values[point] - solution_values[point])

--- a/crates/tensor4all-aci/src/global_guard/tests.rs
+++ b/crates/tensor4all-aci/src/global_guard/tests.rs
@@ -111,7 +111,7 @@ fn find_global_pivots_noop_without_search_budget() {
     // Direct finder check: a zero budget returns nothing without touching
     // the problem.
     let input = two_peak_tt(10);
-    let problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
+    let mut problem = ElementwiseProblem::new(vec![input], AciOptions::default()).unwrap();
     let options = AciOptions {
         nsearch_global_pivots: 0,
         max_nglobal_pivot: 0,
@@ -121,7 +121,7 @@ fn find_global_pivots_noop_without_search_budget() {
         output.fill(0.0);
         Ok(())
     };
-    let pivots = find_global_pivots(&problem, &mut op, &options, 0).unwrap();
+    let pivots = find_global_pivots(&mut problem, &mut op, &options, 0).unwrap();
     assert!(pivots.is_empty());
 }
 

--- a/crates/tensor4all-aci/src/state.rs
+++ b/crates/tensor4all-aci/src/state.rs
@@ -3,7 +3,8 @@ use std::cell::RefCell;
 use crate::scalar::AciScalar;
 use crate::{initial_guess, AciError, AciOptions, ElementwiseBatch, LocalBlockEvaluator, Result};
 use tensor4all_simplett::{
-    tensor3_from_data, AbstractTensorTrain, SimpleTensorTrain, Tensor3, Tensor3Ops,
+    tensor3_from_data, AbstractTensorTrain, EinsumScalar, SimpleTensorTrain, TTCache, Tensor3,
+    Tensor3Ops,
 };
 use tensor4all_tcicore::{
     matrix_luci_factors_from_matrix, matrix_luci_factors_from_matrix_owned, RrLUOptions,
@@ -28,6 +29,12 @@ pub(crate) struct ElementwiseProblem<T: AciScalar> {
     pub(crate) right_frames: Vec<Vec<Option<Matrix<T>>>>,
     pub(crate) pivot_errors: Vec<f64>,
     pub(crate) pivot_scales: Vec<f64>,
+    /// Persistent evaluation caches for the inputs, one per input.
+    ///
+    /// The inputs never change for the whole run, so the global pivot guard
+    /// reuses these caches across every sweep and starting point instead of
+    /// rebuilding the partial contractions from scratch on every batch.
+    pub(crate) input_caches: Vec<TTCache<T>>,
 }
 
 #[derive(Clone)]
@@ -55,10 +62,14 @@ impl<T: AciScalar> InputCoreMatrices<T> {
 }
 
 impl<T: AciScalar> ElementwiseProblem<T> {
-    pub(crate) fn new(inputs: Vec<SimpleTensorTrain<T>>, options: AciOptions<T>) -> Result<Self> {
+    pub(crate) fn new(inputs: Vec<SimpleTensorTrain<T>>, options: AciOptions<T>) -> Result<Self>
+    where
+        T: EinsumScalar,
+    {
         let solution = initial_guess(&inputs, &options)?;
         let n = solution.len();
         let n_inputs = inputs.len();
+        let input_caches = inputs.iter().map(TTCache::new).collect();
         let input_core_matrices = inputs
             .iter()
             .map(|input| {
@@ -85,6 +96,7 @@ impl<T: AciScalar> ElementwiseProblem<T> {
             right_frames,
             pivot_errors: vec![0.0; n.saturating_sub(1)],
             pivot_scales: vec![0.0; n.saturating_sub(1)],
+            input_caches,
         };
         problem.initialize_right_frames()?;
         Ok(problem)

--- a/crates/tensor4all-simplett/src/contraction/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/contraction/tests/mod.rs
@@ -195,6 +195,39 @@ fn test_einsum_tensors_reports_backend_error() {
 }
 
 #[test]
+fn test_row_vector_times_matrix_matches_mat_vec() {
+    // Column-major (2 x 3): M[r, c] at r + 2*c.
+    let v = [1.0, -2.0];
+    let m = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let out = row_vector_times_matrix::<f64>(&v, &m, 2, 3).unwrap();
+    // out[c] = v0*m[0,c] + v1*m[1,c]
+    assert_eq!(
+        out,
+        vec![
+            1.0 * 1.0 + (-2.0) * 2.0,
+            1.0 * 3.0 + (-2.0) * 4.0,
+            1.0 * 5.0 + (-2.0) * 6.0
+        ]
+    );
+}
+
+#[test]
+fn test_matrix_times_col_vector_matches_mat_vec() {
+    // Column-major (2 x 3): M[r, c] at r + 2*c.
+    let m = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let v = [1.0, -2.0, 3.0];
+    let out = matrix_times_col_vector::<f64>(&m, 2, 3, &v).unwrap();
+    // out[r] = sum_c M[r,c]*v[c]
+    assert_eq!(
+        out,
+        vec![
+            1.0 * 1.0 + 3.0 * (-2.0) + 5.0 * 3.0,
+            2.0 * 1.0 + 4.0 * (-2.0) + 6.0 * 3.0
+        ]
+    );
+}
+
+#[test]
 fn test_row_vector_times_matrix_reports_shape_error() {
     let err = row_vector_times_matrix::<f64>(&[1.0], &[1.0, 2.0, 3.0, 4.0], 2, 2).unwrap_err();
 

--- a/crates/tensor4all-simplett/src/einsum_helper.rs
+++ b/crates/tensor4all-simplett/src/einsum_helper.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fmt;
 
+use crate::traits::TTScalar;
 use tenferro_einsum::Subscripts;
 use tenferro_tensor::{Tensor, TensorScalar, TypedTensor};
 use tensor4all_tensorbackend::einsum_native_tensors;
@@ -175,7 +176,7 @@ pub(crate) fn tensor_to_col_major_vec<T: TensorScalar>(tensor: &TypedTensor<T>) 
     tensor.host_data().to_vec()
 }
 
-pub(crate) fn row_vector_times_matrix<T: EinsumScalar>(
+pub(crate) fn row_vector_times_matrix<T: TTScalar + EinsumScalar>(
     vector: &[T],
     matrix: &[T],
     rows: usize,
@@ -202,16 +203,21 @@ pub(crate) fn row_vector_times_matrix<T: EinsumScalar>(
         });
     }
 
-    let vector_tf = typed_tensor_from_col_major_slice(vector, &[rows])?;
-    let matrix_tf = typed_tensor_from_col_major_slice(matrix, &[rows, cols])?;
-
-    Ok(tensor_to_col_major_vec(&einsum_tensors(
-        "l,lr->r",
-        &[&vector_tf, &matrix_tf],
-    )?))
+    // Direct loop: `einsum_tensors` re-traces and re-compiles the graph on
+    // every call (the bridge clears the compile cache for safety), which
+    // costs ~70 us even for a 2x2 product. TTCache's environment recursion
+    // calls this thousands of times per global-pivot guard search, so the
+    // mat-vec is computed inline.
+    Ok((0..cols)
+        .map(|c| {
+            (0..rows)
+                .map(|r| vector[r] * matrix[r + c * rows])
+                .fold(T::zero(), |acc, x| acc + x)
+        })
+        .collect())
 }
 
-pub(crate) fn matrix_times_col_vector<T: EinsumScalar>(
+pub(crate) fn matrix_times_col_vector<T: TTScalar + EinsumScalar>(
     matrix: &[T],
     rows: usize,
     cols: usize,
@@ -237,13 +243,16 @@ pub(crate) fn matrix_times_col_vector<T: EinsumScalar>(
         });
     }
 
-    let matrix_tf = typed_tensor_from_col_major_slice(matrix, &[rows, cols])?;
-    let vector_tf = typed_tensor_from_col_major_slice(vector, &[cols])?;
-
-    Ok(tensor_to_col_major_vec(&einsum_tensors(
-        "lr,r->l",
-        &[&matrix_tf, &vector_tf],
-    )?))
+    // Direct loop, same rationale as `row_vector_times_matrix`: the einsum
+    // dispatch recompiles the graph on every call, which dominates small
+    // environment contractions.
+    Ok((0..rows)
+        .map(|r| {
+            (0..cols)
+                .map(|c| matrix[r + c * rows] * vector[c])
+                .fold(T::zero(), |acc, x| acc + x)
+        })
+        .collect())
 }
 
 /// Scalar types supported by the tenferro-backed einsum helpers used in


### PR DESCRIPTION
## Summary

Resolves #620. The per-sweep global pivot guard (introduced in #617) built
fresh `TTCache` instances on every evaluation batch, so the floating-zone
walks paid `O(n_sites * chi^2)` per point: left/right environments were
recomputed from scratch on each call even though consecutive batches share
almost all partial contractions. A second, hidden cost: the small mat-vec
helpers used for environment contractions dispatched to `einsum_tensors`,
which re-traces and re-compiles the tenferro graph on **every call**
(the bridge clears the compile cache for safety), costing ~70 us even for a
2x2 product.

### Changes

1. **aci** (`state.rs`): `ElementwiseProblem` now owns persistent input
   `TTCache`s, built once in `new`. The inputs never change for the run, so
   the caches accumulate across all sweeps and starting points.
2. **aci** (`global_guard.rs`): `find_global_pivots` uses the persistent
   input caches for the starting-point evaluation and every walk batch, and
   creates one solution cache per guard invocation (the solution is fixed
   during the search; pivots are injected only after it returns) instead of
   one per batch. Walk candidate batches are evaluated with the split at the
   varying site, so the shared side is contracted once and reused across
   scans (`O(chi^2 * dim)` per site scan).
3. **simplett** (`einsum_helper.rs`): `row_vector_times_matrix` /
   `matrix_times_col_vector` compute the mat-vec inline (column-major,
   same error validation) instead of dispatching to `einsum_tensors`.
   `pub(crate)`, used by `TTCache` and MPO evaluation.
4. Tests: value tests for both mat-vec helpers; guard test updated for the
   new signature.

The guard's safety contract (#610 / gw-rs#9) is unchanged — same searches,
same injection, identical results (see benchmark).

## Benchmark (issue reproduction: elementwise product of 1D quantics
Fourier QTTs, rank-2 inputs, `RAYON_NUM_THREADS=1`)

| R (sites) | before (b160bb7) | after | speedup |
|---|---|---|---|
| 10 | 374 ms | 2.0 ms | ~185x |
| 20 | 1.9 s | 5.2 ms | ~366x |

Ranks, sweep histories, and pointwise errors are identical to the guard-off
run (max diff 0.0) — the guard's constant factor is what dropped, not its
behavior.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo nextest run --release --workspace` 2798 passed
- `cargo test --doc --release --workspace` 865 passed
- `./scripts/test-mdbook.sh` pass
- `scripts/repository-rules-review.py --base origin/main --worktree --dry-run` pass
- Independent gpt-review of the full diff: no findings