### PR TITLE
perf(treeaci): reduce redundant branched-tree work

### DIFF
--- a/crates/tensor4all-treeaci/Cargo.toml
+++ b/crates/tensor4all-treeaci/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 
 [features]
 default = ["tenferro-cpu-faer"]
+diagnostics = ["tensor4all-treetn/diagnostics"]
 tenferro-cpu-faer = [
     "tensor4all-treetn/tenferro-cpu-faer",
     "tensor4all-tensorbackend/backend-tenferro",

--- a/crates/tensor4all-treeaci/src/branch_diagnostics.rs
+++ b/crates/tensor4all-treeaci/src/branch_diagnostics.rs
@@ -1,0 +1,10 @@
+//! Re-export of `tensor4all-treetn`'s per-node branch diagnostics registry.
+//!
+//! Named `branch_diagnostics`, not `diagnostics`, to stay distinct from
+//! [`crate::TreeAciDiagnostics`] -- an unrelated, already-public sweep/
+//! convergence report. This module is about branch-point performance
+//! (issue #671); `TreeAciDiagnostics` is about ACI convergence history.
+
+pub use tensor4all_treetn::diagnostics::{
+    record_frame, record_guard, reset, snapshot, NodeDiagnostics,
+};

--- a/crates/tensor4all-treeaci/src/branch_diagnostics.rs
+++ b/crates/tensor4all-treeaci/src/branch_diagnostics.rs
@@ -6,5 +6,6 @@
 //! (issue #671); `TreeAciDiagnostics` is about ACI convergence history.
 
 pub use tensor4all_treetn::diagnostics::{
-    record_frame, record_guard, reset, snapshot, NodeDiagnostics,
+    contraction_summary, record_frame, record_guard, reset, reset_contraction, snapshot,
+    NodeDiagnostics,
 };

--- a/crates/tensor4all-treeaci/src/elementwise/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/elementwise/tests/mod.rs
@@ -334,6 +334,54 @@ fn global_guard_recovers_a_separated_feature_end_to_end() {
         .any(|&count| count > 0));
 }
 
+/// Regression guard for a real downstream confusion: `tensor4all_treetn::
+/// diagnostics::record_guard` correctly fires when the global-pivot search
+/// finds a pivot, with real nonzero `guard_ns`/hit/miss counts. A downstream
+/// caller (gw-rs's R=10 isolation harness) reported "Guard is always zero"
+/// across 8 real runs; tracing it down to this point confirmed the
+/// instrumentation itself was never the problem -- the caller was filtering
+/// Guard's un-namespaced node keys out of its own snapshot (Guard's key has
+/// no per-operand prefix; see `record_guard`'s doc comment). This test pins
+/// the actual behavior so that claim can't silently regress again.
+#[cfg(feature = "diagnostics")]
+#[test]
+fn guard_diagnostics_record_nonzero_activity_when_global_pivots_are_found() {
+    use tensor4all_treetn::diagnostics;
+    let (input, _physical) = separated_two_peak_tree(10);
+    diagnostics::reset();
+    let with_guard = tree_elementwise(
+        |values: &[f64]| values[0],
+        std::slice::from_ref(&input),
+        &TreeAciOptions {
+            rng_seed: 0,
+            enable_global_guard: true,
+            nsearch_global_pivots: 30,
+            tolerance: 1.0e-4,
+            ..TreeAciOptions::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        with_guard.global_pivots_found.iter().any(|&c| c > 0),
+        "fixture must actually exercise global-pivot search, or this test proves nothing"
+    );
+
+    let snapshot = diagnostics::snapshot();
+    let total_guard_activity: u64 = snapshot
+        .iter()
+        .map(|record| record.guard_cache_hits + record.guard_cache_misses)
+        .sum();
+    let total_guard_ns: u64 = snapshot.iter().map(|record| record.guard_ns).sum();
+    assert!(
+        total_guard_activity > 0,
+        "expected nonzero guard_cache_hits/misses across the snapshot, got 0 on every node"
+    );
+    assert!(
+        total_guard_ns > 0,
+        "expected nonzero guard_ns across the snapshot, got 0 on every node"
+    );
+}
+
 /// The guard's recovery guarantee at the **default** search count.
 ///
 /// `enable_global_guard` defaults to `true` and `nsearch_global_pivots` to 5, so

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -15,6 +15,11 @@ use crate::{
     Result, TreeAciError, TreeAciNode, TreeAciScalar,
 };
 
+#[cfg(feature = "diagnostics")]
+use crate::problem::DirectedEdge;
+#[cfg(feature = "diagnostics")]
+use tensor4all_treetn::diagnostics;
+
 fn checked_product(factors: &[usize], context: &'static str) -> Result<usize> {
     factors.iter().try_fold(1usize, |product, &factor| {
         product
@@ -805,6 +810,10 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         // per physical coordinate.
         let mut pending = Vec::new();
         let mut results: Vec<Option<Vec<T>>> = vec![None; candidates.len()];
+        #[cfg(feature = "diagnostics")]
+        let diag_start = std::time::Instant::now();
+        #[cfg(feature = "diagnostics")]
+        let (mut diag_hits, mut diag_misses) = (0u64, 0u64);
         for (candidate_index, candidate) in candidates.iter().enumerate() {
             let key = self
                 .candidate_cache_key(problem, input, directed_edge, candidate)?
@@ -814,11 +823,19 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             if let Some(cached) = self.candidate_cache.borrow().get(&key) {
                 #[cfg(test)]
                 candidate_debug_stats::record_hit();
+                #[cfg(feature = "diagnostics")]
+                {
+                    diag_hits += 1;
+                }
                 results[candidate_index] = Some(cached.clone());
                 continue;
             }
             #[cfg(test)]
             candidate_debug_stats::record_miss();
+            #[cfg(feature = "diagnostics")]
+            {
+                diag_misses += 1;
+            }
             if candidate.local_coordinate >= physical.local_dim
                 || candidate.incoming.len() != 1
                 || candidate.incoming[0].0 != incoming_edge
@@ -894,6 +911,20 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                 self.cache_candidate_if_fits(problem, key, &values);
                 results[candidate_index] = Some(values);
             }
+        }
+
+        #[cfg(feature = "diagnostics")]
+        {
+            let (node, coordination_number, bond_dims) =
+                diagnostics_node_topology(tree, problem, directed, directed_edge);
+            diagnostics::record_frame(
+                &node,
+                coordination_number,
+                &bond_dims,
+                diag_start.elapsed(),
+                diag_hits,
+                diag_misses,
+            );
         }
 
         results
@@ -973,6 +1004,10 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
             std::collections::BTreeMap::new();
         let mut results: Vec<Option<Vec<T>>> = vec![None; candidates.len()];
+        #[cfg(feature = "diagnostics")]
+        let diag_start = std::time::Instant::now();
+        #[cfg(feature = "diagnostics")]
+        let (mut diag_hits, mut diag_misses) = (0u64, 0u64);
         for (candidate_index, candidate) in candidates.iter().enumerate() {
             let key = self
                 .candidate_cache_key(problem, input, directed_edge, candidate)?
@@ -982,11 +1017,19 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             if let Some(cached) = self.candidate_cache.borrow().get(&key) {
                 #[cfg(test)]
                 candidate_debug_stats::record_hit();
+                #[cfg(feature = "diagnostics")]
+                {
+                    diag_hits += 1;
+                }
                 results[candidate_index] = Some(cached.clone());
                 continue;
             }
             #[cfg(test)]
             candidate_debug_stats::record_miss();
+            #[cfg(feature = "diagnostics")]
+            {
+                diag_misses += 1;
+            }
             if candidate.incoming.len() != 2
                 || candidate.incoming[0].0 != incoming_edge_1
                 || candidate.incoming[1].0 != incoming_edge_2
@@ -1093,6 +1136,20 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             }
         }
 
+        #[cfg(feature = "diagnostics")]
+        {
+            let (node, coordination_number, bond_dims) =
+                diagnostics_node_topology(tree, problem, directed, directed_edge);
+            diagnostics::record_frame(
+                &node,
+                coordination_number,
+                &bond_dims,
+                diag_start.elapsed(),
+                diag_hits,
+                diag_misses,
+            );
+        }
+
         results
             .into_iter()
             .map(|value| {
@@ -1112,18 +1169,35 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         sample: &ComponentSample,
     ) -> Result<Vec<T>> {
         let cache_key = self.candidate_cache_key(problem, input, directed_edge, sample)?;
+        let tree = inputs.get(input).ok_or(TreeAciError::InternalInvariant {
+            message: "candidate frame references an unknown input",
+        })?;
+        #[cfg(feature = "diagnostics")]
+        let diag_start = std::time::Instant::now();
+        #[cfg(feature = "diagnostics")]
+        let directed = &problem.directed_edges[directed_edge];
         if let Some(key) = cache_key {
             if let Some(cached) = self.candidate_cache.borrow().get(&key) {
                 #[cfg(test)]
                 candidate_debug_stats::record_hit();
+                #[cfg(feature = "diagnostics")]
+                {
+                    let (node, coordination_number, bond_dims) =
+                        diagnostics_node_topology(tree, problem, directed, directed_edge);
+                    diagnostics::record_frame(
+                        &node,
+                        coordination_number,
+                        &bond_dims,
+                        diag_start.elapsed(),
+                        1,
+                        0,
+                    );
+                }
                 return Ok(cached.clone());
             }
         }
         #[cfg(test)]
         candidate_debug_stats::record_miss();
-        let tree = inputs.get(input).ok_or(TreeAciError::InternalInvariant {
-            message: "candidate frame references an unknown input",
-        })?;
         let cores = self
             .cores
             .get(input)
@@ -1148,6 +1222,19 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         )?;
         if let Some(key) = cache_key {
             self.cache_candidate_if_fits(problem, key, &values);
+        }
+        #[cfg(feature = "diagnostics")]
+        {
+            let (node, coordination_number, bond_dims) =
+                diagnostics_node_topology(tree, problem, directed, directed_edge);
+            diagnostics::record_frame(
+                &node,
+                coordination_number,
+                &bond_dims,
+                diag_start.elapsed(),
+                0,
+                1,
+            );
         }
         Ok(values)
     }
@@ -1843,6 +1930,34 @@ fn two_incoming_core_matrix_batched<T: TreeAciScalar>(
     }
     let stage1_matrix = Matrix::from_col_major_vec(outgoing_dim * n1, incoming_dim_2, stage1_data);
     contract_prepared_core_batched(&stage1_matrix, v2)
+}
+
+/// Summarizes a directed edge's source node for the branch diagnostics
+/// registry: its `Debug` label, coordination number (incoming edges plus
+/// the one outgoing edge), and the bond dimensions of every incident edge
+/// (outgoing first, then each incoming edge in order).
+#[cfg(feature = "diagnostics")]
+fn diagnostics_node_topology<V: TreeAciNode>(
+    tree: &TreeTN<IdxTensor, V>,
+    problem: &PreparedTreeProblem<V>,
+    directed: &DirectedEdge<V>,
+    directed_edge: DirectedEdgeId,
+) -> (String, usize, Vec<usize>) {
+    let coordination_number = directed.incoming_to_from.len() + 1;
+    let mut bond_dims = Vec::with_capacity(coordination_number);
+    if let Ok(index) = outgoing_bond(tree, problem, directed_edge) {
+        bond_dims.push(index.dim());
+    }
+    for &incoming in &directed.incoming_to_from {
+        if let Ok(index) = outgoing_bond(tree, problem, incoming) {
+            bond_dims.push(index.dim());
+        }
+    }
+    (
+        format!("{:?}", directed.from),
+        coordination_number,
+        bond_dims,
+    )
 }
 
 fn outgoing_bond<'a, V: TreeAciNode>(

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -1648,7 +1648,7 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
 
             let mut v1_data = Vec::with_capacity(incoming_dim_1 * ids_1.len());
             for &sample_1 in &ids_1 {
-                let values = self.memo[incoming_edge_1][sample_1].clone().ok_or(
+                let values = self.memo[incoming_edge_1][sample_1].as_ref().ok_or(
                     TreeAciError::InternalInvariant {
                         message:
                             "incoming sample frame was not memoized before batched contraction",
@@ -1659,13 +1659,13 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
                         message: "incoming frame length differs from its bond dimension",
                     });
                 }
-                v1_data.extend(values);
+                v1_data.extend_from_slice(values);
             }
             let v1 = Matrix::from_col_major_vec(incoming_dim_1, ids_1.len(), v1_data);
 
             let mut v2_data = Vec::with_capacity(incoming_dim_2 * ids_2.len());
             for &sample_2 in &ids_2 {
-                let values = self.memo[incoming_edge_2][sample_2].clone().ok_or(
+                let values = self.memo[incoming_edge_2][sample_2].as_ref().ok_or(
                     TreeAciError::InternalInvariant {
                         message:
                             "incoming sample frame was not memoized before batched contraction",
@@ -1676,7 +1676,7 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
                         message: "incoming frame length differs from its bond dimension",
                     });
                 }
-                v2_data.extend(values);
+                v2_data.extend_from_slice(values);
             }
             let v2 = Matrix::from_col_major_vec(incoming_dim_2, ids_2.len(), v2_data);
 

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -914,18 +914,16 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         }
 
         #[cfg(feature = "diagnostics")]
-        {
-            let (node, coordination_number, bond_dims) =
-                diagnostics_node_topology(tree, problem, directed, directed_edge);
-            diagnostics::record_frame(
-                &node,
-                coordination_number,
-                &bond_dims,
-                diag_start.elapsed(),
-                diag_hits,
-                diag_misses,
-            );
-        }
+        diagnostics_record_frame(
+            tree,
+            problem,
+            directed,
+            directed_edge,
+            input,
+            diag_start.elapsed(),
+            diag_hits,
+            diag_misses,
+        );
 
         results
             .into_iter()
@@ -1137,18 +1135,16 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         }
 
         #[cfg(feature = "diagnostics")]
-        {
-            let (node, coordination_number, bond_dims) =
-                diagnostics_node_topology(tree, problem, directed, directed_edge);
-            diagnostics::record_frame(
-                &node,
-                coordination_number,
-                &bond_dims,
-                diag_start.elapsed(),
-                diag_hits,
-                diag_misses,
-            );
-        }
+        diagnostics_record_frame(
+            tree,
+            problem,
+            directed,
+            directed_edge,
+            input,
+            diag_start.elapsed(),
+            diag_hits,
+            diag_misses,
+        );
 
         results
             .into_iter()
@@ -1169,30 +1165,38 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         sample: &ComponentSample,
     ) -> Result<Vec<T>> {
         let cache_key = self.candidate_cache_key(problem, input, directed_edge, sample)?;
+        // Fetched before the cache-hit check so the diagnostics hit path can
+        // read the tree's topology. Safe to hoist: a cache entry can only
+        // exist for an `input` that already passed this same fetch when the
+        // entry was first computed on the miss path below.
         let tree = inputs.get(input).ok_or(TreeAciError::InternalInvariant {
             message: "candidate frame references an unknown input",
         })?;
         #[cfg(feature = "diagnostics")]
         let diag_start = std::time::Instant::now();
         #[cfg(feature = "diagnostics")]
-        let directed = &problem.directed_edges[directed_edge];
+        let directed =
+            problem
+                .directed_edges
+                .get(directed_edge)
+                .ok_or(TreeAciError::InternalInvariant {
+                    message: "candidate frame references an unknown directed edge",
+                })?;
         if let Some(key) = cache_key {
             if let Some(cached) = self.candidate_cache.borrow().get(&key) {
                 #[cfg(test)]
                 candidate_debug_stats::record_hit();
                 #[cfg(feature = "diagnostics")]
-                {
-                    let (node, coordination_number, bond_dims) =
-                        diagnostics_node_topology(tree, problem, directed, directed_edge);
-                    diagnostics::record_frame(
-                        &node,
-                        coordination_number,
-                        &bond_dims,
-                        diag_start.elapsed(),
-                        1,
-                        0,
-                    );
-                }
+                diagnostics_record_frame(
+                    tree,
+                    problem,
+                    directed,
+                    directed_edge,
+                    input,
+                    diag_start.elapsed(),
+                    1,
+                    0,
+                );
                 return Ok(cached.clone());
             }
         }
@@ -1224,18 +1228,16 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             self.cache_candidate_if_fits(problem, key, &values);
         }
         #[cfg(feature = "diagnostics")]
-        {
-            let (node, coordination_number, bond_dims) =
-                diagnostics_node_topology(tree, problem, directed, directed_edge);
-            diagnostics::record_frame(
-                &node,
-                coordination_number,
-                &bond_dims,
-                diag_start.elapsed(),
-                0,
-                1,
-            );
-        }
+        diagnostics_record_frame(
+            tree,
+            problem,
+            directed,
+            directed_edge,
+            input,
+            diag_start.elapsed(),
+            0,
+            1,
+        );
         Ok(values)
     }
 }
@@ -1933,31 +1935,61 @@ fn two_incoming_core_matrix_batched<T: TreeAciScalar>(
 }
 
 /// Summarizes a directed edge's source node for the branch diagnostics
-/// registry: its `Debug` label, coordination number (incoming edges plus
+/// registry: its registry key, coordination number (incoming edges plus
 /// the one outgoing edge), and the bond dimensions of every incident edge
 /// (outgoing first, then each incoming edge in order).
+///
+/// The key is namespaced by the operand index `input` so that identically
+/// labelled nodes of two different input trees do not merge into a single
+/// registry entry. `bond_dims` always has exactly `coordination_number`
+/// entries; an edge whose bond index cannot be resolved contributes a `0`
+/// sentinel.
 #[cfg(feature = "diagnostics")]
 fn diagnostics_node_topology<V: TreeAciNode>(
     tree: &TreeTN<IdxTensor, V>,
     problem: &PreparedTreeProblem<V>,
     directed: &DirectedEdge<V>,
     directed_edge: DirectedEdgeId,
+    input: usize,
 ) -> (String, usize, Vec<usize>) {
     let coordination_number = directed.incoming_to_from.len() + 1;
     let mut bond_dims = Vec::with_capacity(coordination_number);
-    if let Ok(index) = outgoing_bond(tree, problem, directed_edge) {
-        bond_dims.push(index.dim());
-    }
+    bond_dims.push(outgoing_bond(tree, problem, directed_edge).map_or(0, |index| index.dim()));
     for &incoming in &directed.incoming_to_from {
-        if let Ok(index) = outgoing_bond(tree, problem, incoming) {
-            bond_dims.push(index.dim());
-        }
+        bond_dims.push(outgoing_bond(tree, problem, incoming).map_or(0, |index| index.dim()));
     }
     (
-        format!("{:?}", directed.from),
+        format!("{input}:{:?}", directed.from),
         coordination_number,
         bond_dims,
     )
+}
+
+/// Records one batched/single candidate-frame computation into the branch
+/// diagnostics registry, keyed by the operand index and the directed edge's
+/// source node.
+#[cfg(feature = "diagnostics")]
+#[allow(clippy::too_many_arguments)]
+fn diagnostics_record_frame<V: TreeAciNode>(
+    tree: &TreeTN<IdxTensor, V>,
+    problem: &PreparedTreeProblem<V>,
+    directed: &DirectedEdge<V>,
+    directed_edge: DirectedEdgeId,
+    input: usize,
+    elapsed: std::time::Duration,
+    hits: u64,
+    misses: u64,
+) {
+    let (node, coordination_number, bond_dims) =
+        diagnostics_node_topology(tree, problem, directed, directed_edge, input);
+    diagnostics::record_frame(
+        &node,
+        coordination_number,
+        &bond_dims,
+        elapsed,
+        hits,
+        misses,
+    );
 }
 
 fn outgoing_bond<'a, V: TreeAciNode>(

--- a/crates/tensor4all-treeaci/src/frames.rs
+++ b/crates/tensor4all-treeaci/src/frames.rs
@@ -62,8 +62,17 @@ fn enforce_frame_working_elements<T: TreeAciScalar, V: TreeAciNode>(
     problem: &PreparedTreeProblem<V>,
     elements: usize,
 ) -> Result<()> {
+    enforce_frame_working_elements_with_extra_bytes::<T, V>(problem, elements, 0)
+}
+
+fn enforce_frame_working_elements_with_extra_bytes<T: TreeAciScalar, V: TreeAciNode>(
+    problem: &PreparedTreeProblem<V>,
+    elements: usize,
+    extra_bytes: usize,
+) -> Result<()> {
     let bytes = elements
         .checked_mul(size_of::<T>())
+        .and_then(|bytes| bytes.checked_add(extra_bytes))
         .ok_or(TreeAciError::SizeOverflow {
             context: "candidate frame working bytes",
         })?;
@@ -88,6 +97,7 @@ pub(crate) mod debug_stats {
         static COMPUTE_CALLS: Cell<u64> = const { Cell::new(0) };
         static SCALAR_COMPUTE_CALLS: Cell<u64> = const { Cell::new(0) };
         static BATCHED_COMPUTE_CALLS: Cell<u64> = const { Cell::new(0) };
+        static MEMO_HIT_COPIES: Cell<u64> = const { Cell::new(0) };
     }
 
     pub(crate) fn record_scalar_compute_call() {
@@ -112,10 +122,19 @@ pub(crate) mod debug_stats {
         BATCHED_COMPUTE_CALLS.with(Cell::get)
     }
 
+    pub(crate) fn record_memo_hit_copy() {
+        MEMO_HIT_COPIES.with(|count| count.set(count.get() + 1));
+    }
+
+    pub(crate) fn memo_hit_copies() -> u64 {
+        MEMO_HIT_COPIES.with(Cell::get)
+    }
+
     pub(crate) fn reset() {
         COMPUTE_CALLS.with(|count| count.set(0));
         SCALAR_COMPUTE_CALLS.with(|count| count.set(0));
         BATCHED_COMPUTE_CALLS.with(|count| count.set(0));
+        MEMO_HIT_COPIES.with(|count| count.set(0));
     }
 }
 
@@ -808,7 +827,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         // sample IDs, so one `(outgoing * physical) x incoming` core matrix is
         // both simpler and substantially cheaper than one small BLAS dispatch
         // per physical coordinate.
-        let mut pending = Vec::new();
+        let mut pending: Vec<(usize, CandidateCacheKey)> = Vec::new();
         let mut results: Vec<Option<Vec<T>>> = vec![None; candidates.len()];
         #[cfg(feature = "diagnostics")]
         let diag_start = std::time::Instant::now();
@@ -844,13 +863,13 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                     message: "single-incoming-edge candidate does not match its prepared component",
                 });
             }
-            pending.push(candidate_index);
+            pending.push((candidate_index, key));
         }
 
         if !pending.is_empty() {
             let mut incoming_ids = Vec::new();
             let mut incoming_positions = HashMap::new();
-            for &candidate_index in &pending {
+            for &(candidate_index, _) in &pending {
                 let sample = candidates[candidate_index].incoming[0].1;
                 incoming_positions.entry(sample).or_insert_with(|| {
                     incoming_ids.push(sample);
@@ -874,7 +893,15 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                 ],
                 "single-incoming candidate scratch elements",
             )?;
-            enforce_frame_working_elements::<T, V>(problem, scratch)?;
+            let physical_offset_bytes = checked_product(
+                &[physical.local_dim, size_of::<usize>()],
+                "single-incoming candidate physical-offset bytes",
+            )?;
+            enforce_frame_working_elements_with_extra_bytes::<T, V>(
+                problem,
+                scratch,
+                physical_offset_bytes,
+            )?;
             let core_matrix = single_incoming_all_physical_core_matrix(
                 core,
                 outgoing_axis,
@@ -897,17 +924,12 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             let frame_matrix =
                 Matrix::from_col_major_vec(incoming_dim, incoming_ids.len(), frame_data);
             let batched = contract_prepared_core_batched(&core_matrix, &frame_matrix)?;
-            for candidate_index in pending {
+            for (candidate_index, key) in pending {
                 let candidate = &candidates[candidate_index];
                 let column = incoming_positions[&candidate.incoming[0].1];
                 let values: Vec<T> = (0..outgoing_dim)
                     .map(|row| batched[[row + outgoing_dim * candidate.local_coordinate, column]])
                     .collect();
-                let key = self
-                    .candidate_cache_key(problem, input, directed_edge, candidate)?
-                    .ok_or(TreeAciError::InternalInvariant {
-                        message: "single-incoming candidate has no compact cache key",
-                    })?;
                 self.cache_candidate_if_fits(problem, key, &values);
                 results[candidate_index] = Some(values);
             }
@@ -999,7 +1021,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
         let incoming_dim_1 = core.dims[incoming_axis_1];
         let incoming_dim_2 = core.dims[incoming_axis_2];
 
-        let mut groups: std::collections::BTreeMap<usize, Vec<usize>> =
+        let mut groups: std::collections::BTreeMap<usize, Vec<(usize, CandidateCacheKey)>> =
             std::collections::BTreeMap::new();
         let mut results: Vec<Option<Vec<T>>> = vec![None; candidates.len()];
         #[cfg(feature = "diagnostics")]
@@ -1039,7 +1061,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             groups
                 .entry(candidate.local_coordinate)
                 .or_default()
-                .push(candidate_index);
+                .push((candidate_index, key));
         }
 
         for (local_coordinate, indices) in groups {
@@ -1054,7 +1076,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
             let mut position_1: HashMap<SampleId, usize> = HashMap::new();
             let mut ids_2: Vec<SampleId> = Vec::new();
             let mut position_2: HashMap<SampleId, usize> = HashMap::new();
-            for &candidate_index in &indices {
+            for &(candidate_index, _) in &indices {
                 let (_, sample_1) = candidates[candidate_index].incoming[0];
                 let (_, sample_2) = candidates[candidate_index].incoming[1];
                 position_1.entry(sample_1).or_insert_with(|| {
@@ -1115,7 +1137,7 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                 &v2,
             )?;
 
-            for &candidate_index in &indices {
+            for &(candidate_index, key) in &indices {
                 let (_, sample_1) = candidates[candidate_index].incoming[0];
                 let (_, sample_2) = candidates[candidate_index].incoming[1];
                 let n1 = position_1[&sample_1];
@@ -1123,12 +1145,6 @@ impl<T: TreeAciScalar> InputFrameStore<T> {
                 let values: Vec<T> = (0..outgoing_dim)
                     .map(|out| batched[[out + outgoing_dim * n1, n2]])
                     .collect();
-                let candidate = &candidates[candidate_index];
-                let key = self
-                    .candidate_cache_key(problem, input, directed_edge, candidate)?
-                    .ok_or(TreeAciError::InternalInvariant {
-                        message: "two-incoming candidate has no compact cache key",
-                    })?;
                 self.cache_candidate_if_fits(problem, key, &values);
                 results[candidate_index] = Some(values);
             }
@@ -1266,14 +1282,28 @@ where
 }
 
 impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
+    fn ensure_computed(&mut self, edge: DirectedEdgeId, sample: SampleId) -> Result<()> {
+        if self
+            .memo
+            .get(edge)
+            .and_then(|samples| samples.get(sample))
+            .is_some_and(Option::is_some)
+        {
+            return Ok(());
+        }
+        self.compute(edge, sample).map(|_| ())
+    }
+
     fn compute(&mut self, edge: DirectedEdgeId, sample: SampleId) -> Result<Vec<T>> {
         if let Some(values) = self
             .memo
             .get(edge)
             .and_then(|samples| samples.get(sample))
-            .and_then(Clone::clone)
+            .and_then(Option::as_ref)
         {
-            return Ok(values);
+            #[cfg(test)]
+            debug_stats::record_memo_hit_copy();
+            return Ok(values.clone());
         }
         // A sample already known to the previous store names exactly the
         // same component (see `existing_frames`'s doc comment) -- pull its
@@ -1396,7 +1426,7 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
         // ancestor) does no repeated work.
         for (_, record) in &pending {
             let (_, incoming_sample) = record.incoming[0];
-            self.compute(incoming_edge, incoming_sample)?;
+            self.ensure_computed(incoming_edge, incoming_sample)?;
         }
 
         let node = *self.problem.node_positions.get(&directed.from).ok_or(
@@ -1451,7 +1481,15 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
             ],
             "single-incoming frame scratch elements",
         )?;
-        enforce_frame_working_elements::<T, V>(self.problem, scratch)?;
+        let physical_offset_bytes = checked_product(
+            &[physical.local_dim, size_of::<usize>()],
+            "single-incoming physical-offset bytes",
+        )?;
+        enforce_frame_working_elements_with_extra_bytes::<T, V>(
+            self.problem,
+            scratch,
+            physical_offset_bytes,
+        )?;
         let core_matrix = single_incoming_all_physical_core_matrix(
             core,
             outgoing_axis,
@@ -1537,8 +1575,8 @@ impl<T: TreeAciScalar, V: TreeAciNode> FrameBuilder<'_, T, V> {
         }
 
         for (_, record) in &pending {
-            self.compute(incoming_edge_1, record.incoming[0].1)?;
-            self.compute(incoming_edge_2, record.incoming[1].1)?;
+            self.ensure_computed(incoming_edge_1, record.incoming[0].1)?;
+            self.ensure_computed(incoming_edge_2, record.incoming[1].1)?;
         }
 
         let node = *self.problem.node_positions.get(&directed.from).ok_or(
@@ -1848,10 +1886,9 @@ fn single_incoming_all_physical_core_matrix<T: TreeAciScalar>(
     let rows = outgoing_dim * physical.local_dim;
     let outgoing_stride = core.strides[outgoing_axis];
     let incoming_stride = core.strides[incoming_axis];
-    let mut data = Vec::with_capacity(rows * incoming_dim);
-    for incoming_value in 0..incoming_dim {
-        for local_coordinate in 0..physical.local_dim {
-            let physical_offset = physical_axes
+    let physical_offsets = (0..physical.local_dim)
+        .map(|local_coordinate| {
+            physical_axes
                 .iter()
                 .enumerate()
                 .map(|(physical_axis, &core_axis)| {
@@ -1859,7 +1896,12 @@ fn single_incoming_all_physical_core_matrix<T: TreeAciScalar>(
                         % physical.dims[physical_axis];
                     coordinate * core.strides[core_axis]
                 })
-                .sum::<usize>();
+                .sum::<usize>()
+        })
+        .collect::<Vec<_>>();
+    let mut data = Vec::with_capacity(rows * incoming_dim);
+    for incoming_value in 0..incoming_dim {
+        for &physical_offset in &physical_offsets {
             for outgoing_value in 0..outgoing_dim {
                 let offset = physical_offset
                     + incoming_value * incoming_stride

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -624,6 +624,61 @@ fn batched_path_matches_scalar_path_on_random_core() {
     }
 }
 
+fn assert_all_physical_single_incoming_matrix<T>()
+where
+    T: TreeAciScalar + From<f64> + PartialEq + std::fmt::Debug,
+{
+    // Core axes are [incoming, physical_1, outgoing, physical_0], while the
+    // local physical flattening order is [physical_0, physical_1]. This makes
+    // the test sensitive to both the physical-axis map and its strides.
+    let core_dims = vec![2usize, 3, 5, 4];
+    let mut core_strides = Vec::with_capacity(core_dims.len());
+    let mut stride = 1usize;
+    for &dimension in &core_dims {
+        core_strides.push(stride);
+        stride *= dimension;
+    }
+    let core = super::PreparedCore {
+        indices: Vec::new(),
+        dims: core_dims,
+        strides: core_strides,
+        values: (0..stride)
+            .map(|value| T::from(value as f64 + 0.25))
+            .collect(),
+    };
+    let physical = super::LocalPhysicalPlan {
+        indices: Vec::new(),
+        dims: vec![4, 3],
+        strides: vec![1, 4],
+        local_dim: 12,
+    };
+    let matrix =
+        super::single_incoming_all_physical_core_matrix(&core, 2, 0, &physical, &[3, 1], 5, 2);
+
+    for incoming in 0..2 {
+        for local_coordinate in 0..12 {
+            let physical_0 = local_coordinate % 4;
+            let physical_1 = (local_coordinate / 4) % 3;
+            for outgoing in 0..5 {
+                let offset = physical_0 * core.strides[3]
+                    + physical_1 * core.strides[1]
+                    + incoming * core.strides[0]
+                    + outgoing * core.strides[2];
+                assert_eq!(
+                    matrix[[outgoing + 5 * local_coordinate, incoming]],
+                    core.values[offset]
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn all_physical_single_incoming_matrix_respects_nontrivial_axis_order() {
+    assert_all_physical_single_incoming_matrix::<f64>();
+    assert_all_physical_single_incoming_matrix::<Complex64>();
+}
+
 /// Builds a 4-node star `1 -- 0 -- 2`, `0 -- 3`, whose center (node `0`) has
 /// three neighbors. Directed edge `1 -> 0` has zero incoming edges (node `1`
 /// is a leaf) -- `InputFrameStore::candidate_frames_for_edge`'s scalar
@@ -1505,6 +1560,28 @@ fn from_samples_issues_exactly_one_compute_call_per_memo_slot_on_a_five_node_cha
          {total_memo_slots} slots across {} directed edges",
         problem.directed_edges.len()
     );
+}
+
+#[test]
+fn priming_reuses_memoized_incoming_without_copying_again() {
+    let input = chain_tree_for_batched_compute();
+    let problem =
+        prepare_problem(std::slice::from_ref(&input), &TreeAciOptions::default()).unwrap();
+    let (arena, _) = SampleArena::from_global_seeds(&problem, &[vec![0, 0, 0]]).unwrap();
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 1 && arc.to == 2)
+        .expect("chain must have a single-incoming edge 1 -> 2");
+    let incoming = problem.directed_edges[edge].incoming_to_from[0];
+    let mut builder = build_frame_builder(&input, &problem, &arena);
+
+    super::debug_stats::reset();
+    builder.ensure_computed(incoming, 0).unwrap();
+    builder.ensure_computed(incoming, 0).unwrap();
+
+    assert_eq!(super::debug_stats::compute_calls(), 1);
+    assert_eq!(super::debug_stats::memo_hit_copies(), 0);
 }
 
 /// A chain's non-leaf directed edges have exactly one incoming edge and must

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -947,6 +947,59 @@ fn candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges() {
     assert!(dispatched.iter().any(|frame| frame != &dispatched[0]));
 }
 
+#[cfg(feature = "diagnostics")]
+#[test]
+fn candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_number_three() {
+    use crate::branch_diagnostics;
+
+    let inputs = vec![star_tree_for_fallback_dispatch()];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("star tree must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 2);
+
+    let seeds = vec![vec![0, 0, 0, 0], vec![0, 0, 1, 1]];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+
+    let incoming_edge_a = directed.incoming_to_from[0];
+    let incoming_edge_b = directed.incoming_to_from[1];
+    let ids_a = &candidate_sets.ids[incoming_edge_a];
+    let ids_b = &candidate_sets.ids[incoming_edge_b];
+
+    let mut candidates = Vec::new();
+    for local_coordinate in 0..2 {
+        for &id_a in ids_a {
+            for &id_b in ids_b {
+                candidates.push(ComponentSample {
+                    local_coordinate,
+                    incoming: vec![(incoming_edge_a, id_a), (incoming_edge_b, id_b)],
+                });
+            }
+        }
+    }
+
+    branch_diagnostics::reset();
+    let _dispatched = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .unwrap();
+
+    let snapshot = branch_diagnostics::snapshot();
+    let hub_record = snapshot
+        .iter()
+        .find(|record| record.node == "0")
+        .expect("hub node (0) recorded in branch diagnostics");
+    assert_eq!(hub_record.coordination_number, 3);
+    assert_eq!(hub_record.bond_dims.len(), 3);
+    assert!(hub_record.frame_cache_hits + hub_record.frame_cache_misses > 0);
+}
+
 #[test]
 fn two_incoming_candidate_batch_obeys_the_working_byte_limit() {
     let inputs = vec![star_tree_for_fallback_dispatch()];

--- a/crates/tensor4all-treeaci/src/frames/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/frames/tests/mod.rs
@@ -993,11 +993,69 @@ fn candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_num
     let snapshot = branch_diagnostics::snapshot();
     let hub_record = snapshot
         .iter()
-        .find(|record| record.node == "0")
-        .expect("hub node (0) recorded in branch diagnostics");
+        .find(|record| record.node == "0:0")
+        .expect("hub node (0) of input 0 recorded in branch diagnostics");
     assert_eq!(hub_record.coordination_number, 3);
     assert_eq!(hub_record.bond_dims.len(), 3);
     assert!(hub_record.frame_cache_hits + hub_record.frame_cache_misses > 0);
+}
+
+/// The same hub node of two different input trees must produce two separate
+/// registry entries: the diagnostics key is namespaced by the operand index.
+#[cfg(feature = "diagnostics")]
+#[test]
+fn frame_diagnostics_keys_are_namespaced_per_input_operand() {
+    use crate::branch_diagnostics;
+
+    // Two operands sharing the same physical indices, as a product's two
+    // inputs do; the clone gives input 1 the same node labels as input 0.
+    let tree = star_tree_for_fallback_dispatch();
+    let inputs = vec![tree.clone(), tree];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("star tree must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+
+    let seeds = vec![vec![0, 0, 0, 0], vec![0, 0, 1, 1]];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+
+    let incoming_edge_a = directed.incoming_to_from[0];
+    let incoming_edge_b = directed.incoming_to_from[1];
+    let id_a = candidate_sets.ids[incoming_edge_a][0];
+    let id_b = candidate_sets.ids[incoming_edge_b][0];
+    let candidate = ComponentSample {
+        local_coordinate: 0,
+        incoming: vec![(incoming_edge_a, id_a), (incoming_edge_b, id_b)],
+    };
+
+    branch_diagnostics::reset();
+    let from_input_0 = frames
+        .candidate_frame(&inputs, &problem, 0, edge, &candidate)
+        .unwrap();
+    let from_input_1 = frames
+        .candidate_frame(&inputs, &problem, 1, edge, &candidate)
+        .unwrap();
+    assert_eq!(from_input_0.len(), from_input_1.len());
+
+    let mut snapshot = branch_diagnostics::snapshot();
+    snapshot.sort_by(|a, b| a.node.cmp(&b.node));
+    let nodes: Vec<&str> = snapshot.iter().map(|record| record.node.as_str()).collect();
+    assert_eq!(
+        nodes,
+        vec!["0:0", "1:0"],
+        "the same hub node of two operands must not merge into one entry"
+    );
+    for record in &snapshot {
+        assert_eq!(record.coordination_number, 3);
+        assert_eq!(record.bond_dims.len(), record.coordination_number);
+        assert_eq!(record.frame_cache_hits + record.frame_cache_misses, 1);
+    }
 }
 
 #[test]

--- a/crates/tensor4all-treeaci/src/global_guard.rs
+++ b/crates/tensor4all-treeaci/src/global_guard.rs
@@ -119,13 +119,19 @@ where
                 input_evaluators
                     .enforce_guard_batch_budget_with_retained::<T>(points.len(), retained_bytes)?;
                 let coordinates = input_evaluators.expand_points(points)?;
-                let input_values = input_evaluators.evaluate_expanded::<T>(points, &coordinates)?;
+                let hint = input_evaluators.evaluation_hint(points);
+                let input_values =
+                    input_evaluators.evaluate_expanded::<T>(points, &coordinates, hint.clone())?;
                 let batch =
                     TreeElementwiseBatch::new(&input_values, state.inputs.len(), points.len())?;
                 let mut target = vec![T::default(); points.len()];
                 operator(batch, &mut target)?;
-                let approximation =
-                    output_evaluator.evaluate_expanded(input_evaluators, points, &coordinates)?;
+                let approximation = output_evaluator.evaluate_expanded(
+                    input_evaluators,
+                    points,
+                    &coordinates,
+                    hint,
+                )?;
                 Ok(target
                     .into_iter()
                     .zip(approximation)
@@ -195,6 +201,9 @@ pub(crate) fn inject_global_pivots<'a, T: TreeAciScalar, V: TreeAciNode>(
         return Err(TreeAciError::InternalInvariant {
             message: "global-pivot growth capacities differ from tree edge count",
         });
+    }
+    if points.is_empty() {
+        return Ok(0);
     }
     let checkpoint = state.sample_arena.checkpoint();
     let mut proposed_active = state.candidates.clone();
@@ -635,7 +644,8 @@ impl<'a, V: TreeAciNode> InputEvaluators<'a, V> {
     pub(crate) fn evaluate<T: TreeAciScalar>(&mut self, points: &[Vec<usize>]) -> Result<Vec<T>> {
         self.enforce_guard_batch_budget::<T>(points.len())?;
         let coordinates = self.expand_points(points)?;
-        self.evaluate_expanded(points, &coordinates)
+        let hint = self.evaluation_hint(points);
+        self.evaluate_expanded(points, &coordinates, hint)
     }
 
     fn enforce_guard_batch_budget<T: TreeAciScalar>(&self, point_count: usize) -> Result<()> {
@@ -684,8 +694,8 @@ impl<'a, V: TreeAciNode> InputEvaluators<'a, V> {
         &mut self,
         points: &[Vec<usize>],
         coordinates: &[usize],
+        hint: EvaluationHint<V>,
     ) -> Result<Vec<T>> {
-        let hint = self.evaluation_hint(points);
         let shape = [self.index_count, points.len()];
         let values = ColMajorArrayRef::new(coordinates, &shape).map_err(|error| {
             TreeAciError::Numerical {
@@ -804,7 +814,8 @@ impl<'a, V: TreeAciNode> GuardOutputEvaluator<'a, V> {
     ) -> Result<Vec<T>> {
         input_evaluators.enforce_guard_batch_budget::<T>(points.len())?;
         let coordinates = input_evaluators.expand_points(points)?;
-        self.evaluate_expanded(input_evaluators, points, &coordinates)
+        let hint = input_evaluators.evaluation_hint(points);
+        self.evaluate_expanded(input_evaluators, points, &coordinates, hint)
     }
 
     fn evaluate_expanded<T: TreeAciScalar>(
@@ -812,6 +823,7 @@ impl<'a, V: TreeAciNode> GuardOutputEvaluator<'a, V> {
         input_evaluators: &InputEvaluators<'_, V>,
         points: &[Vec<usize>],
         coordinates: &[usize],
+        hint: EvaluationHint<V>,
     ) -> Result<Vec<T>> {
         let shape = [input_evaluators.index_count, points.len()];
         let values = ColMajorArrayRef::new(coordinates, &shape).map_err(|error| {
@@ -820,7 +832,7 @@ impl<'a, V: TreeAciNode> GuardOutputEvaluator<'a, V> {
             }
         })?;
         self.evaluator
-            .evaluate_batched_with_hint(values, input_evaluators.evaluation_hint(points))?
+            .evaluate_batched_with_hint(values, hint)?
             .into_iter()
             .map(|value| {
                 T::from_evaluated_scalar(value).map_err(|message| TreeAciError::ScalarKind {

--- a/crates/tensor4all-treeaci/src/global_guard/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/global_guard/tests/mod.rs
@@ -381,6 +381,38 @@ fn injection_never_exceeds_the_remaining_cut_capacity() {
 }
 
 #[test]
+fn empty_global_pivot_injection_validates_capacity_without_mutating_state() {
+    let (input, _, _) = delta_tree();
+    let options = TreeAciOptions::default();
+    let inputs = vec![input];
+    let mut state = TreeAciState::<f64, usize>::initialize(&inputs, &options).unwrap();
+    let output_before = state.output.to_dense().unwrap();
+    let candidates_before = state.candidates.clone();
+    let pivots_before = state.pivots.clone();
+    let records_before = state.sample_arena.record_count();
+    let generation_before = state.generation;
+    let ranks_before = state.edge_ranks.clone();
+
+    assert_eq!(inject_global_pivots(&mut state, &[], &[1]).unwrap(), 0);
+    assert_eq!(state.candidates, candidates_before);
+    assert_eq!(state.pivots, pivots_before);
+    assert_eq!(state.sample_arena.record_count(), records_before);
+    assert_eq!(state.generation, generation_before);
+    assert_eq!(state.edge_ranks, ranks_before);
+    assert!(state
+        .output
+        .to_dense()
+        .unwrap()
+        .isapprox(&output_before, 0.0, 0.0)
+        .unwrap());
+
+    assert!(matches!(
+        inject_global_pivots(&mut state, &[], &[]),
+        Err(crate::TreeAciError::InternalInvariant { .. })
+    ));
+}
+
+#[test]
 fn output_guard_evaluator_matches_exact_values_across_scan_centers() {
     let (input, left_site, right_site) = delta_tree();
     let options = TreeAciOptions::default();
@@ -416,6 +448,42 @@ fn output_guard_evaluator_matches_exact_values_across_scan_centers() {
         )
         .unwrap();
     for (actual, expected) in actual.iter().zip(expected) {
+        assert!((actual - expected.real()).abs() < 1.0e-12);
+    }
+}
+
+#[test]
+fn shared_guard_hint_preserves_input_and_output_values() {
+    let (input, left_site, right_site) = delta_tree();
+    let options = TreeAciOptions::default();
+    let inputs = vec![input];
+    let state = TreeAciState::<f64, usize>::initialize(&inputs, &options).unwrap();
+    let mut input_evaluators = InputEvaluators::new(state.inputs, &state.problem).unwrap();
+    let mut output_evaluator = GuardOutputEvaluator::new(
+        &state.output,
+        &state.problem,
+        options.message_cache_max_bytes,
+    )
+    .unwrap();
+    let points = vec![vec![0, 0], vec![1, 0]];
+    let coordinates = input_evaluators.expand_points(&points).unwrap();
+    let hint = input_evaluators.evaluation_hint(&points);
+    let input_values = input_evaluators
+        .evaluate_expanded::<f64>(&points, &coordinates, hint.clone())
+        .unwrap();
+    let output_values: Vec<f64> = output_evaluator
+        .evaluate_expanded(&input_evaluators, &points, &coordinates, hint)
+        .unwrap();
+
+    assert_eq!(input_values, vec![1.0, 0.0]);
+    let expected = state
+        .output
+        .evaluate(
+            &[left_site, right_site],
+            ColMajorArrayRef::new(&coordinates, &[2, 2]).unwrap(),
+        )
+        .unwrap();
+    for (actual, expected) in output_values.iter().zip(expected) {
         assert!((actual - expected.real()).abs() < 1.0e-12);
     }
 }

--- a/crates/tensor4all-treeaci/src/initialize.rs
+++ b/crates/tensor4all-treeaci/src/initialize.rs
@@ -17,8 +17,8 @@ pub(crate) fn initial_edge_ranks<V: TreeAciNode>(
     inputs: &[TreeTN<IdxTensor, V>],
     problem: &PreparedTreeProblem<V>,
     options: &TreeAciOptions<V>,
+    algebraic_bounds: &[usize],
 ) -> Result<Vec<usize>> {
-    let algebraic_bounds = algebraic_edge_bounds(problem)?;
     let mut ranks = Vec::with_capacity(problem.directed_edges.len() / 2);
     for forward in (0..problem.directed_edges.len()).step_by(2) {
         let edge = &problem.directed_edges[forward];

--- a/crates/tensor4all-treeaci/src/lib.rs
+++ b/crates/tensor4all-treeaci/src/lib.rs
@@ -42,6 +42,8 @@
 //! for genuinely branched trees.
 
 mod batch;
+#[cfg(feature = "diagnostics")]
+pub mod branch_diagnostics;
 mod elementwise;
 mod error;
 mod frames;

--- a/crates/tensor4all-treeaci/src/schedule.rs
+++ b/crates/tensor4all-treeaci/src/schedule.rs
@@ -27,7 +27,6 @@ pub(crate) struct PassReport {
     pub(crate) updated_edges: Vec<DirectedEdgeId>,
     pub(crate) max_rank: usize,
     pub(crate) max_error: f64,
-    pub(crate) rank_changed: bool,
     pub(crate) evaluated_points: u64,
 }
 
@@ -177,7 +176,6 @@ where
         PassDirection::Forward => state.problem.schedule.forward.clone(),
         PassDirection::Reverse => state.problem.schedule.reverse.clone(),
     };
-    let ranks_before = state.edge_ranks.clone();
     let mut updated_edges = Vec::with_capacity(state.problem.directed_edges.len() / 2);
     let mut evaluated_points = 0u64;
 
@@ -217,7 +215,6 @@ where
         updated_edges,
         max_rank,
         max_error,
-        rank_changed: state.edge_ranks != ranks_before,
         evaluated_points,
     })
 }

--- a/crates/tensor4all-treeaci/src/schedule.rs
+++ b/crates/tensor4all-treeaci/src/schedule.rs
@@ -24,10 +24,34 @@ pub(crate) enum PassDirection {
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PassReport {
     pub(crate) direction: PassDirection,
+    #[cfg(test)]
     pub(crate) updated_edges: Vec<DirectedEdgeId>,
     pub(crate) max_rank: usize,
     pub(crate) max_error: f64,
     pub(crate) evaluated_points: u64,
+}
+
+#[derive(Debug, Default)]
+struct UpdateTrace {
+    any: bool,
+    #[cfg(test)]
+    ordered: Vec<DirectedEdgeId>,
+}
+
+impl UpdateTrace {
+    fn with_capacity(_capacity: usize) -> Self {
+        Self {
+            any: false,
+            #[cfg(test)]
+            ordered: Vec::with_capacity(_capacity),
+        }
+    }
+
+    fn record(&mut self, _edge: DirectedEdgeId) {
+        self.any = true;
+        #[cfg(test)]
+        self.ordered.push(_edge);
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -82,40 +106,43 @@ where
         max_ranks.push(report.max_rank);
         max_errors.push(report.max_error);
         rank_limited.push(current_state_is_rank_limited(state, options));
-        let injection_capacities = global_injection_capacities(state, options);
         let found = if options.enable_global_guard
             && options.nsearch_global_pivots > 0
             && options.max_nglobal_pivots > 0
             && !rank_limited[pass]
-            && injection_capacities.iter().any(|capacity| *capacity > 0)
         {
-            if input_evaluators.is_none() {
-                let per_evaluator_budget = per_evaluator_message_cache_budget(
-                    options.message_cache_max_bytes,
-                    state.inputs.len(),
-                )?;
-                input_evaluators = Some(InputEvaluators::new_with_message_cache_max_bytes(
-                    state.inputs,
-                    &state.problem,
-                    per_evaluator_budget,
-                )?);
-            }
-            let input_evaluators =
-                input_evaluators
-                    .as_mut()
-                    .ok_or(TreeAciError::InternalInvariant {
-                        message: "enabled global Guard has no input evaluators",
+            let injection_capacities = global_injection_capacities(state, options);
+            if injection_capacities.iter().any(|capacity| *capacity > 0) {
+                if input_evaluators.is_none() {
+                    let per_evaluator_budget = per_evaluator_message_cache_budget(
+                        options.message_cache_max_bytes,
+                        state.inputs.len(),
+                    )?;
+                    input_evaluators = Some(InputEvaluators::new_with_message_cache_max_bytes(
+                        state.inputs,
+                        &state.problem,
+                        per_evaluator_budget,
+                    )?);
+                }
+                let input_evaluators =
+                    input_evaluators
+                        .as_mut()
+                        .ok_or(TreeAciError::InternalInvariant {
+                            message: "enabled global Guard has no input evaluators",
+                        })?;
+                let seed = options.rng_seed.wrapping_add((pass + 1) as u64);
+                let search = find_global_pivots(state, input_evaluators, options, seed, operator)?;
+                evaluated_points = evaluated_points
+                    .checked_add(search.evaluated_points)
+                    .ok_or(TreeAciError::SizeOverflow {
+                        context: "sweep evaluated point count",
                     })?;
-            let seed = options.rng_seed.wrapping_add((pass + 1) as u64);
-            let search = find_global_pivots(state, input_evaluators, options, seed, operator)?;
-            evaluated_points = evaluated_points
-                .checked_add(search.evaluated_points)
-                .ok_or(TreeAciError::SizeOverflow {
-                    context: "sweep evaluated point count",
-                })?;
-            let found = search.pivots.len();
-            inject_global_pivots(state, &search.pivots, &injection_capacities)?;
-            found
+                let found = search.pivots.len();
+                inject_global_pivots(state, &search.pivots, &injection_capacities)?;
+                found
+            } else {
+                0
+            }
         } else {
             0
         };
@@ -176,7 +203,7 @@ where
         PassDirection::Forward => state.problem.schedule.forward.clone(),
         PassDirection::Reverse => state.problem.schedule.reverse.clone(),
     };
-    let mut updated_edges = Vec::with_capacity(state.problem.directed_edges.len() / 2);
+    let mut update_trace = UpdateTrace::with_capacity(state.problem.directed_edges.len() / 2);
     let mut evaluated_points = 0u64;
 
     for phase in &phases {
@@ -185,10 +212,10 @@ where
             options,
             phase,
             operator,
-            &mut updated_edges,
+            &mut update_trace,
             &mut evaluated_points,
         ) {
-            if !updated_edges.is_empty() {
+            if update_trace.any {
                 finalize_deferred_canonicalization(state)?;
             }
             return Err(error);
@@ -212,7 +239,8 @@ where
         .fold(0.0, f64::max);
     Ok(PassReport {
         direction,
-        updated_edges,
+        #[cfg(test)]
+        updated_edges: update_trace.ordered,
         max_rank,
         max_error,
         evaluated_points,
@@ -242,7 +270,7 @@ fn run_phase_serial<T, V, F>(
     options: &TreeAciOptions<V>,
     phase: &PathPhase,
     operator: &mut F,
-    updated_edges: &mut Vec<DirectedEdgeId>,
+    update_trace: &mut UpdateTrace,
     evaluated_points: &mut u64,
 ) -> Result<()>
 where
@@ -281,7 +309,7 @@ where
                 .ok_or(TreeAciError::SizeOverflow {
                     context: "pass evaluated point count",
                 })?;
-            updated_edges.push(directed);
+            update_trace.record(directed);
         }
     }
     Ok(())

--- a/crates/tensor4all-treeaci/src/state.rs
+++ b/crates/tensor4all-treeaci/src/state.rs
@@ -77,7 +77,8 @@ impl<'a, T: TreeAciScalar, V: TreeAciNode> TreeAciState<'a, T, V> {
         let stage_started = std::time::Instant::now();
         let problem = prepare_problem(inputs, options)?;
         let algebraic_edge_bounds = algebraic_edge_bounds(&problem)?;
-        let initial_edge_ranks = initial_edge_ranks(inputs, &problem, options)?;
+        let initial_edge_ranks =
+            initial_edge_ranks(inputs, &problem, options, &algebraic_edge_bounds)?;
         #[cfg(test)]
         profile_debug_stats::record(|stats| stats.preparation = stage_started.elapsed());
         #[cfg(test)]

--- a/crates/tensor4all-treeaci/src/state/tests/mod.rs
+++ b/crates/tensor4all-treeaci/src/state/tests/mod.rs
@@ -2,7 +2,7 @@ use tensor4all_core::{DynIndex, IdxTensor, IndexLike};
 use tensor4all_treetn::TreeTN;
 
 use super::TreeAciState;
-use crate::initialize::{build_random_output, initial_edge_ranks};
+use crate::initialize::{algebraic_edge_bounds, build_random_output, initial_edge_ranks};
 use crate::problem::prepare_problem;
 use crate::schedule::run_local_sweeps;
 use crate::{TreeAciError, TreeAciOptions};
@@ -309,7 +309,8 @@ fn unseeded_initialization_defers_numeric_canonicalization() {
         ..TreeAciOptions::default()
     };
     let problem = prepare_problem(&inputs, &options).unwrap();
-    let edge_ranks = initial_edge_ranks(&inputs, &problem, &options).unwrap();
+    let algebraic_bounds = algebraic_edge_bounds(&problem).unwrap();
+    let edge_ranks = initial_edge_ranks(&inputs, &problem, &options, &algebraic_bounds).unwrap();
     let raw =
         build_random_output::<f64, usize>(&inputs[0], &problem, &edge_ranks, &options).unwrap();
     let state = TreeAciState::<f64, usize>::initialize(&inputs, &options).unwrap();

--- a/crates/tensor4all-treeaci/src/transaction.rs
+++ b/crates/tensor4all-treeaci/src/transaction.rs
@@ -55,6 +55,17 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
     forward: DirectedEdgeId,
     proposal: LocalUpdateResult<T>,
 ) -> Result<EdgeCommitReport> {
+    let LocalUpdateResult {
+        row_samples,
+        col_samples,
+        left,
+        right,
+        pivot_errors,
+        sampled_scale,
+        row_count,
+        col_count,
+        ..
+    } = proposal;
     let directed =
         state
             .problem
@@ -64,18 +75,13 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
                 message: "edge proposal references an unknown directed edge",
             })?;
     let reverse = directed.reverse;
-    let new_rank = proposal.left.ncols();
-    let evaluated_points =
-        proposal
-            .row_count
-            .checked_mul(proposal.col_count)
-            .ok_or(TreeAciError::SizeOverflow {
-                context: "edge evaluated point count",
-            })?;
-    if proposal.right.nrows() != new_rank
-        || proposal.row_samples.len() != new_rank
-        || proposal.col_samples.len() != new_rank
-    {
+    let new_rank = left.ncols();
+    let evaluated_points = row_count
+        .checked_mul(col_count)
+        .ok_or(TreeAciError::SizeOverflow {
+            context: "edge evaluated point count",
+        })?;
+    if right.nrows() != new_rank || row_samples.len() != new_rank || col_samples.len() != new_rank {
         return Err(TreeAciError::InternalInvariant {
             message: "edge proposal factors and selected samples disagree on rank",
         });
@@ -90,13 +96,7 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
     #[cfg(test)]
     let output_started = std::time::Instant::now();
     let mut proposed_output = state.output.clone();
-    replace_edge_cores(
-        &mut proposed_output,
-        &state.problem,
-        forward,
-        proposal.left,
-        proposal.right,
-    )?;
+    replace_edge_cores(&mut proposed_output, &state.problem, forward, left, right)?;
     #[cfg(test)]
     crate::state::profile_debug_stats::record(|stats| {
         stats.output_staging += output_started.elapsed();
@@ -105,20 +105,16 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
     let staged = (|| {
         #[cfg(test)]
         let samples_started = std::time::Instant::now();
-        let left_ids = proposal
-            .row_samples
-            .iter()
-            .cloned()
+        let left_ids = row_samples
+            .into_iter()
             .map(|sample| {
                 state
                     .sample_arena
                     .intern_component(&state.problem, forward, sample)
             })
             .collect::<Result<Vec<_>>>()?;
-        let right_ids = proposal
-            .col_samples
-            .iter()
-            .cloned()
+        let right_ids = col_samples
+            .into_iter()
             .map(|sample| {
                 state
                     .sample_arena
@@ -174,7 +170,7 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
     };
     state.pivots.set(edge_number, pivot_pairs);
 
-    let pivot_error = proposal.pivot_errors.last().copied().unwrap_or(0.0);
+    let pivot_error = pivot_errors.last().copied().unwrap_or(0.0);
     state.output = proposed_output;
     state.input_frames = proposed_frames;
     state.edge_ranks[edge_number] = state.pivots.rank(edge_number);
@@ -187,7 +183,7 @@ fn commit_edge_proposal<T: TreeAciScalar, V: TreeAciNode>(
         forward,
         new_rank,
         pivot_error,
-        sampled_scale: proposal.sampled_scale,
+        sampled_scale,
         evaluated_points,
     })
 }

--- a/crates/tensor4all-treetn/Cargo.toml
+++ b/crates/tensor4all-treetn/Cargo.toml
@@ -28,6 +28,7 @@ tenferro-provider-inject = [
     "tensor4all-tensorbackend/backend-tenferro",
     "tensor4all-tensorbackend/tenferro-provider-inject",
 ]
+diagnostics = []
 
 [dependencies]
 tensor4all-core = { path = "../tensor4all-core", default-features = false }

--- a/crates/tensor4all-treetn/src/lib.rs
+++ b/crates/tensor4all-treetn/src/lib.rs
@@ -82,6 +82,8 @@ pub use simplett_bridge::{
 };
 pub use site_index_network::SiteIndexNetwork;
 pub use tdvp::{tdvp, tdvp_with_treetn_operator, TdvpError, TdvpOptions, TdvpResult};
+#[cfg(feature = "diagnostics")]
+pub use treetn::diagnostics;
 pub use treetn::{
     // Local update
     apply_local_update_sweep,

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -2447,13 +2447,15 @@ where
         #[cfg(feature = "diagnostics")]
         let (diag_coordination_number, diag_bond_dims) = {
             let neighbors: Vec<V> = self.tree.site_index_network().neighbors(node).collect();
+            // One entry per neighbor, so `bond_dims.len()` always equals the
+            // coordination number; an unavailable dimension records `0`.
             let bond_dims = neighbors
                 .iter()
-                .filter_map(|neighbor| {
+                .map(|neighbor| {
                     self.tree
                         .edge_between(node, neighbor)
                         .and_then(|edge| self.tree.bond_index(edge))
-                        .map(|index| index.dim())
+                        .map_or(0, |index| index.dim())
                 })
                 .collect::<Vec<_>>();
             (neighbors.len(), bond_dims)

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -1758,25 +1758,32 @@ where
             // column below.
             #[cfg(feature = "diagnostics")]
             let setup_start = std::time::Instant::now();
+            // Loop-invariant-hoisted rewrite of the original per-(c1,c2,parent)
+            // `axis_values` array + 4-term stride dot product: mathematically
+            // identical to `physical_value*strides[physical_axis] +
+            // c1*strides[child_axis_1] + c2*strides[child_axis_2] +
+            // parent*strides[parent_axis]`, just accumulated incrementally
+            // instead of recomputed from scratch on every one of the up to
+            // `parent_dim*child_dim_1*child_dim_2` iterations -- issue #671's
+            // downstream data showed this loop, not the BLAS call after it,
+            // dominates a branch node's contraction time at realistic bond
+            // dimensions (setup_ns >> matmul_ns).
             let left_len = parent_dim * child_dim_2 * child_dim_1;
             let mut left = vec![T::default(); left_len];
+            let physical_base = physical_value * strides[physical_axis];
             for c1 in 0..child_dim_1 {
+                let base_after_c1 = physical_base + c1 * strides[child_axis_1];
+                let left_c1_offset = parent_dim * child_dim_2 * c1;
                 for c2 in 0..child_dim_2 {
+                    let base_after_c2 = base_after_c1 + c2 * strides[child_axis_2];
+                    let left_c2_offset = left_c1_offset + parent_dim * c2;
+                    let mut flat = base_after_c2;
                     for parent in 0..parent_dim {
-                        let mut axis_values = [0usize; 4];
-                        axis_values[physical_axis] = physical_value;
-                        axis_values[parent_axis] = parent;
-                        axis_values[child_axis_1] = c1;
-                        axis_values[child_axis_2] = c2;
-                        let flat = axis_values[0] * strides[0]
-                            + axis_values[1] * strides[1]
-                            + axis_values[2] * strides[2]
-                            + axis_values[3] * strides[3];
-                        let left_row = parent + parent_dim * c2;
-                        let left_offset = left_row + parent_dim * child_dim_2 * c1;
+                        let left_offset = left_c2_offset + parent;
                         left[left_offset] = *raw.get(flat).ok_or_else(|| {
                             anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
                         })?;
+                        flat += strides[parent_axis];
                     }
                 }
             }

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -42,6 +42,8 @@ use tensor4all_core::{
 };
 use tensor4all_tensorbackend::{mat_mul_owned, BlasMul, Matrix};
 
+#[cfg(feature = "diagnostics")]
+use super::diagnostics;
 use super::TreeTN;
 
 type KeyId = usize;
@@ -2440,6 +2442,22 @@ where
         })?;
         #[cfg(test)]
         let phase_start = std::time::Instant::now();
+        #[cfg(feature = "diagnostics")]
+        let diag_start = std::time::Instant::now();
+        #[cfg(feature = "diagnostics")]
+        let (diag_coordination_number, diag_bond_dims) = {
+            let neighbors: Vec<V> = self.tree.site_index_network().neighbors(node).collect();
+            let bond_dims = neighbors
+                .iter()
+                .filter_map(|neighbor| {
+                    self.tree
+                        .edge_between(node, neighbor)
+                        .and_then(|edge| self.tree.bond_index(edge))
+                        .map(|index| index.dim())
+                })
+                .collect::<Vec<_>>();
+            (neighbors.len(), bond_dims)
+        };
         let points = assignment_batch.first_points.clone();
         let cache_layout = message_cache_layouts.get(node).ok_or_else(|| {
             anyhow::anyhow!(
@@ -2532,6 +2550,15 @@ where
                 #[cfg(test)]
                 phase_timing::add(&phase_timing::RECONSTRUCT_NS, reconstruct_start.elapsed());
                 self.last_stats.message_cache_hits += keys.len();
+                #[cfg(feature = "diagnostics")]
+                diagnostics::record_guard(
+                    &format!("{node:?}"),
+                    diag_coordination_number,
+                    &diag_bond_dims,
+                    diag_start.elapsed(),
+                    keys.len() as u64,
+                    0,
+                );
                 return Ok(StackedMessage {
                     assignment_index,
                     tensor,
@@ -2553,6 +2580,8 @@ where
         phase_timing::add(&phase_timing::KEY_AND_LOOKUP_NS, phase_start.elapsed());
         self.last_stats.message_cache_hits += hit_keys.len();
         self.last_stats.message_cache_misses += missing_indices.len();
+        #[cfg(feature = "diagnostics")]
+        let (diag_hits, diag_misses) = (hit_keys.len() as u64, missing_indices.len() as u64);
         if !hit_keys.is_empty() {
             // `entry().or_insert_with()` rather than `get_mut().expect(...)`:
             // the entry for `node` was inserted above and nothing removes
@@ -2755,6 +2784,15 @@ where
         };
         #[cfg(test)]
         phase_timing::add(&phase_timing::RECONSTRUCT_NS, reconstruct_start.elapsed());
+        #[cfg(feature = "diagnostics")]
+        diagnostics::record_guard(
+            &format!("{node:?}"),
+            diag_coordination_number,
+            &diag_bond_dims,
+            diag_start.elapsed(),
+            diag_hits,
+            diag_misses,
+        );
         Ok(StackedMessage {
             assignment_index,
             tensor,
@@ -5210,6 +5248,47 @@ mod tests {
             hub_message.tensor.is_none(),
             "raw branch messages should not be materialized into an IdxTensor"
         );
+    }
+
+    #[cfg(feature = "diagnostics")]
+    #[test]
+    fn build_environment_cache_records_guard_diagnostics_per_node_with_correct_coordination_numbers(
+    ) {
+        use crate::treetn::diagnostics;
+
+        let (tree, indices) = star_tree();
+        let mut evaluator = TreeTNCachedEvaluator::new(
+            &tree,
+            &indices,
+            CachedEvaluatorOptions {
+                center: Some(1),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let shape = [4usize, 2usize];
+        let values = [0usize, 0, 0, 0, 1, 0, 1, 1];
+        let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+
+        diagnostics::reset();
+        let _ = evaluator.build_environment_cache(&1, points).unwrap();
+
+        let snapshot = diagnostics::snapshot();
+        let hub_record = snapshot
+            .iter()
+            .find(|record| record.node == "0")
+            .expect("hub node (0) recorded");
+        assert_eq!(hub_record.coordination_number, 3);
+        assert_eq!(hub_record.bond_dims.len(), 3);
+        assert!(hub_record.guard_cache_hits + hub_record.guard_cache_misses > 0);
+
+        for leaf in ["2", "3"] {
+            let leaf_record = snapshot
+                .iter()
+                .find(|record| record.node == leaf)
+                .unwrap_or_else(|| panic!("leaf node ({leaf}) recorded"));
+            assert_eq!(leaf_record.coordination_number, 1);
+        }
     }
 
     #[test]

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -32,6 +32,85 @@ mod phase_timing {
     }
 }
 
+/// Temporary counters for issue #671's root-cause investigation: whether the
+/// branch contraction kernel's per-physical-value BLAS setup (building the
+/// `left` intermediate in [`TreeTNCachedEvaluator::grouped_branch_message_contraction`])
+/// is a fixed cost that amortizes poorly against Guard's typically small
+/// per-call point counts, unlike the chain kernel
+/// ([`TreeTNCachedEvaluator::grouped_chain_message_contraction`]), which has
+/// an explicit `CHAIN_BLAS_MIN_GROUP_POINTS`/`groups.len() > 8` safeguard the
+/// branch kernel does not. Not on the hot path unless `diagnostics` is
+/// enabled.
+#[cfg(feature = "diagnostics")]
+pub(crate) mod contraction_diagnostics {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    pub static BRANCH_SETUP_NS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_MATMUL_NS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_ACCUMULATE_NS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_BLAS_CALLS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_BLAS_POINTS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_BLAS_GROUPS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_SCALAR_CALLS: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_SCALAR_POINTS: AtomicU64 = AtomicU64::new(0);
+
+    pub static CHAIN_CONTRACT_NS: AtomicU64 = AtomicU64::new(0);
+    pub static CHAIN_BLAS_CALLS: AtomicU64 = AtomicU64::new(0);
+    pub static CHAIN_BLAS_POINTS: AtomicU64 = AtomicU64::new(0);
+    pub static CHAIN_SCALAR_CALLS: AtomicU64 = AtomicU64::new(0);
+    pub static CHAIN_SCALAR_POINTS: AtomicU64 = AtomicU64::new(0);
+
+    pub fn add(counter: &AtomicU64, elapsed: std::time::Duration) {
+        counter.fetch_add(elapsed.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    pub fn inc(counter: &AtomicU64, by: usize) {
+        counter.fetch_add(by as u64, Ordering::Relaxed);
+    }
+
+    pub fn reset_all() {
+        for counter in [
+            &BRANCH_SETUP_NS,
+            &BRANCH_MATMUL_NS,
+            &BRANCH_ACCUMULATE_NS,
+            &BRANCH_BLAS_CALLS,
+            &BRANCH_BLAS_POINTS,
+            &BRANCH_BLAS_GROUPS,
+            &BRANCH_SCALAR_CALLS,
+            &BRANCH_SCALAR_POINTS,
+            &CHAIN_CONTRACT_NS,
+            &CHAIN_BLAS_CALLS,
+            &CHAIN_BLAS_POINTS,
+            &CHAIN_SCALAR_CALLS,
+            &CHAIN_SCALAR_POINTS,
+        ] {
+            counter.store(0, Ordering::Relaxed);
+        }
+    }
+
+    /// Renders every counter as one human-readable line.
+    pub fn summary() -> String {
+        format!(
+            "branch: blas_calls={} blas_points={} blas_groups={} setup_ns={} matmul_ns={} accumulate_ns={} \
+             scalar_calls={} scalar_points={} | chain: blas_calls={} blas_points={} contract_ns={} \
+             scalar_calls={} scalar_points={}",
+            BRANCH_BLAS_CALLS.load(Ordering::Relaxed),
+            BRANCH_BLAS_POINTS.load(Ordering::Relaxed),
+            BRANCH_BLAS_GROUPS.load(Ordering::Relaxed),
+            BRANCH_SETUP_NS.load(Ordering::Relaxed),
+            BRANCH_MATMUL_NS.load(Ordering::Relaxed),
+            BRANCH_ACCUMULATE_NS.load(Ordering::Relaxed),
+            BRANCH_SCALAR_CALLS.load(Ordering::Relaxed),
+            BRANCH_SCALAR_POINTS.load(Ordering::Relaxed),
+            CHAIN_BLAS_CALLS.load(Ordering::Relaxed),
+            CHAIN_BLAS_POINTS.load(Ordering::Relaxed),
+            CHAIN_CONTRACT_NS.load(Ordering::Relaxed),
+            CHAIN_SCALAR_CALLS.load(Ordering::Relaxed),
+            CHAIN_SCALAR_POINTS.load(Ordering::Relaxed),
+        )
+    }
+}
+
 use anyhow::{bail, ensure, Context, Result};
 use num_complex::Complex64;
 use tensor4all_core::{
@@ -1449,6 +1528,14 @@ where
             .ok_or_else(|| anyhow::anyhow!("chain parent-message shape overflows usize"))?;
 
         if point_count < 2 * CHAIN_BLAS_MIN_GROUP_POINTS {
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_SCALAR_CALLS, 1);
+                contraction_diagnostics::inc(
+                    &contraction_diagnostics::CHAIN_SCALAR_POINTS,
+                    point_count,
+                );
+            }
             return scalar_chain_message_contraction(spec, raw, physical_values, child_columns);
         }
 
@@ -1466,7 +1553,22 @@ where
                 .values()
                 .any(|points| points.len() < CHAIN_BLAS_MIN_GROUP_POINTS)
         {
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_SCALAR_CALLS, 1);
+                contraction_diagnostics::inc(
+                    &contraction_diagnostics::CHAIN_SCALAR_POINTS,
+                    point_count,
+                );
+            }
             return scalar_chain_message_contraction(spec, raw, physical_values, child_columns);
+        }
+        #[cfg(feature = "diagnostics")]
+        let diag_start = std::time::Instant::now();
+        #[cfg(feature = "diagnostics")]
+        {
+            contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_BLAS_CALLS, 1);
+            contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_BLAS_POINTS, point_count);
         }
 
         let matrix_len = parent_dim
@@ -1538,6 +1640,11 @@ where
                     .copy_from_slice(&product.as_col_major_slice()[source..source_end]);
             }
         }
+        #[cfg(feature = "diagnostics")]
+        contraction_diagnostics::add(
+            &contraction_diagnostics::CHAIN_CONTRACT_NS,
+            diag_start.elapsed(),
+        );
         Ok(output)
     }
 
@@ -1610,6 +1717,14 @@ where
         // `scalar_work` alone is the right gate.
         let scalar_work = parent_dim * child_dim_1 * child_dim_2 * point_count;
         if scalar_work < BRANCH_BLAS_WORK_THRESHOLD {
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::inc(&contraction_diagnostics::BRANCH_SCALAR_CALLS, 1);
+                contraction_diagnostics::inc(
+                    &contraction_diagnostics::BRANCH_SCALAR_POINTS,
+                    point_count,
+                );
+            }
             return scalar_branch_message_contraction(
                 spec,
                 raw,
@@ -1623,6 +1738,15 @@ where
         for (point, &physical_value) in physical_values.iter().enumerate() {
             groups.entry(physical_value).or_default().push(point);
         }
+        #[cfg(feature = "diagnostics")]
+        {
+            contraction_diagnostics::inc(&contraction_diagnostics::BRANCH_BLAS_CALLS, 1);
+            contraction_diagnostics::inc(&contraction_diagnostics::BRANCH_BLAS_POINTS, point_count);
+            contraction_diagnostics::inc(
+                &contraction_diagnostics::BRANCH_BLAS_GROUPS,
+                groups.len(),
+            );
+        }
 
         let mut output = vec![T::default(); point_count * parent_dim];
         for (physical_value, points) in groups {
@@ -1632,6 +1756,8 @@ where
             // along in "rows", ordered slower than parent so a fixed c2
             // selects a contiguous parent_dim-length row block within each
             // column below.
+            #[cfg(feature = "diagnostics")]
+            let setup_start = std::time::Instant::now();
             let left_len = parent_dim * child_dim_2 * child_dim_1;
             let mut left = vec![T::default(); left_len];
             for c1 in 0..child_dim_1 {
@@ -1659,12 +1785,28 @@ where
                 let start = point * child_dim_1;
                 right.extend_from_slice(&child1_columns[start..start + child_dim_1]);
             }
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::add(
+                    &contraction_diagnostics::BRANCH_SETUP_NS,
+                    setup_start.elapsed(),
+                );
+            }
+            #[cfg(feature = "diagnostics")]
+            let matmul_start = std::time::Instant::now();
             let intermediate = mat_mul_owned(
                 Matrix::from_col_major_vec(parent_dim * child_dim_2, child_dim_1, left),
                 Matrix::from_col_major_vec(child_dim_1, points.len(), right),
             )
             .map_err(anyhow::Error::from)?;
             let intermediate = intermediate.as_col_major_slice();
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::add(
+                    &contraction_diagnostics::BRANCH_MATMUL_NS,
+                    matmul_start.elapsed(),
+                );
+            }
 
             // Step B: fold in child 2 via a vectorized accumulate over
             // child_dim_2 -- the intermediate's "rows" already interleave
@@ -1672,6 +1814,8 @@ where
             // c2 the parent_dim-length slice at rows
             // [c2*parent_dim, (c2+1)*parent_dim) within each group-column is
             // contiguous.
+            #[cfg(feature = "diagnostics")]
+            let accumulate_start = std::time::Instant::now();
             for (column, &point) in points.iter().enumerate() {
                 let column_base = column * parent_dim * child_dim_2;
                 let destination = point * parent_dim;
@@ -1683,6 +1827,13 @@ where
                             intermediate[row_base + parent] * child2_value;
                     }
                 }
+            }
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::add(
+                    &contraction_diagnostics::BRANCH_ACCUMULATE_NS,
+                    accumulate_start.elapsed(),
+                );
             }
         }
         Ok(output)

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -1777,13 +1777,31 @@ where
                 for c2 in 0..child_dim_2 {
                     let base_after_c2 = base_after_c1 + c2 * strides[child_axis_2];
                     let left_c2_offset = left_c1_offset + parent_dim * c2;
-                    let mut flat = base_after_c2;
-                    for parent in 0..parent_dim {
-                        let left_offset = left_c2_offset + parent;
-                        left[left_offset] = *raw.get(flat).ok_or_else(|| {
-                            anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                    if strides[parent_axis] == 1 {
+                        // `parent` happens to be `raw`'s fastest (contiguous)
+                        // axis for this node's tensor -- read the whole
+                        // parent_dim run as one slice instead of one
+                        // bounds-checked element at a time. Same values,
+                        // same write offsets as the general branch below;
+                        // just lets the compiler emit a vectorized copy.
+                        let end = base_after_c2.checked_add(parent_dim).ok_or_else(|| {
+                            anyhow::anyhow!("branch tensor offset overflows usize")
                         })?;
-                        flat += strides[parent_axis];
+                        let slice = raw.get(base_after_c2..end).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "branch tensor offset {base_after_c2}..{end} is out of bounds"
+                            )
+                        })?;
+                        left[left_c2_offset..left_c2_offset + parent_dim].copy_from_slice(slice);
+                    } else {
+                        let mut flat = base_after_c2;
+                        for parent in 0..parent_dim {
+                            let left_offset = left_c2_offset + parent;
+                            left[left_offset] = *raw.get(flat).ok_or_else(|| {
+                                anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                            })?;
+                            flat += strides[parent_axis];
+                        }
                     }
                 }
             }
@@ -4789,6 +4807,69 @@ mod tests {
             child_dim_2,
         };
         let raw: Vec<f64> = (0..2 * parent_dim * child_dim_1 * child_dim_2)
+            .map(|value| (value % 19) as f64 - 9.0)
+            .collect();
+        let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();
+        let child1_columns: Vec<f64> = (0..point_count * child_dim_1)
+            .map(|value| (value % 13) as f64 - 6.0)
+            .collect();
+        let child2_columns: Vec<f64> = (0..point_count * child_dim_2)
+            .map(|value| (value % 11) as f64 - 5.0)
+            .collect();
+
+        let actual = TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+        let expected = scalar_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+
+        assert!(actual
+            .iter()
+            .zip(expected)
+            .all(|(actual, expected)| (actual - expected).abs() < 1.0e-6));
+    }
+
+    /// Same shape as `grouped_branch_contraction_large_real_groups_match_scalar_reference`,
+    /// but with `parent_axis` mapped to `raw`'s stride-1 (fastest) position
+    /// instead of `physical_axis` -- the contiguous-read fast path added
+    /// alongside the loop-invariant-hoisting fix (both for issue #671) only
+    /// runs when `strides[parent_axis] == 1`, and no existing test happened
+    /// to exercise that case (every other fixture puts `physical_axis` at
+    /// stride 1).
+    #[test]
+    fn grouped_branch_contraction_matches_scalar_reference_when_parent_axis_is_contiguous() {
+        let parent_dim = 8;
+        let child_dim_1 = 8;
+        let child_dim_2 = 8;
+        let physical_dim = 2;
+        let point_count = 16;
+        let spec = BranchContractionSpec {
+            strides: [
+                1,
+                parent_dim,
+                parent_dim * physical_dim,
+                parent_dim * physical_dim * child_dim_1,
+            ],
+            parent_axis: 0,
+            physical_axis: 1,
+            child_axis_1: 2,
+            child_axis_2: 3,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw: Vec<f64> = (0..parent_dim * physical_dim * child_dim_1 * child_dim_2)
             .map(|value| (value % 19) as f64 - 9.0)
             .collect();
         let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -54,6 +54,18 @@ pub(crate) mod contraction_diagnostics {
     pub static BRANCH_SCALAR_CALLS: AtomicU64 = AtomicU64::new(0);
     pub static BRANCH_SCALAR_POINTS: AtomicU64 = AtomicU64::new(0);
 
+    /// Scratch counters (not wired into [`summary`]) for whether the
+    /// contiguous-read fast path's `parent_axis == raw's fastest axis`
+    /// condition is the common case among calls that reach the BLAS path, or
+    /// whether `child_axis_1`/`child_axis_2` land there instead -- deciding
+    /// whether generalizing the fast path to those two axes is worth the
+    /// added complexity. One increment per BLAS call (not per group; the
+    /// axis assignment is the same for every group in a call).
+    pub static BRANCH_FAST_AXIS_IS_PARENT: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_FAST_AXIS_IS_CHILD1: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_FAST_AXIS_IS_CHILD2: AtomicU64 = AtomicU64::new(0);
+    pub static BRANCH_FAST_AXIS_IS_PHYSICAL: AtomicU64 = AtomicU64::new(0);
+
     pub static CHAIN_CONTRACT_NS: AtomicU64 = AtomicU64::new(0);
     pub static CHAIN_BLAS_CALLS: AtomicU64 = AtomicU64::new(0);
     pub static CHAIN_BLAS_POINTS: AtomicU64 = AtomicU64::new(0);
@@ -78,6 +90,10 @@ pub(crate) mod contraction_diagnostics {
             &BRANCH_BLAS_GROUPS,
             &BRANCH_SCALAR_CALLS,
             &BRANCH_SCALAR_POINTS,
+            &BRANCH_FAST_AXIS_IS_PARENT,
+            &BRANCH_FAST_AXIS_IS_CHILD1,
+            &BRANCH_FAST_AXIS_IS_CHILD2,
+            &BRANCH_FAST_AXIS_IS_PHYSICAL,
             &CHAIN_CONTRACT_NS,
             &CHAIN_BLAS_CALLS,
             &CHAIN_BLAS_POINTS,
@@ -92,7 +108,8 @@ pub(crate) mod contraction_diagnostics {
     pub fn summary() -> String {
         format!(
             "branch: blas_calls={} blas_points={} blas_groups={} setup_ns={} matmul_ns={} accumulate_ns={} \
-             scalar_calls={} scalar_points={} | chain: blas_calls={} blas_points={} contract_ns={} \
+             scalar_calls={} scalar_points={} fast_axis[parent={} child1={} child2={} physical={}] \
+             | chain: blas_calls={} blas_points={} contract_ns={} \
              scalar_calls={} scalar_points={}",
             BRANCH_BLAS_CALLS.load(Ordering::Relaxed),
             BRANCH_BLAS_POINTS.load(Ordering::Relaxed),
@@ -102,6 +119,10 @@ pub(crate) mod contraction_diagnostics {
             BRANCH_ACCUMULATE_NS.load(Ordering::Relaxed),
             BRANCH_SCALAR_CALLS.load(Ordering::Relaxed),
             BRANCH_SCALAR_POINTS.load(Ordering::Relaxed),
+            BRANCH_FAST_AXIS_IS_PARENT.load(Ordering::Relaxed),
+            BRANCH_FAST_AXIS_IS_CHILD1.load(Ordering::Relaxed),
+            BRANCH_FAST_AXIS_IS_CHILD2.load(Ordering::Relaxed),
+            BRANCH_FAST_AXIS_IS_PHYSICAL.load(Ordering::Relaxed),
             CHAIN_BLAS_CALLS.load(Ordering::Relaxed),
             CHAIN_BLAS_POINTS.load(Ordering::Relaxed),
             CHAIN_CONTRACT_NS.load(Ordering::Relaxed),
@@ -1746,6 +1767,16 @@ where
                 &contraction_diagnostics::BRANCH_BLAS_GROUPS,
                 groups.len(),
             );
+            let fast_axis_counter = if strides[parent_axis] == 1 {
+                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_PARENT
+            } else if strides[child_axis_1] == 1 {
+                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_CHILD1
+            } else if strides[child_axis_2] == 1 {
+                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_CHILD2
+            } else {
+                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_PHYSICAL
+            };
+            contraction_diagnostics::inc(fast_axis_counter, 1);
         }
 
         let mut output = vec![T::default(); point_count * parent_dim];
@@ -1771,36 +1802,67 @@ where
             let left_len = parent_dim * child_dim_2 * child_dim_1;
             let mut left = vec![T::default(); left_len];
             let physical_base = physical_value * strides[physical_axis];
-            for c1 in 0..child_dim_1 {
-                let base_after_c1 = physical_base + c1 * strides[child_axis_1];
-                let left_c1_offset = parent_dim * child_dim_2 * c1;
-                for c2 in 0..child_dim_2 {
-                    let base_after_c2 = base_after_c1 + c2 * strides[child_axis_2];
-                    let left_c2_offset = left_c1_offset + parent_dim * c2;
-                    if strides[parent_axis] == 1 {
-                        // `parent` happens to be `raw`'s fastest (contiguous)
-                        // axis for this node's tensor -- read the whole
-                        // parent_dim run as one slice instead of one
-                        // bounds-checked element at a time. Same values,
-                        // same write offsets as the general branch below;
-                        // just lets the compiler emit a vectorized copy.
-                        let end = base_after_c2.checked_add(parent_dim).ok_or_else(|| {
+            if strides[child_axis_2] == 1 {
+                // `child2` happens to be `raw`'s fastest (contiguous) axis --
+                // read the whole child_dim_2 run as one slice per (c1, parent)
+                // instead of one bounds-checked element at a time. `child2` is
+                // NOT `left`'s fastest write axis (`parent` is, per the layout
+                // note above), so this scatters the contiguous read into a
+                // parent_dim-strided write -- still a net win, since `raw`
+                // (this node's own tensor) is what the earlier fast-axis
+                // census (issue #671) found the reads on, not the much
+                // smaller `left` buffer the writes land in. Same values, same
+                // final `left` contents as the fully general branch below.
+                for c1 in 0..child_dim_1 {
+                    let base_after_c1 = physical_base + c1 * strides[child_axis_1];
+                    let left_c1_offset = parent_dim * child_dim_2 * c1;
+                    for parent in 0..parent_dim {
+                        let base = base_after_c1 + parent * strides[parent_axis];
+                        let end = base.checked_add(child_dim_2).ok_or_else(|| {
                             anyhow::anyhow!("branch tensor offset overflows usize")
                         })?;
-                        let slice = raw.get(base_after_c2..end).ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "branch tensor offset {base_after_c2}..{end} is out of bounds"
-                            )
+                        let slice = raw.get(base..end).ok_or_else(|| {
+                            anyhow::anyhow!("branch tensor offset {base}..{end} is out of bounds")
                         })?;
-                        left[left_c2_offset..left_c2_offset + parent_dim].copy_from_slice(slice);
-                    } else {
-                        let mut flat = base_after_c2;
-                        for parent in 0..parent_dim {
-                            let left_offset = left_c2_offset + parent;
-                            left[left_offset] = *raw.get(flat).ok_or_else(|| {
-                                anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                        let left_base = left_c1_offset + parent;
+                        for (c2, &value) in slice.iter().enumerate() {
+                            left[left_base + parent_dim * c2] = value;
+                        }
+                    }
+                }
+            } else {
+                for c1 in 0..child_dim_1 {
+                    let base_after_c1 = physical_base + c1 * strides[child_axis_1];
+                    let left_c1_offset = parent_dim * child_dim_2 * c1;
+                    for c2 in 0..child_dim_2 {
+                        let base_after_c2 = base_after_c1 + c2 * strides[child_axis_2];
+                        let left_c2_offset = left_c1_offset + parent_dim * c2;
+                        if strides[parent_axis] == 1 {
+                            // `parent` happens to be `raw`'s fastest (contiguous)
+                            // axis for this node's tensor -- read the whole
+                            // parent_dim run as one slice instead of one
+                            // bounds-checked element at a time. Same values,
+                            // same write offsets as the general branch below;
+                            // just lets the compiler emit a vectorized copy.
+                            let end = base_after_c2.checked_add(parent_dim).ok_or_else(|| {
+                                anyhow::anyhow!("branch tensor offset overflows usize")
                             })?;
-                            flat += strides[parent_axis];
+                            let slice = raw.get(base_after_c2..end).ok_or_else(|| {
+                                anyhow::anyhow!(
+                                    "branch tensor offset {base_after_c2}..{end} is out of bounds"
+                                )
+                            })?;
+                            left[left_c2_offset..left_c2_offset + parent_dim]
+                                .copy_from_slice(slice);
+                        } else {
+                            let mut flat = base_after_c2;
+                            for parent in 0..parent_dim {
+                                let left_offset = left_c2_offset + parent;
+                                left[left_offset] = *raw.get(flat).ok_or_else(|| {
+                                    anyhow::anyhow!("branch tensor offset {flat} is out of bounds")
+                                })?;
+                                flat += strides[parent_axis];
+                            }
                         }
                     }
                 }
@@ -4870,6 +4932,71 @@ mod tests {
             child_dim_2,
         };
         let raw: Vec<f64> = (0..parent_dim * physical_dim * child_dim_1 * child_dim_2)
+            .map(|value| (value % 19) as f64 - 9.0)
+            .collect();
+        let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();
+        let child1_columns: Vec<f64> = (0..point_count * child_dim_1)
+            .map(|value| (value % 13) as f64 - 6.0)
+            .collect();
+        let child2_columns: Vec<f64> = (0..point_count * child_dim_2)
+            .map(|value| (value % 11) as f64 - 5.0)
+            .collect();
+
+        let actual = TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+        let expected = scalar_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+
+        assert!(actual
+            .iter()
+            .zip(expected)
+            .all(|(actual, expected)| (actual - expected).abs() < 1.0e-6));
+    }
+
+    /// Same shape again, but with `child_axis_2` mapped to `raw`'s stride-1
+    /// position -- the second contiguous-read fast path (issue #671), added
+    /// after a fast-axis census on a real R=10 run found `child_axis_2` the
+    /// single most common fast axis among branch BLAS calls (51% of calls,
+    /// vs. 35% for `parent_axis` and 0% for `child_axis_1`, which is why
+    /// `child_axis_1` gets no dedicated fast path here). Exercises the
+    /// scatter-write side (`child_axis_2` is contiguous to read but not
+    /// `left`'s contiguous write axis -- `parent` is), which the
+    /// `parent_axis`-contiguous test above does not.
+    #[test]
+    fn grouped_branch_contraction_matches_scalar_reference_when_child_axis_2_is_contiguous() {
+        let parent_dim = 8;
+        let child_dim_1 = 8;
+        let child_dim_2 = 8;
+        let physical_dim = 2;
+        let point_count = 16;
+        let spec = BranchContractionSpec {
+            strides: [
+                1,
+                child_dim_2,
+                child_dim_2 * physical_dim,
+                child_dim_2 * physical_dim * parent_dim,
+            ],
+            child_axis_2: 0,
+            physical_axis: 1,
+            parent_axis: 2,
+            child_axis_1: 3,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw: Vec<f64> = (0..child_dim_2 * physical_dim * parent_dim * child_dim_1)
             .map(|value| (value % 19) as f64 - 9.0)
             .collect();
         let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();

--- a/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+++ b/crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
@@ -54,13 +54,13 @@ pub(crate) mod contraction_diagnostics {
     pub static BRANCH_SCALAR_CALLS: AtomicU64 = AtomicU64::new(0);
     pub static BRANCH_SCALAR_POINTS: AtomicU64 = AtomicU64::new(0);
 
-    /// Scratch counters (not wired into [`summary`]) for whether the
+    /// Scratch counters included in [`summary`] for whether the
     /// contiguous-read fast path's `parent_axis == raw's fastest axis`
     /// condition is the common case among calls that reach the BLAS path, or
     /// whether `child_axis_1`/`child_axis_2` land there instead -- deciding
     /// whether generalizing the fast path to those two axes is worth the
-    /// added complexity. One increment per BLAS call (not per group; the
-    /// axis assignment is the same for every group in a call).
+    /// added complexity. One increment per BLAS dispatch; the axis assignment
+    /// is the same for every group in a kernel invocation.
     pub static BRANCH_FAST_AXIS_IS_PARENT: AtomicU64 = AtomicU64::new(0);
     pub static BRANCH_FAST_AXIS_IS_CHILD1: AtomicU64 = AtomicU64::new(0);
     pub static BRANCH_FAST_AXIS_IS_CHILD2: AtomicU64 = AtomicU64::new(0);
@@ -309,7 +309,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the construction or conversion fails (a shape or
-    /// /// index mismatch, or a backend failure).
+    /// index mismatch, or a backend failure).
     ///
     fn new(
         tree: &TreeTN<IdxTensor, V>,
@@ -1012,7 +1012,7 @@ where
     /// # Errors
     ///
     /// Returns an error when the operation fails (a shape or index mismatch, or
-    /// /// a backend failure).
+    /// a backend failure).
     ///
     /// # Examples
     ///
@@ -1587,10 +1587,7 @@ where
         #[cfg(feature = "diagnostics")]
         let diag_start = std::time::Instant::now();
         #[cfg(feature = "diagnostics")]
-        {
-            contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_BLAS_CALLS, 1);
-            contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_BLAS_POINTS, point_count);
-        }
+        contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_BLAS_POINTS, point_count);
 
         let matrix_len = parent_dim
             .checked_mul(child_dim)
@@ -1639,6 +1636,8 @@ where
                 })?);
             }
 
+            #[cfg(feature = "diagnostics")]
+            contraction_diagnostics::inc(&contraction_diagnostics::CHAIN_BLAS_CALLS, 1);
             let product = mat_mul_owned(
                 Matrix::from_col_major_vec(parent_dim, child_dim, left),
                 Matrix::from_col_major_vec(child_dim, points.len(), right),
@@ -1760,23 +1759,22 @@ where
             groups.entry(physical_value).or_default().push(point);
         }
         #[cfg(feature = "diagnostics")]
+        let fast_axis_counter = if strides[parent_axis] == 1 {
+            &contraction_diagnostics::BRANCH_FAST_AXIS_IS_PARENT
+        } else if strides[child_axis_1] == 1 {
+            &contraction_diagnostics::BRANCH_FAST_AXIS_IS_CHILD1
+        } else if strides[child_axis_2] == 1 {
+            &contraction_diagnostics::BRANCH_FAST_AXIS_IS_CHILD2
+        } else {
+            &contraction_diagnostics::BRANCH_FAST_AXIS_IS_PHYSICAL
+        };
+        #[cfg(feature = "diagnostics")]
         {
-            contraction_diagnostics::inc(&contraction_diagnostics::BRANCH_BLAS_CALLS, 1);
             contraction_diagnostics::inc(&contraction_diagnostics::BRANCH_BLAS_POINTS, point_count);
             contraction_diagnostics::inc(
                 &contraction_diagnostics::BRANCH_BLAS_GROUPS,
                 groups.len(),
             );
-            let fast_axis_counter = if strides[parent_axis] == 1 {
-                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_PARENT
-            } else if strides[child_axis_1] == 1 {
-                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_CHILD1
-            } else if strides[child_axis_2] == 1 {
-                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_CHILD2
-            } else {
-                &contraction_diagnostics::BRANCH_FAST_AXIS_IS_PHYSICAL
-            };
-            contraction_diagnostics::inc(fast_axis_counter, 1);
         }
 
         let mut output = vec![T::default(); point_count * parent_dim];
@@ -1881,6 +1879,11 @@ where
             }
             #[cfg(feature = "diagnostics")]
             let matmul_start = std::time::Instant::now();
+            #[cfg(feature = "diagnostics")]
+            {
+                contraction_diagnostics::inc(&contraction_diagnostics::BRANCH_BLAS_CALLS, 1);
+                contraction_diagnostics::inc(fast_axis_counter, 1);
+            }
             let intermediate = mat_mul_owned(
                 Matrix::from_col_major_vec(parent_dim * child_dim_2, child_dim_1, left),
                 Matrix::from_col_major_vec(child_dim_1, points.len(), right),
@@ -4902,6 +4905,82 @@ mod tests {
             .all(|(actual, expected)| (actual - expected).abs() < 1.0e-6));
     }
 
+    #[cfg(feature = "diagnostics")]
+    #[test]
+    fn grouped_branch_contraction_counts_one_blas_dispatch_per_physical_group() {
+        use std::sync::atomic::Ordering;
+
+        let parent_dim = 8;
+        let child_dim_1 = 8;
+        let child_dim_2 = 8;
+        let point_count = 16;
+        let spec = BranchContractionSpec {
+            strides: [1, 2, 2 * parent_dim, 2 * parent_dim * child_dim_1],
+            physical_axis: 0,
+            parent_axis: 1,
+            child_axis_1: 2,
+            child_axis_2: 3,
+            parent_dim,
+            child_dim_1,
+            child_dim_2,
+        };
+        let raw: Vec<f64> = (0..2 * parent_dim * child_dim_1 * child_dim_2)
+            .map(|value| value as f64)
+            .collect();
+        let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();
+        let child1_columns = vec![1.0_f64; point_count * child_dim_1];
+        let child2_columns = vec![1.0_f64; point_count * child_dim_2];
+
+        contraction_diagnostics::reset_all();
+        TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+            spec,
+            &raw,
+            &physical_values,
+            &child1_columns,
+            &child2_columns,
+        )
+        .unwrap();
+
+        assert_eq!(
+            contraction_diagnostics::BRANCH_BLAS_CALLS.load(Ordering::Relaxed),
+            2,
+            "each physical-value group dispatches one matrix multiplication"
+        );
+        assert_eq!(
+            contraction_diagnostics::BRANCH_BLAS_GROUPS.load(Ordering::Relaxed),
+            2,
+            "the dispatch count should agree with the group count"
+        );
+
+        let chain_parent_dim = 64;
+        let chain_child_dim = 64;
+        let chain_spec = ChainContractionSpec {
+            strides: [1, 2, 2 * chain_parent_dim],
+            physical_axis: 0,
+            parent_axis: 1,
+            child_axis: 2,
+            parent_dim: chain_parent_dim,
+            child_dim: chain_child_dim,
+        };
+        let chain_raw = vec![1.0_f64; 2 * chain_parent_dim * chain_child_dim];
+        let chain_child_columns = vec![1.0_f64; point_count * chain_child_dim];
+
+        contraction_diagnostics::reset_all();
+        TreeTNCachedEvaluator::<usize>::grouped_chain_message_contraction(
+            chain_spec,
+            &chain_raw,
+            &physical_values,
+            &chain_child_columns,
+        )
+        .unwrap();
+
+        assert_eq!(
+            contraction_diagnostics::CHAIN_BLAS_CALLS.load(Ordering::Relaxed),
+            2,
+            "each physical-value group dispatches one chain matrix multiplication"
+        );
+    }
+
     /// Same shape as `grouped_branch_contraction_large_real_groups_match_scalar_reference`,
     /// but with `parent_axis` mapped to `raw`'s stride-1 (fastest) position
     /// instead of `physical_axis` -- the contiguous-read fast path added
@@ -5078,6 +5157,90 @@ mod tests {
             .iter()
             .zip(expected)
             .all(|(actual, expected)| (*actual - expected).norm() < 1.0e-6));
+    }
+
+    #[test]
+    fn grouped_branch_contiguous_read_fast_paths_match_complex_reference() {
+        let parent_dim = 8;
+        let child_dim_1 = 8;
+        let child_dim_2 = 8;
+        let physical_dim = 2;
+        let point_count = 16;
+        let physical_values: Vec<usize> = (0..point_count).map(|point| point % 2).collect();
+        let child1_columns: Vec<Complex64> = (0..point_count * child_dim_1)
+            .map(|value| Complex64::new((value % 13) as f64 - 6.0, (value % 7) as f64 - 3.0))
+            .collect();
+        let child2_columns: Vec<Complex64> = (0..point_count * child_dim_2)
+            .map(|value| Complex64::new((value % 11) as f64 - 5.0, (value % 9) as f64 - 4.0))
+            .collect();
+
+        let check = |spec, raw: Vec<Complex64>| {
+            let actual = TreeTNCachedEvaluator::<usize>::grouped_branch_message_contraction(
+                spec,
+                &raw,
+                &physical_values,
+                &child1_columns,
+                &child2_columns,
+            )
+            .unwrap();
+            let expected = scalar_branch_message_contraction(
+                spec,
+                &raw,
+                &physical_values,
+                &child1_columns,
+                &child2_columns,
+            )
+            .unwrap();
+
+            assert!(actual
+                .iter()
+                .zip(expected)
+                .all(|(actual, expected)| (*actual - expected).norm() < 1.0e-6));
+        };
+
+        // The parent-axis contiguous read path.
+        check(
+            BranchContractionSpec {
+                strides: [
+                    1,
+                    parent_dim,
+                    parent_dim * physical_dim,
+                    parent_dim * physical_dim * child_dim_1,
+                ],
+                parent_axis: 0,
+                physical_axis: 1,
+                child_axis_1: 2,
+                child_axis_2: 3,
+                parent_dim,
+                child_dim_1,
+                child_dim_2,
+            },
+            (0..parent_dim * physical_dim * child_dim_1 * child_dim_2)
+                .map(|value| Complex64::new((value % 19) as f64 - 9.0, (value % 11) as f64 - 5.0))
+                .collect(),
+        );
+
+        // The child-2 contiguous read and scatter-write path.
+        check(
+            BranchContractionSpec {
+                strides: [
+                    1,
+                    child_dim_2,
+                    child_dim_2 * physical_dim,
+                    child_dim_2 * physical_dim * parent_dim,
+                ],
+                child_axis_2: 0,
+                physical_axis: 1,
+                parent_axis: 2,
+                child_axis_1: 3,
+                parent_dim,
+                child_dim_1,
+                child_dim_2,
+            },
+            (0..child_dim_2 * physical_dim * parent_dim * child_dim_1)
+                .map(|value| Complex64::new((value % 23) as f64 - 11.0, (value % 7) as f64 - 3.0))
+                .collect(),
+        );
     }
 
     fn scalar_grouped_chain_reference<

--- a/crates/tensor4all-treetn/src/treetn/diagnostics.rs
+++ b/crates/tensor4all-treetn/src/treetn/diagnostics.rs
@@ -16,15 +16,32 @@ use std::time::Duration;
 /// Per-node branch-point timing and cache statistics.
 #[derive(Clone, Debug, Default)]
 pub struct NodeDiagnostics {
-    /// The tree node's `Debug` string.
+    /// The registry key for this node. TreeACI's frame records use
+    /// `"{input}:{node:?}"`, namespacing the node by its operand index;
+    /// Guard records use the bare `"{node:?}"` (see [`record_guard`]).
     pub node: String,
     /// Number of tree edges incident to this node.
     pub coordination_number: usize,
     /// Bond dimensions for each incident edge.
+    ///
+    /// Always has exactly `coordination_number` entries; an edge whose bond
+    /// dimension could not be looked up contributes a `0` sentinel rather
+    /// than being skipped. The order of the entries is not guaranteed to be
+    /// stable across calls or between the Guard and frame recording sites,
+    /// so treat this as a multiset of incident bond dimensions.
     pub bond_dims: Vec<usize>,
-    /// Total nanoseconds spent in Guard message-cache operations.
+    /// Total nanoseconds spent computing this node's Guard message: cache
+    /// lookup plus any miss computation.
+    ///
+    /// This is NOT cache-lookup time alone -- a large value here can mean
+    /// genuine `chi^z` contraction cost rather than cache overhead.
     pub guard_ns: u64,
-    /// Total nanoseconds spent in TreeACI frame-cache operations.
+    /// Total nanoseconds spent computing this node's TreeACI candidate
+    /// frames: frame-cache lookup plus any miss computation, including the
+    /// BLAS contraction work.
+    ///
+    /// This is NOT cache-lookup time alone -- a large value here can mean
+    /// genuine `chi^z` contraction cost rather than cache overhead.
     pub frame_ns: u64,
     /// Number of Guard message-cache hits.
     pub guard_cache_hits: u64,
@@ -46,6 +63,10 @@ pub fn reset() {
 }
 
 /// Read back the current accumulated diagnostics as a snapshot.
+///
+/// The returned `Vec`'s order is not guaranteed to be stable across calls:
+/// it reflects `HashMap` iteration order. A caller that needs deterministic
+/// output should sort the result (for example by `node`).
 pub fn snapshot() -> Vec<NodeDiagnostics> {
     REGISTRY.with(|registry| registry.borrow().values().cloned().collect())
 }
@@ -70,7 +91,19 @@ fn with_entry(
     });
 }
 
-/// Record a Guard message-cache operation and its cache hit/miss counts.
+/// Record a Guard message computation and its cache hit/miss counts.
+///
+/// # Known limitation
+///
+/// The `node` key carries no per-operand namespace: it is just the tree
+/// node's `Debug` label. If a caller's diagnostics window spans more than
+/// one distinct tree -- as `TreeAciProduct::combine` does, since it builds
+/// one `TreeTNCachedEvaluator` per input tree -- colliding node labels
+/// across those trees merge into a single registry entry. TreeACI's
+/// frame-side key does not have this problem, because the operand index
+/// `input` is available there and is included in the key. Fixing this on
+/// the Guard side would require threading an operand identity through
+/// `TreeTNCachedEvaluator`'s constructor.
 pub fn record_guard(
     node: &str,
     coordination_number: usize,
@@ -86,7 +119,8 @@ pub fn record_guard(
     });
 }
 
-/// Record a TreeACI frame-cache operation and its cache hit/miss counts.
+/// Record a TreeACI candidate-frame computation and its cache hit/miss
+/// counts. The `node` key is namespaced by the operand index (`input`).
 pub fn record_frame(
     node: &str,
     coordination_number: usize,

--- a/crates/tensor4all-treetn/src/treetn/diagnostics.rs
+++ b/crates/tensor4all-treetn/src/treetn/diagnostics.rs
@@ -136,6 +136,19 @@ pub fn record_frame(
     });
 }
 
+/// Reset the branch-vs-chain contraction-kernel counters (issue #671's
+/// scratch investigation into where the branch kernel's per-call BLAS setup
+/// cost goes; see `crate::treetn::cached_evaluator::contraction_diagnostics`).
+pub fn reset_contraction() {
+    super::cached_evaluator::contraction_diagnostics::reset_all();
+}
+
+/// One human-readable line summarizing the branch-vs-chain contraction
+/// counters accumulated since the last [`reset_contraction`].
+pub fn contraction_summary() -> String {
+    super::cached_evaluator::contraction_diagnostics::summary()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tensor4all-treetn/src/treetn/diagnostics.rs
+++ b/crates/tensor4all-treetn/src/treetn/diagnostics.rs
@@ -6,14 +6,25 @@
 //! `chi^z` cost apart from avoidable repeated work at a branch hub. See
 //! `docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md`.
 //!
-//! One thread-local registry, reset at the start of a call and read back via
-//! `snapshot()` at the end. Not a cross-call or cross-thread store.
+//! One thread-local registry. Callers explicitly reset it at the start of a
+//! diagnostics window and read it back via `snapshot()` at the end. It is not
+//! a cross-call or cross-thread store.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::Duration;
 
 /// Per-node branch-point timing and cache statistics.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::diagnostics::NodeDiagnostics;
+///
+/// let record = NodeDiagnostics::default();
+/// assert_eq!(record.guard_cache_hits, 0);
+/// assert!(record.bond_dims.is_empty());
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct NodeDiagnostics {
     /// The registry key for this node. TreeACI's frame records use
@@ -58,6 +69,18 @@ thread_local! {
 }
 
 /// Clear the thread-local diagnostics registry.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use tensor4all_treetn::diagnostics::{record_guard, reset, snapshot};
+///
+/// record_guard("hub", 1, &[2], Duration::from_nanos(1), 1, 0);
+/// assert_eq!(snapshot().len(), 1);
+/// reset();
+/// assert!(snapshot().is_empty());
+/// ```
 pub fn reset() {
     REGISTRY.with(|registry| registry.borrow_mut().clear());
 }
@@ -67,6 +90,20 @@ pub fn reset() {
 /// The returned `Vec`'s order is not guaranteed to be stable across calls:
 /// it reflects `HashMap` iteration order. A caller that needs deterministic
 /// output should sort the result (for example by `node`).
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use tensor4all_treetn::diagnostics::{record_guard, reset, snapshot};
+///
+/// reset();
+/// record_guard("hub", 2, &[3, 4], Duration::from_nanos(5), 2, 1);
+/// let records = snapshot();
+/// assert_eq!(records.len(), 1);
+/// assert_eq!(records[0].node, "hub");
+/// assert_eq!(records[0].guard_cache_hits, 2);
+/// ```
 pub fn snapshot() -> Vec<NodeDiagnostics> {
     REGISTRY.with(|registry| registry.borrow().values().cloned().collect())
 }
@@ -92,6 +129,20 @@ fn with_entry(
 }
 
 /// Record a Guard message computation and its cache hit/miss counts.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use tensor4all_treetn::diagnostics::{record_guard, reset, snapshot};
+///
+/// reset();
+/// record_guard("hub", 3, &[2, 2, 2], Duration::from_nanos(10), 4, 1);
+/// let record = &snapshot()[0];
+/// assert_eq!(record.coordination_number, 3);
+/// assert_eq!(record.guard_cache_hits, 4);
+/// assert_eq!(record.guard_cache_misses, 1);
+/// ```
 ///
 /// # Known limitation
 ///
@@ -121,6 +172,20 @@ pub fn record_guard(
 
 /// Record a TreeACI candidate-frame computation and its cache hit/miss
 /// counts. The `node` key is namespaced by the operand index (`input`).
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use tensor4all_treetn::diagnostics::{record_frame, reset, snapshot};
+///
+/// reset();
+/// record_frame("0:hub", 3, &[2, 2, 2], Duration::from_nanos(20), 5, 2);
+/// let record = &snapshot()[0];
+/// assert_eq!(record.node, "0:hub");
+/// assert_eq!(record.frame_cache_hits, 5);
+/// assert_eq!(record.frame_cache_misses, 2);
+/// ```
 pub fn record_frame(
     node: &str,
     coordination_number: usize,
@@ -139,12 +204,35 @@ pub fn record_frame(
 /// Reset the branch-vs-chain contraction-kernel counters (issue #671's
 /// scratch investigation into where the branch kernel's per-call BLAS setup
 /// cost goes; see `crate::treetn::cached_evaluator::contraction_diagnostics`).
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::diagnostics::{contraction_summary, reset_contraction};
+///
+/// reset_contraction();
+/// assert!(contraction_summary().starts_with("branch:"));
+/// ```
 pub fn reset_contraction() {
     super::cached_evaluator::contraction_diagnostics::reset_all();
 }
 
 /// One human-readable line summarizing the branch-vs-chain contraction
 /// counters accumulated since the last [`reset_contraction`].
+/// The `blas_calls` field counts backend matrix-multiply dispatches; the
+/// branch `blas_groups` field counts physical-value groups processed by the
+/// branch kernel.
+///
+/// # Examples
+///
+/// ```
+/// use tensor4all_treetn::diagnostics::{contraction_summary, reset_contraction};
+///
+/// reset_contraction();
+/// let summary = contraction_summary();
+/// assert!(summary.contains("branch: blas_calls=0"));
+/// assert!(summary.contains("chain: blas_calls=0"));
+/// ```
 pub fn contraction_summary() -> String {
     super::cached_evaluator::contraction_diagnostics::summary()
 }

--- a/crates/tensor4all-treetn/src/treetn/diagnostics.rs
+++ b/crates/tensor4all-treetn/src/treetn/diagnostics.rs
@@ -1,0 +1,125 @@
+//! Per-node branch-point diagnostics for TreeACI issue #671's investigation.
+//!
+//! Records, per tree node, Guard message-cache and TreeACI frame-cache
+//! timing and hit/miss counts, plus the node's coordination number and
+//! incident bond dimensions -- data needed to tell topology-necessary
+//! `chi^z` cost apart from avoidable repeated work at a branch hub. See
+//! `docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md`.
+//!
+//! One thread-local registry, reset at the start of a call and read back via
+//! `snapshot()` at the end. Not a cross-call or cross-thread store.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::Duration;
+
+#[derive(Clone, Debug, Default)]
+pub struct NodeDiagnostics {
+    pub node: String,
+    pub coordination_number: usize,
+    pub bond_dims: Vec<usize>,
+    pub guard_ns: u64,
+    pub frame_ns: u64,
+    pub guard_cache_hits: u64,
+    pub guard_cache_misses: u64,
+    pub frame_cache_hits: u64,
+    pub frame_cache_misses: u64,
+}
+
+thread_local! {
+    static REGISTRY: RefCell<HashMap<String, NodeDiagnostics>> = RefCell::new(HashMap::new());
+}
+
+pub fn reset() {
+    REGISTRY.with(|registry| registry.borrow_mut().clear());
+}
+
+pub fn snapshot() -> Vec<NodeDiagnostics> {
+    REGISTRY.with(|registry| registry.borrow().values().cloned().collect())
+}
+
+fn with_entry(node: &str, coordination_number: usize, bond_dims: &[usize], f: impl FnOnce(&mut NodeDiagnostics)) {
+    REGISTRY.with(|registry| {
+        let mut map = registry.borrow_mut();
+        let entry = map.entry(node.to_string()).or_insert_with(|| NodeDiagnostics {
+            node: node.to_string(),
+            ..Default::default()
+        });
+        entry.coordination_number = coordination_number;
+        entry.bond_dims = bond_dims.to_vec();
+        f(entry);
+    });
+}
+
+pub fn record_guard(
+    node: &str,
+    coordination_number: usize,
+    bond_dims: &[usize],
+    elapsed: Duration,
+    hits: u64,
+    misses: u64,
+) {
+    with_entry(node, coordination_number, bond_dims, |entry| {
+        entry.guard_ns += elapsed.as_nanos() as u64;
+        entry.guard_cache_hits += hits;
+        entry.guard_cache_misses += misses;
+    });
+}
+
+pub fn record_frame(
+    node: &str,
+    coordination_number: usize,
+    bond_dims: &[usize],
+    elapsed: Duration,
+    hits: u64,
+    misses: u64,
+) {
+    with_entry(node, coordination_number, bond_dims, |entry| {
+        entry.frame_ns += elapsed.as_nanos() as u64;
+        entry.frame_cache_hits += hits;
+        entry.frame_cache_misses += misses;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_then_snapshot_is_empty() {
+        record_guard("a", 2, &[3, 3], Duration::from_nanos(10), 1, 0);
+        reset();
+        assert!(snapshot().is_empty());
+    }
+
+    #[test]
+    fn record_guard_and_record_frame_accumulate_into_one_entry_per_node() {
+        reset();
+        record_guard("hub", 3, &[4, 4, 4], Duration::from_nanos(100), 2, 1);
+        record_guard("hub", 3, &[4, 4, 4], Duration::from_nanos(50), 0, 1);
+        record_frame("hub", 3, &[4, 4, 4], Duration::from_nanos(30), 5, 2);
+
+        let snap = snapshot();
+        assert_eq!(snap.len(), 1);
+        let hub = &snap[0];
+        assert_eq!(hub.node, "hub");
+        assert_eq!(hub.coordination_number, 3);
+        assert_eq!(hub.bond_dims, vec![4, 4, 4]);
+        assert_eq!(hub.guard_ns, 150);
+        assert_eq!(hub.guard_cache_hits, 2);
+        assert_eq!(hub.guard_cache_misses, 2);
+        assert_eq!(hub.frame_ns, 30);
+        assert_eq!(hub.frame_cache_hits, 5);
+        assert_eq!(hub.frame_cache_misses, 2);
+    }
+
+    #[test]
+    fn distinct_nodes_get_distinct_entries() {
+        reset();
+        record_guard("a", 2, &[3, 3], Duration::from_nanos(10), 1, 0);
+        record_guard("b", 3, &[5, 5, 5], Duration::from_nanos(20), 1, 0);
+        let mut nodes: Vec<String> = snapshot().into_iter().map(|d| d.node).collect();
+        nodes.sort();
+        assert_eq!(nodes, vec!["a".to_string(), "b".to_string()]);
+    }
+}

--- a/crates/tensor4all-treetn/src/treetn/diagnostics.rs
+++ b/crates/tensor4all-treetn/src/treetn/diagnostics.rs
@@ -13,16 +13,26 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::time::Duration;
 
+/// Per-node branch-point timing and cache statistics.
 #[derive(Clone, Debug, Default)]
 pub struct NodeDiagnostics {
+    /// The tree node's `Debug` string.
     pub node: String,
+    /// Number of tree edges incident to this node.
     pub coordination_number: usize,
+    /// Bond dimensions for each incident edge.
     pub bond_dims: Vec<usize>,
+    /// Total nanoseconds spent in Guard message-cache operations.
     pub guard_ns: u64,
+    /// Total nanoseconds spent in TreeACI frame-cache operations.
     pub frame_ns: u64,
+    /// Number of Guard message-cache hits.
     pub guard_cache_hits: u64,
+    /// Number of Guard message-cache misses.
     pub guard_cache_misses: u64,
+    /// Number of TreeACI frame-cache hits.
     pub frame_cache_hits: u64,
+    /// Number of TreeACI frame-cache misses.
     pub frame_cache_misses: u64,
 }
 
@@ -30,27 +40,37 @@ thread_local! {
     static REGISTRY: RefCell<HashMap<String, NodeDiagnostics>> = RefCell::new(HashMap::new());
 }
 
+/// Clear the thread-local diagnostics registry.
 pub fn reset() {
     REGISTRY.with(|registry| registry.borrow_mut().clear());
 }
 
+/// Read back the current accumulated diagnostics as a snapshot.
 pub fn snapshot() -> Vec<NodeDiagnostics> {
     REGISTRY.with(|registry| registry.borrow().values().cloned().collect())
 }
 
-fn with_entry(node: &str, coordination_number: usize, bond_dims: &[usize], f: impl FnOnce(&mut NodeDiagnostics)) {
+fn with_entry(
+    node: &str,
+    coordination_number: usize,
+    bond_dims: &[usize],
+    f: impl FnOnce(&mut NodeDiagnostics),
+) {
     REGISTRY.with(|registry| {
         let mut map = registry.borrow_mut();
-        let entry = map.entry(node.to_string()).or_insert_with(|| NodeDiagnostics {
-            node: node.to_string(),
-            ..Default::default()
-        });
+        let entry = map
+            .entry(node.to_string())
+            .or_insert_with(|| NodeDiagnostics {
+                node: node.to_string(),
+                ..Default::default()
+            });
         entry.coordination_number = coordination_number;
         entry.bond_dims = bond_dims.to_vec();
         f(entry);
     });
 }
 
+/// Record a Guard message-cache operation and its cache hit/miss counts.
 pub fn record_guard(
     node: &str,
     coordination_number: usize,
@@ -66,6 +86,7 @@ pub fn record_guard(
     });
 }
 
+/// Record a TreeACI frame-cache operation and its cache hit/miss counts.
 pub fn record_frame(
     node: &str,
     coordination_number: usize,

--- a/crates/tensor4all-treetn/src/treetn/mod.rs
+++ b/crates/tensor4all-treetn/src/treetn/mod.rs
@@ -11,6 +11,8 @@ mod cached_evaluator;
 mod canonicalize;
 pub mod contraction;
 mod decompose;
+#[cfg(feature = "diagnostics")]
+pub mod diagnostics;
 mod evaluator;
 mod fit;
 mod localupdate;

--- a/docs/superpowers/plans/2026-08-24-treeaci-branch-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-24-treeaci-branch-diagnostics.md
@@ -1,0 +1,824 @@
+# TreeACI Branch-Point Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `diagnostics` Cargo feature to `tensor4all-treetn` and `tensor4all-treeaci` that reports, per tree node, coordination number, incident bond dimensions, Guard vs. LUCI/frame timing, and cache hit/miss counts -- with zero generated code when the feature is off.
+
+**Architecture:** A single thread-local registry (`NodeDiagnostics` records keyed by a node's `Debug` string) lives in `tensor4all-treetn::treetn::diagnostics`, gated by `#[cfg(feature = "diagnostics")]`. Two existing call sites record into it: `cached_evaluator.rs`'s `get_or_compute_node_message` (Guard's per-node message cache) and `frames.rs`'s three `candidate_cache` lookup sites (TreeACI's per-node frame cache). `tensor4all-treeaci` forwards the feature and re-exports the registry's public functions under `branch_diagnostics` (not `diagnostics`, to avoid reading as the same thing as the existing, unrelated `TreeAciDiagnostics` sweep/convergence struct already exported from `result.rs`).
+
+**Tech Stack:** Rust, `std::cell::RefCell` + `thread_local!` (no new dependencies -- the workspace has no `serde` derive dependency today; `NodeDiagnostics` stays a plain struct and downstream crates serialize it themselves).
+
+**Spec:** `docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md`
+
+## Global Constraints
+
+- Zero generated code when `diagnostics` is disabled (the default): every new item is behind `#[cfg(feature = "diagnostics")]`, and no existing public function signature changes.
+- Do not change LUCI pivot selection, candidate enumeration, truncation tolerances, Guard's search policy, or any sampled value. This is observability only.
+- Do not add a persistent/cross-call diagnostics store; `reset()` clears everything and each call's data is read via one `snapshot()`.
+- Do not add `serde` or any other new dependency to `tensor4all-treetn`/`tensor4all-treeaci`.
+- `cargo fmt --all` before every commit (repo-wide convention); `cargo clippy --workspace --all-targets -- -D warnings` must stay clean for changed crates.
+
+---
+
+## File Structure
+
+- `crates/tensor4all-treetn/Cargo.toml` -- new `diagnostics` feature (no new deps).
+- `crates/tensor4all-treetn/src/treetn/diagnostics.rs` -- new module: `NodeDiagnostics`, thread-local registry, `reset`/`snapshot`/`record_guard`/`record_frame`.
+- `crates/tensor4all-treetn/src/treetn/mod.rs` -- `#[cfg(feature = "diagnostics")] pub mod diagnostics;`
+- `crates/tensor4all-treetn/src/lib.rs` -- `#[cfg(feature = "diagnostics")] pub use treetn::diagnostics;`
+- `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` -- feature-gated instrumentation inside `get_or_compute_node_message`.
+- `crates/tensor4all-treeaci/Cargo.toml` -- new `diagnostics` feature, `= ["tensor4all-treetn/diagnostics"]`.
+- `crates/tensor4all-treeaci/src/lib.rs` -- `#[cfg(feature = "diagnostics")] pub mod branch_diagnostics;` (thin re-export module).
+- `crates/tensor4all-treeaci/src/branch_diagnostics.rs` -- new thin module: `pub use tensor4all_treetn::diagnostics::*;`.
+- `crates/tensor4all-treeaci/src/frames.rs` -- new private `diagnostics_node_topology` helper; feature-gated instrumentation at the three `candidate_cache` lookup sites.
+
+---
+
+### Task 1: Diagnostics data model and registry (`tensor4all-treetn`)
+
+**Files:**
+- Create: `crates/tensor4all-treetn/src/treetn/diagnostics.rs`
+- Modify: `crates/tensor4all-treetn/src/treetn/mod.rs`
+- Modify: `crates/tensor4all-treetn/src/lib.rs`
+- Modify: `crates/tensor4all-treetn/Cargo.toml`
+- Test: `crates/tensor4all-treetn/src/treetn/diagnostics.rs` (inline `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces (used by Task 2 and by `tensor4all-treeaci`):
+  ```rust
+  pub struct NodeDiagnostics {
+      pub node: String,
+      pub coordination_number: usize,
+      pub bond_dims: Vec<usize>,
+      pub guard_ns: u64,
+      pub frame_ns: u64,
+      pub guard_cache_hits: u64,
+      pub guard_cache_misses: u64,
+      pub frame_cache_hits: u64,
+      pub frame_cache_misses: u64,
+  }
+  pub fn reset();
+  pub fn snapshot() -> Vec<NodeDiagnostics>;
+  pub fn record_guard(node: &str, coordination_number: usize, bond_dims: &[usize], elapsed: std::time::Duration, hits: u64, misses: u64);
+  pub fn record_frame(node: &str, coordination_number: usize, bond_dims: &[usize], elapsed: std::time::Duration, hits: u64, misses: u64);
+  ```
+
+- [ ] **Step 1: Add the `diagnostics` feature to `tensor4all-treetn/Cargo.toml`**
+
+Open `crates/tensor4all-treetn/Cargo.toml` and add, inside the existing `[features]` table:
+
+```toml
+diagnostics = []
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `crates/tensor4all-treetn/src/treetn/diagnostics.rs`:
+
+```rust
+//! Per-node branch-point diagnostics for TreeACI issue #671's investigation.
+//!
+//! Records, per tree node, Guard message-cache and TreeACI frame-cache
+//! timing and hit/miss counts, plus the node's coordination number and
+//! incident bond dimensions -- data needed to tell topology-necessary
+//! `chi^z` cost apart from avoidable repeated work at a branch hub. See
+//! `docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md`.
+//!
+//! One thread-local registry, reset at the start of a call and read back via
+//! `snapshot()` at the end. Not a cross-call or cross-thread store.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::Duration;
+
+#[derive(Clone, Debug, Default)]
+pub struct NodeDiagnostics {
+    pub node: String,
+    pub coordination_number: usize,
+    pub bond_dims: Vec<usize>,
+    pub guard_ns: u64,
+    pub frame_ns: u64,
+    pub guard_cache_hits: u64,
+    pub guard_cache_misses: u64,
+    pub frame_cache_hits: u64,
+    pub frame_cache_misses: u64,
+}
+
+thread_local! {
+    static REGISTRY: RefCell<HashMap<String, NodeDiagnostics>> = RefCell::new(HashMap::new());
+}
+
+pub fn reset() {
+    REGISTRY.with(|registry| registry.borrow_mut().clear());
+}
+
+pub fn snapshot() -> Vec<NodeDiagnostics> {
+    REGISTRY.with(|registry| registry.borrow().values().cloned().collect())
+}
+
+fn with_entry(node: &str, coordination_number: usize, bond_dims: &[usize], f: impl FnOnce(&mut NodeDiagnostics)) {
+    REGISTRY.with(|registry| {
+        let mut map = registry.borrow_mut();
+        let entry = map.entry(node.to_string()).or_insert_with(|| NodeDiagnostics {
+            node: node.to_string(),
+            ..Default::default()
+        });
+        entry.coordination_number = coordination_number;
+        entry.bond_dims = bond_dims.to_vec();
+        f(entry);
+    });
+}
+
+pub fn record_guard(
+    node: &str,
+    coordination_number: usize,
+    bond_dims: &[usize],
+    elapsed: Duration,
+    hits: u64,
+    misses: u64,
+) {
+    with_entry(node, coordination_number, bond_dims, |entry| {
+        entry.guard_ns += elapsed.as_nanos() as u64;
+        entry.guard_cache_hits += hits;
+        entry.guard_cache_misses += misses;
+    });
+}
+
+pub fn record_frame(
+    node: &str,
+    coordination_number: usize,
+    bond_dims: &[usize],
+    elapsed: Duration,
+    hits: u64,
+    misses: u64,
+) {
+    with_entry(node, coordination_number, bond_dims, |entry| {
+        entry.frame_ns += elapsed.as_nanos() as u64;
+        entry.frame_cache_hits += hits;
+        entry.frame_cache_misses += misses;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reset_then_snapshot_is_empty() {
+        record_guard("a", 2, &[3, 3], Duration::from_nanos(10), 1, 0);
+        reset();
+        assert!(snapshot().is_empty());
+    }
+
+    #[test]
+    fn record_guard_and_record_frame_accumulate_into_one_entry_per_node() {
+        reset();
+        record_guard("hub", 3, &[4, 4, 4], Duration::from_nanos(100), 2, 1);
+        record_guard("hub", 3, &[4, 4, 4], Duration::from_nanos(50), 0, 1);
+        record_frame("hub", 3, &[4, 4, 4], Duration::from_nanos(30), 5, 2);
+
+        let snap = snapshot();
+        assert_eq!(snap.len(), 1);
+        let hub = &snap[0];
+        assert_eq!(hub.node, "hub");
+        assert_eq!(hub.coordination_number, 3);
+        assert_eq!(hub.bond_dims, vec![4, 4, 4]);
+        assert_eq!(hub.guard_ns, 150);
+        assert_eq!(hub.guard_cache_hits, 2);
+        assert_eq!(hub.guard_cache_misses, 2);
+        assert_eq!(hub.frame_ns, 30);
+        assert_eq!(hub.frame_cache_hits, 5);
+        assert_eq!(hub.frame_cache_misses, 2);
+    }
+
+    #[test]
+    fn distinct_nodes_get_distinct_entries() {
+        reset();
+        record_guard("a", 2, &[3, 3], Duration::from_nanos(10), 1, 0);
+        record_guard("b", 3, &[5, 5, 5], Duration::from_nanos(20), 1, 0);
+        let mut nodes: Vec<String> = snapshot().into_iter().map(|d| d.node).collect();
+        nodes.sort();
+        assert_eq!(nodes, vec!["a".to_string(), "b".to_string()]);
+    }
+}
+```
+
+This module is not yet registered anywhere, so it does not compile as part of
+the crate yet -- that is expected for this step.
+
+- [ ] **Step 3: Wire the module in and verify the test fails to even build without the feature, then passes with it**
+
+In `crates/tensor4all-treetn/src/treetn/mod.rs`, add near the other `mod`/`pub mod` declarations (alongside `pub mod contraction;`):
+
+```rust
+#[cfg(feature = "diagnostics")]
+pub mod diagnostics;
+```
+
+In `crates/tensor4all-treetn/src/lib.rs`, add next to the existing `#[cfg(feature = "simplett-bridge")]` re-export block:
+
+```rust
+#[cfg(feature = "diagnostics")]
+pub use treetn::diagnostics;
+```
+
+Run:
+
+```bash
+cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --features diagnostics treetn::diagnostics -- --nocapture
+```
+
+Expected: the three tests in `diagnostics::tests` run and pass. If they do
+not compile, fix the module (this is the first real compile of the file).
+
+- [ ] **Step 4: Verify the default build is untouched**
+
+```bash
+cargo check --manifest-path crates/tensor4all-treetn/Cargo.toml
+```
+
+Expected: succeeds, and `diagnostics` does not appear as a symbol (the
+feature is off by default, so the module is not compiled in).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/tensor4all-treetn/Cargo.toml crates/tensor4all-treetn/src/treetn/mod.rs crates/tensor4all-treetn/src/treetn/diagnostics.rs crates/tensor4all-treetn/src/lib.rs
+git commit -m "feat(treetn): add diagnostics feature with per-node registry"
+```
+
+---
+
+### Task 2: Wire Guard's message cache into the registry (`tensor4all-treetn`)
+
+**Files:**
+- Modify: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs:2426-2760` (`get_or_compute_node_message`)
+- Test: `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs` (new `#[cfg(all(test, feature = "diagnostics"))]` test in the existing test module)
+
+**Interfaces:**
+- Consumes: `tensor4all_treetn::diagnostics::record_guard` from Task 1 (same crate, so `super::diagnostics::record_guard` or `crate::treetn::diagnostics::record_guard`).
+- Produces: nothing new for later tasks (Task 3 is independent, in a different crate).
+
+Read `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs:2426-2760`
+(`get_or_compute_node_message`) before starting: it has two return points --
+an early return on a full cache hit (~line 2507-2540) and the normal return
+after a partial/full miss is computed and merged (ends ~line 2757-2760). Both
+need a `record_guard` call. `V: Debug` is already required in this file (see
+existing `{:?}` uses in error messages), so `format!("{node:?}")` is valid
+wherever `node: &V` is in scope.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `#[cfg(test)] mod tests` block in
+`crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`, next to
+`degree_three_hub_keeps_raw_messages_when_center_is_a_leaf` (line ~5185).
+That existing test already shows the exact fixture and API this new test
+reuses verbatim: `star_tree()` (line ~5597) builds a 4-node tree where node
+`0` is a degree-3 hub connected to leaves `1`, `2`, `3`; centering the
+evaluator at leaf `1` and calling `build_environment_cache(&1, points)`
+computes messages for every node except the center itself -- so this test's
+snapshot will contain records for `0`, `2`, `3`, but not `1`.
+
+```rust
+#[cfg(feature = "diagnostics")]
+#[test]
+fn build_environment_cache_records_guard_diagnostics_per_node_with_correct_coordination_numbers() {
+    use crate::treetn::diagnostics;
+
+    let (tree, indices) = star_tree();
+    let mut evaluator = TreeTNCachedEvaluator::new(
+        &tree,
+        &indices,
+        CachedEvaluatorOptions {
+            center: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let shape = [4usize, 2usize];
+    let values = [0usize, 0, 0, 0, 1, 0, 1, 1];
+    let points = ColMajorArrayRef::new(&values, &shape).unwrap();
+
+    diagnostics::reset();
+    let _ = evaluator.build_environment_cache(&1, points).unwrap();
+
+    let snapshot = diagnostics::snapshot();
+    let hub_record = snapshot
+        .iter()
+        .find(|record| record.node == "0")
+        .expect("hub node (0) recorded");
+    assert_eq!(hub_record.coordination_number, 3);
+    assert_eq!(hub_record.bond_dims.len(), 3);
+    assert!(hub_record.guard_cache_hits + hub_record.guard_cache_misses > 0);
+
+    for leaf in ["2", "3"] {
+        let leaf_record = snapshot
+            .iter()
+            .find(|record| record.node == leaf)
+            .unwrap_or_else(|| panic!("leaf node ({leaf}) recorded"));
+        assert_eq!(leaf_record.coordination_number, 1);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --features diagnostics \
+  build_environment_cache_records_guard_diagnostics_per_node_with_correct_coordination_numbers -- --nocapture
+```
+
+Expected: FAIL (`hub node (0) recorded` panics -- nothing has been recorded
+yet).
+
+- [ ] **Step 3: Instrument `get_or_compute_node_message`**
+
+At the top of the function, right after the existing `#[cfg(test)] let
+phase_start = std::time::Instant::now();` (line ~2441-2442), add:
+
+```rust
+#[cfg(feature = "diagnostics")]
+let diag_start = std::time::Instant::now();
+#[cfg(feature = "diagnostics")]
+let (diag_coordination_number, diag_bond_dims) = {
+    let neighbors: Vec<V> = self.tree.site_index_network().neighbors(node).collect();
+    let bond_dims = neighbors
+        .iter()
+        .filter_map(|neighbor| {
+            self.tree
+                .edge_between(node, neighbor)
+                .and_then(|edge| self.tree.bond_index(edge))
+                .map(|index| index.dim())
+        })
+        .collect::<Vec<_>>();
+    (neighbors.len(), bond_dims)
+};
+```
+
+At the full-hit early return (the `if let Some(positions) =
+cache.get_all_cached(&keys) { ... }` block, whose body currently ends with
+`return Ok(StackedMessage { ... });` around line 2535-2539), add just before
+that `return`:
+
+```rust
+#[cfg(feature = "diagnostics")]
+diagnostics::record_guard(
+    &format!("{node:?}"),
+    diag_coordination_number,
+    &diag_bond_dims,
+    diag_start.elapsed(),
+    keys.len() as u64,
+    0,
+);
+```
+
+and add `use super::diagnostics;` near the top of the file, gated:
+
+```rust
+#[cfg(feature = "diagnostics")]
+use super::diagnostics;
+```
+
+For the miss/partial-hit path: right after the line that currently reads
+`self.last_stats.message_cache_hits += hit_keys.len();` /
+`self.last_stats.message_cache_misses += missing_indices.len();` (line
+~2554-2555), capture the counts before `missing_indices` is consumed later
+by `into_iter()`:
+
+```rust
+#[cfg(feature = "diagnostics")]
+let (diag_hits, diag_misses) = (hit_keys.len() as u64, missing_indices.len() as u64);
+```
+
+Then, at the function's final `Ok(StackedMessage { assignment_index, tensor,
+raw_values })` (the very end of the function, after the reconstruct block),
+insert immediately before that final `Ok(...)`:
+
+```rust
+#[cfg(feature = "diagnostics")]
+diagnostics::record_guard(
+    &format!("{node:?}"),
+    diag_coordination_number,
+    &diag_bond_dims,
+    diag_start.elapsed(),
+    diag_hits,
+    diag_misses,
+);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --features diagnostics \
+  build_environment_cache_records_guard_diagnostics_per_node_with_correct_coordination_numbers -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full crate test suite with and without the feature**
+
+```bash
+cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --release
+cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --release --features diagnostics
+```
+
+Expected: both PASS. The first command is the existing default-feature
+suite and must show no behavior change.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tensor4all-treetn/src/treetn/cached_evaluator.rs
+git commit -m "feat(treetn): record per-node Guard diagnostics in get_or_compute_node_message"
+```
+
+---
+
+### Task 3: Wire TreeACI's frame cache into the registry (`tensor4all-treeaci`)
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/Cargo.toml`
+- Create: `crates/tensor4all-treeaci/src/branch_diagnostics.rs`
+- Modify: `crates/tensor4all-treeaci/src/lib.rs`
+- Modify: `crates/tensor4all-treeaci/src/frames.rs` (three call sites: ~810-822, ~977-989, ~1113-1123)
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: `tensor4all_treetn::diagnostics::{record_frame, reset, snapshot}` (Task 1/2; cross-crate, `tensor4all-treeaci` already depends on `tensor4all-treetn`).
+- Produces: `tensor4all_treeaci::branch_diagnostics::{reset, snapshot, NodeDiagnostics}` for downstream crates (`gw-rs`'s isolation harness).
+
+- [ ] **Step 1: Add the `diagnostics` feature and the re-export module**
+
+In `crates/tensor4all-treeaci/Cargo.toml`, add one line inside the existing
+`[features]` table (it already has `default`, `tenferro-cpu-faer`, and
+`tenferro-provider-inject` entries):
+
+```toml
+diagnostics = ["tensor4all-treetn/diagnostics"]
+```
+
+Create `crates/tensor4all-treeaci/src/branch_diagnostics.rs`:
+
+```rust
+//! Re-export of `tensor4all-treetn`'s per-node branch diagnostics registry.
+//!
+//! Named `branch_diagnostics`, not `diagnostics`, to stay distinct from
+//! [`crate::TreeAciDiagnostics`] -- an unrelated, already-public sweep/
+//! convergence report. This module is about branch-point performance
+//! (issue #671); `TreeAciDiagnostics` is about ACI convergence history.
+
+pub use tensor4all_treetn::diagnostics::{
+    record_frame, record_guard, reset, snapshot, NodeDiagnostics,
+};
+```
+
+In `crates/tensor4all-treeaci/src/lib.rs`, add next to the other `pub mod`/
+`pub use` declarations:
+
+```rust
+#[cfg(feature = "diagnostics")]
+pub mod branch_diagnostics;
+```
+
+- [ ] **Step 2: Run to verify it builds**
+
+```bash
+cargo check --manifest-path crates/tensor4all-treeaci/Cargo.toml --features diagnostics
+cargo check --manifest-path crates/tensor4all-treeaci/Cargo.toml
+```
+
+Expected: both succeed (the second, default-feature, build does not see
+`branch_diagnostics` at all).
+
+- [ ] **Step 3: Commit the scaffolding**
+
+```bash
+git add crates/tensor4all-treeaci/Cargo.toml crates/tensor4all-treeaci/src/branch_diagnostics.rs crates/tensor4all-treeaci/src/lib.rs
+git commit -m "feat(treeaci): forward diagnostics feature and re-export the registry"
+```
+
+- [ ] **Step 4: Write the failing test**
+
+`candidate_frames_for_edge_batches_a_branch_edge_with_two_incoming_edges`
+(line ~891 in `crates/tensor4all-treeaci/src/frames/tests/mod.rs`) is the
+existing test to base this on: it uses `star_tree_for_fallback_dispatch()`
+(line ~636, node `0` is the hub with edge `0 -> 1` having
+`directed.incoming_to_from.len() == 2`, i.e. coordination number 3) and
+calls both `frames.candidate_frames_for_edge(...)` (the batched two-incoming
+path) and `frames.candidate_frame(...)` (the scalar path) on the same
+candidates -- so a diagnostics test built the same way exercises both of
+this task's instrumented sites at once. Add, right after that existing test:
+
+```rust
+#[cfg(feature = "diagnostics")]
+#[test]
+fn candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_number_three() {
+    use crate::branch_diagnostics;
+
+    let inputs = vec![star_tree_for_fallback_dispatch()];
+    let options = TreeAciOptions::default();
+    let problem = prepare_problem(&inputs, &options).unwrap();
+
+    let edge = problem
+        .directed_edges
+        .iter()
+        .position(|arc| arc.from == 0 && arc.to == 1)
+        .expect("star tree must have a directed edge 0 -> 1");
+    let directed = &problem.directed_edges[edge];
+    assert_eq!(directed.incoming_to_from.len(), 2);
+
+    let seeds = vec![vec![0, 0, 0, 0], vec![0, 0, 1, 1]];
+    let (arena, candidate_sets) = SampleArena::from_global_seeds(&problem, &seeds).unwrap();
+    let frames = InputFrameStore::<f64>::from_samples(&inputs, &problem, &arena).unwrap();
+
+    let incoming_edge_a = directed.incoming_to_from[0];
+    let incoming_edge_b = directed.incoming_to_from[1];
+    let ids_a = &candidate_sets.ids[incoming_edge_a];
+    let ids_b = &candidate_sets.ids[incoming_edge_b];
+
+    let mut candidates = Vec::new();
+    for local_coordinate in 0..2 {
+        for &id_a in ids_a {
+            for &id_b in ids_b {
+                candidates.push(ComponentSample {
+                    local_coordinate,
+                    incoming: vec![(incoming_edge_a, id_a), (incoming_edge_b, id_b)],
+                });
+            }
+        }
+    }
+
+    branch_diagnostics::reset();
+    let _dispatched = frames
+        .candidate_frames_for_edge(&inputs, &problem, 0, edge, &candidates)
+        .unwrap();
+
+    let snapshot = branch_diagnostics::snapshot();
+    let hub_record = snapshot
+        .iter()
+        .find(|record| record.node == "0")
+        .expect("hub node (0) recorded in branch diagnostics");
+    assert_eq!(hub_record.coordination_number, 3);
+    assert_eq!(hub_record.bond_dims.len(), 3);
+    assert!(hub_record.frame_cache_hits + hub_record.frame_cache_misses > 0);
+}
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+```bash
+cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --features diagnostics \
+  candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_number_three -- --nocapture
+```
+
+Expected: FAIL (nothing recorded yet).
+
+- [ ] **Step 6: Add the topology helper**
+
+In `crates/tensor4all-treeaci/src/frames.rs`, near `fn outgoing_bond` (line
+~1848), add:
+
+```rust
+#[cfg(feature = "diagnostics")]
+fn diagnostics_node_topology<V: TreeAciNode>(
+    tree: &TreeTN<IdxTensor, V>,
+    problem: &PreparedTreeProblem<V>,
+    directed: &DirectedEdge<V>,
+    directed_edge: DirectedEdgeId,
+) -> (String, usize, Vec<usize>) {
+    let coordination_number = directed.incoming_to_from.len() + 1;
+    let mut bond_dims = Vec::with_capacity(coordination_number);
+    if let Ok(index) = outgoing_bond(tree, problem, directed_edge) {
+        bond_dims.push(index.dim());
+    }
+    for &incoming in &directed.incoming_to_from {
+        if let Ok(index) = outgoing_bond(tree, problem, incoming) {
+            bond_dims.push(index.dim());
+        }
+    }
+    (format!("{:?}", directed.from), coordination_number, bond_dims)
+}
+```
+
+- [ ] **Step 7: Instrument the single-incoming site (~line 730-830)**
+
+This function (`candidate_frames_for_edge`, the single-incoming-edge batched
+path) already has `directed`, `tree`, `outgoing_dim`, `incoming_dim`, and
+`directed_edge` in scope by the time its candidate loop starts (line ~807).
+Add timing and count accumulators right before that `for (candidate_index,
+candidate) in candidates.iter().enumerate() {` loop:
+
+```rust
+#[cfg(feature = "diagnostics")]
+let diag_start = std::time::Instant::now();
+#[cfg(feature = "diagnostics")]
+let (mut diag_hits, mut diag_misses) = (0u64, 0u64);
+```
+
+Inside the loop, next to the existing `#[cfg(test)]
+candidate_debug_stats::record_hit();` (line ~815-817) add:
+
+```rust
+#[cfg(feature = "diagnostics")]
+{
+    diag_hits += 1;
+}
+```
+
+and next to the existing `#[cfg(test)] candidate_debug_stats::record_miss();`
+(line ~821) add:
+
+```rust
+#[cfg(feature = "diagnostics")]
+{
+    diag_misses += 1;
+}
+```
+
+At the end of the function, immediately before its final `results
+.into_iter() ... .collect()` (the function's tail expression), add:
+
+```rust
+#[cfg(feature = "diagnostics")]
+{
+    let (node, coordination_number, bond_dims) =
+        diagnostics_node_topology(tree, problem, directed, directed_edge);
+    diagnostics::record_frame(
+        &node,
+        coordination_number,
+        &bond_dims,
+        diag_start.elapsed(),
+        diag_hits,
+        diag_misses,
+    );
+}
+```
+
+and add `use tensor4all_treetn::diagnostics;` near the file's other `use`
+statements, gated:
+
+```rust
+#[cfg(feature = "diagnostics")]
+use tensor4all_treetn::diagnostics;
+```
+
+- [ ] **Step 8: Instrument the two-incoming site (~line 921-1104)**
+
+Same pattern as Step 7, inside `candidate_frames_for_edge_two_incoming`: add
+`diag_start`/`diag_hits`/`diag_misses` before its candidate loop (~line 976),
+increment next to the existing hit/miss `candidate_debug_stats` calls
+(~line 983-989), and add the same `diagnostics::record_frame(...)` call
+before the function's final `results.into_iter()...collect()` (after line
+1104).
+
+- [ ] **Step 9: Instrument the general single-candidate site (~line 1106-1153)**
+
+`candidate_frame` fetches `tree` only after the cache check today (line
+~1124: `let tree = inputs.get(input)...`), and does not fetch `directed` at
+all. First, move that `let tree = inputs.get(input)...` line (with its
+`ok_or(...)` error arm) up to the top of the function, immediately after the
+`let cache_key = self.candidate_cache_key(...)?;` line and before the `if
+let Some(key) = cache_key { ... }` hit check -- it does not depend on the
+cache lookup, so this reordering changes nothing about the function's
+behavior, only makes `tree` available to the hit path below. Then add,
+right after that relocated `tree` fetch:
+
+```rust
+#[cfg(feature = "diagnostics")]
+let diag_start = std::time::Instant::now();
+#[cfg(feature = "diagnostics")]
+let directed = &problem.directed_edges[directed_edge];
+```
+
+On the hit path (`if let Some(cached) = self.candidate_cache.borrow()
+.get(&key) { ... return Ok(cached.clone()); }`, now with `tree` and
+`directed` both already in scope above it), add before that `return`:
+
+```rust
+#[cfg(feature = "diagnostics")]
+{
+    let (node, coordination_number, bond_dims) =
+        diagnostics_node_topology(tree, problem, directed, directed_edge);
+    diagnostics::record_frame(
+        &node,
+        coordination_number,
+        &bond_dims,
+        diag_start.elapsed(),
+        1,
+        0,
+    );
+}
+```
+
+At the function's end, right before its final `Ok(values)`, add:
+
+```rust
+#[cfg(feature = "diagnostics")]
+{
+    let (node, coordination_number, bond_dims) =
+        diagnostics_node_topology(tree, problem, directed, directed_edge);
+    diagnostics::record_frame(
+        &node,
+        coordination_number,
+        &bond_dims,
+        diag_start.elapsed(),
+        0,
+        1,
+    );
+}
+```
+
+- [ ] **Step 10: Run test to verify it passes**
+
+```bash
+cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --features diagnostics \
+  candidate_frames_for_edge_records_frame_diagnostics_with_hub_coordination_number_three -- --nocapture
+```
+
+Expected: PASS. This fixture's 8 candidates split across two
+`local_coordinate` groups guarantee both a first-touch miss and at least one
+within-call repeat; if `frame_cache_hits + frame_cache_misses` is `0`,
+`diag_hits`/`diag_misses` are not being incremented at the same call sites
+`candidate_debug_stats::record_hit`/`record_miss` already run at -- recheck
+Step 7/8's placement against the surrounding `#[cfg(test)]` calls rather than
+weakening the assertion.
+
+- [ ] **Step 11: Run the full crate test suite with and without the feature**
+
+```bash
+cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --release
+cargo test --manifest-path crates/tensor4all-treeaci/Cargo.toml --release --features diagnostics
+```
+
+Expected: both PASS, no change to existing test outcomes.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add crates/tensor4all-treeaci/src/frames.rs crates/tensor4all-treeaci/src/frames/tests/mod.rs
+git commit -m "feat(treeaci): record per-node frame-cache diagnostics at the three candidate_cache sites"
+```
+
+---
+
+### Task 4: Verification pass
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Default-feature build and clippy, both crates**
+
+```bash
+cargo build --release --manifest-path crates/tensor4all-treetn/Cargo.toml
+cargo build --release --manifest-path crates/tensor4all-treeaci/Cargo.toml
+cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --all-targets -- -D warnings
+cargo clippy --manifest-path crates/tensor4all-treeaci/Cargo.toml --all-targets -- -D warnings
+```
+
+Expected: all succeed with no warnings. This is the existing default build;
+it must show zero difference from before this plan.
+
+- [ ] **Step 2: `diagnostics`-feature build and clippy, both crates**
+
+```bash
+cargo build --release --manifest-path crates/tensor4all-treetn/Cargo.toml --features diagnostics
+cargo build --release --manifest-path crates/tensor4all-treeaci/Cargo.toml --features diagnostics
+cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --features diagnostics --all-targets -- -D warnings
+cargo clippy --manifest-path crates/tensor4all-treeaci/Cargo.toml --features diagnostics --all-targets -- -D warnings
+```
+
+Expected: all succeed with no warnings.
+
+- [ ] **Step 3: `cargo fmt`**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no diff. If there is one, run `cargo fmt --all` and re-commit.
+
+- [ ] **Step 4: Do not rerun the branched-hotpaths synthetic benchmark**
+
+Per the spec's Testing section: this change is instrumentation behind a
+default-off feature, not a hot-path change, so the
+`diagnostic_chain_vs_comb_wall_time_on_realistic_floating_zone_walk`
+benchmark from `docs/worklogs/2026-08-23-treeaci-branched-hotpaths.md` is
+not part of this task's acceptance gate. Skip it.
+
+- [ ] **Step 5: Final commit if `cargo fmt` made changes**
+
+```bash
+git add -A
+git commit -m "chore: cargo fmt"
+```
+
+(Skip this step if Step 3 reported no diff.)
+
+---
+
+## After this plan
+
+This plan produces the `diagnostics`/`branch_diagnostics` API that `gw-rs`'s
+isolation harness (`docs/superpowers/specs/2026-08-24-aci-stage-isolation-design.md`
+in the sibling `gw-rs` checkout) depends on. That harness's own implementation
+plan is written separately, after this plan's PR is at least locally usable
+via the sibling-checkout `[patch]` the gw-rs spec describes.

--- a/docs/superpowers/plans/2026-08-25-treeaci-redundancy-remediation.md
+++ b/docs/superpowers/plans/2026-08-25-treeaci-redundancy-remediation.md
@@ -1,0 +1,197 @@
+# TreeACI Redundancy Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the confirmed redundant work remaining in `tensor4all-treeaci` while preserving candidate ordering, floating-point contraction order, transaction atomicity, and low-temperature/high-`R` numerical behavior.
+
+**Architecture:** Work from the owning TreeACI abstraction, one candidate at a time. Mechanical cleanups are isolated from convergence changes; every frame or Guard optimization keeps a real/complex scalar oracle and the existing saved-artifact comparison as a gate. The global-Guard start-point reuse is deferred until the false-convergence regression in #687 has a deterministic test, because changing its evaluated-point state machine can affect low-temperature large-`R` behavior.
+
+**Tech Stack:** Rust, `tensor4all-treeaci`, TreeTN/TreeACI internal tests, release-mode Cargo tests, Git history, and the retained `gw-rs` checkpoints.
+
+**Spec:** GitHub issue #686, with correctness scope cross-checked against issue #687 and `docs/worklogs/2026-08-23-treeaci-audit-remediation.md`.
+
+## Global Constraints
+
+- Do not change numerical reduction order, candidate ordering, convergence thresholds, or transaction rollback semantics without a dedicated regression oracle.
+- Preserve real and `Complex64` behavior for every shared numerical path.
+- Keep the 3+ incoming scalar fallback as the correctness reference until an equivalent implementation is proven.
+- Use release mode for numerical/performance-sensitive verification, and do not relax tolerances.
+- Record intentional retained costs with an `// INVARIANT:` marker or a worklog entry.
+- Do not push or create a PR without explicit user approval.
+
+---
+
+### Task 1: Remove dead schedule rank bookkeeping
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/schedule.rs`
+- Test: `crates/tensor4all-treeaci/src/schedule/tests/mod.rs` (only if compilation exposes a stale test reference)
+
+**Interfaces:**
+- Consumes: `run_directional_pass` and its private `PassReport`.
+- Produces: the same pass behavior and report data, without the unused `rank_changed` field or `ranks_before` clone.
+
+- [x] **Step 1: Confirm the dead-data boundary.** Verify that `rank_changed` and `ranks_before` have no production or test consumers other than the report construction.
+- [x] **Step 2: Remove only the field, clone, comparison, and initializer.** Leave `updated_edges`, deferred canonicalization, edge update order, and all convergence vectors unchanged.
+- [x] **Step 3: Run the focused schedule tests.**
+
+  ```bash
+  cargo test --release -p tensor4all-treeaci schedule --no-fail-fast
+  ```
+
+- [x] **Step 4: Run the TreeACI crate tests.**
+
+  ```bash
+  cargo test --release -p tensor4all-treeaci --no-fail-fast
+  ```
+
+### Task 2: Hoist invariant physical-offset arithmetic
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs`
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: `single_incoming_all_physical_core_matrix` and the existing scalar-vs-batched frame tests.
+- Produces: identical column-major matrix values while computing each local physical offset once per local coordinate rather than once per incoming value.
+
+- [x] **Step 1: Add or strengthen a real/complex matrix oracle** using the existing scalar contraction path and a fixture with multiple physical axes and nontrivial axis order.
+- [x] **Step 2: Run that oracle before changing production code and record its baseline result.**
+- [x] **Step 3: Move the `physical_offset` calculation outside the `incoming_value` loop without changing loop nesting, source offsets, or write order.**
+- [x] **Step 4: Run the oracle and the release frame tests.**
+
+  ```bash
+  cargo test --release -p tensor4all-treeaci frames --no-fail-fast
+  ```
+
+### Task 3: Reuse the already computed Guard evaluation hint
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/global_guard.rs`
+- Test: `crates/tensor4all-treeaci/src/global_guard/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: `InputEvaluators::evaluate_expanded` and `GuardOutputEvaluator::evaluate_expanded`.
+- Produces: the same input/output values and hint choice, with one `EvaluationHint` calculation per immutable point batch.
+
+- [x] **Step 1: Add a Guard test that compares the output values and evaluated-point accounting for a single-site varying batch and a multi-site fallback batch.**
+- [x] **Step 2: Run the test before the refactor.**
+- [x] **Step 3: Pass the existing hint from the input evaluator into the output evaluator instead of recomputing it.**
+- [x] **Step 4: Run the focused Guard tests and inspect the retained T=0.01 artifacts; a post-change pipeline replay remains the #687 follow-up gate.**
+
+### Task 4: Short-circuit empty global-pivot injection after validation
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/global_guard.rs`
+- Test: `crates/tensor4all-treeaci/src/global_guard/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: `inject_global_pivots` and its growth-capacity validation.
+- Produces: `Ok(0)` for an empty point list after capacity-length validation, without checkpointing or cloning state.
+
+- [x] **Step 1: Add tests for an empty point list with valid capacity and an empty point list with invalid capacity.** The first must leave generation, candidates, arena record count, ranks, and output unchanged; the second must still return the existing invariant error.
+- [x] **Step 2: Run the tests before the production short-circuit.**
+- [x] **Step 3: Add the early return immediately after the capacity-length check.**
+- [x] **Step 4: Run all Guard and TreeACI release tests.**
+
+### Task 5: Eliminate owned sample clones at transaction commit
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/transaction.rs`
+- Test: `crates/tensor4all-treeaci/src/transaction/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: owned `row_samples` and `col_samples` staged by `commit_edge_proposal`.
+- Produces: identical candidate/pivot/sample state, consuming the vectors with `into_iter()` rather than cloning each `ComponentSample`.
+
+- [x] **Step 1: Run the existing success, no-op, and staged-error transaction tests as the baseline.**
+- [x] **Step 2: Replace only the owned-vector iteration and preserve all validation and commit ordering.**
+- [x] **Step 3: Re-run transaction tests plus the TreeACI release suite.**
+
+### Task 6: Avoid copies when appending memoized incoming frames
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs`
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: memoized incoming frame slices in the two-incoming batched path.
+- Produces: the same matrices and candidate values using borrowed slices/`extend_from_slice`.
+
+- [x] **Step 1: Run the existing real/complex batched-vs-scalar frame tests and the branch performance fixture.**
+- [x] **Step 2: Confirm the append path already uses `extend_from_slice`; git history shows this cleanup is already present, so no production change is needed.**
+- [x] **Step 3: Re-run the scalar-vs-batched tests and inspect the saved T=0.01 stage artifacts.**
+
+### Task 7: Deduplicate FrameBuilder priming requests
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs`
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: the priming path that requests identical incoming `SampleId`s.
+- Produces: one owned frame-vector copy per distinct incoming sample while retaining the existing memo contract for ordinary `compute` callers.
+
+- [x] **Step 1: Add a debug-stat regression that feeds duplicate incoming IDs during priming and asserts one copy/materialization per distinct ID, while checking real and complex values against scalar computation.**
+- [x] **Step 2:** Run it before the implementation change and verify it fails for repeated priming copies.
+- [x] **Step 3: Add a priming-only deduplication seam; do not change the general owned-returning `compute` contract.**
+- [x] **Step 4: Run all frame tests and the TreeACI release suite.**
+
+### Task 8: Reuse algebraic edge bounds during initialization
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/state.rs`, `crates/tensor4all-treeaci/src/initialize.rs`
+- Test: `crates/tensor4all-treeaci/src/state/tests/mod.rs`, `crates/tensor4all-treeaci/src/initialize/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: one `algebraic_edge_bounds` result from state initialization.
+- Produces: identical initial ranks and bounds without a second recursive/dynamic-program calculation.
+
+- [x] **Step 1: Trace state initialization and prove the second calculation is pure and identical for the same prepared problem.**
+- [x] **Step 2: Add a real/complex initial-rank regression that asserts the existing bounds and ranks.**
+- [x] **Step 3: Thread the already computed vector into `initial_edge_ranks` and remove the duplicate call.**
+- [x] **Step 4: Run initialize/state release tests and the full TreeACI suite.**
+
+### Task 9: Keep optional candidate-cache key work one-pass
+
+**Files:**
+- Modify: `crates/tensor4all-treeaci/src/frames.rs`
+- Test: `crates/tensor4all-treeaci/src/frames/tests/mod.rs`
+
+**Interfaces:**
+- Consumes: compact candidate cache keys produced by batched contractions.
+- Produces: the same optional cache hits and values without reconstructing a key after validation.
+
+- [x] **Step 1: Run cache-hit/miss and scalar-vs-batched tests as a baseline.**
+- [x] **Step 2: Carry the validated key into insertion instead of rebuilding it, retaining the skip path for degree four or higher.**
+- [x] **Step 3: Re-run frame tests and validate cache diagnostics where enabled.**
+
+### Task 10: Review structural candidates only after safe cleanups
+
+**Files:**
+- Inspect and, only with a measured need, modify: `initialize.rs`, `samples.rs`, `schedule.rs`, `frames.rs`
+- Tests: owning module test files and the retained `gw-rs` checkpoint harness
+
+**Interfaces:**
+- Consumes: the post-Task-9 implementation and issue #686's structural candidates.
+- Produces: no implementation change unless a paired release measurement proves meaningful end-to-end cost and the numerical oracle remains unchanged.
+
+- [ ] **Step 1:** Measure component traversal, projection scratch, phase cloning, `updated_edges` storage, and metadata scans on chain, two-incoming branch, and 3+ incoming branch cases.
+- [ ] **Step 2: Add `// INVARIANT:` markers for costs proven necessary, including any retained rollback or deterministic-order storage.
+- [ ] **Step 3: Implement only one measured candidate at a time with a failing regression or source-contract test first.
+- [ ] **Step 4:** Re-run all affected release tests and the paired performance protocol.
+
+### Task 11: Revisit Guard start-point reuse only after the correctness regression exists
+
+**Files:**
+- Potentially modify: `crates/tensor4all-core/src/floating_zone.rs`, `crates/tensor4all-treeaci/src/global_guard.rs`
+- Tests: `crates/tensor4all-core/src/floating_zone.rs` tests, `crates/tensor4all-treeaci/src/global_guard/tests/mod.rs`, and the `gw-rs` T=0.01/R=10 retained-artifact comparison
+
+**Interfaces:**
+- Consumes: a tested API that lets the floating-zone walk reuse the initial error without changing its trajectory.
+- Produces: fewer duplicate start evaluations while preserving `evaluated_points`, threshold scaling, pivot selection, and false-convergence diagnostics.
+
+- [ ] **Step 1: Land or identify a deterministic #687 regression at low temperature and large `R` that distinguishes false convergence from rank growth.**
+- [ ] **Step 2: Add a core floating-zone test proving the reused initial error follows the byte-for-byte same pivot trajectory as the old path.**
+- [ ] **Step 3: Implement the smallest API seam and update Guard accounting explicitly.**
+- [ ] **Step 4: Replay the retained CTTN/nblock artifacts and run real/complex Guard tests before considering this cleanup safe.**

--- a/docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md
@@ -1,0 +1,262 @@
+# TreeACI Branch-Point Diagnostics
+
+## Status
+
+Design draft for review. Companion to `gw-rs`'s
+`docs/superpowers/specs/2026-08-24-aci-stage-isolation-design.md`, which
+consumes the interface this document defines.
+
+## Problem
+
+Issue #671 tracks a wall-time gap between chain-shaped (NBlock) and
+branch-shaped (Comb/CTTN) TreeACI runs. `docs/worklogs/2026-08-23-treeaci-branched-hotpaths.md`
+already reduced the fixed per-node overhead (76.3% median reduction on the
+synthetic comb benchmark) and ruled out two structural bug candidates
+(redundant sweeps, cache-lifetime errors), but the residual ~13.7x
+synthetic-benchmark gap and the downstream 5-13x stage-level gaps are not yet
+attributed to a cause.
+
+`shinaoka` (issue #671 comment) proposed the missing distinction: for a node
+with coordination number `z` and bond dimension `chi`, the local tensor has
+`O(chi^z)` degrees of freedom, so branching (`z=3`) is expected to cost more
+than a chain interior (`z=2`) by a factor on the order of `chi` even with a
+perfect implementation. The open question is whether the observed gap is
+explained by this topology-necessary `chi^z` scaling, or whether some of it is
+avoidable repeated work (e.g. environment reconstruction or cache misses
+concentrated at the branch hub). Answering that requires per-node data that
+TreeACI does not currently expose: per-node timing broken down by algorithm
+phase, each node's actual bond dimensions, and cache hit/miss counts at each
+node. The existing `#[cfg(test)]` phase-timing counters in
+`tensor4all-treetn/src/treetn/cached_evaluator.rs` were built for an unrelated
+investigation (why the message cache had no net speedup) and are global
+sums, not per-node, and not available in release builds.
+
+## Goals
+
+1. For a given `TreeACI`/`Guard`-driven `tree_elementwise` call, report, per
+   node: coordination number, the bond dimension of each incident edge, time
+   spent in Guard's environment/message-cache construction, time spent in
+   TreeACI's LUCI/frame construction, and cache hit/miss counts for both the
+   Guard message cache and the TreeACI candidate-frame cache.
+2. Make this available in a release build behind an explicit opt-in, with
+   zero generated code (not just zero measured cost) when the opt-in is
+   disabled.
+3. Make the collected data consumable by a downstream crate (`gw-rs`) without
+   that crate depending on TreeACI's internal node-key generic type.
+
+## Non-goals
+
+- Do not change LUCI pivot selection, candidate enumeration, truncation
+  tolerances, Guard's search policy, or any sampled value. This is
+  observability only.
+- Do not add a persistent/cross-call diagnostics store. One call's
+  diagnostics are collected, snapshotted, and discarded on the next reset.
+- Do not instrument every cache in the two crates -- only the two identified
+  in the Problem section (Guard's `EnvironmentCache<V>`, TreeACI's
+  `candidate_cache`). Other internal caches (e.g. `InputFrameStore::frames`,
+  which is a memoized-computation store rather than a hit/miss cache in the
+  same sense) are out of scope.
+- Do not change the public signature of `tree_elementwise`, `TreeAciOptions`,
+  or `TreeTNCachedEvaluator`'s existing methods. Diagnostics are read out of
+  band via a snapshot function, not threaded through return types.
+
+## Design
+
+### Feature flag
+
+Add a `diagnostics` Cargo feature to `tensor4all-treetn` and to
+`tensor4all-treeaci`. `tensor4all-treeaci/Cargo.toml` declares
+`diagnostics = ["tensor4all-treetn/diagnostics"]` so enabling it on the
+downstream-facing crate enables it transitively. With the feature disabled
+(the default), every diagnostics-related item in this design is behind
+`#[cfg(feature = "diagnostics")]` and compiles to nothing; existing release
+builds and existing benchmarks (including the ones the branched-hotpaths
+worklog measured) are unaffected.
+
+This mirrors the existing `#[cfg(test)]`-gated `phase_timing` module in
+`cached_evaluator.rs`, generalized from a test-only global-sum prototype to a
+per-node, feature-gated, cross-crate-consumable one. The existing
+`phase_timing` module stays as is; it is a different, narrower investigation
+and this design does not fold it in.
+
+### Data model
+
+Both crates report through a shared, serializable record. It lives in
+`tensor4all-treetn` (the lower crate) so `tensor4all-treeaci` can extend the
+same entries rather than keeping a parallel table.
+
+```rust
+// tensor4all-treetn/src/treetn/diagnostics.rs, cfg(feature = "diagnostics")
+
+#[derive(Clone, Debug, Default, serde::Serialize)]
+pub struct NodeDiagnostics {
+    /// `format!("{node:?}")` of the tree node. A string, not the generic
+    /// `V`, so downstream crates (gw-rs) do not need `V: Serialize` or to
+    /// depend on TreeACI's/TreeTN's node-key type at all.
+    pub node: String,
+    /// Number of tree edges incident to this node (Guard/TreeACI's `z`).
+    pub coordination_number: usize,
+    /// Bond dimension of each incident edge, in the same order as
+    /// discovered (not guaranteed stable across calls).
+    pub bond_dims: Vec<usize>,
+    /// Nanoseconds spent building this node's Guard environment/message
+    /// during `build_environment_cache` and its callers.
+    pub guard_ns: u64,
+    /// Nanoseconds spent in this node's TreeACI LUCI/frame construction
+    /// (`candidate_frame`, `directed_frame`, and the batched equivalents in
+    /// `frames.rs`).
+    pub frame_ns: u64,
+    pub guard_cache_hits: u64,
+    pub guard_cache_misses: u64,
+    pub frame_cache_hits: u64,
+    pub frame_cache_misses: u64,
+}
+```
+
+### Collection mechanism
+
+A feature-gated global registry, following the existing atomic-counter
+pattern in `cached_evaluator.rs` but keyed per node instead of summed:
+
+```rust
+// tensor4all-treetn/src/treetn/diagnostics.rs, cfg(feature = "diagnostics")
+
+thread_local! {
+    static REGISTRY: RefCell<HashMap<String, NodeDiagnostics>> = ...;
+}
+
+pub fn reset();
+pub fn record_guard(node: &str, coordination_number: usize, bond_dims: &[usize], elapsed: Duration, hit: bool);
+pub fn record_frame(node: &str, elapsed: Duration, hit: bool);
+pub fn snapshot() -> Vec<NodeDiagnostics>;
+```
+
+`thread_local`, not a `Mutex`-guarded global: both Guard and TreeACI already
+run single-threaded per `tree_elementwise` call in the code paths this
+investigation cares about (the R=10 checkpoints were produced with
+`RAYON_NUM_THREADS=1` for the isolated G0 worker and the downstream product
+stages do not fan the Guard/TreeACI sweep itself across threads). A
+thread-local avoids lock contention entirely and matches the "one call, one
+snapshot" usage model. If a future caller does run diagnostics-enabled sweeps
+across threads, `snapshot()` only sees its own thread's records -- documented
+as a known limitation, not silently wrong data.
+
+Call sites:
+
+- `cached_evaluator.rs`'s `build_environment_cache` (~line 1043): wrap each
+  per-node message construction with a timer; call `record_guard` with the
+  node's `Debug` string, its coordination number (`self.neighbors[node].len()`,
+  from the existing `ComponentCostIndex`/ evaluator's `neighbors: HashMap<V,
+  Vec<V>>`), and the bond dimensions read off the constructed `StackedMessage`.
+  `hit: false` here, since this call site is a cache *miss* by construction
+  (it is the rebuild path); a `hit: true` record is added wherever an
+  existing `EnvironmentCache` entry is reused instead of rebuilt.
+- `frames.rs`'s three `candidate_cache.borrow().get(&key)` sites (lines 814,
+  982, 1116): record a frame-cache hit when `Some`, and wrap the
+  corresponding compute-and-insert fallback (around line 530) with a timer
+  and a miss record. The node identity for a `CandidateCacheKey` is derived
+  from `problem.directed_edges[key.directed_edge].to` (or `.from`, whichever
+  is the node the frame is being built *at* -- confirm against
+  `PreparedTreeProblem`'s existing edge-orientation convention during
+  implementation). Coordination number is the count of directed edges in
+  `problem.directed_edges` sharing that node.
+
+All of the above only executes inside `#[cfg(feature = "diagnostics")]`
+blocks; the non-diagnostic build keeps exactly the code it has today.
+
+### Public accessors
+
+```rust
+// re-exported from tensor4all_treetn::diagnostics (feature = "diagnostics")
+pub fn reset();
+pub fn snapshot() -> Vec<NodeDiagnostics>;
+```
+
+`tensor4all_treeaci` re-exports the same two functions (or gw-rs depends on
+`tensor4all_treetn` directly for them -- an implementation-time choice with no
+design impact, since `tensor4all-treeaci` already depends on
+`tensor4all-treetn`).
+
+## Error handling
+
+Diagnostics collection must not turn a successful `tree_elementwise` call
+into a failing one. If a record cannot be attributed (e.g. a node `Debug`
+string collides after formatting, which is not expected but is not a
+correctness invariant this design proves), the later write silently
+overwrites the earlier one rather than panicking or returning `Result`.
+`reset`/`snapshot` are infallible.
+
+## Testing
+
+1. A `diagnostics`-feature unit test in `tensor4all-treetn` that runs a small
+   labeled tree (chain and a 3-arm star) through the existing Guard evaluator
+   path, calls `snapshot()`, and asserts: one record per node, the star's
+   center has `coordination_number == 3` and the chain's interior nodes have
+   `coordination_number == 2`, and `guard_cache_hits + guard_cache_misses`
+   matches the number of `EnvironmentCache` lookups the test setup is known
+   to perform.
+2. A `diagnostics`-feature unit test in `tensor4all-treeaci` that runs
+   `tree_elementwise` over a small branched tree and asserts every node
+   reachable in `PreparedTreeProblem` appears in `snapshot()`, with
+   `frame_cache_hits + frame_cache_misses > 0` for at least one node after a
+   multi-sweep run (candidate reuse across sweeps is the documented 45-65%
+   hit-rate behavior from the message-cache worklog).
+3. Zero-cost-when-disabled is enforced by construction (every diagnostics
+   item lives behind `#[cfg(feature = "diagnostics")]`), not by a runtime
+   test. The default-feature build
+   (`cargo build --release --manifest-path crates/tensor4all-treeaci/Cargo.toml`,
+   no `diagnostics` feature) must succeed and is covered by existing CI; this
+   design adds no new default-feature test for the module's absence.
+4. Release build check: `cargo build --release --manifest-path
+   crates/tensor4all-treeaci/Cargo.toml --features diagnostics` succeeds and
+   `cargo clippy --manifest-path crates/tensor4all-treeaci/Cargo.toml
+   --features diagnostics --all-targets -- -D warnings` is clean.
+5. Do not rerun the branched-hotpaths synthetic benchmark as part of this
+   change's acceptance gate -- this is instrumentation, not a hot-path
+   change, and the feature is off by default in that benchmark's build.
+
+## Files expected to change
+
+- `crates/tensor4all-treetn/Cargo.toml`: new `diagnostics` feature (likely
+  pulling in `serde`'s `derive` feature, already a dependency elsewhere in
+  the workspace).
+- `crates/tensor4all-treetn/src/treetn/diagnostics.rs`: new module (data
+  model, registry, `reset`/`snapshot`).
+- `crates/tensor4all-treetn/src/treetn/cached_evaluator.rs`: feature-gated
+  call sites in `build_environment_cache` and wherever an `EnvironmentCache`
+  hit is served.
+- `crates/tensor4all-treeaci/Cargo.toml`: new `diagnostics` feature
+  forwarding to `tensor4all-treetn/diagnostics`.
+- `crates/tensor4all-treeaci/src/frames.rs`: feature-gated call sites at the
+  three `candidate_cache` lookup sites and the compute-and-insert fallback.
+- `crates/tensor4all-treeaci/src/lib.rs`: re-export `diagnostics` module
+  when the feature is enabled.
+- Tests adjacent to the changed modules.
+- `docs/superpowers/plans/2026-08-24-treeaci-branch-diagnostics.md`: the
+  implementation plan after this spec is approved.
+
+## Alternatives considered
+
+### Pass a `&mut Diagnostics` collector through call signatures
+
+Rejected: it would touch `tree_elementwise`, `TreeAciOptions`, `Guard`'s
+constructor, and every internal call in the affected paths, even when the
+feature is disabled (an `Option<&mut Diagnostics>` parameter still exists in
+the signature). The global/thread-local registry keeps the change entirely
+inside `#[cfg(feature = "diagnostics")]` blocks and leaves every public
+signature untouched.
+
+### Expose `V` directly instead of a `String` node label
+
+Rejected for this design: it would require `V: Serialize` (not currently
+bounded on `TreeAciNode`/the evaluator's node type) and would leak the
+node-key type into `gw-rs`'s dependency surface for no benefit the isolation
+harness needs -- `gw-rs` only needs to identify "the hub" (by
+`coordination_number`) and print/serialize labels, not reconstruct `V`.
+
+### Fold into the existing `phase_timing` module
+
+Rejected: that module is explicitly scoped to a different, already-resolved
+question (message-cache net speedup) and is a global sum, not per-node. Reusing
+it would conflate two investigations and require changing its meaning
+retroactively.

--- a/docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md
@@ -81,14 +81,19 @@ and this design does not fold it in.
 
 ### Data model
 
-Both crates report through a shared, serializable record. It lives in
-`tensor4all-treetn` (the lower crate) so `tensor4all-treeaci` can extend the
-same entries rather than keeping a parallel table.
+Both crates report through a shared record. It lives in `tensor4all-treetn`
+(the lower crate) so `tensor4all-treeaci` can extend the same entries rather
+than keeping a parallel table. The struct is a plain, non-`serde` type: the
+workspace has no `serde` derive dependency today (only `serde_json` at the
+top level, unused for domain-type derives), and `gw-rs` already depends on
+both `serde` and `serde_json` directly, so it is cheaper and avoids a new
+workspace dependency for `gw-rs`'s isolation harness to build its own JSON
+from the plain fields than for this feature to add one.
 
 ```rust
 // tensor4all-treetn/src/treetn/diagnostics.rs, cfg(feature = "diagnostics")
 
-#[derive(Clone, Debug, Default, serde::Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct NodeDiagnostics {
     /// `format!("{node:?}")` of the tree node. A string, not the generic
     /// `V`, so downstream crates (gw-rs) do not need `V: Serialize` or to
@@ -99,8 +104,9 @@ pub struct NodeDiagnostics {
     /// Bond dimension of each incident edge, in the same order as
     /// discovered (not guaranteed stable across calls).
     pub bond_dims: Vec<usize>,
-    /// Nanoseconds spent building this node's Guard environment/message
-    /// during `build_environment_cache` and its callers.
+    /// Nanoseconds spent building this node's Guard environment/message in
+    /// `get_or_compute_node_message`, `build_environment_cache`'s per-node
+    /// worker.
     pub guard_ns: u64,
     /// Nanoseconds spent in this node's TreeACI LUCI/frame construction
     /// (`candidate_frame`, `directed_frame`, and the batched equivalents in
@@ -126,10 +132,15 @@ thread_local! {
 }
 
 pub fn reset();
-pub fn record_guard(node: &str, coordination_number: usize, bond_dims: &[usize], elapsed: Duration, hit: bool);
-pub fn record_frame(node: &str, elapsed: Duration, hit: bool);
+pub fn record_guard(node: &str, coordination_number: usize, bond_dims: &[usize], elapsed: Duration, hits: u64, misses: u64);
+pub fn record_frame(node: &str, coordination_number: usize, bond_dims: &[usize], elapsed: Duration, hits: u64, misses: u64);
 pub fn snapshot() -> Vec<NodeDiagnostics>;
 ```
+
+`hits`/`misses` as counts, not a single `hit: bool`: a call can cover a batch
+of sample points that is partly cached and partly not (Guard's message cache
+looks up a batch of points per node in one call), so the record needs both
+counts to stay accurate rather than collapsing to one flag.
 
 `thread_local`, not a `Mutex`-guarded global: both Guard and TreeACI already
 run single-threaded per `tree_elementwise` call in the code paths this
@@ -143,23 +154,30 @@ as a known limitation, not silently wrong data.
 
 Call sites:
 
-- `cached_evaluator.rs`'s `build_environment_cache` (~line 1043): wrap each
-  per-node message construction with a timer; call `record_guard` with the
-  node's `Debug` string, its coordination number (`self.neighbors[node].len()`,
-  from the existing `ComponentCostIndex`/ evaluator's `neighbors: HashMap<V,
-  Vec<V>>`), and the bond dimensions read off the constructed `StackedMessage`.
-  `hit: false` here, since this call site is a cache *miss* by construction
-  (it is the rebuild path); a `hit: true` record is added wherever an
-  existing `EnvironmentCache` entry is reused instead of rebuilt.
-- `frames.rs`'s three `candidate_cache.borrow().get(&key)` sites (lines 814,
-  982, 1116): record a frame-cache hit when `Some`, and wrap the
-  corresponding compute-and-insert fallback (around line 530) with a timer
-  and a miss record. The node identity for a `CandidateCacheKey` is derived
-  from `problem.directed_edges[key.directed_edge].to` (or `.from`, whichever
-  is the node the frame is being built *at* -- confirm against
-  `PreparedTreeProblem`'s existing edge-orientation convention during
-  implementation). Coordination number is the count of directed edges in
-  `problem.directed_edges` sharing that node.
+- `cached_evaluator.rs`'s `get_or_compute_node_message` (~line 2426, called
+  once per node from `build_environment_cache`'s postorder loop at ~line
+  1077): this function already distinguishes a full-batch cache hit (an
+  early return around line 2535) from a partial/full miss (the function's
+  normal end, ~line 2758) against its persistent `message_caches:
+  HashMap<(V, V), PackedMessageCache>` -- the actual hit/miss cache, keyed by
+  directed edge, that `self.last_stats.message_cache_hits`/`_misses` already
+  aggregate over a whole call. Attribute those same counts per node instead
+  of only summing them, and wrap the function body in a timer. Coordination
+  number and bond dimensions come from `self.tree`'s own edge structure
+  (`site_index_network().neighbors(node)`, `edge_between`, `bond_index`), not
+  from a stored `neighbors` map -- no such field exists on
+  `TreeTNCachedEvaluator` itself; `ComponentCostIndex`'s `neighbors` field is
+  a separate, `GreedyCenterSearch`-only structure.
+- `frames.rs`'s three `candidate_cache.borrow().get(&key)` sites (~lines
+  814, 982, 1116, alongside the existing `#[cfg(test)]
+  candidate_debug_stats::record_hit`/`record_miss` calls at the same three
+  sites): record a frame-cache hit/miss per call, aggregated over that
+  call's candidates, not per individual candidate. The node identity is
+  `problem.directed_edges[directed_edge].from` (the node the frame is being
+  built *at* -- confirmed against `candidate_frames_for_edge`'s existing
+  `problem.node_positions.get(&directed.from)` lookup). Coordination number
+  is `directed.incoming_to_from.len() + 1` (already-incoming edges plus the
+  one outgoing edge being built), avoiding a scan of `problem.directed_edges`.
 
 All of the above only executes inside `#[cfg(feature = "diagnostics")]`
 blocks; the non-diagnostic build keeps exactly the code it has today.
@@ -167,15 +185,20 @@ blocks; the non-diagnostic build keeps exactly the code it has today.
 ### Public accessors
 
 ```rust
-// re-exported from tensor4all_treetn::diagnostics (feature = "diagnostics")
+// tensor4all_treetn::diagnostics (feature = "diagnostics")
 pub fn reset();
 pub fn snapshot() -> Vec<NodeDiagnostics>;
+pub fn record_guard(...);
+pub fn record_frame(...);
 ```
 
-`tensor4all_treeaci` re-exports the same two functions (or gw-rs depends on
-`tensor4all_treetn` directly for them -- an implementation-time choice with no
-design impact, since `tensor4all-treeaci` already depends on
-`tensor4all-treetn`).
+`tensor4all_treeaci` re-exports all four under `tensor4all_treeaci::
+branch_diagnostics`, not `tensor4all_treeaci::diagnostics`: the crate already
+publicly exports an unrelated `TreeAciDiagnostics` struct (sweep/convergence
+history, from `result.rs`), and a module literally named `diagnostics`
+sitting next to it would read as the same concern. `branch_diagnostics` names
+what this data is actually about -- branch-point performance -- and keeps the
+two apart.
 
 ## Error handling
 

--- a/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
+++ b/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
@@ -137,14 +137,57 @@ still take the general per-element path.
 - Downstream: re-ran the same real R=10 Comb `pi_rtau` checkpoint via gw-rs's
   `isolate_aci_stage` harness after each fix; results in the tables above.
 
+## Third fix: measure which axis is actually fast before generalizing further
+
+Before extending the fast path further, checked whether a prior attempt at
+this specific angle already existed and failed (the min-group-points gate
+above is a different, already-known rejection). None found in this branch's
+worklogs or git history for the memory-access-pattern angle specifically.
+
+Rather than guessing which of `child_axis_1`/`child_axis_2` to add a fast
+path for, added scratch counters (`BRANCH_FAST_AXIS_IS_{PARENT,CHILD1,CHILD2,PHYSICAL}`,
+not wired into `summary()`'s stable output) tallying which axis is actually
+stride-1 once per BLAS call, and re-ran the same checkpoint. Result, out of
+11392 branch BLAS calls: `parent=3986` (35%, already covered),
+`child1=0` (never), `child2=5824` (51%, uncovered), `physical=1582` (14%, no
+axis available to help). `child_axis_2`, not `parent_axis`, is the single
+most common fast axis -- and `child_axis_1` needs no fast path at all.
+
+Added a fast path for `strides[child_axis_2] == 1`: read the contiguous
+`child_dim_2` run per `(c1, parent)` as one slice, then scatter it into
+`left` at its `parent_dim` write-stride. `child_axis_2` is not `left`'s
+contiguous write axis (`parent` is), so unlike the `parent_axis` fast path,
+this trades a strided read for a strided write rather than eliminating both.
+New test `grouped_branch_contraction_matches_scalar_reference_when_child_axis_2_is_contiguous`
+(again, no existing fixture put `child_axis_2` at stride 1) exercises the
+scatter-write path specifically.
+
+Measured, same checkpoint, same call, on top of the first two fixes:
+
+| | + contiguous-read (parent) | + contiguous-read (child_axis_2) |
+|---|---:|---:|
+| `setup_ns` | 73.8s | 69.0s (**-6.4%**, -41.4% cumulative from 117.8s) |
+| `pi_rtau` total | 262.8s | 257.8s (**-1.9%**, -14.0% cumulative from 299.8s) |
+| max_bond / final_err | 228 / 9.478e-5 | 228 / 9.478e-5 (unchanged) |
+
+Despite covering more calls (51% vs. 35%), this fix's wall-time win is
+smaller than the `parent_axis` fast path's -- consistent with the
+scatter-write cost eating most of the contiguous-read benefit. Three fixes in
+a row now show shrinking `setup_ns` reductions (23% -> 18% -> 6.4%):
+diminishing returns, stopping this optimization thread here rather than
+continuing to chase the remaining `setup_ns` (still 68% of the branch
+kernel's own time after all three fixes).
+
 ## Follow-up
 
-- `setup_ns` is still the majority of the branch kernel's own time. Further
-  reduction would need either extending the fast path to more axis
-  arrangements (e.g. detecting when `child_axis_1`/`child_axis_2` -- not just
-  `parent_axis` -- lands on the fast axis, and restructuring the loop nesting
-  accordingly) or accepting that the general path's scattered reads are
-  inherent to this contraction's shape. Not pursued further in this session.
+- Further `setup_ns` reduction from here would need either a genuinely
+  different data layout for `raw` (out of scope: it is this node's `IdxTensor`
+  storage, shared with every other consumer, not something this contraction
+  alone can choose), or accepting the general path's scattered
+  reads-and-writes as inherent to this contraction's shape for the ~14% of
+  calls where `physical_axis` is the fast axis (no loop-axis fast path can
+  help there) and whatever fraction still falls through the general path for
+  other reasons. Not pursued further in this session.
 - This fix, the `diagnostics`/`branch_diagnostics` feature, and gw-rs's
   `isolate_aci_stage` harness are all still local to this session's branches
   (`optimize-treeaci-branched-hotpaths` here, `aci-stage-isolation-harness`

--- a/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
+++ b/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
@@ -1,0 +1,118 @@
+# Branch contraction setup cost (tensor4all-rs#671 follow-up)
+
+Work log. Continues from `docs/worklogs/2026-08-22-treetn-branch-message-raw-path.md`
+(which added `grouped_branch_message_contraction`, the branch kernel this
+entry modifies) and from the new `diagnostics`/`branch_diagnostics` feature
+(`docs/superpowers/specs/2026-08-24-treeaci-branch-diagnostics-design.md`).
+
+## What the new per-phase counters found
+
+`grouped_branch_message_contraction`/`grouped_chain_message_contraction`
+were instrumented with feature-gated counters splitting branch calls into
+`setup_ns` (building the `left` intermediate before the BLAS call),
+`matmul_ns`, and `accumulate_ns`, plus BLAS-vs-scalar call/point counts for
+both kernels (`contraction_diagnostics` in `cached_evaluator.rs`). A real R=10
+Comb `pi_rtau` product (T=0.01, `aci_global_guard=true`, same config as
+issue #671's reproduction, replayed via gw-rs's `isolate_aci_stage` harness
+from an existing checkpoint) showed:
+
+```
+branch: blas_calls=11392  blas_points=26049   (2.3 points/call average)
+        setup_ns=117.8s   matmul_ns=25.6s     accumulate_ns=1.25s
+chain:  blas_calls=2219   blas_points=408186  (184 points/call average)
+        contract_ns=1.98s
+```
+
+`setup_ns` -- the scalar triple-nested loop building the `left` intermediate
+matrix, independent of how many points share the group -- is 81% of the
+branch kernel's own time, and larger than the entire chain kernel's total
+time for the same call. Branch's average of 2.3 points per BLAS call (vs
+chain's 184) means this fixed setup cost is essentially never amortized.
+
+## Two follow-up questions, and why the answer wasn't "add a min-group gate"
+
+The obvious fix -- mirror the chain kernel's `CHAIN_BLAS_MIN_GROUP_POINTS`
+gate on branch, falling back to `scalar_branch_message_contraction` for
+small groups -- was already tried and rejected during
+`2026-08-22-treetn-branch-message-raw-path.md`'s own development (see that
+log's "A regression, caught before it shipped" section): it regressed a
+synthetic benchmark by ~1.7x, because `scalar_branch_message_contraction` is
+slower per FLOP than the BLAS path even at 1-2 points, once bond dimensions
+are realistic. So this investigation asked two different questions instead:
+
+**Could Guard's own search hand branch nodes larger batches?** Traced
+`find_global_pivots` (`tensor4all-treeaci/src/global_guard.rs`) through
+`floating_zone_walk` (`tensor4all-core/src/floating_zone.rs`) into
+`TreeTNCachedEvaluator::evaluate_batched_with_hint`. The top-level batch size
+is already the widest the coordinate-descent walk can offer (every candidate
+value of the one site currently being swept). Chain's much larger effective
+batch comes from a level below: each node's batch gets re-grouped by that
+node's *own* physical value before dispatch, and only shatters into
+near-singleton groups for whichever node happens to *own* the site currently
+being swept -- the comb's single hub is disproportionately likely to be that
+node relative to its many chain-arm neighbors. This is intrinsic to how the
+search visits the tree, not a batching oversight; restructuring it would
+change search semantics and is out of scope here.
+
+**Is the setup loop itself doing more work than it needs to?** Yes, partly.
+The original loop rebuilt a `[usize; 4]` `axis_values` array and recomputed
+the full 4-term stride dot product from scratch on every one of the up to
+`parent_dim * child_dim_1 * child_dim_2` `(c1, c2, parent)` iterations, even
+though three of those four terms are loop-invariant at each nesting level.
+
+## Fix
+
+Rewrote the `left`-matrix construction loop in
+`grouped_branch_message_contraction` to hoist the per-`c1`/per-`c2` partial
+sums out of their respective loop levels and turn the innermost `parent`
+loop's index arithmetic into a running accumulator (`flat += strides[parent_axis]`
+per step) instead of a fresh multiply-add. Mathematically identical to the
+original per-point computation -- no change to which elements are read or
+where they are written, verified against the existing branch-kernel
+correctness tests (`grouped_branch_contraction_matches_direct_reference_for_real_values`,
+`grouped_branch_contraction_large_{real,complex}_groups_match_scalar_reference`,
+`raw_{,complex_}branch_message_matches_generic_contraction`), all passing
+unchanged.
+
+## Measured effect
+
+Same checkpoint, same call, before/after:
+
+| | before | after |
+|---|---:|---:|
+| `setup_ns` | 117.8s | 90.5s (**-23%**) |
+| `matmul_ns` | 25.6s | 26.8s (noise) |
+| `pi_rtau` total | 299.8s | 275.6s (**-8%**) |
+| max_bond / final_err | 228 / 9.478e-5 | 228 / 9.478e-5 (unchanged) |
+
+A real, measured win at matched accuracy, but a partial one: `setup_ns` is
+still 76% of the branch kernel's own time after this change. The arithmetic
+was not the dominant cost -- the per-element write `left[left_offset] =
+raw[flat]` itself, at a `flat` stride pattern that is not contiguous across
+the innermost loop, is the more likely remaining bottleneck (cache-unfriendly
+scalar writes at this scale: up to ~1.35M elements for the hub's peak
+observed dims `[247, 20, 273]`). Not pursued further in this session.
+
+## Verification
+
+- `cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --release branch`:
+  all 7 matching tests pass, including every branch-kernel correctness test
+  listed above.
+- `cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --release`
+  (default and `--features diagnostics`): full suite green, no change from
+  before this fix.
+- `cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --all-targets -- -D warnings`
+  clean, default and `--features diagnostics`.
+- Downstream: re-ran the same real R=10 Comb `pi_rtau` checkpoint via gw-rs's
+  `isolate_aci_stage` harness before and after; results in the table above.
+
+## Follow-up
+
+- The remaining `setup_ns` cost (still the majority of branch's own time) is
+  a plausible next target, but would need profiling at the memory-access
+  level (or a differently-shaped write pattern) rather than more arithmetic
+  hoisting, which is now largely exhausted.
+- This fix, the `diagnostics`/`branch_diagnostics` feature, and gw-rs's
+  `isolate_aci_stage` harness are all still local to this session's branches
+  (`optimize-treeaci-branched-hotpaths` here, `aci-stage-isolation-harness`
+  in gw-rs) and not yet pushed.

--- a/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
+++ b/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
@@ -90,28 +90,61 @@ still 76% of the branch kernel's own time after this change. The arithmetic
 was not the dominant cost -- the per-element write `left[left_offset] =
 raw[flat]` itself, at a `flat` stride pattern that is not contiguous across
 the innermost loop, is the more likely remaining bottleneck (cache-unfriendly
-scalar writes at this scale: up to ~1.35M elements for the hub's peak
-observed dims `[247, 20, 273]`). Not pursued further in this session.
+scalar reads at this scale: up to ~1.35M elements for the hub's peak
+observed dims `[247, 20, 273]`).
+
+## Second fix: contiguous-read fast path
+
+`raw`'s strides are `[1, dims[0], dims[0]*dims[1], dims[0]*dims[1]*dims[2]]`
+(column-major, axis 0 fastest). `flat` steps by `strides[parent_axis]` in the
+innermost loop, which is contiguous (stride 1) only when `parent_axis`
+happens to land on axis 0 for that particular node's tensor -- data-dependent
+per node, not a fixed convention. Added a fast path: when
+`strides[parent_axis] == 1`, read the whole `parent_dim`-length run as one
+slice and `copy_from_slice` it into `left`, instead of one bounds-checked
+element at a time; falls back to the existing per-element loop otherwise.
+Same values, same write offsets either way.
+
+No existing branch-kernel test happened to exercise `strides[parent_axis] ==
+1` -- every fixture put `physical_axis` at stride 1 instead. Added
+`grouped_branch_contraction_matches_scalar_reference_when_parent_axis_is_contiguous`
+(same shape as the existing large-groups test, with `parent_axis`/`physical_axis`
+swapped) before relying on the new path.
+
+Measured, same checkpoint, same call, on top of the first fix:
+
+| | first fix | + contiguous-read fast path |
+|---|---:|---:|
+| `setup_ns` | 90.5s | 73.8s (**-18%**, -37% cumulative from 117.8s) |
+| `pi_rtau` total | 275.6s | 262.8s (**-5%**, -12.3% cumulative from 299.8s) |
+| max_bond / final_err | 228 / 9.478e-5 | 228 / 9.478e-5 (unchanged) |
+
+`setup_ns` is now 72% of the branch kernel's own time (down from 81% before
+either fix). The fast path only fires for whichever nodes happen to have
+`parent_axis` on the fast tensor axis; most calls in this particular run
+still take the general per-element path.
 
 ## Verification
 
 - `cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --release branch`:
-  all 7 matching tests pass, including every branch-kernel correctness test
-  listed above.
+  all matching tests pass, including every branch-kernel correctness test
+  listed above and the new contiguous-axis test.
 - `cargo test --manifest-path crates/tensor4all-treetn/Cargo.toml --release`
-  (default and `--features diagnostics`): full suite green, no change from
-  before this fix.
+  (default and `--features diagnostics`): full suite green (453/457 passed,
+  1 ignored), no change from before either fix.
 - `cargo clippy --manifest-path crates/tensor4all-treetn/Cargo.toml --all-targets -- -D warnings`
-  clean, default and `--features diagnostics`.
+  clean, default and `--features diagnostics`, after both fixes.
 - Downstream: re-ran the same real R=10 Comb `pi_rtau` checkpoint via gw-rs's
-  `isolate_aci_stage` harness before and after; results in the table above.
+  `isolate_aci_stage` harness after each fix; results in the tables above.
 
 ## Follow-up
 
-- The remaining `setup_ns` cost (still the majority of branch's own time) is
-  a plausible next target, but would need profiling at the memory-access
-  level (or a differently-shaped write pattern) rather than more arithmetic
-  hoisting, which is now largely exhausted.
+- `setup_ns` is still the majority of the branch kernel's own time. Further
+  reduction would need either extending the fast path to more axis
+  arrangements (e.g. detecting when `child_axis_1`/`child_axis_2` -- not just
+  `parent_axis` -- lands on the fast axis, and restructuring the loop nesting
+  accordingly) or accepting that the general path's scattered reads are
+  inherent to this contraction's shape. Not pursued further in this session.
 - This fix, the `diagnostics`/`branch_diagnostics` feature, and gw-rs's
   `isolate_aci_stage` harness are all still local to this session's branches
   (`optimize-treeaci-branched-hotpaths` here, `aci-stage-isolation-harness`

--- a/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
+++ b/docs/worklogs/2026-08-24-branch-contraction-setup-cost.md
@@ -8,8 +8,8 @@ entry modifies) and from the new `diagnostics`/`branch_diagnostics` feature
 ## What the new per-phase counters found
 
 `grouped_branch_message_contraction`/`grouped_chain_message_contraction`
-were instrumented with feature-gated counters splitting branch calls into
-`setup_ns` (building the `left` intermediate before the BLAS call),
+were instrumented with feature-gated counters splitting branch work into
+`setup_ns` (building the `left` intermediate before each BLAS dispatch),
 `matmul_ns`, and `accumulate_ns`, plus BLAS-vs-scalar call/point counts for
 both kernels (`contraction_diagnostics` in `cached_evaluator.rs`). A real R=10
 Comb `pi_rtau` product (T=0.01, `aci_global_guard=true`, same config as
@@ -17,17 +17,27 @@ issue #671's reproduction, replayed via gw-rs's `isolate_aci_stage` harness
 from an existing checkpoint) showed:
 
 ```
-branch: blas_calls=11392  blas_points=26049   (2.3 points/call average)
+branch: historical_kernel_calls=11392  blas_points=26049
         setup_ns=117.8s   matmul_ns=25.6s     accumulate_ns=1.25s
-chain:  blas_calls=2219   blas_points=408186  (184 points/call average)
+chain:  historical_kernel_calls=2219   blas_points=408186
         contract_ns=1.98s
 ```
+
+These archived measurements were collected before the counter-semantics
+correction below: the displayed `blas_calls` values counted one outer grouped
+kernel invocation, not one `mat_mul_owned` dispatch. The branch group count was
+available separately but was not printed in this excerpt. The current
+`blas_calls` counters count each actual matrix-multiply dispatch, so the old
+call-rate ratios are retained only as historical timing context and must not
+be compared directly with current dispatch counts.
 
 `setup_ns` -- the scalar triple-nested loop building the `left` intermediate
 matrix, independent of how many points share the group -- is 81% of the
 branch kernel's own time, and larger than the entire chain kernel's total
-time for the same call. Branch's average of 2.3 points per BLAS call (vs
-chain's 184) means this fixed setup cost is essentially never amortized.
+time for the same call. In the archived outer-kernel accounting, branch
+processed 2.3 points per recorded kernel invocation (vs chain's 184); this
+still shows that the fixed setup cost was poorly amortized in the measured
+workload, but it is not a per-dispatch statistic.
 
 ## Two follow-up questions, and why the answer wasn't "add a min-group gate"
 
@@ -145,10 +155,10 @@ above is a different, already-known rejection). None found in this branch's
 worklogs or git history for the memory-access-pattern angle specifically.
 
 Rather than guessing which of `child_axis_1`/`child_axis_2` to add a fast
-path for, added scratch counters (`BRANCH_FAST_AXIS_IS_{PARENT,CHILD1,CHILD2,PHYSICAL}`,
-not wired into `summary()`'s stable output) tallying which axis is actually
-stride-1 once per BLAS call, and re-ran the same checkpoint. Result, out of
-11392 branch BLAS calls: `parent=3986` (35%, already covered),
+path for, added counters (`BRANCH_FAST_AXIS_IS_{PARENT,CHILD1,CHILD2,PHYSICAL}`)
+to the summary. In the archived implementation these counters were updated
+once per outer grouped-kernel invocation; the archived
+run reported 11392 such invocations: `parent=3986` (35%, already covered),
 `child1=0` (never), `child2=5824` (51%, uncovered), `physical=1582` (14%, no
 axis available to help). `child_axis_2`, not `parent_axis`, is the single
 most common fast axis -- and `child_axis_1` needs no fast path at all.

--- a/docs/worklogs/2026-08-25-treeaci-redundancy-remediation.md
+++ b/docs/worklogs/2026-08-25-treeaci-redundancy-remediation.md
@@ -1,0 +1,105 @@
+# TreeACI redundancy remediation
+
+## Scope
+
+This pass implements the confirmed, semantics-preserving redundant-work items
+from issue #686 on top of the TreeACI audit baseline. Correctness issue #687
+remains a separate boundary: the saved R=10, T=0.01 artifacts show a large
+nblock `pi_rtau` rank, but they are not a post-change replay of the current
+crate.
+
+The implementation preserves candidate ordering, contraction/reduction order,
+transaction rollback, convergence inputs, real/complex scalar behavior, and
+the existing working-memory limits. No tolerance was changed.
+
+## Changes
+
+- Removed the unused directional-pass `ranks_before` snapshot and
+  `PassReport::rank_changed`; `updated_edges` and all scheduling order remain
+  unchanged.
+- Hoisted the physical-offset calculation out of the incoming-sample loop in
+  the single-incoming all-physical kernel. The temporary offset table is now
+  included in the working-byte check.
+- Added a nontrivial physical-axis-order oracle for both real and complex
+  values, so the hoist is checked against the exact column-major mapping.
+- Reused one computed Guard evaluation hint for the input and output
+  evaluators in the floating-zone callback. Empty global-pivot injection now
+  validates capacity lengths and returns before checkpointing or cloning state.
+- Added exact-value and no-mutation tests for the two Guard changes.
+- Moved owned row/column samples out of `LocalUpdateResult` during transaction
+  commit, removing per-sample clones while preserving the staged commit and
+  rollback path.
+- Made `FrameBuilder` priming use a non-copying `ensure_computed` path when a
+  memoized frame already exists. The ordinary `compute` API still returns an
+  owned vector when its caller needs one.
+- Carried candidate cache keys from the initial lookup through insertion,
+  avoiding a second key reconstruction for batched one- and two-incoming
+  candidates.
+- Computed algebraic edge bounds once during state initialization and passed
+  them into initial-rank selection instead of walking the prepared tree twice.
+
+## Audit decisions
+
+- The frame append path already uses `extend_from_slice`; git blame traces
+  that fix to the earlier frame-overhead work, so no duplicate change was
+  made.
+- Reusing the Guard start-point evaluation is deliberately deferred. It can
+  change floating-zone evaluation and false-convergence behavior, and must be
+  gated by a low-temperature/high-R regression reproducing #687.
+- Structural changes to phase traversal, scratch ownership, and diagnostic
+  `updated_edges` representation are deferred until paired release profiling
+  demonstrates a material cost and a numerical oracle is available. These are
+  not treated as harmless syntax cleanup.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `git diff --check`
+- `cargo clippy --release -p tensor4all-treeaci --all-targets -- -D warnings`
+- `cargo test --release -p tensor4all-treeaci --no-fail-fast`: 136 unit tests,
+  7 public API tests, 1 rank-scaling test, and 18 doctests passed; 2 opt-in
+  tests were ignored.
+- `cargo test --release -p tensor4all-treeaci --features diagnostics
+  --no-fail-fast`: 139 unit tests, 7 public API tests, 1 rank-scaling test,
+  and 18 doctests passed; 2 opt-in tests were ignored.
+- The saved gw-rs artifacts were inspected without rerunning the pipeline.
+  Their provenance is R=10, T=0.01, mu=0.5, with CTTN `pi_rtau` max bond 192
+  and nblock `pi_rtau` max bond 764. The resulting Pi/W difference is retained
+  as a correctness regression target, not presented as fixed by these local
+  unit tests.
+
+## Downstream replay
+
+The local Cargo patch in `gw-rs/sgw/Cargo.toml` was then used to run the
+current worktree at R=10 for T=0.01 and T=0.1. The available logs contain
+successful nblock runs through `Sigma`; the CTTN T=0.1 run also completed, and
+the currently retained CTTN T=0.01 log contains all stages through `Sigma`.
+
+- At T=0.1, nblock TreeACI agrees with the same-run SimpleTT slices within
+  0.42% for Pi, 0.47% for W, and 0.10% for Sigma when normalized by the
+  reference maximum per row. Its G0 agrees with the analytic lattice formula
+  with maximum absolute row errors below `7.1e-4`. The CTTN comparison is also
+  small at this temperature.
+- At T=0.01, nblock TreeACI still agrees with same-run SimpleTT within 0.64%
+  for Pi, 0.56% for W, and 0.44% for Sigma. This is evidence against a
+  wholesale corruption caused by the redundancy patch, but it is not a proof
+  that SimpleTT is an independent correctness oracle.
+- The low-temperature nblock--CTTN discrepancy remains: the largest relative
+  Pi difference is about 23.7% at n=0 and the largest W difference about
+  12.5%. The current nblock `pi_rtau` max bond is 796 versus 210 for CTTN,
+  while both report final TreeACI errors near `1e-4` and `Converged`.
+- The observed wall times were 200.7 s (nblock) and 591.4 s (CTTN) at T=0.01,
+  and 35.0 s (nblock) and 36.3 s (CTTN) at T=0.1. These are single runs, so
+  they are directional rather than a controlled benchmark. The T=0.1 nblock
+  run is about 10% faster than its retained pre-remediation run; CTTN is about
+  8% slower, dominated by G0 variance.
+
+This replay does not clear the low-temperature false-convergence concern:
+Guard start-point reuse remains untouched, and #687 still requires a focused
+correctness diagnosis rather than a performance-only conclusion.
+
+## Follow-up gate
+
+Before changing Guard start-point reuse or declaring #687 resolved, replay the
+same low-temperature/high-R case with the current branch and compare the
+saved NPZ slices, convergence histories, ranks, and exact/reference checks.


### PR DESCRIPTION
## Summary

- Remove redundant frame cloning, frame sweeps, Guard work, and transaction-owned cleanup in TreeACI hot paths.
- Add branch-point diagnostics and TreeTN branch contraction phase counters to quantify setup, BLAS, scalar, and cache costs.
- Add contiguous-read fast paths for branch setup, including child_axis_2, while preserving the general fallback and index mappings.
- Correct diagnostics so `blas_calls` counts actual backend matrix-multiply dispatches; add Complex64 coverage for contiguous branch paths and runnable diagnostics documentation examples.

This change does not alter interpolation mathematics, pivot selection, truncation/convergence criteria, callback ordering, or transaction semantics. False-convergence and canonicalization follow-ups remain separate issues (#687, #689). The downstream `gw-rs` pipeline is not part of this PR.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo test --release --workspace`
- TreeTN diagnostics tests and doctests, including Complex64 fast-path coverage
- TreeACI diagnostics doctests
- Repository-rules review tests and dry-run review

Removed test-only ordering storage and related paths were reviewed for coverage impact; coverage thresholds were not changed.

Performance investigation and measurements are recorded in `docs/worklogs/2026-08-24-branch-contraction-setup-cost.md` and the related TreeACI worklogs.