### PR TITLE
Fix mechanical audit findings

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -116,7 +116,13 @@ jobs:
         with:
           components: clippy
 
+      - name: Install cbindgen
+        run: cargo install cbindgen --version 0.29.2 --locked
+
       - uses: Swatinem/rust-cache@v2
+
+      - name: Check generated C API header
+        run: ./scripts/check-capi-header.sh
 
       - name: Test the repository-rules review script
         run: python3 scripts/test-repository-rules-review.py

--- a/crates/tensor4all-capi/README.md
+++ b/crates/tensor4all-capi/README.md
@@ -47,6 +47,9 @@ cbindgen crates/tensor4all-capi \
   --output crates/tensor4all-capi/include/tensor4all_capi.h
 ```
 
+Use `./scripts/check-capi-header.sh` from the repository root to verify the
+pinned cbindgen version, generated-header freshness, and C/C++ compilation.
+
 ## License
 
 MIT License

--- a/crates/tensor4all-capi/include/tensor4all_capi.h
+++ b/crates/tensor4all-capi/include/tensor4all_capi.h
@@ -312,8 +312,6 @@ typedef enum t4a_canonical_form {
   T4A_CANONICAL_FORM_CI = 2,
 } t4a_canonical_form;
 
-typedef struct Option_TensorStorageError Option_TensorStorageError;
-
 /**
  * Opaque index type for the C API.
  */
@@ -340,7 +338,6 @@ typedef struct t4a_treetn {
  */
 typedef struct t4a_tensor {
   const void *_private;
-  struct Option_TensorStorageError test_storage_error;
 } t4a_tensor;
 
 /**
@@ -545,6 +542,9 @@ enum t4a_status_code t4a_index_tags(const struct t4a_index *ptr,
  * * `T4A_SUCCESS` - Message written (or length query succeeded).
  * * `T4A_NULL_POINTER` - `out_len` is null.
  * * `T4A_BUFFER_TOO_SMALL` - Buffer too small; `out_len` has the required size.
+ *
+ * An undersized retrieval buffer does not replace the stored diagnostic, so
+ * callers can retry with the reported size and recover the original message.
  */
 enum t4a_status_code t4a_last_error_message(uint8_t *buf, size_t buf_len, size_t *out_len);
 

--- a/crates/tensor4all-capi/src/lib.rs
+++ b/crates/tensor4all-capi/src/lib.rs
@@ -255,6 +255,9 @@ pub(crate) fn panic_message(info: &(dyn std::any::Any + Send)) -> String {
 /// * `T4A_SUCCESS` - Message written (or length query succeeded).
 /// * `T4A_NULL_POINTER` - `out_len` is null.
 /// * `T4A_BUFFER_TOO_SMALL` - Buffer too small; `out_len` has the required size.
+///
+/// An undersized retrieval buffer does not replace the stored diagnostic, so
+/// callers can retry with the reported size and recover the original message.
 #[unsafe(no_mangle)]
 pub extern "C" fn t4a_last_error_message(
     buf: *mut u8,
@@ -276,7 +279,7 @@ pub extern "C" fn t4a_last_error_message(
         }
 
         if buf_len < required_len {
-            return err_buffer_too_small("last_error_message", required_len, buf_len);
+            return T4A_BUFFER_TOO_SMALL;
         }
 
         unsafe {

--- a/crates/tensor4all-capi/src/tests/mod.rs
+++ b/crates/tensor4all-capi/src/tests/mod.rs
@@ -46,18 +46,40 @@ fn test_last_error_message_roundtrip() {
 }
 
 #[test]
-fn test_last_error_message_buffer_too_small() {
+fn test_last_error_message_buffer_too_small_preserves_message_for_retry() {
     set_last_error("hello");
     let mut out_len: libc::size_t = 0;
-    let mut buf = [0u8; 2]; // too small for "hello\0"
+    let mut short_buf = [0u8; 2]; // too small for "hello\0"
+    let status = t4a_last_error_message(
+        short_buf.as_mut_ptr(),
+        short_buf.len(),
+        &mut out_len as *mut libc::size_t,
+    );
+    assert_eq!(status, T4A_BUFFER_TOO_SMALL);
+    assert_eq!(out_len, 6); // "hello" + null
+
+    let required_len = out_len;
+    let mut buf = vec![0u8; required_len];
     let status = t4a_last_error_message(
         buf.as_mut_ptr(),
         buf.len(),
         &mut out_len as *mut libc::size_t,
     );
-    assert_eq!(status, T4A_BUFFER_TOO_SMALL);
-    assert_eq!(out_len, 6); // "hello" + null
-    assert!(read_last_error().contains("last_error_message buffer too small"));
+    assert_eq!(status, T4A_SUCCESS);
+    assert_eq!(out_len, required_len);
+    assert_eq!(buf, b"hello\0");
+}
+
+#[test]
+fn test_tensor_handle_is_one_pointer_word() {
+    assert_eq!(
+        std::mem::size_of::<t4a_tensor>(),
+        std::mem::size_of::<*const ()>()
+    );
+    assert_eq!(
+        std::mem::align_of::<t4a_tensor>(),
+        std::mem::align_of::<*const ()>()
+    );
 }
 
 #[test]

--- a/crates/tensor4all-capi/src/types.rs
+++ b/crates/tensor4all-capi/src/types.rs
@@ -113,27 +113,44 @@ impl From<StorageKind> for t4a_storage_kind {
     }
 }
 
+#[derive(Clone)]
+struct InternalTensorHandle {
+    tensor: InternalTensor,
+    #[cfg(test)]
+    test_storage_error: Option<TensorStorageError>,
+}
+
 /// Opaque tensor type for the C API.
 #[repr(C)]
 pub struct t4a_tensor {
     pub(crate) _private: *const c_void,
-    #[cfg(test)]
-    pub(crate) test_storage_error: Option<TensorStorageError>,
 }
 
 impl t4a_tensor {
     /// Create a wrapper from an internal tensor value.
     pub(crate) fn new(tensor: InternalTensor) -> Self {
-        Self {
-            _private: Box::into_raw(Box::new(tensor)) as *const c_void,
+        Self::from_handle(InternalTensorHandle {
+            tensor,
             #[cfg(test)]
             test_storage_error: None,
+        })
+    }
+
+    fn from_handle(handle: InternalTensorHandle) -> Self {
+        Self {
+            _private: Box::into_raw(Box::new(handle)) as *const c_void,
         }
+    }
+
+    fn handle(&self) -> &InternalTensorHandle {
+        // SAFETY: `_private` is created from `Box<InternalTensorHandle>` and
+        // remains owned by this wrapper until `Drop` reconstructs that box.
+        unsafe { &*(self._private as *const InternalTensorHandle) }
     }
 
     /// Borrow the wrapped tensor.
     pub(crate) fn inner(&self) -> &InternalTensor {
-        unsafe { &*(self._private as *const InternalTensor) }
+        &self.handle().tensor
     }
 
     #[cfg(test)]
@@ -141,33 +158,31 @@ impl t4a_tensor {
         tensor: InternalTensor,
         error: TensorStorageError,
     ) -> Self {
-        Self {
-            _private: Box::into_raw(Box::new(tensor)) as *const c_void,
+        Self::from_handle(InternalTensorHandle {
+            tensor,
             test_storage_error: Some(error),
-        }
+        })
     }
 
     #[cfg(test)]
     pub(crate) fn test_storage_error(&self) -> Option<TensorStorageError> {
-        self.test_storage_error.clone()
+        self.handle().test_storage_error.clone()
     }
 }
 
 impl Clone for t4a_tensor {
     fn clone(&self) -> Self {
-        #[cfg(test)]
-        if let Some(error) = self.test_storage_error() {
-            return Self::with_test_storage_error(self.inner().clone(), error);
-        }
-        Self::new(self.inner().clone())
+        Self::from_handle(self.handle().clone())
     }
 }
 
 impl Drop for t4a_tensor {
     fn drop(&mut self) {
         if !self._private.is_null() {
+            // SAFETY: `_private` was allocated by `from_handle` and is
+            // reconstructed exactly once when this wrapper is dropped.
             unsafe {
-                let _ = Box::from_raw(self._private as *mut InternalTensor);
+                let _ = Box::from_raw(self._private as *mut InternalTensorHandle);
             }
         }
     }

--- a/crates/tensor4all-quanticstransform/src/fourier.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier.rs
@@ -109,6 +109,30 @@ impl Default for FourierOptions {
 }
 
 impl FourierOptions {
+    fn validate(&self) -> std::result::Result<(), QuanticsTransformError> {
+        if self.sign != -1.0 && self.sign != 1.0 {
+            return Err(QuanticsTransformError::InvalidConfiguration {
+                message: "sign must be exactly -1.0 or 1.0".to_string(),
+            });
+        }
+        if !self.tolerance.is_finite() || self.tolerance < 0.0 {
+            return Err(QuanticsTransformError::InvalidConfiguration {
+                message: "tolerance must be finite and nonnegative".to_string(),
+            });
+        }
+        if self.max_bond_dim == Some(0) {
+            return Err(QuanticsTransformError::InvalidConfiguration {
+                message: "max_bond_dim must be positive when specified".to_string(),
+            });
+        }
+        if self.k == 0 {
+            return Err(QuanticsTransformError::InvalidConfiguration {
+                message: "k must be positive".to_string(),
+            });
+        }
+        Ok(())
+    }
+
     /// Create options for forward Fourier transform.
     /// # Errors
     ///
@@ -153,13 +177,15 @@ impl FTCore {
     ///
     /// # Errors
     ///
-    /// Returns an error when the variable count or dimension overflows (an
-    /// /// overflow or invalid-configuration failure).
+    /// Returns [`QuanticsTransformError::InvalidConfiguration`] for invalid
+    /// Fourier options or site counts. It also returns an error when a
+    /// dimension overflows.
     ///
     pub fn new(
         r: usize,
         options: FourierOptions,
     ) -> std::result::Result<Self, QuanticsTransformError> {
+        options.validate()?;
         if r < 2 {
             return Err(QuanticsTransformError::InvalidConfiguration {
                 message: format!("Number of sites must be at least 2, got {r}"),
@@ -232,8 +258,9 @@ impl FTCore {
 /// LinearOperator representing the QFT
 /// # Errors
 ///
-/// Returns an error when the operator construction fails (an overflow or
-/// /// invalid-configuration failure).
+/// Returns [`QuanticsTransformError::InvalidConfiguration`] for invalid
+/// Fourier options or site counts. It also returns an error when operator
+/// construction or allocation overflows.
 ///
 /// # Examples
 /// ```
@@ -247,8 +274,11 @@ pub fn quantics_fourier_operator(
     r: usize,
     options: FourierOptions,
 ) -> std::result::Result<QuanticsOperator, QuanticsTransformError> {
+    options.validate()?;
     if r < 2 {
-        return Err(anyhow::anyhow!("Number of sites must be at least 2, got {r}").into());
+        return Err(QuanticsTransformError::InvalidConfiguration {
+            message: format!("Number of sites must be at least 2, got {r}"),
+        });
     }
 
     let mpo = quantics_fourier_mpo(r, &options)?;
@@ -261,11 +291,10 @@ pub fn quantics_fourier_operator(
 fn quantics_fourier_mpo(
     r: usize,
     options: &FourierOptions,
-) -> Result<SimpleTensorTrain<Complex64>> {
+) -> std::result::Result<SimpleTensorTrain<Complex64>, QuanticsTransformError> {
+    options.validate()?;
     if r < 2 {
-        return Err(anyhow::anyhow!(
-            "Number of sites must be at least 2, got {r}"
-        ));
+        return Err(anyhow::anyhow!("Number of sites must be at least 2, got {r}").into());
     }
 
     let k = options.k;

--- a/crates/tensor4all-quanticstransform/src/fourier/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/fourier/tests/mod.rs
@@ -88,18 +88,67 @@ fn test_fourier_inverse_sign() {
 }
 
 #[test]
+fn test_fourier_rejects_invalid_options_before_allocation() {
+    for sign in [0.0, 2.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let options = FourierOptions {
+            sign,
+            ..FourierOptions::default()
+        };
+        let error = quantics_fourier_operator(usize::MAX, options).unwrap_err();
+        assert!(matches!(
+            error,
+            QuanticsTransformError::InvalidConfiguration { .. }
+        ));
+    }
+
+    for tolerance in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let options = FourierOptions {
+            tolerance,
+            ..FourierOptions::default()
+        };
+        let error = FTCore::new(usize::MAX, options).err().unwrap();
+        assert!(matches!(
+            error,
+            QuanticsTransformError::InvalidConfiguration { .. }
+        ));
+    }
+
+    for options in [
+        FourierOptions {
+            max_bond_dim: Some(0),
+            ..FourierOptions::default()
+        },
+        FourierOptions {
+            k: 0,
+            ..FourierOptions::default()
+        },
+    ] {
+        let error = quantics_fourier_operator(usize::MAX, options).unwrap_err();
+        assert!(matches!(
+            error,
+            QuanticsTransformError::InvalidConfiguration { .. }
+        ));
+    }
+}
+
+#[test]
 fn test_fourier_error_zero_sites() {
-    let options = FourierOptions::default();
-    let result = quantics_fourier_operator(0, options);
-    assert!(result.is_err());
+    let error = quantics_fourier_operator(0, FourierOptions::default()).unwrap_err();
+    assert!(matches!(
+        error,
+        QuanticsTransformError::InvalidConfiguration { .. }
+    ));
 }
 
 #[test]
 fn test_fourier_error_one_site() {
     let options = FourierOptions::default();
-    let result = quantics_fourier_operator(1, options);
-    assert!(result.is_err());
-    let msg = result.unwrap_err().to_string();
+    let error = quantics_fourier_operator(1, options).unwrap_err();
+    assert!(matches!(
+        &error,
+        QuanticsTransformError::InvalidConfiguration { .. }
+    ));
+    let msg = error.to_string();
     assert!(msg.contains("at least 2"), "unexpected error: {msg}");
 }
 

--- a/crates/tensor4all-tensorci/src/error.rs
+++ b/crates/tensor4all-tensorci/src/error.rs
@@ -5,9 +5,34 @@ use thiserror::Error;
 /// Result type for TCI operations
 pub type Result<T> = std::result::Result<T, TCIError>;
 
+pub(crate) fn validate_nonnegative_finite(name: &str, value: f64) -> Result<()> {
+    if !value.is_finite() || value < 0.0 {
+        return Err(TCIError::InvalidConfiguration {
+            message: format!("{name} must be finite and nonnegative"),
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_positive(name: &str, value: usize) -> Result<()> {
+    if value == 0 {
+        return Err(TCIError::InvalidConfiguration {
+            message: format!("{name} must be positive"),
+        });
+    }
+    Ok(())
+}
+
 /// Errors that can occur during tensor cross interpolation operations
 #[derive(Error, Debug)]
 pub enum TCIError {
+    /// Invalid algorithm configuration.
+    #[error("Invalid configuration: {message}")]
+    InvalidConfiguration {
+        /// Description of the invalid option value.
+        message: String,
+    },
+
     /// Dimension mismatch
     #[error("Dimension mismatch: {message}")]
     DimensionMismatch {

--- a/crates/tensor4all-tensorci/src/integration.rs
+++ b/crates/tensor4all-tensorci/src/integration.rs
@@ -507,8 +507,9 @@ fn gk_nodes_weights(gk_order: usize) -> Result<(&'static [f64], &'static [f64])>
 ///
 /// # Errors
 ///
-/// Returns an error when the contraction or operation fails (a shape or
-/// /// index mismatch, or a backend failure).
+/// Returns [`TCIError::InvalidConfiguration`] for invalid TCI2 options. It
+/// also returns an error when the contraction or operation fails (a shape or
+/// index mismatch, or a backend failure).
 ///
 /// # Examples
 ///
@@ -536,6 +537,7 @@ where
     T: Scalar + TTScalar + Default + MatrixLuciScalar,
     F: Fn(&[f64]) -> T,
 {
+    tci_options.validate()?;
     if a.len() != b.len() {
         return Err(TCIError::DimensionMismatch {
             message: format!(
@@ -604,6 +606,28 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_integrate_rejects_invalid_options_before_callback() {
+        let calls = std::cell::Cell::new(0);
+        let f = |_x: &[f64]| {
+            calls.set(calls.get() + 1);
+            1.0_f64
+        };
+        let error = integrate::<f64, _>(
+            &f,
+            &[0.0, 0.0],
+            &[1.0, 1.0],
+            15,
+            TCI2Options {
+                ncheck_history: 0,
+                ..TCI2Options::default()
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+        assert_eq!(calls.get(), 0);
+    }
 
     #[test]
     fn test_integrate_constant() {

--- a/crates/tensor4all-tensorci/src/tensorci1.rs
+++ b/crates/tensor4all-tensorci/src/tensorci1.rs
@@ -1,6 +1,6 @@
 //! TensorCI1 - legacy one-site Tensor Cross Interpolation algorithm.
 
-use crate::error::{Result, TCIError};
+use crate::error::{validate_nonnegative_finite, validate_positive, Result, TCIError};
 use tensor4all_simplett::{
     tensor3_zeros, AbstractTensorTrain, SimpleTensorTrain, TTScalar, Tensor3Ops,
 };
@@ -104,6 +104,14 @@ pub struct TCI1Options {
     /// Each pivot must contain one in-range zero-based index per site. The
     /// default is empty. Duplicate pivots are ignored by the index sets.
     pub additional_pivots: Vec<MultiIndex>,
+}
+
+impl TCI1Options {
+    fn validate(&self) -> Result<()> {
+        validate_nonnegative_finite("tolerance", self.tolerance)?;
+        validate_nonnegative_finite("pivot_tolerance", self.pivot_tolerance)?;
+        validate_positive("max_iter", self.max_iter)
+    }
 }
 
 impl Default for TCI1Options {
@@ -503,8 +511,10 @@ where
     ///
     /// # Errors
     ///
-    /// Returns a [`TCIError`] if `bond` is out of range, a matrix cross
-    /// interpolation update fails, or an internal index set is inconsistent.
+    /// Returns [`TCIError::InvalidConfiguration`] when `tolerance` is negative
+    /// or non-finite. It also returns a [`TCIError`] if `bond` is out of range,
+    /// a matrix cross interpolation update fails, or an internal index set is
+    /// inconsistent.
     ///
     /// # Examples
     ///
@@ -523,6 +533,7 @@ where
     where
         F: Fn(&MultiIndex) -> T,
     {
+        validate_nonnegative_finite("tolerance", tolerance)?;
         if bond >= self.len().saturating_sub(1) {
             return Err(TCIError::IndexOutOfBounds {
                 message: format!("bond {bond} is outside 0..{}", self.len().saturating_sub(1)),
@@ -568,8 +579,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns a [`TCIError`] if `pivot` is malformed or out of range, if a
-    /// pivot update fails, or if index sets become inconsistent.
+    /// Returns [`TCIError::InvalidConfiguration`] when `abstol` is negative or
+    /// non-finite. It also returns a [`TCIError`] if `pivot` is malformed or out
+    /// of range, if a pivot update fails, or if index sets become inconsistent.
     ///
     /// # Examples
     ///
@@ -588,6 +600,7 @@ where
     where
         F: Fn(&MultiIndex) -> T,
     {
+        validate_nonnegative_finite("abstol", abstol)?;
         validate_first_pivot(&self.local_dims, &pivot)?;
         let exact = f(&pivot);
         let current = self.evaluate(&pivot).unwrap_or_else(|_| T::zero());
@@ -869,8 +882,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns a typed [`TCIError`] for invalid dimensions, invalid pivots,
-/// interpolation failures, or tensor-train conversion failures.
+/// Returns [`TCIError::InvalidConfiguration`] for invalid tolerances or a
+/// zero iteration limit. It also returns typed errors for invalid dimensions,
+/// invalid pivots, interpolation failures, or tensor-train conversion failures.
 ///
 /// # Examples
 ///
@@ -903,6 +917,7 @@ where
     T: Scalar + TTScalar + Default + MatrixLuciScalar + MatrixSolveScalar,
     F: Fn(&MultiIndex) -> T,
 {
+    options.validate()?;
     let mut tci = TensorCI1::from_function(&f, local_dims, first_pivot)?;
     let mut ranks = Vec::new();
     let mut errors = Vec::new();

--- a/crates/tensor4all-tensorci/src/tensorci1/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/tensorci1/tests/mod.rs
@@ -359,6 +359,78 @@ fn test_crossinterpolate1_additional_pivots_converges_with_duplicates() {
 }
 
 #[test]
+fn test_crossinterpolate1_rejects_invalid_options_before_callback() {
+    use std::cell::Cell;
+
+    for tolerance in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let calls = Cell::new(0);
+        let options = TCI1Options {
+            tolerance,
+            ..TCI1Options::default()
+        };
+        let error = crossinterpolate1::<f64, _>(
+            |_| {
+                calls.set(calls.get() + 1);
+                1.0
+            },
+            vec![2, 2],
+            vec![0, 0],
+            options,
+        )
+        .unwrap_err();
+        assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+        assert_eq!(calls.get(), 0);
+    }
+
+    for pivot_tolerance in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let options = TCI1Options {
+            pivot_tolerance,
+            ..TCI1Options::default()
+        };
+        let error =
+            crossinterpolate1::<f64, _>(|_| 1.0, vec![2, 2], vec![0, 0], options).unwrap_err();
+        assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    }
+
+    let error = crossinterpolate1::<f64, _>(
+        |_| 1.0,
+        vec![2, 2],
+        vec![0, 0],
+        TCI1Options {
+            max_iter: 0,
+            ..TCI1Options::default()
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+}
+
+#[test]
+fn test_tensorci1_raw_tolerances_validate_before_callback_and_accept_zero() {
+    use std::cell::Cell;
+
+    let calls = Cell::new(0);
+    let f = |idx: &MultiIndex| {
+        calls.set(calls.get() + 1);
+        (idx[0] + idx[1] + 1) as f64
+    };
+    let mut tci = TensorCI1::<f64>::from_function(&f, vec![2, 2], vec![0, 0]).unwrap();
+
+    calls.set(0);
+    let error = tci.add_pivot(0, &f, f64::NAN).unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+
+    calls.set(0);
+    let error = tci.add_global_pivot(&f, vec![1, 1], -1.0).unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+
+    tci.add_pivot(0, &f, 0.0).unwrap();
+    tci.add_global_pivot(&f, vec![1, 1], 0.0).unwrap();
+}
+
+#[test]
 fn test_crossinterpolate1_rejects_invalid_first_pivots() {
     let f = |idx: &MultiIndex| (idx[0] + idx[1] + 1) as f64;
 

--- a/crates/tensor4all-tensorci/src/tensorci2.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2.rs
@@ -4,7 +4,7 @@
 //! more efficient convergence. It supports batch evaluation of function
 //! values through an explicit batch function parameter.
 
-use crate::error::{Result, TCIError};
+use crate::error::{validate_nonnegative_finite, validate_positive, Result, TCIError};
 use crate::globalpivot::{DefaultGlobalPivotFinder, GlobalPivotFinder, GlobalPivotSearchInput};
 use rand::SeedableRng;
 use std::cell::{Cell, RefCell};
@@ -132,6 +132,19 @@ pub struct TCI2Options {
     ///
     /// Set to `Some(seed)` for deterministic results.
     pub seed: Option<u64>,
+}
+
+impl TCI2Options {
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_nonnegative_finite("tolerance", self.tolerance)?;
+        validate_nonnegative_finite("tol_margin_global_search", self.tol_margin_global_search)?;
+        validate_positive("max_iter", self.max_iter)?;
+        validate_positive("ncheck_history", self.ncheck_history)?;
+        if let Some(max_bond_dim) = self.max_bond_dim {
+            validate_positive("max_bond_dim", max_bond_dim)?;
+        }
+        Ok(())
+    }
 }
 
 impl Default for TCI2Options {
@@ -700,8 +713,10 @@ where
     /// suitable for calling from C-API.
     /// # Errors
     ///
-    /// Returns an error when the two-site sweep fails (a shape or index mismatch,
-    /// /// a non-convergence failure, or a backend failure).
+    /// Returns [`TCIError::InvalidConfiguration`] for invalid tolerances,
+    /// iteration/history limits, or an invalid optional bond dimension. It
+    /// also returns an error for a shape or index mismatch, a non-convergence
+    /// failure, or a backend failure.
     ///
     pub fn sweep2site<F, B>(
         &mut self,
@@ -714,6 +729,7 @@ where
         F: Fn(&MultiIndex) -> T,
         B: Fn(&[MultiIndex]) -> Vec<T>,
     {
+        options.validate()?;
         let n = self.len();
         self.invalidate_site_tensors();
         self.flush_pivot_errors();
@@ -813,8 +829,10 @@ where
     /// Port of Julia's `sweep1site!` from `tensorci2.jl`.
     /// # Errors
     ///
-    /// Returns an error when the one-site sweep fails (a shape or index mismatch,
-    /// /// a non-convergence failure, or a backend failure).
+    /// Returns [`TCIError::InvalidConfiguration`] for negative or non-finite
+    /// tolerances or a zero bond dimension. It also returns an error when the
+    /// one-site sweep fails (a shape or index mismatch, a non-convergence
+    /// failure, or a backend failure).
     ///
     pub fn sweep1site<F>(
         &mut self,
@@ -828,6 +846,9 @@ where
     where
         F: Fn(&MultiIndex) -> T,
     {
+        validate_nonnegative_finite("rel_tol", rel_tol)?;
+        validate_nonnegative_finite("abs_tol", abs_tol)?;
+        validate_positive("max_bond_dim", max_bond_dim)?;
         self.flush_pivot_errors();
         self.invalidate_site_tensors();
 
@@ -1114,8 +1135,9 @@ where
     /// Port of Julia's `makecanonical!`.
     /// # Errors
     ///
-    /// Returns an error when the canonicalization fails (a shape or index
-    /// /// mismatch, or a backend failure).
+    /// Returns [`TCIError::InvalidConfiguration`] for negative or non-finite
+    /// tolerances or a zero bond dimension. It also returns an error when the
+    /// canonicalization fails (a shape or index mismatch or a backend failure).
     ///
     pub fn make_canonical<F>(
         &mut self,
@@ -1127,6 +1149,9 @@ where
     where
         F: Fn(&MultiIndex) -> T,
     {
+        validate_nonnegative_finite("rel_tol", rel_tol)?;
+        validate_nonnegative_finite("abs_tol", abs_tol)?;
+        validate_positive("max_bond_dim", max_bond_dim)?;
         // First half-sweep: exact, no truncation
         self.sweep1site(f, true, 0.0, 0.0, usize::MAX, false)?;
         // Second half-sweep: backward with truncation
@@ -1386,9 +1411,9 @@ fn convergence_criterion(
 ///
 /// # Errors
 ///
-/// Returns [`TCIError::DimensionMismatch`] if `local_dims` has fewer than
-/// 2 elements, or [`TCIError::InvalidPivot`] if all initial pivots
-/// evaluate to zero.
+/// Returns [`TCIError::InvalidConfiguration`] for invalid algorithm options,
+/// [`TCIError::DimensionMismatch`] if `local_dims` has fewer than 2 elements,
+/// or [`TCIError::InvalidPivot`] if all initial pivots evaluate to zero.
 ///
 /// # Examples
 ///
@@ -1438,6 +1463,7 @@ where
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
 {
+    options.validate()?;
     if local_dims.len() < 2 {
         return Err(TCIError::DimensionMismatch {
             message: "local_dims should have at least 2 elements".to_string(),
@@ -1502,8 +1528,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`TCIError::InvalidPivot`] when the input state has no pivots. It
-/// also forwards errors from two-site sweeps, tensor-train conversion, callback
+/// Returns [`TCIError::InvalidConfiguration`] for invalid algorithm options or
+/// [`TCIError::InvalidPivot`] when the input state has no pivots. It also
+/// forwards errors from two-site sweeps, tensor-train conversion, callback
 /// length validation, and final one-site cleanup.
 ///
 /// # Examples
@@ -1550,6 +1577,7 @@ where
     B: Fn(&[MultiIndex]) -> Vec<T>,
     G: GlobalPivotFinder,
 {
+    options.validate()?;
     if tci.rank() == 0 {
         return Err(TCIError::InvalidPivot {
             message: "TensorCI2 state must contain at least one pivot before optimization"

--- a/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
+++ b/crates/tensor4all-tensorci/src/tensorci2/tests/mod.rs
@@ -5,6 +5,145 @@ use std::rc::Rc;
 use tensor4all_simplett::AbstractTensorTrain;
 
 #[test]
+fn test_tci2_rejects_invalid_options_before_callback() {
+    let invalid_tolerances = [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY];
+    for tolerance in invalid_tolerances {
+        let calls = Cell::new(0);
+        let options = TCI2Options {
+            tolerance,
+            ..TCI2Options::default()
+        };
+        let error = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            |_| {
+                calls.set(calls.get() + 1);
+                1.0
+            },
+            None,
+            vec![2, 2],
+            vec![vec![0, 0]],
+            options,
+        )
+        .unwrap_err();
+        assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+        assert_eq!(calls.get(), 0);
+    }
+
+    for margin in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let options = TCI2Options {
+            tol_margin_global_search: margin,
+            ..TCI2Options::default()
+        };
+        let error = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            |_| 1.0,
+            None,
+            vec![2, 2],
+            vec![vec![0, 0]],
+            options,
+        )
+        .unwrap_err();
+        assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    }
+
+    for options in [
+        TCI2Options {
+            max_iter: 0,
+            ..TCI2Options::default()
+        },
+        TCI2Options {
+            ncheck_history: 0,
+            ..TCI2Options::default()
+        },
+        TCI2Options {
+            max_bond_dim: Some(0),
+            ..TCI2Options::default()
+        },
+    ] {
+        let error = crossinterpolate2::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+            |_| 1.0,
+            None,
+            vec![2, 2],
+            vec![vec![0, 0]],
+            options,
+        )
+        .unwrap_err();
+        assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    }
+}
+
+#[test]
+fn test_sweep2site_rejects_invalid_options_before_callback() {
+    let mut tci = TensorCI2::<f64>::new(vec![2, 2]).unwrap();
+    let calls = Cell::new(0);
+    let options = TCI2Options {
+        max_iter: 0,
+        ..TCI2Options::default()
+    };
+    type BatchFn = fn(&[MultiIndex]) -> Vec<f64>;
+    let batched: Option<BatchFn> = None;
+    let error = tci
+        .sweep2site(
+            &|_| {
+                calls.set(calls.get() + 1);
+                1.0
+            },
+            &batched,
+            true,
+            &options,
+        )
+        .unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+}
+
+#[test]
+fn test_tci2_raw_parameters_validate_before_callback() {
+    let mut tci = TensorCI2::<f64>::new(vec![2, 2]).unwrap();
+    tci.add_global_pivots(&[vec![0, 0]]).unwrap();
+    let calls = Cell::new(0);
+    let f = |_: &MultiIndex| {
+        calls.set(calls.get() + 1);
+        1.0
+    };
+
+    let error = tci
+        .sweep1site(&f, true, f64::NAN, 0.0, 1, false)
+        .unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+
+    let error = tci.make_canonical(&f, 0.0, -1.0, 1).unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+
+    let error = tci.make_canonical(&f, 0.0, 0.0, 0).unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+}
+
+#[test]
+fn test_optimize_with_finder_rejects_invalid_options_before_callback() {
+    let mut tci = TensorCI2::<f64>::new(vec![2, 2]).unwrap();
+    tci.add_global_pivots(&[vec![0, 0]]).unwrap();
+    let calls = Cell::new(0);
+    let error = optimize_with_finder::<f64, _, fn(&[MultiIndex]) -> Vec<f64>, _>(
+        tci,
+        |_| {
+            calls.set(calls.get() + 1);
+            1.0
+        },
+        None,
+        TCI2Options {
+            tolerance: f64::INFINITY,
+            ..TCI2Options::default()
+        },
+        DefaultGlobalPivotFinder::new(0, 0, 10.0),
+    )
+    .unwrap_err();
+    assert!(matches!(error, TCIError::InvalidConfiguration { .. }));
+    assert_eq!(calls.get(), 0);
+}
+
+#[test]
 fn test_sweep1site_preserves_accuracy() {
     // Build a TCI2 for f(i,j,k) = (i+1)*(j+1)*(k+1)
     let f = |idx: &MultiIndex| ((idx[0] + 1) * (idx[1] + 1) * (idx[2] + 1)) as f64;

--- a/crates/tensor4all-treetci/src/api.rs
+++ b/crates/tensor4all-treetci/src/api.rs
@@ -78,8 +78,9 @@ pub type TreeTciRunResult = (
 #[allow(clippy::too_many_arguments)]
 /// # Errors
 ///
-/// Returns an error when the operation fails (a shape or index mismatch, or
-/// /// a backend failure).
+/// Returns [`TreeTciError::InvalidConfiguration`] for invalid options. It
+/// also returns an error when the operation fails (a shape or index mismatch,
+/// or a backend failure).
 ///
 pub fn crossinterpolate2<T, F, P>(
     evaluate: F,
@@ -99,6 +100,7 @@ where
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
+    options.validate()?;
     if !(local_dims.len() == graph.n_sites()) {
         return Err(anyhow::anyhow!(
             "local_dims length {} must match graph site count {}",

--- a/crates/tensor4all-treetci/src/error.rs
+++ b/crates/tensor4all-treetci/src/error.rs
@@ -16,6 +16,12 @@ pub type Result<T> = std::result::Result<T, TreeTciError>;
 /// - Backend failures: the wrapped source chain identifies the failing stage.
 #[derive(Debug, Error)]
 pub enum TreeTciError {
+    /// Invalid optimization configuration.
+    #[error("invalid tree-TCI configuration: {message}")]
+    InvalidConfiguration {
+        /// Description of the invalid option value.
+        message: String,
+    },
     /// The tree graph is invalid (disconnected, missing vertices, or
     /// inconsistent edge structure).
     #[error("invalid tree-TCI graph: {message}")]

--- a/crates/tensor4all-treetci/src/optimize.rs
+++ b/crates/tensor4all-treetci/src/optimize.rs
@@ -128,6 +128,32 @@ pub struct TreeTciOptions {
     pub seed: Option<u64>,
 }
 
+impl TreeTciOptions {
+    pub(crate) fn validate(&self) -> TreeTciResult<()> {
+        if !self.tolerance.is_finite() || self.tolerance < 0.0 {
+            return Err(crate::TreeTciError::InvalidConfiguration {
+                message: "tolerance must be finite and nonnegative".to_string(),
+            });
+        }
+        if self.max_iter == 0 {
+            return Err(crate::TreeTciError::InvalidConfiguration {
+                message: "max_iter must be positive".to_string(),
+            });
+        }
+        if self.max_bond_dim == Some(0) {
+            return Err(crate::TreeTciError::InvalidConfiguration {
+                message: "max_bond_dim must be positive when specified".to_string(),
+            });
+        }
+        if !self.tol_margin_global_search.is_finite() || self.tol_margin_global_search < 0.0 {
+            return Err(crate::TreeTciError::InvalidConfiguration {
+                message: "tol_margin_global_search must be finite and nonnegative".to_string(),
+            });
+        }
+        Ok(())
+    }
+}
+
 impl Default for TreeTciOptions {
     fn default() -> Self {
         Self {
@@ -154,8 +180,9 @@ impl Default for TreeTciOptions {
 ///
 /// # Errors
 ///
-/// Returns an error when the operation fails (a shape or index mismatch, or
-/// /// a backend failure).
+/// Returns [`TreeTciError::InvalidConfiguration`] for invalid options. It
+/// also returns an error when the operation fails (a shape or index mismatch,
+/// or a backend failure).
 ///
 /// # Examples
 ///
@@ -200,6 +227,7 @@ where
     T: Scalar + CommonScalar + FullPivLuScalar + tensor4all_core::TensorElement + ScalarParts,
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
 {
+    options.validate()?;
     optimize_with_proposer(state, evaluate, options, &crate::DefaultProposer)
 }
 
@@ -213,8 +241,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns an error when the operation fails (a shape or index mismatch, or
-/// /// a backend failure).
+/// Returns [`TreeTciError::InvalidConfiguration`] for invalid options. It
+/// also returns an error when the operation fails (a shape or index mismatch,
+/// or a backend failure).
 ///
 /// # Examples
 ///
@@ -262,18 +291,7 @@ where
     F: Fn(GlobalIndexBatch<'_>) -> Result<Vec<T>>,
     P: PivotCandidateProposer,
 {
-    if !(options.max_iter > 0) {
-        return Err(anyhow::anyhow!("TreeTCI optimization requires max_iter > 0").into());
-    };
-    if options.max_bond_dim == Some(0) {
-        return Err(anyhow::anyhow!("TreeTCI optimization requires max_bond_dim > 0").into());
-    };
-    if !options.tol_margin_global_search.is_finite() || options.tol_margin_global_search < 0.0 {
-        return Err(anyhow::anyhow!(
-            "TreeTCI optimization requires a finite nonnegative tol_margin_global_search"
-        )
-        .into());
-    };
+    options.validate()?;
 
     let mut ranks = Vec::new();
     let mut errors = Vec::new();

--- a/crates/tensor4all-treetci/src/optimize/tests.rs
+++ b/crates/tensor4all-treetci/src/optimize/tests.rs
@@ -8,6 +8,95 @@ fn two_site_graph() -> TreeTciGraph {
 }
 
 #[test]
+fn optimize_rejects_invalid_options_before_callback() {
+    let invalid_tolerances = [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY];
+    for tolerance in invalid_tolerances {
+        let mut tci = TreeTCI2::<f64>::new(vec![2, 2], two_site_graph()).unwrap();
+        tci.add_global_pivots(&[vec![0, 0]]).unwrap();
+        let calls = std::cell::Cell::new(0);
+        let options = TreeTciOptions {
+            tolerance,
+            ..TreeTciOptions::default()
+        };
+        let error = optimize_default(
+            &mut tci,
+            |_| {
+                calls.set(calls.get() + 1);
+                Ok(vec![1.0])
+            },
+            &options,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            crate::TreeTciError::InvalidConfiguration { .. }
+        ));
+        assert_eq!(calls.get(), 0);
+    }
+
+    for options in [
+        TreeTciOptions {
+            max_iter: 0,
+            ..TreeTciOptions::default()
+        },
+        TreeTciOptions {
+            max_bond_dim: Some(0),
+            ..TreeTciOptions::default()
+        },
+        TreeTciOptions {
+            tol_margin_global_search: -1.0,
+            ..TreeTciOptions::default()
+        },
+        TreeTciOptions {
+            tol_margin_global_search: f64::NAN,
+            ..TreeTciOptions::default()
+        },
+        TreeTciOptions {
+            tol_margin_global_search: f64::INFINITY,
+            ..TreeTciOptions::default()
+        },
+        TreeTciOptions {
+            tol_margin_global_search: f64::NEG_INFINITY,
+            ..TreeTciOptions::default()
+        },
+    ] {
+        let mut tci = TreeTCI2::<f64>::new(vec![2, 2], two_site_graph()).unwrap();
+        tci.add_global_pivots(&[vec![0, 0]]).unwrap();
+        let error = optimize_default(&mut tci, |_| Ok(vec![1.0]), &options).unwrap_err();
+        assert!(matches!(
+            error,
+            crate::TreeTciError::InvalidConfiguration { .. }
+        ));
+    }
+}
+
+#[test]
+fn api_crossinterpolate2_rejects_invalid_options_before_callback() {
+    let calls = std::cell::Cell::new(0);
+    let error = crate::crossinterpolate2::<f64, _, _>(
+        |_| {
+            calls.set(calls.get() + 1);
+            Ok(vec![1.0])
+        },
+        vec![2, 2],
+        two_site_graph(),
+        vec![vec![0, 0]],
+        TreeTciOptions {
+            tolerance: f64::NAN,
+            ..TreeTciOptions::default()
+        },
+        None,
+        &crate::DefaultProposer,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        crate::TreeTciError::InvalidConfiguration { .. }
+    ));
+    assert_eq!(calls.get(), 0);
+}
+
+#[test]
 fn optimize_default_converges_on_two_site_identity() {
     let mut tci = TreeTCI2::<f64>::new(vec![2, 2], two_site_graph()).unwrap();
     tci.add_global_pivots(&[vec![0, 0]]).unwrap();

--- a/docs/CAPI_DESIGN.md
+++ b/docs/CAPI_DESIGN.md
@@ -90,7 +90,10 @@ size_t needed = 0;
 t4a_last_error_message(NULL, 0, &needed);
 ```
 
-followed by a second call with a sufficiently large UTF-8 buffer.
+followed by a second call with a sufficiently large UTF-8 buffer. If a
+retrieval buffer is undersized, `t4a_last_error_message` reports the required
+length without replacing the stored diagnostic, so the caller can retry and
+recover the original message.
 
 ### Panic Safety
 
@@ -205,7 +208,8 @@ cbindgen crates/tensor4all-capi \
 ```
 
 Regenerate the header whenever exported types, enums, constants, or function
-signatures change.
+signatures change. Run `./scripts/check-capi-header.sh` to verify the pinned
+cbindgen version, header freshness, and C/C++ compilability.
 
 ## Module Reference
 

--- a/docs/worklogs/2026-08-16-audit-mechanical-fixes.md
+++ b/docs/worklogs/2026-08-16-audit-mechanical-fixes.md
@@ -1,0 +1,173 @@
+# Audit mechanical fixes: issues #632, #635, and #636
+
+## Session summary
+
+Implement the mechanically specified audit fixes in one batch:
+
+- #632: remove test-only state from the exported `t4a_tensor` ABI and mechanically verify the generated C header.
+- #636: preserve the original thread-local diagnostic when `t4a_last_error_message` reports an undersized retrieval buffer.
+- #635: validate numerical options before callbacks, allocation, no-op returns, or backend calls in TensorCI1, TensorCI2, TreeTCI, and the quantics Fourier constructor.
+
+Initial base: `origin/main` at `c9ecb7f0d4eec4bbf6db51dc7648a4b2d84b4f34`.
+Synchronized pre-PR base: `origin/main` at `39b1884b05133d1c4f195e296df238bc2b59b04d`.
+
+## Code and documents read
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, shared common/Rust/numerical rules
+- `docs/CAPI_DESIGN.md`
+- `.github/workflows/CI_rs.yml`
+- `crates/tensor4all-capi/{src/lib.rs,src/types.rs,src/tests/mod.rs,src/tensor/tests/mod.rs,cbindgen.toml,include/tensor4all_capi.h}`
+- `crates/tensor4all-tensorci/{src/error.rs,src/tensorci1.rs,src/tensorci2.rs}` and tests
+- `crates/tensor4all-treetci/{src/error.rs,src/optimize.rs}` and tests
+- `crates/tensor4all-quanticstransform/{src/error.rs,src/fourier.rs}` and tests
+- CodeGraph caller/blast-radius reports for the edited public entries
+
+## Design
+
+### #632: keep test injection behind the opaque pointer
+
+Keep `t4a_tensor` as a one-field opaque C wrapper in every build. Introduce a private Rust heap payload containing `InternalTensor` and, only under `cfg(test)`, the injected `TensorStorageError`. `_private` points to that private payload. `new`, `inner`, `Clone`, `Drop`, and test injection access the payload; no test-only field appears on the exported `#[repr(C)]` struct.
+
+Add `scripts/check-capi-header.sh` that:
+
+1. requires cbindgen 0.29.2 and asserts the generated `Generated with cbindgen:` version line;
+2. regenerates the header to a temporary file;
+3. diffs it against the committed header;
+4. compiles a minimal include-only source as C11 and C++.
+
+Run it in the maintenance-scripts CI job after `cargo install cbindgen --version 0.29.2 --locked`. Regenerate the committed header.
+
+Rejected alternative: a test-only global/thread-local side table keyed by pointer. It adds lifecycle and cross-thread bookkeeping solely for tests; a private heap payload is smaller and keeps ownership local.
+
+### #636: retrieval must not mutate the diagnostic
+
+On an undersized `t4a_last_error_message` buffer, write the required length and return `T4A_BUFFER_TOO_SMALL` directly. Do not call the generic helper that replaces `LAST_ERROR`. Update the regression to retry with the reported size and assert byte-for-byte recovery of the original message. Clarify this preservation guarantee in both the function rustdoc (and therefore the generated C header) and `docs/CAPI_DESIGN.md`.
+
+### #635: one mandatory validation seam per options type
+
+Use crate-local typed configuration errors and small validation helpers:
+
+- `TCI1Options`: finite nonnegative `tolerance` and `pivot_tolerance`; positive `max_iter`. Represent failures as a new `TCIError::InvalidConfiguration` variant.
+- `TCI2Options`: finite nonnegative `tolerance` and `tol_margin_global_search`; positive `max_iter`, `ncheck_history`, and optional `max_bond_dim`. Keep `nsearch == 0` and `max_nglobal_pivot == 0` valid: existing public doctests use both to disable global search while still converging, so validation must preserve that contract. Represent failures as `TCIError::InvalidConfiguration`.
+- `TreeTciOptions`: finite nonnegative `tolerance` in addition to existing checks; retain existing validation for iteration, bond dimension, and global-search margin. Represent failures as `TreeTciError::InvalidConfiguration` rather than an untyped operation error.
+- `FourierOptions`: `sign` exactly `-1.0` or `1.0`, finite nonnegative `tolerance`, positive optional `max_bond_dim`, and positive `k`. Reuse `QuanticsTransformError::InvalidConfiguration`.
+
+Call validation at every direct public entry before callbacks or allocation. Direct lower-level public optimization entry points and convenience constructors both validate, even when one normally delegates to the other. Validate the equivalent raw public parameters at `TensorCI1::add_pivot`, `TensorCI1::add_global_pivot`, `TensorCI2::sweep1site`, and `TensorCI2::make_canonical`: tolerances must be finite and nonnegative, and TensorCI2 raw entries require a positive bond dimension. `make_canonical` validates before its first delegated half-sweep so invalid input cannot invoke callbacks before the later parameterized sweep.
+
+Tests use compact invalid-value tables covering negative, NaN, positive/negative infinity, and zero where prohibited. Add direct-entry regressions for `optimize_with_finder`, `integrate`, and TreeTCI `crossinterpolate2`, plus callback-before-validation checks for the raw-parameter entries. Pin zero tolerance as accepted for the TensorCI1 raw entries, and update every raw entry's `# Errors` documentation for `InvalidConfiguration`. Existing valid defaults and successful numerical paths remain unchanged. No tolerance is relaxed.
+
+## Non-goals
+
+- #633 inert options/input contract choices
+- #634 PartitionedTT API redesign
+- #637 generated Rust API inventory policy
+- broad checked-arithmetic backlog #544
+- unrelated C API output-slot semantics
+- backward-compatibility shims; this repository is early-development
+
+## Verification plan
+
+Focused first:
+
+```bash
+cargo fmt --all -- --check
+./scripts/check-capi-header.sh
+cargo nextest run --release -p tensor4all-capi
+cargo nextest run --release -p tensor4all-tensorci
+cargo nextest run --release -p tensor4all-treetci
+cargo nextest run --release -p tensor4all-quanticstransform
+cargo test --doc --release -p tensor4all-capi -p tensor4all-tensorci -p tensor4all-treetci -p tensor4all-quanticstransform
+```
+
+Pre-PR gates:
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo nextest run --release --workspace
+cargo test --doc --release --workspace
+./scripts/test-mdbook.sh
+cargo doc --workspace --no-deps
+cargo llvm-cov --release --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run
+python3 scripts/test-repository-rules-review.py
+python3 scripts/test-audit-library-panics.py
+python3 scripts/audit-library-panics.py
+python3 scripts/test-check-public-error-docs.py
+python3 scripts/check-public-error-docs.py
+python3 scripts/test-check-crate-boundaries.py
+python3 scripts/check-crate-boundaries.py
+```
+
+Run every gate locally before creating the PR; focused tests do not substitute for coverage, docs, lint, or maintenance-script gates. Before merge, fetch `origin`, synchronize with current `origin/main`, rerun/monitor CI, and record reviewer-flash plus final reviewer-gpt verdicts.
+
+## Remaining risks
+
+- cbindgen output can vary across versions; pin 0.29.2 in CI and verify the version in the script.
+- Validation may expose previously accepted invalid configurations; this is intentional under early-development policy.
+- The full workspace test matrix and coverage job may reveal feature/path interactions not exercised by focused tests.
+
+## #635 implementation and verification record
+
+Implemented the reviewed validation seam without touching the pre-existing #632/#636 C API, header, CI, or maintenance-script changes:
+
+- Added typed `TCIError::InvalidConfiguration` validation for TCI1/TCI2 options, including direct sweep, optimizer, and integration entry points.
+- Added typed `TreeTciError::InvalidConfiguration` validation at both TreeTCI optimization entry points and the convenience constructor path.
+- Added Fourier option validation using `QuanticsTransformError::InvalidConfiguration` at the public operator, `FTCore::new`, and private MPO construction paths.
+- Preserved zero tolerance, `nsearch == 0`, and `max_nglobal_pivot == 0` as valid configurations.
+- Added compact NaN/infinity/negative/zero regression tests and callback-before-validation checks; updated public `# Errors` documentation.
+
+Verification performed:
+
+```text
+RED: cargo test --release -p tensor4all-tensorci --lib test_tci2_rejects_invalid_options_before_callback
+     failed to compile because InvalidConfiguration was not yet implemented.
+PASS: cargo fmt --all
+PASS: cargo fmt --all -- --check
+PASS: cargo nextest run --release -p tensor4all-tensorci (75 tests)
+PASS: cargo nextest run --release -p tensor4all-treetci (57 tests)
+PASS: cargo nextest run --release -p tensor4all-quanticstransform (170 tests)
+PASS: cargo test --doc --release -p tensor4all-capi -p tensor4all-tensorci -p tensor4all-treetci -p tensor4all-quanticstransform (111 doctests)
+PASS: python3 scripts/check-public-error-docs.py
+PASS: git diff --check
+```
+
+Scope review: production/test changes are limited to `tensor4all-tensorci`, `tensor4all-treetci`, `tensor4all-quanticstransform`, and this appended worklog record; the existing #632/#636 files remain unchanged by #635.
+
+## Review-gate record
+
+- Pre-implementation design review for #632/#636: `reviewer-flash`, verdict **Correct-to-merge** before production edits.
+- Post-implementation review for #632/#636: `reviewer-flash`, verdict **Correct-to-merge**.
+- Pre-implementation design review for #635: `reviewer-flash`, verdict **Correct-to-merge** before production edits.
+- Post-implementation review for the main #635 diff: `reviewer-flash`, verdict **Correct-to-merge**.
+- Pre-implementation design review for the #635 raw-parameter/direct-entry addendum: `reviewer-gpt`, verdict **Correct-to-merge** before addendum edits.
+- Post-implementation re-review for that addendum: `reviewer-flash`, verdict **Correct-to-merge**, with no Critical or Important findings.
+- Final full-diff frontier confirmation: `reviewer-gpt` found one Important Fourier public error-contract mismatch; it was fixed with a typed `InvalidConfiguration` return and variant assertions, all local gates were rerun, and `reviewer-gpt` re-reviewed the complete staged diff with verdict **Correct-to-merge**.
+
+## Synchronized pre-PR verification
+
+After synchronizing the branch to `origin/main` at `39b1884b05133d1c4f195e296df238bc2b59b04d`, all required local gates passed:
+
+```text
+PASS: cargo fmt --all
+PASS: cargo fmt --all -- --check
+PASS: ./scripts/check-capi-header.sh (fresh cbindgen 0.29.2 header; C11 and C++ include compile)
+PASS: cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+PASS: cargo nextest run --release --workspace (2815 passed, 14 skipped)
+PASS: cargo test --doc --release --workspace (867 passed)
+PASS: ./scripts/test-mdbook.sh (26 chapters)
+PASS: cargo doc --workspace --no-deps
+PASS: cargo llvm-cov --release --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json
+PASS: python3 scripts/check-coverage.py coverage.json (215/215 files)
+PASS: python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run
+PASS: python3 scripts/test-repository-rules-review.py (90 tests)
+PASS: python3 scripts/test-audit-library-panics.py (11 tests)
+PASS: python3 scripts/audit-library-panics.py (0 unbaselined findings; 0 stale entries)
+PASS: python3 scripts/test-check-public-error-docs.py (15 tests)
+PASS: python3 scripts/check-public-error-docs.py
+PASS: python3 scripts/test-check-crate-boundaries.py (13 tests)
+PASS: python3 scripts/check-crate-boundaries.py
+PASS: git diff --check
+```

--- a/scripts/check-capi-header.sh
+++ b/scripts/check-capi-header.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+expected_version="cbindgen 0.29.2"
+actual_version=$(cbindgen --version)
+if [[ "$actual_version" != "$expected_version" ]]; then
+    echo "expected $expected_version, found $actual_version" >&2
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+generated="$tmp/tensor4all_capi.h"
+committed="$root/crates/tensor4all-capi/include/tensor4all_capi.h"
+
+cbindgen "$root/crates/tensor4all-capi" \
+    --config "$root/crates/tensor4all-capi/cbindgen.toml" \
+    --output "$generated"
+
+grep -Fq 'Generated with cbindgen:0.29.2' "$generated"
+diff -u "$committed" "$generated"
+
+cat >"$tmp/header.c" <<'EOF'
+#include "crates/tensor4all-capi/include/tensor4all_capi.h"
+int main(void) { return 0; }
+EOF
+cat >"$tmp/header.cpp" <<'EOF'
+#include "crates/tensor4all-capi/include/tensor4all_capi.h"
+int main() { return 0; }
+EOF
+
+"${CC:-cc}" -std=c11 -Wall -Wextra -Werror -I"$root" -fsyntax-only "$tmp/header.c"
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror -I"$root" -fsyntax-only "$tmp/header.cpp"


### PR DESCRIPTION
## Summary

- keep `t4a_tensor` permanently one-pointer/opaque by moving test injection state into its private heap payload
- preserve the original C API diagnostic when `t4a_last_error_message` reports an undersized buffer, allowing a lossless retry
- validate TensorCI1, TensorCI2, TreeTCI, and Fourier numerical options before callbacks, allocation, no-op paths, or backend work
- add a pinned cbindgen 0.29.2 header freshness and C11/C++ compilation gate

Closes #632.
Closes #635.
Closes #636.

## Validation behavior

- tolerances must be finite and nonnegative
- iteration/history limits and specified bond dimensions must be positive
- Fourier `sign` must be exactly `-1.0` or `1.0`, and `k` must be positive
- zero tolerance remains valid
- `nsearch == 0` and `max_nglobal_pivot == 0` remain valid documented ways to disable global search
- invalid configurations return typed configuration errors before user callbacks run

## Local verification

Run after synchronizing with `origin/main` (`39b1884b05133d1c4f195e296df238bc2b59b04d`):

- `cargo fmt --all -- --check`
- `./scripts/check-capi-header.sh`
- strict workspace/all-target clippy with missing error/panic docs denied
- `cargo nextest run --release --workspace` — 2815 passed, 14 skipped
- `cargo test --doc --release --workspace` — 867 passed
- `./scripts/test-mdbook.sh` — 26 chapters
- `cargo doc --workspace --no-deps`
- `cargo llvm-cov --release --workspace --exclude tensor4all-hdf5 --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` — 215/215 files passed
- repository-rules review and its 90-test suite
- panic audit and its 11-test suite — no unbaselined findings or stale entries
- public-error-doc audit and its 15-test suite
- crate-boundary audit and its 13-test suite
- `git diff --check`

## Review gates

The design and each implementation slice received recorded pre/post implementation reviews. The final full staged diff was reviewed by `reviewer-gpt`; its one Important Fourier error-contract finding was fixed, all local gates were rerun, and the re-review verdict was **Correct-to-merge**. Details are recorded in `docs/worklogs/2026-08-16-audit-mechanical-fixes.md`.
