### PR TITLE
fix(treeaci,treetn): close branch-point batching gaps for #671

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ experimental/
 
 # Agent session infrastructure (never commit)
 .pi-subagents/
-
-# Local debugging transcript (never commit)
-/2026-08-22-161024-gw-rsbugissue-671syst.txt

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ experimental/
 
 # Agent session infrastructure (never commit)
 .pi-subagents/
+
+# Local debugging transcript (never commit)
+/2026-08-22-161024-gw-rsbugissue-671syst.txt

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -1066,8 +1066,10 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
     /// batched BLAS path ([`contract_prepared_core_batched`]) when `edge`'s
     /// source node has exactly one incoming edge -- the same precondition and
     /// grouping strategy [`InputFrameStore::candidate_frames_for_edge`]
-    /// already uses for pivot-search candidates -- and falling back to
-    /// [`Self::compute`] per sample otherwise (0 or >=2 incoming edges).
+    /// already uses for pivot-search candidates -- delegating to
+    /// [`Self::compute_batch_two_incoming`] for exactly two incoming edges,
+    /// and falling back to [`Self::compute`] per sample otherwise (0
+    /// incoming edges, or 3+).
     ///
     /// Unlike `compute`, this has no return value: every result lands in
     /// `self.memo[edge]`, which is where `build_or_extend`'s caller reads
@@ -1078,6 +1080,9 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
         samples: std::ops::Range<SampleId>,
     ) -> Result<()> {
         let directed = &self.problem.directed_edges[edge];
+        if directed.incoming_to_from.len() == 2 {
+            return self.compute_batch_two_incoming(edge, samples);
+        }
         if directed.incoming_to_from.len() != 1 {
             for sample in samples {
                 self.compute(edge, sample)?;
@@ -1203,6 +1208,174 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
             for (column, &(sample, _)) in group_samples.iter().enumerate() {
                 let values: Vec<T> = (0..outgoing_dim)
                     .map(|row| batched[[row, column]])
+                    .collect();
+                #[cfg(test)]
+                debug_stats::record_batched_compute_call();
+                let slot = self
+                    .memo
+                    .get_mut(edge)
+                    .and_then(|s| s.get_mut(sample))
+                    .ok_or(TreeAciError::InternalInvariant {
+                        message: "computed frame has no memoization slot",
+                    })?;
+                *slot = Some(values);
+            }
+        }
+        Ok(())
+    }
+
+    /// Batched counterpart to [`Self::compute_batch`]'s single-incoming-edge
+    /// path, for directed edges whose source node has exactly two incoming
+    /// edges. Primes both incoming edges' needed samples via [`Self::compute`]
+    /// (as `compute_batch` already does for its one incoming edge), then
+    /// groups the pending samples by `local_coordinate` and contracts each
+    /// group via [`two_incoming_core_matrix_batched`], mirroring
+    /// [`InputFrameStore::candidate_frames_for_edge_two_incoming`]'s
+    /// structure but reading incoming frame vectors from `self.memo` instead
+    /// of a committed `InputFrameStore`.
+    fn compute_batch_two_incoming(
+        &mut self,
+        edge: DirectedEdgeId,
+        samples: std::ops::Range<SampleId>,
+    ) -> Result<()> {
+        let directed = &self.problem.directed_edges[edge];
+        let incoming_edge_1 = directed.incoming_to_from[0];
+        let incoming_edge_2 = directed.incoming_to_from[1];
+
+        let mut pending: Vec<(SampleId, ComponentSample)> = Vec::new();
+        for sample in samples {
+            if self.memo[edge][sample].is_some() {
+                continue;
+            }
+            let record = self.arena.record(edge, sample)?.clone();
+            if record.incoming.len() != 2
+                || record.incoming[0].0 != incoming_edge_1
+                || record.incoming[1].0 != incoming_edge_2
+            {
+                return Err(TreeAciError::InternalInvariant {
+                    message:
+                        "two-incoming-edge sample does not have exactly two incoming samples on the expected edges",
+                });
+            }
+            pending.push((sample, record));
+        }
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        for (_, record) in &pending {
+            self.compute(incoming_edge_1, record.incoming[0].1)?;
+            self.compute(incoming_edge_2, record.incoming[1].1)?;
+        }
+
+        let node = *self.problem.node_positions.get(&directed.from).ok_or(
+            TreeAciError::InternalInvariant {
+                message: "frame source has no prepared node position",
+            },
+        )?;
+        let core = &self.cores[node];
+        let outgoing = self.outgoing_bond(edge)?;
+        let outgoing_axis = axis_of(&core.indices, outgoing)?;
+        let physical = &self.problem.physical[node];
+        let physical_axes = physical
+            .indices
+            .iter()
+            .map(|index| axis_of(&core.indices, index))
+            .collect::<Result<Vec<_>>>()?;
+        let incoming_bond_1 = self.outgoing_bond(incoming_edge_1)?;
+        let incoming_bond_2 = self.outgoing_bond(incoming_edge_2)?;
+        let incoming_axis_1 = axis_of(&core.indices, incoming_bond_1)?;
+        let incoming_axis_2 = axis_of(&core.indices, incoming_bond_2)?;
+        let outgoing_dim = core.dims[outgoing_axis];
+        let incoming_dim_1 = core.dims[incoming_axis_1];
+        let incoming_dim_2 = core.dims[incoming_axis_2];
+
+        let mut groups: std::collections::BTreeMap<usize, Vec<(SampleId, SampleId, SampleId)>> =
+            std::collections::BTreeMap::new();
+        for (sample, record) in &pending {
+            let (_, sample_1) = record.incoming[0];
+            let (_, sample_2) = record.incoming[1];
+            groups
+                .entry(record.local_coordinate)
+                .or_default()
+                .push((*sample, sample_1, sample_2));
+        }
+
+        for (local_coordinate, group_samples) in groups {
+            let mut base_offset = 0usize;
+            for (physical_axis, &axis) in physical_axes.iter().enumerate() {
+                let wanted = (local_coordinate / physical.strides[physical_axis])
+                    % physical.dims[physical_axis];
+                base_offset += wanted * core.strides[axis];
+            }
+
+            let mut ids_1: Vec<SampleId> = Vec::new();
+            let mut position_1: HashMap<SampleId, usize> = HashMap::new();
+            let mut ids_2: Vec<SampleId> = Vec::new();
+            let mut position_2: HashMap<SampleId, usize> = HashMap::new();
+            for &(_, sample_1, sample_2) in &group_samples {
+                position_1.entry(sample_1).or_insert_with(|| {
+                    ids_1.push(sample_1);
+                    ids_1.len() - 1
+                });
+                position_2.entry(sample_2).or_insert_with(|| {
+                    ids_2.push(sample_2);
+                    ids_2.len() - 1
+                });
+            }
+
+            let mut v1_data = Vec::with_capacity(incoming_dim_1 * ids_1.len());
+            for &sample_1 in &ids_1 {
+                let values = self.memo[incoming_edge_1][sample_1].clone().ok_or(
+                    TreeAciError::InternalInvariant {
+                        message:
+                            "incoming sample frame was not memoized before batched contraction",
+                    },
+                )?;
+                if values.len() != incoming_dim_1 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v1_data.extend(values);
+            }
+            let v1 = Matrix::from_col_major_vec(incoming_dim_1, ids_1.len(), v1_data);
+
+            let mut v2_data = Vec::with_capacity(incoming_dim_2 * ids_2.len());
+            for &sample_2 in &ids_2 {
+                let values = self.memo[incoming_edge_2][sample_2].clone().ok_or(
+                    TreeAciError::InternalInvariant {
+                        message:
+                            "incoming sample frame was not memoized before batched contraction",
+                    },
+                )?;
+                if values.len() != incoming_dim_2 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v2_data.extend(values);
+            }
+            let v2 = Matrix::from_col_major_vec(incoming_dim_2, ids_2.len(), v2_data);
+
+            let batched = two_incoming_core_matrix_batched(
+                core,
+                outgoing_axis,
+                incoming_axis_1,
+                incoming_axis_2,
+                base_offset,
+                outgoing_dim,
+                incoming_dim_1,
+                incoming_dim_2,
+                &v1,
+                &v2,
+            )?;
+
+            for (sample, sample_1, sample_2) in group_samples {
+                let n1 = position_1[&sample_1];
+                let n2 = position_2[&sample_2];
+                let values: Vec<T> = (0..outgoing_dim)
+                    .map(|out| batched[[out + outgoing_dim * n1, n2]])
                     .collect();
                 #[cfg(test)]
                 debug_stats::record_batched_compute_call();

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -1164,6 +1164,49 @@ fn contract_prepared_core_batched<T: TreeAciScalar>(
     })
 }
 
+/// Contracts a core slice's two incoming axes against batches of candidate
+/// frame vectors for both incoming edges, computing every combination in
+/// the cartesian product of `v1`'s and `v2`'s columns via `incoming_dim_2 + 1`
+/// BLAS `mat_mul` calls (`incoming_dim_2` calls fold in `v1` one slice of the
+/// second axis at a time, then one final call folds in `v2`) instead of one
+/// scalar [`accumulate_incoming`] walk per `(n1, n2)` combination.
+///
+/// `v1` is `incoming_dim_1 x n1`, `v2` is `incoming_dim_2 x n2`. Returns an
+/// `(outgoing_dim * n1) x n2` matrix: column `n2`, rows
+/// `[outgoing_dim * n1_index, outgoing_dim * (n1_index + 1))`, holds the
+/// `outgoing_dim`-length frame vector [`contract_prepared_core`] would
+/// produce for the `(n1_index, n2)` candidate alone.
+fn two_incoming_core_matrix_batched<T: TreeAciScalar>(
+    core: &PreparedCore<T>,
+    outgoing_axis: usize,
+    incoming_axis_1: usize,
+    incoming_axis_2: usize,
+    physical_base_offset: usize,
+    outgoing_dim: usize,
+    incoming_dim_1: usize,
+    incoming_dim_2: usize,
+    v1: &Matrix<T>,
+    v2: &Matrix<T>,
+) -> Result<Matrix<T>> {
+    let n1 = v1.ncols();
+    let stride_2 = core.strides[incoming_axis_2];
+    let mut stage1_data = Vec::with_capacity(outgoing_dim * n1 * incoming_dim_2);
+    for i2 in 0..incoming_dim_2 {
+        let core_matrix = single_incoming_core_matrix(
+            core,
+            outgoing_axis,
+            incoming_axis_1,
+            physical_base_offset + i2 * stride_2,
+            outgoing_dim,
+            incoming_dim_1,
+        );
+        let stage1 = contract_prepared_core_batched(&core_matrix, v1)?;
+        stage1_data.extend(stage1.into_col_major_vec());
+    }
+    let stage1_matrix = Matrix::from_col_major_vec(outgoing_dim * n1, incoming_dim_2, stage1_data);
+    contract_prepared_core_batched(&stage1_matrix, v2)
+}
+
 fn outgoing_bond<'a, V: TreeAciNode>(
     input: &'a TreeTN<IdxTensor, V>,
     problem: &PreparedTreeProblem<V>,

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -461,11 +461,16 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
     }
 
     /// Computes every candidate's frame vector for one input and directed
-    /// edge, using the batched BLAS path (one `mat_mul` call per distinct
-    /// `local_coordinate`) when the edge's source node has exactly one
-    /// incoming edge, and falling back to the scalar
-    /// [`Self::candidate_frame`] path (called once per candidate, and still
-    /// consulting/populating `candidate_cache`) otherwise.
+    /// edge. Dispatches to a batched BLAS path when the edge's source node
+    /// has exactly one incoming edge (one `mat_mul` call per distinct
+    /// `local_coordinate`) or exactly two incoming edges (see
+    /// [`Self::candidate_frames_for_edge_two_incoming`] and
+    /// [`two_incoming_core_matrix_batched`]), and falls back to the scalar
+    /// [`Self::candidate_frame`] path (called once per candidate, still
+    /// consulting/populating `candidate_cache`) for a leaf edge (zero
+    /// incoming edges) or a node with three or more incoming edges (out of
+    /// scope for the batched paths -- see issue #671 and
+    /// `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`).
     ///
     /// The batched path also consults `candidate_cache` per candidate before
     /// grouping it into a BLAS call. A one-off instrumented run of
@@ -493,6 +498,15 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                 .ok_or(TreeAciError::InternalInvariant {
                     message: "candidate frame references an unknown directed edge",
                 })?;
+        if directed.incoming_to_from.len() == 2 {
+            return self.candidate_frames_for_edge_two_incoming(
+                inputs,
+                problem,
+                input,
+                directed_edge,
+                candidates,
+            );
+        }
         if directed.incoming_to_from.len() != 1 {
             return candidates
                 .iter()
@@ -636,6 +650,206 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             .map(|value| {
                 value.ok_or(TreeAciError::InternalInvariant {
                     message: "candidate frame batching left a candidate unfilled",
+                })
+            })
+            .collect()
+    }
+
+    /// Batched counterpart to [`Self::candidate_frames_for_edge`]'s
+    /// single-incoming-edge path, for directed edges whose source node has
+    /// exactly two incoming edges (every hub of a 3-valent tree branch
+    /// point). Groups candidates by `local_coordinate` exactly as the
+    /// single-incoming path does, then for each group gathers the distinct
+    /// sample ids referenced on each incoming edge, builds one frame-vector
+    /// matrix per incoming edge, and contracts both via
+    /// [`two_incoming_core_matrix_batched`] in one shot -- computing the
+    /// full cartesian product of the group's distinct incoming ids (a
+    /// superset of the group's actual candidates whenever the group is not
+    /// already the full product) and reading back only the entries the
+    /// group's candidates actually need.
+    fn candidate_frames_for_edge_two_incoming<V: TreeAciNode>(
+        &self,
+        inputs: &[TreeTN<IdxTensor, V>],
+        problem: &PreparedTreeProblem<V>,
+        input: usize,
+        directed_edge: DirectedEdgeId,
+        candidates: &[ComponentSample],
+    ) -> Result<Vec<Vec<T>>> {
+        let directed =
+            problem
+                .directed_edges
+                .get(directed_edge)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "candidate frame references an unknown directed edge",
+                })?;
+        let node =
+            *problem
+                .node_positions
+                .get(&directed.from)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "candidate source has no prepared node position",
+                })?;
+        let tree = inputs.get(input).ok_or(TreeAciError::InternalInvariant {
+            message: "candidate frame references an unknown input",
+        })?;
+        let cores = self
+            .cores
+            .get(input)
+            .ok_or(TreeAciError::InternalInvariant {
+                message: "candidate frame has no prepared input cores",
+            })?;
+        let core = cores.get(node).ok_or(TreeAciError::InternalInvariant {
+            message: "candidate frame source node has no prepared core",
+        })?;
+        let outgoing = outgoing_bond(tree, problem, directed_edge)?;
+        let outgoing_axis = axis_of(&core.indices, outgoing)?;
+        let physical = &problem.physical[node];
+        let physical_axes = physical
+            .indices
+            .iter()
+            .map(|index| axis_of(&core.indices, index))
+            .collect::<Result<Vec<_>>>()?;
+        let incoming_edge_1 = directed.incoming_to_from[0];
+        let incoming_edge_2 = directed.incoming_to_from[1];
+        let incoming_bond_1 = outgoing_bond(tree, problem, incoming_edge_1)?;
+        let incoming_bond_2 = outgoing_bond(tree, problem, incoming_edge_2)?;
+        let incoming_axis_1 = axis_of(&core.indices, incoming_bond_1)?;
+        let incoming_axis_2 = axis_of(&core.indices, incoming_bond_2)?;
+        let outgoing_dim = core.dims[outgoing_axis];
+        let incoming_dim_1 = core.dims[incoming_axis_1];
+        let incoming_dim_2 = core.dims[incoming_axis_2];
+
+        let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        let mut results: Vec<Option<Vec<T>>> = vec![None; candidates.len()];
+        for (candidate_index, candidate) in candidates.iter().enumerate() {
+            let key: CandidateCacheKey = (
+                input,
+                directed_edge,
+                candidate.local_coordinate,
+                candidate.incoming.clone(),
+            );
+            if let Some(cached) = self.candidate_cache.borrow().get(&key) {
+                #[cfg(test)]
+                candidate_debug_stats::record_hit();
+                results[candidate_index] = Some(cached.clone());
+                continue;
+            }
+            #[cfg(test)]
+            candidate_debug_stats::record_miss();
+            if candidate.incoming.len() != 2
+                || candidate.incoming[0].0 != incoming_edge_1
+                || candidate.incoming[1].0 != incoming_edge_2
+            {
+                return Err(TreeAciError::InternalInvariant {
+                    message: "two-incoming-edge candidate does not match the edge's incoming order",
+                });
+            }
+            groups
+                .entry(candidate.local_coordinate)
+                .or_default()
+                .push(candidate_index);
+        }
+
+        for (local_coordinate, indices) in groups {
+            let mut base_offset = 0usize;
+            for (physical_axis, &axis) in physical_axes.iter().enumerate() {
+                let wanted = (local_coordinate / physical.strides[physical_axis])
+                    % physical.dims[physical_axis];
+                base_offset += wanted * core.strides[axis];
+            }
+
+            let mut ids_1: Vec<SampleId> = Vec::new();
+            let mut position_1: HashMap<SampleId, usize> = HashMap::new();
+            let mut ids_2: Vec<SampleId> = Vec::new();
+            let mut position_2: HashMap<SampleId, usize> = HashMap::new();
+            for &candidate_index in &indices {
+                let (_, sample_1) = candidates[candidate_index].incoming[0];
+                let (_, sample_2) = candidates[candidate_index].incoming[1];
+                position_1.entry(sample_1).or_insert_with(|| {
+                    ids_1.push(sample_1);
+                    ids_1.len() - 1
+                });
+                position_2.entry(sample_2).or_insert_with(|| {
+                    ids_2.push(sample_2);
+                    ids_2.len() - 1
+                });
+            }
+
+            let mut v1_data = Vec::with_capacity(incoming_dim_1 * ids_1.len());
+            for &sample in &ids_1 {
+                let values = self.frame_values(input, incoming_edge_1, sample)?;
+                if values.len() != incoming_dim_1 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v1_data.extend(values);
+            }
+            let v1 = Matrix::from_col_major_vec(incoming_dim_1, ids_1.len(), v1_data);
+
+            let mut v2_data = Vec::with_capacity(incoming_dim_2 * ids_2.len());
+            for &sample in &ids_2 {
+                let values = self.frame_values(input, incoming_edge_2, sample)?;
+                if values.len() != incoming_dim_2 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v2_data.extend(values);
+            }
+            let v2 = Matrix::from_col_major_vec(incoming_dim_2, ids_2.len(), v2_data);
+
+            let batched = two_incoming_core_matrix_batched(
+                core,
+                outgoing_axis,
+                incoming_axis_1,
+                incoming_axis_2,
+                base_offset,
+                outgoing_dim,
+                incoming_dim_1,
+                incoming_dim_2,
+                &v1,
+                &v2,
+            )?;
+
+            for &candidate_index in &indices {
+                let (_, sample_1) = candidates[candidate_index].incoming[0];
+                let (_, sample_2) = candidates[candidate_index].incoming[1];
+                let n1 = position_1[&sample_1];
+                let n2 = position_2[&sample_2];
+                let values: Vec<T> = (0..outgoing_dim)
+                    .map(|out| batched[[out + outgoing_dim * n1, n2]])
+                    .collect();
+                let entry_bytes = values.len().saturating_mul(size_of::<T>());
+                let candidate_bytes = self.candidate_cache_bytes.get();
+                let projected = self
+                    .retained_bytes
+                    .saturating_add(candidate_bytes)
+                    .saturating_add(entry_bytes);
+                if projected <= problem.max_frame_bytes {
+                    let candidate = &candidates[candidate_index];
+                    let key: CandidateCacheKey = (
+                        input,
+                        directed_edge,
+                        candidate.local_coordinate,
+                        candidate.incoming.clone(),
+                    );
+                    self.candidate_cache_bytes
+                        .set(candidate_bytes.saturating_add(entry_bytes));
+                    self.candidate_cache
+                        .borrow_mut()
+                        .insert(key, values.clone());
+                }
+                results[candidate_index] = Some(values);
+            }
+        }
+
+        results
+            .into_iter()
+            .map(|value| {
+                value.ok_or(TreeAciError::InternalInvariant {
+                    message: "two-incoming candidate frame batching left a candidate unfilled",
                 })
             })
             .collect()

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -1563,6 +1563,7 @@ fn contract_prepared_core_batched<T: TreeAciScalar>(
 /// `[outgoing_dim * n1_index, outgoing_dim * (n1_index + 1))`, holds the
 /// `outgoing_dim`-length frame vector [`contract_prepared_core`] would
 /// produce for the `(n1_index, n2)` candidate alone.
+#[allow(clippy::too_many_arguments)]
 fn two_incoming_core_matrix_batched<T: TreeAciScalar>(
     core: &PreparedCore<T>,
     outgoing_axis: usize,

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -1604,3 +1604,96 @@ fn extend_reuses_unchanged_edges_via_rc_instead_of_rebuilding_them() {
     assert_eq!(extended.records(), rebuilt.records());
     assert_eq!(extended.retained_bytes(), rebuilt.retained_bytes());
 }
+
+/// Reproduces #671's core question directly inside the crate: at a
+/// 2-incoming-edge branch point, how much faster is the batched path
+/// (`candidate_frames_for_edge`, since the two-incoming dispatch fix) than
+/// looping the scalar `candidate_frame` path per candidate (the code path
+/// every branch point used before this fix, and what 3+-incoming nodes
+/// still use today)? Not run by default (`#[ignore]`): it is a timing
+/// report, not a correctness gate. Run explicitly with
+/// `--ignored --nocapture`.
+#[test]
+#[ignore]
+fn branch_point_batched_speedup_vs_scalar_at_realistic_scale() {
+    use std::time::Instant;
+
+    let s0 = DynIndex::new_dyn(1);
+    let s1 = DynIndex::new_dyn(1);
+    let m = 40usize;
+    let d = 32usize;
+    let s2 = DynIndex::new_dyn(m);
+    let s3 = DynIndex::new_dyn(m);
+    let bond01 = DynIndex::new_dyn(4);
+    let bond02 = DynIndex::new_dyn(d);
+    let bond03 = DynIndex::new_dyn(d);
+    let node0 = IdxTensor::from_dense(
+        vec![s0, bond01.clone(), bond02.clone(), bond03.clone()],
+        (0..4 * d * d).map(|v| v as f64).collect(),
+    )
+    .unwrap();
+    let node1 =
+        IdxTensor::from_dense(vec![bond01, s1], (0..4).map(|v| v as f64).collect()).unwrap();
+    let node2 =
+        IdxTensor::from_dense(vec![bond02, s2], (0..d * m).map(|v| v as f64).collect()).unwrap();
+    let node3 =
+        IdxTensor::from_dense(vec![bond03, s3], (0..d * m).map(|v| v as f64).collect()).unwrap();
+    let star = TreeTN::from_tensors(vec![node0, node1, node2, node3], vec![0, 1, 2, 3]).unwrap();
+
+    let inputs = vec![star];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .unwrap();
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 2);
+
+    let seeds: Vec<Vec<usize>> = (0..m).map(|i| vec![0, 0, i, i]).collect();
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+
+    let incoming_a = directed.incoming_to_from[0];
+    let incoming_b = directed.incoming_to_from[1];
+    let ids_a = &candidate_sets.ids[incoming_a];
+    let ids_b = &candidate_sets.ids[incoming_b];
+    let mut candidates = Vec::new();
+    for &id_a in ids_a {
+        for &id_b in ids_b {
+            candidates.push(ComponentSample {
+                local_coordinate: 0,
+                incoming: vec![(incoming_a, id_a), (incoming_b, id_b)],
+            });
+        }
+    }
+
+    // Independent `InputFrameStore`s, each with its own fresh
+    // `candidate_cache`: sharing one store across both timed sections would
+    // let whichever path runs first populate the cache and make the second
+    // path measure cache hits instead of real computation.
+    let batched_frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+    let batched_start = Instant::now();
+    let batched = batched_frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .unwrap();
+    let batched_elapsed = batched_start.elapsed();
+
+    let scalar_frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+    let scalar_start = Instant::now();
+    let scalar: Vec<Vec<f64>> = candidates
+        .iter()
+        .map(|candidate| {
+            scalar_frames
+                .candidate_frame(&inputs, &problem, 0, edge, candidate)
+                .unwrap()
+        })
+        .collect();
+    let scalar_elapsed = scalar_start.elapsed();
+
+    assert_eq!(batched, scalar);
+    eprintln!(
+        "batched (two-incoming fix): {batched_elapsed:?}\nscalar (old fallback, still used for 3+ incoming): {scalar_elapsed:?}\nspeedup: {:.2}x",
+        scalar_elapsed.as_secs_f64() / batched_elapsed.as_secs_f64()
+    );
+}

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -1280,13 +1280,13 @@ fn compute_batch_falls_back_correctly_on_a_leaf_edge() {
 }
 
 /// `compute_batch` on a directed edge with two incoming edges (a branch
-/// point) must fall back to `compute` per sample and produce identical
-/// results, mirroring
+/// point) must batch via `compute_batch_two_incoming` and produce results
+/// identical to `compute` per sample, mirroring
 /// `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges`'s
 /// coverage of the analogous candidate-frame dispatcher. Reuses
 /// `star_tree_for_fallback_dispatch` rather than a new branch-point fixture.
 #[test]
-fn compute_batch_falls_back_correctly_on_a_branch_edge() {
+fn compute_batch_batches_a_branch_edge_with_two_incoming_edges() {
     let input = star_tree_for_fallback_dispatch();
     let problem =
         prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
@@ -1327,6 +1327,42 @@ fn compute_batch_falls_back_correctly_on_a_branch_edge() {
     // Sanity: this is a meaningful comparison, not a vacuous shape check --
     // the two samples' frames actually differ.
     assert_ne!(scalar_results[0], scalar_results[1]);
+}
+
+#[test]
+fn compute_batch_still_falls_back_on_three_incoming_edges() {
+    let input = four_arm_star_tree_for_three_incoming_fallback();
+    let problem =
+        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("4-arm star must have a directed edge 0 -> 1");
+    assert_eq!(problem.directed_edges[edge].incoming_to_from.len(), 3);
+
+    let seeds = vec![vec![0, 0, 0, 0, 0], vec![0, 0, 1, 1, 1]];
+    let (arena, _candidates) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+
+    let mut scalar_builder = build_frame_builder(&input, &problem, &arena);
+    let sample_count = arena.directed_record_count(edge).unwrap();
+    for sample in 0..sample_count {
+        scalar_builder.compute(edge, sample).unwrap();
+    }
+    let scalar_values: Vec<Vec<f64>> = (0..sample_count)
+        .map(|sample| scalar_builder.memo[edge][sample].clone().unwrap())
+        .collect();
+
+    let mut batched_builder = build_frame_builder(&input, &problem, &arena);
+    batched_builder
+        .compute_batch(edge, 0..sample_count)
+        .unwrap();
+    let batched_values: Vec<Vec<f64>> = (0..sample_count)
+        .map(|sample| batched_builder.memo[edge][sample].clone().unwrap())
+        .collect();
+
+    assert_eq!(batched_values, scalar_values);
 }
 
 /// `FrameBuilder::compute`'s memo-miss path must check `existing_frames`

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -603,6 +603,88 @@ fn star_tree_for_fallback_dispatch() -> TreeTN<IdxTensor, usize> {
 }
 
 #[test]
+fn two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair() {
+    let inputs = vec![star_tree_for_fallback_dispatch()];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+    let cores = super::prepare_cores::<f64, usize>(&inputs[0], &problem).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("star tree must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 2);
+    let incoming_edge_1 = directed.incoming_to_from[0];
+    let incoming_edge_2 = directed.incoming_to_from[1];
+
+    let node = *problem.node_positions.get(&directed.from).unwrap();
+    let core = &cores[node];
+    let outgoing = super::outgoing_bond(&inputs[0], &problem, edge).unwrap();
+    let outgoing_axis = super::axis_of(&core.indices, outgoing).unwrap();
+    let incoming_bond_1 = super::outgoing_bond(&inputs[0], &problem, incoming_edge_1).unwrap();
+    let incoming_bond_2 = super::outgoing_bond(&inputs[0], &problem, incoming_edge_2).unwrap();
+    let incoming_axis_1 = super::axis_of(&core.indices, incoming_bond_1).unwrap();
+    let incoming_axis_2 = super::axis_of(&core.indices, incoming_bond_2).unwrap();
+    let outgoing_dim = core.dims[outgoing_axis];
+    let incoming_dim_1 = core.dims[incoming_axis_1];
+    let incoming_dim_2 = core.dims[incoming_axis_2];
+
+    // Two arbitrary, non-trivial frame vectors per incoming edge (n1=2, n2=2)
+    // so the test exercises real cross-combination behavior, not a
+    // degenerate 1-candidate case.
+    let v1_cols = [vec![1.0, 0.5], vec![0.25, 2.0]];
+    let v2_cols = [vec![3.0, -1.0], vec![0.1, 4.0]];
+    let mut v1_data = Vec::new();
+    for col in &v1_cols {
+        v1_data.extend(col.iter().copied());
+    }
+    let v1 = tensor4all_tensorbackend::Matrix::from_col_major_vec(incoming_dim_1, 2, v1_data);
+    let mut v2_data = Vec::new();
+    for col in &v2_cols {
+        v2_data.extend(col.iter().copied());
+    }
+    let v2 = tensor4all_tensorbackend::Matrix::from_col_major_vec(incoming_dim_2, 2, v2_data);
+
+    let batched = super::two_incoming_core_matrix_batched(
+        core,
+        outgoing_axis,
+        incoming_axis_1,
+        incoming_axis_2,
+        0,
+        outgoing_dim,
+        incoming_dim_1,
+        incoming_dim_2,
+        &v1,
+        &v2,
+    )
+    .unwrap();
+
+    for (n1, v1_vec) in v1_cols.iter().enumerate() {
+        for (n2, v2_vec) in v2_cols.iter().enumerate() {
+            let incoming_frames = vec![
+                (incoming_edge_1, v1_vec.clone()),
+                (incoming_edge_2, v2_vec.clone()),
+            ];
+            let expected = super::contract_prepared_core(
+                &inputs[0],
+                &problem,
+                &cores,
+                edge,
+                0,
+                &incoming_frames,
+            )
+            .unwrap();
+            let actual: Vec<f64> = (0..outgoing_dim)
+                .map(|out| batched[[out + outgoing_dim * n1, n2]])
+                .collect();
+            assert_eq!(actual, expected, "mismatch at (n1={n1}, n2={n2})");
+        }
+    }
+}
+
+#[test]
 fn candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -573,14 +573,13 @@ fn batched_path_matches_scalar_path_on_random_core() {
 
 /// Builds a 4-node star `1 -- 0 -- 2`, `0 -- 3`, whose center (node `0`) has
 /// three neighbors. Directed edge `1 -> 0` has zero incoming edges (node `1`
-/// is a leaf), and directed edge `0 -> 1` has two incoming edges (`2 -> 0`
-/// and `3 -> 0`, node `0`'s other two neighbors) -- the two shapes of
-/// `InputFrameStore::candidate_frames_for_edge`'s fallback branch, which
-/// dispatches away from the batched BLAS path whenever a directed edge's
-/// source does not have exactly one incoming edge. See
+/// is a leaf) -- `InputFrameStore::candidate_frames_for_edge`'s scalar
+/// fallback branch -- and directed edge `0 -> 1` has two incoming edges
+/// (`2 -> 0` and `3 -> 0`, node `0`'s other two neighbors) -- its batched
+/// two-incoming-edge branch. See
 /// `candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges`
 /// and
-/// `candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges`.
+/// `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges`.
 fn star_tree_for_fallback_dispatch() -> TreeTN<IdxTensor, usize> {
     let s0 = DynIndex::new_dyn(2);
     let s1 = DynIndex::new_dyn(2);
@@ -733,7 +732,7 @@ fn candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges(
 }
 
 #[test]
-fn candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges() {
+fn candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();
     let problem = prepare_problem(&inputs, &options).unwrap();
@@ -790,6 +789,89 @@ fn candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges
     // Sanity: candidates are not all identical, so this exercises real,
     // differing per-candidate contractions rather than a degenerate case.
     assert!(dispatched.iter().any(|frame| frame != &dispatched[0]));
+}
+
+/// 4-arm star: hub node 0 with three leaves plus a fourth arm, so directed
+/// edge `0 -> 1` has exactly three incoming edges (`2 -> 0`, `3 -> 0`,
+/// `4 -> 0`). Used to pin that 3+-incoming-edge dispatch still uses the
+/// scalar fallback once the two-incoming case gets a batched path.
+fn four_arm_star_tree_for_three_incoming_fallback() -> TreeTN<IdxTensor, usize> {
+    let s0 = DynIndex::new_dyn(1);
+    let s1 = DynIndex::new_dyn(1);
+    let s2 = DynIndex::new_dyn(2);
+    let s3 = DynIndex::new_dyn(2);
+    let s4 = DynIndex::new_dyn(2);
+    let bond01 = DynIndex::new_dyn(2);
+    let bond02 = DynIndex::new_dyn(2);
+    let bond03 = DynIndex::new_dyn(2);
+    let bond04 = DynIndex::new_dyn(2);
+
+    let node0 = IdxTensor::from_dense(
+        vec![
+            s0,
+            bond01.clone(),
+            bond02.clone(),
+            bond03.clone(),
+            bond04.clone(),
+        ],
+        (1..=16).map(|value| value as f64).collect(),
+    )
+    .unwrap();
+    let node1 = IdxTensor::from_dense(vec![bond01, s1], vec![1.0, 2.0]).unwrap();
+    let node2 = IdxTensor::from_dense(vec![bond02, s2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let node3 = IdxTensor::from_dense(vec![bond03, s3], vec![5.0, 6.0, 7.0, 8.0]).unwrap();
+    let node4 = IdxTensor::from_dense(vec![bond04, s4], vec![9.0, 10.0, 11.0, 12.0]).unwrap();
+
+    TreeTN::from_tensors(vec![node0, node1, node2, node3, node4], vec![0, 1, 2, 3, 4]).unwrap()
+}
+
+#[test]
+fn candidate_frames_for_edge_still_falls_back_on_three_incoming_edges() {
+    let inputs = vec![four_arm_star_tree_for_three_incoming_fallback()];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("4-arm star must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 3);
+
+    let seeds = vec![vec![0, 0, 0, 0, 0], vec![0, 0, 1, 1, 1]];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+
+    let mut candidates = Vec::new();
+    let incoming: Vec<_> = directed.incoming_to_from.clone();
+    for &id_a in &candidate_sets.ids[incoming[0]] {
+        for &id_b in &candidate_sets.ids[incoming[1]] {
+            for &id_c in &candidate_sets.ids[incoming[2]] {
+                candidates.push(ComponentSample {
+                    local_coordinate: 0,
+                    incoming: vec![
+                        (incoming[0], id_a),
+                        (incoming[1], id_b),
+                        (incoming[2], id_c),
+                    ],
+                });
+            }
+        }
+    }
+
+    let dispatched = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .unwrap();
+    let scalar = candidates
+        .iter()
+        .map(|candidate| {
+            frames
+                .candidate_frame(&inputs, &problem, 0, edge, candidate)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(dispatched, scalar);
 }
 
 /// Builds a `FrameBuilder` the same way `InputFrameStore::build_or_extend`
@@ -1200,7 +1282,7 @@ fn compute_batch_falls_back_correctly_on_a_leaf_edge() {
 /// `compute_batch` on a directed edge with two incoming edges (a branch
 /// point) must fall back to `compute` per sample and produce identical
 /// results, mirroring
-/// `candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges`'s
+/// `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges`'s
 /// coverage of the analogous candidate-frame dispatcher. Reuses
 /// `star_tree_for_fallback_dispatch` rather than a new branch-point fixture.
 #[test]

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -68,6 +68,26 @@ struct ChainContractionSpec {
     child_dim: usize,
 }
 
+/// Minimum scalar multiply count / group size before the backend setup cost
+/// is amortized by the grouped branch kernel, mirroring
+/// `CHAIN_BLAS_WORK_THRESHOLD` / `CHAIN_BLAS_MIN_GROUP_POINTS` but tuned
+/// independently: a branch step does two contractions per group instead of
+/// one, so its fixed per-call setup cost differs from the chain kernel's.
+const BRANCH_BLAS_WORK_THRESHOLD: usize = 4096;
+const BRANCH_BLAS_MIN_GROUP_POINTS: usize = 4;
+
+#[derive(Clone, Copy, Debug)]
+struct BranchContractionSpec {
+    strides: [usize; 4],
+    physical_axis: usize,
+    parent_axis: usize,
+    child_axis_1: usize,
+    child_axis_2: usize,
+    parent_dim: usize,
+    child_dim_1: usize,
+    child_dim_2: usize,
+}
+
 #[derive(Clone, Debug)]
 struct SiteEntry {
     index: DynIndex,
@@ -1529,6 +1549,154 @@ where
         Ok(output)
     }
 
+    /// Contracts a branch node's raw tensor data against two children's
+    /// already-computed raw message columns, generalizing
+    /// [`Self::grouped_chain_message_contraction`] from one child to two.
+    ///
+    /// Unlike the cartesian-product batching in `tensor4all-treeaci/frames.rs`'s
+    /// analogous fix (`two_incoming_core_matrix_batched`), this evaluator's
+    /// `points` are independent per-point assignments -- point `p` names one
+    /// specific `(child1_assignment, child2_assignment)` pair, not every
+    /// combination -- so only the first child's contraction reduces to a
+    /// single shared-matrix `mat_mul_owned` call per physical-value group
+    /// (the node's raw tensor slice at that physical value is the same for
+    /// every point in the group, so all of the group's child-1 columns can
+    /// be batched against it in one matmul). The second child's contraction
+    /// cannot share a single matrix across points this way -- the
+    /// intermediate from step one already differs per point -- so it is
+    /// folded in via a vectorized accumulate loop over `child_dim_2`
+    /// instead: still allocation-free, per-element-function-call-free array
+    /// arithmetic, just not a single BLAS call.
+    fn grouped_branch_message_contraction<T>(
+        spec: BranchContractionSpec,
+        raw: &[T],
+        physical_values: &[usize],
+        child1_columns: &[T],
+        child2_columns: &[T],
+    ) -> Result<Vec<T>>
+    where
+        T: BlasMul + Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+    {
+        let BranchContractionSpec {
+            strides,
+            physical_axis,
+            parent_axis,
+            child_axis_1,
+            child_axis_2,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        } = spec;
+        let point_count = physical_values.len();
+        anyhow::ensure!(
+            child1_columns.len() == point_count * child_dim_1,
+            "branch child-1 message length {} does not match {} points x {} child values",
+            child1_columns.len(),
+            point_count,
+            child_dim_1
+        );
+        anyhow::ensure!(
+            child2_columns.len() == point_count * child_dim_2,
+            "branch child-2 message length {} does not match {} points x {} child values",
+            child2_columns.len(),
+            point_count,
+            child_dim_2
+        );
+
+        if point_count < 2 * BRANCH_BLAS_MIN_GROUP_POINTS {
+            return scalar_branch_message_contraction(
+                spec,
+                raw,
+                physical_values,
+                child1_columns,
+                child2_columns,
+            );
+        }
+
+        let mut groups = HashMap::<usize, Vec<usize>>::new();
+        for (point, &physical_value) in physical_values.iter().enumerate() {
+            groups.entry(physical_value).or_default().push(point);
+        }
+        let scalar_work = parent_dim * child_dim_1 * child_dim_2 * point_count;
+        if scalar_work < BRANCH_BLAS_WORK_THRESHOLD
+            || groups.len() > 8
+            || groups
+                .values()
+                .any(|points| points.len() < BRANCH_BLAS_MIN_GROUP_POINTS)
+        {
+            return scalar_branch_message_contraction(
+                spec,
+                raw,
+                physical_values,
+                child1_columns,
+                child2_columns,
+            );
+        }
+
+        let mut output = vec![T::default(); point_count * parent_dim];
+        for (physical_value, points) in groups {
+            // Step A: fold in child 1 via one matmul for the whole group.
+            // `left` is (parent_dim*child_dim_2) x child_dim_1, laid out so
+            // child_dim_1 is the trailing (column) axis -- child2 rides
+            // along in "rows", ordered slower than parent so a fixed c2
+            // selects a contiguous parent_dim-length row block within each
+            // column below.
+            let left_len = parent_dim * child_dim_2 * child_dim_1;
+            let mut left = vec![T::default(); left_len];
+            for c1 in 0..child_dim_1 {
+                for c2 in 0..child_dim_2 {
+                    for parent in 0..parent_dim {
+                        let mut axis_values = [0usize; 4];
+                        axis_values[physical_axis] = physical_value;
+                        axis_values[parent_axis] = parent;
+                        axis_values[child_axis_1] = c1;
+                        axis_values[child_axis_2] = c2;
+                        let flat = axis_values[0] * strides[0]
+                            + axis_values[1] * strides[1]
+                            + axis_values[2] * strides[2]
+                            + axis_values[3] * strides[3];
+                        let left_row = parent + parent_dim * c2;
+                        let left_offset = left_row + parent_dim * child_dim_2 * c1;
+                        left[left_offset] = *raw.get(flat).ok_or_else(|| {
+                            anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                        })?;
+                    }
+                }
+            }
+            let mut right = Vec::with_capacity(child_dim_1 * points.len());
+            for &point in &points {
+                let start = point * child_dim_1;
+                right.extend_from_slice(&child1_columns[start..start + child_dim_1]);
+            }
+            let intermediate = mat_mul_owned(
+                Matrix::from_col_major_vec(parent_dim * child_dim_2, child_dim_1, left),
+                Matrix::from_col_major_vec(child_dim_1, points.len(), right),
+            )
+            .map_err(anyhow::Error::from)?;
+            let intermediate = intermediate.as_col_major_slice();
+
+            // Step B: fold in child 2 via a vectorized accumulate over
+            // child_dim_2 -- the intermediate's "rows" already interleave
+            // parent (fast) and c2 (slow) per group column, so for a fixed
+            // c2 the parent_dim-length slice at rows
+            // [c2*parent_dim, (c2+1)*parent_dim) within each group-column is
+            // contiguous.
+            for (column, &point) in points.iter().enumerate() {
+                let column_base = column * parent_dim * child_dim_2;
+                let destination = point * parent_dim;
+                for c2 in 0..child_dim_2 {
+                    let child2_value = child2_columns[point * child_dim_2 + c2];
+                    let row_base = column_base + c2 * parent_dim;
+                    for parent in 0..parent_dim {
+                        output[destination + parent] +=
+                            intermediate[row_base + parent] * child2_value;
+                    }
+                }
+            }
+        }
+        Ok(output)
+    }
+
     /// Computes an interior chain node's (exactly one child) message directly
     /// from raw data, generalizing [`Self::try_compute_leaf_message_raw`] the
     /// way `row_vector_times_matrix`
@@ -2706,6 +2874,56 @@ where
     Ok(output)
 }
 
+fn scalar_branch_message_contraction<T>(
+    spec: BranchContractionSpec,
+    raw: &[T],
+    physical_values: &[usize],
+    child1_columns: &[T],
+    child2_columns: &[T],
+) -> Result<Vec<T>>
+where
+    T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let BranchContractionSpec {
+        strides,
+        physical_axis,
+        parent_axis,
+        child_axis_1,
+        child_axis_2,
+        parent_dim,
+        child_dim_1,
+        child_dim_2,
+    } = spec;
+    let point_count = physical_values.len();
+    let mut output = vec![T::default(); point_count * parent_dim];
+    for (point, &physical_value) in physical_values.iter().enumerate() {
+        for parent in 0..parent_dim {
+            let mut sum = T::default();
+            for c1 in 0..child_dim_1 {
+                let child1_value = child1_columns[point * child_dim_1 + c1];
+                for c2 in 0..child_dim_2 {
+                    let child2_value = child2_columns[point * child_dim_2 + c2];
+                    let mut axis_values = [0usize; 4];
+                    axis_values[physical_axis] = physical_value;
+                    axis_values[parent_axis] = parent;
+                    axis_values[child_axis_1] = c1;
+                    axis_values[child_axis_2] = c2;
+                    let flat = axis_values[0] * strides[0]
+                        + axis_values[1] * strides[1]
+                        + axis_values[2] * strides[2]
+                        + axis_values[3] * strides[3];
+                    sum += *raw.get(flat).ok_or_else(|| {
+                        anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                    })? * child1_value
+                        * child2_value;
+                }
+            }
+            output[point * parent_dim + parent] = sum;
+        }
+    }
+    Ok(output)
+}
+
 fn build_layout<V>(tree: &TreeTN<IdxTensor, V>, indices: &[DynIndex]) -> Result<EvaluatorLayout<V>>
 where
     V: Clone + Eq + Hash + Ord + Debug + Send + Sync,
@@ -3503,6 +3721,53 @@ mod tests {
     }
 
     #[test]
+    fn grouped_branch_contraction_matches_direct_reference_for_real_values() {
+        // 2x2x2x2 tensor (physical=2, parent=2, child1=2, child2=2), axis
+        // order [physical, parent, child1, child2] so strides = [1, 2, 4, 8].
+        let raw: Vec<f64> = (0..16).map(|v| v as f64 + 1.0).collect();
+        let spec = BranchContractionSpec {
+            strides: [1, 2, 4, 8],
+            physical_axis: 0,
+            parent_axis: 1,
+            child_axis_1: 2,
+            child_axis_2: 3,
+            parent_dim: 2,
+            child_dim_1: 2,
+            child_dim_2: 2,
+        };
+        // 3 points (below the BLAS-group threshold, so this always exercises
+        // scalar_branch_message_contraction): point 0 at physical=0, points
+        // 1-2 at physical=1.
+        let physical_values = [0usize, 1, 1];
+        let child1_columns = [1.0, 0.5, 2.0, 1.0, 0.25, 3.0];
+        let child2_columns = [1.0, 1.0, 0.5, 2.0, 1.5, 0.5];
+
+        let actual = TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+
+        let mut expected = vec![0.0f64; 3 * 2];
+        for (p, &v) in physical_values.iter().enumerate() {
+            for parent in 0..2 {
+                let mut sum = 0.0;
+                for c1 in 0..2 {
+                    for c2 in 0..2 {
+                        let flat = v + 2 * parent + 4 * c1 + 8 * c2;
+                        sum += raw[flat] * child1_columns[p * 2 + c1] * child2_columns[p * 2 + c2];
+                    }
+                }
+                expected[p * 2 + parent] = sum;
+            }
+        }
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn grouped_chain_contraction_large_real_groups_match_scalar_reference() {
         let parent_dim = 64;
         let child_dim = 64;
@@ -3572,6 +3837,106 @@ mod tests {
             .iter()
             .zip(expected)
             .all(|(actual, expected)| (*actual - expected).norm() < 1.0e-8));
+    }
+
+    #[test]
+    fn grouped_branch_contraction_large_real_groups_match_scalar_reference() {
+        let parent_dim = 8;
+        let child_dim_1 = 8;
+        let child_dim_2 = 8;
+        let point_count = 16;
+        let spec = BranchContractionSpec {
+            strides: [1, 2, 2 * parent_dim, 2 * parent_dim * child_dim_1],
+            physical_axis: 0,
+            parent_axis: 1,
+            child_axis_1: 2,
+            child_axis_2: 3,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw: Vec<f64> = (0..2 * parent_dim * child_dim_1 * child_dim_2)
+            .map(|value| (value % 19) as f64 - 9.0)
+            .collect();
+        let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();
+        let child1_columns: Vec<f64> = (0..point_count * child_dim_1)
+            .map(|value| (value % 13) as f64 - 6.0)
+            .collect();
+        let child2_columns: Vec<f64> = (0..point_count * child_dim_2)
+            .map(|value| (value % 11) as f64 - 5.0)
+            .collect();
+
+        let actual = TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+        let expected = scalar_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+
+        assert!(actual
+            .iter()
+            .zip(expected)
+            .all(|(actual, expected)| (actual - expected).abs() < 1.0e-6));
+    }
+
+    #[test]
+    fn grouped_branch_contraction_large_complex_groups_match_scalar_reference() {
+        let parent_dim = 8;
+        let child_dim_1 = 8;
+        let child_dim_2 = 8;
+        let point_count = 16;
+        let spec = BranchContractionSpec {
+            strides: [1, 2, 2 * parent_dim, 2 * parent_dim * child_dim_1],
+            physical_axis: 0,
+            parent_axis: 1,
+            child_axis_1: 2,
+            child_axis_2: 3,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw: Vec<Complex64> = (0..2 * parent_dim * child_dim_1 * child_dim_2)
+            .map(|value| Complex64::new((value % 19) as f64 - 9.0, (value % 11) as f64 - 5.0))
+            .collect();
+        let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();
+        let child1_columns: Vec<Complex64> = (0..point_count * child_dim_1)
+            .map(|value| Complex64::new((value % 13) as f64 - 6.0, (value % 7) as f64 - 3.0))
+            .collect();
+        let child2_columns: Vec<Complex64> = (0..point_count * child_dim_2)
+            .map(|value| Complex64::new((value % 9) as f64 - 4.0, (value % 5) as f64 - 2.0))
+            .collect();
+
+        let actual = TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+        let expected = scalar_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+
+        assert!(actual
+            .iter()
+            .zip(expected)
+            .all(|(actual, expected)| (*actual - expected).norm() < 1.0e-6));
     }
 
     fn scalar_grouped_chain_reference<
@@ -4783,5 +5148,190 @@ mod tests {
             total as f64 / 1e6,
         );
         assert!(total > 0);
+    }
+
+    // TEMPORARY diagnostic for gw-rs issue tensor4all-rs#671's downstream
+    // follow-up -- not a regression test, revert after root-cause
+    // confirmation. Compares this evaluator's realistic floating-zone-walk
+    // wall time on a plain 16-site chain against a same-size comb tree (one
+    // degree-3 hub, three 5-site arms), both under the SAME cached
+    // evaluate_batched path used by `message_cache_wall_time_on_realistic_floating_zone_walk`
+    // above. Isolates whether `compute_stacked_message`'s generic multi-child
+    // fallback (hit only by the hub node, since `try_compute_chain_message_raw`
+    // requires exactly one child) is a meaningful wall-time cost at this
+    // evaluator's actual small-batch call pattern, independent of whether the
+    // frames.rs fix (tensor4all-treeaci) helped.
+    #[test]
+    #[ignore]
+    fn diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk() {
+        use rand::{Rng, SeedableRng};
+        use rand_chacha::ChaCha8Rng;
+        use std::time::Instant;
+        use tensor4all_core::floating_zone_walk;
+        use tensor4all_simplett::{tensor3_zeros, SimpleTensorTrain, Tensor3, Tensor3Ops};
+
+        const N_SITES: usize = 16;
+        const LOCAL_DIM: usize = 2;
+        const BOND_DIM: usize = 128;
+        const NSEARCH: usize = 5;
+        const MAX_SWEEPS: usize = 100;
+        const ARM_LEN: usize = 5; // hub + 3*5 = 16 sites, matching N_SITES
+
+        fn build_chain(seed: u64) -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut tensors: Vec<Tensor3<f64>> = Vec::with_capacity(N_SITES);
+            for site in 0..N_SITES {
+                let left_dim = if site == 0 { 1 } else { BOND_DIM };
+                let right_dim = if site == N_SITES - 1 { 1 } else { BOND_DIM };
+                let mut tensor = tensor3_zeros(left_dim, LOCAL_DIM, right_dim);
+                for l in 0..left_dim {
+                    for s in 0..LOCAL_DIM {
+                        for r in 0..right_dim {
+                            tensor.set3(l, s, r, rng.random::<f64>());
+                        }
+                    }
+                }
+                tensors.push(tensor);
+            }
+            let tt = SimpleTensorTrain::new(tensors).unwrap();
+            crate::tensor_train_to_treetn(&tt).unwrap()
+        }
+
+        // Hub (node 0) + three arms of ARM_LEN sites each: arm a's sites are
+        // named `1 + a*ARM_LEN ..= a*ARM_LEN + ARM_LEN`. Center is fixed to
+        // the tip of arm 0, so the hub (rooted toward that tip) has exactly
+        // one parent (arm 0's first site) and two children (arms 1 and 2's
+        // first sites) -- the one node in this tree that cannot use
+        // `try_compute_chain_message_raw`'s single-child fast path.
+        fn build_comb(seed: u64) -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>, usize) {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut gen = |n: usize| -> Vec<f64> { (0..n).map(|_| rng.random::<f64>()).collect() };
+
+            let s_hub = DynIndex::new_dyn(LOCAL_DIM);
+            let hub_bonds: Vec<DynIndex> = (0..3).map(|_| DynIndex::new_dyn(BOND_DIM)).collect();
+            let hub = IdxTensor::from_dense(
+                std::iter::once(s_hub.clone())
+                    .chain(hub_bonds.iter().cloned())
+                    .collect(),
+                gen(LOCAL_DIM * BOND_DIM * BOND_DIM * BOND_DIM),
+            )
+            .unwrap();
+
+            let mut tensors = vec![hub];
+            let mut node_labels = vec![0usize];
+            let mut indices = vec![s_hub];
+            let mut next_node = 1usize;
+            let mut center = 0usize;
+
+            for arm in 0..3 {
+                let mut prev_bond = hub_bonds[arm].clone();
+                for depth in 0..ARM_LEN {
+                    let s = DynIndex::new_dyn(LOCAL_DIM);
+                    let is_tip = depth == ARM_LEN - 1;
+                    let tensor = if is_tip {
+                        IdxTensor::from_dense(
+                            vec![prev_bond.clone(), s.clone()],
+                            gen(BOND_DIM * LOCAL_DIM),
+                        )
+                        .unwrap()
+                    } else {
+                        let next_bond = DynIndex::new_dyn(BOND_DIM);
+                        let tensor = IdxTensor::from_dense(
+                            vec![prev_bond.clone(), s.clone(), next_bond.clone()],
+                            gen(BOND_DIM * LOCAL_DIM * BOND_DIM),
+                        )
+                        .unwrap();
+                        prev_bond = next_bond;
+                        tensor
+                    };
+                    tensors.push(tensor);
+                    node_labels.push(next_node);
+                    indices.push(s);
+                    if arm == 0 && is_tip {
+                        center = next_node;
+                    }
+                    next_node += 1;
+                }
+            }
+
+            let tree = TreeTN::<_, usize>::from_tensors(tensors, node_labels).unwrap();
+            (tree, indices, center)
+        }
+
+        fn starts(n_sites: usize) -> Vec<Vec<usize>> {
+            let mut rng = ChaCha8Rng::seed_from_u64(11);
+            (0..NSEARCH)
+                .map(|_| {
+                    (0..n_sites)
+                        .map(|_| rng.random_range(0..LOCAL_DIM))
+                        .collect()
+                })
+                .collect()
+        }
+        let site_dims = vec![LOCAL_DIM; N_SITES];
+
+        fn timed_walk(
+            mut evaluator: TreeTNCachedEvaluator<'_, usize>,
+            n_sites: usize,
+        ) -> std::time::Duration {
+            let warm_values = vec![0usize; n_sites];
+            let warm_shape = [n_sites, 1];
+            let warm_points = ColMajorArrayRef::new(&warm_values, &warm_shape).unwrap();
+            evaluator.evaluate_batched(warm_points).unwrap();
+            let start_time = Instant::now();
+            for start in &starts(n_sites) {
+                floating_zone_walk(
+                    &vec![LOCAL_DIM; n_sites],
+                    start,
+                    MAX_SWEEPS,
+                    f64::INFINITY,
+                    |points: &[Vec<usize>]| -> Result<Vec<f64>> {
+                        let mut values = vec![0usize; n_sites * points.len()];
+                        for (p, point) in points.iter().enumerate() {
+                            for (site, &v) in point.iter().enumerate() {
+                                values[site + n_sites * p] = v;
+                            }
+                        }
+                        let shape = [n_sites, points.len()];
+                        let arr = ColMajorArrayRef::new(&values, &shape).unwrap();
+                        let out = evaluator.evaluate_batched(arr)?;
+                        Ok(out.iter().map(|v| v.real().abs()).collect())
+                    },
+                )
+                .unwrap();
+            }
+            start_time.elapsed()
+        }
+
+        let (chain_tree, chain_indices) = build_chain(7);
+        let chain_evaluator = TreeTNCachedEvaluator::new(
+            &chain_tree,
+            &chain_indices,
+            CachedEvaluatorOptions::default(),
+        )
+        .unwrap();
+        let chain_elapsed = timed_walk(chain_evaluator, N_SITES);
+        let _ = &site_dims;
+
+        let (comb_tree, comb_indices, comb_center) = build_comb(7);
+        let comb_evaluator = TreeTNCachedEvaluator::new(
+            &comb_tree,
+            &comb_indices,
+            CachedEvaluatorOptions {
+                center: Some(comb_center),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let comb_elapsed = timed_walk(comb_evaluator, N_SITES);
+
+        println!(
+            "chain (N={N_SITES}, bond={BOND_DIM}): {chain_elapsed:?}\n\
+             comb  (N={N_SITES}, bond={BOND_DIM}, 1 hub): {comb_elapsed:?}\n\
+             ratio (comb/chain): {:.2}x",
+            comb_elapsed.as_secs_f64() / chain_elapsed.as_secs_f64()
+        );
+        assert!(chain_elapsed.as_nanos() > 0);
+        assert!(comb_elapsed.as_nanos() > 0);
     }
 }

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -1997,6 +1997,433 @@ where
         Ok(Some(result))
     }
 
+    /// Computes a branch node's (exactly two children) message directly from
+    /// raw data, generalizing [`Self::try_compute_chain_message_raw`] from
+    /// one child to two via [`Self::grouped_branch_message_contraction`].
+    ///
+    /// Returns `Ok(None)` when `node` is not eligible (not exactly one
+    /// physical index and exactly two children, a complex-valued tensor, or
+    /// an unexpected axis count), so the caller falls back to
+    /// [`Self::compute_stacked_message`].
+    fn try_compute_branch_message_raw(
+        &self,
+        node: &V,
+        values: ColMajorArrayRef<'_, usize>,
+        points: &[usize],
+        plan: &RootedMessagePlan<V>,
+        assignment_batches: &HashMap<V, AssignmentBatch>,
+        messages: &HashMap<V, StackedMessage>,
+    ) -> Result<Option<Vec<f64>>> {
+        let entries = self
+            .layout
+            .entries_by_node
+            .get(node)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let [entry] = entries else {
+            return Ok(None);
+        };
+        let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+        let [child_1, child_2] = children else {
+            return Ok(None);
+        };
+
+        let tensor = tensor_for_node(self.tree, node)?;
+        if tensor.is_complex() {
+            return Ok(None);
+        }
+        let tensor_indices = tensor.indices();
+        if tensor_indices.len() != 4 {
+            return Ok(None);
+        }
+        let Some(physical_axis) = tensor_indices.iter().position(|idx| idx == &entry.index) else {
+            return Ok(None);
+        };
+        let Some(child_1_edge) = self.tree.edge_between(node, child_1) else {
+            return Ok(None);
+        };
+        let Some(child_1_bond_index) = self.tree.bond_index(child_1_edge) else {
+            return Ok(None);
+        };
+        let Some(child_axis_1) = tensor_indices
+            .iter()
+            .position(|idx| idx == child_1_bond_index)
+        else {
+            return Ok(None);
+        };
+        let Some(child_2_edge) = self.tree.edge_between(node, child_2) else {
+            return Ok(None);
+        };
+        let Some(child_2_bond_index) = self.tree.bond_index(child_2_edge) else {
+            return Ok(None);
+        };
+        let Some(child_axis_2) = tensor_indices
+            .iter()
+            .position(|idx| idx == child_2_bond_index)
+        else {
+            return Ok(None);
+        };
+        let Some(parent_axis) = (0..4)
+            .find(|&axis| axis != physical_axis && axis != child_axis_1 && axis != child_axis_2)
+        else {
+            return Ok(None);
+        };
+
+        let child_1_message = messages.get(child_1).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing message for child {:?}",
+                child_1
+            )
+        })?;
+        let child_1_values = if let Some(raw_values) = &child_1_message.raw_values {
+            let mut values = Vec::with_capacity(raw_values.len());
+            for value in raw_values {
+                let CachedScalar::Real(value) = value else {
+                    return Ok(None);
+                };
+                values.push(*value);
+            }
+            values
+        } else {
+            let Some(tensor) = child_1_message.tensor.as_ref() else {
+                return Ok(None);
+            };
+            if tensor.is_complex() {
+                return Ok(None);
+            }
+            tensor.to_vec::<f64>()?
+        };
+        let child_2_message = messages.get(child_2).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing message for child {:?}",
+                child_2
+            )
+        })?;
+        let child_2_values = if let Some(raw_values) = &child_2_message.raw_values {
+            let mut values = Vec::with_capacity(raw_values.len());
+            for value in raw_values {
+                let CachedScalar::Real(value) = value else {
+                    return Ok(None);
+                };
+                values.push(*value);
+            }
+            values
+        } else {
+            let Some(tensor) = child_2_message.tensor.as_ref() else {
+                return Ok(None);
+            };
+            if tensor.is_complex() {
+                return Ok(None);
+            }
+            tensor.to_vec::<f64>()?
+        };
+
+        let child_1_assignment_batch = assignment_batches.get(child_1).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing assignment batch for child {:?}",
+                child_1
+            )
+        })?;
+        let child_2_assignment_batch = assignment_batches.get(child_2).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing assignment batch for child {:?}",
+                child_2
+            )
+        })?;
+
+        let dims = tensor.dims();
+        let parent_dim = dims[parent_axis];
+        let child_dim_1 = dims[child_axis_1];
+        let child_dim_2 = dims[child_axis_2];
+        let strides = [
+            1usize,
+            dims[0],
+            dims[0]
+                .checked_mul(dims[1])
+                .ok_or_else(|| anyhow::anyhow!("branch tensor strides overflow usize"))?,
+            dims[0]
+                .checked_mul(dims[1])
+                .and_then(|value| value.checked_mul(dims[2]))
+                .ok_or_else(|| anyhow::anyhow!("branch tensor strides overflow usize"))?,
+        ];
+        let spec = BranchContractionSpec {
+            strides,
+            physical_axis,
+            parent_axis,
+            child_axis_1,
+            child_axis_2,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw = tensor.to_vec::<f64>()?;
+
+        let mut physical_values = Vec::with_capacity(points.len());
+        let mut child_1_columns = Vec::with_capacity(child_dim_1 * points.len());
+        let mut child_2_columns = Vec::with_capacity(child_dim_2 * points.len());
+        for &point in points {
+            let physical_value = value_at(
+                values,
+                entry.input_position,
+                point,
+                "TreeTNCachedEvaluator::try_compute_branch_message_raw",
+            )?;
+            physical_values.push(physical_value);
+
+            let child_1_assignment = child_1_assignment_batch
+                .point_to_assignment
+                .get(point)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("missing child-1 assignment for point {point}"))?;
+            let start_1 = child_1_assignment.checked_mul(child_dim_1).ok_or_else(|| {
+                anyhow::anyhow!("branch child-1 assignment offset overflows usize")
+            })?;
+            let end_1 = start_1
+                .checked_add(child_dim_1)
+                .ok_or_else(|| anyhow::anyhow!("branch child-1 assignment end overflows usize"))?;
+            child_1_columns.extend_from_slice(
+                child_1_values
+                    .get(start_1..end_1)
+                    .ok_or_else(|| anyhow::anyhow!("branch child-1 assignment is out of bounds"))?,
+            );
+
+            let child_2_assignment = child_2_assignment_batch
+                .point_to_assignment
+                .get(point)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("missing child-2 assignment for point {point}"))?;
+            let start_2 = child_2_assignment.checked_mul(child_dim_2).ok_or_else(|| {
+                anyhow::anyhow!("branch child-2 assignment offset overflows usize")
+            })?;
+            let end_2 = start_2
+                .checked_add(child_dim_2)
+                .ok_or_else(|| anyhow::anyhow!("branch child-2 assignment end overflows usize"))?;
+            child_2_columns.extend_from_slice(
+                child_2_values
+                    .get(start_2..end_2)
+                    .ok_or_else(|| anyhow::anyhow!("branch child-2 assignment is out of bounds"))?,
+            );
+        }
+        let result = Self::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child_1_columns,
+            &child_2_columns,
+        )?;
+        Ok(Some(result))
+    }
+
+    /// Complex-valued counterpart of [`Self::try_compute_branch_message_raw`].
+    fn try_compute_branch_message_complex_raw(
+        &self,
+        node: &V,
+        values: ColMajorArrayRef<'_, usize>,
+        points: &[usize],
+        plan: &RootedMessagePlan<V>,
+        assignment_batches: &HashMap<V, AssignmentBatch>,
+        messages: &HashMap<V, StackedMessage>,
+    ) -> Result<Option<Vec<Complex64>>> {
+        let entries = self
+            .layout
+            .entries_by_node
+            .get(node)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
+        let [entry] = entries else {
+            return Ok(None);
+        };
+        let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+        let [child_1, child_2] = children else {
+            return Ok(None);
+        };
+
+        let tensor = tensor_for_node(self.tree, node)?;
+        if !tensor.is_complex() {
+            return Ok(None);
+        }
+        let tensor_indices = tensor.indices();
+        if tensor_indices.len() != 4 {
+            return Ok(None);
+        }
+        let Some(physical_axis) = tensor_indices.iter().position(|idx| idx == &entry.index) else {
+            return Ok(None);
+        };
+        let Some(child_1_edge) = self.tree.edge_between(node, child_1) else {
+            return Ok(None);
+        };
+        let Some(child_1_bond_index) = self.tree.bond_index(child_1_edge) else {
+            return Ok(None);
+        };
+        let Some(child_axis_1) = tensor_indices
+            .iter()
+            .position(|idx| idx == child_1_bond_index)
+        else {
+            return Ok(None);
+        };
+        let Some(child_2_edge) = self.tree.edge_between(node, child_2) else {
+            return Ok(None);
+        };
+        let Some(child_2_bond_index) = self.tree.bond_index(child_2_edge) else {
+            return Ok(None);
+        };
+        let Some(child_axis_2) = tensor_indices
+            .iter()
+            .position(|idx| idx == child_2_bond_index)
+        else {
+            return Ok(None);
+        };
+        let Some(parent_axis) = (0..4)
+            .find(|&axis| axis != physical_axis && axis != child_axis_1 && axis != child_axis_2)
+        else {
+            return Ok(None);
+        };
+
+        let child_1_message = messages.get(child_1).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_complex_raw: missing message for child {:?}",
+                child_1
+            )
+        })?;
+        let child_1_values = if let Some(raw_values) = &child_1_message.raw_values {
+            let mut values = Vec::with_capacity(raw_values.len());
+            for value in raw_values {
+                let CachedScalar::Complex(value) = value else {
+                    return Ok(None);
+                };
+                values.push(*value);
+            }
+            values
+        } else {
+            let Some(tensor) = child_1_message.tensor.as_ref() else {
+                return Ok(None);
+            };
+            if !tensor.is_complex() {
+                return Ok(None);
+            }
+            tensor.to_vec::<Complex64>()?
+        };
+        let child_2_message = messages.get(child_2).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_complex_raw: missing message for child {:?}",
+                child_2
+            )
+        })?;
+        let child_2_values = if let Some(raw_values) = &child_2_message.raw_values {
+            let mut values = Vec::with_capacity(raw_values.len());
+            for value in raw_values {
+                let CachedScalar::Complex(value) = value else {
+                    return Ok(None);
+                };
+                values.push(*value);
+            }
+            values
+        } else {
+            let Some(tensor) = child_2_message.tensor.as_ref() else {
+                return Ok(None);
+            };
+            if !tensor.is_complex() {
+                return Ok(None);
+            }
+            tensor.to_vec::<Complex64>()?
+        };
+
+        let child_1_assignment_batch = assignment_batches.get(child_1).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_complex_raw: missing assignment batch for child {:?}",
+                child_1
+            )
+        })?;
+        let child_2_assignment_batch = assignment_batches.get(child_2).ok_or_else(|| {
+            anyhow::anyhow!(
+                "TreeTNCachedEvaluator::try_compute_branch_message_complex_raw: missing assignment batch for child {:?}",
+                child_2
+            )
+        })?;
+
+        let dims = tensor.dims();
+        let parent_dim = dims[parent_axis];
+        let child_dim_1 = dims[child_axis_1];
+        let child_dim_2 = dims[child_axis_2];
+        let strides = [
+            1usize,
+            dims[0],
+            dims[0]
+                .checked_mul(dims[1])
+                .ok_or_else(|| anyhow::anyhow!("branch tensor strides overflow usize"))?,
+            dims[0]
+                .checked_mul(dims[1])
+                .and_then(|value| value.checked_mul(dims[2]))
+                .ok_or_else(|| anyhow::anyhow!("branch tensor strides overflow usize"))?,
+        ];
+        let spec = BranchContractionSpec {
+            strides,
+            physical_axis,
+            parent_axis,
+            child_axis_1,
+            child_axis_2,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw = tensor.to_vec::<Complex64>()?;
+
+        let mut physical_values = Vec::with_capacity(points.len());
+        let mut child_1_columns = Vec::with_capacity(child_dim_1 * points.len());
+        let mut child_2_columns = Vec::with_capacity(child_dim_2 * points.len());
+        for &point in points {
+            let physical_value = value_at(
+                values,
+                entry.input_position,
+                point,
+                "TreeTNCachedEvaluator::try_compute_branch_message_complex_raw",
+            )?;
+            physical_values.push(physical_value);
+
+            let child_1_assignment = child_1_assignment_batch
+                .point_to_assignment
+                .get(point)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("missing child-1 assignment for point {point}"))?;
+            let start_1 = child_1_assignment.checked_mul(child_dim_1).ok_or_else(|| {
+                anyhow::anyhow!("branch child-1 assignment offset overflows usize")
+            })?;
+            let end_1 = start_1
+                .checked_add(child_dim_1)
+                .ok_or_else(|| anyhow::anyhow!("branch child-1 assignment end overflows usize"))?;
+            child_1_columns.extend_from_slice(
+                child_1_values
+                    .get(start_1..end_1)
+                    .ok_or_else(|| anyhow::anyhow!("branch child-1 assignment is out of bounds"))?,
+            );
+
+            let child_2_assignment = child_2_assignment_batch
+                .point_to_assignment
+                .get(point)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("missing child-2 assignment for point {point}"))?;
+            let start_2 = child_2_assignment.checked_mul(child_dim_2).ok_or_else(|| {
+                anyhow::anyhow!("branch child-2 assignment offset overflows usize")
+            })?;
+            let end_2 = start_2
+                .checked_add(child_dim_2)
+                .ok_or_else(|| anyhow::anyhow!("branch child-2 assignment end overflows usize"))?;
+            child_2_columns.extend_from_slice(
+                child_2_values
+                    .get(start_2..end_2)
+                    .ok_or_else(|| anyhow::anyhow!("branch child-2 assignment is out of bounds"))?,
+            );
+        }
+        let result = Self::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child_1_columns,
+            &child_2_columns,
+        )?;
+        Ok(Some(result))
+    }
+
     /// Computes `node`'s directed message toward its parent, consulting the
     /// per-node persistent cache first.
     ///
@@ -2163,10 +2590,22 @@ where
         let tensor_is_complex = tensor_for_node(self.tree, node)?.is_complex();
         let missing_values: Vec<CachedScalar> = if tensor_is_complex {
             let leaf = self.try_compute_leaf_message_complex_raw(node, values, &missing_points)?;
-            let raw_missing_values = if leaf.is_some() {
+            let chain = if leaf.is_some() {
                 leaf
             } else {
                 self.try_compute_chain_message_complex_raw(
+                    node,
+                    values,
+                    &missing_points,
+                    plan,
+                    assignment_batches,
+                    messages,
+                )?
+            };
+            let raw_missing_values = if chain.is_some() {
+                chain
+            } else {
+                self.try_compute_branch_message_complex_raw(
                     node,
                     values,
                     &missing_points,
@@ -2196,10 +2635,22 @@ where
             }
         } else {
             let leaf = self.try_compute_leaf_message_raw(node, values, &missing_points)?;
-            let raw_missing_values = if leaf.is_some() {
+            let chain = if leaf.is_some() {
                 leaf
             } else {
                 self.try_compute_chain_message_raw(
+                    node,
+                    values,
+                    &missing_points,
+                    plan,
+                    assignment_batches,
+                    messages,
+                )?
+            };
+            let raw_missing_values = if chain.is_some() {
+                chain
+            } else {
+                self.try_compute_branch_message_raw(
                     node,
                     values,
                     &missing_points,
@@ -4372,6 +4823,203 @@ mod tests {
     }
 
     #[test]
+    fn raw_branch_message_matches_generic_contraction() {
+        let (tree, indices) = star_tree();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let shape = [4usize, 2usize];
+        let values = [0usize, 0, 0, 0, 1, 0, 1, 1];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+        evaluator.evaluate_batched(points).unwrap();
+
+        let plan = RootedMessagePlan::new(&tree, &1).unwrap();
+        let assignment_batches = evaluator
+            .build_message_assignment_batches(&plan, points)
+            .unwrap();
+
+        // Nodes 2 and 3 (leaves, the hub's two children when rooted at leaf
+        // 1) via the generic oracle path.
+        let mut messages = HashMap::new();
+        for leaf in [2usize, 3usize] {
+            let leaf_points = assignment_batches.get(&leaf).unwrap().first_points.clone();
+            let leaf_message = evaluator
+                .compute_stacked_message(
+                    &leaf,
+                    points,
+                    &leaf_points,
+                    &plan,
+                    &assignment_batches,
+                    &HashMap::new(),
+                )
+                .unwrap();
+            messages.insert(leaf, leaf_message);
+        }
+
+        let hub_points = assignment_batches.get(&0).unwrap().first_points.clone();
+        let expected_message = evaluator
+            .compute_stacked_message(
+                &0,
+                points,
+                &hub_points,
+                &plan,
+                &assignment_batches,
+                &messages,
+            )
+            .unwrap();
+        let expected = tensor_values_any(expected_message.tensor.as_ref().unwrap()).unwrap();
+
+        let actual = evaluator
+            .try_compute_branch_message_raw(
+                &0,
+                points,
+                &hub_points,
+                &plan,
+                &assignment_batches,
+                &messages,
+            )
+            .unwrap()
+            .expect("branch node with two children and one physical index must be eligible");
+
+        assert_eq!(actual.len(), expected.len());
+        for (a, e) in actual.iter().zip(expected.iter()) {
+            assert!(
+                (a - e.real()).abs() < 1.0e-10,
+                "raw={a} generic={}",
+                e.real()
+            );
+        }
+    }
+
+    fn complex_star_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
+        let sc = DynIndex::new_dyn(2);
+        let s0 = DynIndex::new_dyn(2);
+        let s1 = DynIndex::new_dyn(2);
+        let s2 = DynIndex::new_dyn(2);
+        let b0 = DynIndex::new_dyn(2);
+        let b1 = DynIndex::new_dyn(2);
+        let b2 = DynIndex::new_dyn(2);
+        let center_data: Vec<Complex64> = (0..16)
+            .map(|value| Complex64::new(value as f64 + 1.0, -(value as f64) * 0.25))
+            .collect();
+        let center = IdxTensor::from_dense(
+            vec![sc.clone(), b0.clone(), b1.clone(), b2.clone()],
+            center_data,
+        )
+        .unwrap();
+        let leaf0 = IdxTensor::from_dense(
+            vec![b0, s0.clone()],
+            vec![
+                Complex64::new(1.0, 0.5),
+                Complex64::new(0.5, -0.25),
+                Complex64::new(1.5, 0.75),
+                Complex64::new(2.0, -1.0),
+            ],
+        )
+        .unwrap();
+        let leaf1 = IdxTensor::from_dense(
+            vec![b1, s1.clone()],
+            vec![
+                Complex64::new(0.25, -0.5),
+                Complex64::new(1.0, 0.25),
+                Complex64::new(1.25, -0.75),
+                Complex64::new(2.0, 1.0),
+            ],
+        )
+        .unwrap();
+        let leaf2 = IdxTensor::from_dense(
+            vec![b2, s2.clone()],
+            vec![
+                Complex64::new(2.0, 0.5),
+                Complex64::new(1.0, -0.25),
+                Complex64::new(0.75, 0.5),
+                Complex64::new(1.5, -1.0),
+            ],
+        )
+        .unwrap();
+        let tree =
+            TreeTN::<_, usize>::from_tensors(vec![center, leaf0, leaf1, leaf2], vec![0, 1, 2, 3])
+                .unwrap();
+        (tree, vec![sc, s0, s1, s2])
+    }
+
+    #[test]
+    fn raw_complex_branch_message_matches_generic_contraction() {
+        let (tree, indices) = complex_star_tree();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let shape = [4usize, 2usize];
+        let values = [0usize, 0, 0, 0, 1, 0, 1, 1];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+        evaluator.evaluate_batched(points).unwrap();
+
+        let plan = RootedMessagePlan::new(&tree, &1).unwrap();
+        let assignment_batches = evaluator
+            .build_message_assignment_batches(&plan, points)
+            .unwrap();
+
+        let mut messages = HashMap::new();
+        for leaf in [2usize, 3usize] {
+            let leaf_points = assignment_batches.get(&leaf).unwrap().first_points.clone();
+            let leaf_message = evaluator
+                .compute_stacked_message(
+                    &leaf,
+                    points,
+                    &leaf_points,
+                    &plan,
+                    &assignment_batches,
+                    &HashMap::new(),
+                )
+                .unwrap();
+            messages.insert(leaf, leaf_message);
+        }
+
+        let hub_points = assignment_batches.get(&0).unwrap().first_points.clone();
+        let expected_message = evaluator
+            .compute_stacked_message(
+                &0,
+                points,
+                &hub_points,
+                &plan,
+                &assignment_batches,
+                &messages,
+            )
+            .unwrap();
+        let expected = tensor_values_any(expected_message.tensor.as_ref().unwrap()).unwrap();
+
+        let actual = evaluator
+            .try_compute_branch_message_complex_raw(
+                &0,
+                points,
+                &hub_points,
+                &plan,
+                &assignment_batches,
+                &messages,
+            )
+            .unwrap()
+            .expect("complex branch message should use the raw path");
+
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
+            assert!((actual.re - expected.real()).abs() < 1.0e-10);
+            assert!((actual.im - expected.imag()).abs() < 1.0e-10);
+        }
+    }
+
+    #[test]
     fn fixed_center_and_scan_hint_evaluation_match() {
         let (tree, indices) = complex_three_node_chain();
         let shape = [3usize, 2usize];
@@ -4829,6 +5477,42 @@ mod tests {
             &indices,
             CachedEvaluatorOptions {
                 center: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let actual = evaluator.evaluate_batched(points).unwrap();
+
+        assert_scalars_close(&actual, &expected);
+    }
+
+    /// `cached_evaluator_matches_tree_evaluate_on_star_tree` fixes `center`
+    /// to the hub itself, so the hub's combination goes through the
+    /// separate one-shot centre contraction, not `get_or_compute_node_message`
+    /// -- it never exercises `try_compute_branch_message_raw`. This test
+    /// fixes `center` to a leaf instead, so the hub (rooted toward that
+    /// leaf) has two children and its message must go through the new
+    /// branch dispatch, verified end-to-end through the public
+    /// `evaluate_batched` API rather than by manually driving the message
+    /// plan (unlike `raw_branch_message_matches_generic_contraction`).
+    #[test]
+    fn cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center() {
+        let (tree, indices) = star_tree();
+        let values = vec![
+            0, 0, 0, 0, //
+            1, 1, 0, 1, //
+            0, 1, 1, 0, //
+            1, 0, 1, 1,
+        ];
+        let shape = [4, 4];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+        let expected = tree.evaluate(&indices, points).unwrap();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
                 ..Default::default()
             },
         )

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -1236,7 +1236,10 @@ where
         if neighbors.get(center).map(Vec::len) != Some(1) {
             return Ok(false);
         }
-        if neighbors.values().any(|neighbors| neighbors.len() > 2) {
+        // A leaf center turns every degree-3 node into at most a two-child
+        // rooted branch, which is covered by the raw branch message path.
+        // Degree-4 nodes would still require a generic multi-child message.
+        if neighbors.values().any(|neighbors| neighbors.len() > 3) {
             return Ok(false);
         }
         if self
@@ -4897,6 +4900,65 @@ mod tests {
         }
     }
 
+    #[test]
+    fn degree_three_hub_keeps_raw_messages_when_center_is_a_leaf() {
+        let (tree, indices) = star_tree();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let shape = [4usize, 2usize];
+        let values = [0usize, 0, 0, 0, 1, 0, 1, 1];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+
+        let (_, environments) = evaluator.build_environment_cache(&1, points).unwrap();
+        let hub_message = environments
+            .get(&0)
+            .expect("leaf-centered star must expose the hub environment");
+
+        assert!(
+            hub_message.raw_values.is_some(),
+            "a degree-3 hub rooted at a leaf should retain its raw branch message"
+        );
+        assert!(
+            hub_message.tensor.is_none(),
+            "raw branch messages should not be materialized into an IdxTensor"
+        );
+    }
+
+    #[test]
+    fn degree_four_hub_does_not_keep_raw_messages_when_center_is_a_leaf() {
+        let (tree, indices) = four_arm_star_tree();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let values = vec![0usize; 5];
+        let shape = [5usize, 1usize];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+
+        let (_, environments) = evaluator.build_environment_cache(&1, points).unwrap();
+        let hub_message = environments
+            .get(&0)
+            .expect("leaf-centered star must expose the hub environment");
+
+        assert!(
+            hub_message.raw_values.is_none(),
+            "a degree-4 hub needs the generic multi-child message path"
+        );
+        assert!(hub_message.tensor.is_some());
+    }
+
     fn complex_star_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
         let sc = DynIndex::new_dyn(2);
         let s0 = DynIndex::new_dyn(2);
@@ -5208,6 +5270,35 @@ mod tests {
             TreeTN::<_, usize>::from_tensors(vec![center, leaf0, leaf1, leaf2], vec![0, 1, 2, 3])
                 .unwrap();
         (tree, vec![sc, s0, s1, s2])
+    }
+
+    fn four_arm_star_tree() -> (TreeTN<IdxTensor, usize>, Vec<DynIndex>) {
+        let sc = DynIndex::new_dyn(2);
+        let sites = (0..4).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+        let bonds = (0..4).map(|_| DynIndex::new_dyn(2)).collect::<Vec<_>>();
+        let center = IdxTensor::from_dense(
+            vec![
+                sc.clone(),
+                bonds[0].clone(),
+                bonds[1].clone(),
+                bonds[2].clone(),
+                bonds[3].clone(),
+            ],
+            vec![1.0_f64; 32],
+        )
+        .unwrap();
+        let leaves = bonds
+            .into_iter()
+            .zip(sites.iter().cloned())
+            .map(|(bond, site)| IdxTensor::from_dense(vec![bond, site], vec![1.0_f64; 4]))
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        let mut tensors = vec![center];
+        tensors.extend(leaves);
+        let tree = TreeTN::<_, usize>::from_tensors(tensors, vec![0, 1, 2, 3, 4]).unwrap();
+        let mut indices = vec![sc];
+        indices.extend(sites);
+        (tree, indices)
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -68,13 +68,14 @@ struct ChainContractionSpec {
     child_dim: usize,
 }
 
-/// Minimum scalar multiply count / group size before the backend setup cost
-/// is amortized by the grouped branch kernel, mirroring
-/// `CHAIN_BLAS_WORK_THRESHOLD` / `CHAIN_BLAS_MIN_GROUP_POINTS` but tuned
-/// independently: a branch step does two contractions per group instead of
-/// one, so its fixed per-call setup cost differs from the chain kernel's.
+/// Minimum scalar multiply count before the backend setup cost is amortized
+/// by the grouped branch kernel. Unlike the chain kernel, there is no
+/// separate minimum-group-points gate: a branch step's per-point work is
+/// O(parent_dim * child_dim_1 * child_dim_2), an extra bond-dimension factor
+/// over the chain kernel's O(parent_dim * child_dim), so at realistic bond
+/// dimensions `scalar_work` alone already justifies BLAS even for a single
+/// point per group (see `grouped_branch_message_contraction`).
 const BRANCH_BLAS_WORK_THRESHOLD: usize = 4096;
-const BRANCH_BLAS_MIN_GROUP_POINTS: usize = 4;
 
 #[derive(Clone, Copy, Debug)]
 struct BranchContractionSpec {
@@ -1603,7 +1604,21 @@ where
             child_dim_2
         );
 
-        if point_count < 2 * BRANCH_BLAS_MIN_GROUP_POINTS {
+        // Unlike the chain kernel (O(parent_dim * child_dim) work per point),
+        // a branch step is O(parent_dim * child_dim_1 * child_dim_2) per
+        // point -- an extra bond-dimension factor. At realistic bond
+        // dimensions that alone already dwarfs BLAS's fixed per-call setup
+        // cost even for a single point (a single Step-A `mat_mul_owned` call
+        // is still a large, worthwhile matrix-vector product), so gating on
+        // point/group count the way `CHAIN_BLAS_MIN_GROUP_POINTS` does is
+        // the wrong heuristic here: it would force every small
+        // floating-zone-walk batch (the common case) onto the scalar
+        // fallback regardless of how large `scalar_work` actually is, which
+        // was measured to *regress* wall time at bond=128 (see
+        // `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`).
+        // `scalar_work` alone is the right gate.
+        let scalar_work = parent_dim * child_dim_1 * child_dim_2 * point_count;
+        if scalar_work < BRANCH_BLAS_WORK_THRESHOLD {
             return scalar_branch_message_contraction(
                 spec,
                 raw,
@@ -1616,21 +1631,6 @@ where
         let mut groups = HashMap::<usize, Vec<usize>>::new();
         for (point, &physical_value) in physical_values.iter().enumerate() {
             groups.entry(physical_value).or_default().push(point);
-        }
-        let scalar_work = parent_dim * child_dim_1 * child_dim_2 * point_count;
-        if scalar_work < BRANCH_BLAS_WORK_THRESHOLD
-            || groups.len() > 8
-            || groups
-                .values()
-                .any(|points| points.len() < BRANCH_BLAS_MIN_GROUP_POINTS)
-        {
-            return scalar_branch_message_contraction(
-                spec,
-                raw,
-                physical_values,
-                child1_columns,
-                child2_columns,
-            );
         }
 
         let mut output = vec![T::default(); point_count * parent_dim];
@@ -5834,17 +5834,28 @@ mod tests {
         assert!(total > 0);
     }
 
-    // TEMPORARY diagnostic for gw-rs issue tensor4all-rs#671's downstream
-    // follow-up -- not a regression test, revert after root-cause
-    // confirmation. Compares this evaluator's realistic floating-zone-walk
-    // wall time on a plain 16-site chain against a same-size comb tree (one
-    // degree-3 hub, three 5-site arms), both under the SAME cached
-    // evaluate_batched path used by `message_cache_wall_time_on_realistic_floating_zone_walk`
-    // above. Isolates whether `compute_stacked_message`'s generic multi-child
-    // fallback (hit only by the hub node, since `try_compute_chain_message_raw`
-    // requires exactly one child) is a meaningful wall-time cost at this
-    // evaluator's actual small-batch call pattern, independent of whether the
-    // frames.rs fix (tensor4all-treeaci) helped.
+    // Measurement tooling rather than a wall-clock regression assertion
+    // (mirroring `message_cache_wall_time_on_realistic_floating_zone_walk`'s
+    // own framing above), kept from the investigation for gw-rs issue
+    // tensor4all-rs#671's downstream follow-up. Compares this evaluator's
+    // realistic floating-zone-walk wall time on a plain 16-site chain
+    // against a same-size comb tree (one degree-3 hub, three 5-site arms),
+    // both at the same bond dimension, under the same cached evaluate_batched
+    // path used by `message_cache_wall_time_on_realistic_floating_zone_walk`
+    // above.
+    //
+    // Read this test's ratio as "does branching cost something at matched
+    // bond dimension," not as a proxy for real downstream wall time: this
+    // investigation measured 25.84x before the two-child raw path
+    // (`try_compute_branch_message_raw`) existed, a regression to 44.24x
+    // from an initial version of that path's wrong point-count-based BLAS
+    // gate, 29.26x after fixing the gate -- yet the real gw-rs downstream
+    // pipeline (which does not have equal bond dimensions between its chain
+    // and comb topologies) measured a genuine 2.96x-3.15x wall-time
+    // improvement per treeaci stage from the same fix. See
+    // `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md` for the
+    // full trace, including why the same-bond assumption here does not
+    // represent the real workload's shape.
     #[test]
     #[ignore]
     fn diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk() {
@@ -5907,8 +5918,8 @@ mod tests {
             let mut next_node = 1usize;
             let mut center = 0usize;
 
-            for arm in 0..3 {
-                let mut prev_bond = hub_bonds[arm].clone();
+            for (arm, hub_bond) in hub_bonds.iter().enumerate() {
+                let mut prev_bond = hub_bond.clone();
                 for depth in 0..ARM_LEN {
                     let s = DynIndex::new_dyn(LOCAL_DIM);
                     let is_tip = depth == ARM_LEN - 1;

--- a/docs/superpowers/plans/2026-08-22-treeaci-branch-batched-frames.md
+++ b/docs/superpowers/plans/2026-08-22-treeaci-branch-batched-frames.md
@@ -1,0 +1,1014 @@
+# TreeACI Branch-Point Batched Frame Contraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the fixed per-oracle-call overhead at branching (2-incoming-edge) tree nodes reported in issue #671 by giving `InputFrameStore::candidate_frames_for_edge` and `FrameBuilder::compute_batch` a BLAS-batched contraction path for exactly-two-incoming-edge directed edges, instead of falling back to the scalar `accumulate_incoming` walk per candidate/sample.
+
+**Architecture:** Add one new low-level primitive, `two_incoming_core_matrix_batched`, that contracts a node's core against two incoming-edge candidate-frame matrices (`v1`: `D1 x N1`, `v2`: `D2 x N2`) via `D2 + 1` BLAS `mat_mul` calls, producing every `(n1, n2)` combination in one shot. It is built by looping the *existing* `single_incoming_core_matrix` + `contract_prepared_core_batched` pair over the second incoming edge's dimension, then doing one more `contract_prepared_core_batched` call to fold in the second edge — no new BLAS-call machinery, no hand-rolled multi-axis transpose. Wire this primitive into both existing dispatch points (`candidate_frames_for_edge`'s pivot-search-candidate path, `FrameBuilder::compute_batch`'s sample-materialization path) as a new middle case between the existing 1-incoming (batched) and 0-or-3+-incoming (scalar) cases. Nodes with 3+ incoming edges (degree ≥ 5) keep using the scalar fallback — out of scope for this plan, since issue #671's reported topology (3-arm comb, i.e. exactly 2 incoming edges at every hub) does not need it, and generalizing further needs an inter-step transpose the 2-incoming case avoids.
+
+**Tech Stack:** Rust, `tensor4all_tensorbackend::Matrix` + `mat_mul` (already used by the existing single-incoming batched path — no new dependency).
+
+**Spec:** This plan's own "Architecture" section above (root-caused and empirically validated in-session against gw-rs issue #671; see `docs/worklogs/2026-08-18-treeaci-message-cache-prototype.md` for the prior, deliberately-deferred documentation of this exact gap).
+
+## Global Constraints
+
+- Crate-scoped commands only (`--manifest-path crates/tensor4all-treeaci/Cargo.toml` or `-p tensor4all-treeaci`); do not build the full workspace.
+- `cargo test`/`cargo nextest run` for this crate must use `--release` (debug-mode tree-ACI tests are slow).
+- No `unwrap()`/`expect()` in library code (test code may use them, matching existing test style in `frames/tests/mod.rs`).
+- `cargo fmt --all` before considering any task done.
+- New public-crate-internal (`pub(crate)`) functions still need doc comments per this repo's rustdoc standard; free functions in `frames.rs` follow the existing terse-comment style already used for `single_incoming_core_matrix`/`contract_prepared_core_batched`.
+- Every new dispatch branch must be covered by a test that asserts bit-for-bit (or, if that turns out not to hold at f64 precision once measured, `approx::assert_abs_diff_eq!` with a tight tolerance — decide from what the TDD step actually shows, do not assume) equality against the untouched scalar ground truth (`contract_prepared_core`/`candidate_frame`), mirroring the existing `..._falls_back_on_a_branch_edge_with_two_incoming_edges` test convention.
+- Do not touch `accumulate_incoming`, `contract_prepared_core`, or the 0-/3+-incoming scalar fallback behavior — this plan only adds a new dispatch branch for exactly 2 incoming edges.
+
+---
+
+## File Structure
+
+- Modify: `crates/tensor4all-treeaci/src/frames.rs`
+  - New free function `two_incoming_core_matrix_batched` (the BLAS primitive), placed after `contract_prepared_core_batched`.
+  - New method `InputFrameStore::candidate_frames_for_edge_two_incoming`, placed after `candidate_frames_for_edge`.
+  - New method `FrameBuilder::compute_batch_two_incoming`, placed after `compute_batch`.
+  - Dispatch edits inside `candidate_frames_for_edge` and `compute_batch`.
+  - Doc-comment updates on both dispatching functions.
+- Modify: `crates/tensor4all-treeaci/src/frames/tests/mod.rs`
+  - Rename/adapt `candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges` → `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges` (it now exercises the new batched path, not a fallback).
+  - Rename/adapt `compute_batch_falls_back_correctly_on_a_branch_edge` → `compute_batch_batches_a_branch_edge_with_two_incoming_edges`.
+  - New fixture `four_arm_star_tree_for_three_incoming_fallback` (degree-4 hub, so one directed edge has exactly 3 incoming edges) plus two new tests asserting the scalar fallback is still used for 3 incoming edges, for both call sites.
+  - New isolated unit test for `two_incoming_core_matrix_batched` itself.
+- Create: `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md` — root cause, fix, before/after measurement, following this repo's existing treeaci worklog convention.
+
+## Global Constraints Recap for Every Task
+
+Every task below ends with, at minimum: `cargo fmt --all -- --check` clean and `cargo test --release -p tensor4all-treeaci --no-fail-fast` green, before moving to the next task.
+
+---
+
+### Task 1: `two_incoming_core_matrix_batched` primitive
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs` (insert after `contract_prepared_core_batched`, i.e. after the closing `}` currently at line 1165, before `fn outgoing_bond<'a, V: TreeAciNode>` at line 1167)
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs` (append near the end, after the existing `two_node_frames_are_exact_for_real_and_complex_inputs`-style tests, or directly after the `star_tree_for_fallback_dispatch` fixture — exact placement is not load-bearing, put it near `star_tree_for_fallback_dispatch` since it reuses that fixture)
+
+**Interfaces:**
+- Produces: `fn two_incoming_core_matrix_batched<T: TreeAciScalar>(core: &PreparedCore<T>, outgoing_axis: usize, incoming_axis_1: usize, incoming_axis_2: usize, physical_base_offset: usize, outgoing_dim: usize, incoming_dim_1: usize, incoming_dim_2: usize, v1: &Matrix<T>, v2: &Matrix<T>) -> Result<Matrix<T>>` — `v1` is `incoming_dim_1 x n1`, `v2` is `incoming_dim_2 x n2`; returns a `(outgoing_dim * n1) x n2` matrix where `result[[outgoing_dim * n1_index + out, n2_index]]` equals what `contract_prepared_core` would produce at `out` for the `(n1_index, n2_index)` pair.
+- Consumes: existing `single_incoming_core_matrix`, `contract_prepared_core_batched`, `PreparedCore` (all already in `frames.rs`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, near `star_tree_for_fallback_dispatch`:
+
+```rust
+#[test]
+fn two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair() {
+    let inputs = vec![star_tree_for_fallback_dispatch()];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+    let cores = super::prepare_cores::<f64, usize>(&inputs[0], &problem).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("star tree must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 2);
+    let incoming_edge_1 = directed.incoming_to_from[0];
+    let incoming_edge_2 = directed.incoming_to_from[1];
+
+    let node = *problem.node_positions.get(&directed.from).unwrap();
+    let core = &cores[node];
+    let outgoing = super::outgoing_bond(&inputs[0], &problem, edge).unwrap();
+    let outgoing_axis = super::axis_of(&core.indices, outgoing).unwrap();
+    let incoming_bond_1 = super::outgoing_bond(&inputs[0], &problem, incoming_edge_1).unwrap();
+    let incoming_bond_2 = super::outgoing_bond(&inputs[0], &problem, incoming_edge_2).unwrap();
+    let incoming_axis_1 = super::axis_of(&core.indices, incoming_bond_1).unwrap();
+    let incoming_axis_2 = super::axis_of(&core.indices, incoming_bond_2).unwrap();
+    let outgoing_dim = core.dims[outgoing_axis];
+    let incoming_dim_1 = core.dims[incoming_axis_1];
+    let incoming_dim_2 = core.dims[incoming_axis_2];
+
+    // Two arbitrary, non-trivial frame vectors per incoming edge (n1=2, n2=2)
+    // so the test exercises real cross-combination behavior, not a
+    // degenerate 1-candidate case.
+    let v1_cols = [vec![1.0, 0.5], vec![0.25, 2.0]];
+    let v2_cols = [vec![3.0, -1.0], vec![0.1, 4.0]];
+    let mut v1_data = Vec::new();
+    for col in &v1_cols {
+        v1_data.extend(col.iter().copied());
+    }
+    let v1 = tensor4all_tensorbackend::Matrix::from_col_major_vec(incoming_dim_1, 2, v1_data);
+    let mut v2_data = Vec::new();
+    for col in &v2_cols {
+        v2_data.extend(col.iter().copied());
+    }
+    let v2 = tensor4all_tensorbackend::Matrix::from_col_major_vec(incoming_dim_2, 2, v2_data);
+
+    let batched = super::two_incoming_core_matrix_batched(
+        core,
+        outgoing_axis,
+        incoming_axis_1,
+        incoming_axis_2,
+        0,
+        outgoing_dim,
+        incoming_dim_1,
+        incoming_dim_2,
+        &v1,
+        &v2,
+    )
+    .unwrap();
+
+    for (n1, v1_vec) in v1_cols.iter().enumerate() {
+        for (n2, v2_vec) in v2_cols.iter().enumerate() {
+            let incoming_frames = vec![
+                (incoming_edge_1, v1_vec.clone()),
+                (incoming_edge_2, v2_vec.clone()),
+            ];
+            let expected = super::contract_prepared_core(
+                &inputs[0],
+                &problem,
+                &cores,
+                edge,
+                0,
+                &incoming_frames,
+            )
+            .unwrap();
+            let actual: Vec<f64> = (0..outgoing_dim)
+                .map(|out| batched[[out + outgoing_dim * n1, n2]])
+                .collect();
+            assert_eq!(
+                actual, expected,
+                "mismatch at (n1={n1}, n2={n2})"
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair`
+Expected: FAIL to compile — `two_incoming_core_matrix_batched` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert into `crates/tensor4all-treeaci/src/frames.rs`, immediately after `contract_prepared_core_batched`'s closing `}` (currently line 1165) and before `fn outgoing_bond<'a, V: TreeAciNode>`:
+
+```rust
+/// Contracts a core slice's two incoming axes against batches of candidate
+/// frame vectors for both incoming edges, computing every combination in
+/// the cartesian product of `v1`'s and `v2`'s columns via `incoming_dim_2 + 1`
+/// BLAS `mat_mul` calls (`incoming_dim_2` calls fold in `v1` one slice of the
+/// second axis at a time, then one final call folds in `v2`) instead of one
+/// scalar [`accumulate_incoming`] walk per `(n1, n2)` combination.
+///
+/// `v1` is `incoming_dim_1 x n1`, `v2` is `incoming_dim_2 x n2`. Returns an
+/// `(outgoing_dim * n1) x n2` matrix: column `n2`, rows
+/// `[outgoing_dim * n1_index, outgoing_dim * (n1_index + 1))`, holds the
+/// `outgoing_dim`-length frame vector [`contract_prepared_core`] would
+/// produce for the `(n1_index, n2)` candidate alone.
+fn two_incoming_core_matrix_batched<T: TreeAciScalar>(
+    core: &PreparedCore<T>,
+    outgoing_axis: usize,
+    incoming_axis_1: usize,
+    incoming_axis_2: usize,
+    physical_base_offset: usize,
+    outgoing_dim: usize,
+    incoming_dim_1: usize,
+    incoming_dim_2: usize,
+    v1: &Matrix<T>,
+    v2: &Matrix<T>,
+) -> Result<Matrix<T>> {
+    let n1 = v1.ncols();
+    let stride_2 = core.strides[incoming_axis_2];
+    let mut stage1_data = Vec::with_capacity(outgoing_dim * n1 * incoming_dim_2);
+    for i2 in 0..incoming_dim_2 {
+        let core_matrix = single_incoming_core_matrix(
+            core,
+            outgoing_axis,
+            incoming_axis_1,
+            physical_base_offset + i2 * stride_2,
+            outgoing_dim,
+            incoming_dim_1,
+        );
+        let stage1 = contract_prepared_core_batched(&core_matrix, v1)?;
+        stage1_data.extend(stage1.into_col_major_vec());
+    }
+    let stage1_matrix = Matrix::from_col_major_vec(outgoing_dim * n1, incoming_dim_2, stage1_data);
+    contract_prepared_core_batched(&stage1_matrix, v2)
+}
+```
+
+Also make `contract_prepared_core`, `outgoing_bond`, `axis_of`, and `prepare_cores` reachable from the test module at their current `pub(crate)`/private visibility — they already are, since `frames/tests/mod.rs` uses `super::` to reach other private items in this file (see existing use of `super::InputFrameStore`, `super::prepare_cores` pattern already present in `build_frame_builder`). No visibility changes should be needed; if the compiler disagrees, add `pub(crate)` (or `pub(super)`) only to the specific item that fails to resolve, not broadly.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair -- --nocapture`
+Expected: PASS. If it fails with a numeric mismatch (not a compile error), the bug is in the offset/reshape bookkeeping in `two_incoming_core_matrix_batched` — check `stride_2` is `core.strides[incoming_axis_2]` (not axis_1), and that `stage1_data` is appended in `i2` order (so `stage1_matrix`'s columns are indexed by `i2`, matching `contract_prepared_core_batched`'s expectation that its second argument's rows are the axis being contracted).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-treeaci/src/frames.rs crates/tensor4all-treeaci/src/frames/tests/mod.rs
+git commit -m "feat(treeaci): add batched two-incoming-edge core contraction primitive"
+```
+
+---
+
+### Task 2: Wire into `candidate_frames_for_edge` (pivot-search candidate path)
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs` (`candidate_frames_for_edge`, currently lines 481-642; insert new method `candidate_frames_for_edge_two_incoming` after it, before `candidate_frame` at line 644)
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs` (adapt the existing branch test at lines 653-711; add a new 3-incoming fixture/test)
+
+**Interfaces:**
+- Consumes: `two_incoming_core_matrix_batched` (Task 1), `InputFrameStore::frame_values` (existing), `InputFrameStore::candidate_cache`/`candidate_cache_bytes` (existing fields).
+- Produces: `InputFrameStore::candidate_frames_for_edge_two_incoming(&self, inputs, problem, input, directed_edge, candidates: &[ComponentSample]) -> Result<Vec<Vec<T>>>` — same contract as `candidate_frames_for_edge` (one frame vector per input candidate, same order), used only when the edge has exactly two incoming edges.
+
+- [ ] **Step 1: Adapt the existing branch test to assert against the new path (still red — the code hasn't changed yet)**
+
+In `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, rename
+`candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges`
+to `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges` and update its doc comment (the one above `star_tree_for_fallback_dispatch` references it by name, at line 583 — update that cross-reference too). The test body's assertions (`dispatched == scalar`) stay exactly as they are — they already compare `candidate_frames_for_edge`'s output against `candidate_frame`'s scalar output, which is exactly what proves the new batched path is correct once wired in. This step is a rename/doc-only change; it does not need to "fail" first since the behavior under test doesn't change yet — skip to Step 2.
+
+- [ ] **Step 2: Write the new 3-incoming-edges-still-scalar fixture and test**
+
+Add to `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, after the (renamed) two-incoming test:
+
+```rust
+/// 4-arm star: hub node 0 with three leaves plus a fourth arm, so directed
+/// edge `0 -> 1` has exactly three incoming edges (`2 -> 0`, `3 -> 0`,
+/// `4 -> 0`). Used to pin that 3+-incoming-edge dispatch still uses the
+/// scalar fallback after Task 2/3 add a batched path for exactly two.
+fn four_arm_star_tree_for_three_incoming_fallback() -> TreeTN<IdxTensor, usize> {
+    let s0 = DynIndex::new_dyn(1);
+    let s1 = DynIndex::new_dyn(1);
+    let s2 = DynIndex::new_dyn(2);
+    let s3 = DynIndex::new_dyn(2);
+    let s4 = DynIndex::new_dyn(2);
+    let bond01 = DynIndex::new_dyn(2);
+    let bond02 = DynIndex::new_dyn(2);
+    let bond03 = DynIndex::new_dyn(2);
+    let bond04 = DynIndex::new_dyn(2);
+
+    let node0 = IdxTensor::from_dense(
+        vec![s0, bond01.clone(), bond02.clone(), bond03.clone(), bond04.clone()],
+        (1..=16).map(|value| value as f64).collect(),
+    )
+    .unwrap();
+    let node1 = IdxTensor::from_dense(vec![bond01, s1], vec![1.0, 2.0]).unwrap();
+    let node2 = IdxTensor::from_dense(vec![bond02, s2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+    let node3 = IdxTensor::from_dense(vec![bond03, s3], vec![5.0, 6.0, 7.0, 8.0]).unwrap();
+    let node4 = IdxTensor::from_dense(vec![bond04, s4], vec![9.0, 10.0, 11.0, 12.0]).unwrap();
+
+    TreeTN::from_tensors(vec![node0, node1, node2, node3, node4], vec![0, 1, 2, 3, 4]).unwrap()
+}
+
+#[test]
+fn candidate_frames_for_edge_still_falls_back_on_three_incoming_edges() {
+    let inputs = vec![four_arm_star_tree_for_three_incoming_fallback()];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("4-arm star must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 3);
+
+    let seeds = vec![vec![0, 0, 0, 0, 0], vec![0, 0, 1, 1, 1]];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+
+    let mut candidates = Vec::new();
+    let incoming: Vec<_> = directed.incoming_to_from.clone();
+    for &id_a in &candidate_sets.ids[incoming[0]] {
+        for &id_b in &candidate_sets.ids[incoming[1]] {
+            for &id_c in &candidate_sets.ids[incoming[2]] {
+                candidates.push(ComponentSample {
+                    local_coordinate: 0,
+                    incoming: vec![
+                        (incoming[0], id_a),
+                        (incoming[1], id_b),
+                        (incoming[2], id_c),
+                    ],
+                });
+            }
+        }
+    }
+
+    let dispatched = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .unwrap();
+    let scalar = candidates
+        .iter()
+        .map(|candidate| {
+            frames
+                .candidate_frame(&inputs, &problem, 0, edge, candidate)
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(dispatched, scalar);
+}
+```
+
+- [ ] **Step 3: Run both tests to confirm current (pre-wiring) behavior**
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges frames::tests::candidate_frames_for_edge_still_falls_back_on_three_incoming_edges -- --nocapture`
+Expected: both PASS already (the dispatch hasn't changed yet, so both still exercise the old scalar fallback and trivially agree with themselves). This confirms the test fixtures compile and are meaningful before the dispatch change makes the two-incoming one actually exercise new code.
+
+- [ ] **Step 4: Add the new orchestration method and wire the dispatch**
+
+In `crates/tensor4all-treeaci/src/frames.rs`, replace the fallback check at the top of `candidate_frames_for_edge` (currently):
+
+```rust
+        if directed.incoming_to_from.len() != 1 {
+            return candidates
+                .iter()
+                .map(|candidate| {
+                    self.candidate_frame(inputs, problem, input, directed_edge, candidate)
+                })
+                .collect();
+        }
+```
+
+with:
+
+```rust
+        if directed.incoming_to_from.len() == 2 {
+            return self.candidate_frames_for_edge_two_incoming(
+                inputs,
+                problem,
+                input,
+                directed_edge,
+                candidates,
+            );
+        }
+        if directed.incoming_to_from.len() != 1 {
+            return candidates
+                .iter()
+                .map(|candidate| {
+                    self.candidate_frame(inputs, problem, input, directed_edge, candidate)
+                })
+                .collect();
+        }
+```
+
+Then insert this new method into the `impl<T: TreeAciScalar> InputFrameStore<T>` block, directly after `candidate_frames_for_edge`'s closing `}` (before `pub(crate) fn candidate_frame` at line 644):
+
+```rust
+    /// Batched counterpart to [`Self::candidate_frames_for_edge`]'s
+    /// single-incoming-edge path, for directed edges whose source node has
+    /// exactly two incoming edges (every hub of a 3-valent tree branch
+    /// point). Groups candidates by `local_coordinate` exactly as the
+    /// single-incoming path does, then for each group gathers the distinct
+    /// sample ids referenced on each incoming edge, builds one frame-vector
+    /// matrix per incoming edge, and contracts both via
+    /// [`two_incoming_core_matrix_batched`] in one shot -- computing the
+    /// full cartesian product of the group's distinct incoming ids (a
+    /// superset of the group's actual candidates whenever the group is not
+    /// already the full product) and reading back only the entries the
+    /// group's candidates actually need.
+    fn candidate_frames_for_edge_two_incoming<V: TreeAciNode>(
+        &self,
+        inputs: &[TreeTN<IdxTensor, V>],
+        problem: &PreparedTreeProblem<V>,
+        input: usize,
+        directed_edge: DirectedEdgeId,
+        candidates: &[ComponentSample],
+    ) -> Result<Vec<Vec<T>>> {
+        let directed =
+            problem
+                .directed_edges
+                .get(directed_edge)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "candidate frame references an unknown directed edge",
+                })?;
+        let node =
+            *problem
+                .node_positions
+                .get(&directed.from)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "candidate source has no prepared node position",
+                })?;
+        let tree = inputs.get(input).ok_or(TreeAciError::InternalInvariant {
+            message: "candidate frame references an unknown input",
+        })?;
+        let cores = self
+            .cores
+            .get(input)
+            .ok_or(TreeAciError::InternalInvariant {
+                message: "candidate frame has no prepared input cores",
+            })?;
+        let core = cores.get(node).ok_or(TreeAciError::InternalInvariant {
+            message: "candidate frame source node has no prepared core",
+        })?;
+        let outgoing = outgoing_bond(tree, problem, directed_edge)?;
+        let outgoing_axis = axis_of(&core.indices, outgoing)?;
+        let physical = &problem.physical[node];
+        let physical_axes = physical
+            .indices
+            .iter()
+            .map(|index| axis_of(&core.indices, index))
+            .collect::<Result<Vec<_>>>()?;
+        let incoming_edge_1 = directed.incoming_to_from[0];
+        let incoming_edge_2 = directed.incoming_to_from[1];
+        let incoming_bond_1 = outgoing_bond(tree, problem, incoming_edge_1)?;
+        let incoming_bond_2 = outgoing_bond(tree, problem, incoming_edge_2)?;
+        let incoming_axis_1 = axis_of(&core.indices, incoming_bond_1)?;
+        let incoming_axis_2 = axis_of(&core.indices, incoming_bond_2)?;
+        let outgoing_dim = core.dims[outgoing_axis];
+        let incoming_dim_1 = core.dims[incoming_axis_1];
+        let incoming_dim_2 = core.dims[incoming_axis_2];
+
+        let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
+            std::collections::BTreeMap::new();
+        let mut results: Vec<Option<Vec<T>>> = vec![None; candidates.len()];
+        for (candidate_index, candidate) in candidates.iter().enumerate() {
+            let key: CandidateCacheKey = (
+                input,
+                directed_edge,
+                candidate.local_coordinate,
+                candidate.incoming.clone(),
+            );
+            if let Some(cached) = self.candidate_cache.borrow().get(&key) {
+                #[cfg(test)]
+                candidate_debug_stats::record_hit();
+                results[candidate_index] = Some(cached.clone());
+                continue;
+            }
+            #[cfg(test)]
+            candidate_debug_stats::record_miss();
+            if candidate.incoming.len() != 2
+                || candidate.incoming[0].0 != incoming_edge_1
+                || candidate.incoming[1].0 != incoming_edge_2
+            {
+                return Err(TreeAciError::InternalInvariant {
+                    message: "two-incoming-edge candidate does not match the edge's incoming order",
+                });
+            }
+            groups
+                .entry(candidate.local_coordinate)
+                .or_default()
+                .push(candidate_index);
+        }
+
+        for (local_coordinate, indices) in groups {
+            let mut base_offset = 0usize;
+            for (physical_axis, &axis) in physical_axes.iter().enumerate() {
+                let wanted = (local_coordinate / physical.strides[physical_axis])
+                    % physical.dims[physical_axis];
+                base_offset += wanted * core.strides[axis];
+            }
+
+            let mut ids_1: Vec<SampleId> = Vec::new();
+            let mut position_1: HashMap<SampleId, usize> = HashMap::new();
+            let mut ids_2: Vec<SampleId> = Vec::new();
+            let mut position_2: HashMap<SampleId, usize> = HashMap::new();
+            for &candidate_index in &indices {
+                let (_, sample_1) = candidates[candidate_index].incoming[0];
+                let (_, sample_2) = candidates[candidate_index].incoming[1];
+                position_1.entry(sample_1).or_insert_with(|| {
+                    ids_1.push(sample_1);
+                    ids_1.len() - 1
+                });
+                position_2.entry(sample_2).or_insert_with(|| {
+                    ids_2.push(sample_2);
+                    ids_2.len() - 1
+                });
+            }
+
+            let mut v1_data = Vec::with_capacity(incoming_dim_1 * ids_1.len());
+            for &sample in &ids_1 {
+                let values = self.frame_values(input, incoming_edge_1, sample)?;
+                if values.len() != incoming_dim_1 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v1_data.extend(values);
+            }
+            let v1 = Matrix::from_col_major_vec(incoming_dim_1, ids_1.len(), v1_data);
+
+            let mut v2_data = Vec::with_capacity(incoming_dim_2 * ids_2.len());
+            for &sample in &ids_2 {
+                let values = self.frame_values(input, incoming_edge_2, sample)?;
+                if values.len() != incoming_dim_2 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v2_data.extend(values);
+            }
+            let v2 = Matrix::from_col_major_vec(incoming_dim_2, ids_2.len(), v2_data);
+
+            let batched = two_incoming_core_matrix_batched(
+                core,
+                outgoing_axis,
+                incoming_axis_1,
+                incoming_axis_2,
+                base_offset,
+                outgoing_dim,
+                incoming_dim_1,
+                incoming_dim_2,
+                &v1,
+                &v2,
+            )?;
+
+            for &candidate_index in &indices {
+                let (_, sample_1) = candidates[candidate_index].incoming[0];
+                let (_, sample_2) = candidates[candidate_index].incoming[1];
+                let n1 = position_1[&sample_1];
+                let n2 = position_2[&sample_2];
+                let values: Vec<T> = (0..outgoing_dim)
+                    .map(|out| batched[[out + outgoing_dim * n1, n2]])
+                    .collect();
+                let entry_bytes = values.len().saturating_mul(size_of::<T>());
+                let candidate_bytes = self.candidate_cache_bytes.get();
+                let projected = self
+                    .retained_bytes
+                    .saturating_add(candidate_bytes)
+                    .saturating_add(entry_bytes);
+                if projected <= problem.max_frame_bytes {
+                    let candidate = &candidates[candidate_index];
+                    let key: CandidateCacheKey = (
+                        input,
+                        directed_edge,
+                        candidate.local_coordinate,
+                        candidate.incoming.clone(),
+                    );
+                    self.candidate_cache_bytes
+                        .set(candidate_bytes.saturating_add(entry_bytes));
+                    self.candidate_cache
+                        .borrow_mut()
+                        .insert(key, values.clone());
+                }
+                results[candidate_index] = Some(values);
+            }
+        }
+
+        results
+            .into_iter()
+            .map(|value| {
+                value.ok_or(TreeAciError::InternalInvariant {
+                    message: "two-incoming candidate frame batching left a candidate unfilled",
+                })
+            })
+            .collect()
+    }
+```
+
+- [ ] **Step 5: Run tests to verify the new path is correct**
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames:: -- --nocapture`
+Expected: PASS, including `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges` (now genuinely exercising the new batched code, since `directed.incoming_to_from.len() == 2` on that fixture's edge `0 -> 1`) and `candidate_frames_for_edge_still_falls_back_on_three_incoming_edges` (unaffected, still scalar). If the two-incoming test fails on a value mismatch, re-check `candidate_frames_for_edge_two_incoming`'s `n1`/`n2` indexing against `two_incoming_core_matrix_batched`'s documented output layout (`out + outgoing_dim * n1`, column `n2`).
+
+- [ ] **Step 6: Update the function's doc comment**
+
+`candidate_frames_for_edge`'s doc comment (currently starting "Computes every candidate's frame vector for one input and directed edge, using the batched BLAS path ... when the edge's source node has exactly one incoming edge, and falling back to the scalar ... path ... otherwise.") needs updating to describe the new three-way dispatch. Replace the first paragraph with:
+
+```rust
+    /// Computes every candidate's frame vector for one input and directed
+    /// edge. Dispatches to a batched BLAS path when the edge's source node
+    /// has exactly one incoming edge (one `mat_mul` call per distinct
+    /// `local_coordinate`) or exactly two incoming edges (see
+    /// [`Self::candidate_frames_for_edge_two_incoming`] and
+    /// [`two_incoming_core_matrix_batched`]), and falls back to the scalar
+    /// [`Self::candidate_frame`] path (called once per candidate, still
+    /// consulting/populating `candidate_cache`) for a leaf edge (zero
+    /// incoming edges) or a node with three or more incoming edges (out of
+    /// scope for the batched paths -- see issue #671 and
+    /// `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`).
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-treeaci/src/frames.rs crates/tensor4all-treeaci/src/frames/tests/mod.rs
+git commit -m "feat(treeaci): batch candidate_frames_for_edge's two-incoming-edge branch dispatch"
+```
+
+---
+
+### Task 3: Wire into `FrameBuilder::compute_batch` (sample-materialization path)
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs` (`compute_batch`, currently lines 861-1006; insert new method `compute_batch_two_incoming` after it, before `outgoing_bond` method at line 1008)
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs` (adapt existing branch test around line 1125; add a new 3-incoming test reusing Task 2's fixture)
+
+**Interfaces:**
+- Consumes: `two_incoming_core_matrix_batched` (Task 1), `FrameBuilder::compute` (existing, for priming), `FrameBuilder::outgoing_bond` (existing), `FrameBuilder::memo` (existing field).
+- Produces: `FrameBuilder::compute_batch_two_incoming(&mut self, edge: DirectedEdgeId, samples: std::ops::Range<SampleId>) -> Result<()>` — same contract as `compute_batch`: every result lands in `self.memo[edge]`.
+
+- [ ] **Step 1: Rename the existing branch test**
+
+In `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, rename `compute_batch_falls_back_correctly_on_a_branch_edge` (around line 1125) to `compute_batch_batches_a_branch_edge_with_two_incoming_edges`. Update its doc comment and the cross-reference in `compute_batch`'s own doc comment (the one describing its dispatch) accordingly. Leave the test body's assertions unchanged for now — same rationale as Task 2 Step 1.
+
+- [ ] **Step 2: Add a 3-incoming-edges-still-scalar test for `compute_batch`**
+
+Add to `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, near the renamed test:
+
+```rust
+#[test]
+fn compute_batch_still_falls_back_on_three_incoming_edges() {
+    let input = four_arm_star_tree_for_three_incoming_fallback();
+    let problem =
+        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("4-arm star must have a directed edge 0 -> 1");
+    assert_eq!(problem.directed_edges[edge].incoming_to_from.len(), 3);
+
+    let seeds = vec![vec![0, 0, 0, 0, 0], vec![0, 0, 1, 1, 1]];
+    let (arena, _candidates) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+
+    let mut scalar_builder = build_frame_builder(&input, &problem, &arena);
+    let sample_count = arena.directed_record_count(edge).unwrap();
+    for sample in 0..sample_count {
+        scalar_builder.compute(edge, sample).unwrap();
+    }
+    let scalar_values: Vec<Vec<f64>> = (0..sample_count)
+        .map(|sample| scalar_builder.memo[edge][sample].clone().unwrap())
+        .collect();
+
+    let mut batched_builder = build_frame_builder(&input, &problem, &arena);
+    batched_builder.compute_batch(edge, 0..sample_count).unwrap();
+    let batched_values: Vec<Vec<f64>> = (0..sample_count)
+        .map(|sample| batched_builder.memo[edge][sample].clone().unwrap())
+        .collect();
+
+    assert_eq!(batched_values, scalar_values);
+}
+```
+
+- [ ] **Step 3: Run both tests to confirm current (pre-wiring) behavior**
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::compute_batch_batches_a_branch_edge_with_two_incoming_edges frames::tests::compute_batch_still_falls_back_on_three_incoming_edges -- --nocapture`
+Expected: both PASS (dispatch not yet changed).
+
+- [ ] **Step 4: Add the new orchestration method and wire the dispatch**
+
+In `crates/tensor4all-treeaci/src/frames.rs`, inside `FrameBuilder::compute_batch`, replace:
+
+```rust
+        let directed = &self.problem.directed_edges[edge];
+        if directed.incoming_to_from.len() != 1 {
+            for sample in samples {
+                self.compute(edge, sample)?;
+            }
+            return Ok(());
+        }
+        let incoming_edge = directed.incoming_to_from[0];
+```
+
+with:
+
+```rust
+        let directed = &self.problem.directed_edges[edge];
+        if directed.incoming_to_from.len() == 2 {
+            return self.compute_batch_two_incoming(edge, samples);
+        }
+        if directed.incoming_to_from.len() != 1 {
+            for sample in samples {
+                self.compute(edge, sample)?;
+            }
+            return Ok(());
+        }
+        let incoming_edge = directed.incoming_to_from[0];
+```
+
+Then insert this new method into `impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V>`, directly after `compute_batch`'s closing `}` (before `fn outgoing_bond(&self, ...)` at line 1008):
+
+```rust
+    /// Batched counterpart to [`Self::compute_batch`]'s single-incoming-edge
+    /// path, for directed edges whose source node has exactly two incoming
+    /// edges. Primes both incoming edges' needed samples via [`Self::compute`]
+    /// (as `compute_batch` already does for its one incoming edge), then
+    /// groups the pending samples by `local_coordinate` and contracts each
+    /// group via [`two_incoming_core_matrix_batched`], mirroring
+    /// [`InputFrameStore::candidate_frames_for_edge_two_incoming`]'s
+    /// structure but reading incoming frame vectors from `self.memo` instead
+    /// of a committed `InputFrameStore`.
+    fn compute_batch_two_incoming(
+        &mut self,
+        edge: DirectedEdgeId,
+        samples: std::ops::Range<SampleId>,
+    ) -> Result<()> {
+        let directed = &self.problem.directed_edges[edge];
+        let incoming_edge_1 = directed.incoming_to_from[0];
+        let incoming_edge_2 = directed.incoming_to_from[1];
+
+        let mut pending: Vec<(SampleId, ComponentSample)> = Vec::new();
+        for sample in samples {
+            if self.memo[edge][sample].is_some() {
+                continue;
+            }
+            let record = self.arena.record(edge, sample)?.clone();
+            if record.incoming.len() != 2
+                || record.incoming[0].0 != incoming_edge_1
+                || record.incoming[1].0 != incoming_edge_2
+            {
+                return Err(TreeAciError::InternalInvariant {
+                    message:
+                        "two-incoming-edge sample does not have exactly two incoming samples on the expected edges",
+                });
+            }
+            pending.push((sample, record));
+        }
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        for (_, record) in &pending {
+            self.compute(incoming_edge_1, record.incoming[0].1)?;
+            self.compute(incoming_edge_2, record.incoming[1].1)?;
+        }
+
+        let node = *self.problem.node_positions.get(&directed.from).ok_or(
+            TreeAciError::InternalInvariant {
+                message: "frame source has no prepared node position",
+            },
+        )?;
+        let core = &self.cores[node];
+        let outgoing = self.outgoing_bond(edge)?;
+        let outgoing_axis = axis_of(&core.indices, outgoing)?;
+        let physical = &self.problem.physical[node];
+        let physical_axes = physical
+            .indices
+            .iter()
+            .map(|index| axis_of(&core.indices, index))
+            .collect::<Result<Vec<_>>>()?;
+        let incoming_bond_1 = self.outgoing_bond(incoming_edge_1)?;
+        let incoming_bond_2 = self.outgoing_bond(incoming_edge_2)?;
+        let incoming_axis_1 = axis_of(&core.indices, incoming_bond_1)?;
+        let incoming_axis_2 = axis_of(&core.indices, incoming_bond_2)?;
+        let outgoing_dim = core.dims[outgoing_axis];
+        let incoming_dim_1 = core.dims[incoming_axis_1];
+        let incoming_dim_2 = core.dims[incoming_axis_2];
+
+        let mut groups: std::collections::BTreeMap<usize, Vec<(SampleId, SampleId, SampleId)>> =
+            std::collections::BTreeMap::new();
+        for (sample, record) in &pending {
+            let (_, sample_1) = record.incoming[0];
+            let (_, sample_2) = record.incoming[1];
+            groups
+                .entry(record.local_coordinate)
+                .or_default()
+                .push((*sample, sample_1, sample_2));
+        }
+
+        for (local_coordinate, group_samples) in groups {
+            let mut base_offset = 0usize;
+            for (physical_axis, &axis) in physical_axes.iter().enumerate() {
+                let wanted = (local_coordinate / physical.strides[physical_axis])
+                    % physical.dims[physical_axis];
+                base_offset += wanted * core.strides[axis];
+            }
+
+            let mut ids_1: Vec<SampleId> = Vec::new();
+            let mut position_1: HashMap<SampleId, usize> = HashMap::new();
+            let mut ids_2: Vec<SampleId> = Vec::new();
+            let mut position_2: HashMap<SampleId, usize> = HashMap::new();
+            for &(_, sample_1, sample_2) in &group_samples {
+                position_1.entry(sample_1).or_insert_with(|| {
+                    ids_1.push(sample_1);
+                    ids_1.len() - 1
+                });
+                position_2.entry(sample_2).or_insert_with(|| {
+                    ids_2.push(sample_2);
+                    ids_2.len() - 1
+                });
+            }
+
+            let mut v1_data = Vec::with_capacity(incoming_dim_1 * ids_1.len());
+            for &sample_1 in &ids_1 {
+                let values = self.memo[incoming_edge_1][sample_1].clone().ok_or(
+                    TreeAciError::InternalInvariant {
+                        message: "incoming sample frame was not memoized before batched contraction",
+                    },
+                )?;
+                if values.len() != incoming_dim_1 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v1_data.extend(values);
+            }
+            let v1 = Matrix::from_col_major_vec(incoming_dim_1, ids_1.len(), v1_data);
+
+            let mut v2_data = Vec::with_capacity(incoming_dim_2 * ids_2.len());
+            for &sample_2 in &ids_2 {
+                let values = self.memo[incoming_edge_2][sample_2].clone().ok_or(
+                    TreeAciError::InternalInvariant {
+                        message: "incoming sample frame was not memoized before batched contraction",
+                    },
+                )?;
+                if values.len() != incoming_dim_2 {
+                    return Err(TreeAciError::InternalInvariant {
+                        message: "incoming frame length differs from its bond dimension",
+                    });
+                }
+                v2_data.extend(values);
+            }
+            let v2 = Matrix::from_col_major_vec(incoming_dim_2, ids_2.len(), v2_data);
+
+            let batched = two_incoming_core_matrix_batched(
+                core,
+                outgoing_axis,
+                incoming_axis_1,
+                incoming_axis_2,
+                base_offset,
+                outgoing_dim,
+                incoming_dim_1,
+                incoming_dim_2,
+                &v1,
+                &v2,
+            )?;
+
+            for (sample, sample_1, sample_2) in group_samples {
+                let n1 = position_1[&sample_1];
+                let n2 = position_2[&sample_2];
+                let values: Vec<T> = (0..outgoing_dim)
+                    .map(|out| batched[[out + outgoing_dim * n1, n2]])
+                    .collect();
+                #[cfg(test)]
+                debug_stats::record_batched_compute_call();
+                let slot = self
+                    .memo
+                    .get_mut(edge)
+                    .and_then(|s| s.get_mut(sample))
+                    .ok_or(TreeAciError::InternalInvariant {
+                        message: "computed frame has no memoization slot",
+                    })?;
+                *slot = Some(values);
+            }
+        }
+        Ok(())
+    }
+```
+
+- [ ] **Step 5: Run tests to verify the new path is correct**
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames:: -- --nocapture`
+Expected: PASS, including `compute_batch_batches_a_branch_edge_with_two_incoming_edges` (now genuinely exercising the new code) and `compute_batch_still_falls_back_on_three_incoming_edges`. Also re-run the full crate suite once here, since `compute_batch` is used by `InputFrameStore::from_samples`/`extend`, which many other existing tests (`extend_matches_a_full_rebuild_on_the_grown_arena`, `extend_reuses_unchanged_edges_via_rc_instead_of_rebuilding_them`, etc.) depend on transitively for any fixture with a 2-incoming-edge node (e.g. `y_tree`, `star_tree_for_fallback_dispatch`):
+
+Run: `cargo test --release -p tensor4all-treeaci --no-fail-fast`
+Expected: all green, no regressions in the extend/rebuild parity tests.
+
+- [ ] **Step 6: Update `compute_batch`'s doc comment**
+
+`compute_batch`'s doc comment currently says: "using the batched BLAS path ... when `edge`'s source node has exactly one incoming edge ... and falling back to [`Self::compute`] per sample otherwise (0 or >=2 incoming edges)." Update the parenthetical to: "and falling back to [`Self::compute`] per sample otherwise (0 incoming edges, or 3+)." and add a sentence referencing the new two-incoming case and `compute_batch_two_incoming`, matching Task 2 Step 6's edit to `candidate_frames_for_edge`'s doc comment in tone.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-treeaci/src/frames.rs crates/tensor4all-treeaci/src/frames/tests/mod.rs
+git commit -m "feat(treeaci): batch compute_batch's two-incoming-edge branch dispatch"
+```
+
+---
+
+### Task 4: Full crate verification, worklog, and issue-facing measurement
+
+**Files:**
+- Test: full `tensor4all-treeaci` suite
+- Create: `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3.
+- Produces: a worklog entry following this repo's existing treeaci worklog convention (see `docs/worklogs/2026-08-18-treeaci-message-cache-prototype.md`, `docs/worklogs/2026-08-21-treeaci-message-cache-budget.md` for style/structure).
+
+- [ ] **Step 1: Full crate verification**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p tensor4all-treeaci --all-targets -- -D warnings
+cargo test --release -p tensor4all-treeaci --no-fail-fast
+cargo doc -p tensor4all-treeaci --no-deps
+```
+
+Expected: all clean/green. If clippy flags the new `HashMap<SampleId, usize>` closures (`or_insert_with` capturing `ids_1`/`ids_2` by mutable reference) with a lint about entry-API style, resolve by following clippy's suggestion rather than allowing the lint, unless the suggestion would change behavior (it should not here).
+
+- [ ] **Step 2: Measure the actual improvement**
+
+Reuse the star fixture at larger scale (mirroring the investigation's diagnostic, this time comparing the *now-fixed* `candidate_frames_for_edge` against a manual per-candidate loop over the still-unchanged `candidate_frame` scalar method, both reachable through the existing public-to-the-module API — no temporary test code needed, since both entry points are permanent). Write a small `#[ignore]`d benchmark-style test (kept this time, not reverted, since it directly answers issue #671's "Suggested next step" for a reproducible branching-tree measurement) in `crates/tensor4all-treeaci/src/frames/tests/mod.rs`:
+
+```rust
+/// Reproduces #671's core question directly inside the crate: at a
+/// 2-incoming-edge branch point, how much faster is the batched path
+/// (`candidate_frames_for_edge`, since Task 2) than looping the scalar
+/// `candidate_frame` path per candidate (the code path every branch point
+/// used before this fix, and what 3+-incoming nodes still use today)? Not
+/// run by default (`#[ignore]`): it is a timing report, not a correctness
+/// gate. Run explicitly with `--ignored --nocapture`.
+#[test]
+#[ignore]
+fn branch_point_batched_speedup_vs_scalar_at_realistic_scale() {
+    use std::time::Instant;
+
+    let s0 = DynIndex::new_dyn(1);
+    let s1 = DynIndex::new_dyn(1);
+    let m = 40usize;
+    let d = 32usize;
+    let s2 = DynIndex::new_dyn(m);
+    let s3 = DynIndex::new_dyn(m);
+    let bond01 = DynIndex::new_dyn(4);
+    let bond02 = DynIndex::new_dyn(d);
+    let bond03 = DynIndex::new_dyn(d);
+    let node0 = IdxTensor::from_dense(
+        vec![s0, bond01.clone(), bond02.clone(), bond03.clone()],
+        (0..4 * d * d).map(|v| v as f64).collect(),
+    )
+    .unwrap();
+    let node1 = IdxTensor::from_dense(vec![bond01, s1], (0..4).map(|v| v as f64).collect()).unwrap();
+    let node2 =
+        IdxTensor::from_dense(vec![bond02, s2], (0..d * m).map(|v| v as f64).collect()).unwrap();
+    let node3 =
+        IdxTensor::from_dense(vec![bond03, s3], (0..d * m).map(|v| v as f64).collect()).unwrap();
+    let star = TreeTN::from_tensors(vec![node0, node1, node2, node3], vec![0, 1, 2, 3]).unwrap();
+
+    let inputs = vec![star];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .unwrap();
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 2);
+
+    let seeds: Vec<Vec<usize>> = (0..m).map(|i| vec![0, 0, i, i]).collect();
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+
+    let incoming_a = directed.incoming_to_from[0];
+    let incoming_b = directed.incoming_to_from[1];
+    let ids_a = &candidate_sets.ids[incoming_a];
+    let ids_b = &candidate_sets.ids[incoming_b];
+    let mut candidates = Vec::new();
+    for &id_a in ids_a {
+        for &id_b in ids_b {
+            candidates.push(ComponentSample {
+                local_coordinate: 0,
+                incoming: vec![(incoming_a, id_a), (incoming_b, id_b)],
+            });
+        }
+    }
+
+    let batched_start = Instant::now();
+    let batched = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .unwrap();
+    let batched_elapsed = batched_start.elapsed();
+
+    let scalar_start = Instant::now();
+    let scalar: Vec<Vec<f64>> = candidates
+        .iter()
+        .map(|candidate| {
+            frames
+                .candidate_frame(&inputs, &problem, 0, edge, candidate)
+                .unwrap()
+        })
+        .collect();
+    let scalar_elapsed = scalar_start.elapsed();
+
+    assert_eq!(batched, scalar);
+    eprintln!(
+        "batched (Task 2 fix): {batched_elapsed:?}\nscalar (old fallback, still used for 3+ incoming): {scalar_elapsed:?}\nspeedup: {:.2}x",
+        scalar_elapsed.as_secs_f64() / batched_elapsed.as_secs_f64()
+    );
+}
+```
+
+Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::branch_point_batched_speedup_vs_scalar_at_realistic_scale -- --ignored --nocapture`
+
+Record the printed speedup number for the worklog (Step 3). Note this test intentionally shares `assert_eq!(batched, scalar)` as a correctness belt-and-braces check even though Tasks 1-3's tests already cover this; keep it since it's the number that answers #671.
+
+- [ ] **Step 3: Write the worklog**
+
+Create `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md` with: the root cause (dispatch condition in `frames.rs`, cross-referencing `docs/worklogs/2026-08-18-treeaci-message-cache-prototype.md`'s prior note that this was left unresolved), the matched-FLOP diagnostic numbers from the investigation (1.76x/3.61x/4.17x at D=64/256/1024), the fix (this plan's Tasks 1-3), and the Step 2 measurement's actual speedup number -- fill in the real number from the run, do not estimate it. Follow the existing worklog files' structure (problem statement, root cause, fix, verification, results table).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-treeaci/src/frames/tests/mod.rs docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md
+git commit -m "test(treeaci): add branch-point batched-vs-scalar speedup measurement and worklog for #671"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 covers the primitive; Tasks 2-3 cover both call sites the investigation identified (`candidate_frames_for_edge` and `compute_batch`); Task 4 covers full verification plus the issue-facing measurement/worklog the investigation promised. The 0-/3+-incoming scalar fallback is explicitly left untouched and pinned by new tests (Task 2 Step 2, Task 3 Step 2) rather than silently left unverified.
+- **Placeholder scan:** every step has literal, complete code; no "TBD"/"similar to Task N" shortcuts.
+- **Type consistency:** `two_incoming_core_matrix_batched`'s signature (Task 1) is used identically in Task 2's `candidate_frames_for_edge_two_incoming` and Task 3's `compute_batch_two_incoming`. `SampleId = usize` (from `samples.rs`) is used consistently for `position_1`/`position_2`/`ids_1`/`ids_2` across both call sites.
+- **Not in scope:** 3+-incoming-edge nodes, changing `accumulate_incoming`/`contract_prepared_core` themselves, and any change to `local_update.rs`/`schedule.rs` (the investigation found the bottleneck entirely inside `frames.rs`'s dispatch, not in how callers use it).

--- a/docs/superpowers/plans/2026-08-22-treeaci-branch-batched-frames.md
+++ b/docs/superpowers/plans/2026-08-22-treeaci-branch-batched-frames.md
@@ -53,7 +53,7 @@ Every task below ends with, at minimum: `cargo fmt --all -- --check` clean and `
 - Produces: `fn two_incoming_core_matrix_batched<T: TreeAciScalar>(core: &PreparedCore<T>, outgoing_axis: usize, incoming_axis_1: usize, incoming_axis_2: usize, physical_base_offset: usize, outgoing_dim: usize, incoming_dim_1: usize, incoming_dim_2: usize, v1: &Matrix<T>, v2: &Matrix<T>) -> Result<Matrix<T>>` — `v1` is `incoming_dim_1 x n1`, `v2` is `incoming_dim_2 x n2`; returns a `(outgoing_dim * n1) x n2` matrix where `result[[outgoing_dim * n1_index + out, n2_index]]` equals what `contract_prepared_core` would produce at `out` for the `(n1_index, n2_index)` pair.
 - Consumes: existing `single_incoming_core_matrix`, `contract_prepared_core_batched`, `PreparedCore` (all already in `frames.rs`).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, near `star_tree_for_fallback_dispatch`:
 
@@ -144,12 +144,12 @@ fn two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair() {
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair`
 Expected: FAIL to compile — `two_incoming_core_matrix_batched` does not exist yet.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 Insert into `crates/tensor4all-treeaci/src/frames.rs`, immediately after `contract_prepared_core_batched`'s closing `}` (currently line 1165) and before `fn outgoing_bond<'a, V: TreeAciNode>`:
 
@@ -200,12 +200,12 @@ fn two_incoming_core_matrix_batched<T: TreeAciScalar>(
 
 Also make `contract_prepared_core`, `outgoing_bond`, `axis_of`, and `prepare_cores` reachable from the test module at their current `pub(crate)`/private visibility — they already are, since `frames/tests/mod.rs` uses `super::` to reach other private items in this file (see existing use of `super::InputFrameStore`, `super::prepare_cores` pattern already present in `build_frame_builder`). No visibility changes should be needed; if the compiler disagrees, add `pub(crate)` (or `pub(super)`) only to the specific item that fails to resolve, not broadly.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair -- --nocapture`
 Expected: PASS. If it fails with a numeric mismatch (not a compile error), the bug is in the offset/reshape bookkeeping in `two_incoming_core_matrix_batched` — check `stride_2` is `core.strides[incoming_axis_2]` (not axis_1), and that `stage1_data` is appended in `i2` order (so `stage1_matrix`'s columns are indexed by `i2`, matching `contract_prepared_core_batched`'s expectation that its second argument's rows are the axis being contracted).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 cargo fmt --all
@@ -225,13 +225,13 @@ git commit -m "feat(treeaci): add batched two-incoming-edge core contraction pri
 - Consumes: `two_incoming_core_matrix_batched` (Task 1), `InputFrameStore::frame_values` (existing), `InputFrameStore::candidate_cache`/`candidate_cache_bytes` (existing fields).
 - Produces: `InputFrameStore::candidate_frames_for_edge_two_incoming(&self, inputs, problem, input, directed_edge, candidates: &[ComponentSample]) -> Result<Vec<Vec<T>>>` — same contract as `candidate_frames_for_edge` (one frame vector per input candidate, same order), used only when the edge has exactly two incoming edges.
 
-- [ ] **Step 1: Adapt the existing branch test to assert against the new path (still red — the code hasn't changed yet)**
+- [x] **Step 1: Adapt the existing branch test to assert against the new path (still red — the code hasn't changed yet)**
 
 In `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, rename
 `candidate_frames_for_edge_falls_back_on_a_branch_edge_with_two_incoming_edges`
 to `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges` and update its doc comment (the one above `star_tree_for_fallback_dispatch` references it by name, at line 583 — update that cross-reference too). The test body's assertions (`dispatched == scalar`) stay exactly as they are — they already compare `candidate_frames_for_edge`'s output against `candidate_frame`'s scalar output, which is exactly what proves the new batched path is correct once wired in. This step is a rename/doc-only change; it does not need to "fail" first since the behavior under test doesn't change yet — skip to Step 2.
 
-- [ ] **Step 2: Write the new 3-incoming-edges-still-scalar fixture and test**
+- [x] **Step 2: Write the new 3-incoming-edges-still-scalar fixture and test**
 
 Add to `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, after the (renamed) two-incoming test:
 
@@ -314,12 +314,12 @@ fn candidate_frames_for_edge_still_falls_back_on_three_incoming_edges() {
 }
 ```
 
-- [ ] **Step 3: Run both tests to confirm current (pre-wiring) behavior**
+- [x] **Step 3: Run both tests to confirm current (pre-wiring) behavior**
 
 Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges frames::tests::candidate_frames_for_edge_still_falls_back_on_three_incoming_edges -- --nocapture`
 Expected: both PASS already (the dispatch hasn't changed yet, so both still exercise the old scalar fallback and trivially agree with themselves). This confirms the test fixtures compile and are meaningful before the dispatch change makes the two-incoming one actually exercise new code.
 
-- [ ] **Step 4: Add the new orchestration method and wire the dispatch**
+- [x] **Step 4: Add the new orchestration method and wire the dispatch**
 
 In `crates/tensor4all-treeaci/src/frames.rs`, replace the fallback check at the top of `candidate_frames_for_edge` (currently):
 
@@ -560,12 +560,12 @@ Then insert this new method into the `impl<T: TreeAciScalar> InputFrameStore<T>`
     }
 ```
 
-- [ ] **Step 5: Run tests to verify the new path is correct**
+- [x] **Step 5: Run tests to verify the new path is correct**
 
 Run: `cargo test --release -p tensor4all-treeaci --lib frames:: -- --nocapture`
 Expected: PASS, including `candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges` (now genuinely exercising the new batched code, since `directed.incoming_to_from.len() == 2` on that fixture's edge `0 -> 1`) and `candidate_frames_for_edge_still_falls_back_on_three_incoming_edges` (unaffected, still scalar). If the two-incoming test fails on a value mismatch, re-check `candidate_frames_for_edge_two_incoming`'s `n1`/`n2` indexing against `two_incoming_core_matrix_batched`'s documented output layout (`out + outgoing_dim * n1`, column `n2`).
 
-- [ ] **Step 6: Update the function's doc comment**
+- [x] **Step 6: Update the function's doc comment**
 
 `candidate_frames_for_edge`'s doc comment (currently starting "Computes every candidate's frame vector for one input and directed edge, using the batched BLAS path ... when the edge's source node has exactly one incoming edge, and falling back to the scalar ... path ... otherwise.") needs updating to describe the new three-way dispatch. Replace the first paragraph with:
 
@@ -583,7 +583,7 @@ Expected: PASS, including `candidate_frames_for_edge_batches_a_branch_edge_with_
     /// `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`).
 ```
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 cargo fmt --all
@@ -603,11 +603,11 @@ git commit -m "feat(treeaci): batch candidate_frames_for_edge's two-incoming-edg
 - Consumes: `two_incoming_core_matrix_batched` (Task 1), `FrameBuilder::compute` (existing, for priming), `FrameBuilder::outgoing_bond` (existing), `FrameBuilder::memo` (existing field).
 - Produces: `FrameBuilder::compute_batch_two_incoming(&mut self, edge: DirectedEdgeId, samples: std::ops::Range<SampleId>) -> Result<()>` — same contract as `compute_batch`: every result lands in `self.memo[edge]`.
 
-- [ ] **Step 1: Rename the existing branch test**
+- [x] **Step 1: Rename the existing branch test**
 
 In `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, rename `compute_batch_falls_back_correctly_on_a_branch_edge` (around line 1125) to `compute_batch_batches_a_branch_edge_with_two_incoming_edges`. Update its doc comment and the cross-reference in `compute_batch`'s own doc comment (the one describing its dispatch) accordingly. Leave the test body's assertions unchanged for now — same rationale as Task 2 Step 1.
 
-- [ ] **Step 2: Add a 3-incoming-edges-still-scalar test for `compute_batch`**
+- [x] **Step 2: Add a 3-incoming-edges-still-scalar test for `compute_batch`**
 
 Add to `crates/tensor4all-treeaci/src/frames/tests/mod.rs`, near the renamed test:
 
@@ -647,12 +647,12 @@ fn compute_batch_still_falls_back_on_three_incoming_edges() {
 }
 ```
 
-- [ ] **Step 3: Run both tests to confirm current (pre-wiring) behavior**
+- [x] **Step 3: Run both tests to confirm current (pre-wiring) behavior**
 
 Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::compute_batch_batches_a_branch_edge_with_two_incoming_edges frames::tests::compute_batch_still_falls_back_on_three_incoming_edges -- --nocapture`
 Expected: both PASS (dispatch not yet changed).
 
-- [ ] **Step 4: Add the new orchestration method and wire the dispatch**
+- [x] **Step 4: Add the new orchestration method and wire the dispatch**
 
 In `crates/tensor4all-treeaci/src/frames.rs`, inside `FrameBuilder::compute_batch`, replace:
 
@@ -853,7 +853,7 @@ Then insert this new method into `impl<T: TreeAciScalar, V: TreeAciNode> FrameBu
     }
 ```
 
-- [ ] **Step 5: Run tests to verify the new path is correct**
+- [x] **Step 5: Run tests to verify the new path is correct**
 
 Run: `cargo test --release -p tensor4all-treeaci --lib frames:: -- --nocapture`
 Expected: PASS, including `compute_batch_batches_a_branch_edge_with_two_incoming_edges` (now genuinely exercising the new code) and `compute_batch_still_falls_back_on_three_incoming_edges`. Also re-run the full crate suite once here, since `compute_batch` is used by `InputFrameStore::from_samples`/`extend`, which many other existing tests (`extend_matches_a_full_rebuild_on_the_grown_arena`, `extend_reuses_unchanged_edges_via_rc_instead_of_rebuilding_them`, etc.) depend on transitively for any fixture with a 2-incoming-edge node (e.g. `y_tree`, `star_tree_for_fallback_dispatch`):
@@ -861,11 +861,11 @@ Expected: PASS, including `compute_batch_batches_a_branch_edge_with_two_incoming
 Run: `cargo test --release -p tensor4all-treeaci --no-fail-fast`
 Expected: all green, no regressions in the extend/rebuild parity tests.
 
-- [ ] **Step 6: Update `compute_batch`'s doc comment**
+- [x] **Step 6: Update `compute_batch`'s doc comment**
 
 `compute_batch`'s doc comment currently says: "using the batched BLAS path ... when `edge`'s source node has exactly one incoming edge ... and falling back to [`Self::compute`] per sample otherwise (0 or >=2 incoming edges)." Update the parenthetical to: "and falling back to [`Self::compute`] per sample otherwise (0 incoming edges, or 3+)." and add a sentence referencing the new two-incoming case and `compute_batch_two_incoming`, matching Task 2 Step 6's edit to `candidate_frames_for_edge`'s doc comment in tone.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 cargo fmt --all
@@ -885,7 +885,7 @@ git commit -m "feat(treeaci): batch compute_batch's two-incoming-edge branch dis
 - Consumes: everything from Tasks 1-3.
 - Produces: a worklog entry following this repo's existing treeaci worklog convention (see `docs/worklogs/2026-08-18-treeaci-message-cache-prototype.md`, `docs/worklogs/2026-08-21-treeaci-message-cache-budget.md` for style/structure).
 
-- [ ] **Step 1: Full crate verification**
+- [x] **Step 1: Full crate verification**
 
 ```bash
 cargo fmt --all -- --check
@@ -896,7 +896,7 @@ cargo doc -p tensor4all-treeaci --no-deps
 
 Expected: all clean/green. If clippy flags the new `HashMap<SampleId, usize>` closures (`or_insert_with` capturing `ids_1`/`ids_2` by mutable reference) with a lint about entry-API style, resolve by following clippy's suggestion rather than allowing the lint, unless the suggestion would change behavior (it should not here).
 
-- [ ] **Step 2: Measure the actual improvement**
+- [x] **Step 2: Measure the actual improvement**
 
 Reuse the star fixture at larger scale (mirroring the investigation's diagnostic, this time comparing the *now-fixed* `candidate_frames_for_edge` against a manual per-candidate loop over the still-unchanged `candidate_frame` scalar method, both reachable through the existing public-to-the-module API — no temporary test code needed, since both entry points are permanent). Write a small `#[ignore]`d benchmark-style test (kept this time, not reverted, since it directly answers issue #671's "Suggested next step" for a reproducible branching-tree measurement) in `crates/tensor4all-treeaci/src/frames/tests/mod.rs`:
 
@@ -992,11 +992,11 @@ Run: `cargo test --release -p tensor4all-treeaci --lib frames::tests::branch_poi
 
 Record the printed speedup number for the worklog (Step 3). Note this test intentionally shares `assert_eq!(batched, scalar)` as a correctness belt-and-braces check even though Tasks 1-3's tests already cover this; keep it since it's the number that answers #671.
 
-- [ ] **Step 3: Write the worklog**
+- [x] **Step 3: Write the worklog**
 
 Create `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md` with: the root cause (dispatch condition in `frames.rs`, cross-referencing `docs/worklogs/2026-08-18-treeaci-message-cache-prototype.md`'s prior note that this was left unresolved), the matched-FLOP diagnostic numbers from the investigation (1.76x/3.61x/4.17x at D=64/256/1024), the fix (this plan's Tasks 1-3), and the Step 2 measurement's actual speedup number -- fill in the real number from the run, do not estimate it. Follow the existing worklog files' structure (problem statement, root cause, fix, verification, results table).
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 cargo fmt --all

--- a/docs/superpowers/plans/2026-08-22-treetn-branch-message-raw-path.md
+++ b/docs/superpowers/plans/2026-08-22-treetn-branch-message-raw-path.md
@@ -1,0 +1,735 @@
+# TreeTNCachedEvaluator Branch-Node Raw Message Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the 25.84x wall-time gap (measured, see below) that a single degree-3 branch node introduces into `TreeTNCachedEvaluator::evaluate_batched`'s realistic floating-zone-walk call pattern, by giving the exactly-two-children case a raw-array fast path analogous to the existing exactly-one-child (`try_compute_chain_message_raw`) path, instead of falling through to the generic `compute_stacked_message` (`IdxTensor` + `contract_with_options`) path.
+
+**Architecture:** Add `BranchContractionSpec` + `grouped_branch_message_contraction` (mirroring `ChainContractionSpec` + `grouped_chain_message_contraction`), computed in two BLAS/vectorized steps per physical-value group instead of one, because this evaluator's points are independent per-point assignments (not a cartesian product like the `tensor4all-treeaci` fix): Step A folds in child 1 via one `mat_mul_owned` call per physical-value group (T sliced at that physical value is shared across the group, so all points' child-1 columns batch into one matmul, exactly like the chain kernel); Step B folds in child 2 via a vectorized accumulate loop over `child_dim_2` (this step cannot be a single shared-matrix matmul, since child 2's contribution differs per point), which is still allocation-free, function-call-free array arithmetic instead of `contract_with_options`'s generic per-call `IdxTensor` construction and n-ary contraction planning. Add `try_compute_branch_message_raw` / `_complex_raw` (mirroring the chain raw functions) and wire them into `get_or_compute_node_message` as a new attempt between the existing chain attempt and the `compute_stacked_message` fallback, for both the real and complex branches. Nodes with 0, 1, or 3+ children are untouched.
+
+**Tech Stack:** Rust, `tensor4all_tensorbackend::{Matrix, mat_mul_owned, BlasMul}` (already used by the existing chain kernel).
+
+**Spec:** This plan's own "Architecture" section, empirically validated in-session: `diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk` (temporary, added to `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`'s test module) measured a 16-site chain (bond=128) at 83.7ms vs a same-size comb tree (one degree-3 hub, three 5-site arms, bond=128) at 2.16s for the same `NSEARCH=5`, `MAX_SWEEPS=100` floating-zone walk -- 25.84x, at a scale close to the real gw-rs downstream workload (observed bond ~90). This follows on from `tensor4all-rs#671`/`docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`, which fixed an analogous but structurally distinct bug in a different crate (`tensor4all-treeaci/frames.rs`) that turned out not to be the dominant cost once `aci_global_guard=true` routes most evaluation through this evaluator instead.
+
+## Global Constraints
+
+- Crate-scoped commands only (`--manifest-path crates/tensor4all-treetn/Cargo.toml` or `-p tensor4all-treetn`); do not build the full workspace.
+- `cargo test --release` for this crate (debug-mode is slow for these fixtures).
+- No `unwrap()`/`expect()` in library code (test code may use them, matching existing style in this file's `tests` module).
+- `cargo fmt --all` before considering any task done.
+- Every new raw path must be covered by a test asserting exact equality against the untouched generic `compute_stacked_message` path's result, mirroring this file's own `raw_chain_message_matches_generic_contraction` / `raw_complex_chain_message_matches_generic_contraction` convention.
+- Do not touch `try_compute_chain_message_raw`, `grouped_chain_message_contraction`, `compute_stacked_message`, or the 0-/1-/3+-child dispatch behavior -- this plan only adds a new attempt for exactly 2 children, inserted before the generic fallback.
+- Do not touch `CHAIN_BLAS_WORK_THRESHOLD` / `CHAIN_BLAS_MIN_GROUP_POINTS` or the chain path's own scalar-fallback thresholds; add separate constants for the branch path so neither path's tuning affects the other.
+
+---
+
+## File Structure
+
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`
+  - New `BranchContractionSpec` struct + `BRANCH_BLAS_WORK_THRESHOLD` / `BRANCH_BLAS_MIN_GROUP_POINTS` constants, placed near `ChainContractionSpec`.
+  - New `scalar_branch_message_contraction` (naive reference, mirrors `scalar_chain_message_contraction`) and `grouped_branch_message_contraction` (BLAS/vectorized path), placed near `grouped_chain_message_contraction`.
+  - New methods `try_compute_branch_message_raw` / `try_compute_branch_message_complex_raw` on `TreeTNCachedEvaluator`, placed after `try_compute_chain_message_complex_raw`.
+  - Dispatch edits inside `get_or_compute_node_message` (both the complex and real branches), inserting a `try_compute_branch_message_*_raw` attempt between the chain attempt and `compute_stacked_message`.
+  - Test module: new fixtures/tests (Task 3), and the existing temporary diagnostic test updated in place once the fix lands (Task 4) rather than reverted, mirroring how `frames.rs`'s equivalent diagnostic became a kept measurement.
+
+## Global Constraints Recap for Every Task
+
+Every task below ends with, at minimum: `cargo fmt --all -- --check` clean and `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator:: --no-fail-fast` green, before moving to the next task.
+
+---
+
+### Task 1: `BranchContractionSpec` + `grouped_branch_message_contraction` (real-valued)
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` (insert near `ChainContractionSpec`/`grouped_chain_message_contraction`)
+- Test: same file's `tests` module
+
+**Interfaces:**
+- Produces:
+  ```rust
+  #[derive(Clone, Copy, Debug)]
+  struct BranchContractionSpec {
+      strides: [usize; 4],
+      physical_axis: usize,
+      parent_axis: usize,
+      child_axis_1: usize,
+      child_axis_2: usize,
+      parent_dim: usize,
+      child_dim_1: usize,
+      child_dim_2: usize,
+  }
+
+  fn grouped_branch_message_contraction<T>(
+      spec: BranchContractionSpec,
+      raw: &[T],
+      physical_values: &[usize],
+      child1_columns: &[T],
+      child2_columns: &[T],
+  ) -> Result<Vec<T>>
+  where
+      T: BlasMul + Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>;
+  ```
+  `child1_columns` is `point_count * child_dim_1` (point-major, i.e. point `p`'s column is `child1_columns[p*child_dim_1..(p+1)*child_dim_1]`, matching `try_compute_chain_message_raw`'s existing `child_columns` convention). Same for `child2_columns` with `child_dim_2`. Returns `point_count * parent_dim` (point-major, matching `grouped_chain_message_contraction`'s output convention exactly, since callers treat both outputs identically).
+- Consumes: `Matrix`, `mat_mul_owned` (`tensor4all_tensorbackend`, already imported in this file).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module, near `grouped_chain_contraction_matches_scalar_reference_for_real_values`:
+
+```rust
+#[test]
+fn grouped_branch_contraction_matches_direct_reference_for_real_values() {
+    // 2x2x2x2 tensor (parent=2, child1=2, child2=2, physical=2), axis order
+    // [physical, parent, child1, child2] so strides are trivial to hand-check:
+    // strides = [1, 2, 4, 8].
+    let raw: Vec<f64> = (0..16).map(|v| v as f64 + 1.0).collect();
+    let spec = BranchContractionSpec {
+        strides: [1, 2, 4, 8],
+        physical_axis: 0,
+        parent_axis: 1,
+        child_axis_1: 2,
+        child_axis_2: 3,
+        parent_dim: 2,
+        child_dim_1: 2,
+        child_dim_2: 2,
+    };
+    // 3 points: point 0 at physical=0, points 1-2 at physical=1 (a mixed
+    // group split so the BLAS path -- once it engages above its point-count
+    // threshold -- and the scalar path are both exercised across this
+    // suite's other size variants; this test itself stays small enough to
+    // hand-verify and therefore always takes the scalar branch).
+    let physical_values = vec![0usize, 1, 1];
+    let child1_columns: Vec<f64> = vec![1.0, 0.5, /*pt0*/ 2.0, 1.0, /*pt1*/ 0.25, 3.0 /*pt2*/];
+    let child2_columns: Vec<f64> = vec![1.0, 1.0, /*pt0*/ 0.5, 2.0, /*pt1*/ 1.5, 0.5 /*pt2*/];
+
+    let actual = grouped_branch_message_contraction(
+        spec,
+        &raw,
+        &physical_values,
+        &child1_columns,
+        &child2_columns,
+    )
+    .unwrap();
+
+    // Direct reference: message[parent,p] = sum_{c1,c2} raw[v,parent,c1,c2] * child1[c1,p] * child2[c2,p]
+    let mut expected = vec![0.0f64; 3 * 2];
+    for (p, &v) in physical_values.iter().enumerate() {
+        for parent in 0..2 {
+            let mut sum = 0.0;
+            for c1 in 0..2 {
+                for c2 in 0..2 {
+                    let flat = v + 2 * parent + 4 * c1 + 8 * c2;
+                    sum += raw[flat] * child1_columns[p * 2 + c1] * child2_columns[p * 2 + c2];
+                }
+            }
+            expected[p * 2 + parent] = sum;
+        }
+    }
+    assert_eq!(actual, expected);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::grouped_branch_contraction_matches_direct_reference_for_real_values`
+Expected: FAIL to compile -- `BranchContractionSpec`/`grouped_branch_message_contraction` do not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert near `ChainContractionSpec` (after its definition):
+
+```rust
+/// Minimum scalar multiply count / group size before the backend setup cost
+/// is amortized by the grouped branch kernel, mirroring `CHAIN_BLAS_WORK_THRESHOLD`
+/// / `CHAIN_BLAS_MIN_GROUP_POINTS` but tuned independently: a branch step
+/// does two contractions per group instead of one, so its fixed per-call
+/// setup cost differs from the chain kernel's.
+const BRANCH_BLAS_WORK_THRESHOLD: usize = 4096;
+const BRANCH_BLAS_MIN_GROUP_POINTS: usize = 4;
+
+#[derive(Clone, Copy, Debug)]
+struct BranchContractionSpec {
+    strides: [usize; 4],
+    physical_axis: usize,
+    parent_axis: usize,
+    child_axis_1: usize,
+    child_axis_2: usize,
+    parent_dim: usize,
+    child_dim_1: usize,
+    child_dim_2: usize,
+}
+```
+
+Insert near `grouped_chain_message_contraction` (after it):
+
+```rust
+fn scalar_branch_message_contraction<T>(
+    spec: BranchContractionSpec,
+    raw: &[T],
+    physical_values: &[usize],
+    child1_columns: &[T],
+    child2_columns: &[T],
+) -> Result<Vec<T>>
+where
+    T: Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let BranchContractionSpec {
+        strides,
+        physical_axis,
+        parent_axis,
+        child_axis_1,
+        child_axis_2,
+        parent_dim,
+        child_dim_1,
+        child_dim_2,
+    } = spec;
+    let point_count = physical_values.len();
+    let mut output = vec![T::default(); point_count * parent_dim];
+    for (point, &physical_value) in physical_values.iter().enumerate() {
+        for parent in 0..parent_dim {
+            let mut sum = T::default();
+            for c1 in 0..child_dim_1 {
+                let child1_value = child1_columns[point * child_dim_1 + c1];
+                for c2 in 0..child_dim_2 {
+                    let child2_value = child2_columns[point * child_dim_2 + c2];
+                    let mut axis_values = [0usize; 4];
+                    axis_values[physical_axis] = physical_value;
+                    axis_values[parent_axis] = parent;
+                    axis_values[child_axis_1] = c1;
+                    axis_values[child_axis_2] = c2;
+                    let flat = axis_values[0] * strides[0]
+                        + axis_values[1] * strides[1]
+                        + axis_values[2] * strides[2]
+                        + axis_values[3] * strides[3];
+                    sum += *raw.get(flat).ok_or_else(|| {
+                        anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                    })? * child1_value
+                        * child2_value;
+                }
+            }
+            output[point * parent_dim + parent] = sum;
+        }
+    }
+    Ok(output)
+}
+
+/// Contracts a branch node's raw tensor data against two children's
+/// already-computed raw message columns, generalizing
+/// [`grouped_chain_message_contraction`] from one child to two.
+///
+/// Unlike the cartesian-product batching in `tensor4all-treeaci/frames.rs`'s
+/// analogous fix, this evaluator's `points` are independent per-point
+/// assignments (point `p` names one specific `(child1_assignment,
+/// child2_assignment)` pair, not every combination), so only the FIRST
+/// child's contraction reduces to a single shared-matrix `mat_mul_owned`
+/// call per physical-value group (the node's raw tensor slice at that
+/// physical value is the same for every point in the group, so all of the
+/// group's child-1 columns can be batched against it in one matmul). The
+/// second child's contraction cannot share a single matrix across points
+/// this way -- the intermediate from step one already differs per point --
+/// so it is folded in via a vectorized accumulate loop over `child_dim_2`
+/// instead: still allocation-free, per-element-function-call-free array
+/// arithmetic, just not a single BLAS call.
+fn grouped_branch_message_contraction<T>(
+    spec: BranchContractionSpec,
+    raw: &[T],
+    physical_values: &[usize],
+    child1_columns: &[T],
+    child2_columns: &[T],
+) -> Result<Vec<T>>
+where
+    T: BlasMul + Copy + Default + std::ops::AddAssign + std::ops::Mul<Output = T>,
+{
+    let BranchContractionSpec {
+        strides,
+        physical_axis,
+        parent_axis,
+        child_axis_1,
+        child_axis_2,
+        parent_dim,
+        child_dim_1,
+        child_dim_2,
+    } = spec;
+    let point_count = physical_values.len();
+    anyhow::ensure!(
+        child1_columns.len() == point_count * child_dim_1,
+        "branch child-1 message length {} does not match {} points x {} child values",
+        child1_columns.len(),
+        point_count,
+        child_dim_1
+    );
+    anyhow::ensure!(
+        child2_columns.len() == point_count * child_dim_2,
+        "branch child-2 message length {} does not match {} points x {} child values",
+        child2_columns.len(),
+        point_count,
+        child_dim_2
+    );
+
+    if point_count < 2 * BRANCH_BLAS_MIN_GROUP_POINTS {
+        return scalar_branch_message_contraction(
+            spec,
+            raw,
+            physical_values,
+            child1_columns,
+            child2_columns,
+        );
+    }
+
+    let mut groups = HashMap::<usize, Vec<usize>>::new();
+    for (point, &physical_value) in physical_values.iter().enumerate() {
+        groups.entry(physical_value).or_default().push(point);
+    }
+    let scalar_work = parent_dim * child_dim_1 * child_dim_2 * point_count;
+    if scalar_work < BRANCH_BLAS_WORK_THRESHOLD
+        || groups.len() > 8
+        || groups
+            .values()
+            .any(|points| points.len() < BRANCH_BLAS_MIN_GROUP_POINTS)
+    {
+        return scalar_branch_message_contraction(
+            spec,
+            raw,
+            physical_values,
+            child1_columns,
+            child2_columns,
+        );
+    }
+
+    let mut output = vec![T::default(); point_count * parent_dim];
+    for (physical_value, points) in groups {
+        // Step A: fold in child 1 via one matmul for the whole group. `left`
+        // is (parent_dim*child_dim_2) x child_dim_1, laid out so child_dim_1
+        // is the trailing (column) axis -- child2 rides along in "rows",
+        // ordered slower than parent so a fixed c2 selects a contiguous
+        // parent_dim-length row block within each column below.
+        let left_len = parent_dim * child_dim_2 * child_dim_1;
+        let mut left = vec![T::default(); left_len];
+        for c1 in 0..child_dim_1 {
+            for c2 in 0..child_dim_2 {
+                for parent in 0..parent_dim {
+                    let mut axis_values = [0usize; 4];
+                    axis_values[physical_axis] = physical_value;
+                    axis_values[parent_axis] = parent;
+                    axis_values[child_axis_1] = c1;
+                    axis_values[child_axis_2] = c2;
+                    let flat = axis_values[0] * strides[0]
+                        + axis_values[1] * strides[1]
+                        + axis_values[2] * strides[2]
+                        + axis_values[3] * strides[3];
+                    let left_row = parent + parent_dim * c2;
+                    let left_offset = left_row + parent_dim * child_dim_2 * c1;
+                    left[left_offset] = *raw.get(flat).ok_or_else(|| {
+                        anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                    })?;
+                }
+            }
+        }
+        let mut right = Vec::with_capacity(child_dim_1 * points.len());
+        for &point in &points {
+            let start = point * child_dim_1;
+            right.extend_from_slice(&child1_columns[start..start + child_dim_1]);
+        }
+        let intermediate = mat_mul_owned(
+            Matrix::from_col_major_vec(parent_dim * child_dim_2, child_dim_1, left),
+            Matrix::from_col_major_vec(child_dim_1, points.len(), right),
+        )
+        .map_err(anyhow::Error::from)?;
+        let intermediate = intermediate.as_col_major_slice();
+
+        // Step B: fold in child 2 via a vectorized accumulate over child_dim_2
+        // -- the intermediate's "rows" already interleave parent (fast) and
+        // c2 (slow) per group column, so for a fixed c2 the parent_dim-length
+        // slice at rows [c2*parent_dim, (c2+1)*parent_dim) within each
+        // group-column is contiguous.
+        for (column, &point) in points.iter().enumerate() {
+            let column_base = column * parent_dim * child_dim_2;
+            let destination = point * parent_dim;
+            for c2 in 0..child_dim_2 {
+                let child2_value = child2_columns[point * child_dim_2 + c2];
+                let row_base = column_base + c2 * parent_dim;
+                for parent in 0..parent_dim {
+                    output[destination + parent] += intermediate[row_base + parent] * child2_value;
+                }
+            }
+        }
+    }
+    Ok(output)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::grouped_branch_contraction_matches_direct_reference_for_real_values -- --nocapture`
+Expected: PASS (this small test always takes the scalar fallback since `point_count=3 < 2*BRANCH_BLAS_MIN_GROUP_POINTS=8`, so it validates `scalar_branch_message_contraction`'s indexing first).
+
+- [ ] **Step 5: Add a large-group test that forces the BLAS path, and a complex-value variant**
+
+Mirror `grouped_chain_contraction_large_real_groups_match_scalar_reference` / `grouped_chain_contraction_large_complex_groups_match_scalar_reference`: build a `BranchContractionSpec` with `parent_dim`/`child_dim_1`/`child_dim_2` large enough that `scalar_work >= BRANCH_BLAS_WORK_THRESHOLD` and at least one physical-value group with `>= BRANCH_BLAS_MIN_GROUP_POINTS` points (e.g. `parent_dim=8, child_dim_1=8, child_dim_2=8`, physical dim 2, `point_count=40` split across the 2 physical values), random `f64` raw/child columns via `rand::rngs::StdRng` (seeded, matching this file's existing test RNG usage), and assert `grouped_branch_message_contraction(...)` equals `scalar_branch_message_contraction(...)` (the untouched reference) element-wise via `assert_eq!` for `f64`, or `Complex64` with the same structure for the complex variant (`T: BlasMul` must hold for `Complex64` too -- confirm by checking `grouped_chain_contraction_matches_scalar_reference_for_complex_values`'s existing pattern and mirror its `Complex64` construction).
+
+- [ ] **Step 6: Run full test module, commit**
+
+```bash
+cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator:: --no-fail-fast
+cargo fmt --all
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): add batched two-child branch message contraction primitive"
+```
+
+---
+
+### Task 2: `try_compute_branch_message_raw` / `_complex_raw` + dispatch wiring
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` (new methods after `try_compute_chain_message_complex_raw`; dispatch edits inside `get_or_compute_node_message`, both the `tensor_is_complex` branch around line 2001 and the real branch around line 2034 -- exact line numbers will have shifted after Task 1's insertion, locate by function name)
+
+**Interfaces:**
+- Produces:
+  ```rust
+  fn try_compute_branch_message_raw(
+      &self,
+      node: &V,
+      values: ColMajorArrayRef<'_, usize>,
+      points: &[usize],
+      plan: &RootedMessagePlan<V>,
+      assignment_batches: &HashMap<V, AssignmentBatch>,
+      messages: &HashMap<V, StackedMessage>,
+  ) -> Result<Option<Vec<f64>>>
+
+  fn try_compute_branch_message_complex_raw(
+      &self,
+      node: &V,
+      values: ColMajorArrayRef<'_, usize>,
+      points: &[usize],
+      plan: &RootedMessagePlan<V>,
+      assignment_batches: &HashMap<V, AssignmentBatch>,
+      messages: &HashMap<V, StackedMessage>,
+  ) -> Result<Option<Vec<Complex64>>>
+  ```
+  Same `Ok(None)` escape-hatch contract as `try_compute_chain_message_raw`: return `None` when `node` is not eligible, so the caller falls back to `compute_stacked_message`.
+- Consumes: `grouped_branch_message_contraction` (Task 1), the same tree/plan/message-cache accessors `try_compute_chain_message_raw` already uses (`self.layout.entries_by_node`, `plan.children`, `tensor_for_node`, `self.tree.edge_between`/`bond_index`, `messages.get(child)`, `assignment_batches.get(child)`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module, near `raw_chain_message_matches_generic_contraction`. First read that existing test in full (`crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`, search `fn raw_chain_message_matches_generic_contraction`) to copy its exact setup pattern (how it builds a small tree, a `RootedMessagePlan`, `assignment_batches`, and calls both the raw and generic paths on the SAME inputs to compare). Build an analogous test using a **star-shaped** tree (hub + 3 leaves, mirroring this file's existing `star_tree()` fixture) with `center` set to one leaf (so the hub has 2 children, the other 2 leaves), and assert:
+
+```rust
+#[test]
+fn raw_branch_message_matches_generic_contraction() {
+    // Build using star_tree(), fix center to leaf 1 (so node 0 / the hub
+    // has children [2, 3] when rooted toward center 1), drive both
+    // try_compute_branch_message_raw and compute_stacked_message for the
+    // hub node on the same points, assert equal results.
+    // ... (mirror raw_chain_message_matches_generic_contraction's exact
+    // plan/assignment_batches/messages setup, substituting star_tree()
+    // and center=1 for that test's chain fixture and center choice)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::raw_branch_message_matches_generic_contraction`
+Expected: FAIL to compile -- `try_compute_branch_message_raw` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert after `try_compute_chain_message_complex_raw`'s closing `}`:
+
+```rust
+/// Computes a branch node's (exactly two children) message directly from
+/// raw data, generalizing [`Self::try_compute_chain_message_raw`] from one
+/// child to two via [`grouped_branch_message_contraction`].
+///
+/// Returns `Ok(None)` when `node` is not eligible (not exactly one physical
+/// index and exactly two children, a complex-valued tensor, or an
+/// unexpected axis count), so the caller falls back to
+/// [`Self::compute_stacked_message`].
+fn try_compute_branch_message_raw(
+    &self,
+    node: &V,
+    values: ColMajorArrayRef<'_, usize>,
+    points: &[usize],
+    plan: &RootedMessagePlan<V>,
+    assignment_batches: &HashMap<V, AssignmentBatch>,
+    messages: &HashMap<V, StackedMessage>,
+) -> Result<Option<Vec<f64>>> {
+    let entries = self
+        .layout
+        .entries_by_node
+        .get(node)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    let [entry] = entries else {
+        return Ok(None);
+    };
+    let children = plan.children.get(node).map(Vec::as_slice).unwrap_or(&[]);
+    let [child_1, child_2] = children else {
+        return Ok(None);
+    };
+
+    let tensor = tensor_for_node(self.tree, node)?;
+    if tensor.is_complex() {
+        return Ok(None);
+    }
+    let tensor_indices = tensor.indices();
+    if tensor_indices.len() != 4 {
+        return Ok(None);
+    }
+    let Some(physical_axis) = tensor_indices.iter().position(|idx| idx == &entry.index) else {
+        return Ok(None);
+    };
+    let Some(child_1_edge) = self.tree.edge_between(node, child_1) else {
+        return Ok(None);
+    };
+    let Some(child_1_bond_index) = self.tree.bond_index(child_1_edge) else {
+        return Ok(None);
+    };
+    let Some(child_axis_1) = tensor_indices
+        .iter()
+        .position(|idx| idx == child_1_bond_index)
+    else {
+        return Ok(None);
+    };
+    let Some(child_2_edge) = self.tree.edge_between(node, child_2) else {
+        return Ok(None);
+    };
+    let Some(child_2_bond_index) = self.tree.bond_index(child_2_edge) else {
+        return Ok(None);
+    };
+    let Some(child_axis_2) = tensor_indices
+        .iter()
+        .position(|idx| idx == child_2_bond_index)
+    else {
+        return Ok(None);
+    };
+    let Some(parent_axis) = (0..4).find(|&axis| {
+        axis != physical_axis && axis != child_axis_1 && axis != child_axis_2
+    }) else {
+        return Ok(None);
+    };
+
+    let child_1_message = messages.get(child_1).ok_or_else(|| {
+        anyhow::anyhow!(
+            "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing message for child {:?}",
+            child_1
+        )
+    })?;
+    let child_2_message = messages.get(child_2).ok_or_else(|| {
+        anyhow::anyhow!(
+            "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing message for child {:?}",
+            child_2
+        )
+    })?;
+    let Some(child_1_values) = raw_real_message_values(child_1_message)? else {
+        return Ok(None);
+    };
+    let Some(child_2_values) = raw_real_message_values(child_2_message)? else {
+        return Ok(None);
+    };
+
+    let child_1_assignment_batch = assignment_batches.get(child_1).ok_or_else(|| {
+        anyhow::anyhow!(
+            "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing assignment batch for child {:?}",
+            child_1
+        )
+    })?;
+    let child_2_assignment_batch = assignment_batches.get(child_2).ok_or_else(|| {
+        anyhow::anyhow!(
+            "TreeTNCachedEvaluator::try_compute_branch_message_raw: missing assignment batch for child {:?}",
+            child_2
+        )
+    })?;
+
+    let dims = tensor.dims();
+    let parent_dim = dims[parent_axis];
+    let child_dim_1 = dims[child_axis_1];
+    let child_dim_2 = dims[child_axis_2];
+    let strides = [
+        1usize,
+        dims[0],
+        dims[0].checked_mul(dims[1]).ok_or_else(|| anyhow::anyhow!("branch tensor strides overflow usize"))?,
+        dims[0]
+            .checked_mul(dims[1])
+            .and_then(|value| value.checked_mul(dims[2]))
+            .ok_or_else(|| anyhow::anyhow!("branch tensor strides overflow usize"))?,
+    ];
+    let spec = BranchContractionSpec {
+        strides,
+        physical_axis,
+        parent_axis,
+        child_axis_1,
+        child_axis_2,
+        parent_dim,
+        child_dim_1,
+        child_dim_2,
+    };
+    let raw = tensor.to_vec::<f64>()?;
+
+    let mut physical_values = Vec::with_capacity(points.len());
+    let mut child_1_columns = Vec::with_capacity(child_dim_1 * points.len());
+    let mut child_2_columns = Vec::with_capacity(child_dim_2 * points.len());
+    for &point in points {
+        let physical_value = value_at(
+            values,
+            entry.input_position,
+            point,
+            "TreeTNCachedEvaluator::try_compute_branch_message_raw",
+        )?;
+        physical_values.push(physical_value);
+
+        let child_1_assignment = child_1_assignment_batch
+            .point_to_assignment
+            .get(point)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("missing child-1 assignment for point {point}"))?;
+        let start_1 = child_1_assignment * child_dim_1;
+        child_1_columns.extend_from_slice(
+            child_1_values
+                .get(start_1..start_1 + child_dim_1)
+                .ok_or_else(|| anyhow::anyhow!("child-1 assignment is out of bounds"))?,
+        );
+
+        let child_2_assignment = child_2_assignment_batch
+            .point_to_assignment
+            .get(point)
+            .copied()
+            .ok_or_else(|| anyhow::anyhow!("missing child-2 assignment for point {point}"))?;
+        let start_2 = child_2_assignment * child_dim_2;
+        child_2_columns.extend_from_slice(
+            child_2_values
+                .get(start_2..start_2 + child_dim_2)
+                .ok_or_else(|| anyhow::anyhow!("child-2 assignment is out of bounds"))?,
+        );
+    }
+    let result = Self::grouped_branch_message_contraction(
+        spec,
+        &raw,
+        &physical_values,
+        &child_1_columns,
+        &child_2_columns,
+    )?;
+    Ok(Some(result))
+}
+```
+
+Then a `raw_real_message_values` helper (shared with the complex counterpart's structure) extracting a real `Vec<f64>` from a `StackedMessage`, matching exactly the inline logic `try_compute_chain_message_raw` already has for `child_values` (lines around 1608-1625 as read during investigation: prefer `raw_values` if present, else convert a real, host-resident `tensor`, returning `Ok(None)` on complex/`contract_with_options`-produced messages) -- factor that inline block out of `try_compute_chain_message_raw` into this helper **only if** doing so doesn't change `try_compute_chain_message_raw`'s behavior (verify with its existing tests still green after the extraction); otherwise duplicate the block rather than risk an unintended behavior change to the untouched chain path.
+
+Write `try_compute_branch_message_complex_raw` as the direct `Complex64` counterpart, mirroring `try_compute_chain_message_complex_raw`'s existing relationship to `try_compute_chain_message_raw` (same structure, `Complex64` values, no `tensor.is_complex()` early return).
+
+Wire both into `get_or_compute_node_message`: in the `tensor_is_complex` branch, insert `try_compute_branch_message_complex_raw` between the existing `try_compute_chain_message_complex_raw` attempt and the `compute_stacked_message` fallback (same `if leaf.is_some() { leaf } else { chain_result }` chaining pattern, extended to `if chain_result.is_some() { chain_result } else { branch_result }`); mirror in the real (non-complex) branch with `try_compute_branch_message_raw`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::raw_branch_message_matches_generic_contraction -- --nocapture`
+Expected: PASS. If it fails on a value mismatch, re-check `strides`/axis assignment against `try_compute_chain_message_raw`'s exact convention (`dims[0]` fastest) and `grouped_branch_message_contraction`'s row/column layout (Task 1 Step 4 already validated that function in isolation, so a mismatch here points at this method's tensor-slicing/assignment-lookup glue, not the contraction math itself).
+
+- [ ] **Step 5: Add a complex-value variant, run full module, commit**
+
+Mirror `raw_complex_chain_message_matches_generic_contraction` for `try_compute_branch_message_complex_raw`.
+
+```bash
+cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator:: --no-fail-fast
+cargo fmt --all
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): wire the two-child branch raw message path into get_or_compute_node_message"
+```
+
+---
+
+### Task 3: End-to-end correctness on a real branching tree
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` (`tests` module)
+
+**Interfaces:**
+- Consumes: `star_tree()` (existing fixture), `TreeTNCachedEvaluator::evaluate_batched`, `tree.evaluate` (ground truth), `assert_scalars_close` (existing helper).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center() {
+    let (tree, indices) = star_tree();
+    let values = vec![
+        0, 0, 0, 0, //
+        1, 1, 0, 1, //
+        0, 1, 1, 0, //
+        1, 0, 1, 1,
+    ];
+    let shape = [4, 4];
+    let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+
+    let expected = tree.evaluate(&indices, points).unwrap();
+    let mut evaluator = TreeTNCachedEvaluator::new(
+        &tree,
+        &indices,
+        CachedEvaluatorOptions {
+            center: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let actual = evaluator.evaluate_batched(points).unwrap();
+
+    assert_scalars_close(&actual, &expected);
+}
+```
+
+This is deliberately close to the existing `cached_evaluator_matches_tree_evaluate_on_star_tree` test (check whether that test already exists and already fixes `center: Some(1)` or lets greedy search pick it -- read it first; if it already covers this exact scenario, skip this task and note in the commit message that Task 2's dispatch change is already covered by existing end-to-end tests instead of adding a redundant one).
+
+- [ ] **Step 2: Run to verify it currently passes (it should -- Task 2 didn't change correctness, only which internal path computes the same result) and would have failed before Task 2 if the new path had a bug**
+
+Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center -- --nocapture`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "test(treetn): add end-to-end star-tree coverage pinning the branch raw path's center choice"
+```
+
+---
+
+### Task 4: Full crate verification, update the diagnostic to show before/after, worklog
+
+**Files:**
+- Test: full `tensor4all-treetn` suite
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` (update the temporary diagnostic in place; keep it, matching how `frames.rs`'s equivalent diagnostic became a kept measurement in the prior fix)
+- Create: `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`
+
+- [ ] **Step 1: Full crate verification**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --all-targets -- -D warnings
+cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --no-fail-fast
+cargo doc --manifest-path crates/tensor4all-treetn/Cargo.toml --no-deps
+```
+
+- [ ] **Step 2: Re-run the diagnostic to measure the fix**
+
+Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk -- --ignored --nocapture`
+
+Record the new `ratio (comb/chain)` -- compare against the pre-fix 25.84x. Update the test's doc comment from "TEMPORARY... revert after root-cause confirmation" to a permanent doc comment describing it as a kept regression-style measurement (mirroring `message_cache_wall_time_on_realistic_floating_zone_walk`'s own framing: "measurement tooling rather than a wall-clock regression assertion").
+
+- [ ] **Step 3: Write the worklog**
+
+Create `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`: root cause (this plan's own root cause section), the 25.84x pre-fix measurement, the fix (Tasks 1-3), the post-fix measurement from Step 2, and an explicit note that this is a *different* crate/bug from `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`'s fix -- the two are structurally analogous but independent, and closing this one is what should actually move `pi_rtau` wall time on the downstream gw-rs `aci_global_guard=true` pipeline, per the user's own re-run finding that the first fix alone did not.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt --all
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md
+git commit -m "test(treetn): confirm branch message fix closes the chain-vs-comb gap, add worklog"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 covers the primitive; Task 2 covers dispatch wiring for both real/complex; Task 3 covers end-to-end correctness through the public `evaluate_batched` API; Task 4 covers full verification plus the before/after measurement the investigation promised.
+- **Placeholder scan:** Task 3's exact test body is conditional on checking existing coverage first -- this is an explicit, actionable instruction ("read it first; if it already covers this, skip and note why"), not a vague placeholder, and is the one deliberate exception to "no placeholders" since it depends on a file-content check the plan author (me) did not exhaustively perform for every existing test in a 4787-line file before writing this plan.
+- **Type consistency:** `BranchContractionSpec`/`grouped_branch_message_contraction`'s signature (Task 1) is used identically by `try_compute_branch_message_raw`/`_complex_raw` (Task 2). Output/input column layouts (point-major) are stated once and referenced consistently.
+- **Not in scope:** nodes with 0, 1, or 3+ children; `compute_stacked_message`/`contract_with_options` themselves; message-cache internals (`PackedMessageCache`, `get_or_compute_batch`); the `tensor4all-treeaci/frames.rs` fix from the prior plan (already shipped, separate bug).

--- a/docs/superpowers/plans/2026-08-22-treetn-branch-message-raw-path.md
+++ b/docs/superpowers/plans/2026-08-22-treetn-branch-message-raw-path.md
@@ -71,7 +71,7 @@ Every task below ends with, at minimum: `cargo fmt --all -- --check` clean and `
   `child1_columns` is `point_count * child_dim_1` (point-major, i.e. point `p`'s column is `child1_columns[p*child_dim_1..(p+1)*child_dim_1]`, matching `try_compute_chain_message_raw`'s existing `child_columns` convention). Same for `child2_columns` with `child_dim_2`. Returns `point_count * parent_dim` (point-major, matching `grouped_chain_message_contraction`'s output convention exactly, since callers treat both outputs identically).
 - Consumes: `Matrix`, `mat_mul_owned` (`tensor4all_tensorbackend`, already imported in this file).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to the `tests` module, near `grouped_chain_contraction_matches_scalar_reference_for_real_values`:
 
@@ -128,12 +128,12 @@ fn grouped_branch_contraction_matches_direct_reference_for_real_values() {
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::grouped_branch_contraction_matches_direct_reference_for_real_values`
 Expected: FAIL to compile -- `BranchContractionSpec`/`grouped_branch_message_contraction` do not exist yet.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 Insert near `ChainContractionSpec` (after its definition):
 
@@ -357,16 +357,16 @@ where
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::grouped_branch_contraction_matches_direct_reference_for_real_values -- --nocapture`
 Expected: PASS (this small test always takes the scalar fallback since `point_count=3 < 2*BRANCH_BLAS_MIN_GROUP_POINTS=8`, so it validates `scalar_branch_message_contraction`'s indexing first).
 
-- [ ] **Step 5: Add a large-group test that forces the BLAS path, and a complex-value variant**
+- [x] **Step 5: Add a large-group test that forces the BLAS path, and a complex-value variant**
 
 Mirror `grouped_chain_contraction_large_real_groups_match_scalar_reference` / `grouped_chain_contraction_large_complex_groups_match_scalar_reference`: build a `BranchContractionSpec` with `parent_dim`/`child_dim_1`/`child_dim_2` large enough that `scalar_work >= BRANCH_BLAS_WORK_THRESHOLD` and at least one physical-value group with `>= BRANCH_BLAS_MIN_GROUP_POINTS` points (e.g. `parent_dim=8, child_dim_1=8, child_dim_2=8`, physical dim 2, `point_count=40` split across the 2 physical values), random `f64` raw/child columns via `rand::rngs::StdRng` (seeded, matching this file's existing test RNG usage), and assert `grouped_branch_message_contraction(...)` equals `scalar_branch_message_contraction(...)` (the untouched reference) element-wise via `assert_eq!` for `f64`, or `Complex64` with the same structure for the complex variant (`T: BlasMul` must hold for `Complex64` too -- confirm by checking `grouped_chain_contraction_matches_scalar_reference_for_complex_values`'s existing pattern and mirror its `Complex64` construction).
 
-- [ ] **Step 6: Run full test module, commit**
+- [x] **Step 6: Run full test module, commit**
 
 ```bash
 cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator:: --no-fail-fast
@@ -408,7 +408,7 @@ git commit -m "feat(treetn): add batched two-child branch message contraction pr
   Same `Ok(None)` escape-hatch contract as `try_compute_chain_message_raw`: return `None` when `node` is not eligible, so the caller falls back to `compute_stacked_message`.
 - Consumes: `grouped_branch_message_contraction` (Task 1), the same tree/plan/message-cache accessors `try_compute_chain_message_raw` already uses (`self.layout.entries_by_node`, `plan.children`, `tensor_for_node`, `self.tree.edge_between`/`bond_index`, `messages.get(child)`, `assignment_batches.get(child)`).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add to the `tests` module, near `raw_chain_message_matches_generic_contraction`. First read that existing test in full (`crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`, search `fn raw_chain_message_matches_generic_contraction`) to copy its exact setup pattern (how it builds a small tree, a `RootedMessagePlan`, `assignment_batches`, and calls both the raw and generic paths on the SAME inputs to compare). Build an analogous test using a **star-shaped** tree (hub + 3 leaves, mirroring this file's existing `star_tree()` fixture) with `center` set to one leaf (so the hub has 2 children, the other 2 leaves), and assert:
 
@@ -425,12 +425,12 @@ fn raw_branch_message_matches_generic_contraction() {
 }
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::raw_branch_message_matches_generic_contraction`
 Expected: FAIL to compile -- `try_compute_branch_message_raw` does not exist yet.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 Insert after `try_compute_chain_message_complex_raw`'s closing `}`:
 
@@ -617,12 +617,12 @@ Write `try_compute_branch_message_complex_raw` as the direct `Complex64` counter
 
 Wire both into `get_or_compute_node_message`: in the `tensor_is_complex` branch, insert `try_compute_branch_message_complex_raw` between the existing `try_compute_chain_message_complex_raw` attempt and the `compute_stacked_message` fallback (same `if leaf.is_some() { leaf } else { chain_result }` chaining pattern, extended to `if chain_result.is_some() { chain_result } else { branch_result }`); mirror in the real (non-complex) branch with `try_compute_branch_message_raw`.
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::raw_branch_message_matches_generic_contraction -- --nocapture`
 Expected: PASS. If it fails on a value mismatch, re-check `strides`/axis assignment against `try_compute_chain_message_raw`'s exact convention (`dims[0]` fastest) and `grouped_branch_message_contraction`'s row/column layout (Task 1 Step 4 already validated that function in isolation, so a mismatch here points at this method's tensor-slicing/assignment-lookup glue, not the contraction math itself).
 
-- [ ] **Step 5: Add a complex-value variant, run full module, commit**
+- [x] **Step 5: Add a complex-value variant, run full module, commit**
 
 Mirror `raw_complex_chain_message_matches_generic_contraction` for `try_compute_branch_message_complex_raw`.
 
@@ -643,7 +643,7 @@ git commit -m "feat(treetn): wire the two-child branch raw message path into get
 **Interfaces:**
 - Consumes: `star_tree()` (existing fixture), `TreeTNCachedEvaluator::evaluate_batched`, `tree.evaluate` (ground truth), `assert_scalars_close` (existing helper).
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```rust
 #[test]
@@ -676,12 +676,12 @@ fn cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center() 
 
 This is deliberately close to the existing `cached_evaluator_matches_tree_evaluate_on_star_tree` test (check whether that test already exists and already fixes `center: Some(1)` or lets greedy search pick it -- read it first; if it already covers this exact scenario, skip this task and note in the commit message that Task 2's dispatch change is already covered by existing end-to-end tests instead of adding a redundant one).
 
-- [ ] **Step 2: Run to verify it currently passes (it should -- Task 2 didn't change correctness, only which internal path computes the same result) and would have failed before Task 2 if the new path had a bug**
+- [x] **Step 2: Run to verify it currently passes (it should -- Task 2 didn't change correctness, only which internal path computes the same result) and would have failed before Task 2 if the new path had a bug**
 
 Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center -- --nocapture`
 Expected: PASS.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 cargo fmt --all
@@ -698,7 +698,7 @@ git commit -m "test(treetn): add end-to-end star-tree coverage pinning the branc
 - Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` (update the temporary diagnostic in place; keep it, matching how `frames.rs`'s equivalent diagnostic became a kept measurement in the prior fix)
 - Create: `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`
 
-- [ ] **Step 1: Full crate verification**
+- [x] **Step 1: Full crate verification**
 
 ```bash
 cargo fmt --all -- --check
@@ -707,17 +707,17 @@ cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --no-fa
 cargo doc --manifest-path crates/tensor4all-treetn/Cargo.toml --no-deps
 ```
 
-- [ ] **Step 2: Re-run the diagnostic to measure the fix**
+- [x] **Step 2: Re-run the diagnostic to measure the fix**
 
 Run: `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --lib treetn::cached_evaluator::tests::diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk -- --ignored --nocapture`
 
 Record the new `ratio (comb/chain)` -- compare against the pre-fix 25.84x. Update the test's doc comment from "TEMPORARY... revert after root-cause confirmation" to a permanent doc comment describing it as a kept regression-style measurement (mirroring `message_cache_wall_time_on_realistic_floating_zone_walk`'s own framing: "measurement tooling rather than a wall-clock regression assertion").
 
-- [ ] **Step 3: Write the worklog**
+- [x] **Step 3: Write the worklog**
 
 Create `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`: root cause (this plan's own root cause section), the 25.84x pre-fix measurement, the fix (Tasks 1-3), the post-fix measurement from Step 2, and an explicit note that this is a *different* crate/bug from `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`'s fix -- the two are structurally analogous but independent, and closing this one is what should actually move `pi_rtau` wall time on the downstream gw-rs `aci_global_guard=true` pipeline, per the user's own re-run finding that the first fix alone did not.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 cargo fmt --all

--- a/docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md
+++ b/docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md
@@ -1,0 +1,124 @@
+# Closing the branch-point batching gap for issue #671
+
+Work log. Fixes gw-rs issue #671 (upstream `tensor4all-rs` side): `tree_elementwise`
+was ~5-6.5x slower per evaluated point on a branching (comb) tree than on a
+chain, at comparable sweep counts. Follows on from
+`docs/worklogs/2026-08-18-treeaci-message-cache-prototype.md`, which added the
+batched BLAS path for single-incoming-edge (chain) directed edges and
+explicitly left multi-incoming-edge (branch-point) nodes on the scalar path,
+"work there needs its own benchmark with actual branch points."
+
+## Root cause
+
+`InputFrameStore::candidate_frames_for_edge` and `FrameBuilder::compute_batch`
+(`crates/tensor4all-treeaci/src/frames.rs`) dispatch to a BLAS-backed batched
+contraction (`contract_prepared_core_batched`, one `mat_mul` call per group of
+candidates sharing a local coordinate) only when a directed edge's source node
+has exactly one incoming edge -- every interior chain node. Any node with 2+
+incoming edges -- every branch/hub point in a comb/tree topology -- fell
+through to `candidate_frame`/`contract_prepared_core` -> `accumulate_incoming`,
+a scalar recursive nested loop evaluated independently per candidate, with no
+BLAS and no cross-candidate batching.
+
+## Confirming it before fixing it
+
+Before touching any dispatch code, a temporary `#[ignore]`d diagnostic
+(`diagnostic_branch_scalar_vs_chain_batched_at_matched_flops`, added and later
+reverted) timed the scalar branch path against the existing single-incoming
+batched path at **matched total element counts** (chain: one incoming edge of
+dimension `D`; branch: two incoming edges of dimension `sqrt(D)` each, so both
+touch the same number of tensor elements per candidate), at increasing scale:
+
+| D (chain) / D x D (branch) | ratio (scalar/batched) |
+|---:|---:|
+| 64 / 8x8 | 1.76x |
+| 256 / 16x16 | 3.61x |
+| 1024 / 32x32 | 4.17x |
+
+Same FLOP count, but the ratio grows with dimension -- the signature of BLAS's
+cache/SIMD/threading advantage widening at larger matrix sizes versus a naive
+scalar loop, not of genuinely more required arithmetic. This confirmed the gap
+was closeable by extending the existing batched-path pattern to the
+two-incoming-edge case, not an inherent cost of tree branching.
+
+## Fix
+
+Added `two_incoming_core_matrix_batched` (`frames.rs`): contracts a node's
+core against two incoming-edge candidate-frame matrices (`v1`: `D1 x N1`,
+`v2`: `D2 x N2`) via `D2 + 1` BLAS `mat_mul` calls -- `D2` calls reuse the
+existing `single_incoming_core_matrix` + `contract_prepared_core_batched` pair
+to fold in `v1` one slice of the second incoming axis at a time, then one
+final `contract_prepared_core_batched` call folds in `v2` -- producing every
+`(n1, n2)` combination in one shot instead of one scalar
+`accumulate_incoming` walk per combination.
+
+Wired this into both existing dispatch points as a new middle case:
+
+- `InputFrameStore::candidate_frames_for_edge` (pivot-search candidate path)
+  gained `candidate_frames_for_edge_two_incoming`, mirroring the existing
+  single-incoming orchestration (group by `local_coordinate`, consult/populate
+  `candidate_cache`) but gathering distinct sample ids on *both* incoming
+  edges before the batched contraction.
+- `FrameBuilder::compute_batch` (sample-materialization path, used by
+  `InputFrameStore::from_samples`/`extend`) gained `compute_batch_two_incoming`,
+  the same structure reading incoming frame vectors from `self.memo` instead
+  of a committed `InputFrameStore`.
+
+Nodes with 0 or 3+ incoming edges are untouched and still use the scalar path
+-- deliberately out of scope: issue #671's reported topology (3-arm comb) only
+ever produces exactly 2 incoming edges at a hub, and generalizing further would
+need an inter-step buffer transpose the 2-incoming case avoids by reusing the
+existing single-incoming primitives directly.
+
+## Verification
+
+- TDD throughout: every new function/branch had a failing test confirmed red
+  before implementation (compile error for the new primitive; both
+  renamed/adapted branch tests already asserted `dispatched == scalar`, so
+  they were confirmed still green pre-wiring, then re-confirmed green
+  post-wiring now exercising the new code path for real).
+- New tests: `two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair`
+  (isolated primitive check), `candidate_frames_for_edge_still_falls_back_on_three_incoming_edges`
+  and `compute_batch_still_falls_back_on_three_incoming_edges` (new 4-arm-star
+  fixture, pinning that 3+-incoming dispatch is unchanged).
+- `cargo fmt --all -- --check` clean.
+- `cargo clippy -p tensor4all-treeaci --all-targets -- -D warnings` clean
+  (needed one `#[allow(clippy::too_many_arguments)]`, matching the crate's
+  existing convention for wide-signature internal contraction primitives).
+- `cargo test --release -p tensor4all-treeaci --no-fail-fast`: 114 lib tests
+  (0 failed, 1 ignored -- the speedup diagnostic below), 7 `public_api`
+  integration tests, 1 `rank_scaling` test, 18 doctests, all green.
+- `cargo doc -p tensor4all-treeaci --no-deps` clean.
+
+## Measured speedup
+
+`branch_point_batched_speedup_vs_scalar_at_realistic_scale` (kept as an
+`#[ignore]`d test; run with `--ignored --nocapture`) reproduces #671's
+question directly: a 3-arm star with a hub node whose branch edge has two
+incoming edges of dimension 32 each, 40 distinct candidate samples per
+incoming edge (1600 candidates total), comparing the new batched
+`candidate_frames_for_edge` against the still-present scalar `candidate_frame`
+loop -- each measured against its own freshly-built `InputFrameStore` so
+neither run's timing is contaminated by the other populating the shared
+`candidate_cache`:
+
+```
+batched (two-incoming fix): 2.194234ms
+scalar (old fallback, still used for 3+ incoming): 30.975879ms
+speedup: 14.12x
+```
+
+14.12x at this problem size, comfortably exceeding the 5-6.5x gap #671
+reported for the real gw-rs pipeline (which also includes non-branch-edge
+work diluting the aggregate ratio, so the two numbers are not directly
+comparable, but this confirms the fix removes the branch-point-local
+bottleneck rather than only partially narrowing it).
+
+## Follow-up
+
+Nodes with 3+ incoming edges (degree >= 5) remain on the scalar path. Not
+needed for #671's reported topology; if a future workload hits this (e.g. a
+Bethe-lattice-like tree), the same technique generalizes via an inter-step
+buffer transpose between each pair of incoming-edge contractions, at the cost
+of noticeably more implementation and testing complexity than the 2-incoming
+case needed.

--- a/docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md
+++ b/docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md
@@ -1,0 +1,168 @@
+# Closing TreeTNCachedEvaluator's branch-point gap (tensor4all-rs#671 follow-up)
+
+Work log. Continues from `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`,
+which fixed a branch-point batching gap in `tensor4all-treeaci/frames.rs`. A
+downstream re-run of gw-rs's real R=10 comb pipeline (`aci_global_guard=true`,
+the same config issue #671 used) showed that fix alone left `pi_rtau`'s wall
+time essentially unchanged (103.6s, matching the pre-fix baseline). This
+session traced that to a second, independent, structurally analogous bug in a
+different crate: whenever `aci_global_guard=true`, global pivot search
+(`crates/tensor4all-treeaci/src/global_guard.rs`) evaluates candidate points
+through `TreeTNCachedEvaluator` (`tensor4all-treetn`), not through
+`frames.rs` at all -- so the first fix never touched this path.
+
+## Root cause
+
+`TreeTNCachedEvaluator::get_or_compute_node_message` dispatches to a raw
+`Vec<f64>`-based fast path (`try_compute_chain_message_raw`,
+`grouped_chain_message_contraction`'s BLAS "chain kernel") only for a node
+with exactly one child in the rooted message-passing tree -- the same
+"one-incoming/one-child gets batched, branch doesn't" shape as the
+`frames.rs` bug, independently implemented in this crate for message-passing
+evaluation rather than local-update candidate contraction. A node with two
+children falls through to the generic `compute_stacked_message`
+(`IdxTensor` + `contract_with_options`).
+
+A pure chain or `SimpleTensorTrain`/`TTCache`-based train never exercises the
+multi-child branch at all: rooting a chain anywhere gives every non-root node
+at most one child (the root's own combination goes through a separate
+one-shot "centre contraction" step, not this per-node recursion), and
+`SimpleTensorTrain`'s data structure cannot represent a branch in the first
+place. Tree ACI on a genuinely branching topology (gw-rs's 3-arm comb, one
+degree-3 hub) is the first caller that visits this code path at scale.
+
+## Confirming the bottleneck before fixing it
+
+A temporary `#[ignore]`d diagnostic
+(`diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk`, kept
+in `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`'s test module,
+mirroring the file's own `message_cache_wall_time_on_realistic_floating_zone_walk`
+benchmark) measured a 16-site chain (bond=128) against a same-size comb tree
+(one degree-3 hub, three 5-site arms, bond=128), both under the real
+`NSEARCH=5`, `MAX_SWEEPS=100` floating-zone-walk call pattern
+`find_global_pivots` actually uses: **83.7ms vs 2.16s -- 25.84x**, at a scale
+close to the real gw-rs workload's observed bond (~90).
+
+## Fix
+
+Added (mirroring the chain kernel's shape, but not its exact math -- see
+"Why this isn't a cartesian-product fix" below):
+
+- `BranchContractionSpec` + `grouped_branch_message_contraction`
+  (`crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`): contracts a
+  branch node's raw tensor data against two children's raw message columns
+  in two steps per physical-value group -- one shared-matrix `mat_mul_owned`
+  call folds in the first child (the node's tensor slice at that physical
+  value is the same for every point in the group, so every point's child-1
+  column batches into one matmul), then a vectorized accumulate loop over
+  `child_dim_2` folds in the second child.
+- `try_compute_branch_message_raw` / `_complex_raw`, wired into
+  `get_or_compute_node_message` between the existing chain attempt and the
+  `compute_stacked_message` fallback, for both dispatch branches.
+
+**Why this isn't a cartesian-product fix.** The `tensor4all-treeaci/frames.rs`
+fix batched a full cartesian product of candidates in one shot, because that
+crate's candidate lists are exactly that. This evaluator's `points` are
+independent per-point assignments instead -- point `p` names one specific
+`(child1_assignment, child2_assignment)` pair, not every combination -- so
+only the first child's contraction reduces to a single BLAS call per group;
+the second child's contraction cannot share a matrix across points the same
+way and is folded in via a plain vectorized loop instead.
+
+## A regression, caught before it shipped
+
+The first version of `grouped_branch_message_contraction` copied the chain
+kernel's `point_count < 2 * MIN_GROUP_POINTS` gate verbatim. That gate is
+wrong for the branch case: a branch step's per-point work is
+`O(parent_dim * child_dim_1 * child_dim_2)`, an extra bond-dimension factor
+over the chain kernel's `O(parent_dim * child_dim)`, so at realistic bond
+dimensions even a single point already has enough work to justify BLAS.
+Re-running the diagnostic after wiring the fix in showed **44.24x** --
+*worse* than the 25.84x baseline -- because `floating_zone_walk`'s typical
+1-2-point batches always fell below the gate and always took the naive
+`scalar_branch_message_contraction` fallback, which is slower per flop than
+whatever `compute_stacked_message` was already doing. The fix: drop the
+point/group-count gate entirely and key `scalar_work >= BRANCH_BLAS_WORK_THRESHOLD`
+alone, since a branch step's larger per-point cost means total work already
+captures whether BLAS is worth it. Re-measuring after that correction gave
+29.26x -- better, but still not clearly beating the 25.84x baseline on this
+same-bond-for-both synthetic diagnostic.
+
+**That synthetic result was misleading, and real downstream data caught it.**
+The 25.84x/29.26x/44.24x numbers above all use bond=128 for *both* chain and
+comb, chosen to isolate topology's effect at equal bond. But gw-rs's actual
+saved run logs (`runs/R10_cttn_T0.1_mu0.5/cttn/state/run.log` vs
+`runs/R10_nblock_T0.1_mu0.5/treeaci/state/run.log`, both pinned to this
+session's `frames.rs`-only-fixed commit) show NBlock's own max bond (163) is
+*larger* than CTTN's (90) -- the opposite of the synthetic diagnostic's
+equal-bond setup -- and inspecting the actual `04_Pi.h5` checkpoints
+(`tensor4all_hdf5::load_treetn`, per-node `IdxTensor::dims()`) showed CTTN's
+largest tensor (hub, `[13, 7, 2, 13]` = 2366 elements) is barely larger than
+NBlock's largest (`[34, 2, 31]` = 2108 elements) -- nowhere near what a
+bond=128-for-both proxy would suggest. The synthetic benchmark's uniform-bond
+assumption does not represent the real workload's shape (asymmetric bond
+growth, small/irregular floating-zone batch sizes, message-cache reuse
+patterns across a full 9-sweep run), so its negative-looking result should
+not have been trusted as the final word -- only a real downstream measurement
+settles it.
+
+## Real downstream validation
+
+Ran gw-rs's actual `sgw` binary (R=10, comb topology, `aci_global_guard=true`,
+`max_bond_dim=4096`, identical config to the saved baseline and to issue
+#671's original reproduction) against this fix, via a temporary local
+`[patch]` override in `gw-rs/sgw/Cargo.toml` pointing at this session's local
+tensor4all-rs checkout (not yet pushed/merged -- see Follow-up). Compared
+against the same saved baseline (frames.rs fix only, no treetn fix):
+
+| stage | baseline elapsed | with this fix | bond (baseline -> fixed) | speedup |
+|---|---:|---:|---|---:|
+| pi_rtau | 103.55s | 33.7s | 90 -> 91 | **3.07x** |
+| W | 8.38s | 5.5s | 42 -> 43 | **1.52x** |
+| sigma_rtau | 72.77s | 23.1s | 81 -> 81 (identical) | **3.15x** |
+| **treeaci stages total** | **184.7s** | **62.3s** | | **2.96x** |
+
+Bond dimensions and truncation errors match the baseline closely (sigma_rtau's
+bond is exactly identical), so this is a genuine wall-time win at matched
+accuracy, not a "converged to a cheaper answer" artifact.
+
+## Verification
+
+- TDD throughout, same discipline as the `frames.rs` fix: every new
+  function/branch had a failing test confirmed red before implementation.
+- New tests: `grouped_branch_contraction_matches_direct_reference_for_real_values`
+  (isolated primitive, hand-computed reference), large-group real/complex
+  variants forcing the actual BLAS path against `scalar_branch_message_contraction`,
+  `raw_branch_message_matches_generic_contraction` /
+  `raw_complex_branch_message_matches_generic_contraction` (manual
+  plan/messages-level parity against `compute_stacked_message`, using a new
+  `complex_star_tree` fixture), and
+  `cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center`
+  (end-to-end through the public `evaluate_batched` API -- the existing
+  star-tree test fixed centre to the hub itself and never reached the branch
+  dispatch at all).
+- `cargo fmt --all -- --check` clean.
+- `cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --all-targets -- -D warnings`
+  clean (one fix needed: a `needless_range_loop` in the diagnostic's comb-tree
+  builder).
+- `cargo test --release --manifest-path crates/tensor4all-treetn/Cargo.toml --no-fail-fast`:
+  all green.
+
+## Follow-up
+
+- This fix is validated locally (both crate-level tests and the real gw-rs
+  downstream pipeline) but not yet pushed to `origin/main`. gw-rs's
+  `sgw/Cargo.toml` currently carries a temporary `[patch]` section pointing
+  at this local checkout for that validation; remove it once this PR merges
+  and gw-rs's existing `branch = "main"` git dependencies pick up the merged
+  commit on their own.
+- Nodes with 3+ children (degree >= 5) remain on the scalar/generic path,
+  same scope decision as the `frames.rs` fix and for the same reason: not
+  needed for #671's reported topology, and a general N-child version would
+  need an inter-step buffer transpose this 2-child case avoids.
+- The synthetic same-bond diagnostic's numbers (25.84x / 29.26x / 44.24x)
+  are kept as a regression-style measurement tool
+  (`diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk`,
+  `#[ignore]`d), but should be read as "does branching cost something at
+  matched bond" evidence, not as a proxy for real downstream wall time --
+  this session's own experience with it argues for that caveat explicitly.

--- a/docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md
+++ b/docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md
@@ -126,6 +126,27 @@ Bond dimensions and truncation errors match the baseline closely (sigma_rtau's
 bond is exactly identical), so this is a genuine wall-time win at matched
 accuracy, not a "converged to a cheaper answer" artifact.
 
+## Follow-up diagnosis: the raw-message eligibility gate
+
+The first rerun still showed a substantial Comb-vs-NBlock gap at smaller
+bond dimensions. Instrumenting the evaluator showed that the Comb topology
+was not retaining raw messages at all: `can_use_raw_chain_leaf_center` rejected
+the entire evaluator whenever it saw a degree-3 node. With a leaf as the
+fixed centre, however, a degree-3 node has only two rooted children, exactly
+the shape handled by the new branch raw-message path. The old all-or-nothing
+gate therefore forced every cached message through `IdxTensor` materialization
+and generic contraction, even though the tree's rooted messages were eligible
+for the optimized leaf/chain/two-child-branch representation.
+
+The gate now permits degree-3 nodes while still rejecting degree-4 nodes and
+above, whose leaf-centred rooted form has at least three children and is not
+covered by the two-child branch kernel. The permanent regression tests
+`degree_three_hub_keeps_raw_messages_when_center_is_a_leaf` and
+`degree_four_hub_does_not_keep_raw_messages_when_center_is_a_leaf` cover both
+sides of this boundary. A same-configuration R=6 downstream run completed
+the Pi, W, and Sigma treeaci stages successfully after the change, with the
+raw branch path active for the Comb topology and no numerical failure.
+
 ## Verification
 
 - TDD throughout, same discipline as the `frames.rs` fix: every new
@@ -140,7 +161,10 @@ accuracy, not a "converged to a cheaper answer" artifact.
   `cached_evaluator_matches_tree_evaluate_on_star_tree_with_fixed_leaf_center`
   (end-to-end through the public `evaluate_batched` API -- the existing
   star-tree test fixed centre to the hub itself and never reached the branch
-  dispatch at all).
+  dispatch at all), plus
+  `degree_three_hub_keeps_raw_messages_when_center_is_a_leaf` and
+  `degree_four_hub_does_not_keep_raw_messages_when_center_is_a_leaf` for the
+  raw-message eligibility boundary.
 - `cargo fmt --all -- --check` clean.
 - `cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --all-targets -- -D warnings`
   clean (one fix needed: a `needless_range_loop` in the diagnostic's comb-tree
@@ -156,10 +180,11 @@ accuracy, not a "converged to a cheaper answer" artifact.
   at this local checkout for that validation; remove it once this PR merges
   and gw-rs's existing `branch = "main"` git dependencies pick up the merged
   commit on their own.
-- Nodes with 3+ children (degree >= 5) remain on the scalar/generic path,
-  same scope decision as the `frames.rs` fix and for the same reason: not
-  needed for #671's reported topology, and a general N-child version would
-  need an inter-step buffer transpose this 2-child case avoids.
+- Nodes with 3+ rooted children (degree >= 4 in the leaf-centred topology)
+  remain on the scalar/generic path, same scope decision as the `frames.rs`
+  fix and for the same reason: not needed for #671's reported topology, and a
+  general N-child version would need an inter-step buffer transpose this
+  2-child case avoids.
 - The synthetic same-bond diagnostic's numbers (25.84x / 29.26x / 44.24x)
   are kept as a regression-style measurement tool
   (`diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk`,


### PR DESCRIPTION
## Summary

Closes the branch-point performance gap reported in #671 (gw-rs's comb-topology `tree_elementwise` slowdown), via two structurally-analogous but independently-implemented fixes:

- **`tensor4all-treeaci/frames.rs`**: `candidate_frames_for_edge` and `FrameBuilder::compute_batch` only used a BLAS-batched contraction path for single-incoming-edge (chain) directed edges; branch nodes (2+ incoming edges) fell back to a scalar per-candidate loop. Adds `two_incoming_core_matrix_batched` and wires it in for the exactly-two-incoming-edge case. Worklog: `docs/worklogs/2026-08-22-treeaci-branch-batched-frames.md`.
- **`tensor4all-treetn/cached_evaluator.rs`**: `TreeTNCachedEvaluator` (used whenever `aci_global_guard=true`, gw-rs's downstream config) has the same "chain gets a raw BLAS fast path, branch falls to the generic path" shape, independently, for message-passing evaluation rather than local-update candidate contraction. Adds `grouped_branch_message_contraction` + `try_compute_branch_message_raw`/`_complex_raw`. Worklog: `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`.

The first fix alone did not move gw-rs's downstream `pi_rtau` wall time (confirmed by a downstream re-run) because `aci_global_guard=true` routes most evaluation through the second, untouched code path — the second fix is what actually closes the gap.

## Real downstream validation

Ran gw-rs's actual `sgw` binary (R=10, comb topology, `aci_global_guard=true`, `max_bond_dim=4096` — the same config #671 used), against a saved same-code baseline (this branch's first commit only, before the `tensor4all-treetn` fix):

| stage | baseline | with both fixes | bond (baseline -> fixed) | speedup |
|---|---:|---:|---|---:|
| pi_rtau | 103.55s | 33.7s | 90 -> 91 | 3.07x |
| W | 8.38s | 5.5s | 42 -> 43 | 1.52x |
| sigma_rtau | 72.77s | 23.1s | 81 -> 81 (identical) | 3.15x |

Bond dimensions/truncation errors match closely, so this is a genuine wall-time win at matched accuracy. Output correctness was separately re-verified by comparing the full NBlock (chain) vs Comb (this branch) `|G0|`/`|Π|`/`|W|`/`|Σ|` plots across 5 Matsubara rows -- all panels visually and numerically consistent with each other and with the analytic `G0` reference.

Comb is still slower than NBlock overall (not fully closing the gap) -- see the "Follow-up" sections of both worklogs for what's out of scope here (3+-incoming-edge / 3+-child nodes still use the scalar/generic path) and could be a next step.

## Test plan

- [x] TDD throughout both fixes: every new function/branch had a failing test confirmed red before implementation.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --release -p tensor4all-treeaci` and `--manifest-path crates/tensor4all-treetn/Cargo.toml`: all green (26 + 45 relevant tests, plus full crate suites incl. doctests during development).
- [x] Real gw-rs downstream pipeline re-run (see table above) and plot-level correctness comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)