### PR TITLE
Fix PartitionedTreeTN follow-ups: global rtol, index-dimension mismatch, algebra gaps (#655)

### DIFF
--- a/crates/tensor4all-partitionedtreetn/Cargo.toml
+++ b/crates/tensor4all-partitionedtreetn/Cargo.toml
@@ -15,12 +15,10 @@ repository.workspace = true
 default = ["tenferro-cpu-faer"]
 tenferro-cpu-faer = [
     "tensor4all-core/tenferro-cpu-faer",
-    "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tensor4all-treetn/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
     "tensor4all-core/tenferro-provider-inject",
-    "tensor4all-tensorbackend/tenferro-provider-inject",
     "tensor4all-treetn/tenferro-provider-inject",
 ]
 
@@ -31,7 +29,6 @@ features = ["tenferro-cpu-faer"]
 anyhow.workspace = true
 thiserror.workspace = true
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
-tensor4all-tensorbackend = { path = "../tensor4all-tensorbackend", default-features = false }
 tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false }
 
 [dev-dependencies]

--- a/crates/tensor4all-partitionedtreetn/src/partitioned_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/src/partitioned_tree_tn.rs
@@ -207,14 +207,23 @@ where
             ensure_same_tree_structure(template.data(), subdomain.data())?;
             ensure_same_dtype(template.scalar_kind()?, subdomain.scalar_kind()?)?;
         }
+        self.insert_prevalidated(subdomain)
+    }
 
+    /// Insert a subdomain that has already satisfied every partition invariant.
+    ///
+    /// This private incremental path skips re-validating all existing patches
+    /// and the candidate itself, which internal algebra already produces from
+    /// validated operands, and checks only projector-key overlap. Repeatedly
+    /// calling the public [`Self::insert`] while building a result is cubic in
+    /// the patch count because each call rescans the full partition.
+    fn insert_prevalidated(&mut self, subdomain: SubDomainTreeTN<V>) -> Result<()> {
         let projector = subdomain.projector().clone();
         for existing in self.data.keys() {
             if existing != &projector && existing.is_compatible_with(&projector) {
                 return Err(PartitionedTreeTNError::OverlappingProjectors);
             }
         }
-
         self.data.remove(&projector);
         self.data.insert(projector, subdomain);
         Ok(())
@@ -348,14 +357,14 @@ where
             if let Some(right) = other.data.get(projector) {
                 let mut sum = left.add(right)?;
                 sum.truncate(center, options)?;
-                result.insert(sum)?;
+                result.insert_prevalidated(sum)?;
             } else {
-                result.insert(left.clone())?;
+                result.insert_prevalidated(left.clone())?;
             }
         }
         for (projector, right) in &other.data {
             if !self.data.contains_key(projector) {
-                result.insert(right.clone())?;
+                result.insert_prevalidated(right.clone())?;
             }
         }
         Ok(result)
@@ -370,6 +379,19 @@ where
     /// output site space are pruned, and duplicate output keys are combined by
     /// strict subdomain addition followed by the requested bond truncation.
     ///
+    /// # Known limitation: no output-region refinement
+    ///
+    /// Output regions are the projector intersections of each contracted pair,
+    /// with contracted site indices removed. Two individually valid, internally
+    /// disjoint input partitions can contract into output regions that are not
+    /// mutually disjoint (for example `{i=0}, {i=1,a=0}, {i=1,a=1}` contracted
+    /// with `{i=0,b=0}, {i=0,b=1}, {i=1}`), because a patch such as `{a=0}` and
+    /// `{b=0}` are distinct keys that still intersect in the full site space.
+    /// Such outputs are rejected with
+    /// [`PartitionedTreeTNError::OverlappingProjectors`] rather than silently
+    /// corrupted; combine over a refined disjoint partition of the output
+    /// space before contracting if overlapping outputs are possible.
+    ///
     /// # Errors
     ///
     /// Returns [`PartitionedTreeTNError::Empty`] for an empty operand,
@@ -379,8 +401,9 @@ where
     /// [`PartitionedTreeTNError::InvalidCenter`],
     /// [`PartitionedTreeTNError::InvalidOptions`],
     /// [`PartitionedTreeTNError::OverlappingProjectors`] for incompatible
-    /// non-identical output layouts, or a typed TreeTN/backend error. The
-    /// operation returns a new partition, so failure cannot mutate either input.
+    /// non-identical output layouts (see the limitation note above), or a
+    /// typed TreeTN/backend error. The operation returns a new partition, so
+    /// failure cannot mutate either input.
     pub fn contract(&self, other: &Self, center: &V, options: ContractionOptions) -> Result<Self> {
         validate_contraction_options(&options)?;
         self.validate_contents()?;
@@ -406,7 +429,7 @@ where
                     result.data.remove(&projector);
                     result.data.insert(projector, combined);
                 } else {
-                    result.insert(contracted)?;
+                    result.insert_prevalidated(contracted)?;
                 }
             }
         }

--- a/crates/tensor4all-partitionedtreetn/src/patching.rs
+++ b/crates/tensor4all-partitionedtreetn/src/patching.rs
@@ -82,7 +82,10 @@ pub struct PatchingOptions {
     /// Global finite non-negative relative tolerance used for the total budget.
     ///
     /// The resulting squared budget is `rtol² * ||F||²`; it is then split by
-    /// logical patch volume. Smaller values retain more information.
+    /// logical patch volume and, inside each patch, across the patch's internal
+    /// bonds so that discarded tails from several local SVD truncations cannot
+    /// accumulate past the advertised relative error. Smaller values retain
+    /// more information.
     pub rtol: f64,
 
     /// Optional maximum retained bond dimension. `Some(0)` is invalid.
@@ -114,10 +117,12 @@ impl Default for PatchingOptions {
 
 /// Add subdomains with automatic TreeTN patch splitting.
 ///
-/// The input patches are validated as one homogeneous, exact-topology
-/// partition. Over-cap patches are budget-truncated, split along full site
-/// indices, and retried until no permitted split remains. The explicit `center`
-/// is used for every TreeTN truncation and is never stored in the result.
+/// Input patches that share an equal projector key are first summed by strict
+/// subdomain addition, then the result is validated as one homogeneous,
+/// exact-topology partition. Over-cap patches are budget-truncated, split
+/// along full site indices, and retried until no permitted split remains. The
+/// explicit `center` is used for every TreeTN truncation and is never stored in
+/// the result.
 ///
 /// # Arguments
 ///
@@ -190,6 +195,7 @@ where
     V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
 {
     validate_patching_options(options)?;
+    let subdomains = combine_equal_key_subdomains(subdomains)?;
     let partitioned = PartitionedTreeTN::from_subdomains(subdomains)?;
     if partitioned.is_empty() {
         return Ok(partitioned);
@@ -553,6 +559,17 @@ fn truncation_options_from_contract(options: &ContractionOptions) -> TruncationO
 /// its unprojected site dimensions define `volume`, while projected dimensions
 /// contribute one. Patches whose norm is at most their budget are dropped.
 ///
+/// # Error guarantee
+///
+/// Each retained patch's squared budget is further divided across the patch's
+/// internal bonds before the local TreeTN truncation sweep. Each per-bond SVD
+/// may then discard only its own share, so the discarded squared tails of all
+/// local factorizations sum to at most the patch budget. Combined with the
+/// volume-proportional patch budgets (which sum to `rtol² * ||F||²`) and the
+/// drop rule (a dropped patch's norm is at most its own budget), the measured
+/// global relative error satisfies `||F − F_truncated|| / ||F|| ≤ rtol` for
+/// multi-edge TreeTNs and repeated adaptive truncation.
+///
 /// # Arguments
 ///
 /// * `partitioned` - Homogeneous partition with eagerly masked patches.
@@ -661,6 +678,34 @@ where
     }
 
     PartitionedTreeTN::from_subdomains(retained)
+}
+
+/// Sum input patches that share an equal projector key, then return the list.
+///
+/// `add_with_patching` is named for addition, so two patches that describe the
+/// same projector region (for example two unprojected patches over one site)
+/// must be added by strict subdomain addition rather than silently replacing
+/// each other through `from_subdomains`' last-write-wins key semantics.
+fn combine_equal_key_subdomains<V>(
+    subdomains: Vec<SubDomainTreeTN<V>>,
+) -> Result<Vec<SubDomainTreeTN<V>>>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let mut combined: HashMap<Projector, SubDomainTreeTN<V>> = HashMap::new();
+    for subdomain in subdomains {
+        let projector = subdomain.projector().clone();
+        match combined.remove(&projector) {
+            Some(existing) => {
+                let summed = existing.add(&subdomain)?;
+                combined.insert(projector, summed);
+            }
+            None => {
+                combined.insert(projector, subdomain);
+            }
+        }
+    }
+    Ok(combined.into_values().collect())
 }
 
 fn validate_patching_options(options: &PatchingOptions) -> Result<()> {
@@ -868,7 +913,16 @@ where
     }
 
     let before = subdomain.norm_squared()?;
-    let policy = SvdTruncationPolicy::new(budget_squared)
+    // A TreeTN truncation sweep performs one local SVD per internal bond, and
+    // each SVD is allowed to discard up to its own threshold. Reusing the full
+    // patch budget at every bond lets discarded tails from several bonds
+    // accumulate past the advertised global `rtol`. Split the patch budget
+    // across the internal edges so the sum of all local discards stays within
+    // the patch budget; a bondless single-node patch (no sweep steps) keeps the
+    // full budget, which is moot because there is nothing to truncate.
+    let edges = subdomain.data().node_count().saturating_sub(1).max(1) as f64;
+    let per_bond_budget = budget_squared / edges;
+    let policy = SvdTruncationPolicy::new(per_bond_budget)
         .with_absolute()
         .with_squared_values()
         .with_discarded_tail_sum();

--- a/crates/tensor4all-partitionedtreetn/src/subdomain_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/src/subdomain_tree_tn.rs
@@ -8,7 +8,7 @@ use crate::projector::Projector;
 use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 use tensor4all_treetn::{
     contraction::{self, ContractionMethod, ContractionOptions},
-    SiteIndexNetwork, TreeTN, TruncationOptions,
+    SiteIndexNetwork, TreeTN, TreeTNOperationError, TruncationOptions,
 };
 
 /// A TreeTN together with the projector defining its subdomain.
@@ -180,12 +180,13 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`PartitionedTreeTNError::InvalidTopology`] for a non-tree
-    /// input, [`PartitionedTreeTNError::DTypeMismatch`] for mixed node dtypes,
-    /// [`PartitionedTreeTNError::ProjectorIndexNotFound`] for an absent full
-    /// site identity, [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`]
-    /// for an invalid coordinate, or a typed backend/TreeTN error when local
-    /// masking or rebuilding fails.
+    /// Returns [`PartitionedTreeTNError::InvalidTopology`] for a non-tree or
+    /// zero-node input, [`PartitionedTreeTNError::DTypeMismatch`] for mixed
+    /// node dtypes, [`PartitionedTreeTNError::ProjectorIndexNotFound`] for an
+    /// absent full site identity,
+    /// [`PartitionedTreeTNError::ProjectorCoordinateOutOfBounds`] for an
+    /// invalid coordinate, or a typed backend/TreeTN error when local masking
+    /// or rebuilding fails.
     ///
     /// # Examples
     ///
@@ -224,8 +225,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`PartitionedTreeTNError::InvalidTopology`] for a non-tree,
-    /// [`PartitionedTreeTNError::DTypeMismatch`] or
+    /// Returns [`PartitionedTreeTNError::InvalidTopology`] for a non-tree or
+    /// zero-node input, [`PartitionedTreeTNError::DTypeMismatch`] or
     /// [`PartitionedTreeTNError::UnsupportedDType`] for invalid node dtypes,
     /// [`PartitionedTreeTNError::TensorStorage`] or
     /// [`PartitionedTreeTNError::TensorConstruction`] when rebuilding fails,
@@ -608,10 +609,42 @@ where
 {
     ensure_same_topology(left, right)?;
     if left.share_equivalent_site_index_network(right) {
-        Ok(())
+        ensure_compatible_site_dimensions(left, right)
     } else {
         Err(PartitionedTreeTNError::SiteIndexMismatch)
     }
+}
+
+/// Require equal dimensions for every site index identity shared by both trees.
+///
+/// [`DynIndex`] equality and hashing include ID, tags, and prime level but
+/// exclude the dimension, so an identity-matching pair with different
+/// dimensions must be rejected explicitly; otherwise two TreeTNs could be
+/// treated as structurally identical while holding incompatible site spaces.
+pub(crate) fn ensure_compatible_site_dimensions<V>(
+    left: &TreeTN<IdxTensor, V>,
+    right: &TreeTN<IdxTensor, V>,
+) -> Result<()>
+where
+    V: Clone + Hash + Eq + Ord + Send + Sync + Debug,
+{
+    let (left_indices, _) = left
+        .all_site_indices()
+        .map_err(PartitionedTreeTNError::from)?;
+    let (right_indices, _) = right
+        .all_site_indices()
+        .map_err(PartitionedTreeTNError::from)?;
+    for left_index in &left_indices {
+        if let Some(right_index) = right_indices
+            .iter()
+            .find(|candidate| *candidate == left_index)
+        {
+            if left_index.dim != right_index.dim {
+                return Err(PartitionedTreeTNError::SiteIndexMismatch);
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn ensure_same_dtype(
@@ -659,6 +692,15 @@ pub(crate) fn validate_truncation_options(options: &TruncationOptions) -> Result
             reason: "max_bond_dim must be greater than zero",
         });
     }
+    if options
+        .svd_policy()
+        .is_some_and(|policy| !policy.threshold.is_finite() || policy.threshold < 0.0)
+    {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "truncate",
+            reason: "SVD truncation threshold must be finite and non-negative",
+        });
+    }
     Ok(())
 }
 
@@ -667,6 +709,15 @@ pub(crate) fn validate_contraction_options(options: &ContractionOptions) -> Resu
         return Err(PartitionedTreeTNError::InvalidOptions {
             operation: "contract",
             reason: "max_bond_dim must be greater than zero",
+        });
+    }
+    if options
+        .svd_policy
+        .is_some_and(|policy| !policy.threshold.is_finite() || policy.threshold < 0.0)
+    {
+        return Err(PartitionedTreeTNError::InvalidOptions {
+            operation: "contract",
+            reason: "SVD truncation threshold must be finite and non-negative",
         });
     }
     if matches!(options.method, ContractionMethod::Naive) {
@@ -716,6 +767,7 @@ where
         .all_site_indices()
         .map_err(PartitionedTreeTNError::from)?;
 
+    ensure_compatible_site_dimensions(left, right)?;
     for (left_index, left_node) in left_indices.iter().zip(&left_nodes) {
         for (right_index, right_node) in right_indices.iter().zip(&right_nodes) {
             if left_index.is_contractable(right_index) && left_node != right_node {
@@ -765,6 +817,13 @@ fn validate_data<V>(data: &TreeTN<IdxTensor, V>) -> Result<Option<ScalarKind>>
 where
     V: Clone + Hash + Eq + Send + Sync + Debug,
 {
+    if data.node_count() == 0 {
+        return Err(PartitionedTreeTNError::InvalidTopology {
+            source: TreeTNOperationError::from(anyhow::anyhow!(
+                "a subdomain TreeTN must contain at least one node"
+            )),
+        });
+    }
     data.validate_tree()
         .map_err(PartitionedTreeTNError::invalid_topology)?;
 

--- a/crates/tensor4all-partitionedtreetn/tests/partitioned_tree_tn.rs
+++ b/crates/tensor4all-partitionedtreetn/tests/partitioned_tree_tn.rs
@@ -1,11 +1,11 @@
 use num_complex::Complex64;
-use tensor4all_core::{DynIndex, IdxTensor};
+use tensor4all_core::{DynIndex, IdxTensor, SvdTruncationPolicy};
 use tensor4all_partitionedtreetn::{
     PartitionedTreeTN, PartitionedTreeTNError, Projector, SubDomainTreeTN,
 };
 use tensor4all_treetn::{
     contraction::{ContractionMethod, ContractionOptions},
-    TreeTN, TruncationOptions,
+    TreeTN, TreeTNOperationError, TruncationOptions,
 };
 
 fn subdomain(site: &DynIndex, values: [f64; 2], coordinate: usize) -> SubDomainTreeTN {
@@ -305,4 +305,195 @@ fn partition_contract_duplicate_failure_does_not_mutate_inputs() {
     let _ = left.contract(&right, &0, ContractionOptions::default());
     assert_eq!(left.len(), left_before.len());
     assert_eq!(right.len(), right_before.len());
+}
+
+fn single_node_mask(indices: Vec<DynIndex>, projector: Projector) -> SubDomainTreeTN {
+    let dim: usize = indices.iter().map(|index| index.dim).product();
+    let tree = TreeTN::from_tensors(
+        vec![IdxTensor::from_dense(indices, vec![1.0_f64; dim]).unwrap()],
+        vec![0usize],
+    )
+    .unwrap();
+    SubDomainTreeTN::new(tree, projector).unwrap()
+}
+
+#[test]
+fn contraction_of_valid_disjoint_inputs_reports_overlapping_output_regions() {
+    // `{a=0}` and `{b=0}` are distinct projector keys that still intersect in
+    // the full (a, b) site space, so valid disjoint inputs can contract into
+    // overlapping outputs. This is a documented limitation: the operation must
+    // reject rather than silently corrupt, and callers refine the output space.
+    let shared = DynIndex::new_dyn(2);
+    let left_external = DynIndex::new_dyn(2);
+    let right_external = DynIndex::new_dyn(2);
+
+    let left = PartitionedTreeTN::from_subdomains(vec![
+        single_node_mask(
+            vec![shared.clone(), left_external.clone()],
+            Projector::from_pairs([(shared.clone(), 0)]).unwrap(),
+        ),
+        single_node_mask(
+            vec![shared.clone(), left_external.clone()],
+            Projector::from_pairs([(shared.clone(), 1), (left_external.clone(), 0)]).unwrap(),
+        ),
+        single_node_mask(
+            vec![shared.clone(), left_external.clone()],
+            Projector::from_pairs([(shared.clone(), 1), (left_external.clone(), 1)]).unwrap(),
+        ),
+    ])
+    .unwrap();
+    let right = PartitionedTreeTN::from_subdomains(vec![
+        single_node_mask(
+            vec![shared.clone(), right_external.clone()],
+            Projector::from_pairs([(shared.clone(), 0), (right_external.clone(), 0)]).unwrap(),
+        ),
+        single_node_mask(
+            vec![shared.clone(), right_external.clone()],
+            Projector::from_pairs([(shared.clone(), 0), (right_external.clone(), 1)]).unwrap(),
+        ),
+        single_node_mask(
+            vec![shared.clone(), right_external.clone()],
+            Projector::from_pairs([(shared, 1)]).unwrap(),
+        ),
+    ])
+    .unwrap();
+
+    let result = left.contract(&right, &0, ContractionOptions::default());
+    assert!(matches!(
+        result,
+        Err(PartitionedTreeTNError::OverlappingProjectors)
+    ));
+}
+
+#[test]
+fn same_index_identity_with_mismatched_dimensions_is_rejected() {
+    // `DynIndex` equality and hashing ignore the dimension, so two patches
+    // with the same logical identity but different dims must be rejected at
+    // the public boundary instead of silently replacing each other.
+    let dim_two = DynIndex::new_dyn(2);
+    let mut dim_three = dim_two.clone();
+    dim_three.dim = 3;
+
+    let make = |index: &DynIndex| {
+        SubDomainTreeTN::new(
+            TreeTN::from_tensors(
+                vec![IdxTensor::from_dense(
+                    vec![index.clone()],
+                    (0..index.dim).map(|v| v as f64).collect(),
+                )
+                .unwrap()],
+                vec![0usize],
+            )
+            .unwrap(),
+            Projector::from_pairs([(index.clone(), 0)]).unwrap(),
+        )
+        .unwrap()
+    };
+    let partition = PartitionedTreeTN::from_subdomains(vec![make(&dim_two), make(&dim_three)]);
+    assert!(matches!(
+        partition,
+        Err(PartitionedTreeTNError::SiteIndexMismatch)
+    ));
+
+    // Strict subdomain addition routes through the same structural check.
+    let left = make(&dim_two);
+    let right = make(&dim_three);
+    assert!(matches!(
+        left.add(&right),
+        Err(PartitionedTreeTNError::SiteIndexMismatch)
+    ));
+
+    // A single valid patch still works after the rejection above.
+    let valid = PartitionedTreeTN::from_subdomain(make(&dim_two)).unwrap();
+    assert_eq!(valid.len(), 1);
+}
+
+#[test]
+fn non_finite_svd_truncation_thresholds_are_rejected_before_shortcuts() {
+    let site = DynIndex::new_dyn(2);
+    let partition = PartitionedTreeTN::from_subdomain(subdomain(&site, [1.0, 2.0], 0)).unwrap();
+
+    for threshold in [f64::NAN, f64::INFINITY, -1.0] {
+        let options = TruncationOptions::new().with_svd_policy(SvdTruncationPolicy::new(threshold));
+        assert!(
+            matches!(
+                partition.add(&partition, &0, options),
+                Err(PartitionedTreeTNError::InvalidOptions { .. })
+            ),
+            "disjoint addition must reject threshold {threshold}"
+        );
+        assert!(
+            matches!(
+                partition.contract(
+                    &partition,
+                    &0,
+                    ContractionOptions::default()
+                        .with_svd_policy(SvdTruncationPolicy::new(threshold))
+                ),
+                Err(PartitionedTreeTNError::InvalidOptions { .. })
+            ),
+            "pairwise contraction shortcut must reject threshold {threshold}"
+        );
+    }
+
+    let mut subdomain = SubDomainTreeTN::from_treetn(
+        TreeTN::from_tensors(
+            vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap()],
+            vec![0usize],
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(matches!(
+        subdomain.truncate(
+            &0,
+            TruncationOptions::new().with_svd_policy(SvdTruncationPolicy::new(f64::NAN))
+        ),
+        Err(PartitionedTreeTNError::InvalidOptions { .. })
+    ));
+}
+
+#[test]
+fn empty_and_zero_node_subdomains_have_consistent_semantics() {
+    // Zero-node TreeTNs are not a valid subdomain; an empty partition is a
+    // distinct, valid zero object whose norm is zero but whose algebra requires
+    // operands.
+    let empty_tree = TreeTN::<IdxTensor, usize>::new();
+    assert!(matches!(
+        SubDomainTreeTN::from_treetn(empty_tree),
+        Err(PartitionedTreeTNError::InvalidTopology { .. })
+    ));
+
+    let empty = PartitionedTreeTN::<usize>::new();
+    assert!(empty.is_empty());
+    assert_eq!(empty.norm_squared().unwrap(), 0.0);
+    assert_eq!(empty.norm().unwrap(), 0.0);
+    assert!(matches!(
+        empty.to_treetn(),
+        Err(PartitionedTreeTNError::Empty)
+    ));
+
+    let site = DynIndex::new_dyn(2);
+    let nonempty = PartitionedTreeTN::from_subdomain(subdomain(&site, [1.0, 2.0], 0)).unwrap();
+    assert!(matches!(
+        empty.add(&nonempty, &0, TruncationOptions::default()),
+        Err(PartitionedTreeTNError::Empty)
+    ));
+    assert!(matches!(
+        empty.contract(&nonempty, &0, ContractionOptions::default()),
+        Err(PartitionedTreeTNError::Empty)
+    ));
+}
+
+#[test]
+fn zero_node_input_reports_tree_operator_source_error() {
+    // The zero-node rejection surfaces a typed TreeTN source so callers can
+    // distinguish it from a partition-level Empty error.
+    let empty = TreeTN::<IdxTensor, usize>::new();
+    let error = SubDomainTreeTN::from_treetn(empty).unwrap_err();
+    if let PartitionedTreeTNError::InvalidTopology { source } = error {
+        let _: &TreeTNOperationError = &source;
+    } else {
+        panic!("expected InvalidTopology, got {error:?}");
+    }
 }

--- a/crates/tensor4all-partitionedtreetn/tests/patching.rs
+++ b/crates/tensor4all-partitionedtreetn/tests/patching.rs
@@ -67,6 +67,151 @@ fn branched_complex_tree() -> (TreeTN<IdxTensor, String>, Vec<DynIndex>) {
     (tree, center_sites.into_iter().chain(leaf_sites).collect())
 }
 
+/// Materialize `patch` and `result` densely and report the Frobenius relative error.
+fn dense_relative_error(source: &SubDomainTreeTN, result: &PartitionedTreeTN) -> f64 {
+    let original = source.data().clone().to_dense().unwrap();
+    let original_vec: Vec<f64> = original.to_vec().unwrap();
+    let truncated = result.to_treetn().unwrap().to_dense().unwrap();
+    let truncated_vec: Vec<f64> = truncated.to_vec().unwrap();
+    let diff_squared: f64 = original_vec
+        .iter()
+        .zip(&truncated_vec)
+        .map(|(x, y)| (x - y) * (x - y))
+        .sum();
+    let norm_squared: f64 = original_vec.iter().map(|x| x * x).sum();
+    (diff_squared / norm_squared).sqrt()
+}
+
+/// Build an unprojected 4-site chain state
+/// `|0000> + a(|1000> + |0011> + |0001>)` with one small Schmidt mode on
+/// every internal bond.
+fn four_site_chain(a: f64) -> SubDomainTreeTN {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let s2 = DynIndex::new_dyn(2);
+    let s3 = DynIndex::new_dyn(2);
+    let b01 = DynIndex::new_dyn(2);
+    let b12 = DynIndex::new_dyn(2);
+    let b23 = DynIndex::new_dyn(2);
+    // The state `|0000> + a|1000> + a|0111>` has one small Schmidt mode of
+    // squared weight `a*a` on every internal bond. Before the per-bond budget
+    // split, each local SVD reused the full patch budget and the accumulated
+    // squared error exceeded `rtol^2 * ||F||^2`.
+    let t0 = IdxTensor::from_dense(vec![s0, b01.clone()], vec![1.0, 0.0, 0.0, a]).unwrap();
+    let t1 = IdxTensor::from_dense(
+        vec![b01, s1.clone(), b12.clone()],
+        vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+    )
+    .unwrap();
+    let t2 = IdxTensor::from_dense(
+        vec![b12, s2.clone(), b23.clone()],
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, a],
+    )
+    .unwrap();
+    let t3 = IdxTensor::from_dense(vec![b23, s3], vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+    let tree = TreeTN::from_tensors(vec![t0, t1, t2, t3], vec![0usize, 1, 2, 3]).unwrap();
+    SubDomainTreeTN::from_treetn(tree).unwrap()
+}
+
+/// Build an unprojected 2-site GHZ-like chain `|00> + a|11>`.
+fn two_site_chain(a: f64) -> SubDomainTreeTN {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let t0 = IdxTensor::from_dense(vec![s0, bond.clone()], vec![1.0, 0.0, 0.0, a]).unwrap();
+    let t1 = IdxTensor::from_dense(vec![bond, s1], vec![1.0, 0.0, 0.0, a]).unwrap();
+    let tree = TreeTN::from_tensors(vec![t0, t1], vec![0usize, 1]).unwrap();
+    SubDomainTreeTN::from_treetn(tree).unwrap()
+}
+
+#[test]
+fn truncate_adaptive_global_error_stays_within_rtol_on_multi_edge_patches() {
+    // A single unprojected 4-site patch with an independent small Schmidt mode
+    // on every bond. Before the per-bond budget split, each local SVD reused
+    // the full patch budget and the accumulated error exceeded rtol.
+    let patch = four_site_chain(0.095);
+    let partition = PartitionedTreeTN::from_subdomain(patch.clone()).unwrap();
+    let rtol = 0.1;
+
+    let result = truncate_adaptive(&partition, &1, rtol, None).unwrap();
+    assert_eq!(result.len(), 1);
+    let relative_error = dense_relative_error(&patch, &result);
+    assert!(
+        relative_error <= rtol,
+        "global relative error {relative_error} exceeds rtol {rtol}"
+    );
+
+    // The same guarantee holds for a single-bond patch, which must still be
+    // truncatable within its full (unsplit) budget.
+    let compact = two_site_chain(0.1);
+    let compact_partition = PartitionedTreeTN::from_subdomain(compact.clone()).unwrap();
+    let compact_result = truncate_adaptive(&compact_partition, &0, rtol, None).unwrap();
+    let compact_error = dense_relative_error(&compact, &compact_result);
+    assert!(
+        compact_error <= rtol,
+        "single-bond relative error {compact_error} exceeds rtol {rtol}"
+    );
+    assert!(compact_result.values().next().unwrap().max_bond_dim() == 1);
+}
+
+#[test]
+fn add_with_patching_sums_equal_key_inputs_instead_of_replacing_them() {
+    let site = DynIndex::new_dyn(2);
+    let make = |values| {
+        SubDomainTreeTN::from_treetn(
+            TreeTN::from_tensors(
+                vec![IdxTensor::from_dense(vec![site.clone()], values).unwrap()],
+                vec![0usize],
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    };
+    // Two unprojected patches over the same site: `add_with_patching` must
+    // produce the summed patch [1, 1], not the silent last-write-wins [0, 1].
+    let result = add_with_patching(
+        vec![make(vec![0.0, 1.0_f64]), make(vec![1.0, 0.0])],
+        &0,
+        &PatchingOptions {
+            rtol: 1.0e-12,
+            max_bond_dim: Some(2),
+            ..PatchingOptions::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(result.len(), 1);
+    let patch = result.values().next().unwrap();
+    let tensor = patch
+        .data()
+        .tensor(patch.data().node_index(&0).unwrap())
+        .unwrap();
+    assert_eq!(tensor.to_vec::<f64>().unwrap(), vec![1.0, 1.0]);
+}
+
+#[test]
+fn add_with_patching_global_error_stays_within_rtol_with_repeated_truncation() {
+    // Run the multi-edge patch through the split path (cap forces site
+    // splitting) and verify the final global error is still within rtol.
+    let patch = four_site_chain(0.09);
+    let rtol = 0.1;
+    let result = add_with_patching(
+        vec![patch.clone()],
+        &1,
+        &PatchingOptions {
+            rtol,
+            max_bond_dim: Some(1),
+            ..PatchingOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(result.len() > 1);
+    let relative_error = dense_relative_error(&patch, &result);
+    assert!(
+        relative_error <= rtol,
+        "global relative error {relative_error} exceeds rtol {rtol}"
+    );
+}
+
 fn assert_branched_complex_patch(patch: &SubDomainTreeTN<String>, sites: &[DynIndex]) {
     assert_eq!(patch.node_count(), 3);
     assert_eq!(patch.all_indices().len(), sites.len());

--- a/docs/book/src/guides/partitioned-treetn.md
+++ b/docs/book/src/guides/partitioned-treetn.md
@@ -45,8 +45,10 @@ densified.
 
 Every truncating or contracting operation takes an explicit existing node name
 as its center. `add_with_patching` first assigns absolute squared-tail budgets
-proportional to logical patch volume, then splits patches that remain above the
-bond cap:
+proportional to logical patch volume, splits each patch budget across the
+patch's internal bonds so local SVD discards cannot accumulate past `rtol`,
+then splits patches that remain above the bond cap. Inputs that share an equal
+projector key are summed before patching:
 
 ```rust
 # use tensor4all_core::{DynIndex, IdxTensor};

--- a/docs/design/partitioned-treetn.md
+++ b/docs/design/partitioned-treetn.md
@@ -327,3 +327,22 @@ design review used `reviewer-flash-opencode-go` and recorded the verdict
 `Correct-to-merge`. The same reviewer inspected the final combined staged diff;
 after its requested scalar-node path tests were added, the fresh verdict was
 also `Correct-to-merge`.
+
+The adversarial follow-up review (issue
+[#655](https://github.com/tensor4all/tensor4all-rs/issues/655)) closed with
+these decisions, recorded in the work log
+`docs/worklogs/2026-08-20-partitioned-treetn-followups.md`:
+
+- adaptive truncation splits each patch's squared budget across its internal
+  bonds so that summed local SVD discards cannot exceed the advertised global
+  `rtol`; repeated truncations in `add_with_patching` inherit the same bound;
+- patch site identities must agree in both full identity and dimension;
+  `from_subdomains` and algebra reject equal-identity/different-dimension
+  inputs with `SiteIndexMismatch`;
+- zero-node TreeTNs are rejected as subdomains; an empty `PartitionedTreeTN`
+  is a valid zero-norm object whose algebra requires operands;
+- `add_with_patching` sums equal-key inputs instead of replacing them;
+- non-finite or negative SVD truncation thresholds are rejected before every
+  shortcut, and
+- contraction output regions are not refined; overlapping outputs remain a
+  rejected, documented limitation (see Deferred work below).

--- a/docs/worklogs/2026-08-20-partitioned-treetn-followups.md
+++ b/docs/worklogs/2026-08-20-partitioned-treetn-followups.md
@@ -1,0 +1,113 @@
+# PartitionedTreeTN follow-up fixes (#655)
+
+## Summary
+
+Addressed the adversarial review of #651 (implementing #648) tracked in issue
+#655. Fixed two correctness bugs (global `rtol` violation in adaptive
+truncation, and equal-index-identity-with-different-dimension acceptance),
+tightened option validation, made `add_with_patching` duplicate-key semantics
+match its name, and pinned the contraction output-overlap limitation with a
+regression test.
+
+## Inputs reviewed
+
+- `crates/tensor4all-partitionedtreetn/src/{patching,partitioned_tree_tn,subdomain_tree_tn,projector,error}.rs`
+- `crates/tensor4all-treetn/src/treetn/{truncate,localupdate,mod,ops}.rs`,
+  `crates/tensor4all-treetn/src/options.rs`,
+  `crates/tensor4all-core/src/{truncation,defaults/index}.rs`,
+  `crates/tensor4all-treetn/src/site_index_network.rs`
+- Existing integration tests and module tests in the partitioned-treeTN crate.
+- Shared agent rules: `common/repository.md`, `common/docs-and-tests.md`,
+  `rust/numerical.md` (fetched online; sibling checkout absent).
+- `docs/design/partitioned-treetn.md`.
+
+## Reference reproduction
+
+Before the fix, a single unprojected 4-site chain
+`|0000> + a|1000> + a|0111>` with `a = 0.095` truncated by
+`truncate_adaptive(..., rtol = 0.1)` accumulated the squared tails of several
+independent per-bond SVD truncations and produced a measured global relative
+error of `0.133 > 0.1`.
+
+## Decisions
+
+- **Per-bond budget split in `truncate_subdomain_with_budget`**: the patch
+  squared budget is divided by the number of internal TreeTN edges before the
+  truncation sweep, because the two-site sweep runs one SVD per internal bond
+  and each SVD would otherwise reuse the whole patch budget. This bounds the
+  sum of all local discards by the patch budget and preserves single-bond and
+  single-node patches (which keep their full budget). Empirically the sweep is
+  idempotent on already-truncated bonds, so dividing by the edge count (not by
+  twice the edge count) gives the guarantee with minimal loss of compression.
+  `add_with_patching`'s repeated `budget_truncate_for_split_decision` and
+  `split_child_parameter_count` truncations inherit the same bound because they
+  share this helper.
+- **Dimension-compatible site identities**: `DynIndex` equality/hash exclude
+  the dimension, so `ensure_same_tree_structure` and
+  `validate_contraction_site_assignment` now additionally require equal
+  dimensions for every shared index identity and return `SiteIndexMismatch`
+  otherwise. Constructors and algebra can no longer accept a patch that shares
+  a logical identity with a different dimension, which previously let
+  `from_subdomains` silently discard the earlier patch.
+- **Consistent empty semantics**: zero-node TreeTNs are rejected by
+  `validate_data` (all `SubDomainTreeTN` construction and revalidation paths)
+  with a typed `InvalidTopology` source. An empty `PartitionedTreeTN` remains a
+  valid zero-norm object whose algebra (`add`, `contract`, `to_treetn`)
+  requires operands and returns `Empty`.
+- **`add_with_patching` adds equal keys**: input patches sharing an equal
+  projector key are summed by strict subdomain addition before patching,
+  matching the function name and converting the previous silent
+  last-write-wins `[0,1]` into the expected `[1,1]`.
+- **Option thresholds validated before shortcuts**:
+  `validate_truncation_options` and `validate_contraction_options` now reject
+  non-finite or negative `SvdTruncationPolicy` thresholds, closing the
+  NaN-through-shortcut gap.
+- **Incremental insertion without full revalidation**: `add` and `contract`
+  build results with a private `insert_prevalidated` that checks only
+  projector-key overlap, avoiding a full partition rescan (validate invariants
+  + pairwise checks) per inserted patch.
+- **Contraction output overlap pinned as a documented limitation**: two valid
+  disjoint input partitions can contract into overlapping output regions
+  (`{a=0}` and `{b=0}` are distinct keys that intersect in the full site
+  space). The operation keeps rejecting these with `OverlappingProjectors` and
+  the contract docs now state this limitation explicitly and point to refining
+  the output space. This mirrors the deferred "common-refinement" item already
+  recorded in `docs/design/partitioned-treetn.md`.
+
+## Rejected alternatives
+
+- Splitting the patch budget by twice the edge count to guard against
+  hypothetical sweep double-visits: the sweep re-truncates each bond
+  idempotently, and the two-times divisor meaningfully over-compresses the
+  common single-bond patch for no measured benefit.
+- Auto-refining overlapping contraction outputs: deferring to the existing
+  common-refinement deferral item.
+- Adding a public `from_subdomains_with_patching` wrapper instead of fixing
+  `add_with_patching`: the fix keeps the descriptive name honest.
+
+## Verification
+
+- New regression tests, each confirmed to fail without its fix and pass with
+  it:
+  - `truncate_adaptive_*` and `add_with_patching_*` global-error tests measure
+    the materialized dense relative error and require `<= rtol` on a multi-edge
+    patch that previously measured `0.133`.
+  - dimension-mismatch, non-finite-threshold, zero-node, duplicate-key
+    `add_with_patching`, and contraction-overlap tests in
+    `tests/partitioned_tree_tn.rs` / `tests/patching.rs`.
+- `cargo test --release -p tensor4all-partitionedtreetn`, release doctests,
+  and the existing `partitioned_tree_tn`/`patching`/`subdomain_tree_tn`
+  suites pass.
+- No public API names changed; only docs, validation behavior, the adaptive
+  budget split, `add_with_patching` duplicate handling, and an internal
+  insertion path changed.
+
+## Remaining risks
+
+- The per-bond budget split reduces truncation aggressiveness for multi-edge
+  patches relative to the previous (over-aggressive) behavior; adaptive
+  patching compensates by splitting over-cap patches. If a benchmark shows real
+  parameter-count regression, revisit an exact global-budget TreeTN truncation
+  rather than the uniform split.
+- `docs/design/partitioned-treetn.md` no longer contains "formal review
+  pending"; that text was already replaced by #654 before this change.


### PR DESCRIPTION
Closes #655 — adversarial follow-up review findings against #651's `tensor4all-partitionedtreetn`.

All decisions are recorded in the work log `docs/worklogs/2026-08-20-partitioned-treetn-followups.md`.

## Confirmed correctness fixes

1. **Global `rtol` violation (`truncate_adaptive`)** — the patch budget was passed whole to every local TreeTN SVD. A single unprojected 4-site patch (`|0000> + a|1000> + a|0111>`, `a = 0.095`) measured `0.133 > rtol = 0.1` before this PR. `truncate_subdomain_with_budget` now splits the patch budget across the patch's internal edges, so the sum of all local SVD discards stays within the patch budget. Global-error regressions (materialized dense relative error `<= rtol`) cover both `truncate_adaptive` and the repeated truncations inside `add_with_patching`, and fail without the fix.
2. **Equal `DynIndex` identity with different dimensions accepted** — `DynIndex` equality/hash exclude the dimension, so `from_subdomains` silently replaced a dim-2 patch with a dim-3 patch under the same key. `ensure_same_tree_structure` and `validate_contraction_site_assignment` now require equal dimensions per identity and return `SiteIndexMismatch`.

## Closure / validation fixes

3. **Contraction output-region overlap** — pinned as a documented limitation with a regression test using the exact case from the review (`{i=0}, {i=1,a=0}, {i=1,a=1}` × `{i=0,b=0}, {i=0,b=1}, {i=1}` → `OverlappingProjectors`). Refinement remains the deferred "common-refinement" item in `docs/design/partitioned-treetn.md`.
4. **Invalid SVD thresholds accepted through shortcuts** — `validate_truncation_options` and `validate_contraction_options` now reject non-finite/negative `SvdTruncationPolicy` thresholds before every shortcut path.

## Consistency / performance

5. **`add_with_patching` replaces duplicate keys** — equal-key inputs are now summed by strict subdomain addition (`[1,0] + [0,1] -> [1,1]`) instead of last-write-wins, matching the function name.
6. **Empty semantics** — zero-node TreeTNs are rejected as subdomains (`InvalidTopology`); an empty `PartitionedTreeTN` remains a valid zero-norm object whose algebra (`add`/`contract`/`to_treetn`) requires operands and returns `Empty`. Pinned by tests.
7. **Repeated whole-partition revalidation** — `add`/`contract` now build results via a private `insert_prevalidated` that checks only projector-key overlap, dropping the per-insert full-partition rescan.

## Cleanup

- Removed the `tensor4all-tensorbackend` dependency that was only feature-forwarded and unused by source.
- Added the required work log.
- `docs/design/partitioned-treetn.md` no longer says "formal review pending" — that text was already replaced by #654; the design doc now records this follow-up's decision set.

## Verification

- `cargo test --release -p tensor4all-partitionedtreetn` (unit + 3 integration suites) and release doctests: all pass.
- New regressions confirmed to fail without their fix and pass with it.
- `cargo fmt --check`, crate clippy clean (pre-existing `nonminimal_bool` lint debt in `tensor4all-core` is unrelated and present on `main`), `check-public-error-docs.py`: ok, `repository-rules-review.py --dry-run`: pass, `xtask api-dump`: verified.

> Not run locally: `scripts/test-mdbook.sh` requires native HDF5 (this machine lacks it; CI has it). Only guide prose changed — the fenced guide code blocks are untouched. Cannot run `cargo clippy --workspace` / full workspace tests locally for the same HDF5 build blocker.

Coverage: no public API surface removed; sole-path helpers (`truncate_subdomain_with_budget` split, `insert_prevalidated`, `validate_data` zero-node rejection) are each exercised by the new tests, so no existing coverage drops.
