### PR TITLE
Fix PartitionedTT projector invariants

### DIFF
--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
@@ -179,7 +179,7 @@ where
                 &site_indices,
             ));
             let tt = rank_one_full_tt(&site_indices, &patch.projector, value)?;
-            accepted.push(SubDomainTT::new(tt, patch.projector));
+            accepted.push(SubDomainTT::new(tt, patch.projector)?);
             continue;
         }
 
@@ -207,7 +207,7 @@ where
                 &active_positions,
                 &patch.projector,
             )?;
-            accepted.push(SubDomainTT::new(tt, patch.projector));
+            accepted.push(SubDomainTT::new(tt, patch.projector)?);
             continue;
         }
 
@@ -237,7 +237,7 @@ where
             .all(|value| Scalar::abs_val(*value) < ZERO_SAMPLE_THRESHOLD)
         {
             let tt = rank_one_full_tt(&site_indices, &patch.projector, T::zero())?;
-            accepted.push(SubDomainTT::new(tt, patch.projector));
+            accepted.push(SubDomainTT::new(tt, patch.projector)?);
             continue;
         }
 
@@ -296,7 +296,7 @@ where
                 &active_positions,
                 &patch.projector,
             )?;
-            accepted.push(SubDomainTT::new(tt, patch.projector));
+            accepted.push(SubDomainTT::new(tt, patch.projector)?);
             continue;
         }
 
@@ -316,7 +316,7 @@ where
         };
         for value in 0..split_index.dim {
             let mut child_projector = patch.projector.clone();
-            child_projector.insert(split_index.clone(), value);
+            child_projector.insert(split_index.clone(), value)?;
             pending.push_back(PendingPatch {
                 projector: child_projector,
                 recycled_pivots: recycled_pivots.clone(),

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
 use num_complex::Complex64;
 use std::cell::Cell;
 use std::rc::Rc;
@@ -231,7 +235,7 @@ fn extracts_full_diagonal_pivots_for_recycling() {
 #[test]
 fn incompatible_recycled_pivots_are_replenished_for_nonzero_child() {
     let sites = binary_sites(3);
-    let projector = Projector::from_pairs([(sites[0].clone(), 1)]);
+    let projector = projector([(sites[0].clone(), 1)]);
     let active = active_positions(&sites, &projector);
     let recycled = vec![vec![0, 0, 0], vec![0, 1, 1]];
     let mut rng = StdRng::seed_from_u64(7);
@@ -258,7 +262,7 @@ fn incompatible_recycled_pivots_are_replenished_for_nonzero_child() {
 fn projected_middle_sites_use_compact_structured_storage() {
     let sites = binary_sites(3);
     let active = vec![0, 2];
-    let projector = Projector::from_pairs([(sites[1].clone(), 1)]);
+    let projector = projector([(sites[1].clone(), 1)]);
     let active_tt = tensor4all_simplett::SimpleTensorTrain::new(vec![
         tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
         tensor3_from_data(vec![5.0, 6.0, 7.0, 8.0], 2, 2, 1).unwrap(),

--- a/crates/tensor4all-partitionedtt/src/contract.rs
+++ b/crates/tensor4all-partitionedtt/src/contract.rs
@@ -69,7 +69,7 @@ pub fn contract(
 /// let right = SubDomainTT::from_tt(TensorTrain::new(vec![
 ///     IdxTensor::from_dense(vec![i], vec![3.0_f64, 4.0]).unwrap(),
 /// ]).unwrap());
-/// let projector = Projector::from_pairs([(left.all_indices()[0].clone(), 0)]);
+/// let projector = Projector::from_pairs([(left.all_indices()[0].clone(), 0)]).unwrap();
 ///
 /// assert!(proj_contract(&left, &right, &projector, &ContractOptions::default())
 ///     .unwrap()

--- a/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/contract/tests/mod.rs
@@ -1,4 +1,12 @@
 use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+
+fn subdomain(data: TensorTrain, projector: Projector) -> SubDomainTT {
+    SubDomainTT::new(data, projector).unwrap()
+}
 use num_complex::Complex64;
 use tensor4all_core::index::Index;
 use tensor4all_core::{DynIndex, IdxTensor, TensorContractionLike, TensorElement};
@@ -116,10 +124,10 @@ fn test_projector_compatibility_check() {
     let (s0, l01, s1, l12, s2) = make_contraction_indices();
 
     let tt1 = make_tt_generic::<f64>(&s0, &l01, &s1);
-    let m1 = SubDomainTT::new(tt1, Projector::from_pairs([(s0.clone(), 0)]));
+    let m1 = subdomain(tt1, projector([(s0.clone(), 0)]));
 
     let tt2 = make_tt_generic::<f64>(&s1, &l12, &s2);
-    let m2 = SubDomainTT::new(tt2, Projector::from_pairs([(s2.clone(), 0)]));
+    let m2 = subdomain(tt2, projector([(s2.clone(), 0)]));
 
     // Projectors are compatible (different indices)
     assert!(m1.projector().is_compatible_with(m2.projector()));
@@ -130,11 +138,11 @@ fn test_projector_incompatibility_check() {
     let (s0, l01, s1, l12, s2) = make_contraction_indices();
 
     let tt1 = make_tt_generic::<f64>(&s0, &l01, &s1);
-    let m1 = SubDomainTT::new(tt1, Projector::from_pairs([(s1.clone(), 0)]));
+    let m1 = subdomain(tt1, projector([(s1.clone(), 0)]));
 
     let tt2 = make_tt_generic::<f64>(&s1, &l12, &s2);
     // Incompatible: same shared index s1, different values
-    let m2 = SubDomainTT::new(tt2, Projector::from_pairs([(s1.clone(), 1)]));
+    let m2 = subdomain(tt2, projector([(s1.clone(), 1)]));
 
     // Projectors conflict (s1=0 vs s1=1)
     assert!(!m1.projector().is_compatible_with(m2.projector()));
@@ -146,11 +154,11 @@ fn test_contract_compatible_projectors() {
 
     // TT1 with projector on s0
     let tt1 = make_tt_generic::<f64>(&s0, &l01, &s1);
-    let m1 = SubDomainTT::new(tt1, Projector::from_pairs([(s0.clone(), 0)]));
+    let m1 = subdomain(tt1, projector([(s0.clone(), 0)]));
 
     // TT2 with projector on s2
     let tt2 = make_tt_generic::<f64>(&s1, &l12, &s2);
-    let m2 = SubDomainTT::new(tt2, Projector::from_pairs([(s2.clone(), 1)]));
+    let m2 = subdomain(tt2, projector([(s2.clone(), 1)]));
 
     // Contract: s1 is contracted away, result has s0 and s2
     let options = ContractOptions::default();
@@ -172,11 +180,11 @@ fn test_contract_incompatible_projectors() {
 
     // TT1 with projector s1=0
     let tt1 = make_tt_generic::<f64>(&s0, &l01, &s1);
-    let m1 = SubDomainTT::new(tt1, Projector::from_pairs([(s1.clone(), 0)]));
+    let m1 = subdomain(tt1, projector([(s1.clone(), 0)]));
 
     // TT2 with conflicting projector s1=1
     let tt2 = make_tt_generic::<f64>(&s1, &l12, &s2);
-    let m2 = SubDomainTT::new(tt2, Projector::from_pairs([(s1.clone(), 1)]));
+    let m2 = subdomain(tt2, projector([(s1.clone(), 1)]));
 
     // Contract should return None due to incompatible projectors
     let options = ContractOptions::default();
@@ -221,7 +229,7 @@ fn test_proj_contract_projector_filtering() {
     let tt1 = make_tt_generic::<f64>(&s0, &l01, &s1);
     let m1 = SubDomainTT::from_tt(tt1);
 
-    let proj = Projector::from_pairs([(s0.clone(), 0)]);
+    let proj = projector([(s0.clone(), 0)]);
 
     // Project should work since m1 has empty projector (compatible with anything)
     let projected = m1.project(&proj).unwrap();
@@ -242,7 +250,7 @@ fn test_proj_contract() {
     let m2 = SubDomainTT::from_tt(tt2);
 
     // Project both to s0=0, then contract
-    let proj = Projector::from_pairs([(s0.clone(), 0)]);
+    let proj = projector([(s0.clone(), 0)]);
     let options = ContractOptions::default();
     let result = proj_contract(&m1, &m2, &proj, &options).unwrap();
 
@@ -259,7 +267,7 @@ fn test_proj_contract_rejects_projector_index_absent_from_both_operands() {
     let left = SubDomainTT::from_tt(make_tt_generic::<f64>(&s0, &l01, &s1));
     let right = SubDomainTT::from_tt(make_tt_generic::<f64>(&s1, &l12, &s2));
     let absent = make_index(2);
-    let projector = Projector::from_pairs([(absent.clone(), 0)]);
+    let projector = projector([(absent.clone(), 0)]);
 
     let error = proj_contract(&left, &right, &projector, &ContractOptions::default()).unwrap_err();
     assert!(matches!(
@@ -342,11 +350,11 @@ fn test_contract_with_projectors_numerical_correctness_generic<T: TestScalar>() 
     // Create SubDomainTTs with projectors
     // m1 is projected at s0=0
     // m2 is projected at s2=1
-    let proj1 = Projector::from_pairs([(s0.clone(), 0)]);
-    let proj2 = Projector::from_pairs([(s2.clone(), 1)]);
+    let proj1 = projector([(s0.clone(), 0)]);
+    let proj2 = projector([(s2.clone(), 1)]);
 
-    let m1 = SubDomainTT::new(tt1, proj1.clone());
-    let m2 = SubDomainTT::new(tt2, proj2.clone());
+    let m1 = subdomain(tt1, proj1.clone());
+    let m2 = subdomain(tt2, proj2.clone());
 
     // Contract
     // Use Naive method for exact results (no approximation)
@@ -420,11 +428,11 @@ fn test_contract_with_projectors_numerical_correctness_default_zipup_generic<T: 
             let t1_full = tt1.to_dense().unwrap();
             let t2_full = tt2.to_dense().unwrap();
 
-            let proj1 = Projector::from_pairs([(s0.clone(), s0_val)]);
-            let proj2 = Projector::from_pairs([(s2.clone(), s2_val)]);
+            let proj1 = projector([(s0.clone(), s0_val)]);
+            let proj2 = projector([(s2.clone(), s2_val)]);
 
-            let m1 = SubDomainTT::new(tt1, proj1);
-            let m2 = SubDomainTT::new(tt2, proj2);
+            let m1 = subdomain(tt1, proj1);
+            let m2 = subdomain(tt2, proj2);
 
             let result = contract(&m1, &m2, &ContractOptions::default())
                 .unwrap()
@@ -479,11 +487,11 @@ fn test_contract_with_projector_on_contracted_index_generic<T: TestScalar>() {
 
     // Both have projector on the contracted index s1
     // m1: s1=0, m2: s1=0 (compatible)
-    let proj1 = Projector::from_pairs([(s1.clone(), 0)]);
-    let proj2 = Projector::from_pairs([(s1.clone(), 0)]);
+    let proj1 = projector([(s1.clone(), 0)]);
+    let proj2 = projector([(s1.clone(), 0)]);
 
-    let m1 = SubDomainTT::new(tt1, proj1);
-    let m2 = SubDomainTT::new(tt2, proj2);
+    let m1 = subdomain(tt1, proj1);
+    let m2 = subdomain(tt2, proj2);
 
     // Use Naive method for exact results (no approximation)
     let options = naive_reference_options();
@@ -538,8 +546,8 @@ fn test_contract_one_side_has_projector_generic<T: TestScalar>() {
     let t2_full = tt2.to_dense().unwrap();
 
     // m1 has projector on s0, m2 has no projector
-    let proj1 = Projector::from_pairs([(s0.clone(), 1)]);
-    let m1 = SubDomainTT::new(tt1, proj1);
+    let proj1 = projector([(s0.clone(), 1)]);
+    let m1 = subdomain(tt1, proj1);
     let m2 = SubDomainTT::from_tt(tt2);
 
     // Use Naive method for exact results (no approximation)
@@ -597,7 +605,7 @@ fn test_proj_contract_numerical_correctness_generic<T: TestScalar>() {
     let m2 = SubDomainTT::from_tt(tt2);
 
     // proj_contract with projector that projects s0=0 and s2=1
-    let proj = Projector::from_pairs([(s0.clone(), 0), (s2.clone(), 1)]);
+    let proj = projector([(s0.clone(), 0), (s2.clone(), 1)]);
     // Use Naive method for exact results (no approximation)
     let options = naive_reference_options();
     let result = proj_contract(&m1, &m2, &proj, &options).unwrap().unwrap();

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -113,9 +113,11 @@ impl PartitionedTT {
     ///
     /// # Errors
     ///
-    /// Returns a typed projector-validation error if the subdomain's private
-    /// data and projector invariants are inconsistent. No partition is returned
-    /// on failure.
+    /// Returns [`PartitionedTTError::ProjectorIndexNotFound`] if the projector
+    /// contains an index absent from the tensor train, or
+    /// [`PartitionedTTError::ProjectorCoordinateOutOfBounds`] if a coordinate is
+    /// invalid for the matched tensor-train index. No partition is returned on
+    /// failure.
     pub fn from_subdomain(subdomain: SubDomainTT) -> Result<Self> {
         let mut partitioned = Self::new();
         partitioned.insert(subdomain)?;
@@ -210,8 +212,12 @@ impl PartitionedTT {
     /// Append another PartitionedTT (must have non-overlapping projectors).
     /// # Errors
     ///
-    /// Returns an error when a different projector overlaps an existing
-    /// projector. Equal keys replace existing values. All checks happen before
+    /// Returns [`PartitionedTTError::OverlappingProjectors`] when a different
+    /// projector overlaps an existing projector,
+    /// [`PartitionedTTError::ProjectorIndexNotFound`] when an appended
+    /// subdomain refers to an absent tensor-train index, or
+    /// [`PartitionedTTError::ProjectorCoordinateOutOfBounds`] when its coordinate
+    /// is invalid. Equal keys replace existing values. All checks happen before
     /// this partition is mutated.
     ///
     pub fn append(&mut self, other: Self) -> Result<()> {
@@ -236,9 +242,13 @@ impl PartitionedTT {
     /// Append subdomains.
     /// # Errors
     ///
-    /// Returns an error when a different candidate projector overlaps an
-    /// existing projector. The complete candidate set is validated before this
-    /// partition is mutated.
+    /// Returns [`PartitionedTTError::OverlappingProjectors`] when different
+    /// candidate or existing projectors overlap,
+    /// [`PartitionedTTError::ProjectorIndexNotFound`] when a candidate refers to
+    /// an absent tensor-train index, or
+    /// [`PartitionedTTError::ProjectorCoordinateOutOfBounds`] when its coordinate
+    /// is invalid. The complete candidate set is validated before this partition
+    /// is mutated.
     ///
     pub fn append_subdomains(&mut self, subdomains: Vec<SubDomainTT>) -> Result<()> {
         let other = Self::from_subdomains(subdomains)?;

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt.rs
@@ -36,9 +36,9 @@ use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 /// let tt = make_tt(&s0, &bond, &s1);
 ///
 /// // Create a PartitionedTT with one patch projected to s0=0
-/// let proj = Projector::from_pairs([(s0.clone(), 0)]);
-/// let subdomain = SubDomainTT::new(tt, proj);
-/// let ptt = PartitionedTT::from_subdomain(subdomain);
+/// let proj = Projector::from_pairs([(s0.clone(), 0)]).unwrap();
+/// let subdomain = SubDomainTT::new(tt, proj).unwrap();
+/// let ptt = PartitionedTT::from_subdomain(subdomain).unwrap();
 ///
 /// assert_eq!(ptt.len(), 1);
 /// assert!(!ptt.is_empty());
@@ -69,12 +69,14 @@ impl PartitionedTT {
 
     /// Create a PartitionedTT from a vector of SubDomainTTs.
     ///
-    /// Returns an error if the projectors are not mutually disjoint.
+    /// Returns an error if different projectors overlap. Equal projectors
+    /// replace earlier values in input order.
     ///
     /// # Errors
     ///
-    /// Returns an error when the subdomains have incompatible shapes (a shape
-    /// /// mismatch) or the construction fails.
+    /// Returns [`PartitionedTTError::OverlappingProjectors`] when two
+    /// different projectors describe overlapping regions or when a subdomain
+    /// fails projector validation. No partially built value is returned.
     ///
     /// # Examples
     ///
@@ -91,34 +93,33 @@ impl PartitionedTT {
     /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
     /// // Two disjoint patches: s0=0 and s0=1
-    /// let proj0 = Projector::from_pairs([(s0.clone(), 0)]);
-    /// let proj1 = Projector::from_pairs([(s0.clone(), 1)]);
-    /// let sd0 = SubDomainTT::new(tt.clone(), proj0);
-    /// let sd1 = SubDomainTT::new(tt, proj1);
+    /// let proj0 = Projector::from_pairs([(s0.clone(), 0)]).unwrap();
+    /// let proj1 = Projector::from_pairs([(s0.clone(), 1)]).unwrap();
+    /// let sd0 = SubDomainTT::new(tt.clone(), proj0).unwrap();
+    /// let sd1 = SubDomainTT::new(tt, proj1).unwrap();
     ///
     /// let ptt = PartitionedTT::from_subdomains(vec![sd0, sd1]).unwrap();
     /// assert_eq!(ptt.len(), 2);
     /// ```
     pub fn from_subdomains(subdomains: Vec<SubDomainTT>) -> Result<Self> {
-        // Check that projectors are disjoint
-        let projectors: Vec<_> = subdomains.iter().map(|s| s.projector().clone()).collect();
-        if !Projector::are_disjoint(&projectors) {
-            return Err(PartitionedTTError::OverlappingProjectors);
-        }
-
-        let mut data = HashMap::new();
+        let mut partitioned = Self::new();
         for subdomain in subdomains {
-            data.insert(subdomain.projector().clone(), subdomain);
+            partitioned.insert(subdomain)?;
         }
-
-        Ok(Self { data })
+        Ok(partitioned)
     }
 
-    /// Create a PartitionedTT from a single SubDomainTT.
-    pub fn from_subdomain(subdomain: SubDomainTT) -> Self {
-        let mut data = HashMap::new();
-        data.insert(subdomain.projector().clone(), subdomain);
-        Self { data }
+    /// Create a `PartitionedTT` from one validated subdomain.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed projector-validation error if the subdomain's private
+    /// data and projector invariants are inconsistent. No partition is returned
+    /// on failure.
+    pub fn from_subdomain(subdomain: SubDomainTT) -> Result<Self> {
+        let mut partitioned = Self::new();
+        partitioned.insert(subdomain)?;
+        Ok(partitioned)
     }
 
     /// Number of subdomains (patches).
@@ -141,11 +142,6 @@ impl PartitionedTT {
         self.data.get(projector)
     }
 
-    /// Get mutable subdomain by projector.
-    pub fn get_mut(&mut self, projector: &Projector) -> Option<&mut SubDomainTT> {
-        self.data.get_mut(projector)
-    }
-
     /// Check if a projector exists.
     ///
     /// # Examples
@@ -162,12 +158,12 @@ impl PartitionedTT {
     /// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![3.0, 4.0]).unwrap();
     /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
-    /// let proj = Projector::from_pairs([(s0.clone(), 0)]);
-    /// let subdomain = SubDomainTT::new(tt, proj.clone());
-    /// let ptt = PartitionedTT::from_subdomain(subdomain);
+    /// let proj = Projector::from_pairs([(s0.clone(), 0)]).unwrap();
+    /// let subdomain = SubDomainTT::new(tt, proj.clone()).unwrap();
+    /// let ptt = PartitionedTT::from_subdomain(subdomain).unwrap();
     ///
     /// assert!(ptt.contains(&proj));
-    /// let absent = Projector::from_pairs([(s0, 1)]);
+    /// let absent = Projector::from_pairs([(s0, 1)]).unwrap();
     /// assert!(!ptt.contains(&absent));
     /// ```
     pub fn contains(&self, projector: &Projector) -> bool {
@@ -184,45 +180,65 @@ impl PartitionedTT {
         self.data.values()
     }
 
-    /// Iterate over mutable subdomains.
-    pub fn values_mut(&mut self) -> impl Iterator<Item = &mut SubDomainTT> {
-        self.data.values_mut()
-    }
+    /// Insert a subdomain transactionally.
+    ///
+    /// An exactly equal projector replaces the existing key and value together.
+    /// A different projector must be disjoint from every stored projector.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTTError::OverlappingProjectors`] for a different
+    /// compatible projector, or a typed projector-validation error when the
+    /// subdomain's data and projector are inconsistent. On error, this
+    /// partition is unchanged.
+    pub fn insert(&mut self, subdomain: SubDomainTT) -> Result<()> {
+        subdomain.validate_invariants()?;
+        let projector = subdomain.projector().clone();
+        for existing in self.data.keys() {
+            if existing != &projector && existing.is_compatible_with(&projector) {
+                return Err(PartitionedTTError::OverlappingProjectors);
+            }
+        }
 
-    /// Insert a subdomain, replacing any existing one with the same projector.
-    pub fn insert(&mut self, subdomain: SubDomainTT) {
-        self.data.insert(subdomain.projector().clone(), subdomain);
+        // HashMap::insert retains an equal old key. Remove first so the key and
+        // value remain the coherent pair supplied by the caller.
+        self.data.remove(&projector);
+        self.data.insert(projector, subdomain);
+        Ok(())
     }
 
     /// Append another PartitionedTT (must have non-overlapping projectors).
     /// # Errors
     ///
-    /// Returns an error when the partition shapes are incompatible (a shape
-    /// /// mismatch) or the append fails.
+    /// Returns an error when a different projector overlaps an existing
+    /// projector. Equal keys replace existing values. All checks happen before
+    /// this partition is mutated.
     ///
     pub fn append(&mut self, other: Self) -> Result<()> {
-        // Check for overlap
-        for proj in other.data.keys() {
-            for existing_proj in self.data.keys() {
-                if proj.is_compatible_with(existing_proj) {
+        for subdomain in other.data.values() {
+            subdomain.validate_invariants()?;
+        }
+        for projector in other.data.keys() {
+            for existing in self.data.keys() {
+                if projector != existing && projector.is_compatible_with(existing) {
                     return Err(PartitionedTTError::OverlappingProjectors);
                 }
             }
         }
 
-        // Merge
-        for (proj, subdomain) in other.data {
-            self.data.insert(proj, subdomain);
+        for (projector, subdomain) in other.data {
+            self.data.remove(&projector);
+            self.data.insert(projector, subdomain);
         }
-
         Ok(())
     }
 
     /// Append subdomains.
     /// # Errors
     ///
-    /// Returns an error when the partition shapes are incompatible (a shape
-    /// /// mismatch) or the append fails.
+    /// Returns an error when a different candidate projector overlaps an
+    /// existing projector. The complete candidate set is validated before this
+    /// partition is mutated.
     ///
     pub fn append_subdomains(&mut self, subdomains: Vec<SubDomainTT>) -> Result<()> {
         let other = Self::from_subdomains(subdomains)?;
@@ -250,9 +266,9 @@ impl PartitionedTT {
     /// let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0]).unwrap();
     /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
     ///
-    /// let proj = Projector::from_pairs([(s0, 0)]);
-    /// let subdomain = SubDomainTT::new(tt, proj);
-    /// let ptt = PartitionedTT::from_subdomain(subdomain);
+    /// let proj = Projector::from_pairs([(s0, 0)]).unwrap();
+    /// let subdomain = SubDomainTT::new(tt, proj).unwrap();
+    /// let ptt = PartitionedTT::from_subdomain(subdomain).unwrap();
     ///
     /// let n = ptt.norm().unwrap();
     /// assert!(n >= 0.0);
@@ -286,7 +302,7 @@ impl PartitionedTT {
         for (proj, m1, m2) in tasks {
             if let Some(contracted) = m1.contract(&m2, options)? {
                 // Check if we already have a subdomain with the same projector
-                if let Some(existing) = result.get_mut(&proj) {
+                if let Some(existing) = result.data.get_mut(&proj) {
                     // Sum the subdomains using TT addition
                     let mut summed_tt = existing
                         .data()
@@ -303,9 +319,9 @@ impl PartitionedTT {
                     summed_tt
                         .truncate(&truncate_opts)
                         .map_err(|source| PartitionedTTError::TensorTrain { source })?;
-                    *existing = SubDomainTT::new(summed_tt, proj.clone());
+                    *existing = SubDomainTT::new(summed_tt, proj.clone())?;
                 } else {
-                    result.insert(contracted);
+                    result.insert(contracted)?;
                 }
             }
         }
@@ -354,17 +370,17 @@ impl PartitionedTT {
                 summed_tt
                     .truncate(options)
                     .map_err(|source| PartitionedTTError::TensorTrain { source })?;
-                result.insert(SubDomainTT::new(summed_tt, proj.clone()));
+                result.insert(SubDomainTT::new(summed_tt, proj.clone())?)?;
             } else {
                 // Only self has this projector: clone it
-                result.insert(subdomain.clone());
+                result.insert(subdomain.clone())?;
             }
         }
 
         // Process projectors only in other (not in self)
         for (proj, subdomain) in other.iter() {
             if !self.contains(proj) {
-                result.insert(subdomain.clone());
+                result.insert(subdomain.clone())?;
             }
         }
 
@@ -405,7 +421,7 @@ impl PartitionedTT {
                             proj_data.push((idx.clone(), val));
                         }
                     }
-                    let proj_after = Projector::from_pairs(proj_data);
+                    let proj_after = Projector::from_pairs(proj_data)?;
 
                     // SubDomainTT::contract already applies each input projector.
                     // Pre-projecting here is redundant and can attach projector
@@ -438,7 +454,7 @@ impl PartitionedTT {
 
         // Sort subdomains by projector for deterministic ordering
         let mut sorted: Vec<_> = self.data.iter().collect();
-        sorted.sort_by(|(p1, _), (p2, _)| Self::projector_cmp(p1, p2));
+        sorted.sort_by(|(p1, _), (p2, _)| p1.canonical_cmp(p2));
 
         let mut iter = sorted.into_iter().map(|(_, subdomain)| subdomain);
         let first = iter.next().ok_or(PartitionedTTError::Empty)?;
@@ -451,27 +467,6 @@ impl PartitionedTT {
         }
 
         Ok(result)
-    }
-
-    /// Compare two projectors for deterministic ordering.
-    ///
-    /// Orders by: number of projections, then by sorted (index_id, value) pairs.
-    fn projector_cmp(a: &Projector, b: &Projector) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-
-        // First compare by length
-        match a.len().cmp(&b.len()) {
-            Ordering::Equal => {}
-            ord => return ord,
-        }
-
-        // Then compare by sorted (id, value) pairs
-        let mut a_pairs: Vec<_> = a.iter().map(|(idx, &val)| (idx.id, val)).collect();
-        let mut b_pairs: Vec<_> = b.iter().map(|(idx, &val)| (idx.id, val)).collect();
-        a_pairs.sort();
-        b_pairs.sort();
-
-        a_pairs.cmp(&b_pairs)
     }
 }
 

--- a/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/partitioned_tt/tests/mod.rs
@@ -1,6 +1,15 @@
 use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+
+fn subdomain(data: TensorTrain, projector: Projector) -> SubDomainTT {
+    SubDomainTT::new(data, projector).unwrap()
+}
+use std::cmp::Ordering;
 use tensor4all_core::index::Index;
-use tensor4all_core::{IdxTensor, TensorContractionLike};
+use tensor4all_core::{IdxTensor, TagSet, TensorContractionLike};
 use tensor4all_itensorlike::TensorTrainError;
 
 fn make_index(size: usize) -> DynIndex {
@@ -41,15 +50,99 @@ fn test_partitioned_tt_creation() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
 
     let partitioned = PartitionedTT::from_subdomains(vec![subdomain1, subdomain2]).unwrap();
 
     assert_eq!(partitioned.len(), 2);
     assert!(!partitioned.is_empty());
+}
+
+#[test]
+fn deterministic_projector_comparator_is_equal_iff_projector_equal() {
+    let base = make_index(2);
+    let tagged = Index::new_with_tags(base.id, 2, TagSet::from_str("Site").unwrap());
+    let primed = base.prime();
+    let different_dimension = Index::new_with_tags(base.id, 5, base.tags.clone());
+
+    let plain_projector = projector([(base.clone(), 0)]);
+    let tagged_projector = projector([(tagged, 0)]);
+    let primed_projector = projector([(primed, 0)]);
+    let equal_projector = projector([(base, 0)]);
+    let different_dimension_projector = projector([(different_dimension, 0)]);
+
+    assert_ne!(plain_projector, tagged_projector);
+    assert_ne!(plain_projector, primed_projector);
+    assert_eq!(plain_projector, equal_projector);
+    assert_eq!(plain_projector, different_dimension_projector);
+    assert_ne!(
+        plain_projector.canonical_cmp(&tagged_projector),
+        Ordering::Equal
+    );
+    assert_ne!(
+        plain_projector.canonical_cmp(&primed_projector),
+        Ordering::Equal
+    );
+    assert_eq!(
+        plain_projector.canonical_cmp(&equal_projector),
+        Ordering::Equal
+    );
+    assert_eq!(
+        plain_projector.canonical_cmp(&different_dimension_projector),
+        Ordering::Equal
+    );
+}
+
+#[test]
+fn partitioned_tt_insert_overlap_is_transactional() {
+    let (site_inds, link_ind) = make_shared_indices();
+    let original = subdomain(
+        make_tt_with_indices(&site_inds, &link_ind),
+        projector([(site_inds[0].clone(), 0)]),
+    );
+    let overlapping = subdomain(
+        make_tt_with_indices(&site_inds, &link_ind),
+        projector([(site_inds[1].clone(), 0)]),
+    );
+    let original_projector = original.projector().clone();
+    let mut partitioned = PartitionedTT::from_subdomain(original).unwrap();
+
+    let error = partitioned.insert(overlapping).unwrap_err();
+
+    assert!(matches!(error, PartitionedTTError::OverlappingProjectors));
+    assert_eq!(partitioned.len(), 1);
+    assert!(partitioned.contains(&original_projector));
+}
+
+#[test]
+fn partitioned_tt_insert_exact_projector_replaces_key_and_value() {
+    let (site_inds, link_ind) = make_shared_indices();
+    let original_projector = projector([(site_inds[0].clone(), 1)]);
+    let original = subdomain(
+        make_tt_with_indices(&site_inds, &link_ind),
+        original_projector.clone(),
+    );
+    let replacement_site = Index::new_with_tags(site_inds[0].id, 5, site_inds[0].tags.clone());
+    let replacement_projector = projector([(replacement_site.clone(), 1)]);
+    let replacement = subdomain(
+        make_tt_with_indices(&[replacement_site.clone(), site_inds[1].clone()], &link_ind),
+        replacement_projector.clone(),
+    );
+    let mut partitioned = PartitionedTT::from_subdomain(original).unwrap();
+
+    let _ = partitioned.insert(replacement);
+
+    let stored_projector = partitioned.projectors().next().unwrap();
+    let stored_index = stored_projector.projected_indices().next().unwrap();
+    assert_eq!(partitioned.len(), 1);
+    assert_eq!(stored_index, &replacement_site);
+    assert_eq!(
+        partitioned.get(&replacement_projector).unwrap().projector(),
+        &replacement_projector
+    );
 }
 
 #[test]
@@ -65,21 +158,23 @@ fn test_partitioned_tt_overlapping_projectors() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    // Same projector as subdomain1 - this should fail
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[1].clone(), 0)]));
 
     let result = PartitionedTT::from_subdomains(vec![subdomain1, subdomain2]);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(PartitionedTTError::OverlappingProjectors)
+    ));
 }
 
 #[test]
 fn test_partitioned_tt_norm() {
     let (tt, _) = make_simple_tt();
     let subdomain = SubDomainTT::from_tt(tt);
-    let partitioned = PartitionedTT::from_subdomain(subdomain);
+    let partitioned = PartitionedTT::from_subdomain(subdomain).unwrap();
 
     let norm = partitioned.norm().unwrap();
     assert!(norm > 0.0);
@@ -90,12 +185,12 @@ fn test_partitioned_tt_append() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let mut partitioned1 = PartitionedTT::from_subdomain(subdomain1);
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
+    let mut partitioned1 = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
-    let partitioned2 = PartitionedTT::from_subdomain(subdomain2);
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
+    let partitioned2 = PartitionedTT::from_subdomain(subdomain2).unwrap();
 
     partitioned1.append(partitioned2).unwrap();
 
@@ -107,16 +202,21 @@ fn test_partitioned_tt_append_overlapping() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let mut partitioned1 = PartitionedTT::from_subdomain(subdomain1);
+    let projector1 = projector([(site_inds[0].clone(), 0)]);
+    let subdomain1 = subdomain(tt1, projector1.clone());
+    let mut partitioned1 = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    // Same projector - should fail
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let partitioned2 = PartitionedTT::from_subdomain(subdomain2);
+    let subdomain2 = subdomain(tt2, projector([(site_inds[1].clone(), 0)]));
+    let partitioned2 = PartitionedTT::from_subdomain(subdomain2).unwrap();
 
     let result = partitioned1.append(partitioned2);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(PartitionedTTError::OverlappingProjectors)
+    ));
+    assert_eq!(partitioned1.len(), 1);
+    assert!(partitioned1.contains(&projector1));
 }
 
 #[test]
@@ -124,10 +224,10 @@ fn test_partitioned_tt_iteration() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
 
     let partitioned = PartitionedTT::from_subdomains(vec![subdomain1, subdomain2]).unwrap();
 
@@ -141,9 +241,9 @@ fn test_partitioned_tt_iteration() {
 #[test]
 fn test_partitioned_tt_index() {
     let (tt, site_inds) = make_simple_tt();
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let subdomain = SubDomainTT::new(tt, projector.clone());
-    let partitioned = PartitionedTT::from_subdomain(subdomain);
+    let projector = projector([(site_inds[0].clone(), 0)]);
+    let subdomain = subdomain(tt, projector.clone());
+    let partitioned = PartitionedTT::from_subdomain(subdomain).unwrap();
 
     // Access by projector
     let retrieved = partitioned.get(&projector).unwrap();
@@ -207,15 +307,15 @@ fn test_partitioned_tt_contract_numerical() {
     // Create PartitionedTT1 with 2 subdomains: s0=0 and s0=1
     let tt1_a = make_tt1(&s0, &l01, &s1);
     let tt1_b = make_tt1(&s0, &l01, &s1);
-    let subdomain1_a = SubDomainTT::new(tt1_a, Projector::from_pairs([(s0.clone(), 0)]));
-    let subdomain1_b = SubDomainTT::new(tt1_b, Projector::from_pairs([(s0.clone(), 1)]));
+    let subdomain1_a = subdomain(tt1_a, projector([(s0.clone(), 0)]));
+    let subdomain1_b = subdomain(tt1_b, projector([(s0.clone(), 1)]));
     let partitioned1 = PartitionedTT::from_subdomains(vec![subdomain1_a, subdomain1_b]).unwrap();
 
     // Create PartitionedTT2 with 2 subdomains: s2=0 and s2=1
     let tt2_a = make_tt2(&s1, &l12, &s2);
     let tt2_b = make_tt2(&s1, &l12, &s2);
-    let subdomain2_a = SubDomainTT::new(tt2_a, Projector::from_pairs([(s2.clone(), 0)]));
-    let subdomain2_b = SubDomainTT::new(tt2_b, Projector::from_pairs([(s2.clone(), 1)]));
+    let subdomain2_a = subdomain(tt2_a, projector([(s2.clone(), 0)]));
+    let subdomain2_b = subdomain(tt2_b, projector([(s2.clone(), 1)]));
     let partitioned2 = PartitionedTT::from_subdomains(vec![subdomain2_a, subdomain2_b]).unwrap();
 
     // Contract
@@ -278,8 +378,8 @@ fn test_subdomain_tt_norm_with_projector() {
     let full_data = full_tensor.to_vec::<f64>().unwrap();
 
     // Create SubDomainTT with projector s0=0
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let subdomain = SubDomainTT::new(tt.clone(), projector);
+    let projector = projector([(site_inds[0].clone(), 0)]);
+    let subdomain = subdomain(tt.clone(), projector);
 
     // Current norm() returns the norm of the underlying TT data without projection
     // This test documents current behavior
@@ -307,8 +407,8 @@ fn test_partitioned_tt_add_preserves_tensor_train_error_variant() {
     let left = SubDomainTT::from_tt(TensorTrain::new(vec![make_tensor(vec![left_index])]).unwrap());
     let right =
         SubDomainTT::from_tt(TensorTrain::new(vec![make_tensor(vec![right_index])]).unwrap());
-    let left_partitioned = PartitionedTT::from_subdomain(left);
-    let right_partitioned = PartitionedTT::from_subdomain(right);
+    let left_partitioned = PartitionedTT::from_subdomain(left).unwrap();
+    let right_partitioned = PartitionedTT::from_subdomain(right).unwrap();
 
     let error = left_partitioned
         .add(&right_partitioned, &TruncateOptions::svd())
@@ -327,12 +427,12 @@ fn test_partitioned_tt_add_same_structure() {
 
     // Create two PartitionedTTs with the same patch structure
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let partitioned1 = PartitionedTT::from_subdomain(subdomain1);
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
+    let partitioned1 = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let partitioned2 = PartitionedTT::from_subdomain(subdomain2);
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 0)]));
+    let partitioned2 = PartitionedTT::from_subdomain(subdomain2).unwrap();
 
     // Add them
     let options = TruncateOptions::svd();
@@ -342,7 +442,7 @@ fn test_partitioned_tt_add_same_structure() {
     assert_eq!(result.len(), 1);
 
     // The sum should be 2x the original (same TT added to itself)
-    let proj = Projector::from_pairs([(site_inds[0].clone(), 0)]);
+    let proj = projector([(site_inds[0].clone(), 0)]);
     let summed = result.get(&proj).unwrap();
     let summed_dense = summed.data().to_dense().unwrap();
     let summed_data = summed_dense.to_vec::<f64>().unwrap();
@@ -369,14 +469,14 @@ fn test_partitioned_tt_add_missing_patch() {
     // partitioned1 has patches for s0=0 and s0=1
     let tt1_a = make_tt_with_indices(&site_inds, &link_ind);
     let tt1_b = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1_a = SubDomainTT::new(tt1_a, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let subdomain1_b = SubDomainTT::new(tt1_b, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain1_a = subdomain(tt1_a, projector([(site_inds[0].clone(), 0)]));
+    let subdomain1_b = subdomain(tt1_b, projector([(site_inds[0].clone(), 1)]));
     let partitioned1 = PartitionedTT::from_subdomains(vec![subdomain1_a, subdomain1_b]).unwrap();
 
     // partitioned2 has only patch for s0=0
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let partitioned2 = PartitionedTT::from_subdomain(subdomain2);
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 0)]));
+    let partitioned2 = PartitionedTT::from_subdomain(subdomain2).unwrap();
 
     // Add them
     let options = TruncateOptions::svd();
@@ -386,7 +486,7 @@ fn test_partitioned_tt_add_missing_patch() {
     assert_eq!(result.len(), 2);
 
     // s0=0 patch should be summed (2x)
-    let proj0 = Projector::from_pairs([(site_inds[0].clone(), 0)]);
+    let proj0 = projector([(site_inds[0].clone(), 0)]);
     let summed0 = result.get(&proj0).unwrap();
     let original = make_tt_with_indices(&site_inds, &link_ind);
     let original_norm = original.norm().unwrap();
@@ -394,7 +494,7 @@ fn test_partitioned_tt_add_missing_patch() {
     assert!((summed0.norm().unwrap() - 2.0 * original_norm).abs() < 1e-10);
 
     // s0=1 patch should be unchanged (only in partitioned1)
-    let proj1 = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let proj1 = projector([(site_inds[0].clone(), 1)]);
     let unchanged = result.get(&proj1).unwrap();
     assert!((unchanged.norm().unwrap() - original_norm).abs() < 1e-10);
 }
@@ -404,10 +504,10 @@ fn test_partitioned_tt_values() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
 
     let partitioned = PartitionedTT::from_subdomains(vec![subdomain1, subdomain2]).unwrap();
 
@@ -422,33 +522,15 @@ fn test_partitioned_tt_values() {
 }
 
 #[test]
-fn test_partitioned_tt_values_mut() {
-    let (site_inds, link_ind) = make_shared_indices();
-
-    let tt = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain = SubDomainTT::new(tt, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let mut partitioned = PartitionedTT::from_subdomain(subdomain);
-
-    // Test values_mut() - truncate each subdomain
-    let truncate_opts = TruncateOptions::svd();
-    for subdomain in partitioned.values_mut() {
-        subdomain.data_mut().truncate(&truncate_opts).unwrap();
-    }
-
-    assert_eq!(partitioned.len(), 1);
-    assert!(partitioned.norm().unwrap() > 0.0);
-}
-
-#[test]
 fn test_partitioned_tt_append_subdomains() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let mut partitioned = PartitionedTT::from_subdomain(subdomain1);
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
+    let mut partitioned = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
 
     partitioned.append_subdomains(vec![subdomain2]).unwrap();
     assert_eq!(partitioned.len(), 2);
@@ -459,14 +541,20 @@ fn test_partitioned_tt_append_subdomains_overlapping() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let mut partitioned = PartitionedTT::from_subdomain(subdomain1);
+    let projector1 = projector([(site_inds[0].clone(), 0)]);
+    let subdomain1 = subdomain(tt1, projector1.clone());
+    let mut partitioned = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[1].clone(), 0)]));
 
     let result = partitioned.append_subdomains(vec![subdomain2]);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(PartitionedTTError::OverlappingProjectors)
+    ));
+    assert_eq!(partitioned.len(), 1);
+    assert!(partitioned.contains(&projector1));
 }
 
 #[test]
@@ -483,7 +571,7 @@ fn test_partitioned_tt_to_tensor_train_single() {
     let tt = make_tt_with_indices(&site_inds, &link_ind);
     let expected_dense = tt.to_dense().unwrap();
     let subdomain = SubDomainTT::from_tt(tt);
-    let partitioned = PartitionedTT::from_subdomain(subdomain);
+    let partitioned = PartitionedTT::from_subdomain(subdomain).unwrap();
 
     let combined = partitioned.to_tensor_train().unwrap();
     let combined_dense = combined.to_dense().unwrap();
@@ -499,14 +587,8 @@ fn test_partitioned_tt_to_tensor_train_multiple() {
     // Create two subdomains with different projectors
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(
-        tt1.clone(),
-        Projector::from_pairs([(site_inds[0].clone(), 0)]),
-    );
-    let subdomain2 = SubDomainTT::new(
-        tt2.clone(),
-        Projector::from_pairs([(site_inds[0].clone(), 1)]),
-    );
+    let subdomain1 = subdomain(tt1.clone(), projector([(site_inds[0].clone(), 0)]));
+    let subdomain2 = subdomain(tt2.clone(), projector([(site_inds[0].clone(), 1)]));
     let partitioned = PartitionedTT::from_subdomains(vec![subdomain1, subdomain2]).unwrap();
 
     let combined = partitioned.to_tensor_train().unwrap();
@@ -525,10 +607,10 @@ fn test_partitioned_tt_into_iter() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
 
     let partitioned = PartitionedTT::from_subdomains(vec![subdomain1, subdomain2]).unwrap();
 
@@ -557,15 +639,15 @@ fn test_partitioned_tt_contract_with_duplicate_projectors() {
     // TT1 partitioned by s1: patches for s1=0 and s1=1
     let tt1_a = make_tt1(&s0, &l01, &s1);
     let tt1_b = make_tt1(&s0, &l01, &s1);
-    let subdomain1_a = SubDomainTT::new(tt1_a, Projector::from_pairs([(s1.clone(), 0)]));
-    let subdomain1_b = SubDomainTT::new(tt1_b, Projector::from_pairs([(s1.clone(), 1)]));
+    let subdomain1_a = subdomain(tt1_a, projector([(s1.clone(), 0)]));
+    let subdomain1_b = subdomain(tt1_b, projector([(s1.clone(), 1)]));
     let partitioned1 = PartitionedTT::from_subdomains(vec![subdomain1_a, subdomain1_b]).unwrap();
 
     // TT2 partitioned by s1: patches for s1=0 and s1=1
     let tt2_a = make_tt2(&s1, &l12, &s2);
     let tt2_b = make_tt2(&s1, &l12, &s2);
-    let subdomain2_a = SubDomainTT::new(tt2_a, Projector::from_pairs([(s1.clone(), 0)]));
-    let subdomain2_b = SubDomainTT::new(tt2_b, Projector::from_pairs([(s1.clone(), 1)]));
+    let subdomain2_a = subdomain(tt2_a, projector([(s1.clone(), 0)]));
+    let subdomain2_b = subdomain(tt2_b, projector([(s1.clone(), 1)]));
     let partitioned2 = PartitionedTT::from_subdomains(vec![subdomain2_a, subdomain2_b]).unwrap();
 
     // Contract: (s1=0 x s1=0) and (s1=1 x s1=1) both have compatible projectors
@@ -593,14 +675,14 @@ fn test_partitioned_tt_contract_with_rtol_and_max_bond_dim() {
     // Same setup as above to trigger the duplicate-projector branch
     let tt1_a = make_tt1(&s0, &l01, &s1);
     let tt1_b = make_tt1(&s0, &l01, &s1);
-    let subdomain1_a = SubDomainTT::new(tt1_a, Projector::from_pairs([(s1.clone(), 0)]));
-    let subdomain1_b = SubDomainTT::new(tt1_b, Projector::from_pairs([(s1.clone(), 1)]));
+    let subdomain1_a = subdomain(tt1_a, projector([(s1.clone(), 0)]));
+    let subdomain1_b = subdomain(tt1_b, projector([(s1.clone(), 1)]));
     let partitioned1 = PartitionedTT::from_subdomains(vec![subdomain1_a, subdomain1_b]).unwrap();
 
     let tt2_a = make_tt2(&s1, &l12, &s2);
     let tt2_b = make_tt2(&s1, &l12, &s2);
-    let subdomain2_a = SubDomainTT::new(tt2_a, Projector::from_pairs([(s1.clone(), 0)]));
-    let subdomain2_b = SubDomainTT::new(tt2_b, Projector::from_pairs([(s1.clone(), 1)]));
+    let subdomain2_a = subdomain(tt2_a, projector([(s1.clone(), 0)]));
+    let subdomain2_b = subdomain(tt2_b, projector([(s1.clone(), 1)]));
     let partitioned2 = PartitionedTT::from_subdomains(vec![subdomain2_a, subdomain2_b]).unwrap();
 
     let options = ContractOptions::default()
@@ -619,18 +701,12 @@ fn test_partitioned_tt_add_disjoint_patches() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(
-        tt1.clone(),
-        Projector::from_pairs([(site_inds[0].clone(), 0)]),
-    );
-    let partitioned1 = PartitionedTT::from_subdomain(subdomain1);
+    let subdomain1 = subdomain(tt1.clone(), projector([(site_inds[0].clone(), 0)]));
+    let partitioned1 = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(
-        tt2.clone(),
-        Projector::from_pairs([(site_inds[0].clone(), 1)]),
-    );
-    let partitioned2 = PartitionedTT::from_subdomain(subdomain2);
+    let subdomain2 = subdomain(tt2.clone(), projector([(site_inds[0].clone(), 1)]));
+    let partitioned2 = PartitionedTT::from_subdomain(subdomain2).unwrap();
 
     let options = TruncateOptions::svd();
     let result = partitioned1.add(&partitioned2, &options).unwrap();
@@ -639,8 +715,8 @@ fn test_partitioned_tt_add_disjoint_patches() {
     assert_eq!(result.len(), 2);
 
     // Each should have the same norm as the original
-    let proj0 = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let proj1 = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let proj0 = projector([(site_inds[0].clone(), 0)]);
+    let proj1 = projector([(site_inds[0].clone(), 1)]);
     assert!((result.get(&proj0).unwrap().norm().unwrap() - tt1.norm().unwrap()).abs() < 1e-10);
     assert!((result.get(&proj1).unwrap().norm().unwrap() - tt2.norm().unwrap()).abs() < 1e-10);
 }
@@ -651,13 +727,13 @@ fn test_partitioned_tt_add_overlapping_fails() {
 
     // partitioned1 has patch for s0=0
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
-    let partitioned1 = PartitionedTT::from_subdomain(subdomain1);
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
+    let partitioned1 = PartitionedTT::from_subdomain(subdomain1).unwrap();
 
     // partitioned2 has patch for s1=0 (overlaps with s0=0 since they're compatible)
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[1].clone(), 0)]));
-    let partitioned2 = PartitionedTT::from_subdomain(subdomain2);
+    let subdomain2 = subdomain(tt2, projector([(site_inds[1].clone(), 0)]));
+    let partitioned2 = PartitionedTT::from_subdomain(subdomain2).unwrap();
 
     // Add should fail because projectors are compatible (not disjoint)
     let options = TruncateOptions::svd();

--- a/crates/tensor4all-partitionedtt/src/patching.rs
+++ b/crates/tensor4all-partitionedtt/src/patching.rs
@@ -255,10 +255,10 @@ pub fn add_with_patching(
 /// let right_l12 = Index::new_dyn(3);
 /// let left = PartitionedTT::from_subdomain(SubDomainTT::from_tt(three_site_tt(
 ///     &s0, &left_l01, &s1, &left_l12, &s2,
-/// )?));
+/// )?))?;
 /// let right = PartitionedTT::from_subdomain(SubDomainTT::from_tt(three_site_tt(
 ///     &s0, &right_l01, &s1, &right_l12, &s2,
-/// )?));
+/// )?))?;
 /// let patching = PatchingOptions {
 ///     rtol: 0.0,
 ///     max_bond_dim: Some(1),
@@ -333,10 +333,10 @@ pub fn contract_adaptive(
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let s0 = Index::new_dyn(2);
 /// let s1 = Index::new_dyn(2);
-/// let high_proj = Projector::from_pairs([(s0.clone(), 0)]);
-/// let low_proj = Projector::from_pairs([(s0.clone(), 1)]);
-/// let high = SubDomainTT::new(rank_one_tt(&s0, &s1, 10.0)?, high_proj.clone());
-/// let low = SubDomainTT::new(rank_one_tt(&s0, &s1, 0.01)?, low_proj.clone());
+/// let high_proj = Projector::from_pairs([(s0.clone(), 0)])?;
+/// let low_proj = Projector::from_pairs([(s0.clone(), 1)])?;
+/// let high = SubDomainTT::new(rank_one_tt(&s0, &s1, 10.0)?, high_proj.clone())?;
+/// let low = SubDomainTT::new(rank_one_tt(&s0, &s1, 0.01)?, low_proj.clone())?;
 /// let partitioned = PartitionedTT::from_subdomains(vec![high, low])?;
 ///
 /// let truncated = truncate_adaptive(&partitioned, 0.01, Some(4))?;
@@ -679,7 +679,7 @@ fn split_subdomain(subdomain: &SubDomainTT, index: &DynIndex) -> Result<Vec<SubD
         .map(|budget_squared| budget_squared / index.dim as f64);
     let mut children = Vec::with_capacity(index.dim);
     for value in 0..index.dim {
-        let projector = Projector::from_pairs([(index.clone(), value)]);
+        let projector = Projector::from_pairs([(index.clone(), value)])?;
         let child = subdomain.project(&projector)?.ok_or_else(|| {
             PartitionedTTError::IncompatibleProjectors(
                 "split projector was incompatible with subdomain projector".to_string(),

--- a/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
@@ -1,4 +1,12 @@
 use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+
+fn subdomain(data: TensorTrain, projector: Projector) -> SubDomainTT {
+    SubDomainTT::new(data, projector).unwrap()
+}
 use crate::projector::Projector;
 use approx::assert_abs_diff_eq;
 use tensor4all_core::index::Index;
@@ -100,10 +108,10 @@ fn test_add_with_patching_simple() {
     let (site_inds, link_ind) = make_shared_indices();
 
     let tt1 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain1 = SubDomainTT::new(tt1, Projector::from_pairs([(site_inds[0].clone(), 0)]));
+    let subdomain1 = subdomain(tt1, projector([(site_inds[0].clone(), 0)]));
 
     let tt2 = make_tt_with_indices(&site_inds, &link_ind);
-    let subdomain2 = SubDomainTT::new(tt2, Projector::from_pairs([(site_inds[0].clone(), 1)]));
+    let subdomain2 = subdomain(tt2, projector([(site_inds[0].clone(), 1)]));
 
     let options = PatchingOptions::default();
     let result = add_with_patching(vec![subdomain1, subdomain2], &options).unwrap();
@@ -126,8 +134,8 @@ fn test_add_with_patching_splits_unprojected_patch_when_bond_hits_cap() {
     };
 
     let result = add_with_patching(vec![subdomain1], &options).unwrap();
-    let proj0 = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let proj1 = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let proj0 = projector([(site_inds[0].clone(), 0)]);
+    let proj1 = projector([(site_inds[0].clone(), 1)]);
 
     assert_eq!(result.len(), 2);
     assert!(result.contains(&proj0));
@@ -164,11 +172,11 @@ fn test_add_with_patching_truncates_before_deciding_to_split() {
 #[test]
 fn test_truncate_adaptive_drops_patch_below_volume_budget() {
     let site_inds = vec![make_index(2), make_index(2)];
-    let high_proj = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let low_proj = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let high_proj = projector([(site_inds[0].clone(), 0)]);
+    let low_proj = projector([(site_inds[0].clone(), 1)]);
 
-    let high = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 10.0), high_proj.clone());
-    let low = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 0.01), low_proj.clone());
+    let high = subdomain(make_scaled_rank_one_tt(&site_inds, 10.0), high_proj.clone());
+    let low = subdomain(make_scaled_rank_one_tt(&site_inds, 0.01), low_proj.clone());
     let partitioned = PartitionedTT::from_subdomains(vec![high, low]).unwrap();
 
     let result = truncate_adaptive(&partitioned, 0.01, Some(4)).unwrap();
@@ -181,11 +189,11 @@ fn test_truncate_adaptive_drops_patch_below_volume_budget() {
 #[test]
 fn test_truncate_adaptive_assigns_volume_proportional_budgets() {
     let site_inds = vec![make_index(2), make_index(2)];
-    let wide_proj = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let narrow_proj = Projector::from_pairs([(site_inds[0].clone(), 1), (site_inds[1].clone(), 0)]);
+    let wide_proj = projector([(site_inds[0].clone(), 0)]);
+    let narrow_proj = projector([(site_inds[0].clone(), 1), (site_inds[1].clone(), 0)]);
 
-    let wide = SubDomainTT::new(make_scaled_rank_one_tt(&site_inds, 10.0), wide_proj.clone());
-    let narrow = SubDomainTT::new(
+    let wide = subdomain(make_scaled_rank_one_tt(&site_inds, 10.0), wide_proj.clone());
+    let narrow = subdomain(
         make_scaled_rank_one_tt(&site_inds, 10.0),
         narrow_proj.clone(),
     );
@@ -226,10 +234,12 @@ fn test_contract_adaptive_retruncates_output_with_corrected_norm() {
     let r12 = make_index(3);
     let left = PartitionedTT::from_subdomain(SubDomainTT::from_tt(make_contract_tt(
         &s0, &l01, &s1, &l12, &s2,
-    )));
+    )))
+    .unwrap();
     let right = PartitionedTT::from_subdomain(SubDomainTT::from_tt(make_contract_tt(
         &s0, &r01, &s1, &r12, &s2,
-    )));
+    )))
+    .unwrap();
     let patching = PatchingOptions {
         rtol: 0.0,
         max_bond_dim: Some(1),

--- a/crates/tensor4all-partitionedtt/src/projector.rs
+++ b/crates/tensor4all-partitionedtt/src/projector.rs
@@ -3,8 +3,11 @@
 //! A projector maps tensor indices (DynIndex) to fixed values, defining a subdomain
 //! where specific indices are fixed to particular values.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
-use tensor4all_core::DynIndex;
+
+use crate::error::{PartitionedTTError, Result};
+use tensor4all_core::{DynIndex, TagSetLike};
 
 /// A projector maps tensor indices to fixed integer values.
 ///
@@ -21,7 +24,7 @@ use tensor4all_core::DynIndex;
 /// let idx1 = Index::new_dyn(3);
 ///
 /// // Create a projector that fixes idx0 to value 1
-/// let p = Projector::from_pairs([(idx0.clone(), 1)]);
+/// let p = Projector::from_pairs([(idx0.clone(), 1)]).unwrap();
 ///
 /// assert!(p.is_projected_at(&idx0));
 /// assert!(!p.is_projected_at(&idx1));
@@ -41,11 +44,22 @@ impl Projector {
         }
     }
 
-    /// Create a projector from pairs of (index, projected_value)
-    pub fn from_pairs(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Self {
-        Self {
-            data: pairs.into_iter().collect(),
+    /// Create a projector from `(index, projected_value)` pairs.
+    ///
+    /// Coordinates are zero-based and must be smaller than their index
+    /// dimension. If an identity appears more than once, the last validated
+    /// pair replaces the earlier key and value together.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTTError::ProjectorCoordinateOutOfBounds`] when a
+    /// coordinate is not in `0..index.dim()`.
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Result<Self> {
+        let mut projector = Self::new();
+        for (index, value) in pairs {
+            projector.insert(index, value)?;
         }
+        Ok(projector)
     }
 
     /// Check if an index is projected
@@ -78,9 +92,28 @@ impl Projector {
         self.data.iter()
     }
 
-    /// Insert or update a projection
-    pub fn insert(&mut self, index: DynIndex, value: usize) {
+    /// Insert or update a projection.
+    ///
+    /// `value` is a zero-based coordinate and must be smaller than
+    /// `index.dim()`. An update whose index is equal by full projector
+    /// identity replaces the stored key and coordinate together.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTTError::ProjectorCoordinateOutOfBounds`] and
+    /// leaves this projector unchanged when `value >= index.dim()`.
+    pub fn insert(&mut self, index: DynIndex, value: usize) -> Result<()> {
+        if value >= index.dim {
+            let dim = index.dim;
+            return Err(PartitionedTTError::ProjectorCoordinateOutOfBounds { index, value, dim });
+        }
+
+        // HashMap::insert keeps the old key when an equal key already exists.
+        // Remove first so the stored identity and coordinate are replaced as a
+        // pair, including when only the dimension differs.
+        self.data.remove(&index);
         self.data.insert(index, value);
+        Ok(())
     }
 
     /// Remove a projection
@@ -189,6 +222,49 @@ impl Projector {
                 .collect(),
         }
     }
+
+    /// Return entries in the canonical identity and coordinate order.
+    pub(crate) fn canonical_entries(&self) -> Vec<(&DynIndex, usize)> {
+        let mut entries: Vec<_> = self
+            .data
+            .iter()
+            .map(|(index, &value)| (index, value))
+            .collect();
+        entries.sort_by(canonical_entry_cmp);
+        entries
+    }
+
+    /// Compare projectors by a deterministic total order compatible with Eq.
+    pub(crate) fn canonical_cmp(&self, other: &Self) -> Ordering {
+        let left = self.canonical_entries();
+        let right = other.canonical_entries();
+        match left.len().cmp(&right.len()) {
+            Ordering::Equal => {}
+            order => return order,
+        }
+
+        for (left_entry, right_entry) in left.iter().zip(&right) {
+            match canonical_entry_cmp(left_entry, right_entry) {
+                Ordering::Equal => {}
+                order => return order,
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+fn canonical_entry_cmp(
+    (left_index, left_value): &(&DynIndex, usize),
+    (right_index, right_value): &(&DynIndex, usize),
+) -> Ordering {
+    canonical_index_cmp(left_index, right_index).then_with(|| left_value.cmp(right_value))
+}
+
+fn canonical_index_cmp(left: &DynIndex, right: &DynIndex) -> Ordering {
+    left.id
+        .cmp(&right.id)
+        .then_with(|| left.tags.iter().cmp(right.tags.iter()))
+        .then_with(|| left.plev.cmp(&right.plev))
 }
 
 impl PartialEq for Projector {
@@ -201,12 +277,10 @@ impl Eq for Projector {}
 
 impl std::hash::Hash for Projector {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // Sort entries by index ID for consistent hashing
-        let mut entries: Vec<_> = self.data.iter().collect();
-        entries.sort_by_key(|(k, _)| k.id);
-        for (k, v) in entries {
-            k.hash(state);
-            v.hash(state);
+        self.data.len().hash(state);
+        for (index, value) in self.canonical_entries() {
+            index.hash(state);
+            value.hash(state);
         }
     }
 }
@@ -222,12 +296,6 @@ impl PartialOrd for Projector {
         } else {
             None
         }
-    }
-}
-
-impl FromIterator<(DynIndex, usize)> for Projector {
-    fn from_iter<I: IntoIterator<Item = (DynIndex, usize)>>(iter: I) -> Self {
-        Self::from_pairs(iter)
     }
 }
 

--- a/crates/tensor4all-partitionedtt/src/projector/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/projector/tests/mod.rs
@@ -1,5 +1,11 @@
 use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+use std::hash::{Hash, Hasher};
 use tensor4all_core::index::Index;
+use tensor4all_core::TagSet;
 
 fn make_index(size: usize) -> DynIndex {
     Index::new_dyn(size)
@@ -18,7 +24,7 @@ fn test_projector_from_pairs() {
     let idx1 = make_index(3);
     let idx2 = make_index(4);
 
-    let p = Projector::from_pairs([(idx0.clone(), 1), (idx2.clone(), 3)]);
+    let p = projector([(idx0.clone(), 1), (idx2.clone(), 3)]);
     assert_eq!(p.len(), 2);
     assert!(p.is_projected_at(&idx0));
     assert!(!p.is_projected_at(&idx1));
@@ -29,13 +35,38 @@ fn test_projector_from_pairs() {
 }
 
 #[test]
+fn projector_accepts_zero_and_last_coordinates() {
+    let zero = make_index(2);
+    let last = make_index(3);
+    let projector = Projector::from_pairs([(zero.clone(), 0), (last.clone(), 2)]).unwrap();
+
+    assert_eq!(projector.get(&zero), Some(0));
+    assert_eq!(projector.get(&last), Some(2));
+}
+
+#[test]
+fn projector_from_pairs_rejects_out_of_range_coordinate() {
+    let index = make_index(2);
+    let error = Projector::from_pairs([(index.clone(), 2)]).unwrap_err();
+
+    assert!(matches!(
+        error,
+        PartitionedTTError::ProjectorCoordinateOutOfBounds {
+            index: error_index,
+            value: 2,
+            dim: 2,
+        } if error_index == index
+    ));
+}
+
+#[test]
 fn test_projector_intersection_compatible() {
     let idx0 = make_index(2);
     let idx1 = make_index(2);
     let idx2 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0)]);
-    let b = Projector::from_pairs([(idx1.clone(), 0), (idx2.clone(), 1)]);
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 0), (idx2.clone(), 1)]);
 
     let merged = a.intersection(&b).unwrap();
     assert_eq!(merged.len(), 3);
@@ -49,8 +80,8 @@ fn test_projector_intersection_conflict() {
     let idx0 = make_index(2);
     let idx1 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0)]);
-    let b = Projector::from_pairs([(idx1.clone(), 1)]); // Conflict at idx1
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 1)]); // Conflict at idx1
 
     assert!(a.intersection(&b).is_none());
 }
@@ -61,8 +92,8 @@ fn test_projector_common_restriction() {
     let idx1 = make_index(2);
     let idx2 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0)]);
-    let b = Projector::from_pairs([(idx1.clone(), 0), (idx2.clone(), 1)]);
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 0), (idx2.clone(), 1)]);
 
     // Only idx1 is in both with the same value
     let common = a.common_restriction(&b);
@@ -78,9 +109,9 @@ fn test_projector_is_compatible_with() {
     let idx0 = make_index(2);
     let idx1 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1)]);
-    let b = Projector::from_pairs([(idx1.clone(), 0)]);
-    let c = Projector::from_pairs([(idx0.clone(), 0)]); // Different value at same index
+    let a = projector([(idx0.clone(), 1)]);
+    let b = projector([(idx1.clone(), 0)]);
+    let c = projector([(idx0.clone(), 0)]); // Different value at same index
 
     assert!(a.is_compatible_with(&b)); // No common indices, compatible
     assert!(!a.is_compatible_with(&c)); // Same index, different values
@@ -92,9 +123,9 @@ fn test_projector_is_subset_of() {
     let idx1 = make_index(2);
     let idx2 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0), (idx2.clone(), 1)]);
-    let b = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0)]);
-    let c = Projector::from_pairs([(idx0.clone(), 1)]);
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0), (idx2.clone(), 1)]);
+    let b = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let c = projector([(idx0.clone(), 1)]);
 
     assert!(a.is_subset_of(&b)); // a projects more indices
     assert!(a.is_subset_of(&c));
@@ -108,13 +139,13 @@ fn test_projector_are_disjoint() {
     let idx0 = make_index(2);
 
     // Disjoint projectors: different values at same index
-    let p1 = Projector::from_pairs([(idx0.clone(), 0)]);
-    let p2 = Projector::from_pairs([(idx0.clone(), 1)]);
+    let p1 = projector([(idx0.clone(), 0)]);
+    let p2 = projector([(idx0.clone(), 1)]);
 
     assert!(Projector::are_disjoint(&[p1.clone(), p2.clone()]));
 
     // Non-disjoint: same projection
-    let p3 = Projector::from_pairs([(idx0.clone(), 0)]);
+    let p3 = projector([(idx0.clone(), 0)]);
     assert!(!Projector::are_disjoint(&[p1, p3]));
 }
 
@@ -123,9 +154,9 @@ fn test_projector_partial_ord() {
     let idx0 = make_index(2);
     let idx1 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0)]);
-    let b = Projector::from_pairs([(idx0.clone(), 1)]);
-    let c = Projector::from_pairs([(idx0.clone(), 0)]); // Incompatible with a and b
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx0.clone(), 1)]);
+    let c = projector([(idx0.clone(), 0)]); // Incompatible with a and b
 
     assert!(a < b);
     assert!(b > a);
@@ -138,7 +169,7 @@ fn test_projector_iteration() {
     let idx0 = make_index(2);
     let idx1 = make_index(3);
 
-    let p = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 2)]);
+    let p = projector([(idx0.clone(), 1), (idx1.clone(), 2)]);
 
     let pairs: Vec<_> = p.into_iter().collect();
     assert_eq!(pairs.len(), 2);
@@ -151,9 +182,9 @@ fn test_projector_equality_and_hash() {
     let idx0 = make_index(2);
     let idx1 = make_index(2);
 
-    let a = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0)]);
-    let b = Projector::from_pairs([(idx1.clone(), 0), (idx0.clone(), 1)]); // Same content
-    let c = Projector::from_pairs([(idx0.clone(), 1)]);
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 0), (idx0.clone(), 1)]); // Same content
+    let c = projector([(idx0.clone(), 1)]);
 
     assert_eq!(a, b);
     assert_ne!(a, c);
@@ -164,13 +195,92 @@ fn test_projector_equality_and_hash() {
     assert!(!set.contains(&c));
 }
 
+fn hash_projector(projector: &Projector) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    projector.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[test]
+fn projector_hash_uses_canonical_full_identity_order() {
+    let base = make_index(2);
+    let pairs: Vec<_> = (0..32)
+        .map(|value| {
+            let tags = TagSet::from_str(&format!("Tag{value:02}")).unwrap();
+            (Index::new_with_tags(base.id, 2, tags), value % 2)
+        })
+        .collect();
+    let mut reversed = pairs.clone();
+    reversed.reverse();
+
+    let first = projector(pairs);
+    let second = projector(reversed);
+
+    assert_eq!(first, second);
+    assert_eq!(hash_projector(&first), hash_projector(&second));
+}
+
+#[test]
+fn projector_multi_tag_identity_has_canonical_hash_and_order() {
+    let base = make_index(2);
+    let first_index = Index::new_with_tags(
+        base.id,
+        base.dim,
+        TagSet::from_str("Site,Auxiliary").unwrap(),
+    );
+    let second_index = Index::new_with_tags(
+        base.id,
+        base.dim,
+        TagSet::from_str("Auxiliary,Site").unwrap(),
+    );
+    let first = projector([(first_index, 1)]);
+    let second = projector([(second_index, 1)]);
+
+    assert_eq!(first, second);
+    assert_eq!(hash_projector(&first), hash_projector(&second));
+    assert_eq!(first.canonical_cmp(&second), std::cmp::Ordering::Equal);
+}
+
+#[test]
+fn projector_insert_rejects_out_of_range_coordinate_without_mutating() {
+    let index = make_index(2);
+    let mut projector = projector([(index.clone(), 0)]);
+    let before = projector.clone();
+
+    for value in [index.dim, index.dim + 1] {
+        let error = projector.insert(index.clone(), value).unwrap_err();
+        assert!(matches!(
+            error,
+            PartitionedTTError::ProjectorCoordinateOutOfBounds {
+                index: error_index,
+                value: error_value,
+                dim,
+            } if error_index == index && error_value == value && dim == index.dim
+        ));
+        assert_eq!(projector, before);
+    }
+}
+
+#[test]
+fn projector_duplicate_identity_replaces_key_and_value_together() {
+    let index = make_index(2);
+    let replacement = Index::new_with_tags(index.id, 5, index.tags.clone());
+    let mut projector = projector([(index, 1)]);
+
+    projector.insert(replacement.clone(), 3).unwrap();
+
+    let (stored_index, stored_value) = projector.iter().next().unwrap();
+    assert_eq!(stored_index, &replacement);
+    assert_eq!(*stored_value, 3);
+}
+
 #[test]
 fn test_projector_filter_indices() {
     let idx0 = make_index(2);
     let idx1 = make_index(2);
     let idx2 = make_index(2);
 
-    let p = Projector::from_pairs([(idx0.clone(), 1), (idx1.clone(), 0), (idx2.clone(), 1)]);
+    let p = projector([(idx0.clone(), 1), (idx1.clone(), 0), (idx2.clone(), 1)]);
 
     let filtered = p.filter_indices(&[idx0.clone(), idx2.clone()]);
     assert_eq!(filtered.len(), 2);

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt.rs
@@ -28,8 +28,8 @@ use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
 /// let t1 = IdxTensor::from_dense(vec![bond.clone(), site1.clone()], vec![3.0, 4.0]).unwrap();
 /// let tt = TensorTrain::new(vec![t0, t1]).unwrap();
 ///
-/// let projector = Projector::from_pairs([(site0.clone(), 1)]);
-/// let subdomain_tt = SubDomainTT::new(tt, projector);
+/// let projector = Projector::from_pairs([(site0.clone(), 1)]).unwrap();
+/// let subdomain_tt = SubDomainTT::new(tt, projector).unwrap();
 ///
 /// assert_eq!(subdomain_tt.len(), 2);
 /// assert_eq!(subdomain_tt.projector().get(&site0), Some(1));
@@ -46,18 +46,25 @@ pub struct SubDomainTT {
 }
 
 impl SubDomainTT {
-    /// Create a new SubDomainTT from a tensor train and projector.
+    /// Create a new `SubDomainTT` from a tensor train and projector.
     ///
-    /// The projector is trimmed to only include indices that exist in the tensor train.
-    pub fn new(data: TensorTrain, projector: Projector) -> Self {
-        // Trim projector to only include valid indices
-        let all_indices = Self::collect_all_indices(&data);
-        let trimmed_projector = projector.filter_indices(&all_indices);
-        Self {
+    /// Projector indices must match tensor-train site indices by full identity
+    /// (`id`, canonical tags, and prime level). Coordinates are zero-based and
+    /// are checked against the matched tensor-train dimensions. The projector
+    /// is stored unchanged after validation; no entries are filtered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTTError::ProjectorIndexNotFound`] for an absent
+    /// full identity or [`PartitionedTTError::ProjectorCoordinateOutOfBounds`]
+    /// when a coordinate is outside the matched tensor-train dimension.
+    pub fn new(data: TensorTrain, projector: Projector) -> Result<Self> {
+        Self::validate_projector_against_data(&data, &projector)?;
+        Ok(Self {
             data,
-            projector: trimmed_projector,
+            projector,
             budget_squared: None,
-        }
+        })
     }
 
     /// Create a SubDomainTT from a tensor train with an empty projector.
@@ -82,11 +89,6 @@ impl SubDomainTT {
     /// Get a reference to the underlying tensor train.
     pub fn data(&self) -> &TensorTrain {
         &self.data
-    }
-
-    /// Get a mutable reference to the underlying tensor train.
-    pub fn data_mut(&mut self) -> &mut TensorTrain {
-        &mut self.data
     }
 
     /// Get a reference to the projector.
@@ -159,7 +161,7 @@ impl SubDomainTT {
     /// let tensor = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0]).unwrap();
     /// let subdomain = SubDomainTT::from_tt(TensorTrain::new(vec![tensor]).unwrap());
     /// let projected = subdomain
-    ///     .project(&Projector::from_pairs([(site.clone(), 1)]))
+    ///     .project(&Projector::from_pairs([(site.clone(), 1)]).unwrap())
     ///     .unwrap()
     ///     .unwrap();
     ///
@@ -178,6 +180,7 @@ impl SubDomainTT {
             .projector
             .intersection(projector)
             .ok_or(PartitionedTTError::ProjectorConflict)?;
+        self.validate_projector(&merged_projector)?;
         let projected_data = self.project_tensor_data(projector)?;
 
         Ok(Some(Self {
@@ -187,19 +190,28 @@ impl SubDomainTT {
         }))
     }
 
+    pub(crate) fn validate_invariants(&self) -> Result<()> {
+        self.validate_projector(&self.projector)
+    }
+
     fn validate_projector(&self, projector: &Projector) -> Result<()> {
-        let all_indices: HashSet<_> = self.all_indices().into_iter().collect();
+        Self::validate_projector_against_data(&self.data, projector)
+    }
+
+    fn validate_projector_against_data(data: &TensorTrain, projector: &Projector) -> Result<()> {
+        let all_indices = Self::collect_all_indices(data);
         for (index, &value) in projector.iter() {
-            if !all_indices.contains(index) {
+            let matched = all_indices.iter().find(|candidate| *candidate == index);
+            let Some(matched) = matched else {
                 return Err(PartitionedTTError::ProjectorIndexNotFound {
                     index: index.clone(),
                 });
-            }
-            if value >= index.dim {
+            };
+            if value >= matched.dim {
                 return Err(PartitionedTTError::ProjectorCoordinateOutOfBounds {
                     index: index.clone(),
                     value,
-                    dim: index.dim,
+                    dim: matched.dim,
                 });
             }
         }
@@ -350,7 +362,7 @@ impl SubDomainTT {
             .map_err(|source| PartitionedTTError::TensorTrain { source })?;
 
         // Create result with the new projector
-        let result = Self::new(contracted_data, proj_after);
+        let result = Self::new(contracted_data, proj_after)?;
 
         Ok(Some(result))
     }
@@ -390,7 +402,7 @@ impl SubDomainTT {
             }
         }
 
-        Ok((Projector::from_pairs(proj_data), external))
+        Ok((Projector::from_pairs(proj_data)?, external))
     }
 
     /// Inner product with another SubDomainTT.

--- a/crates/tensor4all-partitionedtt/src/subdomain_tt/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/subdomain_tt/tests/mod.rs
@@ -1,4 +1,12 @@
 use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+
+fn subdomain(data: TensorTrain, projector: Projector) -> SubDomainTT {
+    SubDomainTT::new(data, projector).unwrap()
+}
 use std::sync::Arc;
 use tensor4all_core::index::Index;
 use tensor4all_core::{IdxTensorError, TensorStorageError};
@@ -30,9 +38,9 @@ fn make_simple_tt() -> (TensorTrain, Vec<DynIndex>, Vec<DynIndex>) {
 #[test]
 fn test_subdomain_tt_creation() {
     let (tt, site_inds, _) = make_simple_tt();
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let projector = projector([(site_inds[0].clone(), 1)]);
 
-    let subdomain = SubDomainTT::new(tt, projector);
+    let subdomain = subdomain(tt, projector);
 
     assert_eq!(subdomain.len(), 2);
     assert!(subdomain.is_projected_at(&site_inds[0]));
@@ -54,7 +62,7 @@ fn test_subdomain_tt_project() {
     let subdomain = SubDomainTT::from_tt(tt);
 
     // Project to fix site 0 to value 1
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let projector = projector([(site_inds[0].clone(), 1)]);
     let projected = subdomain.project(&projector).unwrap();
 
     assert!(projected.is_some());
@@ -70,7 +78,7 @@ fn test_subdomain_tt_project_value_one_numeric() {
     let full_data = full.to_vec::<f64>().unwrap();
 
     let subdomain = SubDomainTT::from_tt(tt);
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let projector = projector([(site_inds[0].clone(), 1)]);
     let projected = subdomain.project(&projector).unwrap().unwrap();
     let projected_full = projected.data().to_dense().unwrap();
     let projected_data = projected_full.to_vec::<f64>().unwrap();
@@ -85,11 +93,11 @@ fn test_subdomain_tt_project_value_one_numeric() {
 #[test]
 fn test_subdomain_tt_project_incompatible() {
     let (tt, site_inds, _) = make_simple_tt();
-    let projector1 = Projector::from_pairs([(site_inds[0].clone(), 0)]);
-    let subdomain = SubDomainTT::new(tt, projector1);
+    let projector1 = projector([(site_inds[0].clone(), 0)]);
+    let subdomain = subdomain(tt, projector1);
 
     // Try to project with incompatible projector (different value at same site)
-    let projector2 = Projector::from_pairs([(site_inds[0].clone(), 1)]);
+    let projector2 = projector([(site_inds[0].clone(), 1)]);
     let projected = subdomain.project(&projector2).unwrap();
 
     assert!(projected.is_none());
@@ -116,30 +124,73 @@ fn test_subdomain_tt_norm() {
 }
 
 #[test]
-fn test_subdomain_tt_trim_projector() {
+fn subdomain_new_rejects_absent_projector_index() {
     let (tt, site_inds, _) = make_simple_tt();
-    // Projector with an index that doesn't exist in TT
-    let fake_index = make_index(5);
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 1), (fake_index.clone(), 0)]);
+    let absent = make_index(5);
+    let projector = projector([(site_inds[0].clone(), 1), (absent.clone(), 0)]);
 
-    let subdomain = SubDomainTT::new(tt, projector);
+    let error = SubDomainTT::new(tt, projector).unwrap_err();
 
-    // Fake index should be trimmed
-    assert!(subdomain.is_projected_at(&site_inds[0]));
-    assert!(!subdomain.is_projected_at(&fake_index));
-    assert_eq!(subdomain.projector().len(), 1);
+    assert!(matches!(
+        error,
+        PartitionedTTError::ProjectorIndexNotFound { index } if index == absent
+    ));
 }
 
 #[test]
-fn project_rejects_out_of_range_coordinate() {
+fn subdomain_new_rejects_same_id_tag_or_prime_variants() {
+    let (tt, site_inds, _) = make_simple_tt();
+    let tagged = tensor4all_core::index::Index::new_with_tags(
+        site_inds[0].id,
+        site_inds[0].dim,
+        tensor4all_core::TagSet::from_str("Site").unwrap(),
+    );
+    let primed = site_inds[0].prime();
+
+    for absent in [tagged, primed] {
+        let error = SubDomainTT::new(tt.clone(), projector([(absent.clone(), 0)])).unwrap_err();
+        assert!(matches!(
+            error,
+            PartitionedTTError::ProjectorIndexNotFound { index } if index == absent
+        ));
+    }
+}
+
+#[test]
+fn subdomain_new_validates_against_matched_tensor_train_dimension() {
+    let (tt, site_inds, _) = make_simple_tt();
+    let mismatched_dimension =
+        tensor4all_core::index::Index::new_with_tags(site_inds[0].id, 5, site_inds[0].tags.clone());
+    let projector = projector([(mismatched_dimension.clone(), 2)]);
+
+    let error = SubDomainTT::new(tt, projector).unwrap_err();
+
+    assert!(matches!(
+        error,
+        PartitionedTTError::ProjectorCoordinateOutOfBounds {
+            index,
+            value: 2,
+            dim: 2,
+        } if index == mismatched_dimension
+    ));
+}
+
+#[test]
+fn project_rejects_out_of_range_coordinate_against_tt_dimension() {
     let (tt, site_inds, _) = make_simple_tt();
     let subdomain = SubDomainTT::from_tt(tt);
-    let projector = Projector::from_pairs([(site_inds[0].clone(), 2)]);
+    let mismatched_dimension =
+        tensor4all_core::index::Index::new_with_tags(site_inds[0].id, 5, site_inds[0].tags.clone());
+    let projector = projector([(mismatched_dimension.clone(), 2)]);
 
     let error = subdomain.project(&projector).unwrap_err();
     assert!(matches!(
         error,
-        PartitionedTTError::ProjectorCoordinateOutOfBounds { .. }
+        PartitionedTTError::ProjectorCoordinateOutOfBounds {
+            index,
+            value: 2,
+            dim: 2,
+        } if index == mismatched_dimension
     ));
 }
 
@@ -148,12 +199,12 @@ fn project_rejects_index_absent_from_tensor_train() {
     let (tt, _, _) = make_simple_tt();
     let subdomain = SubDomainTT::from_tt(tt);
     let absent = make_index(2);
-    let projector = Projector::from_pairs([(absent, 0)]);
+    let projector = projector([(absent.clone(), 0)]);
 
     let error = subdomain.project(&projector).unwrap_err();
     assert!(matches!(
         error,
-        PartitionedTTError::ProjectorIndexNotFound { .. }
+        PartitionedTTError::ProjectorIndexNotFound { index } if index == absent
     ));
 }
 
@@ -167,10 +218,7 @@ fn project_preserves_autodiff_metadata_and_backward_values() {
     let source_alias = source.clone();
     let subdomain = SubDomainTT::from_tt(TensorTrain::new(vec![source]).unwrap());
 
-    let projected = subdomain
-        .project(&Projector::from_pairs([(site, 1)]))
-        .unwrap()
-        .unwrap();
+    let projected = subdomain.project(&projector([(site, 1)])).unwrap().unwrap();
     let projected_tensor = projected.data().tensor(0).unwrap();
     assert!(projected_tensor.tracks_grad());
     assert_eq!(projected_tensor.to_vec::<f64>().unwrap(), vec![0.0, 4.0]);

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -15,6 +15,7 @@
 | Document | Description |
 |----------|-------------|
 | [adaptive-tci-interpolation.md](./adaptive-tci-interpolation.md) | Adaptive TCI patching, convergence, pivot recycling, and structured embedding |
+| [partitionedtt-projector-invariants.md](./partitionedtt-projector-invariants.md) | Issue #634 design for coherent projector identity, validation, and transactional PartitionedTT mutation |
 | [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |
 
 ## Automatic Differentiation

--- a/docs/design/partitionedtt-projector-invariants.md
+++ b/docs/design/partitionedtt-projector-invariants.md
@@ -1,0 +1,211 @@
+# PartitionedTT projector invariant repair (#634)
+
+## Status
+
+Pre-implementation design for issue #634. This is an independently mergeable
+correctness fix and must land before the TreeTN-native successor in #648 copies
+`Projector`.
+
+## Scope
+
+Repair projector identity, coordinate validation, and transactional partition
+mutation in `tensor4all-partitionedtt`. Breaking cleanup is accepted because the
+repository is in early development.
+
+In scope:
+
+- one deterministic ordering over the fields used by `DynIndex::Eq` and
+  `DynIndex::Hash`;
+- fallible projector construction and insertion;
+- rejection of projector indices absent from a tensor train;
+- transactional, disjoint partition construction and mutation;
+- removal or restriction of unrestricted mutable subdomain access; and
+- contract/property tests and runnable rustdoc for every changed public API.
+
+Out of scope: C API or language bindings, adaptive interpolation behavior,
+backend/device behavior, dtype or AD policy, numerical tolerances, dependencies,
+features, and broader index representation changes.
+
+## Existing contract and defect
+
+`DynIndex` equality and hashing use `id`, `tags`, and `plev`; `dim` is shape
+metadata and is deliberately excluded. `Projector` currently stores a
+`HashMap<DynIndex, usize>` but hashes entries after sorting only by ID. Two equal
+maps can therefore hash differently when equal-ID entries differ by tags or
+prime level. Partition output ordering similarly compares only `(id, value)`,
+so unequal projectors can compare equal.
+
+`Projector::from_pairs` and `Projector::insert` currently accept coordinates
+outside `0..index.dim()`. `SubDomainTT::new` silently filters absent projector
+indices. `PartitionedTT::insert` can bypass disjointness checks, and public
+`get_mut` permits arbitrary mutation after a projector has become a map key.
+
+## Canonical projector entry order
+
+Define one private comparator for `DynIndex` identity with this lexicographic
+key:
+
+1. `DynIndex::id`;
+2. the canonical sorted tag sequence; and
+3. `DynIndex::plev`.
+
+The key must not include `dim`, because `DynIndex::Eq` and `Hash` do not include
+it. Comparator equality must be equivalent to `DynIndex` equality.
+
+Define one private canonical-entry helper that sorts projector entries by that
+identity comparator and then by projected coordinate. Reuse it for:
+
+- `Projector::Hash`, hashing each full `DynIndex` and coordinate in canonical
+  order; and
+- the deterministic total comparator used to order partition results.
+
+The projector comparator is lexicographic over canonical entries, including
+length. It returns `Equal` if and only if `Projector::eq` is true. Public
+`PartialOrd` retains its existing subset semantics and does not become this
+total order.
+
+`dim` remains attached shape metadata. A successful update of an already equal
+identity must not leave an old key object paired with a coordinate validated
+only against a different incoming dimension: validate before mutation and
+replace the stored key/value together. Applying a projector to a tensor train
+validates the coordinate against the matched tensor-train index dimension.
+
+## Fallible projector APIs
+
+Change:
+
+```rust
+pub fn Projector::from_pairs(
+    pairs: impl IntoIterator<Item = (DynIndex, usize)>,
+) -> Result<Projector>
+
+pub fn Projector::insert(
+    &mut self,
+    index: DynIndex,
+    value: usize,
+) -> Result<()>
+```
+
+A coordinate is valid exactly when `value < index.dim()`. Failure returns the
+existing typed `PartitionedTTError::ProjectorCoordinateOutOfBounds` and leaves
+the projector unchanged.
+
+Remove `FromIterator<(DynIndex, usize)> for Projector`: `FromIterator` cannot
+report validation errors, and an infallible compatibility path would violate
+the invariant. Update every production caller, test, benchmark, example, and
+doctest to propagate or explicitly assert the result.
+
+Operations that only retain or combine entries already validated by public
+construction (`common_restriction`, `filter_indices`, and compatible
+intersection) remain infallible. `filter_indices` is the explicit filtering API;
+construction never filters silently.
+
+## SubDomainTT validation
+
+Change `SubDomainTT::new(data, projector)` to return `Result<Self>`.
+
+Before commit, collect the tensor train's site indices and validate every
+projector entry:
+
+- a matching full `DynIndex` identity (`id`, `tags`, and `plev`) must exist;
+- the coordinate must be in range for the matched tensor-train index; and
+- no projector entry is silently removed or clamped.
+
+Use `ProjectorIndexNotFound` for an absent full identity and
+`ProjectorCoordinateOutOfBounds` for an invalid coordinate. `from_tt` remains
+infallible because its projector is empty. `project` validates the merged
+projector before constructing its result.
+
+The stored `TensorTrain`, `Projector`, and truncation budget remain private.
+Existing public accessors remain immutable.
+
+## PartitionedTT transactional mutation
+
+All insertion paths route through one validation rule:
+
+- every stored subdomain is internally coherent by `SubDomainTT::new`;
+- different projector keys are pairwise disjoint;
+- inserting an exactly equal projector may replace its value; and
+- a different compatible/overlapping projector is rejected with
+  `OverlappingProjectors`.
+
+`PartitionedTT::insert` performs all checks before mutating the map. On failure,
+length, keys, and values are unchanged.
+
+`from_subdomains`, `from_subdomain`, `append`, and `append_subdomains` either
+preflight the complete candidate set or build a validated temporary partition
+before commit. They never partially insert before reporting an error.
+
+Restrict `PartitionedTT::get_mut` to crate-private use (or remove it if no
+internal caller remains). Do not add a public unchecked replacement or
+compatibility shim. Internal mutation must not change the private projector/data
+relationship; public replacement goes through `insert` with a validated
+`SubDomainTT`.
+
+## Error and documentation contract
+
+Keep errors in `PartitionedTTError`. Public changed functions document:
+
+- arguments and zero-based coordinate constraints;
+- return values;
+- exact error variants and transactional behavior; and
+- runnable examples with assertions and explicit `unwrap`/error checks.
+
+No public item uses `ignore` or `no_run`. No old infallible aliases are retained.
+
+## Verification
+
+Add focused tests covering every distinct path:
+
+1. equal projectors hash identically across insertion orders and independently
+   created `HashMap` seeds;
+2. canonical comparator equality is equivalent to projector equality;
+3. same-ID indices differing by tags or prime level remain distinct and sort
+   deterministically;
+4. coordinates `0` and `dim - 1` succeed while `dim` and larger fail;
+5. failed `Projector::insert` leaves the projector byte-for-contract unchanged;
+6. duplicate equal identities update the stored key/value coherently;
+7. `SubDomainTT::new` rejects missing full identities, including same-ID
+   tag/prime variants, and validates against the tensor-train dimension;
+8. exact-projector partition replacement succeeds;
+9. overlapping partition insertion, append, and bulk construction fail without
+   changing the receiver; and
+10. disjoint insertion and append remain successful.
+
+Use release mode for the changed crate's tests as required locally. Before the
+PR, run and record:
+
+```text
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --release -p tensor4all-partitionedtt
+cargo test --doc --release --workspace
+cargo nextest run --release --workspace
+cargo doc --workspace --no-deps
+./scripts/test-mdbook.sh
+python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run
+python3 scripts/test-repository-rules-review.py
+```
+
+Run the repository API inventory command if it exists on the synchronized base.
+The current `origin/main` xtask does not yet expose the `api-dump` subcommand, so
+absence of that command is recorded rather than worked around by editing
+generated output.
+
+Coverage is CI-owned. The PR must attest that removed/changed paths were checked
+for coverage impact and that replacement tests exercise every invariant branch;
+coverage thresholds and numerical tolerances are not changed.
+
+## Review and integration order
+
+1. Obtain a recorded `Correct-to-merge` verdict on this document from the
+   selected read-only opencode-go DeepSeek V4 Flash reviewer.
+2. Delegate implementation in this dedicated worktree to GPT-5.6 Luna.
+3. Run local gates and inspect the full diff.
+4. Obtain a recorded post-implementation full-diff verdict from the same
+   reviewer and fix/re-review all blocking findings.
+5. Synchronize with current `origin/main`, rerun affected gates, push, open the
+   PR, monitor CI, and merge only after all required checks pass.
+6. Rebase/recreate #648 from the merged #634 commit; do not copy the buggy
+   `Projector` from an earlier revision.

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -143,14 +143,14 @@ Ports InterpolativeQTT.jl; returns `SimpleTensorTrain<f64>`.
 Split a function's domain into non-overlapping projected patches, each its own TT. Use when a function is low-rank only after fixing some site indices. Re-exports `DynIndex`, `IdxTensor`, `MultiIndex`, `SimpleTensorTrain`, `ContractOptions`/`TruncateOptions`, `TCI2Options` — get them here rather than reaching into core internals.
 
 - `Projector` — maps site `DynIndex` → fixed coordinate, defining a subdomain.
-  - `Projector::new()`, `Projector::from_pairs([(idx, value), ...])`.
-  - `.get(&idx) -> Option<usize>`, `.is_projected_at(&idx)`, `.insert(idx, value)`, `.projected_indices()`, `.len()`, `.is_empty()`.
+  - `Projector::new()`, `Projector::from_pairs([(idx, value), ...])?`.
+  - `.get(&idx) -> Option<usize>`, `.is_projected_at(&idx)`, `.insert(idx, value)?`, `.projected_indices()`, `.len()`, `.is_empty()`.
 - `SubDomainTT` — an itensorlike `TensorTrain` plus its `Projector`.
-  - `SubDomainTT::new(tt, projector)`, `SubDomainTT::from_tt(tt)` (empty projector).
-  - `.data()`, `.data_mut()`, `.projector()`, `.max_bond_dim()`, `.into_data()`, `.all_indices()`.
-- `PartitionedTT` — collection of mutually disjoint `SubDomainTT`s (disjointness validated at construction).
-  - `PartitionedTT::from_subdomains(vec)?`, `::from_subdomain(one)`, `::new()`.
-  - `.len()`, `.is_empty()`, `.projectors()`, `.iter()`, `.values()`, `.values_mut()`, `.contains(&projector)`.
+  - `SubDomainTT::new(tt, projector)?`, `SubDomainTT::from_tt(tt)` (empty projector).
+  - `.data()`, `.projector()`, `.max_bond_dim()`, `.into_data()`, `.all_indices()`.
+- `PartitionedTT` — collection of mutually disjoint `SubDomainTT`s (disjointness validated at construction and insertion).
+  - `PartitionedTT::from_subdomains(vec)?`, `::from_subdomain(one)?`, `::new()`.
+  - `.len()`, `.is_empty()`, `.projectors()`, `.iter()`, `.values()`, `.contains(&projector)`.
   - `.to_tensor_train() -> Result<SimpleTensorTrain>` — recombine all patches into one TT (drops the partition structure).
   - `.contract(&other, &ContractOptions)?` (also free `contract` / `proj_contract`).
 - Adaptive patching — bond-cap-driven splitting plus volume-proportional truncation:


### PR DESCRIPTION
## Summary

Fixes #634 by establishing one validated `Projector`/`PartitionedTT` invariant path.

- orders full `DynIndex` identities by `id + tags + plev` (never `dim`) for coherent hashing and deterministic output;
- makes projector and subdomain construction fallible and rejects invalid coordinates or absent full identities;
- validates coordinates against the matched tensor-train site dimension;
- makes partition insertion/append transactional, allowing exact-key replacement while rejecting different overlapping projectors;
- removes unrestricted mutable escape hatches and the infallible `Projector: FromIterator` path;
- migrates callers, runnable rustdoc, and the usage skill; and
- adds contract tests for hash/order, metadata variants, boundary errors, stale-key replacement, and transactional mutation.

Design: [`docs/design/partitionedtt-projector-invariants.md`](docs/design/partitionedtt-projector-invariants.md)

## Review gates

- Pre-implementation design review: opencode-go DeepSeek V4 Flash, read-only — **Correct-to-merge** ([record](https://github.com/tensor4all/tensor4all-rs/issues/634#issuecomment-5316528155))
- Implementation: GPT-5.6 Luna, dedicated worktree
- Post-implementation complete-diff review: opencode-go DeepSeek V4 Flash, read-only — **Correct-to-merge**; both actionable Minor findings fixed and re-reviewed ([record](https://github.com/tensor4all/tensor4all-rs/issues/634#issuecomment-5317077212))

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p tensor4all-partitionedtt --no-default-features --features tenferro-provider-inject`
- `cargo nextest run --release -p tensor4all-partitionedtt` — 103/103 passed
- `cargo test --doc --release -p tensor4all-partitionedtt` — 18/18 passed
- `cargo nextest run --release --workspace` — 2830 passed, 14 skipped
- `cargo test --doc --release --workspace` — 863 passed
- `cargo doc --workspace --no-deps` — passed (pre-existing warnings only)
- `./scripts/test-mdbook.sh`
- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run` — pass, no findings
- `python3 scripts/test-repository-rules-review.py` — 90 passed
- `cargo run -p api-dump --release -- . -o target/api-dump` — inventory generated; public signatures and removals verified

## Coverage and public-surface attestations

- Reviewed every changed/removed path for coverage impact; replacement tests exercise success, typed-error, metadata-variant, overlap, and transactional-failure branches.
- No coverage threshold or numerical tolerance changed.
- Removed `FromIterator`, `get_mut`, `values_mut`, and `data_mut` surfaces were audited for callers.
- Rustdoc and `skills/use-tensor4all-rs/references/crates.md` match the new fallible API.
- Root README remains accurate.

## New public crate checklist

Not applicable: this PR does not add a crate.
