### PR TITLE
Make simplett contract_fit fail loudly (#571)

### DIFF
--- a/crates/tensor4all-simplett/src/mpo/contract_fit.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit.rs
@@ -1,34 +1,34 @@
-//! Variational fitting algorithm for MPO contraction
+//! Variational fitting algorithm for MPO contraction.
 //!
-//! This module implements the variational fitting (DMRG-like) algorithm
-//! for computing the product of two MPOs with controlled bond dimension.
+//! The variational update is not implemented for the simplett MPO type yet.
+//! [`contract_fit`] therefore reports [`MPOError::Unsupported`] instead of
+//! returning a naive contraction under the misleading `Fit` label.
 
-use super::contraction::ContractionOptions;
 use super::error::{MPOError, Result};
 use super::factorize::{FactorizeMethod, SVDScalar};
 use super::mpo::MPO;
-use super::site_mpo::SiteMPO;
-use super::types::{Tensor4, Tensor4Ops};
 use crate::einsum_helper::EinsumScalar;
 
-/// Options for the variational fit algorithm
+/// Configuration reserved for the simplett variational MPO fitting algorithm.
+///
+/// [`contract_fit`] currently returns [`MPOError::Unsupported`] for valid
+/// inputs, so these fields have no effect until the variational update is
+/// implemented. Use [`super::contract_naive::contract_naive`] or
+/// [`super::contract_zipup::contract_zipup`] for an available contraction.
 #[derive(Debug, Clone)]
 pub struct FitOptions {
     /// Relative truncation tolerance at each step, forwarded to
-    /// [`FactorizeOptions::tolerance`](super::factorize::FactorizeOptions::tolerance).
-    ///
-    /// Singular values smaller than `tolerance * sigma_max` are discarded at
-    /// each bond, where `sigma_max` is the largest singular value of that
-    /// bond's matrix. The threshold is invariant under a global rescaling of
-    /// the operators being contracted.
+    /// [`FactorizeOptions::tolerance`](super::factorize::FactorizeOptions::tolerance)
+    /// once fitting is implemented.
     pub tolerance: f64,
-    /// Maximum bond dimension. `None` means no limit.
+    /// Maximum bond dimension. `None` means no limit once fitting is
+    /// implemented.
     pub max_bond_dim: Option<usize>,
-    /// Maximum number of sweeps
+    /// Maximum number of sweeps once fitting is implemented.
     pub max_sweeps: usize,
-    /// Convergence tolerance (stop if change < this)
+    /// Convergence tolerance once fitting is implemented.
     pub convergence_tol: f64,
-    /// Factorization method
+    /// Factorization method once fitting is implemented.
     pub factorize_method: FactorizeMethod,
 }
 
@@ -44,30 +44,29 @@ impl Default for FitOptions {
     }
 }
 
-/// Perform variational fitting contraction of two MPOs
+/// Attempt variational fitting of the product of two MPOs.
 ///
-/// This computes C = A * B using a variational (DMRG-like) algorithm
-/// that alternates between sweeping left-to-right and right-to-left,
-/// optimizing two sites at a time.
+/// The simplett variational update is not implemented. This function fails
+/// loudly rather than returning the naive contraction as if it were a fitted
+/// result.
 ///
 /// # Arguments
-/// * `mpo_a` - First MPO
-/// * `mpo_b` - Second MPO
-/// * `options` - Fitting options
-/// * `initial` - Optional initial guess (if None, uses naive contraction)
+/// * `mpo_a` - First MPO.
+/// * `mpo_b` - Second MPO.
+/// * `options` - Reserved fitting options; currently ignored after validation.
+/// * `initial` - Reserved initial guess; currently ignored after validation.
 ///
-/// # Returns
-/// The contracted MPO C with bond dimension controlled by options
 /// # Errors
 ///
-/// Returns an error when the contraction or operation fails (a shape or
-/// /// index mismatch, or a backend failure).
-///
+/// Returns [`MPOError::LengthMismatch`] or
+/// [`MPOError::SharedDimensionMismatch`] for invalid inputs. For every valid
+/// input, including an empty MPO, returns [`MPOError::Unsupported`] until the
+/// variational update is implemented.
 pub fn contract_fit<T: SVDScalar + EinsumScalar>(
     mpo_a: &MPO<T>,
     mpo_b: &MPO<T>,
-    options: &FitOptions,
-    initial: Option<MPO<T>>,
+    _options: &FitOptions,
+    _initial: Option<MPO<T>>,
 ) -> Result<MPO<T>>
 where
     <T as num_complex::ComplexFloat>::Real: Into<f64>,
@@ -79,14 +78,7 @@ where
         });
     }
 
-    if mpo_a.is_empty() {
-        return Ok(MPO::from_tensors_unchecked(Vec::new()));
-    }
-
-    let n = mpo_a.len();
-
-    // Validate shared dimensions
-    for i in 0..n {
+    for i in 0..mpo_a.len() {
         let (_, s2_a) = mpo_a.site_dim(i);
         let (s1_b, _) = mpo_b.site_dim(i);
         if s2_a != s1_b {
@@ -98,289 +90,9 @@ where
         }
     }
 
-    // Initialize the result
-    let result = if let Some(init) = initial {
-        SiteMPO::from_mpo(init, 0)?
-    } else {
-        // Use naive contraction as initial guess, then compress
-        let naive_opts = ContractionOptions {
-            tolerance: options.tolerance,
-            max_bond_dim: options.max_bond_dim,
-            factorize_method: options.factorize_method,
-        };
-        let naive_result = super::contract_naive::contract_naive(mpo_a, mpo_b, Some(naive_opts))?;
-        SiteMPO::from_mpo(naive_result, 0)?
-    };
-
-    // For single or two-site systems, return immediately
-    if n <= 2 {
-        return Ok(result.into_mpo());
-    }
-
-    // Build left and right environments
-    let mut left_envs: Vec<Option<Environment<T>>> = vec![None; n];
-    let mut right_envs: Vec<Option<Environment<T>>> = vec![None; n];
-
-    // Initialize boundary environments
-    left_envs[0] = Some(Environment::identity(1, 1, 1));
-    right_envs[n - 1] = Some(Environment::identity(1, 1, 1));
-
-    // Build initial right environments
-    for i in (1..n).rev() {
-        let next_env = require_environment(&right_envs, i, "right")?;
-        let env = build_right_environment(
-            mpo_a.site_tensor(i),
-            mpo_b.site_tensor(i),
-            result.site_tensor(i),
-            next_env,
-        )?;
-        right_envs[i - 1] = Some(env);
-    }
-
-    let mut current = result;
-    let mut _prev_norm = f64::INFINITY;
-
-    // Main optimization loop
-    for _sweep in 0..options.max_sweeps {
-        // Forward sweep (left to right)
-        for i in 0..(n - 1) {
-            // Update two-site core at positions i and i+1
-            let _updated = update_two_site_core(
-                mpo_a,
-                mpo_b,
-                &mut current,
-                i,
-                &left_envs,
-                &right_envs,
-                options,
-            )?;
-
-            // Update left environment at i+1
-            let prev_env = require_environment(&left_envs, i, "left")?;
-            let env = build_left_environment(
-                mpo_a.site_tensor(i),
-                mpo_b.site_tensor(i),
-                current.site_tensor(i),
-                prev_env,
-            )?;
-            left_envs[i + 1] = Some(env);
-        }
-
-        // Backward sweep (right to left)
-        for i in (1..n).rev() {
-            // Update two-site core at positions i-1 and i
-            let _updated = update_two_site_core(
-                mpo_a,
-                mpo_b,
-                &mut current,
-                i - 1,
-                &left_envs,
-                &right_envs,
-                options,
-            )?;
-
-            // Update right environment at i-1
-            if i > 0 {
-                let next_env = require_environment(&right_envs, i, "right")?;
-                let env = build_right_environment(
-                    mpo_a.site_tensor(i),
-                    mpo_b.site_tensor(i),
-                    current.site_tensor(i),
-                    next_env,
-                )?;
-                right_envs[i - 1] = Some(env);
-            }
-        }
-
-        // Check convergence
-        // TODO: Implement proper convergence check using norm difference
-    }
-
-    Ok(current.into_mpo())
-}
-
-/// Environment tensor for variational algorithm
-#[derive(Debug, Clone)]
-struct Environment<T> {
-    /// Shape: (link_result, link_a, link_b)
-    data: Vec<T>,
-    dim_result: usize,
-    dim_a: usize,
-    dim_b: usize,
-}
-
-impl<T: SVDScalar> Environment<T>
-where
-    <T as num_complex::ComplexFloat>::Real: Into<f64>,
-{
-    fn identity(dim_result: usize, dim_a: usize, dim_b: usize) -> Self {
-        let mut data = vec![T::zero(); dim_result * dim_a * dim_b];
-        // Set diagonal elements to 1
-        let min_dim = dim_result.min(dim_a).min(dim_b);
-        for i in 0..min_dim {
-            data[(i * dim_a + i) * dim_b + i] = T::one();
-        }
-        // Actually for identity, we just want a single 1.0
-        if dim_result == 1 && dim_a == 1 && dim_b == 1 {
-            data[0] = T::one();
-        }
-        Self {
-            data,
-            dim_result,
-            dim_a,
-            dim_b,
-        }
-    }
-
-    fn get(&self, r: usize, a: usize, b: usize) -> T {
-        self.data[(r * self.dim_a + a) * self.dim_b + b]
-    }
-
-    fn set(&mut self, r: usize, a: usize, b: usize, val: T) {
-        self.data[(r * self.dim_a + a) * self.dim_b + b] = val;
-    }
-}
-
-fn require_environment<'a, T>(
-    envs: &'a [Option<Environment<T>>],
-    site: usize,
-    side: &'static str,
-) -> Result<&'a Environment<T>> {
-    envs.get(site)
-        .and_then(Option::as_ref)
-        .ok_or_else(|| MPOError::InvalidOperation {
-            message: format!("missing {side} environment at site {site}"),
-        })
-}
-
-/// Build left environment by extending from previous environment
-fn build_left_environment<T: SVDScalar>(
-    tensor_a: &Tensor4<T>,
-    tensor_b: &Tensor4<T>,
-    tensor_result: &Tensor4<T>,
-    prev_env: &Environment<T>,
-) -> Result<Environment<T>>
-where
-    <T as num_complex::ComplexFloat>::Real: Into<f64>,
-{
-    let new_dim_result = tensor_result.right_dim();
-    let new_dim_a = tensor_a.right_dim();
-    let new_dim_b = tensor_b.right_dim();
-
-    let mut new_env = Environment {
-        data: vec![T::zero(); new_dim_result * new_dim_a * new_dim_b],
-        dim_result: new_dim_result,
-        dim_a: new_dim_a,
-        dim_b: new_dim_b,
-    };
-
-    // Contract: L'[rr', ra', rb'] = sum_{rr, ra, rb, s1, s2, k}
-    //   L[rr, ra, rb] * C[rr, s1, s2, rr'] * A[ra, s1, k, ra'] * B[rb, k, s2, rb']
-    for rr in 0..prev_env.dim_result {
-        for ra in 0..prev_env.dim_a {
-            for rb in 0..prev_env.dim_b {
-                let l_val = prev_env.get(rr, ra, rb);
-                for s1 in 0..tensor_result.site_dim_1() {
-                    for s2 in 0..tensor_result.site_dim_2() {
-                        for k in 0..tensor_a.site_dim_2() {
-                            for rr_new in 0..new_dim_result {
-                                for ra_new in 0..new_dim_a {
-                                    for rb_new in 0..new_dim_b {
-                                        let c_val = *tensor_result.get4(rr, s1, s2, rr_new);
-                                        let a_val = *tensor_a.get4(ra, s1, k, ra_new);
-                                        let b_val = *tensor_b.get4(rb, k, s2, rb_new);
-                                        let old = new_env.get(rr_new, ra_new, rb_new);
-                                        new_env.set(
-                                            rr_new,
-                                            ra_new,
-                                            rb_new,
-                                            old + l_val * c_val * a_val * b_val,
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(new_env)
-}
-
-/// Build right environment by extending from next environment
-fn build_right_environment<T: SVDScalar>(
-    tensor_a: &Tensor4<T>,
-    tensor_b: &Tensor4<T>,
-    tensor_result: &Tensor4<T>,
-    next_env: &Environment<T>,
-) -> Result<Environment<T>>
-where
-    <T as num_complex::ComplexFloat>::Real: Into<f64>,
-{
-    let new_dim_result = tensor_result.left_dim();
-    let new_dim_a = tensor_a.left_dim();
-    let new_dim_b = tensor_b.left_dim();
-
-    let mut new_env = Environment {
-        data: vec![T::zero(); new_dim_result * new_dim_a * new_dim_b],
-        dim_result: new_dim_result,
-        dim_a: new_dim_a,
-        dim_b: new_dim_b,
-    };
-
-    // Contract: R'[lr, la, lb] = sum_{rr, ra, rb, s1, s2, k}
-    //   R[rr, ra, rb] * C[lr, s1, s2, rr] * A[la, s1, k, ra] * B[lb, k, s2, rb]
-    for rr in 0..next_env.dim_result {
-        for ra in 0..next_env.dim_a {
-            for rb in 0..next_env.dim_b {
-                let r_val = next_env.get(rr, ra, rb);
-                for s1 in 0..tensor_result.site_dim_1() {
-                    for s2 in 0..tensor_result.site_dim_2() {
-                        for k in 0..tensor_a.site_dim_2() {
-                            for lr in 0..new_dim_result {
-                                for la in 0..new_dim_a {
-                                    for lb in 0..new_dim_b {
-                                        let c_val = *tensor_result.get4(lr, s1, s2, rr);
-                                        let a_val = *tensor_a.get4(la, s1, k, ra);
-                                        let b_val = *tensor_b.get4(lb, k, s2, rb);
-                                        let old = new_env.get(lr, la, lb);
-                                        new_env.set(
-                                            lr,
-                                            la,
-                                            lb,
-                                            old + r_val * c_val * a_val * b_val,
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(new_env)
-}
-
-/// Update the two-site core tensor at positions site and site+1
-fn update_two_site_core<T: SVDScalar>(
-    _mpo_a: &MPO<T>,
-    _mpo_b: &MPO<T>,
-    _result: &mut SiteMPO<T>,
-    _site: usize,
-    _left_envs: &[Option<Environment<T>>],
-    _right_envs: &[Option<Environment<T>>],
-    _options: &FitOptions,
-) -> Result<bool>
-where
-    <T as num_complex::ComplexFloat>::Real: Into<f64>,
-{
-    // For now, just return Ok - full implementation would update the core
-    // This is a placeholder for the variational update step
-    Ok(true)
+    Err(MPOError::Unsupported {
+        message: "simplett variational MPO fitting is not implemented; use contract_naive or contract_zipup instead".to_owned(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-simplett/src/mpo/contract_fit/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/contract_fit/tests/mod.rs
@@ -1,10 +1,4 @@
-use super::super::site_mpo::SiteMPO;
-use super::super::types::tensor4_from_data;
 use super::*;
-
-fn scalar_tensor4(value: f64) -> Tensor4<f64> {
-    tensor4_from_data(vec![value], 1, 1, 1, 1).unwrap()
-}
 
 #[test]
 fn test_fit_options_default_values() {
@@ -17,12 +11,22 @@ fn test_fit_options_default_values() {
 }
 
 #[test]
-fn test_contract_fit_empty_returns_empty_mpo() {
+fn test_contract_fit_empty_returns_unsupported() {
     let mpo_a = MPO::<f64>::constant(&[], 1.0);
     let mpo_b = MPO::<f64>::constant(&[], 2.0);
 
-    let result = contract_fit(&mpo_a, &mpo_b, &FitOptions::default(), None).unwrap();
-    assert!(result.is_empty());
+    let err = contract_fit(&mpo_a, &mpo_b, &FitOptions::default(), None).unwrap_err();
+    assert!(matches!(err, MPOError::Unsupported { .. }));
+    assert!(err.to_string().contains("not implemented"));
+}
+
+#[test]
+fn test_contract_fit_valid_input_returns_unsupported() {
+    let mpo_a = MPO::<f64>::constant(&[(2, 2)], 1.0);
+    let mpo_b = MPO::<f64>::constant(&[(2, 2)], 1.0);
+
+    let err = contract_fit(&mpo_a, &mpo_b, &FitOptions::default(), None).unwrap_err();
+    assert!(matches!(err, MPOError::Unsupported { .. }));
 }
 
 #[test]
@@ -52,99 +56,4 @@ fn test_contract_fit_shared_dimension_mismatch_errors() {
             dim_b: 4,
         })
     ));
-}
-
-#[test]
-fn test_environment_identity_get_and_set() {
-    let mut env = Environment::<f64>::identity(2, 2, 2);
-    assert_eq!(env.get(0, 0, 0), 1.0);
-    assert_eq!(env.get(1, 1, 1), 1.0);
-    assert_eq!(env.get(0, 1, 1), 0.0);
-
-    env.set(0, 1, 1, 3.5);
-    assert_eq!(env.get(0, 1, 1), 3.5);
-
-    let scalar_env = Environment::<f64>::identity(1, 1, 1);
-    assert_eq!(scalar_env.get(0, 0, 0), 1.0);
-}
-
-#[test]
-fn missing_environment_returns_typed_error() {
-    let envs: Vec<Option<Environment<f64>>> = vec![None];
-    let err = require_environment(&envs, 0, "left").unwrap_err();
-
-    assert!(matches!(err, MPOError::InvalidOperation { .. }));
-    assert!(err
-        .to_string()
-        .contains("missing left environment at site 0"));
-}
-
-#[test]
-fn test_build_left_and_right_environment_for_scalar_tensors() {
-    let tensor_a = scalar_tensor4(2.0);
-    let tensor_b = scalar_tensor4(3.0);
-    let tensor_result = scalar_tensor4(5.0);
-    let prev_env = Environment::<f64>::identity(1, 1, 1);
-
-    let left = build_left_environment(&tensor_a, &tensor_b, &tensor_result, &prev_env).unwrap();
-    assert_eq!(left.get(0, 0, 0), 30.0);
-
-    let right = build_right_environment(&tensor_a, &tensor_b, &tensor_result, &prev_env).unwrap();
-    assert_eq!(right.get(0, 0, 0), 30.0);
-}
-
-#[test]
-fn test_update_two_site_core_placeholder_returns_true() {
-    let mpo_a = MPO::<f64>::constant(&[(1, 1), (1, 1)], 2.0);
-    let mpo_b = MPO::<f64>::constant(&[(1, 1), (1, 1)], 3.0);
-    let mut result = SiteMPO::from_mpo(MPO::<f64>::constant(&[(1, 1), (1, 1)], 1.0), 0).unwrap();
-    let left_envs = vec![Some(Environment::<f64>::identity(1, 1, 1)), None];
-    let right_envs = vec![None, Some(Environment::<f64>::identity(1, 1, 1))];
-
-    let updated = update_two_site_core(
-        &mpo_a,
-        &mpo_b,
-        &mut result,
-        0,
-        &left_envs,
-        &right_envs,
-        &FitOptions::default(),
-    )
-    .unwrap();
-    assert!(updated);
-}
-
-#[test]
-fn test_contract_fit_identity() {
-    let mpo_a = MPO::<f64>::identity(&[2, 2]).unwrap();
-    let mpo_b = MPO::<f64>::identity(&[2, 2]).unwrap();
-
-    let options = FitOptions {
-        factorize_method: FactorizeMethod::SVD,
-        ..Default::default()
-    };
-    let result = contract_fit(&mpo_a, &mpo_b, &options, None).unwrap();
-
-    assert_eq!(result.len(), 2);
-
-    // The result should be equivalent to identity
-    assert!((result.evaluate(&[0, 0, 0, 0]).unwrap() - 1.0).abs() < 1e-8);
-    assert!((result.evaluate(&[1, 1, 1, 1]).unwrap() - 1.0).abs() < 1e-8);
-}
-
-#[test]
-fn test_contract_fit_constant() {
-    let mpo_a = MPO::<f64>::constant(&[(2, 2)], 2.0);
-    let mpo_b = MPO::<f64>::constant(&[(2, 2)], 3.0);
-
-    let options = FitOptions {
-        factorize_method: FactorizeMethod::SVD,
-        ..Default::default()
-    };
-    let result = contract_fit(&mpo_a, &mpo_b, &options, None).unwrap();
-
-    // Each element of C = sum over k of A[i, k] * B[k, j]
-    // = sum over k of 2 * 3 = 6 * 2 = 12
-    let val = result.evaluate(&[0, 0]).unwrap();
-    assert!((val - 12.0).abs() < 1e-8);
 }

--- a/crates/tensor4all-simplett/src/mpo/dispatch.rs
+++ b/crates/tensor4all-simplett/src/mpo/dispatch.rs
@@ -11,7 +11,7 @@ pub enum ContractionAlgorithm {
     Naive,
     /// Zip-up contraction with on-the-fly compression
     ZipUp,
-    /// Variational fitting algorithm
+    /// Variational fitting algorithm (currently unsupported for simplett MPOs)
     Fit,
 }
 
@@ -40,7 +40,8 @@ use crate::einsum_helper::EinsumScalar;
 /// # Errors
 ///
 /// Returns an error when the contraction or operation fails (a shape or
-/// /// index mismatch, or a backend failure).
+/// index mismatch, a backend failure, or the selected algorithm is
+/// unsupported).
 ///
 /// # Example
 ///
@@ -59,9 +60,9 @@ use crate::einsum_helper::EinsumScalar;
 /// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::ZipUp, &options).unwrap();
 /// assert_eq!(result.len(), 2);
 ///
-/// // Use variational fitting for controlled bond dimension
-/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options).unwrap();
-/// assert_eq!(result.len(), 2);
+/// // Simplett variational fitting is not implemented yet.
+/// let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options);
+/// assert!(matches!(result, Err(tensor4all_simplett::mpo::MPOError::Unsupported { .. })));
 /// ```
 pub fn contract<T: SVDScalar + EinsumScalar>(
     mpo_a: &MPO<T>,

--- a/crates/tensor4all-simplett/src/mpo/dispatch/tests/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/dispatch/tests/mod.rs
@@ -1,3 +1,4 @@
+use super::super::error::MPOError;
 use super::*;
 
 #[test]
@@ -21,13 +22,13 @@ fn test_contract_dispatch_zipup() {
 }
 
 #[test]
-fn test_contract_dispatch_fit() {
+fn test_contract_dispatch_fit_is_unsupported() {
     let mpo_a = MPO::<f64>::identity(&[2, 2]).unwrap();
     let mpo_b = MPO::<f64>::identity(&[2, 2]).unwrap();
     let options = ContractionOptions::default();
 
-    let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options).unwrap();
-    assert_eq!(result.len(), 2);
+    let result = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options);
+    assert!(matches!(result, Err(MPOError::Unsupported { .. })));
 }
 
 #[test]
@@ -40,15 +41,9 @@ fn test_contract_algorithms_consistent() {
 
     let result_naive = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Naive, &options).unwrap();
     let result_zipup = contract(&mpo_a, &mpo_b, ContractionAlgorithm::ZipUp, &options).unwrap();
-    let result_fit = contract(&mpo_a, &mpo_b, ContractionAlgorithm::Fit, &options).unwrap();
-
-    // Check all algorithms give the same result
+    // Check the available algorithms give the same result
     // evaluate takes &[LocalIndex] - flat list, 2 per site
     let val_naive = result_naive.evaluate(&[0, 0]).unwrap();
     let val_zipup = result_zipup.evaluate(&[0, 0]).unwrap();
-    let val_fit = result_fit.evaluate(&[0, 0]).unwrap();
-
-    // All algorithms should give the same result
     assert!((val_naive - val_zipup).abs() < 1e-10);
-    assert!((val_naive - val_fit).abs() < 1e-10);
 }

--- a/crates/tensor4all-simplett/src/mpo/error.rs
+++ b/crates/tensor4all-simplett/src/mpo/error.rs
@@ -90,6 +90,13 @@ pub enum MPOError {
         message: String,
     },
 
+    /// Operation is not implemented by this backend.
+    #[error("Unsupported operation: {message}")]
+    Unsupported {
+        /// Description of the unsupported operation.
+        message: String,
+    },
+
     /// Invalid operation
     #[error("Invalid operation: {message}")]
     InvalidOperation {

--- a/crates/tensor4all-simplett/src/mpo/mod.rs
+++ b/crates/tensor4all-simplett/src/mpo/mod.rs
@@ -14,7 +14,8 @@
 //!
 //! - [`fn@contract_naive`]: Naive contraction (exact but memory-intensive)
 //! - [`fn@contract_zipup`]: Zip-up contraction with on-the-fly compression
-//! - [`fn@contract_fit`]: Variational fitting algorithm
+//! - [`fn@contract_fit`]: Reserved variational fitting API (currently
+//!   unsupported)
 //!
 //! # Example
 //!

--- a/docs/design/issue-571-contract-fit-placeholder.md
+++ b/docs/design/issue-571-contract-fit-placeholder.md
@@ -1,0 +1,69 @@
+# Design: #571 — make simplett `contract_fit` fail loudly
+
+Status: proposed. Review gate: luna read-only design review before
+implementation, then luna read-only diff review.
+
+## Problem
+
+`tensor4all-simplett::mpo::contract_fit` is presented as a variational
+(DMRG-like) MPO fitting algorithm, but `update_two_site_core` is only a
+placeholder that returns `Ok(true)` without changing the result. The initial
+result is the naive contraction, so every call returns the naive result while
+spending up to `max_sweeps` on dead environment-building and sweep loops. The
+convergence check is also unfinished. This makes `Fit` silently claim a
+contraction method that it does not implement.
+
+The real TreeTN fitting implementation used by `tensor4all-itensorlike` and
+the TreeTN C API is separate and is not changed by this issue.
+
+## Decision
+
+Make the simplett API fail before doing any contraction work:
+
+1. Keep the existing length and shared physical-dimension validation so
+   malformed inputs continue to produce their specific errors.
+2. For every otherwise valid input, including an empty MPO, return a new typed
+   `MPOError::Unsupported` explaining that variational MPO fitting is not
+   implemented and suggesting `contract_naive` or `contract_zipup`.
+3. Ignore the `initial` argument intentionally while Fit is unavailable; it
+   remains in the signature as part of the future fitting API surface.
+4. Remove the unreachable placeholder environment/update implementation and
+   its tests. This removes the dead sweeps rather than retaining code that can
+   never produce a valid fit.
+5. Update `FitOptions`, `contract_fit`, `ContractionAlgorithm::Fit`, module
+   docs, doctests, and dispatch tests to state and assert the unsupported
+   behavior. `FitOptions` remains as the future configuration surface; its
+   fields are not consumed while the algorithm is unavailable.
+
+`ContractionAlgorithm::Fit` continues to dispatch through `contract_fit`, so
+callers receive the same typed error whether they use the function directly or
+the unified dispatcher. No TreeTN APIs or C API behavior are changed.
+
+## Error and compatibility
+
+This is an intentional behavior correction for a function that returned an
+incorrectly labeled result. Valid calls that previously returned a naive result
+will now return `MPOError::Unsupported`; callers must select `Naive` or `ZipUp`
+until a real simplett fit implementation is added. Existing invalid-input
+errors remain unchanged.
+
+## Verification
+
+- Unit tests cover the unsupported result for empty and non-empty valid MPOs,
+  plus preservation of length/shared dimension validation.
+- Dispatcher tests and the public doctest cover
+  `ContractionAlgorithm::Fit` returning the same typed error.
+- `cargo fmt --all`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --release -p tensor4all-simplett`
+- `cargo nextest run --release --workspace`
+- `cargo test --doc --release --workspace`
+- `./scripts/test-mdbook.sh`
+- `cargo doc --workspace --no-deps`
+- repository-rules review and `git diff --check`
+
+## Review verdicts
+
+- Design (pre-implementation), luna: needs-fix (empty-input and unused-
+  `initial` semantics) → fixed and re-reviewed: Correct-to-merge.
+- Diff (post-implementation), luna: Correct-to-merge.


### PR DESCRIPTION
Closes #571.

`tensor4all-simplett::mpo::contract_fit` was labeled as a variational fit,
but its two-site update was a placeholder that never modified the initial
naive contraction. It also ran dead environment/sweep loops before returning
that naive result.

This PR makes the unsupported state explicit and cheap:

- Preserve length and shared-dimension validation.
- Return typed `MPOError::Unsupported` for every valid input, including empty
  MPOs, instead of returning naive-as-Fit.
- Remove the unreachable placeholder environment/update implementation and its
  misleading tests.
- Update `FitOptions`, dispatcher behavior, public docs, doctests, and
  regression tests.
- Leave the separate TreeTN fit engine and C API paths unchanged.

Design/review:
- `docs/design/issue-571-contract-fit-placeholder.md`
- luna design review: Correct-to-merge after one clarification round
- luna diff review: Correct-to-merge

Local verification:
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace` (2820 passed, 14 skipped)
- `cargo test --doc --release --workspace` (863 passed)
- `./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`
- repository-rules review: pass