### PR TITLE
docs: add contribution intake guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ benchmarks/results/*.h5
 # Avoid accidentally committing ad-hoc analysis notes at repo root
 /*.md
 !README.md
+!CONTRIBUTING.md
 !AGENTS.md
 !CLAUDE.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,9 +268,11 @@ Run before pushing. CI runs the same checks, but local = faster feedback:
 ```bash
 cargo fmt --all                        # Auto-fix formatting
 cargo fmt --all -- --check             # Dry-run (matches CI)
-cargo clippy --workspace --all-targets -- -D warnings   # Matches CI
-cargo test -p <changed-crate>          # Quick check first
-cargo nextest run --release --workspace # Full test suite
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo test -p <changed-crate> --release # Quick check first
+cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5
+cargo test --profile ci -p tensor4all-hdf5
+cargo test --doc --profile ci --workspace -j 8
 cargo doc --workspace --no-deps        # Build rustdoc
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to tensor4all-rs
+
+Thank you for contributing. tensor4all-rs is in early development: public APIs may change, and fixes should remove obsolete paths rather than add compatibility shims.
+
+## Start with an issue
+
+Use the repository issue forms so the scope and acceptance criteria are visible before substantial work begins:
+
+- [Bug report](https://github.com/tensor4all/tensor4all-rs/issues/new?template=bug_report.yml): include a minimal reproducer, expected behavior, Rust version, and platform when relevant.
+- [Feature request](https://github.com/tensor4all/tensor4all-rs/issues/new?template=feature_request.yml): explain the use case, proposed behavior, and acceptance criteria. Link the related Tensor4all.jl issue for cross-repository work.
+
+Small documentation and typo fixes may go directly to a pull request. For nontrivial, public-API, numerical, performance, or cross-crate changes, comment on the issue before implementation so maintainers can confirm the scope and dependency boundary.
+
+## Prepare the change
+
+1. Branch from the current `origin/main`.
+2. Read [`AGENTS.md`](AGENTS.md), [`REPOSITORY_RULES.md`](REPOSITORY_RULES.md), and the relevant [architecture guide](docs/book/src/architecture.md).
+3. Keep source code and documentation in English.
+4. Add the smallest test that would fail without the change. Numerical tests must check a meaningful value, identity, residual, or reconstruction error rather than only shapes or finiteness.
+5. Update rustdoc, guides, examples, and generated/public API claims affected by the change.
+6. Record nontrivial work in `docs/worklogs/` with the contract read, decisions, and verification evidence.
+
+### API naming
+
+Follow the repository vocabulary documented in the [architecture guide](docs/book/src/architecture.md#vocabulary-conventions):
+
+- unsuffixed method for the ordinary operation;
+- `_mut` for in-place mutation;
+- `_into` when consuming `self`;
+- `_batched` for batched input;
+- `_owned` only when input ownership enables a distinct optimization.
+
+Use `max_bond_dim: Option<usize>` for bond caps and `SvdTruncationPolicy` for SVD truncation. Dense flat buffers are column-major. Do not add scalar-specific Rust entry points when a generic API works; scalar-specific names belong at the C FFI boundary.
+
+## Validate locally
+
+Run focused changed-crate tests first, then the CI-equivalent repository gates. These require `cargo-nextest`, mdBook 0.5.2, the HDF5 development library, and (for C-header checks) cbindgen 0.29.2; see `.github/workflows/CI_rs.yml` for platform setup.
+
+```bash
+cargo fmt --all -- --check
+cargo check -p tensor4all-tensorbackend --no-default-features --features explicit-context,tenferro-cpu-faer
+cargo doc -p tensor4all-tensorbackend --no-deps --no-default-features --features explicit-context,tenferro-cpu-faer
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5
+cargo test --profile ci -p tensor4all-hdf5
+cargo test --doc --profile ci --workspace -j 8
+TENSOR4ALL_CARGO_PROFILE=ci ./scripts/test-mdbook.sh
+cargo doc --workspace --no-deps
+./scripts/check-capi-header.sh
+cargo run -p xtask --release -- api-dump
+```
+
+Also run maintenance checks relevant to changed public APIs or crate boundaries:
+
+```bash
+python3 scripts/audit-library-panics.py
+python3 scripts/check-public-error-docs.py
+python3 scripts/check-crate-boundaries.py
+```
+
+Do not commit `target/`, coverage output, generated API dumps, or other build artifacts.
+
+## Open the pull request
+
+- Link the issue with `Closes #…` when the PR fully resolves it.
+- Explain the behavior change and why it belongs in the selected crate/layer.
+- List the exact validation commands and results.
+- Call out public API breaks, numerical tolerance changes, dense materialization, new dependencies, or cross-repository sequencing explicitly.
+- Keep unrelated changes in separate PRs.
+
+Required CI and the repository-rules review must pass. Maintainers normally squash-merge accepted PRs and delete the completed branch.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ validated in CI. Longer runnable examples live in the
 - **[Julia Bindings](https://github.com/tensor4all/Tensor4all.jl)** — Tensor4all.jl wrapper
 - **[Design Documents](docs/design/index.md)** — architecture and design decisions
 - **[Provenance and Citation Policy](docs/PROVENANCE_AND_CITATION_POLICY.md)** — which components build on which external projects, algorithm origins, and how to cite
+- **[Contributing](CONTRIBUTING.md)** — issue intake, development conventions, validation, and pull requests
 
 ## Agent Skill
 

--- a/docs/worklogs/2026-08-23-issue-652-contributing-guide.md
+++ b/docs/worklogs/2026-08-23-issue-652-contributing-guide.md
@@ -1,0 +1,43 @@
+# Issue #652 contributing guide worklog
+
+Date: 2026-08-23
+
+## Scope
+
+Add the missing root `CONTRIBUTING.md`, restore the existing `llms.txt` link, and provide a minimal external-contribution intake path without duplicating the full repository policy.
+
+## Contract read
+
+- bug and feature issue forms;
+- `AGENTS.md` development, documentation, testing, API, and Git workflow requirements;
+- `REPOSITORY_RULES.md` and the architecture vocabulary;
+- README and `llms.txt` documentation indexes;
+- workspace CI and maintenance commands.
+
+## Implementation
+
+- direct small documentation fixes to pull requests;
+- direct bugs and feature/API/cross-repository proposals through the existing issue forms;
+- ask nontrivial contributors to align scope and dependency boundaries before implementation;
+- link canonical repository rules instead of copying them wholesale;
+- list the CI-equivalent local validation and PR evidence expected;
+- add the contribution guide to the README documentation index.
+
+## Verification
+
+- all relative links in `CONTRIBUTING.md`, README, and `llms.txt` resolve;
+- `scripts/test-mdbook.sh` passed;
+- independent external-contributor/read-only review returned **Correct-to-merge**;
+- review findings corrected the documented clippy lints, exact nextest/HDF5 split, tool prerequisites, and the matching `AGENTS.md` pre-PR commands.
+
+Exact-state CI-equivalent validation passed after rebasing onto current main:
+
+- explicit-context check and rustdoc;
+- formatting and clippy with the two blocking documentation lints;
+- non-HDF5 nextest: 3141 passed, 13 skipped;
+- HDF5 tests: 57 passed, 4 ignored;
+- workspace doctests: 933 passed;
+- mdBook, workspace rustdoc, C header, and public API inventory;
+- repository-rules, library-panic, public-error-doc, crate-boundary, and coverage-checker test suites.
+
+Repository-rules diff review passed with no findings. GitHub CI remains pending.


### PR DESCRIPTION
## Summary

- add the missing root `CONTRIBUTING.md` and unignore it explicitly
- provide a minimal external intake path through the existing bug/feature issue forms
- document naming, testing, CI-equivalent validation, and PR expectations
- link the guide from README and correct matching pre-PR commands in `AGENTS.md`

The pre-existing `llms.txt` contribution link now resolves.

## Review and validation

- independent external-contributor/read-only review: `Correct-to-merge`
- repository-rules review: pass
- all relative links in CONTRIBUTING, README, and llms.txt resolve
- exact explicit-context check and rustdoc
- formatting and clippy with blocking documentation lints
- CI-profile non-HDF5 nextest: 3141 passed, 13 skipped
- HDF5 tests: 57 passed, 4 ignored
- workspace doctests: 933 passed
- mdBook, workspace rustdoc, C header, and API inventory
- repository-rules, panic, public-error-doc, crate-boundary, and coverage-checker tests

Closes #652
