### PR TITLE
Complete the #566 Phase-4 rename sweep (#616)

### DIFF
--- a/crates/tensor4all-core/src/index_ops.rs
+++ b/crates/tensor4all-core/src/index_ops.rs
@@ -404,17 +404,18 @@ pub fn hasind<I: IndexLike>(indices: &[I], index: &I) -> bool {
 /// # Example
 /// ```
 /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
-/// use tensor4all_core::index_ops::hasinds;
+/// use tensor4all_core::index_ops::has_inds;
 ///
 /// let i = Index::new_dyn(2);
 /// let j = Index::new_dyn(3);
 /// let k = Index::new_dyn(4);
 /// let indices = vec![i.clone(), j.clone(), k.clone()];
 ///
-/// assert!(hasinds(&indices, &[i.clone(), j.clone()]));
-/// assert!(!hasinds(&indices, &[i.clone(), Index::new_dyn(5)]));
+/// assert!(has_inds(&indices, &[i.clone(), j.clone()]));
+/// assert!(!has_inds(&indices, &[i.clone(), Index::new_dyn(5)]));
 /// ```
-pub fn hasinds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
+#[doc(alias = "hasinds")]
+pub fn has_inds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
     targets
         .iter()
         .all(|target| indices.iter().any(|idx| idx == target))
@@ -434,7 +435,7 @@ pub fn hasinds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
 /// # Example
 /// ```
 /// use tensor4all_core::index::{DefaultIndex as Index, DynId};
-/// use tensor4all_core::index_ops::hascommoninds;
+/// use tensor4all_core::index_ops::has_common_inds;
 ///
 /// let i = Index::new_dyn(2);
 /// let j = Index::new_dyn(3);
@@ -443,10 +444,11 @@ pub fn hasinds<I: IndexLike>(indices: &[I], targets: &[I]) -> bool {
 /// let indices_a = vec![i.clone(), j.clone()];
 /// let indices_b = vec![j.clone(), k.clone()];
 ///
-/// assert!(hascommoninds(&indices_a, &indices_b));
-/// assert!(!hascommoninds(&[i.clone()], &[k.clone()]));
+/// assert!(has_common_inds(&indices_a, &indices_b));
+/// assert!(!has_common_inds(&[i.clone()], &[k.clone()]));
 /// ```
-pub fn hascommoninds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> bool {
+#[doc(alias = "hascommoninds")]
+pub fn has_common_inds<I: IndexLike>(indices_a: &[I], indices_b: &[I]) -> bool {
     indices_a
         .iter()
         .any(|idx| indices_b.iter().any(|other| other == idx))

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -88,7 +88,7 @@ pub use index_like::{sort_indices_deterministic, ConjState, IndexLike};
 /// Index operations (replacement, set operations, contraction preparation).
 pub mod index_ops;
 pub use index_ops::{
-    check_unique_indices, common_ind_positions, common_inds, hascommoninds, hasind, hasinds,
+    check_unique_indices, common_ind_positions, common_inds, has_common_inds, has_inds, hasind,
     noncommon_inds, replace_indices, replace_indices_mut, union_inds, unique_inds,
     ReplaceIndsError,
 };

--- a/crates/tensor4all-core/tests/common_index_ops.rs
+++ b/crates/tensor4all-core/tests/common_index_ops.rs
@@ -1,6 +1,6 @@
 use tensor4all_core::index::DefaultIndex as Index;
 use tensor4all_core::index_ops::{
-    common_ind_positions, common_inds, hascommoninds, hasind, hasinds, noncommon_inds,
+    common_ind_positions, common_inds, has_common_inds, has_inds, hasind, noncommon_inds,
     replace_indices, replace_indices_mut, union_inds, unique_inds, ReplaceIndsError,
 };
 use tensor4all_core::{DynId, IndexLike, TagSet};
@@ -150,7 +150,7 @@ fn test_hasind() {
 }
 
 #[test]
-fn test_hasinds() {
+fn test_has_inds() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(4);
@@ -158,14 +158,14 @@ fn test_hasinds() {
 
     let indices = vec![i.clone(), j.clone(), k.clone()];
 
-    assert!(hasinds(&indices, &[i.clone(), j.clone()]));
-    assert!(hasinds(&indices, &[i.clone(), j.clone(), k.clone()]));
-    assert!(!hasinds(&indices, &[i.clone(), l.clone()]));
-    assert!(!hasinds(&indices, std::slice::from_ref(&l)));
+    assert!(has_inds(&indices, &[i.clone(), j.clone()]));
+    assert!(has_inds(&indices, &[i.clone(), j.clone(), k.clone()]));
+    assert!(!has_inds(&indices, &[i.clone(), l.clone()]));
+    assert!(!has_inds(&indices, std::slice::from_ref(&l)));
 }
 
 #[test]
-fn test_hascommoninds() {
+fn test_has_common_inds() {
     let i = Index::new_dyn(2);
     let j = Index::new_dyn(3);
     let k = Index::new_dyn(4);
@@ -175,8 +175,8 @@ fn test_hascommoninds() {
     let indices_b = vec![j.clone(), k.clone()];
     let indices_c = vec![k.clone(), l.clone()];
 
-    assert!(hascommoninds(&indices_a, &indices_b)); // j is common
-    assert!(!hascommoninds(&indices_a, &indices_c)); // no common
+    assert!(has_common_inds(&indices_a, &indices_b)); // j is common
+    assert!(!has_common_inds(&indices_a, &indices_c)); // no common
 }
 
 #[test]
@@ -193,8 +193,8 @@ fn test_common_inds_integration() {
     assert_eq!(common.len(), 1);
     assert_eq!(common[0].id, j.id);
 
-    // Verify hascommoninds matches
-    assert!(hascommoninds(&indices_a, &indices_b));
+    // Verify has_common_inds matches
+    assert!(has_common_inds(&indices_a, &indices_b));
 }
 
 #[test]
@@ -206,8 +206,8 @@ fn test_index_ops_distinguish_same_id_prime_pair() {
 
     assert!(hasind(&indices, &i));
     assert!(hasind(&indices, &i_prime));
-    assert!(hasinds(&indices, &[i.clone(), i_prime.clone()]));
-    assert!(!hascommoninds(
+    assert!(has_inds(&indices, &[i.clone(), i_prime.clone()]));
+    assert!(!has_common_inds(
         std::slice::from_ref(&i),
         std::slice::from_ref(&i_prime)
     ));

--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -51,7 +51,7 @@ tt.truncate(&TruncateOptions::svd()
     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
     .with_max_bond_dim(2))?;
 
-assert!(tt.isortho());
+assert!(tt.is_ortho());
 assert_eq!(s1.dim(), 2);
 let norm = tt.norm()?;
 assert!(norm.is_finite());

--- a/crates/tensor4all-itensorlike/src/prelude.rs
+++ b/crates/tensor4all-itensorlike/src/prelude.rs
@@ -15,7 +15,7 @@
 //! tt.truncate(&TruncateOptions::svd()
 //!     .with_svd_policy(SvdTruncationPolicy::new(1e-10))
 //!     .with_max_bond_dim(2))?;
-//! assert!(tt.isortho());
+//! assert!(tt.is_ortho());
 //! # Ok(())
 //! # }
 //! ```

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -13,7 +13,7 @@ use std::ops::Range;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use tensor4all_core::{
-    common_inds, contract_pair, contract_pair_with_operand_options, hascommoninds, DynIndex,
+    common_inds, contract_pair, contract_pair_with_operand_options, has_common_inds, DynIndex,
     IndexLike, PairwiseContractionOptions,
 };
 use tensor4all_core::{
@@ -384,7 +384,7 @@ impl TensorTrain {
     /// Returns -1 if no sites are left-orthogonal.
     #[inline]
     pub fn llim(&self) -> i32 {
-        match self.orthocenter() {
+        match self.ortho_center() {
             Some(center) => center as i32 - 1,
             None => -1,
         }
@@ -396,7 +396,7 @@ impl TensorTrain {
     /// Returns `len() + 1` if no sites are right-orthogonal.
     #[inline]
     pub fn rlim(&self) -> i32 {
-        match self.orthocenter() {
+        match self.ortho_center() {
             Some(center) => center as i32 + 1,
             None => self.len() as i32 + 1,
         }
@@ -447,7 +447,8 @@ impl TensorTrain {
     ///
     /// Returns true if there is exactly one site that is not guaranteed to be orthogonal.
     #[inline]
-    pub fn isortho(&self) -> bool {
+    #[doc(alias = "isortho")]
+    pub fn is_ortho(&self) -> bool {
         self.treetn.canonical_region().len() == 1
     }
 
@@ -455,7 +456,8 @@ impl TensorTrain {
     ///
     /// Returns `Some(site)` if the tensor train has a single orthogonality center,
     /// `None` otherwise.
-    pub fn orthocenter(&self) -> Option<usize> {
+    #[doc(alias = "orthocenter")]
+    pub fn ortho_center(&self) -> Option<usize> {
         let region = self.treetn.canonical_region();
         if region.len() == 1 {
             // Node name IS the site index since V = usize
@@ -950,7 +952,7 @@ impl TensorTrain {
                 let left = self.treetn.tensor(l);
                 let right = self.treetn.tensor(r);
                 match (left, right) {
-                    (Some(l), Some(r)) => hascommoninds(l.indices(), r.indices()),
+                    (Some(l), Some(r)) => has_common_inds(l.indices(), r.indices()),
                     _ => false,
                 }
             }
@@ -1077,12 +1079,12 @@ impl TensorTrain {
     /// ).unwrap();
     ///
     /// let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
-    /// assert!(!tt.isortho());
+    /// assert!(!tt.is_ortho());
     ///
     /// // Orthogonalize to site 0
     /// tt.orthogonalize(0).unwrap();
-    /// assert!(tt.isortho());
-    /// assert_eq!(tt.orthocenter(), Some(0));
+    /// assert!(tt.is_ortho());
+    /// assert_eq!(tt.ortho_center(), Some(0));
     /// ```
     pub fn orthogonalize(&mut self, site: usize) -> Result<()> {
         self.orthogonalize_with(site, CanonicalForm::Unitary)

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -1240,7 +1240,7 @@ fn test_set_rlim_valid_center() {
     assert_eq!(tt.ortho_center(), Some(0));
 
     // set_rlim to 2 with current llim=-1 => llim will be recomputed.
-    // After set_rlim(2): llim from orthocenter is recalculated.
+    // After set_rlim(2): llim from ortho_center is recalculated.
     // Since set_rlim reads current llim first (which is -1), then checks -1+2==2? No, 1!=2.
     // So this clears ortho. Let's set rlim=1 which keeps center at 0.
     tt.set_rlim(1);

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -24,7 +24,7 @@ fn test_empty_tt() {
     assert_eq!(tt.len(), 0);
     assert_eq!(tt.llim(), -1);
     assert_eq!(tt.rlim(), 1);
-    assert!(!tt.isortho());
+    assert!(!tt.is_ortho());
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn test_single_site_tt() {
 
     let tt = TensorTrain::new(vec![tensor]).unwrap();
     assert_eq!(tt.len(), 1);
-    assert!(!tt.isortho());
+    assert!(!tt.is_ortho());
     assert_eq!(tt.bond_dims(), Vec::<usize>::new());
 }
 
@@ -244,8 +244,8 @@ fn test_ortho_tracking() {
     )
     .unwrap();
 
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(0));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(0));
     assert_eq!(tt.canonical_form(), Some(CanonicalForm::Unitary));
 }
 
@@ -265,8 +265,8 @@ fn test_ortho_lims_range() {
     let tt = TensorTrain::with_ortho(vec![t0, t1, t2], 0, 2, None).unwrap();
 
     assert_eq!(tt.ortho_lims(), 1..2);
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(1));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(1));
 }
 
 #[test]
@@ -296,18 +296,18 @@ fn test_orthogonalize_two_site() {
     let t1 = make_tensor(vec![l01.clone(), s1.clone()]);
 
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
-    assert!(!tt.isortho());
+    assert!(!tt.is_ortho());
 
     // Orthogonalize to site 0
     tt.orthogonalize(0).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(0));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(0));
     assert_eq!(tt.canonical_form(), Some(CanonicalForm::Unitary));
 
     // Orthogonalize to site 1
     tt.orthogonalize(1).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(1));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(1));
 }
 
 #[test]
@@ -327,18 +327,18 @@ fn test_orthogonalize_three_site() {
 
     // Orthogonalize to middle site
     tt.orthogonalize(1).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(1));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(1));
 
     // Orthogonalize to left
     tt.orthogonalize(0).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(0));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(0));
 
     // Orthogonalize to right
     tt.orthogonalize(2).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(2));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(2));
 }
 
 #[test]
@@ -353,8 +353,8 @@ fn test_orthogonalize_with_lu() {
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
 
     tt.orthogonalize_with(0, CanonicalForm::LU).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(0));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(0));
     assert_eq!(tt.canonical_form(), Some(CanonicalForm::LU));
 }
 
@@ -370,8 +370,8 @@ fn test_orthogonalize_with_ci() {
     let mut tt = TensorTrain::new(vec![t0, t1]).unwrap();
 
     tt.orthogonalize_with(1, CanonicalForm::CI).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(1));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(1));
     assert_eq!(tt.canonical_form(), Some(CanonicalForm::CI));
 }
 
@@ -780,12 +780,12 @@ fn test_set_llim_updates_canonical_region() {
         Some(CanonicalForm::Unitary),
     )
     .unwrap();
-    assert!(tt2.isortho());
-    assert_eq!(tt2.orthocenter(), Some(0));
+    assert!(tt2.is_ortho());
+    assert_eq!(tt2.ortho_center(), Some(0));
 
     // Setting llim to a value that breaks single-center should clear ortho
     tt2.set_llim(5);
-    assert!(!tt2.isortho());
+    assert!(!tt2.is_ortho());
 }
 
 #[test]
@@ -800,11 +800,11 @@ fn test_set_rlim_updates_canonical_region() {
         Some(CanonicalForm::Unitary),
     )
     .unwrap();
-    assert!(tt.isortho());
+    assert!(tt.is_ortho());
 
     // Setting rlim to a value that breaks single-center should clear ortho
     tt.set_rlim(5);
-    assert!(!tt.isortho());
+    assert!(!tt.is_ortho());
 }
 
 #[test]
@@ -818,12 +818,12 @@ fn test_set_tensor_invalidates_ortho() {
 
     let mut tt =
         TensorTrain::with_ortho(vec![t0, t1], -1, 1, Some(CanonicalForm::Unitary)).unwrap();
-    assert!(tt.isortho());
+    assert!(tt.is_ortho());
 
     // Replace tensor at site 0
     let new_tensor = make_tensor(vec![s0, l01]);
     tt.set_tensor(0, new_tensor).unwrap();
-    assert!(!tt.isortho());
+    assert!(!tt.is_ortho());
 }
 
 #[test]
@@ -1212,13 +1212,13 @@ fn test_set_llim_valid_center() {
     // Start with ortho center at site 1
     let mut tt =
         TensorTrain::with_ortho(vec![t0, t1, t2], 0, 2, Some(CanonicalForm::Unitary)).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(1));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(1));
 
     // set_llim to 0 with current rlim=2 => center should be 1 (0+1)
     tt.set_llim(0);
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(1));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(1));
 }
 
 #[test]
@@ -1236,16 +1236,16 @@ fn test_set_rlim_valid_center() {
     // Start with ortho center at site 0
     let mut tt =
         TensorTrain::with_ortho(vec![t0, t1, t2], -1, 1, Some(CanonicalForm::Unitary)).unwrap();
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(0));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(0));
 
     // set_rlim to 2 with current llim=-1 => llim will be recomputed.
     // After set_rlim(2): llim from orthocenter is recalculated.
     // Since set_rlim reads current llim first (which is -1), then checks -1+2==2? No, 1!=2.
     // So this clears ortho. Let's set rlim=1 which keeps center at 0.
     tt.set_rlim(1);
-    assert!(tt.isortho());
-    assert_eq!(tt.orthocenter(), Some(0));
+    assert!(tt.is_ortho());
+    assert_eq!(tt.ortho_center(), Some(0));
 }
 
 #[test]
@@ -1485,7 +1485,7 @@ fn test_truncate_with_rtol() {
     let options =
         TruncateOptions::svd().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10));
     tt.truncate(&options).unwrap();
-    assert!(tt.isortho() || tt.len() == 3);
+    assert!(tt.is_ortho() || tt.len() == 3);
 }
 
 #[test]

--- a/crates/tensor4all-quanticstci/src/options.rs
+++ b/crates/tensor4all-quanticstci/src/options.rs
@@ -193,8 +193,8 @@ impl QtciOptions {
     /// let opts = QtciOptions::default().with_maxiter(500);
     /// assert_eq!(opts.max_iter, 500);
     /// ```
-    pub fn with_maxiter(mut self, max_iter: usize) -> Self {
-        self.max_iter = max_iter;
+    pub fn with_maxiter(mut self, maxiter: usize) -> Self {
+        self.max_iter = maxiter;
         self
     }
 

--- a/crates/tensor4all-quanticstci/src/options.rs
+++ b/crates/tensor4all-quanticstci/src/options.rs
@@ -14,9 +14,9 @@ use tensor4all_treetci::TreeTciOptions;
 /// |---|---|---|---|
 /// | `tolerance` | `1e-8` | `1e-6` .. `1e-12` | Relative convergence threshold |
 /// | `max_bond_dim` | `None` (unlimited) | `50` .. `500` | Cap on bond dimension |
-/// | `maxiter` | `200` | `20` .. `500` | Maximum half-sweep iterations |
-/// | `nrandominitpivot` | `5` | `3` .. `20` | Random initial pivots added |
-/// | `unfoldingscheme` | `Interleaved` | — | How quantics bits are arranged |
+/// | `max_iter` | `200` | `20` .. `500` | Maximum half-sweep iterations |
+/// | `n_random_init_pivot` | `5` | `3` .. `20` | Random initial pivots added |
+/// | `unfolding_scheme` | `Interleaved` | — | How quantics bits are arranged |
 /// | `normalize_error` | `true` | — | Normalize error by max sample value |
 /// | `verbosity` | `0` | `0` .. `2` | Logging verbosity |
 /// | `nsearchglobalpivot` | `5` | `1` .. `20` | Global pivots tested per iteration |
@@ -31,8 +31,8 @@ use tensor4all_treetci::TreeTciOptions;
 /// let opts = QtciOptions::default();
 /// assert!((opts.tolerance - 1e-8).abs() < 1e-15);
 /// assert_eq!(opts.max_bond_dim, None);
-/// assert_eq!(opts.maxiter, 200);
-/// assert_eq!(opts.nrandominitpivot, 5);
+/// assert_eq!(opts.max_iter, 200);
+/// assert_eq!(opts.n_random_init_pivot, 5);
 /// assert_eq!(opts.verbosity, 0);
 /// assert!(opts.normalize_error);
 ///
@@ -46,8 +46,8 @@ use tensor4all_treetci::TreeTciOptions;
 ///
 /// assert!((custom.tolerance - 1e-10).abs() < 1e-18);
 /// assert_eq!(custom.max_bond_dim, Some(50));
-/// assert_eq!(custom.maxiter, 100);
-/// assert_eq!(custom.nrandominitpivot, 10);
+/// assert_eq!(custom.max_iter, 100);
+/// assert_eq!(custom.n_random_init_pivot, 10);
 /// assert_eq!(custom.verbosity, 1);
 /// ```
 #[derive(Debug, Clone)]
@@ -80,7 +80,8 @@ pub struct QtciOptions {
     /// functions that need more sweeps.
     ///
     /// Default: `200`.
-    pub maxiter: usize,
+    #[doc(alias = "maxiter")]
+    pub max_iter: usize,
 
     /// Number of random initial pivots to add.
     ///
@@ -90,7 +91,8 @@ pub struct QtciOptions {
     /// extra initial evaluations. Typical values: `3`--`20`.
     ///
     /// Default: `5`.
-    pub nrandominitpivot: usize,
+    #[doc(alias = "nrandominitpivot")]
+    pub n_random_init_pivot: usize,
 
     /// Unfolding scheme for the quantics tensor train.
     ///
@@ -99,7 +101,8 @@ pub struct QtciOptions {
     /// most applications, `Interleaved` gives better compression.
     ///
     /// Default: [`UnfoldingScheme::Interleaved`].
-    pub unfoldingscheme: UnfoldingScheme,
+    #[doc(alias = "unfoldingscheme")]
+    pub unfolding_scheme: UnfoldingScheme,
 
     /// Whether to normalize the convergence error by the maximum
     /// sampled function value.
@@ -141,9 +144,9 @@ impl Default for QtciOptions {
         Self {
             tolerance: 1e-8,
             max_bond_dim: None,
-            maxiter: 200,
-            nrandominitpivot: 5,
-            unfoldingscheme: UnfoldingScheme::Interleaved,
+            max_iter: 200,
+            n_random_init_pivot: 5,
+            unfolding_scheme: UnfoldingScheme::Interleaved,
             normalize_error: true,
             verbosity: 0,
             nsearchglobalpivot: 5,
@@ -188,10 +191,10 @@ impl QtciOptions {
     /// ```
     /// use tensor4all_quanticstci::QtciOptions;
     /// let opts = QtciOptions::default().with_maxiter(500);
-    /// assert_eq!(opts.maxiter, 500);
+    /// assert_eq!(opts.max_iter, 500);
     /// ```
-    pub fn with_maxiter(mut self, maxiter: usize) -> Self {
-        self.maxiter = maxiter;
+    pub fn with_maxiter(mut self, max_iter: usize) -> Self {
+        self.max_iter = max_iter;
         self
     }
 
@@ -202,10 +205,10 @@ impl QtciOptions {
     /// ```
     /// use tensor4all_quanticstci::QtciOptions;
     /// let opts = QtciOptions::default().with_nrandominitpivot(10);
-    /// assert_eq!(opts.nrandominitpivot, 10);
+    /// assert_eq!(opts.n_random_init_pivot, 10);
     /// ```
     pub fn with_nrandominitpivot(mut self, n: usize) -> Self {
-        self.nrandominitpivot = n;
+        self.n_random_init_pivot = n;
         self
     }
 
@@ -216,10 +219,10 @@ impl QtciOptions {
     /// ```
     /// use tensor4all_quanticstci::{QtciOptions, UnfoldingScheme};
     /// let opts = QtciOptions::default().with_unfoldingscheme(UnfoldingScheme::Fused);
-    /// assert_eq!(opts.unfoldingscheme, UnfoldingScheme::Fused);
+    /// assert_eq!(opts.unfolding_scheme, UnfoldingScheme::Fused);
     /// ```
     pub fn with_unfoldingscheme(mut self, scheme: UnfoldingScheme) -> Self {
-        self.unfoldingscheme = scheme;
+        self.unfolding_scheme = scheme;
         self
     }
 
@@ -283,7 +286,7 @@ impl QtciOptions {
     pub fn to_treetci_options(&self) -> TreeTciOptions {
         TreeTciOptions {
             tolerance: self.tolerance,
-            max_iter: self.maxiter,
+            max_iter: self.max_iter,
             max_bond_dim: self.max_bond_dim,
             normalize_error: self.normalize_error,
             // Global pivot search stays opt-in; the legacy `nsearchglobalpivot`

--- a/crates/tensor4all-quanticstci/src/options/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/options/tests/mod.rs
@@ -5,9 +5,9 @@ fn test_default_options() {
     let opts = QtciOptions::default();
     assert!((opts.tolerance - 1e-8).abs() < 1e-15);
     assert!(opts.max_bond_dim.is_none());
-    assert_eq!(opts.maxiter, 200);
-    assert_eq!(opts.nrandominitpivot, 5);
-    assert_eq!(opts.unfoldingscheme, UnfoldingScheme::Interleaved);
+    assert_eq!(opts.max_iter, 200);
+    assert_eq!(opts.n_random_init_pivot, 5);
+    assert_eq!(opts.unfolding_scheme, UnfoldingScheme::Interleaved);
     assert_eq!(opts.nsearchglobalpivot, 5);
     assert_eq!(opts.nsearch, 100);
 }
@@ -23,7 +23,7 @@ fn test_builder_pattern() {
 
     assert!((opts.tolerance - 1e-6).abs() < 1e-15);
     assert_eq!(opts.max_bond_dim, Some(100));
-    assert_eq!(opts.maxiter, 50);
+    assert_eq!(opts.max_iter, 50);
     assert_eq!(opts.nsearchglobalpivot, 10);
     assert_eq!(opts.nsearch, 200);
 }

--- a/crates/tensor4all-quanticstci/src/quantics_tci.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci.rs
@@ -460,7 +460,7 @@ where
 
     // Add random initial pivots (0-indexed for TCI)
     let mut rng = rand::rng();
-    for _ in 0..options.nrandominitpivot {
+    for _ in 0..options.n_random_init_pivot {
         let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.random_range(0..d)).collect();
         qinitialpivots.push(pivot);
     }
@@ -625,7 +625,7 @@ where
     let grid = DiscretizedGrid::builder(&rs)
         .with_lower_bound(&lower)
         .with_upper_bound(&upper)
-        .with_unfolding_scheme(options.unfoldingscheme)
+        .with_unfolding_scheme(options.unfolding_scheme)
         .include_endpoint(true)
         .build()
         .map_err(|e| anyhow!("Failed to build grid: {}", e))?;
@@ -727,7 +727,7 @@ where
     // Build inherent discrete grid - rs is the number of bits per variable
     let rs: Vec<usize> = vec![r; n];
     let grid = InherentDiscreteGrid::builder(&rs)
-        .with_unfolding_scheme(options.unfoldingscheme)
+        .with_unfolding_scheme(options.unfolding_scheme)
         .build()
         .map_err(|e| anyhow!("Failed to build grid: {}", e))?;
 
@@ -784,7 +784,7 @@ where
 
     // Add random initial pivots (0-indexed for TCI)
     let mut rng = rand::rng();
-    for _ in 0..options.nrandominitpivot {
+    for _ in 0..options.n_random_init_pivot {
         let pivot: Vec<usize> = local_dims.iter().map(|&d| rng.random_range(0..d)).collect();
         qinitialpivots.push(pivot);
     }

--- a/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
@@ -154,7 +154,7 @@ fn test_options_builder() {
 
     assert!((opts.tolerance - 1e-6).abs() < 1e-15);
     assert_eq!(opts.max_bond_dim, Some(50));
-    assert_eq!(opts.unfoldingscheme, UnfoldingScheme::Fused);
+    assert_eq!(opts.unfolding_scheme, UnfoldingScheme::Fused);
 }
 
 #[test]

--- a/crates/tensor4all-quanticstci/tests/feature_test_physicist.rs
+++ b/crates/tensor4all-quanticstci/tests/feature_test_physicist.rs
@@ -532,9 +532,9 @@ fn options_builder_all_fields() {
 
     assert!((opts.tolerance - 1e-6).abs() < 1e-15);
     assert_eq!(opts.max_bond_dim, Some(50));
-    assert_eq!(opts.maxiter, 100);
-    assert_eq!(opts.nrandominitpivot, 10);
-    assert_eq!(opts.unfoldingscheme, UnfoldingScheme::Fused);
+    assert_eq!(opts.max_iter, 100);
+    assert_eq!(opts.n_random_init_pivot, 10);
+    assert_eq!(opts.unfolding_scheme, UnfoldingScheme::Fused);
     assert_eq!(opts.verbosity, 2);
     assert_eq!(opts.nsearchglobalpivot, 3);
     assert_eq!(opts.nsearch, 200);

--- a/crates/tensor4all-tensorbackend/src/storage.rs
+++ b/crates/tensor4all-tensorbackend/src/storage.rs
@@ -1252,54 +1252,6 @@ impl Storage {
     /// Create dense f64 storage from column-major logical values.
     ///
     /// # Errors
-    ///
-    /// Returns an error when the data length does not match the logical dimension
-    /// /// product (a shape mismatch).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::Storage;
-    ///
-    /// let s = Storage::from_dense_f64_col_major(vec![1.0, 2.0, 3.0, 4.0], &[2, 2]).unwrap();
-    /// assert!(s.is_f64());
-    /// assert!(s.is_dense());
-    /// ```
-    pub fn from_dense_f64_col_major(data: Vec<f64>, logical_dims: &[usize]) -> StorageResult<Self> {
-        Self::validate_dense_len(&data, logical_dims, "dense f64 payload")?;
-        Ok(Self::from_repr(StorageRepr::F64(
-            StructuredStorage::from_dense_col_major(data, logical_dims)?,
-        )))
-    }
-
-    /// Create dense Complex64 storage from column-major logical values.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the data length does not match the logical dimension
-    /// /// product (a shape mismatch).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tensor4all_tensorbackend::Storage;
-    /// use num_complex::Complex64;
-    ///
-    /// let data = vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 1.0)];
-    /// let s = Storage::from_dense_c64_col_major(data, &[2]).unwrap();
-    /// assert!(s.is_c64());
-    /// assert!(s.is_dense());
-    /// ```
-    pub fn from_dense_c64_col_major(
-        data: Vec<Complex64>,
-        logical_dims: &[usize],
-    ) -> StorageResult<Self> {
-        Self::validate_dense_len(&data, logical_dims, "dense c64 payload")?;
-        Ok(Self::from_repr(StorageRepr::C64(
-            StructuredStorage::from_dense_col_major(data, logical_dims)?,
-        )))
-    }
-
     /// Create diagonal f64 storage from column-major diagonal payload values.
     ///
     /// # Errors

--- a/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
+++ b/crates/tensor4all-tensorbackend/src/storage/tests/mod.rs
@@ -433,13 +433,13 @@ fn test_storage_new_dense_c64() {
 }
 
 #[test]
-fn test_storage_from_dense_f64_col_major_zeros_with_shape() {
+fn test_storage_from_dense_col_major_f64_zeros_with_shape() {
     let s = Storage::from_dense_col_major(vec![0.0; 6], &[2, 3]).unwrap();
     assert_eq!(s.len(), 6);
 }
 
 #[test]
-fn test_storage_from_dense_c64_col_major_zeros_with_shape() {
+fn test_storage_from_dense_col_major_c64_zeros_with_shape() {
     let s = Storage::from_dense_col_major(vec![Complex64::new(0.0, 0.0); 6], &[3, 2]).unwrap();
     assert_eq!(s.len(), 6);
 }

--- a/docs/book/src/guides/tci.md
+++ b/docs/book/src/guides/tci.md
@@ -123,7 +123,7 @@ The quantics representation encodes each grid index in binary and arranges the b
 | Grid points given as explicit coordinate arrays | `quanticscrossinterpolate_from_arrays` |
 | Vector/tensor-valued function | `quanticscrossinterpolate_batched` |
 
-**Tip on `nrandominitpivot`**: The `nrandominitpivot` option (default: 5) controls how many random initial pivot points are used to seed the TCI algorithm. For functions with multiple separated features or high-dimensional problems, increase this to 10--20 to improve robustness.
+**Tip on `n_random_init_pivot`**: The `n_random_init_pivot` option (default: 5) controls how many random initial pivot points are used to seed the TCI algorithm. For functions with multiple separated features or high-dimensional problems, increase this to 10--20 to improve robustness.
 
 ### Discrete grid interpolation
 

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -177,8 +177,8 @@ let mut tt = TensorTrain::new(vec![t0, t1, t2])?;
 let norm_before = tt.norm()?;
 tt.orthogonalize(1)?;
 
-assert!(tt.isortho());
-assert_eq!(tt.orthocenter(), Some(1));
+assert!(tt.is_ortho());
+assert_eq!(tt.ortho_center(), Some(1));
 
 // Orthogonalization preserves the tensor train value
 assert!((tt.norm()? - norm_before).abs() < 1e-10);

--- a/docs/design/issue-616-rename-sweep.md
+++ b/docs/design/issue-616-rename-sweep.md
@@ -79,5 +79,10 @@ matches the tree.
 
 ## Review verdicts
 
-- Design (pre-implementation), luna: TBD.
-- Diff (post-implementation), luna: TBD.
+- Design (pre-implementation), luna: NEEDS-FIX (missed call sites:
+  itensorlike tensortrain.rs hascommoninds import/use, options.rs builder
+  internals + to_treetci_options, Rust-facing docs, Julia examples out of
+  scope) → fixed → approved.
+- Diff (post-implementation), luna: NEEDS-FIX (crates.md backticks,
+  with_maxiter param name, test comment, historical-plan name reference)
+  → fixed → re-approved.

--- a/docs/design/issue-616-rename-sweep.md
+++ b/docs/design/issue-616-rename-sweep.md
@@ -1,0 +1,83 @@
+# Design: #616 — complete the Phase-4 rename sweep (7 names + scalar-suffixed constructors)
+
+Status: user-approved (2026-08, "y" to proceed; no-compatibility phase).
+Review by luna (read-only): design pre-review + diff post-review.
+
+## Problem
+
+Umbrella #566 Phase 4 claimed the Julia-style concatenated names were renamed
+to snake_case (item 32) and scalar-suffixed Rust entry points removed (item 34),
+but 7 names and 2 scalar-suffixed constructors remain public and unrenamed.
+This task completes the sweep and corrects the ledger.
+
+## Renames (snake_case primary + `#[doc(alias = "old")]`; old names removed from API)
+
+| Old | New | Location | Call sites to update |
+|---|---|---|---|
+| `hasinds` | `has_inds` | core/src/index_ops.rs:417 | index_ops doc examples, core lib.rs re-export (:91), tests/common_index_ops.rs |
+| `hascommoninds` | `has_common_inds` | core/src/index_ops.rs:449 | same files; **plus itensorlike/src/tensortrain.rs:16 (import) and :953 (internal use)** |
+| `isortho` | `is_ortho` | itensorlike/src/tensortrain.rs:450 | prelude.rs doctest, tensortrain.rs internal calls (:387/:399) + doctests + tests, itensorlike README.md:54 |
+| `orthocenter` | `ortho_center` | itensorlike/src/tensortrain.rs:458 | same |
+| `maxiter` | `max_iter` | quanticstci/src/options.rs:83 (QtciOptions field) | options.rs default impl + doc examples + **builder internals (:194 `self.maxiter = maxiter`) + to_treetci_options (:286 `max_iter: self.maxiter`)**, quantics_tci.rs, options/tests, feature_test_physicist.rs |
+| `nrandominitpivot` | `n_random_init_pivot` | quanticstci/src/options.rs:93 | quantics_tci.rs (:463/:787), tests |
+| `unfoldingscheme` | `unfolding_scheme` | quanticstci/src/options.rs:102 | quantics_tci.rs (:628/:730), tests |
+
+Builder methods (`with_maxiter`, `with_nrandominitpivot`, `with_unfoldingscheme`)
+are NOT in the #616 enumeration and are left unchanged (their parameter names
+are internal; only the field assignments inside them are renamed). The
+singular `hasind` is not in the enumeration; left unchanged. treetn `maxiter`
+occurrences are GMRES/KrylovKit names — unrelated to QtciOptions.
+
+## Removal (scalar-suffixed constructors)
+
+`Storage::from_dense_f64_col_major` (storage.rs:1268) and
+`Storage::from_dense_c64_col_major` (:1293) are removed; the generic
+`Storage::from_dense_col_major<T>` (storage.rs:315) already exists and the two
+tests in storage/tests/mod.rs already call the generic form (only their test
+names mention the old fns — rename the test names). The removed methods' doc
+examples disappear with them. No `#[doc(alias)]` (the generic is the
+replacement; scalar-suffixed names belong at the FFI boundary only).
+
+## Ledger
+
+`docs/superpowers/ledgers/2026-08-11-issue-566-pr4-ledger.md` items 32 (:65) and
+34 (:67) claim DONE. Append a dated residual-completion note to each item
+stating the 7 names and 2 constructors were completed by this PR, so the ledger
+matches the tree.
+
+## Verified scope boundaries (grep on origin/main)
+
+- No capi/treetn/simplett/treetci/aci usage of the 7 names (treetn `maxiter`
+  hits are GMRES/KrylovKit names).
+- docs/tutorial-code uses QtciOptions only via builders (`.with_*`); its
+  `config.maxiter` hits are local config structs, not QtciOptions fields —
+  out of scope.
+- No `#[doc(alias)]` exists anywhere in crates/ yet — first introduction.
+- `hascommoninds`/`hasinds` are re-exported at core lib.rs:91 — update the
+  list to the new names.
+- **Rust-facing docs to update**: itensorlike README.md:54 (isortho),
+  docs/book/src/guides/tensor-train.md:180-181 (isortho/orthocenter),
+  docs/book/src/guides/tci.md:126 (nrandominitpivot), skills
+  references/crates.md:47 (isortho/orthocenter), references/recipes.md:235
+  (isortho), references lines 86/328 (nrandominitpivot),
+  docs/tutorial-code/docs/tutorials/qtt_function_tutorial.md:137
+  (nrandominitpivot/unfoldingscheme).
+- **Out of scope (Julia-side API)**: docs/examples/julia/core.jl:30
+  (`hascommoninds`) and quanticstci.jl:14 (`unfoldingscheme=:fused`) call
+  the Tensor4all.jl package API, a separate repo; the Rust rename does not
+  change the Julia surface and those examples must NOT be edited here.
+
+## Verification
+
+- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo nextest run --release --workspace`
+- `cargo test --doc --release --workspace`, `./scripts/test-mdbook.sh`
+- `cargo doc --workspace --no-deps` (doc(alias) renders)
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree`
+- grep: no remaining old names except `#[doc(alias)]` attributes and the
+  ledger note.
+
+## Review verdicts
+
+- Design (pre-implementation), luna: TBD.
+- Diff (post-implementation), luna: TBD.

--- a/docs/superpowers/ledgers/2026-08-11-issue-566-pr4-ledger.md
+++ b/docs/superpowers/ledgers/2026-08-11-issue-566-pr4-ledger.md
@@ -62,9 +62,9 @@ Basis: `origin/main` at 69a24e7 (2026-08-02 audit), remediated across PR #589,
 
 30. **Resolve the four semantic traps** — DONE (PR #595: `TreeTN::scale` split into `scale`/`scale_mut`; `evaluate` unsuffixed + `_batched`; `truncate`/`compress` documented; `norm` documented).
 31. **Collapse duplicate types** — DONE (PR #595: simplett positional type renamed `SimpleTensorTrain`; naming resolution documented; no compat aliases).
-32. **Julia-style concatenated names to snake_case** — DONE (PR #595: `link_indices`, `site_indices`, `max_bond_dim`, `full_tensor`, `min_dim`, `replace_indices`, …).
+32. **Julia-style concatenated names to snake_case** — DONE (PR #595: `link_indices`, `site_indices`, `max_bond_dim`, `full_tensor`, `min_dim`, `replace_indices`, …). Residual completed 2026-08 (#616, PR #643): `hasinds`→`has_inds`, `hascommoninds`→`has_common_inds` (core), `isortho`→`is_ortho`, `orthocenter`→`ortho_center` (itensorlike), `maxiter`→`max_iter`, `nrandominitpivot`→`n_random_init_pivot`, `unfoldingscheme`→`unfolding_scheme` (QtciOptions), each with `#[doc(alias)]` on the old name.
 33. **Unify densification / inner-product / canonicalization / options vocabulary** — DONE (PR #595: `inner_product` everywhere; `full_tensor` vs `to_dense` documented; options `max_bond_dim`/`SvdTruncationPolicy` unified; `canonicalize` vs `orthogonalize` documented per stack).
-34. **Remove scalar-suffixed Rust entry points outside capi** — DONE (PR #595: `native_tensor_primal_to_diag<T>`/`dense_col_major<T>` generics; `as_slice_f64/c64` removed; `as_`/`is_` dtype accessors documented as exempt).
+34. **Remove scalar-suffixed Rust entry points outside capi** — DONE (PR #595: `native_tensor_primal_to_diag<T>`/`dense_col_major<T>` generics; `as_slice_f64/c64` removed; `as_`/`is_` dtype accessors documented as exempt). Residual completed 2026-08 (#616, PR #643): `Storage::from_dense_f64_col_major` / `from_dense_c64_col_major` removed in favor of the generic `from_dense_col_major<T>`.
 
 ## Phase 5 — structural decisions
 

--- a/docs/superpowers/plans/2026-04-11-online-documentation-improvement.md
+++ b/docs/superpowers/plans/2026-04-11-online-documentation-improvement.md
@@ -317,7 +317,7 @@ When working on each crate's mdBook guide, add the following missing content:
 - ITensorLike column-major convention explanation
 
 **tci.md** (tensor4all-tensorci, tensor4all-quanticstci):
-- Parameter selection: `tolerance`, `max_bond_dim`, `nrandominitpivot` guidance
+- Parameter selection: `tolerance`, `max_bond_dim`, `n_random_init_pivot` guidance
 - Convergence diagnostics: how to read the errors vector, detect stalled convergence
 - `quanticscrossinterpolate` vs `quanticscrossinterpolate_discrete` selection criteria
 - Index convention highlight: 0-indexed (low-level) vs 1-indexed (quantics grid)

--- a/docs/test-reports/test-feature-20260813-000446.md
+++ b/docs/test-reports/test-feature-20260813-000446.md
@@ -1,0 +1,54 @@
+# Feature Test Report: tensor4all-rs (persona runs)
+
+**Date:** 2026-08-12 (re-run against origin/main after initial wrong-branch doc surface was corrected)
+**Project type:** library (Rust workspace)
+**Features tested:** quantics TCI (quanticstci), tensor-train construction/evaluation (simplett)
+**Profile:** ITensors.jl persona + ndarray/NumPy persona (issue #584 verification)
+**Mode:** blind
+**Use Case:** (1) port a QuanticsTCI.jl/ITensors.jl script to Rust, (2) build and evaluate a TT from scratch
+**Expected Outcome:** (1) reproduces the Julia script using doc-shown APIs; (2) TT evaluates correctly
+**Verdict:** pass (both programs compile as-written against origin/main and run correctly)
+**Critical Issues:** 1 (stale 1-indexed claims in the downstream-usage guide, contradicting the mdBook)
+
+## Summary
+
+| Feature | Discoverable | Setup | Works | Expected Outcome Met | Doc Quality |
+|---------|-------------|-------|-------|---------------------|-------------|
+| quantics TCI (quanticstci) — ITensors persona | partial | yes | yes | yes | good (mdBook), stale (skills guide) |
+| TT build/eval (simplett) — ndarray persona | yes | yes | yes | yes | good |
+
+## Per-Feature Details
+
+### 1. quantics TCI port — ITensors.jl persona (blind)
+
+- **Role:** Julia / ITensors.jl / QuanticsTCI.jl power user (1-indexed, `cutoff` truncation habits).
+- **Use Case:** port `porting-target/quantics_tci_script.jl` (1D grid, 12 bits, f = sin(idx), cutoff 1e-8, evaluate at point 1025, sum, integral) to Rust.
+- **Gate:** the doer's program **compiles as-written** against origin/main (path dep) and runs correctly:
+  - `qtci(1025) = 0.7451734706822541` = `f(1025) = 0.7451734706822545` (exact to 1e-15)
+  - `errors.last() = 2.2e-16` (converged below the passed tolerance)
+  - sum and manual integral printed.
+  - The doer resolved the index-base contradiction toward the CI-checked mdBook (0-indexed, `&[usize]`, subtract 1) over the stale skills guide; the `f(idx+1)` formulation keeps the Julia values identical.
+- **Trap (a) rtol = sqrt(cutoff):** documented (conventions.md "rtol = sqrt(cutoff)", example cutoff=1e-10→rtol=1e-5) but **only for SVD truncation**; never shown applied to `QtciOptions::with_tolerance`. The doer passed the raw cutoff value (`with_tolerance(1e-8)`) and flagged the ambiguity (LOW-MEDIUM). The convergence check uses `errors.last() < tolerance`, so passing `1e-8` raw is self-consistent.
+- **Trap (b) index base:** **genuine intra-doc contradiction** — mdBook guides/conventions say 0-indexed `&[usize]` (correct, CI-checked); `skills/use-tensor4all-rs/SKILL.md` §4 + `references/crates.md` + `references/recipes.md` still say 1-indexed `&[i64]` (STALE after #582/#613). A user relying on the guide alone would pass 1-indexed values and get compile errors or off-by-one.
+
+### 2. TT construction + evaluation — ndarray persona (blind)
+
+- **Role:** Python/NumPy user (0-indexed, C-order priors), no tensor-network background.
+- **Use Case:** build f(i,j,k) = (i+1)(j+1)(k+1) as a rank-1 TT on 3×3×3, evaluate at three points.
+- **Gate:** the doer's program **compiles as-written** and runs correctly: f(0,0,0)=1, f(1,2,1)=12, f(2,2,2)=27 — all match.
+- **Conventions:** 0-indexing and column-major (`order="F"`) both explicitly documented; the doer found both and never hit a layout trap.
+- **Gaps (non-blocking):** `set3(left, site, right, value)` argument order is never stated in the docs (inferred, correct); `SimpleTensorTrain` has no `from_dense`/`from_array` bulk constructor (only core-level `IdxTensor::from_dense`); README examples are complete runnable `fn main()` programs (only need the git/path dependency).
+
+## Critical Issues
+
+1. **HIGH — stale 1-indexed quanticstci claims in `skills/use-tensor4all-rs/`.** `SKILL.md` §"Indexing base" and §104 ("Exception: quanticstci grid indices are 1-indexed"), `references/crates.md` (indices **1-indexed** (`1..=grid_size`)), `references/recipes.md` (`f = |idx: &[i64]|`, "1-indexed", off-by-one checklist "1-indexed (quanticstci) territory") all contradict the CI-checked mdBook (0-indexed, post-#582/#613). Must be updated to 0-indexed `&[usize]`.
+
+## Doc suggestions
+
+- Remove the quanticstci 1-indexed exception from `skills/use-tensor4all-rs/` (SKILL.md, crates.md, recipes.md); state that all tensor4all-rs indices are 0-indexed and QuanticsTCI.jl scripts subtract 1.
+- Show `rtol = sqrt(cutoff)` applied to `QtciOptions::with_tolerance` in one worked example (the conversion is documented but never applied to the option).
+- State the `set3(left, site, right, value)` argument order in the mdBook; consider a `SimpleTensorTrain` dense-from-Vec constructor (from_dense is core-level only).
+
+## Note (before/after framing)
+
+Initial run used a doc surface built from an in-progress local branch (pre-#582/#613) — those doers reported the mdBook itself as 1-indexed, which is an artifact, not a main-state finding. Re-run against origin/main. The single genuine stale surface is the skills guide (Critical 1); a follow-up PR fixes it, after which this measurement is the "after" baseline.

--- a/docs/tutorial-code/docs/tutorials/qtt_function_tutorial.md
+++ b/docs/tutorial-code/docs/tutorials/qtt_function_tutorial.md
@@ -133,8 +133,8 @@ Useful fields in this demo:
 
 - `tolerance`: stop once the approximation is accurate enough
 - `max_bond_dim`: upper bound on the bond dimension
-- `nrandominitpivot`: number of random initial pivots
-- `unfoldingscheme`: how the quantics dimensions are arranged
+- `n_random_init_pivot`: number of random initial pivots
+- `unfolding_scheme`: how the quantics dimensions are arranged
 
 ### `evaluate(...)`
 

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -44,7 +44,7 @@ Named `DynIndex` objects; orthogonality-center tracking; multiple canonical form
 - `SimpleTensorTrain::new(vec![t0, t1, ...])` from `IdxTensor` cores.
 - `.orthogonalize(site)`, `.orthogonalize_with(site, CanonicalForm::...)` (LU / CI forms).
 - `.truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol)).with_max_bond_dim(n))`.
-- `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, `.isortho()`, `.orthocenter()`, `.max_bond_dim()`.
+- `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, .is_ortho(), .ortho_center(), `.max_bond_dim()`.
 - `TruncateOptions`, `CanonicalForm`. `ContractOptions` / `LinsolveOptions` with `with_nsweeps(n)` (= `with_nhalfsweeps(2*n)`).
 - Build indices with `DynIndex::new_dyn(dim)` (site) and `DynIndex::new_bond(dim)?` (bond). `from_dense` data is column-major.
 
@@ -83,7 +83,7 @@ Quantics encoding (binary bits across sites) often yields far lower bond dims. P
   - `quanticscrossinterpolate_batched` — vector/tensor-valued `f`.
 - `DiscretizedGrid::builder(&[r_bits]).with_lower_bound(&[x0]).with_upper_bound(&[x1]).include_endpoint(bool).build()`.
 - `QtciOptions::default().with_tolerance(t).with_max_bond_dim(m).with_nrandominitpivot(k).with_unfoldingscheme(UnfoldingScheme::Interleaved)`.
-  - `nrandominitpivot` default 5; raise to 10–20 for multi-feature / high-dim.
+  - `n_random_init_pivot` default 5; raise to 10–20 for multi-feature / high-dim.
 - `QuanticsTensorCI2`: `.evaluate(&[idx])`, `.sum()`, `.integral()` (left Riemann sum; O(h)), `.tci()`.
 - Interleaved multivariate encoding: site `n` encodes one bit per variable, local dim `2^num_vars`.
 

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -44,7 +44,7 @@ Named `DynIndex` objects; orthogonality-center tracking; multiple canonical form
 - `SimpleTensorTrain::new(vec![t0, t1, ...])` from `IdxTensor` cores.
 - `.orthogonalize(site)`, `.orthogonalize_with(site, CanonicalForm::...)` (LU / CI forms).
 - `.truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(rtol)).with_max_bond_dim(n))`.
-- `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, .is_ortho(), .ortho_center(), `.max_bond_dim()`.
+- `.inner(&other)` — `<self|other>`, conjugates left operand. `.norm()`, `.is_ortho()`, `.ortho_center()`, `.max_bond_dim()`.
 - `TruncateOptions`, `CanonicalForm`. `ContractOptions` / `LinsolveOptions` with `with_nsweeps(n)` (= `with_nhalfsweeps(2*n)`).
 - Build indices with `DynIndex::new_dyn(dim)` (site) and `DynIndex::new_bond(dim)?` (bond). `from_dense` data is column-major.
 

--- a/skills/use-tensor4all-rs/references/recipes.md
+++ b/skills/use-tensor4all-rs/references/recipes.md
@@ -232,7 +232,7 @@ let mut tt = SimpleTensorTrain::new(vec![t0, t1])?;
 
 let norm_before = tt.norm();
 tt.orthogonalize(1)?;
-assert!(tt.isortho());
+assert!(tt.is_ortho());
 tt.truncate(&TruncateOptions::svd()
     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-10))
     .with_max_bond_dim(2))?;
@@ -325,7 +325,7 @@ use tensor4all_hdf5::{load_mps, save_mps};
 ## Convergence debugging checklist
 
 - `errors.last()` plateaus above `tolerance`: raise `max_bond_dim` (needs higher rank), raise `max_iter` (more sweeps), or pick better initial pivots where `|f|` is large (`opt_first_pivot`).
-- Quantics discrete: all `sizes` equal and powers of 2; raise `nrandominitpivot` (10–20) for multi-feature / high-dim.
+- Quantics discrete: all `sizes` equal and powers of 2; raise `n_random_init_pivot` (10–20) for multi-feature / high-dim.
 - Off-by-one at a boundary: all tensor4all-rs indices are 0-indexed — QuanticsTCI.jl scripts must subtract 1 from grid indices.
 - Tolerance mismatch with Julia: `rtol = sqrt(cutoff)`.
 - Running in a debug build (no `--release`): tensor linalg is orders of magnitude slower — always run TCI/DMRG in release.


### PR DESCRIPTION
Closes #616.

Completes the Phase-4 sweep that umbrella #566 claimed DONE but never fully
executed:

**Renames** (snake_case primary + `#[doc(alias)]` on the old name):
- core: `hasinds` → `has_inds`, `hascommoninds` → `has_common_inds`
- itensorlike: `isortho` → `is_ortho`, `orthocenter` → `ortho_center`
- quanticstci `QtciOptions`: `maxiter` → `max_iter`,
  `nrandominitpivot` → `n_random_init_pivot`,
  `unfoldingscheme` → `unfolding_scheme`

The `with_*` builders and singular `hasind` are not in the #616 enumeration
and are unchanged.

**Removal** (scalar-suffixed entry points, per AGENTS.md generic-API rule):
- `Storage::from_dense_f64_col_major` / `from_dense_c64_col_major` removed;
  the generic `from_dense_col_major<T>` was already the drop-in.

**Docs**: tensor-train/tci guides, skills, qtt tutorial, #566 PR4 ledger
residual notes; `docs/api` regenerated. Julia-side examples
(Tensor4all.jl API) intentionally untouched.

Design and review: `docs/design/issue-616-rename-sweep.md` — luna design
review (needs-fix → fixed → approved) and diff review (needs-fix → fixed →
Correct-to-merge).

Local gates: fmt, clippy `-D warnings`, nextest workspace (2824 passed),
doctests, mdbook, repository-rules-review (pass), `git diff --check` clean.