### PR TITLE
Make tensor4all-hdf5 thread-safe by construction (#606)

### DIFF
--- a/crates/tensor4all-hdf5/README.md
+++ b/crates/tensor4all-hdf5/README.md
@@ -2,6 +2,17 @@
 
 HDF5 serialization for tensor4all-rs, compatible with ITensors.jl / ITensorMPS.jl file formats.
 
+**Thread safety.** The HDF5 C library is not thread-safe. All public
+`save_*` / `append_*` / `load_*` calls are serialized through one
+process-wide lock, so the crate is safe to call concurrently by construction
+(even on distinct files). The crate also disables HDF5 OS file locking
+(`HDF5_USE_FILE_LOCKING=FALSE`, set once unless you set it yourself) because
+the OS lock can outlive `H5Fclose` and a serialized reopen of the same path
+would otherwise fail with `errno = 35`. This environment variable is
+process-global; set it yourself if you need cross-process write locking.
+Direct use of the re-exported low-level hdf5-rt passthroughs bypasses the
+crate lock.
+
 ## Key Types
 
 - `save_itensor()` / `load_itensor()` — read/write `IdxTensor` as ITensors.jl `ITensor`

--- a/crates/tensor4all-hdf5/src/backend.rs
+++ b/crates/tensor4all-hdf5/src/backend.rs
@@ -40,3 +40,47 @@ pub(crate) fn attribute_exists(group: &Group, name: &str) -> anyhow::Result<bool
             .context("H5Aexists failed")
     })
 }
+
+/// Disable HDF5's OS file locking once, before any HDF5 call the crate makes,
+/// unless the caller already set `HDF5_USE_FILE_LOCKING` explicitly.
+///
+/// The HDF5 C library is not thread-safe and its per-file OS locks have a
+/// release window that outlives `H5Fclose`, so even fully serialized calls can
+/// hit `errno = 35` (EAGAIN) when the same path is reopened immediately. With
+/// file locking disabled, a process-wide call lock (see [`hdf5_sync`]) is
+/// sufficient. The environment variable is process-global: it also affects any
+/// other HDF5 usage in the process. Callers who want locking keep control by
+/// setting `HDF5_USE_FILE_LOCKING` themselves (their value wins).
+static FILE_LOCKING_INIT: std::sync::Once = std::sync::Once::new();
+
+fn disable_file_locking_once() {
+    FILE_LOCKING_INIT.call_once(|| {
+        if std::env::var_os("HDF5_USE_FILE_LOCKING").is_none() {
+            // Safe on this crate's edition (2021). Runs before the first HDF5
+            // init/open the crate triggers, so it takes effect regardless of
+            // when the C library parses the variable.
+            std::env::set_var("HDF5_USE_FILE_LOCKING", "FALSE");
+        }
+    });
+}
+
+/// Run one whole public HDF5 operation under the backend's process-wide
+/// reentrant lock.
+///
+/// This is the crate's single thread-safety choke point: every public
+/// `save_*`/`load_*`/`append_*` entry point wraps its body in [`hdf5_sync`]
+/// and no internal helper locks on its own. The backend lock is reentrant, so
+/// nested HDF5 calls inside the operation are safe, and it also serializes
+/// against direct hdf5-metno/hdf5-rt usage elsewhere in the process that goes
+/// through the same lock.
+pub(crate) fn hdf5_sync<T>(f: impl FnOnce() -> T) -> T {
+    disable_file_locking_once();
+    #[cfg(all(feature = "link", not(feature = "runtime-loading")))]
+    {
+        hdf5_metno::sync::sync(f)
+    }
+    #[cfg(feature = "runtime-loading")]
+    {
+        hdf5_rt::sync::sync(f)
+    }
+}

--- a/crates/tensor4all-hdf5/src/backend.rs
+++ b/crates/tensor4all-hdf5/src/backend.rs
@@ -21,8 +21,8 @@ pub use hdf5_rt::{types, Attribute, Dataset, File, Group, LinkType, Result};
 // H5Aexists checks one known name without enumerating or allocating all attributes.
 #[cfg(all(feature = "link", not(feature = "runtime-loading")))]
 pub(crate) fn attribute_exists(group: &Group, name: &str) -> anyhow::Result<bool> {
-    let name = CString::new(name).context("HDF5 attribute name contains NUL")?;
-    hdf5_metno::sync::sync(|| {
+    hdf5_sync(|| {
+        let name = CString::new(name).context("HDF5 attribute name contains NUL")?;
         let result = unsafe { hdf5_metno_sys::h5a::H5Aexists(group.id(), name.as_ptr()) };
         hdf5_metno::h5check(result)
             .map(|result| result > 0)
@@ -32,8 +32,8 @@ pub(crate) fn attribute_exists(group: &Group, name: &str) -> anyhow::Result<bool
 
 #[cfg(feature = "runtime-loading")]
 pub(crate) fn attribute_exists(group: &Group, name: &str) -> anyhow::Result<bool> {
-    let name = CString::new(name).context("HDF5 attribute name contains NUL")?;
-    hdf5_rt::sync::sync(|| {
+    hdf5_sync(|| {
+        let name = CString::new(name).context("HDF5 attribute name contains NUL")?;
         let result = unsafe { hdf5_rt::sys::h5a::H5Aexists(group.id(), name.as_ptr()) };
         hdf5_rt::h5check(result)
             .map(|result| result > 0)

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -205,9 +205,11 @@ pub fn save_itensor(
     name: &str,
     tensor: &IdxTensor,
 ) -> std::result::Result<(), Hdf5Error> {
-    let file = File::create(filepath)?;
-    let group = file.create_group(name)?;
-    itensor::write_itensor(&group, tensor).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::create(filepath)?;
+        let group = file.create_group(name)?;
+        itensor::write_itensor(&group, tensor).map_err(Hdf5Error::from)
+    })
 }
 
 /// Append a [`IdxTensor`] as an ITensors.jl-compatible `ITensor` to an HDF5 file.
@@ -246,9 +248,11 @@ pub fn append_itensor(
     name: &str,
     tensor: &IdxTensor,
 ) -> std::result::Result<(), Hdf5Error> {
-    let file = File::append(filepath)?;
-    let group = file.create_group(name)?;
-    itensor::write_itensor(&group, tensor).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::append(filepath)?;
+        let group = file.create_group(name)?;
+        itensor::write_itensor(&group, tensor).map_err(Hdf5Error::from)
+    })
 }
 
 /// Load a [`IdxTensor`] from an ITensors.jl-compatible `ITensor` in an HDF5 file.
@@ -302,9 +306,11 @@ pub fn append_itensor(
 /// # }
 /// ```
 pub fn load_itensor(filepath: &str, name: &str) -> std::result::Result<IdxTensor, Hdf5Error> {
-    let file = File::open(filepath)?;
-    let group = file.group(name)?;
-    itensor::read_itensor(&group).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::open(filepath)?;
+        let group = file.group(name)?;
+        itensor::read_itensor(&group).map_err(Hdf5Error::from)
+    })
 }
 
 /// Save a [`TensorTrain`] as an ITensorMPS.jl-compatible `MPS` in an HDF5 file.
@@ -361,9 +367,11 @@ pub fn save_mps(
     name: &str,
     tt: &TensorTrain,
 ) -> std::result::Result<(), Hdf5Error> {
-    let file = File::create(filepath)?;
-    let group = file.create_group(name)?;
-    mps::write_mps(&group, tt).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::create(filepath)?;
+        let group = file.create_group(name)?;
+        mps::write_mps(&group, tt).map_err(Hdf5Error::from)
+    })
 }
 
 /// Append a [`TensorTrain`] as an ITensorMPS.jl-compatible `MPS` to an HDF5 file.
@@ -406,9 +414,11 @@ pub fn append_mps(
     name: &str,
     tt: &TensorTrain,
 ) -> std::result::Result<(), Hdf5Error> {
-    let file = File::append(filepath)?;
-    let group = file.create_group(name)?;
-    mps::write_mps(&group, tt).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::append(filepath)?;
+        let group = file.create_group(name)?;
+        mps::write_mps(&group, tt).map_err(Hdf5Error::from)
+    })
 }
 
 /// Load a [`TensorTrain`] from an ITensorMPS.jl-compatible `MPS` in an HDF5 file.
@@ -462,9 +472,11 @@ pub fn append_mps(
 /// # }
 /// ```
 pub fn load_mps(filepath: &str, name: &str) -> std::result::Result<TensorTrain, Hdf5Error> {
-    let file = File::open(filepath)?;
-    let group = file.group(name)?;
-    mps::read_mps(&group).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::open(filepath)?;
+        let group = file.group(name)?;
+        mps::read_mps(&group).map_err(Hdf5Error::from)
+    })
 }
 
 /// Save a [`TreeTN`] as a tensor4all-rs `TreeTN` in an HDF5 file.
@@ -527,9 +539,11 @@ pub fn save_treetn<V>(
 where
     V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
 {
-    let file = File::create(filepath)?;
-    let group = file.create_group(name)?;
-    treetn::write_treetn(&group, tn).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::create(filepath)?;
+        let group = file.create_group(name)?;
+        treetn::write_treetn(&group, tn).map_err(Hdf5Error::from)
+    })
 }
 
 /// Append a [`TreeTN`] to an HDF5 file.
@@ -551,9 +565,11 @@ pub fn append_treetn<V>(
 where
     V: ToString + Clone + Hash + Eq + Send + Sync + Debug,
 {
-    let file = File::append(filepath)?;
-    let group = file.create_group(name)?;
-    treetn::write_treetn(&group, tn).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::append(filepath)?;
+        let group = file.create_group(name)?;
+        treetn::write_treetn(&group, tn).map_err(Hdf5Error::from)
+    })
 }
 
 /// Load a [`TreeTN`] from a tensor4all-rs `TreeTN` in an HDF5 file.
@@ -579,7 +595,9 @@ where
     V: FromStr + Ord + Clone + Hash + Eq + Send + Sync + Debug,
     V::Err: std::fmt::Display,
 {
-    let file = File::open(filepath)?;
-    let group = file.group(name)?;
-    treetn::read_treetn(&group).map_err(Hdf5Error::from)
+    backend::hdf5_sync(|| {
+        let file = File::open(filepath)?;
+        let group = file.group(name)?;
+        treetn::read_treetn(&group).map_err(Hdf5Error::from)
+    })
 }

--- a/crates/tensor4all-hdf5/src/lib.rs
+++ b/crates/tensor4all-hdf5/src/lib.rs
@@ -4,6 +4,31 @@
 //! using the HDF5 format compatible with ITensors.jl / ITensorMPS.jl. Files
 //! written by this crate can be read by ITensors.jl and vice versa.
 //!
+//! # Thread safety
+//!
+//! The HDF5 C library is not thread-safe. Every public
+//! [`save_*`](save_itensor) / [`append_*`](append_itensor) / [`load_*`](load_itensor)
+//! call is serialized through one process-wide lock (the hdf5 binding's
+//! reentrant mutex), so the crate is **safe to call concurrently by
+//! construction** — even on distinct files. The lock covers the whole
+//! operation (open, read/write, close), not individual HDF5 calls.
+//!
+//! The crate also disables HDF5's OS file locking by setting
+//! `HDF5_USE_FILE_LOCKING=FALSE` once, before the first HDF5 call, unless the
+//! caller already set that variable (their value wins). This closes the
+//! same-path lock-release window (a writer's OS lock can outlive `H5Fclose`,
+//! so a serialized reopen of the same path could otherwise fail with
+//! `errno = 35`). The variable is process-global and affects any other HDF5
+//! usage in the process; callers who need cross-process write protection
+//! should set it themselves.
+//!
+//! New public functions that touch HDF5 MUST wrap their body in
+//! [`backend::hdf5_sync`] — the public boundary is the crate's single
+//! thread-safety choke point; internal helpers never lock on their own, they
+//! run under the caller's lock. Direct use of the re-exported low-level
+//! hdf5-rt passthroughs (`hdf5_init`, ...) bypasses the lock and is outside
+//! this guarantee.
+//!
 //! # Supported types
 //!
 //! | Rust type | HDF5 schema | Julia equivalent |

--- a/crates/tensor4all-hdf5/tests/test_hdf5.rs
+++ b/crates/tensor4all-hdf5/tests/test_hdf5.rs
@@ -1069,3 +1069,45 @@ fn test_treetn_missing_child_group_error() {
 
     std::fs::remove_file(&path).ok();
 }
+
+/// Regression for #606: the HDF5 C library is not thread-safe and its OS
+/// file locks can outlive H5Fclose, so concurrent crate calls used to fail
+/// intermittently with `H5Fopen(): unable to lock file, errno = 35`.
+/// The crate now serializes every public call through one process-wide lock
+/// and disables HDF5 file locking, so this must not happen.
+#[test]
+fn concurrent_save_load_roundtrips() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+
+    let thread_count = 4;
+    let iterations = 5;
+    let handles: Vec<_> = (0..thread_count)
+        .map(|t| {
+            let path = path.clone();
+            std::thread::spawn(move || {
+                for i in 0..iterations {
+                    let file = path.join(format!("thread{t}_iter{i}.h5"));
+                    let file = file.to_str().unwrap();
+                    let data: Vec<f64> = (0..4).map(|k| (t * 100 + i * 10 + k) as f64).collect();
+                    let tensor = IdxTensor::from_dense(
+                        vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)],
+                        data.clone(),
+                    )
+                    .unwrap();
+
+                    // save then immediately load the SAME path: the
+                    // errno-35 window that serialization alone did not cover.
+                    save_itensor(file, "t", &tensor).unwrap();
+                    let loaded = load_itensor(file, "t").unwrap();
+                    let roundtrip = loaded.to_vec::<f64>().unwrap();
+                    assert_eq!(roundtrip, data, "thread {t} iteration {i} roundtrip");
+                }
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}

--- a/docs/book/src/guides/hdf5-serialization.md
+++ b/docs/book/src/guides/hdf5-serialization.md
@@ -83,3 +83,25 @@ assert_eq!(loaded.node_names(), vec!["left".to_string(), "center".to_string(), "
   TreeTN representation.
 - **General trees**: `save_treetn` / `load_treetn` is the only option — no
   upstream ITensorNetworks.jl format exists.
+
+## Thread safety
+
+The HDF5 C library is not thread-safe, and `tensor4all-hdf5` serializes every
+public `save_*` / `append_*` / `load_*` call through one process-wide lock
+(the hdf5 binding's reentrant mutex), so the crate is **safe to call
+concurrently by construction** — including on distinct files. The lock covers
+the whole operation (open, write/read, close), not individual HDF5 calls.
+
+In addition, the crate disables HDF5's OS file locking by setting
+`HDF5_USE_FILE_LOCKING=FALSE` once, before the first HDF5 call, unless you
+already set that variable (your value wins). This is needed because a writer's
+exclusive OS file lock can outlive `H5Fclose`, so a serialized reopen of the
+*same* path can otherwise still fail with `errno = 35` (EAGAIN). The
+environment variable is process-global: it also affects any other HDF5 usage
+in the process. If you need cross-process write protection, set
+`HDF5_USE_FILE_LOCKING` yourself (e.g. `TRUE`) — but then concurrent
+same-path open-after-close within one process may fail again, so coordinate
+access to shared paths.
+
+Direct use of the re-exported low-level HDF5 passthroughs (hdf5-rt's
+`hdf5_init` etc.) bypasses the crate's lock and is outside this guarantee.

--- a/docs/design/issue-606-hdf5-threadsafe.md
+++ b/docs/design/issue-606-hdf5-threadsafe.md
@@ -1,0 +1,140 @@
+# Design: #606 — make tensor4all-hdf5 thread-safe by construction (central lock)
+
+Status: user-approved direction (2026-08): "Rust 側で排他するのがいい" (internal
+Rust-side serialization) + "一括して管理" (one central mechanism, not ad hoc).
+Review by luna (read-only): design pre-review + diff post-review.
+
+## Problem
+
+The HDF5 C library is not thread-safe. The hdf5-metno binding locks each raw
+H5* call individually (`h5lock!` → process-wide reentrant mutex), but the
+lock is released between calls, so a full save/load operation can interleave
+with another thread's operation. Empirically (lingrui96, gw-rs): 2-3 of ~71
+parallel tests fail with `H5Fopen(): unable to lock file, errno = 35`
+(EAGAIN), and serializing calls alone does NOT cover the same-path
+open-after-close lock-release window — `HDF5_USE_FILE_LOCKING=FALSE` was
+needed too. Nothing in the crate docs mentions threading.
+
+## Fix (one central mechanism)
+
+### 1. Single choke point: `hdf5_sync` wrapper in `backend.rs`
+
+```rust
+// backend.rs
+static FILE_LOCKING_INIT: std::sync::Once = std::sync::Once::new();
+
+pub(crate) fn hdf5_sync<T>(f: impl FnOnce() -> T) -> T {
+    // Disable HDF5's OS file locking once, before any HDF5 call, unless the
+    // caller set HDF5_USE_FILE_LOCKING explicitly. Closes the same-path
+    // lock-release window (errno 35) that serialization alone does not cover.
+    FILE_LOCKING_INIT.call_once(|| {
+        if std::env::var_os("HDF5_USE_FILE_LOCKING").is_none() {
+            // safe: edition 2021
+            std::env::set_var("HDF5_USE_FILE_LOCKING", "FALSE");
+        }
+    });
+    #[cfg(all(feature = "link", not(feature = "runtime-loading")))]
+    { hdf5_metno::sync::sync(f) }
+    #[cfg(feature = "runtime-loading")]
+    { hdf5_rt::sync::sync(f) }
+}
+```
+
+- Uses the hdf5 crate's own process-wide REENTRANT lock: nested internal
+  calls are safe, and the crate's operations also serialize against any
+  direct hdf5-crate usage in the process.
+- The lock is taken exactly once per public call and held for the WHOLE
+  operation (including handle drops), which is the property the per-call
+  `h5lock!` lacks.
+
+### 2. All 9 public entry points wrap in `hdf5_sync`
+
+`save_itensor`, `append_itensor`, `load_itensor`, `save_mps`, `append_mps`,
+`load_mps`, `save_treetn`, `append_treetn`, `load_treetn` (all in lib.rs) get
+their body wrapped: `hdf5_sync(|| { ... })`. Internal helper functions NEVER
+lock — the public boundary is the single choke point, so future public
+functions must also wrap (enforced by a doc note + the crate rule).
+
+The crate also re-exports hdf5-rt passthrough items (`hdf5_init`,
+`hdf5_is_initialized`, `hdf5_library_path`, sys symbols) for the
+runtime-loading backend; those bypass the serialization guarantee and are
+documented as outside it (callers who use them directly own their own
+thread safety).
+
+### 3. Documentation
+
+- `lib.rs` module doc + crate README: thread-safe by construction — all
+  public calls are serialized process-wide (I/O-bound, contention negligible);
+  HDF5 OS file locking is disabled by default (`HDF5_USE_FILE_LOCKING=FALSE`),
+  set once lazily unless the caller set it explicitly; the explicit-env-var
+  note (callers who set it keep their value; multi-process writers should set
+  it themselves); rule: every new public function must go through
+  `hdf5_sync`.
+- `docs/book/src/guides/hdf5-serialization.md`: same notes + the downstream
+  story (why serialization alone was insufficient).
+
+### 4. Regression test
+
+A threaded smoke test in `crates/tensor4all-hdf5/tests/` (integration):
+- N threads (e.g. 4) each do save+load of distinct temp files, asserting the
+  roundtrip equals the input (mirrors the gw-rs reproducer);
+- a same-path save-then-load sequence within each thread's iteration (the
+  errno-35 window case). The lock serializes whole calls, so each save/load
+  is atomic, but the test does NOT assume cross-thread atomicity — each
+  thread owns its own path sequence.
+Keep iterations modest (I/O-bound; HDF5 tests run in a dedicated CI job).
+
+## Verified facts (origin/main)
+
+- 9 public entry points, all in lib.rs; internal helpers (mps.rs, treetn.rs,
+  itensor.rs, index.rs) are pub(crate)/private and reached only from within
+  them. (hdf5-rt passthrough re-exports like `hdf5_init` are backend items,
+  not serialized entry points.)
+- `File::open_as`/`create` lock each raw call via `h5lock!` but not whole
+  operations (hdf5-metno-0.12.6 src/hl/file.rs, macros.rs; the sys LOCK is a
+  parking_lot ReentrantMutex — reentrancy makes nested `sync::sync` safe).
+  hdf5-rt (git tensor4all/hdf5-rt#19fb644) has the identical sync::sync +
+  ReentrantMutex LOCK design.
+- No FAPL-level file-locking control is exposed by the high-level APIs
+  (FileAccessBuilder has no setters) → the env var is the only central
+  mechanism. Ordering guarantee: `hdf5_sync` sets HDF5_USE_FILE_LOCKING at
+  its very top, BEFORE calling the backend `sync::sync` (whose first act is
+  to force library init / H5open), so the variable is in place before any
+  HDF5 initialization or file open the crate triggers — regardless of
+  whether HDF5 parses it at library init or at first file open. The only
+  way to miss it is initializing HDF5 outside the crate (re-exported
+  `hdf5_init` passthrough), documented as outside the guarantee.
+- Both backends (`link`/hdf5-metno, `runtime-loading`/hdf5-rt) expose
+  `sync::sync` (backend.rs already uses it for `attribute_exists`).
+- Workspace edition 2021 → `std::env::set_var` is safe. No other workspace
+  code sets HDF5_USE_FILE_LOCKING.
+
+## Trade-offs / risks
+
+- Setting `HDF5_USE_FILE_LOCKING=FALSE` is a PROCESS-GLOBAL side effect: it
+  affects all HDF5 usage in the process (including direct hdf5-metno/
+  hdf5-rt users and other bindings), not just this crate. It weakens
+  cross-PROCESS write protection for files opened with HDF5; documented.
+  Users who want locking can set the env var themselves (their value wins;
+  only set if unset). Explicitly, callers that set it keep their value, and
+  pre-initialized HDF5 (via the re-exported `hdf5_init` passthrough) is
+  outside the guarantee.
+- `sync::sync` silences HDF5 stderr printing while the lock is held; the
+  crate's `Hdf5Error` conversion reads the error stack and is unaffected.
+- Code that uses hdf5-metno/hdf5-rt directly (not via this crate) is not
+  serialized by this crate's lock; the env-var change still applies to it
+  process-wide.
+
+## Verification
+
+- `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo nextest run --release --workspace --exclude tensor4all-hdf5` +
+  `cargo test --release -p tensor4all-hdf5` (threaded test included)
+- `cargo test --doc --release --workspace`, `./scripts/test-mdbook.sh`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree`
+
+## Review verdicts
+
+- Design (pre-implementation), luna: TBD.
+- Diff (post-implementation), luna: TBD.


### PR DESCRIPTION
Closes #606.

The HDF5 C library is not thread-safe and its OS file locks can outlive
`H5Fclose`, so concurrent crate calls — even on distinct files — failed
intermittently with `H5Fopen(): unable to lock file, errno = 35` (EAGAIN),
and serialization alone did not cover the same-path reopen window.

Fix, centrally managed (one process-wide lock at the public boundary, no
ad hoc locking):

- `backend::hdf5_sync`: runs each whole operation under the backend's
  process-wide reentrant lock (hdf5-metno / hdf5-rt `sync::sync`), after a
  one-time lazy `HDF5_USE_FILE_LOCKING=FALSE` set (unless the caller set it;
  their value wins). The lock also coordinates with direct hdf5 use.
- All 9 public functions (`save_*` / `append_*` / `load_*` × itensor/mps/
  treetn) wrap their body; `attribute_exists` uses the same wrapper;
  internal helpers never lock. Module doc states the rule for new public fns.
- Docs: crate module doc + README + `hdf5-serialization` guide — thread-safe
  by construction, process-global env-var caveat, cross-process locking
  trade-off, low-level passthrough re-exports outside the guarantee.
- Regression test: 4 threads × 5 iterations of save + immediate same-path
  load on distinct files (the gw-rs errno-35 reproducer pattern).

Design and review: `docs/design/issue-606-hdf5-threadsafe.md` — luna design
review (needs-fix ×2 → fixed → approved) and diff review (needs-fix →
fixed → Correct-to-merge).

Local gates: fmt, clippy `-D warnings`, nextest (2778 non-HDF5) + HDF5
(46 integration tests incl. the new concurrent test + 10 doctests), mdbook,
repository-rules-review (pass), `git diff --check` clean.