### PR TITLE
feat: add dense tensor TT-SVD constructor

### DIFF
--- a/crates/tensor4all-itensorlike/README.md
+++ b/crates/tensor4all-itensorlike/README.md
@@ -5,6 +5,7 @@ ITensors.jl-inspired TensorTrain API with orthogonality tracking and multiple ca
 ## Key Types
 
 - `TensorTrain` — tensor train with orthogonality center tracking
+- `TensorTrain::from_dense()` — sequential TT-SVD of an existing indexed tensor
 - `orthogonalize()` — move orthogonality center to a given site
 - `truncate()` — SVD-based bond dimension truncation
 - `inner()` — inner product `<self|other>` with complex conjugation on `self`
@@ -87,4 +88,5 @@ assert!(inner.imag().abs() < 1e-12);
 ## Documentation
 
 - [User Guide: Tensor Train](https://tensor4all.org/tensor4all-rs/guides/tensor-train.html)
+- [Dense Tensor to Tensor Train with TT-SVD](https://tensor4all.org/tensor4all-rs/guides/dense-tt-svd.html)
 - [API Reference](https://tensor4all.org/tensor4all-rs/rustdoc/tensor4all_itensorlike/)

--- a/crates/tensor4all-itensorlike/src/lib.rs
+++ b/crates/tensor4all-itensorlike/src/lib.rs
@@ -14,6 +14,7 @@ pub use linsolve::linsolve;
 pub use options::{
     CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TruncateOptions,
 };
+pub use tensor4all_core::SvdOptions;
 pub use tensortrain::TensorTrain;
 
 /// Type alias for Matrix Product State (MPS).

--- a/crates/tensor4all-itensorlike/src/prelude.rs
+++ b/crates/tensor4all-itensorlike/src/prelude.rs
@@ -21,6 +21,7 @@
 //! ```
 
 pub use crate::{
-    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, TensorTrain, TruncateOptions,
+    CanonicalForm, ContractMethod, ContractOptions, LinsolveOptions, SvdOptions, TensorTrain,
+    TruncateOptions,
 };
 pub use tensor4all_core::{DynIndex, IdxTensor, IndexLike, SvdTruncationPolicy};

--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -8,6 +8,7 @@
 
 use num_complex::Complex64;
 use std::any::TypeId;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ops::Range;
 use std::sync::OnceLock;
@@ -18,11 +19,14 @@ use tensor4all_core::{
 };
 use tensor4all_core::{
     AnyScalar, Canonical, CommonScalar, DirectSumResult, FactorizeAlg, FactorizeError,
-    FactorizeOptions, FactorizeResult, IdxTensor, IdxTensorError, LinearizationOrder,
+    FactorizeOptions, FactorizeResult, IdxTensor, IdxTensorError, LinearizationOrder, SvdOptions,
     TensorConstructionLike, TensorContractionLike, TensorElement, TensorFactorizationLike,
     TensorIndex, TensorVectorSpace,
 };
-use tensor4all_treetn::{CanonicalizationOptions, TreeTN, TruncationOptions};
+use tensor4all_treetn::{
+    factorize_tensor_to_treetn_with, CanonicalizationOptions, TreeTN, TreeTopology,
+    TruncationOptions,
+};
 
 use crate::error::{Result, TensorTrainError};
 use crate::options::{validate_svd_truncation_options, CanonicalForm, TruncateOptions};
@@ -226,6 +230,130 @@ impl TensorTrain {
             canonical_form: None,
         };
         Ok(tt)
+    }
+
+    /// Decompose a dense indexed tensor into a left-canonical tensor train with TT-SVD.
+    ///
+    /// `site_indices` defines the tensor-train order and must contain every index
+    /// of `dense` exactly once. Dense values retain the column-major convention of
+    /// [`IdxTensor::from_dense`]: the first index of `dense` varies fastest.
+    /// The sweep splits sites from left to right, carries `S Vᴴ` into the next
+    /// split, and leaves the orthogonality center at the final site.
+    ///
+    /// `options.policy` controls each local SVD truncation and
+    /// `options.max_bond_dim` independently caps every resulting bond. A local
+    /// cutoff is not the final global reconstruction error; measure the latter by
+    /// reconstructing with [`Self::to_dense`] and comparing with `dense`.
+    ///
+    /// This explicitly dense algorithm can require several times the input size
+    /// in working memory because each sequential SVD materializes decomposition
+    /// workspaces.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TensorTrainError::InvalidStructure`] when `site_indices` is
+    /// empty, duplicated, or differs from the indices of `dense`. Returns
+    /// [`TensorTrainError::Factorize`] for invalid SVD options or unsupported
+    /// input storage, and an operation error if a split or chain construction
+    /// fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tensor4all_core::{DynIndex, IdxTensor, SvdTruncationPolicy};
+    /// use tensor4all_itensorlike::{CanonicalForm, SvdOptions, TensorTrain};
+    ///
+    /// # fn main() -> anyhow::Result<()> {
+    /// let sites = [
+    ///     DynIndex::new_dyn(2),
+    ///     DynIndex::new_dyn(2),
+    ///     DynIndex::new_dyn(2),
+    /// ];
+    /// // Column-major outer product [1, 2] ⊗ [1, 3] ⊗ [1, 4].
+    /// let dense = IdxTensor::from_dense(
+    ///     sites.to_vec(),
+    ///     vec![1.0, 2.0, 3.0, 6.0, 4.0, 8.0, 12.0, 24.0],
+    /// )?;
+    /// let options = SvdOptions::new()
+    ///     .with_policy(SvdTruncationPolicy::new(1.0e-12))
+    ///     .with_max_bond_dim(8);
+    /// let train = TensorTrain::from_dense(&dense, &sites, &options)?;
+    /// let reconstructed = train.to_dense()?;
+    ///
+    /// assert!(dense.distance(&reconstructed)? < 1.0e-12);
+    /// assert_eq!(train.bond_dims(), vec![1, 1]);
+    /// assert_eq!(train.ortho_center(), Some(2));
+    /// assert_eq!(train.canonical_form(), Some(CanonicalForm::Unitary));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_dense(
+        dense: &IdxTensor,
+        site_indices: &[DynIndex],
+        options: &SvdOptions,
+    ) -> Result<Self> {
+        let mut factorize_options = FactorizeOptions::svd();
+        if let Some(policy) = options.policy {
+            factorize_options = factorize_options.with_svd_policy(policy);
+        }
+        if let Some(max_bond_dim) = options.max_bond_dim {
+            factorize_options = factorize_options.with_max_bond_dim(max_bond_dim);
+        }
+        factorize_options.validate()?;
+        if dense.is_diag() {
+            return Err(FactorizeError::UnsupportedStorage(
+                "dense TT-SVD does not accept diagonal storage",
+            )
+            .into());
+        }
+        if !(dense.is_f64() || dense.is_c64()) {
+            return Err(FactorizeError::UnsupportedStorage(
+                "dense TT-SVD currently supports only f64 and Complex64 tensors",
+            )
+            .into());
+        }
+
+        if site_indices.is_empty() {
+            return Err(TensorTrainError::InvalidStructure {
+                message: "dense TT-SVD requires at least one site index".into(),
+            });
+        }
+        let requested: HashSet<_> = site_indices.iter().cloned().collect();
+        if requested.len() != site_indices.len() {
+            return Err(TensorTrainError::InvalidStructure {
+                message: "dense TT-SVD site indices must be unique".into(),
+            });
+        }
+        let dense_indices: HashSet<_> = dense.indices().iter().cloned().collect();
+        if dense_indices.len() != dense.indices().len()
+            || requested.len() != dense_indices.len()
+            || requested != dense_indices
+        {
+            return Err(TensorTrainError::InvalidStructure {
+                message: "dense TT-SVD site indices must match every dense tensor index exactly"
+                    .into(),
+            });
+        }
+
+        let nodes: HashMap<_, _> = site_indices
+            .iter()
+            .cloned()
+            .enumerate()
+            .map(|(site, index)| (site, vec![index]))
+            .collect();
+        let edges = (0..site_indices.len().saturating_sub(1))
+            .map(|site| (site, site + 1))
+            .collect();
+        let topology = TreeTopology::new(nodes, edges);
+        let center = site_indices.len() - 1;
+        let tree = factorize_tensor_to_treetn_with(dense, &topology, factorize_options, &center)
+            .map_err(|error| {
+                TensorTrainError::operation_source(
+                    "Dense TT-SVD decomposition failed",
+                    anyhow::Error::new(error),
+                )
+            })?;
+        Self::from_inner(tree, Some(CanonicalForm::Unitary))
     }
 
     /// Create a new tensor train with specified orthogonality center.

--- a/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain/tests/mod.rs
@@ -2,7 +2,9 @@ use super::*;
 use std::error::Error;
 use std::io;
 use std::time::Duration;
-use tensor4all_core::{DynId, Index, LinearizationOrder, TensorContractionLike, TensorVectorSpace};
+use tensor4all_core::{
+    DynId, Index, LinearizationOrder, SvdTruncationPolicy, TensorContractionLike, TensorVectorSpace,
+};
 
 /// Helper to create a simple tensor for testing
 fn make_tensor(indices: Vec<DynIndex>) -> IdxTensor {
@@ -43,6 +45,118 @@ fn test_single_site_tt() {
     assert_eq!(tt.len(), 1);
     assert!(!tt.is_ortho());
     assert_eq!(tt.bond_dims(), Vec::<usize>::new());
+}
+
+fn dense_tt_svd_round_trip<T: TensorElement>(data: Vec<T>, tolerance: f64) {
+    let sites = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    let dense = IdxTensor::from_dense(sites.to_vec(), data).unwrap();
+    let options = SvdOptions::new().with_policy(SvdTruncationPolicy::new(0.0));
+    let train = TensorTrain::from_dense(&dense, &sites, &options).unwrap();
+    let reconstructed = train.to_dense().unwrap();
+
+    assert!(dense.distance(&reconstructed).unwrap() < tolerance);
+    assert_eq!(train.ortho_center(), Some(2));
+    assert_eq!(train.canonical_form(), Some(CanonicalForm::Unitary));
+}
+
+#[test]
+fn dense_tt_svd_round_trips_f64() {
+    dense_tt_svd_round_trip(vec![1.0_f64, 2.0, 3.0, 5.0, 7.0, 11.0, 13.0, 17.0], 1.0e-12);
+}
+
+#[test]
+fn dense_tt_svd_round_trips_complex64() {
+    dense_tt_svd_round_trip(
+        (0..8)
+            .map(|value| Complex64::new(value as f64 + 1.0, (value % 3) as f64 - 1.0))
+            .collect(),
+        1.0e-12,
+    );
+}
+
+#[test]
+fn dense_tt_svd_caps_bonds_and_reports_expected_truncation_error() {
+    let sites = [
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+        DynIndex::new_dyn(2),
+    ];
+    let mut data = vec![0.0_f64; 8];
+    data[0] = 1.0;
+    data[7] = 0.1;
+    let dense = IdxTensor::from_dense(sites.to_vec(), data).unwrap();
+    let options = SvdOptions::new()
+        .with_policy(SvdTruncationPolicy::new(0.0))
+        .with_max_bond_dim(1);
+    let train = TensorTrain::from_dense(&dense, &sites, &options).unwrap();
+    let error = dense.distance(&train.to_dense().unwrap()).unwrap();
+
+    assert_eq!(train.bond_dims(), vec![1, 1]);
+    assert!(error > 0.09 && error < 0.11, "relative error = {error}");
+}
+
+#[test]
+fn dense_tt_svd_uses_full_index_identity_for_site_order() {
+    let site = DynIndex::new_dyn(2);
+    let primed = site.prime();
+    let dense = IdxTensor::from_dense(
+        vec![primed.clone(), site.clone()],
+        vec![1.0_f64, 2.0, 3.0, 4.0],
+    )
+    .unwrap();
+    let train = TensorTrain::from_dense(
+        &dense,
+        &[site, primed],
+        &SvdOptions::new().with_policy(SvdTruncationPolicy::new(0.0)),
+    )
+    .unwrap();
+
+    assert!(dense.distance(&train.to_dense().unwrap()).unwrap() < 1.0e-12);
+    assert_eq!(train.site_indices()[0][0].plev(), 0);
+    assert_eq!(train.site_indices()[1][0].plev(), 1);
+}
+
+#[test]
+fn dense_tt_svd_rejects_invalid_sites_and_options_before_single_site_shortcut() {
+    let site = DynIndex::new_dyn(2);
+    let dense = IdxTensor::from_dense(vec![site.clone()], vec![1.0_f64, 2.0]).unwrap();
+
+    assert!(matches!(
+        TensorTrain::from_dense(&dense, &[], &SvdOptions::new()).unwrap_err(),
+        TensorTrainError::InvalidStructure { .. }
+    ));
+    assert!(matches!(
+        TensorTrain::from_dense(&dense, &[site.clone(), site.clone()], &SvdOptions::new(),)
+            .unwrap_err(),
+        TensorTrainError::InvalidStructure { .. }
+    ));
+    assert!(matches!(
+        TensorTrain::from_dense(&dense, &[DynIndex::new_dyn(2)], &SvdOptions::new(),).unwrap_err(),
+        TensorTrainError::InvalidStructure { .. }
+    ));
+    assert!(matches!(
+        TensorTrain::from_dense(&dense, &[site], &SvdOptions::new().with_max_bond_dim(0))
+            .unwrap_err(),
+        TensorTrainError::Factorize(FactorizeError::InvalidOptions(_))
+    ));
+
+    let diag_sites = [DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let diagonal = IdxTensor::from_diag(diag_sites.to_vec(), vec![1.0_f64, 2.0]).unwrap();
+    assert!(matches!(
+        TensorTrain::from_dense(&diagonal, &diag_sites, &SvdOptions::new()).unwrap_err(),
+        TensorTrainError::Factorize(FactorizeError::UnsupportedStorage(_))
+    ));
+
+    let f32_site = DynIndex::new_dyn(1);
+    let f32_dense = IdxTensor::from_dense(vec![f32_site.clone()], vec![1.0_f32]).unwrap();
+    assert!(matches!(
+        TensorTrain::from_dense(&f32_dense, &[f32_site], &SvdOptions::new()).unwrap_err(),
+        TensorTrainError::Factorize(FactorizeError::UnsupportedStorage(_))
+    ));
 }
 
 #[test]

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Guides]()
   - [Tensor Basics](guides/tensor-basics.md)
   - [Tensor Train](guides/tensor-train.md)
+  - [Dense Tensor to Tensor Train with TT-SVD](guides/dense-tt-svd.md)
   - [Tensor Cross Interpolation](guides/tci.md)
   - [TCI Advanced Topics](guides/tci-advanced.md)
   - [Compressing Existing Data](guides/compress.md)

--- a/docs/book/src/getting-started.md
+++ b/docs/book/src/getting-started.md
@@ -14,6 +14,10 @@ crates.io yet, so use git dependencies from an external project:
 # Basic tensor train construction and manipulation
 tensor4all-simplett = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-simplett" }
 
+# Indexed tensors and ITensors-like TensorTrain/TT-SVD
+tensor4all-core = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-core" }
+tensor4all-itensorlike = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-itensorlike" }
+
 # Tensor Cross Interpolation (TCI)
 tensor4all-tensorci = { git = "https://github.com/tensor4all/tensor4all-rs", package = "tensor4all-tensorci" }
 
@@ -32,6 +36,8 @@ relative to your project's `Cargo.toml`; adjust `../tensor4all-rs` as needed:
 ```toml
 [dependencies]
 tensor4all-simplett = { path = "../tensor4all-rs/crates/tensor4all-simplett" }
+tensor4all-core = { path = "../tensor4all-rs/crates/tensor4all-core" }
+tensor4all-itensorlike = { path = "../tensor4all-rs/crates/tensor4all-itensorlike" }
 tensor4all-tensorci = { path = "../tensor4all-rs/crates/tensor4all-tensorci" }
 tensor4all-quanticstci = { path = "../tensor4all-rs/crates/tensor4all-quanticstci" }
 tensor4all-treetn = { path = "../tensor4all-rs/crates/tensor4all-treetn" }
@@ -79,4 +85,5 @@ cargo run
 ## Next Steps
 
 - [Concepts](concepts.md) — learn about tensor trains, bond dimensions, and TCI before diving deeper.
+- [Dense Tensor to Tensor Train with TT-SVD](guides/dense-tt-svd.md) — decompose an existing full indexed tensor with sequential SVD.
 - [Guides](guides/tensor-basics.md) — step-by-step walkthroughs for tensor basics, TCI, quantics transforms, and tree tensor networks.

--- a/docs/book/src/guides/dense-tt-svd.md
+++ b/docs/book/src/guides/dense-tt-svd.md
@@ -1,0 +1,81 @@
+# Dense Tensor to Tensor Train with TT-SVD
+
+Use `TensorTrain::from_dense` when all values of an indexed tensor already fit
+in memory and you want a sequential SVD decomposition. For sampled functions
+whose full tensor does not fit in memory, use TCI instead.
+
+## Complete example
+
+```rust
+# fn main() -> anyhow::Result<()> {
+# use tensor4all_core::{DynIndex, IdxTensor, SvdTruncationPolicy};
+# use tensor4all_itensorlike::{CanonicalForm, SvdOptions, TensorTrain};
+let sites = [
+    DynIndex::new_dyn(2),
+    DynIndex::new_dyn(2),
+    DynIndex::new_dyn(2),
+];
+
+// IdxTensor dense buffers are column-major: sites[0] varies fastest.
+// These values are [1, 2] ⊗ [1, 3] ⊗ [1, 4].
+let dense = IdxTensor::from_dense(
+    sites.to_vec(),
+    vec![1.0, 2.0, 3.0, 6.0, 4.0, 8.0, 12.0, 24.0],
+)?;
+let options = SvdOptions::new()
+    .with_policy(SvdTruncationPolicy::new(1.0e-12))
+    .with_max_bond_dim(16);
+let train = TensorTrain::from_dense(&dense, &sites, &options)?;
+
+let reconstructed = train.to_dense()?;
+assert!(dense.distance(&reconstructed)? < 1.0e-12);
+assert_eq!(train.bond_dims(), vec![1, 1]);
+assert_eq!(train.ortho_center(), Some(2));
+assert_eq!(train.canonical_form(), Some(CanonicalForm::Unitary));
+# Ok(())
+# }
+```
+
+The `sites` slice defines the tensor-train order. It must contain every full
+`DynIndex` of the input exactly once, but it need not match the input tensor's
+axis order. Prime levels and tags are part of index identity.
+
+## Sweep and canonical form
+
+TT-SVD splits from left to right. At each bond, `U` becomes the completed
+left-canonical core and `S Vᴴ` is carried into the next split. The final core
+therefore holds the remaining norm, and the returned train records the final
+site as its orthogonality center.
+
+## Truncation
+
+`SvdOptions` has two independent controls:
+
+- `with_policy(...)` chooses which singular-value tail is discarded at each
+  bond;
+- `with_max_bond_dim(n)` caps every retained bond at `n`.
+
+For a discarded-Frobenius-weight rule, use squared singular values and a tail
+sum:
+
+```rust
+# use tensor4all_core::SvdTruncationPolicy;
+let local_policy = SvdTruncationPolicy::new(1.0e-10)
+    .with_squared_values()
+    .with_discarded_tail_sum();
+assert_eq!(local_policy.threshold, 1.0e-10);
+```
+
+The policy is applied separately at each of the `number_of_sites - 1` splits.
+It is therefore not, by itself, a statement of the final global relative error.
+When a global tolerance matters, allocate a tighter per-bond error budget and
+verify the result with `dense.distance(&train.to_dense()?)`, as in the example.
+A hard `max_bond_dim` can force a larger error regardless of the policy.
+
+## Memory cost
+
+This is an explicitly dense algorithm. The input already costs the product of
+all site dimensions, and SVD workspaces plus the carried tensor can require
+several times that storage. Do not use dense TT-SVD as a hidden compression
+path for data that cannot already be materialized. Use TCI for oracle-defined
+or otherwise non-materialized data.

--- a/docs/book/src/guides/tensor-train.md
+++ b/docs/book/src/guides/tensor-train.md
@@ -13,6 +13,8 @@ complementary implementations:
 Use `tensor4all-simplett` when you want fast numerics with minimal boilerplate
 (no named indices needed). Use `tensor4all-itensorlike` when you need named
 indices, automatic orthogonality tracking, or ITensors.jl compatibility.
+If you already have a full `IdxTensor`, follow [Dense Tensor to Tensor Train
+with TT-SVD](dense-tt-svd.md).
 
 ---
 

--- a/docs/worklogs/2026-08-23-dense-tt-svd.md
+++ b/docs/worklogs/2026-08-23-dense-tt-svd.md
@@ -1,0 +1,39 @@
+# Dense `IdxTensor` to `TensorTrain` TT-SVD
+
+## Summary
+
+Issue #665 exposed a discoverability gap: downstream users could compose TT-SVD from `factorize`, but `tensor4all-itensorlike` had no owning high-level entry point. This change adds `TensorTrain::from_dense` and a runnable guide.
+
+## Evidence reviewed
+
+- `tensor4all-itensorlike::TensorTrain` construction and canonical metadata
+- `tensor4all-treetn::factorize_tensor_to_treetn_with`
+- `tensor4all-core::{FactorizeOptions, SvdOptions, SvdTruncationPolicy}`
+- dense layout, public-boundary, numerical, documentation, and memory rules
+
+## Decisions
+
+- Reuse the existing general TreeTN decomposition with a generated chain topology; do not duplicate the sequential factorization loop.
+- Accept the existing `SvdOptions` rather than add another options type. Only the SVD policy and maximum bond dimension are relevant to TT-SVD.
+- Require each full dense index exactly once and use the supplied slice as TT site order. Full index identity preserves prime/tag distinctions.
+- Sweep left-to-right and record unitary canonical metadata with the final site as orthogonality center.
+- Keep the path explicitly dense and document local-versus-global truncation error and workspace cost.
+
+## Alternatives rejected
+
+- A free function would be less discoverable than the constructor users already attempted.
+- Accepting `FactorizeOptions` would expose irrelevant QR/LU/CI and canonical-direction settings.
+- A new TT-SVD options wrapper would duplicate `SvdOptions`.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo nextest run --release --workspace` (3186 passed)
+- `cargo test --doc --release --workspace` (933 passed)
+- `cargo doc --workspace --no-deps`
+- `scripts/test-mdbook.sh`
+- source-blind external path-dependency example copied from the guide: release build and run passed
+- repository-rules review script tests and dry-run passed
+
+Coverage includes f64, Complex64, truncation, invalid site sets/options, canonical metadata, reconstruction residuals, and same-ID/different-prime index identity.


### PR DESCRIPTION
## Summary

- add `TensorTrain::from_dense` for TT-SVD of an indexed dense tensor
- preserve site order and full dynamic-index identity while reusing the existing tree factorization path
- document the user workflow with a runnable mdBook guide

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace` (3186 passed)
- `cargo test --doc --release --workspace` (933 passed)
- `cargo doc --workspace --no-deps`
- `scripts/test-mdbook.sh`
- external path-dependent release example copied from the guide
- repository-rules review: pass

Closes #665
