### PR TITLE
perf(treeaci): borrow cached evaluator payloads

### DIFF
--- a/crates/tensor4all-core/src/defaults/idx_tensor.rs
+++ b/crates/tensor4all-core/src/defaults/idx_tensor.rs
@@ -6269,7 +6269,18 @@ impl IdxTensor {
         &self,
         read: impl FnOnce(&[T]) -> R,
     ) -> std::result::Result<R, IdxTensorError> {
-        let values = self.as_inner()?.duplicate_value()?;
+        let inner = self.as_inner()?;
+        let value = inner.value()?;
+        if let Ok(values) = value.as_slice::<T>() {
+            return Ok(read(values));
+        }
+
+        // Backend-resident and non-contiguous values cannot be borrowed as a
+        // host slice. Preserve the previous materializing behavior for those
+        // cases while avoiding a full payload copy for the ordinary
+        // host-contiguous path above.
+        drop(value);
+        let values = inner.duplicate_value()?;
         let values = values
             .as_slice::<T>()
             .map_err(|source| IdxTensorError::materialization(anyhow::Error::new(source)))?;

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -30,6 +30,29 @@ fn checked_sum(terms: &[usize], context: &'static str) -> Result<usize> {
     })
 }
 
+fn two_incoming_scratch_elements(
+    outgoing_dim: usize,
+    incoming_dim_1: usize,
+    incoming_dim_2: usize,
+    n1: usize,
+    n2: usize,
+) -> Result<usize> {
+    checked_sum(
+        &[
+            checked_product(&[incoming_dim_1, n1], "two-incoming first frame matrix")?,
+            checked_product(&[incoming_dim_2, n2], "two-incoming second frame matrix")?,
+            checked_product(&[outgoing_dim, incoming_dim_1], "two-incoming core matrix")?,
+            checked_product(
+                &[outgoing_dim, n1, incoming_dim_2],
+                "two-incoming stage-one matrix",
+            )?,
+            checked_product(&[outgoing_dim, n1], "two-incoming stage-one slice")?,
+            checked_product(&[outgoing_dim, n1, n2], "two-incoming output matrix")?,
+        ],
+        "two-incoming scratch elements",
+    )
+}
+
 fn enforce_frame_working_elements<T: TreeAciScalar, V: TreeAciNode>(
     problem: &PreparedTreeProblem<V>,
     elements: usize,
@@ -632,35 +655,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                         message: "candidate sets are missing the second incoming directed edge",
                     })?
                     .len();
-                checked_sum(
-                    &[
-                        checked_product(
-                            &[incoming_dim_1, n1],
-                            "two-incoming first candidate frame matrix",
-                        )?,
-                        checked_product(
-                            &[incoming_dim_2, n2],
-                            "two-incoming second candidate frame matrix",
-                        )?,
-                        checked_product(
-                            &[outgoing_dim, n1, incoming_dim_2],
-                            "two-incoming candidate stage-one matrix",
-                        )?,
-                        checked_product(
-                            &[outgoing_dim, n1, n2],
-                            "two-incoming candidate output matrix",
-                        )?,
-                        checked_product(
-                            &[outgoing_dim, incoming_dim_1],
-                            "two-incoming candidate core matrix",
-                        )?,
-                        checked_product(
-                            &[outgoing_dim, n1],
-                            "two-incoming candidate stage-one slice",
-                        )?,
-                    ],
-                    "two-incoming candidate scratch elements",
-                )
+                two_incoming_scratch_elements(outgoing_dim, incoming_dim_1, incoming_dim_2, n1, n2)
             }
             incoming_edges => incoming_edges.iter().try_fold(0usize, |sum, &edge| {
                 let dimension = self.bond_dim(input, edge)?;
@@ -1033,34 +1028,12 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
 
             let n1 = ids_1.len();
             let n2 = ids_2.len();
-            let scratch = checked_sum(
-                &[
-                    checked_product(
-                        &[incoming_dim_1, n1],
-                        "two-incoming first candidate frame matrix",
-                    )?,
-                    checked_product(
-                        &[incoming_dim_2, n2],
-                        "two-incoming second candidate frame matrix",
-                    )?,
-                    checked_product(
-                        &[outgoing_dim, n1, incoming_dim_2],
-                        "two-incoming candidate stage-one matrix",
-                    )?,
-                    checked_product(
-                        &[outgoing_dim, n1, n2],
-                        "two-incoming candidate output matrix",
-                    )?,
-                    checked_product(
-                        &[outgoing_dim, incoming_dim_1],
-                        "two-incoming candidate core matrix",
-                    )?,
-                    checked_product(
-                        &[outgoing_dim, n1],
-                        "two-incoming candidate stage-one slice",
-                    )?,
-                ],
-                "two-incoming candidate scratch elements",
+            let scratch = two_incoming_scratch_elements(
+                outgoing_dim,
+                incoming_dim_1,
+                incoming_dim_2,
+                n1,
+                n2,
             )?;
             enforce_frame_working_elements::<T, V>(problem, scratch)?;
 
@@ -1537,22 +1510,12 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
 
             let n1 = ids_1.len();
             let n2 = ids_2.len();
-            let scratch = checked_sum(
-                &[
-                    checked_product(&[incoming_dim_1, n1], "two-incoming first frame matrix")?,
-                    checked_product(&[incoming_dim_2, n2], "two-incoming second frame matrix")?,
-                    checked_product(
-                        &[outgoing_dim, n1, incoming_dim_2],
-                        "two-incoming frame stage-one matrix",
-                    )?,
-                    checked_product(&[outgoing_dim, n1, n2], "two-incoming frame output matrix")?,
-                    checked_product(
-                        &[outgoing_dim, incoming_dim_1],
-                        "two-incoming frame core matrix",
-                    )?,
-                    checked_product(&[outgoing_dim, n1], "two-incoming frame stage-one slice")?,
-                ],
-                "two-incoming frame scratch elements",
+            let scratch = two_incoming_scratch_elements(
+                outgoing_dim,
+                incoming_dim_1,
+                incoming_dim_2,
+                n1,
+                n2,
             )?;
             enforce_frame_working_elements::<T, V>(self.problem, scratch)?;
 
@@ -1754,16 +1717,8 @@ fn accumulate_incoming<T: TreeAciScalar>(
     sum
 }
 
-/// Gathers a `PreparedCore`'s fixed-physical-value slice into a plain
-/// `outgoing_dim x incoming_dim` column-major matrix, for nodes with exactly
-/// one incoming directed edge.
-///
-/// This exists so the slice can be fed to a single BLAS `mat_mul` call
-/// against every candidate's incoming frame vector at once, instead of the
-/// scalar per-candidate loop in [`accumulate_incoming`]. It is only valid
-/// for the single-incoming-edge case: with two or more incoming edges the
-/// "matrix" this node's core induces is not two-dimensional, and
-/// [`contract_prepared_core`] must be used instead.
+/// Gathers one fixed-physical, single-incoming core slice into a column-major
+/// matrix for the one- and two-incoming batched contraction kernels.
 fn single_incoming_core_matrix<T: TreeAciScalar>(
     core: &PreparedCore<T>,
     outgoing_axis: usize,

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -737,6 +737,109 @@ fn two_incoming_core_matrix_batched_matches_scalar_contraction_on_every_pair() {
 }
 
 #[test]
+fn two_incoming_core_matrix_batched_matches_complex_reference_for_every_axis_order() {
+    use num_complex::Complex64;
+    use tensor4all_tensorbackend::Matrix;
+
+    const PHYSICAL_DIM: usize = 2;
+    const OUTGOING_DIM: usize = 3;
+    const INCOMING_DIM_1: usize = 4;
+    const INCOMING_DIM_2: usize = 5;
+    const N1: usize = 2;
+    const N2: usize = 3;
+
+    let v1 = Matrix::from_col_major_vec(
+        INCOMING_DIM_1,
+        N1,
+        (0..INCOMING_DIM_1 * N1)
+            .map(|i| Complex64::new((i + 1) as f64 / 7.0, (i % 3) as f64 / 11.0))
+            .collect(),
+    );
+    let v2 = Matrix::from_col_major_vec(
+        INCOMING_DIM_2,
+        N2,
+        (0..INCOMING_DIM_2 * N2)
+            .map(|i| Complex64::new((i + 2) as f64 / 13.0, -((i % 4) as f64) / 17.0))
+            .collect(),
+    );
+
+    for physical_axis in 0..4 {
+        for outgoing_axis in 0..4 {
+            if outgoing_axis == physical_axis {
+                continue;
+            }
+            for incoming_axis_1 in 0..4 {
+                if incoming_axis_1 == physical_axis || incoming_axis_1 == outgoing_axis {
+                    continue;
+                }
+                let incoming_axis_2 = (0..4)
+                    .find(|axis| {
+                        *axis != physical_axis && *axis != outgoing_axis && *axis != incoming_axis_1
+                    })
+                    .unwrap();
+                let mut dims = vec![0; 4];
+                dims[physical_axis] = PHYSICAL_DIM;
+                dims[outgoing_axis] = OUTGOING_DIM;
+                dims[incoming_axis_1] = INCOMING_DIM_1;
+                dims[incoming_axis_2] = INCOMING_DIM_2;
+                let mut strides = Vec::with_capacity(4);
+                let mut stride = 1;
+                for &dim in &dims {
+                    strides.push(stride);
+                    stride *= dim;
+                }
+                let core = super::PreparedCore {
+                    indices: dims.iter().map(|&dim| DynIndex::new_dyn(dim)).collect(),
+                    dims,
+                    strides,
+                    values: (0..stride)
+                        .map(|i| Complex64::new((i + 1) as f64 / 19.0, (i % 7) as f64 / 23.0))
+                        .collect(),
+                };
+                let physical_base_offset = core.strides[physical_axis];
+                let actual = super::two_incoming_core_matrix_batched(
+                    &core,
+                    outgoing_axis,
+                    incoming_axis_1,
+                    incoming_axis_2,
+                    physical_base_offset,
+                    OUTGOING_DIM,
+                    INCOMING_DIM_1,
+                    INCOMING_DIM_2,
+                    &v1,
+                    &v2,
+                )
+                .unwrap();
+
+                for candidate_2 in 0..N2 {
+                    for candidate_1 in 0..N1 {
+                        for outgoing in 0..OUTGOING_DIM {
+                            let mut expected = Complex64::new(0.0, 0.0);
+                            for incoming_2 in 0..INCOMING_DIM_2 {
+                                for incoming_1 in 0..INCOMING_DIM_1 {
+                                    let offset = physical_base_offset
+                                        + outgoing * core.strides[outgoing_axis]
+                                        + incoming_1 * core.strides[incoming_axis_1]
+                                        + incoming_2 * core.strides[incoming_axis_2];
+                                    expected += core.values[offset]
+                                        * v1[[incoming_1, candidate_1]]
+                                        * v2[[incoming_2, candidate_2]];
+                                }
+                            }
+                            let got = actual[[outgoing + OUTGOING_DIM * candidate_1, candidate_2]];
+                            assert!(
+                                (got - expected).norm() <= 1.0e-11,
+                                "axis order ({physical_axis}, {outgoing_axis}, {incoming_axis_1}, {incoming_axis_2}) mismatch at ({outgoing}, {candidate_1}, {candidate_2}): got {got}, expected {expected}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
 fn candidate_frames_for_edge_falls_back_on_a_leaf_edge_with_zero_incoming_edges() {
     let inputs = vec![star_tree_for_fallback_dispatch()];
     let options = TreeAciOptions::default();

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -15,12 +15,18 @@ tenferro-cuda = [
     "tensor4all-tensorbackend/tenferro-cuda",
 ]
 tenferro-cpu-faer = [
+    "tensor4all-core/backend-tenferro",
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-simplett?/tenferro-cpu-faer",
+    "tensor4all-tensorbackend/backend-tenferro",
+    "tensor4all-tensorbackend/tenferro-cpu-faer",
 ]
 tenferro-provider-inject = [
+    "tensor4all-core/backend-tenferro",
     "tensor4all-core/tenferro-provider-inject",
     "tensor4all-simplett?/tenferro-provider-inject",
+    "tensor4all-tensorbackend/backend-tenferro",
+    "tensor4all-tensorbackend/tenferro-provider-inject",
 ]
 
 [dependencies]

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -1805,8 +1805,6 @@ where
             parent_dim,
             child_dim,
         };
-        let raw = tensor.to_vec::<f64>()?;
-
         let mut physical_values = Vec::with_capacity(points.len());
         let mut child_columns = Vec::with_capacity(child_dim * points.len());
         for &point in points {
@@ -1838,8 +1836,9 @@ where
                     .ok_or_else(|| anyhow::anyhow!("chain child assignment is out of bounds"))?,
             );
         }
-        let result =
-            Self::grouped_chain_message_contraction(spec, &raw, &physical_values, &child_columns)?;
+        let result = tensor.with_dense_slice::<f64, _>(|raw| {
+            Self::grouped_chain_message_contraction(spec, raw, &physical_values, &child_columns)
+        })??;
         Ok(Some(result))
     }
 
@@ -1948,8 +1947,6 @@ where
             parent_dim,
             child_dim,
         };
-        let raw = tensor.to_vec::<Complex64>()?;
-
         let mut physical_values = Vec::with_capacity(points.len());
         let mut child_columns = Vec::with_capacity(child_dim * points.len());
         for &point in points {
@@ -1981,8 +1978,9 @@ where
                     .ok_or_else(|| anyhow::anyhow!("chain child assignment is out of bounds"))?,
             );
         }
-        let result =
-            Self::grouped_chain_message_contraction(spec, &raw, &physical_values, &child_columns)?;
+        let result = tensor.with_dense_slice::<Complex64, _>(|raw| {
+            Self::grouped_chain_message_contraction(spec, raw, &physical_values, &child_columns)
+        })??;
         Ok(Some(result))
     }
 
@@ -2145,8 +2143,6 @@ where
             child_dim_1,
             child_dim_2,
         };
-        let raw = tensor.to_vec::<f64>()?;
-
         let mut physical_values = Vec::with_capacity(points.len());
         let mut child_1_columns = Vec::with_capacity(child_dim_1 * points.len());
         let mut child_2_columns = Vec::with_capacity(child_dim_2 * points.len());
@@ -2193,13 +2189,15 @@ where
                     .ok_or_else(|| anyhow::anyhow!("branch child-2 assignment is out of bounds"))?,
             );
         }
-        let result = Self::grouped_branch_message_contraction(
-            spec,
-            &raw,
-            &physical_values,
-            &child_1_columns,
-            &child_2_columns,
-        )?;
+        let result = tensor.with_dense_slice::<f64, _>(|raw| {
+            Self::grouped_branch_message_contraction(
+                spec,
+                raw,
+                &physical_values,
+                &child_1_columns,
+                &child_2_columns,
+            )
+        })??;
         Ok(Some(result))
     }
 
@@ -2355,8 +2353,6 @@ where
             child_dim_1,
             child_dim_2,
         };
-        let raw = tensor.to_vec::<Complex64>()?;
-
         let mut physical_values = Vec::with_capacity(points.len());
         let mut child_1_columns = Vec::with_capacity(child_dim_1 * points.len());
         let mut child_2_columns = Vec::with_capacity(child_dim_2 * points.len());
@@ -2403,13 +2399,15 @@ where
                     .ok_or_else(|| anyhow::anyhow!("branch child-2 assignment is out of bounds"))?,
             );
         }
-        let result = Self::grouped_branch_message_contraction(
-            spec,
-            &raw,
-            &physical_values,
-            &child_1_columns,
-            &child_2_columns,
-        )?;
+        let result = tensor.with_dense_slice::<Complex64, _>(|raw| {
+            Self::grouped_branch_message_contraction(
+                spec,
+                raw,
+                &physical_values,
+                &child_1_columns,
+                &child_2_columns,
+            )
+        })??;
         Ok(Some(result))
     }
 

--- a/docs/worklogs/2026-08-23-treeaci-branched-hotpaths.md
+++ b/docs/worklogs/2026-08-23-treeaci-branched-hotpaths.md
@@ -1,0 +1,138 @@
+# TreeACI branched hot-path investigation
+
+## Scope and invariants
+
+This work targets the cost of native branched TreeACI and its Guard evaluator.
+It must not change the sampled function, candidate enumeration, LUCI pivot
+selection, truncation tolerances, accepted ranks, or sweep convergence rules.
+Every optimized contraction is required to implement the same finite sums as
+the scalar reference for both `f64` and `Complex64`.
+
+For a degree-three node rooted through one edge, Guard computes
+
+```text
+m_p(a) = sum_(b,c) A(x_p, a, b, c) m1_p(b) m2_p(c).
+```
+
+For TreeACI's Cartesian candidate frames, the corresponding local map is
+
+```text
+F(a, i, j) = sum_(b,c) A(a, b, c) V1(b, i) V2(c, j).
+```
+
+Both expressions permit reordered, batched contractions without changing the
+mathematical algorithm.  A future change to a hierarchical cross algorithm
+would alter candidate selection and is deliberately outside this optimization.
+
+## Baseline and acceptance gate
+
+- Benchmark baseline commit: `009bacc8bfb93f930d9515b6382047f014dba700`.
+  Before submission, the branch was rebased onto origin/main commit
+  `5a5303228d0c634d3d5daff7dffed0717151405e` (`fix(tensorbackend): return
+  typed matrix swap errors`, #679); that upstream change is outside this
+  benchmarked patch.
+- Branch: `optimize-treeaci-branched-hotpaths`
+- Compiler: `rustc 1.98.0 (88d9e12ae 2026-08-18)`, LLVM 22.1.8
+- Host: AMD Ryzen 9 6900HX, 8 cores / 16 threads, 16 MiB L3
+- Explicit thread environment: `OPENBLAS_NUM_THREADS=1`; the synthetic test is
+  run with `--test-threads=1`.
+- Command (the explicit feature works around a pre-existing standalone feature
+  resolution failure recorded below):
+
+```text
+cargo test --release -p tensor4all-treetn \
+  --features tensor4all-core/backend-tenferro \
+  diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk -- \
+  --ignored --nocapture --test-threads=1
+```
+
+Initial result: chain 84.867 ms, comb 2.712 s, comb/chain 31.96x.
+
+At the baseline commit, `cargo test --release -p tensor4all-treetn` fails before
+running tests because `tensor4all-core` is built without
+`tensor4all-tensorbackend/global-defaults`, although core imports that legacy
+surface. Workspace feature unification can hide this. The optimization
+baseline therefore enables `tensor4all-core/backend-tenferro` explicitly until
+the feature wiring is repaired and independently tested.
+
+A candidate is retained only if all deterministic real/complex contraction
+oracles and crate release tests pass. Performance candidates must be measured
+with at least three post-warm-up samples. The first target is a 20% or larger
+median reduction of comb time without a greater than 5% median chain
+regression. Downstream CTTN, NBlock TreeACI, and SimpleTT comparisons remain
+the final workload-level gate; stage outputs must remain within the existing
+tolerances and no tolerance may be relaxed.
+
+The first candidate makes `IdxTensor::with_dense_slice` borrow an already
+host-contiguous retained value and changes the chain and branch raw kernels to
+keep the core inside that borrow.  It preserves the prior materializing
+fallback for backend-resident or non-contiguous values.  Three post-build runs
+were 47.755/47.689/46.923 ms for the chain and
+647.546/652.474/656.382 ms for the comb.  The medians improve by 44.5% and
+76.3%, respectively, and the median ratio falls to 13.68x.  The candidate
+therefore passes the predeclared synthetic performance gate.
+
+On the existing downstream T=0.01 checkpoints, two cached coordinate sweeps
+improved from 2.898 s to 846.8 ms for CTTN G0 and from 166.9 ms to 45.8 ms for
+CTTN W.  The matching NBlock measurements improved from 112.6 ms to 94.2 ms
+and from 23.1 ms to 19.5 ms.  Thus the CTTN/NBlock ratios fell from 25.7x to
+9.0x for G0 and from 7.22x to 2.36x for W.  CTTN G0 contains 3.81x as many
+core elements as its NBlock counterpart, including one 5,803,320-element hub.
+
+A TreeACI candidate changed the two-incoming Cartesian contraction from
+`incoming_dim_2 + 1` matrix multiplications to two matrix multiplications with
+one algebraically inert axis permutation between them.  A new complex oracle
+covers all 24 placements of physical, outgoing, and both incoming axes.  The
+existing realistic branch microbenchmark changed from a median 2.312 ms to
+1.255 ms (1.84x faster); its scalar-reference time remained about 30.6 ms.
+
+The candidate was rejected after the downstream T=1 gate.  NBlock reproduced
+the old ranks, errors, and values, but CTTN became pivot-path sensitive to the
+changed floating-point reduction: Pi evaluated points increased from 163,260
+to 184,164 and Sigma from 129,424 to 186,750.  The combined Pi/W/Sigma time did
+not improve, and five extracted rows moved slightly farther from SimpleTT
+(relative L2 changed from 3.24e-4--3.79e-4 to 3.51e-4--4.23e-4).  The original
+contraction order was restored.  The 24-axis complex oracle and a centralized
+scratch-size calculation remain as maintainability and correctness coverage.
+
+After restoration, a fresh full T=0.01 CTTN run could not serve as a valid
+performance gate because its pre-TreeACI G0 stage had already regressed: it
+took 381.6 s, produced maximum bond 412, and reported sanity value
+`0.2222113919-0.0015513282i`, versus the trusted run's roughly 14.9 s, bond 118,
+and `0.2211443913-0.0154387910i`.  The run was stopped during `g_rtau`; no
+TreeACI or Guard stage had begun.  Its temporary checkpoint and log are under
+`/tmp/treeaci-guard-fix-cttn-T0.01`.  Therefore only the direct evaluator
+checkpoint comparison above is used for this patch's T=0.01 performance claim.
+
+## Structural audit
+
+- The schedule executes a minimal continuous tree walk and updates each
+  directed edge once per forward/reverse pair; exhaustive labeled-tree tests
+  cover this invariant.  Branching does not introduce a redundant sweep.
+- TreeACI contains neither SVD nor zip-up.  Local rank revelation is LUCI;
+  Guard is a separate bounded global-search phase.
+- Input Guard evaluators persist across passes.  Output messages are correctly
+  rebuilt after output mutation, so the optimization borrows only immutable
+  payloads and does not widen cache lifetime.
+- The three copies of the two-incoming scratch formula are now one checked
+  helper, preventing the planner, committed frame store, and incremental frame
+  builder from disagreeing about the resource limit.
+- `frames.rs` remains large and the committed-store and builder paths have
+  parallel control flow.  They share the numerical kernels and resource
+  accounting; a file split alone would not improve runtime or correctness.
+  Candidate small-vector storage and matrix-shaped return buffers remain
+  possible follow-ups, but were not changed without a workload measurement.
+- Release clippy over core, TreeTN, and TreeACI all targets is warning-free.
+  Library paths contain no unchecked `unwrap`/`expect`; occurrences found by
+  the audit are confined to test modules.
+- A standalone default-feature TreeTN build was broken because its direct
+  legacy tensorbackend calls did not enable `backend-tenferro`.  CPU-faer and
+  provider-inject feature propagation now enables both the core and direct
+  tensorbackend legacy surfaces explicitly.
+
+The more radical theoretical alternative is hierarchical or dimension-tree
+cross interpolation, which avoids forming an edge's full Cartesian candidate
+matrix.  That changes the pivot space and convergence theory rather than merely
+reordering an equal contraction.  It is not an admissible correctness-preserving
+optimization for this repair and would require its own algorithm design and
+validation project.


### PR DESCRIPTION
## Summary
- borrow host-contiguous `IdxTensor` payloads in cached TreeTN chain and branch evaluators, retaining the materializing fallback for backend-resident/non-contiguous values
- centralize TreeACI two-incoming scratch accounting and add a Complex64 oracle covering all axis placements
- repair standalone TreeTN feature propagation and document the benchmark/audit results

## Correctness
- no contraction formula, summation order, pivot selection, truncation tolerance, or sweep rule was changed
- the experimental reduction-order-changing two-GEMM variant was rejected and is not included
- all changed-crate release tests and doctests pass

## Performance evidence
- realistic synthetic comb: 2.712 s -> 652 ms (76.3% median reduction)
- realistic synthetic chain: 84.9 ms -> 47.7 ms (44.5% median reduction)
- direct T=0.01 CTTN checkpoint Guard measurements: G0 2.898 s -> 846.8 ms; W 166.9 ms -> 45.8 ms

## Verification
- `cargo fmt --all -- --check`
- `cargo test --release -p tensor4all-core -p tensor4all-treeaci -p tensor4all-treetn`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- repository rules review and tests
