### PR TITLE
fix(treeaci): canonicalized-guess rank fix + edge-commit hot-path efficiency

### DIFF
--- a/crates/tensor4all-treeaci/src/local_update.rs
+++ b/crates/tensor4all-treeaci/src/local_update.rs
@@ -8,7 +8,7 @@ use std::mem::size_of;
 
 use tensor4all_core::{matrix_luci_factors_from_matrix_owned, RrLUOptions};
 use tensor4all_core::{IdxTensor, IndexLike};
-use tensor4all_tensorbackend::Matrix;
+use tensor4all_tensorbackend::{mat_mul, transpose, Matrix};
 use tensor4all_treetn::TreeTN;
 
 use crate::{
@@ -150,22 +150,49 @@ where
     let row_frames = candidate_frames(inputs, problem, frames, forward, &row_candidates)?;
     let col_frames = candidate_frames(inputs, problem, frames, reverse, &col_candidates)?;
     let mut input_values = vec![T::default(); inputs.len() * point_count];
-    for (col, _) in col_candidates.iter().enumerate() {
-        for (row, _) in row_candidates.iter().enumerate() {
-            let point = row + row_count * col;
-            for input in 0..inputs.len() {
-                let left = &row_frames[input][row];
-                let right = &col_frames[input][col];
-                if left.len() != right.len() {
+    // Per input, `input_values[.., point] = row_frames[row] . col_frames[col]`
+    // is one (row_count x chi) times (chi x col_count) matrix product, not a
+    // per-point scalar dot product: pack each side's candidate frame vectors
+    // into a dense matrix (they are already contiguous per candidate, so this
+    // is a flatten, not a transpose) and let BLAS do the O(row*col*chi)
+    // contraction in one `mat_mul` call. Only the O(row*col) scatter into the
+    // batch's interleaved-by-input layout remains a plain loop.
+    if point_count > 0 {
+        for (input, (row_input_frames, col_input_frames)) in
+            row_frames.iter().zip(col_frames.iter()).enumerate()
+        {
+            let bond_dim = row_input_frames.first().map_or(0, |frame| frame.len());
+            for frame in row_input_frames.iter().chain(col_input_frames.iter()) {
+                if frame.len() != bond_dim {
                     return Err(TreeAciError::InternalInvariant {
                         message: "opposite input frames have different cut bond dimensions",
                     });
                 }
-                input_values[input + inputs.len() * point] = left
-                    .iter()
-                    .copied()
-                    .zip(right.iter().copied())
-                    .fold(T::default(), |sum, (lhs, rhs)| sum + lhs * rhs);
+            }
+            if bond_dim == 0 {
+                continue;
+            }
+            let row_flat: Vec<T> = row_input_frames
+                .iter()
+                .flat_map(|frame| frame.iter().copied())
+                .collect();
+            let col_flat: Vec<T> = col_input_frames
+                .iter()
+                .flat_map(|frame| frame.iter().copied())
+                .collect();
+            let row_bond_matrix = Matrix::from_col_major_vec(bond_dim, row_count, row_flat);
+            let col_bond_matrix = Matrix::from_col_major_vec(bond_dim, col_count, col_flat);
+            let row_candidate_matrix = transpose(&row_bond_matrix);
+            let product = mat_mul(&row_candidate_matrix, &col_bond_matrix).map_err(|error| {
+                TreeAciError::Numerical {
+                    message: error.to_string(),
+                }
+            })?;
+            for col in 0..col_count {
+                for row in 0..row_count {
+                    let point = row + row_count * col;
+                    input_values[input + inputs.len() * point] = product[[row, col]];
+                }
             }
         }
     }

--- a/crates/tensor4all-treeaci/src/schedule.rs
+++ b/crates/tensor4all-treeaci/src/schedule.rs
@@ -243,7 +243,8 @@ where
                 message: "a scheduled path starts at an unknown node",
             })?
             .clone();
-        if state.output.canonical_region() != &std::collections::HashSet::from([start]) {
+        let region = state.output.canonical_region();
+        if region.len() != 1 || !region.contains(&start) {
             return Err(TreeAciError::InternalInvariant {
                 message: "continuous sweep does not start at the current canonical center",
             });

--- a/crates/tensor4all-treeaci/src/state.rs
+++ b/crates/tensor4all-treeaci/src/state.rs
@@ -41,7 +41,7 @@ impl<'a, T: TreeAciScalar, V: TreeAciNode> TreeAciState<'a, T, V> {
     ) -> Result<Self> {
         let problem = prepare_problem(inputs, options)?;
         let algebraic_edge_bounds = algebraic_edge_bounds(&problem)?;
-        let edge_ranks = initial_edge_ranks(inputs, &problem, options)?;
+        let initial_edge_ranks = initial_edge_ranks(inputs, &problem, options)?;
         let output = if let Some(guess) = &options.initial_guess {
             validate_initial_guess::<T, V>(guess, &inputs[0], &problem, options)?;
             let mut output = guess.clone();
@@ -52,9 +52,43 @@ impl<'a, T: TreeAciScalar, V: TreeAciNode> TreeAciState<'a, T, V> {
             output
         } else {
             let mut output =
-                build_random_output::<T, V>(&inputs[0], &problem, &edge_ranks, options)?;
+                build_random_output::<T, V>(&inputs[0], &problem, &initial_edge_ranks, options)?;
             output.set_canonical_region([problem.root.clone()])?;
             output
+        };
+        // INVARIANT: canonicalizing an initial guess may expose a smaller
+        // numerical bond rank, so active ranks must describe the canonical
+        // output used to bootstrap samples and frames rather than the raw
+        // pre-canonicalization guess.
+        let edge_ranks = if options.initial_guess.is_some() {
+            let configured = options.max_bond_dim.unwrap_or(usize::MAX);
+            problem
+                .directed_edges
+                .iter()
+                .step_by(2)
+                .enumerate()
+                .map(|(edge_number, edge)| {
+                    let graph_edge = output.edge_between(&edge.from, &edge.to).ok_or(
+                        crate::TreeAciError::InternalInvariant {
+                            message: "initialized output is missing a prepared edge",
+                        },
+                    )?;
+                    let rank = output
+                        .bond_index(graph_edge)
+                        .ok_or(crate::TreeAciError::InternalInvariant {
+                            message: "initialized output edge has no bond index",
+                        })?
+                        .dim();
+                    if rank > algebraic_edge_bounds[edge_number] || rank > configured {
+                        return Err(crate::TreeAciError::InternalInvariant {
+                            message: "canonicalized initial guess exceeds an active rank bound",
+                        });
+                    }
+                    Ok(rank)
+                })
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            initial_edge_ranks
         };
         for (edge_number, expected) in edge_ranks.iter().copied().enumerate() {
             let edge = &problem.directed_edges[2 * edge_number];

--- a/crates/tensor4all-treeaci/src/state/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/state/tests/mod.rs
@@ -28,6 +28,18 @@ fn two_node_tree(sites: [DynIndex; 2], rank: usize, scale: f64) -> TreeTN<IdxTen
     TreeTN::from_tensors(vec![left, right], vec![0, 1]).unwrap()
 }
 
+fn rank_deficient_two_node_tree(sites: [DynIndex; 2]) -> TreeTN<IdxTensor, usize> {
+    let bond = DynIndex::new_dyn(2);
+    let left = IdxTensor::from_dense(
+        vec![sites[0].clone(), bond.clone()],
+        vec![1.0, 2.0, 1.0, 2.0],
+    )
+    .unwrap();
+    let right =
+        IdxTensor::from_dense(vec![bond, sites[1].clone()], vec![3.0, 4.0, 3.0, 4.0]).unwrap();
+    TreeTN::from_tensors(vec![left, right], vec![0, 1]).unwrap()
+}
+
 fn output_values(state: &TreeAciState<'_, f64, usize>) -> Vec<Vec<f64>> {
     tree_values(&state.output, &state.problem.node_order)
 }
@@ -118,6 +130,32 @@ fn explicit_guess_is_preserved_before_the_first_sweep() {
         .unwrap());
     assert_eq!(state.edge_ranks, vec![1]);
     assert_eq!(state.output.canonical_form(), Some(CanonicalForm::CI));
+}
+
+#[test]
+fn rank_deficient_initial_guess_uses_canonicalized_active_rank() {
+    let sites = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let inputs = vec![two_node_tree(sites.clone(), 1, 1.0)];
+    let guess = rank_deficient_two_node_tree(sites);
+
+    let state = TreeAciState::<f64, usize>::initialize(
+        &inputs,
+        &TreeAciOptions {
+            initial_guess: Some(guess),
+            ..TreeAciOptions::default()
+        },
+    )
+    .expect("rank-deficient initial guess should initialize");
+
+    assert_eq!(state.edge_ranks, vec![1]);
+    assert_eq!(
+        state
+            .output
+            .bond_index(state.output.edge_between(&0, &1).unwrap())
+            .unwrap()
+            .dim(),
+        1
+    );
 }
 
 #[test]

--- a/crates/tensor4all-treeaci/src/transaction.rs
+++ b/crates/tensor4all-treeaci/src/transaction.rs
@@ -134,23 +134,27 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
     // edges see them. Replacement rather than union is what keeps candidate
     // growth bounded without an eviction policy, mirroring train ACI rebuilding
     // its frames from the selected pivots.
-    let mut proposed_candidates = state.candidates.clone();
-    proposed_candidates.ids[forward] = left_ids.clone();
-    proposed_candidates.ids[reverse] = right_ids.clone();
-    proposed_candidates.generation = next_generation;
+    //
+    // `state.candidates`/`state.pivots` are mutated in place rather than
+    // cloned-then-swapped: every step above this point that could fail (the
+    // `staged` closure) has already returned, so nothing below can fail and a
+    // clone-for-rollback buys no atomicity. These two hold one entry list per
+    // directed edge (`CandidateSets::ids`, `PivotPairs::per_edge`), each up to
+    // `max_bond_dim` long, so cloning them here was O(edges * bond_dim) of
+    // pure waste on every single edge commit.
+    state.candidates.ids[forward] = left_ids.clone();
+    state.candidates.ids[reverse] = right_ids.clone();
+    state.candidates.generation = next_generation;
 
-    let mut proposed_pivots = state.pivots.clone();
     let pivot_pairs = if forward.is_multiple_of(2) {
         left_ids.into_iter().zip(right_ids).collect()
     } else {
         right_ids.into_iter().zip(left_ids).collect()
     };
-    proposed_pivots.set(edge_number, pivot_pairs);
+    state.pivots.set(edge_number, pivot_pairs);
 
     let pivot_error = proposal.pivot_errors.last().copied().unwrap_or(0.0);
     state.output = proposed_output;
-    state.candidates = proposed_candidates;
-    state.pivots = proposed_pivots;
     state.input_frames = proposed_frames;
     state.edge_ranks[edge_number] = state.pivots.rank(edge_number);
     state.edge_errors[edge_number] = pivot_error;


### PR DESCRIPTION
## Summary

- Recompute active edge ranks from the *canonicalized* initial guess instead of the raw pre-canonicalization guess, fixing a rank-mismatch crash when canonicalization exposes a smaller numerical bond rank than the guess reports (observed as a rank mismatch on a degree-three branch edge in downstream `gw-rs` runs).
- Drop two `O(edges * bond_dim)` clones (`state.candidates`, `state.pivots`) from `commit_edge_proposal`'s edge-commit hot path -- nothing between the `staged` closure succeeding and the final field assignment can fail, so the clone-then-swap bought no atomicity these two fields didn't already have from in-place mutation.
- Drop a per-sweep-step `HashSet` allocation in `run_phase_serial`'s canonical-center check in favor of a length + containment comparison against the existing set.
- Replace `materialize_and_factor_edge`'s scalar dot-product loop for candidate-frame contraction with a BLAS `mat_mul` call, mirroring the pattern `tensor4all-aci`'s chain-only local update already uses.

## Validation

- `cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --lib`: 115 passed (includes atomicity regression tests for the edge-commit rollback path and a dedicated `rank_deficient_initial_guess_uses_canonicalized_active_rank` test for the canonicalization fix).
- `cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --doc`: 18 passed.
- `cargo test --manifest-path crates/tensor4all-aci/Cargo.toml --lib` (downstream consumer, includes the treeaci/aci parity benchmark harness): 85 passed.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean on both crates.
- Verified against the downstream `gw-rs` R10/T=0.01 nblock treeaci pipeline (guard disabled to isolate the ACI-heavy stages, stacked measurement across each commit): `pi_rtau` 10.9s -> 10.5s -> 9.1s, `sigma_rtau` 2.4s -> 2.3s -> 2.2s, same final errors (~1e-4 target) and sanity values within normal run-to-run noise.
- Also verified guard-enabled (gw-rs's actual default config): raw wall-clock is noisy run-to-run because ACI sweep count is sensitive to floating-point summation order (a known characteristic of this class of algorithm, not a regression), but per-evaluated-point time improved 6-16% consistent with the guard-disabled measurement once normalized for sweep-count variance.
- No coverage-impacting deletions; this PR only adds tests and narrows the amount of runtime state cloned.

## Test plan

- [x] `cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --lib --features tensor4all-core/backend-tenferro`
- [x] `cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --doc --features tensor4all-core/backend-tenferro`
- [x] `cargo test --manifest-path crates/tensor4all-aci/Cargo.toml --lib --features tensor4all-core/backend-tenferro`
- [x] `cargo clippy --manifest-path crates/tensor4all-treeaci/Cargo.toml --all-targets --features tensor4all-core/backend-tenferro -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Downstream `gw-rs` R10/T=0.01 nblock treeaci pipeline, guard disabled and guard enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)