### PR TITLE
Add TreeTN-native partitioned tensor networks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/tensor4all-quanticstransform",
     "crates/tensor4all-simplett",
     "crates/tensor4all-partitionedtt",
+    "crates/tensor4all-partitionedtreetn",
     "crates/tensor4all-tensorci",
     "crates/tensor4all-quanticstci",
     "crates/tensor4all-interpolativeqtt",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Related project: [tenferro-rs](https://github.com/tensor4all/tenferro-rs) provid
 - **Tensor Cross Interpolation**: TCI2 primary algorithm plus legacy TCI1 compatibility for efficient high-dimensional function approximation
 - **Quantics Tensor Train**: Binary encoding of continuous variables with transformation operators
 - **Tree Tensor Networks**: Arbitrary topology with canonicalization, truncation, and contraction
+- **Partitioned TreeTNs**: Eagerly masked subdomains and volume-budgeted adaptive patching
 - **C API**: Minimal Julia-facing FFI surface for indices, structured tensors, TreeTN, and quantics materialization
 
 ## Quick Start
@@ -57,7 +58,8 @@ validated in CI. Longer runnable examples live in the
 | [tensor4all-interpolativeqtt](crates/tensor4all-interpolativeqtt/) | Interpolative QTT construction |
 | [tensor4all-quanticstransform](crates/tensor4all-quanticstransform/) | Quantics transformation operators |
 | [tensor4all-treetci](crates/tensor4all-treetci/) | Tree-structured cross interpolation |
-| [tensor4all-partitionedtt](crates/tensor4all-partitionedtt/) | Partitioned tensor trains and adaptive TCI interpolation |
+| [tensor4all-partitionedtreetn](crates/tensor4all-partitionedtreetn/) | Partitioned TreeTNs with eager masking and adaptive patching |
+| [tensor4all-partitionedtt](crates/tensor4all-partitionedtt/) | **Deprecated:** partitioned tensor trains and adaptive TCI interpolation during migration |
 | [tensor4all-hdf5](crates/tensor4all-hdf5/) | ITensors.jl-compatible HDF5 serialization |
 | [tensor4all-capi](crates/tensor4all-capi/) | C FFI for language bindings |
 

--- a/crates/tensor4all-partitionedtreetn/Cargo.toml
+++ b/crates/tensor4all-partitionedtreetn/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "tensor4all-partitionedtreetn"
+description = "Partitioned Tree Tensor Networks with adaptive patching for tensor4all"
+readme = "README.md"
+keywords = ["tensor-network", "tensor-train", "tree-tensor-network"]
+categories = ["science", "mathematics", "algorithms"]
+rust-version = "1.85"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = ["tenferro-cpu-faer"]
+tenferro-cpu-faer = [
+    "tensor4all-core/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
+    "tensor4all-treetn/tenferro-cpu-faer",
+]
+tenferro-provider-inject = [
+    "tensor4all-core/tenferro-provider-inject",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
+    "tensor4all-treetn/tenferro-provider-inject",
+]
+
+[package.metadata.docs.rs]
+features = ["tenferro-cpu-faer"]
+
+[dependencies]
+anyhow.workspace = true
+thiserror.workspace = true
+tensor4all-core = { path = "../tensor4all-core", default-features = false }
+tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
+tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
+
+[dev-dependencies]
+num-complex.workspace = true

--- a/crates/tensor4all-partitionedtreetn/README.md
+++ b/crates/tensor4all-partitionedtreetn/README.md
@@ -1,0 +1,64 @@
+# tensor4all-partitionedtreetn
+
+TreeTN-native partitioned tensor networks with eagerly masked subdomain
+patches. The crate supports arbitrary named tree topologies, multiple site
+indices per node, homogeneous `f64`/`Complex64` partitions, strict algebra, and
+volume-proportional adaptive patching.
+
+Adaptive patching is bond-cap-driven and independent of adaptive interpolation:
+this crate does **not** provide TCI, sampled-zero inference, or a dependency on
+`tensor4all-treetci`.
+
+## Quick start
+
+```rust
+use tensor4all_core::{DynIndex, IdxTensor};
+use tensor4all_partitionedtreetn::{
+    add_with_patching, PatchSplitStrategy, PatchingOptions, SubDomainTreeTN,
+};
+use tensor4all_treetn::TreeTN;
+
+let site0 = DynIndex::new_dyn(2);
+let bond = DynIndex::new_dyn(2);
+let site1 = DynIndex::new_dyn(2);
+let left = IdxTensor::from_dense(
+    vec![site0.clone(), bond.clone()],
+    vec![1.0_f64, 0.0, 0.0, 1.0],
+)?;
+let right = IdxTensor::from_dense(
+    vec![bond, site1],
+    vec![1.0_f64, 0.0, 0.0, 1.0],
+)?;
+let tree = TreeTN::from_tensors(vec![left, right], vec![0usize, 1])?;
+let patch = SubDomainTreeTN::from_treetn(tree)?;
+let result = add_with_patching(
+    vec![patch],
+    &0,
+    &PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        patch_order: vec![site0],
+        split_strategy: PatchSplitStrategy::Sequential,
+    },
+)?;
+
+assert_eq!(result.len(), 2);
+assert!(result.values().all(|patch| patch.max_bond_dim() <= 1));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+All flat tensor buffers use column-major order: the first listed index varies
+fastest. Coordinates are zero-based. An operation that truncates or contracts
+requires an explicit existing TreeTN node name as its center.
+
+## Documentation
+
+- [Tensor4all-rs user guide](https://tensor4all.org/tensor4all-rs/)
+- [Partitioned TreeTN guide](https://tensor4all.org/tensor4all-rs/guides/partitioned-treetn.html)
+- [API reference](https://tensor4all.org/tensor4all-rs/rustdoc/tensor4all_partitionedtreetn/)
+- [Migration design](../../docs/design/partitioned-treetn.md)
+- [Provenance and citation policy](../../docs/PROVENANCE_AND_CITATION_POLICY.md)
+
+The deprecated `tensor4all-partitionedtt` crate remains buildable during the
+migration window. It is limited to correctness and security fixes; no removal
+date has been set.

--- a/crates/tensor4all-partitionedtreetn/src/error.rs
+++ b/crates/tensor4all-partitionedtreetn/src/error.rs
@@ -1,0 +1,189 @@
+//! Errors returned by partitioned TreeTN operations.
+
+use tensor4all_core::{DynIndex, IdxTensorError, TensorStorageError};
+use tensor4all_treetn::TreeTNOperationError;
+use thiserror::Error;
+
+/// The result type used by this crate.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtreetn::Result;
+///
+/// let result: Result<usize> = Ok(3);
+/// assert_eq!(result.unwrap(), 3);
+/// ```
+pub type Result<T> = std::result::Result<T, PartitionedTreeTNError>;
+
+/// Errors raised while validating or operating on partitioned TreeTNs.
+///
+/// `Projector` validation errors are explicit so callers can repair input
+/// coordinates and full index identities. Backend and TreeTN failures retain
+/// their typed source errors for diagnostics.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::DynIndex;
+/// use tensor4all_partitionedtreetn::{PartitionedTreeTNError, Projector};
+///
+/// let index = DynIndex::new_dyn(2);
+/// let error = Projector::from_pairs([(index, 2)]).unwrap_err();
+/// assert!(matches!(
+///     error,
+///     PartitionedTreeTNError::ProjectorCoordinateOutOfBounds { value: 2, dim: 2, .. }
+/// ));
+/// ```
+#[derive(Debug, Error)]
+pub enum PartitionedTreeTNError {
+    /// A different projector overlaps an existing partition patch.
+    #[error("projectors overlap; use disjoint projector keys or replace the exact key")]
+    OverlappingProjectors,
+
+    /// Two projector entries assign different coordinates to one full index.
+    #[error("projector entries conflict; use compatible coordinates")]
+    ProjectorConflict,
+
+    /// Two TreeTNs do not have the same named node-and-edge topology.
+    #[error("TreeTNs have different named topologies; use the same node names and edges")]
+    TopologyMismatch,
+
+    /// Two TreeTNs assign site indices differently or use different full site spaces.
+    #[error(
+        "TreeTNs have different site-index assignments; reindex explicitly before the operation"
+    )]
+    SiteIndexMismatch,
+
+    /// Two subdomains do not use the same projector key for strict addition.
+    #[error("strict subdomain addition requires identical projector keys")]
+    ProjectorMismatch,
+
+    /// An explicit TreeTN center is absent from the network.
+    #[error("the requested TreeTN center is absent; choose an existing node name")]
+    InvalidCenter,
+
+    /// The supplied operation options are invalid or select a forbidden path.
+    #[error("invalid {operation} options: {reason}")]
+    InvalidOptions {
+        /// Operation whose options were rejected.
+        operation: &'static str,
+        /// Repair guidance for the rejected option combination.
+        reason: &'static str,
+    },
+
+    /// A checked patch-volume product or sum overflowed `usize`.
+    #[error("partition volume overflowed usize; use smaller site dimensions or fewer patches")]
+    VolumeOverflow,
+
+    /// A checked logical local-tensor element count overflowed `usize`.
+    #[error(
+        "logical tensor parameter count overflowed usize; use smaller tensors or bond dimensions"
+    )]
+    LogicalParameterCountOverflow,
+
+    /// A norm or budget required by adaptive patching was not finite.
+    #[error("adaptive patching encountered a non-finite norm or truncation budget")]
+    NonFiniteAdaptiveValue,
+
+    /// The partition has no patches.
+    #[error("partitioned TreeTN is empty; add at least one patch")]
+    Empty,
+
+    /// A projector refers to a site index absent by full identity.
+    #[error("projector index {index:?} is absent from the TreeTN site space")]
+    ProjectorIndexNotFound {
+        /// The full index supplied by the caller.
+        index: DynIndex,
+    },
+
+    /// A projector coordinate is outside the matched TreeTN site dimension.
+    #[error(
+        "projector coordinate {value} is out of range for index {index:?} with dimension {dim}"
+    )]
+    ProjectorCoordinateOutOfBounds {
+        /// The full index supplied by the caller.
+        index: DynIndex,
+        /// The invalid zero-based coordinate.
+        value: usize,
+        /// The dimension of the matching TreeTN site index.
+        dim: usize,
+    },
+
+    /// The input TreeTN is not one connected acyclic tree.
+    #[error("invalid TreeTN topology: {source}")]
+    InvalidTopology {
+        /// The underlying topology diagnostic.
+        #[source]
+        source: TreeTNOperationError,
+    },
+
+    /// The TreeTN tensors have incompatible scalar dtypes.
+    #[error("TreeTN tensors have mixed scalar dtypes: expected {expected}, found {actual}")]
+    DTypeMismatch {
+        /// The dtype established by the first node.
+        expected: String,
+        /// The incompatible dtype found at a later node.
+        actual: String,
+    },
+
+    /// An IdxTensor dtype is not supported by this crate's masking path.
+    #[error("unsupported IdxTensor scalar dtype: {dtype}")]
+    UnsupportedDType {
+        /// A diagnostic name for the unsupported dtype.
+        dtype: String,
+    },
+
+    /// An operation on the underlying TreeTN failed.
+    #[error("TreeTN operation failed: {source}")]
+    TreeTN {
+        /// The original TreeTN diagnostic.
+        #[source]
+        source: TreeTNOperationError,
+    },
+
+    /// Tensor storage materialization or access failed.
+    #[error("tensor storage operation failed: {source}")]
+    TensorStorage {
+        /// The original storage diagnostic.
+        #[source]
+        source: TensorStorageError,
+    },
+
+    /// Tensor construction or backend execution failed.
+    #[error("tensor construction or backend operation failed: {source}")]
+    TensorConstruction {
+        /// The original tensor diagnostic and source chain.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl From<TreeTNOperationError> for PartitionedTreeTNError {
+    fn from(source: TreeTNOperationError) -> Self {
+        Self::TreeTN { source }
+    }
+}
+
+impl From<IdxTensorError> for PartitionedTreeTNError {
+    fn from(source: IdxTensorError) -> Self {
+        match source {
+            IdxTensorError::Storage { source } => Self::TensorStorage { source },
+            source => Self::TensorConstruction {
+                source: anyhow::Error::new(source),
+            },
+        }
+    }
+}
+
+impl PartitionedTreeTNError {
+    pub(crate) fn tree(message: impl Into<String>) -> Self {
+        Self::TreeTN {
+            source: anyhow::anyhow!(message.into()).into(),
+        }
+    }
+
+    pub(crate) fn invalid_topology(source: TreeTNOperationError) -> Self {
+        Self::InvalidTopology { source }
+    }
+}

--- a/crates/tensor4all-partitionedtreetn/src/error.rs
+++ b/crates/tensor4all-partitionedtreetn/src/error.rs
@@ -187,3 +187,173 @@ impl PartitionedTreeTNError {
         Self::InvalidTopology { source }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use super::*;
+
+    fn assert_display(error: PartitionedTreeTNError, expected: &str) {
+        assert_eq!(error.to_string(), expected);
+    }
+
+    #[test]
+    fn every_variant_has_the_documented_display() {
+        assert_display(
+            PartitionedTreeTNError::OverlappingProjectors,
+            "projectors overlap; use disjoint projector keys or replace the exact key",
+        );
+        assert_display(
+            PartitionedTreeTNError::ProjectorConflict,
+            "projector entries conflict; use compatible coordinates",
+        );
+        assert_display(
+            PartitionedTreeTNError::TopologyMismatch,
+            "TreeTNs have different named topologies; use the same node names and edges",
+        );
+        assert_display(
+            PartitionedTreeTNError::SiteIndexMismatch,
+            "TreeTNs have different site-index assignments; reindex explicitly before the operation",
+        );
+        assert_display(
+            PartitionedTreeTNError::ProjectorMismatch,
+            "strict subdomain addition requires identical projector keys",
+        );
+        assert_display(
+            PartitionedTreeTNError::InvalidCenter,
+            "the requested TreeTN center is absent; choose an existing node name",
+        );
+        assert_display(
+            PartitionedTreeTNError::InvalidOptions {
+                operation: "merge",
+                reason: "rtol must be nonnegative",
+            },
+            "invalid merge options: rtol must be nonnegative",
+        );
+        assert_display(
+            PartitionedTreeTNError::VolumeOverflow,
+            "partition volume overflowed usize; use smaller site dimensions or fewer patches",
+        );
+        assert_display(
+            PartitionedTreeTNError::LogicalParameterCountOverflow,
+            "logical tensor parameter count overflowed usize; use smaller tensors or bond dimensions",
+        );
+        assert_display(
+            PartitionedTreeTNError::NonFiniteAdaptiveValue,
+            "adaptive patching encountered a non-finite norm or truncation budget",
+        );
+        assert_display(
+            PartitionedTreeTNError::Empty,
+            "partitioned TreeTN is empty; add at least one patch",
+        );
+
+        let index = DynIndex::new_dyn(3);
+        let index_debug = format!("{index:?}");
+        let error = PartitionedTreeTNError::ProjectorIndexNotFound { index };
+        assert!(error.to_string().contains(&index_debug));
+
+        let index = DynIndex::new_dyn(3);
+        let index_debug = format!("{index:?}");
+        let error = PartitionedTreeTNError::ProjectorCoordinateOutOfBounds {
+            index,
+            value: 4,
+            dim: 3,
+        };
+        let message = error.to_string();
+        assert!(message.contains(&index_debug));
+        assert!(message.contains("4") && message.contains("dimension 3"));
+
+        let tree_error = TreeTNOperationError::from(anyhow::anyhow!("disconnected"));
+        assert_display(
+            PartitionedTreeTNError::InvalidTopology { source: tree_error },
+            "invalid TreeTN topology: TreeTN operation failed: disconnected",
+        );
+        assert_display(
+            PartitionedTreeTNError::DTypeMismatch {
+                expected: "f64".to_string(),
+                actual: "c64".to_string(),
+            },
+            "TreeTN tensors have mixed scalar dtypes: expected f64, found c64",
+        );
+        assert_display(
+            PartitionedTreeTNError::UnsupportedDType {
+                dtype: "f32".to_string(),
+            },
+            "unsupported IdxTensor scalar dtype: f32",
+        );
+
+        let tree_error = TreeTNOperationError::from(anyhow::anyhow!("contraction failed"));
+        assert_display(
+            PartitionedTreeTNError::TreeTN { source: tree_error },
+            "TreeTN operation failed: TreeTN operation failed: contraction failed",
+        );
+        assert_display(
+            PartitionedTreeTNError::TensorStorage {
+                source: TensorStorageError::UnsupportedDtype { dtype: "f32" },
+            },
+            "tensor storage operation failed: compact IdxTensor storage does not support dtype f32; the eager payload remains authoritative",
+        );
+        assert_display(
+            PartitionedTreeTNError::TensorConstruction {
+                source: anyhow::anyhow!("backend unavailable"),
+            },
+            "tensor construction or backend operation failed: backend unavailable",
+        );
+    }
+
+    #[test]
+    fn conversions_preserve_typed_sources_and_messages() {
+        let tree_source = TreeTNOperationError::from(anyhow::anyhow!("tree failure"));
+        let error = PartitionedTreeTNError::from(tree_source);
+        assert!(matches!(error, PartitionedTreeTNError::TreeTN { .. }));
+        assert_eq!(
+            error.to_string(),
+            "TreeTN operation failed: TreeTN operation failed: tree failure"
+        );
+        assert!(Error::source(&error).is_some());
+
+        let storage_source = TensorStorageError::UnsupportedDtype { dtype: "f32" };
+        let error = PartitionedTreeTNError::from(IdxTensorError::Storage {
+            source: storage_source,
+        });
+        assert!(matches!(
+            error,
+            PartitionedTreeTNError::TensorStorage { .. }
+        ));
+        assert!(error.to_string().contains("compact IdxTensor storage"));
+
+        let error = PartitionedTreeTNError::from(IdxTensorError::NaNInput { operation: "norm" });
+        assert!(matches!(
+            error,
+            PartitionedTreeTNError::TensorConstruction { .. }
+        ));
+        assert!(error
+            .to_string()
+            .contains("IdxTensor norm received NaN input"));
+        assert!(Error::source(&error).is_some());
+    }
+
+    #[test]
+    fn private_helpers_wrap_the_requested_diagnostics() {
+        let tree = PartitionedTreeTNError::tree("tensor lookup failed");
+        assert!(matches!(tree, PartitionedTreeTNError::TreeTN { .. }));
+        assert_eq!(
+            tree.to_string(),
+            "TreeTN operation failed: TreeTN operation failed: tensor lookup failed"
+        );
+        assert!(Error::source(&tree).is_some());
+
+        let topology_source = TreeTNOperationError::from(anyhow::anyhow!("cycle"));
+        let topology = PartitionedTreeTNError::invalid_topology(topology_source);
+        assert!(matches!(
+            topology,
+            PartitionedTreeTNError::InvalidTopology { .. }
+        ));
+        assert_eq!(
+            topology.to_string(),
+            "invalid TreeTN topology: TreeTN operation failed: cycle"
+        );
+        assert!(Error::source(&topology).is_some());
+    }
+}

--- a/crates/tensor4all-partitionedtreetn/src/lib.rs
+++ b/crates/tensor4all-partitionedtreetn/src/lib.rs
@@ -1,0 +1,31 @@
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+//! Partitioned Tree Tensor Network subdomains for tensor4all.
+//!
+//! This crate provides [`Projector`], [`SubDomainTreeTN`], and
+//! [`PartitionedTreeTN`] patch algebra, including TreeTN-general adaptive
+//! patching. Stored patch data is eagerly masked, and partition metadata is
+//! validated transactionally.
+//!
+//! The representation follows the partitioned tensor-network approach used by
+//! [PartitionedMPSs.jl](https://github.com/tensor4all/PartitionedMPSs.jl) and
+//! the adaptive patching literature; this crate does not contain TCI-derived
+//! adaptive interpolation code.
+
+mod error;
+mod partitioned_tree_tn;
+mod patching;
+mod projector;
+mod subdomain_tree_tn;
+
+pub use error::{PartitionedTreeTNError, Result};
+pub use partitioned_tree_tn::PartitionedTreeTN;
+pub use patching::{
+    add_with_patching, contract_adaptive, truncate_adaptive, PatchSplitStrategy, PatchingOptions,
+};
+pub use projector::Projector;
+pub use subdomain_tree_tn::SubDomainTreeTN;
+
+pub use tensor4all_core::{DynIndex, IdxTensor};
+pub use tensor4all_treetn::{SiteIndexNetwork, TreeTN};

--- a/crates/tensor4all-partitionedtreetn/src/partitioned_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/src/partitioned_tree_tn.rs
@@ -1,0 +1,550 @@
+//! Collections of eagerly projected [`SubDomainTreeTN`] patches.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use crate::error::{PartitionedTreeTNError, Result};
+use crate::projector::Projector;
+use crate::subdomain_tree_tn::{
+    ensure_center, ensure_same_dtype, ensure_same_topology, ensure_same_tree_structure,
+    validate_contraction_options, validate_contraction_site_assignment,
+    validate_truncation_options, SubDomainTreeTN,
+};
+use tensor4all_treetn::{contraction::ContractionOptions, TreeTN, TruncationOptions};
+
+/// A collection of pairwise-disjoint, eagerly masked TreeTN patches.
+///
+/// All patches in one collection have the same named topology, exact full
+/// site-index assignment at every node, and one homogeneous scalar dtype.
+/// Projector keys are immutable through this type; use [`Self::insert`] or
+/// [`Self::append`] for validated transactional updates.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, IdxTensor};
+/// use tensor4all_partitionedtreetn::{PartitionedTreeTN, Projector, SubDomainTreeTN};
+/// use tensor4all_treetn::TreeTN;
+///
+/// let site = DynIndex::new_dyn(2);
+/// let data = TreeTN::from_tensors(
+///     vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0])?],
+///     vec![0usize],
+/// )?;
+/// let patch = SubDomainTreeTN::new(data, Projector::from_pairs([(site, 0)])?)?;
+/// let partition = PartitionedTreeTN::from_subdomain(patch)?;
+/// assert_eq!(partition.len(), 1);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct PartitionedTreeTN<V = usize>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    data: HashMap<Projector, SubDomainTreeTN<V>>,
+}
+
+impl<V> PartitionedTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Create an empty partition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_partitionedtreetn::PartitionedTreeTN;
+    ///
+    /// let partition = PartitionedTreeTN::<usize>::new();
+    /// assert!(partition.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+
+    /// Return the number of stored patches.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Return whether no patches are stored.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Iterate over projector keys in unspecified hash-map order.
+    pub fn projectors(&self) -> impl Iterator<Item = &Projector> {
+        self.data.keys()
+    }
+
+    /// Get the patch stored under an exact projector key.
+    pub fn get(&self, projector: &Projector) -> Option<&SubDomainTreeTN<V>> {
+        self.data.get(projector)
+    }
+
+    /// Return whether an exact projector key is present.
+    pub fn contains(&self, projector: &Projector) -> bool {
+        self.data.contains_key(projector)
+    }
+
+    /// Iterate over immutable `(projector, patch)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&Projector, &SubDomainTreeTN<V>)> {
+        self.data.iter()
+    }
+
+    /// Iterate over immutable patches.
+    pub fn values(&self) -> impl Iterator<Item = &SubDomainTreeTN<V>> {
+        self.data.values()
+    }
+}
+
+impl<V> PartitionedTreeTN<V>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    /// Construct a partition from validated patches.
+    ///
+    /// Equal projector keys replace earlier patches in input order. Different
+    /// compatible projectors are rejected; all topology, site-space, dtype,
+    /// projector, and overlap checks finish before the returned map is built.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::OverlappingProjectors`] for different
+    /// overlapping keys, [`PartitionedTreeTNError::TopologyMismatch`] or
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`] for inconsistent patch
+    /// structure, [`PartitionedTreeTNError::DTypeMismatch`] for mixed scalar
+    /// dtypes, or the construction/validation source errors from a patch.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_partitionedtreetn::{PartitionedTreeTN, Projector, SubDomainTreeTN};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let make = |value| -> Result<_, Box<dyn std::error::Error>> {
+    ///     let data = TreeTN::from_tensors(
+    ///         vec![IdxTensor::from_dense(vec![site.clone()], vec![value, value])?],
+    ///         vec![0usize],
+    ///     )?;
+    ///     Ok(SubDomainTreeTN::new(
+    ///         data,
+    ///         Projector::from_pairs([(site.clone(), value as usize)])?,
+    ///     )?)
+    /// };
+    /// let partition = PartitionedTreeTN::from_subdomains(vec![make(0.0)?, make(1.0)?])?;
+    /// assert_eq!(partition.len(), 2);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn from_subdomains(subdomains: Vec<SubDomainTreeTN<V>>) -> Result<Self> {
+        let references: Vec<_> = subdomains.iter().collect();
+        validate_candidate_set(&references)?;
+
+        let mut data = HashMap::with_capacity(subdomains.len());
+        for subdomain in subdomains {
+            let projector = subdomain.projector().clone();
+            data.remove(&projector);
+            data.insert(projector, subdomain);
+        }
+        Ok(Self { data })
+    }
+
+    /// Construct a partition containing one patch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::ProjectorIndexNotFound`] or
+    /// [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`] for an invalid
+    /// stored projector, [`PartitionedTreeTNError::InvalidTopology`],
+    /// [`PartitionedTreeTNError::DTypeMismatch`], or
+    /// [`PartitionedTreeTNError::UnsupportedDType`] for invalid TreeTN data, and
+    /// typed [`PartitionedTreeTNError::TreeTN`],
+    /// [`PartitionedTreeTNError::TensorStorage`], or
+    /// [`PartitionedTreeTNError::TensorConstruction`] source failures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_partitionedtreetn::{PartitionedTreeTN, SubDomainTreeTN};
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let data = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![site], vec![2.0_f64, 0.0])?],
+    ///     vec![0usize],
+    /// )?;
+    /// let partition = PartitionedTreeTN::from_subdomain(SubDomainTreeTN::from_treetn(data)?)?;
+    /// assert_eq!(partition.len(), 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn from_subdomain(subdomain: SubDomainTreeTN<V>) -> Result<Self> {
+        Self::from_subdomains(vec![subdomain])
+    }
+
+    /// Insert or exactly replace one patch transactionally.
+    ///
+    /// An equal projector key replaces both the old key and value. A different
+    /// compatible key is rejected. No mutation occurs until the candidate has
+    /// passed all partition invariant checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::OverlappingProjectors`],
+    /// [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`],
+    /// [`PartitionedTreeTNError::DTypeMismatch`], or a typed patch validation
+    /// error. On error, the partition is unchanged.
+    pub fn insert(&mut self, subdomain: SubDomainTreeTN<V>) -> Result<()> {
+        self.validate_contents()?;
+        subdomain.validate_invariants()?;
+        if let Some(template) = self.data.values().next() {
+            ensure_same_tree_structure(template.data(), subdomain.data())?;
+            ensure_same_dtype(template.scalar_kind()?, subdomain.scalar_kind()?)?;
+        }
+
+        let projector = subdomain.projector().clone();
+        for existing in self.data.keys() {
+            if existing != &projector && existing.is_compatible_with(&projector) {
+                return Err(PartitionedTreeTNError::OverlappingProjectors);
+            }
+        }
+
+        self.data.remove(&projector);
+        self.data.insert(projector, subdomain);
+        Ok(())
+    }
+
+    /// Append another partition transactionally.
+    ///
+    /// Equal keys replace existing patches. Different overlapping keys are
+    /// rejected, including overlaps between the two inputs. Every candidate is
+    /// validated before this partition is mutated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::OverlappingProjectors`] for an invalid
+    /// layout, [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`], or
+    /// [`PartitionedTreeTNError::DTypeMismatch`] for incompatible patch
+    /// metadata. On error, `self` is unchanged.
+    pub fn append(&mut self, other: Self) -> Result<()> {
+        self.validate_contents()?;
+        other.validate_contents()?;
+
+        if let (Some(left), Some(right)) = (self.data.values().next(), other.data.values().next()) {
+            ensure_same_tree_structure(left.data(), right.data())?;
+            ensure_same_dtype(left.scalar_kind()?, right.scalar_kind()?)?;
+        }
+
+        for right_projector in other.data.keys() {
+            for left_projector in self.data.keys() {
+                if right_projector != left_projector
+                    && right_projector.is_compatible_with(left_projector)
+                {
+                    return Err(PartitionedTreeTNError::OverlappingProjectors);
+                }
+            }
+        }
+
+        for (projector, subdomain) in other.data {
+            self.data.remove(&projector);
+            self.data.insert(projector, subdomain);
+        }
+        Ok(())
+    }
+
+    /// Append a vector of patches using the same transactional checks as
+    /// [`Self::append`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::OverlappingProjectors`],
+    /// [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`], or
+    /// [`PartitionedTreeTNError::DTypeMismatch`] for incompatible patches, plus
+    /// the typed projector, topology, dtype, tensor, and TreeTN validation errors
+    /// documented by [`Self::from_subdomain`]. `self` is unchanged on failure.
+    pub fn append_subdomains(&mut self, subdomains: Vec<SubDomainTreeTN<V>>) -> Result<()> {
+        let other = Self::from_subdomains(subdomains)?;
+        self.append(other)
+    }
+
+    /// Compute the squared Frobenius norm of all eager patches.
+    ///
+    /// This sums each stored patch's squared norm without remasking or dense
+    /// materialization. The receiver is borrowed immutably; each patch's norm
+    /// implementation clones its TreeTN wrapper for canonicalization.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::OverlappingProjectors`],
+    /// [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`], or
+    /// [`PartitionedTreeTNError::DTypeMismatch`] when stored partition metadata
+    /// is inconsistent, the validation errors documented by
+    /// [`Self::from_subdomain`], or [`PartitionedTreeTNError::TreeTN`] when a
+    /// patch norm cannot be evaluated.
+    pub fn norm_squared(&self) -> Result<f64> {
+        self.validate_contents()?;
+        self.data
+            .values()
+            .try_fold(0.0, |sum, subdomain| Ok(sum + subdomain.norm_squared()?))
+    }
+
+    /// Compute the Frobenius norm of all eager patches.
+    ///
+    /// This returns the square root of [`Self::norm_squared`]. The receiver is
+    /// borrowed immutably and no full dense tensor is materialized.
+    ///
+    /// # Errors
+    ///
+    /// Returns the concrete validation variants documented by
+    /// [`Self::norm_squared`], including
+    /// [`PartitionedTreeTNError::OverlappingProjectors`],
+    /// [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`],
+    /// [`PartitionedTreeTNError::DTypeMismatch`], and
+    /// [`PartitionedTreeTNError::TreeTN`].
+    pub fn norm(&self) -> Result<f64> {
+        Ok(self.norm_squared()?.sqrt())
+    }
+
+    /// Add two partitions patch-wise at an explicit truncation center.
+    ///
+    /// Identical projector keys are added with strict [`TreeTN::add`] semantics
+    /// and truncated with `options`. A key present on only one side is copied as
+    /// the other side's zero contribution. Different overlapping layouts are
+    /// rejected; no projector refinement is performed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::Empty`] for an empty operand,
+    /// [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`], or
+    /// [`PartitionedTreeTNError::DTypeMismatch`] before patch shortcuts,
+    /// [`PartitionedTreeTNError::InvalidCenter`] for an absent center,
+    /// [`PartitionedTreeTNError::InvalidOptions`] for an invalid truncation
+    /// option, [`PartitionedTreeTNError::OverlappingProjectors`] for a different
+    /// overlapping layout, or a typed TreeTN error for addition/truncation.
+    pub fn add(&self, other: &Self, center: &V, options: TruncationOptions) -> Result<Self> {
+        validate_truncation_options(&options)?;
+        self.validate_contents()?;
+        other.validate_contents()?;
+        let (left_template, right_template) = nonempty_templates(self, other)?;
+        ensure_same_tree_structure(left_template.data(), right_template.data())?;
+        ensure_same_dtype(left_template.scalar_kind()?, right_template.scalar_kind()?)?;
+        ensure_center(left_template.data(), center)?;
+        ensure_center(right_template.data(), center)?;
+        ensure_union_disjoint(&self.data, &other.data)?;
+
+        let mut result = Self::new();
+        for (projector, left) in &self.data {
+            if let Some(right) = other.data.get(projector) {
+                let mut sum = left.add(right)?;
+                sum.truncate(center, options)?;
+                result.insert(sum)?;
+            } else {
+                result.insert(left.clone())?;
+            }
+        }
+        for (projector, right) in &other.data {
+            if !self.data.contains_key(projector) {
+                result.insert(right.clone())?;
+            }
+        }
+        Ok(result)
+    }
+
+    /// Contract two partitions at an explicit center.
+    ///
+    /// V1 requires the same named topology. Shared contractable site indices
+    /// must remain assigned to the same named node; distinct site indices are
+    /// retained as external output axes. Compatible patch pairs are contracted
+    /// directly from their eager stored data. Projector entries absent from the
+    /// output site space are pruned, and duplicate output keys are combined by
+    /// strict subdomain addition followed by the requested bond truncation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::Empty`] for an empty operand,
+    /// [`PartitionedTreeTNError::TopologyMismatch`],
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`], or
+    /// [`PartitionedTreeTNError::DTypeMismatch`] before pair iteration,
+    /// [`PartitionedTreeTNError::InvalidCenter`],
+    /// [`PartitionedTreeTNError::InvalidOptions`],
+    /// [`PartitionedTreeTNError::OverlappingProjectors`] for incompatible
+    /// non-identical output layouts, or a typed TreeTN/backend error. The
+    /// operation returns a new partition, so failure cannot mutate either input.
+    pub fn contract(&self, other: &Self, center: &V, options: ContractionOptions) -> Result<Self> {
+        validate_contraction_options(&options)?;
+        self.validate_contents()?;
+        other.validate_contents()?;
+        let (left_template, right_template) = nonempty_templates(self, other)?;
+        ensure_same_topology(left_template.data(), right_template.data())?;
+        ensure_same_dtype(left_template.scalar_kind()?, right_template.scalar_kind()?)?;
+        validate_contraction_site_assignment(left_template.data(), right_template.data())?;
+        ensure_center(left_template.data(), center)?;
+        ensure_center(right_template.data(), center)?;
+
+        let mut result = Self::new();
+        let duplicate_options = truncation_options_from_contraction(&options);
+        for left in self.data.values() {
+            for right in other.data.values() {
+                let Some(contracted) = left.contract(right, center, options.clone())? else {
+                    continue;
+                };
+                let projector = contracted.projector().clone();
+                if let Some(existing) = result.data.get(&projector) {
+                    let mut combined = existing.add(&contracted)?;
+                    combined.truncate(center, duplicate_options)?;
+                    result.data.remove(&projector);
+                    result.data.insert(projector, combined);
+                } else {
+                    result.insert(contracted)?;
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Sum eager patches in deterministic canonical projector order.
+    ///
+    /// The result uses strict high-level [`TreeTN::add`] and never materializes
+    /// the full tensor densely. Equal numerical inputs therefore have stable
+    /// patch traversal and direct-sum construction order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::Empty`] when there are no patches,
+    /// typed invariant errors for invalid metadata, or [`PartitionedTreeTNError::TreeTN`]
+    /// when strict TreeTN addition fails.
+    pub fn to_treetn(&self) -> Result<TreeTN<tensor4all_core::IdxTensor, V>> {
+        self.validate_contents()?;
+        if self.is_empty() {
+            return Err(PartitionedTreeTNError::Empty);
+        }
+
+        let mut patches: Vec<_> = self.data.iter().collect();
+        patches.sort_by(|(left, _), (right, _)| left.canonical_cmp(right));
+        let (_, first) = patches.first().ok_or(PartitionedTreeTNError::Empty)?;
+        let mut result = first.data().clone();
+        for (_, patch) in patches.into_iter().skip(1) {
+            result = result
+                .add(patch.data())
+                .map_err(PartitionedTreeTNError::from)?;
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn validate_contents(&self) -> Result<()> {
+        let references: Vec<_> = self.data.values().collect();
+        validate_candidate_set(&references)
+    }
+}
+
+fn validate_candidate_set<V>(candidates: &[&SubDomainTreeTN<V>]) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    for candidate in candidates {
+        candidate.validate_invariants()?;
+    }
+
+    if let Some(template) = candidates.first() {
+        for candidate in candidates.iter().skip(1) {
+            ensure_same_tree_structure(template.data(), candidate.data())?;
+            ensure_same_dtype(template.scalar_kind()?, candidate.scalar_kind()?)?;
+        }
+    }
+
+    for (position, left) in candidates.iter().enumerate() {
+        for right in candidates.iter().skip(position + 1) {
+            if left.projector() != right.projector()
+                && left.projector().is_compatible_with(right.projector())
+            {
+                return Err(PartitionedTreeTNError::OverlappingProjectors);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn nonempty_templates<'a, V>(
+    left: &'a PartitionedTreeTN<V>,
+    right: &'a PartitionedTreeTN<V>,
+) -> Result<(&'a SubDomainTreeTN<V>, &'a SubDomainTreeTN<V>)>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let left_template = left
+        .data
+        .values()
+        .next()
+        .ok_or(PartitionedTreeTNError::Empty)?;
+    let right_template = right
+        .data
+        .values()
+        .next()
+        .ok_or(PartitionedTreeTNError::Empty)?;
+    Ok((left_template, right_template))
+}
+
+fn ensure_union_disjoint<V>(
+    left: &HashMap<Projector, SubDomainTreeTN<V>>,
+    right: &HashMap<Projector, SubDomainTreeTN<V>>,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    for left_projector in left.keys() {
+        for right_projector in right.keys() {
+            if left_projector != right_projector
+                && left_projector.is_compatible_with(right_projector)
+            {
+                return Err(PartitionedTreeTNError::OverlappingProjectors);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn truncation_options_from_contraction(options: &ContractionOptions) -> TruncationOptions {
+    let mut truncation = TruncationOptions::default();
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        truncation = truncation.with_max_bond_dim(max_bond_dim);
+    }
+    if let Some(policy) = options.svd_policy {
+        truncation = truncation.with_svd_policy(policy);
+    }
+    truncation
+}
+
+impl<V> IntoIterator for PartitionedTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    type Item = (Projector, SubDomainTreeTN<V>);
+    type IntoIter = std::collections::hash_map::IntoIter<Projector, SubDomainTreeTN<V>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<'a, V> IntoIterator for &'a PartitionedTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    type Item = (&'a Projector, &'a SubDomainTreeTN<V>);
+    type IntoIter = std::collections::hash_map::Iter<'a, Projector, SubDomainTreeTN<V>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.iter()
+    }
+}

--- a/crates/tensor4all-partitionedtreetn/src/patching.rs
+++ b/crates/tensor4all-partitionedtreetn/src/patching.rs
@@ -1,0 +1,911 @@
+//! TreeTN-general adaptive patching.
+//!
+//! The partition representation follows the independent Rust successor's
+//! relationship to [PartitionedMPSs.jl](https://github.com/tensor4all/PartitionedMPSs.jl).
+//! The volume-proportional absolute squared-tail policy follows the published
+//! method “Adaptive Patching for Tensor Train Computations”
+//! ([arXiv:2602.22372](https://arxiv.org/abs/2602.22372)). This module does not
+//! implement adaptive interpolation or copy TCIAlgorithms.jl code.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use crate::error::{PartitionedTreeTNError, Result};
+use crate::partitioned_tree_tn::PartitionedTreeTN;
+use crate::projector::{canonical_index_cmp, Projector};
+use crate::subdomain_tree_tn::{ensure_center, SubDomainTreeTN};
+use tensor4all_core::SvdTruncationPolicy;
+use tensor4all_treetn::{contraction::ContractionOptions, TruncationOptions};
+
+#[derive(Debug)]
+struct PatchStats<V>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    subdomain: SubDomainTreeTN<V>,
+    volume: usize,
+    norm_squared: f64,
+}
+
+/// Strategy used to choose the next full site index for patch splitting.
+///
+/// `Sequential` takes the first available index in `PatchingOptions::patch_order`.
+/// `ExactParameterGain` forms, budget-truncates, and logically counts every
+/// candidate's children, selecting the candidate with the smallest total.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtreetn::PatchSplitStrategy;
+///
+/// assert_eq!(PatchSplitStrategy::default(), PatchSplitStrategy::ExactParameterGain);
+/// assert_ne!(PatchSplitStrategy::Sequential, PatchSplitStrategy::ExactParameterGain);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PatchSplitStrategy {
+    /// Split the first available index from the explicit patch order.
+    Sequential,
+    /// Select the split with the smallest checked logical child parameter count.
+    #[default]
+    ExactParameterGain,
+}
+
+/// Options for TreeTN-general adaptive patching and volume-proportional truncation.
+///
+/// The total absolute squared-tail budget is `rtol² * ||F||²`. Each patch gets
+/// a share proportional to its unprojected grid volume. `max_bond_dim` is the
+/// post-truncation cap; `None` leaves the bond dimension uncapped. An empty
+/// `patch_order` lets adaptive patching consider all unprojected site indices in
+/// deterministic full-index order. A nonempty order may be partial, but every
+/// entry must be an exact full site-index identity of the input TreeTN.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtreetn::{PatchSplitStrategy, PatchingOptions};
+///
+/// let options = PatchingOptions::default();
+/// assert_eq!(options.rtol, 1.0e-12);
+/// assert_eq!(options.max_bond_dim, Some(100));
+/// assert!(options.patch_order.is_empty());
+/// assert_eq!(options.split_strategy, PatchSplitStrategy::ExactParameterGain);
+/// ```
+#[derive(Debug, Clone)]
+pub struct PatchingOptions {
+    /// Global finite non-negative relative tolerance used for the total budget.
+    ///
+    /// The resulting squared budget is `rtol² * ||F||²`; it is then split by
+    /// logical patch volume. Smaller values retain more information.
+    pub rtol: f64,
+
+    /// Optional maximum retained bond dimension. `Some(0)` is invalid.
+    ///
+    /// When a budget-truncated patch still exceeds this cap, adaptive patching
+    /// splits it if an unprojected index is available.
+    pub max_bond_dim: Option<usize>,
+
+    /// Full site-index order used by [`PatchSplitStrategy::Sequential`].
+    ///
+    /// Entries are matched by complete index identity, including tags and
+    /// prime level; an entry absent from the TreeTN is rejected.
+    pub patch_order: Vec<tensor4all_core::DynIndex>,
+
+    /// Candidate-selection strategy used for over-cap patches.
+    pub split_strategy: PatchSplitStrategy,
+}
+
+impl Default for PatchingOptions {
+    fn default() -> Self {
+        Self {
+            rtol: 1.0e-12,
+            max_bond_dim: Some(100),
+            patch_order: Vec::new(),
+            split_strategy: PatchSplitStrategy::default(),
+        }
+    }
+}
+
+/// Add subdomains with automatic TreeTN patch splitting.
+///
+/// The input patches are validated as one homogeneous, exact-topology
+/// partition. Over-cap patches are budget-truncated, split along full site
+/// indices, and retried until no permitted split remains. The explicit `center`
+/// is used for every TreeTN truncation and is never stored in the result.
+///
+/// # Arguments
+///
+/// * `subdomains` - Eagerly masked patches with mutually disjoint projectors.
+/// * `center` - Existing named TreeTN node used as every truncation center.
+/// * `options` - Relative tolerance, bond cap, split order, and split strategy.
+///
+/// # Returns
+///
+/// A new partition containing the retained, budget-truncated patches. The
+/// returned partition may still contain a patch above the cap when no
+/// unprojected split candidate exists.
+///
+/// # Errors
+///
+/// Returns [`PartitionedTreeTNError::InvalidOptions`] for invalid tolerance,
+/// cap, or split-order options; [`PartitionedTreeTNError::Empty`] only when a
+/// nonempty operand is required by a downstream TreeTN operation;
+/// [`PartitionedTreeTNError::InvalidCenter`] when `center` is absent;
+/// [`PartitionedTreeTNError::TopologyMismatch`],
+/// [`PartitionedTreeTNError::SiteIndexMismatch`], or
+/// [`PartitionedTreeTNError::DTypeMismatch`] for inconsistent inputs;
+/// [`PartitionedTreeTNError::VolumeOverflow`] or
+/// [`PartitionedTreeTNError::LogicalParameterCountOverflow`] for checked
+/// arithmetic overflow; and typed TreeTN/backend errors for masking or
+/// truncation failures. No input patch is mutated.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, IdxTensor};
+/// use tensor4all_partitionedtreetn::{
+///     add_with_patching, PatchSplitStrategy, PatchingOptions, SubDomainTreeTN,
+/// };
+/// use tensor4all_treetn::TreeTN;
+///
+/// let site0 = DynIndex::new_dyn(2);
+/// let bond = DynIndex::new_dyn(2);
+/// let site1 = DynIndex::new_dyn(2);
+/// let left = IdxTensor::from_dense(
+///     vec![site0.clone(), bond.clone()],
+///     vec![1.0_f64, 0.0, 0.0, 1.0],
+/// )?;
+/// let right = IdxTensor::from_dense(
+///     vec![bond, site1],
+///     vec![1.0_f64, 0.0, 0.0, 1.0],
+/// )?;
+/// let tree = TreeTN::from_tensors(vec![left, right], vec![0usize, 1])?;
+/// let patch = SubDomainTreeTN::from_treetn(tree)?;
+/// let result = add_with_patching(
+///     vec![patch],
+///     &0,
+///     &PatchingOptions {
+///         rtol: 0.0,
+///         max_bond_dim: Some(1),
+///         patch_order: vec![site0],
+///         split_strategy: PatchSplitStrategy::Sequential,
+///     },
+/// )?;
+/// assert_eq!(result.len(), 2);
+/// assert!(result.values().all(|patch| patch.max_bond_dim() <= 1));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn add_with_patching<V>(
+    subdomains: Vec<SubDomainTreeTN<V>>,
+    center: &V,
+    options: &PatchingOptions,
+) -> Result<PartitionedTreeTN<V>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    validate_patching_options(options)?;
+    let partitioned = PartitionedTreeTN::from_subdomains(subdomains)?;
+    if partitioned.is_empty() {
+        return Ok(partitioned);
+    }
+
+    let template = partitioned
+        .values()
+        .next()
+        .ok_or(PartitionedTreeTNError::Empty)?;
+    ensure_center(template.data(), center)?;
+    validate_patch_order(template, options)?;
+
+    let mut working = partitioned
+        .into_iter()
+        .map(|(_, subdomain)| subdomain)
+        .collect::<Vec<_>>();
+
+    loop {
+        working = assign_volume_budgets(working, options.rtol)?;
+        working = budget_truncate_for_split_decision(working, center)?;
+        let over_cap = working.iter().any(|subdomain| {
+            options
+                .max_bond_dim
+                .is_some_and(|cap| subdomain.max_bond_dim() > cap)
+        });
+        if !over_cap {
+            let partitioned = PartitionedTreeTN::from_subdomains(working)?;
+            return truncate_adaptive(&partitioned, center, options.rtol, options.max_bond_dim);
+        }
+
+        let mut next = Vec::new();
+        let mut split_any = false;
+        for subdomain in working {
+            let over_cap = options
+                .max_bond_dim
+                .is_some_and(|cap| subdomain.max_bond_dim() > cap);
+            if over_cap {
+                if let Some(children) = split_subdomain_by_options(&subdomain, center, options)? {
+                    split_any = true;
+                    next.extend(children);
+                    continue;
+                }
+            }
+            next.push(subdomain);
+        }
+
+        if !split_any {
+            let partitioned = PartitionedTreeTN::from_subdomains(next)?;
+            return truncate_adaptive(&partitioned, center, options.rtol, options.max_bond_dim);
+        }
+        working = next;
+    }
+}
+
+/// Contract two partitions and adaptively truncate the output.
+///
+/// Contraction uses the already eager-masked patches and the supplied TreeTN
+/// contraction options. Its output is then retruncated with budgets computed
+/// from the corrected output norm. The split fields of `patching_options` are
+/// retained for API parity but are not used by this post-contraction pass.
+///
+/// # Arguments
+///
+/// * `left` - First validated partition.
+/// * `right` - Second validated partition.
+/// * `center` - Existing node used by contraction and adaptive truncation.
+/// * `contract_options` - Non-dense TreeTN contraction method and rank policy.
+/// * `patching_options` - Output tolerance and bond cap.
+///
+/// # Returns
+///
+/// A new partition containing compatible pairwise contractions and their
+/// volume-proportionally truncated output patches.
+///
+/// # Errors
+///
+/// Returns the typed validation errors from partition contraction, including
+/// invalid options, empty operands, topology, site assignment, dtype, and
+/// center errors. It also returns the checked volume or logical-count overflow
+/// errors and typed TreeTN/backend failures from output retruncation. Neither
+/// input is mutated.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, IdxTensor};
+/// use tensor4all_partitionedtreetn::{
+///     contract_adaptive, PatchingOptions, PartitionedTreeTN, SubDomainTreeTN,
+/// };
+/// use tensor4all_treetn::{contraction::ContractionOptions, TreeTN};
+///
+/// let site = DynIndex::new_dyn(2);
+/// let make = |values| -> Result<_, Box<dyn std::error::Error>> {
+///     let tensor = IdxTensor::from_dense(vec![site.clone()], values)?;
+///     Ok(SubDomainTreeTN::from_treetn(TreeTN::from_tensors(
+///         vec![tensor],
+///         vec![0usize],
+///     )?)?)
+/// };
+/// let left = PartitionedTreeTN::from_subdomain(make(vec![1.0_f64, 2.0])?)?;
+/// let right = PartitionedTreeTN::from_subdomain(make(vec![3.0_f64, 4.0])?)?;
+/// let result = contract_adaptive(
+///     &left,
+///     &right,
+///     &0,
+///     &ContractionOptions::default(),
+///     &PatchingOptions {
+///         rtol: 0.0,
+///         max_bond_dim: Some(1),
+///         ..PatchingOptions::default()
+///     },
+/// )?;
+/// assert_eq!(result.len(), 1);
+/// assert!(result.values().next().ok_or("missing result")?.all_indices().is_empty());
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn contract_adaptive<V>(
+    left: &PartitionedTreeTN<V>,
+    right: &PartitionedTreeTN<V>,
+    center: &V,
+    contract_options: &ContractionOptions,
+    patching_options: &PatchingOptions,
+) -> Result<PartitionedTreeTN<V>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    validate_patching_options(patching_options)?;
+    let contracted = left.contract(right, center, contract_options.clone())?;
+    truncate_adaptive(
+        &contracted,
+        center,
+        patching_options.rtol,
+        patching_options.max_bond_dim,
+    )
+}
+
+/// Truncate a partition with volume-proportional absolute squared-tail budgets.
+///
+/// The global budget is `rtol² * ||F||²`, where the norm is measured from the
+/// eager stored patches. A patch receives `global_budget * volume / total_volume`;
+/// its unprojected site dimensions define `volume`, while projected dimensions
+/// contribute one. Patches whose norm is at most their budget are dropped.
+///
+/// # Arguments
+///
+/// * `partitioned` - Homogeneous partition with eagerly masked patches.
+/// * `center` - Existing TreeTN node used for every local truncation.
+/// * `rtol` - Finite non-negative global relative tolerance.
+/// * `max_bond_dim` - Optional positive maximum retained bond dimension.
+///
+/// # Returns
+///
+/// A new partition with the retained patches and their assigned squared budget
+/// metadata. The input partition is unchanged, including when truncation fails.
+///
+/// # Errors
+///
+/// Returns [`PartitionedTreeTNError::InvalidOptions`] for invalid tolerance or
+/// rank cap, [`PartitionedTreeTNError::InvalidCenter`] for an absent center,
+/// [`PartitionedTreeTNError::VolumeOverflow`] for checked volume arithmetic,
+/// [`PartitionedTreeTNError::NonFiniteAdaptiveValue`] for a non-finite norm or
+/// budget, and typed TreeTN/backend errors for truncation failures. Stored
+/// topology, site assignment, and dtype mismatches are rejected before a patch
+/// can be dropped as a shortcut.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, IdxTensor};
+/// use tensor4all_partitionedtreetn::{
+///     truncate_adaptive, PartitionedTreeTN, Projector, SubDomainTreeTN,
+/// };
+/// use tensor4all_treetn::TreeTN;
+///
+/// let site = DynIndex::new_dyn(2);
+/// let make = |values, coordinate| -> Result<_, Box<dyn std::error::Error>> {
+///     let tensor = IdxTensor::from_dense(vec![site.clone()], values)?;
+///     let tree = TreeTN::from_tensors(vec![tensor], vec![0usize])?;
+///     Ok(SubDomainTreeTN::new(
+///         tree,
+///         Projector::from_pairs([(site.clone(), coordinate)])?,
+///     )?)
+/// };
+/// let partition = PartitionedTreeTN::from_subdomains(vec![
+///     make(vec![10.0_f64, 1.0e12], 0)?,
+///     make(vec![1.0e12, 0.01], 1)?,
+/// ])?;
+/// let result = truncate_adaptive(&partition, &0, 0.1, Some(2))?;
+/// assert_eq!(result.len(), 1);
+/// assert!(result.contains(&Projector::from_pairs([(site, 0)])?));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn truncate_adaptive<V>(
+    partitioned: &PartitionedTreeTN<V>,
+    center: &V,
+    rtol: f64,
+    max_bond_dim: Option<usize>,
+) -> Result<PartitionedTreeTN<V>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    validate_adaptive_truncation_options(rtol, max_bond_dim)?;
+    partitioned.validate_contents()?;
+    if partitioned.is_empty() {
+        return Ok(PartitionedTreeTN::new());
+    }
+
+    let template = partitioned
+        .values()
+        .next()
+        .ok_or(PartitionedTreeTNError::Empty)?;
+    ensure_center(template.data(), center)?;
+
+    let stats = patch_stats(partitioned)?;
+    let total_volume = stats.iter().try_fold(0usize, |total, stat| {
+        total
+            .checked_add(stat.volume)
+            .ok_or(PartitionedTreeTNError::VolumeOverflow)
+    })?;
+    if total_volume == 0 {
+        return Ok(PartitionedTreeTN::new());
+    }
+
+    let total_norm_squared = checked_finite_sum(stats.iter().map(|stat| stat.norm_squared))?;
+    let global_budget_squared = rtol * rtol * total_norm_squared;
+    if !global_budget_squared.is_finite() {
+        return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+    }
+
+    let mut retained = Vec::with_capacity(stats.len());
+    for stat in stats {
+        let patch_budget_squared =
+            global_budget_squared * (stat.volume as f64 / total_volume as f64);
+        if !patch_budget_squared.is_finite() {
+            return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+        }
+        if stat.norm_squared <= patch_budget_squared {
+            continue;
+        }
+
+        let mut subdomain = stat.subdomain;
+        let _unused_budget = truncate_subdomain_with_budget(
+            &mut subdomain,
+            center,
+            patch_budget_squared,
+            max_bond_dim,
+        )?;
+        retained.push(subdomain.with_budget_squared(patch_budget_squared)?);
+    }
+
+    PartitionedTreeTN::from_subdomains(retained)
+}
+
+fn validate_patching_options(options: &PatchingOptions) -> Result<()> {
+    validate_adaptive_truncation_options(options.rtol, options.max_bond_dim)?;
+    for (position, index) in options.patch_order.iter().enumerate() {
+        if index.dim == 0 {
+            return Err(PartitionedTreeTNError::InvalidOptions {
+                operation: "patching",
+                reason: "patch_order cannot contain zero-dimensional indices",
+            });
+        }
+        if options.patch_order[..position]
+            .iter()
+            .any(|previous| previous == index)
+        {
+            return Err(PartitionedTreeTNError::InvalidOptions {
+                operation: "patching",
+                reason: "patch_order cannot contain duplicate full indices",
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_adaptive_truncation_options(rtol: f64, max_bond_dim: Option<usize>) -> Result<()> {
+    if !rtol.is_finite() || rtol < 0.0 {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "patching",
+            reason: "rtol must be finite and non-negative",
+        });
+    }
+    if max_bond_dim == Some(0) {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "patching",
+            reason: "max_bond_dim must be at least 1",
+        });
+    }
+    Ok(())
+}
+
+fn validate_patch_order<V>(subdomain: &SubDomainTreeTN<V>, options: &PatchingOptions) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let indices = subdomain.all_indices();
+    for requested in &options.patch_order {
+        if !indices.iter().any(|candidate| candidate == requested) {
+            return Err(PartitionedTreeTNError::InvalidOptions {
+                operation: "patching",
+                reason: "patch_order must contain only full TreeTN site indices",
+            });
+        }
+    }
+    Ok(())
+}
+
+fn assign_volume_budgets<V>(
+    subdomains: Vec<SubDomainTreeTN<V>>,
+    rtol: f64,
+) -> Result<Vec<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if subdomains.is_empty() {
+        return Ok(subdomains);
+    }
+
+    let partitioned = PartitionedTreeTN::from_subdomains(subdomains)?;
+    let stats = patch_stats(&partitioned)?;
+    let total_volume = stats.iter().try_fold(0usize, |total, stat| {
+        total
+            .checked_add(stat.volume)
+            .ok_or(PartitionedTreeTNError::VolumeOverflow)
+    })?;
+    if total_volume == 0 {
+        return Ok(Vec::new());
+    }
+
+    let total_norm_squared = checked_finite_sum(stats.iter().map(|stat| stat.norm_squared))?;
+    let global_budget_squared = rtol * rtol * total_norm_squared;
+    if !global_budget_squared.is_finite() {
+        return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+    }
+
+    stats
+        .into_iter()
+        .map(|stat| {
+            let budget_squared = global_budget_squared * (stat.volume as f64 / total_volume as f64);
+            if !budget_squared.is_finite() {
+                return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+            }
+            stat.subdomain.with_budget_squared(budget_squared)
+        })
+        .collect()
+}
+
+fn budget_truncate_for_split_decision<V>(
+    subdomains: Vec<SubDomainTreeTN<V>>,
+    center: &V,
+) -> Result<Vec<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut retained = Vec::new();
+    for mut subdomain in subdomains {
+        let budget_squared =
+            subdomain
+                .budget_squared()
+                .ok_or(PartitionedTreeTNError::InvalidOptions {
+                    operation: "patching",
+                    reason: "adaptive split decisions require assigned patch budgets",
+                })?;
+        if subdomain.norm_squared()? <= budget_squared {
+            continue;
+        }
+        let _unused_budget =
+            truncate_subdomain_with_budget(&mut subdomain, center, budget_squared, None)?;
+        retained.push(subdomain);
+    }
+    Ok(retained)
+}
+
+fn patch_stats<V>(partitioned: &PartitionedTreeTN<V>) -> Result<Vec<PatchStats<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut stats = Vec::with_capacity(partitioned.len());
+    for subdomain in partitioned.values() {
+        let volume = subdomain_volume(subdomain)?;
+        let norm_squared = subdomain.norm_squared()?;
+        if !norm_squared.is_finite() {
+            return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+        }
+        stats.push(PatchStats {
+            subdomain: subdomain.clone(),
+            volume,
+            norm_squared,
+        });
+    }
+    Ok(stats)
+}
+
+fn subdomain_volume<V>(subdomain: &SubDomainTreeTN<V>) -> Result<usize>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    checked_product(
+        subdomain.all_indices().into_iter().map(|index| {
+            if index.dim == 0 {
+                return Err(PartitionedTreeTNError::InvalidOptions {
+                    operation: "patching",
+                    reason: "TreeTN site indices must have positive dimensions",
+                });
+            }
+            Ok(if subdomain.projector().is_projected_at(&index) {
+                1
+            } else {
+                index.dim
+            })
+        }),
+        || PartitionedTreeTNError::VolumeOverflow,
+    )
+}
+
+fn checked_product(
+    factors: impl IntoIterator<Item = Result<usize>>,
+    overflow: fn() -> PartitionedTreeTNError,
+) -> Result<usize> {
+    factors.into_iter().try_fold(1usize, |product, factor| {
+        product.checked_mul(factor?).ok_or_else(overflow)
+    })
+}
+
+fn checked_finite_sum(values: impl IntoIterator<Item = f64>) -> Result<f64> {
+    values.into_iter().try_fold(0.0, |sum, value| {
+        if !value.is_finite() {
+            return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+        }
+        let next = sum + value;
+        if next.is_finite() {
+            Ok(next)
+        } else {
+            Err(PartitionedTreeTNError::NonFiniteAdaptiveValue)
+        }
+    })
+}
+
+fn truncate_subdomain_with_budget<V>(
+    subdomain: &mut SubDomainTreeTN<V>,
+    center: &V,
+    budget_squared: f64,
+    max_bond_dim: Option<usize>,
+) -> Result<f64>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if !budget_squared.is_finite() || budget_squared < 0.0 {
+        return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+    }
+    if max_bond_dim == Some(0) {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "patching",
+            reason: "max_bond_dim must be at least 1",
+        });
+    }
+
+    let before = subdomain.norm_squared()?;
+    let policy = SvdTruncationPolicy::new(budget_squared)
+        .with_absolute()
+        .with_squared_values()
+        .with_discarded_tail_sum();
+    let mut options = TruncationOptions::default().with_svd_policy(policy);
+    if let Some(max_bond_dim) = max_bond_dim {
+        options = options.with_max_bond_dim(max_bond_dim);
+    }
+    subdomain.truncate(center, options)?;
+    let after = subdomain.norm_squared()?;
+    if !before.is_finite() || !after.is_finite() {
+        return Err(PartitionedTreeTNError::NonFiniteAdaptiveValue);
+    }
+    let used = (before - after).max(0.0);
+    Ok((budget_squared - used).max(0.0))
+}
+
+fn split_subdomain_by_options<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    center: &V,
+    options: &PatchingOptions,
+) -> Result<Option<Vec<SubDomainTreeTN<V>>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    choose_split_index(subdomain, center, options)?
+        .map(|index| split_subdomain(subdomain, &index))
+        .transpose()
+}
+
+fn choose_split_index<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    center: &V,
+    options: &PatchingOptions,
+) -> Result<Option<tensor4all_core::DynIndex>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let candidates = split_candidates(subdomain, options);
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    match options.split_strategy {
+        PatchSplitStrategy::Sequential => Ok(candidates.into_iter().next()),
+        PatchSplitStrategy::ExactParameterGain => {
+            choose_exact_parameter_gain_split(subdomain, center, options, candidates)
+        }
+    }
+}
+
+fn split_candidates<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    options: &PatchingOptions,
+) -> Vec<tensor4all_core::DynIndex>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut all_indices = subdomain.all_indices();
+    all_indices.sort_by(canonical_index_cmp);
+    let raw_candidates: Vec<_> = if options.patch_order.is_empty() {
+        all_indices.clone()
+    } else {
+        options.patch_order.clone()
+    };
+
+    raw_candidates
+        .into_iter()
+        .filter(|index| !subdomain.is_projected_at(index))
+        .filter(|index| all_indices.iter().any(|candidate| candidate == index))
+        .fold(Vec::new(), |mut candidates, index| {
+            if !candidates.iter().any(|candidate| candidate == &index) {
+                candidates.push(index);
+            }
+            candidates
+        })
+}
+
+fn choose_exact_parameter_gain_split<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    center: &V,
+    options: &PatchingOptions,
+    candidates: Vec<tensor4all_core::DynIndex>,
+) -> Result<Option<tensor4all_core::DynIndex>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut best: Option<(usize, tensor4all_core::DynIndex)> = None;
+    for candidate in candidates {
+        let candidate_count = split_child_parameter_count(subdomain, center, &candidate, options)?;
+        if best
+            .as_ref()
+            .is_none_or(|(best_count, _)| candidate_count < *best_count)
+        {
+            best = Some((candidate_count, candidate));
+        }
+    }
+    Ok(best.map(|(_, index)| index))
+}
+
+fn split_child_parameter_count<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    center: &V,
+    index: &tensor4all_core::DynIndex,
+    options: &PatchingOptions,
+) -> Result<usize>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let children = split_subdomain(subdomain, index)?;
+    children.into_iter().try_fold(0usize, |total, mut child| {
+        let budget_squared =
+            child
+                .budget_squared()
+                .ok_or(PartitionedTreeTNError::InvalidOptions {
+                    operation: "patching",
+                    reason: "adaptive split decisions require assigned patch budgets",
+                })?;
+        if child.norm_squared()? <= budget_squared {
+            return Ok(total);
+        }
+        let _unused_budget = truncate_subdomain_with_budget(
+            &mut child,
+            center,
+            budget_squared,
+            options.max_bond_dim,
+        )?;
+        let child_count = logical_parameter_count(&child)?;
+        total
+            .checked_add(child_count)
+            .ok_or(PartitionedTreeTNError::LogicalParameterCountOverflow)
+    })
+}
+
+fn logical_parameter_count<V>(subdomain: &SubDomainTreeTN<V>) -> Result<usize>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut total = 0usize;
+    for name in subdomain.data().node_names() {
+        let node = subdomain
+            .data()
+            .node_index(&name)
+            .ok_or_else(|| PartitionedTreeTNError::tree("TreeTN node name has no node index"))?;
+        let tensor = subdomain
+            .data()
+            .tensor(node)
+            .ok_or_else(|| PartitionedTreeTNError::tree("TreeTN node has no tensor"))?;
+        let local = checked_product(tensor.dims().into_iter().map(Ok), || {
+            PartitionedTreeTNError::LogicalParameterCountOverflow
+        })?;
+        total = total
+            .checked_add(local)
+            .ok_or(PartitionedTreeTNError::LogicalParameterCountOverflow)?;
+    }
+    Ok(total)
+}
+
+fn split_subdomain<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    index: &tensor4all_core::DynIndex,
+) -> Result<Vec<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if index.dim == 0 {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "patching",
+            reason: "cannot split along a zero-dimensional index",
+        });
+    }
+
+    let child_budget_squared = subdomain
+        .budget_squared()
+        .map(|budget_squared| budget_squared / index.dim as f64);
+    let mut children = Vec::with_capacity(index.dim);
+    for value in 0..index.dim {
+        let projector = Projector::from_pairs([(index.clone(), value)])?;
+        let child = subdomain
+            .project(&projector)?
+            .ok_or(PartitionedTreeTNError::ProjectorConflict)?;
+        children.push(match child_budget_squared {
+            Some(budget_squared) => child.with_budget_squared(budget_squared)?,
+            None => child,
+        });
+    }
+    Ok(children)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tensor4all_core::{DynIndex, IdxTensor};
+    use tensor4all_treetn::TreeTN;
+
+    #[test]
+    fn checked_volume_and_parameter_count_arithmetic_is_fallible() {
+        let volume = checked_product([Ok(usize::MAX), Ok(2)], || {
+            PartitionedTreeTNError::VolumeOverflow
+        });
+        assert!(matches!(
+            volume,
+            Err(PartitionedTreeTNError::VolumeOverflow)
+        ));
+
+        let parameters = checked_product([Ok(usize::MAX), Ok(2)], || {
+            PartitionedTreeTNError::LogicalParameterCountOverflow
+        });
+        assert!(matches!(
+            parameters,
+            Err(PartitionedTreeTNError::LogicalParameterCountOverflow)
+        ));
+    }
+
+    #[test]
+    fn logical_parameter_count_uses_structured_logical_dimensions() {
+        let site = DynIndex::new_dyn(3);
+        let auxiliary = DynIndex::new_dyn(3);
+        let tensor = IdxTensor::from_diag(vec![site, auxiliary], vec![2.0, 3.0, 5.0]).unwrap();
+        let tree = TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap();
+        let subdomain = SubDomainTreeTN::from_treetn(tree).unwrap();
+
+        assert_eq!(logical_parameter_count(&subdomain).unwrap(), 9);
+    }
+
+    #[test]
+    fn exact_parameter_gain_can_choose_a_later_candidate() {
+        let site0 = DynIndex::new_dyn(4);
+        let site1 = DynIndex::new_dyn(2);
+        let site2 = DynIndex::new_dyn(2);
+        let bond01 = DynIndex::new_dyn(2);
+        let bond12 = DynIndex::new_dyn(2);
+        let left =
+            IdxTensor::from_dense(vec![site0.clone(), bond01.clone()], vec![1.0_f64; 8]).unwrap();
+        let mut center_values = vec![0.0_f64; 8];
+        for channel in 0..2 {
+            center_values[channel + 2 * channel + 4 * channel] = 1.0;
+        }
+        let center =
+            IdxTensor::from_dense(vec![bond01, site1.clone(), bond12.clone()], center_values)
+                .unwrap();
+        let right = IdxTensor::from_dense(vec![bond12, site2], vec![1.0_f64; 4]).unwrap();
+        let tree = TreeTN::from_tensors(vec![left, center, right], vec![0usize, 1, 2]).unwrap();
+        let subdomain = SubDomainTreeTN::from_treetn(tree)
+            .unwrap()
+            .with_budget_squared(1.0e-20)
+            .unwrap();
+        let options = PatchingOptions {
+            rtol: 1.0e-12,
+            max_bond_dim: Some(1),
+            patch_order: vec![site0.clone(), site1.clone()],
+            split_strategy: PatchSplitStrategy::ExactParameterGain,
+        };
+
+        assert_eq!(
+            choose_split_index(&subdomain, &1, &options).unwrap(),
+            Some(site1)
+        );
+        let sequential = PatchingOptions {
+            split_strategy: PatchSplitStrategy::Sequential,
+            ..options
+        };
+        assert_eq!(
+            choose_split_index(&subdomain, &1, &sequential).unwrap(),
+            Some(site0)
+        );
+    }
+}

--- a/crates/tensor4all-partitionedtreetn/src/projector.rs
+++ b/crates/tensor4all-partitionedtreetn/src/projector.rs
@@ -1,0 +1,355 @@
+//! Projectors that fix selected TreeTN site indices to coordinates.
+//!
+//! The implementation follows the corrected `Projector` in
+//! `tensor4all-partitionedtt/src/projector.rs` after issue #634. In particular,
+//! equality, hashing, and deterministic ordering use the same full index
+//! identity: ID, canonical tags, and prime level.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use crate::error::{PartitionedTreeTNError, Result};
+use tensor4all_core::{DynIndex, TagSetLike};
+
+/// A map from full dynamic site indices to fixed zero-based coordinates.
+///
+/// Index equality is the core index contract: IDs, tags, and prime levels are
+/// significant, while the dimension is checked separately when a projector is
+/// applied to a TreeTN.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::DynIndex;
+/// use tensor4all_partitionedtreetn::Projector;
+///
+/// let index = DynIndex::new_dyn(2);
+/// let projector = Projector::from_pairs([(index.clone(), 1)]).unwrap();
+/// assert_eq!(projector.get(&index), Some(1));
+/// assert_eq!(projector.len(), 1);
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct Projector {
+    data: HashMap<DynIndex, usize>,
+}
+
+impl Projector {
+    /// Create an empty projector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_partitionedtreetn::Projector;
+    ///
+    /// let projector = Projector::new();
+    /// assert!(projector.is_empty());
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+
+    /// Create a projector from `(index, coordinate)` pairs.
+    ///
+    /// Coordinates are zero-based. Repeated equal full identities replace the
+    /// stored key and coordinate together after validating the new coordinate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`] when
+    /// a coordinate is not smaller than the supplied index dimension.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_partitionedtreetn::Projector;
+    ///
+    /// let index = DynIndex::new_dyn(3);
+    /// let projector = Projector::from_pairs([(index.clone(), 2)]).unwrap();
+    /// assert_eq!(projector.get(&index), Some(2));
+    /// ```
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Result<Self> {
+        let mut projector = Self::new();
+        for (index, value) in pairs {
+            projector.insert(index, value)?;
+        }
+        Ok(projector)
+    }
+
+    /// Return whether `index` has a fixed coordinate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_partitionedtreetn::Projector;
+    ///
+    /// let index = DynIndex::new_dyn(2);
+    /// let projector = Projector::from_pairs([(index.clone(), 0)]).unwrap();
+    /// assert!(projector.is_projected_at(&index));
+    /// ```
+    pub fn is_projected_at(&self, index: &DynIndex) -> bool {
+        self.data.contains_key(index)
+    }
+
+    /// Return the fixed coordinate for `index`, if present.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_partitionedtreetn::Projector;
+    ///
+    /// let index = DynIndex::new_dyn(2);
+    /// let projector = Projector::from_pairs([(index.clone(), 1)]).unwrap();
+    /// assert_eq!(projector.get(&index), Some(1));
+    /// ```
+    pub fn get(&self, index: &DynIndex) -> Option<usize> {
+        self.data.get(index).copied()
+    }
+
+    /// Iterate over projected full indices.
+    ///
+    /// The iteration order is unspecified. Use the projector's deterministic
+    /// ordering implementation when an order-independent result is required.
+    pub fn projected_indices(&self) -> impl Iterator<Item = &DynIndex> {
+        self.data.keys()
+    }
+
+    /// Return the number of projected indices.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Return whether no indices are projected.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Iterate over `(index, coordinate)` pairs in unspecified hash-map order.
+    pub fn iter(&self) -> impl Iterator<Item = (&DynIndex, &usize)> {
+        self.data.iter()
+    }
+
+    /// Insert or replace a projection transactionally.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`] and
+    /// leaves the projector unchanged when `value >= index.dim`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_partitionedtreetn::Projector;
+    ///
+    /// let index = DynIndex::new_dyn(2);
+    /// let mut projector = Projector::new();
+    /// projector.insert(index.clone(), 1).unwrap();
+    /// assert_eq!(projector.get(&index), Some(1));
+    /// ```
+    pub fn insert(&mut self, index: DynIndex, value: usize) -> Result<()> {
+        if value >= index.dim {
+            let dim = index.dim;
+            return Err(PartitionedTreeTNError::ProjectorCoordinateOutOfBounds {
+                index,
+                value,
+                dim,
+            });
+        }
+
+        // HashMap::insert keeps an equal old key. Remove first so the stored
+        // full identity and coordinate are replaced as one transaction.
+        self.data.remove(&index);
+        self.data.insert(index, value);
+        Ok(())
+    }
+
+    /// Remove a projection and return its coordinate, if present.
+    pub fn remove(&mut self, index: &DynIndex) -> Option<usize> {
+        self.data.remove(index)
+    }
+
+    /// Merge compatible projections, or return `None` for a coordinate conflict.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::DynIndex;
+    /// use tensor4all_partitionedtreetn::Projector;
+    ///
+    /// let index = DynIndex::new_dyn(2);
+    /// let left = Projector::from_pairs([(index.clone(), 0)]).unwrap();
+    /// let right = Projector::from_pairs([(index.clone(), 0)]).unwrap();
+    /// assert!(left.intersection(&right).is_some());
+    /// ```
+    pub fn intersection(&self, other: &Self) -> Option<Self> {
+        let mut result = self.data.clone();
+
+        for (index, &value) in &other.data {
+            if let Some(&existing) = result.get(index) {
+                if existing != value {
+                    return None;
+                }
+            } else {
+                result.insert(index.clone(), value);
+            }
+        }
+
+        Some(Self { data: result })
+    }
+
+    /// Keep only projections shared by both projectors with equal coordinates.
+    pub fn common_restriction(&self, other: &Self) -> Self {
+        let mut result = HashMap::new();
+
+        for (index, &value) in &self.data {
+            if other.get(index) == Some(value) {
+                result.insert(index.clone(), value);
+            }
+        }
+
+        Self { data: result }
+    }
+
+    /// Return whether two projectors describe an overlapping region.
+    pub fn is_compatible_with(&self, other: &Self) -> bool {
+        self.intersection(other).is_some()
+    }
+
+    /// Return whether `self` fixes at least all coordinates fixed by `other`.
+    pub fn is_subset_of(&self, other: &Self) -> bool {
+        for (index, &value) in &other.data {
+            match self.data.get(index) {
+                Some(&stored) if stored == value => continue,
+                _ => return false,
+            }
+        }
+        self.data.len() >= other.data.len()
+    }
+
+    /// Return whether all projectors in `projectors` are pairwise disjoint.
+    pub fn are_disjoint(projectors: &[Self]) -> bool {
+        for (i, left) in projectors.iter().enumerate() {
+            for right in projectors.iter().skip(i + 1) {
+                if left.is_compatible_with(right) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Return a projector restricted to the supplied full index set.
+    pub fn filter_indices(&self, indices: &[DynIndex]) -> Self {
+        let index_set: std::collections::HashSet<_> = indices.iter().collect();
+        Self {
+            data: self
+                .data
+                .iter()
+                .filter(|(index, _)| index_set.contains(index))
+                .map(|(index, value)| (index.clone(), *value))
+                .collect(),
+        }
+    }
+
+    /// Return entries in canonical full-identity and coordinate order.
+    pub(crate) fn canonical_entries(&self) -> Vec<(&DynIndex, usize)> {
+        let mut entries: Vec<_> = self
+            .data
+            .iter()
+            .map(|(index, &value)| (index, value))
+            .collect();
+        entries.sort_by(canonical_entry_cmp);
+        entries
+    }
+
+    /// Compare projectors by a deterministic total order compatible with `Eq`.
+    #[allow(dead_code)]
+    pub(crate) fn canonical_cmp(&self, other: &Self) -> Ordering {
+        let left = self.canonical_entries();
+        let right = other.canonical_entries();
+        match left.len().cmp(&right.len()) {
+            Ordering::Equal => {}
+            order => return order,
+        }
+
+        for (left_entry, right_entry) in left.iter().zip(&right) {
+            match canonical_entry_cmp(left_entry, right_entry) {
+                Ordering::Equal => {}
+                order => return order,
+            }
+        }
+        Ordering::Equal
+    }
+}
+
+fn canonical_entry_cmp(
+    (left_index, left_value): &(&DynIndex, usize),
+    (right_index, right_value): &(&DynIndex, usize),
+) -> Ordering {
+    canonical_index_cmp(left_index, right_index).then_with(|| left_value.cmp(right_value))
+}
+
+pub(crate) fn canonical_index_cmp(left: &DynIndex, right: &DynIndex) -> Ordering {
+    left.id
+        .cmp(&right.id)
+        .then_with(|| left.tags.iter().cmp(right.tags.iter()))
+        .then_with(|| left.plev.cmp(&right.plev))
+}
+
+impl PartialEq for Projector {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl Eq for Projector {}
+
+impl std::hash::Hash for Projector {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.data.len().hash(state);
+        for (index, value) in self.canonical_entries() {
+            index.hash(state);
+            value.hash(state);
+        }
+    }
+}
+
+impl PartialOrd for Projector {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            Some(Ordering::Equal)
+        } else if self.is_subset_of(other) {
+            Some(Ordering::Less)
+        } else if other.is_subset_of(self) {
+            Some(Ordering::Greater)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Projector {
+    type Item = (&'a DynIndex, &'a usize);
+    type IntoIter = std::collections::hash_map::Iter<'a, DynIndex, usize>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.iter()
+    }
+}
+
+impl IntoIterator for Projector {
+    type Item = (DynIndex, usize);
+    type IntoIter = std::collections::hash_map::IntoIter<DynIndex, usize>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tensor4all-partitionedtreetn/src/projector/tests.rs
+++ b/crates/tensor4all-partitionedtreetn/src/projector/tests.rs
@@ -1,0 +1,287 @@
+use super::*;
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+
+use std::hash::{Hash, Hasher};
+use tensor4all_core::index::Index;
+use tensor4all_core::TagSet;
+
+fn make_index(size: usize) -> DynIndex {
+    Index::new_dyn(size)
+}
+
+#[test]
+fn test_projector_new() {
+    let p = Projector::new();
+    assert!(p.is_empty());
+    assert_eq!(p.len(), 0);
+}
+
+#[test]
+fn test_projector_from_pairs() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(3);
+    let idx2 = make_index(4);
+
+    let p = projector([(idx0.clone(), 1), (idx2.clone(), 3)]);
+    assert_eq!(p.len(), 2);
+    assert!(p.is_projected_at(&idx0));
+    assert!(!p.is_projected_at(&idx1));
+    assert!(p.is_projected_at(&idx2));
+    assert_eq!(p.get(&idx0), Some(1));
+    assert_eq!(p.get(&idx1), None);
+    assert_eq!(p.get(&idx2), Some(3));
+}
+
+#[test]
+fn projector_accepts_zero_and_last_coordinates() {
+    let zero = make_index(2);
+    let last = make_index(3);
+    let projector = Projector::from_pairs([(zero.clone(), 0), (last.clone(), 2)]).unwrap();
+
+    assert_eq!(projector.get(&zero), Some(0));
+    assert_eq!(projector.get(&last), Some(2));
+}
+
+#[test]
+fn projector_from_pairs_rejects_out_of_range_coordinate() {
+    let index = make_index(2);
+    let error = Projector::from_pairs([(index.clone(), 2)]).unwrap_err();
+
+    assert!(matches!(
+        error,
+        PartitionedTreeTNError::ProjectorCoordinateOutOfBounds {
+            index: error_index,
+            value: 2,
+            dim: 2,
+        } if error_index == index
+    ));
+}
+
+#[test]
+fn test_projector_intersection_compatible() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+    let idx2 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 0), (idx2.clone(), 1)]);
+
+    let merged = a.intersection(&b).unwrap();
+    assert_eq!(merged.len(), 3);
+    assert_eq!(merged.get(&idx0), Some(1));
+    assert_eq!(merged.get(&idx1), Some(0));
+    assert_eq!(merged.get(&idx2), Some(1));
+}
+
+#[test]
+fn test_projector_intersection_conflict() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 1)]);
+
+    assert!(a.intersection(&b).is_none());
+}
+
+#[test]
+fn test_projector_common_restriction() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+    let idx2 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 0), (idx2.clone(), 1)]);
+
+    let common = a.common_restriction(&b);
+    assert_eq!(common.len(), 1);
+    assert!(!common.is_projected_at(&idx0));
+    assert!(common.is_projected_at(&idx1));
+    assert_eq!(common.get(&idx1), Some(0));
+    assert!(!common.is_projected_at(&idx2));
+}
+
+#[test]
+fn test_projector_is_compatible_with() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1)]);
+    let b = projector([(idx1.clone(), 0)]);
+    let c = projector([(idx0.clone(), 0)]);
+
+    assert!(a.is_compatible_with(&b));
+    assert!(!a.is_compatible_with(&c));
+}
+
+#[test]
+fn test_projector_is_subset_of() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+    let idx2 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0), (idx2.clone(), 1)]);
+    let b = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let c = projector([(idx0.clone(), 1)]);
+
+    assert!(a.is_subset_of(&b));
+    assert!(a.is_subset_of(&c));
+    assert!(b.is_subset_of(&c));
+    assert!(!b.is_subset_of(&a));
+    assert!(!c.is_subset_of(&a));
+}
+
+#[test]
+fn test_projector_are_disjoint() {
+    let idx0 = make_index(2);
+
+    let p1 = projector([(idx0.clone(), 0)]);
+    let p2 = projector([(idx0.clone(), 1)]);
+
+    assert!(Projector::are_disjoint(&[p1.clone(), p2.clone()]));
+
+    let p3 = projector([(idx0.clone(), 0)]);
+    assert!(!Projector::are_disjoint(&[p1, p3]));
+}
+
+#[test]
+fn test_projector_partial_ord() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx0.clone(), 1)]);
+    let c = projector([(idx0.clone(), 0)]);
+
+    assert!(a < b);
+    assert!(b > a);
+    assert_eq!(a.partial_cmp(&c), None);
+    assert_eq!(b.partial_cmp(&c), None);
+}
+
+#[test]
+fn test_projector_iteration() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(3);
+
+    let p = projector([(idx0.clone(), 1), (idx1.clone(), 2)]);
+    let pairs: Vec<_> = p.into_iter().collect();
+    assert_eq!(pairs.len(), 2);
+}
+
+#[test]
+fn test_projector_equality_and_hash() {
+    use std::collections::HashSet;
+
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+
+    let a = projector([(idx0.clone(), 1), (idx1.clone(), 0)]);
+    let b = projector([(idx1.clone(), 0), (idx0.clone(), 1)]);
+    let c = projector([(idx0.clone(), 1)]);
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+
+    let mut set = HashSet::new();
+    set.insert(a.clone());
+    assert!(set.contains(&b));
+    assert!(!set.contains(&c));
+}
+
+fn hash_projector(projector: &Projector) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    projector.hash(&mut hasher);
+    hasher.finish()
+}
+
+#[test]
+fn projector_hash_uses_canonical_full_identity_order() {
+    let base = make_index(2);
+    let pairs: Vec<_> = (0..32)
+        .map(|value| {
+            let tags = TagSet::from_str(&format!("Tag{value:02}")).unwrap();
+            (Index::new_with_tags(base.id, 2, tags), value % 2)
+        })
+        .collect();
+    let mut reversed = pairs.clone();
+    reversed.reverse();
+
+    let first = projector(pairs);
+    let second = projector(reversed);
+
+    assert_eq!(first, second);
+    assert_eq!(hash_projector(&first), hash_projector(&second));
+}
+
+#[test]
+fn projector_multi_tag_identity_has_canonical_hash_and_order() {
+    let base = make_index(2);
+    let first_index = Index::new_with_tags(
+        base.id,
+        base.dim,
+        TagSet::from_str("Site,Auxiliary").unwrap(),
+    );
+    let second_index = Index::new_with_tags(
+        base.id,
+        base.dim,
+        TagSet::from_str("Auxiliary,Site").unwrap(),
+    );
+    let first = projector([(first_index, 1)]);
+    let second = projector([(second_index, 1)]);
+
+    assert_eq!(first, second);
+    assert_eq!(hash_projector(&first), hash_projector(&second));
+    assert_eq!(first.canonical_cmp(&second), std::cmp::Ordering::Equal);
+}
+
+#[test]
+fn projector_insert_rejects_out_of_range_coordinate_without_mutating() {
+    let index = make_index(2);
+    let mut projector = projector([(index.clone(), 0)]);
+    let before = projector.clone();
+
+    for value in [index.dim, index.dim + 1] {
+        let error = projector.insert(index.clone(), value).unwrap_err();
+        assert!(matches!(
+            error,
+            PartitionedTreeTNError::ProjectorCoordinateOutOfBounds {
+                index: error_index,
+                value: error_value,
+                dim,
+            } if error_index == index && error_value == value && dim == index.dim
+        ));
+        assert_eq!(projector, before);
+    }
+}
+
+#[test]
+fn projector_duplicate_identity_replaces_key_and_value_together() {
+    let index = make_index(2);
+    let replacement = Index::new_with_tags(index.id, 5, index.tags.clone());
+    let mut projector = projector([(index, 1)]);
+
+    projector.insert(replacement.clone(), 3).unwrap();
+
+    let (stored_index, stored_value) = projector.iter().next().unwrap();
+    assert_eq!(stored_index, &replacement);
+    assert_eq!(*stored_value, 3);
+}
+
+#[test]
+fn test_projector_filter_indices() {
+    let idx0 = make_index(2);
+    let idx1 = make_index(2);
+    let idx2 = make_index(2);
+
+    let p = projector([(idx0.clone(), 1), (idx1.clone(), 0), (idx2.clone(), 1)]);
+
+    let filtered = p.filter_indices(&[idx0.clone(), idx2.clone()]);
+    assert_eq!(filtered.len(), 2);
+    assert!(filtered.is_projected_at(&idx0));
+    assert!(!filtered.is_projected_at(&idx1));
+    assert!(filtered.is_projected_at(&idx2));
+}

--- a/crates/tensor4all-partitionedtreetn/src/subdomain_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/src/subdomain_tree_tn.rs
@@ -1,0 +1,848 @@
+//! Eagerly projected TreeTN subdomains.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use crate::error::{PartitionedTreeTNError, Result};
+use crate::projector::Projector;
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
+use tensor4all_treetn::{
+    contraction::{self, ContractionMethod, ContractionOptions},
+    SiteIndexNetwork, TreeTN, TruncationOptions,
+};
+
+/// A TreeTN together with the projector defining its subdomain.
+///
+/// The stored TreeTN is always eagerly masked. Every original site axis is
+/// retained, and values outside the projector are zero. Rebuilding from local
+/// tensors also clears canonical and orthogonality metadata; a subdomain does
+/// not store a canonical center.
+///
+/// `V` names TreeTN nodes. The tensor storage is intentionally fixed to
+/// [`IdxTensor`] because projection uses its differentiable `mask_index` API.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::{DynIndex, IdxTensor};
+/// use tensor4all_treetn::TreeTN;
+/// use tensor4all_partitionedtreetn::{Projector, SubDomainTreeTN};
+///
+/// let site = DynIndex::new_dyn(2);
+/// let tensor = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0])?;
+/// let tree = TreeTN::from_tensors(vec![tensor], vec![0usize])?;
+/// let subdomain = SubDomainTreeTN::new(
+///     tree,
+///     Projector::from_pairs([(site.clone(), 1)])?,
+/// )?;
+///
+/// assert_eq!(subdomain.node_count(), 1);
+/// assert_eq!(subdomain.data().tensor(subdomain.data().node_index(&0).unwrap())
+///     .unwrap().to_vec::<f64>()?, vec![0.0, 4.0]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct SubDomainTreeTN<V = usize>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    data: TreeTN<IdxTensor, V>,
+    projector: Projector,
+    budget_squared: Option<f64>,
+}
+
+impl<V> SubDomainTreeTN<V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Return the eagerly projected TreeTN by immutable reference.
+    pub fn data(&self) -> &TreeTN<IdxTensor, V> {
+        &self.data
+    }
+
+    /// Return the projector by immutable reference.
+    pub fn projector(&self) -> &Projector {
+        &self.projector
+    }
+
+    /// Consume the subdomain and return its eagerly projected TreeTN.
+    pub fn into_data(self) -> TreeTN<IdxTensor, V> {
+        self.data
+    }
+
+    /// Return the number of TreeTN nodes.
+    pub fn node_count(&self) -> usize {
+        self.data.node_count()
+    }
+
+    /// Return whether the TreeTN has no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.data.node_count() == 0
+    }
+
+    /// Return all full site indices, including every axis on every node.
+    ///
+    /// The order is unspecified because TreeTN site spaces are sets. Full
+    /// index equality, rather than ID-only equality, is used by the stored
+    /// network and projector.
+    pub fn all_indices(&self) -> Vec<DynIndex> {
+        self.data
+            .node_names()
+            .into_iter()
+            .flat_map(|name| {
+                self.data
+                    .site_space(&name)
+                    .into_iter()
+                    .flat_map(|indices| indices.iter().cloned())
+            })
+            .collect()
+    }
+
+    /// Return the TreeTN site-index network describing node topology and site axes.
+    pub fn site_index_network(&self) -> &SiteIndexNetwork<V, DynIndex> {
+        self.data.site_index_network()
+    }
+
+    /// Return whether `index` is fixed by this subdomain projector.
+    pub fn is_projected_at(&self, index: &DynIndex) -> bool {
+        self.projector.is_projected_at(index)
+    }
+
+    fn validate_projector(&self, projector: &Projector) -> Result<()>
+    where
+        V: Ord,
+    {
+        validate_projector_against_data(&self.data, projector)
+    }
+}
+
+impl<V> SubDomainTreeTN<V>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    /// Return the largest internal bond dimension, or one for a bondless tree.
+    pub fn max_bond_dim(&self) -> usize {
+        self.data.link_dims().into_iter().fold(1, usize::max)
+    }
+
+    pub(crate) fn validate_invariants(&self) -> Result<()> {
+        validate_data(&self.data)?;
+        self.validate_projector(&self.projector)?;
+        if let Some(budget_squared) = self.budget_squared {
+            validate_budget_squared(budget_squared)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn budget_squared(&self) -> Option<f64> {
+        self.budget_squared
+    }
+
+    pub(crate) fn with_budget_squared(mut self, budget_squared: f64) -> Result<Self> {
+        validate_budget_squared(budget_squared)?;
+        self.budget_squared = Some(budget_squared);
+        Ok(self)
+    }
+
+    pub(crate) fn scalar_kind(&self) -> Result<Option<ScalarKind>> {
+        validate_data(&self.data)
+    }
+
+    pub(crate) fn from_masked_data(
+        data: TreeTN<IdxTensor, V>,
+        projector: Projector,
+        budget_squared: Option<f64>,
+    ) -> Result<Self> {
+        validate_data(&data)?;
+        validate_projector_against_data(&data, &projector)?;
+        if let Some(budget_squared) = budget_squared {
+            validate_budget_squared(budget_squared)?;
+        }
+        Ok(Self {
+            data,
+            projector,
+            budget_squared,
+        })
+    }
+
+    /// Construct an eagerly projected subdomain from a TreeTN and projector.
+    ///
+    /// The input topology must be one connected acyclic TreeTN. Every
+    /// projector index must match a full site-index identity in the TreeTN;
+    /// coordinates are checked against the TreeTN dimension, not merely the
+    /// dimension carried by the projector key. All nodes must use one
+    /// supported homogeneous `IdxTensor` scalar dtype.
+    ///
+    /// Construction masks each selected local tensor with
+    /// [`IdxTensor::mask_index`], retains all site axes, and rebuilds the
+    /// TreeTN. It therefore does not materialize the full network and does not
+    /// retain canonical metadata from the input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::InvalidTopology`] for a non-tree
+    /// input, [`PartitionedTreeTNError::DTypeMismatch`] for mixed node dtypes,
+    /// [`PartitionedTreeTNError::ProjectorIndexNotFound`] for an absent full
+    /// site identity, [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`]
+    /// for an invalid coordinate, or a typed backend/TreeTN error when local
+    /// masking or rebuilding fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_treetn::TreeTN;
+    /// use tensor4all_partitionedtreetn::{Projector, SubDomainTreeTN};
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let tree = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0])?],
+    ///     vec![0usize],
+    /// )?;
+    /// let subdomain = SubDomainTreeTN::new(
+    ///     tree,
+    ///     Projector::from_pairs([(site.clone(), 0)])?,
+    /// )?;
+    /// assert_eq!(subdomain.projector().get(&site), Some(0));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn new(data: TreeTN<IdxTensor, V>, projector: Projector) -> Result<Self> {
+        let _ = validate_data(&data)?;
+        validate_projector_against_data(&data, &projector)?;
+        let data = rebuild_masked_tree(&data, &projector)?;
+        Ok(Self {
+            data,
+            projector,
+            budget_squared: None,
+        })
+    }
+
+    /// Construct an eagerly rebuilt subdomain with an empty projector.
+    ///
+    /// Rebuilding also clears canonical and orthogonality metadata present on
+    /// the input TreeTN.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::InvalidTopology`] for a non-tree,
+    /// [`PartitionedTreeTNError::DTypeMismatch`] or
+    /// [`PartitionedTreeTNError::UnsupportedDType`] for invalid node dtypes,
+    /// [`PartitionedTreeTNError::TensorStorage`] or
+    /// [`PartitionedTreeTNError::TensorConstruction`] when rebuilding fails,
+    /// and [`PartitionedTreeTNError::TreeTN`] for other TreeTN validation errors.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_treetn::TreeTN;
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let tree = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![site], vec![2.0_f64, 3.0])?],
+    ///     vec![0usize],
+    /// )?;
+    /// let subdomain = SubDomainTreeTN::from_treetn(tree)?;
+    /// assert!(subdomain.projector().is_empty());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn from_treetn(data: TreeTN<IdxTensor, V>) -> Result<Self> {
+        Self::new(data, Projector::new())
+    }
+
+    /// Apply compatible new restrictions and return another eagerly masked value.
+    ///
+    /// Existing restrictions are already represented in `self.data`, so only
+    /// newly added projector entries are sent through `mask_index`. A
+    /// conflicting projector returns `Ok(None)` without changing `self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::ProjectorIndexNotFound`] or
+    /// [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`] for invalid
+    /// restrictions, [`PartitionedTreeTNError::TensorStorage`] or
+    /// [`PartitionedTreeTNError::TensorConstruction`] when masking fails, and
+    /// [`PartitionedTreeTNError::TreeTN`] when site-space validation or rebuilding
+    /// the TreeTN fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_treetn::TreeTN;
+    /// use tensor4all_partitionedtreetn::{Projector, SubDomainTreeTN};
+    ///
+    /// let left = DynIndex::new_dyn(2);
+    /// let right = DynIndex::new_dyn(2);
+    /// let tree = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(
+    ///         vec![left.clone(), right.clone()],
+    ///         vec![1.0_f64, 2.0, 3.0, 4.0],
+    ///     )?],
+    ///     vec![0usize],
+    /// )?;
+    /// let source = SubDomainTreeTN::new(tree, Projector::from_pairs([(left.clone(), 0)])?)?;
+    /// let result = source.project(&Projector::from_pairs([(right.clone(), 1)])?)?;
+    /// let result = result.ok_or("conflicting projector")?;
+    /// assert_eq!(result.projector().get(&left), Some(0));
+    /// assert_eq!(result.projector().get(&right), Some(1));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn project(&self, projector: &Projector) -> Result<Option<Self>> {
+        self.validate_projector(projector)?;
+        let Some(merged_projector) = self.projector.intersection(projector) else {
+            return Ok(None);
+        };
+        self.validate_projector(&merged_projector)?;
+
+        let mut additions = Projector::new();
+        for (index, &value) in projector.iter() {
+            if self.projector.get(index) != Some(value) {
+                additions.insert(index.clone(), value)?;
+            }
+        }
+
+        let data = rebuild_masked_tree(&self.data, &additions)?;
+        Ok(Some(Self {
+            data,
+            projector: merged_projector,
+            budget_squared: self.budget_squared,
+        }))
+    }
+
+    /// Add two subdomains with the same projector using strict TreeTN addition.
+    ///
+    /// The stored TreeTNs are already eagerly masked, so this method performs no
+    /// projector pass. The result retains every site axis and the left budget
+    /// metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::ProjectorMismatch`] when the projector
+    /// keys differ, [`PartitionedTreeTNError::TopologyMismatch`] or
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`] when the TreeTN structures
+    /// differ, [`PartitionedTreeTNError::DTypeMismatch`] for mixed scalar dtypes,
+    /// or [`PartitionedTreeTNError::TreeTN`] for strict addition failures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    /// use tensor4all_treetn::TreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let make = |values| {
+    ///     TreeTN::from_tensors(
+    ///         vec![IdxTensor::from_dense(vec![site.clone()], values)?],
+    ///         vec![0usize],
+    ///     )
+    /// };
+    /// let left = SubDomainTreeTN::from_treetn(make(vec![1.0_f64, 2.0])?)?;
+    /// let right = SubDomainTreeTN::from_treetn(make(vec![3.0_f64, 4.0])?)?;
+    /// let sum = left.add(&right)?;
+    /// let node = sum.data().node_index(&0).ok_or("missing node")?;
+    /// assert_eq!(sum.data().tensor(node).ok_or("missing tensor")?.to_vec::<f64>()?,
+    ///            vec![4.0, 6.0]);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn add(&self, other: &Self) -> Result<Self> {
+        self.validate_invariants()?;
+        other.validate_invariants()?;
+        ensure_same_tree_structure(&self.data, &other.data)?;
+        ensure_same_dtype(self.scalar_kind()?, other.scalar_kind()?)?;
+        if self.projector != other.projector {
+            return Err(PartitionedTreeTNError::ProjectorMismatch);
+        }
+
+        let data = self
+            .data
+            .add(&other.data)
+            .map_err(PartitionedTreeTNError::from)?;
+        ensure_same_tree_structure(&self.data, &data)?;
+        Self::from_masked_data(data, self.projector.clone(), self.budget_squared)
+    }
+
+    /// Truncate this eagerly masked subdomain towards an explicit TreeTN center.
+    ///
+    /// The operation works on a clone and commits only after TreeTN truncation
+    /// and invariant validation succeed. It preserves all site axes, the
+    /// projector, and the internal squared budget; the center is not stored.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::InvalidCenter`] when `center` is absent,
+    /// [`PartitionedTreeTNError::InvalidOptions`] when `options` requests an
+    /// invalid bond dimension, [`PartitionedTreeTNError::TopologyMismatch`] or
+    /// [`PartitionedTreeTNError::SiteIndexMismatch`] if truncation changes the
+    /// site structure, or [`PartitionedTreeTNError::TreeTN`] for canonicalization,
+    /// SVD, or backend failures. The receiver is unchanged on error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    /// use tensor4all_treetn::{TreeTN, TruncationOptions};
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let tree = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![site], vec![3.0_f64, 4.0])?],
+    ///     vec!["center".to_string()],
+    /// )?;
+    /// let mut subdomain = SubDomainTreeTN::from_treetn(tree)?;
+    /// subdomain.truncate(&"center".to_string(), TruncationOptions::default())?;
+    /// assert_eq!(subdomain.node_count(), 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn truncate(&mut self, center: &V, options: TruncationOptions) -> Result<()> {
+        validate_truncation_options(&options)?;
+        self.validate_invariants()?;
+        ensure_center(&self.data, center)?;
+
+        let original = self.data.clone();
+        let mut data = original.clone();
+        data.truncate_mut([center.clone()], options)
+            .map_err(PartitionedTreeTNError::from)?;
+        ensure_same_tree_structure(&original, &data)?;
+        validate_data(&data)?;
+        validate_projector_against_data(&data, &self.projector)?;
+        self.data = data;
+        Ok(())
+    }
+
+    /// Contract two compatible subdomains at an explicit TreeTN center.
+    ///
+    /// The operation contracts the already masked stored TreeTNs directly.
+    /// Compatible projectors are merged, then entries for site indices absent
+    /// from the contracted output are removed. The returned subdomain retains
+    /// the left budget metadata and never stores `center`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::TopologyMismatch`] when named node
+    /// topologies differ, [`PartitionedTreeTNError::SiteIndexMismatch`] when a
+    /// contractable site index is assigned to different nodes,
+    /// [`PartitionedTreeTNError::DTypeMismatch`] for mixed dtypes,
+    /// [`PartitionedTreeTNError::InvalidCenter`] for an absent center,
+    /// [`PartitionedTreeTNError::InvalidOptions`] for forbidden dense/reference
+    /// options, or [`PartitionedTreeTNError::TreeTN`] for contraction failures.
+    /// Returns `Ok(None)` when the projector regions conflict.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    /// use tensor4all_treetn::{contraction::ContractionOptions, TreeTN};
+    ///
+    /// let left_site = DynIndex::new_dyn(2);
+    /// let right_site = DynIndex::new_dyn(2);
+    /// let left = SubDomainTreeTN::from_treetn(TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![left_site], vec![1.0_f64, 2.0])?],
+    ///     vec![0usize],
+    /// )?)?;
+    /// let right = SubDomainTreeTN::from_treetn(TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![right_site], vec![3.0_f64, 4.0])?],
+    ///     vec![0usize],
+    /// )?)?;
+    /// let result = left.contract(&right, &0, ContractionOptions::default())?;
+    /// assert!(result.is_some());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn contract(
+        &self,
+        other: &Self,
+        center: &V,
+        options: ContractionOptions,
+    ) -> Result<Option<Self>> {
+        validate_contraction_options(&options)?;
+        self.validate_invariants()?;
+        other.validate_invariants()?;
+        ensure_same_topology(&self.data, &other.data)?;
+        ensure_same_dtype(self.scalar_kind()?, other.scalar_kind()?)?;
+        validate_contraction_site_assignment(&self.data, &other.data)?;
+        ensure_center(&self.data, center)?;
+        if !self.projector.is_compatible_with(&other.projector) {
+            return Ok(None);
+        }
+
+        let merged_projector = self
+            .projector
+            .intersection(&other.projector)
+            .ok_or(PartitionedTreeTNError::ProjectorConflict)?;
+        let data = contraction::contract(&self.data, &other.data, center, options)
+            .map_err(PartitionedTreeTNError::from)?;
+        let (site_indices, _) = data
+            .all_site_indices()
+            .map_err(PartitionedTreeTNError::from)?;
+        let projector = merged_projector.filter_indices(&site_indices);
+        Self::from_masked_data(data, projector, self.budget_squared).map(Some)
+    }
+
+    /// Compute the Frobenius norm without mutating the stored TreeTN.
+    ///
+    /// This clones the TreeTN wrapper and allows the clone to canonicalize
+    /// internally. The cost is one TreeTN metadata/tensor clone plus the
+    /// underlying canonicalization sweep; it does not materialize the full
+    /// site tensor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::TreeTN`] when TreeTN canonicalization
+    /// or norm evaluation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_treetn::TreeTN;
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let tree = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![site], vec![3.0_f64, 4.0])?],
+    ///     vec![0usize],
+    /// )?;
+    /// let subdomain = SubDomainTreeTN::from_treetn(tree)?;
+    /// assert!((subdomain.norm()? - 5.0).abs() < 1.0e-12);
+    /// assert!(subdomain.data().canonical_region().is_empty());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn norm(&self) -> Result<f64> {
+        let mut data = self.data.clone();
+        data.norm().map_err(PartitionedTreeTNError::from)
+    }
+
+    /// Compute the squared Frobenius norm without mutating the stored TreeTN.
+    ///
+    /// This clones the TreeTN wrapper and lets the clone canonicalize, with the
+    /// same linear-network clone and sweep cost as [`Self::norm`]. No full dense
+    /// materialization is performed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PartitionedTreeTNError::TreeTN`] when TreeTN canonicalization
+    /// or norm evaluation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_treetn::TreeTN;
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let tree = TreeTN::from_tensors(
+    ///     vec![IdxTensor::from_dense(vec![site], vec![3.0_f64, 4.0])?],
+    ///     vec![0usize],
+    /// )?;
+    /// let subdomain = SubDomainTreeTN::from_treetn(tree)?;
+    /// assert!((subdomain.norm_squared()? - 25.0).abs() < 1.0e-12);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn norm_squared(&self) -> Result<f64> {
+        let mut data = self.data.clone();
+        data.norm_squared().map_err(PartitionedTreeTNError::from)
+    }
+
+    /// Compute the inner product using the already masked stored TreeTNs.
+    ///
+    /// No projector is reapplied and no dense materialization is performed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a dtype mismatch, site-space mismatch, TreeTN, or backend error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor};
+    /// use tensor4all_treetn::TreeTN;
+    /// use tensor4all_partitionedtreetn::SubDomainTreeTN;
+    ///
+    /// let site = DynIndex::new_dyn(2);
+    /// let make = || {
+    ///     TreeTN::from_tensors(
+    ///         vec![IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0])?],
+    ///         vec![0usize],
+    ///     )
+    /// };
+    /// let left = SubDomainTreeTN::from_treetn(make()?)?;
+    /// let right = SubDomainTreeTN::from_treetn(make()?)?;
+    /// assert!((left.inner(&right)?.real() - 25.0).abs() < 1.0e-12);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn inner(&self, other: &Self) -> Result<tensor4all_core::AnyScalar> {
+        self.validate_invariants()?;
+        other.validate_invariants()?;
+        ensure_same_tree_structure(&self.data, &other.data)?;
+        ensure_same_dtype(self.scalar_kind()?, other.scalar_kind()?)?;
+        self.data
+            .inner(&other.data)
+            .map_err(PartitionedTreeTNError::from)
+    }
+}
+
+pub(crate) fn ensure_same_topology<V>(
+    left: &TreeTN<IdxTensor, V>,
+    right: &TreeTN<IdxTensor, V>,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if left.same_topology(right) {
+        Ok(())
+    } else {
+        Err(PartitionedTreeTNError::TopologyMismatch)
+    }
+}
+
+pub(crate) fn ensure_same_tree_structure<V>(
+    left: &TreeTN<IdxTensor, V>,
+    right: &TreeTN<IdxTensor, V>,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    ensure_same_topology(left, right)?;
+    if left.share_equivalent_site_index_network(right) {
+        Ok(())
+    } else {
+        Err(PartitionedTreeTNError::SiteIndexMismatch)
+    }
+}
+
+pub(crate) fn ensure_same_dtype(
+    expected: Option<ScalarKind>,
+    actual: Option<ScalarKind>,
+) -> Result<()> {
+    if expected == actual {
+        return Ok(());
+    }
+    Err(PartitionedTreeTNError::DTypeMismatch {
+        expected: expected
+            .map(|dtype| dtype.name().to_string())
+            .unwrap_or_else(|| "empty".to_string()),
+        actual: actual
+            .map(|dtype| dtype.name().to_string())
+            .unwrap_or_else(|| "empty".to_string()),
+    })
+}
+
+pub(crate) fn ensure_center<V>(data: &TreeTN<IdxTensor, V>, center: &V) -> Result<()>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    if data.node_index(center).is_some() {
+        Ok(())
+    } else {
+        Err(PartitionedTreeTNError::InvalidCenter)
+    }
+}
+
+fn validate_budget_squared(budget_squared: f64) -> Result<()> {
+    if !budget_squared.is_finite() || budget_squared < 0.0 {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "patching",
+            reason: "squared patch budgets must be finite and non-negative",
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_truncation_options(options: &TruncationOptions) -> Result<()> {
+    if options.max_bond_dim() == Some(0) {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "truncate",
+            reason: "max_bond_dim must be greater than zero",
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_contraction_options(options: &ContractionOptions) -> Result<()> {
+    if options.max_bond_dim == Some(0) {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "contract",
+            reason: "max_bond_dim must be greater than zero",
+        });
+    }
+    if matches!(options.method, ContractionMethod::Naive) {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "contract",
+            reason: "dense/reference contraction is not allowed in partition algebra",
+        });
+    }
+    if matches!(options.method, ContractionMethod::Fit) && options.nfullsweeps == 0 {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "contract",
+            reason: "Fit contraction requires at least one full sweep",
+        });
+    }
+    if options
+        .qr_rtol
+        .is_some_and(|rtol| !rtol.is_finite() || rtol < 0.0)
+    {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "contract",
+            reason: "qr_rtol must be finite and non-negative",
+        });
+    }
+    if options
+        .convergence_tol
+        .is_some_and(|tol| !tol.is_finite() || tol < 0.0)
+    {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "contract",
+            reason: "convergence_tol must be finite and non-negative",
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_contraction_site_assignment<V>(
+    left: &TreeTN<IdxTensor, V>,
+    right: &TreeTN<IdxTensor, V>,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let (left_indices, left_nodes) = left
+        .all_site_indices()
+        .map_err(PartitionedTreeTNError::from)?;
+    let (right_indices, right_nodes) = right
+        .all_site_indices()
+        .map_err(PartitionedTreeTNError::from)?;
+
+    for (left_index, left_node) in left_indices.iter().zip(&left_nodes) {
+        for (right_index, right_node) in right_indices.iter().zip(&right_nodes) {
+            if left_index.is_contractable(right_index) && left_node != right_node {
+                return Err(PartitionedTreeTNError::SiteIndexMismatch);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScalarKind {
+    F32,
+    F64,
+    C32,
+    C64,
+}
+
+impl ScalarKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::F32 => "f32",
+            Self::F64 => "f64",
+            Self::C32 => "Complex32",
+            Self::C64 => "Complex64",
+        }
+    }
+}
+
+fn scalar_kind(tensor: &IdxTensor) -> Result<ScalarKind> {
+    if tensor.is_f32() {
+        Ok(ScalarKind::F32)
+    } else if tensor.is_f64() {
+        Ok(ScalarKind::F64)
+    } else if tensor.is_c32() {
+        Ok(ScalarKind::C32)
+    } else if tensor.is_c64() {
+        Ok(ScalarKind::C64)
+    } else {
+        Err(PartitionedTreeTNError::UnsupportedDType {
+            dtype: format!("{:?}", tensor.storage_kind()),
+        })
+    }
+}
+
+fn validate_data<V>(data: &TreeTN<IdxTensor, V>) -> Result<Option<ScalarKind>>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    data.validate_tree()
+        .map_err(PartitionedTreeTNError::invalid_topology)?;
+
+    let mut dtype: Option<ScalarKind> = None;
+    for name in data.node_names() {
+        let node = data
+            .node_index(&name)
+            .ok_or_else(|| PartitionedTreeTNError::tree("TreeTN node name has no node index"))?;
+        let tensor = data
+            .tensor(node)
+            .ok_or_else(|| PartitionedTreeTNError::tree("TreeTN node has no tensor"))?;
+        let actual = scalar_kind(tensor)?;
+        if let Some(expected) = dtype {
+            if expected != actual {
+                return Err(PartitionedTreeTNError::DTypeMismatch {
+                    expected: expected.name().to_string(),
+                    actual: actual.name().to_string(),
+                });
+            }
+        } else {
+            dtype = Some(actual);
+        }
+    }
+    Ok(dtype)
+}
+
+fn validate_projector_against_data<V>(
+    data: &TreeTN<IdxTensor, V>,
+    projector: &Projector,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let (site_indices, _) = data
+        .all_site_indices()
+        .map_err(PartitionedTreeTNError::from)?;
+    for (index, &value) in projector.iter() {
+        let Some(matched) = site_indices.iter().find(|candidate| *candidate == index) else {
+            return Err(PartitionedTreeTNError::ProjectorIndexNotFound {
+                index: index.clone(),
+            });
+        };
+        if value >= matched.dim {
+            return Err(PartitionedTreeTNError::ProjectorCoordinateOutOfBounds {
+                index: index.clone(),
+                value,
+                dim: matched.dim,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn rebuild_masked_tree<V>(
+    data: &TreeTN<IdxTensor, V>,
+    projector: &Projector,
+) -> Result<TreeTN<IdxTensor, V>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let node_names = data.node_names();
+    let mut tensors = Vec::with_capacity(node_names.len());
+
+    for name in &node_names {
+        let node = data
+            .node_index(name)
+            .ok_or_else(|| PartitionedTreeTNError::tree("TreeTN node name has no node index"))?;
+        let source = data
+            .tensor(node)
+            .ok_or_else(|| PartitionedTreeTNError::tree("TreeTN node has no tensor"))?;
+        let mut tensor = source.clone();
+        for (index, &value) in projector.iter() {
+            if tensor.indices().iter().any(|candidate| candidate == index) {
+                tensor = tensor.mask_index(index, value)?;
+            }
+        }
+        tensors.push(tensor);
+    }
+
+    TreeTN::from_tensors(tensors, node_names).map_err(PartitionedTreeTNError::from)
+}

--- a/crates/tensor4all-partitionedtreetn/tests/partitioned_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/tests/partitioned_tree_tn.rs
@@ -1,0 +1,308 @@
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, IdxTensor};
+use tensor4all_partitionedtreetn::{
+    PartitionedTreeTN, PartitionedTreeTNError, Projector, SubDomainTreeTN,
+};
+use tensor4all_treetn::{
+    contraction::{ContractionMethod, ContractionOptions},
+    TreeTN, TruncationOptions,
+};
+
+fn subdomain(site: &DynIndex, values: [f64; 2], coordinate: usize) -> SubDomainTreeTN {
+    let tensor = IdxTensor::from_dense(vec![site.clone()], values.to_vec()).unwrap();
+    let tree = TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap();
+    SubDomainTreeTN::new(
+        tree,
+        Projector::from_pairs([(site.clone(), coordinate)]).unwrap(),
+    )
+    .unwrap()
+}
+
+fn unprojected(site: &DynIndex, values: Vec<f64>) -> SubDomainTreeTN {
+    let tensor = IdxTensor::from_dense(vec![site.clone()], values).unwrap();
+    SubDomainTreeTN::from_treetn(TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap()).unwrap()
+}
+
+fn complex_subdomain(site: &DynIndex, coordinate: usize) -> SubDomainTreeTN {
+    let tensor = IdxTensor::from_dense(
+        vec![site.clone()],
+        vec![Complex64::new(3.0, 4.0), Complex64::new(1.0e12, -2.0e12)],
+    )
+    .unwrap();
+    let tree = TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap();
+    SubDomainTreeTN::new(
+        tree,
+        Projector::from_pairs([(site.clone(), coordinate)]).unwrap(),
+    )
+    .unwrap()
+}
+
+#[test]
+fn partition_replaces_exact_keys_and_rejects_overlaps_transactionally() {
+    let site = DynIndex::new_dyn(2);
+    let mut partition = PartitionedTreeTN::from_subdomains(vec![
+        subdomain(&site, [1.0, 2.0], 0),
+        subdomain(&site, [3.0, 4.0], 1),
+    ])
+    .unwrap();
+
+    let replacement = subdomain(&site, [10.0, 20.0], 0);
+    partition.insert(replacement).unwrap();
+    assert_eq!(partition.len(), 2);
+    let stored = partition
+        .get(&Projector::from_pairs([(site.clone(), 0)]).unwrap())
+        .unwrap();
+    assert_eq!(
+        stored
+            .data()
+            .tensor(stored.data().node_index(&0).unwrap())
+            .unwrap()
+            .to_vec::<f64>()
+            .unwrap(),
+        vec![10.0, 0.0]
+    );
+
+    let before = partition.clone();
+    let overlapping = unprojected(&site, vec![7.0, 8.0]);
+    assert!(partition.insert(overlapping).is_err());
+    assert_eq!(partition.len(), before.len());
+    assert!(partition.contains(&Projector::from_pairs([(site.clone(), 0)]).unwrap()));
+    assert!(partition.contains(&Projector::from_pairs([(site, 1)]).unwrap()));
+}
+
+#[test]
+fn partition_norm_sum_and_deterministic_treetn_sum_use_eager_values() {
+    let site = DynIndex::new_dyn(2);
+    let partition = PartitionedTreeTN::from_subdomains(vec![
+        subdomain(&site, [3.0, 1.0e12], 0),
+        subdomain(&site, [1.0e12, 4.0], 1),
+    ])
+    .unwrap();
+
+    assert!((partition.norm_squared().unwrap() - 25.0).abs() < 1.0e-12);
+    assert!((partition.norm().unwrap() - 5.0).abs() < 1.0e-12);
+
+    let first = partition.to_treetn().unwrap();
+    let second = partition.to_treetn().unwrap();
+    let first_tensor = first.tensor(first.node_index(&0).unwrap()).unwrap();
+    let second_tensor = second.tensor(second.node_index(&0).unwrap()).unwrap();
+    assert_eq!(first_tensor.to_vec::<f64>().unwrap(), vec![3.0, 4.0]);
+    assert_eq!(second_tensor.to_vec::<f64>().unwrap(), vec![3.0, 4.0]);
+
+    let empty = PartitionedTreeTN::<usize>::new();
+    assert!(matches!(
+        empty.to_treetn(),
+        Err(PartitionedTreeTNError::Empty)
+    ));
+}
+
+#[test]
+fn partition_supports_complex_dtype_and_rejects_mixed_dtype_before_mutation() {
+    let site = DynIndex::new_dyn(2);
+    let complex = PartitionedTreeTN::from_subdomain(complex_subdomain(&site, 0)).unwrap();
+    assert!((complex.norm_squared().unwrap() - 25.0).abs() < 1.0e-12);
+
+    let real = PartitionedTreeTN::from_subdomain(subdomain(&site, [2.0, 3.0], 1)).unwrap();
+    assert!(matches!(
+        PartitionedTreeTN::from_subdomains(vec![
+            complex.values().next().unwrap().clone(),
+            real.values().next().unwrap().clone(),
+        ]),
+        Err(PartitionedTreeTNError::DTypeMismatch { .. })
+    ));
+
+    let before = complex.clone();
+    let mut target = complex.clone();
+    assert!(matches!(
+        target.append(real.clone()),
+        Err(PartitionedTreeTNError::DTypeMismatch { .. })
+    ));
+    assert_eq!(target.len(), before.len());
+
+    assert!(matches!(
+        complex.add(&real, &0, TruncationOptions::default()),
+        Err(PartitionedTreeTNError::DTypeMismatch { .. })
+    ));
+    assert!(matches!(
+        complex.contract(&real, &0, ContractionOptions::default()),
+        Err(PartitionedTreeTNError::DTypeMismatch { .. })
+    ));
+}
+
+#[test]
+fn partition_addition_allows_missing_keys_and_rejects_overlapping_layouts() {
+    let site = DynIndex::new_dyn(2);
+    let left = PartitionedTreeTN::from_subdomain(subdomain(&site, [2.0, 100.0], 0)).unwrap();
+    let right = PartitionedTreeTN::from_subdomain(subdomain(&site, [300.0, 4.0], 1)).unwrap();
+
+    let sum = left.add(&right, &0, TruncationOptions::default()).unwrap();
+    assert_eq!(sum.len(), 2);
+    let dense = sum.to_treetn().unwrap();
+    assert_eq!(
+        dense
+            .tensor(dense.node_index(&0).unwrap())
+            .unwrap()
+            .to_vec::<f64>()
+            .unwrap(),
+        vec![2.0, 4.0]
+    );
+
+    let overlap = PartitionedTreeTN::from_subdomain(unprojected(&site, vec![1.0, 2.0])).unwrap();
+    let before = left.clone();
+    assert!(matches!(
+        left.add(&overlap, &0, TruncationOptions::default()),
+        Err(PartitionedTreeTNError::OverlappingProjectors)
+    ));
+    assert_eq!(left.len(), before.len());
+}
+
+#[test]
+fn partition_addition_validates_center_and_options_before_shortcuts() {
+    let site = DynIndex::new_dyn(2);
+    let left = PartitionedTreeTN::from_subdomain(subdomain(&site, [1.0, 2.0], 0)).unwrap();
+    let right = PartitionedTreeTN::new();
+
+    assert!(matches!(
+        left.add(&right, &0, TruncationOptions::default()),
+        Err(PartitionedTreeTNError::Empty)
+    ));
+    assert!(matches!(
+        left.add(
+            &left,
+            &99,
+            TruncationOptions::default().with_max_bond_dim(0),
+        ),
+        Err(PartitionedTreeTNError::InvalidOptions { .. })
+    ));
+    assert!(matches!(
+        left.add(&left, &99, TruncationOptions::default()),
+        Err(PartitionedTreeTNError::InvalidCenter)
+    ));
+}
+
+#[test]
+fn partition_append_rejects_cross_overlap_transactionally() {
+    let site = DynIndex::new_dyn(2);
+    let mut target = PartitionedTreeTN::from_subdomain(subdomain(&site, [1.0, 2.0], 0)).unwrap();
+    let before = target.clone();
+    let other = PartitionedTreeTN::from_subdomain(unprojected(&site, vec![9.0, 10.0])).unwrap();
+
+    assert!(matches!(
+        target.append(other),
+        Err(PartitionedTreeTNError::OverlappingProjectors)
+    ));
+    assert_eq!(target.len(), before.len());
+    assert!(target.contains(&Projector::from_pairs([(site, 0)]).unwrap()));
+}
+
+fn shared_contract_patch(
+    shared: &DynIndex,
+    external: Option<&DynIndex>,
+    shared_value: usize,
+    external_value: Option<usize>,
+    values: Vec<f64>,
+) -> SubDomainTreeTN {
+    let mut indices = vec![shared.clone()];
+    let mut pairs = vec![(shared.clone(), shared_value)];
+    if let Some(external) = external {
+        indices.push(external.clone());
+        pairs.push((external.clone(), external_value.unwrap_or(0)));
+    }
+    let tensor = IdxTensor::from_dense(indices, values).unwrap();
+    let tree = TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap();
+    SubDomainTreeTN::new(tree, Projector::from_pairs(pairs).unwrap()).unwrap()
+}
+
+#[test]
+fn contraction_prunes_contracted_projectors_and_retains_external_projectors() {
+    let shared = DynIndex::new_dyn(2);
+    let left_external = DynIndex::new_dyn(2);
+    let right_external = DynIndex::new_dyn(2);
+    let left = shared_contract_patch(
+        &shared,
+        Some(&left_external),
+        0,
+        Some(1),
+        vec![0.0, 0.0, 0.0, 7.0],
+    );
+    let right = shared_contract_patch(
+        &shared,
+        Some(&right_external),
+        0,
+        Some(0),
+        vec![5.0, 0.0, 0.0, 0.0],
+    );
+
+    let result = left
+        .contract(&right, &0, ContractionOptions::default())
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.projector().get(&shared), None);
+    assert_eq!(result.projector().get(&left_external), Some(1));
+    assert_eq!(result.projector().get(&right_external), Some(0));
+    assert!(result.all_indices().contains(&left_external));
+    assert!(result.all_indices().contains(&right_external));
+}
+
+#[test]
+fn partition_contraction_combines_duplicate_output_projectors_strictly() {
+    let shared = DynIndex::new_dyn(2);
+    let left = PartitionedTreeTN::from_subdomains(vec![
+        shared_contract_patch(&shared, None, 0, None, vec![2.0, 100.0]),
+        shared_contract_patch(&shared, None, 1, None, vec![200.0, 3.0]),
+    ])
+    .unwrap();
+    let right = PartitionedTreeTN::from_subdomains(vec![
+        shared_contract_patch(&shared, None, 0, None, vec![5.0, 600.0]),
+        shared_contract_patch(&shared, None, 1, None, vec![700.0, 7.0]),
+    ])
+    .unwrap();
+
+    let result = left
+        .contract(&right, &0, ContractionOptions::default())
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    let dense = result.to_treetn().unwrap();
+    let tensor = dense.tensor(dense.node_index(&0).unwrap()).unwrap();
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), vec![31.0]);
+}
+
+#[test]
+fn partition_contraction_rejects_topology_site_assignment_dtype_and_dense_options() {
+    let site = DynIndex::new_dyn(2);
+    let left = PartitionedTreeTN::from_subdomain(subdomain(&site, [1.0, 2.0], 0)).unwrap();
+    let right_tree = TreeTN::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], vec![3.0, 4.0]).unwrap()],
+        vec![1usize],
+    )
+    .unwrap();
+    let right = PartitionedTreeTN::from_subdomain(
+        SubDomainTreeTN::new(
+            right_tree,
+            Projector::from_pairs([(site.clone(), 0)]).unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(matches!(
+        left.contract(&right, &1, ContractionOptions::default()),
+        Err(PartitionedTreeTNError::TopologyMismatch)
+    ));
+
+    assert!(matches!(
+        left.contract(&left, &0, ContractionOptions::new(ContractionMethod::Naive),),
+        Err(PartitionedTreeTNError::InvalidOptions { .. })
+    ));
+}
+
+#[test]
+fn partition_contract_duplicate_failure_does_not_mutate_inputs() {
+    let site = DynIndex::new_dyn(2);
+    let left = PartitionedTreeTN::from_subdomain(subdomain(&site, [1.0, 2.0], 0)).unwrap();
+    let right = PartitionedTreeTN::from_subdomain(subdomain(&site, [3.0, 4.0], 1)).unwrap();
+    let left_before = left.clone();
+    let right_before = right.clone();
+    let _ = left.contract(&right, &0, ContractionOptions::default());
+    assert_eq!(left.len(), left_before.len());
+    assert_eq!(right.len(), right_before.len());
+}

--- a/crates/tensor4all-partitionedtreetn/tests/patching.rs
+++ b/crates/tensor4all-partitionedtreetn/tests/patching.rs
@@ -1,0 +1,212 @@
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, IdxTensor};
+use tensor4all_partitionedtreetn::{
+    add_with_patching, contract_adaptive, truncate_adaptive, PartitionedTreeTN,
+    PartitionedTreeTNError, PatchSplitStrategy, PatchingOptions, Projector, SubDomainTreeTN,
+};
+use tensor4all_treetn::{contraction::ContractionOptions, TreeTN};
+
+fn rank_two_chain() -> (SubDomainTreeTN, DynIndex, DynIndex) {
+    let site0 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let site1 = DynIndex::new_dyn(2);
+    let left = IdxTensor::from_dense(
+        vec![site0.clone(), bond.clone()],
+        vec![1.0_f64, 0.0, 0.0, 1.0],
+    )
+    .unwrap();
+    let right =
+        IdxTensor::from_dense(vec![bond, site1.clone()], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap();
+    let tree = TreeTN::from_tensors(vec![left, right], vec![0usize, 1]).unwrap();
+    (SubDomainTreeTN::from_treetn(tree).unwrap(), site0, site1)
+}
+
+fn one_site_patch(site: &DynIndex, values: [f64; 2], coordinate: usize) -> SubDomainTreeTN {
+    let tensor = IdxTensor::from_dense(vec![site.clone()], values.to_vec()).unwrap();
+    let tree = TreeTN::from_tensors(vec![tensor], vec![0usize]).unwrap();
+    SubDomainTreeTN::new(
+        tree,
+        Projector::from_pairs([(site.clone(), coordinate)]).unwrap(),
+    )
+    .unwrap()
+}
+
+fn branched_complex_tree() -> (TreeTN<IdxTensor, String>, Vec<DynIndex>) {
+    let center_sites = vec![DynIndex::new_dyn(2), DynIndex::new_dyn(3)];
+    let leaf_sites = vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let bonds = vec![DynIndex::new_dyn(1), DynIndex::new_dyn(1)];
+    let one = Complex64::new(1.0, 1.0);
+    let center = IdxTensor::from_dense(
+        vec![
+            center_sites[0].clone(),
+            center_sites[1].clone(),
+            bonds[0].clone(),
+            bonds[1].clone(),
+        ],
+        vec![one; 6],
+    )
+    .unwrap();
+    let leaves = leaf_sites
+        .iter()
+        .zip(&bonds)
+        .map(|(site, bond)| {
+            IdxTensor::from_dense(vec![bond.clone(), site.clone()], vec![one; 2]).unwrap()
+        })
+        .collect::<Vec<_>>();
+    let mut tensors = vec![center];
+    tensors.extend(leaves);
+    let tree = TreeTN::from_tensors(
+        tensors,
+        vec![
+            "center".to_string(),
+            "leaf0".to_string(),
+            "leaf1".to_string(),
+        ],
+    )
+    .unwrap();
+    (tree, center_sites.into_iter().chain(leaf_sites).collect())
+}
+
+fn assert_branched_complex_patch(patch: &SubDomainTreeTN<String>, sites: &[DynIndex]) {
+    assert_eq!(patch.node_count(), 3);
+    assert_eq!(patch.all_indices().len(), sites.len());
+    assert!(sites.iter().all(|site| patch.all_indices().contains(site)));
+    for name in patch.data().node_names() {
+        let tensor = patch
+            .data()
+            .tensor(patch.data().node_index(&name).unwrap())
+            .unwrap();
+        assert!(tensor.is_c64());
+        assert!(!tensor.to_vec::<Complex64>().unwrap().is_empty());
+    }
+    assert!((patch.norm_squared().unwrap() - 32.0).abs() < 1.0e-10);
+}
+
+fn assert_branched_complex_partition(partition: &PartitionedTreeTN<String>, sites: &[DynIndex]) {
+    assert_eq!(partition.len(), 6);
+    assert!((partition.norm_squared().unwrap() - 192.0).abs() < 1.0e-10);
+    for patch in partition.values() {
+        assert_eq!(patch.max_bond_dim(), 1);
+        assert_branched_complex_patch(patch, sites);
+    }
+}
+
+#[test]
+fn adaptive_patching_preserves_branched_complex_multisite_tree() {
+    let (tree, sites) = branched_complex_tree();
+    let patch = SubDomainTreeTN::from_treetn(tree).unwrap();
+    let center = "center".to_string();
+    let options = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        patch_order: sites[..2].to_vec(),
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
+
+    let patched = add_with_patching(vec![patch], &center, &options).unwrap();
+    assert_branched_complex_partition(&patched, &sites);
+
+    let retruncated = truncate_adaptive(&patched, &center, 0.0, Some(1)).unwrap();
+    assert_branched_complex_partition(&retruncated, &sites);
+}
+
+#[test]
+fn add_with_patching_splits_at_explicit_center() {
+    let (subdomain, site0, _) = rank_two_chain();
+    let options = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        patch_order: vec![site0.clone()],
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
+
+    let result = add_with_patching(vec![subdomain], &0, &options).unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!(result.values().all(|patch| patch.max_bond_dim() <= 1));
+    assert!(result
+        .projectors()
+        .all(|projector| projector.get(&site0).is_some()));
+}
+
+#[test]
+fn truncate_adaptive_uses_absolute_volume_budget_and_keeps_eager_values() {
+    let site = DynIndex::new_dyn(2);
+    let high = one_site_patch(&site, [10.0, 1.0e12], 0);
+    let low = one_site_patch(&site, [1.0e12, 0.01], 1);
+    let partition = PartitionedTreeTN::from_subdomains(vec![high, low]).unwrap();
+
+    let result = truncate_adaptive(&partition, &0, 0.1, Some(2)).unwrap();
+
+    assert_eq!(result.len(), 1);
+    let projector = Projector::from_pairs([(site, 0)]).unwrap();
+    assert!(result.contains(&projector));
+    assert!((result.get(&projector).unwrap().norm_squared().unwrap() - 100.0).abs() < 1e-10);
+}
+
+#[test]
+fn contract_adaptive_retruncates_a_new_partition() {
+    let site = DynIndex::new_dyn(2);
+    let left = PartitionedTreeTN::from_subdomain(
+        SubDomainTreeTN::from_treetn(
+            TreeTN::from_tensors(
+                vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap()],
+                vec![0usize],
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let right = PartitionedTreeTN::from_subdomain(
+        SubDomainTreeTN::from_treetn(
+            TreeTN::from_tensors(
+                vec![IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0]).unwrap()],
+                vec![0usize],
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let options = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        ..PatchingOptions::default()
+    };
+
+    let result =
+        contract_adaptive(&left, &right, &0, &ContractionOptions::default(), &options).unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result.values().next().unwrap().all_indices().is_empty());
+}
+
+#[test]
+fn adaptive_paths_validate_before_shortcuts_and_are_transactional() {
+    let site = DynIndex::new_dyn(2);
+    let partition =
+        PartitionedTreeTN::from_subdomain(one_site_patch(&site, [1.0, 2.0], 0)).unwrap();
+    let before = partition.clone();
+
+    assert!(matches!(
+        truncate_adaptive(&partition, &99, 0.0, Some(1)),
+        Err(PartitionedTreeTNError::InvalidCenter)
+    ));
+    assert!(matches!(
+        truncate_adaptive(&partition, &0, f64::NAN, Some(1)),
+        Err(PartitionedTreeTNError::InvalidOptions { .. })
+    ));
+    assert!(matches!(
+        add_with_patching(
+            vec![partition.values().next().unwrap().clone()],
+            &99,
+            &PatchingOptions {
+                max_bond_dim: Some(0),
+                ..PatchingOptions::default()
+            },
+        ),
+        Err(PartitionedTreeTNError::InvalidOptions { .. })
+    ));
+    assert_eq!(partition.len(), before.len());
+}

--- a/crates/tensor4all-partitionedtreetn/tests/subdomain_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/tests/subdomain_tree_tn.rs
@@ -1,0 +1,535 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+use num_complex::Complex64;
+use tensor4all_core::index::{Index, TagSet};
+use tensor4all_core::{DynIndex, IdxTensor};
+use tensor4all_partitionedtreetn::{PartitionedTreeTNError, Projector, SubDomainTreeTN};
+use tensor4all_treetn::{contraction::ContractionOptions, TreeTN, TruncationOptions};
+
+fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
+    Projector::from_pairs(pairs).unwrap()
+}
+
+fn one_node_f64() -> (TreeTN<IdxTensor, String>, DynIndex, DynIndex) {
+    let left = DynIndex::new_dyn(2);
+    let right = DynIndex::new_dyn(2);
+    let tensor =
+        IdxTensor::from_dense(vec![left.clone(), right.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    (
+        TreeTN::from_tensors(vec![tensor], vec!["root".to_string()]).unwrap(),
+        left,
+        right,
+    )
+}
+
+fn chain_f64() -> (TreeTN<IdxTensor, String>, Vec<DynIndex>) {
+    let s0 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let b12 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let t0 = IdxTensor::from_dense(vec![s0.clone(), b01.clone()], vec![1.0; 4]).unwrap();
+    let t1 = IdxTensor::from_dense(
+        vec![b01, s1.clone(), b12.clone()],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+    )
+    .unwrap();
+    let t2 = IdxTensor::from_dense(vec![b12, s2.clone()], vec![1.0; 4]).unwrap();
+    (
+        TreeTN::from_tensors(
+            vec![t0, t1, t2],
+            vec![
+                "left".to_string(),
+                "middle".to_string(),
+                "right".to_string(),
+            ],
+        )
+        .unwrap(),
+        vec![s0, s1, s2],
+    )
+}
+
+fn branched_f64() -> (TreeTN<IdxTensor, String>, Vec<DynIndex>) {
+    let center_site = DynIndex::new_dyn(2);
+    let leaf_sites: Vec<_> = (0..3).map(|_| DynIndex::new_dyn(2)).collect();
+    let bonds: Vec<_> = (0..3).map(|_| DynIndex::new_dyn(2)).collect();
+    let center = IdxTensor::from_dense(
+        vec![
+            center_site.clone(),
+            bonds[0].clone(),
+            bonds[1].clone(),
+            bonds[2].clone(),
+        ],
+        vec![1.0; 16],
+    )
+    .unwrap();
+    let leaves: Vec<_> = leaf_sites
+        .iter()
+        .zip(&bonds)
+        .map(|(site, bond)| {
+            IdxTensor::from_dense(vec![bond.clone(), site.clone()], vec![1.0; 4]).unwrap()
+        })
+        .collect();
+    let mut tensors = vec![center];
+    tensors.extend(leaves);
+    (
+        TreeTN::from_tensors(
+            tensors,
+            vec![
+                "center".to_string(),
+                "leaf0".to_string(),
+                "leaf1".to_string(),
+                "leaf2".to_string(),
+            ],
+        )
+        .unwrap(),
+        std::iter::once(center_site).chain(leaf_sites).collect(),
+    )
+}
+
+#[test]
+fn constructs_one_node_chain_and_branched_subdomains() {
+    let (one_node, _, _) = one_node_f64();
+    let one = SubDomainTreeTN::from_treetn(one_node).unwrap();
+    assert_eq!(one.node_count(), 1);
+    assert_eq!(one.site_index_network().edge_count(), 0);
+
+    let (chain, sites) = chain_f64();
+    let chain = SubDomainTreeTN::new(chain, projector([(sites[0].clone(), 1)])).unwrap();
+    assert_eq!(chain.node_count(), 3);
+    assert_eq!(chain.site_index_network().edge_count(), 2);
+    assert_eq!(chain.all_indices().len(), 3);
+
+    let (branched, sites) = branched_f64();
+    let branched = SubDomainTreeTN::new(branched, projector([(sites[3].clone(), 0)])).unwrap();
+    assert_eq!(branched.node_count(), 4);
+    assert_eq!(branched.site_index_network().edge_count(), 3);
+    assert_eq!(branched.all_indices().len(), 4);
+}
+
+#[test]
+fn supports_multiple_site_indices_on_one_node_and_retains_axes() {
+    let (tree, site0, site1) = one_node_f64();
+    let original = tree
+        .tensor(tree.node_index(&"root".to_string()).unwrap())
+        .unwrap()
+        .clone();
+    let subdomain = SubDomainTreeTN::new(tree, projector([(site0.clone(), 1)])).unwrap();
+    let masked = subdomain
+        .data()
+        .tensor(subdomain.data().node_index(&"root".to_string()).unwrap())
+        .unwrap();
+
+    assert_eq!(masked.indices(), original.indices());
+    assert_eq!(masked.to_vec::<f64>().unwrap(), vec![0.0, 2.0, 0.0, 4.0]);
+    assert!(subdomain.all_indices().contains(&site0));
+    assert!(subdomain.all_indices().contains(&site1));
+}
+
+#[test]
+fn eager_mask_handles_f64_c64_and_large_outside_values() {
+    let site = DynIndex::new_dyn(3);
+    let f64_tree = TreeTN::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0, 1.0e12, -2.0e12]).unwrap()],
+        vec![0usize],
+    )
+    .unwrap();
+    let f64_subdomain = SubDomainTreeTN::new(f64_tree, projector([(site.clone(), 0)])).unwrap();
+    let f64_tensor = f64_subdomain
+        .data()
+        .tensor(f64_subdomain.data().node_index(&0).unwrap())
+        .unwrap();
+    assert_eq!(f64_tensor.to_vec::<f64>().unwrap(), vec![1.0, 0.0, 0.0]);
+    assert!((f64_subdomain.norm().unwrap() - 1.0).abs() < 1.0e-12);
+    assert!((f64_subdomain.norm_squared().unwrap() - 1.0).abs() < 1.0e-12);
+
+    let complex_site = DynIndex::new_dyn(2);
+    let complex_tree = TreeTN::from_tensors(
+        vec![IdxTensor::from_dense(
+            vec![complex_site.clone()],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(1.0e9, -2.0e9)],
+        )
+        .unwrap()],
+        vec![0usize],
+    )
+    .unwrap();
+    let complex_subdomain =
+        SubDomainTreeTN::new(complex_tree, projector([(complex_site.clone(), 0)])).unwrap();
+    let complex_tensor = complex_subdomain
+        .data()
+        .tensor(complex_subdomain.data().node_index(&0).unwrap())
+        .unwrap();
+    assert_eq!(
+        complex_tensor.to_vec::<Complex64>().unwrap(),
+        vec![Complex64::new(3.0, 4.0), Complex64::new(0.0, 0.0)]
+    );
+    assert!((complex_subdomain.norm_squared().unwrap() - 25.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn project_only_adds_compatible_restrictions_without_mutating_source() {
+    let (tree, site0, site1) = one_node_f64();
+    let source = SubDomainTreeTN::new(tree, projector([(site0.clone(), 0)])).unwrap();
+    let source_values = source
+        .data()
+        .tensor(source.data().node_index(&"root".to_string()).unwrap())
+        .unwrap()
+        .to_vec::<f64>()
+        .unwrap();
+
+    let projected = source
+        .project(&projector([(site1.clone(), 1)]))
+        .unwrap()
+        .unwrap();
+    assert_eq!(projected.projector().get(&site0), Some(0));
+    assert_eq!(projected.projector().get(&site1), Some(1));
+    assert_eq!(source.projector().get(&site1), None);
+    assert_eq!(
+        source
+            .data()
+            .tensor(source.data().node_index(&"root".to_string()).unwrap())
+            .unwrap()
+            .to_vec::<f64>()
+            .unwrap(),
+        source_values
+    );
+
+    assert!(source
+        .project(&projector([(site0.clone(), 1)]))
+        .unwrap()
+        .is_none());
+    assert_eq!(source.projector().get(&site0), Some(0));
+}
+
+#[test]
+fn norms_clone_before_canonicalization_and_rebuild_clears_metadata() {
+    let (tree, site0, _) = one_node_f64();
+    let mut canonical = tree.clone();
+    canonical
+        .set_canonical_region(["root".to_string()])
+        .unwrap();
+    assert!(!canonical.canonical_region().is_empty());
+
+    let subdomain = SubDomainTreeTN::new(canonical, projector([(site0, 1)])).unwrap();
+    assert!(subdomain.data().canonical_region().is_empty());
+    let _ = subdomain.norm().unwrap();
+    let _ = subdomain.norm_squared().unwrap();
+    assert!(subdomain.data().canonical_region().is_empty());
+}
+
+#[test]
+fn preserves_ad_and_structured_storage_through_masking() {
+    let site = DynIndex::new_dyn(2);
+    let source = IdxTensor::from_dense(vec![site.clone()], vec![3.0_f64, 4.0])
+        .unwrap()
+        .enable_grad()
+        .unwrap();
+    let source_alias = source.clone();
+    let tree = TreeTN::from_tensors(vec![source], vec![0usize]).unwrap();
+    let subdomain = SubDomainTreeTN::new(tree, projector([(site.clone(), 1)])).unwrap();
+    let masked = subdomain
+        .data()
+        .tensor(subdomain.data().node_index(&0).unwrap())
+        .unwrap();
+    assert!(masked.tracks_grad());
+    assert_eq!(masked.to_vec::<f64>().unwrap(), vec![0.0, 4.0]);
+    masked.sum().unwrap().backward().unwrap();
+    assert_eq!(
+        source_alias
+            .grad()
+            .unwrap()
+            .unwrap()
+            .to_vec::<f64>()
+            .unwrap(),
+        vec![0.0, 1.0]
+    );
+
+    let diagonal_site = DynIndex::new_dyn(3);
+    let diagonal_aux = DynIndex::new_dyn(3);
+    let diagonal = IdxTensor::from_diag(
+        vec![diagonal_site.clone(), diagonal_aux],
+        vec![2.0, 3.0, 5.0],
+    )
+    .unwrap();
+    let diagonal_tree = TreeTN::from_tensors(vec![diagonal], vec![0usize]).unwrap();
+    let diagonal_subdomain =
+        SubDomainTreeTN::new(diagonal_tree, projector([(diagonal_site, 1)])).unwrap();
+    let masked_diagonal = diagonal_subdomain
+        .data()
+        .tensor(diagonal_subdomain.data().node_index(&0).unwrap())
+        .unwrap();
+    assert!(masked_diagonal.is_diag());
+}
+
+#[test]
+fn rejects_invalid_projector_identity_coordinate_and_dtype() {
+    let (tree, site, _) = one_node_f64();
+    let out_of_range = Projector::from_pairs([(site.clone(), site.dim)]).unwrap_err();
+    assert!(matches!(
+        out_of_range,
+        PartitionedTreeTNError::ProjectorCoordinateOutOfBounds { value, dim, .. }
+            if value == dim
+    ));
+
+    let tagged = Index::new_with_tags(site.id, site.dim, TagSet::from_str("Site").unwrap());
+    let error = SubDomainTreeTN::new(tree.clone(), projector([(tagged.clone(), 0)])).unwrap_err();
+    assert!(matches!(
+        error,
+        PartitionedTreeTNError::ProjectorIndexNotFound { index } if index == tagged
+    ));
+    let primed = site.prime();
+    let error = SubDomainTreeTN::new(tree.clone(), projector([(primed.clone(), 0)])).unwrap_err();
+    assert!(matches!(
+        error,
+        PartitionedTreeTNError::ProjectorIndexNotFound { index } if index == primed
+    ));
+
+    let larger_same_identity = Index::new_with_tags(site.id, site.dim + 1, site.tags.clone());
+    let error = SubDomainTreeTN::new(tree, projector([(larger_same_identity.clone(), site.dim)]))
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        PartitionedTreeTNError::ProjectorCoordinateOutOfBounds { index, value, dim }
+            if index == larger_same_identity && value == 2 && dim == 2
+    ));
+
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(1);
+    let mixed = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0_f64, 2.0]).unwrap(),
+            IdxTensor::from_dense(
+                vec![bond, s1],
+                vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+            )
+            .unwrap(),
+        ],
+        vec![0usize, 1],
+    )
+    .unwrap();
+    assert!(matches!(
+        SubDomainTreeTN::from_treetn(mixed),
+        Err(PartitionedTreeTNError::DTypeMismatch { .. })
+    ));
+}
+
+#[test]
+fn rejects_invalid_tree_topology() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(2);
+    let b12 = DynIndex::new_dyn(2);
+    let b20 = DynIndex::new_dyn(2);
+    let mut tree = TreeTN::<IdxTensor, String>::new();
+    let a = tree
+        .add_tensor(
+            "a".to_string(),
+            IdxTensor::from_dense(vec![s0, b01.clone(), b20.clone()], vec![1.0; 8]).unwrap(),
+        )
+        .unwrap();
+    let b = tree
+        .add_tensor(
+            "b".to_string(),
+            IdxTensor::from_dense(vec![b01, s1, b12.clone()], vec![1.0; 8]).unwrap(),
+        )
+        .unwrap();
+    let c = tree
+        .add_tensor(
+            "c".to_string(),
+            IdxTensor::from_dense(vec![b12, s2, b20], vec![1.0; 8]).unwrap(),
+        )
+        .unwrap();
+    let a_b01 = tree.tensor(a).unwrap().indices()[1].clone();
+    let b_b01 = tree.tensor(b).unwrap().indices()[0].clone();
+    let b_b12 = tree.tensor(b).unwrap().indices()[2].clone();
+    let c_b12 = tree.tensor(c).unwrap().indices()[0].clone();
+    let c_b20 = tree.tensor(c).unwrap().indices()[2].clone();
+    let a_b20 = tree.tensor(a).unwrap().indices()[2].clone();
+    tree.connect(a, &a_b01, b, &b_b01).unwrap();
+    tree.connect(b, &b_b12, c, &c_b12).unwrap();
+    tree.connect(c, &c_b20, a, &a_b20).unwrap();
+
+    assert!(matches!(
+        SubDomainTreeTN::from_treetn(tree),
+        Err(PartitionedTreeTNError::InvalidTopology { .. })
+    ));
+}
+
+#[test]
+fn projector_identity_hash_is_insertion_order_independent_and_full_metadata_matters() {
+    let base = DynIndex::new_dyn(2);
+    let first = Index::new_with_tags(base.id, 2, TagSet::from_str("Site,Auxiliary").unwrap());
+    let second = Index::new_with_tags(base.id, 2, TagSet::from_str("Auxiliary,Site").unwrap());
+    let primed = base.prime();
+    let a = projector([(first.clone(), 1), (primed.clone(), 0)]);
+    let b = projector([(primed.clone(), 0), (second.clone(), 1)]);
+    let mut hasher_a = std::collections::hash_map::DefaultHasher::new();
+    let mut hasher_b = std::collections::hash_map::DefaultHasher::new();
+    a.hash(&mut hasher_a);
+    b.hash(&mut hasher_b);
+    assert_eq!(a, b);
+    assert_eq!(hasher_a.finish(), hasher_b.finish());
+
+    let tagged = projector([(first, 1)]);
+    let untagged = projector([(base, 1)]);
+    assert_ne!(tagged, untagged);
+    let mut map = HashMap::new();
+    map.insert(tagged.clone(), 7usize);
+    assert_eq!(map.get(&tagged), Some(&7));
+    assert!(!map.contains_key(&untagged));
+}
+
+#[test]
+fn projector_insert_failure_is_transactional() {
+    let index = DynIndex::new_dyn(2);
+    let mut projector = projector([(index.clone(), 0)]);
+    let before = projector.clone();
+    assert!(projector.insert(index.clone(), index.dim).is_err());
+    assert_eq!(projector, before);
+}
+
+#[test]
+fn from_treetn_rebuilds_without_storing_projector_metadata_as_canonical_state() {
+    let (tree, site0, _) = one_node_f64();
+    let mut tree = tree;
+    tree.set_canonical_region(["root".to_string()]).unwrap();
+    let subdomain = SubDomainTreeTN::from_treetn(tree).unwrap();
+    assert!(subdomain.projector().is_empty());
+    assert!(subdomain.data().canonical_region().is_empty());
+    assert_eq!(subdomain.max_bond_dim(), 1);
+    assert!(!subdomain.is_empty());
+    assert!(subdomain.all_indices().contains(&site0));
+}
+
+#[test]
+fn subdomain_add_is_strict_and_preserves_full_site_axes() {
+    let (tree, site0, site1) = one_node_f64();
+    let projector = projector([(site0.clone(), 0)]);
+    let left = SubDomainTreeTN::new(tree.clone(), projector.clone()).unwrap();
+    let right = SubDomainTreeTN::new(tree, projector).unwrap();
+
+    let sum = left.add(&right).unwrap();
+    let tensor = sum
+        .data()
+        .tensor(sum.data().node_index(&"root".to_string()).unwrap())
+        .unwrap();
+    assert_eq!(tensor.indices().len(), 2);
+    assert_eq!(tensor.indices(), &[site0, site1]);
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), vec![2.0, 0.0, 6.0, 0.0]);
+}
+
+#[test]
+fn subdomain_truncate_uses_explicit_center_and_is_transactional_on_validation_errors() {
+    let (tree, sites) = chain_f64();
+    let mut subdomain = SubDomainTreeTN::new(tree, projector([(sites[0].clone(), 0)])).unwrap();
+    let before_indices = subdomain.all_indices();
+    let before_projector = subdomain.projector().clone();
+
+    subdomain
+        .truncate(
+            &"middle".to_string(),
+            TruncationOptions::default().with_max_bond_dim(1),
+        )
+        .unwrap();
+    assert!(subdomain.max_bond_dim() <= 1);
+    assert_eq!(subdomain.all_indices(), before_indices);
+    assert_eq!(subdomain.projector(), &before_projector);
+
+    let before = subdomain
+        .data()
+        .tensor(subdomain.data().node_index(&"middle".to_string()).unwrap())
+        .unwrap()
+        .clone();
+    assert!(matches!(
+        subdomain.truncate(&"missing".to_string(), TruncationOptions::default()),
+        Err(PartitionedTreeTNError::InvalidCenter)
+    ));
+    assert!(matches!(
+        subdomain.truncate(
+            &"middle".to_string(),
+            TruncationOptions::default().with_max_bond_dim(0),
+        ),
+        Err(PartitionedTreeTNError::InvalidOptions { .. })
+    ));
+    let after = subdomain
+        .data()
+        .tensor(subdomain.data().node_index(&"middle".to_string()).unwrap())
+        .unwrap();
+    assert_eq!(after.indices(), before.indices());
+    assert_eq!(
+        after.to_vec::<f64>().unwrap(),
+        before.to_vec::<f64>().unwrap()
+    );
+}
+
+#[test]
+fn subdomain_contraction_rejects_site_indices_assigned_to_different_nodes() {
+    let shared = DynIndex::new_dyn(2);
+    let left_site = DynIndex::new_dyn(2);
+    let right_site = DynIndex::new_dyn(2);
+    let left_bond = DynIndex::new_dyn(1);
+    let right_bond = DynIndex::new_dyn(1);
+    let left = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![shared.clone(), left_bond.clone()], vec![1.0, 1.0]).unwrap(),
+            IdxTensor::from_dense(vec![left_bond, left_site], vec![1.0, 1.0]).unwrap(),
+        ],
+        vec![0usize, 1],
+    )
+    .unwrap();
+    let right = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![right_bond.clone(), right_site], vec![1.0, 1.0]).unwrap(),
+            IdxTensor::from_dense(vec![shared, right_bond], vec![1.0, 1.0]).unwrap(),
+        ],
+        vec![0usize, 1],
+    )
+    .unwrap();
+    let left = SubDomainTreeTN::from_treetn(left).unwrap();
+    let right = SubDomainTreeTN::from_treetn(right).unwrap();
+
+    assert!(matches!(
+        left.contract(&right, &0, ContractionOptions::default()),
+        Err(PartitionedTreeTNError::SiteIndexMismatch)
+    ));
+}
+
+#[test]
+fn long_chain_norm_avoids_full_dense_materialization() {
+    let node_count = 32usize;
+    let sites: Vec<_> = (0..node_count).map(|_| DynIndex::new_dyn(2)).collect();
+    let bonds: Vec<_> = (0..node_count - 1).map(|_| DynIndex::new_dyn(1)).collect();
+    let mut tensors = Vec::with_capacity(node_count);
+    for node in 0..node_count {
+        let tensor = if node == 0 {
+            IdxTensor::from_dense(vec![sites[node].clone(), bonds[0].clone()], vec![1.0, 1.0])
+                .unwrap()
+        } else if node + 1 == node_count {
+            IdxTensor::from_dense(
+                vec![bonds[node - 1].clone(), sites[node].clone()],
+                vec![1.0, 1.0],
+            )
+            .unwrap()
+        } else {
+            IdxTensor::from_dense(
+                vec![
+                    bonds[node - 1].clone(),
+                    sites[node].clone(),
+                    bonds[node].clone(),
+                ],
+                vec![1.0, 1.0],
+            )
+            .unwrap()
+        };
+        tensors.push(tensor);
+    }
+    let tree = TreeTN::from_tensors(tensors, (0..node_count).collect()).unwrap();
+    let subdomain = SubDomainTreeTN::new(tree, projector([(sites[0].clone(), 0)])).unwrap();
+
+    let expected = 2.0_f64.powi((node_count - 1) as i32);
+    let actual = subdomain.norm_squared().unwrap();
+    assert!((actual - expected).abs() / expected < 1.0e-12);
+}

--- a/crates/tensor4all-partitionedtt/README.md
+++ b/crates/tensor4all-partitionedtt/README.md
@@ -1,5 +1,12 @@
 # tensor4all-partitionedtt
 
+> **Deprecated:** use [`tensor4all-partitionedtreetn`](../tensor4all-partitionedtreetn/)
+> for new TreeTN-based partitioned tensor-network work.
+>
+> Both crates coexist during migration. This crate remains buildable and accepts
+> correctness and security fixes only; no removal date has been set, and removal
+> requires a separate maintainer decision.
+
 Partitioned Tensor Train for representing functions over non-overlapping subdomains
 with projectors.
 

--- a/crates/tensor4all-partitionedtt/src/lib.rs
+++ b/crates/tensor4all-partitionedtt/src/lib.rs
@@ -1,4 +1,11 @@
-//! Partitioned Tensor Train for tensor4all
+//! Partitioned Tensor Train for tensor4all.
+//!
+//! **Deprecated:** new TreeTN-based work should use
+//! [`tensor4all-partitionedtreetn`](https://docs.rs/tensor4all-partitionedtreetn).
+//! Both crates coexist during migration. This crate remains buildable and
+//! accepts correctness and security fixes only; no removal date has been set,
+//! and removal requires a separate maintainer decision. This documentation-only
+//! deprecation intentionally does not emit a compiler warning.
 //!
 //! This crate provides partitioned tensor train functionality for representing
 //! functions over subdomains with non-overlapping projectors.

--- a/docs/PROVENANCE_AND_CITATION_POLICY.md
+++ b/docs/PROVENANCE_AND_CITATION_POLICY.md
@@ -72,6 +72,7 @@ relationship; the role is stated only on the first row.
 | `tensor4all-aci` | Alternating cross interpolation elementwise ops | [AlternatingCrossInterpolation.jl](https://github.com/tensor4all/AlternatingCrossInterpolation.jl) | Port |
 | `tensor4all-partitionedtt` | Partitioned TT over subdomains | [PartitionedMPSs.jl](https://github.com/tensor4all/PartitionedMPSs.jl) | Port |
 | `tensor4all-partitionedtt` | | [TCIAlgorithms.jl](https://github.com/tensor4all/TCIAlgorithms.jl) | Derived (MIT): adaptive TCI interpolation |
+| `tensor4all-partitionedtreetn` | Eagerly masked partitioned TreeTN representation and adaptive patching | [PartitionedMPSs.jl](https://github.com/tensor4all/PartitionedMPSs.jl) | Inspired (independent TreeTN implementation) |
 | `tensor4all-hdf5` | HDF5 serialization | [ITensors.jl](https://github.com/ITensor/ITensors.jl) / ITensorMPS.jl file formats | Compatible (round-trip validated) |
 | `tensor4all-capi` | C FFI surface for language bindings | — | Original (consumed by [Tensor4all.jl](https://github.com/tensor4all/Tensor4all.jl)) |
 
@@ -94,7 +95,11 @@ list is best-effort; corrections and additions are welcome.
 | Quantum Fourier transform as low-rank MPO | `quanticstransform` | J. Chen and M. Lindsey, "Direct interpolative construction of the discrete Fourier transform as a matrix product operator", Appl. Comput. Harmon. Anal. (2025), [arXiv:2404.03182](https://arxiv.org/abs/2404.03182) |
 | Interpolative QTT construction | `interpolativeqtt` | M. Lindsey, [arXiv:2311.12554](https://arxiv.org/abs/2311.12554) |
 | Alternating cross interpolation (ACI) | `aci` | M. K. Ritter et al., [arXiv:2604.00037](https://arxiv.org/abs/2604.00037) |
-| Partitioned tensor trains / adaptive patching | `partitionedtt` | G. Grosso, M. K. Ritter, S. Rohshap, S. Badr, A. Kauch, M. Wallerberger, J. von Delft, H. Shinaoka, "Adaptive Patching for Tensor Train Computations", [arXiv:2602.22372](https://arxiv.org/abs/2602.22372) |
+| Partitioned tensor trains / adaptive patching | `partitionedtt`, `partitionedtreetn` | G. Grosso, M. K. Ritter, S. Rohshap, S. Badr, A. Kauch, M. Wallerberger, J. von Delft, H. Shinaoka, "Adaptive Patching for Tensor Train Computations", [arXiv:2602.22372](https://arxiv.org/abs/2602.22372) |
+
+The TreeTN-native partitioned crate does not contain adaptive interpolation
+and has no TCIAlgorithms.jl code derivation or TCIAlgorithms license. The
+legacy crate retains its existing TCIAlgorithms derivation notice and license.
 
 License-bearing derivations are declared in the affected crate
 (`tensor4all-treetn`: `LICENSE-APACHE`, SPDX `MIT AND Apache-2.0`;

--- a/docs/book-tests/Cargo.toml
+++ b/docs/book-tests/Cargo.toml
@@ -19,6 +19,7 @@ tensor4all-quanticstransform = { path = "../../crates/tensor4all-quanticstransfo
 tensor4all-quanticstci = { path = "../../crates/tensor4all-quanticstci" }
 tensor4all-interpolativeqtt = { path = "../../crates/tensor4all-interpolativeqtt" }
 tensor4all-itensorlike = { path = "../../crates/tensor4all-itensorlike" }
+tensor4all-partitionedtreetn = { path = "../../crates/tensor4all-partitionedtreetn" }
 tensor4all-treetci = { path = "../../crates/tensor4all-treetci" }
 tensor4all-hdf5 = { path = "../../crates/tensor4all-hdf5" }
 anyhow = { workspace = true }

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -13,6 +13,7 @@
   - [Quantics Transform](guides/quantics.md)
   - [Quantum Fourier Transform](guides/qft.md)
   - [Tree Tensor Networks](guides/tree-tn.md)
+  - [Partitioned TreeTNs](guides/partitioned-treetn.md)
   - [HDF5 Serialization](guides/hdf5-serialization.md)
 - [Tutorials]()
   - [Quantics Basics]()

--- a/docs/book/src/architecture.md
+++ b/docs/book/src/architecture.md
@@ -22,9 +22,11 @@ facade, and each crate can be used on its own.
               |                                                |
    tensor4all-itensorlike (TensorTrain)           tensor4all-tensorci (TCI1/TCI2)
               |                                                |
-   tensor4all-partitionedtt                        tensor4all-quanticstci
+   tensor4all-partitionedtreetn (TreeTN patches)    tensor4all-quanticstci
               |                                                |
-   tensor4all-treetci                              tensor4all-quanticstransform
+   tensor4all-partitionedtt (deprecated)            tensor4all-quanticstransform
+              |
+   tensor4all-treetci
 
    tensor4all-capi  (C FFI for language bindings; depends on both stacks)
    tensor4all-hdf5  (MPS serialization, ITensors.jl-compatible)
@@ -47,7 +49,9 @@ The only sanctioned place where the two stacks convert into each other is
 Crates that need to cross stacks must route through this bridge. New ad hoc
 bridges (hand-rolled conversion logic inside another crate) are rejected.
 `tensor4all-partitionedtt` consumes simplett output (TCI2 results) only via
-`tensor_train_to_treetn`.
+`tensor_train_to_treetn`; the TreeTN-native `tensor4all-partitionedtreetn`
+operates directly on named `TreeTN<IdxTensor, V>` values and does not depend on
+simplett, itensorlike, or TCI crates.
 
 One deliberate exception exists: `tensor4all-quanticstransform` builds
 TreeTN-based `LinearOperator`s from simplett **MPO** data (two site indices
@@ -125,7 +129,8 @@ Rules:
 |-------|-------------|
 | **treetn** | Tree tensor networks with arbitrary graph topology. Supports canonicalization, truncation, contraction, DMRG/TDVP, and hosts the sanctioned `simplett_bridge`. |
 | **itensorlike** | ITensors.jl-inspired `TensorTrain` (tree-based) with orthogonality tracking and multiple canonical forms. |
-| **partitionedtt** | Partitioned tensor trains for subdomain decomposition. Builds on itensorlike and crosses to simplett via `simplett_bridge`. |
+| **partitionedtreetn** | TreeTN-native eagerly masked subdomains, strict partition algebra, and volume-budgeted adaptive patching. |
+| **partitionedtt** | **Deprecated** partitioned tensor trains for subdomain decomposition. Builds on itensorlike and crosses to simplett via `simplett_bridge`; it remains buildable during migration. |
 | **treetci** | Tree TCI: cross interpolation on tree-structured tensor networks. |
 
 ### Simplett stack
@@ -168,7 +173,8 @@ Rules:
 | Simple positional tensor train (create, evaluate, compress) | `tensor4all-simplett` (`SimpleTensorTrain`) |
 | Tensor train with ITensors.jl-style interface | `tensor4all-itensorlike` (`TensorTrain`) |
 | Tree tensor networks | `tensor4all-treetn` |
-| Subdomain decomposition via partitioned TT | `tensor4all-partitionedtt` |
+| Subdomain decomposition on named TreeTNs | `tensor4all-partitionedtreetn` |
+| Legacy simple TT subdomain decomposition or adaptive TCI | `tensor4all-partitionedtt` (deprecated during migration) |
 | Quantics transform operators | `tensor4all-quanticstransform` |
 | HDF5 I/O compatible with Julia | `tensor4all-hdf5` |
 | Interpolative QTT on a coarse grid | `tensor4all-interpolativeqtt` |

--- a/docs/book/src/guides/partitioned-treetn.md
+++ b/docs/book/src/guides/partitioned-treetn.md
@@ -1,0 +1,107 @@
+# Partitioned TreeTNs
+
+`tensor4all-partitionedtreetn` stores TreeTN subdomains as eagerly masked
+patches. It is the TreeTN-native successor to the deprecated
+`tensor4all-partitionedtt` crate and supports named chains, branched trees, and
+multiple site indices on one node.
+
+This crate provides partition algebra and TreeTN-general adaptive patching. It
+does not provide adaptive interpolation or TCI.
+
+## Construct an eager patch
+
+Projectors use zero-based coordinates and full index identity. Construction
+retains every site axis but masks values outside the selected coordinates:
+
+```rust
+# use tensor4all_core::{DynIndex, IdxTensor};
+# use tensor4all_partitionedtreetn::{Projector, SubDomainTreeTN};
+# use tensor4all_treetn::TreeTN;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let site = DynIndex::new_dyn(2);
+let tensor = IdxTensor::from_dense(
+    vec![site.clone()],
+    vec![3.0_f64, 1.0e12],
+)?;
+let tree = TreeTN::from_tensors(vec![tensor], vec!["root".to_string()])?;
+let patch = SubDomainTreeTN::new(
+    tree,
+    Projector::from_pairs([(site.clone(), 0)])?,
+)?;
+
+let node = patch.data().node_index(&"root".to_string()).ok_or("missing root")?;
+assert_eq!(patch.data().tensor(node).ok_or("missing tensor")?.to_vec::<f64>()?,
+           vec![3.0, 0.0]);
+assert!((patch.norm_squared()? - 9.0).abs() < 1.0e-12);
+# Ok(())
+# }
+```
+
+Norms, inner products, contraction, truncation, and summation use this stored
+masked value directly. No projector is re-applied and no full network is
+densified.
+
+## Adaptive patching
+
+Every truncating or contracting operation takes an explicit existing node name
+as its center. `add_with_patching` first assigns absolute squared-tail budgets
+proportional to logical patch volume, then splits patches that remain above the
+bond cap:
+
+```rust
+# use tensor4all_core::{DynIndex, IdxTensor};
+# use tensor4all_partitionedtreetn::{
+#     add_with_patching, PatchSplitStrategy, PatchingOptions, SubDomainTreeTN,
+# };
+# use tensor4all_treetn::TreeTN;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let site0 = DynIndex::new_dyn(2);
+let bond = DynIndex::new_dyn(2);
+let site1 = DynIndex::new_dyn(2);
+let left = IdxTensor::from_dense(
+    vec![site0.clone(), bond.clone()],
+    vec![1.0_f64, 0.0, 0.0, 1.0],
+)?;
+let right = IdxTensor::from_dense(
+    vec![bond, site1],
+    vec![1.0_f64, 0.0, 0.0, 1.0],
+)?;
+let patch = SubDomainTreeTN::from_treetn(
+    TreeTN::from_tensors(vec![left, right], vec![0usize, 1])?,
+)?;
+let result = add_with_patching(
+    vec![patch],
+    &0,
+    &PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        patch_order: vec![site0],
+        split_strategy: PatchSplitStrategy::Sequential,
+    },
+)?;
+
+assert_eq!(result.len(), 2);
+assert!(result.values().all(|patch| patch.max_bond_dim() <= 1));
+# Ok(())
+# }
+```
+
+`PatchSplitStrategy::Sequential` follows `patch_order`. The default
+`ExactParameterGain` forms and budget-truncates every candidate's children,
+then compares checked sums of logical local tensor element counts. Structured
+storage payload length and AD state are not used as the metric.
+
+## Dtype and topology
+
+A partition is homogeneous: all patches must use the same `IdxTensor` scalar
+dtype and the same named topology and site-index assignment. Both `f64` and
+`Complex64` are supported. Topology is not restricted to a chain; a TreeTN
+with a central named node and three named leaves is a valid partition input.
+See the [Tree Tensor Networks guide](tree-tn.md) for constructing branched
+networks and selecting contraction/truncation options.
+
+## Migration
+
+Use this crate for new named TreeTN partition work. The old
+`tensor4all-partitionedtt` crate remains buildable during migration and receives
+correctness and security fixes only; no removal date has been set.

--- a/docs/book/src/guides/tree-tn.md
+++ b/docs/book/src/guides/tree-tn.md
@@ -1,5 +1,8 @@
 # Tree Tensor Networks
 
+For eager subdomain decomposition and volume-budgeted adaptive patching on
+named TreeTNs, continue to the [Partitioned TreeTNs guide](partitioned-treetn.md).
+
 The `tensor4all-treetn` crate provides a generic tree tensor network (`TreeTN`) that supports
 arbitrary tree topologies — not just linear chains. This guide covers construction, canonicalization,
 common operations, and the sweep-counting convention used by iterative algorithms.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -16,6 +16,7 @@
 |----------|-------------|
 | [adaptive-tci-interpolation.md](./adaptive-tci-interpolation.md) | Adaptive TCI patching, convergence, pivot recycling, and structured embedding |
 | [partitionedtt-projector-invariants.md](./partitionedtt-projector-invariants.md) | Issue #634 design for coherent projector identity, validation, and transactional PartitionedTT mutation |
+| [partitioned-treetn.md](./partitioned-treetn.md) | Issue #648 migration design for TreeTN-native eager partitioning and adaptive patching |
 | [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |
 
 ## Automatic Differentiation

--- a/docs/design/partitioned-treetn.md
+++ b/docs/design/partitioned-treetn.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed. The pre-implementation review gate is pending.
+Proposed and revised after the 2026-08-17 readiness comment on tracking issue
+[#648](https://github.com/tensor4all/tensor4all-rs/issues/648). The formal
+cross-model pre-implementation review gate is still pending.
 
 ## Goal
 
@@ -40,8 +42,25 @@ Use these public names:
 - `PatchingOptions`
 - `PatchSplitStrategy`
 
-`Projector` remains full-index-based and is copied without changing its identity
-semantics. Do not add aliases for the old TT names in the new crate.
+`Projector` remains full-index-based. Do not add aliases for the old TT names in
+the new crate.
+
+## Prerequisites
+
+1. Resolve [#634](https://github.com/tensor4all/tensor4all-rs/issues/634) in the
+   deprecated crate before copying `Projector`. The corrected implementation
+   must use one canonical entry ordering consistent with `DynIndex::Eq` and
+   `DynIndex::Hash` (currently ID, tags, and prime level) for both projector
+   hashing and deterministic comparison. Equal projectors must hash identically
+   regardless of insertion order or `HashMap` seed, and the deterministic
+   comparator may return `Equal` only for fully equal projectors. The fix also
+   supplies fallible coordinate validation and transactional partition mutation;
+   the new crate copies that validated implementation rather than the buggy
+   `origin/main` version.
+2. Track the typed TreeTCI termination result as a separate, independently
+   mergeable `tensor4all-treetci` issue and land it before implementing adaptive
+   interpolation here. Add its issue number to this document and #648 once it
+   exists. The required termination contract is specified below.
 
 ## Subdomain model
 
@@ -62,6 +81,12 @@ The public API provides TreeTN-specific vocabulary:
 - `node_count`, `is_empty`, `all_indices`, `site_index_network`,
 - `max_bond_dim`, `project`, `norm`, `norm_squared`, `truncate`, `contract`, and
   `inner`.
+
+`norm` and `norm_squared` take `&mut self`, canonicalize the stored TreeTN to the
+stored center, and delegate to the corresponding TreeTN method. This makes the
+canonicalization mutation and cost explicit and avoids a hidden whole-network
+clone. `PartitionedTreeTN::norm` likewise takes `&mut self`; `inner` remains
+non-mutating.
 
 Projection retains every site index and masks non-selected coordinates with
 `IdxTensor::mask_index`. Rebuild the TreeTN from its local tensors after masking
@@ -131,11 +156,17 @@ full network. Zero-active and one-active patches use exact rank-one TreeTNs.
 Sampled-zero detection remains an explicit finite-sampling policy.
 
 Adaptive acceptance must distinguish convergence from max-iteration and
-rank-cap termination. Extend `tensor4all-treetci` with a typed termination value
-in its optimization/run result and use that value here; do not infer convergence
-from only the last error sample. A patch is accepted only for `Converged` with
-an accepted error at or below tolerance. Rejected patches split on the first
-remaining full index in `patch_order`.
+rank-cap termination. The prerequisite TreeTCI issue replaces the bare result
+tuple with a typed run result carrying `Converged`, `MaxBondDim`, or
+`MaxIterations`; this crate must not infer termination from only the last error
+sample. When convergence and rank saturation become true in the same iteration,
+`Converged` takes precedence if the complete convergence criterion is satisfied;
+otherwise the result is `MaxBondDim`. Exhausting the iteration budget without
+either condition yields `MaxIterations`.
+
+A patch is accepted only for `Converged` with an accepted error at or below
+tolerance. Rejected patches split on the first remaining full index in
+`patch_order`.
 
 The initial port does not recycle internal TreeTCI pivots between parent and
 child patches because the TreeTCI public result does not expose a stable global
@@ -149,9 +180,10 @@ TreeTN methods above. `ExactParameterGain` counts local tensor payload sizes by
 iterating nodes; products and sums use checked arithmetic. Split candidates are
 full external indices and remain independent of tree traversal order.
 
-Volume-proportional truncation keeps the existing absolute squared-tail budget
-semantics. TreeTN `TruncationOptions` and `SvdTruncationPolicy` replace
-itensorlike options.
+Volume-proportional truncation keeps the absolute squared-tail budget semantics
+established by closed issue
+[#554](https://github.com/tensor4all/tensor4all-rs/issues/554). TreeTN
+`TruncationOptions` and `SvdTruncationPolicy` replace itensorlike options.
 
 ## Errors
 
@@ -190,6 +222,9 @@ Minimum focused matrix:
 - multiple external indices on one general TreeTN node;
 - fixed indices at leaves and internal vertices;
 - same-ID indices differing by prime level or tags;
+- equal projectors hashing identically across insertion orders and map seeds;
+- projector comparator equality if and only if full projector equality;
+- same-ID/different-metadata projectors used successfully as `HashMap` keys;
 - invalid center, topology, projector index, coordinate, and options;
 - transactional insert/append failures;
 - strict addition, contraction, truncation, and deterministic `to_treetn`;
@@ -218,4 +253,9 @@ impact attestation in the worklog/PR body.
 
 ## Review record
 
-Pending.
+- 2026-08-17 issue readiness comment: conditional approval after making #634 an
+  explicit prerequisite, splitting the TreeTCI termination API into its own
+  issue, fixing norm receiver semantics, and adding cross-links. These changes
+  are recorded above.
+- Formal cross-model reviewer and verdict: pending. The issue comment does not
+  by itself clear the repository's delegated-implementation review gate.

--- a/docs/design/partitioned-treetn.md
+++ b/docs/design/partitioned-treetn.md
@@ -1,0 +1,221 @@
+# Partitioned TreeTN migration
+
+## Status
+
+Proposed. The pre-implementation review gate is pending.
+
+## Goal
+
+Add `tensor4all-partitionedtreetn`, a TreeTN-native successor to
+`tensor4all-partitionedtt`. Keep the TT crate available but deprecated during a
+migration window. The new crate must support branched tree topologies rather
+than wrapping a linear chain in a TreeTN facade.
+
+## Compatibility window
+
+`tensor4all-partitionedtt` remains buildable and behavior-frozen while users
+migrate. Mark the crate deprecated with a crate-level Rust deprecation attribute
+and point its README and crate docs to `tensor4all-partitionedtreetn`. Only
+correctness and security fixes should land in the deprecated crate.
+
+The provisional removal date is **2026-12-31**, and removal must also wait until
+the new crate passes the migrated TT tests plus the TreeTN-specific test matrix
+below. The date can be extended explicitly, but the old crate must not become a
+permanent compatibility layer.
+
+## Scope and source layout
+
+Create the new crate by copying the existing partition/projector implementation,
+then replace TT-specific storage and algorithms in the copy. Temporary source
+duplication is intentional: sharing code now would couple the deprecated API to
+the new generic TreeTN API and make removal harder.
+
+Use these public names:
+
+- crate: `tensor4all-partitionedtreetn`
+- `SubDomainTreeTN<V = usize>`
+- `PartitionedTreeTN<V = usize>`
+- `PartitionedTreeTNError`
+- `AdaptiveInterpolateOptions`
+- `PatchingOptions`
+- `PatchSplitStrategy`
+
+`Projector` remains full-index-based and is copied without changing its identity
+semantics. Do not add aliases for the old TT names in the new crate.
+
+## Subdomain model
+
+`SubDomainTreeTN<V>` stores:
+
+- `TreeTN<IdxTensor, V>` data,
+- a `Projector`,
+- one validated canonical/truncation center `V`, and
+- the internal absolute squared truncation budget used by adaptive patching.
+
+The center is explicit state rather than a hidden minimum-node policy. The
+constructor validates that the center exists and that every projected full
+index is an external site index with an in-bounds coordinate.
+
+The public API provides TreeTN-specific vocabulary:
+
+- `from_treetn`, `data`, `into_data`, `center`,
+- `node_count`, `is_empty`, `all_indices`, `site_index_network`,
+- `max_bond_dim`, `project`, `norm`, `norm_squared`, `truncate`, `contract`, and
+  `inner`.
+
+Projection retains every site index and masks non-selected coordinates with
+`IdxTensor::mask_index`. Rebuild the TreeTN from its local tensors after masking
+so stale canonical and orthogonality metadata cannot survive tensor changes.
+This is local tensor work only; it must not materialize the full network.
+
+## Partition invariant
+
+A `PartitionedTreeTN<V>` is a map from mutually disjoint projectors to
+subdomains. In addition to projector disjointness, all subdomains in one value
+must have:
+
+- exactly the same named tree topology,
+- exactly the same full site-index set at each node, and
+- the same stored center.
+
+Constructor, insertion, and append operations validate these invariants before
+mutation. Projectors continue to use full index equality, including prime level
+and tags.
+
+`to_treetn` deterministically sums projected patches with TreeTN direct-sum
+addition. It is the replacement for `to_tensor_train`.
+
+## TreeTN operations
+
+Use `tensor4all-treetn` public operations directly:
+
+- strict `TreeTN::add` for patch addition,
+- `TreeTN::truncate_mut([center], TruncationOptions)` for truncation,
+- `tensor4all_treetn::contraction::contract` for contraction,
+- `TreeTN::inner` for inner products, and
+- `TreeTN::link_dims` for the maximum bond dimension.
+
+Contraction first applies each patch projector, contracts at the stored center,
+and keeps projector entries only for surviving external indices. Pairwise
+results with the same output projector are combined by strict TreeTN addition
+and truncated with the contraction SVD policy and rank cap.
+
+No production path may call `to_dense`, `contract_to_tensor`, or a dense
+reference contraction unless the caller explicitly selected and bounded the
+TreeTN dense-reference method.
+
+## Adaptive TreeTCI
+
+The new `adaptiveinterpolate` uses `tensor4all-treetci`, not
+`tensor4all-tensorci` or a TT-to-TreeTN conversion.
+
+Its topology input is a `TreeTciGraph`; ordered `site_indices[i]` belongs to
+TreeTCI vertex `i`. The first implementation supports exactly one external site
+index per TreeTCI vertex. General `PartitionedTreeTN` storage and algebra may
+still hold multiple external indices per node.
+
+For a projected patch, keep the full TreeTCI graph and replace each fixed
+vertex's local dimension by one. The batch evaluator maps that local zero back
+to the fixed full-domain coordinate. This preserves connectivity even when
+removing fixed vertices would split a branched tree.
+
+After TreeTCI materialization:
+
+- active generated site indices are relabeled to the caller's full indices;
+- a dimension-one fixed site is locally contracted with a one-hot bridge to the
+  caller's full-dimensional index; and
+- the TreeTN is rebuilt from the resulting local tensors.
+
+The one-hot bridge is bounded by one site dimension and does not materialize a
+full network. Zero-active and one-active patches use exact rank-one TreeTNs.
+Sampled-zero detection remains an explicit finite-sampling policy.
+
+Adaptive acceptance must distinguish convergence from max-iteration and
+rank-cap termination. Extend `tensor4all-treetci` with a typed termination value
+in its optimization/run result and use that value here; do not infer convergence
+from only the last error sample. A patch is accepted only for `Converged` with
+an accepted error at or below tolerance. Rejected patches split on the first
+remaining full index in `patch_order`.
+
+The initial port does not recycle internal TreeTCI pivots between parent and
+child patches because the TreeTCI public result does not expose a stable global
+pivot set. The deprecated TT crate retains that optional behavior. Add TreeTCI
+pivot recycling only after a dedicated public pivot-provenance contract exists.
+
+## Patching
+
+Copy adaptive patching into the new crate and replace TT operations with the
+TreeTN methods above. `ExactParameterGain` counts local tensor payload sizes by
+iterating nodes; products and sums use checked arithmetic. Split candidates are
+full external indices and remain independent of tree traversal order.
+
+Volume-proportional truncation keeps the existing absolute squared-tail budget
+semantics. TreeTN `TruncationOptions` and `SvdTruncationPolicy` replace
+itensorlike options.
+
+## Errors
+
+Use a crate-local `thiserror` enum. Preserve typed sources from
+`TreeTNOperationError`, `TreeTciError`, tensor storage, and tensor construction.
+Validation errors for topology, center, projector indices, coordinates, and
+options remain structured where callers need their payloads. Every public
+`Result` API documents concrete failure conditions.
+
+## Dependencies and provenance
+
+The new crate depends on `tensor4all-core`, `tensor4all-tensorbackend`,
+`tensor4all-treetn`, and `tensor4all-treetci`; it does not depend on
+`tensor4all-itensorlike`, `tensor4all-simplett`, or `tensor4all-tensorci`.
+Provider features propagate through all direct tensor4all dependencies.
+
+Copied adaptive partition logic remains derived from TCIAlgorithms.jl. Copy the
+existing derivation notices and `LICENSE-TCIALGORITHMS-MIT`, and update the
+repository provenance/citation policy after maintainer confirmation. Do not
+rewrite historical worklogs merely to change the crate name.
+
+## Documentation surface
+
+Update the workspace crate list, architecture guide, design index, `llms.txt`,
+usage skill references, coverage thresholds, and the live adaptive interpolation
+design. Add a crate README included by crate docs and runnable asserted rustdoc
+examples for every public item. The old README and crate docs must state the
+migration target and removal window.
+
+## Verification
+
+Minimum focused matrix:
+
+- `f64` and `Complex64`;
+- one node, chain, and branched tree;
+- multiple external indices on one general TreeTN node;
+- fixed indices at leaves and internal vertices;
+- same-ID indices differing by prime level or tags;
+- invalid center, topology, projector index, coordinate, and options;
+- transactional insert/append failures;
+- strict addition, contraction, truncation, and deterministic `to_treetn`;
+- TreeTCI adaptive interpolation with zero, one, and several active sites;
+- convergence, rank-cap, and max-iteration split paths;
+- checked volume and parameter-count overflow;
+- a long cheap TreeTN regression that would fail under accidental full dense
+  materialization;
+- small dense references materialized once and compared as whole tensors;
+- default CPU and `tenferro-provider-inject` feature builds;
+- release doctests and mdBook tests.
+
+Run the repository's focused crate checks during development, then the complete
+pre-PR format, clippy, release workspace tests, rustdoc, mdBook, API dump, and
+repository-rules review gates. Coverage is CI-owned; record an explicit coverage
+impact attestation in the worklog/PR body.
+
+## Deferred work
+
+- TreeTCI pivot recycling with a stable public pivot-provenance API.
+- Adaptive interpolation with multiple logical site indices on one TreeTCI
+  vertex.
+- Removing `tensor4all-partitionedtt` before the compatibility window closes.
+- Extracting shared projector code; deletion of the old crate is the preferred
+  deduplication step.
+
+## Review record
+
+Pending.

--- a/docs/design/partitioned-treetn.md
+++ b/docs/design/partitioned-treetn.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Proposed and revised after maintainer decisions on tracking issue
-[#648](https://github.com/tensor4all/tensor4all-rs/issues/648). The formal
-cross-model pre-implementation review gate is pending.
+Approved after maintainer decisions on tracking issue
+[#648](https://github.com/tensor4all/tensor4all-rs/issues/648). The rebased
+cross-model pre-implementation review gate passed on commit `bda6a58f`; this
+record is the implementation contract for the migration.
 
 ## Goal
 
@@ -164,8 +165,27 @@ The TreeTN-general patch algebra remains in this crate:
 - `PatchSplitStrategy`.
 
 Each operation requiring truncation or contraction accepts an explicit center.
-Split candidates are full external indices and remain independent of tree
-traversal order. Multiple external indices on one node are supported.
+The public signatures are:
+
+```text
+add_with_patching<V>(Vec<SubDomainTreeTN<V>>, &V, &PatchingOptions)
+    -> Result<PartitionedTreeTN<V>>
+truncate_adaptive<V>(&PartitionedTreeTN<V>, &V, f64, Option<usize>)
+    -> Result<PartitionedTreeTN<V>>
+contract_adaptive<V>(
+    &PartitionedTreeTN<V>,
+    &PartitionedTreeTN<V>,
+    &V,
+    &ContractionOptions,
+    &PatchingOptions,
+) -> Result<PartitionedTreeTN<V>>
+```
+
+`PatchingOptions` contains `rtol`, `max_bond_dim`, a partial full-index
+`patch_order`, and `split_strategy`. `PatchSplitStrategy::Sequential` follows
+that order; `ExactParameterGain` evaluates all available candidates. Split
+candidates are full external indices and remain independent of tree traversal
+order. Multiple external indices on one node are supported.
 
 `ExactParameterGain` preserves the TT predecessor's meaning: after forming and
 budget-truncating each candidate's children, count the checked sum of each local
@@ -194,8 +214,9 @@ zero-detection policy, or merge disposition.
 Use a crate-local `thiserror` enum. Preserve typed sources from
 `TreeTNOperationError`, tensor storage, and tensor construction. Validation
 errors for topology, dtype, center, projector indices, coordinates, and options
-remain structured where callers need their payloads. Every public `Result` API
-documents concrete failure conditions.
+remain structured where callers need their payloads. Volume and logical
+parameter-count overflow return typed crate errors rather than wrapping.
+Every public `Result` API documents concrete failure conditions.
 
 ## Dependencies and provenance
 

--- a/docs/design/partitioned-treetn.md
+++ b/docs/design/partitioned-treetn.md
@@ -2,28 +2,30 @@
 
 ## Status
 
-Proposed and revised after the 2026-08-17 readiness comment on tracking issue
+Proposed and revised after maintainer decisions on tracking issue
 [#648](https://github.com/tensor4all/tensor4all-rs/issues/648). The formal
-cross-model pre-implementation review gate is still pending.
+cross-model pre-implementation review gate is pending.
 
 ## Goal
 
 Add `tensor4all-partitionedtreetn`, a TreeTN-native successor to
 `tensor4all-partitionedtt`. Keep the TT crate available but deprecated during a
-migration window. The new crate must support branched tree topologies rather
-than wrapping a linear chain in a TreeTN facade.
+migration window. The new crate supports arbitrary named tree topologies,
+including branched trees and multiple external site indices per node.
+
+Adaptive interpolation is not part of this crate or this migration task.
 
 ## Compatibility window
 
 `tensor4all-partitionedtt` remains buildable and behavior-frozen while users
-migrate. Mark the crate deprecated with a crate-level Rust deprecation attribute
-and point its README and crate docs to `tensor4all-partitionedtreetn`. Only
-correctness and security fixes should land in the deprecated crate.
+migrate. Its README and crate docs point to `tensor4all-partitionedtreetn` and
+mark it deprecated. Do not add a crate-level `#![deprecated]` attribute or
+compiler warning. Only correctness and security fixes should land in the old
+crate.
 
-The provisional removal date is **2026-12-31**, and removal must also wait until
-the new crate passes the migrated TT tests plus the TreeTN-specific test matrix
-below. The date can be extended explicitly, but the old crate must not become a
-permanent compatibility layer.
+No fixed removal date is declared. Removing the old crate requires a separate
+maintainer decision after the successor reaches parity and downstream users
+have migrated.
 
 ## Scope and source layout
 
@@ -38,204 +40,220 @@ Use these public names:
 - `SubDomainTreeTN<V = usize>`
 - `PartitionedTreeTN<V = usize>`
 - `PartitionedTreeTNError`
-- `AdaptiveInterpolateOptions`
+- `Projector`
 - `PatchingOptions`
 - `PatchSplitStrategy`
 
-`Projector` remains full-index-based. Do not add aliases for the old TT names in
-the new crate.
+Both partition types are generic only over the node-name type `V` and store
+`TreeTN<IdxTensor, V>`. Making the tensor type generic is out of scope because
+projection depends on `IdxTensor::mask_index` and the TT predecessor also uses
+the dynamic `IdxTensor` boundary.
 
-## Prerequisites
+Do not add aliases for the old TT names in the new crate.
 
-1. Resolve [#634](https://github.com/tensor4all/tensor4all-rs/issues/634) in the
-   deprecated crate before copying `Projector`. The corrected implementation
-   must use one canonical entry ordering consistent with `DynIndex::Eq` and
-   `DynIndex::Hash` (currently ID, tags, and prime level) for both projector
-   hashing and deterministic comparison. Equal projectors must hash identically
-   regardless of insertion order or `HashMap` seed, and the deterministic
-   comparator may return `Equal` only for fully equal projectors. The fix also
-   supplies fallible coordinate validation and transactional partition mutation;
-   the new crate copies that validated implementation rather than the buggy
-   `origin/main` version.
-2. Track the typed TreeTCI termination result as a separate, independently
-   mergeable `tensor4all-treetci` issue and land it before implementing adaptive
-   interpolation here. Add its issue number to this document and #648 once it
-   exists. The required termination contract is specified below.
+## Prerequisite
+
+Resolve [#634](https://github.com/tensor4all/tensor4all-rs/issues/634) in the
+deprecated crate before copying `Projector`. The corrected implementation must
+use one canonical entry ordering consistent with `DynIndex::Eq` and
+`DynIndex::Hash` (currently ID, tags, and prime level) for both projector
+hashing and deterministic comparison. Equal projectors must hash identically
+regardless of insertion order or `HashMap` seed, and the deterministic
+comparator may return `Equal` only for fully equal projectors.
+
+The #634 fix also supplies fallible coordinate validation and transactional
+partition mutation. The new crate copies that validated implementation rather
+than the buggy `origin/main` version.
 
 ## Subdomain model
 
 `SubDomainTreeTN<V>` stores:
 
 - `TreeTN<IdxTensor, V>` data,
-- a `Projector`,
-- one validated canonical/truncation center `V`, and
+- a `Projector`, and
 - the internal absolute squared truncation budget used by adaptive patching.
 
-The center is explicit state rather than a hidden minimum-node policy. The
-constructor validates that the center exists and that every projected full
-index is an external site index with an in-bounds coordinate.
+It does not store a canonical or truncation center. A center is operation policy,
+not part of the represented partition. Operations that require one accept an
+explicit `&V`, following the underlying TreeTN API.
 
-The public API provides TreeTN-specific vocabulary:
+Construction is fallible and eagerly applies the projector. The stored TreeTN
+retains every full site index, but values outside the projected coordinates are
+masked to zero with `IdxTensor::mask_index`. Rebuild the TreeTN from its local
+tensors after masking so stale canonical and orthogonality metadata cannot
+survive tensor changes. This is local tensor work only and must not materialize
+the full network.
 
-- `from_treetn`, `data`, `into_data`, `center`,
+This eager invariant is authoritative: `data()` always returns an already
+projected TreeTN. Norms, inner products, truncation budgets, contraction, and
+summation operate directly on that representation and must not apply a second
+lazy projection. `project` applies only newly requested compatible restrictions
+and returns another eagerly masked value.
+
+The public API follows the TT predecessor where tree topology does not require
+an extra choice:
+
+- `from_treetn`, `data`, `into_data`,
 - `node_count`, `is_empty`, `all_indices`, `site_index_network`,
 - `max_bond_dim`, `project`, `norm`, `norm_squared`, `truncate`, `contract`, and
   `inner`.
 
-`norm` and `norm_squared` take `&mut self`, canonicalize the stored TreeTN to the
-stored center, and delegate to the corresponding TreeTN method. This makes the
-canonicalization mutation and cost explicit and avoids a hidden whole-network
-clone. `PartitionedTreeTN::norm` likewise takes `&mut self`; `inner` remains
-non-mutating.
-
-Projection retains every site index and masks non-selected coordinates with
-`IdxTensor::mask_index`. Rebuild the TreeTN from its local tensors after masking
-so stale canonical and orthogonality metadata cannot survive tensor changes.
-This is local tensor work only; it must not materialize the full network.
+`norm` and `norm_squared` keep `&self` receiver semantics for parity with the TT
+crate. They clone the TreeTN wrapper and canonicalize the clone internally;
+rustdoc must state this cost. `truncate` and `contract` take an explicit center
+because arbitrary trees have no TT-like rightmost site.
 
 ## Partition invariant
 
-A `PartitionedTreeTN<V>` is a map from mutually disjoint projectors to
-subdomains. In addition to projector disjointness, all subdomains in one value
-must have:
+A `PartitionedTreeTN<V>` is a map from mutually disjoint projectors to eagerly
+masked subdomains. All subdomains in one value must have:
 
 - exactly the same named tree topology,
 - exactly the same full site-index set at each node, and
-- the same stored center.
+- one homogeneous `IdxTensor` dtype across every node and patch.
 
-Constructor, insertion, and append operations validate these invariants before
-mutation. Projectors continue to use full index equality, including prime level
-and tags.
+Same topology and dimensions with different site-index identities are not
+enough; automatic reindexing is prohibited because `Projector` keys use full
+indices. Mixed `f64`/`Complex64` partitions are rejected before no-op shortcuts
+or TreeTN algebra.
 
-`to_treetn` deterministically sums projected patches with TreeTN direct-sum
-addition. It is the replacement for `to_tensor_train`.
+Constructor, insertion, and append operations validate all invariants before
+mutation. Failure leaves the original partition unchanged.
 
-## TreeTN operations
+`to_treetn` deterministically sums the already projected patches with strict
+TreeTN direct-sum addition. It is the replacement for `to_tensor_train`.
 
-Use `tensor4all-treetn` public operations directly:
+## Addition and contraction
 
-- strict `TreeTN::add` for patch addition,
-- `TreeTN::truncate_mut([center], TruncationOptions)` for truncation,
-- `tensor4all_treetn::contraction::contract` for contraction,
-- `TreeTN::inner` for inner products, and
-- `TreeTN::link_dims` for the maximum bond dimension.
+Patch-wise addition preserves the TT predecessor's restricted contract:
 
-Contraction first applies each patch projector, contracts at the stored center,
-and keeps projector entries only for surviving external indices. Pairwise
-results with the same output projector are combined by strict TreeTN addition
-and truncated with the contraction SVD policy and rank cap.
+- identical projector keys may be added;
+- a patch absent from one operand is treated as zero; and
+- different overlapping projector layouts are rejected rather than refined.
+
+Matching patches use strict `TreeTN::add` and are truncated at the caller's
+explicit center. Addition requires exact named topology, site-index assignment,
+and dtype compatibility.
+
+Contraction likewise requires the two partitions to use the same named topology
+in v1; it does not call `restructure_to` or a mismatched-topology dense fallback.
+For each compatible projector pair it:
+
+1. contracts the already masked TreeTNs with
+   `tensor4all_treetn::contraction::contract` at the explicit center;
+2. keeps projector entries only for surviving external full indices; and
+3. combines duplicate output projectors with strict TreeTN addition and the
+   requested truncation policy.
+
+`SubDomainTreeTN::inner` uses the eagerly masked stored data directly. No
+projector-compatible region may be inferred or lazily remasked during inner
+product evaluation.
 
 No production path may call `to_dense`, `contract_to_tensor`, or a dense
-reference contraction unless the caller explicitly selected and bounded the
+reference contraction unless the caller explicitly selected and bounded a
 TreeTN dense-reference method.
 
-## Adaptive TreeTCI
+## Adaptive patching
 
-The new `adaptiveinterpolate` uses `tensor4all-treetci`, not
-`tensor4all-tensorci` or a TT-to-TreeTN conversion.
+The TreeTN-general patch algebra remains in this crate:
 
-Its topology input is a `TreeTciGraph`; ordered `site_indices[i]` belongs to
-TreeTCI vertex `i`. The first implementation supports exactly one external site
-index per TreeTCI vertex. General `PartitionedTreeTN` storage and algebra may
-still hold multiple external indices per node.
+- `add_with_patching`,
+- `truncate_adaptive`,
+- `contract_adaptive`,
+- `PatchingOptions`, and
+- `PatchSplitStrategy`.
 
-For a projected patch, keep the full TreeTCI graph and replace each fixed
-vertex's local dimension by one. The batch evaluator maps that local zero back
-to the fixed full-domain coordinate. This preserves connectivity even when
-removing fixed vertices would split a branched tree.
+Each operation requiring truncation or contraction accepts an explicit center.
+Split candidates are full external indices and remain independent of tree
+traversal order. Multiple external indices on one node are supported.
 
-After TreeTCI materialization:
-
-- active generated site indices are relabeled to the caller's full indices;
-- a dimension-one fixed site is locally contracted with a one-hot bridge to the
-  caller's full-dimensional index; and
-- the TreeTN is rebuilt from the resulting local tensors.
-
-The one-hot bridge is bounded by one site dimension and does not materialize a
-full network. Zero-active and one-active patches use exact rank-one TreeTNs.
-Sampled-zero detection remains an explicit finite-sampling policy.
-
-Adaptive acceptance must distinguish convergence from max-iteration and
-rank-cap termination. The prerequisite TreeTCI issue replaces the bare result
-tuple with a typed run result carrying `Converged`, `MaxBondDim`, or
-`MaxIterations`; this crate must not infer termination from only the last error
-sample. When convergence and rank saturation become true in the same iteration,
-`Converged` takes precedence if the complete convergence criterion is satisfied;
-otherwise the result is `MaxBondDim`. Exhausting the iteration budget without
-either condition yields `MaxIterations`.
-
-A patch is accepted only for `Converged` with an accepted error at or below
-tolerance. Rejected patches split on the first remaining full index in
-`patch_order`.
-
-The initial port does not recycle internal TreeTCI pivots between parent and
-child patches because the TreeTCI public result does not expose a stable global
-pivot set. The deprecated TT crate retains that optional behavior. Add TreeTCI
-pivot recycling only after a dedicated public pivot-provenance contract exists.
-
-## Patching
-
-Copy adaptive patching into the new crate and replace TT operations with the
-TreeTN methods above. `ExactParameterGain` counts local tensor payload sizes by
-iterating nodes; products and sums use checked arithmetic. Split candidates are
-full external indices and remain independent of tree traversal order.
+`ExactParameterGain` preserves the TT predecessor's meaning: after forming and
+budget-truncating each candidate's children, count the checked sum of each local
+tensor's logical element count (the product of its dimensions). Do not use
+backend payload length, storage bytes, structured-storage compression, or AD
+state as the metric.
 
 Volume-proportional truncation keeps the absolute squared-tail budget semantics
 established by closed issue
 [#554](https://github.com/tensor4all/tensor4all-rs/issues/554). TreeTN
 `TruncationOptions` and `SvdTruncationPolicy` replace itensorlike options.
 
+## Adaptive interpolation ownership
+
+`adaptiveinterpolate`, `AdaptiveInterpolateOptions`, TreeTCI termination changes,
+pivot recycling, sampled-zero inference, and TreeTCI checked-arithmetic work are
+out of scope. The new crate does not depend on `tensor4all-treetci`.
+
+The existing unmerged branch
+`feat/treetci-adaptive-patching@85df576` remains a separate TreeTCI work item.
+This migration neither reimplements it nor decides its public result type,
+zero-detection policy, or merge disposition.
+
 ## Errors
 
 Use a crate-local `thiserror` enum. Preserve typed sources from
-`TreeTNOperationError`, `TreeTciError`, tensor storage, and tensor construction.
-Validation errors for topology, center, projector indices, coordinates, and
-options remain structured where callers need their payloads. Every public
-`Result` API documents concrete failure conditions.
+`TreeTNOperationError`, tensor storage, and tensor construction. Validation
+errors for topology, dtype, center, projector indices, coordinates, and options
+remain structured where callers need their payloads. Every public `Result` API
+documents concrete failure conditions.
 
 ## Dependencies and provenance
 
-The new crate depends on `tensor4all-core`, `tensor4all-tensorbackend`,
-`tensor4all-treetn`, and `tensor4all-treetci`; it does not depend on
-`tensor4all-itensorlike`, `tensor4all-simplett`, or `tensor4all-tensorci`.
-Provider features propagate through all direct tensor4all dependencies.
+The new crate depends on `tensor4all-core`, `tensor4all-tensorbackend`, and
+`tensor4all-treetn`. It does not depend on `tensor4all-itensorlike`,
+`tensor4all-simplett`, `tensor4all-tensorci`, or `tensor4all-treetci`. Provider
+features propagate through all direct tensor4all dependencies.
 
-Copied adaptive partition logic remains derived from TCIAlgorithms.jl. Copy the
-existing derivation notices and `LICENSE-TCIALGORITHMS-MIT`, and update the
-repository provenance/citation policy after maintainer confirmation. Do not
-rewrite historical worklogs merely to change the crate name.
+Preserve and document the partition representation's relationship to
+[PartitionedMPSs.jl](https://github.com/tensor4all/PartitionedMPSs.jl) and the
+scientific credit for “Adaptive Patching for Tensor Train Computations.” Because
+`adaptive_interpolation.rs` is not copied, the new crate does not claim a code
+derivation from TCIAlgorithms.jl and does not copy
+`LICENSE-TCIALGORITHMS-MIT`. The deprecated TT crate retains its existing
+TCIAlgorithms derivation notice and license.
 
 ## Documentation surface
 
 Update the workspace crate list, architecture guide, design index, `llms.txt`,
-usage skill references, coverage thresholds, and the live adaptive interpolation
-design. Add a crate README included by crate docs and runnable asserted rustdoc
-examples for every public item. The old README and crate docs must state the
-migration target and removal window.
+usage skill references, provenance policy, and live partitioned-tensor guides.
+Add the new crate to coverage enforcement; do not lower coverage thresholds
+without separate approval.
+
+Add a crate README included by crate docs and runnable asserted rustdoc examples
+for public types, traits, and functions. Document public fields and enum variants
+without requiring repetitive standalone examples for each field or variant. The
+old README and crate docs state the migration target but no fixed removal date.
 
 ## Verification
 
 Minimum focused matrix:
 
-- `f64` and `Complex64`;
+- `f64` and `Complex64` homogeneous partitions;
+- mixed-dtype rejection before construction, append, addition, contraction, and
+  summation, with no mutation on failure;
 - one node, chain, and branched tree;
-- multiple external indices on one general TreeTN node;
+- multiple external indices on one TreeTN node;
 - fixed indices at leaves and internal vertices;
+- eager masking tests where unprojected values are much larger than projected
+  values, covering norm, inner, truncation budgets, contraction, and summation;
 - same-ID indices differing by prime level or tags;
 - equal projectors hashing identically across insertion orders and map seeds;
 - projector comparator equality if and only if full projector equality;
 - same-ID/different-metadata projectors used successfully as `HashMap` keys;
 - invalid center, topology, projector index, coordinate, and options;
-- transactional insert/append failures;
-- strict addition, contraction, truncation, and deterministic `to_treetn`;
-- TreeTCI adaptive interpolation with zero, one, and several active sites;
-- convergence, rank-cap, and max-iteration split paths;
-- checked volume and parameter-count overflow;
-- a long cheap TreeTN regression that would fail under accidental full dense
-  materialization;
+- transactional construction, insertion, and append failures;
+- identical-layout addition plus rejection of different overlapping layouts;
+- strict same-topology contraction and deterministic `to_treetn`;
+- explicit-center truncate, contract, and patching paths, including invalid
+  centers;
+- logical parameter-count tests using structured masked tensors;
+- checked volume and logical parameter-count overflow;
+- a safe long cheap TreeTN regression that fails quickly under accidental full
+  dense materialization without intentionally exhausting CI memory;
 - small dense references materialized once and compared as whole tensors;
-- default CPU and `tenferro-provider-inject` feature builds;
-- release doctests and mdBook tests.
+- default CPU build and
+  `--no-default-features --features tenferro-provider-inject` build;
+- workspace clippy, release doctests, and mdBook tests.
 
 Run the repository's focused crate checks during development, then the complete
 pre-PR format, clippy, release workspace tests, rustdoc, mdBook, API dump, and
@@ -244,18 +262,32 @@ impact attestation in the worklog/PR body.
 
 ## Deferred work
 
-- TreeTCI pivot recycling with a stable public pivot-provenance API.
-- Adaptive interpolation with multiple logical site indices on one TreeTCI
-  vertex.
-- Removing `tensor4all-partitionedtt` before the compatibility window closes.
+- Adaptive interpolation and the disposition of
+  `feat/treetci-adaptive-patching`.
+- Common-refinement addition for different overlapping projector layouts.
+- Contraction between different named topologies.
+- Generic tensor storage beyond `IdxTensor`.
+- Removing `tensor4all-partitionedtt` after a separate maintainer decision.
 - Extracting shared projector code; deletion of the old crate is the preferred
   deduplication step.
 
 ## Review record
 
-- 2026-08-17 issue readiness comment: conditional approval after making #634 an
-  explicit prerequisite, splitting the TreeTCI termination API into its own
-  issue, fixing norm receiver semantics, and adding cross-links. These changes
-  are recorded above.
-- Formal cross-model reviewer and verdict: pending. The issue comment does not
-  by itself clear the repository's delegated-implementation review gate.
+Maintainer decisions recorded in this revision:
+
+- adaptive interpolation is excluded; TreeTN-general adaptive patching remains;
+- subdomain construction eagerly masks stored data;
+- center is not stored and is passed explicitly to operations that require it;
+- addition rejects different overlapping projector layouts;
+- `ExactParameterGain` counts logical tensor elements;
+- deprecation is documentation-only with no fixed removal date;
+- node names are generic, tensor storage is `IdxTensor`, dtype is homogeneous,
+  and multiple site indices per node are supported;
+- patch topology/site identities are exact, and contraction requires matching
+  named topology; and
+- provenance includes PartitionedMPSs.jl and the adaptive patching paper, but not
+  TCIAlgorithms-derived code or license.
+
+The 2026-08-17 issue reviews informed these decisions but do not by themselves
+clear the repository's delegated-implementation gate. Formal cross-model
+reviewer and verdict: pending.

--- a/llms.txt
+++ b/llms.txt
@@ -14,10 +14,13 @@ transforms (`tensor4all-quanticstransform`), and a C FFI layer
 - [Getting started](docs/book/src/getting-started.md): first steps.
 - [Tensor train guide](docs/book/src/guides/tensor-train.md): `SimpleTensorTrain` (simplett) and ITensor-like `TensorTrain` (itensorlike).
 - [Tree tensor network guide](docs/book/src/guides/tree-tn.md): `TreeTN`.
+- [Partitioned TreeTN guide](docs/book/src/guides/partitioned-treetn.md): eager subdomain masking, strict partition algebra, and adaptive patching.
 - [Quantics TCI guide](docs/book/src/guides/quantics.md) and [TCI guide](docs/book/src/guides/tci.md).
 - [Julia bindings](docs/book/src/julia-bindings.md).
 - [C API design](docs/CAPI_DESIGN.md).
 - [Repository rules](AGENTS.md) and [contributing](CONTRIBUTING.md).
+- [Downstream usage skill](skills/use-tensor4all-rs/SKILL.md): crate selection, imports, layout, and first-try fixes.
+- [Partitioned TreeTN crate README](crates/tensor4all-partitionedtreetn/README.md): TreeTN-native API quickstart.
 
 ## Repository
 

--- a/skills/use-tensor4all-rs/SKILL.md
+++ b/skills/use-tensor4all-rs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-tensor4all-rs
-description: Use the tensor4all-rs Rust tensor-network library (TCI, quantics tensor trains, tree tensor networks, DMRG/TDVP/GSE time evolution, adaptive patch interpolation). Use when working with `tensor4all-*` crates (core/simplett/tensorci/quanticstci/treetn/partitionedtt/...), their `IdxTensor`/`SimpleTensorTrain`/`TreeTN`/`QuanticsTensorCI2`/`PartitionedTT` APIs, or the `dmrg`/`tdvp`/`gse_tdvp`/`adaptiveinterpolate` entry points. Also when porting ITensors.jl, QuanticsTCI.jl, or TCI patterns to Rust, or debugging column-major, `rtol`, or 0-vs-1 indexing mismatches in tensor4all-rs code.
+description: Use the tensor4all-rs Rust tensor-network library (TCI, quantics tensor trains, tree tensor networks, partitioned TreeTNs, DMRG/TDVP/GSE time evolution, and adaptive patching). Use when working with `tensor4all-*` crates (core/simplett/tensorci/quanticstci/treetn/partitionedtreetn/partitionedtt/...), their `IdxTensor`/`SimpleTensorTrain`/`TreeTN`/`QuanticsTensorCI2`/`PartitionedTreeTN`/`PartitionedTT` APIs, or the `dmrg`/`tdvp`/`gse_tdvp`/`add_with_patching`/`adaptiveinterpolate` entry points. Also when porting ITensors.jl, QuanticsTCI.jl, or TCI patterns to Rust, or debugging column-major, `rtol`, or 0-vs-1 indexing mismatches in tensor4all-rs code.
 license: MIT
 ---
 
@@ -27,7 +27,7 @@ tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", pac
 
 This skill tracks `main`; a release tag may not contain every API described below. Add each crate that your code imports directly. Do not add transitive crates that you never name.
 
-- **Import the crate's `prelude`** — every user-facing crate (`tensor4all-core`, `tensor4all-simplett`, `tensor4all-treetn`, `tensor4all-itensorlike`, `tensor4all-tensorci`, `tensor4all-quanticstci`, `tensor4all-aci`, `tensor4all-interpolativeqtt`) ships a `prelude` re-exporting its public traits plus the types needed to call them. Start with `use tensor4all_<crate>::prelude::*;` instead of guessing trait imports; a missing trait import is the top first-try failure (`error[E0599]`).
+- **Import the crate's `prelude`** — the established user-facing crates (`tensor4all-core`, `tensor4all-simplett`, `tensor4all-treetn`, `tensor4all-itensorlike`, `tensor4all-tensorci`, `tensor4all-quanticstci`, `tensor4all-aci`, `tensor4all-interpolativeqtt`) ship a `prelude` re-exporting their public traits plus the types needed to call them. `tensor4all-partitionedtreetn` intentionally exposes its small concrete API at the crate root; import `Projector`, `SubDomainTreeTN`, `PartitionedTreeTN`, and the adaptive patching functions directly. Start with the owning crate's documented imports instead of guessing trait imports; a missing trait import is the top first-try failure (`error[E0599]`).
 
 - **Backend defaults to pure-Rust `faer` — no system BLAS.** Compute crates enable `tenferro-cpu-faer` by default, so a plain dependency compiles standalone. To link a system BLAS (OpenBLAS / MKL / Apple Accelerate) instead, set `default-features = false` and enable `tenferro-system-blas` on each directly imported crate where it is exposed.
 - **Build with `--release`.** Tensor linalg in debug is orders of magnitude slower; TCI and DMRG are unusable without optimization. For benchmarks set `opt-level = 3` (and `lto`, `codegen-units = 1`).
@@ -58,7 +58,8 @@ Match the goal to the crate. This is the leading decision — the rest follows.
 | Tree tensor networks, arbitrary topology; DMRG/TDVP/GSE sweeps | `tensor4all-treetn` |
 | Quantics transform operators (shift, flip, Fourier, affine) | `tensor4all-quanticstransform` |
 | Interpolative QTT construction | `tensor4all-interpolativeqtt` |
-| Adaptive TCI over subdomain patches; patching add/contract/truncate | `tensor4all-partitionedtt` |
+| Partitioned TreeTN subdomains and adaptive patching | `tensor4all-partitionedtreetn` |
+| Adaptive TCI over legacy TT subdomain patches | `tensor4all-partitionedtt` (deprecated during migration) |
 | Core Index / Tensor / contraction / SVD-QR-LU | `tensor4all-core` |
 | HDF5 I/O compatible with ITensors.jl | `tensor4all-hdf5` |
 | C FFI for language bindings | `tensor4all-capi` |
@@ -93,7 +94,7 @@ These apply across crates and fail silently when ignored. Check them against eve
 
 **No hidden dense materialization in production paths.** `to_dense()`, `contract_to_tensor()`, and full-network `evaluate`-every-element loops are for tests and small examples only — they scale as the product of index dimensions. For long TT / TreeTN comparisons use a direct-sum difference plus a tensor-network norm, or sampled `evaluate()` checks. `ApplyOptions::naive()` is local exact apply (bond dims may grow as products), not full dense.
 
-**Index identity is full-index equality, not `id()`.** Two indices with the same id but different prime level, tags, or direction are distinct. Key maps and sets by the full `Index` value. Select concrete legs/sites by passing the full `Index`, never an id. `AdaptiveInterpolateOptions::patch_order` and `PatchingOptions::patch_order` are validated as exact full-`Index` permutations of the site indices — matching by id alone is rejected.
+**Index identity is full-index equality, not `id()`.** Two indices with the same id but different prime level, tags, or direction are distinct. Key maps and sets by the full `Index` value. Select concrete legs/sites by passing the full `Index`, never an id. `AdaptiveInterpolateOptions::patch_order` is an exact full-`Index` permutation; `tensor4all-partitionedtreetn::PatchingOptions::patch_order` accepts a partial order but every entry must be an exact full site-index identity — matching by id alone is rejected.
 
 ## 4.5 Common pitfalls
 

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -138,7 +138,33 @@ Ports InterpolativeQTT.jl; returns `SimpleTensorTrain<f64>`.
 
 - `interpolate_single_scale(f, x_min, x_max, R, oversampling, &InterpolativeQttOptions::default())`.
 
-## tensor4all-partitionedtt — subdomain patches + adaptive TCI
+## tensor4all-partitionedtreetn — named TreeTN subdomains + adaptive patching
+
+Use this crate for new partitioned work on named TreeTNs. It stores eagerly
+masked `TreeTN<IdxTensor, V>` patches, supports branched topologies and multiple
+site indices per node, and does not implement adaptive interpolation.
+
+- `Projector` — maps full `DynIndex` identities to zero-based coordinates.
+- `SubDomainTreeTN<V>` — eagerly masked TreeTN plus its projector.
+- `PartitionedTreeTN<V>` — homogeneous, pairwise-disjoint patches.
+- `PatchingOptions { rtol, max_bond_dim, patch_order, split_strategy }`.
+- `PatchSplitStrategy::{Sequential, ExactParameterGain}` — exact gain uses
+  checked logical local tensor element counts after child truncation.
+- `add_with_patching(patches, &center, &options)` — split over-cap patches.
+- `truncate_adaptive(&partition, &center, rtol, max_bond_dim)` — assign
+  volume-proportional absolute squared-tail budgets and drop patches below them.
+- `contract_adaptive(&left, &right, &center, &contract_options, &patching_options)` —
+  contract and retruncate against the corrected output norm.
+
+All truncating and contracting operations require an explicit existing node name
+as `center`. No production path re-applies eager projectors or materializes a
+full network densely.
+
+## tensor4all-partitionedtt — legacy subdomain patches + adaptive TCI
+
+This crate is deprecated during migration. Use `tensor4all-partitionedtreetn`
+for new named TreeTN work. It remains buildable and receives correctness and
+security fixes only; no removal date is set.
 
 Split a function's domain into non-overlapping projected patches, each its own TT. Use when a function is low-rank only after fixing some site indices. Re-exports `DynIndex`, `IdxTensor`, `MultiIndex`, `SimpleTensorTrain`, `ContractOptions`/`TruncateOptions`, `TCI2Options` — get them here rather than reaching into core internals.
 


### PR DESCRIPTION
## Summary

Closes #648.

Adds `tensor4all-partitionedtreetn`, the TreeTN-native successor to `tensor4all-partitionedtt`:

- generic `SubDomainTreeTN<V>` and `PartitionedTreeTN<V>` over named arbitrary tree topologies;
- eager `IdxTensor::mask_index` projection with full site axes retained and stale canonical metadata cleared;
- corrected #634 `Projector` identity/hash/order/validation contract;
- homogeneous dtype, exact named topology and full per-node site-index invariants;
- explicit-center strict addition, truncation, same-topology contraction, projector pruning, and deterministic `to_treetn`;
- TreeTN-general adaptive add/truncate/contract patching with volume-proportional squared-tail budgets and checked logical `ExactParameterGain` counts;
- no adaptive interpolation, TreeTCI dependency, sampled-zero policy, or TCIAlgorithms-derived code/license;
- docs-only deprecation notice for the legacy TT crate, with coexistence and no removal date; and
- complete crate/docs/architecture/guide/skill/provenance integration.

Prerequisite #634 landed in #649 (`2b11f7fe`) and is an ancestor of this branch.

Design: [`docs/design/partitioned-treetn.md`](docs/design/partitioned-treetn.md)

## Review gates

- Original and rebased pre-implementation design review: opencode-go DeepSeek V4 Flash, read-only — **Correct-to-merge** ([rebased record](https://github.com/tensor4all/tensor4all-rs/issues/648#issuecomment-5317274454))
- Implementation: GPT-5.6 Luna, dedicated worktree, sequential slices
- Complete production + test/doc diff review and focused follow-up: opencode-go DeepSeek V4 Flash, read-only — **Correct-to-merge**, no Critical/Important findings ([record](https://github.com/tensor4all/tensor4all-rs/issues/648#issuecomment-5318106648))

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p tensor4all-partitionedtreetn`
- `cargo check -p tensor4all-partitionedtreetn --no-default-features --features tenferro-provider-inject`
- `cargo nextest run --release -p tensor4all-partitionedtreetn` — 51/51 passed
- `cargo test --doc --release -p tensor4all-partitionedtreetn` — 29/29 passed
- `cargo nextest run --release --workspace` — 2881 passed, 14 skipped
- `cargo test --doc --release --workspace` — 892 passed
- `cargo doc --workspace --no-deps` — passed (pre-existing warnings only)
- `./scripts/test-mdbook.sh`
- `python3 scripts/check-public-error-docs.py`
- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run` — pass, no findings
- `python3 scripts/test-repository-rules-review.py` — 90 passed
- `cargo run -p api-dump --release -- . -o target/api-dump` — complete inventory includes the new crate

## Coverage and public-surface attestations

- Reviewed every new invariant/error/control-flow path for coverage impact; tests cover eager masking, tag/prime identity, transactionality, topology/site/dtype/center/options errors, strict algebra, adaptive paths, structured logical counts, checked overflow, and long no-dense behavior.
- No coverage threshold or numerical tolerance changed.
- Root README and all advertised capability/signature references were audited.
- The old TT crate remains buildable and receives docs-only deprecation; no `#![deprecated]` attribute was added.

## New public crate checklist

- [x] Workspace member and root README crate map
- [x] `llms.txt` with direct guide/README links
- [x] Architecture layer diagram, crate table, and goal-to-crate guidance
- [x] mdBook guide registered in `SUMMARY.md`
- [x] Related TreeTN guide links to the new guide
- [x] Crate README/docs.rs landing page
- [x] Runnable asserted primary adaptive-patching example
- [x] No developer-local paths or inaccessible design references
- [x] Workspace doctests and mdBook tests pass
- [x] Provenance and citation policy updated