### PR TITLE
Fix five small bugs from issue reports (#622 #629 #638 #630 #615)

### DIFF
--- a/crates/tensor4all-aci/src/global_guard/tests.rs
+++ b/crates/tensor4all-aci/src/global_guard/tests.rs
@@ -56,6 +56,22 @@ fn run_case(seed: u64, guard: bool, nsearch: usize) -> SimpleTensorTrain<f64> {
         .tensor_train
 }
 
+/// Same as [`run_case`] but deliberately does NOT override
+/// `nsearch_global_pivots`, so the run exercises whatever the default is.
+/// Changing the default (and breaking recovery at that value) fails this test.
+fn run_case_default_nsearch(seed: u64, guard: bool) -> SimpleTensorTrain<f64> {
+    let input = two_peak_tt(10);
+    let options = AciOptions {
+        rng_seed: seed,
+        enable_global_guard: guard,
+        tolerance: 1e-4,
+        ..AciOptions::default()
+    };
+    elementwise(|xs: &[f64]| xs[0], &[input], &options)
+        .unwrap()
+        .tensor_train
+}
+
 #[test]
 fn global_guard_recovers_missed_near_degenerate_feature() {
     // The two near-degenerate peaks are far apart, so the local sweeps can
@@ -64,8 +80,11 @@ fn global_guard_recovers_missed_near_degenerate_feature() {
     // global pivot search guard finds the missed point, injects it, and the
     // guard-on run captures both peaks.
     let fb = 2.0;
+    // The guard-on arm runs at the DEFAULT search budget (nsearch is not
+    // overridden): a default caller receives `nsearch_global_pivots = 5`, so
+    // the recovery guarantee must hold there, not only at the hand-picked 30.
     let off = run_case(0, false, 5);
-    let on = run_case(0, true, 30);
+    let on = run_case_default_nsearch(0, true);
 
     let err_off = (off.evaluate(&[3; 10]).unwrap() - fb).abs();
     let err_on = (on.evaluate(&[3; 10]).unwrap() - fb).abs();

--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -262,6 +262,10 @@ fn factorize_svd_with_options(
     let bond_index = result.bond_index;
     let singular_values = result.singular_values;
     let rank = result.rank;
+    // Internal SVD plumbing: svd_for_factorize keeps the legacy convention
+    // (vh shares the original `bond` leg), so S's leftover `sim` leg is
+    // renamed back to `bond` after each contraction. The public svd_with API
+    // instead returns V with the `sim` leg and needs no compensation.
     let sim_bond_index = s.indices[1].clone();
 
     match canonical {

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -390,10 +390,15 @@ pub fn svd_with<T>(
     })?;
     let u = IdxTensor::from_inner(u_indices, u_reshaped).map_err(SvdError::ComputationError)?;
 
-    let s_indices = vec![bond_index.clone(), bond_index.sim()];
+    // S carries a fresh `sim` leg (ITensors convention S: [l, l'], V: l');
+    // the SAME sim instance is shared with V^H so the returned triple
+    // reconstructs under plain contraction:
+    // U [left..., bond] · S [bond, sim] · V^H [sim, right...].
+    let sim_bond_index = bond_index.sim();
+    let s_indices = vec![bond_index.clone(), sim_bond_index.clone()];
     let s = IdxTensor::from_diag_inner(s_indices, s_inner).map_err(SvdError::ComputationError)?;
 
-    let mut vh_indices = vec![bond_index.clone()];
+    let mut vh_indices = vec![sim_bond_index];
     vh_indices.extend(right_indices);
     let vh_dims: Vec<usize> = vh_indices.iter().map(|idx| idx.dim).collect();
     let vt_reshaped = vt_inner.reshape(&vh_dims).map_err(|e| {

--- a/crates/tensor4all-core/src/index_ops.rs
+++ b/crates/tensor4all-core/src/index_ops.rs
@@ -539,15 +539,24 @@ fn common_ind_positions_linear<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -
 fn common_ind_positions_hashed<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> AxisPairVec {
     use std::collections::HashMap;
 
-    let mut positions_by_id: HashMap<&I::Id, SmallVec<[usize; 2]>> =
+    // Bucket indices_b by their FULL value and probe each `idx_a` under the
+    // key `conj(idx_a)`: the linear scan accepts exactly `b == conj(a)`
+    // (undirected: conj is the identity; directed: is_contractable requires
+    // `conj(a) == b`, even when conj changes the id). Keying by Id, or by
+    // bare value with a same-value probe, would silently drop directed pairs
+    // whose conj partner carries a different id (#615).
+    let mut positions_by_value: HashMap<I, SmallVec<[usize; 2]>> =
         HashMap::with_capacity(indices_b.len());
     for (pos_b, idx_b) in indices_b.iter().enumerate() {
-        positions_by_id.entry(idx_b.id()).or_default().push(pos_b);
+        positions_by_value
+            .entry(idx_b.clone())
+            .or_default()
+            .push(pos_b);
     }
 
     let mut positions = AxisPairVec::new();
     for (pos_a, idx_a) in indices_a.iter().enumerate() {
-        let Some(candidate_positions) = positions_by_id.get(idx_a.id()) else {
+        let Some(candidate_positions) = positions_by_value.get(&idx_a.conj()) else {
             continue;
         };
         for &pos_b in candidate_positions {
@@ -811,8 +820,139 @@ fn build_contraction_result_indices<I: IndexLike>(
 
 #[cfg(test)]
 mod tests {
+    use super::{common_ind_positions, common_ind_positions_hashed, common_ind_positions_linear};
     use super::{prepare_contraction, prepare_contraction_pairs};
     use crate::index::DefaultIndex as Index;
+    use crate::{ConjState, IndexLike};
+
+    /// Directed test index whose `conj()` toggles Ket <-> Bra AND remaps the
+    /// id (Ket(id) <-> Bra(id + 1000)). This is the case where id-keyed
+    /// contraction pairing silently drops contractable pairs (#615).
+    #[derive(Clone, PartialEq, Eq, Hash, Debug)]
+    struct DirectedIdIndex {
+        id: u64,
+        dim: usize,
+        state: ConjState,
+    }
+
+    impl DirectedIdIndex {
+        fn new(id: u64, dim: usize, state: ConjState) -> Self {
+            Self { id, dim, state }
+        }
+    }
+
+    impl IndexLike for DirectedIdIndex {
+        type Id = u64;
+
+        fn id(&self) -> &u64 {
+            &self.id
+        }
+
+        fn dim(&self) -> usize {
+            self.dim
+        }
+
+        fn conj_state(&self) -> ConjState {
+            self.state
+        }
+
+        fn conj(&self) -> Self {
+            let state = match self.state {
+                ConjState::Undirected => ConjState::Undirected,
+                ConjState::Ket => ConjState::Bra,
+                ConjState::Bra => ConjState::Ket,
+            };
+            let id = match (self.state, state) {
+                (ConjState::Ket, ConjState::Bra) => self.id + 1000,
+                (ConjState::Bra, ConjState::Ket) => self.id - 1000,
+                _ => self.id,
+            };
+            Self {
+                id,
+                dim: self.dim,
+                state,
+            }
+        }
+
+        fn sim(&self) -> Self {
+            Self {
+                id: self.id + 10000,
+                ..self.clone()
+            }
+        }
+
+        fn create_dummy_link_pair() -> (Self, Self) {
+            (
+                Self::new(0, 1, ConjState::Undirected),
+                Self::new(0, 1, ConjState::Undirected),
+            )
+        }
+
+        fn product_link(indices: &[Self]) -> anyhow::Result<Self> {
+            anyhow::ensure!(
+                !indices.is_empty(),
+                "product_link requires at least one index"
+            );
+            let dim = indices.iter().try_fold(1usize, |acc, idx| {
+                acc.checked_mul(idx.dim)
+                    .ok_or_else(|| anyhow::anyhow!("product link dimension overflow"))
+            })?;
+            Ok(Self::new(9999, dim, ConjState::Undirected))
+        }
+    }
+
+    #[test]
+    fn hashed_and_linear_agree_on_directed_conj_id_change() {
+        // a: Ket ids 0,1,2; b: Bra partners 1000,1002 plus an unrelated Ket.
+        // Only (0,0) and (2,2) are contractable; the id-keyed hashed path
+        // would drop both because no b shares a's id.
+        let a = vec![
+            DirectedIdIndex::new(0, 2, ConjState::Ket),
+            DirectedIdIndex::new(1, 2, ConjState::Ket),
+            DirectedIdIndex::new(2, 2, ConjState::Ket),
+        ];
+        let b = vec![
+            DirectedIdIndex::new(1000, 2, ConjState::Bra),
+            DirectedIdIndex::new(5, 2, ConjState::Ket),
+            DirectedIdIndex::new(1002, 2, ConjState::Bra),
+        ];
+
+        let linear = common_ind_positions_linear(&a, &b);
+        assert_eq!(linear.as_slice(), &[(0, 0), (2, 2)]);
+        let hashed = common_ind_positions_hashed(&a, &b);
+        assert_eq!(hashed, linear);
+    }
+
+    #[test]
+    fn hashed_and_linear_agree_on_same_id_different_metadata() {
+        // Same id, different prime level: not contractable; both paths must
+        // reject the pair rather than pairing on id alone.
+        let i = Index::new_dyn(2);
+        let i_prime = i.prime();
+        let j = Index::new_dyn(2);
+
+        let a = vec![i.clone(), j.clone()];
+        let b = vec![i_prime.clone(), j.clone()];
+        let linear = common_ind_positions_linear(&a, &b);
+        let hashed = common_ind_positions_hashed(&a, &b);
+        assert_eq!(linear.as_slice(), &[(1, 1)]);
+        assert_eq!(hashed, linear);
+    }
+
+    #[test]
+    fn common_ind_positions_dispatch_hash_path_matches_linear_reference() {
+        // scan_work = 9*9 = 81 > LINEAR_CONTRACTION_SCAN_LIMIT (64) so the
+        // public entry point dispatches to the hashed path.
+        let lhs: Vec<_> = (0..9).map(|_| Index::new_dyn(2)).collect();
+        let shared = lhs[7].clone();
+        let mut rhs: Vec<_> = (0..9).map(|_| Index::new_dyn(2)).collect();
+        rhs[5] = shared.clone();
+
+        let dispatched = common_ind_positions(&lhs, &rhs);
+        let reference = common_ind_positions_linear(&lhs, &rhs).into_vec();
+        assert_eq!(dispatched, vec![(7, 5)]);
+        assert_eq!(dispatched, reference);
+    }
 
     #[test]
     fn prepare_contraction_pairs_selects_exact_same_id_prime_index() {

--- a/crates/tensor4all-core/tests/linalg_svd.rs
+++ b/crates/tensor4all-core/tests/linalg_svd.rs
@@ -27,11 +27,10 @@ fn vh_from_v(v: &IdxTensor) -> IdxTensor {
 }
 
 fn reconstruct_from_svd(u: &IdxTensor, s: &IdxTensor, v: &IdxTensor) -> IdxTensor {
+    // Plain U·S·V^H: S shares `bond` with U and `sim` with V, so no
+    // reindexing is needed (regression for #629).
     let vh = vh_from_v(v);
     let svh = s.contract_pair(&vh).unwrap();
-    let sim_bond = s.indices[1].clone();
-    let bond = v.indices[v.indices.len() - 1].clone();
-    let svh = svh.replaceind(&sim_bond, &bond).unwrap();
     u.contract_pair(&svh).unwrap()
 }
 
@@ -87,12 +86,13 @@ fn test_svd_simple_matrix() {
     assert_eq!(s.indices.len(), 2);
     assert_eq!(v.indices.len(), 2);
 
-    // Check that U and V share the bond index
+    // Check that U and V share the bond index with S
     assert_eq!(u.indices[1].id, s.indices[0].id);
     // S tensor has two indices with same dimension and tags but different IDs (to avoid duplicate IDs)
     assert_eq!(s.indices[0].size(), s.indices[1].size());
     assert_eq!(s.indices[0].tags(), s.indices[1].tags());
-    assert_eq!(s.indices[0].id, v.indices[1].id);
+    // V carries S's `sim` leg, so S and V share the second bond index
+    assert_eq!(s.indices[1].id, v.indices[1].id);
 
     // Check that bond index has "Link" tag
     assert!(u.indices[1].tags().has_tag("Link"));
@@ -195,12 +195,13 @@ fn test_svd_rank3() {
     assert_eq!(v.indices[0].id, j.id);
     assert_eq!(v.indices[1].id, k.id);
 
-    // Check that U and V share the bond index
+    // Check that U and S share the bond index
     assert_eq!(u.indices[1].id, s.indices[0].id);
     // S tensor has two indices with same dimension and tags but different IDs (to avoid duplicate IDs)
     assert_eq!(s.indices[0].size(), s.indices[1].size());
     assert_eq!(s.indices[0].tags(), s.indices[1].tags());
-    assert_eq!(s.indices[0].id, v.indices[2].id);
+    // V carries S's `sim` leg, so S and V share the second bond index
+    assert_eq!(s.indices[1].id, v.indices[2].id);
 
     // Check that bond index has "Link" tag
     assert!(u.indices[1].tags().has_tag("Link"));

--- a/crates/tensor4all-simplett/src/mpo/contraction.rs
+++ b/crates/tensor4all-simplett/src/mpo/contraction.rs
@@ -152,6 +152,28 @@ where
         self.right_cache.clear();
     }
 
+    /// Validate that caller-supplied index pairs lie within the site physical
+    /// dims before any tensor indexing: `i_k` indexes s1 of MPO A, `j_k`
+    /// indexes s2 of MPO B (the same semantics as [`MPO::evaluate`](super::mpo::MPO::evaluate)).
+    fn validate_indices(
+        &self,
+        indices: &[(usize, usize)],
+        sites: std::ops::Range<usize>,
+    ) -> Result<()> {
+        for site in sites {
+            let (i_k, j_k) = indices[site];
+            let (s1_a, _s2_a, _s1_b, s2_b) = self.site_dims[site];
+            if i_k >= s1_a || j_k >= s2_b {
+                return Err(MPOError::IndexOutOfBounds {
+                    site,
+                    index: i_k.max(j_k),
+                    max: s1_a.max(s2_b),
+                });
+            }
+        }
+        Ok(())
+    }
+
     /// Evaluate the contraction at a specific set of indices
     ///
     /// indices should be [(i1, j1), (i2, j2), ...] where:
@@ -172,6 +194,8 @@ where
         if self.is_empty() {
             return Err(MPOError::Empty);
         }
+
+        self.validate_indices(indices, 0..self.len())?;
 
         // Contract from left to right
         let first_a = self.mpo_a.site_tensor(0);
@@ -248,6 +272,13 @@ where
             return Ok(env);
         }
 
+        if indices.len() < n {
+            return Err(MPOError::InvalidOperation {
+                message: format!("Expected at least {} index pairs, got {}", n, indices.len()),
+            });
+        }
+        self.validate_indices(indices, 0..n)?;
+
         // Check cache
         let key: Vec<(usize, usize)> = indices[..n].to_vec();
         if let Some(cached) = self.left_cache.get(&key) {
@@ -303,6 +334,19 @@ where
             env[[0, 0]] = T::one();
             return Ok(env);
         }
+
+        // The recursion reads absolute positions indices[n] .. indices[len-1],
+        // so the slice must cover every site of the MPO.
+        if indices.len() < len {
+            return Err(MPOError::InvalidOperation {
+                message: format!(
+                    "Expected at least {} index pairs, got {}",
+                    len,
+                    indices.len()
+                ),
+            });
+        }
+        self.validate_indices(indices, n..len)?;
 
         // Check cache
         let key: Vec<(usize, usize)> = indices[n..].to_vec();

--- a/crates/tensor4all-simplett/src/mpo/contraction/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contraction/tests/mod.rs
@@ -229,3 +229,102 @@ fn test_contraction_constant_two_sites() {
     let val = contraction.evaluate(&[(1, 1), (1, 0)]).unwrap();
     assert!((val - 4.0).abs() < 1e-10);
 }
+
+#[test]
+fn test_contraction_evaluate_rejects_out_of_range_values() {
+    // Asymmetric physical dims: mpo_a sites are (2, 3), mpo_b sites are (3, 4)
+    // -> i_k must be < 2, j_k must be < 4.
+    let mpo_a = MPO::<f64>::constant(&[(2, 3)], 1.0);
+    let mpo_b = MPO::<f64>::constant(&[(3, 4)], 1.0);
+    let mut contraction = Contraction::new(mpo_a, mpo_b).unwrap();
+
+    // Valid pair still works.
+    assert!(contraction.evaluate(&[(1, 3)]).is_ok());
+
+    // i out of range.
+    let err = contraction.evaluate(&[(5, 0)]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            MPOError::IndexOutOfBounds {
+                site: 0,
+                index: 5,
+                max: 4
+            }
+        ),
+        "got {err:?}"
+    );
+
+    // j out of range.
+    let err = contraction.evaluate(&[(0, 9)]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            MPOError::IndexOutOfBounds {
+                site: 0,
+                index: 9,
+                max: 4
+            }
+        ),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn test_contraction_evaluate_left_rejects_short_slice() {
+    let mpo_a = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+    let mpo_b = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+    let mut contraction = Contraction::new(mpo_a, mpo_b).unwrap();
+
+    // indices[..2] on a 1-element slice used to panic.
+    let err = contraction.evaluate_left(2, &[(0, 0)]).unwrap_err();
+    assert!(
+        matches!(err, MPOError::InvalidOperation { .. }),
+        "got {err:?}"
+    );
+
+    // Out-of-range value at a covered site is also rejected.
+    let err = contraction.evaluate_left(2, &[(5, 0), (0, 0)]).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            MPOError::IndexOutOfBounds {
+                site: 0,
+                index: 5,
+                max: 2
+            }
+        ),
+        "got {err:?}"
+    );
+}
+
+#[test]
+fn test_contraction_evaluate_right_rejects_short_slice() {
+    let mpo_a = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+    let mpo_b = MPO::<f64>::constant(&[(2, 2), (2, 2)], 1.0);
+    let mut contraction = Contraction::new(mpo_a, mpo_b).unwrap();
+
+    // Right evaluation reads indices[n] .. indices[len-1]; a short slice that
+    // used to panic (len - n would under-require) must be a typed error.
+    let err = contraction.evaluate_right(1, &[(0, 0)]).unwrap_err();
+    assert!(
+        matches!(err, MPOError::InvalidOperation { .. }),
+        "got {err:?}"
+    );
+
+    // Out-of-range value at a covered site is also rejected.
+    let err = contraction
+        .evaluate_right(1, &[(0, 0), (5, 5)])
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            MPOError::IndexOutOfBounds {
+                site: 1,
+                index: 5,
+                max: 2
+            }
+        ),
+        "got {err:?}"
+    );
+}

--- a/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/tenferro_bridge/tests/mod.rs
@@ -153,6 +153,33 @@ fn dense_native_tensor_from_col_major_f32_roundtrip() {
 }
 
 #[test]
+fn diag_native_tensor_from_col_major_overflow_returns_error() {
+    // diag_len^logical_rank == 2^16^4 == 2^64 wraps to 0 in unchecked
+    // arithmetic; the checked product must surface a typed error instead of
+    // an empty allocation followed by an OOB panic.
+    let data = vec![1.0_f64; 65536];
+    let err = diag_native_tensor_from_col_major(&data, 4).unwrap_err();
+    assert!(err.to_string().contains("overflow"), "{err}");
+}
+
+#[test]
+fn dense_native_tensor_from_col_major_overflow_returns_error() {
+    // Same wrap for the dense constructor's shape product feeding the length
+    // check: dims product overflows before any allocation.
+    let data = vec![1.0_f64; 4];
+    let err = dense_native_tensor_from_col_major(&data, &[65536, 65536, 65536, 65536]).unwrap_err();
+    assert!(err.to_string().contains("overflow"), "{err}");
+}
+
+#[test]
+fn diag_native_tensor_from_col_major_zero_size_is_ok() {
+    // Zero diag length is a valid edge case (empty diagonal tensor).
+    let data: Vec<f64> = vec![];
+    let native = diag_native_tensor_from_col_major(&data, 2).unwrap();
+    assert_eq!(native.shape(), &[0, 0]);
+}
+
+#[test]
 fn diag_native_tensor_from_col_major_c32_promotes_to_c64_values() {
     let data = vec![Complex32::new(1.0, -0.5), Complex32::new(-2.0, 0.25)];
     let native = diag_native_tensor_from_col_major(&data, 2).unwrap();

--- a/crates/tensor4all-tensorbackend/src/tensor_element.rs
+++ b/crates/tensor4all-tensorbackend/src/tensor_element.rs
@@ -74,6 +74,13 @@ fn tensor_dtype_name(dtype: DType) -> &'static str {
     }
 }
 
+fn checked_product(dims: &[usize]) -> Result<usize> {
+    dims.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| anyhow::anyhow!("dimension product overflow"))
+    })
+}
+
 fn dense_diagonal_values<T: Copy + Default>(diag: &[T], logical_rank: usize) -> Result<Vec<T>> {
     ensure!(
         logical_rank >= 1,
@@ -81,7 +88,7 @@ fn dense_diagonal_values<T: Copy + Default>(diag: &[T], logical_rank: usize) -> 
     );
     let diag_len = diag.len();
     let dims = vec![diag_len; logical_rank];
-    let total_len = dims.iter().product::<usize>();
+    let total_len = checked_product(&dims)?;
     let mut dense = vec![T::default(); total_len];
     let diagonal_stride = (0..logical_rank)
         .scan(1usize, |stride, _| {
@@ -103,7 +110,7 @@ macro_rules! impl_tensor_element {
                 data: &[Self],
                 dims: &[usize],
             ) -> Result<NativeTensor> {
-                let expected_len: usize = dims.iter().product();
+                let expected_len: usize = checked_product(dims)?;
                 ensure!(
                     data.len() == expected_len,
                     "dense tensor len {} does not match dims {:?} (expected {})",

--- a/docs/design/issue-small-bugs-2026-08.md
+++ b/docs/design/issue-small-bugs-2026-08.md
@@ -1,0 +1,130 @@
+# Design: small bug fixes from bot issues (#622, #629, #638, #630, #615)
+
+Status: approved for implementation by user (2026-08, review by luna).
+Scope decision: #639 (Scalar trait move) and #616 (rename sweep) are structural
+API work, excluded. Only the five concrete bot-reported bugs are in scope.
+
+Review gate (luna, read-only):
+- Pre-implementation design review 2026-08: verdict NEEDS-FIX — one finding:
+  #638 right-side length check must be `indices.len() >= len` (the recursion
+  reads `indices[n]` .. `indices[len-1]`, so `len - n` under-requires, e.g.
+  len=3, n=1, two pairs: check passes but recursion panics). Design updated
+  accordingly (see §3). All other findings APPROVED with test additions:
+  #622 direct macro regression, #638 asymmetric dims + short right side with
+  n>0, #615 ensure the hashed path itself is exercised.
+
+## 1. #622 — tensorbackend unchecked shape product (panic on 2^64 wrap)
+
+**Bug**: `tensor_element.rs` `dense_diagonal_values` computes
+`dims.iter().product::<usize>()` unchecked; for `diag_len^logical_rank == 2^64`
+this wraps to 0, allocates an empty buffer, and the diagonal-fill loop panics.
+`dense_native_tensor_from_col_major` has the same unchecked product feeding an
+`ensure!` length check.
+
+**Fix**: add a crate-local `checked_product(dims: &[usize]) -> Result<usize>`
+(try_fold with checked_mul, same shape as
+`idx_tensor.rs::checked_product`), use it in both sites. Since the crate uses
+`anyhow`, `checked_product(...)?` composes directly.
+
+**Tests**: regression in `tensor_element.rs` tests (or the tenferro_bridge
+integration test) with `data.len() = 2^16`, `logical_rank = 4` expecting a
+typed error, plus a zero-size/empty edge case.
+
+## 2. #629 — svd bond legs do not compose (public API only)
+
+**Bug**: `svd_with` returns `U=[left..., bond]`, `S=[bond, bond.sim()]`,
+`V=[right..., bond]`; `U·S·Vᴴ` fails (`S`'s second leg `sim` never meets `V`'s
+`bond` leg).
+
+**Fix (A案, approved)**: give `vh`/`V` the `sim` leg — `vh_indices =
+vec![bond_index.sim()]` — matching the ITensors convention `S: [l, l'], V: l'`.
+Reconstruction `U·S` contracts on `bond`, then contracts with `Vᴴ` on `sim`.
+
+**Scope**: public `svd_with` only. Internal `svd_for_factorize` + `factorize.rs`
+are left untouched (they work via an internal `replaceind` compensation); add a
+one-line comment in `factorize.rs` documenting the internal sim-scaffolding
+convention.
+
+**Tests**: update `linalg_svd.rs` — flip the two `s.indices[0].id == v...id`
+assertions to `s.indices[1].id == v...id`; remove the `replaceind` step from
+the `reconstruct_from_svd` helper so the existing reconstruction tests exercise
+plain `U·S·Vᴴ`; keep all existing reconstruction tests (they become the
+no-workaround regression).
+
+## 3. #638 — simplett Contraction evaluation panics on caller indices
+
+**Bug**: `Contraction::{evaluate, evaluate_left, evaluate_right}` index into
+tensors/slices with unvalidated caller-supplied `(i_k, j_k)` pairs and slice
+lengths → Rust panic instead of `MPOError`.
+
+**Fix**: mirror the sibling `MPO::evaluate` validation:
+- private helper `validate_indices(&self, range)` checking every `(i_k, j_k)`
+  in the range against `self.site_dims[k]` (`i_k < s1_a`, `j_k < s2_b`),
+  returning `MPOError::IndexOutOfBounds { site, index, max }`;
+- `evaluate`: validate all sites 0..len;
+- `evaluate_left(n)`: add `indices.len() >= n` length check (InvalidOperation),
+  validate sites 0..n;
+- `evaluate_right(n)`: add `indices.len() >= len` length check (the recursion
+  reads `indices[n]` .. `indices[len-1]`; `len - n` would under-require,
+  per luna design review), validate sites n..len.
+
+**Tests**: in `mpo/contraction.rs` tests — out-of-range pair values for both i
+and j on asymmetric physical dims, short slice for `evaluate_left` (n=2 on a
+1-element slice) and `evaluate_right` (short input with n>0), valid path still
+works.
+
+## 4. #630 — ACI default-path guard recovery has no regression test
+
+**Bug (gap)**: the only guard-recovery assertion hardcodes
+`nsearch_global_pivots = 30`; the default caller receives 5. lingrui96 measured
+the default path and it recovers (seeds 0–5, machine-zero), so this is
+test-only.
+
+**Fix**: in `global_guard/tests.rs`, change the guard-on arm of
+`global_guard_recovers_missed_near_degenerate_feature` to **not override**
+`nsearch_global_pivots` (per lingrui96: assert the default by not setting it,
+so a default change breaks the test). Implement via a `run_case` variant whose
+options leave `nsearch_global_pivots` at `AciOptions::default()`. Keep the
+guard-off arm as-is.
+
+**Tests**: the modified test itself.
+
+## 5. #615 — hashed common_ind_positions diverges for directed indices
+
+**Bug**: `common_ind_positions_hashed` buckets `indices_b` by `IndexLike::Id`
+and looks up `idx_a.id()`; the linear path matches on full `is_contractable`.
+For a directed `IndexLike` whose `conj()` changes the id, a Ket matches a Bra
+partner with a different id → hashed path silently drops the pair.
+
+**Fix**: bucket by full index value and look up `conj(idx_a)`:
+- `positions_by_value: HashMap<I, SmallVec<[usize; 2]>>` keyed by `idx_b`
+  (owned; `IndexLike: Clone + Eq + Hash`);
+- for each `idx_a`, probe candidates under key `idx_a.conj()` with
+  `is_contractable`.
+
+Equivalence to the linear path: linear accepts exactly `b == conj(a)`
+(undirected: `conj(a) == a`; directed: `conj(a) == b` by `is_contractable`).
+This deviates from the issue's suggested "key by full value + probe same-value
+candidates", which would still drop directed pairs (Ket vs Bra differ as full
+values); the conj-lookup form is the exact linear equivalent.
+
+**Tests**: add a minimal directed test `IndexLike` impl (Ket/Bra, `conj()`
+switches state **and** id — this is the case where id-keying fails) in the
+`index_ops` test module, calling `common_ind_positions_hashed` directly (it is
+private but same-module tests can reach it) and asserting it equals
+`common_ind_positions_linear` on directed pairs (per luna: ensure the hashed
+path itself is exercised, not only the dispatch); plus a same-ID/different-tags
+case and a dispatch-level case with scan_work > 64 forcing the hashed path.
+
+## Verification
+
+- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo nextest run --release -p tensor4all-core -p tensor4all-tensorbackend -p tensor4all-simplett -p tensor4all-aci` (+ tests dirs)
+- `cargo doc --workspace --no-deps`
+- Review gate: luna (read-only) reviews design (pre) and diff (post).
+
+## Review verdicts
+
+- Design (pre-implementation), luna: NEEDS-FIX → fixed (#638 right length
+  check) → re-approved per findings; all other sections APPROVED.
+- Diff (post-implementation), luna: TBD (record verdict here).

--- a/docs/design/issue-small-bugs-2026-08.md
+++ b/docs/design/issue-small-bugs-2026-08.md
@@ -127,4 +127,5 @@ case and a dispatch-level case with scan_work > 64 forcing the hashed path.
 
 - Design (pre-implementation), luna: NEEDS-FIX → fixed (#638 right length
   check) → re-approved per findings; all other sections APPROVED.
-- Diff (post-implementation), luna: TBD (record verdict here).
+- Diff (post-implementation), luna: APPROVED — Correct-to-merge (commit
+  7decf945, base origin/main).


### PR DESCRIPTION
Closes #622, #629, #638, #630, #615.

Five small bot-reported bugs:

- **#622** tensorbackend: unchecked `dims.iter().product()` in `dense_diagonal_values` / `dense_native_tensor_from_col_major` wraps to 0 for `2^16^4` and panics; now a checked product returns a typed error (regression + zero-size tests).
- **#629** core `svd`/`svd_with`: `V` now carries the same `sim` leg as `S`'s second leg (ITensors convention), so `U·S·Vᴴ` reconstructs under plain contraction without the undocumented `replaceind` step. Internal `svd_for_factorize`/`factorize` legacy path untouched (comment added). Reconstruction tests now exercise the plain contract.
- **#638** simplett `Contraction::{evaluate, evaluate_left, evaluate_right}`: validate caller index pairs/lengths against site dims and return `MPOError::IndexOutOfBounds`/`InvalidOperation` instead of panicking (asymmetric-dims + short-slice tests).
- **#630** aci: guard-recovery regression now runs at the default `nsearch_global_pivots` (not a hand-picked 30) by not overriding the option, so a default change that breaks recovery fails CI.
- **#615** core `common_ind_positions_hashed`: bucket `indices_b` by full index value and probe `idx_a.conj()` — exactly the linear-path semantics, fixing directed-index pairs whose `conj()` changes the id (regression with a directed test index, same-id/different-plev case, dispatch-level hashed-path case).

Design and review: `docs/design/issue-small-bugs-2026-08.md` — design pre-review and diff post-review by luna (read-only). Design verdict: needs-fix → fixed (#638 right-side length requirement) → approved. Diff verdict: Correct-to-merge.

Local gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run --release --workspace` (2824 passed), `cargo test --doc --release --workspace`, `cargo doc --workspace --no-deps`, `./scripts/test-mdbook.sh`, repository-rules-review dry run (pass, no findings).