### PR TITLE
feat(tensorbackend): add explicit CPU execution context

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Check explicit-context-only build
+        run: |
+          cargo check -p tensor4all-tensorbackend --no-default-features --features explicit-context,tenferro-cpu-faer
+          cargo doc -p tensor4all-tensorbackend --no-deps --no-default-features --features explicit-context,tenferro-cpu-faer
+
       - name: Run clippy
         # The public-error-doc backlog is burned down; error/panic doc
         # requirements are now repository-wide blocking (issue #566 PR3).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,9 +211,10 @@ fn test_op_c64() { test_op_generic::<Complex64>(); }
 - Use tenferro-backed `tensor4all-tensorbackend` / existing tensor4all
   abstractions for SVD, QR, einsum, and dense tensor linear algebra instead of
   local reimplementations.
-- Do not instantiate `CpuBackend` directly outside `tensor4all-tensorbackend`.
-  Use tensorbackend wrappers or `with_default_backend` so CPU execution shares
-  the repository's process-global tenferro `CpuContext`.
+- Canonical integrations supply a configured `CpuBackend` to
+  `tensor4all_tensorbackend::CpuExecutionContext`; legacy convenience APIs may
+  use `with_default_backend` behind the `global-defaults` feature. Do not create
+  an unconfigured fallback backend in downstream operation code.
 - `Tensor3Ops::slice_site`, `Tensor4Ops::slice_site`, and dense/full-tensor
   exports return column-major flat data.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,9 +82,9 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "8214b72" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
-tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5a106be3133979d78832a0ca3f4d6b57613b3d7", default-features = false }
-tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5a106be3133979d78832a0ca3f4d6b57613b3d7", default-features = false }
-tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5a106be3133979d78832a0ca3f4d6b57613b3d7", default-features = false }
-tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5a106be3133979d78832a0ca3f4d6b57613b3d7", default-features = false }
-tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5a106be3133979d78832a0ca3f4d6b57613b3d7", default-features = false }
-tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "b5a106be3133979d78832a0ca3f4d6b57613b3d7", default-features = false }
+tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }

--- a/crates/tensor4all-hdf5/Cargo.toml
+++ b/crates/tensor4all-hdf5/Cargo.toml
@@ -11,11 +11,13 @@ default = ["link", "tenferro-cpu-faer"]
 link = ["dep:hdf5-metno", "dep:hdf5-metno-sys"]
 runtime-loading = ["dep:hdf5-rt"]
 tenferro-cpu-faer = [
+    "tensor4all-core/backend-tenferro",
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-itensorlike/tenferro-cpu-faer",
     "tensor4all-treetn/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
+    "tensor4all-core/backend-tenferro",
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-itensorlike/tenferro-provider-inject",
     "tensor4all-treetn/tenferro-provider-inject",

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -11,7 +11,12 @@ categories = ["science", "mathematics"]
 
 [features]
 default = ["backend-tenferro", "tenferro-cpu-faer"]
-backend-tenferro = []
+# Compatibility alias for the legacy process-global operation surface.
+backend-tenferro = ["global-defaults"]
+# Canonical caller-supplied CPU context without process-global fallbacks.
+explicit-context = []
+# Opt-in legacy operations backed by one process-global context.
+global-defaults = ["explicit-context"]
 tenferro-cpu-faer = [
     "tenferro/cpu-faer",
     "tenferro-ad/cpu-faer",
@@ -58,3 +63,7 @@ tenferro-tensor.workspace = true
 
 [dev-dependencies]
 approx.workspace = true
+
+[[test]]
+name = "bench_einsum_native"
+required-features = ["global-defaults"]

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -1,355 +1,566 @@
-//! Process-global tenferro CPU execution helpers.
-//!
-//! tensor4all-rs routes tenferro CPU execution through one process-global
-//! `CpuContext`, matching tenferro's `cpu:0` default-global thread-pool model.
-//! Plain tensor operations, cached traced execution, and eager AD currently use
-//! separate `CpuBackend` values because tenferro does not expose a public API
-//! for borrowing the backend owned by an `EagerRuntime`. All backends are
-//! created from the same global CPU context, so thread-pool configuration is
-//! shared.
+//! Explicit and optional process-global tenferro CPU execution contexts.
 
-#[cfg(test)]
-use std::cell::Cell;
 use std::sync::{Arc, Mutex, OnceLock};
 
-use anyhow::anyhow;
-use tenferro::{GraphCompiler, Runtime};
+use tenferro::{CompiledGraph, GraphCompiler, Runtime, Tensor, TracedGraph};
 use tenferro_ad::{AdContext, EagerRuntime};
-use tenferro_cpu::{BufferPoolStats, CpuBackend, CpuContext};
+use tenferro_cpu::{BufferPoolStats, CpuBackend};
 
-static DEFAULT_CPU_CONTEXT: OnceLock<Arc<CpuContext>> = OnceLock::new();
-static DEFAULT_BACKEND: OnceLock<Mutex<CpuBackend>> = OnceLock::new();
-
-struct DefaultGraphRuntime {
-    compiler: GraphCompiler,
-    runtime: Runtime,
-    backend: CpuBackend,
-}
-
-static DEFAULT_GRAPH_RUNTIME: OnceLock<std::result::Result<Mutex<DefaultGraphRuntime>, String>> =
-    OnceLock::new();
-/// Error returned when the process-global eager AD runtime cannot be initialized.
+/// Error returned by explicit CPU context graph or eager-runtime operations.
 ///
-/// The original backend error is retained as the [`std::error::Error::source`]
-/// so callers can inspect the registration failure without parsing a string.
+/// The original tenferro diagnostic is retained as the error source.
 ///
 /// # Examples
 ///
 /// ```
 /// use std::error::Error;
 /// use std::sync::Arc;
-/// use tensor4all_tensorbackend::EagerContextError;
+/// use tensor4all_tensorbackend::CpuExecutionContextError;
 ///
-/// let error = EagerContextError::Registration {
+/// let error = CpuExecutionContextError::Initialization {
+///     component: "graph runtime",
 ///     source: Arc::new(std::io::Error::other("registration failed")),
 /// };
 /// assert!(error.source().is_some());
-/// assert!(error.to_string().contains("registration failed"));
 /// ```
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum EagerContextError {
-    /// The tenferro linalg AD extension rule could not be registered.
-    #[error("failed to register tenferro linalg AD rule: {source}")]
-    Registration {
-        /// Original diagnostic returned by tenferro.
+pub enum CpuExecutionContextError {
+    /// A context-owned graph or eager runtime could not be initialized.
+    #[error("failed to initialize {component}: {source}")]
+    Initialization {
+        /// Context component being initialized.
+        component: &'static str,
+        /// Original tenferro diagnostic.
+        #[source]
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+    /// Graph compilation or execution failed.
+    #[error("CPU graph {operation} failed: {source}")]
+    Graph {
+        /// Graph operation that failed.
+        operation: &'static str,
+        /// Original tenferro diagnostic.
         #[source]
         source: Arc<dyn std::error::Error + Send + Sync + 'static>,
     },
 }
 
-static DEFAULT_EAGER_RUNTIME: OnceLock<std::result::Result<Arc<EagerRuntime>, EagerContextError>> =
-    OnceLock::new();
+impl CpuExecutionContextError {
+    fn initialization(
+        component: &'static str,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::Initialization {
+            component,
+            source: Arc::new(source),
+        }
+    }
 
-#[cfg(test)]
-thread_local! {
-    static FORCE_EAGER_CONTEXT_FAILURE: Cell<bool> = const { Cell::new(false) };
-}
-
-fn default_cpu_context() -> Arc<CpuContext> {
-    DEFAULT_CPU_CONTEXT
-        .get_or_init(|| Arc::new(CpuContext::from_env()))
-        .clone()
-}
-
-fn default_backend() -> &'static Mutex<CpuBackend> {
-    DEFAULT_BACKEND.get_or_init(|| Mutex::new(CpuBackend::from_context(default_cpu_context())))
-}
-
-fn build_graph_runtime(backend: &CpuBackend) -> std::result::Result<Runtime, String> {
-    let mut builder = Runtime::builder();
-    builder
-        .register_engine(
-            tenferro_cpu::runtime_engine_registration(backend).map_err(|e| e.to_string())?,
-        )
-        .map_err(|e| e.to_string())?;
-    builder
-        .install_extension_module(
-            tenferro_einsum::extension_module::<CpuBackend>(
-                tenferro_cpu::runtime_engine_id().map_err(|e| e.to_string())?,
-            )
-            .map_err(|e| e.to_string())?,
-        )
-        .map_err(|e| e.to_string())?;
-    builder.build().map_err(|e| e.to_string())
-}
-
-fn default_graph_runtime() -> anyhow::Result<&'static Mutex<DefaultGraphRuntime>> {
-    match DEFAULT_GRAPH_RUNTIME.get_or_init(|| {
-        let backend = CpuBackend::from_context(default_cpu_context());
-        build_graph_runtime(&backend).map(|runtime| {
-            Mutex::new(DefaultGraphRuntime {
-                compiler: GraphCompiler::new(),
-                runtime,
-                backend,
-            })
-        })
-    }) {
-        Ok(runtime) => Ok(runtime),
-        Err(error) => Err(anyhow!("failed to initialize graph runtime: {error}")),
+    fn graph(
+        operation: &'static str,
+        source: impl std::error::Error + Send + Sync + 'static,
+    ) -> Self {
+        Self::Graph {
+            operation,
+            source: Arc::new(source),
+        }
     }
 }
 
-fn lock_default_graph_runtime(
-) -> anyhow::Result<std::sync::MutexGuard<'static, DefaultGraphRuntime>> {
-    match default_graph_runtime()?.lock() {
-        Ok(guard) => Ok(guard),
-        Err(poisoned) => Ok(poisoned.into_inner()),
-    }
+struct GraphState {
+    compiler: GraphCompiler,
+    runtime: Runtime,
+    backend: CpuBackend,
 }
 
-/// Run a closure against the process-global CPU backend.
+/// Caller-owned CPU execution domain for plain, graph, and eager-AD work.
 ///
-/// This is the canonical entry point for typed and untyped tenferro tensor
-/// operations inside `tensor4all-tensorbackend`.
-pub fn with_default_backend<R>(f: impl FnOnce(&mut CpuBackend) -> R) -> R {
-    let mut backend = match default_backend().lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    f(&mut backend)
-}
-
-/// Run a closure against the process-global tenferro graph compiler/executor.
-///
-/// This is used for native tensor operations that benefit from tenferro's
-/// persistent execution caches, such as N-ary einsum contraction paths.
-pub(crate) fn with_default_graph_runtime<R>(
-    f: impl FnOnce(&mut GraphCompiler, &Runtime, &mut CpuBackend) -> R,
-) -> anyhow::Result<R> {
-    let mut graph = lock_default_graph_runtime()?;
-    let graph = &mut *graph;
-    let compiler = &mut graph.compiler;
-    let runtime = &graph.runtime;
-    let backend = &mut graph.backend;
-    Ok(f(compiler, runtime, backend))
-}
-
-/// Return retained-buffer statistics for the process-global graph runtime.
-pub(crate) fn default_engine_buffer_pool_stats() -> anyhow::Result<BufferPoolStats> {
-    let graph = lock_default_graph_runtime()?;
-    graph
-        .backend
-        .buffer_pool_stats()
-        .map_err(|e| anyhow!("failed to read graph buffer-pool statistics: {e}"))
-}
-
-/// Reset retained buffers in the process-global graph runtime.
-pub(crate) fn reset_default_engine_buffer_pool() -> anyhow::Result<()> {
-    let mut graph = lock_default_graph_runtime()?;
-    graph
-        .backend
-        .reset_buffer_pool()
-        .map_err(|e| anyhow!("failed to reset graph buffer pool: {e}"))
-}
-
-/// Drop and recreate the process-global graph compiler/runtime.
-///
-/// This releases tenferro's retained execution buffers and cached contraction
-/// paths. It is intended for diagnostics and memory-pressure recovery, not for
-/// normal hot loops where the caches are valuable.
-pub(crate) fn reset_default_engine() -> anyhow::Result<()> {
-    let mut graph = lock_default_graph_runtime()?;
-    let runtime = build_graph_runtime(&graph.backend)
-        .map_err(|e| anyhow!("failed to reset graph runtime: {e}"))?;
-    graph.compiler = GraphCompiler::new();
-    graph.runtime = runtime;
-    graph
-        .backend
-        .reset_buffer_pool()
-        .map_err(|e| anyhow!("failed to reset graph buffer pool: {e}"))
-}
-
-/// Return the process-global eager context used for reverse-mode AD.
-///
-/// This context owns a separate `CpuBackend` from [`with_default_backend`] and
-/// the cached graph executor, but all backends share the same process-global
-/// tenferro CPU context.
-///
-/// # Errors
-///
-/// Returns [`EagerContextError::Registration`] if the tenferro linalg AD rule
-/// cannot be registered.
+/// The supplied backend is the only source of CPU execution resources. Backend
+/// clones preserve its runtime identity; this constructor never uses
+/// `CpuBackend::new`, `CpuContext::from_env`, or a process-global fallback.
+/// Graph preparation caches and the eager runtime are owned by this context and
+/// are released when it is dropped.
 ///
 /// # Examples
 ///
 /// ```
-/// use tensor4all_tensorbackend::default_eager_ctx;
-/// use std::sync::Arc;
+/// use tensor4all_tensorbackend::CpuExecutionContext;
+/// use tenferro_cpu::CpuBackend;
 ///
-/// let first = default_eager_ctx().unwrap();
-/// let second = default_eager_ctx().unwrap();
-/// assert!(Arc::ptr_eq(&first, &second));
+/// let context = CpuExecutionContext::from_backend(CpuBackend::with_threads(1)?);
+/// let threads = context.with_backend(|backend| backend.num_threads());
+/// assert_eq!(threads, 1);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub fn default_eager_ctx() -> std::result::Result<Arc<EagerRuntime>, EagerContextError> {
-    #[cfg(test)]
-    if FORCE_EAGER_CONTEXT_FAILURE.with(Cell::get) {
-        return Err(EagerContextError::Registration {
-            source: Arc::new(std::io::Error::other(
-                "forced default eager context registration failure",
-            )),
-        });
+pub struct CpuExecutionContext {
+    backend: Mutex<CpuBackend>,
+    graph: OnceLock<Result<Mutex<GraphState>, CpuExecutionContextError>>,
+    eager: OnceLock<Result<Arc<EagerRuntime>, CpuExecutionContextError>>,
+}
+
+impl std::fmt::Debug for CpuExecutionContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CpuExecutionContext")
+            .field("graph_initialized", &self.graph.get().is_some())
+            .field("eager_initialized", &self.eager.get().is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CpuExecutionContext {
+    /// Create an execution context from a caller-selected CPU backend.
+    ///
+    /// Runtime construction is lazy, so creating a context cannot fail and does
+    /// not allocate another executor or consult environment configuration.
+    pub fn from_backend(backend: CpuBackend) -> Self {
+        Self {
+            backend: Mutex::new(backend),
+            graph: OnceLock::new(),
+            eager: OnceLock::new(),
+        }
     }
 
-    match DEFAULT_EAGER_RUNTIME.get_or_init(|| {
-        let ad_context = AdContext::builder()
-            .with_semantic_extension_rules(tenferro_linalg::semantic_ad_rules().map_err(
-                |source| EagerContextError::Registration {
-                    source: Arc::new(source),
-                },
-            )?)
-            .map_err(|source| EagerContextError::Registration {
-                source: Arc::new(source),
-            })?
-            .build()
-            .map_err(|source| EagerContextError::Registration {
-                source: Arc::new(source),
-            })?;
-        EagerRuntime::with_cpu_backend_and_ad_context(
-            CpuBackend::from_context(default_cpu_context()),
-            &ad_context,
+    /// Run a plain tensor operation with this context's backend.
+    ///
+    /// The closure runs while the context-local backend lock is held. A poisoned
+    /// lock is recovered because tenferro validates every new backend session.
+    pub fn with_backend<R>(&self, f: impl FnOnce(&mut CpuBackend) -> R) -> R {
+        let mut backend = match self.backend.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        f(&mut backend)
+    }
+
+    fn backend_clone(&self) -> CpuBackend {
+        self.with_backend(|backend| backend.clone())
+    }
+
+    fn graph_state(&self) -> Result<&Mutex<GraphState>, CpuExecutionContextError> {
+        self.graph
+            .get_or_init(|| {
+                let backend = self.backend_clone();
+                build_graph_runtime(&backend).map(|runtime| {
+                    Mutex::new(GraphState {
+                        compiler: GraphCompiler::new(),
+                        runtime,
+                        backend,
+                    })
+                })
+            })
+            .as_ref()
+            .map_err(Clone::clone)
+    }
+
+    fn with_graph_state<R>(
+        &self,
+        f: impl FnOnce(&mut GraphCompiler, &mut Runtime, &mut CpuBackend) -> R,
+    ) -> Result<R, CpuExecutionContextError> {
+        let mut graph = match self.graph_state()?.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let GraphState {
+            compiler,
+            runtime,
+            backend,
+        } = &mut *graph;
+        Ok(f(compiler, runtime, backend))
+    }
+
+    /// Compile a backend-neutral traced graph using this context's compiler cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when graph-runtime initialization or
+    /// graph compilation fails.
+    pub fn compile_graph(
+        &self,
+        graph: &TracedGraph,
+    ) -> Result<CompiledGraph, CpuExecutionContextError> {
+        self.with_graph_state(|compiler, _, _| compiler.compile_traced_graph(graph))?
+            .map_err(|source| CpuExecutionContextError::graph("compilation", source))
+    }
+
+    /// Execute a compiled graph in this context's runtime and prepared-plan cache.
+    ///
+    /// `CompiledGraph` is backend-neutral. Backend-prepared executables and
+    /// workspaces never leave this context-owned runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when runtime initialization,
+    /// preparation, or execution fails.
+    pub fn run_graph(
+        &self,
+        graph: &CompiledGraph,
+        inputs: &[&Tensor],
+    ) -> Result<Vec<Tensor>, CpuExecutionContextError> {
+        self.with_graph_state(|_, runtime, _| runtime.run_compiled(graph, inputs))?
+            .map_err(|source| CpuExecutionContextError::graph("execution", source))
+    }
+
+    /// Return this context's eager reverse-AD runtime.
+    ///
+    /// Repeated calls return the same runtime and therefore the same eager
+    /// compilation cache.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when linalg AD-rule or eager-runtime
+    /// registration fails.
+    pub fn eager_runtime(&self) -> Result<Arc<EagerRuntime>, CpuExecutionContextError> {
+        self.eager
+            .get_or_init(|| build_eager_runtime(self.backend_clone()))
+            .as_ref()
+            .map(Arc::clone)
+            .map_err(Clone::clone)
+    }
+
+    /// Return statistics for this context's runtime-owned graph caches.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when graph initialization or the
+    /// cache statistics query fails.
+    pub fn graph_cache_stats(
+        &self,
+    ) -> Result<tenferro::RuntimeCacheStats, CpuExecutionContextError> {
+        self.with_graph_state(|_, runtime, _| runtime.cache_stats())?
+            .map_err(|source| CpuExecutionContextError::graph("cache statistics", source))
+    }
+
+    /// Return retained-buffer statistics for this context's graph backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when graph initialization or the
+    /// backend statistics query fails.
+    pub fn graph_buffer_pool_stats(&self) -> Result<BufferPoolStats, CpuExecutionContextError> {
+        self.with_graph_state(|_, _, backend| backend.buffer_pool_stats())?
+            .map_err(|source| CpuExecutionContextError::graph("buffer-pool statistics", source))
+    }
+
+    /// Release retained buffers owned by this context's graph backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when graph initialization or reset
+    /// fails.
+    pub fn reset_graph_buffer_pool(&self) -> Result<(), CpuExecutionContextError> {
+        self.with_graph_state(|_, _, backend| backend.reset_buffer_pool())?
+            .map_err(|source| CpuExecutionContextError::graph("buffer-pool reset", source))
+    }
+
+    /// Recreate this context's graph runtime and release its prepared caches.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuExecutionContextError`] when runtime reconstruction or
+    /// buffer release fails.
+    pub fn reset_graph_runtime(&self) -> Result<(), CpuExecutionContextError> {
+        self.with_graph_state(|compiler, runtime, backend| {
+            let replacement = build_graph_runtime(backend)?;
+            *compiler = GraphCompiler::new();
+            let old = std::mem::replace(runtime, replacement);
+            drop(old);
+            backend
+                .reset_buffer_pool()
+                .map_err(|source| CpuExecutionContextError::graph("buffer-pool reset", source))
+        })??;
+        Ok(())
+    }
+}
+
+fn build_graph_runtime(backend: &CpuBackend) -> Result<Runtime, CpuExecutionContextError> {
+    let mut builder = Runtime::builder();
+    builder
+        .register_engine(
+            tenferro_cpu::runtime_engine_registration(backend).map_err(|source| {
+                CpuExecutionContextError::initialization("graph CPU engine", source)
+            })?,
         )
-        .map_err(|source| EagerContextError::Registration {
-            source: Arc::new(source),
+        .map_err(|source| CpuExecutionContextError::initialization("graph CPU engine", source))?;
+    builder
+        .install_extension_module(
+            tenferro_einsum::extension_module::<CpuBackend>(
+                tenferro_cpu::runtime_engine_id().map_err(|source| {
+                    CpuExecutionContextError::initialization("einsum extension", source)
+                })?,
+            )
+            .map_err(|source| {
+                CpuExecutionContextError::initialization("einsum extension", source)
+            })?,
+        )
+        .map_err(|source| CpuExecutionContextError::initialization("einsum extension", source))?;
+    builder
+        .build()
+        .map_err(|source| CpuExecutionContextError::initialization("graph runtime", source))
+}
+
+fn build_eager_runtime(backend: CpuBackend) -> Result<Arc<EagerRuntime>, CpuExecutionContextError> {
+    let ad_context = AdContext::builder()
+        .with_semantic_extension_rules(tenferro_linalg::semantic_ad_rules().map_err(|source| {
+            CpuExecutionContextError::initialization("linalg AD rules", source)
+        })?)
+        .map_err(|source| CpuExecutionContextError::initialization("linalg AD rules", source))?
+        .build()
+        .map_err(|source| CpuExecutionContextError::initialization("AD context", source))?;
+    EagerRuntime::with_cpu_backend_and_ad_context(backend, &ad_context)
+        .map_err(|source| CpuExecutionContextError::initialization("eager runtime", source))
+}
+
+#[cfg(feature = "global-defaults")]
+mod defaults {
+    use super::*;
+    use tenferro_cpu::CpuContext;
+
+    static DEFAULT_CONTEXT: OnceLock<Arc<CpuExecutionContext>> = OnceLock::new();
+
+    #[cfg(test)]
+    thread_local! {
+        static FORCE_EAGER_CONTEXT_FAILURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+
+    #[cfg(test)]
+    static DEFAULT_CONTEXT_HITS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    fn default_context() -> &'static Arc<CpuExecutionContext> {
+        DEFAULT_CONTEXT.get_or_init(|| {
+            #[cfg(test)]
+            DEFAULT_CONTEXT_HITS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Arc::new(CpuExecutionContext::from_backend(CpuBackend::from_context(
+                Arc::new(CpuContext::from_env()),
+            )))
         })
-    }) {
-        Ok(context) => Ok(Arc::clone(context)),
-        Err(error) => Err(error.clone()),
+    }
+
+    /// Error returned when the process-global eager AD runtime cannot be initialized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::error::Error;
+    /// use std::sync::Arc;
+    /// use tensor4all_tensorbackend::EagerContextError;
+    ///
+    /// let error = EagerContextError::Registration {
+    ///     source: Arc::new(std::io::Error::other("registration failed")),
+    /// };
+    /// assert!(error.source().is_some());
+    /// ```
+    #[derive(Debug, Clone, thiserror::Error)]
+    pub enum EagerContextError {
+        /// The tenferro linalg AD extension rule could not be registered.
+        #[error("failed to register tenferro linalg AD rule: {source}")]
+        Registration {
+            /// Original diagnostic returned by tenferro.
+            #[source]
+            source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+        },
+    }
+
+    /// Run a closure against the optional process-global CPU backend.
+    pub fn with_default_backend<R>(f: impl FnOnce(&mut CpuBackend) -> R) -> R {
+        default_context().with_backend(f)
+    }
+
+    pub(crate) fn with_default_graph_runtime<R>(
+        f: impl FnOnce(&mut GraphCompiler, &Runtime, &mut CpuBackend) -> R,
+    ) -> anyhow::Result<R> {
+        default_context()
+            .with_graph_state(|compiler, runtime, backend| f(compiler, runtime, backend))
+            .map_err(anyhow::Error::new)
+    }
+
+    pub(crate) fn default_engine_buffer_pool_stats() -> anyhow::Result<BufferPoolStats> {
+        default_context()
+            .graph_buffer_pool_stats()
+            .map_err(anyhow::Error::new)
+    }
+
+    pub(crate) fn reset_default_engine_buffer_pool() -> anyhow::Result<()> {
+        default_context()
+            .reset_graph_buffer_pool()
+            .map_err(anyhow::Error::new)
+    }
+
+    pub(crate) fn reset_default_engine() -> anyhow::Result<()> {
+        default_context()
+            .reset_graph_runtime()
+            .map_err(anyhow::Error::new)
+    }
+
+    /// Return the optional process-global eager context used by convenience APIs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EagerContextError::Registration`] when eager runtime
+    /// initialization fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_tensorbackend::default_eager_ctx;
+    ///
+    /// let first = default_eager_ctx().unwrap();
+    /// let second = default_eager_ctx().unwrap();
+    /// assert!(Arc::ptr_eq(&first, &second));
+    /// ```
+    pub fn default_eager_ctx() -> Result<Arc<EagerRuntime>, EagerContextError> {
+        #[cfg(test)]
+        if FORCE_EAGER_CONTEXT_FAILURE.with(std::cell::Cell::get) {
+            return Err(EagerContextError::Registration {
+                source: Arc::new(std::io::Error::other(
+                    "forced default eager context registration failure",
+                )),
+            });
+        }
+        default_context()
+            .eager_runtime()
+            .map_err(|source| EagerContextError::Registration {
+                source: Arc::new(source),
+            })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn default_context_hits() -> usize {
+        DEFAULT_CONTEXT_HITS.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_forced_eager_context_failure<T>(f: impl FnOnce() -> T) -> T {
+        let previous = FORCE_EAGER_CONTEXT_FAILURE.with(|failure| failure.replace(true));
+        let result = f();
+        FORCE_EAGER_CONTEXT_FAILURE.with(|failure| failure.set(previous));
+        result
     }
 }
 
-#[cfg(test)]
-pub(crate) fn with_forced_eager_context_failure<T>(f: impl FnOnce() -> T) -> T {
-    let previous = FORCE_EAGER_CONTEXT_FAILURE.with(|failure| failure.replace(true));
-    let result = f();
-    FORCE_EAGER_CONTEXT_FAILURE.with(|failure| failure.set(previous));
-    result
-}
+#[cfg(all(test, feature = "global-defaults"))]
+pub(crate) use defaults::with_forced_eager_context_failure;
+#[cfg(feature = "global-defaults")]
+pub use defaults::{default_eager_ctx, with_default_backend, EagerContextError};
+#[cfg(feature = "global-defaults")]
+pub(crate) use defaults::{
+    default_engine_buffer_pool_stats, reset_default_engine, reset_default_engine_buffer_pool,
+    with_default_graph_runtime,
+};
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
     use super::*;
-    use tenferro_cpu::linalg_interop::PoolScalar;
+    use tenferro::program::{CoreSemanticOp, ProgramInputSpec};
+    use tenferro::{DType, TraceContext};
+    use tenferro_ad::EagerTensor;
+    use tenferro_cpu::{CpuContext, ExternalCpuDomain};
+    use tenferro_tensor::CpuDomainId;
+
+    fn context() -> CpuExecutionContext {
+        CpuExecutionContext::from_backend(CpuBackend::with_threads(1).unwrap())
+    }
 
     #[test]
-    fn eager_context_error_preserves_source_chain() {
-        let source = std::io::Error::other("forced registration failure");
-        let error = EagerContextError::Registration {
-            source: Arc::new(source),
-        };
+    fn explicit_plain_graph_and_eager_paths_share_only_the_supplied_backend() {
+        let context = context();
+        assert_eq!(context.with_backend(|backend| backend.num_threads()), 1);
 
-        assert!(std::error::Error::source(&error).is_some());
+        let mut trace = TraceContext::new();
+        let input = trace
+            .input(ProgramInputSpec::new(DType::F64, [2_usize.into()]))
+            .unwrap();
+        let output = trace.add_op(CoreSemanticOp::Neg, &[input]).unwrap()[0];
+        let graph = trace.finish(&[output]).unwrap();
+        let compiled = context.compile_graph(&graph).unwrap();
+        let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap();
+        let output = context.run_graph(&compiled, &[&input]).unwrap();
+        assert_eq!(output[0].as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
+        context.run_graph(&compiled, &[&input]).unwrap();
+        let cached = context.graph_cache_stats().unwrap().prepared_plans;
+        assert!(cached.entries > 0);
+        assert!(cached.hits > 0);
+        context.reset_graph_runtime().unwrap();
         assert_eq!(
-            std::error::Error::source(&error).unwrap().to_string(),
-            "forced registration failure"
+            context.graph_cache_stats().unwrap().prepared_plans.entries,
+            0
         );
+
+        let eager = context.eager_runtime().unwrap();
+        assert!(Arc::ptr_eq(&eager, &context.eager_runtime().unwrap()));
     }
 
     #[test]
-    fn eager_context_has_typed_error_contract() {
-        let result: std::result::Result<Arc<EagerRuntime>, EagerContextError> = default_eager_ctx();
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn eager_context_failure_uses_production_path_and_preserves_source() {
-        with_forced_eager_context_failure(|| {
-            let error = match default_eager_ctx() {
-                Ok(_) => panic!("forced eager context failure unexpectedly succeeded"),
-                Err(error) => error,
-            };
-            assert!(matches!(error, EagerContextError::Registration { .. }));
-            let source = std::error::Error::source(&error).unwrap();
-            assert_eq!(
-                source.to_string(),
-                "forced default eager context registration failure"
-            );
-            assert!(source.source().is_none());
-        });
-    }
-
-    #[test]
-    fn eager_context_is_process_global() {
-        let first = default_eager_ctx().unwrap();
-        let second = default_eager_ctx().unwrap();
-
-        assert!(Arc::ptr_eq(&first, &second));
-    }
-
-    #[test]
-    fn eager_context_is_shared_across_threads() {
-        let main_context = default_eager_ctx().unwrap();
-        let worker_context = std::thread::spawn(|| default_eager_ctx().unwrap())
-            .join()
-            .expect("worker thread should complete");
-
-        assert!(Arc::ptr_eq(&main_context, &worker_context));
-    }
-
-    #[test]
-    fn default_backend_is_shared_across_threads() {
-        let main_threads = with_default_backend(|backend| backend.num_threads());
-        let worker_threads =
-            std::thread::spawn(|| with_default_backend(|backend| backend.num_threads()))
-                .join()
-                .expect("worker thread should complete");
-
-        assert_eq!(main_threads, worker_threads);
-    }
-
-    #[test]
-    fn reset_default_engine_releases_retained_backend_buffers() {
-        reset_default_engine_buffer_pool().unwrap();
-        with_default_graph_runtime(|_, _, backend| {
-            backend.with_linalg_pool(|_, pool| {
-                let buffer = <f64 as PoolScalar>::pool_acquire_zeroed(pool, 1024);
-                <f64 as PoolScalar>::pool_release(pool, buffer);
-                Ok(())
-            })
-        })
-        .unwrap()
+    fn separate_eager_contexts_reject_cross_context_operations() {
+        let first = context().eager_runtime().unwrap();
+        let second = context().eager_runtime().unwrap();
+        let a = EagerTensor::from_tensor_in(
+            Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+            first,
+        )
         .unwrap();
-
-        let before = default_engine_buffer_pool_stats().unwrap();
-        assert!(
-            before.capacity_bytes > 0,
-            "operation should retain a buffer"
-        );
-        reset_default_engine().unwrap();
-        let after = default_engine_buffer_pool_stats().unwrap();
-        assert_eq!(after.buffers, 0);
-        assert_eq!(after.capacity_bytes, 0);
+        let b = EagerTensor::from_tensor_in(
+            Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+            second,
+        )
+        .unwrap();
+        assert!(matches!(
+            a.add(&b),
+            Err(tenferro_ad::Error::ContextMismatch { .. })
+        ));
     }
 
     #[test]
-    fn default_engine_is_shared_across_threads() {
-        let main_threads =
-            with_default_graph_runtime(|_, _, backend| backend.num_threads()).unwrap();
-        let worker_threads = std::thread::spawn(|| {
-            with_default_graph_runtime(|_, _, backend| backend.num_threads()).unwrap()
-        })
-        .join()
-        .expect("worker thread should complete");
+    fn caller_managed_backend_remains_caller_owned_after_context_drop() {
+        let executor = Arc::new(CpuContext::with_threads(1).unwrap());
+        let id = CpuDomainId::new(7);
+        let domain =
+            ExternalCpuDomain::new_caller_managed(id, executor.clone(), NonZeroUsize::MIN).unwrap();
+        let backend = CpuBackend::from_external_managed_domains(id, [domain]).unwrap();
+        let context = CpuExecutionContext::from_backend(backend);
+        assert_eq!(context.with_backend(|backend| backend.num_threads()), 1);
+        drop(context);
+        assert_eq!(executor.num_threads(), 1);
+    }
 
-        assert_eq!(main_threads, worker_threads);
+    #[test]
+    fn independent_contexts_do_not_share_a_backend_mutex() {
+        let first = Arc::new(context());
+        let second = Arc::new(context());
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let handles = [first, second].map(|context| {
+            let entered_tx = entered_tx.clone();
+            let release_rx = Arc::clone(&release_rx);
+            std::thread::spawn(move || {
+                context.with_backend(|_| {
+                    entered_tx.send(()).unwrap();
+                    release_rx.lock().unwrap().recv().unwrap();
+                });
+            })
+        });
+        entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        release_tx.send(()).unwrap();
+        release_tx.send(()).unwrap();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    }
+
+    #[cfg(feature = "global-defaults")]
+    #[test]
+    fn explicit_paths_do_not_initialize_the_default_context() {
+        let before = defaults::default_context_hits();
+        let context = context();
+        context.with_backend(|backend| assert_eq!(backend.num_threads(), 1));
+        context.eager_runtime().unwrap();
+        assert_eq!(defaults::default_context_hits(), before);
     }
 }

--- a/crates/tensor4all-tensorbackend/src/context.rs
+++ b/crates/tensor4all-tensorbackend/src/context.rs
@@ -469,6 +469,7 @@ mod tests {
     #[test]
     fn explicit_plain_graph_and_eager_paths_share_only_the_supplied_backend() {
         let context = context();
+        assert!(format!("{context:?}").contains("graph_initialized: false"));
         assert_eq!(context.with_backend(|backend| backend.num_threads()), 1);
 
         let mut trace = TraceContext::new();

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -1,40 +1,58 @@
 #![warn(missing_docs)]
 //! Tensor storage and linear algebra backend for tensor4all.
 //!
-//! This crate provides:
-//! - [`Storage`]: Dynamic snapshot storage for logical tensor values
-//! - [`StructuredStorage`]: `axis_classes`-aware materialized snapshots
-//! - [`AnyScalar`]: Dynamic scalar type backed by rank-0 `tenferro::Tensor`
-//! - tenferro-backed execution helpers for tensor algebra
+//! [`CpuExecutionContext`] is the canonical CPU integration path. It requires a
+//! caller-supplied backend and owns plain, graph, and eager-AD runtime state.
 //!
-//! ## Feature Flags
+//! ## Feature flags
 //!
-//! - `backend-tenferro` (default): Use tenferro backend for linalg/einsum
+//! - `explicit-context`: explicit CPU execution and logical tensor transfer.
+//! - `global-defaults`: legacy process-global tensor operations.
+//! - `backend-tenferro` (default): compatibility alias for `global-defaults`.
 
+#[cfg(feature = "global-defaults")]
 /// Dynamic scalar types supporting f32, f64, Complex32, and Complex64.
 mod any_scalar;
+#[cfg(feature = "global-defaults")]
 /// Backend dispatch for dense linear algebra operations.
 mod backend;
-/// Process-global tenferro execution helpers.
+#[cfg(feature = "explicit-context")]
+/// Explicit and optional process-global tenferro execution helpers.
 mod context;
+#[cfg(feature = "explicit-context")]
+/// Backend-free tensor snapshots for execution-domain transfer.
+mod logical_tensor;
+#[cfg(feature = "global-defaults")]
 /// Dense column-major matrix type and backend-backed matrix utilities.
 mod matrix;
+#[cfg(feature = "global-defaults")]
 /// Process-level memory pressure helpers.
 mod memory;
+#[cfg(feature = "global-defaults")]
 /// Tensor snapshot storage types and low-level dense/diagonal kernels.
 mod storage;
+#[cfg(feature = "global-defaults")]
 pub(crate) mod tenferro_bridge;
+#[cfg(feature = "global-defaults")]
 /// Supported public tensor element types and native constructor hooks.
 mod tensor_element;
 
+#[cfg(feature = "global-defaults")]
 pub use any_scalar::AnyScalar;
+#[cfg(feature = "global-defaults")]
 pub use backend::{
     full_piv_lu_backend, full_piv_lu_matrix, qr_backend, solve_backend, solve_matrix,
     solve_matrix_owned, svd_backend, triangular_solve_backend, triangular_solve_matrix,
     triangular_solve_matrix_owned, BackendLinalgError, BackendLinalgScalar, FullPivLuMatrixResult,
     FullPivLuResult, FullPivLuScalar, MatrixSolveScalar, MatrixTriangularSolveScalar, SvdResult,
 };
+#[cfg(feature = "global-defaults")]
 pub use context::{default_eager_ctx, with_default_backend, EagerContextError};
+#[cfg(feature = "explicit-context")]
+pub use context::{CpuExecutionContext, CpuExecutionContextError};
+#[cfg(feature = "explicit-context")]
+pub use logical_tensor::{LogicalTensor, LogicalTensorData, LogicalTensorError};
+#[cfg(feature = "global-defaults")]
 pub use matrix::{
     batched_mat_mul_same_shape, batched_mat_mul_same_shape_owned, from_vec2d,
     hermitian_eigendecomposition, hermitian_exponential_first_column, lowest_hermitian_eigenpair,
@@ -43,11 +61,14 @@ pub use matrix::{
     HermitianEigendecomposition, HermitianEigenpair, Matrix, MatrixScalar, MatrixShapeError,
     MatrixTensorConversionError,
 };
+#[cfg(feature = "global-defaults")]
 pub use memory::{release_process_allocator_cached_memory, AllocatorPressureRelief};
+#[cfg(feature = "global-defaults")]
 pub use storage::{
     contract_storage, make_mut_storage, min_dim, Storage, StorageError, StorageKind, StorageResult,
     StorageScalar, StructuredStorage, SumFromStorage,
 };
+#[cfg(feature = "global-defaults")]
 pub use tenferro_bridge::{
     axpby_native_tensor, axpby_storage_native, conj_native_tensor, contract_native_tensor,
     contract_storage_native, dense_native_tensor_from_col_major, diag_native_tensor_from_col_major,
@@ -60,9 +81,11 @@ pub use tenferro_bridge::{
     storage_to_native_tensor, sum_native_tensor, svd_native_tensor, tangent_native_tensor,
     BridgeError, NativeTensorReadInput,
 };
+#[cfg(feature = "global-defaults")]
 pub use tensor_element::TensorElement;
 
 /// Extract a result whose error branch means validated internal state is inconsistent.
+#[cfg(feature = "global-defaults")]
 pub(crate) fn require_invariant<T, E: std::fmt::Display>(
     result: std::result::Result<T, E>,
     context: &str,
@@ -79,7 +102,7 @@ pub(crate) fn require_invariant<T, E: std::fmt::Display>(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "global-defaults"))]
 mod invariant_tests {
     use super::require_invariant;
 

--- a/crates/tensor4all-tensorbackend/src/logical_tensor.rs
+++ b/crates/tensor4all-tensorbackend/src/logical_tensor.rs
@@ -1,0 +1,330 @@
+//! Backend-free logical tensor snapshots for transfer between execution domains.
+
+use num_complex::{Complex32, Complex64};
+use tenferro::{DType, Tensor, TensorRead};
+use tenferro_tensor::BackendSessionHost;
+
+use crate::CpuExecutionContext;
+
+/// Owned column-major scalar payload for a [`LogicalTensor`].
+///
+/// The enum contains values only; it cannot carry an executor, backend,
+/// runtime, cache, pointer, or address identity.
+#[derive(Clone, Debug, PartialEq)]
+pub enum LogicalTensorData {
+    /// 32-bit real values.
+    F32(Vec<f32>),
+    /// 64-bit real values.
+    F64(Vec<f64>),
+    /// 32-bit signed integer values.
+    I32(Vec<i32>),
+    /// 64-bit signed integer values.
+    I64(Vec<i64>),
+    /// Boolean values.
+    Bool(Vec<bool>),
+    /// 32-bit complex values.
+    C32(Vec<Complex32>),
+    /// 64-bit complex values.
+    C64(Vec<Complex64>),
+}
+
+impl LogicalTensorData {
+    /// Return the scalar dtype represented by this payload.
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::F32(_) => DType::F32,
+            Self::F64(_) => DType::F64,
+            Self::I32(_) => DType::I32,
+            Self::I64(_) => DType::I64,
+            Self::Bool(_) => DType::Bool,
+            Self::C32(_) => DType::C32,
+            Self::C64(_) => DType::C64,
+        }
+    }
+
+    /// Return the number of logical scalar values.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::F32(values) => values.len(),
+            Self::F64(values) => values.len(),
+            Self::I32(values) => values.len(),
+            Self::I64(values) => values.len(),
+            Self::Bool(values) => values.len(),
+            Self::C32(values) => values.len(),
+            Self::C64(values) => values.len(),
+        }
+    }
+
+    /// Return whether the payload contains no values.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Error returned while validating, snapshotting, or reconstructing a logical tensor.
+#[derive(Debug, thiserror::Error)]
+pub enum LogicalTensorError {
+    /// The shape product overflowed `usize`.
+    #[error("logical tensor shape product overflows usize: {shape:?}")]
+    ShapeOverflow {
+        /// Rejected tensor shape.
+        shape: Vec<usize>,
+    },
+    /// The payload length does not match the shape.
+    #[error(
+        "logical tensor element count mismatch: shape {shape:?} requires {expected}, got {actual}"
+    )]
+    ElementCountMismatch {
+        /// Tensor shape.
+        shape: Vec<usize>,
+        /// Required element count.
+        expected: usize,
+        /// Supplied element count.
+        actual: usize,
+    },
+    /// Tenferro could not read or construct the host tensor.
+    #[error("logical tensor {operation} failed: {source}")]
+    Tensor {
+        /// Operation that failed.
+        operation: &'static str,
+        /// Original tenferro diagnostic.
+        #[source]
+        source: tenferro_tensor::Error,
+    },
+}
+
+/// Backend-free, dtype-preserving logical host tensor in column-major order.
+///
+/// Use [`CpuExecutionContext::reconstruct`] in the receiving execution domain.
+/// The adapter, not tensor4all, owns serialization and transport.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{LogicalTensor, LogicalTensorData};
+///
+/// let tensor = LogicalTensor::new(
+///     vec![2, 2],
+///     LogicalTensorData::F64(vec![1.0, 2.0, 3.0, 4.0]),
+/// )?;
+/// assert_eq!(tensor.shape(), &[2, 2]);
+/// assert_eq!(tensor.data().len(), 4);
+/// # Ok::<(), tensor4all_tensorbackend::LogicalTensorError>(())
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct LogicalTensor {
+    shape: Vec<usize>,
+    data: LogicalTensorData,
+}
+
+impl LogicalTensor {
+    /// Create a validated column-major logical tensor snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogicalTensorError::ShapeOverflow`] when the shape product
+    /// overflows, or [`LogicalTensorError::ElementCountMismatch`] when the data
+    /// length differs from that product.
+    pub fn new(shape: Vec<usize>, data: LogicalTensorData) -> Result<Self, LogicalTensorError> {
+        let expected = shape
+            .iter()
+            .try_fold(1_usize, |count, &dim| count.checked_mul(dim).ok_or(()));
+        let expected = expected.map_err(|()| LogicalTensorError::ShapeOverflow {
+            shape: shape.clone(),
+        })?;
+        if data.len() != expected {
+            return Err(LogicalTensorError::ElementCountMismatch {
+                shape,
+                expected,
+                actual: data.len(),
+            });
+        }
+        Ok(Self { shape, data })
+    }
+
+    /// Snapshot a native host tensor without retaining execution identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogicalTensorError::Tensor`] if the native tensor is not
+    /// host-readable with its declared dtype.
+    pub fn from_native(tensor: &Tensor) -> Result<Self, LogicalTensorError> {
+        let data = match tensor.dtype() {
+            DType::F32 => LogicalTensorData::F32(
+                tensor
+                    .as_slice::<f32>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+            DType::F64 => LogicalTensorData::F64(
+                tensor
+                    .as_slice::<f64>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+            DType::I32 => LogicalTensorData::I32(
+                tensor
+                    .as_slice::<i32>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+            DType::I64 => LogicalTensorData::I64(
+                tensor
+                    .as_slice::<i64>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+            DType::Bool => LogicalTensorData::Bool(
+                tensor
+                    .as_slice::<bool>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+            DType::C32 => LogicalTensorData::C32(
+                tensor
+                    .as_slice::<Complex32>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+            DType::C64 => LogicalTensorData::C64(
+                tensor
+                    .as_slice::<Complex64>()
+                    .map_err(|source| LogicalTensorError::Tensor {
+                        operation: "snapshot",
+                        source,
+                    })?
+                    .to_vec(),
+            ),
+        };
+        Self::new(tensor.shape().to_vec(), data)
+    }
+
+    /// Return the logical shape.
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Return the scalar dtype.
+    pub fn dtype(&self) -> DType {
+        self.data.dtype()
+    }
+
+    /// Return the owned scalar payload.
+    pub fn data(&self) -> &LogicalTensorData {
+        &self.data
+    }
+
+    fn to_native(&self) -> Result<Tensor, LogicalTensorError> {
+        let result = match &self.data {
+            LogicalTensorData::F32(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+            LogicalTensorData::F64(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+            LogicalTensorData::I32(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+            LogicalTensorData::I64(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+            LogicalTensorData::Bool(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+            LogicalTensorData::C32(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+            LogicalTensorData::C64(values) => {
+                Tensor::from_vec_col_major(self.shape.clone(), values.clone())
+            }
+        };
+        result.map_err(|source| LogicalTensorError::Tensor {
+            operation: "reconstruction",
+            source,
+        })
+    }
+}
+
+impl CpuExecutionContext {
+    /// Reconstruct a logical host tensor in this receiving execution domain.
+    ///
+    /// The returned value carries only host tensor data. Its first plain, graph,
+    /// or eager operation must use this same explicit context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogicalTensorError`] if tenferro rejects the validated shape or
+    /// dtype payload.
+    pub fn reconstruct(&self, tensor: &LogicalTensor) -> Result<Tensor, LogicalTensorError> {
+        let host = tensor.to_native()?;
+        self.with_backend(|backend| {
+            backend.with_backend_session(|session| {
+                session.upload_host_tensor(TensorRead::from_tensor(&host))
+            })
+        })
+        .map_err(|source| LogicalTensorError::Tensor {
+            operation: "target-context upload",
+            source,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tenferro_cpu::CpuBackend;
+
+    #[test]
+    fn round_trip_preserves_shape_dtype_and_values_in_target_context() {
+        let native = Tensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(1.0, 2.0),
+                Complex32::new(3.0, 4.0),
+                Complex32::new(5.0, 6.0),
+                Complex32::new(7.0, 8.0),
+            ],
+        )
+        .unwrap();
+        let logical = LogicalTensor::from_native(&native).unwrap();
+        let target = CpuExecutionContext::from_backend(CpuBackend::with_threads(1).unwrap());
+        let rebuilt = target.reconstruct(&logical).unwrap();
+
+        assert_eq!(rebuilt.shape(), &[2, 2]);
+        assert_eq!(rebuilt.dtype(), DType::C32);
+        assert_eq!(
+            rebuilt.as_slice::<Complex32>().unwrap(),
+            native.as_slice::<Complex32>().unwrap()
+        );
+    }
+
+    #[test]
+    fn validation_rejects_overflow_and_length_mismatch() {
+        assert!(matches!(
+            LogicalTensor::new(vec![usize::MAX, 2], LogicalTensorData::F64(Vec::new())),
+            Err(LogicalTensorError::ShapeOverflow { .. })
+        ));
+        assert!(matches!(
+            LogicalTensor::new(vec![2], LogicalTensorData::F64(vec![1.0])),
+            Err(LogicalTensorError::ElementCountMismatch { .. })
+        ));
+    }
+}

--- a/crates/tensor4all-tensorbackend/src/logical_tensor.rs
+++ b/crates/tensor4all-tensorbackend/src/logical_tensor.rs
@@ -293,27 +293,45 @@ mod tests {
     use tenferro_cpu::CpuBackend;
 
     #[test]
-    fn round_trip_preserves_shape_dtype_and_values_in_target_context() {
-        let native = Tensor::from_vec_col_major(
-            vec![2, 2],
-            vec![
-                Complex32::new(1.0, 2.0),
-                Complex32::new(3.0, 4.0),
-                Complex32::new(5.0, 6.0),
-                Complex32::new(7.0, 8.0),
-            ],
-        )
-        .unwrap();
-        let logical = LogicalTensor::from_native(&native).unwrap();
-        let target = CpuExecutionContext::from_backend(CpuBackend::with_threads(1).unwrap());
-        let rebuilt = target.reconstruct(&logical).unwrap();
+    fn round_trip_preserves_all_host_dtypes_in_target_context() {
+        macro_rules! assert_round_trip {
+            ($ty:ty, $variant:ident, $dtype:expr, $values:expr) => {{
+                let values: Vec<$ty> = $values;
+                let native =
+                    Tensor::from_vec_col_major(vec![values.len()], values.clone()).unwrap();
+                let logical = LogicalTensor::from_native(&native).unwrap();
+                let target =
+                    CpuExecutionContext::from_backend(CpuBackend::with_threads(1).unwrap());
+                let rebuilt = target.reconstruct(&logical).unwrap();
 
-        assert_eq!(rebuilt.shape(), &[2, 2]);
-        assert_eq!(rebuilt.dtype(), DType::C32);
-        assert_eq!(
-            rebuilt.as_slice::<Complex32>().unwrap(),
-            native.as_slice::<Complex32>().unwrap()
+                assert_eq!(logical.shape(), &[values.len()]);
+                assert_eq!(logical.dtype(), $dtype);
+                assert_eq!(logical.data().len(), values.len());
+                assert!(matches!(logical.data(), LogicalTensorData::$variant(_)));
+                assert_eq!(rebuilt.as_slice::<$ty>().unwrap(), values);
+            }};
+        }
+
+        assert_round_trip!(f32, F32, DType::F32, vec![1.0, 2.0]);
+        assert_round_trip!(f64, F64, DType::F64, vec![1.0, 2.0]);
+        assert_round_trip!(i32, I32, DType::I32, vec![1, 2]);
+        assert_round_trip!(i64, I64, DType::I64, vec![1, 2]);
+        assert_round_trip!(bool, Bool, DType::Bool, vec![true, false]);
+        assert_round_trip!(
+            Complex32,
+            C32,
+            DType::C32,
+            vec![Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)]
         );
+        assert_round_trip!(
+            Complex64,
+            C64,
+            DType::C64,
+            vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]
+        );
+
+        let empty = LogicalTensor::new(vec![0], LogicalTensorData::F64(Vec::new())).unwrap();
+        assert!(empty.data().is_empty());
     }
 
     #[test]

--- a/docs/design/explicit-cpu-execution-context.md
+++ b/docs/design/explicit-cpu-execution-context.md
@@ -1,0 +1,114 @@
+# Explicit CPU execution context
+
+**Status:** Implemented for tensor4all-rs#663
+
+## Goal
+
+Make one caller-supplied `tenferro_cpu::CpuBackend` the root of plain tensor,
+graph, and eager-AD execution without consulting process-global defaults.
+Tensor4all does not define an executor abstraction or depend on a host
+scheduler.
+
+## Public boundary
+
+`tensor4all_tensorbackend::CpuExecutionContext::from_backend` consumes the
+caller-selected backend. `CpuBackend::clone` supplies the graph and eager
+handles; those clones preserve the backend runtime identity and share only the
+caller-selected executor/provider resources. Construction never calls
+`CpuBackend::new`, `CpuContext::from_env`, or placement resolution. The context
+owns:
+
+- a backend handle for plain operations;
+- a graph compiler, runtime, prepared-plan cache, and cloned backend handle;
+- an eager runtime built from another cloned backend handle.
+
+The context exposes explicit methods for borrowing the plain backend, compiling
+and running graph programs, and cloning the eager runtime handle. These methods
+are the canonical explicit integration surface. Existing higher-level
+`IdxTensor`, matrix, and bridge functions remain opt-in global convenience APIs;
+an explicit host adapter must call the context surface (and may wrap values in
+its own application type) rather than those convenience functions. Graph IR
+and `tenferro::CompiledGraph` remain backend-neutral; backend-prepared
+executables, workspaces, and caches stay private to the context-owned runtime.
+
+Separately created contexts never share a tensor4all mutex or cache. Backend
+identity checks remain tenferro's responsibility and errors are preserved as
+typed sources.
+
+## Global convenience path
+
+The existing process-global helpers remain only behind the opt-in
+`global-defaults` Cargo feature. The normal workspace enables that feature for
+compatibility. An integration can depend on `tensor4all-tensorbackend` with
+`default-features = false` and select a CPU provider feature without compiling
+any `DEFAULT_*`, `from_env`, or global backend mutex path. The public context is
+re-exported from `tensor4all-tensorbackend`; no C API change is made.
+
+Explicit methods do not call global helpers. The global wrappers are thin
+adapters over the same context implementation, avoiding a second operation
+implementation.
+
+### Feature-gating inventory
+
+`explicit-context` compiles `context` without its default submodule plus the new
+`logical_tensor` module. Its public surface is
+`CpuExecutionContext`, its typed construction/execution errors,
+`LogicalTensor`, `LogicalTensorData`, and their typed error. This is the small
+integration API for plain backend borrowing, graph compile/run/cache, eager
+runtime access, and target-context reconstruction.
+
+`global-defaults` additionally compiles the legacy `any_scalar`, `backend`,
+`matrix`, `memory`, `storage`, `tenferro_bridge`, and `tensor_element` modules
+and their current re-exports. `backend-tenferro` remains a compatibility alias
+for `global-defaults`, and the crate's default features keep enabling it. This
+coarse module boundary is deliberate: it leaves no legacy operation that can
+reference a default in an explicit-only build and avoids scattered per-function
+cfg gates.
+
+CI checks both isolated code and docs:
+
+```text
+cargo check -p tensor4all-tensorbackend --no-default-features \
+  --features explicit-context,tenferro-cpu-faer
+cargo doc -p tensor4all-tensorbackend --no-deps --no-default-features \
+  --features explicit-context,tenferro-cpu-faer
+```
+
+A source-isolated build proves graph and reconstruction code cannot reference
+the default module; a runtime hit-counter test separately covers explicit plain
+and eager initialization. Other tests exercise graph/cache, reconstruction,
+parallel-context, and drop/fresh-cache behavior. The cross-context test creates eager tensors in two
+separate `EagerRuntime` values and calls `EagerTensor::add`, which tenferro
+rejects specifically with `tenferro_ad::Error::ContextMismatch`; no plain host
+tensor is claimed to be context-bound.
+
+## Logical transfer
+
+`LogicalTensor` is a new owned, canonical column-major host snapshot containing
+only shape and dtype-preserving scalar data for all tenferro CPU dtypes (`f32`,
+`f64`, `i32`, `i64`, `bool`, `Complex32`, and `Complex64`). It is distinct from
+`Storage`, whose scalar contract intentionally covers only `f64` and
+`Complex64` structured payloads. It contains no backend, executor, runtime,
+cache, admission token, pointer, or address identity. Reconstruction is a
+method on `CpuExecutionContext`, making the receiving context mandatory; shape,
+element-count, and dtype failures are typed bridge errors. The adapter owns
+serialization and MPI transport.
+
+## Errors and lifecycle
+
+Construction and graph execution use crate-local typed errors with original
+tenferro errors retained as sources. The context is `Send + Sync`. Dropping the
+last context owner drops its backend handles, graph runtime/cache, and eager
+runtime, but never shuts down a caller-owned executor retained elsewhere. A
+fresh context has a fresh runtime/cache and cannot recover stale prepared
+entries. Tests cover both properties.
+
+## Non-goals
+
+- Hataori, MPI, or serialization dependencies;
+- a generic executor trait, TLS override, or process-global context registry;
+- serializing compiled programs or provider workspaces;
+- changing tenferro's caller-managed admission contract delivered by
+  tenferro-rs#1716 / PR #1717; tensor4all updates its tenferro pin to merge
+  commit `a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45` and verifies the existing
+  backend-session bridges against it.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -6,6 +6,7 @@
 |----------|-------------|
 | [t4a_unified_tensor_backend.md](./t4a_unified_tensor_backend.md) | Unified tensor backend design (tenferro-rs integration) |
 | [tenferro-main-session-migration.md](./tenferro-main-session-migration.md) | First issue #623 slice: pin current tenferro main and migrate internal CPU calls to its canonical session API |
+| [explicit-cpu-execution-context.md](./explicit-cpu-execution-context.md) | Issue #663 explicit plain, graph, eager-AD, and logical reconstruction context |
 | [torch_backend.md](./torch_backend.md) | PyTorch backend design exploration |
 | [tenferro_ad_scalar_operator_extension_note.md](./tenferro_ad_scalar_operator_extension_note.md) | Tenferro AD scalar operator extension notes |
 | [build-profiles.md](./build-profiles.md) | Debug-free ordinary Cargo profiles and the opt-in full-debug release profile |

--- a/docs/worklogs/2026-08-22-issue-663-explicit-cpu-context.md
+++ b/docs/worklogs/2026-08-22-issue-663-explicit-cpu-context.md
@@ -1,0 +1,52 @@
+# Issue #663: explicit CPU execution context
+
+## Summary
+
+Added a caller-supplied CPU context as the canonical tensorbackend integration
+path for plain operations, graph compile/run/cache, eager AD, and logical tensor
+reconstruction. Legacy process-global operations remain behind the opt-in
+`global-defaults` feature.
+
+## Reviewed inputs
+
+- tensor4all-rs issue #663 and Hataori P0 design
+- tenferro-rs issue #1716 and merged PR #1717
+- `tensor4all-tensorbackend` context, bridge, matrix, backend, and storage APIs
+- repository and shared Rust/performance/test rules
+
+## Decisions
+
+- Pin tenferro PR #1717 merge commit
+  `a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45`.
+- Consume one configured `CpuBackend` and clone its runtime identity for graph
+  and eager ownership; never construct an implicit backend in explicit paths.
+- Keep graph-prepared entries private to each context-owned `Runtime`.
+- Use a coarse legacy-module feature boundary instead of scattered per-function
+  cfg gates.
+- Add `LogicalTensor` because existing `Storage` intentionally supports only
+  structured `f64`/`Complex64`, while transfer must preserve every CPU dtype.
+- Keep MPI, serialization, Hataori types, TLS overrides, and global registries
+  out of tensor4all.
+
+## Review gate
+
+- Design: `docs/design/explicit-cpu-execution-context.md`
+- Reviewer: `reviewer-flash-opencode-go` (read-only, DeepSeek family)
+- Rounds: initial findings fixed; feature inventory and exact mismatch path
+  clarified; final verdict **Correct-to-implement**.
+- Post-implementation diff review: `reviewer-flash` verified the full diff;
+  verdict **Correct-to-merge**. One Minor documentation overstatement was fixed.
+
+## Verification
+
+- explicit-only `cargo check` and `cargo doc`
+- explicit-only release tests
+- default tensorbackend release tests
+- workspace `cargo check`
+- formatting and clippy gates
+
+## Remaining risk
+
+The optional Hataori adapter still owns wire encoding and the joint MPI/domain
+integration test. Tensor4all exposes no serialization format and makes no MPI
+claim.

--- a/docs/worklogs/2026-08-22-issue-663-explicit-cpu-context.md
+++ b/docs/worklogs/2026-08-22-issue-663-explicit-cpu-context.md
@@ -36,6 +36,9 @@ reconstruction. Legacy process-global operations remain behind the opt-in
   clarified; final verdict **Correct-to-implement**.
 - Post-implementation diff review: `reviewer-flash` verified the full diff;
   verdict **Correct-to-merge**. One Minor documentation overstatement was fixed.
+- After CI exposed standalone HDF5 feature forwarding and coverage gaps, the
+  focused fixes were re-reviewed by `reviewer-flash-opencode-go`; verdict
+  **Correct-to-merge**.
 
 ## Verification
 
@@ -43,6 +46,8 @@ reconstruction. Legacy process-global operations remain behind the opt-in
 - explicit-only release tests
 - default tensorbackend release tests
 - workspace `cargo check`
+- standalone HDF5 tests
+- workspace and tensorbackend per-file coverage gates
 - formatting and clippy gates
 
 ## Remaining risk


### PR DESCRIPTION
## Summary

- add caller-supplied `CpuExecutionContext` entry points for plain backend access, graph compile/run/cache lifecycle, and eager AD
- add identity-free `LogicalTensor` host snapshots and reconstruction in a supplied target context
- isolate legacy process-global defaults behind the opt-in `global-defaults` feature and add an explicit-only CI build
- pin tenferro to the merged caller-managed executor implementation from tensor4all/tenferro-rs#1717

Closes #663

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p tensor4all-tensorbackend --no-default-features --features explicit-context,tenferro-cpu-faer`
- `cargo test -p tensor4all-tensorbackend --no-default-features --features explicit-context,tenferro-cpu-faer` (9 passed)
- `cargo test -p tensor4all-tensorbackend` (328 passed, 2 ignored)
- `cargo nextest run --release --workspace` before final rebase (3004 passed)
- `python3 scripts/check-public-error-docs.py --changed-from origin/main`
- `python3 scripts/repository-rules-review.py --base origin/main --dry-run`

## Review gate

- pre-implementation design review: **Correct-to-implement**
- post-implementation full-diff review (`reviewer-flash`, read-only, different model family): **Correct-to-merge**
- one Minor documentation precision finding was fixed before this PR
