### PR TITLE
fix(quanticstransform): align triangle helper names

### DIFF
--- a/crates/tensor4all-quanticstransform/src/cumsum.rs
+++ b/crates/tensor4all-quanticstransform/src/cumsum.rs
@@ -58,8 +58,8 @@ pub enum TriangleType {
 ///
 /// # Errors
 ///
-/// Returns an error when the operator construction fails (an overflow or
-/// /// invalid-configuration failure, or a shape mismatch).
+/// Returns an error when the operator construction fails (an overflow,
+/// invalid-configuration failure, or shape mismatch).
 ///
 /// # Examples
 ///
@@ -97,8 +97,8 @@ pub fn cumsum_operator(r: usize) -> std::result::Result<QuanticsOperator, Quanti
 ///
 /// # Errors
 ///
-/// Returns an error when the operator construction fails (an overflow or
-/// /// invalid-configuration failure, or a shape mismatch).
+/// Returns an error when the operator construction fails (an overflow,
+/// invalid-configuration failure, or shape mismatch).
 ///
 /// # Examples
 ///
@@ -129,7 +129,7 @@ pub fn triangle_operator(
 
 /// Create the cumulative sum MPO as a SimpleTensorTrain.
 ///
-/// The cumulative sum is implemented as an upper triangular matrix.
+/// The cumulative sum is implemented as a strict lower triangular matrix.
 /// The MPO tracks whether a comparison has been made:
 /// - State 0: No comparison yet (y and x equal so far)
 /// - State 1: Comparison made (y > x, so this entry is 1)
@@ -146,7 +146,7 @@ fn cumsum_mpo(r: usize) -> Result<SimpleTensorTrain<Complex64>> {
         ));
     }
 
-    let single_tensor = upper_triangle_tensor();
+    let single_tensor = lower_triangle_tensor();
     let mut tensors = try_vec_with_capacity::<tensor4all_simplett::Tensor3<Complex64>>(
         "cumulative-sum MPO site list",
         r,
@@ -170,7 +170,7 @@ fn cumsum_mpo(r: usize) -> Result<SimpleTensorTrain<Complex64>> {
         } else if n == r - 1 {
             // Last tensor: select entries where state is 1 (y > x)
             // The output is 1 only if comparison was made (state 1)
-            // For upper triangle (strict), diagonal is excluded
+            // For the strict lower triangle, the diagonal is excluded
             let mut t = tensor3_zeros(2, 4, 1);
             for cin in 0..2 {
                 for y_bit in 0..2 {
@@ -224,11 +224,9 @@ fn triangle_mpo(r: usize, triangle: TriangleType) -> Result<SimpleTensorTrain<Co
         ));
     }
 
-    // upper_triangle_tensor() has y>x transition → M[i,j]=1 when i>j = Lower triangle
-    // lower_triangle_tensor() has y<x transition → M[i,j]=1 when i<j = Upper triangle
     let single_tensor = match triangle {
-        TriangleType::Lower => upper_triangle_tensor(),
-        TriangleType::Upper => lower_triangle_tensor(),
+        TriangleType::Lower => lower_triangle_tensor(),
+        TriangleType::Upper => upper_triangle_tensor(),
     };
     let mut tensors = try_vec_with_capacity::<tensor4all_simplett::Tensor3<Complex64>>(
         "triangle MPO site list",
@@ -287,18 +285,12 @@ fn triangle_mpo(r: usize, triangle: TriangleType) -> Result<SimpleTensorTrain<Co
         .map_err(|e| anyhow::anyhow!("Failed to create triangle MPO: {}", e))
 }
 
-/// Create the single-site tensor for upper triangular matrix.
+/// Create the single-site tensor for the strict lower triangle.
 ///
-/// Returns a 4D tensor [cin][cout][y_bit][x_bit] where:
-/// - cin: input state (0 = no comparison yet, 1 = comparison made)
-/// - cout: output state
-/// - y_bit: output (row) bit
-/// - x_bit: input (column) bit
-///
-/// The tensor implements strict upper triangle comparison:
-/// - State 0: Comparing bits. If y > x, transition to state 1.
-/// - State 1: Comparison made. All remaining entries are 1.
-fn upper_triangle_tensor() -> [[[[Complex64; 2]; 2]; 2]; 2] {
+/// Returns a 4D tensor `[cin][cout][y_bit][x_bit]` where `y_bit` is the
+/// output row bit and `x_bit` is the input column bit. A `y > x` transition
+/// produces `M[i,j] = 1` when `i > j`.
+fn lower_triangle_tensor() -> [[[[Complex64; 2]; 2]; 2]; 2] {
     let mut tensor = [[[[Complex64::zero(); 2]; 2]; 2]; 2];
 
     // State 0 -> State 0: y == x (continue comparing)
@@ -308,7 +300,7 @@ fn upper_triangle_tensor() -> [[[[Complex64; 2]; 2]; 2]; 2] {
     // State 0 -> State 1: y > x (comparison made, y is greater)
     tensor[0][1][1][0] = Complex64::one(); // y=1, x=0 (y > x at this bit)
 
-    // State 0 -> nowhere: y < x (this entry is 0, not in upper triangle)
+    // State 0 -> nowhere: y < x (this entry is 0, not in lower triangle)
     // tensor[0][*][0][1] = 0 (implicit)
 
     // State 1 -> State 1: Comparison already made, all entries are 1
@@ -320,13 +312,11 @@ fn upper_triangle_tensor() -> [[[[Complex64; 2]; 2]; 2]; 2] {
     tensor
 }
 
-/// Create the single-site tensor for strict upper triangle (i < j).
+/// Create the single-site tensor for the strict upper triangle.
 ///
-/// M[i,j] = 1 when i < j (suffix sum: y_i = Σ_{j > i} x_j).
-///
-/// The tensor is identical to lower_triangle but with the transition
-/// on y < x (y=0, x=1) instead of y > x (y=1, x=0).
-fn lower_triangle_tensor() -> [[[[Complex64; 2]; 2]; 2]; 2] {
+/// A `y < x` transition produces `M[i,j] = 1` when `i < j`, corresponding
+/// to the suffix sum `y_i = Σ_{j > i} x_j`.
+fn upper_triangle_tensor() -> [[[[Complex64; 2]; 2]; 2]; 2] {
     let mut tensor = [[[[Complex64::zero(); 2]; 2]; 2]; 2];
 
     // State 0 -> State 0: y == x (continue comparing)

--- a/crates/tensor4all-quanticstransform/src/cumsum/tests/mod.rs
+++ b/crates/tensor4all-quanticstransform/src/cumsum/tests/mod.rs
@@ -2,8 +2,8 @@ use super::*;
 use tensor4all_simplett::AbstractTensorTrain;
 
 #[test]
-fn test_upper_triangle_tensor() {
-    let t = upper_triangle_tensor();
+fn test_lower_triangle_tensor() {
+    let t = lower_triangle_tensor();
 
     // State 0 -> State 0: diagonal
     assert_eq!(t[0][0][0][0], Complex64::one());

--- a/crates/tensor4all-quanticstransform/tests/integration_test.rs
+++ b/crates/tensor4all-quanticstransform/tests/integration_test.rs
@@ -1729,7 +1729,7 @@ fn test_cumsum_operator_creation() {
 
 /// Test cumsum operator for all x values.
 ///
-/// cumsum is a strict upper triangular matrix:
+/// cumsum is a strict lower triangular matrix:
 /// cumsum(|x⟩) = Σ_{y > x} |y⟩
 ///
 /// The comparison y > x is done in big-endian bit order (MSB to LSB).
@@ -1781,7 +1781,7 @@ fn test_cumsum_all_values() {
 
         eprintln!("cumsum(|{}⟩):", x);
 
-        // For cumsum, result[y] = 1 iff y > x (strict upper triangular)
+        // For cumsum, result[y] = 1 iff y > x (strict lower triangular)
         // Now that contract_treetn_to_vector uses big-endian, result[y] corresponds to value y
         let mut count_positive = 0;
         for y in 0..n {
@@ -2705,7 +2705,7 @@ fn test_cumsum_matches_lower_triangle() {
             for j in 0..n {
                 if (cumsum_mat[i][j] - triangle_mat[i][j]).norm() > 1e-10 {
                     panic!(
-                        "cumsum vs upper_triangle mismatch at r={} [{},{}]: \
+                        "cumsum vs lower_triangle mismatch at r={} [{},{}]: \
                          cumsum=({:.6},{:.6}) triangle=({:.6},{:.6})",
                         r,
                         i,

--- a/docs/worklogs/2026-08-23-issue-658-triangle-helper-names.md
+++ b/docs/worklogs/2026-08-23-issue-658-triangle-helper-names.md
@@ -1,0 +1,29 @@
+# Issue #658 triangle helper naming worklog
+
+Date: 2026-08-23
+
+## Scope
+
+Correct private helper names and documentation in `quanticstransform::cumsum` so they describe the matrix emitted, without changing public operator behavior.
+
+## Implementation
+
+- the `y > x` helper is now `lower_triangle_tensor`;
+- the `y < x` helper is now `upper_triangle_tensor`;
+- `triangle_mpo` maps each public `TriangleType` directly to the same-named helper;
+- cumulative-sum documentation consistently describes a strict lower-triangular prefix sum;
+- helper test and integration failure vocabulary use the corrected names.
+
+## Verification
+
+- `cargo fmt --all -- --check`;
+- focused quanticstransform clippy with warnings denied;
+- focused release tests: 170 passed;
+- focused release doctests: 45 passed;
+- full workspace clippy with warnings denied;
+- full release workspace tests: 3188 passed, 17 skipped;
+- full release workspace doctests: 933 passed;
+- workspace rustdoc and public API inventory;
+- library-panic, public-error-doc, and crate-boundary audits.
+
+Existing dense integration tests pin both public triangle matrices and the cumulative-sum/lower-triangle equivalence. Independent read-only post-implementation review returned **Correct-to-merge**; its two nonblocking stale-doc findings were fixed.


### PR DESCRIPTION
## Summary

- rename the private `y > x` helper to `lower_triangle_tensor`
- rename the private `y < x` helper to `upper_triangle_tensor`
- make `TriangleType` map directly to the same-named helper
- correct cumulative-sum documentation, test names, and diagnostics

The emitted operators are numerically unchanged.

## Review and validation

- independent post-implementation review: `Correct-to-merge`
- repository-rules review: pass
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace` (3188 passed, 17 skipped)
- `cargo test --doc --release --workspace` (933 passed)
- workspace rustdoc and public API inventory
- library panic, public error documentation, and crate-boundary audits

Closes #658
