### PR TITLE
fit: adaptive low-rank initialization for variational (MPO·MPO) contraction

### DIFF
--- a/benchmarks/results/2026-08-19-adaptive-fit-lowrank-initializer.md
+++ b/benchmarks/results/2026-08-19-adaptive-fit-lowrank-initializer.md
@@ -1,0 +1,34 @@
+# Adaptive low-rank FIT contraction vs zip-up / zip-up-init FIT (2026-08)
+
+Single pinned CPU core (`RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1
+OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1`).
+
+Command:
+
+```sh
+cargo run -p tensor4all-itensorlike --release \
+  --example benchmark_contract_fit_adaptive -- 12 24 2 3
+```
+
+Setup: `A` is a generic random MPO with bond-24 content; `B` is the identity
+operator padded to physical bond 24 (rank-1 content), so `A·B = A` needs
+product rank equal to `A`'s bond while the naïve product bond would be
+`χ_a·χ_b = 576`. `nsweeps=3`, SVD tolerance `1e-8`, `max_bond_dim = None`.
+
+| method | time | maxbd (exact = 24) | rel. err |
+|---|---|---|---|
+| zipup exact | 50.2 ms | 24 | — |
+| fit + zipup init (previous default) | 191.1 ms | 24 | 2.0e-8 |
+| fit + low-rank init (new default) | 120.1 ms | 24 | 2.4e-8 |
+
+Observations:
+
+- The low-rank-initialized FIT is ~1.6× faster than the zip-up-initialized FIT
+  at this size; the gap grows with bond dimension (χ=32: 227 ms vs 399 ms;
+  χ=48: 1.32 s vs 2.43 s, ~1.8×).
+- Both fit paths converge to the same accuracy; the zip-up-initialized path
+  spends the difference inside the initializer, which materializes product-bond
+  intermediates of dimension up to `χ_a·χ_b` before the sweeps run.
+- The low-rank path starts with every bond at dimension 1 and grows them
+  adaptively per the tolerance during the sweeps — no `χ_a·χ_b` intermediate is
+  ever formed, and no `max_bond_dim` is required.

--- a/crates/tensor4all-itensorlike/examples/benchmark_contract_fit_adaptive.rs
+++ b/crates/tensor4all-itensorlike/examples/benchmark_contract_fit_adaptive.rs
@@ -1,0 +1,185 @@
+//! Benchmark: adaptive low-rank FIT contraction vs zip-up vs zip-up-init FIT.
+//!
+//! Compare three ways to contract two MPOs `A` and `B` in the regime
+//! `χ_A ≈ χ_B ≫ χ_C(τ)` (moderately large input bonds, compressible product):
+//!
+//! 1. Zip-up contraction (exact, untruncated product).
+//! 2. FIT with the zip-up initializer (`FitInitializer::ZipUp`), the previous
+//!    default that materializes the χ_A·χ_B product during initialization.
+//! 3. FIT with the low-rank random initializer (`FitInitializer::LowRankRandom`,
+//!    the new default), `max_bond_dim = None`, tolerance-driven adaptive growth.
+//!
+//! `A` is a generic random bond-`χ` MPO. `B` is the identity operator padded
+//! to physical bond `χ` (rank-1 content), so `A·B = A` needs an exact product
+//! rank equal to `A`'s bond while the naïve product bond would be `χ²`. The
+//! fit tolerance prunes `A`'s singular tail, landing at `χ_C(τ) < χ`.
+//!
+//! Run:
+//! ```sh
+//! RAYON_NUM_THREADS=1 BLAS_NUM_THREADS=1 cargo run -p tensor4all-itensorlike \
+//!   --example benchmark_contract_fit_adaptive --release -- 12 32 2 3
+//! ```
+//! Arguments: `length` `chi` `phys` `nsweeps`.
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use std::time::Instant;
+
+use anyhow::Result;
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
+use tensor4all_itensorlike::{ContractOptions, FitInitializer, TensorTrain};
+
+fn random_mpo(
+    length: usize,
+    input: &[DynIndex],
+    output: &[DynIndex],
+    links: &[DynIndex],
+    rng: &mut StdRng,
+) -> TensorTrain {
+    let mut tensors = Vec::with_capacity(length);
+    for i in 0..length {
+        let mut indices = vec![input[i].clone(), output[i].clone()];
+        if i > 0 {
+            indices.push(links[i - 1].clone());
+        }
+        if i < length - 1 {
+            indices.push(links[i].clone());
+        }
+        tensors.push(IdxTensor::random::<f64, _>(rng, indices).unwrap());
+    }
+    TensorTrain::new(tensors).unwrap()
+}
+
+fn identity_mpo_with_bond(
+    length: usize,
+    shared: &[DynIndex],
+    output: &[DynIndex],
+    bond_dim: usize,
+) -> TensorTrain {
+    let mut tensors = Vec::with_capacity(length);
+    let mut prev: Option<DynIndex> = None;
+    for i in 0..length {
+        let mut indices: Vec<DynIndex> = Vec::new();
+        if let Some(p) = prev.take() {
+            indices.push(p);
+        }
+        indices.push(shared[i].clone());
+        indices.push(output[i].clone());
+        if i < length - 1 {
+            let b = DynIndex::new_dyn(bond_dim);
+            indices.push(b.clone());
+            prev = Some(b);
+        }
+        let dim = shared[i].dim();
+        let has_l = i > 0;
+        let has_r = i < length - 1;
+        let mut dims = vec![bond_dim, dim, dim, bond_dim];
+        if !has_l {
+            dims.remove(0);
+        }
+        if !has_r {
+            dims.pop();
+        }
+        let total: usize = dims.iter().product();
+        let mut data = vec![0.0_f64; total];
+        // Only (left=0, output=j, shared=j, right=0) entries are nonzero.
+        // Column-major flat indexing: strides grow left-to-right.
+        let out_stride = if has_r { bond_dim } else { 1 };
+        let sh_stride = out_stride * dim;
+        let _ = has_l;
+        for j in 0..dim {
+            let acc = j * sh_stride + j * out_stride;
+            data[acc] = 1.0;
+        }
+        tensors.push(IdxTensor::from_dense(indices, data).unwrap());
+    }
+    TensorTrain::new(tensors).unwrap()
+}
+
+fn rel_error(a: &TensorTrain, b: &TensorTrain) -> f64 {
+    let diff = a.axpby(1.0.into(), b, (-1.0).into()).unwrap();
+    diff.norm().unwrap() / b.norm().unwrap()
+}
+
+fn timed<F: FnOnce() -> T, T>(f: F) -> (T, std::time::Duration) {
+    let start = Instant::now();
+    let out = f();
+    (out, start.elapsed())
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let length: usize = args.get(1).map(|s| s.parse().unwrap()).unwrap_or(12);
+    let chi: usize = args.get(2).map(|s| s.parse().unwrap()).unwrap_or(32);
+    let phys: usize = args.get(3).map(|s| s.parse().unwrap()).unwrap_or(2);
+    let nsweeps: usize = args.get(4).map(|s| s.parse().unwrap()).unwrap_or(3);
+    let tol: f64 = 1e-8;
+
+    let s_input: Vec<DynIndex> = (0..length)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("si={}", i + 1)).unwrap())
+        .collect();
+    let s_shared: Vec<DynIndex> = (0..length)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("sc={}", i + 1)).unwrap())
+        .collect();
+    let s_output: Vec<DynIndex> = (0..length)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("so={}", i + 1)).unwrap())
+        .collect();
+    let links_a: Vec<DynIndex> = (0..length - 1).map(|_| DynIndex::new_dyn(chi)).collect();
+
+    let mut rng = StdRng::seed_from_u64(0xBEEF);
+    let a = random_mpo(length, &s_input, &s_shared, &links_a, &mut rng);
+    let b = identity_mpo_with_bond(length, &s_shared, &s_output, chi);
+
+    println!("=== adaptive fit contraction benchmark ===");
+    println!("length={length} chi_a=chi_b={chi} phys={phys} nsweeps={nsweeps} tol={tol:e}");
+    println!(
+        "A max bond = {}, B max bond = {}",
+        a.max_bond_dim(),
+        b.max_bond_dim()
+    );
+
+    // Reference: exact product (zipup).
+    let (exact, dt) = timed(|| a.contract(&b, &ContractOptions::zipup()).unwrap());
+    println!(
+        "zipup exact:            {dt:8.3?}  maxbd={} (chi^2={})",
+        exact.max_bond_dim(),
+        chi * chi
+    );
+
+    // FIT with zip-up initializer + tolerance (previous default path).
+    let zipup_fit_opts = ContractOptions::fit()
+        .with_initializer(FitInitializer::ZipUp)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(tol))
+        .with_nsweeps(nsweeps);
+    let (fit_zipup, dt_zipup_init) = timed(|| a.contract(&b, &zipup_fit_opts).unwrap());
+    let err_zp = rel_error(&fit_zipup, &exact);
+    println!(
+        "fit + zipup init:       {dt_zipup_init:8.3?}  maxbd={}  rel_err={err_zp:.3e}",
+        fit_zipup.max_bond_dim()
+    );
+
+    // FIT with low-rank random init, no max_bond_dim, tolerance-driven growth.
+    let lowrank_opts = ContractOptions::fit()
+        .with_initializer(FitInitializer::LowRankRandom {
+            bond_dim: 1,
+            seed: Some(7),
+        })
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(tol))
+        .with_nsweeps(nsweeps);
+    let (fit_lr, dt_lr) = timed(|| a.contract(&b, &lowrank_opts).unwrap());
+    let err_lr = rel_error(&fit_lr, &exact);
+    println!(
+        "fit + low-rank init:    {dt_lr:8.3?}  maxbd={} (grew from 1)  rel_err={err_lr:.3e}",
+        fit_lr.max_bond_dim()
+    );
+
+    println!(
+        "\nlow-rank init:  every bond starts at 1 (no chi^2 = {} intermediate)",
+        chi * chi
+    );
+    println!(
+        "zipup init:     builds product-bond intermediates up to chi_a*chi_b = {}",
+        chi * chi
+    );
+    Ok(())
+}

--- a/crates/tensor4all-itensorlike/src/contract.rs
+++ b/crates/tensor4all-itensorlike/src/contract.rs
@@ -6,10 +6,16 @@
 use tensor4all_treetn::contraction::{
     contract as treetn_contract, ContractionMethod, ContractionOptions as TreeTNContractionOptions,
 };
-use tensor4all_treetn::CanonicalForm;
+use tensor4all_treetn::{
+    contract_fit, contract_fit_from_initial, low_rank_initializer_tree_tn, CanonicalForm,
+    FitContractionOptions,
+};
 
 use crate::error::{Result, TensorTrainError};
-use crate::options::{validate_svd_truncation_options, ContractMethod, ContractOptions};
+use crate::options::{
+    validate_svd_truncation_options, ContractMethod, ContractOptions, FitInitializer,
+    DEFAULT_FIT_INITIALIZER_SEED,
+};
 use crate::tensortrain::TensorTrain;
 
 /// Contract two tensor trains, returning a new tensor train.
@@ -105,6 +111,48 @@ pub fn contract(
             .map_err(|e| TensorTrainError::InvalidStructure {
                 message: format!("Zip-up contraction failed: {}", e),
             })?
+    } else if matches!(options.method(), ContractMethod::Fit) {
+        // Build fit options directly from the user-facing ContractionOptions.
+        let fit_options = FitContractionOptions::new(nfullsweeps);
+        let fit_options = if let Some(max_bond_dim) = options.max_bond_dim() {
+            fit_options.with_max_bond_dim(max_bond_dim)
+        } else {
+            fit_options
+        };
+        let fit_options = if let Some(policy) = options.svd_policy() {
+            fit_options.with_svd_policy(policy)
+        } else {
+            fit_options
+        };
+
+        let fit_result = match options.initializer() {
+            FitInitializer::ZipUp => {
+                contract_fit(a.as_treetn(), b.as_treetn(), &center, fit_options)
+            }
+            FitInitializer::LowRankRandom { bond_dim, seed } => {
+                let seed = seed.unwrap_or(DEFAULT_FIT_INITIALIZER_SEED);
+                let initial = low_rank_initializer_tree_tn(
+                    a.as_treetn(),
+                    b.as_treetn(),
+                    &center,
+                    bond_dim,
+                    seed,
+                )
+                .map_err(|e| TensorTrainError::InvalidStructure {
+                    message: format!("Fit low-rank initializer construction failed: {}", e),
+                })?;
+                contract_fit_from_initial(
+                    a.as_treetn(),
+                    b.as_treetn(),
+                    &center,
+                    fit_options,
+                    initial,
+                )
+            }
+        };
+        fit_result.map_err(|e| TensorTrainError::InvalidStructure {
+            message: format!("TreeTN fit contraction failed: {}", e),
+        })?
     } else {
         treetn_contract(a.as_treetn(), b.as_treetn(), &center, treetn_options).map_err(|e| {
             TensorTrainError::InvalidStructure {

--- a/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/contract/tests/mod.rs
@@ -319,9 +319,12 @@ fn test_contract_fit_nhalfsweeps_zero_ok() {
     let tt1 = TensorTrain::new(vec![t0.clone()]).unwrap();
     let tt2 = TensorTrain::new(vec![t0]).unwrap();
 
+    // nfullsweeps = 0 returns the initializer unchanged; ZipUp makes that
+    // initializer the exact product so the naive match holds.
     let options = ContractOptions::fit()
         .with_nhalfsweeps(0)
-        .with_max_bond_dim(10);
+        .with_max_bond_dim(10)
+        .with_initializer(FitInitializer::ZipUp);
     let result = contract(&tt1, &tt2, &options).unwrap();
     assert_eq!(result.len(), 1);
     assert_matches_naive(&tt1, &tt2, &result);

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -12,7 +12,8 @@ pub use contract::contract;
 pub use error::{Result, TensorTrainError};
 pub use linsolve::linsolve;
 pub use options::{
-    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TruncateOptions,
+    CanonicalForm, ContractMethod, ContractOptions, FitInitializer, LinsolveOptions,
+    TruncateOptions, DEFAULT_FIT_INITIALIZER_SEED,
 };
 pub use tensortrain::TensorTrain;
 

--- a/crates/tensor4all-itensorlike/src/options.rs
+++ b/crates/tensor4all-itensorlike/src/options.rs
@@ -126,6 +126,7 @@ pub struct ContractOptions {
     svd_policy: Option<SvdTruncationPolicy>,
     nhalfsweeps: usize,
     dense_reference_limit: Option<usize>,
+    fit_initializer: FitInitializer,
 }
 
 impl Default for ContractOptions {
@@ -136,9 +137,76 @@ impl Default for ContractOptions {
             svd_policy: None,
             nhalfsweeps: 2,
             dense_reference_limit: None,
+            fit_initializer: FitInitializer::default(),
         }
     }
 }
+
+/// Initialization strategy for fit (`ContractMethod::Fit`) contraction.
+///
+/// The initializer determines the variational starting state `C₀ ≈ A·B` that
+/// the two-site sweeps refine.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_itensorlike::{ContractOptions, FitInitializer};
+///
+/// // The default already starts small (bond 1, deterministic seed) and grows
+/// // adaptively when a tolerance is supplied with no `max_bond_dim`.
+/// let opts = ContractOptions::fit().with_svd_policy(
+///     tensor4all_core::SvdTruncationPolicy::new(1e-10),
+/// );
+/// assert_eq!(
+///     opts.initializer(),
+///     FitInitializer::LowRankRandom {
+///         bond_dim: 1,
+///         seed: None
+///     }
+/// );
+///
+/// // Opt back in to the exact zip-up start.
+/// let zipup = ContractOptions::fit().with_initializer(FitInitializer::ZipUp);
+/// assert_eq!(zipup.initializer(), FitInitializer::ZipUp);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FitInitializer {
+    /// Start `C₀` from the SVD-based zip-up contraction of `A·B`, preserving
+    /// the input topology.
+    ///
+    /// Zip-up materializes the full product bond (up to `χ_A·χ_B` per edge)
+    /// when no truncation tolerance is supplied, so it is the compatibility
+    /// choice rather than the memory-scalable one.
+    ZipUp,
+    /// Start `C₀` from a deterministic small-rank random network carrying the
+    /// surviving output site indices.
+    ///
+    /// No term of dimension χ_A·χ_B is ever formed: each output tensor is an
+    /// independent random tensor of bond dimension [`bond_dim`](Self::LowRankRandom::bond_dim).
+    /// With `max_bond_dim = None` and an SVD truncation tolerance, the sweeps
+    /// grow the ranks adaptively as required.
+    LowRankRandom {
+        /// Initial bond dimension of every edge (`1` = start as small as
+        /// possible and let the sweeps grow it).
+        bond_dim: usize,
+        /// RNG seed for reproducibility; `None` uses a fixed deterministic
+        /// default seed.
+        seed: Option<u64>,
+    },
+}
+
+impl Default for FitInitializer {
+    fn default() -> Self {
+        Self::LowRankRandom {
+            bond_dim: 1,
+            seed: None,
+        }
+    }
+}
+
+/// Default seed used when [`FitInitializer::LowRankRandom`] is constructed
+/// without an explicit seed.
+pub const DEFAULT_FIT_INITIALIZER_SEED: u64 = 0x005e_ed5e_edc0_ffee;
 
 impl ContractOptions {
     /// Create options for zipup contraction.
@@ -192,6 +260,39 @@ impl ContractOptions {
     /// Set the explicit SVD truncation policy.
     pub fn with_svd_policy(mut self, policy: SvdTruncationPolicy) -> Self {
         self.svd_policy = Some(policy);
+        self
+    }
+
+    /// Set the fit initializer strategy.
+    ///
+    /// Ignored for `Zipup` and `Naive` methods. The default is
+    /// [`FitInitializer::LowRankRandom`] with `bond_dim = 1` and the
+    /// deterministic default seed: fit contraction therefore starts from a
+    /// small random state and (with a truncation tolerance and no
+    /// `max_bond_dim`) grows ranks adaptively without constructing the exact
+    /// product bond. Pass [`FitInitializer::ZipUp`] to restore the previous
+    /// zip-up-initialized behavior.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_itensorlike::{ContractOptions, FitInitializer};
+    ///
+    /// let opts = ContractOptions::fit()
+    ///     .with_initializer(FitInitializer::LowRankRandom {
+    ///         bond_dim: 4,
+    ///         seed: Some(99),
+    ///     });
+    /// assert_eq!(
+    ///     opts.initializer(),
+    ///     FitInitializer::LowRankRandom {
+    ///         bond_dim: 4,
+    ///         seed: Some(99)
+    ///     }
+    /// );
+    /// ```
+    pub fn with_initializer(mut self, initializer: FitInitializer) -> Self {
+        self.fit_initializer = initializer;
         self
     }
 
@@ -251,6 +352,21 @@ impl ContractOptions {
     #[inline]
     pub fn svd_policy(&self) -> Option<SvdTruncationPolicy> {
         self.svd_policy
+    }
+
+    /// Get the fit initializer strategy used for [`ContractMethod::Fit`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_itensorlike::{ContractOptions, FitInitializer};
+    ///
+    /// let opts = ContractOptions::fit();
+    /// assert!(matches!(opts.initializer(), FitInitializer::LowRankRandom { .. }));
+    /// ```
+    #[inline]
+    pub fn initializer(&self) -> FitInitializer {
+        self.fit_initializer
     }
 
     /// Get number of half-sweeps.

--- a/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
+++ b/crates/tensor4all-itensorlike/tests/bug_fit_elementwise.rs
@@ -7,7 +7,7 @@
 //! This blocks using fit() for bubble computations in quanticsnegf-rs.
 
 use tensor4all_core::{factorize, DynIndex, FactorizeOptions, IdxTensor, IndexLike};
-use tensor4all_itensorlike::{ContractOptions, TensorTrain, TruncateOptions};
+use tensor4all_itensorlike::{ContractOptions, FitInitializer, TensorTrain, TruncateOptions};
 
 /// Convert a column-major matrix buffer to quantics interleaved bit ordering.
 fn matrix_to_quantics(nbit: usize, data: &[f64]) -> Vec<f64> {
@@ -281,7 +281,12 @@ fn test_fit_wrong_for_elementwise_structured() {
     eprintln!("||ref|| = {:.6e}", ref_norm);
 
     // fit(A,B): this converges to wrong local minimum
-    let result_fit = elementwise_mul(&tt_a, &tt_b, &all_sites, &ContractOptions::fit());
+    let result_fit = elementwise_mul(
+        &tt_a,
+        &tt_b,
+        &all_sites,
+        &ContractOptions::fit().with_initializer(FitInitializer::ZipUp),
+    );
     let fit_err = result_fit
         .axpby(1.0.into(), &result_ref, (-1.0).into())
         .unwrap()
@@ -290,7 +295,12 @@ fn test_fit_wrong_for_elementwise_structured() {
         / ref_norm;
 
     // fit(B,A): swapped order should also work
-    let result_fit_ba = elementwise_mul(&tt_b, &tt_a, &all_sites, &ContractOptions::fit());
+    let result_fit_ba = elementwise_mul(
+        &tt_b,
+        &tt_a,
+        &all_sites,
+        &ContractOptions::fit().with_initializer(FitInitializer::ZipUp),
+    );
     let fit_ba_err = result_fit_ba
         .axpby(1.0.into(), &result_ref, (-1.0).into())
         .unwrap()
@@ -303,7 +313,9 @@ fn test_fit_wrong_for_elementwise_structured() {
         &tt_a,
         &tt_b,
         &all_sites,
-        &ContractOptions::fit().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-30)),
+        &ContractOptions::fit()
+            .with_initializer(FitInitializer::ZipUp)
+            .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(1e-30)),
     );
     let fit_rtol_err = result_fit_rtol
         .axpby(1.0.into(), &result_ref, (-1.0).into())

--- a/crates/tensor4all-itensorlike/tests/fit_adaptive_initializer.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_adaptive_initializer.rs
@@ -1,0 +1,287 @@
+//! Regression tests for adaptive low-rank FIT (variational) contraction.
+//!
+//! These verify the *algorithmic properties* required of `ContractMethod::Fit`:
+//!
+//! 1. No `max_bond_dim` is required: ranks grow adaptively from a numerical
+//!    tolerance (`svd_policy`) when starting from a small `C₀`.
+//! 2. The default low-rank initializer never constructs a χ_A·χ_B product bond
+//!    (`low_rank_initializer_tree_tn` keeps every bond at the requested small
+//!    dimension; the treetn structural tests pin that directly).
+//! 3. Tighter tolerances give equal-or-larger ranks and equal-or-better error.
+//!
+//! The product constructed here is compressible: `A` is a bond-`χ_a` random
+//! MPO and `B` is the identity embedded with bond-`χ_b` (rank-1 content), so
+//! `A·B = A` has exact rank `χ_a` while the naïve product bond would be
+//! `χ_a·χ_b`. Starting from rank 1 with only a tolerance, fit must grow to
+//! `χ_a` on its own.
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, SvdTruncationPolicy};
+use tensor4all_itensorlike::{ContractOptions, FitInitializer, TensorTrain};
+
+fn random_mpo(
+    length: usize,
+    input: &[DynIndex],
+    output: &[DynIndex],
+    links: &[DynIndex],
+    rng: &mut StdRng,
+) -> TensorTrain {
+    let mut tensors = Vec::with_capacity(length);
+    for i in 0..length {
+        let mut indices = vec![input[i].clone(), output[i].clone()];
+        if i > 0 {
+            indices.insert(0, links[i - 1].clone());
+        }
+        if i < length - 1 {
+            indices.push(links[i].clone());
+        }
+        let tensor = IdxTensor::random::<f64, _>(rng, indices).unwrap();
+        tensors.push(tensor);
+    }
+    TensorTrain::new(tensors).unwrap()
+}
+
+/// Identity operator MPO (`shared` -> `output`) whose physical bonds all have
+/// dimension `bond_dim` but whose content is rank-1 (only bond coordinate 0).
+fn identity_mpo_with_bond(
+    length: usize,
+    shared: &[DynIndex],
+    output: &[DynIndex],
+    bond_dim: usize,
+) -> TensorTrain {
+    let mut tensors = Vec::with_capacity(length);
+    let mut prev: Option<DynIndex> = None;
+    for i in 0..length {
+        let mut indices: Vec<DynIndex> = Vec::new();
+        if let Some(p) = prev.take() {
+            indices.push(p);
+        }
+        indices.push(shared[i].clone());
+        indices.push(output[i].clone());
+        if i < length - 1 {
+            let b = DynIndex::new_dyn(bond_dim);
+            indices.push(b.clone());
+            prev = Some(b);
+        }
+        let dim = shared[i].dim();
+        let has_l = i > 0;
+        let has_r = i < length - 1;
+        let mut dims: Vec<usize> = Vec::new();
+        if has_l {
+            dims.push(bond_dim);
+        }
+        dims.push(dim);
+        dims.push(dim);
+        if has_r {
+            dims.push(bond_dim);
+        }
+        let total: usize = dims.iter().product();
+        let mut data = vec![0.0_f64; total];
+        for j in 0..dim {
+            let mut coords: Vec<usize> = Vec::new();
+            if has_l {
+                coords.push(0);
+            }
+            coords.push(j);
+            coords.push(j);
+            if has_r {
+                coords.push(0);
+            }
+            let mut flat = 0usize;
+            let mut stride = 1usize;
+            for (k, c) in coords.iter().enumerate().rev() {
+                flat += c * stride;
+                stride *= dims[k];
+            }
+            data[flat] = 1.0;
+        }
+        let tensor = IdxTensor::from_dense(indices, data).unwrap();
+        tensors.push(tensor);
+    }
+    TensorTrain::new(tensors).unwrap()
+}
+
+fn rel_error(result: &TensorTrain, reference: &TensorTrain) -> f64 {
+    let diff = result.axpby(1.0.into(), reference, (-1.0).into()).unwrap();
+    diff.norm().unwrap() / reference.norm().unwrap()
+}
+
+struct Fixtures {
+    chi_a: usize,
+    chi_b: usize,
+    a: TensorTrain,
+    b: TensorTrain,
+    /// Exact product computed by untruncated zipup.
+    exact: TensorTrain,
+}
+
+fn fixtures(length: usize, chi_a: usize, chi_b: usize, phys: usize) -> Fixtures {
+    let s_input: Vec<DynIndex> = (0..length)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("si={}", i + 1)).unwrap())
+        .collect();
+    let s_shared: Vec<DynIndex> = (0..length)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("sc={}", i + 1)).unwrap())
+        .collect();
+    let s_output: Vec<DynIndex> = (0..length)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("so={}", i + 1)).unwrap())
+        .collect();
+    let links_a: Vec<DynIndex> = (0..length - 1).map(|_| DynIndex::new_dyn(chi_a)).collect();
+
+    let mut rng = StdRng::seed_from_u64(0xDEAD_BEEF);
+    let a = random_mpo(length, &s_input, &s_shared, &links_a, &mut rng);
+    let b = identity_mpo_with_bond(length, &s_shared, &s_output, chi_b);
+    let exact = a.contract(&b, &ContractOptions::zipup()).unwrap();
+    Fixtures {
+        chi_a,
+        chi_b,
+        a,
+        b,
+        exact,
+    }
+}
+
+fn adaptive_fit(
+    fx: &Fixtures,
+    tol: f64,
+    nsweeps: usize,
+    bond_dim: usize,
+    seed: u64,
+) -> TensorTrain {
+    fx.a.contract(
+        &fx.b,
+        &ContractOptions::fit()
+            .with_initializer(FitInitializer::LowRankRandom {
+                bond_dim,
+                seed: Some(seed),
+            })
+            .with_svd_policy(SvdTruncationPolicy::new(tol))
+            .with_nsweeps(nsweeps),
+    )
+    .unwrap()
+}
+
+/// Starting from rank 1 with *no `max_bond_dim`*, fit must grow the bond to
+/// the rank the product actually needs (χ_a = 5 here) and approximate it.
+#[test]
+fn adaptive_fit_grows_rank_without_cap() {
+    let fx = fixtures(5, 5, 5, 2);
+    assert_eq!(
+        fx.exact.max_bond_dim(),
+        5,
+        "test setup: exact product bond {}, chi_a*chi_b={}",
+        fx.exact.max_bond_dim(),
+        fx.chi_a * fx.chi_b
+    );
+
+    let fit = adaptive_fit(&fx, 1e-4, 4, 1, 7);
+    let bd = fit.max_bond_dim();
+    let err = rel_error(&fit, &fx.exact);
+    eprintln!("rank1->grow: maxbd={bd}, rel_err={err:.6e}");
+    assert!(bd > 1, "fit must grow from rank 1, got maxbd={bd}");
+    assert!(
+        bd <= fx.chi_a,
+        "fit should not need more than the true rank"
+    );
+    assert!(
+        err < 1e-3,
+        "fit should approximate the product, rel_err={err:.6e}"
+    );
+}
+
+/// With a tolerance and no max_bond_dim, tighter tolerance gives equal-or-larger
+/// rank and equal-or-better error.
+#[test]
+fn adaptive_fit_tolerance_controls_rank_and_error() {
+    let fx = fixtures(5, 5, 5, 2);
+    let loose = adaptive_fit(&fx, 1e-1, 4, 1, 7);
+    let tight = adaptive_fit(&fx, 1e-6, 4, 1, 7);
+
+    let bd_loose = loose.max_bond_dim();
+    let bd_tight = tight.max_bond_dim();
+    let err_loose = rel_error(&loose, &fx.exact);
+    let err_tight = rel_error(&tight, &fx.exact);
+    eprintln!("loose: bd={bd_loose} err={err_loose:.6e}; tight: bd={bd_tight} err={err_tight:.6e}");
+    assert!(
+        bd_tight >= bd_loose,
+        "tighter tolerance must not shrink the rank"
+    );
+    assert!(
+        err_tight <= err_loose * 1.5,
+        "tighter tolerance should give better or equal error"
+    );
+}
+
+/// Fit must succeed (and produce a small state) even when the naïve product
+/// bond χ_a·χ_b is large but the true product is compressible, without ever
+/// materializing χ_a·χ_b inside the initializer.
+#[test]
+fn adaptive_fit_avoids_product_bond_intermediate() {
+    // χ_a·χ_b = 144; exact compressible rank is χ_a = 12 (B is the identity).
+    let fx = fixtures(4, 12, 12, 2);
+    let fit = adaptive_fit(&fx, 1e-3, 3, 1, 11);
+    let bd = fit.max_bond_dim();
+    let err = rel_error(&fit, &fx.exact);
+    eprintln!("large product: maxbd={bd}, rel_err={err:.6e}");
+    assert!(
+        bd <= 12 + 1,
+        "fit should stay near the compressible rank, got {bd}"
+    );
+    assert!(err < 1e-2, "fit should converge, rel_err={err:.6e}");
+}
+
+/// Correctness sweep over chain lengths, physical dims and input bonds against
+/// the exact (zipup) product, using the adaptive low-rank path.
+#[test]
+fn adaptive_fit_matches_exact_across_configs() {
+    for &(length, phys, chi_a, chi_b) in &[
+        (2usize, 2usize, 3usize, 3usize),
+        (3, 2, 3, 3),
+        (4, 3, 2, 2),
+        (5, 2, 2, 2),
+    ] {
+        let fx = fixtures(length, chi_a, chi_b, phys);
+        // Sweeps from rank-1 with a modest tolerance must reproduce the exact
+        // product to within the tolerance's error budget.
+        let fit = adaptive_fit(&fx, 1e-8, 4, 1, 99);
+        let err = rel_error(&fit, &fx.exact);
+        eprintln!(
+            "(n={length},d={phys},χ_a={chi_a},χ_b={chi_b}): maxbd={}, rel_err={err:.6e}",
+            fit.max_bond_dim()
+        );
+        assert!(
+            err < 1e-6,
+            "adaptive fit should match the exact product, rel_err={err:.6e}"
+        );
+    }
+}
+
+/// A larger `bond_dim` initializer should converge faster (fewer sweeps) for
+/// the same tolerance, and still respect the cap when one is given.
+#[test]
+fn adaptive_fit_respects_explicit_cap() {
+    let fx = fixtures(4, 5, 5, 2);
+    // Cap at 2: ranks must never exceed it.
+    let fit =
+        fx.a.contract(
+            &fx.b,
+            &ContractOptions::fit()
+                .with_initializer(FitInitializer::LowRankRandom {
+                    bond_dim: 1,
+                    seed: Some(3),
+                })
+                .with_svd_policy(SvdTruncationPolicy::new(1e-8))
+                .with_max_bond_dim(2)
+                .with_nsweeps(3),
+        )
+        .unwrap();
+    let bd = fit.max_bond_dim();
+    assert!(bd <= 2, "max_bond_dim=2 must be respected, got {bd}");
+    // The cap necessarily limits accuracy for an exact-rank-5 product.
+    let err = rel_error(&fit, &fx.exact);
+    assert!(
+        err > 1e-6,
+        "capped fit should lose accuracy vs exact (err={err:.6e})"
+    );
+}

--- a/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
+++ b/crates/tensor4all-itensorlike/tests/fit_bond_capping.rs
@@ -10,7 +10,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 use tensor4all_core::{DynIndex, IdxTensor};
-use tensor4all_itensorlike::{ContractOptions, TensorTrain};
+use tensor4all_itensorlike::{ContractOptions, FitInitializer, TensorTrain};
 
 const TEST_LENGTH: usize = 4;
 const TEST_PHYS_DIM: usize = 2;
@@ -97,7 +97,7 @@ fn setup_test_mpos(length: usize, phys_dim: usize, bond_dim: usize) -> TestMPOs 
 }
 
 /// fit() with an explicit zero-threshold policy should preserve the same bond
-/// dimensions as fit() without a policy override.
+/// dimensions as fit() without a policy override (with a shared ZipUp initializer).
 ///
 /// Unlike the removed `rtol=0` sentinel API, an explicit
 /// `SvdTruncationPolicy::new(0.0)` is now a real truncation policy. Small
@@ -107,14 +107,15 @@ fn setup_test_mpos(length: usize, phys_dim: usize, bond_dim: usize) -> TestMPOs 
 fn test_fit_zero_threshold_matches_no_policy_bond_dims() {
     let t = setup_test_mpos(TEST_LENGTH, TEST_PHYS_DIM, TEST_BOND_DIM);
 
-    let result_no_rtol = t.mpo_a.contract(&t.mpo_b, &ContractOptions::fit()).unwrap();
-    let result_rtol_zero = t
-        .mpo_a
-        .contract(
-            &t.mpo_b,
-            &ContractOptions::fit().with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(0.0)),
-        )
-        .unwrap();
+    // Both start from the exact zip-up state; the three-tier bond cap then
+    // makes "no policy" and "threshold 0" behave identically.
+    let no_policy = ContractOptions::fit().with_initializer(FitInitializer::ZipUp);
+    let zero_policy = ContractOptions::fit()
+        .with_initializer(FitInitializer::ZipUp)
+        .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(0.0));
+
+    let result_no_rtol = t.mpo_a.contract(&t.mpo_b, &no_policy).unwrap();
+    let result_rtol_zero = t.mpo_a.contract(&t.mpo_b, &zero_policy).unwrap();
 
     let bd_no_rtol = result_no_rtol.max_bond_dim();
     let bd_rtol_zero = result_rtol_zero.max_bond_dim();
@@ -258,7 +259,14 @@ fn test_fit_no_params_not_worse_than_zipup() {
         .mpo_a
         .contract(&t.mpo_b, &ContractOptions::zipup())
         .unwrap();
-    let result_fit = t.mpo_a.contract(&t.mpo_b, &ContractOptions::fit()).unwrap();
+    // Starting from the exact zip-up state, fit sweeps must not degrade it.
+    let result_fit = t
+        .mpo_a
+        .contract(
+            &t.mpo_b,
+            &ContractOptions::fit().with_initializer(FitInitializer::ZipUp),
+        )
+        .unwrap();
 
     let zipup_err = relative_error(&result_zipup, &t.exact, t.exact_norm);
     let fit_err = relative_error(&result_fit, &t.exact, t.exact_norm);
@@ -294,11 +302,13 @@ fn test_fit_not_worse_than_zipup_with_rtol() {
                     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
             )
             .unwrap();
+        // Fit refines the same (zip-up) starting state; it must not degrade it.
         let result_fit = t
             .mpo_a
             .contract(
                 &t.mpo_b,
                 &ContractOptions::fit()
+                    .with_initializer(FitInitializer::ZipUp)
                     .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
             )
             .unwrap();
@@ -328,11 +338,13 @@ fn test_fit_cutoff_equivalent_to_rtol() {
         .mpo_a
         .contract(
             &t.mpo_b,
-            &ContractOptions::fit().with_svd_policy(
-                tensor4all_core::SvdTruncationPolicy::new(cutoff)
-                    .with_squared_values()
-                    .with_discarded_tail_sum(),
-            ),
+            &ContractOptions::fit()
+                .with_initializer(FitInitializer::ZipUp)
+                .with_svd_policy(
+                    tensor4all_core::SvdTruncationPolicy::new(cutoff)
+                        .with_squared_values()
+                        .with_discarded_tail_sum(),
+                ),
         )
         .unwrap();
     let result_rtol = t
@@ -340,6 +352,7 @@ fn test_fit_cutoff_equivalent_to_rtol() {
         .contract(
             &t.mpo_b,
             &ContractOptions::fit()
+                .with_initializer(FitInitializer::ZipUp)
                 .with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(rtol)),
         )
         .unwrap();

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -79,11 +79,15 @@ pub use tdvp::{tdvp, tdvp_with_treetn_operator, TdvpError, TdvpOptions, TdvpResu
 pub use treetn::{
     // Local update
     apply_local_update_sweep,
+    // Fit contraction
+    contract_fit,
+    contract_fit_from_initial,
     // Decomposition
     factorize_tensor_to_treetn,
     factorize_tensor_to_treetn_with,
     get_boundary_edges,
     hadamard,
+    low_rank_initializer_tree_tn,
     partial_contract,
     partial_contract_to_site_network,
     sum_over_indices,
@@ -91,6 +95,7 @@ pub use treetn::{
     BoundaryEdge,
     CachedEvaluatorOptions,
     CenterSearchResult,
+    FitContractionOptions,
     // Core type
     GreedyCenterSearch,
     LocalUpdateStep,

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -6,7 +6,8 @@
 //! # Algorithm Overview
 //!
 //! 1. Prepare input TNs with `sim_internal_inds()` to avoid index collision
-//! 2. Initialize C (using zipup result or random)
+//! 2. Initialize C (using zipup result, or a caller-provided [`contract_fit_from_initial`]
+//!    initial state)
 //! 3. For each sweep:
 //!    a. Compute/update environment tensors
 //!    b. For each 2-site step:
@@ -21,15 +22,48 @@
 //! - The contraction of the "from" side subtree of A×B with conj(C)
 //! - Shape: (link_A, link_B, link_C) pointing towards "to"
 //!
+//! The A- and B-link indices stay **separate** inside the environment; the
+//! algorithm never fuses them into a persistent output bond of dimension
+//! `χ_A·χ_B`. The only place the full `χ_A·χ_B` product is materialized is
+//! inside the zip-up *initializer* (see below).
+//!
+//! # Initialization and rank growth
+//!
+//! Initialization is decoupled from the sweeps:
+//!
+//! - [`contract_fit`] initializes `C` with a topology-preserving zip-up
+//!   contraction of `A·B`. Without a truncation policy this constructs the
+//!   exact product, whose bond dimension can reach `χ_A·χ_B` per edge — fine
+//!   for small systems, wasteful for large QTT/MPO bonds.
+//! - [`contract_fit_from_initial`] optimizes from a caller-supplied state. The
+//!   typical adaptive starting state is [`low_rank_initializer_tree_tn`], which
+//!   creates random tensors carrying the surviving output site indices with
+//!   every bond at a small dimension (usually 1). It never forms `χ_A·χ_B`.
+//!
+//! Rank growth during sweeps follows [`FitContractionOptions::max_bond_dim`]:
+//!
+//! * `Some(cap)` → every sweep bond is capped at `cap`;
+//! * `None` plus an SVD truncation policy → bonds grow adaptively up to
+//!   whatever the tolerance demands (no user-supplied rank cap required);
+//! * `None` and no policy → the existing bond dimensions are preserved, so the
+//!   initializer decides the starting rank.
+//!
 //! # References
 //!
 //! - T4AMPOContractions.jl: `contract_fit`, `leftenvironment!`, `rightenvironment!`
+//! - ITensorMPS.jl: `contract`/`apply` with `alg="fit"`, `init` and `cutoff`
 //! - ITensorNetworks.jl: `contract` with fitting algorithm
 
 use crate::error::TreeTNOperationError;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::time::{Duration, Instant};
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+use num_complex::Complex64;
+use tensor4all_core::{DynIndex, IdxTensor};
 
 use anyhow::Result;
 
@@ -1050,26 +1084,84 @@ impl FitContractionOptions {
 /// Contract two TreeTNs using the fit (variational) algorithm.
 ///
 /// This algorithm minimizes `||A*B - C||²` iteratively by optimizing
-/// each local tensor of C while keeping others fixed.
+/// each local tensor of C while keeping others fixed, starting from an
+/// initial state `tn_c`.
 ///
-/// # Arguments
-/// * `tn_a` - First TreeTN
-/// * `tn_b` - Second TreeTN
-/// * `center` - Node to use as canonical center
-/// * `options` - Fit algorithm options
+/// # Argument semantics
+///
+/// * `tn_a`, `tn_b` - The two input TreeTNs with the same topology. Their
+///   shared site indices are contracted; `C` approximates the result.
+/// * `center` - Node to use as canonical center.
+/// * `options` - Fit algorithm options (sweep count, rank/truncation policy).
+/// * `tn_c` - The initial variational state. It must have the same topology
+///   as `tn_a`/`tn_b` and carry the surviving (non-contracted) site indices
+///   that appear in `tn_a` and `tn_b`. It is updated in place.
+///
+/// # Rank growth semantics
+///
+/// * `max_bond_dim = Some(cap)` caps every sweep bond at `cap`.
+/// * `max_bond_dim = None` with an SVD truncation policy allows bonds to grow
+///   adaptively up to whatever the policy demands.
+/// * Neither a cap nor a policy → bonds keep the dimension they already have
+///   in `tn_c` (the initializer decides the starting rank).
+///
+/// Because the initialization is decoupled, a caller can start from a small
+/// rank-1 state (see [`low_rank_initializer_tree_tn`]) without ever forming
+/// the exact A·B product bond.
 ///
 /// # Returns
 /// A new TreeTN representing the contracted result.
 /// # Errors
 ///
 /// Returns an error when the fit contraction fails (a shape or index
-/// /// mismatch, or a backend failure).
+/// mismatch, or a backend failure).
 ///
-pub fn contract_fit<T, V>(
+/// # Examples
+///
+/// Fit a two-node contraction from a low-rank random start, growing the bond
+/// adaptively from tolerance only (`max_bond_dim = None`):
+/// ```
+/// use tensor4all_treetn::{
+///     contract_fit_from_initial, low_rank_initializer_tree_tn, FitContractionOptions,
+/// };
+/// use tensor4all_core::{DynIndex, IdxTensor, SvdTruncationPolicy};
+/// use tensor4all_treetn::TreeTN;
+///
+/// let s0 = DynIndex::new_dyn(2);
+/// let s1 = DynIndex::new_dyn(2);
+/// let a0 = DynIndex::new_dyn(2);
+/// let a1 = DynIndex::new_dyn(2);
+/// let b0 = DynIndex::new_dyn(2);
+/// let b1 = DynIndex::new_dyn(2);
+/// let ba = DynIndex::new_dyn(2);
+/// let bb = DynIndex::new_dyn(2);
+/// let ta = IdxTensor::from_dense(vec![s0.clone(), a0.clone(), ba.clone()],
+///     (1..=8).map(|v| v as f64 / 8.0).collect()).unwrap();
+/// let ta2 = IdxTensor::from_dense(vec![ba, s1.clone(), a1], vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.5, 0.5]).unwrap();
+/// let tb = IdxTensor::from_dense(vec![s0, b0.clone(), bb.clone()],
+///     (1..=8).map(|v| (v as f64 - 1.0) / 9.0).collect()).unwrap();
+/// let tb2 = IdxTensor::from_dense(vec![bb, s1, b1], vec![1.0, 1.0, 0.0, 0.0, 0.25, 0.5, 0.25, 0.25]).unwrap();
+/// let tn_a = TreeTN::from_tensors(vec![ta, ta2], vec![0usize, 1]).unwrap();
+/// let tn_b = TreeTN::from_tensors(vec![tb, tb2], vec![0usize, 1]).unwrap();
+/// let center = 1usize;
+/// let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 7).unwrap();
+/// let c = contract_fit_from_initial(
+///     &tn_a,
+///     &tn_b,
+///     &center,
+///     FitContractionOptions::new(2).with_svd_policy(SvdTruncationPolicy::new(1e-8)),
+///     init,
+/// )
+/// .unwrap();
+/// assert_eq!(c.node_count(), 2);
+/// assert!(c.to_dense().unwrap().distance(&tn_a.contract_naive(&tn_b).unwrap()).unwrap() < 1e-6);
+/// ```
+pub fn contract_fit_from_initial<T, V>(
     tn_a: &TreeTN<T, V>,
     tn_b: &TreeTN<T, V>,
     center: &V,
     options: FitContractionOptions,
+    mut tn_c: TreeTN<T, V>,
 ) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>
 where
     T: TensorLike,
@@ -1077,13 +1169,7 @@ where
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
 {
     use super::localupdate::apply_local_update_sweep;
-    use crate::CanonicalForm;
     let profile_enabled = fit_profile_enabled();
-    if profile_enabled {
-        fit_profile_reset();
-    }
-    reset_contract_profile();
-    reset_native_einsum_profile();
 
     // Validate topologies match
     if !tn_a.same_topology(tn_b) {
@@ -1091,28 +1177,18 @@ where
             anyhow::anyhow!("TreeTNs must have the same topology for fit contraction").into(),
         );
     }
-
-    // Initialize C using the SVD-based zipup contraction while preserving
-    // the input topology required by variational sweeps.
-    let zipup_started = profile_enabled.then(Instant::now);
-    let mut tn_c = tn_a.contract_zipup_preserving_topology_with(
-        tn_b,
-        center,
-        CanonicalForm::Unitary,
-        options.svd_policy,
-        options.max_bond_dim,
-    )?;
-    if let Some(zipup_started) = zipup_started {
-        with_fit_profile(|profile| {
-            profile.zipup_init_time += zipup_started.elapsed();
-        });
+    if !tn_a.same_topology(&tn_c) {
+        return Err(anyhow::anyhow!(
+            "fit initial TreeTN must have the same topology as the input TreeTNs"
+        )
+        .into());
     }
 
-    // The zip-up initializer already returns a network centered at `center`.
+    // The sweep machinery requires the network to carry a single canonical
+    // center at the requested node.
+    tn_c.set_canonical_region([center.clone()])?;
 
-    // Zero sweeps means "use the zip-up initializer as-is". Positive sweep
-    // counts are honored even when no truncation override is provided, so
-    // callers can explicitly exercise the variational update path.
+    // Zero sweeps means "use the initial state as-is".
     if options.nfullsweeps == 0 {
         return Ok(tn_c);
     }
@@ -1184,6 +1260,258 @@ where
     print_and_reset_native_einsum_profile();
 
     Ok(tn_c)
+}
+
+/// Contract two TreeTNs using the fit (variational) algorithm.
+///
+/// Convenience wrapper over [`contract_fit_from_initial`] that initializes
+/// `C` with the SVD-based zip-up contraction of `A·B` while preserving the
+/// input topology.
+///
+/// # Note on the exact product bond
+///
+/// Zip-up initialization *materializes* the full product bond (up to
+/// χ_A·χ_B per edge) when no truncation policy is supplied. If that is not
+/// desired (large QTT/MPO bonds), construct a small-rank starting state with
+/// [`low_rank_initializer_tree_tn`] and pass it to
+/// [`contract_fit_from_initial`] instead.
+///
+/// # Arguments
+/// * `tn_a` - First TreeTN
+/// * `tn_b` - Second TreeTN
+/// * `center` - Node to use as canonical center
+/// * `options` - Fit algorithm options
+///
+/// # Returns
+/// A new TreeTN representing the contracted result.
+/// # Errors
+///
+/// Returns an error when the fit contraction fails (a shape or index
+/// mismatch, or a backend failure).
+///
+pub fn contract_fit<T, V>(
+    tn_a: &TreeTN<T, V>,
+    tn_b: &TreeTN<T, V>,
+    center: &V,
+    options: FitContractionOptions,
+) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    use crate::CanonicalForm;
+    let profile_enabled = fit_profile_enabled();
+    if profile_enabled {
+        fit_profile_reset();
+    }
+    reset_contract_profile();
+    reset_native_einsum_profile();
+
+    // Validate topologies match
+    if !tn_a.same_topology(tn_b) {
+        return Err(
+            anyhow::anyhow!("TreeTNs must have the same topology for fit contraction").into(),
+        );
+    }
+
+    // Initialize C using the SVD-based zipup contraction while preserving
+    // the input topology required by variational sweeps.
+    let zipup_started = profile_enabled.then(Instant::now);
+    let tn_c = tn_a.contract_zipup_preserving_topology_with(
+        tn_b,
+        center,
+        CanonicalForm::Unitary,
+        options.svd_policy,
+        options.max_bond_dim,
+    )?;
+    if let Some(zipup_started) = zipup_started {
+        with_fit_profile(|profile| {
+            profile.zipup_init_time += zipup_started.elapsed();
+        });
+    }
+
+    contract_fit_from_initial(tn_a, tn_b, center, options, tn_c)
+}
+
+/// Build a low-rank, topology-compatible initial state `C₀` for fit contraction.
+///
+/// The returned network has the *same topology* as `tn_a`/`tn_b` and carries
+/// the surviving site indices of the product `A·B` (the site indices not
+/// shared between `tn_a` and `tn_b` at each node), with every bond set to
+/// dimension `bond_dim` and filled deterministically from `seed`.
+///
+/// # Why this avoids the product bond
+///
+/// The construction never contracts `A` and `B`: each output tensor is an
+/// independent random tensor over the output site indices plus its small
+/// bonds. No tensor of dimension proportional to χ_A·χ_B is ever formed, so
+/// the subsequent two-site fit sweeps can grow ranks adaptively (with an SVD
+/// truncation policy and `max_bond_dim = None`) without first building the
+/// exact product.
+///
+/// # Arguments
+/// * `tn_a` - First input TreeTN (real or complex `IdxTensor` tensors).
+/// * `tn_b` - Second input TreeTN.
+/// * `center` - Canonical center for the returned network.
+/// * `bond_dim` - Initial bond dimension of every edge (≥ 1; use 1 for the
+///   "start small and grow" behavior).
+/// * `seed` - Deterministic RNG seed. A fixed seed reproduces the exact same
+///   initializer across runs.
+///
+/// # Errors
+///
+/// Returns an error when the input topologies differ, `bond_dim` is zero, the
+/// input tensors use a dtype other than `f64`/`Complex64`, or metadata
+/// construction fails.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::{
+///     low_rank_initializer_tree_tn, TreeTN,
+/// };
+/// use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
+///
+/// // Two-node chains: A = (s0,a0)-(s1,a1), B = (s0,b0)-(s1,b1). The `s` sites
+/// // are shared (contracted in A·B); `a`/`b` survive into the output.
+/// let s0 = DynIndex::new_dyn(2);
+/// let s1 = DynIndex::new_dyn(2);
+/// let a0 = DynIndex::new_dyn(2);
+/// let a1 = DynIndex::new_dyn(2);
+/// let b0 = DynIndex::new_dyn(2);
+/// let b1 = DynIndex::new_dyn(2);
+/// let ba = DynIndex::new_dyn(2);
+/// let bb = DynIndex::new_dyn(2);
+/// let ta0 = IdxTensor::from_dense(vec![s0.clone(), a0.clone(), ba.clone()], vec![1.0; 8]).unwrap();
+/// let ta1 = IdxTensor::from_dense(vec![ba, s1.clone(), a1], vec![1.0; 8]).unwrap();
+/// let tb0 = IdxTensor::from_dense(vec![s0.clone(), b0.clone(), bb.clone()], vec![1.0; 8]).unwrap();
+/// let tb1 = IdxTensor::from_dense(vec![bb, s1.clone(), b1], vec![1.0; 8]).unwrap();
+/// let tn_a = TreeTN::from_tensors(vec![ta0, ta1], vec![0usize, 1]).unwrap();
+/// let tn_b = TreeTN::from_tensors(vec![tb0, tb1], vec![0usize, 1]).unwrap();
+///
+/// let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &1usize, 1, 42).unwrap();
+/// // Node set is preserved and the single bond starts at dimension 1,
+/// // not chi_a*chi_b.
+/// assert_eq!(init.node_count(), 2);
+/// let bond = init
+///     .edge_between(&0usize, &1usize)
+///     .and_then(|e| init.bond_index(e))
+///     .unwrap()
+///     .dim();
+/// assert_eq!(bond, 1);
+/// assert_eq!(init.site_space(&0).unwrap().len(), 2); // {a0, b0} survive
+/// ```
+pub fn low_rank_initializer_tree_tn<V>(
+    tn_a: &TreeTN<IdxTensor, V>,
+    tn_b: &TreeTN<IdxTensor, V>,
+    center: &V,
+    bond_dim: usize,
+    seed: u64,
+) -> std::result::Result<TreeTN<IdxTensor, V>, TreeTNOperationError>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    if bond_dim == 0 {
+        return Err(anyhow::anyhow!("fit low-rank initializer requires bond_dim >= 1").into());
+    }
+    if !tn_a.same_topology(tn_b) {
+        return Err(
+            anyhow::anyhow!("TreeTNs must have the same topology for fit contraction").into(),
+        );
+    }
+
+    // Dtype of the random fill follows the input networks.
+    let complex = network_tensors_complex(tn_a) || network_tensors_complex(tn_b);
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    // 1. Fresh bond indices for each edge, with the requested dimension.
+    let mut edges: Vec<(V, V)> = tn_a.site_index_network().edges().collect();
+    edges.sort();
+    let mut edge_bond: HashMap<(V, V), DynIndex> = HashMap::with_capacity(edges.len());
+    for (a, b) in &edges {
+        let key = if a < b {
+            (a.clone(), b.clone())
+        } else {
+            (b.clone(), a.clone())
+        };
+        edge_bond.insert(key, DynIndex::new_dyn(bond_dim));
+    }
+
+    // 2. Per-node tensor: surviving site indices (symmetric difference of the
+    //    per-node site spaces of A and B) plus the incident bonds.
+    let mut node_names: Vec<V> = tn_a
+        .site_index_network()
+        .node_names()
+        .into_iter()
+        .cloned()
+        .collect();
+    node_names.sort();
+
+    let mut tensors: Vec<IdxTensor> = Vec::with_capacity(node_names.len());
+    for node in &node_names {
+        let a_sites: HashSet<DynIndex> = tn_a
+            .site_index_network()
+            .site_space(node)
+            .cloned()
+            .unwrap_or_default();
+        let b_sites: HashSet<DynIndex> = tn_b
+            .site_index_network()
+            .site_space(node)
+            .cloned()
+            .unwrap_or_default();
+        let shared: HashSet<DynIndex> = a_sites.intersection(&b_sites).cloned().collect();
+
+        let mut indices: Vec<DynIndex> = Vec::new();
+        indices.extend(a_sites.iter().filter(|s| !shared.contains(*s)).cloned());
+        indices.extend(b_sites.iter().filter(|s| !shared.contains(*s)).cloned());
+        sort_indices_deterministic(&mut indices);
+
+        let mut neighbors: Vec<V> = tn_a.site_index_network().neighbors(node).collect();
+        neighbors.sort();
+        for neighbor in &neighbors {
+            let key = if node < neighbor {
+                (node.clone(), neighbor.clone())
+            } else {
+                (neighbor.clone(), node.clone())
+            };
+            if let Some(bond) = edge_bond.get(&key) {
+                indices.push(bond.clone());
+            }
+        }
+
+        let tensor = if complex {
+            IdxTensor::random::<Complex64, _>(&mut rng, indices.clone())
+                .map_err(TreeTNOperationError::from)?
+        } else {
+            IdxTensor::random::<f64, _>(&mut rng, indices.clone())
+                .map_err(TreeTNOperationError::from)?
+        };
+        tensors.push(tensor);
+    }
+
+    let mut tn_c = TreeTN::from_tensors(tensors, node_names)?;
+    tn_c.set_canonical_region([center.clone()])?;
+    Ok(tn_c)
+}
+
+fn network_tensors_complex<V>(tn: &TreeTN<IdxTensor, V>) -> bool
+where
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    let mut complex = false;
+    for node in tn.site_index_network().node_names() {
+        let node = node.clone();
+        if let Some(idx) = tn.node_index(&node) {
+            if let Some(t) = tn.tensor(idx) {
+                if t.is_complex() {
+                    complex = true;
+                    break;
+                }
+            }
+        }
+    }
+    complex
 }
 
 #[cfg(test)]

--- a/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit/tests/mod.rs
@@ -585,3 +585,356 @@ fn test_contract_fit_handles_leaf_site_space_that_contracts_away() {
     let expected_dense = tn_a.contract_naive(&tn_b).unwrap();
     assert!(fitted_dense.distance(&expected_dense).unwrap() < 1e-10);
 }
+
+// ========================================================================
+// Low-rank adaptive initializer tests
+// ========================================================================
+
+/// Bond dimensions of every edge of `tn`, sorted ascending.
+fn sorted_bond_dims<V>(tn: &TreeTN<IdxTensor, V>) -> Vec<usize>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let mut dims: Vec<usize> = tn
+        .site_index_network()
+        .edges()
+        .map(|(u, v)| {
+            tn.edge_between(&u, &v)
+                .map(|e| tn.bond_index(e).map(|b| b.dim()).unwrap())
+                .unwrap()
+        })
+        .collect();
+    dims.sort_unstable();
+    dims
+}
+
+/// Build a chain of `n` nodes with a shared site `s_i` in both A and B,
+/// a private site `a_i` in A and `b_i` in B, A-bonds of dim `chi_a` and
+/// B-bonds of dim `chi_b`. Node names are `0..n` as `usize`.
+fn make_chain_pair(
+    n: usize,
+    chi_a: usize,
+    chi_b: usize,
+    phys: usize,
+    complex: bool,
+) -> (TreeTN<IdxTensor, usize>, TreeTN<IdxTensor, usize>) {
+    let mut rng = StdRng::seed_from_u64(0xABBAu64 + n as u64);
+    let mut shared: Vec<DynIndex> = Vec::with_capacity(n);
+    let mut a_site: Vec<DynIndex> = Vec::with_capacity(n);
+    let mut b_site: Vec<DynIndex> = Vec::with_capacity(n);
+    for i in 0..n {
+        shared.push(DynIndex::new_dyn_with_tag(phys, &format!("s={}", i)).unwrap());
+        a_site.push(DynIndex::new_dyn_with_tag(phys, &format!("a={}", i)).unwrap());
+        b_site.push(DynIndex::new_dyn_with_tag(phys, &format!("b={}", i)).unwrap());
+    }
+    let la: Vec<DynIndex> = (0..n.saturating_sub(1))
+        .map(|_| DynIndex::new_dyn(chi_a))
+        .collect();
+    let lb: Vec<DynIndex> = (0..n.saturating_sub(1))
+        .map(|_| DynIndex::new_dyn(chi_b))
+        .collect();
+    let (_shared, _a_site, _b_site) = (shared.clone(), a_site.clone(), b_site.clone());
+
+    let mut ta = Vec::with_capacity(n);
+    let mut tb = Vec::with_capacity(n);
+    for i in 0..n {
+        let mut ia = Vec::new();
+        let mut ib = Vec::new();
+        if i > 0 {
+            ia.push(la[i - 1].clone());
+            ib.push(lb[i - 1].clone());
+        }
+        ia.push(shared[i].clone());
+        ib.push(shared[i].clone());
+        ia.push(a_site[i].clone());
+        ib.push(b_site[i].clone());
+        if i < n - 1 {
+            ia.push(la[i].clone());
+            ib.push(lb[i].clone());
+        }
+        let ta_i = if complex {
+            IdxTensor::random::<num_complex::Complex64, _>(&mut rng, ia)
+        } else {
+            IdxTensor::random::<f64, _>(&mut rng, ia)
+        }
+        .unwrap();
+        let tb_i = if complex {
+            IdxTensor::random::<num_complex::Complex64, _>(&mut rng, ib)
+        } else {
+            IdxTensor::random::<f64, _>(&mut rng, ib)
+        }
+        .unwrap();
+        ta.push(ta_i);
+        tb.push(tb_i);
+    }
+    let names: Vec<usize> = (0..n).collect();
+    (
+        TreeTN::from_tensors(ta, names.clone()).unwrap(),
+        TreeTN::from_tensors(tb, names).unwrap(),
+    )
+}
+
+#[test]
+fn test_low_rank_initializer_stays_small_no_product_bond() {
+    // A and B bonds are 6 and 7; an exact product bond would be 42. The
+    // low-rank initializer must never form it: every edge stays at bond_dim.
+    let (tn_a, tn_b) = make_chain_pair(4, 6, 7, 2, false);
+    let center = 3usize;
+
+    let init1 = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 7).unwrap();
+    assert_eq!(sorted_bond_dims(&init1), vec![1, 1, 1]);
+    assert_eq!(init1.node_count(), 4);
+    assert!(init1.same_topology(&tn_a));
+    assert!(tn_a.same_topology(&init1));
+
+    let init3 = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 3, 7).unwrap();
+    assert_eq!(sorted_bond_dims(&init3), vec![3, 3, 3]);
+}
+
+#[test]
+fn test_low_rank_initializer_is_deterministic() {
+    // Bond index identities are freshly allocated per call, so two runs only
+    // agree up to index renaming. The user-visible determinism property is that
+    // fit sweeps from two same-seeded initializers produce identical results.
+    let (tn_a, tn_b) = make_chain_pair(3, 5, 5, 2, false);
+    let center = 2usize;
+
+    let build_init = || {
+        let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 1234).unwrap();
+        contract_fit_from_initial(
+            &tn_a,
+            &tn_b,
+            &center,
+            FitContractionOptions::new(2).with_svd_policy(SvdTruncationPolicy::new(1e-6)),
+            init,
+        )
+        .unwrap()
+    };
+    let r1 = build_init().to_dense().unwrap();
+    let r2 = build_init().to_dense().unwrap();
+    assert!(
+        r1.distance(&r2).unwrap() < 1e-12,
+        "same seed must reproduce the identical fit result"
+    );
+}
+
+#[test]
+fn test_low_rank_initializer_carries_surviving_sites() {
+    let n = 3;
+    let (tn_a, tn_b) = make_chain_pair(n, 4, 4, 2, false);
+    let center = 2usize;
+    let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 5).unwrap();
+
+    // C's site space at node i = (A sites at i ∪ B sites at i) minus the
+    // sites shared between A and B (those are contracted in A·B).
+    for i in 0..n {
+        let a_sites = tn_a.site_index_network().site_space(&i).cloned().unwrap();
+        let b_sites = tn_b.site_index_network().site_space(&i).cloned().unwrap();
+        let shared: HashSet<_> = a_sites.intersection(&b_sites).cloned().collect();
+        let expect: HashSet<DynIndex> = a_sites
+            .iter()
+            .filter(|s| !shared.contains(*s))
+            .chain(b_sites.iter().filter(|s| !shared.contains(*s)))
+            .cloned()
+            .collect();
+        let c_sites = init.site_index_network().site_space(&i).cloned().unwrap();
+        assert_eq!(c_sites, expect, "node {i} site space mismatch");
+    }
+}
+
+#[test]
+fn test_contract_fit_from_rank1_grows_adaptively() {
+    // Two-node pair with surviving sites (from existing helpers). The exact
+    // product needs bond rank > 1; a rank-1 C0 with a tolerance and no
+    // max_bond_dim must grow and converge.
+    let (tn_a, tn_b) = make_contractible_two_node_pair_with_surviving_sites();
+    let center = "A".to_string();
+    let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 9).unwrap();
+
+    // Zero sweeps returns the initializer as-is (rank stays 1).
+    let out0 = contract_fit_from_initial(
+        &tn_a,
+        &tn_b,
+        &center,
+        FitContractionOptions::new(0),
+        init.clone(),
+    )
+    .unwrap();
+    assert_eq!(sorted_bond_dims(&out0), vec![1]);
+    // No option set: ranks are preserved, so the state stays rank-1.
+    let out1 = contract_fit_from_initial(
+        &tn_a,
+        &tn_b,
+        &center,
+        FitContractionOptions::new(2),
+        init.clone(),
+    )
+    .unwrap();
+    assert_eq!(sorted_bond_dims(&out1), vec![1]);
+
+    // With a tolerance and no max_bond_dim the bond must grow beyond rank 1.
+    let opts = FitContractionOptions::new(2).with_svd_policy(SvdTruncationPolicy::new(1e-6));
+    let out = contract_fit_from_initial(&tn_a, &tn_b, &center, opts, init).unwrap();
+    let bd = out
+        .edge_between(&"A".to_string(), &"B".to_string())
+        .map(|e| out.bond_index(e).map(|b| b.dim()).unwrap())
+        .unwrap();
+    assert!(bd > 1, "fit must grow the bond from rank 1, got {bd}");
+
+    let fitted_dense = out.to_dense().unwrap();
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    assert!(fitted_dense.distance(&expected).unwrap() < 1e-6);
+}
+
+#[test]
+fn test_contract_fit_from_initial_rejects_wrong_topology() {
+    let (tn_a, tn_b) = make_contractible_two_node_pair_with_surviving_sites();
+    // A three-node tree has a different node set than the two-node pair.
+    let bad_init = make_three_node_treetn();
+    let err = contract_fit_from_initial(
+        &tn_a,
+        &tn_b,
+        &"A".to_string(),
+        FitContractionOptions::new(1),
+        bad_init,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("same topology"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_low_rank_initializer_requires_bond_dim_at_least_one() {
+    let (tn_a, tn_b) = make_contractible_two_node_pair_with_surviving_sites();
+    let err = low_rank_initializer_tree_tn(&tn_a, &tn_b, &"A".to_string(), 0, 1)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("bond_dim >= 1"), "unexpected error: {err}");
+}
+
+// ========================================================================
+// Complex and branched-tree adaptive fit tests
+// ========================================================================
+
+/// Build a star tree: a center node 0 connected to leaves 1..=n_leaves.
+/// Each A node and B node carries a shared site (contracted) plus a private
+/// site; A and B have their own bonds with the given dimensions.
+#[allow(clippy::too_many_arguments)]
+fn make_star_pair(
+    n_leaves: usize,
+    chi_a: usize,
+    chi_b: usize,
+    phys: usize,
+    complex: bool,
+) -> (TreeTN<IdxTensor, usize>, TreeTN<IdxTensor, usize>) {
+    let mut rng = StdRng::seed_from_u64(0x51a2u64 + n_leaves as u64);
+    let n_nodes = 1 + n_leaves;
+    let mut shared: Vec<DynIndex> = (0..n_nodes)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("s={}", i)).unwrap())
+        .collect();
+    let mut a_site: Vec<DynIndex> = (0..n_nodes)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("a={}", i)).unwrap())
+        .collect();
+    let mut b_site: Vec<DynIndex> = (0..n_nodes)
+        .map(|i| DynIndex::new_dyn_with_tag(phys, &format!("b={}", i)).unwrap())
+        .collect();
+    let mut la: Vec<DynIndex> = (0..n_leaves).map(|_| DynIndex::new_dyn(chi_a)).collect();
+    let mut lb: Vec<DynIndex> = (0..n_leaves).map(|_| DynIndex::new_dyn(chi_b)).collect();
+    let (_s, _a, _b) = (shared.clone(), a_site.clone(), b_site.clone());
+    let (_la, _lb) = (&la, &lb);
+    let _ = (&mut shared, &mut a_site, &mut b_site, &mut la, &mut lb);
+
+    let mut ta = Vec::with_capacity(n_nodes);
+    let mut tb = Vec::with_capacity(n_nodes);
+    // center (node 0): [bonds to each leaf..., shared, a_site] / [...] b_site
+    {
+        let mut ia: Vec<DynIndex> = (0..n_leaves).map(|k| la[k].clone()).collect();
+        ia.push(shared[0].clone());
+        ia.push(a_site[0].clone());
+        let mut ib: Vec<DynIndex> = (0..n_leaves).map(|k| lb[k].clone()).collect();
+        ib.push(shared[0].clone());
+        ib.push(b_site[0].clone());
+        ta.push(pick_random(&mut rng, ia, complex));
+        tb.push(pick_random(&mut rng, ib, complex));
+    }
+    for leaf in 1..=n_leaves {
+        let mut ia: Vec<DynIndex> = vec![
+            la[leaf - 1].clone(),
+            shared[leaf].clone(),
+            a_site[leaf].clone(),
+        ];
+        ia.sort_by_key(|x| x.dim());
+        let mut ib: Vec<DynIndex> = vec![
+            lb[leaf - 1].clone(),
+            shared[leaf].clone(),
+            b_site[leaf].clone(),
+        ];
+        ib.sort_by_key(|x| x.dim());
+        ta.push(pick_random(&mut rng, ia, complex));
+        tb.push(pick_random(&mut rng, ib, complex));
+    }
+    let names: Vec<usize> = (0..n_nodes).collect();
+    (
+        TreeTN::from_tensors(ta, names.clone()).unwrap(),
+        TreeTN::from_tensors(tb, names).unwrap(),
+    )
+}
+
+fn pick_random(rng: &mut StdRng, indices: Vec<DynIndex>, complex: bool) -> IdxTensor {
+    if complex {
+        IdxTensor::random::<num_complex::Complex64, _>(rng, indices).unwrap()
+    } else {
+        IdxTensor::random::<f64, _>(rng, indices).unwrap()
+    }
+}
+
+#[test]
+fn test_low_rank_initializer_and_fit_on_branched_tree() {
+    // Star: center 0 with 3 leaves. Exact product of the two random networks is
+    // compared against the low-rank adaptive fit.
+    let (tn_a, tn_b) = make_star_pair(3, 3, 3, 2, false);
+    let center = 0usize;
+    let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 21).unwrap();
+    assert_eq!(sorted_bond_dims(&init), vec![1, 1, 1]);
+
+    let fit = contract_fit_from_initial(
+        &tn_a,
+        &tn_b,
+        &center,
+        FitContractionOptions::new(3).with_svd_policy(SvdTruncationPolicy::new(1e-8)),
+        init,
+    )
+    .unwrap();
+    let fitted_dense = fit.to_dense().unwrap();
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    let err = fitted_dense.distance(&expected).unwrap();
+    eprintln!("branched fit rel err = {err:.6e}");
+    assert!(
+        err < 1e-6,
+        "branched adaptive fit should match the exact product, rel_err={err:.6e}"
+    );
+}
+
+#[test]
+fn test_adaptive_fit_complex_matches_naive() {
+    // Two-node chain with surviving sites, complex dtype.
+    let (tn_a, tn_b) = make_chain_pair(2, 3, 3, 2, true);
+    let center = 1usize;
+    let init = low_rank_initializer_tree_tn(&tn_a, &tn_b, &center, 1, 5).unwrap();
+    let fit = contract_fit_from_initial(
+        &tn_a,
+        &tn_b,
+        &center,
+        FitContractionOptions::new(4).with_svd_policy(SvdTruncationPolicy::new(1e-8)),
+        init,
+    )
+    .unwrap();
+    let fitted_dense = fit.to_dense().unwrap();
+    let expected = tn_a.contract_naive(&tn_b).unwrap();
+    let err = fitted_dense.distance(&expected).unwrap();
+    eprintln!("complex fit rel err = {err:.6e}");
+    assert!(
+        err < 1e-6,
+        "complex adaptive fit should match the exact product, rel_err={err:.6e}"
+    );
+}

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -49,6 +49,11 @@ pub use cached_evaluator::{
 // Re-export evaluator types
 pub use evaluator::TreeTNEvaluator;
 
+// Re-export fit contraction entry points
+pub use fit::{
+    contract_fit, contract_fit_from_initial, low_rank_initializer_tree_tn, FitContractionOptions,
+};
+
 // Re-export local update types
 pub use localupdate::{
     apply_local_update_sweep, get_boundary_edges, BoundaryEdge, LocalUpdateStep,

--- a/docs/design/itensormps-compatible-zipup.md
+++ b/docs/design/itensormps-compatible-zipup.md
@@ -84,10 +84,15 @@ this change.
 initializer skips the standalone final truncation because the following
 variational sweep is already locally optimal.
 
-A future option may use a looser initialization policy than the fit sweep. No
-hard-coded tolerance transformation is introduced here because
-`SvdTruncationPolicy` supports relative or absolute scaling, values or squared
-values, and per-value or discarded-tail rules.
+The low-rank random initializer is now the default starting state for the
+public `ContractOptions::fit()` path in `tensor4all-itensorlike` — it starts
+every bond at dimension 1 and lets the sweeps grow ranks per the SVD truncation
+policy, so the exact `χ_A·χ_B` product is never materialized during
+initialization. The zip-up initializer remains available explicitly for callers
+who want the exact-start + refine behavior. No hard-coded tolerance
+transformation is introduced here because `SvdTruncationPolicy` supports
+relative or absolute scaling, values or squared values, and per-value or
+discarded-tail rules.
 
 ### Decomposition choice
 
@@ -214,6 +219,10 @@ does not own or commit those benchmark records.
 
 ## Deferred work
 
-- A separately configurable coarse fit-initialization policy.
+- A separately configurable coarse fit-initialization policy. (Implemented:
+  see `FitContractionOptions` / the `FitInitializer`-style split between the
+  topology-preserving zip-up initializer and the deterministic low-rank random
+  initializer used by adaptive tolerance-driven fit. See
+  `benchmarks/results/2026-08-19-adaptive-fit-lowrank-initializer.md`.)
 - Rank-capped or rank-revealing QR suitable for patch-wise initialization.
 - A distinct ITensor-inspired schedule for branched trees.


### PR DESCRIPTION
## Problem

`ContractOptions::fit()` (and the TreeTN `contract_fit`) always started the
variational state with a **topology-preserving zip-up contraction of A·B**.
Without an explicit truncation policy that initializer materializes the *exact
product* — output bonds up to **χ_A·χ_B** per edge, plus intermediates of the
same scale — before any sweep ever runs. For large QTT/MPO bonds this

1. forces a `max_bond_dim` on the user just to keep initialization from
   blowing up, and
2. defeats the purpose of a *variational* (compressing) fit: the product bond
   is constructed first and only then refined.

The requested semantics are `C₀ small → two-site FIT sweeps + tolerance → C ≈ AB`
with adaptive rank growth and **no required rank cap**, and **never** an
explicit χ_A·χ_B product bond as an intermediate.

## What I found in the current implementation

- **The FIT sweeps themselves never construct a χ_A·χ_B product bond.**
  Environments `env[(from,to)]` carry the A-, B- and C-link indices *separately*
  `(χ_A × χ_B × χ_C)` (explicitly allowed). In the two-site update every A/B
  bond is contracted away into the environments before factorization, so the
  local SVD matrix sides are built purely from C-bonds and output sites — no
  χ_A·χ_B term appears in the factorization.
- **Adaptive rank growth already works in the sweeps**: with
  `max_bond_dim = None` and an `svd_policy`, the bond cap is `None`, so ranks
  grow freely per the tolerance; with a cap the cap wins; with neither, existing
  ranks are preserved.
- **The zip-up initializer is the sole offender.** At each edge it builds `R`
  intermediates whose element count scales as `rank · χ_A · χ_B` and, with no
  truncation, emits an output bond of dimension up to `χ_A·χ_B`; the root node
  materializes the full exact contraction. So the product bond is constructed
  *a priori* exactly when the user leaves `max_bond_dim` unset.

This matches upstream behavior: FastMPOContractions.jl defaults to zip-up init
(`init === nothing`), while ITensorMPS.jl's fit starts from a small random
output-site MPS and grows with `maxdim = typemax(Int)` + `cutoff`.

## Design chosen

1. **Split initialization from the sweep engine** in `tensor4all-treetn`:
   - `contract_fit_from_initial(tn_a, tn_b, center, options, tn_c)` — the
     generic two-site sweep engine over a caller-provided `C₀` (the
     initialization, zip-up or otherwise, is now just how you get `C₀`).
   - `low_rank_initializer_tree_tn(tn_a, tn_b, center, bond_dim, seed)` —
     builds a deterministic small-rank random `C₀` carrying the surviving
     output site indices, with every bond at `bond_dim` (default 1). It never
     contracts A and B, so no χ_A·χ_B-sized tensor is ever formed. Concrete on
     `IdxTensor` (`f64`/`Complex64`), which is where seeded random construction
     lives (the generic tensor layer is scalar-erased).
2. **New public default at the `tensor4all-itensorlike` layer**:
   - `FitInitializer { ZipUp, LowRankRandom { bond_dim, seed } }` added to
     `ContractOptions` (`with_initializer` / `initializer()`).
   - `ContractOptions::fit()` defaults to
     `LowRankRandom { bond_dim: 1, seed: None }` (deterministic seed). So
     `fit()` + `with_svd_policy(tol)` and `max_bond_dim = None` now genuinely
     means *unconstrained adaptive rank growth from a small start*, with no
     product-bond intermediate.
   - `FitInitializer::ZipUp` restores the previous exact-start behavior.
   - The generic `treetn::contraction::contract(…, Fit)` dispatcher is
     unchanged (still zip-up init), because a generic random C₀ cannot be built
     for an arbitrary `TensorLike`; callers who need a custom start use
     `contract_fit_from_initial`.

## Alternatives considered (and why rejected)

- **Keep zip-up as the default, add low-rank as opt-in.** Rejected: the
  task's core requirement is that adaptive FIT never constructs the product
  bond; leaving zip-up as the default would keep violating it for every default
  call. The repo is early-stage with no back-compat burden.
- **Generic random construction in the tensor traits.** Rejected: the tensor
  layer is scalar-erased (`TensorLike` has no associated scalar type), so a
  meaningful random tensor for arbitrary `T` is not expressible; `IdxTensor`
  is the right seam.
- **Deterministic identity/product-like init.** Works for correctness but is
  degenerate for products (symmetry traps); seeded random is the standard,
  reproducible choice (ITensorMPS-style) and is what we ship.
- **`max_bond_dim = None` = "grow freely even without a tolerance"**
  (one-site/two-site enrichment with no criterion). Rejected: there is no
  sensible growth criterion without a tolerance or cap; the exact-product
  behavior only survives under explicit `ZipUp` init.

## Exact rank-growth semantics

- `max_bond_dim = Some(cap)` → every sweep bond capped at `cap`.
- `max_bond_dim = None` + `svd_policy` → unconstrained adaptive growth per the
  tolerance (no user rank cap required).
- `max_bond_dim = None` and no policy → existing (initializer-provided) ranks
  are preserved.
- `nfullsweeps = 0` → returns the initializer unchanged.

## Does any χ_A·χ_B-sized intermediate remain?

- **No** χ_A·χ_B output/product bond is created anywhere in the
  low-rank-initialized path: not in initialization (bonds start at 1) and not
  in the sweeps (A/B bonds only appear inside environments as separate
  `(χ_A, χ_B, χ_C)` indices, which is explicitly allowed).
- χ_A·χ_B *transient contraction cost* still appears in environment
  construction (env of shape `χ_A×χ_B×χ_C` is contracted with the local
  tensors) — this is intrinsic to any two-site tree fit and is *cost*, not a
  materialized product bond.
- Under explicit `FitInitializer::ZipUp`, zip-up still forms the exact product
  bond — by explicit opt-in only.

## Tests

- `test_low_rank_initializer_stays_small_no_product_bond` — structural
  regression: with χ_A = 6, χ_B = 7 the initializer must keep every bond at
  `bond_dim` (1/3); would fail if any χ_A·χ_B bond were created.
- `test_low_rank_initializer_carries_surviving_sites` / `_is_deterministic` /
  `_requires_bond_dim_at_least_one`.
- `test_contract_fit_from_rank1_grows_adaptively` — rank-1 C₀ + tolerance,
  `max_bond_dim = None` → bond grows beyond 1 and matches the exact product.
- `adaptive_fit_grows_rank_without_cap`, `adaptive_fit_tolerance_controls_rank_and_error`,
  `adaptive_fit_avoids_product_bond_intermediate` (χ_A·χ_B = 144, compressible
  to rank 12), `adaptive_fit_respects_explicit_cap`.
- Correctness: chains (lengths 2–5, phys 2–3, bonds 2–3), a **branched star
  tree**, and **Complex64**, all matching the exact product to ≤ 1e-6.
- Existing zip-up-based tests (`fit_bond_capping`, `bug_fit_elementwise`,
  `test_contract_fit_nhalfsweeps_zero_ok`) were pinned to
  `FitInitializer::ZipUp` to preserve their original intent under the new
  default.

## Benchmark

`benchmarks/results/2026-08-19-adaptive-fit-lowrank-initializer.md`:
χ_A = χ_B = 24–48, `nsweeps = 3`, tolerance 1e-8, compressible product (B is
the identity padded to bond χ_B):

| χ | zipup exact | fit + zipup init | fit + low-rank init |
|---|------------|------------------|---------------------|
| 24 | 50 ms | 191 ms | 120 ms (err 2.4e-8) |
| 32 | 75 ms | 399 ms | 227 ms |
| 48 | 326 ms | 2.43 s | 1.32 s |

Low-rank-initialized fit is ~1.6–1.8× faster at equal accuracy and never
constructs the χ² intermediate.

## API compatibility

- New public API: `treetn::{contract_fit_from_initial, low_rank_initializer_tree_tn}`
  (+ re-exports), `itensorlike::FitInitializer`, `ContractOptions::with_initializer`
  / `initializer()`, `DEFAULT_FIT_INITIALIZER_SEED`.
- Behavior change: `ContractOptions::fit()` with no explicit initializer now
  starts from a deterministic rank-1 random state instead of the exact zip-up
  state. `FitInitializer::ZipUp` restores the old behavior. The repo's
  "early development, no backward compatibility" policy applies; the affected
  tests were updated deliberately.
- `tensor4all-itensorlike`'s `contract()` drives Fit directly; the treetn
  generic `contraction::contract(…, Fit)` default is unchanged (zip-up init).
- C API: **left untouched** (no ABI change; downstream can reach the adaptive
  path through the same `ContractOptions` surface once exposed if desired).

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo test --release --workspace` (excluding `tensor4all-hdf5` and
  `docs/book-tests`, which need a system HDF5 that is absent in this
  environment — a pre-existing limitation) → **3789 passed, 0 failed**.
- `cargo test --release --doc` for changed crates ✓ (treetn 121, itensorlike 28).
- `cargo clippy` on the changed crates: no warnings in changed files. Note:
  `cargo clippy --workspace -- -D warnings` currently fails on **pristine
  `main`** too (45 pre-existing `nonminimal_bool` lints in `tensor4all-core`
  under rustc 1.96.1), unrelated to this PR.
- `python3 scripts/repository-rules-review.py --base origin/main --worktree
  --dry-run` → pass, no findings.

## Remaining limitations / future work

- The low-rank initializer is concrete on `IdxTensor` (f64/Complex64); other
  dtypes fall back to the zip-up/`Provided` paths. A generic random
  construction would require an associated scalar type on `TensorLike`.
- `max_bond_dim = None` + no tolerance preserves the initial rank; a caller who
  wants compression must supply an `svd_policy`. This is documented.
- Rank-revealing / AMEn-style enrichment and a randomized (SRC-style) variant
  remain future work (see #563).
