### PR TITLE
Optimize chain zip-up and adaptive patching

### DIFF
--- a/crates/tensor4all-core/src/defaults/factorize.rs
+++ b/crates/tensor4all-core/src/defaults/factorize.rs
@@ -34,7 +34,7 @@
 
 use crate::defaults::idx_tensor::unfold_split_inner;
 use crate::defaults::DynIndex;
-use crate::{contract_pair, unfold_split, IdxTensor};
+use crate::{contract_pair, unfold_split, AnyScalar, IdxTensor};
 use crate::{rrlu, AbstractMatrixCI, MatrixLUCI, RrLUOptions, Scalar as MatrixScalar};
 use anyhow::Result as AnyhowResult;
 use num_complex::{Complex64, ComplexFloat};
@@ -42,9 +42,13 @@ use tenferro_ad::EagerTensor;
 use tenferro_linalg::EagerTensorLinalgExt;
 use tensor4all_tensorbackend::{Matrix, TensorElement};
 
-use crate::defaults::svd::svd_for_factorize;
+use crate::defaults::svd::{compute_retained_rank, svd_for_factorize};
 use crate::qr::{qr_with, QrOptions};
 use crate::svd::SvdOptions;
+use crate::truncation::{
+    validate_svd_truncation_policy, SingularValueMeasure, SvdTruncationPolicy, ThresholdScale,
+    TruncationRule,
+};
 
 // Re-export types from tensor_like for backwards compatibility
 pub use crate::tensor_like::{
@@ -106,6 +110,245 @@ pub fn factorize(
             "factorize currently supports only f64 and Complex64 tensors",
         ))
     }
+}
+
+/// Select Gram eigendecomposition for safe untracked SVD truncations.
+///
+/// This is intentionally crate-visible: the public entry point is the
+/// [`TensorFactorizationLike::factorize_auto`] method.
+pub(crate) fn factorize_auto(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &FactorizeOptions,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    if options.alg != FactorizeAlg::SVD {
+        return Err(FactorizeError::InvalidOptions(
+            "automatic factorization only supports SVD options",
+        ));
+    }
+    options.validate()?;
+
+    let Some(policy) = options.svd_policy else {
+        return factorize(t, left_inds, options);
+    };
+    validate_svd_truncation_policy(policy).map_err(|error| FactorizeError::InvalidRtol(error.0))?;
+
+    let effective_cutoff = match (policy.scale, policy.measure, policy.rule) {
+        (ThresholdScale::Relative, SingularValueMeasure::SquaredValue, _) => policy.threshold,
+        (ThresholdScale::Relative, SingularValueMeasure::Value, TruncationRule::PerValue) => {
+            policy.threshold * policy.threshold
+        }
+        _ => 0.0,
+    };
+    if effective_cutoff <= 1.0e-12 || t.tracks_grad() || t.is_diag() {
+        return factorize(t, left_inds, options);
+    }
+    if !(t.is_f64() || t.is_c64()) {
+        return factorize(t, left_inds, options);
+    }
+
+    factorize_gram(t, left_inds, options, policy).or_else(|_| factorize(t, left_inds, options))
+}
+
+fn factorize_gram(
+    t: &IdxTensor,
+    left_inds: &[DynIndex],
+    options: &FactorizeOptions,
+    policy: SvdTruncationPolicy,
+) -> Result<FactorizeResult<IdxTensor>, FactorizeError> {
+    let (matrix_inner, _, m, n, left_indices, right_indices) = unfold_split_inner(t, left_inds)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::anyhow!(error)))?;
+    if m == 0 || n == 0 {
+        return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+            "cannot factorize a matrix with an empty dimension"
+        )));
+    }
+
+    let row = DynIndex::new_dyn(m);
+    let column = DynIndex::new_dyn(n);
+    let matrix = IdxTensor::from_inner(vec![row.clone(), column.clone()], matrix_inner)
+        .map_err(FactorizeError::ComputationError)?;
+
+    // Form the smaller Gram tensor directly through the native contraction
+    // path. No rectangular host Matrix or Matrix↔backend round-trip is needed.
+    let eigenvectors_left = m <= n;
+    let gram = if eigenvectors_left {
+        let sim_row = DynIndex::new_dyn(m);
+        let adjoint = matrix
+            .conj()
+            .replaceind(&row, &sim_row)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        contract_pair(&matrix, &adjoint)
+    } else {
+        let sim_column = DynIndex::new_dyn(n);
+        let adjoint = matrix
+            .conj()
+            .replaceind(&column, &sim_column)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        contract_pair(&adjoint, &matrix)
+    }
+    .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+    let decomposition = gram
+        .hermitian_eigendecomposition(1.0e-12)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+
+    let lambda_scale = decomposition
+        .eigenvalues
+        .iter()
+        .map(|lambda| lambda.abs())
+        .fold(0.0_f64, f64::max);
+    if lambda_scale == 0.0 {
+        return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+            "zero Gram matrix uses the SVD fallback"
+        )));
+    }
+    let negative_tolerance = 1.0e-12 * lambda_scale;
+    let mut eigenpairs: Vec<(f64, usize)> = decomposition
+        .eigenvalues
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(column, mut lambda)| {
+            if !lambda.is_finite() {
+                return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                    "Gram eigendecomposition returned a non-finite eigenvalue"
+                )));
+            }
+            if lambda < -negative_tolerance {
+                return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+                    "Gram eigendecomposition returned a materially negative eigenvalue"
+                )));
+            }
+            if lambda < 0.0 {
+                lambda = 0.0;
+            }
+            Ok((lambda, column))
+        })
+        .collect::<Result<_, _>>()?;
+    eigenpairs.sort_by(|(left, _), (right, _)| right.total_cmp(left));
+
+    let all_singular_values: Vec<f64> =
+        eigenpairs.iter().map(|(lambda, _)| lambda.sqrt()).collect();
+    let mut rank = compute_retained_rank(&all_singular_values, &policy);
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        rank = rank.min(max_bond_dim);
+    }
+    rank = rank.max(1).min(m.min(n));
+    let singular_values = all_singular_values[..rank].to_vec();
+    if singular_values.contains(&0.0) {
+        return Err(FactorizeError::ComputationError(anyhow::anyhow!(
+            "zero retained singular value uses the SVD fallback"
+        )));
+    }
+
+    let retained_columns: Vec<usize> = eigenpairs
+        .iter()
+        .take(rank)
+        .map(|(_, column)| *column)
+        .collect();
+    let basis_inner = decomposition
+        .eigenvectors
+        .as_inner()
+        .map_err(FactorizeError::ComputationError)?
+        .take_cols(&retained_columns)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+    let bond_index = DynIndex::new_bond(rank)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::anyhow!(error)))?;
+    let basis_index = if eigenvectors_left {
+        row.clone()
+    } else {
+        column.clone()
+    };
+    let basis = IdxTensor::from_inner(vec![basis_index, bond_index.clone()], basis_inner)
+        .map_err(FactorizeError::ComputationError)?;
+
+    let (left_matrix, right_matrix) = if eigenvectors_left {
+        let sigma_vh = contract_pair(&basis.conj(), &matrix)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?
+            .permute_indices(&[bond_index.clone(), column.clone()])
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        match options.canonical {
+            Canonical::Left => (basis, sigma_vh),
+            Canonical::Right => {
+                let inverse: Vec<f64> = singular_values.iter().map(|sigma| 1.0 / sigma).collect();
+                (
+                    scale_bond(&basis, &bond_index, &singular_values)?,
+                    scale_bond(&sigma_vh, &bond_index, &inverse)?,
+                )
+            }
+        }
+    } else {
+        let u_sigma = contract_pair(&matrix, &basis)
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?
+            .permute_indices(&[row.clone(), bond_index.clone()])
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        let vh = basis
+            .conj()
+            .permute_indices(&[bond_index.clone(), column.clone()])
+            .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+        match options.canonical {
+            Canonical::Right => (u_sigma, vh),
+            Canonical::Left => {
+                let inverse: Vec<f64> = singular_values.iter().map(|sigma| 1.0 / sigma).collect();
+                (
+                    scale_bond(&u_sigma, &bond_index, &inverse)?,
+                    scale_bond(&vh, &bond_index, &singular_values)?,
+                )
+            }
+        }
+    };
+
+    let mut output_left_indices = left_indices;
+    output_left_indices.push(bond_index.clone());
+    let left = reshape_factor(left_matrix, output_left_indices)?;
+    let mut output_right_indices = vec![bond_index.clone()];
+    output_right_indices.extend(right_indices);
+    let right = reshape_factor(right_matrix, output_right_indices)?;
+
+    Ok(FactorizeResult {
+        left,
+        right,
+        bond_index,
+        singular_values: Some(singular_values),
+        rank,
+    })
+}
+
+fn scale_bond(
+    tensor: &IdxTensor,
+    bond: &DynIndex,
+    values: &[f64],
+) -> Result<IdxTensor, FactorizeError> {
+    let temporary = DynIndex::new_bond(values.len())
+        .map_err(|error| FactorizeError::ComputationError(anyhow::anyhow!(error)))?;
+    let diagonal_values = values
+        .iter()
+        .map(|value| {
+            if tensor.is_complex() {
+                AnyScalar::new_complex(*value, 0.0)
+            } else {
+                AnyScalar::new_real(*value)
+            }
+        })
+        .collect();
+    let diagonal = IdxTensor::from_diag_any(vec![bond.clone(), temporary.clone()], diagonal_values)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+    contract_pair(tensor, &diagonal)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?
+        .replaceind(&temporary, bond)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?
+        .permute_indices(tensor.indices())
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))
+}
+
+fn reshape_factor(tensor: IdxTensor, indices: Vec<DynIndex>) -> Result<IdxTensor, FactorizeError> {
+    let dims: Vec<usize> = indices.iter().map(|index| index.dim).collect();
+    let inner = tensor
+        .as_inner()
+        .map_err(FactorizeError::ComputationError)?
+        .reshape(&dims)
+        .map_err(|error| FactorizeError::ComputationError(anyhow::Error::new(error)))?;
+    IdxTensor::from_inner(indices, inner).map_err(FactorizeError::ComputationError)
 }
 
 /// Factorize a tensor without applying algorithm-specific truncation options.

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -5436,6 +5436,14 @@ impl TensorFactorizationLike for IdxTensor {
         crate::factorize::factorize(self, left_inds, options)
     }
 
+    fn factorize_auto(
+        &self,
+        left_inds: &[DynIndex],
+        options: &FactorizeOptions,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        crate::factorize::factorize_auto(self, left_inds, options)
+    }
+
     fn factorize_full_rank(
         &self,
         left_inds: &[DynIndex],

--- a/crates/tensor4all-core/src/defaults/svd.rs
+++ b/crates/tensor4all-core/src/defaults/svd.rs
@@ -145,7 +145,7 @@ fn singular_value_measure(value: f64, measure: SingularValueMeasure) -> f64 {
 }
 
 /// Compute the retained rank based on an explicit SVD truncation policy.
-fn compute_retained_rank(s_vec: &[f64], policy: &SvdTruncationPolicy) -> usize {
+pub(crate) fn compute_retained_rank(s_vec: &[f64], policy: &SvdTruncationPolicy) -> usize {
     if s_vec.is_empty() {
         return 1;
     }

--- a/crates/tensor4all-core/src/tensor_like.rs
+++ b/crates/tensor4all-core/src/tensor_like.rs
@@ -798,6 +798,60 @@ pub trait TensorFactorizationLike: TensorIndex {
         options: &FactorizeOptions,
     ) -> std::result::Result<FactorizeResult<Self>, FactorizeError>;
 
+    /// Factorize this tensor using policy-aware automatic SVD/eigen selection.
+    ///
+    /// Implementations may use Hermitian Gram eigendecomposition when the
+    /// requested SVD policy is numerically suitable. The default delegates to
+    /// [`Self::factorize`], preserving the existing behavior for tensor types
+    /// without an automatic eigendecomposition path.
+    ///
+    /// # Arguments
+    /// * `left_inds` - Indices to place on the left side of the split.
+    /// * `options` - Ordinary SVD factorization options, including canonical
+    ///   direction, truncation policy, and maximum bond dimension.
+    ///
+    /// # Returns
+    /// The same factorization result as [`Self::factorize`], with singular
+    /// values populated for SVD-compatible implementations.
+    ///
+    /// # Errors
+    /// Returns [`FactorizeError::InvalidOptions`] when `options.alg` is not
+    /// [`FactorizeAlg::SVD`], or another [`FactorizeError`] when factorization
+    /// fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{
+    ///     DynIndex, FactorizeOptions, IdxTensor, SvdTruncationPolicy,
+    ///     TensorFactorizationLike,
+    /// };
+    ///
+    /// let left = DynIndex::new_dyn(2);
+    /// let right = DynIndex::new_dyn(2);
+    /// let tensor = IdxTensor::from_dense(
+    ///     vec![left.clone(), right],
+    ///     vec![1.0_f64, 0.0, 0.0, 1.0e-3],
+    /// )?;
+    /// let options = FactorizeOptions::svd()
+    ///     .with_svd_policy(SvdTruncationPolicy::new(1.0e-2));
+    /// let result = tensor.factorize_auto(&[left], &options)?;
+    /// assert_eq!(result.rank, 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    fn factorize_auto(
+        &self,
+        left_inds: &[<Self as TensorIndex>::Index],
+        options: &FactorizeOptions,
+    ) -> std::result::Result<FactorizeResult<Self>, FactorizeError> {
+        if options.alg != FactorizeAlg::SVD {
+            return Err(FactorizeError::InvalidOptions(
+                "automatic factorization only supports SVD options",
+            ));
+        }
+        self.factorize(left_inds, options)
+    }
+
     /// Factorize this tensor without applying truncation controls.
     /// # Errors
     ///

--- a/crates/tensor4all-core/tests/linalg_factorize.rs
+++ b/crates/tensor4all-core/tests/linalg_factorize.rs
@@ -1,11 +1,14 @@
 //! Tests for the unified factorize function.
 
+use num_complex::Complex64;
+use tensor4all_core::block_tensor::BlockTensor;
 use tensor4all_core::index::Index;
 use tensor4all_core::{
     factorize, factorize_full_rank, Canonical, DynIndex, FactorizeAlg, FactorizeError,
-    FactorizeOptions, TensorContractionLike,
+    FactorizeOptions, TensorContractionLike, TensorFactorizationLike,
 };
 use tensor4all_core::{IdxTensor, SvdTruncationPolicy};
+use tensor4all_tensorbackend::TensorElement;
 
 // ============================================================================
 // Test Data Helpers
@@ -53,6 +56,52 @@ fn create_non_symmetric_col_major_matrix() -> IdxTensor {
 // ============================================================================
 // Shared Test Helpers
 // ============================================================================
+
+#[test]
+fn factorize_auto_default_validates_and_delegates() {
+    let left = DynIndex::new_dyn(2);
+    let right = DynIndex::new_dyn(2);
+    let dense =
+        IdxTensor::from_dense(vec![left.clone(), right], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap();
+    let block = BlockTensor::new(vec![dense], (1, 1)).unwrap();
+
+    assert!(matches!(
+        block.factorize_auto(std::slice::from_ref(&left), &FactorizeOptions::svd()),
+        Err(FactorizeError::ComputationError(_))
+    ));
+    assert!(matches!(
+        block.factorize_auto(&[left], &FactorizeOptions::qr()),
+        Err(FactorizeError::InvalidOptions(_))
+    ));
+}
+
+#[test]
+fn factorize_auto_matches_svd_for_safe_policy() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let tensor =
+        IdxTensor::from_dense(vec![i.clone(), j], vec![3.0_f64, 0.0, 0.0, 1.0e-3]).unwrap();
+    let options = FactorizeOptions::svd()
+        .with_svd_policy(SvdTruncationPolicy::new(1.0e-2))
+        .with_canonical(Canonical::Left);
+
+    let explicit = tensor
+        .factorize(std::slice::from_ref(&i), &options)
+        .unwrap();
+    let automatic = tensor.factorize_auto(&[i], &options).unwrap();
+
+    assert_eq!(automatic.rank, explicit.rank);
+    assert!(automatic
+        .left
+        .contract_pair(&automatic.right)
+        .unwrap()
+        .isapprox(
+            &explicit.left.contract_pair(&explicit.right).unwrap(),
+            1.0e-10,
+            0.0,
+        )
+        .unwrap());
+}
 
 /// Test factorization with given options and verify reconstruction.
 fn test_factorize_reconstruction(options: &FactorizeOptions) {
@@ -165,6 +214,245 @@ fn test_factorize_svd_rank3() {
 
     let reconstructed = result.left.contract_pair(&result.right).unwrap();
     assert_tensors_approx_equal(&tensor, &reconstructed, 1e-10);
+}
+
+#[test]
+fn factorize_auto_matches_explicit_svd_for_all_policies_and_shapes() {
+    let policies = [
+        SvdTruncationPolicy::new(5.0e-2),
+        SvdTruncationPolicy::new(5.0e-2).with_discarded_tail_sum(),
+        SvdTruncationPolicy::new(5.0e-2).with_squared_values(),
+        SvdTruncationPolicy::new(5.0e-2)
+            .with_squared_values()
+            .with_discarded_tail_sum(),
+        SvdTruncationPolicy::new(5.0e-2).with_absolute(),
+        SvdTruncationPolicy::new(5.0e-2)
+            .with_absolute()
+            .with_discarded_tail_sum(),
+        SvdTruncationPolicy::new(5.0e-2)
+            .with_absolute()
+            .with_squared_values(),
+        SvdTruncationPolicy::new(5.0e-2)
+            .with_absolute()
+            .with_squared_values()
+            .with_discarded_tail_sum(),
+    ];
+
+    for (m, n, data) in [
+        (
+            4,
+            3,
+            vec![10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1],
+        ),
+        (
+            3,
+            4,
+            vec![10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1],
+        ),
+    ] {
+        let left = DynIndex::new_dyn(m);
+        let right = DynIndex::new_dyn(n);
+        let tensor = IdxTensor::from_dense(vec![left.clone(), right], data).unwrap();
+        for canonical in [Canonical::Left, Canonical::Right] {
+            for policy in policies {
+                let options = FactorizeOptions::svd()
+                    .with_canonical(canonical)
+                    .with_svd_policy(policy);
+                let explicit = tensor
+                    .factorize(std::slice::from_ref(&left), &options)
+                    .unwrap();
+                let automatic = tensor
+                    .factorize_auto(std::slice::from_ref(&left), &options)
+                    .unwrap();
+                assert_eq!(automatic.rank, explicit.rank);
+                let explicit_reconstructed = explicit.left.contract_pair(&explicit.right).unwrap();
+                let automatic_reconstructed =
+                    automatic.left.contract_pair(&automatic.right).unwrap();
+                assert_tensors_approx_equal(
+                    &explicit_reconstructed,
+                    &automatic_reconstructed,
+                    1.0e-10,
+                );
+                assert!(
+                    tensor
+                        .sub(&automatic_reconstructed)
+                        .unwrap()
+                        .maxabs()
+                        .unwrap()
+                        <= 1.1
+                );
+                assert_canonical::<f64>(&automatic, canonical, 1.0e-10);
+            }
+        }
+    }
+
+    for (m, n, data) in [
+        (
+            4,
+            2,
+            vec![
+                Complex64::new(10.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(1.0, 0.5),
+                Complex64::new(0.0, 0.0),
+            ],
+        ),
+        (
+            2,
+            4,
+            vec![
+                Complex64::new(10.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(0.0, 0.0),
+                Complex64::new(1.0, 0.5),
+                Complex64::new(0.0, 0.0),
+            ],
+        ),
+    ] {
+        let left = DynIndex::new_dyn(m);
+        let right = DynIndex::new_dyn(n);
+        let tensor = IdxTensor::from_dense(vec![left.clone(), right], data).unwrap();
+        for canonical in [Canonical::Left, Canonical::Right] {
+            let options = FactorizeOptions::svd()
+                .with_canonical(canonical)
+                .with_svd_policy(SvdTruncationPolicy::new(5.0e-2));
+            let explicit = tensor
+                .factorize(std::slice::from_ref(&left), &options)
+                .unwrap();
+            let automatic = tensor
+                .factorize_auto(std::slice::from_ref(&left), &options)
+                .unwrap();
+            assert_eq!(automatic.rank, explicit.rank);
+            let explicit_reconstructed = explicit.left.contract_pair(&explicit.right).unwrap();
+            let automatic_reconstructed = automatic.left.contract_pair(&automatic.right).unwrap();
+            assert_tensors_approx_equal(&explicit_reconstructed, &automatic_reconstructed, 1.0e-10);
+            assert!(
+                tensor
+                    .sub(&automatic_reconstructed)
+                    .unwrap()
+                    .maxabs()
+                    .unwrap()
+                    <= 1.1
+            );
+            assert_canonical::<Complex64>(&automatic, canonical, 1.0e-10);
+        }
+    }
+}
+
+#[test]
+fn factorize_auto_respects_cap_zero_and_rank_deficiency() {
+    let i = DynIndex::new_dyn(3);
+    let j = DynIndex::new_dyn(3);
+    let rank_one = IdxTensor::from_dense(
+        vec![i.clone(), j.clone()],
+        vec![3.0_f64, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    )
+    .unwrap();
+    let options = FactorizeOptions::svd()
+        .with_svd_policy(SvdTruncationPolicy::new(1.0e-2))
+        .with_max_bond_dim(2);
+    let result = rank_one
+        .factorize_auto(std::slice::from_ref(&i), &options)
+        .unwrap();
+    assert_eq!(result.rank, 1);
+    assert_tensors_approx_equal(
+        &rank_one,
+        &result.left.contract_pair(&result.right).unwrap(),
+        1.0e-10,
+    );
+
+    let capped = IdxTensor::from_dense(
+        vec![i.clone(), j.clone()],
+        vec![3.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 1.0],
+    )
+    .unwrap();
+    let capped_options = FactorizeOptions::svd()
+        .with_svd_policy(SvdTruncationPolicy::new(1.0e-6))
+        .with_max_bond_dim(2);
+    assert_eq!(
+        capped
+            .factorize_auto(std::slice::from_ref(&i), &capped_options)
+            .unwrap()
+            .rank,
+        2
+    );
+
+    let zero = IdxTensor::from_dense(vec![i.clone(), j.clone()], vec![0.0; 9]).unwrap();
+    for canonical in [Canonical::Left, Canonical::Right] {
+        let result = zero
+            .factorize_auto(
+                std::slice::from_ref(&i),
+                &FactorizeOptions::svd()
+                    .with_canonical(canonical)
+                    .with_svd_policy(SvdTruncationPolicy::new(1.0e-2)),
+            )
+            .unwrap();
+        assert_eq!(result.rank, 1);
+        assert_tensors_approx_equal(
+            &zero,
+            &result.left.contract_pair(&result.right).unwrap(),
+            1.0e-12,
+        );
+        assert_canonical::<f64>(&result, canonical, 1.0e-12);
+    }
+}
+
+#[test]
+fn factorize_auto_gate_is_strict_and_preserves_tracked_ad() {
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(2);
+    let tensor =
+        IdxTensor::from_dense(vec![i.clone(), j], vec![2.0_f64, 0.0, 0.0, 1.0e-3]).unwrap();
+
+    let squared_boundary = FactorizeOptions::svd()
+        .with_svd_policy(SvdTruncationPolicy::new(1.0e-12).with_squared_values());
+    let value_boundary = FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1.0e-6));
+    assert_eq!(
+        tensor
+            .factorize_auto(std::slice::from_ref(&i), &squared_boundary)
+            .unwrap()
+            .rank,
+        tensor
+            .factorize(std::slice::from_ref(&i), &squared_boundary)
+            .unwrap()
+            .rank
+    );
+    assert_eq!(
+        tensor
+            .factorize_auto(std::slice::from_ref(&i), &value_boundary)
+            .unwrap()
+            .rank,
+        tensor
+            .factorize(std::slice::from_ref(&i), &value_boundary)
+            .unwrap()
+            .rank
+    );
+
+    let tracked = tensor.clone().enable_grad().unwrap();
+    let tracked_result = tracked.factorize_auto(
+        std::slice::from_ref(&i),
+        &FactorizeOptions::svd().with_svd_policy(SvdTruncationPolicy::new(1.0e-2)),
+    );
+    assert!(tracked_result.is_ok());
+    assert!(tracked_result.unwrap().left.tracks_grad());
+
+    let mut invalid = FactorizeOptions::qr();
+    assert!(matches!(
+        tensor.factorize_auto(&[i], &invalid),
+        Err(FactorizeError::InvalidOptions(_))
+    ));
+    invalid.alg = FactorizeAlg::LU;
+    assert!(matches!(
+        tensor.factorize_auto(&[DynIndex::new_dyn(2)], &invalid),
+        Err(FactorizeError::InvalidOptions(_))
+    ));
 }
 
 // ============================================================================
@@ -385,6 +673,76 @@ fn test_diag_dense_contraction_svd_internals() {
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+trait TestScalar:
+    TensorElement + Copy + Default + std::ops::Add<Output = Self> + std::ops::Mul<Output = Self>
+{
+    fn conjugate(self) -> Self;
+    fn distance_from(self, target: f64) -> f64;
+}
+
+impl TestScalar for f64 {
+    fn conjugate(self) -> Self {
+        self
+    }
+
+    fn distance_from(self, target: f64) -> f64 {
+        (self - target).abs()
+    }
+}
+
+impl TestScalar for Complex64 {
+    fn conjugate(self) -> Self {
+        self.conj()
+    }
+
+    fn distance_from(self, target: f64) -> f64 {
+        (self - Complex64::new(target, 0.0)).norm()
+    }
+}
+
+fn assert_canonical<T: TestScalar>(
+    result: &tensor4all_core::FactorizeResult<IdxTensor>,
+    canonical: Canonical,
+    tol: f64,
+) {
+    match canonical {
+        Canonical::Left => {
+            let dims = result.left.dims();
+            let rows = dims[0];
+            let rank = dims[1];
+            let data = result.left.to_vec::<T>().unwrap();
+            for a in 0..rank {
+                for b in 0..rank {
+                    let value = (0..rows).fold(T::default(), |sum, row| {
+                        sum + data[row + rows * a].conjugate() * data[row + rows * b]
+                    });
+                    assert!(
+                        value.distance_from((a == b) as usize as f64) < tol,
+                        "left canonical Gram entry ({a}, {b}) was not orthonormal"
+                    );
+                }
+            }
+        }
+        Canonical::Right => {
+            let dims = result.right.dims();
+            let rank = dims[0];
+            let columns = dims[1];
+            let data = result.right.to_vec::<T>().unwrap();
+            for a in 0..rank {
+                for b in 0..rank {
+                    let value = (0..columns).fold(T::default(), |sum, column| {
+                        sum + data[a + rank * column] * data[b + rank * column].conjugate()
+                    });
+                    assert!(
+                        value.distance_from((a == b) as usize as f64) < tol,
+                        "right canonical Gram entry ({a}, {b}) was not orthonormal"
+                    );
+                }
+            }
+        }
+    }
+}
 
 fn assert_tensors_approx_equal(a: &IdxTensor, b: &IdxTensor, tol: f64) {
     assert!(

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -133,6 +133,44 @@ fn test_fuse_indices_trait_dispatch_returns_unsupported_error() {
 }
 
 #[test]
+fn trait_dispatch_covers_unsupported_ops_and_constructors() {
+    let i = idx(0, 2);
+    let j = idx(1, 2);
+    let tt = TensorTrain::new(vec![make_tensor(vec![i.clone()])]).unwrap();
+
+    assert!(<TensorTrain as TensorContractionLike>::contract(&[&tt]).is_err());
+    assert!(tt.direct_sum(&tt, &[]).is_err());
+    assert!(tt.outer_product(&tt).is_err());
+    assert!(tt.permuteinds(std::slice::from_ref(&i)).is_err());
+    assert!(matches!(
+        tt.factorize_auto(std::slice::from_ref(&i), &FactorizeOptions::svd()),
+        Err(FactorizeError::UnsupportedStorage(_))
+    ));
+    assert!(matches!(
+        tt.factorize_full_rank(std::slice::from_ref(&i), FactorizeAlg::SVD, Canonical::Left,),
+        Err(FactorizeError::UnsupportedStorage(_))
+    ));
+
+    let diagonal = <TensorTrain as TensorConstructionLike>::diagonal(&i, &j).unwrap();
+    assert_eq!(diagonal.len(), 1);
+    assert!(<TensorTrain as TensorConstructionLike>::scalar_one()
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        <TensorTrain as TensorConstructionLike>::ones(std::slice::from_ref(&i))
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        <TensorTrain as TensorConstructionLike>::onehot(&[(i, 1)])
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn test_two_site_tt() {
     // Create two tensors with a shared link index
     let s0 = idx(0, 2); // site 0

--- a/crates/tensor4all-partitionedtreetn/src/patching.rs
+++ b/crates/tensor4all-partitionedtreetn/src/patching.rs
@@ -7,15 +7,22 @@
 //! ([arXiv:2602.22372](https://arxiv.org/abs/2602.22372)). This module does not
 //! implement adaptive interpolation or copy TCIAlgorithms.jl code.
 
+use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 
 use crate::error::{PartitionedTreeTNError, Result};
 use crate::partitioned_tree_tn::PartitionedTreeTN;
 use crate::projector::{canonical_index_cmp, Projector};
-use crate::subdomain_tree_tn::{ensure_center, SubDomainTreeTN};
+use crate::subdomain_tree_tn::{ensure_center, ScalarKind, SubDomainTreeTN};
 use tensor4all_core::SvdTruncationPolicy;
 use tensor4all_treetn::{contraction::ContractionOptions, TruncationOptions};
+
+type ContractGroup<V> = (
+    Vec<(SubDomainTreeTN<V>, SubDomainTreeTN<V>)>,
+    Vec<SubDomainTreeTN<V>>,
+);
 
 #[derive(Debug)]
 struct PatchStats<V>
@@ -310,13 +317,233 @@ where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
     validate_patching_options(patching_options)?;
-    let contracted = left.contract(right, center, contract_options.clone())?;
+    let mut left_patches: Vec<_> = left.values().collect();
+    let mut right_patches: Vec<_> = right.values().collect();
+    left_patches.sort_by(|a, b| {
+        a.projector()
+            .partial_cmp(b.projector())
+            .unwrap_or(Ordering::Equal)
+    });
+    right_patches.sort_by(|a, b| {
+        a.projector()
+            .partial_cmp(b.projector())
+            .unwrap_or(Ordering::Equal)
+    });
+
+    let mut groups: HashMap<Projector, ContractGroup<V>> = HashMap::new();
+    for left_patch in left_patches {
+        for right_patch in &right_patches {
+            if let Some(contribution) =
+                left_patch.contract(right_patch, center, contract_options.clone())?
+            {
+                let entry = groups.entry(contribution.projector().clone()).or_default();
+                entry.0.push((left_patch.clone(), (*right_patch).clone()));
+                entry.1.push(contribution);
+            }
+        }
+    }
+
+    let mut grouped: Vec<_> = groups.into_iter().collect();
+    grouped.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    let mut subdomains = Vec::new();
+    for (_, (pairs, contributions)) in grouped {
+        subdomains.extend(contract_group_project_first(
+            pairs,
+            Some(contributions),
+            center,
+            contract_options,
+            patching_options,
+        )?);
+    }
+    let contracted = PartitionedTreeTN::from_subdomains(subdomains)?;
     truncate_adaptive(
         &contracted,
         center,
         patching_options.rtol,
         patching_options.max_bond_dim,
     )
+}
+
+fn contract_group_project_first<V>(
+    pairs: Vec<(SubDomainTreeTN<V>, SubDomainTreeTN<V>)>,
+    precomputed: Option<Vec<SubDomainTreeTN<V>>>,
+    center: &V,
+    contract_options: &ContractionOptions,
+    patching_options: &PatchingOptions,
+) -> Result<Vec<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let contributions = if let Some(contributions) = precomputed {
+        contributions
+    } else {
+        let mut contributions = Vec::with_capacity(pairs.len());
+        for (left, right) in &pairs {
+            if let Some(contribution) = left.contract(right, center, contract_options.clone())? {
+                contributions.push(contribution);
+            }
+        }
+        contributions
+    };
+    let mut iter = contributions.iter();
+    let Some(first) = iter.next() else {
+        return Ok(Vec::new());
+    };
+    let mut probe = first.clone();
+    let truncation = truncation_options_from_contract(contract_options);
+    for contribution in iter {
+        probe = probe.add(contribution)?;
+        probe.truncate(center, truncation)?;
+    }
+
+    let Some(cap) = patching_options.max_bond_dim else {
+        return Ok(vec![probe]);
+    };
+    let saturated = probe.max_bond_dim() >= cap
+        || contributions
+            .iter()
+            .any(|contribution| contribution.max_bond_dim() >= cap);
+    if !saturated {
+        return Ok(vec![probe]);
+    }
+    let probe = assign_volume_budgets(vec![probe], patching_options.rtol)?
+        .pop()
+        .ok_or(PartitionedTreeTNError::Empty)?;
+    let Some(index) = choose_split_index(&probe, center, patching_options)? else {
+        return Ok(vec![probe]);
+    };
+
+    let mut children = Vec::with_capacity(index.dim);
+    for value in 0..index.dim {
+        let mut child_pairs = Vec::with_capacity(pairs.len());
+        let mut projected_left = HashMap::new();
+        let mut projected_right = HashMap::new();
+        for (left, right) in &pairs {
+            let left_key = left.projector().clone();
+            if !projected_left.contains_key(&left_key) {
+                projected_left.insert(
+                    left_key.clone(),
+                    project_if_present(left, &index, value, center)?,
+                );
+            }
+            let right_key = right.projector().clone();
+            if !projected_right.contains_key(&right_key) {
+                projected_right.insert(
+                    right_key.clone(),
+                    project_if_present(right, &index, value, center)?,
+                );
+            }
+            if let (Some(child_left), Some(child_right)) = (
+                projected_left.get(&left_key).cloned().flatten(),
+                projected_right.get(&right_key).cloned().flatten(),
+            ) {
+                child_pairs.push((child_left, child_right));
+            }
+        }
+        children.extend(contract_group_project_first(
+            child_pairs,
+            None,
+            center,
+            contract_options,
+            patching_options,
+        )?);
+    }
+    Ok(children)
+}
+
+#[cfg(test)]
+fn add_project_first<V>(
+    contributions: Vec<SubDomainTreeTN<V>>,
+    center: &V,
+    contract_options: &ContractionOptions,
+    patching_options: &PatchingOptions,
+) -> Result<Vec<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut iter = contributions.iter();
+    let Some(first) = iter.next() else {
+        return Ok(Vec::new());
+    };
+    let mut probe = first.clone();
+    let truncation = truncation_options_from_contract(contract_options);
+    for contribution in iter {
+        probe = probe.add(contribution)?;
+        probe.truncate(center, truncation)?;
+    }
+
+    let Some(cap) = patching_options.max_bond_dim else {
+        return Ok(vec![probe]);
+    };
+    if probe.max_bond_dim() < cap {
+        return Ok(vec![probe]);
+    }
+    let probe = assign_volume_budgets(vec![probe], patching_options.rtol)?
+        .pop()
+        .ok_or(PartitionedTreeTNError::Empty)?;
+    let Some(index) = choose_split_index(&probe, center, patching_options)? else {
+        return Ok(vec![probe]);
+    };
+
+    let mut children = Vec::new();
+    for value in 0..index.dim {
+        let mut projected = Vec::with_capacity(contributions.len());
+        for contribution in &contributions {
+            if let Some(child) = project_if_present(contribution, &index, value, center)? {
+                projected.push(child);
+            }
+        }
+        children.extend(add_project_first(
+            projected,
+            center,
+            contract_options,
+            patching_options,
+        )?);
+    }
+    Ok(children)
+}
+
+fn project_if_present<V>(
+    subdomain: &SubDomainTreeTN<V>,
+    index: &tensor4all_core::DynIndex,
+    value: usize,
+    center: &V,
+) -> Result<Option<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    if !subdomain
+        .all_indices()
+        .iter()
+        .any(|candidate| candidate == index)
+    {
+        return Ok(Some(subdomain.clone()));
+    }
+    let Some(mut projected) =
+        subdomain.project(&Projector::from_pairs([(index.clone(), value)])?)?
+    else {
+        return Ok(None);
+    };
+    let threshold = match projected.scalar_kind()? {
+        Some(ScalarKind::F32 | ScalarKind::C32) => 64.0 * f32::EPSILON as f64,
+        Some(ScalarKind::F64 | ScalarKind::C64) | None => 64.0 * f64::EPSILON,
+    };
+    projected.truncate(
+        center,
+        TruncationOptions::new().with_svd_policy(SvdTruncationPolicy::new(threshold)),
+    )?;
+    Ok(Some(projected))
+}
+
+fn truncation_options_from_contract(options: &ContractionOptions) -> TruncationOptions {
+    let mut truncation = TruncationOptions::default();
+    if let Some(policy) = options.svd_policy {
+        truncation = truncation.with_svd_policy(policy);
+    }
+    if let Some(max_bond_dim) = options.max_bond_dim {
+        truncation = truncation.with_max_bond_dim(max_bond_dim);
+    }
+    truncation
 }
 
 /// Truncate a partition with volume-proportional absolute squared-tail budgets.
@@ -864,6 +1091,77 @@ mod tests {
         let subdomain = SubDomainTreeTN::from_treetn(tree).unwrap();
 
         assert_eq!(logical_parameter_count(&subdomain).unwrap(), 9);
+    }
+
+    #[test]
+    fn projection_removes_exact_zero_bond_space_without_error_budget() {
+        let site0 = DynIndex::new_dyn(2);
+        let site1 = DynIndex::new_dyn(2);
+        let bond = DynIndex::new_bond(2).unwrap();
+        let left =
+            IdxTensor::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 0.0, 0.0, 1.0])
+                .unwrap();
+        let right = IdxTensor::from_dense(vec![bond, site1], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+        let subdomain = SubDomainTreeTN::from_treetn(
+            TreeTN::from_tensors(vec![left, right], vec![0usize, 1]).unwrap(),
+        )
+        .unwrap();
+        let projector = Projector::from_pairs([(site0.clone(), 0)]).unwrap();
+        let projected = subdomain.project(&projector).unwrap().unwrap();
+        let compressed = project_if_present(&subdomain, &site0, 0, &0)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(projected.max_bond_dim(), 2);
+        assert_eq!(compressed.max_bond_dim(), 1);
+        assert!(
+            (compressed.norm_squared().unwrap() - projected.norm_squared().unwrap()).abs()
+                < 1.0e-12
+        );
+    }
+
+    #[test]
+    fn adaptive_add_projects_original_addends_before_retrying() {
+        let site0 = DynIndex::new_dyn(2);
+        let site1 = DynIndex::new_dyn(2);
+        let product_patch = |left_values: Vec<f64>, right_values: Vec<f64>| {
+            let bond = DynIndex::new_bond(1).unwrap();
+            let left =
+                IdxTensor::from_dense(vec![site0.clone(), bond.clone()], left_values).unwrap();
+            let right = IdxTensor::from_dense(vec![bond, site1.clone()], right_values).unwrap();
+            SubDomainTreeTN::from_treetn(
+                TreeTN::from_tensors(vec![left, right], vec![0usize, 1]).unwrap(),
+            )
+            .unwrap()
+        };
+        let contributions = vec![
+            product_patch(vec![1.0, 0.0], vec![1.0, 0.0]),
+            product_patch(vec![0.0, 1.0], vec![0.0, 1.0]),
+        ];
+        let contraction = ContractionOptions::default().with_max_bond_dim(1);
+        let patching = PatchingOptions {
+            rtol: 0.0,
+            max_bond_dim: Some(1),
+            patch_order: vec![site0.clone()],
+            split_strategy: PatchSplitStrategy::Sequential,
+        };
+
+        let result = add_project_first(contributions, &0, &contraction, &patching).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|patch| patch.max_bond_dim() == 1));
+        assert!(result
+            .iter()
+            .all(|patch| patch.projector().get(&site0).is_some()));
+        assert!(
+            (result
+                .iter()
+                .map(|patch| patch.norm_squared().unwrap())
+                .sum::<f64>()
+                - 2.0)
+                .abs()
+                < 1.0e-12
+        );
     }
 
     #[test]

--- a/crates/tensor4all-partitionedtt/src/patching.rs
+++ b/crates/tensor4all-partitionedtt/src/patching.rs
@@ -7,12 +7,17 @@
 //! complex use cases. The core functionality relies on TT addition which
 //! is now implemented.
 
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
 use crate::error::{PartitionedTTError, Result};
 use crate::partitioned_tt::PartitionedTT;
 use crate::projector::Projector;
 use crate::subdomain_tt::SubDomainTT;
 use tensor4all_core::{DynIndex, SvdTruncationPolicy};
 use tensor4all_itensorlike::{ContractOptions, TruncateOptions};
+
+type ContractGroup = (Vec<(SubDomainTT, SubDomainTT)>, Vec<SubDomainTT>);
 
 #[derive(Debug, Clone)]
 struct PatchStats {
@@ -281,12 +286,223 @@ pub fn contract_adaptive(
     patching_options: &PatchingOptions,
 ) -> Result<PartitionedTT> {
     validate_patching_options(patching_options)?;
-    let contracted = left.contract(right, contract_options)?;
+    let mut left_patches: Vec<_> = left.values().collect();
+    let mut right_patches: Vec<_> = right.values().collect();
+    left_patches.sort_by(|a, b| {
+        a.projector()
+            .partial_cmp(b.projector())
+            .unwrap_or(Ordering::Equal)
+    });
+    right_patches.sort_by(|a, b| {
+        a.projector()
+            .partial_cmp(b.projector())
+            .unwrap_or(Ordering::Equal)
+    });
+
+    let mut groups: HashMap<Projector, ContractGroup> = HashMap::new();
+    for left_patch in left_patches {
+        for right_patch in &right_patches {
+            if let Some(contribution) = left_patch.contract(right_patch, contract_options)? {
+                let entry = groups.entry(contribution.projector().clone()).or_default();
+                entry.0.push((left_patch.clone(), (*right_patch).clone()));
+                entry.1.push(contribution);
+            }
+        }
+    }
+
+    let mut grouped: Vec<_> = groups.into_iter().collect();
+    grouped.sort_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    let mut subdomains = Vec::new();
+    for (_, (pairs, contributions)) in grouped {
+        subdomains.extend(contract_group_project_first(
+            pairs,
+            Some(contributions),
+            contract_options,
+            patching_options,
+        )?);
+    }
+    let contracted = PartitionedTT::from_subdomains(subdomains)?;
     truncate_adaptive(
         &contracted,
         patching_options.rtol,
         patching_options.max_bond_dim,
     )
+}
+
+fn contract_group_project_first(
+    pairs: Vec<(SubDomainTT, SubDomainTT)>,
+    precomputed: Option<Vec<SubDomainTT>>,
+    contract_options: &ContractOptions,
+    patching_options: &PatchingOptions,
+) -> Result<Vec<SubDomainTT>> {
+    let contributions = if let Some(contributions) = precomputed {
+        contributions
+    } else {
+        let mut contributions = Vec::with_capacity(pairs.len());
+        for (left, right) in &pairs {
+            if let Some(contribution) = left.contract(right, contract_options)? {
+                contributions.push(contribution);
+            }
+        }
+        contributions
+    };
+    let mut iter = contributions.iter();
+    let Some(first) = iter.next() else {
+        return Ok(Vec::new());
+    };
+    let projector = first.projector().clone();
+    let mut sum = first.data().clone();
+    let truncation = truncation_options_from_contract(contract_options);
+    for contribution in iter {
+        sum = sum
+            .add_reindexed_like_self(contribution.data())
+            .map_err(|source| PartitionedTTError::TensorTrain { source })?;
+        sum.truncate(&truncation)
+            .map_err(|source| PartitionedTTError::TensorTrain { source })?;
+    }
+    let probe = SubDomainTT::new(sum, projector)?;
+
+    let Some(cap) = patching_options.max_bond_dim else {
+        return Ok(vec![probe]);
+    };
+    let saturated = probe.max_bond_dim() >= cap
+        || contributions
+            .iter()
+            .any(|contribution| contribution.max_bond_dim() >= cap);
+    if !saturated {
+        return Ok(vec![probe]);
+    }
+    let probe = assign_volume_budgets(vec![probe], patching_options.rtol)?
+        .pop()
+        .ok_or(PartitionedTTError::Empty)?;
+    let Some(index) = choose_split_index(&probe, patching_options)? else {
+        return Ok(vec![probe]);
+    };
+
+    let mut children = Vec::with_capacity(index.dim);
+    for value in 0..index.dim {
+        let mut child_pairs = Vec::with_capacity(pairs.len());
+        let mut projected_left = HashMap::new();
+        let mut projected_right = HashMap::new();
+        for (left, right) in &pairs {
+            let left_key = left.projector().clone();
+            if !projected_left.contains_key(&left_key) {
+                projected_left.insert(left_key.clone(), project_if_present(left, &index, value)?);
+            }
+            let right_key = right.projector().clone();
+            if !projected_right.contains_key(&right_key) {
+                projected_right
+                    .insert(right_key.clone(), project_if_present(right, &index, value)?);
+            }
+            if let (Some(child_left), Some(child_right)) = (
+                projected_left.get(&left_key).cloned().flatten(),
+                projected_right.get(&right_key).cloned().flatten(),
+            ) {
+                child_pairs.push((child_left, child_right));
+            }
+        }
+        children.extend(contract_group_project_first(
+            child_pairs,
+            None,
+            contract_options,
+            patching_options,
+        )?);
+    }
+    Ok(children)
+}
+
+#[cfg(test)]
+fn add_project_first(
+    contributions: Vec<SubDomainTT>,
+    contract_options: &ContractOptions,
+    patching_options: &PatchingOptions,
+) -> Result<Vec<SubDomainTT>> {
+    let mut iter = contributions.iter();
+    let Some(first) = iter.next() else {
+        return Ok(Vec::new());
+    };
+    let projector = first.projector().clone();
+    let mut sum = first.data().clone();
+    let truncation = truncation_options_from_contract(contract_options);
+    for contribution in iter {
+        sum = sum
+            .add_reindexed_like_self(contribution.data())
+            .map_err(|source| PartitionedTTError::TensorTrain { source })?;
+        sum.truncate(&truncation)
+            .map_err(|source| PartitionedTTError::TensorTrain { source })?;
+    }
+    let probe = SubDomainTT::new(sum, projector)?;
+
+    let Some(cap) = patching_options.max_bond_dim else {
+        return Ok(vec![probe]);
+    };
+    if probe.max_bond_dim() < cap {
+        return Ok(vec![probe]);
+    }
+    let probe = assign_volume_budgets(vec![probe], patching_options.rtol)?
+        .pop()
+        .ok_or(PartitionedTTError::Empty)?;
+    let Some(index) = choose_split_index(&probe, patching_options)? else {
+        return Ok(vec![probe]);
+    };
+
+    let mut children = Vec::new();
+    for value in 0..index.dim {
+        let mut projected = Vec::with_capacity(contributions.len());
+        for contribution in &contributions {
+            if let Some(child) = project_if_present(contribution, &index, value)? {
+                projected.push(child);
+            }
+        }
+        children.extend(add_project_first(
+            projected,
+            contract_options,
+            patching_options,
+        )?);
+    }
+    Ok(children)
+}
+
+fn project_if_present(
+    subdomain: &SubDomainTT,
+    index: &DynIndex,
+    value: usize,
+) -> Result<Option<SubDomainTT>> {
+    if !subdomain
+        .all_indices()
+        .iter()
+        .any(|candidate| candidate == index)
+    {
+        return Ok(Some(subdomain.clone()));
+    }
+    let Some(mut projected) =
+        subdomain.project(&Projector::from_pairs([(index.clone(), value)])?)?
+    else {
+        return Ok(None);
+    };
+    let first = projected
+        .data()
+        .tensor(0)
+        .map_err(|source| PartitionedTTError::TensorTrain { source })?;
+    let threshold = if first.is_f32() || first.is_c32() {
+        64.0 * f32::EPSILON as f64
+    } else {
+        64.0 * f64::EPSILON
+    };
+    projected
+        .truncate(&TruncateOptions::svd().with_svd_policy(SvdTruncationPolicy::new(threshold)))?;
+    Ok(Some(projected))
+}
+
+fn truncation_options_from_contract(options: &ContractOptions) -> TruncateOptions {
+    let mut truncation = TruncateOptions::svd();
+    if let Some(policy) = options.svd_policy() {
+        truncation = truncation.with_svd_policy(policy);
+    }
+    if let Some(max_bond_dim) = options.max_bond_dim() {
+        truncation = truncation.with_max_bond_dim(max_bond_dim);
+    }
+    truncation
 }
 
 /// Truncate a partitioned tensor train with volume-proportional absolute budgets.

--- a/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
+++ b/crates/tensor4all-partitionedtt/src/patching/tests/mod.rs
@@ -104,6 +104,71 @@ fn make_contract_tt(
 }
 
 #[test]
+fn projection_removes_exact_zero_bond_space_without_error_budget() {
+    let site0 = make_index(2);
+    let site1 = make_index(2);
+    let bond = make_index(2);
+    let train = TensorTrain::new(vec![
+        IdxTensor::from_dense(vec![site0.clone(), bond.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap(),
+        IdxTensor::from_dense(vec![bond, site1], vec![1.0, 0.0, 0.0, 1.0]).unwrap(),
+    ])
+    .unwrap();
+    let subdomain = SubDomainTT::from_tt(train);
+    let projector = Projector::from_pairs([(site0.clone(), 0)]).unwrap();
+    let projected = subdomain.project(&projector).unwrap().unwrap();
+    let compressed = project_if_present(&subdomain, &site0, 0).unwrap().unwrap();
+
+    assert_eq!(projected.max_bond_dim(), 2);
+    assert_eq!(compressed.max_bond_dim(), 1);
+    assert_abs_diff_eq!(
+        compressed.norm_squared().unwrap(),
+        projected.norm_squared().unwrap(),
+        epsilon = 1.0e-12
+    );
+}
+
+#[test]
+fn adaptive_add_projects_original_addends_before_retrying() {
+    let site0 = make_index(2);
+    let site1 = make_index(2);
+    let product = |left_values: Vec<f64>, right_values: Vec<f64>| {
+        let bond = make_index(1);
+        TensorTrain::new(vec![
+            IdxTensor::from_dense(vec![site0.clone(), bond.clone()], left_values).unwrap(),
+            IdxTensor::from_dense(vec![bond, site1.clone()], right_values).unwrap(),
+        ])
+        .unwrap()
+    };
+    let contributions = vec![
+        SubDomainTT::from_tt(product(vec![1.0, 0.0], vec![1.0, 0.0])),
+        SubDomainTT::from_tt(product(vec![0.0, 1.0], vec![0.0, 1.0])),
+    ];
+    let contraction = ContractOptions::default().with_max_bond_dim(1);
+    let patching = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        patch_order: vec![site0.clone()],
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
+
+    let result = add_project_first(contributions, &contraction, &patching).unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!(result.iter().all(|patch| patch.max_bond_dim() == 1));
+    assert!(result
+        .iter()
+        .all(|patch| patch.projector().get(&site0).is_some()));
+    assert_abs_diff_eq!(
+        result
+            .iter()
+            .map(|patch| patch.norm_squared().unwrap())
+            .sum::<f64>(),
+        2.0,
+        epsilon = 1.0e-12
+    );
+}
+
+#[test]
 fn test_add_with_patching_simple() {
     let (site_inds, link_ind) = make_shared_indices();
 
@@ -221,6 +286,54 @@ fn test_truncate_adaptive_rejects_invalid_options() {
 
     let bad_rank = truncate_adaptive(&empty, 1e-12, Some(0)).unwrap_err();
     assert!(matches!(bad_rank, PartitionedTTError::InvalidOptions(_)));
+}
+
+#[test]
+fn contract_adaptive_recomputes_projected_child_operands() {
+    let shared = [make_index(2), make_index(2)];
+    let output_left = [make_index(2), make_index(2)];
+    let output_right = [make_index(2), make_index(2)];
+    let build = |outputs: &[DynIndex; 2], offset: f64| {
+        let bond = make_index(2);
+        TensorTrain::new(vec![
+            IdxTensor::from_dense(
+                vec![outputs[0].clone(), shared[0].clone(), bond.clone()],
+                (0..8).map(|i| offset + f64::from(i) / 10.0).collect(),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![bond, outputs[1].clone(), shared[1].clone()],
+                (0..8).map(|i| offset + 1.0 + f64::from(i) / 10.0).collect(),
+            )
+            .unwrap(),
+        ])
+        .unwrap()
+    };
+    let left =
+        PartitionedTT::from_subdomain(SubDomainTT::from_tt(build(&output_left, 1.0))).unwrap();
+    let right =
+        PartitionedTT::from_subdomain(SubDomainTT::from_tt(build(&output_right, 2.0))).unwrap();
+    let patching = PatchingOptions {
+        rtol: 0.0,
+        max_bond_dim: Some(1),
+        patch_order: vec![output_left[0].clone()],
+        split_strategy: PatchSplitStrategy::Sequential,
+    };
+
+    let result = contract_adaptive(
+        &left,
+        &right,
+        &ContractOptions::default().with_max_bond_dim(1),
+        &patching,
+    )
+    .unwrap();
+
+    assert_eq!(result.len(), 2);
+    assert!(result
+        .values()
+        .all(|patch| patch.projector().get(&output_left[0]).is_some()));
+    assert!(result.values().all(|patch| patch.max_bond_dim() <= 1));
+    assert!(result.norm().unwrap() > 0.0);
 }
 
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/contraction.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction.rs
@@ -32,6 +32,24 @@ fn indices_except_exact<I: IndexLike>(indices: &[I], excluded: &[I]) -> Vec<I> {
     tensor4all_core::index_ops::unique_inds(indices, excluded)
 }
 
+fn zipup_factorize_options(
+    canonical: Canonical,
+    svd_policy: Option<SvdTruncationPolicy>,
+    max_bond_dim: Option<usize>,
+) -> Result<FactorizeOptions> {
+    let mut options = FactorizeOptions::svd().with_canonical(canonical);
+    if let Some(max_bond_dim) = max_bond_dim {
+        options = options.with_max_bond_dim(max_bond_dim);
+    }
+    if let Some(policy) = svd_policy {
+        options = options.with_svd_policy(policy);
+    }
+    options
+        .validate()
+        .map_err(|err| anyhow::anyhow!("invalid zipup factorization options: {err}"))?;
+    Ok(options)
+}
+
 impl<T, V> TreeTN<T, V>
 where
     T: TensorLike,
@@ -363,6 +381,390 @@ where
         )
     }
 
+    fn chain_order(&self, center: &V) -> Option<Vec<V>>
+    where
+        V: Ord,
+    {
+        let graph = self.graph.graph();
+        let node_count = graph.node_count();
+        if node_count == 0 || self.node_index(center).is_none() {
+            return None;
+        }
+        if node_count == 1 {
+            return Some(vec![center.clone()]);
+        }
+        if graph.edge_count() != node_count - 1 {
+            return None;
+        }
+
+        let mut endpoints: Vec<(NodeIndex, V)> = graph
+            .node_indices()
+            .filter(|node| graph.neighbors_undirected(*node).count() == 1)
+            .filter_map(|node| self.graph.node_name(node).cloned().map(|name| (node, name)))
+            .collect();
+        if endpoints.len() != 2 {
+            return None;
+        }
+        endpoints.sort_by(|(_, a), (_, b)| a.cmp(b));
+
+        let (start, end) = if center == &endpoints[0].1 {
+            (endpoints[1].0, endpoints[0].0)
+        } else {
+            (endpoints[0].0, endpoints[1].0)
+        };
+
+        let mut path = Vec::with_capacity(node_count);
+        let mut previous = None;
+        let mut current = start;
+        loop {
+            path.push(self.graph.node_name(current)?.clone());
+            if current == end {
+                break;
+            }
+            let next = graph
+                .neighbors_undirected(current)
+                .find(|node| Some(*node) != previous)?;
+            previous = Some(current);
+            current = next;
+            if path.len() > node_count {
+                return None;
+            }
+        }
+        (path.len() == node_count).then_some(path)
+    }
+
+    // Inspired by ITensorMPS.jl v0.3.45, commit 794c97d, src/mpo.jl;
+    // independently implemented via Rust APIs.
+    fn contract_zipup_chain(
+        &self,
+        other: &Self,
+        center: &V,
+        chain: &[V],
+        svd_policy: Option<SvdTruncationPolicy>,
+        max_bond_dim: Option<usize>,
+        topology_mode: ZipupTopologyMode,
+    ) -> Result<Self>
+    where
+        V: Ord,
+        <T::Index as IndexLike>::Id:
+            Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    {
+        let node_count = chain.len();
+        if node_count == 0 {
+            return Err(anyhow::anyhow!("contract_zipup: empty chain"));
+        }
+
+        // Put both operands in exact QR form at the first sweep site before
+        // changing their internal indices. This keeps the zip-up remainder
+        // well-conditioned without altering either caller-owned operand.
+        let mut tn_a = self.clone();
+        let mut tn_b = other.clone();
+        tn_a.canonicalize_impl(
+            [chain[0].clone()],
+            CanonicalForm::Unitary,
+            "contract_zipup: first operand QR",
+        )?;
+        tn_b.canonicalize_impl(
+            [chain[0].clone()],
+            CanonicalForm::Unitary,
+            "contract_zipup: second operand QR",
+        )?;
+        let tn_a = tn_a.sim_internal_inds();
+        let tn_b = tn_b.sim_internal_inds();
+
+        if node_count == 1 {
+            let node_a = tn_a
+                .node_index(&chain[0])
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: single node missing"))?;
+            let node_b = tn_b
+                .node_index(&chain[0])
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: single node missing"))?;
+            let tensor_a = tn_a
+                .tensor(node_a)
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: single tensor missing"))?;
+            let tensor_b = tn_b
+                .tensor(node_b)
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: single tensor missing"))?;
+            let contracted = tensor_a.contract_pair(tensor_b)?;
+            let mut result = TreeTN::new();
+            result.add_tensor(chain[0].clone(), contracted)?;
+            result.set_canonical_region([center.clone()])?;
+            return Ok(result);
+        }
+
+        let factorize_left = zipup_factorize_options(Canonical::Left, svd_policy, max_bond_dim)?;
+        let factorize_right = zipup_factorize_options(Canonical::Right, svd_policy, max_bond_dim)?;
+        let mut remainder: Option<T> = None;
+        let mut result_tensors: HashMap<V, T> = HashMap::new();
+        let mut result_bonds: Vec<Option<T::Index>> = vec![None; node_count - 1];
+
+        // Contract and factorize all but the final two sites. The multi-tensor
+        // planner owns the order of R + A + B.
+        for site in 0..node_count.saturating_sub(2) {
+            let node = &chain[site];
+            let next = &chain[site + 1];
+            let node_a = tn_a.node_index(node).ok_or_else(|| {
+                anyhow::anyhow!("contract_zipup: node missing from first operand")
+            })?;
+            let node_b = tn_b.node_index(node).ok_or_else(|| {
+                anyhow::anyhow!("contract_zipup: node missing from second operand")
+            })?;
+            let tensor_a = tn_a
+                .tensor(node_a)
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: first site tensor missing"))?;
+            let tensor_b = tn_b
+                .tensor(node_b)
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: second site tensor missing"))?;
+            let right_a = tn_a
+                .edge_between(node, next)
+                .and_then(|edge| tn_a.bond_index(edge))
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: first site bond missing"))?;
+            let right_b = tn_b
+                .edge_between(node, next)
+                .and_then(|edge| tn_b.bond_index(edge))
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: second site bond missing"))?;
+
+            let contracted = if let Some(ref remainder) = remainder {
+                T::contract(&[remainder, tensor_a, tensor_b])
+                    .context("contract_zipup: site contraction failed")?
+            } else {
+                tensor_a
+                    .contract_pair(tensor_b)
+                    .context("contract_zipup: first site contraction failed")?
+            };
+            let left_inds =
+                indices_except_exact(&contracted.external_indices(), &[right_a, right_b]);
+
+            if left_inds.is_empty() {
+                match topology_mode {
+                    ZipupTopologyMode::PruneScalarSubtrees => {
+                        remainder = Some(contracted);
+                    }
+                    ZipupTopologyMode::PreserveInputTopology => {
+                        let (dummy_left, dummy_right) = T::Index::create_dummy_link_pair();
+                        let left_tensor = T::ones(std::slice::from_ref(&dummy_left))
+                            .context("contract_zipup: dummy left tensor failed")?;
+                        let dummy_right_tensor = T::ones(std::slice::from_ref(&dummy_right))
+                            .context("contract_zipup: dummy right tensor failed")?;
+                        let right_tensor = contracted
+                            .outer_product(&dummy_right_tensor)
+                            .context("contract_zipup: dummy bond failed")?;
+                        result_tensors.insert(node.clone(), left_tensor);
+                        result_bonds[site] = Some(dummy_left);
+                        remainder = Some(right_tensor);
+                    }
+                }
+                continue;
+            }
+
+            let factorized = contracted
+                .factorize_auto(&left_inds, &factorize_left)
+                .context("contract_zipup: site factorization failed")?;
+            result_bonds[site] = Some(factorized.bond_index.clone());
+            result_tensors.insert(node.clone(), factorized.left);
+            remainder = Some(factorized.right);
+        }
+
+        // Contract the final two sites as one block, then factorize once. This
+        // is the ITensorMPS schedule and leaves the numerical center at the
+        // penultimate site before the final center reconciliation below.
+        let penultimate = &chain[node_count - 2];
+        let last = &chain[node_count - 1];
+        let penultimate_a = tn_a
+            .node_index(penultimate)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: penultimate node missing"))?;
+        let penultimate_b = tn_b
+            .node_index(penultimate)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: penultimate node missing"))?;
+        let last_a = tn_a
+            .node_index(last)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: last node missing"))?;
+        let last_b = tn_b
+            .node_index(last)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: last node missing"))?;
+        let penultimate_tensor_a = tn_a
+            .tensor(penultimate_a)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: penultimate tensor missing"))?;
+        let penultimate_tensor_b = tn_b
+            .tensor(penultimate_b)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: penultimate tensor missing"))?;
+        let last_tensor_a = tn_a
+            .tensor(last_a)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: last tensor missing"))?;
+        let last_tensor_b = tn_b
+            .tensor(last_b)
+            .ok_or_else(|| anyhow::anyhow!("contract_zipup: last tensor missing"))?;
+        let final_block = if let Some(ref remainder) = remainder {
+            T::contract(&[
+                remainder,
+                penultimate_tensor_a,
+                penultimate_tensor_b,
+                last_tensor_a,
+                last_tensor_b,
+            ])
+            .context("contract_zipup: final block contraction failed")?
+        } else {
+            let block_a = penultimate_tensor_a
+                .contract_pair(last_tensor_a)
+                .context("contract_zipup: first final operand failed")?;
+            let block_b = penultimate_tensor_b
+                .contract_pair(last_tensor_b)
+                .context("contract_zipup: second final operand failed")?;
+            block_a
+                .contract_pair(&block_b)
+                .context("contract_zipup: final operand contraction failed")?
+        };
+        let final_indices = final_block.external_indices();
+        let last_sites: HashSet<T::Index> = tn_a
+            .site_space(last)
+            .into_iter()
+            .flatten()
+            .chain(tn_b.site_space(last).into_iter().flatten())
+            .cloned()
+            .collect();
+        let left_inds: Vec<T::Index> = final_indices
+            .iter()
+            .filter(|index| !last_sites.contains(*index))
+            .cloned()
+            .collect();
+        let right_inds_exist = final_indices.iter().any(|index| last_sites.contains(index));
+
+        if left_inds.is_empty() || !right_inds_exist {
+            match topology_mode {
+                ZipupTopologyMode::PruneScalarSubtrees => {
+                    result_tensors.insert(
+                        if left_inds.is_empty() {
+                            last.clone()
+                        } else {
+                            penultimate.clone()
+                        },
+                        final_block,
+                    );
+                }
+                ZipupTopologyMode::PreserveInputTopology => {
+                    let (dummy_left, dummy_right) = T::Index::create_dummy_link_pair();
+                    let (left_tensor, right_tensor) = if left_inds.is_empty() {
+                        let left = T::ones(std::slice::from_ref(&dummy_left))
+                            .context("contract_zipup: final dummy left failed")?;
+                        let right_dummy = T::ones(std::slice::from_ref(&dummy_right))
+                            .context("contract_zipup: final dummy right failed")?;
+                        (
+                            left,
+                            final_block
+                                .outer_product(&right_dummy)
+                                .context("contract_zipup: final dummy bond failed")?,
+                        )
+                    } else {
+                        let left_dummy = T::ones(std::slice::from_ref(&dummy_left))
+                            .context("contract_zipup: final dummy left failed")?;
+                        let right = T::ones(std::slice::from_ref(&dummy_right))
+                            .context("contract_zipup: final dummy right failed")?;
+                        (
+                            final_block
+                                .outer_product(&left_dummy)
+                                .context("contract_zipup: final dummy bond failed")?,
+                            right,
+                        )
+                    };
+                    result_tensors.insert(penultimate.clone(), left_tensor);
+                    result_tensors.insert(last.clone(), right_tensor);
+                    result_bonds[node_count - 2] = Some(dummy_left);
+                }
+            }
+        } else {
+            let factorized = final_block
+                .factorize_auto(&left_inds, &factorize_right)
+                .context("contract_zipup: final block factorization failed")?;
+            result_bonds[node_count - 2] = Some(factorized.bond_index);
+            result_tensors.insert(penultimate.clone(), factorized.left);
+            result_tensors.insert(last.clone(), factorized.right);
+        }
+
+        let mut result = TreeTN::new();
+        for node in chain {
+            if let Some(tensor) = result_tensors.remove(node) {
+                result.add_tensor(node.clone(), tensor)?;
+            }
+        }
+        for (site, bond) in result_bonds.into_iter().enumerate() {
+            let Some(bond) = bond else { continue };
+            let Some(left) = result.node_index(&chain[site]) else {
+                continue;
+            };
+            let Some(right) = result.node_index(&chain[site + 1]) else {
+                continue;
+            };
+            if result
+                .tensor(left)
+                .is_some_and(|tensor| tensor.external_indices().contains(&bond))
+                && result
+                    .tensor(right)
+                    .is_some_and(|tensor| tensor.external_indices().contains(&bond))
+            {
+                result.connect_internal(left, &bond, right, &bond)?;
+            }
+        }
+
+        let seed = if result.node_index(penultimate).is_some() {
+            penultimate.clone()
+        } else if result.node_index(center).is_some() {
+            center.clone()
+        } else {
+            result
+                .node_names()
+                .into_iter()
+                .min()
+                .ok_or_else(|| anyhow::anyhow!("contract_zipup: result has no nodes"))?
+        };
+        result.set_canonical_region([seed.clone()])?;
+
+        let seed_pos = chain.iter().position(|node| node == &seed);
+        let directions: Vec<_> = result
+            .graph
+            .graph()
+            .edge_indices()
+            .filter_map(|edge| {
+                let (a, b) = result.graph.graph().edge_endpoints(edge)?;
+                let a_name = result.graph.node_name(a)?.clone();
+                let b_name = result.graph.node_name(b)?.clone();
+                let a_pos = chain.iter().position(|node| node == &a_name)?;
+                let b_pos = chain.iter().position(|node| node == &b_name)?;
+                let target = match seed_pos {
+                    Some(seed_pos)
+                        if (a_pos as isize - seed_pos as isize).abs()
+                            < (b_pos as isize - seed_pos as isize).abs() =>
+                    {
+                        a_name
+                    }
+                    _ => b_name,
+                };
+                Some((edge, target))
+            })
+            .collect();
+        for (edge, target) in directions {
+            result.set_edge_ortho_towards(edge, Some(target))?;
+        }
+
+        if result.node_index(center).is_some() {
+            match topology_mode {
+                ZipupTopologyMode::PruneScalarSubtrees => result.truncate_impl(
+                    [center.clone()],
+                    svd_policy,
+                    max_bond_dim,
+                    "contract_zipup: final truncate",
+                )?,
+                ZipupTopologyMode::PreserveInputTopology => result.canonicalize_impl(
+                    [center.clone()],
+                    CanonicalForm::Unitary,
+                    "contract_zipup: move center",
+                )?,
+            }
+        }
+        Ok(result)
+    }
+
     fn contract_zipup_impl(
         &self,
         other: &Self,
@@ -382,6 +784,30 @@ where
             return Err(anyhow::anyhow!(
                 "contract_zipup_with: networks have incompatible topologies"
             ));
+        }
+
+        if form == CanonicalForm::Unitary {
+            let has_output_sites = self.node_names().into_iter().any(|node| {
+                let Some(a) = self.site_space(&node) else {
+                    return false;
+                };
+                let Some(b) = other.site_space(&node) else {
+                    return true;
+                };
+                a != b
+            });
+            if has_output_sites {
+                if let Some(chain) = self.chain_order(center) {
+                    return self.contract_zipup_chain(
+                        other,
+                        center,
+                        &chain,
+                        svd_policy,
+                        max_bond_dim,
+                        topology_mode,
+                    );
+                }
+            }
         }
 
         // 2. Replace internal indices with fresh IDs to avoid collision

--- a/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/contraction/tests/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use num_complex::Complex64;
 use tensor4all_core::{
     DynIndex, IdxTensor, IndexLike, SvdTruncationPolicy, TensorContractionLike, TensorIndex,
 };
@@ -241,6 +242,520 @@ fn test_contract_zipup_topology_mismatch() {
 
     let result = tn1.contract_zipup(&tn2, &"A".to_string(), None, None);
     assert!(result.is_err());
+}
+
+#[test]
+fn zipup_chain_result_has_consistent_canonical_center() {
+    let site_a = DynIndex::new_dyn(2);
+    let site_b = DynIndex::new_dyn(2);
+    let output_a = DynIndex::new_dyn(2);
+    let output_b = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let tensor_a =
+        IdxTensor::from_dense(vec![site_a, output_a, bond.clone()], vec![1.0; 8]).unwrap();
+    let tensor_b = IdxTensor::from_dense(vec![bond, site_b, output_b], vec![1.0; 8]).unwrap();
+    let tn = TreeTN::<IdxTensor, String>::from_tensors(
+        vec![tensor_a, tensor_b],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+
+    let result = tn
+        .contract_zipup(
+            &tn,
+            &"B".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        result.canonical_region(),
+        &["B".to_string()].into_iter().collect()
+    );
+    result.validate_ortho_consistency().unwrap();
+}
+
+fn make_chain_pair_with_outputs(
+    output_sites: &[bool],
+) -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
+    let len = output_sites.len();
+    let shared = (0..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_a = (0..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_b = (0..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_a = (1..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_b = (1..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let names = (0..len).map(|i| format!("S{i}")).collect::<Vec<_>>();
+    let build = |bonds: &[DynIndex], outputs: &[DynIndex], offset: f64| {
+        let tensors = (0..len)
+            .map(|i| {
+                let mut indices = Vec::new();
+                if i > 0 {
+                    indices.push(bonds[i - 1].clone());
+                }
+                indices.push(shared[i].clone());
+                if output_sites[i] {
+                    indices.push(outputs[i].clone());
+                }
+                if i + 1 < len {
+                    indices.push(bonds[i].clone());
+                }
+                let size = indices.iter().map(IndexLike::dim).product();
+                IdxTensor::from_dense(
+                    indices,
+                    (0..size).map(|j| offset + (j + 1) as f64 / 10.0).collect(),
+                )
+                .unwrap()
+            })
+            .collect();
+        TreeTN::from_tensors(tensors, names.clone()).unwrap()
+    };
+    (
+        build(&bonds_a, &output_a, 1.0),
+        build(&bonds_b, &output_b, 2.0),
+    )
+}
+
+fn assert_zipup_matches_naive(
+    actual: &TreeTN<IdxTensor, String>,
+    left: &TreeTN<IdxTensor, String>,
+    right: &TreeTN<IdxTensor, String>,
+) {
+    let expected = left.contract_naive(right).unwrap();
+    let error = actual
+        .to_dense()
+        .unwrap()
+        .sub(&expected)
+        .unwrap()
+        .maxabs()
+        .unwrap();
+    assert!(error < 1e-9, "exact zip-up residual is {error}");
+    actual.validate_ortho_consistency().unwrap();
+}
+
+#[test]
+fn zipup_preserving_topology_keeps_leading_scalar_node() {
+    let (left, right) = make_chain_pair_with_outputs(&[false, true, true]);
+    let actual = left
+        .contract_zipup_preserving_topology_with(
+            &right,
+            &"S2".to_string(),
+            CanonicalForm::Unitary,
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(actual.node_count(), 3);
+    assert_eq!(actual.edge_count(), 2);
+    assert_zipup_matches_naive(&actual, &left, &right);
+}
+
+#[test]
+fn zipup_preserving_topology_keeps_scalar_side_of_final_block() {
+    for output_sites in [[false, true], [true, false]] {
+        let (left, right) = make_chain_pair_with_outputs(&output_sites);
+        let actual = left
+            .contract_zipup_preserving_topology_with(
+                &right,
+                &"S1".to_string(),
+                CanonicalForm::Unitary,
+                Some(SvdTruncationPolicy::new(0.0)),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(actual.node_count(), 2);
+        assert_eq!(actual.edge_count(), 1);
+        assert_zipup_matches_naive(&actual, &left, &right);
+    }
+}
+
+#[test]
+fn zipup_prune_mode_keeps_middle_scalar_node_factorized() {
+    let (left, right) = make_chain_pair_with_outputs(&[true, false, true]);
+    let actual = left
+        .contract_zipup(
+            &right,
+            &"S2".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(actual.node_count(), 3);
+    assert_eq!(actual.edge_count(), 2);
+    assert_zipup_matches_naive(&actual, &left, &right);
+}
+
+fn make_three_node_chain_pair() -> (TreeTN<IdxTensor, String>, TreeTN<IdxTensor, String>) {
+    let shared = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_a = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_b = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_a = (0..2).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_b = (0..2).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+
+    let tn_a = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![shared[0].clone(), output_a[0].clone(), bonds_a[0].clone()],
+                (1..=8).map(f64::from).collect(),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![
+                    bonds_a[0].clone(),
+                    shared[1].clone(),
+                    output_a[1].clone(),
+                    bonds_a[1].clone(),
+                ],
+                (1..=16).map(|x| f64::from(x) / 3.0).collect(),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![bonds_a[1].clone(), shared[2].clone(), output_a[2].clone()],
+                (1..=8).map(|x| f64::from(x) / 5.0).collect(),
+            )
+            .unwrap(),
+        ],
+        vec!["A".to_string(), "B".to_string(), "C".to_string()],
+    )
+    .unwrap();
+    let tn_b = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![shared[0].clone(), output_b[0].clone(), bonds_b[0].clone()],
+                (2..=9).map(f64::from).collect(),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![
+                    bonds_b[0].clone(),
+                    shared[1].clone(),
+                    output_b[1].clone(),
+                    bonds_b[1].clone(),
+                ],
+                (2..=17).map(|x| f64::from(x) / 4.0).collect(),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![bonds_b[1].clone(), shared[2].clone(), output_b[2].clone()],
+                (2..=9).map(|x| f64::from(x) / 6.0).collect(),
+            )
+            .unwrap(),
+        ],
+        vec!["A".to_string(), "B".to_string(), "C".to_string()],
+    )
+    .unwrap();
+    (tn_a, tn_b)
+}
+
+#[test]
+fn zipup_chain_matches_naive_without_truncation() {
+    let (tn_a, tn_b) = make_three_node_chain_pair();
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    let actual = tn_a
+        .contract_zipup(
+            &tn_b,
+            &"C".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap()
+        .to_dense()
+        .unwrap();
+    let error = actual.sub(&expected).unwrap().maxabs().unwrap();
+    assert!(error < 1e-9, "exact zip-up residual is {error}");
+}
+
+#[test]
+fn zipup_complex_chain_matches_naive_without_truncation() {
+    let shared = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let output_a = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let output_b = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let bond_a = DynIndex::new_dyn(2);
+    let bond_b = DynIndex::new_dyn(2);
+    let values = |offset: f64| {
+        (0..8)
+            .map(|i| Complex64::new(offset + f64::from(i), 0.25 * f64::from(i)))
+            .collect()
+    };
+    let tn_a = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![shared[0].clone(), output_a[0].clone(), bond_a.clone()],
+                values(1.0),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![bond_a, shared[1].clone(), output_a[1].clone()],
+                values(2.0),
+            )
+            .unwrap(),
+        ],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+    let tn_b = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![shared[0].clone(), output_b[0].clone(), bond_b.clone()],
+                values(3.0),
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![bond_b, shared[1].clone(), output_b[1].clone()],
+                values(4.0),
+            )
+            .unwrap(),
+        ],
+        vec!["A".to_string(), "B".to_string()],
+    )
+    .unwrap();
+
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    let actual = tn_a
+        .contract_zipup(
+            &tn_b,
+            &"B".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap()
+        .to_dense()
+        .unwrap();
+    assert!(actual.distance(&expected).unwrap() < 1e-9);
+}
+
+#[test]
+fn zipup_mpo_mps_long_chain_stays_factorized() {
+    let len = 16;
+    let shared = (0..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output = (0..len).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_a = (1..len).map(|_| DynIndex::new_dyn(1)).collect::<Vec<_>>();
+    let bonds_b = (1..len).map(|_| DynIndex::new_dyn(1)).collect::<Vec<_>>();
+    let names = (0..len).map(|i| format!("S{i}")).collect::<Vec<_>>();
+    let mut tensors_a = Vec::with_capacity(len);
+    let mut tensors_b = Vec::with_capacity(len);
+    for i in 0..len {
+        let mut inds_a = Vec::new();
+        let mut inds_b = Vec::new();
+        if i > 0 {
+            inds_a.push(bonds_a[i - 1].clone());
+            inds_b.push(bonds_b[i - 1].clone());
+        }
+        inds_a.extend([shared[i].clone(), output[i].clone()]);
+        inds_b.push(shared[i].clone());
+        if i + 1 < len {
+            inds_a.push(bonds_a[i].clone());
+            inds_b.push(bonds_b[i].clone());
+        }
+        let len_a = inds_a.iter().map(IndexLike::dim).product();
+        let len_b = inds_b.iter().map(IndexLike::dim).product();
+        tensors_a.push(IdxTensor::from_dense(inds_a, vec![1.0; len_a]).unwrap());
+        tensors_b.push(IdxTensor::from_dense(inds_b, vec![1.0; len_b]).unwrap());
+    }
+    let tn_a = TreeTN::from_tensors(tensors_a, names.clone()).unwrap();
+    let tn_b = TreeTN::from_tensors(tensors_b, names.clone()).unwrap();
+
+    let result = tn_a
+        .contract_zipup(
+            &tn_b,
+            names.last().unwrap(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            Some(4),
+        )
+        .unwrap();
+    assert_eq!(result.node_count(), len);
+    assert_eq!(result.edge_count(), len - 1);
+    assert!(result
+        .graph
+        .graph()
+        .edge_indices()
+        .all(|edge| result.bond_index(edge).unwrap().dim() <= 4));
+    assert_eq!(
+        result.canonical_region(),
+        &[names[len - 1].clone()].into_iter().collect()
+    );
+    result.validate_ortho_consistency().unwrap();
+}
+
+#[test]
+fn zipup_chain_moves_interior_center_after_endpoint_sweep() {
+    let (tn_a, tn_b) = make_three_node_chain_pair();
+    let result = tn_a
+        .contract_zipup(
+            &tn_b,
+            &"B".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap();
+    assert_eq!(result.node_count(), 3);
+    assert_eq!(result.edge_count(), 2);
+    assert_eq!(
+        result.canonical_region(),
+        &["B".to_string()].into_iter().collect()
+    );
+    result.validate_ortho_consistency().unwrap();
+}
+
+#[test]
+fn zipup_chain_obeys_cap_and_reports_truncation_error() {
+    let (tn_a, tn_b) = make_three_node_chain_pair();
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    let result = tn_a
+        .contract_zipup(
+            &tn_b,
+            &"C".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            Some(1),
+        )
+        .unwrap();
+    assert!(result
+        .graph
+        .graph()
+        .edge_indices()
+        .all(|edge| result.bond_index(edge).unwrap().dim() <= 1));
+    let error = result
+        .to_dense()
+        .unwrap()
+        .sub(&expected)
+        .unwrap()
+        .maxabs()
+        .unwrap();
+    let relative_error = error / expected.maxabs().unwrap();
+    assert!(
+        (1e-8..0.1).contains(&relative_error),
+        "capped relative residual is {relative_error}"
+    );
+}
+
+#[test]
+fn zipup_branched_tree_uses_existing_fallback() {
+    let shared = (0..4).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_a = (0..4).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let output_b = (0..4).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_a = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let bonds_b = (0..3).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+    let build = |bonds: &[DynIndex], outputs: &[DynIndex]| {
+        TreeTN::from_tensors(
+            vec![
+                IdxTensor::from_dense(
+                    vec![
+                        bonds[0].clone(),
+                        bonds[1].clone(),
+                        bonds[2].clone(),
+                        shared[0].clone(),
+                        outputs[0].clone(),
+                    ],
+                    (1..=32).map(f64::from).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![bonds[0].clone(), shared[1].clone(), outputs[1].clone()],
+                    (1..=8).map(|x| f64::from(x) / 2.0).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![bonds[1].clone(), shared[2].clone(), outputs[2].clone()],
+                    (1..=8).map(|x| f64::from(x) / 3.0).collect(),
+                )
+                .unwrap(),
+                IdxTensor::from_dense(
+                    vec![bonds[2].clone(), shared[3].clone(), outputs[3].clone()],
+                    (1..=8).map(|x| f64::from(x) / 4.0).collect(),
+                )
+                .unwrap(),
+            ],
+            vec![
+                "A".to_string(),
+                "B".to_string(),
+                "C".to_string(),
+                "D".to_string(),
+            ],
+        )
+        .unwrap()
+    };
+    let tn_a = build(&bonds_a, &output_a);
+    let tn_b = build(&bonds_b, &output_b);
+    assert!(tn_a.chain_order(&"A".to_string()).is_none());
+    let result = tn_a
+        .contract_zipup(
+            &tn_b,
+            &"A".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap();
+    assert_eq!(result.node_count(), 4);
+    assert_eq!(result.edge_count(), 3);
+}
+
+#[test]
+fn zipup_single_node_with_surviving_output_matches_naive() {
+    let shared = DynIndex::new_dyn(2);
+    let output = DynIndex::new_dyn(2);
+    let tn_a = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![shared.clone(), output], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
+        ],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+    let tn_b = TreeTN::from_tensors(
+        vec![IdxTensor::from_dense(vec![shared], vec![2.0, 3.0]).unwrap()],
+        vec!["A".to_string()],
+    )
+    .unwrap();
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    let actual = tn_a
+        .contract_zipup(
+            &tn_b,
+            &"A".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap()
+        .to_dense()
+        .unwrap();
+    assert_eq!(
+        actual.to_vec::<f64>().unwrap(),
+        expected.to_vec::<f64>().unwrap()
+    );
+}
+
+#[test]
+fn zipup_one_and_two_node_cases_are_correct() {
+    let (two_node, _, _, _) = make_two_node_treetn();
+    let two_expected = two_node.contract_naive(&two_node).unwrap();
+    let two_actual = two_node
+        .contract_zipup(
+            &two_node,
+            &"A".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap()
+        .to_dense()
+        .unwrap();
+    assert!(two_actual.distance(&two_expected).unwrap() < 1e-9);
+
+    let site = DynIndex::new_dyn(2);
+    let tensor = IdxTensor::from_dense(vec![site], vec![1.0, 2.0]).unwrap();
+    let one_node = TreeTN::from_tensors(vec![tensor], vec!["A".to_string()]).unwrap();
+    let one_expected = one_node.contract_naive(&one_node).unwrap();
+    let one_actual = one_node
+        .contract_zipup(
+            &one_node,
+            &"A".to_string(),
+            Some(SvdTruncationPolicy::new(0.0)),
+            None,
+        )
+        .unwrap()
+        .to_dense()
+        .unwrap();
+    assert!(one_actual.distance(&one_expected).unwrap() < 1e-9);
 }
 
 #[test]

--- a/docs/PROVENANCE_AND_CITATION_POLICY.md
+++ b/docs/PROVENANCE_AND_CITATION_POLICY.md
@@ -61,6 +61,7 @@ relationship; the role is stated only on the first row.
 | `tensor4all-itensorlike` | TensorTrain API with orthogonality tracking | [ITensors.jl](https://github.com/ITensor/ITensors.jl) / ITensorMPS.jl | Inspired |
 | `tensor4all-treetn` | Tree tensor networks: canonicalization, DMRG, TDVP, linsolve, GSE | [ITensorNetworks.jl](https://github.com/ITensor/ITensorNetworks.jl) | Inspired (`TreeTN`, `SiteIndexNetwork` data structures) |
 | `tensor4all-treetn` | | [ITensorNetworks.jl](https://github.com/ITensor/ITensorNetworks.jl) | Derived (Apache-2.0): TDVP sweep plans (`src/tdvp/plan.rs`) |
+| `tensor4all-treetn` | | [ITensorMPS.jl](https://github.com/ITensor/ITensorMPS.jl) | Inspired (independent chain zip-up contraction schedule) |
 | `tensor4all-treetn` | | [NamedGraphs.jl](https://github.com/mtfishman/NamedGraphs.jl) | Inspired (named graph wrapper) |
 | `tensor4all-treetn` | | KrylovKit.jl | Compatible (linear/eigen solver conventions) |
 | `tensor4all-core` (TCI substrate, ex-`tensor4all-tcicore`) | rrLU / MatrixLUCI / cross-interpolation infrastructure | [TensorCrossInterpolation.jl](https://github.com/tensor4all/TensorCrossInterpolation.jl) | Port |
@@ -88,6 +89,7 @@ list is best-effort; corrections and additions are welcome.
 | DMRG | `treetn` | S. R. White, [Phys. Rev. Lett. 69, 2863 (1992)](https://doi.org/10.1103/PhysRevLett.69.2863); [Phys. Rev. B 48, 10345 (1993)](https://doi.org/10.1103/PhysRevB.48.10345) |
 | TDVP | `treetn` | J. Haegeman et al., [Phys. Rev. Lett. 107, 070601 (2011)](https://doi.org/10.1103/PhysRevLett.107.070601); [Phys. Rev. B 94, 165116 (2016)](https://doi.org/10.1103/PhysRevB.94.165116) |
 | Global subspace expansion (GSE) | `treetn` | M. Yang and S. R. White, [Phys. Rev. B 102, 094315 (2020)](https://doi.org/10.1103/PhysRevB.102.094315) |
+| Zip-up MPS/MPO contraction | `treetn` | S. Paeckel et al., [Ann. Phys. 411, 167998 (2019)](https://doi.org/10.1016/j.aop.2019.167998) |
 | Tensor cross interpolation / TT-cross | `core` (TCI substrate), `tensorci`, `treetci` | I. Oseledets and E. Tyrtyshnikov, [Linear Algebra Appl. 432, 70 (2010)](https://doi.org/10.1016/j.laa.2009.07.024); Y. Núñez Fernández et al., [Phys. Rev. X 12, 041018 (2022)](https://doi.org/10.1103/PhysRevX.12.041018); [SciPost Phys. 18, 104 (2025)](https://doi.org/10.21468/SciPostPhys.18.3.104) |
 | Quantics representation | `quanticstci`, `quanticstransform` | I. Oseledets, [SIAM J. Matrix Anal. Appl. 31, 2130 (2010)](https://doi.org/10.1137/090757861); B. Khoromskij, [Constr. Approx. 34, 257 (2011)](https://doi.org/10.1007/s00365-011-9131-1) |
 | Quantics tensor cross interpolation (QTCI) | `quanticstci` | M. K. Ritter, Y. Núñez Fernández, M. Wallerberger, J. von Delft, H. Shinaoka, X. Waintal, "Quantics Tensor Cross Interpolation for High-Resolution, Parsimonious Representations of Multivariate Functions in Physics and Beyond", [Phys. Rev. Lett. 132, 056501 (2024)](https://doi.org/10.1103/PhysRevLett.132.056501) |

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -18,6 +18,7 @@
 | [partitionedtt-projector-invariants.md](./partitionedtt-projector-invariants.md) | Issue #634 design for coherent projector identity, validation, and transactional PartitionedTT mutation |
 | [partitioned-treetn.md](./partitioned-treetn.md) | Issue #648 migration design for TreeTN-native eager partitioning and adaptive patching |
 | [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |
+| [itensormps-compatible-zipup.md](./itensormps-compatible-zipup.md) | ITensorMPS-compatible chain zip-up contraction schedule and policy-aware decomposition follow-up |
 
 ## Automatic Differentiation
 

--- a/docs/design/itensormps-compatible-zipup.md
+++ b/docs/design/itensormps-compatible-zipup.md
@@ -1,0 +1,219 @@
+# ITensorMPS-compatible chain zip-up contraction
+
+## Status
+
+Approved chain-schedule implementation, extended for implementation with
+policy-aware automatic SVD versus Hermitian-eigen factorization. The final
+staged diff was reviewed by `reviewer-flash-opencode-go`; after adding coverage
+for topology-preserving scalar-node branches, the fresh verdict was
+`Correct-to-merge`. A separately configurable coarse fit initializer remains
+follow-up work.
+
+## Reference
+
+The chain schedule is inspired by `ITensorMPS.jl` v0.3.45, commit `794c97d`,
+`src/mpo.jl`, method `ITensors.contract(::Algorithm"zipup", A::MPO,
+B::AbstractMPS; ...)`. The Rust implementation does not copy or translate
+upstream source code. It independently expresses the same algorithm through
+existing TreeTN contraction, canonicalization, and factorization APIs. Record
+this as algorithmic inspiration, not as a license-bearing code derivation.
+
+The relevant upstream schedule is:
+
+1. Orthogonalize both operands at the first sweep site.
+2. Carry an intermediate `R` and contract `R * A[i] * B[i]`.
+3. Factorize after each site through the third-to-last site.
+4. Contract the final two sites into one block and factorize that block once.
+5. Apply a final locally optimal truncation to a standalone zip-up result.
+
+## Problem
+
+The current TreeTN zip-up is a tree-general post-order implementation. On a
+chain it differs from ITensorMPS.jl in three material ways:
+
+- it does not orthogonalize both operands at the first sweep site;
+- it factorizes the penultimate site before contracting the last site;
+- it has no final locally optimal truncation sweep for standalone zip-up.
+
+Its internal contraction already submits accumulated intermediates and both
+site tensors to the FLOP-aware multi-tensor contraction planner. The planner,
+not source expression order, owns the contraction order. This change must not
+replace that planner with a hand-written pairwise contraction order.
+
+## Scope
+
+### Chain path
+
+Detect a chain from topology degrees, independently of the requested center.
+Use this path for unitary-form contractions with at least one surviving output
+site index; other forms and pure-scalar contractions retain the general path.
+Choose the requested center as the sweep endpoint when it is a chain endpoint.
+For an interior requested center, choose a deterministic endpoint, sweep to the
+opposite endpoint, then move the result center exactly to the requested node.
+For that path:
+
+1. Clone and orthogonalize each operand at the path's first node with exact QR.
+2. Replace internal bond identities independently in the two operands.
+3. Sweep toward the requested center, carrying the accumulated right factor.
+4. At each ordinary site, jointly contract the accumulated factor and both site
+   tensors through the existing multi-tensor contraction planner.
+5. Use the caller's current SVD policy and maximum bond dimension for local
+   factorization.
+6. Contract the final two sites into one block, then factorize once with the
+   right factor canonical, matching ITensorMPS.jl. This leaves the numerical
+   center on the penultimate site.
+7. Preserve the input topology when the path is used as a fit initializer. Move
+   the numerical center from the penultimate site to the requested center with
+   exact full-rank QR before returning the initializer.
+8. For the standalone chain zip-up API, perform one final truncation sweep with
+   the same policy and cap. The sweep finishes at the requested center and
+   therefore also reconciles the final two-site gauge.
+9. Keep pure-scalar contractions on the existing exact path. Canonicalizing a
+   contraction with no surviving site indices only adds floating-point
+   roundoff and provides no zip-up compression benefit.
+
+### General-tree path
+
+Keep the existing post-order tree-general implementation unchanged. There is no
+single ITensorMPS sweep order for a branched tree, and inventing one is outside
+this change.
+
+### Fit initialization
+
+`contract_fit` continues to use zip-up while preserving topology. The fit
+initializer skips the standalone final truncation because the following
+variational sweep is already locally optimal.
+
+A future option may use a looser initialization policy than the fit sweep. No
+hard-coded tolerance transformation is introduced here because
+`SvdTruncationPolicy` supports relative or absolute scaling, values or squared
+values, and per-value or discarded-tail rules.
+
+### Decomposition choice
+
+Add one method to `TensorFactorizationLike` for policy-aware automatic SVD or
+Hermitian-eigen factorization. Its default implementation delegates to the
+existing explicit factorization method, so generic tensor backends retain their
+current behavior. `IdxTensor` overrides it with the automatic implementation.
+The method accepts ordinary SVD `FactorizeOptions`; its default implementation
+and the `IdxTensor` override both reject other algorithms with
+`FactorizeError::InvalidOptions`. Explicit `FactorizeAlg::SVD` remains full SVD and therefore preserves
+current behavior. QR keeps its separate options and is not used because it
+cannot enforce a maximum retained bond dimension.
+
+Do not add a new `FactorizeAlg` variant or C API enum value. Auto is a concrete
+factorization operation used by zip-up, not a decomposition kind that every
+fit, canonicalization, partial-contraction, C API, and full-rank dispatch site
+must interpret.
+
+The automatic path uses Gram-matrix Hermitian eigendecomposition only for
+untracked `f64` and `Complex64` tensors when the policy gives a conservative
+effective relative eigenvalue cutoff greater than `1e-12`:
+
+- relative squared-value per-value: `threshold`;
+- relative squared-value discarded-tail-sum: `threshold`;
+- relative singular-value per-value: `threshold * threshold`;
+- relative singular-value discarded-tail-sum: fall back to SVD;
+- absolute policy: fall back to SVD;
+- absent policy, zero cutoff, or max-rank-only truncation: fall back to SVD.
+
+Tracked tensors fall back to SVD because the existing eigendecomposition API
+returns eigenvalues as host scalars and cannot preserve derivatives through the
+singular values.
+
+The retained rank after eigendecomposition must exactly preserve every
+`SvdTruncationPolicy` combination, including combinations that Auto currently
+routes to SVD. For each nonnegative Gram eigenvalue `lambda`, evaluate the
+policy on `sqrt(lambda)` for `SingularValueMeasure::Value` and on `lambda` for
+`SquaredValue`, then reuse the existing relative or absolute, per-value or
+discarded-tail rank logic, including minimum retained rank one even when every
+nonzero mode is below cutoff. Apply `max_bond_dim` afterward. Return retained
+`sqrt(lambda)` values in `FactorizeResult::singular_values`, matching SVD. Clamp
+only negative eigenvalues attributable to roundoff; reject materially negative
+eigenvalues.
+
+For an unfolded `m` by `n` matrix `A`:
+
+- when `m <= n`, diagonalize `A A^H`, retain `U`, and reconstruct
+  `V^H = Sigma^-1 U^H A`;
+- when `m > n`, diagonalize `A^H A`, retain `V`, and reconstruct
+  `U = A V Sigma^-1`.
+
+Build the smaller Gram tensor directly with native `IdxTensor` contraction;
+do not materialize the rectangular tensor as a host `Matrix`. Sort eigenpairs
+in descending order. Let `lambda_scale` be the largest absolute eigenvalue.
+Reject any `lambda < -1e-12 * lambda_scale`; clamp eigenvalues in
+`[-1e-12 * lambda_scale, 0)` to zero. All-zero matrices and retained zero
+singular values use the SVD fallback, which preserves the established rank-one
+and canonical-factor behavior without a special eigen basis.
+
+Call Hermitian eigendecomposition with relative Hermitian tolerance `1e-12`.
+Auto falls back to explicit SVD if Gram construction or eigendecomposition
+fails. The deterministic policy gate decides whether eigen is attempted;
+numerical failure never makes a contraction fail when SVD can complete.
+
+The `1e-12` Auto boundary keeps requested Gram eigenvalues above the regime
+where condition-number squaring and `O(epsilon * lambda_max)` Gram roundoff are
+likely to dominate. Mathematical rank semantics match SVD, but spectra exactly
+on a truncation boundary may select different ranks because the decompositions
+round differently. Rank-equality tests therefore use spectra separated from
+the cutoff and separately pin both sides of the strict Auto boundary.
+
+Chain zip-up local factorizations call the automatic trait method. General-tree
+zip-up, fit refinement sweeps, final standalone truncation, and explicit SVD
+callers remain on their existing SVD paths.
+
+## API impact
+
+`TensorFactorizationLike` gains one documented automatic factorization method
+with a default implementation. No enum or C ABI value changes. Existing
+`contract_zipup`, `contract_zipup_with`, and `ContractionOptions::zipup` retain
+their signatures.
+
+## Correctness requirements
+
+- Compare internal Hermitian-eigen factorization with explicit SVD for `f64` and
+  `Complex64`, tall and wide matrices, both canonical directions, every policy
+  combination, cap-only and zero-matrix edge cases. Assert retained-rank equality
+  on spectra separated from each cutoff as well as reconstruction error.
+- Verify Auto selects eigen only for the documented safe policy combinations and
+  falls back for tracked tensors, unsupported policies, eigen numerical failure,
+  and effective cutoffs at or below `1e-12`.
+- Pin the strict Auto boundary for squared-value policies at `1e-12` and for
+  singular-value per-value policies at threshold `1e-6`.
+- Match a small dense reference exactly for untruncated `f64` and `Complex64`
+  chains.
+- Exercise one-, two-, and multi-site chains, including an interior requested
+  center.
+- Cover both MPO-like times MPO-like and MPO-like times MPS-like local site
+  spaces.
+- Verify truncated results obey the requested cap and a numerical error bound
+  separately from the exact no-truncation reference.
+- Verify standalone zip-up and fit initialization preserve the expected output
+  site indices, chain topology, and requested canonical center.
+- Keep a branched-tree regression to prove the existing fallback remains in
+  use and numerically unchanged.
+- Include a long-chain test whose intended path is cheap but accidental full
+  dense materialization would fail quickly.
+
+## Performance evidence
+
+Measure on one pinned CPU core with Rayon, OpenMP, and BLAS set to one thread.
+Setup, format conversion, and patch preparation stay outside timing. Record:
+
+- total standalone zip-up time;
+- fit zip-up initialization and fit sweep time separately;
+- input, patch, and output bond dimensions;
+- patch count and sampled numerical error.
+
+The primary experiment lives in the separate
+`tensor4all-benchmark-correctness` worktree. It contracts anisotropic Gaussian
+MPOs at `N = 2048`, input maximum bond dimension about 256, patch cap 128, and
+eight compatible patch contractions. The tensor4all-rs implementation worktree
+does not own or commit those benchmark records.
+
+## Deferred work
+
+- A separately configurable coarse fit-initialization policy.
+- Rank-capped or rank-revealing QR suitable for patch-wise initialization.
+- A distinct ITensor-inspired schedule for branched trees.

--- a/docs/design/partitioned-treetn.md
+++ b/docs/design/partitioned-treetn.md
@@ -146,6 +146,19 @@ For each compatible projector pair it:
 3. combines duplicate output projectors with strict TreeTN addition and the
    requested truncation policy.
 
+`contract_adaptive` adds the stronger project-first rule inherited from
+`PartitionedMPSs.jl`. A contraction or duplicate-projector sum that reaches the
+patch cap is only a probe and is discarded. The next child projector is chosen,
+each original operand or addend is projected to that child, and contraction or
+addition is retried recursively. It is incorrect to cap-truncate a parent sum
+and split that already lossy value afterward. Equality with the cap counts as
+saturation because a capped probe cannot distinguish an exact rank from a
+truncated one. Each newly projected operand is first compressed without a bond
+cap at a dtype-scaled numerical-rank threshold (`64 * epsilon`). This removes
+projection-created null bond space without spending the caller's truncation
+budget; user-requested approximation remains confined to contraction and
+post-addition truncation.
+
 `SubDomainTreeTN::inner` uses the eagerly masked stored data directly. No
 projector-compatible region may be inferred or lazily remasked during inner
 product evaluation.
@@ -309,6 +322,8 @@ Maintainer decisions recorded in this revision:
 - provenance includes PartitionedMPSs.jl and the adaptive patching paper, but not
   TCIAlgorithms-derived code or license.
 
-The 2026-08-17 issue reviews informed these decisions but do not by themselves
-clear the repository's delegated-implementation gate. Formal cross-model
-reviewer and verdict: pending.
+The 2026-08-17 issue reviews informed these decisions. The final cross-model
+design review used `reviewer-flash-opencode-go` and recorded the verdict
+`Correct-to-merge`. The same reviewer inspected the final combined staged diff;
+after its requested scalar-node path tests were added, the fresh verdict was
+also `Correct-to-merge`.

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:5996:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:6004:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
## Summary

- align chain TreeTN zip-up with the ITensorMPS-inspired endpoint sweep, input QR, joint final two-site factorization, and explicit center handling
- add policy-aware `factorize_auto` with a guarded native Gram/Hermitian-eigh path and full-SVD fallback
- fix adaptive TT/TreeTN contraction to project original operands before recomputing saturated child patches
- compress projection-created numerical null spaces at a dtype-scaled machine-precision threshold

Follow-up to #648.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace` — 2969 passed, 14 skipped
- `cargo test --doc --release --workspace` — 903 passed
- `cargo doc --workspace --no-deps`
- `./scripts/test-mdbook.sh`
- `cargo run -p xtask --release -- api-dump`
- repository-rules dry-run and script tests — 90 passed

## Review gate

- design: `reviewer-flash-opencode-go` — `Correct-to-merge`
- final staged diff: initial `Changes requested` for uncovered topology-preserving scalar-node branches; tests added; fresh verdict `Correct-to-merge`

## Coverage impact

No paths or tests were removed. New tests cover real/complex chain schedules, cap/error behavior, centers, branched fallback, policy gates, adaptive project-first recomputation, and topology-preserving scalar-node branches. Coverage thresholds and numerical tolerances were not lowered.

## Provenance

The chain schedule is independently implemented and recorded as inspired by ITensorMPS.jl; no source was copied or translated.
