### PR TITLE
Add explicit CUDA TreeTN contraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,3 +88,4 @@ tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a
 tenferro-einsum = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
 tenferro-linalg = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
 tenferro-tensor = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
+tenferro-gpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }

--- a/crates/tensor4all-core/Cargo.toml
+++ b/crates/tensor4all-core/Cargo.toml
@@ -10,6 +10,14 @@ description = "Core tensor types, indices, and operations (SVD, QR, contraction)
 [features]
 default = ["backend-tenferro", "tenferro-cpu-faer"]
 backend-tenferro = ["tensor4all-tensorbackend/backend-tenferro"]
+tenferro-cuda = [
+    "backend-tenferro",
+    "tenferro-cpu-faer",
+    "tensor4all-tensorbackend/tenferro-cuda",
+    "tenferro-ad/cuda",
+    "tenferro-einsum/cuda",
+    "tenferro-linalg/cuda",
+]
 tenferro-cpu-faer = [
     "tensor4all-tensorbackend/tenferro-cpu-faer",
     "tenferro/cpu-faer",

--- a/crates/tensor4all-core/src/defaults/cuda.rs
+++ b/crates/tensor4all-core/src/defaults/cuda.rs
@@ -1,0 +1,306 @@
+//! CUDA transfer boundaries for [`IdxTensor`].
+
+use std::sync::Arc;
+
+use tenferro_ad::EagerTensor;
+use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError, StorageKind};
+
+use super::idx_tensor::{IdxTensor, TensorStorageError};
+
+/// Error returned by explicit [`IdxTensor`] CUDA transfer and residency checks.
+///
+/// CUDA transfer is deliberately limited to untracked, logically dense values.
+/// The error retains deferred-storage and context failures as typed sources; it
+/// never falls back to a CPU transfer or exposes runtime identifiers.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_core::defaults::IdxTensorCudaError;
+///
+/// let error = IdxTensorCudaError::Tracked { operation: "upload" };
+/// assert!(error.to_string().contains("tracked"));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum IdxTensorCudaError {
+    /// The tensor has a deferred storage diagnostic that must be reported first.
+    #[error("IdxTensor CUDA {operation} rejected deferred storage: {source}")]
+    DeferredStorage {
+        /// Operation that observed the deferred storage.
+        operation: &'static str,
+        /// Original storage diagnostic.
+        #[source]
+        source: TensorStorageError,
+    },
+    /// CUDA transfer does not preserve automatic-differentiation tracking.
+    #[error(
+        "IdxTensor CUDA {operation} rejects tracked values; provide an untracked dense tensor"
+    )]
+    Tracked {
+        /// Operation that rejected the tracked tensor.
+        operation: &'static str,
+    },
+    /// CUDA transfer does not accept diagonal or general structured storage.
+    #[error("IdxTensor CUDA {operation} requires dense storage, got {kind:?}")]
+    UnsupportedStorage {
+        /// Operation that rejected the storage layout.
+        operation: &'static str,
+        /// Logical storage layout observed before any materialization.
+        kind: StorageKind,
+    },
+    /// CUDA transfer requires canonical one-class-per-axis metadata.
+    #[error("IdxTensor CUDA {operation} requires dense axis classes")]
+    NonDenseAxisClasses {
+        /// Operation that rejected the axis metadata.
+        operation: &'static str,
+    },
+    /// A residency check found no eager value to inspect.
+    #[error("IdxTensor CUDA {operation} requires an eager value")]
+    MissingEagerInner {
+        /// Operation that required the eager value.
+        operation: &'static str,
+    },
+    /// The supplied CUDA context rejected placement or initialization metadata.
+    #[error("IdxTensor CUDA {operation} context operation failed: {source}")]
+    Context {
+        /// Operation that observed the context failure.
+        operation: &'static str,
+        /// Original typed context diagnostic.
+        #[source]
+        source: CudaExecutionContextError,
+    },
+    /// The tensor belongs to another eager CUDA context.
+    #[error("IdxTensor CUDA {operation} received a value from another context")]
+    ForeignContext {
+        /// Operation that observed the context mismatch.
+        operation: &'static str,
+    },
+    /// Native eager wrapping or explicit transfer preparation failed.
+    #[error("IdxTensor CUDA {operation} failed: {source}")]
+    Operation {
+        /// Operation that failed.
+        operation: &'static str,
+        /// Original native or eager diagnostic.
+        #[source]
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+}
+
+fn precheck(tensor: &IdxTensor, operation: &'static str) -> Result<(), IdxTensorCudaError> {
+    if let Some(source) = tensor.deferred_storage_error() {
+        return Err(IdxTensorCudaError::DeferredStorage {
+            operation,
+            source: source.clone(),
+        });
+    }
+    if tensor.tracks_grad() {
+        return Err(IdxTensorCudaError::Tracked { operation });
+    }
+    let kind = tensor.storage_kind();
+    if kind != StorageKind::Dense {
+        return Err(IdxTensorCudaError::UnsupportedStorage { operation, kind });
+    }
+    if !tensor
+        .axis_classes()
+        .iter()
+        .copied()
+        .eq(0..tensor.indices().len())
+    {
+        return Err(IdxTensorCudaError::NonDenseAxisClasses { operation });
+    }
+    Ok(())
+}
+
+fn operation_error<E>(operation: &'static str, source: E) -> IdxTensorCudaError
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+{
+    IdxTensorCudaError::Operation {
+        operation,
+        source: Arc::from(source.into()),
+    }
+}
+
+fn context_error(operation: &'static str, source: CudaExecutionContextError) -> IdxTensorCudaError {
+    IdxTensorCudaError::Context { operation, source }
+}
+
+impl IdxTensor {
+    /// Upload this untracked, logically dense tensor into a CUDA context.
+    ///
+    /// The host value is duplicated before the explicit device transfer. The
+    /// returned tensor keeps the original ordered indices and is owned by the
+    /// supplied context's eager runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorCudaError`] when storage is deferred, tracked,
+    /// structured, not eagerly materializable, unsupported by CUDA, or when the
+    /// explicit context transfer fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{CudaExecutionContext, IdxTensor, IdxTensorCudaError};
+    ///
+    /// let upload: fn(
+    ///     &IdxTensor,
+    ///     &CudaExecutionContext,
+    /// ) -> Result<IdxTensor, IdxTensorCudaError> = IdxTensor::upload_cuda;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&upload),
+    ///     std::mem::size_of::<fn(
+    ///         &IdxTensor,
+    ///         &CudaExecutionContext,
+    ///     ) -> Result<IdxTensor, IdxTensorCudaError>>(),
+    /// );
+    /// ```
+    pub fn upload_cuda(&self, context: &CudaExecutionContext) -> Result<Self, IdxTensorCudaError> {
+        precheck(self, "upload")?;
+        let native = self
+            .cuda_duplicate_native()
+            .map_err(|source| operation_error("upload materialization", source))?;
+        let uploaded = context
+            .upload_cuda(&native)
+            .map_err(|source| context_error("upload", source))?;
+        let inner = EagerTensor::from_tensor_in(
+            uploaded,
+            context
+                .eager_runtime()
+                .map_err(|source| context_error("upload", source))?,
+        )
+        .map_err(|source| operation_error("upload eager wrapping", source))?;
+        Self::from_inner(self.indices.clone(), inner)
+            .map_err(|source| operation_error("upload tensor construction", source))
+    }
+
+    /// Download this CUDA-resident tensor into the host eager context.
+    ///
+    /// The residency and context checks are metadata-only. The resident value
+    /// is then duplicated in its device allocation domain, downloaded
+    /// explicitly, and reconstructed with the original ordered indices.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorCudaError`] when the value is not an untracked dense
+    /// tensor resident in the supplied context, or when explicit download or
+    /// host reconstruction fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{CudaExecutionContext, IdxTensor, IdxTensorCudaError};
+    ///
+    /// let download: fn(
+    ///     &IdxTensor,
+    ///     &CudaExecutionContext,
+    /// ) -> Result<IdxTensor, IdxTensorCudaError> = IdxTensor::download;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&download),
+    ///     std::mem::size_of::<fn(
+    ///         &IdxTensor,
+    ///         &CudaExecutionContext,
+    ///     ) -> Result<IdxTensor, IdxTensorCudaError>>(),
+    /// );
+    /// ```
+    pub fn download(&self, context: &CudaExecutionContext) -> Result<Self, IdxTensorCudaError> {
+        self.validate_cuda_residency(context)?;
+        let resident = self
+            .cuda_duplicate_native()
+            .map_err(|source| operation_error("download materialization", source))?;
+        let host = context
+            .download(&resident)
+            .map_err(|source| context_error("download", source))?;
+        Self::from_native(self.indices.clone(), host)
+            .map_err(|source| operation_error("download tensor construction", source))
+    }
+
+    /// Validate CUDA placement and eager-runtime identity without reading data.
+    ///
+    /// This checks the existing eager value's context identity and
+    /// [`tenferro::TensorRead`] placement metadata. It does not duplicate,
+    /// download, or otherwise access host tensor values.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorCudaError`] when the tensor is deferred, tracked,
+    /// structured, missing an eager value, placed on a different CUDA context,
+    /// or rejected by the supplied context's placement validator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{CudaExecutionContext, IdxTensor, IdxTensorCudaError};
+    ///
+    /// let validate: fn(
+    ///     &IdxTensor,
+    ///     &CudaExecutionContext,
+    /// ) -> Result<(), IdxTensorCudaError> = IdxTensor::validate_cuda_residency;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&validate),
+    ///     std::mem::size_of::<fn(
+    ///         &IdxTensor,
+    ///         &CudaExecutionContext,
+    ///     ) -> Result<(), IdxTensorCudaError>>(),
+    /// );
+    /// ```
+    pub fn validate_cuda_residency(
+        &self,
+        context: &CudaExecutionContext,
+    ) -> Result<(), IdxTensorCudaError> {
+        precheck(self, "validate CUDA residency")?;
+        let inner = self
+            .cuda_eager_inner()
+            .ok_or(IdxTensorCudaError::MissingEagerInner {
+                operation: "validate CUDA residency",
+            })?;
+        let expected_context = context
+            .context_id()
+            .map_err(|source| context_error("validate CUDA residency", source))?;
+        if inner.ctx_id() != expected_context {
+            return Err(IdxTensorCudaError::ForeignContext {
+                operation: "validate CUDA residency",
+            });
+        }
+        let read = inner.tensor_read();
+        context
+            .validate_cuda_placement_metadata(read.placement(), read.allocation_domain())
+            .map_err(|source| context_error("validate CUDA residency", source))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tensor4all_tensorbackend::{Storage, StorageKind};
+
+    use super::*;
+    use crate::{DynIndex, IdxTensor};
+
+    #[test]
+    fn structured_transfer_rejection_needs_no_cuda_context() {
+        let i = DynIndex::new_dyn(2);
+        let j = DynIndex::new_dyn(2);
+        let storage = Arc::new(Storage::from_diag_col_major(vec![1.0_f64, 2.0], 2).unwrap());
+        let tensor = IdxTensor::from_structured_storage(vec![i, j], storage).unwrap();
+
+        assert!(matches!(
+            precheck(&tensor, "upload"),
+            Err(IdxTensorCudaError::UnsupportedStorage {
+                kind: StorageKind::Diagonal,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tracked_transfer_rejection_needs_no_cuda_context() {
+        let tensor = IdxTensor::scalar(1.0_f64).unwrap().enable_grad().unwrap();
+
+        assert!(matches!(
+            precheck(&tensor, "upload"),
+            Err(IdxTensorCudaError::Tracked { .. })
+        ));
+    }
+}

--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -3057,6 +3057,23 @@ impl IdxTensor {
         self.storage.axis_classes()
     }
 
+    #[cfg(feature = "tenferro-cuda")]
+    pub(crate) fn deferred_storage_error(&self) -> Option<&TensorStorageError> {
+        self.storage.deferred_error()
+    }
+
+    #[cfg(feature = "tenferro-cuda")]
+    pub(crate) fn cuda_eager_inner(&self) -> Option<&EagerTensor> {
+        self.storage
+            .eager()
+            .or_else(|| self.eager_cache.get().map(AsRef::as_ref))
+    }
+
+    #[cfg(feature = "tenferro-cuda")]
+    pub(crate) fn cuda_duplicate_native(&self) -> Result<NativeTensor> {
+        Ok(self.try_materialized_inner()?.duplicate_value()?)
+    }
+
     /// Enable reverse-mode AD tracking on this tensor by creating a tracked leaf.
     /// # Errors
     /// Returns an error when the tensor is not a scalar (a rank mismatch) or the
@@ -3270,6 +3287,39 @@ impl IdxTensor {
     /// ```
     pub fn storage_kind(&self) -> StorageKind {
         self.storage.storage_kind()
+    }
+
+    /// Return the exact eager scalar dtype without reading tensor values.
+    ///
+    /// This feature-gated accessor is used by the CUDA TreeTN boundary to
+    /// reject mixed dtypes before the first device contraction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdxTensorError`] when the dtype cannot be determined from the
+    /// tensor metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "tenferro-cuda")]
+    /// # {
+    /// use tensor4all_core::{DynIndex, IdxTensor, IdxTensorError};
+    ///
+    /// let tensor = IdxTensor::from_dense(vec![DynIndex::new_dyn(1)], vec![1.0_f32]).unwrap();
+    /// let dtype = tensor.cuda_dtype().unwrap();
+    /// assert_eq!(dtype, tenferro::DType::F32);
+    /// let accessor: fn(&IdxTensor) -> Result<tenferro::DType, IdxTensorError> =
+    ///     IdxTensor::cuda_dtype;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&accessor),
+    ///     std::mem::size_of::<fn(&IdxTensor) -> Result<tenferro::DType, IdxTensorError>>(),
+    /// );
+    /// # }
+    /// ```
+    #[cfg(feature = "tenferro-cuda")]
+    pub fn cuda_dtype(&self) -> std::result::Result<DType, IdxTensorError> {
+        self.scalar_dtype().map_err(IdxTensorError::from)
     }
 
     /// Sum all elements, returning `AnyScalar`.

--- a/crates/tensor4all-core/src/defaults/mod.rs
+++ b/crates/tensor4all-core/src/defaults/mod.rs
@@ -17,6 +17,8 @@
 //! These types are suitable for most tensor network applications and provide
 //! a good balance of flexibility and performance.
 
+#[cfg(feature = "tenferro-cuda")]
+mod cuda;
 /// Dynamic-length tensor implementation.
 pub mod idx_tensor;
 pub mod index;
@@ -36,6 +38,8 @@ pub use contract::{
     contract_pair_with_options, contract_with_options, outer_product,
     print_and_reset_contract_profile, reset_contract_profile, tensordot, ContractionOptions,
 };
+#[cfg(feature = "tenferro-cuda")]
+pub use cuda::IdxTensorCudaError;
 pub use idx_tensor::{
     compute_permutation_from_indices, diag_idx_tensor, print_and_reset_pairwise_contract_profile,
     reset_pairwise_contract_profile, unfold_split, IdxTensor, IdxTensorError, TensorStorageError,

--- a/crates/tensor4all-core/src/lib.rs
+++ b/crates/tensor4all-core/src/lib.rs
@@ -117,10 +117,14 @@ pub use defaults::idx_tensor::{
     compute_permutation_from_indices, diag_idx_tensor, unfold_split, IdxTensor, IdxTensorError,
     StructuredSelectorError, TensorStorageError,
 };
+#[cfg(feature = "tenferro-cuda")]
+pub use defaults::IdxTensorCudaError;
 pub use tensor4all_tensorbackend::TensorElement;
 pub use tensor4all_tensorbackend::{
     print_and_reset_native_einsum_profile, reset_native_einsum_profile,
 };
+#[cfg(feature = "tenferro-cuda")]
+pub use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError, CUDA_ORDINAL};
 pub use tensor_like::{
     Canonical, DirectSumResult, FactorizeAlg, FactorizeError, FactorizeOptions, FactorizeResult,
     LinearizationOrder, TensorConstructionLike, TensorContractionLike, TensorFactorizationLike,

--- a/crates/tensor4all-core/tests/cuda_transfer.rs
+++ b/crates/tensor4all-core/tests/cuda_transfer.rs
@@ -1,0 +1,43 @@
+#![cfg(feature = "tenferro-cuda")]
+
+use tensor4all_core::{CudaExecutionContext, DynIndex, IdxTensor, IdxTensorCudaError};
+
+#[test]
+fn dense_upload_download_preserves_indices_and_values() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let i = DynIndex::new_dyn(2);
+    let j = DynIndex::new_dyn(3);
+    let source = IdxTensor::from_dense(
+        vec![i.clone(), j.clone()],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+    )
+    .unwrap();
+
+    let resident = source.upload_cuda(&context).unwrap();
+    resident.validate_cuda_residency(&context).unwrap();
+    assert!(resident.to_vec::<f64>().is_err());
+
+    let restored = resident.download(&context).unwrap();
+    assert_eq!(restored.indices(), &[i, j]);
+    assert_eq!(
+        restored.to_vec::<f64>().unwrap(),
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    );
+}
+
+#[test]
+fn foreign_context_is_typed() {
+    let first = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let second = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let source = IdxTensor::from_dense(vec![DynIndex::new_dyn(1)], vec![2.0_f64]).unwrap();
+    let resident = source.upload_cuda(&first).unwrap();
+
+    assert!(matches!(
+        resident.validate_cuda_residency(&second),
+        Err(IdxTensorCudaError::ForeignContext { .. })
+    ));
+    assert!(matches!(
+        resident.download(&second),
+        Err(IdxTensorCudaError::ForeignContext { .. })
+    ));
+}

--- a/crates/tensor4all-tensorbackend/Cargo.toml
+++ b/crates/tensor4all-tensorbackend/Cargo.toml
@@ -17,6 +17,17 @@ backend-tenferro = ["global-defaults"]
 explicit-context = []
 # Opt-in legacy operations backed by one process-global context.
 global-defaults = ["explicit-context"]
+tenferro-cuda = [
+    "explicit-context",
+    "tenferro-cpu-faer",
+    "dep:tenferro-gpu",
+    "tenferro-gpu/cuda",
+    "tenferro-ad/cuda",
+    "tenferro-einsum/autodiff",
+    "tenferro-einsum/cuda",
+    "tenferro-linalg/autodiff",
+    "tenferro-linalg/cuda",
+]
 tenferro-cpu-faer = [
     "tenferro/cpu-faer",
     "tenferro-ad/cpu-faer",
@@ -60,6 +71,7 @@ tenferro-cpu.workspace = true
 tenferro-einsum.workspace = true
 tenferro-linalg.workspace = true
 tenferro-tensor.workspace = true
+tenferro-gpu = { workspace = true, optional = true }
 
 [dev-dependencies]
 approx.workspace = true

--- a/crates/tensor4all-tensorbackend/src/cuda.rs
+++ b/crates/tensor4all-tensorbackend/src/cuda.rs
@@ -1,0 +1,517 @@
+//! Explicit CUDA execution context and transfer boundaries.
+
+use std::fmt;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tenferro::Tensor;
+use tenferro_ad::{ContextId, EagerRuntime};
+use tenferro_gpu::cuda::{cuda_devices, CudaBackend};
+use tenferro_tensor::{
+    AllocationDomainId, BackendSessionHost, DeviceId, DeviceKind, GpuBackendKind, MemoryKind,
+    Placement, TensorRead,
+};
+
+/// The only CUDA ordinal selected by [`CudaExecutionContext`].
+pub const CUDA_ORDINAL: u32 = 0;
+
+/// Error returned by explicit CUDA context creation, placement validation, and
+/// device transfer.
+///
+/// The original provider, runtime, or tensor diagnostic is retained as the
+/// standard error source where one exists. CUDA operations never fall back to
+/// a CPU backend or perform an implicit transfer.
+///
+/// # Remedies
+///
+/// - Initialization failures: make visible CUDA ordinal 0 and its runtime
+///   libraries available, then retry [`CudaExecutionContext::new`].
+/// - Placement failures: use [`CudaExecutionContext::upload_cuda`] for a host
+///   tensor, or use one context consistently for resident values.
+/// - Transfer failures: keep the explicit upload/download boundary and inspect
+///   the retained source error.
+///
+/// # Examples
+///
+/// ```
+/// use std::error::Error;
+/// use std::sync::Arc;
+/// use tensor4all_tensorbackend::CudaExecutionContextError;
+///
+/// let error = CudaExecutionContextError::Initialization {
+///     component: "CUDA backend",
+///     source: Arc::new(std::io::Error::other("driver unavailable")),
+/// };
+/// assert!(error.source().is_some());
+/// assert!(error.to_string().contains("driver unavailable"));
+/// ```
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum CudaExecutionContextError {
+    /// CUDA device or eager-runtime initialization failed.
+    #[error(
+        "failed to initialize CUDA {component}: {source}; make visible CUDA ordinal 0 and retry"
+    )]
+    Initialization {
+        /// Context component that failed to initialize.
+        component: &'static str,
+        /// Original provider or runtime diagnostic.
+        #[source]
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+    /// An explicit upload or download failed.
+    #[error("CUDA {operation} transfer failed: {source}; keep the transfer explicit and inspect the source error")]
+    Transfer {
+        /// Transfer operation that failed.
+        operation: &'static str,
+        /// Original backend transfer diagnostic.
+        #[source]
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+    /// A host/device placement does not satisfy the context contract.
+    #[error("CUDA {operation} placement mismatch: expected a dense value on visible CUDA ordinal 0; use explicit upload_cuda/download or one context consistently")]
+    PlacementMismatch {
+        /// Operation that observed the mismatch.
+        operation: &'static str,
+    },
+    /// A resident allocation belongs to another CUDA allocation domain.
+    #[error("CUDA {operation} received a foreign allocation domain; use one CudaExecutionContext for upload, computation, and download")]
+    ForeignAllocation {
+        /// Operation that observed the foreign allocation.
+        operation: &'static str,
+    },
+    /// An input violates the host-only upload boundary.
+    #[error("CUDA {operation} received an unsupported input: {reason}; {remedy}")]
+    UnsupportedInput {
+        /// Operation that rejected the input.
+        operation: &'static str,
+        /// Stable reason for rejecting the input.
+        reason: &'static str,
+        /// Corrective action for the caller.
+        remedy: &'static str,
+    },
+    /// Synchronization of the context-owned CUDA stream failed.
+    #[error("CUDA synchronization failed: {source}; retry after checking the CUDA runtime")]
+    Synchronization {
+        /// Original CUDA synchronization diagnostic.
+        #[source]
+        source: Arc<dyn std::error::Error + Send + Sync + 'static>,
+    },
+}
+
+/// Caller-owned CUDA execution domain for explicit ordinal-0 transfers.
+///
+/// The context owns one [`CudaBackend`] and lazily creates one shared
+/// [`EagerRuntime`] from a clone of that backend. Cloning preserves the
+/// provider's runtime and allocation-domain identity. No CPU backend, global
+/// CUDA context, or implicit transfer is used.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+/// use std::sync::Arc;
+/// use tenferro_ad::EagerRuntime;
+/// use tenferro::Tensor;
+///
+/// let new_context: fn() -> Result<CudaExecutionContext, CudaExecutionContextError> =
+///     CudaExecutionContext::new;
+/// let upload: fn(&CudaExecutionContext, &Tensor) -> Result<Tensor, CudaExecutionContextError> =
+///     CudaExecutionContext::upload_cuda;
+/// let eager: fn(&CudaExecutionContext) -> Result<Arc<EagerRuntime>, CudaExecutionContextError> =
+///     CudaExecutionContext::eager_runtime;
+/// assert_eq!(std::mem::size_of_val(&new_context), std::mem::size_of::<fn() -> Result<CudaExecutionContext, CudaExecutionContextError>>());
+/// assert_eq!(std::mem::size_of_val(&upload), std::mem::size_of::<fn(&CudaExecutionContext, &Tensor) -> Result<Tensor, CudaExecutionContextError>>());
+/// assert_eq!(std::mem::size_of_val(&eager), std::mem::size_of::<fn(&CudaExecutionContext) -> Result<Arc<EagerRuntime>, CudaExecutionContextError>>());
+/// ```
+pub struct CudaExecutionContext {
+    backend: Mutex<CudaBackend>,
+    eager: OnceLock<Result<Arc<EagerRuntime>, CudaExecutionContextError>>,
+    device_name: String,
+}
+
+impl fmt::Debug for CudaExecutionContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CudaExecutionContext")
+            .field("ordinal", &CUDA_ORDINAL)
+            .field("device_name", &self.device_name)
+            .field("eager_initialized", &self.eager.get().is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CudaExecutionContext {
+    /// Create a context for visible CUDA ordinal 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError, CUDA_ORDINAL};
+    /// let constructor: fn() -> Result<CudaExecutionContext, CudaExecutionContextError> = CudaExecutionContext::new;
+    /// assert_eq!(CUDA_ORDINAL, 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::Initialization`] when device
+    /// discovery or CUDA runtime initialization fails.
+    pub fn new() -> Result<Self, CudaExecutionContextError> {
+        let device = cuda_devices()
+            .map_err(|source| CudaExecutionContextError::Initialization {
+                component: "device discovery",
+                source: Arc::new(source),
+            })?
+            .into_iter()
+            .find(|device| device.id().ordinal() == CUDA_ORDINAL)
+            .ok_or_else(|| CudaExecutionContextError::Initialization {
+                component: "device discovery",
+                source: Arc::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "visible CUDA ordinal 0 is unavailable",
+                )),
+            })?;
+        let device_name = device.name().to_owned();
+        let backend = CudaBackend::new(device.id()).map_err(|source| {
+            CudaExecutionContextError::Initialization {
+                component: "backend",
+                source: Arc::new(source),
+            }
+        })?;
+        Ok(Self {
+            backend: Mutex::new(backend),
+            eager: OnceLock::new(),
+            device_name,
+        })
+    }
+
+    /// Return the only supported visible CUDA ordinal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CUDA_ORDINAL};
+    /// let accessor: fn(&CudaExecutionContext) -> u32 = CudaExecutionContext::ordinal;
+    /// assert_eq!(CUDA_ORDINAL, 0);
+    /// ```
+    pub const fn ordinal(&self) -> u32 {
+        CUDA_ORDINAL
+    }
+
+    /// Return the discovered name of visible CUDA ordinal 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::CudaExecutionContext;
+    /// let accessor: for<'a> fn(&'a CudaExecutionContext) -> &'a str = CudaExecutionContext::device_name;
+    /// assert!(std::mem::size_of_val(&accessor) > 0);
+    /// ```
+    pub fn device_name(&self) -> &str {
+        &self.device_name
+    }
+
+    /// Return this context's eager runtime identity, initializing it lazily.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// let accessor: fn(&CudaExecutionContext) -> Result<tenferro_ad::ContextId, CudaExecutionContextError> = CudaExecutionContext::context_id;
+    /// assert!(std::mem::size_of_val(&accessor) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::Initialization`] when the CUDA
+    /// eager runtime or its runtime registration cannot be created.
+    pub fn context_id(&self) -> Result<ContextId, CudaExecutionContextError> {
+        self.eager_runtime().map(|runtime| runtime.id())
+    }
+
+    /// Return the context-owned CUDA eager runtime.
+    ///
+    /// Repeated calls return the same [`Arc`] and preserve the runtime and
+    /// allocation identity shared with the context-owned backend.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// let accessor: fn(&CudaExecutionContext) -> Result<Arc<tenferro_ad::EagerRuntime>, CudaExecutionContextError> = CudaExecutionContext::eager_runtime;
+    /// assert!(std::mem::size_of_val(&accessor) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::Initialization`] when eager
+    /// runtime registration fails.
+    pub fn eager_runtime(&self) -> Result<Arc<EagerRuntime>, CudaExecutionContextError> {
+        self.eager
+            .get_or_init(|| {
+                let backend = self.backend_clone();
+                EagerRuntime::with_cuda_backend(backend).map_err(|source| {
+                    CudaExecutionContextError::Initialization {
+                        component: "eager runtime",
+                        source: Arc::new(source),
+                    }
+                })
+            })
+            .as_ref()
+            .map(Arc::clone)
+            .map_err(Clone::clone)
+    }
+
+    /// Upload a host tensor explicitly into this CUDA context.
+    ///
+    /// The source must be host-backed. A resident CUDA or foreign-backend
+    /// tensor is rejected rather than copied implicitly.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// let upload: fn(&CudaExecutionContext, &tenferro::Tensor) -> Result<tenferro::Tensor, CudaExecutionContextError> = CudaExecutionContext::upload_cuda;
+    /// assert!(std::mem::size_of_val(&upload) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::UnsupportedInput`] for a
+    /// non-host source, [`CudaExecutionContextError::Transfer`] for a backend
+    /// transfer failure, or [`CudaExecutionContextError::PlacementMismatch`]
+    /// for invalid placement metadata.
+    pub fn upload_cuda(&self, tensor: &Tensor) -> Result<Tensor, CudaExecutionContextError> {
+        let read = TensorRead::from_tensor(tensor);
+        self.validate_host_placement_metadata(read.placement(), read.allocation_domain())?;
+        self.with_backend_session(|session| session.upload_host_tensor(read))
+            .map_err(|source| CudaExecutionContextError::Transfer {
+                operation: "upload",
+                source: Arc::new(source),
+            })
+    }
+
+    /// Download a tensor resident on this exact CUDA context into host storage.
+    ///
+    /// This method never accepts host tensors and never downloads from a
+    /// different allocation domain.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// let download: fn(&CudaExecutionContext, &tenferro::Tensor) -> Result<tenferro::Tensor, CudaExecutionContextError> = CudaExecutionContext::download;
+    /// assert!(std::mem::size_of_val(&download) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::PlacementMismatch`] for host,
+    /// non-CUDA, or nonzero-ordinal inputs,
+    /// [`CudaExecutionContextError::ForeignAllocation`] for a tensor owned by
+    /// another CUDA context, or [`CudaExecutionContextError::Transfer`] when
+    /// the explicit download fails.
+    pub fn download(&self, tensor: &Tensor) -> Result<Tensor, CudaExecutionContextError> {
+        self.validate_cuda_placement(tensor)?;
+        let read = TensorRead::from_tensor(tensor);
+        self.with_backend_session(|session| session.download_to_host(read))
+            .map_err(|source| CudaExecutionContextError::Transfer {
+                operation: "download",
+                source: Arc::new(source),
+            })
+    }
+
+    /// Validate an owned tensor's placement without transferring or reading it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// let validate: fn(&CudaExecutionContext, &tenferro::Tensor) -> Result<(), CudaExecutionContextError> = CudaExecutionContext::validate_cuda_placement;
+    /// assert!(std::mem::size_of_val(&validate) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::PlacementMismatch`] when the tensor
+    /// is not CUDA-resident on visible ordinal 0, or
+    /// [`CudaExecutionContextError::ForeignAllocation`] when it belongs to a
+    /// different CUDA context.
+    pub fn validate_cuda_placement(
+        &self,
+        tensor: &Tensor,
+    ) -> Result<(), CudaExecutionContextError> {
+        let read = TensorRead::from_tensor(tensor);
+        if read.backend_family() != Some("cuda") {
+            return Err(CudaExecutionContextError::PlacementMismatch {
+                operation: "validate CUDA placement",
+            });
+        }
+        self.validate_cuda_placement_metadata(read.placement(), read.allocation_domain())
+    }
+
+    /// Validate placement metadata obtained from a borrowed eager value.
+    ///
+    /// This is a metadata-only check: it performs no host access and no device
+    /// transfer. It exists so higher-level wrappers can validate an
+    /// [`EagerRuntime`] value without first materializing an owned [`Tensor`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// use tenferro_tensor::{AllocationDomainId, Placement};
+    /// let validate: fn(&CudaExecutionContext, &Placement, Option<AllocationDomainId>) -> Result<(), CudaExecutionContextError> = CudaExecutionContext::validate_cuda_placement_metadata;
+    /// assert!(std::mem::size_of_val(&validate) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::PlacementMismatch`] for a
+    /// non-CUDA-ordinal-0 placement and
+    /// [`CudaExecutionContextError::ForeignAllocation`] for a different
+    /// allocation domain.
+    pub fn validate_cuda_placement_metadata(
+        &self,
+        placement: &Placement,
+        allocation_domain: Option<AllocationDomainId>,
+    ) -> Result<(), CudaExecutionContextError> {
+        if !is_cuda_ordinal_zero_placement(placement) {
+            return Err(CudaExecutionContextError::PlacementMismatch {
+                operation: "validate CUDA placement",
+            });
+        }
+        let expected = self.with_backend(|backend| backend.runtime().allocation_domain());
+        if allocation_domain != Some(expected) {
+            return Err(CudaExecutionContextError::ForeignAllocation {
+                operation: "validate CUDA placement",
+            });
+        }
+        Ok(())
+    }
+
+    /// Validate metadata for a host-only upload source.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// use tenferro_tensor::{AllocationDomainId, Placement};
+    /// let validate: fn(&CudaExecutionContext, &Placement, Option<AllocationDomainId>) -> Result<(), CudaExecutionContextError> = CudaExecutionContext::validate_host_placement_metadata;
+    /// assert!(std::mem::size_of_val(&validate) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::UnsupportedInput`] when the source
+    /// carries device or backend allocation metadata.
+    pub fn validate_host_placement_metadata(
+        &self,
+        placement: &Placement,
+        allocation_domain: Option<AllocationDomainId>,
+    ) -> Result<(), CudaExecutionContextError> {
+        validate_host_placement_metadata(placement, allocation_domain)
+    }
+
+    /// Synchronize work submitted through this context's CUDA runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_tensorbackend::{CudaExecutionContext, CudaExecutionContextError};
+    /// let synchronize: fn(&CudaExecutionContext) -> Result<(), CudaExecutionContextError> = CudaExecutionContext::synchronize;
+    /// assert!(std::mem::size_of_val(&synchronize) > 0);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaExecutionContextError::Synchronization`] when the CUDA
+    /// stream cannot be synchronized.
+    pub fn synchronize(&self) -> Result<(), CudaExecutionContextError> {
+        self.with_backend(|backend| backend.runtime().synchronize())
+            .map_err(|source| CudaExecutionContextError::Synchronization {
+                source: Arc::new(source),
+            })
+    }
+
+    fn with_backend<R>(&self, f: impl FnOnce(&mut CudaBackend) -> R) -> R {
+        let mut backend = match self.backend.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        f(&mut backend)
+    }
+
+    fn backend_clone(&self) -> CudaBackend {
+        self.with_backend(|backend| backend.clone())
+    }
+
+    fn with_backend_session<R: Send>(
+        &self,
+        f: impl FnOnce(&mut dyn tenferro_tensor::BackendSession) -> R + Send,
+    ) -> R {
+        self.with_backend(|backend| backend.with_backend_session(f))
+    }
+}
+
+fn validate_host_placement_metadata(
+    placement: &Placement,
+    allocation_domain: Option<AllocationDomainId>,
+) -> Result<(), CudaExecutionContextError> {
+    if placement.device.is_some()
+        || matches!(placement.memory_kind, MemoryKind::Device)
+        || allocation_domain.is_some()
+    {
+        return Err(CudaExecutionContextError::UnsupportedInput {
+            operation: "upload",
+            reason: "the source is not host-resident",
+            remedy: "download it explicitly or provide a host tensor",
+        });
+    }
+    Ok(())
+}
+
+fn is_cuda_ordinal_zero_placement(placement: &Placement) -> bool {
+    placement.memory_kind == MemoryKind::Device
+        && placement.device.as_ref()
+            == Some(&DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal: CUDA_ORDINAL as usize,
+            })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn source_chain_is_preserved_for_initialization() {
+        let error = CudaExecutionContextError::Initialization {
+            component: "backend",
+            source: Arc::new(std::io::Error::other("driver unavailable")),
+        };
+        assert!(error.source().is_some());
+        assert_eq!(error.source().unwrap().to_string(), "driver unavailable");
+    }
+
+    #[test]
+    fn metadata_rejections_do_not_need_a_cuda_context() {
+        let host = Placement::default();
+        assert!(validate_host_placement_metadata(&host, None).is_ok());
+        assert!(!is_cuda_ordinal_zero_placement(&host));
+
+        let cuda = Placement {
+            memory_kind: MemoryKind::Device,
+            device: Some(DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal: CUDA_ORDINAL as usize,
+            }),
+            cpu_affinity: None,
+        };
+        assert!(is_cuda_ordinal_zero_placement(&cuda));
+        assert!(matches!(
+            validate_host_placement_metadata(&cuda, None),
+            Err(CudaExecutionContextError::UnsupportedInput { .. })
+        ));
+    }
+}

--- a/crates/tensor4all-tensorbackend/src/lib.rs
+++ b/crates/tensor4all-tensorbackend/src/lib.rs
@@ -19,6 +19,9 @@ mod backend;
 #[cfg(feature = "explicit-context")]
 /// Explicit and optional process-global tenferro execution helpers.
 mod context;
+#[cfg(feature = "tenferro-cuda")]
+/// Explicit visible-ordinal-0 CUDA execution and transfer boundaries.
+mod cuda;
 #[cfg(feature = "explicit-context")]
 /// Backend-free tensor snapshots for execution-domain transfer.
 mod logical_tensor;
@@ -50,6 +53,8 @@ pub use backend::{
 pub use context::{default_eager_ctx, with_default_backend, EagerContextError};
 #[cfg(feature = "explicit-context")]
 pub use context::{CpuExecutionContext, CpuExecutionContextError};
+#[cfg(feature = "tenferro-cuda")]
+pub use cuda::{CudaExecutionContext, CudaExecutionContextError, CUDA_ORDINAL};
 #[cfg(feature = "explicit-context")]
 pub use logical_tensor::{LogicalTensor, LogicalTensorData, LogicalTensorError};
 #[cfg(feature = "global-defaults")]

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -10,6 +10,10 @@ description = "Tree tensor networks with arbitrary graph topology for tensor4all
 [features]
 default = ["tenferro-cpu-faer", "simplett-bridge"]
 simplett-bridge = ["dep:tensor4all-simplett"]
+tenferro-cuda = [
+    "tensor4all-core/tenferro-cuda",
+    "tensor4all-tensorbackend/tenferro-cuda",
+]
 tenferro-cpu-faer = [
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-simplett?/tenferro-cpu-faer",
@@ -38,3 +42,7 @@ rand_chacha.workspace = true
 [[bench]]
 name = "cached_evaluator"
 harness = false
+
+[[example]]
+name = "cuda_tree_contraction"
+required-features = ["tenferro-cuda", "tenferro-cpu-faer"]

--- a/crates/tensor4all-treetn/examples/cuda_tree_contraction.rs
+++ b/crates/tensor4all-treetn/examples/cuda_tree_contraction.rs
@@ -1,0 +1,189 @@
+use std::env;
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+use tensor4all_core::{CudaExecutionContext, DynIndex, IdxTensor, IndexLike};
+use tensor4all_treetn::TreeTN;
+
+#[derive(Debug, Clone, Copy)]
+struct Config {
+    chain_length: usize,
+    bond_dim: usize,
+    iterations: usize,
+}
+
+fn parse_positive(name: &str, value: &str) -> Result<usize, Box<dyn Error>> {
+    let value = value.parse::<usize>()?;
+    if value == 0 {
+        return Err(format!("{name} must be positive").into());
+    }
+    Ok(value)
+}
+
+fn env_setting(name: &str, default: usize) -> Result<usize, Box<dyn Error>> {
+    match env::var(name) {
+        Ok(value) => parse_positive(name, &value),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn config() -> Result<Config, Box<dyn Error>> {
+    let mut config = Config {
+        chain_length: env_setting("CUDA_TREE_CHAIN_LENGTH", 4)?,
+        bond_dim: env_setting("CUDA_TREE_BOND_DIM", 3)?,
+        iterations: env_setting("CUDA_TREE_ITERATIONS", 10)?,
+    };
+    let args: Vec<_> = env::args().skip(1).collect();
+    let mut index = 0;
+    while index < args.len() {
+        let flag = args[index].as_str();
+        let value = args
+            .get(index + 1)
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag {
+            "--chain-length" => config.chain_length = parse_positive(flag, value)?,
+            "--bond-dim" => config.bond_dim = parse_positive(flag, value)?,
+            "--iterations" => config.iterations = parse_positive(flag, value)?,
+            _ => return Err(format!("unknown argument {flag}").into()),
+        }
+        index += 2;
+    }
+    Ok(config)
+}
+
+fn dense(indices: Vec<DynIndex>, seed: usize) -> Result<IdxTensor, Box<dyn Error>> {
+    let elements = indices
+        .iter()
+        .map(IndexLike::dim)
+        .try_fold(1usize, |size, dim| size.checked_mul(dim))
+        .ok_or("tensor element count overflow")?;
+    let values = (0..elements)
+        .map(|offset| ((seed + offset) % 19) as f64 / 19.0 + 0.25)
+        .collect();
+    Ok(IdxTensor::from_dense(indices, values)?)
+}
+
+fn build_chain(config: Config) -> Result<TreeTN<IdxTensor, usize>, Box<dyn Error>> {
+    let sites: Vec<_> = (0..config.chain_length)
+        .map(|_| DynIndex::new_dyn(2))
+        .collect();
+    let bonds: Vec<_> = (0..config.chain_length.saturating_sub(1))
+        .map(|_| DynIndex::new_dyn(config.bond_dim))
+        .collect();
+    let mut tensors = Vec::with_capacity(config.chain_length);
+    for node in 0..config.chain_length {
+        let mut indices = Vec::with_capacity(3);
+        if let Some(left) = node.checked_sub(1).and_then(|index| bonds.get(index)) {
+            indices.push(left.clone());
+        }
+        indices.push(
+            sites
+                .get(node)
+                .cloned()
+                .ok_or("site index missing while building chain")?,
+        );
+        if let Some(right) = bonds.get(node) {
+            indices.push(right.clone());
+        }
+        tensors.push(dense(indices, node * 31 + 1)?);
+    }
+    Ok(TreeTN::from_tensors(
+        tensors,
+        (0..config.chain_length).collect(),
+    )?)
+}
+
+fn milliseconds(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1.0e3
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let config = config()?;
+
+    let started = Instant::now();
+    let host_tree = build_chain(config)?;
+    let host_setup = started.elapsed();
+
+    let started = Instant::now();
+    let context = CudaExecutionContext::new()?;
+    let cuda_context_setup = started.elapsed();
+
+    let started = Instant::now();
+    let resident_tree = host_tree.upload_cuda(&context)?;
+    let upload = started.elapsed();
+
+    let started = Instant::now();
+    let warmup = resident_tree.contract_to_tensor_cuda(&context)?;
+    context.synchronize()?;
+    std::hint::black_box(&warmup);
+    let cuda_warmup = started.elapsed();
+
+    let started = Instant::now();
+    let mut resident_result = None;
+    for _ in 0..config.iterations {
+        let result = resident_tree.contract_to_tensor_cuda(&context)?;
+        context.synchronize()?;
+        std::hint::black_box(&result);
+        resident_result = Some(result);
+    }
+    let cuda_steady = started.elapsed();
+    let resident_result = resident_result.ok_or("no CUDA steady-state result")?;
+    resident_result.validate_cuda_residency(&context)?;
+    assert!(
+        resident_result.to_vec::<f64>().is_err(),
+        "resident CUDA output unexpectedly allowed host extraction"
+    );
+
+    let started = Instant::now();
+    let downloaded = resident_result.download(&context)?;
+    let download = started.elapsed();
+
+    let started = Instant::now();
+    let mut cpu_result = None;
+    for _ in 0..config.iterations {
+        let result = host_tree.contract_to_tensor()?;
+        std::hint::black_box(&result);
+        cpu_result = Some(result);
+    }
+    let cpu_steady = started.elapsed();
+    let cpu_result = cpu_result.ok_or("no CPU steady-state result")?;
+
+    assert_eq!(downloaded.indices(), cpu_result.indices());
+    let residual = downloaded.sub(&cpu_result)?.maxabs()?;
+    assert!(
+        residual <= 1.0e-10,
+        "CUDA/CPU residual {residual} exceeds 1e-10"
+    );
+
+    println!(
+        "config chain_length={} bond_dim={} iterations={}",
+        config.chain_length, config.bond_dim, config.iterations
+    );
+    println!(
+        "device name={:?} visible_cuda_ordinal={} runtime=cuda-eager",
+        context.device_name(),
+        context.ordinal()
+    );
+    println!("residual_max_abs={residual:.6e}");
+    println!("host_setup_ms={:.6}", milliseconds(host_setup));
+    println!(
+        "cuda_context_setup_ms={:.6}",
+        milliseconds(cuda_context_setup)
+    );
+    println!("upload_ms={:.6}", milliseconds(upload));
+    println!("cuda_warmup_ms={:.6}", milliseconds(cuda_warmup));
+    println!(
+        "cuda_steady_sync_ms_total={:.6} cuda_steady_sync_ms_per_iter={:.6}",
+        milliseconds(cuda_steady),
+        milliseconds(cuda_steady) / config.iterations as f64
+    );
+    println!("download_ms={:.6}", milliseconds(download));
+    println!(
+        "cpu_steady_ms_total={:.6} cpu_steady_ms_per_iter={:.6}",
+        milliseconds(cpu_steady),
+        milliseconds(cpu_steady) / config.iterations as f64
+    );
+
+    Ok(())
+}

--- a/crates/tensor4all-treetn/src/cuda.rs
+++ b/crates/tensor4all-treetn/src/cuda.rs
@@ -1,0 +1,388 @@
+//! Explicit CUDA transfer and pairwise TreeTN contraction for `IdxTensor`.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use petgraph::stable_graph::NodeIndex;
+use tensor4all_core::{
+    IdxTensor, IdxTensorCudaError, IdxTensorError, TensorContractionLike, TensorIndex,
+};
+use tensor4all_tensorbackend::CudaExecutionContext;
+
+use crate::error::TreeTNOperationError;
+use crate::TreeTN;
+
+/// Error returned by the explicit CUDA TreeTN transfer and contraction methods.
+///
+/// Node-local failures retain the failing [`NodeIndex`] and the typed source
+/// error. The methods never transfer implicitly and never fall back to the CPU
+/// contraction runtime.
+///
+/// # Examples
+///
+/// ```
+/// use petgraph::stable_graph::NodeIndex;
+/// use tensor4all_treetn::CudaTreeTNError;
+///
+/// let error = CudaTreeTNError::MissingTensor {
+///     node: NodeIndex::new(0),
+/// };
+/// assert!(error.to_string().contains("node tensor"));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum CudaTreeTNError {
+    /// The network has no nodes to transfer or contract.
+    #[error("CUDA TreeTN received an empty TreeTN; add at least one node")]
+    EmptyNetwork,
+    /// The network is not a connected tree.
+    #[error("CUDA TreeTN topology validation failed; provide one connected tree: {source}")]
+    Topology {
+        /// Original topology diagnostic.
+        #[source]
+        source: TreeTNOperationError,
+    },
+    /// The selected root name had no graph node.
+    #[error("CUDA TreeTN root node is missing; repair the network topology")]
+    MissingRoot,
+    /// A node index had no tensor payload.
+    #[error(
+        "CUDA TreeTN node tensor is missing; repair the network before transfer or contraction"
+    )]
+    MissingTensor {
+        /// Node whose tensor was missing.
+        node: NodeIndex,
+    },
+    /// An explicit upload failed for one node.
+    #[error("CUDA TreeTN upload failed for a node; keep the source unchanged and inspect explicit upload: {source}")]
+    Upload {
+        /// Node whose tensor failed to upload.
+        node: NodeIndex,
+        /// Original typed tensor transfer diagnostic.
+        #[source]
+        source: IdxTensorCudaError,
+    },
+    /// An explicit download failed for one node.
+    #[error("CUDA TreeTN download failed for a node; keep the source unchanged and use the same CUDA context: {source}")]
+    Download {
+        /// Node whose tensor failed to download.
+        node: NodeIndex,
+        /// Original typed tensor transfer diagnostic.
+        #[source]
+        source: IdxTensorCudaError,
+    },
+    /// A node or intermediate was not resident on the supplied CUDA context.
+    #[error("CUDA TreeTN node residency validation failed; upload every node with this context and keep output transfer explicit: {source}")]
+    Residency {
+        /// Node whose residency failed validation.
+        node: NodeIndex,
+        /// Original typed residency diagnostic.
+        #[source]
+        source: IdxTensorCudaError,
+    },
+    /// A node dtype could not be read from metadata.
+    #[error(
+        "CUDA TreeTN node dtype validation failed; provide one supported dense dtype: {source}"
+    )]
+    Dtype {
+        /// Node whose dtype failed validation.
+        node: NodeIndex,
+        /// Original typed dtype diagnostic.
+        #[source]
+        source: IdxTensorError,
+    },
+    /// Node tensors do not all have one exact dtype.
+    #[error("CUDA TreeTN nodes have mixed dtypes; upload one exact dtype for every node before contraction")]
+    MixedDtype {
+        /// Node whose dtype differs from the first validated node.
+        node: NodeIndex,
+    },
+    /// A pairwise edge contraction failed.
+    #[error("CUDA TreeTN pairwise contraction failed; use dense same-dtype CUDA nodes: {source}")]
+    Pairwise {
+        /// Parent node receiving the pairwise contraction result.
+        node: NodeIndex,
+        /// Child node removed by this edge step.
+        other_node: NodeIndex,
+        /// Original typed pairwise contraction diagnostic.
+        #[source]
+        source: IdxTensorError,
+    },
+    /// The final result could not be permuted to canonical site-index order.
+    #[error("CUDA TreeTN final index permutation failed; preserve the network site-index metadata: {source}")]
+    Permutation {
+        /// Root node holding the final result.
+        node: NodeIndex,
+        /// Original typed permutation diagnostic.
+        #[source]
+        source: IdxTensorError,
+    },
+    /// A transferred tensor could not replace its cloned source node.
+    #[error("CUDA TreeTN node replacement failed; preserve the source network and repair its metadata: {source}")]
+    Replacement {
+        /// Node whose cloned network replacement failed.
+        node: NodeIndex,
+        /// Original typed TreeTN replacement diagnostic.
+        #[source]
+        source: TreeTNOperationError,
+    },
+    /// The pairwise result did not contain the network's complete site-index set.
+    #[error("CUDA TreeTN result site indices are inconsistent; preserve the network site-index metadata")]
+    OutputIndices {
+        /// Root node holding the inconsistent result.
+        node: NodeIndex,
+    },
+}
+
+fn validate_cuda_tensor(
+    node: NodeIndex,
+    tensor: &IdxTensor,
+    context: &CudaExecutionContext,
+) -> Result<(), CudaTreeTNError> {
+    tensor
+        .validate_cuda_residency(context)
+        .map_err(|source| CudaTreeTNError::Residency { node, source })
+}
+
+impl<V> TreeTN<IdxTensor, V>
+where
+    V: Clone + Hash + Eq + Send + Sync + Debug,
+{
+    /// Upload every node into one caller-owned CUDA context.
+    ///
+    /// The source TreeTN and all of its metadata remain unchanged. The returned
+    /// network is a cloned metadata graph whose node tensors are CUDA-resident.
+    /// All transfers are staged before the cloned graph is changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaTreeTNError`] when a node cannot be transferred or the
+    /// cloned metadata graph rejects a replacement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{CudaExecutionContext, IdxTensor};
+    /// use tensor4all_treetn::{CudaTreeTNError, TreeTN};
+    ///
+    /// let upload: fn(
+    ///     &TreeTN<IdxTensor, usize>,
+    ///     &CudaExecutionContext,
+    /// ) -> Result<TreeTN<IdxTensor, usize>, CudaTreeTNError> = TreeTN::upload_cuda;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&upload),
+    ///     std::mem::size_of::<fn(
+    ///         &TreeTN<IdxTensor, usize>,
+    ///         &CudaExecutionContext,
+    ///     ) -> Result<TreeTN<IdxTensor, usize>, CudaTreeTNError>>(),
+    /// );
+    /// ```
+    pub fn upload_cuda(&self, context: &CudaExecutionContext) -> Result<Self, CudaTreeTNError> {
+        let nodes = self.node_indices();
+        let mut replacements = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            let tensor = self
+                .tensor(node)
+                .ok_or(CudaTreeTNError::MissingTensor { node })?;
+            let uploaded = tensor
+                .upload_cuda(context)
+                .map_err(|source| CudaTreeTNError::Upload { node, source })?;
+            replacements.push((node, uploaded));
+        }
+
+        let mut result = self.clone();
+        for (node, tensor) in replacements {
+            result
+                .replace_tensor(node, tensor)
+                .map_err(|source| CudaTreeTNError::Replacement { node, source })?;
+        }
+        Ok(result)
+    }
+
+    /// Download every node into host storage using one caller-owned CUDA context.
+    ///
+    /// The source TreeTN and all of its metadata remain unchanged. The returned
+    /// network is a cloned metadata graph with host-backed node tensors.
+    /// All downloads are staged before the cloned graph is changed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaTreeTNError`] when a node is not resident on `context`, an
+    /// explicit download fails, or a cloned metadata replacement fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{CudaExecutionContext, IdxTensor};
+    /// use tensor4all_treetn::{CudaTreeTNError, TreeTN};
+    ///
+    /// let download: fn(
+    ///     &TreeTN<IdxTensor, usize>,
+    ///     &CudaExecutionContext,
+    /// ) -> Result<TreeTN<IdxTensor, usize>, CudaTreeTNError> = TreeTN::download;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&download),
+    ///     std::mem::size_of::<fn(
+    ///         &TreeTN<IdxTensor, usize>,
+    ///         &CudaExecutionContext,
+    ///     ) -> Result<TreeTN<IdxTensor, usize>, CudaTreeTNError>>(),
+    /// );
+    /// ```
+    pub fn download(&self, context: &CudaExecutionContext) -> Result<Self, CudaTreeTNError> {
+        let nodes = self.node_indices();
+        let mut replacements = Vec::with_capacity(nodes.len());
+        for node in nodes {
+            let tensor = self
+                .tensor(node)
+                .ok_or(CudaTreeTNError::MissingTensor { node })?;
+            let downloaded = tensor
+                .download(context)
+                .map_err(|source| CudaTreeTNError::Download { node, source })?;
+            replacements.push((node, downloaded));
+        }
+
+        let mut result = self.clone();
+        for (node, tensor) in replacements {
+            result
+                .replace_tensor(node, tensor)
+                .map_err(|source| CudaTreeTNError::Replacement { node, source })?;
+        }
+        Ok(result)
+    }
+
+    /// Contract a dense CUDA-resident TreeTN to one CUDA-resident tensor.
+    ///
+    /// This is an explicitly dense full-network contraction. It validates every
+    /// input before the first edge, walks the existing post-order topology, and
+    /// calls only pairwise [`TensorContractionLike::contract_pair`] operations.
+    /// The source network is never modified and the returned tensor remains on
+    /// the supplied CUDA context until [`IdxTensor::download`] is called.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CudaTreeTNError`] for an empty or invalid tree, host/foreign
+    /// placement, structured or tracked tensors, mixed dtypes, pairwise
+    /// contraction failures, or final index-order failures. No CPU fallback is
+    /// attempted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{CudaExecutionContext, IdxTensor};
+    /// use tensor4all_treetn::{CudaTreeTNError, TreeTN};
+    ///
+    /// let contract: fn(
+    ///     &TreeTN<IdxTensor, usize>,
+    ///     &CudaExecutionContext,
+    /// ) -> Result<IdxTensor, CudaTreeTNError> = TreeTN::contract_to_tensor_cuda;
+    /// assert_eq!(
+    ///     std::mem::size_of_val(&contract),
+    ///     std::mem::size_of::<fn(
+    ///         &TreeTN<IdxTensor, usize>,
+    ///         &CudaExecutionContext,
+    ///     ) -> Result<IdxTensor, CudaTreeTNError>>(),
+    /// );
+    /// ```
+    pub fn contract_to_tensor_cuda(
+        &self,
+        context: &CudaExecutionContext,
+    ) -> Result<IdxTensor, CudaTreeTNError>
+    where
+        V: Ord,
+    {
+        if self.node_count() == 0 {
+            return Err(CudaTreeTNError::EmptyNetwork);
+        }
+        self.validate_tree()
+            .map_err(|source| CudaTreeTNError::Topology { source })?;
+
+        let mut node_names = self.node_names();
+        node_names.sort();
+        let root_name = node_names.first().ok_or(CudaTreeTNError::EmptyNetwork)?;
+        let root = self
+            .node_index(root_name)
+            .ok_or(CudaTreeTNError::MissingRoot)?;
+
+        let nodes = self.node_indices();
+        let mut tensors = HashMap::with_capacity(nodes.len());
+        let mut common_dtype = None;
+        for node in nodes {
+            let tensor = self
+                .tensor(node)
+                .cloned()
+                .ok_or(CudaTreeTNError::MissingTensor { node })?;
+            validate_cuda_tensor(node, &tensor, context)?;
+            let dtype = tensor
+                .cuda_dtype()
+                .map_err(|source| CudaTreeTNError::Dtype { node, source })?;
+            if let Some(expected) = common_dtype {
+                if dtype != expected {
+                    return Err(CudaTreeTNError::MixedDtype { node });
+                }
+            } else {
+                common_dtype = Some(dtype);
+            }
+            tensors.insert(node, tensor);
+        }
+
+        if self.node_count() == 1 {
+            return tensors
+                .remove(&root)
+                .ok_or(CudaTreeTNError::MissingTensor { node: root });
+        }
+
+        let edges = self.site_index_network().edges_to_canonicalize(None, root);
+        for (from, to) in edges {
+            let from_tensor = tensors
+                .remove(&from)
+                .ok_or(CudaTreeTNError::MissingTensor { node: from })?;
+            let to_tensor = tensors
+                .remove(&to)
+                .ok_or(CudaTreeTNError::MissingTensor { node: to })?;
+            let contracted = to_tensor.contract_pair(&from_tensor).map_err(|source| {
+                CudaTreeTNError::Pairwise {
+                    node: to,
+                    other_node: from,
+                    source,
+                }
+            })?;
+            validate_cuda_tensor(to, &contracted, context)?;
+            let dtype = contracted
+                .cuda_dtype()
+                .map_err(|source| CudaTreeTNError::Dtype { node: to, source })?;
+            if common_dtype != Some(dtype) {
+                return Err(CudaTreeTNError::MixedDtype { node: to });
+            }
+            tensors.insert(to, contracted);
+        }
+
+        let mut result = tensors
+            .remove(&root)
+            .ok_or(CudaTreeTNError::MissingTensor { node: root })?;
+        let mut expected_indices = Vec::new();
+        let mut expected_node_names = self.node_names();
+        expected_node_names.sort();
+        for node_name in expected_node_names {
+            if let Some(site_space) = self.site_space(&node_name) {
+                expected_indices.extend(site_space.iter().cloned());
+            }
+        }
+        let current_indices = result.external_indices();
+        if current_indices.len() != expected_indices.len() {
+            return Err(CudaTreeTNError::OutputIndices { node: root });
+        }
+        if current_indices != expected_indices {
+            result = result
+                .permute_indices(&expected_indices)
+                .map_err(|source| CudaTreeTNError::Permutation { node: root, source })?;
+        }
+        validate_cuda_tensor(root, &result, context)?;
+        let dtype = result
+            .cuda_dtype()
+            .map_err(|source| CudaTreeTNError::Dtype { node: root, source })?;
+        if common_dtype != Some(dtype) {
+            return Err(CudaTreeTNError::MixedDtype { node: root });
+        }
+        Ok(result)
+    }
+}

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -26,6 +26,8 @@ pub struct ReadmeDoctests;
 pub mod prelude;
 
 mod algorithm;
+#[cfg(feature = "tenferro-cuda")]
+mod cuda;
 // dyn_treetn.rs has been removed.
 // TreeTN uses the `T: TensorLike` pattern, making a separate dyn wrapper unnecessary.
 mod dmrg;
@@ -46,6 +48,8 @@ mod tdvp;
 mod treetn;
 
 pub use algorithm::{CanonicalForm, CompressionAlgorithm, ContractionAlgorithm};
+#[cfg(feature = "tenferro-cuda")]
+pub use cuda::CudaTreeTNError;
 pub use dmrg::{dmrg, dmrg_with_treetn_operator, DmrgError, DmrgOptions, DmrgResult};
 pub use error::{
     LinearOperatorIndexApplyError, LinearOperatorIndexBindingError, LinearOperatorTaggedApplyError,

--- a/crates/tensor4all-treetn/tests/cuda_tree_contraction.rs
+++ b/crates/tensor4all-treetn/tests/cuda_tree_contraction.rs
@@ -1,0 +1,254 @@
+#![cfg(feature = "tenferro-cuda")]
+
+use tensor4all_core::{CudaExecutionContext, DynIndex, IdxTensor, IndexLike};
+use tensor4all_treetn::{CudaTreeTNError, TreeTN};
+
+fn dense(indices: Vec<DynIndex>, seed: usize) -> IdxTensor {
+    let len = indices
+        .iter()
+        .map(IndexLike::dim)
+        .try_fold(1usize, |size, dim| size.checked_mul(dim))
+        .unwrap();
+    let values = (0..len)
+        .map(|offset| ((seed + offset) % 17) as f64 / 17.0 + 0.25)
+        .collect();
+    IdxTensor::from_dense(indices, values).unwrap()
+}
+
+fn two_node_tree() -> TreeTN<IdxTensor, usize> {
+    let left_site = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let right_site = DynIndex::new_dyn(2);
+    TreeTN::from_tensors(
+        vec![
+            dense(vec![left_site, bond.clone()], 1),
+            dense(vec![bond, right_site], 5),
+        ],
+        vec![0, 1],
+    )
+    .unwrap()
+}
+
+fn branched_tree() -> TreeTN<IdxTensor, usize> {
+    let center_site = DynIndex::new_dyn(2);
+    let leaf_sites = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    let bonds = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    TreeTN::from_tensors(
+        vec![
+            dense(
+                vec![
+                    center_site,
+                    bonds[0].clone(),
+                    bonds[1].clone(),
+                    bonds[2].clone(),
+                ],
+                1,
+            ),
+            dense(vec![bonds[0].clone(), leaf_sites[0].clone()], 3),
+            dense(vec![bonds[1].clone(), leaf_sites[1].clone()], 7),
+            dense(vec![bonds[2].clone(), leaf_sites[2].clone()], 11),
+        ],
+        vec![0, 1, 2, 3],
+    )
+    .unwrap()
+}
+
+fn scalar_closed_tree() -> TreeTN<IdxTensor, usize> {
+    let bonds = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    TreeTN::from_tensors(
+        vec![
+            dense(vec![bonds[0].clone(), bonds[1].clone()], 1),
+            dense(vec![bonds[0].clone()], 5),
+            dense(vec![bonds[1].clone()], 9),
+        ],
+        vec![0, 1, 2],
+    )
+    .unwrap()
+}
+
+fn single_node_tree() -> TreeTN<IdxTensor, usize> {
+    let first_site = DynIndex::new_dyn(2);
+    let second_site = DynIndex::new_dyn(3);
+    let tree = TreeTN::from_tensors(
+        vec![dense(vec![first_site.clone(), second_site.clone()], 13)],
+        vec![0],
+    )
+    .unwrap();
+    let canonical: Vec<_> = tree.site_space(&0).unwrap().iter().cloned().collect();
+    if canonical != tree.tensor(tree.node_indices()[0]).unwrap().indices() {
+        return tree;
+    }
+    TreeTN::from_tensors(vec![dense(vec![second_site, first_site], 13)], vec![0]).unwrap()
+}
+
+fn assert_cuda_parity(tree: TreeTN<IdxTensor, usize>, context: &CudaExecutionContext) {
+    let cpu = tree.contract_to_tensor().unwrap();
+    let source_indices: Vec<_> = tree
+        .node_indices()
+        .into_iter()
+        .map(|node| tree.tensor(node).unwrap().indices().to_vec())
+        .collect();
+
+    let resident_tree = tree.upload_cuda(context).unwrap();
+    for node in resident_tree.node_indices() {
+        resident_tree
+            .tensor(node)
+            .unwrap()
+            .validate_cuda_residency(context)
+            .unwrap();
+    }
+    let restored_tree = resident_tree.download(context).unwrap();
+    for (node, indices) in tree.node_indices().into_iter().zip(source_indices.iter()) {
+        let restored = restored_tree.tensor(node).unwrap();
+        assert_eq!(restored.indices(), indices);
+        assert_eq!(
+            restored.to_vec::<f64>().unwrap(),
+            tree.tensor(node).unwrap().to_vec::<f64>().unwrap()
+        );
+    }
+
+    let resident = resident_tree.contract_to_tensor_cuda(context).unwrap();
+    resident.validate_cuda_residency(context).unwrap();
+    assert!(resident.to_vec::<f64>().is_err());
+
+    let downloaded = resident.download(context).unwrap();
+    assert_eq!(downloaded.indices(), cpu.indices());
+    let residual = downloaded.sub(&cpu).unwrap().maxabs().unwrap();
+    assert!(residual <= 1.0e-10, "CUDA/CPU residual: {residual}");
+
+    for (node, indices) in tree.node_indices().into_iter().zip(source_indices) {
+        assert_eq!(tree.tensor(node).unwrap().indices(), indices);
+        assert!(tree.tensor(node).unwrap().to_vec::<f64>().is_ok());
+    }
+}
+
+#[test]
+fn two_node_cuda_contraction_matches_cpu() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    assert_cuda_parity(two_node_tree(), &context);
+}
+
+#[test]
+fn branched_cuda_contraction_matches_cpu() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    assert_cuda_parity(branched_tree(), &context);
+}
+
+#[test]
+fn scalar_closed_cuda_contraction_matches_cpu() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let tree = scalar_closed_tree();
+    assert_cuda_parity(tree, &context);
+}
+
+#[test]
+fn single_node_cuda_contraction_preserves_index_order_and_matches_cpu() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let tree = single_node_tree();
+    let node = tree.node_indices()[0];
+    let expected_indices = tree.tensor(node).unwrap().indices().to_vec();
+    let cpu = tree.contract_to_tensor().unwrap();
+    assert_eq!(cpu.indices(), expected_indices);
+
+    let resident_tree = tree.upload_cuda(&context).unwrap();
+    let resident = resident_tree.contract_to_tensor_cuda(&context).unwrap();
+    assert_eq!(resident.indices(), expected_indices);
+
+    let downloaded = resident.download(&context).unwrap();
+    assert_eq!(downloaded.indices(), expected_indices);
+    assert_eq!(
+        downloaded.to_vec::<f64>().unwrap(),
+        cpu.to_vec::<f64>().unwrap()
+    );
+}
+
+#[test]
+fn empty_cuda_tree_contraction_returns_typed_error() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let tree = TreeTN::<IdxTensor, usize>::from_tensors(Vec::new(), Vec::new()).unwrap();
+
+    assert!(matches!(
+        tree.contract_to_tensor_cuda(&context),
+        Err(CudaTreeTNError::EmptyNetwork)
+    ));
+}
+
+#[test]
+fn mixed_host_and_cuda_nodes_are_rejected_before_contraction() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let host = two_node_tree();
+    let nodes = host.node_indices();
+    let mixed = TreeTN::from_tensors(
+        vec![
+            host.tensor(nodes[0])
+                .unwrap()
+                .upload_cuda(&context)
+                .unwrap(),
+            host.tensor(nodes[1]).unwrap().clone(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap();
+
+    assert!(matches!(
+        mixed.contract_to_tensor_cuda(&context),
+        Err(CudaTreeTNError::Residency { .. })
+    ));
+}
+
+#[test]
+fn mixed_cuda_dtypes_are_rejected_before_contraction() {
+    let context = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let left_site = DynIndex::new_dyn(2);
+    let bond = DynIndex::new_dyn(2);
+    let right_site = DynIndex::new_dyn(2);
+    let mixed = TreeTN::from_tensors(
+        vec![
+            IdxTensor::from_dense(vec![left_site, bond.clone()], vec![1.0_f64, 2.0, 3.0, 4.0])
+                .unwrap(),
+            IdxTensor::from_dense(vec![bond, right_site], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap(),
+        ],
+        vec![0, 1],
+    )
+    .unwrap()
+    .upload_cuda(&context)
+    .unwrap();
+
+    assert!(matches!(
+        mixed.contract_to_tensor_cuda(&context),
+        Err(CudaTreeTNError::MixedDtype { .. })
+    ));
+}
+
+#[test]
+fn foreign_cuda_context_is_rejected_with_a_typed_error() {
+    let first = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let second = CudaExecutionContext::new().expect("CUDA ordinal 0 must be available");
+    let resident = two_node_tree().upload_cuda(&first).unwrap();
+
+    assert!(matches!(
+        resident.contract_to_tensor_cuda(&second),
+        Err(CudaTreeTNError::Residency { .. })
+    ));
+}
+
+#[test]
+fn source_contract_requires_pairwise_edge_walk() {
+    let source = include_str!("../src/cuda.rs");
+    let method = source
+        .split_once("pub fn contract_to_tensor_cuda")
+        .map(|(_, method)| method)
+        .expect("CUDA contraction method must exist");
+
+    assert!(method.contains("contract_pair"));
+    assert!(!method.contains("contract_to_tensor("));
+    assert!(!method.contains("T::contract"));
+}

--- a/docs/design/cuda-tree-contraction.md
+++ b/docs/design/cuda-tree-contraction.md
@@ -1,0 +1,314 @@
+# CUDA TreeTN Contraction Vertical Slice
+
+## Status and scope
+
+This document defines PR 2 of the two-PR GPU foundation for
+[tensor4all-rs #623](https://github.com/tensor4all/tensor4all-rs/issues/623)
+and [#553](https://github.com/tensor4all/tensor4all-rs/issues/553). PR #674
+already centralized concrete CPU session entry on `CpuExecutionContext`.
+
+This PR adds explicit single-GPU transfer and one device-resident TreeTN
+contraction path. The supported algorithm is a CUDA-specific deterministic
+edge walk over dense, untracked, same-dtype node tensors uploaded into one CUDA
+eager runtime. It deliberately does not call the existing generic
+`contract_to_tensor`, whose N-ary route currently enters the process-global CPU
+graph runtime. It does not claim general GPU support for zip-up, fitting,
+TCI/ACI, truncation, or host-backed matrix algorithms.
+
+## Goals
+
+1. Add optional `tenferro-gpu` plumbing behind `tenferro-cuda` features.
+2. Add a caller-owned `CudaExecutionContext` for visible CUDA ordinal 0.
+3. Add explicit `IdxTensor::upload_cuda` and `IdxTensor::download` boundaries.
+4. Preserve full `Index` metadata and exact logical values across transfer.
+5. Reject tracked, structured, foreign-runtime, host/CUDA-mixed, unsupported
+   dtype, and unavailable-CUDA cases with typed errors; never fall back to CPU.
+6. Add `TreeTN<IdxTensor>` upload/download helpers and a checked
+   `contract_to_tensor_cuda` vertical slice whose intermediate pairwise
+   contractions remain in one CUDA `EagerRuntime`.
+7. Add a reproducible CPU/CUDA benchmark harness that reports context setup,
+   upload, steady-state contraction, download, and CPU contraction separately.
+8. Keep the default CPU-only build and public CPU behavior unchanged.
+
+## Non-goals
+
+- Multi-GPU, nonzero visible ordinals, sharding, streams exposed to callers, or
+  device meshes.
+- Automatic transfer, automatic backend selection, or CPU fallback.
+- Tracked-value transfer or cross-runtime AD migration.
+- Structured/diagonal payload upload; this first slice rejects it instead of
+  silently densifying an unbounded tensor.
+- CUDA SVD/QR/eigh/truncation, TreeTN×TreeTN zip-up/fitting, TCI, ACI, GSE,
+  TDVP, DMRG, C API, or language-binding support.
+- Making CUDA a default feature or requiring CUDA in ordinary CI.
+- A generic public CPU/GPU context trait or backend enum.
+
+## Feature plumbing
+
+Add the pinned `tenferro-gpu` crate to root workspace dependencies. It is
+optional only at the consuming crate boundary.
+
+`tensor4all-tensorbackend` exposes:
+
+```text
+tenferro-cuda = [
+    "explicit-context",
+    "tenferro-cpu-faer",
+    "dep:tenferro-gpu",
+    "tenferro-gpu/cuda",
+    "tenferro-ad/cuda",
+    "tenferro-einsum/autodiff",
+    "tenferro-einsum/cuda",
+    "tenferro-linalg/autodiff",
+    "tenferro-linalg/cuda",
+]
+```
+
+Do not add `tenferro/cuda`: `tenferro-runtime` has no such feature.
+
+`tensor4all-core/tenferro-cuda` includes its existing `backend-tenferro` and
+`tenferro-cpu-faer` features (needed for host reconstruction through the
+existing CPU default context), propagates to tensorbackend, and enables CUDA on its direct
+`tenferro-ad`, `tenferro-einsum`, and `tenferro-linalg` dependencies.
+`tensor4all-treetn/tenferro-cuda` propagates to core and tensorbackend. CUDA
+remains absent from every default feature set.
+
+## CUDA execution context
+
+Under `tensor4all-tensorbackend::cuda`, add:
+
+- `CudaExecutionContext`;
+- `CudaExecutionContextError`;
+- visible-ordinal-0 constants or accessors needed by tests.
+
+The context owns:
+
+- one `Mutex<CudaBackend>` created with `CudaDeviceId::from_ordinal(0)`;
+- one lazy `Arc<EagerRuntime>` built from a clone of that backend, preserving
+  CUDA runtime/allocation identity;
+- no CPU backend and no graph runtime in this first slice.
+
+Public operations:
+
+- `CudaExecutionContext::new()` selects visible ordinal 0 and returns a typed
+  device/runtime error when unavailable;
+- `upload_cuda(&Tensor)` accepts host tensors only;
+- `download(&Tensor)` accepts tensors resident on this CUDA context only;
+- `eager_runtime()` returns the context-owned CUDA eager runtime;
+- `synchronize()` provides an explicit timing boundary;
+- placement validation helpers reject non-CUDA0 or incompatible inputs.
+
+Transfers use `TensorDeviceTransfer` through one context-owned CUDA session.
+No transfer occurs inside an arithmetic or contraction operation.
+
+`CudaExecutionContextError` preserves tenferro/CUDA sources and has explicit
+variants for initialization, transfer, placement mismatch, unsupported input,
+and synchronization. Error messages identify the operation and remedy
+(upload, download, use one context, or disable tracked values).
+
+## IdxTensor transfer contract
+
+Behind `tensor4all-core/tenferro-cuda`, add:
+
+- `IdxTensorCudaError`;
+- `IdxTensor::upload_cuda(&CudaExecutionContext)`;
+- `IdxTensor::download(&CudaExecutionContext)`;
+- `IdxTensor::validate_cuda_residency(&CudaExecutionContext)`, which checks
+  device placement and `EagerTensor::ctx_id()` against the supplied context
+  without host access.
+
+`upload_cuda`:
+
+1. validates deferred storage errors;
+2. rejects `tracks_grad()` before transfer;
+3. requires both logical-dense axis classes and `StorageKind::Dense`, rejecting
+   diagonal/structured storage before materialization;
+4. obtains the existing dense native value without scalar conversion;
+5. uploads explicitly through the supplied CUDA context;
+6. wraps the resident value in the context's CUDA `EagerRuntime`;
+7. reconstructs `IdxTensor` with the original ordered full indices.
+
+`download` performs the inverse explicit transfer, then reconstructs the host
+value through the existing CPU eager context enabled by core's
+`backend-tenferro` compatibility feature. It rejects host tensors, foreign CUDA
+allocation domains, and tracked values. Both methods preserve f32/f64, c32/c64,
+integer, and bool dtypes only where tenferro CUDA transfer supports them;
+unsupported dtypes return typed errors.
+
+The first slice does not preserve compact diagonal/structured representation
+because it does not upload those inputs. Dense input remains dense.
+
+## TreeTN vertical slice
+
+Behind `tensor4all-treetn/tenferro-cuda`, add an `IdxTensor`-specific module
+with:
+
+- `CudaTreeTNError` containing the failing `NodeIndex` and typed source;
+- `TreeTN<IdxTensor, V>::upload_cuda(&CudaExecutionContext)`;
+- `TreeTN<IdxTensor, V>::download(&CudaExecutionContext)`;
+- `TreeTN<IdxTensor, V>::contract_to_tensor_cuda(&CudaExecutionContext)`.
+
+Upload/download clone the network metadata and replace node tensors only after
+each replacement validates successfully. Failure returns an error without
+mutating the source network.
+
+`contract_to_tensor_cuda` first validates every node tensor:
+
+- CUDA device memory on visible ordinal 0;
+- `EagerTensor::ctx_id()` equal to the supplied context's eager-runtime id;
+- untracked dense value and `StorageKind::Dense`;
+- one common dtype across all nodes.
+
+It must not delegate to generic `contract_to_tensor`: that method uses
+`T::contract`, whose N-ary plan enters the default CPU graph runtime. Instead,
+the CUDA method repeats only the small topology-level algorithm:
+
+1. validate tree topology and choose the deterministic minimum-name root;
+2. obtain the existing post-order edge schedule;
+3. remove each child/parent pair from a local tensor map;
+4. contract with the pairwise `TensorContractionLike::contract_pair` path;
+5. validate each intermediate's CUDA residency/context, dense axis classes,
+   and `StorageKind::Dense` before reinsertion;
+6. permute the final tensor to canonical site-index order through the existing
+   eager transpose path;
+7. validate and return the still-resident CUDA result.
+
+For same-dtype dense EagerTensor operands, pairwise contraction reaches
+`EagerTensor::dot_general_with_conj` in the operands' own eager runtime. The
+mixed-dtype fallback through `contract_native_tensor` is unreachable because
+same dtype is validated before the first edge.
+
+A mixed host/CUDA, foreign-context, or mixed-dtype TreeTN fails at the typed
+validation boundary before contraction. It is never sent to the CPU graph
+runtime and never falls back.
+
+This is an explicitly dense full-network contraction and retains the existing
+`contract_to_tensor` output-size cost. It is the first measurable vertical
+slice, not the scalable TreeTN×TreeTN production contraction milestone.
+
+## Benchmark harness
+
+Add a feature-gated release example or bench target under
+`tensor4all-treetn` that builds a deterministic dense chain with:
+
+- endpoint physical dimension 2;
+- configurable chain length and bond dimension;
+- dense f64 node tensors with bounded deterministic values;
+- small output size so benchmark memory is controlled while bond contractions
+  are nontrivial.
+
+The harness reports separate durations for:
+
+1. host TreeTN setup;
+2. CUDA context setup;
+3. host-to-device upload;
+4. CUDA warm-up (reported but excluded from steady state);
+5. steady-state CUDA `contract_to_tensor_cuda` plus explicit synchronize;
+6. device-to-host download;
+7. steady-state CPU `contract_to_tensor`.
+
+It prints configuration, iteration count, GPU name/runtime information when
+available, and milliseconds per stage. Correctness is checked outside timed
+loops by comparing the downloaded CUDA result against the CPU result using
+exact index order and a reported max-absolute residual. The output tensor's
+CUDA residency is asserted before download.
+
+Suggested command:
+
+```text
+cargo run --release -p tensor4all-treetn \
+  --example cuda_tree_contraction --features tenferro-cuda,tenferro-cpu-faer
+```
+
+## Tests
+
+### Hardware-independent
+
+- CPU-only default build has no `tenferro-gpu` activation.
+- CUDA feature compile-checks for tensorbackend, core, and treetn.
+- Public CUDA error/source chains and feature-gated API signatures compile.
+- Mock/metadata tests cover host-vs-CUDA placement classification without
+  requiring a CUDA device where practical.
+- Mixed-placement, foreign-context, and mixed-dtype validation is tested before
+  contraction execution.
+- Structured and tracked transfer rejection is tested before CUDA access.
+- A source-contract regression proves `contract_to_tensor_cuda` uses the
+  pairwise edge walk and does not call generic `contract_to_tensor` or
+  `T::contract`.
+
+### CUDA hardware
+
+On visible CUDA ordinal 0:
+
+- context creation reports ordinal 0;
+- dense f64 upload retains shape/dtype and produces device placement;
+- download restores exact values and ordered full indices;
+- foreign-context download returns a typed error;
+- a two-node, a branched TreeTN, and a scalar-output closed tree upload,
+  contract, and download match CPU;
+- every checked intermediate and the output are CUDA-resident in the supplied
+  eager context before download;
+- mixed host/CUDA, foreign-context, and mixed-dtype node tensors return typed
+  errors before the first edge contraction;
+- no host access succeeds on the resident output; the output-residency check
+  plus the source-contract regression proves no default CPU graph route ran;
+- benchmark harness completes and reports all timing categories.
+
+## Review gate
+
+- Reviewer: `reviewer-flash-opencode-go`
+- Round 1 verdict: **Needs changes** because generic `contract_to_tensor` routes
+  through the default CPU graph runtime.
+- Fix: define a same-dtype, pairwise eager edge walk; reject structured storage
+  by `StorageKind`; propagate `backend-tenferro` for download reconstruction.
+- Updated design verdict: **Correct-to-merge**. The reviewer verified that the
+  pairwise same-dtype dense branches execute in the operands' CUDA eager
+  runtime and that required TreeTN topology/schedule accessors are public.
+- Implementation recon added `tenferro-cpu-faer` to tensorbackend/core CUDA
+  features because `explicit-context`/`backend-tenferro` compile `CpuBackend`
+  and download reconstruction uses the existing CPU default context; the
+  no-default CUDA gates otherwise fail closed with tenferro-cpu's provider
+  check. The reviewer confirmed this is the minimal provider choice.
+
+## Verification
+
+CPU/default gates:
+
+```text
+cargo fmt --all -- --check
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --release --workspace --no-fail-fast
+cargo test --doc --release --workspace
+cargo doc --workspace --no-deps
+```
+
+Feature and hardware gates:
+
+```text
+cargo check -p tensor4all-tensorbackend --no-default-features --features tenferro-cuda
+cargo check -p tensor4all-core --no-default-features --features tenferro-cuda
+cargo check -p tensor4all-treetn --no-default-features --features tenferro-cuda,tenferro-cpu-faer
+cargo nextest run --release -p tensor4all-tensorbackend --features tenferro-cuda
+cargo nextest run --release -p tensor4all-core --features tenferro-cuda
+cargo nextest run --release -p tensor4all-treetn --features tenferro-cuda
+cargo run --release -p tensor4all-treetn --example cuda_tree_contraction \
+  --features tenferro-cuda,tenferro-cpu-faer
+```
+
+Also run repository-rules review, panic/public-error audits, mdBook tests, and
+`git diff --check`.
+
+## Acceptance criteria
+
+- CUDA is optional and absent from CPU defaults.
+- Visible ordinal 0 is the only supported CUDA device.
+- Explicit upload/download preserve dense values, dtype, shape, and full Index
+  metadata without hidden transfer.
+- Tracked, structured, foreign, unsupported, and mixed-placement inputs return
+  typed errors with no CPU fallback.
+- One TreeTN full contraction remains CUDA-resident until explicit download and
+  matches CPU numerically.
+- Setup, upload, warm-up, steady-state contraction, download, and CPU timings
+  are reported separately.
+- CPU-only CI and all available CUDA feature/hardware gates pass.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -8,6 +8,7 @@
 | [tenferro-main-session-migration.md](./tenferro-main-session-migration.md) | First issue #623 slice: pin current tenferro main and migrate internal CPU calls to its canonical session API |
 | [explicit-cpu-execution-context.md](./explicit-cpu-execution-context.md) | Issue #663 explicit plain, graph, eager-AD, and logical reconstruction context |
 | [tensorbackend-session-entry.md](./tensorbackend-session-entry.md) | Issue #623 slice: centralize concrete CPU sessions on explicit contexts before CUDA dispatch |
+| [cuda-tree-contraction.md](./cuda-tree-contraction.md) | Issues #623/#553 single-CUDA explicit transfer and TreeTN contraction vertical slice |
 | [torch_backend.md](./torch_backend.md) | PyTorch backend design exploration |
 | [tenferro_ad_scalar_operator_extension_note.md](./tenferro_ad_scalar_operator_extension_note.md) | Tenferro AD scalar operator extension notes |
 | [build-profiles.md](./build-profiles.md) | Debug-free ordinary Cargo profiles and the opt-in full-debug release profile |

--- a/docs/worklogs/2026-08-23-cuda-tree-contraction.md
+++ b/docs/worklogs/2026-08-23-cuda-tree-contraction.md
@@ -1,0 +1,118 @@
+# CUDA TreeTN Contraction Worklog
+
+## Summary
+
+Implemented PR 2 of the issue #623/#553 GPU foundation: optional CUDA feature
+plumbing, a caller-owned visible-ordinal-0 CUDA context, explicit dense
+IdxTensor transfer, typed placement/context errors, a pairwise device-resident
+TreeTN full contraction, and a separated-timing benchmark harness.
+
+## Material reviewed
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, shared Rust/GPU/performance rules
+- issues #623, #553, and merged PR #674
+- `docs/design/tensorbackend-session-entry.md`
+- pinned tenferro `a21a4c6` CUDA backend, transfer, eager-runtime, einsum, and
+  linalg contracts
+- IdxTensor storage/eager/context paths
+- generic TreeTN `contract_to_tensor` and core n-ary/pairwise contraction paths
+
+## Review gates
+
+- Design: `docs/design/cuda-tree-contraction.md`
+- Reviewer: `reviewer-flash-opencode-go`
+- Round 1: **Needs changes** — generic `contract_to_tensor` enters the default
+  CPU graph runtime
+- Fixed design: direct deterministic pairwise edge walk, same-dtype validation,
+  `StorageKind::Dense` rejection, and host-provider feature propagation
+- Final pre-implementation verdict: **Correct-to-merge**
+- Implementation: `luna-implementer`, max thinking, with parent integration
+- Post-implementation reviewer: `reviewer-flash-opencode-go`
+- Initial verdict: **Correct-to-merge** with six minor findings
+- Findings fixed: redundant validation removed; single/empty tests added;
+  per-method rustdoc completed; GPU name reported; metadata tests strengthened;
+  root sentinel replaced.
+- Final re-review verdict: **Correct-to-merge**
+- Final panic-baseline delta review: **Correct-to-merge**
+
+## Decisions
+
+- CUDA is optional and absent from all default feature sets.
+- `CudaExecutionContext` owns one ordinal-0 `CudaBackend` and one lazy eager
+  runtime built from a backend clone, preserving allocation identity.
+- Transfers are explicit; tracked and structured inputs fail before CUDA
+  access. No automatic transfer or CPU fallback exists.
+- Dense transfer preserves dtype, shape, ordered full indices, values, CUDA
+  placement, and eager context identity.
+- The CUDA TreeTN method duplicates only the topology-level edge schedule. It
+  uses `contract_pair`; it does not call generic `contract_to_tensor` or
+  `T::contract`, avoiding the CPU n-ary graph runtime.
+- Every node, intermediate, and final result is validated against the supplied
+  CUDA context and common dtype.
+- CUDA feature activation includes faer CPU support because host download
+  reconstruction uses the existing default CPU eager context.
+
+## Changed surface
+
+- root and tensorbackend/core/treetn Cargo feature plumbing
+- `tensor4all-tensorbackend/src/cuda.rs`
+- `tensor4all-core/src/defaults/cuda.rs` plus minimal IdxTensor accessors
+- `tensor4all-treetn/src/cuda.rs`
+- CUDA transfer and TreeTN integration tests
+- `tensor4all-treetn/examples/cuda_tree_contraction.rs`
+- design index and design document
+- panic baseline line shift caused by the feature-gated IdxTensor accessors
+- this worklog
+
+## Focused verification
+
+Hardware: NVIDIA A100 80GB PCIe, visible ordinal 0.
+
+- default tensorbackend cargo tree: no `tenferro-gpu`
+- CUDA tensorbackend cargo tree: `tenferro-gpu` present
+- CUDA no-default checks: tensorbackend/core/treetn pass
+- CUDA clippy `-D warnings`: tensorbackend/core/treetn pass
+- tensorbackend CUDA nextest: 196 passed, 2 skipped
+- core CUDA nextest: 823 passed, 2 skipped
+- treetn CUDA nextest: 726 passed, 1 skipped
+- focused TreeTN CUDA tests: 9 passed
+- core dense transfer tests: 2 passed
+- CPU workspace nextest: 3161 passed, 16 skipped
+- CPU workspace and CUDA-feature doctests: pass
+- workspace docs and mdBook tests: pass (pre-existing rustdoc warnings only)
+- repository-rules tests: 90 passed; dry run: pass
+- panic audit: 0 unbaselined, 0 stale
+- changed public-error-doc audit and `git diff --check`: pass
+
+Small benchmark run:
+
+```text
+config chain_length=4 bond_dim=2 iterations=2
+device name="NVIDIA A100 80GB PCIe" visible_cuda_ordinal=0 runtime=cuda-eager
+residual_max_abs=0.000000e0
+host_setup_ms=4.718398
+cuda_context_setup_ms=191.252571
+upload_ms=339.436728
+cuda_warmup_ms=2.374865
+cuda_steady_sync_ms_total=0.936309 cuda_steady_sync_ms_per_iter=0.468154
+download_ms=18.629205
+cpu_steady_ms_total=5.981228 cpu_steady_ms_per_iter=2.990614
+```
+
+The benchmark is a functional vertical-slice measurement, not a general GPU
+performance claim; setup and transfer dominate this intentionally small case.
+
+## Coverage impact
+
+No test or tolerance was removed or weakened. New coverage includes typed
+tracked/structured/foreign/mixed-placement and mixed-dtype failures, exact
+transfer round trips, two-node/branched/scalar-output contraction parity,
+resident host-access rejection, pairwise source contract, and benchmark
+correctness.
+
+## Remaining issue #623 work
+
+This PR does not support zip-up/fitting, SVD/QR/truncation, TCI/ACI, tracked
+transfer, structured storage, C API/bindings, automatic placement, or multiple
+GPUs. Those require separately reviewed vertical slices after this explicit
+contract is stable.

--- a/scripts/library-panics-baseline.json
+++ b/scripts/library-panics-baseline.json
@@ -1,5 +1,5 @@
 [
-  "crates/tensor4all-core/src/defaults/idx_tensor.rs:6004:debug_assert_eq",
+  "crates/tensor4all-core/src/defaults/idx_tensor.rs:6054:debug_assert_eq",
   "crates/tensor4all-core/src/matrixlu.rs:741:debug_assert_eq",
   "crates/tensor4all-core/src/matrixluci/source.rs:103:assert",
   "crates/tensor4all-core/src/matrixluci/source.rs:108:assert_eq",


### PR DESCRIPTION
## Summary

- add optional `tenferro-cuda` plumbing and a caller-owned visible-ordinal-0 `CudaExecutionContext`
- add explicit dense, untracked `IdxTensor::upload_cuda` / `download` with typed placement, context, structured, and tracking errors
- add transactional TreeTN transfer and a same-dtype pairwise CUDA edge walk that remains device-resident and never enters the default CPU graph runtime
- add A100 parity/error tests and a reproducible benchmark reporting setup, upload, warm-up, steady GPU+sync, download, and CPU timings separately

Refs #623
Refs #553

## Scope

This is the second PR of the two-PR GPU foundation. It intentionally does not add automatic transfer/fallback, multi-GPU, tracked or structured transfer, zip-up/fitting, CUDA SVD/QR/truncation, TCI/ACI, C API, or bindings.

## Design and review gates

- Design: `docs/design/cuda-tree-contraction.md`
- Worklog: `docs/worklogs/2026-08-23-cuda-tree-contraction.md`
- Pre-implementation review round 1: `reviewer-flash-opencode-go` — **Needs changes** (generic contraction used CPU graph runtime)
- Design fixed to a direct pairwise eager edge walk
- Final pre-implementation review: **Correct-to-merge**
- Implementation: `luna-implementer`, max thinking, with parent integration
- Post-implementation full-diff review: **Correct-to-merge**
- Finding-fix re-review: **Correct-to-merge**
- Panic-baseline delta review: **Correct-to-merge**

## Verification

Hardware: NVIDIA A100 80GB PCIe, visible CUDA ordinal 0.

- `cargo fmt --all -- --check`
- CPU workspace check and clippy `-D warnings`
- CUDA no-default checks and clippy for tensorbackend/core/treetn
- CPU workspace nextest — **3161 passed, 16 skipped**
- tensorbackend CUDA nextest — **196 passed, 2 skipped**
- core CUDA nextest — **823 passed, 2 skipped**
- treetn CUDA nextest — **726 passed, 1 skipped**
- focused TreeTN CUDA tests — **9 passed**
- dense transfer tests — **2 passed**
- CPU workspace and CUDA-feature doctests
- workspace docs and mdBook tests
- repository-rules tests — **90 passed**; dry run pass
- panic audit — **0 unbaselined, 0 stale**
- changed public-error-doc audit and `git diff --check`
- default cargo tree excludes `tenferro-gpu`; CUDA tree includes it

## Benchmark smoke result

```text
config chain_length=4 bond_dim=2 iterations=2
device name="NVIDIA A100 80GB PCIe" visible_cuda_ordinal=0 runtime=cuda-eager
residual_max_abs=0.000000e0
host_setup_ms=4.718398
cuda_context_setup_ms=191.252571
upload_ms=339.436728
cuda_warmup_ms=2.374865
cuda_steady_sync_ms_total=0.936309 cuda_steady_sync_ms_per_iter=0.468154
download_ms=18.629205
cpu_steady_ms_total=5.981228 cpu_steady_ms_per_iter=2.990614
```

This is a functional vertical-slice measurement, not a general GPU performance claim.

## Coverage impact

No tests or tolerances were removed or weakened. New coverage includes typed tracked/structured/foreign/mixed-placement/mixed-dtype failures, exact transfer round trips, two-node/branched/scalar/single-node contraction parity, empty input, resident host-access rejection, pairwise source contract, and benchmark correctness.
