### PR TITLE
Fix small tensor-train correctness issues

### DIFF
--- a/crates/tensor4all-itensorlike/src/tensortrain.rs
+++ b/crates/tensor4all-itensorlike/src/tensortrain.rs
@@ -1379,7 +1379,7 @@ impl TensorTrain {
         }
 
         if self.is_empty() {
-            return Ok(AnyScalar::new_real(0.0));
+            return Ok(AnyScalar::new_real(1.0));
         }
 
         // Sequential bra-ket contraction along the chain: O(N·D²·d).
@@ -1590,7 +1590,7 @@ impl TensorTrain {
 
     fn norm_squared_fast_path(&self) -> Result<Option<f64>> {
         if self.is_empty() {
-            return Ok(Some(0.0));
+            return Ok(Some(1.0));
         }
         if !self.has_simple_linear_links()? {
             return Ok(None);

--- a/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
+++ b/crates/tensor4all-itensorlike/tests/tensortrain_inner.rs
@@ -1,17 +1,16 @@
 //! Tests for TensorTrain inner product operations
 
 use tensor4all_core::index::DefaultIndex as Index;
-use tensor4all_core::IdxTensor;
+use tensor4all_core::{IdxTensor, TensorConstructionLike};
 use tensor4all_itensorlike::TensorTrain;
 
-/// Test inner product of empty tensor trains
+/// Test metrics of the empty tensor train representing scalar one.
 #[test]
 fn test_inner_empty_tensor_trains() {
-    let tt1 = TensorTrain::new(vec![]).unwrap();
-    let tt2 = TensorTrain::new(vec![]).unwrap();
+    let one = <TensorTrain as TensorConstructionLike>::scalar_one().unwrap();
 
-    let result = tt1.inner(&tt2).unwrap();
-    assert_eq!(result.real(), 0.0);
+    assert_eq!(one.inner(&one).unwrap().real(), 1.0);
+    assert_eq!(one.norm_squared().unwrap(), 1.0);
 }
 
 /// Test inner product of single-site tensor trains

--- a/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
+++ b/crates/tensor4all-quanticstci/src/quantics_tci/tests/mod.rs
@@ -49,7 +49,7 @@ fn test_discrete_simple_function() {
         .with_nrandominitpivot(3)
         .with_unfoldingscheme(UnfoldingScheme::Fused);
 
-    let result = quanticscrossinterpolate_discrete(&sizes, f, None, opts);
+    let result = quanticscrossinterpolate_discrete(&sizes, f, Some(vec![vec![1, 0]]), opts);
     assert!(result.is_ok(), "Error: {:?}", result.err());
 
     let (qtci, _ranks, _errors) = result.unwrap();
@@ -77,7 +77,7 @@ fn test_discrete_tci_structure() {
         .with_nrandominitpivot(3)
         .with_unfoldingscheme(UnfoldingScheme::Fused);
 
-    let result = quanticscrossinterpolate_discrete(&sizes, f, None, opts);
+    let result = quanticscrossinterpolate_discrete(&sizes, f, Some(vec![vec![1, 0]]), opts);
     assert!(result.is_ok(), "Error: {:?}", result.err());
 
     let (qtci, _ranks, _errors) = result.unwrap();
@@ -212,7 +212,8 @@ fn test_discrete_inherent_grid_accessor() {
         .with_nrandominitpivot(3)
         .with_unfoldingscheme(UnfoldingScheme::Fused);
 
-    let (qtci, _ranks, _errors) = quanticscrossinterpolate_discrete(&sizes, f, None, opts).unwrap();
+    let (qtci, _ranks, _errors) =
+        quanticscrossinterpolate_discrete(&sizes, f, Some(vec![vec![1, 0]]), opts).unwrap();
 
     // inherent_grid should be Some, discretized_grid should be None
     assert!(qtci.inherent_grid().is_some());

--- a/docs/worklogs/2026-08-28-small-correctness-issues.md
+++ b/docs/worklogs/2026-08-28-small-correctness-issues.md
@@ -1,0 +1,50 @@
+# Small correctness issue batch (#653, #685)
+
+## Summary
+
+Fixed two independent low-risk correctness issues in one batch: deterministic
+initial pivots for zero-at-origin QuanticsTCI tests, and scalar-identity norms
+for empty `tensor4all-itensorlike::TensorTrain` values.
+
+## Reviewed material
+
+- `AGENTS.md`, `REPOSITORY_RULES.md`, root `README.md`, and workspace coding rules
+- Shared common, Rust, testing, and numerical agent rules
+- Generated API inventories for `tensor4all-itensorlike` and
+  `tensor4all-quanticstci`
+- `TensorTrain::{inner,norm_squared,norm_squared_fast_path}` and
+  `TensorConstructionLike::scalar_one`
+- Every QuanticsTCI test using `f(i, j) = i + j`, including the sibling test not
+  named in #653
+
+## Decisions
+
+- Preserve the tested function in #653 and provide the known nonzero grid pivot
+  `[1, 0]`. This removes dependence on unseeded random pivots without changing
+  production interpolation behavior or expected values.
+- Return one from both empty `TensorTrain` metric fast paths because this type's
+  public `scalar_one` implementation explicitly defines the empty train as the
+  multiplicative identity.
+- Do not change `SimpleTensorTrain::inner_product`: its empty constructor erases
+  the requested constant value and it has no equivalent explicit scalar-one
+  contract, so changing that separate API requires a dedicated contract decision.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo test -p tensor4all-itensorlike --release`
+- `cargo test -p tensor4all-quanticstci --release`
+- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
+- `cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5`
+- `cargo test --profile ci -p tensor4all-hdf5`
+- `cargo test --doc --profile ci --workspace -j 8`
+- `cargo doc --workspace --no-deps`
+- `./scripts/test-mdbook.sh`
+- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run`
+- `python3 scripts/test-repository-rules-review.py`
+- `cargo run -p xtask --release -- api-dump`
+- `git diff --check`
+
+The first full itensorlike run found an older integration assertion that encoded
+the buggy zero result. It was replaced by the focused scalar-one contract test,
+and the full gate was rerun successfully.


### PR DESCRIPTION
## Summary

- make all zero-at-origin QuanticsTCI tests deterministic with an explicit nonzero pivot
- make empty `TensorTrain` inner products and squared norms honor its scalar-one contract
- record the reviewed scope and verification in a concise worklog

Fixes #653
Fixes #685

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p tensor4all-itensorlike --release`
- `cargo test -p tensor4all-quanticstci --release`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo nextest run --cargo-profile ci --workspace --exclude tensor4all-hdf5` (3155 passed)
- `cargo test --profile ci -p tensor4all-hdf5`
- `cargo test --doc --profile ci --workspace -j 8`
- `cargo doc --workspace --no-deps` (existing warnings only)
- `./scripts/test-mdbook.sh`
- `python3 scripts/repository-rules-review.py --base origin/main --worktree --dry-run`
- `python3 scripts/test-repository-rules-review.py`
- `cargo run -p xtask --release -- api-dump`

Root README and public API inventory remain accurate.