### PR TITLE
Add variational fitting for TreeTN sums

### DIFF
--- a/crates/tensor4all-core/src/matrixluci/source.rs
+++ b/crates/tensor4all-core/src/matrixluci/source.rs
@@ -68,7 +68,7 @@ impl<'a, T: Scalar> DenseMatrixSource<'a, T> {
             expected.is_some(),
             "dense matrix source shape product overflow"
         );
-        let expected = expected.map_or(0, |expected| expected);
+        let expected = expected.unwrap_or(0);
         assert_eq!(data.len(), expected);
         Self { data, nrows, ncols }
     }
@@ -104,7 +104,7 @@ impl<T: Scalar> CandidateMatrixSource<T> for DenseMatrixSource<'_, T> {
             expected.is_some(),
             "dense matrix block shape product overflow"
         );
-        let expected = expected.map_or(0, |expected| expected);
+        let expected = expected.unwrap_or(0);
         assert_eq!(out.len(), expected);
         for (j, &col) in cols.iter().enumerate() {
             for (i, &row) in rows.iter().enumerate() {
@@ -136,7 +136,7 @@ where
             expected.is_some(),
             "lazy matrix block shape product overflow"
         );
-        let expected = expected.map_or(0, |expected| expected);
+        let expected = expected.unwrap_or(0);
         assert_eq!(out.len(), expected);
         (self.fill_block)(rows, cols, out);
     }

--- a/crates/tensor4all-tensorbackend/src/matrix.rs
+++ b/crates/tensor4all-tensorbackend/src/matrix.rs
@@ -439,7 +439,7 @@ impl<T> Matrix<T> {
             expected.is_some(),
             "matrix shape product overflow: {nrows} rows * {ncols} columns"
         );
-        let expected = expected.map_or(0, |expected| expected);
+        let expected = expected.unwrap_or(0);
         assert_eq!(data.len(), expected);
         Self { data, nrows, ncols }
     }
@@ -939,7 +939,7 @@ impl<T: Clone> Matrix<T> {
             len.is_some(),
             "matrix shape product overflow: {nrows} rows * {ncols} columns"
         );
-        let len = len.map_or(0, |len| len);
+        let len = len.unwrap_or(0);
         Self {
             data: vec![elem; len],
             nrows,
@@ -984,7 +984,7 @@ impl<T: Clone + Zero> Matrix<T> {
             len.is_some(),
             "matrix shape product overflow: {nrows} rows * {ncols} columns"
         );
-        let len = len.map_or(0, |len| len);
+        let len = len.unwrap_or(0);
         Self {
             data: vec![T::zero(); len],
             nrows,

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -82,6 +82,7 @@ pub use treetn::{
     // Decomposition
     factorize_tensor_to_treetn,
     factorize_tensor_to_treetn_with,
+    fit_sum,
     get_boundary_edges,
     hadamard,
     partial_contract,
@@ -91,6 +92,7 @@ pub use treetn::{
     BoundaryEdge,
     CachedEvaluatorOptions,
     CenterSearchResult,
+    FitOptions,
     // Core type
     GreedyCenterSearch,
     LocalUpdateStep,

--- a/crates/tensor4all-treetn/src/treetn/fit.rs
+++ b/crates/tensor4all-treetn/src/treetn/fit.rs
@@ -31,12 +31,13 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use tensor4all_core::{
     print_and_reset_contract_profile, print_and_reset_native_einsum_profile,
-    reset_contract_profile, reset_native_einsum_profile, sort_indices_deterministic, Canonical,
-    FactorizeAlg, FactorizeOptions, FactorizeResult, IndexLike, SvdTruncationPolicy, TensorLike,
+    reset_contract_profile, reset_native_einsum_profile, sort_indices_deterministic, AnyScalar,
+    Canonical, FactorizeAlg, FactorizeOptions, FactorizeResult, IndexLike, SvdTruncationPolicy,
+    TensorLike,
 };
 
 use super::localupdate::{LocalUpdateStep, LocalUpdateSweepPlan, LocalUpdater};
@@ -509,6 +510,266 @@ where
 // Environment computation helpers
 // ============================================================================
 
+/// Environment cache for one sum target and the current variational state.
+#[derive(Debug, Clone)]
+struct SumFitEnvironment<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq,
+{
+    envs: HashMap<(V, V), T>,
+}
+
+impl<T, V> SumFitEnvironment<T, V>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    fn new() -> Self {
+        Self {
+            envs: HashMap::new(),
+        }
+    }
+
+    fn get_or_compute(
+        &mut self,
+        from: &V,
+        to: &V,
+        target: &TreeTN<T, V>,
+        psi: &TreeTN<T, V>,
+    ) -> std::result::Result<T, TreeTNOperationError> {
+        if let Some(env) = self.envs.get(&(from.clone(), to.clone())) {
+            return Ok(env.clone());
+        }
+
+        let child_neighbors = sorted_neighbors_by_node_index(
+            psi,
+            from,
+            Some(to),
+            "SumFitEnvironment::get_or_compute",
+        )?;
+        let child_envs = child_neighbors
+            .iter()
+            .map(|child| self.get_or_compute(child, from, target, psi))
+            .collect::<std::result::Result<Vec<_>, TreeTNOperationError>>()?;
+
+        let target_tensor = tensor_at_node(target, from, "sum target")?;
+        let psi_conj = tensor_at_node(psi, from, "fit state")?.conj();
+        let mut tensor_refs = vec![target_tensor, &psi_conj];
+        tensor_refs.extend(child_envs.iter());
+        let env = contract_fit_tensor_refs(&tensor_refs)
+            .map_err(|e| anyhow::anyhow!("sum target environment contraction failed: {e}"))?;
+        self.envs.insert((from.clone(), to.clone()), env.clone());
+        Ok(env)
+    }
+
+    fn prepare(
+        &mut self,
+        target: &TreeTN<T, V>,
+        psi: &TreeTN<T, V>,
+    ) -> std::result::Result<(), TreeTNOperationError> {
+        for from in psi.node_names() {
+            let neighbors: Vec<_> = psi.site_index_network().neighbors(&from).collect();
+            for to in neighbors {
+                self.get_or_compute(&from, &to, target, psi)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn invalidate(
+        &mut self,
+        region: &[V],
+        psi: &TreeTN<T, V>,
+    ) -> std::result::Result<(), TreeTNOperationError> {
+        for node in region {
+            let neighbors =
+                sorted_neighbors_by_node_index(psi, node, None, "SumFitEnvironment::invalidate")?;
+            for neighbor in neighbors {
+                self.invalidate_recursive(node, &neighbor, psi)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn invalidate_recursive(
+        &mut self,
+        from: &V,
+        to: &V,
+        psi: &TreeTN<T, V>,
+    ) -> std::result::Result<(), TreeTNOperationError> {
+        if self.envs.remove(&(from.clone(), to.clone())).is_some() {
+            let neighbors = sorted_neighbors_by_node_index(
+                psi,
+                to,
+                Some(from),
+                "SumFitEnvironment::invalidate_recursive",
+            )?;
+            for neighbor in neighbors {
+                self.invalidate_recursive(to, &neighbor, psi)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FitFactorizeConfig {
+    max_bond_dim: Option<usize>,
+    svd_policy: Option<SvdTruncationPolicy>,
+    qr_rtol: Option<f64>,
+    factorize_alg: FactorizeAlg,
+}
+
+fn fit_factorize_options(config: FitFactorizeConfig) -> Result<FactorizeOptions> {
+    let mut options = match config.factorize_alg {
+        FactorizeAlg::SVD => FactorizeOptions::svd(),
+        FactorizeAlg::QR => FactorizeOptions::qr(),
+        FactorizeAlg::LU => FactorizeOptions::lu(),
+        FactorizeAlg::CI => FactorizeOptions::ci(),
+    }
+    .with_canonical(Canonical::Left);
+    if let Some(max_bond_dim) = config.max_bond_dim {
+        options = options.with_max_bond_dim(max_bond_dim);
+    }
+    if let Some(policy) = config.svd_policy {
+        options = options.with_svd_policy(policy);
+    }
+    if let Some(qr_rtol) = config.qr_rtol {
+        options = options.with_qr_rtol(qr_rtol);
+    }
+    options
+        .validate()
+        .map_err(|e| anyhow::anyhow!("invalid fit factorization options: {e}"))?;
+    Ok(options)
+}
+
+fn fit_two_site_update<T, V>(
+    mut subtree: TreeTN<T, V>,
+    step: &LocalUpdateStep<V>,
+    full_treetn: &TreeTN<T, V>,
+    local_optimum: T,
+    left_bond_indices: &[T::Index],
+    config: FitFactorizeConfig,
+) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let node_u = step
+        .nodes
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("fit two-site update requires a first node"))?;
+    let node_v = step
+        .nodes
+        .get(1)
+        .ok_or_else(|| anyhow::anyhow!("fit two-site update requires a second node"))?;
+    let site_c_u = full_treetn.site_space(node_u).cloned().ok_or_else(|| {
+        anyhow::anyhow!(
+            "fit two-site update: site space for node {:?} not found in full TreeTN",
+            node_u
+        )
+    })?;
+
+    let local_indices = local_optimum.external_indices();
+    let left_inds_started = fit_profile_enabled().then(Instant::now);
+    let mut left_inds: Vec<_> = local_indices
+        .iter()
+        .filter(|idx| site_c_u.contains(*idx) || left_bond_indices.iter().any(|bond| bond == *idx))
+        .cloned()
+        .collect();
+    sort_indices_deterministic(&mut left_inds);
+    if let Some(left_inds_started) = left_inds_started {
+        with_fit_profile(|profile| {
+            profile.left_inds_time += left_inds_started.elapsed();
+        });
+    }
+
+    let mut options = fit_factorize_options(config)?;
+    let bond_cap = if config.max_bond_dim.is_some() {
+        config.max_bond_dim
+    } else if config.svd_policy.is_some() || config.qr_rtol.is_some() {
+        None
+    } else {
+        subtree
+            .edge_between(node_u, node_v)
+            .and_then(|edge| subtree.bond_index(edge))
+            .map(|bond| bond.dim())
+    };
+    if let Some(bond_cap) = bond_cap {
+        options = options.with_max_bond_dim(bond_cap);
+    }
+
+    let factorize_started = fit_profile_enabled().then(Instant::now);
+    let factorize_result = if left_inds.is_empty() || left_inds.len() == local_indices.len() {
+        let (dummy_left, dummy_right) = T::Index::create_dummy_link_pair();
+        let dummy_left_tensor = T::ones(std::slice::from_ref(&dummy_left))
+            .map_err(|e| anyhow::anyhow!("failed to create dummy left tensor: {e}"))?;
+        let dummy_right_tensor = T::ones(std::slice::from_ref(&dummy_right))
+            .map_err(|e| anyhow::anyhow!("failed to create dummy right tensor: {e}"))?;
+        let (left, right) = if left_inds.is_empty() {
+            let right = local_optimum
+                .outer_product(&dummy_right_tensor)
+                .map_err(|e| anyhow::anyhow!("failed to attach dummy right bond: {e}"))?;
+            (dummy_left_tensor, right)
+        } else {
+            let left = local_optimum
+                .outer_product(&dummy_left_tensor)
+                .map_err(|e| anyhow::anyhow!("failed to attach dummy left bond: {e}"))?;
+            (left, dummy_right_tensor)
+        };
+        FactorizeResult {
+            left,
+            right,
+            bond_index: dummy_left,
+            singular_values: None,
+            rank: 1,
+        }
+    } else {
+        local_optimum
+            .factorize(&left_inds, &options)
+            .map_err(|e| anyhow::anyhow!("factorization failed: {e}"))?
+    };
+    if let Some(factorize_started) = factorize_started {
+        with_fit_profile(|profile| {
+            profile.factorize_time += factorize_started.elapsed();
+        });
+    }
+
+    let edge_uv = subtree.edge_between(node_u, node_v).ok_or_else(|| {
+        anyhow::anyhow!(
+            "fit two-site update: subtree is missing edge between {:?} and {:?}",
+            node_u,
+            node_v
+        )
+    })?;
+    let idx_u_sub = subtree
+        .node_index(node_u)
+        .ok_or_else(|| anyhow::anyhow!("fit two-site update: node {:?} not found", node_u))?;
+    let idx_v_sub = subtree
+        .node_index(node_v)
+        .ok_or_else(|| anyhow::anyhow!("fit two-site update: node {:?} not found", node_v))?;
+
+    let replace_started = fit_profile_enabled().then(Instant::now);
+    subtree.replace_edge_bond(edge_uv, factorize_result.bond_index.clone())?;
+    subtree
+        .replace_tensor(idx_u_sub, factorize_result.left)?
+        .ok_or_else(|| anyhow::anyhow!("fit two-site update: first node disappeared"))?;
+    subtree
+        .replace_tensor(idx_v_sub, factorize_result.right)?
+        .ok_or_else(|| anyhow::anyhow!("fit two-site update: second node disappeared"))?;
+    subtree.set_ortho_towards(&factorize_result.bond_index, Some(step.new_center.clone()));
+    subtree.set_canonical_region([step.new_center.clone()])?;
+    if let Some(replace_started) = replace_started {
+        with_fit_profile(|profile| {
+            profile.replace_time += replace_started.elapsed();
+        });
+    }
+    Ok(subtree)
+}
+
 /// Compute environment for a leaf node (no children in subtree).
 fn compute_leaf_environment<T, V>(
     node: &V,
@@ -683,11 +944,10 @@ where
 {
     fn update(
         &mut self,
-        mut subtree: TreeTN<T, V>,
+        subtree: TreeTN<T, V>,
         step: &LocalUpdateStep<V>,
         full_treetn: &TreeTN<T, V>,
     ) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError> {
-        // FitUpdater is designed for nsite=2
         if step.nodes.len() != 2 {
             return Err(anyhow::anyhow!(
                 "FitUpdater requires exactly 2 nodes, got {}",
@@ -701,12 +961,6 @@ where
         with_fit_profile(|profile| {
             profile.step_count += 1;
         });
-
-        // Get tensors
-        let a_u = tensor_at_node(&self.tn_a, node_u, "tn_a")?;
-        let a_v = tensor_at_node(&self.tn_a, node_v, "tn_a")?;
-        let b_u = tensor_at_node(&self.tn_b, node_u, "tn_b")?;
-        let b_v = tensor_at_node(&self.tn_b, node_v, "tn_b")?;
 
         if full_treetn.node_index(node_u).is_none() {
             return Err(anyhow::anyhow!("Node {:?} not found in full TreeTN", node_u).into());
@@ -723,11 +977,12 @@ where
             .into());
         }
 
-        // Collect environments from neighbors (excluding the edge between u and v)
-        // Uses lazy evaluation: computes and caches if not already present
-        let mut env_tensors: Vec<T> = Vec::new();
+        let a_u = tensor_at_node(&self.tn_a, node_u, "tn_a")?;
+        let a_v = tensor_at_node(&self.tn_a, node_v, "tn_a")?;
+        let b_u = tensor_at_node(&self.tn_b, node_u, "tn_b")?;
+        let b_v = tensor_at_node(&self.tn_b, node_v, "tn_b")?;
 
-        // Environments from u's neighbors (except v)
+        let mut env_tensors = Vec::new();
         let u_neighbors =
             sorted_neighbors_by_node_index(full_treetn, node_u, None, "FitUpdater::update")?;
         let mut left_bond_indices = Vec::new();
@@ -750,192 +1005,52 @@ where
                 )
             })?;
             left_bond_indices.push(bond.clone());
-            let env =
-                self.envs
-                    .get_or_compute(neighbor, node_u, &self.tn_a, &self.tn_b, full_treetn)?;
-            env_tensors.push(env);
+            env_tensors.push(self.envs.get_or_compute(
+                neighbor,
+                node_u,
+                &self.tn_a,
+                &self.tn_b,
+                full_treetn,
+            )?);
         }
 
-        // Environments from v's neighbors (except u)
         let v_neighbors =
             sorted_neighbors_by_node_index(full_treetn, node_v, None, "FitUpdater::update")?;
         for neighbor in &v_neighbors {
-            if neighbor == node_u {
-                continue;
+            if neighbor != node_u {
+                env_tensors.push(self.envs.get_or_compute(
+                    neighbor,
+                    node_v,
+                    &self.tn_a,
+                    &self.tn_b,
+                    full_treetn,
+                )?);
             }
-            let env =
-                self.envs
-                    .get_or_compute(neighbor, node_v, &self.tn_a, &self.tn_b, full_treetn)?;
-            env_tensors.push(env);
         }
 
-        // Compute optimal 2-site tensor: env × A[u] × B[u] × A[v] × B[v] × env.
-        // Collect all tensors and let contract() find the optimal contraction order.
         let contract_started = fit_profile_enabled().then(Instant::now);
-        let mut tensor_refs: Vec<&T> = vec![a_u, b_u, a_v, b_v];
+        let mut tensor_refs = vec![a_u, b_u, a_v, b_v];
         tensor_refs.extend(env_tensors.iter());
-        let ab_uv = contract_fit_tensor_refs(&tensor_refs)?;
+        let local_optimum = contract_fit_tensor_refs(&tensor_refs)?;
         if let Some(contract_started) = contract_started {
             with_fit_profile(|profile| {
                 profile.two_site_contract_time += contract_started.elapsed();
             });
         }
 
-        // The result ab_uv is the optimal 2-site tensor
-        // Factorize to get new C[u] and C[v]
-
-        // Determine left indices (indices that will remain on u after factorization)
-        let left_inds_started = fit_profile_enabled().then(Instant::now);
-        let site_c_u = full_treetn.site_space(node_u).cloned().ok_or_else(|| {
-            anyhow::anyhow!(
-                "FitUpdater: site space for node {:?} not found in full TreeTN",
-                node_u
-            )
-        })?;
-        let ab_uv_indices = ab_uv.external_indices();
-        let mut left_inds: Vec<_> = ab_uv_indices
-            .iter()
-            .filter(|idx| {
-                // Keep site indices of u and link indices to u's other neighbors
-                site_c_u.contains(*idx) || left_bond_indices.iter().any(|bond| bond == *idx)
-            })
-            .cloned()
-            .collect();
-        sort_indices_deterministic(&mut left_inds);
-        if let Some(left_inds_started) = left_inds_started {
-            with_fit_profile(|profile| {
-                profile.left_inds_time += left_inds_started.elapsed();
-            });
-        }
-
-        // Set up factorization options
-        let mut options = match self.factorize_alg {
-            FactorizeAlg::SVD => FactorizeOptions::svd(),
-            FactorizeAlg::QR => FactorizeOptions::qr(),
-            FactorizeAlg::LU => FactorizeOptions::lu(),
-            FactorizeAlg::CI => FactorizeOptions::ci(),
-        };
-        options = options.with_canonical(Canonical::Left);
-
-        if let Some(policy) = self.svd_policy {
-            options = options.with_svd_policy(policy);
-        }
-        if let Some(qr_rtol) = self.qr_rtol {
-            options = options.with_qr_rtol(qr_rtol);
-        }
-        options
-            .validate()
-            .map_err(|e| anyhow::anyhow!("invalid fit factorization options: {e}"))?;
-
-        // Determine bond dimension cap for this factorization step.
-        // - If max_bond_dim is explicitly specified, use it.
-        // - If an algorithm-specific tolerance is specified (but max_bond_dim is not),
-        //   allow bonds to grow freely and let the factorization policy decide.
-        // - Otherwise, cap at the existing bond dimension to preserve the zipup
-        //   initialization size.
-        let bond_cap = if self.max_bond_dim.is_some() {
-            self.max_bond_dim
-        } else if self.svd_policy.is_some() || self.qr_rtol.is_some() {
-            None
-        } else {
-            subtree
-                .edge_between(node_u, node_v)
-                .and_then(|e| subtree.bond_index(e))
-                .map(|b| b.dim())
-        };
-        if let Some(cap) = bond_cap {
-            options = options.with_max_bond_dim(cap);
-        }
-
-        // Factorize using TensorFactorizationLike::factorize
-        let factorize_started = fit_profile_enabled().then(Instant::now);
-        let factorize_result = if left_inds.is_empty() || left_inds.len() == ab_uv_indices.len() {
-            let (dummy_left, dummy_right) = T::Index::create_dummy_link_pair();
-            let dummy_left_tensor = T::ones(std::slice::from_ref(&dummy_left))
-                .map_err(|e| anyhow::anyhow!("Failed to create dummy left tensor: {e}"))?;
-            let dummy_right_tensor = T::ones(std::slice::from_ref(&dummy_right))
-                .map_err(|e| anyhow::anyhow!("Failed to create dummy right tensor: {e}"))?;
-
-            let (left, right) = if left_inds.is_empty() {
-                let right = ab_uv
-                    .outer_product(&dummy_right_tensor)
-                    .map_err(|e| anyhow::anyhow!("Failed to attach dummy right bond: {e}"))?;
-                (dummy_left_tensor, right)
-            } else {
-                let left = ab_uv
-                    .outer_product(&dummy_left_tensor)
-                    .map_err(|e| anyhow::anyhow!("Failed to attach dummy left bond: {e}"))?;
-                (left, dummy_right_tensor)
-            };
-
-            FactorizeResult {
-                left,
-                right,
-                bond_index: dummy_left,
-                singular_values: None,
-                rank: 1,
-            }
-        } else {
-            ab_uv
-                .factorize(&left_inds, &options)
-                .map_err(|e| anyhow::anyhow!("Factorization failed: {}", e))?
-        };
-        if let Some(factorize_started) = factorize_started {
-            with_fit_profile(|profile| {
-                profile.factorize_time += factorize_started.elapsed();
-            });
-        }
-
-        let new_tensor_u = factorize_result.left;
-        let new_tensor_v = factorize_result.right;
-        let new_bond = factorize_result.bond_index;
-
-        // Get edge between u and v
-        let edge_uv = subtree.edge_between(node_u, node_v).ok_or_else(|| {
-            anyhow::anyhow!(
-                "FitUpdater: subtree is missing edge between {:?} and {:?}",
-                node_u,
-                node_v
-            )
-        })?;
-
-        // Update subtree with new bond and tensors
-        let idx_u_sub = subtree.node_index(node_u).ok_or_else(|| {
-            anyhow::anyhow!("FitUpdater: node {:?} not found in update subtree", node_u)
-        })?;
-        let idx_v_sub = subtree.node_index(node_v).ok_or_else(|| {
-            anyhow::anyhow!("FitUpdater: node {:?} not found in update subtree", node_v)
-        })?;
-
-        let replace_started = fit_profile_enabled().then(Instant::now);
-        subtree.replace_edge_bond(edge_uv, new_bond.clone())?;
-        subtree
-            .replace_tensor(idx_u_sub, new_tensor_u)?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "FitUpdater: node {:?} disappeared before tensor replacement",
-                    node_u
-                )
-            })?;
-        subtree
-            .replace_tensor(idx_v_sub, new_tensor_v)?
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "FitUpdater: node {:?} disappeared before tensor replacement",
-                    node_v
-                )
-            })?;
-
-        // Set ortho_towards
-        subtree.set_ortho_towards(&new_bond, Some(step.new_center.clone()));
-        subtree.set_canonical_region([step.new_center.clone()])?;
-        if let Some(replace_started) = replace_started {
-            with_fit_profile(|profile| {
-                profile.replace_time += replace_started.elapsed();
-            });
-        }
-
-        Ok(subtree)
+        fit_two_site_update(
+            subtree,
+            step,
+            full_treetn,
+            local_optimum,
+            &left_bond_indices,
+            FitFactorizeConfig {
+                max_bond_dim: self.max_bond_dim,
+                svd_policy: self.svd_policy,
+                qr_rtol: self.qr_rtol,
+                factorize_alg: self.factorize_alg,
+            },
+        )
     }
 
     fn after_step(
@@ -956,29 +1071,315 @@ where
 }
 
 // ============================================================================
+// Shared Euler-tour sweep loop
+// ============================================================================
+fn run_fit_sweeps<T, V, U>(
+    treetn: &mut TreeTN<T, V>,
+    plan: &LocalUpdateSweepPlan<V>,
+    updater: &mut U,
+    nfullsweeps: usize,
+    convergence_tol: Option<f64>,
+) -> Result<()>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+    U: LocalUpdater<T, V>,
+{
+    use super::localupdate::apply_local_update_sweep;
+
+    for _sweep in 0..nfullsweeps {
+        with_fit_profile(|profile| {
+            profile.sweep_count += 1;
+        });
+        let log_norm_before = convergence_tol.map(|_| treetn.log_norm()).transpose()?;
+        let sweep_started = fit_profile_enabled().then(Instant::now);
+        apply_local_update_sweep(treetn, plan, updater)?;
+        if let Some(sweep_started) = sweep_started {
+            with_fit_profile(|profile| {
+                profile.sweep_time += sweep_started.elapsed();
+            });
+        }
+
+        if let (Some(log_norm_before), Some(tol)) = (log_norm_before, convergence_tol) {
+            let log_norm_after = treetn.log_norm()?;
+            let relative_change = (f64::exp(log_norm_after - log_norm_before) - 1.0).abs();
+            if relative_change < tol {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn finish_fit_profile(entry_point: &str) {
+    if let Some(profile) = take_fit_profile() {
+        eprintln!("=== {entry_point} Profiling ===");
+        eprintln!("zipup init:        {:?}", profile.zipup_init_time);
+        eprintln!("canonicalize:      {:?}", profile.canonicalize_time);
+        eprintln!("sweeps total:      {:?}", profile.sweep_time);
+        eprintln!("steps:             {}", profile.step_count);
+        eprintln!("sweeps:            {}", profile.sweep_count);
+        eprintln!(
+            "env get:           {:?} (requests={}, hits={}, misses={})",
+            profile.env_get_time, profile.env_requests, profile.env_hits, profile.env_misses
+        );
+        eprintln!("env leaf compute:  {:?}", profile.env_leaf_time);
+        eprintln!("env node compute:  {:?}", profile.env_internal_time);
+        eprintln!("2-site contract:   {:?}", profile.two_site_contract_time);
+        eprintln!("left_inds:         {:?}", profile.left_inds_time);
+        eprintln!("factorize:         {:?}", profile.factorize_time);
+        eprintln!("replace/update:    {:?}", profile.replace_time);
+        eprintln!("invalidate:        {:?}", profile.invalidate_time);
+    }
+    print_and_reset_contract_profile();
+    print_and_reset_native_einsum_profile();
+}
+
+#[derive(Debug)]
+struct SumFitUpdater<T, V>
+where
+    T: TensorLike,
+    V: Clone + Hash + Eq + Send + Sync + std::fmt::Debug,
+{
+    targets: Vec<TreeTN<T, V>>,
+    envs: Vec<SumFitEnvironment<T, V>>,
+    factorize_config: FitFactorizeConfig,
+}
+
+impl<T, V> SumFitUpdater<T, V>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    fn new(
+        targets: Vec<TreeTN<T, V>>,
+        max_bond_dim: Option<usize>,
+        svd_policy: Option<SvdTruncationPolicy>,
+        qr_rtol: Option<f64>,
+        factorize_alg: FactorizeAlg,
+    ) -> Self {
+        let envs = targets.iter().map(|_| SumFitEnvironment::new()).collect();
+        Self {
+            targets,
+            envs,
+            factorize_config: FitFactorizeConfig {
+                max_bond_dim,
+                svd_policy,
+                qr_rtol,
+                factorize_alg,
+            },
+        }
+    }
+
+    fn prepare(&mut self, psi: &TreeTN<T, V>) -> std::result::Result<(), TreeTNOperationError> {
+        for (target_index, (target, env)) in
+            self.targets.iter().zip(self.envs.iter_mut()).enumerate()
+        {
+            env.prepare(target, psi).map_err(|error| {
+                anyhow::anyhow!(
+                    "fit_sum: target {target_index} initial environment construction failed: {error}"
+                )
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl<T, V> LocalUpdater<T, V> for SumFitUpdater<T, V>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    fn update(
+        &mut self,
+        subtree: TreeTN<T, V>,
+        step: &LocalUpdateStep<V>,
+        full_treetn: &TreeTN<T, V>,
+    ) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError> {
+        if step.nodes.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "fit_sum updater requires exactly 2 nodes, got {}",
+                step.nodes.len()
+            )
+            .into());
+        }
+        let node_u = &step.nodes[0];
+        let node_v = &step.nodes[1];
+        if full_treetn.node_index(node_u).is_none() || full_treetn.node_index(node_v).is_none() {
+            return Err(anyhow::anyhow!("fit_sum updater step references a missing node").into());
+        }
+        if full_treetn.edge_between(node_u, node_v).is_none() {
+            return Err(anyhow::anyhow!("fit_sum updater step nodes are not adjacent").into());
+        }
+        with_fit_profile(|profile| {
+            profile.step_count += 1;
+        });
+
+        let u_neighbors =
+            sorted_neighbors_by_node_index(full_treetn, node_u, None, "fit_sum updater")?;
+        let v_neighbors =
+            sorted_neighbors_by_node_index(full_treetn, node_v, None, "fit_sum updater")?;
+        let mut left_bond_indices = Vec::new();
+        for neighbor in &u_neighbors {
+            if neighbor == node_v {
+                continue;
+            }
+            let edge = full_treetn.edge_between(node_u, neighbor).ok_or_else(|| {
+                anyhow::anyhow!("fit_sum updater: missing edge to a neighboring node")
+            })?;
+            let bond = full_treetn
+                .bond_index(edge)
+                .ok_or_else(|| anyhow::anyhow!("fit_sum updater: missing neighboring bond"))?;
+            left_bond_indices.push(bond.clone());
+        }
+
+        let mut local_sum: Option<T> = None;
+        for (target_index, (target, env)) in
+            self.targets.iter().zip(self.envs.iter_mut()).enumerate()
+        {
+            let target_u = tensor_at_node(target, node_u, "sum target")
+                .map_err(|error| anyhow::anyhow!("fit_sum: target {target_index}: {error}"))?;
+            let target_v = tensor_at_node(target, node_v, "sum target")
+                .map_err(|error| anyhow::anyhow!("fit_sum: target {target_index}: {error}"))?;
+            let mut env_tensors = Vec::new();
+            for neighbor in &u_neighbors {
+                if neighbor != node_v {
+                    env_tensors.push(
+                        env.get_or_compute(neighbor, node_u, target, full_treetn)
+                            .map_err(|error| {
+                                anyhow::anyhow!(
+                                    "fit_sum: target {target_index} environment contraction failed: {error}"
+                                )
+                            })?,
+                    );
+                }
+            }
+            for neighbor in &v_neighbors {
+                if neighbor != node_u {
+                    env_tensors.push(
+                        env.get_or_compute(neighbor, node_v, target, full_treetn)
+                            .map_err(|error| {
+                                anyhow::anyhow!(
+                                    "fit_sum: target {target_index} environment contraction failed: {error}"
+                                )
+                            })?,
+                    );
+                }
+            }
+
+            let contract_started = fit_profile_enabled().then(Instant::now);
+            let mut tensor_refs = vec![target_u, target_v];
+            tensor_refs.extend(env_tensors.iter());
+            let contribution = contract_fit_tensor_refs(&tensor_refs).map_err(|error| {
+                anyhow::anyhow!(
+                    "fit_sum: target {target_index} local contribution contraction failed: {error}"
+                )
+            })?;
+            if let Some(contract_started) = contract_started {
+                with_fit_profile(|profile| {
+                    profile.two_site_contract_time += contract_started.elapsed();
+                });
+            }
+
+            local_sum = Some(match local_sum {
+                None => contribution,
+                Some(accumulated) => accumulated
+                    .axpby(
+                        AnyScalar::new_real(1.0),
+                        &contribution,
+                        AnyScalar::new_real(1.0),
+                    )
+                    .map_err(|error| {
+                        anyhow::anyhow!(
+                            "fit_sum: target {target_index} tensor accumulation failed: {error}"
+                        )
+                    })?,
+            });
+        }
+        let local_sum =
+            local_sum.ok_or_else(|| anyhow::anyhow!("fit_sum: no targets to accumulate"))?;
+        fit_two_site_update(
+            subtree,
+            step,
+            full_treetn,
+            local_sum,
+            &left_bond_indices,
+            self.factorize_config,
+        )
+        .map_err(|error| anyhow::anyhow!("fit_sum: two-site update failed: {error}"))
+        .map_err(TreeTNOperationError::from)
+    }
+
+    fn after_step(
+        &mut self,
+        step: &LocalUpdateStep<V>,
+        full_treetn_after: &TreeTN<T, V>,
+    ) -> std::result::Result<(), TreeTNOperationError> {
+        let started = fit_profile_enabled().then(Instant::now);
+        for (target_index, env) in self.envs.iter_mut().enumerate() {
+            env.invalidate(&step.nodes, full_treetn_after)
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "fit_sum: target {target_index} environment invalidation failed: {error}"
+                    )
+                })?;
+        }
+        if let Some(started) = started {
+            with_fit_profile(|profile| {
+                profile.invalidate_time += started.elapsed();
+            });
+        }
+        Ok(())
+    }
+}
+
 // High-level API: contract_fit
 // ============================================================================
 
-/// Options for fit contraction.
+/// Options for [`fit_sum`] and `contract_fit`.
+///
+/// The crate-root [`crate::FitOptions`] alias exposes this type for sum fitting.
+/// A zero sweep count is valid and returns the validated initial state for
+/// [`fit_sum`]. Invalid dimensions or tolerances are rejected before that
+/// short-circuit.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::FitOptions;
+///
+/// let options = FitOptions::new(0).with_max_bond_dim(2);
+/// assert_eq!(options.nfullsweeps, 0);
+/// assert_eq!(options.max_bond_dim, Some(2));
+/// ```
 #[derive(Debug, Clone)]
 pub struct FitContractionOptions {
     /// Number of full sweeps to perform.
     ///
     /// A full sweep visits each edge twice (forward and backward) using an Euler tour.
+    /// `0` skips fitting after validation; positive values perform that many sweeps
+    /// unless `convergence_tol` stops earlier.
     pub nfullsweeps: usize,
-    /// Maximum bond dimension.
+    /// Optional maximum output bond dimension. `None` preserves the existing
+    /// bond-space cap when no truncation policy overrides it; `Some(0)` is invalid.
     pub max_bond_dim: Option<usize>,
     /// Legacy relative tolerance retained for same-crate tests and call chains.
     pub(crate) rtol: Option<f64>,
-    /// Explicit SVD truncation policy.
+    /// Explicit SVD truncation policy. Its settings are validated before fitting,
+    /// including when `nfullsweeps == 0`.
     pub svd_policy: Option<SvdTruncationPolicy>,
-    /// QR-specific relative tolerance.
+    /// QR-specific relative tolerance. It must be finite and non-negative and
+    /// must be accepted by the selected factorization algorithm.
     pub qr_rtol: Option<f64>,
-    /// Factorization algorithm.
+    /// Factorization algorithm used for local two-site updates.
     pub factorize_alg: FactorizeAlg,
     /// Tolerance for early termination based on relative change.
-    /// If `None`, run exactly `nfullsweeps` sweeps.
-    /// If `Some(tol)`, stop early if `||C_{i+1} - C_i|| / ||C_i|| < tol`.
+    /// If `None`, run exactly `nfullsweeps` sweeps. If `Some(tol)`, `tol` must
+    /// be finite and non-negative; fitting stops when the relative change in
+    /// the network norm is below `tol`.
     pub convergence_tol: Option<f64>,
 }
 
@@ -1047,6 +1448,201 @@ impl FitContractionOptions {
     }
 }
 
+fn validate_fit_sum_options(options: &FitContractionOptions) -> Result<()> {
+    if let Some(tol) = options.convergence_tol {
+        if !tol.is_finite() || tol < 0.0 {
+            return Err(anyhow::anyhow!(
+                "convergence tolerance must be finite and non-negative"
+            ));
+        }
+    }
+    if let Some(qr_rtol) = options.qr_rtol {
+        if !qr_rtol.is_finite() || qr_rtol < 0.0 {
+            return Err(anyhow::anyhow!(
+                "QR relative tolerance must be finite and non-negative"
+            ));
+        }
+    }
+    fit_factorize_options(FitFactorizeConfig {
+        max_bond_dim: options.max_bond_dim,
+        svd_policy: options.svd_policy,
+        qr_rtol: options.qr_rtol,
+        factorize_alg: options.factorize_alg,
+    })?;
+    Ok(())
+}
+
+/// Fit a TreeTN to the sum of one or more target TreeTNs.
+///
+/// The `initial` network supplies the output topology, site-index identities,
+/// and starting bond spaces. Each target is reindexed to that site space before
+/// the variational sweeps; target bonds remain private to their term.
+///
+/// # Arguments
+/// * `targets` - Non-empty target networks with the same named topology and
+///   per-node site dimensions as `initial`.
+/// * `initial` - The required initial approximation and output topology.
+/// * `center` - The node at which canonicalization and the Euler-tour sweeps
+///   start.
+/// * `options` - Fit sweep, factorization, truncation, and convergence options.
+///   `nfullsweeps == 0` returns an unchanged clone of `initial` after validation.
+///
+/// # Errors
+///
+/// Returns [`TreeTNOperationError`] when validation, site reindexing,
+/// environment construction, tensor contraction, accumulation, or
+/// factorization fails.
+///
+/// # Examples
+/// ```
+/// use tensor4all_core::{DynIndex, IdxTensor};
+/// use tensor4all_treetn::{fit_sum, FitOptions, TreeTN};
+///
+/// let site = DynIndex::new_dyn(2);
+/// let make = |values| {
+///     TreeTN::<IdxTensor, usize>::from_tensors(
+///         vec![IdxTensor::from_dense(vec![site.clone()], values).unwrap()],
+///         vec![0],
+///     )
+///     .unwrap()
+/// };
+/// let targets = [make(vec![1.0, 2.0]), make(vec![3.0, 4.0])];
+/// let initial = make(vec![0.0, 0.0]);
+/// let fitted = fit_sum(&targets, &initial, &0, FitOptions::new(1)).unwrap();
+/// assert_eq!(
+///     fitted
+///         .to_dense()
+///         .unwrap()
+///         .to_vec::<f64>()
+///         .unwrap(),
+///     vec![4.0, 6.0]
+/// );
+/// ```
+pub fn fit_sum<T, V>(
+    targets: &[TreeTN<T, V>],
+    initial: &TreeTN<T, V>,
+    center: &V,
+    options: FitContractionOptions,
+) -> std::result::Result<TreeTN<T, V>, TreeTNOperationError>
+where
+    T: TensorLike,
+    <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
+    V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
+{
+    let profile_enabled = fit_profile_enabled();
+    if profile_enabled {
+        fit_profile_reset();
+    }
+    reset_contract_profile();
+    reset_native_einsum_profile();
+
+    validate_fit_sum_options(&options).context("fit_sum: invalid options")?;
+    if targets.is_empty() {
+        return Err(anyhow::anyhow!("fit_sum: targets must not be empty").into());
+    }
+    if initial.node_count() == 0 {
+        return Err(anyhow::anyhow!("fit_sum: initial TreeTN must not be empty").into());
+    }
+    initial
+        .verify_internal_consistency()
+        .context("fit_sum: initial TreeTN validation failed")?;
+    if initial.node_index(center).is_none() {
+        return Err(anyhow::anyhow!("fit_sum: center node is not in initial TreeTN").into());
+    }
+
+    let mut aligned_targets = Vec::with_capacity(targets.len());
+    for (target_index, target) in targets.iter().enumerate() {
+        if target.node_count() == 0 {
+            return Err(
+                anyhow::anyhow!("fit_sum: target {target_index} TreeTN must not be empty").into(),
+            );
+        }
+        target
+            .verify_internal_consistency()
+            .with_context(|| format!("fit_sum: target {target_index} TreeTN validation failed"))?;
+        if !target.same_topology(initial) {
+            return Err(anyhow::anyhow!(
+                "fit_sum: target {target_index} has an incompatible named topology"
+            )
+            .into());
+        }
+        let aligned = target.reindex_site_space_like(initial).with_context(|| {
+            format!("fit_sum: target {target_index} site-space validation failed")
+        })?;
+        aligned_targets.push(aligned.sim_internal_inds());
+    }
+
+    if options.nfullsweeps == 0 {
+        finish_fit_profile("fit_sum");
+        return Ok(initial.clone());
+    }
+
+    if initial.node_count() == 1 {
+        let node = initial.node_names().into_iter().next().ok_or_else(|| {
+            anyhow::anyhow!("fit_sum: initial node disappeared during validation")
+        })?;
+        let mut local_sum: Option<T> = None;
+        for (target_index, target) in aligned_targets.iter().enumerate() {
+            let tensor = tensor_at_node(target, &node, "sum target")
+                .with_context(|| format!("fit_sum: target {target_index} tensor lookup failed"))?;
+            local_sum = Some(match local_sum {
+                None => tensor.clone(),
+                Some(accumulated) => accumulated
+                    .axpby(AnyScalar::new_real(1.0), tensor, AnyScalar::new_real(1.0))
+                    .with_context(|| {
+                        format!("fit_sum: target {target_index} tensor accumulation failed")
+                    })?,
+            });
+        }
+        let local_sum = local_sum.ok_or_else(|| anyhow::anyhow!("fit_sum: no targets to sum"))?;
+        let node_index = initial
+            .node_index(&node)
+            .ok_or_else(|| anyhow::anyhow!("fit_sum: initial node lookup failed"))?;
+        let mut result = initial.clone();
+        result
+            .replace_tensor(node_index, local_sum)
+            .context("fit_sum: failed to replace one-node result tensor")?
+            .ok_or_else(|| anyhow::anyhow!("fit_sum: one-node result disappeared"))?;
+        finish_fit_profile("fit_sum");
+        return Ok(result);
+    }
+
+    let canonicalize_started = profile_enabled.then(Instant::now);
+    let mut psi = initial.clone();
+    psi.canonicalize_mut(
+        std::iter::once(center.clone()),
+        crate::options::CanonicalizationOptions::forced(),
+    )
+    .context("fit_sum: failed to canonicalize initial TreeTN")?;
+    if let Some(canonicalize_started) = canonicalize_started {
+        with_fit_profile(|profile| {
+            profile.canonicalize_time += canonicalize_started.elapsed();
+        });
+    }
+
+    let mut updater = SumFitUpdater::new(
+        aligned_targets,
+        options.max_bond_dim,
+        options.svd_policy,
+        options.qr_rtol,
+        options.factorize_alg,
+    );
+    updater
+        .prepare(&psi)
+        .context("fit_sum: failed to build initial target environments")?;
+    let plan = LocalUpdateSweepPlan::from_treetn(&psi, center, 2)
+        .ok_or_else(|| anyhow::anyhow!("fit_sum: failed to create two-site sweep plan"))?;
+    run_fit_sweeps(
+        &mut psi,
+        &plan,
+        &mut updater,
+        options.nfullsweeps,
+        options.convergence_tol,
+    )?;
+    finish_fit_profile("fit_sum");
+    Ok(psi)
+}
+
 /// Contract two TreeTNs using the fit (variational) algorithm.
 ///
 /// This algorithm minimizes `||A*B - C||²` iteratively by optimizing
@@ -1076,7 +1672,6 @@ where
     <T::Index as IndexLike>::Id: Clone + std::hash::Hash + Eq + Ord + std::fmt::Debug + Send + Sync,
     V: Clone + Hash + Eq + Ord + Send + Sync + std::fmt::Debug,
 {
-    use super::localupdate::apply_local_update_sweep;
     use crate::CanonicalForm;
     let profile_enabled = fit_profile_enabled();
     if profile_enabled {
@@ -1114,6 +1709,7 @@ where
     // counts are honored even when no truncation override is provided, so
     // callers can explicitly exercise the variational update path.
     if options.nfullsweeps == 0 {
+        finish_fit_profile("contract_fit");
         return Ok(tn_c);
     }
 
@@ -1127,61 +1723,14 @@ where
     let plan = LocalUpdateSweepPlan::from_treetn(&tn_c, center, 2)
         .ok_or_else(|| anyhow::anyhow!("Failed to create sweep plan"))?;
 
-    // Perform sweeps
-    for _sweep in 0..options.nfullsweeps {
-        with_fit_profile(|profile| {
-            profile.sweep_count += 1;
-        });
-        let log_norm_before = if options.convergence_tol.is_some() {
-            Some(tn_c.log_norm()?)
-        } else {
-            None
-        };
-
-        let sweep_started = profile_enabled.then(Instant::now);
-        apply_local_update_sweep(&mut tn_c, &plan, &mut updater)?;
-        if let Some(sweep_started) = sweep_started {
-            with_fit_profile(|profile| {
-                profile.sweep_time += sweep_started.elapsed();
-            });
-        }
-
-        // Check convergence using log_norm
-        if let (Some(tol), Some(log_norm_before)) = (options.convergence_tol, log_norm_before) {
-            let log_norm_after = tn_c.log_norm()?;
-            // relative change in norm: |exp(log_after) - exp(log_before)| / exp(log_before)
-            // = |exp(log_after - log_before) - 1|
-            let relative_change = (f64::exp(log_norm_after - log_norm_before) - 1.0).abs();
-            if relative_change < tol {
-                break;
-            }
-        }
-    }
-
-    if let Some(profile) = take_fit_profile() {
-        eprintln!("=== contract_fit Profiling ===");
-        eprintln!("zipup init:        {:?}", profile.zipup_init_time);
-        eprintln!("canonicalize:      {:?}", profile.canonicalize_time);
-        eprintln!("sweeps total:      {:?}", profile.sweep_time);
-        eprintln!("steps:             {}", profile.step_count);
-        eprintln!("sweeps:            {}", profile.sweep_count);
-        eprintln!(
-            "env get:           {:?} (requests={}, hits={}, misses={})",
-            profile.env_get_time, profile.env_requests, profile.env_hits, profile.env_misses
-        );
-        eprintln!("env leaf compute:  {:?}", profile.env_leaf_time);
-        eprintln!("env node compute:  {:?}", profile.env_internal_time);
-        eprintln!("2-site contract:   {:?}", profile.two_site_contract_time);
-        eprintln!("left_inds:         {:?}", profile.left_inds_time);
-        eprintln!("factorize:         {:?}", profile.factorize_time);
-        eprintln!("replace/update:    {:?}", profile.replace_time);
-        eprintln!("invalidate:        {:?}", profile.invalidate_time);
-    }
-    // These are tensor4all-owned profiling hooks, intentionally kept during the
-    // migration so fit profiling still works without the removed tenferro
-    // runtime APIs.
-    print_and_reset_contract_profile();
-    print_and_reset_native_einsum_profile();
+    run_fit_sweeps(
+        &mut tn_c,
+        &plan,
+        &mut updater,
+        options.nfullsweeps,
+        options.convergence_tol,
+    )?;
+    finish_fit_profile("contract_fit");
 
     Ok(tn_c)
 }

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -55,6 +55,9 @@ pub use localupdate::{
     LocalUpdateSweepPlan, LocalUpdater, TruncateUpdater,
 };
 
+// Re-export the variational sum-fit entry point and its contraction options alias.
+pub use fit::{fit_sum, FitContractionOptions as FitOptions};
+
 // Re-export partial contraction types
 pub use partial_contraction::{
     hadamard, partial_contract, partial_contract_to_site_network, sum_over_indices,

--- a/crates/tensor4all-treetn/tests/fit_sum.rs
+++ b/crates/tensor4all-treetn/tests/fit_sum.rs
@@ -1,0 +1,592 @@
+use tensor4all_core::{DynIndex, IdxTensor, IndexLike, TensorElement};
+use tensor4all_treetn::{fit_sum, FitOptions, TreeTN};
+
+fn one_node<T: TensorElement>(site: &DynIndex, values: Vec<T>) -> TreeTN<IdxTensor, usize> {
+    TreeTN::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], values).unwrap()],
+        vec![0],
+    )
+    .unwrap()
+}
+
+#[test]
+fn fit_sum_one_node_sums_targets_exactly() {
+    let site = DynIndex::new_dyn(2);
+    let targets = [
+        one_node(&site, vec![1.0, 2.0]),
+        one_node(&site, vec![3.0, 4.0]),
+    ];
+    let initial = one_node(&site, vec![0.0, 0.0]);
+    let result = fit_sum(&targets, &initial, &0, FitOptions::new(1)).unwrap();
+
+    assert_eq!(
+        result.to_dense().unwrap().to_vec::<f64>().unwrap(),
+        vec![4.0, 6.0]
+    );
+}
+
+#[test]
+fn fit_sum_two_node_matches_dense_sum() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let b1 = DynIndex::new_dyn(2);
+    let b2 = DynIndex::new_dyn(3);
+    let b_initial = DynIndex::new_dyn(2);
+
+    let target_one = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![s0.clone(), b1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap(),
+            IdxTensor::from_dense(vec![b1, s1.clone()], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let target_two = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![s0.clone(), b2.clone()],
+                vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(vec![b2, s1.clone()], vec![2.0, 4.0, 6.0, 8.0, 10.0, 12.0])
+                .unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![s0.clone(), b_initial.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(vec![b_initial, s1], vec![1.0, 1.0, 1.0, 1.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+
+    let expected_one = target_one.contract_to_tensor().unwrap();
+    let expected_two = target_two.contract_to_tensor().unwrap();
+    let expected = expected_one
+        .axpby(
+            tensor4all_core::AnyScalar::new_real(1.0),
+            &expected_two,
+            tensor4all_core::AnyScalar::new_real(1.0),
+        )
+        .unwrap();
+    let result = fit_sum(
+        &[target_one, target_two],
+        &initial,
+        &0,
+        FitOptions::new(1).with_max_bond_dim(2),
+    )
+    .unwrap();
+    let actual = result.contract_to_tensor().unwrap();
+    assert!(actual.distance(&expected).unwrap() < 1e-10);
+}
+
+#[test]
+fn fit_sum_one_node_supports_complex_dense_values() {
+    use num_complex::Complex64;
+
+    let site = DynIndex::new_dyn(2);
+    let targets = [
+        one_node(
+            &site,
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 1.0)],
+        ),
+        one_node(
+            &site,
+            vec![Complex64::new(4.0, -1.0), Complex64::new(2.0, 5.0)],
+        ),
+    ];
+    let result = fit_sum(
+        &targets,
+        &one_node(
+            &site,
+            vec![Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0)],
+        ),
+        &0,
+        FitOptions::new(1),
+    )
+    .unwrap();
+    assert_eq!(
+        result.to_dense().unwrap().to_vec::<Complex64>().unwrap(),
+        vec![Complex64::new(5.0, 1.0), Complex64::new(-1.0, 6.0)]
+    );
+}
+
+#[test]
+fn fit_sum_preserves_backend_real_to_complex_promotion() {
+    use num_complex::Complex64;
+
+    let site = DynIndex::new_dyn(2);
+    let real = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0, 2.0]).unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    let complex = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(
+            vec![site.clone()],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(-1.0, 2.0)],
+        )
+        .unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(vec![site], vec![0.0, 0.0]).unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    let result = fit_sum(&[real, complex], &initial, &0, FitOptions::new(1)).unwrap();
+    assert_eq!(
+        result.to_dense().unwrap().to_vec::<Complex64>().unwrap(),
+        vec![Complex64::new(4.0, 4.0), Complex64::new(1.0, 2.0)]
+    );
+}
+
+#[test]
+fn fit_sum_two_node_complex_matches_dense_sum() {
+    use num_complex::Complex64;
+
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let b1 = DynIndex::new_dyn(2);
+    let b2 = DynIndex::new_dyn(2);
+    let b_initial = DynIndex::new_dyn(2);
+    let c = Complex64::new;
+
+    let target_one = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![s0.clone(), b1.clone()],
+                vec![c(1.0, 1.0), c(0.0, 0.0), c(0.0, 0.0), c(2.0, -1.0)],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![b1, s1.clone()],
+                vec![c(1.0, 2.0), c(2.0, -1.0), c(3.0, 1.0), c(4.0, -2.0)],
+            )
+            .unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let target_two = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![s0.clone(), b2.clone()],
+                vec![c(2.0, -1.0), c(0.0, 0.0), c(0.0, 0.0), c(-1.0, 3.0)],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![b2, s1.clone()],
+                vec![c(2.0, 1.0), c(4.0, -2.0), c(6.0, 1.0), c(8.0, -3.0)],
+            )
+            .unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![s0, b_initial.clone()],
+                vec![c(1.0, 0.0), c(0.0, 0.0), c(0.0, 0.0), c(1.0, 0.0)],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(vec![b_initial, s1], vec![c(1.0, 0.0); 4]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+
+    let expected = target_one
+        .contract_to_tensor()
+        .unwrap()
+        .axpby(
+            tensor4all_core::AnyScalar::new_complex(1.0, 0.0),
+            &target_two.contract_to_tensor().unwrap(),
+            tensor4all_core::AnyScalar::new_complex(1.0, 0.0),
+        )
+        .unwrap();
+    let result = fit_sum(
+        &[target_one, target_two],
+        &initial,
+        &0,
+        FitOptions::new(1).with_max_bond_dim(2),
+    )
+    .unwrap();
+    let actual = result.contract_to_tensor().unwrap();
+    let residual = actual.distance(&expected).unwrap();
+    assert!(
+        residual < 1e-8,
+        "complex two-node fit residual: {residual:e}"
+    );
+}
+
+#[test]
+fn fit_sum_zero_sweep_returns_exact_initial_clone() {
+    let site = DynIndex::new_dyn(2);
+    let initial = one_node(&site, vec![7.0, -2.0]);
+    let targets = [one_node(&site, vec![1.0, 2.0])];
+    let result = fit_sum(&targets, &initial, &0, FitOptions::new(0)).unwrap();
+    assert_eq!(
+        result.to_dense().unwrap().to_vec::<f64>().unwrap(),
+        vec![7.0, -2.0]
+    );
+    assert_eq!(result.canonical_region(), initial.canonical_region());
+}
+
+#[test]
+fn fit_sum_reindexes_same_id_prime_site_pair_deterministically() {
+    let target_base = DynIndex::new_dyn_with_tag(2, "site").unwrap();
+    let target_prime = target_base.prime();
+    let initial_base = DynIndex::new_dyn_with_tag(2, "site").unwrap();
+    let initial_prime = initial_base.prime();
+    let target = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(
+            vec![target_prime.clone(), target_base.clone()],
+            vec![1.0, 2.0, 3.0, 4.0],
+        )
+        .unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(
+            vec![initial_base.clone(), initial_prime.clone()],
+            vec![0.0; 4],
+        )
+        .unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    let expected =
+        IdxTensor::from_dense(vec![initial_prime, initial_base], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let result = fit_sum(&[target], &initial, &0, FitOptions::new(1)).unwrap();
+    assert!(result
+        .to_dense()
+        .unwrap()
+        .isapprox(&expected, 1e-12, 0.0)
+        .unwrap());
+}
+
+#[test]
+fn fit_sum_rejects_validation_errors_before_shortcuts() {
+    let site = DynIndex::new_dyn(2);
+    let initial = one_node(&site, vec![1.0, 2.0]);
+    let target = one_node(&site, vec![3.0, 4.0]);
+
+    assert!(fit_sum(&[], &initial, &0, FitOptions::new(0)).is_err());
+    assert!(fit_sum(
+        std::slice::from_ref(&target),
+        &TreeTN::new(),
+        &0,
+        FitOptions::new(0)
+    )
+    .is_err());
+    assert!(fit_sum(&[TreeTN::new()], &initial, &0, FitOptions::new(0)).is_err());
+    let missing_center_error = fit_sum(
+        std::slice::from_ref(&target),
+        &initial,
+        &1,
+        FitOptions::new(0),
+    )
+    .unwrap_err();
+    assert!(missing_center_error.to_string().contains("fit_sum"));
+    let invalid_bond_error = fit_sum(
+        std::slice::from_ref(&target),
+        &initial,
+        &0,
+        FitOptions::new(0).with_max_bond_dim(0),
+    )
+    .unwrap_err();
+    assert!(invalid_bond_error.to_string().contains("fit_sum"));
+    assert!(fit_sum(
+        std::slice::from_ref(&target),
+        &initial,
+        &0,
+        FitOptions::new(0).with_convergence_tol(f64::NAN)
+    )
+    .is_err());
+    assert!(fit_sum(
+        &[target],
+        &initial,
+        &0,
+        FitOptions::new(0).with_svd_policy(tensor4all_core::SvdTruncationPolicy::new(-1.0))
+    )
+    .is_err());
+}
+
+#[test]
+fn fit_sum_rejects_topology_and_site_space_mismatches() {
+    let site = DynIndex::new_dyn(2);
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0, 2.0]).unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    let different_topology = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(vec![site.clone()], vec![1.0, 2.0]).unwrap()],
+        vec![1],
+    )
+    .unwrap();
+    assert!(fit_sum(&[different_topology], &initial, &0, FitOptions::new(0)).is_err());
+    let wrong_dimension = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![IdxTensor::from_dense(vec![DynIndex::new_dyn(3)], vec![1.0; 3]).unwrap()],
+        vec![0],
+    )
+    .unwrap();
+    assert!(fit_sum(&[wrong_dimension], &initial, &0, FitOptions::new(0)).is_err());
+    assert!(fit_sum(
+        std::slice::from_ref(&initial),
+        &initial,
+        &0,
+        FitOptions::new(0).with_qr_rtol(1.0e-8)
+    )
+    .is_err());
+
+    let bond = DynIndex::new_dyn(1);
+    let extra = DynIndex::new_dyn(2);
+    let extra_bond = DynIndex::new_dyn(1);
+    let initial_chain = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![site.clone(), bond.clone()], vec![1.0, 0.0]).unwrap(),
+            IdxTensor::from_dense(vec![bond, site.clone()], vec![1.0, 1.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let extra_site_target = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![site.clone(), extra.clone(), extra_bond.clone()],
+                vec![1.0; 4],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(vec![extra_bond, site], vec![1.0, 1.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    assert!(fit_sum(&[extra_site_target], &initial_chain, &0, FitOptions::new(0)).is_err());
+}
+
+#[test]
+fn fit_sum_handles_branched_tree_with_site_less_internal_node() {
+    let left_site = DynIndex::new_dyn(2);
+    let right_site = DynIndex::new_dyn(2);
+    let target_left_bond = DynIndex::new_dyn(2);
+    let target_right_bond = DynIndex::new_dyn(2);
+    let other_left_bond = DynIndex::new_dyn(3);
+    let other_right_bond = DynIndex::new_dyn(3);
+    let initial_left_bond = DynIndex::new_dyn(2);
+    let initial_right_bond = DynIndex::new_dyn(2);
+
+    let target_one = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![left_site.clone(), target_left_bond.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![target_left_bond.clone(), target_right_bond.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![right_site.clone(), target_right_bond.clone()],
+                vec![2.0, 1.0, 3.0, 4.0],
+            )
+            .unwrap(),
+        ],
+        vec![1, 0, 2],
+    )
+    .unwrap();
+    let target_two = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![left_site.clone(), other_left_bond.clone()],
+                vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![other_left_bond.clone(), other_right_bond.clone()],
+                vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![right_site.clone(), other_right_bond.clone()],
+                vec![2.0, 0.0, 0.0, 4.0, 0.0, 0.0],
+            )
+            .unwrap(),
+        ],
+        vec![1, 0, 2],
+    )
+    .unwrap();
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![left_site.clone(), initial_left_bond.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![initial_left_bond.clone(), initial_right_bond.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(
+                vec![right_site.clone(), initial_right_bond.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+        ],
+        vec![1, 0, 2],
+    )
+    .unwrap();
+
+    let target_edge = target_one.edge_between(&0, &1).unwrap();
+    let initial_edge = initial.edge_between(&0, &1).unwrap();
+    assert_ne!(
+        target_one.bond_index(target_edge),
+        initial.bond_index(initial_edge),
+        "target and variational cut bonds must remain distinct"
+    );
+    assert!(target_one.site_space(&0).unwrap().is_empty());
+    assert!(initial.site_space(&0).unwrap().is_empty());
+
+    let expected = target_one
+        .contract_to_tensor()
+        .unwrap()
+        .axpby(
+            tensor4all_core::AnyScalar::new_real(1.0),
+            &target_two.contract_to_tensor().unwrap(),
+            tensor4all_core::AnyScalar::new_real(1.0),
+        )
+        .unwrap();
+    let result = fit_sum(
+        &[target_one, target_two],
+        &initial,
+        &0,
+        FitOptions::new(2).with_max_bond_dim(2),
+    )
+    .unwrap();
+    assert!(result.site_space(&0).unwrap().is_empty());
+    assert!(
+        result
+            .contract_to_tensor()
+            .unwrap()
+            .distance(&expected)
+            .unwrap()
+            < 1e-9
+    );
+}
+
+#[test]
+fn fit_sum_fixed_rank_reduces_dense_objective_without_growing_bonds() {
+    let s0 = DynIndex::new_dyn(2);
+    let s1 = DynIndex::new_dyn(2);
+    let target_bond = DynIndex::new_dyn(2);
+    let initial_bond = DynIndex::new_dyn(1);
+    let target = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(
+                vec![s0.clone(), target_bond.clone()],
+                vec![1.0, 0.0, 0.0, 1.0],
+            )
+            .unwrap(),
+            IdxTensor::from_dense(vec![target_bond, s1.clone()], vec![1.0, 0.0, 0.0, 1.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let initial = TreeTN::<IdxTensor, usize>::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![s0, initial_bond.clone()], vec![1.0, 1.0]).unwrap(),
+            IdxTensor::from_dense(vec![initial_bond, s1], vec![1.0, 1.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+    let expected = target.contract_to_tensor().unwrap();
+    let before = expected
+        .sub(&initial.contract_to_tensor().unwrap())
+        .unwrap()
+        .norm()
+        .unwrap();
+    let result = fit_sum(
+        &[target],
+        &initial,
+        &0,
+        FitOptions::new(2).with_max_bond_dim(1),
+    )
+    .unwrap();
+    let after = expected
+        .sub(&result.contract_to_tensor().unwrap())
+        .unwrap()
+        .norm()
+        .unwrap();
+    assert!(
+        after < before,
+        "objective did not improve: before={before}, after={after}"
+    );
+    for (left, right) in result.site_index_network().edges() {
+        let edge = result.edge_between(&left, &right).unwrap();
+        assert!(result.bond_index(edge).unwrap().dim() <= 1);
+    }
+}
+
+#[test]
+fn fit_sum_long_chain_keeps_bonds_bounded_without_dense_reference() {
+    let nsites = 30;
+    let sites: Vec<_> = (0..nsites).map(|_| DynIndex::new_dyn(2)).collect();
+
+    let make_chain = |value: f64, bond_seed: usize| {
+        let mut tensors = Vec::with_capacity(nsites);
+        let mut left_bond: Option<DynIndex> = None;
+        for (position, site) in sites.iter().enumerate() {
+            let right_bond = if position + 1 < nsites {
+                Some(
+                    DynIndex::new_dyn_with_tag(1, &format!("fit-sum-{bond_seed}-{position}"))
+                        .unwrap(),
+                )
+            } else {
+                None
+            };
+            let mut indices = Vec::new();
+            if let Some(left_bond) = &left_bond {
+                indices.push(left_bond.clone());
+            }
+            indices.push(site.clone());
+            if let Some(right_bond) = &right_bond {
+                indices.push(right_bond.clone());
+            }
+            tensors.push(IdxTensor::from_dense(indices, vec![value; 2]).unwrap());
+            left_bond = right_bond;
+        }
+        TreeTN::<IdxTensor, usize>::from_tensors(tensors, (0..nsites).collect()).unwrap()
+    };
+
+    let target_one = make_chain(1.0, 1);
+    let target_two = make_chain(2.0, 2);
+    let initial = make_chain(1.0, 3);
+    let result = fit_sum(
+        &[target_one, target_two],
+        &initial,
+        &(nsites / 2),
+        FitOptions::new(1).with_max_bond_dim(1),
+    )
+    .unwrap();
+    assert_eq!(result.node_count(), nsites);
+    for (left, right) in result.site_index_network().edges() {
+        let edge = result.edge_between(&left, &right).unwrap();
+        assert!(result.bond_index(edge).unwrap().dim() <= 1);
+    }
+}

--- a/docs/design/fit-sum.md
+++ b/docs/design/fit-sum.md
@@ -1,0 +1,63 @@
+# Variational fitting of TreeTN sums
+
+## Status
+
+Issue: [#660](https://github.com/tensor4all/tensor4all-rs/issues/660)
+
+Pre-implementation review:
+
+- Round 1: `CHANGES-REQUIRED` by `reviewer-flash-opencode-go`. Required clarification of site-only environment contractions, a single-node path, the public options export, and same-ID/prime coverage.
+- Round 2: `CORRECT-TO-IMPLEMENT` by `reviewer-flash-opencode-go`. The reviewer confirmed every blocking Round-1 finding was resolved.
+
+## Contract
+
+Add this crate-root API:
+
+```rust
+pub fn fit_sum<T, V>(
+    targets: &[TreeTN<T, V>],
+    initial: &TreeTN<T, V>,
+    center: &V,
+    options: FitOptions,
+) -> Result<TreeTN<T, V>, TreeTNOperationError>
+```
+
+`initial` is required and fixes the output topology, site-index identities, and starting bond spaces. Crate root re-exports the existing private-module `FitContractionOptions` as `FitOptions`; the implementation type and contraction dispatcher remain unchanged. The unrelated `tensor4all-simplett::FitOptions` remains crate-qualified and unchanged. The options control full sweeps, maximum bond dimension, factorization/truncation policy, and convergence.
+
+Inputs are compatible when every nonempty target has the same named topology as the nonempty `initial` and, at each node, the same number and dimensions of site indices. Target site indices are deterministically relabeled to those of `initial` with the existing `reindex_site_space_like` operation. When a node owns multiple equal-dimensional indices, correspondence is the existing full-index deterministic sort order (including prime level/tags), not caller insertion order. Target bond identities and dimensions need not match `initial`.
+
+Before mutating the result, validate the nonempty target list, nonempty networks, center membership, topology/site-space compatibility, SVD/factorization options, finite nonnegative convergence tolerance, and initial target-environment construction. Tensor scalar/backend failures receive `fit_sum` and target-index context. Unsupported scalar combinations fail; combinations supported by the tensor backend (including its normal real-to-complex promotion) remain compatible. Because all arguments use one tensor type `T`, a distinct Rust scalar type cannot be mixed at this API boundary; the integration test therefore documents the backend's real-to-complex promotion contract rather than adding a type-specific downcast.
+
+## Algorithm
+
+Reuse the existing two-site local-update machinery rather than construct an exact direct-sum TreeTN.
+
+1. Validate options, `initial`, `center`, and every target; relabel target site spaces to `initial`.
+2. Validate options first, including rejection of `max_bond_dim == 0`, even on short-circuit paths. If `nfullsweeps == 0`, return an unchanged clone of validated `initial` (including for a single-node topology). Otherwise clone and canonicalize `initial` to `center` without truncation.
+3. For a single-node topology with a positive sweep count, directly sum the target node tensors with tensor-level `axpby`, apply the configured factorization-independent semantics, and return that one-node TreeTN. This path does not use an empty sweep plan.
+4. Keep one directed-edge environment cache per target. For target `g_i`, `env_i[(from,to)]` contracts the `from`-side subtree of `g_i` with `conj(psi)` **only over corresponding site indices**. On the cut edge it leaves the target bond and variational bond as two distinct open legs; their identities and dimensions are never paired or required to match. Nodes with no site indices still remain connected through their target/variational bond legs and child environments.
+5. Before the first mutation, build the initial environments with target-index context. At each two-site step, independently contract each target's two local tensors with its environments. The open physical legs are the `initial` site indices; accumulate the resulting local tensors one at a time with `TensorVectorSpace::axpby`.
+6. Factorize the summed local optimum with the existing policy and replace the same two tensors/bond in `psi`; invalidate every target cache through the existing invalidation path.
+7. Repeat the existing Euler-tour sweep and convergence loop. Profiling labels the shared machinery neutrally and identifies the `contract_fit` or `fit_sum` entry point.
+
+The memory retained for targets and environments is linear in the number of terms, but no tensor-network bond dimension is the sum of all target bond dimensions. Local target contributions are accumulated one at a time, so no exact direct-sum network or full dense target is materialized.
+
+## Refactoring boundary
+
+Keep `FitEnvironment` and `FitUpdater` public behavior intact for contraction fitting. Add a private target-factor environment helper and extract the common two-site update body so:
+
+- contraction fitting supplies one target term with local factors `[A, B]`;
+- sum fitting supplies one target term per input with local factors `[g_i]`.
+
+Do not duplicate the factorization/replacement logic and do not add a chain-specific implementation.
+
+## Verification
+
+- Small dense-reference tests for `f64` and `Complex64` sums, plus one-node exact summation and zero-sweep identity behavior.
+- A normal chain and a branched tree whose internal node has no site index; assert that target and variational cut-bond legs remain distinct there.
+- A fixed-rank test comparing the dense objective before and after fitting.
+- Empty target list/network, empty initial network, missing center, named-topology mismatch, per-node site-count/dimension mismatch, and incompatible scalar/backend diagnostics.
+- Reindexing regression with same-ID indices that differ by prime level/tags, pinning the full-index deterministic correspondence.
+- A long cheap chain asserting bounded output bonds, guarding against exact direct-sum or dense materialization.
+- Runnable public rustdoc with a known numerical result.
+- Existing contraction-fit tests remain green.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -19,6 +19,7 @@
 | [partitioned-treetn.md](./partitioned-treetn.md) | Issue #648 migration design for TreeTN-native eager partitioning and adaptive patching |
 | [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |
 | [itensormps-compatible-zipup.md](./itensormps-compatible-zipup.md) | ITensorMPS-compatible chain zip-up contraction schedule and policy-aware decomposition follow-up |
+| [fit-sum.md](./fit-sum.md) | Variational fitting of compatible TreeTN sums without exact direct-sum materialization |
 
 ## Automatic Differentiation
 

--- a/docs/worklogs/2026-08-21-fit-sum.md
+++ b/docs/worklogs/2026-08-21-fit-sum.md
@@ -58,7 +58,13 @@ rustdoc, and work-log cleanup is recorded in the PR body.
 Fresh local evidence on the `origin/main`-synchronized worktree:
 
 - `cargo fmt --all -- --check`: pass.
-- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
+- CI initially exposed three pre-existing Clippy 1.98 `map_or_identity`
+  findings in `tensor4all-tensorbackend/src/matrix.rs`; the three identity
+  closures were mechanically replaced with `unwrap_or(0)`.
+- `cargo clippy --workspace --all-targets -- -D warnings -D
+  clippy::missing_errors_doc -D clippy::missing_panics_doc`: pass after that
+  toolchain-compatibility fix.
+- `cargo test --release -p tensor4all-tensorbackend`: 326 passed, 2 ignored.
 - `cargo nextest run --release --workspace`: 3005 passed, 14 skipped.
 - `cargo test --doc --release --workspace`: 907 passed.
 - `./scripts/test-mdbook.sh`: pass.

--- a/docs/worklogs/2026-08-21-fit-sum.md
+++ b/docs/worklogs/2026-08-21-fit-sum.md
@@ -1,0 +1,87 @@
+# Variational TreeTN sum fitting (#660)
+
+This work log records the implementation of
+[`fit_sum`](../design/fit-sum.md), which approximates a sum of compatible
+TreeTNs from a caller-provided initial variational state without constructing
+an exact direct-sum network.
+
+## Sources and contracts reviewed
+
+- Issue [#660](https://github.com/tensor4all/tensor4all-rs/issues/660).
+- `docs/design/fit-sum.md` (authoritative design for this change).
+- Existing TreeTN fit, local-update, canonicalization, contraction, addition,
+  tensor-vector-space, index-identity, error, and public-export contracts.
+- Shared and repository-local Rust, numerical, performance, documentation,
+  coverage, and public-surface rules.
+
+No third-party implementation was consulted or translated. The implementation
+refactors the existing tensor4all-rs contraction-fit sweep machinery.
+
+## Decisions
+
+- `initial` is required and owns the output topology, site-index identities,
+  starting bonds, and zero-sweep result.
+- Targets must share the same named topology and compatible per-node site
+  counts/dimensions. Existing deterministic full-index reindexing aligns their
+  site spaces to `initial`; target bond identities and dimensions remain
+  independent.
+- One site-only directed-edge environment cache is retained per target. Local
+  target contributions are contracted and tensor-level-accumulated one at a
+  time. Production code never calls TreeTN direct-sum addition or full dense
+  materialization.
+- Multi-node fitting shares the existing two-site factorization, replacement,
+  invalidation, Euler-tour sweep, and convergence paths. A positive-sweep
+  single-node input uses exact tensor-level summation; zero sweeps return the
+  validated initial clone.
+- The existing private-module `FitContractionOptions` is exported at crate root
+  as `FitOptions`, avoiding a duplicate options type or compatibility shim.
+- Backend-supported real-to-complex promotion is compatible. The scalar-generic
+  API cannot mix distinct Rust tensor types; unsupported backend combinations
+  retain contextual tensor/backend errors.
+
+## Review gates
+
+Pre-implementation read-only review used `reviewer-flash-opencode-go`.
+Round 1 returned **CHANGES-REQUIRED** for site-only environment semantics,
+single-node behavior, options export, and same-ID/prime coverage. The design
+was corrected; Round 2 returned **CORRECT-TO-IMPLEMENT** before source edits.
+
+Implementation used `luna-implementer`. Post-implementation read-only full-diff
+review used `reviewer-flash-opencode-go`. Round 1 returned
+**CORRECT-TO-MERGE** with two minor improvements: multi-node complex coverage
+and zero-sweep fit-profile cleanup. Both were implemented; Round 2 returned
+**CORRECT-TO-MERGE**. A final fresh full-diff verdict after mechanical clippy,
+rustdoc, and work-log cleanup is recorded in the PR body.
+
+## Verification
+
+Fresh local evidence on the `origin/main`-synchronized worktree:
+
+- `cargo fmt --all -- --check`: pass.
+- `cargo clippy --workspace --all-targets -- -D warnings`: pass.
+- `cargo nextest run --release --workspace`: 3005 passed, 14 skipped.
+- `cargo test --doc --release --workspace`: 907 passed.
+- `./scripts/test-mdbook.sh`: pass.
+- `cargo doc --workspace --no-deps`: pass; a new private-link warning was fixed.
+- `cargo doc -p tensor4all-treetn --no-deps`: pass without warnings.
+- `cargo test --doc --release -p tensor4all-treetn`: 121 passed.
+- `cargo test --release -p tensor4all-treetn --test fit_sum`: 12 passed.
+- `cargo test --release -p tensor4all-treetn contract_fit`: 5 passed.
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run`: pass, no findings.
+- `python3 scripts/test-repository-rules-review.py`: 90 passed.
+- `python3 scripts/check-public-error-docs.py`: pass.
+- API dump regeneration exposes `fit_sum`; generated files remain unchanged/ignored.
+- README, mdBook, and bundled usage-skill searches found no stale `fit_sum` or
+  fit-options claims requiring synchronization. Public rustdoc is the new API's
+  documented source of truth.
+- Production-path search confirms no `contract_to_tensor`/`to_dense` and no
+  TreeTN-level direct-sum call in `fit_sum`; tensor-level `axpby` is the only
+  sum accumulator.
+
+Coverage-impact attestation: every new control-flow path is exercised by the
+12-test integration suite: real and multi-node complex dense references,
+backend promotion, chain and site-less branched topologies, fixed-rank objective
+improvement, bounded long chain, one-node and zero-sweep behavior, same-ID prime
+mapping, and input/options/topology/site-space errors. Existing contraction-fit
+coverage remains and passed after the shared refactor. CI coverage is the
+authoritative measurement; no threshold or tolerance was changed.

--- a/docs/worklogs/2026-08-21-fit-sum.md
+++ b/docs/worklogs/2026-08-21-fit-sum.md
@@ -58,13 +58,16 @@ rustdoc, and work-log cleanup is recorded in the PR body.
 Fresh local evidence on the `origin/main`-synchronized worktree:
 
 - `cargo fmt --all -- --check`: pass.
-- CI initially exposed three pre-existing Clippy 1.98 `map_or_identity`
-  findings in `tensor4all-tensorbackend/src/matrix.rs`; the three identity
-  closures were mechanically replaced with `unwrap_or(0)`.
-- `cargo clippy --workspace --all-targets -- -D warnings -D
-  clippy::missing_errors_doc -D clippy::missing_panics_doc`: pass after that
-  toolchain-compatibility fix.
+- CI exposed six pre-existing Clippy 1.98 `map_or_identity` findings:
+  three in `tensor4all-tensorbackend/src/matrix.rs`, then three in
+  `tensor4all-core/src/matrixluci/source.rs` after CI progressed to the next
+  crate. All six identity closures were mechanically replaced with
+  `unwrap_or(0)`; a whole-repository pattern search finds no remaining identity
+  `map_or` closure.
+- The exact CI clippy command passed locally under Clippy 1.97 after the first
+  three fixes; CI is authoritative for the 1.98-only lint.
 - `cargo test --release -p tensor4all-tensorbackend`: 326 passed, 2 ignored.
+- `cargo test --release -p tensor4all-core matrixluci`: 36 passed.
 - `cargo nextest run --release --workspace`: 3005 passed, 14 skipped.
 - `cargo test --doc --release --workspace`: 907 passed.
 - `./scripts/test-mdbook.sh`: pass.


### PR DESCRIPTION
## Summary

- add crate-root `fit_sum(targets, initial, center, FitOptions)` for variationally fitting compatible TreeTN sums
- require a caller-provided initial state and validate named topology, per-node site spaces, center, and fit options before mutation
- accumulate per-target site-only environments and local tensors without constructing an exact direct-sum TreeTN or dense production target
- reuse the existing two-site fit factorization, cache invalidation, Euler-tour sweep, and convergence machinery
- cover real/complex, chain/branched, one-node/zero-sweep, fixed-rank objective, long-chain bounded-rank, index-identity, and error paths

Closes #660

## Design and review gates

- Design: `docs/design/fit-sum.md`
- Pre-implementation review: `reviewer-flash-opencode-go`
  - R1: **CHANGES-REQUIRED**
  - R2 after fixes: **CORRECT-TO-IMPLEMENT**
- Implementation: `luna-implementer`
- Full-diff review: `reviewer-flash-opencode-go`
  - R1: **CORRECT-TO-MERGE**, two minor improvements requested and fixed
  - R2: **CORRECT-TO-MERGE**
  - Final R3 after clippy/rustdoc/worklog cleanup: **CORRECT-TO-MERGE**, no blocking findings
- Work log: `docs/worklogs/2026-08-21-fit-sum.md`

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace` — 3005 passed, 14 skipped
- `cargo test --doc --release --workspace` — 907 passed
- `./scripts/test-mdbook.sh`
- `cargo doc --workspace --no-deps`
- `cargo test --release -p tensor4all-treetn --test fit_sum` — 12 passed
- `cargo test --release -p tensor4all-treetn contract_fit` — 5 passed
- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run` — pass
- `python3 scripts/test-repository-rules-review.py` — 90 passed
- `python3 scripts/check-public-error-docs.py` — pass
- regenerated API dump exposes `fit_sum`; generated files unchanged/ignored
- README, mdBook, and bundled usage skill checked for public-surface drift

## Coverage impact attestation

Reviewed every new control-flow path. The integration suite covers real and multi-node complex dense references, backend promotion, chain and site-less branched topologies, fixed-rank objective improvement, bounded long chain, one-node and zero-sweep behavior, same-ID/prime mapping, and input/options/topology/site-space errors. Existing contraction-fit coverage remains green after the shared refactor. No threshold or tolerance was changed; CI coverage is authoritative.
