### PR TITLE
Parallelize adaptive interpolation with Hataori

### DIFF
--- a/.github/workflows/CI_rs.yml
+++ b/.github/workflows/CI_rs.yml
@@ -113,8 +113,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install HDF5
-        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev
+      - name: Install HDF5 and MPI
+        run: sudo apt-get update && sudo apt-get install -y libhdf5-dev libopenmpi-dev openmpi-bin
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ num-complex = "0.4"
 num-traits = "0.2"
 anyhow = "1.0"
 approx = "0.5"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 criterion = "0.5"
 bnum = "0.12"
@@ -75,6 +76,8 @@ thiserror = "2.0"
 rand = "0.9"
 rand_chacha = "0.9"
 rand_distr = "0.5"
+rayon = "1.10"
+mpi = { version = "=0.8.1", default-features = false }
 petgraph = "0.7"
 dyn-clone = "1.0"
 omeco = "0.2.1"
@@ -82,6 +85,7 @@ hdf5-metno = { version = "0.12", default-features = false }
 ndarray = "0.17"
 quanticsgrids = { git = "https://github.com/tensor4all/quanticsgrids-rs", rev = "8214b72" }
 hdf5-rt = { git = "https://github.com/tensor4all/hdf5-rt", default-features = false }
+hataori = { git = "https://github.com/shinaoka/hataori-rs.git", rev = "59d0ccd6b403e285b7e716a8ae6d12d851da13b1", default-features = false }
 tenferro = { package = "tenferro-runtime", git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
 tenferro-ad = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }
 tenferro-cpu = { git = "https://github.com/tensor4all/tenferro-rs.git", rev = "a21a4c602fc6700b9bc0c3f1b14ebd19b9d7ec45", default-features = false }

--- a/crates/tensor4all-partitionedtt/Cargo.toml
+++ b/crates/tensor4all-partitionedtt/Cargo.toml
@@ -8,7 +8,15 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-default = ["tenferro-cpu-faer"]
+default = ["tenferro-cpu-faer", "adaptive-hataori-rayon"]
+adaptive-hataori-rayon = ["dep:hataori", "hataori/rayon"]
+adaptive-hataori-mpi = [
+    "adaptive-hataori-rayon",
+    "hataori/mpi",
+    "dep:mpi",
+    "dep:serde",
+    "num-complex/serde",
+]
 tenferro-cpu-faer = [
     "tensor4all-core/tenferro-cpu-faer",
     "tensor4all-itensorlike/tenferro-cpu-faer",
@@ -32,6 +40,9 @@ num-traits.workspace = true
 rand.workspace = true
 thiserror.workspace = true
 anyhow.workspace = true
+hataori = { workspace = true, optional = true }
+mpi = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 tensor4all-core = { path = "../tensor4all-core", default-features = false }
 tensor4all-itensorlike = { path = "../tensor4all-itensorlike", default-features = false }
 tensor4all-simplett = { path = "../tensor4all-simplett", default-features = false }
@@ -41,3 +52,8 @@ tensor4all-treetn = { path = "../tensor4all-treetn", default-features = false, f
 
 [dev-dependencies]
 approx.workspace = true
+rayon.workspace = true
+
+[[example]]
+name = "adaptive_mpi_smoke"
+required-features = ["adaptive-hataori-mpi"]

--- a/crates/tensor4all-partitionedtt/README.md
+++ b/crates/tensor4all-partitionedtt/README.md
@@ -17,6 +17,7 @@ with projectors.
 - `Projector` — maps tensor indices to fixed values defining subdomains
 - `adaptiveinterpolate` — runs TCI2 per patch and subdivides patches that miss the requested tolerance
 - `AdaptiveInterpolateOptions` — controls TCI2, patch order, initial pivots, and opt-in pivot recycling
+- `AdaptiveInterpolationResult` — partitioned TT plus one returned sample cache per accepted patch
 
 ## Adaptive interpolation
 
@@ -36,15 +37,27 @@ let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
 )
 .unwrap();
 
-assert_eq!(result.len(), 1);
-assert!(result.projectors().next().unwrap().is_empty());
+assert_eq!(result.partitioned_tt().len(), 1);
+assert!(result.partitioned_tt().projectors().next().unwrap().is_empty());
+assert_eq!(result.patch_caches().len(), 1);
+assert!(!result.patch_caches()[0].is_empty());
 ```
 
 Set `recycle_pivots` to reuse compatible parent TCI pivots in child patches.
 Children with no compatible recycled pivots are replenished with seeded random
 candidates rather than being treated as zero. A patch is classified as sampled
 zero only when all of its initial candidates evaluate below `1e-30`; provide
-known nonzero pivots for very sparse functions.
+known nonzero pivots for very sparse functions. When a patch splits, its cache
+is consumed and partitioned among all children in one pass; each sample moves to
+exactly one child. The accepted per-patch caches are returned with the result.
+
+The default feature set enables optional Hataori rank-local scheduling. Use
+`adaptiveinterpolate_in` with an explicit Hataori domain for
+`LocalMode::Outer` Rayon patch execution; Rayon used inside a callback is nested
+in the same pool. MPI remains default-off behind `adaptive-hataori-mpi` and uses
+`adaptiveinterpolate_mpi` collectively. Building that feature requires a system
+MPI implementation and development headers (`libopenmpi-dev`/`openmpi-bin` on
+Ubuntu).
 
 ## Documentation
 

--- a/crates/tensor4all-partitionedtt/examples/adaptive_mpi_smoke.rs
+++ b/crates/tensor4all-partitionedtt/examples/adaptive_mpi_smoke.rs
@@ -1,0 +1,156 @@
+use mpi::environment::Threading;
+use mpi::traits::*;
+use num_complex::Complex64;
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use tensor4all_core::contract;
+use tensor4all_partitionedtt::{
+    adaptiveinterpolate_mpi, AdaptiveInterpolateOptions, DynIndex, MultiIndex, PartitionedTTError,
+    TCI2Options,
+};
+
+fn main() {
+    let (universe, provided) = mpi::initialize_with_threading(Threading::Funneled)
+        .expect("MPI must not already be initialized or finalized");
+    assert!(provided >= Threading::Funneled);
+    let world = universe.world();
+    let rank = world.rank();
+    let workers = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(2);
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(workers)
+            .build()
+            .unwrap(),
+    );
+    let domain =
+        hataori::Domain::external(Arc::clone(&pool), (0..workers).collect(), workers).unwrap();
+
+    let sites: Vec<_> = (0..3).map(|_| DynIndex::new_dyn(4)).collect();
+    let function = |index: &MultiIndex| {
+        if index.iter().all(|value| *value == index[0]) {
+            2.0
+        } else {
+            0.5
+        }
+    };
+    let options = AdaptiveInterpolateOptions {
+        tci_options: TCI2Options {
+            tolerance: 1.0e-14,
+            max_bond_dim: Some(1),
+            max_iter: 4,
+            ncheck_history: 1,
+            nsearch: 0,
+            max_nglobal_pivot: 0,
+            seed: Some(17),
+            ..TCI2Options::default()
+        },
+        patch_order: sites.clone(),
+        recycle_pivots: true,
+        ..AdaptiveInterpolateOptions::default()
+    };
+    let calls = Arc::new(AtomicI64::new(0));
+    let calls_for_callback = Arc::clone(&calls);
+    let delayed_function = move |index: &MultiIndex| {
+        calls_for_callback.fetch_add(1, Ordering::Relaxed);
+        if rank == 0 {
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+        function(index)
+    };
+    let result = adaptiveinterpolate_mpi::<_, f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        &world,
+        &domain,
+        0,
+        delayed_function,
+        None,
+        sites.clone(),
+        vec![vec![0, 0, 0], vec![3, 3, 3]],
+        options.clone(),
+    )
+    .unwrap();
+    let mut remote_calls = 0_i64;
+    let local_remote_calls = if rank == 0 {
+        0
+    } else {
+        calls.load(Ordering::Relaxed)
+    };
+    world.all_reduce_into(
+        &local_remote_calls,
+        &mut remote_calls,
+        mpi::collective::SystemOperation::sum(),
+    );
+    if world.size() > 1 {
+        assert!(
+            remote_calls > 0,
+            "at least one remote rank must evaluate a patch"
+        );
+    }
+    assert_eq!(result.is_some(), rank == 0);
+    let first_dense = result.map(|result| {
+        assert_eq!(result.patch_caches().len(), result.partitioned_tt().len());
+        let tt = result.partitioned_tt().to_tensor_train().unwrap();
+        let tensors: Vec<_> = (0..tt.len()).map(|site| tt.tensor(site).unwrap()).collect();
+        contract(&tensors).unwrap().to_vec::<f64>().unwrap()
+    });
+    if let Some(dense) = &first_dense {
+        let expected: Vec<_> = (0..4)
+            .flat_map(|k| {
+                (0..4).flat_map(move |j| {
+                    (0..4).map(move |i| if i == j && j == k { 2.0 } else { 0.5 })
+                })
+            })
+            .collect();
+        assert_eq!(dense, &expected);
+    }
+
+    let repeated = adaptiveinterpolate_mpi::<_, f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        &world,
+        &domain,
+        0,
+        function,
+        None,
+        sites,
+        vec![vec![0, 0, 0], vec![3, 3, 3]],
+        options,
+    )
+    .unwrap();
+    let repeated_dense = repeated.map(|result| {
+        let tt = result.partitioned_tt().to_tensor_train().unwrap();
+        let tensors: Vec<_> = (0..tt.len()).map(|site| tt.tensor(site).unwrap()).collect();
+        contract(&tensors).unwrap().to_vec::<f64>().unwrap()
+    });
+    assert_eq!(repeated_dense, first_dense);
+
+    let complex_sites = vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)];
+    let complex = adaptiveinterpolate_mpi::<_, Complex64, _, fn(&[MultiIndex]) -> Vec<Complex64>>(
+        &world,
+        &domain,
+        0,
+        |index| Complex64::new((index[0] + 1) as f64, index[1] as f64),
+        None,
+        complex_sites,
+        vec![vec![1, 1]],
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(complex.is_some(), rank == 0);
+
+    let invalid = adaptiveinterpolate_mpi::<_, f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        &world,
+        &domain,
+        0,
+        |_| 1.0,
+        None,
+        vec![DynIndex::new_dyn(2), DynIndex::new_dyn(2)],
+        vec![vec![0]],
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        invalid,
+        PartitionedTTError::DistributedAdaptiveInterpolation(_)
+    ));
+}

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs
@@ -5,13 +5,19 @@
 //! TCIAlgorithms.jl at commit e501032278c9dd41b46c5851d8238169c8d178c5
 //! (MIT license; Copyright 2023 Ritter.Marc and contributors).
 
-use std::collections::{HashSet, VecDeque};
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+#[cfg(feature = "adaptive-hataori-mpi")]
+use std::num::NonZeroUsize;
+#[cfg(feature = "adaptive-hataori-mpi")]
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use tensor4all_core::{DynIndex, IdxTensor, TensorElement};
-use tensor4all_core::{MatrixLuciScalar, MultiIndex, Scalar};
+use tensor4all_core::{DynIndex, IdxTensor, MatrixLuciScalar, MultiIndex, Scalar, TensorElement};
 use tensor4all_itensorlike::TensorTrain;
+#[cfg(feature = "adaptive-hataori-mpi")]
+use tensor4all_simplett::Tensor3Ops;
 use tensor4all_simplett::{tensor3_from_data, SimpleTensorTrain, TTScalar};
 use tensor4all_tensorbackend::StorageScalar;
 use tensor4all_tensorci::{
@@ -83,10 +89,367 @@ impl Default for AdaptiveInterpolateOptions {
     }
 }
 
-#[derive(Debug)]
-struct PendingPatch {
+#[cfg_attr(
+    feature = "adaptive-hataori-mpi",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug, Clone)]
+struct PatchCache<T> {
+    active_dims: Vec<usize>,
+    entries: HashMap<MultiIndex, T>,
+}
+
+impl<T> PatchCache<T> {
+    fn new(active_dims: Vec<usize>) -> Self {
+        Self {
+            active_dims,
+            entries: HashMap::new(),
+        }
+    }
+
+    fn split(self, split_pos: usize, child_count: usize) -> Result<Vec<Self>> {
+        if split_pos >= self.active_dims.len() || self.active_dims[split_pos] != child_count {
+            return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "cache split does not match the active patch dimensions".to_string(),
+            ));
+        }
+        let mut child_dims = self.active_dims;
+        child_dims.remove(split_pos);
+        let mut children: Vec<_> = (0..child_count)
+            .map(|_| Self::new(child_dims.clone()))
+            .collect();
+        for (mut key, value) in self.entries {
+            if key.len() != child_dims.len() + 1 {
+                return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                    "cached key rank does not match the parent patch".to_string(),
+                ));
+            }
+            let child = key.remove(split_pos);
+            let child_cache = children.get_mut(child).ok_or_else(|| {
+                PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                    "cached split coordinate is outside the child range".to_string(),
+                )
+            })?;
+            child_cache.entries.insert(key, value);
+        }
+        Ok(children)
+    }
+}
+
+/// Samples retained for one accepted adaptive patch.
+///
+/// Keys passed to [`Self::get`] contain only the patch's active coordinates,
+/// in the original site order. The projector records all fixed coordinates.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtt::{adaptiveinterpolate, AdaptiveInterpolateOptions, DynIndex, MultiIndex};
+/// let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+///     |index| (index[0] + 1) as f64,
+///     None,
+///     vec![DynIndex::new_dyn(2)],
+///     Vec::new(),
+///     AdaptiveInterpolateOptions::default(),
+/// )?;
+/// let cache = &result.patch_caches()[0];
+/// assert_eq!(cache.get(&[1]), Some(&2.0));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct AcceptedPatchCache<T> {
     projector: Projector,
+    active_positions: Vec<usize>,
+    cache: PatchCache<T>,
+}
+
+impl<T> AcceptedPatchCache<T> {
+    /// Return the projector identifying the accepted patch.
+    ///
+    /// The projector is empty when the root patch converges without splitting.
+    pub fn projector(&self) -> &Projector {
+        &self.projector
+    }
+
+    /// Return the full-domain positions represented by local cache keys.
+    ///
+    /// For an unsplit two-site patch this returns `[0, 1]`.
+    pub fn active_positions(&self) -> &[usize] {
+        &self.active_positions
+    }
+
+    /// Return a retained value by patch-local active coordinates.
+    ///
+    /// Returns `None` when TCI did not sample the requested point.
+    pub fn get(&self, local_index: &[usize]) -> Option<&T> {
+        self.cache.entries.get(local_index)
+    }
+
+    /// Return the number of retained sample entries.
+    ///
+    /// This is the cache's retained-entry statistic.
+    pub fn len(&self) -> usize {
+        self.cache.entries.len()
+    }
+
+    /// Return whether this patch retains no samples.
+    pub fn is_empty(&self) -> bool {
+        self.cache.entries.is_empty()
+    }
+
+    /// Drop all retained samples while preserving patch metadata.
+    pub fn clear(&mut self) {
+        self.cache.entries.clear();
+    }
+}
+
+/// Adaptive interpolation output and its accepted per-patch sample caches.
+///
+/// The cache collection is paired with tensor-network patches by full
+/// [`Projector`] equality, not by index ID.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_partitionedtt::{adaptiveinterpolate, AdaptiveInterpolateOptions, DynIndex, MultiIndex};
+/// let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+///     |index| (index[0] + 1) as f64,
+///     None,
+///     vec![DynIndex::new_dyn(2)],
+///     Vec::new(),
+///     AdaptiveInterpolateOptions::default(),
+/// )?;
+/// assert_eq!(result.partitioned_tt().len(), 1);
+/// assert_eq!(result.patch_caches().len(), 1);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Debug, Clone)]
+pub struct AdaptiveInterpolationResult<T> {
+    partitioned_tt: PartitionedTT,
+    patch_caches: Vec<AcceptedPatchCache<T>>,
+}
+
+impl<T> AdaptiveInterpolationResult<T> {
+    /// Return the interpolated partitioned tensor train.
+    pub fn partitioned_tt(&self) -> &PartitionedTT {
+        &self.partitioned_tt
+    }
+
+    /// Return caches paired with accepted patches by projector.
+    pub fn patch_caches(&self) -> &[AcceptedPatchCache<T>] {
+        &self.patch_caches
+    }
+
+    /// Consume the result without copying the tensor train or cache entries.
+    pub fn into_parts(self) -> (PartitionedTT, Vec<AcceptedPatchCache<T>>) {
+        (self.partitioned_tt, self.patch_caches)
+    }
+}
+
+#[cfg_attr(
+    feature = "adaptive-hataori-mpi",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[derive(Debug)]
+struct PendingPatch<T> {
+    path: Vec<usize>,
     recycled_pivots: Vec<MultiIndex>,
+    cache: PatchCache<T>,
+}
+
+#[derive(Debug)]
+struct AcceptedPatch<T>
+where
+    T: TTScalar,
+{
+    path: Vec<usize>,
+    data: AcceptedData<T>,
+    cache: AcceptedPatchCache<T>,
+}
+
+#[derive(Debug)]
+enum AcceptedData<T>
+where
+    T: TTScalar,
+{
+    Scalar(T),
+    Active(SimpleTensorTrain<T>),
+}
+
+#[derive(Debug)]
+enum PatchOutcome<T: TTScalar> {
+    Accepted(AcceptedPatch<T>),
+    Split(Vec<PendingPatch<T>>),
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[derive(serde::Serialize, serde::Deserialize)]
+struct WireCore<T> {
+    dims: [usize; 3],
+    data: Vec<T>,
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[derive(serde::Serialize, serde::Deserialize)]
+enum WireAcceptedData<T> {
+    Scalar(T),
+    Active(Vec<WireCore<T>>),
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[derive(serde::Serialize, serde::Deserialize)]
+struct WireAcceptedPatch<T> {
+    path: Vec<usize>,
+    active_positions: Vec<usize>,
+    cache: PatchCache<T>,
+    data: WireAcceptedData<T>,
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[derive(serde::Serialize, serde::Deserialize)]
+enum WirePatchOutcome<T> {
+    Accepted(WireAcceptedPatch<T>),
+    Split(Vec<PendingPatch<T>>),
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[derive(serde::Serialize, serde::Deserialize)]
+enum WaveControl {
+    Continue,
+    Stop,
+    Fail(String),
+}
+
+struct PatchEvaluator<'a, T, F, B> {
+    f: &'a F,
+    batched_f: Option<&'a B>,
+    active_positions: &'a [usize],
+    projector: &'a Projector,
+    site_indices: &'a [DynIndex],
+    cache: RefCell<PatchCache<T>>,
+    pending_error: RefCell<Option<PartitionedTTError>>,
+}
+
+impl<'a, T, F, B> PatchEvaluator<'a, T, F, B>
+where
+    T: Scalar + Copy,
+    F: Fn(&MultiIndex) -> T,
+    B: Fn(&[MultiIndex]) -> Vec<T>,
+{
+    fn new(
+        f: &'a F,
+        batched_f: Option<&'a B>,
+        active_positions: &'a [usize],
+        projector: &'a Projector,
+        site_indices: &'a [DynIndex],
+        cache: PatchCache<T>,
+    ) -> Result<Self> {
+        let expected_dims: Vec<_> = active_positions
+            .iter()
+            .map(|&position| site_indices[position].dim)
+            .collect();
+        if cache.active_dims != expected_dims {
+            return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "cache dimensions do not match the active patch".to_string(),
+            ));
+        }
+        Ok(Self {
+            f,
+            batched_f,
+            active_positions,
+            projector,
+            site_indices,
+            cache: RefCell::new(cache),
+            pending_error: RefCell::new(None),
+        })
+    }
+
+    fn eval(&self, local_index: &MultiIndex) -> T {
+        if let Some(value) = self.cache.borrow().entries.get(local_index).copied() {
+            return value;
+        }
+        let full_index = expand_pivot(
+            local_index,
+            self.active_positions,
+            self.projector,
+            self.site_indices,
+        );
+        let value = (self.f)(&full_index);
+        self.cache
+            .borrow_mut()
+            .entries
+            .insert(local_index.clone(), value);
+        value
+    }
+
+    fn eval_many(&self, local_indices: &[MultiIndex]) -> Vec<T> {
+        let mut output = vec![None; local_indices.len()];
+        let mut missing = Vec::new();
+        let mut missing_positions = HashMap::<MultiIndex, Vec<usize>>::new();
+        {
+            let cache = self.cache.borrow();
+            for (position, index) in local_indices.iter().enumerate() {
+                if let Some(value) = cache.entries.get(index).copied() {
+                    output[position] = Some(value);
+                } else {
+                    missing_positions
+                        .entry(index.clone())
+                        .or_insert_with(|| {
+                            missing.push(index.clone());
+                            Vec::new()
+                        })
+                        .push(position);
+                }
+            }
+        }
+        if !missing.is_empty() {
+            let full_indices: Vec<_> = missing
+                .iter()
+                .map(|index| {
+                    expand_pivot(
+                        index,
+                        self.active_positions,
+                        self.projector,
+                        self.site_indices,
+                    )
+                })
+                .collect();
+            let values = if let Some(batch) = self.batched_f {
+                batch(&full_indices)
+            } else {
+                full_indices.iter().map(self.f).collect()
+            };
+            if values.len() != missing.len() {
+                *self.pending_error.borrow_mut() = Some(
+                    PartitionedTTError::InvalidAdaptiveInterpolationInput(format!(
+                        "batch callback returned {} values for {} cache misses",
+                        values.len(),
+                        missing.len()
+                    )),
+                );
+                return vec![T::zero(); local_indices.len()];
+            }
+            let mut cache = self.cache.borrow_mut();
+            for (index, value) in missing.into_iter().zip(values) {
+                cache.entries.insert(index.clone(), value);
+                for &position in &missing_positions[&index] {
+                    output[position] = Some(value);
+                }
+            }
+        }
+        output
+            .into_iter()
+            .map(|value| value.unwrap_or_else(T::zero))
+            .collect()
+    }
+
+    fn take_error(&self) -> Option<PartitionedTTError> {
+        self.pending_error.borrow_mut().take()
+    }
+
+    fn into_cache(self) -> PatchCache<T> {
+        self.cache.into_inner()
+    }
 }
 
 /// Adaptively interpolate a discrete function as a partitioned tensor train.
@@ -107,7 +470,6 @@ struct PendingPatch {
 ///
 /// - `f`: scalar evaluator receiving one full, zero-based multi-index.
 /// - `batched_f`: optional batch evaluator receiving full multi-indices and
-///
 ///   returning values in the same order. Use `None` when batching is unavailable.
 /// - `site_indices`: one distinct [`DynIndex`] per TCI site, in evaluator order.
 /// - `initial_pivots`: full-domain, zero-based pivots. Empty input is allowed.
@@ -115,8 +477,8 @@ struct PendingPatch {
 ///
 /// # Returns
 ///
-/// A [`PartitionedTT`] whose mutually disjoint patches cover the full domain.
-/// Calling [`PartitionedTT::to_tensor_train`] combines the patches into one TT.
+/// An [`AdaptiveInterpolationResult`] containing mutually disjoint patches and
+/// one physically separate sample cache for each accepted patch.
 ///
 /// # Errors
 ///
@@ -144,7 +506,7 @@ struct PendingPatch {
 /// )
 /// .unwrap();
 ///
-/// let tt = result.to_tensor_train().unwrap();
+/// let tt = result.partitioned_tt().to_tensor_train().unwrap();
 /// let dense = contract(&[tt.tensor(0).unwrap(), tt.tensor(1).unwrap()]).unwrap();
 /// assert_eq!(dense.to_vec::<f64>().unwrap(), vec![1.0, 2.0, 2.0, 4.0]);
 /// ```
@@ -154,177 +516,675 @@ pub fn adaptiveinterpolate<T, F, B>(
     site_indices: Vec<DynIndex>,
     initial_pivots: Vec<MultiIndex>,
     options: AdaptiveInterpolateOptions,
-) -> Result<PartitionedTT>
+) -> Result<AdaptiveInterpolationResult<T>>
 where
     T: Scalar + TTScalar + MatrixLuciScalar + TensorElement + StorageScalar + Default + Copy,
     F: Fn(&MultiIndex) -> T,
     B: Fn(&[MultiIndex]) -> Vec<T>,
 {
     let patch_order = validate_inputs(&site_indices, &initial_pivots, &options)?;
-    let mut rng = StdRng::seed_from_u64(options.tci_options.seed.unwrap_or(0));
-    let mut pending = VecDeque::from([PendingPatch {
-        projector: Projector::new(),
+    let root_dims = site_indices.iter().map(|index| index.dim).collect();
+    let mut wave = vec![PendingPatch {
+        path: Vec::new(),
         recycled_pivots: Vec::new(),
-    }]);
+        cache: PatchCache::new(root_dims),
+    }];
     let mut accepted = Vec::new();
 
-    while let Some(patch) = pending.pop_front() {
-        let active_positions = active_positions(&site_indices, &patch.projector);
-
-        if active_positions.is_empty() {
-            let value = f(&expand_pivot(
-                &Vec::new(),
-                &active_positions,
-                &patch.projector,
+    while !wave.is_empty() {
+        let mut next_wave = Vec::new();
+        for patch in wave {
+            match process_patch(
+                patch,
+                &f,
+                batched_f.as_ref(),
                 &site_indices,
-            ));
-            let tt = rank_one_full_tt(&site_indices, &patch.projector, value)?;
-            accepted.push(SubDomainTT::new(tt, patch.projector)?);
-            continue;
-        }
-
-        if active_positions.len() == 1 {
-            let dim = site_indices[active_positions[0]].dim;
-            let data = (0..dim)
-                .map(|value| {
-                    f(&expand_pivot(
-                        &vec![value],
-                        &active_positions,
-                        &patch.projector,
-                        &site_indices,
-                    ))
-                })
-                .collect();
-            let core = tensor3_from_data(data, 1, dim, 1)
-                .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))?;
-            let exact = SimpleTensorTrain::new(vec![core])
-                .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))?;
-            let (exact_tree, _) = tensor_train_to_treetn(&exact)
-                .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))?;
-            let tt = embed_active_tt::<T>(
-                exact_tree,
-                &site_indices,
-                &active_positions,
-                &patch.projector,
-            )?;
-            accepted.push(SubDomainTT::new(tt, patch.projector)?);
-            continue;
-        }
-
-        let candidate_pivots = patch_candidates(
-            &site_indices,
-            &active_positions,
-            &patch.projector,
-            &initial_pivots,
-            &patch.recycled_pivots,
-            options.n_initial_pivots,
-            &mut rng,
-        )?;
-        let candidate_values: Vec<T> = candidate_pivots
-            .iter()
-            .map(|pivot| {
-                f(&expand_pivot(
-                    pivot,
-                    &active_positions,
-                    &patch.projector,
-                    &site_indices,
-                ))
-            })
-            .collect();
-
-        if candidate_values
-            .iter()
-            .all(|value| Scalar::abs_val(*value) < ZERO_SAMPLE_THRESHOLD)
-        {
-            let tt = rank_one_full_tt(&site_indices, &patch.projector, T::zero())?;
-            accepted.push(SubDomainTT::new(tt, patch.projector)?);
-            continue;
-        }
-
-        let local_dims = active_positions
-            .iter()
-            .map(|&position| site_indices[position].dim)
-            .collect();
-        let local_f = |pivot: &MultiIndex| {
-            f(&expand_pivot(
-                pivot,
-                &active_positions,
-                &patch.projector,
-                &site_indices,
-            ))
-        };
-        let local_batch = batched_f.as_ref().map(|batch| {
-            |pivots: &[MultiIndex]| {
-                let full_pivots: Vec<_> = pivots
-                    .iter()
-                    .map(|pivot| {
-                        expand_pivot(pivot, &active_positions, &patch.projector, &site_indices)
-                    })
-                    .collect();
-                batch(&full_pivots)
+                &initial_pivots,
+                &patch_order,
+                &options,
+            )? {
+                PatchOutcome::Accepted(patch) => accepted.push(patch),
+                PatchOutcome::Split(children) => next_wave.extend(children),
             }
-        });
-        let TCI2OptimizationResult {
-            tci,
-            errors,
-            termination,
-            ..
-        } = crossinterpolate2(
-            local_f,
-            local_batch,
-            local_dims,
-            candidate_pivots,
-            options.tci_options.clone(),
-        )?;
-        let normalization = if options.tci_options.normalize_error && tci.max_sample_value() > 0.0 {
-            tci.max_sample_value()
-        } else {
-            1.0
-        };
-        let final_error = errors
-            .last()
-            .copied()
-            .unwrap_or_else(|| tci.max_bond_error() / normalization);
-
-        if patch_is_accepted(termination, final_error, options.tci_options.tolerance) {
-            let simple_tt = tci.to_tensor_train()?;
-            let (active_tree, _) = tensor_train_to_treetn(&simple_tt)
-                .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))?;
-            let tt = embed_active_tt::<T>(
-                active_tree,
-                &site_indices,
-                &active_positions,
-                &patch.projector,
-            )?;
-            accepted.push(SubDomainTT::new(tt, patch.projector)?);
-            continue;
         }
-
-        let split_index = patch_order
-            .iter()
-            .find(|index| !patch.projector.is_projected_at(index))
-            .ok_or_else(|| {
-                PartitionedTTError::InvalidAdaptiveInterpolationInput(
-                    "a nonconverged patch has no remaining split index".to_string(),
-                )
-            })?
-            .clone();
-        let recycled_pivots = if options.recycle_pivots {
-            global_diagonal_pivots(&tci, &active_positions, &patch.projector, &site_indices)
-        } else {
-            Vec::new()
-        };
-        for value in 0..split_index.dim {
-            let mut child_projector = patch.projector.clone();
-            child_projector.insert(split_index.clone(), value)?;
-            pending.push_back(PendingPatch {
-                projector: child_projector,
-                recycled_pivots: recycled_pivots.clone(),
-            });
-        }
+        wave = next_wave;
     }
 
-    PartitionedTT::from_subdomains(accepted)
+    assemble_result(accepted, &site_indices, &patch_order)
+}
+
+/// Adaptively interpolate patches in parallel on an explicit Hataori Rayon domain.
+///
+/// Different patches use [`hataori::LocalMode::Outer`]. Rayon work started by a
+/// patch callback is nested in the same domain pool. The domain must be backed
+/// by a Rayon pool, and the call must originate outside a foreign Rayon pool.
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use tensor4all_partitionedtt::{adaptiveinterpolate_in, AdaptiveInterpolateOptions, DynIndex, MultiIndex};
+/// let pool = Arc::new(rayon::ThreadPoolBuilder::new().num_threads(1).build()?);
+/// let domain = hataori::Domain::external(pool, vec![0], 1)?;
+/// let result = adaptiveinterpolate_in::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+///     &domain,
+///     |index| (index[0] + 1) as f64,
+///     None,
+///     vec![DynIndex::new_dyn(2)],
+///     Vec::new(),
+///     AdaptiveInterpolateOptions::default(),
+/// )?;
+/// assert_eq!(result.patch_caches()[0].get(&[1]), Some(&2.0));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns the same interpolation errors as [`adaptiveinterpolate`], or
+/// [`PartitionedTTError::HataoriLocal`] when domain admission or scheduling
+/// fails. No partial partition or cache is returned.
+#[cfg(feature = "adaptive-hataori-rayon")]
+pub fn adaptiveinterpolate_in<T, F, B>(
+    domain: &hataori::Domain,
+    f: F,
+    batched_f: Option<B>,
+    site_indices: Vec<DynIndex>,
+    initial_pivots: Vec<MultiIndex>,
+    options: AdaptiveInterpolateOptions,
+) -> Result<AdaptiveInterpolationResult<T>>
+where
+    T: Scalar + TTScalar + MatrixLuciScalar + TensorElement + StorageScalar + Default + Copy + Send,
+    F: Fn(&MultiIndex) -> T + Send + Sync,
+    B: Fn(&[MultiIndex]) -> Vec<T> + Send + Sync,
+{
+    let patch_order = validate_inputs(&site_indices, &initial_pivots, &options)?;
+    let root_dims = site_indices.iter().map(|index| index.dim).collect();
+    let mut wave = vec![PendingPatch {
+        path: Vec::new(),
+        recycled_pivots: Vec::new(),
+        cache: PatchCache::new(root_dims),
+    }];
+    let mut accepted = Vec::new();
+
+    while !wave.is_empty() {
+        let paths: Vec<_> = wave.iter().map(|patch| patch.path.clone()).collect();
+        let outcomes = hataori::map_in(domain, hataori::LocalMode::Outer, wave, |patch| {
+            process_patch(
+                patch,
+                &f,
+                batched_f.as_ref(),
+                &site_indices,
+                &initial_pivots,
+                &patch_order,
+                &options,
+            )
+        })
+        .map_err(|source| {
+            let path = match &source {
+                hataori::MapInError::Callback(error) => paths.get(error.index()).cloned(),
+                _ => None,
+            };
+            PartitionedTTError::HataoriLocal { path, source }
+        })?;
+        let mut next_wave = Vec::new();
+        for outcome in outcomes {
+            match outcome {
+                PatchOutcome::Accepted(patch) => accepted.push(patch),
+                PatchOutcome::Split(children) => next_wave.extend(children),
+            }
+        }
+        wave = next_wave;
+    }
+
+    assemble_result(accepted, &site_indices, &patch_order)
+}
+
+/// Collectively interpolate adaptive patches across MPI ranks and local Rayon domains.
+///
+/// Every rank must call this function from the MPI main thread with equivalent
+/// callbacks and interpolation metadata. Each rank supplies a pool-backed,
+/// id-zero Hataori domain; MPI must provide `MPI_THREAD_FUNNELED` or stronger.
+/// Only `root` receives `Some(result)`.
+///
+/// # Examples
+///
+/// A runnable multi-rank example with numerical and cache assertions is provided
+/// at `examples/adaptive_mpi_smoke.rs` and is executed with
+/// `mpiexec -n 2 target/release/examples/adaptive_mpi_smoke`.
+///
+/// # Errors
+///
+/// Returns [`PartitionedTTError::HataoriMpiPlacement`] when collective
+/// validation or `WaveControl` broadcast fails,
+/// [`PartitionedTTError::HataoriMpiPmap`] when a patch callback, MPI scheduler,
+/// or Hataori wire operation fails, and
+/// [`PartitionedTTError::DistributedAdaptiveInterpolation`] when common input
+/// is invalid or root-side cache/core reconstruction and final partition
+/// validation fails. No rank receives a partial partition or cache.
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[allow(clippy::too_many_arguments)]
+pub fn adaptiveinterpolate_mpi<C, T, F, B>(
+    world: &C,
+    domain: &hataori::Domain,
+    root: i32,
+    f: F,
+    batched_f: Option<B>,
+    site_indices: Vec<DynIndex>,
+    initial_pivots: Vec<MultiIndex>,
+    options: AdaptiveInterpolateOptions,
+) -> Result<Option<AdaptiveInterpolationResult<T>>>
+where
+    C: mpi::traits::Communicator,
+    T: Scalar
+        + TTScalar
+        + MatrixLuciScalar
+        + TensorElement
+        + StorageScalar
+        + Default
+        + Copy
+        + Send
+        + Sync
+        + serde::Serialize
+        + serde::de::DeserializeOwned,
+    F: Fn(&MultiIndex) -> T + Send + Sync,
+    B: Fn(&[MultiIndex]) -> Vec<T> + Send + Sync,
+{
+    let rank = world.rank();
+    let local_validation = validate_inputs(&site_indices, &initial_pivots, &options);
+    let local_error = local_validation.as_ref().err().map(ToString::to_string);
+    let gathered = hataori::gather(world, root, local_error)
+        .map_err(|source| PartitionedTTError::HataoriMpiPlacement { source })?;
+    let validation_control = if rank == root {
+        let first_error = gathered
+            .as_ref()
+            .and_then(|errors| errors.iter().flatten().next())
+            .cloned();
+        Some(match first_error {
+            Some(message) => WaveControl::Fail(message),
+            None => WaveControl::Continue,
+        })
+    } else {
+        None
+    };
+    match hataori::broadcast(world, root, validation_control)
+        .map_err(|source| PartitionedTTError::HataoriMpiPlacement { source })?
+    {
+        WaveControl::Continue => {}
+        WaveControl::Fail(message) => {
+            return Err(PartitionedTTError::DistributedAdaptiveInterpolation(
+                message,
+            ));
+        }
+        WaveControl::Stop => {
+            return Err(PartitionedTTError::DistributedAdaptiveInterpolation(
+                "invalid stop control during MPI validation".to_string(),
+            ));
+        }
+    }
+    let patch_order = local_validation
+        .map_err(|error| PartitionedTTError::DistributedAdaptiveInterpolation(error.to_string()))?;
+
+    let root_dims = site_indices.iter().map(|index| index.dim).collect();
+    let mut wave = if rank == root {
+        vec![PendingPatch {
+            path: Vec::new(),
+            recycled_pivots: Vec::new(),
+            cache: PatchCache::new(root_dims),
+        }]
+    } else {
+        Vec::new()
+    };
+    let mut accepted = Vec::new();
+    let pmap_options = hataori::PmapOptions {
+        root,
+        batch_size: NonZeroUsize::MIN,
+        local_mode: hataori::LocalMode::Outer,
+        prefetch: false,
+    };
+
+    loop {
+        let root_items = (rank == root).then(|| std::mem::take(&mut wave));
+        let wire_outcomes = hataori::pmap(world, domain, pmap_options, root_items, |patch| {
+            process_patch(
+                patch,
+                &f,
+                batched_f.as_ref(),
+                &site_indices,
+                &initial_pivots,
+                &patch_order,
+                &options,
+            )
+            .map(patch_outcome_to_wire)
+        })
+        .map_err(|source| PartitionedTTError::HataoriMpiPmap { source })?;
+
+        let mut root_result = None;
+        let root_control = if rank == root {
+            let root_postprocess = catch_unwind(AssertUnwindSafe(|| -> Result<WaveControl> {
+                let mut next_wave = Vec::new();
+                for wire in wire_outcomes.ok_or_else(|| {
+                    PartitionedTTError::DistributedAdaptiveInterpolation(
+                        "MPI root did not receive patch outcomes".to_string(),
+                    )
+                })? {
+                    match patch_outcome_from_wire(wire, &site_indices, &patch_order)? {
+                        PatchOutcome::Accepted(patch) => accepted.push(patch),
+                        PatchOutcome::Split(children) => next_wave.extend(children),
+                    }
+                }
+                if next_wave.is_empty() {
+                    root_result = Some(assemble_result(
+                        std::mem::take(&mut accepted),
+                        &site_indices,
+                        &patch_order,
+                    )?);
+                    Ok(WaveControl::Stop)
+                } else {
+                    wave = next_wave;
+                    Ok(WaveControl::Continue)
+                }
+            }));
+            Some(match root_postprocess {
+                Ok(Ok(control)) => control,
+                Ok(Err(error)) => WaveControl::Fail(error.to_string()),
+                Err(_) => world.abort(75),
+            })
+        } else {
+            None
+        };
+
+        match hataori::broadcast(world, root, root_control)
+            .map_err(|source| PartitionedTTError::HataoriMpiPlacement { source })?
+        {
+            WaveControl::Continue => continue,
+            WaveControl::Stop if rank == root => {
+                return Ok(Some(root_result.unwrap_or_else(|| world.abort(76))));
+            }
+            WaveControl::Stop => return Ok(None),
+            WaveControl::Fail(message) => {
+                return Err(PartitionedTTError::DistributedAdaptiveInterpolation(
+                    message,
+                ));
+            }
+        }
+    }
+}
+
+fn assemble_result<T>(
+    mut accepted: Vec<AcceptedPatch<T>>,
+    site_indices: &[DynIndex],
+    patch_order: &[DynIndex],
+) -> Result<AdaptiveInterpolationResult<T>>
+where
+    T: Scalar + TTScalar + TensorElement + StorageScalar + Default + Copy,
+{
+    accepted.sort_by(|left, right| left.path.cmp(&right.path));
+    let mut subdomains = Vec::with_capacity(accepted.len());
+    let mut patch_caches = Vec::with_capacity(accepted.len());
+    for patch in accepted {
+        let projector = projector_from_path(patch_order, &patch.path)?;
+        let tt = match patch.data {
+            AcceptedData::Scalar(value) => rank_one_full_tt(site_indices, &projector, value)?,
+            AcceptedData::Active(active_tt) => {
+                let (active_tree, _) = tensor_train_to_treetn(&active_tt).map_err(|error| {
+                    PartitionedTTError::tensor_train_operation(error.to_string())
+                })?;
+                embed_active_tt::<T>(
+                    active_tree,
+                    site_indices,
+                    patch.cache.active_positions(),
+                    &projector,
+                )?
+            }
+        };
+        subdomains.push(SubDomainTT::new(tt, projector)?);
+        patch_caches.push(patch.cache);
+    }
+    let partitioned_tt = PartitionedTT::from_subdomains(subdomains)?;
+    Ok(AdaptiveInterpolationResult {
+        partitioned_tt,
+        patch_caches,
+    })
+}
+
+fn process_patch<T, F, B>(
+    patch: PendingPatch<T>,
+    f: &F,
+    batched_f: Option<&B>,
+    site_indices: &[DynIndex],
+    initial_pivots: &[MultiIndex],
+    patch_order: &[DynIndex],
+    options: &AdaptiveInterpolateOptions,
+) -> Result<PatchOutcome<T>>
+where
+    T: Scalar + TTScalar + MatrixLuciScalar + TensorElement + StorageScalar + Default + Copy,
+    F: Fn(&MultiIndex) -> T,
+    B: Fn(&[MultiIndex]) -> Vec<T>,
+{
+    let projector = projector_from_path(patch_order, &patch.path)?;
+    let active_positions = active_positions(site_indices, &projector);
+    let evaluator = PatchEvaluator::new(
+        f,
+        batched_f,
+        &active_positions,
+        &projector,
+        site_indices,
+        patch.cache,
+    )?;
+
+    if active_positions.is_empty() {
+        let value = evaluator.eval(&Vec::new());
+        let cache = evaluator.into_cache();
+        return Ok(accepted_outcome(
+            patch.path,
+            projector,
+            active_positions,
+            AcceptedData::Scalar(value),
+            cache,
+        ));
+    }
+
+    if active_positions.len() == 1 {
+        let dim = site_indices[active_positions[0]].dim;
+        let data = (0..dim).map(|value| evaluator.eval(&vec![value])).collect();
+        let core = tensor3_from_data(data, 1, dim, 1)
+            .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))?;
+        let exact = SimpleTensorTrain::new(vec![core])
+            .map_err(|error| PartitionedTTError::tensor_train_operation(error.to_string()))?;
+        let cache = evaluator.into_cache();
+        return Ok(accepted_outcome(
+            patch.path,
+            projector,
+            active_positions,
+            AcceptedData::Active(exact),
+            cache,
+        ));
+    }
+
+    let seed = patch_seed(options.tci_options.seed.unwrap_or(0), &patch.path);
+    let mut rng = StdRng::seed_from_u64(seed);
+    let candidate_pivots = patch_candidates(
+        site_indices,
+        &active_positions,
+        &projector,
+        initial_pivots,
+        &patch.recycled_pivots,
+        options.n_initial_pivots,
+        &mut rng,
+    )?;
+    let candidate_values = evaluator.eval_many(&candidate_pivots);
+    if let Some(error) = evaluator.take_error() {
+        return Err(error);
+    }
+
+    if candidate_values
+        .iter()
+        .all(|value| Scalar::abs_val(*value) < ZERO_SAMPLE_THRESHOLD)
+    {
+        let cache = evaluator.into_cache();
+        return Ok(accepted_outcome(
+            patch.path,
+            projector,
+            active_positions,
+            AcceptedData::Scalar(T::zero()),
+            cache,
+        ));
+    }
+
+    let local_dims = active_positions
+        .iter()
+        .map(|&position| site_indices[position].dim)
+        .collect();
+    let local_f = |pivot: &MultiIndex| evaluator.eval(pivot);
+    let local_batch = batched_f.map(|_| |pivots: &[MultiIndex]| evaluator.eval_many(pivots));
+    let mut tci_options = options.tci_options.clone();
+    tci_options.seed = Some(splitmix64(seed));
+    let tci_result = crossinterpolate2(
+        local_f,
+        local_batch,
+        local_dims,
+        candidate_pivots,
+        tci_options,
+    );
+    if let Some(error) = evaluator.take_error() {
+        return Err(error);
+    }
+    let TCI2OptimizationResult {
+        tci,
+        errors,
+        termination,
+        ..
+    } = tci_result?;
+    let normalization = if options.tci_options.normalize_error && tci.max_sample_value() > 0.0 {
+        tci.max_sample_value()
+    } else {
+        1.0
+    };
+    let final_error = errors
+        .last()
+        .copied()
+        .unwrap_or_else(|| tci.max_bond_error() / normalization);
+
+    if patch_is_accepted(termination, final_error, options.tci_options.tolerance) {
+        let simple_tt = tci.to_tensor_train()?;
+        let cache = evaluator.into_cache();
+        return Ok(accepted_outcome(
+            patch.path,
+            projector,
+            active_positions,
+            AcceptedData::Active(simple_tt),
+            cache,
+        ));
+    }
+
+    let split_index = patch_order.get(patch.path.len()).ok_or_else(|| {
+        PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "a nonconverged patch has no remaining split index".to_string(),
+        )
+    })?;
+    let split_site_position = site_indices
+        .iter()
+        .position(|index| index == split_index)
+        .ok_or_else(|| {
+            PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "split index is absent from site_indices".to_string(),
+            )
+        })?;
+    let split_active_position = active_positions
+        .iter()
+        .position(|&position| position == split_site_position)
+        .ok_or_else(|| {
+            PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "split index is not active in its parent patch".to_string(),
+            )
+        })?;
+    let recycled_pivots = if options.recycle_pivots {
+        global_diagonal_pivots(&tci, &active_positions, &projector, site_indices)
+    } else {
+        Vec::new()
+    };
+    let child_caches = evaluator
+        .into_cache()
+        .split(split_active_position, split_index.dim)?;
+    let mut children = Vec::with_capacity(split_index.dim);
+    for (value, cache) in child_caches.into_iter().enumerate() {
+        let mut path = patch.path.clone();
+        path.push(value);
+        children.push(PendingPatch {
+            path,
+            recycled_pivots: recycled_pivots.clone(),
+            cache,
+        });
+    }
+    Ok(PatchOutcome::Split(children))
+}
+
+fn accepted_outcome<T: TTScalar>(
+    path: Vec<usize>,
+    projector: Projector,
+    active_positions: Vec<usize>,
+    data: AcceptedData<T>,
+    cache: PatchCache<T>,
+) -> PatchOutcome<T> {
+    PatchOutcome::Accepted(AcceptedPatch {
+        path,
+        data,
+        cache: AcceptedPatchCache {
+            projector,
+            active_positions,
+            cache,
+        },
+    })
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+fn patch_outcome_to_wire<T>(outcome: PatchOutcome<T>) -> WirePatchOutcome<T>
+where
+    T: TTScalar + Copy,
+{
+    match outcome {
+        PatchOutcome::Split(children) => WirePatchOutcome::Split(children),
+        PatchOutcome::Accepted(patch) => {
+            let data = match patch.data {
+                AcceptedData::Scalar(value) => WireAcceptedData::Scalar(value),
+                AcceptedData::Active(tt) => WireAcceptedData::Active(
+                    tt.into_site_tensors()
+                        .into_iter()
+                        .map(|core| WireCore {
+                            dims: [core.left_dim(), core.site_dim(), core.right_dim()],
+                            data: core.to_col_major_vec(),
+                        })
+                        .collect(),
+                ),
+            };
+            WirePatchOutcome::Accepted(WireAcceptedPatch {
+                path: patch.path,
+                active_positions: patch.cache.active_positions,
+                cache: patch.cache.cache,
+                data,
+            })
+        }
+    }
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+fn patch_outcome_from_wire<T>(
+    outcome: WirePatchOutcome<T>,
+    site_indices: &[DynIndex],
+    patch_order: &[DynIndex],
+) -> Result<PatchOutcome<T>>
+where
+    T: TTScalar + Copy,
+{
+    match outcome {
+        WirePatchOutcome::Split(children) => Ok(PatchOutcome::Split(children)),
+        WirePatchOutcome::Accepted(patch) => {
+            let projector = projector_from_path(patch_order, &patch.path)?;
+            let expected_active = active_positions(site_indices, &projector);
+            let expected_dims: Vec<_> = expected_active
+                .iter()
+                .map(|&position| site_indices[position].dim)
+                .collect();
+            if patch.active_positions != expected_active || patch.cache.active_dims != expected_dims
+            {
+                return Err(PartitionedTTError::DistributedAdaptiveInterpolation(
+                    "wire accepted cache metadata does not match its patch path".to_string(),
+                ));
+            }
+            let data = match patch.data {
+                WireAcceptedData::Scalar(value) => AcceptedData::Scalar(value),
+                WireAcceptedData::Active(wire_cores) => {
+                    if wire_cores.len() != expected_dims.len() {
+                        return Err(PartitionedTTError::DistributedAdaptiveInterpolation(
+                            format!(
+                                "wire TT has {} cores for {} active sites",
+                                wire_cores.len(),
+                                expected_dims.len()
+                            ),
+                        ));
+                    }
+                    let mut cores = Vec::with_capacity(wire_cores.len());
+                    for (site, core) in wire_cores.into_iter().enumerate() {
+                        if core.dims[1] != expected_dims[site] {
+                            return Err(PartitionedTTError::DistributedAdaptiveInterpolation(
+                                format!(
+                                    "wire TT core {site} has site dimension {} but patch requires {}",
+                                    core.dims[1], expected_dims[site]
+                                ),
+                            ));
+                        }
+                        let expected = core.dims.iter().try_fold(1usize, |count, &dim| {
+                            count.checked_mul(dim).ok_or_else(|| {
+                                PartitionedTTError::DistributedAdaptiveInterpolation(
+                                    "wire TT core shape product exceeds usize".to_string(),
+                                )
+                            })
+                        })?;
+                        if core.data.len() != expected {
+                            return Err(
+                                PartitionedTTError::DistributedAdaptiveInterpolation(format!(
+                                    "wire TT core has {} values for shape {:?} requiring {expected}",
+                                    core.data.len(),
+                                    core.dims
+                                )),
+                            );
+                        }
+                        cores.push(
+                            tensor3_from_data(core.data, core.dims[0], core.dims[1], core.dims[2])
+                                .map_err(|error| {
+                                    PartitionedTTError::tensor_train_operation(error.to_string())
+                                })?,
+                        );
+                    }
+                    AcceptedData::Active(SimpleTensorTrain::new(cores).map_err(|error| {
+                        PartitionedTTError::tensor_train_operation(error.to_string())
+                    })?)
+                }
+            };
+            Ok(PatchOutcome::Accepted(AcceptedPatch {
+                path: patch.path,
+                data,
+                cache: AcceptedPatchCache {
+                    projector,
+                    active_positions: patch.active_positions,
+                    cache: patch.cache,
+                },
+            }))
+        }
+    }
+}
+
+fn projector_from_path(patch_order: &[DynIndex], path: &[usize]) -> Result<Projector> {
+    if path.len() > patch_order.len() {
+        return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+            "patch path is deeper than patch_order".to_string(),
+        ));
+    }
+    let mut projector = Projector::new();
+    for (index, &value) in patch_order.iter().zip(path) {
+        if value >= index.dim {
+            return Err(PartitionedTTError::InvalidAdaptiveInterpolationInput(
+                "patch path coordinate is outside its site dimension".to_string(),
+            ));
+        }
+        projector.insert(index.clone(), value)?;
+    }
+    Ok(projector)
+}
+
+// Stable SplitMix64 derivation; changing these constants changes reproducible patch candidates.
+fn patch_seed(root_seed: u64, path: &[usize]) -> u64 {
+    path.iter().enumerate().fold(
+        splitmix64(root_seed ^ 0x6a09_e667_f3bc_c909),
+        |state, (depth, &value)| splitmix64(state ^ (depth as u64).rotate_left(32) ^ value as u64),
+    )
+}
+
+fn splitmix64(mut value: u64) -> u64 {
+    value = value.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
 }
 
 fn validate_inputs(

--- a/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
+++ b/crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs
@@ -1,16 +1,16 @@
 use super::*;
-
-fn projector(pairs: impl IntoIterator<Item = (DynIndex, usize)>) -> Projector {
-    Projector::from_pairs(pairs).unwrap()
-}
 use num_complex::Complex64;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+#[cfg(feature = "adaptive-hataori-rayon")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "adaptive-hataori-rayon")]
+use std::sync::Arc;
 use tensor4all_core::contract;
 use tensor4all_tensorbackend::StorageKind;
 
-fn dense_f64(result: &PartitionedTT) -> Vec<f64> {
-    let tt = result.to_tensor_train().unwrap();
+fn dense_f64(result: &AdaptiveInterpolationResult<f64>) -> Vec<f64> {
+    let tt = result.partitioned_tt().to_tensor_train().unwrap();
     let tensors: Vec<_> = (0..tt.len()).map(|site| tt.tensor(site).unwrap()).collect();
     contract(&tensors).unwrap().to_vec::<f64>().unwrap()
 }
@@ -57,7 +57,7 @@ fn interpolates_low_rank_function_without_splitting() {
     )
     .unwrap();
 
-    assert_eq!(result.len(), 1);
+    assert_eq!(result.partitioned_tt().len(), 1);
     assert_eq!(
         dense_f64(&result),
         vec![6.0, 12.0, 9.0, 18.0, 8.0, 16.0, 12.0, 24.0]
@@ -87,7 +87,7 @@ fn evaluates_single_active_site_exactly() {
     )
     .unwrap();
 
-    assert_eq!(result.len(), 1);
+    assert_eq!(result.partitioned_tt().len(), 1);
     assert_eq!(dense_f64(&result), vec![1.0, 2.0, 5.0, 10.0]);
 }
 
@@ -119,20 +119,43 @@ fn rank_cap_forces_disjoint_exact_child_patches() {
     let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
         function,
         None,
-        sites,
+        sites.clone(),
         vec![vec![0, 0, 0], vec![1, 1, 1]],
         options,
     )
     .unwrap();
 
-    assert!(result.len() >= 2);
+    assert!(result.partitioned_tt().len() >= 2);
     assert!(Projector::are_disjoint(
-        &result.projectors().cloned().collect::<Vec<_>>()
+        &result
+            .partitioned_tt()
+            .projectors()
+            .cloned()
+            .collect::<Vec<_>>()
     ));
     assert_eq!(
         dense_f64(&result),
         vec![2.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 2.0]
     );
+    assert_eq!(result.patch_caches().len(), result.partitioned_tt().len());
+    for cache in result.patch_caches() {
+        assert!(result.partitioned_tt().contains(cache.projector()));
+        for local_index in cache.cache.entries.keys() {
+            let full = expand_pivot(
+                local_index,
+                cache.active_positions(),
+                cache.projector(),
+                &sites,
+            );
+            assert!(is_compatible_pivot(&full, &sites, cache.projector()));
+        }
+    }
+    let mut returned = result.patch_caches().to_vec();
+    assert!(returned.iter().map(AcceptedPatchCache::len).sum::<usize>() > 0);
+    let projector = returned[0].projector().clone();
+    returned[0].clear();
+    assert!(returned[0].is_empty());
+    assert_eq!(returned[0].projector(), &projector);
 }
 
 #[test]
@@ -176,7 +199,7 @@ fn supports_complex_values() {
         AdaptiveInterpolateOptions::default(),
     )
     .unwrap();
-    let tt = result.to_tensor_train().unwrap();
+    let tt = result.partitioned_tt().to_tensor_train().unwrap();
     let tensors: Vec<_> = (0..tt.len()).map(|site| tt.tensor(site).unwrap()).collect();
     let dense = contract(&tensors).unwrap().to_vec::<Complex64>().unwrap();
 
@@ -203,7 +226,7 @@ fn sampled_zero_patch_is_represented_as_zero() {
     )
     .unwrap();
 
-    assert_eq!(result.len(), 1);
+    assert_eq!(result.partitioned_tt().len(), 1);
     assert_eq!(dense_f64(&result), vec![0.0; 4]);
 }
 
@@ -235,7 +258,7 @@ fn extracts_full_diagonal_pivots_for_recycling() {
 #[test]
 fn incompatible_recycled_pivots_are_replenished_for_nonzero_child() {
     let sites = binary_sites(3);
-    let projector = projector([(sites[0].clone(), 1)]);
+    let projector = Projector::from_pairs([(sites[0].clone(), 1)]).unwrap();
     let active = active_positions(&sites, &projector);
     let recycled = vec![vec![0, 0, 0], vec![0, 1, 1]];
     let mut rng = StdRng::seed_from_u64(7);
@@ -262,7 +285,7 @@ fn incompatible_recycled_pivots_are_replenished_for_nonzero_child() {
 fn projected_middle_sites_use_compact_structured_storage() {
     let sites = binary_sites(3);
     let active = vec![0, 2];
-    let projector = projector([(sites[1].clone(), 1)]);
+    let projector = Projector::from_pairs([(sites[1].clone(), 1)]).unwrap();
     let active_tt = tensor4all_simplett::SimpleTensorTrain::new(vec![
         tensor3_from_data(vec![1.0, 2.0, 3.0, 4.0], 1, 2, 2).unwrap(),
         tensor3_from_data(vec![5.0, 6.0, 7.0, 8.0], 2, 2, 1).unwrap(),
@@ -285,6 +308,191 @@ fn projected_middle_sites_use_compact_structured_storage() {
         .collect();
     let dense = contract(&tensors).unwrap().to_vec::<f64>().unwrap();
     assert_eq!(dense, vec![0.0, 0.0, 23.0, 34.0, 0.0, 0.0, 31.0, 46.0]);
+}
+
+#[test]
+fn cache_split_moves_entries_to_one_child_for_every_split_position() {
+    let dims = vec![2, 3, 2];
+    let mut parent = PatchCache::new(dims.clone());
+    for i in 0..dims[0] {
+        for j in 0..dims[1] {
+            for k in 0..dims[2] {
+                parent.entries.insert(vec![i, j, k], 100 * i + 10 * j + k);
+            }
+        }
+    }
+
+    for (split_pos, &child_count) in dims.iter().enumerate() {
+        let children = parent.clone().split(split_pos, child_count).unwrap();
+        assert_eq!(children.len(), child_count);
+        assert_eq!(
+            children
+                .iter()
+                .map(|cache| cache.entries.len())
+                .sum::<usize>(),
+            parent.entries.len()
+        );
+        for (child, cache) in children.iter().enumerate() {
+            for (local, &value) in &cache.entries {
+                let mut full = local.clone();
+                full.insert(split_pos, child);
+                assert_eq!(parent.entries.get(&full), Some(&value));
+            }
+        }
+    }
+}
+
+#[test]
+fn cache_split_keeps_sibling_maps_independent() {
+    let mut parent = PatchCache::new(vec![2, 2]);
+    parent.entries.insert(vec![0, 0], 1);
+    parent.entries.insert(vec![1, 1], 2);
+    let mut children = parent.split(0, 2).unwrap();
+
+    children[0].entries.clear();
+
+    assert!(children[0].entries.is_empty());
+    assert_eq!(children[1].entries.get(&vec![1]), Some(&2));
+}
+
+#[test]
+fn child_cache_hits_inherited_samples_but_not_sibling_samples() {
+    let sites = binary_sites(2);
+    let mut parent = PatchCache::new(vec![2, 2]);
+    parent.entries.insert(vec![0, 1], 7.0_f64);
+    parent.entries.insert(vec![1, 0], 8.0_f64);
+    let mut children = parent.split(0, 2).unwrap();
+    let calls = Cell::new(0);
+    let function = |full: &MultiIndex| {
+        calls.set(calls.get() + 1);
+        (10 * full[0] + full[1]) as f64
+    };
+    let projector = Projector::from_pairs([(sites[0].clone(), 0)]).unwrap();
+    let evaluator = PatchEvaluator::<_, _, fn(&[MultiIndex]) -> Vec<f64>>::new(
+        &function,
+        None,
+        &[1],
+        &projector,
+        &sites,
+        children.remove(0),
+    )
+    .unwrap();
+
+    assert_eq!(evaluator.eval(&vec![1]), 7.0);
+    assert_eq!(
+        calls.get(),
+        0,
+        "the matching parent sample must be inherited"
+    );
+    assert_eq!(evaluator.eval(&vec![0]), 0.0);
+    assert_eq!(calls.get(), 1, "a sibling-only sample must be re-evaluated");
+}
+
+#[test]
+fn batch_cache_deduplicates_misses_and_restores_order() {
+    let sites = binary_sites(2);
+    let calls = Rc::new(RefCell::new(Vec::<Vec<MultiIndex>>::new()));
+    let recorded = Rc::clone(&calls);
+    let scalar = |index: &MultiIndex| (10 * index[0] + index[1]) as f64;
+    let batch = move |indices: &[MultiIndex]| {
+        recorded.borrow_mut().push(indices.to_vec());
+        indices
+            .iter()
+            .map(|index| (10 * index[0] + index[1]) as f64)
+            .collect()
+    };
+    let projector = Projector::new();
+    let evaluator = PatchEvaluator::new(
+        &scalar,
+        Some(&batch),
+        &[0, 1],
+        &projector,
+        &sites,
+        PatchCache::new(vec![2, 2]),
+    )
+    .unwrap();
+    let input = vec![vec![0, 1], vec![0, 1], vec![1, 0]];
+
+    assert_eq!(evaluator.eval_many(&input), vec![1.0, 1.0, 10.0]);
+    assert_eq!(calls.borrow().as_slice(), &[vec![vec![0, 1], vec![1, 0]]]);
+    assert_eq!(evaluator.eval_many(&input), vec![1.0, 1.0, 10.0]);
+    assert_eq!(calls.borrow().len(), 1);
+    assert_eq!(evaluator.into_cache().entries.len(), 2);
+}
+
+#[test]
+fn batch_cache_length_mismatch_is_reported_without_inserting() {
+    let sites = binary_sites(2);
+    let scalar = |_: &MultiIndex| 1.0_f64;
+    let batch = |_: &[MultiIndex]| vec![1.0_f64];
+    let projector = Projector::new();
+    let evaluator = PatchEvaluator::new(
+        &scalar,
+        Some(&batch),
+        &[0, 1],
+        &projector,
+        &sites,
+        PatchCache::new(vec![2, 2]),
+    )
+    .unwrap();
+
+    assert_eq!(
+        evaluator.eval_many(&[vec![0, 0], vec![1, 1]]),
+        vec![0.0, 0.0]
+    );
+    assert!(matches!(
+        evaluator.take_error(),
+        Some(PartitionedTTError::InvalidAdaptiveInterpolationInput(message))
+            if message.contains("cache misses")
+    ));
+    assert!(evaluator.into_cache().entries.is_empty());
+}
+
+#[cfg(feature = "adaptive-hataori-mpi")]
+#[test]
+fn malformed_wire_cores_are_rejected_before_reconstruction() {
+    let valid = || WireCore {
+        dims: [1, 2, 1],
+        data: vec![1.0_f64, 2.0],
+    };
+    let cases = vec![
+        vec![valid()],
+        vec![
+            WireCore {
+                dims: [usize::MAX, 2, 1],
+                data: Vec::new(),
+            },
+            valid(),
+        ],
+        vec![
+            WireCore {
+                dims: [1, 2, 1],
+                data: vec![1.0],
+            },
+            valid(),
+        ],
+        vec![
+            WireCore {
+                dims: [1, 3, 1],
+                data: vec![1.0, 2.0, 3.0],
+            },
+            valid(),
+        ],
+    ];
+    for cores in cases {
+        let outcome = WirePatchOutcome::Accepted(WireAcceptedPatch {
+            path: Vec::new(),
+            active_positions: vec![0, 1],
+            cache: PatchCache::new(vec![2, 2]),
+            data: WireAcceptedData::Active(cores),
+        });
+        let sites = binary_sites(2);
+        let error = patch_outcome_from_wire(outcome, &sites, &sites).unwrap_err();
+        assert!(matches!(
+            error,
+            PartitionedTTError::DistributedAdaptiveInterpolation(_)
+        ));
+    }
 }
 
 #[test]
@@ -431,13 +639,102 @@ fn rejects_invalid_patch_order_and_pivots() {
     }
 }
 
+#[cfg(feature = "adaptive-hataori-rayon")]
+#[test]
+fn hataori_outer_matches_sequential_and_allows_nested_rayon() {
+    let sites = binary_sites(1);
+    let function = |index: &MultiIndex| (index[0] + 1) as f64;
+    let options = AdaptiveInterpolateOptions {
+        tci_options: TCI2Options {
+            seed: Some(11),
+            ..TCI2Options::default()
+        },
+        ..AdaptiveInterpolateOptions::default()
+    };
+    let sequential = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        function,
+        None,
+        sites.clone(),
+        Vec::new(),
+        options.clone(),
+    )
+    .unwrap();
+
+    // One explicit worker keeps this nested-pool contract test independent of
+    // workspace-wide nextest process parallelism and host thread limits.
+    let workers = 1;
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(workers)
+            .build()
+            .unwrap(),
+    );
+    let domain =
+        hataori::Domain::external(Arc::clone(&pool), (0..workers).collect(), workers).unwrap();
+    let nested = Arc::new(AtomicBool::new(false));
+    let nested_for_callback = Arc::clone(&nested);
+    let parallel_function = move |index: &MultiIndex| {
+        let (left, right) = rayon::join(
+            || rayon::current_thread_index().is_some(),
+            || rayon::current_thread_index().is_some(),
+        );
+        nested_for_callback.fetch_or(left && right, Ordering::Relaxed);
+        function(index)
+    };
+    let parallel = adaptiveinterpolate_in::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        &domain,
+        parallel_function,
+        None,
+        sites,
+        Vec::new(),
+        options,
+    )
+    .unwrap();
+
+    assert!(nested.load(Ordering::Relaxed));
+    assert_eq!(parallel.patch_caches()[0].get(&[0]), Some(&1.0));
+    assert_eq!(parallel.patch_caches()[0].get(&[1]), Some(&2.0));
+    assert_eq!(
+        parallel.patch_caches()[0].len(),
+        sequential.patch_caches()[0].len()
+    );
+    let sequential_projectors: HashSet<_> = sequential
+        .patch_caches()
+        .iter()
+        .map(|cache| cache.projector().clone())
+        .collect();
+    let parallel_projectors: HashSet<_> = parallel
+        .patch_caches()
+        .iter()
+        .map(|cache| cache.projector().clone())
+        .collect();
+    assert_eq!(parallel_projectors, sequential_projectors);
+}
+
+#[cfg(feature = "adaptive-hataori-rayon")]
+#[test]
+fn hataori_entry_rejects_a_sequential_domain() {
+    let error = adaptiveinterpolate_in::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
+        &hataori::Domain::sequential(),
+        |_| 1.0,
+        None,
+        binary_sites(2),
+        Vec::new(),
+        AdaptiveInterpolateOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        PartitionedTTError::HataoriLocal {
+            source: hataori::MapInError::MissingPool,
+            ..
+        }
+    ));
+}
+
 #[test]
 fn numerically_zero_child_patch_is_accepted_not_crash_issue598() {
-    // Regression test for issue #598: a 2D fused-quantics Gaussian mixture
-    // whose child patches decay below floating-point resolution used to make
-    // TCI2 empty its pivot sets and fail with "Dimension mismatch: tensor at
-    // site 5 has incompatible dimensions". The zero (sub)domain must be
-    // accepted as a rank-one patch instead.
     const WEIGHTS: [f64; 3] = [1.3, 0.9, 0.9];
     const ALPHAS: [f64; 3] = [2.8, 5.4, 0.7];
     const CENTERS: [(f64, f64); 3] = [(0.4, 0.1), (3.8, -0.8), (-5.5, -2.1)];
@@ -483,8 +780,8 @@ fn numerically_zero_child_patch_is_accepted_not_crash_issue598() {
     )
     .expect("adaptiveinterpolate must accept every patch, including near-zero ones");
 
-    // The patches must cover the full domain with a valid global tensor train.
     let tt = result
+        .partitioned_tt()
         .to_tensor_train()
         .expect("valid combined tensor train");
     let _ = tt.bond_dims();

--- a/crates/tensor4all-partitionedtt/src/error.rs
+++ b/crates/tensor4all-partitionedtt/src/error.rs
@@ -78,6 +78,40 @@ pub enum PartitionedTTError {
     #[error("Tensor cross interpolation error: {0}")]
     TensorCrossInterpolation(#[from] tensor4all_tensorci::TCIError),
 
+    /// Error from rank-local Hataori patch scheduling.
+    #[cfg(feature = "adaptive-hataori-rayon")]
+    #[error("Hataori patch scheduling failed at path {path:?}: {source}")]
+    HataoriLocal {
+        /// Patch path when the scheduling error identifies one input.
+        path: Option<Vec<usize>>,
+        /// Original Hataori diagnostic.
+        #[source]
+        source: hataori::MapInError,
+    },
+
+    /// Error from MPI Hataori patch scheduling.
+    #[cfg(feature = "adaptive-hataori-mpi")]
+    #[error("MPI Hataori patch scheduling failed: {source}")]
+    HataoriMpiPmap {
+        /// Original converged Hataori diagnostic.
+        #[source]
+        source: hataori::PmapError,
+    },
+
+    /// Error from an MPI Hataori placement collective.
+    #[cfg(feature = "adaptive-hataori-mpi")]
+    #[error("MPI Hataori placement failed: {source}")]
+    HataoriMpiPlacement {
+        /// Original converged Hataori diagnostic.
+        #[source]
+        source: hataori::PlacementError,
+    },
+
+    /// Adaptive interpolation failure converged across MPI ranks.
+    #[cfg(feature = "adaptive-hataori-mpi")]
+    #[error("Distributed adaptive interpolation failed: {0}")]
+    DistributedAdaptiveInterpolation(String),
+
     /// Invalid site-index or pivot input for adaptive interpolation
     #[error("Invalid adaptive interpolation input: {0}")]
     InvalidAdaptiveInterpolationInput(String),

--- a/crates/tensor4all-partitionedtt/src/lib.rs
+++ b/crates/tensor4all-partitionedtt/src/lib.rs
@@ -27,7 +27,14 @@ mod subdomain_tt;
 #[cfg(test)]
 mod test_utils;
 
-pub use adaptive_interpolation::{adaptiveinterpolate, AdaptiveInterpolateOptions};
+#[cfg(feature = "adaptive-hataori-rayon")]
+pub use adaptive_interpolation::adaptiveinterpolate_in;
+#[cfg(feature = "adaptive-hataori-mpi")]
+pub use adaptive_interpolation::adaptiveinterpolate_mpi;
+pub use adaptive_interpolation::{
+    adaptiveinterpolate, AcceptedPatchCache, AdaptiveInterpolateOptions,
+    AdaptiveInterpolationResult,
+};
 pub use contract::{contract, proj_contract};
 pub use error::{PartitionedTTError, Result};
 pub use partitioned_tt::PartitionedTT;

--- a/docs/design/adaptive-tci-parallel-execution.md
+++ b/docs/design/adaptive-tci-parallel-execution.md
@@ -1,0 +1,381 @@
+# Parallel adaptive TCI patch execution
+
+## Status and scope
+
+This document specifies parallel execution for
+`tensor4all-partitionedtt::adaptiveinterpolate`. It does not change the TCI2
+algorithm or the mathematical patch partition. Hataori schedules independent
+patches; TCI2 continues to process one patch at a time.
+
+`tensor4all-partitionedtt` is otherwise behavior-frozen during the
+`tensor4all-partitionedtreetn` migration. Adaptive interpolation is explicitly
+excluded from that successor's migration scope, so this user-approved change
+stays with the existing adaptive-interpolation owner rather than introducing a
+second implementation in the TreeTN crate.
+
+The required behavior is:
+
+- Rayon is the default rank-local scheduler when Hataori support is enabled;
+- Hataori and MPI remain optional dependencies/features;
+- Rayon work inside a patch may be nested under Rayon patch-level work;
+- a rejected parent's sample cache is transferred to its children;
+- each child receives only samples belonging to that child; and
+- accepted-patch caches are returned with the interpolation result.
+
+## Cargo features
+
+Use one optional dependency and two additive crate features:
+
+```toml
+[features]
+default = ["tenferro-cpu-faer", "adaptive-hataori-rayon"]
+adaptive-hataori-rayon = ["dep:hataori", "hataori/rayon"]
+adaptive-hataori-mpi = [
+    "adaptive-hataori-rayon",
+    "hataori/mpi",
+    "dep:mpi",
+    "dep:serde",
+    "num-complex/serde",
+]
+
+[dependencies]
+hataori = { git = "https://github.com/shinaoka/hataori-rs.git", rev = "59d0ccd6b403e285b7e716a8ae6d12d851da13b1", default-features = false, optional = true }
+mpi = { version = "=0.8.1", default-features = false, optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+```
+
+Thus `--no-default-features` does not build Hataori, while an ordinary build has
+rank-local Rayon execution available. MPI is never enabled by default.
+`adaptive-hataori-mpi` must use the same upstream `mpi` package/version as
+Hataori when naming the communicator trait.
+
+An `rsmpi-rt` forwarding feature is deliberately deferred. It can be added as a
+mutually exclusive sibling of `adaptive-hataori-mpi` when a runtime-loaded MPI
+consumer is ready to test it.
+
+## Public entry points
+
+Keep the existing sequential entry-point name for minimal and
+no-default-feature builds, but change its return type to
+`AdaptiveInterpolationResult<T>` so the required caches are returned uniformly.
+It uses the same wave processor and per-path seed derivation as parallel modes,
+with a sequential scheduler. Add feature-gated entry points rather than putting
+feature-dependent bounds on the existing function:
+
+```rust
+#[cfg(feature = "adaptive-hataori-rayon")]
+pub fn adaptiveinterpolate_in<T, F, B>(
+    domain: &hataori::Domain,
+    f: F,
+    batched_f: Option<B>,
+    site_indices: Vec<DynIndex>,
+    initial_pivots: Vec<MultiIndex>,
+    options: AdaptiveInterpolateOptions,
+) -> Result<AdaptiveInterpolationResult<T>>
+where
+    T: /* existing scalar bounds */ + Send + Sync,
+    F: Fn(&MultiIndex) -> T + Send + Sync,
+    B: Fn(&[MultiIndex]) -> Vec<T> + Send + Sync;
+```
+
+The Hataori domain is explicit. Tensor4all must not create a hidden Rayon pool,
+guess CPU affinity, or establish a second threading policy. Rank-local patch
+execution always uses `hataori::LocalMode::Outer`. The domain must be backed by
+a Rayon pool. Call `adaptiveinterpolate_in` from outside a Rayon worker or from
+within that same domain's pool; Hataori rejects a sequential domain with
+`MissingPool` and a foreign pool worker with `ForeignPool`.
+
+The MPI entry point is collective and returns the result only on `root`, matching
+`hataori::pmap`:
+
+```rust
+#[cfg(feature = "adaptive-hataori-mpi")]
+pub fn adaptiveinterpolate_mpi<C, T, F, B>(
+    world: &C,
+    domain: &hataori::Domain,
+    root: i32,
+    f: F,
+    batched_f: Option<B>,
+    site_indices: Vec<DynIndex>,
+    initial_pivots: Vec<MultiIndex>,
+    options: AdaptiveInterpolateOptions,
+) -> Result<Option<AdaptiveInterpolationResult<T>>>
+where
+    C: mpi::traits::Communicator,
+    T: /* local bounds */ + serde::Serialize + serde::de::DeserializeOwned,
+    F: Fn(&MultiIndex) -> T + Send + Sync,
+    B: Fn(&[MultiIndex]) -> Vec<T> + Send + Sync;
+```
+
+Every rank supplies equivalent callbacks and metadata. Only the root supplies
+pending work. Invalid common input is rejected collectively before the first
+patch wave. Every rank passes its own pool-backed, id-zero `Domain`; the call
+originates on the MPI main thread outside any Rayon worker, and MPI must provide
+`MPI_THREAD_FUNNELED` or stronger, matching Hataori preflight.
+
+All three entry points return the same result shape:
+
+```text
+AdaptiveInterpolationResult<T> {
+    partitioned_tt: PartitionedTT,
+    patch_caches: Vec<AcceptedPatchCache<T>>,
+}
+```
+
+The result owns the final per-patch caches. It provides `partitioned_tt()`,
+`patch_caches()`, and `into_parts()` accessors. Each returned cache is paired
+with exactly one accepted projector and provides local lookup, `len()`,
+`is_empty()`, `clear()`, and retained-entry statistics. This replaces the old
+bare-`PartitionedTT` adaptive return rather than adding a second parallel-only
+result convention. The same branch updates all affected rustdoc, tests,
+`crates/tensor4all-partitionedtt/README.md`, generated API references, and
+`skills/use-tensor4all-rs/references/{recipes,crates}.md`; no stale bare-result
+examples remain.
+
+## Stable patch identity
+
+Represent a pending patch by its path in the subdivision tree:
+
+```text
+PendingPatch<T> {
+    path: Vec<usize>,
+    recycled_pivots: Vec<MultiIndex>,
+    cache: PatchCache<T>,
+}
+```
+
+`path[d]` is the selected value of `patch_order[d]`. Because adaptive splitting
+always selects the first unprojected index in `patch_order`, the path reconstructs
+the full `Projector` without serializing `DynIndex` or matching indices by ID.
+Full index identity remains local in `site_indices` and `patch_order`.
+
+The path also supplies a schedule-independent RNG seed. All entry points,
+including the no-default-feature sequential entry point, derive each patch seed
+from the configured root seed and all path coordinates with one fixed documented
+integer mixer. The implementation uses SplitMix64: initialize with
+`splitmix64(root_seed ^ 0x6a09e667f3bcc909)`, then for every `(depth, value)`
+apply `splitmix64(state ^ rotate_left(depth as u64, 32) ^ value as u64)`. TCI's
+inner seed is one further `splitmix64` application. Do not use `DefaultHasher`,
+whose stability is not a contract. This intentionally replaces the legacy
+single RNG stream so sequential, Rayon, and MPI modes generate identical
+candidates independent of completion order.
+
+## Wavefront scheduling
+
+Replace the sequential FIFO loop with breadth-first waves:
+
+1. The root starts with the empty-path patch and an empty cache.
+2. Process every patch in the current wave with Hataori.
+3. Preserve input order in the returned outcomes.
+4. Append accepted patches and their returned caches to the result; append
+   rejected patches' children to the next wave, in path order.
+5. Stop when the next wave is empty.
+
+The rank-local implementation uses:
+
+```text
+hataori::map_in(domain, LocalMode::Outer, wave, process_patch)
+```
+
+The MPI implementation uses one collective `hataori::pmap` per wave with
+`batch_size = 1` and `LocalMode::Outer`. Unit batches let remote ranks receive
+small child waves instead of allowing the root's local batch to consume every
+child; nested Rayon work inside each patch still uses the supplied domain pool.
+After `pmap` returns, root
+returns, root performs every fallible root-only step for that wave, including
+wire-core reconstruction, cache/result alignment, next-wave construction, and,
+for the last wave, `PartitionedTT::from_subdomains`. Root then broadcasts one
+serializable control result:
+
+```text
+WaveControl = Continue | Stop | Fail(WireAdaptiveError)
+```
+
+Every rank consumes this control before either entering another `pmap` or
+returning. `Fail` preserves the diagnostic message and maps it to the public
+`DistributedAdaptiveInterpolation` error category on every rank; patch paths
+are included when the originating diagnostic provides one. `Stop` is
+broadcast only after final root validation succeeds. Thus no root-side failure
+window can leave non-root ranks in the next collective or return success on
+only part of the communicator. Any failure returns no partial partition or
+cache.
+
+Breadth-first waves preserve the current FIFO subdivision order. Final accepted
+patches are sorted by `path` before constructing `PartitionedTT`, making output
+order independent of scheduling.
+
+## Nested Rayon contract
+
+`LocalMode::Outer` executes different patches in parallel. A patch callback may
+itself use Rayon (`join`, `scope`, or parallel iterators). Because Hataori enters
+the supplied domain pool before invoking the callback, nested Rayon work uses
+the same pool and work-stealing scheduler; Tensor4all must not create another
+pool or divide the thread count manually.
+
+This is intentional nested parallelism. It avoids oversubscription as long as
+inner work remains on the current Rayon pool. Callbacks that create their own
+thread pools are outside the contract.
+
+## Patch-owned sample cache
+
+Add one private cache owned by each pending patch:
+
+```text
+PatchCache<T> {
+    active_dims: Vec<usize>,
+    entries: HashMap<MultiIndex, T>,
+}
+```
+
+Keys use coordinates of the patch's active sites in their existing order. A
+pending cache moves into either its children or the accepted result; it is never
+silently dropped at a scheduling boundary. Its size is naturally bounded by the
+finite patch volume and the number of distinct points requested by TCI2. No
+global or thread-local cache is introduced.
+
+All evaluations for a patch go through one cache wrapper, including:
+
+- seeded candidate checks;
+- scalar TCI2 evaluations;
+- batch TCI2 evaluations; and
+- final site-tensor and global-pivot evaluations.
+
+For a batch, look up and deduplicate keys first, call the user batch callback
+only for misses, validate the returned length, then insert and restore the
+original order. Do not hold a cache lock while executing user code. A
+patch-local lock is sufficient for the `Fn` callback required by TCI2; caches
+are never shared between concurrently scheduled patches.
+
+## One-pass cache projection on split
+
+When a parent fixes active coordinate `split_pos` with dimension `m`, consume
+the parent cache and partition it into all `m` child caches in one pass:
+
+```text
+split_cache(parent, split_pos, m):
+    children = m empty caches with the split dimension removed
+    for (key, value) in parent.entries:
+        child = key[split_pos]
+        child_key = key with coordinate split_pos removed
+        children[child].insert(child_key, value)
+    return children
+```
+
+Mathematically, child `v` receives exactly
+
+```text
+C_v = { (x without split_pos, y) | (x, y) in C_parent
+                                      and x[split_pos] = v }.
+```
+
+Therefore every parent entry follows exactly one edge of the split tree. No
+entry is copied to a sibling, and no child receives a sample outside its patch.
+The operation is `O(number of parent entries)` plus child allocation, rather
+than scanning the parent once per child.
+
+The same child-construction loop must zip together:
+
+- child path;
+- reconstructed projector value;
+- projected cache bucket; and
+- compatible recycled pivots.
+
+This keeps projector, cache, and pivot projection on one canonical split path.
+Malformed cache keys or out-of-range split coordinates are internal invariant
+errors, not silently dropped entries.
+
+## Returned per-patch caches
+
+An accepted worker outcome contains its path, TT cores, and the final
+`PatchCache<T>`. The root returns these caches as a collection aligned one-to-one
+with the accepted `SubDomainTT`s. There is no shared parent cache and no cache
+stored on the subdivision tree.
+
+```text
+AcceptedPatchCache<T> {
+    projector: Projector,
+    active_positions: Vec<usize>,
+    cache: PatchCache<T>,
+}
+```
+
+A split physically consumes the parent's map and creates independent child
+maps. Each entry is moved into exactly one child map; siblings share neither the
+map nor its entries. The subdivision path is only stable patch identity and MPI
+metadata, not cache storage or cache lookup machinery.
+
+`into_parts()` returns the `PartitionedTT` and the aligned cache collection
+without copying entries. A global full-index lookup index is deferred; add one
+only if a measured caller needs it.
+
+## MPI wire representation
+
+Hataori serializes work and outcomes, but closures remain rank-local. Keep wire
+types private:
+
+- pending path, recycled pivots, and `PatchCache<T>` are serialized directly;
+- a rejected outcome returns child pending patches;
+- an accepted outcome returns the path, its final `PatchCache<T>`, and TT cores
+  as column-major core buffers plus their three dimensions.
+
+The accepted wire form serializes only TT parameters, not the full dense tensor.
+The root reconstructs each core through existing `tensor3_from_data` and embeds
+it with the projector reconstructed from the path. Shape products and wire
+lengths are checked before allocation. No public tensor serialization format is
+created by this feature.
+
+## Error and cancellation semantics
+
+- Callback values must describe the same deterministic function on every rank.
+- Batch length mismatches remain typed adaptive/TCI errors.
+- Hataori scheduling, wire, or collective failures are wrapped with their patch
+  path and preserved as the source of `PartitionedTTError`.
+- After any wave failure, no later wave starts and no partial result is returned.
+- MPI ranks converge on the same failure through Hataori before leaving the
+  collective entry point.
+
+## Verification matrix
+
+Required focused tests:
+
+1. the public sequential entry point and `adaptiveinterpolate_in` agree
+   numerically, have identical projector paths, and use identical per-path
+   candidates for a problem that splits more than once;
+2. nested Rayon work inside `process_patch` completes on the supplied domain
+   without creating another pool;
+3. one-pass cache projection sends every entry to exactly one child and removes
+   the fixed coordinate from its key;
+4. child evaluation hits inherited in-patch samples and re-evaluates samples
+   belonging to siblings;
+5. cache projection works when the split site is first, middle, or last among
+   active sites;
+6. fixed seed results are independent of Rayon scheduling order;
+7. invalid common MPI input is rejected collectively before the first wave;
+8. batch-cache lookup deduplicates misses, calls the user callback only for
+   misses, validates returned length, and restores input order; the mismatch
+   path returns no partial result;
+9. `--no-default-features` builds without Hataori;
+10. the default feature set builds Rayon support without MPI;
+11. returned caches are aligned one-to-one with accepted patches, have distinct
+    map allocations, contain no sibling-only samples, and correctly implement
+    `clear()` and retained-entry statistics;
+12. malformed wire core shape products and payload lengths are rejected before
+    root allocation/reconstruction and the failure converges on every rank;
+13. the MPI feature build and a multi-rank smoke test agree with rank-local
+    execution, including a split whose accepted TT and cache are returned from
+    a worker;
+14. fixed-seed results are independent of MPI completion order;
+15. callback, malformed wire, root post-processing, and batch-length failures
+    return no partial partition or cache on any rank.
+
+Performance evidence should report patch counts, cache hits, newly evaluated
+samples, and wall time for sequential, Rayon, and MPI runs. It must also confirm
+that cache projection is linear in retained entries and that MPI transfers TT
+core parameters rather than dense-domain values.
+
+## Deferred work
+
+Do not add a general executor trait, global cache, work-stealing patch queue, or
+cache eviction policy in the first implementation. Hataori already owns
+scheduling, and breadth-first waves are sufficient until measurements show a
+load-balance problem that bounded prefetch cannot address.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -18,6 +18,7 @@
 | Document | Description |
 |----------|-------------|
 | [adaptive-tci-interpolation.md](./adaptive-tci-interpolation.md) | Adaptive TCI patching, convergence, pivot recycling, and structured embedding |
+| [adaptive-tci-parallel-execution.md](./adaptive-tci-parallel-execution.md) | Optional Hataori/Rayon/MPI patch scheduling and one-pass cache projection |
 | [partitionedtt-projector-invariants.md](./partitionedtt-projector-invariants.md) | Issue #634 design for coherent projector identity, validation, and transactional PartitionedTT mutation |
 | [partitioned-treetn.md](./partitioned-treetn.md) | Issue #648 migration design for TreeTN-native eager partitioning and adaptive patching |
 | [gse-chain-mps-algorithm.md](./gse-chain-mps-algorithm.md) | Chain MPS global subspace expansion analysis for TreeTN GSE-TDVP planning |

--- a/docs/worklogs/2026-08-25-adaptive-hataori-parallelism.md
+++ b/docs/worklogs/2026-08-25-adaptive-hataori-parallelism.md
@@ -1,0 +1,193 @@
+# Adaptive Hataori parallelism work log
+
+## Scope
+
+Design and implement optional Hataori scheduling for adaptive TCI patches,
+with default rank-local Rayon, optional MPI, physical one-pass child-cache
+partitioning, and returned per-patch caches.
+
+## Documents and code reviewed
+
+- `docs/design/adaptive-tci-interpolation.md`
+- `docs/design/adaptive-tci-parallel-execution.md`
+- `crates/tensor4all-partitionedtt/src/adaptive_interpolation.rs`
+- `crates/tensor4all-partitionedtt/src/adaptive_interpolation/tests.rs`
+- `crates/tensor4all-partitionedtt/Cargo.toml`
+- Hataori `Domain`, `LocalMode`, `map_in`, `pmap`, placement, and Cargo features
+- Workspace and repository rules for public APIs, caches, performance, and tests
+
+## Design decisions
+
+- Hataori is an optional dependency enabled by the default
+  `adaptive-hataori-rayon` feature; MPI is a separate default-off feature.
+- Hataori receives explicit caller-owned domains. Rank-local patch scheduling
+  uses `LocalMode::Outer`, allowing intentional nested Rayon work in the same
+  pool.
+- A split consumes its parent cache and moves every entry to exactly one child
+  cache in one pass. Parent and sibling maps are not shared.
+- Accepted caches are returned one-to-one with accepted `SubDomainTT`s.
+- MPI processes breadth-first waves. Root broadcasts a fallible `WaveControl`
+  only after all root post-processing and final validation, preventing rank
+  divergence between collectives.
+- All execution modes derive deterministic per-patch seeds from the root seed
+  and stable patch path.
+
+## Pre-implementation reviewer gate
+
+Selected reviewer: `reviewer-flash` (read-only, high thinking).
+
+### Round 1
+
+Verdict: **Changes required**.
+
+Findings:
+
+1. Root post-wave reconstruction/final-validation errors were outside a
+   collective and could deadlock or desynchronize MPI ranks.
+2. The public `mpi::traits::Communicator` bound needed a direct optional
+   `mpi = 0.8.1` dependency.
+3. Sequential/Rayon seed equivalence and the intentional legacy RNG change
+   needed to be explicit.
+4. MPI domain, main-thread, and `MPI_THREAD_FUNNELED` requirements were missing.
+5. Collective input, batch-cache, wire validation, cache stats, and MPI
+   determinism tests were missing from the matrix.
+6. The bare `PartitionedTT` return-type migration and documentation consumers
+   were ambiguous.
+7. `MissingPool`/`ForeignPool` entry restrictions were undocumented.
+
+All findings were corrected in
+`docs/design/adaptive-tci-parallel-execution.md`.
+
+### Round 2
+
+Verdict: **Correct-to-merge**.
+
+The reviewer verified all seven corrections against current Hataori,
+mpi-0.8.1, and tensor4all sources. It also reconfirmed that physical one-pass
+cache splitting and accepted-cache return remain intact. Non-blocking
+implementation notes: root post-processing must remain panic-free or abort the
+MPI communicator on panic, and the exact stable integer seed mixer must be
+pinned and documented before merge.
+
+## Verification
+
+Design-only checks completed so far:
+
+- `git diff --check`
+- design index link exists
+- pre-implementation cross-model reviewer verdict recorded
+
+## Implementation status
+
+Implemented in `tensor4all-partitionedtt`:
+
+- uniform `AdaptiveInterpolationResult<T>` and returned
+  `AcceptedPatchCache<T>` values;
+- patch-owned deduplicating scalar/batch evaluation cache;
+- physical one-pass cache partitioning with moved, sibling-isolated maps;
+- deterministic SplitMix64-derived per-path candidate and TCI seeds;
+- sequential breadth-first waves and Hataori `LocalMode::Outer` Rayon waves;
+- default `adaptive-hataori-rayon` and default-off
+  `adaptive-hataori-mpi` Cargo features;
+- private column-major TT-core MPI wire representation with checked shape
+  products and payload lengths;
+- collective validation, `pmap` waves, root-only reconstruction, fallible
+  `WaveControl`, root-only result, and communicator abort on root panic;
+- MPI f64 and Complex64 serialization plus a multi-rank smoke program.
+
+The upstream-MPI build needed
+`BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include` in this
+checkout because clang did not find GCC's `stddef.h` automatically. This is an
+environment workaround, not a source or CI requirement.
+
+## Verification in progress
+
+Passed so far:
+
+- focused default release tests: 116 tests;
+- focused MPI-feature release tests: 117 tests;
+- default focused clippy;
+- Hataori-absent feature graph and build with
+  `--no-default-features --features tenferro-cpu-faer`;
+- two-rank MPI smoke, including remote patch evaluation, accepted TT/cache
+  return, completion-order determinism, Complex64 wire values, and collective
+  invalid-input rejection;
+- partitionedtt rustdoc tests.
+
+Full workspace gates passed: workspace clippy, 2,740 nextest tests,
+843 rustdoc tests, mdBook tests, rustdoc build, formatting, and repository-rules
+dry run. The two-rank MPI smoke passed with exit status 0.
+
+## Post-implementation reviewer gate
+
+Selected reviewer: `reviewer-flash` (read-only, high thinking). It inspected the
+full tracked and untracked worktree diff plus the pinned Hataori source.
+
+Verdict: **Correct-to-merge**. No block or major findings.
+
+Three minor findings were addressed before final validation:
+
+1. The design now matches the implemented converged distributed-error category
+   and diagnostic-message behavior.
+2. The exact SplitMix64 path-seed formula is pinned in the design and source.
+3. A direct callback-count test proves that a child hits its inherited cache but
+   re-evaluates a sample retained only by its sibling.
+
+## Origin-main synchronization
+
+Before PR preparation, the branch was recreated from current `origin/main`
+(`a15d30c57e86b478132de56137dd1ce930696bc7`). That base included the
+`IdxTensor`/TreeTN ownership migration and the issue #598 adaptive-interpolation
+regression. The implementation was integrated with the new owner types:
+accepted simple TTs are converted through `tensor_train_to_treetn`, embedding
+uses `TreeTN<IdxTensor, usize>`, fallible projector/subdomain construction is
+preserved, `Option<usize>` bond caps are used, and the upstream issue #598 test
+remains present. Focused, MPI, and full workspace gates were rerun after this
+integration.
+
+The synchronized full diff was re-reviewed by `reviewer-flash` (read-only,
+high thinking). Verdict: **Correct-to-merge**, with no block or major findings.
+Its one new minor defensive finding was fixed: MPI accepted-wire validation now
+rejects incorrect core counts and per-core site dimensions before allocation or
+TreeTN reconstruction, with direct malformed-wire coverage.
+
+## Final verification
+
+All required local gates passed after the final corrections and base sync:
+
+- `cargo fmt --all -- --check` and `git diff --check`;
+- `cargo clippy --workspace --all-targets -- -D warnings`;
+- 135 default focused release tests;
+- 136 MPI-feature focused release tests and MPI-feature clippy;
+- Hataori-absent build and dependency graph with
+  `--no-default-features --features tenferro-cpu-faer`;
+- two-rank MPI smoke (`mpi_smoke_exit=0`), including remote evaluation,
+  completion-order repeat, f64/Complex64 wire values, root-only result, and
+  collective invalid-input failure;
+- 3,195 workspace nextest tests (17 skipped by existing configuration);
+- 936 workspace rustdoc tests;
+- all mdBook tests;
+- workspace rustdoc build (only pre-existing warnings in core and
+  quanticstransform);
+- repository-rules dry run and its 89 self-tests;
+- public-surface grep found no stale bare adaptive result usage.
+
+Hosted CI exposed two maintenance-gate issues and both were corrected:
+
+1. its all-feature panic audit enabled `adaptive-hataori-mpi` on a runner
+   without MPI, so the maintenance native-dependency step now installs OpenMPI
+   development/runtime packages, matching the feature's documented build
+   prerequisite;
+2. the public-error-doc audit required concrete variants on
+   `adaptiveinterpolate_mpi`, so its `# Errors` section now names placement,
+   pmap, and converged distributed-error variants and their conditions.
+
+Default lint, test, doctest, and coverage jobs do not enable the default-off MPI
+feature.
+
+Coverage impact attestation: the sequential queue implementation was replaced
+by the common wave/patch processor, not simply deleted. Replacement tests cover
+sequential, Rayon, MPI, exact 0/1-site paths, accepted/split/zero paths,
+first/middle/last cache projection, inherited hit and sibling miss, batch
+deduplication and error, wire validation, and collective failure. No coverage
+threshold or numerical tolerance was relaxed.

--- a/skills/use-tensor4all-rs/references/crates.md
+++ b/skills/use-tensor4all-rs/references/crates.md
@@ -189,7 +189,8 @@ Split a function's domain into non-overlapping projected patches, each its own T
   - `PatchingOptions { rtol: 1e-12, max_bond_dim: 100, patch_order: Vec<DynIndex>, split_strategy: ExactParameterGain }`.
   - `PatchSplitStrategy::{Sequential, ExactParameterGain (default)}` — `ExactParameterGain` forms + counts child cores to pick the smallest split; `Sequential` takes the first unprojected `patch_order` index.
 - Adaptive TCI interpolation — ports TCIAlgorithms.jl `adaptiveinterpolate` / `createpatch` / `_globalpivots`:
-  - `adaptiveinterpolate::<T, F, B>(f, batched_f: Option<B>, site_indices: Vec<DynIndex>, initial_pivots: Vec<MultiIndex>, AdaptiveInterpolateOptions) -> Result<PartitionedTT>`.
+  - `adaptiveinterpolate::<T, F, B>(f, batched_f: Option<B>, site_indices: Vec<DynIndex>, initial_pivots: Vec<MultiIndex>, AdaptiveInterpolateOptions) -> Result<AdaptiveInterpolationResult<T>>`; use `.partitioned_tt()` and `.patch_caches()`.
+  - Default feature `adaptive-hataori-rayon` provides `adaptiveinterpolate_in(&Domain, ...)` with `LocalMode::Outer`; `adaptive-hataori-mpi` is default-off and provides collective `adaptiveinterpolate_mpi`.
     - `f: &MultiIndex -> T` receives one **full, 0-based** multi-index (tensorci territory, not quanticstci).
     - `batched_f: Option<B>` with `B: Fn(&[MultiIndex]) -> Vec<T>` — same function, batched; pass `None` when batching is unavailable.
     - `initial_pivots` — full-domain, 0-based; empty allowed.

--- a/skills/use-tensor4all-rs/references/recipes.md
+++ b/skills/use-tensor4all-rs/references/recipes.md
@@ -270,7 +270,8 @@ assert!(*result.errors.last().unwrap() < 1e-10);
 
 `adaptiveinterpolate` runs TCI2 per patch and subdivides patches that miss the
 tolerance. Pivots are full-domain and **0-indexed** (tensorci territory, not
-quanticstci). The result is a `PartitionedTT`; `to_tensor_train()` recombines it.
+quanticstci). The result contains a `PartitionedTT` and one sample cache per
+accepted patch; `partitioned_tt().to_tensor_train()` recombines the patches.
 
 ```rust
 use tensor4all_core::contract;
@@ -288,9 +289,10 @@ let result = adaptiveinterpolate::<f64, _, fn(&[MultiIndex]) -> Vec<f64>>(
     vec![vec![1, 1]],                      // initial pivots where |f| is large
     AdaptiveInterpolateOptions::default(), // tci_options tol 1e-8, n_initial_pivots 5
 )?;
-assert_eq!(result.len(), 1);               // one patch covered the whole domain
+assert_eq!(result.partitioned_tt().len(), 1); // one patch covered the whole domain
+assert_eq!(result.patch_caches().len(), 1);
 
-let tt = result.to_tensor_train()?;
+let tt = result.partitioned_tt().to_tensor_train()?;
 let dense = contract(&[tt.tensor(0)?, tt.tensor(1)?])?;
 assert_eq!(dense.to_vec::<f64>()?, vec![1.0, 2.0, 2.0, 4.0]); // column-major
 # Ok::<(), Box<dyn std::error::Error>>(())


### PR DESCRIPTION
## Summary

- parallelize adaptive TCI patch waves with optional Hataori
- enable rank-local `LocalMode::Outer` Rayon scheduling by default while keeping Hataori removable with feature selection
- add default-off MPI wave scheduling with collective validation, checked private TT-core wire data, root-only results, and converged failures
- return one accepted sample cache per patch and physically partition parent caches among children in one pass
- preserve deterministic per-path sampling across sequential, Rayon, and MPI execution

## Design and ownership

Canonical design: `docs/design/adaptive-tci-parallel-execution.md`.

`tensor4all-partitionedtt` is otherwise behavior-frozen during the TreeTN migration. The existing migration design explicitly excludes adaptive interpolation from `tensor4all-partitionedtreetn`; this user-approved change therefore remains at the current adaptive-interpolation owner rather than creating a duplicate implementation.

## Cache contract

A split consumes the parent cache. Each retained entry is visited once, removes the fixed coordinate from its key, and moves into exactly one matching child map. Siblings share neither maps nor entries. Accepted caches are returned one-to-one with accepted projectors through `AdaptiveInterpolationResult<T>`.

## Features

- default: `adaptive-hataori-rayon`
- opt out: `--no-default-features --features tenferro-cpu-faer` (verified Hataori absent from the graph)
- default-off MPI: `adaptive-hataori-mpi`

## Review gates

Selected reviewer: read-only `reviewer-flash` (high thinking).

- pre-implementation design round 1: **Changes required**; all seven findings fixed
- pre-implementation design round 2: **Correct-to-merge**
- post-implementation full diff: **Correct-to-merge**, no block/major findings; all three minors fixed
- post-`origin/main` IdxTensor/TreeTN integration re-review: **Correct-to-merge**, no block/major findings; defensive wire core-count/site-dimension minor fixed

Full evidence is recorded in `docs/worklogs/2026-08-25-adaptive-hataori-parallelism.md`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --release -p tensor4all-partitionedtt` — 135 passed
- MPI-feature focused tests — 136 passed
- MPI-feature clippy — passed
- no-Hataori build and dependency graph — passed
- `mpiexec -n 2 target/release/examples/adaptive_mpi_smoke` — exit 0
  - remote patch evaluation and returned TT/cache
  - completion-order repeat
  - f64 and Complex64 wire values
  - collective invalid-input failure
- `cargo nextest run --release --workspace` — 3,195 passed, 17 existing skips
- `cargo test --doc --release --workspace` — 936 passed
- `./scripts/test-mdbook.sh` — passed
- `cargo doc --workspace --no-deps` — passed (pre-existing unrelated warnings only)
- repository-rules dry run — pass
- repository-rules script tests — 89 passed

The local upstream-MPI build required `BINDGEN_EXTRA_CLANG_ARGS=-I/usr/lib/gcc/x86_64-linux-gnu/13/include` because local clang did not discover GCC's `stddef.h`; this is an environment workaround, not a source requirement.

## Coverage impact attestation

The old sequential queue was replaced by the common wave/patch processor. Replacement coverage includes sequential, Rayon, MPI, exact 0/1-site paths, accepted/split/zero paths, first/middle/last cache projection, inherited hit and sibling miss, batch deduplication/error/order restoration, malformed wire metadata/core validation, collective validation/failure, issue #598, and f64/Complex64. No coverage threshold or numerical tolerance was relaxed.
